### PR TITLE
fix(sentry): stop logging display names and full identity keys

### DIFF
--- a/packages/common/sentry/package.json
+++ b/packages/common/sentry/package.json
@@ -23,6 +23,7 @@
     "@dxos/debug": "workspace:*",
     "@dxos/log": "workspace:*",
     "@dxos/node-std": "workspace:*",
+    "@dxos/util": "workspace:*",
     "@sentry/browser": "^7.45.0",
     "@sentry/integrations": "7.45.0",
     "@sentry/node": "^7.45.0",

--- a/packages/common/sentry/src/tracing.ts
+++ b/packages/common/sentry/src/tracing.ts
@@ -9,6 +9,7 @@ import assert from 'node:assert';
 import { runInContext, scheduleTask, Trigger } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { getContextFromEntry, log, LogLevel, LogProcessor } from '@dxos/log';
+import { humanize } from '@dxos/util';
 
 let TX!: Transaction;
 const SPAN_MAP = new Map<string, Span>();
@@ -59,8 +60,7 @@ export const SENTRY_PROCESSOR: LogProcessor = (config, entry) => {
 
     if (entry.message === 'dxos.halo.identity' && context?.identityKey) {
       setUser({
-        id: context.identityKey,
-        username: context.displayName,
+        id: humanize(context.identityKey),
       });
     }
 

--- a/packages/common/sentry/tsconfig.json
+++ b/packages/common/sentry/tsconfig.json
@@ -26,6 +26,9 @@
     },
     {
       "path": "../node-std"
+    },
+    {
+      "path": "../util"
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1277,6 +1277,7 @@ importers:
       '@dxos/debug': workspace:*
       '@dxos/log': workspace:*
       '@dxos/node-std': workspace:*
+      '@dxos/util': workspace:*
       '@sentry/browser': ^7.45.0
       '@sentry/integrations': 7.45.0
       '@sentry/node': ^7.45.0
@@ -1289,6 +1290,7 @@ importers:
       '@dxos/debug': link:../debug
       '@dxos/log': link:../log
       '@dxos/node-std': link:../node-std
+      '@dxos/util': link:../util
       '@sentry/browser': 7.46.0
       '@sentry/integrations': 7.45.0
       '@sentry/node': 7.46.0


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 94f82c3</samp>

### Summary
📦🔧🌟

<!--
1.  📦 - This emoji represents the addition of a new dependency or package to a project. It can be used to indicate that the `@dxos/util` package was added as a dependency to the `@dxos/sentry` package.
2.  🔧 - This emoji represents the modification of configuration or settings files, such as `tsconfig.json`. It can be used to indicate that the `../util` path was added to the `tsconfig.json` file of the `@dxos/sentry` package.
3.  🌟 - This emoji represents the improvement or enhancement of a feature or functionality. It can be used to indicate that the Sentry integration was improved by using `humanize` to format identity keys and removing display names from user data.
-->
Improved Sentry integration and added `@dxos/util` dependency to `@dxos/sentry` package. The `@dxos/util` package provides some useful functions for formatting and manipulating DXOS data.

> _To make Sentry more user-friendly_
> _We added `@dxos/util` dependency_
> _We used `humanize` to show keys_
> _And dropped display names with ease_
> _Now Sentry looks more neat and tidy_

### Walkthrough
*  Add `@dxos/util` as a dependency and a project reference for `@dxos/sentry` ([link](https://github.com/dxos/dxos/pull/3339/files?diff=unified&w=0#diff-aed248339cba6080e24cbd05e4bc323349f78ad3d9512b3519c851d32927bb85R26), [link](https://github.com/dxos/dxos/pull/3339/files?diff=unified&w=0#diff-b798188d330788447a244fba1eb33bc2f12d0895b0dbb09d1c6bcbb434093890R29-R31))
*  Import `humanize` function from `@dxos/util` in `tracing.ts` ([link](https://github.com/dxos/dxos/pull/3339/files?diff=unified&w=0#diff-d12149c834044a01e667ff114118549ee71332f71adce2526ebcf3743ffd14d2R12))
*  Use `humanize` function to format `context.identityKey` for Sentry in `SENTRY_PROCESSOR` ([link](https://github.com/dxos/dxos/pull/3339/files?diff=unified&w=0#diff-d12149c834044a01e667ff114118549ee71332f71adce2526ebcf3743ffd14d2L62-R63))
*  Remove `context.displayName` from `setUser` call in `SENTRY_PROCESSOR` to avoid sending sensitive information ([link](https://github.com/dxos/dxos/pull/3339/files?diff=unified&w=0#diff-d12149c834044a01e667ff114118549ee71332f71adce2526ebcf3743ffd14d2L62-R63))


