### PR TITLE
fix: proper path to copy proto files

### DIFF
--- a/.github/workflows/proto-sync.yml
+++ b/.github/workflows/proto-sync.yml
@@ -54,7 +54,7 @@ jobs:
           sudo mv protoc-gen-go-dxrpc /usr/local/bin/protoc-gen-go-dxrpc
 
           # Update protos & gen defs.
-          cp -r ../packages/core/protocols/src/proto proto
+          cp -r ../packages/core/protocols/src/proto/. proto/
           go generate ./...
 
           # Setup Git.


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at af1d06c</samp>

### Summary
🐛📁🔄

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change to the `cp` command.
2.  📁 - This emoji represents a folder or directory, which is the object of the change to the `cp` command. It indicates that the change affects how directories are copied or structured.
3.  🔄 - This emoji represents a refresh or update, which is the effect of the change to the `cp` command. It indicates that the change ensures that the proto definitions are updated correctly.
-->
Fixed a bug in the `proto-sync` workflow that caused incorrect proto file copying. Changed the `cp` command to copy the contents of `src/proto` to `proto` instead of the whole directory.

> _`cp` command changed_
> _No more nested `proto` dir_
> _Winter bug is fixed_

### Walkthrough
* Fix proto sync workflow to copy files correctly ([link](https://github.com/dxos/dxos/pull/3054/files?diff=unified&w=0#diff-e7d437633ea6076b901fed1047441b3ccaa2a227466f31a1b609bc1ed09910e8L57-R57))


