### PR TITLE
feat(bare-template): add error boundary

### DIFF
--- a/packages/apps/templates/bare-template/src/src/App.tsx.t.ts
+++ b/packages/apps/templates/bare-template/src/src/App.tsx.t.ts
@@ -10,18 +10,20 @@ export default defineTemplate(
     const { Config, Dynamics, Defaults } = imports.lazy(['Config', 'Dynamics', 'Defaults'], '@dxos/config');
     const ThemeProvider = imports.lazy('ThemeProvider', '@dxos/react-components');
     const useRegisterSW = imports.lazy('useRegisterSW', 'virtual:pwa-register/react');
-    const { ServiceWorkerToastContainer, GenericFallback, appkitTranslations } = imports.lazy(
-      ['ServiceWorkerToastContainer', 'GenericFallback', 'appkitTranslations'],
+    const { FatalError, ServiceWorkerToastContainer, GenericFallback, appkitTranslations } = imports.lazy(
+      ['FatalError', 'ServiceWorkerToastContainer', 'GenericFallback', 'appkitTranslations'],
       '@dxos/react-appkit'
     );
 
     const swToast = () => `<${ServiceWorkerToastContainer()} {...serviceWorker} />`;
     
     const coreContent = text`
-    <${ClientProvider()} config={config} ${dxosUi ? `fallback={${GenericFallback()}}` : ''}>
-      ${render?.content?.()}
-      ${dxosUi && pwa && swToast()}
-    </${ClientProvider()}>`;
+    <ErrorBoundary fallback={${FatalError()}}>
+      <${ClientProvider()} config={config} ${dxosUi ? `fallback={${GenericFallback()}}` : ''}>
+        ${render?.content?.()}
+        ${dxosUi && pwa && swToast()}
+      </${ClientProvider()}>
+    </ErrorBoundary>`;
 
     const themeProvider = (content: string) => text`
     <${ThemeProvider()} appNs='${name}' resourceExtensions={[${appkitTranslations()}]} fallback={<${GenericFallback()} />}>
@@ -34,6 +36,7 @@ export default defineTemplate(
       : text`
       import React from 'react';
       ${() => imports.render(defaultOutputFile)}
+      import { ErrorBoundary } from './ErrorBoundary';
       
       ${render?.extraImports?.()}
       

--- a/packages/apps/templates/bare-template/src/src/App.tsx.t.ts
+++ b/packages/apps/templates/bare-template/src/src/App.tsx.t.ts
@@ -10,15 +10,15 @@ export default defineTemplate(
     const { Config, Dynamics, Defaults } = imports.lazy(['Config', 'Dynamics', 'Defaults'], '@dxos/config');
     const ThemeProvider = imports.lazy('ThemeProvider', '@dxos/react-components');
     const useRegisterSW = imports.lazy('useRegisterSW', 'virtual:pwa-register/react');
-    const { FatalError, ServiceWorkerToastContainer, GenericFallback, appkitTranslations } = imports.lazy(
-      ['FatalError', 'ServiceWorkerToastContainer', 'GenericFallback', 'appkitTranslations'],
+    const { ResetDialog, ServiceWorkerToastContainer, GenericFallback, appkitTranslations } = imports.lazy(
+      ['ResetDialog', 'ServiceWorkerToastContainer', 'GenericFallback', 'appkitTranslations'],
       '@dxos/react-appkit'
     );
 
     const swToast = () => `<${ServiceWorkerToastContainer()} {...serviceWorker} />`;
     
     const coreContent = text`
-    <ErrorBoundary fallback={${FatalError()}}>
+    <ErrorBoundary fallback={${ResetDialog()}}>
       <${ClientProvider()} config={config} ${dxosUi ? `fallback={${GenericFallback()}}` : ''}>
         ${render?.content?.()}
         ${dxosUi && pwa && swToast()}

--- a/packages/apps/templates/bare-template/src/src/ErrorBoundary.tsx.t.ts
+++ b/packages/apps/templates/bare-template/src/src/ErrorBoundary.tsx.t.ts
@@ -1,0 +1,40 @@
+import { defineTemplate, text } from '@dxos/plate';
+import config from '../config.t';
+
+export default defineTemplate(
+  ({ input: { react } }) => {
+    return !react
+      ? null
+      : text`
+      import React, { Component, FC, PropsWithChildren } from 'react';
+
+      type Props = PropsWithChildren<{
+        fallback: FC<{ error: Error }>
+      }>
+
+      type State = { error: Error | null }
+
+      export class ErrorBoundary extends Component<Props, State> {
+        constructor(props: Props) {
+          super(props);
+          this.state = { error: null }
+        }
+
+        static getDerivedStateFromError(error: Error) {
+          return { error };
+        }
+
+        override render() {
+          if (this.state.error) {
+            const { fallback: Fallback } = this.props;
+            return <Fallback error={this.state.error} />;
+          }
+
+          return this.props.children;
+        }
+      }`;
+  },
+  {
+    config
+  }
+);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 98d87a6</samp>

### Summary
🐛🛡️🎨

<!--
1.  🐛 - This emoji represents a bug or an error, which is the main topic of these changes. The `ErrorBoundary` component is used to catch and handle errors in the app, and the `FatalError` component is used to display a user-friendly message when an error occurs.
2.  🛡️ - This emoji represents a shield or protection, which is the effect of these changes. The `ErrorBoundary` component protects the app from crashing due to unhandled errors, and the `FatalError` component provides a way to recover from the error or report it.
3.  🎨 - This emoji represents art or design, which is also involved in these changes. The `ErrorBoundary` component is a template that can be customized with different fallback components, and the `FatalError` component has a simple and clean design that shows the error message and some actions.
-->
Added error handling to the bare template app using a new `ErrorBoundary` component. The component catches errors in the app and renders a `FatalError` component or the normal app content.

> _`ErrorBoundary`_
> _catches errors in the app_
> _a safe fallback_

### Walkthrough
*  Import and use `FatalError` component as fallback for `ErrorBoundary` component ([link](https://github.com/dxos/dxos/pull/3011/files?diff=unified&w=0#diff-bfff92a7fdaf408956a26b7defb460c56d304cbc06cd85746172919f608bf5c7L13-R14), [link](https://github.com/dxos/dxos/pull/3011/files?diff=unified&w=0#diff-bfff92a7fdaf408956a26b7defb460c56d304cbc06cd85746172919f608bf5c7L21-R26))
*  Define and import `ErrorBoundary` component to handle uncaught errors in the app ([link](https://github.com/dxos/dxos/pull/3011/files?diff=unified&w=0#diff-bfff92a7fdaf408956a26b7defb460c56d304cbc06cd85746172919f608bf5c7R39), [link](https://github.com/dxos/dxos/pull/3011/files?diff=unified&w=0#diff-07c993f7eef4ec380e55794a628086df646acd9b3b55651606fb569fa821be4cR1-R40))
*  Add template logic to `ErrorBoundary` component to render only when `react` input is true ([link](https://github.com/dxos/dxos/pull/3011/files?diff=unified&w=0#diff-07c993f7eef4ec380e55794a628086df646acd9b3b55651606fb569fa821be4cR1-R40))


