### PR TITLE
fix: Remove `Collection` from List so it doesn’t log `SlotClone` errors

### DIFF
--- a/packages/common/react-components/src/components/List/List.tsx
+++ b/packages/common/react-components/src/components/List/List.tsx
@@ -208,7 +208,7 @@ const PureListItem = forwardRef<ListItemElement, ListItemProps & { id: string }>
           ref={forwardedRef}
           aria-labelledby={headingId}
           {...(selectable && { role: 'option', 'aria-selected': !!selected })}
-          className={mx('flex', draggable && 'touch-none',slots.root?.className)}
+          className={mx('flex', slots.root?.className)}
         >
           {draggable && <ListItemDragHandle {...slots.dragHandle} className={slots.dragHandle?.className} />}
           {selectable && (

--- a/packages/common/react-components/src/components/List/List.tsx
+++ b/packages/common/react-components/src/components/List/List.tsx
@@ -6,7 +6,6 @@ import { DndContext } from '@dnd-kit/core';
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
 import { SortableContext, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { createCollection } from '@radix-ui/react-collection';
 import { useComposedRefs } from '@radix-ui/react-compose-refs';
 import { createContextScope } from '@radix-ui/react-context';
 import { Primitive } from '@radix-ui/react-primitive';
@@ -82,17 +81,11 @@ interface ListItemProps extends Omit<ListItemData, 'id'> {
   id?: string;
 }
 
-// COLLECTION
-
 type ListItemElement = React.ElementRef<typeof Primitive.li>;
-
-const [Collection, useListCollection, createCollectionScope] = createCollection<ListItemElement, ListItemData>(
-  LIST_NAME
-);
 
 // LIST
 
-const [createListContext, createListScope] = createContextScope(LIST_NAME, [createCollectionScope]);
+const [createListContext, createListScope] = createContextScope(LIST_NAME, []);
 
 type ListContextValue = Pick<ListProps, 'selectable' | 'variant'>;
 
@@ -115,15 +108,13 @@ const List: FC<ListProps> = (props: ScopedProps<ListProps>) => {
           selectable
         }}
       >
-        <Collection.Provider scope={__scopeSelect}>
-          {variant === 'ordered-draggable' ? (
-            <DndContext onDragEnd={(props as DraggableListProps).onDragEnd} modifiers={[restrictToVerticalAxis]}>
-              <SortableContext items={(props as DraggableListProps).listItemIds}>{children}</SortableContext>
-            </DndContext>
-          ) : (
-            <>{children}</>
-          )}
-        </Collection.Provider>
+        {variant === 'ordered-draggable' ? (
+          <DndContext onDragEnd={(props as DraggableListProps).onDragEnd} modifiers={[restrictToVerticalAxis]}>
+            <SortableContext items={(props as DraggableListProps).listItemIds}>{children}</SortableContext>
+          </DndContext>
+        ) : (
+          <>{children}</>
+        )}
       </ListProvider>
     </ListRoot>
   );
@@ -206,30 +197,28 @@ const PureListItem = forwardRef<ListItemElement, ListItemProps & { id: string }>
     const headingId = useId('listItem__heading');
 
     return (
-      <Collection.ItemSlot id={id} scope={__scopeSelect} selected={selected}>
-        <ListItemProvider scope={__scopeSelect} headingId={headingId}>
-          <Primitive.li
-            {...slots.root}
-            id={id}
-            ref={forwardedRef}
-            aria-labelledby={headingId}
-            {...(selectable && { role: 'option', 'aria-selected': !!selected })}
-            className={mx('flex', draggable && 'touch-none', slots.root?.className)}
-          >
-            {draggable && <ListItemDragHandle {...slots.dragHandle} className={slots.dragHandle?.className} />}
-            {selectable && (
-              <ListItemEndcap>
-                <Checkbox
-                  labelId={headingId}
-                  className='mbs-2.5'
-                  {...{ checked: selected, onCheckedChange: setSelected }}
-                />
-              </ListItemEndcap>
-            )}
-            {children}
-          </Primitive.li>
-        </ListItemProvider>
-      </Collection.ItemSlot>
+      <ListItemProvider scope={__scopeSelect} headingId={headingId}>
+        <Primitive.li
+          {...slots.root}
+          id={id}
+          ref={forwardedRef}
+          aria-labelledby={headingId}
+          {...(selectable && { role: 'option', 'aria-selected': !!selected })}
+          className={mx('flex', draggable && 'touch-none', slots.root?.className)}
+        >
+          {draggable && <ListItemDragHandle {...slots.dragHandle} className={slots.dragHandle?.className} />}
+          {selectable && (
+            <ListItemEndcap>
+              <Checkbox
+                labelId={headingId}
+                className='mbs-2.5'
+                {...{ checked: selected, onCheckedChange: setSelected }}
+              />
+            </ListItemEndcap>
+          )}
+          {children}
+        </Primitive.li>
+      </ListItemProvider>
     );
   }
 );
@@ -242,20 +231,18 @@ const DraggableListItem = forwardRef<ListItemElement, ListItemProps & { id: stri
     const ref = useComposedRefs(forwardedRef, setNodeRef) as ComponentPropsWithRef<typeof Primitive.li>['ref'];
 
     return (
-      <Collection.Slot scope={props.__scopeSelect}>
-        <PureListItem
-          {...props}
-          ref={ref}
-          slots={{
-            ...props.slots,
-            root: {
-              ...props.slots?.root,
-              style: { transform: CSS.Transform.toString(transform), transition, ...props.slots?.root?.style }
-            },
-            dragHandle: { ...listeners, ...attributes, ...props.slots?.dragHandle }
-          }}
-        />
-      </Collection.Slot>
+      <PureListItem
+        {...props}
+        ref={ref}
+        slots={{
+          ...props.slots,
+          root: {
+            ...props.slots?.root,
+            style: { transform: CSS.Transform.toString(transform), transition, ...props.slots?.root?.style }
+          },
+          dragHandle: { ...listeners, ...attributes, ...props.slots?.dragHandle }
+        }}
+      />
     );
   }
 );
@@ -271,15 +258,6 @@ const ListItem = forwardRef<ListItemElement, ListItemProps>((props: ScopedProps<
   }
 });
 
-export {
-  List,
-  createListScope,
-  useListCollection,
-  ListItem,
-  ListItemHeading,
-  ListItemEndcap,
-  ListItemDragHandle,
-  createListItemScope
-};
+export { List, createListScope, ListItem, ListItemHeading, ListItemEndcap, ListItemDragHandle, createListItemScope };
 
 export type { ListProps, ListVariant, ListItemProps };

--- a/packages/common/react-components/src/components/List/List.tsx
+++ b/packages/common/react-components/src/components/List/List.tsx
@@ -168,7 +168,11 @@ const ListItemHeading = ({
 const ListItemDragHandle = ({ className, ...props }: Omit<ComponentPropsWithoutRef<'div'>, 'children'>) => {
   const { themeVariant } = useThemeContext();
   return (
-    <div role='button' {...props} className={mx('bs-10 is-5 rounded', themeVariantFocus(themeVariant), className)}>
+    <div
+      role='button'
+      {...props}
+      className={mx('bs-10 is-5 rounded touch-none', themeVariantFocus(themeVariant), className)}
+    >
       <DotsSixVertical className={mx(getSize(5), 'mbs-2.5')} />
     </div>
   );
@@ -204,7 +208,7 @@ const PureListItem = forwardRef<ListItemElement, ListItemProps & { id: string }>
           ref={forwardedRef}
           aria-labelledby={headingId}
           {...(selectable && { role: 'option', 'aria-selected': !!selected })}
-          className={mx('flex', draggable && 'touch-none', slots.root?.className)}
+          className={mx('flex', slots.root?.className)}
         >
           {draggable && <ListItemDragHandle {...slots.dragHandle} className={slots.dragHandle?.className} />}
           {selectable && (

--- a/packages/common/react-components/src/components/List/List.tsx
+++ b/packages/common/react-components/src/components/List/List.tsx
@@ -195,6 +195,7 @@ const PureListItem = forwardRef<ListItemElement, ListItemProps & { id: string }>
       slots = {}
     } = props;
     const { variant, selectable } = useListContext(LIST_NAME, __scopeSelect);
+    const draggable = variant === 'ordered-draggable';
 
     const [selected = false, setSelected] = useControllableState({
       prop: propsSelected,
@@ -213,11 +214,9 @@ const PureListItem = forwardRef<ListItemElement, ListItemProps & { id: string }>
             ref={forwardedRef}
             aria-labelledby={headingId}
             {...(selectable && { role: 'option', 'aria-selected': !!selected })}
-            className={mx('flex', slots.root?.className)}
+            className={mx('flex', draggable && 'touch-none', slots.root?.className)}
           >
-            {variant === 'ordered-draggable' && (
-              <ListItemDragHandle {...slots.dragHandle} className={slots.dragHandle?.className} />
-            )}
+            {draggable && <ListItemDragHandle {...slots.dragHandle} className={slots.dragHandle?.className} />}
             {selectable && (
               <ListItemEndcap>
                 <Checkbox


### PR DESCRIPTION
I'll continue chatting with the Radix team to see if I might have missed something in `Collection`’s implementation in List.