### PR TITLE
chore: Upgrade DXOS dependencies

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -355,7 +355,7 @@ importers:
       '@dxos/echo-protocol': workspace:*
       '@dxos/echo-testing': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.4
       '@dxos/gem-core': ~1.0.0-beta.25
       '@dxos/gem-spore': ~1.0.0-beta.25
       '@dxos/object-model': workspace:*
@@ -439,7 +439,7 @@ importers:
       '@dxos/async': link:../common/async
       '@dxos/debug': link:../common/debug
       '@dxos/esbuild-plugins': link:../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.4_@types+react@17.0.37
       '@dxos/toolchain-node-library': link:../../toolchains/toolchain-node-library
       '@types/d3': 7.0.0
       '@types/faker': 5.5.9
@@ -654,7 +654,7 @@ importers:
       '@dxos/echo-db': workspace:*
       '@dxos/echo-protocol': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.4
       '@dxos/messenger-model': workspace:*
       '@dxos/model-factory': workspace:*
       '@dxos/network-manager': workspace:*
@@ -718,7 +718,7 @@ importers:
       '@babel/core': 7.13.16
       '@dxos/echo-db': link:../../echo/echo-db
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.4_@types+react@17.0.37
       '@dxos/messenger-model': link:../../echo/messenger-model
       '@dxos/network-manager': link:../../mesh/network-manager
       '@dxos/object-model': link:../../echo/object-model
@@ -831,7 +831,7 @@ importers:
       '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.4
       '@dxos/gem-core': ~1.0.0-beta.25
       '@dxos/gem-spore': ~1.0.0-beta.25
       '@dxos/network-manager': workspace:*
@@ -881,7 +881,7 @@ importers:
       '@babel/core': 7.13.16
       '@babel/plugin-transform-runtime': 7.16.4_@babel+core@7.13.16
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.4_@types+react@17.0.37
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@types/react': 17.0.37
       '@types/react-copy-to-clipboard': 5.0.2
@@ -2027,7 +2027,7 @@ importers:
       '@dxos/debug': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.4
       '@dxos/toolchain-node-library': workspace:*
       '@dxos/util': workspace:*
       '@mui/material': ^5.0.1
@@ -2069,7 +2069,7 @@ importers:
       use-subscription: 1.5.1_react@17.0.2
     devDependencies:
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.4_@types+react@17.0.37
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@mui/material': 5.2.3_5539cae010396b202b015f3568914e95
       '@testing-library/react': 11.2.7_react-dom@17.0.2+react@17.0.2
@@ -2100,7 +2100,7 @@ importers:
       '@dxos/debug': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.4
       '@dxos/react-client': workspace:*
       '@dxos/toolchain-node-library': workspace:*
       '@emotion/react': ^11.4.1
@@ -2147,7 +2147,7 @@ importers:
       '@dxos/client': link:../client
       '@dxos/echo-db': link:../../echo/echo-db
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.4_@types+react@17.0.37
       '@dxos/react-client': link:../react-client
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@emotion/react': 11.7.1_c8f47004f4d29cd7909f1411b83f7eb5
@@ -2183,7 +2183,7 @@ importers:
       '@dxos/debug': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.4
       '@dxos/object-model': workspace:*
       '@dxos/react-client': workspace:*
       '@dxos/react-components': workspace:*
@@ -2238,7 +2238,7 @@ importers:
       '@dxos/credentials': link:../../halo/credentials
       '@dxos/echo-db': link:../../echo/echo-db
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.4_@types+react@17.0.37
       '@dxos/object-model': link:../../echo/object-model
       '@dxos/react-client': link:../react-client
       '@dxos/react-components': link:../react-components
@@ -2269,7 +2269,7 @@ importers:
       '@dxos/codec-protobuf': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.4
       '@dxos/registry-client': workspace:*
       '@dxos/toolchain-node-library': workspace:*
       '@dxos/util': workspace:*
@@ -2294,7 +2294,7 @@ importers:
       '@babel/core': 7.13.16
       '@dxos/codec-protobuf': link:../../common/codec-protobuf
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.4_@types+react@17.0.37
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@types/debug': 4.1.7
       '@types/lodash': 4.14.178
@@ -2312,7 +2312,7 @@ importers:
       '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.4
       '@dxos/toolchain-node-library': workspace:*
       '@dxos/util': workspace:*
       '@polkadot/api': 4.17.1
@@ -2358,7 +2358,7 @@ importers:
       protobufjs: 6.11.2
     devDependencies:
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2
+      '@dxos/esbuild-server': 1.7.4
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@polkadot/typegen': 4.17.1
       '@types/chai': 4.3.0
@@ -2381,7 +2381,7 @@ importers:
       '@dxos/crypto': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.4
       '@dxos/object-model': workspace:*
       '@dxos/react-client': workspace:*
       '@dxos/react-components': workspace:*
@@ -2430,7 +2430,7 @@ importers:
     devDependencies:
       '@babel/core': 7.13.16
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.4_@types+react@17.0.37
       '@types/mocha': 8.2.3
       '@types/node': 14.18.0
       '@types/react': 17.0.37
@@ -2537,7 +2537,7 @@ importers:
       '@dxos/config': workspace:*
       '@dxos/crypto': workspace:*
       '@dxos/esbuild-plugins': workspace:*
-      '@dxos/esbuild-server': ~1.7.2
+      '@dxos/esbuild-server': ~1.7.4
       '@dxos/react-client': workspace:*
       '@dxos/react-components': workspace:*
       '@dxos/react-framework': workspace:*
@@ -2562,7 +2562,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@dxos/esbuild-plugins': link:../../../toolchains/esbuild-plugins
-      '@dxos/esbuild-server': 1.7.2_@types+react@17.0.37
+      '@dxos/esbuild-server': 1.7.4_@types+react@17.0.37
       '@dxos/toolchain-node-library': link:../../../toolchains/toolchain-node-library
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
@@ -5162,15 +5162,14 @@ packages:
       - webpack-command
     dev: true
 
-  /@dxos/esbuild-server/1.7.2:
-    resolution: {integrity: sha512-wuo9Fn/4ykGt+45HUVoP4y7W9hytJySzvqIIlnZ47LUe0xxEFvr1mNlCVDvEebuqxB83u2n7XV13t2vAB+y4qQ==}
+  /@dxos/esbuild-server/1.7.4:
+    resolution: {integrity: sha512-YfKir/tsFtO9FeK/MJiQGi0NzEX9sHtF9fbkOAJltJDv07Gbb/Ny3ktnsvIPezO7GWqfsMMq0c83jLeUioAwMg==}
     hasBin: true
     dependencies:
       '@babel/core': 7.16.5
       '@mdx-js/esbuild': 2.0.0-rc.1_esbuild@0.12.29
       '@mdx-js/mdx': 2.0.0-rc.2
       '@mdx-js/react': 2.0.0-rc.2_react@17.0.2
-      '@styled-icons/material-outlined': 10.34.0_c17876e09d792e0c7b0f44e49f814625
       chalk: 4.1.2
       esbuild: 0.12.29
       glob: 7.2.0
@@ -5183,7 +5182,6 @@ packages:
       react-syntax-highlighter: 15.4.5_react@17.0.2
       rehype-highlight: 5.0.1
       styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-      styled-icons: 10.45.0_c17876e09d792e0c7b0f44e49f814625
       theme-ui: 0.12.1_@babel+core@7.16.5+react@17.0.2
       yargs: 17.3.0
     transitivePeerDependencies:
@@ -5191,15 +5189,14 @@ packages:
       - supports-color
     dev: true
 
-  /@dxos/esbuild-server/1.7.2_@types+react@17.0.37:
-    resolution: {integrity: sha512-wuo9Fn/4ykGt+45HUVoP4y7W9hytJySzvqIIlnZ47LUe0xxEFvr1mNlCVDvEebuqxB83u2n7XV13t2vAB+y4qQ==}
+  /@dxos/esbuild-server/1.7.4_@types+react@17.0.37:
+    resolution: {integrity: sha512-YfKir/tsFtO9FeK/MJiQGi0NzEX9sHtF9fbkOAJltJDv07Gbb/Ny3ktnsvIPezO7GWqfsMMq0c83jLeUioAwMg==}
     hasBin: true
     dependencies:
       '@babel/core': 7.16.5
       '@mdx-js/esbuild': 2.0.0-rc.1_esbuild@0.12.29
       '@mdx-js/mdx': 2.0.0-rc.2
       '@mdx-js/react': 2.0.0-rc.2_react@17.0.2
-      '@styled-icons/material-outlined': 10.34.0_c17876e09d792e0c7b0f44e49f814625
       chalk: 4.1.2
       esbuild: 0.12.29
       glob: 7.2.0
@@ -5212,7 +5209,6 @@ packages:
       react-syntax-highlighter: 15.4.5_react@17.0.2
       rehype-highlight: 5.0.1
       styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-      styled-icons: 10.45.0_c17876e09d792e0c7b0f44e49f814625
       theme-ui: 0.12.1_23551ae5df81be1ad77d4e4acd306532
       yargs: 17.3.0
     transitivePeerDependencies:
@@ -6944,450 +6940,6 @@ packages:
     resolution: {integrity: sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==}
     dependencies:
       '@sinonjs/commons': 1.8.3
-
-  /@styled-icons/bootstrap/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-UpzdVUR7r9BNqEfPrMchJdgMZEg9eXQxLQJUXM0ouvbI5o9j21/y1dGameO4PZtYbutT/dWv5O6y24z5JWzd5w==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/boxicons-logos/10.38.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-DpkUi9qV76RsyuzihQhfCho142WCxK/2oUfjcqo6BsP92qxV+4rtS5nfVsmqfnSEef4av+qSeg33fJWDyURyKg==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/boxicons-regular/10.38.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-xjhafoa0/EeYtQOyTw+ohuSlBx599t8l8++JH1tQlM0l73dP4icTpF4znYL+HhZeaUe3D+UhrkfWuBBua2w2Qw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/boxicons-solid/10.38.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-uuMtF1R61smQT5r6HIYMHvpVD0XSErXXNQYl5d6lCtMyefd0gIE5Rw+iD9i/RxHFUHNHbvL69LvitCLtNWrSqw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/crypto/10.38.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-SOfJFfofCOgExaRB0u3AA7Fdv2vbFIxtCAmyNDdjqvnTncg4HVPEg5+rysN3oHGiJBF8+uqUdtLerx3rmhYI7g==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/entypo-social/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-amhrYcc/buvTJrunRnYNeFNJ5Ru1ByV/pcICj7An9TF/NNC4exfnzaoUzOJNcMGOHU5jphrqjSosC4pQNJKqkA==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/entypo/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-9hl109HydOfi/q9ceqoI9Bmj5tv1v/RoUY2nbuGuVtKDVNCVw7WQ0eTiZkb1OgiVYsJXs6xQBcNZdVeo4en/lQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/evaicons-outline/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-ONPKJO+u3DB/rsCJdIKt6OBoKBvIvM/EsulxuWniRPPr0rR5lwueGocJpJmEUi+C4gsMllBSkcL5cOdFyd1Nbw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/evaicons-solid/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-74S0zzxovKTXNpID8bXB4Qy34EBq3vuVAlTd9xsT2gY16BtPH7JcGHLmtQpbpJcHuWkcQH4bSv+GLq+0/i/ljQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/evil/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-rU5MrgMow9I0Vkqo6V5WkTcj0o1toDzn8kQSQywTL1N7JuyATKZgN3kgkzNUgHd5LorcsGMetPsvDmgS31XAPw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/fa-brands/10.38.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-zZzGkcshXIF55geFIpMzMLH6tSPzQeeFPFZ1RMrZ3TWBjUuquMx+vYFsO7kzq939X84gLjmpkJZsAP9QKJFvMg==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/fa-regular/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-QUqljT+uIfowGurV5GzjnHA1qvq922H+6yGRzQYBxBZ5Vgaak4Q71jtCSMqZKXcOG3tngMyhrOuaNaPOw1Q1pQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/fa-solid/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-PnJMUPcbuPA7gswxl9FKd725qaqP5VSbmX7rk+ZZ7ivdA6Dbi1VoKYXqAc62OEisGDhzn5g56KbBvE14W1n7vw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/feather/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-UdhKaUC8T98V5H4WEh+UBRfVT7ZTcPpgUUrXlRM2CWanuNIUKpIjj0SKhsnkuprqtzV1L6s3Koa40VTfpG9LYQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/fluentui-system-filled/10.35.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-uupqp8u2FdnpOhVPAIAVb9Ax8p6Yu/ZDsRq3XUHhDd0e4Mb1e2KIXorwg1sRfR+PHCvWLbu6knIt17Az1OlmHQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/fluentui-system-regular/10.35.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-DHZRTLw6tGkmG6EOo46iHsta6xx+Gd71iHEg5GTVTsoUtk2ZFHL1GRW9KPnkcPPB6h3/QQE4c36MyHFPvPfjzA==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/foundation/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-RJksGQoStOqVQegwvtDTqrhEQjc7x5izqzBuwMw6R+18XcBC+pP8oRtuisv2ogn5icVrN/FWQHMx8EJ14jMdig==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/heroicons-outline/10.36.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-1IcNp8rjPetb5IMvSzCgh1/QDsz7brzMKv6AEbchByKM6oyOsv9p2PapGMRs6L5rH3LDGzouxNSYPUES8aY3Vw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/heroicons-solid/10.36.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-cbC0roQSwvrw+ryVx1MfK3NAxh5CyOCzJwFgwZTuXsYpk7IVNNFFSRn1uRGaFDHn3aLLEikMkxxR4q5NM07ZpA==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/icomoon/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-nimtxPqlA6K2iNDeGCCYrFvPbjJl2TwM+YtX55RYC3YJFrh+MeKL+F60uvzoKWY3vZ1vsmQR3iW+aRFQHvhIOw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/ionicons-outline/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-8zLCIizxxKAA8tpJLmEnfXy+NcWW7CIxaqDQPZ/GEri4f6GA4QEf4BxCz+XXfEBoBthj+cPr/3d8oB7YygC5TQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/ionicons-sharp/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-2vmb5xa0fNDWe6QoKsfATilv9Qvlnv4z/3m1NMY+tU5ER+Z9YvPQkLcRqeS/dpm4HHfRAlGsVX5A8r8B+rPnag==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/ionicons-solid/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-gp85y8VbxhBUx0xP3eokyxIkAiWkSaJO3kN1/mGfCSKcWllLBhoHikyGjWAxFPMunhzix4PM0tVudWrsSxmLeQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/material-outlined/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-scn3Ih15t82rUJPI9vwnZaYL6ZiDhlYoashIJAs8c8QjJfK0rWdt+hr3E6/0wixx67BkLB3j96Jn9y+qXfVVIQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/material-rounded/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-Y2QB3bz+tDmrtcgNXKIPnw8xqarObpcFxOapkP3pMDGl+guCgV5jNHrE8xTKyN5lYYQmm9oBZ5odwgT3B+Uw5g==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/material-sharp/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-XY1N68Tj5TyyAHJDQwYtasKis4xuNl5xjbISdz8zreWlsY5N4nO4rh/SgAUYvblz+Xjf4P+JZAF22foVpZwIeg==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/material-twotone/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-o5EwR1WdjUwNebFAWqIiZwbP1ibOPy8vHX0KdkV0WDZTCXDW5Nhj3C5JeTAwPeRtFU+Bxt7NHjUmrsm3jNRzzw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/material/10.34.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-BQCyzAN0RhkpI6mpIP7RvUoZOZ15d5opKfQRqQXVOfKD3Dkyi26Uog1KTuaaa/MqtqrWaYXC6Y1ypanvfpyL2g==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/octicons/10.44.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-7pLWrUDkc/acwJ4ayL+Xmb7o1j5WUB6nI5dATRPzcm2CENUdEEyf17uL1J9qwB5aFoyDpo7c/UYWtq5QpGpk6A==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/open-iconic/10.18.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-H+uiRUDm09SXlOgJheOmhT0KeLs5uBS85H2VF1ypMN1m/vy/NdaGP5QAvWTCzBk088JJGYEkvhb4i4pGcwRsEA==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/remix-editor/10.33.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-V1jZ3G1J8PaBiIwf2Va7UuEXot8xR39UQ3XNIJNQClnGA04ahTsEC2mpN5pHwr4mkJijXu0Htjhnf/YiWYVsCw==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/remix-fill/10.18.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-FbnQMvxt2R7CYb8j/dVAXd31CDg4k3vX1zG/9GH9qpL536yxndnyopa7hwF/Yisy2pzR7uNlNXmTQAmYK2HSrg==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/remix-line/10.18.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-UZllhk6hEWFyZt+jdPCO4zbeM0P3Y/Lc1iWWOwUXGP5AzStM2KadjaGpi99FhNfrvrly98cVB8b4M/GVExYn0Q==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/simple-icons/10.45.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-2agGgrxuiBjicbz5kgF1M691oNfRUYwSWy80kqJCEGXyJ9YGtLWXTSNdLYMk0Dt4JnL0/3eKItU9jYf24rCcJg==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/styled-icon/10.6.3_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-/A95L3peioLoWFiy+/eKRhoQ9r/oRrN/qzbSX4hXU1nGP2rUXcX3LWUhoBNAOp9Rw38ucc/4ralY427UUNtcGQ==}
-    peerDependencies:
-      react: '*'
-      styled-components: '>=4.1.0 <6'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@emotion/is-prop-valid': 0.8.8
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/typicons/10.18.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-VN9vEzeAn5//uUvBN2N/OAXnrC6zCERu1eXUiXmYTwd7n8ZoMMASKmVWrAho20YmhUjEPZdSvS1cJ/pzV9K6Zg==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
-
-  /@styled-icons/zondicons/10.18.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-P+XDzHRjY7zgcOYI22VJPg4GW01760VICwMSF2vJFRd0bux3hKIJI8voABA9v00Ce1TeOZnUbKcgQFBNIThs5w==}
-    peerDependencies:
-      react: '*'
-      styled-components: '*'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
-    dev: true
 
   /@styled-system/background/5.1.2:
     resolution: {integrity: sha512-jtwH2C/U6ssuGSvwTN3ri/IyjdHb8W9X/g8Y0JLcrH02G+BW3OS8kZdHphF1/YyRklnrKrBT2ngwGUK6aqqV3A==}
@@ -23909,54 +23461,6 @@ packages:
       react-is: 17.0.2
       shallowequal: 1.1.0
       supports-color: 5.5.0
-    dev: true
-
-  /styled-icons/10.45.0_c17876e09d792e0c7b0f44e49f814625:
-    resolution: {integrity: sha512-oUsAAr95m+IPS3JxExaxdxoVA6FIqTPEykebMe7h7rkD6X5JS5K37kg4HlWJOcpMznL0Vj3GW6S5LF1qqUwN7Q==}
-    peerDependencies:
-      react: '*'
-      styled-components: '>=4.1.0 <6'
-    dependencies:
-      '@babel/runtime': 7.16.3
-      '@styled-icons/bootstrap': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/boxicons-logos': 10.38.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/boxicons-regular': 10.38.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/boxicons-solid': 10.38.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/crypto': 10.38.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/entypo': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/entypo-social': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/evaicons-outline': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/evaicons-solid': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/evil': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/fa-brands': 10.38.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/fa-regular': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/fa-solid': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/feather': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/fluentui-system-filled': 10.35.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/fluentui-system-regular': 10.35.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/foundation': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/heroicons-outline': 10.36.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/heroicons-solid': 10.36.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/icomoon': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/ionicons-outline': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/ionicons-sharp': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/ionicons-solid': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/material': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/material-outlined': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/material-rounded': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/material-sharp': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/material-twotone': 10.34.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/octicons': 10.44.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/open-iconic': 10.18.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/remix-editor': 10.33.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/remix-fill': 10.18.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/remix-line': 10.18.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/simple-icons': 10.45.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/styled-icon': 10.6.3_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/typicons': 10.18.0_c17876e09d792e0c7b0f44e49f814625
-      '@styled-icons/zondicons': 10.18.0_c17876e09d792e0c7b0f44e49f814625
-      react: 17.0.2
-      styled-components: 5.3.3_281a4fa50a045c9112baf635f3bc27a7
     dev: true
 
   /styled-system/5.1.5:

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -65,7 +65,7 @@
     "@dxos/async": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.4",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/d3": "~7.0.0",
     "@types/faker": "^5.5.1",

--- a/packages/devtools/devtools-mesh/package.json
+++ b/packages/devtools/devtools-mesh/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "~7.13.15",
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.4",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/react": "^17.0.24",
     "@types/react-copy-to-clipboard": "~5.0.1",

--- a/packages/devtools/devtools/package.json
+++ b/packages/devtools/devtools/package.json
@@ -48,7 +48,7 @@
     "@babel/core": "~7.13.15",
     "@dxos/echo-db": "workspace:*",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.4",
     "@dxos/messenger-model": "workspace:*",
     "@dxos/network-manager": "workspace:*",
     "@dxos/object-model": "workspace:*",

--- a/packages/sdk/react-client/package.json
+++ b/packages/sdk/react-client/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.4",
     "@dxos/toolchain-node-library": "workspace:*",
     "@mui/material": "^5.0.1",
     "@testing-library/react": "^11.0.4",

--- a/packages/sdk/react-components/package.json
+++ b/packages/sdk/react-components/package.json
@@ -37,7 +37,7 @@
     "@dxos/client": "workspace:*",
     "@dxos/echo-db": "workspace:*",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.4",
     "@dxos/react-client": "workspace:*",
     "@dxos/toolchain-node-library": "workspace:*",
     "@emotion/react": "^11.4.1",

--- a/packages/sdk/react-framework/package.json
+++ b/packages/sdk/react-framework/package.json
@@ -42,7 +42,7 @@
     "@dxos/credentials": "workspace:*",
     "@dxos/echo-db": "workspace:*",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.4",
     "@dxos/object-model": "workspace:*",
     "@dxos/react-client": "workspace:*",
     "@dxos/react-components": "workspace:*",

--- a/packages/sdk/react-registry-client/package.json
+++ b/packages/sdk/react-registry-client/package.json
@@ -25,7 +25,7 @@
     "@babel/core": "~7.13.15",
     "@dxos/codec-protobuf": "workspace:*",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.4",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/debug": "^4.1.7",
     "@types/lodash": "^4.14.175",

--- a/packages/sdk/registry-client/package.json
+++ b/packages/sdk/registry-client/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.4",
     "@dxos/toolchain-node-library": "workspace:*",
     "@polkadot/typegen": "^4.17.1",
     "@types/chai": "^4.2.15",

--- a/packages/tutorials/tutorials-tasks-app/package.json
+++ b/packages/tutorials/tutorials-tasks-app/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@babel/core": "~7.13.15",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.4",
     "@types/mocha": "~8.2.2",
     "@types/node": "^14.0.9",
     "@types/react": "^17.0.24",

--- a/packages/wallet/wallet-playground/package.json
+++ b/packages/wallet/wallet-playground/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~1.7.2",
+    "@dxos/esbuild-server": "~1.7.4",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc</em></summary>



</details>
<details>
<summary><em>sudo ./common/scripts/install-dependencies.sh</em></summary>

```Shell
Hit:1 http://azure.archive.ubuntu.com/ubuntu focal InRelease
Get:2 http://azure.archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
Get:4 https://packages.microsoft.com/ubuntu/20.04/prod focal InRelease [10.5 kB]
Get:5 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Hit:6 http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal InRelease
Get:7 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [1469 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 c-n-f Metadata [14.7 kB]
Get:9 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [892 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe Translation-en [196 kB]
Get:11 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 c-n-f Metadata [20.0 kB]
Get:12 https://packages.microsoft.com/ubuntu/20.04/prod focal/main amd64 Packages [122 kB]
Get:13 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [1135 kB]
Get:14 http://security.ubuntu.com/ubuntu focal-security/main amd64 c-n-f Metadata [9104 B]
Get:15 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [675 kB]
Get:16 http://security.ubuntu.com/ubuntu focal-security/universe amd64 c-n-f Metadata [13.0 kB]
Fetched 4892 kB in 1s (3576 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
autoconf is already the newest version (2.69-11.1).
autoconf set to manually installed.
automake is already the newest version (1:1.16.1-4ubuntu6).
automake set to manually installed.
g++ is already the newest version (4:9.3.0-1ubuntu2).
g++ set to manually installed.
libpng-dev is already the newest version (1.6.37-2).
libpng-dev set to manually installed.
libtool is already the newest version (2.4.6-14).
libtool set to manually installed.
make is already the newest version (4.2.1-1.2).
make set to manually installed.
libx11-dev is already the newest version (2:1.6.9-2ubuntu1.2).
libx11-dev set to manually installed.
jq is already the newest version (1.6-1ubuntu0.20.04.1).
The following additional packages will be installed:
  libxfixes-dev libxi-dev x11proto-input-dev x11proto-record-dev
The following NEW packages will be installed:
  libxfixes-dev libxi-dev libxtst-dev x11proto-input-dev x11proto-record-dev
0 upgraded, 5 newly installed, 0 to remove and 28 not upgraded.
Need to get 219 kB of archives.
After this operation, 876 kB of additional disk space will be used.
Get:1 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libxfixes-dev amd64 1:5.0.3-2 [11.4 kB]
Get:2 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 x11proto-input-dev all 2019.2-1ubuntu1 [2628 B]
Get:3 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libxi-dev amd64 2:1.7.10-0ubuntu1 [187 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 x11proto-record-dev all 2019.2-1ubuntu1 [2624 B]
Get:5 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libxtst-dev amd64 2:1.2.3-1 [15.2 kB]
Fetched 219 kB in 0s (2010 kB/s)
Selecting previously unselected package libxfixes-dev:amd64.
(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 235035 files and directories currently installed.)
Preparing to unpack .../libxfixes-dev_1%3a5.0.3-2_amd64.deb ...
Unpacking libxfixes-dev:amd64 (1:5.0.3-2) ...
Selecting previously unselected package x11proto-input-dev.
Preparing to unpack .../x11proto-input-dev_2019.2-1ubuntu1_all.deb ...
Unpacking x11proto-input-dev (2019.2-1ubuntu1) ...
Selecting previously unselected package libxi-dev:amd64.
Preparing to unpack .../libxi-dev_2%3a1.7.10-0ubuntu1_amd64.deb ...
Unpacking libxi-dev:amd64 (2:1.7.10-0ubuntu1) ...
Selecting previously unselected package x11proto-record-dev.
Preparing to unpack .../x11proto-record-dev_2019.2-1ubuntu1_all.deb ...
Unpacking x11proto-record-dev (2019.2-1ubuntu1) ...
Selecting previously unselected package libxtst-dev:amd64.
Preparing to unpack .../libxtst-dev_2%3a1.2.3-1_amd64.deb ...
Unpacking libxtst-dev:amd64 (2:1.2.3-1) ...
Setting up libxfixes-dev:amd64 (1:5.0.3-2) ...
Setting up x11proto-input-dev (2019.2-1ubuntu1) ...
Setting up x11proto-record-dev (2019.2-1ubuntu1) ...
Setting up libxi-dev:amd64 (2:1.7.10-0ubuntu1) ...
Setting up libxtst-dev:amd64 (2:1.2.3-1) ...
Processing triggers for man-db (2.9.1-1) ...
Reading package lists...
Building dependency tree...
Reading state information...
lsof is already the newest version (4.93.2+dfsg-1ubuntu0.20.04.1).
lsof set to manually installed.
The following additional packages will be installed:
  enchant gstreamer1.0-plugins-base i965-va-driver intel-media-va-driver
  libaacs0 libaom0 libass9 libasyncns0 libavcodec58 libavfilter7 libavformat58
  libavutil56 libbdplus0 libbluray2 libbs2b0 libcdparanoia0 libchromaprint1
  libcodec2-0.9 libdc1394-22 libdca0 libde265-0 libdvdnav4 libdvdread7
  libfaad2 libflac8 libflite1 libfluidsynth2 libgme0 libgsm1 libgssdp-1.2-0
  libgstreamer-plugins-bad1.0-0 libgstreamer-plugins-base1.0-0
  libgstreamer-plugins-good1.0-0 libgupnp-1.2-0 libgupnp-igd-1.0-4 libigdgmm11
  libinstpatch-1.0-2 libjack-jackd2-0 libkate1 liblilv-0-0 libmjpegutils-2.1-0
  libmodplug1 libmp3lame0 libmpcdec6 libmpeg2encpp-2.1-0 libmpg123-0
  libmplex2-2.1-0 libmysofa1 libnice10 libofa0 libopenal-data libopenal1
  libopenjp2-7 libopenmpt0 libopus0 liborc-0.4-0 libpostproc55 libpulse0
  libraw1394-11 librubberband2 libsamplerate0 libsbc1 libsdl2-2.0-0
  libserd-0-0 libshine3 libsndfile1 libsndio7.0 libsord-0-0 libsoundtouch1
  libsoxr0 libspandsp2 libspeex1 libsratom-0-0 libsrt1 libsrtp2-1
  libssh-gcrypt-4 libswresample3 libswscale5 libtheora0 libtwolame0
  libusrsctp1 libv4l-0 libv4lconvert0 libva-drm2 libva-x11-2 libva2 libvdpau1
  libvidstab1.1 libvisual-0.4-0 libvo-aacenc0 libvo-amrwbenc0 libvorbisenc2
  libwavpack1 libwebrtc-audio-processing1 libwildmidi2 libx264-155 libx265-179
  libxvidcore4 libzbar0 libzvbi-common libzvbi0 mesa-va-drivers
  mesa-vdpau-drivers ocl-icd-libopencl1 timgm6mb-soundfont va-driver-all
  vdpau-driver-all
Suggested packages:
  frei0r-plugins gvfs i965-va-driver-shaders libbluray-bdj libdvdcss2
  libenchant-voikko libvisual-0.4-plugins jackd2 libportaudio2 opus-tools
  pulseaudio libraw1394-doc serdi sndiod sordi speex libwildmidi-config
  opencl-icd fluid-soundfont-gm fluidsynth timidity musescore libvdpau-va-gl1
  nvidia-vdpau-driver nvidia-legacy-340xx-vdpau-driver
  nvidia-legacy-304xx-vdpau-driver
The following NEW packages will be installed:
  enchant gstreamer1.0-libav gstreamer1.0-plugins-bad
  gstreamer1.0-plugins-base i965-va-driver intel-media-va-driver libaacs0
  libaom0 libass9 libasyncns0 libavcodec58 libavfilter7 libavformat58
  libavutil56 libbdplus0 libbluray2 libbs2b0 libcdparanoia0 libchromaprint1
  libcodec2-0.9 libdc1394-22 libdca0 libde265-0 libdvdnav4 libdvdread7
  libenchant1c2a libfaad2 libflac8 libflite1 libfluidsynth2 libgme0 libgsm1
  libgssdp-1.2-0 libgstreamer-plugins-bad1.0-0 libgstreamer-plugins-base1.0-0
  libgstreamer-plugins-good1.0-0 libgupnp-1.2-0 libgupnp-igd-1.0-4 libigdgmm11
  libinstpatch-1.0-2 libjack-jackd2-0 libkate1 liblilv-0-0 libmjpegutils-2.1-0
  libmodplug1 libmp3lame0 libmpcdec6 libmpeg2encpp-2.1-0 libmpg123-0
  libmplex2-2.1-0 libmysofa1 libnice10 libofa0 libopenal-data libopenal1
  libopenjp2-7 libopenmpt0 libopus0 liborc-0.4-0 libpostproc55 libpulse0
  libraw1394-11 librubberband2 libsamplerate0 libsbc1 libsdl2-2.0-0
  libserd-0-0 libshine3 libsndfile1 libsndio7.0 libsord-0-0 libsoundtouch1
  libsoxr0 libspandsp2 libspeex1 libsratom-0-0 libsrt1 libsrtp2-1
  libssh-gcrypt-4 libswresample3 libswscale5 libtheora0 libtwolame0
  libusrsctp1 libv4l-0 libv4lconvert0 libva-drm2 libva-x11-2 libva2 libvdpau1
  libvidstab1.1 libvisual-0.4-0 libvo-aacenc0 libvo-amrwbenc0 libvorbisenc2
  libwavpack1 libwebrtc-audio-processing1 libwildmidi2 libx264-155 libx265-179
  libxvidcore4 libzbar0 libzvbi-common libzvbi0 mesa-va-drivers
  mesa-vdpau-drivers ocl-icd-libopencl1 timgm6mb-soundfont va-driver-all
  vdpau-driver-all
0 upgraded, 110 newly installed, 0 to remove and 28 not upgraded.
Need to get 58.4 MB of archives.
After this operation, 230 MB of additional disk space will be used.
Get:1 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libenchant1c2a amd64 1.6.0-11.3build1 [64.7 kB]
Get:2 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 enchant amd64 1.6.0-11.3build1 [12.4 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libaom0 amd64 1.0.0.errata1-3build1 [1160 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libva2 amd64 2.7.0-2 [53.5 kB]
Get:5 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libva-drm2 amd64 2.7.0-2 [7044 B]
Get:6 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libva-x11-2 amd64 2.7.0-2 [11.9 kB]
Get:7 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libvdpau1 amd64 1.3-1ubuntu2 [25.6 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 ocl-icd-libopencl1 amd64 2.2.11-1ubuntu1 [30.3 kB]
Get:9 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 libavutil56 amd64 7:4.2.4-1ubuntu0.1 [241 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libcodec2-0.9 amd64 0.9.2-2 [7886 kB]
Get:11 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libgsm1 amd64 1.0.18-2 [24.4 kB]
Get:12 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libmp3lame0 amd64 3.100-3 [133 kB]
Get:13 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libopenjp2-7 amd64 2.3.1-1ubuntu4.20.04.1 [141 kB]
Get:14 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libopus0 amd64 1.3.1-0ubuntu1 [191 kB]
Get:15 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libshine3 amd64 3.1.1-2 [23.2 kB]
Get:16 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libspeex1 amd64 1.2~rc1.2-1.1ubuntu1 [53.2 kB]
Get:17 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libsoxr0 amd64 0.1.3-2build1 [78.0 kB]
Get:18 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 libswresample3 amd64 7:4.2.4-1ubuntu0.1 [57.1 kB]
Get:19 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libtheora0 amd64 1.1.1+dfsg.1-15ubuntu2 [162 kB]
Get:20 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libtwolame0 amd64 0.4.0-2 [47.6 kB]
Get:21 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libvorbisenc2 amd64 1.3.6-2ubuntu1 [70.7 kB]
Get:22 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libwavpack1 amd64 5.2.0-1ubuntu0.1 [77.3 kB]
Get:23 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libx264-155 amd64 2:0.155.2917+git0a84d98-2 [521 kB]
Get:24 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libx265-179 amd64 3.2.1-1build1 [1060 kB]
Get:25 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libxvidcore4 amd64 2:1.3.7-1 [201 kB]
Get:26 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libzvbi-common all 0.2.35-17 [32.5 kB]
Get:27 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libzvbi0 amd64 0.2.35-17 [237 kB]
Get:28 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 libavcodec58 amd64 7:4.2.4-1ubuntu0.1 [4876 kB]
Get:29 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libass9 amd64 1:0.14.0-2 [88.0 kB]
Get:30 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libbluray2 amd64 1:1.2.0-1 [138 kB]
Get:31 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libchromaprint1 amd64 1.4.3-3build1 [37.6 kB]
Get:32 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libgme0 amd64 0.6.2-1build1 [123 kB]
Get:33 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libmpg123-0 amd64 1.25.13-1 [124 kB]
Get:34 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libopenmpt0 amd64 0.4.11-1build1 [599 kB]
Get:35 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libssh-gcrypt-4 amd64 0.9.3-2ubuntu2.2 [202 kB]
Get:36 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 libavformat58 amd64 7:4.2.4-1ubuntu0.1 [981 kB]
Get:37 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libbs2b0 amd64 3.1.0+dfsg-2.2build1 [10.2 kB]
Get:38 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libflite1 amd64 2.1-release-3 [12.8 MB]
Get:39 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libserd-0-0 amd64 0.30.2-1 [46.6 kB]
Get:40 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libsord-0-0 amd64 0.16.4-1 [19.5 kB]
Get:41 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libsratom-0-0 amd64 0.6.4-1 [16.9 kB]
Get:42 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 liblilv-0-0 amd64 0.24.6-1ubuntu0.1 [40.6 kB]
Get:43 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libmysofa1 amd64 1.0~dfsg0-1 [39.2 kB]
Get:44 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 libpostproc55 amd64 7:4.2.4-1ubuntu0.1 [55.3 kB]
Get:45 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libsamplerate0 amd64 0.1.9-2 [939 kB]
Get:46 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 librubberband2 amd64 1.8.2-1build1 [89.4 kB]
Get:47 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 libswscale5 amd64 7:4.2.4-1ubuntu0.1 [156 kB]
Get:48 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libvidstab1.1 amd64 1.1.0-2 [35.0 kB]
Get:49 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 libavfilter7 amd64 7:4.2.4-1ubuntu0.1 [1084 kB]
Get:50 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 liborc-0.4-0 amd64 1:0.4.31-1 [188 kB]
Get:51 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libgstreamer-plugins-base1.0-0 amd64 1.16.2-4ubuntu0.1 [735 kB]
Get:52 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 gstreamer1.0-libav amd64 1.16.2-2 [123 kB]
Get:53 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libcdparanoia0 amd64 3.10.2+debian-13 [46.7 kB]
Get:54 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libvisual-0.4-0 amd64 0.4.0-17 [99.8 kB]
Get:55 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 gstreamer1.0-plugins-base amd64 1.16.2-4ubuntu0.1 [620 kB]
Get:56 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libigdgmm11 amd64 20.1.1+ds1-1 [111 kB]
Get:57 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 intel-media-va-driver amd64 20.1.1+dfsg1-1 [1764 kB]
Get:58 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libaacs0 amd64 0.9.0-2 [50.1 kB]
Get:59 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libasyncns0 amd64 0.8-6 [12.1 kB]
Get:60 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libbdplus0 amd64 0.1.2-3 [47.3 kB]
Get:61 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libde265-0 amd64 1.0.4-1build1 [239 kB]
Get:62 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libdvdread7 amd64 6.1.0+really6.0.2-1 [49.9 kB]
Get:63 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libdvdnav4 amd64 6.0.1-1build1 [39.0 kB]
Get:64 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libfaad2 amd64 2.9.1-1 [154 kB]
Get:65 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libflac8 amd64 1.3.3-1build1 [103 kB]
Get:66 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libsndfile1 amd64 1.0.28-7ubuntu0.1 [170 kB]
Get:67 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libinstpatch-1.0-2 amd64 1.1.2-2build1 [238 kB]
Get:68 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libjack-jackd2-0 amd64 1.9.12~dfsg-2ubuntu2 [267 kB]
Get:69 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libpulse0 amd64 1:13.99.1-1ubuntu3.13 [262 kB]
Get:70 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libsdl2-2.0-0 amd64 2.0.10+dfsg1-3 [407 kB]
Get:71 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 timgm6mb-soundfont all 1.3-3 [5420 kB]
Get:72 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libfluidsynth2 amd64 2.1.1-2 [198 kB]
Get:73 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libgssdp-1.2-0 amd64 1.2.3-0ubuntu0.20.04.1 [37.1 kB]
Get:74 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libgupnp-1.2-0 amd64 1.2.4-0ubuntu1 [81.3 kB]
Get:75 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libgupnp-igd-1.0-4 amd64 0.2.5-5 [14.8 kB]
Get:76 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libkate1 amd64 0.4.1-11build1 [39.4 kB]
Get:77 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libmjpegutils-2.1-0 amd64 1:2.1.0+debian-6build1 [24.1 kB]
Get:78 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libmodplug1 amd64 1:0.8.9.0-2build1 [150 kB]
Get:79 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libmpcdec6 amd64 2:0.1~r495-2 [32.4 kB]
Get:80 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libmpeg2encpp-2.1-0 amd64 1:2.1.0+debian-6build1 [69.4 kB]
Get:81 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libmplex2-2.1-0 amd64 1:2.1.0+debian-6build1 [44.4 kB]
Get:82 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libnice10 amd64 0.1.16-1 [136 kB]
Get:83 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libofa0 amd64 0.9.3-21 [49.6 kB]
Get:84 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libopenal-data all 1:1.19.1-1 [162 kB]
Get:85 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libraw1394-11 amd64 2.1.2-1 [30.7 kB]
Get:86 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libsndio7.0 amd64 1.5.0-3 [24.5 kB]
Get:87 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libsoundtouch1 amd64 2.1.2+ds1-1build1 [30.4 kB]
Get:88 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libspandsp2 amd64 0.0.6+dfsg-2 [272 kB]
Get:89 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libsrt1 amd64 1.4.0-1build1 [236 kB]
Get:90 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libsrtp2-1 amd64 2.3.0-2 [57.5 kB]
Get:91 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libusrsctp1 amd64 0.9.3.0+20190901-1 [217 kB]
Get:92 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libv4lconvert0 amd64 1.18.0-2build1 [76.5 kB]
Get:93 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libv4l-0 amd64 1.18.0-2build1 [41.9 kB]
Get:94 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libwebrtc-audio-processing1 amd64 0.3.1-0ubuntu3 [263 kB]
Get:95 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libwildmidi2 amd64 0.4.3-1 [59.9 kB]
Get:96 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libzbar0 amd64 0.23-1.3 [119 kB]
Get:97 http://azure.archive.ubuntu.com/ubuntu focal-updates/universe amd64 mesa-va-drivers amd64 21.0.3-0ubuntu0.3~20.04.5 [2825 kB]
Get:98 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 mesa-vdpau-drivers amd64 21.0.3-0ubuntu0.3~20.04.5 [2944 kB]
Get:99 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 i965-va-driver amd64 2.4.0-0ubuntu1 [924 kB]
Get:100 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 va-driver-all amd64 2.7.0-2 [4020 B]
Get:101 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 vdpau-driver-all amd64 1.3-1ubuntu2 [4596 B]
Get:102 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libdc1394-22 amd64 2.2.5-2.1 [79.6 kB]
Get:103 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libdca0 amd64 0.0.6-1 [91.0 kB]
Get:104 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libgstreamer-plugins-bad1.0-0 amd64 1.16.2-2.1ubuntu1 [320 kB]
Get:105 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libgstreamer-plugins-good1.0-0 amd64 1.16.2-1ubuntu2.1 [63.7 kB]
Get:106 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libopenal1 amd64 1:1.19.1-1 [492 kB]
Get:107 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libsbc1 amd64 1.4-1 [31.9 kB]
Get:108 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libvo-aacenc0 amd64 0.1.3-2 [69.4 kB]
Get:109 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libvo-amrwbenc0 amd64 0.1.3-2 [68.2 kB]
Get:110 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 gstreamer1.0-plugins-bad amd64 1.16.2-2.1ubuntu1 [1717 kB]
Fetched 58.4 MB in 4s (13.7 MB/s)
Selecting previously unselected package libenchant1c2a:amd64.
(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 235151 files and directories currently installed.)
Preparing to unpack .../000-libenchant1c2a_1.6.0-11.3build1_amd64.deb ...
Unpacking libenchant1c2a:amd64 (1.6.0-11.3build1) ...
Selecting previously unselected package enchant.
Preparing to unpack .../001-enchant_1.6.0-11.3build1_amd64.deb ...
Unpacking enchant (1.6.0-11.3build1) ...
Selecting previously unselected package libaom0:amd64.
Preparing to unpack .../002-libaom0_1.0.0.errata1-3build1_amd64.deb ...
Unpacking libaom0:amd64 (1.0.0.errata1-3build1) ...
Selecting previously unselected package libva2:amd64.
Preparing to unpack .../003-libva2_2.7.0-2_amd64.deb ...
Unpacking libva2:amd64 (2.7.0-2) ...
Selecting previously unselected package libva-drm2:amd64.
Preparing to unpack .../004-libva-drm2_2.7.0-2_amd64.deb ...
Unpacking libva-drm2:amd64 (2.7.0-2) ...
Selecting previously unselected package libva-x11-2:amd64.
Preparing to unpack .../005-libva-x11-2_2.7.0-2_amd64.deb ...
Unpacking libva-x11-2:amd64 (2.7.0-2) ...
Selecting previously unselected package libvdpau1:amd64.
Preparing to unpack .../006-libvdpau1_1.3-1ubuntu2_amd64.deb ...
Unpacking libvdpau1:amd64 (1.3-1ubuntu2) ...
Selecting previously unselected package ocl-icd-libopencl1:amd64.
Preparing to unpack .../007-ocl-icd-libopencl1_2.2.11-1ubuntu1_amd64.deb ...
Unpacking ocl-icd-libopencl1:amd64 (2.2.11-1ubuntu1) ...
Selecting previously unselected package libavutil56:amd64.
Preparing to unpack .../008-libavutil56_7%3a4.2.4-1ubuntu0.1_amd64.deb ...
Unpacking libavutil56:amd64 (7:4.2.4-1ubuntu0.1) ...
Selecting previously unselected package libcodec2-0.9:amd64.
Preparing to unpack .../009-libcodec2-0.9_0.9.2-2_amd64.deb ...
Unpacking libcodec2-0.9:amd64 (0.9.2-2) ...
Selecting previously unselected package libgsm1:amd64.
Preparing to unpack .../010-libgsm1_1.0.18-2_amd64.deb ...
Unpacking libgsm1:amd64 (1.0.18-2) ...
Selecting previously unselected package libmp3lame0:amd64.
Preparing to unpack .../011-libmp3lame0_3.100-3_amd64.deb ...
Unpacking libmp3lame0:amd64 (3.100-3) ...
Selecting previously unselected package libopenjp2-7:amd64.
Preparing to unpack .../012-libopenjp2-7_2.3.1-1ubuntu4.20.04.1_amd64.deb ...
Unpacking libopenjp2-7:amd64 (2.3.1-1ubuntu4.20.04.1) ...
Selecting previously unselected package libopus0:amd64.
Preparing to unpack .../013-libopus0_1.3.1-0ubuntu1_amd64.deb ...
Unpacking libopus0:amd64 (1.3.1-0ubuntu1) ...
Selecting previously unselected package libshine3:amd64.
Preparing to unpack .../014-libshine3_3.1.1-2_amd64.deb ...
Unpacking libshine3:amd64 (3.1.1-2) ...
Selecting previously unselected package libspeex1:amd64.
Preparing to unpack .../015-libspeex1_1.2~rc1.2-1.1ubuntu1_amd64.deb ...
Unpacking libspeex1:amd64 (1.2~rc1.2-1.1ubuntu1) ...
Selecting previously unselected package libsoxr0:amd64.
Preparing to unpack .../016-libsoxr0_0.1.3-2build1_amd64.deb ...
Unpacking libsoxr0:amd64 (0.1.3-2build1) ...
Selecting previously unselected package libswresample3:amd64.
Preparing to unpack .../017-libswresample3_7%3a4.2.4-1ubuntu0.1_amd64.deb ...
Unpacking libswresample3:amd64 (7:4.2.4-1ubuntu0.1) ...
Selecting previously unselected package libtheora0:amd64.
Preparing to unpack .../018-libtheora0_1.1.1+dfsg.1-15ubuntu2_amd64.deb ...
Unpacking libtheora0:amd64 (1.1.1+dfsg.1-15ubuntu2) ...
Selecting previously unselected package libtwolame0:amd64.
Preparing to unpack .../019-libtwolame0_0.4.0-2_amd64.deb ...
Unpacking libtwolame0:amd64 (0.4.0-2) ...
Selecting previously unselected package libvorbisenc2:amd64.
Preparing to unpack .../020-libvorbisenc2_1.3.6-2ubuntu1_amd64.deb ...
Unpacking libvorbisenc2:amd64 (1.3.6-2ubuntu1) ...
Selecting previously unselected package libwavpack1:amd64.
Preparing to unpack .../021-libwavpack1_5.2.0-1ubuntu0.1_amd64.deb ...
Unpacking libwavpack1:amd64 (5.2.0-1ubuntu0.1) ...
Selecting previously unselected package libx264-155:amd64.
Preparing to unpack .../022-libx264-155_2%3a0.155.2917+git0a84d98-2_amd64.deb ...
Unpacking libx264-155:amd64 (2:0.155.2917+git0a84d98-2) ...
Selecting previously unselected package libx265-179:amd64.
Preparing to unpack .../023-libx265-179_3.2.1-1build1_amd64.deb ...
Unpacking libx265-179:amd64 (3.2.1-1build1) ...
Selecting previously unselected package libxvidcore4:amd64.
Preparing to unpack .../024-libxvidcore4_2%3a1.3.7-1_amd64.deb ...
Unpacking libxvidcore4:amd64 (2:1.3.7-1) ...
Selecting previously unselected package libzvbi-common.
Preparing to unpack .../025-libzvbi-common_0.2.35-17_all.deb ...
Unpacking libzvbi-common (0.2.35-17) ...
Selecting previously unselected package libzvbi0:amd64.
Preparing to unpack .../026-libzvbi0_0.2.35-17_amd64.deb ...
Unpacking libzvbi0:amd64 (0.2.35-17) ...
Selecting previously unselected package libavcodec58:amd64.
Preparing to unpack .../027-libavcodec58_7%3a4.2.4-1ubuntu0.1_amd64.deb ...
Unpacking libavcodec58:amd64 (7:4.2.4-1ubuntu0.1) ...
Selecting previously unselected package libass9:amd64.
Preparing to unpack .../028-libass9_1%3a0.14.0-2_amd64.deb ...
Unpacking libass9:amd64 (1:0.14.0-2) ...
Selecting previously unselected package libbluray2:amd64.
Preparing to unpack .../029-libbluray2_1%3a1.2.0-1_amd64.deb ...
Unpacking libbluray2:amd64 (1:1.2.0-1) ...
Selecting previously unselected package libchromaprint1:amd64.
Preparing to unpack .../030-libchromaprint1_1.4.3-3build1_amd64.deb ...
Unpacking libchromaprint1:amd64 (1.4.3-3build1) ...
Selecting previously unselected package libgme0:amd64.
Preparing to unpack .../031-libgme0_0.6.2-1build1_amd64.deb ...
Unpacking libgme0:amd64 (0.6.2-1build1) ...
Selecting previously unselected package libmpg123-0:amd64.
Preparing to unpack .../032-libmpg123-0_1.25.13-1_amd64.deb ...
Unpacking libmpg123-0:amd64 (1.25.13-1) ...
Selecting previously unselected package libopenmpt0:amd64.
Preparing to unpack .../033-libopenmpt0_0.4.11-1build1_amd64.deb ...
Unpacking libopenmpt0:amd64 (0.4.11-1build1) ...
Selecting previously unselected package libssh-gcrypt-4:amd64.
Preparing to unpack .../034-libssh-gcrypt-4_0.9.3-2ubuntu2.2_amd64.deb ...
Unpacking libssh-gcrypt-4:amd64 (0.9.3-2ubuntu2.2) ...
Selecting previously unselected package libavformat58:amd64.
Preparing to unpack .../035-libavformat58_7%3a4.2.4-1ubuntu0.1_amd64.deb ...
Unpacking libavformat58:amd64 (7:4.2.4-1ubuntu0.1) ...
Selecting previously unselected package libbs2b0:amd64.
Preparing to unpack .../036-libbs2b0_3.1.0+dfsg-2.2build1_amd64.deb ...
Unpacking libbs2b0:amd64 (3.1.0+dfsg-2.2build1) ...
Selecting previously unselected package libflite1:amd64.
Preparing to unpack .../037-libflite1_2.1-release-3_amd64.deb ...
Unpacking libflite1:amd64 (2.1-release-3) ...
Selecting previously unselected package libserd-0-0:amd64.
Preparing to unpack .../038-libserd-0-0_0.30.2-1_amd64.deb ...
Unpacking libserd-0-0:amd64 (0.30.2-1) ...
Selecting previously unselected package libsord-0-0:amd64.
Preparing to unpack .../039-libsord-0-0_0.16.4-1_amd64.deb ...
Unpacking libsord-0-0:amd64 (0.16.4-1) ...
Selecting previously unselected package libsratom-0-0:amd64.
Preparing to unpack .../040-libsratom-0-0_0.6.4-1_amd64.deb ...
Unpacking libsratom-0-0:amd64 (0.6.4-1) ...
Selecting previously unselected package liblilv-0-0:amd64.
Preparing to unpack .../041-liblilv-0-0_0.24.6-1ubuntu0.1_amd64.deb ...
Unpacking liblilv-0-0:amd64 (0.24.6-1ubuntu0.1) ...
Selecting previously unselected package libmysofa1:amd64.
Preparing to unpack .../042-libmysofa1_1.0~dfsg0-1_amd64.deb ...
Unpacking libmysofa1:amd64 (1.0~dfsg0-1) ...
Selecting previously unselected package libpostproc55:amd64.
Preparing to unpack .../043-libpostproc55_7%3a4.2.4-1ubuntu0.1_amd64.deb ...
Unpacking libpostproc55:amd64 (7:4.2.4-1ubuntu0.1) ...
Selecting previously unselected package libsamplerate0:amd64.
Preparing to unpack .../044-libsamplerate0_0.1.9-2_amd64.deb ...
Unpacking libsamplerate0:amd64 (0.1.9-2) ...
Selecting previously unselected package librubberband2:amd64.
Preparing to unpack .../045-librubberband2_1.8.2-1build1_amd64.deb ...
Unpacking librubberband2:amd64 (1.8.2-1build1) ...
Selecting previously unselected package libswscale5:amd64.
Preparing to unpack .../046-libswscale5_7%3a4.2.4-1ubuntu0.1_amd64.deb ...
Unpacking libswscale5:amd64 (7:4.2.4-1ubuntu0.1) ...
Selecting previously unselected package libvidstab1.1:amd64.
Preparing to unpack .../047-libvidstab1.1_1.1.0-2_amd64.deb ...
Unpacking libvidstab1.1:amd64 (1.1.0-2) ...
Selecting previously unselected package libavfilter7:amd64.
Preparing to unpack .../048-libavfilter7_7%3a4.2.4-1ubuntu0.1_amd64.deb ...
Unpacking libavfilter7:amd64 (7:4.2.4-1ubuntu0.1) ...
Selecting previously unselected package liborc-0.4-0:amd64.
Preparing to unpack .../049-liborc-0.4-0_1%3a0.4.31-1_amd64.deb ...
Unpacking liborc-0.4-0:amd64 (1:0.4.31-1) ...
Selecting previously unselected package libgstreamer-plugins-base1.0-0:amd64.
Preparing to unpack .../050-libgstreamer-plugins-base1.0-0_1.16.2-4ubuntu0.1_amd64.deb ...
Unpacking libgstreamer-plugins-base1.0-0:amd64 (1.16.2-4ubuntu0.1) ...
Selecting previously unselected package gstreamer1.0-libav:amd64.
Preparing to unpack .../051-gstreamer1.0-libav_1.16.2-2_amd64.deb ...
Unpacking gstreamer1.0-libav:amd64 (1.16.2-2) ...
Selecting previously unselected package libcdparanoia0:amd64.
Preparing to unpack .../052-libcdparanoia0_3.10.2+debian-13_amd64.deb ...
Unpacking libcdparanoia0:amd64 (3.10.2+debian-13) ...
Selecting previously unselected package libvisual-0.4-0:amd64.
Preparing to unpack .../053-libvisual-0.4-0_0.4.0-17_amd64.deb ...
Unpacking libvisual-0.4-0:amd64 (0.4.0-17) ...
Selecting previously unselected package gstreamer1.0-plugins-base:amd64.
Preparing to unpack .../054-gstreamer1.0-plugins-base_1.16.2-4ubuntu0.1_amd64.deb ...
Unpacking gstreamer1.0-plugins-base:amd64 (1.16.2-4ubuntu0.1) ...
Selecting previously unselected package libigdgmm11:amd64.
Preparing to unpack .../055-libigdgmm11_20.1.1+ds1-1_amd64.deb ...
Unpacking libigdgmm11:amd64 (20.1.1+ds1-1) ...
Selecting previously unselected package intel-media-va-driver:amd64.
Preparing to unpack .../056-intel-media-va-driver_20.1.1+dfsg1-1_amd64.deb ...
Unpacking intel-media-va-driver:amd64 (20.1.1+dfsg1-1) ...
Selecting previously unselected package libaacs0:amd64.
Preparing to unpack .../057-libaacs0_0.9.0-2_amd64.deb ...
Unpacking libaacs0:amd64 (0.9.0-2) ...
Selecting previously unselected package libasyncns0:amd64.
Preparing to unpack .../058-libasyncns0_0.8-6_amd64.deb ...
Unpacking libasyncns0:amd64 (0.8-6) ...
Selecting previously unselected package libbdplus0:amd64.
Preparing to unpack .../059-libbdplus0_0.1.2-3_amd64.deb ...
Unpacking libbdplus0:amd64 (0.1.2-3) ...
Selecting previously unselected package libde265-0:amd64.
Preparing to unpack .../060-libde265-0_1.0.4-1build1_amd64.deb ...
Unpacking libde265-0:amd64 (1.0.4-1build1) ...
Selecting previously unselected package libdvdread7:amd64.
Preparing to unpack .../061-libdvdread7_6.1.0+really6.0.2-1_amd64.deb ...
Unpacking libdvdread7:amd64 (6.1.0+really6.0.2-1) ...
Selecting previously unselected package libdvdnav4:amd64.
Preparing to unpack .../062-libdvdnav4_6.0.1-1build1_amd64.deb ...
Unpacking libdvdnav4:amd64 (6.0.1-1build1) ...
Selecting previously unselected package libfaad2:amd64.
Preparing to unpack .../063-libfaad2_2.9.1-1_amd64.deb ...
Unpacking libfaad2:amd64 (2.9.1-1) ...
Selecting previously unselected package libflac8:amd64.
Preparing to unpack .../064-libflac8_1.3.3-1build1_amd64.deb ...
Unpacking libflac8:amd64 (1.3.3-1build1) ...
Selecting previously unselected package libsndfile1:amd64.
Preparing to unpack .../065-libsndfile1_1.0.28-7ubuntu0.1_amd64.deb ...
Unpacking libsndfile1:amd64 (1.0.28-7ubuntu0.1) ...
Selecting previously unselected package libinstpatch-1.0-2:amd64.
Preparing to unpack .../066-libinstpatch-1.0-2_1.1.2-2build1_amd64.deb ...
Unpacking libinstpatch-1.0-2:amd64 (1.1.2-2build1) ...
Selecting previously unselected package libjack-jackd2-0:amd64.
Preparing to unpack .../067-libjack-jackd2-0_1.9.12~dfsg-2ubuntu2_amd64.deb ...
Unpacking libjack-jackd2-0:amd64 (1.9.12~dfsg-2ubuntu2) ...
Selecting previously unselected package libpulse0:amd64.
Preparing to unpack .../068-libpulse0_1%3a13.99.1-1ubuntu3.13_amd64.deb ...
Unpacking libpulse0:amd64 (1:13.99.1-1ubuntu3.13) ...
Selecting previously unselected package libsdl2-2.0-0:amd64.
Preparing to unpack .../069-libsdl2-2.0-0_2.0.10+dfsg1-3_amd64.deb ...
Unpacking libsdl2-2.0-0:amd64 (2.0.10+dfsg1-3) ...
Selecting previously unselected package timgm6mb-soundfont.
Preparing to unpack .../070-timgm6mb-soundfont_1.3-3_all.deb ...
Unpacking timgm6mb-soundfont (1.3-3) ...
Selecting previously unselected package libfluidsynth2:amd64.
Preparing to unpack .../071-libfluidsynth2_2.1.1-2_amd64.deb ...
Unpacking libfluidsynth2:amd64 (2.1.1-2) ...
Selecting previously unselected package libgssdp-1.2-0:amd64.
Preparing to unpack .../072-libgssdp-1.2-0_1.2.3-0ubuntu0.20.04.1_amd64.deb ...
Unpacking libgssdp-1.2-0:amd64 (1.2.3-0ubuntu0.20.04.1) ...
Selecting previously unselected package libgupnp-1.2-0:amd64.
Preparing to unpack .../073-libgupnp-1.2-0_1.2.4-0ubuntu1_amd64.deb ...
Unpacking libgupnp-1.2-0:amd64 (1.2.4-0ubuntu1) ...
Selecting previously unselected package libgupnp-igd-1.0-4:amd64.
Preparing to unpack .../074-libgupnp-igd-1.0-4_0.2.5-5_amd64.deb ...
Unpacking libgupnp-igd-1.0-4:amd64 (0.2.5-5) ...
Selecting previously unselected package libkate1:amd64.
Preparing to unpack .../075-libkate1_0.4.1-11build1_amd64.deb ...
Unpacking libkate1:amd64 (0.4.1-11build1) ...
Selecting previously unselected package libmjpegutils-2.1-0:amd64.
Preparing to unpack .../076-libmjpegutils-2.1-0_1%3a2.1.0+debian-6build1_amd64.deb ...
Unpacking libmjpegutils-2.1-0:amd64 (1:2.1.0+debian-6build1) ...
Selecting previously unselected package libmodplug1:amd64.
Preparing to unpack .../077-libmodplug1_1%3a0.8.9.0-2build1_amd64.deb ...
Unpacking libmodplug1:amd64 (1:0.8.9.0-2build1) ...
Selecting previously unselected package libmpcdec6:amd64.
Preparing to unpack .../078-libmpcdec6_2%3a0.1~r495-2_amd64.deb ...
Unpacking libmpcdec6:amd64 (2:0.1~r495-2) ...
Selecting previously unselected package libmpeg2encpp-2.1-0:amd64.
Preparing to unpack .../079-libmpeg2encpp-2.1-0_1%3a2.1.0+debian-6build1_amd64.deb ...
Unpacking libmpeg2encpp-2.1-0:amd64 (1:2.1.0+debian-6build1) ...
Selecting previously unselected package libmplex2-2.1-0:amd64.
Preparing to unpack .../080-libmplex2-2.1-0_1%3a2.1.0+debian-6build1_amd64.deb ...
Unpacking libmplex2-2.1-0:amd64 (1:2.1.0+debian-6build1) ...
Selecting previously unselected package libnice10:amd64.
Preparing to unpack .../081-libnice10_0.1.16-1_amd64.deb ...
Unpacking libnice10:amd64 (0.1.16-1) ...
Selecting previously unselected package libofa0:amd64.
Preparing to unpack .../082-libofa0_0.9.3-21_amd64.deb ...
Unpacking libofa0:amd64 (0.9.3-21) ...
Selecting previously unselected package libopenal-data.
Preparing to unpack .../083-libopenal-data_1%3a1.19.1-1_all.deb ...
Unpacking libopenal-data (1:1.19.1-1) ...
Selecting previously unselected package libraw1394-11:amd64.
Preparing to unpack .../084-libraw1394-11_2.1.2-1_amd64.deb ...
Unpacking libraw1394-11:amd64 (2.1.2-1) ...
Selecting previously unselected package libsndio7.0:amd64.
Preparing to unpack .../085-libsndio7.0_1.5.0-3_amd64.deb ...
Unpacking libsndio7.0:amd64 (1.5.0-3) ...
Selecting previously unselected package libsoundtouch1:amd64.
Preparing to unpack .../086-libsoundtouch1_2.1.2+ds1-1build1_amd64.deb ...
Unpacking libsoundtouch1:amd64 (2.1.2+ds1-1build1) ...
Selecting previously unselected package libspandsp2:amd64.
Preparing to unpack .../087-libspandsp2_0.0.6+dfsg-2_amd64.deb ...
Unpacking libspandsp2:amd64 (0.0.6+dfsg-2) ...
Selecting previously unselected package libsrt1:amd64.
Preparing to unpack .../088-libsrt1_1.4.0-1build1_amd64.deb ...
Unpacking libsrt1:amd64 (1.4.0-1build1) ...
Selecting previously unselected package libsrtp2-1:amd64.
Preparing to unpack .../089-libsrtp2-1_2.3.0-2_amd64.deb ...
Unpacking libsrtp2-1:amd64 (2.3.0-2) ...
Selecting previously unselected package libusrsctp1:amd64.
Preparing to unpack .../090-libusrsctp1_0.9.3.0+20190901-1_amd64.deb ...
Unpacking libusrsctp1:amd64 (0.9.3.0+20190901-1) ...
Selecting previously unselected package libv4lconvert0:amd64.
Preparing to unpack .../091-libv4lconvert0_1.18.0-2build1_amd64.deb ...
Unpacking libv4lconvert0:amd64 (1.18.0-2build1) ...
Selecting previously unselected package libv4l-0:amd64.
Preparing to unpack .../092-libv4l-0_1.18.0-2build1_amd64.deb ...
Unpacking libv4l-0:amd64 (1.18.0-2build1) ...
Selecting previously unselected package libwebrtc-audio-processing1:amd64.
Preparing to unpack .../093-libwebrtc-audio-processing1_0.3.1-0ubuntu3_amd64.deb ...
Unpacking libwebrtc-audio-processing1:amd64 (0.3.1-0ubuntu3) ...
Selecting previously unselected package libwildmidi2:amd64.
Preparing to unpack .../094-libwildmidi2_0.4.3-1_amd64.deb ...
Unpacking libwildmidi2:amd64 (0.4.3-1) ...
Selecting previously unselected package libzbar0:amd64.
Preparing to unpack .../095-libzbar0_0.23-1.3_amd64.deb ...
Unpacking libzbar0:amd64 (0.23-1.3) ...
Selecting previously unselected package mesa-va-drivers:amd64.
Preparing to unpack .../096-mesa-va-drivers_21.0.3-0ubuntu0.3~20.04.5_amd64.deb ...
Unpacking mesa-va-drivers:amd64 (21.0.3-0ubuntu0.3~20.04.5) ...
Selecting previously unselected package mesa-vdpau-drivers:amd64.
Preparing to unpack .../097-mesa-vdpau-drivers_21.0.3-0ubuntu0.3~20.04.5_amd64.deb ...
Unpacking mesa-vdpau-drivers:amd64 (21.0.3-0ubuntu0.3~20.04.5) ...
Selecting previously unselected package i965-va-driver:amd64.
Preparing to unpack .../098-i965-va-driver_2.4.0-0ubuntu1_amd64.deb ...
Unpacking i965-va-driver:amd64 (2.4.0-0ubuntu1) ...
Selecting previously unselected package va-driver-all:amd64.
Preparing to unpack .../099-va-driver-all_2.7.0-2_amd64.deb ...
Unpacking va-driver-all:amd64 (2.7.0-2) ...
Selecting previously unselected package vdpau-driver-all:amd64.
Preparing to unpack .../100-vdpau-driver-all_1.3-1ubuntu2_amd64.deb ...
Unpacking vdpau-driver-all:amd64 (1.3-1ubuntu2) ...
Selecting previously unselected package libdc1394-22:amd64.
Preparing to unpack .../101-libdc1394-22_2.2.5-2.1_amd64.deb ...
Unpacking libdc1394-22:amd64 (2.2.5-2.1) ...
Selecting previously unselected package libdca0:amd64.
Preparing to unpack .../102-libdca0_0.0.6-1_amd64.deb ...
Unpacking libdca0:amd64 (0.0.6-1) ...
Selecting previously unselected package libgstreamer-plugins-bad1.0-0:amd64.
Preparing to unpack .../103-libgstreamer-plugins-bad1.0-0_1.16.2-2.1ubuntu1_amd64.deb ...
Unpacking libgstreamer-plugins-bad1.0-0:amd64 (1.16.2-2.1ubuntu1) ...
Selecting previously unselected package libgstreamer-plugins-good1.0-0:amd64.
Preparing to unpack .../104-libgstreamer-plugins-good1.0-0_1.16.2-1ubuntu2.1_amd64.deb ...
Unpacking libgstreamer-plugins-good1.0-0:amd64 (1.16.2-1ubuntu2.1) ...
Selecting previously unselected package libopenal1:amd64.
Preparing to unpack .../105-libopenal1_1%3a1.19.1-1_amd64.deb ...
Unpacking libopenal1:amd64 (1:1.19.1-1) ...
Selecting previously unselected package libsbc1:amd64.
Preparing to unpack .../106-libsbc1_1.4-1_amd64.deb ...
Unpacking libsbc1:amd64 (1.4-1) ...
Selecting previously unselected package libvo-aacenc0:amd64.
Preparing to unpack .../107-libvo-aacenc0_0.1.3-2_amd64.deb ...
Unpacking libvo-aacenc0:amd64 (0.1.3-2) ...
Selecting previously unselected package libvo-amrwbenc0:amd64.
Preparing to unpack .../108-libvo-amrwbenc0_0.1.3-2_amd64.deb ...
Unpacking libvo-amrwbenc0:amd64 (0.1.3-2) ...
Selecting previously unselected package gstreamer1.0-plugins-bad:amd64.
Preparing to unpack .../109-gstreamer1.0-plugins-bad_1.16.2-2.1ubuntu1_amd64.deb ...
Unpacking gstreamer1.0-plugins-bad:amd64 (1.16.2-2.1ubuntu1) ...
Setting up libgme0:amd64 (0.6.2-1build1) ...
Setting up libssh-gcrypt-4:amd64 (0.9.3-2ubuntu2.2) ...
Setting up libmodplug1:amd64 (1:0.8.9.0-2build1) ...
Setting up libcdparanoia0:amd64 (3.10.2+debian-13) ...
Setting up libvo-amrwbenc0:amd64 (0.1.3-2) ...
Setting up libraw1394-11:amd64 (2.1.2-1) ...
Setting up libsbc1:amd64 (1.4-1) ...
Setting up libkate1:amd64 (0.4.1-11build1) ...
Setting up libmpg123-0:amd64 (1.25.13-1) ...
Setting up libspeex1:amd64 (1.2~rc1.2-1.1ubuntu1) ...
Setting up libshine3:amd64 (3.1.1-2) ...
Setting up libtwolame0:amd64 (0.4.0-2) ...
Setting up libgsm1:amd64 (1.0.18-2) ...
Setting up libx264-155:amd64 (2:0.155.2917+git0a84d98-2) ...
Setting up libx265-179:amd64 (3.2.1-1build1) ...
Setting up libvisual-0.4-0:amd64 (0.4.0-17) ...
Setting up libsoxr0:amd64 (0.1.3-2build1) ...
Setting up libdvdread7:amd64 (6.1.0+really6.0.2-1) ...
Setting up libaom0:amd64 (1.0.0.errata1-3build1) ...
Setting up libsrtp2-1:amd64 (2.3.0-2) ...
Setting up libmysofa1:amd64 (1.0~dfsg0-1) ...
Setting up libdc1394-22:amd64 (2.2.5-2.1) ...
Setting up libwebrtc-audio-processing1:amd64 (0.3.1-0ubuntu3) ...
Setting up libenchant1c2a:amd64 (1.6.0-11.3build1) ...
Setting up libxvidcore4:amd64 (2:1.3.7-1) ...
Setting up libmpcdec6:amd64 (2:0.1~r495-2) ...
Setting up libspandsp2:amd64 (0.0.6+dfsg-2) ...
Setting up libflac8:amd64 (1.3.3-1build1) ...
Setting up libvo-aacenc0:amd64 (0.1.3-2) ...
Setting up libsoundtouch1:amd64 (2.1.2+ds1-1build1) ...
Setting up libass9:amd64 (1:0.14.0-2) ...
Setting up libva2:amd64 (2.7.0-2) ...
Setting up libigdgmm11:amd64 (20.1.1+ds1-1) ...
Setting up libcodec2-0.9:amd64 (0.9.2-2) ...
Setting up enchant (1.6.0-11.3build1) ...
Setting up libopus0:amd64 (1.3.1-0ubuntu1) ...
Setting up libfaad2:amd64 (2.9.1-1) ...
Setting up intel-media-va-driver:amd64 (20.1.1+dfsg1-1) ...
Setting up liborc-0.4-0:amd64 (1:0.4.31-1) ...
Setting up libaacs0:amd64 (0.9.0-2) ...
Setting up libofa0:amd64 (0.9.3-21) ...
Setting up libsndio7.0:amd64 (1.5.0-3) ...
Setting up libbdplus0:amd64 (0.1.2-3) ...
Setting up libvidstab1.1:amd64 (1.1.0-2) ...
Setting up libsrt1:amd64 (1.4.0-1build1) ...
Setting up libflite1:amd64 (2.1-release-3) ...
Setting up libva-drm2:amd64 (2.7.0-2) ...
Setting up ocl-icd-libopencl1:amd64 (2.2.11-1ubuntu1) ...
Setting up libasyncns0:amd64 (0.8-6) ...
Setting up libwildmidi2:amd64 (0.4.3-1) ...
Setting up libvdpau1:amd64 (1.3-1ubuntu2) ...
Setting up libwavpack1:amd64 (5.2.0-1ubuntu0.1) ...
Setting up libbs2b0:amd64 (3.1.0+dfsg-2.2build1) ...
Setting up libtheora0:amd64 (1.1.1+dfsg.1-15ubuntu2) ...
Setting up libv4lconvert0:amd64 (1.18.0-2build1) ...
Setting up libdca0:amd64 (0.0.6-1) ...
Setting up libopenjp2-7:amd64 (2.3.1-1ubuntu4.20.04.1) ...
Setting up libopenal-data (1:1.19.1-1) ...
Setting up mesa-va-drivers:amd64 (21.0.3-0ubuntu0.3~20.04.5) ...
Setting up libbluray2:amd64 (1:1.2.0-1) ...
Setting up libde265-0:amd64 (1.0.4-1build1) ...
Setting up libsamplerate0:amd64 (0.1.9-2) ...
Setting up timgm6mb-soundfont (1.3-3) ...
update-alternatives: using /usr/share/sounds/sf2/TimGM6mb.sf2 to provide /usr/share/sounds/sf2/default-GM.sf2 (default-GM.sf2) in auto mode
update-alternatives: using /usr/share/sounds/sf2/TimGM6mb.sf2 to provide /usr/share/sounds/sf3/default-GM.sf3 (default-GM.sf3) in auto mode
Setting up libva-x11-2:amd64 (2.7.0-2) ...
Setting up libusrsctp1:amd64 (0.9.3.0+20190901-1) ...
Setting up libopenmpt0:amd64 (0.4.11-1build1) ...
Setting up libmjpegutils-2.1-0:amd64 (1:2.1.0+debian-6build1) ...
Setting up libzvbi-common (0.2.35-17) ...
Setting up libgssdp-1.2-0:amd64 (1.2.3-0ubuntu0.20.04.1) ...
Setting up libmp3lame0:amd64 (3.100-3) ...
Setting up i965-va-driver:amd64 (2.4.0-0ubuntu1) ...
Setting up libvorbisenc2:amd64 (1.3.6-2ubuntu1) ...
Setting up libdvdnav4:amd64 (6.0.1-1build1) ...
Setting up libserd-0-0:amd64 (0.30.2-1) ...
Setting up mesa-vdpau-drivers:amd64 (21.0.3-0ubuntu0.3~20.04.5) ...
Setting up libzvbi0:amd64 (0.2.35-17) ...
Setting up libgupnp-1.2-0:amd64 (1.2.4-0ubuntu1) ...
Setting up libgstreamer-plugins-base1.0-0:amd64 (1.16.2-4ubuntu0.1) ...
Setting up libopenal1:amd64 (1:1.19.1-1) ...
Setting up libavutil56:amd64 (7:4.2.4-1ubuntu0.1) ...
Setting up libv4l-0:amd64 (1.18.0-2build1) ...
Setting up libgstreamer-plugins-bad1.0-0:amd64 (1.16.2-2.1ubuntu1) ...
Setting up libgupnp-igd-1.0-4:amd64 (0.2.5-5) ...
Setting up libgstreamer-plugins-good1.0-0:amd64 (1.16.2-1ubuntu2.1) ...
Setting up gstreamer1.0-plugins-base:amd64 (1.16.2-4ubuntu0.1) ...
Setting up libnice10:amd64 (0.1.16-1) ...
Setting up va-driver-all:amd64 (2.7.0-2) ...
Setting up libpostproc55:amd64 (7:4.2.4-1ubuntu0.1) ...
Setting up libmpeg2encpp-2.1-0:amd64 (1:2.1.0+debian-6build1) ...
Setting up librubberband2:amd64 (1.8.2-1build1) ...
Setting up libjack-jackd2-0:amd64 (1.9.12~dfsg-2ubuntu2) ...
Setting up vdpau-driver-all:amd64 (1.3-1ubuntu2) ...
Setting up libsord-0-0:amd64 (0.16.4-1) ...
Setting up libsratom-0-0:amd64 (0.6.4-1) ...
Setting up libswscale5:amd64 (7:4.2.4-1ubuntu0.1) ...
Setting up libmplex2-2.1-0:amd64 (1:2.1.0+debian-6build1) ...
Setting up libsndfile1:amd64 (1.0.28-7ubuntu0.1) ...
Setting up liblilv-0-0:amd64 (0.24.6-1ubuntu0.1) ...
Setting up libinstpatch-1.0-2:amd64 (1.1.2-2build1) ...
Setting up libpulse0:amd64 (1:13.99.1-1ubuntu3.13) ...
Setting up libzbar0:amd64 (0.23-1.3) ...
Setting up libswresample3:amd64 (7:4.2.4-1ubuntu0.1) ...
Setting up libavcodec58:amd64 (7:4.2.4-1ubuntu0.1) ...
Setting up libsdl2-2.0-0:amd64 (2.0.10+dfsg1-3) ...
Setting up libfluidsynth2:amd64 (2.1.1-2) ...
Setting up libchromaprint1:amd64 (1.4.3-3build1) ...
Setting up libavformat58:amd64 (7:4.2.4-1ubuntu0.1) ...
Setting up gstreamer1.0-plugins-bad:amd64 (1.16.2-2.1ubuntu1) ...
Setting up libavfilter7:amd64 (7:4.2.4-1ubuntu0.1) ...
Setting up gstreamer1.0-libav:amd64 (1.16.2-2) ...
Processing triggers for man-db (2.9.1-1) ...
Processing triggers for libc-bin (2.31-0ubuntu9.2) ...
```



</details>
<details>
<summary><em>cli.js -u --deep '@dxos/*'</em></summary>

```Shell
Using config file /home/runner/work/protocols/protocols/.ncurc.js
Upgrading /home/runner/work/protocols/protocols/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/docs/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/demos/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.4     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/toolchains/esbuild-plugins/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/toolchains/toolchain-node-library/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/bot/bot-factory-client/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/bot/botkit/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/async/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/codec-protobuf/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/crypto/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/debug/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/proto/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/protobuf-compiler/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/protobuf-compiler-browser-test/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/protobuf-test/package.json

No dependencies.
Upgrading /home/runner/work/protocols/protocols/packages/common/random-access-multi-storage/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/rpc/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/testutils/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/common/util/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/devtools/devtools/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.4     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/devtools/devtools-extension/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/devtools/devtools-mesh/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.4     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/echo/echo-db/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/echo-protocol/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/echo-testing/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/feed-store/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/messenger-model/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/model-factory/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/object-model/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/echo/text-model/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/gravity/browser-mocha/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/gravity/browser-tests/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/gravity/gravity-core/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/halo/credentials/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/halo/halo-protocol/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/broadcast/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/network-generator/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/network-manager/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-network-generator/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-plugin-messenger/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-plugin-presence/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-plugin-replicator/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/protocol-plugin-rpc/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/signal/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/sdk/client/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/sdk/config/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/sdk/react-client/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.4     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/sdk/react-components/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.4     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/sdk/react-framework/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.4     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/sdk/react-registry-client/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.4     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/sdk/registry-client/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.4     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/tutorials/tutorials-tasks-app/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.4     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/wallet/wallet-extension/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/wallet/wallet-playground/package.json

 @dxos/esbuild-server  ~1.7.2  →  ~1.7.4     

Run npm install to install new versions.

Upgrading /home/runner/work/protocols/protocols/packages/deprecated/bot/bot-deprecated/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/deprecated/bot/botkit-client-deprecated/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/deprecated/bot/botkit-deprecated/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/deprecated/bot/protocol-plugin-bot-deprecated/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/deprecated/bot/test-bot-deprecated/package.json

All dependencies match the latest package versions :)
Upgrading /home/runner/work/protocols/protocols/packages/mesh/broadcast/example/package.json

No dependencies.
```



</details>
<details>
<summary><em>npm install -g @microsoft/rush pnpm</em></summary>

```Shell
added 287 packages, and audited 288 packages in 9s

33 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

### stderr:

```Shell
npm WARN deprecated read-package-tree@5.1.6: The functionality that this package provided is now in @npmcli/arborist
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated @opentelemetry/types@0.2.0: Package renamed to @opentelemetry/api, see https://github.com/open-telemetry/opentelemetry-js
```

</details>
<details>
<summary><em>node common/scripts/install-run-rush.js update</em></summary>

```Shell
The rush.json configuration requests Rush version 5.58.0
Transforming /home/runner/work/protocols/protocols/common/config/rush/.npmrc
  --> "/home/runner/work/protocols/protocols/common/temp/install-run/@microsoft+rush@5.58.0/.npmrc"
Installing @microsoft/rush...

added 286 packages, and audited 287 packages in 5s

32 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
Successfully installed @microsoft/rush@5.58.0

Invoking "rush update"
----------------------



Rush Multi-Project Build Tool 5.58.0 - https://rushjs.io
Node.js version is 16.1.0 (pre-LTS)


Starting "rush update"

Creating /home/runner/.rush/node-v16.1.0
Trying to acquire lock for pnpm-6.24.2
Acquired lock for pnpm-6.24.2
Installing pnpm version 6.24.2

Transforming /home/runner/work/protocols/protocols/common/config/rush/.npmrc
  --> "/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/.npmrc"

Running "npm install" in /home/runner/.rush/node-v16.1.0/pnpm-6.24.2

added 1 package, and audited 2 packages in 668ms

1 package is looking for funding
  run `npm fund` for details

found 0 vulnerabilities
Successfully installed pnpm version 6.24.2

Symlinking "/home/runner/work/protocols/protocols/common/temp/pnpm-local"
  --> "/home/runner/.rush/node-v16.1.0/pnpm-6.24.2"

Using the default variant for installation.
Transforming /home/runner/work/protocols/protocols/common/config/rush/.npmrc
  --> "/home/runner/work/protocols/protocols/common/temp/.npmrc"

Updating workspace files in /home/runner/work/protocols/protocols/common/temp
Copying "/home/runner/work/protocols/protocols/common/config/rush/pnpm-lock.yaml"
  --> "/home/runner/work/protocols/protocols/common/temp/pnpm-lock.yaml"
Copying "/home/runner/work/protocols/protocols/common/config/rush/pnpm-lock.yaml"
  --> "/home/runner/work/protocols/protocols/common/temp/pnpm-lock-preinstall.yaml"

The shrinkwrap file contains the following issues:
  Dependencies of project "@dxos/demos" do not match the current shrinkwrap.
  Dependencies of project "@dxos/devtools" do not match the current shrinkwrap.
  Dependencies of project "@dxos/devtools-mesh" do not match the current shrinkwrap.
  Dependencies of project "@dxos/react-client" do not match the current shrinkwrap.
  Dependencies of project "@dxos/react-components" do not match the current shrinkwrap.
  Dependencies of project "@dxos/react-framework" do not match the current shrinkwrap.
  Dependencies of project "@dxos/react-registry-client" do not match the current shrinkwrap.
  Dependencies of project "@dxos/registry-client" do not match the current shrinkwrap.
  Dependencies of project "@dxos/tutorials-tasks-app" do not match the current shrinkwrap.
  Dependencies of project "@dxos/wallet-playground" do not match the current shrinkwrap.


Checking installation in "/home/runner/work/protocols/protocols/common/temp"


Running "pnpm install" in /home/runner/work/protocols/protocols/common/temp

Scope: all 59 workspace projects
Progress: resolved 1, reused 0, downloaded 0, added 0
../../packages/halo/halo-protocol        |  WARN  deprecated @types/expect@24.3.0
.../common/random-access-multi-storage   |  WARN  deprecated @types/expect@24.3.0
../../packages/halo/credentials          |  WARN  deprecated @types/expect@24.3.0
../../packages/mesh/protocol-plugin-rpc  |  WARN  deprecated @types/expect@24.3.0
../../packages/sdk/client                |  WARN  deprecated @types/expect@24.3.0
../../packages/bot/botkit                |  WARN  deprecated @types/expect@24.3.0
Progress: resolved 63, reused 0, downloaded 53, added 0
Progress: resolved 92, reused 0, downloaded 83, added 0
Progress: resolved 156, reused 0, downloaded 149, added 0
Progress: resolved 214, reused 0, downloaded 205, added 0
../../packages/wallet/wallet-extension   |  WARN  deprecated webextension-polyfill-ts@0.25.0
Packages are hard linked from the content-addressable store to the virtual store.
  Content-addressable store is at: /home/runner/work/protocols/protocols/common/temp/pnpm-store/v3
  Virtual store is at:             node_modules/.pnpm
Progress: resolved 250, reused 0, downloaded 239, added 0
Progress: resolved 333, reused 0, downloaded 320, added 0
Progress: resolved 430, reused 0, downloaded 422, added 0
Progress: resolved 502, reused 0, downloaded 487, added 0
Progress: resolved 579, reused 0, downloaded 566, added 0
Progress: resolved 679, reused 0, downloaded 659, added 0
Progress: resolved 755, reused 0, downloaded 733, added 0
Progress: resolved 788, reused 0, downloaded 764, added 0
Progress: resolved 818, reused 0, downloaded 795, added 0
Progress: resolved 847, reused 0, downloaded 818, added 0
Progress: resolved 912, reused 0, downloaded 877, added 0
Progress: resolved 980, reused 0, downloaded 940, added 0
Progress: resolved 1044, reused 0, downloaded 1005, added 0
Progress: resolved 1127, reused 0, downloaded 1087, added 0
Progress: resolved 1214, reused 0, downloaded 1175, added 0
Progress: resolved 1316, reused 0, downloaded 1274, added 0
Progress: resolved 1408, reused 0, downloaded 1364, added 0
Progress: resolved 1495, reused 0, downloaded 1456, added 0
Progress: resolved 1665, reused 0, downloaded 1618, added 0
Progress: resolved 1776, reused 0, downloaded 1725, added 0
Progress: resolved 1924, reused 0, downloaded 1886, added 0
Progress: resolved 1986, reused 0, downloaded 1954, added 0
Progress: resolved 2096, reused 0, downloaded 2069, added 0
Progress: resolved 2225, reused 0, downloaded 2198, added 0
Progress: resolved 2396, reused 0, downloaded 2361, added 0
Progress: resolved 2521, reused 0, downloaded 2499, added 0
Progress: resolved 2662, reused 0, downloaded 2628, added 0
Progress: resolved 2817, reused 0, downloaded 2792, added 0
Progress: resolved 2931, reused 0, downloaded 2918, added 0
.                                        |    +3023 ++++++++++++++++++++++++++++
Progress: resolved 2931, reused 0, downloaded 2919, added 0
Progress: resolved 2931, reused 0, downloaded 2919, added 456
Progress: resolved 2931, reused 0, downloaded 2919, added 1239
Progress: resolved 2931, reused 0, downloaded 2919, added 1758
Progress: resolved 2931, reused 0, downloaded 2919, added 1919
Progress: resolved 2931, reused 0, downloaded 2919, added 2560
Progress: resolved 2931, reused 0, downloaded 2919, added 3023, done
.../node_modules/core-js-pure postinstall$ node -e "try{require('./postinstall')}catch(e){}"
.../core-js@2.6.12/node_modules/core-js postinstall$ node -e "try{require('./postinstall')}catch(e){}"
.../core-js@3.18.0/node_modules/core-js postinstall$ node -e "try{require('./postinstall')}catch(e){}"
.../core-js@3.19.3/node_modules/core-js postinstall$ node -e "try{require('./postinstall')}catch(e){}"
.../core-js@2.6.12/node_modules/core-js postinstall: Done
.../node_modules/core-js-pure postinstall: Done
.../node_modules/dtrace-provider install$ node-gyp rebuild || node suppress-error.js
.../core-js@3.18.0/node_modules/core-js postinstall: Done
.../.pnpm/ejs@2.7.4/node_modules/ejs postinstall$ node ./postinstall.js
.../core-js@3.19.3/node_modules/core-js postinstall: Done
.../node_modules/bufferutil install$ node-gyp-build
.../esbuild@0.11.23/node_modules/esbuild postinstall$ node install.js
.../esbuild@0.12.29/node_modules/esbuild postinstall$ node install.js
.../node_modules/dtrace-provider install: gyp info it worked if it ends with ok
.../node_modules/dtrace-provider install: gyp info using node-gyp@8.4.1
.../node_modules/dtrace-provider install: gyp info using node@16.1.0 | linux | x64
.../.pnpm/ejs@2.7.4/node_modules/ejs postinstall: Done
.../.pnpm/fsctl@1.0.0/node_modules/fsctl install$ node-gyp-build
.../node_modules/dtrace-provider install: gyp info find Python using Python version 3.8.10 found at "/usr/bin/python3"
.../node_modules/bufferutil install: Done
.../node_modules/leveldown install$ node-gyp-build
.../.pnpm/fsctl@1.0.0/node_modules/fsctl install: Done
.../node_modules/playwright install$ node install.js
.../node_modules/dtrace-provider install: gyp http GET https://nodejs.org/download/release/v16.1.0/node-v16.1.0-headers.tar.gz
.../node_modules/leveldown install: Done
.../node_modules/dtrace-provider install: gyp http 200 https://nodejs.org/download/release/v16.1.0/node-v16.1.0-headers.tar.gz
.../node_modules/protobufjs postinstall$ node scripts/postinstall
.../node_modules/protobufjs postinstall: Done
.../node_modules/puppeteer install$ node install.js
.../esbuild@0.12.29/node_modules/esbuild postinstall: Done
.../robotjs@0.6.0/node_modules/robotjs install$ prebuild-install || node-gyp rebuild
.../node_modules/dtrace-provider install: gyp http GET https://nodejs.org/download/release/v16.1.0/SHASUMS256.txt
.../node_modules/dtrace-provider install: gyp http 200 https://nodejs.org/download/release/v16.1.0/SHASUMS256.txt
.../esbuild@0.11.23/node_modules/esbuild postinstall: Done
.../node_modules/secp256k1 install$ npm run rebuild || echo "Secp256k1 bindings compilation fail. Pure JS implementation will be used."
.../node_modules/dtrace-provider install: gyp info spawn /usr/bin/python3
.../node_modules/dtrace-provider install: gyp info spawn args [
.../node_modules/dtrace-provider install: gyp info spawn args   '/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
.../node_modules/dtrace-provider install: gyp info spawn args   'binding.gyp',
.../node_modules/dtrace-provider install: gyp info spawn args   '-f',
.../node_modules/dtrace-provider install: gyp info spawn args   'make',
.../node_modules/dtrace-provider install: gyp info spawn args   '-I',
.../node_modules/dtrace-provider install: gyp info spawn args   '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/dtrace-provider@0.8.8/node_modules/dtrace-provider/build/config.gypi',
.../node_modules/dtrace-provider install: gyp info spawn args   '-I',
.../node_modules/dtrace-provider install: gyp info spawn args   '/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
.../node_modules/dtrace-provider install: gyp info spawn args   '-I',
.../node_modules/dtrace-provider install: gyp info spawn args   '/home/runner/.cache/node-gyp/16.1.0/include/node/common.gypi',
.../node_modules/dtrace-provider install: gyp info spawn args   '-Dlibrary=shared_library',
.../node_modules/dtrace-provider install: gyp info spawn args   '-Dvisibility=default',
.../node_modules/dtrace-provider install: gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/16.1.0',
.../node_modules/dtrace-provider install: gyp info spawn args   '-Dnode_gyp_dir=/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node_modules/node-gyp',
.../node_modules/dtrace-provider install: gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/16.1.0/<(target_arch)/node.lib',
.../node_modules/dtrace-provider install: gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/dtrace-provider@0.8.8/node_modules/dtrace-provider',
.../node_modules/dtrace-provider install: gyp info spawn args   '-Dnode_engine=v8',
.../node_modules/dtrace-provider install: gyp info spawn args   '--depth=.',
.../node_modules/dtrace-provider install: gyp info spawn args   '--no-parallel',
.../node_modules/dtrace-provider install: gyp info spawn args   '--generator-output',
.../node_modules/dtrace-provider install: gyp info spawn args   'build',
.../node_modules/dtrace-provider install: gyp info spawn args   '-Goutput_dir=.'
.../node_modules/dtrace-provider install: gyp info spawn args ]
.../node_modules/dtrace-provider install: gyp info spawn make
.../node_modules/dtrace-provider install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
.../node_modules/dtrace-provider install: make: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/dtrace-provider@0.8.8/node_modules/dtrace-provider/build'
.../node_modules/dtrace-provider install:   TOUCH Release/obj.target/DTraceProviderStub.stamp
.../node_modules/dtrace-provider install: make: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/dtrace-provider@0.8.8/node_modules/dtrace-provider/build'
.../node_modules/dtrace-provider install: gyp info ok 
.../node_modules/dtrace-provider install: Done
.../node_modules/sodium-native install$ node-gyp-build
.../robotjs@0.6.0/node_modules/robotjs install: prebuild-install WARN install No prebuilt binaries found (target=16.1.0 runtime=node arch=x64 libc= platform=linux)
.../robotjs@0.6.0/node_modules/robotjs install: gyp info it worked if it ends with ok
.../robotjs@0.6.0/node_modules/robotjs install: gyp info using node-gyp@8.4.1
.../robotjs@0.6.0/node_modules/robotjs install: gyp info using node@16.1.0 | linux | x64
.../robotjs@0.6.0/node_modules/robotjs install: gyp info find Python using Python version 3.8.10 found at "/usr/bin/python3"
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn /usr/bin/python3
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args [
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   'binding.gyp',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-f',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   'make',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-I',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/robotjs@0.6.0/node_modules/robotjs/build/config.gypi',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-I',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-I',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '/home/runner/.cache/node-gyp/16.1.0/include/node/common.gypi',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Dlibrary=shared_library',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Dvisibility=default',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/16.1.0',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Dnode_gyp_dir=/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node_modules/node-gyp',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/16.1.0/<(target_arch)/node.lib',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/robotjs@0.6.0/node_modules/robotjs',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Dnode_engine=v8',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '--depth=.',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '--no-parallel',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '--generator-output',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   'build',
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args   '-Goutput_dir=.'
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args ]
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn make
.../robotjs@0.6.0/node_modules/robotjs install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
.../node_modules/sodium-native install: Done
.../node_modules/spawn-sync postinstall$ node postinstall
.../robotjs@0.6.0/node_modules/robotjs install: make: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/robotjs@0.6.0/node_modules/robotjs/build'
.../robotjs@0.6.0/node_modules/robotjs install:   CXX(target) Release/obj.target/robotjs/src/robotjs.o
.../node_modules/secp256k1 install: > secp256k1@3.8.0 rebuild
.../node_modules/secp256k1 install: > node-gyp rebuild
.../node_modules/secp256k1 install: gyp info it worked if it ends with ok
.../robotjs@0.6.0/node_modules/robotjs install: cc1plus: warning: command line option ‘-Wbad-function-cast’ is valid for C/ObjC but not for C++
.../node_modules/secp256k1 install: gyp info using node-gyp@7.1.2
.../node_modules/secp256k1 install: gyp info using node@16.1.0 | linux | x64
.../node_modules/spawn-sync postinstall: Done
.../node_modules/tiny-secp256k1 install$ npm run build || echo "secp256k1 bindings compilation fail. Pure JS implementation will be used."
.../node_modules/secp256k1 install: gyp info find Python using Python version 3.8.10 found at "/usr/bin/python3"
.../node_modules/secp256k1 install: (node:4705) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
.../node_modules/secp256k1 install: (Use `node --trace-deprecation ...` to show where the warning was created)
.../node_modules/secp256k1 install: gyp info spawn /usr/bin/python3
.../node_modules/secp256k1 install: gyp info spawn args [
.../node_modules/secp256k1 install: gyp info spawn args   '/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
.../node_modules/secp256k1 install: gyp info spawn args   'binding.gyp',
.../node_modules/secp256k1 install: gyp info spawn args   '-f',
.../node_modules/secp256k1 install: gyp info spawn args   'make',
.../node_modules/secp256k1 install: gyp info spawn args   '-I',
.../node_modules/secp256k1 install: gyp info spawn args   '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/secp256k1@3.8.0/node_modules/secp256k1/build/config.gypi',
.../node_modules/secp256k1 install: gyp info spawn args   '-I',
.../node_modules/secp256k1 install: gyp info spawn args   '/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
.../node_modules/secp256k1 install: gyp info spawn args   '-I',
.../node_modules/secp256k1 install: gyp info spawn args   '/home/runner/.cache/node-gyp/16.1.0/include/node/common.gypi',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dlibrary=shared_library',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dvisibility=default',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/16.1.0',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dnode_gyp_dir=/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/16.1.0/<(target_arch)/node.lib',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/secp256k1@3.8.0/node_modules/secp256k1',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dnode_engine=v8',
.../node_modules/secp256k1 install: gyp info spawn args   '--depth=.',
.../node_modules/secp256k1 install: gyp info spawn args   '--no-parallel',
.../node_modules/secp256k1 install: gyp info spawn args   '--generator-output',
.../node_modules/secp256k1 install: gyp info spawn args   'build',
.../node_modules/secp256k1 install: gyp info spawn args   '-Goutput_dir=.'
.../node_modules/secp256k1 install: gyp info spawn args ]
.../node_modules/tiny-secp256k1 install: > tiny-secp256k1@1.1.6 build
.../node_modules/tiny-secp256k1 install: > node-gyp rebuild
.../node_modules/tiny-secp256k1 install: gyp info it worked if it ends with ok
.../node_modules/tiny-secp256k1 install: gyp info using node-gyp@7.1.2
.../node_modules/tiny-secp256k1 install: gyp info using node@16.1.0 | linux | x64
.../node_modules/secp256k1 install: gyp info spawn make
.../node_modules/secp256k1 install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
.../node_modules/secp256k1 install: make: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/secp256k1@3.8.0/node_modules/secp256k1/build'
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/addon.o
.../node_modules/tiny-secp256k1 install: gyp info find Python using Python version 3.8.10 found at "/usr/bin/python3"
.../node_modules/tiny-secp256k1 install: (node:4741) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
.../node_modules/tiny-secp256k1 install: (Use `node --trace-deprecation ...` to show where the warning was created)
.../node_modules/tiny-secp256k1 install: gyp info spawn /usr/bin/python3
.../node_modules/tiny-secp256k1 install: gyp info spawn args [
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   'binding.gyp',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-f',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   'make',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-I',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/tiny-secp256k1@1.1.6/node_modules/tiny-secp256k1/build/config.gypi',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-I',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-I',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '/home/runner/.cache/node-gyp/16.1.0/include/node/common.gypi',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dlibrary=shared_library',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dvisibility=default',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/16.1.0',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dnode_gyp_dir=/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/16.1.0/<(target_arch)/node.lib',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/tiny-secp256k1@1.1.6/node_modules/tiny-secp256k1',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dnode_engine=v8',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '--depth=.',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '--no-parallel',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '--generator-output',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   'build',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Goutput_dir=.'
.../node_modules/tiny-secp256k1 install: gyp info spawn args ]
.../node_modules/tiny-secp256k1 install: gyp info spawn make
.../node_modules/tiny-secp256k1 install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
.../node_modules/tiny-secp256k1 install: make: Entering directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/tiny-secp256k1@1.1.6/node_modules/tiny-secp256k1/build'
.../node_modules/tiny-secp256k1 install:   CXX(target) Release/obj.target/secp256k1/native/addon.o
.../robotjs@0.6.0/node_modules/robotjs install: In file included from ../src/robotjs.cc:1:
.../robotjs@0.6.0/node_modules/robotjs install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:806:43: warning: cast between incompatible function types from ‘void (*)(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)’ {aka ‘void (*)(v8::Local<v8::Object>)’} to ‘node::addon_register_func’ {aka ‘void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)’} [-Wcast-function-type]
.../robotjs@0.6.0/node_modules/robotjs install:   806 |       (node::addon_register_func) (regfunc),                          \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                           ^
.../robotjs@0.6.0/node_modules/robotjs install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:840:3: note: in expansion of macro ‘NODE_MODULE_X’
.../robotjs@0.6.0/node_modules/robotjs install:   840 |   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
.../robotjs@0.6.0/node_modules/robotjs install:       |   ^~~~~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: ../src/robotjs.cc:907:1: note: in expansion of macro ‘NODE_MODULE’
.../robotjs@0.6.0/node_modules/robotjs install:   907 | NODE_MODULE(robotjs, InitAll)
.../robotjs@0.6.0/node_modules/robotjs install:       | ^~~~~~~~~~~
.../node_modules/secp256k1 install: In file included from ../src/addon.cc:1:
.../node_modules/secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:806:43: warning: cast between incompatible function types from ‘void (*)(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)’ {aka ‘void (*)(v8::Local<v8::Object>)’} to ‘node::addon_register_func’ {aka ‘void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)’} [-Wcast-function-type]
.../node_modules/secp256k1 install:   806 |       (node::addon_register_func) (regfunc),                          \
.../node_modules/secp256k1 install:       |                                           ^
.../node_modules/secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:840:3: note: in expansion of macro ‘NODE_MODULE_X’
.../node_modules/secp256k1 install:   840 |   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
.../node_modules/secp256k1 install:       |   ^~~~~~~~~~~~~
.../node_modules/secp256k1 install: ../src/addon.cc:50:1: note: in expansion of macro ‘NODE_MODULE’
.../node_modules/secp256k1 install:    50 | NODE_MODULE(secp256k1, Init)
.../node_modules/secp256k1 install:       | ^~~~~~~~~~~
.../node_modules/tiny-secp256k1 install: In file included from ../../../../nan@2.15.0/node_modules/nan/nan.h:58,
.../node_modules/tiny-secp256k1 install:                  from ../native/addon.cpp:4:
.../node_modules/tiny-secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:806:43: warning: cast between incompatible function types from ‘void (*)(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)’ {aka ‘void (*)(v8::Local<v8::Object>)’} to ‘node::addon_register_func’ {aka ‘void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)’} [-Wcast-function-type]
.../node_modules/tiny-secp256k1 install:   806 |       (node::addon_register_func) (regfunc),                          \
.../node_modules/tiny-secp256k1 install:       |                                           ^
.../node_modules/tiny-secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:840:3: note: in expansion of macro ‘NODE_MODULE_X’
.../node_modules/tiny-secp256k1 install:   840 |   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
.../node_modules/tiny-secp256k1 install:       |   ^~~~~~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:372:1: note: in expansion of macro ‘NODE_MODULE’
.../node_modules/tiny-secp256k1 install:   372 | NODE_MODULE(secp256k1, Init)
.../node_modules/tiny-secp256k1 install:       | ^~~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: ../src/robotjs.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE keyToggle(Nan::NAN_METHOD_ARGS_TYPE)’:
.../robotjs@0.6.0/node_modules/robotjs install: ../src/robotjs.cc:592:17: warning: ‘down’ may be used uninitialized in this function [-Wmaybe-uninitialized]
.../robotjs@0.6.0/node_modules/robotjs install:   592 |    toggleKeyCode(key, down, flags);
.../robotjs@0.6.0/node_modules/robotjs install:       |    ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp: In instantiation of ‘unsigned int {anonymous}::assumeCompression(const I&, const A&) [with long unsigned int index = 2; I = Nan::FunctionCallbackInfo<v8::Value>; A = v8::Local<v8::Object>]’:
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:151:50:   required from here
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:80:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
.../node_modules/tiny-secp256k1 install:    80 |   if (info.Length() <= index || info[index]->IsUndefined()) {
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp: In instantiation of ‘unsigned int {anonymous}::assumeCompression(const I&, const A&) [with long unsigned int index = 1; I = Nan::FunctionCallbackInfo<v8::Value>; A = v8::Local<v8::Object>]’:
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:183:49:   required from here
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:80:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp: In instantiation of ‘unsigned int {anonymous}::assumeCompression(const I&) [with long unsigned int index = 1; I = Nan::FunctionCallbackInfo<v8::Value>]’:
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:198:46:   required from here
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:92:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
.../node_modules/tiny-secp256k1 install:    92 |   if (info.Length() <= index) return SECP256K1_EC_COMPRESSED;
.../robotjs@0.6.0/node_modules/robotjs install: In file included from ../../../../nan@2.15.0/node_modules/nan/nan_new.h:189,
.../robotjs@0.6.0/node_modules/robotjs install:                  from ../../../../nan@2.15.0/node_modules/nan/nan.h:292,
.../robotjs@0.6.0/node_modules/robotjs install:                  from ../src/robotjs.cc:2:
.../robotjs@0.6.0/node_modules/robotjs install: ../../../../nan@2.15.0/node_modules/nan/nan_implementation_12_inl.h: In function ‘void InitAll(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)’:
.../robotjs@0.6.0/node_modules/robotjs install: ../../../../nan@2.15.0/node_modules/nan/nan_implementation_12_inl.h:119:1: warning: inlining failed in call to ‘static Nan::imp::FactoryBase<v8::FunctionTemplate>::return_t Nan::imp::Factory<v8::FunctionTemplate>::New(Nan::FunctionCallback, v8::Local<v8::Value>, v8::Local<v8::Signature>)’: --param large-function-growth limit reached [-Winline]
.../robotjs@0.6.0/node_modules/robotjs install:   119 | Factory<v8::FunctionTemplate>::New( FunctionCallback callback
.../robotjs@0.6.0/node_modules/robotjs install:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: In file included from ../../../../nan@2.15.0/node_modules/nan/nan.h:292,
.../robotjs@0.6.0/node_modules/robotjs install:                  from ../src/robotjs.cc:2:
.../robotjs@0.6.0/node_modules/robotjs install: ../../../../nan@2.15.0/node_modules/nan/nan_new.h:239:32: note: called from here
.../robotjs@0.6.0/node_modules/robotjs install:   239 |     return imp::Factory<T>::New(callback, data);
.../robotjs@0.6.0/node_modules/robotjs install:       |            ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: In file included from ../../../../nan@2.15.0/node_modules/nan/nan_new.h:189,
.../robotjs@0.6.0/node_modules/robotjs install:                  from ../../../../nan@2.15.0/node_modules/nan/nan.h:292,
.../robotjs@0.6.0/node_modules/robotjs install:                  from ../src/robotjs.cc:2:
.../robotjs@0.6.0/node_modules/robotjs install: ../../../../nan@2.15.0/node_modules/nan/nan_implementation_12_inl.h:119:1: warning: inlining failed in call to ‘static Nan::imp::FactoryBase<v8::FunctionTemplate>::return_t Nan::imp::Factory<v8::FunctionTemplate>::New(Nan::FunctionCallback, v8::Local<v8::Value>, v8::Local<v8::Signature>)’: --param large-function-growth limit reached [-Winline]
.../robotjs@0.6.0/node_modules/robotjs install:   119 | Factory<v8::FunctionTemplate>::New( FunctionCallback callback
.../robotjs@0.6.0/node_modules/robotjs install:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: In file included from ../../../../nan@2.15.0/node_modules/nan/nan.h:292,
.../robotjs@0.6.0/node_modules/robotjs install:                  from ../src/robotjs.cc:2:
.../robotjs@0.6.0/node_modules/robotjs install: ../../../../nan@2.15.0/node_modules/nan/nan_new.h:239:32: note: called from here
.../robotjs@0.6.0/node_modules/robotjs install:   239 |     return imp::Factory<T>::New(callback, data);
.../robotjs@0.6.0/node_modules/robotjs install:       |            ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp: In function ‘Nan::NAN_METHOD_RETURN_TYPE eccPrivateSub(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:249:29: warning: ignoring return value of ‘int secp256k1_ec_privkey_negate(const secp256k1_context*, unsigned char*)’, declared with attribute warn_unused_result [-Wunused-result]
.../node_modules/tiny-secp256k1 install:   249 |  secp256k1_ec_privkey_negate(context, tweak_negated); // returns 1 always
.../node_modules/tiny-secp256k1 install:       |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/privatekey.o
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/deadbeef_rand.o
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/mouse.o
.../node_modules/tiny-secp256k1 install:   CC(target) Release/obj.target/secp256k1/native/secp256k1/src/secp256k1.o
.../node_modules/tiny-secp256k1 install: In file included from ../native/secp256k1/src/assumptions.h:12,
.../node_modules/tiny-secp256k1 install:                  from ../native/secp256k1/src/secp256k1.c:10:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_context_preallocated_clone’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘prealloc’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:168:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   168 |     ARG_CHECK(prealloc != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_parse’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:283:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   283 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘input’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:285:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   285 |     ARG_CHECK(input != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_serialize’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘output’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:307:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   307 |     ARG_CHECK(output != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘outputlen’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:303:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   303 |     ARG_CHECK(outputlen != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:309:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   309 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_signature_parse_der’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sig’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:348:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   348 |     ARG_CHECK(sig != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘input’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:349:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   349 |     ARG_CHECK(input != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_signature_parse_compact’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sig’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:366:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   366 |     ARG_CHECK(sig != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘input64’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:367:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   367 |     ARG_CHECK(input64 != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_signature_serialize_der’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘output’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:385:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   385 |     ARG_CHECK(output != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘outputlen’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:386:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   386 |     ARG_CHECK(outputlen != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sig’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:387:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   387 |     ARG_CHECK(sig != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_signature_serialize_compact’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘output64’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:397:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   397 |     ARG_CHECK(output64 != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sig’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:398:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   398 |     ARG_CHECK(sig != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_signature_normalize’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sigin’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:411:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   411 |     ARG_CHECK(sigin != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_verify’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sig’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:432:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   432 |     ARG_CHECK(sig != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘msg32’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:431:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   431 |     ARG_CHECK(msg32 != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:433:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   433 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_sign’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘signature’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:542:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   542 |     ARG_CHECK(signature != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘msg32’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:541:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   541 |     ARG_CHECK(msg32 != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:543:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   543 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_seckey_verify’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:554:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   554 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_create’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:578:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   578 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:581:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   581 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_seckey_negate’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:595:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   595 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_negate’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:614:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   614 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_seckey_tweak_add’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:641:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   641 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘tweak’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:642:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   642 |     ARG_CHECK(tweak != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_tweak_add’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:669:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   669 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘tweak’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:670:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   670 |     ARG_CHECK(tweak != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_seckey_tweak_mul’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:688:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   688 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘tweak’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:689:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   689 |     ARG_CHECK(tweak != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_tweak_mul’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:713:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   713 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘tweak’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:714:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   714 |     ARG_CHECK(tweak != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_combine’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubnonce’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:743:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   743 |     ARG_CHECK(pubnonce != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubnonces’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:746:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   746 |     ARG_CHECK(pubnonces != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/keypress.o
.../node_modules/playwright install: Playwright build of chromium v939194 downloaded to /home/runner/.cache/ms-playwright/chromium-939194
.../node_modules/playwright install: Playwright build of ffmpeg v1006 downloaded to /home/runner/.cache/ms-playwright/ffmpeg-1006
.../robotjs@0.6.0/node_modules/robotjs install: ../src/keypress.c: In function ‘typeString’:
.../robotjs@0.6.0/node_modules/robotjs install: ../src/keypress.c:274:16: warning: ‘n’ may be used uninitialized in this function [-Wmaybe-uninitialized]
.../robotjs@0.6.0/node_modules/robotjs install:   274 |  unsigned long n;
.../robotjs@0.6.0/node_modules/robotjs install:       |                ^
.../node_modules/secp256k1 install: ../src/privatekey.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE privateKeyNegate(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/secp256k1 install: ../src/privatekey.cc:73:30: warning: ignoring return value of ‘int secp256k1_ec_privkey_negate(const secp256k1_context*, unsigned char*)’, declared with attribute warn_unused_result [-Wunused-result]
.../node_modules/secp256k1 install:    73 |   secp256k1_ec_privkey_negate(secp256k1ctx, &private_key[0]);
.../node_modules/secp256k1 install:       |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../node_modules/puppeteer install: Chromium (756035) downloaded to /home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/puppeteer@3.3.0/node_modules/puppeteer/.local-chromium/linux-756035
.../node_modules/puppeteer install: Done
.../node_modules/utf-8-validate install$ node-gyp-build
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/keycode.o
.../node_modules/utf-8-validate install: Done
.../node_modules/utp-native install$ node-gyp-build
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/publickey.o
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/screen.o
.../node_modules/utp-native install: Done
.../.pnpm/yjs@13.5.22/node_modules/yjs postinstall$ node ./sponsor-y.js
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/screengrab.o
.../.pnpm/yjs@13.5.22/node_modules/yjs postinstall: Done
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/snprintf.o
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c: In function ‘portable_vsnprintf’:
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:557:35: warning: operand of ?: changes signedness from ‘long int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   557 |       size_t n = !q ? strlen(p) : (q-p);
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^~~~~
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:704:42: warning: operand of ?: changes signedness from ‘long int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   704 |             str_arg_l = !q ? precision : (q-str_arg);
.../robotjs@0.6.0/node_modules/robotjs install:       |                                          ^~~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:943:62: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   943 |             fast_memset(str+str_l, (zero_padding?'0':' '), (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                                              ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:372:35: note: in definition of macro ‘fast_memset’
.../robotjs@0.6.0/node_modules/robotjs install:   372 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:943:75: warning: operand of ?: changes signedness from ‘int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   943 |             fast_memset(str+str_l, (zero_padding?'0':' '), (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                                                           ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:372:35: note: in definition of macro ‘fast_memset’
.../robotjs@0.6.0/node_modules/robotjs install:   372 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:960:47: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   960 |             fast_memcpy(str+str_l, str_arg, (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                               ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:365:35: note: in definition of macro ‘fast_memcpy’
.../robotjs@0.6.0/node_modules/robotjs install:   365 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:960:60: warning: operand of ?: changes signedness from ‘int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   960 |             fast_memcpy(str+str_l, str_arg, (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                                            ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:365:35: note: in definition of macro ‘fast_memcpy’
.../robotjs@0.6.0/node_modules/robotjs install:   365 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:969:43: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   969 |             fast_memset(str+str_l, '0', (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                           ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:372:35: note: in definition of macro ‘fast_memset’
.../robotjs@0.6.0/node_modules/robotjs install:   372 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:969:56: warning: operand of ?: changes signedness from ‘int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   969 |             fast_memset(str+str_l, '0', (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                                        ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:372:35: note: in definition of macro ‘fast_memset’
.../robotjs@0.6.0/node_modules/robotjs install:   372 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:981:27: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   981 |                         (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                           ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:365:35: note: in definition of macro ‘fast_memcpy’
.../robotjs@0.6.0/node_modules/robotjs install:   365 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:981:40: warning: operand of ?: changes signedness from ‘int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   981 |                         (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                        ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:365:35: note: in definition of macro ‘fast_memcpy’
.../robotjs@0.6.0/node_modules/robotjs install:   365 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:992:43: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   992 |             fast_memset(str+str_l, ' ', (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                           ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:372:35: note: in definition of macro ‘fast_memset’
.../robotjs@0.6.0/node_modules/robotjs install:   372 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:992:56: warning: operand of ?: changes signedness from ‘int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
.../robotjs@0.6.0/node_modules/robotjs install:   992 |             fast_memset(str+str_l, ' ', (n>avail?avail:n));
.../robotjs@0.6.0/node_modules/robotjs install:       |                                                        ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:372:35: note: in definition of macro ‘fast_memset’
.../robotjs@0.6.0/node_modules/robotjs install:   372 |   { register size_t nn = (size_t)(n); \
.../robotjs@0.6.0/node_modules/robotjs install:       |                                   ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:564:19: warning: variable ‘starting_p’ set but not used [-Wunused-but-set-variable]
.../robotjs@0.6.0/node_modules/robotjs install:   564 |       const char *starting_p;
.../robotjs@0.6.0/node_modules/robotjs install:       |                   ^~~~~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:369:48: warning: ‘str_arg’ may be used uninitialized in this function [-Wmaybe-uninitialized]
.../robotjs@0.6.0/node_modules/robotjs install:   369 |       for (ss=(s), dd=(d); nn>0; nn--) *dd++ = *ss++; } }
.../robotjs@0.6.0/node_modules/robotjs install:       |                                                ^
.../robotjs@0.6.0/node_modules/robotjs install: ../src/snprintf.c:573:19: note: ‘str_arg’ was declared here
.../robotjs@0.6.0/node_modules/robotjs install:   573 |       const char *str_arg;      /* string address in case of string argument */
.../robotjs@0.6.0/node_modules/robotjs install:       |                   ^~~~~~~
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/MMBitmap.o
.../robotjs@0.6.0/node_modules/robotjs install:   CC(target) Release/obj.target/robotjs/src/xdisplay.o
.../robotjs@0.6.0/node_modules/robotjs install: ../src/xdisplay.c: In function ‘setXDisplay’:
.../robotjs@0.6.0/node_modules/robotjs install: ../src/xdisplay.c:53:16: warning: implicit declaration of function ‘strdup’ [-Wimplicit-function-declaration]
.../robotjs@0.6.0/node_modules/robotjs install:    53 |  displayName = strdup(name);
.../robotjs@0.6.0/node_modules/robotjs install:       |                ^~~~~~
.../robotjs@0.6.0/node_modules/robotjs install: ../src/xdisplay.c:53:16: warning: incompatible implicit declaration of built-in function ‘strdup’
.../robotjs@0.6.0/node_modules/robotjs install:   SOLINK_MODULE(target) Release/obj.target/robotjs.node
.../robotjs@0.6.0/node_modules/robotjs install:   COPY Release/robotjs.node
.../robotjs@0.6.0/node_modules/robotjs install: make: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/robotjs@0.6.0/node_modules/robotjs/build'
.../robotjs@0.6.0/node_modules/robotjs install: gyp info ok 
.../robotjs@0.6.0/node_modules/robotjs install: Done
.../node_modules/playwright install: Playwright build of firefox v1304 downloaded to /home/runner/.cache/ms-playwright/firefox-1304
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/signature.o
.../node_modules/tiny-secp256k1 install:   SOLINK_MODULE(target) Release/obj.target/secp256k1.node
.../node_modules/tiny-secp256k1 install:   COPY Release/secp256k1.node
.../node_modules/tiny-secp256k1 install: make: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/tiny-secp256k1@1.1.6/node_modules/tiny-secp256k1/build'
.../node_modules/tiny-secp256k1 install: gyp info ok 
.../node_modules/tiny-secp256k1 install: Done
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/ecdsa.o
.../node_modules/secp256k1 install: ../src/ecdsa.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE sign(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/secp256k1 install: ../src/ecdsa.cc:88:131: warning: ignoring return value of ‘v8::Maybe<bool> v8::Object::Set(v8::Local<v8::Context>, v8::Local<v8::Value>, v8::Local<v8::Value>)’, declared with attribute warn_unused_result [-Wunused-result]
.../node_modules/secp256k1 install:    88 |   obj->Set(info.GetIsolate()->GetCurrentContext(), Nan::New<v8::String>("signature").ToLocalChecked(), COPY_BUFFER(&output[0], 64));
.../node_modules/secp256k1 install:       |                                                                                                                                   ^
.../node_modules/secp256k1 install: In file included from /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:63,
.../node_modules/secp256k1 install:                  from ../src/ecdsa.cc:1:
.../node_modules/secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/v8.h:3926:37: note: declared here
.../node_modules/secp256k1 install:  3926 |   V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context,
.../node_modules/secp256k1 install:       |                                     ^~~
.../node_modules/secp256k1 install: ../src/ecdsa.cc:89:130: warning: ignoring return value of ‘v8::Maybe<bool> v8::Object::Set(v8::Local<v8::Context>, v8::Local<v8::Value>, v8::Local<v8::Value>)’, declared with attribute warn_unused_result [-Wunused-result]
.../node_modules/secp256k1 install:    89 |   obj->Set(info.GetIsolate()->GetCurrentContext(), Nan::New<v8::String>("recovery").ToLocalChecked(), Nan::New<v8::Number>(recid));
.../node_modules/secp256k1 install:       |                                                                                                                                  ^
.../node_modules/secp256k1 install: In file included from /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:63,
.../node_modules/secp256k1 install:                  from ../src/ecdsa.cc:1:
.../node_modules/secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/v8.h:3926:37: note: declared here
.../node_modules/secp256k1 install:  3926 |   V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context,
.../node_modules/secp256k1 install:       |                                     ^~~
.../node_modules/playwright install: Playwright build of webkit v1578 downloaded to /home/runner/.cache/ms-playwright/webkit-1578
.../node_modules/playwright install: Done
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/ecdh.o
.../node_modules/secp256k1 install:   CC(target) Release/obj.target/secp256k1/src/secp256k1-src/src/secp256k1.o
.../node_modules/secp256k1 install:   CC(target) Release/obj.target/secp256k1/src/secp256k1-src/contrib/lax_der_parsing.o
.../node_modules/secp256k1 install:   CC(target) Release/obj.target/secp256k1/src/secp256k1-src/contrib/lax_der_privatekey_parsing.o
.../node_modules/secp256k1 install:   SOLINK_MODULE(target) Release/obj.target/secp256k1.node
.../node_modules/secp256k1 install:   COPY Release/secp256k1.node
.../node_modules/secp256k1 install: make: Leaving directory '/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/secp256k1@3.8.0/node_modules/secp256k1/build'
.../node_modules/secp256k1 install: gyp info ok 
.../node_modules/secp256k1 install: Done
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install$ node scripts/download-prebuilt.js
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info it worked if it ends with ok
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info using node-pre-gyp@1.0.3
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info using node@16.1.0 | linux | x64
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info check checked for "/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/wrtc@0.4.7/node_modules/wrtc/build/Release/wrtc.node" (not found)
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp http GET https://node-webrtc.s3.amazonaws.com/wrtc/v0.4.7/Release/linux-x64.tar.gz
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info install unpacking Release/wrtc.node
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info extracted file count: 1 
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info ok 
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: [wrtc] Success: "/home/runner/work/protocols/protocols/common/temp/node_modules/.pnpm/wrtc@0.4.7/node_modules/wrtc/build/Release/wrtc.node" is installed via remote
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: Done

Copying "/home/runner/work/protocols/protocols/common/temp/pnpm-lock.yaml"
  --> "/home/runner/work/protocols/protocols/common/config/rush/pnpm-lock.yaml"


Rush update finished successfully. (1 minute 7.4 seconds)
```

### stderr:

```Shell
npm WARN deprecated read-package-tree@5.1.6: The functionality that this package provided is now in @npmcli/arborist
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated @opentelemetry/types@0.2.0: Package renamed to @opentelemetry/api, see https://github.com/open-telemetry/opentelemetry-js
Your version of Node.js (16.1.0) is not a Long-Term Support (LTS) release. These versions frequently have bugs. Please consider installing a stable release.
```

</details>
<details>
<summary><em>rm -rf .npmrc</em></summary>



</details>

</details>

## Changed files
<details>
<summary>Changed 11 files: </summary>

- common/config/rush/pnpm-lock.yaml
- packages/demos/package.json
- packages/devtools/devtools-mesh/package.json
- packages/devtools/devtools/package.json
- packages/sdk/react-client/package.json
- packages/sdk/react-components/package.json
- packages/sdk/react-framework/package.json
- packages/sdk/react-registry-client/package.json
- packages/sdk/registry-client/package.json
- packages/tutorials/tutorials-tasks-app/package.json
- packages/wallet/wallet-playground/package.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)