### PR TITLE
fix: Input value

### DIFF
--- a/packages/common/react-components/src/components/Input/Input.tsx
+++ b/packages/common/react-components/src/components/Input/Input.tsx
@@ -58,7 +58,7 @@ export const Input = ({
     ...(autoFocus && !hasIosKeyboard && { autoFocus: true }),
     disabled,
     placeholder,
-    value: value ?? '',
+    value,
     defaultValue,
     onChange,
     validationMessage,

--- a/packages/experimental/kai/src/frames/Note/NoteTile.tsx
+++ b/packages/experimental/kai/src/frames/Note/NoteTile.tsx
@@ -28,7 +28,7 @@ export const NoteTile = withReactor(({ item, onDelete }: TileContentProps) => {
           <Input
             label='Title'
             variant='subdued'
-            value={note.title}
+            value={note.title ?? ''}
             onChange={(event) => {
               note.title = event.target.value;
             }}


### PR DESCRIPTION
Don’t set defaults in any component’s controlled state props, e.g. `value` `defaultValue` or `onChange`. Instead, set these defaults downstream where the component is used.