### PR TITLE
chore: Sort package.json and update references in tsconfig.json files

### DIFF
--- a/packages/sdk/client/package.json
+++ b/packages/sdk/client/package.json
@@ -31,6 +31,9 @@
     "@dxos/proto": "workspace:*",
     "@dxos/rpc": "workspace:*",
     "@dxos/util": "workspace:*",
+    "@polkadot/keyring": "6.11.1",
+    "@polkadot/util": "6.11.1",
+    "@polkadot/util-crypto": "6.11.1",
     "@wirelineio/registry-client": "~1.1.0-beta.3",
     "abstract-leveldown": "~7.0.0",
     "assert": "^2.0.0",
@@ -41,10 +44,7 @@
     "lodash.defaultsdeep": "^4.6.1",
     "memdown": "^5.1.0",
     "readable-stream": "^3.6.0",
-    "uuid": "^8.3.2",
-    "@polkadot/util-crypto": "6.11.1",
-    "@polkadot/util": "6.11.1",
-    "@polkadot/keyring": "6.11.1"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@dxos/random-access-multi-storage": "workspace:*",

--- a/packages/sdk/registry-client/package.json
+++ b/packages/sdk/registry-client/package.json
@@ -42,6 +42,8 @@
     "protobufjs": "^6.9.0"
   },
   "devDependencies": {
+    "@dxos/client": "workspace:*",
+    "@dxos/credentials": "workspace:*",
     "@dxos/toolchain-node-library": "workspace:*",
     "@polkadot/typegen": "^4.17.1",
     "@types/chai": "^4.2.15",
@@ -54,9 +56,7 @@
     "chai-as-promised": "^7.1.1",
     "mocha": "~8.4.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.5.2",
-    "@dxos/client": "workspace:*",
-    "@dxos/credentials": "workspace:*"
+    "typescript": "^4.5.2"
   },
   "engines": {
     "node": ">= 14"

--- a/packages/sdk/registry-client/tsconfig.json
+++ b/packages/sdk/registry-client/tsconfig.json
@@ -35,6 +35,12 @@
     },
     {
       "path": "../../common/util"
+    },
+    {
+      "path": "../client"
+    },
+    {
+      "path": "../../halo/credentials"
     }
   ]
 }


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>npx @sfomin/for-each-package@0.0.2 -n "@dxos/*" "npx sort-package-json@1.53.1"</em></summary>

```Shell
[@dxos/toolchain-node-library]: npx sort-package-json@1.53.1



[@dxos/esbuild-plugins]: npx sort-package-json@1.53.1



[@dxos/wallet-playground]: npx sort-package-json@1.53.1



[@dxos/wallet-extension]: npx sort-package-json@1.53.1



[@dxos/tutorials-tasks-app]: npx sort-package-json@1.53.1



[@dxos/registry-client]: npx sort-package-json@1.53.1

package.json is sorted!


[@dxos/react-registry-client]: npx sort-package-json@1.53.1



[@dxos/react-framework]: npx sort-package-json@1.53.1



[@dxos/react-components]: npx sort-package-json@1.53.1



[@dxos/react-client]: npx sort-package-json@1.53.1



[@dxos/config]: npx sort-package-json@1.53.1



[@dxos/client]: npx sort-package-json@1.53.1

package.json is sorted!


[@dxos/signal]: npx sort-package-json@1.53.1



[@dxos/protocol-plugin-rpc]: npx sort-package-json@1.53.1



[@dxos/protocol-plugin-replicator]: npx sort-package-json@1.53.1



[@dxos/protocol-plugin-presence]: npx sort-package-json@1.53.1



[@dxos/protocol-plugin-messenger]: npx sort-package-json@1.53.1



[@dxos/protocol-network-generator]: npx sort-package-json@1.53.1



[@dxos/protocol]: npx sort-package-json@1.53.1



[@dxos/network-manager]: npx sort-package-json@1.53.1



[@dxos/network-generator]: npx sort-package-json@1.53.1



[@dxos/broadcast]: npx sort-package-json@1.53.1



[@dxos/halo-protocol]: npx sort-package-json@1.53.1



[@dxos/credentials]: npx sort-package-json@1.53.1



[@dxos/gravity-core]: npx sort-package-json@1.53.1



[@dxos/browser-tests]: npx sort-package-json@1.53.1



[@dxos/browser-mocha]: npx sort-package-json@1.53.1



[@dxos/text-model]: npx sort-package-json@1.53.1



[@dxos/object-model]: npx sort-package-json@1.53.1



[@dxos/model-factory]: npx sort-package-json@1.53.1



[@dxos/messenger-model]: npx sort-package-json@1.53.1



[@dxos/feed-store]: npx sort-package-json@1.53.1



[@dxos/echo-testing]: npx sort-package-json@1.53.1



[@dxos/echo-protocol]: npx sort-package-json@1.53.1



[@dxos/echo-db]: npx sort-package-json@1.53.1



[@dxos/devtools-mesh]: npx sort-package-json@1.53.1



[@dxos/devtools-extension]: npx sort-package-json@1.53.1



[@dxos/devtools]: npx sort-package-json@1.53.1



[@dxos/test-bot-deprecated]: npx sort-package-json@1.53.1



[@dxos/protocol-plugin-bot-deprecated]: npx sort-package-json@1.53.1



[@dxos/botkit-deprecated]: npx sort-package-json@1.53.1



[@dxos/botkit-client-deprecated]: npx sort-package-json@1.53.1



[@dxos/bot-deprecated]: npx sort-package-json@1.53.1



[@dxos/demos]: npx sort-package-json@1.53.1



[@dxos/util]: npx sort-package-json@1.53.1



[@dxos/testutils]: npx sort-package-json@1.53.1



[@dxos/rpc]: npx sort-package-json@1.53.1



[@dxos/random-access-multi-storage]: npx sort-package-json@1.53.1



[@dxos/protobuf-test]: npx sort-package-json@1.53.1



[@dxos/protobuf-compiler-browser-test]: npx sort-package-json@1.53.1



[@dxos/protobuf-compiler]: npx sort-package-json@1.53.1



[@dxos/proto]: npx sort-package-json@1.53.1



[@dxos/debug]: npx sort-package-json@1.53.1



[@dxos/crypto]: npx sort-package-json@1.53.1



[@dxos/codec-protobuf]: npx sort-package-json@1.53.1



[@dxos/async]: npx sort-package-json@1.53.1



[@dxos/botkit]: npx sort-package-json@1.53.1



[@dxos/bot-factory-client]: npx sort-package-json@1.53.1



[@dxos/sdk-docs]: npx sort-package-json@1.53.1
```

### stderr:

```Shell
npm WARN exec The following package was not found and will be installed: @sfomin/for-each-package@0.0.2
npm WARN deprecated cli-ux@4.9.3: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm WARN deprecated cli-ux@5.6.6: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm WARN exec The following package was not found and will be installed: sort-package-json@1.53.1
```

</details>
<details>
<summary><em>npx @monorepo-utils/workspaces-to-typescript-project-references@2.7.4</em></summary>

```Shell
Update Project References!
```

### stderr:

```Shell
npm WARN exec The following package was not found and will be installed: @monorepo-utils/workspaces-to-typescript-project-references@2.7.4
```

</details>

</details>

## Changed files
<details>
<summary>Changed 3 files: </summary>

- packages/sdk/client/package.json
- packages/sdk/registry-client/package.json
- packages/sdk/registry-client/tsconfig.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)