### PR TITLE
fix: onChange event and add accept prop

### DIFF
--- a/packages/sdk/react-components/src/Files/FileUploadDialog.tsx
+++ b/packages/sdk/react-components/src/Files/FileUploadDialog.tsx
@@ -7,7 +7,6 @@ import React, { FC, useEffect, useRef } from 'react';
 /**
  * Standard file upload dialog.
  */
-// TODO(gcolotti): Use FileUploadDialog from react-components, onChange wasn't working.
 export const FileUploadDialog: FC<{
   open?: boolean
   onClose: () => void


### PR DESCRIPTION
PR created to discuss about the component `FileUploadDialog` and a possible fix to a bug/unexpected behavior. 

The `FileUploadDialog` component is working perfectly in `Kitchen-sink`, but when I tried to implement it in the `notebook-app`, the `onChange` event is not being triggered.
I tried several things I found on the internet with no luck, the most relevant:
- Verify that the `id` of the input is not used on any other component
- Try using `onInput` instead of `onChange`
- Also try with `onInputCapture` and `onChangeCapture`.

So removing the handler on the input and adding an event listener when the component is mounted fixed the issue, and its working both on kitchen-sink and braneframe.

My question here is: should we do that or should we try to get the `onChange` working?