### PR TITLE
chore: kube service to expose list of its well-knowns endpoints

### DIFF
--- a/packages/core/protocols/src/proto/dxos/service/supervisor.proto
+++ b/packages/core/protocols/src/proto/dxos/service/supervisor.proto
@@ -35,11 +35,26 @@ message Service {
   Status status = 2;
   repeated string addresses = 4;
   Type type = 5;
+  repeated WellKnown well_knowns = 6;
 }
 
 // Public .well-known endpoint.
 message Services {
   repeated Service services = 1;
+}
+
+message WellKnown {
+  string url = 1;
+  string description = 2;
+}
+
+message WellKnowns {
+  message WellKnownsByService {
+    string service_name = 1;
+    repeated WellKnown well_knowns = 2;
+  }
+
+  repeated WellKnownsByService well_knowns = 1;
 }
 
 message ConfigPair {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8e636e6</samp>

### Summary
🌐🔗🛠️

<!--
1.  🌐 - This emoji represents the concept of well-known URLs, which are standardized and recognizable ways of identifying and accessing services on the web. It also suggests the idea of network connectivity and communication between different services.
2.  🔗 - This emoji represents the concept of linking or connecting services together, as well as the idea of exposing or sharing endpoints and functionality. It also suggests the idea of references or pointers to resources or locations.
3.  🛠️ - This emoji represents the concept of adding support or functionality, as well as the idea of tools or utilities that can help with service discovery and integration. It also suggests the idea of building or improving something.
-->
Add well-known URLs for services in supervisor protocol. This enables service discovery and integration with the supervisor and other clients.

> _To help services communicate_
> _They need well-known URLs to state_
> _Their endpoints and features_
> _To supervisor and creatures_
> _That use `ServiceStatus` and `WellKnowns` to relate_

### Walkthrough
*  Add `well_knowns` field to `ServiceStatus` message to allow services to advertise their well-known endpoints ([link](https://github.com/dxos/dxos/pull/3323/files?diff=unified&w=0#diff-c0d81e13f7279f2905dc9179d716a843cea34a51add9c0bf1746e2d2d3781f51R38)).


