### PR TITLE
chore: Make traces use same context

### DIFF
--- a/packages/common/sentry/src/tracing.ts
+++ b/packages/common/sentry/src/tracing.ts
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { setUser, startTransaction } from '@sentry/browser';
+import { setUser, getCurrentHub } from '@sentry/browser';
 import { Transaction, Span } from '@sentry/types';
 
 import { runInContext, scheduleTask, Trigger } from '@dxos/async';
@@ -17,7 +17,7 @@ const ctx = new Context({ onError: (err) => log.warn('Unhandled error in Sentry 
 export const configureTracing = () => {
   runInContext(ctx, () => {
     // Configure root transaction.
-    TX = startTransaction({
+    TX = getCurrentHub().startTransaction({
       name: 'DXOS Core Tracing',
       op: 'dxos'
     });


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2135ed8</samp>

### Summary
🛠️🚀🔬

<!--
1.  🛠️ - This emoji conveys the idea of refactoring or fixing something, which is the main purpose of the change.
2.  🚀 - This emoji suggests improvement or enhancement, which is the intended outcome of the change for the tracing module and its users.
3.  🔬 - This emoji implies testing or experimentation, which is relevant for the change since it involves using a different Sentry API and ensuring it works as expected.
-->
Improved Sentry tracing module by using `getCurrentHub` API. This makes the module more flexible and reliable for different Sentry configurations.

> _To trace errors with Sentry_
> _We refactored the tracing entry_
> _We use `getCurrentHub`_
> _Instead of `startTransaction`_
> _For better compatibility and consistency_

### Walkthrough
*  Replace `startTransaction` import with `getCurrentHub` to support different Sentry configurations ([link](https://github.com/dxos/dxos/pull/2934/files?diff=unified&w=0#diff-d12149c834044a01e667ff114118549ee71332f71adce2526ebcf3743ffd14d2L5-R5))
*  Use `getCurrentHub().startTransaction` to create transactions and associate them with the current scope and client ([link](https://github.com/dxos/dxos/pull/2934/files?diff=unified&w=0#diff-d12149c834044a01e667ff114118549ee71332f71adce2526ebcf3743ffd14d2L20-R20))


