### PR TITLE
protobuf-compiler: fix workspaces usage

### DIFF
--- a/packages/common/protobuf-compiler/package.json
+++ b/packages/common/protobuf-compiler/package.json
@@ -5,6 +5,7 @@
   "author": "DXOS.org",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
+  "private": true,
   "bin": {
     "build-protobuf": "./bin/main.js"
   },
@@ -37,6 +38,9 @@
     "read-pkg": "^5.2.0",
     "ts-morph": "~10.0.2"
   },
+  "workspaces": [
+    "../"
+  ],
   "devDependencies": {
     "@dxos/codec-protobuf": "workspace:*",
     "@dxos/eslint-plugin": "~1.0.14",


### PR DESCRIPTION
This patch fixes an error on `yarn install` in protobuf compiler:
```console
error Workspaces can only be enabled in private projects.
```

The fix is more of a workaround that I have stolen from this thread: https://github.com/yarnpkg/yarn/issues/8580
and not a real solution, but it WOMM.