### PR TITLE
feat(composer-app): Unhide Spaces

### DIFF
--- a/packages/apps/composer-app/src/components/Sidebar/HiddenSpacesTree.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/HiddenSpacesTree.tsx
@@ -1,0 +1,110 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { CaretDown, CaretRight, Eye } from '@phosphor-icons/react';
+import React, { useCallback } from 'react';
+
+import { Button, ListItemScopedProps, useId, useListItemContext, useTranslation } from '@dxos/aurora';
+import { getSize } from '@dxos/aurora-theme';
+import { Space, SpaceState } from '@dxos/client';
+import {
+  Tooltip,
+  TreeBranch,
+  TreeItem,
+  TreeItemBody,
+  TreeItemHeading,
+  TreeItemOpenTrigger,
+  TreeRoot
+} from '@dxos/react-appkit';
+import { useMulticastObservable } from '@dxos/react-async';
+import { useIdentity } from '@dxos/react-client';
+
+import { getSpaceDisplayName } from '../../util/getSpaceDisplayName';
+
+export type HiddenSpacesTreeProps = {
+  hiddenSpaces?: Space[];
+};
+
+const HiddenSpaceItem = ({ space, handleUnhideSpace }: { space: Space; handleUnhideSpace: (space: Space) => void }) => {
+  const { t } = useTranslation('composer');
+  const spaceSate = useMulticastObservable(space.state);
+  const disabled = spaceSate !== SpaceState.READY;
+  const spaceDisplayName = getSpaceDisplayName(t, space, disabled);
+  return (
+    <TreeItem className='flex mis-1 mie-1.5'>
+      <TreeItemHeading className='grow'>{spaceDisplayName}</TreeItemHeading>
+      <Tooltip content={t('unhide space label')} tooltipLabelsTrigger side='top' zIndex='z-[31]'>
+        <Button
+          variant='ghost'
+          data-testid='composer.unhideSpace'
+          className='shrink-0 pli-1'
+          onClick={() => handleUnhideSpace(space)}
+        >
+          <Eye className={getSize(4)} />
+        </Button>
+      </Tooltip>
+    </TreeItem>
+  );
+};
+
+const HiddenSpacesBranch = ({ __listItemScope, hiddenSpaces }: ListItemScopedProps<HiddenSpacesTreeProps>) => {
+  const { t } = useTranslation('composer');
+  const { open } = useListItemContext('HiddenSpacesBranch', __listItemScope);
+  const identity = useIdentity();
+
+  const OpenTriggerIcon = open ? CaretDown : CaretRight;
+
+  const handleUnhideSpace = useCallback(
+    (space: Space) => {
+      if (identity) {
+        const identityHex = identity.identityKey.toHex();
+        space.properties.members = {
+          ...space.properties.members,
+          [identityHex]: {
+            ...space.properties.members?.[identityHex],
+            hidden: false
+          }
+        };
+      }
+    },
+    [identity]
+  );
+
+  return (
+    <>
+      <div role='none' className='flex'>
+        <TreeItemOpenTrigger>
+          <OpenTriggerIcon />
+        </TreeItemOpenTrigger>
+        <TreeItemHeading className='grow break-words pbs-1.5 text-sm font-system-medium'>
+          {t('hidden spaces tree label')}
+        </TreeItemHeading>
+      </div>
+      <TreeItemBody className='mbs-2'>
+        <TreeBranch>
+          {hiddenSpaces!.map((space) => (
+            <HiddenSpaceItem key={space.key.toHex()} {...{ space, handleUnhideSpace }} />
+          ))}
+        </TreeBranch>
+      </TreeItemBody>
+    </>
+  );
+};
+
+export const HiddenSpacesTree = (props: HiddenSpacesTreeProps) => {
+  const { t } = useTranslation('composer');
+  const treeLabel = useId('hiddenSpacesTree');
+  return props.hiddenSpaces?.length ? (
+    <>
+      <span className='sr-only' id={treeLabel}>
+        {t('hidden spaces tree label')}
+      </span>
+      <TreeRoot aria-labelledby={treeLabel} data-testid='composer.hiddenSpaces' className='shrink-0'>
+        <TreeItem collapsible className='mis-1 block'>
+          <HiddenSpacesBranch {...props} />
+        </TreeItem>
+      </TreeRoot>
+    </>
+  ) : null;
+};

--- a/packages/apps/composer-app/src/components/Sidebar/Sidebar.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/Sidebar.tsx
@@ -25,6 +25,7 @@ import { ComposerDocument } from '../../proto';
 import { getPath } from '../../router';
 import { useOctokitContext } from '../OctokitProvider';
 import { Separator } from '../Separator';
+import { HiddenSpacesTree } from './HiddenSpacesTree';
 import { SpaceTreeItem } from './SpaceTreeItem';
 
 const DocumentTree = observer(() => {
@@ -34,17 +35,23 @@ const DocumentTree = observer(() => {
   const { t } = useTranslation('composer');
   const identity = useIdentity();
   return (
-    <div className='grow plb-1.5 pis-1 pie-1.5 min-bs-0 overflow-y-auto'>
+    <div className='grow flex flex-col plb-1.5 pis-1 pie-1.5 min-bs-0 overflow-y-auto'>
       <span className='sr-only' id={treeLabel}>
         {t('sidebar tree label')}
       </span>
-      <TreeRoot aria-labelledby={treeLabel} data-testid='composer.sidebarTree'>
+      <TreeRoot aria-labelledby={treeLabel} data-testid='composer.sidebarTree' className='shrink-0'>
         {spaces
           .filter((space) => !identity || space.properties.members?.[identity.identityKey.toHex()]?.hidden !== true)
           .map((space) => {
             return <SpaceTreeItem key={space.key.toHex()} space={space} />;
           })}
       </TreeRoot>
+      <div role='none' className='grow' />
+      <HiddenSpacesTree
+        hiddenSpaces={spaces.filter(
+          (space) => !identity || space.properties.members?.[identity.identityKey.toHex()]?.hidden === true
+        )}
+      />
     </div>
   );
 });

--- a/packages/apps/composer-app/src/components/Sidebar/SpaceTreeItem.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/SpaceTreeItem.tsx
@@ -18,7 +18,7 @@ import { FileUploader } from 'react-drag-drop-files';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { Button, useTranslation } from '@dxos/aurora';
-import { defaultDisabled, getSize, mx } from '@dxos/aurora-theme';
+import { defaultDisabled, getSize } from '@dxos/aurora-theme';
 import { SpaceState } from '@dxos/client';
 import {
   Tooltip,
@@ -43,6 +43,7 @@ import { useShell } from '@dxos/react-shell';
 import { ComposerDocument } from '../../proto';
 import { abbreviateKey, getPath } from '../../router';
 import { backupSpace, restoreSpace } from '../../util';
+import { getSpaceDisplayName } from '../../util/getSpaceDisplayName';
 import { Separator } from '../Separator';
 import { DocumentTreeItem } from './DocumentTreeItem';
 
@@ -88,12 +89,7 @@ export const SpaceTreeItem = observer(({ space }: { space: Space }) => {
     spaceKey === abbreviateKey(space.key) && setOpen(true);
   }, [spaceKey]);
 
-  const spaceDisplayName =
-    (space.properties.name?.length ?? 0) > 0
-      ? space.properties.name
-      : disabled
-      ? t('loading space title')
-      : t('untitled space title');
+  const spaceDisplayName = getSpaceDisplayName(t, space, disabled);
 
   const OpenTriggerIcon = open ? CaretDown : CaretRight;
 
@@ -102,7 +98,8 @@ export const SpaceTreeItem = observer(({ space }: { space: Space }) => {
       collapsible
       open={open}
       onOpenChange={setOpen}
-      {...{ className: mx('mbe-2 block', disabled && defaultDisabled), ...(disabled && { 'aria-disabled': true }) }}
+      className={['mbe-2 block', disabled && defaultDisabled]}
+      {...(disabled && { 'aria-disabled': true })}
     >
       <div role='none' className='flex mis-1 items-start'>
         <TreeItemOpenTrigger>

--- a/packages/apps/composer-app/src/translations/en-US.ts
+++ b/packages/apps/composer-app/src/translations/en-US.ts
@@ -49,5 +49,7 @@ export const composer = {
   'download all docs in space label': 'Download backup',
   'upload all docs in space label': 'Upload backup',
   'invitation ready for auth code message': 'An invitation is ready for its authentication code',
-  'view invitations label': 'View'
+  'view invitations label': 'View',
+  'hidden spaces tree label': 'Hidden spaces',
+  'unhide space label': 'Un-hide space'
 };

--- a/packages/apps/composer-app/src/util/getSpaceDisplayName.ts
+++ b/packages/apps/composer-app/src/util/getSpaceDisplayName.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { TFunction } from '@dxos/aurora';
+import { Space } from '@dxos/client';
+
+export const getSpaceDisplayName = (t: TFunction, space: Space, disabled?: boolean) => {
+  return (space.properties.name?.length ?? 0) > 0
+    ? space.properties.name
+    : disabled
+    ? t('loading space title')
+    : t('untitled space title');
+};

--- a/packages/ui/aurora/src/index.ts
+++ b/packages/ui/aurora/src/index.ts
@@ -2,6 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
+export type { TFunction } from 'i18next';
 export { useTranslation, Trans } from 'react-i18next';
 export * from '@dxos/aurora-types';
 export * from '@dxos/react-hooks';


### PR DESCRIPTION
https://user-images.githubusercontent.com/855039/236957775-7fad7938-2643-4481-8a37-496a943190ac.mp4

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d159270</samp>

### Summary
🌲🙈🌐

<!--
1.  🌲 - This emoji represents the new tree component that shows hidden spaces.
2.  🙈 - This emoji represents the hiding and un-hiding functionality of spaces.
3.  🌐 - This emoji represents the translation and internationalization aspects of the changes.
-->
This pull request adds a feature to the composer app that allows users to see and un-hide spaces that they have hidden. It introduces a new component `HiddenSpacesTree` that renders a tree of hidden spaces in the sidebar, and a utility function `getSpaceDisplayName` that formats space names. It also refactors the `SpaceTreeItem` component and updates the translation and UI libraries.

> _Sing, O Muse, of the skillful coder who devised_
> _A wondrous tree of hidden spaces, where the wise_
> _Could hide or un-hide with a click their precious realms_
> _And see their names displayed by `getSpaceDisplayName`'s charms._

### Walkthrough
*  Add a new component `HiddenSpacesTree` to render hidden spaces in the sidebar ([link](https://github.com/dxos/dxos/pull/3152/files?diff=unified&w=0#diff-9af28b3e1330cf215f070c08ad34b4483a4e5f2c309179372819528a2927a040R1-R110), [link](https://github.com/dxos/dxos/pull/3152/files?diff=unified&w=0#diff-482c9b21fffe3f8d8d5630a3ea7190f05252d6f672a1161ac7de35d8b7b725f5R28), [link](https://github.com/dxos/dxos/pull/3152/files?diff=unified&w=0#diff-482c9b21fffe3f8d8d5630a3ea7190f05252d6f672a1161ac7de35d8b7b725f5R49-R54), [link](https://github.com/dxos/dxos/pull/3152/files?diff=unified&w=0#diff-df4fb09070ae8aa16c554fe8dc845b2f339eb7e852b9b7934010cbcf2eee0721L52-R54)).


