### PR TITLE
fix: react hook warning in monolithic apps

### DIFF
--- a/packages/apps/composer-app/src/Routes.tsx
+++ b/packages/apps/composer-app/src/Routes.tsx
@@ -16,20 +16,9 @@ export const Routes = () => {
   const identity = useIdentity();
 
   // TODO(wittjosiah): Settings to disable telemetry, sync from HALO?
-  useTelemetry({ namespace: 'tasks-app' });
+  useTelemetry({ namespace: 'composer-app' });
 
-  // Allow the client to auto-create an identity if env DX_VAULT=false
-  useEffect(() => {
-    if (process.env.DX_VAULT === 'false' && !identity) {
-      void client.halo.createProfile();
-    }
-  }, []);
-
-  if (process.env.DX_VAULT === 'false' && !identity) {
-    return null;
-  }
-
-  return useRoutes([
+  const routes = useRoutes([
     {
       path: '/',
       element: <RequireIdentity />,
@@ -67,4 +56,17 @@ export const Routes = () => {
       ]
     }
   ]);
+
+  // Allow the client to auto-create an identity if env DX_VAULT=false
+  useEffect(() => {
+    if (process.env.DX_VAULT === 'false' && !identity) {
+      void client.halo.createProfile();
+    }
+  }, []);
+
+  if (process.env.DX_VAULT === 'false' && !identity) {
+    return null;
+  }
+
+  return routes;
 };

--- a/packages/apps/tasks-app/src/Routes.tsx
+++ b/packages/apps/tasks-app/src/Routes.tsx
@@ -18,18 +18,7 @@ export const Routes = () => {
   // TODO(wittjosiah): Settings to disable telemetry, sync from HALO?
   useTelemetry({ namespace: 'tasks-app' });
 
-  // Allow the client to auto-create an identity if env DX_VAULT=false
-  useEffect(() => {
-    if (process.env.DX_VAULT === 'false' && !identity) {
-      void client.halo.createProfile();
-    }
-  }, []);
-
-  if (process.env.DX_VAULT === 'false' && !identity) {
-    return null;
-  }
-
-  return useRoutes([
+  const routes = useRoutes([
     {
       path: '/',
       element: <RequireIdentity />,
@@ -67,4 +56,17 @@ export const Routes = () => {
       ]
     }
   ]);
+
+  // Allow the client to auto-create an identity if env DX_VAULT=false
+  useEffect(() => {
+    if (process.env.DX_VAULT === 'false' && !identity) {
+      void client.halo.createProfile();
+    }
+  }, []);
+
+  if (process.env.DX_VAULT === 'false' && !identity) {
+    return null;
+  }
+
+  return routes;
 };


### PR DESCRIPTION
`useRoutes` is a hook and causes React to generate a warning when DX_VAULT is false because the number of hooks in the `Routes` component changes when an identity is created.

