### PR TITLE
fix(react-components): Margin for input in dialog

### DIFF
--- a/packages/sdk/react-components/src/Dialog.tsx
+++ b/packages/sdk/react-components/src/Dialog.tsx
@@ -68,8 +68,8 @@ export const ModalDialog = ({
       <DialogContent
         dividers={dividers}
         sx={{
-          '& .MuiFormControl-root > div:first-of-type': {
-            marginTop: '4px' // Room for first control border.
+          '& .MuiFormControl-root': {
+            marginTop: 1 // Room for first control border.
           }
         }}
       >

--- a/packages/sdk/react-components/stories/Dialog.stories.tsx
+++ b/packages/sdk/react-components/stories/Dialog.stories.tsx
@@ -16,7 +16,7 @@ import {
 import { Dialog, DialogProps } from '../src';
 
 export default {
-  title: 'react-components/CustomizableDialog'
+  title: 'react-components/Dialog'
 };
 
 //
@@ -81,6 +81,7 @@ const useTestDialogState = (initialState = TestState.INIT): [TestDialogState, ()
             <TextField
               fullWidth
               autoFocus
+              label='Name'
               value={value}
               onChange={event => setValue(event.target.value)}
             />
@@ -132,14 +133,7 @@ export const Primary = () => {
     <Box>
       <Button onClick={reset}>Reset</Button>
 
-      <Dialog
-        {...dialogProps}
-        sx={{
-          '.MuiDialog-paper': {
-            minHeight: 200
-          }
-        }}
-      />
+      <Dialog {...dialogProps} />
     </Box>
   );
 };


### PR DESCRIPTION
Before:
![Screenshot from 2022-01-14 14-48-45](https://user-images.githubusercontent.com/4529818/149576510-105bab5e-f9a3-4498-80b1-d487bf777bf4.png)
![Screenshot from 2022-01-14 14-49-05](https://user-images.githubusercontent.com/4529818/149576512-4f418baf-b32c-48a7-a457-d77695320b96.png)
After:
![Screenshot from 2022-01-14 14-49-38](https://user-images.githubusercontent.com/4529818/149576513-c760fe4f-fd38-4f92-8194-939f6242d6b8.png)
![Screenshot from 2022-01-14 14-49-45](https://user-images.githubusercontent.com/4529818/149576515-a701c078-a830-4de2-8ef1-aecc263f7117.png)

Spotted this issue when doing QA on Braneframe.