### PR TITLE
ci: ensure test results are uploaded to datadog on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,15 +160,16 @@ jobs:
         type: string
     steps:
       - checkout
+      - *install_datadog
       - run:
           command: npm run start
           working_directory: ./tools/monitors/messaging-monitor
           environment:
             DX_ENVIRONMENT: << parameters.dx_environment >>
-      - *install_datadog
       - run:
           name: Upload results to Datadog
           command: datadog-ci junit upload --service dxos ./tools/monitors/messaging-monitor/test-results.xml
+          when: always
           environment:
             DD_TAGS: env:<< parameters.dx_environment >>
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 25cc29a</samp>

### Summary
🐶📊🔁

<!--
1.  🐶 - This emoji represents Datadog, the service that we are uploading the test results to.
2.  📊 - This emoji represents the test results, which are displayed as graphs and dashboards on Datadog.
3.  🔁 - This emoji represents the reusable command, which allows us to avoid duplicating code and simplify the configuration.
-->
This pull request enhances the CI pipeline by uploading messaging-monitor test results to Datadog. It modifies the `.circleci/config.yml` file to use a reusable command and a post-run step.

> _To Datadog we want to report_
> _Our test results of every sort_
> _So we `install_datadog`_
> _In our CircleCI config_
> _And upload the data as we ought_

### Walkthrough
*  Add `install_datadog` command to `messaging-monitor` job ([link](https://github.com/dxos/dxos/pull/2977/files?diff=unified&w=0#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R163))
*  Remove redundant `install_datadog` command and ensure results are always uploaded to Datadog ([link](https://github.com/dxos/dxos/pull/2977/files?diff=unified&w=0#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L168-R172))


