### PR TITLE
Automatic: sort package.json and update references in tsconfig.json files

### DIFF
--- a/packages/sdk/registry-api/package.json
+++ b/packages/sdk/registry-api/package.json
@@ -2,45 +2,45 @@
   "name": "@dxos/registry-api",
   "version": "2.14.0",
   "description": "DXNS API",
-  "main": "./dist/src/index.js",
-  "types": "./dist/src/index.d.ts",
   "license": "AGPL-3.0",
   "author": "DXOS.org",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
   "scripts": {
     "build": "toolchain build",
     "build:test": "toolchain build:test",
-    "generate:types": "toolchain generate:defs && yarn generate:meta",
     "generate:defs": "NODE_OPTIONS='-r ts-node/register/transpile-only' node_modules/.bin/polkadot-types-from-defs --package sample-polkadotjs-typegen/interfaces --input ./src/interfaces",
     "generate:meta": "NODE_OPTIONS='-r ts-node/register/transpile-only' node_modules/.bin/polkadot-types-from-chain --package sample-polkadotjs-typegen/interfaces --endpoint ws://127.0.0.1:9944 --output ./src/interfaces",
+    "generate:types": "toolchain generate:defs && yarn generate:meta",
     "lint": "toolchain lint",
     "test": "toolchain test",
     "test:int": "NODE_ENV=test mocha '{src,test,int}/**/*.int-test.ts'",
-    "test:int:registry": "NODE_ENV=test mocha '{src,test,int}/**/registry-api.int-test.ts'",
-    "test:int:auctions": "NODE_ENV=test mocha '{src,test,int}/**/auctions-api.int-test.ts'"
+    "test:int:auctions": "NODE_ENV=test mocha '{src,test,int}/**/auctions-api.int-test.ts'",
+    "test:int:registry": "NODE_ENV=test mocha '{src,test,int}/**/registry-api.int-test.ts'"
   },
   "dependencies": {
     "@dxos/codec-protobuf": "workspace:*",
     "@dxos/util": "workspace:*",
     "@polkadot/api": "4.17.1",
+    "@polkadot/keyring": "6.11.1",
+    "@polkadot/metadata": "4.17.1",
+    "@polkadot/rpc-core": "4.17.1",
+    "@polkadot/types": "4.17.1",
+    "@polkadot/util": "6.11.1",
+    "@polkadot/util-crypto": "6.11.1",
+    "bn.js": "4.12.0",
     "crypto": "^1.0.1",
     "faker": "^5.1.0",
     "fs-extra": "^8.1.0",
     "multihashes": "^4.0.2",
-    "protobufjs": "^6.9.0",
-    "@polkadot/rpc-core": "4.17.1",
-    "@polkadot/types": "4.17.1",
-    "@polkadot/util": "6.11.1",
-    "@polkadot/keyring": "6.11.1",
-    "@polkadot/util-crypto": "6.11.1",
-    "@polkadot/metadata": "4.17.1",
-    "bn.js": "4.12.0"
+    "protobufjs": "^6.9.0"
   },
   "devDependencies": {
     "@dxos/toolchain-node-library": "workspace:*",
-    "@types/faker": "~5.5.1",
     "@polkadot/typegen": "^4.17.1",
     "@types/chai": "^4.2.15",
     "@types/chai-as-promised": "^7.1.3",
+    "@types/faker": "~5.5.1",
     "@types/fs-extra": "^9.0.4",
     "@types/mocha": "~8.2.2",
     "@types/node": "^14.0.9",
@@ -50,13 +50,13 @@
     "ts-node": "^9.1.1",
     "typescript": "^4.3.5"
   },
-  "toolchain": {
-    "testingFramework": "mocha"
-  },
   "engines": {
     "node": ">= 14"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "toolchain": {
+    "testingFramework": "mocha"
   }
 }

--- a/packages/sdk/registry-api/tsconfig.json
+++ b/packages/sdk/registry-api/tsconfig.json
@@ -5,9 +5,15 @@
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": false,
     "paths": {
-      "sample-polkadotjs-typegen/*": ["./src/*"],
-      "@polkadot/api/augment": ["./src/interfaces/augment-api.ts"],
-      "@polkadot/types/augment": ["./src/interfaces/augment-types.ts"]
+      "sample-polkadotjs-typegen/*": [
+        "./src/*"
+      ],
+      "@polkadot/api/augment": [
+        "./src/interfaces/augment-api.ts"
+      ],
+      "@polkadot/types/augment": [
+        "./src/interfaces/augment-types.ts"
+      ]
     }
   },
   "include": [
@@ -16,5 +22,13 @@
   ],
   "exclude": [
     "dist"
+  ],
+  "references": [
+    {
+      "path": "../../common/codec-protobuf"
+    },
+    {
+      "path": "../../common/util"
+    }
   ]
 }


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>npx @sfomin/for-each-package -n "@dxos/*" "npx sort-package-json"</em></summary>

```Shell
[@dxos/toolchain-node-library]: npx sort-package-json



[@dxos/esbuild-plugins]: npx sort-package-json



[@dxos/deps-checker]: npx sort-package-json



[@dxos/wallet-playground]: npx sort-package-json



[@dxos/wallet-extension]: npx sort-package-json



[@dxos/wallet-core]: npx sort-package-json



[@dxos/tutorials-tasks-app]: npx sort-package-json



[@dxos/registry-api]: npx sort-package-json

package.json is sorted!


[@dxos/react-framework]: npx sort-package-json



[@dxos/react-client]: npx sort-package-json



[@dxos/devtools-extension]: npx sort-package-json



[@dxos/devtools]: npx sort-package-json



[@dxos/demos]: npx sort-package-json



[@dxos/config]: npx sort-package-json



[@dxos/client]: npx sort-package-json



[@dxos/signal]: npx sort-package-json



[@dxos/protocol-plugin-replicator]: npx sort-package-json



[@dxos/protocol-plugin-presence]: npx sort-package-json



[@dxos/protocol-plugin-messenger]: npx sort-package-json



[@dxos/protocol-network-generator]: npx sort-package-json



[@dxos/protocol]: npx sort-package-json



[@dxos/network-manager]: npx sort-package-json



[@dxos/network-generator]: npx sort-package-json



[@dxos/network-devtools]: npx sort-package-json



[@dxos/broadcast]: npx sort-package-json



[@dxos/halo-protocol]: npx sort-package-json



[@dxos/credentials]: npx sort-package-json



[@dxos/gravity-core]: npx sort-package-json



[@dxos/browser-tests]: npx sort-package-json



[@dxos/browser-mocha]: npx sort-package-json



[@dxos/text-model]: npx sort-package-json



[@dxos/object-model]: npx sort-package-json



[@dxos/model-factory]: npx sort-package-json



[@dxos/messenger-model]: npx sort-package-json



[@dxos/feed-store]: npx sort-package-json



[@dxos/echo-testing]: npx sort-package-json



[@dxos/echo-protocol]: npx sort-package-json



[@dxos/echo-db]: npx sort-package-json



[@dxos/util]: npx sort-package-json



[@dxos/testutils]: npx sort-package-json



[@dxos/rpc]: npx sort-package-json



[@dxos/random-access-multi-storage]: npx sort-package-json



[@dxos/protobuf-test]: npx sort-package-json



[@dxos/protobuf-compiler]: npx sort-package-json



[@dxos/debug]: npx sort-package-json



[@dxos/crypto]: npx sort-package-json



[@dxos/codec-protobuf]: npx sort-package-json



[@dxos/async]: npx sort-package-json



[@dxos/test-bot]: npx sort-package-json



[@dxos/protocol-plugin-bot]: npx sort-package-json



[@dxos/botkit-client]: npx sort-package-json



[@dxos/botkit]: npx sort-package-json



[@dxos/bot]: npx sort-package-json



[@dxos/sdk-docs]: npx sort-package-json
```

### stderr:

```Shell
npx: installed 213 in 5.655s
npx: installed 44 in 1.891s
npx: installed 44 in 1.822s
npx: installed 44 in 2.253s
npx: installed 44 in 1.744s
npx: installed 44 in 1.912s
npx: installed 44 in 1.743s
npx: installed 44 in 1.801s
npx: installed 44 in 1.741s
npx: installed 44 in 1.87s
npx: installed 44 in 1.791s
npx: installed 44 in 1.745s
npx: installed 44 in 1.711s
npx: installed 44 in 1.853s
npx: installed 44 in 1.747s
npx: installed 44 in 1.808s
npx: installed 44 in 1.738s
npx: installed 44 in 1.734s
npx: installed 44 in 1.832s
npx: installed 44 in 1.78s
npx: installed 44 in 1.883s
npx: installed 44 in 1.901s
npx: installed 44 in 2.385s
npx: installed 44 in 1.815s
npx: installed 44 in 1.706s
npx: installed 44 in 1.718s
npx: installed 44 in 1.869s
npx: installed 44 in 1.826s
npx: installed 44 in 1.766s
npx: installed 44 in 1.78s
npx: installed 44 in 1.885s
npx: installed 44 in 1.838s
npx: installed 44 in 1.895s
npx: installed 44 in 1.746s
npx: installed 44 in 1.906s
npx: installed 44 in 1.831s
npx: installed 44 in 1.769s
npx: installed 44 in 1.764s
npx: installed 44 in 1.736s
npx: installed 44 in 1.896s
npx: installed 44 in 1.815s
npx: installed 44 in 1.774s
npx: installed 44 in 1.814s
npx: installed 44 in 1.76s
npx: installed 44 in 1.768s
npx: installed 44 in 1.772s
npx: installed 44 in 1.745s
npx: installed 44 in 2.234s
npx: installed 44 in 1.748s
npx: installed 44 in 1.808s
npx: installed 44 in 1.875s
npx: installed 44 in 1.746s
npx: installed 44 in 1.917s
npx: installed 44 in 2.233s
npx: installed 44 in 1.739s
```

</details>
<details>
<summary><em>npx @monorepo-utils/workspaces-to-typescript-project-references</em></summary>

```Shell
Update Project References!
```

### stderr:

```Shell
npx: installed 97 in 3.296s
```

</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- packages/sdk/registry-api/package.json
- packages/sdk/registry-api/tsconfig.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)