### PR TITLE
fix: Fix webFS reset

### DIFF
--- a/packages/common/random-access-storage/src/browser/web-fs.ts
+++ b/packages/common/random-access-storage/src/browser/web-fs.ts
@@ -79,14 +79,19 @@ export class WebFS implements Storage {
   private async _delete(path: string): Promise<void> {
     await Promise.all(
       Array.from(this._getFiles(path)).map(async ([path, file]) => {
-        await file.destroy().catch((err: any) => log.catch(err));
+        await file.destroy().catch((err: any) => log.warn(err));
         this._files.delete(path);
       })
     );
   }
 
   async reset() {
-    await this._delete('');
+    await this._initialize();
+    for await (const filename of await (this._root as any).keys()) {
+      assert(typeof filename === 'string');
+      this._files.delete(filename);
+      await this._root!.removeEntry(filename, { recursive: true }).catch((err: any) => log.warn(err));
+    }
     this._root = undefined;
   }
 

--- a/packages/common/random-access-storage/src/browser/web-fs.ts
+++ b/packages/common/random-access-storage/src/browser/web-fs.ts
@@ -88,7 +88,6 @@ export class WebFS implements Storage {
   async reset() {
     await this._initialize();
     for await (const filename of await (this._root as any).keys()) {
-      assert(typeof filename === 'string');
       this._files.delete(filename);
       await this._root!.removeEntry(filename, { recursive: true }).catch((err: any) => log.warn(err));
     }

--- a/packages/common/random-access-storage/src/testing/storage.blueprint-test.ts
+++ b/packages/common/random-access-storage/src/testing/storage.blueprint-test.ts
@@ -250,7 +250,7 @@ export const storageTests = (testGroupName: StorageType, createStorage: () => St
     test('reset', async () => {
       if (
         testGroupName === StorageType.RAM || // RAM storage does not persist data.
-        testGroupName === StorageType.IDB // IDB is blocked by testing IDB.
+        testGroupName === StorageType.IDB // IDB storage is blocked by `testing` IDB.
       ) {
         return;
       }

--- a/packages/common/random-access-storage/src/testing/storage.blueprint-test.ts
+++ b/packages/common/random-access-storage/src/testing/storage.blueprint-test.ts
@@ -250,7 +250,7 @@ export const storageTests = (testGroupName: StorageType, createStorage: () => St
     test('reset', async () => {
       if (
         testGroupName === StorageType.RAM || // RAM storage does not persist data.
-        testGroupName === StorageType.IDB // IDB storage is blocked by `testing` IDB.
+        testGroupName === StorageType.IDB // IDB storage is blocked by opened connection, and there is no handle to close it.
       ) {
         return;
       }

--- a/packages/common/random-access-storage/src/testing/storage.blueprint-test.ts
+++ b/packages/common/random-access-storage/src/testing/storage.blueprint-test.ts
@@ -248,7 +248,10 @@ export const storageTests = (testGroupName: StorageType, createStorage: () => St
     });
 
     test('reset', async () => {
-      if (testGroupName === StorageType.RAM) {
+      if (
+        testGroupName === StorageType.RAM || // RAM storage does not persist data.
+        testGroupName === StorageType.IDB // IDB is blocked by testing IDB.
+      ) {
         return;
       }
       const filename = randomText();


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 720e0b5</samp>

### Summary
🐛🚨🚧

<!--
1.  🐛 - This emoji represents the bug fix in the `reset` method of the `WebFS` class, which did not delete the root directory properly. It conveys that the code is more reliable and functional after the change.
2.  🚨 - This emoji represents the test case added for the `reset` method, using the `asyncTimeout` utility function. It conveys that the code is more robust and verified after the change, and that potential errors or regressions can be detected early.
3.  🚧 - This emoji represents the skipped test for RAM and IDB storage implementations, which are not supported by the `WebFS` class. It conveys that the code is still under development and that some features or scenarios are not yet implemented or compatible.
-->
Improved the browser-based `WebFS` random-access storage implementation and added a test case for the `reset` method. Fixed a bug in `WebFS.reset` and changed the error handling of `File.destroy`.

> _Sing, O Muse, of the web-born storage interface_
> _That lets the mortal browsers access files at random_
> _And of the skillful coder who fixed its errors and flaws_
> _And made it more consistent and robust for all._

### Walkthrough
*  Modify error handling of `destroy` method of `File` class to avoid rethrowing errors when deleting files ([link](https://github.com/dxos/dxos/pull/3036/files?diff=unified&w=0#diff-ccda6ccab8c2365217eb1ce5fb59fee83beca7a5b48b18eeec7d5f189b25abb4L82-R82)).


