### PR TITLE
feat: Local bots

### DIFF
--- a/packages/experimental/bot-lab/config/index.ts
+++ b/packages/experimental/bot-lab/config/index.ts
@@ -14,7 +14,7 @@ const defaults = {
     client: {
       storage: {
         persistent: true,
-        path: './dxos_client_storage'
+        path: process.env.DX_BOT_STORAGE ?? './dxos_client_storage'
       }
     },
     services: {

--- a/packages/experimental/bot-lab/package.json
+++ b/packages/experimental/bot-lab/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "build": "node -r @swc-node/register src/build.ts",
     "build:local": "pnpm -w nx compile bot-lab && pnpm run build && docker build . -t ghcr.io/dxos/bot:latest",
-    "build:remote": "pnpm -w nx compile bot-lab && pnpm run build && docker buildx build --platform linux/amd64 -t ghcr.io/dxos/bot:latest . --push"
+    "build:remote": "pnpm -w nx compile bot-lab && pnpm run build && docker buildx build --platform linux/amd64 -t ghcr.io/dxos/bot:latest . --push",
+    "dev": "node -r @swc-node/register src/main.ts"
   },
   "dependencies": {
     "@dxos/client": "workspace:*",
@@ -36,6 +37,6 @@
     "express": "4.17.1",
     "http-proxy": "^1.18.1",
     "node-http-proxy": "^0.2.4",
-    "sort-keys": "^5.0.0"
+    "sort-keys": "^4.0.0"
   }
 }

--- a/packages/experimental/bot-lab/src/main.ts
+++ b/packages/experimental/bot-lab/src/main.ts
@@ -67,7 +67,10 @@ const start = async () => {
   });
 
   await server.open();
-  log.info('listening', { rpcPort });
+  log.info('listening', { 
+    rpcPort,
+    url: 'ws://localhost:' + rpcPort
+  });
 
   let bot: Bot | undefined;
   // TODO(burdon): Reconcile this subscription with the ECHO db.query.

--- a/packages/experimental/kai/src/containers/BotManager/BotManager.tsx
+++ b/packages/experimental/kai/src/containers/BotManager/BotManager.tsx
@@ -10,7 +10,7 @@ import { debounce } from '@dxos/async';
 import { PublicKey } from '@dxos/keys';
 import { TableCellProps, TableColumn, Table, Toolbar } from '@dxos/mosaic';
 import { useKeyStore } from '@dxos/react-client';
-import { Button, getSize, mx, Select } from '@dxos/react-components';
+import { Button, getSize, Input, mx, Select } from '@dxos/react-components';
 
 import { botDefs, useAppRouter, useBotClient, getBotEnvs, botKeys } from '../../hooks';
 
@@ -86,6 +86,7 @@ export const BotManager = () => {
   const { space } = useAppRouter();
   const botClient = useBotClient(space!);
   const [keyMap] = useKeyStore(Object.keys(botKeys));
+  const [localOverride, setLocalOverride] = useState<string>('');
 
   useEffect(() => {
     void refresh();
@@ -162,7 +163,8 @@ export const BotManager = () => {
               </Select.Item>
             ))}
           </Select>
-          <Button className='mr-2' onClick={() => botId && botClient.startBot(botId, getBotEnvs(keyMap))}>
+          <Input label="Local target override" placeholder='ws://localhost:7400' value={localOverride} onChange={e => setLocalOverride(e.target.value)} />
+          <Button className='mr-2' onClick={() => botId && botClient.startBot(botId, getBotEnvs(keyMap), localOverride)}>
             Start
           </Button>
         </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2840,7 +2840,7 @@ importers:
       express: 4.17.1
       http-proxy: ^1.18.1
       node-http-proxy: ^0.2.4
-      sort-keys: ^5.0.0
+      sort-keys: ^4.0.0
     dependencies:
       '@dxos/client': link:../../sdk/client
       '@dxos/client-services': link:../../sdk/client-services
@@ -2856,7 +2856,7 @@ importers:
       express: 4.17.1
       http-proxy: 1.18.1
       node-http-proxy: 0.2.4
-      sort-keys: 5.0.0
+      sort-keys: 4.2.0
 
   packages/experimental/chess-app:
     specifiers:
@@ -16039,7 +16039,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.20.12
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.2.0_@types+node@18.11.9
+      vite: 4.2.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -34509,13 +34509,6 @@ packages:
       is-plain-obj: 2.1.0
     dev: false
 
-  /sort-keys/5.0.0:
-    resolution: {integrity: sha512-Pdz01AvCAottHTPQGzndktFNdbRA75BgOfeT1hH+AMnJFv8lynkPi42rfeEhpx1saTEI3YNMWxfqu0sFD1G8pw==}
-    engines: {node: '>=12'}
-    dependencies:
-      is-plain-obj: 4.1.0
-    dev: false
-
   /sort-object-keys/1.1.3:
     resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
     dev: false
@@ -37087,7 +37080,7 @@ packages:
       fast-glob: 3.2.12
       pretty-bytes: 6.0.0
       rollup: 3.9.1
-      vite: 4.2.0_@types+node@18.11.9
+      vite: 4.2.0
       workbox-build: 6.5.4
       workbox-window: 6.5.4
     transitivePeerDependencies:


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 66f55b4</samp>

### Summary
🛠️🚀🔌

<!--
1.  🛠️ - This emoji represents the configuration and debugging improvements that the changes provide.
2.  🚀 - This emoji represents the faster development workflow and local execution feature that the changes enable.
3.  🔌 - This emoji represents the WebSocket connection and communication aspect of the changes.
-->
This pull request adds a new feature and improves the development workflow for the `bot-lab` and `kai` packages. It enables the user to run and connect to a local bot server using a WebSocket URL, instead of a docker container. It also uses a faster TypeScript compiler and fixes a dependency issue for the `bot-lab` package. It adds more configuration and logging options for the bot storage and server.

> _`bot-lab` package_
> _more flexible and faster_
> _autumn leaves falling_

### Walkthrough
*  Allow bot storage path to be configured by environment variable or default value ([link](https://github.com/dxos/dxos/pull/3044/files?diff=unified&w=0#diff-dd9d9744b64972c430d10bd5af0ccb320701a8130279e8783ae795ed735c19aeL17-R17)).


