### PR TITLE
refactor(client-services): make invitations service stateful

### DIFF
--- a/packages/apps/halo-app/src/pages/DevicesPage.tsx
+++ b/packages/apps/halo-app/src/pages/DevicesPage.tsx
@@ -22,10 +22,6 @@ const DevicesPage = () => {
     client.halo.createInvitation();
   }, []);
 
-  const handleRemove = useCallback((id: string) => {
-    void client.halo.deleteInvitation(id);
-  }, []);
-
   return (
     <>
       <HeadingWithActions
@@ -45,7 +41,7 @@ const DevicesPage = () => {
       <InvitationList
         invitations={invitations as unknown as CancellableInvitationObservable[] | undefined}
         createInvitationUrl={(invitationCode) => createInvitationUrl('/identity/join', invitationCode)}
-        onClickRemove={handleRemove}
+        onClickRemove={(invitation) => invitation.cancel()}
       />
     </>
   );

--- a/packages/apps/halo-app/src/pages/DevicesPage.tsx
+++ b/packages/apps/halo-app/src/pages/DevicesPage.tsx
@@ -23,7 +23,7 @@ const DevicesPage = () => {
   }, []);
 
   const handleRemove = useCallback((id: string) => {
-    void client.halo.removeInvitation(id);
+    void client.halo.deleteInvitation(id);
   }, []);
 
   return (

--- a/packages/apps/patterns/react-appkit/src/components/InvitationList/PendingInvitation.tsx
+++ b/packages/apps/patterns/react-appkit/src/components/InvitationList/PendingInvitation.tsx
@@ -3,7 +3,7 @@
 //
 
 import { ProhibitInset, XCircle } from '@phosphor-icons/react';
-import React, { useCallback } from 'react';
+import React from 'react';
 
 import { Invitation, CancellableInvitationObservable } from '@dxos/client';
 import { useInvitationStatus } from '@dxos/react-client';
@@ -25,7 +25,7 @@ import { Tooltip } from '../Tooltip';
 export interface PendingInvitationProps {
   wrapper: CancellableInvitationObservable;
   createInvitationUrl: (invitation: string) => string;
-  onClickRemove: (id: string) => void;
+  onClickRemove: (invitation: CancellableInvitationObservable) => void;
 }
 
 const PendingInvitationSkeleton = ({ message }: { message: string }) => {
@@ -35,11 +35,6 @@ const PendingInvitationSkeleton = ({ message }: { message: string }) => {
 export const PendingInvitation = ({ wrapper, createInvitationUrl, onClickRemove }: PendingInvitationProps) => {
   const { t } = useTranslation('appkit');
   const { cancel, status, haltedAt, authCode, invitationCode } = useInvitationStatus(wrapper);
-
-  const handleRemove = useCallback(() => {
-    const id = wrapper.get().invitationId;
-    id && onClickRemove(id);
-  }, []);
 
   return (
     <div role='group' className={mx(defaultGroup({ elevation: 'group' }), 'mbe-2')}>
@@ -79,11 +74,11 @@ export const PendingInvitation = ({ wrapper, createInvitationUrl, onClickRemove 
                 status === Invitation.State.SUCCESS ? (
                   <>
                     <Tooltip content={t('remove label')} tooltipLabelsTrigger>
-                      <Button className='flex md:hidden gap-1 items-center' onClick={handleRemove}>
+                      <Button className='flex md:hidden gap-1 items-center' onClick={() => onClickRemove(wrapper)}>
                         <XCircle className={getSize(5)} />
                       </Button>
                     </Tooltip>
-                    <Button className='hidden md:flex gap-1 items-center' onClick={handleRemove}>
+                    <Button className='hidden md:flex gap-1 items-center' onClick={() => onClickRemove(wrapper)}>
                       <XCircle className={getSize(5)} />
                       <span>{t('remove label')}</span>
                     </Button>

--- a/packages/apps/patterns/react-appkit/src/components/ManageSpacePage/ManageSpacePage.tsx
+++ b/packages/apps/patterns/react-appkit/src/components/ManageSpacePage/ManageSpacePage.tsx
@@ -48,7 +48,7 @@ export const ManageSpacePage = ({
     }
   }, [space]);
 
-  const handleRemove = useCallback((id: string) => space?.removeInvitation(id), [space]);
+  const handleRemove = useCallback((id: string) => space?.deleteInvitation(id), [space]);
 
   return (
     <>

--- a/packages/apps/patterns/react-appkit/src/components/ManageSpacePage/ManageSpacePage.tsx
+++ b/packages/apps/patterns/react-appkit/src/components/ManageSpacePage/ManageSpacePage.tsx
@@ -48,8 +48,6 @@ export const ManageSpacePage = ({
     }
   }, [space]);
 
-  const handleRemove = useCallback((id: string) => space?.deleteInvitation(id), [space]);
-
   return (
     <>
       <HeadingWithActions
@@ -75,7 +73,7 @@ export const ManageSpacePage = ({
       <InvitationList
         invitations={invitations}
         createInvitationUrl={createInvitationUrl}
-        onClickRemove={handleRemove}
+        onClickRemove={(invitation) => invitation.cancel()}
       />
     </>
   );

--- a/packages/apps/patterns/react-ui/src/components/InvitationList/InvitationListContainer.tsx
+++ b/packages/apps/patterns/react-ui/src/components/InvitationList/InvitationListContainer.tsx
@@ -20,7 +20,7 @@ export const InvitationListContainer = ({ spaceKey, createInvitationUrl }: Invit
   const onClickRemove = useCallback(
     (invitation: CancellableInvitationObservable) => {
       const invitationId = invitation.get().invitationId;
-      invitationId && space?.removeInvitation(invitationId);
+      invitationId && space?.deleteInvitation(invitationId);
     },
     [space]
   );

--- a/packages/apps/patterns/react-ui/src/components/InvitationList/InvitationListContainer.tsx
+++ b/packages/apps/patterns/react-ui/src/components/InvitationList/InvitationListContainer.tsx
@@ -19,8 +19,7 @@ export const InvitationListContainer = ({ spaceKey, createInvitationUrl }: Invit
   const invitations = useSpaceInvitations(spaceKey);
   const onClickRemove = useCallback(
     (invitation: CancellableInvitationObservable) => {
-      const invitationId = invitation.get().invitationId;
-      invitationId && space?.deleteInvitation(invitationId);
+      void invitation.cancel();
     },
     [space]
   );

--- a/packages/apps/patterns/react-ui/src/panels/DevicesPanel/DevicesPanel.tsx
+++ b/packages/apps/patterns/react-ui/src/panels/DevicesPanel/DevicesPanel.tsx
@@ -64,9 +64,7 @@ const DeviceListView = ({ createInvitationUrl, titleId, onDone, doneActionParent
       <div role='region' className={mx(defaultSurface, 'rounded-be-md p-2')}>
         <InvitationList
           invitations={invitations}
-          onClickRemove={(invitation) =>
-            invitation.get() && client.halo.deleteInvitation(invitation.get().invitationId)
-          }
+          onClickRemove={(invitation) => invitation.cancel()}
           createInvitationUrl={createInvitationUrl}
         />
         <Button

--- a/packages/apps/patterns/react-ui/src/panels/DevicesPanel/DevicesPanel.tsx
+++ b/packages/apps/patterns/react-ui/src/panels/DevicesPanel/DevicesPanel.tsx
@@ -65,7 +65,7 @@ const DeviceListView = ({ createInvitationUrl, titleId, onDone, doneActionParent
         <InvitationList
           invitations={invitations}
           onClickRemove={(invitation) =>
-            invitation.get() && client.halo.removeInvitation(invitation.get().invitationId)
+            invitation.get() && client.halo.deleteInvitation(invitation.get().invitationId)
           }
           createInvitationUrl={createInvitationUrl}
         />

--- a/packages/apps/patterns/react-ui/src/panels/SpacePanel/SpacePanel.tsx
+++ b/packages/apps/patterns/react-ui/src/panels/SpacePanel/SpacePanel.tsx
@@ -52,7 +52,7 @@ const CurrentSpaceView = observer(({ space, createInvitationUrl, titleId }: Spac
       <div role='region' className={mx(defaultSurface, 'rounded-be-md p-2')}>
         <InvitationList
           invitations={invitations}
-          onClickRemove={(invitation) => invitation.get() && space?.deleteInvitation(invitation.get().invitationId)}
+          onClickRemove={(invitation) => invitation.cancel()}
           createInvitationUrl={createInvitationUrl}
         />
         <Button

--- a/packages/apps/patterns/react-ui/src/panels/SpacePanel/SpacePanel.tsx
+++ b/packages/apps/patterns/react-ui/src/panels/SpacePanel/SpacePanel.tsx
@@ -52,7 +52,7 @@ const CurrentSpaceView = observer(({ space, createInvitationUrl, titleId }: Spac
       <div role='region' className={mx(defaultSurface, 'rounded-be-md p-2')}>
         <InvitationList
           invitations={invitations}
-          onClickRemove={(invitation) => invitation.get() && space?.removeInvitation(invitation.get().invitationId)}
+          onClickRemove={(invitation) => invitation.get() && space?.deleteInvitation(invitation.get().invitationId)}
           createInvitationUrl={createInvitationUrl}
         />
         <Button

--- a/packages/core/protocols/src/proto/dxos/client/services.proto
+++ b/packages/core/protocols/src/proto/dxos/client/services.proto
@@ -325,11 +325,29 @@ message CancelInvitationRequest {
   string invitation_id = 1;
 }
 
+message DeleteInvitationRequest {
+  string invitation_id = 1;
+}
+
+message InvitationMethod {
+  oneof kind {
+    Invitation created = 1;
+    Invitation accepted = 2;
+  }
+}
+
+message QueryInvitationsResponse {
+  optional InvitationMethod added = 1;
+  optional InvitationMethod removed = 2;
+}
+
 service InvitationsService {
   rpc CreateInvitation(Invitation) returns (stream Invitation);
-  rpc Authenticate(AuthenticationRequest) returns (google.protobuf.Empty);
   rpc AcceptInvitation(Invitation) returns (stream Invitation);
+  rpc Authenticate(AuthenticationRequest) returns (google.protobuf.Empty);
   rpc CancelInvitation(CancelInvitationRequest) returns (google.protobuf.Empty);
+  rpc DeleteInvitation(DeleteInvitationRequest) returns (google.protobuf.Empty);
+  rpc QueryInvitations(google.protobuf.Empty) returns (stream QueryInvitationsResponse);
 }
 
 //

--- a/packages/core/protocols/src/proto/dxos/client/services.proto
+++ b/packages/core/protocols/src/proto/dxos/client/services.proto
@@ -325,10 +325,6 @@ message CancelInvitationRequest {
   string invitation_id = 1;
 }
 
-message DeleteInvitationRequest {
-  string invitation_id = 1;
-}
-
 message InvitationMethod {
   oneof kind {
     Invitation created = 1;
@@ -337,8 +333,19 @@ message InvitationMethod {
 }
 
 message QueryInvitationsResponse {
-  optional InvitationMethod added = 1;
-  optional InvitationMethod removed = 2;
+  enum Action {
+    ADDED = 0;
+    REMOVED = 1;
+  }
+
+  enum Type {
+    CREATED = 0;
+    ACCEPTED = 1;
+  }
+
+  Action action = 1;
+  Type type = 2;
+  repeated Invitation invitations = 3;
 }
 
 service InvitationsService {
@@ -346,7 +353,6 @@ service InvitationsService {
   rpc AcceptInvitation(Invitation) returns (stream Invitation);
   rpc Authenticate(AuthenticationRequest) returns (google.protobuf.Empty);
   rpc CancelInvitation(CancelInvitationRequest) returns (google.protobuf.Empty);
-  rpc DeleteInvitation(DeleteInvitationRequest) returns (google.protobuf.Empty);
   rpc QueryInvitations(google.protobuf.Empty) returns (stream QueryInvitationsResponse);
 }
 

--- a/packages/sdk/client/src/packlets/client/client.ts
+++ b/packages/sdk/client/src/packlets/client/client.ts
@@ -200,13 +200,6 @@ export class Client {
   }
 
   /**
-   * Removes accepted space invitation.
-   */
-  deleteInvitation(invitationId: string) {
-    return this._echo.deleteInvitation(invitationId);
-  }
-
-  /**
    * Initializes internal resources in an idempotent way.
    * Required before using the Client instance.
    */

--- a/packages/sdk/client/src/packlets/client/client.ts
+++ b/packages/sdk/client/src/packlets/client/client.ts
@@ -200,6 +200,13 @@ export class Client {
   }
 
   /**
+   * Removes accepted space invitation.
+   */
+  deleteInvitation(invitationId: string) {
+    return this._echo.deleteInvitation(invitationId);
+  }
+
+  /**
    * Initializes internal resources in an idempotent way.
    * Required before using the Client instance.
    */

--- a/packages/sdk/client/src/packlets/invitations/invitations-proxy.ts
+++ b/packages/sdk/client/src/packlets/invitations/invitations-proxy.ts
@@ -45,6 +45,8 @@ export class InvitationsProxy {
   // Invitations originating from this proxy.
   private _invitations = new Set<string>();
 
+  private _opened = false;
+
   // prettier-ignore
   constructor(
     private readonly _invitationsService: InvitationsService,
@@ -59,7 +61,16 @@ export class InvitationsProxy {
     return this._accepted;
   }
 
+  get isOpen(): boolean {
+    return this._opened;
+  }
+
   async open() {
+    if (this._opened) {
+      return;
+    }
+
+    log('opening...', this._getInvitationContext());
     this._ctx = new Context();
 
     const stream = this._invitationsService.queryInvitations();
@@ -91,12 +102,20 @@ export class InvitationsProxy {
     });
 
     this._ctx.onDispose(() => stream.close());
+    this._opened = true;
+    log('opened', this._getInvitationContext());
   }
 
   async close() {
+    if (!this._opened) {
+      return;
+    }
+
+    log('closing...', this._getInvitationContext());
     await this._ctx.dispose();
     this._createdUpdate.emit([]);
     this._acceptedUpdate.emit([]);
+    log('closed', this._getInvitationContext());
   }
 
   getInvitationOptions(): Invitation {

--- a/packages/sdk/client/src/packlets/invitations/invitations-proxy.ts
+++ b/packages/sdk/client/src/packlets/invitations/invitations-proxy.ts
@@ -4,10 +4,12 @@
 
 import assert from 'node:assert';
 
-import { Observable, PushStream } from '@dxos/async';
+import { Event, MulticastObservable, Observable, PushStream } from '@dxos/async';
 import { Stream } from '@dxos/codec-protobuf';
+import { Context } from '@dxos/context';
 import { PublicKey } from '@dxos/keys';
-import { Invitation, InvitationsService } from '@dxos/protocols/proto/dxos/client/services';
+import { log } from '@dxos/log';
+import { Invitation, InvitationsService, QueryInvitationsResponse } from '@dxos/protocols/proto/dxos/client/services';
 
 import { AuthenticatingInvitationObservable, CancellableInvitationObservable } from './invitations';
 
@@ -35,11 +37,81 @@ const createObservable = <T>(rpcStream: Stream<T>): Observable<T> => {
 };
 
 export class InvitationsProxy {
+  private _ctx!: Context;
+  private _createdUpdate = new Event<CancellableInvitationObservable[]>();
+  private _acceptedUpdate = new Event<AuthenticatingInvitationObservable[]>();
+  private _created = MulticastObservable.from(this._createdUpdate, []);
+  private _accepted = MulticastObservable.from(this._acceptedUpdate, []);
+  // Invitations originating from this proxy.
+  private _invitations = new Set<string>();
+
   // prettier-ignore
   constructor(
     private readonly _invitationsService: InvitationsService,
-    private readonly _getContext: () => Partial<Invitation> & Pick<Invitation, 'kind'>
+    private readonly _getInvitationContext: () => Partial<Invitation> & Pick<Invitation, 'kind'>
   ) {}
+
+  get created(): MulticastObservable<CancellableInvitationObservable[]> {
+    return this._created;
+  }
+
+  get accepted(): MulticastObservable<AuthenticatingInvitationObservable[]> {
+    return this._accepted;
+  }
+
+  async open() {
+    this._ctx = new Context();
+
+    const stream = this._invitationsService.queryInvitations();
+    stream.subscribe(({ added, removed }: QueryInvitationsResponse) => {
+      if (
+        added?.created &&
+        this._matchesInvitationContext(added.created) &&
+        !this._invitations.has(added.created.invitationId)
+      ) {
+        log('remote invitation created', { invitation: added.created });
+        this.createInvitation(added.created);
+      }
+
+      if (
+        added?.accepted &&
+        this._matchesInvitationContext(added.accepted) &&
+        !this._invitations.has(added.accepted.invitationId)
+      ) {
+        log('remote invitation accepted', { invitation: added.accepted });
+        this.acceptInvitation(added.accepted);
+      }
+
+      if (removed?.created) {
+        const index = this._created
+          .get()
+          .findIndex((invitation) => invitation.get().invitationId === removed.created?.invitationId);
+        void this._created.get()[index]?.cancel();
+        index >= 0 &&
+          this._createdUpdate.emit([...this._created.get().slice(0, index), ...this._created.get().slice(index + 1)]);
+      }
+
+      if (removed?.accepted) {
+        const index = this._accepted
+          .get()
+          .findIndex((invitation) => invitation.get().invitationId === removed.accepted?.invitationId);
+        void this._accepted.get()[index]?.cancel();
+        index >= 0 &&
+          this._acceptedUpdate.emit([
+            ...this._accepted.get().slice(0, index),
+            ...this._accepted.get().slice(index + 1)
+          ]);
+      }
+    });
+
+    this._ctx.onDispose(() => stream.close());
+  }
+
+  async close() {
+    await this._ctx.dispose();
+    this._createdUpdate.emit([]);
+    this._acceptedUpdate.emit([]);
+  }
 
   getInvitationOptions(): Invitation {
     return {
@@ -48,12 +120,19 @@ export class InvitationsProxy {
       authMethod: Invitation.AuthMethod.SHARED_SECRET,
       state: Invitation.State.INIT,
       swarmKey: PublicKey.random(),
-      ...this._getContext()
+      ...this._getInvitationContext()
     };
   }
 
   createInvitation(options?: Partial<Invitation>): CancellableInvitationObservable {
     const invitation: Invitation = { ...this.getInvitationOptions(), ...options };
+    this._invitations.add(invitation.invitationId);
+
+    const existing = this._created.get().find((created) => created.get().invitationId === invitation.invitationId);
+    if (existing) {
+      return existing;
+    }
+
     const observable = new CancellableInvitationObservable({
       initialInvitation: invitation,
       subscriber: createObservable(this._invitationsService.createInvitation(invitation)),
@@ -63,12 +142,20 @@ export class InvitationsProxy {
         await this._invitationsService.cancelInvitation({ invitationId });
       }
     });
+    this._createdUpdate.emit([...this._created.get(), observable]);
 
     return observable;
   }
 
   acceptInvitation(invitation: Invitation): AuthenticatingInvitationObservable {
     assert(invitation && invitation.swarmKey);
+    this._invitations.add(invitation.invitationId);
+
+    const existing = this._accepted.get().find((accepted) => accepted.get().invitationId === invitation.invitationId);
+    if (existing) {
+      return existing;
+    }
+
     const observable = new AuthenticatingInvitationObservable({
       initialInvitation: invitation,
       subscriber: createObservable(this._invitationsService.acceptInvitation({ ...invitation })),
@@ -83,7 +170,25 @@ export class InvitationsProxy {
         await this._invitationsService.authenticate({ invitationId, authCode });
       }
     });
+    this._acceptedUpdate.emit([...this._accepted.get(), observable]);
 
     return observable;
+  }
+
+  deleteInvitation(invitationId: string): Promise<void> {
+    return this._invitationsService.deleteInvitation({ invitationId });
+  }
+
+  private _matchesInvitationContext(invitation: Invitation): boolean {
+    const context = this._getInvitationContext();
+    log('checking invitation context', { invitation, context });
+    return Object.entries(context).reduce((acc, [key, value]) => {
+      const invitationValue = (invitation as any)[key];
+      if (invitationValue instanceof PublicKey && value instanceof PublicKey) {
+        return acc && invitationValue.equals(value);
+      } else {
+        return acc && invitationValue === value;
+      }
+    }, true);
   }
 }

--- a/packages/sdk/client/src/packlets/proxies/echo-proxy.ts
+++ b/packages/sdk/client/src/packlets/proxies/echo-proxy.ts
@@ -234,7 +234,6 @@ export class EchoProxy implements Echo {
   /**
    * Initiates an interactive accept invitation flow.
    */
-  // TODO(wittjosiah): Make idempotent.
   acceptInvitation(invitation: Invitation) {
     if (!this.opened) {
       throw new ApiError('Client not open.');
@@ -242,5 +241,17 @@ export class EchoProxy implements Echo {
 
     log('accept invitation', invitation);
     return this._invitationProxy!.acceptInvitation(invitation);
+  }
+
+  /**
+   * Removes accepted space invitation.
+   */
+  deleteInvitation(id: string) {
+    if (!this.opened) {
+      throw new ApiError('Client not open.');
+    }
+
+    log('remove invitation', { id });
+    return this._invitationProxy!.deleteInvitation(id);
   }
 }

--- a/packages/sdk/client/src/packlets/proxies/echo-proxy.ts
+++ b/packages/sdk/client/src/packlets/proxies/echo-proxy.ts
@@ -52,7 +52,6 @@ export class EchoProxy implements Echo {
   public readonly dbRouter = new DatabaseRouter();
 
   private _invitationProxy?: InvitationsProxy;
-  private _destroying = false; // TODO(burdon): Standardize enum.
   private readonly _instanceId = PublicKey.random().toHex();
   /**
    * @internal
@@ -112,6 +111,7 @@ export class EchoProxy implements Echo {
     this._invitationProxy = new InvitationsProxy(this._serviceProvider.services.InvitationsService, () => ({
       kind: Invitation.Kind.SPACE
     }));
+    await this._invitationProxy.open();
 
     // Subscribe to spaces and create proxies.
     const gotInitialUpdate = new Trigger();
@@ -165,6 +165,7 @@ export class EchoProxy implements Echo {
     this._spacesMap.clear();
     this._spacesChanged.emit([]);
 
+    await this._invitationProxy?.close();
     this._invitationProxy = undefined;
     log.trace('dxos.sdk.echo-proxy', trace.end({ id: this._instanceId }));
   }

--- a/packages/sdk/client/src/packlets/proxies/echo-proxy.ts
+++ b/packages/sdk/client/src/packlets/proxies/echo-proxy.ts
@@ -242,16 +242,4 @@ export class EchoProxy implements Echo {
     log('accept invitation', invitation);
     return this._invitationProxy!.acceptInvitation(invitation);
   }
-
-  /**
-   * Removes accepted space invitation.
-   */
-  deleteInvitation(id: string) {
-    if (!this.opened) {
-      throw new ApiError('Client not open.');
-    }
-
-    log('remove invitation', { id });
-    return this._invitationProxy!.deleteInvitation(id);
-  }
 }

--- a/packages/sdk/client/src/packlets/proxies/halo-proxy.ts
+++ b/packages/sdk/client/src/packlets/proxies/halo-proxy.ts
@@ -40,7 +40,6 @@ export interface Halo {
 
   createInvitation(): CancellableInvitationObservable;
   acceptInvitation(invitation: Invitation): AuthenticatingInvitationObservable;
-  deleteInvitation(id: string): void;
 }
 
 const THROW_TIMEOUT_ERROR_AFTER = 3000;
@@ -269,18 +268,6 @@ export class HaloProxy implements Halo {
 
     log('accept invitation', invitation);
     return this._invitationProxy!.acceptInvitation(invitation);
-  }
-
-  /**
-   * Removes device invitation.
-   */
-  deleteInvitation(id: string) {
-    if (!this.opened) {
-      throw new ApiError('Client not open.');
-    }
-
-    log('remove invitation', { id });
-    return this._invitationProxy!.deleteInvitation(id);
   }
 
   /**

--- a/packages/sdk/client/src/packlets/proxies/space-proxy.ts
+++ b/packages/sdk/client/src/packlets/proxies/space-proxy.ts
@@ -71,7 +71,6 @@ export interface Space {
   listen: (channel: string, callback: (message: GossipMessage) => void) => UnsubscribeCallback;
 
   createInvitation(options?: Partial<Invitation>): CancellableInvitationObservable;
-  deleteInvitation(id: string): void;
 
   createSnapshot(): Promise<SpaceSnapshot>;
 }
@@ -368,14 +367,6 @@ export class SpaceProxy implements Space {
   createInvitation(options?: Partial<Invitation>) {
     log('create invitation', options);
     return this._invitationProxy.createInvitation(options);
-  }
-
-  /**
-   * Remove invitation from space.
-   */
-  deleteInvitation(id: string) {
-    log('delete invitation', { id });
-    return this._invitationProxy.deleteInvitation(id);
   }
 
   /**

--- a/packages/sdk/client/src/packlets/proxies/space-proxy.ts
+++ b/packages/sdk/client/src/packlets/proxies/space-proxy.ts
@@ -71,7 +71,7 @@ export interface Space {
   listen: (channel: string, callback: (message: GossipMessage) => void) => UnsubscribeCallback;
 
   createInvitation(options?: Partial<Invitation>): CancellableInvitationObservable;
-  removeInvitation(id: string): void;
+  deleteInvitation(id: string): void;
 
   createSnapshot(): Promise<SpaceSnapshot>;
 }
@@ -110,7 +110,6 @@ export class SpaceProxy implements Space {
    */
   _initialized = false;
 
-  private readonly _invitationsUpdate = new Event<CancellableInvitationObservable[]>();
   private readonly _membersUpdate = new Event<SpaceMember[]>();
 
   private readonly _db!: EchoDatabase;
@@ -121,7 +120,6 @@ export class SpaceProxy implements Space {
 
   private readonly _state = MulticastObservable.from(this._stateUpdate, SpaceState.CLOSED);
   private readonly _pipeline = MulticastObservable.from(this._pipelineUpdate, {});
-  private readonly _invitations = MulticastObservable.from(this._invitationsUpdate, []);
   private readonly _members = MulticastObservable.from(this._membersUpdate, []);
 
   // TODO(dmaretskyi): Cache properties in the metadata.
@@ -210,7 +208,7 @@ export class SpaceProxy implements Space {
    * @inheritdoc
    */
   get invitations() {
-    return this._invitations;
+    return this._invitationProxy.created;
   }
 
   /**
@@ -266,6 +264,8 @@ export class SpaceProxy implements Space {
     // TODO(burdon): Does this need to be set before method completes?
     this._initializing = true;
 
+    await this._invitationProxy.open();
+
     await this._dbBackend!.open(this._itemManager!, this._modelFactory);
     log('ready');
     this._databaseInitialized.wake();
@@ -312,6 +312,7 @@ export class SpaceProxy implements Space {
   async _destroy() {
     log('destroying...');
     await this._ctx.dispose();
+    await this._invitationProxy.close();
     await this._dbBackend?.close();
     await this._itemManager?.destroy();
     log('destroyed');
@@ -366,21 +367,15 @@ export class SpaceProxy implements Space {
    */
   createInvitation(options?: Partial<Invitation>) {
     log('create invitation', options);
-    const invitation = this._invitationProxy.createInvitation(options);
-    this._invitationsUpdate.emit([...this._invitations.get(), invitation]);
-
-    return invitation;
+    return this._invitationProxy.createInvitation(options);
   }
 
   /**
    * Remove invitation from space.
    */
-  removeInvitation(id: string) {
-    log('remove invitation', { id });
-    const invitations = this._invitations.get();
-    const index = invitations.findIndex((invitation) => invitation.get().invitationId === id);
-    void invitations[index]?.cancel();
-    this._invitationsUpdate.emit([...invitations.slice(0, index), ...invitations.slice(index + 1)]);
+  deleteInvitation(id: string) {
+    log('delete invitation', { id });
+    return this._invitationProxy.deleteInvitation(id);
   }
 
   /**


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2098be4</samp>

### Summary
🗑️🔧📡

<!--
1.  🗑️ - This emoji represents the deletion of invitations and the removal of unused code.
2.  🔧 - This emoji represents the refactoring of the codebase to rename methods and improve logic.
3.  📡 - This emoji represents the addition of new RPCs and events to enable the client to subscribe to invitations changes.
-->
This pull request adds new features and fixes some bugs related to the management of invitations in the DXOS client. It introduces new RPCs and events to the `InvitationsService` protocol and implements them in the `invitations-service` and `invitations-proxy` classes. It also refactors the existing logic for creating, accepting, and querying invitations in the `echo-proxy`, `halo-proxy`, and `space-proxy` classes. It renames the `removeInvitation` method to `deleteInvitation` across the codebase to avoid confusion and align with the protocol definition. It updates the UI components in the `halo-app` and `patterns` packages to use the new `deleteInvitation` method and to handle the invitations changes.

> _`deleteInvitation`_
> _Refactoring invitations_
> _Spring cleaning the code_

### Walkthrough
*  Rename `removeInvitation` method to `deleteInvitation` in `Halo`, `Space`, and `DevicesPage` components ([link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-02daddd5f5a45d0feb9070ce22dafe151b7a892af3f9c6f630ee978bf9f0c266L26-R26), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-90bac4205e57c362428b22d8d8237e8b85e39b3f408b68821ac0ac01e018def1L55-R55), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-d90997a1f7cda10930b303e1c0cf1c6da0f51a5ad0325bf34ce05149ff953dcaL42-R43), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-c7c8293dd63e2f726cbe9f712c70f9aeb469a4598b1570026ec6e381ff0693dbL74-R74), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-4e65b8a5db2fec59de6dc4e5e5a586985deed0d2b4facac383bab4036d01e852L68-R68))
*  Add `deleteInvitation` method to `Client`, `EchoProxy`, `HaloProxy`, and `SpaceProxy` classes to delegate the deletion of an invitation to the `InvitationsProxy` class ([link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-702cccad0a49b2071d83df862eec7dbd2e7235377a2951e736ff9f15ece49f99R203-R209), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-ae11bb8e97270f09239f66ed109f614dde703cb4308abea3004b1e4492d3192eR245-R256), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-d90997a1f7cda10930b303e1c0cf1c6da0f51a5ad0325bf34ce05149ff953dcaR275-R286), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-c7c8293dd63e2f726cbe9f712c70f9aeb469a4598b1570026ec6e381ff0693dbL378-R378))
*  Add `deleteInvitation` and `queryInvitations` methods to `InvitationsServiceImpl` and `InvitationsProxy` classes to implement the new RPCs for deleting an invitation from the server side and subscribing to the changes in the invitations list ([link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-2a4dbb238c06bc6b25c60ddf0f5527492506263980a735eded1c7632643e4053L209-R167), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-395d9b9918d88a0f45b077954f8824c5d298dc118f7170c92a5b3c363f6b8821L86-R193))
*  Add `DeleteInvitationRequest`, `InvitationMethod`, and `QueryInvitationsResponse` messages to the `InvitationsService` protocol definition ([link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-1f246514dbba8145aea2c94eadcc3265b76da0f434106ef87e58db92bdaf5aa0L328-R350))
*  Refactor `createInvitation` and `acceptInvitation` methods in `InvitationsServiceImpl` and `InvitationsProxy` classes to check for existing invitations and avoid duplication ([link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-2a4dbb238c06bc6b25c60ddf0f5527492506263980a735eded1c7632643e4053L34-R60),  [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-395d9b9918d88a0f45b077954f8824c5d298dc118f7170c92a5b3c363f6b8821R129-R135), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-395d9b9918d88a0f45b077954f8824c5d298dc118f7170c92a5b3c363f6b8821R152-R158))
*  Remove unused `_destroying` field from `EchoProxy` class ([link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-ae11bb8e97270f09239f66ed109f614dde703cb4308abea3004b1e4492d3192eL55))
*  Remove unused `_invitationsUpdate` and `_invitations` fields from `HaloProxy` and `SpaceProxy` classes and use `_invitationProxy.created` observable instead ([link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-d90997a1f7cda10930b303e1c0cf1c6da0f51a5ad0325bf34ce05149ff953dcaL52), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-d90997a1f7cda10930b303e1c0cf1c6da0f51a5ad0325bf34ce05149ff953dcaL60), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-d90997a1f7cda10930b303e1c0cf1c6da0f51a5ad0325bf34ce05149ff953dcaL105-R104), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-c7c8293dd63e2f726cbe9f712c70f9aeb469a4598b1570026ec6e381ff0693dbL113), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-c7c8293dd63e2f726cbe9f712c70f9aeb469a4598b1570026ec6e381ff0693dbL124), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-c7c8293dd63e2f726cbe9f712c70f9aeb469a4598b1570026ec6e381ff0693dbL213-R211))
*  Remove `resetInvitation` action from `joinMachine` state machine and replace it with `resetHaloInvitation` and `resetSpaceInvitation` actions that also delete the invitation from the server side ([link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-d25853855adbe8df22739a1c04b2649ad121bd86fe2df5f69bc5d4a9be36c35fL324-L343), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-d25853855adbe8df22739a1c04b2649ad121bd86fe2df5f69bc5d4a9be36c35fR398-R438), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-d25853855adbe8df22739a1c04b2649ad121bd86fe2df5f69bc5d4a9be36c35fL422-R448))
*  Update `handleRemove` function in `ManageSpacePage` and `InvitationListContainer` components to use `deleteInvitation` method ([link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-0eeb548092be3a065971063e8f7a60ea6af5c53fe1c05cfd8cc72bd03cb0256eL51-R51), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-5beffd5f1635b274002ca50aa700d9e262b19e479491f063afddc108c8889ff5L23-R23))
*  Fix bug in `createInvitation` and `acceptInvitation` methods in `InvitationsServiceImpl` class by moving the `return` statement outside the `observable.subscribe` callback ([link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-2a4dbb238c06bc6b25c60ddf0f5527492506263980a735eded1c7632643e4053L99-R88), [link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-2a4dbb238c06bc6b25c60ddf0f5527492506263980a735eded1c7632643e4053L177-L187))
*  Remove `TODO` comment from `EchoProxy` class as it is not relevant anymore ([link](https://github.com/dxos/dxos/pull/2939/files?diff=unified&w=0#diff-ae11bb8e97270f09239f66ed109f614dde703cb4308abea3004b1e4492d3192eL236))


