### PR TITLE
fix(aurora): Missing forwarded refs

### DIFF
--- a/packages/ui/aurora/src/components/Input/Input.tsx
+++ b/packages/ui/aurora/src/components/Input/Input.tsx
@@ -1,7 +1,7 @@
 //
 // Copyright 2023 DXOS.org
 //
-import React, { useCallback } from 'react';
+import React, { forwardRef, useCallback } from 'react';
 
 import { Density, Elevation, ClassNameValue } from '@dxos/aurora-types';
 import {
@@ -37,59 +37,71 @@ const Root = (props: RootProps) => {
 
 type LabelProps = ThemedClassName<LabelPrimitiveProps> & { srOnly?: boolean };
 
-const Label = ({ srOnly, className, children, ...props }: LabelProps) => {
+const Label = forwardRef<HTMLLabelElement, LabelProps>(({ srOnly, className, children, ...props }, forwardedRef) => {
   const { tx } = useThemeContext();
   return (
-    <LabelPrimitive {...props} className={tx('input.label', 'input__label', { srOnly }, className)}>
+    <LabelPrimitive {...props} className={tx('input.label', 'input__label', { srOnly }, className)} ref={forwardedRef}>
       {children}
     </LabelPrimitive>
   );
-};
+});
 
 type DescriptionProps = ThemedClassName<DescriptionPrimitiveProps> & { srOnly?: boolean };
 
-const Description = ({ srOnly, className, children, ...props }: DescriptionProps) => {
-  const { tx } = useThemeContext();
-  return (
-    <DescriptionPrimitive {...props} className={tx('input.description', 'input__description', { srOnly }, className)}>
-      {children}
-    </DescriptionPrimitive>
-  );
-};
+const Description = forwardRef<HTMLSpanElement, DescriptionProps>(
+  ({ srOnly, className, children, ...props }, forwardedRef) => {
+    const { tx } = useThemeContext();
+    return (
+      <DescriptionPrimitive
+        {...props}
+        className={tx('input.description', 'input__description', { srOnly }, className)}
+        ref={forwardedRef}
+      >
+        {children}
+      </DescriptionPrimitive>
+    );
+  }
+);
 
 type ValidationProps = ThemedClassName<ValidationPrimitiveProps> & { srOnly?: boolean };
 
-const Validation = ({ __inputScope, srOnly, className, children, ...props }: InputScopedProps<ValidationProps>) => {
-  const { tx } = useThemeContext();
-  const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
-  return (
-    <ValidationPrimitive
-      {...props}
-      className={tx(
-        'input.validation',
-        `input__validation-message input__validation-message--${validationValence}`,
-        { srOnly, validationValence },
-        className
-      )}
-    >
-      {children}
-    </ValidationPrimitive>
-  );
-};
+const Validation = forwardRef<HTMLSpanElement, InputScopedProps<ValidationProps>>(
+  ({ __inputScope, srOnly, className, children, ...props }, forwardedRef) => {
+    const { tx } = useThemeContext();
+    const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
+    return (
+      <ValidationPrimitive
+        {...props}
+        className={tx(
+          'input.validation',
+          `input__validation-message input__validation-message--${validationValence}`,
+          { srOnly, validationValence },
+          className
+        )}
+        ref={forwardedRef}
+      >
+        {children}
+      </ValidationPrimitive>
+    );
+  }
+);
 
 type DescriptionAndValidationProps = ThemedClassName<DescriptionAndValidationPrimitiveProps> & { srOnly?: boolean };
 
-const DescriptionAndValidation = ({ srOnly, className, children, ...props }: DescriptionAndValidationProps) => {
-  const { tx } = useThemeContext();
-  return (
-    <DescriptionAndValidationPrimitive
-      {...props}
-      className={tx('input.descriptionAndValidation', 'input__description-and-validation', { srOnly }, className)}
-    >
-      {children}
-    </DescriptionAndValidationPrimitive>
-  );
-};
+const DescriptionAndValidation = forwardRef<HTMLParagraphElement, DescriptionAndValidationProps>(
+  ({ srOnly, className, children, ...props }, forwardedRef) => {
+    const { tx } = useThemeContext();
+    return (
+      <DescriptionAndValidationPrimitive
+        {...props}
+        className={tx('input.descriptionAndValidation', 'input__description-and-validation', { srOnly }, className)}
+        ref={forwardedRef}
+      >
+        {children}
+      </DescriptionAndValidationPrimitive>
+    );
+  }
+);
 
 type InputVariant = 'default' | 'subdued';
 
@@ -101,119 +113,117 @@ type PinInputProps = InputSharedProps &
     inputClassName?: ClassNameValue;
   };
 
-const PinInput = ({
-  density: propsDensity,
-  elevation: propsElevation,
-  segmentClassName: propsSegmentClassName,
-  inputClassName,
-  variant,
-  ...props
-}: PinInputProps) => {
-  const { hasIosKeyboard } = useThemeContext();
-  const { tx } = useThemeContext();
-  const density = useDensityContext(propsDensity);
-  const elevation = useElevationContext(propsElevation);
+const PinInput = forwardRef<HTMLInputElement, PinInputProps>(
+  (
+    {
+      density: propsDensity,
+      elevation: propsElevation,
+      segmentClassName: propsSegmentClassName,
+      inputClassName,
+      variant,
+      ...props
+    },
+    forwardedRef
+  ) => {
+    const { hasIosKeyboard } = useThemeContext();
+    const { tx } = useThemeContext();
+    const density = useDensityContext(propsDensity);
+    const elevation = useElevationContext(propsElevation);
 
-  const segmentClassName = useCallback(
-    ({ focused, validationValence }: Parameters<Exclude<PinInputPrimitiveProps['segmentClassName'], undefined>>[0]) =>
-      tx(
-        'input.input',
-        'input--pin-segment',
-        {
-          variant: 'static',
-          focused,
-          disabled: props.disabled,
-          density,
-          elevation,
-          validationValence
-        },
-        propsSegmentClassName
-      ),
-    [tx, props.disabled, elevation, propsElevation, density]
-  );
-  return (
-    <PinInputPrimitive
-      {...{
-        ...props,
-        segmentClassName,
-        ...(props.autoFocus && !hasIosKeyboard && { autoFocus: true })
-      }}
-      inputClassName={tx('input.inputWithSegments', 'input input--pin', { disabled: props.disabled }, inputClassName)}
-    />
-  );
-};
+    const segmentClassName = useCallback(
+      ({ focused, validationValence }: Parameters<Exclude<PinInputPrimitiveProps['segmentClassName'], undefined>>[0]) =>
+        tx(
+          'input.input',
+          'input--pin-segment',
+          {
+            variant: 'static',
+            focused,
+            disabled: props.disabled,
+            density,
+            elevation,
+            validationValence
+          },
+          propsSegmentClassName
+        ),
+      [tx, props.disabled, elevation, propsElevation, density]
+    );
+    return (
+      <PinInputPrimitive
+        {...{
+          ...props,
+          segmentClassName,
+          ...(props.autoFocus && !hasIosKeyboard && { autoFocus: true })
+        }}
+        inputClassName={tx('input.inputWithSegments', 'input input--pin', { disabled: props.disabled }, inputClassName)}
+        ref={forwardedRef}
+      />
+    );
+  }
+);
 
 type TextInputProps = InputSharedProps & ThemedClassName<TextInputPrimitiveProps>;
 
-const TextInput = ({
-  __inputScope,
-  className,
-  density: propsDensity,
-  elevation: propsElevation,
-  variant,
-  ...props
-}: InputScopedProps<TextInputProps>) => {
-  const { hasIosKeyboard } = useThemeContext();
-  const { tx } = useThemeContext();
-  const density = useDensityContext(propsDensity);
-  const elevation = useElevationContext(propsElevation);
-  const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
+const TextInput = forwardRef<HTMLInputElement, InputScopedProps<TextInputProps>>(
+  ({ __inputScope, className, density: propsDensity, elevation: propsElevation, variant, ...props }, forwardedRef) => {
+    const { hasIosKeyboard } = useThemeContext();
+    const { tx } = useThemeContext();
+    const density = useDensityContext(propsDensity);
+    const elevation = useElevationContext(propsElevation);
+    const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
 
-  return (
-    <TextInputPrimitive
-      {...props}
-      className={tx(
-        'input.input',
-        'input',
-        {
-          variant,
-          disabled: props.disabled,
-          density,
-          elevation,
-          validationValence
-        },
-        className
-      )}
-      {...(props.autoFocus && !hasIosKeyboard && { autoFocus: true })}
-    />
-  );
-};
+    return (
+      <TextInputPrimitive
+        {...props}
+        className={tx(
+          'input.input',
+          'input',
+          {
+            variant,
+            disabled: props.disabled,
+            density,
+            elevation,
+            validationValence
+          },
+          className
+        )}
+        {...(props.autoFocus && !hasIosKeyboard && { autoFocus: true })}
+        ref={forwardedRef}
+      />
+    );
+  }
+);
 
 type TextAreaProps = InputSharedProps & ThemedClassName<TextAreaPrimitiveProps>;
 
-const TextArea = ({
-  __inputScope,
-  className,
-  density: propsDensity,
-  elevation: propsElevation,
-  variant,
-  ...props
-}: InputScopedProps<TextAreaProps>) => {
-  const { hasIosKeyboard } = useThemeContext();
-  const { tx } = useThemeContext();
-  const density = useDensityContext(propsDensity);
-  const elevation = useElevationContext(propsElevation);
-  const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
+const TextArea = forwardRef<HTMLTextAreaElement, InputScopedProps<TextAreaProps>>(
+  ({ __inputScope, className, density: propsDensity, elevation: propsElevation, variant, ...props }, forwardedRef) => {
+    const { hasIosKeyboard } = useThemeContext();
+    const { tx } = useThemeContext();
+    const density = useDensityContext(propsDensity);
+    const elevation = useElevationContext(propsElevation);
+    const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
 
-  return (
-    <TextAreaPrimitive
-      {...props}
-      className={tx(
-        'input.input',
-        'input--text-area',
-        {
-          variant,
-          disabled: props.disabled,
-          density,
-          elevation,
-          validationValence
-        },
-        className
-      )}
-      {...(props.autoFocus && !hasIosKeyboard && { autoFocus: true })}
-    />
-  );
-};
+    return (
+      <TextAreaPrimitive
+        {...props}
+        className={tx(
+          'input.input',
+          'input--text-area',
+          {
+            variant,
+            disabled: props.disabled,
+            density,
+            elevation,
+            validationValence
+          },
+          className
+        )}
+        {...(props.autoFocus && !hasIosKeyboard && { autoFocus: true })}
+        ref={forwardedRef}
+      />
+    );
+  }
+);
 
 export {
   Root,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3d0ba47</samp>

### Summary
🆕🔗🎛️

<!--
1.  🆕 - This emoji conveys that a new feature or functionality has been added to the input components and their subcomponents. It could be used to highlight the `forwardRef` support in the changelog or release notes.
2.  🔗 - This emoji conveys that a connection or link has been established between the input components and their subcomponents and the ref objects that are passed to them. It could be used to emphasize the ref forwarding and custom ref types feature in the documentation or examples.
3.  🎛️ - This emoji conveys that a knob or control has been added or enhanced for the input components and their subcomponents. It could be used to indicate the flexibility and control that the `forwardRef` support provides to the users or developers of the input components.
-->
Added `forwardRef` support to input components in `Input.tsx`. This enables ref forwarding and custom ref types for input elements.

> _Sing, O Muse, of the skillful coder who devised_
> _A way to forward refs to input components and their kin,_
> _And thus bestowed on them the power to be revised_
> _By custom types, as if by Hephaestus' fiery pin._

### Walkthrough
* Import `forwardRef` from React to enable passing refs to input components ([link](https://github.com/dxos/dxos/pull/3153/files?diff=unified&w=0#diff-f419668fe8241d8cf01b2d29346cdd5b0d5a2421a8a7fb311e05c5532798393cL4-R4)).


