### PR TITLE
feat(aurora,composer-app): Sidebar improvements

### DIFF
--- a/packages/apps/composer-app/src/components/Sidebar/Sidebar.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/Sidebar.tsx
@@ -203,8 +203,10 @@ const SidebarToggle = () => {
       <div
         role='none'
         className={mx(
-          'fixed block-start-0 p-2 transition-[inset-inline-start,opacity] ease-in-out duration-200',
-          sidebarOpen ? 'inline-start-sidebar opacity-0 pointer-events-none' : 'inline-start-0 opacity-100'
+          'fixed block-start-0 pointer-coarse:block-end-0 pointer-coarse:block-start-auto p-2 transition-[inset-inline-start,opacity] ease-in-out duration-200 inline-start-0',
+          sidebarOpen
+            ? 'inline-start-[100vw] sm:inline-start-[270px] opacity-0 pointer-events-none'
+            : 'inline-start-0 opacity-100'
         )}
       >
         {sidebarOpen ? (

--- a/packages/apps/composer-app/src/components/Sidebar/Sidebar.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/Sidebar.tsx
@@ -204,9 +204,7 @@ const SidebarToggle = () => {
         role='none'
         className={mx(
           'fixed block-start-0 pointer-coarse:block-end-0 pointer-coarse:block-start-auto p-2 transition-[inset-inline-start,opacity] ease-in-out duration-200 inline-start-0',
-          sidebarOpen
-            ? 'inline-start-[100vw] sm:inline-start-[270px] opacity-0 pointer-events-none'
-            : 'inline-start-0 opacity-100'
+          sidebarOpen && 'opacity-0 pointer-events-none'
         )}
       >
         {sidebarOpen ? (

--- a/packages/apps/composer-app/src/pages/DocumentPage.tsx
+++ b/packages/apps/composer-app/src/pages/DocumentPage.tsx
@@ -31,10 +31,10 @@ import TurndownService from 'turndown';
 
 import { Button, useTranslation, ThemeContext, Trans, useThemeContext } from '@dxos/aurora';
 import { Composer, MarkdownComposerRef, TextKind, TipTapEditor } from '@dxos/aurora-composer';
-import { getSize, mx, osTx } from '@dxos/aurora-theme';
+import { getSize, osTx } from '@dxos/aurora-theme';
 import { Space } from '@dxos/client';
 import { log } from '@dxos/log';
-import { useFileDownload, DropdownMenu, Input, Dialog, DropdownMenuItem } from '@dxos/react-appkit';
+import { useFileDownload, Input, Dialog, DropdownMenuItem, DropdownMenu } from '@dxos/react-appkit';
 import { observer, useIdentity } from '@dxos/react-client';
 
 import { useOctokitContext } from '../components';
@@ -85,34 +85,39 @@ const DocumentPageContent = observer(
     const themeContext = useThemeContext();
     return (
       <>
-        <div role='none' className='mli-auto max-is-[50rem] min-bs-[80vh] border border-neutral-500/20 flex flex-col'>
-          <Input
-            key={document.id}
-            variant='subdued'
-            label={t('document title label')}
-            labelVisuallyHidden
-            placeholder={t('untitled document title')}
-            value={document.title ?? ''}
-            onChange={({ target: { value } }) => (document.title = value)}
-            slots={{
-              root: { className: 'shrink-0 pli-6 plb-1 bg-neutral-500/20' },
-              input: { 'data-testid': 'composer.documentTitle' } as HTMLAttributes<HTMLInputElement>
-            }}
-          />
+        <div
+          role='none'
+          className='mli-auto max-is-[50rem] min-bs-[100vh] bg-white/20 dark:bg-neutral-850/20 flex flex-col'
+        >
+          <div role='none' className='flex items-center gap-2 bg-neutral-500/20 pis-12 md:pis-0'>
+            <Input
+              key={document.id}
+              variant='subdued'
+              label={t('document title label')}
+              labelVisuallyHidden
+              placeholder={t('untitled document title')}
+              value={document.title ?? ''}
+              onChange={({ target: { value } }) => (document.title = value)}
+              slots={{
+                root: { className: 'shrink-0 grow pis-6 plb-2' },
+                input: { 'data-testid': 'composer.documentTitle' } as HTMLAttributes<HTMLInputElement>
+              }}
+            />
+            <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}>
+              <DropdownMenu
+                trigger={
+                  <Button className='p-0 is-10' variant='ghost' density='coarse'>
+                    <DotsThreeVertical className={getSize(6)} />
+                  </Button>
+                }
+              >
+                {dropdownMenuContent}
+              </DropdownMenu>
+            </ThemeContext.Provider>
+          </div>
           {children}
         </div>
         <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}>
-          <div role='none' className={mx('fixed block-start-0 inline-end-0 p-2')}>
-            <DropdownMenu
-              trigger={
-                <Button className='p-0 is-10' density='coarse'>
-                  <DotsThreeVertical className={getSize(6)} />
-                </Button>
-              }
-            >
-              {dropdownMenuContent}
-            </DropdownMenu>
-          </div>
           {handleImport && (
             <Dialog
               open={importDialogOpen}
@@ -619,7 +624,7 @@ export const DocumentPage = observer(() => {
   const document = space && docKey ? (space.db.getObjectById(docKey) as ComposerDocument) : undefined;
 
   return (
-    <div role='none' className='pli-14 plb-11'>
+    <div role='none'>
       {document && space ? (
         document.content.kind === TextKind.PLAIN ? (
           <MarkdownDocumentPage document={document} space={space} />

--- a/packages/ui/aurora-theme/package.json
+++ b/packages/ui/aurora-theme/package.json
@@ -26,7 +26,8 @@
     "tailwind-merge": "^1.10.0",
     "tailwindcss": "~3.2.7",
     "tailwindcss-logical": "^3.0.0",
-    "tailwindcss-radix": "^2.8.0"
+    "tailwindcss-radix": "^2.8.0",
+    "tailwindcss-touch": "^1.0.1"
   },
   "devDependencies": {
     "@dxos/aurora-types": "workspace:*",

--- a/packages/ui/aurora-theme/src/config/tailwind.ts
+++ b/packages/ui/aurora-theme/src/config/tailwind.ts
@@ -6,6 +6,7 @@ import tailwindcssForms from '@tailwindcss/forms';
 import merge from 'lodash.merge';
 import tailwindcssLogical from 'tailwindcss-logical';
 import tailwindcssRadix from 'tailwindcss-radix';
+import tailwindTouch from 'tailwindcss-touch';
 import tailwindColors from 'tailwindcss/colors';
 import defaultConfig from 'tailwindcss/stubs/defaultConfig.stub.js';
 import { Config, ThemeConfig } from 'tailwindcss/types/config';
@@ -619,7 +620,7 @@ export const tailwindConfig = ({
       ...extensions
     )
   },
-  plugins: [tailwindcssLogical, tailwindcssForms, tailwindcssRadix()],
+  plugins: [tailwindcssLogical, tailwindcssForms, tailwindcssRadix(), tailwindTouch()],
   ...(env === 'development' && { mode: 'jit' }),
   content,
   future: {

--- a/packages/ui/aurora-theme/src/styles/components/main.ts
+++ b/packages/ui/aurora-theme/src/styles/components/main.ts
@@ -14,16 +14,16 @@ export type MainStyleProps = Partial<{
 
 export const mainSidebar: ComponentFunction<MainStyleProps> = ({ isLg, sidebarOpen }, ...etc) =>
   mx(
-    'fixed block-start-0 block-end-0 is-[270px] z-[31] overscroll-contain overflow-x-hidden overflow-y-auto bg-neutral-25 dark:bg-neutral-900',
+    'fixed block-start-0 block-end-0 is-[100vw] sm:is-[270px] z-30 overscroll-contain overflow-x-hidden overflow-y-auto bg-neutral-25 dark:bg-neutral-900',
     'transition-[inset-inline-start,inset-inline-end] duration-200 ease-in-out',
-    sidebarOpen ? 'inline-start-0' : '-inline-start-[270px]',
+    sidebarOpen ? 'inline-start-0' : '-inline-start-[100vw] sm:-inline-start-[270px]',
     surfaceElevation({ elevation: 'chrome' }),
     ...etc
   );
 
 export const mainOverlay: ComponentFunction<MainStyleProps> = ({ isLg, sidebarOpen }, ...etc) =>
   mx(
-    'fixed inset-0 z-30 bg-transparent',
+    'fixed inset-0 z-[29] bg-transparent',
     'transition-opacity duration-200 ease-in-out',
     !isLg && sidebarOpen ? 'opacity-100' : 'opacity-0',
     !isLg && sidebarOpen ? 'block' : 'hidden',

--- a/packages/ui/aurora-theme/src/typings.d.ts
+++ b/packages/ui/aurora-theme/src/typings.d.ts
@@ -5,3 +5,4 @@
 declare module 'tailwindcss/stubs/defaultConfig.stub.js';
 declare module 'tailwindcss-radix';
 declare module 'tailwindcss-logical';
+declare module 'tailwindcss-touch';

--- a/packages/ui/aurora/src/components/Main/Main.tsx
+++ b/packages/ui/aurora/src/components/Main/Main.tsx
@@ -9,11 +9,12 @@ import { Slot } from '@radix-ui/react-slot';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import React, { ComponentPropsWithRef, Dispatch, forwardRef, PropsWithChildren, SetStateAction } from 'react';
 
-import { useMediaQuery } from '@dxos/react-hooks';
+import { useMediaQuery, useForwardedRef } from '@dxos/react-hooks';
 
 import { useThemeContext } from '../../hooks';
 import { ThemedClassName } from '../../util';
 import { ElevationProvider } from '../ElevationProvider';
+import { useSwipeToDismiss } from './useSwipeToDismiss';
 
 const MAIN_ROOT_NAME = 'MainRoot';
 const SIDEBAR_NAME = 'Sidebar';
@@ -65,8 +66,10 @@ type SidebarProps = ThemedClassName<ComponentPropsWithRef<typeof DialogContent>>
 
 const Sidebar = forwardRef<HTMLDivElement, SidebarProps>(({ className, children, ...props }, forwardedRef) => {
   const [isLg] = useMediaQuery('lg', { ssr: false });
-  const { sidebarOpen } = useMainContext(SIDEBAR_NAME);
+  const { sidebarOpen, setSidebarOpen } = useMainContext(SIDEBAR_NAME);
   const { tx } = useThemeContext();
+  const ref = useForwardedRef(forwardedRef);
+  useSwipeToDismiss(ref, () => setSidebarOpen(false), 48, 'left', 0);
   return (
     <DialogContent
       forceMount
@@ -74,7 +77,7 @@ const Sidebar = forwardRef<HTMLDivElement, SidebarProps>(({ className, children,
       onCloseAutoFocus={(event) => isLg && event.preventDefault()}
       {...props}
       className={tx('main.sidebar', 'main__sidebar', { isLg, sidebarOpen }, className)}
-      ref={forwardedRef}
+      ref={ref}
     >
       <ElevationProvider elevation='chrome'>{children}</ElevationProvider>
     </DialogContent>

--- a/packages/ui/aurora/src/components/Main/useSwipeToDismiss.ts
+++ b/packages/ui/aurora/src/components/Main/useSwipeToDismiss.ts
@@ -1,0 +1,133 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+// This implementation is based upon https://github.com/hosembafer/react-swipe-to-dismiss, commit d88deafe910a6bd1400cf8fa90459a76cf4f71d3
+
+import { RefObject, useCallback, useEffect, useState } from 'react';
+
+const getScreenX = (event: MouseEvent | TouchEvent) => {
+  let screenX;
+  if (event instanceof TouchEvent) {
+    screenX = event.touches[0].screenX;
+  } else {
+    screenX = (event as MouseEvent).screenX;
+  }
+  return screenX;
+};
+
+export const useSwipeToDismiss = (
+  ref: RefObject<HTMLElement | null>,
+  onDismiss: () => void,
+  distanceBeforeDismiss = 100,
+  direction = 'right',
+  offset = 0
+) => {
+  const node = ref.current;
+  const directionValue = direction === 'right' ? 1 : -1;
+
+  const [removing, setRemoving] = useState(false);
+  const [pressedPosition, setPressedPosition] = useState(0);
+  const [positionLeft, setPositionLeft] = useState(0);
+  const [animate, setAnimate] = useState(false);
+
+  const remove = useCallback(() => {
+    onDismiss();
+    setTimeout(() => {
+      setRemoving(false);
+      setPositionLeft(0);
+      setPressedPosition(0);
+      setAnimate(false);
+    }, 200);
+  }, [node, onDismiss]);
+
+  const onMouseUp = useCallback(() => {
+    if (!node) {
+      return;
+    }
+    setAnimate(true);
+    if (!removing && positionLeft * directionValue >= (node.offsetWidth * distanceBeforeDismiss) / 100) {
+      setPositionLeft(positionLeft + node.offsetWidth * directionValue);
+      setRemoving(true);
+      remove();
+    } else {
+      setPositionLeft(0);
+    }
+    setPressedPosition(0);
+  }, [node, removing, positionLeft, directionValue, distanceBeforeDismiss]);
+
+  const onMouseMove = useCallback(
+    (event: MouseEvent | TouchEvent) => {
+      event.preventDefault();
+      if (!node || removing) {
+        return;
+      }
+
+      const screenX = getScreenX(event);
+
+      if (pressedPosition) {
+        let nextPositionLeft = screenX - pressedPosition;
+
+        if (direction === 'right') {
+          nextPositionLeft = nextPositionLeft < 0 ? 0 : nextPositionLeft;
+        } else {
+          nextPositionLeft = nextPositionLeft > 0 ? 0 : nextPositionLeft;
+        }
+
+        setPositionLeft(nextPositionLeft);
+      }
+    },
+    [removing, pressedPosition, direction, node, remove]
+  );
+
+  const onMouseDown = useCallback((event: MouseEvent | TouchEvent) => {
+    const screenX = getScreenX(event);
+    setPressedPosition(screenX);
+    setAnimate(false);
+  }, []);
+
+  useEffect(() => {
+    if (node) {
+      node.addEventListener('mousedown', onMouseDown);
+      node.addEventListener('touchstart', onMouseDown);
+    }
+    return () => {
+      if (node) {
+        node.removeEventListener('mousedown', onMouseDown);
+        node.removeEventListener('touchstart', onMouseDown);
+      }
+    };
+  }, [node, onMouseDown]);
+
+  useEffect(() => {
+    document.body.addEventListener('mouseup', onMouseUp);
+    document.body.addEventListener('mousemove', onMouseMove);
+
+    document.body.addEventListener('touchmove', onMouseMove, { passive: false });
+    document.body.addEventListener('touchend', onMouseUp);
+
+    return () => {
+      document.body.removeEventListener('mouseup', onMouseUp);
+      document.body.removeEventListener('mousemove', onMouseMove);
+
+      document.body.removeEventListener('touchmove', onMouseMove);
+      document.body.removeEventListener('touchend', onMouseMove);
+    };
+  }, [onMouseUp, onMouseDown, onMouseMove]);
+
+  useEffect(() => {
+    if (!node) {
+      return;
+    }
+    if (positionLeft === 0) {
+      node.style.removeProperty('inset-inline-start');
+    } else {
+      node.style.setProperty('inset-inline-start', `${offset + positionLeft}px`);
+    }
+    if (animate) {
+      node.style.setProperty('transition-duration', '200ms');
+    } else {
+      node.style.setProperty('transition-duration', '0ms');
+    }
+  }, [animate, positionLeft]);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4477,6 +4477,7 @@ importers:
       tailwindcss: ~3.2.7
       tailwindcss-logical: ^3.0.0
       tailwindcss-radix: ^2.8.0
+      tailwindcss-touch: ^1.0.1
       vite: ^4.3.0
     dependencies:
       '@fontsource/fira-code': 4.5.12
@@ -4491,6 +4492,7 @@ importers:
       tailwindcss: 3.2.7
       tailwindcss-logical: 3.0.0_gbtt6ss3tbiz4yjtvdr6fbrj44
       tailwindcss-radix: 2.8.0
+      tailwindcss-touch: 1.0.1
     devDependencies:
       '@dxos/aurora-types': link:../aurora-types
       '@types/lodash.get': 4.4.7
@@ -34310,6 +34312,10 @@ packages:
 
   /tailwindcss-radix/2.8.0:
     resolution: {integrity: sha512-1k1UfoIYgVyBl13FKwwoKavjnJ5VEaUClCTAsgz3VLquN4ay/lyaMPzkbqD71sACDs2fRGImytAUlMb4TzOt1A==}
+
+  /tailwindcss-touch/1.0.1:
+    resolution: {integrity: sha512-h8A/S9+Mk2rnnaOB/NGCE7CxDhtGKbsAWf8Y2tCO6Zf381Y8dKcygPl1OXkFDnWXkL+FfHxmrGpwculDWAumbA==}
+    dev: false
 
   /tailwindcss/3.0.7_ee22xw2qfzolowrlqapvox2wrq:
     resolution: {integrity: sha512-rZdKNHtC64jcQncLoWOuCzj4lQDTAgLtgK3WmQS88tTdpHh9OwLqULTQxI3tw9AMJsqSpCKlmcjW/8CSnni6zQ==}


### PR DESCRIPTION
- Sidebar is full-width on mobile devices up to `sm`
- Sidebar can be swiped to dismiss

Resolves #2658.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9e2adc9</samp>

### Summary
📱👆🎨

<!--
1.  📱 - This emoji represents the touch device support and the `pointer-coarse` media query.
2.  👆 - This emoji represents the swipe-to-dismiss feature and the `useSwipeToDismiss` hook.
3.  🎨 - This emoji represents the responsiveness and usability improvements and the TailwindCSS utility classes.
-->
This pull request adds touch-friendly features and responsiveness to the `Sidebar` and `Overlay` components in the `aurora` and `composer-app` packages. It uses the `tailwindcss-touch` plugin to enable touch-specific variants in the `aurora-theme` package. It also implements a custom hook `useSwipeToDismiss` to allow swiping the sidebar to close it.

> _We swipe away the darkness with our fingers of fire_
> _We toggle the sidebar with a touch of desire_
> _We use the `tailwindcss-touch` to unleash our power_
> _We make the aurora theme responsive and devour_

### Walkthrough
*  Add `useSwipeToDismiss` hook to enable dismissing elements by swiping them ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL12-R17), [link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL68-R72), [link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL77-R80), [link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-e01adeff6f99ce764f9635d1e7d60c8401e85dc9a4fddc0bb32ba7e33c22bb55R1-R133))
  - Import `useSwipeToDismiss` and `useForwardedRef` hooks in `Main.tsx` ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL12-R17))
  - Use `useForwardedRef` hook to pass a ref object to `useSwipeToDismiss` hook ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL68-R72), [link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL77-R80))
  - Use `useSwipeToDismiss` hook to dismiss the `Sidebar` component by swiping it to the left ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL68-R72))
  - Pass `setSidebarOpen` function from `useMainContext` hook as the `onDismiss` callback to `useSwipeToDismiss` hook ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL68-R72))
  - Implement `useSwipeToDismiss` hook in `useSwipeToDismiss.ts` using TailwindCSS and TypeScript ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-e01adeff6f99ce764f9635d1e7d60c8401e85dc9a4fddc0bb32ba7e33c22bb55R1-R133))
* Modify `SidebarToggle` component to adjust its position and size depending on the screen size and the sidebar state ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-482c9b21fffe3f8d8d5630a3ea7190f05252d6f672a1161ac7de35d8b7b725f5L206-R209))
  - Use `pointer-coarse` media query to make the toggle button cover the whole height of the screen on touch devices ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-482c9b21fffe3f8d8d5630a3ea7190f05252d6f672a1161ac7de35d8b7b725f5L206-R209))
  - Use `sidebarOpen` state from `useMainContext` hook to change the toggle button's `inline-start` property ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-482c9b21fffe3f8d8d5630a3ea7190f05252d6f672a1161ac7de35d8b7b725f5L206-R209))
  - Use `screen` breakpoints from TailwindCSS to change the toggle button's `width` and `height` properties ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-482c9b21fffe3f8d8d5630a3ea7190f05252d6f672a1161ac7de35d8b7b725f5L206-R209))
* Modify `mainSidebar` and `mainOverlay` style functions to make the sidebar cover the whole width of the screen on small devices and lower the overlay's `z-index` value ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-6cb9ca47f40030efd387c6b913991939307763cd606e18959254290504ded3a8L17-R19), [link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-6cb9ca47f40030efd387c6b913991939307763cd606e18959254290504ded3a8L26-R26))
  - Use `screen` breakpoints from TailwindCSS to change the sidebar's `width` and `inline-start` properties ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-6cb9ca47f40030efd387c6b913991939307763cd606e18959254290504ded3a8L17-R19))
  - Use a different transition value for the `inline-start` property to match the swipe behavior ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-6cb9ca47f40030efd387c6b913991939307763cd606e18959254290504ded3a8L17-R19))
  - Lower the `z-index` value of the overlay element to avoid overlapping with the `SidebarToggle` component ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-6cb9ca47f40030efd387c6b913991939307763cd606e18959254290504ded3a8L26-R26))
* Add `tailwindcss-touch` dependency and plugin to the `aurora-theme` package ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-d1b94d11b62d10124d3f901f7d3181d8efd19e79c866b2a9bdb6ff22b86f140bL29-R30), [link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-104ae02f9b930ab0f54259fab127bc58060e28f0c63fc48f7a52913ba4626acaR9), [link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-104ae02f9b930ab0f54259fab127bc58060e28f0c63fc48f7a52913ba4626acaL622-R623))
  - Add `tailwindcss-touch` to the `package.json` file ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-d1b94d11b62d10124d3f901f7d3181d8efd19e79c866b2a9bdb6ff22b86f140bL29-R30))
  - Import `tailwindcss-touch` plugin in the `tailwind.ts` file ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-104ae02f9b930ab0f54259fab127bc58060e28f0c63fc48f7a52913ba4626acaR9))
  - Add `tailwindcss-touch` plugin to the `tailwindConfig` object in the `tailwind.ts` file ([link](https://github.com/dxos/dxos/pull/3138/files?diff=unified&w=0#diff-104ae02f9b930ab0f54259fab127bc58060e28f0c63fc48f7a52913ba4626acaL622-R623))


