### PR TITLE
fix(client): revert default remote source

### DIFF
--- a/packages/apps/templates/bare-template/src/dx-dev.yml.t.ts
+++ b/packages/apps/templates/bare-template/src/dx-dev.yml.t.ts
@@ -1,19 +1,16 @@
 import { defineTemplate, text } from '@dxos/plate';
 import config from './config.t';
 
-export default defineTemplate<typeof config>(({ input }) => {
-  const { name, monorepo } = input;
-  return !monorepo
-    ? null
-    : text`
+export default defineTemplate<typeof config>(() => {
+  return text`
   version: 1
 
   runtime:
     client:
       remoteSource: http://localhost:3967/vault.html
-
-    services:
-      signal:
-        server: ws://localhost:8888/.well-known/dx/signal
   `;
+  // TODO(wittjosiah): Use local signal in monorepo.
+  // ${monorepo && text`services:
+  //   signal:
+  //     server: ws://localhost:8888/.well-known/dx/signal`}
 });

--- a/packages/experimental/kai/dx-dev.yml
+++ b/packages/experimental/kai/dx-dev.yml
@@ -2,6 +2,7 @@ version: 1
 
 runtime:
   client:
+    remoteSource: http://localhost:3967/vault.html
     storage:
       persistent: true
 

--- a/packages/sdk/client/src/packlets/client/config.ts
+++ b/packages/sdk/client/src/packlets/client/config.ts
@@ -7,8 +7,7 @@ import { ConfigProto } from '@dxos/config';
 export const DEFAULT_CLIENT_CHANNEL = 'dxos:app';
 export const DEFAULT_SHELL_CHANNEL = 'dxos:shell';
 
-export const DEFAULT_CLIENT_ORIGIN =
-  process.env.NODE_ENV === 'production' ? 'https://halo.dxos.org/vault.html' : 'http://localhost:3967/vault.html';
+export const DEFAULT_CLIENT_ORIGIN = 'https://halo.dxos.org/vault.html';
 
 export const EXPECTED_CONFIG_VERSION = 1;
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f07b88a</samp>

### Summary
🌐🪓🧹

<!--
1.  🌐 - This emoji represents the change to use the production URL for the client origin, since it implies connecting to the global network instead of a local one.
2.  🪓 - This emoji represents the simplification of the bare template by cutting out unused parameters and features, since it implies removing excess or unnecessary parts.
3.  🧹 - This emoji represents the cleanup of the code by commenting out and dropping unused code, since it implies tidying up and making things neater.
-->
Simplify the bare template for DXOS apps and ensure network connectivity. Remove unused features and parameters from `dx-dev.yml.t.ts` and `defineTemplate`. Use the production URL for `DEFAULT_CLIENT_ORIGIN` in `config.ts`.

> _The bare template was too complex_
> _So they trimmed it down with some regex_
> _They dropped `input` and `services.signal`_
> _And set `DEFAULT_CLIENT_ORIGIN` to the prod portal_
> _To make it easier to connect to DXOS_

### Walkthrough
*  Simplify `defineTemplate` function by removing unused `input` parameter ([link](https://github.com/dxos/dxos/pull/2988/files?diff=unified&w=0#diff-91747b8e41017a18042459d81c44bb9397880b397f344263ed2838ddfacba555L4-R5)).


