### PR TITLE
fix: template use with vault

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -58,6 +58,15 @@ jobs:
           DX_SENTRY_DESTINATION: ${{ secrets.CLI_SENTRY_DESTINATION }}
           DX_TELEMETRY_API_KEY: ${{ secrets.CLI_SEGMENT_API_KEY }}
 
+      - name: Bundle Vault
+        run: pnpm nx run-many --target=bundle --projects=vault --skip-nx-cache
+        env:
+          NODE_ENV: production
+          DX_ENVIRONMENT: production
+          DX_IPDATA_API_KEY: ${{ secrets.IPDATA_API_KEY }}
+          DX_SENTRY_DESTINATION: ${{ secrets.VAULT_SENTRY_DESTINATION }}
+          DX_TELEMETRY_API_KEY: ${{ secrets.VAULT_SEGMENT_API_KEY }}
+
       - name: Publish to NPM
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc

--- a/packages/apps/templates/bare-template/src/package.json.t.ts
+++ b/packages/apps/templates/bare-template/src/package.json.t.ts
@@ -84,7 +84,8 @@ export const base = ({ name, monorepo, version, depVersion }: Context): Partial<
     },
     dependencies: {
       '@dxos/client': depVersion,
-      '@dxos/config': depVersion
+      '@dxos/config': depVersion,
+      '@dxos/vault': depVersion
     },
     devDependencies: {
       '@types/node': '^18.11.9',

--- a/packages/apps/templates/bare-template/src/vite.config.ts.t.ts
+++ b/packages/apps/templates/bare-template/src/vite.config.ts.t.ts
@@ -54,6 +54,7 @@ export default defineTemplate<typeof config>(({ input, defaultOutputFile }) => {
   return /* javascript */ text`
   import { defineConfig } from 'vite';
   import { ConfigPlugin } from '@dxos/config/vite-plugin';
+  import { VaultPlugin } from '@dxos/vault/vite-plugin';
   ${() => imports.render(defaultOutputFile)}
 
   // https://vitejs.dev/config/
@@ -64,6 +65,7 @@ export default defineTemplate<typeof config>(({ input, defaultOutputFile }) => {
     },
     ${input.monorepo ? monorepoConfig : basicConfig}
     plugins: [
+      VaultPlugin(),
       ConfigPlugin(),
       ${react ? `${reactPlugin()}(),` : ''}
       ${


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2b0ef4e</samp>

### Summary
📦🔑🧩

<!--
1.  📦 for adding a step to bundle the Vault app.
2.  🔑 for adding the `@dxos/vault` dependency to the base template.
3.  🧩 for adding the `VaultPlugin` to the Vite configuration.
-->
This pull request enables the use of the `Vault` app as a virtual module and a dependency for DXOS apps. It updates the `bare-template` app and the staging workflow to support the `Vault` app features and configuration.

> _Sing, O Muse, of the cunning code changes_
> _That the skilled DXOS developers wrought_
> _To bundle the Vault app, the keeper of secrets_
> _And the guardian of identities and keys._

### Walkthrough
*  Add Vault app bundling to staging workflow ([link](https://github.com/dxos/dxos/pull/2962/files?diff=unified&w=0#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bR61-R69))
*  Add Vault app dependency and plugin to base app template ([link](https://github.com/dxos/dxos/pull/2962/files?diff=unified&w=0#diff-d83602a894290b2f00d9a22febe231219271786b1e99e7270af8e5a46b6c06e9L87-R88), [link](https://github.com/dxos/dxos/pull/2962/files?diff=unified&w=0#diff-6b219bb48d30bb79cfc7f5e8269f799cf7ba91c4dabbf44bc2c4fcbe3c5a1f19R57), [link](https://github.com/dxos/dxos/pull/2962/files?diff=unified&w=0#diff-6b219bb48d30bb79cfc7f5e8269f799cf7ba91c4dabbf44bc2c4fcbe3c5a1f19R68))


