### PR TITLE
fix: iOS caret & theme color

### DIFF
--- a/packages/apps/composer-app/index.html
+++ b/packages/apps/composer-app/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="DXOS Composer Application">
 
     <link rel="icon" href="/favicon.ico">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#005887">
     <script>
       function setTheme(darkMode) {
         document.documentElement.classList[darkMode ? 'add' : 'remove']('dark')

--- a/packages/apps/patterns/react-composer/src/components/Markdown/markdownDark.ts
+++ b/packages/apps/patterns/react-composer/src/components/Markdown/markdownDark.ts
@@ -103,6 +103,12 @@ export const markdownDarktheme = {
   '.dark & .cm-selectionMatch': {
     background: get(tokens, 'extend.colors.primary.400', '#00ffff') + '44'
   },
+  '& .cm-content': {
+    caretColor: 'black'
+  },
+  '.dark & .cm-content': {
+    caretColor: cursor
+  },
   '& .cm-cursor': {
     borderLeftColor: 'black'
   },


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d9dce5c</samp>

### Summary
🎨🌙🖊️

<!--
1.  🎨 - This emoji can be used to represent any change related to colors, themes, or styles. It is also one of the official emojis for the GitHub label "design".
2.  🌙 - This emoji can be used to represent any change related to dark mode, night mode, or low-light settings. It is also a common symbol for toggling between light and dark themes.
3.  🖊️ - This emoji can be used to represent any change related to writing, editing, or formatting text. It is also a suitable emoji for the markdown editor component.
-->
Improved the visual appearance and consistency of the composer app and the markdown editor component. Changed the `theme-color` meta tag in `index.html` and the `caretColor` property in `markdownDark.ts` to match the DXOS brand color and the dark mode setting.

> _`theme-color` changed_
> _browser tab and address bar_
> _match DXOS brand_

### Walkthrough
* Change the browser tab and address bar color to match the DXOS brand color in `index.html` ([link](https://github.com/dxos/dxos/pull/3063/files?diff=unified&w=0#diff-73f2d078949e23df5dfcae7d4613e4fe5999f685bce92867da914446d2819a98L10-R10)).


