### PR TITLE
ci: update kai build command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
           command: ./.circleci/scripts/publish.sh
           environment:
             NODE_ENV: production
-            NODE_OPTIONS: --max_old_space_size=4096
+            NODE_OPTIONS: --max_old_space_size=8198
 
 workflows:
   default:

--- a/packages/experimental/kai/dx.yml
+++ b/packages/experimental/kai/dx.yml
@@ -7,7 +7,7 @@ package:
       displayName: kai
       description: Kai Demo.
       build:
-        command: DEMO=true NODE_OPTIONS="--max_old_space_size=8096" pnpm -w nx bundle kai
+        command: pnpm -w nx bundle kai
       tunnel: true
 
 runtime:


### PR DESCRIPTION
Kai build has been failing when publishing https://app.circleci.com/pipelines/github/dxos/dxos/5375/workflows/9163c957-70c5-4fc7-894d-39d977adf8d7/jobs/8057?invite=true#step-106-339