### PR TITLE
fix(composer-app): Spacing, alignment, color

### DIFF
--- a/packages/apps/composer-app/src/components/Sidebar/DocumentLinkTreeItem.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/DocumentLinkTreeItem.tsx
@@ -16,6 +16,7 @@ import {
   Button,
   TreeItem,
   DropdownMenu,
+  useMediaQuery,
 } from '@dxos/aurora';
 import { TextKind } from '@dxos/aurora-composer';
 import { getSize, mx, appTx } from '@dxos/aurora-theme';
@@ -25,11 +26,13 @@ import { getPath } from '../../router';
 
 export const DocumentLinkTreeItem = observer(
   ({ document, space, linkTo }: { document: Document; space: Space; linkTo: string }) => {
-    const { sidebarOpen } = useSidebar();
+    const { sidebarOpen, closeSidebar } = useSidebar();
     const { t } = useTranslation('composer');
     const { docKey } = useParams();
     const density = useDensityContext();
     const navigate = useNavigate();
+    const [isLg] = useMediaQuery('lg', { ssr: false });
+
     const active = docKey === document.id;
     const Icon = document.content.kind === TextKind.PLAIN ? ArticleMedium : Article;
 
@@ -45,7 +48,7 @@ export const DocumentLinkTreeItem = observer(
     }, [space, document]);
 
     return (
-      <TreeItem.Root classNames='pis-7 pointer-fine:pis-6 pie-1 pointer-fine:pie-0 flex'>
+      <TreeItem.Root classNames='pis-7 pointer-fine:pis-6 pointer-fine:pie-0 flex'>
         <TreeItem.Heading
           asChild
           classNames={appTx(
@@ -55,7 +58,12 @@ export const DocumentLinkTreeItem = observer(
             'grow text-base p-0 font-normal flex items-start gap-1 pointer-fine:min-height-6',
           )}
         >
-          <Link to={linkTo} data-testid='composer.documentTreeItem.Heading' {...(!sidebarOpen && { tabIndex: -1 })}>
+          <Link
+            to={linkTo}
+            data-testid='composer.documentTreeItem.Heading'
+            {...(!sidebarOpen && { tabIndex: -1 })}
+            onClick={() => !isLg && closeSidebar()}
+          >
             <Icon weight='regular' className={mx(getSize(4), 'shrink-0 mbs-2')} />
             <p className='grow mbs-1'>{document.title || t('untitled document title')}</p>
           </Link>
@@ -93,7 +101,7 @@ export const DocumentLinkTreeItem = observer(
                 <Button
                   variant='ghost'
                   data-testid='composer.openSpaceMenu'
-                  classNames='shrink-0 pli-2 pointer-fine:pli-1'
+                  classNames='shrink-0 pli-2 pointer-fine:pli-1 self-start'
                   {...(!sidebarOpen && { tabIndex: -1 })}
                 >
                   <DotsThreeVertical className={getSize(4)} />
@@ -111,7 +119,7 @@ export const DocumentLinkTreeItem = observer(
             </DropdownMenu.Portal>
           </DropdownMenu.Root>
         </Tooltip.Root>
-        <ListItem.Endcap classNames='is-6 flex items-center'>
+        <ListItem.Endcap classNames='is-8 pointer-fine:is-6 flex items-center'>
           <Circle
             weight='fill'
             className={mx(getSize(3), 'text-primary-500 dark:text-primary-300', !active && 'invisible')}

--- a/packages/apps/composer-app/src/components/Sidebar/HiddenSpacesTree.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/HiddenSpacesTree.tsx
@@ -81,7 +81,7 @@ const HiddenSpacesBranch = ({ __listItemScope, hiddenSpaces }: ListItemScopedPro
         <TreeItem.OpenTrigger {...(!sidebarOpen && { tabIndex: -1 })}>
           <OpenTriggerIcon />
         </TreeItem.OpenTrigger>
-        <TreeItem.Heading classNames='grow break-words pbs-1.5 text-sm font-system-medium'>
+        <TreeItem.Heading classNames='grow break-words pis-1 pbs-2.5 pointer-fine:pbs-1.5 text-sm font-system-medium'>
           {t('hidden spaces tree label')}
         </TreeItem.Heading>
       </div>

--- a/packages/apps/composer-app/src/components/Sidebar/Sidebar.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/Sidebar.tsx
@@ -109,7 +109,7 @@ const SidebarContent = () => {
             <SidebarTree />
             <Separator flush />
             {identity && (
-              <div role='none' className='shrink-0 flex items-center gap-1 pis-3 pie-1 pointer-fine:pie-3 plb-1.5'>
+              <div role='none' className='shrink-0 flex items-center gap-1 pis-3 pie-1.5 pointer-fine:pie-1.5 plb-1.5'>
                 <Avatar
                   size={6}
                   variant='circle'

--- a/packages/apps/composer-app/src/components/Sidebar/Sidebar.tsx
+++ b/packages/apps/composer-app/src/components/Sidebar/Sidebar.tsx
@@ -109,7 +109,10 @@ const SidebarContent = () => {
             <SidebarTree />
             <Separator flush />
             {identity && (
-              <div role='none' className='shrink-0 flex items-center gap-1 pis-3 pie-1.5 pointer-fine:pie-1.5 plb-1.5'>
+              <div
+                role='none'
+                className='shrink-0 flex items-center gap-1 pis-3 pie-1.5 plb-3 pointer-fine:pie-1.5 pointer-fine:plb-1.5'
+              >
                 <Avatar
                   size={6}
                   variant='circle'
@@ -157,7 +160,7 @@ const SidebarToggle = () => {
       <div
         role='none'
         className={mx(
-          'fixed z-10 block-end-0 pointer-fine:block-end-auto pointer-fine:block-start-0 p-2 transition-[inset-inline-start,opacity] ease-in-out duration-200 inline-start-0',
+          'fixed z-10 block-end-0 pointer-fine:block-end-auto pointer-fine:block-start-0 p-4 pointer-fine:p-2 transition-[inset-inline-start,opacity] ease-in-out duration-200 inline-start-0',
           sidebarOpen && 'opacity-0 pointer-events-none',
         )}
       >

--- a/packages/apps/composer-app/src/pages/DocumentPage/StandaloneDocumentPage.tsx
+++ b/packages/apps/composer-app/src/pages/DocumentPage/StandaloneDocumentPage.tsx
@@ -8,7 +8,7 @@ import { FileUploader } from 'react-drag-drop-files';
 
 import { Document } from '@braneframe/types';
 import { Button, DropdownMenu, ThemeContext, useThemeContext, useTranslation } from '@dxos/aurora';
-import { getSize, osTx } from '@dxos/aurora-theme';
+import { defaultBlockSeparator, getSize, mx, osTx } from '@dxos/aurora-theme';
 import { Dialog, Input } from '@dxos/react-appkit';
 import { observer } from '@dxos/react-client';
 
@@ -31,14 +31,8 @@ export const StandaloneDocumentPage = observer(
     const themeContext = useThemeContext();
     return (
       <>
-        <div
-          role='none'
-          className='mli-auto max-is-[60rem] min-bs-[100vh] bg-white/20 dark:bg-neutral-850/20 flex flex-col'
-        >
-          <div
-            role='none'
-            className='flex items-center gap-2 bg-neutral-500/20 pis-0 pointer-fine:pis-8 lg:pis-0 pointer-fine:lg:pis-0'
-          >
+        <div role='none' className='mli-auto max-is-[60rem] min-bs-[100vh] bg-white dark:bg-neutral-850 flex flex-col'>
+          <div role='none' className='flex items-center gap-2 pis-0 pointer-fine:pis-8 lg:pis-0 pointer-fine:lg:pis-0'>
             <Input
               key={document.id}
               variant='subdued'
@@ -48,7 +42,7 @@ export const StandaloneDocumentPage = observer(
               value={document.title ?? ''}
               onChange={({ target: { value } }) => (document.title = value)}
               slots={{
-                root: { className: 'shrink-0 grow pis-6 plb-2' },
+                root: { className: 'shrink-0 grow pis-6 plb-1.5 pointer-fine:plb-0.5' },
                 input: {
                   'data-testid': 'composer.documentTitle',
                   className: 'text-center',
@@ -58,12 +52,12 @@ export const StandaloneDocumentPage = observer(
             <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}>
               <DropdownMenu.Root>
                 <DropdownMenu.Trigger asChild>
-                  <Button classNames='p-0 is-10 shrink-0' variant='ghost' density='coarse'>
+                  <Button classNames='p-0 is-10 shrink-0 mie-3' variant='ghost' density='coarse'>
                     <DotsThreeVertical className={getSize(6)} />
                   </Button>
                 </DropdownMenu.Trigger>
                 <DropdownMenu.Portal>
-                  <DropdownMenu.Content sideOffset={10} classNames='z-10'>
+                  <DropdownMenu.Content sideOffset={4} classNames='z-10'>
                     {dropdownMenuContent}
                     <DropdownMenu.Arrow />
                   </DropdownMenu.Content>
@@ -71,6 +65,7 @@ export const StandaloneDocumentPage = observer(
               </DropdownMenu.Root>
             </ThemeContext.Provider>
           </div>
+          <div role='separator' className={mx(defaultBlockSeparator, 'mli-3 opacity-50')} />
           {children}
         </div>
         <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}>

--- a/packages/apps/halo-app/src/components/AlertDialog/AlertDialog.tsx
+++ b/packages/apps/halo-app/src/components/AlertDialog/AlertDialog.tsx
@@ -97,7 +97,7 @@ export const AlertDialog = ({
             tabIndex={0}
             {...slots.title}
             className={mx(
-              'text-2xl font-display font-medium text-neutral-900 dark:text-neutral-100 rounded-md',
+              'text-2xl font-system-medium text-neutral-900 dark:text-neutral-100 rounded-md',
               titleVisuallyHidden && 'sr-only',
               defaultFocus,
               slots.title?.className,

--- a/packages/ui/aurora-theme/src/styles/components/main.ts
+++ b/packages/ui/aurora-theme/src/styles/components/main.ts
@@ -17,7 +17,7 @@ export const mainSidebar: ComponentFunction<MainStyleProps> = ({ isLg, sidebarOp
     'fixed block-start-0 block-end-0 is-[100vw] sm:is-[270px] z-10 overscroll-contain overflow-x-hidden overflow-y-auto bg-neutral-25 dark:bg-neutral-850',
     'transition-[inset-inline-start,inset-inline-end] duration-200 ease-in-out',
     sidebarOpen ? 'inline-start-0' : '-inline-start-[100vw] sm:-inline-start-[270px]',
-    surfaceElevation({ elevation: 'chrome' }),
+    sidebarOpen && surfaceElevation({ elevation: 'chrome' }),
     ...etc,
   );
 

--- a/packages/ui/aurora-theme/src/styles/fragments/ornament.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/ornament.ts
@@ -2,5 +2,5 @@
 // Copyright 2022 DXOS.org
 //
 
-export const defaultInlineSeparator = 'border-is border-neutral-300 dark:border-neutral-700';
-export const defaultBlockSeparator = 'border-bs border-neutral-300 dark:border-neutral-700';
+export const defaultInlineSeparator = 'border-is border-neutral-200 dark:border-neutral-800';
+export const defaultBlockSeparator = 'border-bs border-neutral-200 dark:border-neutral-800';

--- a/packages/ui/aurora/src/components/Main/Main.tsx
+++ b/packages/ui/aurora/src/components/Main/Main.tsx
@@ -98,7 +98,7 @@ const MainSidebar = forwardRef<HTMLDivElement, MainSidebarProps>(
     const Root = isLg ? Primitive.div : DialogContent;
     return (
       <Root
-        {...(!isLg && { forceMount: true })}
+        {...(!isLg && { forceMount: true, tabIndex: -1 })}
         {...props}
         className={tx('main.sidebar', 'main__sidebar', { isLg, sidebarOpen }, classNames)}
         ref={ref}

--- a/packages/ui/react-appkit/src/components/Heading/Heading.tsx
+++ b/packages/ui/react-appkit/src/components/Heading/Heading.tsx
@@ -24,6 +24,6 @@ export const Heading = ({ level, ...rootSlot }: PropsWithChildren<HeadingProps>)
   const resolvedLevel = level || 1;
   return createElement(`h${resolvedLevel}`, {
     ...rootSlot,
-    className: mx('font-bold font-display', levelClassNameMap.get(resolvedLevel), rootSlot.className),
+    className: mx('font-system-bold', levelClassNameMap.get(resolvedLevel), rootSlot.className),
   });
 };


### PR DESCRIPTION
Resolves #3342.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6e1f36f</samp>

### Summary
🌳🚨🌄

<!--
1.  🌳 - This emoji represents the `TreeItem` component and the changes related to its padding and alignment.
2.  🚨 - This emoji represents the `AlertDialog` component and the changes related to its font family and heading.
3.  🌄 - This emoji represents the `surfaceElevation` utility and the changes related to its conditional application on the sidebar.
-->
This pull request improves the layout, appearance, and usability of various components in the composer and halo apps, and the aurora and react-appkit UI libraries. It mainly involves adjusting the padding, margin, alignment, size, opacity, and font family of some elements, using some hooks and utilities to handle different screen sizes and pointer types, and changing some border colors to make the separators more subtle. It affects the files `DocumentLinkTreeItem.tsx`, `Sidebar.tsx`, `StandaloneDocumentPage.tsx`, `HiddenSpacesTree.tsx`, `AlertDialog.tsx`, `main.ts`, `ornament.ts`, `Main.tsx`, and `Heading.tsx`.

> _`Sidebar` and `Tree`_
> _Adjusting fonts and spacing_
> _Winter UI polish_

### Walkthrough
*  Close the sidebar on small screens when clicking on a document link ([link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-8d60398455991977c09d201d32cd4061ea1c3e76b0f4a8ffe262e8c7e283566aR19), [link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-8d60398455991977c09d201d32cd4061ea1c3e76b0f4a8ffe262e8c7e283566aL28-R35), [link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-8d60398455991977c09d201d32cd4061ea1c3e76b0f4a8ffe262e8c7e283566aL58-R66))
*  Adjust the padding, margin, and size of various elements in the sidebar to create more space and visibility ([link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-8d60398455991977c09d201d32cd4061ea1c3e76b0f4a8ffe262e8c7e283566aL48-R51), [link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-8d60398455991977c09d201d32cd4061ea1c3e76b0f4a8ffe262e8c7e283566aL96-R104), [link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-8d60398455991977c09d201d32cd4061ea1c3e76b0f4a8ffe262e8c7e283566aL114-R122), [link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-9af28b3e1330cf215f070c08ad34b4483a4e5f2c309179372819528a2927a040L84-R84), [link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-482c9b21fffe3f8d8d5630a3ea7190f05252d6f672a1161ac7de35d8b7b725f5L112-R115), [link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-482c9b21fffe3f8d8d5630a3ea7190f05252d6f672a1161ac7de35d8b7b725f5L160-R163))
*  Remove the elevation shadow from the sidebar when it is closed on small screens ([link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-6cb9ca47f40030efd387c6b913991939307763cd606e18959254290504ded3a8L20-R20), [link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL101-R101))
*  Add a separator between the document title and the document content in the `StandaloneDocumentPage` component ([link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-c74d1db15adcba24f36188ee32b8a257c6d61cae1bc9b4e8ac696d3359e93446L11-R11), [link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-c74d1db15adcba24f36188ee32b8a257c6d61cae1bc9b4e8ac696d3359e93446R68))
*  Reduce the opacity and padding of the document content background in the `StandaloneDocumentPage` component ([link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-c74d1db15adcba24f36188ee32b8a257c6d61cae1bc9b4e8ac696d3359e93446L34-R35), [link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-c74d1db15adcba24f36188ee32b8a257c6d61cae1bc9b4e8ac696d3359e93446L51-R45))
*  Add some margin and reduce the offset of the document menu button and the dropdown menu in the `StandaloneDocumentPage` component ([link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-c74d1db15adcba24f36188ee32b8a257c6d61cae1bc9b4e8ac696d3359e93446L61-R60))
*  Change the font family of the `Heading` component and the `AlertDialog` component from `font-display` to `font-system` ([link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-a9531a93be4c445fc9cb8b1fb6a1fe1b02020f186da3a07ba49e90eaedbb3451L100-R100), [link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-2c474b42c1f9e38681a925a2152af4f39577e5d0f5a5f594398a41db303fcfe7L27-R27))
*  Change the border color of the separators in the `ornament` style fragment to make them more subtle ([link](https://github.com/dxos/dxos/pull/3343/files?diff=unified&w=0#diff-015f0e510d4f7149712b621a35361cfb195e9da00ee7ff03007b1be39e268d09L5-R6))


