### PR TITLE
chore: temp skip sentry upload for vault

### DIFF
--- a/packages/sdk/vault/vite.config.ts
+++ b/packages/sdk/vault/vite.config.ts
@@ -60,16 +60,17 @@ export default defineConfig({
     }),
     ReactPlugin(),
     // https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/vite
-    ...(process.env.NODE_ENV === 'production'
-      ? [
-          sentryVitePlugin({
-            org: 'dxos',
-            project: 'vault',
-            include: './dist/bundle',
-            authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN
-          })
-        ]
-      : [])
+    // TODO(wittjosiah): Get github to recognize sentry token.
+    // ...(process.env.NODE_ENV === 'production'
+    //   ? [
+    //       sentryVitePlugin({
+    //         org: 'dxos',
+    //         project: 'vault',
+    //         include: './dist/bundle',
+    //         authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN
+    //       })
+    //     ]
+    //   : [])
   ],
   worker: {
     format: 'es',


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5cc120d</samp>

### Summary
:construction::bug::wrench:

<!--
1.  :construction: This emoji is often used to indicate work in progress or temporary changes that are not meant to be permanent. It can convey the idea that the Sentry integration is not fully functional or complete at the moment, and that it will be restored or improved later.
2.  :bug: This emoji is typically used to denote bug fixes or issues that affect the quality or functionality of the code. It can suggest that the problem with GitHub not recognizing the Sentry token is a bug that needs to be resolved, and that it affects the error tracking capabilities of the app.
3.  :wrench: This emoji can represent tools, configuration, or maintenance tasks that are related to the build and deployment process of the app. It can imply that the change was made as part of a larger effort to fix or optimize the way the app is built and deployed, and that it involves some technical adjustments or settings.
-->
Temporarily disabled Sentry integration for Vault app. Commented out code that uploads source maps to Sentry in `vite.config.ts` to avoid build errors.

> _`Sentry` silenced_
> _Build and deploy must work_
> _Spring cleaning TODO_

### Walkthrough
*  Disable Sentry integration for source maps ([link](https://github.com/dxos/dxos/pull/2964/files?diff=unified&w=0#diff-25084f30840ca7bf47bffa200a1e8791317d106d81e96307b5249bdc8a4fe1d5L63-R73)) in `vite.config.ts`. This is a temporary workaround for a GitHub token issue that prevents the Vault app from building and deploying correctly.


