### PR TITLE
Automatic: sort package.json and update references in tsconfig.json files

### DIFF
--- a/packages/common/rpc/package.json
+++ b/packages/common/rpc/package.json
@@ -29,10 +29,10 @@
   },
   "devDependencies": {
     "@dxos/toolchain-node-library": "workspace:*",
+    "@types/debug": "^4.1.1",
     "@types/mocha": "~8.2.2",
     "@types/node": "^14.0.9",
-    "earljs": "~0.1.10",
-    "@types/debug": "^4.1.1"
+    "earljs": "~0.1.10"
   },
   "publishConfig": {
     "access": "restricted"

--- a/packages/sdk/tutorials/apps/tasks-app/package.json
+++ b/packages/sdk/tutorials/apps/tasks-app/package.json
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@craco/craco": "~6.1.2",
-    "@dxos/config": "workspace:*",
     "@dxos/client": "workspace:*",
+    "@dxos/config": "workspace:*",
     "@dxos/crypto": "workspace:*",
     "@dxos/echo-db": "workspace:*",
     "@dxos/object-model": "workspace:*",


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>npx @sfomin/for-each-package -n "@dxos/*" "npx sort-package-json"</em></summary>

```Shell
[@dxos/toolchain-node-library]: npx sort-package-json



[@dxos/esbuild-plugins]: npx sort-package-json



[@dxos/deps-checker]: npx sort-package-json



[@dxos/wallet-playground]: npx sort-package-json



[@dxos/wallet-extension]: npx sort-package-json



[@dxos/wallet-core]: npx sort-package-json



[@dxos/tutorials-tasks-app]: npx sort-package-json

package.json is sorted!


[@dxos/react-framework]: npx sort-package-json



[@dxos/react-client]: npx sort-package-json



[@dxos/devtools-extension]: npx sort-package-json



[@dxos/devtools]: npx sort-package-json



[@dxos/demos]: npx sort-package-json



[@dxos/config]: npx sort-package-json



[@dxos/client]: npx sort-package-json



[@dxos/signal]: npx sort-package-json



[@dxos/protocol-plugin-replicator]: npx sort-package-json



[@dxos/protocol-plugin-presence]: npx sort-package-json



[@dxos/protocol-plugin-messenger]: npx sort-package-json



[@dxos/protocol-network-generator]: npx sort-package-json



[@dxos/protocol]: npx sort-package-json



[@dxos/network-manager]: npx sort-package-json



[@dxos/network-generator]: npx sort-package-json



[@dxos/network-devtools]: npx sort-package-json



[@dxos/broadcast]: npx sort-package-json



[@dxos/credentials]: npx sort-package-json



[@dxos/gravity-core]: npx sort-package-json



[@dxos/browser-tests]: npx sort-package-json



[@dxos/browser-mocha]: npx sort-package-json



[@dxos/text-model]: npx sort-package-json



[@dxos/object-model]: npx sort-package-json



[@dxos/model-factory]: npx sort-package-json



[@dxos/messenger-model]: npx sort-package-json



[@dxos/feed-store]: npx sort-package-json



[@dxos/echo-testing]: npx sort-package-json



[@dxos/echo-protocol]: npx sort-package-json



[@dxos/echo-db]: npx sort-package-json



[@dxos/util]: npx sort-package-json



[@dxos/testutils]: npx sort-package-json



[@dxos/rpc]: npx sort-package-json

package.json is sorted!


[@dxos/random-access-multi-storage]: npx sort-package-json



[@dxos/protobuf-compiler]: npx sort-package-json



[@dxos/debug]: npx sort-package-json



[@dxos/crypto]: npx sort-package-json



[@dxos/codec-protobuf]: npx sort-package-json



[@dxos/async]: npx sort-package-json



[@dxos/protocol-plugin-bot]: npx sort-package-json



[@dxos/botkit-client]: npx sort-package-json



[@dxos/botkit]: npx sort-package-json



[@dxos/bot]: npx sort-package-json



[@dxos/sdk-docs]: npx sort-package-json
```

### stderr:

```Shell
npx: installed 213 in 17.586s
npx: installed 44 in 2.001s
npx: installed 44 in 1.193s
npx: installed 44 in 1.153s
npx: installed 44 in 1.158s
npx: installed 44 in 1.228s
npx: installed 44 in 1.214s
npx: installed 44 in 1.152s
npx: installed 44 in 1.158s
npx: installed 44 in 1.229s
npx: installed 44 in 1.155s
npx: installed 44 in 1.154s
npx: installed 44 in 1.174s
npx: installed 44 in 1.169s
npx: installed 44 in 1.158s
npx: installed 44 in 1.234s
npx: installed 44 in 1.15s
npx: installed 44 in 1.175s
npx: installed 44 in 1.149s
npx: installed 44 in 1.158s
npx: installed 44 in 1.155s
npx: installed 44 in 1.258s
npx: installed 44 in 1.241s
npx: installed 44 in 1.279s
npx: installed 44 in 1.189s
npx: installed 44 in 1.174s
npx: installed 44 in 1.184s
npx: installed 44 in 1.231s
npx: installed 44 in 1.142s
npx: installed 44 in 1.215s
npx: installed 44 in 1.232s
npx: installed 44 in 1.406s
npx: installed 44 in 1.154s
npx: installed 44 in 1.143s
npx: installed 44 in 1.16s
npx: installed 44 in 1.158s
npx: installed 44 in 1.16s
npx: installed 44 in 1.154s
npx: installed 44 in 1.155s
npx: installed 44 in 1.164s
npx: installed 44 in 1.166s
npx: installed 44 in 1.162s
npx: installed 44 in 1.152s
npx: installed 44 in 1.158s
npx: installed 44 in 1.154s
npx: installed 44 in 1.189s
npx: installed 44 in 1.232s
npx: installed 44 in 1.231s
npx: installed 44 in 1.227s
npx: installed 44 in 1.147s
npx: installed 44 in 1.155s
```

</details>
<details>
<summary><em>npx @monorepo-utils/workspaces-to-typescript-project-references</em></summary>

```Shell
Update Project References!
```

### stderr:

```Shell
npx: installed 97 in 4.382s
```

</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- packages/common/rpc/package.json
- packages/sdk/tutorials/apps/tasks-app/package.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)