### PR TITLE
fix(react-components): adjust jittering on custom text field

### DIFF
--- a/packages/sdk/react-components/src/CustomTextField.tsx
+++ b/packages/sdk/react-components/src/CustomTextField.tsx
@@ -206,7 +206,7 @@ export const CustomTextField = ({
       <Typography
         sx={{
           color: text ? undefined : theme.palette.text.disabled,
-          boxSizing: 'content-box',
+          boxSizing: 'content-box'
         }}
         onClick={() => !readonly && clickToEdit && setEditing(true)}
       >


### PR DESCRIPTION
The problem was detected on the braneframe test application. At first, it could not be replicated, but upon further investigation, the issue was the styles the CssBaseline from MaterialUI was adding, in particular, the "box-sizing" set to "inherit".
The solution proposed is manually setting the "box-sizing" property to the one needed for this to work correctly.