### PR TITLE
Automatic: sort package.json and update references in tsconfig.json files

### DIFF
--- a/packages/halo/halo-protocol/tsconfig.json
+++ b/packages/halo/halo-protocol/tsconfig.json
@@ -12,9 +12,6 @@
   ],
   "references": [
     {
-      "path": "../../common/async"
-    },
-    {
       "path": "../../common/codec-protobuf"
     },
     {
@@ -24,19 +21,7 @@
       "path": "../../common/debug"
     },
     {
-      "path": "../../echo/feed-store"
-    },
-    {
-      "path": "../../mesh/protocol"
-    },
-    {
       "path": "../../common/util"
-    },
-    {
-      "path": "../../mesh/protocol-plugin-replicator"
-    },
-    {
-      "path": "../../common/random-access-multi-storage"
     }
   ]
 }

--- a/packages/mesh/network-devtools/package.json
+++ b/packages/mesh/network-devtools/package.json
@@ -17,9 +17,9 @@
     "@dxos/protocol-plugin-presence": "workspace:*",
     "@dxos/react-framework": "workspace:*",
     "@material-ui/core": "^4.11.4",
+    "@material-ui/icons": "^4.11.2",
     "@types/react": "^16.14.0",
-    "react-resize-aware": "^3.0.0",
-    "@material-ui/icons": "^4.11.2"
+    "react-resize-aware": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "~7.13.15",

--- a/packages/sdk/react-framework/package.json
+++ b/packages/sdk/react-framework/package.json
@@ -23,8 +23,8 @@
     "clsx": "^1.1.0",
     "lodash.defaultsdeep": "^4.6.1",
     "lodash.isplainobject": "^4.0.6",
-    "url-join": "^4.0.1",
-    "react-copy-to-clipboard": "~5.0.3"
+    "react-copy-to-clipboard": "~5.0.3",
+    "url-join": "^4.0.1"
   },
   "devDependencies": {
     "@babel/core": "~7.13.15",
@@ -37,12 +37,12 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@types/react": "^16.14.0",
+    "@types/react-copy-to-clipboard": "~5.0.1",
     "@types/url-join": "~4.0.1",
     "babel-plugin-add-module-exports": "^1.0.4",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
-    "typescript": "^4.3.5",
-    "@types/react-copy-to-clipboard": "~5.0.1"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "@dxos/client": "*",


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>npx @sfomin/for-each-package -n "@dxos/*" "npx sort-package-json"</em></summary>

```Shell
[@dxos/toolchain-node-library]: npx sort-package-json



[@dxos/esbuild-plugins]: npx sort-package-json



[@dxos/deps-checker]: npx sort-package-json



[@dxos/wallet-playground]: npx sort-package-json



[@dxos/wallet-extension]: npx sort-package-json



[@dxos/wallet-core]: npx sort-package-json



[@dxos/tutorials-tasks-app]: npx sort-package-json



[@dxos/react-framework]: npx sort-package-json

package.json is sorted!


[@dxos/react-client]: npx sort-package-json



[@dxos/devtools-extension]: npx sort-package-json



[@dxos/devtools]: npx sort-package-json



[@dxos/demos]: npx sort-package-json



[@dxos/config]: npx sort-package-json



[@dxos/client]: npx sort-package-json



[@dxos/signal]: npx sort-package-json



[@dxos/protocol-plugin-replicator]: npx sort-package-json



[@dxos/protocol-plugin-presence]: npx sort-package-json



[@dxos/protocol-plugin-messenger]: npx sort-package-json



[@dxos/protocol-network-generator]: npx sort-package-json



[@dxos/protocol]: npx sort-package-json



[@dxos/network-manager]: npx sort-package-json



[@dxos/network-generator]: npx sort-package-json



[@dxos/network-devtools]: npx sort-package-json

package.json is sorted!


[@dxos/broadcast]: npx sort-package-json



[@dxos/halo-protocol]: npx sort-package-json



[@dxos/credentials]: npx sort-package-json



[@dxos/gravity-core]: npx sort-package-json



[@dxos/browser-tests]: npx sort-package-json



[@dxos/browser-mocha]: npx sort-package-json



[@dxos/text-model]: npx sort-package-json



[@dxos/object-model]: npx sort-package-json



[@dxos/model-factory]: npx sort-package-json



[@dxos/messenger-model]: npx sort-package-json



[@dxos/feed-store]: npx sort-package-json



[@dxos/echo-testing]: npx sort-package-json



[@dxos/echo-protocol]: npx sort-package-json



[@dxos/echo-db]: npx sort-package-json



[@dxos/util]: npx sort-package-json



[@dxos/testutils]: npx sort-package-json



[@dxos/rpc]: npx sort-package-json



[@dxos/random-access-multi-storage]: npx sort-package-json



[@dxos/protobuf-test]: npx sort-package-json



[@dxos/protobuf-compiler]: npx sort-package-json



[@dxos/debug]: npx sort-package-json



[@dxos/crypto]: npx sort-package-json



[@dxos/codec-protobuf]: npx sort-package-json



[@dxos/async]: npx sort-package-json



[@dxos/test-bot]: npx sort-package-json



[@dxos/protocol-plugin-bot]: npx sort-package-json



[@dxos/botkit-client]: npx sort-package-json



[@dxos/botkit]: npx sort-package-json



[@dxos/bot]: npx sort-package-json



[@dxos/sdk-docs]: npx sort-package-json
```

### stderr:

```Shell
npx: installed 213 in 11.131s
npx: installed 44 in 2.165s
npx: installed 44 in 1.698s
npx: installed 44 in 1.575s
npx: installed 44 in 1.508s
npx: installed 44 in 1.511s
npx: installed 44 in 1.594s
npx: installed 44 in 1.557s
npx: installed 44 in 1.617s
npx: installed 44 in 1.537s
npx: installed 44 in 1.557s
npx: installed 44 in 1.558s
npx: installed 44 in 1.675s
npx: installed 44 in 2.106s
npx: installed 44 in 1.658s
npx: installed 44 in 1.564s
npx: installed 44 in 1.589s
npx: installed 44 in 1.587s
npx: installed 44 in 1.596s
npx: installed 44 in 1.546s
npx: installed 44 in 2.122s
npx: installed 44 in 1.599s
npx: installed 44 in 1.6s
npx: installed 44 in 1.692s
npx: installed 44 in 1.685s
npx: installed 44 in 1.639s
npx: installed 44 in 2.04s
npx: installed 44 in 1.58s
npx: installed 44 in 1.539s
npx: installed 44 in 1.557s
npx: installed 44 in 1.641s
npx: installed 44 in 2.023s
npx: installed 44 in 1.502s
npx: installed 44 in 1.497s
npx: installed 44 in 1.535s
npx: installed 44 in 1.574s
npx: installed 44 in 1.682s
npx: installed 44 in 1.527s
npx: installed 44 in 1.573s
npx: installed 44 in 1.555s
npx: installed 44 in 1.589s
npx: installed 44 in 1.538s
npx: installed 44 in 1.579s
npx: installed 44 in 1.568s
npx: installed 44 in 1.515s
npx: installed 44 in 1.524s
npx: installed 44 in 1.522s
npx: installed 44 in 2.471s
npx: installed 44 in 1.625s
npx: installed 44 in 1.5s
npx: installed 44 in 1.728s
npx: installed 44 in 1.478s
npx: installed 44 in 1.511s
npx: installed 44 in 1.51s
```

</details>
<details>
<summary><em>npx @monorepo-utils/workspaces-to-typescript-project-references</em></summary>

```Shell
Update Project References!
```

### stderr:

```Shell
npx: installed 97 in 6.42s
```

</details>

</details>

## Changed files
<details>
<summary>Changed 3 files: </summary>

- packages/halo/halo-protocol/tsconfig.json
- packages/mesh/network-devtools/package.json
- packages/sdk/react-framework/package.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)