### PR TITLE
chore: Sort package.json and update references in tsconfig.json files

### DIFF
--- a/packages/echo/echo-testing/package.json
+++ b/packages/echo/echo-testing/package.json
@@ -16,8 +16,8 @@
   "scripts": {
     "build": "toolchain build",
     "build:test": "toolchain build:test",
-    "test": "toolchain test",
     "lint": "toolchain lint",
+    "test": "toolchain test",
     "update:saved-state": "ts-node --transpile-only ./scripts/update-saved-state.ts"
   },
   "dependencies": {
@@ -28,23 +28,23 @@
     "lodash": "4.17.21"
   },
   "devDependencies": {
+    "@dxos/object-model": "workspace:*",
+    "@dxos/random-access-multi-storage": "workspace:*",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/faker": "^5.5.1",
     "@types/jest": "^26.0.7",
     "@types/lodash": "^4.14.175",
-    "expect": "~27.0.2",
     "@types/mocha": "~8.2.2",
-    "@dxos/random-access-multi-storage": "workspace:*",
-    "jsondown": "dxos/jsondown#main",
     "abstract-leveldown": "~7.0.0",
-    "@dxos/object-model": "workspace:*",
+    "expect": "~27.0.2",
+    "jsondown": "dxos/jsondown#main",
     "ts-node": "^9.1.1",
     "typescript": "^4.5.2"
   },
-  "toolchain": {
-    "testingFramework": "mocha"
-  },
   "publishConfig": {
     "access": "public"
+  },
+  "toolchain": {
+    "testingFramework": "mocha"
   }
 }

--- a/packages/echo/echo-testing/tsconfig.json
+++ b/packages/echo/echo-testing/tsconfig.json
@@ -15,6 +15,12 @@
     },
     {
       "path": "../object-model"
+    },
+    {
+      "path": "../object-model"
+    },
+    {
+      "path": "../../common/random-access-multi-storage"
     }
   ]
 }

--- a/packages/wallet/wallet-extension/package.json
+++ b/packages/wallet/wallet-extension/package.json
@@ -5,13 +5,13 @@
   "license": "AGPL-3.0",
   "author": "DXOS.org",
   "scripts": {
+    "book": "esbuild-server book",
     "browser-mocha": "browser-mocha --headless=false --setup browser-mocha/setup.js 'browser-mocha/*.test.ts' --browserArg=--disable-extensions-except=$(pwd)/dist --browserArg=--load-extension=$(pwd)/dist",
     "build": "toolchain build && node scripts/build.js",
     "build:test": "pnpm run build && pnpm run test",
     "lint": "toolchain lint",
     "test": "pnpm run lint",
-    "test:e2e": "toolchain test",
-    "book": "esbuild-server book"
+    "test:e2e": "toolchain test"
   },
   "dependencies": {
     "@dxos/async": "workspace:*",
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@dxos/browser-mocha": "workspace:*",
     "@dxos/esbuild-plugins": "workspace:*",
+    "@dxos/esbuild-server": "~1.7.4",
     "@dxos/toolchain-node-library": "workspace:*",
     "@types/faker": "^5.5.1",
     "@types/mocha": "~8.2.2",
@@ -57,8 +58,7 @@
     "rmdir": "~1.2.0",
     "typescript": "^4.5.2",
     "uuid": "^8.3.2",
-    "webextension-polyfill-ts": "~0.25.0",
-    "@dxos/esbuild-server": "~1.7.4"
+    "webextension-polyfill-ts": "~0.25.0"
   },
   "toolchain": {
     "testingFramework": "mocha"


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>npx @sfomin/for-each-package@0.0.2 -n "@dxos/*" "npx sort-package-json@1.53.1"</em></summary>

```Shell
[@dxos/toolchain-node-library]: npx sort-package-json@1.53.1



[@dxos/esbuild-plugins]: npx sort-package-json@1.53.1



[@dxos/wallet-playground]: npx sort-package-json@1.53.1



[@dxos/wallet-extension]: npx sort-package-json@1.53.1

package.json is sorted!


[@dxos/tutorials-tasks-app]: npx sort-package-json@1.53.1



[@dxos/registry-client]: npx sort-package-json@1.53.1



[@dxos/react-registry-client]: npx sort-package-json@1.53.1



[@dxos/react-framework]: npx sort-package-json@1.53.1



[@dxos/react-components]: npx sort-package-json@1.53.1



[@dxos/react-client]: npx sort-package-json@1.53.1



[@dxos/config]: npx sort-package-json@1.53.1



[@dxos/client]: npx sort-package-json@1.53.1



[@dxos/signal]: npx sort-package-json@1.53.1



[@dxos/protocol-plugin-rpc]: npx sort-package-json@1.53.1



[@dxos/protocol-plugin-replicator]: npx sort-package-json@1.53.1



[@dxos/protocol-plugin-presence]: npx sort-package-json@1.53.1



[@dxos/protocol-plugin-messenger]: npx sort-package-json@1.53.1



[@dxos/protocol-network-generator]: npx sort-package-json@1.53.1



[@dxos/protocol]: npx sort-package-json@1.53.1



[@dxos/network-manager]: npx sort-package-json@1.53.1



[@dxos/network-generator]: npx sort-package-json@1.53.1



[@dxos/broadcast]: npx sort-package-json@1.53.1



[@dxos/halo-protocol]: npx sort-package-json@1.53.1



[@dxos/credentials]: npx sort-package-json@1.53.1



[@dxos/gravity-core]: npx sort-package-json@1.53.1



[@dxos/browser-tests]: npx sort-package-json@1.53.1



[@dxos/browser-mocha]: npx sort-package-json@1.53.1



[@dxos/text-model]: npx sort-package-json@1.53.1



[@dxos/object-model]: npx sort-package-json@1.53.1



[@dxos/model-factory]: npx sort-package-json@1.53.1



[@dxos/messenger-model]: npx sort-package-json@1.53.1



[@dxos/feed-store]: npx sort-package-json@1.53.1



[@dxos/echo-testing]: npx sort-package-json@1.53.1

package.json is sorted!


[@dxos/echo-protocol]: npx sort-package-json@1.53.1



[@dxos/echo-db]: npx sort-package-json@1.53.1



[@dxos/devtools-mesh]: npx sort-package-json@1.53.1



[@dxos/devtools-extension]: npx sort-package-json@1.53.1



[@dxos/devtools]: npx sort-package-json@1.53.1



[@dxos/test-bot-deprecated]: npx sort-package-json@1.53.1



[@dxos/protocol-plugin-bot-deprecated]: npx sort-package-json@1.53.1



[@dxos/botkit-deprecated]: npx sort-package-json@1.53.1



[@dxos/botkit-client-deprecated]: npx sort-package-json@1.53.1



[@dxos/bot-deprecated]: npx sort-package-json@1.53.1



[@dxos/demos]: npx sort-package-json@1.53.1



[@dxos/util]: npx sort-package-json@1.53.1



[@dxos/testutils]: npx sort-package-json@1.53.1



[@dxos/rpc]: npx sort-package-json@1.53.1



[@dxos/random-access-multi-storage]: npx sort-package-json@1.53.1



[@dxos/protobuf-test]: npx sort-package-json@1.53.1



[@dxos/protobuf-compiler-browser-test]: npx sort-package-json@1.53.1



[@dxos/protobuf-compiler]: npx sort-package-json@1.53.1



[@dxos/proto]: npx sort-package-json@1.53.1



[@dxos/debug]: npx sort-package-json@1.53.1



[@dxos/crypto]: npx sort-package-json@1.53.1



[@dxos/codec-protobuf]: npx sort-package-json@1.53.1



[@dxos/async]: npx sort-package-json@1.53.1



[@dxos/botkit]: npx sort-package-json@1.53.1



[@dxos/bot-factory-client]: npx sort-package-json@1.53.1



[@dxos/sdk-docs]: npx sort-package-json@1.53.1
```

### stderr:

```Shell
npm WARN exec The following package was not found and will be installed: @sfomin/for-each-package@0.0.2
npm WARN exec The following package was not found and will be installed: sort-package-json@1.53.1
```

</details>
<details>
<summary><em>npx @monorepo-utils/workspaces-to-typescript-project-references@2.7.4</em></summary>

```Shell
Update Project References!
```

### stderr:

```Shell
npm WARN exec The following package was not found and will be installed: @monorepo-utils/workspaces-to-typescript-project-references@2.7.4
```

</details>

</details>

## Changed files
<details>
<summary>Changed 3 files: </summary>

- packages/echo/echo-testing/package.json
- packages/echo/echo-testing/tsconfig.json
- packages/wallet/wallet-extension/package.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)