### PR TITLE
chore: Remove build/compile target race condition

### DIFF
--- a/packages/common/esbuild-plugins/project.json
+++ b/packages/common/esbuild-plugins/project.json
@@ -2,20 +2,6 @@
   "sourceRoot": "packages/common/esbuild-plugins/src",
   "projectType": "library",
   "targets": {
-    "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": [
-          "nx compile esbuild-plugins"
-        ]
-      },
-      "outputs": [
-        "packages/common/esbuild-plugins/dist"
-      ]
-    },
     "compile": {
       "executor": "@nrwl/js:tsc",
       "options": {

--- a/packages/devtools/cli/project.json
+++ b/packages/devtools/cli/project.json
@@ -12,6 +12,10 @@
       }
     },
     "build": {
+      "dependsOn": [
+        "^build",
+        "prebuild"
+      ],
       "executor": "@nrwl/js:tsc",
       "options": {
         "main": "packages/devtools/cli/src/index.ts",

--- a/tools/executors/esbuild/project.json
+++ b/tools/executors/esbuild/project.json
@@ -1,20 +1,6 @@
 {
   "sourceRoot": "tools/executors/esbuild/src",
   "targets": {
-    "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": [
-          "nx compile esbuild"
-        ]
-      },
-      "outputs": [
-        "tools/executors/esbuild/dist"
-      ]
-    },
     "compile": {
       "executor": "@nrwl/js:tsc",
       "options": {

--- a/tools/executors/playwright/project.json
+++ b/tools/executors/playwright/project.json
@@ -2,20 +2,6 @@
   "sourceRoot": "tools/executors/playwright/src",
   "projectType": "library",
   "targets": {
-    "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": [
-          "nx compile playwright"
-        ]
-      },
-      "outputs": [
-        "tools/executors/playwright/dist"
-      ]
-    },
     "compile": {
       "executor": "@nrwl/js:tsc",
       "options": {

--- a/tools/executors/protobuf-compiler/project.json
+++ b/tools/executors/protobuf-compiler/project.json
@@ -2,20 +2,6 @@
   "sourceRoot": "tools/executors/protobuf-compiler/src",
   "projectType": "library",
   "targets": {
-    "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": [
-          "nx compile protobuf-compiler"
-        ]
-      },
-      "outputs": [
-        "tools/executors/protobuf-compiler/dist"
-      ]
-    },
     "compile": {
       "executor": "@nrwl/js:tsc",
       "options": {

--- a/tools/executors/test/project.json
+++ b/tools/executors/test/project.json
@@ -2,20 +2,6 @@
   "sourceRoot": "tools/executors/test/src",
   "projectType": "library",
   "targets": {
-    "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": [
-          "nx compile test"
-        ]
-      },
-      "outputs": [
-        "tools/executors/test/dist"
-      ]
-    },
     "compile": {
       "executor": "@nrwl/js:tsc",
       "options": {

--- a/tools/executors/toolbox/project.json
+++ b/tools/executors/toolbox/project.json
@@ -2,20 +2,6 @@
   "sourceRoot": "tools/executors/toolbox/src",
   "projectType": "library",
   "targets": {
-    "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": [
-          "nx compile toolbox"
-        ]
-      },
-      "outputs": [
-        "tools/executors/toolbox/dist"
-      ]
-    },
     "compile": {
       "executor": "@nrwl/js:tsc",
       "options": {

--- a/tools/log-hook/project.json
+++ b/tools/log-hook/project.json
@@ -2,28 +2,11 @@
   "sourceRoot": "tools/log-hook/src",
   "projectType": "library",
   "targets": {
-    "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": [
-          "nx compile log-hook"
-        ]
-      },
-      "outputs": [
-        "tools/log-hook/dist"
-      ]
-    },
     "compile": {
       "executor": "@nrwl/js:tsc",
       "options": {
         "main": "tools/log-hook/src/index.ts",
         "outputPath": "tools/log-hook/dist",
-        "transformers": [
-          "@dxos/log-hook/transformer"
-        ],
         "tsConfig": "tools/log-hook/tsconfig.json"
       },
       "outputs": [


### PR DESCRIPTION
The `build` alias for `compile` in tools was causing them to be compiled twice during build and causing build failures.