### PR TITLE
test(composer-app): skip collab tests in webkit when not on macos

### DIFF
--- a/packages/apps/composer-app/src/playwright/basic.spec.ts
+++ b/packages/apps/composer-app/src/playwright/basic.spec.ts
@@ -4,6 +4,7 @@
 
 import { test } from '@playwright/test';
 import { expect } from 'chai';
+import { platform } from 'node:os';
 import waitForExpect from 'wait-for-expect';
 
 import { AppManager } from './app-manager';
@@ -51,8 +52,12 @@ test.describe('Basic test', () => {
     });
   });
 
+  // TODO(wittjosiah): WebRTC only available in chromium browser for testing currently.
+  //   https://github.com/microsoft/playwright/issues/2973
   test.describe('Collab tests', () => {
     test('guest joins host’s space', async ({ browserName }) => {
+      test.skip(platform() !== 'darwin' && browserName === 'webkit');
+
       await guest.shell.createIdentity('guest');
       const invitationCode = await host.shell.createSpaceInvitation();
       await guest.joinSpace();
@@ -69,7 +74,9 @@ test.describe('Basic test', () => {
       });
     });
 
-    test('guest can see same documents on join', async () => {
+    test('guest can see same documents on join', async ({ browserName }) => {
+      test.skip(platform() !== 'darwin' && browserName === 'webkit');
+
       const hostLinks = await Promise.all([
         host.getDocumentLinks().nth(0).getAttribute('href'),
         host.getDocumentLinks().nth(1).getAttribute('href')
@@ -82,7 +89,9 @@ test.describe('Basic test', () => {
       expect(hostLinks[1]).to.equal(guestLinks[1]);
     });
 
-    test('host and guest can see each others’ presence when same document is in focus', async () => {
+    test('host and guest can see each others’ presence when same document is in focus', async ({ browserName }) => {
+      test.skip(platform() !== 'darwin' && browserName === 'webkit');
+
       await Promise.all([
         host.getDocumentLinks().nth(0).click(),
         guest.getDocumentLinks().nth(0).click(),
@@ -101,7 +110,9 @@ test.describe('Basic test', () => {
       });
     });
 
-    test('host and guest can see each others’ changes in same document', async () => {
+    test('host and guest can see each others’ changes in same document', async ({ browserName }) => {
+      test.skip(platform() !== 'darwin' && browserName === 'webkit');
+
       const parts = [
         'Lorem ipsum dolor sit amet,',
         ' consectetur adipiscing elit,',


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 35cd788</samp>

### Summary
🚧🌐🦊

<!--
1.  🚧 - This emoji conveys the idea of work in progress or a temporary solution, which fits the use of `test.skip` and the mention of a workaround.
2.  🌐 - This emoji conveys the idea of the web or internet, which fits the context of WebRTC and cross-platform testing.
3.  🦊 - This emoji conveys the idea of Safari, since it is the animal that represents the browser's logo. Alternatively, one could use 🍎 to represent macOS, since the issue is specific to that platform.
-->
Skipped some WebRTC tests in Safari for non-macOS platforms in `basic.spec.ts` to avoid failures due to a known issue.

> _We face the doom of WebRTC_
> _In Safari's broken realm_
> _We skip the tests that make us bleed_
> _Until we find a way to heal_

### Walkthrough
* Import `platform` function from `node:os` module to check operating system platform ([link](https://github.com/dxos/dxos/pull/3051/files?diff=unified&w=0#diff-615a8fa2d770170d158b9feb2bfbaaf0d2ef698d8c702b6293817a8b406a0708R7))
* Skip four tests involving WebRTC collaboration if platform is not `darwin` and browser is `webkit`, as this feature is not available in Safari for testing ([link](https://github.com/dxos/dxos/pull/3051/files?diff=unified&w=0#diff-615a8fa2d770170d158b9feb2bfbaaf0d2ef698d8c702b6293817a8b406a0708L54-R60), [link](https://github.com/dxos/dxos/pull/3051/files?diff=unified&w=0#diff-615a8fa2d770170d158b9feb2bfbaaf0d2ef698d8c702b6293817a8b406a0708L72-R79), [link](https://github.com/dxos/dxos/pull/3051/files?diff=unified&w=0#diff-615a8fa2d770170d158b9feb2bfbaaf0d2ef698d8c702b6293817a8b406a0708L85-R94), [link](https://github.com/dxos/dxos/pull/3051/files?diff=unified&w=0#diff-615a8fa2d770170d158b9feb2bfbaaf0d2ef698d8c702b6293817a8b406a0708L104-R115))


