### PR TITLE
fix(react-shell): `JoinPanel` predicate typo

### DIFF
--- a/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanel.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanel.tsx
@@ -145,8 +145,10 @@ export const JoinPanel = ({
               ].some(joinState.matches),
               Kind: 'Halo',
               ...(joinState.matches({
-                acceptingHaloInvitation: {
-                  acceptingRedeemedHaloInvitation: 'authenticationFailingHaloVerificationCode'
+                choosingIdentity: {
+                  acceptingHaloInvitation: {
+                    acceptingRedeemedHaloInvitation: 'authenticationFailingHaloVerificationCode'
+                  }
                 }
               }) && { failed: true })
             }}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f07f5b3</samp>

### Summary
🐛🛠️🙈

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change.
2.  🛠️ - This emoji represents a tool or a fix, which is another way to describe the change.
3.  🙈 - This emoji represents a mistake or an oversight, which is what caused the bug in the first place.
-->
Fixed a bug in `JoinPanel` component that prevented showing a failed state when accepting a halo invitation with an invalid verification code. Updated the condition for showing the failed state to check both `acceptingHaloInvitation` and `choosingIdentity` states.

> _`JoinPanel` renders_
> _party or halo options_
> _bug fix for winter_

### Walkthrough
* Fix a bug where the failed state was not shown when accepting a halo invitation with an invalid verification code ([link](https://github.com/dxos/dxos/pull/3151/files?diff=unified&w=0#diff-2d39365b754c6a396cbee16332fda4338cbd7f5f39ae25b329d5a8973889443fL148-R151))


