### PR TITLE
refactor(aurora): `Avatar`

### DIFF
--- a/packages/apps/composer-app/src/components/Sidebar/DocumentTreeItem.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/DocumentTreeItem.tsx
@@ -8,7 +8,7 @@ import { Link, useParams } from 'react-router-dom';
 
 import { useTranslation, ListItemEndcap } from '@dxos/aurora';
 import { TextKind } from '@dxos/aurora-composer';
-import { getSize, mx, tx } from '@dxos/aurora-theme';
+import { getSize, mx, appTx } from '@dxos/aurora-theme';
 import { TreeItem, TreeItemHeading } from '@dxos/react-appkit';
 import { observer } from '@dxos/react-client';
 
@@ -24,8 +24,10 @@ export const DocumentTreeItem = observer(({ document, linkTo }: { document: Comp
       <TreeItemHeading asChild>
         <Link
           to={linkTo}
-          className={mx(
-            tx('button.root', 'tree-item__heading--link', { variant: 'ghost' }),
+          className={appTx(
+            'button.root',
+            'tree-item__heading--link',
+            { variant: 'ghost' },
             'is-full text-base p-0 font-normal items-start gap-1'
           )}
           data-testid='composer.documentTreeItemHeading'

--- a/packages/experimental/kai-framework/src/containers/Surface/Surface.stories.tsx
+++ b/packages/experimental/kai-framework/src/containers/Surface/Surface.stories.tsx
@@ -8,7 +8,7 @@ import { createMemoryRouter, RouterProvider, useLocation, useNavigate, useParams
 
 import { Event } from '@dxos/async';
 import { Button, MainRoot, Sidebar as SidebarRoot, Main, ThemeProvider, MainOverlay, useSidebar } from '@dxos/aurora';
-import { getSize, mx, tx } from '@dxos/aurora-theme';
+import { getSize, mx, appTx } from '@dxos/aurora-theme';
 import { raise } from '@dxos/debug';
 import { FullscreenDecorator } from '@dxos/kai-frames';
 import { appkitTranslations, Input } from '@dxos/react-appkit';
@@ -329,7 +329,7 @@ const TestApp = () => {
   };
 
   const Root = () => (
-    <ThemeProvider appNs='kai' rootDensity='fine' resourceExtensions={[osTranslations, appkitTranslations]} tx={tx}>
+    <ThemeProvider appNs='kai' rootDensity='fine' resourceExtensions={[osTranslations, appkitTranslations]} tx={appTx}>
       <SurfaceControllerContextProvider components={components}>
         <Layout />
       </SurfaceControllerContextProvider>

--- a/packages/sdk/react-client/.storybook/preview.cjs
+++ b/packages/sdk/react-client/.storybook/preview.cjs
@@ -1,6 +1,6 @@
 import { createElement, useEffect } from 'react';
 import { ThemeProvider } from '@dxos/aurora';
-import { tx } from '@dxos/aurora-theme';
+import { appTx } from '@dxos/aurora-theme';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -38,7 +38,7 @@ const withTheme = (StoryFn, context) => {
     document.documentElement.classList[theme === 'dark' ? 'add' : 'remove']('dark');
   }, [theme]);
 
-  return createElement(ThemeProvider, { tx, children: StoryFn() });
+  return createElement(ThemeProvider, { tx: appTx, children: StoryFn() });
 };
 
 export const decorators = [withTheme];

--- a/packages/ui/aurora-theme/src/styles/components/avatar.ts
+++ b/packages/ui/aurora-theme/src/styles/components/avatar.ts
@@ -1,0 +1,41 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { ComponentFunction, Size, Theme } from '@dxos/aurora-types';
+
+import { mx } from '../../util';
+import { getSize } from '../fragments';
+
+export type AvatarStyleProps = Partial<{
+  size: Size;
+  srOnly: boolean;
+  status: 'active' | 'inactive';
+}>;
+
+export const avatarRoot: ComponentFunction<AvatarStyleProps> = ({ size = 10 }, ...etc) =>
+  mx('relative inline-flex', getSize(size), ...etc);
+
+export const avatarLabel: ComponentFunction<AvatarStyleProps> = ({ srOnly = true }, ...etc) =>
+  mx(srOnly && 'sr-only', ...etc);
+
+export const avatarStatus: ComponentFunction<AvatarStyleProps> = (_props, ...etc) => mx('is-full bs-full', ...etc);
+
+export const avatarStatusIcon: ComponentFunction<AvatarStyleProps> = ({ status, size = 3 }, ...etc) =>
+  mx(
+    'absolute block-end-0 inline-end-0',
+    getSize(size),
+    status === 'inactive'
+      ? 'text-warning-350 dark:text-warning-250'
+      : status === 'active'
+      ? 'text-success-350 dark:text-success-250'
+      : 'text-neutral-350 dark:text-neutral-250',
+    ...etc
+  );
+
+export const avatarTheme: Theme<AvatarStyleProps> = {
+  root: avatarRoot,
+  label: avatarLabel,
+  statusIcon: avatarStatusIcon,
+  status: avatarStatus
+};

--- a/packages/ui/aurora-theme/src/styles/components/index.ts
+++ b/packages/ui/aurora-theme/src/styles/components/index.ts
@@ -2,6 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
+export * from './avatar';
 export * from './button';
 export * from './input';
 export * from './dropdown-menu';

--- a/packages/ui/aurora-theme/src/styles/theme.ts
+++ b/packages/ui/aurora-theme/src/styles/theme.ts
@@ -14,7 +14,8 @@ import {
   inputTheme,
   inputOsTheme,
   mainTheme,
-  messageTheme
+  messageTheme,
+  avatarTheme
 } from './components';
 
 export const theme: Theme<Record<string, any>> = {
@@ -24,7 +25,8 @@ export const theme: Theme<Record<string, any>> = {
   input: inputTheme,
   list: listTheme,
   main: mainTheme,
-  message: messageTheme
+  message: messageTheme,
+  avatar: avatarTheme
 };
 
 export const osTheme: Theme<Record<string, any>> = {

--- a/packages/ui/aurora-theme/src/styles/theme.ts
+++ b/packages/ui/aurora-theme/src/styles/theme.ts
@@ -35,7 +35,7 @@ export const osTheme: Theme<Record<string, any>> = {
   list: listOsTheme
 };
 
-export const tx = <P extends Record<string, any>>(
+export const appTx = <P extends Record<string, any>>(
   path: string,
   defaultClassName: string,
   styleProps: P,

--- a/packages/ui/aurora/.storybook/preview.cjs
+++ b/packages/ui/aurora/.storybook/preview.cjs
@@ -1,6 +1,6 @@
 import React, {createElement, useEffect} from 'react';
 import {ThemeProvider} from '../src';
-import {tx} from '@dxos/aurora-theme';
+import {appTx} from '@dxos/aurora-theme';
 
 export const parameters = {
   actions: {argTypesRegex: "^on[A-Z].*"},
@@ -36,7 +36,7 @@ const withTheme = (StoryFn, context) => {
   useEffect(()=>{
     document.documentElement.classList[theme === 'dark' ? 'add' : 'remove']('dark')
   }, [theme])
-  return createElement(ThemeProvider, {children: createElement(StoryFn), tx})
+  return createElement(ThemeProvider, {children: createElement(StoryFn), tx: appTx})
 }
 
 export const decorators = [withTheme];

--- a/packages/ui/aurora/package.json
+++ b/packages/ui/aurora/package.json
@@ -18,12 +18,14 @@
     "chromatic": "chromatic --project-token=\"44ade288043a\" --storybook-build-dir out/aurora --exit-zero-on-changes"
   },
   "dependencies": {
+    "@radix-ui/react-avatar": "^1.0.2",
     "@radix-ui/react-context": "^1.0.0",
     "@radix-ui/react-dialog": "^1.0.3",
     "@radix-ui/react-primitive": "^1.0.2",
     "@radix-ui/react-slot": "^1.0.1",
     "@radix-ui/react-use-controllable-state": "^1.0.0",
     "i18next": "^21.10.0",
+    "jdenticon": "^3.2.0",
     "react-i18next": "^11.18.6"
   },
   "devDependencies": {

--- a/packages/ui/aurora/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/ui/aurora/src/components/Avatar/Avatar.stories.tsx
@@ -1,0 +1,65 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+import '@dxosTheme';
+import React from 'react';
+
+import { Size } from '@dxos/aurora-types';
+
+import {
+  AvatarFallback,
+  AvatarImage,
+  AvatarLabel,
+  AvatarMaskedImage,
+  AvatarRoot,
+  AvatarStatus,
+  useJdenticonHref
+} from './Avatar';
+
+type StorybookAvatarProps = {
+  imgSrc?: string;
+  fallbackValue: string;
+  label: string;
+  status?: 'active' | 'inactive';
+  variant?: 'circle' | 'square';
+  size?: Size;
+};
+
+const StorybookAvatar = ({
+  status = 'active',
+  size = 12,
+  variant = 'circle',
+  label,
+  fallbackValue,
+  imgSrc
+}: StorybookAvatarProps) => {
+  const jdenticon = useJdenticonHref(fallbackValue ?? '', size);
+  return (
+    <AvatarRoot {...{ size, variant }}>
+      <AvatarLabel>{label}</AvatarLabel>
+      <AvatarStatus status={status}>
+        <AvatarImage asChild>
+          <AvatarMaskedImage href={imgSrc} />
+        </AvatarImage>
+        <AvatarFallback asChild>
+          <AvatarMaskedImage href={jdenticon} />
+        </AvatarFallback>
+      </AvatarStatus>
+    </AvatarRoot>
+  );
+};
+
+export default {
+  component: StorybookAvatar
+};
+
+export const Default = {
+  args: {
+    fallbackValue: '20970b563fc49b5bb194a6ffdff376031a3a11f9481360c071c3fed87874106b',
+    label: 'Display name',
+    status: 'active',
+    variant: 'circle',
+    size: 12
+  }
+};

--- a/packages/ui/aurora/src/components/Avatar/Avatar.tsx
+++ b/packages/ui/aurora/src/components/Avatar/Avatar.tsx
@@ -23,15 +23,15 @@ import { useThemeContext } from '../../hooks';
 
 type AvatarVariant = 'square' | 'circle';
 
-type AvatarRootProps = AvatarRootPrimitiveProps & { size?: Size; variant?: AvatarVariant };
+type AvatarRootProps = AvatarRootPrimitiveProps & { labelId?: string; size?: Size; variant?: AvatarVariant };
 
 type AvatarContextValue = { labelId: string; maskId: string; size: Size; variant: AvatarVariant };
 const AVATAR_NAME = 'Avatar';
 const [AvatarProvider, useAvatarContext] = createContext<AvatarContextValue>(AVATAR_NAME);
 
 const AvatarRoot = forwardRef<HTMLSpanElement, AvatarRootProps>(
-  ({ size = 10, variant = 'circle', className, id: propsId, ...props }, forwardedRef) => {
-    const labelId = useId('avatar__label', propsId);
+  ({ size = 10, variant = 'circle', className, labelId: propsLabelId, ...props }, forwardedRef) => {
+    const labelId = useId('avatar__label', propsLabelId);
     const maskId = useId('mask');
     const { tx } = useThemeContext();
     return (

--- a/packages/ui/aurora/src/components/Avatar/Avatar.tsx
+++ b/packages/ui/aurora/src/components/Avatar/Avatar.tsx
@@ -1,0 +1,173 @@
+//
+// Copyright 2023 DXOS.org
+//
+import { Circle, Moon } from '@phosphor-icons/react';
+import {
+  Root as AvatarRootPrimitive,
+  AvatarProps as AvatarRootPrimitiveProps,
+  Image as AvatarImagePrimitive,
+  AvatarImageProps as AvatarImagePrimitiveProps,
+  Fallback as AvatarFallbackPrimitive,
+  AvatarFallbackProps as AvatarFallbackPrimitiveProps
+} from '@radix-ui/react-avatar';
+import { createContext } from '@radix-ui/react-context';
+import { Primitive } from '@radix-ui/react-primitive';
+import { Slot } from '@radix-ui/react-slot';
+import { toSvg } from 'jdenticon';
+import React, { ComponentPropsWithRef, forwardRef, useMemo } from 'react';
+
+import { Size } from '@dxos/aurora-types';
+import { useId } from '@dxos/react-hooks';
+
+import { useThemeContext } from '../../hooks';
+
+type AvatarVariant = 'square' | 'circle';
+
+type AvatarRootProps = AvatarRootPrimitiveProps & { size?: Size; variant?: AvatarVariant };
+
+type AvatarContextValue = { labelId: string; maskId: string; size: Size; variant: AvatarVariant };
+const AVATAR_NAME = 'Avatar';
+const [AvatarProvider, useAvatarContext] = createContext<AvatarContextValue>(AVATAR_NAME);
+
+const AvatarRoot = forwardRef<HTMLSpanElement, AvatarRootProps>(
+  ({ size = 10, variant = 'circle', className, id: propsId, ...props }, forwardedRef) => {
+    const labelId = useId('avatar__label', propsId);
+    const maskId = useId('mask');
+    const { tx } = useThemeContext();
+    return (
+      <AvatarProvider {...{ labelId, maskId, size, variant }}>
+        <AvatarRootPrimitive
+          {...props}
+          className={tx('avatar.root', 'avatar', { size, variant }, className)}
+          ref={forwardedRef}
+        />
+      </AvatarProvider>
+    );
+  }
+);
+
+type AvatarLabelProps = Omit<ComponentPropsWithRef<typeof Primitive.span>, 'id'> & {
+  asChild?: boolean;
+  srOnly?: boolean;
+};
+
+const AvatarLabel = forwardRef<HTMLSpanElement, AvatarLabelProps>(
+  ({ asChild, srOnly, className, ...props }, forwardedRef) => {
+    const Root = asChild ? Slot : Primitive.span;
+    const { tx } = useThemeContext();
+    const { labelId } = useAvatarContext('AvatarLabel');
+    return (
+      <Root
+        {...props}
+        id={labelId}
+        ref={forwardedRef}
+        className={tx('avatar.label', 'avatar__label', { srOnly }, className)}
+      />
+    );
+  }
+);
+
+type AvatarImageProps = AvatarImagePrimitiveProps;
+
+const AvatarImage = forwardRef<HTMLImageElement, AvatarImageProps>((props, forwardedRef) => {
+  const { labelId } = useAvatarContext('AvatarImage');
+  return <AvatarImagePrimitive role='img' {...props} aria-labelledby={labelId} ref={forwardedRef} />;
+});
+
+type AvatarFallbackProps = AvatarFallbackPrimitiveProps;
+
+const AvatarFallback = forwardRef<HTMLSpanElement, AvatarFallbackProps>((props, forwardedRef) => {
+  const { labelId } = useAvatarContext('AvatarFallback');
+  return <AvatarFallbackPrimitive role='img' {...props} aria-labelledby={labelId} ref={forwardedRef} />;
+});
+
+type AvatarStatusProps = ComponentPropsWithRef<'svg'> & { status?: 'active' | 'inactive' };
+
+const AvatarStatus = forwardRef<SVGSVGElement, AvatarStatusProps>(
+  ({ children, className, status, ...props }, forwardedRef) => {
+    const { labelId, maskId, size, variant } = useAvatarContext('AvatarStatus');
+    const { tx } = useThemeContext();
+    const imageSizeNumber = size === 'px' ? 1 : size * 4;
+    const statusIconSize = size > 9 ? 4 : size < 6 ? 2 : 3;
+    const maskSize = statusIconSize * 4 + 2;
+    const maskCenter = imageSizeNumber - (statusIconSize * 4) / 2;
+    return (
+      <>
+        <svg
+          role='img'
+          {...props}
+          viewBox={`0 0 ${imageSizeNumber} ${imageSizeNumber}`}
+          width={imageSizeNumber}
+          height={imageSizeNumber}
+          aria-labelledby={labelId}
+          className={tx('avatar.status', 'avatar__status', {}, className)}
+        >
+          <defs>
+            <mask id={maskId}>
+              {variant === 'circle' ? (
+                <circle fill='white' cx='50%' cy='50%' r='50%' />
+              ) : (
+                <rect fill='white' width='100%' height='100%' />
+              )}
+              {status && (
+                <circle
+                  fill='black'
+                  cx={`${(100 * maskCenter) / imageSizeNumber}%`}
+                  cy={`${(100 * maskCenter) / imageSizeNumber}%`}
+                  r={`${(50 * maskSize) / imageSizeNumber}%`}
+                />
+              )}
+            </mask>
+          </defs>
+          {children}
+        </svg>
+        {status === 'inactive' ? (
+          <Moon
+            mirrored
+            weight='fill'
+            className={tx('avatar.statusIcon', 'avatar__status__icon', { size: statusIconSize, status })}
+          />
+        ) : (
+          <Circle
+            weight='fill'
+            className={tx('avatar.statusIcon', 'avatar__status__icon', { size: statusIconSize, status })}
+          />
+        )}
+      </>
+    );
+  }
+);
+
+type AvatarMaskedImageProps = ComponentPropsWithRef<'image'>;
+
+const AvatarMaskedImage = forwardRef<SVGImageElement, AvatarMaskedImageProps>((props, forwardedRef) => {
+  const { maskId } = useAvatarContext('AvatarFallback');
+  return <image width='100%' height='100%' {...props} mask={`url(#${maskId})`} ref={forwardedRef} />;
+});
+
+const useJdenticonHref = (value: string, size: Size) => {
+  return useMemo(
+    () => `data:image/svg+xml;utf8,${encodeURIComponent(toSvg(value, size === 'px' ? 1 : size * 4, { padding: 0 }))}`,
+    [value]
+  );
+};
+
+export {
+  AvatarRoot,
+  AvatarImage,
+  AvatarFallback,
+  AvatarLabel,
+  AvatarStatus,
+  AvatarMaskedImage,
+  useJdenticonHref,
+  useAvatarContext
+};
+
+export type {
+  AvatarRootProps,
+  AvatarImageProps,
+  AvatarFallbackProps,
+  AvatarLabelProps,
+  AvatarStatusProps,
+  AvatarMaskedImageProps
+};

--- a/packages/ui/aurora/src/components/Avatar/index.ts
+++ b/packages/ui/aurora/src/components/Avatar/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+export * from './Avatar';

--- a/packages/ui/aurora/src/components/Input/Input.tsx
+++ b/packages/ui/aurora/src/components/Input/Input.tsx
@@ -29,12 +29,6 @@ import {
 import { useDensityContext, useElevationContext, useThemeContext } from '../../hooks';
 import { ThemedClassName } from '../../util';
 
-type RootProps = InputRootProps;
-
-const Root = (props: RootProps) => {
-  return <InputRoot {...props} />;
-};
-
 type LabelProps = ThemedClassName<LabelPrimitiveProps> & { srOnly?: boolean };
 
 const Label = forwardRef<HTMLLabelElement, LabelProps>(({ srOnly, className, children, ...props }, forwardedRef) => {
@@ -225,21 +219,10 @@ const TextArea = forwardRef<HTMLTextAreaElement, InputScopedProps<TextAreaProps>
   }
 );
 
-export {
-  Root,
-  Root as InputRoot,
-  Label,
-  Description,
-  Validation,
-  DescriptionAndValidation,
-  PinInput,
-  TextInput,
-  TextArea
-};
+export { InputRoot, Label, Description, Validation, DescriptionAndValidation, PinInput, TextInput, TextArea };
 
 export type {
-  RootProps,
-  RootProps as InputRootProps,
+  InputRootProps,
   LabelProps,
   DescriptionProps,
   ValidationProps,

--- a/packages/ui/aurora/src/components/Message/Message.tsx
+++ b/packages/ui/aurora/src/components/Message/Message.tsx
@@ -16,6 +16,8 @@ type MessageProps = ComponentPropsWithRef<typeof Primitive.div> & {
   valence?: MessageValence;
   elevation?: Elevation;
   asChild?: boolean;
+  titleId?: string;
+  descriptionId?: string;
 };
 
 type MessageContextValue = { titleId?: string; descriptionId: string };
@@ -23,10 +25,19 @@ const MESSAGE_NAME = 'Message';
 const [MessageProvider, useMessageContext] = createContext<MessageContextValue>(MESSAGE_NAME);
 
 const Message = forwardRef<HTMLDivElement, MessageProps>(
-  ({ asChild, valence, elevation: propsElevation, className, children, ...props }) => {
+  ({
+    asChild,
+    valence,
+    elevation: propsElevation,
+    className,
+    titleId: propsTitleId,
+    descriptionId: propsDescriptionId,
+    children,
+    ...props
+  }) => {
     const { tx } = useThemeContext();
-    const titleId = useId('message__title');
-    const descriptionId = useId('message__description');
+    const titleId = useId('message__title', propsTitleId);
+    const descriptionId = useId('message__description', propsDescriptionId);
     const elevation = useElevationContext(propsElevation);
     const Root = asChild ? Slot : Primitive.div;
     return (

--- a/packages/ui/aurora/src/components/index.ts
+++ b/packages/ui/aurora/src/components/index.ts
@@ -2,6 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
+export * from './Avatar';
 export * from './Button';
 export * from './Input';
 export * from './List';

--- a/packages/ui/primitives/react-input/src/Root.tsx
+++ b/packages/ui/primitives/react-input/src/Root.tsx
@@ -13,7 +13,12 @@ type Valence = 'success' | 'info' | 'warning' | 'error' | 'neutral';
 
 type InputScopedProps<P> = P & { __inputScope?: Scope };
 
-type InputRootProps = PropsWithChildren<{ id?: string; validationValence?: Valence }>;
+type InputRootProps = PropsWithChildren<{
+  id?: string;
+  validationValence?: Valence;
+  descriptionId?: string;
+  errorMessageId?: string;
+}>;
 
 const [createInputContext, createInputScope] = createContextScope(INPUT_NAME, []);
 
@@ -27,14 +32,16 @@ type InputContextValue = {
 const [InputProvider, useInputContext] = createInputContext<InputContextValue>(INPUT_NAME);
 
 const InputRoot = ({
-  id: propsId,
-  validationValence = 'neutral',
   __inputScope,
+  id: propsId,
+  descriptionId: propsDescriptionId,
+  errorMessageId: propsErrorMessageId,
+  validationValence = 'neutral',
   children
 }: InputScopedProps<InputRootProps>) => {
   const id = useId('input', propsId);
-  const descriptionId = useId('input__description');
-  const errorMessageId = useId('input__error-message');
+  const descriptionId = useId('input__description', propsDescriptionId);
+  const errorMessageId = useId('input__error-message', propsErrorMessageId);
   return (
     <InputProvider {...{ id, descriptionId, errorMessageId, validationValence }} scope={__inputScope}>
       {children}

--- a/packages/ui/react-appkit/package.json
+++ b/packages/ui/react-appkit/package.json
@@ -64,7 +64,6 @@
     "@radix-ui/react-toolbar": "^1.0.3",
     "@radix-ui/react-tooltip": "^1.0.5",
     "@radix-ui/react-use-controllable-state": "^1.0.0",
-    "jdenticon": "^3.2.0",
     "localforage": "^1.10.0",
     "lodash.merge": "^4.6.2",
     "lodash.throttle": "^4.1.1",

--- a/packages/ui/react-appkit/src/components/Avatar/Avatar.tsx
+++ b/packages/ui/react-appkit/src/components/Avatar/Avatar.tsx
@@ -5,7 +5,6 @@
 import { Circle, Moon } from '@phosphor-icons/react';
 import * as AvatarPrimitive from '@radix-ui/react-avatar';
 import * as PortalPrimitive from '@radix-ui/react-portal';
-import { toSvg } from 'jdenticon';
 import React, {
   cloneElement,
   ComponentProps,
@@ -13,8 +12,7 @@ import React, {
   forwardRef,
   PropsWithChildren,
   ReactHTMLElement,
-  ReactNode,
-  useMemo
+  ReactNode
 } from 'react';
 
 import { useId, Size } from '@dxos/aurora';
@@ -73,13 +71,6 @@ export const Avatar = forwardRef(
     const descriptionId = useId('avatarDescription', propsDescriptionId);
     const maskId = useId('mask');
     const svgId = useId('mask');
-    const fallbackSrc = useMemo(
-      () =>
-        `data:image/svg+xml;utf8,${encodeURIComponent(
-          toSvg(fallbackValue, size === 'px' ? 1 : size * 4, { padding: 0 })
-        )}`,
-      [fallbackValue]
-    );
 
     const imageSizeNumber = size === 'px' ? 1 : size * 4;
     const statusIconSize = size > 9 ? 4 : size < 6 ? 2 : 3;
@@ -125,7 +116,7 @@ export const Avatar = forwardRef(
               </AvatarPrimitive.Image>
             )}
             <AvatarPrimitive.Fallback delayMs={0} {...slots.fallback} asChild>
-              <image href={fallbackSrc} width='100%' height='100%' mask={`url(#${maskId})`} />
+              <image width='100%' height='100%' mask={`url(#${maskId})`} />
             </AvatarPrimitive.Fallback>
           </svg>
           {status === 'active' && (

--- a/packages/ui/react-appkit/src/components/Avatar/Avatar.tsx
+++ b/packages/ui/react-appkit/src/components/Avatar/Avatar.tsx
@@ -2,9 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import { Circle, Moon } from '@phosphor-icons/react';
 import * as AvatarPrimitive from '@radix-ui/react-avatar';
-import * as PortalPrimitive from '@radix-ui/react-portal';
 import React, {
   cloneElement,
   ComponentProps,
@@ -15,14 +13,23 @@ import React, {
   ReactNode
 } from 'react';
 
-import { useId, Size } from '@dxos/aurora';
-import { getSize, mx } from '@dxos/aurora-theme';
+import {
+  Size,
+  AvatarRoot,
+  AvatarFallback,
+  AvatarMaskedImage,
+  AvatarStatus,
+  AvatarImage,
+  useJdenticonHref,
+  useId
+} from '@dxos/aurora';
+import { mx } from '@dxos/aurora-theme';
 
 export interface AvatarSlots {
   root?: Omit<ComponentProps<typeof AvatarPrimitive.Root>, 'children'>;
   image?: ComponentProps<'image'>;
   fallback?: Omit<ComponentProps<typeof AvatarPrimitive.Fallback>, 'children'>;
-  labels?: Omit<ComponentProps<'div'>, 'children'>;
+  labels?: Omit<ComponentProps<'div'>, 'children' | 'ref'>;
 }
 
 interface SharedAvatarProps {
@@ -50,6 +57,9 @@ interface IdLabeledAvatarProps extends Omit<SharedAvatarProps, 'labelId'> {
 
 export type AvatarProps = DirectlyLabeledAvatarProps | IdLabeledAvatarProps;
 
+/**
+ * @deprecated please use `Avatar` from ui/aurora.
+ */
 export const Avatar = forwardRef(
   (
     {
@@ -67,90 +77,37 @@ export const Avatar = forwardRef(
     }: PropsWithChildren<AvatarProps>,
     ref: ForwardedRef<HTMLSpanElement>
   ) => {
-    const labelId = useId('avatarLabel', propsLabelId);
+    const jdenticon = useJdenticonHref(fallbackValue, size);
     const descriptionId = useId('avatarDescription', propsDescriptionId);
-    const maskId = useId('mask');
-    const svgId = useId('mask');
-
-    const imageSizeNumber = size === 'px' ? 1 : size * 4;
-    const statusIconSize = size > 9 ? 4 : size < 6 ? 2 : 3;
-    const maskSize = statusIconSize * 4 + 2;
-    const maskCenter = imageSizeNumber - (statusIconSize * 4) / 2;
+    const labelId = useId('avatarLabel', propsLabelId);
 
     return (
       <>
-        <AvatarPrimitive.Root
-          {...slots.root}
-          className={mx('relative inline-flex', getSize(size), slots.root?.className)}
-          aria-labelledby={labelId}
-          {...((description || propsDescriptionId) && { 'aria-describedby': descriptionId })}
-          ref={ref}
-        >
-          <svg
-            viewBox={`0 0 ${imageSizeNumber} ${imageSizeNumber}`}
-            width={imageSizeNumber}
-            height={imageSizeNumber}
-            id={svgId}
-            className='is-full bs-full'
-          >
-            <defs>
-              <mask id={maskId}>
-                {variant === 'circle' ? (
-                  <circle fill='white' cx='50%' cy='50%' r='50%' />
-                ) : (
-                  <rect fill='white' width='100%' height='100%' />
-                )}
-                {status && (
-                  <circle
-                    fill='black'
-                    cx={`${(100 * maskCenter) / imageSizeNumber}%`}
-                    cy={`${(100 * maskCenter) / imageSizeNumber}%`}
-                    r={`${(50 * maskSize) / imageSizeNumber}%`}
-                  />
-                )}
-              </mask>
-            </defs>
-            {mediaSrc && (
-              <AvatarPrimitive.Image asChild>
-                <image href={mediaSrc} width='100%' height='100%' {...slots.image} mask={`url(#${maskId})`} />
-              </AvatarPrimitive.Image>
-            )}
-            <AvatarPrimitive.Fallback delayMs={0} {...slots.fallback} asChild>
-              <image width='100%' height='100%' mask={`url(#${maskId})`} />
-            </AvatarPrimitive.Fallback>
-          </svg>
-          {status === 'active' && (
-            <Circle
-              className={mx(
-                getSize(statusIconSize),
-                'absolute block-end-0 inline-end-0 text-success-500 dark:text-success-400'
+        <AvatarRoot labelId={labelId} {...{ size, variant }} {...slots.root} ref={ref}>
+          {status ? (
+            <AvatarStatus {...{ status }}>
+              {mediaSrc && (
+                <AvatarImage asChild>
+                  <AvatarMaskedImage href={mediaSrc} />
+                </AvatarImage>
               )}
-              weight='fill'
-            />
+              <AvatarFallback delayMs={0} asChild>
+                <AvatarMaskedImage href={jdenticon} />
+              </AvatarFallback>
+            </AvatarStatus>
+          ) : (
+            <>
+              <AvatarImage src={mediaSrc} />
+              <AvatarFallback asChild delayMs={0}>
+                <img src={jdenticon} />
+              </AvatarFallback>
+            </>
           )}
-          {status === 'inactive' && (
-            <Moon
-              mirrored
-              className={mx(
-                getSize(statusIconSize),
-                'absolute block-end-0 inline-end-0 text-warning-500 dark:text-warning-400'
-              )}
-              weight='fill'
-            />
-          )}
-        </AvatarPrimitive.Root>
+        </AvatarRoot>
         <div role='none' {...slots.labels} className={mx('contents', slots?.labels?.className)}>
           {!propsLabelId &&
             label &&
-            (typeof label === 'string' ? (
-              <PortalPrimitive.Root asChild>
-                <span id={labelId} className='sr-only'>
-                  {label}
-                </span>
-              </PortalPrimitive.Root>
-            ) : (
-              cloneElement(label, { id: labelId })
-            ))}
+            (typeof label === 'string' ? <span id={labelId}>{label}</span> : cloneElement(label, { id: labelId }))}
           {!propsDescriptionId &&
             description &&
             (typeof description === 'string' ? (

--- a/packages/ui/react-appkit/src/components/Menubar/SpaceMenu.tsx
+++ b/packages/ui/react-appkit/src/components/Menubar/SpaceMenu.tsx
@@ -6,7 +6,7 @@ import { Gear, UserPlus, UsersThree } from '@phosphor-icons/react';
 import React from 'react';
 
 import { Button, useTranslation } from '@dxos/aurora';
-import { defaultInlineSeparator, getSize, mx, tx } from '@dxos/aurora-theme';
+import { defaultInlineSeparator, getSize, mx, appTx } from '@dxos/aurora-theme';
 import { Space } from '@dxos/client';
 import { useMembers } from '@dxos/react-client';
 
@@ -34,7 +34,7 @@ export const SpaceMenu = ({ space, onClickManageSpace }: SpaceMenuProps) => {
       slots={{
         content: { collisionPadding: 8, sideOffset: 4, className: 'flex flex-col gap-4 items-center z-[2]' },
         trigger: {
-          className: tx(
+          className: appTx(
             'button.root',
             'button button--popover-trigger',
             {},

--- a/packages/ui/react-appkit/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/ui/react-appkit/src/components/ThemeProvider/ThemeProvider.tsx
@@ -12,7 +12,7 @@ import { Provider as TooltipProvider, TooltipProviderProps } from '@radix-ui/rea
 import React, { PropsWithChildren } from 'react';
 
 import { ThemeProvider as AuroraThemeProvider, ThemeProviderProps as AuroraThemeProviderProps } from '@dxos/aurora';
-import { mx, osTx, tx } from '@dxos/aurora-theme';
+import { mx, osTx, appTx } from '@dxos/aurora-theme';
 
 export type ThemeProviderProps = AuroraThemeProviderProps &
   PropsWithChildren<{
@@ -31,7 +31,7 @@ export const ThemeProvider = ({
   ...auroraThemeProviderProps
 }: ThemeProviderProps) => {
   return (
-    <AuroraThemeProvider tx={themeVariant === 'os' ? osTx : tx} {...auroraThemeProviderProps}>
+    <AuroraThemeProvider tx={themeVariant === 'os' ? osTx : appTx} {...auroraThemeProviderProps}>
       <ToastProvider {...toastProviderProps}>
         <TooltipProvider delayDuration={100} skipDelayDuration={400} {...tooltipProviderProps}>
           {children}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4355,6 +4355,7 @@ importers:
       '@dxos/react-input': workspace:*
       '@dxos/react-list': workspace:*
       '@phosphor-icons/react': ^2.0.5
+      '@radix-ui/react-avatar': ^1.0.2
       '@radix-ui/react-context': ^1.0.0
       '@radix-ui/react-dialog': ^1.0.3
       '@radix-ui/react-primitive': ^1.0.2
@@ -4364,17 +4365,20 @@ importers:
       '@types/react-dom': ^18.0.6
       chromatic: ^6.17.0
       i18next: ^21.10.0
+      jdenticon: ^3.2.0
       react: ^18.2.0
       react-dom: ^18.2.0
       react-i18next: ^11.18.6
       vite: ^4.3.0
     dependencies:
+      '@radix-ui/react-avatar': 1.0.2_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-context': 1.0.0_react@18.2.0
       '@radix-ui/react-dialog': 1.0.3_rj7ozvcq3uehdlnj3cbwzbi5ce
       '@radix-ui/react-primitive': 1.0.2_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-slot': 1.0.1_react@18.2.0
       '@radix-ui/react-use-controllable-state': 1.0.0_react@18.2.0
       i18next: 21.10.0
+      jdenticon: 3.2.0
       react-i18next: 11.18.6_vfm63zmruocgezzfl2v26zlzpy
     devDependencies:
       '@dxos/aurora-theme': link:../aurora-theme
@@ -4674,7 +4678,6 @@ importers:
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
       '@vitejs/plugin-react': ^3.0.1
-      jdenticon: ^3.2.0
       localforage: ^1.10.0
       lodash.merge: ^4.6.2
       lodash.throttle: ^4.1.1
@@ -4723,7 +4726,6 @@ importers:
       '@radix-ui/react-toolbar': 1.0.3_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-tooltip': 1.0.5_rj7ozvcq3uehdlnj3cbwzbi5ce
       '@radix-ui/react-use-controllable-state': 1.0.0_react@18.2.0
-      jdenticon: 3.2.0
       localforage: 1.10.0
       lodash.merge: 4.6.2
       lodash.throttle: 4.1.1
@@ -16164,7 +16166,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.21.3
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.3.1_@types+node@18.11.9
+      vite: 4.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 626016c</samp>

### Summary
🆕🔄🗑️

<!--
1.  🆕 - This emoji represents the addition of a new component (`Avatar`) and its styles, stories, and exports.
2.  🔄 - This emoji represents the refactoring of existing components (`Surface`, `DocumentTreeItem`, `Input`, `Message`, `InputRoot`, `SpaceMenu`, `ThemeProvider`) to use a new function (`appTx`) or a new package (`@radix-ui/react-avatar`) or to improve their accessibility or performance.
3.  🗑️ - This emoji represents the removal of unused or deprecated code (`jdenticon`, `Root`) or dependencies.
-->
Refactored and improved the `Avatar` component and the `appTx` function across various packages. The `Avatar` component was moved from `@dxos/react-appkit` to `@dxos/aurora` and uses a new package for generating icons. The `appTx` function was used instead of `tx` for consistent and flexible theming and translation. Some accessibility and performance improvements were also made to the `Input` and `Message` components.

> _`Avatar` changes_
> _New package, styles, and props_
> _Cutting edge for spring_

### Walkthrough
*  Replace `tx` function with `appTx` function to use app-specific styles ([link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-d58f0f2d275d6bac5d0e020f74a09a1197fdc5fa3b5753bac2dff0bfb0561a04L11-R11), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-d58f0f2d275d6bac5d0e020f74a09a1197fdc5fa3b5753bac2dff0bfb0561a04L27-R30), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-8414a6bed737078dfd7178f17edcac05c2e5cbde4ec60f6e077d9223d10612dbL11-R11), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-8414a6bed737078dfd7178f17edcac05c2e5cbde4ec60f6e077d9223d10612dbL332-R332), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-7bb2012b247ad6a0f900eb04f56a017e4784a19be48c0200440b8e3eab4e36e1L3-R3), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-7bb2012b247ad6a0f900eb04f56a017e4784a19be48c0200440b8e3eab4e36e1L41-R41), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-69241f25f1647f6105233f677788a042089cb28715f9649a78636af9e554b8f5L38-R40), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-35ada7ce186768f3d7de34f31c0bfe38caa25af8fc52e1f6e72ebf88b5519781L3-R3), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-35ada7ce186768f3d7de34f31c0bfe38caa25af8fc52e1f6e72ebf88b5519781L39-R39), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-027fe9683eaa7e619b37f58e22e715ca55229830195e031f8b6db66de674dc65L9-R9), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-027fe9683eaa7e619b37f58e22e715ca55229830195e031f8b6db66de674dc65L37-R37), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-ed533ab05629c46751557f105f35b92564883cbddc26dc531e92b17ac89d0daaL15-R15), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-ed533ab05629c46751557f105f35b92564883cbddc26dc531e92b17ac89d0daaL34-R34))
* Create and export `Avatar` component from `@dxos/aurora` package, using `@radix-ui/react-avatar` and `jdenticon` libraries ([link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-50942872b0c5fdb1949c71c0c2de699b6e9d3532628d0533c3aa23949e43f66fR1-R41), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-6717dc8c34c2b5550dda33499aa5cb6877d28d65cdfc39790eb914faeec857a8R5), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-69241f25f1647f6105233f677788a042089cb28715f9649a78636af9e554b8f5L17-R18), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-69241f25f1647f6105233f677788a042089cb28715f9649a78636af9e554b8f5L27-R29), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-a281489d84c41bfc075f623060a2d0a3177bead5686f51e924af6c324b0d82bcR21), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-a281489d84c41bfc075f623060a2d0a3177bead5686f51e924af6c324b0d82bcR28), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-8c1865aba82a8cae819b3ec7c8848072a1e43aa4dcd71595e174aef7ec9437f9R1-R65), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-c423c77e2320cfc193556e34f2a45a3812493b4fc8a99addc67d152e4eabb5d1R1-R173), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-1463d1feae7b3334ee7f6ca5946808e5dbf2f7af18b6b873acb2702cc3c7dee3R1-R5), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-02990b17e78f053383504a80f8a57533e77557d6203d20a3e26f5ebe2034b2ffR5))
* Deprecate and refactor `Avatar` component from `@dxos/react-appkit` package, using `Avatar` component from `@dxos/aurora` package ([link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-c0621cb4939fa7023b777e8876037584b53b27550fe898ce6648fc8020638df0L67), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-9cb633e69ae5505f089c876f43fd02e0f09b366f5833aa02349c96ab228573bcL5-R5), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-9cb633e69ae5505f089c876f43fd02e0f09b366f5833aa02349c96ab228573bcL16-R26), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-9cb633e69ae5505f089c876f43fd02e0f09b366f5833aa02349c96ab228573bcL27-R32), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-9cb633e69ae5505f089c876f43fd02e0f09b366f5833aa02349c96ab228573bcR60-R62), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-9cb633e69ae5505f089c876f43fd02e0f09b366f5833aa02349c96ab228573bcL72-R110))
* Add `titleId` and `descriptionId` props to `Message` component for accessibility purposes ([link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-aff41d5d392f11eefc47a2f6abccbf86bc6738fc7a5213c9cda2d354c8522f8cR19-R20), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-aff41d5d392f11eefc47a2f6abccbf86bc6738fc7a5213c9cda2d354c8522f8cL26-R40))
* Add `descriptionId` and `errorMessageId` props to `InputRoot` component for accessibility purposes ([link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-47ad2f84783b63194dbe5d5bd928b5209627d69030ef7c017881bd44a9350c2aL16-R21), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-47ad2f84783b63194dbe5d5bd928b5209627d69030ef7c017881bd44a9350c2aL30-R44))
* Remove `Root` component and props from `Input` component as redundant ([link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-f419668fe8241d8cf01b2d29346cdd5b0d5a2421a8a7fb311e05c5532798393cL32-L37), [link](https://github.com/dxos/dxos/pull/3157/files?diff=unified&w=0#diff-f419668fe8241d8cf01b2d29346cdd5b0d5a2421a8a7fb311e05c5532798393cL228-R225))


