### PR TITLE
feat: Add @dxos/kube-testing

### DIFF
--- a/packages/common/context/src/context.ts
+++ b/packages/common/context/src/context.ts
@@ -95,6 +95,7 @@ export class Context {
    */
   raise(error: Error): void {
     if (this._isDisposed) {
+      // TODO(dmaretskyi): Don't log those.
       log.warn('Error in disposed context', error);
       return;
     }

--- a/packages/common/context/src/context.ts
+++ b/packages/common/context/src/context.ts
@@ -96,7 +96,7 @@ export class Context {
   raise(error: Error): void {
     if (this._isDisposed) {
       // TODO(dmaretskyi): Don't log those.
-      log.warn('Error in disposed context', error);
+      // log.warn('Error in disposed context', error);
       return;
     }
 

--- a/packages/core/mesh/messaging/src/messenger.test.ts
+++ b/packages/core/mesh/messaging/src/messenger.test.ts
@@ -8,7 +8,7 @@ import { asyncTimeout, latch, sleep } from '@dxos/async';
 import { TaggedType } from '@dxos/codec-protobuf';
 import { PublicKey } from '@dxos/keys';
 import { TYPES } from '@dxos/protocols';
-import { createTestBroker, TestBroker } from '@dxos/signal';
+import { runTestSignalServer, SignalServerRunner } from '@dxos/signal';
 import { afterAll, beforeAll, describe, test, afterTest } from '@dxos/test';
 import { range } from '@dxos/util';
 
@@ -36,10 +36,10 @@ const PAYLOAD_3: TaggedType<TYPES, 'google.protobuf.Any'> = {
 };
 
 describe('Messenger', () => {
-  let broker: TestBroker;
+  let broker: SignalServerRunner;
 
   beforeAll(async () => {
-    broker = await createTestBroker();
+    broker = await runTestSignalServer();
   });
 
   afterAll(() => {

--- a/packages/core/mesh/messaging/src/signal-client/signal-client.test.ts
+++ b/packages/core/mesh/messaging/src/signal-client/signal-client.test.ts
@@ -8,7 +8,7 @@ import { sleep, Event, Trigger, asyncTimeout } from '@dxos/async';
 import { Any, TaggedType } from '@dxos/codec-protobuf';
 import { PublicKey } from '@dxos/keys';
 import { TYPES } from '@dxos/protocols';
-import { createTestBroker, TestBroker } from '@dxos/signal';
+import { runTestSignalServer, SignalServerRunner } from '@dxos/signal';
 import { afterAll, beforeAll, describe, test, afterTest } from '@dxos/test';
 
 import { SignalClient } from './signal-client';
@@ -20,12 +20,12 @@ const PAYLOAD: TaggedType<TYPES, 'google.protobuf.Any'> = {
 };
 
 describe('SignalClient', () => {
-  let broker1: TestBroker;
+  let broker1: SignalServerRunner;
 
-  let broker2: TestBroker;
+  let broker2: SignalServerRunner;
 
   beforeAll(async () => {
-    broker1 = await createTestBroker();
+    broker1 = await runTestSignalServer();
     // broker2 = await await createTestBroker(signalApiPort2);
   });
 

--- a/packages/core/mesh/messaging/src/signal-client/signal-rpc-client.test.ts
+++ b/packages/core/mesh/messaging/src/signal-client/signal-rpc-client.test.ts
@@ -9,16 +9,16 @@ import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { schema } from '@dxos/protocols';
 import { Message as SignalMessage, SwarmEvent } from '@dxos/protocols/proto/dxos/mesh/signal';
-import { createTestBroker, TestBroker } from '@dxos/signal';
+import { runTestSignalServer, SignalServerRunner } from '@dxos/signal';
 import { afterAll, afterTest, beforeAll, describe, test } from '@dxos/test';
 
 import { SignalRPCClient } from './signal-rpc-client';
 
 describe('SignalRPCClient', () => {
-  let broker: TestBroker;
+  let broker: SignalServerRunner;
 
   beforeAll(async () => {
-    broker = await createTestBroker();
+    broker = await runTestSignalServer();
   });
 
   afterAll(() => {

--- a/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.test.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.test.ts
@@ -18,9 +18,9 @@ describe('WebSocketSignalManager', () => {
     broker2 = await runTestSignalServer({ port: 5002 });
   });
 
-  afterAll(async () => {
-    await broker1.stop();
-    await broker2.stop();
+  afterAll(() => {
+    broker1.stop();
+    broker2.stop();
   });
 
   const expectPeerAvailable = (client: WebsocketSignalManager, expectedTopic: PublicKey, peer: PublicKey) =>

--- a/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.test.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.test.ts
@@ -14,8 +14,8 @@ describe('WebSocketSignalManager', () => {
   let broker2: SignalServerRunner;
 
   beforeAll(async () => {
-    broker1 = await runTestSignalServer(5001);
-    broker2 = await runTestSignalServer(5002);
+    broker1 = await runTestSignalServer({ port: 5001 });
+    broker2 = await runTestSignalServer({ port: 5002 });
   });
 
   afterAll(async () => {

--- a/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.test.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.test.ts
@@ -2,19 +2,20 @@
 // Copyright 2023 DXOS.org
 //
 
+import { asyncTimeout, sleep } from '@dxos/async';
 import { PublicKey } from '@dxos/keys';
-import { createTestBroker, TestBroker } from '@dxos/signal';
+import { runTestSignalServer, SignalServerRunner } from '@dxos/signal';
 import { afterAll, beforeAll, describe, test, openAndClose } from '@dxos/test';
 
 import { WebsocketSignalManager } from './websocket-signal-manager';
 
 describe('WebSocketSignalManager', () => {
-  let broker1: TestBroker;
-  let broker2: TestBroker;
+  let broker1: SignalServerRunner;
+  let broker2: SignalServerRunner;
 
   beforeAll(async () => {
-    broker1 = await createTestBroker(5001);
-    broker2 = await createTestBroker(5002);
+    broker1 = await runTestSignalServer(5001);
+    broker2 = await runTestSignalServer(5002);
   });
 
   afterAll(async () => {
@@ -27,6 +28,15 @@ describe('WebSocketSignalManager', () => {
       ({ swarmEvent, topic }) =>
         !!swarmEvent.peerAvailable && peer.equals(swarmEvent.peerAvailable.peer) && expectedTopic.equals(topic)
     );
+
+  const expectReceivedMessage = (client: WebsocketSignalManager, expectedMessage: any) => {
+    return client.onMessage.waitFor(
+      (msg) =>
+        msg.author.equals(expectedMessage.author) &&
+        msg.recipient.equals(expectedMessage.recipient) &&
+        PublicKey.from(msg.payload.value).equals(expectedMessage.payload.value)
+    );
+  };
 
   test('join swarm with two brokers', async () => {
     const client1 = new WebsocketSignalManager([{ server: broker1.url() }, { server: broker2.url() }]);
@@ -49,6 +59,35 @@ describe('WebSocketSignalManager', () => {
   })
     .timeout(1_000)
     .retries(2);
+
+  test('join single swarm with doubled brokers', async () => {
+    const client1 = new WebsocketSignalManager([{ server: broker1.url() }, { server: broker2.url() }]);
+    const client2 = new WebsocketSignalManager([{ server: broker1.url() }, { server: broker2.url() }]);
+    await openAndClose(client1, client2);
+
+    const [topic, peer1, peer2] = PublicKey.randomSequence();
+
+    const joined12 = expectPeerAvailable(client1, topic, peer2);
+    const joined21 = expectPeerAvailable(client2, topic, peer1);
+
+    await client1.join({ topic, peerId: peer1 });
+    await client2.join({ topic, peerId: peer2 });
+
+    await asyncTimeout(Promise.all([joined12, joined21]), 1_000);
+
+    const message = {
+      author: peer1,
+      recipient: peer2,
+      payload: { type_url: 'google.protobuf.Any', value: Uint8Array.from([1, 2, 3]) }
+    };
+
+    const received = expectReceivedMessage(client2, message);
+    await client2.subscribeMessages(peer2);
+    await sleep(50);
+    await client1.sendMessage(message);
+
+    await asyncTimeout(received, 1_000);
+  });
 
   test('works with one broken server', async () => {
     const client1 = new WebsocketSignalManager([{ server: 'ws://broken.server/signal' }, { server: broker1.url() }]);

--- a/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.test.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.test.ts
@@ -60,7 +60,7 @@ describe('WebSocketSignalManager', () => {
     .timeout(1_000)
     .retries(2);
 
-  test('join single swarm with doubled brokers', async () => {
+  test.only('join single swarm with doubled brokers', async () => {
     const client1 = new WebsocketSignalManager([{ server: broker1.url() }, { server: broker2.url() }]);
     const client2 = new WebsocketSignalManager([{ server: broker1.url() }, { server: broker2.url() }]);
     await openAndClose(client1, client2);

--- a/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.test.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.test.ts
@@ -9,7 +9,7 @@ import { afterAll, beforeAll, describe, test, openAndClose } from '@dxos/test';
 
 import { WebsocketSignalManager } from './websocket-signal-manager';
 
-describe('WebSocketSignalManager', () => {
+describe.only('WebSocketSignalManager', () => {
   let broker1: SignalServerRunner;
   let broker2: SignalServerRunner;
 
@@ -60,35 +60,34 @@ describe('WebSocketSignalManager', () => {
     .timeout(1_000)
     .retries(2);
 
-  test
-    .only('join single swarm with doubled brokers', async () => {
-      const client1 = new WebsocketSignalManager([{ server: broker1.url() }, { server: broker2.url() }]);
-      const client2 = new WebsocketSignalManager([{ server: broker1.url() }, { server: broker2.url() }]);
-      await openAndClose(client1, client2);
+  test('join single swarm with doubled brokers', async () => {
+    const client1 = new WebsocketSignalManager([{ server: broker1.url() }, { server: broker2.url() }]);
+    const client2 = new WebsocketSignalManager([{ server: broker1.url() }, { server: broker2.url() }]);
+    await openAndClose(client1, client2);
 
-      const [topic, peer1, peer2] = PublicKey.randomSequence();
+    const [topic, peer1, peer2] = PublicKey.randomSequence();
 
-      const joined12 = expectPeerAvailable(client1, topic, peer2);
-      const joined21 = expectPeerAvailable(client2, topic, peer1);
+    const joined12 = expectPeerAvailable(client1, topic, peer2);
+    const joined21 = expectPeerAvailable(client2, topic, peer1);
 
-      await client1.join({ topic, peerId: peer1 });
-      await client2.join({ topic, peerId: peer2 });
+    await client1.join({ topic, peerId: peer1 });
+    await client2.join({ topic, peerId: peer2 });
 
-      await asyncTimeout(Promise.all([joined12, joined21]), 1_000);
+    await asyncTimeout(Promise.all([joined12, joined21]), 1_000);
 
-      const message = {
-        author: peer1,
-        recipient: peer2,
-        payload: { type_url: 'google.protobuf.Any', value: Uint8Array.from([1, 2, 3]) }
-      };
+    const message = {
+      author: peer1,
+      recipient: peer2,
+      payload: { type_url: 'google.protobuf.Any', value: Uint8Array.from([1, 2, 3]) }
+    };
 
-      const received = expectReceivedMessage(client2, message);
-      await client2.subscribeMessages(peer2);
-      await sleep(50);
-      await client1.sendMessage(message);
+    const received = expectReceivedMessage(client2, message);
+    await client2.subscribeMessages(peer2);
+    await sleep(50);
+    await client1.sendMessage(message);
 
-      await asyncTimeout(received, 1_000);
-    })
+    await asyncTimeout(received, 1_000);
+  })
     .timeout(1_000)
     .retries(2);
 

--- a/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.test.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.test.ts
@@ -60,34 +60,37 @@ describe('WebSocketSignalManager', () => {
     .timeout(1_000)
     .retries(2);
 
-  test.only('join single swarm with doubled brokers', async () => {
-    const client1 = new WebsocketSignalManager([{ server: broker1.url() }, { server: broker2.url() }]);
-    const client2 = new WebsocketSignalManager([{ server: broker1.url() }, { server: broker2.url() }]);
-    await openAndClose(client1, client2);
+  test
+    .only('join single swarm with doubled brokers', async () => {
+      const client1 = new WebsocketSignalManager([{ server: broker1.url() }, { server: broker2.url() }]);
+      const client2 = new WebsocketSignalManager([{ server: broker1.url() }, { server: broker2.url() }]);
+      await openAndClose(client1, client2);
 
-    const [topic, peer1, peer2] = PublicKey.randomSequence();
+      const [topic, peer1, peer2] = PublicKey.randomSequence();
 
-    const joined12 = expectPeerAvailable(client1, topic, peer2);
-    const joined21 = expectPeerAvailable(client2, topic, peer1);
+      const joined12 = expectPeerAvailable(client1, topic, peer2);
+      const joined21 = expectPeerAvailable(client2, topic, peer1);
 
-    await client1.join({ topic, peerId: peer1 });
-    await client2.join({ topic, peerId: peer2 });
+      await client1.join({ topic, peerId: peer1 });
+      await client2.join({ topic, peerId: peer2 });
 
-    await asyncTimeout(Promise.all([joined12, joined21]), 1_000);
+      await asyncTimeout(Promise.all([joined12, joined21]), 1_000);
 
-    const message = {
-      author: peer1,
-      recipient: peer2,
-      payload: { type_url: 'google.protobuf.Any', value: Uint8Array.from([1, 2, 3]) }
-    };
+      const message = {
+        author: peer1,
+        recipient: peer2,
+        payload: { type_url: 'google.protobuf.Any', value: Uint8Array.from([1, 2, 3]) }
+      };
 
-    const received = expectReceivedMessage(client2, message);
-    await client2.subscribeMessages(peer2);
-    await sleep(50);
-    await client1.sendMessage(message);
+      const received = expectReceivedMessage(client2, message);
+      await client2.subscribeMessages(peer2);
+      await sleep(50);
+      await client1.sendMessage(message);
 
-    await asyncTimeout(received, 1_000);
-  });
+      await asyncTimeout(received, 1_000);
+    })
+    .timeout(1_000)
+    .retries(2);
 
   test('works with one broken server', async () => {
     const client1 = new WebsocketSignalManager([{ server: 'ws://broken.server/signal' }, { server: broker1.url() }]);

--- a/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.test.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.test.ts
@@ -9,7 +9,7 @@ import { afterAll, beforeAll, describe, test, openAndClose } from '@dxos/test';
 
 import { WebsocketSignalManager } from './websocket-signal-manager';
 
-describe.only('WebSocketSignalManager', () => {
+describe('WebSocketSignalManager', () => {
   let broker1: SignalServerRunner;
   let broker2: SignalServerRunner;
 

--- a/packages/core/mesh/network-manager/src/signal/integration.test.ts
+++ b/packages/core/mesh/network-manager/src/signal/integration.test.ts
@@ -9,17 +9,17 @@ import waitForExpect from 'wait-for-expect';
 
 import { PublicKey } from '@dxos/keys';
 import { Messenger, WebsocketSignalManager } from '@dxos/messaging';
-import { createTestBroker, TestBroker } from '@dxos/signal';
+import { runTestSignalServer, SignalServerRunner } from '@dxos/signal';
 import { afterAll, afterTest, beforeAll, describe, test } from '@dxos/test';
 
 import { MessageRouter } from './message-router';
 import { SignalMessage } from './signal-messenger';
 
 describe('Signal Integration Test', () => {
-  let broker: TestBroker;
+  let broker: SignalServerRunner;
 
   beforeAll(async () => {
-    broker = await createTestBroker();
+    broker = await runTestSignalServer();
   });
 
   afterAll(() => {

--- a/packages/core/mesh/network-manager/src/signal/message-router.test.ts
+++ b/packages/core/mesh/network-manager/src/signal/message-router.test.ts
@@ -11,7 +11,7 @@ import { Awaited } from '@dxos/async';
 import { PublicKey } from '@dxos/keys';
 import { Messenger, WebsocketSignalManager } from '@dxos/messaging';
 import { Answer } from '@dxos/protocols/proto/dxos/mesh/swarm';
-import { createTestBroker } from '@dxos/signal';
+import { runTestSignalServer } from '@dxos/signal';
 import { afterAll, beforeAll, describe, test, afterTest } from '@dxos/test';
 
 import { MessageRouter } from './message-router';
@@ -20,10 +20,10 @@ import { OfferMessage, SignalMessage } from './signal-messenger';
 describe('MessageRouter', () => {
   let topic: PublicKey;
 
-  let broker1: Awaited<ReturnType<typeof createTestBroker>>;
+  let broker1: Awaited<ReturnType<typeof runTestSignalServer>>;
 
   beforeAll(async () => {
-    broker1 = await createTestBroker();
+    broker1 = await runTestSignalServer();
   });
 
   beforeEach(() => {

--- a/packages/core/mesh/signal/src/index.ts
+++ b/packages/core/mesh/signal/src/index.ts
@@ -2,4 +2,4 @@
 // Copyright 2022 DXOS.org
 //
 
-export * from './test-broker';
+export * from './signal-server-runner';

--- a/packages/core/mesh/signal/src/signal-server-runner.ts
+++ b/packages/core/mesh/signal/src/signal-server-runner.ts
@@ -34,7 +34,7 @@ export class SignalServerRunner {
   private readonly _timeout: number;
   private _serverProcess: ChildProcessWithoutNullStreams;
 
-  constructor({ binCommand, signalArguments, cwd, port = 8080, timeout = 5_000, env = {}}: TestBrokerOptions) {
+  constructor({ binCommand, signalArguments, cwd, port = 8080, timeout = 5_000, env = {} }: TestBrokerOptions) {
     this._binCommand = binCommand;
     this._signalArguments = signalArguments;
     this._cwd = cwd;
@@ -46,7 +46,7 @@ export class SignalServerRunner {
   }
 
   public startProcess(): ChildProcessWithoutNullStreams {
-    log(`starting`, {
+    log('starting', {
       binCommand: this._binCommand,
       signalArguments: this._signalArguments,
       cwd: this._cwd,

--- a/packages/core/mesh/signal/src/signal-server-runner.ts
+++ b/packages/core/mesh/signal/src/signal-server-runner.ts
@@ -43,7 +43,12 @@ export class SignalServerRunner {
   }
 
   public startProcess(): ChildProcessWithoutNullStreams {
-    log(`Starting ${this._binCommand} (cwd: ${this._cwd})`);
+    log(`starting`, {
+      binCommand: this._binCommand,
+      signalArguments: this._signalArguments,
+      cwd: this._cwd,
+      port: this._port
+    });
     if (this._cwd && !fs.existsSync(this._cwd)) {
       throw new Error(`CWD not exists: ${this._cwd}`);
     }

--- a/packages/core/mesh/signal/src/signal-server-runner.ts
+++ b/packages/core/mesh/signal/src/signal-server-runner.ts
@@ -4,7 +4,6 @@
 
 import fetch from 'node-fetch';
 import { ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
-import { assert } from 'node:console';
 import path, { dirname } from 'node:path';
 import pkgUp from 'pkg-up';
 
@@ -95,8 +94,7 @@ export class SignalServerRunner {
   }
 
   public stop(): void {
-    assert(!!this._serverProcess, 'Server process is not running');
-    this._serverProcess!.kill('SIGINT');
+    this._serverProcess.kill('SIGINT');
   }
 
   public url(): string {

--- a/packages/core/mesh/signal/src/signal-server-runner.ts
+++ b/packages/core/mesh/signal/src/signal-server-runner.ts
@@ -77,7 +77,7 @@ export class SignalServerRunner {
     });
 
     server.on('close', (code) => {
-      log(`TestServer exited with code ${code}`);
+      log.info(`TestServer exited with code ${code}`);
     });
 
     this._serverProcess = server;
@@ -111,7 +111,10 @@ export class SignalServerRunner {
   }
 
   public stop(): void {
-    this._serverProcess.kill('SIGTERM');
+    const delivered = this._serverProcess.kill('SIGINT');
+    if (!delivered) {
+      log.warn('kill signal was not delivered to child process');
+    }
   }
 
   public url(): string {

--- a/packages/core/mesh/signal/src/signal-server-runner.ts
+++ b/packages/core/mesh/signal/src/signal-server-runner.ts
@@ -12,7 +12,7 @@ import { log } from '@dxos/log';
 import { randomInt } from '@dxos/util';
 
 interface TestBrokerOptions {
-  binPath: string;
+  binCommand: string;
   cwd: string;
   signalArguments: string[];
   port?: number;
@@ -21,7 +21,7 @@ interface TestBrokerOptions {
 
 // TODO(burdon): Convert to TestBuilder pattern.
 export class SignalServerRunner {
-  private readonly _binPath: string;
+  private readonly _binCommand: string;
   private readonly _signalArguments: string[];
   private readonly _cwd?: string;
 
@@ -31,8 +31,8 @@ export class SignalServerRunner {
   private readonly _timeout: number;
   private _serverProcess: ChildProcessWithoutNullStreams;
 
-  constructor({ binPath, cwd, signalArguments, port = 8080, timeout = 5_000 }: TestBrokerOptions) {
-    this._binPath = binPath;
+  constructor({ binCommand: binPath, cwd, signalArguments, port = 8080, timeout = 5_000 }: TestBrokerOptions) {
+    this._binCommand = binPath;
     this._signalArguments = signalArguments;
     this._cwd = cwd;
     this._port = port;
@@ -42,8 +42,8 @@ export class SignalServerRunner {
   }
 
   public startProcess(): ChildProcessWithoutNullStreams {
-    log(`Starting ${this._binPath} (cwd: ${this._cwd})`);
-    const server = spawn(this._binPath, ['-port', this._port.toString(), ...this._signalArguments], {
+    log(`Starting ${this._binCommand} (cwd: ${this._cwd})`);
+    const server = spawn(this._binCommand, ['-port', this._port.toString(), ...this._signalArguments], {
       cwd: this._cwd
     });
 
@@ -126,7 +126,7 @@ export const runTestSignalServer = async (port?: number): Promise<SignalServerRu
   const binPath = `./signal-test-${OS}-${ARCH}`;
 
   const server = new SignalServerRunner({
-    binPath,
+    binCommand: binPath,
     signalArguments: ['server'],
     cwd: path.join(dirname(pkgUp.sync({ cwd: __dirname })!), 'bin'),
     port: port ?? randomInt(10000, 50000)

--- a/packages/core/mesh/signal/src/signal-server-runner.ts
+++ b/packages/core/mesh/signal/src/signal-server-runner.ts
@@ -48,7 +48,8 @@ export class SignalServerRunner {
       throw new Error(`CWD not exists: ${this._cwd}`);
     }
     const server = spawn(this._binCommand, [...this._signalArguments, '--port', this._port.toString()], {
-      cwd: this._cwd
+      cwd: this._cwd,
+      shell: true
     });
 
     server.stdout.on('data', (data) => {

--- a/packages/core/mesh/signal/src/signal-server-runner.ts
+++ b/packages/core/mesh/signal/src/signal-server-runner.ts
@@ -18,6 +18,7 @@ interface TestBrokerOptions {
   cwd?: string;
   port?: number;
   timeout?: number;
+  env?: Record<string, string>;
 }
 
 // TODO(burdon): Convert to TestBuilder pattern.
@@ -25,6 +26,7 @@ export class SignalServerRunner {
   private readonly _binCommand: string;
   private readonly _signalArguments: string[];
   private readonly _cwd?: string;
+  private readonly _env: Record<string, string>;
 
   private _startRetries = 0;
   private readonly _retriesLimit = 3;
@@ -32,12 +34,13 @@ export class SignalServerRunner {
   private readonly _timeout: number;
   private _serverProcess: ChildProcessWithoutNullStreams;
 
-  constructor({ binCommand, signalArguments, cwd, port = 8080, timeout = 5_000 }: TestBrokerOptions) {
+  constructor({ binCommand, signalArguments, cwd, port = 8080, timeout = 5_000, env = {}}: TestBrokerOptions) {
     this._binCommand = binCommand;
     this._signalArguments = signalArguments;
     this._cwd = cwd;
     this._port = port;
     this._timeout = timeout;
+    this._env = env;
 
     this._serverProcess = this.startProcess();
   }
@@ -54,7 +57,11 @@ export class SignalServerRunner {
     }
     const server = spawn(this._binCommand, [...this._signalArguments, '--port', this._port.toString()], {
       cwd: this._cwd,
-      shell: true
+      shell: true,
+      env: {
+        ...process.env,
+        ...this._env
+      }
     });
 
     server.stdout.on('data', (data) => {

--- a/packages/core/mesh/signal/src/signal-server-runner.ts
+++ b/packages/core/mesh/signal/src/signal-server-runner.ts
@@ -19,6 +19,7 @@ interface TestBrokerOptions {
   port?: number;
   timeout?: number;
   env?: Record<string, string>;
+  shell?: boolean;
 }
 
 // TODO(burdon): Convert to TestBuilder pattern.
@@ -27,6 +28,7 @@ export class SignalServerRunner {
   private readonly _signalArguments: string[];
   private readonly _cwd?: string;
   private readonly _env: Record<string, string>;
+  private readonly _shell: boolean;
 
   private _startRetries = 0;
   private readonly _retriesLimit = 3;
@@ -34,13 +36,22 @@ export class SignalServerRunner {
   private readonly _timeout: number;
   private _serverProcess: ChildProcessWithoutNullStreams;
 
-  constructor({ binCommand, signalArguments, cwd, port = 8080, timeout = 5_000, env = {} }: TestBrokerOptions) {
+  constructor({
+    binCommand,
+    signalArguments,
+    cwd,
+    port = 8080,
+    timeout = 5_000,
+    env = {},
+    shell = false
+  }: TestBrokerOptions) {
     this._binCommand = binCommand;
     this._signalArguments = signalArguments;
     this._cwd = cwd;
     this._port = port;
     this._timeout = timeout;
     this._env = env;
+    this._shell = shell;
 
     this._serverProcess = this.startProcess();
   }
@@ -57,7 +68,7 @@ export class SignalServerRunner {
     }
     const server = spawn(this._binCommand, [...this._signalArguments, '--port', this._port.toString()], {
       cwd: this._cwd,
-      shell: true,
+      shell: this._shell,
       env: {
         ...process.env,
         ...this._env

--- a/packages/core/mesh/signal/src/signal-server-runner.ts
+++ b/packages/core/mesh/signal/src/signal-server-runner.ts
@@ -58,7 +58,7 @@ export class SignalServerRunner {
     });
 
     server.stdout.on('data', (data) => {
-      log(`TestServer stdout: ${data}`);
+      log.info(`TestServer stdout: ${data}`);
     });
 
     server.stderr.on('data', (data) => {
@@ -104,7 +104,7 @@ export class SignalServerRunner {
   }
 
   public stop(): void {
-    this._serverProcess.kill('SIGINT');
+    this._serverProcess.kill('SIGTERM');
   }
 
   public url(): string {

--- a/packages/core/mesh/signal/src/signal-server-runner.ts
+++ b/packages/core/mesh/signal/src/signal-server-runner.ts
@@ -13,8 +13,8 @@ import { randomInt } from '@dxos/util';
 
 interface TestBrokerOptions {
   binCommand: string;
-  cwd: string;
   signalArguments: string[];
+  cwd?: string;
   port?: number;
   timeout?: number;
 }
@@ -31,8 +31,8 @@ export class SignalServerRunner {
   private readonly _timeout: number;
   private _serverProcess: ChildProcessWithoutNullStreams;
 
-  constructor({ binCommand: binPath, cwd, signalArguments, port = 8080, timeout = 5_000 }: TestBrokerOptions) {
-    this._binCommand = binPath;
+  constructor({ binCommand, signalArguments, cwd, port = 8080, timeout = 5_000 }: TestBrokerOptions) {
+    this._binCommand = binCommand;
     this._signalArguments = signalArguments;
     this._cwd = cwd;
     this._port = port;

--- a/packages/core/mesh/signal/src/signal-server-runner.ts
+++ b/packages/core/mesh/signal/src/signal-server-runner.ts
@@ -19,6 +19,10 @@ interface TestBrokerOptions {
   port?: number;
   timeout?: number;
   env?: Record<string, string>;
+
+  /**
+   * Allows arbitrary commands. WARNING: It stalls on Linux machine if `true`.
+   */
   shell?: boolean;
 }
 

--- a/packages/core/mesh/signal/testing/setup.js
+++ b/packages/core/mesh/signal/testing/setup.js
@@ -7,6 +7,6 @@ const { runTestSignalServer } = require('@dxos/signal');
 
 module.exports = {
   setup: async () => {
-    await runTestSignalServer(4000);
+    await runTestSignalServer({ port: 4000 });
   }
 };

--- a/packages/core/mesh/signal/testing/setup.js
+++ b/packages/core/mesh/signal/testing/setup.js
@@ -3,10 +3,10 @@
 //
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { createTestBroker } = require('@dxos/signal');
+const { runTestSignalServer } = require('@dxos/signal');
 
 module.exports = {
   setup: async () => {
-    await createTestBroker(4000);
+    await runTestSignalServer(4000);
   }
 };

--- a/packages/gravity/kube-testing/package.json
+++ b/packages/gravity/kube-testing/package.json
@@ -9,15 +9,25 @@
   "author": "DXOS.org",
   "type": "module",
   "scripts": {
-    "run-tests": "node --loader ts-node/esm  ./src/main.ts"
+    "run-tests": "node ./dist/lib/node/main.cjs"
   },
   "dependencies": {
+    "@dxos/async": "workspace:*",
+    "@dxos/context": "workspace:*",
+    "@dxos/keys": "workspace:*",
+    "@dxos/log": "workspace:*",
+    "@dxos/messaging": "workspace:*",
     "@dxos/node-std": "workspace:*",
+    "@dxos/protocols": "workspace:*",
     "@dxos/signal": "workspace:*",
-    "@dxos/util": "workspace:*"
+    "@dxos/util": "workspace:*",
+    "faker": "^5.5.3",
+    "seedrandom": "^3.0.5"
   },
   "devDependencies": {
+    "@types/faker": "^5.5.9",
     "@types/node": "^18.11.9",
+    "@types/seedrandom": "^3.0.5",
     "ts-node": "10.9.1",
     "typescript": "^4.8.4"
   },

--- a/packages/gravity/kube-testing/package.json
+++ b/packages/gravity/kube-testing/package.json
@@ -7,16 +7,19 @@
   "bugs": "https://github.com/dxos/dxos/issues",
   "license": "MIT",
   "author": "DXOS.org",
-  "main": "dist/lib/node/index.cjs",
-  "browser": {
-    "./dist/lib/node/index.cjs": "./dist/lib/browser/index.mjs"
-  },
-  "types": "dist/types/src/index.d.ts",
+  "type": "module",
   "scripts": {
-    "check": "true"
+    "run-tests": "node --loader ts-node/esm  ./src/main.ts"
   },
   "dependencies": {
-    "@dxos/signal": "workspace:*"
+    "@dxos/node-std": "workspace:*",
+    "@dxos/signal": "workspace:*",
+    "@dxos/util": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^18.11.9",
+    "ts-node": "10.9.1",
+    "typescript": "^4.8.4"
   },
   "publishConfig": {
     "access": "restricted"

--- a/packages/gravity/kube-testing/package.json
+++ b/packages/gravity/kube-testing/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@dxos/kube-testing",
+  "version": "0.1.41",
+  "private": true,
+  "description": "KUBE Testing.",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "license": "MIT",
+  "author": "DXOS.org",
+  "main": "dist/lib/node/index.cjs",
+  "browser": {
+    "./dist/lib/node/index.cjs": "./dist/lib/browser/index.mjs"
+  },
+  "types": "dist/types/src/index.d.ts",
+  "scripts": {
+    "check": "true"
+  },
+  "dependencies": {
+    "@dxos/signal": "workspace:*"
+  },
+  "publishConfig": {
+    "access": "restricted"
+  }
+}

--- a/packages/gravity/kube-testing/package.json
+++ b/packages/gravity/kube-testing/package.json
@@ -7,9 +7,8 @@
   "bugs": "https://github.com/dxos/dxos/issues",
   "license": "MIT",
   "author": "DXOS.org",
-  "type": "module",
   "scripts": {
-    "run-tests": "node ./dist/lib/node/main.cjs"
+    "run-tests": "node -r ts-node/register ./src/main.ts"
   },
   "dependencies": {
     "@dxos/async": "workspace:*",

--- a/packages/gravity/kube-testing/project.json
+++ b/packages/gravity/kube-testing/project.json
@@ -1,0 +1,68 @@
+{
+  "sourceRoot": "packages/gravity/kube-testing/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "options": {
+        "main": "packages/gravity/kube-testing/src/index.ts",
+        "outputPath": "packages/gravity/kube-testing/dist/types",
+        "tsConfig": "packages/gravity/kube-testing/tsconfig.json"
+      },
+      "outputs": [
+        "{options.outputPath}"
+      ]
+    },
+    "compile": {
+      "executor": "@dxos/esbuild:build",
+      "options": {
+        "entryPoints": [
+          "packages/gravity/kube-testing/src/main.ts"
+        ],
+        "outputPath": "packages/gravity/kube-testing/dist/lib"
+      },
+      "outputs": [
+        "{options.outputPath}"
+      ]
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "options": {
+        "format": "unix",
+        "lintFilePatterns": [
+          "packages/gravity/kube-testing/**/*.{ts,tsx,js,jsx}"
+        ]
+      },
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    },
+    "test": {
+      "executor": "@dxos/test:run",
+      "options": {
+        "coveragePath": "coverage/packages/gravity/kube-testing",
+        "environments": [
+          "nodejs"
+        ],
+        "outputPath": "tmp/mocha/packages/gravity/kube-testing",
+        "resultsPath": "test-results/packages/gravity/kube-testing",
+        "setup": "packages/core/mesh/signal/testing/setup.js",
+        "testPatterns": [
+          "packages/gravity/kube-testing/src/**/*.test.{ts,js}"
+        ],
+        "watchPatterns": [
+          "packages/gravity/kube-testing/src/**/*"
+        ]
+      },
+      "outputs": [
+        "{options.coveragePath}",
+        "{options.outputPath}",
+        "{options.resultsPath}"
+      ]
+    }
+  },
+  "implicitDependencies": [
+    "esbuild",
+    "test"
+  ]
+}

--- a/packages/gravity/kube-testing/project.json
+++ b/packages/gravity/kube-testing/project.json
@@ -2,17 +2,6 @@
   "sourceRoot": "packages/gravity/kube-testing/src",
   "projectType": "library",
   "targets": {
-    "build": {
-      "executor": "@nrwl/js:tsc",
-      "options": {
-        "main": "packages/gravity/kube-testing/src/index.ts",
-        "outputPath": "packages/gravity/kube-testing/dist/types",
-        "tsConfig": "packages/gravity/kube-testing/tsconfig.json"
-      },
-      "outputs": [
-        "{options.outputPath}"
-      ]
-    },
     "compile": {
       "executor": "@dxos/esbuild:build",
       "options": {
@@ -36,33 +25,6 @@
       "outputs": [
         "{options.outputFile}"
       ]
-    },
-    "test": {
-      "executor": "@dxos/test:run",
-      "options": {
-        "coveragePath": "coverage/packages/gravity/kube-testing",
-        "environments": [
-          "nodejs"
-        ],
-        "outputPath": "tmp/mocha/packages/gravity/kube-testing",
-        "resultsPath": "test-results/packages/gravity/kube-testing",
-        "setup": "packages/core/mesh/signal/testing/setup.js",
-        "testPatterns": [
-          "packages/gravity/kube-testing/src/**/*.test.{ts,js}"
-        ],
-        "watchPatterns": [
-          "packages/gravity/kube-testing/src/**/*"
-        ]
-      },
-      "outputs": [
-        "{options.coveragePath}",
-        "{options.outputPath}",
-        "{options.resultsPath}"
-      ]
     }
-  },
-  "implicitDependencies": [
-    "esbuild",
-    "test"
-  ]
+  }
 }

--- a/packages/gravity/kube-testing/readme.md
+++ b/packages/gravity/kube-testing/readme.md
@@ -1,4 +1,4 @@
 ## How to run tests
-1. Specify path to kube repo path constant `PATH_TO_KUBE_REPO` in `src/run-test-signal.ts`
+1. Specify path to kube repo in constant `PATH_TO_KUBE_REPO` at `src/run-test-signal.ts`
 2. Compile package with `pnpm -w nx compile kube-testing`
 3. Run tests with `pnpm run run-tests`

--- a/packages/gravity/kube-testing/readme.md
+++ b/packages/gravity/kube-testing/readme.md
@@ -1,0 +1,4 @@
+## How to run tests
+1. Specify path to kube repo path constant `PATH_TO_KUBE_REPO` in `src/run-test-signal.ts`
+2. Compile package with `pnpm -w nx compile kube-testing`
+3. Run tests with `pnpm run run-tests`

--- a/packages/gravity/kube-testing/src/analysys/per-peer.ts
+++ b/packages/gravity/kube-testing/src/analysys/per-peer.ts
@@ -1,13 +1,17 @@
-import { readFileSync } from "fs";
+//
+// Copyright 2023 DXOS.org
+//
+
+import { readFileSync } from 'fs';
 
 const data = JSON.parse(readFileSync(process.argv[2], 'utf8'));
 
-const { testConfig, shortStats, stats } = data;
+const { stats } = data;
 
 const statsPerPeer = new Map();
 
 // const key = 'peerThatDiscovering'
-const key = 'peerToDiscover'
+const key = 'peerToDiscover';
 
 for (const evt of stats.failures) {
   const peer = evt.action[key];
@@ -16,8 +20,6 @@ for (const evt of stats.failures) {
     discoveredPeers: 0,
     exchangedMessages: 0
   };
-
-
   counters.failures++;
   statsPerPeer.set(peer, counters);
 }
@@ -29,8 +31,6 @@ for (const evt of stats.exchangedMessages) {
     discoveredPeers: 0,
     exchangedMessages: 0
   };
-
-
   counters.exchangedMessages++;
   statsPerPeer.set(peer, counters);
 }
@@ -49,6 +49,6 @@ for (const evt of stats.discoveredPeers) {
 
 const output = Array.from(statsPerPeer.entries()).sort((a, b) => b[1].failures - a[1].failures);
 
-for(const [peer, counters] of output) {
-  console.log(`${peer}: ${counters.failures} ${(counters.failures / counters.discoveredPeers * 100).toFixed(2)}%`);
+for (const [peer, counters] of output) {
+  console.log(`${peer}: ${counters.failures} ${((counters.failures / counters.discoveredPeers) * 100).toFixed(2)}%`);
 }

--- a/packages/gravity/kube-testing/src/analysys/per-peer.ts
+++ b/packages/gravity/kube-testing/src/analysys/per-peer.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "fs";
+
+const data = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+
+const { testConfig, shortStats, stats } = data;
+
+const statsPerPeer = new Map();
+
+for (const failure of stats.failures) {
+  const peer = failure.action.peerThatDiscovering;
+  const counters = statsPerPeer.get(peer) ?? {
+    failures: 0,
+    discoveredPeers: 0,
+    exchangedMessages: 0
+  };
+
+
+  counters.failures++;
+  statsPerPeer.set(peer, counters);
+}
+
+for (const failure of stats.exchangedMessages) {
+  const peer = failure.action.peerThatDiscovering;
+  const counters = statsPerPeer.get(peer) ?? {
+    failures: 0,
+    discoveredPeers: 0,
+    exchangedMessages: 0
+  };
+
+
+  counters.exchangedMessages++;
+  statsPerPeer.set(peer, counters);
+}
+
+for (const failure of stats.discoveredPeers) {
+  const peer = failure.peerThatDiscovering;
+  const counters = statsPerPeer.get(peer) ?? {
+    failures: 0,
+    discoveredPeers: 0,
+    exchangedMessages: 0
+  };
+
+  counters.discoveredPeers++;
+  statsPerPeer.set(peer, counters);
+}
+
+const output = Array.from(statsPerPeer.entries()).sort((a, b) => b[1].failures - a[1].failures);
+
+for(const [peer, counters] of output) {
+  console.log(`${peer}: ${counters.failures} ${(counters.failures / counters.discoveredPeers * 100).toFixed(2)}%`);
+}

--- a/packages/gravity/kube-testing/src/analysys/per-peer.ts
+++ b/packages/gravity/kube-testing/src/analysys/per-peer.ts
@@ -6,8 +6,11 @@ const { testConfig, shortStats, stats } = data;
 
 const statsPerPeer = new Map();
 
-for (const failure of stats.failures) {
-  const peer = failure.action.peerThatDiscovering;
+// const key = 'peerThatDiscovering'
+const key = 'peerToDiscover'
+
+for (const evt of stats.failures) {
+  const peer = evt.action[key];
   const counters = statsPerPeer.get(peer) ?? {
     failures: 0,
     discoveredPeers: 0,
@@ -19,8 +22,8 @@ for (const failure of stats.failures) {
   statsPerPeer.set(peer, counters);
 }
 
-for (const failure of stats.exchangedMessages) {
-  const peer = failure.action.peerThatDiscovering;
+for (const evt of stats.exchangedMessages) {
+  const peer = evt.action[key];
   const counters = statsPerPeer.get(peer) ?? {
     failures: 0,
     discoveredPeers: 0,
@@ -32,8 +35,8 @@ for (const failure of stats.exchangedMessages) {
   statsPerPeer.set(peer, counters);
 }
 
-for (const failure of stats.discoveredPeers) {
-  const peer = failure.peerThatDiscovering;
+for (const evt of stats.discoveredPeers) {
+  const peer = evt[key];
   const counters = statsPerPeer.get(peer) ?? {
     failures: 0,
     discoveredPeers: 0,

--- a/packages/gravity/kube-testing/src/index.ts
+++ b/packages/gravity/kube-testing/src/index.ts
@@ -1,3 +1,0 @@
-//
-// Copyright 2023 DXOS.org
-//

--- a/packages/gravity/kube-testing/src/index.ts
+++ b/packages/gravity/kube-testing/src/index.ts
@@ -1,0 +1,3 @@
+//
+// Copyright 2023 DXOS.org
+//

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -1,0 +1,3 @@
+//
+// Copyright 2023 DXOS.org
+//

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -88,6 +88,9 @@ const test = async () => {
     );
   }
 
+  // NOTE: Sometimes first message is not dropped if it is sent too soon.
+  await sleep(1_000)
+
   //
   // test
   //

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -27,10 +27,10 @@ type TestConfig = {
 };
 
 const testConfig: TestConfig = {
-  servers: 1,
-  agents: 200,
+  servers: 2,
+  agents: 40,
   serversPerAgent: 1,
-  topicCount: 100,
+  topicCount: 1,
   topicsPerAgent: 1,
   discoverTimeout: 5_000,
   repeatInterval: 0,
@@ -53,6 +53,8 @@ const setupTest = async (builder: TestBuilder, testConfig: TestConfig, stats: St
       })),
       testConfig.serversPerAgent
     );
+
+    // const signals = [{ server: 'ws://localhost:1337/.well-known/dx/signal'}];
 
     // NOTE: Opening too many connections too fast causes some of them to be dropped.
     await sleep(5)
@@ -115,7 +117,7 @@ const test = async () => {
 
           await Promise.all(
             Array.from(stats.topics.entries()).map(([topic, agents]) =>
-              Promise.all(Array.from(agents.values()).map((agent) => cancelWithContext(ctx, agent.discoverPeers(topic))))
+              Promise.all(Array.from(agents.values()).map((agent) => cancelWithContext(ctx, agent.discoverPeers(topic, testConfig.discoverTimeout))))
             )
           );
 

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -51,6 +51,9 @@ const setupTest = async (builder: TestBuilder, testConfig: TestConfig, stats: St
       })),
       testConfig.serversPerAgent
     );
+
+    // NOTE: Opening too many connections too fast causes some of them to be dropped.
+    await sleep(5)
     await builder.createPeer({ signals, stats });
   }
 };

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -129,6 +129,7 @@ const test = async () => {
   //
   {
     log.info('Short stats', stats.shortStats);
+    fs.mkdirSync('./out/results', { recursive: true })
     fs.writeFileSync(
       `./out/results/stats${testConfig.randomSeed}.json`,
       JSON.stringify({ testConfig, shortStats: stats.shortStats, stats: stats.performance }, null, 2)

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -41,9 +41,9 @@ const testConfig: TestConfig = {
 
 seedrandom(testConfig.randomSeed, { global: true });
 
-const setupTest = async (builder: TestBuilder, testConfig: TestConfig, stats: Stats) => {
-  for (const _ of range(testConfig.servers)) {
-    await builder.createServer();
+const setupTest = async (builder: TestBuilder, testConfig: TestConfig, stats: Stats, outFolder: string) => {
+  for (const num of range(testConfig.servers)) {
+    await builder.createServer(num, outFolder);
   }
 
   for (const _ of range(testConfig.agents)) {
@@ -78,10 +78,13 @@ const test = async () => {
 
   const topics = Array.from(range(testConfig.topicCount)).map(() => PublicKey.random());
 
+  const outFolder = `${process.cwd()}/out/results/${new Date().toISOString()}`
+
   {
     log.info('Test setup...', testConfig);
+    fs.mkdirSync(outFolder, { recursive: true })
 
-    await setupTest(builder, testConfig, stats);
+    await setupTest(builder, testConfig, stats, outFolder);
 
     log.info('Test setup complete');
     log.info(
@@ -153,8 +156,7 @@ const test = async () => {
   //
   {
     log.info('Short stats', stats.shortStats);
-    fs.mkdirSync('./out/results', { recursive: true })
-    const fileName = `./out/results/stats-${new Date().toISOString()}.json`
+    const fileName = `${outFolder}/stats.json`
     fs.writeFileSync(fileName, JSON.stringify({ testConfig, shortStats: stats.shortStats, stats: stats.performance }, null, 2));
     log.info('Stats written to file', { fileName })
     console.log(`stats file: ${fileName}`)

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -1,23 +1,91 @@
 //
 // Copyright 2023 DXOS.org
 //
-import path from 'node:path';
 
-import { SignalServerRunner } from '@dxos/signal';
-import { randomInt } from '@dxos/util';
+import seedrandom from 'seedrandom';
 
-const PATH_TO_KUBE_REPO = '/Users/mykola/Documents/dev/kube/';
+import { PublicKey } from '@dxos/keys';
+import { log } from '@dxos/log';
+import { range } from '@dxos/util';
 
-const startSignalServer = async () => {
-  debugger;
-  const binPath = path.join(PATH_TO_KUBE_REPO, 'cmds/signal/signal-test/main.go');
-  const signalRunner = new SignalServerRunner({
-    binCommand: `go run ${binPath}`,
-    signalArguments: ['p2pserver'],
-    port: randomInt(10000, 50000)
-  });
-  await signalRunner.waitUntilStarted();
-  return signalRunner;
+import { Stats, TestBuilder } from './test-builder';
+
+type TestConfig = {
+  servers: number;
+  agents: number;
+  serversPerAgent: number;
+  topics: PublicKey[];
+  topicsPerAgent: number;
+  randomSeed: string;
 };
 
-await startSignalServer();
+const testConfig = {
+  servers: 1,
+  agents: 2,
+  serversPerAgent: 1,
+  topics: [PublicKey.random()],
+  topicsPerAgent: 1,
+  randomSeed: PublicKey.random().toHex()
+};
+
+seedrandom(testConfig.randomSeed, { global: true });
+
+const setupTest = async (builder: TestBuilder, testConfig: TestConfig, stats: Stats) => {
+  for (const _ of range(testConfig.servers)) {
+    await builder.createServer();
+  }
+
+  for (const _ of range(testConfig.agents)) {
+    const signals = randomArraySlice(
+      builder.servers.map((server) => ({
+        server: server.url()
+      })),
+      testConfig.serversPerAgent
+    );
+    await builder.createPeer({ signals, stats });
+  }
+};
+
+const randomArraySlice = <T>(array: T[], size: number) => {
+  const result = [];
+  const arrayCopy = [...array];
+  for (let i = 0; i < size; i++) {
+    const randomIndex = Math.floor(Math.random() * arrayCopy.length);
+    result.push(arrayCopy[randomIndex]);
+    arrayCopy.splice(randomIndex, 1);
+  }
+  return result;
+};
+
+const test = async () => {
+  const builder = new TestBuilder();
+  const stats = new Stats();
+
+  await setupTest(builder, testConfig, stats);
+  log.info('Test setup complete');
+  log.info(
+    'Servers',
+    builder.servers.map((s) => s.url())
+  );
+
+  for (const peer of builder.peers) {
+    for (const topic of randomArraySlice(testConfig.topics, testConfig.topicsPerAgent)) {
+      await peer.joinTopic(topic);
+    }
+  }
+
+  await Promise.all(
+    Array.from(stats.topics.entries()).map(([topic, agents]) =>
+      Promise.all(Array.from(agents.values()).map((agent) => agent.discoverPeers(topic)))
+    )
+  );
+  
+  await builder.destroy();
+
+  log.info('Test config', testConfig);
+  log.info('Stats', stats.performance);
+};
+
+test()
+  .then(() => log.info('Done'))
+  .catch((e) => log.catch(e));

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -1,3 +1,23 @@
 //
 // Copyright 2023 DXOS.org
 //
+import path from 'node:path';
+
+import { SignalServerRunner } from '@dxos/signal';
+import { randomInt } from '@dxos/util';
+
+const PATH_TO_KUBE_REPO = '/Users/mykola/Documents/dev/kube/';
+
+const startSignalServer = async () => {
+  debugger;
+  const binPath = path.join(PATH_TO_KUBE_REPO, 'cmds/signal/signal-test/main.go');
+  const signalRunner = new SignalServerRunner({
+    binCommand: `go run ${binPath}`,
+    signalArguments: ['p2pserver'],
+    port: randomInt(10000, 50000)
+  });
+  await signalRunner.waitUntilStarted();
+  return signalRunner;
+};
+
+await startSignalServer();

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -27,7 +27,7 @@ type TestConfig = {
 
 const testConfig: TestConfig = {
   servers: 1,
-  agents: 20,
+  agents: 200,
   serversPerAgent: 1,
   topics: [PublicKey.random(), PublicKey.random(), PublicKey.random(), PublicKey.random(), PublicKey.random()],
   topicsPerAgent: 2,
@@ -108,7 +108,7 @@ const test = async () => {
           Promise.all(Array.from(agents.values()).map((agent) => cancelWithContext(ctx, agent.leaveTopic(topic))))
         )
       );
-      log.info('iteration finished');
+      log.info('iteration finished', stats.shortStats);
     },
     testConfig.repeatInterval
   );
@@ -134,6 +134,7 @@ const test = async () => {
       `./out/results/stats${testConfig.randomSeed}.json`,
       JSON.stringify({ testConfig, shortStats: stats.shortStats, stats: stats.performance }, null, 2)
     );
+    log.info('Stats written to file', { fileName: `./out/results/stats${testConfig.randomSeed}.json` })
   }
 };
 

--- a/packages/gravity/kube-testing/src/run-test-signal.ts
+++ b/packages/gravity/kube-testing/src/run-test-signal.ts
@@ -1,0 +1,35 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { SignalServerRunner } from '@dxos/signal';
+import { randomInt } from '@dxos/util';
+
+const PATH_TO_KUBE_REPO = '/Users/mykola/Documents/dev/kube/';
+const BIN_PATH = './cmds/signal-test/main.go';
+// const PATH_TO_KUBE_REPO = '/Users/mykola/Documents/dev/dxos/packages/gravity/kube-testing/src/';
+// const binPath = 'hello-world.go';
+
+{
+  if (!fs.existsSync(PATH_TO_KUBE_REPO)) {
+    throw new Error(`Kube repo not exists: ${PATH_TO_KUBE_REPO}`);
+  }
+
+  if (!fs.existsSync(path.join(PATH_TO_KUBE_REPO, BIN_PATH))) {
+    throw new Error(`Bin not exists: ${path.join(PATH_TO_KUBE_REPO, BIN_PATH)}`);
+  }
+}
+
+export const runSignal = async () => {
+  const runner = new SignalServerRunner({
+    port: randomInt(10000, 20000),
+    binCommand: `go run ${BIN_PATH}`,
+    signalArguments: ['p2pserver'],
+    cwd: PATH_TO_KUBE_REPO
+  });
+  await runner.waitUntilStarted();
+  return runner;
+};

--- a/packages/gravity/kube-testing/src/run-test-signal.ts
+++ b/packages/gravity/kube-testing/src/run-test-signal.ts
@@ -28,7 +28,7 @@ export const runSignal = async () => {
   const runner = new SignalServerRunner({
     port: randomInt(10000, 20000),
     binCommand: `go run ${BIN_PATH}`,
-    signalArguments: ['p2pserver'],
+    signalArguments: ['p2pserver',],
     cwd: PATH_TO_KUBE_REPO
   });
   await runner.waitUntilStarted();

--- a/packages/gravity/kube-testing/src/run-test-signal.ts
+++ b/packages/gravity/kube-testing/src/run-test-signal.ts
@@ -24,12 +24,17 @@ const BIN_PATH = './cmds/signal-test/main.go';
   }
 }
 
-export const runSignal = async () => {
+export const runSignal = async (num: number, outFolder: string) => {
   const runner = new SignalServerRunner({
     port: randomInt(10000, 20000),
     binCommand: `go run ${BIN_PATH}`,
     signalArguments: ['p2pserver',],
-    cwd: PATH_TO_KUBE_REPO
+    cwd: PATH_TO_KUBE_REPO,
+    env: {
+      'GOLOG_FILE': `${outFolder}/signal-${num}.log`,
+      'GOLOG_OUTPUT':'file',
+      'GOLOG_LOG_FMT':'json',
+    }
   });
   await runner.waitUntilStarted();
   return runner;

--- a/packages/gravity/kube-testing/src/run-test-signal.ts
+++ b/packages/gravity/kube-testing/src/run-test-signal.ts
@@ -27,8 +27,11 @@ const BIN_PATH = './cmds/signal-test/main.go';
 export const runSignal = async (num: number, outFolder: string) => {
   const runner = new SignalServerRunner({
     port: randomInt(10000, 20000),
-    binCommand: `go run ${BIN_PATH}`,
-    signalArguments: ['p2pserver',],
+    binCommand: `go run -gcflags="all=-N -l" ${BIN_PATH}`,
+    signalArguments: [
+      // 'p2pserver',
+      'globalsubserver'
+    ],
     cwd: PATH_TO_KUBE_REPO,
     env: {
       'GOLOG_FILE': `${outFolder}/signal-${num}.log`,

--- a/packages/gravity/kube-testing/src/run-test-signal.ts
+++ b/packages/gravity/kube-testing/src/run-test-signal.ts
@@ -8,11 +8,9 @@ import path from 'node:path';
 import { SignalServerRunner } from '@dxos/signal';
 import { randomInt } from '@dxos/util';
 
-// const PATH_TO_KUBE_REPO = '/Users/mykola/Documents/dev/kube/';
-const PATH_TO_KUBE_REPO = '/Users/dmaretskyi/Projects/kube/';
+const PATH_TO_KUBE_REPO = '/Users/mykola/Documents/dev/kube/';
+// const PATH_TO_KUBE_REPO = '/Users/dmaretskyi/Projects/kube/';
 const BIN_PATH = './cmds/signal-test/main.go';
-// const PATH_TO_KUBE_REPO = '/Users/mykola/Documents/dev/dxos/packages/gravity/kube-testing/src/';
-// const binPath = 'hello-world.go';
 
 {
   if (!fs.existsSync(PATH_TO_KUBE_REPO)) {
@@ -29,14 +27,14 @@ export const runSignal = async (num: number, outFolder: string) => {
     port: randomInt(10000, 20000),
     binCommand: `go run -gcflags="all=-N -l" ${BIN_PATH}`,
     signalArguments: [
-      // 'p2pserver',
-      'globalsubserver'
+      'p2pserver'
+      // 'globalsubserver'
     ],
     cwd: PATH_TO_KUBE_REPO,
     env: {
-      'GOLOG_FILE': `${outFolder}/signal-${num}.log`,
-      'GOLOG_OUTPUT':'file',
-      'GOLOG_LOG_FMT':'json',
+      GOLOG_FILE: `${outFolder}/signal-${num}.log`,
+      GOLOG_OUTPUT: 'file',
+      GOLOG_LOG_FMT: 'json'
     }
   });
   await runner.waitUntilStarted();

--- a/packages/gravity/kube-testing/src/run-test-signal.ts
+++ b/packages/gravity/kube-testing/src/run-test-signal.ts
@@ -8,7 +8,8 @@ import path from 'node:path';
 import { SignalServerRunner } from '@dxos/signal';
 import { randomInt } from '@dxos/util';
 
-const PATH_TO_KUBE_REPO = '/Users/mykola/Documents/dev/kube/';
+// const PATH_TO_KUBE_REPO = '/Users/mykola/Documents/dev/kube/';
+const PATH_TO_KUBE_REPO = '/Users/dmaretskyi/Projects/kube/';
 const BIN_PATH = './cmds/signal-test/main.go';
 // const PATH_TO_KUBE_REPO = '/Users/mykola/Documents/dev/dxos/packages/gravity/kube-testing/src/';
 // const binPath = 'hello-world.go';

--- a/packages/gravity/kube-testing/src/start-signal-server.ts
+++ b/packages/gravity/kube-testing/src/start-signal-server.ts
@@ -1,3 +1,0 @@
-//
-// Copyright 2023 DXOS.org
-//

--- a/packages/gravity/kube-testing/src/start-signal-server.ts
+++ b/packages/gravity/kube-testing/src/start-signal-server.ts
@@ -1,0 +1,3 @@
+//
+// Copyright 2023 DXOS.org
+//

--- a/packages/gravity/kube-testing/src/test-builder.ts
+++ b/packages/gravity/kube-testing/src/test-builder.ts
@@ -13,7 +13,7 @@ import { ComplexMap, ComplexSet } from '@dxos/util';
 import { runSignal } from './run-test-signal';
 
 export type Failure = {
-  error: Error;
+  error: string;
   action: ExchangedMessage | DiscoverdPeer;
 };
 
@@ -66,7 +66,7 @@ export class Stats {
 
   addFailure(error: Error, action: ExchangedMessage | DiscoverdPeer) {
     if (!this._testFinished) {
-      this.performance.failures.push({ error, action });
+      this.performance.failures.push({ error: error.toString(), action });
     }
   }
 

--- a/packages/gravity/kube-testing/src/test-builder.ts
+++ b/packages/gravity/kube-testing/src/test-builder.ts
@@ -2,6 +2,8 @@
 // Copyright 2023 DXOS.org
 //
 
+import { randomBytes } from 'node:crypto';
+
 import { asyncTimeout, sleep } from '@dxos/async';
 import { Context, cancelWithContext } from '@dxos/context';
 import { PublicKey } from '@dxos/keys';
@@ -10,7 +12,6 @@ import { Message, WebsocketSignalManager } from '@dxos/messaging';
 import { Runtime } from '@dxos/protocols/proto/dxos/config';
 import { SignalServerRunner } from '@dxos/signal';
 import { ComplexMap, ComplexSet } from '@dxos/util';
-import { randomBytes } from 'node:crypto';
 
 import { runSignal } from './run-test-signal';
 
@@ -171,7 +172,7 @@ export class TestAgent {
       // process.stdout.write('#')
       const peers = this._topics.get(discoveredTopic);
       if (!peers) {
-        log.warn('Topic not found', { discoveredTopic })
+        log.warn('Topic not found', { discoveredTopic });
         return;
       }
       if (swarmEvent.peerAvailable) {
@@ -181,7 +182,7 @@ export class TestAgent {
       }
     });
     await this.signalManager.open();
-    await this.signalManager.subscribeMessages(this.peerId)
+    await this.signalManager.subscribeMessages(this.peerId);
   }
 
   async destroy() {
@@ -206,9 +207,8 @@ export class TestAgent {
   }
 
   async discoverPeers(topic: PublicKey, timeout = 5_000) {
-    
     await cancelWithContext(this._ctx, sleep(timeout));
-    
+
     const expectedPeers: PublicKey[] = Array.from(this._stats.topics.get(topic)?.values() ?? []).map((a) => a.peerId);
     const discoverdPeers = this._topics.get(topic) ?? new ComplexSet(PublicKey.hash);
     // log.info('discover', {
@@ -242,11 +242,11 @@ export class TestAgent {
         type_url: 'example.Message',
         value: randomBytes(32)
       }
-    }
+    };
 
-    const received = to.signalManager.onMessage.waitFor(data =>
+    const received = to.signalManager.onMessage.waitFor((data) =>
       Buffer.from(data.payload.value).equals(Buffer.from(message.payload.value))
-    )
+    );
 
     await this.signalManager.sendMessage(message);
 
@@ -257,17 +257,16 @@ export class TestAgent {
         type: 'MESSAGE',
         signalServers: this.signalServers,
         author: this.peerId,
-        recipient: to.peerId,
+        recipient: to.peerId
       });
-    } catch(err: any) {
+    } catch (err: any) {
       this._stats.addFailure(err, {
         type: 'MESSAGE',
         signalServers: this.signalServers,
         author: this.peerId,
-        recipient: to.peerId,
+        recipient: to.peerId
       });
     }
-
   }
 }
 

--- a/packages/gravity/kube-testing/src/test-builder.ts
+++ b/packages/gravity/kube-testing/src/test-builder.ts
@@ -128,8 +128,8 @@ export class TestBuilder {
     return peer;
   }
 
-  async createServer() {
-    const server = await runSignal();
+  async createServer(num: number, outFolder: string) {
+    const server = await runSignal(num, outFolder);
     await server.waitUntilStarted();
     this._servers.set(server.url(), server);
     return server;

--- a/packages/gravity/kube-testing/src/test-builder.ts
+++ b/packages/gravity/kube-testing/src/test-builder.ts
@@ -182,9 +182,10 @@ export class TestAgent {
 
   async leaveTopic(topic: PublicKey) {
     await this.signalManager.leave({ topic, peerId: this.peerId });
+    this._stats.leaveTopic(topic, this);
   }
 
-  async discoverPeers(topic: PublicKey) {
+  async discoverPeers(topic: PublicKey, timeout = 5_000) {
     const discoverdPeers: PublicKey[] = [];
     this.signalManager.swarmEvent.on(({ swarmEvent, topic: discoveredTopic }) => {
       if (discoveredTopic.equals(topic) && swarmEvent.peerAvailable) {
@@ -192,7 +193,7 @@ export class TestAgent {
       }
     });
 
-    await cancelWithContext(this._ctx, sleep(5_000));
+    await cancelWithContext(this._ctx, sleep(timeout));
 
     const expectedPeers: PublicKey[] = Array.from(this._stats.topics.get(topic)?.values() ?? []).map((a) => a.peerId);
 

--- a/packages/gravity/kube-testing/tsconfig.json
+++ b/packages/gravity/kube-testing/tsconfig.json
@@ -8,8 +8,8 @@
       "ESNext"
     ],
     "module": "CommonJS",
-    "target": "esnext",
-    "outDir": "dist"
+    "outDir": "dist",
+    "target": "esnext"
   },
   "exclude": [
     "/node_modules/"

--- a/packages/gravity/kube-testing/tsconfig.json
+++ b/packages/gravity/kube-testing/tsconfig.json
@@ -7,7 +7,8 @@
       "DOM",
       "ESNext"
     ],
-    "module": "ESNext",
+    "module": "CommonJS",
+    "target": "esnext",
     "outDir": "dist"
   },
   "exclude": [

--- a/packages/gravity/kube-testing/tsconfig.json
+++ b/packages/gravity/kube-testing/tsconfig.json
@@ -8,8 +8,7 @@
       "ESNext"
     ],
     "module": "ESNext",
-    "outDir": "dist",
-
+    "outDir": "dist"
   },
   "exclude": [
     "/node_modules/"
@@ -19,7 +18,31 @@
   ],
   "references": [
     {
+      "path": "../../common/async"
+    },
+    {
+      "path": "../../common/context"
+    },
+    {
+      "path": "../../common/keys"
+    },
+    {
+      "path": "../../common/log"
+    },
+    {
+      "path": "../../common/node-std"
+    },
+    {
+      "path": "../../common/util"
+    },
+    {
+      "path": "../../core/mesh/messaging"
+    },
+    {
       "path": "../../core/mesh/signal"
+    },
+    {
+      "path": "../../core/protocols"
     }
-  ],
+  ]
 }

--- a/packages/gravity/kube-testing/tsconfig.json
+++ b/packages/gravity/kube-testing/tsconfig.json
@@ -7,7 +7,7 @@
       "DOM",
       "ESNext"
     ],
-    "module": "ES2020",
+    "module": "ESNext",
     "outDir": "dist",
 
   },

--- a/packages/gravity/kube-testing/tsconfig.json
+++ b/packages/gravity/kube-testing/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "jsx": "react",
+    "lib": [
+      "DOM",
+      "ESNext"
+    ],
+    "module": "ESNext",
+    "outDir": "dist"
+  },
+  "exclude": [
+    "/node_modules/"
+  ],
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../../core/mesh/signal"
+    }
+  ]
+}

--- a/packages/gravity/kube-testing/tsconfig.json
+++ b/packages/gravity/kube-testing/tsconfig.json
@@ -7,8 +7,9 @@
       "DOM",
       "ESNext"
     ],
-    "module": "ESNext",
-    "outDir": "dist"
+    "module": "ES2020",
+    "outDir": "dist",
+
   },
   "exclude": [
     "/node_modules/"
@@ -20,5 +21,5 @@
     {
       "path": "../../core/mesh/signal"
     }
-  ]
+  ],
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3910,6 +3910,43 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
 
+  packages/gravity/kube-testing:
+    specifiers:
+      '@dxos/async': workspace:*
+      '@dxos/context': workspace:*
+      '@dxos/keys': workspace:*
+      '@dxos/log': workspace:*
+      '@dxos/messaging': workspace:*
+      '@dxos/node-std': workspace:*
+      '@dxos/protocols': workspace:*
+      '@dxos/signal': workspace:*
+      '@dxos/util': workspace:*
+      '@types/faker': ^5.5.9
+      '@types/node': ^18.11.9
+      '@types/seedrandom': ^3.0.5
+      faker: ^5.5.3
+      seedrandom: ^3.0.5
+      ts-node: 10.9.1
+      typescript: ^4.8.4
+    dependencies:
+      '@dxos/async': link:../../common/async
+      '@dxos/context': link:../../common/context
+      '@dxos/keys': link:../../common/keys
+      '@dxos/log': link:../../common/log
+      '@dxos/messaging': link:../../core/mesh/messaging
+      '@dxos/node-std': link:../../common/node-std
+      '@dxos/protocols': link:../../core/protocols
+      '@dxos/signal': link:../../core/mesh/signal
+      '@dxos/util': link:../../common/util
+      faker: 5.5.3
+      seedrandom: 3.0.5
+    devDependencies:
+      '@types/faker': 5.5.9
+      '@types/node': 18.11.9
+      '@types/seedrandom': 3.0.5
+      ts-node: 10.9.1_rke3py7up3u364r7wwqfla7cdm_cbe7ovvae6zqfnmtgctpgpys54
+      typescript: 4.8.4
+
   packages/sdk/client:
     specifiers:
       '@dxos/async': workspace:*
@@ -4411,7 +4448,7 @@ importers:
       '@codemirror/commands': 6.2.2
       '@codemirror/lang-markdown': 6.1.0
       '@codemirror/language': 6.6.0
-      '@codemirror/language-data': 6.1.0
+      '@codemirror/language-data': 6.1.0_252h5dwvsiu2pnu2vr7ql3rya4
       '@codemirror/lint': 6.2.0
       '@codemirror/search': 6.3.0
       '@codemirror/state': 6.2.0
@@ -4435,7 +4472,7 @@ importers:
       '@tiptap/pm': 2.0.0-beta.220_7w7m52asdh3tod4ocz57yex63q
       '@tiptap/react': 2.0.0-beta.220_xig6hpp4glylmgjqbtp4uwsv5e
       '@tiptap/starter-kit': 2.0.0-beta.220_@tiptap+pm@2.0.0-beta.220
-      codemirror: 6.0.1
+      codemirror: 6.0.1_@lezer+common@1.0.2
       lib0: 0.2.65
       lodash.get: 4.4.2
       prosemirror-model: 1.19.0
@@ -7840,15 +7877,6 @@ packages:
       minimist: 1.2.8
     dev: true
 
-  /@codemirror/autocomplete/6.4.2:
-    resolution: {integrity: sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==}
-    dependencies:
-      '@codemirror/language': 6.6.0
-      '@codemirror/state': 6.2.0
-      '@codemirror/view': 6.9.2
-      '@lezer/common': 1.0.2
-    dev: false
-
   /@codemirror/autocomplete/6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e:
     resolution: {integrity: sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==}
     peerDependencies:
@@ -7879,20 +7907,23 @@ packages:
       '@lezer/cpp': 1.1.0
     dev: false
 
-  /@codemirror/lang-css/6.1.1:
+  /@codemirror/lang-css/6.1.1_i3aqn63zftbgivbr4riltn5mqe:
     resolution: {integrity: sha512-P6jdNEHyRcqqDgbvHYyC9Wxkek0rnG3a9aVSRi4a7WrjPbQtBTaOmvYpXmm13zZMAatO4Oqpac+0QZs7sy+LnQ==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/language': 6.6.0
       '@codemirror/state': 6.2.0
       '@lezer/css': 1.1.1
+    transitivePeerDependencies:
+      - '@codemirror/view'
+      - '@lezer/common'
     dev: false
 
   /@codemirror/lang-html/6.4.2:
     resolution: {integrity: sha512-bqCBASkteKySwtIbiV/WCtGnn/khLRbbiV5TE+d9S9eQJD7BA4c5dTRm2b3bVmSpilff5EYxvB4PQaZzM/7cNw==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
-      '@codemirror/lang-css': 6.1.1
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
+      '@codemirror/lang-css': 6.1.1_i3aqn63zftbgivbr4riltn5mqe
       '@codemirror/lang-javascript': 6.1.4
       '@codemirror/language': 6.6.0
       '@codemirror/state': 6.2.0
@@ -7912,7 +7943,7 @@ packages:
   /@codemirror/lang-javascript/6.1.4:
     resolution: {integrity: sha512-OxLf7OfOZBTMRMi6BO/F72MNGmgOd9B0vetOLvHsDACFXayBzW8fm8aWnDM0yuy68wTK03MBf4HbjSBNRG5q7A==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/language': 6.6.0
       '@codemirror/lint': 6.2.0
       '@codemirror/state': 6.2.0
@@ -7949,12 +7980,16 @@ packages:
       '@lezer/php': 1.0.1
     dev: false
 
-  /@codemirror/lang-python/6.1.2:
+  /@codemirror/lang-python/6.1.2_252h5dwvsiu2pnu2vr7ql3rya4:
     resolution: {integrity: sha512-nbQfifLBZstpt6Oo4XxA2LOzlSp4b/7Bc5cmodG1R+Cs5PLLCTUvsMNWDnziiCfTOG/SW1rVzXq/GbIr6WXlcw==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/language': 6.6.0
       '@lezer/python': 1.1.2
+    transitivePeerDependencies:
+      - '@codemirror/state'
+      - '@codemirror/view'
+      - '@lezer/common'
     dev: false
 
   /@codemirror/lang-rust/6.0.1:
@@ -7964,14 +7999,17 @@ packages:
       '@lezer/rust': 1.0.0
     dev: false
 
-  /@codemirror/lang-sql/6.4.0:
+  /@codemirror/lang-sql/6.4.0_i3aqn63zftbgivbr4riltn5mqe:
     resolution: {integrity: sha512-UWGK1+zc9+JtkiT+XxHByp4N6VLgLvC2x0tIudrJG26gyNtn0hWOVoB0A8kh/NABPWkKl3tLWDYf2qOBJS9Zdw==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/language': 6.6.0
       '@codemirror/state': 6.2.0
       '@lezer/highlight': 1.1.3
       '@lezer/lr': 1.3.3
+    transitivePeerDependencies:
+      - '@codemirror/view'
+      - '@lezer/common'
     dev: false
 
   /@codemirror/lang-wast/6.0.1:
@@ -7982,34 +8020,40 @@ packages:
       '@lezer/lr': 1.3.3
     dev: false
 
-  /@codemirror/lang-xml/6.0.2:
+  /@codemirror/lang-xml/6.0.2_@codemirror+view@6.9.2:
     resolution: {integrity: sha512-JQYZjHL2LAfpiZI2/qZ/qzDuSqmGKMwyApYmEUUCTxLM4MWS7sATUEfIguZQr9Zjx/7gcdnewb039smF6nC2zw==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/language': 6.6.0
       '@codemirror/state': 6.2.0
       '@lezer/common': 1.0.2
       '@lezer/xml': 1.0.1
+    transitivePeerDependencies:
+      - '@codemirror/view'
     dev: false
 
-  /@codemirror/language-data/6.1.0:
+  /@codemirror/language-data/6.1.0_252h5dwvsiu2pnu2vr7ql3rya4:
     resolution: {integrity: sha512-g9V23fuLRI9AEbpM6bDy1oquqgpFlIDHTihUhL21NPmxp+x67ZJbsKk+V71W7/Bj8SCqEO1PtqQA/tDGgt1nfw==}
     dependencies:
       '@codemirror/lang-cpp': 6.0.2
-      '@codemirror/lang-css': 6.1.1
+      '@codemirror/lang-css': 6.1.1_i3aqn63zftbgivbr4riltn5mqe
       '@codemirror/lang-html': 6.4.2
       '@codemirror/lang-java': 6.0.1
       '@codemirror/lang-javascript': 6.1.4
       '@codemirror/lang-json': 6.0.1
       '@codemirror/lang-markdown': 6.1.0
       '@codemirror/lang-php': 6.0.1
-      '@codemirror/lang-python': 6.1.2
+      '@codemirror/lang-python': 6.1.2_252h5dwvsiu2pnu2vr7ql3rya4
       '@codemirror/lang-rust': 6.0.1
-      '@codemirror/lang-sql': 6.4.0
+      '@codemirror/lang-sql': 6.4.0_i3aqn63zftbgivbr4riltn5mqe
       '@codemirror/lang-wast': 6.0.1
-      '@codemirror/lang-xml': 6.0.2
+      '@codemirror/lang-xml': 6.0.2_@codemirror+view@6.9.2
       '@codemirror/language': 6.6.0
       '@codemirror/legacy-modes': 6.3.1
+    transitivePeerDependencies:
+      - '@codemirror/state'
+      - '@codemirror/view'
+      - '@lezer/common'
     dev: false
 
   /@codemirror/language/6.6.0:
@@ -15660,6 +15704,10 @@ packages:
   /@types/scheduler/0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
 
+  /@types/seedrandom/3.0.5:
+    resolution: {integrity: sha512-kopEpYpFQvQdYsZkZVwht/0THHmTFFYXDaqV/lM45eweJ8kcGVDgZHs0RVTolSq55UPZNmjhKc9r7UvLu/mQQg==}
+    dev: true
+
   /@types/semver/7.3.13:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
 
@@ -16099,7 +16147,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.20.12
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.3.1
+      vite: 4.3.1_@types+node@18.11.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -17034,20 +17082,12 @@ packages:
       acorn: 7.4.1
     dev: true
 
-  /acorn-jsx/5.3.2_acorn@8.8.0:
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      acorn: 8.8.0
-
   /acorn-jsx/5.3.2_acorn@8.8.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 8.8.2
-    dev: true
 
   /acorn-node/1.8.2:
     resolution: {integrity: sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==}
@@ -17079,12 +17119,12 @@ packages:
     resolution: {integrity: sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+    dev: true
 
   /acorn/8.8.2:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: true
 
   /add/2.0.6:
     resolution: {integrity: sha512-j5QzrmsokwWWp6kUcJQySpbG+xfOBqqKnup3OIk1pz+kB/80SLorZ9V8zHFLO92Lcd+hbvq8bT+zOGoPkmBV0Q==}
@@ -19334,16 +19374,18 @@ packages:
     resolution: {integrity: sha512-LuO8/7LW6XuR5ERn1yavXAfodGRhuY2yP60JTZIw5yNYMCE5lUVbk3NFUCJxjnphQH+Xemp5hOGb1LgUXm00Xw==}
     dev: true
 
-  /codemirror/6.0.1:
+  /codemirror/6.0.1_@lezer+common@1.0.2:
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/commands': 6.2.2
       '@codemirror/language': 6.6.0
       '@codemirror/lint': 6.2.0
       '@codemirror/search': 6.3.0
       '@codemirror/state': 6.2.0
       '@codemirror/view': 6.9.2
+    transitivePeerDependencies:
+      - '@lezer/common'
     dev: false
 
   /codesandbox-import-util-types/2.2.3:
@@ -22190,8 +22232,8 @@ packages:
     resolution: {integrity: sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.8.0
-      acorn-jsx: 5.3.2_acorn@8.8.0
+      acorn: 8.8.2
+      acorn-jsx: 5.3.2_acorn@8.8.2
       eslint-visitor-keys: 3.3.0
 
   /esprima/4.0.1:
@@ -32941,6 +32983,10 @@ packages:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
     dev: false
 
+  /seedrandom/3.0.5:
+    resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
+    dev: false
+
   /seek-bzip/1.0.6:
     resolution: {integrity: sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==}
     hasBin: true
@@ -35001,7 +35047,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 18.11.9
-      acorn: 8.8.0
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -35033,7 +35079,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 18.11.9
-      acorn: 8.8.0
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -36033,7 +36079,7 @@ packages:
       fast-glob: 3.2.12
       pretty-bytes: 6.0.0
       rollup: 3.20.4
-      vite: 4.3.1
+      vite: 4.3.1_@types+node@18.11.9
       workbox-build: 6.5.4
       workbox-window: 6.5.4
     transitivePeerDependencies:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -403,6 +403,11 @@
         },
         {
           "type": "json",
+          "path": "packages/gravity/kube-testing/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "packages/sdk/client/package.json",
           "jsonpath": "$.version"
         },


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 191c47d</samp>

### Summary
🚧🧪🐛

<!--
1.  🚧 - This emoji can represent the changes that involve creating new modules, packages, and files, as well as renaming and refactoring existing ones. These changes are related to the construction and improvement of the codebase and its structure.
2. 🧪 - This emoji can represent the changes that involve adding, updating, and improving tests for different classes and modules. These changes are related to the testing and verification of the code functionality and quality.
3. 🐛 - This emoji can represent the changes that involve fixing bugs or potential issues, such as logging errors in disposed contexts or avoiding conflicts with other tests. These changes are related to the debugging and maintenance of the code.
-->
This pull request adds a new package `@dxos/kube-testing` that can run tests for the KUBE project, a peer-to-peer network layer for DXOS. It also improves the testing and logging of the signal server and the messaging components, using new utility functions and modules. It renames and deletes some files to reflect the changes.

> _Testing KUBE code_
> _`SignalServerRunner` helps_
> _Autumn bugs fall off_

### Walkthrough
*  Add a new package @dxos/kube-testing that can run tests for the KUBE project ([link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-f0d6c7a7f9231529ff0842d982a42b3753342e9cf1f32cfcea542a23998897ecR1-R36), [link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-2b1270dadc0bb722d87791be320e2863353ce645d5131b7917ecbc302aa28206R1-R30), [link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-98a483c35bec84f503d4323222b6b105d60c67964122a51f142c7b643f4639d4R1-R4))
*  Implement the main entry point for the test runner in main.ts ([link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-07d9a4fe62c5ce84347caf3b0b32a13540ad7cb7704251c7230663f3d92d4958R1-R176))
*  Implement the utility class TestBuilder that can create and destroy test agents and servers in test-builder.ts ([link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-23fcceff4bbb5c7dc8a4eb49fc2e831c1da6ae4c21b5b9e9708296591dd49a99R1-R275))
*  Implement the utility function runTestSignalServer that can run a test instance of the signal server using the KUBE binary in run-test-signal.ts ([link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-5a506647d78a762607d6aae67d479ca113b8f0fe0320f46449e2cf12d8c05cc7R1-R42))
*  Implement the script that can analyze the stats.json file generated by the test and output the number and percentage of failures per peer in analysys/per-peer.ts ([link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-65d8dfeeb1d259337dbcc11cd4ea7f455abb7c936012f402f91363200cb8cb9cR1-R54))
*  Rename the export of test-broker to signal-server-runner in the index.ts file of the @dxos/mesh/signal package ([link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-482e93fb6b99b29076948b78f52ca382cbf97d1efe036b33a98bf0fe6b9ead16L5-R5))
*  Add a new module signal-server-runner.ts to the @dxos/mesh/signal package that provides the utility class SignalServerRunner and the utility function runTestSignalServer that can run a test instance of the signal server with swarming disabled ([link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-72d0214e1874fdfc413e9312c3e68cf8af57457ac538aaed38f2fefbea167ef8R1-R164))
*  Add an import of @dxos/log to the package.json and a path mapping for it to the tsconfig.json of the @dxos/mesh/signal package ([link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-bce155b6775694d98b0d2ae6ecd65b5ed72af2c86eb52131e3464b59b324142dR14), [link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-2d6982f0a6fc3b9ee4b5753c117dd9a5125670d829c0cc7b70cb60c72e564308R14-R16))
*  Delete the module test-broker.ts from the @dxos/mesh/signal package ([link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-e2d10d6e87831f6c0cc8f3d38fa7cf9146087c9d9113a27ad57192539e1b56c0))
*  Replace the import and the call of createTestBroker with the import and the call of runTestSignalServer in the test files for the Messenger, SignalClient, SignalRPCClient, WebSocketSignalManager, signal integration and message router classes ([link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-1ba4d468aaf63677520006246f1c7c38b4dbc74a7ec42d08ea6df68f0179bd77L11-R11), [link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-1ba4d468aaf63677520006246f1c7c38b4dbc74a7ec42d08ea6df68f0179bd77L39-R42), [link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-192c9f5d433de451c7414880034ae1c62779e6e984a2901beab0ca6a93d38d64L11-R11), [link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-192c9f5d433de451c7414880034ae1c62779e6e984a2901beab0ca6a93d38d64L23-R28), [link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-49eb260fecbfaef7340bfa62f723ef430e93602b1c59784c27eb86ac4f0dc8f5L12-R12), [link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-49eb260fecbfaef7340bfa62f723ef430e93602b1c59784c27eb86ac4f0dc8f5L18-R21), [link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-ddcf32b046fe25533a59b12b96938aabdbedcc991b88192cfb4bf1810707f817L12-R18), [link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-1a283b146bcd2c151788e4c0939bb1d5992e3043c406a5147460f31835376337L12-R12), [link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-1a283b146bcd2c151788e4c0939bb1d5992e3043c406a5147460f31835376337L19-R22), [link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-e838dcfcf4fa479c1aab4e74e27fae06d1093ed3970f3ea4f219ddde0f847aeaL14-R14), [link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-e838dcfcf4fa479c1aab4e74e27fae06d1093ed3970f3ea4f219ddde0f847aeaL23-R26))
*  Replace the call of createTestBroker with the call of runTestSignalServer in the setup.js file of the @dxos/mesh/signal/testing package ([link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-42aa7e7c0c2847ac8bf5abffe7ac3803532d23f8f1ed3496d6f95da45f576c4aL6-R10))
*  Add two imports of asyncTimeout and sleep from @dxos/async to the test file for the WebSocketSignalManager class ([link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-ddcf32b046fe25533a59b12b96938aabdbedcc991b88192cfb4bf1810707f817L5-R7))
*  Add a new function expectReceivedMessage that can test the sendMessage method of the WebSocketSignalManager class ([link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-ddcf32b046fe25533a59b12b96938aabdbedcc991b88192cfb4bf1810707f817R32-R40))
*  Add a new test case for the WebSocketSignalManager class that tests the join and sendMessage methods with two signal servers ([link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-ddcf32b046fe25533a59b12b96938aabdbedcc991b88192cfb4bf1810707f817R63-R91))
*  Comment out the log.warn statement in the Context.raise method to avoid logging errors that occur in disposed contexts ([link](https://github.com/dxos/dxos/pull/3147/files?diff=unified&w=0#diff-9c01791d40e657e125e1d3ce1c3e848a80251a0074a8a2b2387be63472cc85bdL98-R99))


