### PR TITLE
Exclude demos build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,7 +64,7 @@ jobs:
         echo "::endgroup::"
 
         # Quick build
-        node common/scripts/github-actions-folding.js node common/scripts/install-run-rush.js build --verbose --to @dxos/demos
+        node common/scripts/github-actions-folding.js node common/scripts/install-run-rush.js build --verbose --to-exclude @dxos/demos
     - name: Chromatic
       run:  |
         \. "$NVM_DIR/nvm.sh" && nvm use ${{ matrix.node-version }}


### PR DESCRIPTION
@dxos/demos is build by the chromatic, no need to build it twice