### PR TITLE
chore: disable sentry for non-production environments

### DIFF
--- a/.circleci/scripts/publish.sh
+++ b/.circleci/scripts/publish.sh
@@ -21,13 +21,13 @@ for APP in "${APPS[@]}"; do
   PACKAGE_CAPS=${PACKAGE^^}
   PACKAGE_ENV=${PACKAGE_CAPS//-/_}
 
-  eval "export DX_SENTRY_DESTINATION=$"${PACKAGE_ENV}_SENTRY_DSN""
-  eval "export DX_TELEMETRY_API_KEY=$"${PACKAGE_ENV}_SEGMENT_API_KEY""
-
   if [ $BRANCH = "production" ]; then
     export DX_ENVIRONMENT=production
     DX_CONFIG="$ROOT/packages/devtools/cli/config/config.yml"
     VERSION=$(cat package.json | jq -r ".version")
+
+    eval "export DX_SENTRY_DESTINATION=$"${PACKAGE_ENV}_SENTRY_DSN""
+    eval "export DX_TELEMETRY_API_KEY=$"${PACKAGE_ENV}_SEGMENT_API_KEY""
 
     $ROOT/packages/devtools/cli/bin/run app publish \
       --config=$DX_CONFIG \

--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -83,7 +83,7 @@ export default defineConfig({
         assets: './packages/apps/composer-app/out/composer/**',
       },
       authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN,
-      dryRun: !process.env.CI,
+      dryRun: process.env.DX_ENVIRONMENT !== 'production',
     }),
   ],
 });

--- a/packages/apps/halo-app/vite.config.ts
+++ b/packages/apps/halo-app/vite.config.ts
@@ -91,7 +91,7 @@ export default defineConfig({
         assets: './packages/apps/halo-app/out/halo/**',
       },
       authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN,
-      dryRun: !process.env.CI,
+      dryRun: process.env.DX_ENVIRONMENT !== 'production',
     }),
     // https://www.bundle-buddy.com/rollup
     {

--- a/packages/apps/tasks-app/vite.config.ts
+++ b/packages/apps/tasks-app/vite.config.ts
@@ -79,7 +79,7 @@ export default defineConfig({
         assets: './packages/apps/tasks-app/out/tasks/**',
       },
       authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN,
-      dryRun: !process.env.CI,
+      dryRun: process.env.DX_ENVIRONMENT !== 'production',
     }),
   ],
 });

--- a/packages/apps/todomvc/vite.config.ts
+++ b/packages/apps/todomvc/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
         assets: './packages/apps/todomvc/out/todomvc/**'
       },
       authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN,
-      dryRun: !process.env.CI
+      dryRun: process.env.DX_ENVIRONMENT !== 'production'
     })
   ]
 });

--- a/packages/devtools/devtools-extension/vite.config.ts
+++ b/packages/devtools/devtools-extension/vite.config.ts
@@ -101,7 +101,7 @@ export default defineConfig({
     //     assets: './packages/devtools/devtools-extension/out/devtools-extension/**'
     //   },
     //   authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN,
-    //   dryRun: !process.env.CI
+    //   dryRun: process.env.DX_ENVIRONMENT !== 'production'
     // })
 
     // Add "style-src 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'unsafe-inline' https://fonts.googleapis.com" in content_security_policy in manifest.json when uncommenting this.

--- a/packages/experimental/kai-frames/vite.config.ts
+++ b/packages/experimental/kai-frames/vite.config.ts
@@ -127,7 +127,7 @@ export default defineConfig({
     //     assets: './packages/experimental/kai-frames/out/kai-showcase/**'
     //   },
     //   authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN,
-    //   dryRun: !process.env.CI
+    //   dryRun: process.env.DX_ENVIRONMENT !== 'production'
     // }),
 
     // https://www.bundle-buddy.com/rollup

--- a/packages/experimental/kai-framework/vite.config.ts
+++ b/packages/experimental/kai-framework/vite.config.ts
@@ -124,7 +124,7 @@ export default defineConfig({
     //     assets: './packages/experimental/kai-framework/out/kai-demo/**'
     //   },
     //   authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN,
-    //   dryRun: !process.env.CI
+    //   dryRun: process.env.DX_ENVIRONMENT !== 'production'
     // }),
 
     // https://www.bundle-buddy.com/rollup

--- a/packages/experimental/kai/vite.config.ts
+++ b/packages/experimental/kai/vite.config.ts
@@ -122,7 +122,7 @@ export default defineConfig({
         assets: './packages/experimental/kai/out/kai/**',
       },
       authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN,
-      dryRun: !process.env.CI,
+      dryRun: process.env.DX_ENVIRONMENT !== 'production',
     }),
 
     // https://www.bundle-buddy.com/rollup

--- a/packages/experimental/kube-console/vite.config.ts
+++ b/packages/experimental/kube-console/vite.config.ts
@@ -86,7 +86,7 @@ export default defineConfig({
     //     assets: './packages/experimental/kube-console/out/console/**'
     //   },
     //   authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN,
-    //   dryRun: !process.env.CI
+    //   dryRun: process.env.DX_ENVIRONMENT !== 'production'
     // }),
 
     // https://www.bundle-buddy.com/rollup

--- a/packages/sdk/vault/vite.config.ts
+++ b/packages/sdk/vault/vite.config.ts
@@ -65,7 +65,7 @@ export default defineConfig({
         assets: './packages/sdk/vault/dist/bundle/**',
       },
       authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN,
-      dryRun: !process.env.CI,
+      dryRun: process.env.DX_ENVIRONMENT !== 'production',
     }),
   ],
   worker: {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cb60a08</samp>

### Summary
🚀🌎🔧

<!--
1.  🚀 - This emoji represents the deployment or release of the packages to Sentry, which is enabled by the changes to the `dryRun` option. It also conveys the idea of speed and performance, which are important aspects of the Vite framework and the Sentry service.
2.  🌎 - This emoji represents the different environments that the packages can target, such as production, staging, or development. It also conveys the idea of global reach and impact, which are relevant for the web applications and extensions that the packages provide.
3.  🔧 - This emoji represents the configuration or customization of the packages, which is enabled by the changes to the environment variables. It also conveys the idea of tooling and development, which are essential for the Vite framework and the Sentry service.
-->
This pull request updates the `publish.sh` script and the `vite.config.ts` files of several packages to enable Sentry releases only for the production environment. It uses the `DX_ENVIRONMENT` variable instead of the `CI` variable to determine the target environment for each package. It also sets the Sentry and Telemetry environment variables locally for each package instead of globally.

> _We're setting sail for production, mates, with Sentry on our side_
> _We've tweaked the `dryRun` option for each package in our ride_
> _So heave away and hoist the main, on the count of one, two, three_
> _And let the `DX_ENVIRONMENT` guide us to our destiny_

### Walkthrough
*  Remove global export of `DX_SENTRY_DESTINATION` and `DX_TELEMETRY_API_KEY` from `publish.sh` script ([link](https://github.com/dxos/dxos/pull/3313/files?diff=unified&w=0#diff-c5c15589d74b93a8db5e3edf022db76416f7612a9c9578bd77589b52a7c05adfL24-L26))
*  Add local export of `DX_SENTRY_DESTINATION` and `DX_TELEMETRY_API_KEY` from `publish.sh` script for each package based on `PACKAGE_ENV` variable ([link](https://github.com/dxos/dxos/pull/3313/files?diff=unified&w=0#diff-c5c15589d74b93a8db5e3edf022db76416f7612a9c9578bd77589b52a7c05adfR29-R31))
*  Modify `dryRun` option of `sentry-cli-plugin` in `vite.config.ts` files of various packages to enable Sentry release only for production environment and use `DX_ENVIRONMENT` variable instead of `CI` variable ([link](https://github.com/dxos/dxos/pull/3313/files?diff=unified&w=0#diff-813f00d5c5485f0f83ea1fb6782e90691a233ccb1d82f30a61d1a956f996082eL93-R93), [link](https://github.com/dxos/dxos/pull/3313/files?diff=unified&w=0#diff-a745999da1e2bed73f69f9a92baaad22d02ded554612912cb17f5727cfdb516eL100-R100), [link](https://github.com/dxos/dxos/pull/3313/files?diff=unified&w=0#diff-b50a3de770bc0fec7314ef96a3eb0e8b687fc8f69bebdde57381269b3ae80569L86-R86), [link](https://github.com/dxos/dxos/pull/3313/files?diff=unified&w=0#diff-955b7ce41cc63c8d70b4b0d24bf26a96ec19a38c09fc3cb3de21195d1e7ba157L45-R45), [link](https://github.com/dxos/dxos/pull/3313/files?diff=unified&w=0#diff-b77a1bdcd9dea4a72382eb503000998a17ee8fe62f0e4342cbe2932073ee6fb6L109-R109), [link](https://github.com/dxos/dxos/pull/3313/files?diff=unified&w=0#diff-d6858d926eb31ae41b4bdb1036f81cd9f741856f497b6fb3b78ad3dbc94a4a93L135-R135), [link](https://github.com/dxos/dxos/pull/3313/files?diff=unified&w=0#diff-da01d9c267be68ab7139795bc898003a5f7af0362ad450cd70c54175d3165335L132-R132), [link](https://github.com/dxos/dxos/pull/3313/files?diff=unified&w=0#diff-1b6e458082eedcfe31725fea53d5102140945550075306914e79cd2664265c42L130-R130), [link](https://github.com/dxos/dxos/pull/3313/files?diff=unified&w=0#diff-bdb255315a50314d3345d6d144668095f3c75e89bccc041a82ccc67309a10d96L95-R95), [link](https://github.com/dxos/dxos/pull/3313/files?diff=unified&w=0#diff-25084f30840ca7bf47bffa200a1e8791317d106d81e96307b5249bdc8a4fe1d5L74-R74))


