### PR TITLE
Automatic: sort package.json and update references in tsconfig.json files

### DIFF
--- a/packages/mesh/network-devtools/package.json
+++ b/packages/mesh/network-devtools/package.json
@@ -15,10 +15,10 @@
     "@dxos/gem-spore": "~1.0.0-beta.25",
     "@dxos/network-manager": "workspace:*",
     "@dxos/protocol-plugin-presence": "workspace:*",
+    "@dxos/react-framework": "workspace:*",
     "@material-ui/core": "^4.11.4",
     "@types/react": "^16.14.0",
-    "react-resize-aware": "^3.0.0",
-    "@dxos/react-framework": "workspace:*"
+    "react-resize-aware": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "~7.13.15",

--- a/packages/mesh/network-devtools/tsconfig.json
+++ b/packages/mesh/network-devtools/tsconfig.json
@@ -21,7 +21,7 @@
       "path": "../protocol-plugin-presence"
     },
     {
-      "path": "../../sdk/react-ux"
+      "path": "../../sdk/react-framework"
     }
   ]
 }

--- a/packages/sdk/demos/package.json
+++ b/packages/sdk/demos/package.json
@@ -43,6 +43,7 @@
     "@dxos/gem-spore": "~1.0.0-beta.25",
     "@dxos/object-model": "workspace:*",
     "@dxos/react-client": "workspace:*",
+    "@dxos/react-framework": "workspace:*",
     "@dxos/util": "workspace:*",
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
@@ -54,8 +55,7 @@
     "immutability-helper": "^3.0.2",
     "mobile-detect": "~1.4.5",
     "playwright": "^1.7.0",
-    "react-resize-aware": "^3.0.0",
-    "@dxos/react-framework": "workspace:*"
+    "react-resize-aware": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "~7.13.15",

--- a/packages/sdk/demos/tsconfig.json
+++ b/packages/sdk/demos/tsconfig.json
@@ -52,7 +52,7 @@
       "path": "../react-client"
     },
     {
-      "path": "../react-ux"
+      "path": "../react-framework"
     },
     {
       "path": "../../common/util"

--- a/packages/sdk/devtools-extension/package.json
+++ b/packages/sdk/devtools-extension/package.json
@@ -24,6 +24,7 @@
     "@dxos/debug": "workspace:*",
     "@dxos/devtools": "workspace:*",
     "@dxos/network-manager": "workspace:*",
+    "@dxos/react-framework": "workspace:*",
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
@@ -34,8 +35,7 @@
     "react": "^16.14.0",
     "react-copy-to-clipboard": "~5.0.3",
     "react-dom": "^16.14.0",
-    "webextension-polyfill-ts": "~0.25.0",
-    "@dxos/react-framework": "workspace:*"
+    "webextension-polyfill-ts": "~0.25.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/packages/sdk/devtools-extension/tsconfig.json
+++ b/packages/sdk/devtools-extension/tsconfig.json
@@ -34,7 +34,7 @@
       "path": "../../mesh/network-manager"
     },
     {
-      "path": "../react-ux"
+      "path": "../react-framework"
     }
   ]
 }

--- a/packages/sdk/devtools/package.json
+++ b/packages/sdk/devtools/package.json
@@ -20,6 +20,7 @@
     "@dxos/crypto": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/network-devtools": "workspace:*",
+    "@dxos/react-framework": "workspace:*",
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
@@ -29,8 +30,7 @@
     "moment": "^2.24.0",
     "react": "^16.14.0",
     "react-copy-to-clipboard": "~5.0.3",
-    "react-dom": "^16.14.0",
-    "@dxos/react-framework": "workspace:*"
+    "react-dom": "^16.14.0"
   },
   "devDependencies": {
     "@dxos/network-manager": "workspace:*",

--- a/packages/sdk/devtools/tsconfig.json
+++ b/packages/sdk/devtools/tsconfig.json
@@ -24,7 +24,7 @@
       "path": "../../mesh/network-devtools"
     },
     {
-      "path": "../react-ux"
+      "path": "../react-framework"
     },
     {
       "path": "../../mesh/network-manager"

--- a/packages/sdk/react-framework/package.json
+++ b/packages/sdk/react-framework/package.json
@@ -17,13 +17,20 @@
     "test": "toolchain test",
     "build:test": "toolchain build:test"
   },
+  "dependencies": {
+    "@dxos/crypto": "workspace:*",
+    "@dxos/debug": "workspace:*",
+    "clsx": "^1.1.0",
+    "lodash.defaultsdeep": "^4.6.1",
+    "lodash.isplainobject": "^4.0.6"
+  },
   "devDependencies": {
-    "@dxos/toolchain-node-library": "workspace:*",
-    "@dxos/react-client": "workspace:*",
-    "@dxos/client": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@babel/core": "~7.13.15",
     "@babel/plugin-transform-runtime": "^7.11.5",
+    "@dxos/client": "workspace:*",
+    "@dxos/echo-db": "workspace:*",
+    "@dxos/react-client": "workspace:*",
+    "@dxos/toolchain-node-library": "workspace:*",
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
@@ -44,12 +51,5 @@
   },
   "publishConfig": {
     "access": "restricted"
-  },
-  "dependencies": {
-    "@dxos/debug": "workspace:*",
-    "@dxos/crypto": "workspace:*",
-    "lodash.isplainobject": "^4.0.6",
-    "clsx": "^1.1.0",
-    "lodash.defaultsdeep": "^4.6.1"
   }
 }

--- a/packages/sdk/react-framework/tsconfig.json
+++ b/packages/sdk/react-framework/tsconfig.json
@@ -9,9 +9,26 @@
     ]
   },
   "include": [
-    "src",
+    "src"
   ],
   "exclude": [
     "/node_modules/"
+  ],
+  "references": [
+    {
+      "path": "../../common/crypto"
+    },
+    {
+      "path": "../../common/debug"
+    },
+    {
+      "path": "../client"
+    },
+    {
+      "path": "../../echo/echo-db"
+    },
+    {
+      "path": "../react-client"
+    }
   ]
 }


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>npx @sfomin/for-each-package -n "@dxos/*" "npx sort-package-json"</em></summary>

```Shell
[@dxos/toolchain-node-library]: npx sort-package-json



[@dxos/esbuild-plugins]: npx sort-package-json



[@dxos/deps-checker]: npx sort-package-json



[@dxos/wallet-playground]: npx sort-package-json



[@dxos/wallet-extension]: npx sort-package-json



[@dxos/wallet-core]: npx sort-package-json



[@dxos/tutorials-tasks-app]: npx sort-package-json



[@dxos/react-ux]: npx sort-package-json



[@dxos/react-framework]: npx sort-package-json

package.json is sorted!


[@dxos/react-client]: npx sort-package-json



[@dxos/devtools-extension]: npx sort-package-json

package.json is sorted!


[@dxos/devtools]: npx sort-package-json

package.json is sorted!


[@dxos/demos]: npx sort-package-json

package.json is sorted!


[@dxos/config]: npx sort-package-json



[@dxos/client]: npx sort-package-json



[@dxos/signal]: npx sort-package-json



[@dxos/protocol-plugin-replicator]: npx sort-package-json



[@dxos/protocol-plugin-presence]: npx sort-package-json



[@dxos/protocol-plugin-messenger]: npx sort-package-json



[@dxos/protocol-network-generator]: npx sort-package-json



[@dxos/protocol]: npx sort-package-json



[@dxos/network-manager]: npx sort-package-json



[@dxos/network-generator]: npx sort-package-json



[@dxos/network-devtools]: npx sort-package-json

package.json is sorted!


[@dxos/broadcast]: npx sort-package-json



[@dxos/credentials]: npx sort-package-json



[@dxos/gravity-core]: npx sort-package-json



[@dxos/browser-tests]: npx sort-package-json



[@dxos/browser-mocha]: npx sort-package-json



[@dxos/text-model]: npx sort-package-json



[@dxos/object-model]: npx sort-package-json



[@dxos/model-factory]: npx sort-package-json



[@dxos/messenger-model]: npx sort-package-json



[@dxos/feed-store]: npx sort-package-json



[@dxos/echo-testing]: npx sort-package-json



[@dxos/echo-protocol]: npx sort-package-json



[@dxos/echo-db]: npx sort-package-json



[@dxos/util]: npx sort-package-json



[@dxos/testutils]: npx sort-package-json



[@dxos/rpc]: npx sort-package-json



[@dxos/random-access-multi-storage]: npx sort-package-json



[@dxos/protobuf-compiler]: npx sort-package-json



[@dxos/debug]: npx sort-package-json



[@dxos/crypto]: npx sort-package-json



[@dxos/codec-protobuf]: npx sort-package-json



[@dxos/async]: npx sort-package-json



[@dxos/protocol-plugin-bot]: npx sort-package-json



[@dxos/botkit-client]: npx sort-package-json



[@dxos/botkit]: npx sort-package-json



[@dxos/bot]: npx sort-package-json



[@dxos/sdk-docs]: npx sort-package-json
```

### stderr:

```Shell
npx: installed 213 in 12.255s
npx: installed 44 in 2.077s
npx: installed 44 in 1.429s
npx: installed 44 in 1.465s
npx: installed 44 in 1.401s
npx: installed 44 in 1.416s
npx: installed 44 in 1.421s
npx: installed 44 in 1.402s
npx: installed 44 in 1.417s
npx: installed 44 in 1.435s
npx: installed 44 in 1.669s
npx: installed 44 in 1.666s
npx: installed 44 in 1.489s
npx: installed 44 in 1.58s
npx: installed 44 in 1.66s
npx: installed 44 in 1.564s
npx: installed 44 in 1.633s
npx: installed 44 in 1.615s
npx: installed 44 in 1.576s
npx: installed 44 in 1.689s
npx: installed 44 in 1.568s
npx: installed 44 in 1.421s
npx: installed 44 in 1.407s
npx: installed 44 in 1.409s
npx: installed 44 in 1.417s
npx: installed 44 in 1.412s
npx: installed 44 in 1.494s
npx: installed 44 in 1.659s
npx: installed 44 in 1.504s
npx: installed 44 in 1.55s
npx: installed 44 in 1.498s
npx: installed 44 in 1.818s
npx: installed 44 in 1.773s
npx: installed 44 in 1.531s
npx: installed 44 in 1.434s
npx: installed 44 in 1.397s
npx: installed 44 in 1.433s
npx: installed 44 in 1.514s
npx: installed 44 in 1.678s
npx: installed 44 in 1.414s
npx: installed 44 in 1.49s
npx: installed 44 in 1.494s
npx: installed 44 in 1.408s
npx: installed 44 in 1.41s
npx: installed 44 in 1.399s
npx: installed 44 in 1.476s
npx: installed 44 in 1.643s
npx: installed 44 in 1.411s
npx: installed 44 in 1.515s
npx: installed 44 in 1.506s
npx: installed 44 in 1.49s
npx: installed 44 in 1.432s
```

</details>
<details>
<summary><em>npx @monorepo-utils/workspaces-to-typescript-project-references</em></summary>

```Shell
Update Project References!
```

### stderr:

```Shell
npx: installed 97 in 6.868s
```

</details>

</details>

## Changed files
<details>
<summary>Changed 10 files: </summary>

- packages/mesh/network-devtools/package.json
- packages/mesh/network-devtools/tsconfig.json
- packages/sdk/demos/package.json
- packages/sdk/demos/tsconfig.json
- packages/sdk/devtools-extension/package.json
- packages/sdk/devtools-extension/tsconfig.json
- packages/sdk/devtools/package.json
- packages/sdk/devtools/tsconfig.json
- packages/sdk/react-framework/package.json
- packages/sdk/react-framework/tsconfig.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)