### PR TITLE
chore: Use patched version of hypertrie

### DIFF
--- a/packages/echo/echo-db/package.json
+++ b/packages/echo/echo-db/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^14.0.9",
     "buffer-json-encoding": "^1.0.2",
     "debug": "^4.1.1",
-    "hypertrie": "5.1.1",
+    "hypertrie": "dxos/hypertrie#8af4c23bc739f6e1c298cc15c12528e7f7483681",
     "json-stable-stringify": "^1.0.1",
     "pify": "~5.0.0"
   },

--- a/packages/echo/feed-store/package.json
+++ b/packages/echo/feed-store/package.json
@@ -33,7 +33,7 @@
     "end-of-stream": "^1.4.1",
     "from2": "^2.3.0",
     "hypercore": "^9.10.0",
-    "hypertrie": "5.1.1",
+    "hypertrie": "dxos/hypertrie#8af4c23bc739f6e1c298cc15c12528e7f7483681",
     "pify": "~5.0.0",
     "pump": "^3.0.0",
     "through2": "^3.0.1"


### PR DESCRIPTION
Another issue discovered when working on https://github.com/dxos/protocols/issues/446