### PR TITLE
test(react-ui): add more time to improve test stability

### DIFF
--- a/packages/apps/patterns/react-ui/project.json
+++ b/packages/apps/patterns/react-ui/project.json
@@ -40,7 +40,6 @@
         "testPatterns": [
           "packages/apps/patterns/react-ui/src/playwright/**/*.spec.{ts,js}"
         ],
-        "timeout": 60000,
         "watchPatterns": [
           "packages/apps/patterns/react-ui/src/**/*"
         ]

--- a/packages/apps/patterns/react-ui/src/components/IdentityList/IdentityListItem.tsx
+++ b/packages/apps/patterns/react-ui/src/components/IdentityList/IdentityListItem.tsx
@@ -31,7 +31,10 @@ export const IdentityListItem = ({
           ...(presence === SpaceMember.PresenceState.OFFLINE && {
             status: 'inactive',
             description: (
-              <p className='font-system-normal text-xs text-neutral-700 dark:text-neutral-300'>
+              <p
+                className='font-system-normal text-xs text-neutral-700 dark:text-neutral-300'
+                data-testid='identity-list-item.description'
+              >
                 {t('identity offline description')}
               </p>
             )

--- a/packages/apps/patterns/react-ui/src/playwright/invitations.spec.ts
+++ b/packages/apps/patterns/react-ui/src/playwright/invitations.spec.ts
@@ -109,7 +109,7 @@ test.describe('Invitations', () => {
       await manager.openPanel(1, 'identity');
       await manager.acceptInvitation(1, 'device', invitation);
       // Wait for invitation to connect before cancelling it.
-      await sleep(100);
+      await sleep(500);
       await manager.cancelInvitation('device', 'host', manager.peer(0));
 
       // Wait for cancellation to propagate.
@@ -177,6 +177,8 @@ test.describe('Invitations', () => {
         manager.acceptInvitation(2, 'device', invitation2)
       ]);
       await manager.authenticateInvitation('device', authCode1, manager.peer(1));
+      // Helps to ensure both auth codes are fully input (especially in webkit).
+      await sleep(10);
       await manager.authenticateInvitation('device', authCode2, manager.peer(2));
       await manager.doneInvitation('device', manager.peer(1));
       await manager.doneInvitation('device', manager.peer(2));
@@ -296,7 +298,7 @@ test.describe('Invitations', () => {
       await manager.openPanel(1, 'join');
       await manager.acceptInvitation(1, 'space', invitation);
       // Wait for invitation to connect before cancelling it.
-      await sleep(100);
+      await sleep(500);
       await manager.cancelInvitation('space', 'host', manager.peer(0));
 
       // Wait for cancellation to propagate.
@@ -369,6 +371,8 @@ test.describe('Invitations', () => {
       await sleep(100);
       const [authCode2] = await Promise.all([manager.getAuthCode(), manager.acceptInvitation(2, 'space', invitation2)]);
       await manager.authenticateInvitation('space', authCode1, manager.peer(1));
+      // Helps to ensure both auth codes are fully input (especially in webkit).
+      await sleep(10);
       await manager.authenticateInvitation('space', authCode2, manager.peer(2));
       await manager.doneInvitation('space', manager.peer(1));
       await manager.doneInvitation('space', manager.peer(2));

--- a/packages/apps/patterns/react-ui/src/playwright/invitations.spec.ts
+++ b/packages/apps/patterns/react-ui/src/playwright/invitations.spec.ts
@@ -4,7 +4,6 @@
 
 import { test } from '@playwright/test';
 import { expect } from 'chai';
-import waitForExpect from 'wait-for-expect';
 
 import { sleep } from '@dxos/async';
 import { ConnectionState, Invitation } from '@dxos/protocols/proto/dxos/client/services';
@@ -53,6 +52,8 @@ test.describe('Invitations', () => {
     });
 
     test('invalid & retry auth code', async () => {
+      test.slow();
+
       await manager.createIdentity(0);
       await manager.openPanel(0, 'devices');
       const invitation = await manager.createInvitation(0, 'device');
@@ -104,10 +105,7 @@ test.describe('Invitations', () => {
       await manager.openPanel(1, 'identity');
       await manager.acceptInvitation(1, 'device', invitation);
 
-      // Wait for timeout to fire.
-      await waitForExpect(async () => {
-        expect(await manager.invitationFailed(manager.peer(1))).to.be.true;
-      }, 500);
+      expect(await manager.invitationFailed(manager.peer(1))).to.be.true;
     });
 
     test('invitation cancelled by host', async () => {
@@ -117,14 +115,10 @@ test.describe('Invitations', () => {
 
       await manager.openPanel(1, 'identity');
       await manager.acceptInvitation(1, 'device', invitation);
-      // Wait for invitation to connect before cancelling it.
-      await sleep(500);
+      expect(await manager.readyToAuthenticate('device', manager.peer(1))).to.be.true;
       await manager.cancelInvitation('device', 'host', manager.peer(0));
 
-      // Wait for cancellation to propagate.
-      await waitForExpect(async () => {
-        expect(await manager.invitationFailed(manager.peer(1))).to.be.true;
-      }, 500);
+      expect(await manager.invitationFailed(manager.peer(1))).to.be.true;
     });
 
     test('invitation cancelled by guest & retry', async () => {
@@ -153,12 +147,11 @@ test.describe('Invitations', () => {
 
       await manager.openPanel(1, 'identity');
       await manager.acceptInvitation(1, 'device', invitation);
-      // Wait for invitation to connect before going offline.
-      await sleep(500);
-      await manager.setConnectionState(0, ConnectionState.OFFLINE);
-      // Wait for network failure to propagate.
-      await sleep(500);
-      await manager.setConnectionState(0, ConnectionState.ONLINE);
+      expect(await manager.readyToAuthenticate('device', manager.peer(1))).to.be.true;
+      await manager.toggleNetworkStatus(0);
+      expect(await manager.getNetworkStatus(0)).to.equal(ConnectionState.OFFLINE);
+      await manager.toggleNetworkStatus(0);
+      expect(await manager.getNetworkStatus(0)).to.equal(ConnectionState.ONLINE);
       await manager.resetInvitation(manager.peer(1));
       await manager.invitationInputContinue('device', manager.peer(1));
       const [authCode] = await Promise.all([manager.getAuthCode(), manager.clearAuthCode('device', manager.peer(1))]);
@@ -173,22 +166,24 @@ test.describe('Invitations', () => {
 
       await manager.createIdentity(0);
       await manager.openPanel(0, 'devices');
-      const invitation1 = await manager.createInvitation(0, 'device');
-      const invitation2 = await manager.createInvitation(0, 'device');
-
       await manager.openPanel(1, 'identity');
       await manager.openPanel(2, 'identity');
+
+      // TODO(wittjosiah): Improve auth code fetching to make it easier to disambiguate them.
+      const invitation1 = await manager.createInvitation(0, 'device');
       const [authCode1] = await Promise.all([
         manager.getAuthCode(),
         manager.acceptInvitation(1, 'device', invitation1)
       ]);
-      // Prevent auth code from being reused.
-      await sleep(100);
+
+      const invitation2 = await manager.createInvitation(0, 'device');
       const [authCode2] = await Promise.all([
         manager.getAuthCode(),
         manager.acceptInvitation(2, 'device', invitation2)
       ]);
+
       await manager.authenticateInvitation('device', authCode1, manager.peer(1));
+      // TODO(wittjosiah): Managing focus in tests is flaky.
       // Helps to ensure both auth codes are fully input (especially in webkit).
       await sleep(100);
       await manager.authenticateInvitation('device', authCode2, manager.peer(2));
@@ -257,6 +252,8 @@ test.describe('Invitations', () => {
     });
 
     test('invalid & max auth code retries reached, retry invitation', async () => {
+      test.slow();
+
       await manager.createIdentity(0);
       await manager.createSpace(0);
       await manager.openPanel(0, 0);
@@ -296,10 +293,7 @@ test.describe('Invitations', () => {
       await manager.openPanel(1, 'join');
       await manager.acceptInvitation(1, 'space', invitation);
 
-      // Wait for timeout to fire.
-      await waitForExpect(async () => {
-        expect(await manager.invitationFailed(manager.peer(1))).to.be.true;
-      }, 500);
+      expect(await manager.invitationFailed(manager.peer(1))).to.be.true;
     });
 
     test('invitation cancelled by host', async () => {
@@ -311,14 +305,10 @@ test.describe('Invitations', () => {
       await manager.createIdentity(1);
       await manager.openPanel(1, 'join');
       await manager.acceptInvitation(1, 'space', invitation);
-      // Wait for invitation to connect before cancelling it.
-      await sleep(500);
+      expect(await manager.readyToAuthenticate('space', manager.peer(1))).to.be.true;
       await manager.cancelInvitation('space', 'host', manager.peer(0));
 
-      // Wait for cancellation to propagate.
-      await waitForExpect(async () => {
-        expect(await manager.invitationFailed(manager.peer(1))).to.be.true;
-      }, 500);
+      expect(await manager.invitationFailed(manager.peer(1))).to.be.true;
     });
 
     test('invitation cancelled by guest & retry', async () => {
@@ -354,12 +344,11 @@ test.describe('Invitations', () => {
       await manager.createIdentity(1);
       await manager.openPanel(1, 'join');
       await manager.acceptInvitation(1, 'space', invitation);
-      // Wait for invitation to connect before going offline.
-      await sleep(500);
-      await manager.setConnectionState(0, ConnectionState.OFFLINE);
-      // Wait for network failure to propagate.
-      await sleep(500);
-      await manager.setConnectionState(0, ConnectionState.ONLINE);
+      expect(await manager.readyToAuthenticate('space', manager.peer(1))).to.be.true;
+      await manager.toggleNetworkStatus(0);
+      expect(await manager.getNetworkStatus(0)).to.equal(ConnectionState.OFFLINE);
+      await manager.toggleNetworkStatus(0);
+      expect(await manager.getNetworkStatus(0)).to.equal(ConnectionState.ONLINE);
       await manager.resetInvitation(manager.peer(1));
       await manager.invitationInputContinue('space', manager.peer(1));
       const [authCode] = await Promise.all([manager.getAuthCode(), manager.clearAuthCode('space', manager.peer(1))]);
@@ -374,19 +363,20 @@ test.describe('Invitations', () => {
       test.slow();
 
       await manager.createIdentity(0);
-      await manager.createSpace(0);
-      await manager.openPanel(0, 0);
-      const invitation1 = await manager.createInvitation(0, 'space');
-      const invitation2 = await manager.createInvitation(0, 'space');
-
       await manager.createIdentity(1);
       await manager.createIdentity(2);
+
+      await manager.createSpace(0);
+      await manager.openPanel(0, 0);
       await manager.openPanel(1, 'join');
       await manager.openPanel(2, 'join');
+
+      const invitation1 = await manager.createInvitation(0, 'space');
       const [authCode1] = await Promise.all([manager.getAuthCode(), manager.acceptInvitation(1, 'space', invitation1)]);
-      // Prevent auth code from being reused.
-      await sleep(100);
+
+      const invitation2 = await manager.createInvitation(0, 'space');
       const [authCode2] = await Promise.all([manager.getAuthCode(), manager.acceptInvitation(2, 'space', invitation2)]);
+
       await manager.authenticateInvitation('space', authCode1, manager.peer(1));
       // Helps to ensure both auth codes are fully input (especially in webkit).
       await sleep(100);

--- a/packages/apps/patterns/react-ui/src/playwright/invitations.spec.ts
+++ b/packages/apps/patterns/react-ui/src/playwright/invitations.spec.ts
@@ -144,20 +144,21 @@ test.describe('Invitations', () => {
       expect(await manager.getDisplayName(0)).to.equal(await manager.getDisplayName(1));
     });
 
-    // TODO(wittjosiah): This is flaky and regularly fails CI.
-    test.skip('recover from network failure during invitation', async () => {
+    test('recover from network failure during invitation', async () => {
+      test.slow();
+
       await manager.createIdentity(0);
       await manager.openPanel(0, 'devices');
       const invitation = await manager.createInvitation(0, 'device');
 
       await manager.openPanel(1, 'identity');
       await manager.acceptInvitation(1, 'device', invitation);
-      await sleep(100);
+      // Wait for invitation to connect before going offline.
+      await sleep(500);
       await manager.setConnectionState(0, ConnectionState.OFFLINE);
-      await sleep(100);
+      // Wait for network failure to propagate.
+      await sleep(500);
       await manager.setConnectionState(0, ConnectionState.ONLINE);
-      // TODO(wittjosiah): Requires attempting an action to discover the network failure.
-      await manager.authenticateInvitation('device', '00000', manager.peer(1));
       await manager.resetInvitation(manager.peer(1));
       await manager.invitationInputContinue('device', manager.peer(1));
       const [authCode] = await Promise.all([manager.getAuthCode(), manager.clearAuthCode('device', manager.peer(1))]);
@@ -342,8 +343,9 @@ test.describe('Invitations', () => {
       expect(await manager.getSpaceName(0, 0)).to.equal(await manager.getSpaceName(1, 0));
     });
 
-    // TODO(wittjosiah): This is flaky and regularly fails CI.
-    test.skip('recover from network failure during invitation', async () => {
+    test('recover from network failure during invitation', async () => {
+      test.slow();
+
       await manager.createIdentity(0);
       await manager.createSpace(0);
       await manager.openPanel(0, 0);
@@ -352,12 +354,12 @@ test.describe('Invitations', () => {
       await manager.createIdentity(1);
       await manager.openPanel(1, 'join');
       await manager.acceptInvitation(1, 'space', invitation);
-      await sleep(100);
+      // Wait for invitation to connect before going offline.
+      await sleep(500);
       await manager.setConnectionState(0, ConnectionState.OFFLINE);
-      await sleep(100);
+      // Wait for network failure to propagate.
+      await sleep(500);
       await manager.setConnectionState(0, ConnectionState.ONLINE);
-      // TODO(wittjosiah): Requires attempting an action to discover the network failure.
-      await manager.authenticateInvitation('space', '00000', manager.peer(1));
       await manager.resetInvitation(manager.peer(1));
       await manager.invitationInputContinue('space', manager.peer(1));
       const [authCode] = await Promise.all([manager.getAuthCode(), manager.clearAuthCode('space', manager.peer(1))]);

--- a/packages/apps/patterns/react-ui/src/playwright/invitations.spec.ts
+++ b/packages/apps/patterns/react-ui/src/playwright/invitations.spec.ts
@@ -14,6 +14,13 @@ import { InvitationsManager } from './invitations-manager';
 test.describe('Invitations', () => {
   let manager: InvitationsManager;
 
+  // TODO(wittjosiah): Storybook takes a bit to be ready for testing against.
+  test.beforeAll(async ({ browser }) => {
+    test.setTimeout(60_000);
+    manager = new InvitationsManager(browser);
+    await manager.init();
+  });
+
   test.beforeEach(async ({ browser }) => {
     manager = new InvitationsManager(browser);
     await manager.init();
@@ -61,6 +68,8 @@ test.describe('Invitations', () => {
     });
 
     test('invalid & max auth code retries reached, retry invitation', async () => {
+      test.slow();
+
       await manager.createIdentity(0);
       await manager.openPanel(0, 'devices');
       const invitation = await manager.createInvitation(0, 'device');
@@ -98,7 +107,7 @@ test.describe('Invitations', () => {
       // Wait for timeout to fire.
       await waitForExpect(async () => {
         expect(await manager.invitationFailed(manager.peer(1))).to.be.true;
-      }, 100);
+      }, 500);
     });
 
     test('invitation cancelled by host', async () => {
@@ -115,7 +124,7 @@ test.describe('Invitations', () => {
       // Wait for cancellation to propagate.
       await waitForExpect(async () => {
         expect(await manager.invitationFailed(manager.peer(1))).to.be.true;
-      }, 100);
+      }, 500);
     });
 
     test('invitation cancelled by guest & retry', async () => {
@@ -159,6 +168,8 @@ test.describe('Invitations', () => {
     });
 
     test('multiple concurrent invitations', async () => {
+      test.slow();
+
       await manager.createIdentity(0);
       await manager.openPanel(0, 'devices');
       const invitation1 = await manager.createInvitation(0, 'device');
@@ -178,7 +189,7 @@ test.describe('Invitations', () => {
       ]);
       await manager.authenticateInvitation('device', authCode1, manager.peer(1));
       // Helps to ensure both auth codes are fully input (especially in webkit).
-      await sleep(10);
+      await sleep(100);
       await manager.authenticateInvitation('device', authCode2, manager.peer(2));
       await manager.doneInvitation('device', manager.peer(1));
       await manager.doneInvitation('device', manager.peer(2));
@@ -222,6 +233,8 @@ test.describe('Invitations', () => {
     });
 
     test('invalid & retry auth code', async () => {
+      test.slow();
+
       await manager.createIdentity(0);
       await manager.createSpace(0);
       await manager.openPanel(0, 0);
@@ -285,7 +298,7 @@ test.describe('Invitations', () => {
       // Wait for timeout to fire.
       await waitForExpect(async () => {
         expect(await manager.invitationFailed(manager.peer(1))).to.be.true;
-      }, 100);
+      }, 500);
     });
 
     test('invitation cancelled by host', async () => {
@@ -304,7 +317,7 @@ test.describe('Invitations', () => {
       // Wait for cancellation to propagate.
       await waitForExpect(async () => {
         expect(await manager.invitationFailed(manager.peer(1))).to.be.true;
-      }, 100);
+      }, 500);
     });
 
     test('invitation cancelled by guest & retry', async () => {
@@ -356,6 +369,8 @@ test.describe('Invitations', () => {
     });
 
     test('multiple concurrent invitations', async () => {
+      test.slow();
+
       await manager.createIdentity(0);
       await manager.createSpace(0);
       await manager.openPanel(0, 0);
@@ -372,7 +387,7 @@ test.describe('Invitations', () => {
       const [authCode2] = await Promise.all([manager.getAuthCode(), manager.acceptInvitation(2, 'space', invitation2)]);
       await manager.authenticateInvitation('space', authCode1, manager.peer(1));
       // Helps to ensure both auth codes are fully input (especially in webkit).
-      await sleep(10);
+      await sleep(100);
       await manager.authenticateInvitation('space', authCode2, manager.peer(2));
       await manager.doneInvitation('space', manager.peer(1));
       await manager.doneInvitation('space', manager.peer(2));

--- a/packages/apps/patterns/react-ui/src/stories/Invitations.stories.tsx
+++ b/packages/apps/patterns/react-ui/src/stories/Invitations.stories.tsx
@@ -4,10 +4,11 @@
 
 import '@dxosTheme';
 import { faker } from '@faker-js/faker';
-import { Intersect, Laptop, Planet, Plus, PlusCircle, QrCode } from '@phosphor-icons/react';
+import { Intersect, Laptop, Planet, Plus, PlusCircle, QrCode, WifiHigh, WifiSlash } from '@phosphor-icons/react';
 import React, { useMemo, useState } from 'react';
 
-import { Space, SpaceProxy, useClient, useIdentity, useSpaces } from '@dxos/react-client';
+import { ConnectionState, SpaceMember } from '@dxos/protocols/proto/dxos/client/services';
+import { Space, SpaceProxy, useClient, useIdentity, useNetworkStatus, useSpaces } from '@dxos/react-client';
 import { ClientDecorator } from '@dxos/react-client/testing';
 import { Button, ButtonGroup, getSize, Group } from '@dxos/react-components';
 
@@ -96,6 +97,7 @@ const Panel = ({ id, panel, setPanel }: { id: number; panel?: PanelType; setPane
 
 const render = ({ id }: { id: number }) => {
   const client = useClient();
+  const networkStatus = useNetworkStatus().state;
   const identity = useIdentity();
   const [panel, setPanel] = useState<PanelType>();
 
@@ -138,6 +140,22 @@ const render = ({ id }: { id: number }) => {
         <Planet weight='fill' className={getSize(6)} />
       </Button>
       {/* </Tooltip> */}
+      {/* <ToolTip content='Toggle Network'> */}
+      <Button
+        onClick={() =>
+          client.mesh.setConnectionState(
+            networkStatus === ConnectionState.ONLINE ? ConnectionState.OFFLINE : ConnectionState.ONLINE
+          )
+        }
+        data-testid='invitations.toggle-network'
+      >
+        {networkStatus === ConnectionState.ONLINE ? (
+          <WifiHigh weight='fill' className={getSize(6)} />
+        ) : (
+          <WifiSlash weight='fill' className={getSize(6)} />
+        )}
+      </Button>
+      {/* </ToolTip> */}
     </ButtonGroup>
   );
 
@@ -152,7 +170,11 @@ const render = ({ id }: { id: number }) => {
   return (
     <div className='flex flex-col p-4 flex-1 min-w-0' data-testid={`peer-${id}`}>
       <Group label={{ children: header }} className='mbe-2'>
-        {identity ? <IdentityListItem identity={identity} /> : <div className='text-center'>No identity</div>}
+        {identity ? (
+          <IdentityListItem identity={identity} presence={networkStatus as unknown as SpaceMember.PresenceState} />
+        ) : (
+          <div className='text-center'>No identity</div>
+        )}
       </Group>
       {identity || panel ? <Panel id={id} panel={panel} setPanel={setPanel} /> : null}
     </div>

--- a/packages/apps/patterns/react-ui/src/testing/shell-manager.ts
+++ b/packages/apps/patterns/react-ui/src/testing/shell-manager.ts
@@ -13,8 +13,14 @@ export class ShellManager {
     return (scope || this.page).getByTestId(`${type === 'device' ? 'halo' : 'space'}-auth-code-input`).isVisible();
   }
 
-  invitationFailed(scope?: Scope) {
-    return (scope || this.page).getByTestId('invitation-rescuer-reset').isVisible();
+  async invitationFailed(scope?: Scope, timeout = 3000) {
+    const peer = scope || this.page;
+    try {
+      await peer.locator('[data-testid=invitation-rescuer-reset]:not([disabled])').waitFor({ timeout });
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async inputInvitation(type: 'device' | 'space', invitation: string, scope?: Scope) {
@@ -33,6 +39,18 @@ export class ShellManager {
         .click();
     } else {
       await (scope || this.page).getByTestId('cancel-invitation').nth(0).click();
+    }
+  }
+
+  async readyToAuthenticate(type: 'device' | 'space', scope?: Scope, timeout = 3000) {
+    const peer = scope || this.page;
+    try {
+      await peer
+        .locator(`[data-testid=${type === 'device' ? 'halo' : 'space'}-auth-code-input]:not([disabled])`)
+        .waitFor({ timeout });
+      return true;
+    } catch {
+      return false;
     }
   }
 

--- a/packages/sdk/react-client/src/invitations/useInvitationStatus.ts
+++ b/packages/sdk/react-client/src/invitations/useInvitationStatus.ts
@@ -105,9 +105,7 @@ export const useInvitationStatus = (initialObservable?: CancellableInvitationObs
   // Handle unmount
 
   useEffect(() => {
-    console.log('sub');
     const update = (invitation: Invitation) => {
-      console.log('update');
       switch (invitation.state) {
         case Invitation.State.CONNECTED:
         case Invitation.State.READY_FOR_AUTHENTICATION:

--- a/tools/executors/test/src/playwright.ts
+++ b/tools/executors/test/src/playwright.ts
@@ -127,7 +127,7 @@ const getProject = (browser: BrowserType | MobileType): Project => {
 export const defaultPlaywrightConfig: PlaywrightTestConfig = {
   testDir: '.',
   outputDir: process.env.OUTPUT_PATH,
-  timeout: process.env.TIMEOUT ? Number(process.env.TIMEOUT) : 30_000,
+  timeout: process.env.TIMEOUT ? Number(process.env.TIMEOUT) : undefined,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   reporter:


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9a9852d</samp>

### Summary
🗑️🔄🚀

<!--
1.  🗑️ - This emoji represents the removal of the timeout property from the project.json file and the console.log statements from the useInvitationStatus hook. It conveys the idea of deleting or discarding something that is no longer needed or useful.
2.  🔄 - This emoji represents the change of the timeout property from 30_000 to undefined in the defaultPlaywrightConfig object. It conveys the idea of updating or refreshing something to a different or better value or state.
3.  🚀 - This emoji represents the increase of the sleep and waitForExpect durations, the addition of the test.slow and test.beforeAll methods, and the enabling of the previously skipped tests in the invitations.spec.ts file. It conveys the idea of improving or enhancing something to make it faster, more reliable, or more complete.
-->
This pull request improves the playwright tests for the React UI app by adjusting the timeouts, enabling skipped tests, and removing unnecessary console logs. It also removes the timeout property from the `project.json` and `playwright.ts` files to use the default playwright timeout instead.

> _Oh, we're the playwright testers, and we sail the code sea_
> _We set the timeout as we please, by `TIMEOUT` or `test.setTimeout`_
> _We clean the console logs and the project.json file_
> _And we heave away the invitations tests, with `test.slow` and `test.beforeAll`_

### Walkthrough
*  Remove global timeout property from `project.json` file and use environment variable or test-specific methods instead ([link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-b50fa6b3dec30986329c90be1b26ef663297027acf286c633b0f56fa29b3b758L43))
*  Add test.beforeAll hook to initialize InvitationsManager and set test timeout to 60 seconds in `invitations.spec.ts` file ([link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276R17-R23))
*  Increase sleep and waitForExpect durations and mark some tests as slow to reduce flakiness and timeout errors in `invitations.spec.ts` file ([link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276R71-R72), [link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276L101-R110), [link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276L112-R121), [link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276L118-R127), [link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276L146-R160), [link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276R171-R172), [link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276R191-R192), [link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276R236-R237), [link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276L286-R301), [link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276L299-R314), [link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276L305-R320), [link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276L340-R359), [link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276R371-R372), [link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276R388-R389))
*  Enable previously skipped tests and verify that they can pass after the changes in `invitations.spec.ts` file ([link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276L139-R148), [link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-39a6732508bc908a784751924aa48d6b345890596eb212153958629a3060b276L330-R345))
*  Remove console.log statements from useInvitationStatus hook in `useInvitationStatus.ts` file ([link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-84e9274d409976705203542e74f34a4438c268b9d52bef68371b5f44c0a53964L108-R108))
*  Use default timeout value of playwright library instead of overriding it in `playwright.ts` file ([link](https://github.com/dxos/dxos/pull/3045/files?diff=unified&w=0#diff-a803c7c351cb2280e8e7fbfcefda21db6c2439a92591bf7251f00dc9368cdf10L130-R130))


