### PR TITLE
ci: update release please git mechanics

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -84,22 +84,14 @@ jobs:
           git add .
           git commit -m "chore: apidoc update for ${{ steps.release.outputs.tag_name }}"
 
-      - name: Merge with production
+      - name: Fast-forward production
         if: ${{ steps.release.outputs.release_created }}
         run: |
           git switch production
-          git merge --no-ff ${{ github.ref_name }} -m "Merge ${{ github.ref_name }} into production"
-          git push
-
-      - name: Merge with main
-        if: ${{ steps.release.outputs.release_created }}
-        run: |
-          git switch main
-          git merge --no-ff ${{ github.ref_name }} -m "Merge ${{ github.ref_name }} into main"
+          git merge --ff-only ${{ github.ref_name }}
           git push
 
       - name: Fast-forward main
-        if: ${{ !steps.release.outputs.release_created }}
         run: |
           git switch main
           git merge --ff-only ${{ github.ref_name }}


### PR DESCRIPTION
The way this job is currently setup, `production` and `main` diverge because of merge commits. This causes the job to fail when doing a hotfix after there have been a number of releases. This change stops using merge commits and only ever fast-forwards `main` and `production` from the release branches; this ensures that they maintain the same history. `main` continues to fast-forward on every commit, ensuring that updates to the release are ported back to `main`, while `production` is only fast-forwarded once the release is created. By using fast-forward only, `production` is essentially just a time-delayed version of `main`. One caveat to this flow is that if there is ever a conflict the CI jobs will fail and need to be resolved manually, however this was also the case before as well.
