### PR TITLE
Automatic: sort package.json and update references in tsconfig.json files

### DIFF
--- a/packages/common/crypto/package.json
+++ b/packages/common/crypto/package.json
@@ -17,10 +17,10 @@
     "lint": "toolchain lint"
   },
   "dependencies": {
+    "bip39": "^3.0.2",
     "crypto-js": "^3.1.9-1",
     "humanhash": "^1.0.4",
-    "hypercore-crypto": "^2.3.0",
-    "bip39": "^3.0.2"
+    "hypercore-crypto": "^2.3.0"
   },
   "devDependencies": {
     "@dxos/toolchain-node-library": "workspace:*",

--- a/packages/mesh/network-devtools/package.json
+++ b/packages/mesh/network-devtools/package.json
@@ -31,17 +31,17 @@
     "@storybook/core-events": "^6.3.4",
     "@storybook/react": "^6.3.4",
     "@storybook/theming": "^6.3.4",
+    "@types/react-router": "~5.1.16",
+    "@types/react-router-dom": "~5.1.7",
     "fork-ts-checker-webpack-plugin": "~6.2.5",
     "react": "^16.14.0",
     "react-docgen-typescript-loader": "^3.7.2",
     "react-dom": "^16.14.0",
+    "react-router": "~5.2.1",
+    "react-router-dom": "^5.1.2",
     "ts-loader": "~8.1.0",
     "typescript": "^4.3.5",
-    "webpack": "4.44.2",
-    "react-router": "~5.2.1",
-    "@types/react-router": "~5.1.16",
-    "@types/react-router-dom": "~5.1.7",
-    "react-router-dom": "^5.1.2"
+    "webpack": "4.44.2"
   },
   "peerDependencies": {
     "react": "*"

--- a/packages/sdk/demos/tsconfig.json
+++ b/packages/sdk/demos/tsconfig.json
@@ -31,9 +31,6 @@
       "path": "../client"
     },
     {
-      "path": "../../halo/credentials"
-    },
-    {
       "path": "../../common/crypto"
     },
     {

--- a/packages/wallet/extension/tsconfig.json
+++ b/packages/wallet/extension/tsconfig.json
@@ -29,9 +29,6 @@
       "path": "../../common/codec-protobuf"
     },
     {
-      "path": "../../halo/credentials"
-    },
-    {
       "path": "../../common/crypto"
     },
     {

--- a/toolchains/node-library/package.json
+++ b/toolchains/node-library/package.json
@@ -22,8 +22,8 @@
     "pkg-dir": "~5.0.0",
     "ts-jest": "^26.5.6",
     "typescript": "^4.3.5",
-    "yargs": "~16.2.0",
-    "wtfnode": "~0.9.1"
+    "wtfnode": "~0.9.1",
+    "yargs": "~16.2.0"
   },
   "devDependencies": {
     "@types/glob": "~7.1.3",


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>npx @sfomin/for-each-package -n "@dxos/*" "npx sort-package-json"</em></summary>

```Shell
[@dxos/toolchain-node-library]: npx sort-package-json

package.json is sorted!


[@dxos/esbuild-plugins]: npx sort-package-json



[@dxos/deps-checker]: npx sort-package-json



[@dxos/wallet-playground]: npx sort-package-json



[@dxos/wallet-extension]: npx sort-package-json



[@dxos/wallet-core]: npx sort-package-json



[@dxos/tutorials-tasks-app]: npx sort-package-json



[@dxos/react-framework]: npx sort-package-json



[@dxos/react-client]: npx sort-package-json



[@dxos/devtools-extension]: npx sort-package-json



[@dxos/devtools]: npx sort-package-json



[@dxos/demos]: npx sort-package-json



[@dxos/config]: npx sort-package-json



[@dxos/client]: npx sort-package-json



[@dxos/signal]: npx sort-package-json



[@dxos/protocol-plugin-replicator]: npx sort-package-json



[@dxos/protocol-plugin-presence]: npx sort-package-json



[@dxos/protocol-plugin-messenger]: npx sort-package-json



[@dxos/protocol-network-generator]: npx sort-package-json



[@dxos/protocol]: npx sort-package-json



[@dxos/network-manager]: npx sort-package-json



[@dxos/network-generator]: npx sort-package-json



[@dxos/network-devtools]: npx sort-package-json

package.json is sorted!


[@dxos/broadcast]: npx sort-package-json



[@dxos/credentials]: npx sort-package-json



[@dxos/gravity-core]: npx sort-package-json



[@dxos/browser-tests]: npx sort-package-json



[@dxos/browser-mocha]: npx sort-package-json



[@dxos/text-model]: npx sort-package-json



[@dxos/object-model]: npx sort-package-json



[@dxos/model-factory]: npx sort-package-json



[@dxos/messenger-model]: npx sort-package-json



[@dxos/feed-store]: npx sort-package-json



[@dxos/echo-testing]: npx sort-package-json



[@dxos/echo-protocol]: npx sort-package-json



[@dxos/echo-db]: npx sort-package-json



[@dxos/util]: npx sort-package-json



[@dxos/testutils]: npx sort-package-json



[@dxos/rpc]: npx sort-package-json



[@dxos/random-access-multi-storage]: npx sort-package-json



[@dxos/protobuf-compiler]: npx sort-package-json



[@dxos/debug]: npx sort-package-json



[@dxos/crypto]: npx sort-package-json

package.json is sorted!


[@dxos/codec-protobuf]: npx sort-package-json



[@dxos/async]: npx sort-package-json



[@dxos/test-bot]: npx sort-package-json



[@dxos/protocol-plugin-bot]: npx sort-package-json



[@dxos/botkit-client]: npx sort-package-json



[@dxos/botkit]: npx sort-package-json



[@dxos/bot]: npx sort-package-json



[@dxos/sdk-docs]: npx sort-package-json
```

### stderr:

```Shell
npx: installed 213 in 9.795s
npx: installed 44 in 1.842s
npx: installed 44 in 1.221s
npx: installed 44 in 1.27s
npx: installed 44 in 1.216s
npx: installed 44 in 1.32s
npx: installed 44 in 1.295s
npx: installed 44 in 1.306s
npx: installed 44 in 1.221s
npx: installed 44 in 1.221s
npx: installed 44 in 1.219s
npx: installed 44 in 1.232s
npx: installed 44 in 1.213s
npx: installed 44 in 1.227s
npx: installed 44 in 1.689s
npx: installed 44 in 1.208s
npx: installed 44 in 1.299s
npx: installed 44 in 1.18s
npx: installed 44 in 1.212s
npx: installed 44 in 1.213s
npx: installed 44 in 1.217s
npx: installed 44 in 1.291s
npx: installed 44 in 1.23s
npx: installed 44 in 1.193s
npx: installed 44 in 1.196s
npx: installed 44 in 1.213s
npx: installed 44 in 1.219s
npx: installed 44 in 1.214s
npx: installed 44 in 1.208s
npx: installed 44 in 1.201s
npx: installed 44 in 1.218s
npx: installed 44 in 1.227s
npx: installed 44 in 1.394s
npx: installed 44 in 1.212s
npx: installed 44 in 1.3s
npx: installed 44 in 1.211s
npx: installed 44 in 1.269s
npx: installed 44 in 1.208s
npx: installed 44 in 1.199s
npx: installed 44 in 1.319s
npx: installed 44 in 1.209s
npx: installed 44 in 1.349s
npx: installed 44 in 1.299s
npx: installed 44 in 1.338s
npx: installed 44 in 1.216s
npx: installed 44 in 1.315s
npx: installed 44 in 1.34s
npx: installed 44 in 1.221s
npx: installed 44 in 1.221s
npx: installed 44 in 1.235s
npx: installed 44 in 1.233s
npx: installed 44 in 1.301s
```

</details>
<details>
<summary><em>npx @monorepo-utils/workspaces-to-typescript-project-references</em></summary>

```Shell
Update Project References!
```

### stderr:

```Shell
npx: installed 97 in 6.319s
```

</details>

</details>

## Changed files
<details>
<summary>Changed 5 files: </summary>

- packages/common/crypto/package.json
- packages/mesh/network-devtools/package.json
- packages/sdk/demos/tsconfig.json
- packages/wallet/extension/tsconfig.json
- toolchains/node-library/package.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)