### PR TITLE
fix: Sidebar layout & motion

### DIFF
--- a/packages/apps/patterns/react-ui/src/layouts/PanelSidebar/PanelSidebar.tsx
+++ b/packages/apps/patterns/react-ui/src/layouts/PanelSidebar/PanelSidebar.tsx
@@ -19,8 +19,6 @@ import { defaultOverlay, mx, useMediaQuery, useTranslation } from '@dxos/react-c
 
 export type PanelSidebarState = 'show' | 'hide';
 
-export const sidebarWidth = 272;
-
 export interface PanelSidebarContextValue {
   setDisplayState: Dispatch<SetStateAction<PanelSidebarState>>;
   displayState: PanelSidebarState;
@@ -49,40 +47,44 @@ export interface PanelSidebarProviderProps {
   slots?: PanelSidebarProviderSlots;
 }
 
-export const PanelSidebarProvider = ({ children, slots }: PropsWithChildren<PanelSidebarProviderProps>) => {
+export const PanelSidebarProvider = ({
+  children,
+  inlineStart,
+  slots
+}: PropsWithChildren<PanelSidebarProviderProps>) => {
   const { t } = useTranslation('os');
-  const [displayState, setInternalDisplayState] = useState<PanelSidebarState>('hide');
-  const [transitionShow, setTransitionShow] = useState(false);
-  const isOpen = displayState === 'show';
-
   const [isLg] = useMediaQuery('lg');
+  const [displayState, setInternalDisplayState] = useState<PanelSidebarState>(isLg ? 'show' : 'hide');
+  const isOpen = displayState === 'show';
+  const [transitionShow, setTransitionShow] = useState(isOpen);
+  const [domShow, setDomShow] = useState(isOpen);
 
   const internalHide = () => {
     setTransitionShow(false);
+    setInternalDisplayState('hide');
     setTimeout(() => {
-      setInternalDisplayState('hide');
+      setDomShow(false);
     }, 200);
   };
-
   const internalShow = () => {
+    setDomShow(true);
     setInternalDisplayState('show');
     setTimeout(() => {
       setTransitionShow(true);
       // todo (thure): this may be a race condition in certain situations
     }, 0);
   };
-
   const setDisplayState = (displayState: SetStateAction<PanelSidebarState>) =>
     displayState === 'show' ? internalShow() : internalHide();
 
   return (
     <PanelSidebarContext.Provider value={{ setDisplayState, displayState }}>
-      <DialogPrimitive.Root open={isOpen} modal={!isLg}>
+      <DialogPrimitive.Root open={domShow} modal={!isLg}>
         <DialogPrimitive.Content
           className={mx(
-            'fixed block-start-0 block-end-0 is-[272px] z-50 transition-[inset-inline-start,inset-inline-end] duration-200 ease-in-out',
+            'fixed block-start-0 block-end-0 is-[272px] z-50 transition-[inset-inline-start,inset-inline-end] duration-200 ease-in-out overflow-x-hidden overflow-y-auto',
             'bg-neutral-50 dark:bg-neutral-950',
-            transitionShow ? 'inline-start-0' : `inline-start-[-${sidebarWidth}px]`
+            transitionShow ? 'inline-start-0' : 'inline-start-[-272px]'
           )}
         >
           <DialogPrimitive.Title className='sr-only'>{t('sidebar label')}</DialogPrimitive.Title>

--- a/packages/experimental/kai/src/app/pages/AppBar.tsx
+++ b/packages/experimental/kai/src/app/pages/AppBar.tsx
@@ -7,7 +7,7 @@ import React, { FC, useContext } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { getSize, mx, useMediaQuery } from '@dxos/react-components';
-import { PanelSidebarContext, sidebarWidth, useTogglePanelSidebar } from '@dxos/react-ui';
+import { PanelSidebarContext, useTogglePanelSidebar } from '@dxos/react-ui';
 
 import { useOptions, viewConfig } from '../../hooks';
 
@@ -58,7 +58,7 @@ export const ViewSelector: FC = () => {
     <div
       className={mx(
         'flex flex-col flex-1 bg-orange-500 pt-1 fixed inline-end-0 block-start-[48px] z-[1] transition-[inset-inline-start] duration-200 ease-in-out',
-        isLg && isOpen ? `inline-start-[${sidebarWidth}px]` : 'inline-start-0'
+        isLg && isOpen ? 'inline-start-[272px]' : 'inline-start-0'
       )}
     >
       <div className='flex pl-2'>


### PR DESCRIPTION
Tailwind doesn't support string interpolation in utility classes — we can either export a full string literal or use inline styles, if a property like this should be shared.