### PR TITLE
fix(composer-app): Restore Composer e2e tests

### DIFF
--- a/packages/apps/composer-app/src/playwright/basic.spec.ts
+++ b/packages/apps/composer-app/src/playwright/basic.spec.ts
@@ -8,7 +8,7 @@ import waitForExpect from 'wait-for-expect';
 
 import { AppManager } from './app-manager';
 
-test.describe.skip('Basic test', () => {
+test.describe('Basic test', () => {
   let host: AppManager;
   let guest: AppManager;
 
@@ -26,7 +26,7 @@ test.describe.skip('Basic test', () => {
     }
   });
 
-  test.describe.skip('Solo tests', () => {
+  test.describe('Solo tests', () => {
     test('create identity, space is created by default', async () => {
       await host.shell.createIdentity('host');
       await waitForExpect(async () => {
@@ -55,7 +55,7 @@ test.describe.skip('Basic test', () => {
     });
   });
 
-  test.describe.skip('Collab tests', () => {
+  test.describe('Collab tests', () => {
     test('guest joins host’s space', async ({ browserName }) => {
       if (browserName !== 'chromium') {
         return;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 65e6d7f</samp>

### Summary
🚀🧪🤝

<!--
1.  🚀 This emoji conveys the idea of launching or enabling something new, such as the test suites for the composer-app. It also suggests a sense of speed and excitement, as the app can now be tested more thoroughly and reliably.
2.  🧪 This emoji represents the concept of testing, experimentation, or science. It can be used to indicate that the changes involve adding or improving tests for the app, or that the app is being tested in different environments or modes.
3.  🤝 This emoji signifies the idea of collaboration, partnership, or teamwork. It can be used to highlight that the changes enable testing the app's functionality in collab mode, where multiple users can work together on the same project. It also suggests a sense of cooperation and support among the developers and testers.
-->
Enabled playwright test suites for `composer-app` to test app functionality in CI. Removed `test.describe.skip` method from `basic.spec.ts`.

> _No more silence, no more hiding, unleash the tests of doom_
> _`composer-app` must face the trials, in solo and in collab mode_
> _The scenarios are endless, the challenges are fierce_
> _But we will not surrender, we will code and we will pierce_

### Walkthrough
*  Enable basic, solo, and collab test suites for the composer app by replacing `test.describe.skip` with `test.describe` in `basic.spec.ts` ([link](https://github.com/dxos/dxos/pull/2949/files?diff=unified&w=0#diff-615a8fa2d770170d158b9feb2bfbaaf0d2ef698d8c702b6293817a8b406a0708L11-R11), [link](https://github.com/dxos/dxos/pull/2949/files?diff=unified&w=0#diff-615a8fa2d770170d158b9feb2bfbaaf0d2ef698d8c702b6293817a8b406a0708L29-R29), [link](https://github.com/dxos/dxos/pull/2949/files?diff=unified&w=0#diff-615a8fa2d770170d158b9feb2bfbaaf0d2ef698d8c702b6293817a8b406a0708L58-R58))


