### PR TITLE
feat(aurora): `useSidebar`

### DIFF
--- a/packages/apps/composer-app/src/components/Sidebar/Sidebar.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/Sidebar.tsx
@@ -14,7 +14,7 @@ import {
   useId,
   useThemeContext,
   useTranslation,
-  useMainContext
+  useSidebar
 } from '@dxos/aurora';
 import { getSize, mx, osTx } from '@dxos/aurora-theme';
 import { Tooltip, Avatar, Dialog, Input, TreeRoot } from '@dxos/react-appkit';
@@ -56,7 +56,7 @@ const SidebarContent = () => {
   const shell = useShell();
   const navigate = useNavigate();
   const { t } = useTranslation('composer');
-  const { sidebarOpen, setSidebarOpen } = useMainContext(SIDEBAR_CONTENT_NAME);
+  const { closeSidebar } = useSidebar(SIDEBAR_CONTENT_NAME);
   const identity = useIdentity();
   const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
   const { pat, setPat } = useOctokitContext();
@@ -145,7 +145,7 @@ const SidebarContent = () => {
                 <Button
                   variant='ghost'
                   data-testid='composer.toggleSidebarWithinSidebar'
-                  onClick={() => setSidebarOpen(!sidebarOpen)}
+                  onClick={closeSidebar}
                   className='pli-1'
                 >
                   <ArrowLineLeft className={getSize(4)} />
@@ -190,11 +190,11 @@ SidebarContent.displayName = SIDEBAR_CONTENT_NAME;
 const SIDEBAR_TOGGLE_NAME = 'SidebarToggle';
 
 const SidebarToggle = () => {
-  const { sidebarOpen, setSidebarOpen } = useMainContext(SIDEBAR_TOGGLE_NAME);
+  const { openSidebar, sidebarOpen } = useSidebar(SIDEBAR_TOGGLE_NAME);
   const { t } = useTranslation('os');
   const themeContext = useThemeContext();
   const button = (
-    <Button data-testid='composer.toggleSidebar' onClick={() => setSidebarOpen(true)} className='p-0 is-[40px]'>
+    <Button data-testid='composer.toggleSidebar' onClick={openSidebar} className='p-0 is-[40px]'>
       <Sidebar weight='light' className={getSize(6)} />
     </Button>
   );

--- a/packages/experimental/kai-framework/src/containers/Sidebar/Sidebar.stories.tsx
+++ b/packages/experimental/kai-framework/src/containers/Sidebar/Sidebar.stories.tsx
@@ -6,7 +6,7 @@ import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { withRouter } from 'storybook-addon-react-router-v6';
 
-import { Button, Main, MainOverlay, MainRoot, useMainContext } from '@dxos/aurora';
+import { Button, Main, MainOverlay, MainRoot, useSidebar } from '@dxos/aurora';
 import { frameDefs, frameModules, FrameRegistryContextProvider } from '@dxos/kai-frames';
 import { MetagraphClientFake } from '@dxos/metagraph';
 import { useSpaces } from '@dxos/react-client';
@@ -19,8 +19,8 @@ import { AppStateProvider, createPath, defaultFrames } from '../../hooks';
 import { Sidebar } from './Sidebar';
 
 const SidebarInvoker = () => {
-  const { setSidebarOpen } = useMainContext('KaiFrameworkStorybookSidebarInvoker');
-  return <Button onClick={() => setSidebarOpen(true)}>Open</Button>;
+  const { openSidebar } = useSidebar();
+  return <Button onClick={openSidebar}>Open</Button>;
 };
 
 const Test = () => {

--- a/packages/experimental/kai-framework/src/containers/Sidebar/Sidebar.tsx
+++ b/packages/experimental/kai-framework/src/containers/Sidebar/Sidebar.tsx
@@ -6,7 +6,7 @@ import { AppWindow, CaretLeft, Info, Graph, Robot, Users, WifiHigh, WifiSlash } 
 import assert from 'assert';
 import React, { useEffect, useState, Suspense } from 'react';
 
-import { Button, DensityProvider, useMainContext, Sidebar as NaturalSidebar, ClassNameValue } from '@dxos/aurora';
+import { Button, DensityProvider, Sidebar as NaturalSidebar, ClassNameValue, useSidebar } from '@dxos/aurora';
 import { getSize, mx } from '@dxos/aurora-theme';
 import { TypedObject } from '@dxos/client';
 import { searchMeta } from '@dxos/kai-frames';
@@ -68,8 +68,7 @@ export const Sidebar = observer(({ className, onNavigate }: SidebarProps) => {
   // App state
   //
 
-  const { sidebarOpen, setSidebarOpen } = useMainContext(SIDEBAR_NAME);
-  const toggleSidebar = () => setSidebarOpen(!sidebarOpen);
+  const { toggleSidebar, sidebarOpen } = useSidebar(SIDEBAR_NAME);
   const { swarm: connectionState } = useNetworkStatus();
   const [showSpacePanel, setShowSpacePanel] = useState(false);
 

--- a/packages/experimental/kai-framework/src/containers/Surface/Surface.stories.tsx
+++ b/packages/experimental/kai-framework/src/containers/Surface/Surface.stories.tsx
@@ -7,15 +7,7 @@ import React, { FC, ReactNode, Suspense, useContext, useEffect, useState } from 
 import { createMemoryRouter, RouterProvider, useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { Event } from '@dxos/async';
-import {
-  Button,
-  MainRoot,
-  Sidebar as SidebarRoot,
-  Main,
-  ThemeProvider,
-  useMainContext,
-  MainOverlay
-} from '@dxos/aurora';
+import { Button, MainRoot, Sidebar as SidebarRoot, Main, ThemeProvider, MainOverlay, useSidebar } from '@dxos/aurora';
 import { getSize, mx, tx } from '@dxos/aurora-theme';
 import { raise } from '@dxos/debug';
 import { FullscreenDecorator } from '@dxos/kai-frames';
@@ -121,7 +113,7 @@ const SurfaceOutlet = () => {
 const SIDEBAR_SURFACE_NAME = 'KaiFrameworkSidebarSurface';
 
 const SidebarSurface = () => {
-  const { sidebarOpen, setSidebarOpen } = useMainContext(SIDEBAR_SURFACE_NAME);
+  const { toggleSidebar } = useSidebar(SIDEBAR_SURFACE_NAME);
   const { controller } = useContext(SurfaceControllerContext);
 
   return (
@@ -136,7 +128,7 @@ const SidebarSurface = () => {
           </Button>
         </div>
         <div>
-          <Button variant='ghost' onClick={() => setSidebarOpen(!sidebarOpen)}>
+          <Button variant='ghost' onClick={toggleSidebar}>
             <CaretLeft className={getSize(5)} />
           </Button>
         </div>
@@ -279,13 +271,13 @@ const Component3 = () => (
 const PANEL_SIDEBAR_CONTENT_NAME = 'PanelSidebarContent';
 
 const PanelSidebarContent: FC<{ children: ReactNode }> = ({ children }) => {
-  const { sidebarOpen, setSidebarOpen } = useMainContext(PANEL_SIDEBAR_CONTENT_NAME);
+  const { sidebarOpen, openSidebar } = useSidebar(PANEL_SIDEBAR_CONTENT_NAME);
   return (
     <div className='flex grow overflow-hidden'>
       {!sidebarOpen && (
         <div className='flex flex-col h-full px-2'>
           <div className='flex h-[32px] items-center'>
-            <Button variant='ghost' onClick={() => setSidebarOpen(true)}>
+            <Button variant='ghost' onClick={openSidebar}>
               <CaretRight className={getSize(5)} />
             </Button>
           </div>

--- a/packages/experimental/kai-framework/src/pages/SpacePanel.tsx
+++ b/packages/experimental/kai-framework/src/pages/SpacePanel.tsx
@@ -6,7 +6,7 @@ import { CaretRight } from '@phosphor-icons/react';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
-import { Button, useMainContext } from '@dxos/aurora';
+import { Button, useSidebar } from '@dxos/aurora';
 import { getSize, mx } from '@dxos/aurora-theme';
 import { FrameDef, useFrameRegistry } from '@dxos/kai-frames';
 import { SpaceState } from '@dxos/react-client';
@@ -22,8 +22,7 @@ export const SpacePanel = () => {
   const { chat, dev, fullscreen } = useAppState();
   const { space, frame, objectId } = useAppRouter();
   const { section } = useParams();
-  const { sidebarOpen, setSidebarOpen } = useMainContext(SPACE_PANEL_NAME);
-  const toggleSidebar = () => setSidebarOpen(!sidebarOpen);
+  const { sidebarOpen, toggleSidebar } = useSidebar(SPACE_PANEL_NAME);
 
   const frameRegistry = useFrameRegistry();
   let sidebarFrameDef: FrameDef<any> | undefined;

--- a/packages/ui/aurora/src/components/Main/Main.stories.tsx
+++ b/packages/ui/aurora/src/components/Main/Main.stories.tsx
@@ -6,13 +6,13 @@ import '@dxosTheme';
 import React from 'react';
 
 import { Button } from '../Button';
-import { Main, MainRoot, MainOverlay, Sidebar, useMainContext } from './Main';
+import { Main, MainRoot, MainOverlay, Sidebar, useSidebar } from './Main';
 
 type StoryMainArgs = {};
 
 const SidebarToggle = () => {
-  const { sidebarOpen, setSidebarOpen } = useMainContext('StoryMain__SidebarToggle');
-  return <Button onClick={() => setSidebarOpen(!sidebarOpen)}>Toggle sidebar</Button>;
+  const { toggleSidebar } = useSidebar('StoryMain__SidebarToggle');
+  return <Button onClick={toggleSidebar}>Toggle sidebar</Button>;
 };
 
 const StoryMain = (_args: StoryMainArgs) => {

--- a/packages/ui/aurora/src/components/Main/Main.tsx
+++ b/packages/ui/aurora/src/components/Main/Main.tsx
@@ -7,7 +7,14 @@ import { Root as DialogRoot, DialogContent } from '@radix-ui/react-dialog';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Slot } from '@radix-ui/react-slot';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
-import React, { ComponentPropsWithRef, Dispatch, forwardRef, PropsWithChildren, SetStateAction } from 'react';
+import React, {
+  ComponentPropsWithRef,
+  Dispatch,
+  forwardRef,
+  PropsWithChildren,
+  SetStateAction,
+  useCallback
+} from 'react';
 
 import { useMediaQuery, useForwardedRef } from '@dxos/react-hooks';
 
@@ -19,6 +26,7 @@ import { useSwipeToDismiss } from './useSwipeToDismiss';
 const MAIN_ROOT_NAME = 'MainRoot';
 const SIDEBAR_NAME = 'Sidebar';
 const MAIN_NAME = 'Main';
+const GENERIC_CONSUMER_NAME = 'GenericConsumer';
 
 type MainContextValue = {
   sidebarOpen: boolean;
@@ -31,6 +39,17 @@ const [MainProvider, useMainContext] = createContext<MainContextValue>(MAIN_NAME
     console.warn('Attempt to set sidebar state without initializing `MainRoot`');
   }
 });
+
+const useSidebar = (consumerName = GENERIC_CONSUMER_NAME) => {
+  const { setSidebarOpen, sidebarOpen } = useMainContext(consumerName);
+  return {
+    sidebarOpen,
+    setSidebarOpen,
+    toggleSidebar: useCallback(() => setSidebarOpen(!sidebarOpen), [sidebarOpen, setSidebarOpen]),
+    openSidebar: useCallback(() => setSidebarOpen(true), [setSidebarOpen]),
+    closeSidebar: useCallback(() => setSidebarOpen(false), [setSidebarOpen])
+  };
+};
 
 type MainRootProps = PropsWithChildren<{
   sidebarOpen?: boolean;
@@ -124,6 +143,6 @@ const MainOverlay = forwardRef<HTMLDivElement, MainOverlayProps>(({ className, .
   );
 });
 
-export { MainRoot, Main, Sidebar, MainOverlay, useMainContext };
+export { MainRoot, Main, Sidebar, MainOverlay, useMainContext, useSidebar };
 
 export type { MainRootProps, MainProps, SidebarProps, MainOverlayProps };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ea29019</samp>

### Summary
🎣🚪📚

<!--
1.  🎣 - This emoji represents the use of custom hooks, which are a way of extracting and reusing stateful logic in React components. The `useSidebar` hook is an example of a custom hook that simplifies the sidebar logic and makes it easier to share across components and stories.
2.  🚪 - This emoji represents the opening and closing actions of the sidebar, which are the main features of the sidebar component and the hook. The `useSidebar` hook provides methods to toggle and open the sidebar, which are used by various components and stories to demonstrate the functionality of the sidebar.
3.  📚 - This emoji represents the story files, which are a way of documenting and testing the components in isolation. The story files for the main, sidebar, and surface components were updated to use the `useSidebar` hook and show different scenarios of using the sidebar.
-->
Refactored the sidebar logic across different components and stories to use a custom `useSidebar` hook. This hook simplifies the sidebar state management and provides a consistent way to access and control the sidebar. The hook is defined and exported in the `Main.tsx` file and used by the `Sidebar.tsx`, `SpacePanel.tsx`, `Sidebar.stories.tsx`, and `Surface.stories.tsx` files.

> _`useSidebar` is the hook of doom_
> _It controls the fate of the panel and the surface_
> _No more `useMainContext` to consume_
> _Only the dark logic of the sidebar to embrace_

### Walkthrough
*  Replace `useMainContext` hook with `useSidebar` hook in several components and stories that use the sidebar functionality ([link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-482c9b21fffe3f8d8d5630a3ea7190f05252d6f672a1161ac7de35d8b7b725f5L17-R17), [link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-482c9b21fffe3f8d8d5630a3ea7190f05252d6f672a1161ac7de35d8b7b725f5L59-R59), [link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-482c9b21fffe3f8d8d5630a3ea7190f05252d6f672a1161ac7de35d8b7b725f5L148-R148), [link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-482c9b21fffe3f8d8d5630a3ea7190f05252d6f672a1161ac7de35d8b7b725f5L193-R197), [link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-185b957235af8888875aa2ea61db1b05ab41591ff98a745440beebba1451b1c3L9-R9), [link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-185b957235af8888875aa2ea61db1b05ab41591ff98a745440beebba1451b1c3L22-R23), [link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-03348ed7c59459d40c5d6d8e58cd78f1edfa333a5f3eba764591bed96746b776L9-R9), [link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-03348ed7c59459d40c5d6d8e58cd78f1edfa333a5f3eba764591bed96746b776L71-R71), [link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-8414a6bed737078dfd7178f17edcac05c2e5cbde4ec60f6e077d9223d10612dbL10-R10), [link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-8414a6bed737078dfd7178f17edcac05c2e5cbde4ec60f6e077d9223d10612dbL124-R116), [link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-8414a6bed737078dfd7178f17edcac05c2e5cbde4ec60f6e077d9223d10612dbL139-R131), [link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-8414a6bed737078dfd7178f17edcac05c2e5cbde4ec60f6e077d9223d10612dbL282-R274), [link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-8414a6bed737078dfd7178f17edcac05c2e5cbde4ec60f6e077d9223d10612dbL288-R280), [link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-8277e07e9df756bf56e913a93645ebba6ef35a6410d697a2d9459e5a31f3bce3L9-R9), [link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-8277e07e9df756bf56e913a93645ebba6ef35a6410d697a2d9459e5a31f3bce3L25-R25), [link](https://github.com/dxos/dxos/pull/3141/files?diff=unified&w=0#diff-cdca4b3b8016d6454480d72a4763fac9d3d5396dee56b11ae68400922873ca9cL9-R15)).


