### PR TITLE
fix: factor out tunnel service

### DIFF
--- a/packages/core/protocols/src/proto/dxos/config.proto
+++ b/packages/core/protocols/src/proto/dxos/config.proto
@@ -332,6 +332,10 @@ message Runtime {
       optional string server = 1;
     }
 
+    message Tunneling {
+      optional string server = 1;
+    }
+
     message Supervisor { // TODO(burdon): Is this a service?
       optional string server = 1;
     }
@@ -346,6 +350,7 @@ message Runtime {
     optional BotHost bot = 8;
     optional Publisher publisher = 9;
     optional Supervisor supervisor = 10; // TODO(burdon): Promote to 1; start others at 10.
+    optional Tunneling tunneling = 11;
   }
 
   message Keys {

--- a/packages/core/protocols/src/proto/dxos/service/publisher.proto
+++ b/packages/core/protocols/src/proto/dxos/service/publisher.proto
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 DXOS.org
+// Copyright 2023 DXOS.org
 //
 
 syntax = "proto3";

--- a/packages/core/protocols/src/proto/dxos/service/publisher.proto
+++ b/packages/core/protocols/src/proto/dxos/service/publisher.proto
@@ -35,25 +35,8 @@ message ResetResponse {
   int32 count = 1;
 }
 
-message TunnelRequest {
-  string name = 1;
-  bool enabled = 2;
-}
-
-message TunnelResponse {
-  string name = 1;
-  bool enabled = 2;
-  string url = 3;
-}
-
-message ListTunnelsResponse {
-  repeated TunnelResponse tunnels = 1;
-}
-
 service Publisher {
   rpc Publish(PublishRequest) returns (PublishResponse);
   rpc List(google.protobuf.Empty) returns (ListResponse);
   rpc Reset(google.protobuf.Empty) returns (ResetResponse);
-  rpc Tunnel(TunnelRequest) returns (TunnelResponse);
-  rpc ListTunnels(google.protobuf.Empty) returns (ListTunnelsResponse);
 }

--- a/packages/core/protocols/src/proto/dxos/service/tunnel.proto
+++ b/packages/core/protocols/src/proto/dxos/service/tunnel.proto
@@ -1,0 +1,31 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package dxos.service.tunnel;
+
+option go_package = "github.com/dxos/kube/proto/def/dxos/service/tunnel";
+
+message TunnelRequest {
+  string name = 1;
+  bool enabled = 2;
+}
+
+message TunnelResponse {
+  string name = 1;
+  bool enabled = 2;
+  string url = 3;
+}
+
+message ListTunnelsResponse {
+  repeated TunnelResponse tunnels = 1;
+}
+
+service Tunnel {
+  rpc Tunnel(TunnelRequest) returns (TunnelResponse);
+  rpc ListTunnels(google.protobuf.Empty) returns (ListTunnelsResponse);
+}

--- a/packages/devtools/cli/config/config-default.yml
+++ b/packages/devtools/cli/config/config-default.yml
@@ -22,5 +22,7 @@ runtime:
       server: ws://127.0.0.1/.well-known/dx/deploy
     supervisor:
       server: ws://127.0.0.1/.well-known/dx/supervisor
+    tunneling:
+      server: ws://127.0.0.1/.well-known/dx/tunnel
     machine:
       doAccessToken: ''

--- a/packages/devtools/cli/config/config-dev.yml
+++ b/packages/devtools/cli/config/config-dev.yml
@@ -22,3 +22,5 @@ runtime:
       server: 'wss://dx.dev.kube.dxos.org/.well-known/dx/deploy'
     supervisor:
       server: wss://dx.dev.kube.dxos.org/.well-known/dx/supervisor
+    tunneling:
+      server: wss://dx.dev.kube.dxos.org/.well-known/dx/tunnel

--- a/packages/devtools/cli/config/config-local.yml
+++ b/packages/devtools/cli/config/config-local.yml
@@ -29,5 +29,7 @@ runtime:
       server: ws://127.0.0.1/.well-known/dx/deploy
     supervisor:
       server: ws://127.0.0.1/.well-known/dx/supervisor
+    tunneling:
+      server: wss://127.0.0.1/.well-known/dx/tunnel
     machine:
       doAccessToken: ''

--- a/packages/devtools/cli/config/config-staging.yml
+++ b/packages/devtools/cli/config/config-staging.yml
@@ -22,3 +22,5 @@ runtime:
       server: 'wss://staging.kube.dxos.org/.well-known/dx/deploy'
     supervisor:
       server: wss://staging.kube.dxos.org/.well-known/dx/supervisor
+    tunneling:
+      server: wss://staging.kube.dxos.org/.well-known/dx/tunnel

--- a/packages/devtools/cli/config/config.yml
+++ b/packages/devtools/cli/config/config.yml
@@ -22,5 +22,7 @@ runtime:
       server: 'wss://kube.dxos.org/.well-known/dx/deploy'
     supervisor:
       server: wss://kube.dxos.org/.well-known/dx/supervisor
+    tunneling:
+      server: wss://kube.dxos.org/.well-known/dx/tunnel
     machine:
       doAccessToken: ''

--- a/packages/devtools/cli/src/commands/tunnel/list.ts
+++ b/packages/devtools/cli/src/commands/tunnel/list.ts
@@ -5,7 +5,7 @@
 import assert from 'node:assert';
 
 import { BaseCommand } from '../../base-command';
-import { PublisherRpcPeer, printTunnels } from '../../util';
+import { TunnelRpcPeer, printTunnels } from '../../util';
 
 export default class List extends BaseCommand {
   static override enableJsonFlag = true;
@@ -14,8 +14,8 @@ export default class List extends BaseCommand {
   async run(): Promise<any> {
     const { flags } = await this.parse(List);
     try {
-      return await this.execWithPublisher(async (publisher: PublisherRpcPeer) => {
-        const listResponse = await publisher.rpc.listTunnels();
+      return await this.execWithTunneling(async (tunnel: TunnelRpcPeer) => {
+        const listResponse = await tunnel.rpc.listTunnels();
         assert(listResponse.tunnels!, 'Unable to list tunnels.');
         printTunnels(listResponse.tunnels!, flags);
       });

--- a/packages/devtools/cli/src/commands/tunnel/set.ts
+++ b/packages/devtools/cli/src/commands/tunnel/set.ts
@@ -6,7 +6,7 @@ import { Flags } from '@oclif/core';
 import assert from 'node:assert';
 
 import { BaseCommand } from '../../base-command';
-import { PublisherRpcPeer, printTunnels } from '../../util';
+import { TunnelRpcPeer, printTunnels } from '../../util';
 
 export default class Set extends BaseCommand {
   static override enableJsonFlag = true;
@@ -33,8 +33,8 @@ export default class Set extends BaseCommand {
       if (!!enabled === !!disabled) {
         throw new Error('Specify either --enabled or --disabled.');
       }
-      return await this.execWithPublisher(async (publisher: PublisherRpcPeer) => {
-        const tunnelResponse = await publisher.rpc.tunnel({ name: app, enabled: enabled && !disabled });
+      return await this.execWithTunneling(async (tunnel: TunnelRpcPeer) => {
+        const tunnelResponse = await tunnel.rpc.tunnel({ name: app, enabled: enabled && !disabled });
         assert(tunnelResponse, 'Unable to set tunnel.');
         printTunnels([tunnelResponse], flags);
       });

--- a/packages/devtools/cli/src/util/index.ts
+++ b/packages/devtools/cli/src/util/index.ts
@@ -8,5 +8,6 @@ export * from './print';
 export * from './publish';
 export * from './supervisor';
 export * from './telemetry';
-export * from './util';
 export * from './test-util';
+export * from './tunnel';
+export * from './util';

--- a/packages/devtools/cli/src/util/publish/common.ts
+++ b/packages/devtools/cli/src/util/publish/common.ts
@@ -6,7 +6,6 @@ import { ux } from '@oclif/core';
 import { CID } from 'ipfs-http-client';
 
 import type { ConfigProto } from '@dxos/config';
-import { TunnelResponse } from '@dxos/protocols/proto/dxos/service/publisher';
 
 export type PackageModule = NonNullable<NonNullable<ConfigProto['package']>['modules']>[0];
 export type PackageRepo = NonNullable<NonNullable<ConfigProto['package']>['repos']>[0];
@@ -19,14 +18,6 @@ export const mapModules = (modules: PackageModule[]) => {
   }));
 };
 
-export const mapTunnels = (tunnels: TunnelResponse[]) => {
-  return tunnels.map((tunnel) => ({
-    key: tunnel.name,
-    enabled: tunnel.enabled,
-    url: tunnel.url,
-  }));
-};
-
 export const printModules = (modules: PackageModule[], flags = {}) => {
   ux.table(
     mapModules(modules),
@@ -36,26 +27,6 @@ export const printModules = (modules: PackageModule[], flags = {}) => {
       },
       bundle: {
         header: 'Bundle',
-      },
-    },
-    {
-      ...flags,
-    },
-  );
-};
-
-export const printTunnels = (tunnels: TunnelResponse[], flags = {}) => {
-  ux.table(
-    mapTunnels(tunnels),
-    {
-      key: {
-        header: 'App',
-      },
-      enabled: {
-        header: 'Enabled',
-      },
-      url: {
-        header: 'URL',
       },
     },
     {

--- a/packages/devtools/cli/src/util/publish/common.ts
+++ b/packages/devtools/cli/src/util/publish/common.ts
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 DXOS.org
+// Copyright 2023 DXOS.org
 //
 
 import { ux } from '@oclif/core';

--- a/packages/devtools/cli/src/util/tunnel/common.ts
+++ b/packages/devtools/cli/src/util/tunnel/common.ts
@@ -1,0 +1,35 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { ux } from '@oclif/core';
+
+import { TunnelResponse } from '@dxos/protocols/proto/dxos/service/tunnel';
+
+export const mapTunnels = (tunnels: TunnelResponse[]) => {
+  return tunnels.map((tunnel) => ({
+    key: tunnel.name,
+    enabled: tunnel.enabled,
+    url: tunnel.url,
+  }));
+};
+
+export const printTunnels = (tunnels: TunnelResponse[], flags = {}) => {
+  ux.table(
+    mapTunnels(tunnels),
+    {
+      key: {
+        header: 'App',
+      },
+      enabled: {
+        header: 'Enabled',
+      },
+      url: {
+        header: 'URL',
+      },
+    },
+    {
+      ...flags,
+    },
+  );
+};

--- a/packages/devtools/cli/src/util/tunnel/index.ts
+++ b/packages/devtools/cli/src/util/tunnel/index.ts
@@ -2,4 +2,5 @@
 // Copyright 2023 DXOS.org
 //
 
+export * from './common';
 export * from './tunnel-rpc-peer';

--- a/packages/devtools/cli/src/util/tunnel/index.ts
+++ b/packages/devtools/cli/src/util/tunnel/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+export * from './tunnel-rpc-peer';

--- a/packages/devtools/cli/src/util/tunnel/tunnel-rpc-peer.ts
+++ b/packages/devtools/cli/src/util/tunnel/tunnel-rpc-peer.ts
@@ -1,0 +1,89 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+// TODO(egorgripasov): Factor out.
+import debug from 'debug';
+import WebSocket from 'isomorphic-ws';
+
+import { Trigger, Event } from '@dxos/async';
+import { schema } from '@dxos/protocols';
+import { Tunnel } from '@dxos/protocols/proto/dxos/service/tunnel';
+import { createProtoRpcPeer, ProtoRpcPeer } from '@dxos/rpc';
+
+const log = debug('dxos:cli:tunnel-rpc-peer');
+
+export class TunnelRpcPeer {
+  private readonly _socket: WebSocket;
+  private readonly _rpc: ProtoRpcPeer<{ Tunnel: Tunnel }>;
+  private readonly _connectTrigger = new Trigger();
+
+  readonly connected = new Event();
+  readonly disconnected = new Event();
+  readonly error = new Event<Error>();
+
+  constructor(private readonly _url: string) {
+    this._socket = new WebSocket(this._url);
+    this._socket.onopen = async () => {
+      try {
+        await this._rpc.open();
+        log(`RPC open ${this._url}`);
+        this.connected.emit();
+        this._connectTrigger.wake();
+      } catch (err: any) {
+        this.error.emit(err);
+      }
+    };
+
+    this._socket.onclose = async () => {
+      log(`Disconnected ${this._url}`);
+      this.disconnected.emit();
+      try {
+        await this._rpc.close();
+      } catch (err: any) {
+        this.error.emit(err);
+      }
+    };
+
+    this._socket.onerror = (event: WebSocket.ErrorEvent) => {
+      log(`Publisher socket error ${this._url} ${event.message}`);
+      this.error.emit(event.error ?? new Error(event.message));
+    };
+
+    this._rpc = createProtoRpcPeer({
+      requested: {
+        Tunnel: schema.getService('dxos.service.tunnel.Tunnel'),
+      },
+      exposed: {},
+      handlers: {},
+      noHandshake: true,
+      timeout: 1_000_000,
+      port: {
+        send: (msg) => {
+          this._socket.send(msg);
+        },
+        subscribe: (cb) => {
+          this._socket.onmessage = async (msg: WebSocket.MessageEvent) => {
+            if (typeof Blob !== 'undefined' && msg.data instanceof Blob) {
+              cb(Buffer.from(await msg.data.arrayBuffer()));
+            } else {
+              cb(msg.data as any);
+            }
+          };
+        },
+      },
+    });
+  }
+
+  get rpc(): Tunnel {
+    return this._rpc.rpc.Tunnel;
+  }
+
+  async close() {
+    try {
+      await this._rpc.close();
+    } finally {
+      this._socket.close();
+    }
+  }
+}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 70bfa8a</samp>

### Summary
🚇🔒📜

<!--
1.  🚇 This emoji represents a tunnel, which is the main feature of the code. It also suggests the idea of connecting different locations or services through a secure channel.
2.  🔒 This emoji represents security, which is an important aspect of the tunnel service. It also implies that the tunnels are encrypted and protected from unauthorized access.
3.  📜 This emoji represents a document or a file, which is what the protocol buffer file is. It also suggests the idea of defining the structure and format of the data and the service.
-->
Added a new `tunnel.proto` file to define the protocol buffer for the tunnel service. The tunnel service enables secure access to DXOS services via tunnels.

> _`Tunnel` service born_
> _Secure access to DXOS_
> _Winter of the web_

### Walkthrough
*  Define a new protocol buffer file for the tunnel service ([link](https://github.com/dxos/dxos/pull/3335/files?diff=unified&w=0#diff-f48f1030828d7028c959ef942e5ec2b589e1c81229010dd8cd8924a1ff9000eaR1-R31)). The file `tunnel.proto` declares the syntax, package, imports, messages and service for the tunnel service, which allows creating and listing secure tunnels to access DXOS services. The messages include the name, enabled status and url of each tunnel. The service defines two rpc methods: `Tunnel` and `ListTunnels`.


