### PR TITLE
sdk/config: export browser variables

### DIFF
--- a/packages/sdk/config/src/loaders/index.ts
+++ b/packages/sdk/config/src/loaders/index.ts
@@ -14,6 +14,14 @@ import { mapFromKeyValues } from '../config';
 
 const DEFAULT_BASE_PATH = path.resolve(process.cwd(), 'config');
 
+// NOTE: we need to export LocalStorage and Dynamics
+// for typescript to typecheck browser code.
+// See ConfigPlugin.js:33
+
+export const LocalStorage = () => 0;
+
+export const Dynamics = () => 0;
+
 export const Envs = (basePath = DEFAULT_BASE_PATH) => {
   const content = yaml.load(fs.readFileSync(path.resolve(basePath, 'envs-map.yml'), { encoding: 'utf8' }));
   return mapFromKeyValues(content, process.env);


### PR DESCRIPTION
Fixes typescript error when importing `Dynamics` from `@dxos/config`.