### PR TITLE
fix(react-ui): don't swallow create identity error

### DIFF
--- a/packages/apps/patterns/react-ui/src/panels/JoinPanel/view-states/IdentityInput.tsx
+++ b/packages/apps/patterns/react-ui/src/panels/JoinPanel/view-states/IdentityInput.tsx
@@ -5,6 +5,7 @@
 import { CaretLeft, CaretRight } from '@phosphor-icons/react';
 import React, { ComponentPropsWithoutRef, useState } from 'react';
 
+import { log } from '@dxos/log';
 import { useClient } from '@dxos/react-client';
 import { Button, getSize, Input, mx, useTranslation } from '@dxos/react-components';
 
@@ -27,7 +28,8 @@ export const IdentityInput = ({ method, ...viewStateProps }: IdentityCreatorProp
       (identity) => {
         joinSend({ type: 'selectIdentity', identity });
       },
-      (_error) => {
+      (error) => {
+        log.catch(error);
         setValidationMessage(t(isRecover ? 'failed to recover identity message' : 'failed to create identity message'));
       }
     );


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c20cccf</samp>

### Summary
🐛📝🚸

<!--
1.  🐛 - This emoji represents a bug fix, since the lack of logging and user feedback was a bug that prevented users from knowing what went wrong when creating an identity.
2.  📝 - This emoji represents documentation, since the logging and validation messages provide more information and guidance for users and developers.
3.  🚸 - This emoji represents an improvement in user experience, since the identity creation process is now more transparent and responsive to user input and actions.
-->
Improved error handling for identity creation in `JoinPanel`. Added logging and user feedback using `log` and validation messages in `IdentityInput.tsx`.

> _`IdentityInput`_
> _Logs and shows errors to users_
> _Autumn leaves falling_

### Walkthrough
* Import `log` module to handle errors in `IdentityInput` component ([link](https://github.com/dxos/dxos/pull/2987/files?diff=unified&w=0#diff-966f1bd00409c86891a56d8017edb9d820eec31084fd490cbab18c9d7527c58aR8)).


