### PR TITLE
fix(react-composer): Styles

### DIFF
--- a/packages/apps/patterns/react-composer/package.json
+++ b/packages/apps/patterns/react-composer/package.json
@@ -23,6 +23,7 @@
     "@tiptap/core": "2.0.0-beta.199",
     "@tiptap/extension-collaboration": "2.0.0-beta.199",
     "@tiptap/extension-heading": "2.0.0-beta.220",
+    "@tiptap/extension-list-item": "2.0.0-beta.220",
     "@tiptap/extension-placeholder": "2.0.0-beta.199",
     "@tiptap/react": "2.0.0-beta.199",
     "@tiptap/starter-kit": "2.0.0-beta.199",

--- a/packages/apps/patterns/react-composer/package.json
+++ b/packages/apps/patterns/react-composer/package.json
@@ -22,6 +22,7 @@
     "@dxos/react-components": "workspace:*",
     "@tiptap/core": "2.0.0-beta.199",
     "@tiptap/extension-collaboration": "2.0.0-beta.199",
+    "@tiptap/extension-heading": "2.0.0-beta.220",
     "@tiptap/extension-placeholder": "2.0.0-beta.199",
     "@tiptap/react": "2.0.0-beta.199",
     "@tiptap/starter-kit": "2.0.0-beta.199",

--- a/packages/apps/patterns/react-composer/src/components/Composer/Composer.tsx
+++ b/packages/apps/patterns/react-composer/src/components/Composer/Composer.tsx
@@ -2,7 +2,9 @@
 // Copyright 2022 DXOS.org
 //
 
+import { mergeAttributes } from '@tiptap/core';
 import Collaboration from '@tiptap/extension-collaboration';
+import Heading from '@tiptap/extension-heading';
 import Placeholder from '@tiptap/extension-placeholder';
 import { EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
@@ -27,6 +29,17 @@ export interface ComposerProps {
   slots?: ComposerSlots;
 }
 
+type Levels = 1 | 2 | 3 | 4 | 5 | 6;
+
+const headingClassNames: Record<Levels, string> = {
+  1: 'mbs-4 mbe-2 text-4xl font-semibold',
+  2: 'mbs-4 mbe-2 text-3xl font-semibold',
+  3: 'mbs-4 mbe-2 text-2xl font-bold',
+  4: 'mbs-4 mbe-2 text-xl font-bold',
+  5: 'mbs-4 mbe-2 text-lg font-extrabold',
+  6: 'mbs-4 mbe-2 font-extrabold'
+};
+
 export const Composer = ({ document, field = 'content', placeholder, slots = {} }: ComposerProps) => {
   // TODO(wittjosiah): Provide own translations?
   //   Maybe default is not translated and translated placeholder can be provided by the app.
@@ -39,7 +52,78 @@ export const Composer = ({ document, field = 'content', placeholder, slots = {} 
   const editor = useEditor(
     {
       extensions: [
-        StarterKit.configure({ history: false }),
+        StarterKit.configure({
+          // Extensions
+          history: false,
+          // Nodes
+          blockquote: {
+            HTMLAttributes: {
+              class: 'mlb-2 border-is-4 border-neutral-500/50 pis-5'
+            }
+          },
+          bulletList: {
+            HTMLAttributes: {
+              class: 'mlb-2 space-b-1 list-disc pis-5'
+            }
+          },
+          codeBlock: {
+            HTMLAttributes: {
+              class: 'mlb-2 font-mono bg-neutral-500/10 p-3 rounded'
+            }
+          },
+          heading: false, // (thure): `StarterKit` doesn’t let you configure how headings are rendered, see `Heading` below.
+          horizontalRule: {
+            HTMLAttributes: {
+              class: 'mlb-4 border-neutral-500/50'
+            }
+          },
+          listItem: {},
+          orderedList: {
+            HTMLAttributes: {
+              class: 'space-b-1 list-decimal pis-5'
+            }
+          },
+          paragraph: {
+            HTMLAttributes: {
+              class: 'mlb-1'
+            }
+          },
+          // Marks
+          bold: {
+            HTMLAttributes: {
+              class: 'font-bold'
+            }
+          },
+          code: {
+            HTMLAttributes: {
+              class: 'font-mono bg-neutral-500/10 rounded pli-1.5 mli-0.5 plb-0.5 -mlb-0.5'
+            }
+          },
+          italic: {
+            HTMLAttributes: {
+              class: 'italic'
+            }
+          },
+          strike: {
+            HTMLAttributes: {
+              class: 'line-through'
+            }
+          }
+        }),
+        Heading.extend({
+          renderHTML({ node, HTMLAttributes }) {
+            const hasLevel = this.options.levels.includes(node.attrs.level);
+            const level: Levels = hasLevel ? node.attrs.level : this.options.levels[0];
+
+            return [
+              `h${level}`,
+              mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+                class: `${headingClassNames[level]}`
+              }),
+              0
+            ];
+          }
+        }),
         // https://github.com/ueberdosis/tiptap/tree/main/packages/extension-collaboration
         Collaboration.configure({ document: document.doc!, field }),
         Placeholder.configure({

--- a/packages/apps/patterns/react-composer/src/components/Composer/Composer.tsx
+++ b/packages/apps/patterns/react-composer/src/components/Composer/Composer.tsx
@@ -34,11 +34,11 @@ type Levels = 1 | 2 | 3 | 4 | 5 | 6;
 
 const headingClassNames: Record<Levels, string> = {
   1: 'mbs-4 mbe-2 text-4xl font-semibold',
-  2: 'mbs-4 mbe-2 text-3xl font-semibold',
+  2: 'mbs-4 mbe-2 text-3xl font-bold',
   3: 'mbs-4 mbe-2 text-2xl font-bold',
-  4: 'mbs-4 mbe-2 text-xl font-bold',
+  4: 'mbs-4 mbe-2 text-xl font-extrabold',
   5: 'mbs-4 mbe-2 text-lg font-extrabold',
-  6: 'mbs-4 mbe-2 font-extrabold'
+  6: 'mbs-4 mbe-2 font-black'
 };
 
 export const Composer = ({ document, field = 'content', placeholder, slots = {} }: ComposerProps) => {

--- a/packages/apps/patterns/react-composer/src/components/Composer/Composer.tsx
+++ b/packages/apps/patterns/react-composer/src/components/Composer/Composer.tsx
@@ -5,6 +5,7 @@
 import { mergeAttributes } from '@tiptap/core';
 import Collaboration from '@tiptap/extension-collaboration';
 import Heading from '@tiptap/extension-heading';
+import ListItem from '@tiptap/extension-list-item';
 import Placeholder from '@tiptap/extension-placeholder';
 import { EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
@@ -63,7 +64,9 @@ export const Composer = ({ document, field = 'content', placeholder, slots = {} 
           },
           bulletList: {
             HTMLAttributes: {
-              class: 'mlb-2 space-b-1 list-disc pis-5'
+              class:
+                // todo (thure): Tailwind was not seeing `[&>li:before]:content-["•"]` as a utility class, but it would work if instead of `"•"` it was `"X"`… why?
+                'mlb-2 grid grid-cols-[min-content_1fr] [&>li:before]:content-[attr(marker)] [&>li:before]:mlb-1 [&>li:before]:mie-2'
             }
           },
           codeBlock: {
@@ -77,10 +80,11 @@ export const Composer = ({ document, field = 'content', placeholder, slots = {} 
               class: 'mlb-4 border-neutral-500/50'
             }
           },
-          listItem: {},
+          listItem: false, // (thure): `StarterKit` doesn’t let you configure how list items are rendered, see `ListItem` below.
           orderedList: {
             HTMLAttributes: {
-              class: 'space-b-1 list-decimal pis-5'
+              class:
+                'mlb-2 grid grid-cols-[min-content_1fr]  [&>li:before]:content-[counters(section,_".")_"._"] [counter-reset:section] [&>li:before]:mlb-1'
             }
           },
           paragraph: {
@@ -118,11 +122,21 @@ export const Composer = ({ document, field = 'content', placeholder, slots = {} 
             return [
               `h${level}`,
               mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
-                class: `${headingClassNames[level]}`
+                class: headingClassNames[level]
               }),
               0
             ];
           }
+        }),
+        ListItem.extend({
+          renderHTML: ({ HTMLAttributes }) => [
+            'li',
+            mergeAttributes(HTMLAttributes, {
+              marker: '• ',
+              class: 'contents before:[counter-increment:section]'
+            }),
+            ['div', { role: 'none' }, 0]
+          ]
         }),
         // https://github.com/ueberdosis/tiptap/tree/main/packages/extension-collaboration
         Collaboration.configure({ document: document.doc!, field }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,6 +576,7 @@ importers:
       '@tiptap/core': 2.0.0-beta.199
       '@tiptap/extension-collaboration': 2.0.0-beta.199
       '@tiptap/extension-heading': 2.0.0-beta.220
+      '@tiptap/extension-list-item': 2.0.0-beta.220
       '@tiptap/extension-placeholder': 2.0.0-beta.199
       '@tiptap/react': 2.0.0-beta.199
       '@tiptap/starter-kit': 2.0.0-beta.199
@@ -595,6 +596,7 @@ importers:
       '@tiptap/core': 2.0.0-beta.199
       '@tiptap/extension-collaboration': 2.0.0-beta.199_wrs3r2liyxd6sebc64ic7svwo4
       '@tiptap/extension-heading': 2.0.0-beta.220_4focsuckzeocqotdxlryrtksam
+      '@tiptap/extension-list-item': 2.0.0-beta.220_4focsuckzeocqotdxlryrtksam
       '@tiptap/extension-placeholder': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam
       '@tiptap/react': 2.0.0-beta.199_la4wgmshzfaebh4rq27xtbsa3y
       '@tiptap/starter-kit': 2.0.0-beta.199
@@ -12146,10 +12148,10 @@ packages:
       '@tiptap/core': 2.0.0-beta.199
     dev: false
 
-  /@tiptap/extension-list-item/2.0.0-beta.199_4focsuckzeocqotdxlryrtksam:
-    resolution: {integrity: sha512-rzcz5MJgoX1M9M9e1iruyRxcwYyYmdCXsl9gB8hhJYh4R+AW1peRmHJ3vVX5oPZXg/tXOMTv/or2x8v30c9tJw==}
+  /@tiptap/extension-list-item/2.0.0-beta.220_4focsuckzeocqotdxlryrtksam:
+    resolution: {integrity: sha512-+O0ivwxPP2l/m9PAowb2ytDT/cM5kwu0s1W5MUsHPIqf+M6ahnl4ESjhWZfDHUzvjqPq6MTbqoQLHbB1KS/N7w==}
     peerDependencies:
-      '@tiptap/core': ^2.0.0-beta.193
+      '@tiptap/core': ^2.0.0-beta.209
     dependencies:
       '@tiptap/core': 2.0.0-beta.199
     dev: false
@@ -12229,7 +12231,7 @@ packages:
       '@tiptap/extension-history': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam
       '@tiptap/extension-horizontal-rule': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam
       '@tiptap/extension-italic': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam
-      '@tiptap/extension-list-item': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam
+      '@tiptap/extension-list-item': 2.0.0-beta.220_4focsuckzeocqotdxlryrtksam
       '@tiptap/extension-ordered-list': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam
       '@tiptap/extension-paragraph': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam
       '@tiptap/extension-strike': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -575,6 +575,7 @@ importers:
       '@dxos/react-components': workspace:*
       '@tiptap/core': 2.0.0-beta.199
       '@tiptap/extension-collaboration': 2.0.0-beta.199
+      '@tiptap/extension-heading': 2.0.0-beta.220
       '@tiptap/extension-placeholder': 2.0.0-beta.199
       '@tiptap/react': 2.0.0-beta.199
       '@tiptap/starter-kit': 2.0.0-beta.199
@@ -593,6 +594,7 @@ importers:
       '@dxos/react-components': link:../../../common/react-components
       '@tiptap/core': 2.0.0-beta.199
       '@tiptap/extension-collaboration': 2.0.0-beta.199_wrs3r2liyxd6sebc64ic7svwo4
+      '@tiptap/extension-heading': 2.0.0-beta.220_4focsuckzeocqotdxlryrtksam
       '@tiptap/extension-placeholder': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam
       '@tiptap/react': 2.0.0-beta.199_la4wgmshzfaebh4rq27xtbsa3y
       '@tiptap/starter-kit': 2.0.0-beta.199
@@ -12110,10 +12112,10 @@ packages:
       '@tiptap/core': 2.0.0-beta.199
     dev: false
 
-  /@tiptap/extension-heading/2.0.0-beta.199_4focsuckzeocqotdxlryrtksam:
-    resolution: {integrity: sha512-WGQ7ET2TBpldrD8JX37OXHXq05LU3OWItIVBs9nKGh4otZTUwPtwfOyMlFfA+IMfQif+ilwLGvUC6EHOw/LwxQ==}
+  /@tiptap/extension-heading/2.0.0-beta.220_4focsuckzeocqotdxlryrtksam:
+    resolution: {integrity: sha512-7mrHRj++UaZ26C2Gjwb0WKWAzpiKb8TOYkVC2uMaCwaNhLDXpFEwZ7RtJRSTNBHkIGnMO46BH8Z0qlkFMmk9Jw==}
     peerDependencies:
-      '@tiptap/core': ^2.0.0-beta.193
+      '@tiptap/core': ^2.0.0-beta.209
     dependencies:
       '@tiptap/core': 2.0.0-beta.199
     dev: false
@@ -12223,7 +12225,7 @@ packages:
       '@tiptap/extension-dropcursor': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam
       '@tiptap/extension-gapcursor': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam
       '@tiptap/extension-hard-break': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam
-      '@tiptap/extension-heading': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam
+      '@tiptap/extension-heading': 2.0.0-beta.220_4focsuckzeocqotdxlryrtksam
       '@tiptap/extension-history': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam
       '@tiptap/extension-horizontal-rule': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam
       '@tiptap/extension-italic': 2.0.0-beta.199_4focsuckzeocqotdxlryrtksam


### PR DESCRIPTION
This PR styles known Node and Mark extensions in `react-composer` using Tailwind.

Resolves #2636.

Special attention was given to list item marker alignment to support numbered outlines that align neatly.

<img width="741" alt="Screenshot 2023-03-02 at 16 59 39" src="https://user-images.githubusercontent.com/855039/222605253-4603b4e6-02cb-4b06-a25b-4fe07b600e57.png">
