### PR TITLE
Automatic: sort package.json and update references in tsconfig.json files

### DIFF
--- a/packages/sdk/config/package.json
+++ b/packages/sdk/config/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@dxos/codec-protobuf": "workspace:*",
     "@dxos/debug": "workspace:*",
+    "@dxos/proto": "workspace:*",
     "boolean": "^3.0.1",
     "debug": "^4.1.1",
     "js-yaml": "^3.13.1",
@@ -28,8 +29,7 @@
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
     "node-fetch": "^2.6.0",
-    "protobufjs": "^6.9.0",
-    "@dxos/proto": "workspace:*"
+    "protobufjs": "^6.9.0"
   },
   "devDependencies": {
     "@dxos/toolchain-node-library": "workspace:*",

--- a/packages/sdk/config/tsconfig.json
+++ b/packages/sdk/config/tsconfig.json
@@ -17,6 +17,9 @@
     },
     {
       "path": "../../common/debug"
+    },
+    {
+      "path": "../../common/proto"
     }
   ]
 }


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>npx @sfomin/for-each-package -n "@dxos/*" "npx sort-package-json"</em></summary>

```Shell
[@dxos/toolchain-node-library]: npx sort-package-json



[@dxos/esbuild-plugins]: npx sort-package-json



[@dxos/deps-checker]: npx sort-package-json



[@dxos/wallet-playground]: npx sort-package-json



[@dxos/wallet-extension]: npx sort-package-json



[@dxos/tutorials-tasks-app]: npx sort-package-json



[@dxos/registry-client]: npx sort-package-json



[@dxos/react-registry-client]: npx sort-package-json



[@dxos/react-framework]: npx sort-package-json



[@dxos/react-components]: npx sort-package-json



[@dxos/react-client]: npx sort-package-json



[@dxos/devtools-extension]: npx sort-package-json



[@dxos/devtools]: npx sort-package-json



[@dxos/demos]: npx sort-package-json



[@dxos/config]: npx sort-package-json

package.json is sorted!


[@dxos/client]: npx sort-package-json



[@dxos/signal]: npx sort-package-json



[@dxos/protocol-plugin-replicator]: npx sort-package-json



[@dxos/protocol-plugin-presence]: npx sort-package-json



[@dxos/protocol-plugin-messenger]: npx sort-package-json



[@dxos/protocol-network-generator]: npx sort-package-json



[@dxos/protocol]: npx sort-package-json



[@dxos/network-manager]: npx sort-package-json



[@dxos/network-generator]: npx sort-package-json



[@dxos/network-devtools]: npx sort-package-json



[@dxos/broadcast]: npx sort-package-json



[@dxos/halo-protocol]: npx sort-package-json



[@dxos/credentials]: npx sort-package-json



[@dxos/gravity-core]: npx sort-package-json



[@dxos/browser-tests]: npx sort-package-json



[@dxos/browser-mocha]: npx sort-package-json



[@dxos/text-model]: npx sort-package-json



[@dxos/object-model]: npx sort-package-json



[@dxos/model-factory]: npx sort-package-json



[@dxos/messenger-model]: npx sort-package-json



[@dxos/feed-store]: npx sort-package-json



[@dxos/echo-testing]: npx sort-package-json



[@dxos/echo-protocol]: npx sort-package-json



[@dxos/echo-db]: npx sort-package-json



[@dxos/test-bot-deprecated]: npx sort-package-json



[@dxos/protocol-plugin-bot-deprecated]: npx sort-package-json



[@dxos/botkit-deprecated]: npx sort-package-json



[@dxos/botkit-client-deprecated]: npx sort-package-json



[@dxos/bot-deprecated]: npx sort-package-json



[@dxos/util]: npx sort-package-json



[@dxos/testutils]: npx sort-package-json



[@dxos/rpc]: npx sort-package-json



[@dxos/random-access-multi-storage]: npx sort-package-json



[@dxos/protobuf-test]: npx sort-package-json



[@dxos/protobuf-compiler]: npx sort-package-json



[@dxos/proto]: npx sort-package-json



[@dxos/debug]: npx sort-package-json



[@dxos/crypto]: npx sort-package-json



[@dxos/codec-protobuf]: npx sort-package-json



[@dxos/async]: npx sort-package-json



[@dxos/botkit]: npx sort-package-json



[@dxos/sdk-docs]: npx sort-package-json
```

### stderr:

```Shell
npx: installed 213 in 10.605s
npx: installed 44 in 1.811s
npx: installed 44 in 1.216s
npx: installed 44 in 1.321s
npx: installed 44 in 1.278s
npx: installed 44 in 1.194s
npx: installed 44 in 1.217s
npx: installed 44 in 1.188s
npx: installed 44 in 1.276s
npx: installed 44 in 1.212s
npx: installed 44 in 1.332s
npx: installed 44 in 1.186s
npx: installed 44 in 1.205s
npx: installed 44 in 1.21s
npx: installed 44 in 1.217s
npx: installed 44 in 1.204s
npx: installed 44 in 1.196s
npx: installed 44 in 1.201s
npx: installed 44 in 1.21s
npx: installed 44 in 1.266s
npx: installed 44 in 1.114s
npx: installed 44 in 1.116s
npx: installed 44 in 1.235s
npx: installed 44 in 1.131s
npx: installed 44 in 1.211s
npx: installed 44 in 1.22s
npx: installed 44 in 1.205s
npx: installed 44 in 1.202s
npx: installed 44 in 1.197s
npx: installed 44 in 1.189s
npx: installed 44 in 1.205s
npx: installed 44 in 1.203s
npx: installed 44 in 1.228s
npx: installed 44 in 1.197s
npx: installed 44 in 1.199s
npx: installed 44 in 1.208s
npx: installed 44 in 1.206s
npx: installed 44 in 1.238s
npx: installed 44 in 1.329s
npx: installed 44 in 1.205s
npx: installed 44 in 1.198s
npx: installed 44 in 1.18s
npx: installed 44 in 1.262s
npx: installed 44 in 1.763s
npx: installed 44 in 1.199s
npx: installed 44 in 1.209s
npx: installed 44 in 1.283s
npx: installed 44 in 1.213s
npx: installed 44 in 1.191s
npx: installed 44 in 1.199s
npx: installed 44 in 1.213s
npx: installed 44 in 1.119s
npx: installed 44 in 1.215s
npx: installed 44 in 1.228s
npx: installed 44 in 1.23s
npx: installed 44 in 1.225s
npx: installed 44 in 1.197s
npx: installed 44 in 1.326s
```

</details>
<details>
<summary><em>npx @monorepo-utils/workspaces-to-typescript-project-references</em></summary>

```Shell
Update Project References!
```

### stderr:

```Shell
npx: installed 97 in 6.194s
```

</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- packages/sdk/config/package.json
- packages/sdk/config/tsconfig.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)