### PR TITLE
feat(composer-extension): Space picker badging

### DIFF
--- a/packages/apps/composer-app/src/translations/en-US.ts
+++ b/packages/apps/composer-app/src/translations/en-US.ts
@@ -62,4 +62,6 @@ export const composer = {
   'comment stale body':
     'The document in Github was updated in another session. To re-sync, please save your changes, reload the page, and choose to edit from Github again.',
   'open in composer label': 'Open in Composer',
+  'bound members message_one': 'One member uses this space for this repository',
+  'bound members message_other': '{{count}} members use this space for this repository',
 };

--- a/packages/ui/aurora-theme/src/styles/components/tag.ts
+++ b/packages/ui/aurora-theme/src/styles/components/tag.ts
@@ -36,7 +36,7 @@ const paletteColorMap: Record<Exclude<TagStyleProps['palette'], undefined>, stri
 };
 
 export const tagRoot: ComponentFunction<TagStyleProps> = ({ palette = 'neutral' }, ...etc) =>
-  mx('text-xs font-semibold pli-2 plb-0.5 rounded', paletteColorMap[palette], ...etc);
+  mx('text-xs font-semibold pli-2 plb-0.5 rounded cursor-default', paletteColorMap[palette], ...etc);
 
 export const tagTheme: Theme<TagStyleProps> = {
   root: tagRoot,


### PR DESCRIPTION
<img width="452" alt="Screenshot 2023-05-17 at 14 25 30" src="https://github.com/dxos/dxos/assets/855039/ead668ab-3167-4150-bcc6-436a80235ff5">

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4773a8e</samp>

### Summary
🏷️🌐🖱️

<!--
1.  🏷️ - This emoji represents the addition of the tag element to the `SpacePickerTreeItem` component. It is a suitable emoji because it conveys the idea of labeling or categorizing something, which is what the tag does for the spaces.
2.  🌐 - This emoji represents the addition of the translation keys and messages for the tag tooltip. It is a suitable emoji because it conveys the idea of globalization or multilingualism, which is what the translation feature supports.
3.  🖱️ - This emoji represents the modification of the tag style to change the cursor behavior. It is a suitable emoji because it conveys the idea of mouse interaction or user interface, which is what the style change affects.
-->
This pull request adds a feature to the `composer-app` that shows the number of members bound to a space for a repository in the `ResolverDialog`. It also adds the necessary translations and styles for the feature. The feature aims to enhance the user experience and feedback when selecting a space.

> _`SpacePickerTreeItem`_
> _Shows members bound to spaces_
> _Tag with tooltip_

### Walkthrough
*  Display the number of space members for each repository in a tag with a tooltip ([link](https://github.com/dxos/dxos/pull/3198/files?diff=unified&w=0#diff-5160af812ac7ecca95074b5eccefe42cdfe3dc8b829fe7eb777810c35b4f1eceL6-R117), [link](https://github.com/dxos/dxos/pull/3198/files?diff=unified&w=0#diff-df4fb09070ae8aa16c554fe8dc845b2f339eb7e852b9b7934010cbcf2eee0721R65-R66), [link](https://github.com/dxos/dxos/pull/3198/files?diff=unified&w=0#diff-39b0a7708931dc73c081ffb38ab2ede7c44293164f9dd994197bdc60eddf5db6L39-R39))


