### PR TITLE
fix(aurora): Make sidebar swipe-to-dismiss optional

### DIFF
--- a/packages/ui/aurora/src/components/Main/Main.tsx
+++ b/packages/ui/aurora/src/components/Main/Main.tsx
@@ -13,7 +13,8 @@ import React, {
   forwardRef,
   PropsWithChildren,
   SetStateAction,
-  useCallback, useRef
+  useCallback,
+  useRef
 } from 'react';
 
 import { useMediaQuery, useForwardedRef } from '@dxos/react-hooks';

--- a/packages/ui/aurora/src/components/Main/Main.tsx
+++ b/packages/ui/aurora/src/components/Main/Main.tsx
@@ -13,7 +13,7 @@ import React, {
   forwardRef,
   PropsWithChildren,
   SetStateAction,
-  useCallback
+  useCallback, useRef
 } from 'react';
 
 import { useMediaQuery, useForwardedRef } from '@dxos/react-hooks';
@@ -82,27 +82,30 @@ const MainRoot = ({
 
 MainRoot.displayName = MAIN_ROOT_NAME;
 
-type SidebarProps = ThemedClassName<ComponentPropsWithRef<typeof DialogContent>>;
+type SidebarProps = ThemedClassName<ComponentPropsWithRef<typeof DialogContent>> & { swipeToDismiss?: boolean };
 
-const Sidebar = forwardRef<HTMLDivElement, SidebarProps>(({ className, children, ...props }, forwardedRef) => {
-  const [isLg] = useMediaQuery('lg', { ssr: false });
-  const { sidebarOpen, setSidebarOpen } = useMainContext(SIDEBAR_NAME);
-  const { tx } = useThemeContext();
-  const ref = useForwardedRef(forwardedRef);
-  useSwipeToDismiss(ref, () => setSidebarOpen(false), 48, 'left', 0);
-  return (
-    <DialogContent
-      forceMount
-      onOpenAutoFocus={(event) => isLg && event.preventDefault()}
-      onCloseAutoFocus={(event) => isLg && event.preventDefault()}
-      {...props}
-      className={tx('main.sidebar', 'main__sidebar', { isLg, sidebarOpen }, className)}
-      ref={ref}
-    >
-      <ElevationProvider elevation='chrome'>{children}</ElevationProvider>
-    </DialogContent>
-  );
-});
+const Sidebar = forwardRef<HTMLDivElement, SidebarProps>(
+  ({ className, children, swipeToDismiss, ...props }, forwardedRef) => {
+    const [isLg] = useMediaQuery('lg', { ssr: false });
+    const { sidebarOpen, setSidebarOpen } = useMainContext(SIDEBAR_NAME);
+    const { tx } = useThemeContext();
+    const ref = useForwardedRef(forwardedRef);
+    const noopRef = useRef(null);
+    useSwipeToDismiss(swipeToDismiss ? ref : noopRef, () => setSidebarOpen(false), 48, 'left', 0);
+    return (
+      <DialogContent
+        forceMount
+        onOpenAutoFocus={(event) => isLg && event.preventDefault()}
+        onCloseAutoFocus={(event) => isLg && event.preventDefault()}
+        {...props}
+        className={tx('main.sidebar', 'main__sidebar', { isLg, sidebarOpen }, className)}
+        ref={ref}
+      >
+        <ElevationProvider elevation='chrome'>{children}</ElevationProvider>
+      </DialogContent>
+    );
+  }
+);
 
 Sidebar.displayName = SIDEBAR_NAME;
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0c1f290</samp>

### Summary
🆕👆🛠️

<!--
1.  🆕 - This emoji can be used to indicate that a new feature or functionality was added, such as the `swipeToDismiss` prop.
2.  👆 - This emoji can be used to indicate that a gesture or interaction was added or improved, such as the swipe to dismiss feature.
3.  🛠️ - This emoji can be used to indicate that a bug or issue was fixed or resolved, such as the ref to access the sidebar element.
-->
Added a swipe to dismiss feature for the `Sidebar` component in the `aurora` UI package. This feature can be toggled by a prop and uses a ref to access the sidebar element.

> _Sing, O Muse, of the skillful coder who devised_
> _A clever prop for the Sidebar, swift and wise,_
> _That by a touch of finger could dismiss_
> _The sliding panel, like a breeze that hisses._

### Walkthrough
* Import `useRef` hook to create a ref for the sidebar element ([link](https://github.com/dxos/dxos/pull/3178/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL16-R16))
* Modify `Sidebar` component to accept `swipeToDismiss` prop and use it to conditionally apply the `useSwipeToDismiss` hook ([link](https://github.com/dxos/dxos/pull/3178/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL85-R108))
* Update `useSwipeToDismiss` hook to use either the sidebar ref or a noop ref depending on the `swipeToDismiss` prop value ([link](https://github.com/dxos/dxos/pull/3178/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL85-R108))


