### PR TITLE
fix(aurora): Try fixing Chess by not binding to `document.body`

### DIFF
--- a/packages/ui/aurora/src/components/Main/useSwipeToDismiss.ts
+++ b/packages/ui/aurora/src/components/Main/useSwipeToDismiss.ts
@@ -87,31 +87,27 @@ export const useSwipeToDismiss = (
   }, []);
 
   useEffect(() => {
-    if (node) {
-      node.addEventListener('mousedown', onMouseDown);
-      node.addEventListener('touchstart', onMouseDown);
-    }
+    node?.addEventListener('mousedown', onMouseDown);
+    node?.addEventListener('touchstart', onMouseDown);
     return () => {
-      if (node) {
-        node.removeEventListener('mousedown', onMouseDown);
-        node.removeEventListener('touchstart', onMouseDown);
-      }
+      node?.removeEventListener('mousedown', onMouseDown);
+      node?.removeEventListener('touchstart', onMouseDown);
     };
   }, [node, onMouseDown]);
 
   useEffect(() => {
-    document.body.addEventListener('mouseup', onMouseUp);
-    document.body.addEventListener('mousemove', onMouseMove);
+    node?.addEventListener('mouseup', onMouseUp);
+    node?.addEventListener('mousemove', onMouseMove);
 
-    document.body.addEventListener('touchmove', onMouseMove, { passive: false });
-    document.body.addEventListener('touchend', onMouseUp);
+    node?.addEventListener('touchmove', onMouseMove, { passive: false });
+    node?.addEventListener('touchend', onMouseUp);
 
     return () => {
-      document.body.removeEventListener('mouseup', onMouseUp);
-      document.body.removeEventListener('mousemove', onMouseMove);
+      node?.removeEventListener('mouseup', onMouseUp);
+      node?.removeEventListener('mousemove', onMouseMove);
 
-      document.body.removeEventListener('touchmove', onMouseMove);
-      document.body.removeEventListener('touchend', onMouseMove);
+      node?.removeEventListener('touchmove', onMouseMove);
+      node?.removeEventListener('touchend', onMouseMove);
     };
   }, [onMouseUp, onMouseDown, onMouseMove]);
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fc18249</samp>

### Summary
🐛🖱️👆

<!--
1.  🐛 - This emoji represents a bug fix, which is the main goal of the change. It conveys that the change addresses a problem or error in the code.
2.  🖱️ - This emoji represents a mouse, which is one of the input devices that the change affects. It conveys that the change involves mouse events or interactions.
3.  👆 - This emoji represents a finger pointing up, which is a gesture that can be used to swipe on touch devices. It conveys that the change also involves touch events or interactions.
-->
Fixed swipe to dismiss gesture for modal component by changing event target. The change affects the `useSwipeToDismiss` hook in `packages/ui/aurora/src/components/Main/useSwipeToDismiss.ts`.

> _Swipe to dismiss modal_
> _`useSwipeToDismiss` changes_
> _`document.body` no more_

### Walkthrough
* Fix swipe to dismiss bug on some devices by using node instead of document.body as event target (`[link](https://github.com/dxos/dxos/pull/3175/files?diff=unified&w=0#diff-e01adeff6f99ce764f9635d1e7d60c8401e85dc9a4fddc0bb32ba7e33c22bb55L90-R110)` in `useSwipeToDismiss.ts`)


