### PR TITLE
Automatic: sort package.json and update references in tsconfig.json files

### DIFF
--- a/packages/common/protobuf-compiler/package.json
+++ b/packages/common/protobuf-compiler/package.json
@@ -2,11 +2,11 @@
   "name": "@dxos/protobuf-compiler",
   "version": "2.12.10",
   "license": "MIT",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "bin": {
     "build-protobuf": "./bin/main.js"
   },
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
   "files": [
     "dist",
     "src"

--- a/packages/mesh/protocol-plugin-presence/package.json
+++ b/packages/mesh/protocol-plugin-presence/package.json
@@ -37,12 +37,12 @@
     "queue-microtask": "^1.1.2"
   },
   "devDependencies": {
+    "@dxos/async": "workspace:*",
     "@dxos/protocol-network-generator": "workspace:*",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/jest": "^26.0.7",
     "ngraph.path": "~1.3.1",
-    "wait-for-expect": "^3.0.2",
-    "@dxos/async": "workspace:*"
+    "wait-for-expect": "^3.0.2"
   },
   "publishConfig": {
     "access": "restricted"

--- a/packages/mesh/protocol-plugin-presence/tsconfig.json
+++ b/packages/mesh/protocol-plugin-presence/tsconfig.json
@@ -21,6 +21,9 @@
       "path": "../protocol"
     },
     {
+      "path": "../../common/async"
+    },
+    {
       "path": "../protocol-network-generator"
     }
   ]


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>npx @sfomin/for-each-package -n "@dxos/*" "npx sort-package-json"</em></summary>

```Shell
[@dxos/toolchain-node-library]: npx sort-package-json



[@dxos/esbuild-plugins]: npx sort-package-json



[@dxos/deps-checker]: npx sort-package-json



[@dxos/wallet-playground]: npx sort-package-json



[@dxos/wallet-extension]: npx sort-package-json



[@dxos/wallet-core]: npx sort-package-json



[@dxos/tutorials-tasks-app]: npx sort-package-json



[@dxos/react-framework]: npx sort-package-json



[@dxos/react-client]: npx sort-package-json



[@dxos/devtools-extension]: npx sort-package-json



[@dxos/devtools]: npx sort-package-json



[@dxos/demos]: npx sort-package-json



[@dxos/config]: npx sort-package-json



[@dxos/client]: npx sort-package-json



[@dxos/signal]: npx sort-package-json



[@dxos/protocol-plugin-replicator]: npx sort-package-json



[@dxos/protocol-plugin-presence]: npx sort-package-json

package.json is sorted!


[@dxos/protocol-plugin-messenger]: npx sort-package-json



[@dxos/protocol-network-generator]: npx sort-package-json



[@dxos/protocol]: npx sort-package-json



[@dxos/network-manager]: npx sort-package-json



[@dxos/network-generator]: npx sort-package-json



[@dxos/network-devtools]: npx sort-package-json



[@dxos/broadcast]: npx sort-package-json



[@dxos/credentials]: npx sort-package-json



[@dxos/gravity-core]: npx sort-package-json



[@dxos/browser-tests]: npx sort-package-json



[@dxos/browser-mocha]: npx sort-package-json



[@dxos/text-model]: npx sort-package-json



[@dxos/object-model]: npx sort-package-json



[@dxos/model-factory]: npx sort-package-json



[@dxos/messenger-model]: npx sort-package-json



[@dxos/feed-store]: npx sort-package-json



[@dxos/echo-testing]: npx sort-package-json



[@dxos/echo-protocol]: npx sort-package-json



[@dxos/echo-db]: npx sort-package-json



[@dxos/util]: npx sort-package-json



[@dxos/testutils]: npx sort-package-json



[@dxos/rpc]: npx sort-package-json



[@dxos/random-access-multi-storage]: npx sort-package-json



[@dxos/protobuf-compiler]: npx sort-package-json

package.json is sorted!


[@dxos/debug]: npx sort-package-json



[@dxos/crypto]: npx sort-package-json



[@dxos/codec-protobuf]: npx sort-package-json



[@dxos/async]: npx sort-package-json



[@dxos/protocol-plugin-bot]: npx sort-package-json



[@dxos/botkit-client]: npx sort-package-json



[@dxos/botkit]: npx sort-package-json



[@dxos/bot]: npx sort-package-json



[@dxos/sdk-docs]: npx sort-package-json
```

### stderr:

```Shell
npx: installed 213 in 137.702s
npx: installed 44 in 2.138s
npx: installed 44 in 1.171s
npx: installed 44 in 1.167s
npx: installed 44 in 1.186s
npx: installed 44 in 1.167s
npx: installed 44 in 1.182s
npx: installed 44 in 1.186s
npx: installed 44 in 1.341s
npx: installed 44 in 1.689s
npx: installed 44 in 1.192s
npx: installed 44 in 1.182s
npx: installed 44 in 1.165s
npx: installed 44 in 1.17s
npx: installed 44 in 1.2s
npx: installed 44 in 1.174s
npx: installed 44 in 1.182s
npx: installed 44 in 1.195s
npx: installed 44 in 1.175s
npx: installed 44 in 1.175s
npx: installed 44 in 1.18s
npx: installed 44 in 1.168s
npx: installed 44 in 1.17s
npx: installed 44 in 1.171s
npx: installed 44 in 1.185s
npx: installed 44 in 1.331s
npx: installed 44 in 1.314s
npx: installed 44 in 1.654s
npx: installed 44 in 1.726s
npx: installed 44 in 1.198s
npx: installed 44 in 1.191s
npx: installed 44 in 1.17s
npx: installed 44 in 1.17s
npx: installed 44 in 1.18s
npx: installed 44 in 1.183s
npx: installed 44 in 1.196s
npx: installed 44 in 1.178s
npx: installed 44 in 1.18s
npx: installed 44 in 1.185s
npx: installed 44 in 1.167s
npx: installed 44 in 1.202s
npx: installed 44 in 1.177s
npx: installed 44 in 1.18s
npx: installed 44 in 1.177s
npx: installed 44 in 1.186s
npx: installed 44 in 1.182s
npx: installed 44 in 1.17s
npx: installed 44 in 1.683s
npx: installed 44 in 1.177s
npx: installed 44 in 1.195s
npx: installed 44 in 1.196s
```

</details>
<details>
<summary><em>npx @monorepo-utils/workspaces-to-typescript-project-references</em></summary>

```Shell
Update Project References!
```

### stderr:

```Shell
npx: installed 97 in 4.405s
```

</details>

</details>

## Changed files
<details>
<summary>Changed 3 files: </summary>

- packages/common/protobuf-compiler/package.json
- packages/mesh/protocol-plugin-presence/package.json
- packages/mesh/protocol-plugin-presence/tsconfig.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)