### PR TITLE
feat: Make devtools link congruent with the app env

### DIFF
--- a/packages/core/mesh/rpc-tunnel/src/ports/iframe.ts
+++ b/packages/core/mesh/rpc-tunnel/src/ports/iframe.ts
@@ -135,8 +135,12 @@ export const createIFrame = (source: string, id: string, { hidden = true, allow 
       `%cDXOS Client is communicating with the shared worker on ${source}.\nInspect the worker using: chrome://inspect/#workers (URL must be copied manually).`,
       cssStyle,
     );
+
+    const devtoolsHost = `devtools${
+      window.location.href.includes('.dev.') || window.location.href.includes('localhost') ? '.dev.' : '.'
+    }dxos.org`;
     console.log(
-      `%cTo inspect this application, click here:\nhttps://devtools.dxos.org/?target=vault:${source}`,
+      `%cTo inspect this application, click here:\nhttps://${devtoolsHost}/?target=vault:${source}`,
       cssStyle,
     );
   }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0381955</samp>

### Summary
🛠️🌐🚀

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate that the change improves the debugging tools for the developers.
2.  🌐 - This emoji represents the web or the internet, and can be used to indicate that the change affects the devtools link based on the window location, which is a web-related feature.
3.  🚀 - This emoji represents a launch or a deployment, and can be used to indicate that the change enables the devtools link to work across different environments, such as development, staging, and production.
-->
Dynamically set `devtoolsHost` in `iframe.ts` based on window location. This improves the devtools link for different environments.

> _`devtoolsHost` changes_
> _link to the right domain now_
> _a winter bug fix_

### Walkthrough
*  Dynamically set the devtools link domain based on the window location ([link](https://github.com/dxos/dxos/pull/3324/files?diff=unified&w=0#diff-944f32c710ea3af57c84e1e60a70ab714c435265dcca8e9e973b7e5e15eb9174L138-R143)). This improves the developer experience and debugging tools for the dxos applications.


