### PR TITLE
fix: Race conditions in the data pipeline

### DIFF
--- a/packages/core/echo/echo-pipeline/src/pipeline/pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/pipeline/pipeline.ts
@@ -70,6 +70,10 @@ export class PipelineState {
     return this._timeframeClock.timeframe;
   }
 
+  get pendingTimeframe() {
+    return this._timeframeClock.pendingTimeframe;
+  }
+
   get targetTimeframe() {
     return this._targetTimeframe ? this._targetTimeframe : new Timeframe();
   }
@@ -265,10 +269,11 @@ export class Pipeline implements PipelineAccessor {
 
     for await (const block of this._feedSetIterator) {
       this._processingTrigger.reset();
+      this._timeframeClock.updatePendingTimeframe(PublicKey.from(block.feedKey), block.seq);
       yield block;
       this._processingTrigger.wake();
 
-      this._timeframeClock.updateTimeframe(PublicKey.from(block.feedKey), block.seq);
+      this._timeframeClock.updateTimeframe();
     }
 
     // TODO(burdon): Test re-entrant?

--- a/packages/core/echo/echo-pipeline/src/pipeline/timeframe-clock.ts
+++ b/packages/core/echo/echo-pipeline/src/pipeline/timeframe-clock.ts
@@ -24,17 +24,36 @@ export const startAfter = (timeframe: Timeframe): FeedIndex[] =>
 export class TimeframeClock {
   readonly update = new Event<Timeframe>();
 
+  private _pendingTimeframe: Timeframe;
+
   // prettier-ignore
   constructor(
     private _timeframe = new Timeframe()
-  ) {}
+  ) {
+    this._pendingTimeframe = _timeframe;
+  }
 
+  /**
+   * Timeframe that was processed by ECHO.
+   */
   get timeframe() {
     return this._timeframe;
   }
 
-  updateTimeframe(key: PublicKey, seq: number) {
-    this._timeframe = Timeframe.merge(this._timeframe, new Timeframe([[key, seq]]));
+  /**
+   * Timeframe that is currently being processed by ECHO.
+   * Will be equal to `timeframe` after the processing is complete.
+   */
+  get pendingTimeframe() {
+    return this._pendingTimeframe;
+  }
+
+  updatePendingTimeframe(key: PublicKey, seq: number) {
+    this._pendingTimeframe = Timeframe.merge(this._pendingTimeframe, new Timeframe([[key, seq]]));
+  }
+
+  updateTimeframe() {
+    this._timeframe = this._pendingTimeframe;
     this.update.emit(this._timeframe);
   }
 

--- a/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
@@ -144,7 +144,7 @@ export class DataPipeline {
     }
     log('close');
     this._isOpen = false;
-    
+
     await this._ctx.dispose();
     await this._pipeline?.stop();
 
@@ -159,7 +159,7 @@ export class DataPipeline {
     } catch (err) {
       log.catch(err);
     }
-    
+
     await this.databaseBackend?.close();
     await this._itemManager?.destroy();
     await this._params.snapshotManager.close();

--- a/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
@@ -4,7 +4,7 @@
 
 import assert from 'node:assert';
 
-import { Event, scheduleTask, synchronized, trackLeaks } from '@dxos/async';
+import { scheduleTask, synchronized, trackLeaks } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { FeedInfo } from '@dxos/credentials';
 import { failUndefined } from '@dxos/debug';
@@ -74,7 +74,7 @@ export class DataPipeline {
   private _lastTimeframeSaveTime = 0;
   private _lastSnapshotSaveTime = 0;
 
-  constructor(private readonly _params: DataPipelineParams) { }
+  constructor(private readonly _params: DataPipelineParams) {}
 
   public _itemManager!: ItemManager;
   public databaseBackend?: DatabaseHost;
@@ -147,7 +147,7 @@ export class DataPipeline {
 
     try {
       if (this._pipeline) {
-        await this._saveTargetTimeframe(this._pipeline.state.timeframe)
+        await this._saveTargetTimeframe(this._pipeline.state.timeframe);
         if (!DISABLE_SNAPSHOT_CACHE) {
           await this._saveSnapshot(this._pipeline.state.timeframe);
         }
@@ -161,7 +161,6 @@ export class DataPipeline {
     await this._itemManager?.destroy();
     await this._params.snapshotManager.close();
   }
-
 
   private async _consumePipeline() {
     assert(this._pipeline, 'Pipeline is not initialized.');
@@ -237,8 +236,6 @@ export class DataPipeline {
       log('save', { snapshot });
     }
   }
-
-
 
   async waitUntilTimeframe(timeframe: Timeframe) {
     assert(this._pipeline, 'Pipeline is not initialized.');

--- a/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
@@ -144,7 +144,11 @@ export class DataPipeline {
     }
     log('close');
     this._isOpen = false;
+    
+    await this._ctx.dispose();
+    await this._pipeline?.stop();
 
+    // NOTE: Make sure the processing is stopped BEFORE we save the snapshot.
     try {
       if (this._pipeline) {
         await this._saveTargetTimeframe(this._pipeline.state.timeframe);
@@ -155,8 +159,7 @@ export class DataPipeline {
     } catch (err) {
       log.catch(err);
     }
-    await this._ctx.dispose();
-    await this._pipeline?.stop();
+    
     await this.databaseBackend?.close();
     await this._itemManager?.destroy();
     await this._params.snapshotManager.close();

--- a/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
@@ -46,7 +46,7 @@ const MESSAGES_PER_SNAPSHOT = 10;
 const AUTOMATIC_SNAPSHOT_DEBOUNCE_INTERVAL = 5000;
 
 /**
- * Minimum time between recording latest timeframe in metadata.
+ * Minimum time in MS between recording latest timeframe in metadata.
  */
 const TIMEFRAME_SAVE_DEBOUNCE_INTERVAL = 500;
 
@@ -71,9 +71,10 @@ export class DataPipeline {
   private _lastAutomaticSnapshotTimeframe = new Timeframe();
   private _isOpen = false;
 
-  public readonly onTimeframeReached = new Event<Timeframe>();
+  private _lastTimeframeSaveTime = 0;
+  private _lastSnapshotSaveTime = 0;
 
-  constructor(private readonly _params: DataPipelineParams) {}
+  constructor(private readonly _params: DataPipelineParams) { }
 
   public _itemManager!: ItemManager;
   public databaseBackend?: DatabaseHost;
@@ -133,51 +134,7 @@ export class DataPipeline {
       await this._consumePipeline();
     });
 
-    this._createPeriodicSnapshots();
-
     this._isOpen = true;
-  }
-
-  private _createPeriodicSnapshots() {
-    // Record last timeframe.
-    this.onTimeframeReached.debounce(TIMEFRAME_SAVE_DEBOUNCE_INTERVAL).on(this._ctx, async () => {
-      await this._saveLatestTimeframe();
-    });
-
-    if (!DISABLE_SNAPSHOT_CACHE) {
-      this.onTimeframeReached.debounce(AUTOMATIC_SNAPSHOT_DEBOUNCE_INTERVAL).on(this._ctx, async () => {
-        const latestTimeframe = this._pipeline?.state.timeframe;
-        if (!latestTimeframe) {
-          return;
-        }
-
-        // Save snapshot.
-        if (
-          latestTimeframe.totalMessages() - this._lastAutomaticSnapshotTimeframe.totalMessages() >
-          MESSAGES_PER_SNAPSHOT
-        ) {
-          const snapshot = await this._saveSnapshot();
-          this._lastAutomaticSnapshotTimeframe = snapshot.timeframe ?? failUndefined();
-          log('save', { snapshot });
-        }
-      });
-    }
-  }
-
-  private async _saveSnapshot() {
-    const snapshot = await this.createSnapshot();
-    const snapshotKey = await this._params.snapshotManager.store(snapshot);
-    await this._params.metadataStore.setSpaceSnapshot(this._params.spaceKey, snapshotKey);
-    return snapshot;
-  }
-
-  private async _saveLatestTimeframe() {
-    const latestTimeframe = this._pipeline?.state.timeframe;
-    log('save latest timeframe', { latestTimeframe, spaceKey: this._params.spaceKey });
-    if (latestTimeframe) {
-      const newTimeframe = Timeframe.merge(this._targetTimeframe ?? new Timeframe(), latestTimeframe);
-      await this._params.metadataStore.setSpaceLatestTimeframe(this._params.spaceKey, newTimeframe);
-    }
   }
 
   @synchronized
@@ -189,8 +146,12 @@ export class DataPipeline {
     this._isOpen = false;
 
     try {
-      await this._saveLatestTimeframe();
-      await this._saveSnapshot();
+      if (this._pipeline) {
+        await this._saveTargetTimeframe(this._pipeline.state.timeframe)
+        if (!DISABLE_SNAPSHOT_CACHE) {
+          await this._saveSnapshot(this._pipeline.state.timeframe);
+        }
+      }
     } catch (err) {
       log.catch(err);
     }
@@ -201,14 +162,6 @@ export class DataPipeline {
     await this._params.snapshotManager.close();
   }
 
-  createSnapshot(): SpaceSnapshot {
-    assert(this.databaseBackend, 'Database backend is not initialized.');
-    return {
-      spaceKey: this._params.spaceKey.asUint8Array(),
-      timeframe: this._pipeline?.state.timeframe ?? new Timeframe(),
-      database: this.databaseBackend!.createSnapshot()
-    };
-  }
 
   private async _consumePipeline() {
     assert(this._pipeline, 'Pipeline is not initialized.');
@@ -233,13 +186,59 @@ export class DataPipeline {
               memberKey: feedInfo.assertion.identityKey
             }
           });
-          this.onTimeframeReached.emit(data.timeframe);
+
+          // Timeframe clock is not updated yet
+          await this._noteTargetStateIfNeeded(this._pipeline.state.pendingTimeframe);
         }
       } catch (err: any) {
         log.catch(err);
       }
     }
   }
+
+  private _createSnapshot(timeframe: Timeframe): SpaceSnapshot {
+    assert(this.databaseBackend, 'Database backend is not initialized.');
+    return {
+      spaceKey: this._params.spaceKey.asUint8Array(),
+      timeframe,
+      database: this.databaseBackend!.createSnapshot()
+    };
+  }
+
+  private async _saveSnapshot(timeframe: Timeframe) {
+    const snapshot = await this._createSnapshot(timeframe);
+    const snapshotKey = await this._params.snapshotManager.store(snapshot);
+    await this._params.metadataStore.setSpaceSnapshot(this._params.spaceKey, snapshotKey);
+    return snapshot;
+  }
+
+  private async _saveTargetTimeframe(timeframe: Timeframe) {
+    const newTimeframe = Timeframe.merge(this._targetTimeframe ?? new Timeframe(), timeframe);
+    await this._params.metadataStore.setSpaceLatestTimeframe(this._params.spaceKey, newTimeframe);
+    this._targetTimeframe = newTimeframe;
+  }
+
+  private async _noteTargetStateIfNeeded(timeframe: Timeframe) {
+    if (Date.now() - this._lastTimeframeSaveTime > TIMEFRAME_SAVE_DEBOUNCE_INTERVAL) {
+      this._lastTimeframeSaveTime = Date.now();
+
+      await this._saveTargetTimeframe(timeframe);
+    }
+
+    if (
+      !DISABLE_SNAPSHOT_CACHE &&
+      Date.now() - this._lastSnapshotSaveTime > AUTOMATIC_SNAPSHOT_DEBOUNCE_INTERVAL &&
+      timeframe.totalMessages() - this._lastAutomaticSnapshotTimeframe.totalMessages() > MESSAGES_PER_SNAPSHOT
+    ) {
+      this._lastSnapshotSaveTime = Date.now();
+
+      const snapshot = await this._saveSnapshot(timeframe);
+      this._lastAutomaticSnapshotTimeframe = snapshot.timeframe ?? failUndefined();
+      log('save', { snapshot });
+    }
+  }
+
+
 
   async waitUntilTimeframe(timeframe: Timeframe) {
     assert(this._pipeline, 'Pipeline is not initialized.');


### PR DESCRIPTION
closes [#2953](https://github.com/dxos/dxos/issues/2953)
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at df1851a</samp>

### Summary
🕒🔄💾

<!--
1.  🕒 - This emoji represents the `TimeframeClock` class and the concept of timeframes in general. It also conveys the idea of updating and synchronizing the timeframes with the data pipeline.
2.  🔄 - This emoji represents the logic for setting and emitting the `timeframe` of the pipeline, and the idea of data synchronization and progress reporting. It also conveys the idea of merging the key and seq with the pending timeframe.
3.  💾 - This emoji represents the logic for saving snapshots and timeframes, and the idea of data persistence and backup. It also conveys the idea of checking the need for saving after each block.
-->
This pull request enhances the `echo-pipeline` package by adding a new `pendingTimeframe` property and getter to the `Pipeline` and `TimeframeClock` classes, and by refactoring the `DataPipeline` class to improve the snapshot and timeframe saving logic. These changes aim to improve the performance and accuracy of the data synchronization process.

> _We're the crew of the data pipeline, we work with blocks and timeframes_
> _We update the `pendingTimeframe` as we go, and save when we need to_
> _We don't need no `onTimeframeReached`, we check after every block_
> _So heave away, me hearties, heave away on the count of three_

### Walkthrough
*  Add `pendingTimeframe` property and getter to `PipelineState` class to track the current timeframe being processed ([link](https://github.com/dxos/dxos/pull/2952/files?diff=unified&w=0#diff-1df1310cca796382869c882d8f953732c5ea557af4f9e4219223c7eada3fb9b3R73-R76)).


