### PR TITLE
chore: Add restart method in Daemon

### DIFF
--- a/packages/devtools/cli/src/commands/daemon/list.ts
+++ b/packages/devtools/cli/src/commands/daemon/list.ts
@@ -1,6 +1,4 @@
 //
-
-//
 // Copyright 2023 DXOS.org
 //
 

--- a/packages/devtools/cli/src/commands/daemon/restart.ts
+++ b/packages/devtools/cli/src/commands/daemon/restart.ts
@@ -6,9 +6,9 @@ import { Flags } from '@oclif/core';
 
 import { BaseCommand } from '../../base-command';
 
-export default class Stop extends BaseCommand {
+export default class Restart extends BaseCommand {
   static override enableJsonFlag = true;
-  static override description = 'Stop daemon process.';
+  static override description = 'Restart daemon process.';
 
   static override flags = {
     ...BaseCommand.flags,
@@ -20,10 +20,9 @@ export default class Stop extends BaseCommand {
 
   async run(): Promise<any> {
     return await this.execWithDaemon(async (daemon) => {
-      const params = await this.parse(Stop);
-      await daemon.stop(params.flags.profile);
-
-      this.log('Stopped');
+      const params = await this.parse(Restart);
+      await daemon.restart(params.flags.profile);
+      this.log('Restarted');
     });
   }
 }

--- a/packages/devtools/cli/src/commands/daemon/run.ts
+++ b/packages/devtools/cli/src/commands/daemon/run.ts
@@ -5,6 +5,7 @@
 //
 
 import { Flags } from '@oclif/core';
+import assert from 'node:assert';
 
 import { BaseCommand } from '../../base-command';
 import { runServices } from '../../daemon';
@@ -29,7 +30,8 @@ export default class Run extends BaseCommand {
     const {
       flags: { listen, profile },
     } = await this.parse(Run);
-    await runServices({ listen, profile });
+    assert(this.clientConfig);
+    await runServices({ listen, profile, config: this.clientConfig });
 
     this.log('daemon started');
   }

--- a/packages/devtools/cli/src/commands/halo/share.ts
+++ b/packages/devtools/cli/src/commands/halo/share.ts
@@ -5,7 +5,7 @@
 import { ux } from '@oclif/core';
 import chalk from 'chalk';
 
-import { Trigger, sleep } from '@dxos/async';
+import { Trigger } from '@dxos/async';
 import { Client, Invitation, InvitationEncoder } from '@dxos/client';
 
 import { BaseCommand } from '../../base-command';
@@ -55,9 +55,6 @@ export default class Share extends BaseCommand {
         ux.action.start('Waiting for peer to connect');
         await done.wait();
         ux.action.stop();
-
-        // TODO(egorgripasov): Wait to replicate?
-        await sleep(15_000);
       }
     });
   }

--- a/packages/devtools/cli/src/commands/reset/index.ts
+++ b/packages/devtools/cli/src/commands/reset/index.ts
@@ -2,6 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
+import { Flags } from '@oclif/core';
 import fs from 'fs';
 
 import { BaseCommand } from '../../base-command';
@@ -9,12 +10,25 @@ import { BaseCommand } from '../../base-command';
 export default class Reset extends BaseCommand {
   static override description = 'Reset all data.';
 
+  static override flags = {
+    ...BaseCommand.flags,
+    profile: Flags.string({
+      description: 'Profile name.',
+      env: 'DX_PROFILE',
+    }),
+  };
+
   async run(): Promise<any> {
+    const params = await this.parse(Reset);
     // TODO(burdon): Warning prompt.
     const path = this.clientConfig?.get('runtime.client.storage.path');
     if (path) {
-      fs.rmSync(path, { recursive: true });
+      fs.rmSync(path, { recursive: true, force: true });
       this.ok();
     }
+
+    await this.execWithDaemon(async (daemon) => daemon.restart(params.flags.profile));
+
+    this.log('Reset finished');
   }
 }

--- a/packages/devtools/cli/src/daemon/daemon.ts
+++ b/packages/devtools/cli/src/daemon/daemon.ts
@@ -67,6 +67,15 @@ export class Daemon {
     return promisify(this._pm2.stop.bind(this._pm2))(profile);
   }
 
+  async restart(profile = DEFAULT_PROFILE) {
+    assert(this._pm2);
+    if (await this.isRunning(profile)) {
+      return promisify(this._pm2.restart.bind(this._pm2))(profile);
+    }
+
+    return this.start(profile);
+  }
+
   async list() {
     assert(this._pm2);
     const list = await promisify(this._pm2.list.bind(this._pm2))();

--- a/packages/devtools/cli/src/daemon/pm2.ts
+++ b/packages/devtools/cli/src/daemon/pm2.ts
@@ -5,7 +5,6 @@
 import pm2 from 'pm2';
 
 import { Trigger } from '@dxos/async';
-import { log } from '@dxos/log';
 
 type Pm2Params = {
   cwd?: string; // * @param {String}  [opts.cwd=<current>]         override pm2 cwd for starting scripts
@@ -35,9 +34,7 @@ export const getPm2 = async () => {
     }
   });
 
-  log.info('Waiting for PM2 to connect...');
   await connected;
-  log.info('PM2 connected.');
 
   return instance;
 };

--- a/packages/devtools/cli/src/daemon/run.ts
+++ b/packages/devtools/cli/src/daemon/run.ts
@@ -15,25 +15,11 @@ import { WebsocketRpcServer } from '@dxos/websocket-rpc';
 export type RunServicesParams = {
   profile: string;
   listen: string;
+  config: Config;
 };
 
 export const runServices = async (params: RunServicesParams) => {
-  const config = new Config({
-    runtime: {
-      services: {
-        signaling: [
-          {
-            server: 'wss://kube.dxos.org/.well-known/dx/signal',
-          },
-          {
-            server: 'wss://dev.kube.dxos.org/.well-known/dx/signal',
-          },
-        ],
-      },
-    },
-  });
-
-  const services = fromHost(config);
+  const services = fromHost(params.config);
 
   await services.open();
   log.info('open');


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c32e7c1</samp>

### Summary
🗑️🔄🛠️

<!--
1.  🗑️ - This emoji represents the removal of the empty comment line and the unused logging, as well as the refactoring of the `daemon:stop` command to use flags instead of arguments.
2.  🔄 - This emoji represents the addition of the `daemon:restart` command and the `restart` method, as well as the daemon restart in the `reset` command, which all perform the action of restarting the daemon process.
3.  🛠️ - This emoji represents the modification of the `runServices` function and the `fromHost` function to accept the client config as a parameter and use it for the services, as well as the addition of the profile flag to the `reset` command, which all improve the functionality and flexibility of the CLI.
-->
This pull request adds and refactors several commands and functions related to the daemon process and its configuration. It enables passing client config to the daemon services, using flags for the `daemon:stop` command, specifying profiles for the `reset` and `daemon:restart` commands, and simplifying the PM2 connection and logging.

> _We are the masters of the daemon_
> _We control its life and death_
> _We restart it with our profile_
> _We run it with our config_

### Walkthrough
*  Implement `dx daemon:restart` command to restart the daemon process using PM2 ([link](https://github.com/dxos/dxos/pull/3226/files?diff=unified&w=0#diff-f02f931f1564a98170863268fc4b6d00274e74eb52c2430b7df98935756a93f4R1-R28), [link](https://github.com/dxos/dxos/pull/3226/files?diff=unified&w=0#diff-294bc132e7f6223c80ca5f10a2e0e8338bd9e16af789627c4a1d513019b59125R70-R78))
*  Modify `dx daemon:run` command to accept client config as a parameter and pass it to the services instance ([link](https://github.com/dxos/dxos/pull/3226/files?diff=unified&w=0#diff-ea43aa589798fe354612607534c296571035d345af998b10ae0a2365e771f2d5R8), [link](https://github.com/dxos/dxos/pull/3226/files?diff=unified&w=0#diff-ea43aa589798fe354612607534c296571035d345af998b10ae0a2365e771f2d5L32-R34), [link](https://github.com/dxos/dxos/pull/3226/files?diff=unified&w=0#diff-59ebd69ad6acd9128246644914e7d7738fcb8f0017058c3230c0f319609e4fceL18-R23))
*  Modify `dx daemon:stop` command to use `profile` flag instead of `name` argument for consistency ([link](https://github.com/dxos/dxos/pull/3226/files?diff=unified&w=0#diff-d1ac23c098afabb8b996275ce9588300b260de0f84514032c35d878cea7b5700L5-R5), [link](https://github.com/dxos/dxos/pull/3226/files?diff=unified&w=0#diff-d1ac23c098afabb8b996275ce9588300b260de0f84514032c35d878cea7b5700L13-R16), [link](https://github.com/dxos/dxos/pull/3226/files?diff=unified&w=0#diff-d1ac23c098afabb8b996275ce9588300b260de0f84514032c35d878cea7b5700L24-R24))
*  Modify `dx reset` command to accept `profile` flag and restart the daemon process after deleting the storage path ([link](https://github.com/dxos/dxos/pull/3226/files?diff=unified&w=0#diff-5d00313c7beafef3c3b49e0ebe9be4c6cde9c9183b4232bd7f79e24f08e9fd8cR5), [link](https://github.com/dxos/dxos/pull/3226/files?diff=unified&w=0#diff-5d00313c7beafef3c3b49e0ebe9be4c6cde9c9183b4232bd7f79e24f08e9fd8cL12-R32))
*  Remove empty comment line from `packages/devtools/cli/src/commands/daemon/list.ts` for code style consistency ([link](https://github.com/dxos/dxos/pull/3226/files?diff=unified&w=0#diff-23c76927586f170761f14a0e93efced1c106c78ecbbcf351b5ca4c5b62de43f9L2-L3))
*  Remove log messages from `getPm2` function in `packages/devtools/cli/src/daemon/pm2.ts` as they were redundant and noisy ([link](https://github.com/dxos/dxos/pull/3226/files?diff=unified&w=0#diff-318602659b979321c6a1d765abeb81ed09eda26022d523569e6d34ea1d7a0199L8), [link](https://github.com/dxos/dxos/pull/3226/files?diff=unified&w=0#diff-318602659b979321c6a1d765abeb81ed09eda26022d523569e6d34ea1d7a0199L38-R37))


