### PR TITLE
fix: Fix publish extension script

### DIFF
--- a/.circleci/scripts/publish-extension.sh
+++ b/.circleci/scripts/publish-extension.sh
@@ -14,7 +14,7 @@ if [ $BRANCH = "production" ]; then
     pushd $EXTENSION
 
     PACKAGE=${PWD##*/}
-    PACKAGE_CAPS='DEVTOOLS-EXTENSION'
+    PACKAGE_CAPS=${PACKAGE^^}
     PACKAGE_ENV=${PACKAGE_CAPS//-/_}
 
     eval "CLIENT_ID=$"${PACKAGE_ENV}_CLIENT_ID""


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 593c08c</samp>

### Summary
:recycle::sparkles::wrench:

<!--
1.  :recycle: - This emoji conveys the idea of refactoring or improving existing code without changing its functionality, which is what the parameter expansion does.
2.  :sparkles: - This emoji conveys the idea of adding a new feature or enhancement, which is what the script does by making it more generic and reusable for other packages.
3.  :wrench: - This emoji conveys the idea of fixing or adjusting something, which is what the script does by avoiding hardcoding a specific package name.
-->
Refactored the publish-extension script to use dynamic package name. This allows the script to publish any extension package to the Chrome Web Store.

> _`PACKAGE_CAPS` changed_
> _Using bash expansion now_
> _Script more flexible_

### Walkthrough
* Convert package name to uppercase using bash parameter expansion ([link](https://github.com/dxos/dxos/pull/3280/files?diff=unified&w=0#diff-93c772872a267e00ca5e36929beaf255965dc20845625d046877fb26634d484aL17-R17))


