### PR TITLE
feat(protocols): manage vault service worker

### DIFF
--- a/packages/core/protocols/src/proto/dxos/client/services.proto
+++ b/packages/core/protocols/src/proto/dxos/client/services.proto
@@ -381,6 +381,31 @@ service NetworkService {
 }
 
 //
+// Service Worker
+//
+
+enum ApplicationStatus {
+  // Before application has been cached by the service worker.
+  NOT_REGISTERED = 0;
+  // When application has been cached by the service worker and there are no known updates.
+  UP_TO_DATE = 1;
+  // When application has been cached by the service worker and there are known updates.
+  UPDATE_AVAILABLE = 2;
+}
+
+message QueryStatusResponse {
+  ApplicationStatus status = 1;
+  optional dxos.rpc.Error error = 2;
+}
+
+service ApplicationService {
+  // Update service worker and reload page.
+  rpc Update(google.protobuf.Empty) returns (google.protobuf.Empty);
+  // Query for when update is available.
+  rpc QueryStatus(google.protobuf.Empty) returns (stream QueryStatusResponse);
+}
+
+//
 // Development Tooling
 //
 


### PR DESCRIPTION
Some interesting results from service worker experiments:
- confirmed that the plugin provides a way to registerSW when not using a framework https://vite-plugin-pwa.netlify.app/frameworks/
- tracked down what immediate does https://developer.chrome.com/docs/workbox/reference/workbox-window/ "By default this method delays registration until after the window has loaded." Though this doesn't seem to make a big difference in baseline service worker behaviour that I've seen so far
- confirmed when the following callbacks are called:
  - onRegisteredSW: on each page now when the service worker is registered
  - onOfflineReady: when the the service worker is installed for the first time
  - onNeedRefresh: on each page load when there is a new version of the service worker available
- now for the interesting part, Chromium & Firefox when running service worker in a cross-domain iframe, updates are automatically installed on the next reload
- webkit does not seem to have this behaviour, it still needs to be updated by calling the function provided by the plugin
- I've not yet been able to confirm if this is related to the plugin or the browsers, but since it seems to vary between browsers I'm assuming that it's something the browser is doing

Proposal here is that this service would allow an application to listen for updates to the vault service worker similar to how it listens for updates to it's own.
Update could then be called to immediately load in the new vault (though in many browsers reloading alone seems to accomplish this, it's not universal so this method seems likely to still be required).
After calling update, the parent page would either need to be reloaded as well or the client would need to be re-initialized alongside the vault page reloading.

