### PR TITLE
Automatic: sort package.json and update references in tsconfig.json files

### DIFF
--- a/packages/echo/text-model/package.json
+++ b/packages/echo/text-model/package.json
@@ -33,11 +33,11 @@
     "yjs": "^13.4.1"
   },
   "devDependencies": {
+    "@dxos/object-model": "workspace:*",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/jest": "^26.0.7",
     "@types/mocha": "~8.2.2",
-    "expect": "~27.0.2",
-    "@dxos/object-model": "workspace:*"
+    "expect": "~27.0.2"
   },
   "publishConfig": {
     "access": "restricted"

--- a/packages/echo/text-model/tsconfig.json
+++ b/packages/echo/text-model/tsconfig.json
@@ -18,6 +18,9 @@
     },
     {
       "path": "../model-factory"
+    },
+    {
+      "path": "../object-model"
     }
   ]
 }

--- a/packages/mesh/network-manager/package.json
+++ b/packages/mesh/network-manager/package.json
@@ -44,10 +44,10 @@
     "@types/mocha": "~8.2.2",
     "@types/node": "^14.0.9",
     "earljs": "~0.1.10",
+    "expect": "~27.0.2",
     "fast-check": "~2.14.0",
-    "wait-for-expect": "^3.0.2",
     "mocha": "~8.4.0",
-    "expect": "~27.0.2"
+    "wait-for-expect": "^3.0.2"
   },
   "publishConfig": {
     "access": "restricted"

--- a/packages/mesh/network-manager/tsconfig.json
+++ b/packages/mesh/network-manager/tsconfig.json
@@ -33,6 +33,9 @@
       "path": "../../common/util"
     },
     {
+      "path": "../../gravity/browser-mocha"
+    },
+    {
       "path": "../signal"
     },
     {

--- a/packages/mesh/signal/package.json
+++ b/packages/mesh/signal/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.1",
     "@dxos/broadcast": "workspace:*",
+    "@dxos/crypto": "workspace:*",
     "@hyperswarm/dht": "^4.0.1",
     "buffer-json-encoding": "^1.0.2",
     "debug": "^4.1.1",
@@ -61,8 +62,7 @@
     "systeminformation": "^5.7.7",
     "tiny-lru": "^7.0.6",
     "varint": "^5.0.0",
-    "yargs": "~16.2.0",
-    "@dxos/crypto": "workspace:*"
+    "yargs": "~16.2.0"
   },
   "devDependencies": {
     "@dxos/toolchain-node-library": "workspace:*",

--- a/packages/mesh/signal/tsconfig.json
+++ b/packages/mesh/signal/tsconfig.json
@@ -13,6 +13,9 @@
   "references": [
     {
       "path": "../broadcast"
+    },
+    {
+      "path": "../../common/crypto"
     }
   ]
 }


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>npx @sfomin/for-each-package -n "@dxos/*" "npx sort-package-json"</em></summary>

```Shell
[@dxos/toolchain-node-library]: npx sort-package-json



[@dxos/esbuild-plugins]: npx sort-package-json



[@dxos/deps-checker]: npx sort-package-json



[@dxos/wallet-playground]: npx sort-package-json



[@dxos/wallet-extension]: npx sort-package-json



[@dxos/wallet-core]: npx sort-package-json



[@dxos/tutorials-tasks-app]: npx sort-package-json



[@dxos/react-framework]: npx sort-package-json



[@dxos/react-client]: npx sort-package-json



[@dxos/devtools-extension]: npx sort-package-json



[@dxos/devtools]: npx sort-package-json



[@dxos/demos]: npx sort-package-json



[@dxos/config]: npx sort-package-json



[@dxos/client]: npx sort-package-json



[@dxos/signal]: npx sort-package-json

package.json is sorted!


[@dxos/protocol-plugin-replicator]: npx sort-package-json



[@dxos/protocol-plugin-presence]: npx sort-package-json



[@dxos/protocol-plugin-messenger]: npx sort-package-json



[@dxos/protocol-network-generator]: npx sort-package-json



[@dxos/protocol]: npx sort-package-json



[@dxos/network-manager]: npx sort-package-json

package.json is sorted!


[@dxos/network-generator]: npx sort-package-json



[@dxos/network-devtools]: npx sort-package-json



[@dxos/broadcast]: npx sort-package-json



[@dxos/credentials]: npx sort-package-json



[@dxos/gravity-core]: npx sort-package-json



[@dxos/browser-tests]: npx sort-package-json



[@dxos/browser-mocha]: npx sort-package-json



[@dxos/text-model]: npx sort-package-json

package.json is sorted!


[@dxos/object-model]: npx sort-package-json



[@dxos/model-factory]: npx sort-package-json



[@dxos/messenger-model]: npx sort-package-json



[@dxos/feed-store]: npx sort-package-json



[@dxos/echo-testing]: npx sort-package-json



[@dxos/echo-protocol]: npx sort-package-json



[@dxos/echo-db]: npx sort-package-json



[@dxos/util]: npx sort-package-json



[@dxos/testutils]: npx sort-package-json



[@dxos/rpc]: npx sort-package-json



[@dxos/random-access-multi-storage]: npx sort-package-json



[@dxos/protobuf-compiler]: npx sort-package-json



[@dxos/debug]: npx sort-package-json



[@dxos/crypto]: npx sort-package-json



[@dxos/codec-protobuf]: npx sort-package-json



[@dxos/async]: npx sort-package-json



[@dxos/protocol-plugin-bot]: npx sort-package-json



[@dxos/botkit-client]: npx sort-package-json



[@dxos/botkit]: npx sort-package-json



[@dxos/bot]: npx sort-package-json



[@dxos/sdk-docs]: npx sort-package-json
```

### stderr:

```Shell
npx: installed 213 in 10.532s
npx: installed 44 in 1.946s
npx: installed 44 in 1.419s
npx: installed 44 in 1.334s
npx: installed 44 in 1.297s
npx: installed 44 in 1.369s
npx: installed 44 in 1.386s
npx: installed 44 in 1.418s
npx: installed 44 in 1.358s
npx: installed 44 in 1.407s
npx: installed 44 in 1.369s
npx: installed 44 in 1.322s
npx: installed 44 in 1.423s
npx: installed 44 in 1.316s
npx: installed 44 in 1.338s
npx: installed 44 in 1.258s
npx: installed 44 in 1.396s
npx: installed 44 in 1.304s
npx: installed 44 in 1.277s
npx: installed 44 in 1.32s
npx: installed 44 in 1.299s
npx: installed 44 in 1.309s
npx: installed 44 in 1.347s
npx: installed 44 in 1.33s
npx: installed 44 in 1.359s
npx: installed 44 in 1.297s
npx: installed 44 in 1.336s
npx: installed 44 in 1.32s
npx: installed 44 in 1.37s
npx: installed 44 in 1.416s
npx: installed 44 in 1.612s
npx: installed 44 in 1.511s
npx: installed 44 in 1.552s
npx: installed 44 in 1.587s
npx: installed 44 in 1.505s
npx: installed 44 in 1.578s
npx: installed 44 in 1.5s
npx: installed 44 in 1.438s
npx: installed 44 in 1.497s
npx: installed 44 in 1.33s
npx: installed 44 in 1.372s
npx: installed 44 in 1.336s
npx: installed 44 in 1.287s
npx: installed 44 in 1.258s
npx: installed 44 in 1.292s
npx: installed 44 in 1.359s
npx: installed 44 in 1.285s
npx: installed 44 in 1.374s
npx: installed 44 in 1.313s
npx: installed 44 in 1.793s
npx: installed 44 in 1.354s
```

</details>
<details>
<summary><em>npx @monorepo-utils/workspaces-to-typescript-project-references</em></summary>

```Shell
Update Project References!
```

### stderr:

```Shell
npx: installed 97 in 6.15s
```

</details>

</details>

## Changed files
<details>
<summary>Changed 6 files: </summary>

- packages/echo/text-model/package.json
- packages/echo/text-model/tsconfig.json
- packages/mesh/network-manager/package.json
- packages/mesh/network-manager/tsconfig.json
- packages/mesh/signal/package.json
- packages/mesh/signal/tsconfig.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)