### PR TITLE
feat: Role exchange for invitation extension

### DIFF
--- a/packages/core/protocols/src/proto/dxos/halo/invitations.proto
+++ b/packages/core/protocols/src/proto/dxos/halo/invitations.proto
@@ -13,6 +13,16 @@ import "dxos/keys.proto";
 
 package dxos.halo.invitations;
 
+message Options {
+  enum Role {
+    GUEST = 0;
+    HOST = 1;
+  }
+
+  /// Role of the peer.
+  Role role = 1;
+}
+
 message IntroductionRequest {
   /// Guest's profile.
   optional halo.credentials.ProfileDocument profile = 1;
@@ -87,13 +97,17 @@ message AdmissionResponse {
 
 /// Host service for two peers exchanging an invitation.
 // TODO(wittjosiah): Handle invitations where guest is the initiatating peer.
+// TODO(dmaretskyi): Rename to InvitationExtensionService.
 service InvitationHostService {
-  /// Introduce guest to the host.
+  /// Both peers must call this method before any other.
+  rpc Options(Options) returns (google.protobuf.Empty);
+
+  /// Introduce guest to the host. Only on the host.
   rpc Introduce(IntroductionRequest) returns (IntroductionResponse);
 
-  /// Authenticate request.
+  /// Authenticate request. Only on the host.
   rpc Authenticate(AuthenticationRequest) returns (AuthenticationResponse);
 
-  /// Process admission credentials.
+  /// Process admission credentials. Only on the host.
   rpc Admit(AdmissionRequest) returns (AdmissionResponse);
 }

--- a/packages/sdk/client-services/src/packlets/invitations/invitation-extension.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitation-extension.ts
@@ -1,0 +1,134 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+import assert from 'node:assert';
+
+import { PushStream, scheduleTask, sleep, TimeoutError, Trigger } from '@dxos/async';
+import {
+  AUTHENTICATION_CODE_LENGTH,
+  CancellableInvitationObservable,
+  INVITATION_TIMEOUT,
+  ON_CLOSE_DELAY,
+  AuthenticatingInvitationObservable
+} from '@dxos/client';
+import { Context } from '@dxos/context';
+import { generatePasscode } from '@dxos/credentials';
+import { PublicKey } from '@dxos/keys';
+import { log } from '@dxos/log';
+import { createTeleportProtocolFactory, NetworkManager, StarTopology } from '@dxos/network-manager';
+import { schema, trace } from '@dxos/protocols';
+import { Invitation } from '@dxos/protocols/proto/dxos/client/services';
+import { ProfileDocument } from '@dxos/protocols/proto/dxos/halo/credentials';
+import {
+  AuthenticationRequest,
+  AuthenticationResponse,
+  IntroductionRequest,
+  IntroductionResponse,
+  AdmissionRequest,
+  AdmissionResponse,
+  InvitationHostService
+} from '@dxos/protocols/proto/dxos/halo/invitations';
+import { ExtensionContext, RpcExtension } from '@dxos/teleport';
+
+import { InvitationProtocol } from './invitation-protocol';
+
+type InvitationHostExtensionCallbacks = {
+  // Deliberately not async to not block the extensions opening.
+  onOpen: () => void;
+
+  introduce: (request: IntroductionRequest) => Promise<IntroductionResponse>;
+  authenticate: (request: AuthenticationRequest) => Promise<AuthenticationResponse>;
+  admit: (request: AdmissionRequest) => Promise<AdmissionResponse>;
+};
+
+/**
+ * Host's side for a connection to a concrete peer in p2p network during invitation.
+ */
+export class InvitationHostExtension extends RpcExtension<{}, { InvitationHostService: InvitationHostService }> {
+  /**
+   * @internal
+   */
+  public _traceParent?: string;
+
+  constructor(private readonly _callbacks: InvitationHostExtensionCallbacks) {
+    super({
+      exposed: {
+        InvitationHostService: schema.getService('dxos.halo.invitations.InvitationHostService')
+      }
+    });
+  }
+
+  protected override async getHandlers(): Promise<{ InvitationHostService: InvitationHostService }> {
+    return {
+      // TODO(dmaretskyi): For now this is just forwarding the data to callbacks since we don't have session-specific logic.
+      // Perhaps in the future we will have more complex logic here.
+      InvitationHostService: {
+        introduce: async (request) => {
+          const traceId = PublicKey.random().toHex();
+          log.trace(
+            'dxos.sdk.invitation-handler.host.introduce',
+            trace.begin({ id: traceId, parentId: this._traceParent })
+          );
+          const response = await this._callbacks.introduce(request);
+          log.trace('dxos.sdk.invitation-handler.host.introduce', trace.end({ id: traceId }));
+          return response;
+        },
+
+        authenticate: async (request) => {
+          const traceId = PublicKey.random().toHex();
+          log.trace(
+            'dxos.sdk.invitation-handler.host.authenticate',
+            trace.begin({ id: traceId, parentId: this._traceParent })
+          );
+          const response = await this._callbacks.authenticate(request);
+          log.trace('dxos.sdk.invitation-handler.host.authenticate', trace.end({ id: traceId, data: { ...response } }));
+          return response;
+        },
+
+        admit: async (request) => {
+          const traceId = PublicKey.random().toHex();
+          log.trace(
+            'dxos.sdk.invitation-handler.host.admit',
+            trace.begin({ id: traceId, parentId: this._traceParent })
+          );
+          const response = await this._callbacks.admit(request);
+          log.trace('dxos.sdk.invitation-handler.host.admit', trace.end({ id: traceId }));
+          return response;
+        }
+      }
+    };
+  }
+
+  override async onOpen(context: ExtensionContext) {
+    await super.onOpen(context);
+    this._callbacks.onOpen();
+  }
+}
+
+type InvitationGuestExtensionCallbacks = {
+  // Deliberately not async to not block the extensions opening.
+  onOpen: () => void;
+};
+
+/**
+ * Guest's side for a connection to a concrete peer in p2p network during invitation.
+ */
+export class InvitationGuestExtension extends RpcExtension<{ InvitationHostService: InvitationHostService }, {}> {
+  constructor(private readonly _callbacks: InvitationGuestExtensionCallbacks) {
+    super({
+      requested: {
+        InvitationHostService: schema.getService('dxos.halo.invitations.InvitationHostService')
+      }
+    });
+  }
+
+  protected override async getHandlers() {
+    return {};
+  }
+
+  override async onOpen(context: ExtensionContext) {
+    await super.onOpen(context);
+    this._callbacks.onOpen();
+  }
+}

--- a/packages/sdk/client-services/src/packlets/invitations/invitation-extension.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitation-extension.ts
@@ -128,7 +128,7 @@ export class InvitationHostExtension extends RpcExtension<{ InvitationHostServic
 
 type InvitationGuestExtensionCallbacks = {
   // Deliberately not async to not block the extensions opening.
-  onOpen: () => void;
+  onOpen: (ctx: Context) => void;
   onError: (error: Error) => void;
 };
 
@@ -171,23 +171,23 @@ export class InvitationGuestExtension extends RpcExtension<{ InvitationHostServi
     await super.onOpen(context);
 
     try {
-      log.info('begin options')
+      log('begin options')
       await cancelWithContext(this._ctx, this.rpc.InvitationHostService.options({ role: Options.Role.GUEST }));    
       await cancelWithContext(this._ctx, this._remoteOptionsTrigger.wait({ timeout: OPTIONS_TIMEOUT }));
-      log.info('end options')
+      log('end options')
       if(this._remoteOptions?.role !== Options.Role.HOST) {
         throw new InvalidInvitationExtensionRoleError(undefined, { expected: Options.Role.HOST, remoteOptions: this._remoteOptions });
       }
 
-      this._callbacks.onOpen();
+      this._callbacks.onOpen(this._ctx);
     } catch (err: any) {
-      log.info('openError', err)
+      log('openError', err)
       this._callbacks.onError(err);
     }
   }
 
   override async onClose() {
-    log.info('onClose')
+    log('onClose')
     await this._ctx.dispose();
   }
 }

--- a/packages/sdk/client-services/src/packlets/invitations/invitation-extension.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitation-extension.ts
@@ -4,38 +4,30 @@
 
 import assert from 'node:assert';
 
-import { PushStream, scheduleTask, sleep, TimeoutError, Trigger } from '@dxos/async';
-import {
-  AUTHENTICATION_CODE_LENGTH,
-  CancellableInvitationObservable,
-  INVITATION_TIMEOUT,
-  ON_CLOSE_DELAY,
-  AuthenticatingInvitationObservable
-} from '@dxos/client';
-import { Context } from '@dxos/context';
-import { generatePasscode } from '@dxos/credentials';
+import { Trigger } from '@dxos/async';
+import { cancelWithContext, Context } from '@dxos/context';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
-import { createTeleportProtocolFactory, NetworkManager, StarTopology } from '@dxos/network-manager';
 import { schema, trace } from '@dxos/protocols';
-import { Invitation } from '@dxos/protocols/proto/dxos/client/services';
-import { ProfileDocument } from '@dxos/protocols/proto/dxos/halo/credentials';
 import {
-  AuthenticationRequest,
+  AdmissionRequest,
+  AdmissionResponse, AuthenticationRequest,
   AuthenticationResponse,
   IntroductionRequest,
-  IntroductionResponse,
-  AdmissionRequest,
-  AdmissionResponse,
-  InvitationHostService
+  IntroductionResponse, InvitationHostService,
+  Options
 } from '@dxos/protocols/proto/dxos/halo/invitations';
 import { ExtensionContext, RpcExtension } from '@dxos/teleport';
+import { InvalidInvitationExtensionRoleError } from '@dxos/errors';
 
-import { InvitationProtocol } from './invitation-protocol';
+
+/// Timeout for the options exchange.
+const OPTIONS_TIMEOUT = 10_000;
 
 type InvitationHostExtensionCallbacks = {
   // Deliberately not async to not block the extensions opening.
   onOpen: () => void;
+  onError: (error: Error) => void;
 
   introduce: (request: IntroductionRequest) => Promise<IntroductionResponse>;
   authenticate: (request: AuthenticationRequest) => Promise<AuthenticationResponse>;
@@ -45,14 +37,21 @@ type InvitationHostExtensionCallbacks = {
 /**
  * Host's side for a connection to a concrete peer in p2p network during invitation.
  */
-export class InvitationHostExtension extends RpcExtension<{}, { InvitationHostService: InvitationHostService }> {
+export class InvitationHostExtension extends RpcExtension<{ InvitationHostService: InvitationHostService }, { InvitationHostService: InvitationHostService }> {
   /**
    * @internal
    */
   public _traceParent?: string;
 
+  private _ctx = new Context();
+  private _remoteOptions?: Options;
+  private _remoteOptionsTrigger = new Trigger();
+
   constructor(private readonly _callbacks: InvitationHostExtensionCallbacks) {
     super({
+      requested: {
+        InvitationHostService: schema.getService('dxos.halo.invitations.InvitationHostService')
+      },
       exposed: {
         InvitationHostService: schema.getService('dxos.halo.invitations.InvitationHostService')
       }
@@ -64,6 +63,12 @@ export class InvitationHostExtension extends RpcExtension<{}, { InvitationHostSe
       // TODO(dmaretskyi): For now this is just forwarding the data to callbacks since we don't have session-specific logic.
       // Perhaps in the future we will have more complex logic here.
       InvitationHostService: {
+        options: async (options) => {
+          assert(!this._remoteOptions, 'Remote options already set.');
+          this._remoteOptions = options;
+          this._remoteOptionsTrigger.wake();
+        },
+
         introduce: async (request) => {
           const traceId = PublicKey.random().toHex();
           log.trace(
@@ -102,33 +107,87 @@ export class InvitationHostExtension extends RpcExtension<{}, { InvitationHostSe
 
   override async onOpen(context: ExtensionContext) {
     await super.onOpen(context);
-    this._callbacks.onOpen();
+
+    try {
+      await this.rpc.InvitationHostService.options({ role: Options.Role.HOST });    
+      await cancelWithContext(this._ctx, this._remoteOptionsTrigger.wait({ timeout: OPTIONS_TIMEOUT }));
+      if(this._remoteOptions?.role !== Options.Role.GUEST) {
+        throw new InvalidInvitationExtensionRoleError(undefined, { expected: Options.Role.GUEST, remoteOptions: this._remoteOptions });
+      }
+
+      this._callbacks.onOpen();
+    } catch (err: any) {
+      this._callbacks.onError(err);
+    }
+  }
+
+  override async onClose() {
+    await this._ctx.dispose();
   }
 }
 
 type InvitationGuestExtensionCallbacks = {
   // Deliberately not async to not block the extensions opening.
   onOpen: () => void;
+  onError: (error: Error) => void;
 };
 
 /**
  * Guest's side for a connection to a concrete peer in p2p network during invitation.
  */
-export class InvitationGuestExtension extends RpcExtension<{ InvitationHostService: InvitationHostService }, {}> {
+export class InvitationGuestExtension extends RpcExtension<{ InvitationHostService: InvitationHostService }, { InvitationHostService: InvitationHostService }> {
+
+  private _ctx = new Context();
+  private _remoteOptions?: Options;
+  private _remoteOptionsTrigger = new Trigger();
+
   constructor(private readonly _callbacks: InvitationGuestExtensionCallbacks) {
     super({
       requested: {
+        InvitationHostService: schema.getService('dxos.halo.invitations.InvitationHostService')
+      },
+      exposed: {
         InvitationHostService: schema.getService('dxos.halo.invitations.InvitationHostService')
       }
     });
   }
 
-  protected override async getHandlers() {
-    return {};
+  protected override async getHandlers(): Promise<{ InvitationHostService: InvitationHostService }>  {
+    return {
+      InvitationHostService: {
+        options: async (options) => {
+          assert(!this._remoteOptions, 'Remote options already set.');
+          this._remoteOptions = options;
+          this._remoteOptionsTrigger.wake();
+        },
+        introduce: () => { throw new Error('Method not allowed.'); },
+        authenticate: () => { throw new Error('Method not allowed.'); },
+        admit: () => { throw new Error('Method not allowed.'); },
+      },
+    };
   }
 
   override async onOpen(context: ExtensionContext) {
     await super.onOpen(context);
-    this._callbacks.onOpen();
+
+    try {
+      log.info('begin options')
+      await cancelWithContext(this._ctx, this.rpc.InvitationHostService.options({ role: Options.Role.GUEST }));    
+      await cancelWithContext(this._ctx, this._remoteOptionsTrigger.wait({ timeout: OPTIONS_TIMEOUT }));
+      log.info('end options')
+      if(this._remoteOptions?.role !== Options.Role.HOST) {
+        throw new InvalidInvitationExtensionRoleError(undefined, { expected: Options.Role.HOST, remoteOptions: this._remoteOptions });
+      }
+
+      this._callbacks.onOpen();
+    } catch (err: any) {
+      log.info('openError', err)
+      this._callbacks.onError(err);
+    }
+  }
+
+  override async onClose() {
+    log.info('onClose')
+    await this._ctx.dispose();
   }
 }

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
@@ -33,6 +33,7 @@ import { ExtensionContext, RpcExtension } from '@dxos/teleport';
 
 import { InvitationProtocol } from './invitation-protocol';
 import { InvitationGuestExtension, InvitationHostExtension } from './invitation-extension';
+import { InvalidInvitationExtensionRoleError } from '@dxos/errors';
 
 const MAX_OTP_ATTEMPTS = 3;
 
@@ -220,6 +221,18 @@ export class InvitationsHandler {
               }
             }
           });
+        },
+        onError: (err) => {
+          if(err instanceof InvalidInvitationExtensionRoleError) {
+            return;
+          }
+          if (err instanceof TimeoutError) {
+            log('timeout', { ...protocol.toJSON() });
+            stream.next({ ...invitation, state: Invitation.State.TIMEOUT });
+          } else {
+            log.error('failed', err);
+            stream.error(err);
+          }
         }
       });
       extension._traceParent = this._traceParent;
@@ -366,6 +379,18 @@ export class InvitationsHandler {
               await ctx.dispose();
             }
           });
+        },
+        onError: (err) => {
+          if(err instanceof InvalidInvitationExtensionRoleError) {
+            return;
+          }
+          if (err instanceof TimeoutError) {
+            log('timeout', { ...protocol.toJSON() });
+            stream.next({ ...invitation, state: Invitation.State.TIMEOUT });
+          } else {
+            log('auth failed', err);
+            stream.error(err);
+          }
         }
       });
 

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
@@ -32,6 +32,7 @@ import {
 import { ExtensionContext, RpcExtension } from '@dxos/teleport';
 
 import { InvitationProtocol } from './invitation-protocol';
+import { InvitationGuestExtension, InvitationHostExtension } from './invitation-extension';
 
 const MAX_OTP_ATTEMPTS = 3;
 
@@ -405,103 +406,3 @@ export class InvitationsHandler {
 }
 
 const isAuthenticationRequired = (invitation: Invitation) => invitation.authMethod !== Invitation.AuthMethod.NONE;
-
-type InvitationHostExtensionCallbacks = {
-  // Deliberately not async to not block the extensions opening.
-  onOpen: () => void;
-
-  introduce: (request: IntroductionRequest) => Promise<IntroductionResponse>;
-  authenticate: (request: AuthenticationRequest) => Promise<AuthenticationResponse>;
-  admit: (request: AdmissionRequest) => Promise<AdmissionResponse>;
-};
-
-/**
- * Host's side for a connection to a concrete peer in p2p network during invitation.
- */
-class InvitationHostExtension extends RpcExtension<{}, { InvitationHostService: InvitationHostService }> {
-  /**
-   * @internal
-   */
-  public _traceParent?: string;
-
-  constructor(private readonly _callbacks: InvitationHostExtensionCallbacks) {
-    super({
-      exposed: {
-        InvitationHostService: schema.getService('dxos.halo.invitations.InvitationHostService')
-      }
-    });
-  }
-
-  protected override async getHandlers(): Promise<{ InvitationHostService: InvitationHostService }> {
-    return {
-      // TODO(dmaretskyi): For now this is just forwarding the data to callbacks since we don't have session-specific logic.
-      // Perhaps in the future we will have more complex logic here.
-      InvitationHostService: {
-        introduce: async (request) => {
-          const traceId = PublicKey.random().toHex();
-          log.trace(
-            'dxos.sdk.invitation-handler.host.introduce',
-            trace.begin({ id: traceId, parentId: this._traceParent })
-          );
-          const response = await this._callbacks.introduce(request);
-          log.trace('dxos.sdk.invitation-handler.host.introduce', trace.end({ id: traceId }));
-          return response;
-        },
-
-        authenticate: async (request) => {
-          const traceId = PublicKey.random().toHex();
-          log.trace(
-            'dxos.sdk.invitation-handler.host.authenticate',
-            trace.begin({ id: traceId, parentId: this._traceParent })
-          );
-          const response = await this._callbacks.authenticate(request);
-          log.trace('dxos.sdk.invitation-handler.host.authenticate', trace.end({ id: traceId, data: { ...response } }));
-          return response;
-        },
-
-        admit: async (request) => {
-          const traceId = PublicKey.random().toHex();
-          log.trace(
-            'dxos.sdk.invitation-handler.host.admit',
-            trace.begin({ id: traceId, parentId: this._traceParent })
-          );
-          const response = await this._callbacks.admit(request);
-          log.trace('dxos.sdk.invitation-handler.host.admit', trace.end({ id: traceId }));
-          return response;
-        }
-      }
-    };
-  }
-
-  override async onOpen(context: ExtensionContext) {
-    await super.onOpen(context);
-    this._callbacks.onOpen();
-  }
-}
-
-type InvitationGuestExtensionCallbacks = {
-  // Deliberately not async to not block the extensions opening.
-  onOpen: () => void;
-};
-
-/**
- * Guest's side for a connection to a concrete peer in p2p network during invitation.
- */
-class InvitationGuestExtension extends RpcExtension<{ InvitationHostService: InvitationHostService }, {}> {
-  constructor(private readonly _callbacks: InvitationGuestExtensionCallbacks) {
-    super({
-      requested: {
-        InvitationHostService: schema.getService('dxos.halo.invitations.InvitationHostService')
-      }
-    });
-  }
-
-  protected override async getHandlers() {
-    return {};
-  }
-
-  override async onOpen(context: ExtensionContext) {
-    await super.onOpen(context);
-    this._callbacks.onOpen();
-  }
-}

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
@@ -6,24 +6,23 @@ import assert from 'node:assert';
 
 import { PushStream, scheduleTask, sleep, TimeoutError, Trigger } from '@dxos/async';
 import {
-  AuthenticatingInvitationObservable, AUTHENTICATION_CODE_LENGTH,
+  AuthenticatingInvitationObservable,
+  AUTHENTICATION_CODE_LENGTH,
   CancellableInvitationObservable,
   INVITATION_TIMEOUT,
   ON_CLOSE_DELAY
 } from '@dxos/client';
 import { Context } from '@dxos/context';
 import { generatePasscode } from '@dxos/credentials';
+import { InvalidInvitationExtensionRoleError } from '@dxos/errors';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { createTeleportProtocolFactory, NetworkManager, StarTopology } from '@dxos/network-manager';
 import { trace } from '@dxos/protocols';
 import { Invitation } from '@dxos/protocols/proto/dxos/client/services';
 import { ProfileDocument } from '@dxos/protocols/proto/dxos/halo/credentials';
-import {
-  AuthenticationResponse
-} from '@dxos/protocols/proto/dxos/halo/invitations';
+import { AuthenticationResponse } from '@dxos/protocols/proto/dxos/halo/invitations';
 
-import { InvalidInvitationExtensionRoleError } from '@dxos/errors';
 import { InvitationGuestExtension, InvitationHostExtension } from './invitation-extension';
 import { InvitationProtocol } from './invitation-protocol';
 
@@ -215,7 +214,7 @@ export class InvitationsHandler {
           });
         },
         onError: (err) => {
-          if(err instanceof InvalidInvitationExtensionRoleError) {
+          if (err instanceof InvalidInvitationExtensionRoleError) {
             return;
           }
           if (err instanceof TimeoutError) {
@@ -299,8 +298,8 @@ export class InvitationsHandler {
         onOpen: (extensionCtx) => {
           extensionCtx.onDispose(async () => {
             log('extension disposed', { currentState });
-            if(currentState !== Invitation.State.SUCCESS) {
-              stream.error(new Error('Remote peer disconnected.'))
+            if (currentState !== Invitation.State.SUCCESS) {
+              stream.error(new Error('Remote peer disconnected.'));
             }
           });
 
@@ -387,7 +386,7 @@ export class InvitationsHandler {
           });
         },
         onError: (err) => {
-          if(err instanceof InvalidInvitationExtensionRoleError) {
+          if (err instanceof InvalidInvitationExtensionRoleError) {
             return;
           }
           if (err instanceof TimeoutError) {

--- a/packages/sdk/client-services/src/packlets/invitations/space-invitation-protocol.test.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/space-invitation-protocol.test.ts
@@ -125,7 +125,7 @@ describe('services/space-invitations-protocol', () => {
     ).to.equal(2); // own halo + newly joined space.
   });
 
-  test.only('cancels invitation', async () => {
+  test('cancels invitation', async () => {
     const [host, guest] = await asyncChain<ServiceContext>([createIdentity, closeAfterTest])(createPeers(2));
 
     const hostConnected = new Trigger<Invitation>();

--- a/packages/sdk/client-services/src/packlets/invitations/space-invitation-protocol.test.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/space-invitation-protocol.test.ts
@@ -125,7 +125,7 @@ describe('services/space-invitations-protocol', () => {
     ).to.equal(2); // own halo + newly joined space.
   });
 
-  test('cancels invitation', async () => {
+  test.only('cancels invitation', async () => {
     const [host, guest] = await asyncChain<ServiceContext>([createIdentity, closeAfterTest])(createPeers(2));
 
     const hostConnected = new Trigger<Invitation>();

--- a/packages/sdk/errors/src/errors.ts
+++ b/packages/sdk/errors/src/errors.ts
@@ -49,3 +49,9 @@ export class DataCorruptionError extends SystemError {
     super('DATA_CORRUPTION', message, context);
   }
 }
+
+export class InvalidInvitationExtensionRoleError extends SystemError {
+  constructor(message?: string, context?: any) {
+    super('INVALID_INVITATION_EXTENSION_ROLE', message, context);
+  }
+}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 65ed707</samp>

### Summary
📄🚫🔄

<!--
1.  📄 for adding a new file `invitation-extension.ts`.
2.  🚫 for adding a new error class `InvalidInvitationExtensionRoleError`.
3.  🔄 for refactoring and reorganizing the existing code.
-->
This pull request adds role-based validation and negotiation to the invitation protocol, using a new `Options` message and RPC method, and new classes that extend the `teleport` framework for p2p RPC calls. It also refactors and cleans up the existing code for the `InvitationsHandler` class and the `invitations.proto` file, and defines a new custom error type for incompatible roles.

> _We're sailing on the p2p sea, with `InvitationHostExtension`_
> _We'll exchange our options and roles, with `InvitationGuestExtension`_
> _Heave away, me hearties, heave away_
> _We'll use the `teleport` framework for RPC today_

### Walkthrough
*  Add a new message type `Options` and a new RPC method `Options` to the `invitations.proto` file, to enable the peers to exchange and validate their roles in the invitation protocol. ([link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-55065c9fa7ebb65ea7ebd50a82ebd8d2bf07a4739c06b641cf90d13072926f32R16-R25), [link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-55065c9fa7ebb65ea7ebd50a82ebd8d2bf07a4739c06b641cf90d13072926f32L90-R111))
* Define two classes `InvitationHostExtension` and `InvitationGuestExtension` in the `invitation-extension.ts` file, to implement the `InvitationHostService` service using the `teleport` framework for RPC calls. ([link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-a9bdaf18c65f53c82258411f1523b052bddbaab16ce9e5057456f6ed9906bd4eR1-R193))
* Update the `InvitationsHandler` class in the `invitations-handler.ts` file, to use the new extension classes for creating and managing the invitation protocol instances for the host and guest peers. ([link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328L9-R12), [link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328L20-R27), [link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328R216-R227), [link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328L263-R281), [link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328L286-R306), [link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328L302-R322), [link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328L319-R343), [link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328L340-R360), [link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328L353-R378), [link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328R388-R399), [link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328L387-R419), [link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328L394-R426), [link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-a500427a482f5955cca7bc3ec02a0f6740a1b27dbac56eeeea7cf9131a9cf328L408-L507))
* Add a new class `InvalidInvitationExtensionRoleError` to the `errors.ts` file, to define a custom error type for the case where the peers have incompatible roles. ([link](https://github.com/dxos/dxos/pull/3042/files?diff=unified&w=0#diff-d30e0f9503f6e5118fb4693a103a9a8aa94206ef00da9397208a22329b31b7ddR52-R57))


