### PR TITLE
fix: deduplicate signal connections

### DIFF
--- a/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/websocket-signal-manager.ts
@@ -46,6 +46,9 @@ export class WebsocketSignalManager implements SignalManager {
   ) {
     log('Created WebsocketSignalManager', { hosts: this._hosts });
     for (const host of this._hosts) {
+      if (this._servers.has(host.server)) {
+        continue;
+      }
       const server = new SignalClient(
         host.server,
         async (message) => this.onMessage.emit(message),


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e612f71</samp>

### Summary
🚫🕸️🚀

<!--
1.  🚫 - This emoji conveys the idea of skipping or preventing something, which is what the condition does for hosts that are already in the set.
2.  🕸️ - This emoji represents websockets, which are the type of connections that the signal manager creates and manages.
3.  🚀 - This emoji suggests improvement, speed, or performance, which are the goals of this change for the signal manager.
-->
Prevent duplicate websocket connections to the same signal server in `websocket-signal-manager.ts`. This improves the performance and stability of the peer-to-peer network.

> _No duplicate hosts_
> _Signal manager improves_
> _Websockets in spring_

### Walkthrough
*  Prevent duplicate websocket connections to the same server by checking the `_servers` set before creating a new connection ([link](https://github.com/dxos/dxos/pull/3208/files?diff=unified&w=0#diff-d47a5fbdadbc8b50998afe7983dd2333813cfb7a31fbfa4df62d7e0c93d1bff5R49-R51)).


