### PR TITLE
feat: Add Invitations tracing

### DIFF
--- a/packages/sdk/client-services/src/packlets/services/service-context.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-context.ts
@@ -100,6 +100,7 @@ export class ServiceContext {
     this.identityManager._traceParent = this._instanceId;
 
     this.invitations = new InvitationsHandler(this.networkManager);
+    this.invitations._traceParent = this._instanceId;
 
     // TODO(burdon): _initialize called in multiple places.
     // TODO(burdon): Call _initialize on success.


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 329edc1</samp>

### Summary
🛠️📝📞

<!--
1.  🛠️ - This emoji represents the modification of the `ServiceContext` class, which is a tool or utility class that provides common functionality to other classes. The wrench emoji can be used to indicate fixing, adjusting, or improving something.
2.  📝 - This emoji represents the addition of tracing functionality, which involves writing or logging information about the execution of the program. The memo emoji can be used to indicate documentation, notes, or records.
3.  📞 - This emoji represents the invitation protocol, which involves communication or interaction between the host and the guest. The telephone emoji can be used to indicate calling, chatting, or connecting with someone.
-->
Added tracing functionality to the invitation protocol in the SDK client services. This allows tracking the flow of events and messages between hosts and guests when they join a party. The tracing uses the `trace` module and the instance ID as the parent trace ID.

> _Oh we are the coders of the `ServiceContext` class_
> _And we trace the invitations with a skillful touch_
> _We pass the instance ID as the parent trace ID_
> _And we heave away, me hearties, heave away_

### Walkthrough
* Import and use `trace` module to enable tracing of invitation protocol messages ([link](https://github.com/dxos/dxos/pull/2986/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328L20-R20), [link](https://github.com/dxos/dxos/pull/2986/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328L190-R199), [link](https://github.com/dxos/dxos/pull/2986/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328R205), [link](https://github.com/dxos/dxos/pull/2986/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328R214), [link](https://github.com/dxos/dxos/pull/2986/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328L276-R293), [link](https://github.com/dxos/dxos/pull/2986/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328R354), [link](https://github.com/dxos/dxos/pull/2986/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328R363), [link](https://github.com/dxos/dxos/pull/2986/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328L417-R470))
* Add `_traceParent` property to `InvitationsHandler` and `InvitationHostExtensionCallbacks` classes to store the parent trace ID for the service instance and the host extension ([link](https://github.com/dxos/dxos/pull/2986/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328R66-R69), [link](https://github.com/dxos/dxos/pull/2986/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328R224), [link](https://github.com/dxos/dxos/pull/2986/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328R422-R426))
* Pass the instance ID as the parent trace ID to the `InvitationsHandler` class in the `ServiceContext` constructor ([link](https://github.com/dxos/dxos/pull/2986/files?diff=unified&w=0#diff-32609ec40439f8092b97c3e3d20956a8e6651e0c6f70c9989fef4ec774e26f3bR103))


