### PR TITLE
chore(protocols): Test depends on prebuild

### DIFF
--- a/packages/core/protocols/project.json
+++ b/packages/core/protocols/project.json
@@ -40,6 +40,11 @@
       ]
     },
     "test": {
+      "dependsOn": [
+        "^build",
+        "^bundle",
+        "prebuild"
+      ],
       "executor": "@dxos/mocha:mocha",
       "options": {
         "coveragePath": "coverage/packages/core/protocols",


### PR DESCRIPTION
Example failed test run: https://app.circleci.com/pipelines/github/dxos/dxos/3320/workflows/74596a18-1d5a-4ee0-ba84-aac996b846de/jobs/3977