### PR TITLE
build: code split esm out for packages

### DIFF
--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -185,19 +185,30 @@ To make all eslint errors look yellow in `vscode`, open your user preferences (n
   "eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }]
 ```
 
-### Storybook
+### Vite Optimize Dependencies
 
-```
-Cannot GET /` when running 'pnpm run storybook'
-```
+The repo is currently in the process of transitioning to ESM but still contains some packages which do not output ESM.
+This causes issues for Vite because it expects all source code to be ESM and treats all code within the repo as source code because it resolves outside of a `node_modules` directory.
+In order to address this, [vite needs to be configured](https://vitejs.dev/guide/dep-pre-bundling.html#monorepos-and-linked-dependencies) to explicitly optimize these dependencies.
+Optimizing dependencies which are not available in a package generates warnings so instead of a single common list the following list is provided as a guideline of packages which are known to be needed in this list:
 
-Solution:
-
-```bash
-pnpm run storybook --no-manager-cache
-```
-
-[Source](https://github.com/storybookjs/storybook/issues/14672#issuecomment-824627909)
+- `@dxos/config`
+- `@dxos/keys`
+- `@dxos/mosaic`
+- `@dxos/plexus`
+- `@dxos/protocols`
+- `@dxos/protocols/proto/dxos/client`
+- `@dxos/protocols/proto/dxos/client/services`
+- `@dxos/protocols/proto/dxos/config`
+- `@dxos/protocols/proto/dxos/echo/feed`
+- `@dxos/protocols/proto/dxos/echo/model/document`
+- `@dxos/protocols/proto/dxos/echo/object`
+- `@dxos/protocols/proto/dxos/halo/credentials`
+- `@dxos/protocols/proto/dxos/halo/invitations`
+- `@dxos/protocols/proto/dxos/halo/keys`
+- `@dxos/protocols/proto/dxos/iframe`
+- `@dxos/protocols/proto/dxos/mesh/bridge`
+- `@dxos/protocols/proto/dxos/rpc`
 
 ### Mobile development
 

--- a/docs/vuepress.config.ts
+++ b/docs/vuepress.config.ts
@@ -16,7 +16,6 @@ import { apiSidebar, telemetryPlugin } from './src';
 const env = (value?: string) => (value ? `'${value}'` : undefined);
 
 const OPTIMIZE_DEPS = [
-  '@dxos/client/testing',
   '@dxos/config',
   '@dxos/keys',
   '@dxos/log',

--- a/packages/apps/braneframe/.storybook/main.cjs
+++ b/packages/apps/braneframe/.storybook/main.cjs
@@ -22,10 +22,7 @@ module.exports = {
     mergeConfig(config, {
       optimizeDeps: {
         force: true,
-        include: [
-          ...viteConfig.optimizeDeps.include,
-          'storybook-dark-mode'
-        ]
+        include: viteConfig.optimizeDeps.include
       },
       plugins: [
         viteConfig.plugins.find(plugin => plugin.name === 'dxos-config'),

--- a/packages/apps/patterns/react-appkit/.storybook/main.cjs
+++ b/packages/apps/patterns/react-appkit/.storybook/main.cjs
@@ -21,10 +21,8 @@ module.exports = {
       optimizeDeps: {
         force: true,
         include: [
-          '@dxos/client/testing',
           '@dxos/config',
           '@dxos/keys',
-          '@dxos/log',
           '@dxos/protocols',
           '@dxos/protocols/proto/dxos/client',
           '@dxos/protocols/proto/dxos/client/services',
@@ -35,23 +33,17 @@ module.exports = {
           '@dxos/protocols/proto/dxos/halo/credentials',
           '@dxos/protocols/proto/dxos/halo/invitations',
           '@dxos/protocols/proto/dxos/halo/keys',
+          '@dxos/protocols/proto/dxos/iframe',
           '@dxos/protocols/proto/dxos/mesh/bridge',
-          '@dxos/protocols/proto/dxos/rpc',
-          '@dxos/react-client/testing',
-          'storybook-dark-mode'
+          '@dxos/protocols/proto/dxos/rpc'
         ]
-      },
-      build: {
-        commonjsOptions: {
-          include: [/packages/, /node_modules/]
-        }
       },
       plugins: [
         ConfigPlugin(),
         ThemePlugin({
           content: [
             resolve(__dirname, '../src/**/*.{js,ts,jsx,tsx}'),
-            resolve(__dirname, '../node_modules/@dxos/react-components/dist/**/*.js')
+            resolve(__dirname, '../node_modules/@dxos/react-components/dist/**/*.mjs')
           ]
         })
       ]

--- a/packages/apps/patterns/react-composer/.storybook/main.cjs
+++ b/packages/apps/patterns/react-composer/.storybook/main.cjs
@@ -22,7 +22,6 @@ module.exports = {
         force: true,
         include: [
           '@dxos/client',
-          '@dxos/client/testing',
           '@dxos/config',
           '@dxos/debug',
           '@dxos/react-async',

--- a/packages/apps/patterns/react-ui/.storybook/main.cjs
+++ b/packages/apps/patterns/react-ui/.storybook/main.cjs
@@ -23,22 +23,22 @@ module.exports = {
     optimizeDeps: {
       force: true,
       include: [
-        '@dxos/client',
-        '@dxos/client/testing',
         '@dxos/config',
-        '@dxos/react-client',
-        '@dxos/react-components',
-        '@dxos/util',
-        'storybook-dark-mode'
+        '@dxos/keys',
+        '@dxos/protocols',
+        '@dxos/protocols/proto/dxos/client',
+        '@dxos/protocols/proto/dxos/client/services',
+        '@dxos/protocols/proto/dxos/config',
+        '@dxos/protocols/proto/dxos/echo/feed',
+        '@dxos/protocols/proto/dxos/echo/model/document',
+        '@dxos/protocols/proto/dxos/echo/object',
+        '@dxos/protocols/proto/dxos/halo/credentials',
+        '@dxos/protocols/proto/dxos/halo/invitations',
+        '@dxos/protocols/proto/dxos/halo/keys',
+        '@dxos/protocols/proto/dxos/iframe',
+        '@dxos/protocols/proto/dxos/mesh/bridge',
+        '@dxos/protocols/proto/dxos/rpc'
       ]
-    },
-    build: {
-      commonjsOptions: {
-        include: [
-          /packages/,
-          /node_modules/
-        ]
-      }
     },
     plugins: [ConfigPlugin(), ThemePlugin({
       content: [resolve(__dirname, '../src') + '/**/*.{ts,tsx,js,jsx}']

--- a/packages/apps/patterns/react-ui/package.json
+++ b/packages/apps/patterns/react-ui/package.json
@@ -18,6 +18,7 @@
     "@dxos/config": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/keys": "workspace:*",
+    "@dxos/log": "workspace:*",
     "@dxos/react-client": "workspace:*",
     "@dxos/react-components": "workspace:*",
     "@dxos/util": "workspace:*",
@@ -32,7 +33,7 @@
   },
   "devDependencies": {
     "@dxos/async": "workspace:*",
-    "@dxos/log": "workspace:*",
+    "@dxos/protocols": "workspace:*",
     "@dxos/react-async": "workspace:*",
     "@types/debug": "^4.1.7",
     "@types/react": "^18.0.21",

--- a/packages/apps/patterns/react-ui/tsconfig.json
+++ b/packages/apps/patterns/react-ui/tsconfig.json
@@ -42,6 +42,9 @@
       "path": "../../../common/util"
     },
     {
+      "path": "../../../core/protocols"
+    },
+    {
       "path": "../../../sdk/client"
     },
     {

--- a/packages/core/echo/echo-db/package.json
+++ b/packages/core/echo/echo-db/package.json
@@ -9,7 +9,7 @@
   "main": "dist/lib/node/index.cjs",
   "browser": {
     "./dist/lib/node/index.cjs": "./dist/lib/browser/index.mjs",
-    "./dist/lib/node/packlets/testing/index.cjs": "./dist/lib/browser/packlets/testing/index.mjs"
+    "./testing.js": "./dist/lib/browser/packlets/testing/index.mjs"
   },
   "types": "dist/types/src/index.d.ts",
   "files": [

--- a/packages/devtools/devtools/vite.config.ts
+++ b/packages/devtools/devtools/vite.config.ts
@@ -24,7 +24,6 @@ export default defineConfig({
     force: true,
     include: [
       '@dxos/config',
-      '@dxos/gem-spore/testing',
       '@dxos/keys',
       '@dxos/log',
       '@dxos/mosaic',

--- a/packages/experimental/gem-spore/package.json
+++ b/packages/experimental/gem-spore/package.json
@@ -11,7 +11,7 @@
   "main": "dist/lib/node/index.cjs",
   "browser": {
     "./dist/lib/node/index.cjs": "./dist/lib/browser/index.mjs",
-    "./dist/lib/node/testing/index.cjs": "./dist/lib/browser/testing/index.mjs"
+    "./testing.js": "./dist/lib/browser/testing/index.mjs"
   },
   "types": "dist/types/src/index.d.ts",
   "files": [

--- a/packages/experimental/gem-spore/src/graph/projector.ts
+++ b/packages/experimental/gem-spore/src/graph/projector.ts
@@ -4,7 +4,7 @@
 
 import { EventEmitter, SVGContext } from '@dxos/gem-core';
 
-import { defaultIdAccessor, IdAccessor } from '../graph';
+import { defaultIdAccessor, IdAccessor } from './types';
 
 export type ProjectorOptions = {
   idAccessor: IdAccessor;

--- a/packages/experimental/kai/.storybook/main.cjs
+++ b/packages/experimental/kai/.storybook/main.cjs
@@ -6,6 +6,7 @@ const { mergeConfig } = require('vite');
 const { resolve } = require('path');
 
 const { ThemePlugin } = require('@dxos/react-components/plugin');
+const { default: viteConfig } = require('../vite.config');
 
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -23,27 +24,7 @@ module.exports = {
     mergeConfig(config, {
       optimizeDeps: {
         force: true,
-        include: [
-          '@dxos/gem-spore/testing',
-          '@dxos/protocols',
-          '@dxos/protocols/proto/dxos/client',
-          '@dxos/protocols/proto/dxos/client/services',
-          '@dxos/protocols/proto/dxos/config',
-          '@dxos/protocols/proto/dxos/echo/feed',
-          '@dxos/protocols/proto/dxos/echo/model/document',
-          '@dxos/protocols/proto/dxos/echo/object',
-          '@dxos/protocols/proto/dxos/halo/credentials',
-          '@dxos/protocols/proto/dxos/halo/invitations',
-          '@dxos/protocols/proto/dxos/halo/keys',
-          '@dxos/protocols/proto/dxos/mesh/bridge',
-          '@dxos/protocols/proto/dxos/rpc',
-          'storybook-dark-mode'
-        ]
-      },
-      build: {
-        commonjsOptions: {
-          include: [/packages/, /node_modules/]
-        }
+        include: viteConfig.optimizeDeps.include
       },
       plugins: [
         ThemePlugin({

--- a/packages/experimental/kai/vite.config.ts
+++ b/packages/experimental/kai/vite.config.ts
@@ -43,11 +43,10 @@ export default defineConfig({
     force: true,
     include: [
       '@dxos/config',
-      '@dxos/gem-spore/testing',
+      '@dxos/keys',
       '@dxos/mosaic',
       '@dxos/plexus',
       '@dxos/protocols',
-      '@dxos/keys',
       '@dxos/protocols/proto/dxos/client',
       '@dxos/protocols/proto/dxos/client/services',
       '@dxos/protocols/proto/dxos/config',
@@ -57,6 +56,7 @@ export default defineConfig({
       '@dxos/protocols/proto/dxos/halo/credentials',
       '@dxos/protocols/proto/dxos/halo/invitations',
       '@dxos/protocols/proto/dxos/halo/keys',
+      '@dxos/protocols/proto/dxos/iframe',
       '@dxos/protocols/proto/dxos/mesh/bridge',
       '@dxos/protocols/proto/dxos/rpc'
     ]

--- a/packages/experimental/plexus/.storybook/main.cjs
+++ b/packages/experimental/plexus/.storybook/main.cjs
@@ -23,27 +23,7 @@ module.exports = {
     mergeConfig(config, {
       optimizeDeps: {
         force: true,
-        include: [
-          '@dxos/gem-spore/testing',
-          '@dxos/protocols',
-          '@dxos/protocols/proto/dxos/client',
-          '@dxos/protocols/proto/dxos/client/services',
-          '@dxos/protocols/proto/dxos/config',
-          '@dxos/protocols/proto/dxos/echo/feed',
-          '@dxos/protocols/proto/dxos/echo/model/document',
-          '@dxos/protocols/proto/dxos/echo/object',
-          '@dxos/protocols/proto/dxos/halo/credentials',
-          '@dxos/protocols/proto/dxos/halo/invitations',
-          '@dxos/protocols/proto/dxos/halo/keys',
-          '@dxos/protocols/proto/dxos/mesh/bridge',
-          '@dxos/protocols/proto/dxos/rpc',
-          'storybook-dark-mode'
-        ]
-      },
-      build: {
-        commonjsOptions: {
-          include: [/packages/, /node_modules/]
-        }
+        include: []
       },
       plugins: [
         ThemePlugin({

--- a/packages/sdk/client-services/package.json
+++ b/packages/sdk/client-services/package.json
@@ -10,7 +10,7 @@
   "browser": {
     "jsondown": false,
     "./dist/lib/node/index.cjs": "./dist/lib/browser/index.mjs",
-    "./dist/lib/node/packlets/testing/index.cjs": "./dist/lib/browser/packlets/testing/index.mjs"
+    "./testing.cjs": "./dist/lib/browser/packlets/testing/index.mjs"
   },
   "types": "dist/types/src/index.d.ts",
   "files": [

--- a/packages/sdk/client-services/package.json
+++ b/packages/sdk/client-services/package.json
@@ -10,7 +10,7 @@
   "browser": {
     "jsondown": false,
     "./dist/lib/node/index.cjs": "./dist/lib/browser/index.mjs",
-    "./testing.cjs": "./dist/lib/browser/packlets/testing/index.mjs"
+    "./testing.js": "./dist/lib/browser/packlets/testing/index.mjs"
   },
   "types": "dist/types/src/index.d.ts",
   "files": [

--- a/packages/sdk/client/package.json
+++ b/packages/sdk/client/package.json
@@ -10,7 +10,7 @@
   "main": "dist/lib/node/index.cjs",
   "browser": {
     "./dist/lib/node/index.cjs": "./dist/lib/browser/index.mjs",
-    "./dist/lib/node/packlets/testing/index.cjs": "./dist/lib/browser/packlets/testing/index.mjs"
+    "./testing.js": "./dist/lib/browser/packlets/testing/index.mjs"
   },
   "types": "dist/types/src/index.d.ts",
   "files": [

--- a/packages/sdk/react-client/.storybook/main.cjs
+++ b/packages/sdk/react-client/.storybook/main.cjs
@@ -19,7 +19,11 @@ module.exports = {
   viteFinal: async (config) =>
     mergeConfig(config, {
       optimizeDeps: {
-        force: true,
+        // TODO(wittjosiah): Including force makes startup take longer.
+        //   Without force occasionally optimized deps are out of date.
+        //   However the remaining deps here rarely change much.
+        //   Excluding force seems to help playwright tests pass so it should be left commented out for now.
+        // force: true,
         include: [
           '@dxos/config',
           '@dxos/keys',

--- a/packages/sdk/react-client/.storybook/main.cjs
+++ b/packages/sdk/react-client/.storybook/main.cjs
@@ -21,28 +21,22 @@ module.exports = {
       optimizeDeps: {
         force: true,
         include: [
-          '@dxos/async',
-          '@dxos/client',
-          '@dxos/client/testing',
-          '@dxos/codec-protobuf',
           '@dxos/config',
-          '@dxos/debug',
           '@dxos/keys',
-          '@dxos/log',
-          '@dxos/messaging',
           '@dxos/protocols',
-          '@dxos/react-async',
-          '@dxos/react-components',
-          '@dxos/rpc',
-          '@dxos/rpc-tunnel',
-          '@dxos/util',
-          'storybook-dark-mode'
+          '@dxos/protocols/proto/dxos/client',
+          '@dxos/protocols/proto/dxos/client/services',
+          '@dxos/protocols/proto/dxos/config',
+          '@dxos/protocols/proto/dxos/echo/feed',
+          '@dxos/protocols/proto/dxos/echo/model/document',
+          '@dxos/protocols/proto/dxos/echo/object',
+          '@dxos/protocols/proto/dxos/halo/credentials',
+          '@dxos/protocols/proto/dxos/halo/invitations',
+          '@dxos/protocols/proto/dxos/halo/keys',
+          '@dxos/protocols/proto/dxos/iframe',
+          '@dxos/protocols/proto/dxos/mesh/bridge',
+          '@dxos/protocols/proto/dxos/rpc'
         ]
-      },
-      build: {
-        commonjsOptions: {
-          include: [/packages/, /node_modules/]
-        }
       },
       plugins: [
         ConfigPlugin(),

--- a/packages/sdk/react-client/package.json
+++ b/packages/sdk/react-client/package.json
@@ -9,7 +9,7 @@
   "main": "dist/lib/node/index.cjs",
   "browser": {
     "./dist/lib/node/index.cjs": "./dist/lib/browser/index.mjs",
-    "./dist/lib/node/testing/index.cjs": "./dist/lib/browser/testing/index.mjs"
+    "./testing.js": "./dist/lib/browser/testing/index.mjs"
   },
   "types": "dist/types/src/index.d.ts",
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
       '@types/react': 18.0.21
       '@types/sharedworker': 0.0.80
       '@types/uuid': 8.3.4
-      '@typescript-eslint/eslint-plugin': 5.45.0_usuh4uodfyzfr5qbbynfqnfnsy
-      '@typescript-eslint/parser': 5.45.0_typescript@4.8.4
+      '@typescript-eslint/eslint-plugin': 5.45.0_pi7zx7ojc4phxkdwiczrakx6sq
+      '@typescript-eslint/parser': 5.45.0_z4bbprzjrhnsfa24uvmcbu7f5q
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
       chalk: 4.1.2
@@ -382,10 +382,10 @@ importers:
       postcss: 8.4.21
       require-from-string: 2.0.2
       storybook-dark-mode: 1.1.2_biqbaboplfbrettd7655fr4n2y
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.21
       typescript: 4.8.4
       vite: 4.0.4_udc44hkgfm6fy435xbwnwc7wvu_@types+node@18.11.9
-      vite-plugin-pwa: 0.14.1_vite@4.0.4
+      vite-plugin-pwa: 0.14.1_aln3rhi4rqbizqxdkcc2hwlswu
       webpack: 5.75.0
       workbox-window: 6.5.4
 
@@ -431,7 +431,7 @@ importers:
       '@types/react-dom': 18.0.6
       '@vitejs/plugin-react': 3.0.1_vite@4.0.4
       vite: 4.0.4_udc44hkgfm6fy435xbwnwc7wvu
-      vite-plugin-pwa: 0.14.1_vite@4.0.4
+      vite-plugin-pwa: 0.14.1_aln3rhi4rqbizqxdkcc2hwlswu
       workbox-window: 6.5.4
 
   packages/apps/halo-app:
@@ -510,7 +510,7 @@ importers:
       '@vitejs/plugin-react': 3.0.1_vite@4.0.4
       typescript: 4.8.4
       vite: 4.0.4_udc44hkgfm6fy435xbwnwc7wvu_@types+node@18.11.9
-      vite-plugin-pwa: 0.14.1_vite@4.0.4
+      vite-plugin-pwa: 0.14.1_aln3rhi4rqbizqxdkcc2hwlswu
       workbox-window: 6.5.4
 
   packages/apps/patterns/assets:
@@ -628,6 +628,7 @@ importers:
       '@dxos/debug': workspace:*
       '@dxos/keys': workspace:*
       '@dxos/log': workspace:*
+      '@dxos/protocols': workspace:*
       '@dxos/react-async': workspace:*
       '@dxos/react-client': workspace:*
       '@dxos/react-components': workspace:*
@@ -654,6 +655,7 @@ importers:
       '@dxos/config': link:../../../sdk/config
       '@dxos/debug': link:../../../common/debug
       '@dxos/keys': link:../../../common/keys
+      '@dxos/log': link:../../../common/log
       '@dxos/react-client': link:../../../sdk/react-client
       '@dxos/react-components': link:../../../common/react-components
       '@dxos/util': link:../../../common/util
@@ -667,7 +669,7 @@ importers:
       url-join: 5.0.0
     devDependencies:
       '@dxos/async': link:../../../common/async
-      '@dxos/log': link:../../../common/log
+      '@dxos/protocols': link:../../../core/protocols
       '@dxos/react-async': link:../../../common/react-async
       '@types/debug': 4.1.7
       '@types/react': 18.0.21
@@ -741,10 +743,10 @@ importers:
       postcss: 8.4.21
       require-from-string: 2.0.2
       storybook-dark-mode: 1.1.2_biqbaboplfbrettd7655fr4n2y
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.21
       typescript: 4.8.4
       vite: 4.0.4_udc44hkgfm6fy435xbwnwc7wvu_@types+node@18.11.9
-      vite-plugin-pwa: 0.14.1_vite@4.0.4
+      vite-plugin-pwa: 0.14.1_aln3rhi4rqbizqxdkcc2hwlswu
       webpack: 5.75.0
       workbox-window: 6.5.4
 
@@ -792,7 +794,7 @@ importers:
       '@types/react-dom': 18.0.6
       '@vitejs/plugin-react': 3.0.1_vite@4.0.4
       vite: 4.0.4_udc44hkgfm6fy435xbwnwc7wvu
-      vite-plugin-pwa: 0.14.1_vite@4.0.4
+      vite-plugin-pwa: 0.14.1_aln3rhi4rqbizqxdkcc2hwlswu
       workbox-window: 6.5.4
 
   packages/apps/tasks-app-2:
@@ -859,7 +861,7 @@ importers:
       postcss: 8.4.21
       require-from-string: 2.0.2
       storybook-dark-mode: 1.1.2_biqbaboplfbrettd7655fr4n2y
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.21
       typescript: 4.8.4
       vite: 4.0.4_udc44hkgfm6fy435xbwnwc7wvu_@types+node@18.11.9
       webpack: 5.75.0
@@ -896,7 +898,7 @@ importers:
       '@dxos/bare-template': link:../bare-template
       '@dxos/plate': link:../../../common/plate
       postcss: 8.4.21
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.21
     devDependencies:
       typescript: 4.8.4
 
@@ -1428,7 +1430,7 @@ importers:
       react-i18next: 11.18.6_vfm63zmruocgezzfl2v26zlzpy
       react-table: 7.8.0_react@18.2.0
       tailwind-merge: 1.8.0
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.18
       tailwindcss-logical: 3.0.0_xkowlklhtk6sfvtndbucb3hfiy
       tailwindcss-radix: 2.6.0
     devDependencies:
@@ -2530,11 +2532,11 @@ importers:
       '@types/react-vis': 1.11.11
       '@vitejs/plugin-react': 3.0.1_vite@4.0.4
       postcss: 8.4.21
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.21
       typescript: 4.8.4
       vite: 4.0.4_udc44hkgfm6fy435xbwnwc7wvu
       vite-plugin-fonts: 0.7.0_vite@4.0.4
-      vite-plugin-pwa: 0.14.1_vite@4.0.4
+      vite-plugin-pwa: 0.14.1_aln3rhi4rqbizqxdkcc2hwlswu
       workbox-window: 6.5.4
 
   packages/devtools/devtools-extension:
@@ -2648,7 +2650,7 @@ importers:
       postcss: 8.4.21
       rmdir: 1.2.0
       safe-compare: 1.1.4
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.21
       vite: 4.0.4_udc44hkgfm6fy435xbwnwc7wvu
       vite-plugin-fonts: 0.7.0_vite@4.0.4
 
@@ -3100,12 +3102,12 @@ importers:
       faker: 5.5.3
       monaco-editor: 0.25.2
       postcss: 8.4.18
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.18
       typescript: 4.8.4
       vite: 4.0.4_udc44hkgfm6fy435xbwnwc7wvu
       vite-plugin-fonts: 0.7.0_vite@4.0.4
       vite-plugin-inspect: 0.7.15_vite@4.0.4
-      vite-plugin-pwa: 0.14.1_vite@4.0.4
+      vite-plugin-pwa: 0.14.1_aln3rhi4rqbizqxdkcc2hwlswu
       workbox-window: 6.5.4
 
   packages/experimental/metagraph:
@@ -3181,12 +3183,12 @@ importers:
       '@vitejs/plugin-react': 3.0.1_vite@4.0.4
       faker: 5.5.3
       postcss: 8.4.21
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.21
       typescript: 4.8.4
       vite: 4.0.4_udc44hkgfm6fy435xbwnwc7wvu
       vite-plugin-fonts: 0.7.0_vite@4.0.4
       vite-plugin-inspect: 0.7.15_vite@4.0.4
-      vite-plugin-pwa: 0.14.1_vite@4.0.4
+      vite-plugin-pwa: 0.14.1_aln3rhi4rqbizqxdkcc2hwlswu
       workbox-window: 6.5.4
 
   packages/experimental/plexus:
@@ -3252,12 +3254,12 @@ importers:
       faker: 5.5.3
       postcss: 8.4.21
       string-hash: 1.1.3
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.21
       typescript: 4.8.4
       vite: 4.0.4_udc44hkgfm6fy435xbwnwc7wvu
       vite-plugin-fonts: 0.7.0_vite@4.0.4
       vite-plugin-inspect: 0.7.15_vite@4.0.4
-      vite-plugin-pwa: 0.14.1_vite@4.0.4
+      vite-plugin-pwa: 0.14.1_aln3rhi4rqbizqxdkcc2hwlswu
       workbox-window: 6.5.4
 
   packages/experimental/react-metagraph:
@@ -3818,8 +3820,8 @@ importers:
       '@dxos/eslint-plugin-rules': link:../eslint-rules
       '@rushstack/eslint-plugin-packlets': 0.4.1_z4bbprzjrhnsfa24uvmcbu7f5q
       '@stayradiated/eslint-plugin-prefer-arrow-functions': 4.4.0_eslint@8.25.0
-      '@typescript-eslint/eslint-plugin': 5.45.0_usuh4uodfyzfr5qbbynfqnfnsy
-      '@typescript-eslint/parser': 5.45.0_typescript@4.8.4
+      '@typescript-eslint/eslint-plugin': 5.45.0_pi7zx7ojc4phxkdwiczrakx6sq
+      '@typescript-eslint/parser': 5.45.0_z4bbprzjrhnsfa24uvmcbu7f5q
       eslint-config-semistandard: 16.0.0_u7hi4tob5jexe3bxs45csc22mq
       eslint-config-standard: 17.0.0_qjhcey4ofknbrbveepk4bditci
       eslint-plugin-import: 2.26.0_3rwetfi6epq3x3lrbut2iai3km
@@ -4030,7 +4032,7 @@ importers:
       remark-parse-frontmatter: 1.0.3
       remark-unwrap-texts: 1.0.3
       rollup: 3.9.1
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.18
       tailwindcss-logical: 3.0.0_xkowlklhtk6sfvtndbucb3hfiy
       tailwindcss-radix: 2.6.0
       typescript: 4.8.4
@@ -8325,7 +8327,7 @@ packages:
         optional: true
     dependencies:
       '@nrwl/devkit': 15.4.5_nx@15.4.5+typescript@4.8.4
-      '@typescript-eslint/parser': 5.45.0_typescript@4.8.4
+      '@typescript-eslint/parser': 5.45.0_z4bbprzjrhnsfa24uvmcbu7f5q
       '@typescript-eslint/utils': 5.45.0_z4bbprzjrhnsfa24uvmcbu7f5q
       chalk: 4.1.0
       confusing-browser-globals: 1.0.11
@@ -11953,7 +11955,7 @@ packages:
     peerDependencies:
       tailwindcss: '>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1'
     dependencies:
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.18
     dev: true
 
   /@tailwindcss/forms/0.5.3_tailwindcss@3.1.8:
@@ -11962,7 +11964,7 @@ packages:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.18
     dev: false
 
   /@tailwindcss/typography/0.5.8_tailwindcss@3.1.8:
@@ -11974,7 +11976,7 @@ packages:
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.18
     dev: true
 
   /@testing-library/dom/8.19.0:
@@ -13572,17 +13574,18 @@ packages:
     resolution: {integrity: sha512-RRHc1+8Hc5mf/2lZKnom6kCnqcNS07s8keahniWTOva0KELF6RgDJmaEcvGEKUUJgN4UgessmEsWuidaOycIOw==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.45.0_usuh4uodfyzfr5qbbynfqnfnsy:
+  /@typescript-eslint/eslint-plugin/5.45.0_pi7zx7ojc4phxkdwiczrakx6sq:
     resolution: {integrity: sha512-CXXHNlf0oL+Yg021cxgOdMHNTXD17rHkq7iW6RFHoybdFgQBjU3yIXhhcPpGwr1CjZlo6ET8C6tzX5juQoXeGA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.45.0_typescript@4.8.4
+      '@typescript-eslint/parser': 5.45.0_z4bbprzjrhnsfa24uvmcbu7f5q
       '@typescript-eslint/scope-manager': 5.45.0
       '@typescript-eslint/type-utils': 5.45.0_z4bbprzjrhnsfa24uvmcbu7f5q
       '@typescript-eslint/utils': 5.45.0_z4bbprzjrhnsfa24uvmcbu7f5q
@@ -13610,10 +13613,11 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/parser/5.45.0_typescript@4.8.4:
+  /@typescript-eslint/parser/5.45.0_z4bbprzjrhnsfa24uvmcbu7f5q:
     resolution: {integrity: sha512-brvs/WSM4fKUmF5Ot/gEve6qYiCMjm6w4HkHPfS6ZNmxTS0m0iNN4yOChImaCkqc1hRwFGqUyanMXuGal6oyyQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -13779,7 +13783,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.20.12
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.0.4_udc44hkgfm6fy435xbwnwc7wvu
+      vite: 4.0.4_udc44hkgfm6fy435xbwnwc7wvu_@types+node@18.11.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -19545,7 +19549,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.45.0_typescript@4.8.4
+      '@typescript-eslint/parser': 5.45.0_z4bbprzjrhnsfa24uvmcbu7f5q
       debug: 3.2.7
       eslint: 8.25.0
       eslint-import-resolver-node: 0.3.6
@@ -19585,7 +19589,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.45.0_typescript@4.8.4
+      '@typescript-eslint/parser': 5.45.0_z4bbprzjrhnsfa24uvmcbu7f5q
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
@@ -19707,7 +19711,7 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.45.0_usuh4uodfyzfr5qbbynfqnfnsy
+      '@typescript-eslint/eslint-plugin': 5.45.0_pi7zx7ojc4phxkdwiczrakx6sq
       eslint: 8.25.0
       eslint-rule-composer: 0.3.0
     dev: false
@@ -20703,6 +20707,18 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  /follow-redirects/1.15.2_debug@4.3.4:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+    dev: true
 
   /fontkit/2.0.2:
     resolution: {integrity: sha512-jc4k5Yr8iov8QfS6u8w2CnHWVmbOGtdBtOXMze5Y+QD966Rx6PEVWXSEGwXlsDlKtu1G12cJjcsybnqhSk/+LA==}
@@ -21926,7 +21942,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2_debug@4.3.4
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -27947,6 +27963,17 @@ packages:
       postcss: 8.4.21
     dev: true
 
+  /postcss-import/14.1.0_postcss@8.4.18:
+    resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss: 8.4.18
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.1
+
   /postcss-import/14.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
     engines: {node: '>=10.0.0'}
@@ -27964,6 +27991,15 @@ packages:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.21
+
+  /postcss-js/4.0.0_postcss@8.4.18:
+    resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.4.18
 
   /postcss-js/4.0.0_postcss@8.4.21:
     resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
@@ -32079,10 +32115,44 @@ packages:
     transitivePeerDependencies:
       - ts-node
 
-  /tailwindcss/3.1.8:
+  /tailwindcss/3.1.8_postcss@8.4.18:
     resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
+    dependencies:
+      arg: 5.0.2
+      chokidar: 3.5.3
+      color-name: 1.1.4
+      detective: 5.2.1
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.12
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      lilconfig: 2.0.6
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.18
+      postcss-import: 14.1.0_postcss@8.4.18
+      postcss-js: 4.0.0_postcss@8.4.18
+      postcss-load-config: 3.1.4_postcss@8.4.18
+      postcss-nested: 5.0.6_postcss@8.4.18
+      postcss-selector-parser: 6.0.10
+      postcss-value-parser: 4.2.0
+      quick-lru: 5.1.1
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - ts-node
+
+  /tailwindcss/3.1.8_postcss@8.4.21:
+    resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -33683,17 +33753,18 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-pwa/0.14.1_vite@4.0.4:
+  /vite-plugin-pwa/0.14.1_aln3rhi4rqbizqxdkcc2hwlswu:
     resolution: {integrity: sha512-5zx7yhQ8RTLwV71+GA9YsQQ63ALKG8XXIMqRJDdZkR8ZYftFcRgnzM7wOWmQZ/DATspyhPih5wCdcZnAIsM+mA==}
     peerDependencies:
       vite: ^3.1.0 || ^4.0.0
+      workbox-window: ^6.5.4
     dependencies:
       '@rollup/plugin-replace': 5.0.2_rollup@3.9.1
       debug: 4.3.4
       fast-glob: 3.2.12
       pretty-bytes: 6.0.0
       rollup: 3.9.1
-      vite: 4.0.4_udc44hkgfm6fy435xbwnwc7wvu
+      vite: 4.0.4_udc44hkgfm6fy435xbwnwc7wvu_@types+node@18.11.9
       workbox-build: 6.5.4
       workbox-window: 6.5.4
     transitivePeerDependencies:

--- a/tools/executors/esbuild/src/main.ts
+++ b/tools/executors/esbuild/src/main.ts
@@ -53,6 +53,7 @@ export default async (options: EsbuildExecutorOptions, context: ExecutorContext)
         outdir,
         outExtension: { '.js': extension },
         format,
+        splitting: format === 'esm',
         write: true,
         sourcemap: options.sourcemap,
         metafile: options.metafile,


### PR DESCRIPTION
- helps to resolve issue of duplicate copies of classes being included in storybooks caused by testing entrypoints bundling all source by turning on code splitting for esm versions
- removes the need to "optimize" testing entrypoints by adding a direct browser mapping to esm for them
- adds notes on why optimize deps is needed and which deps to optimize