### PR TITLE
docs: add note about firefox

### DIFF
--- a/docs/docs/guide/platform/README.md
+++ b/docs/docs/guide/platform/README.md
@@ -83,6 +83,10 @@ This means that when apps request the user's identity (ask to log in), they are 
 For Node.js applications, the vault is implemented by an in-process storage engine that persists to files on disk, and is not isolated from the consuming application the way it is in browser.
 :::
 
+::: warning
+The vault relies on worker ES modules and as such is [not yet functional in Firefox](https://developer.mozilla.org/en-US/docs/Web/API/Worker). The feature is currently under development however, currently behind the `about:config` preference `dom.workers.modules.enabled`. The hope and expectation is that this should be enabled by default in the not-too-distant future.
+:::
+
 ## Next steps
 
 *   If using `react` see the [React guide](../react/)


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c514df5</samp>

### Summary
🚧📝⚠️

<!--
1.  🚧 - This emoji means construction or work in progress, and it can be used to indicate that the vault is not fully compatible with all browsers yet and that some features are still under development.
2.  📝 - This emoji means document or memo, and it can be used to indicate that the change involves updating the documentation of the vault to reflect its current status and limitations.
3.  ⚠️ - This emoji means warning or caution, and it can be used to indicate that the change involves adding a warning box to alert the readers of the potential issues they might encounter if they use the vault in Firefox.
-->
Added a warning to the platform documentation about the local vault not working in Firefox yet. Provided a workaround and a reference for the missing feature.

> _`local vault` warns_
> _Firefox not ready yet - wait_
> _Winter is coming_

### Walkthrough
* Add a warning box to the local vault documentation ([link](https://github.com/dxos/dxos/pull/3086/files?diff=unified&w=0#diff-5a67c7118ea9f0344f8fe729ff43ad7861047617ff29b1d4a9cdee607dcd27d4R86-R89)) to inform users that Firefox does not support worker ES modules yet and how to enable them in the browser settings.


