### PR TITLE
fix(client-services): use ice config

### DIFF
--- a/packages/sdk/client-services/src/packlets/tests/shared-worker.test.ts
+++ b/packages/sdk/client-services/src/packlets/tests/shared-worker.test.ts
@@ -10,14 +10,14 @@ import { Client, ClientServicesProxy, fromIFrame } from '@dxos/client';
 import { Config } from '@dxos/config';
 import { createLinkedPorts } from '@dxos/rpc';
 import { describe, test, afterTest } from '@dxos/test';
-import { MaybePromise } from '@dxos/util';
+import { MaybePromise, Provider } from '@dxos/util';
 
 import { TestBuilder } from '../testing';
 import { IFrameProxyRuntime, WorkerRuntime } from '../vault';
 
 chai.use(chaiAsPromised);
 
-const setup = (getConfig: () => MaybePromise<Config>) => {
+const setup = (getConfig: Provider<MaybePromise<Config>>) => {
   const workerRuntime = new WorkerRuntime(getConfig);
 
   const systemPorts = createLinkedPorts();
@@ -30,6 +30,7 @@ const setup = (getConfig: () => MaybePromise<Config>) => {
     shellPort: shellPorts[1]
   });
   const clientProxy = new IFrameProxyRuntime({
+    config: getConfig,
     systemPort: systemPorts[0],
     windowAppPort: proxyWindowPorts[0],
     workerAppPort: workerProxyPorts[0],
@@ -58,8 +59,9 @@ describe('Shared worker', () => {
     });
 
     const promise = Promise.all([
-      workerRuntime.start().catch(() => {}), // This error should be propagated to client.initialize() call.
-      clientProxy.open('*')
+      // This error should be propagated to client.initialize() call.
+      workerRuntime.start().catch(() => {}),
+      clientProxy.open('*').catch(() => {})
     ]);
 
     await expect(client.initialize()).to.be.rejectedWith('Test error');

--- a/packages/sdk/client-services/src/packlets/vault/iframe-proxy-runtime.ts
+++ b/packages/sdk/client-services/src/packlets/vault/iframe-proxy-runtime.ts
@@ -2,17 +2,19 @@
 // Copyright 2022 DXOS.org
 //
 
-import { iframeServiceBundle, workerServiceBundle, WorkerServiceBundle } from '@dxos/client';
+import { Config, iframeServiceBundle, workerServiceBundle, WorkerServiceBundle } from '@dxos/client';
 import { RemoteServiceConnectionError } from '@dxos/errors';
 import { log } from '@dxos/log';
 import { WebRTCTransportService } from '@dxos/network-manager';
 import { BridgeService } from '@dxos/protocols/proto/dxos/mesh/bridge';
 import { createProtoRpcPeer, ProtoRpcPeer, RpcPort } from '@dxos/rpc';
+import { getAsyncValue, MaybePromise, Provider } from '@dxos/util';
 
 import { ShellRuntime, ShellRuntimeImpl } from './shell-runtime';
 
 // NOTE: Keep as RpcPorts to avoid dependency on @dxos/rpc-tunnel so we don't depend on browser-specific apis.
 export type IFrameProxyRuntimeParams = {
+  config: Config | Provider<MaybePromise<Config>>;
   systemPort: RpcPort;
   workerAppPort: RpcPort;
   windowAppPort: RpcPort;
@@ -23,41 +25,22 @@ export type IFrameProxyRuntimeParams = {
  * Manages the client connection to the shared worker.
  */
 export class IFrameProxyRuntime {
+  private readonly _configProvider: IFrameProxyRuntimeParams['config'];
   private readonly _systemPort: RpcPort;
   private readonly _windowAppPort: RpcPort;
   private readonly _workerAppPort: RpcPort;
   private readonly _shellPort?: RpcPort;
-  private readonly _systemRpc: ProtoRpcPeer<WorkerServiceBundle>;
-  private readonly _shellRuntime?: ShellRuntimeImpl;
-  private readonly _transportService = new WebRTCTransportService({
-    iceServers: [
-      { urls: 'stun:dev.kube.dxos.org:3478', username: 'dxos', credential: 'dxos' },
-      { urls: 'turn:dev.kube.dxos.org:3478', username: 'dxos', credential: 'dxos' },
-      { urls: 'stun:kube.dxos.org:3478', username: 'dxos', credential: 'dxos' },
-      { urls: 'turn:kube.dxos.org:3478', username: 'dxos', credential: 'dxos' }
-    ]
-  });
+  private _config!: Config;
+  private _transportService!: BridgeService;
+  private _systemRpc!: ProtoRpcPeer<WorkerServiceBundle>;
+  private _shellRuntime?: ShellRuntimeImpl;
 
-  constructor({ systemPort, workerAppPort, windowAppPort, shellPort }: IFrameProxyRuntimeParams) {
+  constructor({ config, systemPort, workerAppPort, windowAppPort, shellPort }: IFrameProxyRuntimeParams) {
+    this._configProvider = config;
     this._systemPort = systemPort;
     this._windowAppPort = windowAppPort;
     this._workerAppPort = workerAppPort;
     this._shellPort = shellPort;
-
-    this._systemRpc = createProtoRpcPeer({
-      requested: workerServiceBundle,
-      exposed: iframeServiceBundle,
-      handlers: {
-        BridgeService: this._transportService as BridgeService,
-        IframeService: {
-          async heartbeat() {
-            // Ok.
-          }
-        }
-      },
-      port: this._systemPort,
-      timeout: 1000
-    });
 
     this._workerAppPort.subscribe((msg) => this._windowAppPort.send(msg));
     this._windowAppPort.subscribe((msg) => this._workerAppPort.send(msg));
@@ -72,6 +55,27 @@ export class IFrameProxyRuntime {
   }
 
   async open(origin: string) {
+    this._config = await getAsyncValue(this._configProvider);
+
+    this._transportService = new WebRTCTransportService({
+      iceServers: this._config.get('runtime.services.ice')
+    });
+
+    this._systemRpc = createProtoRpcPeer({
+      requested: workerServiceBundle,
+      exposed: iframeServiceBundle,
+      handlers: {
+        BridgeService: this._transportService,
+        IframeService: {
+          async heartbeat() {
+            // Ok.
+          }
+        }
+      },
+      port: this._systemPort,
+      timeout: 200
+    });
+
     try {
       await this._systemRpc.open();
       await this._systemRpc.rpc.WorkerService.start({ origin });
@@ -79,7 +83,6 @@ export class IFrameProxyRuntime {
       log.catch(err);
       throw new RemoteServiceConnectionError('Failed to connect to worker');
     }
-
     await this._shellRuntime?.open();
   }
 

--- a/packages/sdk/vault/src/iframe.ts
+++ b/packages/sdk/vault/src/iframe.ts
@@ -52,7 +52,7 @@ export const startIFrameRuntime = async (getWorker: () => SharedWorker): Promise
   if (mobileAndTabletCheck() || typeof SharedWorker === 'undefined') {
     console.log('Running DXOS vault in compatibility mode.');
     const iframeRuntime: IFrameHostRuntime = new IFrameHostRuntime({
-      configProvider: config,
+      config,
       appPort: createIFramePort({
         channel: 'dxos:app',
         onOrigin: async (origin) => {
@@ -80,6 +80,7 @@ export const startIFrameRuntime = async (getWorker: () => SharedWorker): Promise
     }
 
     const iframeRuntime: IFrameProxyRuntime = new IFrameProxyRuntime({
+      config,
       // TODO(dmaretskyi): Extract channel names to config.ts.
       systemPort: portMuxer.createWorkerPort({ channel: 'dxos:system' }),
       workerAppPort: portMuxer.createWorkerPort({ channel: 'dxos:app' }),


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b2eb150</samp>

### Summary
🛠️🚀♻️

<!--
1.  🛠️ for improved test setup and error handling
2.  🚀 for adding custom transport factory support and updating types and parameters
3.  ♻️ for refactoring and reorganizing the iframe communication classes and config
-->
This pull request enhances the configuration and communication of the iframe-based vault service. It allows passing different types of config values to the `IFrameHostRuntime` and `IFrameProxyRuntime` classes, and using a custom transport factory for WebRTC connections. It also improves the test setup and code readability of the related files.

> _`IFrame` classes_
> _change config and transport_
> _autumn of refactor_

### Walkthrough
*  Allow passing a config value or a provider function to the `IFrameProxyRuntime` and `IFrameHostRuntime` classes ([link](https://github.com/dxos/dxos/pull/3034/files?diff=unified&w=0#diff-fea3792003acd92b627d68a34a083e93515bf89c30ee1314ab92e3e0e934e2efL20-R20), [link](https://github.com/dxos/dxos/pull/3034/files?diff=unified&w=0#diff-fea3792003acd92b627d68a34a083e93515bf89c30ee1314ab92e3e0e934e2efL32-R32), [link](https://github.com/dxos/dxos/pull/3034/files?diff=unified&w=0#diff-fea3792003acd92b627d68a34a083e93515bf89c30ee1314ab92e3e0e934e2efR70-R72), [link](https://github.com/dxos/dxos/pull/3034/files?diff=unified&w=0#diff-a7d952f18c8922752062e72d62c1552118afbc133b1b4db8db07a1b04451c185R15), [link](https://github.com/dxos/dxos/pull/3034/files?diff=unified&w=0#diff-a7d952f18c8922752062e72d62c1552118afbc133b1b4db8db07a1b04451c185L24-R37), [link](https://github.com/dxos/dxos/pull/3034/files?diff=unified&w=0#diff-a7d952f18c8922752062e72d62c1552118afbc133b1b4db8db07a1b04451c185L60-L72), [link](https://github.com/dxos/dxos/pull/3034/files?diff=unified&w=0#diff-ab250f2acd4b584871491e81ca9ce20acfdf156949461d59dca74bac55130a7bL48-R48), [link](https://github.com/dxos/dxos/pull/3034/files?diff=unified&w=0#diff-ab250f2acd4b584871491e81ca9ce20acfdf156949461d59dca74bac55130a7bR76)).


