### PR TITLE
fix(composer-extension): Wait for Space & unbind Space option

### DIFF
--- a/packages/apps/composer-app/src/components/ResolverDialog/ResolverDialog.tsx
+++ b/packages/apps/composer-app/src/components/ResolverDialog/ResolverDialog.tsx
@@ -7,6 +7,7 @@ import React, { useContext } from 'react';
 import { Button, DensityProvider, useTranslation } from '@dxos/aurora';
 import { osTx } from '@dxos/aurora-theme';
 import { ShellLayout } from '@dxos/client';
+import { Loading } from '@dxos/react-appkit';
 import { useClient } from '@dxos/react-client';
 import { useShell } from '@dxos/react-shell';
 
@@ -40,18 +41,20 @@ export const ResolverDialog = () => {
           )}
         >
           {!space ? (
-            <ResolverTree />
+            <>
+              <ResolverTree />
+              <div role='group' className='shrink-0 flex is-full gap-2'>
+                <Button classNames='grow' onClick={handleCreateSpace}>
+                  {t('create space label', { ns: 'appkit' })}
+                </Button>
+                <Button classNames='grow' onClick={handleJoinSpace}>
+                  {t('join space label', { ns: 'appkit' })}
+                </Button>
+              </div>
+            </>
           ) : (
-            <h1 className='shrink-0 text-lg font-system-normal'>{t('resolver init document message')}</h1>
+            <Loading label={t('resolver init document message')} />
           )}
-          <div role='group' className='shrink-0 flex is-full gap-2'>
-            <Button classNames='grow' onClick={handleCreateSpace}>
-              {t('create space label', { ns: 'appkit' })}
-            </Button>
-            <Button classNames='grow' onClick={handleJoinSpace}>
-              {t('join space label', { ns: 'appkit' })}
-            </Button>
-          </div>
         </div>
       </div>
     </DensityProvider>

--- a/packages/apps/composer-app/src/pages/DocumentPage/DocumentPage.tsx
+++ b/packages/apps/composer-app/src/pages/DocumentPage/DocumentPage.tsx
@@ -576,7 +576,7 @@ export const DocumentPage = observer(() => {
   const { space, document } = useOutletContext<OutletContext>();
   return (
     <div role='none'>
-      {document && space ? (
+      {document && document.content && space ? (
         document.content.kind === TextKind.PLAIN ? (
           <MarkdownDocumentPage document={document} space={space} />
         ) : (

--- a/packages/apps/composer-app/src/translations/en-US.ts
+++ b/packages/apps/composer-app/src/translations/en-US.ts
@@ -77,4 +77,6 @@ export const composer = {
   'stale rescue title': 'Set a personal access token',
   'stale rescue description':
     'Another user has recently updated this issue, so Github won’t accept your changes unless you set a personal access token (a PAT) here, or refresh the page.',
+  'embedded options label': 'Options',
+  'unset repo space label': 'Select a different space for this repository',
 };

--- a/packages/apps/composer-app/src/util/spaceResolvers.ts
+++ b/packages/apps/composer-app/src/util/spaceResolvers.ts
@@ -42,6 +42,29 @@ export const bindSpace = (space: Space, identityHex: string, source: string, id:
       return [];
   }
 };
+const ghUnbind = (space: Space, identityHex: string, id: string): string[] => {
+  const [ghOwner, ghRepo, ..._ghEtc] = id.split('/');
+  update(space.properties, ['members', identityHex, 'github', 'repos'], (ghBindings) => {
+    const index = ghBindings.indexOf(`${ghOwner}/${ghRepo}`);
+    if (index >= 0) {
+      const result = [...ghBindings];
+      result.splice(index, 1);
+      return result;
+    } else {
+      return ghBindings;
+    }
+  });
+  return space.properties.members?.[identityHex]?.github?.repos ?? [];
+};
+
+export const unbindSpace = (space: Space, identityHex: string, source: string, id: string): string[] => {
+  switch (source) {
+    case 'com.github':
+      return ghUnbind(space, identityHex, id);
+    default:
+      return [];
+  }
+};
 
 const ghDisplayName = (id: string): string => {
   const [ghOwner, ghRepo, ghResource, ...etc] = id.split('/');


### PR DESCRIPTION
Resolves #3316. Resolves #3317.

https://github.com/dxos/dxos/assets/855039/61e20de0-a22a-4d8c-8ccc-a5006b2d4daf

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0476282</samp>

### Summary
🛠️🔗🎨

<!--
1.  🛠️ - This emoji represents the modification of the `DocumentPage` component to fix the rendering errors and the addition of the translation strings for the labels. It conveys the idea of fixing or improving something.
2.  🔗 - This emoji represents the addition of the `ghUnbind` and `unbindSpace` functions to implement the unbinding logic for the spaces. It conveys the idea of breaking or removing a link or connection.
3.  🎨 - This emoji represents the improvement of the user interface and the usability of the `ResolverDialog` and the embedded layout components. It conveys the idea of enhancing or beautifying something.
-->
This pull request enhances the composer app by improving the space state management, the document resolver dialog, the embedded layout, and the unbind space functionality. It also adds some translation strings and fixes some rendering errors. It affects the files `ResolverContext.tsx`, `ResolverDialog.tsx`, `EmbeddedLayout.tsx`, `DocumentPage.tsx`, `en-US.ts`, and `spaceResolvers.ts`.

> _`ResolverContext`_
> _Space state changes gracefully_
> _Autumn leaves falling_

### Walkthrough
*  Import `SpaceState` enum and use it to check space readiness before handling messages and setting document from query ([link](https://github.com/dxos/dxos/pull/3319/files?diff=unified&w=0#diff-f80ad10b3f3a53671c8e7559fa049d6cd30f148753da3571e245e4cc25c3b561L9-R11), [link](https://github.com/dxos/dxos/pull/3319/files?diff=unified&w=0#diff-f80ad10b3f3a53671c8e7559fa049d6cd30f148753da3571e245e4cc25c3b561R84), [link](https://github.com/dxos/dxos/pull/3319/files?diff=unified&w=0#diff-f80ad10b3f3a53671c8e7559fa049d6cd30f148753da3571e245e4cc25c3b561L92-R95), [link](https://github.com/dxos/dxos/pull/3319/files?diff=unified&w=0#diff-f80ad10b3f3a53671c8e7559fa049d6cd30f148753da3571e245e4cc25c3b561L117-R120)).


