### PR TITLE
Automatic: sort package.json and update references in tsconfig.json files

### DIFF
--- a/packages/common/protobuf-compiler/tsconfig.json
+++ b/packages/common/protobuf-compiler/tsconfig.json
@@ -6,6 +6,9 @@
   "references": [
     {
       "path": "../codec-protobuf"
+    },
+    {
+      "path": "../protobuf-test"
     }
   ],
   "include": [

--- a/packages/common/protobuf-test/package.json
+++ b/packages/common/protobuf-test/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@dxos/protobuf-test",
   "version": "1.0.0",
+  "private": true,
   "license": "AGPL-3.0",
   "author": "DXOS.org",
-  "private": true,
   "files": [
     "dist",
     "src"

--- a/packages/mesh/network-manager/package.json
+++ b/packages/mesh/network-manager/package.json
@@ -20,11 +20,11 @@
   },
   "dependencies": {
     "@dxos/async": "workspace:*",
+    "@dxos/credentials": "workspace:*",
     "@dxos/crypto": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/protocol": "workspace:*",
     "@dxos/protocol-plugin-presence": "workspace:*",
-    "@dxos/credentials": "workspace:*",
     "@dxos/util": "workspace:*",
     "@types/simple-peer": "9.11.3",
     "@types/ws": "^7.4.0",

--- a/packages/mesh/network-manager/tsconfig.json
+++ b/packages/mesh/network-manager/tsconfig.json
@@ -18,6 +18,9 @@
       "path": "../../common/async"
     },
     {
+      "path": "../../halo/credentials"
+    },
+    {
       "path": "../../common/crypto"
     },
     {


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>npx @sfomin/for-each-package -n "@dxos/*" "npx sort-package-json"</em></summary>

```Shell
[@dxos/toolchain-node-library]: npx sort-package-json



[@dxos/esbuild-plugins]: npx sort-package-json



[@dxos/deps-checker]: npx sort-package-json



[@dxos/wallet-playground]: npx sort-package-json



[@dxos/wallet-extension]: npx sort-package-json



[@dxos/wallet-core]: npx sort-package-json



[@dxos/tutorials-tasks-app]: npx sort-package-json



[@dxos/react-framework]: npx sort-package-json



[@dxos/react-client]: npx sort-package-json



[@dxos/devtools-extension]: npx sort-package-json



[@dxos/devtools]: npx sort-package-json



[@dxos/demos]: npx sort-package-json



[@dxos/config]: npx sort-package-json



[@dxos/client]: npx sort-package-json



[@dxos/signal]: npx sort-package-json



[@dxos/protocol-plugin-replicator]: npx sort-package-json



[@dxos/protocol-plugin-presence]: npx sort-package-json



[@dxos/protocol-plugin-messenger]: npx sort-package-json



[@dxos/protocol-network-generator]: npx sort-package-json



[@dxos/protocol]: npx sort-package-json



[@dxos/network-manager]: npx sort-package-json

package.json is sorted!


[@dxos/network-generator]: npx sort-package-json



[@dxos/network-devtools]: npx sort-package-json



[@dxos/broadcast]: npx sort-package-json



[@dxos/credentials]: npx sort-package-json



[@dxos/gravity-core]: npx sort-package-json



[@dxos/browser-tests]: npx sort-package-json



[@dxos/browser-mocha]: npx sort-package-json



[@dxos/text-model]: npx sort-package-json



[@dxos/object-model]: npx sort-package-json



[@dxos/model-factory]: npx sort-package-json



[@dxos/messenger-model]: npx sort-package-json



[@dxos/feed-store]: npx sort-package-json



[@dxos/echo-testing]: npx sort-package-json



[@dxos/echo-protocol]: npx sort-package-json



[@dxos/echo-db]: npx sort-package-json



[@dxos/util]: npx sort-package-json



[@dxos/testutils]: npx sort-package-json



[@dxos/rpc]: npx sort-package-json



[@dxos/random-access-multi-storage]: npx sort-package-json



[@dxos/protobuf-test]: npx sort-package-json

package.json is sorted!


[@dxos/protobuf-compiler]: npx sort-package-json



[@dxos/debug]: npx sort-package-json



[@dxos/crypto]: npx sort-package-json



[@dxos/codec-protobuf]: npx sort-package-json



[@dxos/async]: npx sort-package-json



[@dxos/test-bot]: npx sort-package-json



[@dxos/protocol-plugin-bot]: npx sort-package-json



[@dxos/botkit-client]: npx sort-package-json



[@dxos/botkit]: npx sort-package-json



[@dxos/bot]: npx sort-package-json



[@dxos/sdk-docs]: npx sort-package-json
```

### stderr:

```Shell
npx: installed 213 in 25.421s
npx: installed 44 in 2.507s
npx: installed 44 in 2.083s
npx: installed 44 in 1.615s
npx: installed 44 in 1.567s
npx: installed 44 in 1.615s
npx: installed 44 in 1.683s
npx: installed 44 in 1.65s
npx: installed 44 in 1.681s
npx: installed 44 in 1.683s
npx: installed 44 in 1.767s
npx: installed 44 in 1.682s
npx: installed 44 in 1.752s
npx: installed 44 in 1.654s
npx: installed 44 in 1.64s
npx: installed 44 in 1.61s
npx: installed 44 in 1.588s
npx: installed 44 in 1.741s
npx: installed 44 in 1.63s
npx: installed 44 in 1.594s
npx: installed 44 in 1.621s
npx: installed 44 in 1.608s
npx: installed 44 in 1.579s
npx: installed 44 in 1.672s
npx: installed 44 in 1.65s
npx: installed 44 in 1.619s
npx: installed 44 in 1.697s
npx: installed 44 in 1.699s
npx: installed 44 in 1.719s
npx: installed 44 in 1.678s
npx: installed 44 in 1.621s
npx: installed 44 in 1.661s
npx: installed 44 in 2.102s
npx: installed 44 in 1.696s
npx: installed 44 in 1.592s
npx: installed 44 in 1.671s
npx: installed 44 in 1.593s
npx: installed 44 in 1.598s
npx: installed 44 in 1.609s
npx: installed 44 in 1.605s
npx: installed 44 in 1.608s
npx: installed 44 in 1.675s
npx: installed 44 in 1.605s
npx: installed 44 in 1.611s
npx: installed 44 in 1.624s
npx: installed 44 in 1.565s
npx: installed 44 in 1.6s
npx: installed 44 in 1.603s
npx: installed 44 in 1.6s
npx: installed 44 in 1.59s
npx: installed 44 in 1.717s
npx: installed 44 in 1.571s
npx: installed 44 in 1.683s
```

</details>
<details>
<summary><em>npx @monorepo-utils/workspaces-to-typescript-project-references</em></summary>

```Shell
Update Project References!
```

### stderr:

```Shell
npx: installed 97 in 7.207s
```

</details>

</details>

## Changed files
<details>
<summary>Changed 4 files: </summary>

- packages/common/protobuf-compiler/tsconfig.json
- packages/common/protobuf-test/package.json
- packages/mesh/network-manager/package.json
- packages/mesh/network-manager/tsconfig.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)