### PR TITLE
feat(config): Add multiple signal servers in Config

### DIFF
--- a/packages/core/mesh/messaging/src/signal-client/signal-client.test.ts
+++ b/packages/core/mesh/messaging/src/signal-client/signal-client.test.ts
@@ -129,7 +129,7 @@ describe('SignalClient', () => {
     client2.open();
     afterTest(() => client2.close());
 
-    const unsubscribeHandle = await client1.subscribeMessages(peer1);
+    await client1.subscribeMessages(peer1);
     await client2.subscribeMessages(peer2);
     await waitForSubscription(client2, peer2);
 
@@ -149,7 +149,7 @@ describe('SignalClient', () => {
     }
 
     // unsubscribing.
-    await unsubscribeHandle.unsubscribe();
+    await client1.unsubscribeMessages(peer1);
 
     {
       const promise = received.waitFor((msg) => {

--- a/packages/core/mesh/messaging/src/signal-client/signal-client.ts
+++ b/packages/core/mesh/messaging/src/signal-client/signal-client.ts
@@ -260,6 +260,7 @@ export class SignalClient implements SignalMethods {
     log('creating client', { host: this._host, state: this._state });
     this._connectionStarted = new Date();
 
+    // Create new context for each connection.
     this._connectionCtx = this._ctx!.derive();
     this._connectionCtx.onDispose(() => {
       log('connection context disposed');

--- a/packages/core/mesh/messaging/src/signal-client/signal-client.ts
+++ b/packages/core/mesh/messaging/src/signal-client/signal-client.ts
@@ -258,6 +258,7 @@ export class SignalClient implements SignalMethods {
 
   private _createClient() {
     log('creating client', { host: this._host, state: this._state });
+    assert(!this._client, 'Client already created');
     this._connectionStarted = new Date();
 
     // Create new context for each connection.

--- a/packages/core/mesh/messaging/src/signal-client/signal-client.ts
+++ b/packages/core/mesh/messaging/src/signal-client/signal-client.ts
@@ -231,14 +231,13 @@ export class SignalClient implements SignalMethods {
     log('subscribing to messages', { peerId });
     this._subscribedMessages.add({ peerId });
     this._reconcileTask!.schedule();
+  }
 
-    return {
-      unsubscribe: async () => {
-        this._messageStreams.get(peerId)!.close();
-        this._messageStreams.delete(peerId);
-        this._subscribedMessages.delete({ peerId });
-      }
-    };
+  async unsubscribeMessages(peerId: PublicKey) {
+    log('unsubscribing from messages', { peerId });
+    this._subscribedMessages.delete({ peerId });
+    this._messageStreams.get(peerId)?.close();
+    this._messageStreams.delete(peerId);
   }
 
   private _scheduleReconcileAfterError() {
@@ -408,7 +407,6 @@ export class SignalClient implements SignalMethods {
         cancelWithContext(this._connectionCtx!, client.receiveMessages(peerId)),
         5000
       );
-
       messageStream.subscribe(async (message: SignalMessage) => {
         this._performance.receivedMessages++;
         await this._onMessage({

--- a/packages/core/mesh/messaging/src/signal-client/signal-client.ts
+++ b/packages/core/mesh/messaging/src/signal-client/signal-client.ts
@@ -156,6 +156,9 @@ export class SignalClient implements SignalMethods {
 
     this._ctx = new Context({
       onError: (err) => {
+        if (this._state === SignalState.CLOSED || this._ctx?.disposed) {
+          return;
+        }
         log.warn('Signal Client Error', err);
         this._scheduleReconcileAfterError();
       }
@@ -183,7 +186,7 @@ export class SignalClient implements SignalMethods {
     await this._ctx?.dispose();
 
     this._clientReady.reset();
-    await this._client!.close();
+    await this._client?.close();
     this._client = undefined;
     this._setState(SignalState.CLOSED);
     log('closed');
@@ -328,7 +331,7 @@ export class SignalClient implements SignalMethods {
     // Close client if it wasn't already closed.
     this._clientReady.reset();
     await this._connectionCtx?.dispose();
-    this._client!.close().catch(() => {});
+    this._client?.close().catch(() => {});
     this._client = undefined;
 
     await cancelWithContext(this._ctx!, sleep(this._reconnectAfter));

--- a/packages/core/mesh/messaging/src/signal-client/signal-client.ts
+++ b/packages/core/mesh/messaging/src/signal-client/signal-client.ts
@@ -285,22 +285,22 @@ export class SignalClient implements SignalMethods {
 
           onDisconnected: () => {
             log('socket disconnected', { state: this._state });
-            if (this._state !== SignalState.CONNECTED && this._state !== SignalState.CONNECTING) {
+            if (this._state === SignalState.RE_CONNECTING) {
               this._incrementReconnectTimeout();
             }
             this._setState(SignalState.DISCONNECTED);
-            this._reconcileTask!.schedule();
+            this._reconnectTask!.schedule();
           },
 
           onError: (error) => {
             log('socket error', { error, state: this._state });
-            if (this._state !== SignalState.CONNECTED && this._state !== SignalState.CONNECTING) {
+            if (this._state === SignalState.RE_CONNECTING) {
               this._incrementReconnectTimeout();
             }
 
             this._lastError = error;
             this._setState(SignalState.DISCONNECTED);
-            this._reconcileTask!.schedule();
+            this._reconnectTask!.schedule();
           }
         }
       });
@@ -312,7 +312,7 @@ export class SignalClient implements SignalMethods {
       // TODO(burdon): If client isn't set, then flows through to error below.
       this._lastError = err;
       this._setState(SignalState.DISCONNECTED);
-      this._reconcileTask!.schedule();
+      this._reconnectTask!.schedule();
     }
   }
 

--- a/packages/core/mesh/messaging/src/signal-client/signal-client.ts
+++ b/packages/core/mesh/messaging/src/signal-client/signal-client.ts
@@ -339,7 +339,7 @@ export class SignalClient implements SignalMethods {
   }
 
   private async _reconcileSwarmSubscriptions(): Promise<void> {
-    await asyncTimeout(this._clientReady.wait(), 1000);
+    await asyncTimeout(cancelWithContext(this._connectionCtx!, this._clientReady.wait()), 5_000);
     // Copy Client reference to avoid client change during the reconcile.
     const client = this._client!;
     assert(this._state === SignalState.CONNECTED, 'Not connected to Signal Server');
@@ -362,7 +362,10 @@ export class SignalClient implements SignalMethods {
         continue;
       }
 
-      const swarmStream = await client.join({ topic, peerId });
+      const swarmStream = await asyncTimeout(
+        cancelWithContext(this._connectionCtx!, client.join({ topic, peerId })),
+        5000
+      );
       // Subscribing to swarm events.
       // TODO(mykola): What happens when the swarm stream is closed? Maybe send leave event for each peer?
       swarmStream.subscribe((swarmEvent: SwarmEvent) => {
@@ -376,7 +379,7 @@ export class SignalClient implements SignalMethods {
   }
 
   private async _reconcileMessageSubscriptions(): Promise<void> {
-    await asyncTimeout(this._clientReady.wait(), 1000);
+    await asyncTimeout(cancelWithContext(this._connectionCtx!, this._clientReady.wait()), 5_000);
     // Copy Client reference to avoid client change during the reconcile.
     const client = this._client!;
     assert(this._state === SignalState.CONNECTED, 'Not connected to Signal Server');
@@ -398,7 +401,11 @@ export class SignalClient implements SignalMethods {
         continue;
       }
 
-      const messageStream = await client.receiveMessages(peerId);
+      const messageStream = await asyncTimeout(
+        cancelWithContext(this._connectionCtx!, client.receiveMessages(peerId)),
+        5000
+      );
+
       messageStream.subscribe(async (message: SignalMessage) => {
         this._performance.receivedMessages++;
         await this._onMessage({

--- a/packages/core/mesh/messaging/src/signal-client/signal-rpc-client.ts
+++ b/packages/core/mesh/messaging/src/signal-client/signal-rpc-client.ts
@@ -57,7 +57,7 @@ export class SignalRPCClient {
           try {
             this._socket!.send(msg);
           } catch (err) {
-            log.warn(String(err));
+            log.warn('send error', err);
           }
         },
         subscribe: (cb) => {
@@ -118,7 +118,7 @@ export class SignalRPCClient {
       await this._rpc?.close();
       this._socket?.close();
     } catch (err) {
-      log.warn(String(err));
+      log.warn('close error', err);
     }
   }
 

--- a/packages/core/mesh/messaging/src/signal-client/signal-rpc-client.ts
+++ b/packages/core/mesh/messaging/src/signal-client/signal-rpc-client.ts
@@ -19,7 +19,13 @@ interface Services {
 
 export type SignalCallbacks = {
   onConnected?: () => void;
+
+  /**
+   * Called on disconnect.
+   * In case of error, `onError` will be called first and then `onDisconnected`.
+   */
   onDisconnected?: () => void;
+
   onError?: (error: Error) => void;
 };
 

--- a/packages/core/mesh/messaging/src/signal-manager/memory-signal-manager.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/memory-signal-manager.ts
@@ -169,12 +169,10 @@ export class MemorySignalManager implements SignalManager {
   async subscribeMessages(peerId: PublicKey) {
     log('subscribing', { peerId });
     this._context.connections.set(peerId, this);
+  }
 
-    return {
-      unsubscribe: async () => {
-        log('unsubscribing', { peerId });
-        this._context.connections.delete(peerId);
-      }
-    };
+  async unsubscribeMessages(peerId: PublicKey) {
+    log('unsubscribing', { peerId });
+    this._context.connections.delete(peerId);
   }
 }

--- a/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.ts
@@ -124,14 +124,14 @@ export class WebsocketSignalManager implements SignalManager {
     log(`Subscribed for message stream peerId=${peerId}`);
     assert(this._opened, 'Closed');
 
-    const unsubscribeHandles = this._forEachServer(async (server) => server.subscribeMessages(peerId));
+    await this._forEachServer(async (server) => server.subscribeMessages(peerId));
+  }
 
-    // TODO(mykola): on multiple subscription for same peerId, everybody will receive same unsubscribe handle.
-    return {
-      unsubscribe: async () => {
-        await Promise.all((await unsubscribeHandles).map((handle) => handle.unsubscribe()));
-      }
-    };
+  async unsubscribeMessages(peerId: PublicKey) {
+    log(`Subscribed for message stream peerId=${peerId}`);
+    assert(this._opened, 'Closed');
+
+    await this._forEachServer(async (server) => server.unsubscribeMessages(peerId));
   }
 
   private _initContext() {

--- a/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.ts
@@ -11,7 +11,6 @@ import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { trace } from '@dxos/protocols';
 import { SwarmEvent } from '@dxos/protocols/proto/dxos/mesh/signal';
-import { ComplexSet } from '@dxos/util';
 
 import { CommandTrace, SignalClient, SignalStatus } from '../signal-client';
 import { SignalManager } from './signal-manager';
@@ -21,14 +20,6 @@ import { SignalManager } from './signal-manager';
  */
 export class WebsocketSignalManager implements SignalManager {
   private readonly _servers = new Map<string, SignalClient>();
-
-  /** Topics joined: topic => peerId */
-  private readonly _topicsJoined = new ComplexSet<{ topic: PublicKey; peerId: PublicKey }>(
-    ({ topic, peerId }) => topic.toHex() + peerId.toHex()
-  );
-
-  /** peerId[] */
-  private readonly _subscribedMessages = new ComplexSet<PublicKey>(PublicKey.hash);
 
   private _ctx!: Context;
   private _opened = false;
@@ -78,17 +69,6 @@ export class WebsocketSignalManager implements SignalManager {
 
     [...this._servers.values()].forEach((server) => server.open());
 
-    await Promise.all(
-      [...this._servers.values()].map((server) =>
-        Promise.all([...this._topicsJoined.values()].map((params) => server.join(params)))
-      )
-    );
-
-    await Promise.all(
-      [...this._servers.values()].map((server) =>
-        Promise.all([...this._subscribedMessages.values()].map((peerId) => server.subscribeMessages(peerId)))
-      )
-    );
     this._opened = true;
   }
 
@@ -111,10 +91,8 @@ export class WebsocketSignalManager implements SignalManager {
   @synchronized
   async join({ topic, peerId }: { topic: PublicKey; peerId: PublicKey }) {
     log('Join', { topic, peerId });
-    assert(!this._topicsJoined.has({ topic, peerId }), 'Already joined');
     assert(this._opened, 'Closed');
-    this._topicsJoined.add({ topic, peerId });
-    await Promise.all(Array.from(this._servers.values()).map((server) => server.join({ topic, peerId })));
+    await this._forEachServer((server) => server.join({ topic, peerId }));
   }
 
   @synchronized
@@ -122,8 +100,7 @@ export class WebsocketSignalManager implements SignalManager {
     log('leaving', { topic, peerId });
     assert(this._opened, 'Closed');
 
-    this._topicsJoined.delete({ topic, peerId });
-    await Promise.all(Array.from(this._servers.values()).map((server) => server.leave({ topic, peerId })));
+    await this._forEachServer((server) => server.leave({ topic, peerId }));
   }
 
   async sendMessage({
@@ -138,7 +115,7 @@ export class WebsocketSignalManager implements SignalManager {
     log(`Signal ${recipient}`);
     assert(this._opened, 'Closed');
 
-    [...this._servers.values()].forEach((server: SignalClient) => {
+    void this._forEachServer(async (server) => {
       void server.sendMessage({ author, recipient, payload }).catch((err) => log(err));
     });
   }
@@ -146,17 +123,13 @@ export class WebsocketSignalManager implements SignalManager {
   async subscribeMessages(peerId: PublicKey) {
     log(`Subscribed for message stream peerId=${peerId}`);
     assert(this._opened, 'Closed');
-    this._subscribedMessages.add(peerId);
 
-    const unsubscribeHandles = await Promise.all(
-      [...this._servers.values()].map((signalClient: SignalClient) => signalClient.subscribeMessages(peerId))
-    );
+    const unsubscribeHandles = this._forEachServer(async (server) => server.subscribeMessages(peerId));
 
     // TODO(mykola): on multiple subscription for same peerId, everybody will receive same unsubscribe handle.
     return {
       unsubscribe: async () => {
-        await Promise.all(unsubscribeHandles.map((handle) => handle.unsubscribe()));
-        this._subscribedMessages.delete(peerId);
+        await Promise.all((await unsubscribeHandles).map((handle) => handle.unsubscribe()));
       }
     };
   }
@@ -165,5 +138,9 @@ export class WebsocketSignalManager implements SignalManager {
     this._ctx = new Context({
       onError: (err) => log.catch(err)
     });
+  }
+
+  private async _forEachServer(fn: (server: SignalClient) => Promise<any>) {
+    return Promise.all(Array.from(this._servers.values()).map(fn));
   }
 }

--- a/packages/core/mesh/messaging/src/signal-methods.ts
+++ b/packages/core/mesh/messaging/src/signal-methods.ts
@@ -28,7 +28,12 @@ export interface SignalMethods {
   sendMessage: (message: Message) => Promise<void>;
 
   /**
-   * Start receiving messages from
+   * Start receiving messages from peer.
    */
-  subscribeMessages: (peerId: PublicKey) => Promise<{ unsubscribe: () => Promise<void> }>;
+  subscribeMessages: (peerId: PublicKey) => Promise<void>;
+
+  /**
+   * Stop receiving messages from peer.
+   */
+  unsubscribeMessages: (peerId: PublicKey) => Promise<void>;
 }

--- a/packages/core/mesh/network-manager/src/signal/integration.test.ts
+++ b/packages/core/mesh/network-manager/src/signal/integration.test.ts
@@ -57,7 +57,6 @@ describe('Signal Integration Test', () => {
 
     const peerNetworking1 = await setupPeer({ topic });
     const peerNetworking2 = await setupPeer({ topic });
-
     const promise1 = peerNetworking1.signalManager.swarmEvent.waitFor(
       ({ swarmEvent }) => !!swarmEvent.peerAvailable && peer2.equals(swarmEvent.peerAvailable.peer)
     );

--- a/packages/core/protocols/src/proto/dxos/config.proto
+++ b/packages/core/protocols/src/proto/dxos/config.proto
@@ -301,7 +301,7 @@ message Runtime {
     }
 
     message Signal {
-      optional string server = 1;
+      repeated string servers = 1;
       optional string api = 2;
       optional string status = 3;
     }

--- a/packages/core/protocols/src/proto/dxos/config.proto
+++ b/packages/core/protocols/src/proto/dxos/config.proto
@@ -301,7 +301,7 @@ message Runtime {
     }
 
     message Signal {
-      optional string server = 1;
+      optional string servers = 1;
       optional string api = 2;
       optional string status = 3;
     }
@@ -336,7 +336,7 @@ message Runtime {
     optional AppServer app = 2;
     optional Dxns dxns = 3;
     optional Ipfs ipfs = 4;
-    optional Signal signal = 5;
+    repeated Signal signal = 5;
     repeated Ice ice = 6;
     optional Machine machine = 7;
     optional BotHost bot = 8;

--- a/packages/core/protocols/src/proto/dxos/config.proto
+++ b/packages/core/protocols/src/proto/dxos/config.proto
@@ -301,7 +301,7 @@ message Runtime {
     }
 
     message Signal {
-      repeated string servers = 1;
+      optional string server = 1;
       optional string api = 2;
       optional string status = 3;
     }

--- a/packages/experimental/kai/dx-dev.yml
+++ b/packages/experimental/kai/dx-dev.yml
@@ -7,8 +7,8 @@ runtime:
 
   services:
     signal:
-      server: wss://kube.dxos.org/.well-known/dx/signal
-#      server: wss://kube.dx.ninja/.well-known/dx/signal
+      - servers: wss://kube.dxos.org/.well-known/dx/signal
+      - servers: wss://kube.dev.dxos.org/.well-known/dx/signal
     ice:
       - urls: stun:kube.dxos.org:3478
         username: dxos

--- a/packages/experimental/kai/dx-dev.yml
+++ b/packages/experimental/kai/dx-dev.yml
@@ -7,7 +7,8 @@ runtime:
 
   services:
     signal:
-      servers: [ws://localhost:5767/.well-known/dx/signal, ws://localhost/.well-known/dx/signal]
+      server: wss://kube.dxos.org/.well-known/dx/signal
+#      server: wss://kube.dx.ninja/.well-known/dx/signal
     ice:
       - urls: stun:kube.dxos.org:3478
         username: dxos

--- a/packages/experimental/kai/dx-dev.yml
+++ b/packages/experimental/kai/dx-dev.yml
@@ -7,8 +7,7 @@ runtime:
 
   services:
     signal:
-      server: wss://kube.dxos.org/.well-known/dx/signal
-#      server: wss://kube.dx.ninja/.well-known/dx/signal
+      servers: [wss://broken.kube, wss://kube.dxos.org/.well-known/dx/signal]
     ice:
       - urls: stun:kube.dxos.org:3478
         username: dxos

--- a/packages/experimental/kai/dx-dev.yml
+++ b/packages/experimental/kai/dx-dev.yml
@@ -7,7 +7,7 @@ runtime:
 
   services:
     signal:
-      servers: [wss://broken.kube, wss://kube.dxos.org/.well-known/dx/signal]
+      servers: [ws://localhost:5767/.well-known/dx/signal, ws://localhost/.well-known/dx/signal]
     ice:
       - urls: stun:kube.dxos.org:3478
         username: dxos

--- a/packages/experimental/kai/dx.yml
+++ b/packages/experimental/kai/dx.yml
@@ -31,7 +31,7 @@ runtime:
   # TODO(burdon): Are these provided by KUBE?
   services:
     signal:
-      server: wss://kube.dxos.org/.well-known/dx/signal
+      - servers: wss://kube.dxos.org/.well-known/dx/signal
     ice:
       - urls: turn:kube.dxos.org:3478
         username: dxos

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
@@ -219,7 +219,6 @@ export class InvitationsHandler {
       const swarmConnection = await this._networkManager.joinSwarm({
         topic,
         peerId: topic,
-        label: 'invitation host',
         protocolProvider: createTeleportProtocolFactory(async (teleport) => {
           teleport.addExtension('dxos.halo.invitations', createExtension());
         }),
@@ -358,7 +357,6 @@ export class InvitationsHandler {
       const topic = invitation.swarmKey;
       const swarmConnection = await this._networkManager.joinSwarm({
         topic,
-        label: 'invitation guest',
         peerId: PublicKey.random(),
         protocolProvider: createTeleportProtocolFactory(async (teleport) => {
           teleport.addExtension('dxos.halo.invitations', createExtension());

--- a/packages/sdk/client-services/src/packlets/services/utils.ts
+++ b/packages/sdk/client-services/src/packlets/services/utils.ts
@@ -30,11 +30,11 @@ export const fromHost = (config: Config = new Config()): ClientServicesProvider 
  */
 // TODO(burdon): Move to client-services and remove dependencies from here.
 const createNetworkManager = (config: Config, options: Partial<NetworkManagerOptions> = {}): NetworkManager => {
-  const signalServer = config.get('runtime.services.signal.server');
-  if (signalServer) {
+  const signalServers = config.get('runtime.services.signal.servers');
+  if (signalServers) {
     const {
       log = true,
-      signalManager = new WebsocketSignalManager([signalServer]),
+      signalManager = new WebsocketSignalManager(signalServers),
       transportFactory = createWebRTCTransportFactory({
         iceServers: config.get('runtime.services.ice')
       })

--- a/packages/sdk/client-services/src/packlets/services/utils.ts
+++ b/packages/sdk/client-services/src/packlets/services/utils.ts
@@ -30,11 +30,11 @@ export const fromHost = (config: Config = new Config()): ClientServicesProvider 
  */
 // TODO(burdon): Move to client-services and remove dependencies from here.
 const createNetworkManager = (config: Config, options: Partial<NetworkManagerOptions> = {}): NetworkManager => {
-  const signalServers = config.get('runtime.services.signal.servers');
-  if (signalServers) {
+  const signalServer = config.get('runtime.services.signal.server');
+  if (signalServer) {
     const {
       log = true,
-      signalManager = new WebsocketSignalManager(signalServers),
+      signalManager = new WebsocketSignalManager([signalServer]),
       transportFactory = createWebRTCTransportFactory({
         iceServers: config.get('runtime.services.ice')
       })

--- a/packages/sdk/client-services/src/packlets/services/utils.ts
+++ b/packages/sdk/client-services/src/packlets/services/utils.ts
@@ -30,11 +30,11 @@ export const fromHost = (config: Config = new Config()): ClientServicesProvider 
  */
 // TODO(burdon): Move to client-services and remove dependencies from here.
 const createNetworkManager = (config: Config, options: Partial<NetworkManagerOptions> = {}): NetworkManager => {
-  const signalServer = config.get('runtime.services.signal.server');
-  if (signalServer) {
+  const signalServers = config.get('runtime.services.signal')?.map((server: any) => server.servers);
+  if (signalServers) {
     const {
       log = true,
-      signalManager = new WebsocketSignalManager([signalServer]),
+      signalManager = new WebsocketSignalManager(signalServers),
       transportFactory = createWebRTCTransportFactory({
         iceServers: config.get('runtime.services.ice')
       })


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 71d11d8</samp>

### Summary
🔄🌐🐛

<!--
1.  🔄 This emoji represents the change in the subscription and unsubscription logic of the `MemorySignalManager` and `SignalMethods` classes, as well as the removal of the corresponding tests from the `integration.test.ts` file. It suggests a refactoring or a change in the interface or behavior of the code.
2. 🌐 This emoji represents the change in the `dx-dev.yml` and `dx.yml` files, as well as the `createNetworkManager` function, to support multiple signal servers in the configuration. It suggests a change in the network or infrastructure layer of the code.
3. 🐛 This emoji represents the improvement in the reconnection logic and error handling of the `SignalClient` and `SignalRpcClient` classes, as well as the removal of unnecessary state and logic from the `WebsocketSignalManager` class. It suggests a bug fix or an enhancement in the code quality or reliability.
-->
This pull request improves the signal client and manager classes by simplifying the message subscription and unsubscription logic, enhancing the reconnection and error handling mechanisms, and supporting multiple signal servers in the configuration. It also updates the core protocol, the invitations handler, and the network manager to use the new signal client and manager interfaces. It removes some unused or unnecessary code and dependencies, and modifies the test and configuration files accordingly.

> _`SignalClient` changed_
> _Reconnects and unsubscribes_
> _Winter of errors_

### Walkthrough
*  Add `ERROR` state to `SignalState` enum and handle errors from server by setting state and scheduling reconnection ([link](https://github.com/dxos/dxos/pull/2982/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fR36-R38), [link](https://github.com/dxos/dxos/pull/2982/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL263-R278), [link](https://github.com/dxos/dxos/pull/2982/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL284-R316)).


