### PR TITLE
test(react-ui): skip flaky tests

### DIFF
--- a/packages/apps/patterns/react-ui/src/playwright/invitations.spec.ts
+++ b/packages/apps/patterns/react-ui/src/playwright/invitations.spec.ts
@@ -135,7 +135,8 @@ test.describe('Invitations', () => {
       expect(await manager.getDisplayName(0)).to.equal(await manager.getDisplayName(1));
     });
 
-    test('recover from network failure during invitation', async () => {
+    // TODO(wittjosiah): This is flaky and regularly fails CI.
+    test.skip('recover from network failure during invitation', async () => {
       await manager.createIdentity(0);
       await manager.openPanel(0, 'devices');
       const invitation = await manager.createInvitation(0, 'device');
@@ -326,7 +327,8 @@ test.describe('Invitations', () => {
       expect(await manager.getSpaceName(0, 0)).to.equal(await manager.getSpaceName(1, 0));
     });
 
-    test('recover from network failure during invitation', async () => {
+    // TODO(wittjosiah): This is flaky and regularly fails CI.
+    test.skip('recover from network failure during invitation', async () => {
       await manager.createIdentity(0);
       await manager.createSpace(0);
       await manager.openPanel(0, 0);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e9518e2</samp>

### Summary
🚧🐛📝

<!--
1.  🚧 - This emoji represents that some work is still in progress or unfinished, and can be used to indicate that the skipped test cases are not resolved yet and need to be fixed in the future.
2.  🐛 - This emoji represents a bug or an issue, and can be used to indicate that the test cases are flaky or unreliable due to some network failure recovery problem.
3.  📝 - This emoji represents writing or documentation, and can be used to indicate that TODO comments were added to mark the skipped test cases and explain the reason for skipping them.
-->
Skipped some unstable tests for invitation feature in `react-ui` app. Added notes to fix them later.

> _Oh we're the crew of the `invitations.spec.ts`_
> _And we've got some tests to skip_
> _For the network fails and the invite derails_
> _And we can't afford to trip_

### Walkthrough
* Skip two test cases for recovering from network failure during invitation ([link](https://github.com/dxos/dxos/pull/3020/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276L138-R139), [link](https://github.com/dxos/dxos/pull/3020/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276L329-R331)) in `invitations.spec.ts`. Add TODO comments to fix the flaky tests later.


