### PR TITLE
fix: Topbar & Sidebar coordination in `kai`

### DIFF
--- a/packages/apps/patterns/react-ui/src/layouts/PanelSidebar/PanelSidebar.tsx
+++ b/packages/apps/patterns/react-ui/src/layouts/PanelSidebar/PanelSidebar.tsx
@@ -7,7 +7,6 @@ import React, {
   ComponentProps,
   createContext,
   Dispatch,
-  Fragment,
   PropsWithChildren,
   SetStateAction,
   useCallback,
@@ -37,7 +36,7 @@ export const useTogglePanelSidebar = () => {
 };
 
 export interface PanelSidebarProviderSlots {
-  content?: ComponentProps<typeof Fragment>;
+  content?: ComponentProps<typeof DialogPrimitive.Content>;
   fixedBlockStart?: ComponentProps<'div'>;
   fixedBlockEnd?: ComponentProps<'div'>;
 }
@@ -83,13 +82,15 @@ export const PanelSidebarProvider = ({
     <PanelSidebarContext.Provider value={{ setDisplayState, displayState }}>
       <DialogPrimitive.Root open={domShow} modal={!isLg}>
         <DialogPrimitive.Content
+          {...slots?.content}
           className={mx(
             'fixed block-start-0 block-end-0 is-[272px] z-50 transition-[inset-inline-start,inset-inline-end] duration-200 ease-in-out overflow-x-hidden overflow-y-auto',
-            transitionShow ? 'inline-start-0' : 'inline-start-[-272px]'
+            transitionShow ? 'inline-start-0' : 'inline-start-[-272px]',
+            slots?.content?.className
           )}
         >
           <DialogPrimitive.Title className='sr-only'>{t('sidebar label')}</DialogPrimitive.Title>
-          <Fragment {...slots?.content} />
+          {slots?.content?.children}
         </DialogPrimitive.Content>
         {slots?.fixedBlockStart && (
           <div

--- a/packages/experimental/kai/src/app/AppBar.tsx
+++ b/packages/experimental/kai/src/app/AppBar.tsx
@@ -3,11 +3,11 @@
 //
 
 import { Bug, Globe, List, User } from 'phosphor-react';
-import React, { useContext } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { getSize, mx } from '@dxos/react-components';
-import { PanelSidebarContext, useTogglePanelSidebar } from '@dxos/react-ui';
+import { useTogglePanelSidebar } from '@dxos/react-ui';
 
 import { FrameID } from '../hooks';
 
@@ -26,15 +26,10 @@ export const Menu = () => {
 
 export const AppBar = () => {
   const toggleSidebar = useTogglePanelSidebar();
-  const { displayState } = useContext(PanelSidebarContext);
-  const isOpen = displayState === 'show';
 
   return (
     <div
-      className={mx(
-        'flex items-center pl-4 pr-4 fixed inline-end-0 block-start-0 bg-orange-400 transition-[inset-inline-start] duration-200 ease-in-out',
-        isOpen ? 'inline-start-0 lg:inline-start-[272px]' : 'inline-start-0'
-      )}
+      className='flex items-center pl-4 pr-4 fixed inline-start-0 inline-end-0 block-start-0 bg-orange-400'
       style={{ height: 48 }}
     >
       <div className='flex'>

--- a/packages/experimental/kai/src/app/Frames.tsx
+++ b/packages/experimental/kai/src/app/Frames.tsx
@@ -93,7 +93,7 @@ export const FrameContainer: FC<{ frame: string }> = ({ frame }) => {
   const { Component } = active ?? {};
 
   return (
-    <PanelSidebarProvider inlineStart slots={{ content: { children: <Sidebar /> } }}>
+    <PanelSidebarProvider inlineStart slots={{ content: { children: <Sidebar />, className: 'block-start-[48px]' } }}>
       <AppBar />
       <FrameSelector />
       {Component && (

--- a/packages/experimental/kai/src/app/Sidebar.tsx
+++ b/packages/experimental/kai/src/app/Sidebar.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import { PlusCircle, X } from 'phosphor-react';
+import { PlusCircle } from 'phosphor-react';
 import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -47,12 +47,6 @@ export const Sidebar = () => {
       role='none'
       className='flex flex-col overflow-auto min-bs-full backdrop-blur bg-neutral-50/[.33] dark:bg-neutral-950/[.33]'
     >
-      <div className='flex justify-end bg-orange-500/50 lg:bg-orange-400'>
-        <Button onClick={toggleSidebar} className='p-3'>
-          <span className='sr-only'>Close sidebar</span>
-          <X className={getSize(6)} />
-        </Button>
-      </div>
       {/* Spaces */}
       <div className='flex shrink-0 flex-col overflow-y-scroll'>
         <SpaceList />


### PR DESCRIPTION
This PR lets `kai`’s `AppBar` remain on top and displace the top edge of the sidebar.


https://user-images.githubusercontent.com/855039/212783998-812cdd3d-0cdc-495e-9fb5-e0ce56241e4c.mp4

