### PR TITLE
refactor(aurora): `Tooltip`

### DIFF
--- a/packages/apps/composer-app/src/components/Sidebar/FullSpaceTreeItem.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/FullSpaceTreeItem.tsx
@@ -42,8 +42,7 @@ import { observer, ShellLayout, Space, useIdentity, useQuery } from '@dxos/react
 import { useShell } from '@dxos/react-shell';
 
 import { abbreviateKey, getPath } from '../../router';
-import { backupSpace, restoreSpace } from '../../util';
-import { getSpaceDisplayName } from '../../util/getSpaceDisplayName';
+import { backupSpace, restoreSpace, getSpaceDisplayName } from '../../util';
 import { Separator } from '../Separator';
 import { DocumentLinkTreeItem } from './DocumentLinkTreeItem';
 

--- a/packages/ui/aurora-theme/src/styles/components/index.ts
+++ b/packages/ui/aurora-theme/src/styles/components/index.ts
@@ -9,3 +9,4 @@ export * from './dropdown-menu';
 export * from './list';
 export * from './main';
 export * from './message';
+export * from './tooltip';

--- a/packages/ui/aurora-theme/src/styles/components/tooltip.ts
+++ b/packages/ui/aurora-theme/src/styles/components/tooltip.ts
@@ -5,11 +5,22 @@
 import { ComponentFunction, Theme } from '@dxos/aurora-types';
 
 import { mx } from '../../util';
+import { defaultTooltip } from '../fragments';
 
 export type TooltipStyleProps = {};
 
-export const tooltipContent: ComponentFunction<TooltipStyleProps> = (_props, ...etc) => mx(...etc);
+export const tooltipContent: ComponentFunction<TooltipStyleProps> = (_props, ...etc) =>
+  mx(
+    'inline-flex items-center rounded-md plb-2 pli-3',
+    'shadow-lg bg-white dark:bg-neutral-800',
+    defaultTooltip,
+    ...etc
+  );
+
+export const tooltipArrow: ComponentFunction<TooltipStyleProps> = (_props, ...etc) =>
+  mx('fill-white dark:fill-neutral-800', ...etc);
 
 export const tooltipTheme: Theme<TooltipStyleProps> = {
-  content: tooltipContent
+  content: tooltipContent,
+  arrow: tooltipArrow
 };

--- a/packages/ui/aurora-theme/src/styles/components/tooltip.ts
+++ b/packages/ui/aurora-theme/src/styles/components/tooltip.ts
@@ -1,0 +1,15 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { ComponentFunction, Theme } from '@dxos/aurora-types';
+
+import { mx } from '../../util';
+
+export type TooltipStyleProps = {};
+
+export const tooltipContent: ComponentFunction<TooltipStyleProps> = (_props, ...etc) => mx(...etc);
+
+export const tooltipTheme: Theme<TooltipStyleProps> = {
+  content: tooltipContent
+};

--- a/packages/ui/aurora-theme/src/styles/theme.ts
+++ b/packages/ui/aurora-theme/src/styles/theme.ts
@@ -15,7 +15,8 @@ import {
   inputOsTheme,
   mainTheme,
   messageTheme,
-  avatarTheme
+  avatarTheme,
+  tooltipTheme
 } from './components';
 
 export const theme: Theme<Record<string, any>> = {
@@ -26,7 +27,8 @@ export const theme: Theme<Record<string, any>> = {
   list: listTheme,
   main: mainTheme,
   message: messageTheme,
-  avatar: avatarTheme
+  avatar: avatarTheme,
+  tooltip: tooltipTheme
 };
 
 export const osTheme: Theme<Record<string, any>> = {

--- a/packages/ui/aurora/package.json
+++ b/packages/ui/aurora/package.json
@@ -18,12 +18,16 @@
     "chromatic": "chromatic --project-token=\"44ade288043a\" --storybook-build-dir out/aurora --exit-zero-on-changes"
   },
   "dependencies": {
+    "@dxos/react-hooks": "workspace:*",
+    "@dxos/react-input": "workspace:*",
+    "@dxos/react-list": "workspace:*",
     "@radix-ui/react-avatar": "^1.0.2",
     "@radix-ui/react-checkbox": "^1.0.3",
     "@radix-ui/react-context": "^1.0.0",
     "@radix-ui/react-dialog": "^1.0.3",
     "@radix-ui/react-primitive": "^1.0.2",
     "@radix-ui/react-slot": "^1.0.1",
+    "@radix-ui/react-tooltip": "^1.0.5",
     "@radix-ui/react-use-controllable-state": "^1.0.0",
     "i18next": "^21.10.0",
     "jdenticon": "^3.2.0",
@@ -32,9 +36,6 @@
   "devDependencies": {
     "@dxos/aurora-theme": "workspace:*",
     "@dxos/aurora-types": "workspace:*",
-    "@dxos/react-hooks": "workspace:*",
-    "@dxos/react-input": "workspace:*",
-    "@dxos/react-list": "workspace:*",
     "@phosphor-icons/react": "^2.0.5",
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",

--- a/packages/ui/aurora/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/ui/aurora/src/components/Tooltip/Tooltip.stories.tsx
@@ -13,19 +13,21 @@ type StoryTooltipProps = {
 };
 
 const StoryTooltip = ({ content }: StoryTooltipProps) => (
-  <TooltipProvider>
-    <TooltipRoot defaultOpen>
-      <TooltipTrigger asChild>
-        <Button>Trigger tooltip</Button>
-      </TooltipTrigger>
-      <TooltipPortal>
-        <TooltipContent side='right'>
-          <TooltipArrow />
-          {content}
-        </TooltipContent>
-      </TooltipPortal>
-    </TooltipRoot>
-  </TooltipProvider>
+  <div role='none' style={{ minWidth: '320px' }}>
+    <TooltipProvider>
+      <TooltipRoot defaultOpen>
+        <TooltipTrigger asChild>
+          <Button>Trigger tooltip</Button>
+        </TooltipTrigger>
+        <TooltipPortal>
+          <TooltipContent side='right'>
+            <TooltipArrow />
+            {content}
+          </TooltipContent>
+        </TooltipPortal>
+      </TooltipRoot>
+    </TooltipProvider>
+  </div>
 );
 
 export default {
@@ -35,5 +37,8 @@ export default {
 export const Default = {
   args: {
     content: 'This is the tooltip content'
+  },
+  parameters: {
+    chromatic: { delay: 500 }
   }
 };

--- a/packages/ui/aurora/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/ui/aurora/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,39 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+import '@dxosTheme';
+import React from 'react';
+
+import { Button } from '../Button';
+import { TooltipRoot, TooltipPortal, TooltipContent, TooltipArrow, TooltipTrigger, TooltipProvider } from './Tooltip';
+
+type StoryTooltipProps = {
+  content: string;
+};
+
+const StoryTooltip = ({ content }: StoryTooltipProps) => (
+  <TooltipProvider>
+    <TooltipRoot defaultOpen>
+      <TooltipTrigger asChild>
+        <Button>Trigger tooltip</Button>
+      </TooltipTrigger>
+      <TooltipPortal>
+        <TooltipContent side='right'>
+          <TooltipArrow />
+          {content}
+        </TooltipContent>
+      </TooltipPortal>
+    </TooltipRoot>
+  </TooltipProvider>
+);
+
+export default {
+  component: StoryTooltip
+};
+
+export const Default = {
+  args: {
+    content: 'This is the tooltip content'
+  }
+};

--- a/packages/ui/aurora/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/aurora/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,17 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import {
+  Provider as TooltipProviderPrimitive,
+  TooltipProviderProps as TooltipProviderPrimitiveProps
+} from '@radix-ui/react-tooltip';
+import { FunctionComponent } from 'react';
+
+type TooltipProviderProps = TooltipProviderPrimitiveProps;
+
+const TooltipProvider: FunctionComponent<TooltipProviderProps> = TooltipProviderPrimitive;
+
+export { TooltipProvider };
+
+export type { TooltipProviderProps };

--- a/packages/ui/aurora/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/aurora/src/components/Tooltip/Tooltip.tsx
@@ -4,14 +4,72 @@
 
 import {
   Provider as TooltipProviderPrimitive,
-  TooltipProviderProps as TooltipProviderPrimitiveProps
+  TooltipProviderProps as TooltipProviderPrimitiveProps,
+  Root as TooltipRootPrimitive,
+  TooltipProps as TooltipRootPrimitiveProps,
+  TooltipContentProps as TooltipContentPrimitiveProps,
+  TooltipContent as TooltipContentPrimitive,
+  TooltipTriggerProps as TooltipTriggerPrimitiveProps,
+  TooltipTrigger as TooltipTriggerPrimitive,
+  TooltipPortalProps as TooltipPortalPrimitiveProps,
+  TooltipPortal as TooltipPortalPrimitive,
+  TooltipArrowProps as TooltipArrowPrimitiveProps,
+  TooltipArrow as TooltipArrowPrimitive
 } from '@radix-ui/react-tooltip';
-import { FunctionComponent } from 'react';
+import React, { forwardRef, FunctionComponent } from 'react';
+
+import { useThemeContext } from '../../hooks';
+import { ThemedClassName } from '../../util';
 
 type TooltipProviderProps = TooltipProviderPrimitiveProps;
 
 const TooltipProvider: FunctionComponent<TooltipProviderProps> = TooltipProviderPrimitive;
 
-export { TooltipProvider };
+type TooltipRootProps = TooltipRootPrimitiveProps;
 
-export type { TooltipProviderProps };
+const TooltipRoot: FunctionComponent<TooltipRootProps> = TooltipRootPrimitive;
+
+type TooltipPortalProps = TooltipPortalPrimitiveProps;
+
+const TooltipPortal = TooltipPortalPrimitive;
+
+type TooltipTriggerProps = TooltipTriggerPrimitiveProps;
+
+const TooltipTrigger = TooltipTriggerPrimitive;
+
+type TooltipArrowProps = ThemedClassName<TooltipArrowPrimitiveProps>;
+
+const TooltipArrow = forwardRef<SVGSVGElement, TooltipArrowProps>(({ className, ...props }, forwardedRef) => {
+  const { tx } = useThemeContext();
+  return (
+    <TooltipArrowPrimitive
+      {...props}
+      className={tx('tooltip.arrow', 'tooltip__arrow', {}, className)}
+      ref={forwardedRef}
+    />
+  );
+});
+
+type TooltipContentProps = ThemedClassName<TooltipContentPrimitiveProps>;
+
+const TooltipContent = forwardRef<HTMLDivElement, TooltipContentProps>(({ className, ...props }, forwardedRef) => {
+  const { tx } = useThemeContext();
+  return (
+    <TooltipContentPrimitive
+      {...props}
+      className={tx('tooltip.content', 'tooltip', {}, className)}
+      ref={forwardedRef}
+    />
+  );
+});
+
+export { TooltipProvider, TooltipRoot, TooltipPortal, TooltipTrigger, TooltipArrow, TooltipContent };
+
+export type {
+  TooltipProviderProps,
+  TooltipRootProps,
+  TooltipPortalProps,
+  TooltipTriggerProps,
+  TooltipArrowProps,
+  TooltipContentProps
+};

--- a/packages/ui/aurora/src/components/Tooltip/index.ts
+++ b/packages/ui/aurora/src/components/Tooltip/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+export * from './Tooltip';

--- a/packages/ui/aurora/src/components/index.ts
+++ b/packages/ui/aurora/src/components/index.ts
@@ -8,6 +8,7 @@ export * from './Input';
 export * from './List';
 export * from './Main';
 export * from './Message';
+export * from './Tooltip';
 
 export * from './DensityProvider';
 export * from './ElevationProvider';

--- a/packages/ui/react-appkit/package.json
+++ b/packages/ui/react-appkit/package.json
@@ -62,7 +62,6 @@
     "@radix-ui/react-slot": "^1.0.1",
     "@radix-ui/react-toast": "^1.1.3",
     "@radix-ui/react-toolbar": "^1.0.3",
-    "@radix-ui/react-tooltip": "^1.0.5",
     "@radix-ui/react-use-controllable-state": "^1.0.0",
     "localforage": "^1.10.0",
     "lodash.merge": "^4.6.2",

--- a/packages/ui/react-appkit/src/components/NavMenu/NavMenu.tsx
+++ b/packages/ui/react-appkit/src/components/NavMenu/NavMenu.tsx
@@ -5,6 +5,7 @@
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu';
 import React, { ComponentProps, ForwardedRef, forwardRef, ReactNode } from 'react';
 
+import { TooltipRoot, TooltipContent, TooltipTrigger, TooltipContentProps } from '@dxos/aurora';
 import {
   defaultFocus,
   defaultHover,
@@ -14,8 +15,6 @@ import {
   primaryAppButtonColors,
   surfaceElevation
 } from '@dxos/aurora-theme';
-
-import { TooltipRoot, TooltipContent, TooltipTrigger, TooltipContentProps } from '../Tooltip';
 
 interface NavMenuItemSharedProps {
   children: ReactNode;

--- a/packages/ui/react-appkit/src/components/QrCode/QrCode.tsx
+++ b/packages/ui/react-appkit/src/components/QrCode/QrCode.tsx
@@ -3,7 +3,7 @@
 //
 
 import { QrCode as QrCodeIcon, CopySimple } from '@phosphor-icons/react';
-import * as PopoverPrimitive from '@radix-ui/react-popover';
+import type { PopoverContentProps } from '@radix-ui/react-popover';
 import { QRCodeSVG } from 'qrcode.react';
 import React, { useCallback, ReactHTMLElement, ComponentProps } from 'react';
 
@@ -32,9 +32,9 @@ export interface FullQrCodeProps extends SharedQrCodeProps {
 export type QrCodeProps = FullQrCodeProps;
 
 interface CompactQrCodeSlots {
-  qrTooltipContent?: Omit<ComponentProps<typeof PopoverPrimitive.Content>, 'children'>;
+  qrTooltipContent?: Omit<PopoverContentProps, 'children'>;
   qrButton?: Omit<ComponentProps<'button'>, 'ref' | 'children'>;
-  copyTooltipContent?: Omit<ComponentProps<typeof PopoverPrimitive.Content>, 'children'>;
+  copyTooltipContent?: Omit<PopoverContentProps, 'children'>;
   copyButton?: Omit<ComponentProps<'button'>, 'ref' | 'children'>;
   qrSvg?: ComponentProps<typeof QRCodeSVG>;
 }

--- a/packages/ui/react-appkit/src/components/QrCode/QrCode.tsx
+++ b/packages/ui/react-appkit/src/components/QrCode/QrCode.tsx
@@ -3,6 +3,7 @@
 //
 
 import { QrCode as QrCodeIcon, CopySimple } from '@phosphor-icons/react';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
 import { QRCodeSVG } from 'qrcode.react';
 import React, { useCallback, ReactHTMLElement, ComponentProps } from 'react';
 
@@ -10,7 +11,7 @@ import { Button, ButtonGroup, ButtonProps, Size, useId } from '@dxos/aurora';
 import { getSize, mx } from '@dxos/aurora-theme';
 
 import { Popover } from '../Popover';
-import { TooltipContent, TooltipContentProps, TooltipRoot, TooltipTrigger } from '../Tooltip';
+import { TooltipContent, TooltipRoot, TooltipTrigger, TooltipContentProps } from '../Tooltip';
 
 interface SharedQrCodeProps extends Pick<ButtonProps, 'density' | 'elevation'> {
   value: string;
@@ -31,9 +32,9 @@ export interface FullQrCodeProps extends SharedQrCodeProps {
 export type QrCodeProps = FullQrCodeProps;
 
 interface CompactQrCodeSlots {
-  qrTooltipContent?: Omit<TooltipContentProps, 'children'>;
+  qrTooltipContent?: Omit<ComponentProps<typeof PopoverPrimitive.Content>, 'children'>;
   qrButton?: Omit<ComponentProps<'button'>, 'ref' | 'children'>;
-  copyTooltipContent?: Omit<TooltipContentProps, 'children'>;
+  copyTooltipContent?: Omit<ComponentProps<typeof PopoverPrimitive.Content>, 'children'>;
   copyButton?: Omit<ComponentProps<'button'>, 'ref' | 'children'>;
   qrSvg?: ComponentProps<typeof QRCodeSVG>;
 }

--- a/packages/ui/react-appkit/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/ui/react-appkit/src/components/ThemeProvider/ThemeProvider.tsx
@@ -8,10 +8,14 @@ import {
   Viewport as ToastViewport,
   ToastViewportProps
 } from '@radix-ui/react-toast';
-import { Provider as TooltipProvider, TooltipProviderProps } from '@radix-ui/react-tooltip';
 import React, { PropsWithChildren } from 'react';
 
-import { ThemeProvider as AuroraThemeProvider, ThemeProviderProps as AuroraThemeProviderProps } from '@dxos/aurora';
+import {
+  ThemeProvider as AuroraThemeProvider,
+  ThemeProviderProps as AuroraThemeProviderProps,
+  TooltipProvider,
+  TooltipProviderProps
+} from '@dxos/aurora';
 import { mx, osTx, appTx } from '@dxos/aurora-theme';
 
 export type ThemeProviderProps = AuroraThemeProviderProps &

--- a/packages/ui/react-appkit/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/react-appkit/src/components/Tooltip/Tooltip.tsx
@@ -4,46 +4,33 @@
 
 import { Root as PortalRoot } from '@radix-ui/react-portal';
 import { Button as ToolbarButtonItem } from '@radix-ui/react-toolbar';
-import { Portal as TooltipPortal } from '@radix-ui/react-tooltip';
-import * as TooltipPrimitive from '@radix-ui/react-tooltip';
-import type {
+import React, { ComponentProps, ReactNode, useState, forwardRef, ForwardRefExoticComponent } from 'react';
+
+import {
+  useId,
+  TooltipRootProps,
+  TooltipRoot,
   TooltipContentProps,
+  TooltipPortal,
+  TooltipContent as AuroraTooltipContent,
+  TooltipArrow,
   TooltipTriggerProps,
-  TooltipProps as RadixTooltipProps
-} from '@radix-ui/react-tooltip';
-import React, { ComponentProps, ReactNode, useState, forwardRef } from 'react';
+  TooltipTrigger
+} from '@dxos/aurora';
 
-import { useId } from '@dxos/aurora';
-import { defaultTooltip, mx } from '@dxos/aurora-theme';
-
-type TooltipRootProps = RadixTooltipProps;
-
-export const TooltipRoot = TooltipPrimitive.Root;
-
-export const TooltipContent = forwardRef<HTMLDivElement, TooltipContentProps>(
-  ({ children, className, ...props }, forwardedRef) => {
-    return (
-      <TooltipPrimitive.Portal>
-        <TooltipPrimitive.Content
-          forceMount
-          {...props}
-          className={mx(
-            'inline-flex items-center rounded-md plb-2 pli-3',
-            'shadow-lg bg-white dark:bg-neutral-800',
-            defaultTooltip,
-            className
-          )}
-          ref={forwardedRef}
-        >
-          <TooltipPrimitive.Arrow className='fill-white dark:fill-neutral-800' />
-          {children}
-        </TooltipPrimitive.Content>
-      </TooltipPrimitive.Portal>
-    );
-  }
-);
-
-export const TooltipTrigger = TooltipPrimitive.Trigger;
+export const TooltipContent: ForwardRefExoticComponent<TooltipContentProps> = forwardRef<
+  HTMLDivElement,
+  TooltipContentProps
+>(({ children, ...props }, forwardedRef) => {
+  return (
+    <TooltipPortal>
+      <AuroraTooltipContent forceMount {...props} ref={forwardedRef}>
+        <TooltipArrow />
+        {children}
+      </AuroraTooltipContent>
+    </TooltipPortal>
+  );
+});
 
 export type { TooltipContentProps, TooltipTriggerProps, TooltipRootProps };
 
@@ -63,6 +50,9 @@ type TooltipProps = {
   slots?: TooltipSlots;
 };
 
+/**
+ * @deprecated please use Tooltip from @dxos/aurora directly.
+ */
 export const Tooltip = ({
   content,
   children,
@@ -82,7 +72,7 @@ export const Tooltip = ({
       forceMount
       {...slots.content}
       side={side ?? slots.content?.side ?? 'top'}
-      className={mx(zIndex, !compact && 'px-4 py-2.5', !isOpen && 'sr-only', defaultTooltip, slots.content?.className)}
+      className={[zIndex, !compact && 'px-4 py-2.5', !isOpen && 'sr-only', slots.content?.className]}
     >
       {content}
     </TooltipContent>
@@ -114,3 +104,5 @@ export const Tooltip = ({
     </TooltipRoot>
   );
 };
+
+export { TooltipRoot, TooltipTrigger };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4688,7 +4688,6 @@ importers:
       '@radix-ui/react-slot': ^1.0.1
       '@radix-ui/react-toast': ^1.1.3
       '@radix-ui/react-toolbar': ^1.0.3
-      '@radix-ui/react-tooltip': ^1.0.5
       '@radix-ui/react-use-controllable-state': ^1.0.0
       '@types/lodash.throttle': ^4.1.7
       '@types/react': ^18.0.21
@@ -4740,7 +4739,6 @@ importers:
       '@radix-ui/react-slot': 1.0.1_react@18.2.0
       '@radix-ui/react-toast': 1.1.3_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-toolbar': 1.0.3_biqbaboplfbrettd7655fr4n2y
-      '@radix-ui/react-tooltip': 1.0.5_rj7ozvcq3uehdlnj3cbwzbi5ce
       '@radix-ui/react-use-controllable-state': 1.0.0_react@18.2.0
       localforage: 1.10.0
       lodash.merge: 4.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4373,6 +4373,7 @@ importers:
       '@radix-ui/react-dialog': ^1.0.3
       '@radix-ui/react-primitive': ^1.0.2
       '@radix-ui/react-slot': ^1.0.1
+      '@radix-ui/react-tooltip': ^1.0.5
       '@radix-ui/react-use-controllable-state': ^1.0.0
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
@@ -4390,6 +4391,7 @@ importers:
       '@radix-ui/react-dialog': 1.0.3_rj7ozvcq3uehdlnj3cbwzbi5ce
       '@radix-ui/react-primitive': 1.0.2_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-slot': 1.0.1_react@18.2.0
+      '@radix-ui/react-tooltip': 1.0.5_rj7ozvcq3uehdlnj3cbwzbi5ce
       '@radix-ui/react-use-controllable-state': 1.0.0_react@18.2.0
       i18next: 21.10.0
       jdenticon: 3.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4385,6 +4385,9 @@ importers:
       react-i18next: ^11.18.6
       vite: ^4.3.0
     dependencies:
+      '@dxos/react-hooks': link:../primitives/react-hooks
+      '@dxos/react-input': link:../primitives/react-input
+      '@dxos/react-list': link:../primitives/react-list
       '@radix-ui/react-avatar': 1.0.2_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-checkbox': 1.0.3_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-context': 1.0.0_react@18.2.0
@@ -4399,9 +4402,6 @@ importers:
     devDependencies:
       '@dxos/aurora-theme': link:../aurora-theme
       '@dxos/aurora-types': link:../aurora-types
-      '@dxos/react-hooks': link:../primitives/react-hooks
-      '@dxos/react-input': link:../primitives/react-input
-      '@dxos/react-list': link:../primitives/react-list
       '@phosphor-icons/react': 2.0.5_biqbaboplfbrettd7655fr4n2y
       '@types/react': 18.0.21
       '@types/react-dom': 18.0.6


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 809fbae</samp>

### Summary
🔄🎨🛠️

<!--
1.  🔄 - This emoji represents the refactoring of the `getSpaceDisplayName` utility function and the `tooltip` component style to avoid duplication and simplify the import statements.
2.  🎨 - This emoji represents the creation of the `Tooltip` component and the `tooltipTheme` object in the `@dxos/aurora` package, which provide a consistent and customizable style for the tooltip components.
3.  🛠️ - This emoji represents the removal of the `@radix-ui/react-tooltip` dependency from the `@dxos/react-appkit` package, and the replacement of the local tooltip elements with the imported ones from the `@dxos/aurora` package in the `NavMenu` and `QrCode` components, which improve the functionality and reusability of the tooltip components.
-->
Added a `Tooltip` component to the `@dxos/aurora` package and updated the `@dxos/react-appkit` and `@dxos/composer-app` packages to use it. The `Tooltip` component uses the `@radix-ui/react-tooltip` primitives and the `aurora-theme` styles to provide consistent and customizable tooltips across the UI. The `@dxos/react-appkit` package also replaced the `Tooltip` component with the `Popover` component for displaying popovers on hover. The `@dxos/composer-app` package also fixed a minor import issue.

> _We wanted to make our UI slick_
> _So we changed how we handle `Tooltip`_
> _We used `aurora-theme` and `@radix-ui`_
> _And refactored some components too_
> _Now our tooltips are consistent and quick_

### Walkthrough
*  Simplify the import of `getSpaceDisplayName` in `FullSpaceTreeItem.tsx` ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-9381d8cc5a751972e73014363c87e8436f6d41ded419c8fdecb3b093103a2608L45-R45))
*  Define and export the `tooltip` component style in `./tooltip.ts` using the `@radix-ui/react-tooltip` primitives and the `aurora-theme` utilities ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-77502583beaf31f36d3e1392bbb7275c0d402e63e28cd5dbe60f77ae63469625R1-R26))
*  Export the `tooltip` component style from `./components/index.ts` ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-6717dc8c34c2b5550dda33499aa5cb6877d28d65cdfc39790eb914faeec857a8R12))
*  Import and add the `tooltip` component style to the `theme` object in `./theme.ts` ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-69241f25f1647f6105233f677788a042089cb28715f9649a78636af9e554b8f5L18-R19), [link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-69241f25f1647f6105233f677788a042089cb28715f9649a78636af9e554b8f5L29-R31))
*  Add the `@radix-ui/react-tooltip` package as a dependency of the `@dxos/aurora` package ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-a281489d84c41bfc075f623060a2d0a3177bead5686f51e924af6c324b0d82bcR30))
*  Define and export the `Tooltip` component in `./Tooltip/Tooltip.tsx` using the `@radix-ui/react-tooltip` primitives and the `aurora-theme` utilities ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-b07e83f3c331b8d30608d862c7510cdced98ba856f9577b653afaf6d2f920e5cR1-R75))
*  Export the `Tooltip` component from `./components/index.ts` and `./components/Tooltip/index.ts` ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-bc962d2b54c0c16ce92c0051b2e406d5746a3e9594d1f0bfe03f4fbd96a8b6ddR1-R5), [link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-02990b17e78f053383504a80f8a57533e77557d6203d20a3e26f5ebe2034b2ffR11))
*  Import and use the `Tooltip` component from the `@dxos/aurora` package in the `NavMenu` and `QrCode` components ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-8da8701448a3e863576fb923b243bf1af9e2e810fbf5242eb2ff38ee771f04f9R8), [link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-3669a0e421f62770a44869e97c45107759b832ceac3f56d78e35ba7be7314053L13-R14))
*  Import and use the `TooltipProvider` and `TooltipPortal` elements from the `@dxos/aurora` package in the `ThemeProvider` and `Tooltip` components ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-ed533ab05629c46751557f105f35b92564883cbddc26dc531e92b17ac89d0daaL11-R18), [link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-a1d97d6e6f81b88d341152eb338033ba809c507d94c2060e2b3d778c2be82bcdL7-R34))
*  Mark the `Tooltip` component in the `@dxos/react-appkit` package as deprecated and recommend using the `Tooltip` component from the `@dxos/aurora` package instead ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-a1d97d6e6f81b88d341152eb338033ba809c507d94c2060e2b3d778c2be82bcdR53-R55))
*  Export the `TooltipRoot` and `TooltipTrigger` elements from the `Tooltip` component in the `@dxos/react-appkit` package for backward compatibility ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-a1d97d6e6f81b88d341152eb338033ba809c507d94c2060e2b3d778c2be82bcdR107-R108))
*  Remove the `@radix-ui/react-tooltip` package as a dependency of the `@dxos/react-appkit` package ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-c0621cb4939fa7023b777e8876037584b53b27550fe898ce6648fc8020638df0L65))
*  Remove the unnecessary dependencies of the `@dxos/react-hooks`, `@dxos/react-input`, and `@dxos/react-list` packages from the `@dxos/aurora` package ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-a281489d84c41bfc075f623060a2d0a3177bead5686f51e924af6c324b0d82bcL35-L37))
*  Update the `qrTooltipContent` and `copyTooltipContent` slots in the `CompactQrCodeSlots` interface to use the `PopoverPrimitive.Content` element instead of the `TooltipContentProps` type ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-3669a0e421f62770a44869e97c45107759b832ceac3f56d78e35ba7be7314053L34-R37))
*  Import the `@radix-ui/react-popover` package in the `QrCode` component ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-3669a0e421f62770a44869e97c45107759b832ceac3f56d78e35ba7be7314053R6))
*  Adjust the `className` prop of the `TooltipContent` element in the `Tooltip` component to use an array instead of the `mx` utility function ([link](https://github.com/dxos/dxos/pull/3193/files?diff=unified&w=0#diff-a1d97d6e6f81b88d341152eb338033ba809c507d94c2060e2b3d778c2be82bcdL85-R75))


