### PR TITLE
feat(composer-app): Open in Github

### DIFF
--- a/packages/apps/composer-app/src/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/apps/composer-app/src/pages/DocumentPage/DocumentPage.tsx
@@ -3,6 +3,7 @@
 //
 
 import {
+  ArrowSquareOut,
   DownloadSimple,
   Eye,
   FileArrowDown,
@@ -302,24 +303,6 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
 
   const dropdownMenuContent = (
     <>
-      {octokit && (
-        <DropdownMenuItem
-          className='flex items-center gap-2'
-          onClick={() => setEditorViewState(editorViewState === 'preview' ? 'editor' : 'preview')}
-        >
-          {editorViewState === 'preview' ? (
-            <>
-              <PencilSimpleLine className={getSize(4)} />
-              <span>{t('exit gfm preview label')}</span>
-            </>
-          ) : (
-            <>
-              <Eye className={getSize(4)} />
-              <span>{t('preview gfm label')}</span>
-            </>
-          )}
-        </DropdownMenuItem>
-      )}
       <DropdownMenuItem className='flex items-center gap-2' onClick={fileProps.handleFileExport}>
         <DownloadSimple className={getSize(4)} />
         <span>{t('export to file label')}</span>
@@ -331,6 +314,22 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
       {octokit && (
         <>
           <div role='separator' className='bs-px mli-2 mlb-1 bg-neutral-500 opacity-20' />
+          <DropdownMenuItem
+            className='flex items-center gap-2'
+            onClick={() => setEditorViewState(editorViewState === 'preview' ? 'editor' : 'preview')}
+          >
+            {editorViewState === 'preview' ? (
+              <>
+                <PencilSimpleLine className={getSize(4)} />
+                <span>{t('exit gfm preview label')}</span>
+              </>
+            ) : (
+              <>
+                <Eye className={getSize(4)} />
+                <span>{t('preview gfm label')}</span>
+              </>
+            )}
+          </DropdownMenuItem>
           {docGhId ? (
             <>
               <DropdownMenuItem
@@ -351,6 +350,12 @@ const MarkdownDocumentPage = observer(({ document, space }: DocumentPageProps) =
               <DropdownMenuItem className='flex items-center gap-2' onClick={handleGhExport}>
                 <FileArrowUp className={getSize(4)} />
                 <span>{t('export to github label')}</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild className='flex items-center gap-2'>
+                <a href={`https://github.com/${ghId}`} target='_blank' rel='noreferrer'>
+                  <ArrowSquareOut className={getSize(4)} />
+                  <span>{t('open in github label')}</span>
+                </a>
               </DropdownMenuItem>
             </>
           ) : (

--- a/packages/apps/composer-app/src/translations/en-US.ts
+++ b/packages/apps/composer-app/src/translations/en-US.ts
@@ -73,4 +73,5 @@ export const composer = {
   'loading preview message': 'Loading preview…',
   'preview gfm label': 'Preview Markdown',
   'exit gfm preview label': 'Edit Markdown',
+  'open in github label': 'Open in Github',
 };


### PR DESCRIPTION
Resolves #3234.

<img width="254" alt="Screenshot 2023-05-24 at 16 38 48" src="https://github.com/dxos/dxos/assets/855039/dd6ff0ea-cac6-4194-aff9-9ffba1b8eeea">

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b78a775</samp>

### Summary
🌐🐙📝

<!--
1.  🌐 - This emoji represents the addition of a new translation for the label 'Open in Github'. It is often used to indicate localization, internationalization, or multilingual support.
2.  🐙 - This emoji represents the use of the `octokit` integration, which is a library for interacting with the Github API. The octopus is the mascot of Github, and this emoji is often used to refer to Github-related features or projects.
3.  📝 - This emoji represents the menu item to toggle between editor and preview modes for markdown documents. It is often used to indicate writing, editing, or documentation.
-->
Added a feature to open documents in Github from the composer app. Updated the `en-US` locale file with the translation for the new menu item.

> _To open a doc in Github_
> _They added a new menu stub_
> _Using `octokit`_
> _They made it a hit_
> _And moved the toggle for markdown rub_

### Walkthrough
*  Added a new menu item to open a document in Github if the Github integration is available ([link](https://github.com/dxos/dxos/pull/3244/files?diff=unified&w=0#diff-885c69fa0fe39b538801d9644438359e97fa54cb75a2e3b07437cda497ebd61dR6), [link](https://github.com/dxos/dxos/pull/3244/files?diff=unified&w=0#diff-885c69fa0fe39b538801d9644438359e97fa54cb75a2e3b07437cda497ebd61dR354-R359), [link](https://github.com/dxos/dxos/pull/3244/files?diff=unified&w=0#diff-df4fb09070ae8aa16c554fe8dc845b2f339eb7e852b9b7934010cbcf2eee0721R76)).


