### PR TITLE
refactor(crypto): Migrate human hasher to util

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -509,10 +509,10 @@ importers:
       eslint: ^7.12.1
       typescript: ^4.7.2
     dependencies:
-      '@dxos/crypto': link:../crypto
       '@dxos/debug': link:../debug
       '@dxos/protocols': link:../protocols
     devDependencies:
+      '@dxos/crypto': link:../crypto
       '@dxos/eslint-plugin': 1.0.34_hxadhbs2xogijvk7vq4t2azzbu
       '@dxos/protocols-toolchain': link:../../../toolchains/protocols-toolchain
       '@types/jest': 26.0.24
@@ -584,7 +584,6 @@ importers:
       '@dxos/client': workspace:*
       '@dxos/client-testing': workspace:*
       '@dxos/config': workspace:*
-      '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/echo-protocol': workspace:*
@@ -645,7 +644,6 @@ importers:
       '@dxos/client': link:../../sdk/client
       '@dxos/client-testing': link:../../sdk/client-testing
       '@dxos/config': link:../../sdk/config
-      '@dxos/crypto': link:../../common/crypto
       '@dxos/echo-db': link:../../echo/echo-db
       '@dxos/echo-protocol': link:../../echo/echo-protocol
       '@dxos/echo-testing': link:../../echo/echo-testing
@@ -712,7 +710,6 @@ importers:
       '@dxos/client-testing': workspace:*
       '@dxos/codec-protobuf': workspace:*
       '@dxos/config': workspace:*
-      '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/eslint-plugin': ~1.0.34
       '@dxos/protocols': workspace:*
@@ -750,7 +747,6 @@ importers:
       '@dxos/client-testing': link:../../sdk/client-testing
       '@dxos/codec-protobuf': link:../../common/codec-protobuf
       '@dxos/config': link:../../sdk/config
-      '@dxos/crypto': link:../../common/crypto
       '@dxos/debug': link:../../common/debug
       '@dxos/protocols': link:../../common/protocols
       '@dxos/react-async': link:../../common/react-async
@@ -962,7 +958,6 @@ importers:
       '@babel/core': ~7.13.15
       '@dxos/client': workspace:*
       '@dxos/config': workspace:*
-      '@dxos/crypto': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/esbuild-plugins': ~2.28.10
       '@dxos/esbuild-server': ~2.28.10
@@ -996,7 +991,6 @@ importers:
     dependencies:
       '@dxos/client': link:../../sdk/client
       '@dxos/config': link:../../sdk/config
-      '@dxos/crypto': link:../../common/crypto
       '@dxos/echo-db': link:../../echo/echo-db
       '@dxos/object-model': link:../../echo/object-model
       '@dxos/react-client': link:../../sdk/react-client
@@ -1038,7 +1032,6 @@ importers:
       '@dxos/codec-protobuf': workspace:*
       '@dxos/config': workspace:*
       '@dxos/credentials': workspace:*
-      '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/devtools-mesh': workspace:*
       '@dxos/echo-db': workspace:*
@@ -1082,7 +1075,6 @@ importers:
       '@dxos/client': link:../../sdk/client
       '@dxos/codec-protobuf': link:../../common/codec-protobuf
       '@dxos/credentials': link:../../halo/credentials
-      '@dxos/crypto': link:../../common/crypto
       '@dxos/debug': link:../../common/debug
       '@dxos/devtools-mesh': link:../devtools-mesh
       '@dxos/echo-protocol': link:../../echo/echo-protocol
@@ -1134,7 +1126,6 @@ importers:
       '@dxos/codec-protobuf': workspace:*
       '@dxos/config': workspace:*
       '@dxos/credentials': workspace:*
-      '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/devtools': workspace:*
       '@dxos/esbuild-plugins': ~2.28.10
@@ -1181,7 +1172,6 @@ importers:
       '@dxos/codec-protobuf': link:../../common/codec-protobuf
       '@dxos/config': link:../../sdk/config
       '@dxos/credentials': link:../../halo/credentials
-      '@dxos/crypto': link:../../common/crypto
       '@dxos/debug': link:../../common/debug
       '@dxos/devtools': link:../devtools
       '@dxos/network-manager': link:../../mesh/network-manager
@@ -1227,7 +1217,6 @@ importers:
   ../../packages/devtools/devtools-mesh:
     specifiers:
       '@babel/core': ~7.13.15
-      '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/esbuild-plugins': ~2.28.10
       '@dxos/eslint-plugin': ~1.0.34
@@ -1239,6 +1228,7 @@ importers:
       '@dxos/protocols-toolchain': workspace:*
       '@dxos/react-components': workspace:*
       '@dxos/react-toolkit': workspace:*
+      '@dxos/util': workspace:*
       '@emotion/css': ^11.7.1
       '@emotion/react': ^11.9.0
       '@emotion/styled': ^11.8.1
@@ -1254,7 +1244,6 @@ importers:
       react-router-dom: ^6.3.0
       typescript: ^4.7.2
     dependencies:
-      '@dxos/crypto': link:../../common/crypto
       '@dxos/debug': link:../../common/debug
       '@dxos/gem-core': 2.2.1-beta.11_2z7gpx7w77mn2fduvx4j6f34be
       '@dxos/gem-spore': 2.2.1-beta.11_2z7gpx7w77mn2fduvx4j6f34be
@@ -1262,6 +1251,7 @@ importers:
       '@dxos/protocol-plugin-presence': link:../../mesh/protocol-plugin-presence
       '@dxos/react-components': link:../../sdk/react-components
       '@dxos/react-toolkit': link:../../sdk/react-toolkit
+      '@dxos/util': link:../../common/util
       '@emotion/css': 11.7.1_@babel+core@7.13.16
       '@emotion/react': 11.9.3_d5bzas45mfehtvmrop73rv3yw4
       '@emotion/styled': 11.9.3_rtk2r4lsmeeb4eofjg7vjptjzm
@@ -1611,7 +1601,6 @@ importers:
     specifiers:
       '@dxos/async': workspace:*
       '@dxos/codec-protobuf': workspace:*
-      '@dxos/crypto': workspace:*
       '@dxos/echo-protocol': workspace:*
       '@dxos/eslint-plugin': ~1.0.34
       '@dxos/model-factory': workspace:*
@@ -1636,7 +1625,6 @@ importers:
     dependencies:
       '@dxos/async': link:../../common/async
       '@dxos/codec-protobuf': link:../../common/codec-protobuf
-      '@dxos/crypto': link:../../common/crypto
       '@dxos/echo-protocol': link:../echo-protocol
       '@dxos/model-factory': link:../model-factory
       '@dxos/util': link:../../common/util
@@ -1934,7 +1922,6 @@ importers:
   ../../packages/halo/halo-protocol:
     specifiers:
       '@dxos/codec-protobuf': workspace:*
-      '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/eslint-plugin': ~1.0.34
       '@dxos/protocols-toolchain': workspace:*
@@ -1945,7 +1932,6 @@ importers:
       typescript: ^4.7.2
     dependencies:
       '@dxos/codec-protobuf': link:../../common/codec-protobuf
-      '@dxos/crypto': link:../../common/crypto
       '@dxos/debug': link:../../common/debug
       '@dxos/util': link:../../common/util
     devDependencies:
@@ -2095,10 +2081,10 @@ importers:
     specifiers:
       '@dxos/async': workspace:*
       '@dxos/codec-protobuf': workspace:*
-      '@dxos/crypto': workspace:*
       '@dxos/eslint-plugin': ~1.0.34
       '@dxos/protocols': workspace:*
       '@dxos/protocols-toolchain': workspace:*
+      '@dxos/util': workspace:*
       '@types/assert': ^1.5.4
       '@types/debug': ^4.1.7
       '@types/end-of-stream': ^1.4.0
@@ -2121,7 +2107,7 @@ importers:
     dependencies:
       '@dxos/async': link:../../common/async
       '@dxos/codec-protobuf': link:../../common/codec-protobuf
-      '@dxos/crypto': link:../../common/crypto
+      '@dxos/util': link:../../common/util
       assert: 2.0.0
       buffer-json-encoding: 1.0.2
       debug: 4.3.3
@@ -2273,7 +2259,6 @@ importers:
     specifiers:
       '@dxos/async': workspace:*
       '@dxos/codec-protobuf': workspace:*
-      '@dxos/crypto': workspace:*
       '@dxos/eslint-plugin': ~1.0.34
       '@dxos/mesh-protocol': workspace:*
       '@dxos/network-manager': workspace:*
@@ -2290,7 +2275,6 @@ importers:
       wait-for-expect: ^3.0.2
     dependencies:
       '@dxos/async': link:../../common/async
-      '@dxos/crypto': link:../../common/crypto
       '@dxos/mesh-protocol': link:../protocol
       '@dxos/rpc': link:../../common/rpc
       '@dxos/util': link:../../common/util
@@ -2312,7 +2296,6 @@ importers:
     specifiers:
       '@azure/abort-controller': ^1.0.1
       '@dxos/broadcast': workspace:*
-      '@dxos/crypto': workspace:*
       '@dxos/eslint-plugin': ~1.0.34
       '@dxos/protocols': workspace:*
       '@dxos/protocols-toolchain': workspace:*
@@ -2365,7 +2348,6 @@ importers:
     dependencies:
       '@azure/abort-controller': 1.0.4
       '@dxos/broadcast': link:../broadcast
-      '@dxos/crypto': link:../../common/crypto
       '@hyperswarm/dht': 4.0.1
       buffer-json-encoding: 1.0.2
       debug: 4.3.3
@@ -2423,7 +2405,6 @@ importers:
       '@dxos/codec-protobuf': workspace:*
       '@dxos/config': workspace:*
       '@dxos/credentials': workspace:*
-      '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/echo-protocol': workspace:*
@@ -2467,7 +2448,6 @@ importers:
       '@dxos/codec-protobuf': link:../../common/codec-protobuf
       '@dxos/config': link:../config
       '@dxos/credentials': link:../../halo/credentials
-      '@dxos/crypto': link:../../common/crypto
       '@dxos/debug': link:../../common/debug
       '@dxos/echo-db': link:../../echo/echo-db
       '@dxos/echo-protocol': link:../../echo/echo-protocol
@@ -2637,7 +2617,6 @@ importers:
       '@dxos/client': workspace:*
       '@dxos/codec-protobuf': workspace:*
       '@dxos/config': workspace:*
-      '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/esbuild-plugins': ~2.28.10
@@ -2688,7 +2667,6 @@ importers:
       debug: 4.3.3
       use-subscription: 1.8.0_react@18.2.0
     devDependencies:
-      '@dxos/crypto': link:../../common/crypto
       '@dxos/esbuild-plugins': 2.28.10
       '@dxos/eslint-plugin': 1.0.34_hxadhbs2xogijvk7vq4t2azzbu
       '@dxos/protocols-toolchain': link:../../../toolchains/protocols-toolchain
@@ -2799,12 +2777,12 @@ importers:
       '@babel/plugin-transform-runtime': ^7.11.5
       '@dxos/async': workspace:*
       '@dxos/client': workspace:*
-      '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/esbuild-plugins': ~2.28.10
       '@dxos/eslint-plugin': ~1.0.34
       '@dxos/protocols': workspace:*
       '@dxos/protocols-toolchain': workspace:*
+      '@dxos/util': workspace:*
       '@emotion/css': ^11.7.1
       '@emotion/react': ^11.9.0
       '@emotion/styled': ^11.8.1
@@ -2836,8 +2814,8 @@ importers:
       url-join: ^4.0.1
     dependencies:
       '@dxos/async': link:../../common/async
-      '@dxos/crypto': link:../../common/crypto
       '@dxos/debug': link:../../common/debug
+      '@dxos/util': link:../../common/util
       '@emotion/css': 11.7.1_@babel+core@7.13.16
       debug: 4.3.3
       lodash.defaultsdeep: 4.6.1
@@ -3020,7 +2998,6 @@ importers:
       '@dxos/client': workspace:*
       '@dxos/config': workspace:*
       '@dxos/credentials': workspace:*
-      '@dxos/crypto': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/echo-db': workspace:*
       '@dxos/echo-protocol': workspace:*
@@ -3064,7 +3041,6 @@ importers:
       url-join: ^4.0.1
       uuid: ^8.3.2
     dependencies:
-      '@dxos/crypto': link:../../common/crypto
       '@dxos/debug': link:../../common/debug
       '@dxos/protocols': link:../../common/protocols
       '@dxos/react-async': link:../../common/react-async

--- a/packages/common/crypto/src/index.ts
+++ b/packages/common/crypto/src/index.ts
@@ -4,6 +4,5 @@
 
 export * from './encrypt';
 export * from './hash';
-export * from './human-hash';
 export * from './keys';
 export * from './validator';

--- a/packages/common/crypto/src/keys.test.ts
+++ b/packages/common/crypto/src/keys.test.ts
@@ -4,16 +4,8 @@
 
 // DXOS testing browser.
 
-import { PublicKey } from '@dxos/protocols';
+import { createId } from './keys';
 
-import { createKeyPair, createId, hasher, humanize } from './keys';
-
-test('Hashing', () => {
-  const { publicKey, secretKey } = createKeyPair();
-
+test('Create id is unique', () => {
   expect(createId()).not.toEqual(createId());
-
-  expect(humanize(publicKey)).not.toEqual(humanize(secretKey));
-  expect(humanize(publicKey)).toEqual(hasher.humanize(PublicKey.stringify(publicKey)));
-  expect(hasher.humanize(createId())).toBeDefined();
 });

--- a/packages/common/crypto/src/keys.ts
+++ b/packages/common/crypto/src/keys.ts
@@ -7,10 +7,6 @@ import crypto from 'hypercore-crypto';
 
 import { PublicKey, PublicKeyLike, PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH } from '@dxos/protocols';
 
-import { HumanHasher } from './human-hash';
-
-export const hasher = new HumanHasher();
-
 export const SIGNATURE_LENGTH = 64;
 
 export const zeroKey = () => new Uint8Array(32);
@@ -29,16 +25,6 @@ export const createKeyPair = (seed?: Buffer): KeyPair => {
 };
 
 export const discoveryKey = (key: PublicKeyLike): Buffer => crypto.discoveryKey(PublicKey.from(key).asBuffer());
-
-export const humanize = (value: PublicKeyLike): string => {
-  if (value instanceof Buffer || value instanceof Uint8Array) {
-    value = PublicKey.stringify(value);
-  } else if (value instanceof PublicKey) {
-    value = value.toHex();
-  }
-
-  return hasher.humanize(value);
-};
 
 /**
  * Return random bytes of length.

--- a/packages/common/util/package.json
+++ b/packages/common/util/package.json
@@ -17,12 +17,13 @@
     "test": "toolchain test"
   },
   "dependencies": {
-    "@dxos/crypto": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/protocols": "workspace:*"
   },
   "devDependencies": {
+    "@dxos/crypto": "workspace:*",
     "@dxos/eslint-plugin": "~1.0.34",
+    "@dxos/protocols": "workspace:*",
     "@dxos/protocols-toolchain": "workspace:*",
     "@types/jest": "^26.0.7",
     "@types/node": "^16.11.27",

--- a/packages/common/util/src/human-hash.test.ts
+++ b/packages/common/util/src/human-hash.test.ts
@@ -1,0 +1,18 @@
+//
+// Copyright 2020 DXOS.org
+//
+
+// DXOS testing browser.
+
+import { createKeyPair, createId } from '@dxos/crypto';
+import { PublicKey } from '@dxos/protocols';
+
+import { humanize } from './human-hash';
+
+test('Hashing', () => {
+  const { publicKey, secretKey } = createKeyPair();
+
+  expect(humanize(publicKey)).not.toEqual(humanize(secretKey));
+  expect(humanize(publicKey)).toEqual(humanize(PublicKey.from(publicKey)));
+  expect(humanize(createId())).toBeDefined();
+});

--- a/packages/common/util/src/human-hash.ts
+++ b/packages/common/util/src/human-hash.ts
@@ -2,6 +2,8 @@
 // Copyright 2021 DXOS.org
 //
 
+import { PublicKey, PublicKeyLike } from '@dxos/protocols';
+
 // From https://github.com/SEBv15/humanhash/blob/166c1a6f70d854fe6767cdd76be1237112d4eaf1/index.js
 
 const DEFAULT_WORDLIST = [
@@ -45,7 +47,6 @@ const DEFAULT_WORDLIST = [
 /**
  * humanhash: Human-readable representations of digests.
  */
-// TODO(wittjosiah): Move to debug?
 export class HumanHasher {
   /**
    * Transforms hex digests to human-readable strings.
@@ -117,3 +118,15 @@ export class HumanHasher {
     return checksums;
   }
 }
+
+const hasher = new HumanHasher();
+
+export const humanize = (value: PublicKeyLike): string => {
+  if (value instanceof Buffer || value instanceof Uint8Array) {
+    value = PublicKey.stringify(value);
+  } else if (value instanceof PublicKey) {
+    value = value.toHex();
+  }
+
+  return hasher.humanize(value);
+};

--- a/packages/common/util/src/index.ts
+++ b/packages/common/util/src/index.ts
@@ -3,6 +3,7 @@
 //
 
 export * from './complex';
+export * from './human-hash';
 export * from './json';
 export * from './map';
 export * from './range';

--- a/packages/common/util/src/json.ts
+++ b/packages/common/util/src/json.ts
@@ -4,8 +4,9 @@
 
 import { inspect } from 'util';
 
-import { humanize } from '@dxos/crypto';
 import { PublicKey } from '@dxos/protocols';
+
+import { humanize } from './human-hash';
 
 /**
  * JSON.stringify replacer.

--- a/packages/demos/kitchen-sink/package.json
+++ b/packages/demos/kitchen-sink/package.json
@@ -30,7 +30,6 @@
     "@dxos/client": "workspace:*",
     "@dxos/client-testing": "workspace:*",
     "@dxos/config": "workspace:*",
-    "@dxos/crypto": "workspace:*",
     "@dxos/echo-db": "workspace:*",
     "@dxos/echo-protocol": "workspace:*",
     "@dxos/echo-testing": "workspace:*",

--- a/packages/demos/kodama/package.json
+++ b/packages/demos/kodama/package.json
@@ -25,7 +25,6 @@
     "@dxos/client-testing": "workspace:*",
     "@dxos/codec-protobuf": "workspace:*",
     "@dxos/config": "workspace:*",
-    "@dxos/crypto": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/protocols": "workspace:*",
     "@dxos/react-async": "workspace:*",

--- a/packages/demos/tutorials-tasks-app/package.json
+++ b/packages/demos/tutorials-tasks-app/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "@dxos/client": "workspace:*",
     "@dxos/config": "workspace:*",
-    "@dxos/crypto": "workspace:*",
     "@dxos/echo-db": "workspace:*",
     "@dxos/object-model": "workspace:*",
     "@dxos/react-client": "workspace:*",

--- a/packages/devtools/devtools-extension/package.json
+++ b/packages/devtools/devtools-extension/package.json
@@ -23,7 +23,6 @@
     "@dxos/codec-protobuf": "workspace:*",
     "@dxos/config": "workspace:*",
     "@dxos/credentials": "workspace:*",
-    "@dxos/crypto": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/devtools": "workspace:*",
     "@dxos/network-manager": "workspace:*",

--- a/packages/devtools/devtools-mesh/package.json
+++ b/packages/devtools/devtools-mesh/package.json
@@ -12,7 +12,6 @@
     "lint": "toolchain lint"
   },
   "dependencies": {
-    "@dxos/crypto": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/gem-core": "~2.2.1-beta.11",
     "@dxos/gem-spore": "~2.2.1-beta.11",
@@ -20,6 +19,7 @@
     "@dxos/protocol-plugin-presence": "workspace:*",
     "@dxos/react-components": "workspace:*",
     "@dxos/react-toolkit": "workspace:*",
+    "@dxos/util": "workspace:*",
     "@emotion/css": "^11.7.1",
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",

--- a/packages/devtools/devtools-mesh/src/PeerGraph.tsx
+++ b/packages/devtools/devtools-mesh/src/PeerGraph.tsx
@@ -4,11 +4,11 @@
 
 import React, { useState, useEffect } from 'react';
 
-import { humanize } from '@dxos/crypto';
 import { SVG, SVGContextProvider } from '@dxos/gem-core';
 import { Graph } from '@dxos/gem-spore';
 import { PeerInfo } from '@dxos/network-manager';
 import type { PublicKey } from '@dxos/protocols';
+import { humanize } from '@dxos/util';
 
 // const classMap: Record<string, string> = {
 //   ME: 'blue',

--- a/packages/devtools/devtools/package.json
+++ b/packages/devtools/devtools/package.json
@@ -22,7 +22,6 @@
     "@dxos/client": "workspace:*",
     "@dxos/codec-protobuf": "workspace:*",
     "@dxos/credentials": "workspace:*",
-    "@dxos/crypto": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/devtools-mesh": "workspace:*",
     "@dxos/echo-protocol": "workspace:*",

--- a/packages/echo/echo-db/src/echo.test.ts
+++ b/packages/echo/echo-db/src/echo.test.ts
@@ -11,9 +11,9 @@ import { latch, promiseTimeout, waitForCondition } from '@dxos/async';
 import {
   defaultSecretProvider, defaultSecretValidator, generateSeedPhrase, keyPairFromSeedPhrase
 } from '@dxos/credentials';
-import { humanize } from '@dxos/crypto';
 import { ObjectModel } from '@dxos/object-model';
 import { afterTest } from '@dxos/testutils';
+import { humanize } from '@dxos/util';
 
 import { ECHO } from './echo';
 import { Contact } from './halo';

--- a/packages/echo/echo-db/src/halo/halo.ts
+++ b/packages/echo/echo-db/src/halo/halo.ts
@@ -7,11 +7,12 @@ import debug from 'debug';
 
 import { synchronized } from '@dxos/async';
 import { KeyRecord, Keyring, KeyType, SecretProvider } from '@dxos/credentials';
-import { createKeyPair, humanize, KeyPair } from '@dxos/crypto';
+import { createKeyPair, KeyPair } from '@dxos/crypto';
 import { raise } from '@dxos/debug';
 import { ModelFactory } from '@dxos/model-factory';
 import { NetworkManager } from '@dxos/network-manager';
 import { PublicKey } from '@dxos/protocols';
+import { humanize } from '@dxos/util';
 
 import { ResultSet } from '../api';
 import { InvitationAuthenticator, InvitationDescriptor, InvitationOptions } from '../invitations';

--- a/packages/echo/echo-db/src/parties/party-factory.ts
+++ b/packages/echo/echo-db/src/parties/party-factory.ts
@@ -13,13 +13,13 @@ import {
   SecretProvider,
   wrapMessage
 } from '@dxos/credentials';
-import { humanize } from '@dxos/crypto';
 import { failUndefined, raise, timed } from '@dxos/debug';
 import { createFeedWriter, FeedMessage, PartyKey, PartySnapshot, Timeframe } from '@dxos/echo-protocol';
 import { ModelFactory } from '@dxos/model-factory';
 import { NetworkManager } from '@dxos/network-manager';
 import { ObjectModel } from '@dxos/object-model';
 import { PublicKey } from '@dxos/protocols';
+import { humanize } from '@dxos/util';
 
 import {
   createDataPartyAdmissionMessages,

--- a/packages/echo/echo-db/src/parties/party-manager.test.ts
+++ b/packages/echo/echo-db/src/parties/party-manager.test.ts
@@ -19,10 +19,10 @@ import {
 } from '@dxos/credentials';
 import {
   createKeyPair,
-  humanize,
   randomBytes,
   sign,
-  SIGNATURE_LENGTH, verify
+  SIGNATURE_LENGTH,
+  verify
 } from '@dxos/crypto';
 import { checkType } from '@dxos/debug';
 import { codec, EchoEnvelope, Timeframe } from '@dxos/echo-protocol';
@@ -33,6 +33,7 @@ import { ObjectModel } from '@dxos/object-model';
 import { PublicKey } from '@dxos/protocols';
 import { createStorage, StorageType } from '@dxos/random-access-multi-storage';
 import { afterTest, testTimeout } from '@dxos/testutils';
+import { humanize } from '@dxos/util';
 
 import { defaultInvitationAuthenticator, OfflineInvitationClaimer } from '../invitations';
 import { Item } from '../packlets/database';

--- a/packages/echo/echo-db/src/protocol/identity-credentials.ts
+++ b/packages/echo/echo-db/src/protocol/identity-credentials.ts
@@ -2,8 +2,11 @@
 // Copyright 2022 DXOS.org
 //
 
-import { createIdentityInfoMessage, createKeyAdmitMessage, createPartyGenesisMessage, KeyChain, KeyRecord, Keyring, KeyType, SignedMessage } from '@dxos/credentials';
-import { humanize } from '@dxos/crypto';
+import {
+  createIdentityInfoMessage, createKeyAdmitMessage, createPartyGenesisMessage,
+  KeyChain, KeyRecord, Keyring, KeyType, SignedMessage
+} from '@dxos/credentials';
+import { humanize } from '@dxos/util';
 
 import { ContactManager, Preferences } from '../halo';
 import { CredentialsSigner } from './credentials-signer';

--- a/packages/echo/echo-db/src/snapshots/snapshot-generator.ts
+++ b/packages/echo/echo-db/src/snapshots/snapshot-generator.ts
@@ -4,7 +4,7 @@
 
 import debug from 'debug';
 
-import { humanize } from '@dxos/crypto';
+import { humanize } from '@dxos/util';
 
 import { TimeframeClock } from '../packlets/database';
 import { PartyPipeline } from '../pipeline';

--- a/packages/echo/echo-protocol/src/spacetime/timeframe.ts
+++ b/packages/echo/echo-protocol/src/spacetime/timeframe.ts
@@ -4,8 +4,7 @@
 
 import { inspect } from 'util';
 
-import { humanize } from '@dxos/crypto';
-import { ComplexMap } from '@dxos/util';
+import { ComplexMap, humanize } from '@dxos/util';
 
 import { FeedKey } from '../types';
 

--- a/packages/echo/object-model/package.json
+++ b/packages/echo/object-model/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@dxos/async": "workspace:*",
     "@dxos/codec-protobuf": "workspace:*",
-    "@dxos/crypto": "workspace:*",
     "@dxos/echo-protocol": "workspace:*",
     "@dxos/model-factory": "workspace:*",
     "@dxos/util": "workspace:*",

--- a/packages/halo/halo-protocol/package.json
+++ b/packages/halo/halo-protocol/package.json
@@ -24,7 +24,6 @@
   ],
   "dependencies": {
     "@dxos/codec-protobuf": "workspace:*",
-    "@dxos/crypto": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/util": "workspace:*"
   },

--- a/packages/mesh/protocol-plugin-rpc/package.json
+++ b/packages/mesh/protocol-plugin-rpc/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@dxos/async": "workspace:*",
-    "@dxos/crypto": "workspace:*",
     "@dxos/mesh-protocol": "workspace:*",
     "@dxos/rpc": "workspace:*",
     "@dxos/util": "workspace:*"

--- a/packages/mesh/protocol/package.json
+++ b/packages/mesh/protocol/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@dxos/async": "workspace:*",
     "@dxos/codec-protobuf": "workspace:*",
-    "@dxos/crypto": "workspace:*",
+    "@dxos/util": "workspace:*",
     "assert": "^2.0.0",
     "buffer-json-encoding": "^1.0.2",
     "debug": "^4.3.3",

--- a/packages/mesh/protocol/src/utils.ts
+++ b/packages/mesh/protocol/src/utils.ts
@@ -4,14 +4,12 @@
 
 import assert from 'assert';
 
-import { HumanHasher } from '@dxos/crypto';
-
-const hasher = new HumanHasher();
+import { humanize } from '@dxos/util';
 
 export const keyToHuman = (key: Buffer, prefix?: string) => {
   assert(Buffer.isBuffer(key));
 
-  const name = hasher.humanize(key.toString('hex'));
+  const name = humanize(key.toString('hex'));
   if (prefix) {
     return `${prefix}(${name})`;
   }

--- a/packages/mesh/signal/package.json
+++ b/packages/mesh/signal/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.1",
     "@dxos/broadcast": "workspace:*",
-    "@dxos/crypto": "workspace:*",
     "@hyperswarm/dht": "^4.0.1",
     "buffer-json-encoding": "^1.0.2",
     "debug": "^4.3.3",

--- a/packages/sdk/client/package.json
+++ b/packages/sdk/client/package.json
@@ -21,7 +21,6 @@
     "@dxos/codec-protobuf": "workspace:*",
     "@dxos/config": "workspace:*",
     "@dxos/credentials": "workspace:*",
-    "@dxos/crypto": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/echo-db": "workspace:*",
     "@dxos/echo-protocol": "workspace:*",

--- a/packages/sdk/react-client/package.json
+++ b/packages/sdk/react-client/package.json
@@ -32,7 +32,6 @@
     "use-subscription": "^1.8.0"
   },
   "devDependencies": {
-    "@dxos/crypto": "workspace:*",
     "@dxos/esbuild-plugins": "~2.28.10",
     "@dxos/eslint-plugin": "~1.0.34",
     "@dxos/protocols-toolchain": "workspace:*",

--- a/packages/sdk/react-components/package.json
+++ b/packages/sdk/react-components/package.json
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "@dxos/async": "workspace:*",
-    "@dxos/crypto": "workspace:*",
     "@dxos/debug": "workspace:*",
+    "@dxos/util": "workspace:*",
     "@emotion/css": "^11.7.1",
     "debug": "^4.3.3",
     "lodash.defaultsdeep": "^4.6.1",

--- a/packages/sdk/react-components/src/MemberList/MemberAvatar.tsx
+++ b/packages/sdk/react-components/src/MemberList/MemberAvatar.tsx
@@ -11,8 +11,8 @@ import {
 import { Avatar, Tooltip, colors, useTheme } from '@mui/material';
 
 import { PartyMember } from '@dxos/client';
-import { humanize } from '@dxos/crypto';
 import { PublicKeyLike } from '@dxos/protocols';
+import { humanize } from '@dxos/util';
 
 const { red, pink, deepPurple, deepOrange, indigo, blue, cyan, teal, green, amber } = colors;
 const depth = 500;

--- a/packages/sdk/react-toolkit/package.json
+++ b/packages/sdk/react-toolkit/package.json
@@ -19,7 +19,6 @@
     "test": "toolchain test"
   },
   "dependencies": {
-    "@dxos/crypto": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/protocols": "workspace:*",
     "@dxos/react-async": "workspace:*",


### PR DESCRIPTION
Part 3 of eliminating the need for sdk to depend on @dxos/crypto.
Progresses #1325

