### PR TITLE
fix: Metadata corruption 

### DIFF
--- a/packages/core/echo/echo-pipeline/package.json
+++ b/packages/core/echo/echo-pipeline/package.json
@@ -27,6 +27,7 @@
     "@dxos/debug": "workspace:*",
     "@dxos/document-model": "workspace:*",
     "@dxos/echo-db": "workspace:*",
+    "@dxos/errors": "workspace:*",
     "@dxos/feed-store": "workspace:*",
     "@dxos/hypercore": "workspace:*",
     "@dxos/keyring": "workspace:*",
@@ -46,6 +47,7 @@
     "@dxos/timeframe": "workspace:*",
     "@dxos/typings": "workspace:*",
     "@dxos/util": "workspace:*",
+    "crc-32": "^1.2.2",
     "debug": "^4.3.3"
   },
   "devDependencies": {

--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -2,17 +2,17 @@
 // Copyright 2021 DXOS.org
 //
 
+import CRC32 from 'crc-32';
 import assert from 'node:assert';
 
 import { synchronized } from '@dxos/async';
+import { DataCorruptionError } from '@dxos/errors';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { schema } from '@dxos/protocols';
-import { DataCorruptionError } from '@dxos/errors'
 import { EchoMetadata, SpaceMetadata, IdentityRecord } from '@dxos/protocols/proto/dxos/echo/metadata';
 import { Directory } from '@dxos/random-access-storage';
 import { Timeframe } from '@dxos/timeframe';
-import CRC32 from 'crc-32'
 
 /**
  * Version for the schema of the stored data as defined in dxos.echo.metadata.EchoMetadata.
@@ -73,7 +73,6 @@ export class MetadataStore {
         throw new DataCorruptionError('Metadata size is smaller than expected.');
       }
 
-
       const data = await file.read(8, dataSize);
 
       const calculatedChecksum = CRC32.buf(data);
@@ -106,13 +105,13 @@ export class MetadataStore {
       const checksum = CRC32.buf(encoded);
 
       const result = Buffer.alloc(8 + encoded.length);
-      
+
       result.writeInt32LE(encoded.length, 0);
       result.writeInt32LE(checksum, 4);
       encoded.copy(result, 8);
 
       // NOTE: This must be done in one write operation, otherwise the file can be corrupted.
-      await file.write(0, result)
+      await file.write(0, result);
 
       log('saved', { size: encoded.length, checksum });
     } finally {

--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -8,9 +8,11 @@ import { synchronized } from '@dxos/async';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { schema } from '@dxos/protocols';
+import { DataCorruptionError } from '@dxos/errors'
 import { EchoMetadata, SpaceMetadata, IdentityRecord } from '@dxos/protocols/proto/dxos/echo/metadata';
 import { Directory } from '@dxos/random-access-storage';
 import { Timeframe } from '@dxos/timeframe';
+import CRC32 from 'crc-32'
 
 /**
  * Version for the schema of the stored data as defined in dxos.echo.metadata.EchoMetadata.
@@ -59,21 +61,26 @@ export class MetadataStore {
     const file = this._directory.getOrCreateFile('EchoMetadata');
     try {
       const { size: fileLength } = await file.stat();
-      if (fileLength < 4) {
+      if (fileLength < 8) {
         return;
       }
       // Loading file size from first 4 bytes.
       const dataSize = fromBytesInt32(await file.read(0, 4));
-      log('loaded', { size: dataSize });
+      const checksum = fromBytesInt32(await file.read(4, 4));
+      log('loaded', { size: dataSize, checksum });
 
-      // Sanity check.
-      {
-        if (fileLength < dataSize + 4) {
-          throw new Error('Metadata storage is corrupted');
-        }
+      if (fileLength < dataSize + 8) {
+        throw new DataCorruptionError('Metadata size is smaller than expected.');
       }
 
-      const data = await file.read(4, dataSize);
+
+      const data = await file.read(8, dataSize);
+
+      const calculatedChecksum = CRC32.buf(data);
+      if (calculatedChecksum !== checksum) {
+        throw new DataCorruptionError('Metadata checksum is invalid.');
+      }
+
       this._metadata = schema.getCodecForType('dxos.echo.metadata.EchoMetadata').decode(data);
     } catch (err: any) {
       log.error('failed to load metadata', { err });
@@ -96,13 +103,16 @@ export class MetadataStore {
 
     try {
       const encoded = Buffer.from(schema.getCodecForType('dxos.echo.metadata.EchoMetadata').encode(data));
+      const checksum = CRC32.buf(encoded);
 
       // Saving file size at first 4 bytes.
       await file.write(0, toBytesInt32(encoded.length));
-      log('saved', { size: encoded.length });
-
+      // Saving checksum at 4th byte.
+      await file.write(4, toBytesInt32(checksum));
       // Saving data.
-      await file.write(4, encoded);
+      await file.write(8, encoded);
+
+      log('saved', { size: encoded.length, checksum });
     } finally {
       await file.close();
     }

--- a/packages/core/echo/echo-pipeline/tsconfig.json
+++ b/packages/core/echo/echo-pipeline/tsconfig.json
@@ -55,6 +55,9 @@
       "path": "../../../common/util"
     },
     {
+      "path": "../../../sdk/errors"
+    },
+    {
       "path": "../../halo/credentials"
     },
     {

--- a/packages/sdk/errors/src/errors.ts
+++ b/packages/sdk/errors/src/errors.ts
@@ -43,3 +43,9 @@ export class RemoteServiceConnectionTimeout extends ApiError {
     super('REMOTE_SERVICE_CONNECTION_TIMEOUT', message, context);
   }
 }
+
+export class DataCorruptionError extends SystemError {
+  constructor(message?: string, context?: any) {
+    super('DATA_CORRUPTION', message, context);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1766,6 +1766,7 @@ importers:
       '@dxos/debug': workspace:*
       '@dxos/document-model': workspace:*
       '@dxos/echo-db': workspace:*
+      '@dxos/errors': workspace:*
       '@dxos/feed-store': workspace:*
       '@dxos/hypercore': workspace:*
       '@dxos/keyring': workspace:*
@@ -1787,6 +1788,7 @@ importers:
       '@dxos/typings': workspace:*
       '@dxos/util': workspace:*
       '@types/debug': ^4.1.7
+      crc-32: ^1.2.2
       debug: ^4.3.3
       fast-check: ~3.3.0
       hypercore-protocol: ^8.0.7
@@ -1801,6 +1803,7 @@ importers:
       '@dxos/debug': link:../../../common/debug
       '@dxos/document-model': link:../document-model
       '@dxos/echo-db': link:../echo-db
+      '@dxos/errors': link:../../../sdk/errors
       '@dxos/feed-store': link:../../../common/feed-store
       '@dxos/hypercore': link:../../../common/hypercore
       '@dxos/keyring': link:../../halo/keyring
@@ -1820,6 +1823,7 @@ importers:
       '@dxos/timeframe': link:../../../common/timeframe
       '@dxos/typings': link:../../../common/typings
       '@dxos/util': link:../../../common/util
+      crc-32: 1.2.2
       debug: 4.3.4
     devDependencies:
       '@dxos/text-model': link:../text-model
@@ -19703,6 +19707,12 @@ packages:
 
   /count-trailing-zeros/1.0.1:
     resolution: {integrity: sha512-ZnX7MMZDpu7R1aMwQRe0P1RGvfnXHibhTE+Oe/BHOCAZ/Mrp0Nv8VwaZ3G5cfFHMl5RrZ9s3HxnYoaVNB2gzgA==}
+    dev: false
+
+  /crc-32/1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
     dev: false
 
   /crc/3.8.0:


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b70edbd</samp>

### Summary
🛠️🚨🧮

<!--
1.  🛠️ for adding a path mapping for the `@dxos/errors` package, which is a configuration change.
2.  🚨 for adding the `DataCorruptionError` class, which is a new error type.
3.  🧮 for adding checksum verification to the echo metadata file storage, which is a data-related change.
-->
This pull request enhances the data integrity and error handling of the `echo-pipeline` package by adding checksum verification to the metadata file storage. It also adds the `DataCorruptionError` class to the `@dxos/errors` package and configures the TypeScript compiler to import it as a workspace dependency.

> _We'll store our data with a checksum_
> _To catch corruption on the run_
> _Heave away, me hearties, heave away_
> _We'll use the `DataCorruptionError` if something goes astray_

### Walkthrough
*  Add and use custom error class for data corruption scenarios ([link](https://github.com/dxos/dxos/pull/2951/files?diff=unified&w=0#diff-35dcf69161c70a31b71ee5e07cf1947fbfb5b7a67e965234c21a0048d6200456R30), [link](https://github.com/dxos/dxos/pull/2951/files?diff=unified&w=0#diff-ad1c28ba5710e2ea59c29b77568da4f157118487250877e42876eca69494a42cL5-R9), [link](https://github.com/dxos/dxos/pull/2951/files?diff=unified&w=0#diff-ad1c28ba5710e2ea59c29b77568da4f157118487250877e42876eca69494a42cL62-R82), [link](https://github.com/dxos/dxos/pull/2951/files?diff=unified&w=0#diff-d30e0f9503f6e5118fb4693a103a9a8aa94206ef00da9397208a22329b31b7ddR46-R51))
* Add and use checksum verification for metadata file ([link](https://github.com/dxos/dxos/pull/2951/files?diff=unified&w=0#diff-35dcf69161c70a31b71ee5e07cf1947fbfb5b7a67e965234c21a0048d6200456R50), [link](https://github.com/dxos/dxos/pull/2951/files?diff=unified&w=0#diff-ad1c28ba5710e2ea59c29b77568da4f157118487250877e42876eca69494a42cL5-R9), [link](https://github.com/dxos/dxos/pull/2951/files?diff=unified&w=0#diff-ad1c28ba5710e2ea59c29b77568da4f157118487250877e42876eca69494a42cL62-R82), [link](https://github.com/dxos/dxos/pull/2951/files?diff=unified&w=0#diff-ad1c28ba5710e2ea59c29b77568da4f157118487250877e42876eca69494a42cL99-R116))
* Remove unused function `toBytesInt32` from `metadata-store.ts` ([link](https://github.com/dxos/dxos/pull/2951/files?diff=unified&w=0#diff-ad1c28ba5710e2ea59c29b77568da4f157118487250877e42876eca69494a42cL165-L171))


