### PR TITLE
refactor: factor out timeout constants

### DIFF
--- a/packages/common/timeouts/package.json
+++ b/packages/common/timeouts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@dxos/timeouts",
+  "version": "0.1.41",
+  "description": "Common timeouts used by DXOS.",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "license": "MIT",
+  "author": "DXOS.org",
+  "main": "dist/lib/node/index.cjs",
+  "browser": {
+    "./dist/lib/node/index.cjs": "./dist/lib/browser/index.mjs"
+  },
+  "types": "dist/types/src/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/common/timeouts/project.json
+++ b/packages/common/timeouts/project.json
@@ -1,0 +1,44 @@
+{
+  "sourceRoot": "packages/common/timeouts/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "options": {
+        "main": "packages/common/timeouts/src/index.ts",
+        "outputPath": "packages/common/timeouts/dist/types",
+        "tsConfig": "packages/common/timeouts/tsconfig.json"
+      },
+      "outputs": [
+        "{options.outputPath}"
+      ]
+    },
+    "compile": {
+      "executor": "@dxos/esbuild:build",
+      "options": {
+        "entryPoints": [
+          "packages/common/timeouts/src/index.ts"
+        ],
+        "outputPath": "packages/common/timeouts/dist/lib"
+      },
+      "outputs": [
+        "{options.outputPath}"
+      ]
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "options": {
+        "format": "unix",
+        "lintFilePatterns": [
+          "packages/common/timeouts/src/**/*.{ts,js}"
+        ]
+      },
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  },
+  "implicitDependencies": [
+    "esbuild"
+  ]
+}

--- a/packages/common/timeouts/src/index.ts
+++ b/packages/common/timeouts/src/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+export * from './timeouts';

--- a/packages/common/timeouts/src/timeouts.ts
+++ b/packages/common/timeouts/src/timeouts.ts
@@ -1,0 +1,21 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+// TODO(wittjosiah): Specify when when and why this is used.
+/**
+ *
+ */
+export const DEFAULT_TIMEOUT = 30_000;
+
+// TODO(wittjosiah): Specify when when and why this is used.
+/**
+ *
+ */
+export const LONG_TIMEOUT = 60_000;
+
+// TODO(wittjosiah): Specify when when and why this is used.
+/**
+ *
+ */
+export const SHORT_TIMEOUT = 10_000;

--- a/packages/common/timeouts/tsconfig.json
+++ b/packages/common/timeouts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/types"
+  },
+  "include": [
+    "src"
+  ],
+  "references": []
+}

--- a/packages/sdk/client/package.json
+++ b/packages/sdk/client/package.json
@@ -41,6 +41,7 @@
     "@dxos/rpc": "workspace:*",
     "@dxos/rpc-tunnel": "workspace:*",
     "@dxos/text-model": "workspace:*",
+    "@dxos/timeouts": "workspace:*",
     "@dxos/util": "workspace:*",
     "base-x": "~3.0.9",
     "debug": "^4.3.3",

--- a/packages/sdk/client/src/packlets/client/iframe-service-proxy.ts
+++ b/packages/sdk/client/src/packlets/client/iframe-service-proxy.ts
@@ -12,6 +12,7 @@ import { LogEntry, LogLevel } from '@dxos/protocols/proto/dxos/client/services';
 import { LayoutRequest, ShellDisplay, ShellLayout } from '@dxos/protocols/proto/dxos/iframe';
 import { RpcPort } from '@dxos/rpc';
 import { createIFrame, createIFramePort, createWorkerPort } from '@dxos/rpc-tunnel';
+import { DEFAULT_TIMEOUT } from '@dxos/timeouts';
 import { Provider } from '@dxos/util';
 
 import { ShellController } from '../proxies';
@@ -70,7 +71,7 @@ export class IFrameClientServicesProxy implements ClientServicesProvider {
     shell = DEFAULT_SHELL_CHANNEL,
     vault = DEFAULT_INTERNAL_CHANNEL,
     logFilter = 'error,warn',
-    timeout = 3000
+    timeout = DEFAULT_TIMEOUT
   }: Partial<IFrameClientServicesProxyOptions> = {}) {
     this._handleKeyDown = this._handleKeyDown.bind(this);
     this._options = { source, channel, shell, vault, logFilter, timeout };

--- a/packages/sdk/client/tsconfig.json
+++ b/packages/sdk/client/tsconfig.json
@@ -43,6 +43,9 @@
       "path": "../../common/random-access-storage"
     },
     {
+      "path": "../../common/timeouts"
+    },
+    {
       "path": "../../common/util"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1323,6 +1323,9 @@ importers:
     devDependencies:
       '@types/debug': 4.1.7
 
+  packages/common/timeouts:
+    specifiers: {}
+
   packages/common/typings:
     specifiers: {}
 
@@ -3972,6 +3975,7 @@ importers:
       '@dxos/rpc': workspace:*
       '@dxos/rpc-tunnel': workspace:*
       '@dxos/text-model': workspace:*
+      '@dxos/timeouts': workspace:*
       '@dxos/util': workspace:*
       '@types/lodash.isequal': ^4.5.0
       '@types/lodash.isequalwith': ^4.4.0
@@ -4003,6 +4007,7 @@ importers:
       '@dxos/rpc': link:../../core/mesh/rpc
       '@dxos/rpc-tunnel': link:../../core/mesh/rpc-tunnel
       '@dxos/text-model': link:../../core/echo/text-model
+      '@dxos/timeouts': link:../../common/timeouts
       '@dxos/util': link:../../common/util
       base-x: 3.0.9
       debug: 4.3.4
@@ -16149,7 +16154,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.20.12
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.3.1_@types+node@18.11.9
+      vite: 4.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -16166,7 +16171,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.21.3
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.3.1
+      vite: 4.3.1_@types+node@18.11.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -36081,7 +36086,7 @@ packages:
       fast-glob: 3.2.12
       pretty-bytes: 6.0.0
       rollup: 3.20.4
-      vite: 4.3.1_@types+node@18.11.9
+      vite: 4.3.1
       workbox-build: 6.5.4
       workbox-window: 6.5.4
     transitivePeerDependencies:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -158,6 +158,11 @@
         },
         {
           "type": "json",
+          "path": "packages/common/timeouts/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "packages/common/typings/package.json",
           "jsonpath": "$.version"
         },


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5891d65</samp>

### Summary
📦⏱️🔄

<!--
1.  📦 - This emoji represents the addition of a new package to the monorepo. It conveys the idea of packaging and distributing code as a reusable module.
2.  ⏱️ - This emoji represents the use of timeouts for controlling the execution of asynchronous operations. It conveys the idea of time and duration.
3.  🔄 - This emoji represents the update of an existing package to use the new package as a dependency. It conveys the idea of change and improvement.
-->
This pull request introduces a new package, `@dxos/timeouts`, that contains common timeout values used by DXOS. It also updates the `@dxos/client` package to use this package for setting the timeout option of the `IFrameClientServicesProxy` class. Additionally, it adds the necessary configuration files for building, linting, and releasing the new package.

> _`@dxos/timeouts`_
> _New package for common use_
> _Spring cleaning the code_

### Walkthrough
*  Add a new package `@dxos/timeouts` that contains common timeout values used by DXOS ([link](https://github.com/dxos/dxos/pull/3156/files?diff=unified&w=0#diff-3858650ab76df96c76a0448a0fb08f9458f04851e169cf51ea7d7b656e82589eR1-R17), [link](https://github.com/dxos/dxos/pull/3156/files?diff=unified&w=0#diff-83f0dfba5ec84f33613e0ce108851efe09d9c2640b69f7d69081b95e47e919c2R1-R44), [link](https://github.com/dxos/dxos/pull/3156/files?diff=unified&w=0#diff-6a843424a39540205a0cf987cecad390372b52021600a23dce96543106845ab0R1-R5), [link](https://github.com/dxos/dxos/pull/3156/files?diff=unified&w=0#diff-5126b7281394f0903caaaec74e91c554d607c97465945b538ed295ee0f8f66acR1-R21), [link](https://github.com/dxos/dxos/pull/3156/files?diff=unified&w=0#diff-2a5a27d04e99ebaf9dd683890ffd77cd7d962327d19ade8c8f7d7a54b200fb63R1-R10), [link](https://github.com/dxos/dxos/pull/3156/files?diff=unified&w=0#diff-c55d4dcb68c348b2c06d263819702fbce72eeeb35b662956d02049a5a18fcf2bR161-R165)).


