### PR TITLE
fix(composer-app): Spacing & pending space list items

### DIFF
--- a/packages/apps/composer-app/src/components/Sidebar/FullSpaceTreeItem.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/FullSpaceTreeItem.tsx
@@ -100,13 +100,13 @@ export const FullSpaceTreeItem = observer(({ space }: { space: Space }) => {
   return (
     <TreeItem
       collapsible
-      open={open}
-      onOpenChange={setOpen}
+      open={!disabled && open}
+      onOpenChange={(nextOpen) => setOpen(disabled ? false : nextOpen)}
       classNames={['mbe-1 block', disabled && defaultDisabled]}
       {...(disabled && { 'aria-disabled': true })}
     >
       <div role='none' className='flex mis-1 items-start'>
-        <TreeItemOpenTrigger {...(!sidebarOpen && { tabIndex: -1 })}>
+        <TreeItemOpenTrigger disabled={disabled} {...(!sidebarOpen && { tabIndex: -1 })}>
           <OpenTriggerIcon
             {...(hasActiveDocument && !open && { weight: 'fill', className: 'text-primary-500 dark:text-primary-300' })}
           />

--- a/packages/apps/composer-app/src/pages/DocumentPage/StandaloneDocumentPage.tsx
+++ b/packages/apps/composer-app/src/pages/DocumentPage/StandaloneDocumentPage.tsx
@@ -35,7 +35,10 @@ export const StandaloneDocumentPage = observer(
           role='none'
           className='mli-auto max-is-[50rem] min-bs-[100vh] bg-white/20 dark:bg-neutral-850/20 flex flex-col'
         >
-          <div role='none' className='flex items-center gap-2 bg-neutral-500/20 pis-0 pointer-fine:pis-8 lg:pis-0'>
+          <div
+            role='none'
+            className='flex items-center gap-2 bg-neutral-500/20 pis-0 pointer-fine:pis-8 lg:pis-0 pointer-fine:lg:pis-0'
+          >
             <Input
               key={document.id}
               variant='subdued'

--- a/packages/apps/composer-app/src/pages/DocumentPage/StandaloneDocumentPage.tsx
+++ b/packages/apps/composer-app/src/pages/DocumentPage/StandaloneDocumentPage.tsx
@@ -33,7 +33,7 @@ export const StandaloneDocumentPage = observer(
       <>
         <div
           role='none'
-          className='mli-auto max-is-[50rem] min-bs-[100vh] bg-white/20 dark:bg-neutral-850/20 flex flex-col'
+          className='mli-auto max-is-[60rem] min-bs-[100vh] bg-white/20 dark:bg-neutral-850/20 flex flex-col'
         >
           <div
             role='none'


### PR DESCRIPTION
Resolves #3222.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 46ecd21</samp>

### Summary
🔒🌲📄

<!--
1.  🔒 for the locking and unlocking feature
2.  🌲 for the tree component modification
3.  📄 for the document page UI improvement
-->
This pull request adds a feature to lock and unlock spaces and documents in the composer app, and improves the responsiveness and consistency of the standalone document page. It modifies the `FullSpaceTreeItem` and `TreeItemOpenTrigger` components to handle the locking logic, and adjusts the width and padding of the document title input in `StandaloneDocumentPage.tsx`.

> _`FullSpaceTreeItem`_
> _locks and unlocks with a click_
> _a new feature blooms_

### Walkthrough
*  Prevent disabled spaces and documents from opening or closing in the sidebar ([link](https://github.com/dxos/dxos/pull/3223/files?diff=unified&w=0#diff-9381d8cc5a751972e73014363c87e8436f6d41ded419c8fdecb3b093103a2608L103-R109))
* Increase maximum width and remove left padding of standalone document page ([link](https://github.com/dxos/dxos/pull/3223/files?diff=unified&w=0#diff-c74d1db15adcba24f36188ee32b8a257c6d61cae1bc9b4e8ac696d3359e93446L36-R41))


