### PR TITLE
chore: fix react-framework peer dependencies

### DIFF
--- a/packages/sdk/react-framework/package.json
+++ b/packages/sdk/react-framework/package.json
@@ -38,7 +38,7 @@
     "@dxos/react-client": "*",
     "@material-ui/core": "*",
     "@material-ui/icons": ">=4.11.2",
-    "@material-ui/lab": "*",
+    "@material-ui/lab": ">=4.0.0-alpha",
     "react": "*",
     "react-dom": "*"
   },


### PR DESCRIPTION
The problem here was that in node sem ver `*` doesn't match pre-release versions but also that `@material-ui/lab` only is released as pre-releases. This meant that the peer dependency was not actually able to be matched.

https://github.com/npm/node-semver#prerelease-tags
https://github.com/npm/node-semver/issues/130