### PR TITLE
chore: Upgrade DXOS dependencies

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -329,7 +329,7 @@ importers:
       '@dxos/echo-protocol': workspace:*
       '@dxos/echo-testing': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.1
+      '@dxos/esbuild-server': ~1.7.2
       '@dxos/gem-core': ~1.0.0-beta.25
       '@dxos/gem-spore': ~1.0.0-beta.25
       '@dxos/object-model': workspace:*
@@ -413,7 +413,7 @@ importers:
       '@dxos/async': link:../common/async
       '@dxos/debug': link:../common/debug
       '@dxos/esbuild-plugins': link:../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.1_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
       '@dxos/toolchain-node-library': link:../../toolchains/toolchain-node-library
       '@types/d3': 7.0.0
       '@types/faker': 5.5.9
@@ -628,7 +628,7 @@ importers:
       '@dxos/echo-db': workspace:*
       '@dxos/echo-protocol': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.1
+      '@dxos/esbuild-server': ~1.7.2
       '@dxos/messenger-model': workspace:*
       '@dxos/model-factory': workspace:*
       '@dxos/network-manager': workspace:*
@@ -690,7 +690,7 @@ importers:
       '@babel/core': 7.13.16
       '@dxos/echo-db': link:../../echo/echo-db
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.1_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
       '@dxos/messenger-model': link:../../echo/messenger-model
       '@dxos/network-manager': link:../../mesh/network-manager
       '@dxos/object-model': link:../../echo/object-model
@@ -803,7 +803,7 @@ importers:
       '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.1
+      '@dxos/esbuild-server': ~1.7.2
       '@dxos/gem-core': ~1.0.0-beta.25
       '@dxos/gem-spore': ~1.0.0-beta.25
       '@dxos/network-manager': workspace:*
@@ -853,7 +853,7 @@ importers:
       '@babel/core': 7.13.16
       '@babel/plugin-transform-runtime': 7.16.4_@babel+core@7.13.16
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.1_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@types/react': 17.0.37
       '@types/react-copy-to-clipboard': 5.0.2
@@ -1997,7 +1997,7 @@ importers:
       '@dxos/debug': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.1
+      '@dxos/esbuild-server': ~1.7.2
       '@dxos/toolchain-node-library': workspace:*
       '@dxos/util': workspace:*
       '@mui/material': ^5.0.1
@@ -2039,7 +2039,7 @@ importers:
       use-subscription: 1.5.1_react@17.0.2
     devDependencies:
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.1_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@mui/material': 5.2.3_5539cae010396b202b015f3568914e95
       '@testing-library/react': 11.2.7_react-dom@17.0.2+react@17.0.2
@@ -2070,7 +2070,7 @@ importers:
       '@dxos/debug': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.1
+      '@dxos/esbuild-server': ~1.7.2
       '@dxos/react-client': workspace:*
       '@dxos/toolchain-node-library': workspace:*
       '@emotion/react': ^11.4.1
@@ -2117,7 +2117,7 @@ importers:
       '@dxos/client': link:../client
       '@dxos/echo-db': link:../../echo/echo-db
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.1_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
       '@dxos/react-client': link:../react-client
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@emotion/react': 11.7.1_c8f47004f4d29cd7909f1411b83f7eb5
@@ -2153,7 +2153,7 @@ importers:
       '@dxos/debug': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.1
+      '@dxos/esbuild-server': ~1.7.2
       '@dxos/object-model': workspace:*
       '@dxos/react-client': workspace:*
       '@dxos/react-components': workspace:*
@@ -2207,7 +2207,7 @@ importers:
       '@dxos/credentials': link:../../halo/credentials
       '@dxos/echo-db': link:../../echo/echo-db
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.1_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
       '@dxos/object-model': link:../../echo/object-model
       '@dxos/react-client': link:../react-client
       '@dxos/react-components': link:../react-components
@@ -2237,7 +2237,7 @@ importers:
       '@dxos/codec-protobuf': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.1
+      '@dxos/esbuild-server': ~1.7.2
       '@dxos/registry-client': workspace:*
       '@dxos/toolchain-node-library': workspace:*
       '@dxos/util': workspace:*
@@ -2262,7 +2262,7 @@ importers:
       '@babel/core': 7.13.16
       '@dxos/codec-protobuf': link:../../common/codec-protobuf
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.1_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@types/debug': 4.1.7
       '@types/lodash': 4.14.178
@@ -2280,7 +2280,7 @@ importers:
       '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.1
+      '@dxos/esbuild-server': ~1.7.2
       '@dxos/toolchain-node-library': workspace:*
       '@dxos/util': workspace:*
       '@polkadot/api': 4.17.1
@@ -2326,7 +2326,7 @@ importers:
       protobufjs: 6.11.2
     devDependencies:
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.1
+      '@dxos/esbuild-server': 1.7.2
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@polkadot/typegen': 4.17.1
       '@types/chai': 4.3.0
@@ -2349,7 +2349,7 @@ importers:
       '@dxos/crypto': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.1
+      '@dxos/esbuild-server': ~1.7.2
       '@dxos/object-model': workspace:*
       '@dxos/react-client': workspace:*
       '@dxos/react-components': workspace:*
@@ -2398,7 +2398,7 @@ importers:
     devDependencies:
       '@babel/core': 7.13.16
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.1_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
       '@types/mocha': 8.2.3
       '@types/node': 14.18.0
       '@types/react': 17.0.37
@@ -2501,7 +2501,7 @@ importers:
       '@dxos/config': workspace:*
       '@dxos/crypto': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.1
+      '@dxos/esbuild-server': ~1.7.2
       '@dxos/react-client': workspace:*
       '@dxos/react-components': workspace:*
       '@dxos/react-framework': workspace:*
@@ -2526,7 +2526,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.1_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
@@ -5126,8 +5126,8 @@ packages:
       - webpack-command
     dev: true
 
-  /@dxos/esbuild-server/1.7.1:
-    resolution: {integrity: sha512-+Uvne5mz6ZcYyZzjTKgFH4eN1V4v27DsvQ4YQdwU0oTC9iYXQ4/dV1NNP74P0ZPpxMk7sonWZ53OeZFbPeoUgA==}
+  /@dxos/esbuild-server/1.7.2:
+    resolution: {integrity: sha512-wuo9Fn/4ykGt+45HUVoP4y7W9hytJySzvqIIlnZ47LUe0xxEFvr1mNlCVDvEebuqxB83u2n7XV13t2vAB+y4qQ==}
     hasBin: true
     dependencies:
       '@babel/core': 7.16.5
@@ -5155,8 +5155,8 @@ packages:
       - supports-color
     dev: true
 
-  /@dxos/esbuild-server/1.7.1_@types+react@17.0.37:
-    resolution: {integrity: sha512-+Uvne5mz6ZcYyZzjTKgFH4eN1V4v27DsvQ4YQdwU0oTC9iYXQ4/dV1NNP74P0ZPpxMk7sonWZ53OeZFbPeoUgA==}
+  /@dxos/esbuild-server/1.7.2_@types+react@17.0.37:
+    resolution: {integrity: sha512-wuo9Fn/4ykGt+45HUVoP4y7W9hytJySzvqIIlnZ47LUe0xxEFvr1mNlCVDvEebuqxB83u2n7XV13t2vAB+y4qQ==}
     hasBin: true
     dependencies:
       '@babel/core': 7.16.5

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -65,7 +65,7 @@
     "@dxos/async": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.1",
+    "@dxos/esbuild-server": "~1.7.2",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/d3": "~7.0.0",
     "@types/faker": "^5.5.1",

--- a/packages/devtools/devtools-mesh/package.json
+++ b/packages/devtools/devtools-mesh/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "~7.13.15",
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.1",
+    "@dxos/esbuild-server": "~1.7.2",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/react": "^17.0.24",
     "@types/react-copy-to-clipboard": "~5.0.1",

--- a/packages/devtools/devtools/package.json
+++ b/packages/devtools/devtools/package.json
@@ -47,7 +47,7 @@
     "@babel/core": "~7.13.15",
     "@dxos/echo-db": "workspace:*",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.1",
+    "@dxos/esbuild-server": "~1.7.2",
     "@dxos/messenger-model": "workspace:*",
     "@dxos/network-manager": "workspace:*",
     "@dxos/object-model": "workspace:*",

--- a/packages/sdk/react-client/package.json
+++ b/packages/sdk/react-client/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.1",
+    "@dxos/esbuild-server": "~1.7.2",
     "@dxos/toolchain-node-library": "workspace:*",
     "@mui/material": "^5.0.1",
     "@testing-library/react": "^11.0.4",

--- a/packages/sdk/react-components/package.json
+++ b/packages/sdk/react-components/package.json
@@ -37,7 +37,7 @@
     "@dxos/client": "workspace:*",
     "@dxos/echo-db": "workspace:*",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.1",
+    "@dxos/esbuild-server": "~1.7.2",
     "@dxos/react-client": "workspace:*",
     "@dxos/toolchain-node-library": "workspace:*",
     "@emotion/react": "^11.4.1",

--- a/packages/sdk/react-framework/package.json
+++ b/packages/sdk/react-framework/package.json
@@ -42,7 +42,7 @@
     "@dxos/credentials": "workspace:*",
     "@dxos/echo-db": "workspace:*",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.1",
+    "@dxos/esbuild-server": "~1.7.2",
     "@dxos/object-model": "workspace:*",
     "@dxos/react-client": "workspace:*",
     "@dxos/react-components": "workspace:*",

--- a/packages/sdk/react-registry-client/package.json
+++ b/packages/sdk/react-registry-client/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@babel/core": "~7.13.15",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.1",
+    "@dxos/esbuild-server": "~1.7.2",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/debug": "^4.1.7",
     "@types/lodash": "^4.14.175",

--- a/packages/sdk/registry-client/package.json
+++ b/packages/sdk/registry-client/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.1",
+    "@dxos/esbuild-server": "~1.7.2",
     "@dxos/toolchain-node-library": "workspace:*",
     "@polkadot/typegen": "^4.17.1",
     "@types/chai": "^4.2.15",

--- a/packages/tutorials/tutorials-tasks-app/package.json
+++ b/packages/tutorials/tutorials-tasks-app/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@babel/core": "~7.13.15",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.1",
+    "@dxos/esbuild-server": "~1.7.2",
     "@types/mocha": "~8.2.2",
     "@types/node": "^14.0.9",
     "@types/react": "^17.0.24",

--- a/packages/wallet/wallet-playground/package.json
+++ b/packages/wallet/wallet-playground/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.1",
+    "@dxos/esbuild-server": "~1.7.2",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc</em></summary>



</details>
<details>
<summary><em>sudo ./common/scripts/install-dependencies.sh</em></summary>

```Shell
Hit:1 http://azure.archive.ubuntu.com/ubuntu focal InRelease
Hit:2 http://azure.archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:3 http://azure.archive.ubuntu.com/ubuntu focal-backports InRelease
Hit:4 http://security.ubuntu.com/ubuntu focal-security InRelease
Hit:5 https://packages.microsoft.com/ubuntu/20.04/prod focal InRelease
Hit:6 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal InRelease
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
autoconf is already the newest version (2.69-11.1).
automake is already the newest version (1:1.16.1-4ubuntu6).
g++ is already the newest version (4:9.3.0-1ubuntu2).
libpng-dev is already the newest version (1.6.37-2).
libtool is already the newest version (2.4.6-14).
libxtst-dev is already the newest version (2:1.2.3-1).
make is already the newest version (4.2.1-1.2).
libx11-dev is already the newest version (2:1.6.9-2ubuntu1.2).
jq is already the newest version (1.6-1ubuntu0.20.04.1).
0 upgraded, 0 newly installed, 0 to remove and 18 not upgraded.
Reading package lists...
Building dependency tree...
Reading state information...
gstreamer1.0-libav is already the newest version (1.16.2-2).
gstreamer1.0-plugins-bad is already the newest version (1.16.2-2.1ubuntu1).
libenchant1c2a is already the newest version (1.6.0-11.3build1).
lsof is already the newest version (4.93.2+dfsg-1ubuntu0.20.04.1).
0 upgraded, 0 newly installed, 0 to remove and 18 not upgraded.
```



</details>
<details>
<summary><em>cli.js -u --deep '@dxos/*'</em></summary>

```Shell
Using config file /home/runner/work/protocols/protocols/.ncurc.js
Upgrading /home/runner/work/protocols/protocols/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/docs/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/common/temp/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/packages/demos/package.json

 @dxos/esbuild-server  ~1.7.1  →  ~1.7.2     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/toolchains/esbuild-plugins/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/toolchains/toolchain-node-library/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/common/temp/pnpm-local/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/packages/bot/bot-factory-client/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/bot/botkit/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/async/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/codec-protobuf/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/crypto/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/debug/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/proto/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/protobuf-compiler/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/protobuf-test/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/packages/common/random-access-multi-storage/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/rpc/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/testutils/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/util/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/devtools/devtools/package.json

 @dxos/esbuild-server  ~1.7.1  →  ~1.7.2     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/devtools/devtools-extension/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/devtools/devtools-mesh/package.json

 @dxos/esbuild-server  ~1.7.1  →  ~1.7.2     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/echo/echo-db/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/echo-protocol/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/echo-testing/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/feed-store/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/messenger-model/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/model-factory/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/object-model/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/text-model/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/gravity/browser-mocha/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/gravity/browser-tests/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/gravity/gravity-core/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/halo/credentials/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/halo/halo-protocol/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/broadcast/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/network-generator/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/network-manager/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-network-generator/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-plugin-messenger/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-plugin-presence/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-plugin-replicator/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-plugin-rpc/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/signal/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/sdk/client/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/sdk/config/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/sdk/react-client/package.json

 @dxos/esbuild-server  ~1.7.1  →  ~1.7.2     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/sdk/react-components/package.json

 @dxos/esbuild-server  ~1.7.1  →  ~1.7.2     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/sdk/react-framework/package.json

 @dxos/esbuild-server  ~1.7.1  →  ~1.7.2     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/sdk/react-registry-client/package.json

 @dxos/esbuild-server  ~1.7.1  →  ~1.7.2     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/sdk/registry-client/package.json

 @dxos/esbuild-server  ~1.7.1  →  ~1.7.2     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/tutorials/tutorials-tasks-app/package.json

 @dxos/esbuild-server  ~1.7.1  →  ~1.7.2     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/wallet/wallet-extension/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/wallet/wallet-playground/package.json

 @dxos/esbuild-server  ~1.7.1  →  ~1.7.2     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/common/temp/install-run/@microsoft+rush@5.58.0/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/packages/deprecated/bot/bot-deprecated/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/deprecated/bot/botkit-client-deprecated/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/deprecated/bot/botkit-deprecated/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/deprecated/bot/protocol-plugin-bot-deprecated/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/deprecated/bot/test-bot-deprecated/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/broadcast/example/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/common/temp/pnpm-store/v3/tmp/_tmp_4320_41be5b26fec31910960d72186074eaf5/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/common/temp/pnpm-store/v3/tmp/_tmp_4320_8688164c7854016fe48bfe07f2bd0966/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/common/temp/pnpm-store/v3/tmp/_tmp_4320_8705a3ec16d8787de7eabac53a2f06d2/package.json

No dependencies.
```



</details>
<details>
<summary><em>npm install -g @microsoft/rush pnpm</em></summary>

```Shell
changed 287 packages, and audited 288 packages in 10s

33 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

### stderr:

```Shell
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated @opentelemetry/types@0.2.0: Package renamed to @opentelemetry/api, see https://github.com/open-telemetry/opentelemetry-js
```

</details>
<details>
<summary><em>node common/scripts/install-run-rush.js update</em></summary>

```Shell
The rush.json configuration requests Rush version 5.58.0

Invoking "rush update"
----------------------



Rush Multi-Project Build Tool 5.58.0 - https://rushjs.io
Node.js version is 16.1.0 (pre-LTS)


Starting "rush update"

Trying to acquire lock for pnpm-6.24.2
Acquired lock for pnpm-6.24.2
Found pnpm version 6.24.2 in /home/runner/.rush/node-v16.1.0/pnpm-6.24.2

Symlinking "/home/runner/work/protocols/protocols/common/temp/pnpm-local"
  --> "/home/runner/.rush/node-v16.1.0/pnpm-6.24.2"
Transforming /home/runner/work/protocols/protocols/common/config/rush/.npmrc
  --> "/home/runner/work/protocols/protocols/common/temp/.npmrc"

Updating workspace files in /home/runner/work/protocols/protocols/common/temp
Copying "/home/runner/work/protocols/protocols/common/config/rush/pnpm-lock.yaml"
  --> "/home/runner/work/protocols/protocols/common/temp/pnpm-lock.yaml"
Copying "/home/runner/work/protocols/protocols/common/config/rush/pnpm-lock.yaml"
  --> "/home/runner/work/protocols/protocols/common/temp/pnpm-lock-preinstall.yaml"

The shrinkwrap file contains the following issues:
  Dependencies of project "@dxos/demos" do not match the current shrinkwrap.
  Dependencies of project "@dxos/devtools" do not match the current shrinkwrap.
  Dependencies of project "@dxos/devtools-mesh" do not match the current shrinkwrap.
  Dependencies of project "@dxos/react-client" do not match the current shrinkwrap.
  Dependencies of project "@dxos/react-components" do not match the current shrinkwrap.
  Dependencies of project "@dxos/react-framework" do not match the current shrinkwrap.
  Dependencies of project "@dxos/react-registry-client" do not match the current shrinkwrap.
  Dependencies of project "@dxos/registry-client" do not match the current shrinkwrap.
  Dependencies of project "@dxos/tutorials-tasks-app" do not match the current shrinkwrap.
  Dependencies of project "@dxos/wallet-playground" do not match the current shrinkwrap.


Checking installation in "/home/runner/work/protocols/protocols/common/temp"


Running "pnpm install" in /home/runner/work/protocols/protocols/common/temp

Scope: all 58 workspace projects
Progress: resolved 1, reused 0, downloaded 0, added 0
../../packages/halo/halo-protocol        |  WARN  deprecated @types/expect@24.3.0
.../common/random-access-multi-storage   |  WARN  deprecated @types/expect@24.3.0
../../packages/halo/credentials          |  WARN  deprecated @types/expect@24.3.0
../../packages/mesh/protocol-plugin-rpc  |  WARN  deprecated @types/expect@24.3.0
../../packages/sdk/client                |  WARN  deprecated @types/expect@24.3.0
../../packages/bot/botkit                |  WARN  deprecated @types/expect@24.3.0
Progress: resolved 181, reused 180, downloaded 0, added 0
../../packages/wallet/wallet-extension   |  WARN  deprecated webextension-polyfill-ts@0.25.0
Progress: resolved 299, reused 260, downloaded 0, added 0
Progress: resolved 441, reused 260, downloaded 0, added 0
Progress: resolved 594, reused 263, downloaded 0, added 0
Progress: resolved 965, reused 652, downloaded 0, added 0
Progress: resolved 1039, reused 791, downloaded 0, added 0
Progress: resolved 1039, reused 807, downloaded 0, added 0
Progress: resolved 1255, reused 1209, downloaded 0, added 0
Progress: resolved 1533, reused 1506, downloaded 0, added 0
Progress: resolved 1916, reused 1897, downloaded 0, added 0
Progress: resolved 2294, reused 2282, downloaded 0, added 0
Progress: resolved 2737, reused 2725, downloaded 0, added 0
Progress: resolved 2954, reused 2942, downloaded 0, added 0
Progress: resolved 2954, reused 2942, downloaded 0, added 0, done

Copying "/home/runner/work/protocols/protocols/common/temp/pnpm-lock.yaml"
  --> "/home/runner/work/protocols/protocols/common/config/rush/pnpm-lock.yaml"


Rush update finished successfully. (18.49 seconds)
```

### stderr:

```Shell
Your version of Node.js (16.1.0) is not a Long-Term Support (LTS) release. These versions frequently have bugs. Please consider installing a stable release.
```

</details>
<details>
<summary><em>rm -rf .npmrc</em></summary>



</details>

</details>

## Changed files
<details>
<summary>Changed 11 files: </summary>

- common/config/rush/pnpm-lock.yaml
- packages/demos/package.json
- packages/devtools/devtools-mesh/package.json
- packages/devtools/devtools/package.json
- packages/sdk/react-client/package.json
- packages/sdk/react-components/package.json
- packages/sdk/react-framework/package.json
- packages/sdk/react-registry-client/package.json
- packages/sdk/registry-client/package.json
- packages/tutorials/tutorials-tasks-app/package.json
- packages/wallet/wallet-playground/package.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)