### PR TITLE
feat(composer-app): Pop a toast when an invitation is ready for an auth code.

### DIFF
--- a/packages/apps/composer-app/src/translations/en-US.ts
+++ b/packages/apps/composer-app/src/translations/en-US.ts
@@ -47,5 +47,7 @@ export const composer = {
   'github branch name placeholder': 'update-readme',
   'github commit message label': 'Updated README.md',
   'download all docs in space label': 'Download backup',
-  'upload all docs in space label': 'Upload backup'
+  'upload all docs in space label': 'Upload backup',
+  'invitation ready for auth code message': 'An invitation is ready for its authentication code',
+  'view invitations label': 'View'
 };


### PR DESCRIPTION
Resolves partially #2892.

https://user-images.githubusercontent.com/855039/232177077-db23de13-77a4-4a97-bbff-bd2690a8e562.mp4

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4e5c704</samp>

### Summary
🌐🎁🔑

<!--
1.  🌐 - This emoji represents the addition of new translations or localization features, which is the case for the new entries in the `en-US.ts` file.
2.  🎁 - This emoji represents the addition of a new feature or enhancement, which is the case for the new notification and invitation viewing functionality.
3.  🔑 - This emoji represents the addition of a security or authentication feature, which is the case for the invitation authentication code.
-->
Added a feature to notify and show invitations for spaces in the composer app. Modified `DocumentLayout.tsx` to use `InvitationToast` component and updated `en-US.ts` with new translations.

> _`InvitationToast` rises from the ashes_
> _A message of doom or salvation_
> _`useSpaceInvitations` to join the fray_
> _Or face the wrath of the composer_

### Walkthrough
*  Import modules and components for invitation toast feature ([link](https://github.com/dxos/dxos/pull/3039/files?diff=unified&w=0#diff-ab842413d79b2347164063c420684cfba714cfb93ffae9ba01708ed26f303117L7-R40))
*  Fetch invitations for the current space using `useSpaceInvitations` hook ([link](https://github.com/dxos/dxos/pull/3039/files?diff=unified&w=0#diff-ab842413d79b2347164063c420684cfba714cfb93ffae9ba01708ed26f303117R50))
*  Render `InvitationToast` component for each invitation in `DocumentLayout.tsx` ([link](https://github.com/dxos/dxos/pull/3039/files?diff=unified&w=0#diff-ab842413d79b2347164063c420684cfba714cfb93ffae9ba01708ed26f303117R82-R85))
*  Add English translations for toast message and button label in `en-US.ts` ([link](https://github.com/dxos/dxos/pull/3039/files?diff=unified&w=0#diff-df4fb09070ae8aa16c554fe8dc845b2f339eb7e852b9b7934010cbcf2eee0721L50-R52))


