### PR TITLE
fix(composer-extension): False negatives

### DIFF
--- a/packages/apps/composer-app/src/components/ResolverDialog/ResolverContext.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/ResolverContext.tsx
@@ -45,7 +45,7 @@ export const SpaceResolverProvider = observer(({ children }: PropsWithChildren<{
   const space = useMemo(
     () =>
       nextSpace ?? (identityHex ? spaces.find((space) => matchSpace(space, identityHex, source, id)) ?? null : null),
-    [spaces, identityHex, source, id]
+    [spaces, nextSpace, identityHex, source, id]
   );
 
   return (

--- a/packages/apps/composer-app/src/components/ResolverDialog/ResolverContext.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/ResolverContext.tsx
@@ -6,9 +6,7 @@ import React, { Context, createContext, PropsWithChildren, useContext, useEffect
 import { useParams, useSearchParams } from 'react-router-dom';
 
 import { Document } from '@braneframe/types';
-import { useTranslation } from '@dxos/aurora';
 import { log } from '@dxos/log';
-import { Loading } from '@dxos/react-appkit';
 import { Space, useIdentity, useQuery, useSpaces, Text, observer } from '@dxos/react-client';
 import { ShellProvider } from '@dxos/react-shell';
 
@@ -41,23 +39,14 @@ export const SpaceResolverProvider = observer(({ children }: PropsWithChildren<{
   const identityHex = identity?.identityKey.toHex();
   const [source, id] = useLocationIdentifier();
   const spaces = useSpaces({ all: true });
-  const { t } = useTranslation('appkit');
 
   const [nextSpace, setSpace] = useState<Space | null>(null);
-  const [ready, setReady] = useState(false);
 
   const space = useMemo(
     () =>
       nextSpace ?? (identityHex ? spaces.find((space) => matchSpace(space, identityHex, source, id)) ?? null : null),
     [spaces, identityHex, source, id]
   );
-
-  // [thure] This effect is intended to cause the context to wait a moment if at first no space is found, to avoid false
-  // negatives due to replication time.
-  useEffect(() => {
-    !space && setTimeout(() => setReady(false), 0);
-    setTimeout(() => setReady(true), !space ? 1e3 : 0);
-  }, [identityHex, source, id]);
 
   return (
     <ShellProvider
@@ -68,13 +57,9 @@ export const SpaceResolverProvider = observer(({ children }: PropsWithChildren<{
         console.warn('TODO: onJoinedSpace', nextSpaceKey);
       }}
     >
-      {space || ready ? (
-        <SpaceResolverContext.Provider value={{ space, setSpace, source, id, identityHex }}>
-          {children}
-        </SpaceResolverContext.Provider>
-      ) : (
-        <Loading label={t('generic loading label')} />
-      )}
+      <SpaceResolverContext.Provider value={{ space, setSpace, source, id, identityHex }}>
+        {children}
+      </SpaceResolverContext.Provider>
     </ShellProvider>
   );
 });


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 99e84f4</samp>

### Summary
🛠️👁️🚀

<!--
1.  🛠️ - This emoji can be used to indicate that something was fixed or improved, such as a bug, a performance issue, or a code quality improvement. In this case, the memoization of `currentSpace` based on `spaces` could be seen as a fix or an improvement.
2.  👁️ - This emoji can be used to indicate that something was added or enhanced related to visibility, observation, or monitoring. In this case, the `observer` function was added to components that need to react to data changes, which could be seen as an enhancement related to observation.
3.  🚀 - This emoji can be used to indicate that something was added or enhanced related to speed, performance, or efficiency. In this case, the `observer` function could also be seen as an enhancement related to performance, as it could make the components more responsive and avoid unnecessary re-rendering.
-->
Improved reactivity and performance of `ResolverDialog` components in `composer-app` by using `observer` and memoizing `currentSpace`.

> _We are the observers of the data storm_
> _We react to every change with rage and scorn_
> _We don't rely on stale or faulty space_
> _We memoize the current with a blazing trace_

### Walkthrough
*  Wrap `SpaceResolverProvider` and `DocumentResolverProvider` components with `observer` function to enable re-rendering on observable changes ([link](https://github.com/dxos/dxos/pull/3191/files?diff=unified&w=0#diff-f80ad10b3f3a53671c8e7559fa049d6cd30f148753da3571e245e4cc25c3b561L10-R10), [link](https://github.com/dxos/dxos/pull/3191/files?diff=unified&w=0#diff-f80ad10b3f3a53671c8e7559fa049d6cd30f148753da3571e245e4cc25c3b561L34-R34), [link](https://github.com/dxos/dxos/pull/3191/files?diff=unified&w=0#diff-f80ad10b3f3a53671c8e7559fa049d6cd30f148753da3571e245e4cc25c3b561L65-R65)).

