### PR TITLE
fix(kube-testing): Fix empty array stat

### DIFF
--- a/packages/gravity/kube-testing/src/analysys/logging.ts
+++ b/packages/gravity/kube-testing/src/analysys/logging.ts
@@ -50,12 +50,13 @@ export class LogReader implements AsyncIterable<SerializedLogEntry> {
 
   addFile(path: string) {
     // TODO(dmaretskyi): Read files chunk by chunk.
-    this._logs.push(
+    this._logs = [
+      this._logs,
       ...readFileSync(path, 'utf-8')
         .split('\n')
         .filter((line) => line.trim().length > 0)
         .map((line) => JSON.parse(line))
-    );
+    ];
   }
 
   async *[Symbol.asyncIterator](): AsyncGenerator<SerializedLogEntry> {

--- a/packages/gravity/kube-testing/src/analysys/stat-analysys.ts
+++ b/packages/gravity/kube-testing/src/analysys/stat-analysys.ts
@@ -141,7 +141,7 @@ export const analyzeSwarmEvents = async (results: PlanResults) => {
 
   let failures = 0;
   let ignored = 0;
-  const discoverLag = [];
+  const discoverLag = [0];
   const failureTtt = []; // Time Together on Topic
 
   for (const [_, peersPerTopic] of topics.entries()) {

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -2,31 +2,35 @@
 // Copyright 2023 DXOS.org
 //
 
+import { PublicKey } from '@dxos/keys';
+
 import { runPlan } from './plan/run-plan';
 import { SignalTestPlan } from './plan/signal-spec';
 
 void runPlan({
   plan: new SignalTestPlan(),
   spec: {
-    servers: 1,
-    agents: 30,
-    serversPerAgent: 1,
+    servers: 3,
+    agents: 20,
+    serversPerAgent: 2,
     signalArguments: [
-      // 'p2pserver'
-      'globalsubserver'
+      'p2pserver'
+      // 'globalsubserver'
     ],
-    topicCount: 1,
-    topicsPerAgent: 1,
+    topicCount: 5,
+    topicsPerAgent: 3,
     startWaitTime: 1_000,
     discoverTimeout: 5_000,
     repeatInterval: 200,
     agentWaitTime: 5_000,
-    duration: 10_000,
+    duration: 30_000,
     type: 'discovery'
     // serverOverride: 'ws://localhost:1337/.well-known/dx/signal'
   },
   options: {
-    staggerAgents: 5
-    // repeatAnalysis: '/Users/dmaretskyi/Projects/protocols/packages/gravity/kube-testing/out/results/2023-05-11T10:49:46-0cba/test.json'
+    staggerAgents: 5,
+    randomSeed: PublicKey.random().toHex()
+    // repeatAnalysis:
+    // '/Users/mykola/Documents/dev/dxos/packages/gravity/kube-testing/out/results/2023-05-11T12:29:06-c896/test.json'
   }
 });

--- a/packages/gravity/kube-testing/src/plan/run-plan.ts
+++ b/packages/gravity/kube-testing/src/plan/run-plan.ts
@@ -19,6 +19,7 @@ const AGENT_LOG_FILE = 'agent.log';
 type PlanOptions = {
   staggerAgents?: number;
   repeatAnalysis?: string;
+  randomSeed?: string;
 };
 
 type TestSummary = {
@@ -45,7 +46,7 @@ export const runPlan = async <S, C>({ plan, spec, options }: RunPlanParams<S, C>
   if (options.repeatAnalysis) {
     // Analysis mode
     const summary: TestSummary = JSON.parse(fs.readFileSync(options.repeatAnalysis, 'utf8'));
-    await plan.finishPlan(
+    await plan.finish(
       { spec: summary.spec, outDir: summary.params?.outDir, testId: summary.params?.testId },
       summary.results
     );

--- a/packages/gravity/kube-testing/src/run-test-signal.ts
+++ b/packages/gravity/kube-testing/src/run-test-signal.ts
@@ -7,6 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { raise } from '@dxos/debug';
+import { log } from '@dxos/log';
 import { SignalServerRunner } from '@dxos/signal';
 import { randomInt } from '@dxos/util';
 
@@ -27,7 +28,18 @@ const BIN_PATH = './cmds/signal-test/main.go';
   }
 }
 
+const ports = new Set<number>();
+
 export const runSignal = async (num: number, outFolder: string, signalArguments: string[]) => {
+  let port = randomInt(10000, 20000);
+
+  while (ports.has(port)) {
+    log.warn(`port in use ${port}`);
+    port = randomInt(10000, 20000);
+  }
+
+  ports.add(port);
+
   const runner = new SignalServerRunner({
     port: randomInt(10000, 20000),
     binCommand: `go run -gcflags="all=-N -l" ${BIN_PATH}`,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ec94f07</samp>

### Summary
🐛📊🧪

<!--
1.  🐛 for the bug fix in the `addFile` method of the `LogReader` class.
2.  📊 for the improvement in the accuracy of the log analysis in the `analyzeSwarmEvents` function.
3.  🧪 for the addition of the reproducible tests option and the test plan updates.
-->
This pull request adds a new option for reproducible tests with a random seed and improves the logging, reliability, and accuracy of the signal discovery test and the log analysis. It also fixes some minor bugs and typos in the `kube-testing` package.

> _We're testing the swarm with a random seed_
> _We're fixing the bugs in the `LogReader`_
> _We're heaving away on the count of three_
> _We're sailing the code to the `main` harbor_

### Walkthrough
*  Fixed a bug that caused the log analysis to fail when multiple files were added by using array concatenation instead of array spreading in the `addFile` method of the `LogReader` class ([link](https://github.com/dxos/dxos/pull/3167/files?diff=unified&w=0#diff-29a798a1c4f54ad8a76ac955f4584fada266863fd5e58cd923fb742210e00b13L53-R59)).


