### PR TITLE
fix(composer-app,composer-extension): Polish items

### DIFF
--- a/packages/apps/composer-app/src/components/ResolverDialog/ResolverContext.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/ResolverContext.tsx
@@ -10,7 +10,7 @@ import { log } from '@dxos/log';
 import { Space, useIdentity, useQuery, useSpaces, Text } from '@dxos/react-client';
 import { ShellProvider } from '@dxos/react-shell';
 
-import { matchSpace } from '../../util';
+import { displayName, matchSpace } from '../../util';
 import { DocumentResolverProps, SpaceResolverProps } from './ResolverProps';
 
 const useLocationIdentifier = () => {
@@ -79,6 +79,7 @@ const DocumentsQueryableDocumentResolverProvider = ({
   children
 }: PropsWithChildren<{ space: Space; source: string; id: string }>) => {
   const [document, setDocument] = useState<Document | null>(null);
+  const defaultDisplayName = displayName(source, id);
 
   const documents = useQuery(space, (obj) => {
     const keys = obj.meta?.keys;
@@ -96,7 +97,8 @@ const DocumentsQueryableDocumentResolverProvider = ({
           meta: {
             keys: [{ source, id }]
           },
-          content: new Text(event.data.content)
+          content: new Text(event.data.content),
+          title: defaultDisplayName
         });
         space.db.add(nextDocument);
         setDocument(nextDocument);

--- a/packages/apps/composer-app/src/components/ResolverDialog/ResolverDialog.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/ResolverDialog.tsx
@@ -4,9 +4,10 @@
 
 import React, { useContext } from 'react';
 
-import { ThemeContext, useThemeContext, useTranslation } from '@dxos/aurora';
+import { Button, DensityProvider, ThemeContext, useThemeContext, useTranslation } from '@dxos/aurora';
 import { mx, osTx } from '@dxos/aurora-theme';
-import { defaultDialogContent, defaultOverlay } from '@dxos/react-shell';
+import { ShellLayout } from '@dxos/client';
+import { defaultDialogContent, defaultOverlay, useShell } from '@dxos/react-shell';
 
 import { SpaceResolverContext } from './ResolverContext';
 import { ResolverTree } from './ResolverTree';
@@ -15,17 +16,26 @@ export const ResolverDialog = () => {
   const themeContext = useThemeContext();
   const { space } = useContext(SpaceResolverContext);
   const { t } = useTranslation('composer');
+  const shell = useShell();
+  const handleJoinSpace = () => {
+    void shell.setLayout(ShellLayout.JOIN_SPACE);
+  };
   return (
     <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}>
-      <div role='none' className={mx(defaultOverlay, 'static bs-full')}>
-        <div role='none' className={mx(defaultDialogContent, 'p-2 bs-64 shadow-none bg-transparent')}>
-          {!space ? (
-            <ResolverTree />
-          ) : (
-            <h1 className='text-lg font-system-normal'>{t('resolver init document message')}</h1>
-          )}
+      <DensityProvider density='fine'>
+        <div role='none' className={mx(defaultOverlay, 'static bs-full')}>
+          <div role='none' className={mx(defaultDialogContent, 'p-2 bs-64 shadow-none bg-transparent')}>
+            {!space ? (
+              <ResolverTree />
+            ) : (
+              <h1 className='text-lg font-system-normal'>{t('resolver init document message')}</h1>
+            )}
+            <Button className='is-full' onClick={handleJoinSpace}>
+              {t('join space label', { ns: 'appkit' })}
+            </Button>
+          </div>
         </div>
-      </div>
+      </DensityProvider>
     </ThemeContext.Provider>
   );
 };

--- a/packages/apps/composer-app/src/components/ResolverDialog/SpacePickerTreeItem.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/SpacePickerTreeItem.tsx
@@ -52,7 +52,7 @@ export const SpacePickerTreeItem = ({
           <MockListItemOpenTrigger />
         )}
         <TreeItemHeading
-          className='grow break-words pbs-2 text-base font-medium'
+          className='grow break-words pbs-1 text-base font-medium'
           data-testid='composer.spaceTreeItemHeading'
         >
           {spaceDisplayName}

--- a/packages/apps/composer-app/src/layouts/EmbeddedLayout.tsx
+++ b/packages/apps/composer-app/src/layouts/EmbeddedLayout.tsx
@@ -42,7 +42,9 @@ const EmbeddedLayoutImpl = () => {
       )}
       <ButtonGroup className='fixed inline-end-2 block-end-2 z-[70]'>
         <Button onClick={handleCloseEmbed}>{t('close label', { ns: 'appkit' })}</Button>
-        <Button onClick={handleSaveAndCloseEmbed}>{t('save and close label')}</Button>
+        <Button disabled={!(space && document)} onClick={handleSaveAndCloseEmbed}>
+          {t('save and close label')}
+        </Button>
       </ButtonGroup>
     </>
   );

--- a/packages/apps/composer-app/src/layouts/EmbeddedLayout.tsx
+++ b/packages/apps/composer-app/src/layouts/EmbeddedLayout.tsx
@@ -7,6 +7,8 @@ import React, { useCallback, useContext } from 'react';
 import { Outlet } from 'react-router-dom';
 
 import { Button, ButtonGroup, useTranslation } from '@dxos/aurora';
+import { ShellLayout } from '@dxos/client';
+import { useShell } from '@dxos/react-shell';
 
 import {
   ResolverDialog,
@@ -22,6 +24,7 @@ const EmbeddedLayoutImpl = () => {
   const { t } = useTranslation('composer');
   const { space, source, id, identityHex } = useContext(SpaceResolverContext);
   const { document } = useContext(DocumentResolverContext);
+  const shell = useShell();
 
   const handleCloseEmbed = useCallback(() => {
     window.parent.postMessage({ type: 'close-embed' }, 'https://github.com');
@@ -30,6 +33,10 @@ const EmbeddedLayoutImpl = () => {
   const handleSaveAndCloseEmbed = useCallback(() => {
     document && window.parent.postMessage({ type: 'save-data', content: document.content.text }, 'https://github.com');
   }, [document]);
+
+  const handleInvite = useCallback(() => {
+    void shell.setLayout(ShellLayout.SPACE_INVITATIONS, space?.key && { spaceKey: space.key });
+  }, [shell, space]);
 
   return (
     <>
@@ -40,12 +47,17 @@ const EmbeddedLayoutImpl = () => {
       ) : (
         <EmbeddedFirstRunPage />
       )}
-      <ButtonGroup className='fixed inline-end-2 block-end-2 z-[70]'>
-        <Button onClick={handleCloseEmbed}>{t('close label', { ns: 'appkit' })}</Button>
-        <Button disabled={!(space && document)} onClick={handleSaveAndCloseEmbed}>
-          {t('save and close label')}
+      <div role='none' className='fixed inline-end-2 block-end-2 z-[70] flex gap-2'>
+        <Button disabled={!space} onClick={handleInvite}>
+          {t('create invitation label', { ns: 'appkit' })}
         </Button>
-      </ButtonGroup>
+        <ButtonGroup>
+          <Button onClick={handleCloseEmbed}>{t('close label', { ns: 'appkit' })}</Button>
+          <Button disabled={!(space && document)} onClick={handleSaveAndCloseEmbed}>
+            {t('save and close label')}
+          </Button>
+        </ButtonGroup>
+      </div>
     </>
   );
 };

--- a/packages/apps/composer-app/src/layouts/Root.tsx
+++ b/packages/apps/composer-app/src/layouts/Root.tsx
@@ -60,7 +60,7 @@ export const Root = () => {
       {/* TODO(wittjosiah): Hook up user feedback mechanism. */}
       <ErrorBoundary fallback={({ error }) => <ResetDialog error={error} config={configProvider} />}>
         <ClientProvider config={configProvider} services={servicesProvider} fallback={ClientFallback}>
-          <ErrorProvider config={configProvider}>
+          <ErrorProvider config={configProvider} isDev={false}>
             <Outlet />
           </ErrorProvider>
         </ClientProvider>

--- a/packages/apps/composer-app/src/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/apps/composer-app/src/pages/DocumentPage/DocumentPage.tsx
@@ -490,6 +490,7 @@ export const DocumentPage = observer(() => {
   const { t } = useTranslation('composer');
   const { space, document, layout } = useOutletContext<OutletContext>();
   const embedded = layout === 'embedded';
+  const [staleDialogOpen, setStaleDialogOpen] = useState(false);
 
   useEffect(() => {
     const handler = (event: MessageEvent) => {
@@ -498,8 +499,7 @@ export const DocumentPage = observer(() => {
       }
 
       if (event.data.type === 'comment-stale') {
-        // TODO(wittjosiah): Display in UI.
-        alert('comment stale');
+        setStaleDialogOpen(true);
       }
     };
 
@@ -511,6 +511,18 @@ export const DocumentPage = observer(() => {
 
   return (
     <div role='none'>
+      <Dialog
+        open={staleDialogOpen}
+        onOpenChange={setStaleDialogOpen}
+        title={t('comment stale title')}
+        closeTriggers={[
+          <Button key='c1' variant='primary'>
+            {t('confirm label', { ns: 'appkit' })}
+          </Button>
+        ]}
+      >
+        <p className='plb-2'>{t('comment stale body')}</p>
+      </Dialog>
       {document && space ? (
         document.content.kind === TextKind.PLAIN ? (
           <MarkdownDocumentPage document={document} space={space} />

--- a/packages/apps/composer-app/src/translations/en-US.ts
+++ b/packages/apps/composer-app/src/translations/en-US.ts
@@ -57,5 +57,8 @@ export const composer = {
   'resolver no spaces message': 'You aren’t in any spaces yet',
   'resolver create space label': 'Create a space for this repository',
   'save and close label': 'Save & close',
-  'resolver init document message': 'Syncing this document, one moment…'
+  'resolver init document message': 'Syncing this document, one moment…',
+  'comment stale title': 'No longer in-sync',
+  'comment stale body':
+    'The document in Github was updated in another session. To re-sync, please save your changes, reload the page, and choose to edit from Github again.'
 };

--- a/packages/apps/composer-app/src/util/spaceResolvers.ts
+++ b/packages/apps/composer-app/src/util/spaceResolvers.ts
@@ -10,11 +10,6 @@ import { Space } from '@dxos/client';
 // todo(thure): Why is the value that gets set in `ghBind` always undefined by the time this is called?
 const ghMatch = (space: Space, identityHex: string, id: string): boolean => {
   const [ghOwner, ghRepo, ..._ghEtc] = id.split('/');
-  console.log(
-    '[gh match]',
-    ['members', identityHex, 'github', 'repos'],
-    get(space.properties, ['members', identityHex, 'github', 'repos'])
-  );
   return get(space.properties, ['members', identityHex, 'github', 'repos'], []).includes(`${ghOwner}/${ghRepo}`);
 };
 
@@ -36,7 +31,6 @@ const ghBind = (space: Space, identityHex: string, id: string): string[] => {
   update(space.properties, ['members', identityHex, 'github', 'repos'], (ghBindings) => {
     return [...(ghBindings ?? []), `${ghOwner}/${ghRepo}`];
   });
-  console.log('[updated repos]', space.properties.members?.[identityHex]?.github?.repos);
   return space.properties.members?.[identityHex]?.github?.repos ?? [];
 };
 

--- a/packages/apps/composer-app/src/util/spaceResolvers.ts
+++ b/packages/apps/composer-app/src/util/spaceResolvers.ts
@@ -42,3 +42,22 @@ export const bindSpace = (space: Space, identityHex: string, source: string, id:
       return [];
   }
 };
+
+const ghDisplayName = (id: string): string => {
+  const [ghOwner, ghRepo, ghResource, ...etc] = id.split('/');
+  switch (ghResource) {
+    case 'issues':
+      return `${ghOwner}/${ghRepo} #${etc[0]}`;
+    default:
+      return `${ghOwner}/${ghRepo} ${[ghResource, ...etc].join('/')}`;
+  }
+};
+
+export const displayName = (source: string, id: string): string => {
+  switch (source) {
+    case 'com.github':
+      return ghDisplayName(id);
+    default:
+      return id;
+  }
+};

--- a/packages/apps/composer-extension/src/content.ts
+++ b/packages/apps/composer-extension/src/content.ts
@@ -54,6 +54,7 @@ const setupComposer = () => {
     composer.setAttribute('id', composerId);
     composer.setAttribute('src', `${baseUrl.href}embedded/${window.location.href}`);
     composer.setAttribute('style', composerStyles);
+    composer.setAttribute('allow', 'clipboard-write *');
     Array.from(commentForm.children).forEach((element) => element.setAttribute('style', srOnly));
 
     let stale = false;


### PR DESCRIPTION
Resolves several tasks from #3097.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 651f895</samp>

### Summary
🎨🚀🐛

<!--
1.  🎨 - This emoji is often used to indicate UI improvements or design changes, which are relevant for the padding-bottom adjustment, the new UI components and hooks, and the invitation feature.
2.  🚀 - This emoji is often used to indicate new features or performance improvements, which are relevant for the error handling mode, the document title property, and the joining space feature.
3.  🐛 - This emoji is often used to indicate bug fixes or error handling, which are relevant for the clipboard access, the stale comment dialog, and the removal of console.log statements.
-->
Improved the user experience and functionality of the composer app and extension. Added features to create and share invitations for spaces, join spaces from the resolver dialog, and handle stale comments from Github. Updated the UI components and hooks to use the new `@dxos/aurora` and `@dxos/react-shell` packages. Fixed some code quality and error handling issues.

> _We write to the clipboard, we join the space_
> _We handle the errors, we adjust the UI_
> _We create invitations, we share the link_
> _We face the doom of the stale comment_

### Walkthrough
*  Add `displayName` functions to generate human-readable names for documents ([link](https://github.com/dxos/dxos/pull/3182/files?diff=unified&w=0#diff-f80ad10b3f3a53671c8e7559fa049d6cd30f148753da3571e245e4cc25c3b561L13-R13), [link](https://github.com/dxos/dxos/pull/3182/files?diff=unified&w=0#diff-f80ad10b3f3a53671c8e7559fa049d6cd30f148753da3571e245e4cc25c3b561R82), [link](https://github.com/dxos/dxos/pull/3182/files?diff=unified&w=0#diff-f80ad10b3f3a53671c8e7559fa049d6cd30f148753da3571e245e4cc25c3b561L99-R101), [link](https://github.com/dxos/dxos/pull/3182/files?diff=unified&w=0#diff-c01ce68796316a7042580d929c96dc6f2b6a42f696eaec7ed6a50865a7bb6e5bR45-R63)).


