### PR TITLE
fix: docs cleanup and improved printing of urls in publish cmd to sup…

### DIFF
--- a/docs/docs/guide/getting-started.md
+++ b/docs/docs/guide/getting-started.md
@@ -28,26 +28,35 @@ DXOS works in any Node.js or Browser environment. There is a [TypeScript API](ty
 
 This guide will walk you through creating and deploying a `react` app.
 
-Initialize an empty folder with `npm init` like this:
+Ensure `node -v` is at version 18 or higher (recommend [Node Version Manager](https://github.com/nvm-sh/nvm)).
+
+First, create a new empty folder
+
+```bash
+mkdir hello
+cd hello
+```
+
+Initialize the app with `npm init` like this:
 
 ```bash
 npm init @dxos@latest
 ```
 
-Then:
+::: note
+If you encounter an error with `EINVALIDPACKAGENAME` it's likely the npm/node versions are out of date. Ensure `node -v` is 18 or higher and `npm -v` is 9 or higher.
+:::
+
+Then, use your favorite package manager such as `yarn`, `npm` or `pnpm`:
 
 ```bash
 pnpm install
 pnpm serve
 ```
 
-::: note
-Only [`pnpm`](https://pnpm.io/) is supported for now: `npm i -g pnpm`.
-:::
+This will start the development server and print its URL 🚀.
 
-This will start the development server 🚀.
-
-You should be able to open two windows pointed at the dev server and see reactive updates like in the video below.
+Now it should be possible to open two windows to that URL and see reactive updates like in the video below.
 
 <video class="dark" controls loop autoplay style="width:100%" src="/images/hello-dark.mp4"></video> <video class="light" controls loop autoplay style="width:100%" src="/images/hello-light.mp4"></video>
 

--- a/docs/docs/guide/troubleshoot.md
+++ b/docs/docs/guide/troubleshoot.md
@@ -4,8 +4,20 @@ order: 100
 
 # Troubleshooting
 
-### Resetting IndexDB
+### Resetting Storage
 
-You may occasionally need to reset the IndexDB database behind [`HALO`](./platform/halo.md) in case of problems.
+You may occasionally need to reset the storage state behind [`HALO`](./platform/halo.md) in case of problems.
 
-To do this, navigate to the `Application` tab in your browser developer tools, and locate the IndexDB node. Select the IndexDB database on the `halo.dxos.org` domain (or any others you control) and click `Delete`. The database will be re-created on the next run.
+::: warning
+This procedure clears all storage for all apps using ECHO and HALO on the machine.
+:::
+
+- navigate a browser to `halo.dxos.org` (or wherever the [vault](./glossary.md#vault) was configured to be - by default it's `halo.dxos.org`)
+- open developer tools in the browser
+- go to the `Application` tab developer tools, and locate the Storage node. 
+- click `Clear site data`
+- go back to your app and reload, the storage should be re-created
+
+### `EINVALIDPACKAGENAME` when initializing a new app
+
+This is likely due to an older version of `npm` and/or `node`. To use `npm init @dxos@latest` node needs to be at `v18` or newer. We recommend using [Node Version Manager](https://github.com/nvm-sh/nvm) or similar to ensure `node >= 18` and `npm >= 9`.

--- a/packages/devtools/cli/src/commands/app/publish.ts
+++ b/packages/devtools/cli/src/commands/app/publish.ts
@@ -75,7 +75,8 @@ export default class Publish extends BaseCommand {
         result?.modules?.forEach(({ module, urls }) => {
           // TODO (zhenyasav): this is to de-advertise any non localhost urls because of security sandboxes
           // in the browser requiring https for those domains to support halo vault
-          const filteredUrls = urls?.length ? urls.filter((u) => /localhost/.test(u)) : [];
+          // also allow https urls but not any http urls unless they contain localhost (not perfect)
+          const filteredUrls = urls?.length ? urls.filter((u) => !/^http:/.test(u) || /localhost/.test(u)) : [];
           this.log(`Module ${module.name} published.${filteredUrls?.length ? os.EOL + filteredUrls.join(os.EOL) : ''}`);
         });
       });


### PR DESCRIPTION
…port tunneling

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a98ca93</samp>

### Summary
📚🔒🚀

<!--
1.  📚 for moving and updating the troubleshooting section, since this is related to documentation and knowledge.
2. 🔒 for modifying the URL filtering logic, since this is related to security and encryption.
3. 🚀 for improving the getting started guide, since this is related to launching and developing an app.
-->
This pull request enhances the documentation and the devtools CLI for creating and publishing apps with DXOS. It adds more guidance and options for `getting-started.md`, moves and expands the `Troubleshooting` section, and filters out insecure URLs from `publish.ts`.

> _We are the devtools of doom_
> _We publish our modules with `halo`_
> _We troubleshoot the `EINVALIDPACKAGENAME`_
> _We create our apps with DXOS_

### Walkthrough
* Update the `Create an app` section of the getting started guide to include node and npm version checks, folder creation, and package manager flexibility ([link](https://github.com/dxos/dxos/pull/3010/files?diff=unified&w=0#diff-2c07c4c912c91450e98a2760b54580d151051cc9189bafc658f3a362b88a7712L31-R51),[link](https://github.com/dxos/dxos/pull/3010/files?diff=unified&w=0#diff-2c07c4c912c91450e98a2760b54580d151051cc9189bafc658f3a362b88a7712L44-R60)).


