### PR TITLE
feat(react-appkit): Affordance for resetting client

### DIFF
--- a/packages/apps/composer-app/src/pages/DocumentPage.tsx
+++ b/packages/apps/composer-app/src/pages/DocumentPage.tsx
@@ -193,6 +193,8 @@ const RichTextDocumentPage = observer(({ document, space }: { document: Composer
 type ExportViewState = 'init' | 'pending' | 'response' | null;
 
 const MarkdownDocumentPage = observer(({ document, space }: { document: ComposerDocument; space: Space }) => {
+  throw new Error('Test fatal error');
+
   const editorRef = useRef<MarkdownComposerRef>(null);
   const identity = useIdentity();
   const { octokit } = useOctokitContext();

--- a/packages/apps/patterns/react-appkit/src/components/FatalError/FatalError.tsx
+++ b/packages/apps/patterns/react-appkit/src/components/FatalError/FatalError.tsx
@@ -5,7 +5,7 @@
 import { Clipboard } from '@phosphor-icons/react';
 import React, { useCallback } from 'react';
 
-import { Alert, Button, Dialog, useTranslation } from '@dxos/react-components';
+import { Alert, Button, Dialog, DropdownMenu, DropdownMenuItem, useTranslation } from '@dxos/react-components';
 
 import { Tooltip } from '../Tooltip';
 
@@ -55,17 +55,26 @@ export const FatalError = ({ error }: FatalErrorProps) => {
       ) : (
         <p>{t('fatal error message')}</p>
       )}
-      <div role='none' className='flex'>
+      <div role='none' className='flex gap-2'>
         <Tooltip content={t('copy error label')} zIndex={'z-[21]'}>
           <Button onClick={onCopyError}>
             <Clipboard weight='duotone' size='1em' />
           </Button>
         </Tooltip>
         <div role='none' className='flex-grow' />
-        {/* TODO(wittjosiah): How do we get access to Client here so that we can trigger reset? */}
-        {/* <Button variant='primary' onClick={() => client.reset()}>
-          {t('reset client label')}
-        </Button> */}
+        <DropdownMenu
+          trigger={<Button variant='ghost'>{t('reset client label')}</Button>}
+          slots={{ content: { side: 'top', className: 'z-[51]' } }}
+        >
+          <DropdownMenuItem
+            onClick={() => {
+              // TODO(wittjosiah): How do we get access to Client here so that we can trigger reset?
+              console.log('todo: reset');
+            }}
+          >
+            {t('reset client confirm label')}
+          </DropdownMenuItem>
+        </DropdownMenu>
         <Button variant='primary' onClick={() => location.reload()}>
           {t('reload page label')}
         </Button>

--- a/packages/apps/patterns/react-appkit/src/translations/en-US.ts
+++ b/packages/apps/patterns/react-appkit/src/translations/en-US.ts
@@ -95,5 +95,7 @@ export const appkit = {
   'list item input label': 'List item title',
   'list item input placeholder': 'Enter text…',
   'new list item input label': 'New list item title',
-  'new list item input placeholder': 'Enter text…'
+  'new list item input placeholder': 'Enter text…',
+  'reset client label': 'Reset',
+  'reset client confirm label': 'Yes, confirm reset'
 };

--- a/packages/common/react-components/src/styles/valence.ts
+++ b/packages/common/react-components/src/styles/valence.ts
@@ -5,10 +5,10 @@
 import { ThemeContextValue } from '../components';
 import { MessageValence } from '../props';
 
-export const successText = 'text-xs font-medium text-success-700 dark:text-success-300';
-export const infoText = 'text-xs font-medium text-info-700 dark:text-info-300';
-export const warningText = 'text-xs font-medium text-warning-700 dark:text-warning-300';
-export const errorText = 'text-xs font-medium text-error-700 dark:text-error-300';
+export const successText = 'text-xs font-medium text-success-600 dark:text-success-300';
+export const infoText = 'text-xs font-medium text-info-600 dark:text-info-300';
+export const warningText = 'text-xs font-medium text-warning-600 dark:text-warning-300';
+export const errorText = 'text-xs font-medium text-error-600 dark:text-error-300';
 
 export const valenceColorText = (valence?: MessageValence) => {
   switch (valence) {
@@ -50,13 +50,13 @@ export const inputValence = (valence?: MessageValence, themeVariant: ThemeContex
 
 export const neutralAlertColors = '';
 export const successAlertColors =
-  'shadow-success-500/50 dark:shadow-success-600/50 text-success-700 dark:text-success-100 bg-success-50 dark:bg-success-900';
+  'shadow-success-500/50 dark:shadow-success-500/50 text-success-600 dark:text-success-100 bg-success-50 dark:bg-success-900';
 export const infoAlertColors =
-  'shadow-info-500/50 dark:shadow-info-600/50 text-info-700 dark:text-info-100 bg-info-50 dark:bg-info-900';
+  'shadow-info-500/50 dark:shadow-info-500/50 text-info-600 dark:text-info-100 bg-info-50 dark:bg-info-900';
 export const warningAlertColors =
-  'shadow-warning-500/50 dark:shadow-warning-600/50 text-warning-700 dark:text-warning-100 bg-warning-50 dark:bg-warning-900';
+  'shadow-warning-500/50 dark:shadow-warning-500/50 text-warning-600 dark:text-warning-100 bg-warning-50 dark:bg-warning-900';
 export const errorAlertColors =
-  'shadow-error-500/50 dark:shadow-error-600/50 text-error-700 dark:text-error-100 bg-error-50 dark:bg-error-900';
+  'shadow-error-500/50 dark:shadow-error-500/50 text-error-600 dark:text-error-100 bg-error-50 dark:bg-error-900';
 
 export const alertValence = (valence?: MessageValence) => {
   switch (valence) {


### PR DESCRIPTION
Resolves #2888.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3058c0c</samp>

### Summary
🐛🌐🛠️

<!--
1.  🐛 for the test fatal error line, since it is a bug that should be fixed.
2.  🌐 for the new translation keys, since they are related to localization and language support.
3.  🛠️ for the `FatalError` component enhancement, since it is a feature improvement and a tool for troubleshooting.
-->
This pull request enhances the error handling and user interface of the `FatalError` component in the `react-appkit` package. It adds a dropdown menu for resetting the client, a confirmation dialog, and some style improvements. It also updates the text and shadow colors in `valence.ts` and adds new translation keys for the reset client option.

> _Sing, O Muse, of the valiant code warriors who toiled_
> _To enhance the `FatalError` component with new features and style_
> _But one among them, heedless of the final merge, left behind_
> _A test fatal error in the `ExportViewState` type, a grave mistake_

### Walkthrough
*  Add a dropdown menu for resetting the client in case of a fatal error ([link](https://github.com/dxos/dxos/pull/2994/files?diff=unified&w=0#diff-5db3b2ec4851302bbce072a243d8ee7d39c53188fe5a818f94e66488a435ddf8L8-R8), [link](https://github.com/dxos/dxos/pull/2994/files?diff=unified&w=0#diff-5db3b2ec4851302bbce072a243d8ee7d39c53188fe5a818f94e66488a435ddf8L58-R58), [link](https://github.com/dxos/dxos/pull/2994/files?diff=unified&w=0#diff-5db3b2ec4851302bbce072a243d8ee7d39c53188fe5a818f94e66488a435ddf8L65-R77), [link](https://github.com/dxos/dxos/pull/2994/files?diff=unified&w=0#diff-31f77f086c35d9ef0388af8545d917bdf59aa97f2bfdd6517036ab84833b1022L98-R100))
*  Adjust the text and shadow colors for the different valences of messages and alerts ([link](https://github.com/dxos/dxos/pull/2994/files?diff=unified&w=0#diff-882fa3d3652f0f159821e26664b1c3f437b79b810482852da8c8feffc735e5ddL8-R11), [link](https://github.com/dxos/dxos/pull/2994/files?diff=unified&w=0#diff-882fa3d3652f0f159821e26664b1c3f437b79b810482852da8c8feffc735e5ddL53-R59))
*  Throw a test fatal error in the `ExportViewState` type ([link](https://github.com/dxos/dxos/pull/2994/files?diff=unified&w=0#diff-d8c3220ce0c248d14eba87df32ecfe6231a829016f2898a8879a2a30c1bff130R196-R197))


