### PR TITLE
fix(composer-app,react-ui): Restore Webkit tests

### DIFF
--- a/packages/apps/composer-app/src/playwright/basic.spec.ts
+++ b/packages/apps/composer-app/src/playwright/basic.spec.ts
@@ -6,24 +6,20 @@ import { test } from '@playwright/test';
 import { expect } from 'chai';
 import waitForExpect from 'wait-for-expect';
 
+import { sleep } from '@dxos/async';
+
 import { AppManager } from './app-manager';
 
 test.describe('Basic test', () => {
   let host: AppManager;
   let guest: AppManager;
 
-  // TODO(wittjosiah): Currently not running in Firefox.
-  //   https://bugzilla.mozilla.org/show_bug.cgi?id=1247687
   test.beforeAll(async ({ browser, browserName }) => {
     host = new AppManager(browser, true);
 
     await host.init();
-    // TODO(wittjosiah): WebRTC only available in chromium browser for testing currently.
-    //   https://github.com/microsoft/playwright/issues/2973
-    guest = browserName === 'chromium' ? new AppManager(browser, true) : host;
-    if (browserName === 'chromium') {
-      await guest.init();
-    }
+    guest = new AppManager(browser, true);
+    await guest.init();
   });
 
   test.describe('Solo tests', () => {
@@ -57,9 +53,6 @@ test.describe('Basic test', () => {
 
   test.describe('Collab tests', () => {
     test('guest joins host’s space', async ({ browserName }) => {
-      if (browserName !== 'chromium') {
-        return;
-      }
       await guest.shell.createIdentity('guest');
       const invitationCode = await host.shell.createSpaceInvitation();
       await guest.joinSpace();
@@ -67,6 +60,7 @@ test.describe('Basic test', () => {
         host.shell.getAuthCode(),
         guest.shell.acceptSpaceInvitation(invitationCode)
       ]);
+      await sleep(1000);
       await guest.shell.authenticate(authCode);
       await host.shell.closeShell();
       await host.page.getByRole('link').last().click();

--- a/packages/apps/composer-app/src/playwright/basic.spec.ts
+++ b/packages/apps/composer-app/src/playwright/basic.spec.ts
@@ -6,14 +6,14 @@ import { test } from '@playwright/test';
 import { expect } from 'chai';
 import waitForExpect from 'wait-for-expect';
 
-import { sleep } from '@dxos/async';
-
 import { AppManager } from './app-manager';
 
 test.describe('Basic test', () => {
   let host: AppManager;
   let guest: AppManager;
 
+  // TODO(wittjosiah): Currently not running in Firefox.
+  //   https://bugzilla.mozilla.org/show_bug.cgi?id=1247687
   test.beforeAll(async ({ browser, browserName }) => {
     host = new AppManager(browser, true);
 
@@ -60,7 +60,6 @@ test.describe('Basic test', () => {
         host.shell.getAuthCode(),
         guest.shell.acceptSpaceInvitation(invitationCode)
       ]);
-      await sleep(1000);
       await guest.shell.authenticate(authCode);
       await host.shell.closeShell();
       await host.page.getByRole('link').last().click();

--- a/packages/sdk/vault/src/testing/shell-manager.ts
+++ b/packages/sdk/vault/src/testing/shell-manager.ts
@@ -77,7 +77,7 @@ export class ShellManager extends NaturalShellManager {
 
   async authenticate(authCode: string) {
     // Wait for focus to shift before typing.
-    await sleep(10);
+    await sleep(1000);
     await this.authenticateInvitation('space', authCode, this.shell);
     await this.doneInvitation('space', this.shell);
   }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 864715e</samp>

### Summary
🐌🧹🔎

<!--
1.  🐌 - This emoji represents the change to use a longer sleep before typing the invitation code, since it implies that the test is slower or more patient. The snail emoji can also be used to indicate performance issues or delays in general.
2.  🧹 - This emoji represents the change to simplify the setup and enable a skipped test, since it implies that the test code was cleaned up or improved. The broom emoji can also be used to indicate refactoring, linting, or removing unused code or dependencies.
3.  🔎 - This emoji represents the change to import a utility function and add a wait for input focus, since it implies that the test code was made more robust or reliable. The magnifying glass emoji can also be used to indicate debugging, searching, or finding bugs or errors.
-->
Improved the reliability and readability of the playwright tests for the composer app and the vault SDK. Adjusted the `authenticate` method and the test case to use a consistent sleep duration before typing the invitation code.

> _We are the party crashers, we break the code of silence_
> _We use the `authenticate` method to join the shell alliance_
> _We are the playwright masters, we test the composer app_
> _We import the utility function and make the input snap_

### Walkthrough
*  Simplify test setup and make it run on all browsers by removing browser-specific conditions and always initializing host and guest app managers ([link](https://github.com/dxos/dxos/pull/3038/files?diff=unified&w=0#diff-615a8fa2d770170d158b9feb2bfbaaf0d2ef698d8c702b6293817a8b406a0708R9-R10), [link](https://github.com/dxos/dxos/pull/3038/files?diff=unified&w=0#diff-615a8fa2d770170d158b9feb2bfbaaf0d2ef698d8c702b6293817a8b406a0708L15-R22), [link](https://github.com/dxos/dxos/pull/3038/files?diff=unified&w=0#diff-615a8fa2d770170d158b9feb2bfbaaf0d2ef698d8c702b6293817a8b406a0708L60-L62)).


