### PR TITLE
feat(composer-extension): Add continuous deployment

### DIFF
--- a/.circleci/scripts/publish-extension.sh
+++ b/.circleci/scripts/publish-extension.sh
@@ -1,38 +1,42 @@
 #!/bin/bash
 
-EXTENSION=./packages/devtools/devtools-extension
-
+EXTENSIONS=(
+  ./packages/devtools/devtools-extension
+  ./packages/apps/composer-extension
+)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 ROOT=$(git rev-parse --show-toplevel)
 
 # See https://developer.chrome.com/docs/webstore/using_webstore_api/
 # See how to obtaine ACCESS_TOKEN from REFRESH_TOKEN https://circleci.com/blog/continuously-deploy-a-chrome-extension/
 if [ $BRANCH = "production" ]; then
-  pushd $EXTENSION
+  for EXTENSIONS in "${EXTENSIONS[@]}"; do
+    pushd $EXTENSION
 
-  PACKAGE=${PWD##*/}
-  PACKAGE_CAPS='DEVTOOLS-EXTENSION'
-  PACKAGE_ENV=${PACKAGE_CAPS//-/_}
+    PACKAGE=${PWD##*/}
+    PACKAGE_CAPS='DEVTOOLS-EXTENSION'
+    PACKAGE_ENV=${PACKAGE_CAPS//-/_}
 
-  eval "CLIENT_ID=$"${PACKAGE_ENV}_CLIENT_ID""
-  eval "CLIENT_SECRET=$"${PACKAGE_ENV}_CLIENT_SECRET""
-  eval "REFRESH_TOKEN=$"${PACKAGE_ENV}_REFRESH_TOKEN""
-  eval "APP_ID=$"${PACKAGE_ENV}_APP_ID""
+    eval "CLIENT_ID=$"${PACKAGE_ENV}_CLIENT_ID""
+    eval "CLIENT_SECRET=$"${PACKAGE_ENV}_CLIENT_SECRET""
+    eval "REFRESH_TOKEN=$"${PACKAGE_ENV}_REFRESH_TOKEN""
+    eval "APP_ID=$"${PACKAGE_ENV}_APP_ID""
 
-  ZIP_PATH=${ROOT}/artifacts/${PACKAGE}.zip
-  mkdir ${ROOT}/artifacts
-  zip -r $ZIP_PATH ./out/${PACKAGE}
+    ZIP_PATH=${ROOT}/artifacts/${PACKAGE}.zip
+    mkdir ${ROOT}/artifacts
+    zip -r $ZIP_PATH ./out/${PACKAGE}
 
-  echo ---------------------------------------------------
-  ACCESS_TOKEN=$(curl "https://accounts.google.com/o/oauth2/token" -d "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token&redirect_uri=urn:ietf:wg:oauth:2.0:oob" | jq -r .access_token)
-  echo "${PACKAGE_ENV}: Obtained ACCESS_TOKEN: ${ACCESS_TOKEN}"
+    echo ---------------------------------------------------
+    ACCESS_TOKEN=$(curl "https://accounts.google.com/o/oauth2/token" -d "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token&redirect_uri=urn:ietf:wg:oauth:2.0:oob" | jq -r .access_token)
+    echo "${PACKAGE_ENV}: Obtained ACCESS_TOKEN: ${ACCESS_TOKEN}"
 
-  echo ---------------------------------------------------
-  curl -H "Authorization: Bearer $ACCESS_TOKEN" -H "x-goog-api-version: 2" -X PUT -T $ZIP_PATH https://www.googleapis.com/upload/chromewebstore/v1.1/items/${APP_ID}
-  echo "${PACKAGE_ENV}: Uploaded extension bundle"
+    echo ---------------------------------------------------
+    curl -H "Authorization: Bearer $ACCESS_TOKEN" -H "x-goog-api-version: 2" -X PUT -T $ZIP_PATH https://www.googleapis.com/upload/chromewebstore/v1.1/items/${APP_ID}
+    echo "${PACKAGE_ENV}: Uploaded extension bundle"
 
-  echo ---------------------------------------------------
-  curl -H "Authorization: Bearer ${ACCESS_TOKEN}" -H "x-goog-api-version: 2" -H "Content-Length: 0" -X POST -v "https://www.googleapis.com/chromewebstore/v1.1/items/${APP_ID}/publish"
-  echo "${PACKAGE_ENV}: Posted bundle for review"
-  popd
+    echo ---------------------------------------------------
+    curl -H "Authorization: Bearer ${ACCESS_TOKEN}" -H "x-goog-api-version: 2" -H "Content-Length: 0" -X POST -v "https://www.googleapis.com/chromewebstore/v1.1/items/${APP_ID}/publish"
+    echo "${PACKAGE_ENV}: Posted bundle for review"
+    popd
+  done
 fi


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2f3f7f8</samp>

### Summary
:recycle::sparkles::package:

<!--
1.  :recycle: - This emoji can be used to indicate that code was refactored or improved without changing its functionality or behavior.
2.  :sparkles: - This emoji can be used to indicate that a new feature or enhancement was added, such as supporting multiple extensions in the script.
3.  :package: - This emoji can be used to indicate that something related to packaging or distribution was changed, such as publishing to the Chrome Web Store.
-->
Refactored `publish-extension.sh` script to enable batch publishing of Chrome extensions.

> _To publish extensions with ease_
> _The script `publish-extension.sh` was refactored, please_
> _It uses an array_
> _And a for loop to say_
> _Which ones to send to the Chrome Web Store keys_

### Walkthrough
*  Refactor publish-extension.sh script to support multiple extensions ([link](https://github.com/dxos/dxos/pull/3260/files?diff=unified&w=0#diff-93c772872a267e00ca5e36929beaf255965dc20845625d046877fb26634d484aL3-R6),[link](https://github.com/dxos/dxos/pull/3260/files?diff=unified&w=0#diff-93c772872a267e00ca5e36929beaf255965dc20845625d046877fb26634d484aL11-R41))


