### PR TITLE
Automatic: Upgrade DXOS dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=06b0bc51-7ce8-4fbc-862c-48741c648132

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,7 @@
     "generate:docs": "typedoc --out content/api --packages '../packages/{sdk,echo,halo,mesh}/*' --tsconfig tsconfig.typedoc.json"
   },
   "dependencies": {
-    "@dxos/docs-theme": "^1.0.0-beta.22",
+    "@dxos/docs-theme": "^1.0.0-beta.23",
     "gatsby": "^2.17.11",
     "gatsby-plugin-sharp": "^2.6.14",
     "gatsby-source-filesystem": "^2.3.14",

--- a/packages/echo/feed-store/package.json
+++ b/packages/echo/feed-store/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@dxos/benchmark-suite": "^1.0.0-beta.1",
-    "@dxos/browser-runner": "^1.0.0-beta.8",
+    "@dxos/browser-runner": "^1.0.0-beta.13",
     "@dxos/crypto": "workspace:*",
     "@dxos/random-access-multi-storage": "workspace:*",
     "@dxos/toolchain-node-library": "workspace:*",

--- a/packages/sdk/client/package.json
+++ b/packages/sdk/client/package.json
@@ -26,7 +26,7 @@
     "@dxos/model-factory": "workspace:*",
     "@dxos/network-manager": "workspace:*",
     "@dxos/object-model": "workspace:*",
-    "@dxos/registry-client": "~1.1.1",
+    "@dxos/registry-client": "~1.1.2",
     "@wirelineio/registry-client": "~1.1.0-beta.3",
     "abstract-leveldown": "~7.0.0",
     "assert": "^2.0.0",


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc</em></summary>



</details>
<details>
<summary><em>sudo ./common/scripts/install-dependencies.sh</em></summary>

```Shell
Hit:1 http://azure.archive.ubuntu.com/ubuntu focal InRelease
Get:2 http://azure.archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu focal-backports InRelease [101 kB]
Get:4 https://packages.microsoft.com/ubuntu/20.04/prod focal InRelease [10.5 kB]
Get:5 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Hit:6 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal InRelease
Get:7 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [1142 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu focal-updates/main Translation-en [249 kB]
Get:9 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 c-n-f Metadata [13.9 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [377 kB]
Get:11 http://azure.archive.ubuntu.com/ubuntu focal-updates/restricted Translation-en [54.4 kB]
Get:12 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [845 kB]
Get:13 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe Translation-en [177 kB]
Get:14 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 c-n-f Metadata [18.4 kB]
Get:15 https://packages.microsoft.com/ubuntu/20.04/prod focal/main amd64 Packages [90.7 kB]
Get:16 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [793 kB]
Get:17 http://security.ubuntu.com/ubuntu focal-security/main Translation-en [157 kB]
Get:18 http://security.ubuntu.com/ubuntu focal-security/main amd64 c-n-f Metadata [8424 B]
Get:19 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [636 kB]
Get:20 http://security.ubuntu.com/ubuntu focal-security/universe Translation-en [98.9 kB]
Get:21 http://security.ubuntu.com/ubuntu focal-security/universe amd64 c-n-f Metadata [12.1 kB]
Fetched 5012 kB in 1s (5527 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
autoconf is already the newest version (2.69-11.1).
autoconf set to manually installed.
automake is already the newest version (1:1.16.1-4ubuntu6).
automake set to manually installed.
g++ is already the newest version (4:9.3.0-1ubuntu2).
g++ set to manually installed.
libpng-dev is already the newest version (1.6.37-2).
libpng-dev set to manually installed.
libtool is already the newest version (2.4.6-14).
libtool set to manually installed.
make is already the newest version (4.2.1-1.2).
make set to manually installed.
libx11-dev is already the newest version (2:1.6.9-2ubuntu1.2).
libx11-dev set to manually installed.
jq is already the newest version (1.6-1ubuntu0.20.04.1).
The following additional packages will be installed:
  libxfixes-dev libxi-dev x11proto-input-dev x11proto-record-dev
The following NEW packages will be installed:
  libxfixes-dev libxi-dev libxtst-dev x11proto-input-dev x11proto-record-dev
0 upgraded, 5 newly installed, 0 to remove and 47 not upgraded.
Need to get 219 kB of archives.
After this operation, 876 kB of additional disk space will be used.
Get:1 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libxfixes-dev amd64 1:5.0.3-2 [11.4 kB]
Get:2 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 x11proto-input-dev all 2019.2-1ubuntu1 [2628 B]
Get:3 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libxi-dev amd64 2:1.7.10-0ubuntu1 [187 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 x11proto-record-dev all 2019.2-1ubuntu1 [2624 B]
Get:5 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libxtst-dev amd64 2:1.2.3-1 [15.2 kB]
Fetched 219 kB in 0s (11.3 MB/s)
Selecting previously unselected package libxfixes-dev:amd64.
(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 235129 files and directories currently installed.)
Preparing to unpack .../libxfixes-dev_1%3a5.0.3-2_amd64.deb ...
Unpacking libxfixes-dev:amd64 (1:5.0.3-2) ...
Selecting previously unselected package x11proto-input-dev.
Preparing to unpack .../x11proto-input-dev_2019.2-1ubuntu1_all.deb ...
Unpacking x11proto-input-dev (2019.2-1ubuntu1) ...
Selecting previously unselected package libxi-dev:amd64.
Preparing to unpack .../libxi-dev_2%3a1.7.10-0ubuntu1_amd64.deb ...
Unpacking libxi-dev:amd64 (2:1.7.10-0ubuntu1) ...
Selecting previously unselected package x11proto-record-dev.
Preparing to unpack .../x11proto-record-dev_2019.2-1ubuntu1_all.deb ...
Unpacking x11proto-record-dev (2019.2-1ubuntu1) ...
Selecting previously unselected package libxtst-dev:amd64.
Preparing to unpack .../libxtst-dev_2%3a1.2.3-1_amd64.deb ...
Unpacking libxtst-dev:amd64 (2:1.2.3-1) ...
Setting up libxfixes-dev:amd64 (1:5.0.3-2) ...
Setting up x11proto-input-dev (2019.2-1ubuntu1) ...
Setting up x11proto-record-dev (2019.2-1ubuntu1) ...
Setting up libxi-dev:amd64 (2:1.7.10-0ubuntu1) ...
Setting up libxtst-dev:amd64 (2:1.2.3-1) ...
Processing triggers for man-db (2.9.1-1) ...
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  enchant gstreamer1.0-plugins-base i965-va-driver intel-media-va-driver
  libaacs0 libaom0 libass9 libasyncns0 libavcodec58 libavfilter7 libavformat58
  libavutil56 libbdplus0 libbluray2 libbs2b0 libcdparanoia0 libchromaprint1
  libcodec2-0.9 libdc1394-22 libdca0 libde265-0 libdvdnav4 libdvdread7
  libfaad2 libflac8 libflite1 libfluidsynth2 libgme0 libgsm1 libgssdp-1.2-0
  libgstreamer-plugins-bad1.0-0 libgstreamer-plugins-base1.0-0
  libgstreamer-plugins-good1.0-0 libgupnp-1.2-0 libgupnp-igd-1.0-4 libigdgmm11
  libinstpatch-1.0-2 libjack-jackd2-0 libkate1 liblilv-0-0 libmjpegutils-2.1-0
  libmodplug1 libmp3lame0 libmpcdec6 libmpeg2encpp-2.1-0 libmpg123-0
  libmplex2-2.1-0 libmysofa1 libnice10 libofa0 libopenal-data libopenal1
  libopenjp2-7 libopenmpt0 libopus0 liborc-0.4-0 libpostproc55 libpulse0
  libraw1394-11 librubberband2 libsamplerate0 libsbc1 libsdl2-2.0-0
  libserd-0-0 libshine3 libsnappy1v5 libsndfile1 libsndio7.0 libsord-0-0
  libsoundtouch1 libsoxr0 libspandsp2 libspeex1 libsratom-0-0 libsrt1
  libsrtp2-1 libssh-gcrypt-4 libswresample3 libswscale5 libtheora0 libtwolame0
  libusrsctp1 libv4l-0 libv4lconvert0 libva-drm2 libva-x11-2 libva2 libvdpau1
  libvidstab1.1 libvisual-0.4-0 libvo-aacenc0 libvo-amrwbenc0 libvorbisenc2
  libwavpack1 libwebrtc-audio-processing1 libwildmidi2 libx264-155 libx265-179
  libxvidcore4 libzbar0 libzvbi-common libzvbi0 mesa-va-drivers
  mesa-vdpau-drivers ocl-icd-libopencl1 timgm6mb-soundfont va-driver-all
  vdpau-driver-all
Suggested packages:
  frei0r-plugins gvfs i965-va-driver-shaders libbluray-bdj libdvdcss2
  libenchant-voikko libvisual-0.4-plugins jackd2 libportaudio2 opus-tools
  pulseaudio libraw1394-doc serdi sndiod sordi speex libwildmidi-config
  opencl-icd fluid-soundfont-gm fluidsynth timidity musescore libvdpau-va-gl1
  nvidia-vdpau-driver nvidia-legacy-340xx-vdpau-driver
  nvidia-legacy-304xx-vdpau-driver
The following NEW packages will be installed:
  enchant gstreamer1.0-libav gstreamer1.0-plugins-bad
  gstreamer1.0-plugins-base i965-va-driver intel-media-va-driver libaacs0
  libaom0 libass9 libasyncns0 libavcodec58 libavfilter7 libavformat58
  libavutil56 libbdplus0 libbluray2 libbs2b0 libcdparanoia0 libchromaprint1
  libcodec2-0.9 libdc1394-22 libdca0 libde265-0 libdvdnav4 libdvdread7
  libenchant1c2a libfaad2 libflac8 libflite1 libfluidsynth2 libgme0 libgsm1
  libgssdp-1.2-0 libgstreamer-plugins-bad1.0-0 libgstreamer-plugins-base1.0-0
  libgstreamer-plugins-good1.0-0 libgupnp-1.2-0 libgupnp-igd-1.0-4 libigdgmm11
  libinstpatch-1.0-2 libjack-jackd2-0 libkate1 liblilv-0-0 libmjpegutils-2.1-0
  libmodplug1 libmp3lame0 libmpcdec6 libmpeg2encpp-2.1-0 libmpg123-0
  libmplex2-2.1-0 libmysofa1 libnice10 libofa0 libopenal-data libopenal1
  libopenjp2-7 libopenmpt0 libopus0 liborc-0.4-0 libpostproc55 libpulse0
  libraw1394-11 librubberband2 libsamplerate0 libsbc1 libsdl2-2.0-0
  libserd-0-0 libshine3 libsnappy1v5 libsndfile1 libsndio7.0 libsord-0-0
  libsoundtouch1 libsoxr0 libspandsp2 libspeex1 libsratom-0-0 libsrt1
  libsrtp2-1 libssh-gcrypt-4 libswresample3 libswscale5 libtheora0 libtwolame0
  libusrsctp1 libv4l-0 libv4lconvert0 libva-drm2 libva-x11-2 libva2 libvdpau1
  libvidstab1.1 libvisual-0.4-0 libvo-aacenc0 libvo-amrwbenc0 libvorbisenc2
  libwavpack1 libwebrtc-audio-processing1 libwildmidi2 libx264-155 libx265-179
  libxvidcore4 libzbar0 libzvbi-common libzvbi0 mesa-va-drivers
  mesa-vdpau-drivers ocl-icd-libopencl1 timgm6mb-soundfont va-driver-all
  vdpau-driver-all
0 upgraded, 111 newly installed, 0 to remove and 47 not upgraded.
Need to get 58.4 MB of archives.
After this operation, 230 MB of additional disk space will be used.
Get:1 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libenchant1c2a amd64 1.6.0-11.3build1 [64.7 kB]
Get:2 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 enchant amd64 1.6.0-11.3build1 [12.4 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libaom0 amd64 1.0.0.errata1-3build1 [1160 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libva2 amd64 2.7.0-2 [53.5 kB]
Get:5 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libva-drm2 amd64 2.7.0-2 [7044 B]
Get:6 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libva-x11-2 amd64 2.7.0-2 [11.9 kB]
Get:7 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libvdpau1 amd64 1.3-1ubuntu2 [25.6 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 ocl-icd-libopencl1 amd64 2.2.11-1ubuntu1 [30.3 kB]
Get:9 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 libavutil56 amd64 7:4.2.4-1ubuntu0.1 [241 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libcodec2-0.9 amd64 0.9.2-2 [7886 kB]
Get:11 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libgsm1 amd64 1.0.18-2 [24.4 kB]
Get:12 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libmp3lame0 amd64 3.100-3 [133 kB]
Get:13 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libopenjp2-7 amd64 2.3.1-1ubuntu4.20.04.1 [141 kB]
Get:14 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libopus0 amd64 1.3.1-0ubuntu1 [191 kB]
Get:15 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libshine3 amd64 3.1.1-2 [23.2 kB]
Get:16 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libsnappy1v5 amd64 1.1.8-1build1 [16.7 kB]
Get:17 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libspeex1 amd64 1.2~rc1.2-1.1ubuntu1 [53.2 kB]
Get:18 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libsoxr0 amd64 0.1.3-2build1 [78.0 kB]
Get:19 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 libswresample3 amd64 7:4.2.4-1ubuntu0.1 [57.1 kB]
Get:20 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libtheora0 amd64 1.1.1+dfsg.1-15ubuntu2 [162 kB]
Get:21 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libtwolame0 amd64 0.4.0-2 [47.6 kB]
Get:22 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libvorbisenc2 amd64 1.3.6-2ubuntu1 [70.7 kB]
Get:23 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libwavpack1 amd64 5.2.0-1ubuntu0.1 [77.3 kB]
Get:24 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libx264-155 amd64 2:0.155.2917+git0a84d98-2 [521 kB]
Get:25 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libx265-179 amd64 3.2.1-1build1 [1060 kB]
Get:26 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libxvidcore4 amd64 2:1.3.7-1 [201 kB]
Get:27 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libzvbi-common all 0.2.35-17 [32.5 kB]
Get:28 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libzvbi0 amd64 0.2.35-17 [237 kB]
Get:29 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 libavcodec58 amd64 7:4.2.4-1ubuntu0.1 [4876 kB]
Get:30 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libass9 amd64 1:0.14.0-2 [88.0 kB]
Get:31 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libbluray2 amd64 1:1.2.0-1 [138 kB]
Get:32 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libchromaprint1 amd64 1.4.3-3build1 [37.6 kB]
Get:33 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libgme0 amd64 0.6.2-1build1 [123 kB]
Get:34 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libmpg123-0 amd64 1.25.13-1 [124 kB]
Get:35 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libopenmpt0 amd64 0.4.11-1build1 [599 kB]
Get:36 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libssh-gcrypt-4 amd64 0.9.3-2ubuntu2.1 [201 kB]
Get:37 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 libavformat58 amd64 7:4.2.4-1ubuntu0.1 [981 kB]
Get:38 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libbs2b0 amd64 3.1.0+dfsg-2.2build1 [10.2 kB]
Get:39 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libflite1 amd64 2.1-release-3 [12.8 MB]
Get:40 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libserd-0-0 amd64 0.30.2-1 [46.6 kB]
Get:41 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libsord-0-0 amd64 0.16.4-1 [19.5 kB]
Get:42 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libsratom-0-0 amd64 0.6.4-1 [16.9 kB]
Get:43 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 liblilv-0-0 amd64 0.24.6-1ubuntu0.1 [40.6 kB]
Get:44 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libmysofa1 amd64 1.0~dfsg0-1 [39.2 kB]
Get:45 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 libpostproc55 amd64 7:4.2.4-1ubuntu0.1 [55.3 kB]
Get:46 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libsamplerate0 amd64 0.1.9-2 [939 kB]
Get:47 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 librubberband2 amd64 1.8.2-1build1 [89.4 kB]
Get:48 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 libswscale5 amd64 7:4.2.4-1ubuntu0.1 [156 kB]
Get:49 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libvidstab1.1 amd64 1.1.0-2 [35.0 kB]
Get:50 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 libavfilter7 amd64 7:4.2.4-1ubuntu0.1 [1084 kB]
Get:51 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 liborc-0.4-0 amd64 1:0.4.31-1 [188 kB]
Get:52 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libgstreamer-plugins-base1.0-0 amd64 1.16.2-4ubuntu0.1 [735 kB]
Get:53 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 gstreamer1.0-libav amd64 1.16.2-2 [123 kB]
Get:54 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libcdparanoia0 amd64 3.10.2+debian-13 [46.7 kB]
Get:55 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libvisual-0.4-0 amd64 0.4.0-17 [99.8 kB]
Get:56 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 gstreamer1.0-plugins-base amd64 1.16.2-4ubuntu0.1 [620 kB]
Get:57 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libigdgmm11 amd64 20.1.1+ds1-1 [111 kB]
Get:58 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 intel-media-va-driver amd64 20.1.1+dfsg1-1 [1764 kB]
Get:59 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libaacs0 amd64 0.9.0-2 [50.1 kB]
Get:60 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libasyncns0 amd64 0.8-6 [12.1 kB]
Get:61 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libbdplus0 amd64 0.1.2-3 [47.3 kB]
Get:62 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libde265-0 amd64 1.0.4-1build1 [239 kB]
Get:63 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libdvdread7 amd64 6.1.0+really6.0.2-1 [49.9 kB]
Get:64 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libdvdnav4 amd64 6.0.1-1build1 [39.0 kB]
Get:65 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libfaad2 amd64 2.9.1-1 [154 kB]
Get:66 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libflac8 amd64 1.3.3-1build1 [103 kB]
Get:67 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libsndfile1 amd64 1.0.28-7ubuntu0.1 [170 kB]
Get:68 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libinstpatch-1.0-2 amd64 1.1.2-2build1 [238 kB]
Get:69 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libjack-jackd2-0 amd64 1.9.12~dfsg-2ubuntu2 [267 kB]
Get:70 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libpulse0 amd64 1:13.99.1-1ubuntu3.11 [262 kB]
Get:71 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libsdl2-2.0-0 amd64 2.0.10+dfsg1-3 [407 kB]
Get:72 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 timgm6mb-soundfont all 1.3-3 [5420 kB]
Get:73 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libfluidsynth2 amd64 2.1.1-2 [198 kB]
Get:74 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libgssdp-1.2-0 amd64 1.2.3-0ubuntu0.20.04.1 [37.1 kB]
Get:75 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libgupnp-1.2-0 amd64 1.2.4-0ubuntu1 [81.3 kB]
Get:76 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libgupnp-igd-1.0-4 amd64 0.2.5-5 [14.8 kB]
Get:77 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libkate1 amd64 0.4.1-11build1 [39.4 kB]
Get:78 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libmjpegutils-2.1-0 amd64 1:2.1.0+debian-6build1 [24.1 kB]
Get:79 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libmodplug1 amd64 1:0.8.9.0-2build1 [150 kB]
Get:80 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libmpcdec6 amd64 2:0.1~r495-2 [32.4 kB]
Get:81 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libmpeg2encpp-2.1-0 amd64 1:2.1.0+debian-6build1 [69.4 kB]
Get:82 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libmplex2-2.1-0 amd64 1:2.1.0+debian-6build1 [44.4 kB]
Get:83 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libnice10 amd64 0.1.16-1 [136 kB]
Get:84 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libofa0 amd64 0.9.3-21 [49.6 kB]
Get:85 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libopenal-data all 1:1.19.1-1 [162 kB]
Get:86 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libraw1394-11 amd64 2.1.2-1 [30.7 kB]
Get:87 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libsndio7.0 amd64 1.5.0-3 [24.5 kB]
Get:88 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libsoundtouch1 amd64 2.1.2+ds1-1build1 [30.4 kB]
Get:89 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libspandsp2 amd64 0.0.6+dfsg-2 [272 kB]
Get:90 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libsrt1 amd64 1.4.0-1build1 [236 kB]
Get:91 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libsrtp2-1 amd64 2.3.0-2 [57.5 kB]
Get:92 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libusrsctp1 amd64 0.9.3.0+20190901-1 [217 kB]
Get:93 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libv4lconvert0 amd64 1.18.0-2build1 [76.5 kB]
Get:94 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libv4l-0 amd64 1.18.0-2build1 [41.9 kB]
Get:95 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libwebrtc-audio-processing1 amd64 0.3.1-0ubuntu3 [263 kB]
Get:96 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libwildmidi2 amd64 0.4.3-1 [59.9 kB]
Get:97 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libzbar0 amd64 0.23-1.3 [119 kB]
Get:98 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 mesa-va-drivers amd64 21.0.3-0ubuntu0.3~20.04.1 [2825 kB]
Get:99 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 mesa-vdpau-drivers amd64 21.0.3-0ubuntu0.3~20.04.1 [2945 kB]
Get:100 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 i965-va-driver amd64 2.4.0-0ubuntu1 [924 kB]
Get:101 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 va-driver-all amd64 2.7.0-2 [4020 B]
Get:102 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 vdpau-driver-all amd64 1.3-1ubuntu2 [4596 B]
Get:103 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libdc1394-22 amd64 2.2.5-2.1 [79.6 kB]
Get:104 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libdca0 amd64 0.0.6-1 [91.0 kB]
Get:105 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libgstreamer-plugins-bad1.0-0 amd64 1.16.2-2.1ubuntu1 [320 kB]
Get:106 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libgstreamer-plugins-good1.0-0 amd64 1.16.2-1ubuntu2.1 [63.7 kB]
Get:107 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libopenal1 amd64 1:1.19.1-1 [492 kB]
Get:108 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libsbc1 amd64 1.4-1 [31.9 kB]
Get:109 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libvo-aacenc0 amd64 0.1.3-2 [69.4 kB]
Get:110 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libvo-amrwbenc0 amd64 0.1.3-2 [68.2 kB]
Get:111 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 gstreamer1.0-plugins-bad amd64 1.16.2-2.1ubuntu1 [1717 kB]
Fetched 58.4 MB in 1s (95.8 MB/s)
Selecting previously unselected package libenchant1c2a:amd64.
(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 235245 files and directories currently installed.)
Preparing to unpack .../000-libenchant1c2a_1.6.0-11.3build1_amd64.deb ...
Unpacking libenchant1c2a:amd64 (1.6.0-11.3build1) ...
Selecting previously unselected package enchant.
Preparing to unpack .../001-enchant_1.6.0-11.3build1_amd64.deb ...
Unpacking enchant (1.6.0-11.3build1) ...
Selecting previously unselected package libaom0:amd64.
Preparing to unpack .../002-libaom0_1.0.0.errata1-3build1_amd64.deb ...
Unpacking libaom0:amd64 (1.0.0.errata1-3build1) ...
Selecting previously unselected package libva2:amd64.
Preparing to unpack .../003-libva2_2.7.0-2_amd64.deb ...
Unpacking libva2:amd64 (2.7.0-2) ...
Selecting previously unselected package libva-drm2:amd64.
Preparing to unpack .../004-libva-drm2_2.7.0-2_amd64.deb ...
Unpacking libva-drm2:amd64 (2.7.0-2) ...
Selecting previously unselected package libva-x11-2:amd64.
Preparing to unpack .../005-libva-x11-2_2.7.0-2_amd64.deb ...
Unpacking libva-x11-2:amd64 (2.7.0-2) ...
Selecting previously unselected package libvdpau1:amd64.
Preparing to unpack .../006-libvdpau1_1.3-1ubuntu2_amd64.deb ...
Unpacking libvdpau1:amd64 (1.3-1ubuntu2) ...
Selecting previously unselected package ocl-icd-libopencl1:amd64.
Preparing to unpack .../007-ocl-icd-libopencl1_2.2.11-1ubuntu1_amd64.deb ...
Unpacking ocl-icd-libopencl1:amd64 (2.2.11-1ubuntu1) ...
Selecting previously unselected package libavutil56:amd64.
Preparing to unpack .../008-libavutil56_7%3a4.2.4-1ubuntu0.1_amd64.deb ...
Unpacking libavutil56:amd64 (7:4.2.4-1ubuntu0.1) ...
Selecting previously unselected package libcodec2-0.9:amd64.
Preparing to unpack .../009-libcodec2-0.9_0.9.2-2_amd64.deb ...
Unpacking libcodec2-0.9:amd64 (0.9.2-2) ...
Selecting previously unselected package libgsm1:amd64.
Preparing to unpack .../010-libgsm1_1.0.18-2_amd64.deb ...
Unpacking libgsm1:amd64 (1.0.18-2) ...
Selecting previously unselected package libmp3lame0:amd64.
Preparing to unpack .../011-libmp3lame0_3.100-3_amd64.deb ...
Unpacking libmp3lame0:amd64 (3.100-3) ...
Selecting previously unselected package libopenjp2-7:amd64.
Preparing to unpack .../012-libopenjp2-7_2.3.1-1ubuntu4.20.04.1_amd64.deb ...
Unpacking libopenjp2-7:amd64 (2.3.1-1ubuntu4.20.04.1) ...
Selecting previously unselected package libopus0:amd64.
Preparing to unpack .../013-libopus0_1.3.1-0ubuntu1_amd64.deb ...
Unpacking libopus0:amd64 (1.3.1-0ubuntu1) ...
Selecting previously unselected package libshine3:amd64.
Preparing to unpack .../014-libshine3_3.1.1-2_amd64.deb ...
Unpacking libshine3:amd64 (3.1.1-2) ...
Selecting previously unselected package libsnappy1v5:amd64.
Preparing to unpack .../015-libsnappy1v5_1.1.8-1build1_amd64.deb ...
Unpacking libsnappy1v5:amd64 (1.1.8-1build1) ...
Selecting previously unselected package libspeex1:amd64.
Preparing to unpack .../016-libspeex1_1.2~rc1.2-1.1ubuntu1_amd64.deb ...
Unpacking libspeex1:amd64 (1.2~rc1.2-1.1ubuntu1) ...
Selecting previously unselected package libsoxr0:amd64.
Preparing to unpack .../017-libsoxr0_0.1.3-2build1_amd64.deb ...
Unpacking libsoxr0:amd64 (0.1.3-2build1) ...
Selecting previously unselected package libswresample3:amd64.
Preparing to unpack .../018-libswresample3_7%3a4.2.4-1ubuntu0.1_amd64.deb ...
Unpacking libswresample3:amd64 (7:4.2.4-1ubuntu0.1) ...
Selecting previously unselected package libtheora0:amd64.
Preparing to unpack .../019-libtheora0_1.1.1+dfsg.1-15ubuntu2_amd64.deb ...
Unpacking libtheora0:amd64 (1.1.1+dfsg.1-15ubuntu2) ...
Selecting previously unselected package libtwolame0:amd64.
Preparing to unpack .../020-libtwolame0_0.4.0-2_amd64.deb ...
Unpacking libtwolame0:amd64 (0.4.0-2) ...
Selecting previously unselected package libvorbisenc2:amd64.
Preparing to unpack .../021-libvorbisenc2_1.3.6-2ubuntu1_amd64.deb ...
Unpacking libvorbisenc2:amd64 (1.3.6-2ubuntu1) ...
Selecting previously unselected package libwavpack1:amd64.
Preparing to unpack .../022-libwavpack1_5.2.0-1ubuntu0.1_amd64.deb ...
Unpacking libwavpack1:amd64 (5.2.0-1ubuntu0.1) ...
Selecting previously unselected package libx264-155:amd64.
Preparing to unpack .../023-libx264-155_2%3a0.155.2917+git0a84d98-2_amd64.deb ...
Unpacking libx264-155:amd64 (2:0.155.2917+git0a84d98-2) ...
Selecting previously unselected package libx265-179:amd64.
Preparing to unpack .../024-libx265-179_3.2.1-1build1_amd64.deb ...
Unpacking libx265-179:amd64 (3.2.1-1build1) ...
Selecting previously unselected package libxvidcore4:amd64.
Preparing to unpack .../025-libxvidcore4_2%3a1.3.7-1_amd64.deb ...
Unpacking libxvidcore4:amd64 (2:1.3.7-1) ...
Selecting previously unselected package libzvbi-common.
Preparing to unpack .../026-libzvbi-common_0.2.35-17_all.deb ...
Unpacking libzvbi-common (0.2.35-17) ...
Selecting previously unselected package libzvbi0:amd64.
Preparing to unpack .../027-libzvbi0_0.2.35-17_amd64.deb ...
Unpacking libzvbi0:amd64 (0.2.35-17) ...
Selecting previously unselected package libavcodec58:amd64.
Preparing to unpack .../028-libavcodec58_7%3a4.2.4-1ubuntu0.1_amd64.deb ...
Unpacking libavcodec58:amd64 (7:4.2.4-1ubuntu0.1) ...
Selecting previously unselected package libass9:amd64.
Preparing to unpack .../029-libass9_1%3a0.14.0-2_amd64.deb ...
Unpacking libass9:amd64 (1:0.14.0-2) ...
Selecting previously unselected package libbluray2:amd64.
Preparing to unpack .../030-libbluray2_1%3a1.2.0-1_amd64.deb ...
Unpacking libbluray2:amd64 (1:1.2.0-1) ...
Selecting previously unselected package libchromaprint1:amd64.
Preparing to unpack .../031-libchromaprint1_1.4.3-3build1_amd64.deb ...
Unpacking libchromaprint1:amd64 (1.4.3-3build1) ...
Selecting previously unselected package libgme0:amd64.
Preparing to unpack .../032-libgme0_0.6.2-1build1_amd64.deb ...
Unpacking libgme0:amd64 (0.6.2-1build1) ...
Selecting previously unselected package libmpg123-0:amd64.
Preparing to unpack .../033-libmpg123-0_1.25.13-1_amd64.deb ...
Unpacking libmpg123-0:amd64 (1.25.13-1) ...
Selecting previously unselected package libopenmpt0:amd64.
Preparing to unpack .../034-libopenmpt0_0.4.11-1build1_amd64.deb ...
Unpacking libopenmpt0:amd64 (0.4.11-1build1) ...
Selecting previously unselected package libssh-gcrypt-4:amd64.
Preparing to unpack .../035-libssh-gcrypt-4_0.9.3-2ubuntu2.1_amd64.deb ...
Unpacking libssh-gcrypt-4:amd64 (0.9.3-2ubuntu2.1) ...
Selecting previously unselected package libavformat58:amd64.
Preparing to unpack .../036-libavformat58_7%3a4.2.4-1ubuntu0.1_amd64.deb ...
Unpacking libavformat58:amd64 (7:4.2.4-1ubuntu0.1) ...
Selecting previously unselected package libbs2b0:amd64.
Preparing to unpack .../037-libbs2b0_3.1.0+dfsg-2.2build1_amd64.deb ...
Unpacking libbs2b0:amd64 (3.1.0+dfsg-2.2build1) ...
Selecting previously unselected package libflite1:amd64.
Preparing to unpack .../038-libflite1_2.1-release-3_amd64.deb ...
Unpacking libflite1:amd64 (2.1-release-3) ...
Selecting previously unselected package libserd-0-0:amd64.
Preparing to unpack .../039-libserd-0-0_0.30.2-1_amd64.deb ...
Unpacking libserd-0-0:amd64 (0.30.2-1) ...
Selecting previously unselected package libsord-0-0:amd64.
Preparing to unpack .../040-libsord-0-0_0.16.4-1_amd64.deb ...
Unpacking libsord-0-0:amd64 (0.16.4-1) ...
Selecting previously unselected package libsratom-0-0:amd64.
Preparing to unpack .../041-libsratom-0-0_0.6.4-1_amd64.deb ...
Unpacking libsratom-0-0:amd64 (0.6.4-1) ...
Selecting previously unselected package liblilv-0-0:amd64.
Preparing to unpack .../042-liblilv-0-0_0.24.6-1ubuntu0.1_amd64.deb ...
Unpacking liblilv-0-0:amd64 (0.24.6-1ubuntu0.1) ...
Selecting previously unselected package libmysofa1:amd64.
Preparing to unpack .../043-libmysofa1_1.0~dfsg0-1_amd64.deb ...
Unpacking libmysofa1:amd64 (1.0~dfsg0-1) ...
Selecting previously unselected package libpostproc55:amd64.
Preparing to unpack .../044-libpostproc55_7%3a4.2.4-1ubuntu0.1_amd64.deb ...
Unpacking libpostproc55:amd64 (7:4.2.4-1ubuntu0.1) ...
Selecting previously unselected package libsamplerate0:amd64.
Preparing to unpack .../045-libsamplerate0_0.1.9-2_amd64.deb ...
Unpacking libsamplerate0:amd64 (0.1.9-2) ...
Selecting previously unselected package librubberband2:amd64.
Preparing to unpack .../046-librubberband2_1.8.2-1build1_amd64.deb ...
Unpacking librubberband2:amd64 (1.8.2-1build1) ...
Selecting previously unselected package libswscale5:amd64.
Preparing to unpack .../047-libswscale5_7%3a4.2.4-1ubuntu0.1_amd64.deb ...
Unpacking libswscale5:amd64 (7:4.2.4-1ubuntu0.1) ...
Selecting previously unselected package libvidstab1.1:amd64.
Preparing to unpack .../048-libvidstab1.1_1.1.0-2_amd64.deb ...
Unpacking libvidstab1.1:amd64 (1.1.0-2) ...
Selecting previously unselected package libavfilter7:amd64.
Preparing to unpack .../049-libavfilter7_7%3a4.2.4-1ubuntu0.1_amd64.deb ...
Unpacking libavfilter7:amd64 (7:4.2.4-1ubuntu0.1) ...
Selecting previously unselected package liborc-0.4-0:amd64.
Preparing to unpack .../050-liborc-0.4-0_1%3a0.4.31-1_amd64.deb ...
Unpacking liborc-0.4-0:amd64 (1:0.4.31-1) ...
Selecting previously unselected package libgstreamer-plugins-base1.0-0:amd64.
Preparing to unpack .../051-libgstreamer-plugins-base1.0-0_1.16.2-4ubuntu0.1_amd64.deb ...
Unpacking libgstreamer-plugins-base1.0-0:amd64 (1.16.2-4ubuntu0.1) ...
Selecting previously unselected package gstreamer1.0-libav:amd64.
Preparing to unpack .../052-gstreamer1.0-libav_1.16.2-2_amd64.deb ...
Unpacking gstreamer1.0-libav:amd64 (1.16.2-2) ...
Selecting previously unselected package libcdparanoia0:amd64.
Preparing to unpack .../053-libcdparanoia0_3.10.2+debian-13_amd64.deb ...
Unpacking libcdparanoia0:amd64 (3.10.2+debian-13) ...
Selecting previously unselected package libvisual-0.4-0:amd64.
Preparing to unpack .../054-libvisual-0.4-0_0.4.0-17_amd64.deb ...
Unpacking libvisual-0.4-0:amd64 (0.4.0-17) ...
Selecting previously unselected package gstreamer1.0-plugins-base:amd64.
Preparing to unpack .../055-gstreamer1.0-plugins-base_1.16.2-4ubuntu0.1_amd64.deb ...
Unpacking gstreamer1.0-plugins-base:amd64 (1.16.2-4ubuntu0.1) ...
Selecting previously unselected package libigdgmm11:amd64.
Preparing to unpack .../056-libigdgmm11_20.1.1+ds1-1_amd64.deb ...
Unpacking libigdgmm11:amd64 (20.1.1+ds1-1) ...
Selecting previously unselected package intel-media-va-driver:amd64.
Preparing to unpack .../057-intel-media-va-driver_20.1.1+dfsg1-1_amd64.deb ...
Unpacking intel-media-va-driver:amd64 (20.1.1+dfsg1-1) ...
Selecting previously unselected package libaacs0:amd64.
Preparing to unpack .../058-libaacs0_0.9.0-2_amd64.deb ...
Unpacking libaacs0:amd64 (0.9.0-2) ...
Selecting previously unselected package libasyncns0:amd64.
Preparing to unpack .../059-libasyncns0_0.8-6_amd64.deb ...
Unpacking libasyncns0:amd64 (0.8-6) ...
Selecting previously unselected package libbdplus0:amd64.
Preparing to unpack .../060-libbdplus0_0.1.2-3_amd64.deb ...
Unpacking libbdplus0:amd64 (0.1.2-3) ...
Selecting previously unselected package libde265-0:amd64.
Preparing to unpack .../061-libde265-0_1.0.4-1build1_amd64.deb ...
Unpacking libde265-0:amd64 (1.0.4-1build1) ...
Selecting previously unselected package libdvdread7:amd64.
Preparing to unpack .../062-libdvdread7_6.1.0+really6.0.2-1_amd64.deb ...
Unpacking libdvdread7:amd64 (6.1.0+really6.0.2-1) ...
Selecting previously unselected package libdvdnav4:amd64.
Preparing to unpack .../063-libdvdnav4_6.0.1-1build1_amd64.deb ...
Unpacking libdvdnav4:amd64 (6.0.1-1build1) ...
Selecting previously unselected package libfaad2:amd64.
Preparing to unpack .../064-libfaad2_2.9.1-1_amd64.deb ...
Unpacking libfaad2:amd64 (2.9.1-1) ...
Selecting previously unselected package libflac8:amd64.
Preparing to unpack .../065-libflac8_1.3.3-1build1_amd64.deb ...
Unpacking libflac8:amd64 (1.3.3-1build1) ...
Selecting previously unselected package libsndfile1:amd64.
Preparing to unpack .../066-libsndfile1_1.0.28-7ubuntu0.1_amd64.deb ...
Unpacking libsndfile1:amd64 (1.0.28-7ubuntu0.1) ...
Selecting previously unselected package libinstpatch-1.0-2:amd64.
Preparing to unpack .../067-libinstpatch-1.0-2_1.1.2-2build1_amd64.deb ...
Unpacking libinstpatch-1.0-2:amd64 (1.1.2-2build1) ...
Selecting previously unselected package libjack-jackd2-0:amd64.
Preparing to unpack .../068-libjack-jackd2-0_1.9.12~dfsg-2ubuntu2_amd64.deb ...
Unpacking libjack-jackd2-0:amd64 (1.9.12~dfsg-2ubuntu2) ...
Selecting previously unselected package libpulse0:amd64.
Preparing to unpack .../069-libpulse0_1%3a13.99.1-1ubuntu3.11_amd64.deb ...
Unpacking libpulse0:amd64 (1:13.99.1-1ubuntu3.11) ...
Selecting previously unselected package libsdl2-2.0-0:amd64.
Preparing to unpack .../070-libsdl2-2.0-0_2.0.10+dfsg1-3_amd64.deb ...
Unpacking libsdl2-2.0-0:amd64 (2.0.10+dfsg1-3) ...
Selecting previously unselected package timgm6mb-soundfont.
Preparing to unpack .../071-timgm6mb-soundfont_1.3-3_all.deb ...
Unpacking timgm6mb-soundfont (1.3-3) ...
Selecting previously unselected package libfluidsynth2:amd64.
Preparing to unpack .../072-libfluidsynth2_2.1.1-2_amd64.deb ...
Unpacking libfluidsynth2:amd64 (2.1.1-2) ...
Selecting previously unselected package libgssdp-1.2-0:amd64.
Preparing to unpack .../073-libgssdp-1.2-0_1.2.3-0ubuntu0.20.04.1_amd64.deb ...
Unpacking libgssdp-1.2-0:amd64 (1.2.3-0ubuntu0.20.04.1) ...
Selecting previously unselected package libgupnp-1.2-0:amd64.
Preparing to unpack .../074-libgupnp-1.2-0_1.2.4-0ubuntu1_amd64.deb ...
Unpacking libgupnp-1.2-0:amd64 (1.2.4-0ubuntu1) ...
Selecting previously unselected package libgupnp-igd-1.0-4:amd64.
Preparing to unpack .../075-libgupnp-igd-1.0-4_0.2.5-5_amd64.deb ...
Unpacking libgupnp-igd-1.0-4:amd64 (0.2.5-5) ...
Selecting previously unselected package libkate1:amd64.
Preparing to unpack .../076-libkate1_0.4.1-11build1_amd64.deb ...
Unpacking libkate1:amd64 (0.4.1-11build1) ...
Selecting previously unselected package libmjpegutils-2.1-0:amd64.
Preparing to unpack .../077-libmjpegutils-2.1-0_1%3a2.1.0+debian-6build1_amd64.deb ...
Unpacking libmjpegutils-2.1-0:amd64 (1:2.1.0+debian-6build1) ...
Selecting previously unselected package libmodplug1:amd64.
Preparing to unpack .../078-libmodplug1_1%3a0.8.9.0-2build1_amd64.deb ...
Unpacking libmodplug1:amd64 (1:0.8.9.0-2build1) ...
Selecting previously unselected package libmpcdec6:amd64.
Preparing to unpack .../079-libmpcdec6_2%3a0.1~r495-2_amd64.deb ...
Unpacking libmpcdec6:amd64 (2:0.1~r495-2) ...
Selecting previously unselected package libmpeg2encpp-2.1-0:amd64.
Preparing to unpack .../080-libmpeg2encpp-2.1-0_1%3a2.1.0+debian-6build1_amd64.deb ...
Unpacking libmpeg2encpp-2.1-0:amd64 (1:2.1.0+debian-6build1) ...
Selecting previously unselected package libmplex2-2.1-0:amd64.
Preparing to unpack .../081-libmplex2-2.1-0_1%3a2.1.0+debian-6build1_amd64.deb ...
Unpacking libmplex2-2.1-0:amd64 (1:2.1.0+debian-6build1) ...
Selecting previously unselected package libnice10:amd64.
Preparing to unpack .../082-libnice10_0.1.16-1_amd64.deb ...
Unpacking libnice10:amd64 (0.1.16-1) ...
Selecting previously unselected package libofa0:amd64.
Preparing to unpack .../083-libofa0_0.9.3-21_amd64.deb ...
Unpacking libofa0:amd64 (0.9.3-21) ...
Selecting previously unselected package libopenal-data.
Preparing to unpack .../084-libopenal-data_1%3a1.19.1-1_all.deb ...
Unpacking libopenal-data (1:1.19.1-1) ...
Selecting previously unselected package libraw1394-11:amd64.
Preparing to unpack .../085-libraw1394-11_2.1.2-1_amd64.deb ...
Unpacking libraw1394-11:amd64 (2.1.2-1) ...
Selecting previously unselected package libsndio7.0:amd64.
Preparing to unpack .../086-libsndio7.0_1.5.0-3_amd64.deb ...
Unpacking libsndio7.0:amd64 (1.5.0-3) ...
Selecting previously unselected package libsoundtouch1:amd64.
Preparing to unpack .../087-libsoundtouch1_2.1.2+ds1-1build1_amd64.deb ...
Unpacking libsoundtouch1:amd64 (2.1.2+ds1-1build1) ...
Selecting previously unselected package libspandsp2:amd64.
Preparing to unpack .../088-libspandsp2_0.0.6+dfsg-2_amd64.deb ...
Unpacking libspandsp2:amd64 (0.0.6+dfsg-2) ...
Selecting previously unselected package libsrt1:amd64.
Preparing to unpack .../089-libsrt1_1.4.0-1build1_amd64.deb ...
Unpacking libsrt1:amd64 (1.4.0-1build1) ...
Selecting previously unselected package libsrtp2-1:amd64.
Preparing to unpack .../090-libsrtp2-1_2.3.0-2_amd64.deb ...
Unpacking libsrtp2-1:amd64 (2.3.0-2) ...
Selecting previously unselected package libusrsctp1:amd64.
Preparing to unpack .../091-libusrsctp1_0.9.3.0+20190901-1_amd64.deb ...
Unpacking libusrsctp1:amd64 (0.9.3.0+20190901-1) ...
Selecting previously unselected package libv4lconvert0:amd64.
Preparing to unpack .../092-libv4lconvert0_1.18.0-2build1_amd64.deb ...
Unpacking libv4lconvert0:amd64 (1.18.0-2build1) ...
Selecting previously unselected package libv4l-0:amd64.
Preparing to unpack .../093-libv4l-0_1.18.0-2build1_amd64.deb ...
Unpacking libv4l-0:amd64 (1.18.0-2build1) ...
Selecting previously unselected package libwebrtc-audio-processing1:amd64.
Preparing to unpack .../094-libwebrtc-audio-processing1_0.3.1-0ubuntu3_amd64.deb ...
Unpacking libwebrtc-audio-processing1:amd64 (0.3.1-0ubuntu3) ...
Selecting previously unselected package libwildmidi2:amd64.
Preparing to unpack .../095-libwildmidi2_0.4.3-1_amd64.deb ...
Unpacking libwildmidi2:amd64 (0.4.3-1) ...
Selecting previously unselected package libzbar0:amd64.
Preparing to unpack .../096-libzbar0_0.23-1.3_amd64.deb ...
Unpacking libzbar0:amd64 (0.23-1.3) ...
Selecting previously unselected package mesa-va-drivers:amd64.
Preparing to unpack .../097-mesa-va-drivers_21.0.3-0ubuntu0.3~20.04.1_amd64.deb ...
Unpacking mesa-va-drivers:amd64 (21.0.3-0ubuntu0.3~20.04.1) ...
Selecting previously unselected package mesa-vdpau-drivers:amd64.
Preparing to unpack .../098-mesa-vdpau-drivers_21.0.3-0ubuntu0.3~20.04.1_amd64.deb ...
Unpacking mesa-vdpau-drivers:amd64 (21.0.3-0ubuntu0.3~20.04.1) ...
Selecting previously unselected package i965-va-driver:amd64.
Preparing to unpack .../099-i965-va-driver_2.4.0-0ubuntu1_amd64.deb ...
Unpacking i965-va-driver:amd64 (2.4.0-0ubuntu1) ...
Selecting previously unselected package va-driver-all:amd64.
Preparing to unpack .../100-va-driver-all_2.7.0-2_amd64.deb ...
Unpacking va-driver-all:amd64 (2.7.0-2) ...
Selecting previously unselected package vdpau-driver-all:amd64.
Preparing to unpack .../101-vdpau-driver-all_1.3-1ubuntu2_amd64.deb ...
Unpacking vdpau-driver-all:amd64 (1.3-1ubuntu2) ...
Selecting previously unselected package libdc1394-22:amd64.
Preparing to unpack .../102-libdc1394-22_2.2.5-2.1_amd64.deb ...
Unpacking libdc1394-22:amd64 (2.2.5-2.1) ...
Selecting previously unselected package libdca0:amd64.
Preparing to unpack .../103-libdca0_0.0.6-1_amd64.deb ...
Unpacking libdca0:amd64 (0.0.6-1) ...
Selecting previously unselected package libgstreamer-plugins-bad1.0-0:amd64.
Preparing to unpack .../104-libgstreamer-plugins-bad1.0-0_1.16.2-2.1ubuntu1_amd64.deb ...
Unpacking libgstreamer-plugins-bad1.0-0:amd64 (1.16.2-2.1ubuntu1) ...
Selecting previously unselected package libgstreamer-plugins-good1.0-0:amd64.
Preparing to unpack .../105-libgstreamer-plugins-good1.0-0_1.16.2-1ubuntu2.1_amd64.deb ...
Unpacking libgstreamer-plugins-good1.0-0:amd64 (1.16.2-1ubuntu2.1) ...
Selecting previously unselected package libopenal1:amd64.
Preparing to unpack .../106-libopenal1_1%3a1.19.1-1_amd64.deb ...
Unpacking libopenal1:amd64 (1:1.19.1-1) ...
Selecting previously unselected package libsbc1:amd64.
Preparing to unpack .../107-libsbc1_1.4-1_amd64.deb ...
Unpacking libsbc1:amd64 (1.4-1) ...
Selecting previously unselected package libvo-aacenc0:amd64.
Preparing to unpack .../108-libvo-aacenc0_0.1.3-2_amd64.deb ...
Unpacking libvo-aacenc0:amd64 (0.1.3-2) ...
Selecting previously unselected package libvo-amrwbenc0:amd64.
Preparing to unpack .../109-libvo-amrwbenc0_0.1.3-2_amd64.deb ...
Unpacking libvo-amrwbenc0:amd64 (0.1.3-2) ...
Selecting previously unselected package gstreamer1.0-plugins-bad:amd64.
Preparing to unpack .../110-gstreamer1.0-plugins-bad_1.16.2-2.1ubuntu1_amd64.deb ...
Unpacking gstreamer1.0-plugins-bad:amd64 (1.16.2-2.1ubuntu1) ...
Setting up libgme0:amd64 (0.6.2-1build1) ...
Setting up libssh-gcrypt-4:amd64 (0.9.3-2ubuntu2.1) ...
Setting up libmodplug1:amd64 (1:0.8.9.0-2build1) ...
Setting up libcdparanoia0:amd64 (3.10.2+debian-13) ...
Setting up libvo-amrwbenc0:amd64 (0.1.3-2) ...
Setting up libraw1394-11:amd64 (2.1.2-1) ...
Setting up libsbc1:amd64 (1.4-1) ...
Setting up libkate1:amd64 (0.4.1-11build1) ...
Setting up libmpg123-0:amd64 (1.25.13-1) ...
Setting up libspeex1:amd64 (1.2~rc1.2-1.1ubuntu1) ...
Setting up libshine3:amd64 (3.1.1-2) ...
Setting up libtwolame0:amd64 (0.4.0-2) ...
Setting up libgsm1:amd64 (1.0.18-2) ...
Setting up libx264-155:amd64 (2:0.155.2917+git0a84d98-2) ...
Setting up libx265-179:amd64 (3.2.1-1build1) ...
Setting up libvisual-0.4-0:amd64 (0.4.0-17) ...
Setting up libsoxr0:amd64 (0.1.3-2build1) ...
Setting up libdvdread7:amd64 (6.1.0+really6.0.2-1) ...
Setting up libaom0:amd64 (1.0.0.errata1-3build1) ...
Setting up libsrtp2-1:amd64 (2.3.0-2) ...
Setting up libmysofa1:amd64 (1.0~dfsg0-1) ...
Setting up libdc1394-22:amd64 (2.2.5-2.1) ...
Setting up libwebrtc-audio-processing1:amd64 (0.3.1-0ubuntu3) ...
Setting up libenchant1c2a:amd64 (1.6.0-11.3build1) ...
Setting up libxvidcore4:amd64 (2:1.3.7-1) ...
Setting up libmpcdec6:amd64 (2:0.1~r495-2) ...
Setting up libspandsp2:amd64 (0.0.6+dfsg-2) ...
Setting up libsnappy1v5:amd64 (1.1.8-1build1) ...
Setting up libflac8:amd64 (1.3.3-1build1) ...
Setting up libvo-aacenc0:amd64 (0.1.3-2) ...
Setting up libsoundtouch1:amd64 (2.1.2+ds1-1build1) ...
Setting up libass9:amd64 (1:0.14.0-2) ...
Setting up libva2:amd64 (2.7.0-2) ...
Setting up libigdgmm11:amd64 (20.1.1+ds1-1) ...
Setting up libcodec2-0.9:amd64 (0.9.2-2) ...
Setting up enchant (1.6.0-11.3build1) ...
Setting up libopus0:amd64 (1.3.1-0ubuntu1) ...
Setting up libfaad2:amd64 (2.9.1-1) ...
Setting up intel-media-va-driver:amd64 (20.1.1+dfsg1-1) ...
Setting up liborc-0.4-0:amd64 (1:0.4.31-1) ...
Setting up libaacs0:amd64 (0.9.0-2) ...
Setting up libofa0:amd64 (0.9.3-21) ...
Setting up libsndio7.0:amd64 (1.5.0-3) ...
Setting up libbdplus0:amd64 (0.1.2-3) ...
Setting up libvidstab1.1:amd64 (1.1.0-2) ...
Setting up libsrt1:amd64 (1.4.0-1build1) ...
Setting up libflite1:amd64 (2.1-release-3) ...
Setting up libva-drm2:amd64 (2.7.0-2) ...
Setting up ocl-icd-libopencl1:amd64 (2.2.11-1ubuntu1) ...
Setting up libasyncns0:amd64 (0.8-6) ...
Setting up libwildmidi2:amd64 (0.4.3-1) ...
Setting up libvdpau1:amd64 (1.3-1ubuntu2) ...
Setting up libwavpack1:amd64 (5.2.0-1ubuntu0.1) ...
Setting up libbs2b0:amd64 (3.1.0+dfsg-2.2build1) ...
Setting up libtheora0:amd64 (1.1.1+dfsg.1-15ubuntu2) ...
Setting up libv4lconvert0:amd64 (1.18.0-2build1) ...
Setting up libdca0:amd64 (0.0.6-1) ...
Setting up libopenjp2-7:amd64 (2.3.1-1ubuntu4.20.04.1) ...
Setting up libopenal-data (1:1.19.1-1) ...
Setting up mesa-va-drivers:amd64 (21.0.3-0ubuntu0.3~20.04.1) ...
Setting up libbluray2:amd64 (1:1.2.0-1) ...
Setting up libde265-0:amd64 (1.0.4-1build1) ...
Setting up libsamplerate0:amd64 (0.1.9-2) ...
Setting up timgm6mb-soundfont (1.3-3) ...
update-alternatives: using /usr/share/sounds/sf2/TimGM6mb.sf2 to provide /usr/share/sounds/sf2/default-GM.sf2 (default-GM.sf2) in auto mode
update-alternatives: using /usr/share/sounds/sf2/TimGM6mb.sf2 to provide /usr/share/sounds/sf3/default-GM.sf3 (default-GM.sf3) in auto mode
Setting up libva-x11-2:amd64 (2.7.0-2) ...
Setting up libusrsctp1:amd64 (0.9.3.0+20190901-1) ...
Setting up libopenmpt0:amd64 (0.4.11-1build1) ...
Setting up libmjpegutils-2.1-0:amd64 (1:2.1.0+debian-6build1) ...
Setting up libzvbi-common (0.2.35-17) ...
Setting up libgssdp-1.2-0:amd64 (1.2.3-0ubuntu0.20.04.1) ...
Setting up libmp3lame0:amd64 (3.100-3) ...
Setting up i965-va-driver:amd64 (2.4.0-0ubuntu1) ...
Setting up libvorbisenc2:amd64 (1.3.6-2ubuntu1) ...
Setting up libdvdnav4:amd64 (6.0.1-1build1) ...
Setting up libserd-0-0:amd64 (0.30.2-1) ...
Setting up mesa-vdpau-drivers:amd64 (21.0.3-0ubuntu0.3~20.04.1) ...
Setting up libzvbi0:amd64 (0.2.35-17) ...
Setting up libgupnp-1.2-0:amd64 (1.2.4-0ubuntu1) ...
Setting up libgstreamer-plugins-base1.0-0:amd64 (1.16.2-4ubuntu0.1) ...
Setting up libopenal1:amd64 (1:1.19.1-1) ...
Setting up libavutil56:amd64 (7:4.2.4-1ubuntu0.1) ...
Setting up libv4l-0:amd64 (1.18.0-2build1) ...
Setting up libgstreamer-plugins-bad1.0-0:amd64 (1.16.2-2.1ubuntu1) ...
Setting up libgupnp-igd-1.0-4:amd64 (0.2.5-5) ...
Setting up libgstreamer-plugins-good1.0-0:amd64 (1.16.2-1ubuntu2.1) ...
Setting up gstreamer1.0-plugins-base:amd64 (1.16.2-4ubuntu0.1) ...
Setting up libnice10:amd64 (0.1.16-1) ...
Setting up va-driver-all:amd64 (2.7.0-2) ...
Setting up libpostproc55:amd64 (7:4.2.4-1ubuntu0.1) ...
Setting up libmpeg2encpp-2.1-0:amd64 (1:2.1.0+debian-6build1) ...
Setting up librubberband2:amd64 (1.8.2-1build1) ...
Setting up libjack-jackd2-0:amd64 (1.9.12~dfsg-2ubuntu2) ...
Setting up vdpau-driver-all:amd64 (1.3-1ubuntu2) ...
Setting up libsord-0-0:amd64 (0.16.4-1) ...
Setting up libsratom-0-0:amd64 (0.6.4-1) ...
Setting up libswscale5:amd64 (7:4.2.4-1ubuntu0.1) ...
Setting up libmplex2-2.1-0:amd64 (1:2.1.0+debian-6build1) ...
Setting up libsndfile1:amd64 (1.0.28-7ubuntu0.1) ...
Setting up liblilv-0-0:amd64 (0.24.6-1ubuntu0.1) ...
Setting up libinstpatch-1.0-2:amd64 (1.1.2-2build1) ...
Setting up libpulse0:amd64 (1:13.99.1-1ubuntu3.11) ...
Setting up libzbar0:amd64 (0.23-1.3) ...
Setting up libswresample3:amd64 (7:4.2.4-1ubuntu0.1) ...
Setting up libavcodec58:amd64 (7:4.2.4-1ubuntu0.1) ...
Setting up libsdl2-2.0-0:amd64 (2.0.10+dfsg1-3) ...
Setting up libfluidsynth2:amd64 (2.1.1-2) ...
Setting up libchromaprint1:amd64 (1.4.3-3build1) ...
Setting up libavformat58:amd64 (7:4.2.4-1ubuntu0.1) ...
Setting up gstreamer1.0-plugins-bad:amd64 (1.16.2-2.1ubuntu1) ...
Setting up libavfilter7:amd64 (7:4.2.4-1ubuntu0.1) ...
Setting up gstreamer1.0-libav:amd64 (1.16.2-2) ...
Processing triggers for man-db (2.9.1-1) ...
Processing triggers for libc-bin (2.31-0ubuntu9.2) ...
```



</details>
<details>
<summary><em>cli.js -u --deep '@dxos/*'</em></summary>

```Shell
Upgrading /home/runner/work/protocols/protocols/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/docs/package.json

 @dxos/docs-theme  ^1.0.0-beta.22  →  ^1.0.0-beta.23     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/toolchains/deps-checker/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/toolchains/esbuild-plugins/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/toolchains/node-library/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/bot/bot/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/bot/botkit/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/bot/botkit-client/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/bot/protocol-plugin-bot/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/async/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/codec-protobuf/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/crypto/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/debug/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/protobuf-compiler/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/random-access-multi-storage/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/rpc/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/testutils/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/util/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/echo-db/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/echo-protocol/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/echo-testing/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/feed-store/package.json

 @dxos/browser-runner  ^1.0.0-beta.8  →  ^1.0.0-beta.13     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/echo/messenger-model/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/model-factory/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/object-model/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/text-model/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/gravity/browser-mocha/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/gravity/browser-tests/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/gravity/gravity-core/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/halo/credentials/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/broadcast/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/network-devtools/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/network-generator/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/network-manager/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-network-generator/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-plugin-messenger/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-plugin-presence/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-plugin-replicator/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/signal/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/sdk/client/package.json

 @dxos/registry-client  ~1.1.1  →  ~1.1.2     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/sdk/config/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/sdk/demos/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/sdk/devtools/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/sdk/devtools-extension/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/sdk/react-client/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/sdk/react-ux/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/wallet/core/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/wallet/extension/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/wallet/playground/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/broadcast/example/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/packages/sdk/tutorials/apps/tasks-app/package.json

All dependencies match the latest package versions :)
```



</details>
<details>
<summary><em>npm install -g @microsoft/rush pnpm</em></summary>

```Shell
added 281 packages, and audited 282 packages in 10s

34 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

### stderr:

```Shell
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated @opentelemetry/types@0.2.0: Package renamed to @opentelemetry/api, see https://github.com/open-telemetry/opentelemetry-js
```

</details>
<details>
<summary><em>node common/scripts/install-run-rush.js install</em></summary>

```Shell
The rush.json configuration requests Rush version 5.45.2
Transforming /home/runner/work/protocols/protocols/common/config/rush/.npmrc
  --> "/home/runner/work/protocols/protocols/common/temp/install-run/@microsoft+rush@5.45.2/.npmrc"
Installing @microsoft/rush...

added 347 packages, and audited 348 packages in 9s

41 packages are looking for funding
  run `npm fund` for details

3 moderate severity vulnerabilities

To address all issues, run:
  npm audit fix --force

Run `npm audit` for details.
Successfully installed @microsoft/rush@5.45.2

Invoking "rush install"
-----------------------



Rush Multi-Project Build Tool 5.45.2 - https://rushjs.io
Node.js version is 16.1.0 (pre-LTS)


Starting "rush install"

Validating package manager shrinkwrap file.

Creating /home/runner/.rush/node-v16.1.0
Trying to acquire lock for pnpm-5.15.2
Acquired lock for pnpm-5.15.2
Installing pnpm version 5.15.2

Transforming /home/runner/work/protocols/protocols/common/config/rush/.npmrc
  --> "/home/runner/.rush/node-v16.1.0/pnpm-5.15.2/.npmrc"

Running "npm install" in /home/runner/.rush/node-v16.1.0/pnpm-5.15.2

added 1 package, and audited 2 packages in 974ms

1 package is looking for funding
  run `npm fund` for details

found 0 vulnerabilities
Successfully installed pnpm version 5.15.2

Symlinking "/home/runner/work/protocols/protocols/common/temp/pnpm-local"
  --> "/home/runner/.rush/node-v16.1.0/pnpm-5.15.2"

Using the default variant for installation.
Transforming /home/runner/work/protocols/protocols/common/config/rush/.npmrc
  --> "/home/runner/work/protocols/protocols/common/temp/.npmrc"
Copying "/home/runner/work/protocols/protocols/common/config/rush/pnpmfile.js"
  --> "/home/runner/work/protocols/protocols/common/temp/pnpmfile.js"

Updating workspace files in /home/runner/work/protocols/protocols/common/temp
WARNING: Not validating Git-based specifier: "dxos/jsondown#main"
WARNING: Not validating Git-based specifier: "dxos/hypercore-protocol#05513f9266f8bec4d29b144b72c59257c2d7bd60"
WARNING: Not validating Git-based specifier: "dxos/simple-hypercore-protocol#bc23f0747e55954ec0bd94754910c92f88ec561c"
Copying "/home/runner/work/protocols/protocols/common/config/rush/pnpm-lock.yaml"
  --> "/home/runner/work/protocols/protocols/common/temp/pnpm-lock.yaml"
Copying "/home/runner/work/protocols/protocols/common/config/rush/pnpm-lock.yaml"
  --> "/home/runner/work/protocols/protocols/common/temp/pnpm-lock-preinstall.yaml"

Checking installation in "/home/runner/work/protocols/protocols/common/temp"


Running "pnpm install" in /home/runner/work/protocols/protocols/common/temp

Scope: all 50 workspace projects
Using hooks from: /home/runner/work/protocols/protocols/common/temp/pnpmfile.js
readPackage hook is declared. Manifests of dependencies might get overridden
Progress: resolved 1, reused 0, downloaded 0, added 0
../../toolchains/deps-checker            |  WARN  deprecated @types/chalk@2.2.0
../../packages/gravity/browser-mocha     |  WARN  deprecated @types/chalk@2.2.0
../../packages/gravity/browser-mocha     |  WARN  deprecated uuid@3.4.0
../../packages/wallet/extension          |  WARN  deprecated uuid@3.4.0
Progress: resolved 51, reused 0, downloaded 40, added 0
Progress: resolved 51, reused 0, downloaded 41, added 0
.../common/random-access-multi-storage   |  WARN  deprecated @types/expect@24.3.0
../../packages/halo/credentials          |  WARN  deprecated @types/expect@24.3.0
Progress: resolved 105, reused 0, downloaded 94, added 0
Progress: resolved 105, reused 0, downloaded 95, added 0
Progress: resolved 142, reused 0, downloaded 132, added 0
Progress: resolved 143, reused 0, downloaded 132, added 0
../../packages/sdk/react-ux              |  WARN  deprecated @storybook/addon-knobs@6.3.0
../../packages/mesh/network-devtools     |  WARN  deprecated @storybook/addon-knobs@6.3.0
.../sdk/tutorials/apps/tasks-app         |  WARN  deprecated @storybook/addon-knobs@6.3.0
Progress: resolved 190, reused 0, downloaded 179, added 0
Progress: resolved 190, reused 0, downloaded 180, added 0
Progress: resolved 219, reused 0, downloaded 208, added 0
Progress: resolved 220, reused 0, downloaded 208, added 0
Progress: resolved 285, reused 0, downloaded 270, added 0
Progress: resolved 285, reused 0, downloaded 271, added 0
Progress: resolved 388, reused 0, downloaded 378, added 0
Progress: resolved 388, reused 0, downloaded 379, added 0
Progress: resolved 471, reused 0, downloaded 458, added 0
Progress: resolved 472, reused 0, downloaded 458, added 0
Progress: resolved 546, reused 0, downloaded 525, added 0
Progress: resolved 547, reused 0, downloaded 525, added 0
Progress: resolved 658, reused 0, downloaded 645, added 0
Progress: resolved 659, reused 0, downloaded 645, added 0
Progress: resolved 739, reused 0, downloaded 716, added 0
Progress: resolved 739, reused 0, downloaded 717, added 0
Progress: resolved 839, reused 0, downloaded 814, added 0
Progress: resolved 839, reused 0, downloaded 815, added 0
Progress: resolved 940, reused 0, downloaded 916, added 0
Progress: resolved 940, reused 0, downloaded 917, added 0
Progress: resolved 1013, reused 0, downloaded 993, added 0
Progress: resolved 1013, reused 0, downloaded 994, added 0
Progress: resolved 1054, reused 0, downloaded 1031, added 0
Progress: resolved 1054, reused 0, downloaded 1032, added 0
Progress: resolved 1091, reused 0, downloaded 1070, added 0
Progress: resolved 1092, reused 0, downloaded 1070, added 0
Progress: resolved 1179, reused 0, downloaded 1159, added 0
Progress: resolved 1180, reused 0, downloaded 1159, added 0
Progress: resolved 1239, reused 0, downloaded 1214, added 0
Progress: resolved 1240, reused 0, downloaded 1214, added 0
Progress: resolved 1318, reused 0, downloaded 1298, added 0
Progress: resolved 1318, reused 0, downloaded 1299, added 0
Progress: resolved 1472, reused 0, downloaded 1447, added 0
Progress: resolved 1473, reused 0, downloaded 1447, added 0
Progress: resolved 1609, reused 0, downloaded 1583, added 0
Progress: resolved 1610, reused 0, downloaded 1583, added 0
Progress: resolved 1728, reused 0, downloaded 1706, added 0
Progress: resolved 1728, reused 0, downloaded 1707, added 0
Progress: resolved 1854, reused 0, downloaded 1835, added 0
Progress: resolved 1854, reused 0, downloaded 1836, added 0
Progress: resolved 1957, reused 0, downloaded 1939, added 0
Progress: resolved 1958, reused 0, downloaded 1939, added 0
Progress: resolved 2064, reused 0, downloaded 2053, added 0
Progress: resolved 2065, reused 0, downloaded 2053, added 0
Progress: resolved 2188, reused 0, downloaded 2174, added 0
Progress: resolved 2188, reused 0, downloaded 2175, added 0
Progress: resolved 2298, reused 0, downloaded 2284, added 0
Progress: resolved 2299, reused 0, downloaded 2284, added 0
Progress: resolved 2398, reused 0, downloaded 2379, added 0
Progress: resolved 2398, reused 0, downloaded 2380, added 0
Progress: resolved 2538, reused 0, downloaded 2520, added 0
Progress: resolved 2538, reused 0, downloaded 2521, added 0
Progress: resolved 2644, reused 0, downloaded 2629, added 0
Progress: resolved 2644, reused 0, downloaded 2630, added 0
Progress: resolved 2761, reused 0, downloaded 2744, added 0
Progress: resolved 2761, reused 0, downloaded 2745, added 0
.                                        |    +2971 ++++++++++++++++++++++++++++
Progress: resolved 2874, reused 0, downloaded 2870, added 0
Progress: resolved 2874, reused 0, downloaded 2871, added 0
Packages are hard linked from the content-addressable store to the virtual store.
  Content-addressable store is at: /home/runner/work/protocols/protocols/common/temp/pnpm-store/v3
  Virtual store is at:             node_modules/.pnpm
Progress: resolved 2874, reused 0, downloaded 2871, added 1
Progress: resolved 2874, reused 0, downloaded 2873, added 555
Progress: resolved 2874, reused 0, downloaded 2873, added 556
Progress: resolved 2874, reused 0, downloaded 2874, added 1412
Progress: resolved 2874, reused 0, downloaded 2874, added 1413
Progress: resolved 2874, reused 0, downloaded 2874, added 2144
Progress: resolved 2874, reused 0, downloaded 2874, added 2145
Progress: resolved 2874, reused 0, downloaded 2874, added 2971, done
 WARN  Failed to find "/fsevents/2.3.2" in lockfile during hoisting. Next aliases will not be hoisted: fsevents
.../node_modules/core-js-pure postinstall$ node -e "try{require('./postinstall')}catch(e){}"
.../core-js@2.6.12/node_modules/core-js postinstall$ node -e "try{require('./postinstall')}catch(e){}"
.../core-js@3.12.1/node_modules/core-js postinstall$ node -e "try{require('./postinstall')}catch(e){}"
.../.pnpm/ejs@2.7.4/node_modules/ejs postinstall$ node ./postinstall.js
.../node_modules/@apollo/protobufjs postinstall$ node scripts/postinstall
.../core-js@2.6.12/node_modules/core-js postinstall: Done
.../node_modules/core-js-pure postinstall: Done
.../core-js@3.12.1/node_modules/core-js postinstall: Done
.../esbuild@0.11.23/node_modules/esbuild postinstall$ node install.js
.../.pnpm/ejs@2.7.4/node_modules/ejs postinstall: Done
.../fd-lock@1.2.0/node_modules/fd-lock install$ node-gyp-build
.../.pnpm/fsctl@1.0.0/node_modules/fsctl install$ node-gyp-build
.../node_modules/@apollo/protobufjs postinstall: Done
.../node_modules/leveldown install$ node-gyp-build
.../node_modules/playwright install$ node install.js
.../fd-lock@1.2.0/node_modules/fd-lock install: Done
.../node_modules/protobufjs postinstall$ node scripts/postinstall
.../.pnpm/fsctl@1.0.0/node_modules/fsctl install: Done
.../node_modules/leveldown install: Done
.../node_modules/puppeteer install$ node install.js
.../robotjs@0.6.0/node_modules/robotjs install$ prebuild-install || node-gyp rebuild
.../node_modules/protobufjs postinstall: Done
.../node_modules/secp256k1 install$ npm run rebuild || echo "Secp256k1 bindings compilation fail. Pure JS implementation will be used."
.../node_modules/secp256k1 install: > secp256k1@3.8.0 rebuild
.../node_modules/secp256k1 install: > node-gyp rebuild
.../robotjs@0.6.0/node_modules/robotjs install: prebuild-install WARN install No prebuilt binaries found (target=16.1.0 runtime=node arch=x64 libc= platform=linux)
.../robotjs@0.6.0/node_modules/robotjs install: gyp info it worked if it ends with ok
.../node_modules/secp256k1 install: gyp info it worked if it ends with ok
.../robotjs@0.6.0/node_modules/robotjs install: gyp info using node-gyp@7.1.2
.../robotjs@0.6.0/node_modules/robotjs install: gyp info using node@16.1.0 | linux | x64
.../node_modules/secp256k1 install: gyp info using node-gyp@7.1.2
.../node_modules/secp256k1 install: gyp info using node@16.1.0 | linux | x64
.../robotjs@0.6.0/node_modules/robotjs install: gyp info find Python using Python version 3.8.10 found at "/usr/bin/python3"
.../node_modules/secp256k1 install: gyp info find Python using Python version 3.8.10 found at "/usr/bin/python3"
.../esbuild@0.11.23/node_modules/esbuild postinstall: Done
.../node_modules/sodium-native install$ node-gyp-build "node preinstall.js" "node postinstall.js"
.../robotjs@0.6.0/node_modules/robotjs install: gyp http GET https://nodejs.org/download/release/v16.1.0/node-v16.1.0-headers.tar.gz
.../node_modules/secp256k1 install: gyp http GET https://nodejs.org/download/release/v16.1.0/node-v16.1.0-headers.tar.gz
.../robotjs@0.6.0/node_modules/robotjs install: gyp http 200 https://nodejs.org/download/release/v16.1.0/node-v16.1.0-headers.tar.gz
.../node_modules/secp256k1 install: gyp http 200 https://nodejs.org/download/release/v16.1.0/node-v16.1.0-headers.tar.gz
.../node_modules/secp256k1 install: gyp http GET https://nodejs.org/download/release/v16.1.0/SHASUMS256.txt
.../node_modules/secp256k1 install: gyp http 200 https://nodejs.org/download/release/v16.1.0/SHASUMS256.txt
.../node_modules/secp256k1 install: (node:4596) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
.../node_modules/secp256k1 install: (Use `node --trace-deprecation ...` to show where the warning was created)
.../node_modules/secp256k1 install: gyp info spawn /usr/bin/python3
.../node_modules/secp256k1 install: gyp info spawn args [
.../node_modules/secp256k1 install: gyp info spawn args   '/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
.../node_modules/secp256k1 install: gyp info spawn args   'binding.gyp',
.../node_modules/secp256k1 install: gyp info spawn args   '-f',
.../node_modules/secp256k1 install: gyp info spawn args   'make',
.../node_modules/secp256k1 install: gyp info spawn args   '-I',
.../node_modules/secp256k1 install: gyp info spawn args   '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/secp256k1@3.8.0/node_modules/secp256k1/build/config.gypi',
.../node_modules/secp256k1 install: gyp info spawn args   '-I',
.../node_modules/secp256k1 install: gyp info spawn args   '/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
.../node_modules/secp256k1 install: gyp info spawn args   '-I',
.../node_modules/secp256k1 install: gyp info spawn args   '/home/runner/.cache/node-gyp/16.1.0/include/node/common.gypi',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dlibrary=shared_library',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dvisibility=default',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/16.1.0',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dnode_gyp_dir=/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/16.1.0/<(target_arch)/node.lib',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/secp256k1@3.8.0/node_modules/secp256k1',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dnode_engine=v8',
.../node_modules/secp256k1 install: gyp info spawn args   '--depth=.',
.../node_modules/secp256k1 install: gyp info spawn args   '--no-parallel',
.../node_modules/secp256k1 install: gyp info spawn args   '--generator-output',
.../node_modules/secp256k1 install: gyp info spawn args   'build',
.../node_modules/secp256k1 install: gyp info spawn args   '-Goutput_dir=.'
.../node_modules/secp256k1 install: gyp info spawn args ]
.../node_modules/sodium-native install: autoreconf: Entering directory `.'
.../node_modules/sodium-native install: autoreconf: configure.ac: not using Gettext
.../robotjs@0.6.0/node_modules/robotjs install: gyp http GET https://nodejs.org/download/release/v16.1.0/SHASUMS256.txt
.../robotjs@0.6.0/node_modules/robotjs install: gyp http 200 https://nodejs.org/download/release/v16.1.0/SHASUMS256.txt
.../robotjs@0.6.0/node_modules/robotjs install: (node:4595) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
.../robotjs@0.6.0/node_modules/robotjs install: (Use `node --trace-deprecation ...` to show where the warning was created)
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn /usr/bin/python3
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args [
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '/home/runner/.rush/node-v16.1.0/pnpm-5.15.2/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   'binding.gyp',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-f',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   'make',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-I',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/robotjs@0.6.0/node_modules/robotjs/build/config.gypi',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-I',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '/home/runner/.rush/node-v16.1.0/pnpm-5.15.2/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-I',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '/home/runner/.cache/node-gyp/16.1.0/include/node/common.gypi',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Dlibrary=shared_library',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Dvisibility=default',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/16.1.0',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Dnode_gyp_dir=/home/runner/.rush/node-v16.1.0/pnpm-5.15.2/node_modules/pnpm/dist/node_modules/node-gyp',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/16.1.0/<(target_arch)/node.lib',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/robotjs@0.6.0/node_modules/robotjs',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Dnode_engine=v8',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '--depth=.',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '--no-parallel',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '--generator-output',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   'build',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Goutput_dir=.'
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args ]
.../node_modules/secp256k1 install: gyp info spawn make
.../node_modules/secp256k1 install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
.../node_modules/sodium-native install: autoreconf: running: aclocal --force -I m4
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn make
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
.../robotjs@0.6.0/node_modules/robotjs install: make: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/robotjs@0.6.0/node_modules/robotjs/build'
.../node_modules/secp256k1 install: make: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/secp256k1@3.8.0/node_modules/secp256k1/build'
.../robotjs@0.6.0/node_modules/robotjs install:   CXX(target) Release/obj.target/robotjs/src/robotjs.o
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/addon.o
.../robotjs@0.6.0/node_modules/robotjs install: cc1plus: warning: command line option ‘-Wbad-function-cast’ is valid for C/ObjC but not for C++
.../node_modules/secp256k1 install: In file included from ../src/addon.cc:1:
.../node_modules/secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:806:43: warning: cast between incompatible function types from ‘void (*)(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)’ {aka ‘void (*)(v8::Local<v8::Object>)’} to ‘node::addon_register_func’ {aka ‘void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)’} [-Wcast-function-type]
.../node_modules/secp256k1 install:   806 |       (node::addon_register_func) (regfunc),                          \
.../node_modules/secp256k1 install:       |                                           ^
.../node_modules/secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:840:3: note: in expansion of macro ‘NODE_MODULE_X’
.../node_modules/secp256k1 install:   840 |   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
.../node_modules/secp256k1 install:       |   ^~~~~~~~~~~~~
.../node_modules/secp256k1 install: ../src/addon.cc:50:1: note: in expansion of macro ‘NODE_MODULE’
.../node_modules/secp256k1 install:    50 | NODE_MODULE(secp256k1, Init)
.../node_modules/secp256k1 install:       | ^~~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: In file included from ../src/robotjs.cc:1:
.../robotjs@0.6.0/node_modules/robotjs install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:806:43: warning: cast between incompatible function types from ‘void (*)(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)’ {aka ‘void (*)(v8::Local<v8::Object>)’} to ‘node::addon_register_func’ {aka ‘void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)’} [-Wcast-function-type]
.../robotjs@0.6.0/node_modules/robotjs install:   806 |       (node::addon_register_func) (regfunc),                          \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                           ^
.../robotjs@0.6.0/node_modules/robotjs install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:840:3: note: in expansion of macro ‘NODE_MODULE_X’
.../robotjs@0.6.0/node_modules/robotjs install:   840 |   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
.../robotjs@0.6.0/node_modules/robotjs install:       |   ^~~~~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: ../src/robotjs.cc:907:1: note: in expansion of macro ‘NODE_MODULE’
.../robotjs@0.6.0/node_modules/robotjs install:   907 | NODE_MODULE(robotjs, InitAll)
.../robotjs@0.6.0/node_modules/robotjs install:       | ^~~~~~~~~~~
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/privatekey.o
.../node_modules/playwright install: chromium v878941 downloaded to /home/runner/.cache/ms-playwright/chromium-878941
.../node_modules/puppeteer install: Chromium (756035) downloaded to /home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/puppeteer@3.3.0/node_modules/puppeteer/.local-chromium/linux-756035
.../node_modules/puppeteer install: Done
.../node_modules/sodium-native install$ node-gyp-build "node preinstall.js" "node postinstall.js"
.../robotjs@0.6.0/node_modules/robotjs install: ../src/robotjs.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE keyToggle(Nan::NAN_METHOD_ARGS_TYPE)’:
.../robotjs@0.6.0/node_modules/robotjs install: ../src/robotjs.cc:592:17: warning: ‘down’ may be used uninitialized in this function [-Wmaybe-uninitialized]
.../robotjs@0.6.0/node_modules/robotjs install:   592 |    toggleKeyCode(key, down, flags);
.../robotjs@0.6.0/node_modules/robotjs install:       |    ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: In file included from ../../../../nan@2.14.2/node_modules/nan/nan_new.h:189,
.../robotjs@0.6.0/node_modules/robotjs install:                  from ../../../../nan@2.14.2/node_modules/nan/nan.h:290,
.../robotjs@0.6.0/node_modules/robotjs install:                  from ../src/robotjs.cc:2:
.../robotjs@0.6.0/node_modules/robotjs install: ../../../../nan@2.14.2/node_modules/nan/nan_implementation_12_inl.h: In function ‘void InitAll(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)’:
.../robotjs@0.6.0/node_modules/robotjs install: ../../../../nan@2.14.2/node_modules/nan/nan_implementation_12_inl.h:119:1: warning: inlining failed in call to ‘static Nan::imp::FactoryBase<v8::FunctionTemplate>::return_t Nan::imp::Factory<v8::FunctionTemplate>::New(Nan::FunctionCallback, v8::Local<v8::Value>, v8::Local<v8::Signature>)’: --param large-function-growth limit reached [-Winline]
.../robotjs@0.6.0/node_modules/robotjs install:   119 | Factory<v8::FunctionTemplate>::New( FunctionCallback callback
.../robotjs@0.6.0/node_modules/robotjs install:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: In file included from ../../../../nan@2.14.2/node_modules/nan/nan.h:290,
.../robotjs@0.6.0/node_modules/robotjs install:                  from ../src/robotjs.cc:2:
.../robotjs@0.6.0/node_modules/robotjs install: ../../../../nan@2.14.2/node_modules/nan/nan_new.h:239:32: note: called from here
.../robotjs@0.6.0/node_modules/robotjs install:   239 |     return imp::Factory<T>::New(callback, data);
.../robotjs@0.6.0/node_modules/robotjs install:       |            ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: In file included from ../../../../nan@2.14.2/node_modules/nan/nan_new.h:189,
.../robotjs@0.6.0/node_modules/robotjs install:                  from ../../../../nan@2.14.2/node_modules/nan/nan.h:290,
.../robotjs@0.6.0/node_modules/robotjs install:                  from ../src/robotjs.cc:2:
.../robotjs@0.6.0/node_modules/robotjs install: ../../../../nan@2.14.2/node_modules/nan/nan_implementation_12_inl.h:119:1: warning: inlining failed in call to ‘static Nan::imp::FactoryBase<v8::FunctionTemplate>::return_t Nan::imp::Factory<v8::FunctionTemplate>::New(Nan::FunctionCallback, v8::Local<v8::Value>, v8::Local<v8::Signature>)’: --param large-function-growth limit reached [-Winline]
.../robotjs@0.6.0/node_modules/robotjs install:   119 | Factory<v8::FunctionTemplate>::New( FunctionCallback callback
.../robotjs@0.6.0/node_modules/robotjs install:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: In file included from ../../../../nan@2.14.2/node_modules/nan/nan.h:290,
.../robotjs@0.6.0/node_modules/robotjs install:                  from ../src/robotjs.cc:2:
.../robotjs@0.6.0/node_modules/robotjs install: ../../../../nan@2.14.2/node_modules/nan/nan_new.h:239:32: note: called from here
.../robotjs@0.6.0/node_modules/robotjs install:   239 |     return imp::Factory<T>::New(callback, data);
.../robotjs@0.6.0/node_modules/robotjs install:       |            ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
.../node_modules/sodium-native install: Done
.../node_modules/tiny-secp256k1 install$ npm run build || echo "secp256k1 bindings compilation fail. Pure JS implementation will be used."
.../node_modules/tiny-secp256k1 install: > tiny-secp256k1@1.1.6 build
.../node_modules/tiny-secp256k1 install: > node-gyp rebuild
.../node_modules/tiny-secp256k1 install: gyp info it worked if it ends with ok
.../node_modules/tiny-secp256k1 install: gyp info using node-gyp@7.1.2
.../node_modules/tiny-secp256k1 install: gyp info using node@16.1.0 | linux | x64
.../node_modules/tiny-secp256k1 install: gyp info find Python using Python version 3.8.10 found at "/usr/bin/python3"
.../node_modules/secp256k1 install: ../src/privatekey.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE privateKeyNegate(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/secp256k1 install: ../src/privatekey.cc:73:30: warning: ignoring return value of ‘int secp256k1_ec_privkey_negate(const secp256k1_context*, unsigned char*)’, declared with attribute warn_unused_result [-Wunused-result]
.../node_modules/secp256k1 install:    73 |   secp256k1_ec_privkey_negate(secp256k1ctx, &private_key[0]);
.../node_modules/secp256k1 install:       |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../node_modules/tiny-secp256k1 install: (node:4825) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
.../node_modules/tiny-secp256k1 install: (Use `node --trace-deprecation ...` to show where the warning was created)
.../node_modules/tiny-secp256k1 install: gyp info spawn /usr/bin/python3
.../node_modules/tiny-secp256k1 install: gyp info spawn args [
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   'binding.gyp',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-f',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   'make',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-I',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/tiny-secp256k1@1.1.6/node_modules/tiny-secp256k1/build/config.gypi',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-I',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-I',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '/home/runner/.cache/node-gyp/16.1.0/include/node/common.gypi',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dlibrary=shared_library',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dvisibility=default',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/16.1.0',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dnode_gyp_dir=/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/16.1.0/<(target_arch)/node.lib',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/tiny-secp256k1@1.1.6/node_modules/tiny-secp256k1',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dnode_engine=v8',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '--depth=.',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '--no-parallel',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '--generator-output',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   'build',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Goutput_dir=.'
.../node_modules/tiny-secp256k1 install: gyp info spawn args ]
.../node_modules/tiny-secp256k1 install: gyp info spawn make
.../node_modules/tiny-secp256k1 install: make: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/tiny-secp256k1@1.1.6/node_modules/tiny-secp256k1/build'
.../node_modules/tiny-secp256k1 install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
.../node_modules/tiny-secp256k1 install:   CXX(target) Release/obj.target/secp256k1/native/addon.o
.../node_modules/sodium-native install: autoreconf: configure.ac: tracing
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/deadbeef_rand.o
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/publickey.o
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/mouse.o
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/keypress.o
.../robotjs@0.6.0/node_modules/robotjs install: ../src/keypress.c: In function ‘typeString’:
.../robotjs@0.6.0/node_modules/robotjs install: ../src/keypress.c:274:16: warning: ‘n’ may be used uninitialized in this function [-Wmaybe-uninitialized]
.../robotjs@0.6.0/node_modules/robotjs install:   274 |  unsigned long n;
.../robotjs@0.6.0/node_modules/robotjs install:       |                ^
.../node_modules/tiny-secp256k1 install: In file included from ../../../../nan@2.14.2/node_modules/nan/nan.h:56,
.../node_modules/tiny-secp256k1 install:                  from ../native/addon.cpp:4:
.../node_modules/tiny-secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:806:43: warning: cast between incompatible function types from ‘void (*)(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)’ {aka ‘void (*)(v8::Local<v8::Object>)’} to ‘node::addon_register_func’ {aka ‘void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)’} [-Wcast-function-type]
.../node_modules/tiny-secp256k1 install:   806 |       (node::addon_register_func) (regfunc),                          \
.../node_modules/tiny-secp256k1 install:       |                                           ^
.../node_modules/tiny-secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:840:3: note: in expansion of macro ‘NODE_MODULE_X’
.../node_modules/tiny-secp256k1 install:   840 |   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
.../node_modules/tiny-secp256k1 install:       |   ^~~~~~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:372:1: note: in expansion of macro ‘NODE_MODULE’
.../node_modules/tiny-secp256k1 install:   372 | NODE_MODULE(secp256k1, Init)
.../node_modules/tiny-secp256k1 install:       | ^~~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/keycode.o
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp: In instantiation of ‘unsigned int {anonymous}::assumeCompression(const I&, const A&) [with long unsigned int index = 2; I = Nan::FunctionCallbackInfo<v8::Value>; A = v8::Local<v8::Object>]’:
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:151:50:   required from here
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:80:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
.../node_modules/tiny-secp256k1 install:    80 |   if (info.Length() <= index || info[index]->IsUndefined()) {
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp: In instantiation of ‘unsigned int {anonymous}::assumeCompression(const I&, const A&) [with long unsigned int index = 1; I = Nan::FunctionCallbackInfo<v8::Value>; A = v8::Local<v8::Object>]’:
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:183:49:   required from here
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:80:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp: In instantiation of ‘unsigned int {anonymous}::assumeCompression(const I&) [with long unsigned int index = 1; I = Nan::FunctionCallbackInfo<v8::Value>]’:
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:198:46:   required from here
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:92:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
.../node_modules/tiny-secp256k1 install:    92 |   if (info.Length() <= index) return SECP256K1_EC_COMPRESSED;
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp: In function ‘Nan::NAN_METHOD_RETURN_TYPE eccPrivateSub(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:249:29: warning: ignoring return value of ‘int secp256k1_ec_privkey_negate(const secp256k1_context*, unsigned char*)’, declared with attribute warn_unused_result [-Wunused-result]
.../node_modules/tiny-secp256k1 install:   249 |  secp256k1_ec_privkey_negate(context, tweak_negated); // returns 1 always
.../node_modules/tiny-secp256k1 install:       |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/screen.o
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/screengrab.o
.../node_modules/sodium-native install: autoreconf: configure.ac: creating directory build-aux
.../node_modules/sodium-native install: autoreconf: running: libtoolize --copy --force
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/snprintf.o
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c: In function ‘portable_vsnprintf’:
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:557:35: warning: operand of ?: changes signedness from ‘long int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   557 |       size_t n = !q ? strlen(p) : (q-p);
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^~~~~
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:704:42: warning: operand of ?: changes signedness from ‘long int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   704 |             str_arg_l = !q ? precision : (q-str_arg);
.../robotjs@0.6.0/node_modules/robotjs install:       |                                          ^~~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:943:62: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   943 |             fast_memset(str+str_l, (zero_padding?'0':' '), (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                                              ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:372:35: note: in definition of macro ‘fast_memset’
.../robotjs@0.6.0/node_modules/robotjs install:   372 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:943:75: warning: operand of ?: changes signedness from ‘int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   943 |             fast_memset(str+str_l, (zero_padding?'0':' '), (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                                                           ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:372:35: note: in definition of macro ‘fast_memset’
.../robotjs@0.6.0/node_modules/robotjs install:   372 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:960:47: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   960 |             fast_memcpy(str+str_l, str_arg, (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                               ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:365:35: note: in definition of macro ‘fast_memcpy’
.../robotjs@0.6.0/node_modules/robotjs install:   365 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:960:60: warning: operand of ?: changes signedness from ‘int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   960 |             fast_memcpy(str+str_l, str_arg, (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                                            ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:365:35: note: in definition of macro ‘fast_memcpy’
.../robotjs@0.6.0/node_modules/robotjs install:   365 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:969:43: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   969 |             fast_memset(str+str_l, '0', (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                           ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:372:35: note: in definition of macro ‘fast_memset’
.../robotjs@0.6.0/node_modules/robotjs install:   372 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:969:56: warning: operand of ?: changes signedness from ‘int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   969 |             fast_memset(str+str_l, '0', (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                                        ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:372:35: note: in definition of macro ‘fast_memset’
.../robotjs@0.6.0/node_modules/robotjs install:   372 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:981:27: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   981 |                         (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                           ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:365:35: note: in definition of macro ‘fast_memcpy’
.../robotjs@0.6.0/node_modules/robotjs install:   365 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:981:40: warning: operand of ?: changes signedness from ‘int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   981 |                         (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                        ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:365:35: note: in definition of macro ‘fast_memcpy’
.../robotjs@0.6.0/node_modules/robotjs install:   365 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:992:43: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   992 |             fast_memset(str+str_l, ' ', (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                           ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:372:35: note: in definition of macro ‘fast_memset’
.../robotjs@0.6.0/node_modules/robotjs install:   372 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:992:56: warning: operand of ?: changes signedness from ‘int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   992 |             fast_memset(str+str_l, ' ', (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                                        ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:372:35: note: in definition of macro ‘fast_memset’
.../robotjs@0.6.0/node_modules/robotjs install:   372 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:564:19: warning: variable ‘starting_p’ set but not used [-Wunused-but-set-variable]
.../robotjs@0.6.0/node_modules/robotjs install:   564 |       const char *starting_p;
.../robotjs@0.6.0/node_modules/robotjs install:       |                   ^~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:369:48: warning: ‘str_arg’ may be used uninitialized in this function [-Wmaybe-uninitialized]
.../robotjs@0.6.0/node_modules/robotjs install:   369 |       for (ss=(s), dd=(d); nn>0; nn--) *dd++ = *ss++; } }
.../robotjs@0.6.0/node_modules/robotjs install:       |                                                ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:573:19: note: ‘str_arg’ was declared here
.../robotjs@0.6.0/node_modules/robotjs install:   573 |       const char *str_arg;      /* string address in case of string argument */
.../robotjs@0.6.0/node_modules/robotjs install:       |                   ^~~~~~~
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/signature.o
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/MMBitmap.o
.../node_modules/tiny-secp256k1 install:   CC(target) Release/obj.target/secp256k1/native/secp256k1/src/secp256k1.o
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/xdisplay.o
.../node_modules/tiny-secp256k1 install: In file included from ../native/secp256k1/src/assumptions.h:12,
.../node_modules/tiny-secp256k1 install:                  from ../native/secp256k1/src/secp256k1.c:10:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_context_preallocated_clone’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘prealloc’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:168:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   168 |     ARG_CHECK(prealloc != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_parse’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:283:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   283 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘input’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:285:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   285 |     ARG_CHECK(input != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_serialize’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘output’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:307:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   307 |     ARG_CHECK(output != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘outputlen’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:303:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   303 |     ARG_CHECK(outputlen != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:309:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   309 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_signature_parse_der’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sig’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:348:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   348 |     ARG_CHECK(sig != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘input’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:349:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   349 |     ARG_CHECK(input != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_signature_parse_compact’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sig’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:366:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   366 |     ARG_CHECK(sig != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘input64’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:367:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   367 |     ARG_CHECK(input64 != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_signature_serialize_der’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘output’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:385:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   385 |     ARG_CHECK(output != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘outputlen’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:386:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   386 |     ARG_CHECK(outputlen != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sig’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:387:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   387 |     ARG_CHECK(sig != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_signature_serialize_compact’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘output64’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:397:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   397 |     ARG_CHECK(output64 != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sig’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:398:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   398 |     ARG_CHECK(sig != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_signature_normalize’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sigin’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:411:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   411 |     ARG_CHECK(sigin != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_verify’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sig’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:432:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   432 |     ARG_CHECK(sig != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘msg32’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:431:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   431 |     ARG_CHECK(msg32 != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:433:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   433 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_sign’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘signature’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:542:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   542 |     ARG_CHECK(signature != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘msg32’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:541:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   541 |     ARG_CHECK(msg32 != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:543:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   543 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_seckey_verify’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:554:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   554 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_create’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:578:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   578 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:581:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   581 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_seckey_negate’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:595:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   595 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_negate’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:614:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   614 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_seckey_tweak_add’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:641:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   641 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘tweak’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:642:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   642 |     ARG_CHECK(tweak != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_tweak_add’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:669:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   669 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘tweak’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:670:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   670 |     ARG_CHECK(tweak != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_seckey_tweak_mul’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:688:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   688 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘tweak’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:689:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   689 |     ARG_CHECK(tweak != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_tweak_mul’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:713:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   713 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘tweak’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:714:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   714 |     ARG_CHECK(tweak != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_combine’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubnonce’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:743:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   743 |     ARG_CHECK(pubnonce != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubnonces’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:746:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   746 |     ARG_CHECK(pubnonces != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: ../src/xdisplay.c: In function ‘setXDisplay’:
.../robotjs@0.6.0/node_modules/robotjs install: ../src/xdisplay.c:53:16: warning: implicit declaration of function ‘strdup’ [-Wimplicit-function-declaration]
.../robotjs@0.6.0/node_modules/robotjs install:    53 |  displayName = strdup(name);
.../robotjs@0.6.0/node_modules/robotjs install:       |                ^~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: ../src/xdisplay.c:53:16: warning: incompatible implicit declaration of built-in function ‘strdup’
.../robotjs@0.6.0/node_modules/robotjs install:   SOLINK_MODULE(target) Release/obj.target/robotjs.node
.../node_modules/sodium-native install: libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
.../node_modules/sodium-native install: libtoolize: copying file 'build-aux/ltmain.sh'
.../node_modules/playwright install: firefox v1250 downloaded to /home/runner/.cache/ms-playwright/firefox-1250
.../robotjs@0.6.0/node_modules/robotjs install:   COPY Release/robotjs.node
.../robotjs@0.6.0/node_modules/robotjs install: make: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/robotjs@0.6.0/node_modules/robotjs/build'
.../robotjs@0.6.0/node_modules/robotjs install: gyp info ok 
.../robotjs@0.6.0/node_modules/robotjs install: Done
.../node_modules/utp-native install$ node-gyp-build
.../node_modules/sodium-native install: libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
.../node_modules/sodium-native install: libtoolize: copying file 'm4/libtool.m4'
.../node_modules/utp-native install: Done
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install$ node scripts/download-prebuilt.js
.../node_modules/sodium-native install: libtoolize: copying file 'm4/ltoptions.m4'
.../node_modules/sodium-native install: libtoolize: copying file 'm4/ltsugar.m4'
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info it worked if it ends with ok
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info using node-pre-gyp@1.0.3
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info using node@16.1.0 | linux | x64
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info check checked for "/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/wrtc@0.4.7/node_modules/wrtc/build/Release/wrtc.node" (not found)
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp http GET https://node-webrtc.s3.amazonaws.com/wrtc/v0.4.7/Release/linux-x64.tar.gz
.../node_modules/sodium-native install: libtoolize: copying file 'm4/ltversion.m4'
.../node_modules/sodium-native install: libtoolize: copying file 'm4/lt~obsolete.m4'
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info install unpacking Release/wrtc.node
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/ecdsa.o
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info extracted file count: 1 
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: [wrtc] Success: "/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/wrtc@0.4.7/node_modules/wrtc/build/Release/wrtc.node" is installed via remote
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info ok 
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: Done
.../.pnpm/yjs@13.5.5/node_modules/yjs postinstall$ node ./sponsor-y.js
.../.pnpm/yjs@13.5.5/node_modules/yjs postinstall: Thank you for using Yjs ❤
.../.pnpm/yjs@13.5.5/node_modules/yjs postinstall: 
.../.pnpm/yjs@13.5.5/node_modules/yjs postinstall: The project has grown considerably in the past year. Too much for me to maintain
.../.pnpm/yjs@13.5.5/node_modules/yjs postinstall: in my spare time. Several companies built their products with Yjs.
.../.pnpm/yjs@13.5.5/node_modules/yjs postinstall: Yet, this project receives very little funding. Yjs is far from done. I want to
.../.pnpm/yjs@13.5.5/node_modules/yjs postinstall: create more awesome extensions and work on the growing number of open issues.
.../.pnpm/yjs@13.5.5/node_modules/yjs postinstall: Dear user, the future of this project entirely depends on you.
.../.pnpm/yjs@13.5.5/node_modules/yjs postinstall: 
.../.pnpm/yjs@13.5.5/node_modules/yjs postinstall: Please start funding the project now: https://github.com/sponsors/dmonad 
.../.pnpm/yjs@13.5.5/node_modules/yjs postinstall: 
.../.pnpm/yjs@13.5.5/node_modules/yjs postinstall: (This message will be removed when I achieved my funding goal)
.../.pnpm/yjs@13.5.5/node_modules/yjs postinstall: 
.../.pnpm/yjs@13.5.5/node_modules/yjs postinstall: Done
.../node_modules/secp256k1 install: ../src/ecdsa.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE sign(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/secp256k1 install: ../src/ecdsa.cc:88:131: warning: ignoring return value of ‘v8::Maybe<bool> v8::Object::Set(v8::Local<v8::Context>, v8::Local<v8::Value>, v8::Local<v8::Value>)’, declared with attribute warn_unused_result [-Wunused-result]
.../node_modules/secp256k1 install:    88 |   obj->Set(info.GetIsolate()->GetCurrentContext(), Nan::New<v8::String>("signature").ToLocalChecked(), COPY_BUFFER(&output[0], 64));
.../node_modules/secp256k1 install:       |                                                                                                                                   ^
.../node_modules/secp256k1 install: In file included from /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:63,
.../node_modules/secp256k1 install:                  from ../src/ecdsa.cc:1:
.../node_modules/secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/v8.h:3926:37: note: declared here
.../node_modules/secp256k1 install:  3926 |   V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context,
.../node_modules/secp256k1 install:       |                                     ^~~
.../node_modules/secp256k1 install: ../src/ecdsa.cc:89:130: warning: ignoring return value of ‘v8::Maybe<bool> v8::Object::Set(v8::Local<v8::Context>, v8::Local<v8::Value>, v8::Local<v8::Value>)’, declared with attribute warn_unused_result [-Wunused-result]
.../node_modules/secp256k1 install:    89 |   obj->Set(info.GetIsolate()->GetCurrentContext(), Nan::New<v8::String>("recovery").ToLocalChecked(), Nan::New<v8::Number>(recid));
.../node_modules/secp256k1 install:       |                                                                                                                                  ^
.../node_modules/secp256k1 install: In file included from /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:63,
.../node_modules/secp256k1 install:                  from ../src/ecdsa.cc:1:
.../node_modules/secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/v8.h:3926:37: note: declared here
.../node_modules/secp256k1 install:  3926 |   V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context,
.../node_modules/secp256k1 install:       |                                     ^~~
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/ecdh.o
.../node_modules/tiny-secp256k1 install:   SOLINK_MODULE(target) Release/obj.target/secp256k1.node
.../node_modules/tiny-secp256k1 install:   COPY Release/secp256k1.node
.../node_modules/tiny-secp256k1 install: make: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/tiny-secp256k1@1.1.6/node_modules/tiny-secp256k1/build'
.../node_modules/tiny-secp256k1 install: gyp info ok 
.../node_modules/tiny-secp256k1 install: Done
.../node_modules/sodium-native install: autoreconf: running: /usr/bin/autoconf --force
.../node_modules/playwright install: webkit v1472 downloaded to /home/runner/.cache/ms-playwright/webkit-1472
.../node_modules/secp256k1 install:   CC(target) Release/obj.target/secp256k1/src/secp256k1-src/src/secp256k1.o
.../node_modules/playwright install: ffmpeg v1005 downloaded to /home/runner/.cache/ms-playwright/ffmpeg-1005
.../node_modules/playwright install: Done
.../node_modules/sodium-native install: autoreconf: configure.ac: not using Autoheader
.../node_modules/sodium-native install: autoreconf: running: automake --add-missing --copy --force-missing
.../node_modules/sodium-native install: configure.ac:74: installing 'build-aux/compile'
.../node_modules/sodium-native install: configure.ac:9: installing 'build-aux/config.guess'
.../node_modules/sodium-native install: configure.ac:9: installing 'build-aux/config.sub'
.../node_modules/sodium-native install: configure.ac:10: installing 'build-aux/install-sh'
.../node_modules/sodium-native install: configure.ac:10: installing 'build-aux/missing'
.../node_modules/sodium-native install: src/libsodium/Makefile.am: installing 'build-aux/depcomp'
.../node_modules/secp256k1 install:   CC(target) Release/obj.target/secp256k1/src/secp256k1-src/contrib/lax_der_parsing.o
.../node_modules/secp256k1 install:   CC(target) Release/obj.target/secp256k1/src/secp256k1-src/contrib/lax_der_privatekey_parsing.o
.../node_modules/sodium-native install: parallel-tests: installing 'build-aux/test-driver'
.../node_modules/secp256k1 install:   SOLINK_MODULE(target) Release/obj.target/secp256k1.node
.../node_modules/sodium-native install: autoreconf: Leaving directory `.'
.../node_modules/secp256k1 install:   COPY Release/secp256k1.node
.../node_modules/secp256k1 install: make: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/secp256k1@3.8.0/node_modules/secp256k1/build'
.../node_modules/secp256k1 install: gyp info ok 
.../node_modules/secp256k1 install: Done
.../node_modules/sodium-native install: checking build system type... x86_64-pc-linux-gnu
.../node_modules/sodium-native install: checking host system type... x86_64-pc-linux-gnu
.../node_modules/sodium-native install: checking for a BSD-compatible install... /usr/bin/install -c
.../node_modules/sodium-native install: checking whether build environment is sane... yes
.../node_modules/sodium-native install: checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
.../node_modules/sodium-native install: checking for gawk... gawk
.../node_modules/sodium-native install: checking whether make sets $(MAKE)... yes
.../node_modules/sodium-native install: checking whether make supports nested variables... yes
.../node_modules/sodium-native install: checking whether UID '1001' is supported by ustar format... yes
.../node_modules/sodium-native install: checking whether GID '121' is supported by ustar format... yes
.../node_modules/sodium-native install: checking how to create a ustar tar archive... gnutar
.../node_modules/sodium-native install: checking whether make supports nested variables... (cached) yes
.../node_modules/sodium-native install: checking whether to enable maintainer-specific portions of Makefiles... no
.../node_modules/sodium-native install: checking whether make supports the include directive... yes (GNU style)
.../node_modules/sodium-native install: checking for gcc... gcc
.../node_modules/sodium-native install: checking whether the C compiler works... yes
.../node_modules/sodium-native install: checking for C compiler default output file name... a.out
.../node_modules/sodium-native install: checking for suffix of executables... 
.../node_modules/sodium-native install: checking whether we are cross compiling... no
.../node_modules/sodium-native install: checking for suffix of object files... o
.../node_modules/sodium-native install: checking whether we are using the GNU C compiler... yes
.../node_modules/sodium-native install: checking whether gcc accepts -g... yes
.../node_modules/sodium-native install: checking for gcc option to accept ISO C89... none needed
.../node_modules/sodium-native install: checking whether gcc understands -c and -o together... yes
.../node_modules/sodium-native install: checking dependency style of gcc... gcc3
.../node_modules/sodium-native install: checking for a sed that does not truncate output... /usr/bin/sed
.../node_modules/sodium-native install: checking how to run the C preprocessor... gcc -E
.../node_modules/sodium-native install: checking for grep that handles long lines and -e... /usr/bin/grep
.../node_modules/sodium-native install: checking for egrep... /usr/bin/grep -E
.../node_modules/sodium-native install: checking whether gcc is Clang... no
.../node_modules/sodium-native install: checking whether pthreads work with -pthread... yes
.../node_modules/sodium-native install: checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
.../node_modules/sodium-native install: checking whether more special flags are required for pthreads... no
.../node_modules/sodium-native install: checking for PTHREAD_PRIO_INHERIT... yes
.../node_modules/sodium-native install: checking for gcc option to accept ISO C99... none needed
.../node_modules/sodium-native install: checking dependency style of gcc... gcc3
.../node_modules/sodium-native install: checking for ANSI C header files... yes
.../node_modules/sodium-native install: checking for sys/types.h... yes
.../node_modules/sodium-native install: checking for sys/stat.h... yes
.../node_modules/sodium-native install: checking for stdlib.h... yes
.../node_modules/sodium-native install: checking for string.h... yes
.../node_modules/sodium-native install: checking for memory.h... yes
.../node_modules/sodium-native install: checking for strings.h... yes
.../node_modules/sodium-native install: checking for inttypes.h... yes
.../node_modules/sodium-native install: checking for stdint.h... yes
.../node_modules/sodium-native install: checking for unistd.h... yes
.../node_modules/sodium-native install: checking minix/config.h usability... no
.../node_modules/sodium-native install: checking minix/config.h presence... no
.../node_modules/sodium-native install: checking for minix/config.h... no
.../node_modules/sodium-native install: checking whether it is safe to define __EXTENSIONS__... yes
.../node_modules/sodium-native install: checking for variable-length arrays... yes
.../node_modules/sodium-native install: checking for __native_client__ defined... no
.../node_modules/sodium-native install: checking for _FORTIFY_SOURCE defined... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -fvisibility=hidden... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -fPIC... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -fPIE... yes
.../node_modules/sodium-native install: checking whether the linker accepts -pie... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -fno-strict-aliasing... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -fno-strict-overflow... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -fstack-protector... yes
.../node_modules/sodium-native install: checking whether the linker accepts -fstack-protector... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wall... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra... yes
.../node_modules/sodium-native install: checking for clang... no
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls -Wrestrict... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls -Wrestrict -Wshorten-64-to-32... no
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls -Wrestrict -Wsometimes-uninitialized... no
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls -Wrestrict -Wstrict-prototypes... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls -Wrestrict -Wstrict-prototypes -Wswitch-enum... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls -Wrestrict -Wstrict-prototypes -Wswitch-enum -Wvariable-decl... no
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls -Wrestrict -Wstrict-prototypes -Wswitch-enum -Wwrite-strings... yes
.../node_modules/sodium-native install: checking whether the linker accepts -Wl,-z,relro... yes
.../node_modules/sodium-native install: checking whether the linker accepts -Wl,-z,now... yes
.../node_modules/sodium-native install: checking whether the linker accepts -Wl,-z,noexecstack... yes
.../node_modules/sodium-native install: checking whether segmentation violations can be caught when using the C compiler... yes
.../node_modules/sodium-native install: checking whether SIGABRT can be caught when using the C compiler... yes
.../node_modules/sodium-native install: checking for thread local storage (TLS) class... _Thread_local
.../node_modules/sodium-native install: thread local storage is supported
.../node_modules/sodium-native install: checking whether C compiler accepts -ftls-model=local-dynamic... yes
.../node_modules/sodium-native install: checking how to print strings... printf
.../node_modules/sodium-native install: checking for a sed that does not truncate output... (cached) /usr/bin/sed
.../node_modules/sodium-native install: checking for fgrep... /usr/bin/grep -F
.../node_modules/sodium-native install: checking for ld used by gcc... /usr/bin/ld
.../node_modules/sodium-native install: checking if the linker (/usr/bin/ld) is GNU ld... yes
.../node_modules/sodium-native install: checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
.../node_modules/sodium-native install: checking the name lister (/usr/bin/nm -B) interface... BSD nm
.../node_modules/sodium-native install: checking whether ln -s works... yes
.../node_modules/sodium-native install: checking the maximum length of command line arguments... 3145728
.../node_modules/sodium-native install: checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
.../node_modules/sodium-native install: checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
.../node_modules/sodium-native install: checking for /usr/bin/ld option to reload object files... -r
.../node_modules/sodium-native install: checking for objdump... objdump
.../node_modules/sodium-native install: checking how to recognize dependent libraries... pass_all
.../node_modules/sodium-native install: checking for dlltool... no
.../node_modules/sodium-native install: checking how to associate runtime and link libraries... printf %s\n
.../node_modules/sodium-native install: checking for ar... ar
.../node_modules/sodium-native install: checking for archiver @FILE support... @
.../node_modules/sodium-native install: checking for strip... strip
.../node_modules/sodium-native install: checking for ranlib... ranlib
.../node_modules/sodium-native install: checking command to parse /usr/bin/nm -B output from gcc object... ok
.../node_modules/sodium-native install: checking for sysroot... no
.../node_modules/sodium-native install: checking for a working dd... /usr/bin/dd
.../node_modules/sodium-native install: checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
.../node_modules/sodium-native install: checking for mt... mt
.../node_modules/sodium-native install: checking if mt is a manifest tool... no
.../node_modules/sodium-native install: checking for dlfcn.h... yes
.../node_modules/sodium-native install: checking for objdir... .libs
.../node_modules/sodium-native install: checking if gcc supports -fno-rtti -fno-exceptions... no
.../node_modules/sodium-native install: checking for gcc option to produce PIC... -fPIC -DPIC
.../node_modules/sodium-native install: checking if gcc PIC flag -fPIC -DPIC works... yes
.../node_modules/sodium-native install: checking if gcc static flag -static works... yes
.../node_modules/sodium-native install: checking if gcc supports -c -o file.o... yes
.../node_modules/sodium-native install: checking if gcc supports -c -o file.o... (cached) yes
.../node_modules/sodium-native install: checking whether the gcc linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
.../node_modules/sodium-native install: checking whether -lc should be explicitly linked in... no
.../node_modules/sodium-native install: checking dynamic linker characteristics... GNU/Linux ld.so
.../node_modules/sodium-native install: checking how to hardcode library paths into programs... immediate
.../node_modules/sodium-native install: checking whether stripping libraries is possible... yes
.../node_modules/sodium-native install: checking if libtool supports shared libraries... yes
.../node_modules/sodium-native install: checking whether to build shared libraries... yes
.../node_modules/sodium-native install: checking whether to build static libraries... yes
.../node_modules/sodium-native install: checking for ar... (cached) ar
.../node_modules/sodium-native install: checking whether C compiler accepts -mmmx... yes
.../node_modules/sodium-native install: checking for MMX instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mmmx... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -msse2... yes
.../node_modules/sodium-native install: checking for SSE2 instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -msse2... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -msse3... yes
.../node_modules/sodium-native install: checking for SSE3 instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -msse3... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mssse3... yes
.../node_modules/sodium-native install: checking for SSSE3 instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mssse3... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -msse4.1... yes
.../node_modules/sodium-native install: checking for SSE4.1 instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -msse4.1... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mavx... yes
.../node_modules/sodium-native install: checking for AVX instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mavx... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mavx2... yes
.../node_modules/sodium-native install: checking for AVX2 instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mavx2... (cached) yes
.../node_modules/sodium-native install: checking if _mm256_broadcastsi128_si256 is correctly defined... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mavx512f... yes
.../node_modules/sodium-native install: checking for AVX512F instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mavx512f... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -maes... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mpclmul... yes
.../node_modules/sodium-native install: checking for AESNI instructions set and PCLMULQDQ... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -maes... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mpclmul... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mrdrnd... yes
.../node_modules/sodium-native install: checking for RDRAND... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mrdrnd... (cached) yes
.../node_modules/sodium-native install: checking sys/mman.h usability... yes
.../node_modules/sodium-native install: checking sys/mman.h presence... yes
.../node_modules/sodium-native install: checking for sys/mman.h... yes
.../node_modules/sodium-native install: checking intrin.h usability... no
.../node_modules/sodium-native install: checking intrin.h presence... no
.../node_modules/sodium-native install: checking for intrin.h... no
.../node_modules/sodium-native install: checking if _xgetbv() is available... no
.../node_modules/sodium-native install: checking for inline... inline
.../node_modules/sodium-native install: checking whether byte ordering is bigendian... (cached) no
.../node_modules/sodium-native install: checking whether __STDC_LIMIT_MACROS is required... no
.../node_modules/sodium-native install: checking whether we can use inline asm code... yes
.../node_modules/sodium-native install: no
.../node_modules/sodium-native install: checking whether we can use x86_64 asm code... yes
.../node_modules/sodium-native install: checking whether we can assemble AVX opcodes... yes
.../node_modules/sodium-native install: checking for 128-bit arithmetic... yes
.../node_modules/sodium-native install: checking for cpuid instruction... yes
.../node_modules/sodium-native install: checking if the .private_extern asm directive is supported... no
.../node_modules/sodium-native install: checking if the .hidden asm directive is supported... yes
.../node_modules/sodium-native install: checking if weak symbols are supported... yes
.../node_modules/sodium-native install: checking if data alignment is required... no
.../node_modules/sodium-native install: checking if atomic operations are supported... yes
.../node_modules/sodium-native install: checking for size_t... yes
.../node_modules/sodium-native install: checking for working alloca.h... yes
.../node_modules/sodium-native install: checking for alloca... yes
.../node_modules/sodium-native install: checking for arc4random... no
.../node_modules/sodium-native install: checking for arc4random_buf... no
.../node_modules/sodium-native install: checking for mmap... yes
.../node_modules/sodium-native install: checking for mlock... yes
.../node_modules/sodium-native install: checking for madvise... yes
.../node_modules/sodium-native install: checking for mprotect... yes
.../node_modules/sodium-native install: checking for memset_s... no
.../node_modules/sodium-native install: checking for explicit_bzero... yes
.../node_modules/sodium-native install: checking for explicit_memset... no
.../node_modules/sodium-native install: checking for nanosleep... yes
.../node_modules/sodium-native install: checking for posix_memalign... yes
.../node_modules/sodium-native install: checking for getpid... yes
.../node_modules/sodium-native install: checking if gcc/ld supports -Wl,--output-def... no
.../node_modules/sodium-native install: checking that generated files are newer than configure... done
.../node_modules/sodium-native install: configure: creating ./config.status
.../node_modules/sodium-native install: config.status: creating Makefile
.../node_modules/sodium-native install: config.status: creating builds/Makefile
.../node_modules/sodium-native install: config.status: creating contrib/Makefile
.../node_modules/sodium-native install: config.status: creating dist-build/Makefile
.../node_modules/sodium-native install: config.status: creating libsodium.pc
.../node_modules/sodium-native install: config.status: creating libsodium-uninstalled.pc
.../node_modules/sodium-native install: config.status: creating msvc-scripts/Makefile
.../node_modules/sodium-native install: config.status: creating src/Makefile
.../node_modules/sodium-native install: config.status: creating src/libsodium/Makefile
.../node_modules/sodium-native install: config.status: creating src/libsodium/include/Makefile
.../node_modules/sodium-native install: config.status: creating src/libsodium/include/sodium/version.h
.../node_modules/sodium-native install: config.status: creating test/default/Makefile
.../node_modules/sodium-native install: config.status: creating test/Makefile
.../node_modules/sodium-native install: config.status: executing depfiles commands
.../node_modules/sodium-native install: config.status: executing libtool commands
.../node_modules/sodium-native install: Making clean in builds
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/builds'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/builds'
.../node_modules/sodium-native install: Making clean in contrib
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/contrib'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/contrib'
.../node_modules/sodium-native install: Making clean in dist-build
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/dist-build'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/dist-build'
.../node_modules/sodium-native install: Making clean in msvc-scripts
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/msvc-scripts'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/msvc-scripts'
.../node_modules/sodium-native install: Making clean in src
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: Making clean in libsodium
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: Making clean in include
.../node_modules/sodium-native install: make[3]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium/include'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[3]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium/include'
.../node_modules/sodium-native install: make[3]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: test -z "" || rm -f 
.../node_modules/sodium-native install: test -z "libsodium.la" || rm -f libsodium.la
.../node_modules/sodium-native install: rm -f ./so_locations
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -rf crypto_aead/aes256gcm/aesni/.libs crypto_aead/aes256gcm/aesni/_libs
.../node_modules/sodium-native install: rm -rf crypto_aead/chacha20poly1305/sodium/.libs crypto_aead/chacha20poly1305/sodium/_libs
.../node_modules/sodium-native install: rm -rf crypto_aead/xchacha20poly1305/sodium/.libs crypto_aead/xchacha20poly1305/sodium/_libs
.../node_modules/sodium-native install: rm -rf crypto_auth/.libs crypto_auth/_libs
.../node_modules/sodium-native install: rm -rf crypto_auth/hmacsha256/.libs crypto_auth/hmacsha256/_libs
.../node_modules/sodium-native install: rm -rf crypto_auth/hmacsha512/.libs crypto_auth/hmacsha512/_libs
.../node_modules/sodium-native install: rm -rf crypto_auth/hmacsha512256/.libs crypto_auth/hmacsha512256/_libs
.../node_modules/sodium-native install: rm -rf crypto_box/.libs crypto_box/_libs
.../node_modules/sodium-native install: rm -rf crypto_box/curve25519xchacha20poly1305/.libs crypto_box/curve25519xchacha20poly1305/_libs
.../node_modules/sodium-native install: rm -rf crypto_box/curve25519xsalsa20poly1305/.libs crypto_box/curve25519xsalsa20poly1305/_libs
.../node_modules/sodium-native install: rm -rf crypto_core/ed25519/.libs crypto_core/ed25519/_libs
.../node_modules/sodium-native install: rm -rf crypto_core/ed25519/ref10/.libs crypto_core/ed25519/ref10/_libs
.../node_modules/sodium-native install: rm -rf crypto_core/hchacha20/.libs crypto_core/hchacha20/_libs
.../node_modules/sodium-native install: rm -rf crypto_core/hsalsa20/.libs crypto_core/hsalsa20/_libs
.../node_modules/sodium-native install: rm -rf crypto_core/hsalsa20/ref2/.libs crypto_core/hsalsa20/ref2/_libs
.../node_modules/sodium-native install: rm -rf crypto_core/salsa/ref/.libs crypto_core/salsa/ref/_libs
.../node_modules/sodium-native install: rm -rf crypto_generichash/.libs crypto_generichash/_libs
.../node_modules/sodium-native install: rm -rf crypto_generichash/blake2b/.libs crypto_generichash/blake2b/_libs
.../node_modules/sodium-native install: rm -rf crypto_generichash/blake2b/ref/.libs crypto_generichash/blake2b/ref/_libs
.../node_modules/sodium-native install: rm -rf crypto_hash/.libs crypto_hash/_libs
.../node_modules/sodium-native install: rm -rf crypto_hash/sha256/.libs crypto_hash/sha256/_libs
.../node_modules/sodium-native install: rm -rf crypto_hash/sha256/cp/.libs crypto_hash/sha256/cp/_libs
.../node_modules/sodium-native install: rm -rf crypto_hash/sha512/.libs crypto_hash/sha512/_libs
.../node_modules/sodium-native install: rm -rf crypto_hash/sha512/cp/.libs crypto_hash/sha512/cp/_libs
.../node_modules/sodium-native install: rm -rf crypto_kdf/.libs crypto_kdf/_libs
.../node_modules/sodium-native install: rm -rf crypto_kdf/blake2b/.libs crypto_kdf/blake2b/_libs
.../node_modules/sodium-native install: rm -rf crypto_kx/.libs crypto_kx/_libs
.../node_modules/sodium-native install: rm -rf crypto_onetimeauth/.libs crypto_onetimeauth/_libs
.../node_modules/sodium-native install: rm -rf crypto_onetimeauth/poly1305/.libs crypto_onetimeauth/poly1305/_libs
.../node_modules/sodium-native install: rm -rf crypto_onetimeauth/poly1305/donna/.libs crypto_onetimeauth/poly1305/donna/_libs
.../node_modules/sodium-native install: rm -rf crypto_onetimeauth/poly1305/sse2/.libs crypto_onetimeauth/poly1305/sse2/_libs
.../node_modules/sodium-native install: rm -rf crypto_pwhash/.libs crypto_pwhash/_libs
.../node_modules/sodium-native install: rm -rf crypto_pwhash/argon2/.libs crypto_pwhash/argon2/_libs
.../node_modules/sodium-native install: rm -rf crypto_pwhash/scryptsalsa208sha256/.libs crypto_pwhash/scryptsalsa208sha256/_libs
.../node_modules/sodium-native install: rm -rf crypto_pwhash/scryptsalsa208sha256/nosse/.libs crypto_pwhash/scryptsalsa208sha256/nosse/_libs
.../node_modules/sodium-native install: rm -rf crypto_pwhash/scryptsalsa208sha256/sse/.libs crypto_pwhash/scryptsalsa208sha256/sse/_libs
.../node_modules/sodium-native install: rm -rf crypto_scalarmult/.libs crypto_scalarmult/_libs
.../node_modules/sodium-native install: rm -rf crypto_scalarmult/curve25519/.libs crypto_scalarmult/curve25519/_libs
.../node_modules/sodium-native install: rm -rf crypto_scalarmult/curve25519/ref10/.libs crypto_scalarmult/curve25519/ref10/_libs
.../node_modules/sodium-native install: rm -rf crypto_scalarmult/curve25519/sandy2x/.libs crypto_scalarmult/curve25519/sandy2x/_libs
.../node_modules/sodium-native install: rm -rf crypto_scalarmult/ed25519/ref10/.libs crypto_scalarmult/ed25519/ref10/_libs
.../node_modules/sodium-native install: rm -rf crypto_secretbox/.libs crypto_secretbox/_libs
.../node_modules/sodium-native install: rm -rf crypto_secretbox/xchacha20poly1305/.libs crypto_secretbox/xchacha20poly1305/_libs
.../node_modules/sodium-native install: rm -rf crypto_secretbox/xsalsa20poly1305/.libs crypto_secretbox/xsalsa20poly1305/_libs
.../node_modules/sodium-native install: rm -rf crypto_secretstream/xchacha20poly1305/.libs crypto_secretstream/xchacha20poly1305/_libs
.../node_modules/sodium-native install: rm -rf crypto_shorthash/.libs crypto_shorthash/_libs
.../node_modules/sodium-native install: rm -rf crypto_shorthash/siphash24/.libs crypto_shorthash/siphash24/_libs
.../node_modules/sodium-native install: rm -rf crypto_shorthash/siphash24/ref/.libs crypto_shorthash/siphash24/ref/_libs
.../node_modules/sodium-native install: rm -rf crypto_sign/.libs crypto_sign/_libs
.../node_modules/sodium-native install: rm -rf crypto_sign/ed25519/.libs crypto_sign/ed25519/_libs
.../node_modules/sodium-native install: rm -rf crypto_sign/ed25519/ref10/.libs crypto_sign/ed25519/ref10/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/.libs crypto_stream/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/chacha20/.libs crypto_stream/chacha20/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/chacha20/dolbeau/.libs crypto_stream/chacha20/dolbeau/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/chacha20/ref/.libs crypto_stream/chacha20/ref/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa20/.libs crypto_stream/salsa20/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa20/ref/.libs crypto_stream/salsa20/ref/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa20/xmm6/.libs crypto_stream/salsa20/xmm6/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa20/xmm6int/.libs crypto_stream/salsa20/xmm6int/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa2012/.libs crypto_stream/salsa2012/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa2012/ref/.libs crypto_stream/salsa2012/ref/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa208/.libs crypto_stream/salsa208/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa208/ref/.libs crypto_stream/salsa208/ref/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/xchacha20/.libs crypto_stream/xchacha20/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/xsalsa20/.libs crypto_stream/xsalsa20/_libs
.../node_modules/sodium-native install: rm -rf crypto_verify/sodium/.libs crypto_verify/sodium/_libs
.../node_modules/sodium-native install: rm -rf randombytes/.libs randombytes/_libs
.../node_modules/sodium-native install: rm -rf randombytes/nativeclient/.libs randombytes/nativeclient/_libs
.../node_modules/sodium-native install: rm -rf randombytes/salsa20/.libs randombytes/salsa20/_libs
.../node_modules/sodium-native install: rm -rf randombytes/sysrandom/.libs randombytes/sysrandom/_libs
.../node_modules/sodium-native install: rm -rf sodium/.libs sodium/_libs
.../node_modules/sodium-native install: test -z "libaesni.la libsse2.la libssse3.la libsse41.la libavx2.la libavx512f.la librdrand.la" || rm -f libaesni.la libsse2.la libssse3.la libsse41.la libavx2.la libavx512f.la librdrand.la
.../node_modules/sodium-native install: rm -f ./so_locations
.../node_modules/sodium-native install: rm -f *.o
.../node_modules/sodium-native install: rm -f crypto_aead/aes256gcm/aesni/*.o
.../node_modules/sodium-native install: rm -f crypto_aead/aes256gcm/aesni/*.lo
.../node_modules/sodium-native install: rm -f crypto_aead/chacha20poly1305/sodium/*.o
.../node_modules/sodium-native install: rm -f crypto_aead/chacha20poly1305/sodium/*.lo
.../node_modules/sodium-native install: rm -f crypto_aead/xchacha20poly1305/sodium/*.o
.../node_modules/sodium-native install: rm -f crypto_aead/xchacha20poly1305/sodium/*.lo
.../node_modules/sodium-native install: rm -f crypto_auth/*.o
.../node_modules/sodium-native install: rm -f crypto_auth/*.lo
.../node_modules/sodium-native install: rm -f crypto_auth/hmacsha256/*.o
.../node_modules/sodium-native install: rm -f crypto_auth/hmacsha256/*.lo
.../node_modules/sodium-native install: rm -f crypto_auth/hmacsha512/*.o
.../node_modules/sodium-native install: rm -f crypto_auth/hmacsha512/*.lo
.../node_modules/sodium-native install: rm -f crypto_auth/hmacsha512256/*.o
.../node_modules/sodium-native install: rm -f crypto_auth/hmacsha512256/*.lo
.../node_modules/sodium-native install: rm -f crypto_box/*.o
.../node_modules/sodium-native install: rm -f crypto_box/*.lo
.../node_modules/sodium-native install: rm -f crypto_box/curve25519xchacha20poly1305/*.o
.../node_modules/sodium-native install: rm -f crypto_box/curve25519xchacha20poly1305/*.lo
.../node_modules/sodium-native install: rm -f crypto_box/curve25519xsalsa20poly1305/*.o
.../node_modules/sodium-native install: rm -f crypto_box/curve25519xsalsa20poly1305/*.lo
.../node_modules/sodium-native install: rm -f crypto_core/ed25519/*.o
.../node_modules/sodium-native install: rm -f crypto_core/ed25519/*.lo
.../node_modules/sodium-native install: rm -f crypto_core/ed25519/ref10/*.o
.../node_modules/sodium-native install: rm -f crypto_core/ed25519/ref10/*.lo
.../node_modules/sodium-native install: rm -f crypto_core/hchacha20/*.o
.../node_modules/sodium-native install: rm -f crypto_core/hchacha20/*.lo
.../node_modules/sodium-native install: rm -f crypto_core/hsalsa20/*.o
.../node_modules/sodium-native install: rm -f crypto_core/hsalsa20/*.lo
.../node_modules/sodium-native install: rm -f crypto_core/hsalsa20/ref2/*.o
.../node_modules/sodium-native install: rm -f crypto_core/hsalsa20/ref2/*.lo
.../node_modules/sodium-native install: rm -f crypto_core/salsa/ref/*.o
.../node_modules/sodium-native install: rm -f crypto_core/salsa/ref/*.lo
.../node_modules/sodium-native install: rm -f crypto_generichash/*.o
.../node_modules/sodium-native install: rm -f crypto_generichash/*.lo
.../node_modules/sodium-native install: rm -f crypto_generichash/blake2b/*.o
.../node_modules/sodium-native install: rm -f crypto_generichash/blake2b/*.lo
.../node_modules/sodium-native install: rm -f crypto_generichash/blake2b/ref/*.o
.../node_modules/sodium-native install: rm -f crypto_generichash/blake2b/ref/*.lo
.../node_modules/sodium-native install: rm -f crypto_hash/*.o
.../node_modules/sodium-native install: rm -f crypto_hash/*.lo
.../node_modules/sodium-native install: rm -f crypto_hash/sha256/*.o
.../node_modules/sodium-native install: rm -f crypto_hash/sha256/*.lo
.../node_modules/sodium-native install: rm -f crypto_hash/sha256/cp/*.o
.../node_modules/sodium-native install: rm -f crypto_hash/sha256/cp/*.lo
.../node_modules/sodium-native install: rm -f crypto_hash/sha512/*.o
.../node_modules/sodium-native install: rm -f crypto_hash/sha512/*.lo
.../node_modules/sodium-native install: rm -f crypto_hash/sha512/cp/*.o
.../node_modules/sodium-native install: rm -f crypto_hash/sha512/cp/*.lo
.../node_modules/sodium-native install: rm -f crypto_kdf/*.o
.../node_modules/sodium-native install: rm -f crypto_kdf/*.lo
.../node_modules/sodium-native install: rm -f crypto_kdf/blake2b/*.o
.../node_modules/sodium-native install: rm -f crypto_kdf/blake2b/*.lo
.../node_modules/sodium-native install: rm -f crypto_kx/*.o
.../node_modules/sodium-native install: rm -f crypto_kx/*.lo
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/*.o
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/*.lo
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/poly1305/*.o
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/poly1305/*.lo
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/poly1305/donna/*.o
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/poly1305/donna/*.lo
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/poly1305/sse2/*.o
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/poly1305/sse2/*.lo
.../node_modules/sodium-native install: rm -f crypto_pwhash/*.o
.../node_modules/sodium-native install: rm -f crypto_pwhash/*.lo
.../node_modules/sodium-native install: rm -f crypto_pwhash/argon2/*.o
.../node_modules/sodium-native install: rm -f crypto_pwhash/argon2/*.lo
.../node_modules/sodium-native install: rm -f crypto_pwhash/scryptsalsa208sha256/*.o
.../node_modules/sodium-native install: rm -f crypto_pwhash/scryptsalsa208sha256/*.lo
.../node_modules/sodium-native install: rm -f crypto_pwhash/scryptsalsa208sha256/nosse/*.o
.../node_modules/sodium-native install: rm -f crypto_pwhash/scryptsalsa208sha256/nosse/*.lo
.../node_modules/sodium-native install: rm -f crypto_pwhash/scryptsalsa208sha256/sse/*.o
.../node_modules/sodium-native install: rm -f crypto_pwhash/scryptsalsa208sha256/sse/*.lo
.../node_modules/sodium-native install: rm -f crypto_scalarmult/*.o
.../node_modules/sodium-native install: rm -f crypto_scalarmult/*.lo
.../node_modules/sodium-native install: rm -f crypto_scalarmult/curve25519/*.o
.../node_modules/sodium-native install: rm -f crypto_scalarmult/curve25519/*.lo
.../node_modules/sodium-native install: rm -f crypto_scalarmult/curve25519/ref10/*.o
.../node_modules/sodium-native install: rm -f crypto_scalarmult/curve25519/ref10/*.lo
.../node_modules/sodium-native install: rm -f crypto_scalarmult/curve25519/sandy2x/*.o
.../node_modules/sodium-native install: rm -f crypto_scalarmult/curve25519/sandy2x/*.lo
.../node_modules/sodium-native install: rm -f crypto_scalarmult/ed25519/ref10/*.o
.../node_modules/sodium-native install: rm -f crypto_scalarmult/ed25519/ref10/*.lo
.../node_modules/sodium-native install: rm -f crypto_secretbox/*.o
.../node_modules/sodium-native install: rm -f crypto_secretbox/*.lo
.../node_modules/sodium-native install: rm -f crypto_secretbox/xchacha20poly1305/*.o
.../node_modules/sodium-native install: rm -f crypto_secretbox/xchacha20poly1305/*.lo
.../node_modules/sodium-native install: rm -f crypto_secretbox/xsalsa20poly1305/*.o
.../node_modules/sodium-native install: rm -f crypto_secretbox/xsalsa20poly1305/*.lo
.../node_modules/sodium-native install: rm -f crypto_secretstream/xchacha20poly1305/*.o
.../node_modules/sodium-native install: rm -f crypto_secretstream/xchacha20poly1305/*.lo
.../node_modules/sodium-native install: rm -f crypto_shorthash/*.o
.../node_modules/sodium-native install: rm -f crypto_shorthash/*.lo
.../node_modules/sodium-native install: rm -f crypto_shorthash/siphash24/*.o
.../node_modules/sodium-native install: rm -f crypto_shorthash/siphash24/*.lo
.../node_modules/sodium-native install: rm -f crypto_shorthash/siphash24/ref/*.o
.../node_modules/sodium-native install: rm -f crypto_shorthash/siphash24/ref/*.lo
.../node_modules/sodium-native install: rm -f crypto_sign/*.o
.../node_modules/sodium-native install: rm -f crypto_sign/*.lo
.../node_modules/sodium-native install: rm -f crypto_sign/ed25519/*.o
.../node_modules/sodium-native install: rm -f crypto_sign/ed25519/*.lo
.../node_modules/sodium-native install: rm -f crypto_sign/ed25519/ref10/*.o
.../node_modules/sodium-native install: rm -f crypto_sign/ed25519/ref10/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/chacha20/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/chacha20/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/chacha20/dolbeau/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/chacha20/dolbeau/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/chacha20/ref/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/chacha20/ref/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/ref/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/ref/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/xmm6/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/xmm6/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/xmm6int/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/xmm6int/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa2012/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa2012/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa2012/ref/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa2012/ref/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa208/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa208/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa208/ref/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa208/ref/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/xchacha20/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/xchacha20/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/xsalsa20/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/xsalsa20/*.lo
.../node_modules/sodium-native install: rm -f crypto_verify/sodium/*.o
.../node_modules/sodium-native install: rm -f crypto_verify/sodium/*.lo
.../node_modules/sodium-native install: rm -f randombytes/*.o
.../node_modules/sodium-native install: rm -f randombytes/*.lo
.../node_modules/sodium-native install: rm -f randombytes/nativeclient/*.o
.../node_modules/sodium-native install: rm -f randombytes/nativeclient/*.lo
.../node_modules/sodium-native install: rm -f randombytes/salsa20/*.o
.../node_modules/sodium-native install: rm -f randombytes/salsa20/*.lo
.../node_modules/sodium-native install: rm -f randombytes/sysrandom/*.o
.../node_modules/sodium-native install: rm -f randombytes/sysrandom/*.lo
.../node_modules/sodium-native install: rm -f sodium/*.o
.../node_modules/sodium-native install: rm -f sodium/*.lo
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[3]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: Making clean in test
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: Making clean in default
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test/default'
.../node_modules/sodium-native install:  rm -f aead_aes256gcm aead_aes256gcm2 aead_chacha20poly1305 aead_chacha20poly13052 aead_xchacha20poly1305 auth auth2 auth3 auth5 auth6 auth7 box box2 box7 box8 box_easy box_easy2 box_seal box_seed chacha20 codecs core1 core2 core3 core4 core5 core6 ed25519_convert generichash generichash2 generichash3 hash hash3 kdf keygen kx metamorphic misuse onetimeauth onetimeauth2 onetimeauth7 pwhash_argon2i pwhash_argon2id randombytes scalarmult scalarmult2 scalarmult5 scalarmult6 scalarmult7 scalarmult8 secretbox secretbox2 secretbox7 secretbox8 secretbox_easy secretbox_easy2 secretstream shorthash sign sodium_core sodium_utils sodium_version stream stream2 stream3 stream4 verify1 sodium_utils2 sodium_utils3 core_ed25519 pwhash_scrypt pwhash_scrypt_ll scalarmult_ed25519 siphashx24 xchacha20
.../node_modules/sodium-native install: test -z "" || rm -f 
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.o
.../node_modules/sodium-native install: test -z "aead_aes256gcm.log aead_aes256gcm2.log aead_chacha20poly1305.log aead_chacha20poly13052.log aead_xchacha20poly1305.log auth.log auth2.log auth3.log auth5.log auth6.log auth7.log box.log box2.log box7.log box8.log box_easy.log box_easy2.log box_seal.log box_seed.log chacha20.log codecs.log core1.log core2.log core3.log core4.log core5.log core6.log ed25519_convert.log generichash.log generichash2.log generichash3.log hash.log hash3.log kdf.log keygen.log kx.log metamorphic.log misuse.log onetimeauth.log onetimeauth2.log onetimeauth7.log pwhash_argon2i.log pwhash_argon2id.log randombytes.log scalarmult.log scalarmult2.log scalarmult5.log scalarmult6.log scalarmult7.log scalarmult8.log secretbox.log secretbox2.log secretbox7.log secretbox8.log secretbox_easy.log secretbox_easy2.log secretstream.log shorthash.log sign.log sodium_core.log sodium_utils.log sodium_version.log stream.log stream2.log stream3.log stream4.log verify1.log sodium_utils2.log sodium_utils3.log core_ed25519.log pwhash_scrypt.log pwhash_scrypt_ll.log scalarmult_ed25519.log siphashx24.log xchacha20.log" || rm -f aead_aes256gcm.log aead_aes256gcm2.log aead_chacha20poly1305.log aead_chacha20poly13052.log aead_xchacha20poly1305.log auth.log auth2.log auth3.log auth5.log auth6.log auth7.log box.log box2.log box7.log box8.log box_easy.log box_easy2.log box_seal.log box_seed.log chacha20.log codecs.log core1.log core2.log core3.log core4.log core5.log core6.log ed25519_convert.log generichash.log generichash2.log generichash3.log hash.log hash3.log kdf.log keygen.log kx.log metamorphic.log misuse.log onetimeauth.log onetimeauth2.log onetimeauth7.log pwhash_argon2i.log pwhash_argon2id.log randombytes.log scalarmult.log scalarmult2.log scalarmult5.log scalarmult6.log scalarmult7.log scalarmult8.log secretbox.log secretbox2.log secretbox7.log secretbox8.log secretbox_easy.log secretbox_easy2.log secretstream.log shorthash.log sign.log sodium_core.log sodium_utils.log sodium_version.log stream.log stream2.log stream3.log stream4.log verify1.log sodium_utils2.log sodium_utils3.log core_ed25519.log pwhash_scrypt.log pwhash_scrypt_ll.log scalarmult_ed25519.log siphashx24.log xchacha20.log
.../node_modules/sodium-native install: test -z "aead_aes256gcm.trs aead_aes256gcm2.trs aead_chacha20poly1305.trs aead_chacha20poly13052.trs aead_xchacha20poly1305.trs auth.trs auth2.trs auth3.trs auth5.trs auth6.trs auth7.trs box.trs box2.trs box7.trs box8.trs box_easy.trs box_easy2.trs box_seal.trs box_seed.trs chacha20.trs codecs.trs core1.trs core2.trs core3.trs core4.trs core5.trs core6.trs ed25519_convert.trs generichash.trs generichash2.trs generichash3.trs hash.trs hash3.trs kdf.trs keygen.trs kx.trs metamorphic.trs misuse.trs onetimeauth.trs onetimeauth2.trs onetimeauth7.trs pwhash_argon2i.trs pwhash_argon2id.trs randombytes.trs scalarmult.trs scalarmult2.trs scalarmult5.trs scalarmult6.trs scalarmult7.trs scalarmult8.trs secretbox.trs secretbox2.trs secretbox7.trs secretbox8.trs secretbox_easy.trs secretbox_easy2.trs secretstream.trs shorthash.trs sign.trs sodium_core.trs sodium_utils.trs sodium_version.trs stream.trs stream2.trs stream3.trs stream4.trs verify1.trs sodium_utils2.trs sodium_utils3.trs core_ed25519.trs pwhash_scrypt.trs pwhash_scrypt_ll.trs scalarmult_ed25519.trs siphashx24.trs xchacha20.trs" || rm -f aead_aes256gcm.trs aead_aes256gcm2.trs aead_chacha20poly1305.trs aead_chacha20poly13052.trs aead_xchacha20poly1305.trs auth.trs auth2.trs auth3.trs auth5.trs auth6.trs auth7.trs box.trs box2.trs box7.trs box8.trs box_easy.trs box_easy2.trs box_seal.trs box_seed.trs chacha20.trs codecs.trs core1.trs core2.trs core3.trs core4.trs core5.trs core6.trs ed25519_convert.trs generichash.trs generichash2.trs generichash3.trs hash.trs hash3.trs kdf.trs keygen.trs kx.trs metamorphic.trs misuse.trs onetimeauth.trs onetimeauth2.trs onetimeauth7.trs pwhash_argon2i.trs pwhash_argon2id.trs randombytes.trs scalarmult.trs scalarmult2.trs scalarmult5.trs scalarmult6.trs scalarmult7.trs scalarmult8.trs secretbox.trs secretbox2.trs secretbox7.trs secretbox8.trs secretbox_easy.trs secretbox_easy2.trs secretstream.trs shorthash.trs sign.trs sodium_core.trs sodium_utils.trs sodium_version.trs stream.trs stream2.trs stream3.trs stream4.trs verify1.trs sodium_utils2.trs sodium_utils3.trs core_ed25519.trs pwhash_scrypt.trs pwhash_scrypt_ll.trs scalarmult_ed25519.trs siphashx24.trs xchacha20.trs
.../node_modules/sodium-native install: test -z "test-suite.log" || rm -f test-suite.log
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test/default'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium'
.../node_modules/sodium-native install: Making install in builds
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/builds'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/builds'
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/builds'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/builds'
.../node_modules/sodium-native install: Making install in contrib
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/contrib'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/contrib'
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/contrib'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/contrib'
.../node_modules/sodium-native install: Making install in dist-build
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/dist-build'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/dist-build'
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/dist-build'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/dist-build'
.../node_modules/sodium-native install: Making install in msvc-scripts
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/msvc-scripts'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/msvc-scripts'
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/msvc-scripts'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/msvc-scripts'
.../node_modules/sodium-native install: Making install in src
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: Making install in libsodium
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: Making install in include
.../node_modules/sodium-native install: make[3]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium/include'
.../node_modules/sodium-native install: make[4]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium/include'
.../node_modules/sodium-native install: make[4]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install:  /usr/bin/mkdir -p '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include'
.../node_modules/sodium-native install:  /usr/bin/mkdir -p '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include/sodium'
.../node_modules/sodium-native install:  /usr/bin/install -c -m 644  sodium/core.h sodium/crypto_aead_aes256gcm.h sodium/crypto_aead_chacha20poly1305.h sodium/crypto_aead_xchacha20poly1305.h sodium/crypto_auth.h sodium/crypto_auth_hmacsha256.h sodium/crypto_auth_hmacsha512.h sodium/crypto_auth_hmacsha512256.h sodium/crypto_box.h sodium/crypto_box_curve25519xchacha20poly1305.h sodium/crypto_box_curve25519xsalsa20poly1305.h sodium/crypto_core_ed25519.h sodium/crypto_core_hchacha20.h sodium/crypto_core_hsalsa20.h sodium/crypto_core_salsa20.h sodium/crypto_core_salsa2012.h sodium/crypto_core_salsa208.h sodium/crypto_generichash.h sodium/crypto_generichash_blake2b.h sodium/crypto_hash.h sodium/crypto_hash_sha256.h sodium/crypto_hash_sha512.h sodium/crypto_kdf.h sodium/crypto_kdf_blake2b.h sodium/crypto_kx.h sodium/crypto_onetimeauth.h sodium/crypto_onetimeauth_poly1305.h sodium/crypto_pwhash.h sodium/crypto_pwhash_argon2i.h sodium/crypto_pwhash_argon2id.h sodium/crypto_pwhash_scryptsalsa208sha256.h sodium/crypto_scalarmult.h sodium/crypto_scalarmult_curve25519.h sodium/crypto_scalarmult_ed25519.h sodium/crypto_secretbox.h sodium/crypto_secretbox_xchacha20poly1305.h sodium/crypto_secretbox_xsalsa20poly1305.h sodium/crypto_secretstream_xchacha20poly1305.h sodium/crypto_shorthash.h sodium/crypto_shorthash_siphash24.h '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include/sodium'
.../node_modules/sodium-native install:  /usr/bin/mkdir -p '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include/sodium'
.../node_modules/sodium-native install:  /usr/bin/install -c -m 644  sodium/crypto_sign.h sodium/crypto_sign_ed25519.h sodium/crypto_sign_edwards25519sha512batch.h sodium/crypto_stream.h sodium/crypto_stream_chacha20.h sodium/crypto_stream_salsa20.h sodium/crypto_stream_salsa2012.h sodium/crypto_stream_salsa208.h sodium/crypto_stream_xchacha20.h sodium/crypto_stream_xsalsa20.h sodium/crypto_verify_16.h sodium/crypto_verify_32.h sodium/crypto_verify_64.h sodium/export.h sodium/randombytes.h sodium/randombytes_salsa20_random.h sodium/randombytes_sysrandom.h sodium/runtime.h sodium/utils.h '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include/sodium'
.../node_modules/sodium-native install:  /usr/bin/install -c -m 644  sodium.h '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include/.'
.../node_modules/sodium-native install:  /usr/bin/mkdir -p '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include'
.../node_modules/sodium-native install:  /usr/bin/mkdir -p '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include/sodium'
.../node_modules/sodium-native install:  /usr/bin/install -c -m 644  sodium/version.h '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include/sodium'
.../node_modules/sodium-native install: make[4]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium/include'
.../node_modules/sodium-native install: make[3]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium/include'
.../node_modules/sodium-native install: make[3]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install:   CC       crypto_aead/chacha20poly1305/sodium/libsodium_la-aead_chacha20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_aead/xchacha20poly1305/sodium/libsodium_la-aead_xchacha20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_auth/libsodium_la-crypto_auth.lo
.../node_modules/sodium-native install:   CC       crypto_auth/hmacsha256/libsodium_la-auth_hmacsha256.lo
.../node_modules/sodium-native install:   CC       crypto_auth/hmacsha512/libsodium_la-auth_hmacsha512.lo
.../node_modules/sodium-native install:   CC       crypto_auth/hmacsha512256/libsodium_la-auth_hmacsha512256.lo
.../node_modules/sodium-native install:   CC       crypto_box/libsodium_la-crypto_box.lo
.../node_modules/sodium-native install:   CC       crypto_box/libsodium_la-crypto_box_easy.lo
.../node_modules/sodium-native install:   CC       crypto_box/libsodium_la-crypto_box_seal.lo
.../node_modules/sodium-native install:   CC       crypto_box/curve25519xsalsa20poly1305/libsodium_la-box_curve25519xsalsa20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_core/ed25519/ref10/libsodium_la-ed25519_ref10.lo
.../node_modules/sodium-native install:   CC       crypto_core/hchacha20/libsodium_la-core_hchacha20.lo
.../node_modules/sodium-native install:   CC       crypto_core/hsalsa20/ref2/libsodium_la-core_hsalsa20_ref2.lo
.../node_modules/sodium-native install:   CC       crypto_core/hsalsa20/libsodium_la-core_hsalsa20.lo
.../node_modules/sodium-native install:   CC       crypto_core/salsa/ref/libsodium_la-core_salsa_ref.lo
.../node_modules/sodium-native install:   CC       crypto_generichash/libsodium_la-crypto_generichash.lo
.../node_modules/sodium-native install:   CC       crypto_generichash/blake2b/libsodium_la-generichash_blake2.lo
.../node_modules/sodium-native install:   CC       crypto_generichash/blake2b/ref/libsodium_la-blake2b-compress-ref.lo
.../node_modules/sodium-native install:   CC       crypto_generichash/blake2b/ref/libsodium_la-blake2b-ref.lo
.../node_modules/sodium-native install:   CC       crypto_generichash/blake2b/ref/libsodium_la-generichash_blake2b.lo
.../node_modules/sodium-native install:   CC       crypto_hash/libsodium_la-crypto_hash.lo
.../node_modules/sodium-native install:   CC       crypto_hash/sha256/libsodium_la-hash_sha256.lo
.../node_modules/sodium-native install:   CC       crypto_hash/sha256/cp/libsodium_la-hash_sha256_cp.lo
.../node_modules/sodium-native install:   CC       crypto_hash/sha512/libsodium_la-hash_sha512.lo
.../node_modules/sodium-native install:   CC       crypto_hash/sha512/cp/libsodium_la-hash_sha512_cp.lo
.../node_modules/sodium-native install:   CC       crypto_kdf/blake2b/libsodium_la-kdf_blake2b.lo
.../node_modules/sodium-native install:   CC       crypto_kdf/libsodium_la-crypto_kdf.lo
.../node_modules/sodium-native install:   CC       crypto_kx/libsodium_la-crypto_kx.lo
.../node_modules/sodium-native install:   CC       crypto_onetimeauth/libsodium_la-crypto_onetimeauth.lo
.../node_modules/sodium-native install:   CC       crypto_onetimeauth/poly1305/libsodium_la-onetimeauth_poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_onetimeauth/poly1305/donna/libsodium_la-poly1305_donna.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libsodium_la-argon2-core.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libsodium_la-argon2-encoding.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libsodium_la-argon2-fill-block-ref.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libsodium_la-argon2.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libsodium_la-blake2b-long.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libsodium_la-pwhash_argon2i.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libsodium_la-pwhash_argon2id.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/libsodium_la-crypto_pwhash.lo
.../node_modules/sodium-native install:   CC       crypto_scalarmult/libsodium_la-crypto_scalarmult.lo
.../node_modules/sodium-native install:   CC       crypto_scalarmult/curve25519/ref10/libsodium_la-x25519_ref10.lo
.../node_modules/sodium-native install:   CC       crypto_scalarmult/curve25519/libsodium_la-scalarmult_curve25519.lo
.../node_modules/sodium-native install:   CC       crypto_secretbox/libsodium_la-crypto_secretbox.lo
.../node_modules/sodium-native install:   CC       crypto_secretbox/libsodium_la-crypto_secretbox_easy.lo
.../node_modules/sodium-native install:   CC       crypto_secretbox/xsalsa20poly1305/libsodium_la-secretbox_xsalsa20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_secretstream/xchacha20poly1305/libsodium_la-secretstream_xchacha20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_shorthash/libsodium_la-crypto_shorthash.lo
.../node_modules/sodium-native install:   CC       crypto_shorthash/siphash24/libsodium_la-shorthash_siphash24.lo
.../node_modules/sodium-native install:   CC       crypto_shorthash/siphash24/ref/libsodium_la-shorthash_siphash24_ref.lo
.../node_modules/sodium-native install:   CC       crypto_sign/libsodium_la-crypto_sign.lo
.../node_modules/sodium-native install:   CC       crypto_sign/ed25519/libsodium_la-sign_ed25519.lo
.../node_modules/sodium-native install:   CC       crypto_sign/ed25519/ref10/libsodium_la-keypair.lo
.../node_modules/sodium-native install:   CC       crypto_sign/ed25519/ref10/libsodium_la-open.lo
.../node_modules/sodium-native install:   CC       crypto_sign/ed25519/ref10/libsodium_la-sign.lo
.../node_modules/sodium-native install:   CC       crypto_stream/chacha20/libsodium_la-stream_chacha20.lo
.../node_modules/sodium-native install:   CC       crypto_stream/chacha20/ref/libsodium_la-chacha20_ref.lo
.../node_modules/sodium-native install:   CC       crypto_stream/libsodium_la-crypto_stream.lo
.../node_modules/sodium-native install:   CC       crypto_stream/salsa20/libsodium_la-stream_salsa20.lo
.../node_modules/sodium-native install:   CC       crypto_stream/xsalsa20/libsodium_la-stream_xsalsa20.lo
.../node_modules/sodium-native install:   CC       crypto_verify/sodium/libsodium_la-verify.lo
.../node_modules/sodium-native install:   CC       randombytes/libsodium_la-randombytes.lo
.../node_modules/sodium-native install:   CC       sodium/libsodium_la-codecs.lo
.../node_modules/sodium-native install:   CC       sodium/libsodium_la-core.lo
.../node_modules/sodium-native install:   CC       sodium/libsodium_la-runtime.lo
.../node_modules/sodium-native install:   CC       sodium/libsodium_la-utils.lo
.../node_modules/sodium-native install:   CC       sodium/libsodium_la-version.lo
.../node_modules/sodium-native install:   CPPAS    crypto_stream/salsa20/xmm6/libsodium_la-salsa20_xmm6-asm.lo
.../node_modules/sodium-native install:   CC       crypto_stream/salsa20/xmm6/libsodium_la-salsa20_xmm6.lo
.../node_modules/sodium-native install:   CC       crypto_scalarmult/curve25519/sandy2x/libsodium_la-curve25519_sandy2x.lo
.../node_modules/sodium-native install:   CC       crypto_scalarmult/curve25519/sandy2x/libsodium_la-fe51_invert.lo
.../node_modules/sodium-native install:   CC       crypto_scalarmult/curve25519/sandy2x/libsodium_la-fe_frombytes_sandy2x.lo
.../node_modules/sodium-native install:   CPPAS    crypto_scalarmult/curve25519/sandy2x/libsodium_la-sandy2x.lo
.../node_modules/sodium-native install:   CC       crypto_box/curve25519xchacha20poly1305/libsodium_la-box_curve25519xchacha20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_box/curve25519xchacha20poly1305/libsodium_la-box_seal_curve25519xchacha20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_core/ed25519/libsodium_la-core_ed25519.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/scryptsalsa208sha256/libsodium_la-crypto_scrypt-common.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/scryptsalsa208sha256/libsodium_la-scrypt_platform.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/scryptsalsa208sha256/libsodium_la-pbkdf2-sha256.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/scryptsalsa208sha256/libsodium_la-pwhash_scryptsalsa208sha256.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/scryptsalsa208sha256/nosse/libsodium_la-pwhash_scryptsalsa208sha256_nosse.lo
.../node_modules/sodium-native install:   CC       crypto_scalarmult/ed25519/ref10/libsodium_la-scalarmult_ed25519_ref10.lo
.../node_modules/sodium-native install:   CC       crypto_secretbox/xchacha20poly1305/libsodium_la-secretbox_xchacha20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_shorthash/siphash24/libsodium_la-shorthash_siphashx24.lo
.../node_modules/sodium-native install:   CC       crypto_shorthash/siphash24/ref/libsodium_la-shorthash_siphashx24_ref.lo
.../node_modules/sodium-native install:   CC       crypto_sign/ed25519/ref10/libsodium_la-obsolete.lo
.../node_modules/sodium-native install:   CC       crypto_stream/salsa2012/ref/libsodium_la-stream_salsa2012_ref.lo
.../node_modules/sodium-native install:   CC       crypto_stream/salsa2012/libsodium_la-stream_salsa2012.lo
.../node_modules/sodium-native install:   CC       crypto_stream/salsa208/ref/libsodium_la-stream_salsa208_ref.lo
.../node_modules/sodium-native install:   CC       crypto_stream/salsa208/libsodium_la-stream_salsa208.lo
.../node_modules/sodium-native install:   CC       crypto_stream/xchacha20/libsodium_la-stream_xchacha20.lo
.../node_modules/sodium-native install:   CC       randombytes/sysrandom/libsodium_la-randombytes_sysrandom.lo
.../node_modules/sodium-native install:   CC       crypto_aead/aes256gcm/aesni/libaesni_la-aead_aes256gcm_aesni.lo
.../node_modules/sodium-native install:   CCLD     libaesni.la
.../node_modules/sodium-native install: libtool: warning: '-version-info/-version-number' is ignored for convenience libraries
.../node_modules/sodium-native install:   CC       crypto_onetimeauth/poly1305/sse2/libsse2_la-poly1305_sse2.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/scryptsalsa208sha256/sse/libsse2_la-pwhash_scryptsalsa208sha256_sse.lo
.../node_modules/sodium-native install:   CCLD     libsse2.la
.../node_modules/sodium-native install: libtool: warning: '-version-info/-version-number' is ignored for convenience libraries
.../node_modules/sodium-native install:   CC       crypto_generichash/blake2b/ref/libssse3_la-blake2b-compress-ssse3.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libssse3_la-argon2-fill-block-ssse3.lo
.../node_modules/sodium-native install:   CC       crypto_stream/chacha20/dolbeau/libssse3_la-chacha20_dolbeau-ssse3.lo
.../node_modules/sodium-native install:   CCLD     libssse3.la
.../node_modules/sodium-native install: libtool: warning: '-version-info/-version-number' is ignored for convenience libraries
.../node_modules/sodium-native install:   CC       crypto_generichash/blake2b/ref/libsse41_la-blake2b-compress-sse41.lo
.../node_modules/sodium-native install:   CCLD     libsse41.la
.../node_modules/sodium-native install: libtool: warning: '-version-info/-version-number' is ignored for convenience libraries
.../node_modules/sodium-native install:   CC       crypto_generichash/blake2b/ref/libavx2_la-blake2b-compress-avx2.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libavx2_la-argon2-fill-block-avx2.lo
.../node_modules/sodium-native install:   CC       crypto_stream/chacha20/dolbeau/libavx2_la-chacha20_dolbeau-avx2.lo
.../node_modules/sodium-native install:   CC       crypto_stream/salsa20/xmm6int/libavx2_la-salsa20_xmm6int-avx2.lo
.../node_modules/sodium-native install:   CCLD     libavx2.la
.../node_modules/sodium-native install: libtool: warning: '-version-info/-version-number' is ignored for convenience libraries
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libavx512f_la-argon2-fill-block-avx512f.lo
.../node_modules/sodium-native install:   CCLD     libavx512f.la
.../node_modules/sodium-native install: libtool: warning: '-version-info/-version-number' is ignored for convenience libraries
.../node_modules/sodium-native install:   CC       randombytes/salsa20/librdrand_la-randombytes_salsa20_random.lo
.../node_modules/sodium-native install:   CCLD     librdrand.la
.../node_modules/sodium-native install: libtool: warning: '-version-info/-version-number' is ignored for convenience libraries
.../node_modules/sodium-native install:   CCLD     libsodium.la
.../node_modules/sodium-native install: make[4]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install:  /usr/bin/mkdir -p '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib'
.../node_modules/sodium-native install:  /bin/bash ../../libtool   --mode=install /usr/bin/install -c   libsodium.la '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib'
.../node_modules/sodium-native install: libtool: install: /usr/bin/install -c .libs/libsodium.so.23.2.0 /home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib/libsodium.so.23.2.0
.../node_modules/sodium-native install: libtool: install: (cd /home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib && { ln -s -f libsodium.so.23.2.0 libsodium.so.23 || { rm -f libsodium.so.23 && ln -s libsodium.so.23.2.0 libsodium.so.23; }; })
.../node_modules/sodium-native install: libtool: install: (cd /home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib && { ln -s -f libsodium.so.23.2.0 libsodium.so || { rm -f libsodium.so && ln -s libsodium.so.23.2.0 libsodium.so; }; })
.../node_modules/sodium-native install: libtool: install: /usr/bin/install -c .libs/libsodium.lai /home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib/libsodium.la
.../node_modules/sodium-native install: libtool: install: /usr/bin/install -c .libs/libsodium.a /home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib/libsodium.a
.../node_modules/sodium-native install: libtool: install: chmod 644 /home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib/libsodium.a
.../node_modules/sodium-native install: libtool: install: ranlib /home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib/libsodium.a
.../node_modules/sodium-native install: libtool: finish: PATH="/home/runner/.rush/node-v16.1.0/pnpm-5.15.2/node_modules/pnpm/dist/node-gyp-bin:/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/node_modules/.bin:/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/.bin:/home/runner/work/protocols/protocols/common/temp/node_modules/.bin:/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/node_modules/.bin:/home/runner/work/protocols/protocols/common/temp/node_modules/.bin:/home/runner/work/protocols/protocols/common/temp/node_modules/.bin:/home/runner/work/protocols/protocols/common/temp/install-run/@microsoft+rush@5.45.2/node_modules/.bin:/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin:/opt/hostedtoolcache/node/16.1.0/x64/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/home/runner/.local/bin:/opt/pipx_bin:/usr/share/rust/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/sbin" ldconfig -n /home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib
.../node_modules/sodium-native install: ----------------------------------------------------------------------
.../node_modules/sodium-native install: Libraries have been installed in:
.../node_modules/sodium-native install:    /home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib
.../node_modules/sodium-native install: If you ever happen to want to link against installed libraries
.../node_modules/sodium-native install: in a given directory, LIBDIR, you must either use libtool, and
.../node_modules/sodium-native install: specify the full pathname of the library, or use the '-LLIBDIR'
.../node_modules/sodium-native install: flag during linking and do at least one of the following:
.../node_modules/sodium-native install:    - add LIBDIR to the 'LD_LIBRARY_PATH' environment variable
.../node_modules/sodium-native install:      during execution
.../node_modules/sodium-native install:    - add LIBDIR to the 'LD_RUN_PATH' environment variable
.../node_modules/sodium-native install:      during linking
.../node_modules/sodium-native install:    - use the '-Wl,-rpath -Wl,LIBDIR' linker flag
.../node_modules/sodium-native install:    - have your system administrator add LIBDIR to '/etc/ld.so.conf'
.../node_modules/sodium-native install: See any operating system documentation about shared libraries for
.../node_modules/sodium-native install: more information, such as the ld(1) and ld.so(8) manual pages.
.../node_modules/sodium-native install: ----------------------------------------------------------------------
.../node_modules/sodium-native install: make[4]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[4]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: make[3]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: make[3]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: make[3]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install: make[3]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[3]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: Making install in test
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: Making install in default
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test/default'
.../node_modules/sodium-native install: make[3]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test/default'
.../node_modules/sodium-native install: make[3]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install: make[3]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[3]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test/default'
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test/default'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: make[3]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: make[3]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install: make[3]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[3]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium'
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install:  /usr/bin/mkdir -p '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib/pkgconfig'
.../node_modules/sodium-native install:  /usr/bin/install -c -m 644 libsodium.pc '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib/pkgconfig'
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium'
.../node_modules/sodium-native install: gyp info it worked if it ends with ok
.../node_modules/sodium-native install: gyp info using node-gyp@7.1.2
.../node_modules/sodium-native install: gyp info using node@16.1.0 | linux | x64
.../node_modules/sodium-native install: gyp info find Python using Python version 3.8.10 found at "/usr/bin/python3"
.../node_modules/sodium-native install: (node:30930) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
.../node_modules/sodium-native install: (Use `node --trace-deprecation ...` to show where the warning was created)
.../node_modules/sodium-native install: gyp info spawn /usr/bin/python3
.../node_modules/sodium-native install: gyp info spawn args [
.../node_modules/sodium-native install: gyp info spawn args   '/home/runner/.rush/node-v16.1.0/pnpm-5.15.2/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
.../node_modules/sodium-native install: gyp info spawn args   'binding.gyp',
.../node_modules/sodium-native install: gyp info spawn args   '-f',
.../node_modules/sodium-native install: gyp info spawn args   'make',
.../node_modules/sodium-native install: gyp info spawn args   '-I',
.../node_modules/sodium-native install: gyp info spawn args   '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/build/config.gypi',
.../node_modules/sodium-native install: gyp info spawn args   '-I',
.../node_modules/sodium-native install: gyp info spawn args   '/home/runner/.rush/node-v16.1.0/pnpm-5.15.2/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
.../node_modules/sodium-native install: gyp info spawn args   '-I',
.../node_modules/sodium-native install: gyp info spawn args   '/home/runner/.cache/node-gyp/16.1.0/include/node/common.gypi',
.../node_modules/sodium-native install: gyp info spawn args   '-Dlibrary=shared_library',
.../node_modules/sodium-native install: gyp info spawn args   '-Dvisibility=default',
.../node_modules/sodium-native install: gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/16.1.0',
.../node_modules/sodium-native install: gyp info spawn args   '-Dnode_gyp_dir=/home/runner/.rush/node-v16.1.0/pnpm-5.15.2/node_modules/pnpm/dist/node_modules/node-gyp',
.../node_modules/sodium-native install: gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/16.1.0/<(target_arch)/node.lib',
.../node_modules/sodium-native install: gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native',
.../node_modules/sodium-native install: gyp info spawn args   '-Dnode_engine=v8',
.../node_modules/sodium-native install: gyp info spawn args   '--depth=.',
.../node_modules/sodium-native install: gyp info spawn args   '--no-parallel',
.../node_modules/sodium-native install: gyp info spawn args   '--generator-output',
.../node_modules/sodium-native install: gyp info spawn args   'build',
.../node_modules/sodium-native install: gyp info spawn args   '-Goutput_dir=.'
.../node_modules/sodium-native install: gyp info spawn args ]
.../node_modules/sodium-native install: gyp info spawn make
.../node_modules/sodium-native install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
.../node_modules/sodium-native install: make: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/build'
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/binding.o
.../node_modules/sodium-native install: In file included from ../src/crypto_pwhash_async.cc:2,
.../node_modules/sodium-native install:                  from ../binding.cc:12:
.../node_modules/sodium-native install: ../binding.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE sodium_malloc(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/sodium-native install: ../src/macros.h:102:24: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
.../node_modules/sodium-native install:   102 |   if (((uint64_t) var) < min) { \
.../node_modules/sodium-native install: ../binding.cc:49:3: note: in expansion of macro ‘ASSERT_UINT_BOUNDS’
.../node_modules/sodium-native install:    49 |   ASSERT_UINT_BOUNDS(info[0], size, 0, 0, `buffer.constants.MAX_LENGTH`, node::Buffer::kMaxLength)
.../node_modules/sodium-native install:       |   ^~~~~~~~~~~~~~~~~~
.../node_modules/sodium-native install: ../binding.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE randombytes_uniform(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/sodium-native install: ../src/macros.h:102:24: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
.../node_modules/sodium-native install:   102 |   if (((uint64_t) var) < min) { \
.../node_modules/sodium-native install: ../binding.cc:95:3: note: in expansion of macro ‘ASSERT_UINT_BOUNDS’
.../node_modules/sodium-native install:    95 |   ASSERT_UINT_BOUNDS(info[0], upper_bound, 0, 0, 0xffffffff, 0xffffffff)
.../node_modules/sodium-native install:       |   ^~~~~~~~~~~~~~~~~~
.../node_modules/sodium-native install: ../binding.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE sodium_pad(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/sodium-native install: ../src/macros.h:102:24: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
.../node_modules/sodium-native install:   102 |   if (((uint64_t) var) < min) { \
.../node_modules/sodium-native install: ../binding.cc:157:3: note: in expansion of macro ‘ASSERT_UINT_BOUNDS’
.../node_modules/sodium-native install:   157 |   ASSERT_UINT_BOUNDS(info[1], unpadded_buflen, 0, 0, `buf.length`, buf_length)
.../node_modules/sodium-native install:       |   ^~~~~~~~~~~~~~~~~~
.../node_modules/sodium-native install: ../binding.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE sodium_unpad(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/sodium-native install: ../src/macros.h:102:24: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
.../node_modules/sodium-native install:   102 |   if (((uint64_t) var) < min) { \
.../node_modules/sodium-native install: ../binding.cc:169:3: note: in expansion of macro ‘ASSERT_UINT_BOUNDS’
.../node_modules/sodium-native install:   169 |   ASSERT_UINT_BOUNDS(info[1], padded_buflen, 0, 0, `buf.length`, buf_length)
.../node_modules/sodium-native install:       |   ^~~~~~~~~~~~~~~~~~
.../node_modules/sodium-native install: In file included from ../binding.cc:1:
.../node_modules/sodium-native install: ../binding.cc: At global scope:
.../node_modules/sodium-native install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:806:43: warning: cast between incompatible function types from ‘void (*)(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)’ {aka ‘void (*)(v8::Local<v8::Object>)’} to ‘node::addon_register_func’ {aka ‘void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)’} [-Wcast-function-type]
.../node_modules/sodium-native install:   806 |       (node::addon_register_func) (regfunc),                          \
.../node_modules/sodium-native install:       |                                           ^
.../node_modules/sodium-native install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:840:3: note: in expansion of macro ‘NODE_MODULE_X’
.../node_modules/sodium-native install:   840 |   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
.../node_modules/sodium-native install:       |   ^~~~~~~~~~~~~
.../node_modules/sodium-native install: ../binding.cc:1593:1: note: in expansion of macro ‘NODE_MODULE’
.../node_modules/sodium-native install:  1593 | NODE_MODULE(sodium, InitAll)
.../node_modules/sodium-native install:       | ^~~~~~~~~~~
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_hash_sha256_wrap.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_hash_sha512_wrap.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_generichash_wrap.o
.../node_modules/sodium-native install: ../src/crypto_generichash_wrap.cc: In static member function ‘static Nan::NAN_METHOD_RETURN_TYPE CryptoGenericHashWrap::New(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/sodium-native install: ../src/crypto_generichash_wrap.cc:11:58: warning: ‘new’ of type ‘CryptoGenericHashWrap’ with extended alignment 64 [-Waligned-new=]
.../node_modules/sodium-native install:    11 |   CryptoGenericHashWrap* obj = new CryptoGenericHashWrap();
.../node_modules/sodium-native install:       |                                                          ^
.../node_modules/sodium-native install: ../src/crypto_generichash_wrap.cc:11:58: note: uses ‘void* operator new(std::size_t)’, which does not have an alignment parameter
.../node_modules/sodium-native install: ../src/crypto_generichash_wrap.cc:11:58: note: use ‘-faligned-new’ to enable C++17 over-aligned new support
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_onetimeauth_wrap.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_stream_xor_wrap.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_stream_chacha20_xor_wrap.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_secretstream_xchacha20poly1305_state_wrap.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_pwhash_async.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_pwhash_str_async.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_pwhash_str_verify_async.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_pwhash_scryptsalsa208sha256_async.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_pwhash_scryptsalsa208sha256_str_async.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_pwhash_scryptsalsa208sha256_str_verify_async.o
.../node_modules/sodium-native install:   SOLINK_MODULE(target) Release/obj.target/sodium.node
.../node_modules/sodium-native install:   COPY Release/sodium.node
.../node_modules/sodium-native install: make: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/build'
.../node_modules/sodium-native install: gyp info ok 
.../node_modules/sodium-native install: Done



Rush install finished successfully. (2 minutes 21.7 seconds)
```

### stderr:

```Shell
Your version of Node.js (16.1.0) is not a Long-Term Support (LTS) release. These versions frequently have bugs. Please consider installing a stable release.
```

</details>

</details>

## Changed files
<details>
<summary>Changed 4 files: </summary>

- .npmrc
- docs/package.json
- packages/echo/feed-store/package.json
- packages/sdk/client/package.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)