### PR TITLE
fix(client): grab inivitation codes in iframe service host

### DIFF
--- a/packages/sdk/client/src/packlets/client/iframe-service-host.ts
+++ b/packages/sdk/client/src/packlets/client/iframe-service-host.ts
@@ -126,6 +126,21 @@ export class IFrameClientServicesHost implements ClientServicesProvider {
     });
     this._shellController = new ShellController(this._iframeController, this.joinedSpace);
     await this._shellController.open();
+
+    // TODO(wittjosiah): Allow path/params for invitations to be customizable.
+    const searchParams = new URLSearchParams(window.location.search);
+    const spaceInvitationCode = searchParams.get('spaceInvitationCode');
+    if (spaceInvitationCode) {
+      await this._shellController.setLayout(ShellLayout.JOIN_SPACE, { invitationCode: spaceInvitationCode });
+      return;
+    }
+
+    const deviceInvitationCode = searchParams.get('deviceInvitationCode');
+    if (deviceInvitationCode) {
+      await this._shellController.setLayout(ShellLayout.INITIALIZE_IDENTITY, {
+        invitationCode: deviceInvitationCode ?? undefined,
+      });
+    }
   }
 
   async close() {

--- a/packages/sdk/client/src/packlets/client/iframe-service-proxy.ts
+++ b/packages/sdk/client/src/packlets/client/iframe-service-proxy.ts
@@ -44,7 +44,6 @@ export class IFrameClientServicesProxy implements ClientServicesProvider {
 
   private _iframe?: HTMLIFrameElement;
   private _appPort!: RpcPort;
-  private _shellPort?: RpcPort;
   private _clientServicesProxy?: ClientServicesProxy;
   private _loggingStream?: Stream<LogEntry>;
   private _iframeController!: IFrameController;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2ac7f96</samp>

### Summary
🚀🔧🗑️

<!--
1.  🚀 - This emoji represents the feature of enabling users to join spaces and devices via invitations, which is a new and exciting functionality that could increase user engagement and retention.
2.  🔧 - This emoji represents the refactor of simplifying the communication between the iframe and the shell, which is a technical improvement that could enhance the code quality and performance.
3.  🗑️ - This emoji represents the removal of the unused `_shellPort` property, which is a cleanup that could reduce the code complexity and potential bugs.
-->
This pull request adds invitation code handling to the `IFrameServiceHost` class and refactors the `IFrameClientServicesProxy` class. This enables users to join spaces and devices via invitations and simplifies the iframe-shell communication.

> _`IFrameServiceHost`_
> _Handles invitation codes_
> _Join or initialize_

### Walkthrough
*  Add logic to handle invitation codes in the URL query parameters ([link](https://github.com/dxos/dxos/pull/3273/files?diff=unified&w=0#diff-779cd4fad9079c75b1e0c02a5fe3cb6bb559c81af3d162df3feee8ad4434a4aaR129-R143))
* Remove unused property from the `IFrameClientServicesProxy` class ([link](https://github.com/dxos/dxos/pull/3273/files?diff=unified&w=0#diff-834bad88edf4fe7524e1dec39240cfaea7edb5e085d465624fd568c2d42b859fL47))


