### PR TITLE
fix(react-ui): Don’t autofocus in iOS on elements that are not results of local actions

### DIFF
--- a/packages/apps/patterns/react-ui/src/composites/DevicesDialog/DevicesDialog.tsx
+++ b/packages/apps/patterns/react-ui/src/composites/DevicesDialog/DevicesDialog.tsx
@@ -5,7 +5,7 @@
 import { Close } from '@radix-ui/react-dialog';
 import React from 'react';
 
-import { ThemeContext, useId } from '@dxos/react-components';
+import { ThemeContext, useId, useThemeContext } from '@dxos/react-components';
 
 import { PanelDialog, PanelDialogProps } from '../../layouts';
 import { DevicesPanel, DevicesPanelProps } from '../../panels';
@@ -16,6 +16,7 @@ export interface DevicesDialogProps
 
 export const DevicesDialog = ({ slots, ...devicesDialogProps }: DevicesDialogProps) => {
   const titleId = useId('spaceDialog__title');
+  const themeContextValue = useThemeContext();
 
   return (
     <PanelDialog
@@ -24,7 +25,7 @@ export const DevicesDialog = ({ slots, ...devicesDialogProps }: DevicesDialogPro
         titleId
       }}
     >
-      <ThemeContext.Provider value={{ themeVariant: 'os' }}>
+      <ThemeContext.Provider value={{ ...themeContextValue, themeVariant: 'os' }}>
         <DevicesPanel
           {...{
             ...devicesDialogProps,

--- a/packages/apps/patterns/react-ui/src/composites/JoinDialog/JoinDialog.tsx
+++ b/packages/apps/patterns/react-ui/src/composites/JoinDialog/JoinDialog.tsx
@@ -5,7 +5,7 @@
 import { Action, Cancel } from '@radix-ui/react-alert-dialog';
 import React from 'react';
 
-import { ThemeContext, useId } from '@dxos/react-components';
+import { ThemeContext, useId, useThemeContext } from '@dxos/react-components';
 
 import { PanelAlertDialog, PanelAlertDialogProps } from '../../layouts';
 import { JoinPanel, JoinPanelProps } from '../../panels';
@@ -16,9 +16,11 @@ export interface JoinDialogProps
 
 export const JoinDialog = ({ slots, ...joinPanelProps }: JoinDialogProps) => {
   const titleId = useId('joinDialog__title');
+  const themeContextValue = useThemeContext();
+
   return (
     <PanelAlertDialog {...{ slots, titleId }}>
-      <ThemeContext.Provider value={{ themeVariant: 'os' }}>
+      <ThemeContext.Provider value={{ ...themeContextValue, themeVariant: 'os' }}>
         <JoinPanel
           {...{
             ...joinPanelProps,

--- a/packages/apps/patterns/react-ui/src/composites/SpaceDialog/SpaceDialog.tsx
+++ b/packages/apps/patterns/react-ui/src/composites/SpaceDialog/SpaceDialog.tsx
@@ -5,7 +5,7 @@
 import { Close } from '@radix-ui/react-dialog';
 import React from 'react';
 
-import { ThemeContext, useId } from '@dxos/react-components';
+import { ThemeContext, useId, useThemeContext } from '@dxos/react-components';
 
 import { PanelDialog, PanelDialogProps } from '../../layouts';
 import { SpacePanel, SpacePanelProps } from '../../panels';
@@ -16,6 +16,7 @@ export interface SpaceDialogProps
 
 export const SpaceDialog = ({ slots, ...spacePanelProps }: SpaceDialogProps) => {
   const titleId = useId('spaceDialog__title');
+  const themeContextValue = useThemeContext();
 
   return (
     <PanelDialog
@@ -24,7 +25,7 @@ export const SpaceDialog = ({ slots, ...spacePanelProps }: SpaceDialogProps) => 
         titleId
       }}
     >
-      <ThemeContext.Provider value={{ themeVariant: 'os' }}>
+      <ThemeContext.Provider value={{ ...themeContextValue, themeVariant: 'os' }}>
         <SpacePanel
           {...{
             ...spacePanelProps,

--- a/packages/apps/patterns/react-ui/src/panels/IdentityPanel/IdentityPanel.tsx
+++ b/packages/apps/patterns/react-ui/src/panels/IdentityPanel/IdentityPanel.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import type { Identity } from '@dxos/client';
 import { useClient } from '@dxos/react-client';
-import { Avatar, Button, DensityProvider, ThemeContext, useTranslation } from '@dxos/react-components';
+import { Avatar, Button, DensityProvider, ThemeContext, useThemeContext, useTranslation } from '@dxos/react-components';
 
 export const IdentityPanel = ({
   identity,
@@ -16,13 +16,15 @@ export const IdentityPanel = ({
 }) => {
   const { t } = useTranslation('os');
   const client = useClient();
+  const themeContextValue = useThemeContext();
+
   const defaultManageProfile = () => {
     const remoteSource = new URL(client?.config.get('runtime.client.remoteSource') || 'https://halo.dxos.org');
     const tab = window.open(remoteSource.origin, '_blank');
     tab?.focus();
   };
   return (
-    <ThemeContext.Provider value={{ themeVariant: 'os' }}>
+    <ThemeContext.Provider value={{ ...themeContextValue, themeVariant: 'os' }}>
       <DensityProvider density='fine'>
         <div className='flex flex-col gap-2 justify-center items-center'>
           <Avatar

--- a/packages/apps/patterns/react-ui/src/panels/JoinPanel/JoinPanel.tsx
+++ b/packages/apps/patterns/react-ui/src/panels/JoinPanel/JoinPanel.tsx
@@ -5,7 +5,7 @@ import React, { useEffect } from 'react';
 
 import { log } from '@dxos/log';
 import { useClient, useIdentity } from '@dxos/react-client';
-import { DensityProvider, useId } from '@dxos/react-components';
+import { DensityProvider, useId, useThemeContext } from '@dxos/react-components';
 
 import { JoinHeading } from './JoinHeading';
 import { JoinPanelProps } from './JoinPanelProps';
@@ -32,6 +32,7 @@ export const JoinPanel = ({
   const client = useClient();
   const identity = useIdentity();
   const titleId = useId('joinPanel__title');
+  const { hasIosKeyboard } = useThemeContext();
 
   const [joinState, joinSend, joinService] = useJoinMachine(client, {
     context: {
@@ -57,10 +58,10 @@ export const JoinPanel = ({
     const innermostState = stateStack[stateStack.length - 1];
     const autoFocusValue = innermostState === 'finishingJoining' ? 'successSpaceInvitation' : innermostState;
     const $nextAutofocus: HTMLElement | null = document.querySelector(`[data-autofocus~="${autoFocusValue}"]`);
-    if ($nextAutofocus) {
+    if ($nextAutofocus && !(hasIosKeyboard && $nextAutofocus.hasAttribute('data-prevent-ios-autofocus'))) {
       $nextAutofocus.focus();
     }
-  }, [joinState.value]);
+  }, [joinState.value, hasIosKeyboard]);
 
   return (
     <DensityProvider density='fine'>

--- a/packages/apps/patterns/react-ui/src/panels/JoinPanel/view-states/InvitationAuthenticator.tsx
+++ b/packages/apps/patterns/react-ui/src/panels/JoinPanel/view-states/InvitationAuthenticator.tsx
@@ -55,6 +55,7 @@ const PureInvitationAuthenticatorContent = ({
             autoComplete: 'off',
             pattern: '\\d*',
             'data-autofocus': `connecting${Domain}Invitation inputting${Domain}VerificationCode authenticationFailing${Domain}VerificationCode authenticating${Domain}VerificationCode`,
+            'data-prevent-ios-autofocus': true,
             'data-testid': `${invitationType}-auth-code-input`,
             'data-1p-ignore': true
           } as ComponentPropsWithoutRef<'input'>


### PR DESCRIPTION
This PR also fixes the ThemeContext value getting cleared in `react-ui`.