### PR TITLE
fix(react-client,composer-app): Shell & Toast z-indexes.

### DIFF
--- a/packages/common/react-components/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/common/react-components/src/components/ThemeProvider/ThemeProvider.tsx
@@ -76,7 +76,7 @@ export const ThemeProvider = ({
           <ToastViewport
             {...toastViewportProps}
             className={mx(
-              'z-50 fixed bottom-4 inset-x-4 w-auto md:top-4 md:right-4 md:left-auto md:bottom-auto md:w-full md:max-w-sm rounded-lg flex flex-col gap-2',
+              'z-[70] fixed bottom-4 inset-x-4 w-auto md:top-4 md:right-4 md:left-auto md:bottom-auto md:w-full md:max-w-sm rounded-lg flex flex-col gap-2',
               themeVariantFocus(themeVariant),
               toastViewportProps?.className
             )}

--- a/packages/common/react-components/src/components/Toast/Toast.tsx
+++ b/packages/common/react-components/src/components/Toast/Toast.tsx
@@ -8,6 +8,7 @@ import React, { cloneElement, ComponentProps, ReactHTMLElement, ReactNode, useSt
 import { defaultDescription, defaultFocus } from '../../styles';
 import { mx } from '../../util';
 import { Button } from '../Button';
+import { ElevationProvider } from '../ElevationProvider';
 
 export interface ToastSlots {
   root?: Omit<ComponentProps<typeof ToastPrimitive.Root>, 'children'>;
@@ -65,41 +66,46 @@ export const Toast = ({
           slots.root?.className
         )}
       >
-        <div
-          role='none'
-          {...slots.heading}
-          className={mx('w-0 flex-1 flex items-center pl-5 py-4 min-h-full', slots.heading?.className)}
-        >
+        <ElevationProvider elevation='chrome'>
           <div
             role='none'
-            {...slots.headingInner}
-            className={mx('w-full radix flex flex-col justify-center min-h-full gap-1', slots.headingInner?.className)}
+            {...slots.heading}
+            className={mx('w-0 flex-1 flex items-center pl-5 py-4 min-h-full', slots.heading?.className)}
           >
-            <ToastPrimitive.Title className={mx('text-md font-medium', titleVisuallyHidden && 'sr-only')}>
-              {title}
-            </ToastPrimitive.Title>
-            {description && (
-              <ToastPrimitive.Description className={defaultDescription}>{description}</ToastPrimitive.Description>
+            <div
+              role='none'
+              {...slots.headingInner}
+              className={mx(
+                'w-full radix flex flex-col justify-center min-h-full gap-1',
+                slots.headingInner?.className
+              )}
+            >
+              <ToastPrimitive.Title className={mx('text-md font-medium', titleVisuallyHidden && 'sr-only')}>
+                {title}
+              </ToastPrimitive.Title>
+              {description && (
+                <ToastPrimitive.Description className={defaultDescription}>{description}</ToastPrimitive.Description>
+              )}
+            </div>
+          </div>
+          <div
+            role='none'
+            {...slots.actions}
+            className={mx(
+              'flex flex-col px-3 py-2 gap-1 items-stretch justify-center min-h-full',
+              slots.actions?.className
+            )}
+          >
+            {(actionTriggers || []).map(({ altText, trigger }, index) => (
+              <ToastPrimitive.Action key={index} altText={altText} asChild={typeof trigger !== 'string'}>
+                {trigger}
+              </ToastPrimitive.Action>
+            ))}
+            {closeTrigger && (
+              <ToastPrimitive.Close asChild={typeof closeTrigger !== 'string'}>{closeTrigger}</ToastPrimitive.Close>
             )}
           </div>
-        </div>
-        <div
-          role='none'
-          {...slots.actions}
-          className={mx(
-            'flex flex-col px-3 py-2 gap-1 items-stretch justify-center min-h-full',
-            slots.actions?.className
-          )}
-        >
-          {(actionTriggers || []).map(({ altText, trigger }, index) => (
-            <ToastPrimitive.Action key={index} altText={altText} asChild={typeof trigger !== 'string'}>
-              {trigger}
-            </ToastPrimitive.Action>
-          ))}
-          {closeTrigger && (
-            <ToastPrimitive.Close asChild={typeof closeTrigger !== 'string'}>{closeTrigger}</ToastPrimitive.Close>
-          )}
-        </div>
+        </ElevationProvider>
       </ToastPrimitive.Root>
     </>
   );

--- a/packages/sdk/client/src/packlets/client/iframe-service-proxy.ts
+++ b/packages/sdk/client/src/packlets/client/iframe-service-proxy.ts
@@ -25,7 +25,7 @@ const shellStyles = Object.entries({
   width: '100vw',
   height: '100vh',
   border: 0,
-  'z-index': 1000000
+  'z-index': 60
 }).reduce((acc, [key, value]) => `${acc}${key}: ${value};`, '');
 
 export type IFrameClientServicesProxyOptions = {


### PR DESCRIPTION
https://user-images.githubusercontent.com/855039/230464996-d7c006f9-1eae-43f1-ba07-2e391fe83c67.mp4

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cd7faec</samp>

### Summary
🔼🔽🌟

<!--
1.  🔼 - This emoji can be used to represent the increase in the `z-index` value of the toast viewport, as it suggests a higher position or level.
2.  🔽 - This emoji can be used to represent the decrease in the `z-index` value of the iframe shell, as it suggests a lower position or level.
3.  🌟 - This emoji can be used to represent the addition of the `ElevationProvider` component to toast notifications, as it suggests a shiny or glowing effect.
-->
Improved the UI of toast notifications by adding elevation effects and adjusting the `z-index` values of the toast viewport and the iframe shell. This ensures that the notifications are always visible and readable, and do not interfere with the app content or other UI elements.

> _Oh we are the coders of the sea_
> _And we make the toast notifications zee_
> _We heave and we ho on the count of three_
> _And we lower the `iframe` shell with glee_

### Walkthrough
*  Increase the `z-index` of the toast viewport to 70 to ensure toast notifications are visible above other elements ([link](https://github.com/dxos/dxos/pull/2959/files?diff=unified&w=0#diff-96bf101bc0545d6b23bcc7026090c8d510926fd2fe1c9c5e29a19ad0f8734acdL79-R79))
*  Import and wrap the toast content with `ElevationProvider` component to apply the `chrome` elevation style for better contrast and visibility ([link](https://github.com/dxos/dxos/pull/2959/files?diff=unified&w=0#diff-7d6309e29b787ee4b9172ca0c4c9a676ac2d5dc0f527ca9b9ba41b1dedf81defR11), [link](https://github.com/dxos/dxos/pull/2959/files?diff=unified&w=0#diff-7d6309e29b787ee4b9172ca0c4c9a676ac2d5dc0f527ca9b9ba41b1dedf81defL68-R108))


