### PR TITLE
fix(vault): avoid double-initializing client services

### DIFF
--- a/packages/sdk/vault/src/iframe.ts
+++ b/packages/sdk/vault/src/iframe.ts
@@ -50,13 +50,15 @@ export const startIFrameRuntime = async (getWorker: () => SharedWorker) => {
         channel: 'dxos:app',
         onOrigin: async (origin) => {
           iframeRuntime.origin = origin;
-          iframeRuntime.shell && (await startShell(config, iframeRuntime.shell, iframeRuntime.services, origin));
         }
       }),
       shellPort: shellDisabled ? undefined : createIFramePort({ channel: 'dxos:shell' })
     });
 
     await iframeRuntime.start();
+    iframeRuntime.shell &&
+      iframeRuntime.origin &&
+      (await startShell(config, iframeRuntime.shell, iframeRuntime.services, iframeRuntime.origin));
 
     window.addEventListener('beforeunload', () => {
       iframeRuntime.stop().catch((err: Error) => log.catch(err));


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5e1e3e8</samp>

### Summary
🔒🛡️🔄

<!--
1.  🔒 - This emoji represents security, and can be used to indicate that the pull request enhances the security of the code or the application.
2.  🛡️ - This emoji represents protection, and can be used to indicate that the pull request improves the reliability or robustness of the code or the application.
3.  🔄 - This emoji represents change, and can be used to indicate that the pull request modifies or updates the existing code or functionality.
-->
This pull request enhances the iframe communication in the `IFrameRuntime` class. It uses the iframe's location to determine the origin instead of a variable.

> _`IFrameRuntime` class_
> _Secures the window talk_
> _With `origin` change_

### Walkthrough
*  Remove `origin` variable and use `iframeRuntime.origin` property instead to determine parent window origin ([link](https://github.com/dxos/dxos/pull/3007/files?diff=unified&w=0#diff-ab250f2acd4b584871491e81ca9ce20acfdf156949461d59dca74bac55130a7bL53), [link](https://github.com/dxos/dxos/pull/3007/files?diff=unified&w=0#diff-ab250f2acd4b584871491e81ca9ce20acfdf156949461d59dca74bac55130a7bR59-R61))


