### PR TITLE
feat(composer-extension): Rescue stale Github updates 

### DIFF
--- a/packages/apps/composer-app/src/components/OctokitProvider/PatDialog.tsx
+++ b/packages/apps/composer-app/src/components/OctokitProvider/PatDialog.tsx
@@ -9,7 +9,14 @@ import { Dialog, Input } from '@dxos/react-appkit';
 
 import { useOctokitContext } from './OctokitProvider';
 
-export const PatDialog = ({ open, setOpen }: { open: boolean; setOpen: Dispatch<SetStateAction<boolean>> }) => {
+export type PatDialogProps = {
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+  title?: string;
+  description?: string;
+};
+
+export const PatDialog = ({ open, setOpen, title, description }: PatDialogProps) => {
   const { t } = useTranslation('composer');
   const { pat, setPat } = useOctokitContext();
   const [patValue, setPatValue] = useState(pat);
@@ -20,7 +27,8 @@ export const PatDialog = ({ open, setOpen }: { open: boolean; setOpen: Dispatch<
 
   return (
     <Dialog
-      title={t('profile settings label')}
+      title={title ?? t('profile settings label')}
+      {...(description && { description })}
       open={open}
       onOpenChange={(nextOpen) => {
         setOpen(nextOpen);

--- a/packages/apps/composer-app/src/translations/en-US.ts
+++ b/packages/apps/composer-app/src/translations/en-US.ts
@@ -74,4 +74,7 @@ export const composer = {
   'preview gfm label': 'Preview Markdown',
   'exit gfm preview label': 'Edit Markdown',
   'open in github label': 'Open in Github',
+  'stale rescue title': 'Set a personal access token',
+  'stale rescue description':
+    'Another user has recently updated this issue, so Github won’t accept your changes unless you set a personal access token (a PAT) here, or refresh the page.',
 };

--- a/packages/apps/composer-extension/src/content.ts
+++ b/packages/apps/composer-extension/src/content.ts
@@ -90,6 +90,11 @@ const setupComposer = () => {
           break;
         }
 
+        case 'close-embed-after-api': {
+          location.reload();
+          break;
+        }
+
         case 'save-data': {
           if (body) {
             body.value = event.data.content;


### PR DESCRIPTION
https://github.com/dxos/dxos/assets/855039/6ba9cb8e-2343-435c-8e0f-968c3d8b2d43

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0bb0523</samp>

### Summary
:sparkles::recycle::bug:

<!--
1.  :sparkles: - This emoji represents the addition of new features or enhancements, such as the translation values and the message event handler.
2.  :recycle: - This emoji represents the refactoring or improvement of existing code or functionality, such as the `PatDialog` component and the GitHub integration.
3.  :bug: - This emoji represents the fixing of a bug or an issue, such as the stale rescue dialog for markdown documents.
-->
Improved GitHub integration for markdown documents in the composer app and extension. Refactored `PatDialog` component to handle stale issue content and prompt for a personal access token. Added translation values and a message event handler to support the feature.

> _The issue is stale, the content is old_
> _We need a token to break the mold_
> _`PatDialog` shows us the way_
> _To update the document and save the day_

### Walkthrough
*  Refactor `PatDialog` component to accept optional `title` and `description` props ([link](https://github.com/dxos/dxos/pull/3254/files?diff=unified&w=0#diff-30c97972c92b7cb681785584fa1cc379e3da2ef1d6c3604f41bae243331a768aL12-R19), [link](https://github.com/dxos/dxos/pull/3254/files?diff=unified&w=0#diff-30c97972c92b7cb681785584fa1cc379e3da2ef1d6c3604f41bae243331a768aL23-R31))
*  Add `PatDialog` import and `staleDialogOpen` state to `MarkdownDocumentPage` component ([link](https://github.com/dxos/dxos/pull/3254/files?diff=unified&w=0#diff-885c69fa0fe39b538801d9644438359e97fa54cb75a2e3b07437cda497ebd61dL29-R28), [link](https://github.com/dxos/dxos/pull/3254/files?diff=unified&w=0#diff-885c69fa0fe39b538801d9644438359e97fa54cb75a2e3b07437cda497ebd61dR99))
*  Extract `updateIssueContent` function from `exportGhIssueContent` function in `MarkdownDocumentPage` component ([link](https://github.com/dxos/dxos/pull/3254/files?diff=unified&w=0#diff-885c69fa0fe39b538801d9644438359e97fa54cb75a2e3b07437cda497ebd61dL267-R283))
*  Add `handleGhSave` function to `MarkdownDocumentPage` component to update GitHub issue or file content ([link](https://github.com/dxos/dxos/pull/3254/files?diff=unified&w=0#diff-885c69fa0fe39b538801d9644438359e97fa54cb75a2e3b07437cda497ebd61dR302-R309))
*  Add `useEffect` hook to `MarkdownDocumentPage` component to listen for `comment-stale` message event and show `PatDialog` if needed ([link](https://github.com/dxos/dxos/pull/3254/files?diff=unified&w=0#diff-885c69fa0fe39b538801d9644438359e97fa54cb75a2e3b07437cda497ebd61dR316-R337))
*  Render `PatDialog` component in `MarkdownDocumentPage` component with `staleDialogOpen` state and translation values ([link](https://github.com/dxos/dxos/pull/3254/files?diff=unified&w=0#diff-885c69fa0fe39b538801d9644438359e97fa54cb75a2e3b07437cda497ebd61dR452-R457))
*  Simplify `DocumentPage` component by removing stale comment dialog logic and state ([link](https://github.com/dxos/dxos/pull/3254/files?diff=unified&w=0#diff-885c69fa0fe39b538801d9644438359e97fa54cb75a2e3b07437cda497ebd61dL536-R578))
*  Add translation values for `stale rescue title` and `stale rescue description` keys to `composer` namespace ([link](https://github.com/dxos/dxos/pull/3254/files?diff=unified&w=0#diff-df4fb09070ae8aa16c554fe8dc845b2f339eb7e852b9b7934010cbcf2eee0721R77-R79))
*  Add `close-embed-after-api` message event handler to `setupComposer` function in `content.ts` to reload page after embedded document update ([link](https://github.com/dxos/dxos/pull/3254/files?diff=unified&w=0#diff-965ede101d150f7552038c94915dccb69e3c1de6a37c42d654aa2a643c51a415R93-R97))


