### PR TITLE
refactor(cli): Demo prep cleanup

### DIFF
--- a/packages/apps/templates/hello-template/package.json
+++ b/packages/apps/templates/hello-template/package.json
@@ -10,8 +10,8 @@
   "author": "DXOS.org",
   "scripts": {
     "build": "tsc",
-    "bundle": "vite build",
-    "deploy": "dx app publish",
+    "bundle": "NODE_OPTIONS=\"--max-old-space-size=4096\" vite build",
+    "deploy": "NODE_OPTIONS=\"--max-old-space-size=4096\" dx app publish",
     "preview": "vite preview",
     "serve": "vite",
     "storybook": "start-storybook -p 9009 --no-open"

--- a/packages/devtools/cli/src/commands/app/create.ts
+++ b/packages/devtools/cli/src/commands/app/create.ts
@@ -47,13 +47,15 @@ export default class Create extends BaseCommand {
     const outputDirectory = `${cwd()}/${name}`;
 
     try {
-      // Git clone template.
+      this.log('Cloning template from Github...');
       await promisify(exec)(`
         git clone --filter=blob:none --no-checkout git@github.com:dxos/dxos.git ${tmpDirectory} &&
           cd ${tmpDirectory} &&
           git sparse-checkout set --cone tsconfig.json patches packages/apps/templates/${template}-template &&
           git checkout ${tag}
       `);
+
+      this.log('Preparing template...');
 
       // Copy vite patch.
       await mkdir(`${templateDirectory}/patches`);
@@ -62,6 +64,8 @@ export default class Create extends BaseCommand {
       // Remove unneccessary files.
       await rm(`${templateDirectory}/project.json`);
       await rm(`${templateDirectory}/tsconfig.plate.json`);
+
+      this.log('Creating app...');
 
       // TS templating.
       const result = await executeDirectoryTemplate({
@@ -73,6 +77,8 @@ export default class Create extends BaseCommand {
         }
       });
       await Promise.all(result.map((file) => file.save()));
+
+      this.log(`App created. To get started run the following commands:\n\n  cd ${name}\n  pnpm install\n  pnpm serve`);
     } catch (err: any) {
       this.log(`Unable to create: ${err.message}`);
       this.error(err, { exit: 1 });

--- a/packages/devtools/cli/src/commands/app/publish.ts
+++ b/packages/devtools/cli/src/commands/app/publish.ts
@@ -40,7 +40,7 @@ export default class Publish extends BaseCommand {
       assert(moduleConfig.values.package, 'Missing package definition in dx.yml');
 
       for (const module of moduleConfig.values.package!.modules ?? []) {
-        verbose && this.log(`Deploying module ${module.name}...`);
+        this.log(`Building module ${module.name}...`);
 
         await build({ verbose }, { log: (...args) => this.log(...args), module });
         const cid = await publish({ verbose }, { module, config: this.clientConfig });
@@ -58,12 +58,14 @@ export default class Publish extends BaseCommand {
         )
       });
 
+      this.log('Publishing to KUBE...');
+
       return await this.execWithPublisher(async (publisher: PublisherRpcPeer) => {
         await publisher.rpc.publish({
           package: moduleConfig.values.package!,
           skipExisting
         });
-        verbose && this.log('Published to KUBE.');
+        this.log('Published to KUBE.');
       });
     } catch (err: any) {
       captureException(err);


### PR DESCRIPTION
#1889

- [x] dx publish does not forward output from pnpm bundle
- [x] make dx app create properly verbose
- [x] "bundle": "NODE_OPTIONS="--max-old-space-size=4096" vite build",