### PR TITLE
fix: cosmetic improvements in kai

### DIFF
--- a/packages/common/react-components/src/config/tailwind.ts
+++ b/packages/common/react-components/src/config/tailwind.ts
@@ -246,5 +246,8 @@ export const tailwindConfig = ({
   },
   plugins: [tailwindcssLogical, tailwindcssForms, tailwindcssRadix()],
   ...(env === 'development' && { mode: 'jit' }),
-  content: [resolve(root, 'node_modules/@dxos/react-components/dist/**/*.mjs'), ...content]
+  content: [resolve(root, 'node_modules/@dxos/react-components/dist/**/*.mjs'), ...content],
+  future: {
+    hoverOnlyWhenSupported: true
+  }
 });

--- a/packages/experimental/kai/README.md
+++ b/packages/experimental/kai/README.md
@@ -6,7 +6,7 @@ The word kai (貝) is the Japanese word for shell.
 ## Development
 
 ```bash
-p serve
+pnpm nx serve kai
 ```
 
 ## Deploying the App

--- a/packages/experimental/kai/src/app/App.tsx
+++ b/packages/experimental/kai/src/app/App.tsx
@@ -29,7 +29,7 @@ const clientProvider = async (demo: boolean) => {
   // TODO(burdon): Auto invite/join if demo mode.
   // TODO(burdon): Manifest file to expose windows API to auto open invitee window.
   // chrome.windows.create({ '/join', incognito: true });
-  if (demo) {
+  if (demo && !client.halo.profile) {
     await client.halo.createProfile();
     const space = await client.echo.createSpace();
 

--- a/packages/experimental/kai/src/app/Sidebar.tsx
+++ b/packages/experimental/kai/src/app/Sidebar.tsx
@@ -43,34 +43,35 @@ export const Sidebar = () => {
       role='none'
       className='flex flex-col overflow-auto min-bs-full box-shadow backdrop-blur bg-neutral-50/[.33] dark:bg-neutral-950/[.33]'
     >
-      {/* Spaces */}
-      <div className='flex shrink-0 flex-col overflow-y-scroll'>
-        {/* Match Frame selector. */}
-        <div className='flex p-1 pl-4 h-[36px] pt-2 bg-orange-500'>
-          <div>Spaces</div>
-        </div>
-
-        <SpaceList />
-
-        <div className='p-3'>
-          <Button className='flex' title='Create new space' onClick={handleCreateSpace}>
-            <span className='sr-only'>Create new space</span>
-            <PlusCircle className={getSize(6)} />
-          </Button>
-        </div>
+      {/* Match Frame selector. */}
+      <div className='flex p-1 pl-4 h-[36px] pt-2 bg-orange-500'>
+        <div>Spaces</div>
       </div>
+      <div className='flex flex-col flex-1 border-r border-slate-200'>
+        {/* Spaces */}
+        <div className='flex shrink-0 flex-col overflow-y-auto'>
+          <SpaceList />
 
-      <div className='flex flex-1'></div>
-
-      {/* Members */}
-      <div className='flex flex-col shrink-0 mt-6'>
-        <div className='flex p-1 pl-3 mb-2 text-xs'>Members</div>
-        <div className='flex shrink-0 pl-3'>
-          <MemberList spaceKey={space.key} />
+          <div className='p-3'>
+            <Button className='flex' title='Create new space' onClick={handleCreateSpace}>
+              <span className='sr-only'>Create new space</span>
+              <PlusCircle className={getSize(6)} />
+            </Button>
+          </div>
         </div>
-      </div>
 
-      <Actions />
+        <div className='flex flex-1'></div>
+
+        {/* Members */}
+        <div className='flex flex-col shrink-0 mt-6'>
+          <div className='flex p-1 pl-3 mb-2 text-xs'>Members</div>
+          <div className='flex shrink-0 pl-3'>
+            <MemberList spaceKey={space.key} />
+          </div>
+        </div>
+
+        <Actions />
+      </div>
     </div>
   );
 };

--- a/packages/experimental/kai/src/bots/research-bot.test.ts
+++ b/packages/experimental/kai/src/bots/research-bot.test.ts
@@ -18,6 +18,7 @@ const API_KEY = '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';
 // TODO(burdon): Navigation: Calendar event => Person => Create Org (Blue Yard) => Magic.
 
 describe('openai', () => {
+  // eslint-disable-next-line mocha/no-skipped-tests
   test.skip('basic', async () => {
     // https://beta.openai.com/docs/api-reference/authentication
     const configuration = new Configuration({

--- a/packages/experimental/kai/src/components/Table.tsx
+++ b/packages/experimental/kai/src/components/Table.tsx
@@ -61,12 +61,12 @@ export const Table: FC<{ columns: Column<EchoObject>[]; data: EchoObject[] }> = 
               {...headerGroup.getHeaderGroupProps({
                 // style: { paddingRight: '15px' },
               })}
-              className='tr bg-gray-200 sticky'
+              className='tr bg-gray-200'
             >
               {/* TODO(burdon): see UseResizeColumnsColumnProps */}
               {headerGroup.headers.map((column: any) => (
                 // eslint-disable-next-line react/jsx-key
-                <div {...column.getHeaderProps(headerProps)} className='th px-4 py-1 sticky'>
+                <div {...column.getHeaderProps(headerProps)} className='th px-4 py-1'>
                   {column.render('Header')}
 
                   {/* Use column.getResizerProps to hook up the events correctly. */}

--- a/packages/experimental/kai/src/components/Table.tsx
+++ b/packages/experimental/kai/src/components/Table.tsx
@@ -51,8 +51,8 @@ export const Table: FC<{ columns: Column<EchoObject>[]; data: EchoObject[] }> = 
 
   return (
     // TODO(burdon): Remove table class to force scrolling.
-    <div className='flex overflow-x-scroll'>
-      <div {...getTableProps()} className='table'>
+    <div className='flex flex-auto overflow-x-auto'>
+      <div {...getTableProps()} className='table flex-auto'>
         {/* Header */}
         <div>
           {headerGroups.map((headerGroup) => (
@@ -61,12 +61,12 @@ export const Table: FC<{ columns: Column<EchoObject>[]; data: EchoObject[] }> = 
               {...headerGroup.getHeaderGroupProps({
                 // style: { paddingRight: '15px' },
               })}
-              className='tr bg-gray-200'
+              className='tr bg-gray-200 sticky'
             >
               {/* TODO(burdon): see UseResizeColumnsColumnProps */}
               {headerGroup.headers.map((column: any) => (
                 // eslint-disable-next-line react/jsx-key
-                <div {...column.getHeaderProps(headerProps)} className='th px-4 py-1'>
+                <div {...column.getHeaderProps(headerProps)} className='th px-4 py-1 sticky'>
                   {column.render('Header')}
 
                   {/* Use column.getResizerProps to hook up the events correctly. */}
@@ -80,16 +80,19 @@ export const Table: FC<{ columns: Column<EchoObject>[]; data: EchoObject[] }> = 
         </div>
 
         {/* Body */}
-        <div className='tbody overflow-y-scroll mt-2'>
+        <div className='tbody overflow-y-auto mt-2'>
           {rows.map((row, i) => {
             prepareRow(row);
             return (
               // eslint-disable-next-line react/jsx-key
-              <div className='tr' {...row.getRowProps()}>
+              <div
+                className='tr border-b border-solid border-slate-100 transition-colors duration-300 hover:duration-500 hover:delay-300 hover:border-orange-200'
+                {...row.getRowProps()}
+              >
                 {row.cells.map((cell) => {
                   return (
                     // eslint-disable-next-line react/jsx-key
-                    <div {...cell.getCellProps(cellProps)} className='td px-4'>
+                    <div {...cell.getCellProps(cellProps)} className='td py-2 px-4'>
                       <div className='overflow-hidden text-ellipsis whitespace-nowrap'>{cell.render('Cell')}</div>
                     </div>
                   );

--- a/packages/experimental/kai/src/containers/TaskList.tsx
+++ b/packages/experimental/kai/src/containers/TaskList.tsx
@@ -90,7 +90,7 @@ export const TaskList: FC<{ completed?: boolean; readonly?: boolean }> = ({
 
   return (
     <div className='flex flex-1 justify-center bg-gray-100'>
-      <div className={'flex flex-col overflow-y-scroll pl-3 pr-3 pt-2 pb-8 bg-white w-screen is-full md:is-[400px]'}>
+      <div className={'flex flex-col overflow-y-auto pl-3 pr-3 pt-2 pb-8 bg-white w-screen is-full md:is-[400px]'}>
         <div className={'mt-2'}>
           {tasks?.map((task, index) => (
             <TaskItem

--- a/packages/experimental/kai/src/containers/frames/TableFrame.tsx
+++ b/packages/experimental/kai/src/containers/frames/TableFrame.tsx
@@ -82,7 +82,7 @@ export const TableFrame = () => {
 
   return (
     <div className='flex flex-col flex-1 overflow-hidden'>
-      <div className='flex p-3'>
+      <div className='flex p-3 border-b border-slate-200 border-solid'>
         <div className='flex'>
           <div className='mr-2'>
             <Selector options={types} value={type.id} onSelect={handleSelect} />
@@ -92,10 +92,9 @@ export const TableFrame = () => {
           </div>
         </div>
       </div>
-
-      <div className='flex flex-1 overflow-hidden'>
-        <Table columns={type.columns} data={objects} />{' '}
-      </div>
+      {/* <div className='flex flex-1 overflow-hidden'> */}
+      <Table columns={type.columns} data={objects} />
+      {/* </div> */}
     </div>
   );
 };

--- a/packages/experimental/kai/style.css
+++ b/packages/experimental/kai/style.css
@@ -21,6 +21,10 @@
   width: 100%;
   height: 62px;
   background-image: linear-gradient(to bottom, rgba(255,255,255,0), white);
+  /* pointer-events: none; */
+}
+.fade:after:hover {
+  opacity: 0;
 }
 
 /*

--- a/packages/experimental/kai/style.css
+++ b/packages/experimental/kai/style.css
@@ -21,10 +21,7 @@
   width: 100%;
   height: 62px;
   background-image: linear-gradient(to bottom, rgba(255,255,255,0), white);
-  /* pointer-events: none; */
-}
-.fade:after:hover {
-  opacity: 0;
+  pointer-events: none;
 }
 
 /*

--- a/packages/experimental/kai/tailwind.js
+++ b/packages/experimental/kai/tailwind.js
@@ -1,0 +1,5 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+// empty file for tooling detection in vscode


### PR DESCRIPTION
- [x] sidebar border
- [x] table row height, row borders, cell padding, full width
- [x] table frame search bar bottom border
- [x] no pointer events on the fade `:after` element in cards to allow clicking through it
- [x] do not initialize another identity in demo mode if one exists