### PR TITLE
fix(composer-app,composer-extension): Improvements

### DIFF
--- a/packages/apps/composer-app/src/components/ResolverDialog/ResolverContext.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/ResolverContext.tsx
@@ -3,7 +3,7 @@
 //
 
 import React, { Context, createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 
 import { Document } from '@braneframe/types';
 import { log } from '@dxos/log';
@@ -14,7 +14,8 @@ import { displayName, matchSpace } from '../../util';
 import { DocumentResolverProps, SpaceResolverProps } from './ResolverProps';
 
 const useLocationIdentifier = () => {
-  const { '*': location } = useParams();
+  const [searchParams] = useSearchParams();
+  const location = searchParams.get('location');
   let source, id;
   try {
     const url = location ? new URL(location) : undefined;

--- a/packages/apps/composer-app/src/components/ResolverDialog/ResolverDialog.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/ResolverDialog.tsx
@@ -4,41 +4,51 @@
 
 import React, { useContext } from 'react';
 
-import { Button, DensityProvider, ThemeContext, useThemeContext, useTranslation } from '@dxos/aurora';
+import { Button, DensityProvider, useTranslation } from '@dxos/aurora';
 import { osTx } from '@dxos/aurora-theme';
 import { ShellLayout } from '@dxos/client';
+import { useClient } from '@dxos/react-client';
 import { useShell } from '@dxos/react-shell';
 
 import { SpaceResolverContext } from './ResolverContext';
 import { ResolverTree } from './ResolverTree';
 
 export const ResolverDialog = () => {
-  const themeContext = useThemeContext();
   const { space } = useContext(SpaceResolverContext);
   const { t } = useTranslation('composer');
+  const client = useClient();
   const shell = useShell();
+
   const handleJoinSpace = () => {
     void shell.setLayout(ShellLayout.JOIN_SPACE);
   };
+
+  const handleCreateSpace = () => {
+    void client.createSpace();
+  };
+
   return (
-    <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}>
-      <DensityProvider density='fine'>
-        <div role='none' className={osTx('dialog.overlay', 'dialog--resolver__overlay', {}, 'static bs-full')}>
-          <div
-            role='none'
-            className={osTx('dialog.content', 'dialog--resolver__content', {}, 'p-2 bs-64 shadow-none bg-transparent')}
-          >
-            {!space ? (
-              <ResolverTree />
-            ) : (
-              <h1 className='text-lg font-system-normal'>{t('resolver init document message')}</h1>
-            )}
-            <Button classNames='is-full' onClick={handleJoinSpace}>
+    <DensityProvider density='fine'>
+      <div role='none' className={osTx('dialog.overlay', 'dialog--resolver__overlay', {}, 'static bs-full')}>
+        <div
+          role='none'
+          className={osTx('dialog.content', 'dialog--resolver__content', {}, 'p-2 bs-64 shadow-none bg-transparent')}
+        >
+          {!space ? (
+            <ResolverTree />
+          ) : (
+            <h1 className='text-lg font-system-normal'>{t('resolver init document message')}</h1>
+          )}
+          <div role='group' className='flex is-full gap-2'>
+            <Button classNames='grow' onClick={handleCreateSpace}>
+              {t('create space label', { ns: 'appkit' })}
+            </Button>
+            <Button classNames='grow' onClick={handleJoinSpace}>
               {t('join space label', { ns: 'appkit' })}
             </Button>
           </div>
         </div>
-      </DensityProvider>
-    </ThemeContext.Provider>
+      </div>
+    </DensityProvider>
   );
 };

--- a/packages/apps/composer-app/src/components/Sidebar/DocumentLinkTreeItem.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/DocumentLinkTreeItem.tsx
@@ -2,46 +2,117 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Article, ArticleMedium, Circle } from '@phosphor-icons/react';
-import React from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Article, ArticleMedium, Circle, DotsThreeVertical, FileMinus } from '@phosphor-icons/react';
+import React, { useCallback, useRef, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { Document } from '@braneframe/types';
-import { useTranslation, ListItemEndcap, useSidebar, useDensityContext } from '@dxos/aurora';
+import {
+  useTranslation,
+  ListItemEndcap,
+  useSidebar,
+  useDensityContext,
+  TooltipTrigger,
+  Button,
+  TooltipRoot,
+} from '@dxos/aurora';
 import { TextKind } from '@dxos/aurora-composer';
 import { getSize, mx, appTx } from '@dxos/aurora-theme';
-import { TreeItem, TreeItemHeading } from '@dxos/react-appkit';
-import { observer } from '@dxos/react-client';
+import { DropdownMenu, DropdownMenuItem, TooltipContent, TreeItem, TreeItemHeading } from '@dxos/react-appkit';
+import { observer, Space } from '@dxos/react-client';
 
-export const DocumentLinkTreeItem = observer(({ document, linkTo }: { document: Document; linkTo: string }) => {
-  const { sidebarOpen } = useSidebar();
-  const { t } = useTranslation('composer');
-  const { docKey } = useParams();
-  const density = useDensityContext();
-  const active = docKey === document.id;
-  const Icon = document.content.kind === TextKind.PLAIN ? ArticleMedium : Article;
-  return (
-    <TreeItem classNames='pis-7 pointer-fine:pis-6 pie-1 pointer-fine:pie-0'>
-      <TreeItemHeading
-        asChild
-        classNames={appTx(
-          'button.root',
-          'tree-item__heading--link',
-          { variant: 'ghost', density },
-          'is-full text-base p-0 font-normal items-start gap-1 pointer-fine:min-height-6',
-        )}
-      >
-        <Link to={linkTo} data-testid='composer.documentTreeItemHeading' {...(!sidebarOpen && { tabIndex: -1 })}>
-          <Icon weight='regular' className={mx(getSize(4), 'shrink-0 mbs-2')} />
-          <p className='grow mbs-1'>{document.title || t('untitled document title')}</p>
-          <ListItemEndcap classNames='is-6 flex items-center'>
-            <Circle
-              weight='fill'
-              className={mx(getSize(3), 'text-primary-500 dark:text-primary-300', !active && 'invisible')}
-            />
-          </ListItemEndcap>
-        </Link>
-      </TreeItemHeading>
-    </TreeItem>
-  );
-});
+import { getPath } from '../../router';
+
+export const DocumentLinkTreeItem = observer(
+  ({ document, space, linkTo }: { document: Document; space: Space; linkTo: string }) => {
+    const { sidebarOpen } = useSidebar();
+    const { t } = useTranslation('composer');
+    const { docKey } = useParams();
+    const density = useDensityContext();
+    const navigate = useNavigate();
+    const active = docKey === document.id;
+    const Icon = document.content.kind === TextKind.PLAIN ? ArticleMedium : Article;
+
+    const suppressNextTooltip = useRef<boolean>(false);
+    const [optionsTooltipOpen, setOptionsTooltipOpen] = useState(false);
+    const [optionsMenuOpen, setOpetionsMenuOpen] = useState(false);
+
+    const handleDelete = useCallback(() => {
+      if (active) {
+        navigate(getPath(space.key));
+      }
+      space.db.remove(document);
+    }, [space, document]);
+
+    return (
+      <TreeItem classNames='pis-7 pointer-fine:pis-6 pie-1 pointer-fine:pie-0 flex'>
+        <TreeItemHeading
+          asChild
+          classNames={appTx(
+            'button.root',
+            'tree-item__heading--link',
+            { variant: 'ghost', density },
+            'grow text-base p-0 font-normal flex items-start gap-1 pointer-fine:min-height-6',
+          )}
+        >
+          <Link to={linkTo} data-testid='composer.documentTreeItemHeading' {...(!sidebarOpen && { tabIndex: -1 })}>
+            <Icon weight='regular' className={mx(getSize(4), 'shrink-0 mbs-2')} />
+            <p className='grow mbs-1'>{document.title || t('untitled document title')}</p>
+          </Link>
+        </TreeItemHeading>
+        <TooltipRoot
+          open={optionsTooltipOpen}
+          onOpenChange={(nextOpen) => {
+            if (suppressNextTooltip.current) {
+              setOptionsTooltipOpen(false);
+              suppressNextTooltip.current = false;
+            } else {
+              setOptionsTooltipOpen(nextOpen);
+            }
+          }}
+        >
+          <TooltipContent classNames='z-[31]' side='bottom'>
+            {t('document options label')}
+          </TooltipContent>
+          <DropdownMenu
+            trigger={
+              <TooltipTrigger asChild>
+                <Button
+                  variant='ghost'
+                  data-testid='composer.openSpaceMenu'
+                  classNames='shrink-0 pli-2 pointer-fine:pli-1'
+                  {...(!sidebarOpen && { tabIndex: -1 })}
+                >
+                  <DotsThreeVertical className={getSize(4)} />
+                </Button>
+              </TooltipTrigger>
+            }
+            slots={{
+              root: {
+                open: optionsMenuOpen,
+                onOpenChange: (nextOpen: boolean) => {
+                  if (!nextOpen) {
+                    suppressNextTooltip.current = true;
+                  }
+                  return setOpetionsMenuOpen(nextOpen);
+                },
+              },
+              content: { className: 'z-[31]' },
+            }}
+          >
+            <DropdownMenuItem onClick={handleDelete} className='flex items-center gap-2'>
+              <FileMinus className={getSize(4)} />
+              <span>{t('delete document label')}</span>
+            </DropdownMenuItem>
+          </DropdownMenu>
+        </TooltipRoot>
+        <ListItemEndcap classNames='is-6 flex items-center'>
+          <Circle
+            weight='fill'
+            className={mx(getSize(3), 'text-primary-500 dark:text-primary-300', !active && 'invisible')}
+          />
+        </ListItemEndcap>
+      </TreeItem>
+    );
+  },
+);

--- a/packages/apps/composer-app/src/components/Sidebar/FullSpaceTreeItem.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/FullSpaceTreeItem.tsx
@@ -112,8 +112,12 @@ export const FullSpaceTreeItem = observer(({ space }: { space: Space }) => {
           />
         </TreeItemOpenTrigger>
         <TreeItemHeading
-          classNames='grow break-words pis-1 pbs-2.5 pointer-fine:pbs-1.5 text-sm font-medium'
+          classNames={[
+            'grow break-words pis-1 pbs-2.5 pointer-fine:pbs-1.5 text-sm font-medium',
+            !disabled && 'cursor-pointer',
+          ]}
           data-testid='composer.spaceTreeItemHeading'
+          onClick={() => setOpen(!open)}
         >
           {spaceDisplayName}
         </TreeItemHeading>
@@ -208,7 +212,12 @@ export const FullSpaceTreeItem = observer(({ space }: { space: Space }) => {
         {documents.length > 0 ? (
           <TreeBranch>
             {documents.map((document) => (
-              <DocumentLinkTreeItem key={document.id} document={document} linkTo={getPath(space.key, document.id)} />
+              <DocumentLinkTreeItem
+                key={document.id}
+                document={document}
+                space={space}
+                linkTo={getPath(space.key, document.id)}
+              />
             ))}
           </TreeBranch>
         ) : (

--- a/packages/apps/composer-app/src/router.tsx
+++ b/packages/apps/composer-app/src/router.tsx
@@ -9,7 +9,7 @@ import { createBrowserRouter } from 'react-router-dom';
 import { PublicKey, Space } from '@dxos/client';
 
 import { StandaloneLayout, EmbeddedLayout, Root } from './layouts';
-import { DocumentPage, FirstRunPage, EmbeddedFirstRunPage } from './pages';
+import { DocumentPage, FirstRunPage } from './pages';
 
 export const namespace = 'composer-app';
 
@@ -33,12 +33,8 @@ export const createRouter = (): Router =>
           element: <EmbeddedLayout />,
           children: [
             {
-              path: '*',
-              element: <DocumentPage />,
-            },
-            {
               path: '',
-              element: <EmbeddedFirstRunPage />,
+              element: <DocumentPage />,
             },
           ],
         },

--- a/packages/apps/composer-app/src/translations/en-US.ts
+++ b/packages/apps/composer-app/src/translations/en-US.ts
@@ -6,6 +6,7 @@ export const composer = {
   'current app name': 'Composer',
   'sidebar tree label': 'Spaces with documents',
   'space options label': 'Configure this space',
+  'document options label': 'Document options',
   'create document label': 'Create new document',
   'untitled document title': 'Untitled document',
   'untitled space title': 'Untitled space',
@@ -64,4 +65,5 @@ export const composer = {
   'open in composer label': 'Open in Composer',
   'bound members message_one': 'One member uses this space for this repository',
   'bound members message_other': '{{count}} members use this space for this repository',
+  'delete document label': 'Delete',
 };

--- a/packages/apps/composer-extension/src/content.ts
+++ b/packages/apps/composer-extension/src/content.ts
@@ -52,7 +52,7 @@ const setupComposer = () => {
     const composer = document.createElement('iframe');
     const baseUrl = new URL(import.meta.env.VITE_COMPOSER_URL ?? 'https://composer.dxos.org');
     composer.setAttribute('id', composerId);
-    composer.setAttribute('src', `${baseUrl.href}embedded/${window.location.href}`);
+    composer.setAttribute('src', `${baseUrl.href}embedded?location=${window.location.href}`);
     composer.setAttribute('style', composerStyles);
     composer.setAttribute('allow', 'clipboard-write *');
     Array.from(commentForm.children).forEach((element) => element.setAttribute('style', srOnly));


### PR DESCRIPTION
This PR:
- changes Composer app & extension to use search params for `location` instead of the app URL
- enables document deletion
- enables space creation from the resolver dialog

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bd80ba2</samp>

### Summary
🌲🛠️🖼️

<!--
1.  🌲 - This emoji represents the changes to the sidebar tree items, which are now more interactive and functional. The tree emoji also suggests the hierarchical structure of the spaces and documents.
2.  🛠️ - This emoji represents the changes to the document options and delete document features, which give users more tools and control over their documents. The wrench emoji also suggests the settings and actions that are available in the menu and tooltip.
3.  🖼️ - This emoji represents the changes to the embedded route and the composer iframe, which simplify the code and improve the compatibility with different URL formats. The frame emoji also suggests the embedded view of the document in the app.
-->
This pull request enhances the composer app and extension with new features and improvements. It adds the ability to create a new space and access document options from the resolver dialog and the sidebar. It also simplifies the routing and URL handling for the embedded composer iframe. It updates the translations and removes unused code. The main files affected are `ResolverContext.tsx`, `ResolverDialog.tsx`, `FullSpaceTreeItem.tsx`, `DocumentLinkTreeItem.tsx`, `router.tsx`, `en-US.ts`, and `content.ts`.

> _This pull request has some changes to see_
> _In `ResolverContext` and `router.tsx`_
> _It adds document options and tooltips_
> _And simplifies the URL and routes_
> _And also some translations for `en-US.ts`_

### Walkthrough
*  Removed unused imports and added new imports for hooks and components (`[link](https://github.com/dxos/dxos/pull/3230/files?diff=unified&w=0#diff-f80ad10b3f3a53671c8e7559fa049d6cd30f148753da3571e245e4cc25c3b561L6-R6)`, `[link](https://github.com/dxos/dxos/pull/3230/files?diff=unified&w=0#diff-25c0436dbaff0f8af375544e6a2a4c5b3c182a4259ace155ee37605e16e7dfe2L7-R10)`, `[link](https://github.com/dxos/dxos/pull/3230/files?diff=unified&w=0#diff-8d60398455991977c09d201d32cd4061ea1c3e76b0f4a8ffe262e8c7e283566aL5-R118)`, `[link](https://github.com/dxos/dxos/pull/3230/files?diff=unified&w=0#diff-25d5cf797a5850b2f0b032fe804a0a30f3d403f194ccee4d4040442ff476bd55L12-R12)`)


