### PR TITLE
refactor: print vault debug messages in more accurate locations

### DIFF
--- a/packages/core/mesh/rpc-tunnel/src/ports/iframe.ts
+++ b/packages/core/mesh/rpc-tunnel/src/ports/iframe.ts
@@ -128,22 +128,5 @@ export const createIFrame = (source: string, id: string, { hidden = true, allow 
     return iframe;
   };
 
-  {
-    const cssStyle = 'color:#C026D3;font-weight:bold';
-
-    console.log(
-      `%cDXOS Client is communicating with the shared worker on ${source}.\nInspect the worker using: chrome://inspect/#workers (URL must be copied manually).`,
-      cssStyle,
-    );
-
-    const devtoolsHost = `devtools${
-      window.location.href.includes('.dev.') || window.location.href.includes('localhost') ? '.dev.' : '.'
-    }dxos.org`;
-    console.log(
-      `%cTo inspect this application, click here:\nhttps://${devtoolsHost}/?target=vault:${source}`,
-      cssStyle,
-    );
-  }
-
   return (document.getElementById(id) as HTMLIFrameElement) ?? create();
 };

--- a/packages/sdk/vault/src/iframe.ts
+++ b/packages/sdk/vault/src/iframe.ts
@@ -21,6 +21,8 @@ import { osTranslations, Shell } from '@dxos/react-shell';
 import { createIFramePort, createWorkerPort } from '@dxos/rpc-tunnel';
 import { safariCheck } from '@dxos/util';
 
+const cssStyle = 'color:#C026D3;font-weight:bold';
+
 const startShell = async (config: Config, runtime: ShellRuntime, services: ClientServicesProvider, origin: string) => {
   const { createElement } = await import('react');
   const { createRoot } = await import('react-dom/client');
@@ -87,7 +89,16 @@ export const startIFrameRuntime = async (createWorker: () => SharedWorker): Prom
       await shellRuntime.open();
       await startShell(config, shellRuntime, shellClientProxy, origin);
     }
-  } else if (typeof SharedWorker === 'undefined') {
+
+    return;
+  } else {
+    console.log(
+      `%cTo inspect this application, click here:\nhttps://devtools.dxos.org/?target=vault:${window.location.href}`,
+      cssStyle,
+    );
+  }
+
+  if (typeof SharedWorker === 'undefined') {
     log.info('Running DXOS vault in main process.');
 
     const messageChannel = new MessageChannel();
@@ -120,6 +131,10 @@ export const startIFrameRuntime = async (createWorker: () => SharedWorker): Prom
       iframeRuntime.stop().catch((err: Error) => log.catch(err));
     });
   } else {
+    console.log(
+      `%cDXOS Client is communicating with the shared worker on ${window.location.origin}.\nInspect the worker using: chrome://inspect/#workers (URL must be copied manually).`,
+      cssStyle,
+    );
     const ports = new Trigger<{ systemPort: MessagePort; shellPort: MessagePort; appPort: MessagePort }>();
     createWorker().port.onmessage = (event) => {
       const { command, payload } = event.data;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b7c0a31</samp>

### Summary
🔧🕵️‍♂️🚀

<!--
1.  🔧 - This emoji represents a wrench or a tool, and it can be used to indicate a change that improves the debugging or configuration of the code, such as moving the console logs to a more appropriate place.
2.  🕵️‍♂️ - This emoji represents a detective or a spy, and it can be used to indicate a change that enhances the inspection or analysis of the code, such as adding more information or instructions for the user to inspect the shared worker.
3.  🚀 - This emoji represents a rocket or a launch, and it can be used to indicate a change that boosts the performance or speed of the code, such as removing unnecessary logs that might slow down the execution of the vault.
-->
This pull request enhances the vault inspection experience by providing better logging and debugging tools. It also cleans up the console output by moving the inspection URLs to the appropriate places in the code.

> _`console.log` moves_
> _better vault inspection_
> _autumn debugging_

### Walkthrough
* Move console logs for inspection URLs to vault iframe logic ([link](https://github.com/dxos/dxos/pull/3311/files?diff=unified&w=0#diff-944f32c710ea3af57c84e1e60a70ab714c435265dcca8e9e973b7e5e15eb9174L131-L143), [link](https://github.com/dxos/dxos/pull/3311/files?diff=unified&w=0#diff-ab250f2acd4b584871491e81ca9ce20acfdf156949461d59dca74bac55130a7bR24-R25), [link](https://github.com/dxos/dxos/pull/3311/files?diff=unified&w=0#diff-ab250f2acd4b584871491e81ca9ce20acfdf156949461d59dca74bac55130a7bL90-R101), [link](https://github.com/dxos/dxos/pull/3311/files?diff=unified&w=0#diff-ab250f2acd4b584871491e81ca9ce20acfdf156949461d59dca74bac55130a7bR134-R137))
  - Define CSS style for logs as a constant in `iframe.ts` ([link](https://github.com/dxos/dxos/pull/3311/files?diff=unified&w=0#diff-ab250f2acd4b584871491e81ca9ce20acfdf156949461d59dca74bac55130a7bR24-R25))
  - Check if vault is running in an iframe but not in a shared worker and log the iframe location as the inspection URL ([link](https://github.com/dxos/dxos/pull/3311/files?diff=unified&w=0#diff-ab250f2acd4b584871491e81ca9ce20acfdf156949461d59dca74bac55130a7bL90-R101))
  - If vault is running in a shared worker, log the iframe origin as the inspection URL and instruct the user to copy it manually ([link](https://github.com/dxos/dxos/pull/3311/files?diff=unified&w=0#diff-ab250f2acd4b584871491e81ca9ce20acfdf156949461d59dca74bac55130a7bR134-R137))
  - Remove logs from `ports/iframe.ts` as they are redundant ([link](https://github.com/dxos/dxos/pull/3311/files?diff=unified&w=0#diff-944f32c710ea3af57c84e1e60a70ab714c435265dcca8e9e973b7e5e15eb9174L131-L143))


