### PR TITLE
ci: tweak release please main merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -92,9 +92,17 @@ jobs:
           git push
 
       - name: Fast-forward main
+        if: ${{ !steps.release.outputs.release_created }}
         run: |
           git switch main
           git merge --ff-only ${{ github.ref_name }}
+          git push
+
+      - name: Merge main
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          git switch main
+          git merge --no-ff ${{ github.ref_name }} -m "Merge ${{ github.ref_name }} into main"
           git push
 
       - name: Delete release branch


### PR DESCRIPTION
Git was unable to fast-forward release onto `main`. This uses a merge commit when going back into main instead. Theory is that this will be okay because production wouldn't diverge as it would end up in it's history later (on the next release).
