### PR TITLE
fix(react-appkit): client fallback pending state

### DIFF
--- a/packages/apps/patterns/react-appkit/src/components/Fallback/Fallback.tsx
+++ b/packages/apps/patterns/react-appkit/src/components/Fallback/Fallback.tsx
@@ -31,7 +31,7 @@ export const GenericFallback = () => {
  */
 export const ClientFallback = ({ client, status }: Partial<ClientContextProps>) => {
   const { t } = useTranslation('appkit');
-  const [pending, setPending] = useState(true);
+  const [pending, setPending] = useState(false);
 
   // Set timeout to prevent flickering.
   // TODO(burdon): Wait 200ms before showing then display for at least 500ms if it is then displayed.


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 21c1fe7</samp>

### Summary
🔄🚫🚀

<!--
1.  🔄 This emoji conveys the idea of changing or updating something, which is what the `pending` state does. It also suggests a circular motion, which could be associated with a loading spinner.
2.  🚫 This emoji implies stopping or preventing something, which is what the default `false` value does for the `pending` state. It also indicates a negative or undesirable outcome, which is how the user might perceive the loading spinner before the client is initialized.
3.  🚀 This emoji expresses speed or acceleration, which is what the improved user experience and reduced rendering aim for. It also implies launching or starting something, which is what the client initialization does.
-->
Improved the `ClientFallback` component to avoid showing a loading spinner by default. This component is used in `react-appkit` to handle the client initialization process.

> _No spinner at first_
> _`ClientFallback` waits a bit_
> _Winter patience grows_

### Walkthrough
* Change the default `pending` state of `ClientFallback` to `false` to avoid showing a loading spinner before the client is initialized ([link](https://github.com/dxos/dxos/pull/2942/files?diff=unified&w=0#diff-39f3d8c9a4f92d69a3e0c7ad8ebfd49dff4ace4289bf2e9ea414147dd3cae7a7L34-R34)).


