### PR TITLE
fix(composer-app): `ResolverDialog` height

### DIFF
--- a/packages/apps/composer-app/src/components/ResolverDialog/ResolverDialog.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/ResolverDialog.tsx
@@ -32,14 +32,19 @@ export const ResolverDialog = () => {
       <div role='none' className={osTx('dialog.overlay', 'dialog--resolver__overlay', {}, 'static bs-full')}>
         <div
           role='none'
-          className={osTx('dialog.content', 'dialog--resolver__content', {}, 'p-2 bs-64 shadow-none bg-transparent')}
+          className={osTx(
+            'dialog.content',
+            'dialog--resolver__content',
+            {},
+            'p-2 bs-72 flex flex-col shadow-none bg-transparent',
+          )}
         >
           {!space ? (
             <ResolverTree />
           ) : (
-            <h1 className='text-lg font-system-normal'>{t('resolver init document message')}</h1>
+            <h1 className='shrink-0 text-lg font-system-normal'>{t('resolver init document message')}</h1>
           )}
-          <div role='group' className='flex is-full gap-2'>
+          <div role='group' className='shrink-0 flex is-full gap-2'>
             <Button classNames='grow' onClick={handleCreateSpace}>
               {t('create space label', { ns: 'appkit' })}
             </Button>

--- a/packages/apps/composer-app/src/components/ResolverDialog/ResolverTree.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/ResolverTree.tsx
@@ -20,11 +20,15 @@ export const ResolverTree = observer(() => {
   return spaces.length ? (
     <>
       {' '}
-      <h1 className='text-lg font-system-normal' id={treeLabel}>
+      <h1 className='shrink-0 text-lg font-system-normal' id={treeLabel}>
         {t('resolver tree label')}
       </h1>
-      <div role='separator' className='bs-px bg-neutral-500/20 mlb-2' />
-      <TreeRoot aria-labelledby={treeLabel} data-testid='composer.sidebarTree' classNames='shrink-0'>
+      <div role='separator' className='shrink-0 bs-px bg-neutral-500/20 mlb-2' />
+      <TreeRoot
+        aria-labelledby={treeLabel}
+        data-testid='composer.sidebarTree'
+        classNames='overflow-y-auto -mli-2 pli-2'
+      >
         {spaces.map((space) => {
           return (
             <SpacePickerTreeItem

--- a/packages/apps/composer-app/src/layouts/EmbeddedLayout.tsx
+++ b/packages/apps/composer-app/src/layouts/EmbeddedLayout.tsx
@@ -80,13 +80,13 @@ const EmbeddedLayoutImpl = () => {
           <span className='sr-only'>{t('open in composer label')}</span>
           <Eye className={getSize(5)} />
         </Toggle>
-        <ButtonGroup>
+        <ButtonGroup classNames={[!(space && document) && 'shadow-none']}>
           <Button disabled={!(space && document)} onClick={handleSaveAndCloseEmbed}>
             {t('save and close label')}
           </Button>
           <DropdownMenuRoot>
             <DropdownMenuTrigger asChild>
-              <Button>
+              <Button disabled={!(space && document)}>
                 <CaretDown />
               </Button>
             </DropdownMenuTrigger>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2083d10</samp>

### Summary
🎨🛠️🔒

<!--
1.  🎨 - This emoji represents changes related to improving the appearance or design of the user interface, such as the flex layout and the box shadow and background of the dialog content.
2.  🛠️ - This emoji represents changes related to fixing or improving the functionality or performance of the user interface, such as the overflow and margin classes that prevent the header and separator from collapsing or overlapping with the tree items, and the vertical scrolling of the tree.
3.  🔒 - This emoji represents changes related to enhancing the security or privacy of the user interface, such as disabling and styling some buttons according to the state of the space and document selection.
-->
This pull request improves the user interface of the `EmbeddedLayout` and the `ResolverDialog` components in the `composer-app` package. It fixes some layout and style issues and enhances the responsiveness and usability of the components.

> _We are the resolvers of the tree_
> _We flex and scroll to set it free_
> _We style the buttons of the layout_
> _We disable them when there's no way out_

### Walkthrough
*  Improve the appearance and responsiveness of the `ResolverDialog` component ([link](https://github.com/dxos/dxos/pull/3307/files?diff=unified&w=0#diff-25c0436dbaff0f8af375544e6a2a4c5b3c182a4259ace155ee37605e16e7dfe2L35-R47), [link](https://github.com/dxos/dxos/pull/3307/files?diff=unified&w=0#diff-703e403cf2c85b5578d98c16274cb0fb0c015f72a0ab6199f94720c665b39edfL23-R31))
* Disable the dropdown menu when the space and document are not selected in the `EmbeddedLayout` component ([link](https://github.com/dxos/dxos/pull/3307/files?diff=unified&w=0#diff-55e414a49a1b76e7fdc1b1dce7f46d18f1a36ee400f9b3319cbbec472d207c93L89-R89))
* Remove the box shadow from the save and close button group when the button is disabled in the `EmbeddedLayout` component ([link](https://github.com/dxos/dxos/pull/3307/files?diff=unified&w=0#diff-55e414a49a1b76e7fdc1b1dce7f46d18f1a36ee400f9b3319cbbec472d207c93L83-R83))


