### PR TITLE
fix: telemetry config for kube.

### DIFF
--- a/packages/core/protocols/src/proto/dxos/config.proto
+++ b/packages/core/protocols/src/proto/dxos/config.proto
@@ -174,6 +174,21 @@ message Runtime {
       repeated string bootstrap = 3;
     }
 
+    message Monitoring {
+      bool enabled = 1;
+      string endpoint = 2;
+      /// Seconds
+      int64 interval = 3;
+    }
+
+    message Trace {
+      bool disabled = 1;
+    }
+
+    message Telemetry {
+      bool disabled = 1;
+    }
+
     optional string host = 1;
     optional string port = 2;
     optional Autoupdate autoupdate = 3;
@@ -182,6 +197,9 @@ message Runtime {
     optional string confhost = 6;
     repeated string env = 7;
     repeated string alias = 8;
+    optional Monitoring monitoring = 9;
+    optional Trace trace = 10;
+    optional Telemetry telemetry = 11;
   }
 
   //


### PR DESCRIPTION
Configuration required for KUBE
- monitoring (otel)
- telemetry (segment)
- trace (sentry)