### PR TITLE
chore: Add multiple signal in Kai, Composer, Halo configs

### DIFF
--- a/packages/apps/composer-app/dx.yml
+++ b/packages/apps/composer-app/dx.yml
@@ -21,6 +21,7 @@ runtime:
   services:
     signaling:
       - server: wss://kube.dxos.org/.well-known/dx/signal
+      - server: wss://dev.kube.dxos.org/.well-known/dx/signal
     ice:
       - urls: turn:kube.dxos.org:3478
         username: dxos

--- a/packages/apps/halo-app/dx.yml
+++ b/packages/apps/halo-app/dx.yml
@@ -20,6 +20,7 @@ runtime:
   services:
     signaling:
       - server: wss://kube.dxos.org/.well-known/dx/signal
+      - server: wss://dev.kube.dxos.org/.well-known/dx/signal
     ice:
       - urls: turn:kube.dxos.org:3478
         username: dxos

--- a/packages/experimental/kai/dx.yml
+++ b/packages/experimental/kai/dx.yml
@@ -32,6 +32,7 @@ runtime:
   services:
     signaling:
       - server: wss://kube.dxos.org/.well-known/dx/signal
+      - server: wss://dev.kube.dxos.org/.well-known/dx/signal
     ice:
       - urls: turn:kube.dxos.org:3478
         username: dxos


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0049ba1</samp>

### Summary
📡🧪🤝

<!--
1.  📡 - This emoji represents the signaling server, which is a network device that facilitates peer-to-peer communication. It can also suggest radio waves, broadcasting, or satellite communication.
2.  🧪 - This emoji represents the dev.kube.dxos.org domain, which is a development environment for testing and debugging purposes. It can also suggest experimentation, science, or innovation.
3.  🤝 - This emoji represents the peer-to-peer connections that are enabled by the signaling server and the dev.kube.dxos.org domain. It can also suggest cooperation, collaboration, or partnership.
-->
This pull request adds a new signaling server to the `dx.yml` configuration files of three DXOS applications: `composer-app`, `halo-app`, and `kai`. The new server allows these applications to communicate with other clients in the `dev.kube.dxos.org` domain for testing and debugging purposes.

> _`signaling server`_
> _added to three apps for dev_
> _testing in the fall_

### Walkthrough
*  Add a new signaling server to the composer-app, halo-app, and kai configurations ([link](https://github.com/dxos/dxos/pull/3053/files?diff=unified&w=0#diff-e1dbd958f1b16453725453af5c7364a95998fc16cdf71784a589313210636e69R24), [link](https://github.com/dxos/dxos/pull/3053/files?diff=unified&w=0#diff-ea041d464a6833f7d5d369b3e28b68af7bb847f499996da8a8856a3af496e00dR23), [link](https://github.com/dxos/dxos/pull/3053/files?diff=unified&w=0#diff-98e0cc4888e1226452168613a8ebe9edf90cf98b5be1269f37920b629eaac9f7R35)). The signaling server is located in the `dev.kube.dxos.org` domain and enables peer-to-peer connections between clients for testing and debugging purposes. The configurations are defined in the `dx.yml` files of each application.


