### PR TITLE
refactor(aurora): Harmonize `useElevationContext` with `useDensityContext`

### DIFF
--- a/packages/ui/aurora/src/components/Button/Button.tsx
+++ b/packages/ui/aurora/src/components/Button/Button.tsx
@@ -3,7 +3,7 @@
 //
 
 import { createContext } from '@radix-ui/react-context';
-import React, { ComponentProps, ComponentPropsWithRef, forwardRef, ReactNode } from 'react';
+import React, { ComponentPropsWithoutRef, ComponentPropsWithRef, forwardRef } from 'react';
 
 import { Density, Elevation } from '@dxos/aurora-types';
 
@@ -28,8 +28,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ children, density: propsDensity, elevation: propsElevation, variant = 'default', ...rootSlot }, ref) => {
     const { inGroup } = useButtonGroupContext(BUTTON_NAME);
     const { tx } = useThemeContext();
-    const { elevation } = useElevationContext();
-    const density = useDensityContext();
+    const elevation = useElevationContext(propsElevation);
+    const density = useDensityContext(propsDensity);
     return (
       <button
         ref={ref}
@@ -41,8 +41,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             variant,
             inGroup,
             disabled: rootSlot.disabled,
-            density: propsDensity ?? density,
-            elevation: propsElevation ?? elevation
+            density,
+            elevation
           },
           rootSlot.className
         )}
@@ -56,13 +56,11 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
 Button.displayName = BUTTON_NAME;
 
-interface ButtonGroupProps extends ComponentProps<'div'> {
-  children?: ReactNode;
-}
+type ButtonGroupProps = ComponentPropsWithoutRef<'div'> & { elevation?: Elevation };
 
-const ButtonGroup = ({ children, ...divProps }: ButtonGroupProps) => {
+const ButtonGroup = ({ children, elevation: propsElevation, ...divProps }: ButtonGroupProps) => {
   const { tx } = useThemeContext();
-  const { elevation } = useElevationContext();
+  const elevation = useElevationContext(propsElevation);
   return (
     <div role='none' {...divProps} className={tx('button.group', 'button-group', { elevation }, divProps.className)}>
       <ButtonGroupProvider inGroup>{children}</ButtonGroupProvider>

--- a/packages/ui/aurora/src/components/Input/Input.tsx
+++ b/packages/ui/aurora/src/components/Input/Input.tsx
@@ -112,7 +112,7 @@ const PinInput = ({
   const { hasIosKeyboard } = useThemeContext();
   const { tx } = useThemeContext();
   const density = useDensityContext(propsDensity);
-  const { elevation } = useElevationContext();
+  const elevation = useElevationContext(propsElevation);
 
   const segmentClassName = useCallback(
     ({ focused, validationValence }: Parameters<Exclude<PinInputPrimitiveProps['segmentClassName'], undefined>>[0]) =>
@@ -124,7 +124,7 @@ const PinInput = ({
           focused,
           disabled: props.disabled,
           density,
-          elevation: propsElevation ?? elevation,
+          elevation,
           validationValence
         },
         propsSegmentClassName
@@ -156,7 +156,7 @@ const TextInput = ({
   const { hasIosKeyboard } = useThemeContext();
   const { tx } = useThemeContext();
   const density = useDensityContext(propsDensity);
-  const { elevation } = useElevationContext();
+  const elevation = useElevationContext(propsElevation);
   const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
 
   return (
@@ -169,7 +169,7 @@ const TextInput = ({
           variant,
           disabled: props.disabled,
           density,
-          elevation: propsElevation ?? elevation,
+          elevation,
           validationValence
         },
         className
@@ -192,7 +192,7 @@ const TextArea = ({
   const { hasIosKeyboard } = useThemeContext();
   const { tx } = useThemeContext();
   const density = useDensityContext(propsDensity);
-  const { elevation } = useElevationContext();
+  const elevation = useElevationContext(propsElevation);
   const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
 
   return (
@@ -205,7 +205,7 @@ const TextArea = ({
           variant,
           disabled: props.disabled,
           density,
-          elevation: propsElevation ?? elevation,
+          elevation,
           validationValence
         },
         className

--- a/packages/ui/aurora/src/hooks/useElevationContext.ts
+++ b/packages/ui/aurora/src/hooks/useElevationContext.ts
@@ -4,6 +4,11 @@
 
 import { useContext } from 'react';
 
+import { Elevation } from '@dxos/aurora-types';
+
 import { ElevationContext } from '../components';
 
-export const useElevationContext = () => useContext(ElevationContext);
+export const useElevationContext = (propsElevation?: Elevation) => {
+  const { elevation } = useContext(ElevationContext);
+  return propsElevation ?? elevation;
+};

--- a/packages/ui/react-appkit/src/components/Alert/Alert.tsx
+++ b/packages/ui/react-appkit/src/components/Alert/Alert.tsx
@@ -23,7 +23,7 @@ export interface AlertProps {
 
 export const Alert = ({ title, children, assertive, valence, elevation: propsElevation, slots = {} }: AlertProps) => {
   const labelId = useId('alertLabel');
-  const { elevation } = useElevationContext();
+  const elevation = useElevationContext(propsElevation) ?? 'group';
   return (
     <div
       {...slots.root}
@@ -31,7 +31,7 @@ export const Alert = ({ title, children, assertive, valence, elevation: propsEle
       aria-labelledby={labelId}
       className={mx(
         'p-3 rounded-md max-is-full overflow-auto',
-        surfaceElevation({ elevation: propsElevation ?? elevation ?? 'group' }),
+        surfaceElevation({ elevation }),
         alertValence(valence),
         slots.root?.className
       )}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7ed2f4a</samp>

### Summary
🪙🧹🎚️

<!--
1.  🪙 - This emoji represents the `useElevationContext` hook accepting an optional prop for `elevation`, which is like a coin that can have different values depending on the context.
2.  🧹 - This emoji represents the simplification and cleanup of the elevation and density logic for the `Button` and `ButtonGroup` components, which is like sweeping away unnecessary code and imports.
3.  🎚️ - This emoji represents the extension of the `useElevationContext` hook to allow components to specify their own `elevation` prop, which is like a slider that can adjust the level of elevation for each component.
-->
The pull request enhances the elevation handling of various UI components by allowing them to override the default elevation from the context if needed. It also simplifies some logic and removes some unused code in the `Button`, `Input`, and `Alert` components and the `useElevationContext` hook.

> _`useElevationContext`_
> _More flexible for components_
> _Autumn leaves falling_

### Walkthrough
*  Simplify the use of `useElevationContext` hook by allowing components to pass an optional `elevation` prop and use it directly in the `className` props ([link](https://github.com/dxos/dxos/pull/3142/files?diff=unified&w=0#diff-db74e97e4b3e6c236c103e2ed48be7203885be901ce304302cecb5a2133ca744L31-R32),[link](https://github.com/dxos/dxos/pull/3142/files?diff=unified&w=0#diff-db74e97e4b3e6c236c103e2ed48be7203885be901ce304302cecb5a2133ca744L44-R45),[link](https://github.com/dxos/dxos/pull/3142/files?diff=unified&w=0#diff-db74e97e4b3e6c236c103e2ed48be7203885be901ce304302cecb5a2133ca744L59-R63),[link](https://github.com/dxos/dxos/pull/3142/files?diff=unified&w=0#diff-f419668fe8241d8cf01b2d29346cdd5b0d5a2421a8a7fb311e05c5532798393cL115-R115),[link](https://github.com/dxos/dxos/pull/3142/files?diff=unified&w=0#diff-f419668fe8241d8cf01b2d29346cdd5b0d5a2421a8a7fb311e05c5532798393cL127-R127),[link](https://github.com/dxos/dxos/pull/3142/files?diff=unified&w=0#diff-f419668fe8241d8cf01b2d29346cdd5b0d5a2421a8a7fb311e05c5532798393cL159-R159),[link](https://github.com/dxos/dxos/pull/3142/files?diff=unified&w=0#diff-f419668fe8241d8cf01b2d29346cdd5b0d5a2421a8a7fb311e05c5532798393cL172-R172),[link](https://github.com/dxos/dxos/pull/3142/files?diff=unified&w=0#diff-f419668fe8241d8cf01b2d29346cdd5b0d5a2421a8a7fb311e05c5532798393cL195-R195),[link](https://github.com/dxos/dxos/pull/3142/files?diff=unified&w=0#diff-f419668fe8241d8cf01b2d29346cdd5b0d5a2421a8a7fb311e05c5532798393cL208-R208),[link](https://github.com/dxos/dxos/pull/3142/files?diff=unified&w=0#diff-fa07c1b8af869fa06bab002b70b0a5c3c498885dd59a1de6da3fac0e8994da5bL7-R14),[link](https://github.com/dxos/dxos/pull/3142/files?diff=unified&w=0#diff-66f63b01eeab1f825fa356c25887471d4b381510260ebf87468119b5bf99fe97L26-R26),[link](https://github.com/dxos/dxos/pull/3142/files?diff=unified&w=0#diff-66f63b01eeab1f825fa356c25887471d4b381510260ebf87468119b5bf99fe97L34-R34)).


