### PR TITLE
fix(aurora): Use `classNames`

### DIFF
--- a/packages/apps/composer-app/src/components/ResolverDialog/DocumentTreeItem.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/DocumentTreeItem.tsx
@@ -16,8 +16,8 @@ export const DocumentTreeItem = observer(({ document }: { document: Document }) 
   const { t } = useTranslation('composer');
   const Icon = document.content.kind === TextKind.PLAIN ? ArticleMedium : Article;
   return (
-    <TreeItem className='flex gap-2'>
-      <TreeItemHeading className='contents'>
+    <TreeItem classNames='flex gap-2'>
+      <TreeItemHeading classNames='contents'>
         <Icon weight='regular' className={mx(getSize(4), 'shrink-0 mbs-2')} />
         <span className='grow mbs-2 text-sm no-leading'>{document.title || t('untitled document title')}</span>
       </TreeItemHeading>

--- a/packages/apps/composer-app/src/components/ResolverDialog/ResolverDialog.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/ResolverDialog.tsx
@@ -30,7 +30,7 @@ export const ResolverDialog = () => {
             ) : (
               <h1 className='text-lg font-system-normal'>{t('resolver init document message')}</h1>
             )}
-            <Button className='is-full' onClick={handleJoinSpace}>
+            <Button classNames='is-full' onClick={handleJoinSpace}>
               {t('join space label', { ns: 'appkit' })}
             </Button>
           </div>

--- a/packages/apps/composer-app/src/components/ResolverDialog/ResolverTree.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/ResolverTree.tsx
@@ -25,7 +25,7 @@ export const ResolverTree = observer(() => {
         {t('resolver tree label')}
       </h1>
       <div role='separator' className='bs-px bg-neutral-500/20 mlb-2' />
-      <TreeRoot aria-labelledby={treeLabel} data-testid='composer.sidebarTree' className='shrink-0'>
+      <TreeRoot aria-labelledby={treeLabel} data-testid='composer.sidebarTree' classNames='shrink-0'>
         {spaces.map((space) => {
           return (
             <SpacePickerTreeItem
@@ -43,7 +43,7 @@ export const ResolverTree = observer(() => {
       </h1>
       <div role='separator' className='bs-px bg-neutral-500/20 mlb-2' />
       <Button
-        className='block is-full'
+        classNames='block is-full'
         onClick={async () => {
           const space = await client.createSpace();
           bindSpace(space, identityHex!, source!, id!);

--- a/packages/apps/composer-app/src/components/ResolverDialog/SpacePickerTreeItem.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/SpacePickerTreeItem.tsx
@@ -57,7 +57,7 @@ export const SpacePickerTreeItem = observer(
         collapsible
         open={open}
         onOpenChange={setOpen}
-        className={['mbe-2 block', disabled && defaultDisabled]}
+        classNames={['mbe-2 block', disabled && defaultDisabled]}
         {...(disabled && { 'aria-disabled': true })}
       >
         <div role='none' className='flex items-center gap-2'>
@@ -69,7 +69,7 @@ export const SpacePickerTreeItem = observer(
             <MockListItemOpenTrigger />
           )}
           <TreeItemHeading
-            className='grow break-words pbs-1 text-base font-medium'
+            classNames='grow break-words pbs-1 text-base font-medium'
             data-testid='composer.spaceTreeItemHeading'
           >
             {spaceDisplayName}
@@ -91,7 +91,7 @@ export const SpacePickerTreeItem = observer(
           )}
           <Button
             density='fine'
-            className='shrink-0'
+            classNames='shrink-0'
             onClick={() => {
               if (identityHex) {
                 bindSpace(space, identityHex, source, id);

--- a/packages/apps/composer-app/src/components/Sidebar/DocumentLinkTreeItem.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/DocumentLinkTreeItem.tsx
@@ -19,7 +19,7 @@ export const DocumentLinkTreeItem = observer(({ document, linkTo }: { document: 
   const active = docKey === document.id;
   const Icon = document.content.kind === TextKind.PLAIN ? ArticleMedium : Article;
   return (
-    <TreeItem className='pis-4'>
+    <TreeItem classNames='pis-4'>
       <TreeItemHeading asChild>
         <Link
           to={linkTo}
@@ -27,13 +27,13 @@ export const DocumentLinkTreeItem = observer(({ document, linkTo }: { document: 
             'button.root',
             'tree-item__heading--link',
             { variant: 'ghost' },
-            'is-full text-base p-0 font-normal items-start gap-1'
+            'is-full text-base p-0 font-normal items-start gap-1',
           )}
           data-testid='composer.documentTreeItemHeading'
         >
           <Icon weight='regular' className={mx(getSize(4), 'shrink-0 mbs-2')} />
           <p className='grow mbs-1'>{document.title || t('untitled document title')}</p>
-          <ListItemEndcap className='is-6 flex items-center'>
+          <ListItemEndcap classNames='is-6 flex items-center'>
             <Circle
               weight='fill'
               className={mx(getSize(3), 'text-primary-500 dark:text-primary-300', !active && 'invisible')}

--- a/packages/apps/composer-app/src/components/Sidebar/FullSpaceTreeItem.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/FullSpaceTreeItem.tsx
@@ -11,7 +11,7 @@ import {
   FilePlus,
   PaperPlaneTilt,
   Plus,
-  Upload
+  Upload,
 } from '@phosphor-icons/react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { FileUploader } from 'react-drag-drop-files';
@@ -35,7 +35,7 @@ import {
   TreeItem,
   TreeItemBody,
   TreeItemHeading,
-  TreeItemOpenTrigger
+  TreeItemOpenTrigger,
 } from '@dxos/react-appkit';
 import { useMulticastObservable } from '@dxos/react-async';
 import { observer, ShellLayout, Space, useIdentity, useQuery } from '@dxos/react-client';
@@ -73,8 +73,8 @@ export const FullSpaceTreeItem = observer(({ space }: { space: Space }) => {
         ...space.properties.members,
         [identityHex]: {
           ...space.properties.members?.[identityHex],
-          hidden: true
-        }
+          hidden: true,
+        },
       };
       if (spaceKey === abbreviateKey(space.key)) {
         navigate('/');
@@ -101,7 +101,7 @@ export const FullSpaceTreeItem = observer(({ space }: { space: Space }) => {
       collapsible
       open={open}
       onOpenChange={setOpen}
-      className={['mbe-2 block', disabled && defaultDisabled]}
+      classNames={['mbe-2 block', disabled && defaultDisabled]}
       {...(disabled && { 'aria-disabled': true })}
     >
       <div role='none' className='flex mis-1 items-start'>
@@ -111,7 +111,7 @@ export const FullSpaceTreeItem = observer(({ space }: { space: Space }) => {
           />
         </TreeItemOpenTrigger>
         <TreeItemHeading
-          className='grow break-words pbs-1.5 text-sm font-medium'
+          classNames='grow break-words pbs-1.5 text-sm font-medium'
           data-testid='composer.spaceTreeItemHeading'
         >
           {spaceDisplayName}
@@ -127,13 +127,13 @@ export const FullSpaceTreeItem = observer(({ space }: { space: Space }) => {
             }
           }}
         >
-          <TooltipContent className='z-[31]' side='bottom'>
+          <TooltipContent classNames='z-[31]' side='bottom'>
             {t('space options label')}
           </TooltipContent>
           <DropdownMenu
             trigger={
               <TooltipTrigger asChild>
-                <Button variant='ghost' data-testid='composer.openSpaceMenu' className='shrink-0 pli-1'>
+                <Button variant='ghost' data-testid='composer.openSpaceMenu' classNames='shrink-0 pli-1'>
                   <DotsThreeVertical className={getSize(4)} />
                 </Button>
               </TooltipTrigger>
@@ -146,9 +146,9 @@ export const FullSpaceTreeItem = observer(({ space }: { space: Space }) => {
                     suppressNextTooltip.current = true;
                   }
                   return setOpetionsMenuOpen(nextOpen);
-                }
+                },
               },
-              content: { className: 'z-[31]' }
+              content: { className: 'z-[31]' },
             }}
           >
             <DropdownMenuItem asChild>
@@ -189,7 +189,7 @@ export const FullSpaceTreeItem = observer(({ space }: { space: Space }) => {
           <Button
             variant='ghost'
             data-testid='composer.createDocument'
-            className='shrink-0 pli-1'
+            classNames='shrink-0 pli-1'
             onClick={handleCreate}
           >
             <span className='sr-only'>{t('create document label')}</span>
@@ -209,7 +209,7 @@ export const FullSpaceTreeItem = observer(({ space }: { space: Space }) => {
             role='none'
             className={mx(
               'p-2 mli-2 mbe-2 text-center border border-dashed border-neutral-400/50 rounded-xl',
-              defaultDescription
+              defaultDescription,
             )}
           >
             {t('empty space message')}
@@ -234,7 +234,7 @@ export const FullSpaceTreeItem = observer(({ space }: { space: Space }) => {
           <FilePlus weight='duotone' className={getSize(8)} />
           <span>{t('upload file message')}</span>
         </FileUploader>
-        <Button className='block is-full' onClick={() => setRestoreDialogOpen?.(false)}>
+        <Button classNames='block is-full' onClick={() => setRestoreDialogOpen?.(false)}>
           {t('cancel label', { ns: 'appkit' })}
         </Button>
       </Dialog>

--- a/packages/apps/composer-app/src/components/Sidebar/HiddenSpacesTree.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/HiddenSpacesTree.tsx
@@ -15,7 +15,7 @@ import {
   TreeItemBody,
   TreeItemHeading,
   TreeItemOpenTrigger,
-  TreeRoot
+  TreeRoot,
 } from '@dxos/react-appkit';
 import { useMulticastObservable } from '@dxos/react-async';
 import { useIdentity } from '@dxos/react-client';
@@ -32,13 +32,13 @@ const HiddenSpaceItem = ({ space, handleUnhideSpace }: { space: Space; handleUnh
   const disabled = spaceSate !== SpaceState.READY;
   const spaceDisplayName = getSpaceDisplayName(t, space, disabled);
   return (
-    <TreeItem className='flex mis-1 mie-1.5'>
-      <TreeItemHeading className='grow'>{spaceDisplayName}</TreeItemHeading>
+    <TreeItem classNames='flex mis-1 mie-1.5'>
+      <TreeItemHeading classNames='grow'>{spaceDisplayName}</TreeItemHeading>
       <Tooltip content={t('unhide space label')} tooltipLabelsTrigger side='top' zIndex='z-[31]'>
         <Button
           variant='ghost'
           data-testid='composer.unhideSpace'
-          className='shrink-0 pli-1'
+          classNames='shrink-0 pli-1'
           onClick={() => handleUnhideSpace(space)}
         >
           <Eye className={getSize(4)} />
@@ -63,12 +63,12 @@ const HiddenSpacesBranch = ({ __listItemScope, hiddenSpaces }: ListItemScopedPro
           ...space.properties.members,
           [identityHex]: {
             ...space.properties.members?.[identityHex],
-            hidden: false
-          }
+            hidden: false,
+          },
         };
       }
     },
-    [identity]
+    [identity],
   );
 
   return (
@@ -77,7 +77,7 @@ const HiddenSpacesBranch = ({ __listItemScope, hiddenSpaces }: ListItemScopedPro
         <TreeItemOpenTrigger>
           <OpenTriggerIcon />
         </TreeItemOpenTrigger>
-        <TreeItemHeading className='grow break-words pbs-1.5 text-sm font-system-medium'>
+        <TreeItemHeading classNames='grow break-words pbs-1.5 text-sm font-system-medium'>
           {t('hidden spaces tree label')}
         </TreeItemHeading>
       </div>
@@ -100,8 +100,8 @@ export const HiddenSpacesTree = (props: HiddenSpacesTreeProps) => {
       <span className='sr-only' id={treeLabel}>
         {t('hidden spaces tree label')}
       </span>
-      <TreeRoot aria-labelledby={treeLabel} data-testid='composer.hiddenSpaces' className='shrink-0'>
-        <TreeItem collapsible className='mis-1 block'>
+      <TreeRoot aria-labelledby={treeLabel} data-testid='composer.hiddenSpaces' classNames='shrink-0'>
+        <TreeItem collapsible classNames='mis-1 block'>
           <HiddenSpacesBranch {...props} />
         </TreeItem>
       </TreeRoot>

--- a/packages/apps/composer-app/src/components/Sidebar/Sidebar.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/Sidebar.tsx
@@ -14,7 +14,7 @@ import {
   ThemeContext,
   useThemeContext,
   useTranslation,
-  useSidebar
+  useSidebar,
 } from '@dxos/aurora';
 import { getSize, mx, osTx } from '@dxos/aurora-theme';
 import { Tooltip, Avatar, Dialog, Input } from '@dxos/react-appkit';
@@ -71,7 +71,7 @@ const SidebarContent = () => {
             closeTriggers={[
               <Button key='a1' variant='primary' data-testid='composer.closeUserSettingsDialog'>
                 {t('done label', { ns: 'os' })}
-              </Button>
+              </Button>,
             ]}
           >
             <Input
@@ -81,7 +81,7 @@ const SidebarContent = () => {
               onChange={({ target: { value } }) => setPatValue(value)}
               slots={{
                 root: { className: 'mlb-2' },
-                input: { autoFocus: true, spellCheck: false, className: 'font-mono' }
+                input: { autoFocus: true, spellCheck: false, className: 'font-mono' },
               }}
             />
           </Dialog>
@@ -98,7 +98,7 @@ const SidebarContent = () => {
                   variant='ghost'
                   data-testid='composer.createSpace'
                   onClick={handleCreateSpace}
-                  className='pli-1'
+                  classNames='pli-1'
                 >
                   <Planet className={getSize(4)} />
                 </Button>
@@ -109,7 +109,7 @@ const SidebarContent = () => {
                 side='bottom'
                 tooltipLabelsTrigger
               >
-                <Button variant='ghost' data-testid='composer.joinSpace' onClick={handleJoinSpace} className='pli-1'>
+                <Button variant='ghost' data-testid='composer.joinSpace' onClick={handleJoinSpace} classNames='pli-1'>
                   <Intersect className={getSize(4)} />
                 </Button>
               </Tooltip>
@@ -123,7 +123,7 @@ const SidebarContent = () => {
                   variant='ghost'
                   data-testid='composer.toggleSidebarWithinSidebar'
                   onClick={closeSidebar}
-                  className='pli-1'
+                  classNames='pli-1'
                 >
                   <ArrowLineLeft className={getSize(4)} />
                 </Button>
@@ -148,7 +148,7 @@ const SidebarContent = () => {
                     variant='ghost'
                     data-testid='composer.openUserSettingsDialog'
                     onClick={() => setSettingsDialogOpen(true)}
-                    className='pli-1'
+                    classNames='pli-1'
                   >
                     <GearSix className={mx(getSize(4), 'rotate-90')} />
                   </Button>
@@ -171,7 +171,7 @@ const SidebarToggle = () => {
   const { t } = useTranslation('os');
   const themeContext = useThemeContext();
   const button = (
-    <Button data-testid='composer.toggleSidebar' onClick={openSidebar} className='p-0 is-[40px]'>
+    <Button data-testid='composer.toggleSidebar' onClick={openSidebar} classNames='p-0 is-[40px]'>
       <Sidebar weight='light' className={getSize(6)} />
     </Button>
   );
@@ -181,7 +181,7 @@ const SidebarToggle = () => {
         role='none'
         className={mx(
           'fixed block-start-0 pointer-coarse:block-end-0 pointer-coarse:block-start-auto p-2 transition-[inset-inline-start,opacity] ease-in-out duration-200 inline-start-0',
-          sidebarOpen && 'opacity-0 pointer-events-none'
+          sidebarOpen && 'opacity-0 pointer-events-none',
         )}
       >
         {sidebarOpen ? (

--- a/packages/apps/composer-app/src/components/Sidebar/SidebarTree.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/SidebarTree.tsx
@@ -21,7 +21,7 @@ export const SidebarTree = observer(() => {
       <span className='sr-only' id={treeLabel}>
         {t('sidebar tree label')}
       </span>
-      <TreeRoot aria-labelledby={treeLabel} data-testid='composer.sidebarTree' className='shrink-0'>
+      <TreeRoot aria-labelledby={treeLabel} data-testid='composer.sidebarTree' classNames='shrink-0'>
         {spaces
           .filter((space) => !identity || space.properties.members?.[identity.identityKey.toHex()]?.hidden !== true)
           .map((space) => {
@@ -31,7 +31,7 @@ export const SidebarTree = observer(() => {
       <div role='none' className='grow' />
       <HiddenSpacesTree
         hiddenSpaces={spaces.filter(
-          (space) => !identity || space.properties.members?.[identity.identityKey.toHex()]?.hidden === true
+          (space) => !identity || space.properties.members?.[identity.identityKey.toHex()]?.hidden === true,
         )}
       />
     </div>

--- a/packages/apps/composer-app/src/layouts/StandaloneLayout.tsx
+++ b/packages/apps/composer-app/src/layouts/StandaloneLayout.tsx
@@ -19,7 +19,7 @@ import type { OutletContext } from './OutletContext';
 
 const InvitationToast = ({
   invitation,
-  spaceKey
+  spaceKey,
 }: {
   invitation: CancellableInvitationObservable;
   spaceKey: PublicKey;
@@ -35,8 +35,8 @@ const InvitationToast = ({
       actionTriggers={[
         {
           altText: 'View',
-          trigger: <Button onClick={handleViewInvitations}>{t('view invitations label')}</Button>
-        }
+          trigger: <Button onClick={handleViewInvitations}>{t('view invitations label')}</Button>,
+        },
       ]}
     />
   ) : null;
@@ -50,7 +50,7 @@ export const StandaloneLayout = () => {
   const { spaceKey, docKey } = useParams();
   const allSpaces = useSpaces({ all: true });
   const space = allSpaces.find(
-    (space) => abbreviateKey(space.key) === spaceKey && space.state.get() === SpaceState.READY
+    (space) => abbreviateKey(space.key) === spaceKey && space.state.get() === SpaceState.READY,
   );
   const document = space && docKey ? (space.db.getObjectById(docKey) as Document) : undefined;
   const invitations = useSpaceInvitations(space?.key);
@@ -77,12 +77,12 @@ export const StandaloneLayout = () => {
             {...{
               className: [defaultOsButtonColors, 'backdrop-blur overflow-visible'],
               onOpenAutoFocus: (event) => event.preventDefault(),
-              onCloseAutoFocus: (event) => event.preventDefault()
+              onCloseAutoFocus: (event) => event.preventDefault(),
             }}
           >
             <SidebarContent />
           </Sidebar>
-          <Main className='min-bs-full'>
+          <Main classNames='min-bs-full'>
             <Outlet context={{ space, document, layout: 'standalone' } as OutletContext} />
             <SidebarToggle />
           </Main>

--- a/packages/apps/composer-app/src/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/apps/composer-app/src/pages/DocumentPage/DocumentPage.tsx
@@ -57,7 +57,7 @@ const RichTextDocumentPage = observer(({ document, space }: DocumentPageProps) =
     <Root
       {...{
         document,
-        ...fileProps
+        ...fileProps,
       }}
     >
       <Composer
@@ -68,9 +68,9 @@ const RichTextDocumentPage = observer(({ document, space }: DocumentPageProps) =
         slots={{
           root: {
             role: 'none',
-            className: 'pli-6 mbs-4'
+            className: 'pli-6 mbs-4',
           },
-          editor: { className: 'pbe-20' }
+          editor: { className: 'pbe-20' },
         }}
       />
     </Root>
@@ -98,7 +98,7 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
 
   const fileProps = useTextFile({
     editorRef,
-    content
+    content,
   });
 
   const docGhId = useMemo<GhIdentifier | null>(() => {
@@ -109,7 +109,7 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
         return {
           owner,
           repo,
-          issueNumber: parseInt(rest[0], 10)
+          issueNumber: parseInt(rest[0], 10),
         };
       } else if (type === 'blob') {
         const [ref, ...pathParts] = rest;
@@ -117,7 +117,7 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
           owner,
           repo,
           ref,
-          path: pathParts.join('/')
+          path: pathParts.join('/'),
         };
       } else {
         return null;
@@ -162,7 +162,7 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
         const { data } = await octokit.rest.repos.getContent({ owner, repo, path });
         if (!Array.isArray(data) && data.type === 'file') {
           editorRef.current.view.dispatch({
-            changes: { from: 0, to: editorRef.current.view.state.doc.length, insert: atob(data.content) }
+            changes: { from: 0, to: editorRef.current.view.state.doc.length, insert: atob(data.content) },
           });
         } else {
           log.error('Did not receive file with content from Github.');
@@ -188,7 +188,7 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
         const { owner, repo, issueNumber } = docGhId as GhIssueIdentifier;
         const { data } = await octokit.rest.issues.get({ owner, repo, issue_number: issueNumber });
         editorRef.current.view.dispatch({
-          changes: { from: 0, to: editorRef.current.view.state.doc.length, insert: data.body ?? '' }
+          changes: { from: 0, to: editorRef.current.view.state.doc.length, insert: data.body ?? '' },
         });
       } catch (err) {
         log.error('Failed to import from Github issue', err);
@@ -213,14 +213,14 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
         const { sha: fileSha } = fileData;
         const {
           data: {
-            object: { sha: baseSha }
-          }
+            object: { sha: baseSha },
+          },
         } = await octokit.rest.git.getRef({ owner, repo, ref: `heads/${ref}` });
         await octokit.rest.git.createRef({
           owner,
           repo,
           ref: `refs/heads/${branchName}`,
-          sha: baseSha
+          sha: baseSha,
         });
         await octokit.rest.repos.createOrUpdateFileContents({
           owner,
@@ -229,16 +229,16 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
           message: commitMessage,
           branch: branchName,
           sha: fileSha,
-          content: btoa(content.toString())
+          content: btoa(content.toString()),
         });
         const {
-          data: { html_url: prUrl }
+          data: { html_url: prUrl },
         } = await octokit.rest.pulls.create({
           owner,
           repo,
           head: branchName,
           base: ref,
-          title: commitMessage
+          title: commitMessage,
         });
         setGhResponseUrl(prUrl);
         setExportViewState('response');
@@ -259,12 +259,12 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
       try {
         const { owner, repo, issueNumber } = docGhId as GhIssueIdentifier;
         const {
-          data: { html_url: issueUrl }
+          data: { html_url: issueUrl },
         } = await octokit.rest.issues.update({
           owner,
           repo,
           issue_number: issueNumber,
-          body: content.toString()
+          body: content.toString(),
         });
         setGhResponseUrl(issueUrl);
         setExportViewState('response');
@@ -346,7 +346,7 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
         {...{
           document,
           ...fileProps,
-          dropdownMenuContent
+          dropdownMenuContent,
         }}
       >
         <Composer
@@ -358,15 +358,15 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
             root: {
               role: 'none',
               className: 'shrink-0 grow flex flex-col',
-              'data-testid': 'composer.markdownRoot'
+              'data-testid': 'composer.markdownRoot',
             } as HTMLAttributes<HTMLDivElement>,
             editor: {
               markdownTheme: {
                 '&, & .cm-scroller': { display: 'flex', flexDirection: 'column', flex: '1 0 auto', inlineSize: '100%' },
                 '& .cm-content': { flex: '1 0 auto', inlineSize: '100%', paddingBlock: '1rem' },
-                '& .cm-line': { paddingInline: '1.5rem' }
-              }
-            }
+                '& .cm-line': { paddingInline: '1.5rem' },
+              },
+            },
           }}
         />
       </Root>
@@ -384,7 +384,7 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
         closeTriggers={[
           <Button key='done' variant='primary'>
             {t('done label', { ns: 'os' })}
-          </Button>
+          </Button>,
         ]}
       >
         <Input
@@ -396,7 +396,7 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
           {...(ghUrlValue.length > 0 &&
             !ghId && {
               validationValence: 'error',
-              validationMessage: t('error github markdown path message')
+              validationMessage: t('error github markdown path message'),
             })}
         />
       </Dialog>
@@ -409,11 +409,11 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
           <Button
             key='done'
             variant='primary'
-            className='bg-warning-600 dark:bg-warning-600 hover:bg-warning-700 dark:hover:bg-warning-700'
+            classNames='bg-warning-600 dark:bg-warning-600 hover:bg-warning-700 dark:hover:bg-warning-700'
             onClick={handleGhImport}
           >
             {t('import from github label')}
-          </Button>
+          </Button>,
         ]}
       >
         <p className='plb-2'>{t('confirm import body')}</p>
@@ -444,8 +444,8 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
                       >
                         _
                       </a>
-                    )
-                  }
+                    ),
+                  },
                 }}
               />
             </p>
@@ -518,7 +518,7 @@ export const DocumentPage = observer(() => {
         closeTriggers={[
           <Button key='c1' variant='primary'>
             {t('confirm label', { ns: 'appkit' })}
-          </Button>
+          </Button>,
         ]}
       >
         <p className='plb-2'>{t('comment stale body')}</p>

--- a/packages/apps/composer-app/src/pages/DocumentPage/StandaloneDocumentPage.tsx
+++ b/packages/apps/composer-app/src/pages/DocumentPage/StandaloneDocumentPage.tsx
@@ -19,7 +19,7 @@ export const StandaloneDocumentPage = observer(
     dropdownMenuContent,
     handleFileImport,
     fileImportDialogOpen,
-    setFileImportDialogOpen
+    setFileImportDialogOpen,
   }: PropsWithChildren<{
     document: Document;
     dropdownMenuContent?: ReactNode;
@@ -48,14 +48,14 @@ export const StandaloneDocumentPage = observer(
                 root: { className: 'shrink-0 grow pis-6 plb-2' },
                 input: {
                   'data-testid': 'composer.documentTitle',
-                  className: 'text-center'
-                } as HTMLAttributes<HTMLInputElement>
+                  className: 'text-center',
+                } as HTMLAttributes<HTMLInputElement>,
               }}
             />
             <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}>
               <DropdownMenu
                 trigger={
-                  <Button className='p-0 is-10 shrink-0' variant='ghost' density='coarse'>
+                  <Button classNames='p-0 is-10 shrink-0' variant='ghost' density='coarse'>
                     <DotsThreeVertical className={getSize(6)} />
                   </Button>
                 }
@@ -84,7 +84,7 @@ export const StandaloneDocumentPage = observer(
                 <FilePlus weight='duotone' className={getSize(8)} />
                 <span>{t('upload file message')}</span>
               </FileUploader>
-              <Button className='block is-full' onClick={() => setFileImportDialogOpen?.(false)}>
+              <Button classNames='block is-full' onClick={() => setFileImportDialogOpen?.(false)}>
                 {t('cancel label', { ns: 'appkit' })}
               </Button>
             </Dialog>
@@ -92,5 +92,5 @@ export const StandaloneDocumentPage = observer(
         </ThemeContext.Provider>
       </>
     );
-  }
+  },
 );

--- a/packages/apps/composer-app/src/translations/en-US.ts
+++ b/packages/apps/composer-app/src/translations/en-US.ts
@@ -62,4 +62,6 @@ export const composer = {
   'comment stale body':
     'The document in Github was updated in another session. To re-sync, please save your changes, reload the page, and choose to edit from Github again.',
   'open in composer label': 'Open in Composer',
+  'bound members message_one': 'One member uses this space for this repository',
+  'bound members message_other': '{{count}} members use this space for this repository',
 };

--- a/packages/apps/halo-app/src/pages/ContactsPage.tsx
+++ b/packages/apps/halo-app/src/pages/ContactsPage.tsx
@@ -17,7 +17,7 @@ const ContactsPage = () => {
         className='mlb-4'
         heading={{ children: t('contacts label') }}
         actions={
-          <Button variant='primary' className='grow flex gap-1'>
+          <Button variant='primary' classNames='grow flex gap-1'>
             <Plus className={getSize(5)} />
             {t('add contact label', { ns: 'appkit' })}
           </Button>
@@ -28,7 +28,7 @@ const ContactsPage = () => {
         label={{
           level: 2,
           children: t('empty contacts message'),
-          className: mx('text-xl', defaultDisabled)
+          className: mx('text-xl', defaultDisabled),
         }}
         elevation='base'
       />

--- a/packages/apps/halo-app/src/pages/DevicesPage.tsx
+++ b/packages/apps/halo-app/src/pages/DevicesPage.tsx
@@ -29,7 +29,7 @@ const DevicesPage = () => {
         className='mlb-4'
         heading={{ children: t('devices label') }}
         actions={
-          <Button variant='primary' className='grow flex gap-1' onClick={handleCreateInvitation}>
+          <Button variant='primary' classNames='grow flex gap-1' onClick={handleCreateInvitation}>
             <Plus className={getSize(5)} />
             {t('add device label')}
           </Button>

--- a/packages/apps/halo-app/src/pages/IdentityPage.tsx
+++ b/packages/apps/halo-app/src/pages/IdentityPage.tsx
@@ -12,7 +12,7 @@ import {
   BASE_TELEMETRY_PROPERTIES,
   getTelemetryIdentifier,
   isTelemetryDisabled,
-  storeTelemetryDisabled
+  storeTelemetryDisabled,
 } from '@dxos/react-appkit/telemetry';
 import { useClient, useIdentity } from '@dxos/react-client';
 import * as Telemetry from '@dxos/telemetry';
@@ -46,7 +46,7 @@ const IdentityPage = () => {
         identity.profile.displayName = value;
       }
     },
-    [identity]
+    [identity],
   );
 
   return (
@@ -78,7 +78,7 @@ const IdentityPage = () => {
         title={telemetryDisabled ? t('enable telemetry label') : t('disable telemetry label')}
         description={telemetryDisabled ? t('enable telemetry description') : t('disable telemetry description')}
         openTrigger={
-          <Button variant='outline' className='flex gap-1 w-full'>
+          <Button variant='outline' classNames='flex gap-1 w-full'>
             <Activity className={getSize(5)} />
             {telemetryDisabled ? t('enable telemetry label') : t('disable telemetry label')}
           </Button>
@@ -92,13 +92,13 @@ const IdentityPage = () => {
                 name: 'halo-app:telemetry:toggle',
                 properties: {
                   ...BASE_TELEMETRY_PROPERTIES,
-                  value: !telemetryDisabled
-                }
+                  value: !telemetryDisabled,
+                },
               });
-              storeTelemetryDisabled(namespace, String(!telemetryDisabled));
+              void storeTelemetryDisabled(namespace, String(!telemetryDisabled));
               window.location.reload();
             }}
-            className='text-error-700 dark:text-error-400'
+            classNames='text-error-700 dark:text-error-400'
           >
             {telemetryDisabled ? t('enable telemetry label') : t('disable telemetry label')}
           </Button>
@@ -107,14 +107,14 @@ const IdentityPage = () => {
       <AlertDialog
         title={t('reset device label')}
         openTrigger={
-          <Button variant='outline' className='flex gap-1 w-full'>
+          <Button variant='outline' classNames='flex gap-1 w-full'>
             <Eraser className={getSize(5)} />
             {t('reset device label')}
           </Button>
         }
         destructiveConfirmString={confirmString}
         destructiveConfirmInputProps={{
-          label: t('confirm reset device label', { confirmString })
+          label: t('confirm reset device label', { confirmString }),
         }}
         cancelTrigger={<Button>{t('cancel label', { ns: 'appkit' })}</Button>}
         confirmTrigger={
@@ -123,7 +123,7 @@ const IdentityPage = () => {
               await client.reset();
               window.location.reload();
             }}
-            className='text-error-700 dark:text-error-400'
+            classNames='text-error-700 dark:text-error-400'
           >
             {t('reset device label')}
           </Button>

--- a/packages/apps/halo-app/src/pages/LockPage.tsx
+++ b/packages/apps/halo-app/src/pages/LockPage.tsx
@@ -52,8 +52,8 @@ const LockPage = () => {
                   if (event.detail === 3) {
                     throw new Error('test error');
                   }
-                }
-              }
+                },
+              },
             }}
           />
           <Heading>{t('current app name')}</Heading>
@@ -63,7 +63,7 @@ const LockPage = () => {
                 t,
                 i18nKey: 'using halo as message',
                 values: { displayName: identity.profile?.displayName ?? humanize(identity.identityKey.toHex()) },
-                components: { nameStyle: <span className='text-success-600 dark:text-success-300'>_</span> }
+                components: { nameStyle: <span className='text-success-600 dark:text-success-300'>_</span> },
               }}
             />
           </p>
@@ -82,7 +82,7 @@ const LockPage = () => {
             {...{
               onJoin: () => navigate(`/identity/join?redirect=${redirect}`),
               onCreate: () => navigate(`/identity/create?redirect=${redirect}`),
-              onRecover: () => navigate(`/identity/recover?redirect=${redirect}`)
+              onRecover: () => navigate(`/identity/recover?redirect=${redirect}`),
             }}
           />
         </div>
@@ -90,13 +90,13 @@ const LockPage = () => {
 
       <div role='none' className='text-center px-2 space-b-2'>
         {identity && (
-          <Button className='w-full' variant='primary' onClick={handleUnlock}>
+          <Button classNames='w-full' variant='primary' onClick={handleUnlock}>
             {t('unlock label')}
           </Button>
         )}
         <Button
           variant='outline'
-          className='w-full'
+          classNames='w-full'
           onClick={() => window.open('https://github.com/dxos/dxos', '_blank')}
         >
           {t('generic help label', { ns: 'appkit' })}

--- a/packages/apps/tasks-app-2/src/components/CheckboxItem.tsx
+++ b/packages/apps/tasks-app-2/src/components/CheckboxItem.tsx
@@ -65,7 +65,7 @@ export const CheckboxItem = forwardRef<Ref, CheckBoxItemProps>((props, ref) => {
         />
       </div>
       <div role='none' className='actions'>
-        <Button className='rounded-full p-2 border-none' onClick={onDeleteClicked}>
+        <Button classNames='rounded-full p-2 border-none' onClick={onDeleteClicked}>
           <X className={getSize(4)} />
         </Button>
       </div>

--- a/packages/apps/tasks-app-2/src/components/TaskList.tsx
+++ b/packages/apps/tasks-app-2/src/components/TaskList.tsx
@@ -123,7 +123,7 @@ export const TaskList = <T extends Task = Task>(props: TaskListProps<T>) => {
         ))}
       </List>
       <div role='none' className='my-5'>
-        <Button className='rounded-full p-3 border-none' onClick={() => onTaskCreate?.()}>
+        <Button classNames='rounded-full p-3 border-none' onClick={() => onTaskCreate?.()}>
           <Plus className={getSize(5)} />
         </Button>
       </div>

--- a/packages/apps/tasks-app/src/components/CheckboxItem.tsx
+++ b/packages/apps/tasks-app/src/components/CheckboxItem.tsx
@@ -65,7 +65,7 @@ export const CheckboxItem = forwardRef<Ref, CheckBoxItemProps>((props, ref) => {
         />
       </div>
       <div role='none' className='actions'>
-        <Button className='rounded-full p-2 border-none' onClick={onDeleteClicked}>
+        <Button classNames='rounded-full p-2 border-none' onClick={onDeleteClicked}>
           <X className={getSize(4)} />
         </Button>
       </div>

--- a/packages/apps/tasks-app/src/components/TaskList.tsx
+++ b/packages/apps/tasks-app/src/components/TaskList.tsx
@@ -126,7 +126,7 @@ export const TaskList = <T extends Task = Task>(props: TaskListProps<T>) => {
         ))}
       </List>
       <div role='none' className='my-5'>
-        <Button className='rounded-full p-3 border-none' onClick={() => onTaskCreate?.()}>
+        <Button classNames='rounded-full p-3 border-none' onClick={() => onTaskCreate?.()}>
           <Plus className={getSize(5)} />
         </Button>
       </div>

--- a/packages/apps/templates/tasks-template/src/src/components/CheckboxItem.tsx
+++ b/packages/apps/templates/tasks-template/src/src/components/CheckboxItem.tsx
@@ -65,7 +65,7 @@ export const CheckboxItem = forwardRef<Ref, CheckBoxItemProps>((props, ref) => {
         />
       </div>
       <div role='none' className='actions'>
-        <Button className='rounded-full p-2 border-none' onClick={onDeleteClicked}>
+        <Button classNames='rounded-full p-2 border-none' onClick={onDeleteClicked}>
           <X className={getSize(4)} />
         </Button>
       </div>

--- a/packages/apps/templates/tasks-template/src/src/components/TaskList.tsx
+++ b/packages/apps/templates/tasks-template/src/src/components/TaskList.tsx
@@ -123,7 +123,7 @@ export const TaskList = <T extends Task = Task>(props: TaskListProps<T>) => {
         ))}
       </List>
       <div role='none' className='my-5'>
-        <Button className='rounded-full p-3 border-none' onClick={() => onTaskCreate?.()}>
+        <Button classNames='rounded-full p-3 border-none' onClick={() => onTaskCreate?.()}>
           <Plus className={getSize(5)} />
         </Button>
       </div>

--- a/packages/devtools/devtools/src/containers/RootContainer.tsx
+++ b/packages/devtools/devtools/src/containers/RootContainer.tsx
@@ -27,7 +27,7 @@ const Footer = () => {
         onClick={async () => {
           await services?.SystemService.reset();
         }}
-        className='w-full'
+        classNames='w-full'
       >
         <span className='mis-2'>Reset Storage</span>
       </Button>

--- a/packages/experimental/kai-frames/src/cards/ContactList.tsx
+++ b/packages/experimental/kai-frames/src/cards/ContactList.tsx
@@ -16,7 +16,7 @@ export const ContactList: FC<{ space: Space }> = ({ space }) => {
   const contacts: Contact[] = useQuery(space, Contact.filter());
 
   return (
-    <List density='coarse' aria-labelledby='todo' className='is-full'>
+    <List density='coarse' aria-labelledby='todo' classNames='is-full'>
       {contacts.map((contact) => (
         <ContactListItem key={contact.id} contact={contact} />
       ))}
@@ -28,7 +28,7 @@ export const ContactListItem: FC<{ contact: Contact }> = observer(({ contact }) 
   const address = (address: Address) => `${address.city}, ${address.state} ${address.zip}`;
 
   return (
-    <ListItem className='mbe-1 is-full'>
+    <ListItem classNames='mbe-1 is-full'>
       <ListItemEndcap>
         <User className={mx(getSize(5), 'mlb-2.5')} />
       </ListItemEndcap>

--- a/packages/experimental/kai-frames/src/cards/OrganizationList.tsx
+++ b/packages/experimental/kai-frames/src/cards/OrganizationList.tsx
@@ -48,13 +48,13 @@ export const OrganizationListItem: FC<{ organization: Organization }> = observer
 
           {/* Contacts */}
           {organization.people?.length > 0 && (
-            <List density='fine' aria-labelledby='todo' className='mlb-1'>
+            <List density='fine' aria-labelledby='todo' classNames='mlb-1'>
               {organization.people?.map((contact) => (
                 <ListItem key={contact.id}>
-                  <ListItemEndcap className='flex items-center'>
+                  <ListItemEndcap classNames='flex items-center'>
                     <User className={getSize(5)} />
                   </ListItemEndcap>
-                  <ListItemHeading className='text-sm pbs-1.5'>{contact.name}</ListItemHeading>
+                  <ListItemHeading classNames='text-sm pbs-1.5'>{contact.name}</ListItemHeading>
                 </ListItem>
               ))}
             </List>

--- a/packages/experimental/kai-frames/src/cards/ProjectCard.tsx
+++ b/packages/experimental/kai-frames/src/cards/ProjectCard.tsx
@@ -68,13 +68,13 @@ export const ProjectCard: FC<{ space: Space; object: Project }> = observer(({ sp
       {object.team?.length > 0 && (
         <div className='pt-2'>
           <h2 className='pl-2 text-xs'>Team</h2>
-          <List aria-labelledby='todo' className='mlb-1'>
+          <List aria-labelledby='todo' classNames='mlb-1'>
             {object.team?.map((contact) => (
               <ListItem key={contact.id}>
-                <ListItemEndcap className={getSize(6)}>
+                <ListItemEndcap classNames={getSize(6)}>
                   <User className={mx(getSize(4), 'mbs-1')} />
                 </ListItemEndcap>
-                <ListItemHeading className='text-sm mbs-0.5'>{contact.name}</ListItemHeading>
+                <ListItemHeading classNames='text-sm mbs-0.5'>{contact.name}</ListItemHeading>
               </ListItem>
             ))}
           </List>

--- a/packages/experimental/kai-frames/src/components/Presenter/Deck.tsx
+++ b/packages/experimental/kai-frames/src/components/Presenter/Deck.tsx
@@ -44,7 +44,7 @@ export const Deck = ({
 
   const Expand = () => {
     return (
-      <Button variant='ghost' className='mx-2 my-4 text-gray-400' onClick={() => onToggleFullscreen?.(!fullscreen)}>
+      <Button variant='ghost' classNames='mx-2 my-4 text-gray-400' onClick={() => onToggleFullscreen?.(!fullscreen)}>
         <ArrowsOut className={mx(getSize(8))} />
       </Button>
     );

--- a/packages/experimental/kai-frames/src/components/Presenter/Pager.tsx
+++ b/packages/experimental/kai-frames/src/components/Presenter/Pager.tsx
@@ -81,16 +81,16 @@ export const Pager = ({ index: controlledIndex = 0, count = 0, keys, onMove, onC
 
   return (
     <div className='flex m-4 items-center text-gray-400'>
-      <Button variant='ghost' className='p-0' onClick={() => onMove?.(1)}>
+      <Button variant='ghost' classNames='p-0' onClick={() => onMove?.(1)}>
         <CaretDoubleLeft className={mx(getSize(6))} />
       </Button>
-      <Button variant='ghost' className='p-0' onClick={() => handleMove(-1)}>
+      <Button variant='ghost' classNames='p-0' onClick={() => handleMove(-1)}>
         <CaretLeft className={mx(getSize(8))} />
       </Button>
-      <Button variant='ghost' className='p-0' onClick={() => handleMove(1)}>
+      <Button variant='ghost' classNames='p-0' onClick={() => handleMove(1)}>
         <CaretRight className={mx(getSize(8))} />
       </Button>
-      <Button variant='ghost' className='p-0' onClick={() => onMove?.(count)}>
+      <Button variant='ghost' classNames='p-0' onClick={() => onMove?.(count)}>
         <CaretDoubleRight className={mx(getSize(6))} />
       </Button>
     </div>

--- a/packages/experimental/kai-frames/src/frames/Calendar/CalendarFrame.tsx
+++ b/packages/experimental/kai-frames/src/frames/Calendar/CalendarFrame.tsx
@@ -106,7 +106,7 @@ export const CalendarFrame = () => {
             <Button
               key={v}
               variant='ghost'
-              className={mx('text-gray-300', v === view && 'text-gray-700')}
+              classNames={['text-gray-300', v === view && 'text-gray-700']}
               onClick={() => setView(v)}
             >
               <Icon weight='light' className={getSize(6)} />

--- a/packages/experimental/kai-frames/src/frames/Chat/ChatMessage.tsx
+++ b/packages/experimental/kai-frames/src/frames/Chat/ChatMessage.tsx
@@ -35,13 +35,13 @@ export const ChatMessage: FC<{ message: Message; onSelect: () => void; onDelete:
   return (
     <div className='flex shrink-0 w-full px-1'>
       <div>
-        <Button variant='ghost' className='p-0' onClick={onSelect}>
+        <Button variant='ghost' classNames='p-0' onClick={onSelect}>
           <UserCircle className={mx(getSize(6), getColor(message.from.name ?? 'unknown'))} />
         </Button>
       </div>
       <div className='w-full px-2 py-1'>{message.subject}</div>
       <div>
-        <Button variant='ghost' className='p-0 text-zinc-400' onClick={onDelete}>
+        <Button variant='ghost' classNames='p-0 text-zinc-400' onClick={onDelete}>
           <X className={mx(getSize(4))} />
         </Button>
       </div>

--- a/packages/experimental/kai-frames/src/frames/Chat/Video.tsx
+++ b/packages/experimental/kai-frames/src/frames/Chat/Video.tsx
@@ -178,12 +178,12 @@ export const Video: FC<{ space: Space }> = ({ space }) => {
     <div className='flex flex-col bg-zinc-300'>
       <div className='flex mx-3 justify-end'>
         {localVideoRef.current && localVideoRef.current!.srcObject && (
-          <Button className='p-1' variant='ghost' onClick={handleStop}>
+          <Button classNames='p-1' variant='ghost' onClick={handleStop}>
             <VideoCameraSlash className={getSize(6)} />
           </Button>
         )}
         {localVideoRef.current && !localVideoRef.current!.srcObject && (
-          <Button className='p-1' variant='ghost' onClick={handleStart}>
+          <Button classNames='p-1' variant='ghost' onClick={handleStart}>
             <VideoCamera className={getSize(6)} />
           </Button>
         )}

--- a/packages/experimental/kai-frames/src/frames/Chess/ChessFrame.tsx
+++ b/packages/experimental/kai-frames/src/frames/Chess/ChessFrame.tsx
@@ -111,10 +111,10 @@ const Play: FC<{
 
       <div className='flex flex-row-reverse w-full p-4'>
         <div className='flex'>
-          <Button className='ml-2' onClick={() => onSetPieces(pieces > 0 ? pieces - 1 : chessPieces.length - 1)}>
+          <Button classNames='ml-2' onClick={() => onSetPieces(pieces > 0 ? pieces - 1 : chessPieces.length - 1)}>
             <CaretLeft weight='thin' className={getSize(6)} />
           </Button>
-          <Button className='ml-1' onClick={() => onSetPieces(pieces < chessPieces.length - 1 ? pieces + 1 : 0)}>
+          <Button classNames='ml-1' onClick={() => onSetPieces(pieces < chessPieces.length - 1 ? pieces + 1 : 0)}>
             <CaretRight weight='thin' className={getSize(6)} />
           </Button>
         </div>

--- a/packages/experimental/kai-frames/src/frames/Explorer/ExplorerFrame.tsx
+++ b/packages/experimental/kai-frames/src/frames/Explorer/ExplorerFrame.tsx
@@ -98,7 +98,7 @@ export const ExplorerFrame = () => {
             variant='ghost'
             key={type}
             title={label}
-            className={mx('mx-1', view === type && 'text-black')}
+            classNames={['mx-1', view === type && 'text-black']}
             onClick={() => setView(type)}
           >
             <Icon className={getSize(6)} />

--- a/packages/experimental/kai-frames/src/frames/Note/NoteTile.tsx
+++ b/packages/experimental/kai-frames/src/frames/Note/NoteTile.tsx
@@ -60,7 +60,7 @@ export const NoteTile = observer(({ item, onDelete }: TileContentProps) => {
         <div className='order-1'>
           <DropdownMenu
             trigger={
-              <Button variant='ghost' className='p-2'>
+              <Button variant='ghost' classNames='p-2'>
                 <List className={getSize(5)} />
               </Button>
             }

--- a/packages/experimental/kai-framework/src/components/SpaceList/SpaceItem.tsx
+++ b/packages/experimental/kai-framework/src/components/SpaceList/SpaceItem.tsx
@@ -68,7 +68,7 @@ export const SpaceItem = observer(({ space, selected, children, onAction }: Spac
 
         <Button
           variant='ghost'
-          className={mx(selected ? 'flex' : 'invisible')}
+          classNames={[selected ? 'flex' : 'invisible']}
           title='Share space'
           onClick={(event) =>
             onAction({

--- a/packages/experimental/kai-framework/src/components/SpaceSettings/SpaceSettings.tsx
+++ b/packages/experimental/kai-framework/src/components/SpaceSettings/SpaceSettings.tsx
@@ -36,7 +36,7 @@ export const SpaceThemes: FC<{ selected: string; onSelect: (selected: string) =>
     <div className='flex'>
       <div className='grid grid-cols-6'>
         {themes.map(({ id, classes }) => (
-          <Button key={id} variant='ghost' className='p-0' onClick={() => onSelect(id)}>
+          <Button key={id} variant='ghost' classNames='p-0' onClick={() => onSelect(id)}>
             <div className={mx('m-2', selected === id && 'ring-2 ring-black')}>
               <Square className={mx(getSize(6), classes.header, 'text-transparent')} />
             </div>
@@ -52,7 +52,7 @@ export const SpaceIcons: FC<{ selected: string; onSelect: (selected: string) => 
     <div className='flex'>
       <div className='grid grid-cols-6'>
         {icons.map(({ id, Icon }) => (
-          <Button key={id} variant='ghost' className='p-0' onClick={() => onSelect(id)}>
+          <Button key={id} variant='ghost' classNames='p-0' onClick={() => onSelect(id)}>
             <div className={mx('m-1 p-1', selected === id && 'rounded ring-2 ring-black')}>
               <Icon className={getSize(6)} />
             </div>

--- a/packages/experimental/kai-framework/src/containers/AppMenu/AppMenu.tsx
+++ b/packages/experimental/kai-framework/src/containers/AppMenu/AppMenu.tsx
@@ -44,7 +44,7 @@ export const AppMenu = () => {
         <DensityProvider density='coarse'>
           <Button
             variant='ghost'
-            className='p-2'
+            classNames='p-2'
             onClick={() => {
               setChat(!chat);
               setNewChat(false);
@@ -54,13 +54,13 @@ export const AppMenu = () => {
               <Chat className={getSize(6)} />
             )}
           </Button>
-          <Button variant='ghost' className='p-2' onClick={() => shell.setLayout(ShellLayout.DEVICE_INVITATIONS)}>
+          <Button variant='ghost' classNames='p-2' onClick={() => shell.setLayout(ShellLayout.DEVICE_INVITATIONS)}>
             <User className={getSize(6)} />
           </Button>
           <DropdownMenu
             slots={{ content: { className: 'z-50' } }}
             trigger={
-              <Button variant='ghost' className='p-2'>
+              <Button variant='ghost' classNames='p-2'>
                 <List className={getSize(6)} />
               </Button>
             }

--- a/packages/experimental/kai-framework/src/containers/Sidebar/FrameList.tsx
+++ b/packages/experimental/kai-framework/src/containers/Sidebar/FrameList.tsx
@@ -30,10 +30,10 @@ export const FrameList = () => {
             <ListItem
               id={id}
               key={id}
-              className={['flex w-full px-3 items-center', id === currentFrame?.module.id && 'bg-zinc-200']}
+              classNames={['flex w-full px-3 items-center', id === currentFrame?.module.id && 'bg-zinc-200']}
             >
               <Link key={id} className='flex w-full items-center' to={createPath({ spaceKey: space.key, frame: id })}>
-                <ListItemEndcap className='items-center'>
+                <ListItemEndcap classNames='items-center'>
                   <Icon className={getSize(6)} />
                 </ListItemEndcap>
                 <div className='pl-1'>{displayName}</div>

--- a/packages/experimental/kai-framework/src/containers/Sidebar/Sidebar.tsx
+++ b/packages/experimental/kai-framework/src/containers/Sidebar/Sidebar.tsx
@@ -154,7 +154,7 @@ export const Sidebar = observer(({ className, onNavigate }: SidebarProps) => {
   const Icon = getIcon(space.properties.icon);
 
   return (
-    <NaturalSidebar className={className}>
+    <NaturalSidebar classNames={className}>
       <DensityProvider density='fine'>
         <div role='none' className={mx('flex flex-col w-full h-full overflow-hidden min-bs-full bg-sidebar-bg')}>
           {/* Header */}
@@ -170,13 +170,13 @@ export const Sidebar = observer(({ className, onNavigate }: SidebarProps) => {
               <div className='flex shrink-0 items-center'>
                 <Button
                   variant='ghost'
-                  className='flex p-0 px-1'
+                  classNames='flex p-0 px-1'
                   data-testid='sidebar.showSpaceList'
                   onClick={() => setShowSpacePanel((show) => !show)}
                 >
                   <Info className={getSize(5)} />
                 </Button>
-                <Button variant='ghost' className='p-0 pr-2' onClick={toggleSidebar}>
+                <Button variant='ghost' classNames='p-0 pr-2' onClick={toggleSidebar}>
                   {sidebarOpen && <CaretLeft className={getSize(6)} />}
                 </Button>
               </div>
@@ -222,7 +222,7 @@ export const Sidebar = observer(({ className, onNavigate }: SidebarProps) => {
                   variant='ghost'
                   data-testid='space-share'
                   title='Share space'
-                  className='p-0 items-center'
+                  classNames='p-0 items-center'
                   onClick={(event) =>
                     handleSpaceAction({
                       action: IntentAction.SPACE_SHARE,
@@ -250,7 +250,7 @@ export const Sidebar = observer(({ className, onNavigate }: SidebarProps) => {
                     <Button
                       variant='ghost'
                       title='Select frame.'
-                      className='mli-2 p-0 px-2 items-center'
+                      classNames='mli-2 p-0 px-2 items-center'
                       onClick={() => setShowFrames(true)}
                     >
                       <PuzzlePiece className={getSize(6)} />
@@ -264,7 +264,7 @@ export const Sidebar = observer(({ className, onNavigate }: SidebarProps) => {
                     <Button
                       variant='ghost'
                       title='Show bot console.'
-                      className='mli-2 p-0 px-2 items-center'
+                      classNames='mli-2 p-0 px-2 items-center'
                       onClick={() => onNavigate(createPath({ spaceKey: space.key, section: Section.BOTS }))}
                     >
                       <Function className={getSize(6)} />
@@ -278,7 +278,7 @@ export const Sidebar = observer(({ className, onNavigate }: SidebarProps) => {
                     <Button
                       variant='ghost'
                       title='Show metagraph.'
-                      className='mli-2 p-0 px-2 items-center'
+                      classNames='mli-2 p-0 px-2 items-center'
                       onClick={() => onNavigate(createPath({ spaceKey: space.key, section: Section.DMG }))}
                     >
                       <Graph className={getSize(6)} />
@@ -295,7 +295,7 @@ export const Sidebar = observer(({ className, onNavigate }: SidebarProps) => {
               <Button
                 variant='ghost'
                 title='Toggle connection state.'
-                className='mli-2 p-0 px-2 items-center'
+                classNames='mli-2 p-0 px-2 items-center'
                 onClick={handleToggleConnection}
               >
                 {connectionState === ConnectionState.ONLINE ? (

--- a/packages/experimental/kai-framework/src/containers/Sidebar/SpaceListPanel.tsx
+++ b/packages/experimental/kai-framework/src/containers/Sidebar/SpaceListPanel.tsx
@@ -67,7 +67,7 @@ export const SpaceListPanel = ({ onAction, onNavigate, onClose }: SpacePanelProp
 
         <Button
           variant='ghost'
-          className='flex p-0 justify-start'
+          classNames='flex p-0 justify-start'
           title='Create new space'
           data-testid='sidebar.createSpace'
           onClick={handleCreateSpace}
@@ -77,7 +77,7 @@ export const SpaceListPanel = ({ onAction, onNavigate, onClose }: SpacePanelProp
         </Button>
         <Button
           variant='ghost'
-          className='flex p-0 justify-start'
+          classNames='flex p-0 justify-start'
           title='Join a space'
           data-testid='sidebar.joinSpace'
           onClick={handleJoinSpace}
@@ -87,7 +87,7 @@ export const SpaceListPanel = ({ onAction, onNavigate, onClose }: SpacePanelProp
         </Button>
         <Button
           variant='ghost'
-          className='flex p-0 justify-start'
+          classNames='flex p-0 justify-start'
           title='Close settings'
           data-testid='sidebar.closeSettings'
           onClick={onClose}

--- a/packages/experimental/kai-framework/src/pages/SpacePage.tsx
+++ b/packages/experimental/kai-framework/src/pages/SpacePage.tsx
@@ -47,7 +47,7 @@ const SpacePage = () => {
         className={['!block-start-appbar md:is-sidebar', !sidebarOpen && 'md:-inline-start-sidebar']}
         onNavigate={(path) => navigate(path)}
       />
-      <Main className={['flex flex-col bs-full overflow-hidden', sidebarOpen && 'md:pis-sidebar']}>
+      <Main classNames={['flex flex-col bs-full overflow-hidden', sidebarOpen && 'md:pis-sidebar']}>
         <SpacePanel />
       </Main>
     </div>

--- a/packages/experimental/kube-console/src/components/util.tsx
+++ b/packages/experimental/kube-console/src/components/util.tsx
@@ -18,7 +18,7 @@ export type ListItemButtonProps = ListItemProps & {
 export const ListItemButton = ({ slots, onClick, selected, ...rest }: ListItemButtonProps) => {
   return (
     <ListItem
-      className={[
+      classNames={[
         'flex items-center overflow-hidden cursor-pointer px-2 py-1',
         selected && 'bg-highlight-bg dark:bg-dark-highlight-bg',
       ]}

--- a/packages/experimental/kube-console/src/containers/ModuleContainer.tsx
+++ b/packages/experimental/kube-console/src/containers/ModuleContainer.tsx
@@ -31,7 +31,7 @@ export const ModuleContainer = () => {
       <SidebarRoot>
         <Sidebar modules={modules} active={active.id} onActiveChange={handleActiveChange} />
       </SidebarRoot>
-      <Main className='flex overflow-hidden'>
+      <Main classNames='flex overflow-hidden'>
         <Component />
       </Main>
     </MainRoot>

--- a/packages/experimental/mosaic/src/components/List/EditableObjectList.tsx
+++ b/packages/experimental/mosaic/src/components/List/EditableObjectList.tsx
@@ -66,13 +66,13 @@ export const EditableObjectList = <T extends Object>({
             <ListItem
               id={object.id}
               key={object.id}
-              className={['flex w-full px-3 items-center', selected === object.id && slots?.selected?.className]}
+              classNames={['flex w-full px-3 items-center', selected === object.id && slots?.selected?.className]}
             >
               <ListItemEndcap>
                 <Button
                   variant='ghost'
                   onClick={() => onSelect?.(object.id)}
-                  className={isSelected && 'text-selection-text'}
+                  classNames={isSelected && 'text-selection-text'}
                 >
                   <Icon className={getSize(6)} />
                 </Button>

--- a/packages/experimental/mosaic/src/components/Stack/StackMenu.tsx
+++ b/packages/experimental/mosaic/src/components/Stack/StackMenu.tsx
@@ -50,7 +50,7 @@ export const StackMenu = ({ actions = [], onAction }: StackMenuProps) => {
       slots={{ content: { className: 'z-50', align: 'end' } }}
       trigger={
         <div className='flex'>
-          <Button variant='ghost' density='fine' className='p-0'>
+          <Button variant='ghost' density='fine' classNames='p-0'>
             <DotsThreeCircle className={getSize(6)} />
           </Button>
         </div>

--- a/packages/sdk/react-shell/src/components/Clipboard/CopyButton.tsx
+++ b/packages/sdk/react-shell/src/components/Clipboard/CopyButton.tsx
@@ -22,7 +22,7 @@ export const CopyButton = ({ value }: CopyButtonProps) => {
   const isCopied = textValue === value;
   return (
     <Button
-      className='inline-flex flex-col justify-center'
+      classNames='inline-flex flex-col justify-center'
       onClick={() => setTextValue(value)}
       data-testid='copy-invitation'
     >

--- a/packages/sdk/react-shell/src/components/InvitationList/InvitationListItem.tsx
+++ b/packages/sdk/react-shell/src/components/InvitationList/InvitationListItem.tsx
@@ -49,7 +49,7 @@ export const InvitationListItem = ({
         {showShare && invitationUrl ? (
           <>
             <AccordionPrimitive.Trigger asChild>
-              <Button className='grow flex gap-1' data-testid='show-qrcode'>
+              <Button classNames='grow flex gap-1' data-testid='show-qrcode'>
                 <span>{t('open share panel label')}</span>
                 <QrCode className={getSize(4)} weight='bold' />
               </Button>
@@ -62,12 +62,12 @@ export const InvitationListItem = ({
           <span role='none' className='grow' />
         )}
         {isCancellable ? (
-          <Button variant='ghost' className='flex gap-1' onClick={cancel} data-testid='cancel-invitation'>
+          <Button variant='ghost' classNames='flex gap-1' onClick={cancel} data-testid='cancel-invitation'>
             <span className='sr-only'>{t('cancel invitation label')}</span>
             <ProhibitInset className={getSize(4)} weight='bold' />
           </Button>
         ) : (
-          <Button variant='ghost' className='flex gap-1' onClick={handleClickRemove} data-testid='remove-invitation'>
+          <Button variant='ghost' classNames='flex gap-1' onClick={handleClickRemove} data-testid='remove-invitation'>
             <span className='sr-only'>{t('remove invitation label')}</span>
             <X className={getSize(4)} weight='bold' />
           </Button>

--- a/packages/sdk/react-shell/src/panels/DevicesPanel/DevicesPanel.tsx
+++ b/packages/sdk/react-shell/src/panels/DevicesPanel/DevicesPanel.tsx
@@ -48,7 +48,7 @@ const DeviceListView = ({ createInvitationUrl, titleId, onDone, doneActionParent
           {displayName ?? identity.identityKey.truncate()}
         </h2>
         <TooltipRoot>
-          <TooltipContent className='z-50'>{t('close label')}</TooltipContent>
+          <TooltipContent classNames='z-50'>{t('close label')}</TooltipContent>
           <TooltipTrigger asChild>
             {doneActionParent ? cloneElement(doneActionParent, {}, doneButton) : doneButton}
           </TooltipTrigger>
@@ -61,7 +61,7 @@ const DeviceListView = ({ createInvitationUrl, titleId, onDone, doneActionParent
           createInvitationUrl={createInvitationUrl}
         />
         <Button
-          className='is-full flex gap-2 mbs-2'
+          classNames='is-full flex gap-2 mbs-2'
           onClick={() => client.halo.createInvitation()}
           data-testid='devices-panel.create-invitation'
         >

--- a/packages/sdk/react-shell/src/panels/IdentityPanel/IdentityPanel.tsx
+++ b/packages/sdk/react-shell/src/panels/IdentityPanel/IdentityPanel.tsx
@@ -35,7 +35,7 @@ export const IdentityPanel = ({
             fallbackValue={identity.identityKey.toHex()}
             label={identity.profile?.displayName ?? ''}
           />
-          <Button onClick={onClickManageProfile ?? defaultManageProfile} className='is-full'>
+          <Button onClick={onClickManageProfile ?? defaultManageProfile} classNames='is-full'>
             {t('manage profile label')}
           </Button>
         </div>

--- a/packages/sdk/react-shell/src/panels/JoinPanel/JoinHeading.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/JoinHeading.tsx
@@ -41,7 +41,7 @@ export const JoinHeading = forwardRef(
       <Button
         variant='ghost'
         {...(onExit && { onClick: onExit })}
-        className={mx(defaultDescription, 'plb-0 pli-2 absolute block-start-1.5 inline-end-2 z-[1]')}
+        classNames={mx(defaultDescription, 'plb-0 pli-2 absolute block-start-1.5 inline-end-2 z-[1]')}
         data-testid='join-exit'
       >
         <X weight='bold' className={getSize(4)} />

--- a/packages/sdk/react-shell/src/panels/JoinPanel/view-states/IdentityAdded.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/view-states/IdentityAdded.tsx
@@ -32,7 +32,7 @@ const Done = ({ onDone, doneActionParent, active }: DoneProps) => {
     <Button
       {...(onDone && { onClick: () => onDone(null) })}
       disabled={disabled}
-      className='grow flex items-center gap-2 pli-2'
+      classNames='grow flex items-center gap-2 pli-2'
       data-autofocus='confirmingAddedIdentity'
       data-testid='identity-added-done'
     >
@@ -78,7 +78,7 @@ export const IdentityAdded = ({
         <div className='flex gap-2'>
           <Button
             disabled={disabled || !addedIdentity}
-            className='grow flex items-center gap-2 pli-2 order-2'
+            classNames='grow flex items-center gap-2 pli-2 order-2'
             onClick={() => addedIdentity && joinSend({ type: 'selectIdentity', identity: addedIdentity })}
             data-autofocus='confirmingAddedIdentity'
           >
@@ -89,7 +89,7 @@ export const IdentityAdded = ({
           <Button
             disabled={disabled}
             onClick={() => joinSend({ type: 'deselectAuthMethod' })}
-            className='flex items-center gap-2 pis-2 pie-4'
+            classNames='flex items-center gap-2 pis-2 pie-4'
           >
             <CaretLeft weight='bold' className={getSize(4)} />
             <span>{t('deselect identity label')}</span>

--- a/packages/sdk/react-shell/src/panels/JoinPanel/view-states/IdentityInput.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/view-states/IdentityInput.tsx
@@ -60,7 +60,7 @@ export const IdentityInput = ({ method, ...viewStateProps }: IdentityCreatorProp
       <div className='flex gap-2'>
         <Button
           disabled={disabled}
-          className='grow flex items-center gap-2 pli-2 order-2'
+          classNames='grow flex items-center gap-2 pli-2 order-2'
           onClick={handleNext}
           data-testid={`${method === 'recover identity' ? 'recover' : 'create'}-identity-input-continue`}
         >
@@ -71,7 +71,7 @@ export const IdentityInput = ({ method, ...viewStateProps }: IdentityCreatorProp
         <Button
           disabled={disabled}
           onClick={() => joinSend({ type: 'deselectAuthMethod' })}
-          className='flex items-center gap-2 pis-2 pie-4'
+          classNames='flex items-center gap-2 pis-2 pie-4'
           data-testid={`${method === 'recover identity' ? 'recover' : 'create'}-identity-input-back`}
         >
           <CaretLeft weight='bold' className={getSize(4)} />

--- a/packages/sdk/react-shell/src/panels/JoinPanel/view-states/InvitationAccepted.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/view-states/InvitationAccepted.tsx
@@ -32,7 +32,7 @@ const PureInvitationAcceptedContent = ({
     <Button
       onClick={() => onDone?.(result)}
       disabled={disabled}
-      className='flex items-center gap-2 pli-2'
+      classNames='flex items-center gap-2 pli-2'
       data-autofocus={`success${Kind}Invitation finishingJoining${Kind}`}
       data-testid={`${Kind.toLowerCase()}-invitation-accepted-done`}
     >

--- a/packages/sdk/react-shell/src/panels/JoinPanel/view-states/InvitationAuthenticator.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/view-states/InvitationAuthenticator.tsx
@@ -71,7 +71,7 @@ const PureInvitationAuthenticatorContent = ({
       <div className='flex gap-2'>
         <Button
           disabled={disabled}
-          className='grow flex items-center gap-2 pli-2 order-2'
+          classNames='grow flex items-center gap-2 pli-2 order-2'
           onClick={onAuthenticate}
           data-autofocus-pinlength={invitationType}
           data-testid={`${invitationType}-invitation-authenticator-next`}
@@ -82,7 +82,7 @@ const PureInvitationAuthenticatorContent = ({
         </Button>
         <Button
           disabled={disabled}
-          className='flex items-center gap-2 pis-2 pie-4'
+          classNames='flex items-center gap-2 pis-2 pie-4'
           onClick={() => joinState?.context[invitationType].invitationObservable?.cancel()}
           data-testid={`${invitationType}-invitation-authenticator-cancel`}
         >

--- a/packages/sdk/react-shell/src/panels/JoinPanel/view-states/InvitationInput.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/view-states/InvitationInput.tsx
@@ -54,7 +54,7 @@ export const InvitationInput = ({ Kind, ...viewStateProps }: InvitationInputProp
       <div className='flex gap-2'>
         <Button
           disabled={disabled}
-          className='grow flex items-center gap-2 pli-2 order-2'
+          classNames='grow flex items-center gap-2 pli-2 order-2'
           onClick={handleNext}
           data-testid={`${Kind.toLowerCase()}-invitation-input-continue`}
         >
@@ -65,7 +65,7 @@ export const InvitationInput = ({ Kind, ...viewStateProps }: InvitationInputProp
         <Button
           disabled={disabled || Kind === 'Space'}
           onClick={() => joinSend({ type: 'deselectAuthMethod' })}
-          className='flex items-center gap-2 pis-2 pie-4'
+          classNames='flex items-center gap-2 pis-2 pie-4'
           data-testid={`${Kind.toLowerCase()}-invitation-input-back`}
         >
           <CaretLeft weight='bold' className={getSize(4)} />

--- a/packages/sdk/react-shell/src/panels/JoinPanel/view-states/InvitationRescuer.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/view-states/InvitationRescuer.tsx
@@ -38,14 +38,14 @@ const InvitationActions = ({
           <ViewStateHeading className={defaultDescription}>{t('connecting status label')}</ViewStateHeading>
           <div role='none' className='grow' />
           <div className='flex gap-2'>
-            <Button disabled className='grow flex items-center gap-2 pli-2 order-2' data-testid='next'>
+            <Button disabled classNames='grow flex items-center gap-2 pli-2 order-2' data-testid='next'>
               <CaretLeft weight='bold' className={mx(getSize(2), 'invisible')} />
               <span className='grow'>{t('next label')}</span>
               <CaretRight weight='bold' className={getSize(4)} />
             </Button>
             <Button
               disabled={disabled}
-              className='flex items-center gap-2 pis-2 pie-4'
+              classNames='flex items-center gap-2 pis-2 pie-4'
               onClick={() => joinState?.context[invitationType].invitationObservable?.cancel()}
               data-testid='invitation-rescuer-cancel'
             >
@@ -73,7 +73,7 @@ const InvitationActions = ({
           <div role='none' className='grow' />
           <Button
             disabled={disabled}
-            className='flex items-center gap-2 pli-2'
+            classNames='flex items-center gap-2 pli-2'
             onClick={() => joinSend({ type: `reset${Kind}Invitation` })}
             data-testid='invitation-rescuer-reset'
           >
@@ -98,7 +98,7 @@ export const InvitationRescuer = ({ Kind, ...viewStateProps }: InvitationConnect
           <div role='none' className='grow' />
           <Button
             disabled={disabled}
-            className='flex items-center gap-2 pli-2'
+            classNames='flex items-center gap-2 pli-2'
             data-autofocus={`inputting${Kind}InvitationCode`}
             data-testid='invitation-rescuer-blank-reset'
             onClick={() => joinSend({ type: `reset${Kind}Invitation` })}

--- a/packages/sdk/react-shell/src/panels/SpacePanel/SpacePanel.tsx
+++ b/packages/sdk/react-shell/src/panels/SpacePanel/SpacePanel.tsx
@@ -57,7 +57,7 @@ const CurrentSpaceView = observer(({ space, createInvitationUrl, titleId }: Spac
           createInvitationUrl={createInvitationUrl}
         />
         <Button
-          className='is-full flex gap-2 mbs-2'
+          classNames='is-full flex gap-2 mbs-2'
           onClick={() => {
             const invitation = space?.createInvitation();
             if (process.env.NODE_ENV !== 'production') {

--- a/packages/ui/aurora-theme/src/styles/components/tag.ts
+++ b/packages/ui/aurora-theme/src/styles/components/tag.ts
@@ -36,7 +36,7 @@ const paletteColorMap: Record<Exclude<TagStyleProps['palette'], undefined>, stri
 };
 
 export const tagRoot: ComponentFunction<TagStyleProps> = ({ palette = 'neutral' }, ...etc) =>
-  mx('text-xs font-semibold pli-2 plb-0.5 rounded', paletteColorMap[palette], ...etc);
+  mx('text-xs font-semibold pli-2 plb-0.5 rounded cursor-default', paletteColorMap[palette], ...etc);
 
 export const tagTheme: Theme<TagStyleProps> = {
   root: tagRoot,

--- a/packages/ui/aurora/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/ui/aurora/src/components/Avatar/Avatar.stories.tsx
@@ -43,8 +43,8 @@ const StorybookAvatar = ({
         <AvatarImage href={imgSrc} />
         <AvatarFallback href={jdenticon} />
       </Avatar>
-      <AvatarLabel className='block'>{label}</AvatarLabel>
-      <AvatarDescription className='block'>{description}</AvatarDescription>
+      <AvatarLabel classNames='block'>{label}</AvatarLabel>
+      <AvatarDescription classNames='block'>{description}</AvatarDescription>
     </AvatarRoot>
   );
 };

--- a/packages/ui/aurora/src/components/Avatar/Avatar.tsx
+++ b/packages/ui/aurora/src/components/Avatar/Avatar.tsx
@@ -53,7 +53,7 @@ const AvatarRoot = ({
 
 type AvatarProps = ThemedClassName<AvatarRootPrimitiveProps>;
 
-const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(({ children, className, ...props }, forwardedRef) => {
+const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(({ children, classNames, ...props }, forwardedRef) => {
   const { labelId, descriptionId, maskId, size, variant, status } = useAvatarContext('AvatarStatus');
   const { tx } = useThemeContext();
   const imageSizeNumber = size === 'px' ? 1 : size * 4;
@@ -64,7 +64,7 @@ const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(({ children, className, 
     <AvatarRootPrimitive
       role='img'
       {...props}
-      className={tx('avatar.root', 'avatar', { size, variant }, className)}
+      className={tx('avatar.root', 'avatar', { size, variant }, classNames)}
       ref={forwardedRef}
       aria-labelledby={labelId}
       aria-describedby={descriptionId}
@@ -116,7 +116,7 @@ type AvatarLabelProps = ThemedClassName<Omit<ComponentPropsWithRef<typeof Primit
 };
 
 const AvatarLabel = forwardRef<HTMLSpanElement, AvatarLabelProps>(
-  ({ asChild, srOnly, className, ...props }, forwardedRef) => {
+  ({ asChild, srOnly, classNames, ...props }, forwardedRef) => {
     const Root = asChild ? Slot : Primitive.span;
     const { tx } = useThemeContext();
     const { labelId } = useAvatarContext('AvatarLabel');
@@ -125,7 +125,7 @@ const AvatarLabel = forwardRef<HTMLSpanElement, AvatarLabelProps>(
         {...props}
         id={labelId}
         ref={forwardedRef}
-        className={tx('avatar.label', 'avatar__label', { srOnly }, className)}
+        className={tx('avatar.label', 'avatar__label', { srOnly }, classNames)}
       />
     );
   },
@@ -137,7 +137,7 @@ type AvatarDescriptionProps = ThemedClassName<Omit<ComponentPropsWithRef<typeof 
 };
 
 const AvatarDescription = forwardRef<HTMLSpanElement, AvatarDescriptionProps>(
-  ({ asChild, srOnly, className, ...props }, forwardedRef) => {
+  ({ asChild, srOnly, classNames, ...props }, forwardedRef) => {
     const Root = asChild ? Slot : Primitive.span;
     const { tx } = useThemeContext();
     const { descriptionId } = useAvatarContext('AvatarDescription');
@@ -146,7 +146,7 @@ const AvatarDescription = forwardRef<HTMLSpanElement, AvatarDescriptionProps>(
         {...props}
         id={descriptionId}
         ref={forwardedRef}
-        className={tx('avatar.description', 'avatar__description', { srOnly }, className)}
+        className={tx('avatar.description', 'avatar__description', { srOnly }, classNames)}
       />
     );
   },

--- a/packages/ui/aurora/src/components/Button/Button.tsx
+++ b/packages/ui/aurora/src/components/Button/Button.tsx
@@ -27,7 +27,7 @@ const [ButtonGroupProvider, useButtonGroupContext] = createContext<ButtonGroupCo
 });
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ children, density: propsDensity, elevation: propsElevation, variant = 'default', asChild, ...rootSlot }, ref) => {
+  ({ children, density: propsDensity, elevation: propsElevation, variant = 'default', asChild, ...props }, ref) => {
     const { inGroup } = useButtonGroupContext(BUTTON_NAME);
     const { tx } = useThemeContext();
     const elevation = useElevationContext(propsElevation);
@@ -36,20 +36,20 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <Root
         ref={ref}
-        {...rootSlot}
+        {...props}
         className={tx(
           'button.root',
           'button',
           {
             variant,
             inGroup,
-            disabled: rootSlot.disabled,
+            disabled: props.disabled,
             density,
             elevation,
           },
-          rootSlot.className,
+          props.classNames,
         )}
-        {...(rootSlot.disabled && { disabled: true })}
+        {...(props.disabled && { disabled: true })}
       >
         {children}
       </Root>

--- a/packages/ui/aurora/src/components/Input/Input.tsx
+++ b/packages/ui/aurora/src/components/Input/Input.tsx
@@ -89,7 +89,7 @@ const PinInput = forwardRef<HTMLInputElement, PinInputProps>(
 type TextInputProps = InputSharedProps & ThemedClassName<TextInputPrimitiveProps>;
 
 const TextInput = forwardRef<HTMLInputElement, InputScopedProps<TextInputProps>>(
-  ({ __inputScope, className, density: propsDensity, elevation: propsElevation, variant, ...props }, forwardedRef) => {
+  ({ __inputScope, classNames, density: propsDensity, elevation: propsElevation, variant, ...props }, forwardedRef) => {
     const { hasIosKeyboard } = useThemeContext();
     const { tx } = useThemeContext();
     const density = useDensityContext(propsDensity);
@@ -109,7 +109,7 @@ const TextInput = forwardRef<HTMLInputElement, InputScopedProps<TextInputProps>>
             elevation,
             validationValence,
           },
-          className,
+          classNames,
         )}
         {...(props.autoFocus && !hasIosKeyboard && { autoFocus: true })}
         ref={forwardedRef}
@@ -121,7 +121,7 @@ const TextInput = forwardRef<HTMLInputElement, InputScopedProps<TextInputProps>>
 type TextAreaProps = InputSharedProps & ThemedClassName<TextAreaPrimitiveProps>;
 
 const TextArea = forwardRef<HTMLTextAreaElement, InputScopedProps<TextAreaProps>>(
-  ({ __inputScope, className, density: propsDensity, elevation: propsElevation, variant, ...props }, forwardedRef) => {
+  ({ __inputScope, classNames, density: propsDensity, elevation: propsElevation, variant, ...props }, forwardedRef) => {
     const { hasIosKeyboard } = useThemeContext();
     const { tx } = useThemeContext();
     const density = useDensityContext(propsDensity);
@@ -141,7 +141,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, InputScopedProps<TextAreaProps>
             elevation,
             validationValence,
           },
-          className,
+          classNames,
         )}
         {...(props.autoFocus && !hasIosKeyboard && { autoFocus: true })}
         ref={forwardedRef}
@@ -164,7 +164,7 @@ const Checkbox: ForwardRefExoticComponent<CheckboxProps> = forwardRef<
       onCheckedChange: propsOnCheckedChange,
       size,
       weight = 'bold',
-      className,
+      classNames,
       ...props
     },
     forwardedRef,
@@ -189,7 +189,7 @@ const Checkbox: ForwardRefExoticComponent<CheckboxProps> = forwardRef<
             'aria-invalid': 'true' as const,
             'aria-errormessage': errorMessageId,
           }),
-          className: tx('input.checkbox', 'input--checkbox', { size }, className),
+          className: tx('input.checkbox', 'input--checkbox', { size }, classNames),
         }}
         ref={forwardedRef}
       >

--- a/packages/ui/aurora/src/components/Input/InputMeta.tsx
+++ b/packages/ui/aurora/src/components/Input/InputMeta.tsx
@@ -23,10 +23,10 @@ import { ThemedClassName } from '../../util';
 
 type LabelProps = ThemedClassName<LabelPrimitiveProps> & { srOnly?: boolean };
 
-const Label = forwardRef<HTMLLabelElement, LabelProps>(({ srOnly, className, children, ...props }, forwardedRef) => {
+const Label = forwardRef<HTMLLabelElement, LabelProps>(({ srOnly, classNames, children, ...props }, forwardedRef) => {
   const { tx } = useThemeContext();
   return (
-    <LabelPrimitive {...props} className={tx('input.label', 'input__label', { srOnly }, className)} ref={forwardedRef}>
+    <LabelPrimitive {...props} className={tx('input.label', 'input__label', { srOnly }, classNames)} ref={forwardedRef}>
       {children}
     </LabelPrimitive>
   );
@@ -35,12 +35,12 @@ const Label = forwardRef<HTMLLabelElement, LabelProps>(({ srOnly, className, chi
 type DescriptionProps = ThemedClassName<DescriptionPrimitiveProps> & { srOnly?: boolean };
 
 const Description = forwardRef<HTMLSpanElement, DescriptionProps>(
-  ({ srOnly, className, children, ...props }, forwardedRef) => {
+  ({ srOnly, classNames, children, ...props }, forwardedRef) => {
     const { tx } = useThemeContext();
     return (
       <DescriptionPrimitive
         {...props}
-        className={tx('input.description', 'input__description', { srOnly }, className)}
+        className={tx('input.description', 'input__description', { srOnly }, classNames)}
         ref={forwardedRef}
       >
         {children}
@@ -52,7 +52,7 @@ const Description = forwardRef<HTMLSpanElement, DescriptionProps>(
 type ValidationProps = ThemedClassName<ValidationPrimitiveProps> & { srOnly?: boolean };
 
 const Validation = forwardRef<HTMLSpanElement, InputScopedProps<ValidationProps>>(
-  ({ __inputScope, srOnly, className, children, ...props }, forwardedRef) => {
+  ({ __inputScope, srOnly, classNames, children, ...props }, forwardedRef) => {
     const { tx } = useThemeContext();
     const { validationValence } = useInputContext(INPUT_NAME, __inputScope);
     return (
@@ -62,7 +62,7 @@ const Validation = forwardRef<HTMLSpanElement, InputScopedProps<ValidationProps>
           'input.validation',
           `input__validation-message input__validation-message--${validationValence}`,
           { srOnly, validationValence },
-          className,
+          classNames,
         )}
         ref={forwardedRef}
       >
@@ -75,12 +75,12 @@ const Validation = forwardRef<HTMLSpanElement, InputScopedProps<ValidationProps>
 type DescriptionAndValidationProps = ThemedClassName<DescriptionAndValidationPrimitiveProps> & { srOnly?: boolean };
 
 const DescriptionAndValidation = forwardRef<HTMLParagraphElement, DescriptionAndValidationProps>(
-  ({ srOnly, className, children, ...props }, forwardedRef) => {
+  ({ srOnly, classNames, children, ...props }, forwardedRef) => {
     const { tx } = useThemeContext();
     return (
       <DescriptionAndValidationPrimitive
         {...props}
-        className={tx('input.descriptionAndValidation', 'input__description-and-validation', { srOnly }, className)}
+        className={tx('input.descriptionAndValidation', 'input__description-and-validation', { srOnly }, classNames)}
         ref={forwardedRef}
       >
         {children}

--- a/packages/ui/aurora/src/components/List/List.stories.tsx
+++ b/packages/ui/aurora/src/components/List/List.stories.tsx
@@ -51,7 +51,7 @@ export const Default = {
             <ListItemEndcap>
               <Play className={mx(getSize(5), 'mbs-2.5')} />
             </ListItemEndcap>
-            <ListItemHeading className='grow pbs-2'>{text}</ListItemHeading>
+            <ListItemHeading classNames='grow pbs-2'>{text}</ListItemHeading>
             <ListItemEndcap>
               <PushPin className={mx(getSize(5), 'mbs-2.5')} />
             </ListItemEndcap>
@@ -81,7 +81,7 @@ export const Collapsible = {
         {items.map(({ id, text, body }, index) => (
           <ListItem key={id} id={id} collapsible={index !== 2}>
             {index !== 2 ? <ListItemOpenTrigger /> : <MockListItemOpenTrigger />}
-            <ListItemHeading className='grow pbs-2'>{text}</ListItemHeading>
+            <ListItemHeading classNames='grow pbs-2'>{text}</ListItemHeading>
             <ListItemEndcap>
               <PushPin className={mx(getSize(5), 'mbs-2.5')} />
             </ListItemEndcap>

--- a/packages/ui/aurora/src/components/List/List.tsx
+++ b/packages/ui/aurora/src/components/List/List.tsx
@@ -41,13 +41,13 @@ const useListDensity = ({ density, variant }: Pick<ListProps, 'density' | 'varia
   return variant === 'ordered-draggable' ? 'coarse' : contextDensity ?? 'coarse';
 };
 
-const List = forwardRef<HTMLOListElement, ListProps>(({ className, children, ...props }, forwardedRef) => {
+const List = forwardRef<HTMLOListElement, ListProps>(({ classNames, children, ...props }, forwardedRef) => {
   const { tx } = useThemeContext();
   const density = useListDensity(props);
 
   return (
     <DensityProvider density={density}>
-      <ListPrimitive {...props} className={tx('list.root', 'list', {}, className)} ref={forwardedRef}>
+      <ListPrimitive {...props} className={tx('list.root', 'list', {}, classNames)} ref={forwardedRef}>
         {children}
       </ListPrimitive>
     </DensityProvider>
@@ -57,7 +57,7 @@ const List = forwardRef<HTMLOListElement, ListProps>(({ className, children, ...
 type ListItemEndcapProps = ThemedClassName<ComponentPropsWithoutRef<'div'>> & { asChild?: boolean };
 
 const ListItemEndcap = forwardRef<HTMLDivElement, ListItemEndcapProps>(
-  ({ children, className, asChild, ...props }, forwardedRef) => {
+  ({ children, classNames, asChild, ...props }, forwardedRef) => {
     const Root = asChild ? Slot : 'div';
     const density = useDensityContext();
     const { tx } = useThemeContext();
@@ -65,7 +65,7 @@ const ListItemEndcap = forwardRef<HTMLDivElement, ListItemEndcapProps>(
       <Root
         {...(!asChild && { role: 'none' })}
         {...props}
-        className={tx('list.item.endcap', 'list__listItem__endcap', { density }, className)}
+        className={tx('list.item.endcap', 'list__listItem__endcap', { density }, classNames)}
         ref={forwardedRef}
       >
         {children}
@@ -75,7 +75,7 @@ const ListItemEndcap = forwardRef<HTMLDivElement, ListItemEndcapProps>(
 );
 
 const MockListItemOpenTrigger = ({
-  className,
+  classNames,
   ...props
 }: ThemedClassName<Omit<ComponentPropsWithoutRef<'div'>, 'children'>>) => {
   const density = useDensityContext();
@@ -84,31 +84,31 @@ const MockListItemOpenTrigger = ({
     <div
       role='none'
       {...props}
-      className={tx('list.item.openTrigger', 'list__listItem__openTrigger--mock', { density }, className)}
+      className={tx('list.item.openTrigger', 'list__listItem__openTrigger--mock', { density }, classNames)}
     />
   );
 };
 
 const MockListItemDragHandle = ({
-  className,
+  classNames,
   ...props
 }: ThemedClassName<Omit<ComponentPropsWithoutRef<'div'>, 'children'>>) => {
   const { tx } = useThemeContext();
   return (
-    <div role='none' {...props} className={tx('list.item.dragHandle', 'list__listItem__dragHandle', {}, className)} />
+    <div role='none' {...props} className={tx('list.item.dragHandle', 'list__listItem__dragHandle', {}, classNames)} />
   );
 };
 
 type ListItemHeadingProps = ThemedClassName<ListPrimitiveItemHeadingProps>;
 
 const ListItemHeading = forwardRef<HTMLParagraphElement, ListItemHeadingProps>(
-  ({ children, className, ...props }, forwardedRef) => {
+  ({ children, classNames, ...props }, forwardedRef) => {
     const { tx } = useThemeContext();
     const density = useDensityContext();
     return (
       <ListPrimitiveItemHeading
         {...props}
-        className={tx('list.item.heading', 'list__listItem__heading', { density }, className)}
+        className={tx('list.item.heading', 'list__listItem__heading', { density }, classNames)}
         ref={forwardedRef}
       >
         {children}
@@ -120,12 +120,12 @@ const ListItemHeading = forwardRef<HTMLParagraphElement, ListItemHeadingProps>(
 type ListItemDragHandleProps = ThemedClassName<ListPrimitiveItemDragHandleProps>;
 
 const ListItemDragHandle = forwardRef<HTMLDivElement, ListItemDragHandleProps>(
-  ({ className, children, ...props }, forwardedRef) => {
+  ({ classNames, children, ...props }, forwardedRef) => {
     const { tx } = useThemeContext();
     return (
       <ListPrimitiveItemDragHandle
         {...props}
-        className={tx('list.item.dragHandle', 'list__listItem__dragHandle', {}, className)}
+        className={tx('list.item.dragHandle', 'list__listItem__dragHandle', {}, classNames)}
         ref={forwardedRef}
       >
         {children || (
@@ -139,7 +139,7 @@ const ListItemDragHandle = forwardRef<HTMLDivElement, ListItemDragHandleProps>(
 type ListItemOpenTriggerProps = ThemedClassName<ListPrimitiveItemOpenTriggerProps>;
 
 const ListItemOpenTrigger = forwardRef<HTMLButtonElement, ListItemOpenTriggerProps>(
-  ({ __listItemScope, className, children, ...props }, forwardedRef) => {
+  ({ __listItemScope, classNames, children, ...props }, forwardedRef) => {
     const { tx } = useThemeContext();
     const density = useDensityContext();
     const { toggleOpenLabel } = useListContext(LIST_NAME, __listItemScope);
@@ -148,7 +148,7 @@ const ListItemOpenTrigger = forwardRef<HTMLButtonElement, ListItemOpenTriggerPro
     return (
       <ListPrimitiveItemOpenTrigger
         {...props}
-        className={tx('list.item.openTrigger', 'list__listItem__openTrigger', { density }, className)}
+        className={tx('list.item.openTrigger', 'list__listItem__openTrigger', { density }, classNames)}
         ref={forwardedRef}
       >
         {typeof toggleOpenLabel === 'string' ? <span className='sr-only'>{toggleOpenLabel}</span> : toggleOpenLabel}
@@ -167,13 +167,13 @@ const ListItemOpenTrigger = forwardRef<HTMLButtonElement, ListItemOpenTriggerPro
 
 type ListItemProps = ThemedClassName<ListPrimitiveItemProps>;
 
-const ListItem = forwardRef<HTMLLIElement, ListItemProps>(({ className, children, ...props }, forwardedRef) => {
+const ListItem = forwardRef<HTMLLIElement, ListItemProps>(({ classNames, children, ...props }, forwardedRef) => {
   const { tx } = useThemeContext();
   const density = useDensityContext();
   return (
     <ListPrimitiveItem
       {...props}
-      className={tx('list.item.root', 'list__listItem', { density }, className)}
+      className={tx('list.item.root', 'list__listItem', { density }, classNames)}
       ref={forwardedRef}
     >
       {children}

--- a/packages/ui/aurora/src/components/Main/Main.tsx
+++ b/packages/ui/aurora/src/components/Main/Main.tsx
@@ -86,7 +86,7 @@ MainRoot.displayName = MAIN_ROOT_NAME;
 type SidebarProps = ThemedClassName<ComponentPropsWithRef<typeof DialogContent>> & { swipeToDismiss?: boolean };
 
 const Sidebar = forwardRef<HTMLDivElement, SidebarProps>(
-  ({ className, children, swipeToDismiss, ...props }, forwardedRef) => {
+  ({ classNames, children, swipeToDismiss, ...props }, forwardedRef) => {
     const [isLg] = useMediaQuery('lg', { ssr: false });
     const { sidebarOpen, setSidebarOpen } = useMainContext(SIDEBAR_NAME);
     const { tx } = useThemeContext();
@@ -99,7 +99,7 @@ const Sidebar = forwardRef<HTMLDivElement, SidebarProps>(
         onOpenAutoFocus={(event) => isLg && event.preventDefault()}
         onCloseAutoFocus={(event) => isLg && event.preventDefault()}
         {...props}
-        className={tx('main.sidebar', 'main__sidebar', { isLg, sidebarOpen }, className)}
+        className={tx('main.sidebar', 'main__sidebar', { isLg, sidebarOpen }, classNames)}
         ref={ref}
       >
         <ElevationProvider elevation='chrome'>{children}</ElevationProvider>
@@ -113,14 +113,14 @@ Sidebar.displayName = SIDEBAR_NAME;
 type MainProps = ThemedClassName<ComponentPropsWithRef<typeof Primitive.div>> & { asChild?: boolean };
 
 const Main = forwardRef<HTMLDivElement, MainProps>(
-  ({ asChild, className, children, ...props }: MainProps, forwardedRef) => {
+  ({ asChild, classNames, children, ...props }: MainProps, forwardedRef) => {
     const [isLg] = useMediaQuery('lg', { ssr: false });
     const { sidebarOpen } = useMainContext(MAIN_NAME);
     const { tx } = useThemeContext();
     const Root = asChild ? Slot : 'main';
 
     return (
-      <Root {...props} className={tx('main.content', 'main', { isLg, sidebarOpen }, className)} ref={forwardedRef}>
+      <Root {...props} className={tx('main.content', 'main', { isLg, sidebarOpen }, classNames)} ref={forwardedRef}>
         {children}
       </Root>
     );
@@ -131,7 +131,7 @@ Main.displayName = MAIN_NAME;
 
 type MainOverlayProps = ThemedClassName<Omit<ComponentPropsWithRef<typeof Primitive.div>, 'children'>>;
 
-const MainOverlay = forwardRef<HTMLDivElement, MainOverlayProps>(({ className, ...props }, forwardedRef) => {
+const MainOverlay = forwardRef<HTMLDivElement, MainOverlayProps>(({ classNames, ...props }, forwardedRef) => {
   const [isLg] = useMediaQuery('lg', { ssr: false });
   const { sidebarOpen, setSidebarOpen } = useMainContext(MAIN_NAME);
   const { tx } = useThemeContext();
@@ -139,7 +139,7 @@ const MainOverlay = forwardRef<HTMLDivElement, MainOverlayProps>(({ className, .
     <div
       onClick={() => setSidebarOpen(false)}
       {...props}
-      className={tx('main.overlay', 'main__overlay', { isLg, sidebarOpen }, className)}
+      className={tx('main.overlay', 'main__overlay', { isLg, sidebarOpen }, classNames)}
       data-open={sidebarOpen}
       aria-hidden='true'
       data-aria-hidden='true'

--- a/packages/ui/aurora/src/components/Tag/Tag.tsx
+++ b/packages/ui/aurora/src/components/Tag/Tag.tsx
@@ -16,8 +16,8 @@ type TagProps = ThemedClassName<ComponentPropsWithRef<typeof Primitive.span>> & 
   asChild?: boolean;
 };
 
-export const Tag = forwardRef<HTMLSpanElement, TagProps>(({ asChild, palette, className, ...props }, forwardedRef) => {
+export const Tag = forwardRef<HTMLSpanElement, TagProps>(({ asChild, palette, classNames, ...props }, forwardedRef) => {
   const { tx } = useThemeContext();
   const Root = asChild ? Slot : Primitive.span;
-  return <Root {...props} className={tx('tag.root', 'tag', { palette }, className)} ref={forwardedRef} />;
+  return <Root {...props} className={tx('tag.root', 'tag', { palette }, classNames)} ref={forwardedRef} />;
 });

--- a/packages/ui/aurora/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/aurora/src/components/Tooltip/Tooltip.tsx
@@ -39,12 +39,12 @@ const TooltipTrigger = TooltipTriggerPrimitive;
 
 type TooltipArrowProps = ThemedClassName<TooltipArrowPrimitiveProps>;
 
-const TooltipArrow = forwardRef<SVGSVGElement, TooltipArrowProps>(({ className, ...props }, forwardedRef) => {
+const TooltipArrow = forwardRef<SVGSVGElement, TooltipArrowProps>(({ classNames, ...props }, forwardedRef) => {
   const { tx } = useThemeContext();
   return (
     <TooltipArrowPrimitive
       {...props}
-      className={tx('tooltip.arrow', 'tooltip__arrow', {}, className)}
+      className={tx('tooltip.arrow', 'tooltip__arrow', {}, classNames)}
       ref={forwardedRef}
     />
   );
@@ -52,12 +52,12 @@ const TooltipArrow = forwardRef<SVGSVGElement, TooltipArrowProps>(({ className, 
 
 type TooltipContentProps = ThemedClassName<TooltipContentPrimitiveProps>;
 
-const TooltipContent = forwardRef<HTMLDivElement, TooltipContentProps>(({ className, ...props }, forwardedRef) => {
+const TooltipContent = forwardRef<HTMLDivElement, TooltipContentProps>(({ classNames, ...props }, forwardedRef) => {
   const { tx } = useThemeContext();
   return (
     <TooltipContentPrimitive
       {...props}
-      className={tx('tooltip.content', 'tooltip', {}, className)}
+      className={tx('tooltip.content', 'tooltip', {}, classNames)}
       ref={forwardedRef}
     />
   );

--- a/packages/ui/aurora/src/util/ThemedClassName.ts
+++ b/packages/ui/aurora/src/util/ThemedClassName.ts
@@ -4,4 +4,4 @@
 
 import { ClassNameValue } from '@dxos/aurora-types';
 
-export type ThemedClassName<P> = Omit<P, 'className'> & { className?: ClassNameValue };
+export type ThemedClassName<P> = Omit<P, 'className'> & { classNames?: ClassNameValue };

--- a/packages/ui/react-appkit/src/components/AuthChoices/AuthChoices.tsx
+++ b/packages/ui/react-appkit/src/components/AuthChoices/AuthChoices.tsx
@@ -25,7 +25,7 @@ export const AuthChoices = ({ onCreate, onJoin, onRecover }: AuthChoicesProps) =
           description={t('create identity description')}
           before={<Plus className='w-6 h-6' />}
           after={<CaretRight className='w-4 h-4' weight='bold' />}
-          className='text-lg w-full'
+          classNames='text-lg w-full'
           onClick={onCreate}
           data-testid='create-identity-button'
         >
@@ -37,7 +37,7 @@ export const AuthChoices = ({ onCreate, onJoin, onRecover }: AuthChoicesProps) =
           description={t('join identity description')}
           before={<QrCode className='w-6 h-6' />}
           after={<CaretRight className='w-4 h-4' weight='bold' />}
-          className='text-lg w-full'
+          classNames='text-lg w-full'
           onClick={onJoin}
           data-testid='join-identity-button'
         >
@@ -51,7 +51,7 @@ export const AuthChoices = ({ onCreate, onJoin, onRecover }: AuthChoicesProps) =
           description={t('recover identity description')}
           before={<Textbox className='w-6 h-6' />}
           after={<CaretRight className='w-4 h-4' weight='bold' />}
-          className='text-lg w-full'
+          classNames='text-lg w-full'
           onClick={onRecover}
           data-testid='recover-identity-button'
         >

--- a/packages/ui/react-appkit/src/components/DeviceList/Device.tsx
+++ b/packages/ui/react-appkit/src/components/DeviceList/Device.tsx
@@ -31,7 +31,7 @@ export const Device = (props: DeviceProps) => {
               <p>
                 {props.displayName}
                 {props.isCurrentDevice && (
-                  <Tag palette='info' className='mli-2 align-middle'>
+                  <Tag palette='info' classNames='mli-2 align-middle'>
                     {t('current device label')}
                   </Tag>
                 )}

--- a/packages/ui/react-appkit/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/react-appkit/src/components/Dialog/Dialog.tsx
@@ -125,7 +125,7 @@ export const Dialog = ({
 
             {closeLabel && (
               <TooltipRoot>
-                <TooltipContent className='z-[51]'>{closeLabel}</TooltipContent>
+                <TooltipContent classNames='z-[51]'>{closeLabel}</TooltipContent>
                 <TooltipTrigger asChild>
                   <DialogPrimitive.Close
                     className={mx(

--- a/packages/ui/react-appkit/src/components/EditableList/EditableList.tsx
+++ b/packages/ui/react-appkit/src/components/EditableList/EditableList.tsx
@@ -158,7 +158,7 @@ export const EditableList = ({
       <div className='flex'>
         <DensityProvider density={density}>
           {variant === 'ordered-draggable' && <MockListItemDragHandle />}
-          {completable && <ListItemEndcap className='invisible' />}
+          {completable && <ListItemEndcap classNames='invisible' />}
           <Input
             variant='subdued'
             label={t('new list item input label')}
@@ -191,7 +191,7 @@ export const EditableList = ({
               <Button
                 variant='ghost'
                 {...slots.addItemButton}
-                className={['p-1', slots.addItemButton?.className]}
+                classNames={['p-1', slots.addItemButton?.classNames]}
                 onClick={onClickAdd}
               >
                 <Plus className={getSize(4)} />
@@ -234,10 +234,10 @@ export const EditableListItem = forwardRef<HTMLLIElement, ListScopedProps<Editab
       >
         {variant === 'ordered-draggable' && <ListItemDragHandle />}
         {selectable && (
-          <ListItemEndcap className='items-center'>
+          <ListItemEndcap classNames='items-center'>
             <InputRoot id={`${id}__checkbox`}>
               <Checkbox
-                className={slots?.selectableCheckbox?.className}
+                classNames={slots?.selectableCheckbox?.className}
                 checked={completed}
                 defaultChecked={defaultCompleted}
                 onCheckedChange={onChangeCompleted}
@@ -245,7 +245,7 @@ export const EditableListItem = forwardRef<HTMLLIElement, ListScopedProps<Editab
             </InputRoot>
           </ListItemEndcap>
         )}
-        <ListItemHeading className='sr-only'>{title}</ListItemHeading>
+        <ListItemHeading classNames='sr-only'>{title}</ListItemHeading>
         <Input
           {...{
             variant: 'subdued',
@@ -269,7 +269,7 @@ export const EditableListItem = forwardRef<HTMLLIElement, ListScopedProps<Editab
         {onClickDelete && (
           <ListItemEndcap>
             <Tooltip content={t('delete list item label')} side='left' tooltipLabelsTrigger>
-              <Button variant='ghost' className='p-1' onClick={onClickDelete}>
+              <Button variant='ghost' classNames='p-1' onClick={onClickDelete}>
                 <X className={getSize(4)} />
               </Button>
             </Tooltip>

--- a/packages/ui/react-appkit/src/components/ErrorProvider/ErrorProvider.tsx
+++ b/packages/ui/react-appkit/src/components/ErrorProvider/ErrorProvider.tsx
@@ -82,7 +82,7 @@ export const ErrorProvider = ({ children, config, isDev = true }: ErrorProviderP
                   <Button
                     variant='ghost'
                     onClick={() => setErrorDialogOpen(true)}
-                    className={valenceColorText('warning')}
+                    classNames={valenceColorText('warning')}
                   >
                     <Warning weight='duotone' className={getSize(6)} />
                   </Button>
@@ -90,7 +90,7 @@ export const ErrorProvider = ({ children, config, isDev = true }: ErrorProviderP
               ) : (
                 <Button
                   variant='ghost'
-                  className={
+                  classNames={
                     clientContextValue?.status === SystemStatus.ACTIVE
                       ? valenceColorText('success')
                       : !clientContextValue?.status

--- a/packages/ui/react-appkit/src/components/Input/Input.tsx
+++ b/packages/ui/react-appkit/src/components/Input/Input.tsx
@@ -80,11 +80,11 @@ export const Input = forwardRef<HTMLInputElement | HTMLTextAreaElement, InputPro
           </Label>
           {bareInput}
           {(description || validationMessage) && (
-            <DescriptionAndValidation className={slots.description?.className}>
+            <DescriptionAndValidation classNames={slots.description?.className}>
               {validationMessage && (
-                <Validation className={slots.validation?.className}>{validationMessage} </Validation>
+                <Validation classNames={slots.validation?.className}>{validationMessage} </Validation>
               )}
-              <Description srOnly={descriptionVisuallyHidden} className={slots.description?.className}>
+              <Description srOnly={descriptionVisuallyHidden} classNames={slots.description?.className}>
                 {description}
               </Description>
             </DescriptionAndValidation>

--- a/packages/ui/react-appkit/src/components/InvitationList/PendingInvitation.tsx
+++ b/packages/ui/react-appkit/src/components/InvitationList/PendingInvitation.tsx
@@ -69,11 +69,11 @@ export const PendingInvitation = ({ wrapper, createInvitationUrl, onClickRemove 
                 status === Invitation.State.SUCCESS ? (
                   <>
                     <Tooltip content={t('remove label')} tooltipLabelsTrigger>
-                      <Button className='flex md:hidden gap-1 items-center' onClick={() => onClickRemove(wrapper)}>
+                      <Button classNames='flex md:hidden gap-1 items-center' onClick={() => onClickRemove(wrapper)}>
                         <XCircle className={getSize(5)} />
                       </Button>
                     </Tooltip>
-                    <Button className='hidden md:flex gap-1 items-center' onClick={() => onClickRemove(wrapper)}>
+                    <Button classNames='hidden md:flex gap-1 items-center' onClick={() => onClickRemove(wrapper)}>
                       <XCircle className={getSize(5)} />
                       <span>{t('remove label')}</span>
                     </Button>
@@ -81,11 +81,11 @@ export const PendingInvitation = ({ wrapper, createInvitationUrl, onClickRemove 
                 ) : (
                   <>
                     <Tooltip content={t('cancel label')} tooltipLabelsTrigger>
-                      <Button className='flex md:hidden gap-1 items-center' onClick={cancel}>
+                      <Button classNames='flex md:hidden gap-1 items-center' onClick={cancel}>
                         <ProhibitInset className={getSize(5)} />
                       </Button>
                     </Tooltip>
-                    <Button className='hidden md:flex gap-1 items-center' onClick={cancel}>
+                    <Button classNames='hidden md:flex gap-1 items-center' onClick={cancel}>
                       <ProhibitInset className={getSize(5)} />
                       <span>{t('cancel label')}</span>
                     </Button>

--- a/packages/ui/react-appkit/src/components/ManageSpacePage/ManageSpacePage.tsx
+++ b/packages/ui/react-appkit/src/components/ManageSpacePage/ManageSpacePage.tsx
@@ -61,7 +61,7 @@ export const ManageSpacePage = ({
             <Button
               variant='primary'
               onClick={handleCreateInvitation}
-              className='flex gap-1 items-center'
+              classNames='flex gap-1 items-center'
               disabled={!space}
             >
               <span>{t('create invitation label')}</span>

--- a/packages/ui/react-appkit/src/components/Menubar/SpaceLink.tsx
+++ b/packages/ui/react-appkit/src/components/Menubar/SpaceLink.tsx
@@ -17,7 +17,7 @@ export const SpaceLink = ({ onClickGoToSpace }: SpaceLinkProps) => {
   const { t } = useTranslation('appkit');
   return (
     <ToolbarButtonItem asChild>
-      <Button className='pointer-events-auto flex gap-1 pli-2' onClick={onClickGoToSpace}>
+      <Button classNames='pointer-events-auto flex gap-1 pli-2' onClick={onClickGoToSpace}>
         <span className='text-xs'>{t('go to space label')}</span>
         <Check className={getSize(4)} />
       </Button>

--- a/packages/ui/react-appkit/src/components/Menubar/SpaceMenu.tsx
+++ b/packages/ui/react-appkit/src/components/Menubar/SpaceMenu.tsx
@@ -45,7 +45,7 @@ export const SpaceMenu = ({ space, onClickManageSpace }: SpaceMenuProps) => {
       triggerIsInToolbar
     >
       {onClickManageSpace && (
-        <Button className='flex w-full gap-2' onClick={onClickManageSpace}>
+        <Button classNames='flex w-full gap-2' onClick={onClickManageSpace}>
           <Gear className={getSize(5)} />
           <span>{t('manage space label')}</span>
         </Button>

--- a/packages/ui/react-appkit/src/components/Menubar/SpacesLink.tsx
+++ b/packages/ui/react-appkit/src/components/Menubar/SpacesLink.tsx
@@ -18,7 +18,7 @@ export const SpacesLink = ({ onClickGoToSpaces }: SpacesLinkProps) => {
   const { t } = useTranslation('appkit');
   return (
     <Tooltip content={t('back to spaces label')} side='right' tooltipLabelsTrigger triggerIsInToolbar>
-      <Button onClick={onClickGoToSpaces} className='pointer-events-auto flex gap-1'>
+      <Button onClick={onClickGoToSpaces} classNames='pointer-events-auto flex gap-1'>
         <CaretLeft className={getSize(4)} />
         <Planet className={getSize(4)} />
       </Button>

--- a/packages/ui/react-appkit/src/components/ProfileList/ProfileList.tsx
+++ b/packages/ui/react-appkit/src/components/ProfileList/ProfileList.tsx
@@ -33,7 +33,7 @@ export const ProfileList = ({ identities }: ProfileListProps) => {
                 <p>
                   {identity.profile?.displayName ?? humanize(identityHex)}
                   {identityHex === myIdentityHex && (
-                    <Tag palette='info' className='mli-2 align-middle'>
+                    <Tag palette='info' classNames='mli-2 align-middle'>
                       {t('current identity label')}
                     </Tag>
                   )}

--- a/packages/ui/react-appkit/src/components/QrCode/QrCode.tsx
+++ b/packages/ui/react-appkit/src/components/QrCode/QrCode.tsx
@@ -57,7 +57,7 @@ export const FullQrCode = ({ value, label, size, density, elevation, slots = {} 
         <Button
           {...{ density, elevation }}
           {...slots.button}
-          className={mx('overflow-hidden p-0', getSize(size ?? 32), slots.button?.className)}
+          classNames={['overflow-hidden p-0', getSize(size ?? 32), slots.button?.className]}
           onClick={copyValue}
         >
           <QRCodeSVG
@@ -101,7 +101,7 @@ export const CompactQrCode = ({
             <Button
               {...{ density, elevation }}
               {...slots.qrButton}
-              className={mx('border-ie-0 grow rounded-ie-none rounded-is-md', slots.qrButton?.className)}
+              classNames={['border-ie-0 grow rounded-ie-none rounded-is-md', slots.qrButton?.className]}
               aria-labelledby={labelId}
             >
               <QrCodeIcon className={getSize(5)} />
@@ -128,7 +128,7 @@ export const CompactQrCode = ({
             <Button
               {...{ density, elevation }}
               {...slots.copyButton}
-              className={mx('rounded-is-none rounded-ie-md grow', slots.copyButton?.className)}
+              classNames={mx('rounded-is-none rounded-ie-md grow', slots.copyButton?.className)}
               onClick={copyValue}
             >
               <CopySimple className={getSize(5)} />
@@ -142,7 +142,7 @@ export const CompactQrCode = ({
             <Button
               {...{ density, elevation }}
               {...slots.qrButton}
-              className={mx('border-ie-0 flex gap-1 rounded-ie-none rounded-is-md', slots.qrButton?.className)}
+              classNames={['border-ie-0 flex gap-1 rounded-ie-none rounded-is-md', slots.qrButton?.className]}
             >
               <QrCodeIcon className={getSize(5)} />
               {displayQrLabel}
@@ -166,7 +166,7 @@ export const CompactQrCode = ({
         <Button
           {...{ density, elevation }}
           {...slots.copyButton}
-          className={mx('flex gap-1 rounded-ie-md rounded-is-none', slots.copyButton?.className)}
+          classNames={['flex gap-1 rounded-ie-md rounded-is-none', slots.copyButton?.className]}
           onClick={copyValue}
         >
           <CopySimple className={getSize(5)} />

--- a/packages/ui/react-appkit/src/components/SingleInputStep/SingleInputStep.tsx
+++ b/packages/ui/react-appkit/src/components/SingleInputStep/SingleInputStep.tsx
@@ -58,7 +58,7 @@ export const SingleInputStep = ({
         slots={inputSlots}
       />
       <div role='none' aria-live='polite' className='flex gap-4 justify-end items-center'>
-        <Button variant='primary' onClick={onNext} {...(pending && { disabled: true })} className='order-last'>
+        <Button variant='primary' onClick={onNext} {...(pending && { disabled: true })} classNames='order-last'>
           {nextLabel ?? t('next label')}
         </Button>
         {onBack && (

--- a/packages/ui/react-appkit/src/components/SpacesPage/SpacesPage.tsx
+++ b/packages/ui/react-appkit/src/components/SpacesPage/SpacesPage.tsx
@@ -69,14 +69,14 @@ export const SpacesPage = ({
               dialogProps={{
                 defaultOpen: Boolean(invitationParam),
                 openTrigger: (
-                  <Button className='grow flex gap-1'>
+                  <Button classNames='grow flex gap-1'>
                     <Rocket className={getSize(5)} />
                     {t('join space label', { ns: 'appkit' })}
                   </Button>
                 ),
               }}
             />
-            <Button variant='primary' onClick={handleCreateSpace} className='grow flex gap-1'>
+            <Button variant='primary' onClick={handleCreateSpace} classNames='grow flex gap-1'>
               <Plus className={getSize(5)} />
               {t('create space label', { ns: 'appkit' })}
             </Button>

--- a/packages/ui/react-appkit/src/components/SpacesPage/SpacesPageComponent.tsx
+++ b/packages/ui/react-appkit/src/components/SpacesPage/SpacesPageComponent.tsx
@@ -54,7 +54,7 @@ export const SpacesPageComponent = (props: SpacesPageComponentProps) => {
               dialogProps={{
                 defaultOpen: Boolean(invitationParam),
                 openTrigger: (
-                  <Button className='grow flex gap-1'>
+                  <Button classNames='grow flex gap-1'>
                     <Rocket className={getSize(5)} />
                     {t('join space label', { ns: 'appkit' })}
                   </Button>
@@ -67,7 +67,7 @@ export const SpacesPageComponent = (props: SpacesPageComponentProps) => {
                 const space = await client.createSpace();
                 onSpaceCreated?.(space);
               }}
-              className='grow flex gap-1'
+              classNames='grow flex gap-1'
             >
               <Plus className={getSize(5)} />
               {t('create space label', { ns: 'appkit' })}

--- a/packages/ui/react-appkit/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/react-appkit/src/components/Tooltip/Tooltip.tsx
@@ -72,7 +72,7 @@ export const Tooltip = ({
       forceMount
       {...slots.content}
       side={side ?? slots.content?.side ?? 'top'}
-      className={[zIndex, !compact && 'px-4 py-2.5', !isOpen && 'sr-only', slots.content?.className]}
+      classNames={[zIndex, !compact && 'px-4 py-2.5', !isOpen && 'sr-only', slots.content?.classNames]}
     >
       {content}
     </TooltipContent>

--- a/packages/ui/react-appkit/src/components/Tree/JsonTree.tsx
+++ b/packages/ui/react-appkit/src/components/Tree/JsonTree.tsx
@@ -22,10 +22,10 @@ const JsonTreeBranch = ({ data, prefix }: JsonTreeNodeProps) => {
         return (
           <TreeItem key={id} id={id} collapsible={!valueIsScalar}>
             {valueIsScalar ? (
-              <TreeItemHeading className='flex items-center'>{String(value)}</TreeItemHeading>
+              <TreeItemHeading classNames='flex items-center'>{String(value)}</TreeItemHeading>
             ) : (
               <>
-                <TreeItemHeading className='flex items-center'>{key}</TreeItemHeading>
+                <TreeItemHeading classNames='flex items-center'>{key}</TreeItemHeading>
                 <TreeItemBody asChild>
                   <TreeBranch>
                     <JsonTreeBranch data={value} prefix={id} />


### PR DESCRIPTION
This PR adjusts the prop aurora uses for customizing the theme to use `classNames` since it also accepts arrays there.