### PR TITLE
chore: Use REFRESH_TOKEN in extension publish script

### DIFF
--- a/.circleci/scripts/publish-extension.sh
+++ b/.circleci/scripts/publish-extension.sh
@@ -6,27 +6,25 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 ROOT=$(git rev-parse --show-toplevel)
 
 # See https://developer.chrome.com/docs/webstore/using_webstore_api/
+# See how to obtaine ACCESS_TOKEN from REFRESH_TOKEN https://circleci.com/blog/continuously-deploy-a-chrome-extension/
 if [ $BRANCH = "production" ]; then
   pushd $EXTENSION
 
   PACKAGE=${PWD##*/}
-  PACKAGE_CAPS=${PACKAGE^^}
+  PACKAGE_CAPS='DEVTOOLS-EXTENSION'
   PACKAGE_ENV=${PACKAGE_CAPS//-/_}
 
   eval "CLIENT_ID=$"${PACKAGE_ENV}_CLIENT_ID""
   eval "CLIENT_SECRET=$"${PACKAGE_ENV}_CLIENT_SECRET""
-  eval "AUTH_CODE=$"${PACKAGE_ENV}_AUTH_CODE""
+  eval "REFRESH_TOKEN=$"${PACKAGE_ENV}_REFRESH_TOKEN""
   eval "APP_ID=$"${PACKAGE_ENV}_APP_ID""
 
   ZIP_PATH=${ROOT}/artifacts/${PACKAGE}.zip
   mkdir ${ROOT}/artifacts
   zip -r $ZIP_PATH ./out/${PACKAGE}
 
-  # NOTE: you can curl ACCESS_TOKEN only once per hour with AUTH_CODE. 
-  #   That ACCESS_TOKEN will be valid for an hour, and in ideal world you need to store it, because you can not curl it again for this hour.
-  #   In our use case, it is ok to be able to run this script only once per hour and to not store ACCESS_TOKEN anywhere, because extension publish takes more than a day.
   echo ---------------------------------------------------
-  ACCESS_TOKEN=$(curl "https://accounts.google.com/o/oauth2/token" -d "client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&code=$AUTH_CODE&grant_type=authorization_code&redirect_uri=urn:ietf:wg:oauth:2.0:oob" | jq -r .access_token)
+  ACCESS_TOKEN=$(curl "https://accounts.google.com/o/oauth2/token" -d "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token&redirect_uri=urn:ietf:wg:oauth:2.0:oob" | jq -r .access_token)
   echo "${PACKAGE_ENV}: Obtained ACCESS_TOKEN: ${ACCESS_TOKEN}"
 
   echo ---------------------------------------------------


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 47df3c4</samp>

### Summary
:lock::wrench::sparkles:

<!--
1.  :lock: - This emoji can be used to indicate a change related to security, encryption, or authentication, such as using a refresh token instead of an auth code.
2.  :wrench: - This emoji can be used to indicate a change related to fixing, improving, or adjusting something, such as fixing a bug with the package caps variable.
3.  :sparkles: - This emoji can be used to indicate a change related to adding, enhancing, or updating something, such as using a more flexible way of authenticating with the API.
-->
Improved Chrome Web Store authentication and fixed a bug in `.circleci/scripts/publish-extension.sh`. The script now uses a `REFRESH_TOKEN` to access the API and handles `PACKAGE_CAPS` correctly.

> _The script had a bug and a flaw_
> _With `AUTH_CODE` and `PACKAGE_CAPS` raw_
> _But it got a new token_
> _That won't easily be broken_
> _And now it can publish with awe_

### Walkthrough
*  Use `REFRESH_TOKEN` instead of `AUTH_CODE` to obtain `ACCESS_TOKEN` for Chrome Web Store API ([link](https://github.com/dxos/dxos/pull/3210/files?diff=unified&w=0#diff-93c772872a267e00ca5e36929beaf255965dc20845625d046877fb26634d484aL9-R19), [link](https://github.com/dxos/dxos/pull/3210/files?diff=unified&w=0#diff-93c772872a267e00ca5e36929beaf255965dc20845625d046877fb26634d484aL25-R27))
*  Use fixed value for `PACKAGE_CAPS` variable to avoid invalid environment variable names ([link](https://github.com/dxos/dxos/pull/3210/files?diff=unified&w=0#diff-93c772872a267e00ca5e36929beaf255965dc20845625d046877fb26634d484aL9-R19))
*  Add comment with link to blog post on how to get `REFRESH_TOKEN` from `AUTH_CODE` ([link](https://github.com/dxos/dxos/pull/3210/files?diff=unified&w=0#diff-93c772872a267e00ca5e36929beaf255965dc20845625d046877fb26634d484aL9-R19))


