### PR TITLE
fix: Stop pnpm workspace from including dists

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,12 @@
 packages:
-  - 'packages/**/*'
-  - 'toolchains/*'
+  - packages/bot/*
+  - packages/common/*
+  - packages/demos/*
+  - packages/devtools/*
+  - packages/echo/*
+  - packages/gravity/*
+  - packages/halo/*
+  - packages/mesh/*
+  - packages/sdk/*
+  - packages/wallet/*
+  - toolchains/*


### PR DESCRIPTION
The way the pnpm workspace was defined, once the build had run if pnpm install was run again sometimes i would result in packages being linked to the dist folder, which broke builds.
