### PR TITLE
feat: Add self-check on ipfs upload

### DIFF
--- a/packages/devtools/cli/src/util/publish/ipfs-upload.ts
+++ b/packages/devtools/cli/src/util/publish/ipfs-upload.ts
@@ -5,9 +5,9 @@
 import fs from 'fs';
 import { CID, create, globSource } from 'ipfs-http-client';
 import assert from 'node:assert';
+import { join } from 'path';
 
 import { Config } from '@dxos/client';
-import { join } from 'path';
 import { log } from '@dxos/log';
 
 interface UploadOptions {
@@ -39,23 +39,22 @@ export const uploadToIPFS = async (path: string, config?: Config, options?: Uplo
     })) {
       const fullPath = join(path, file.path);
 
-
       if (!fs.lstatSync(fullPath).isDirectory()) {
-        let remoteChunks = []
+        const remoteChunks = [];
         for await (const chunk of ipfsClient.cat(file.cid)) {
-          remoteChunks.push(chunk)
+          remoteChunks.push(chunk);
         }
         const remoteContent = Buffer.concat(remoteChunks);
 
         const localContent = fs.readFileSync(fullPath);
 
         if (!localContent.equals(remoteContent)) {
-          log.error('file content mismatch', { 
+          log.error('file content mismatch', {
             path: fullPath,
             cid: file.cid.toString(),
             localSize: localContent.length,
-            remoteSize: remoteContent.length,
-          })
+            remoteSize: remoteContent.length
+          });
         }
       }
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 97ed83d</samp>

### Summary
🛡️📝🔄

<!--
1.  🛡️ - This emoji can be used to represent validation, security, or protection. It suggests that the function is more robust and trustworthy after the changes.
2.  📝 - This emoji can be used to represent logging, writing, or documentation. It indicates that the function produces useful information or records about its operation or performance.
3.  🔄 - This emoji can be used to represent comparison, matching, or synchronization. It implies that the function verifies that the local and remote content are consistent and aligned.
-->
Improved IPFS upload function in `ipfs-upload.ts`. Added validation and logging to verify and report file content consistency.

> _To upload files to IPFS_
> _We added some checks and finesse_
> _We compare local and remote_
> _And log errors that we note_
> _To ensure integrity and success_

### Walkthrough
* Import `join` and `log` functions to construct file paths and log errors ([link](https://github.com/dxos/dxos/pull/2981/files?diff=unified&w=0#diff-8f4eed568bab061a0b6119c3809328bf92d1018c95bdb62e8d27322f6f748237R10-R11)).


