### PR TITLE
feat(vault): reset storage

### DIFF
--- a/packages/apps/braneframe/src/App.tsx
+++ b/packages/apps/braneframe/src/App.tsx
@@ -47,7 +47,7 @@ export const App = () => {
     >
       <ErrorProvider>
         {/* TODO: (wittjosiah): Hook up user feedback mechanism. */}
-        <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} />}>
+        <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} config={configProvider} />}>
           <ClientProvider config={configProvider} services={servicesProvider} fallback={ClientFallback}>
             <HashRouter>
               <Routes />

--- a/packages/apps/composer-app/src/layouts/Root/Root.tsx
+++ b/packages/apps/composer-app/src/layouts/Root/Root.tsx
@@ -65,7 +65,7 @@ export const Root = () => {
       tooltipProviderProps={{ delayDuration: 1200, skipDelayDuration: 600, disableHoverableContent: true }}
     >
       {/* TODO(wittjosiah): Hook up user feedback mechanism. */}
-      <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} />}>
+      <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} config={configProvider} />}>
         <ClientProvider config={configProvider} services={servicesProvider} fallback={ClientFallback}>
           <ErrorProvider>
             <DocumentLayout />

--- a/packages/apps/halo-app/src/App.tsx
+++ b/packages/apps/halo-app/src/App.tsx
@@ -106,7 +106,7 @@ export const App = withProfiler(() => {
     >
       <ErrorProvider>
         {/* TODO(wittjosiah): Hook-up user feedback mechanism. */}
-        <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} />}>
+        <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} config={configProvider} />}>
           <ClientProvider config={configProvider} services={serviceProvider} fallback={ClientFallback}>
             <MetagraphProvider>
               <HashRouter>

--- a/packages/apps/halo-app/src/vault.ts
+++ b/packages/apps/halo-app/src/vault.ts
@@ -5,16 +5,23 @@
 import '@dxosTheme';
 import { Config, Defaults } from '@dxos/config';
 import { initializeAppTelemetry } from '@dxos/react-appkit/telemetry';
-import { startIFrameRuntime } from '@dxos/vault';
+import { startIFrameRuntime, forceClientReset } from '@dxos/vault';
 
 import { namespace } from './util';
 
 void initializeAppTelemetry({ namespace, config: new Config(Defaults()) });
-void startIFrameRuntime(
-  () =>
-    // NOTE: Url must be within SharedWorker instantiation for bundling to work as expected.
-    new SharedWorker(new URL('@dxos/vault/shared-worker', import.meta.url), {
-      type: 'module',
-      name: 'dxos-vault'
-    })
-);
+
+const reset = window.location.hash === '#reset';
+
+if (reset) {
+  void forceClientReset();
+} else {
+  void startIFrameRuntime(
+    () =>
+      // NOTE: Url must be within SharedWorker instantiation for bundling to work as expected.
+      new SharedWorker(new URL('@dxos/vault/shared-worker', import.meta.url), {
+        type: 'module',
+        name: 'dxos-vault'
+      })
+  );
+}

--- a/packages/apps/patterns/react-appkit/src/components/ResetDialog/ResetDialog.tsx
+++ b/packages/apps/patterns/react-appkit/src/components/ResetDialog/ResetDialog.tsx
@@ -5,6 +5,8 @@
 import { Clipboard } from '@phosphor-icons/react';
 import React, { useCallback } from 'react';
 
+import { DEFAULT_CLIENT_ORIGIN } from '@dxos/client';
+import { Config } from '@dxos/config';
 import {
   Alert,
   Button,
@@ -14,6 +16,7 @@ import {
   DropdownMenuItem,
   useTranslation
 } from '@dxos/react-components';
+import { getAsyncValue, Provider } from '@dxos/util';
 
 import { Tooltip } from '../Tooltip';
 
@@ -38,12 +41,15 @@ const parseError = (error: Error) => {
 export type FatalErrorProps = Pick<DialogProps, 'defaultOpen' | 'open' | 'onOpenChange'> & {
   error?: Error;
   errors?: Error[];
+  config?: Config | Provider<Promise<Config>>;
   isDev?: boolean;
 };
 
 export const ResetDialog = ({
   error,
   errors: propsErrors,
+  config: configProvider,
+  // TODO(wittjosiah): Don't use process.env.
   isDev = process.env.NODE_ENV === 'development',
   defaultOpen,
   open,
@@ -94,9 +100,11 @@ export const ResetDialog = ({
           slots={{ content: { side: 'top', className: 'z-[51]' } }}
         >
           <DropdownMenuItem
-            onClick={() => {
-              // TODO(wittjosiah): How do we get access to Client here so that we can trigger reset?
-              console.log('todo: reset');
+            onClick={async () => {
+              // TODO(wittjosiah): This is a hack.
+              //   We should have access to client here and be able to reset over rpc even if storage is corrupted.
+              const config = await getAsyncValue(configProvider);
+              window.open(`${config?.get('runtime.client.remoteSource') ?? DEFAULT_CLIENT_ORIGIN}#reset`, '_blank');
             }}
           >
             {t('reset client confirm label')}

--- a/packages/apps/tasks-app/src/App.tsx
+++ b/packages/apps/tasks-app/src/App.tsx
@@ -51,7 +51,7 @@ export const App = withProfiler(() => {
     >
       <ErrorProvider>
         {/* TODO: (wittjosiah): Hook up user feedback mechanism. */}
-        <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} />}>
+        <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} config={configProvider} />}>
           <ClientProvider config={configProvider} services={servicesProvider} fallback={ClientFallback}>
             <HashRouter>
               <Routes />

--- a/packages/apps/templates/bare-template/src/src/App.tsx.t.ts
+++ b/packages/apps/templates/bare-template/src/src/App.tsx.t.ts
@@ -18,7 +18,7 @@ export default defineTemplate(
     const swToast = () => `<${ServiceWorkerToastContainer()} {...serviceWorker} />`;
     
     const coreContent = text`
-    <ErrorBoundary fallback={${ResetDialog()}}>
+    <ErrorBoundary fallback={({ error }) => <${ResetDialog()} error={error} config={config} />}>
       <${ClientProvider()} config={config} ${dxosUi ? `fallback={${GenericFallback()}}` : ''}>
         ${render?.content?.()}
         ${dxosUi && pwa && swToast()}

--- a/packages/experimental/kai/src/containers/Root/Root.tsx
+++ b/packages/experimental/kai/src/containers/Root/Root.tsx
@@ -15,7 +15,7 @@ import { ThemeProvider } from '@dxos/react-components';
 import { MetagraphProvider } from '@dxos/react-metagraph';
 import { osTranslations } from '@dxos/react-ui';
 
-import { AppState, AppStateProvider, useClientProvider, botModules, defaultFrames } from '../../hooks';
+import { AppState, AppStateProvider, configProvider, useClientProvider, botModules, defaultFrames } from '../../hooks';
 import kaiTranslations from '../../translations';
 import { ShellProvider } from '../ShellProvider';
 
@@ -35,7 +35,7 @@ export const Root: FC<PropsWithChildren<{ initialState?: Partial<AppState> }>> =
       resourceExtensions={[appkitTranslations, kaiTranslations, osTranslations]}
     >
       <ErrorProvider>
-        <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} />}>
+        <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} config={configProvider} />}>
           <ClientProvider client={clientProvider}>
             <MetagraphProvider value={metagraphContext}>
               <FrameRegistryContextProvider frameDefs={frameDefs}>

--- a/packages/experimental/kai/src/hooks/useClientProvider.ts
+++ b/packages/experimental/kai/src/hooks/useClientProvider.ts
@@ -12,9 +12,11 @@ import { schema as sandboxSchema } from '@dxos/kai-sandbox';
 import { schema } from '@dxos/kai-types';
 import { Generator } from '@dxos/kai-types/testing';
 
+export const configProvider = async () => new Config(await Dynamics(), await Envs(), Defaults());
+
 export const useClientProvider = (dev: boolean) => {
   return useCallback(async () => {
-    const config = new Config(await Dynamics(), await Envs(), Defaults());
+    const config = await configProvider();
     const client = new Client({
       config,
       services: config.get('runtime.app.env.DX_VAULT') === 'false' ? fromHost(config) : fromIFrame(config)

--- a/packages/experimental/kube-console/src/containers/Root.tsx
+++ b/packages/experimental/kube-console/src/containers/Root.tsx
@@ -23,7 +23,7 @@ export const Root: FC<PropsWithChildren> = ({ children }) => {
   return (
     <ThemeProvider appNs='console' rootDensity='fine' resourceExtensions={[appkitTranslations, osTranslations]}>
       <ErrorProvider>
-        <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} />}>
+        <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} config={configProvider} />}>
           <ClientProvider config={configProvider} services={fromHost}>
             <Fullscreen>
               <Outlet />

--- a/packages/sdk/client-services/src/packlets/services/service-context.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-context.ts
@@ -138,13 +138,6 @@ export class ServiceContext {
     log.trace('dxos.sdk.service-context', trace.end({ id: this._instanceId }));
   }
 
-  async reset() {
-    log('resetting...');
-    await this.close();
-    await this.storage.reset();
-    log('reset');
-  }
-
   async createIdentity(params: CreateIdentityOptions = {}) {
     const identity = await this.identityManager.createIdentity(params);
 

--- a/packages/sdk/client-services/src/packlets/services/service-host.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-host.ts
@@ -109,8 +109,7 @@ export class ClientServicesHost {
       },
 
       onReset: async () => {
-        assert(this._serviceContext, 'service host is closed');
-        await this._serviceContext.reset();
+        await this.reset();
       }
     });
 
@@ -235,5 +234,12 @@ export class ClientServicesHost {
     log('closed', { deviceKey });
 
     log.trace('dxos.sdk.client-services-host', trace.end({ id: this._instanceId }));
+  }
+
+  async reset() {
+    log('resetting...');
+    await this._serviceContext?.close();
+    await this._storage!.reset();
+    log('reset');
   }
 }

--- a/packages/sdk/vault/src/iframe.ts
+++ b/packages/sdk/vault/src/iframe.ts
@@ -5,7 +5,7 @@
 import { StrictMode } from 'react';
 
 import { Client, ClientServicesProvider, ClientServicesProxy } from '@dxos/client';
-import { IFrameHostRuntime, IFrameProxyRuntime, ShellRuntime } from '@dxos/client-services';
+import { fromHost, IFrameHostRuntime, IFrameProxyRuntime, ShellRuntime } from '@dxos/client-services';
 import { Config, Defaults, Dynamics } from '@dxos/config';
 import { log } from '@dxos/log';
 import { ClientContext } from '@dxos/react-client';
@@ -92,4 +92,24 @@ export const startIFrameRuntime = async (getWorker: () => SharedWorker) => {
       iframeRuntime.close().catch((err: Error) => log.catch(err));
     });
   }
+};
+
+/**
+ * Resets client storage directly via the host and renders message on completion.
+ */
+export const forceClientReset = async () => {
+  const config = new Config(Defaults());
+
+  // TODO(wittjosiah): This doesn't work with WebFS adapter because files aren't loaded yet.
+  // const services = new ClientServicesHost({ config });
+  // await services.reset();
+
+  const client = new Client({ config, services: fromHost(config) });
+  await client.initialize();
+  await client.reset();
+
+  // TODO(wittjosiah): Make this look nicer.
+  const message = document.createElement('div');
+  message.textContent = 'Client storage has been reset. Return to the app and reload.';
+  document.body.appendChild(message);
 };

--- a/packages/sdk/vault/src/main.ts
+++ b/packages/sdk/vault/src/main.ts
@@ -6,15 +6,22 @@ import '@dxosTheme';
 import { Config, Defaults } from '@dxos/config';
 import { initializeAppTelemetry } from '@dxos/react-appkit/telemetry';
 
-import { startIFrameRuntime } from './iframe';
+import { forceClientReset, startIFrameRuntime } from './iframe';
 import { namespace } from './util';
 
 void initializeAppTelemetry({ namespace, config: new Config(Defaults()) });
-void startIFrameRuntime(
-  () =>
-    // NOTE: Url must be within SharedWorker instantiation for bundling to work as expected.
-    new SharedWorker(new URL('./shared-worker', import.meta.url), {
-      type: 'module',
-      name: 'dxos-vault'
-    })
-);
+
+const reset = window.location.hash === '#reset';
+
+if (reset) {
+  void forceClientReset();
+} else {
+  void startIFrameRuntime(
+    () =>
+      // NOTE: Url must be within SharedWorker instantiation for bundling to work as expected.
+      new SharedWorker(new URL('./shared-worker', import.meta.url), {
+        type: 'module',
+        name: 'dxos-vault'
+      })
+  );
+}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fbd2eb9</samp>

### Summary
🗑️🔁🔧

<!--
1.  🗑️ - This emoji represents the removal of the `reset` method from the `ServiceContext` class, as well as the deletion of the `reset.ts` file from the `util` folder of the `vault` package. It conveys the idea of discarding or deleting something that is no longer needed or used.
2.  🔁 - This emoji represents the addition of the `reset.ts` file to the `util` folder of the `vault` package, as well as the modification of the `main.ts` file to check the window location hash for the `#reset` value. It conveys the idea of resetting or restarting something that has an issue or needs a fresh start.
3.  🔧 - This emoji represents the simplification and refactoring of the reset logic of the `ClientServicesHost` class, as well as the relocation of the responsibility of closing and resetting the service context and storage from the `ServiceContext` class to the `ClientServicesHost` class. It conveys the idea of fixing or improving something that is broken or suboptimal.
-->
Refactored the client storage reset logic and added a way to trigger it via the vault URL. Moved the storage management from the `ServiceContext` class to the `ClientServicesHost` class and exposed a `reset` method on the host. Added a `reset.ts` file to the `vault` package that defines a `forceClientReset` function, which is called by the `main.ts` file when the window location hash is `#reset`.

> _To reset the client storage with ease_
> _We added a hash to the URL, please_
> _The `forceClientReset` function_
> _Does the job without obstruction_
> _And the `ServiceContext` can rest in peace_

### Walkthrough
*  Remove `reset` method from `ServiceContext` class and delegate storage management to `ClientServicesHost` class ([link](https://github.com/dxos/dxos/pull/3009/files?diff=unified&w=0#diff-32609ec40439f8092b97c3e3d20956a8e6651e0c6f70c9989fef4ec774e26f3bL141-L147))
*  Simplify `onReset` handler of `ClientServicesHost` class to call its own `reset` method instead of accessing private property ([link](https://github.com/dxos/dxos/pull/3009/files?diff=unified&w=0#diff-428c756de00c4abe2ea87923e6692247b6d3c07051fab795a5385d36954ff93eL112-R112))
*  Add `reset` method to `ClientServicesHost` class to close service context and reset storage, with logging for debugging ([link](https://github.com/dxos/dxos/pull/3009/files?diff=unified&w=0#diff-428c756de00c4abe2ea87923e6692247b6d3c07051fab795a5385d36954ff93eR238-R246))
*  Add `reset.ts` file to `util` folder of `vault` package, defining `forceClientReset` function to reset client storage directly via `ClientServicesHost` instance ([link](https://github.com/dxos/dxos/pull/3009/files?diff=unified&w=0#diff-27d6aef516f305d597a5734cb8f1fb24e1a48c0fbbf3d5042f36a66189fda25aR1-R19))
*  Export `reset.ts` file from `util` folder of `vault` package ([link](https://github.com/dxos/dxos/pull/3009/files?diff=unified&w=0#diff-6ee87cdf9fb5e2e321133276887e1ea729c42316c4bf90eccbad7808e2834c05R7))
*  Modify `main.ts` file of `vault` package to check window location hash for `#reset` value and call `forceClientReset` function if present, otherwise start iframe runtime ([link](https://github.com/dxos/dxos/pull/3009/files?diff=unified&w=0#diff-58320d941ded4a886277f6d18b49d578ced201f7e42c12f4d637e42c6c1bf428L10-R27))


