### PR TITLE
feat: Add CLI test

### DIFF
--- a/packages/devtools/cli/src/commands/app/app.test.ts
+++ b/packages/devtools/cli/src/commands/app/app.test.ts
@@ -8,11 +8,18 @@ import path from 'path';
 
 import { describe, test } from '@dxos/test';
 
+import { runCommand } from '../../util';
+
 describe('App', () => {
   const tmpFolder = path.join(__dirname, '../../../tmp/dx');
 
+  afterEach(() => {
+    fs.rmSync(tmpFolder, { recursive: true, force: true });
+  });
+
   test('create', async () => {
     const appName = 'test-app';
+    await runCommand(`app create ${appName}`, tmpFolder);
     expect(fs.existsSync(path.join(tmpFolder, appName, 'dx.yml'))).to.be.true;
   });
 });

--- a/packages/devtools/cli/src/commands/app/app.test.ts
+++ b/packages/devtools/cli/src/commands/app/app.test.ts
@@ -8,7 +8,7 @@ import path from 'path';
 
 import { describe, test } from '@dxos/test';
 
-describe.only('App', () => {
+describe('App', () => {
   const tmpFolder = path.join(__dirname, '../../../tmp/dx');
 
   test('create', async () => {

--- a/packages/devtools/cli/src/commands/app/publish-workflow.test.ts
+++ b/packages/devtools/cli/src/commands/app/publish-workflow.test.ts
@@ -2,34 +2,17 @@
 // Copyright 2023 DXOS.org
 //
 
-import { expect, test } from '@oclif/test';
-import * as fs from 'fs-extra';
-import yaml from 'js-yaml';
+import { expect } from 'chai';
+import fs from 'node:fs';
 import path from 'path';
 
-import { describe } from '@dxos/test';
+import { describe, test } from '@dxos/test';
 
-describe.skip('App', () => {
-  const configPath = path.join(__dirname, '../../../config/config-local.yml');
-  const config = yaml.load(String(fs.readFileSync(configPath))) as any;
+describe.only('App', () => {
+  const tmpFolder = path.join(__dirname, '../../../tmp/dx');
 
-  const tmpFolder = './tmp/dx';
-
-  test
-    .stdout()
-    .stderr()
-    .stdin(`mkdir -p ${tmpFolder}`)
-    .stdin(`pushd ${tmpFolder}`)
-
-    .command(['app create', 'test-app', '--json', '--config', configPath])
-    .command(['app publish', '--configPath', './test-app/dx.yml', '--config', configPath])
-    .command(['app list', '--config', configPath])
-
-    .stdin('popd')
-
-    .it('Create and publish app', (ctx) => {
-      console.log(ctx.stderr);
-      console.log(ctx.stdout);
-      expect(JSON.stringify(JSON.parse(ctx.stdout))).to.equal(JSON.stringify(config));
-    });
+  test('create', async () => {
+    const appName = 'test-app';
+    expect(fs.existsSync(path.join(tmpFolder, appName, 'dx.yml'))).to.be.true;
+  });
 });

--- a/packages/devtools/cli/src/util/index.ts
+++ b/packages/devtools/cli/src/util/index.ts
@@ -8,3 +8,4 @@ export * from './publish';
 export * from './supervisor';
 export * from './telemetry';
 export * from './util';
+export * from './test-util';

--- a/packages/devtools/cli/src/util/test-util.ts
+++ b/packages/devtools/cli/src/util/test-util.ts
@@ -1,0 +1,18 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import path from 'node:path';
+
+import { exec } from './exec';
+
+export const runCommand = async (command: string, cwd: string) => {
+  const bin = path.join(__dirname, '../../bin/run');
+
+  return await exec(`
+    mkdir -p ${cwd} &&
+    pushd ${cwd} &&
+    ${bin} ${command} &&
+    popd
+  `);
+};

--- a/packages/devtools/cli/src/util/test-util.ts
+++ b/packages/devtools/cli/src/util/test-util.ts
@@ -11,8 +11,7 @@ export const runCommand = async (command: string, cwd: string) => {
 
   return await exec(`
     mkdir -p ${cwd} &&
-    pushd ${cwd} &&
-    ${bin} ${command} &&
-    popd
+    cd ${cwd} &&
+    ${bin} ${command}
   `);
 };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1189eff</samp>

### Summary
🧪📦🛠️

<!--
1.  🧪 - This emoji represents testing, experimentation, or science. It can be used to indicate that a change adds or modifies a test file or a test case.
2.  📦 - This emoji represents packaging, bundling, or exporting. It can be used to indicate that a change adds or modifies a module, a dependency, or a distribution file.
3.  🛠️ - This emoji represents tools, fixing, or building. It can be used to indicate that a change adds or modifies a utility, a helper function, or a build script.
-->
This pull request adds a test file for the `app` command of the dxos CLI and a test-util module to run CLI commands in a temporary folder. It also deletes an unused test file for the `publish-workflow` command.

> _`test-util` module_
> _runs CLI commands in temp_
> _autumn leaves fall_

### Walkthrough
* Add a test file for the app command of the CLI ([link](https://github.com/dxos/dxos/pull/3212/files?diff=unified&w=0#diff-820b8fc29d9172e6f757a907500f53cd71c71375cab887420ede246c9698e35eR1-R18)). The test uses the `runCommand` function from the `test-util` module to create an app folder and verify that a `dx.yml` file is generated.


