### PR TITLE
[Tasks App] Add reset storage button to the app bar

### DIFF
--- a/packages/sdk/tutorials/apps/tasks-app/src/components/Main.js
+++ b/packages/sdk/tutorials/apps/tasks-app/src/components/Main.js
@@ -59,7 +59,6 @@ const Main = () => {
   const handleResetStorage = async () => {
     const reset = confirm('Are you sure you want to reset storage?');
     if (reset) {
-      localStorage.clear();
       await client.reset();
       window.location.reload();
     }


### PR DESCRIPTION
**Background**

Currently, on the Tasks App, the way to reset the storage is a keyboard shortcut (CMD + Shift + Del) to access the browser's settings and manually delete it from there.

**Changes**

- adds an icon button to the app bar which resets the storage after a confirm dialog
- the reset method was simply copied over [from the teamwork app](https://github.com/dxos/braneframe/blob/29c5ef85800b819964e83033cb9251eb05ac0aa7/packages/sdk/react-appkit/src/containers/AppBar.js#L229-L231) and seems to work well without crashing the app
- this should resolve #222 

**Questions**

- I started to try to add a test the playwright tests in order to test this functionality, but had a little bit of trouble getting the tests to run. Is this something worth pursuing?