### PR TITLE
fix: vite injected env vars missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
       "@nrwl/storybook@15.4.5": "patches/@nrwl__storybook@15.4.5.patch",
       "@nrwl/vite@15.4.5": "patches/@nrwl__vite@15.4.5.patch",
       "memdown@5.1.0": "patches/memdown@5.1.0.patch",
+      "process@0.11.10": "patches/process@0.11.10.patch",
       "ts-node@10.9.1": "patches/ts-node@10.9.1.patch",
       "uuid@8.3.2": "patches/uuid@8.3.2.patch",
       "vite@4.0.4": "patches/vite@4.0.4.patch"

--- a/patches/process@0.11.10.patch
+++ b/patches/process@0.11.10.patch
@@ -1,0 +1,20 @@
+diff --git a/browser.js b/browser.js
+index d059362306586e0ed53170099e2e34aa7c756adb..fa334c6ac8c16432fa016d5b7dac64634386817c 100644
+--- a/browser.js
++++ b/browser.js
+@@ -1,5 +1,5 @@
+ // shim for using process in browser
+-var process = module.exports = {};
++var process = module.exports = globalThis.process || {};
+ 
+ // cached from whatever global is present so that test runners that stub it
+ // don't break things.  But we need to wrap it in a try catch in case it is
+@@ -154,7 +154,7 @@ Item.prototype.run = function () {
+ };
+ process.title = 'browser';
+ process.browser = true;
+-process.env = {};
++process.env = process.env || {};
+ process.argv = [];
+ process.version = ''; // empty string to avoid regexp issues
+ process.versions = {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ patchedDependencies:
   memdown@5.1.0:
     hash: tjbpekhnedejisbcwvc5eec3ii
     path: patches/memdown@5.1.0.patch
+  process@0.11.10:
+    hash: dj6mswaqw6gwz4lkspp5zukugi
+    path: patches/process@0.11.10.patch
   ts-node@10.9.1:
     hash: rke3py7up3u364r7wwqfla7cdm
     path: patches/ts-node@10.9.1.patch
@@ -1023,7 +1026,7 @@ importers:
       buffer: 6.0.3
       events: 3.3.0
       path-browserify: 1.0.1
-      process: 0.11.10
+      process: 0.11.10_dj6mswaqw6gwz4lkspp5zukugi
       readable-stream: 3.6.0
       util: 0.12.5
 
@@ -10570,7 +10573,7 @@ packages:
       express: 4.18.2
       find-cache-dir: 4.0.0
       fs-extra: 9.1.0
-      process: 0.11.10
+      process: 0.11.10_dj6mswaqw6gwz4lkspp5zukugi
       slash: 3.0.0
       util: 0.12.5
     transitivePeerDependencies:
@@ -20823,7 +20826,7 @@ packages:
     resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
     dependencies:
       min-document: 2.19.0
-      process: 0.11.10
+      process: 0.11.10_dj6mswaqw6gwz4lkspp5zukugi
     dev: true
 
   /globals/11.12.0:
@@ -26131,7 +26134,7 @@ packages:
       https-browserify: 1.0.0
       os-browserify: 0.3.0
       path-browserify: 0.0.1
-      process: 0.11.10
+      process: 0.11.10_dj6mswaqw6gwz4lkspp5zukugi
       punycode: 1.4.1
       querystring-es3: 0.2.1
       readable-stream: 2.3.7
@@ -27833,9 +27836,10 @@ packages:
       fromentries: 1.3.2
     dev: true
 
-  /process/0.11.10:
+  /process/0.11.10_dj6mswaqw6gwz4lkspp5zukugi:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+    patched: true
 
   /progress/2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}


### PR DESCRIPTION
Presently, when injecting env vars into a vite app (e.g., https://github.com/dxos/dxos/blob/main/packages/apps/tasks-app/vite.config.ts#L25) the result is that process.env is an empty object. This is because after the transition to `@dxos/node-std` the `process` shim is overwriting these. This patches the `process` browser shim to allow vite to `define` env vars inside process by shimming into an existing `process` global if it exists.