### PR TITLE
Update quick-start.md

### DIFF
--- a/docs/docs/guide/quick-start.md
+++ b/docs/docs/guide/quick-start.md
@@ -33,6 +33,7 @@ Now you can use the `dx` command line tool:
 ```bash
 dx app create hello # or with --template=bare
 cd hello
+pnpm install
 pnpm serve
 ```
 


### PR DESCRIPTION
```pnpm i``` fails:

```
│ /bin/sh: node-pre-gyp: command not found
```

```
▶ pnpm --version
7.9.0
```