### PR TITLE
Automatic: sort package.json and update references in tsconfig.json files

### DIFF
--- a/packages/sdk/client/package.json
+++ b/packages/sdk/client/package.json
@@ -38,18 +38,18 @@
   "devDependencies": {
     "@dxos/random-access-multi-storage": "workspace:*",
     "@dxos/toolchain-node-library": "workspace:*",
+    "@types/expect": "~24.3.0",
     "@types/jest": "^26.0.7",
     "@types/level-js": "~4.0.1",
     "@types/memdown": "^3.0.0",
-    "mocha": "~8.4.0",
     "@types/mocha": "~8.2.2",
     "expect": "~27.0.2",
-    "@types/expect": "~24.3.0"
+    "mocha": "~8.4.0"
   },
   "publishConfig": {
     "access": "public"
   },
-  "toolchain" : {
+  "toolchain": {
     "testingFramework": "mocha",
     "forceCloseTests": true
   }

--- a/packages/sdk/react-registry-client/package.json
+++ b/packages/sdk/react-registry-client/package.json
@@ -14,15 +14,15 @@
     "test": "toolchain test"
   },
   "dependencies": {
+    "@dxos/registry-client": "workspace:*",
     "@dxos/util": "workspace:*",
     "assert": "^2.0.0",
-    "debug": "^4.1.1",
-    "@dxos/registry-client": "workspace:*"
+    "debug": "^4.1.1"
   },
   "devDependencies": {
     "@dxos/client": "workspace:*",
-    "@types/debug": "^4.1.1",
     "@dxos/toolchain-node-library": "workspace:*",
+    "@types/debug": "^4.1.1",
     "@types/node": "^14.0.9",
     "@types/react": "^17.0.24",
     "react": "^17.0.2",

--- a/packages/sdk/react-registry-client/tsconfig.json
+++ b/packages/sdk/react-registry-client/tsconfig.json
@@ -6,9 +6,20 @@
     "lib": [
       "DOM",
       "ESNext"
-    ],
+    ]
   },
   "include": [
     "src"
   ],
+  "references": [
+    {
+      "path": "../registry-client"
+    },
+    {
+      "path": "../../common/util"
+    },
+    {
+      "path": "../client"
+    }
+  ]
 }


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>npx @sfomin/for-each-package -n "@dxos/*" "npx sort-package-json"</em></summary>

```Shell
[@dxos/toolchain-node-library]: npx sort-package-json



[@dxos/esbuild-plugins]: npx sort-package-json



[@dxos/deps-checker]: npx sort-package-json



[@dxos/wallet-playground]: npx sort-package-json



[@dxos/wallet-extension]: npx sort-package-json



[@dxos/wallet-core]: npx sort-package-json



[@dxos/tutorials-tasks-app]: npx sort-package-json



[@dxos/registry-client]: npx sort-package-json



[@dxos/react-registry-client]: npx sort-package-json

package.json is sorted!


[@dxos/react-framework]: npx sort-package-json



[@dxos/react-client]: npx sort-package-json



[@dxos/devtools-extension]: npx sort-package-json



[@dxos/devtools]: npx sort-package-json



[@dxos/demos]: npx sort-package-json



[@dxos/config]: npx sort-package-json



[@dxos/client]: npx sort-package-json

package.json is sorted!


[@dxos/signal]: npx sort-package-json



[@dxos/protocol-plugin-replicator]: npx sort-package-json



[@dxos/protocol-plugin-presence]: npx sort-package-json



[@dxos/protocol-plugin-messenger]: npx sort-package-json



[@dxos/protocol-network-generator]: npx sort-package-json



[@dxos/protocol]: npx sort-package-json



[@dxos/network-manager]: npx sort-package-json



[@dxos/network-generator]: npx sort-package-json



[@dxos/network-devtools]: npx sort-package-json



[@dxos/broadcast]: npx sort-package-json



[@dxos/halo-protocol]: npx sort-package-json



[@dxos/credentials]: npx sort-package-json



[@dxos/gravity-core]: npx sort-package-json



[@dxos/browser-tests]: npx sort-package-json



[@dxos/browser-mocha]: npx sort-package-json



[@dxos/text-model]: npx sort-package-json



[@dxos/object-model]: npx sort-package-json



[@dxos/model-factory]: npx sort-package-json



[@dxos/messenger-model]: npx sort-package-json



[@dxos/feed-store]: npx sort-package-json



[@dxos/echo-testing]: npx sort-package-json



[@dxos/echo-protocol]: npx sort-package-json



[@dxos/echo-db]: npx sort-package-json



[@dxos/util]: npx sort-package-json



[@dxos/testutils]: npx sort-package-json



[@dxos/rpc]: npx sort-package-json



[@dxos/random-access-multi-storage]: npx sort-package-json



[@dxos/protobuf-test]: npx sort-package-json



[@dxos/protobuf-compiler]: npx sort-package-json



[@dxos/debug]: npx sort-package-json



[@dxos/crypto]: npx sort-package-json



[@dxos/codec-protobuf]: npx sort-package-json



[@dxos/async]: npx sort-package-json



[@dxos/test-bot]: npx sort-package-json



[@dxos/protocol-plugin-bot]: npx sort-package-json



[@dxos/botkit-client]: npx sort-package-json



[@dxos/botkit]: npx sort-package-json



[@dxos/bot]: npx sort-package-json



[@dxos/sdk-docs]: npx sort-package-json
```

### stderr:

```Shell
npx: installed 213 in 4.482s
npx: installed 44 in 1.452s
npx: installed 44 in 1.386s
npx: installed 44 in 1.473s
npx: installed 44 in 1.413s
npx: installed 44 in 1.427s
npx: installed 44 in 1.394s
npx: installed 44 in 1.374s
npx: installed 44 in 1.496s
npx: installed 44 in 1.435s
npx: installed 44 in 1.392s
npx: installed 44 in 1.429s
npx: installed 44 in 1.458s
npx: installed 44 in 1.455s
npx: installed 44 in 1.942s
npx: installed 44 in 1.538s
npx: installed 44 in 1.454s
npx: installed 44 in 1.446s
npx: installed 44 in 1.466s
npx: installed 44 in 1.424s
npx: installed 44 in 1.442s
npx: installed 44 in 1.546s
npx: installed 44 in 1.479s
npx: installed 44 in 1.42s
npx: installed 44 in 1.818s
npx: installed 44 in 1.431s
npx: installed 44 in 1.558s
npx: installed 44 in 1.434s
npx: installed 44 in 1.456s
npx: installed 44 in 1.464s
npx: installed 44 in 1.445s
npx: installed 44 in 1.915s
npx: installed 44 in 1.487s
npx: installed 44 in 1.464s
npx: installed 44 in 1.513s
npx: installed 44 in 1.537s
npx: installed 44 in 1.5s
npx: installed 44 in 1.491s
npx: installed 44 in 1.468s
npx: installed 44 in 1.481s
npx: installed 44 in 1.386s
npx: installed 44 in 1.482s
npx: installed 44 in 1.597s
npx: installed 44 in 1.396s
npx: installed 44 in 1.414s
npx: installed 44 in 1.445s
npx: installed 44 in 1.419s
npx: installed 44 in 1.518s
npx: installed 44 in 1.463s
npx: installed 44 in 1.508s
npx: installed 44 in 1.919s
npx: installed 44 in 1.463s
npx: installed 44 in 1.388s
npx: installed 44 in 1.459s
npx: installed 44 in 1.483s
npx: installed 44 in 1.59s
```

</details>
<details>
<summary><em>npx @monorepo-utils/workspaces-to-typescript-project-references</em></summary>

```Shell
Update Project References!
```

### stderr:

```Shell
npx: installed 97 in 2.579s
```

</details>

</details>

## Changed files
<details>
<summary>Changed 3 files: </summary>

- packages/sdk/client/package.json
- packages/sdk/react-registry-client/package.json
- packages/sdk/react-registry-client/tsconfig.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)