### PR TITLE
fix: Topbar & Sidebar coordination in `kai`

### DIFF
--- a/packages/apps/patterns/react-ui/src/layouts/PanelSidebar/PanelSidebar.tsx
+++ b/packages/apps/patterns/react-ui/src/layouts/PanelSidebar/PanelSidebar.tsx
@@ -19,8 +19,6 @@ import { defaultOverlay, mx, useMediaQuery, useTranslation } from '@dxos/react-c
 
 export type PanelSidebarState = 'show' | 'hide';
 
-export const sidebarWidth = 272;
-
 export interface PanelSidebarContextValue {
   setDisplayState: Dispatch<SetStateAction<PanelSidebarState>>;
   displayState: PanelSidebarState;
@@ -49,7 +47,11 @@ export interface PanelSidebarProviderProps {
   slots?: PanelSidebarProviderSlots;
 }
 
-export const PanelSidebarProvider = ({ children, slots }: PropsWithChildren<PanelSidebarProviderProps>) => {
+export const PanelSidebarProvider = ({
+  children,
+  inlineStart,
+  slots
+}: PropsWithChildren<PanelSidebarProviderProps>) => {
   const { t } = useTranslation('os');
   const [isLg] = useMediaQuery('lg');
   const [displayState, setInternalDisplayState] = useState<PanelSidebarState>(isLg ? 'show' : 'hide');
@@ -83,8 +85,7 @@ export const PanelSidebarProvider = ({ children, slots }: PropsWithChildren<Pane
         <DialogPrimitive.Content
           className={mx(
             'fixed block-start-0 block-end-0 is-[272px] z-50 transition-[inset-inline-start,inset-inline-end] duration-200 ease-in-out overflow-x-hidden overflow-y-auto',
-            'bg-neutral-50 dark:bg-neutral-950',
-            transitionShow ? 'inline-start-0' : `inline-start-[-${sidebarWidth}px]`
+            transitionShow ? 'inline-start-0' : 'inline-start-[-272px]'
           )}
         >
           <DialogPrimitive.Title className='sr-only'>{t('sidebar label')}</DialogPrimitive.Title>

--- a/packages/apps/patterns/react-ui/src/layouts/PanelSidebar/PanelSidebar.tsx
+++ b/packages/apps/patterns/react-ui/src/layouts/PanelSidebar/PanelSidebar.tsx
@@ -7,7 +7,6 @@ import React, {
   ComponentProps,
   createContext,
   Dispatch,
-  Fragment,
   PropsWithChildren,
   SetStateAction,
   useCallback,
@@ -37,7 +36,7 @@ export const useTogglePanelSidebar = () => {
 };
 
 export interface PanelSidebarProviderSlots {
-  content?: ComponentProps<typeof Fragment>;
+  content?: ComponentProps<typeof DialogPrimitive.Content>;
   fixedBlockStart?: ComponentProps<'div'>;
   fixedBlockEnd?: ComponentProps<'div'>;
 }
@@ -83,13 +82,15 @@ export const PanelSidebarProvider = ({
     <PanelSidebarContext.Provider value={{ setDisplayState, displayState }}>
       <DialogPrimitive.Root open={domShow} modal={!isLg}>
         <DialogPrimitive.Content
+          {...slots?.content}
           className={mx(
             'fixed block-start-0 block-end-0 is-[272px] z-50 transition-[inset-inline-start,inset-inline-end] duration-200 ease-in-out overflow-x-hidden overflow-y-auto',
-            transitionShow ? 'inline-start-0' : 'inline-start-[-272px]'
+            transitionShow ? 'inline-start-0' : 'inline-start-[-272px]',
+            slots?.content?.className
           )}
         >
           <DialogPrimitive.Title className='sr-only'>{t('sidebar label')}</DialogPrimitive.Title>
-          <Fragment {...slots?.content} />
+          {slots?.content?.children}
         </DialogPrimitive.Content>
         {slots?.fixedBlockStart && (
           <div

--- a/packages/common/react-components/src/components/Dialog/dialogStyles.ts
+++ b/packages/common/react-components/src/components/Dialog/dialogStyles.ts
@@ -2,4 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-export const defaultOverlay = 'fixed inset-0 z-20 bg-black/50 backdrop-blur';
+export const defaultOverlay = 'fixed inset-0 z-20 bg-transparent';

--- a/packages/experimental/kai/src/app/AppBar.tsx
+++ b/packages/experimental/kai/src/app/AppBar.tsx
@@ -3,11 +3,11 @@
 //
 
 import { Bug, Globe, List, User } from 'phosphor-react';
-import React from 'react';
+import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 
 import { getSize, mx } from '@dxos/react-components';
-import { useTogglePanelSidebar } from '@dxos/react-ui';
+import { PanelSidebarContext, useTogglePanelSidebar } from '@dxos/react-ui';
 
 import { FrameID } from '../hooks';
 
@@ -26,9 +26,17 @@ export const Menu = () => {
 
 export const AppBar = () => {
   const toggleSidebar = useTogglePanelSidebar();
+  const { displayState } = useContext(PanelSidebarContext);
+  const isOpen = displayState === 'show';
 
   return (
-    <div className='flex items-center pl-4 pr-4' style={{ height: 48 }}>
+    <div
+      className={mx(
+        'flex items-center pl-4 pr-4 fixed inline-end-0 block-start-0 bg-orange-400 transition-[inset-inline-start] duration-200 ease-in-out',
+        isOpen ? 'inline-start-0 lg:inline-start-[272px]' : 'inline-start-0'
+      )}
+      style={{ height: 48 }}
+    >
       <div className='flex'>
         <button onClick={toggleSidebar}>
           <List className={getSize(6)} />

--- a/packages/experimental/kai/src/app/AppBar.tsx
+++ b/packages/experimental/kai/src/app/AppBar.tsx
@@ -3,11 +3,11 @@
 //
 
 import { Bug, Globe, List, User } from 'phosphor-react';
-import React, { useContext } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { getSize, mx } from '@dxos/react-components';
-import { PanelSidebarContext, useTogglePanelSidebar } from '@dxos/react-ui';
+import { useTogglePanelSidebar } from '@dxos/react-ui';
 
 import { FrameID } from '../hooks';
 
@@ -26,15 +26,10 @@ export const Menu = () => {
 
 export const AppBar = () => {
   const toggleSidebar = useTogglePanelSidebar();
-  const { displayState } = useContext(PanelSidebarContext);
-  const isOpen = displayState === 'show';
 
   return (
     <div
-      className={mx(
-        'flex items-center pl-4 pr-4 fixed inline-end-0 block-start-0 bg-orange-400 transition-[inset-inline-start] duration-200 ease-in-out',
-        isOpen ? 'inline-start-0 lg:inline-start-[272px]' : 'inline-start-0'
-      )}
+      className='flex items-center pl-4 pr-4 fixed inline-start-0 inline-end-0 block-start-0 bg-orange-400'
       style={{ height: 48 }}
     >
       <div className='flex'>

--- a/packages/experimental/kai/src/app/Frames.tsx
+++ b/packages/experimental/kai/src/app/Frames.tsx
@@ -6,7 +6,7 @@ import { Article, Calendar, Compass, Gear, Globe, Graph, Kanban, ListChecks, Swo
 import React, { FC, useContext } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { mx, getSize, useMediaQuery } from '@dxos/react-components';
+import { mx, getSize } from '@dxos/react-components';
 import { PanelSidebarProvider, PanelSidebarContext } from '@dxos/react-ui';
 
 // TODO(burdon): Rename views.
@@ -50,15 +50,14 @@ export const FrameSelector: FC = () => {
   const { space } = useSpace();
   const frames = useActiveFrames();
   const { frame: currentFrame } = useParams();
-  const { displayState } = useContext(PanelSidebarContext); // TODO(burdon): Context lags.
+  const { displayState } = useContext(PanelSidebarContext);
   const isOpen = displayState === 'show';
-  const [isLg] = useMediaQuery('lg');
 
   return (
     <div
       className={mx(
         'flex flex-col flex-1 bg-orange-500 pt-1 fixed inline-end-0 block-start-[48px] z-[1] transition-[inset-inline-start] duration-200 ease-in-out',
-        isLg && isOpen ? 'inline-start-[272px]' : 'inline-start-0'
+        isOpen ? 'inline-start-0 lg:inline-start-[272px]' : 'inline-start-0'
       )}
     >
       <div className='flex pl-2'>
@@ -94,13 +93,8 @@ export const FrameContainer: FC<{ frame: string }> = ({ frame }) => {
   const { Component } = active ?? {};
 
   return (
-    <PanelSidebarProvider
-      inlineStart
-      slots={{
-        fixedBlockStart: { children: <AppBar />, className: 'bg-orange-400' },
-        content: { children: <Sidebar /> }
-      }}
-    >
+    <PanelSidebarProvider inlineStart slots={{ content: { children: <Sidebar /> } }}>
+      <AppBar />
       <FrameSelector />
       {Component && (
         <div className={mx(frames.length > 1 ? 'pbs-[84px]' : 'pbs-[48px]', 'flex h-screen bg-white')}>

--- a/packages/experimental/kai/src/app/Frames.tsx
+++ b/packages/experimental/kai/src/app/Frames.tsx
@@ -93,7 +93,7 @@ export const FrameContainer: FC<{ frame: string }> = ({ frame }) => {
   const { Component } = active ?? {};
 
   return (
-    <PanelSidebarProvider inlineStart slots={{ content: { children: <Sidebar /> } }}>
+    <PanelSidebarProvider inlineStart slots={{ content: { children: <Sidebar />, className: 'block-start-[48px]' } }}>
       <AppBar />
       <FrameSelector />
       {Component && (

--- a/packages/experimental/kai/src/app/Sidebar.tsx
+++ b/packages/experimental/kai/src/app/Sidebar.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import { PlusCircle } from 'phosphor-react';
+import { PlusCircle, X } from 'phosphor-react';
 import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -43,12 +43,22 @@ export const Sidebar = () => {
   };
 
   return (
-    <div className='flex flex-1 flex-col overflow-auto min-bs-full'>
+    <div
+      role='none'
+      className='flex flex-col overflow-auto min-bs-full backdrop-blur bg-neutral-50/[.33] dark:bg-neutral-950/[.33]'
+    >
+      <div className='flex justify-end bg-orange-500/50 lg:bg-orange-400'>
+        <Button onClick={toggleSidebar} className='p-3'>
+          <span className='sr-only'>Close sidebar</span>
+          <X className={getSize(6)} />
+        </Button>
+      </div>
       {/* Spaces */}
-      <div className='flex flex-shrink-0 flex-col overflow-y-scroll'>
+      <div className='flex shrink-0 flex-col overflow-y-scroll'>
         <SpaceList />
         <div className='p-3'>
           <Button className='flex' title='Create new space' onClick={handleCreateSpace}>
+            <span className='sr-only'>Create new space</span>
             <PlusCircle className={getSize(6)} />
           </Button>
         </div>
@@ -57,9 +67,9 @@ export const Sidebar = () => {
       <div className='flex flex-1'></div>
 
       {/* Members */}
-      <div className='flex flex-col flex-shrink-0 mt-6'>
+      <div className='flex flex-col shrink-0 mt-6'>
         <div className='flex p-1 pl-3 mb-2 text-xs'>Members</div>
-        <div className='flex flex-shrink-0 pl-3'>
+        <div className='flex shrink-0 pl-3'>
           <MemberList spaceKey={space.key} />
         </div>
       </div>

--- a/packages/experimental/kai/src/app/Sidebar.tsx
+++ b/packages/experimental/kai/src/app/Sidebar.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import { PlusCircle, X } from 'phosphor-react';
+import { PlusCircle } from 'phosphor-react';
 import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -47,12 +47,6 @@ export const Sidebar = () => {
       role='none'
       className='flex flex-col overflow-auto min-bs-full backdrop-blur bg-neutral-50/[.33] dark:bg-neutral-950/[.33]'
     >
-      <div className='flex justify-end bg-orange-500/50 lg:bg-orange-400'>
-        <Button onClick={toggleSidebar} className='p-3'>
-          <span className='sr-only'>Close sidebar</span>
-          <X className={getSize(6)} />
-        </Button>
-      </div>
       {/* Spaces */}
       <div className='flex shrink-0 flex-col overflow-y-scroll'>
         <SpaceList />


### PR DESCRIPTION
This PR lets `kai`’s `AppBar` remain on top and displace the top edge of the sidebar.