### PR TITLE
feat(composer-app): Tab without a11y regression

### DIFF
--- a/packages/apps/composer-app/src/layouts/EmbeddedLayout.tsx
+++ b/packages/apps/composer-app/src/layouts/EmbeddedLayout.tsx
@@ -43,13 +43,6 @@ const EmbeddedLayoutImpl = () => {
 
   return (
     <>
-      {space && document ? (
-        <Outlet context={{ space, document, layout: 'embedded' } as OutletContext} />
-      ) : source && id && identityHex ? (
-        <ResolverDialog />
-      ) : (
-        <EmbeddedFirstRunPage />
-      )}
       <div role='none' className='fixed inline-end-2 block-end-2 z-[70] flex gap-2'>
         <Button disabled={!space} onClick={handleInvite}>
           {t('create invitation label', { ns: 'appkit' })}
@@ -71,6 +64,13 @@ const EmbeddedLayoutImpl = () => {
           </Button>
         </ButtonGroup>
       </div>
+      {space && document ? (
+        <Outlet context={{ space, document, layout: 'embedded' } as OutletContext} />
+      ) : source && id && identityHex ? (
+        <ResolverDialog />
+      ) : (
+        <EmbeddedFirstRunPage />
+      )}
     </>
   );
 };

--- a/packages/apps/composer-app/src/layouts/StandaloneLayout.tsx
+++ b/packages/apps/composer-app/src/layouts/StandaloneLayout.tsx
@@ -75,7 +75,7 @@ export const StandaloneLayout = () => {
           <MainOverlay />
           <Sidebar
             {...{
-              className: [defaultOsButtonColors, 'backdrop-blur overflow-visible'],
+              classNames: [defaultOsButtonColors, 'backdrop-blur overflow-visible'],
               onOpenAutoFocus: (event) => event.preventDefault(),
               onCloseAutoFocus: (event) => event.preventDefault(),
             }}

--- a/packages/apps/composer-app/src/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/apps/composer-app/src/pages/DocumentPage/DocumentPage.tsx
@@ -10,7 +10,7 @@ import { useOutletContext } from 'react-router-dom';
 import { Document } from '@braneframe/types';
 import { Button, useTranslation, Trans } from '@dxos/aurora';
 import { Composer, MarkdownComposerRef, TextKind, TipTapEditor } from '@dxos/aurora-composer';
-import { getSize } from '@dxos/aurora-theme';
+import { defaultFocus, getSize, mx } from '@dxos/aurora-theme';
 import { Space } from '@dxos/client';
 import { log } from '@dxos/log';
 import { Input, Dialog, DropdownMenuItem } from '@dxos/react-appkit';
@@ -357,7 +357,7 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
           slots={{
             root: {
               role: 'none',
-              className: 'shrink-0 grow flex flex-col',
+              className: mx(defaultFocus, 'shrink-0 grow flex flex-col'),
               'data-testid': 'composer.markdownRoot',
             } as HTMLAttributes<HTMLDivElement>,
             editor: {

--- a/packages/apps/composer-app/src/pages/DocumentPage/EmbeddedDocumentPage.tsx
+++ b/packages/apps/composer-app/src/pages/DocumentPage/EmbeddedDocumentPage.tsx
@@ -6,7 +6,7 @@ import React, { PropsWithChildren } from 'react';
 
 export const EmbeddedDocumentPage = ({ children }: PropsWithChildren<{}>) => {
   return (
-    <div role='none' className='min-bs-[100vh] flex flex-col'>
+    <div role='none' className='min-bs-[100vh] flex flex-col p-0.5'>
       {children}
     </div>
   );

--- a/packages/ui/aurora-composer/src/components/Markdown/Markdown.tsx
+++ b/packages/ui/aurora-composer/src/components/Markdown/Markdown.tsx
@@ -3,7 +3,7 @@
 //
 
 import { autocompletion, completionKeymap, closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete';
-import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import {
   bracketMatching,
@@ -29,7 +29,7 @@ import {
   rectangularSelection,
   EditorView,
 } from '@codemirror/view';
-import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useState, KeyboardEvent } from 'react';
 import { yCollab } from 'y-codemirror.next';
 
 import { useThemeContext } from '@dxos/aurora';
@@ -85,6 +85,7 @@ export const MarkdownComposer = forwardRef<MarkdownComposerRef, MarkdownComposer
     const [parent, setParent] = useState<HTMLDivElement | null>(null);
     const [state, setState] = useState<EditorState>();
     const [view, setView] = useState<EditorView>();
+
     useImperativeHandle(forwardedRef, () => ({
       editor: parent,
       state,
@@ -143,6 +144,7 @@ export const MarkdownComposer = forwardRef<MarkdownComposerRef, MarkdownComposer
             ...foldKeymap,
             ...completionKeymap,
             ...lintKeymap,
+            indentWithTab,
           ]),
           EditorView.lineWrapping,
           // Theme
@@ -175,6 +177,15 @@ export const MarkdownComposer = forwardRef<MarkdownComposerRef, MarkdownComposer
       };
     }, [parent, content, provider?.awareness, themeMode]);
 
-    return <div key={id} {...slots.root} ref={setParent} />;
+    const escKeyUp = useCallback(
+      ({ key }: KeyboardEvent) => {
+        if (parent && key === 'Escape') {
+          parent.focus();
+        }
+      },
+      [parent],
+    );
+
+    return <div tabIndex={0} onKeyUp={escKeyUp} key={id} {...slots.root} ref={setParent} />;
   },
 );

--- a/packages/ui/aurora/src/components/Button/Button.tsx
+++ b/packages/ui/aurora/src/components/Button/Button.tsx
@@ -27,7 +27,10 @@ const [ButtonGroupProvider, useButtonGroupContext] = createContext<ButtonGroupCo
 });
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ children, density: propsDensity, elevation: propsElevation, variant = 'default', asChild, ...props }, ref) => {
+  (
+    { classNames, children, density: propsDensity, elevation: propsElevation, variant = 'default', asChild, ...props },
+    ref,
+  ) => {
     const { inGroup } = useButtonGroupContext(BUTTON_NAME);
     const { tx } = useThemeContext();
     const elevation = useElevationContext(propsElevation);
@@ -47,7 +50,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             density,
             elevation,
           },
-          props.classNames,
+          classNames,
         )}
         {...(props.disabled && { disabled: true })}
       >


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b262393</samp>

### Summary
🐛💄♻️

<!--
1.  🐛 - This emoji represents a bug fix, which is the case for the first change that corrects a typo in the `StandaloneLayout` component.
2.  💄 - This emoji represents a cosmetic or UI improvement, which is the case for the second and fourth changes that add some padding and styling to the embedded layout and the markdown editor.
3.  ♻️ - This emoji represents a refactor or code improvement, which is the case for the third and fifth changes that simplify the rendering logic and enhance the keyboard interaction of the `EmbeddedDocumentPage` and `Markdown` components.
-->
This pull request improves the user interface and experience of the composer app, especially for the embedded layout of the markdown editor. It refactors some components, adds some styling and keyboard features, and fixes some minor bugs. It mainly affects the files in `packages/apps/composer-app` and `packages/ui/aurora-composer`.

> _We're fixing bugs and styling `EmbeddedLayout`_
> _We're adding features to the `Markdown` and `Button`_
> _We're heaving hard on the code review line_
> _We're making the composer app look fine_

### Walkthrough
*  Refactor the embedded layout logic and structure to simplify the code and improve the appearance and alignment of the document page ([link](https://github.com/dxos/dxos/pull/3207/files?diff=unified&w=0#diff-55e414a49a1b76e7fdc1b1dce7f46d18f1a36ee400f9b3319cbbec472d207c93L46-L52), [link](https://github.com/dxos/dxos/pull/3207/files?diff=unified&w=0#diff-55e414a49a1b76e7fdc1b1dce7f46d18f1a36ee400f9b3319cbbec472d207c93R67-R73), [link](https://github.com/dxos/dxos/pull/3207/files?diff=unified&w=0#diff-885c69fa0fe39b538801d9644438359e97fa54cb75a2e3b07437cda497ebd61dL13-R13), [link](https://github.com/dxos/dxos/pull/3207/files?diff=unified&w=0#diff-885c69fa0fe39b538801d9644438359e97fa54cb75a2e3b07437cda497ebd61dL360-R360), [link](https://github.com/dxos/dxos/pull/3207/files?diff=unified&w=0#diff-6a6c4a22dd5f42fffce9c9f971dc0a6c27f670d3be1c151714b83b87729e277eL9-R9)).


