### PR TITLE
refactor(client-services): signal manager status

### DIFF
--- a/packages/core/mesh/messaging/src/signal-manager/memory-signal-manager.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/memory-signal-manager.ts
@@ -4,7 +4,7 @@
 
 import assert from 'node:assert';
 
-import { Event } from '@dxos/async';
+import { Event, MulticastObservable } from '@dxos/async';
 import { Any } from '@dxos/codec-protobuf';
 import { Context } from '@dxos/context';
 import { PublicKey } from '@dxos/keys';
@@ -36,7 +36,7 @@ export class MemorySignalManagerContext {
  * In memory signal manager for testing.
  */
 export class MemorySignalManager implements SignalManager {
-  readonly statusChanged = new Event<SignalStatus[]>();
+  readonly status = MulticastObservable.of([]);
   readonly commandTrace = new Event<CommandTrace>();
   readonly swarmEvent = new Event<{
     topic: PublicKey;

--- a/packages/core/mesh/messaging/src/signal-manager/memory-signal-manager.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/memory-signal-manager.ts
@@ -4,7 +4,7 @@
 
 import assert from 'node:assert';
 
-import { Event, MulticastObservable } from '@dxos/async';
+import { Event } from '@dxos/async';
 import { Any } from '@dxos/codec-protobuf';
 import { Context } from '@dxos/context';
 import { PublicKey } from '@dxos/keys';
@@ -36,7 +36,7 @@ export class MemorySignalManagerContext {
  * In memory signal manager for testing.
  */
 export class MemorySignalManager implements SignalManager {
-  readonly status = MulticastObservable.of([]);
+  readonly statusChanged = new Event<SignalStatus[]>();
   readonly commandTrace = new Event<CommandTrace>();
   readonly swarmEvent = new Event<{
     topic: PublicKey;

--- a/packages/core/mesh/messaging/src/signal-manager/signal-manager.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/signal-manager.ts
@@ -2,7 +2,7 @@
 // Copyright 2020 DXOS.org
 //
 
-import { Event, MulticastObservable } from '@dxos/async';
+import { Event } from '@dxos/async';
 import { PublicKey } from '@dxos/keys';
 import { SwarmEvent } from '@dxos/protocols/proto/dxos/mesh/signal';
 
@@ -13,7 +13,7 @@ import { Message, SignalMethods } from '../signal-methods';
  *
  */
 export interface SignalManager extends SignalMethods {
-  status: MulticastObservable<SignalStatus[]>;
+  statusChanged: Event<SignalStatus[]>;
   commandTrace: Event<CommandTrace>;
   swarmEvent: Event<{ topic: PublicKey; swarmEvent: SwarmEvent }>;
   onMessage: Event<Message>;

--- a/packages/core/mesh/messaging/src/signal-manager/signal-manager.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/signal-manager.ts
@@ -2,7 +2,7 @@
 // Copyright 2020 DXOS.org
 //
 
-import { Event } from '@dxos/async';
+import { Event, MulticastObservable } from '@dxos/async';
 import { PublicKey } from '@dxos/keys';
 import { SwarmEvent } from '@dxos/protocols/proto/dxos/mesh/signal';
 
@@ -13,7 +13,7 @@ import { Message, SignalMethods } from '../signal-methods';
  *
  */
 export interface SignalManager extends SignalMethods {
-  statusChanged: Event<SignalStatus[]>;
+  status: MulticastObservable<SignalStatus[]>;
   commandTrace: Event<CommandTrace>;
   swarmEvent: Event<{ topic: PublicKey; swarmEvent: SwarmEvent }>;
   onMessage: Event<Message>;

--- a/packages/core/mesh/network-manager/src/testing/test-builder.ts
+++ b/packages/core/mesh/network-manager/src/testing/test-builder.ts
@@ -3,7 +3,12 @@
 //
 
 import { PublicKey } from '@dxos/keys';
-import { MemorySignalManager, MemorySignalManagerContext, WebsocketSignalManager } from '@dxos/messaging';
+import {
+  MemorySignalManager,
+  MemorySignalManagerContext,
+  SignalManager,
+  WebsocketSignalManager
+} from '@dxos/messaging';
 import { schema } from '@dxos/protocols';
 import { ConnectionState } from '@dxos/protocols/proto/dxos/client/services';
 import { Runtime } from '@dxos/protocols/proto/dxos/config';
@@ -61,12 +66,18 @@ export class TestPeer {
   /**
    * @internal
    */
+  readonly _signalManager: SignalManager;
+
+  /**
+   * @internal
+   */
   readonly _networkManager: NetworkManager;
 
   private _proxy?: ProtoRpcPeer<any>;
   private _service?: ProtoRpcPeer<any>;
 
   constructor(private readonly testBuilder: TestBuilder) {
+    this._signalManager = this.testBuilder.createSignalManager();
     this._networkManager = this.createNetworkManager();
   }
 
@@ -111,7 +122,7 @@ export class TestPeer {
     }
 
     return new NetworkManager({
-      signalManager: this.testBuilder.createSignalManager(),
+      signalManager: this._signalManager,
       transportFactory
     });
   }

--- a/packages/core/mesh/network-manager/src/tests/basic-test-suite.ts
+++ b/packages/core/mesh/network-manager/src/tests/basic-test-suite.ts
@@ -150,7 +150,7 @@ export const basicTestSuite = (testBuilder: TestBuilder, runTests = true) => {
       .getSwarm(topic)
       ?.disconnected.waitFor((peerId) => peerId.equals(peer1.peerId));
 
-    const peerLeft = peer2._networkManager.signalManager.swarmEvent.waitFor(
+    const peerLeft = peer2._signalManager.swarmEvent.waitFor(
       (event) => !!event.swarmEvent.peerLeft && peer1.peerId.equals(event.swarmEvent.peerLeft?.peer)
     );
 

--- a/packages/core/protocols/src/proto/dxos/client/services.proto
+++ b/packages/core/protocols/src/proto/dxos/client/services.proto
@@ -360,24 +360,30 @@ service InvitationsService {
 // MESH
 //
 
+// TODO(wittjosiah): Rename to SwarnState?
 enum ConnectionState {
   OFFLINE = 0;
   ONLINE = 1;
 }
 
 message NetworkStatus {
-  ConnectionState state = 1;
+  message Signal {
+    string server = 1;
+    dxos.mesh.signal.SignalState state = 2;
+  }
+
+  ConnectionState swarm = 1;
+  repeated Signal signaling = 2;
 }
 
-message SetNetworkOptionsRequest {
-  ConnectionState state = 1;
+message UpdateConfigRequest {
+  ConnectionState swarm = 1;
 }
 
 // TODO(burdon): Widen API (too heavy for single feature: e.g., status).
 service NetworkService {
-  // TODO(wittjosiah): Align verbs with other services.
-  rpc SubscribeToNetworkStatus(google.protobuf.Empty) returns (stream NetworkStatus);
-  rpc SetNetworkOptions(SetNetworkOptionsRequest) returns (google.protobuf.Empty);
+  rpc UpdateConfig(UpdateConfigRequest) returns (google.protobuf.Empty);
+  rpc QueryStatus(google.protobuf.Empty) returns (stream NetworkStatus);
 }
 
 //

--- a/packages/core/protocols/src/proto/dxos/devtools/host.proto
+++ b/packages/core/protocols/src/proto/dxos/devtools/host.proto
@@ -259,8 +259,7 @@ message SubscribeToSignalStatusResponse {
   message SignalServer {
     string host = 1;
 
-    // SignalApi.State enum.
-    string state = 2;
+    dxos.mesh.signal.SignalState state = 2;
 
     optional string error = 3;
 

--- a/packages/core/protocols/src/proto/dxos/mesh/signal.proto
+++ b/packages/core/protocols/src/proto/dxos/mesh/signal.proto
@@ -74,6 +74,21 @@ message PeerEvent {
   }
 }
 
+enum SignalState {
+  /// Connection is being established.
+  CONNECTING = 0;
+  /// Connection is being re-established.
+  RECONNECTING = 1;
+  /// Connected.
+  CONNECTED = 2;
+  /// Server terminated the connection. Socket will be reconnected.
+  DISCONNECTED = 3;
+  /// Server terminated the connection with an ERROR. Socket will be reconnected.
+  ERROR = 4;
+  /// Socket was closed.
+  CLOSED = 5;
+}
+
 // TOOD(burdon): Rename.
 // TODO(burdon): Reconcile with `@dxos/kube`.
 service Signal {

--- a/packages/devtools/devtools/src/panels/mesh/SignalStatus.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SignalStatus.tsx
@@ -6,14 +6,15 @@ import React, { useEffect, useState } from 'react';
 
 import { scheduleTaskInterval } from '@dxos/async';
 import { Context } from '@dxos/context';
-import { SignalState, SignalStatus } from '@dxos/messaging';
+import { SignalStatus } from '@dxos/messaging';
 import { SubscribeToSignalStatusResponse } from '@dxos/protocols/proto/dxos/devtools/host';
+import { SignalState } from '@dxos/protocols/proto/dxos/mesh/signal';
 import { useDevtools, useStream } from '@dxos/react-client';
 
 const getColor = (state: SignalState) => {
   switch (state) {
     case SignalState.CONNECTING:
-    case SignalState.RE_CONNECTING:
+    case SignalState.RECONNECTING:
       return 'orange';
     case SignalState.CONNECTED:
       return 'green';
@@ -28,24 +29,13 @@ export interface SignalStatusProps {
   status: SignalStatus[];
 }
 
-const stringToState = (state: string): SignalState => {
-  const dict: Record<string, SignalState> = {
-    CONNECTING: SignalState.CONNECTING,
-    RE_CONNECTING: SignalState.RE_CONNECTING,
-    CONNECTED: SignalState.CONNECTED,
-    DISCONNECTED: SignalState.DISCONNECTED,
-    CLOSED: SignalState.CLOSED
-  };
-  return dict[state];
-};
-
 const getSignalStatus = (server: SubscribeToSignalStatusResponse.SignalServer): SignalStatus => {
   return {
     connectionStarted: server.connectionStarted!,
     lastStateChange: server.lastStateChange!,
     reconnectIn: server.reconnectIn!,
     host: server.host!,
-    state: stringToState(server.state!)
+    state: server.state!
   };
 };
 

--- a/packages/experimental/kai-framework/src/containers/Sidebar/Sidebar.tsx
+++ b/packages/experimental/kai-framework/src/containers/Sidebar/Sidebar.tsx
@@ -69,7 +69,7 @@ export const Sidebar = observer(({ onNavigate }: SidebarProps) => {
 
   const toggleSidebar = useTogglePanelSidebar();
   const { displayState } = useContext(PanelSidebarContext);
-  const { state: connectionState } = useNetworkStatus();
+  const { swarm: connectionState } = useNetworkStatus();
   const [showSpacePanel, setShowSpacePanel] = useState(false);
 
   const [showSearchResults, setShowSearchResults] = useState(false);
@@ -131,12 +131,12 @@ export const Sidebar = observer(({ onNavigate }: SidebarProps) => {
   const handleToggleConnection = async () => {
     switch (connectionState) {
       case ConnectionState.OFFLINE: {
-        await client.mesh.setConnectionState(ConnectionState.ONLINE);
+        await client.mesh.updateConfig(ConnectionState.ONLINE);
         break;
       }
 
       case ConnectionState.ONLINE: {
-        await client.mesh.setConnectionState(ConnectionState.OFFLINE);
+        await client.mesh.updateConfig(ConnectionState.OFFLINE);
         break;
       }
     }

--- a/packages/sdk/client-services/src/packlets/devtools/devtools.ts
+++ b/packages/sdk/client-services/src/packlets/devtools/devtools.ts
@@ -130,11 +130,11 @@ export class DevtoolsServiceImpl implements DevtoolsHost {
   }
 
   subscribeToSignalStatus(request: void): Stream<SubscribeToSignalStatusResponse> {
-    return subscribeToNetworkStatus({ networkManager: this.params.context.networkManager });
+    return subscribeToNetworkStatus({ signalManager: this.params.context.signalManager });
   }
 
   subscribeToSignal(): Stream<SignalResponse> {
-    return subscribeToSignal({ networkManager: this.params.context.networkManager });
+    return subscribeToSignal({ signalManager: this.params.context.signalManager });
   }
 
   subscribeToSwarmInfo(): Stream<SubscribeToSwarmInfoResponse> {

--- a/packages/sdk/client-services/src/packlets/devtools/network.ts
+++ b/packages/sdk/client-services/src/packlets/devtools/network.ts
@@ -27,7 +27,7 @@ export const subscribeToNetworkStatus = ({ signalManager }: { signalManager: Sig
       }
     };
 
-    signalManager.status.subscribe(() => update());
+    signalManager.statusChanged.on(() => update());
     update();
   });
 

--- a/packages/sdk/client-services/src/packlets/network/network-service.test.ts
+++ b/packages/sdk/client-services/src/packlets/network/network-service.test.ts
@@ -19,7 +19,7 @@ describe('NetworkService', () => {
   beforeEach(async () => {
     serviceContext = createServiceContext();
     await serviceContext.open();
-    networkService = new NetworkServiceImpl(serviceContext.networkManager);
+    networkService = new NetworkServiceImpl(serviceContext.networkManager, serviceContext.signalManager);
   });
 
   afterEach(async () => {
@@ -27,25 +27,25 @@ describe('NetworkService', () => {
   });
 
   test('setNetworkOptions changes network status', async () => {
-    await networkService.setNetworkOptions({
-      state: ConnectionState.OFFLINE
+    await networkService.updateConfig({
+      swarm: ConnectionState.OFFLINE
     });
 
     expect(serviceContext.networkManager.connectionState).to.equal(ConnectionState.OFFLINE);
   });
 
   test('subscribeToNetworkStatus returns current network status', async () => {
-    const query = networkService.subscribeToNetworkStatus();
+    const query = networkService.queryStatus();
     let result = new Trigger<ConnectionState | undefined>();
-    query.subscribe(({ state }) => {
-      result.wake(state);
+    query.subscribe(({ swarm }) => {
+      result.wake(swarm);
     });
     afterTest(() => query.close());
     expect(await result.wait()).to.equal(ConnectionState.ONLINE);
 
     result = new Trigger<ConnectionState | undefined>();
-    await networkService.setNetworkOptions({
-      state: ConnectionState.OFFLINE
+    await networkService.updateConfig({
+      swarm: ConnectionState.OFFLINE
     });
     expect(await result.wait()).to.equal(ConnectionState.OFFLINE);
   });

--- a/packages/sdk/client-services/src/packlets/network/network-service.ts
+++ b/packages/sdk/client-services/src/packlets/network/network-service.ts
@@ -21,6 +21,7 @@ export class NetworkServiceImpl implements NetworkService {
 
       const unsubscribeSwarm = this.networkManager.connectionStateChanged.on(() => update());
       const unsubscribeSignal = this.signalManager.statusChanged.on(() => update());
+      update();
 
       return () => {
         unsubscribeSwarm();

--- a/packages/sdk/client-services/src/packlets/network/network-service.ts
+++ b/packages/sdk/client-services/src/packlets/network/network-service.ts
@@ -14,17 +14,17 @@ export class NetworkServiceImpl implements NetworkService {
     return new Stream<NetworkStatus>(({ next }) => {
       const update = () => {
         next({
-          swarm: this.networkManager.connectionState.get(),
-          signaling: this.signalManager.status.get().map(({ host, state }) => ({ server: host, state }))
+          swarm: this.networkManager.connectionState,
+          signaling: this.signalManager.getStatus().map(({ host, state }) => ({ server: host, state }))
         });
       };
 
-      const swarmSubscription = this.networkManager.connectionState.subscribe(() => update());
-      const signalSubscription = this.signalManager.status.subscribe(() => update());
+      const unsubscribeSwarm = this.networkManager.connectionStateChanged.on(() => update());
+      const unsubscribeSignal = this.signalManager.statusChanged.on(() => update());
 
       return () => {
-        swarmSubscription.unsubscribe();
-        signalSubscription.unsubscribe();
+        unsubscribeSwarm();
+        unsubscribeSignal();
       };
     });
   }

--- a/packages/sdk/client-services/src/packlets/services/service-context.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-context.ts
@@ -20,6 +20,7 @@ import { FeedFactory, FeedStore } from '@dxos/feed-store';
 import { Keyring } from '@dxos/keyring';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
+import { SignalManager } from '@dxos/messaging';
 import { ModelFactory } from '@dxos/model-factory';
 import { NetworkManager } from '@dxos/network-manager';
 import { trace } from '@dxos/protocols';
@@ -67,6 +68,7 @@ export class ServiceContext {
   constructor(
     public readonly storage: Storage,
     public readonly networkManager: NetworkManager,
+    public readonly signalManager: SignalManager,
     public readonly modelFactory: ModelFactory
   ) {
     // TODO(burdon): Move strings to constants.
@@ -115,6 +117,7 @@ export class ServiceContext {
     log.trace('dxos.sdk.service-context.open', trace.begin({ id: this._instanceId }));
 
     log('opening...');
+    await this.signalManager.open();
     await this.networkManager.open();
     await this.spaceManager.open();
     await this.identityManager.open();
@@ -133,6 +136,7 @@ export class ServiceContext {
     await this.spaceManager.close();
     await this.feedStore.close();
     await this.networkManager.close();
+    await this.signalManager.close();
     this.dataServiceSubscriptions.clear();
     log('closed');
   }

--- a/packages/sdk/client-services/src/packlets/services/utils.ts
+++ b/packages/sdk/client-services/src/packlets/services/utils.ts
@@ -6,12 +6,7 @@ import { ClientServicesProvider } from '@dxos/client';
 import { Config } from '@dxos/config';
 import { log } from '@dxos/log';
 import { MemorySignalManager, MemorySignalManagerContext, WebsocketSignalManager } from '@dxos/messaging';
-import {
-  createWebRTCTransportFactory,
-  MemoryTransportFactory,
-  NetworkManager,
-  NetworkManagerOptions
-} from '@dxos/network-manager';
+import { createWebRTCTransportFactory, MemoryTransportFactory, NetworkManagerOptions } from '@dxos/network-manager';
 
 import { LocalClientServices } from './local-client-services';
 
@@ -21,33 +16,37 @@ import { LocalClientServices } from './local-client-services';
 export const fromHost = (config: Config = new Config()): ClientServicesProvider => {
   return new LocalClientServices({
     config,
-    networkManager: createNetworkManager(config)
+    ...setupNetworking(config)
   });
 };
 
 /**
- * Creates a WebRTC network manager connected to the specified signal server.
+ * Creates signal manager and transport factory based on config.
+ * These are used to create a WebRTC network manager connected to the specified signal server.
  */
-// TODO(burdon): Move to client-services and remove dependencies from here.
-const createNetworkManager = (config: Config, options: Partial<NetworkManagerOptions> = {}): NetworkManager => {
+const setupNetworking = (config: Config, options: Partial<NetworkManagerOptions> = {}) => {
   const signals = config.get('runtime.services.signaling');
   if (signals) {
     const {
-      log = true,
       signalManager = new WebsocketSignalManager(signals),
       transportFactory = createWebRTCTransportFactory({
         iceServers: config.get('runtime.services.ice')
       })
     } = options;
 
-    return new NetworkManager({ log, signalManager, transportFactory });
+    return {
+      signalManager,
+      transportFactory
+    };
   }
 
   // TODO(burdon): Should not provide a memory signal manager since no shared context.
   //  Use TestClientBuilder for shared memory tests.
   log.warn('P2P network is not configured.');
-  return new NetworkManager({
-    signalManager: new MemorySignalManager(new MemorySignalManagerContext()),
-    transportFactory: MemoryTransportFactory
-  });
+  const signalManager = new MemorySignalManager(new MemorySignalManagerContext());
+  const transportFactory = MemoryTransportFactory;
+  return {
+    signalManager,
+    transportFactory
+  };
 };

--- a/packages/sdk/client-services/src/packlets/testing/host-test-builder.ts
+++ b/packages/sdk/client-services/src/packlets/testing/host-test-builder.ts
@@ -27,14 +27,10 @@ import { ClientServicesHost, ServiceContext } from '../services';
 //
 
 export const createServiceHost = (config: Config, signalManagerContext: MemorySignalManagerContext) => {
-  const networkManager = new NetworkManager({
-    signalManager: new MemorySignalManager(signalManagerContext),
-    transportFactory: MemoryTransportFactory
-  });
-
   return new ClientServicesHost({
     config,
-    networkManager
+    signalManager: new MemorySignalManager(signalManagerContext),
+    transportFactory: MemoryTransportFactory
   });
 };
 
@@ -45,13 +41,14 @@ export const createServiceContext = ({
   signalContext?: MemorySignalManagerContext;
   storage?: Storage;
 } = {}) => {
+  const signalManager = new MemorySignalManager(signalContext);
   const networkManager = new NetworkManager({
-    signalManager: new MemorySignalManager(signalContext),
+    signalManager,
     transportFactory: MemoryTransportFactory
   });
 
   const modelFactory = createDefaultModelFactory();
-  return new ServiceContext(storage, networkManager, modelFactory);
+  return new ServiceContext(storage, networkManager, signalManager, modelFactory);
 };
 
 export const createPeers = async (numPeers: number) => {

--- a/packages/sdk/client-services/src/packlets/testing/test-builder.ts
+++ b/packages/sdk/client-services/src/packlets/testing/test-builder.ts
@@ -13,7 +13,7 @@ import { DatabaseProxy, genesisMutation } from '@dxos/echo-db';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { MemorySignalManager, MemorySignalManagerContext, WebsocketSignalManager } from '@dxos/messaging';
-import { createWebRTCTransportFactory, MemoryTransportFactory, NetworkManager } from '@dxos/network-manager';
+import { createWebRTCTransportFactory, MemoryTransportFactory } from '@dxos/network-manager';
 import { Storage } from '@dxos/random-access-storage';
 import { createLinkedPorts, createProtoRpcPeer, ProtoRpcPeer } from '@dxos/rpc';
 
@@ -57,24 +57,22 @@ export class TestBuilder {
   /**
    * Get network manager using local shared memory or remote signal manager.
    */
-  get networkManager() {
+  private get networking() {
     const signals = this._config.get('runtime.services.signaling');
     if (signals) {
-      return new NetworkManager({
-        log: true,
+      return {
         signalManager: new WebsocketSignalManager(signals),
         transportFactory: createWebRTCTransportFactory({
           iceServers: this._config.get('runtime.services.ice')
         })
-      });
+      };
     }
 
     // Memory transport with shared context.
-    return new NetworkManager({
-      log: true,
+    return {
       signalManager: new MemorySignalManager(this._signalManagerContext),
       transportFactory: MemoryTransportFactory
-    });
+    };
   }
 
   /**
@@ -84,8 +82,8 @@ export class TestBuilder {
     return new ClientServicesHost({
       config: this._config,
       modelFactory: this._modelFactory,
-      networkManager: this.networkManager,
-      storage: this.storage
+      storage: this.storage,
+      ...this.networking
     });
   }
 
@@ -96,8 +94,8 @@ export class TestBuilder {
     return new LocalClientServices({
       config: this._config,
       modelFactory: this._modelFactory,
-      networkManager: this.networkManager,
-      storage: this.storage
+      storage: this.storage,
+      ...this.networking
     });
   }
 

--- a/packages/sdk/client-services/src/packlets/vault/iframe-host-runtime.ts
+++ b/packages/sdk/client-services/src/packlets/vault/iframe-host-runtime.ts
@@ -6,7 +6,7 @@ import { Trigger } from '@dxos/async';
 import { Config } from '@dxos/config';
 import { log, logInfo } from '@dxos/log';
 import { MemorySignalManager, MemorySignalManagerContext, WebsocketSignalManager } from '@dxos/messaging';
-import { createWebRTCTransportFactory, NetworkManager, TransportFactory } from '@dxos/network-manager';
+import { createWebRTCTransportFactory, TransportFactory } from '@dxos/network-manager';
 import { RpcPort } from '@dxos/rpc';
 import { getAsyncValue, MaybePromise, Provider } from '@dxos/util';
 
@@ -76,13 +76,10 @@ export class IFrameHostRuntime {
       this._clientServices = new LocalClientServices({
         lockKey: LOCK_KEY,
         config: this._config,
-        networkManager: new NetworkManager({
-          log: true,
-          signalManager: signals
-            ? new WebsocketSignalManager(signals)
-            : new MemorySignalManager(new MemorySignalManagerContext()), // TODO(dmaretskyi): Inject this context.
-          transportFactory: this._transportFactory
-        })
+        signalManager: signals
+          ? new WebsocketSignalManager(signals)
+          : new MemorySignalManager(new MemorySignalManagerContext()), // TODO(dmaretskyi): Inject this context.
+        transportFactory: this._transportFactory
       });
 
       const middleware: Pick<ClientRpcServerParams, 'handleCall' | 'handleStream'> = {

--- a/packages/sdk/client-services/src/packlets/vault/worker-runtime.ts
+++ b/packages/sdk/client-services/src/packlets/vault/worker-runtime.ts
@@ -6,7 +6,7 @@ import { Trigger } from '@dxos/async';
 import { Config } from '@dxos/config';
 import { log } from '@dxos/log';
 import { MemorySignalManager, MemorySignalManagerContext, WebsocketSignalManager } from '@dxos/messaging';
-import { NetworkManager, WebRTCTransportProxyFactory } from '@dxos/network-manager';
+import { WebRTCTransportProxyFactory } from '@dxos/network-manager';
 import { RpcPort } from '@dxos/rpc';
 import { MaybePromise } from '@dxos/util';
 
@@ -51,13 +51,10 @@ export class WorkerRuntime {
       const signals = this._config.get('runtime.services.signaling');
       this._clientServices.initialize({
         config: this._config,
-        networkManager: new NetworkManager({
-          log: true,
-          signalManager: signals
-            ? new WebsocketSignalManager(signals)
-            : new MemorySignalManager(new MemorySignalManagerContext()), // TODO(dmaretskyi): Inject this context.
-          transportFactory: this._transportFactory
-        })
+        signalManager: signals
+          ? new WebsocketSignalManager(signals)
+          : new MemorySignalManager(new MemorySignalManagerContext()), // TODO(dmaretskyi): Inject this context.
+        transportFactory: this._transportFactory
       });
 
       await this._clientServices.open();

--- a/packages/sdk/client/src/packlets/proxies/mesh-proxy.ts
+++ b/packages/sdk/client/src/packlets/proxies/mesh-proxy.ts
@@ -19,7 +19,8 @@ import { ClientServicesProvider } from '../client';
 export class MeshProxy {
   private readonly _networkStatusUpdated = new Event<NetworkStatus>();
   private readonly _networkStatus = MulticastObservable.from(this._networkStatusUpdated, {
-    state: ConnectionState.OFFLINE
+    swarm: ConnectionState.OFFLINE,
+    signaling: []
   });
 
   private _ctx?: Context;
@@ -45,9 +46,9 @@ export class MeshProxy {
     return this._networkStatus;
   }
 
-  async setConnectionState(state: ConnectionState) {
+  async updateConfig(swarm: ConnectionState) {
     assert(this._serviceProvider.services.NetworkService, 'NetworkService is not available.');
-    return this._serviceProvider.services.NetworkService.setNetworkOptions({ state });
+    return this._serviceProvider.services.NetworkService.updateConfig({ swarm });
   }
 
   /**
@@ -58,7 +59,7 @@ export class MeshProxy {
     this._ctx = new Context({ onError: (err) => log.catch(err) });
 
     assert(this._serviceProvider.services.NetworkService, 'NetworkService is not available.');
-    const networkStatusStream = this._serviceProvider.services.NetworkService.subscribeToNetworkStatus();
+    const networkStatusStream = this._serviceProvider.services.NetworkService.queryStatus();
     networkStatusStream.subscribe((networkStatus: NetworkStatus) => {
       this._networkStatusUpdated.emit(networkStatus);
     });

--- a/packages/sdk/react-shell/src/stories/Invitations.stories.tsx
+++ b/packages/sdk/react-shell/src/stories/Invitations.stories.tsx
@@ -99,7 +99,7 @@ const Panel = ({ id, panel, setPanel }: { id: number; panel?: PanelType; setPane
 
 const Invitations = ({ id }: { id: number }) => {
   const client = useClient();
-  const networkStatus = useNetworkStatus().state;
+  const networkStatus = useNetworkStatus().swarm;
   const identity = useIdentity();
   const [panel, setPanel] = useState<PanelType>();
 
@@ -145,7 +145,7 @@ const Invitations = ({ id }: { id: number }) => {
       {/* <ToolTip content='Toggle Network'> */}
       <Button
         onClick={() =>
-          client.mesh.setConnectionState(
+          client.mesh.updateConfig(
             networkStatus === ConnectionState.ONLINE ? ConnectionState.OFFLINE : ConnectionState.ONLINE
           )
         }

--- a/packages/ui/react-appkit/src/components/StatusIndicator/StatusIndicator.tsx
+++ b/packages/ui/react-appkit/src/components/StatusIndicator/StatusIndicator.tsx
@@ -15,17 +15,17 @@ import { Tooltip } from '../Tooltip';
 // TODO(burdon): Extend to show heartbeat, network status, etc.
 // TODO(burdon): Merge with ErrorBoundary indicator since overlaps.
 export const StatusIndicator = () => {
-  const { state } = useNetworkStatus();
+  const { swarm } = useNetworkStatus();
   const client = useClient();
   const handleStateToggle = async () => {
-    void (state === ConnectionState.ONLINE
-      ? client.mesh.setConnectionState(ConnectionState.OFFLINE)
-      : client.mesh.setConnectionState(ConnectionState.ONLINE));
+    void (swarm === ConnectionState.ONLINE
+      ? client.mesh.updateConfig(ConnectionState.OFFLINE)
+      : client.mesh.updateConfig(ConnectionState.ONLINE));
   };
 
   const toggleButton = (
     <Button onClick={handleStateToggle}>
-      {state && state === ConnectionState.ONLINE ? <WifiHigh /> : <WifiSlash />}
+      {swarm && swarm === ConnectionState.ONLINE ? <WifiHigh /> : <WifiSlash />}
     </Button>
   );
   const onlineBall = (
@@ -45,10 +45,10 @@ export const StatusIndicator = () => {
         role='none'
         className={mx(
           'fixed bottom-4 right-4',
-          valenceColorText(state && state === ConnectionState.ONLINE ? 'success' : 'error')
+          valenceColorText(swarm && swarm === ConnectionState.ONLINE ? 'success' : 'error')
         )}
       >
-        <Tooltip content={toggleButton}>{state && state === ConnectionState.ONLINE ? onlineBall : offlineBall}</Tooltip>
+        <Tooltip content={toggleButton}>{swarm && swarm === ConnectionState.ONLINE ? onlineBall : offlineBall}</Tooltip>
       </div>
     </div>
   );


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 85b82a9</samp>

### Summary
🔄📡🕸️

<!--
1.  🔄 Refactor
2.  📡 Signal
3.  🕸️ Network
-->
The pull request refactors and enhances the network and signal management logic for the client services and the devtools. It uses observables, streams, and enums from `@dxos/async` and `@dxos/protocols` to simplify the state management and avoid duplication and race conditions. It also introduces interfaces and factories for the signal managers and the transports, which allow testing and configuring different implementations of these components. It updates the network service API and the devtools UI to use the new terminology and formats for the network and signal status and configuration. It modifies several files in `packages/core/mesh`, `packages/core/protocols`, `packages/sdk/client-services`, `packages/devtools/devtools`, and `packages/experimental/kai`.

> _To make the network service more robust_
> _We refactored the code with some gust_
> _We used `SignalManager` and `TransportFactory`_
> _And observables from `@dxos/async`_
> _And enums from `@dxos/protocols` we trust_

### Walkthrough
*  Replace the `statusChanged` event and the `_state` field of the `SignalClient` class with a `state` observable and a `_pushState` stream, using the `SignalState` enum from `@dxos/protocols` ([link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL7-R17),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL13-R23),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL24-L43),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL68-R58),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL97-R87),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL158-R148),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL164-R157),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL184-R174),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL198-R196),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL218-R212),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL245-R239),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL273-R272),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL309-R302),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL316-R308),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL324-R318),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL336-R328),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL351-R351),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL371-R363),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL380-R372),[link](https://github.com/dxos/dxos/pull/3120/files?diff=unified&w=0#diff-ce6f3b0b5070c5323d58e3f92d0e262f3a2f39e82d550ffc4bd47c4857f44a2fL420-R412)).


