### PR TITLE
[react-client] Update useParty to accept PublicKeyLike

### DIFF
--- a/packages/sdk/react-client/src/hooks/echo-queries/parties.ts
+++ b/packages/sdk/react-client/src/hooks/echo-queries/parties.ts
@@ -4,7 +4,7 @@
 
 import { useEffect, useState } from 'react';
 
-import { PublicKey } from '@dxos/crypto';
+import { PublicKey, PublicKeyLike } from '@dxos/crypto';
 import { Party } from '@dxos/echo-db';
 
 import { useClient } from '../client';
@@ -13,7 +13,7 @@ import { useClient } from '../client';
  * Get a specific Party.
  * To be used with `ClientProvider` or `ClientInitializer` component wrapper.
  */
-export const useParty = (partyKey: Uint8Array) => {
+export const useParty = (partyKey: PublicKeyLike) => {
   const client = useClient();
   return partyKey ? client.echo.getParty(PublicKey.from(partyKey)) : undefined;
 };


### PR DESCRIPTION
As per https://github.com/dxos/braneframe/pull/38#discussion_r676557868, allow `PublicKey`s to be used to get parties. Using `PublicKeyLike` as the type should be backwards compatible with all existing usages of this hook while allowing them to be updated in line with [guidelines to maintain keys as buffers in objects only for display](https://github.com/dxos/protocols/blob/4586b5015ddd2c876ef84320b374493cfcb18414/packages/common/crypto/src/keys.ts#L21-L22).