### PR TITLE
fix: Stabilize layout in `kai`

### DIFF
--- a/packages/apps/patterns/react-ui/src/layouts/PanelSidebar/PanelSidebar.tsx
+++ b/packages/apps/patterns/react-ui/src/layouts/PanelSidebar/PanelSidebar.tsx
@@ -120,7 +120,7 @@ export const PanelSidebarProvider = ({
           role='none'
           {...slots?.main}
           className={mx(
-            'min-bs-full transition-[padding-inline-start] duration-200 ease-in-out',
+            'transition-[padding-inline-start] duration-200 ease-in-out',
             isLg && isOpen ? 'pis-[272px]' : 'pis-0',
             slots?.main?.className
           )}

--- a/packages/apps/patterns/react-ui/src/layouts/PanelSidebar/PanelSidebar.tsx
+++ b/packages/apps/patterns/react-ui/src/layouts/PanelSidebar/PanelSidebar.tsx
@@ -39,6 +39,7 @@ export interface PanelSidebarProviderSlots {
   content?: ComponentProps<typeof DialogPrimitive.Content>;
   fixedBlockStart?: ComponentProps<'div'>;
   fixedBlockEnd?: ComponentProps<'div'>;
+  main?: ComponentProps<'div'>;
 }
 
 export interface PanelSidebarProviderProps {
@@ -117,9 +118,11 @@ export const PanelSidebarProvider = ({
         )}
         <div
           role='none'
+          {...slots?.main}
           className={mx(
-            'bs-full transition-[padding-inline-start] duration-200 ease-in-out',
-            isLg && isOpen ? 'pis-[272px]' : 'pis-0'
+            'min-bs-full transition-[padding-inline-start] duration-200 ease-in-out',
+            isLg && isOpen ? 'pis-[272px]' : 'pis-0',
+            slots?.main?.className
           )}
         >
           {children}

--- a/packages/experimental/kai/src/app/AppBar.tsx
+++ b/packages/experimental/kai/src/app/AppBar.tsx
@@ -28,10 +28,7 @@ export const AppBar = () => {
   const toggleSidebar = useTogglePanelSidebar();
 
   return (
-    <div
-      className='flex items-center pl-4 pr-4 fixed inline-start-0 inline-end-0 block-start-0 bg-orange-400 z-[1]'
-      style={{ height: 48 }}
-    >
+    <div className='flex items-center pl-4 pr-4 fixed inline-start-0 inline-end-0 block-start-0 bs-[48px] bg-orange-400 z-[1]'>
       <div className='flex'>
         <button onClick={toggleSidebar}>
           <List className={getSize(6)} />

--- a/packages/experimental/kai/src/app/Frames.tsx
+++ b/packages/experimental/kai/src/app/Frames.tsx
@@ -93,14 +93,21 @@ export const FrameContainer: FC<{ frame: string }> = ({ frame }) => {
   const { Component } = active ?? {};
 
   return (
-    <PanelSidebarProvider inlineStart slots={{ content: { children: <Sidebar />, className: 'block-start-[48px]' } }}>
+    <PanelSidebarProvider
+      inlineStart
+      slots={{
+        content: { children: <Sidebar />, className: 'block-start-[48px]' },
+        main: {
+          className: mx(
+            frames.length > 1 ? 'pbs-[84px]' : 'pbs-[48px]',
+            'min-bs-screen max-bs-screen flex flex-col bg-white'
+          )
+        }
+      }}
+    >
       <AppBar />
       <FrameSelector />
-      {Component && (
-        <div className={mx(frames.length > 1 ? 'pbs-[84px]' : 'pbs-[48px]', 'flex h-screen bg-white')}>
-          <Component />
-        </div>
-      )}
+      {Component && <Component />}
     </PanelSidebarProvider>
   );
 };

--- a/packages/experimental/kai/src/app/Frames.tsx
+++ b/packages/experimental/kai/src/app/Frames.tsx
@@ -97,12 +97,7 @@ export const FrameContainer: FC<{ frame: string }> = ({ frame }) => {
       inlineStart
       slots={{
         content: { children: <Sidebar />, className: 'block-start-[48px]' },
-        main: {
-          className: mx(
-            frames.length > 1 ? 'pbs-[84px]' : 'pbs-[48px]',
-            'min-bs-screen max-bs-screen flex flex-col bg-white'
-          )
-        }
+        main: { className: mx(frames.length > 1 ? 'pbs-[84px]' : 'pbs-[48px]', 'bs-screen flex flex-col bg-white') }
       }}
     >
       <AppBar />

--- a/packages/experimental/kai/src/app/Frames.tsx
+++ b/packages/experimental/kai/src/app/Frames.tsx
@@ -56,7 +56,7 @@ export const FrameSelector: FC = () => {
   return (
     <div
       className={mx(
-        'flex flex-col flex-1 bg-orange-500 pt-1 fixed inline-end-0 block-start-[48px] z-[1] transition-[inset-inline-start] duration-200 ease-in-out',
+        'flex flex-col flex-1 bg-orange-500 pt-1 fixed inline-end-0 block-start-[48px] bs-[36px] z-[1] transition-[inset-inline-start] duration-200 ease-in-out',
         isOpen ? 'inline-start-0 lg:inline-start-[272px]' : 'inline-start-0'
       )}
     >


### PR DESCRIPTION
This PR fixes `AppBar` and `FrameSelector` heights in `kai` and allows the OS’s `PanelSidebar`’s main content area to be styled for layout purposes.

<img width="1681" alt="Screenshot 2023-01-17 at 10 51 29" src="https://user-images.githubusercontent.com/855039/212986496-f4562cf5-7424-48fe-9f51-7060840d85f6.png">