### PR TITLE
chore: Sort package.json and update references in tsconfig.json files

### DIFF
--- a/packages/common/typedoc/package.json
+++ b/packages/common/typedoc/package.json
@@ -12,14 +12,14 @@
   "scripts": {
     "build": "",
     "build:test": "",
-    "test": "",
-    "lint": "",
-    "generate:sdk": "typedoc --json src/api/sdk.json --entryPointStrategy packages '../../sdk/*' --name '@dxos/typedoc'",
-    "generate:echo": "typedoc --json src/api/echo.json --entryPointStrategy packages '../../echo/*' --name '@dxos/typedoc'",
-    "generate:mesh": "typedoc --json src/api/mesh.json --entryPointStrategy packages '../../mesh/*' --name '@dxos/typedoc'",
-    "generate:halo": "typedoc --json src/api/halo.json --entryPointStrategy packages '../../halo/*' --name '@dxos/typedoc'",
     "generate": "npm run generate:sdk && npm run generate:echo && npm run generate:mesh && npm run generate:halo",
-    "prerelease": "npm run generate 2>&1 && tsc"
+    "generate:echo": "typedoc --json src/api/echo.json --entryPointStrategy packages '../../echo/*' --name '@dxos/typedoc'",
+    "generate:halo": "typedoc --json src/api/halo.json --entryPointStrategy packages '../../halo/*' --name '@dxos/typedoc'",
+    "generate:mesh": "typedoc --json src/api/mesh.json --entryPointStrategy packages '../../mesh/*' --name '@dxos/typedoc'",
+    "generate:sdk": "typedoc --json src/api/sdk.json --entryPointStrategy packages '../../sdk/*' --name '@dxos/typedoc'",
+    "lint": "",
+    "prerelease": "npm run generate 2>&1 && tsc",
+    "test": ""
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/common/typedoc/tsconfig.json
+++ b/packages/common/typedoc/tsconfig.json
@@ -6,5 +6,6 @@
   "include": [
     "src",
     "src/api/*.json"
-  ]
+  ],
+  "references": []
 }


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/protocols/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>npx @sfomin/for-each-package@0.0.2 -n "@dxos/*" "npx sort-package-json@1.53.1"</em></summary>

```Shell
[@dxos/toolchain-node-library]: npx sort-package-json@1.53.1



[@dxos/esbuild-plugins]: npx sort-package-json@1.53.1



[@dxos/wallet-playground]: npx sort-package-json@1.53.1



[@dxos/wallet-extension]: npx sort-package-json@1.53.1



[@dxos/tutorials-tasks-app]: npx sort-package-json@1.53.1



[@dxos/registry-client]: npx sort-package-json@1.53.1



[@dxos/react-registry-client]: npx sort-package-json@1.53.1



[@dxos/react-framework]: npx sort-package-json@1.53.1



[@dxos/react-components]: npx sort-package-json@1.53.1



[@dxos/react-client]: npx sort-package-json@1.53.1



[@dxos/config]: npx sort-package-json@1.53.1



[@dxos/client]: npx sort-package-json@1.53.1



[@dxos/signal]: npx sort-package-json@1.53.1



[@dxos/protocol-plugin-rpc]: npx sort-package-json@1.53.1



[@dxos/protocol-plugin-replicator]: npx sort-package-json@1.53.1



[@dxos/protocol-plugin-presence]: npx sort-package-json@1.53.1



[@dxos/protocol-plugin-messenger]: npx sort-package-json@1.53.1



[@dxos/protocol-network-generator]: npx sort-package-json@1.53.1



[@dxos/protocol]: npx sort-package-json@1.53.1



[@dxos/network-manager]: npx sort-package-json@1.53.1



[@dxos/network-generator]: npx sort-package-json@1.53.1



[@dxos/broadcast]: npx sort-package-json@1.53.1



[@dxos/halo-protocol]: npx sort-package-json@1.53.1



[@dxos/credentials]: npx sort-package-json@1.53.1



[@dxos/gravity-core]: npx sort-package-json@1.53.1



[@dxos/browser-tests]: npx sort-package-json@1.53.1



[@dxos/browser-mocha]: npx sort-package-json@1.53.1



[@dxos/text-model]: npx sort-package-json@1.53.1



[@dxos/object-model]: npx sort-package-json@1.53.1



[@dxos/model-factory]: npx sort-package-json@1.53.1



[@dxos/messenger-model]: npx sort-package-json@1.53.1



[@dxos/feed-store]: npx sort-package-json@1.53.1



[@dxos/echo-testing]: npx sort-package-json@1.53.1



[@dxos/echo-protocol]: npx sort-package-json@1.53.1



[@dxos/echo-db]: npx sort-package-json@1.53.1



[@dxos/devtools-mesh]: npx sort-package-json@1.53.1



[@dxos/devtools-extension]: npx sort-package-json@1.53.1



[@dxos/devtools]: npx sort-package-json@1.53.1



[@dxos/test-bot-deprecated]: npx sort-package-json@1.53.1



[@dxos/protocol-plugin-bot-deprecated]: npx sort-package-json@1.53.1



[@dxos/botkit-deprecated]: npx sort-package-json@1.53.1



[@dxos/botkit-client-deprecated]: npx sort-package-json@1.53.1



[@dxos/bot-deprecated]: npx sort-package-json@1.53.1



[@dxos/demos]: npx sort-package-json@1.53.1



[@dxos/util]: npx sort-package-json@1.53.1



[@dxos/typedoc]: npx sort-package-json@1.53.1

package.json is sorted!


[@dxos/testutils]: npx sort-package-json@1.53.1



[@dxos/rpc]: npx sort-package-json@1.53.1



[@dxos/random-access-multi-storage]: npx sort-package-json@1.53.1



[@dxos/protobuf-test]: npx sort-package-json@1.53.1



[@dxos/protobuf-compiler-browser-test]: npx sort-package-json@1.53.1



[@dxos/protobuf-compiler]: npx sort-package-json@1.53.1



[@dxos/proto]: npx sort-package-json@1.53.1



[@dxos/debug]: npx sort-package-json@1.53.1



[@dxos/crypto]: npx sort-package-json@1.53.1



[@dxos/codec-protobuf]: npx sort-package-json@1.53.1



[@dxos/async]: npx sort-package-json@1.53.1



[@dxos/botkit]: npx sort-package-json@1.53.1



[@dxos/bot-factory-client]: npx sort-package-json@1.53.1



[@dxos/sdk-docs]: npx sort-package-json@1.53.1
```

### stderr:

```Shell
npm WARN exec The following package was not found and will be installed: @sfomin/for-each-package@0.0.2
npm WARN deprecated cli-ux@4.9.3: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm WARN deprecated cli-ux@5.6.6: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm WARN exec The following package was not found and will be installed: sort-package-json@1.53.1
```

</details>
<details>
<summary><em>npx @monorepo-utils/workspaces-to-typescript-project-references@2.7.4</em></summary>

```Shell
Update Project References!
```

### stderr:

```Shell
npm WARN exec The following package was not found and will be installed: @monorepo-utils/workspaces-to-typescript-project-references@2.7.4
```

</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- packages/common/typedoc/package.json
- packages/common/typedoc/tsconfig.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)