### PR TITLE
chore(composer-extension): Change name in manifest

### DIFF
--- a/packages/apps/composer-extension/package.json
+++ b/packages/apps/composer-extension/package.json
@@ -2,7 +2,7 @@
   "name": "@dxos/composer-extension",
   "version": "0.1.41",
   "private": true,
-  "description": "Composer Web Extension",
+  "description": "DXOS Composer Web Extension",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
   "repository": "github:dxos/dxos",

--- a/packages/apps/composer-extension/vite.config.ts
+++ b/packages/apps/composer-extension/vite.config.ts
@@ -12,7 +12,8 @@ const generateManifest = () => {
   const packageJson = readJsonFile(resolve(__dirname, 'package.json'));
 
   return {
-    name: packageJson.name,
+    name: 'DXOS Composer',
+    author: 'DXOS.org',
     description: packageJson.description,
     version: packageJson.version,
     ...manifest


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8a5f0ce</samp>

### Summary
📝🏷️🌐

<!--
1.  📝 - This emoji can be used to indicate that the description of the package was updated, as it implies writing or editing text.
2. 🏷️ - This emoji can be used to indicate that the name and author of the manifest were changed, as it implies labeling or tagging something with a different name or identity.
3. 🌐 - This emoji can be used to indicate that the changes are related to the web extension aspect of the package, as it implies the internet or the web.
-->
Updated the package and manifest metadata of the `composer-extension` to reflect the DXOS branding and identity. Renamed the package description and the manifest name and author to avoid confusion with other composer extensions.

> _`DXOS` prefix added_
> _Composer web extension shines_
> _Autumn of branding_

### Walkthrough
*  Update package description to include DXOS prefix ([link](https://github.com/dxos/dxos/pull/3218/files?diff=unified&w=0#diff-83962f302d46802426714f28b83c5340ba0c2e5d931369b860cc19a9bf8e2444L5-R5))
*  Change manifest name and author to match DXOS Composer web extension branding ([link](https://github.com/dxos/dxos/pull/3218/files?diff=unified&w=0#diff-4cdc5d1cfbe23154700bad13022ca67372bede34cab466fa82f6090c2ceebc23L15-R16))


