### PR TITLE
fix: Fix plural in publish extensions script

### DIFF
--- a/.circleci/scripts/publish-extension.sh
+++ b/.circleci/scripts/publish-extension.sh
@@ -10,7 +10,7 @@ ROOT=$(git rev-parse --show-toplevel)
 # See https://developer.chrome.com/docs/webstore/using_webstore_api/
 # See how to obtaine ACCESS_TOKEN from REFRESH_TOKEN https://circleci.com/blog/continuously-deploy-a-chrome-extension/
 if [ $BRANCH = "production" ]; then
-  for EXTENSIONS in "${EXTENSIONS[@]}"; do
+  for EXTENSION in "${EXTENSIONS[@]}"; do
     pushd $EXTENSION
 
     PACKAGE=${PWD##*/}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5c68937</samp>

### Summary
🐛📝♻️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request. The typo in the script could cause errors or unexpected behavior when publishing extensions.
2.  📝 - This emoji represents documentation, which is also updated in the pull request to reflect the correct variable name and usage. Documentation is important for clarity and consistency of the code.
3.  ♻️ - This emoji represents refactoring, which is the process of improving the structure or quality of the code without changing its functionality. Changing the variable name to a more appropriate one is a form of refactoring that enhances readability and maintainability of the code.
-->
Fix typo in `publish-extension.sh` script. Rename `EXTENSIONS` variable to `EXTENSION` for clarity.

> _`EXTENSIONS` to `EXTENSION`_
> _A typo fixed in the script_
> _Autumn leaves falling_

### Walkthrough
* Renamed variable `EXTENSIONS` to `EXTENSION` to match loop variable and avoid confusion ([link](https://github.com/dxos/dxos/pull/3282/files?diff=unified&w=0#diff-93c772872a267e00ca5e36929beaf255965dc20845625d046877fb26634d484aL13-R13))


