### PR TITLE
feat: Polish sketch demo

### DIFF
--- a/packages/experimental/kai-frames/src/frames/Sketch/SketchFrame.tsx
+++ b/packages/experimental/kai-frames/src/frames/Sketch/SketchFrame.tsx
@@ -46,8 +46,8 @@ export const SketchFrame = observer(() => {
   const ipfsClient = useIpfsClient();
   const download = useFileDownload();
   const canvasRef = useRef<any>();
-  const [strokeColor, setStrokeColor] = useState('#333');
-  const [strokeWidth, setStrokeWidth] = useState(4);
+  const [strokeColor, setStrokeColor] = useState('#B80000');
+  const [strokeWidth, setStrokeWidth] = useState(16);
   const active = useRef(false); // TODO(burdon): Review ref pattern.
 
   const { space, frame, objectId, fullscreen, onStateChange } = useFrameContext();
@@ -156,12 +156,13 @@ export const SketchFrame = observer(() => {
 
   if (fullscreen) {
     return (
-      <div className='relative flex flex-col bs-full' onClick={handleClear} onDoubleClick={handleReset}>
-        <div className='flex flex-col flex-1 items-center justify-center overflow-auto'>
+      <div className='relative flex flex-col bs-full bg-white' onClick={handleClear} onDoubleClick={handleReset}>
+        <div className='flex z-10 flex-col flex-1 items-center justify-center overflow-auto'>
           <ReactSketchCanvas
             ref={canvasRef}
             // className='shadow-1'
-            style={{}} // Replace defaults.
+            canvasColor="transparent"
+            // style={{ background: 'transparent' }} // Replace defaults.
             width={'100%'}
             height={'100%'}
             strokeWidth={strokeWidth}
@@ -171,8 +172,8 @@ export const SketchFrame = observer(() => {
           />
         </div>
 
-        <div className='fixed z-10 flex flex-col h-full flex-1 items-center place-items-center justify-center overflow-auto overflow-hidden w-full opacity-25 pointer-events-none'>
-          <div className='flex w-1/2'>
+        <div className='fixed flex flex-col h-full flex-1 items-center place-items-center justify-center overflow-auto overflow-hidden w-full opacity-50 pointer-events-none'>
+          <div className='flex w-3/4'>
             <KioskInvitationQr space={space} />
           </div>
         </div>
@@ -182,7 +183,7 @@ export const SketchFrame = observer(() => {
             .filter((member) => member.presence === SpaceMember.PresenceState.ONLINE)
             .slice(1)
             .map((member) => (
-              <div className='w-2 h-2 m-2 bg-black rounded-full' key={member.identity.identityKey.toHex()} />
+              <div className='w-4 h-4 m-4 bg-black rounded-full' key={member.identity.identityKey.toHex()} />
             ))}
         </div>
       </div>

--- a/packages/experimental/kai-frames/src/frames/Sketch/SketchFrame.tsx
+++ b/packages/experimental/kai-frames/src/frames/Sketch/SketchFrame.tsx
@@ -161,7 +161,7 @@ export const SketchFrame = observer(() => {
           <ReactSketchCanvas
             ref={canvasRef}
             // className='shadow-1'
-            canvasColor="transparent"
+            canvasColor='transparent'
             // style={{ background: 'transparent' }} // Replace defaults.
             width={'100%'}
             height={'100%'}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 51dc4b9</samp>

### Summary
🎨🔎🖼️

<!--
1.  🎨 This emoji represents the artistic aspect of changing the colors and opacities of the sketch frame elements, as well as the overall aesthetics of the UI.
2.  🔎 This emoji represents the goal of enhancing the visibility and readability of the canvas, QR code, and user icons, by making them more prominent and clear.
3.  🖼️ This emoji represents the sketch frame itself, as the main component of the UI that displays the user's drawings and interactions.
-->
Improved the UI of the `SketchFrame` component in the `kai-frames` package. Changed the styles of the canvas, QR code, and user icons to make them more visible and appealing.

> _Sing, O Muse, of the skillful coder who improved the sketch frame UI_
> _And made the canvas shine like the sun, the QR code clear as the sky_
> _And the user icons radiant as the stars that crown the night_
> _With colors, sizes, and opacities that please the eye and mind_

### Walkthrough
* Change the default stroke color and width of the sketch canvas to red and 16 pixels ([link](https://github.com/dxos/dxos/pull/3046/files?diff=unified&w=0#diff-0c8733c6aa7137deae7cbe1aec706d8abeac3b199e45b21bc5929f076ee27a53L49-R50))
* Change the background color of the sketch frame to white and the canvas color to transparent ([link](https://github.com/dxos/dxos/pull/3046/files?diff=unified&w=0#diff-0c8733c6aa7137deae7cbe1aec706d8abeac3b199e45b21bc5929f076ee27a53L159-R165))
* Increase the opacity, width, size, and margin of the QR code and the user icons ([link](https://github.com/dxos/dxos/pull/3046/files?diff=unified&w=0#diff-0c8733c6aa7137deae7cbe1aec706d8abeac3b199e45b21bc5929f076ee27a53L174-R176), [link](https://github.com/dxos/dxos/pull/3046/files?diff=unified&w=0#diff-0c8733c6aa7137deae7cbe1aec706d8abeac3b199e45b21bc5929f076ee27a53L185-R186))
* Remove the redundant style prop from the `SketchFrame` component ([link](https://github.com/dxos/dxos/pull/3046/files?diff=unified&w=0#diff-0c8733c6aa7137deae7cbe1aec706d8abeac3b199e45b21bc5929f076ee27a53L159-R165))


