### PR TITLE
chore: Align @emotion/react version

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -594,7 +594,7 @@ importers:
       '@dxos/react-toolkit': workspace:*
       '@dxos/util': workspace:*
       '@emotion/css': ^11.7.1
-      '@emotion/react': ^11.4.1
+      '@emotion/react': ^11.8.2
       '@emotion/styled': ^11.3.0
       '@mui/icons-material': ^5.4.2
       '@mui/lab': ^5.0.0-alpha.69
@@ -639,8 +639,8 @@ importers:
       '@dxos/echo-db': link:../../echo/echo-db
       '@dxos/echo-protocol': link:../../echo/echo-protocol
       '@dxos/echo-testing': link:../../echo/echo-testing
-      '@dxos/gem-core': 2.2.1-beta.11_h44jlxhx5wlm2ewevq2feijgl4
-      '@dxos/gem-spore': 2.2.1-beta.11_h44jlxhx5wlm2ewevq2feijgl4
+      '@dxos/gem-core': 2.2.1-beta.11_6vuhyxdoedouik2aizrogpbpme
+      '@dxos/gem-spore': 2.2.1-beta.11_6vuhyxdoedouik2aizrogpbpme
       '@dxos/object-model': link:../../echo/object-model
       '@dxos/react-client': link:../../sdk/react-client
       '@dxos/react-client-testing': link:../../sdk/react-client-testing
@@ -650,13 +650,13 @@ importers:
       '@dxos/react-toolkit': link:../../sdk/react-toolkit
       '@dxos/util': link:../../common/util
       '@emotion/css': 11.7.1_@babel+core@7.13.16
-      '@emotion/react': 11.7.1_zd2habhu2konpee7cqi3qp36wu
-      '@emotion/styled': 11.6.0_i6myypufbcsfwoh3o7hlv4fkcq
+      '@emotion/react': 11.8.2_zd2habhu2konpee7cqi3qp36wu
+      '@emotion/styled': 11.6.0_3ykywuw2ymvikfiuh223mfxuvq
       '@mui/icons-material': 5.4.2_6dqunvur4qyh6txjpxrdnmfucy
-      '@mui/lab': 5.0.0-alpha.69_qs2lszykn622lnkwnv44em2vme
-      '@mui/material': 5.4.2_7itellgzua2ua3ibqryroeg6ke
+      '@mui/lab': 5.0.0-alpha.69_hw6y66r7ofivsji7dkgqr2l34u
+      '@mui/material': 5.4.2_tedopk7kxcqvemqshyzlgc57wq
       '@mui/styles': 5.4.2_z7w6vgz62d5pbxpnoxayoqdmly
-      '@mui/system': 5.4.2_56lgv6ej77cijhtsejusgffagm
+      '@mui/system': 5.4.2_jsjqrlwrmeqxz2lrgrnw2nobdu
       '@mui/x-data-grid': 5.5.1_mdr3ne43bcrsx7lgpoojkl33zq
       clsx: 1.1.1
       debug: 4.3.3
@@ -713,7 +713,7 @@ importers:
       '@dxos/react-toolkit': workspace:*
       '@dxos/text-model': workspace:*
       '@emotion/css': ^11.7.1
-      '@emotion/react': ^11.4.1
+      '@emotion/react': ^11.8.2
       '@emotion/styled': ^11.3.0
       '@lexical/hashtag': ~0.2.5
       '@lexical/list': ~0.2.5
@@ -801,7 +801,7 @@ importers:
       '@dxos/react-client': workspace:*
       '@dxos/react-components': workspace:*
       '@dxos/react-toolkit': workspace:*
-      '@emotion/react': ^11.4.1
+      '@emotion/react': ^11.8.2
       '@emotion/styled': ^11.3.0
       '@mui/icons-material': ^5.4.2
       '@mui/lab': ^5.0.0-alpha.69
@@ -832,11 +832,11 @@ importers:
       '@dxos/react-client': link:../../sdk/react-client
       '@dxos/react-components': link:../../sdk/react-components
       '@dxos/react-toolkit': link:../../sdk/react-toolkit
-      '@emotion/react': 11.7.1_zd2habhu2konpee7cqi3qp36wu
-      '@emotion/styled': 11.6.0_i6myypufbcsfwoh3o7hlv4fkcq
+      '@emotion/react': 11.8.2_zd2habhu2konpee7cqi3qp36wu
+      '@emotion/styled': 11.6.0_3ykywuw2ymvikfiuh223mfxuvq
       '@mui/icons-material': 5.4.2_6dqunvur4qyh6txjpxrdnmfucy
-      '@mui/lab': 5.0.0-alpha.69_qs2lszykn622lnkwnv44em2vme
-      '@mui/material': 5.4.2_7itellgzua2ua3ibqryroeg6ke
+      '@mui/lab': 5.0.0-alpha.69_hw6y66r7ofivsji7dkgqr2l34u
+      '@mui/material': 5.4.2_tedopk7kxcqvemqshyzlgc57wq
       '@mui/styles': 5.4.2_z7w6vgz62d5pbxpnoxayoqdmly
       buffer: 6.0.3
       react: 17.0.2
@@ -887,7 +887,7 @@ importers:
       '@dxos/react-toolkit': workspace:*
       '@dxos/rpc': workspace:*
       '@dxos/text-model': workspace:*
-      '@emotion/react': ^11.4.1
+      '@emotion/react': ^11.8.2
       '@emotion/styled': ^11.3.0
       '@mui/icons-material': ^5.4.2
       '@mui/lab': ^5.0.0-alpha.69
@@ -923,11 +923,11 @@ importers:
       '@dxos/react-components': link:../../sdk/react-components
       '@dxos/react-toolkit': link:../../sdk/react-toolkit
       '@dxos/rpc': link:../../common/rpc
-      '@emotion/react': 11.7.1_zd2habhu2konpee7cqi3qp36wu
-      '@emotion/styled': 11.6.0_i6myypufbcsfwoh3o7hlv4fkcq
+      '@emotion/react': 11.8.2_zd2habhu2konpee7cqi3qp36wu
+      '@emotion/styled': 11.6.0_3ykywuw2ymvikfiuh223mfxuvq
       '@mui/icons-material': 5.4.2_6dqunvur4qyh6txjpxrdnmfucy
-      '@mui/lab': 5.0.0-alpha.69_g7ugx7za7oprrwbwwmhdonbzqe
-      '@mui/material': 5.4.2_7itellgzua2ua3ibqryroeg6ke
+      '@mui/lab': 5.0.0-alpha.69_j2wldh5vogrbdhofa36dbqbv5y
+      '@mui/material': 5.4.2_tedopk7kxcqvemqshyzlgc57wq
       '@mui/styles': 5.4.2_z7w6vgz62d5pbxpnoxayoqdmly
       color-hash: 1.1.1
       faker: 5.5.3
@@ -948,7 +948,7 @@ importers:
       '@dxos/protocols-toolchain': link:../../../toolchains/protocols-toolchain
       '@dxos/react-client': link:../../sdk/react-client
       '@dxos/text-model': link:../../echo/text-model
-      '@mui/system': 5.4.2_56lgv6ej77cijhtsejusgffagm
+      '@mui/system': 5.4.2_jsjqrlwrmeqxz2lrgrnw2nobdu
       '@types/color-hash': 1.0.2
       '@types/faker': 5.5.9
       '@types/react': 17.0.37
@@ -975,7 +975,7 @@ importers:
       '@dxos/protocols-toolchain': workspace:*
       '@dxos/react-toolkit': workspace:*
       '@dxos/rpc': workspace:*
-      '@emotion/react': ^11.4.1
+      '@emotion/react': ^11.8.2
       '@emotion/styled': ^11.3.0
       '@mui/icons-material': ^5.4.2
       '@mui/lab': ^5.0.0-alpha.69
@@ -1020,11 +1020,11 @@ importers:
       '@dxos/network-manager': link:../../mesh/network-manager
       '@dxos/react-toolkit': link:../../sdk/react-toolkit
       '@dxos/rpc': link:../../common/rpc
-      '@emotion/react': 11.7.1_zd2habhu2konpee7cqi3qp36wu
-      '@emotion/styled': 11.6.0_i6myypufbcsfwoh3o7hlv4fkcq
+      '@emotion/react': 11.8.2_zd2habhu2konpee7cqi3qp36wu
+      '@emotion/styled': 11.6.0_3ykywuw2ymvikfiuh223mfxuvq
       '@mui/icons-material': 5.4.2_6dqunvur4qyh6txjpxrdnmfucy
-      '@mui/lab': 5.0.0-alpha.69_g7ugx7za7oprrwbwwmhdonbzqe
-      '@mui/material': 5.4.2_7itellgzua2ua3ibqryroeg6ke
+      '@mui/lab': 5.0.0-alpha.69_j2wldh5vogrbdhofa36dbqbv5y
+      '@mui/material': 5.4.2_tedopk7kxcqvemqshyzlgc57wq
       '@mui/styles': 5.4.2_z7w6vgz62d5pbxpnoxayoqdmly
       clsx: 1.1.1
       color-hash: 1.1.1
@@ -1073,7 +1073,7 @@ importers:
       '@dxos/react-components': workspace:*
       '@dxos/react-toolkit': workspace:*
       '@emotion/css': ^11.7.1
-      '@emotion/react': ^11.4.1
+      '@emotion/react': ^11.8.2
       '@emotion/styled': ^11.3.0
       '@mui/icons-material': ^5.4.2
       '@mui/material': ^5.4.2
@@ -1090,17 +1090,17 @@ importers:
     dependencies:
       '@dxos/crypto': link:../../common/crypto
       '@dxos/debug': link:../../common/debug
-      '@dxos/gem-core': 2.2.1-beta.11_h44jlxhx5wlm2ewevq2feijgl4
-      '@dxos/gem-spore': 2.2.1-beta.11_h44jlxhx5wlm2ewevq2feijgl4
+      '@dxos/gem-core': 2.2.1-beta.11_6vuhyxdoedouik2aizrogpbpme
+      '@dxos/gem-spore': 2.2.1-beta.11_6vuhyxdoedouik2aizrogpbpme
       '@dxos/network-manager': link:../../mesh/network-manager
       '@dxos/protocol-plugin-presence': link:../../mesh/protocol-plugin-presence
       '@dxos/react-components': link:../../sdk/react-components
       '@dxos/react-toolkit': link:../../sdk/react-toolkit
       '@emotion/css': 11.7.1_@babel+core@7.13.16
-      '@emotion/react': 11.7.1_zd2habhu2konpee7cqi3qp36wu
-      '@emotion/styled': 11.6.0_i6myypufbcsfwoh3o7hlv4fkcq
+      '@emotion/react': 11.8.2_zd2habhu2konpee7cqi3qp36wu
+      '@emotion/styled': 11.6.0_3ykywuw2ymvikfiuh223mfxuvq
       '@mui/icons-material': 5.4.2_6dqunvur4qyh6txjpxrdnmfucy
-      '@mui/material': 5.4.2_7itellgzua2ua3ibqryroeg6ke
+      '@mui/material': 5.4.2_tedopk7kxcqvemqshyzlgc57wq
       '@mui/styles': 5.4.2_z7w6vgz62d5pbxpnoxayoqdmly
       react-copy-to-clipboard: 5.0.4_react@17.0.2
       react-resize-aware: 3.1.1_react@17.0.2
@@ -2543,7 +2543,7 @@ importers:
       '@dxos/react-client': workspace:*
       '@dxos/react-components': workspace:*
       '@dxos/util': workspace:*
-      '@emotion/react': ^11.4.1
+      '@emotion/react': ^11.8.2
       '@emotion/styled': ^11.3.0
       '@mui/icons-material': ^5.4.2
       '@mui/lab': ^5.0.0-alpha.69
@@ -2605,7 +2605,7 @@ importers:
       '@dxos/eslint-plugin': ~1.0.27
       '@dxos/protocols-toolchain': workspace:*
       '@emotion/css': ^11.7.1
-      '@emotion/react': ^11.4.1
+      '@emotion/react': ^11.8.2
       '@emotion/styled': ^11.3.0
       '@mui/icons-material': ^5.4.2
       '@mui/lab': ^5.0.0-alpha.69
@@ -2655,12 +2655,12 @@ importers:
       '@dxos/esbuild-plugins': 2.28.7
       '@dxos/eslint-plugin': 1.0.27_nv27fge2mo5alj7g7fxbwkxkv4
       '@dxos/protocols-toolchain': link:../../../toolchains/protocols-toolchain
-      '@emotion/react': 11.7.1_zd2habhu2konpee7cqi3qp36wu
-      '@emotion/styled': 11.6.0_i6myypufbcsfwoh3o7hlv4fkcq
+      '@emotion/react': 11.8.2_zd2habhu2konpee7cqi3qp36wu
+      '@emotion/styled': 11.6.0_3ykywuw2ymvikfiuh223mfxuvq
       '@mui/icons-material': 5.4.2_6dqunvur4qyh6txjpxrdnmfucy
-      '@mui/lab': 5.0.0-alpha.69_qs2lszykn622lnkwnv44em2vme
-      '@mui/material': 5.4.2_7itellgzua2ua3ibqryroeg6ke
-      '@mui/system': 5.4.2_56lgv6ej77cijhtsejusgffagm
+      '@mui/lab': 5.0.0-alpha.69_hw6y66r7ofivsji7dkgqr2l34u
+      '@mui/material': 5.4.2_tedopk7kxcqvemqshyzlgc57wq
+      '@mui/system': 5.4.2_jsjqrlwrmeqxz2lrgrnw2nobdu
       '@types/debug': 4.1.7
       '@types/faker': 5.5.9
       '@types/lodash.defaultsdeep': 4.6.6
@@ -2696,7 +2696,7 @@ importers:
       '@dxos/react-client-testing': workspace:*
       '@dxos/react-components': workspace:*
       '@emotion/css': ^11.7.1
-      '@emotion/react': ^11.4.1
+      '@emotion/react': ^11.8.2
       '@emotion/styled': ^11.3.0
       '@mui/icons-material': ^5.4.2
       '@mui/lab': ^5.0.0-alpha.69
@@ -2837,7 +2837,7 @@ importers:
       '@dxos/react-registry-client': workspace:*
       '@dxos/registry-client': workspace:*
       '@emotion/css': ^11.7.1
-      '@emotion/react': ^11.4.1
+      '@emotion/react': ^11.8.2
       '@emotion/styled': ^11.3.0
       '@mui/icons-material': ^5.4.2
       '@mui/lab': ^5.0.0-alpha.69
@@ -5973,27 +5973,6 @@ packages:
       - supports-color
     dev: false
 
-  /@dxos/gem-core/2.2.1-beta.11_h44jlxhx5wlm2ewevq2feijgl4:
-    resolution: {integrity: sha512-6Y963BY9YhJ+GbOh43Vb18RHNhPrlK1SIUFWp8pTsOz1pnHRKwpuIQmP5HsItIZ/v8VdvslHhMoIJhzYk+bpHw==}
-    peerDependencies:
-      '@emotion/css': '>=11.0.0'
-      '@emotion/react': '>=11.0.0'
-      react: '*'
-      react-dom: '*'
-    dependencies:
-      '@emotion/css': 11.7.1_@babel+core@7.13.16
-      '@emotion/react': 11.7.1_zd2habhu2konpee7cqi3qp36wu
-      assert: 2.0.0
-      csstype: 3.0.10
-      d3: 7.3.0
-      debug: 4.3.3
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      use-resize-observer: 8.0.0_sfoxds7t5ydpegc3knd667wn6m
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@dxos/gem-spore/2.2.1-beta.11_6vuhyxdoedouik2aizrogpbpme:
     resolution: {integrity: sha512-YIPVo8zIS/AyOQwDvt5pnI0RbiwMK1N3PP0bnnlTvLsDcuHpd8CwWF1Vu9N5vKx/fHOPB1ZI+ZyRH1309L5GjA==}
     peerDependencies:
@@ -6005,30 +5984,6 @@ packages:
       '@dxos/gem-core': 2.2.1-beta.11_6vuhyxdoedouik2aizrogpbpme
       '@emotion/css': 11.7.1_@babel+core@7.13.16
       '@emotion/react': 11.8.2_zd2habhu2konpee7cqi3qp36wu
-      clsx: 1.1.1
-      csstype: 3.0.10
-      d3: 7.3.0
-      d3-force: 3.0.0
-      debug: 4.3.3
-      immutability-helper: 3.1.1
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      use-resize-observer: 8.0.0_sfoxds7t5ydpegc3knd667wn6m
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@dxos/gem-spore/2.2.1-beta.11_h44jlxhx5wlm2ewevq2feijgl4:
-    resolution: {integrity: sha512-YIPVo8zIS/AyOQwDvt5pnI0RbiwMK1N3PP0bnnlTvLsDcuHpd8CwWF1Vu9N5vKx/fHOPB1ZI+ZyRH1309L5GjA==}
-    peerDependencies:
-      '@emotion/css': '>=11.0.0'
-      '@emotion/react': '>=11.0.0'
-      react: '*'
-      react-dom: '*'
-    dependencies:
-      '@dxos/gem-core': 2.2.1-beta.11_h44jlxhx5wlm2ewevq2feijgl4
-      '@emotion/css': 11.7.1_@babel+core@7.13.16
-      '@emotion/react': 11.7.1_zd2habhu2konpee7cqi3qp36wu
       clsx: 1.1.1
       csstype: 3.0.10
       d3: 7.3.0
@@ -6140,29 +6095,6 @@ packages:
 
   /@emotion/memoize/0.7.5:
     resolution: {integrity: sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==}
-
-  /@emotion/react/11.7.1_zd2habhu2konpee7cqi3qp36wu:
-    resolution: {integrity: sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      '@types/react': '*'
-      react: '>=16.8.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/react':
-        optional: true
-    dependencies:
-      '@babel/core': 7.13.16
-      '@babel/runtime': 7.17.2
-      '@emotion/cache': 11.7.1
-      '@emotion/serialize': 1.0.2
-      '@emotion/sheet': 1.1.0
-      '@emotion/utils': 1.0.0
-      '@emotion/weak-memoize': 0.2.5
-      '@types/react': 17.0.37
-      hoist-non-react-statics: 3.3.2
-      react: 17.0.2
 
   /@emotion/react/11.8.2_enkrvzo7qg7bvv35jzfm2mdfgi:
     resolution: {integrity: sha512-+1bcHBaNJv5nkIIgnGKVsie3otS0wF9f1T1hteF3WeVvMNQEtfZ4YyFpnphGoot3ilU/wWMgP2SgIDuHLE/wAA==}
@@ -6293,29 +6225,6 @@ packages:
       react: 17.0.2
     dev: true
 
-  /@emotion/styled/11.6.0_i6myypufbcsfwoh3o7hlv4fkcq:
-    resolution: {integrity: sha512-mxVtVyIOTmCAkFbwIp+nCjTXJNgcz4VWkOYQro87jE2QBTydnkiYusMrRGFtzuruiGK4dDaNORk4gH049iiQuw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      '@emotion/react': ^11.0.0-rc.0
-      '@types/react': '*'
-      react: '>=16.8.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/react':
-        optional: true
-    dependencies:
-      '@babel/core': 7.13.16
-      '@babel/runtime': 7.17.2
-      '@emotion/babel-plugin': 11.7.1_@babel+core@7.13.16
-      '@emotion/is-prop-valid': 1.1.1
-      '@emotion/react': 11.7.1_zd2habhu2konpee7cqi3qp36wu
-      '@emotion/serialize': 1.0.2
-      '@emotion/utils': 1.1.0
-      '@types/react': 17.0.37
-      react: 17.0.2
-
   /@emotion/styled/11.6.0_vraatsk2f4kfrl6iqhrnwwyayi:
     resolution: {integrity: sha512-mxVtVyIOTmCAkFbwIp+nCjTXJNgcz4VWkOYQro87jE2QBTydnkiYusMrRGFtzuruiGK4dDaNORk4gH049iiQuw==}
     peerDependencies:
@@ -6344,9 +6253,6 @@ packages:
 
   /@emotion/unitless/0.7.5:
     resolution: {integrity: sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==}
-
-  /@emotion/utils/1.0.0:
-    resolution: {integrity: sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==}
 
   /@emotion/utils/1.1.0:
     resolution: {integrity: sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ==}
@@ -7137,56 +7043,9 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.17.2
-      '@mui/material': 5.4.2_7itellgzua2ua3ibqryroeg6ke
+      '@mui/material': 5.4.2_tedopk7kxcqvemqshyzlgc57wq
       '@types/react': 17.0.37
       react: 17.0.2
-
-  /@mui/lab/5.0.0-alpha.69_g7ugx7za7oprrwbwwmhdonbzqe:
-    resolution: {integrity: sha512-VrTcmXTS9UlTsp40nIZ/R/HBHOvxP2lvgSY9zLSn5XPhMQEMD1H0wTJ68mEuCm18cnl1sbcUOCMfWx9io/u5zg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@mui/material': ^5.0.0
-      '@types/react': ^16.8.6 || ^17.0.0
-      date-fns: ^2.25.0
-      dayjs: ^1.10.7
-      luxon: ^1.28.0 || ^2.0.0
-      moment: ^2.29.1
-      react: ^17.0.0
-      react-dom: ^17.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      date-fns:
-        optional: true
-      dayjs:
-        optional: true
-      luxon:
-        optional: true
-      moment:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.17.2
-      '@date-io/date-fns': 2.13.1
-      '@date-io/dayjs': 2.13.1
-      '@date-io/luxon': 2.13.1
-      '@date-io/moment': 2.13.1_moment@2.29.1
-      '@mui/base': 5.0.0-alpha.69_ku44vyaqhfvsakybl42wrekosu
-      '@mui/material': 5.4.2_7itellgzua2ua3ibqryroeg6ke
-      '@mui/system': 5.4.2_56lgv6ej77cijhtsejusgffagm
-      '@mui/utils': 5.4.2_react@17.0.2
-      '@types/react': 17.0.37
-      clsx: 1.1.1
-      moment: 2.29.1
-      prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-is: 17.0.2
-      react-transition-group: 4.4.2_sfoxds7t5ydpegc3knd667wn6m
-      rifm: 0.12.1_react@17.0.2
-    transitivePeerDependencies:
-      - '@emotion/react'
-      - '@emotion/styled'
-    dev: false
 
   /@mui/lab/5.0.0-alpha.69_hw6y66r7ofivsji7dkgqr2l34u:
     resolution: {integrity: sha512-VrTcmXTS9UlTsp40nIZ/R/HBHOvxP2lvgSY9zLSn5XPhMQEMD1H0wTJ68mEuCm18cnl1sbcUOCMfWx9io/u5zg==}
@@ -7232,9 +7091,8 @@ packages:
     transitivePeerDependencies:
       - '@emotion/react'
       - '@emotion/styled'
-    dev: true
 
-  /@mui/lab/5.0.0-alpha.69_qs2lszykn622lnkwnv44em2vme:
+  /@mui/lab/5.0.0-alpha.69_j2wldh5vogrbdhofa36dbqbv5y:
     resolution: {integrity: sha512-VrTcmXTS9UlTsp40nIZ/R/HBHOvxP2lvgSY9zLSn5XPhMQEMD1H0wTJ68mEuCm18cnl1sbcUOCMfWx9io/u5zg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -7262,13 +7120,14 @@ packages:
       '@date-io/date-fns': 2.13.1
       '@date-io/dayjs': 2.13.1
       '@date-io/luxon': 2.13.1
-      '@date-io/moment': 2.13.1
+      '@date-io/moment': 2.13.1_moment@2.29.1
       '@mui/base': 5.0.0-alpha.69_ku44vyaqhfvsakybl42wrekosu
-      '@mui/material': 5.4.2_7itellgzua2ua3ibqryroeg6ke
-      '@mui/system': 5.4.2_56lgv6ej77cijhtsejusgffagm
+      '@mui/material': 5.4.2_tedopk7kxcqvemqshyzlgc57wq
+      '@mui/system': 5.4.2_jsjqrlwrmeqxz2lrgrnw2nobdu
       '@mui/utils': 5.4.2_react@17.0.2
       '@types/react': 17.0.37
       clsx: 1.1.1
+      moment: 2.29.1
       prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -7278,41 +7137,7 @@ packages:
     transitivePeerDependencies:
       - '@emotion/react'
       - '@emotion/styled'
-
-  /@mui/material/5.4.2_7itellgzua2ua3ibqryroeg6ke:
-    resolution: {integrity: sha512-jmeLWEO6AA6g7HErhI3MXVGaMZtqDZjDwcHCg24WY954wO38Xn0zJ53VfpFc44ZTJLV9Ejd7ci9fLlG/HmJCeg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.5.0
-      '@emotion/styled': ^11.3.0
-      '@types/react': ^16.8.6 || ^17.0.0
-      react: ^17.0.0
-      react-dom: ^17.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-      '@types/react':
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.17.2
-      '@emotion/react': 11.7.1_zd2habhu2konpee7cqi3qp36wu
-      '@emotion/styled': 11.6.0_i6myypufbcsfwoh3o7hlv4fkcq
-      '@mui/base': 5.0.0-alpha.69_ku44vyaqhfvsakybl42wrekosu
-      '@mui/system': 5.4.2_56lgv6ej77cijhtsejusgffagm
-      '@mui/types': 7.1.2_@types+react@17.0.37
-      '@mui/utils': 5.4.2_react@17.0.2
-      '@types/react': 17.0.37
-      '@types/react-transition-group': 4.4.4
-      clsx: 1.1.1
-      csstype: 3.0.10
-      hoist-non-react-statics: 3.3.2
-      prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-is: 17.0.2
-      react-transition-group: 4.4.2_sfoxds7t5ydpegc3knd667wn6m
+    dev: false
 
   /@mui/material/5.4.2_ku44vyaqhfvsakybl42wrekosu:
     resolution: {integrity: sha512-jmeLWEO6AA6g7HErhI3MXVGaMZtqDZjDwcHCg24WY954wO38Xn0zJ53VfpFc44ZTJLV9Ejd7ci9fLlG/HmJCeg==}
@@ -7416,26 +7241,6 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
 
-  /@mui/styled-engine/5.4.2_sivilwsx4nsguv2gln4xbmg6qu:
-    resolution: {integrity: sha512-tz9p3aRtzXHKAg7x3BgP0hVQEoGKaxNCFxsJ+d/iqEHYvywWFSs6oxqYAvDHIRpvMlUZyPNoTrkcNnbdMmH/ng==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.4.1
-      '@emotion/styled': ^11.3.0
-      react: ^17.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.17.2
-      '@emotion/cache': 11.7.1
-      '@emotion/react': 11.7.1_zd2habhu2konpee7cqi3qp36wu
-      '@emotion/styled': 11.6.0_i6myypufbcsfwoh3o7hlv4fkcq
-      prop-types: 15.8.1
-      react: 17.0.2
-
   /@mui/styled-engine/5.4.2_ylcjx3bfm5nyvs4tcdbdhmw4ya:
     resolution: {integrity: sha512-tz9p3aRtzXHKAg7x3BgP0hVQEoGKaxNCFxsJ+d/iqEHYvywWFSs6oxqYAvDHIRpvMlUZyPNoTrkcNnbdMmH/ng==}
     engines: {node: '>=12.0.0'}
@@ -7486,35 +7291,6 @@ packages:
       prop-types: 15.7.2
       react: 17.0.2
     dev: false
-
-  /@mui/system/5.4.2_56lgv6ej77cijhtsejusgffagm:
-    resolution: {integrity: sha512-QegBVu6fxUNov1X9bWc1MZUTeV3A5g9PIpli7d0kzkGfq6JzrJWuPlhSPZ+6hlWmWky+bbAXhU65Qz8atWxDGw==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.5.0
-      '@emotion/styled': ^11.3.0
-      '@types/react': ^16.8.6 || ^17.0.0
-      react: ^17.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-      '@types/react':
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.17.2
-      '@emotion/react': 11.7.1_zd2habhu2konpee7cqi3qp36wu
-      '@emotion/styled': 11.6.0_i6myypufbcsfwoh3o7hlv4fkcq
-      '@mui/private-theming': 5.4.2_z7w6vgz62d5pbxpnoxayoqdmly
-      '@mui/styled-engine': 5.4.2_sivilwsx4nsguv2gln4xbmg6qu
-      '@mui/types': 7.1.2_@types+react@17.0.37
-      '@mui/utils': 5.4.2_react@17.0.2
-      '@types/react': 17.0.37
-      clsx: 1.1.1
-      csstype: 3.0.10
-      prop-types: 15.8.1
-      react: 17.0.2
 
   /@mui/system/5.4.2_jsjqrlwrmeqxz2lrgrnw2nobdu:
     resolution: {integrity: sha512-QegBVu6fxUNov1X9bWc1MZUTeV3A5g9PIpli7d0kzkGfq6JzrJWuPlhSPZ+6hlWmWky+bbAXhU65Qz8atWxDGw==}
@@ -7603,8 +7379,8 @@ packages:
       '@mui/system': ^5.2.8
       react: ^17.0.2
     dependencies:
-      '@mui/material': 5.4.2_7itellgzua2ua3ibqryroeg6ke
-      '@mui/system': 5.4.2_56lgv6ej77cijhtsejusgffagm
+      '@mui/material': 5.4.2_tedopk7kxcqvemqshyzlgc57wq
+      '@mui/system': 5.4.2_jsjqrlwrmeqxz2lrgrnw2nobdu
       '@mui/utils': 5.4.2_react@17.0.2
       clsx: 1.1.1
       prop-types: 15.8.1
@@ -19953,7 +19729,7 @@ packages:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   /mkdirp/0.5.1:
-    resolution: {integrity: sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=}
+    resolution: {integrity: sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==}
     deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
     hasBin: true
     dependencies:
@@ -23007,7 +22783,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.17.2
       react: 17.0.2
       use-composed-ref: 1.1.0_react@17.0.2
       use-latest: 1.2.0_z7w6vgz62d5pbxpnoxayoqdmly
@@ -24407,7 +24183,7 @@ packages:
     deprecated: See https://github.com/lydell/source-map-url#deprecated
 
   /source-map/0.5.7:
-    resolution: {integrity: sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=}
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
     engines: {node: '>=0.10.0'}
 
   /source-map/0.6.1:
@@ -25302,7 +25078,7 @@ packages:
     resolution: {integrity: sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==}
 
   /to-fast-properties/2.0.0:
-    resolution: {integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=}
+    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
 
   /to-file/0.2.0:

--- a/packages/demos/kitchen-sink/package.json
+++ b/packages/demos/kitchen-sink/package.json
@@ -45,7 +45,7 @@
     "@dxos/react-toolkit": "workspace:*",
     "@dxos/util": "workspace:*",
     "@emotion/css": "^11.7.1",
-    "@emotion/react": "^11.4.1",
+    "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.3.0",
     "@mui/icons-material": "^5.4.2",
     "@mui/lab": "^5.0.0-alpha.69",

--- a/packages/demos/lexical-editor/package.json
+++ b/packages/demos/lexical-editor/package.json
@@ -48,7 +48,7 @@
     "@dxos/protocols-toolchain": "workspace:*",
     "@dxos/react-client-testing": "workspace:*",
     "@emotion/css": "^11.7.1",
-    "@emotion/react": "^11.4.1",
+    "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.3.0",
     "@lexical/react": "~0.2.5",
     "@types/debug": "^4.1.7",

--- a/packages/demos/tutorials-tasks-app/package.json
+++ b/packages/demos/tutorials-tasks-app/package.json
@@ -32,7 +32,7 @@
     "@dxos/react-client": "workspace:*",
     "@dxos/react-components": "workspace:*",
     "@dxos/react-toolkit": "workspace:*",
-    "@emotion/react": "^11.4.1",
+    "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.3.0",
     "@mui/icons-material": "^5.4.2",
     "@mui/lab": "^5.0.0-alpha.69",

--- a/packages/devtools/devtools-extension/package.json
+++ b/packages/devtools/devtools-extension/package.json
@@ -29,7 +29,7 @@
     "@dxos/network-manager": "workspace:*",
     "@dxos/react-toolkit": "workspace:*",
     "@dxos/rpc": "workspace:*",
-    "@emotion/react": "^11.4.1",
+    "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.3.0",
     "@mui/icons-material": "^5.4.2",
     "@mui/lab": "^5.0.0-alpha.69",

--- a/packages/devtools/devtools-mesh/package.json
+++ b/packages/devtools/devtools-mesh/package.json
@@ -21,7 +21,7 @@
     "@dxos/react-components": "workspace:*",
     "@dxos/react-toolkit": "workspace:*",
     "@emotion/css": "^11.7.1",
-    "@emotion/react": "^11.4.1",
+    "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.3.0",
     "@mui/icons-material": "^5.4.2",
     "@mui/material": "^5.4.2",

--- a/packages/devtools/devtools/package.json
+++ b/packages/devtools/devtools/package.json
@@ -32,7 +32,7 @@
     "@dxos/react-components": "workspace:*",
     "@dxos/react-toolkit": "workspace:*",
     "@dxos/rpc": "workspace:*",
-    "@emotion/react": "^11.4.1",
+    "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.3.0",
     "@mui/icons-material": "^5.4.2",
     "@mui/lab": "^5.0.0-alpha.69",

--- a/packages/sdk/client/src/version.ts
+++ b/packages/sdk/client/src/version.ts
@@ -1,1 +1,1 @@
-export const DXOS_VERSION = "2.33.0";
+export const DXOS_VERSION = "2.33.4";

--- a/packages/sdk/react-client-testing/package.json
+++ b/packages/sdk/react-client-testing/package.json
@@ -33,7 +33,7 @@
     "@dxos/react-client": "workspace:*",
     "@dxos/react-components": "workspace:*",
     "@dxos/util": "workspace:*",
-    "@emotion/react": "^11.4.1",
+    "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.3.0",
     "@mui/icons-material": "^5.4.2",
     "@mui/lab": "^5.0.0-alpha.69",

--- a/packages/sdk/react-components/package.json
+++ b/packages/sdk/react-components/package.json
@@ -39,7 +39,7 @@
     "@dxos/esbuild-plugins": "~2.28.7",
     "@dxos/eslint-plugin": "~1.0.27",
     "@dxos/protocols-toolchain": "workspace:*",
-    "@emotion/react": "^11.4.1",
+    "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.3.0",
     "@mui/icons-material": "^5.4.2",
     "@mui/lab": "^5.0.0-alpha.69",

--- a/packages/sdk/react-echo-graph/package.json
+++ b/packages/sdk/react-echo-graph/package.json
@@ -37,7 +37,7 @@
     "@dxos/react-client-testing": "workspace:*",
     "@dxos/react-components": "workspace:*",
     "@emotion/css": "^11.7.1",
-    "@emotion/react": "^11.4.1",
+    "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.3.0",
     "@mui/icons-material": "^5.4.2",
     "@mui/lab": "^5.0.0-alpha.69",

--- a/packages/sdk/react-toolkit/package.json
+++ b/packages/sdk/react-toolkit/package.json
@@ -51,7 +51,7 @@
     "@dxos/react-client-testing": "workspace:*",
     "@dxos/react-components": "workspace:*",
     "@dxos/registry-client": "workspace:*",
-    "@emotion/react": "^11.4.1",
+    "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.3.0",
     "@mui/icons-material": "^5.4.2",
     "@mui/lab": "^5.0.0-alpha.69",


### PR DESCRIPTION
Devtools was giving a warning about multiple versions on @emotion/react. I found that in the lockfile there were two versions depending on the package so this bumps them all to align what they are locked to.

It seems that Rush isn't perfect at ensuring consistency of versions between packages (this isn't the first time I've noticed something like this happening). This may contribute to considering using Nx to manage our repos (they use a single version policy with one root package.json instead).
