### PR TITLE
feat(composer-extension): Open in Composer main app

### DIFF
--- a/packages/apps/composer-app/src/components/ResolverDialog/ResolverContext.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/ResolverContext.tsx
@@ -45,7 +45,7 @@ export const SpaceResolverProvider = observer(({ children }: PropsWithChildren<{
   const space = useMemo(
     () =>
       nextSpace ?? (identityHex ? spaces.find((space) => matchSpace(space, identityHex, source, id)) ?? null : null),
-    [spaces, identityHex, source, id]
+    [spaces, nextSpace, identityHex, source, id]
   );
 
   return (

--- a/packages/apps/composer-app/src/components/ResolverDialog/ResolverContext.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/ResolverContext.tsx
@@ -6,9 +6,7 @@ import React, { Context, createContext, PropsWithChildren, useContext, useEffect
 import { useParams, useSearchParams } from 'react-router-dom';
 
 import { Document } from '@braneframe/types';
-import { useTranslation } from '@dxos/aurora';
 import { log } from '@dxos/log';
-import { Loading } from '@dxos/react-appkit';
 import { Space, useIdentity, useQuery, useSpaces, Text, observer } from '@dxos/react-client';
 import { ShellProvider } from '@dxos/react-shell';
 
@@ -41,23 +39,14 @@ export const SpaceResolverProvider = observer(({ children }: PropsWithChildren<{
   const identityHex = identity?.identityKey.toHex();
   const [source, id] = useLocationIdentifier();
   const spaces = useSpaces({ all: true });
-  const { t } = useTranslation('appkit');
 
   const [nextSpace, setSpace] = useState<Space | null>(null);
-  const [ready, setReady] = useState(false);
 
   const space = useMemo(
     () =>
       nextSpace ?? (identityHex ? spaces.find((space) => matchSpace(space, identityHex, source, id)) ?? null : null),
     [spaces, identityHex, source, id]
   );
-
-  // [thure] This effect is intended to cause the context to wait a moment if at first no space is found, to avoid false
-  // negatives due to replication time.
-  useEffect(() => {
-    !space && setTimeout(() => setReady(false), 0);
-    setTimeout(() => setReady(true), !space ? 1e3 : 0);
-  }, [identityHex, source, id]);
 
   return (
     <ShellProvider
@@ -68,13 +57,9 @@ export const SpaceResolverProvider = observer(({ children }: PropsWithChildren<{
         console.warn('TODO: onJoinedSpace', nextSpaceKey);
       }}
     >
-      {space || ready ? (
-        <SpaceResolverContext.Provider value={{ space, setSpace, source, id, identityHex }}>
-          {children}
-        </SpaceResolverContext.Provider>
-      ) : (
-        <Loading label={t('generic loading label')} />
-      )}
+      <SpaceResolverContext.Provider value={{ space, setSpace, source, id, identityHex }}>
+        {children}
+      </SpaceResolverContext.Provider>
     </ShellProvider>
   );
 });

--- a/packages/apps/composer-app/src/layouts/EmbeddedLayout.tsx
+++ b/packages/apps/composer-app/src/layouts/EmbeddedLayout.tsx
@@ -3,10 +3,12 @@
 //
 import '../embedded.css';
 
+import { ArrowSquareOut } from '@phosphor-icons/react';
 import React, { useCallback, useContext } from 'react';
 import { Outlet } from 'react-router-dom';
 
-import { Button, ButtonGroup, useTranslation } from '@dxos/aurora';
+import { Button, ButtonGroup, useThemeContext, useTranslation } from '@dxos/aurora';
+import { getSize } from '@dxos/aurora-theme';
 import { ShellLayout } from '@dxos/client';
 import { useShell } from '@dxos/react-shell';
 
@@ -18,6 +20,7 @@ import {
   SpaceResolverProvider
 } from '../components';
 import { EmbeddedFirstRunPage } from '../pages';
+import { abbreviateKey } from '../router';
 import type { OutletContext } from './OutletContext';
 
 const EmbeddedLayoutImpl = () => {
@@ -25,6 +28,7 @@ const EmbeddedLayoutImpl = () => {
   const { space, source, id, identityHex } = useContext(SpaceResolverContext);
   const { document } = useContext(DocumentResolverContext);
   const shell = useShell();
+  const { tx } = useThemeContext();
 
   const handleCloseEmbed = useCallback(() => {
     window.parent.postMessage({ type: 'close-embed' }, 'https://github.com');
@@ -50,6 +54,16 @@ const EmbeddedLayoutImpl = () => {
       <div role='none' className='fixed inline-end-2 block-end-2 z-[70] flex gap-2'>
         <Button disabled={!space} onClick={handleInvite}>
           {t('create invitation label', { ns: 'appkit' })}
+        </Button>
+        <Button disabled={!(space && document)} asChild>
+          <a
+            target='_blank'
+            rel='noreferrer'
+            href={space && document ? `${location.origin}/${abbreviateKey(space?.key)}/${document.id}` : '#'}
+          >
+            <span className='sr-only'>{t('open in composer label')}</span>
+            <ArrowSquareOut className={getSize(5)} />
+          </a>
         </Button>
         <ButtonGroup>
           <Button onClick={handleCloseEmbed}>{t('close label', { ns: 'appkit' })}</Button>

--- a/packages/apps/composer-app/src/translations/en-US.ts
+++ b/packages/apps/composer-app/src/translations/en-US.ts
@@ -60,5 +60,6 @@ export const composer = {
   'resolver init document message': 'Syncing this document, one moment…',
   'comment stale title': 'No longer in-sync',
   'comment stale body':
-    'The document in Github was updated in another session. To re-sync, please save your changes, reload the page, and choose to edit from Github again.'
+    'The document in Github was updated in another session. To re-sync, please save your changes, reload the page, and choose to edit from Github again.',
+  'open in composer label': 'Open in Composer'
 };

--- a/packages/ui/aurora-theme/src/styles/components/button.ts
+++ b/packages/ui/aurora-theme/src/styles/components/button.ts
@@ -89,7 +89,11 @@ export const buttonOsRoot: ComponentFunction<OsButtonStyleProps> = (props, ...et
 };
 
 export const buttonGroup: ComponentFunction<{ elevation?: Elevation }> = (props, ...etc) => {
-  return mx('rounded-md overflow-hidden', contentElevation({ elevation: props.elevation }), ...etc);
+  return mx(
+    'rounded-md [&>:first-child]:rounded-is-md [&>:last-child]:rounded-ie-md [&>button]:relative',
+    contentElevation({ elevation: props.elevation }),
+    ...etc
+  );
 };
 
 export const buttonTheme: Theme<AppButtonStyleProps> = {

--- a/packages/ui/aurora/src/components/Button/Button.tsx
+++ b/packages/ui/aurora/src/components/Button/Button.tsx
@@ -3,6 +3,8 @@
 //
 
 import { createContext } from '@radix-ui/react-context';
+import { Primitive } from '@radix-ui/react-primitive';
+import { Slot } from '@radix-ui/react-slot';
 import React, { ComponentPropsWithoutRef, ComponentPropsWithRef, forwardRef } from 'react';
 
 import { Density, Elevation } from '@dxos/aurora-types';
@@ -10,11 +12,11 @@ import { Density, Elevation } from '@dxos/aurora-types';
 import { useDensityContext, useElevationContext, useThemeContext } from '../../hooks';
 import { ThemedClassName } from '../../util';
 
-interface ButtonProps extends ThemedClassName<ComponentPropsWithRef<'button'>> {
+interface ButtonProps extends ThemedClassName<ComponentPropsWithRef<typeof Primitive.button>> {
   variant?: 'default' | 'primary' | 'outline' | 'ghost';
   density?: Density;
   elevation?: Elevation;
-  disabled?: boolean;
+  asChild?: boolean;
 }
 
 type ButtonGroupContextValue = { inGroup?: boolean };
@@ -25,13 +27,14 @@ const [ButtonGroupProvider, useButtonGroupContext] = createContext<ButtonGroupCo
 });
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ children, density: propsDensity, elevation: propsElevation, variant = 'default', ...rootSlot }, ref) => {
+  ({ children, density: propsDensity, elevation: propsElevation, variant = 'default', asChild, ...rootSlot }, ref) => {
     const { inGroup } = useButtonGroupContext(BUTTON_NAME);
     const { tx } = useThemeContext();
     const elevation = useElevationContext(propsElevation);
     const density = useDensityContext(propsDensity);
+    const Root = asChild ? Slot : Primitive.button;
     return (
-      <button
+      <Root
         ref={ref}
         {...rootSlot}
         className={tx(
@@ -49,7 +52,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...(rootSlot.disabled && { disabled: true })}
       >
         {children}
-      </button>
+      </Root>
     );
   }
 );


### PR DESCRIPTION
This PR also adds `asChild` support to `Button` in aurora.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at be5de2b</samp>

### Summary
🌐🎨🔗

<!--
1.  🌐 - This emoji represents the translation for the new button label, as it is related to localization and language.
2.  🎨 - This emoji represents the style modification for the button group, as it is related to design and appearance.
3.  🔗 - This emoji represents the button to open the document in the full Composer app, as it is related to linking and navigation.
-->
This pull request adds a feature to the Composer app that lets users open embedded documents in a full window. It also improves the `Button` component and the `buttonGroup` style using a new library and some CSS tweaks. It updates the translation file for the new button label.

> _Sing, O Muse, of the skillful coder who devised_
> _A new button for the embedded layout, shining bright_
> _Like the eye of Zeus that flashes across the sky_
> _When he hurls his thunderbolts at the earth below._

### Walkthrough
* Add a button to the embedded layout for opening the document in Composer ([link](https://github.com/dxos/dxos/pull/3192/files?diff=unified&w=0#diff-55e414a49a1b76e7fdc1b1dce7f46d18f1a36ee400f9b3319cbbec472d207c93L6-R11), [link](https://github.com/dxos/dxos/pull/3192/files?diff=unified&w=0#diff-55e414a49a1b76e7fdc1b1dce7f46d18f1a36ee400f9b3319cbbec472d207c93R23), [link](https://github.com/dxos/dxos/pull/3192/files?diff=unified&w=0#diff-55e414a49a1b76e7fdc1b1dce7f46d18f1a36ee400f9b3319cbbec472d207c93R31), [link](https://github.com/dxos/dxos/pull/3192/files?diff=unified&w=0#diff-55e414a49a1b76e7fdc1b1dce7f46d18f1a36ee400f9b3319cbbec472d207c93R58-R67), [link](https://github.com/dxos/dxos/pull/3192/files?diff=unified&w=0#diff-df4fb09070ae8aa16c554fe8dc845b2f339eb7e852b9b7934010cbcf2eee0721L63-R64)).


