### PR TITLE
fix(ras): Fix storage fall back in browser

### DIFF
--- a/packages/common/random-access-storage/package.json
+++ b/packages/common/random-access-storage/package.json
@@ -23,6 +23,7 @@
     "@dxos/node-std": "workspace:*",
     "@dxos/util": "workspace:*",
     "del": "^5.1.0",
+    "detect-browser": "^5.3.0",
     "pify": "~5.0.0",
     "random-access-file": "^2.2.1",
     "random-access-idb": "^1.2.2",

--- a/packages/common/random-access-storage/src/browser/storage.ts
+++ b/packages/common/random-access-storage/src/browser/storage.ts
@@ -2,22 +2,24 @@
 // Copyright 2021 DXOS.org
 //
 
+import { detect } from 'detect-browser';
+
 import { MemoryStorage, Storage, StorageConstructor, StorageType } from '../common';
 import { FirefoxStorage } from './firefox-storage';
 import { IDbStorage } from './idb-storage';
 import { WebFS } from './web-fs';
 
 export const createStorage: StorageConstructor = ({ type, root = '' } = {}): Storage => {
-  let insideWebkit: boolean;
-  try {
-    insideWebkit = mochaExecutor.environment === 'webkit';
-  } catch (e) {
-    insideWebkit = false;
-  }
+  const browser = detect();
 
   if (type === undefined) {
-    if (navigator && navigator.storage && typeof navigator.storage.getDirectory === 'function' && !insideWebkit) {
-      // WEBFS is not supported in webkit test environment but it passes check for navigator.storage.getDirectory.
+    if (
+      navigator &&
+      navigator.storage &&
+      typeof navigator.storage.getDirectory === 'function' &&
+      browser &&
+      (browser?.name === 'chrome' || browser?.name === 'chromium-webview' || browser?.name === 'edge-chromium')
+    ) {
       return new WebFS(root);
     } else {
       return new IDbStorage(root);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1452,6 +1452,7 @@ importers:
       '@types/pify': ^3.0.2
       '@types/randombytes': ^2.0.0
       del: ^5.1.0
+      detect-browser: ^5.3.0
       pify: ~5.0.0
       random-access-file: ^2.2.1
       random-access-idb: ^1.2.2
@@ -1467,6 +1468,7 @@ importers:
       '@dxos/node-std': link:../node-std
       '@dxos/util': link:../util
       del: 5.1.0
+      detect-browser: 5.3.0
       pify: 5.0.0
       random-access-file: 2.2.1
       random-access-idb: 1.2.2
@@ -15884,7 +15886,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.20.12
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.2.0_@types+node@18.11.9
+      vite: 4.2.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -20832,6 +20834,10 @@ packages:
   /destroy/1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  /detect-browser/5.3.0:
+    resolution: {integrity: sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==}
+    dev: false
 
   /detect-indent/6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -36916,7 +36922,7 @@ packages:
       fast-glob: 3.2.12
       pretty-bytes: 6.0.0
       rollup: 3.9.1
-      vite: 4.2.0_@types+node@18.11.9
+      vite: 4.2.0
       workbox-build: 6.5.4
       workbox-window: 6.5.4
     transitivePeerDependencies:


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cb58e0d</samp>

### Summary
:sparkles::package::globe_with_meridians:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, which is the browser detection functionality and the WebFS storage option.
2.  :package: This emoji represents the addition of a new dependency or library, which is the `detect-browser` package.
3.  :globe_with_meridians: This emoji represents the improvement of cross-browser or cross-platform compatibility, which is the goal of the storage module update.
-->
The `random-access-storage` package was enhanced to support WebFS storage for browsers that support it, using the `detect-browser` library. This allows the package to use more efficient and persistent storage mechanisms in the browser.

> _`detect-browser`_
> _a new dependency_
> _for the storage module_

### Walkthrough
*  Add `detect-browser` dependency to support browser detection in storage module ([link](https://github.com/dxos/dxos/pull/2943/files?diff=unified&w=0#diff-7b65ef4c2a78e17dfdc3747a8e4eafabdac32c7be908a8f183f7e1c8e6e553d0R26)).


