### PR TITLE
fix: reset vault

### DIFF
--- a/packages/apps/composer-app/src/layouts/Root.tsx
+++ b/packages/apps/composer-app/src/layouts/Root.tsx
@@ -60,7 +60,7 @@ export const Root = () => {
       {/* TODO(wittjosiah): Hook up user feedback mechanism. */}
       <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} config={configProvider} />}>
         <ClientProvider config={configProvider} services={servicesProvider} fallback={ClientFallback}>
-          <ErrorProvider>
+          <ErrorProvider config={configProvider}>
             <Outlet />
           </ErrorProvider>
         </ClientProvider>

--- a/packages/apps/halo-app/src/App.tsx
+++ b/packages/apps/halo-app/src/App.tsx
@@ -104,7 +104,7 @@ export const App = withProfiler(() => {
       fallback={<Fallback message='Loading...' />}
       appNs='halo'
     >
-      <ErrorProvider>
+      <ErrorProvider config={configProvider}>
         {/* TODO(wittjosiah): Hook-up user feedback mechanism. */}
         <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} config={configProvider} />}>
           <ClientProvider config={configProvider} services={serviceProvider} fallback={ClientFallback}>

--- a/packages/apps/tasks-app/src/App.tsx
+++ b/packages/apps/tasks-app/src/App.tsx
@@ -49,7 +49,7 @@ export const App = withProfiler(() => {
       resourceExtensions={[appkitTranslations, osTranslations, tasksTranslations]}
       fallback={<Fallback message='Loading...' />}
     >
-      <ErrorProvider>
+      <ErrorProvider config={configProvider}>
         {/* TODO: (wittjosiah): Hook up user feedback mechanism. */}
         <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} config={configProvider} />}>
           <ClientProvider config={configProvider} services={servicesProvider} fallback={ClientFallback}>

--- a/packages/experimental/kai-framework/src/containers/Root/Root.tsx
+++ b/packages/experimental/kai-framework/src/containers/Root/Root.tsx
@@ -37,7 +37,7 @@ export const Root: FC<PropsWithChildren<{ initialState?: Partial<AppState> }>> =
       rootDensity='fine'
       resourceExtensions={[appkitTranslations, kaiTranslations, osTranslations]}
     >
-      <ErrorProvider>
+      <ErrorProvider config={configProvider}>
         <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} config={configProvider} />}>
           <ClientProvider client={clientProvider}>
             <MetagraphProvider value={metagraphContext}>

--- a/packages/experimental/kai/src/Root.tsx
+++ b/packages/experimental/kai/src/Root.tsx
@@ -42,7 +42,7 @@ export const Root: FC<PropsWithChildren<{ initialState?: Partial<AppState> }>> =
       rootDensity='fine'
       resourceExtensions={[appkitTranslations, kaiTranslations, osTranslations]}
     >
-      <ErrorProvider>
+      <ErrorProvider config={configProvider}>
         <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} config={configProvider} />}>
           <ClientProvider client={clientProvider}>
             <MetagraphProvider value={metagraphContext}>

--- a/packages/experimental/kube-console/src/containers/Root.tsx
+++ b/packages/experimental/kube-console/src/containers/Root.tsx
@@ -21,7 +21,7 @@ export const Root: FC<PropsWithChildren> = ({ children }) => {
 
   return (
     <ThemeProvider appNs='console' rootDensity='fine' resourceExtensions={[appkitTranslations, osTranslations]}>
-      <ErrorProvider>
+      <ErrorProvider config={configProvider}>
         <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} config={configProvider} />}>
           <ClientProvider config={configProvider} services={fromHost}>
             <Fullscreen>

--- a/packages/ui/react-appkit/src/components/ErrorProvider/ErrorProvider.tsx
+++ b/packages/ui/react-appkit/src/components/ErrorProvider/ErrorProvider.tsx
@@ -7,8 +7,9 @@ import React, { createContext, PropsWithChildren, useCallback, useContext, useEf
 
 import { useTranslation, Button, DensityProvider } from '@dxos/aurora';
 import { valenceColorText, getSize } from '@dxos/aurora-theme';
-import { SystemStatus, ClientContext } from '@dxos/react-client';
+import { SystemStatus, ClientContext, Config } from '@dxos/react-client';
 import { captureException } from '@dxos/sentry';
+import { Provider } from '@dxos/util';
 
 import { ResetDialog } from '../ResetDialog';
 import { Tooltip } from '../Tooltip';
@@ -28,7 +29,12 @@ export const ErrorContext = createContext<ErrorContextState>({
 // TODO(burdon): Override if dev-only?
 const logError = (f: string, ...args: any[]) => console.error(f, ...args);
 
-export const ErrorProvider = ({ children, isDev = true }: PropsWithChildren<{ isDev?: boolean }>) => {
+export type ErrorProviderProps = PropsWithChildren<{
+  config?: Config | Provider<Promise<Config>>;
+  isDev?: boolean;
+}>;
+
+export const ErrorProvider = ({ children, config, isDev = true }: ErrorProviderProps) => {
   const { t } = useTranslation('appkit');
   const [errors, setErrors] = useState<Error[]>([]);
   const addError = useCallback((error: Error) => setErrors([error, ...errors]), []);
@@ -98,7 +104,7 @@ export const ErrorProvider = ({ children, isDev = true }: PropsWithChildren<{ is
               )}
             </DensityProvider>
           </div>
-          <ResetDialog errors={errors} open={errorDialogOpen} onOpenChange={setErrorDialogOpen} />
+          <ResetDialog config={config} errors={errors} open={errorDialogOpen} onOpenChange={setErrorDialogOpen} />
         </>
       )}
     </ErrorContext.Provider>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7c90c63</samp>

### Summary
🛠️🚀🔄

<!--
1.  🛠️ - This emoji represents a fix or improvement to an existing component or feature, such as the `ErrorProvider` component.
2.  🚀 - This emoji represents a new feature or enhancement that adds value to the app or framework, such as the ability to reset the app configuration from the error dialog.
3.  🔄 - This emoji represents a change or update to the app or framework that affects multiple packages or components, such as passing the `configProvider` to the `ErrorProvider` component.
-->
Added a `config` prop to the `ErrorProvider` component to customize the reset dialog behavior. Updated several apps and packages to pass the `configProvider` to the `ErrorProvider`.

> _Oh we are the coders of the `ErrorProvider`_
> _We pass the `config` prop to the `ResetDialog`_
> _We work on many packages with the same provider_
> _We heave and we ho and we pull on the count of three_

### Walkthrough
*  Add `config` prop to `ErrorProvider` component to enable app reset functionality ([link](https://github.com/dxos/dxos/pull/3180/files?diff=unified&w=0#diff-6b7173b1279a12072bd6bf5f99fd2dfb5ca082c763b34cdd9921c31fc9d5500fL63-R63), [link](https://github.com/dxos/dxos/pull/3180/files?diff=unified&w=0#diff-ddc0826b99fe231f4263f1f99f8c1c5785ce1dadf6f9724b854d89acb028acefL10-R12), [link](https://github.com/dxos/dxos/pull/3180/files?diff=unified&w=0#diff-ddc0826b99fe231f4263f1f99f8c1c5785ce1dadf6f9724b854d89acb028acefL31-R37), [link](https://github.com/dxos/dxos/pull/3180/files?diff=unified&w=0#diff-ddc0826b99fe231f4263f1f99f8c1c5785ce1dadf6f9724b854d89acb028acefL101-R107)).


