### PR TITLE
Automatic: sort package.json and update references in tsconfig.json files

### DIFF
--- a/packages/gravity/gravity-core/package.json
+++ b/packages/gravity/gravity-core/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "@dxos/async": "workspace:*",
     "@dxos/bot-deprecated": "workspace:*",
-    "@dxos/botkit-deprecated": "workspace:*",
     "@dxos/botkit-client-deprecated": "workspace:*",
+    "@dxos/botkit-deprecated": "workspace:*",
     "@dxos/client": "workspace:*",
     "@dxos/config": "workspace:*",
     "@dxos/credentials": "workspace:*",

--- a/packages/gravity/gravity-core/tsconfig.json
+++ b/packages/gravity/gravity-core/tsconfig.json
@@ -24,10 +24,10 @@
       "path": "../../bot-deprecated/bot-deprecated"
     },
     {
-      "path": "../../bot-deprecated/botkit-deprecated"
+      "path": "../../bot-deprecated/botkit-client-deprecated"
     },
     {
-      "path": "../../bot-deprecated/botkit-client-deprecated"
+      "path": "../../bot-deprecated/botkit-deprecated"
     },
     {
       "path": "../../sdk/client"

--- a/packages/halo/credentials/package.json
+++ b/packages/halo/credentials/package.json
@@ -28,6 +28,7 @@
     "@dxos/crypto": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/feed-store": "workspace:*",
+    "@dxos/proto": "workspace:*",
     "@dxos/protocol": "workspace:*",
     "@dxos/util": "workspace:*",
     "@types/debug": "^4.1.1",
@@ -46,8 +47,7 @@
     "moment": "^2.24.0",
     "performance-now": "^2.1.0",
     "pump": "^3.0.0",
-    "stream-to-array": "^2.3.0",
-    "@dxos/proto": "workspace:*"
+    "stream-to-array": "^2.3.0"
   },
   "devDependencies": {
     "@dxos/protocol-plugin-replicator": "workspace:*",

--- a/packages/halo/credentials/tsconfig.json
+++ b/packages/halo/credentials/tsconfig.json
@@ -27,6 +27,9 @@
       "path": "../../echo/feed-store"
     },
     {
+      "path": "../../common/proto"
+    },
+    {
       "path": "../../mesh/protocol"
     },
     {

--- a/packages/sdk/client/package.json
+++ b/packages/sdk/client/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@dxos/async": "workspace:*",
+    "@dxos/codec-protobuf": "workspace:*",
     "@dxos/config": "workspace:*",
     "@dxos/credentials": "workspace:*",
     "@dxos/crypto": "workspace:*",
@@ -27,6 +28,8 @@
     "@dxos/model-factory": "workspace:*",
     "@dxos/network-manager": "workspace:*",
     "@dxos/object-model": "workspace:*",
+    "@dxos/proto": "workspace:*",
+    "@dxos/rpc": "workspace:*",
     "@wirelineio/registry-client": "~1.1.0-beta.3",
     "abstract-leveldown": "~7.0.0",
     "assert": "^2.0.0",
@@ -35,10 +38,7 @@
     "jsondown": "dxos/jsondown#main",
     "level-js": "^5.0.2",
     "lodash.defaultsdeep": "^4.6.1",
-    "memdown": "^5.1.0",
-    "@dxos/proto": "workspace:*",
-    "@dxos/rpc": "workspace:*",
-    "@dxos/codec-protobuf": "workspace:*"
+    "memdown": "^5.1.0"
   },
   "devDependencies": {
     "@dxos/random-access-multi-storage": "workspace:*",

--- a/packages/sdk/client/tsconfig.json
+++ b/packages/sdk/client/tsconfig.json
@@ -17,6 +17,9 @@
       "path": "../../common/async"
     },
     {
+      "path": "../../common/codec-protobuf"
+    },
+    {
       "path": "../config"
     },
     {
@@ -45,6 +48,12 @@
     },
     {
       "path": "../../echo/object-model"
+    },
+    {
+      "path": "../../common/proto"
+    },
+    {
+      "path": "../../common/rpc"
     },
     {
       "path": "../../common/random-access-multi-storage"

--- a/packages/sdk/devtools/package.json
+++ b/packages/sdk/devtools/package.json
@@ -21,6 +21,7 @@
     "@dxos/crypto": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/network-devtools": "workspace:*",
+    "@dxos/proto": "workspace:*",
     "@dxos/react-components": "workspace:*",
     "@dxos/react-framework": "workspace:*",
     "@dxos/rpc": "workspace:*",
@@ -36,8 +37,7 @@
     "moment": "^2.24.0",
     "react": "^17.0.2",
     "react-copy-to-clipboard": "~5.0.3",
-    "react-dom": "^17.0.2",
-    "@dxos/proto": "workspace:*"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@babel/core": "~7.13.15",

--- a/packages/sdk/devtools/tsconfig.json
+++ b/packages/sdk/devtools/tsconfig.json
@@ -27,6 +27,9 @@
       "path": "../../mesh/network-devtools"
     },
     {
+      "path": "../../common/proto"
+    },
+    {
       "path": "../react-components"
     },
     {


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>npx @sfomin/for-each-package -n "@dxos/*" "npx sort-package-json"</em></summary>

```Shell
[@dxos/toolchain-node-library]: npx sort-package-json



[@dxos/esbuild-plugins]: npx sort-package-json



[@dxos/deps-checker]: npx sort-package-json



[@dxos/wallet-playground]: npx sort-package-json



[@dxos/wallet-extension]: npx sort-package-json



[@dxos/wallet-core]: npx sort-package-json



[@dxos/tutorials-tasks-app]: npx sort-package-json



[@dxos/registry-client]: npx sort-package-json



[@dxos/react-registry-client]: npx sort-package-json



[@dxos/react-framework]: npx sort-package-json



[@dxos/react-components]: npx sort-package-json



[@dxos/react-client]: npx sort-package-json



[@dxos/devtools-extension]: npx sort-package-json



[@dxos/devtools]: npx sort-package-json

package.json is sorted!


[@dxos/demos]: npx sort-package-json



[@dxos/config]: npx sort-package-json



[@dxos/client]: npx sort-package-json

package.json is sorted!


[@dxos/signal]: npx sort-package-json



[@dxos/protocol-plugin-replicator]: npx sort-package-json



[@dxos/protocol-plugin-presence]: npx sort-package-json



[@dxos/protocol-plugin-messenger]: npx sort-package-json



[@dxos/protocol-network-generator]: npx sort-package-json



[@dxos/protocol]: npx sort-package-json



[@dxos/network-manager]: npx sort-package-json



[@dxos/network-generator]: npx sort-package-json



[@dxos/network-devtools]: npx sort-package-json



[@dxos/broadcast]: npx sort-package-json



[@dxos/halo-protocol]: npx sort-package-json



[@dxos/credentials]: npx sort-package-json

package.json is sorted!


[@dxos/gravity-core]: npx sort-package-json

package.json is sorted!


[@dxos/browser-tests]: npx sort-package-json



[@dxos/browser-mocha]: npx sort-package-json



[@dxos/text-model]: npx sort-package-json



[@dxos/object-model]: npx sort-package-json



[@dxos/model-factory]: npx sort-package-json



[@dxos/messenger-model]: npx sort-package-json



[@dxos/feed-store]: npx sort-package-json



[@dxos/echo-testing]: npx sort-package-json



[@dxos/echo-protocol]: npx sort-package-json



[@dxos/echo-db]: npx sort-package-json



[@dxos/util]: npx sort-package-json



[@dxos/testutils]: npx sort-package-json



[@dxos/rpc]: npx sort-package-json



[@dxos/random-access-multi-storage]: npx sort-package-json



[@dxos/protobuf-test]: npx sort-package-json



[@dxos/protobuf-compiler]: npx sort-package-json



[@dxos/proto]: npx sort-package-json



[@dxos/debug]: npx sort-package-json



[@dxos/crypto]: npx sort-package-json



[@dxos/codec-protobuf]: npx sort-package-json



[@dxos/async]: npx sort-package-json



[@dxos/test-bot-deprecated]: npx sort-package-json



[@dxos/protocol-plugin-bot-deprecated]: npx sort-package-json



[@dxos/botkit-deprecated]: npx sort-package-json



[@dxos/botkit-client-deprecated]: npx sort-package-json



[@dxos/bot-deprecated]: npx sort-package-json



[@dxos/sdk-docs]: npx sort-package-json
```

### stderr:

```Shell
npx: installed 213 in 13.425s
npx: installed 44 in 2.978s
npx: installed 44 in 1.459s
npx: installed 44 in 1.524s
npx: installed 44 in 1.539s
npx: installed 44 in 1.546s
npx: installed 44 in 1.551s
npx: installed 44 in 1.501s
npx: installed 44 in 1.48s
npx: installed 44 in 1.515s
npx: installed 44 in 1.496s
npx: installed 44 in 1.497s
npx: installed 44 in 1.484s
npx: installed 44 in 1.585s
npx: installed 44 in 1.541s
npx: installed 44 in 1.479s
npx: installed 44 in 1.5s
npx: installed 44 in 1.551s
npx: installed 44 in 1.474s
npx: installed 44 in 1.511s
npx: installed 44 in 1.461s
npx: installed 44 in 1.459s
npx: installed 44 in 1.527s
npx: installed 44 in 1.465s
npx: installed 44 in 1.495s
npx: installed 44 in 1.482s
npx: installed 44 in 1.509s
npx: installed 44 in 1.467s
npx: installed 44 in 1.604s
npx: installed 44 in 1.478s
npx: installed 44 in 1.479s
npx: installed 44 in 1.471s
npx: installed 44 in 1.555s
npx: installed 44 in 1.478s
npx: installed 44 in 1.659s
npx: installed 44 in 1.574s
npx: installed 44 in 1.54s
npx: installed 44 in 1.576s
npx: installed 44 in 1.47s
npx: installed 44 in 1.582s
npx: installed 44 in 1.632s
npx: installed 44 in 1.534s
npx: installed 44 in 1.541s
npx: installed 44 in 1.486s
npx: installed 44 in 1.513s
npx: installed 44 in 1.505s
npx: installed 44 in 1.504s
npx: installed 44 in 1.549s
npx: installed 44 in 1.504s
npx: installed 44 in 1.446s
npx: installed 44 in 1.474s
npx: installed 44 in 1.482s
npx: installed 44 in 2.005s
npx: installed 44 in 2.037s
npx: installed 44 in 1.519s
npx: installed 44 in 1.521s
npx: installed 44 in 1.581s
npx: installed 44 in 1.504s
```

</details>
<details>
<summary><em>npx @monorepo-utils/workspaces-to-typescript-project-references</em></summary>

```Shell
Update Project References!
```

### stderr:

```Shell
npx: installed 97 in 6.699s
```

</details>

</details>

## Changed files
<details>
<summary>Changed 8 files: </summary>

- packages/gravity/gravity-core/package.json
- packages/gravity/gravity-core/tsconfig.json
- packages/halo/credentials/package.json
- packages/halo/credentials/tsconfig.json
- packages/sdk/client/package.json
- packages/sdk/client/tsconfig.json
- packages/sdk/devtools/package.json
- packages/sdk/devtools/tsconfig.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)