### PR TITLE
feat(composer-app): Layout adjustments

### DIFF
--- a/packages/apps/composer-app/src/pages/DocumentPage.tsx
+++ b/packages/apps/composer-app/src/pages/DocumentPage.tsx
@@ -84,7 +84,7 @@ const DocumentPageContent = observer(
     const { t } = useTranslation('composer');
     return (
       <>
-        <div role='none' className='mli-auto max-is-[50rem] min-bs-screen border border-neutral-500/20'>
+        <div role='none' className='mli-auto max-is-[50rem] min-bs-[80vh] border border-neutral-500/20 flex flex-col'>
           <Input
             key={document.id}
             variant='subdued'
@@ -93,7 +93,7 @@ const DocumentPageContent = observer(
             placeholder={t('untitled document title')}
             value={document.title ?? ''}
             onChange={({ target: { value } }) => (document.title = value)}
-            slots={{ root: { className: 'pli-6 plb-1 mbe-3 bg-neutral-500/20' } }}
+            slots={{ root: { className: 'shrink-0 pli-6 plb-1 mbe-3 bg-neutral-500/20' } }}
           />
           {children}
         </div>
@@ -402,10 +402,12 @@ const MarkdownDocumentPage = observer(({ document, space }: { document: Composer
           slots={{
             root: {
               role: 'none',
-              className: 'pli-6 mbs-4'
+              className: 'shrink-0 grow flex flex-col pbe-3'
             },
             editor: {
               markdownTheme: {
+                '&, & .cm-scroller': { display: 'flex', flexDirection: 'column', flex: '1 0 auto' },
+                '& .cm-content': { flex: '1 0 auto' },
                 '& .cm-line': {
                   paddingInline: '1.5rem'
                 }

--- a/packages/apps/patterns/react-composer/src/components/Markdown/Markdown.tsx
+++ b/packages/apps/patterns/react-composer/src/components/Markdown/Markdown.tsx
@@ -175,6 +175,6 @@ export const MarkdownComposer = forwardRef<MarkdownComposerRef, MarkdownComposer
       };
     }, [parent, content, provider?.awareness]);
 
-    return <div key={id} ref={setParent} />;
+    return <div key={id} {...slots.root} ref={setParent} />;
   }
 );

--- a/packages/apps/patterns/react-composer/src/components/Markdown/Markdown.tsx
+++ b/packages/apps/patterns/react-composer/src/components/Markdown/Markdown.tsx
@@ -141,7 +141,7 @@ export const MarkdownComposer = forwardRef<MarkdownComposerRef, MarkdownComposer
             ...completionKeymap,
             ...lintKeymap
           ]),
-
+          EditorView.lineWrapping,
           // Theme
           markdown({ base: markdownLanguage, codeLanguages: languages, extensions: [markdownTagsExtension] }),
           EditorView.theme({ ...markdownDarktheme, ...slots.editor?.markdownTheme }),


### PR DESCRIPTION
The Markdown composer now occupies the full width of Composer app’s `DocumentPage`. `react-composer` also applies soft wrapping by default.