### PR TITLE
fix(appkit,aurora,halo-app): Group spacing, HALO Avatar label, Avatar status badging

### DIFF
--- a/packages/apps/halo-app/src/components/AppList/App.tsx
+++ b/packages/apps/halo-app/src/components/AppList/App.tsx
@@ -21,7 +21,7 @@ export const App = (props: AppProps) => {
       href={props.launchUrl}
     >
       <Group
-        className='mbe-2'
+        className='mbe-2 p-2 rounded'
         label={{
           level: 2,
           className: 'text-lg font-body flex gap-2 items-center',

--- a/packages/apps/halo-app/src/pages/ContactsPage.tsx
+++ b/packages/apps/halo-app/src/pages/ContactsPage.tsx
@@ -24,7 +24,7 @@ const ContactsPage = () => {
         }
       />
       <Group
-        className='mlb-4'
+        className='mlb-4 p-2 rounded'
         label={{
           level: 2,
           children: t('empty contacts message'),

--- a/packages/ui/aurora/src/components/Avatar/Avatar.tsx
+++ b/packages/ui/aurora/src/components/Avatar/Avatar.tsx
@@ -100,12 +100,12 @@ const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(({ children, className, 
           weight='fill'
           className={tx('avatar.statusIcon', 'avatar__status-icon', { size: statusIconSize, status })}
         />
-      ) : (
+      ) : status ? (
         <Circle
           weight='fill'
           className={tx('avatar.statusIcon', 'avatar__status-icon', { size: statusIconSize, status })}
         />
-      )}
+      ) : null}
     </AvatarRootPrimitive>
   );
 });

--- a/packages/ui/react-appkit/src/components/AuthChoices/AuthChoices.stories.tsx
+++ b/packages/ui/react-appkit/src/components/AuthChoices/AuthChoices.stories.tsx
@@ -6,7 +6,6 @@ import '@dxosTheme';
 import React from 'react';
 
 import { useTranslation } from '@dxos/aurora';
-import { mx } from '@dxos/aurora-theme';
 
 import { Group } from '../Group';
 import { AuthChoices, AuthChoicesProps } from './AuthChoices';
@@ -29,7 +28,7 @@ export const Default = {
           className: 'mb-4 text-3xl',
           children: t('auth choices label')
         }}
-        className={mx('p-5 rounded-xl max-w-md mx-auto my-4')}
+        className='p-5 rounded-xl max-w-md mx-auto my-4'
       >
         <AuthChoices {...args} />
       </Group>

--- a/packages/ui/react-appkit/src/components/DeviceList/Device.tsx
+++ b/packages/ui/react-appkit/src/components/DeviceList/Device.tsx
@@ -41,7 +41,7 @@ export const Device = (props: DeviceProps) => {
           />
         )
       }}
-      className='mbe-2'
+      className='mbe-2 p-2 rounded'
     />
   );
 };

--- a/packages/ui/react-appkit/src/components/InvitationList/InvitationList.tsx
+++ b/packages/ui/react-appkit/src/components/InvitationList/InvitationList.tsx
@@ -22,7 +22,7 @@ export const InvitationList = ({ createInvitationUrl, invitations, onClickRemove
   const empty = !invitations || invitations.length < 1;
   return (
     <Group
-      className='mlb-4'
+      className='mlb-4 p-2 rounded'
       label={{
         level: 2,
         children: !empty ? t('invitations label') : t('empty invitations message'),

--- a/packages/ui/react-appkit/src/components/InvitationList/PendingInvitation.tsx
+++ b/packages/ui/react-appkit/src/components/InvitationList/PendingInvitation.tsx
@@ -32,7 +32,7 @@ export const PendingInvitation = ({ wrapper, createInvitationUrl, onClickRemove 
   const { cancel, status, haltedAt, authCode, invitationCode } = useInvitationStatus(wrapper);
 
   return (
-    <div role='group' className={mx(group({ elevation: 'group' }), 'mbe-2')}>
+    <div role='group' className={mx(group({ elevation: 'group' }), 'mbe-2 p-2 rounded')}>
       {wrapper.get() ? (
         <>
           <HeadingWithActions

--- a/packages/ui/react-appkit/src/components/Menubar/ProfileMenu.tsx
+++ b/packages/ui/react-appkit/src/components/Menubar/ProfileMenu.tsx
@@ -4,10 +4,10 @@
 
 import React, { PropsWithChildren } from 'react';
 
+import { AvatarFallback, AvatarLabel, AvatarRoot, Avatar, useJdenticonHref } from '@dxos/aurora';
 import { Identity as IdentityType } from '@dxos/client';
 import { humanize } from '@dxos/util';
 
-import { Avatar } from '../Avatar';
 import { Popover } from '../Popover';
 
 export interface ProfileMenuProps {
@@ -16,15 +16,16 @@ export interface ProfileMenuProps {
 
 export const ProfileMenu = (props: PropsWithChildren<ProfileMenuProps>) => {
   const { identity } = props;
+  const jdenticon = useJdenticonHref(identity.identityKey.toHex() ?? '', 10);
   return (
     <Popover
       openTrigger={
-        <Avatar
-          size={10}
-          variant='circle'
-          fallbackValue={identity.identityKey.toHex()}
-          label={identity.profile?.displayName ?? humanize(identity.identityKey.toHex())}
-        />
+        <AvatarRoot>
+          <AvatarLabel srOnly>{identity.profile?.displayName ?? humanize(identity.identityKey.toHex())}</AvatarLabel>
+          <Avatar>
+            <AvatarFallback href={jdenticon} />
+          </Avatar>
+        </AvatarRoot>
       }
       slots={{
         content: { collisionPadding: 8, sideOffset: 4, className: 'flex flex-col gap-4 items-center z-[2]' },

--- a/packages/ui/react-appkit/src/components/ProfileList/ProfileList.tsx
+++ b/packages/ui/react-appkit/src/components/ProfileList/ProfileList.tsx
@@ -47,7 +47,7 @@ export const ProfileList = ({ identities }: ProfileListProps) => {
     </ul>
   ) : (
     <Group
-      className='mlb-4'
+      className='mlb-4 p-2 rounded'
       label={{
         level: 2,
         children: t('empty members message'),

--- a/packages/ui/react-appkit/src/components/SingleInputStep/SingleInputStep.stories.tsx
+++ b/packages/ui/react-appkit/src/components/SingleInputStep/SingleInputStep.stories.tsx
@@ -6,7 +6,6 @@ import '@dxosTheme';
 import React from 'react';
 
 import { useTranslation } from '@dxos/aurora';
-import { mx } from '@dxos/aurora-theme';
 
 import { Group } from '../Group';
 import { SingleInputStep, SingleInputStepProps } from './SingleInputStep';
@@ -30,7 +29,7 @@ const render = ({ rootLabel, ...args }: SingleInputStepProps & { rootLabel: stri
         className: 'mb-2 text-3xl',
         children: t(rootLabel)
       }}
-      className={mx('p-5 rounded-xl max-w-md mx-auto my-4')}
+      className='p-5 rounded-xl max-w-md mx-auto my-4'
     >
       <SingleInputStep {...args} className='max-w-md mx-auto my-4' />
     </Group>

--- a/packages/ui/react-appkit/src/components/SpaceList/SpaceList.tsx
+++ b/packages/ui/react-appkit/src/components/SpaceList/SpaceList.tsx
@@ -52,7 +52,7 @@ export const SpaceList = ({ spaces = [] }: SpaceListProps) => {
     </>
   ) : (
     <Group
-      className='mlb-4'
+      className='mlb-4 p-2 rounded'
       label={{
         level: 2,
         children: t('empty spaces label'),


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0ae10d8</samp>

### Summary
🎨🐛♿

<!--
1.  🎨 - This emoji represents the changes related to styling and appearance of the components, such as adding padding and rounded corners.
2.  🐛 - This emoji represents the change related to fixing a bug in the `Avatar` component, where it would render an empty circle for offline users.
3.  ♿ - This emoji represents the change related to improving the accessibility of the `ProfileMenu` component, by using aurora components and hooks for avatar rendering.
-->
This pull request updates the styling of various components in the `react-appkit` and `halo-app` packages to improve their appearance and consistency. It also refactors the `ProfileMenu` and `Avatar` components to use aurora components and hooks, and removes some unnecessary usage of the `mx` utility function in some stories.

> _The halo-app got a makeover_
> _With padding and corners all over_
> _The `Avatar` got smart_
> _The `ProfileMenu` got art_
> _And some stories got rid of their `mx` clover_

### Walkthrough
*  Styled various components with padding and rounded corners to match the design of halo-app ([link](https://github.com/dxos/dxos/pull/3190/files?diff=unified&w=0#diff-041fd3f62b3267ae746d685368a6f11e51577e7999c0788c17a6ba15415aefb1L24-R24), [link](https://github.com/dxos/dxos/pull/3190/files?diff=unified&w=0#diff-33ad4c87aa516bdf260cfd8c853794451ca12177c8eeb0e06298fbfbffd42532L27-R27), [link](https://github.com/dxos/dxos/pull/3190/files?diff=unified&w=0#diff-d69a69079f55dcc12c4485626be6bb4bd948658d464ac853c872b5c89c826f6bL44-R44), [link](https://github.com/dxos/dxos/pull/3190/files?diff=unified&w=0#diff-11748206acc8b7e660706a503e151dc26ec606962ace8a802a353efebd1b4e03L25-R25), [link](https://github.com/dxos/dxos/pull/3190/files?diff=unified&w=0#diff-96c3ce568f08472327db0694d39c7c725272a0b65013fcb8508e631549e6da47L35-R35), [link](https://github.com/dxos/dxos/pull/3190/files?diff=unified&w=0#diff-82f51cef296e4cf7f1971809f013b59456d33849184330eac87e9934a6d295b4L50-R50), [link](https://github.com/dxos/dxos/pull/3190/files?diff=unified&w=0#diff-d5ebb47267bf13bab7b4d1f4817e126bd6739d0c3ff1b3b04d6ddea899932431L55-R55)).


