### PR TITLE
fix: Debounce & storage issues

### DIFF
--- a/packages/common/async/src/events.ts
+++ b/packages/common/async/src/events.ts
@@ -279,7 +279,7 @@ export class Event<T = void> implements ReadOnlyEvent<T> {
     debouncedEvent.addEffect(() => {
       const unsubscribe = this.on(() => {
         if (!firing) {
-          const fireIn = !lastFired || (Date.now() - lastFired) > timeout ? timeout / 8 : timeout;
+          const fireIn = !lastFired || Date.now() - lastFired > timeout ? timeout / 8 : timeout;
 
           firing = setTimeout(() => {
             lastFired = Date.now();

--- a/packages/common/async/src/events.ts
+++ b/packages/common/async/src/events.ts
@@ -279,7 +279,7 @@ export class Event<T = void> implements ReadOnlyEvent<T> {
     debouncedEvent.addEffect(() => {
       const unsubscribe = this.on(() => {
         if (!firing) {
-          const fireIn = !lastFired || lastFired > timeout ? timeout / 8 : timeout;
+          const fireIn = !lastFired || (Date.now() - lastFired) > timeout ? timeout / 8 : timeout;
 
           firing = setTimeout(() => {
             lastFired = Date.now();

--- a/packages/common/random-access-storage/src/browser/storage.ts
+++ b/packages/common/random-access-storage/src/browser/storage.ts
@@ -14,7 +14,7 @@ export const createStorage: StorageConstructor = ({ type, root = '' } = {}): Sto
       navigator.storage &&
       typeof navigator.storage.getDirectory === 'function' &&
       FileSystemFileHandle &&
-      typeof (FileSystemFileHandle.prototype as any).createWriteable === 'function'
+      typeof (FileSystemFileHandle.prototype as any).createWritable === 'function'
     ) {
       return new WebFS(root);
     } else {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c0905bd</samp>

### Summary
🐛🕒📝

<!--
1.  🐛 for fixing a bug in the `Event` class
2.  🕒 for fixing a timing issue with the `debounce` option
3.  📝 for fixing a typo in the `createStorage` function
-->
This pull request fixes two bugs in the `common` package: one in the `Event` class that affected the `debounce` option, and one in the `createStorage` function that prevented the use of the Web File System API. These fixes improve the reliability and compatibility of the `common` package.

> _`Event` bug fixed_
> _Debounce works as expected_
> _Autumn leaves fall fast_

### Walkthrough
* Fix bug in `Event` class that caused `debounce` option to not work properly ([link](https://github.com/dxos/dxos/pull/2969/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aL282-R282))
* Fix typo in `createStorage` function that prevented use of Web File System API in browsers that support it ([link](https://github.com/dxos/dxos/pull/2969/files?diff=unified&w=0#diff-60d6e0692a789eb4ed7157e66e3522cccfbfe5a73552561c6fb1824e3f35a2afL17-R17))


