### PR TITLE
fix: Proper error message when crypto is not available

### DIFF
--- a/packages/core/halo/keyring/src/keyring.ts
+++ b/packages/core/halo/keyring/src/keyring.ts
@@ -24,7 +24,9 @@ export class Keyring implements Signer {
     private readonly _storage: Directory = createStorage({
       type: StorageType.RAM
     }).createDirectory('keyring')
-  ) {}
+  ) {
+    assert(subtleCrypto, 'SubtleCrypto not available in this environment.');
+  }
 
   async sign(key: PublicKey, message: Uint8Array): Promise<Uint8Array> {
     const keyPair = await this._getKey(key);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5cb16f5</samp>

### Summary
🔒🚨🌐

<!--
1.  🔒 - This emoji represents security, encryption, or protection, and can be used to indicate that the change is related to cryptography or preventing unauthorized access.
2.  🚨 - This emoji represents an alert, warning, or error, and can be used to indicate that the change introduces a new assertion or validation that may throw an exception or stop the execution if not satisfied.
3.  🌐 - This emoji represents the web, internet, or browser, and can be used to indicate that the change is related to a global variable or feature that is specific to web environments or platforms.
-->
Added a security check to the `Keyring` class constructor to require the Web Crypto API. This affects the file `keyring.ts` in the `halo/keyring` package.

> _`Keyring` checks for_
> _`subtleCrypto` presence_
> _A winter safeguard_

### Walkthrough
*  Add assertion to check for `subtleCrypto` support in `Keyring` constructor ([link](https://github.com/dxos/dxos/pull/3049/files?diff=unified&w=0#diff-9850c0b9352fc77c6b6508008121d48fc3611cb32328d953bbd409d1abd33db8L27-R29)). This prevents the keyring from being used in insecure environments that do not provide cryptographic operations.


