### PR TITLE
fix: halo vault pwa cache

### DIFF
--- a/packages/apps/composer-app/project.json
+++ b/packages/apps/composer-app/project.json
@@ -46,6 +46,13 @@
         "packages/apps/composer-app/src/proto/gen"
       ]
     },
+    "preview": {
+      "executor": "@nrwl/web:file-server",
+      "options": {
+        "buildTarget": "composer-app:bundle",
+        "staticFilePath": "packages/apps/composer-app/out/composer"
+      }
+    },
     "serve": {
       "executor": "@nrwl/vite:dev-server",
       "options": {
@@ -53,21 +60,10 @@
       }
     },
     "serve-with-halo": {
-      "dependsOn": [
-        "^compile"
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": [
-          {
-            "command": "nx serve halo-app"
-          },
-          {
-            "command": "nx serve composer-app"
-          }
-        ],
-        "parallel": true
-      }
+      "executor": "@dxos/serve-with-halo:run"
     }
-  }
+  },
+  "implicitDependencies": [
+    "serve-with-halo"
+  ]
 }

--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -44,8 +44,6 @@ export default defineConfig({
     }),
     ReactPlugin(),
     VitePWA({
-      // TODO(wittjosiah): Remove.
-      selfDestroying: true,
       workbox: {
         maximumFileSizeToCacheInBytes: 30000000
       },

--- a/packages/apps/halo-app/src/vault/main.ts
+++ b/packages/apps/halo-app/src/vault/main.ts
@@ -42,8 +42,7 @@ const startShell = async (config: Config, runtime: ShellRuntime, services: Clien
 };
 
 const main = async () => {
-  const params = new URLSearchParams(window.location.search);
-  const shellDisabled = params.get('shell') === 'false';
+  const shellDisabled = window.location.hash === '#disableshell';
   const config = new Config(await Dynamics(), Defaults());
 
   // TODO(wittjosiah): Remove mobile check once we can inspect shared workers in iOS Safari.

--- a/packages/apps/halo-app/vite.config.ts
+++ b/packages/apps/halo-app/vite.config.ts
@@ -61,8 +61,6 @@ export default defineConfig({
     }),
     ReactPlugin(),
     VitePWA({
-      // TODO(wittjosiah): Remove.
-      selfDestroying: true,
       // TODO(wittjosiah): Bundle size is massive.
       workbox: {
         maximumFileSizeToCacheInBytes: 30000000

--- a/packages/sdk/client/src/packlets/client/iframe-service-proxy.ts
+++ b/packages/sdk/client/src/packlets/client/iframe-service-proxy.ts
@@ -140,8 +140,10 @@ export class IFrameClientServicesProxy implements ClientServicesProvider {
   }
 
   private async _getIFramePort(channel: string): Promise<RpcPort> {
+    // NOTE: Using query params invalidates the service worker cache & requires a custom worker.
+    //   https://developer.chrome.com/docs/workbox/modules/workbox-build/#generatesw
     const source = new URL(
-      typeof this._options.shell === 'string' ? this._options.source : `${this._options.source}?shell=false`,
+      typeof this._options.shell === 'string' ? this._options.source : `${this._options.source}#disableshell`,
       window.location.origin
     );
 


### PR DESCRIPTION
- `/vault.html` is what the halo service worker precaches and `/vault.html?shell=false` misses the cache
- the fix here is to use `/vault.html#disableshell` instead because it does not cause a cache miss
- it's still unclear to me why the cache miss causes `/vault.html?shell=false` to return the `/index.html` document rather than hitting the server for the document (this is reproducible on localhost, it's not due to kube behaviour)