### PR TITLE
feat(composer-extension): Match Github colors

### DIFF
--- a/packages/apps/composer-app/src/components/ResolverDialog/SpacePickerTreeItem.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/SpacePickerTreeItem.tsx
@@ -8,7 +8,6 @@ import React, { useMemo, useState } from 'react';
 import { Document } from '@braneframe/types';
 import {
   Button,
-  MockListItemOpenTrigger,
   Tag,
   TooltipArrow,
   TooltipContent,
@@ -70,7 +69,9 @@ export const SpacePickerTreeItem = observer(
               <OpenTriggerIcon />
             </TreeItemOpenTrigger>
           ) : (
-            <MockListItemOpenTrigger />
+            <TreeItemOpenTrigger disabled classNames={defaultDisabled}>
+              <CaretRight />
+            </TreeItemOpenTrigger>
           )}
           <TreeItemHeading
             classNames='grow break-words pbs-1 text-base font-medium'

--- a/packages/apps/composer-app/src/layouts/EmbeddedLayout.tsx
+++ b/packages/apps/composer-app/src/layouts/EmbeddedLayout.tsx
@@ -57,65 +57,75 @@ const EmbeddedLayoutImpl = () => {
   const [editorViewState, setEditorViewState] = useState<EditorViewState>('editor');
 
   return (
-    <DensityProvider density='fine'>
-      <div role='none' className='fixed inline-end-2 block-end-2 z-[70] flex gap-2'>
-        <Button disabled={!space} onClick={handleInvite}>
-          {t('create invitation label', { ns: 'appkit' })}
-        </Button>
-        <Button disabled={!(space && document)} asChild>
-          <a
-            target='_blank'
-            rel='noreferrer'
-            href={space && document ? `${location.origin}/${abbreviateKey(space?.key)}/${document.id}` : '#'}
+    <>
+      <style type='text/css'>{`
+        :root {
+          --surface-bg: #F6F8FA;
+        }
+        .dark:root {
+          --surface-bg: #161b22;
+        }
+      `}</style>
+      <DensityProvider density='fine'>
+        <div role='none' className='fixed inline-end-2 block-end-2 z-[70] flex gap-2'>
+          <Button disabled={!space} onClick={handleInvite}>
+            {t('create invitation label', { ns: 'appkit' })}
+          </Button>
+          <Button disabled={!(space && document)} asChild>
+            <a
+              target='_blank'
+              rel='noreferrer'
+              href={space && document ? `${location.origin}/${abbreviateKey(space?.key)}/${document.id}` : '#'}
+            >
+              <span className='sr-only'>{t('open in composer label')}</span>
+              <ArrowSquareOut className={getSize(5)} />
+            </a>
+          </Button>
+          <Toggle
+            disabled={!(space && document)}
+            pressed={editorViewState === 'preview'}
+            onPressedChange={(nextPressed) => setEditorViewState(nextPressed ? 'preview' : 'editor')}
           >
             <span className='sr-only'>{t('open in composer label')}</span>
-            <ArrowSquareOut className={getSize(5)} />
-          </a>
-        </Button>
-        <Toggle
-          disabled={!(space && document)}
-          pressed={editorViewState === 'preview'}
-          onPressedChange={(nextPressed) => setEditorViewState(nextPressed ? 'preview' : 'editor')}
-        >
-          <span className='sr-only'>{t('open in composer label')}</span>
-          <Eye className={getSize(5)} />
-        </Toggle>
-        <ButtonGroup classNames={[!(space && document) && 'shadow-none']}>
-          <Button disabled={!(space && document)} onClick={handleSaveAndCloseEmbed}>
-            {t('save and close label')}
-          </Button>
-          <DropdownMenuRoot>
-            <DropdownMenuTrigger asChild>
-              <Button disabled={!(space && document)}>
-                <CaretDown />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuPortal>
-              <DropdownMenuContent>
-                <DropdownMenuItem onClick={handleSaveAndCloseEmbed} classNames='block'>
-                  <p>{t('save and close label')}</p>
-                  <p className={defaultDescription}>{t('save and close description')}</p>
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={handleCloseEmbed} classNames='block'>
-                  <p>{t('close label', { ns: 'appkit' })}</p>
-                  <p className={defaultDescription}>{t('close embed description')}</p>
-                </DropdownMenuItem>
-                <DropdownMenuArrow />
-              </DropdownMenuContent>
-            </DropdownMenuPortal>
-          </DropdownMenuRoot>
-        </ButtonGroup>
-      </div>
-      {space && document ? (
-        <Outlet
-          context={{ space, document, layout: 'embedded', editorViewState, setEditorViewState } as OutletContext}
-        />
-      ) : source && id && identityHex ? (
-        <ResolverDialog />
-      ) : (
-        <EmbeddedFirstRunPage />
-      )}
-    </DensityProvider>
+            <Eye className={getSize(5)} />
+          </Toggle>
+          <ButtonGroup classNames={[!(space && document) && 'shadow-none']}>
+            <Button disabled={!(space && document)} onClick={handleSaveAndCloseEmbed}>
+              {t('save and close label')}
+            </Button>
+            <DropdownMenuRoot>
+              <DropdownMenuTrigger asChild>
+                <Button disabled={!(space && document)}>
+                  <CaretDown />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuPortal>
+                <DropdownMenuContent>
+                  <DropdownMenuItem onClick={handleSaveAndCloseEmbed} classNames='block'>
+                    <p>{t('save and close label')}</p>
+                    <p className={defaultDescription}>{t('save and close description')}</p>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={handleCloseEmbed} classNames='block'>
+                    <p>{t('close label', { ns: 'appkit' })}</p>
+                    <p className={defaultDescription}>{t('close embed description')}</p>
+                  </DropdownMenuItem>
+                  <DropdownMenuArrow />
+                </DropdownMenuContent>
+              </DropdownMenuPortal>
+            </DropdownMenuRoot>
+          </ButtonGroup>
+        </div>
+        {space && document ? (
+          <Outlet
+            context={{ space, document, layout: 'embedded', editorViewState, setEditorViewState } as OutletContext}
+          />
+        ) : source && id && identityHex ? (
+          <ResolverDialog />
+        ) : (
+          <EmbeddedFirstRunPage />
+        )}
+      </DensityProvider>
+    </>
   );
 };
 

--- a/packages/ui/aurora-theme/src/styles/theme.ts
+++ b/packages/ui/aurora-theme/src/styles/theme.ts
@@ -49,22 +49,13 @@ export const osTheme: Theme<Record<string, any>> = {
   list: listOsTheme,
 };
 
-export const appTx = <P extends Record<string, any>>(
-  path: string,
-  defaultClassName: string,
-  styleProps: P,
-  ...options: any[]
-): string => {
-  const result: Theme<P> | ComponentFunction<P> = get(theme, path);
-  return typeof result === 'function' ? result(styleProps, ...options) : defaultClassName;
+export const bindTheme = <P extends Record<string, any>>(theme: Theme<Record<string, any>>) => {
+  return (path: string, defaultClassName: string, styleProps: P, ...options: any[]): string => {
+    const result: Theme<P> | ComponentFunction<P> = get(theme, path);
+    return typeof result === 'function' ? result(styleProps, ...options) : defaultClassName;
+  };
 };
 
-export const osTx = <P extends Record<string, any>>(
-  path: string,
-  defaultClassName: string,
-  styleProps: P,
-  ...options: any[]
-): string => {
-  const result: Theme<P> | ComponentFunction<P> = get(osTheme, path);
-  return typeof result === 'function' ? result(styleProps, ...options) : defaultClassName;
-};
+export const appTx = bindTheme(theme);
+
+export const osTx = bindTheme(osTheme);


### PR DESCRIPTION
Github uses white (in light theme) for inputs & textareas that have focus, however `aurora` is designed such that white is not used on base surfaces in the same way, so the least expensive intervention that achieves the goal is to use Github’s unfocused background colors.

This PR also facilitates creating new `tx` functions by exporting `bindTheme`.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4611676</samp>

### Summary
🎨🧹🚀

<!--
1.  🎨 - This emoji represents the change in the `EmbeddedLayoutImpl` component, which involves adding a style tag and a CSS variable to support theme-based styling. The emoji is often used for artistic or creative changes, such as adding colors, fonts, or graphics.
2.  🧹 - This emoji represents the change in the `appTx` and `osTx` functions, which involves refactoring them to use a `bindTheme` function and removing the global theme dependency. The emoji is often used for cleaning up or simplifying code, such as removing unused or redundant code, improving readability, or fixing bugs.
3.  🚀 - This emoji represents the change in the space picker dialog, which involves adding a visual indicator for empty tree items. The emoji is often used for launching or improving features, such as adding new functionality, enhancing performance, or increasing user engagement.
-->
This pull request improves the `ResolverDialog` component in the `composer-app` package by removing unused code, adding a visual indicator for empty spaces, and setting the background color based on the theme mode. It also refactors the theme functions in the `aurora-theme` package to make them more reusable and testable.

> _We bind the theme to our will, no global scope can hold us back_
> _We wrap the layout in a fragment, we set the color for the attack_
> _We remove the useless component, we show the emptiness inside_
> _We are the masters of the dialog, we resolve the conflicts with our might_

### Walkthrough
*  Refactor `appTx` and `osTx` functions to use `bindTheme` function for better reusability and testability ([link](https://github.com/dxos/dxos/pull/3308/files?diff=unified&w=0#diff-69241f25f1647f6105233f677788a042089cb28715f9649a78636af9e554b8f5L52-R61)).


