### PR TITLE
test: Kai sidebar story

### DIFF
--- a/packages/apps/patterns/react-icons/.storybook/main.cjs
+++ b/packages/apps/patterns/react-icons/.storybook/main.cjs
@@ -12,8 +12,7 @@ module.exports = {
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
-    '@storybook/addon-interactions',
-    'storybook-addon-react-router-v6'
+    '@storybook/addon-interactions'
   ],
   framework: {
     name: '@storybook/react-vite',

--- a/packages/experimental/kai-frames/src/index.ts
+++ b/packages/experimental/kai-frames/src/index.ts
@@ -5,3 +5,6 @@
 export * from './hooks';
 export * from './frames';
 export * from './registry';
+
+// TODO(burdon): Separate export path.
+export * from './testing';

--- a/packages/experimental/kai/src/components/SpaceList/SpaceItem.tsx
+++ b/packages/experimental/kai/src/components/SpaceList/SpaceItem.tsx
@@ -54,6 +54,7 @@ export const SpaceItem = observer(({ space, selected, children, onAction }: Spac
             labelVisuallyHidden
             placeholder={t('space title placeholder')}
             slots={{
+              root: { className: 'w-full' },
               input: { autoFocus: !space.properties.name?.length }
             }}
             value={space.properties.name ?? ''}

--- a/packages/experimental/kai/src/components/SpaceSettings/SpaceSettings.tsx
+++ b/packages/experimental/kai/src/components/SpaceSettings/SpaceSettings.tsx
@@ -52,7 +52,7 @@ export const SpaceIcons: FC<{ selected: string; onSelect: (selected: string) => 
       <div className='grid grid-cols-6'>
         {icons.map(({ id, Icon }) => (
           <Button key={id} variant='ghost' className='p-0' onClick={() => onSelect(id)}>
-            <div className={mx('m-1 p-1', selected === id && 'ring-2 ring-black')}>
+            <div className={mx('m-1 p-1', selected === id && 'rounded ring-2 ring-black')}>
               <Icon className={getSize(6)} />
             </div>
           </Button>

--- a/packages/experimental/kai/src/containers/AppMenu/AppMenu.tsx
+++ b/packages/experimental/kai/src/containers/AppMenu/AppMenu.tsx
@@ -15,12 +15,12 @@ import { Actions } from './Actions';
 
 export const AppMenu = () => {
   const shell = useShell();
+  const { space } = useAppRouter();
+
+  // TODO(burdon): Factor out kai-types Message dep (frame triggers event?)
   const { chat } = useAppState();
   const { setChat } = useAppReducer();
   const [newChat, setNewChat] = useState(false);
-  const { space } = useAppRouter();
-
-  // TODO(burdon): Factor out kai-types Message dep (event).
   const messages = useQuery(space, Message.filter());
   const messageCount = useRef(0);
   useEffect(() => {

--- a/packages/experimental/kai/src/containers/Sidebar/Sidebar.stories.tsx
+++ b/packages/experimental/kai/src/containers/Sidebar/Sidebar.stories.tsx
@@ -2,30 +2,50 @@
 // Copyright 2023 DXOS.org
 //
 
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { withRouter } from 'storybook-addon-react-router-v6';
 
+import { frameDefs, frameModules, FrameRegistryContextProvider } from '@dxos/kai-frames';
 import { MetagraphClientFake } from '@dxos/metagraph';
+import { useSpaces } from '@dxos/react-client';
 import { ClientSpaceDecorator } from '@dxos/react-client/testing';
 import { MetagraphProvider } from '@dxos/react-metagraph';
+import { PanelSidebarContext } from '@dxos/react-ui';
 
 import '@dxosTheme';
 
-import { AppStateProvider } from '../../hooks';
+import { AppStateProvider, createPath, defaultFrames } from '../../hooks';
 import { Sidebar } from './Sidebar';
 
 const Test = () => {
+  const navigate = useNavigate();
+  const spaces = useSpaces();
+  useEffect(() => {
+    navigate(createPath({ spaceKey: spaces[0].key }));
+  }, []);
+
   // TODO(burdon): Factor out providers or create decorator for Kai storybooks.
   const metagraphContext = {
-    client: new MetagraphClientFake([])
+    client: new MetagraphClientFake(frameModules)
   };
 
   return (
-    <div className='flex flex-col w-full md:w-[390px] m-4 space-y-8'>
+    <div className='flex w-full h-[100vh] bg-zinc-200'>
       <MetagraphProvider value={metagraphContext}>
-        <AppStateProvider>
-          <Sidebar onNavigate={() => {}} />
-        </AppStateProvider>
+        <FrameRegistryContextProvider frameDefs={frameDefs}>
+          <AppStateProvider
+            initialState={{
+              frames: defaultFrames
+            }}
+          >
+            <div className='flex h-[100vh] w-[300px] bg-white'>
+              <PanelSidebarContext.Provider value={{ displayState: 'show', setDisplayState: () => {} }}>
+                <Sidebar onNavigate={() => {}} />
+              </PanelSidebarContext.Provider>
+            </div>
+          </AppStateProvider>
+        </FrameRegistryContextProvider>
       </MetagraphProvider>
     </div>
   );
@@ -36,12 +56,12 @@ export default {
   decorators: [ClientSpaceDecorator(), withRouter],
   parameters: {
     layout: 'fullscreen',
-    // TODO(burdon): Factor out nav so that tests don't require params.
     // https://storybook.js.org/addons/storybook-addon-react-router-v6
     reactRouter: {
-      // TODO(burdon): Space ID.
-      routePath: '',
-      routeParams: {}
+      routePath: '/:spaceKey',
+      routeParams: {
+        spaceKey: 'invalid'
+      }
     }
   }
 };

--- a/packages/experimental/kai/src/containers/Sidebar/Sidebar.tsx
+++ b/packages/experimental/kai/src/containers/Sidebar/Sidebar.tsx
@@ -6,7 +6,7 @@ import {
   AppWindow,
   CaretCircleDoubleDown,
   CaretLeft,
-  Info as CaretUpDown,
+  Info,
   Graph,
   PlusCircle,
   Robot,
@@ -269,31 +269,33 @@ export const Sidebar = observer(({ onNavigate }: SidebarProps) => {
       <div
         role='none'
         className={mx(
-          'flex flex-col h-full overflow-hidden min-bs-full bg-sidebar-bg',
+          'flex flex-col w-full h-full overflow-hidden min-bs-full bg-sidebar-bg',
           theme.panel === 'flat' && 'border-r'
         )}
       >
-        {/* Space Selector */}
+        {/* Header */}
         <div className='flex flex-col shrink-0'>
-          <div className={mx('flex items-center h-[40px]', theme.classes.header)}>
-            <div className='flex w-full items-center'>
-              <div className='flex justify-center px-3'>
+          <div className={mx('flex overflow-hidden items-center h-[40px]', theme.classes.header)}>
+            <div className='flex overflow-hidden grow items-center'>
+              <div className='flex shrink-0 px-3'>
                 <Icon className={getSize(8)} weight='duotone' data-testid='sidebar.spaceIcon' />
               </div>
+              <div className='truncate text-lg'>{space.properties.name ?? 'Space'}</div>
+            </div>
+
+            <div className='flex shrink-0 items-center'>
               <Button
                 variant='ghost'
-                className='flex w-full p-0'
+                className='flex p-0 px-1'
                 data-testid='sidebar.showSpaceList'
                 onClick={() => setShowSpaceList((show) => !show)}
               >
-                <div className='px-2 text-lg'>{space.properties.name ?? 'Space'}</div>
-                <CaretUpDown className={getSize(4)} />
+                <Info className={getSize(5)} />
+              </Button>
+              <Button variant='ghost' className='p-0 pr-2' onClick={toggleSidebar}>
+                {displayState === 'show' && <CaretLeft className={getSize(6)} />}
               </Button>
             </div>
-
-            <Button variant='ghost' className='p-0 pr-2' onClick={toggleSidebar}>
-              {displayState === 'show' && <CaretLeft className={getSize(6)} />}
-            </Button>
           </div>
         </div>
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 78f0cab</samp>

### Summary
🗑️📦🛠️

<!--
1.  🗑️ - This emoji represents the removal of the `storybook-addon-react-router-v6` dependency, as it is no longer needed and can be discarded.
2.  📦 - This emoji represents the export of the `testing` module from the `kai-frames` package, as it is a useful feature that can be shared and reused by other packages that depend on the frame definitions and modules.
3.  🛠️ - This emoji represents the various fixes and improvements made to the `SpaceItem`, `AppMenu`, and `Sidebar` components and stories, as they enhance the functionality, layout, and design of the app.
-->
Improved the sidebar UI and story, removed an unnecessary dependency, exported a testing module, and fixed a hook order issue. Specifically, the `Sidebar` component and story were updated to use the new navigation and frame context features, and to match the app layout and routing. The `storybook-addon-react-router-v6` dependency was removed from the `react-icons` storybook configuration. The `testing` module from the `kai-frames` package was exported to allow testing with frame definitions and modules. The `useAppRouter` hook was moved before the other hooks in the `AppMenu` component, to avoid errors or inconsistencies when the `space` value changes.

> _`storybook` and `kai`_
> _refined for icons and frames_
> _autumn cleaning code_

### Walkthrough
* Remove unused dependency from storybook configuration ([link](https://github.com/dxos/dxos/pull/2975/files?diff=unified&w=0#diff-eb4739844a87cfea6217922ccd17e9b5a78c6790abe019a8cdc064f4adc40abbL15-R15)).


