### PR TITLE
feat(react-components): Procedural color in Tailwind

### DIFF
--- a/packages/common/react-components/package.json
+++ b/packages/common/react-components/package.json
@@ -58,6 +58,7 @@
     "tailwindcss-radix": "^2.8.0"
   },
   "devDependencies": {
+    "@fluent-blocks/colors": "^9.2.0",
     "@phosphor-icons/react": "^2.0.5",
     "@types/lodash.merge": "^4.6.6",
     "@types/react": "^18.0.21",

--- a/packages/common/react-components/src/config/color-plugin.ts
+++ b/packages/common/react-components/src/config/color-plugin.ts
@@ -1,0 +1,63 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import {
+  curvePathFromPalette,
+  paletteShadesFromCurve,
+  Lab_to_hex as labToHex,
+  hex_to_LCH as hexToLch
+} from '@fluent-blocks/colors';
+import plugin from 'tailwindcss/plugin';
+
+export type PaletteConfig = {
+  keyColor: string;
+  darkCp: number;
+  lightCp: number;
+  hueTorsion: number;
+};
+
+const defaultShadeNumbers: number[] = [...Array(19)].map((_, i) => 50 + i * 50);
+const shadeValues = defaultShadeNumbers.reduce((acc: Record<string, string>, n) => {
+  acc[n] = `${n}`;
+  return acc;
+}, {});
+
+export const colorPlugin = plugin(({ matchUtilities, theme }) => {
+  const palettes = Object.keys(theme('palettes') ?? {});
+  palettes.forEach((palette) => {
+    const paletteConfig = theme(`palettes.${palette}`) as PaletteConfig;
+    const curve = curvePathFromPalette({
+      ...paletteConfig,
+      keyColor: hexToLch(paletteConfig.keyColor)
+    });
+    const defaultShades = paletteShadesFromCurve(curve, 21, [0, 100], 1, 24).reverse();
+    const valueToHex = (value: string) => {
+      const shadeNumber = parseInt(value);
+      if (shadeNumber > 999) {
+        return '#000000';
+      } else if (shadeNumber < 1) {
+        return '#ffffff';
+      } else if (shadeNumber % 50 === 0) {
+        return labToHex(defaultShades[shadeNumber / 50]);
+      } else {
+        const k2 = (shadeNumber % 50) / 50;
+        const k1 = 1 - k2;
+        const [l1, a1, b1] = defaultShades[Math.floor(shadeNumber / 50)];
+        const [l2, a2, b2] = defaultShades[Math.ceil(shadeNumber / 50)];
+        return labToHex([l1 * k1 + l2 * k2, a1 * k1 + a2 * k2, b1 * k1 + b2 * k2]);
+      }
+    };
+    matchUtilities(
+      {
+        // todo(thure): Register utility for all that apply colors
+        // todo(thure): How to handle opacity?
+        // https://github.com/tailwindlabs/tailwindcss/blob/ac1738e74807136a0aa05c3a39197f6ec80b689a/src/util/getAllConfigs.js#L23-L28
+        [`text-${palette}`]: (value) => {
+          return { color: valueToHex(value) };
+        }
+      },
+      { values: shadeValues }
+    );
+  });
+});

--- a/packages/common/react-components/src/config/tailwind.ts
+++ b/packages/common/react-components/src/config/tailwind.ts
@@ -10,6 +10,8 @@ import tailwindColors from 'tailwindcss/colors';
 import defaultConfig from 'tailwindcss/stubs/defaultConfig.stub.js';
 import { Config, ThemeConfig } from 'tailwindcss/types/config';
 
+import { colorPlugin } from './color-plugin';
+
 export type TailwindConfig = Config;
 export type TailwindThemeConfig = ThemeConfig;
 
@@ -443,6 +445,20 @@ export const tailwindConfig = ({
     },
     extend: merge(
       {
+        palettes: {
+          pprimary: {
+            keyColor: '#00e0e0',
+            darkCp: 1,
+            lightCp: 1,
+            hueTorsion: (-73.5 * Math.PI) / 180
+          },
+          pneutral: {
+            keyColor: '#707076',
+            darkCp: 0.8,
+            lightCp: 0.88,
+            hueTorsion: 0
+          }
+        },
         colors: {
           ...configPalettes,
           slate: tailwindColors.slate,
@@ -619,7 +635,7 @@ export const tailwindConfig = ({
       ...extensions
     )
   },
-  plugins: [tailwindcssLogical, tailwindcssForms, tailwindcssRadix()],
+  plugins: [tailwindcssLogical, tailwindcssForms, tailwindcssRadix(), colorPlugin],
   ...(env === 'development' && { mode: 'jit' }),
   content,
   future: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,7 +456,7 @@ importers:
       '@vitejs/plugin-react': 3.0.1_vite@4.2.0
       react-is: 18.2.0
       vite: 4.2.0
-      vite-plugin-pwa: 0.14.1_qiyilc3fs7u6eza5zyshkxwo24
+      vite-plugin-pwa: 0.14.1_vite@4.2.0
       workbox-window: 6.5.4
 
   packages/apps/halo-app:
@@ -1510,6 +1510,7 @@ importers:
       '@dnd-kit/modifiers': ^6.0.0
       '@dnd-kit/sortable': ^7.0.1
       '@dnd-kit/utilities': ^3.2.0
+      '@fluent-blocks/colors': ^9.2.0
       '@fontsource/fira-code': ^4.5.12
       '@fontsource/roboto-flex': ^4.5.2
       '@fontsource/space-grotesk': ^4.5.10
@@ -1596,10 +1597,11 @@ importers:
       rci: 0.0.3_biqbaboplfbrettd7655fr4n2y
       react-i18next: 11.18.6_vfm63zmruocgezzfl2v26zlzpy
       tailwind-merge: 1.10.0
-      tailwindcss: 3.2.7_postcss@8.4.21
+      tailwindcss: 3.2.7
       tailwindcss-logical: 3.0.0_ee22xw2qfzolowrlqapvox2wrq
       tailwindcss-radix: 2.8.0
     devDependencies:
+      '@fluent-blocks/colors': 9.2.0
       '@phosphor-icons/react': 2.0.5_biqbaboplfbrettd7655fr4n2y
       '@types/lodash.merge': 4.6.7
       '@types/react': 18.0.21
@@ -8837,6 +8839,11 @@ packages:
       - '@types/react'
     dev: false
 
+  /@fluent-blocks/colors/9.2.0:
+    resolution: {integrity: sha512-NgK+n4IHRj35ttJjN3UBF8oqk2ZT8xwCdT52+nTXvVSL5yHDtKwQlgb+zvrNFhYNajbqEeqYdj4QA3XSkytLww==}
+    engines: {node: '>=12.0.0 <17.0.0', pnpm: ^7}
+    dev: true
+
   /@fontsource/fira-code/4.5.12:
     resolution: {integrity: sha512-dAVGsgiVR6jslpuXosHH4/Jf8bsAIKL1RWqjVq4WpmxL7CFHfg9hT5bAv/Y3xsEj8kDTibEgpuC3eMfr9kb02g==}
     dev: false
@@ -14043,7 +14050,7 @@ packages:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.2.7_postcss@8.4.21
+      tailwindcss: 3.2.7
     dev: false
 
   /@tailwindcss/typography/0.5.8_tailwindcss@3.2.7:
@@ -35405,6 +35412,38 @@ packages:
     transitivePeerDependencies:
       - ts-node
 
+  /tailwindcss/3.2.7:
+    resolution: {integrity: sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+    dependencies:
+      arg: 5.0.2
+      chokidar: 3.5.3
+      color-name: 1.1.4
+      detective: 5.2.1
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.12
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      lilconfig: 2.1.0
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.21
+      postcss-import: 14.1.0_postcss@8.4.21
+      postcss-js: 4.0.1_postcss@8.4.21
+      postcss-load-config: 3.1.4_postcss@8.4.21
+      postcss-nested: 6.0.0_postcss@8.4.21
+      postcss-selector-parser: 6.0.11
+      postcss-value-parser: 4.2.0
+      quick-lru: 5.1.1
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - ts-node
+    dev: false
+
   /tailwindcss/3.2.7_postcss@8.4.21:
     resolution: {integrity: sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==}
     engines: {node: '>=12.13.0'}
@@ -37089,6 +37128,24 @@ packages:
     peerDependencies:
       vite: ^3.1.0 || ^4.0.0
       workbox-window: ^6.5.4
+    dependencies:
+      '@rollup/plugin-replace': 5.0.2_rollup@3.9.1
+      debug: 4.3.4
+      fast-glob: 3.2.12
+      pretty-bytes: 6.0.0
+      rollup: 3.9.1
+      vite: 4.2.0
+      workbox-build: 6.5.4
+      workbox-window: 6.5.4
+    transitivePeerDependencies:
+      - '@types/babel__core'
+      - supports-color
+    dev: true
+
+  /vite-plugin-pwa/0.14.1_vite@4.2.0:
+    resolution: {integrity: sha512-5zx7yhQ8RTLwV71+GA9YsQQ63ALKG8XXIMqRJDdZkR8ZYftFcRgnzM7wOWmQZ/DATspyhPih5wCdcZnAIsM+mA==}
+    peerDependencies:
+      vite: ^3.1.0 || ^4.0.0
     dependencies:
       '@rollup/plugin-replace': 5.0.2_rollup@3.9.1
       debug: 4.3.4


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4426afd</samp>

### Summary
🎨🔌🌈

<!--
1.  🎨 - This emoji represents the addition of a color-related dependency and plugin, as well as the use of color palettes in the component styles.
2.  🔌 - This emoji represents the creation of a custom plugin for Tailwind CSS, which extends the functionality of the framework and adds new utilities.
3.  🌈 - This emoji represents the generation of color curves and shades based on perceptual color models, which can create more harmonious and accessible color schemes.
-->
This pull request adds a custom Tailwind CSS plugin to the `react-components` package, which enables the use of perceptual color palettes in the component styles. The plugin depends on the `@fluent-blocks/colors` package and creates color utilities for two predefined palettes, `pprimary` and `pneutral`. The plugin is configured in the `tailwind.ts` file and exported from the `color-plugin.ts` file.

> _`react-components`_
> _New color plugin for styles_
> _`@fluent-blocks/colors`_

### Walkthrough
*  Add `@fluent-blocks/colors` dependency to `react-components` package ([link](https://github.com/dxos/dxos/pull/3074/files?diff=unified&w=0#diff-d72eda2c358ed5d258d9ed50c05539d113c364f1b7bd53da8270938cfc1f064bR61))
*  Create `color-plugin.ts` file to export a custom Tailwind plugin that uses `@fluent-blocks/colors` to generate color utilities ([link](https://github.com/dxos/dxos/pull/3074/files?diff=unified&w=0#diff-035d62c517d67e3859a5809dfd3748fa7c44dd576f852a21b1381233429825d1R1-R63))
*  Import `colorPlugin` from `color-plugin.ts` in `tailwind.ts` file ([link](https://github.com/dxos/dxos/pull/3074/files?diff=unified&w=0#diff-499dc7e4947410df12259a3c36a2bda4f7bfd3c132d3b133dd905c360cafba96R13-R14))
*  Define two palettes, `pprimary` and `pneutral`, in Tailwind config using `PaletteConfig` type ([link](https://github.com/dxos/dxos/pull/3074/files?diff=unified&w=0#diff-499dc7e4947410df12259a3c36a2bda4f7bfd3c132d3b133dd905c360cafba96R448-R461))
*  Add `colorPlugin` to the list of plugins in Tailwind config to enable color utilities ([link](https://github.com/dxos/dxos/pull/3074/files?diff=unified&w=0#diff-499dc7e4947410df12259a3c36a2bda4f7bfd3c132d3b133dd905c360cafba96L622-R638))


