### PR TITLE
fix: Sketch frame

### DIFF
--- a/packages/experimental/kai-frames/src/frames/Sketch/SketchFrame.tsx
+++ b/packages/experimental/kai-frames/src/frames/Sketch/SketchFrame.tsx
@@ -4,7 +4,7 @@
 
 import { DownloadSimple, UploadSimple, ScribbleLoop, Trash } from '@phosphor-icons/react';
 import assert from 'assert';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { GithubPicker } from 'react-color';
 import { CanvasPath, ReactSketchCanvas } from 'react-sketch-canvas';
 

--- a/packages/experimental/kai-frames/src/frames/Sketch/SketchFrame.tsx
+++ b/packages/experimental/kai-frames/src/frames/Sketch/SketchFrame.tsx
@@ -9,7 +9,7 @@ import { GithubPicker } from 'react-color';
 import { CanvasPath, ReactSketchCanvas } from 'react-sketch-canvas';
 
 import { File, Sketch } from '@dxos/kai-types';
-import { observer } from '@dxos/react-client';
+import { observer, useSubscription } from '@dxos/react-client';
 import { Button, getSize, mx } from '@dxos/react-components';
 
 import { useFrameContext, useFileDownload, useIpfsClient } from '../../hooks';
@@ -51,7 +51,7 @@ export const SketchFrame = observer(() => {
 
   const { space, objectId } = useFrameContext();
   const sketch = objectId ? space!.db.getObjectById<Sketch>(objectId) : undefined;
-  useEffect(() => {
+  useSubscription(() => {
     if (sketch) {
       setTimeout(async () => {
         await canvasRef.current.resetCanvas();

--- a/packages/experimental/kai/src/hooks/useAppState.tsx
+++ b/packages/experimental/kai/src/hooks/useAppState.tsx
@@ -19,7 +19,7 @@ export const defaultFrames = [
   // 'dxos.module.frame.kanban',
   // 'dxos.module.frame.table',
   // 'dxos.module.frame.note',
-  'dxos.module.frame.sketch',
+  'dxos.module.frame.sketch'
   // 'dxos.module.frame.chess',
   // 'dxos.module.frame.sandbox',
   // 'dxos.module.frame.maps',

--- a/packages/experimental/kai/src/hooks/useAppState.tsx
+++ b/packages/experimental/kai/src/hooks/useAppState.tsx
@@ -15,11 +15,11 @@ export const defaultFrames = [
   'dxos.module.frame.inbox',
   'dxos.module.frame.calendar',
   'dxos.module.frame.contact',
-  'dxos.module.frame.file'
+  'dxos.module.frame.file',
   // 'dxos.module.frame.kanban',
   // 'dxos.module.frame.table',
   // 'dxos.module.frame.note',
-  // 'dxos.module.frame.sketch',
+  'dxos.module.frame.sketch',
   // 'dxos.module.frame.chess',
   // 'dxos.module.frame.sandbox',
   // 'dxos.module.frame.maps',


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bced371</samp>

### Summary
🎨🚀🧰

<!--
1.  🎨 This emoji represents the sketch frame, which is a creative and artistic feature of the app.
2.  🚀 This emoji represents the performance improvement and refactoring of the component, which makes the app faster and more reliable.
3.  🧰 This emoji represents the use of custom hooks and context, which are useful tools for building React components and accessing data.
-->
Refactored the sketch frame component to use custom hooks and enabled it in the app. This improves the sketching functionality and performance in `kai-frames` and `kai`.

> _Sing, O Muse, of the skillful developers who wrought_
> _The splendid sketch frame, a marvel of art and thought_
> _They unleashed its power from the `defaultFrames` array_
> _And with custom hooks they refined its display_

### Walkthrough
* Enable the sketch frame in the app by uncommenting it in the `defaultFrames` array ([link](https://github.com/dxos/dxos/pull/3040/files?diff=unified&w=0#diff-65897fd3ea7f972c518d01fad666ed3bd99df73338d8eaa56840242aca8fc177L18-R22)).


