### PR TITLE
fix: Fix root inside publish extension script

### DIFF
--- a/.circleci/scripts/publish-extension.sh
+++ b/.circleci/scripts/publish-extension.sh
@@ -4,14 +4,15 @@ EXTENSIONS=(
   ./packages/devtools/devtools-extension
   ./packages/apps/composer-extension
 )
+
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-ROOT=$(git rev-parse --show-toplevel)
 
 # See https://developer.chrome.com/docs/webstore/using_webstore_api/
 # See how to obtaine ACCESS_TOKEN from REFRESH_TOKEN https://circleci.com/blog/continuously-deploy-a-chrome-extension/
 if [ $BRANCH = "production" ]; then
   for EXTENSION in "${EXTENSIONS[@]}"; do
     pushd $EXTENSION
+    ROOT=$(git rev-parse --show-toplevel)
 
     PACKAGE=${PWD##*/}
     PACKAGE_CAPS=${PACKAGE^^}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0b67b7b</samp>

### Summary
🚚📝🌟

<!--
1.  🚚 This emoji can be used to indicate that something was moved or relocated, such as a variable assignment or a file.
2.  📝 This emoji can be used to indicate that something was edited or modified, such as a script or a code block.
3.  🌟 This emoji can be used to indicate that something was improved or enhanced, such as variable scoping or readability.
-->
Refactored `publish-extension.sh` script to improve variable scoping and readability. Moved `ROOT` variable assignment to `publish` function.

> _To publish an extension with ease_
> _You moved `ROOT` to where it should be_
> _Now the script is more clear_
> _And the scope is less weird_
> _Well done on this change, I agree_

### Walkthrough
*  Moved `ROOT` variable assignment to `publish` function to avoid global scope and reflect current working directory ([link](https://github.com/dxos/dxos/pull/3297/files?diff=unified&w=0#diff-93c772872a267e00ca5e36929beaf255965dc20845625d046877fb26634d484aL7-R8),[link](https://github.com/dxos/dxos/pull/3297/files?diff=unified&w=0#diff-93c772872a267e00ca5e36929beaf255965dc20845625d046877fb26634d484aR15)).


