### PR TITLE
fix: print urls after publish command better

### DIFF
--- a/packages/devtools/cli/src/commands/app/publish.ts
+++ b/packages/devtools/cli/src/commands/app/publish.ts
@@ -4,6 +4,7 @@
 
 import { Flags } from '@oclif/core';
 import assert from 'node:assert';
+import os from 'os';
 
 import { captureException } from '@dxos/sentry';
 
@@ -75,7 +76,7 @@ export default class Publish extends BaseCommand {
           // TODO (zhenyasav): this is to de-advertise any non localhost urls because of security sandboxes
           // in the browser requiring https for those domains to support halo vault
           const filteredUrls = urls?.length ? urls.filter((u) => /localhost/.test(u)) : [];
-          this.log(`Module ${module.name} published${filteredUrls?.length ? filteredUrls.join(', ') : ''}.`);
+          this.log(`Module ${module.name} published.${filteredUrls?.length ? os.EOL + filteredUrls.join(os.EOL) : ''}`);
         });
       });
     } catch (err: any) {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 10cb603</samp>

### Summary
🖋️🎨📝

<!--
1.  🖋️ - This emoji can be used to indicate improvements or enhancements in writing, editing, or formatting, as well as changes related to documentation or communication. It is also known as the fountain pen emoji or the lower nib emoji.
2.  🎨 - This emoji can be used to indicate improvements or enhancements in the design, appearance, or style of something, as well as changes related to creativity or aesthetics. It is also known as the artist palette emoji or the painting emoji.
3.  📝 - This emoji can be used to indicate changes or updates to notes, memos, or lists, as well as changes related to tasks or planning. It is also known as the memo emoji or the pencil emoji.
-->
Enhanced the user experience of the `app:publish` command by improving the output format. Fixed some minor issues with end-of-line and punctuation in `publish.ts`.

> _The `app:publish` command was a mess_
> _It printed its output with excess_
> _So the coder refined_
> _The end-of-line and sign_
> _Now it looks much more neat and clear, yes?_

### Walkthrough
* Import `os` module to use `os.EOL` constant for end-of-line marker ([link](https://github.com/dxos/dxos/pull/2997/files?diff=unified&w=0#diff-180a94c19ada4302da939766ae95a1a3ced36737000ebcb5271704a9d8479635R7))
* Format output of `app:publish` command with `os.EOL` instead of comma and add period after module name ([link](https://github.com/dxos/dxos/pull/2997/files?diff=unified&w=0#diff-180a94c19ada4302da939766ae95a1a3ced36737000ebcb5271704a9d8479635L78-R79))


