### PR TITLE
feat: Epochs

### DIFF
--- a/packages/common/feed-store/src/feed-wrapper.ts
+++ b/packages/common/feed-store/src/feed-wrapper.ts
@@ -96,14 +96,7 @@ export class FeedWrapper<T extends {}> {
             this._writeLock.reset();
           }
 
-          const seq = await this.append(data);
-          assert(seq < this.length, 'Invalid seq after write');
-          log('write complete', { feed: this._key, seq });
-          const receipt: WriteReceipt = {
-            feedKey: this.key,
-            seq,
-          };
-
+          const receipt = await this.appendWithReceipt(data);
           await afterWrite?.(receipt);
 
           return receipt;
@@ -116,6 +109,17 @@ export class FeedWrapper<T extends {}> {
         }
       },
     };
+  }
+
+  async appendWithReceipt(data: T): Promise<WriteReceipt> {
+    const seq = await this.append(data);
+    assert(seq < this.length, 'Invalid seq after write');
+    log('write complete', { feed: this._key, seq });
+    const receipt: WriteReceipt = {
+      feedKey: this.key,
+      seq,
+    }
+    return receipt;
   }
 
   get opened() {

--- a/packages/common/feed-store/src/feed-wrapper.ts
+++ b/packages/common/feed-store/src/feed-wrapper.ts
@@ -118,7 +118,7 @@ export class FeedWrapper<T extends {}> {
     const receipt: WriteReceipt = {
       feedKey: this.key,
       seq,
-    }
+    };
     return receipt;
   }
 

--- a/packages/common/typings/src/hypercore.d.ts
+++ b/packages/common/typings/src/hypercore.d.ts
@@ -206,6 +206,9 @@ declare module 'hypercore' {
     // https://github.com/hypercore-protocol/hypercore/tree/v9.12.0#var-bool--feedhasindex
     has(start: number, end?: number): boolean;
 
+    // https://github.com/holepunchto/hypercore/tree/v9.12.0#feedclearstart-end-callback
+    clear (start: number, end?: number, cb?: Callback<void>): void;
+
     // https://github.com/hypercore-protocol/hypercore/tree/v9.12.0#feedheadoptions-callback
     /** @deprecated remove in v10 */
     head(options: any, cb: Callback<T>): void;

--- a/packages/core/echo/echo-pipeline/src/dbhost/database-host.ts
+++ b/packages/core/echo/echo-pipeline/src/dbhost/database-host.ts
@@ -8,7 +8,6 @@ import { EchoProcessor, ItemDemuxer, ItemManager } from '@dxos/echo-db';
 import { FeedWriter } from '@dxos/feed-store';
 import { ModelFactory } from '@dxos/model-factory';
 import { DataMessage } from '@dxos/protocols/proto/dxos/echo/feed';
-import { EchoSnapshot } from '@dxos/protocols/proto/dxos/echo/snapshot';
 
 import { DataServiceHost } from './data-service-host';
 
@@ -22,9 +21,7 @@ export class DatabaseHost {
   private _itemManager!: ItemManager;
   public _itemDemuxer!: ItemDemuxer;
 
-  constructor(
-    private readonly _outboundStream: FeedWriter<DataMessage> | undefined,
-  ) {}
+  constructor(private readonly _outboundStream: FeedWriter<DataMessage> | undefined) {}
 
   get isReadOnly(): boolean {
     return !!this._outboundStream;

--- a/packages/core/echo/echo-pipeline/src/dbhost/database-host.ts
+++ b/packages/core/echo/echo-pipeline/src/dbhost/database-host.ts
@@ -24,7 +24,6 @@ export class DatabaseHost {
 
   constructor(
     private readonly _outboundStream: FeedWriter<DataMessage> | undefined,
-    private readonly _snapshot?: EchoSnapshot,
   ) {}
 
   get isReadOnly(): boolean {
@@ -41,10 +40,6 @@ export class DatabaseHost {
 
     this._itemDemuxer = new ItemDemuxer(itemManager, modelFactory);
     this._echoProcessor = this._itemDemuxer.open();
-
-    if (this._snapshot) {
-      this._itemDemuxer.restoreFromSnapshot(this._snapshot);
-    }
   }
 
   async close() {}

--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -159,11 +159,6 @@ export class MetadataStore {
     await this._save();
   }
 
-  async setSpaceSnapshot(spaceKey: PublicKey, snapshot: string) {
-    this._getSpace(spaceKey).snapshot = snapshot;
-    await this._save();
-  }
-
   async setCache(spaceKey: PublicKey, cache: SpaceCache) {
     this._getSpace(spaceKey).cache = cache;
     await this._save();

--- a/packages/core/echo/echo-pipeline/src/pipeline/pipeline.test.ts
+++ b/packages/core/echo/echo-pipeline/src/pipeline/pipeline.test.ts
@@ -20,10 +20,14 @@ import { range } from '@dxos/util';
 import { TestFeedBuilder } from '../testing';
 import { Pipeline } from './pipeline';
 
+const TEST_MESSAGE: FeedMessage = {
+  timeframe: new Timeframe(),
+  payload: {},
+}
+
 describe('pipeline/Pipeline', () => {
   test('asynchronous reader & writer without ordering', async () => {
-    const pipeline = new Pipeline(new Timeframe());
-    afterTest(() => pipeline.stop());
+    const pipeline = new Pipeline();
 
     const builder = new TestFeedBuilder();
     const feedStore = builder.createFeedStore();
@@ -38,22 +42,7 @@ describe('pipeline/Pipeline', () => {
 
       setTimeout(async () => {
         for (const msgIdx in range(messagesPerFeed)) {
-          await feed.append(
-            checkType<FeedMessage>({
-              timeframe: new Timeframe(),
-              payload: {
-                data: {
-                  batch: {
-                    objects: [
-                      {
-                        objectId: `${feedIdx}-${msgIdx}`,
-                      },
-                    ],
-                  },
-                },
-              },
-            }),
-          );
+          await feed.append(TEST_MESSAGE);
         }
       });
     }
@@ -65,26 +54,64 @@ describe('pipeline/Pipeline', () => {
     pipeline.setWriteFeed(feed);
 
     for (const msgIdx in range(messagesPerFeed)) {
-      await pipeline.writer!.write({
-        data: {
-          batch: {
-            objects: [
-              {
-                objectId: `local-${msgIdx}`,
-              },
-            ],
-          },
-        },
-      });
+      await pipeline.writer!.write({});
     }
 
+    await pipeline.start()
+
     let msgCount = 0;
-    for await (const _ of pipeline.consume()) {
+    for await (const block of pipeline.consume()) {
       if (++msgCount === numFeeds * messagesPerFeed) {
         void pipeline.stop();
       }
     }
   });
+
+  test('reading and writing with cursor changes', async () => {
+    const pipeline = new Pipeline();
+    afterTest(() => pipeline.stop());
+
+    const builder = new TestFeedBuilder();
+    const feedStore = builder.createFeedStore();
+    const key = await builder.keyring.createKey();
+    const feed = await feedStore.openFeed(key, { writable: true });
+    await pipeline.addFeed(feed);
+
+    const numMessages = 30;
+    const sequenceNumbers: number[] = []
+    for(const _ of range(numMessages)) {
+      const { seq } = await feed.appendWithReceipt(TEST_MESSAGE);
+      sequenceNumbers.push(seq);
+    }
+
+    const processedSequenceNumbers: number[] = [];
+
+    // skip first 10, process the rest, and the repeat the last 10.
+    const expectedSequenceNumbers = [
+      ...sequenceNumbers.slice(10, 30),
+      ...sequenceNumbers.slice(20, 30),
+    ]
+
+    await pipeline.setCursor(new Timeframe([[feed.key, 9]]));
+    await pipeline.start();
+
+    for await (const block of pipeline.consume()) {
+      processedSequenceNumbers.push(block.seq);
+
+      if(processedSequenceNumbers.length === 20) {
+        // not awaited to avoid a deadlock.
+        pipeline.pause().then(async () => {
+          await pipeline.setCursor(new Timeframe([[feed.key, 19]]));
+          await pipeline.unpause();
+        })
+      }
+      if(processedSequenceNumbers.length === 30) {
+        void pipeline.stop();
+      }
+    }
+
+    expect(processedSequenceNumbers).toEqual(expectedSequenceNumbers);
+  })
 
   test
     .skip('stress', async () => {
@@ -108,7 +135,8 @@ describe('pipeline/Pipeline', () => {
         }
 
         async start() {
-          this.pipeline = new Pipeline(this.startingTimeframe);
+          this.pipeline = new Pipeline();
+          await this.pipeline.setCursor(this.startingTimeframe);
 
           await this.pipeline.start();
 

--- a/packages/core/echo/echo-pipeline/src/pipeline/pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/pipeline/pipeline.ts
@@ -83,7 +83,7 @@ export class PipelineState {
   }
 
   get feeds() {
-    return Array.from(this._feeds);
+    return Array.from(this._feeds.values());
   }
 
   async waitUntilTimeframe(target: Timeframe) {
@@ -290,7 +290,9 @@ export class Pipeline implements PipelineAccessor {
   @synchronized
   async pause() {
     assert(this._isStarted, 'Pipeline is not open.');
-    assert(!this._isPaused, 'Pipeline is already paused.');
+    if(this._isPaused) {
+      return;
+    }
 
     this._pauseTrigger.reset();
     await this._processingTrigger.wait();

--- a/packages/core/echo/echo-pipeline/src/pipeline/pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/pipeline/pipeline.ts
@@ -6,18 +6,18 @@ import assert from 'node:assert';
 
 import { Event, sleep, synchronized, Trigger } from '@dxos/async';
 import { Context, rejectOnDispose } from '@dxos/context';
+import { failUndefined } from '@dxos/debug';
 import { FeedSetIterator, FeedWrapper, FeedWriter } from '@dxos/feed-store';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { FeedMessageBlock } from '@dxos/protocols';
 import type { FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
 import { Timeframe } from '@dxos/timeframe';
+import { ComplexMap } from '@dxos/util';
 
 import { createMappedFeedWriter } from '../common';
 import { createMessageSelector } from './message-selector';
 import { mapFeedIndexesToTimeframe, startAfter, TimeframeClock } from './timeframe-clock';
-import { failUndefined } from '@dxos/debug';
-import { ComplexMap } from '@dxos/util';
 
 export type WaitUntilReachedTargetParams = {
   /**
@@ -227,7 +227,7 @@ export class Pipeline implements PipelineAccessor {
   // which might be opening feeds during the mutation processing, which w
   async addFeed(feed: FeedWrapper<FeedMessage>) {
     this._feeds.set(feed.key, feed);
-    if(this._feedSetIterator) {
+    if (this._feedSetIterator) {
       await this._feedSetIterator.addFeed(feed);
     }
   }
@@ -277,7 +277,7 @@ export class Pipeline implements PipelineAccessor {
 
     this._timeframeClock.setTimeframe(timeframe);
 
-    if(this._feedSetIterator) {
+    if (this._feedSetIterator) {
       await this._feedSetIterator.close();
       await this._initIterator();
       await this._feedSetIterator.open();
@@ -290,7 +290,7 @@ export class Pipeline implements PipelineAccessor {
   @synchronized
   async pause() {
     assert(this._isStarted, 'Pipeline is not open.');
-    if(this._isPaused) {
+    if (this._isPaused) {
       return;
     }
 
@@ -320,18 +320,18 @@ export class Pipeline implements PipelineAccessor {
     let lastFeedSetIterator = this._feedSetIterator;
     let iterable = lastFeedSetIterator[Symbol.asyncIterator]();
 
-    while(!this._isStopping) {
+    while (!this._isStopping) {
       await this._pauseTrigger.wait();
 
       // Iterator might have been changed while we were waiting for the processing to complete.
-      if(lastFeedSetIterator !== this._feedSetIterator) {
+      if (lastFeedSetIterator !== this._feedSetIterator) {
         assert(this._feedSetIterator, 'Iterator not initialized.');
         lastFeedSetIterator = this._feedSetIterator;
         iterable = lastFeedSetIterator[Symbol.asyncIterator]();
       }
 
       const { done, value } = await iterable.next();
-      if(done) {
+      if (done) {
         continue;
       }
 
@@ -358,7 +358,7 @@ export class Pipeline implements PipelineAccessor {
       this._state.stalled.emit();
     });
 
-    for(const feed of this._feeds.values()) {
+    for (const feed of this._feeds.values()) {
       await this._feedSetIterator.addFeed(feed);
     }
   }

--- a/packages/core/echo/echo-pipeline/src/pipeline/timeframe-clock.ts
+++ b/packages/core/echo/echo-pipeline/src/pipeline/timeframe-clock.ts
@@ -48,6 +48,12 @@ export class TimeframeClock {
     return this._pendingTimeframe;
   }
 
+  setTimeframe(timeframe: Timeframe) {
+    this._timeframe = timeframe;
+    this._pendingTimeframe = timeframe;
+    this.update.emit(this._timeframe);
+  }
+
   updatePendingTimeframe(key: PublicKey, seq: number) {
     this._pendingTimeframe = Timeframe.merge(this._pendingTimeframe, new Timeframe([[key, seq]]));
   }

--- a/packages/core/echo/echo-pipeline/src/pipeline/timeframe-clock.ts
+++ b/packages/core/echo/echo-pipeline/src/pipeline/timeframe-clock.ts
@@ -70,7 +70,7 @@ export class TimeframeClock {
 
   @timed(5_000)
   async waitUntilReached(target: Timeframe) {
-    log.info('waitUntilReached', { target, current: this._timeframe });
+    log('waitUntilReached', { target, current: this._timeframe });
     await this.update.waitForCondition(() => {
       log('check if reached', {
         target,

--- a/packages/core/echo/echo-pipeline/src/space/control-pipeline.test.ts
+++ b/packages/core/echo/echo-pipeline/src/space/control-pipeline.test.ts
@@ -45,7 +45,6 @@ describe('space/control-pipeline', () => {
     const controlPipeline = new ControlPipeline({
       spaceKey,
       genesisFeed,
-      initialTimeframe: new Timeframe(),
       feedProvider: (key) => feedStore.openFeed(key),
     });
 

--- a/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
@@ -10,6 +10,7 @@ import type { FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
 import { AdmittedFeed, Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
 import { Timeframe } from '@dxos/timeframe';
 import { AsyncCallback, Callback } from '@dxos/util';
+import assert from 'node:assert';
 
 import { Pipeline, PipelineAccessor } from '../pipeline';
 
@@ -17,7 +18,6 @@ export type ControlPipelineParams = {
   spaceKey: PublicKey;
   genesisFeed: FeedWrapper<FeedMessage>;
   feedProvider: (feedKey: PublicKey) => Promise<FeedWrapper<FeedMessage>>;
-  initialTimeframe?: Timeframe;
 };
 
 /**
@@ -31,8 +31,8 @@ export class ControlPipeline {
   public readonly onMemberAdmitted: Callback<AsyncCallback<MemberInfo>>;
   public readonly onCredentialProcessed: Callback<AsyncCallback<Credential>>;
 
-  constructor({ spaceKey, genesisFeed, feedProvider, initialTimeframe }: ControlPipelineParams) {
-    this._pipeline = new Pipeline(initialTimeframe);
+  constructor({ spaceKey, genesisFeed, feedProvider }: ControlPipelineParams) {
+    this._pipeline = new Pipeline();
     void this._pipeline.addFeed(genesisFeed); // TODO(burdon): Require async open/close?
 
     this._spaceStateMachine = new SpaceStateMachine(spaceKey);

--- a/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
@@ -8,9 +8,7 @@ import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import type { FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
 import { AdmittedFeed, Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
-import { Timeframe } from '@dxos/timeframe';
 import { AsyncCallback, Callback } from '@dxos/util';
-import assert from 'node:assert';
 
 import { Pipeline, PipelineAccessor } from '../pipeline';
 

--- a/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
@@ -134,7 +134,8 @@ export class DataPipeline {
       this._lastAutomaticSnapshotTimeframe = this._snapshot?.timeframe ?? new Timeframe();
     }
 
-    this._pipeline = new Pipeline(this.getStartTimeframe());
+    this._pipeline = new Pipeline();
+    // TODO(dmaretskyi): Set cursor.
     await this._params.onPipelineCreated(this._pipeline);
     if (this._targetTimeframe) {
       this._pipeline.state.setTargetTimeframe(this._targetTimeframe);

--- a/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
@@ -303,6 +303,8 @@ export class DataPipeline {
     assert(this._isOpen) // TODO: In the future we might process epochs before we are open so that data pipeline starts from the last one.
     assert(this._pipeline);
 
+    // TODO(dmaretskyi): Reset db to snapshot.
+
     await this._pipeline.pause();
     await this._pipeline.setCursor(epoch.timeframe);
     await this._pipeline.unpause();

--- a/packages/core/echo/echo-pipeline/src/space/space-manager.browser.test.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space-manager.browser.test.ts
@@ -22,11 +22,11 @@ describe('space-manager', () => {
     afterTest(async () => await builder.close());
 
     const peer1 = await builder.createPeer();
-    const spaceManager1 = peer1.createSpaceManager();
+    const spaceManager1 = peer1.spaceManager;
     await spaceManager1.open();
 
     const peer2 = await builder.createPeer();
-    const spaceManager2 = peer2.createSpaceManager();
+    const spaceManager2 = peer2.spaceManager;
     await spaceManager2.open();
 
     afterTest(() => spaceManager1.close());

--- a/packages/core/echo/echo-pipeline/src/space/space-manager.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space-manager.ts
@@ -95,7 +95,6 @@ export class SpaceManager {
       metadataStore: this._metadataStore,
       snapshotManager,
       memberKey,
-      snapshotId: metadata.snapshot,
     });
     this._spaces.set(space.key, space);
     log.trace('dxos.echo.space-manager.construct-space', trace.end({ id: this._instanceId }));

--- a/packages/core/echo/echo-pipeline/src/space/space.test.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space.test.ts
@@ -4,13 +4,13 @@
 
 import expect from 'expect';
 import assert from 'node:assert';
+import { promisify } from 'node:util';
 
-import { createCredential, createCredentialMessage, CredentialGenerator } from '@dxos/credentials';
+import { createCredential, CredentialGenerator } from '@dxos/credentials';
+import { log } from '@dxos/log';
 import { afterTest, describe, test } from '@dxos/test';
 
 import { TestAgentBuilder, testLocalDatabase } from '../testing';
-import { log } from '@dxos/log';
-import { promisify } from 'node:util';
 
 // TODO(burdon): Factor out?
 const run = <T>(cb: () => Promise<T>): Promise<T> => cb();
@@ -54,7 +54,6 @@ describe('space/space', () => {
       await space.open();
       expect(space.isOpen).toBeTruthy();
       afterTest(() => space.close());
-
 
       await agent.spaceGenesis(space);
 
@@ -197,19 +196,19 @@ describe('space/space', () => {
           issuer: agent.identityKey,
           subject: space1.key,
           assertion: {
-            '@type': "dxos.halo.credentials.Epoch",
+            '@type': 'dxos.halo.credentials.Epoch',
             ...epoch,
           },
           signer: agent.keyring,
-        })
-      }
+        }),
+      },
     });
 
     await space1.close();
     expect(space1.isOpen).toBeFalsy();
 
     // Clear the data feed - epoch snapshot should have the data.
-    const feed = await agent.feedStore.openFeed(space1.dataFeedKey!)
+    const feed = await agent.feedStore.openFeed(space1.dataFeedKey!);
     await promisify(feed.core.clear.bind(feed.core))(0, feed.length);
 
     log.break();

--- a/packages/core/echo/echo-pipeline/src/space/space.test.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space.test.ts
@@ -46,6 +46,7 @@ describe('space/space', () => {
     }
 
     await space.initializeDataPipeline();
+    await space.dataPipeline.ensureEpochInitialized();
 
     assert(space.dataPipeline.databaseHost);
     await testLocalDatabase(space.dataPipeline);
@@ -88,6 +89,7 @@ describe('space/space', () => {
       }
 
       await space.initializeDataPipeline();
+      await space.dataPipeline.ensureEpochInitialized();
 
       return [agent, space];
     });
@@ -130,6 +132,7 @@ describe('space/space', () => {
     }
 
     await space2.initializeDataPipeline();
+    await space2.dataPipeline.ensureEpochInitialized();
 
     {
       // Initial data exchange.

--- a/packages/core/echo/echo-pipeline/src/space/space.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space.ts
@@ -239,6 +239,7 @@ export class Space {
   }
 
   async initializeDataPipeline() {
+    log.info('initializeDataPipeline');
     assert(this._isOpen, 'Space must be open to initialize data pipeline.');
     await this._dataPipeline.open();
     await this._dataPipelineCredentialConsumer.open();

--- a/packages/core/echo/echo-pipeline/src/space/space.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space.ts
@@ -131,7 +131,6 @@ export class Space {
             }
           }
         });
-        await pipeline.start();
       },
     });
     this._dataPipelineCredentialConsumer = this._controlPipeline.spaceState.registerProcessor(

--- a/packages/core/echo/echo-pipeline/src/space/space.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space.ts
@@ -228,8 +228,6 @@ export class Space {
     if (!this._isOpen) {
       return;
     }
-
-    
     await this._dataPipelineCredentialConsumer?.close();
     this._dataPipelineCredentialConsumer = undefined;
 

--- a/packages/core/echo/echo-pipeline/src/testing/database-test-rig.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/database-test-rig.ts
@@ -64,31 +64,29 @@ export class DatabaseTestPeer {
 
   async open() {
     this.hostItems = new ItemManager(this.modelFactory);
-    this.host = new DatabaseHost(
-      {
-        write: async (message) => {
-          const seq =
-            this.feedMessages.push({
-              timeframe: this.timeframe,
-              payload: {
-                data: message,
-              },
-            }) - 1;
+    this.host = new DatabaseHost({
+      write: async (message) => {
+        const seq =
+          this.feedMessages.push({
+            timeframe: this.timeframe,
+            payload: {
+              data: message,
+            },
+          }) - 1;
 
-          await this._onConfirm.waitFor(() => this.confirmed >= seq);
-          return {
-            seq,
-            feedKey: this.key,
-          };
-        },
+        await this._onConfirm.waitFor(() => this.confirmed >= seq);
+        return {
+          seq,
+          feedKey: this.key,
+        };
       },
-    );
-    
+    });
+
     await this.host.open(this.hostItems, this.modelFactory);
-    if(this.snapshot) {
-      this.host._itemDemuxer.restoreFromSnapshot(this.snapshot.database)
+    if (this.snapshot) {
+      this.host._itemDemuxer.restoreFromSnapshot(this.snapshot.database);
     }
-    
+
     this.proxy = new DatabaseProxy(this.host.createDataServiceHost(), SPACE_KEY);
     this.items = new ItemManager(this.modelFactory);
     await this.proxy.open(this.items, this.modelFactory);

--- a/packages/core/echo/echo-pipeline/src/testing/database-test-rig.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/database-test-rig.ts
@@ -82,10 +82,13 @@ export class DatabaseTestPeer {
           };
         },
       },
-      this.snapshot?.database,
     );
+    
     await this.host.open(this.hostItems, this.modelFactory);
-
+    if(this.snapshot) {
+      this.host._itemDemuxer.restoreFromSnapshot(this.snapshot.database)
+    }
+    
     this.proxy = new DatabaseProxy(this.host.createDataServiceHost(), SPACE_KEY);
     this.items = new ItemManager(this.modelFactory);
     await this.proxy.open(this.items, this.modelFactory);

--- a/packages/core/echo/echo-pipeline/src/testing/test-agent-builder.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/test-agent-builder.ts
@@ -7,7 +7,6 @@ import { DocumentModel } from '@dxos/document-model';
 import { FeedStore } from '@dxos/feed-store';
 import { Keyring } from '@dxos/keyring';
 import { PublicKey } from '@dxos/keys';
-import { log } from '@dxos/log';
 import { MemorySignalManager, MemorySignalManagerContext, WebsocketSignalManager } from '@dxos/messaging';
 import { ModelFactory } from '@dxos/model-factory';
 import { createWebRTCTransportFactory, MemoryTransportFactory, NetworkManager } from '@dxos/network-manager';
@@ -18,7 +17,7 @@ import { createStorage, Storage, StorageType } from '@dxos/random-access-storage
 import { Gossip, Presence } from '@dxos/teleport-extension-gossip';
 import { ComplexMap } from '@dxos/util';
 
-import { SnapshotManager, SnapshotStore } from '../dbhost';
+import { SnapshotStore } from '../dbhost';
 import { MetadataStore } from '../metadata';
 import { MOCK_AUTH_PROVIDER, MOCK_AUTH_VERIFIER, Space, SpaceManager, SpaceProtocol } from '../space';
 import { TestFeedBuilder } from './test-feed-builder';
@@ -27,19 +26,19 @@ export type NetworkManagerProvider = () => NetworkManager;
 
 export const MemoryNetworkManagerProvider =
   (signalContext: MemorySignalManagerContext): NetworkManagerProvider =>
-    () =>
-      new NetworkManager({
-        signalManager: new MemorySignalManager(signalContext),
-        transportFactory: MemoryTransportFactory,
-      });
+  () =>
+    new NetworkManager({
+      signalManager: new MemorySignalManager(signalContext),
+      transportFactory: MemoryTransportFactory,
+    });
 
 export const WebsocketNetworkManagerProvider =
   (signalUrl: string): NetworkManagerProvider =>
-    () =>
-      new NetworkManager({
-        signalManager: new WebsocketSignalManager([{ server: signalUrl }]),
-        transportFactory: createWebRTCTransportFactory(),
-      });
+  () =>
+    new NetworkManager({
+      signalManager: new WebsocketSignalManager([{ server: signalUrl }]),
+      transportFactory: createWebRTCTransportFactory(),
+    });
 
 export type TestAgentBuilderOptions = {
   storage?: Storage;
@@ -96,15 +95,14 @@ export class TestAgent {
   public readonly keyring: Keyring;
   public readonly feedStore: FeedStore<FeedMessage>;
 
-
   private _metadataStore?: MetadataStore;
   get metadataStore() {
-    return this._metadataStore ??= new MetadataStore(this.storage.createDirectory('metadata'));
+    return (this._metadataStore ??= new MetadataStore(this.storage.createDirectory('metadata')));
   }
 
   private _snapshotStore?: SnapshotStore;
   get snapshotStore() {
-    return this._snapshotStore ??= new SnapshotStore(this.storage.createDirectory('snapshots'));
+    return (this._snapshotStore ??= new SnapshotStore(this.storage.createDirectory('snapshots')));
   }
 
   public modelFactory = new ModelFactory().registerModel(DocumentModel);
@@ -134,13 +132,13 @@ export class TestAgent {
 
   private _spaceManager?: SpaceManager;
   get spaceManager() {
-    return this._spaceManager ??= new SpaceManager({
+    return (this._spaceManager ??= new SpaceManager({
       feedStore: this.feedStore,
       networkManager: this._networkManagerProvider(),
       modelFactory: this.modelFactory,
       metadataStore: this.metadataStore,
       snapshotStore: this.snapshotStore,
-    });
+    }));
   }
 
   async createSpace(
@@ -159,7 +157,7 @@ export class TestAgent {
     }
 
     const controlFeed = await this.feedStore.openFeed(genesisKey, { writable: true });
-    const dataFeed = await this.feedStore.openFeed(dataKey ?? await this.keyring.createKey(), { writable: true });
+    const dataFeed = await this.feedStore.openFeed(dataKey ?? (await this.keyring.createKey()), { writable: true });
 
     const metadata: SpaceMetadata = {
       key: spaceKey,
@@ -167,7 +165,7 @@ export class TestAgent {
       controlFeedKey: controlFeed.key,
       dataFeedKey: dataFeed.key,
     };
-    if(saveMetadata) {
+    if (saveMetadata) {
       await this.metadataStore.addSpace(metadata);
     }
 
@@ -185,7 +183,7 @@ export class TestAgent {
           'dxos.mesh.teleport.gossip',
           this.createGossip().createExtension({ remotePeerId: session.remotePeerId }),
         );
-      }
+      },
     });
     space.setControlFeed(controlFeed);
     space.setDataFeed(dataFeed);

--- a/packages/core/echo/echo-pipeline/src/testing/test-agent-builder.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/test-agent-builder.ts
@@ -147,8 +147,11 @@ export class TestAgent {
     identityKey: PublicKey = this.identityKey,
     spaceKey?: PublicKey,
     genesisKey?: PublicKey,
+    dataKey?: PublicKey,
   ): Promise<Space> {
+    let saveMetadata = false;
     if (!spaceKey) {
+      saveMetadata = true;
       spaceKey = await this.keyring.createKey();
     }
     if (!genesisKey) {
@@ -156,7 +159,7 @@ export class TestAgent {
     }
 
     const controlFeed = await this.feedStore.openFeed(genesisKey, { writable: true });
-    const dataFeed = await this.feedStore.openFeed(await this.keyring.createKey(), { writable: true });
+    const dataFeed = await this.feedStore.openFeed(dataKey ?? await this.keyring.createKey(), { writable: true });
 
     const metadata: SpaceMetadata = {
       key: spaceKey,
@@ -164,7 +167,9 @@ export class TestAgent {
       controlFeedKey: controlFeed.key,
       dataFeedKey: dataFeed.key,
     };
-    await this.metadataStore.addSpace(metadata);
+    if(saveMetadata) {
+      await this.metadataStore.addSpace(metadata);
+    }
 
     await this.spaceManager.open();
     const space = await this.spaceManager.constructSpace({

--- a/packages/core/echo/echo-pipeline/src/testing/util.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/util.ts
@@ -72,7 +72,7 @@ export const testLocalDatabase = async (create: DataPipeline, check: DataPipelin
   });
 
   await asyncTimeout(
-    check.databaseHost!._itemDemuxer.mutation.waitForCondition(() => check._itemManager.entities.has(objectId)),
+    check.databaseHost!._itemDemuxer.mutation.waitForCondition(() => check.itemManager.entities.has(objectId)),
     500,
   );
 };

--- a/packages/core/echo/echo-pipeline/src/testing/util.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/util.ts
@@ -16,7 +16,7 @@ import { DataPipeline } from '../space';
 
 export const createMemoryDatabase = async (modelFactory: ModelFactory) => {
   const feed = new MockFeedWriter<DataMessage>();
-  const backend = new DatabaseHost(feed, undefined);
+  const backend = new DatabaseHost(feed);
 
   feed.written.on(([data, meta]) =>
     backend.echoProcessor({

--- a/packages/core/protocols/src/proto/dxos/echo/metadata.proto
+++ b/packages/core/protocols/src/proto/dxos/echo/metadata.proto
@@ -58,9 +58,6 @@ message SpaceMetadata {
   // Latest data timeframe reached while processing space messages.
   optional timeframe.TimeframeVector data_timeframe = 5;
 
-  optional string snapshot = 7;
-
-
   optional SpaceCache cache = 9;
 }
 

--- a/packages/sdk/client-services/src/packlets/logging/logging-service.ts
+++ b/packages/sdk/client-services/src/packlets/logging/logging-service.ts
@@ -66,7 +66,7 @@ const jsonify = (value: any, handles = new WeakSet<any>()): any => {
     handles.add(value);
 
     if (Array.isArray(value)) {
-      return value.map(x => jsonify(x, handles));
+      return value.map((x) => jsonify(x, handles));
     } else {
       if (typeof value.toJSON === 'function') {
         return value.toJSON();

--- a/packages/sdk/client-services/src/packlets/logging/logging-service.ts
+++ b/packages/sdk/client-services/src/packlets/logging/logging-service.ts
@@ -56,19 +56,24 @@ export class LoggingServiceImpl implements LoggingService {
 /**
  * Recursively converts an object into a JSON-compatible object.
  */
-const jsonify = (value: any): any => {
+const jsonify = (value: any, handles = new WeakSet<any>()): any => {
   if (typeof value === 'function') {
     return null;
   } else if (typeof value === 'object' && value !== null) {
+    if (handles.has(value)) {
+      return null;
+    }
+    handles.add(value);
+
     if (Array.isArray(value)) {
-      return value.map(jsonify);
+      return value.map(x => jsonify(x, handles));
     } else {
       if (typeof value.toJSON === 'function') {
         return value.toJSON();
       }
       const res: any = {};
       for (const key of Object.keys(value)) {
-        res[key] = jsonify(value[key]);
+        res[key] = jsonify(value[key], handles);
       }
       return res;
     }

--- a/packages/sdk/client-services/src/packlets/spaces/data-space.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space.ts
@@ -4,7 +4,7 @@
 
 import { Event, scheduleTask, trackLeaks } from '@dxos/async';
 import { SpaceState } from '@dxos/client';
-import { Context } from '@dxos/context';
+import { cancelWithContext, Context } from '@dxos/context';
 import { CredentialConsumer } from '@dxos/credentials';
 import { timed } from '@dxos/debug';
 import { MetadataStore, Space, createMappedFeedWriter, DataPipeline } from '@dxos/echo-pipeline';
@@ -196,6 +196,9 @@ export class DataSpace {
     );
 
     await this._inner.initializeDataPipeline();
+
+    // Wait for the first epoch.
+    await cancelWithContext(this._ctx, this._inner.dataPipeline.onNewEpoch.waitForCondition(() => !!this._inner.dataPipeline.currentEpoch));
 
     log('waiting for data pipeline to reach target timeframe');
     // Wait for the data pipeline to catch up to its desired timeframe.

--- a/packages/sdk/client-services/src/packlets/spaces/data-space.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space.ts
@@ -198,7 +198,7 @@ export class DataSpace {
     await this._inner.initializeDataPipeline();
 
     // Wait for the first epoch.
-    await cancelWithContext(this._ctx, this._inner.dataPipeline.onNewEpoch.waitForCondition(() => !!this._inner.dataPipeline.currentEpoch));
+    await cancelWithContext(this._ctx, this._inner.dataPipeline.ensureEpochInitialized());
 
     log('waiting for data pipeline to reach target timeframe');
     // Wait for the data pipeline to catch up to its desired timeframe.


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 23634d8</samp>

### Summary
🗑️🛠️🆕

<!--
1.  🗑️ - This emoji represents the removal of unused or obsolete code, such as the `setSpaceSnapshot` method, the `initialTimeframe` parameter, the `snapshotId` property, the `snapshot` field, and the snapshot-related functionality in the `DatabaseHost` class.
2.  🛠️ - This emoji represents the refactoring and improvement of existing code, such as the extraction of the `appendWithReceipt` method, the simplification of the `DatabaseTestPeer` and `ControlPipeline` modules, the refactoring of the `Pipeline`, `DataPipeline`, `Space`, `TestAgent`, and `util` modules, and the improvement of the `jsonify` function and the `DataSpace` opening process.
3.  🆕 - This emoji represents the addition of new features or functionality, such as the new `stalled` event in the `PipelineState` class, the new properties and methods for epoch processing and state restoration in the `DataPipeline` class, the new tests for space lifecycle and epoch creation in the `Space` test module, and the new method to generate genesis credentials for spaces in the `TestAgent` class.
-->
This pull request refactors and improves the echo pipeline and related modules, by removing the snapshot dependency, using epoch assertions, simplifying the feed and timeframe management, adding new events and tests, and fixing some bugs. It also updates the metadata proto file and the logging service module accordingly. The main affected files are `pipeline.ts`, `data-pipeline.ts`, `space.ts`, `test-agent-builder.ts`, and `logging-service.ts`.

> _Sing, O Muse, of the mighty pull request_
> _That cleansed the code of snapshot-related mess_
> _And refactored the pipeline of data and control_
> _To handle the epochs of the echo soul_

### Walkthrough
*  Refactor the logic of appending data to a feed and getting a receipt into a separate method `appendWithReceipt` in `feed-wrapper.ts` ([link](https://github.com/dxos/dxos/pull/3220/files?diff=unified&w=0#diff-64fa5ed50276a5b9c275e0a0c5783bf20564f732925405ced87a10f9fd6dc8d5L99-R99),[link](https://github.com/dxos/dxos/pull/3220/files?diff=unified&w=0#diff-64fa5ed50276a5b9c275e0a0c5783bf20564f732925405ced87a10f9fd6dc8d5R114-R124)).


