### PR TITLE
fix: make useParty key optional

### DIFF
--- a/packages/sdk/react-client/src/hooks/echo-queries/parties.ts
+++ b/packages/sdk/react-client/src/hooks/echo-queries/parties.ts
@@ -13,7 +13,7 @@ import { useClient } from '../client';
  * Get a specific Party.
  * To be used with `ClientProvider` or `ClientInitializer` component wrapper.
  */
-export const useParty = (partyKey: PublicKeyLike) => {
+export const useParty = (partyKey?: PublicKeyLike) => {
   const client = useClient();
   return partyKey ? client.echo.getParty(PublicKey.from(partyKey)) : undefined;
 };


### PR DESCRIPTION
This is just aligning the type signature with the actual functionality of the hook, it's already handling the case where the key isn't passed.