### PR TITLE
chore: Upgrade DXOS dependencies

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -337,7 +337,7 @@ importers:
       '@dxos/echo-protocol': workspace:*
       '@dxos/echo-testing': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.3
       '@dxos/gem-core': ~1.0.0-beta.25
       '@dxos/gem-spore': ~1.0.0-beta.25
       '@dxos/object-model': workspace:*
@@ -421,7 +421,7 @@ importers:
       '@dxos/async': link:../common/async
       '@dxos/debug': link:../common/debug
       '@dxos/esbuild-plugins': link:../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.3_@types+react@17.0.37
       '@dxos/toolchain-node-library': link:../../toolchains/toolchain-node-library
       '@types/d3': 7.0.0
       '@types/faker': 5.5.9
@@ -636,7 +636,7 @@ importers:
       '@dxos/echo-db': workspace:*
       '@dxos/echo-protocol': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.3
       '@dxos/messenger-model': workspace:*
       '@dxos/model-factory': workspace:*
       '@dxos/network-manager': workspace:*
@@ -700,7 +700,7 @@ importers:
       '@babel/core': 7.13.16
       '@dxos/echo-db': link:../../echo/echo-db
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.3_@types+react@17.0.37
       '@dxos/messenger-model': link:../../echo/messenger-model
       '@dxos/network-manager': link:../../mesh/network-manager
       '@dxos/object-model': link:../../echo/object-model
@@ -813,7 +813,7 @@ importers:
       '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.3
       '@dxos/gem-core': ~1.0.0-beta.25
       '@dxos/gem-spore': ~1.0.0-beta.25
       '@dxos/network-manager': workspace:*
@@ -863,7 +863,7 @@ importers:
       '@babel/core': 7.13.16
       '@babel/plugin-transform-runtime': 7.16.4_@babel+core@7.13.16
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.3_@types+react@17.0.37
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@types/react': 17.0.37
       '@types/react-copy-to-clipboard': 5.0.2
@@ -2007,7 +2007,7 @@ importers:
       '@dxos/debug': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.3
       '@dxos/toolchain-node-library': workspace:*
       '@dxos/util': workspace:*
       '@mui/material': ^5.0.1
@@ -2049,7 +2049,7 @@ importers:
       use-subscription: 1.5.1_react@17.0.2
     devDependencies:
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.3_@types+react@17.0.37
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@mui/material': 5.2.3_5539cae010396b202b015f3568914e95
       '@testing-library/react': 11.2.7_react-dom@17.0.2+react@17.0.2
@@ -2080,7 +2080,7 @@ importers:
       '@dxos/debug': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.3
       '@dxos/react-client': workspace:*
       '@dxos/toolchain-node-library': workspace:*
       '@emotion/react': ^11.4.1
@@ -2127,7 +2127,7 @@ importers:
       '@dxos/client': link:../client
       '@dxos/echo-db': link:../../echo/echo-db
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.3_@types+react@17.0.37
       '@dxos/react-client': link:../react-client
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@emotion/react': 11.7.1_c8f47004f4d29cd7909f1411b83f7eb5
@@ -2163,7 +2163,7 @@ importers:
       '@dxos/debug': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.3
       '@dxos/object-model': workspace:*
       '@dxos/react-client': workspace:*
       '@dxos/react-components': workspace:*
@@ -2218,7 +2218,7 @@ importers:
       '@dxos/credentials': link:../../halo/credentials
       '@dxos/echo-db': link:../../echo/echo-db
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.3_@types+react@17.0.37
       '@dxos/object-model': link:../../echo/object-model
       '@dxos/react-client': link:../react-client
       '@dxos/react-components': link:../react-components
@@ -2249,7 +2249,7 @@ importers:
       '@dxos/codec-protobuf': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.3
       '@dxos/registry-client': workspace:*
       '@dxos/toolchain-node-library': workspace:*
       '@dxos/util': workspace:*
@@ -2274,7 +2274,7 @@ importers:
       '@babel/core': 7.13.16
       '@dxos/codec-protobuf': link:../../common/codec-protobuf
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.3_@types+react@17.0.37
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@types/debug': 4.1.7
       '@types/lodash': 4.14.178
@@ -2292,7 +2292,7 @@ importers:
       '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.3
       '@dxos/toolchain-node-library': workspace:*
       '@dxos/util': workspace:*
       '@polkadot/api': 4.17.1
@@ -2338,7 +2338,7 @@ importers:
       protobufjs: 6.11.2
     devDependencies:
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2
+      '@dxos/esbuild-server': 1.7.3
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@polkadot/typegen': 4.17.1
       '@types/chai': 4.3.0
@@ -2361,7 +2361,7 @@ importers:
       '@dxos/crypto': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.3
       '@dxos/object-model': workspace:*
       '@dxos/react-client': workspace:*
       '@dxos/react-components': workspace:*
@@ -2410,7 +2410,7 @@ importers:
     devDependencies:
       '@babel/core': 7.13.16
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.3_@types+react@17.0.37
       '@types/mocha': 8.2.3
       '@types/node': 14.18.0
       '@types/react': 17.0.37
@@ -2517,7 +2517,7 @@ importers:
       '@dxos/config': workspace:*
       '@dxos/crypto': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.3
       '@dxos/react-client': workspace:*
       '@dxos/react-components': workspace:*
       '@dxos/react-framework': workspace:*
@@ -2542,7 +2542,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.3_@types+react@17.0.37
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
@@ -5142,15 +5142,14 @@ packages:
       - webpack-command
     dev: true
 
-  /@dxos/esbuild-server/1.7.2:
-    resolution: {integrity: sha512-wuo9Fn/4ykGt+45HUVoP4y7W9hytJySzvqIIlnZ47LUe0xxEFvr1mNlCVDvEebuqxB83u2n7XV13t2vAB+y4qQ==}
+  /@dxos/esbuild-server/1.7.3:
+    resolution: {integrity: sha512-fc8kX2fw/vuPkpyMPtOAJVvc4caq/zx5x1DYoCFAdss7ug2FnxxqYwD4c6SqExWf7IVW0p3eud8vmm+McCBNCA==}
     hasBin: true
     dependencies:
       '@babel/core': 7.16.5
       '@mdx-js/esbuild': 2.0.0-rc.1_esbuild@0.12.29
       '@mdx-js/mdx': 2.0.0-rc.2
       '@mdx-js/react': 2.0.0-rc.2_react@17.0.2
-      '@styled-icons/material-outlined': 10.34.0_c17876e09d792e0c7b0f44e49f814625
       chalk: 4.1.2
       esbuild: 0.12.29
       glob: 7.2.0
@@ -5163,7 +5162,6 @@ packages:
       react-syntax-highlighter: 15.4.5_react@17.0.2
       rehype-highlight: 5.0.1
       styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-      styled-icons: 10.45.0_c17876e09d792e0c7b0f44e49f814625
       theme-ui: 0.12.1_@babel+core@7.16.5+react@17.0.2
       yargs: 17.3.0
     transitivePeerDependencies:
@@ -5171,15 +5169,14 @@ packages:
       - supports-color
     dev: true
 
-  /@dxos/esbuild-server/1.7.2_@types+react@17.0.37:
-    resolution: {integrity: sha512-wuo9Fn/4ykGt+45HUVoP4y7W9hytJySzvqIIlnZ47LUe0xxEFvr1mNlCVDvEebuqxB83u2n7XV13t2vAB+y4qQ==}
+  /@dxos/esbuild-server/1.7.3_@types+react@17.0.37:
+    resolution: {integrity: sha512-fc8kX2fw/vuPkpyMPtOAJVvc4caq/zx5x1DYoCFAdss7ug2FnxxqYwD4c6SqExWf7IVW0p3eud8vmm+McCBNCA==}
     hasBin: true
     dependencies:
       '@babel/core': 7.16.5
       '@mdx-js/esbuild': 2.0.0-rc.1_esbuild@0.12.29
       '@mdx-js/mdx': 2.0.0-rc.2
       '@mdx-js/react': 2.0.0-rc.2_react@17.0.2
-      '@styled-icons/material-outlined': 10.34.0_c17876e09d792e0c7b0f44e49f814625
       chalk: 4.1.2
       esbuild: 0.12.29
       glob: 7.2.0
@@ -5192,7 +5189,6 @@ packages:
       react-syntax-highlighter: 15.4.5_react@17.0.2
       rehype-highlight: 5.0.1
       styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-      styled-icons: 10.45.0_c17876e09d792e0c7b0f44e49f814625
       theme-ui: 0.12.1_23551ae5df81be1ad77d4e4acd306532
       yargs: 17.3.0
     transitivePeerDependencies:
@@ -6924,450 +6920,6 @@ packages:
     resolution: {integrity: sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==}
     dependencies:
       '@sinonjs/commons': 1.8.3
-
-  /@styled-icons/bootstrap/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-UpzdVUR7r9BNqEfPrMchJdgMZEg9eXQxLQJUXM0ouvbI5o9j21/y1dGameO4PZtYbutT/dWv5O6y24z5JWzd5w==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/boxicons-logos/10.38.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-DpkUi9qV76RsyuzihQhfCho142WCxK/2oUfjcqo6BsP92qxV+4rtS5nfVsmqfnSEef4av+qSeg33fJWDyURyKg==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/boxicons-regular/10.38.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-xjhafoa0/EeYtQOyTw+ohuSlBx599t8l8++JH1tQlM0l73dP4icTpF4znYL+HhZeaUe3D+UhrkfWuBBua2w2Qw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/boxicons-solid/10.38.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-uuMtF1R61smQT5r6HIYMHvpVD0XSErXXNQYl5d6lCtMyefd0gIE5Rw+iD9i/RxHFUHNHbvL69LvitCLtNWrSqw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/crypto/10.38.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-SOfJFfofCOgExaRB0u3AA7Fdv2vbFIxtCAmyNDdjqvnTncg4HVPEg5+rysN3oHGiJBF8+uqUdtLerx3rmhYI7g==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/entypo-social/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-amhrYcc/buvTJrunRnYNeFNJ5Ru1ByV/pcICj7An9TF/NNC4exfnzaoUzOJNcMGOHU5jphrqjSosC4pQNJKqkA==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/entypo/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-9hl109HydOfi/q9ceqoI9Bmj5tv1v/RoUY2nbuGuVtKDVNCVw7WQ0eTiZkb1OgiVYsJXs6xQBcNZdVeo4en/lQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/evaicons-outline/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-ONPKJO+u3DB/rsCJdIKt6OBoKBvIvM/EsulxuWniRPPr0rR5lwueGocJpJmEUi+C4gsMllBSkcL5cOdFyd1Nbw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/evaicons-solid/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-74S0zzxovKTXNpID8bXB4Qy34EBq3vuVAlTd9xsT2gY16BtPH7JcGHLmtQpbpJcHuWkcQH4bSv+GLq+0/i/ljQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/evil/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-rU5MrgMow9I0Vkqo6V5WkTcj0o1toDzn8kQSQywTL1N7JuyATKZgN3kgkzNUgHd5LorcsGMetPsvDmgS31XAPw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/fa-brands/10.38.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-zZzGkcshXIF55geFIpMzMLH6tSPzQeeFPFZ1RMrZ3TWBjUuquMx+vYFsO7kzq939X84gLjmpkJZsAP9QKJFvMg==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/fa-regular/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-QUqljT+uIfowGurV5GzjnHA1qvq922H+6yGRzQYBxBZ5Vgaak4Q71jtCSMqZKXcOG3tngMyhrOuaNaPOw1Q1pQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/fa-solid/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-PnJMUPcbuPA7gswxl9FKd725qaqP5VSbmX7rk+ZZ7ivdA6Dbi1VoKYXqAc62OEisGDhzn5g56KbBvE14W1n7vw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/feather/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-UdhKaUC8T98V5H4WEh+UBRfVT7ZTcPpgUUrXlRM2CWanuNIUKpIjj0SKhsnkuprqtzV1L6s3Koa40VTfpG9LYQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/fluentui-system-filled/10.35.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-uupqp8u2FdnpOhVPAIAVb9Ax8p6Yu/ZDsRq3XUHhDd0e4Mb1e2KIXorwg1sRfR+PHCvWLbu6knIt17Az1OlmHQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/fluentui-system-regular/10.35.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-DHZRTLw6tGkmG6EOo46iHsta6xx+Gd71iHEg5GTVTsoUtk2ZFHL1GRW9KPnkcPPB6h3/QQE4c36MyHFPvPfjzA==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/foundation/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-RJksGQoStOqVQegwvtDTqrhEQjc7x5izqzBuwMw6R+18XcBC+pP8oRtuisv2ogn5icVrN/FWQHMx8EJ14jMdig==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/heroicons-outline/10.36.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-1IcNp8rjPetb5IMvSzCgh1/QDsz7brzMKv6AEbchByKM6oyOsv9p2PapGMRs6L5rH3LDGzouxNSYPUES8aY3Vw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/heroicons-solid/10.36.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-cbC0roQSwvrw+ryVx1MfK3NAxh5CyOCzJwFgwZTuXsYpk7IVNNFFSRn1uRGaFDHn3aLLEikMkxxR4q5NM07ZpA==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/icomoon/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-nimtxPqlA6K2iNDeGCCYrFvPbjJl2TwM+YtX55RYC3YJFrh+MeKL+F60uvzoKWY3vZ1vsmQR3iW+aRFQHvhIOw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/ionicons-outline/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-8zLCIizxxKAA8tpJLmEnfXy+NcWW7CIxaqDQPZ/GEri4f6GA4QEf4BxCz+XXfEBoBthj+cPr/3d8oB7YygC5TQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/ionicons-sharp/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-2vmb5xa0fNDWe6QoKsfATilv9Qvlnv4z/3m1NMY+tU5ER+Z9YvPQkLcRqeS/dpm4HHfRAlGsVX5A8r8B+rPnag==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/ionicons-solid/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-gp85y8VbxhBUx0xP3eokyxIkAiWkSaJO3kN1/mGfCSKcWllLBhoHikyGjWAxFPMunhzix4PM0tVudWrsSxmLeQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/material-outlined/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-scn3Ih15t82rUJPI9vwnZaYL6ZiDhlYoashIJAs8c8QjJfK0rWdt+hr3E6/0wixx67BkLB3j96Jn9y+qXfVVIQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/material-rounded/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-Y2QB3bz+tDmrtcgNXKIPnw8xqarObpcFxOapkP3pMDGl+guCgV5jNHrE8xTKyN5lYYQmm9oBZ5odwgT3B+Uw5g==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/material-sharp/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-XY1N68Tj5TyyAHJDQwYtasKis4xuNl5xjbISdz8zreWlsY5N4nO4rh/SgAUYvblz+Xjf4P+JZAF22foVpZwIeg==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/material-twotone/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-o5EwR1WdjUwNebFAWqIiZwbP1ibOPy8vHX0KdkV0WDZTCXDW5Nhj3C5JeTAwPeRtFU+Bxt7NHjUmrsm3jNRzzw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/material/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-BQCyzAN0RhkpI6mpIP7RvUoZOZ15d5opKfQRqQXVOfKD3Dkyi26Uog1KTuaaa/MqtqrWaYXC6Y1ypanvfpyL2g==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/octicons/10.44.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-7pLWrUDkc/acwJ4ayL+Xmb7o1j5WUB6nI5dATRPzcm2CENUdEEyf17uL1J9qwB5aFoyDpo7c/UYWtq5QpGpk6A==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/open-iconic/10.18.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-H+uiRUDm09SXlOgJheOmhT0KeLs5uBS85H2VF1ypMN1m/vy/NdaGP5QAvWTCzBk088JJGYEkvhb4i4pGcwRsEA==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/remix-editor/10.33.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-V1jZ3G1J8PaBiIwf2Va7UuEXot8xR39UQ3XNIJNQClnGA04ahTsEC2mpN5pHwr4mkJijXu0Htjhnf/YiWYVsCw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/remix-fill/10.18.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-FbnQMvxt2R7CYb8j/dVAXd31CDg4k3vX1zG/9GH9qpL536yxndnyopa7hwF/Yisy2pzR7uNlNXmTQAmYK2HSrg==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/remix-line/10.18.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-UZllhk6hEWFyZt+jdPCO4zbeM0P3Y/Lc1iWWOwUXGP5AzStM2KadjaGpi99FhNfrvrly98cVB8b4M/GVExYn0Q==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/simple-icons/10.45.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-2agGgrxuiBjicbz5kgF1M691oNfRUYwSWy80kqJCEGXyJ9YGtLWXTSNdLYMk0Dt4JnL0/3eKItU9jYf24rCcJg==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/styled-icon/10.6.3_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-/A95L3peioLoWFiy+/eKRhoQ9r/oRrN/qzbSX4hXU1nGP2rUXcX3LWUhoBNAOp9Rw38ucc/4ralY427UUNtcGQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '>=4.1.0 <6'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@emotion/is-prop-valid': 0.8.8
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/typicons/10.18.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-VN9vEzeAn5//uUvBN2N/OAXnrC6zCERu1eXUiXmYTwd7n8ZoMMASKmVWrAho20YmhUjEPZdSvS1cJ/pzV9K6Zg==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/zondicons/10.18.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-P+XDzHRjY7zgcOYI22VJPg4GW01760VICwMSF2vJFRd0bux3hKIJI8voABA9v00Ce1TeOZnUbKcgQFBNIThs5w==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
 
   /@styled-system/background/5.1.2:
     resolution: {integrity: sha512-jtwH2C/U6ssuGSvwTN3ri/IyjdHb8W9X/g8Y0JLcrH02G+BW3OS8kZdHphF1/YyRklnrKrBT2ngwGUK6aqqV3A==}
@@ -23849,54 +23401,6 @@ packages:
       react-is: 17.0.2
       shallowequal: 1.1.0
       supports-color: 5.5.0
-    dev: true
-
-  /styled-icons/10.45.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-oUsAAr95m+IPS3JxExaxdxoVA6FIqTPEykebMe7h7rkD6X5JS5K37kg4HlWJOcpMznL0Vj3GW6S5LF1qqUwN7Q==}
-    peerDependencies:
-      react: '*'
-      styled-components: '>=4.1.0 <6'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/bootstrap': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/boxicons-logos': 10.38.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/boxicons-regular': 10.38.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/boxicons-solid': 10.38.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/crypto': 10.38.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/entypo': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/entypo-social': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/evaicons-outline': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/evaicons-solid': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/evil': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/fa-brands': 10.38.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/fa-regular': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/fa-solid': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/feather': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/fluentui-system-filled': 10.35.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/fluentui-system-regular': 10.35.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/foundation': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/heroicons-outline': 10.36.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/heroicons-solid': 10.36.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/icomoon': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/ionicons-outline': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/ionicons-sharp': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/ionicons-solid': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/material': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/material-outlined': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/material-rounded': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/material-sharp': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/material-twotone': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/octicons': 10.44.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/open-iconic': 10.18.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/remix-editor': 10.33.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/remix-fill': 10.18.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/remix-line': 10.18.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/simple-icons': 10.45.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/typicons': 10.18.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/zondicons': 10.18.0_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
     dev: true
 
   /styled-system/5.1.5:

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -65,7 +65,7 @@
     "@dxos/async": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.3",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/d3": "~7.0.0",
     "@types/faker": "^5.5.1",

--- a/packages/devtools/devtools-mesh/package.json
+++ b/packages/devtools/devtools-mesh/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "~7.13.15",
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.3",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/react": "^17.0.24",
     "@types/react-copy-to-clipboard": "~5.0.1",

--- a/packages/devtools/devtools/package.json
+++ b/packages/devtools/devtools/package.json
@@ -48,7 +48,7 @@
     "@babel/core": "~7.13.15",
     "@dxos/echo-db": "workspace:*",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.3",
     "@dxos/messenger-model": "workspace:*",
     "@dxos/network-manager": "workspace:*",
     "@dxos/object-model": "workspace:*",

--- a/packages/sdk/react-client/package.json
+++ b/packages/sdk/react-client/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.3",
     "@dxos/toolchain-node-library": "workspace:*",
     "@mui/material": "^5.0.1",
     "@testing-library/react": "^11.0.4",

--- a/packages/sdk/react-components/package.json
+++ b/packages/sdk/react-components/package.json
@@ -37,7 +37,7 @@
     "@dxos/client": "workspace:*",
     "@dxos/echo-db": "workspace:*",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.3",
     "@dxos/react-client": "workspace:*",
     "@dxos/toolchain-node-library": "workspace:*",
     "@emotion/react": "^11.4.1",

--- a/packages/sdk/react-framework/package.json
+++ b/packages/sdk/react-framework/package.json
@@ -42,7 +42,7 @@
     "@dxos/credentials": "workspace:*",
     "@dxos/echo-db": "workspace:*",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.3",
     "@dxos/object-model": "workspace:*",
     "@dxos/react-client": "workspace:*",
     "@dxos/react-components": "workspace:*",

--- a/packages/sdk/react-registry-client/package.json
+++ b/packages/sdk/react-registry-client/package.json
@@ -25,7 +25,7 @@
     "@babel/core": "~7.13.15",
     "@dxos/codec-protobuf": "workspace:*",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.3",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/debug": "^4.1.7",
     "@types/lodash": "^4.14.175",

--- a/packages/sdk/registry-client/package.json
+++ b/packages/sdk/registry-client/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.3",
     "@dxos/toolchain-node-library": "workspace:*",
     "@polkadot/typegen": "^4.17.1",
     "@types/chai": "^4.2.15",

--- a/packages/tutorials/tutorials-tasks-app/package.json
+++ b/packages/tutorials/tutorials-tasks-app/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@babel/core": "~7.13.15",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.3",
     "@types/mocha": "~8.2.2",
     "@types/node": "^14.0.9",
     "@types/react": "^17.0.24",

--- a/packages/wallet/wallet-playground/package.json
+++ b/packages/wallet/wallet-playground/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.3",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc</em></summary>



</details>
<details>
<summary><em>sudo ./common/scripts/install-dependencies.sh</em></summary>

```Shell
Hit:1 http://azure.archive.ubuntu.com/ubuntu focal InRelease
Hit:2 http://azure.archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:3 http://azure.archive.ubuntu.com/ubuntu focal-backports InRelease
Hit:4 https://packages.microsoft.com/ubuntu/20.04/prod focal InRelease
Hit:5 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal InRelease
Hit:6 http://security.ubuntu.com/ubuntu focal-security InRelease
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
autoconf is already the newest version (2.69-11.1).
automake is already the newest version (1:1.16.1-4ubuntu6).
g++ is already the newest version (4:9.3.0-1ubuntu2).
libpng-dev is already the newest version (1.6.37-2).
libtool is already the newest version (2.4.6-14).
libxtst-dev is already the newest version (2:1.2.3-1).
make is already the newest version (4.2.1-1.2).
libx11-dev is already the newest version (2:1.6.9-2ubuntu1.2).
jq is already the newest version (1.6-1ubuntu0.20.04.1).
0 upgraded, 0 newly installed, 0 to remove and 26 not upgraded.
Reading package lists...
Building dependency tree...
Reading state information...
gstreamer1.0-libav is already the newest version (1.16.2-2).
gstreamer1.0-plugins-bad is already the newest version (1.16.2-2.1ubuntu1).
libenchant1c2a is already the newest version (1.6.0-11.3build1).
lsof is already the newest version (4.93.2+dfsg-1ubuntu0.20.04.1).
0 upgraded, 0 newly installed, 0 to remove and 26 not upgraded.
```



</details>
<details>
<summary><em>cli.js -u --deep '@dxos/*'</em></summary>

```Shell
Using config file /home/runner/work/protocols/protocols/.ncurc.js
Upgrading /home/runner/work/protocols/protocols/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/docs/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/common/temp/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/packages/demos/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.3     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/toolchains/esbuild-plugins/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/toolchains/toolchain-node-library/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/common/temp/pnpm-local/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/packages/bot/bot-factory-client/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/bot/botkit/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/async/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/codec-protobuf/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/crypto/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/debug/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/proto/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/protobuf-compiler/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/protobuf-test/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/packages/common/random-access-multi-storage/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/rpc/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/testutils/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/util/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/devtools/devtools/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.3     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/devtools/devtools-extension/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/devtools/devtools-mesh/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.3     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/echo/echo-db/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/echo-protocol/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/echo-testing/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/feed-store/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/messenger-model/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/model-factory/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/object-model/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/text-model/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/gravity/browser-mocha/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/gravity/browser-tests/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/gravity/gravity-core/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/halo/credentials/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/halo/halo-protocol/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/broadcast/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/network-generator/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/network-manager/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-network-generator/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-plugin-messenger/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-plugin-presence/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-plugin-replicator/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-plugin-rpc/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/signal/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/sdk/client/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/sdk/config/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/sdk/react-client/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.3     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/sdk/react-components/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.3     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/sdk/react-framework/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.3     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/sdk/react-registry-client/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.3     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/sdk/registry-client/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.3     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/tutorials/tutorials-tasks-app/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.3     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/wallet/wallet-extension/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/wallet/wallet-playground/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.3     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/common/temp/install-run/@microsoft+rush@5.58.0/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/packages/deprecated/bot/bot-deprecated/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/deprecated/bot/botkit-client-deprecated/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/deprecated/bot/botkit-deprecated/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/deprecated/bot/protocol-plugin-bot-deprecated/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/deprecated/bot/test-bot-deprecated/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/broadcast/example/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/common/temp/pnpm-store/v3/tmp/_tmp_4304_7500bc6e0d800127edcac99c6df01a87/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/common/temp/pnpm-store/v3/tmp/_tmp_4304_b5ed57cd2b5107834abf07899e2b0201/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/common/temp/pnpm-store/v3/tmp/_tmp_4304_ed4504503c8ca159796704d818f319be/package.json

No dependencies.
```



</details>
<details>
<summary><em>npm install -g @microsoft/rush pnpm</em></summary>

```Shell
changed 287 packages, and audited 288 packages in 8s

33 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

### stderr:

```Shell
npm WARN deprecated read-package-tree@5.1.6: The functionality that this package provided is now in @npmcli/arborist
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated @opentelemetry/types@0.2.0: Package renamed to @opentelemetry/api, see https://github.com/open-telemetry/opentelemetry-js
```

</details>
<details>
<summary><em>node common/scripts/install-run-rush.js update</em></summary>

```Shell
The rush.json configuration requests Rush version 5.58.0

Invoking "rush update"
----------------------



Rush Multi-Project Build Tool 5.58.0 - https://rushjs.io
Node.js version is 16.1.0 (pre-LTS)


Starting "rush update"

Trying to acquire lock for pnpm-6.24.2
Acquired lock for pnpm-6.24.2
Found pnpm version 6.24.2 in /home/runner/.rush/node-v16.1.0/pnpm-6.24.2

Symlinking "/home/runner/work/protocols/protocols/common/temp/pnpm-local"
  --> "/home/runner/.rush/node-v16.1.0/pnpm-6.24.2"
Transforming /home/runner/work/protocols/protocols/common/config/rush/.npmrc
  --> "/home/runner/work/protocols/protocols/common/temp/.npmrc"

Updating workspace files in /home/runner/work/protocols/protocols/common/temp
Copying "/home/runner/work/protocols/protocols/common/config/rush/pnpm-lock.yaml"
  --> "/home/runner/work/protocols/protocols/common/temp/pnpm-lock.yaml"
Copying "/home/runner/work/protocols/protocols/common/config/rush/pnpm-lock.yaml"
  --> "/home/runner/work/protocols/protocols/common/temp/pnpm-lock-preinstall.yaml"

The shrinkwrap file contains the following issues:
  Dependencies of project "@dxos/demos" do not match the current shrinkwrap.
  Dependencies of project "@dxos/devtools" do not match the current shrinkwrap.
  Dependencies of project "@dxos/devtools-mesh" do not match the current shrinkwrap.
  Dependencies of project "@dxos/react-client" do not match the current shrinkwrap.
  Dependencies of project "@dxos/react-components" do not match the current shrinkwrap.
  Dependencies of project "@dxos/react-framework" do not match the current shrinkwrap.
  Dependencies of project "@dxos/react-registry-client" do not match the current shrinkwrap.
  Dependencies of project "@dxos/registry-client" do not match the current shrinkwrap.
  Dependencies of project "@dxos/tutorials-tasks-app" do not match the current shrinkwrap.
  Dependencies of project "@dxos/wallet-playground" do not match the current shrinkwrap.


Checking installation in "/home/runner/work/protocols/protocols/common/temp"


Running "pnpm install" in /home/runner/work/protocols/protocols/common/temp

Scope: all 58 workspace projects
Progress: resolved 1, reused 0, downloaded 0, added 0
../../packages/halo/halo-protocol        |  WARN  deprecated @types/expect@24.3.0
.../common/random-access-multi-storage   |  WARN  deprecated @types/expect@24.3.0
../../packages/halo/credentials          |  WARN  deprecated @types/expect@24.3.0
../../packages/mesh/protocol-plugin-rpc  |  WARN  deprecated @types/expect@24.3.0
../../packages/sdk/client                |  WARN  deprecated @types/expect@24.3.0
../../packages/bot/botkit                |  WARN  deprecated @types/expect@24.3.0
Progress: resolved 77, reused 76, downloaded 0, added 0
Progress: resolved 199, reused 120, downloaded 0, added 0
Progress: resolved 368, reused 121, downloaded 0, added 0
Progress: resolved 553, reused 225, downloaded 0, added 0
../../packages/wallet/wallet-extension   |  WARN  deprecated webextension-polyfill-ts@0.25.0
Progress: resolved 609, reused 260, downloaded 0, added 0
Progress: resolved 752, reused 413, downloaded 0, added 0
Progress: resolved 917, reused 863, downloaded 0, added 0
Progress: resolved 1194, reused 1184, downloaded 0, added 0
Progress: resolved 1428, reused 1408, downloaded 0, added 0
Progress: resolved 1692, reused 1673, downloaded 0, added 0
Progress: resolved 1995, reused 1976, downloaded 0, added 0
Progress: resolved 2248, reused 2236, downloaded 0, added 0
Progress: resolved 2551, reused 2539, downloaded 0, added 0
Progress: resolved 2793, reused 2781, downloaded 0, added 0
Progress: resolved 2924, reused 2912, downloaded 0, added 0
Progress: resolved 2924, reused 2912, downloaded 0, added 0, done

Copying "/home/runner/work/protocols/protocols/common/temp/pnpm-lock.yaml"
  --> "/home/runner/work/protocols/protocols/common/config/rush/pnpm-lock.yaml"


Rush update finished successfully. (22.34 seconds)
```

### stderr:

```Shell
Your version of Node.js (16.1.0) is not a Long-Term Support (LTS) release. These versions frequently have bugs. Please consider installing a stable release.
```

</details>
<details>
<summary><em>rm -rf .npmrc</em></summary>



</details>

</details>

## Changed files
<details>
<summary>Changed 11 files: </summary>

- common/config/rush/pnpm-lock.yaml
- packages/demos/package.json
- packages/devtools/devtools-mesh/package.json
- packages/devtools/devtools/package.json
- packages/sdk/react-client/package.json
- packages/sdk/react-components/package.json
- packages/sdk/react-framework/package.json
- packages/sdk/react-registry-client/package.json
- packages/sdk/registry-client/package.json
- packages/tutorials/tutorials-tasks-app/package.json
- packages/wallet/wallet-playground/package.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)