### PR TITLE
Update Buffer polyfill

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1552,6 +1552,7 @@ importers:
       '@types/react': 16.14.6
       babel-loader: 8.1.0_0c9ed85c987bca43d65931123ef87b6c
       babel-plugin-add-module-exports: 1.0.4
+      buffer: 6.0.3
       chance: 1.1.7
       chromatic: 5.8.0
       del-cli: 3.0.1
@@ -1609,6 +1610,7 @@ importers:
       '@types/stream-buffers': ^3.0.2
       babel-loader: 8.1.0
       babel-plugin-add-module-exports: ^1.0.4
+      buffer: ^6.0.3
       chance: ^1.1.6
       chromatic: ^5.8.0
       clsx: ^1.1.0

--- a/packages/sdk/demos/.storybook/main.js
+++ b/packages/sdk/demos/.storybook/main.js
@@ -3,6 +3,7 @@
 //
 
 const path = require('path');
+const webpack = require('webpack');
 
 module.exports = {
   stories: [
@@ -27,6 +28,12 @@ module.exports = {
       ],
     });
     config.resolve.extensions.push('.ts', '.tsx');
+    config.node = {
+      Buffer: false
+    };
+    config.plugins.push(new webpack.ProvidePlugin({
+      Buffer: [require.resolve('buffer/'), 'Buffer']
+    }));
     return config;
   },
 };

--- a/packages/sdk/demos/package.json
+++ b/packages/sdk/demos/package.json
@@ -93,6 +93,7 @@
     "@types/react": "^16.14.0",
     "babel-loader": "8.1.0",
     "babel-plugin-add-module-exports": "^1.0.4",
+    "buffer": "^6.0.3",
     "chance": "^1.1.6",
     "chromatic": "^5.8.0",
     "del-cli": "^3.0.0",


### PR DESCRIPTION
By default it was pulling an old version of the Buffer polyfill 4.X.X which had a bug where the `subarray` function returned a `Uint8Array` rather than another `Buffer`. After the upgrade this seemed to be breaking something when trying to join a party, while using the most recent version of the buffer package stopped the crash from occurring.