### PR TITLE
fix: Composer presence themeMode

### DIFF
--- a/packages/apps/patterns/react-composer/src/components/Markdown/Markdown.tsx
+++ b/packages/apps/patterns/react-composer/src/components/Markdown/Markdown.tsx
@@ -106,7 +106,7 @@ export const MarkdownComposer = forwardRef<MarkdownComposerRef, MarkdownComposer
             ]
         });
       }
-    }, [provider, peer]);
+    }, [provider, peer, themeMode]);
 
     useEffect(() => {
       if (!parent) {
@@ -170,7 +170,7 @@ export const MarkdownComposer = forwardRef<MarkdownComposerRef, MarkdownComposer
           setState(undefined);
         }
       };
-    }, [parent, content, provider?.awareness]);
+    }, [parent, content, provider?.awareness, themeMode]);
 
     return <div key={id} {...slots.root} ref={setParent} />;
   }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9b93802</samp>

### Summary
🌗🔄📝

<!--
1.  🌗 - This emoji represents the theme mode, which can be toggled between light and dark modes.
2.  🔄 - This emoji represents the synchronization or updating of the content and the awareness state based on the theme mode change.
3.  📝 - This emoji represents the Markdown component and the Yjs document that are being edited collaboratively.
-->
Improved theme mode synchronization for Markdown component. Fixed a bug where `themeMode` changes were not reflected in the Yjs document and the awareness state by adding it as a dependency to `useEffect` hooks in `Markdown.tsx`.

> _`themeMode` is the key to our fate_
> _We sync the content and the state_
> _No matter if it's dark or light_
> _We share the Markdown of the night_

### Walkthrough
*  Add `themeMode` dependency to `useEffect` hooks in `Markdown.tsx` ([link](https://github.com/dxos/dxos/pull/2948/files?diff=unified&w=0#diff-30d367683db06f5bd67ed369f5166f50c37a022f106c59ba4eef23a6a7e71eebL109-R109), [link](https://github.com/dxos/dxos/pull/2948/files?diff=unified&w=0#diff-30d367683db06f5bd67ed369f5166f50c37a022f106c59ba4eef23a6a7e71eebL173-R173))


