### PR TITLE
ci: list playwright test results

### DIFF
--- a/tools/executors/test/src/playwright.ts
+++ b/tools/executors/test/src/playwright.ts
@@ -134,7 +134,7 @@ export const defaultPlaywrightConfig: PlaywrightTestConfig = {
     process.env.WATCH === 'true'
       ? [['dot']]
       : process.env.RESULTS_PATH
-      ? [['dot'], ['junit', { outputFile: process.env.RESULTS_PATH }]]
+      ? [['list'], ['junit', { outputFile: process.env.RESULTS_PATH }]]
       : [['list']],
   use: {
     headless: process.env.HEADLESS !== 'false',


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ec51f6c</samp>

### Summary
📝📊🚀

<!--
1.  📝 - This emoji can be used to indicate that the reporter option was changed, as it suggests writing or editing something.
2.  📊 - This emoji can be used to indicate that the list format was chosen over the dot format, as it suggests a more structured and detailed way of presenting data or results.
3.  🚀 - This emoji can be used to indicate that the change improves the readability and consistency of the test output in the CI environment, as it suggests speed, performance, or deployment.
-->
Changed the test output format for playwright tests in CI. Use the list reporter option instead of the dot option when `RESULTS_PATH` is set.

> _`reporter` option_
> _changed to list format when_
> _`RESULTS_PATH` is set_

### Walkthrough
*  Changed the reporter option for the playwright test runner to use the list format ([link](https://github.com/dxos/dxos/pull/2960/files?diff=unified&w=0#diff-a803c7c351cb2280e8e7fbfcefda21db6c2439a92591bf7251f00dc9368cdf10L137-R137)). This improves the readability and consistency of the test output in the CI environment.


