### PR TITLE
feat: Add ability to cache Properties in metadata

### DIFF
--- a/packages/core/echo/echo-db/src/packlets/database/item.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/item.ts
@@ -339,3 +339,7 @@ export class Item<M extends Model = Model> {
     }
   }
 }
+
+export const getStateMachineFromItem = (item: Item) => {
+  return item._stateMachine;
+};

--- a/packages/core/echo/echo-db/src/packlets/database/item.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/item.ts
@@ -72,8 +72,9 @@ export class Item<M extends Model = Model> {
 
   /**
    * Model state-machine.
+   * @internal
    */
-  private _stateMachine: StateMachine<StateOf<M>, MutationOf<Model>, unknown> | null = null;
+  _stateMachine: StateMachine<StateOf<M>, MutationOf<Model>, unknown> | null = null;
 
   /**
    * Items are constructed by the `Database` object.

--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -168,8 +168,7 @@ export class MetadataStore {
   }
 
   async setSpaceProperties(spaceKey: PublicKey, properties: string) {
-    const space = this._getSpace(spaceKey);
-    space.properties = properties;
+    this._getSpace(spaceKey).properties = properties;
     await this._save();
   }
 

--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -10,7 +10,7 @@ import { DataCorruptionError } from '@dxos/errors';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { schema } from '@dxos/protocols';
-import { EchoMetadata, SpaceMetadata, IdentityRecord } from '@dxos/protocols/proto/dxos/echo/metadata';
+import { EchoMetadata, SpaceMetadata, IdentityRecord, SpaceCache } from '@dxos/protocols/proto/dxos/echo/metadata';
 import { Directory } from '@dxos/random-access-storage';
 import { Timeframe } from '@dxos/timeframe';
 
@@ -164,8 +164,8 @@ export class MetadataStore {
     await this._save();
   }
 
-  async setSpaceProperties(spaceKey: PublicKey, properties: string) {
-    this._getSpace(spaceKey).properties = properties;
+  async setCache(spaceKey: PublicKey, cache: SpaceCache) {
+    this._getSpace(spaceKey).cache = cache;
     await this._save();
   }
 

--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -119,6 +119,12 @@ export class MetadataStore {
     }
   }
 
+  _getSpace(spaceKey: PublicKey): SpaceMetadata {
+    const space = this.spaces.find((space) => space.key === spaceKey);
+    assert(space, 'Space not found');
+    return space;
+  }
+
   /**
    * Clears storage - doesn't work for now.
    */
@@ -149,25 +155,26 @@ export class MetadataStore {
   }
 
   async setSpaceLatestTimeframe(spaceKey: PublicKey, timeframe: Timeframe) {
-    const space = this.spaces.find((space) => space.key === spaceKey);
-    assert(space, 'Space not found');
+    const space = this._getSpace(spaceKey);
 
     space.dataTimeframe = timeframe;
     await this._save();
   }
 
   async setSpaceSnapshot(spaceKey: PublicKey, snapshot: string) {
-    const space = this.spaces.find((space) => space.key === spaceKey);
-    assert(space, 'Space not found');
-
+    const space = this._getSpace(spaceKey);
     space.snapshot = snapshot;
     await this._save();
   }
 
-  async setWritableFeedKeys(spaceKey: PublicKey, controlFeedKey: PublicKey, dataFeedKey: PublicKey) {
-    const space = this.spaces.find((space) => space.key === spaceKey);
-    assert(space, 'Space not found');
+  async setSpaceProperties(spaceKey: PublicKey, properties: string) {
+    const space = this._getSpace(spaceKey);
+    space.properties = properties;
+    await this._save();
+  }
 
+  async setWritableFeedKeys(spaceKey: PublicKey, controlFeedKey: PublicKey, dataFeedKey: PublicKey) {
+    const space = this._getSpace(spaceKey);
     space.controlFeedKey = controlFeedKey;
     space.dataFeedKey = dataFeedKey;
     await this._save();

--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -155,15 +155,12 @@ export class MetadataStore {
   }
 
   async setSpaceLatestTimeframe(spaceKey: PublicKey, timeframe: Timeframe) {
-    const space = this._getSpace(spaceKey);
-
-    space.dataTimeframe = timeframe;
+    this._getSpace(spaceKey).dataTimeframe = timeframe;
     await this._save();
   }
 
   async setSpaceSnapshot(spaceKey: PublicKey, snapshot: string) {
-    const space = this._getSpace(spaceKey);
-    space.snapshot = snapshot;
+    this._getSpace(spaceKey).snapshot = snapshot;
     await this._save();
   }
 

--- a/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
@@ -13,8 +13,8 @@ import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { ModelFactory } from '@dxos/model-factory';
 import { DataMessage, FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
+import { SpaceCache } from '@dxos/protocols/proto/dxos/echo/metadata';
 import { SpaceSnapshot } from '@dxos/protocols/proto/dxos/echo/snapshot';
-import { SpaceCache } from '@dxos/protocols/src/proto/gen/dxos/echo/metadata';
 import { Timeframe } from '@dxos/timeframe';
 
 import { createMappedFeedWriter } from '../common';
@@ -123,7 +123,7 @@ export class DataPipeline {
     // Create database backend.
     const feedWriter = createMappedFeedWriter<DataMessage, FeedMessage.Payload>(
       (data: DataMessage) => ({ data }),
-      this._pipeline.writer ?? failUndefined(),
+      this._pipeline.writer ?? failUndefined()
     );
 
     this.databaseBackend = new DatabaseHost(feedWriter, this._snapshot?.database);
@@ -192,8 +192,8 @@ export class DataPipeline {
               feedKey,
               seq,
               timeframe: data.timeframe,
-              memberKey: feedInfo.assertion.identityKey,
-            },
+              memberKey: feedInfo.assertion.identityKey
+            }
           });
 
           // Timeframe clock is not updated yet
@@ -210,7 +210,7 @@ export class DataPipeline {
     return {
       spaceKey: this._params.spaceKey.asUint8Array(),
       timeframe,
-      database: this.databaseBackend!.createSnapshot(),
+      database: this.databaseBackend!.createSnapshot()
     };
   }
 

--- a/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
@@ -235,12 +235,8 @@ export class DataPipeline {
       }
     }
 
-    {
-      // Save cache.
-      if (Object.keys(cache).length > 0) {
-        await this._params.metadataStore.setCache(this._params.spaceKey, cache);
-      }
-    }
+    // Save cache.
+    await this._params.metadataStore.setCache(this._params.spaceKey, cache);
   }
 
   private async _noteTargetStateIfNeeded(timeframe: Timeframe) {

--- a/packages/core/echo/echo-schema/src/defs.ts
+++ b/packages/core/echo/echo-schema/src/defs.ts
@@ -7,3 +7,4 @@ export const proxy = Symbol.for('dxos.echo.proxy');
 export const base = Symbol.for('dxos.echo.base');
 export const db = Symbol.for('dxos.echo.db');
 export const data = Symbol.for('dxos.echo.data');
+export const readOnly = Symbol.for('dxos.echo.readOnly');

--- a/packages/core/echo/echo-schema/src/object.ts
+++ b/packages/core/echo/echo-schema/src/object.ts
@@ -169,6 +169,6 @@ export abstract class EchoObject<T extends Model = any> {
 }
 
 export const setStateFromSnapshot = (obj: EchoObject, snapshot: ObjectSnapshot) => {
-  assert(obj._stateMachine);
-  obj._stateMachine.reset(snapshot);
+  assert(obj[base]._stateMachine);
+  obj[base]._stateMachine.reset(snapshot);
 };

--- a/packages/core/echo/echo-schema/src/object.ts
+++ b/packages/core/echo/echo-schema/src/object.ts
@@ -8,6 +8,7 @@ import { Any, ProtoCodec } from '@dxos/codec-protobuf';
 import { createModelMutation, encodeModelMutation, Item, MutateResult } from '@dxos/echo-db';
 import { PublicKey } from '@dxos/keys';
 import { Model, ModelConstructor, MutationOf, MutationWriteReceipt, StateMachine, StateOf } from '@dxos/model-factory';
+import { ObjectSnapshot } from '@dxos/protocols/proto/dxos/echo/model/document';
 
 import { EchoDatabase } from './database';
 import { base, db } from './defs';
@@ -166,3 +167,8 @@ export abstract class EchoObject<T extends Model = any> {
     }
   }
 }
+
+export const setStateFromSnapshot = (obj: EchoObject, snapshot: ObjectSnapshot) => {
+  assert(obj._stateMachine);
+  obj._stateMachine.reset(snapshot);
+};

--- a/packages/core/echo/echo-schema/src/typed-object.ts
+++ b/packages/core/echo/echo-schema/src/typed-object.ts
@@ -10,7 +10,7 @@ import { log } from '@dxos/log';
 import { TextModel } from '@dxos/text-model';
 
 import { EchoArray } from './array';
-import { base, data, proxy, schema } from './defs';
+import { base, data, proxy, readOnly, schema } from './defs';
 import { EchoObject } from './object';
 import { EchoSchemaField, EchoSchemaType } from './schema';
 import { Text } from './text-object';
@@ -113,6 +113,13 @@ class TypedObjectImpl<T> extends EchoObject<DocumentModel> {
   // TODO(burdon): Method on TypedObject vs EchoObject?
   get [schema](): EchoSchemaType | undefined {
     return this[base]?._schemaType;
+  }
+
+  /**
+   * Returns boolean. If `true`, read only access is activated.
+   */
+  get [readOnly](): boolean {
+    return !!this[base]?._opts?.readOnly;
   }
 
   /** Deletion. */

--- a/packages/core/echo/echo-schema/src/typed-object.ts
+++ b/packages/core/echo/echo-schema/src/typed-object.ts
@@ -350,7 +350,7 @@ class TypedObjectImpl<T> extends EchoObject<DocumentModel> {
       },
 
       set: (target, property, value, receiver) => {
-        if (this._opts?.readOnlyAccess) {
+        if (this._opts?.readOnly) {
           log.warn('Read only access');
           return false;
         }
@@ -413,7 +413,7 @@ Object.defineProperty(TypedObjectImpl, 'name', { value: 'TypedObject' });
 export type TypedObject<T extends Record<string, any> = Record<string, any>> = TypedObjectImpl<T> & T;
 
 export type TypedObjectOpts = {
-  readOnlyAccess?: boolean;
+  readOnly?: boolean;
 };
 
 type TypedObjectConstructor = {

--- a/packages/core/echo/echo-schema/src/typed-object.ts
+++ b/packages/core/echo/echo-schema/src/typed-object.ts
@@ -425,7 +425,7 @@ type TypedObjectConstructor = {
   new <T extends Record<string, any> = Record<string, any>>(
     initialProps?: NoInfer<Partial<T>>,
     _schemaType?: EchoSchemaType,
-    opts?: TypedObjectOpts
+    opts?: TypedObjectOpts,
   ): TypedObject<T>;
 };
 

--- a/packages/core/echo/echo-typegen/src/codegen.ts
+++ b/packages/core/echo/echo-typegen/src/codegen.ts
@@ -190,8 +190,8 @@ export const createObjectClass = (type: pb.Type) => {
       return ${name}.type.createFilter(opts);
       }
 
-      constructor(opts?: Partial<${name}Props>) {
-        super({ ...opts}, ${name}.type);
+      constructor(initValues?: Partial<${name}Props>, opts?: ${importNamespace}.TypedObjectOpts) {
+        super({ ...initValues}, ${name}.type, opts);
       }
       ${fields}
     }

--- a/packages/core/protocols/src/proto/dxos/client/services.proto
+++ b/packages/core/protocols/src/proto/dxos/client/services.proto
@@ -10,6 +10,7 @@ import "dxos/config.proto";
 import "dxos/halo/credentials.proto";
 import "dxos/mesh/teleport/gossip.proto";
 import "dxos/keys.proto";
+import "dxos/echo/metadata.proto";
 
 // TODO(burdon): Reorganize packages (e.g., client.services, echo.database).
 
@@ -196,7 +197,7 @@ message Space {
 
   repeated SpaceMember members = 10;
 
-  // TODO(dmaretskyi): Inline a snapshot of space.properties here so that inactive spaces still display their title.
+  optional dxos.echo.metadata.SpaceCache cache = 20;
 }
 
 message UpdateSpaceRequest {

--- a/packages/core/protocols/src/proto/dxos/echo/metadata.proto
+++ b/packages/core/protocols/src/proto/dxos/echo/metadata.proto
@@ -4,6 +4,7 @@
 
 syntax = "proto3";
 
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 import "dxos/echo/timeframe.proto";
@@ -27,6 +28,10 @@ message EchoMetadata {
 
   /// List of the data spaces.
   repeated SpaceMetadata spaces = 11;
+}
+
+message SpaceCache {
+  optional google.protobuf.Struct properties = 1;
 }
 
 // TODO(dmaretskyi): Cleanup numbering.
@@ -54,7 +59,8 @@ message SpaceMetadata {
 
   optional string snapshot = 7;
 
-  optional string properties = 9;
+
+  optional SpaceCache cache = 9;
 }
 
 /// Information needed to bootstrap an Identity.

--- a/packages/core/protocols/src/proto/dxos/echo/metadata.proto
+++ b/packages/core/protocols/src/proto/dxos/echo/metadata.proto
@@ -4,9 +4,9 @@
 
 syntax = "proto3";
 
-import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
+import "dxos/echo/model/document.proto";
 import "dxos/echo/timeframe.proto";
 import "dxos/keys.proto";
 
@@ -31,7 +31,8 @@ message EchoMetadata {
 }
 
 message SpaceCache {
-  optional google.protobuf.Struct properties = 1;
+  /// Properties snapshot.
+  optional dxos.echo.model.document.ObjectSnapshot properties = 1;
 }
 
 // TODO(dmaretskyi): Cleanup numbering.

--- a/packages/core/protocols/src/proto/dxos/echo/metadata.proto
+++ b/packages/core/protocols/src/proto/dxos/echo/metadata.proto
@@ -53,6 +53,8 @@ message SpaceMetadata {
   optional timeframe.TimeframeVector data_timeframe = 5;
 
   optional string snapshot = 7;
+
+  optional string properties = 9;
 }
 
 /// Information needed to bootstrap an Identity.

--- a/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
@@ -240,9 +240,9 @@ export class DataSpaceManager {
           if (this._isOpen) {
             this.updated.emit();
           }
-        }
+        },
       },
-      cache: metadata.cache
+      cache: metadata.cache,
     });
 
     await dataSpace.open();

--- a/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
@@ -240,8 +240,9 @@ export class DataSpaceManager {
           if (this._isOpen) {
             this.updated.emit();
           }
-        },
+        }
       },
+      cache: metadata.cache
     });
 
     await dataSpace.open();

--- a/packages/sdk/client-services/src/packlets/spaces/data-space.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space.ts
@@ -22,6 +22,7 @@ import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { ModelFactory } from '@dxos/model-factory';
 import { FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
+import { SpaceCache } from '@dxos/protocols/proto/dxos/echo/metadata';
 import { AdmittedFeed, Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
 import { GossipMessage } from '@dxos/protocols/proto/dxos/mesh/teleport/gossip';
 import { Gossip, Presence } from '@dxos/teleport-extension-gossip';
@@ -57,6 +58,7 @@ export type DataSpaceParams = {
   memberKey: PublicKey;
   snapshotId?: string | undefined;
   callbacks?: DataSpaceCallbacks;
+  cache?: SpaceCache;
 };
 
 @trackLeaks('open', 'close')
@@ -72,6 +74,7 @@ export class DataSpace {
   private readonly _signingContext: SigningContext;
   private readonly _notarizationPluginConsumer: CredentialConsumer<NotarizationPlugin>;
   private readonly _callbacks: DataSpaceCallbacks;
+  private readonly _cache?: SpaceCache;
 
   private _state = SpaceState.CLOSED;
 
@@ -106,6 +109,7 @@ export class DataSpace {
     });
 
     this._notarizationPluginConsumer = this._inner.spaceState.registerProcessor(new NotarizationPlugin());
+    this._cache = params.cache;
   }
 
   get key() {
@@ -135,6 +139,10 @@ export class DataSpace {
 
   get notarizationPlugin() {
     return this._notarizationPluginConsumer.processor;
+  }
+
+  get cache() {
+    return this._cache;
   }
 
   async open() {

--- a/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
@@ -170,9 +170,9 @@ export class SpacesServiceImpl implements SpacesService {
           this._identityManager.identity?.identityKey.equals(member.key) ||
           space.presence.getPeersOnline().filter(({ identityKey }) => identityKey.equals(member.key)).length > 0
             ? SpaceMember.PresenceState.ONLINE
-            : SpaceMember.PresenceState.OFFLINE
+            : SpaceMember.PresenceState.OFFLINE,
       })),
-      cache: space.cache
+      cache: space.cache,
     };
   }
 }

--- a/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
@@ -170,8 +170,9 @@ export class SpacesServiceImpl implements SpacesService {
           this._identityManager.identity?.identityKey.equals(member.key) ||
           space.presence.getPeersOnline().filter(({ identityKey }) => identityKey.equals(member.key)).length > 0
             ? SpaceMember.PresenceState.ONLINE
-            : SpaceMember.PresenceState.OFFLINE,
+            : SpaceMember.PresenceState.OFFLINE
       })),
+      cache: space.cache
     };
   }
 }

--- a/packages/sdk/client/src/packlets/proxies/echo-proxy.ts
+++ b/packages/sdk/client/src/packlets/proxies/echo-proxy.ts
@@ -127,7 +127,7 @@ export class EchoProxy implements Echo {
 
         let spaceProxy = this._spacesMap.get(space.spaceKey);
         if (!spaceProxy) {
-          spaceProxy = new SpaceProxy(this._serviceProvider, this._modelFactory, space, this.dbRouter, space.cache);
+          spaceProxy = new SpaceProxy(this._serviceProvider, this._modelFactory, space, this.dbRouter);
 
           // Propagate space state updates to the space list observable.
           spaceProxy._stateUpdate.on(this._ctx, () => this._updateSpaceList());

--- a/packages/sdk/client/src/packlets/proxies/echo-proxy.ts
+++ b/packages/sdk/client/src/packlets/proxies/echo-proxy.ts
@@ -127,7 +127,7 @@ export class EchoProxy implements Echo {
 
         let spaceProxy = this._spacesMap.get(space.spaceKey);
         if (!spaceProxy) {
-          spaceProxy = new SpaceProxy(this._serviceProvider, this._modelFactory, space, this.dbRouter);
+          spaceProxy = new SpaceProxy(this._serviceProvider, this._modelFactory, space, this.dbRouter, space.cache);
 
           // Propagate space state updates to the space list observable.
           spaceProxy._stateUpdate.on(this._ctx, () => this._updateSpaceList());

--- a/packages/sdk/client/src/packlets/proxies/space-proxy.ts
+++ b/packages/sdk/client/src/packlets/proxies/space-proxy.ts
@@ -16,6 +16,7 @@ import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { ModelFactory } from '@dxos/model-factory';
 import { Invitation, Space as SpaceData, SpaceMember, SpaceState } from '@dxos/protocols/proto/dxos/client/services';
+import { SpaceCache } from '@dxos/protocols/proto/dxos/echo/metadata';
 import { SpaceSnapshot } from '@dxos/protocols/proto/dxos/echo/snapshot';
 import { GossipMessage } from '@dxos/protocols/proto/dxos/mesh/teleport/gossip';
 
@@ -133,7 +134,8 @@ export class SpaceProxy implements Space {
     private _clientServices: ClientServicesProvider,
     private _modelFactory: ModelFactory,
     private _data: SpaceData,
-    databaseRouter: DatabaseRouter
+    databaseRouter: DatabaseRouter,
+    cache?: SpaceCache
   ) {
     assert(this._clientServices.services.InvitationsService, 'InvitationsService not available');
     this._invitationProxy = new InvitationsProxy(this._clientServices.services.InvitationsService, () => ({
@@ -156,6 +158,10 @@ export class SpaceProxy implements Space {
     this._stateUpdate.emit(this._currentState);
     this._pipelineUpdate.emit(_data.pipeline ?? {});
     this._membersUpdate.emit(_data.members ?? []);
+
+    if (cache?.properties) {
+      this._cachedProperties = Object.freeze({ name: 'Loading...', ...cache.properties }) as Properties;
+    }
   }
 
   get key() {

--- a/packages/sdk/client/src/packlets/proxies/space-proxy.ts
+++ b/packages/sdk/client/src/packlets/proxies/space-proxy.ts
@@ -184,7 +184,6 @@ export class SpaceProxy implements Space {
   }
 
   get properties() {
-    console.log('cached properties', this._cachedProperties.toJSON());
     if (this._currentState !== SpaceState.READY) {
       return this._cachedProperties;
     } else {

--- a/packages/sdk/client/src/packlets/proxies/space-proxy.ts
+++ b/packages/sdk/client/src/packlets/proxies/space-proxy.ts
@@ -16,7 +16,6 @@ import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { ModelFactory } from '@dxos/model-factory';
 import { Invitation, Space as SpaceData, SpaceMember, SpaceState } from '@dxos/protocols/proto/dxos/client/services';
-import { SpaceCache } from '@dxos/protocols/proto/dxos/echo/metadata';
 import { SpaceSnapshot } from '@dxos/protocols/proto/dxos/echo/snapshot';
 import { GossipMessage } from '@dxos/protocols/proto/dxos/mesh/teleport/gossip';
 
@@ -130,8 +129,7 @@ export class SpaceProxy implements Space {
     private _clientServices: ClientServicesProvider,
     private _modelFactory: ModelFactory,
     private _data: SpaceData,
-    databaseRouter: DatabaseRouter,
-    cache: SpaceCache = {}
+    databaseRouter: DatabaseRouter
   ) {
     assert(this._clientServices.services.InvitationsService, 'InvitationsService not available');
     this._invitationProxy = new InvitationsProxy(this._clientServices.services.InvitationsService, () => ({
@@ -155,7 +153,7 @@ export class SpaceProxy implements Space {
     this._pipelineUpdate.emit(_data.pipeline ?? {});
     this._membersUpdate.emit(_data.members ?? []);
 
-      this._cachedProperties = new Properties({ name: 'Loading...', ...cache.properties }, { readOnlyAccess: true });
+      this._cachedProperties = new Properties({}, { readOnly: true });
   }
 
   get key() {

--- a/packages/sdk/client/src/packlets/proxies/space-proxy.ts
+++ b/packages/sdk/client/src/packlets/proxies/space-proxy.ts
@@ -122,11 +122,7 @@ export class SpaceProxy implements Space {
   private readonly _pipeline = MulticastObservable.from(this._pipelineUpdate, {});
   private readonly _members = MulticastObservable.from(this._membersUpdate, []);
 
-  // TODO(dmaretskyi): Cache properties in the metadata.
-  private _cachedProperties = new Properties({
-    name: 'Loading...',
-  });
-
+  private _cachedProperties: Properties;
   private _properties?: TypedObject;
 
   // prettier-ignore
@@ -135,7 +131,7 @@ export class SpaceProxy implements Space {
     private _modelFactory: ModelFactory,
     private _data: SpaceData,
     databaseRouter: DatabaseRouter,
-    cache?: SpaceCache
+    cache: SpaceCache = {}
   ) {
     assert(this._clientServices.services.InvitationsService, 'InvitationsService not available');
     this._invitationProxy = new InvitationsProxy(this._clientServices.services.InvitationsService, () => ({
@@ -159,9 +155,7 @@ export class SpaceProxy implements Space {
     this._pipelineUpdate.emit(_data.pipeline ?? {});
     this._membersUpdate.emit(_data.members ?? []);
 
-    if (cache?.properties) {
-      this._cachedProperties = Object.freeze({ name: 'Loading...', ...cache.properties }) as Properties;
-    }
+      this._cachedProperties = new Properties({ name: 'Loading...', ...cache.properties }, { readOnlyAccess: true });
   }
 
   get key() {
@@ -190,6 +184,7 @@ export class SpaceProxy implements Space {
   }
 
   get properties() {
+    console.log('cached properties', this._cachedProperties.toJSON());
     if (this._currentState !== SpaceState.READY) {
       return this._cachedProperties;
     } else {

--- a/packages/sdk/client/src/packlets/proxies/space-proxy.ts
+++ b/packages/sdk/client/src/packlets/proxies/space-proxy.ts
@@ -10,7 +10,7 @@ import { Event, MulticastObservable, synchronized, Trigger, UnsubscribeCallback 
 import { cancelWithContext, Context } from '@dxos/context';
 import { loadashEqualityFn, todo } from '@dxos/debug';
 import { DatabaseProxy, ItemManager } from '@dxos/echo-db';
-import { DatabaseRouter, TypedObject, EchoDatabase } from '@dxos/echo-schema';
+import { DatabaseRouter, TypedObject, EchoDatabase, setStateFromSnapshot } from '@dxos/echo-schema';
 import { ApiError } from '@dxos/errors';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
@@ -153,7 +153,10 @@ export class SpaceProxy implements Space {
     this._pipelineUpdate.emit(_data.pipeline ?? {});
     this._membersUpdate.emit(_data.members ?? []);
 
-      this._cachedProperties = new Properties({}, { readOnly: true });
+    this._cachedProperties = new Properties({}, { readOnly: true });
+    if (this._data.cache?.properties) {
+      setStateFromSnapshot(this._cachedProperties, this._data.cache.properties);
+    }
   }
 
   get key() {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a08357b</samp>

### Summary
🚀🔒🛠️

<!--
1.  🚀 - This emoji represents the improvement in performance and efficiency of the space operations due to the caching mechanism and the use of the `SpaceCache` message.
2.  🔒 - This emoji represents the enhancement in security and integrity of the space data due to the read-only access option and the warning about unwanted changes.
3.  🛠️ - This emoji represents the refactoring and modification of the existing code and methods to support the new features and logic.
-->
This pull request adds a caching mechanism for space metadata using the `SpaceCache` message type and the `metadataStore` class. It also adds a read-only option for typed objects to prevent unwanted modifications. The changes affect the echo pipeline, the echo schema, the client services, the protocols, and the typegen modules. The purpose of these changes is to improve the performance and security of the space operations.

> _`SpaceCache` message_
> _enhances space metadata_
> _autumn of data flow_

### Walkthrough
*  Add `SpaceCache` message to store the cache data of a space in the `dxos/echo/metadata.proto` file ([link](https://github.com/dxos/dxos/pull/3188/files?diff=unified&w=0#diff-9e302de5922448e74f3a3aec27ab01382614017e90cc1e54ecc1f6bf143220a3R33-R36), [link](https://github.com/dxos/dxos/pull/3188/files?diff=unified&w=0#diff-9e302de5922448e74f3a3aec27ab01382614017e90cc1e54ecc1f6bf143220a3R61-R63)).


