### PR TITLE
fix(react-appkit): `CompoundButton` `tx` call.

### DIFF
--- a/packages/ui/react-appkit/src/components/CompoundButton/CompoundButton.tsx
+++ b/packages/ui/react-appkit/src/components/CompoundButton/CompoundButton.tsx
@@ -38,7 +38,7 @@ export const CompoundButton = ({
   const isOs = tx('themeName', 'aurora', {}) === 'dxos';
   const styleProps = { ...buttonProps, variant };
   const buttonClassName = tx(
-    'button.button',
+    'button.root',
     'button button--compound',
     styleProps,
     'flex items-center gap-4 plb-2.5',


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b9bf7d6</samp>

### Summary
🎨♻️🚚

<!--
1.  🎨 - This emoji can be used to indicate a change related to the style, appearance, or design of a UI component. In this case, the class name change affects how the button is styled and rendered.
2.  ♻️ - This emoji can be used to indicate a change related to refactoring, improving, or simplifying existing code. In this case, the class name change is part of a larger refactor to make the UI component library more consistent and readable.
3.  🚚 - This emoji can be used to indicate a change related to moving, renaming, or deleting files or code. In this case, the class name change involves renaming a class selector that is used in multiple files.
-->
Refactored the button component class names to follow a `root` convention. Updated the `CompoundButton` component to use the new class names.

> _`button.button` gone_
> _refactor for clarity_
> _autumn leaves fall fast_

### Walkthrough
*  Rename `button.button` class to `button.root` for consistency ([link](https://github.com/dxos/dxos/pull/3118/files?diff=unified&w=0#diff-f320a52bca98fff9db8c898d32621015ee43736e1627e0f19a6bf0525b9696ecL41-R41))


