### PR TITLE
feat(client): include commit hash in client message if available

### DIFF
--- a/packages/sdk/react-client/src/banner.ts
+++ b/packages/sdk/react-client/src/banner.ts
@@ -5,14 +5,20 @@
 import { Client } from '@dxos/client';
 
 // http://patorjk.com/software/taag/#p=testall&f=Patorjk-HeX&t=DXOS
-const BANNER = (client: Client) =>
-  '\n' +
-  '_/\\/\\/\\/\\/\\____/\\/\\____/\\/\\____/\\/\\/\\/\\______/\\/\\/\\/\\/\\_\n' +
-  '_/\\/\\____/\\/\\____/\\/\\/\\/\\____/\\/\\____/\\/\\__/\\/\\_________\n' +
-  '_/\\/\\____/\\/\\______/\\/\\______/\\/\\____/\\/\\____/\\/\\/\\/\\___\n' +
-  '_/\\/\\____/\\/\\____/\\/\\/\\/\\____/\\/\\____/\\/\\__________/\\/\\_\n' +
-  '_/\\/\\/\\/\\/\\____/\\/\\____/\\/\\____/\\/\\/\\/\\____/\\/\\/\\/\\/\\___\n' +
-  `\n DXOS Client ${client.version} \n`;
+const BANNER = (client: Client) => {
+  const commitHash = client.config.get('runtime.app.build.commitHash');
+  const hash = commitHash ? ` App Commit ${commitHash} \n` : '';
+
+  return (
+    '\n' +
+    '_/\\/\\/\\/\\/\\____/\\/\\____/\\/\\____/\\/\\/\\/\\______/\\/\\/\\/\\/\\_\n' +
+    '_/\\/\\____/\\/\\____/\\/\\/\\/\\____/\\/\\____/\\/\\__/\\/\\_________\n' +
+    '_/\\/\\____/\\/\\______/\\/\\______/\\/\\____/\\/\\____/\\/\\/\\/\\___\n' +
+    '_/\\/\\____/\\/\\____/\\/\\/\\/\\____/\\/\\____/\\/\\__________/\\/\\_\n' +
+    '_/\\/\\/\\/\\/\\____/\\/\\____/\\/\\____/\\/\\/\\/\\____/\\/\\/\\/\\/\\___\n' +
+    `\n DXOS Client ${client.version} \n${hash}`
+  );
+};
 
 let bannerPrinted = false;
 
@@ -22,5 +28,5 @@ export const printBanner = (client: Client) => {
   }
 
   bannerPrinted = true;
-  console.log(BANNER(client));
+  console.log(`%c${BANNER(client)}`, 'font-family: monospace;');
 };


### PR DESCRIPTION
Monospace style is for safari which doesn't use a monospace font by default in the console anymore which makes the banner not render as expected.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0942c84</samp>

### Summary
🆕📝🎨

<!--
1.  🆕 - This emoji conveys the idea of adding something new, such as the app commit hash and the monospace font.
2.  📝 - This emoji represents writing or editing text, which is what the `BANNER` and `printBanner` functions do.
3.  🎨 - This emoji symbolizes creativity or design, which relates to the improved output format of the app banner.
-->
Improved app banner display and information. Added `appCommit` parameter and monospace font to `BANNER` and `printBanner` functions in `banner.ts`.

> _Oh we're the crew of the app dev ship_
> _And we work hard to make it fit_
> _We print the banner with the hash_
> _And the monospace font so it won't clash_

### Walkthrough
* Include app commit hash in banner output if available ([link](https://github.com/dxos/dxos/pull/3312/files?diff=unified&w=0#diff-b26f4221a17bc868eb2e6e0a64936d94a0161bf52244c8e3a81512f50eedeee1L8-R22)). This helps with debugging and tracking app versions.


