### PR TITLE
fix: bare input onChange

### DIFF
--- a/packages/common/react-ui/src/components/Input/BarePinInput.tsx
+++ b/packages/common/react-ui/src/components/Input/BarePinInput.tsx
@@ -21,7 +21,10 @@ export type BarePinInputProps = Omit<InputProps, 'ref' | 'label' | 'onChange' | 
 
 // TODO(thure): supplying a `value` prop to CodeInput does not yield correct controlled input interactivity; this may be an issue with RCI (filed as https://github.com/leonardodino/rci/issues/25).
 export const BarePinInput = forwardRef<HTMLInputElement, BarePinInputProps>(
-  ({ initialValue, size, validationMessage, validationValence, value, placeholder, disabled, inputSlot }, ref) => {
+  (
+    { initialValue, size, validationMessage, validationValence, value, onChange, placeholder, disabled, inputSlot },
+    ref
+  ) => {
     const width = getSegmentCssWidth('13px');
     const inputRef = useForwardedRef(ref);
     const inputFocused = useIsFocused(inputRef);
@@ -46,16 +49,17 @@ export const BarePinInput = forwardRef<HTMLInputElement, BarePinInputProps>(
       <CodeInput
         {...{
           spellCheck: false,
-          placeholder,
-          ...inputSlot,
           ...bareInputStyleProps,
+          ...inputSlot,
+          placeholder,
+          onChange,
           inputRef,
+          renderSegment,
           className: mx(
             'font-mono selection:bg-transparent mli-auto',
             disabled && 'cursor-not-allowed',
             inputSlot?.className
-          ),
-          renderSegment
+          )
         }}
       />
     );

--- a/packages/common/react-ui/src/components/Input/BareTextInput.tsx
+++ b/packages/common/react-ui/src/components/Input/BareTextInput.tsx
@@ -24,12 +24,14 @@ export const BareTextInput = ({
   size,
   disabled,
   placeholder,
+  onChange,
   inputSlot
 }: BareTextInputProps) => {
   return (
     <input
-      placeholder={placeholder}
       {...inputSlot}
+      placeholder={placeholder}
+      onChange={onChange}
       className={mx(
         defaultInput({
           disabled,

--- a/packages/common/react-ui/src/components/Input/BareTextareaInput.tsx
+++ b/packages/common/react-ui/src/components/Input/BareTextareaInput.tsx
@@ -14,15 +14,16 @@ export type BareTextareaInputProps = Omit<TextareaProps, 'label' | 'initialValue
 export const BareTextareaInput = ({
   validationValence,
   validationMessage,
-  size,
+  onChange,
   disabled,
   placeholder,
   inputSlot
 }: BareTextareaInputProps) => {
   return (
     <textarea
-      placeholder={placeholder}
       {...inputSlot}
+      placeholder={placeholder}
+      onChange={onChange}
       className={mx(
         defaultInput({
           disabled,


### PR DESCRIPTION
This PR fixes my goof. `onChange` now propagates as before.

<img width="250" alt="Screenshot 2022-12-05 at 15 31 37" src="https://user-images.githubusercontent.com/855039/205767241-b595f179-cb31-449c-9062-0079ca703870.png">
