### PR TITLE
feat(react-appkit): Persistent status & warning in corner, invokes Reset dialog

### DIFF
--- a/packages/apps/braneframe/src/App.tsx
+++ b/packages/apps/braneframe/src/App.tsx
@@ -16,7 +16,7 @@ import {
   ClientFallback,
   ErrorProvider,
   Fallback,
-  FatalError,
+  ResetDialog,
   ServiceWorkerToastContainer
 } from '@dxos/react-appkit';
 import { ClientProvider } from '@dxos/react-client';
@@ -47,7 +47,7 @@ export const App = () => {
     >
       <ErrorProvider>
         {/* TODO: (wittjosiah): Hook up user feedback mechanism. */}
-        <ErrorBoundary fallback={({ error }) => <FatalError error={error} />}>
+        <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} />}>
           <ClientProvider config={configProvider} services={servicesProvider} fallback={ClientFallback}>
             <HashRouter>
               <Routes />

--- a/packages/apps/composer-app/src/layouts/Root/Root.tsx
+++ b/packages/apps/composer-app/src/layouts/Root/Root.tsx
@@ -64,14 +64,14 @@ export const Root = () => {
       appNs='composer'
       tooltipProviderProps={{ delayDuration: 1200, skipDelayDuration: 600, disableHoverableContent: true }}
     >
-      <ErrorProvider>
-        {/* TODO(wittjosiah): Hook up user feedback mechanism. */}
-        <ErrorBoundary fallback={({ error }) => <FatalError error={error} />}>
-          <ClientProvider config={configProvider} services={servicesProvider} fallback={ClientFallback}>
+      {/* TODO(wittjosiah): Hook up user feedback mechanism. */}
+      <ErrorBoundary fallback={({ error }) => <FatalError error={error} />}>
+        <ClientProvider config={configProvider} services={servicesProvider} fallback={ClientFallback}>
+          <ErrorProvider>
             <DocumentLayout />
-          </ClientProvider>
-        </ErrorBoundary>
-      </ErrorProvider>
+          </ErrorProvider>
+        </ClientProvider>
+      </ErrorBoundary>
       {/* NOTE: Outside error boundary so that this renders even in the event of a fatal error. */}
       {needRefresh ? (
         <ServiceWorkerToast {...{ variant: 'needRefresh', updateServiceWorker }} />

--- a/packages/apps/composer-app/src/layouts/Root/Root.tsx
+++ b/packages/apps/composer-app/src/layouts/Root/Root.tsx
@@ -15,7 +15,7 @@ import {
   ClientFallback,
   ErrorProvider,
   Fallback,
-  FatalError,
+  ResetDialog,
   ServiceWorkerToast
 } from '@dxos/react-appkit';
 import { ClientProvider } from '@dxos/react-client';
@@ -65,7 +65,7 @@ export const Root = () => {
       tooltipProviderProps={{ delayDuration: 1200, skipDelayDuration: 600, disableHoverableContent: true }}
     >
       {/* TODO(wittjosiah): Hook up user feedback mechanism. */}
-      <ErrorBoundary fallback={({ error }) => <FatalError error={error} />}>
+      <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} />}>
         <ClientProvider config={configProvider} services={servicesProvider} fallback={ClientFallback}>
           <ErrorProvider>
             <DocumentLayout />

--- a/packages/apps/halo-app/src/App.tsx
+++ b/packages/apps/halo-app/src/App.tsx
@@ -15,7 +15,7 @@ import {
   ClientFallback,
   ErrorProvider,
   Fallback,
-  FatalError,
+  ResetDialog,
   ServiceWorkerToast,
   useTelemetry
 } from '@dxos/react-appkit';
@@ -112,7 +112,7 @@ export const App = withProfiler(() => {
     >
       <ErrorProvider>
         {/* TODO(wittjosiah): Hook-up user feedback mechanism. */}
-        <ErrorBoundary fallback={({ error }) => <FatalError error={error} />}>
+        <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} />}>
           <ClientProvider config={configProvider} services={serviceProvider} fallback={ClientFallback}>
             <MetagraphProvider>
               <HashRouter>

--- a/packages/apps/patterns/react-appkit/src/components/ErrorProvider/ErrorProvider.tsx
+++ b/packages/apps/patterns/react-appkit/src/components/ErrorProvider/ErrorProvider.tsx
@@ -9,7 +9,7 @@ import { SystemStatus, ClientContext } from '@dxos/react-client';
 import { valenceColorText, useTranslation, Button, getSize, DensityProvider } from '@dxos/react-components';
 import { captureException } from '@dxos/sentry';
 
-import { FatalError } from '../FatalError';
+import { ResetDialog } from '../ResetDialog';
 import { Tooltip } from '../Tooltip';
 
 export interface ErrorContextState {
@@ -97,7 +97,7 @@ export const ErrorProvider = ({ children, isDev = true }: PropsWithChildren<{ is
               )}
             </DensityProvider>
           </div>
-          <FatalError errors={errors} open={errorDialogOpen} onOpenChange={setErrorDialogOpen} />
+          <ResetDialog errors={errors} open={errorDialogOpen} onOpenChange={setErrorDialogOpen} />
         </>
       )}
     </ErrorContext.Provider>

--- a/packages/apps/patterns/react-appkit/src/components/ResetDialog/ResetDialog.tsx
+++ b/packages/apps/patterns/react-appkit/src/components/ResetDialog/ResetDialog.tsx
@@ -61,6 +61,7 @@ export const ResetDialog = ({
   return (
     <Dialog
       title={t(errors.length > 0 ? 'fatal error label' : 'reset dialog label')}
+      slots={{ content: { className: 'block' } }}
       {...(typeof defaultOpen === 'undefined' && typeof open === 'undefined' && typeof onOpenChange === 'undefined'
         ? { defaultOpen: true }
         : { defaultOpen, open, onOpenChange })}
@@ -81,7 +82,7 @@ export const ResetDialog = ({
       )}
       <div role='none' className='flex gap-2 mbs-4'>
         {errors.length > 0 && (
-          <Tooltip content={t('copy error label')} zIndex={'z-[21]'}>
+          <Tooltip content={t('copy error label')} zIndex='z-[51]'>
             <Button onClick={onCopyError}>
               <Clipboard weight='duotone' size='1em' />
             </Button>

--- a/packages/apps/patterns/react-appkit/src/components/ResetDialog/ResetDialog.tsx
+++ b/packages/apps/patterns/react-appkit/src/components/ResetDialog/ResetDialog.tsx
@@ -41,7 +41,7 @@ export type FatalErrorProps = Pick<DialogProps, 'defaultOpen' | 'open' | 'onOpen
   isDev?: boolean;
 };
 
-export const FatalError = ({
+export const ResetDialog = ({
   error,
   errors: propsErrors,
   isDev = process.env.NODE_ENV === 'development',
@@ -60,7 +60,7 @@ export const FatalError = ({
   // TODO(burdon): Make responsive (full page mobile).
   return (
     <Dialog
-      title={t('fatal error label')}
+      title={t(errors.length > 0 ? 'fatal error label' : 'reset dialog label')}
       {...(typeof defaultOpen === 'undefined' && typeof open === 'undefined' && typeof onOpenChange === 'undefined'
         ? { defaultOpen: true }
         : { defaultOpen, open, onOpenChange })}
@@ -71,20 +71,22 @@ export const FatalError = ({
             key={`${index}--${message}`}
             title={message}
             valence={'error'}
-            slots={{ root: { className: 'mlb-4' } }}
+            slots={{ root: { className: 'mlb-4 overflow-auto max-bs-72' } }}
           >
-            <pre className='text-xs overflow-auto max-w-72 max-h-72 overflow-hidden'>{stack}</pre>
+            <pre className='text-xs'>{stack}</pre>
           </Alert>
         ))
       ) : (
-        <p>{t('fatal error message')}</p>
+        <p>{t(errors.length > 0 ? 'fatal error message' : 'reset dialog message')}</p>
       )}
-      <div role='none' className='flex gap-2'>
-        <Tooltip content={t('copy error label')} zIndex={'z-[21]'}>
-          <Button onClick={onCopyError}>
-            <Clipboard weight='duotone' size='1em' />
-          </Button>
-        </Tooltip>
+      <div role='none' className='flex gap-2 mbs-4'>
+        {errors.length > 0 && (
+          <Tooltip content={t('copy error label')} zIndex={'z-[21]'}>
+            <Button onClick={onCopyError}>
+              <Clipboard weight='duotone' size='1em' />
+            </Button>
+          </Tooltip>
+        )}
         <div role='none' className='flex-grow' />
         <DropdownMenu
           trigger={<Button variant='ghost'>{t('reset client label')}</Button>}

--- a/packages/apps/patterns/react-appkit/src/components/ResetDialog/index.ts
+++ b/packages/apps/patterns/react-appkit/src/components/ResetDialog/index.ts
@@ -2,4 +2,4 @@
 // Copyright 2022 DXOS.org
 //
 
-export * from './FatalError';
+export * from './ResetDialog';

--- a/packages/apps/patterns/react-appkit/src/components/index.ts
+++ b/packages/apps/patterns/react-appkit/src/components/index.ts
@@ -7,7 +7,7 @@ export * from './DeviceList';
 export * from './EditableList';
 export * from './ErrorProvider';
 export * from './Fallback';
-export * from './FatalError';
+export * from './ResetDialog';
 export * from './HeadingWithActions';
 export * from './InvitationList';
 export * from './Join';

--- a/packages/apps/patterns/react-appkit/src/translations/en-US.ts
+++ b/packages/apps/patterns/react-appkit/src/translations/en-US.ts
@@ -30,8 +30,11 @@ export const appkit = {
   'remove label': 'Remove',
   'confirm label': 'Okay',
   'validate seed phrase label': 'Validate seed phrase',
-  'fatal error label': 'Runtime error',
-  'fatal error message': 'Something went wrong that requires the app to be reloaded.',
+  'fatal error label': 'A wild error appeared',
+  'fatal error message': 'Reloading the app might fix the issue. If it doesn’t, consider resetting the app.',
+  'reset dialog label': 'Reload or reset',
+  'reset dialog message':
+    'If you’re encountering issues, reloading may fix the issue. If reloading doesn’t help, consider resetting the app.',
   'caught error message': 'Something went wrong; check the console for details.',
   'copy error label': 'Copy this error',
   'reload page label': 'Reload',

--- a/packages/apps/patterns/react-appkit/src/translations/en-US.ts
+++ b/packages/apps/patterns/react-appkit/src/translations/en-US.ts
@@ -30,7 +30,7 @@ export const appkit = {
   'remove label': 'Remove',
   'confirm label': 'Okay',
   'validate seed phrase label': 'Validate seed phrase',
-  'fatal error label': 'A wild error appeared',
+  'fatal error label': 'The app encountered one or more errors',
   'fatal error message': 'Reloading the app might fix the issue. If it doesn’t, consider resetting the app.',
   'reset dialog label': 'Reload or reset',
   'reset dialog message':

--- a/packages/apps/tasks-app/src/App.tsx
+++ b/packages/apps/tasks-app/src/App.tsx
@@ -16,7 +16,7 @@ import {
   ClientFallback,
   ErrorProvider,
   Fallback,
-  FatalError,
+  ResetDialog,
   ServiceWorkerToast
 } from '@dxos/react-appkit';
 import { ClientProvider } from '@dxos/react-client';
@@ -51,7 +51,7 @@ export const App = withProfiler(() => {
     >
       <ErrorProvider>
         {/* TODO: (wittjosiah): Hook up user feedback mechanism. */}
-        <ErrorBoundary fallback={({ error }) => <FatalError error={error} />}>
+        <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} />}>
           <ClientProvider config={configProvider} services={servicesProvider} fallback={ClientFallback}>
             <HashRouter>
               <Routes />

--- a/packages/common/react-components/src/styles/valence.ts
+++ b/packages/common/react-components/src/styles/valence.ts
@@ -5,10 +5,10 @@
 import { ThemeContextValue } from '../components';
 import { MessageValence } from '../props';
 
-export const successText = 'text-xs font-medium text-success-600 dark:text-success-300';
-export const infoText = 'text-xs font-medium text-info-600 dark:text-info-300';
-export const warningText = 'text-xs font-medium text-warning-600 dark:text-warning-300';
-export const errorText = 'text-xs font-medium text-error-600 dark:text-error-300';
+export const successText = 'text-xs font-medium text-success-550 dark:text-success-300';
+export const infoText = 'text-xs font-medium text-info-550 dark:text-info-300';
+export const warningText = 'text-xs font-medium text-warning-550 dark:text-warning-300';
+export const errorText = 'text-xs font-medium text-error-550 dark:text-error-300';
 
 export const valenceColorText = (valence?: MessageValence) => {
   switch (valence) {

--- a/packages/experimental/kai/src/containers/Root/Root.tsx
+++ b/packages/experimental/kai/src/containers/Root/Root.tsx
@@ -9,7 +9,7 @@ import { Outlet } from 'react-router-dom';
 import { FrameRegistryContextProvider, frameDefs, frameModules } from '@dxos/kai-frames';
 import { typeModules } from '@dxos/kai-types';
 import { MetagraphClientFake } from '@dxos/metagraph';
-import { appkitTranslations, ErrorProvider, FatalError } from '@dxos/react-appkit';
+import { appkitTranslations, ErrorProvider, ResetDialog } from '@dxos/react-appkit';
 import { ClientProvider } from '@dxos/react-client';
 import { ThemeProvider } from '@dxos/react-components';
 import { MetagraphProvider } from '@dxos/react-metagraph';
@@ -35,7 +35,7 @@ export const Root: FC<PropsWithChildren<{ initialState?: Partial<AppState> }>> =
       resourceExtensions={[appkitTranslations, kaiTranslations, osTranslations]}
     >
       <ErrorProvider>
-        <ErrorBoundary fallback={({ error }) => <FatalError error={error} />}>
+        <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} />}>
           <ClientProvider client={clientProvider}>
             <MetagraphProvider value={metagraphContext}>
               <FrameRegistryContextProvider frameDefs={frameDefs}>

--- a/packages/experimental/kube-console/src/containers/Root.tsx
+++ b/packages/experimental/kube-console/src/containers/Root.tsx
@@ -8,7 +8,7 @@ import { Outlet } from 'react-router-dom';
 
 import { fromHost } from '@dxos/client-services';
 import { Defaults, Envs } from '@dxos/config';
-import { appkitTranslations, ErrorProvider, FatalError } from '@dxos/react-appkit';
+import { appkitTranslations, ErrorProvider, ResetDialog } from '@dxos/react-appkit';
 import { ClientProvider, Config } from '@dxos/react-client';
 import { ThemeProvider } from '@dxos/react-components';
 import { osTranslations } from '@dxos/react-ui';
@@ -23,7 +23,7 @@ export const Root: FC<PropsWithChildren> = ({ children }) => {
   return (
     <ThemeProvider appNs='console' rootDensity='fine' resourceExtensions={[appkitTranslations, osTranslations]}>
       <ErrorProvider>
-        <ErrorBoundary fallback={({ error }) => <FatalError error={error} />}>
+        <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} />}>
           <ClientProvider config={configProvider} services={fromHost}>
             <Fullscreen>
               <Outlet />


### PR DESCRIPTION
Quick and dirty implementation of the feature discussed here, open to feedback & refinement ideas.

Resolves #2992.
Resolves #2993.

https://user-images.githubusercontent.com/855039/231321935-19392252-9dca-4e0f-8454-fdff7f3176b8.mp4

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8f6cd6e</samp>

### Summary
🚚🌈🚨

<!--
1.  🚚 - This emoji represents the moving of the `ErrorProvider` component inside the `ClientProvider` component, as it suggests relocation or transportation.
2.  🌈 - This emoji represents the updating of the `valenceColorText` function to use lighter colors, as it suggests brightness or diversity of colors.
3.  🚨 - This emoji represents the enhancement of the `ErrorProvider` component to show a system status icon and an error dialog, as it suggests urgency or alertness.
-->
Enhanced the error handling and display in the `react-appkit` and `composer-app` packages. Added a system status icon and an error dialog to the `ErrorProvider` component, and improved the `FatalError` component to show multiple errors. Moved the `ErrorProvider` inside the `ClientProvider` to avoid unnecessary errors. Adjusted the text color of the error button and icon for better contrast.

> _To handle errors with more grace_
> _We moved `ErrorProvider` in place_
> _Inside `ClientProvider`_
> _It shows an icon higher_
> _And a dialog in dev mode's case_

### Walkthrough
*  Move `ErrorProvider` inside `ClientProvider` to avoid rendering errors when the client is not ready or offline, and to access the client status ([link](https://github.com/dxos/dxos/pull/2998/files?diff=unified&w=0#diff-dfc3f057afef5177d1e4486bc64df322bbe85f763dbe9c1b024193320ded966cL67-R74)).


