### PR TITLE
fix(aurora): Avatar props

### DIFF
--- a/packages/ui/aurora/src/components/Avatar/Avatar.tsx
+++ b/packages/ui/aurora/src/components/Avatar/Avatar.tsx
@@ -163,21 +163,23 @@ type AvatarImageProps = ComponentPropsWithRef<'image'> & {
   onLoadingStatusChange?: (status: ImageLoadingStatus) => void;
 };
 
-const AvatarImage = forwardRef<SVGImageElement, AvatarImageProps>((props, forwardedRef) => {
-  return (
-    <AvatarImagePrimitive asChild>
-      <AvatarMaskedImage {...props} ref={forwardedRef} />
-    </AvatarImagePrimitive>
-  );
-});
+const AvatarImage = forwardRef<SVGImageElement, AvatarImageProps>(
+  ({ onLoadingStatusChange, ...props }, forwardedRef) => {
+    return (
+      <AvatarImagePrimitive onLoadingStatusChange={onLoadingStatusChange} asChild>
+        <AvatarMaskedImage {...props} ref={forwardedRef} />
+      </AvatarImagePrimitive>
+    );
+  }
+);
 
 type AvatarFallbackProps = ComponentPropsWithRef<'image'> & {
   delayMs?: number;
 };
 
-const AvatarFallback = forwardRef<SVGImageElement, AvatarFallbackProps>((props, forwardedRef) => {
+const AvatarFallback = forwardRef<SVGImageElement, AvatarFallbackProps>(({ delayMs, ...props }, forwardedRef) => {
   return (
-    <AvatarFallbackPrimitive asChild>
+    <AvatarFallbackPrimitive delayMs={delayMs} asChild>
       <AvatarMaskedImage {...props} ref={forwardedRef} />
     </AvatarFallbackPrimitive>
   );


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 225c30a</samp>

### Summary
:sparkles::zap::art:

<!--
1.  :sparkles: - This emoji can be used to indicate that a new feature or enhancement was added to the project. In this case, the props for `AvatarImage` and `AvatarFallback` are new additions that improve the functionality of the `Avatar` component.
2.  :zap: - This emoji can be used to indicate that a performance improvement or optimization was made to the project. In this case, the loading and fallback behavior of the `Avatar` component is more efficient and responsive with the new props.
3.  :art: - This emoji can be used to indicate that a UI or design improvement was made to the project. In this case, the user experience of displaying profile pictures in the DXOS app is more aesthetically pleasing and consistent with the new props.
-->
Improved loading and fallback behavior of `Avatar` component in `ui/aurora`. This component is used to display profile pictures in the DXOS app.

> _In the dark of the night, we see your face_
> _`Avatar` of the fallen, loading with grace_
> _But if the image fails, we have a plan_
> _`AvatarFallback` will save the day, you're the man_

### Walkthrough
* Add `onLoadingStatusChange` prop to `AvatarImage` and `AvatarImagePrimitive` components to handle loading state of avatar image ([link](https://github.com/dxos/dxos/pull/3170/files?diff=unified&w=0#diff-c423c77e2320cfc193556e34f2a45a3812493b4fc8a99addc67d152e4eabb5d1L166-R174)).


