### PR TITLE
refactor(client-services): replace vault heartbeat w/ weblock

### DIFF
--- a/packages/core/protocols/src/proto/dxos/iframe.proto
+++ b/packages/core/protocols/src/proto/dxos/iframe.proto
@@ -13,11 +13,8 @@ package dxos.iframe;
 
 message StartRequest {
   string origin = 1;
-}
-
-/// Worker-to-iframe RPCs.
-service IframeService {
-  rpc Heartbeat(google.protobuf.Empty) returns (google.protobuf.Empty);
+  // Unique identifier for a browser tab.
+  string id = 2;
 }
 
 /// Iframe-to-worker RPCs.

--- a/packages/core/protocols/src/proto/dxos/iframe.proto
+++ b/packages/core/protocols/src/proto/dxos/iframe.proto
@@ -13,8 +13,8 @@ package dxos.iframe;
 
 message StartRequest {
   string origin = 1;
-  // Unique identifier for a browser tab.
-  string id = 2;
+  /// Key for the iframe resource lock used to determine when the service is closing.
+  optional string lock_key = 2;
 }
 
 /// Iframe-to-worker RPCs.

--- a/packages/sdk/client-services/src/packlets/vault/worker-runtime.ts
+++ b/packages/sdk/client-services/src/packlets/vault/worker-runtime.ts
@@ -99,6 +99,7 @@ export class WorkerRuntime {
    * Selects one of the existing session fro WebRTC networking.
    */
   private _reconnectWebrtc() {
+    log('reconnecting webrtc...');
     // Check if current session is already closed.
     if (this._sessionForNetworking) {
       if (!this.sessions.has(this._sessionForNetworking)) {

--- a/packages/sdk/client/src/packlets/client/service-definitions.ts
+++ b/packages/sdk/client/src/packlets/client/service-definitions.ts
@@ -14,7 +14,7 @@ import {
 } from '@dxos/protocols/proto/dxos/client/services';
 import { DevtoolsHost } from '@dxos/protocols/proto/dxos/devtools/host';
 import { DataService } from '@dxos/protocols/proto/dxos/echo/service';
-import type { IframeService, AppService, ShellService, WorkerService } from '@dxos/protocols/proto/dxos/iframe';
+import type { AppService, ShellService, WorkerService } from '@dxos/protocols/proto/dxos/iframe';
 import type { BridgeService } from '@dxos/protocols/proto/dxos/mesh/bridge';
 import { createServiceBundle, ServiceBundle } from '@dxos/rpc';
 
@@ -68,12 +68,10 @@ export const clientServiceBundle = createServiceBundle<ClientServices>({
 });
 
 export type IframeServiceBundle = {
-  IframeService: IframeService;
   BridgeService: BridgeService;
 };
 
 export const iframeServiceBundle: ServiceBundle<IframeServiceBundle> = {
-  IframeService: schema.getService('dxos.iframe.IframeService'),
   BridgeService: schema.getService('dxos.mesh.bridge.BridgeService')
 };
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 31ca894</samp>

### Summary
🆔🔄🔒

<!--
1.  🆔 - This emoji represents the addition of the `id` field to the `StartRequest` message, which is a new identifier for the browser tab.
2. 🔄 - This emoji represents the log statement added to the `reconnect` method of the `WorkerRuntime` class, which indicates a reconnection of the WebRTC connection.
3. 🔒 - This emoji represents the refactoring of the `iframe-proxy-runtime.ts` and `worker-session.ts` files to use the Web Locks API instead of the `IframeService` and the heartbeat mechanism, which improves the coordination and reliability of the vault service worker access.
-->
Refactored the vault service worker and the iframe proxy runtime to use the Web Locks API for concurrency control and session management. Removed the obsolete `IframeService` and updated the `iframe.proto` file to support the Web Locks feature. Added a log statement in the `worker-runtime.ts` file for WebRTC reconnection.

> _Sing, O Muse, of the valiant iframe proxy runtime_
> _That with cunning and skill used the Web Locks divine_
> _To secure the access to the vault service worker_
> _And avoid the contention of the multiple tabs._

### Walkthrough
*  Replace the heartbeat mechanism with the Web Locks API to prevent multiple tabs from accessing the same vault service worker. ([link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-4a996471f1f94b731c591092c8a77355fe4ac462c01413e9ce3e69e133293806L16-R19), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-a7d952f18c8922752062e72d62c1552118afbc133b1b4db8db07a1b04451c185L5-R6), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-a7d952f18c8922752062e72d62c1552118afbc133b1b4db8db07a1b04451c185R30), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-a7d952f18c8922752062e72d62c1552118afbc133b1b4db8db07a1b04451c185L57-R60), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-a7d952f18c8922752062e72d62c1552118afbc133b1b4db8db07a1b04451c185L70-R77), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-a7d952f18c8922752062e72d62c1552118afbc133b1b4db8db07a1b04451c185R86), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-667889a7acb94381c8d55fa2da17284e0ff341a71c20d86752666fa2b298774eL23-L25), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-667889a7acb94381c8d55fa2da17284e0ff341a71c20d86752666fa2b298774eL37-L38), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-667889a7acb94381c8d55fa2da17284e0ff341a71c20d86752666fa2b298774eL45-R46), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-667889a7acb94381c8d55fa2da17284e0ff341a71c20d86752666fa2b298774eR86), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-667889a7acb94381c8d55fa2da17284e0ff341a71c20d86752666fa2b298774eL125-R117), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-667889a7acb94381c8d55fa2da17284e0ff341a71c20d86752666fa2b298774eL151-L154), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-db6d8e5ec5ccabc0025008d27435131e432a193c2de5f89b98ca6700e722be54L17-R17), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-db6d8e5ec5ccabc0025008d27435131e432a193c2de5f89b98ca6700e722be54L71-R74))
  * Remove the `IframeService` from the `iframe.proto` file and the `service-definitions.ts` file as it is no longer needed. ([link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-4a996471f1f94b731c591092c8a77355fe4ac462c01413e9ce3e69e133293806L16-R19), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-db6d8e5ec5ccabc0025008d27435131e432a193c2de5f89b98ca6700e722be54L17-R17), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-db6d8e5ec5ccabc0025008d27435131e432a193c2de5f89b98ca6700e722be54L71-R74))
  * Add a new field `id` to the `StartRequest` message in the `iframe.proto` file to represent a unique identifier for a browser tab. ([link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-4a996471f1f94b731c591092c8a77355fe4ac462c01413e9ce3e69e133293806L16-R19))
  * Import the `Trigger` class from `@dxos/async` in the `iframe-proxy-runtime.ts` file to implement the Web Locks logic. ([link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-a7d952f18c8922752062e72d62c1552118afbc133b1b4db8db07a1b04451c185L5-R6))
  * Add a new private property `_release` to the `IFrameProxyRuntime` class in the `iframe-proxy-runtime.ts` file to signal when the iframe should release the Web Lock. ([link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-a7d952f18c8922752062e72d62c1552118afbc133b1b4db8db07a1b04451c185R30))
  * Remove the `IframeService` from the exposed services in the `_systemRpc` peer in the `IFrameProxyRuntime` class in the `iframe-proxy-runtime.ts` file. ([link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-a7d952f18c8922752062e72d62c1552118afbc133b1b4db8db07a1b04451c185L57-R60))
  * Request and wait for a Web Lock before opening the `_systemRpc` peer and calling the `start` method on the `WorkerService` in the `IFrameProxyRuntime` class in the `iframe-proxy-runtime.ts` file. Use a name composed of the origin and a random id for the Web Lock, and pass the id to the `start` method. ([link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-a7d952f18c8922752062e72d62c1552118afbc133b1b4db8db07a1b04451c185L70-R77))
  * Wake the `_release` trigger in the `close` method of the `IFrameProxyRuntime` class in the `iframe-proxy-runtime.ts` file to release the Web Lock when the iframe is closed or disconnected. ([link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-a7d952f18c8922752062e72d62c1552118afbc133b1b4db8db07a1b04451c185R86))
  * Remove the `options` property from the `WorkerSessionParams` type and the `_options` and `_heartbeatTimer` properties from the `WorkerSession` class in the `worker-session.ts` file as they are only used for the heartbeat mechanism. ([link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-667889a7acb94381c8d55fa2da17284e0ff341a71c20d86752666fa2b298774eL23-L25), [link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-667889a7acb94381c8d55fa2da17284e0ff341a71c20d86752666fa2b298774eL37-L38))
  * Add a decorator `@logInfo` to the public property `id` and remove the default value for the `options` parameter in the constructor of the `WorkerSession` class in the `worker-session.ts` file. Log the id of the tab that acquired the Web Lock for the vault service worker. ([link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-667889a7acb94381c8d55fa2da17284e0ff341a71c20d86752666fa2b298774eL45-R46))
  * Assign the `id` property from the `request` parameter in the `start` method of the `WorkerSession` class in the `worker-session.ts` file. Store the id of the tab that acquired the Web Lock for the vault service worker. ([link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-667889a7acb94381c8d55fa2da17284e0ff341a71c20d86752666fa2b298774eR86))
  * Replace the logic for the heartbeat mechanism with the logic for the Web Locks API in the `open` method of the `WorkerSession` class in the `worker-session.ts` file. Use the Web Locks API to detect when the tab that acquired the Web Lock for the vault service worker is closed or navigated away, and close the session accordingly. ([link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-667889a7acb94381c8d55fa2da17284e0ff341a71c20d86752666fa2b298774eL125-R117))
  * Remove the line that cleared the `_heartbeatTimer` in the `close` method of the `WorkerSession` class in the `worker-session.ts` file as it is no longer used. ([link](https://github.com/dxos/dxos/pull/3129/files?diff=unified&w=0#diff-667889a7acb94381c8d55fa2da17284e0ff341a71c20d86752666fa2b298774eL151-L154))


