### PR TITLE
fix(composer-app): Aggressive tooltip

### DIFF
--- a/packages/apps/composer-app/src/components/Sidebar/SpaceTreeItem.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/SpaceTreeItem.tsx
@@ -13,7 +13,7 @@ import {
   Plus,
   Upload
 } from '@phosphor-icons/react';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { FileUploader } from 'react-drag-drop-files';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -93,6 +93,10 @@ export const SpaceTreeItem = observer(({ space }: { space: Space }) => {
 
   const OpenTriggerIcon = open ? CaretDown : CaretRight;
 
+  const suppressNextTooltip = useRef<boolean>(false);
+  const [optionsTooltipOpen, setOptionsTooltipOpen] = useState(false);
+  const [optionsMenuOpen, setOpetionsMenuOpen] = useState(false);
+
   return (
     <TreeItem
       collapsible
@@ -113,7 +117,17 @@ export const SpaceTreeItem = observer(({ space }: { space: Space }) => {
         >
           {spaceDisplayName}
         </TreeItemHeading>
-        <TooltipRoot>
+        <TooltipRoot
+          open={optionsTooltipOpen}
+          onOpenChange={(nextOpen) => {
+            if (suppressNextTooltip.current) {
+              setOptionsTooltipOpen(false);
+              suppressNextTooltip.current = false;
+            } else {
+              setOptionsTooltipOpen(nextOpen);
+            }
+          }}
+        >
           <TooltipContent className='z-[31]' side='bottom'>
             {t('space options label')}
           </TooltipContent>
@@ -125,7 +139,18 @@ export const SpaceTreeItem = observer(({ space }: { space: Space }) => {
                 </Button>
               </TooltipTrigger>
             }
-            slots={{ content: { className: 'z-[31]' } }}
+            slots={{
+              root: {
+                open: optionsMenuOpen,
+                onOpenChange: (nextOpen: boolean) => {
+                  if (!nextOpen) {
+                    suppressNextTooltip.current = true;
+                  }
+                  return setOpetionsMenuOpen(nextOpen);
+                }
+              },
+              content: { className: 'z-[31]' }
+            }}
           >
             <DropdownMenuItem asChild>
               <Input


### PR DESCRIPTION
This PR suppresses the space options tooltip if the space options menu has just closed. Maybe this combination should have its own component so behavior is consistent.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f0b0e41</samp>

### Summary
🛠️🎛️🚫

<!--
1.  🛠️ - This emoji conveys the idea of adding or fixing some functionality, which is what the state and logic for the tooltip and options menu do.
2.  🎛️ - This emoji suggests the idea of controlling or adjusting some settings or features, which is what the user can do with the options menu for the space tree item.
3.  🚫 - This emoji implies the idea of preventing or stopping something, which is what the suppression of the tooltip does when the menu is closed.
-->
Improved the user interface of the `SpaceTreeItem` component by adding a tooltip and an options menu. The tooltip shows the space name and is hidden when the menu is open.

> _`SpaceTreeItem` shows_
> _menu and tooltip logic_
> _cut by state changes_

### Walkthrough
* Import `useRef` hook from React and create a ref for suppressing tooltip ([link](https://github.com/dxos/dxos/pull/3155/files?diff=unified&w=0#diff-f8e3808db58778e839e4a238076a4165fddf59cf5114ae4bfb296d923c3e2044L16-R16))
* Add state variables for controlling tooltip and options menu visibility and suppression ([link](https://github.com/dxos/dxos/pull/3155/files?diff=unified&w=0#diff-f8e3808db58778e839e4a238076a4165fddf59cf5114ae4bfb296d923c3e2044R96-R99))
* Sync `TooltipRoot` component with `optionsTooltipOpen` state and check `suppressNextTooltip` ref value ([link](https://github.com/dxos/dxos/pull/3155/files?diff=unified&w=0#diff-f8e3808db58778e839e4a238076a4165fddf59cf5114ae4bfb296d923c3e2044L116-R130))
* Sync `DropdownMenu` component with `optionsMenuOpen` state and set `suppressNextTooltip` ref value ([link](https://github.com/dxos/dxos/pull/3155/files?diff=unified&w=0#diff-f8e3808db58778e839e4a238076a4165fddf59cf5114ae4bfb296d923c3e2044L128-R153))


