### PR TITLE
fix: Fix stale connection init process

### DIFF
--- a/packages/core/mesh/messaging/src/messenger.test.ts
+++ b/packages/core/mesh/messaging/src/messenger.test.ts
@@ -153,10 +153,10 @@ describe('Messenger', () => {
         recipient: peer2.peerId,
         payload: PAYLOAD_1,
       };
+      const promise = peer2.waitTillReceive(message);
       await peer1.messenger.sendMessage(message);
 
       // 3 listeners (default one that was returned by setupPeer() and 2 that listen for type "1") should receive message.
-      const promise = peer2.waitTillReceive(message);
       await asyncTimeout(promise, 1_000);
       expect(onMessage1).toHaveBeenCalledWith([message]);
       expect(onMessage2).toHaveBeenCalledWith([message]);

--- a/packages/core/mesh/messaging/src/timeouts.ts
+++ b/packages/core/mesh/messaging/src/timeouts.ts
@@ -1,0 +1,8 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+/**
+ * Timeout for retrying messages.
+ */
+export const MESSAGE_TIMEOUT = 3_000;

--- a/packages/core/mesh/network-manager/src/signal/message-router.ts
+++ b/packages/core/mesh/network-manager/src/signal/message-router.ts
@@ -26,7 +26,6 @@ interface MessageRouterOptions {
   topic: PublicKey;
 }
 
-const OFFER_TIMEOUT = 2_000;
 /**
  * Adds offer/answer and signal interfaces.
  */
@@ -80,7 +79,7 @@ export class MessageRouter implements SignalMessenger {
 
   async signal(message: SignalMessage): Promise<void> {
     assert(message.data?.signal);
-    await this._sendReliableMessage({
+    return this._sendReliableMessage({
       author: message.author,
       recipient: message.recipient,
       message,
@@ -118,7 +117,7 @@ export class MessageRouter implements SignalMessenger {
     };
 
     log('sending', { from: author, to: recipient, msg: networkMessage });
-    await this._sendMessage({
+    return this._sendMessage({
       author,
       recipient,
       payload: {

--- a/packages/core/mesh/network-manager/src/signal/message-router.ts
+++ b/packages/core/mesh/network-manager/src/signal/message-router.ts
@@ -27,7 +27,7 @@ interface MessageRouterOptions {
   topic: PublicKey;
 }
 
-const OFFER_TIMEOUT = 5_000;
+const OFFER_TIMEOUT = 2_000;
 /**
  * Adds offer/answer and signal interfaces.
  */
@@ -95,7 +95,14 @@ export class MessageRouter implements SignalMessenger {
     };
     return new Promise<Answer>((resolve, reject) => {
       this._offerRecords.set(networkMessage.messageId!, { resolve, reject });
-      scheduleTask(this._ctx, () => reject(new Error(`Offer timeout exceeded ${OFFER_TIMEOUT}`)), OFFER_TIMEOUT);
+      scheduleTask(
+        this._ctx,
+        () => {
+          reject(new Error(`Offer timeout exceeded ${OFFER_TIMEOUT}`));
+          this._offerRecords.delete(networkMessage.messageId!);
+        },
+        OFFER_TIMEOUT,
+      );
       return this._sendReliableMessage({
         author: message.author,
         recipient: message.recipient,

--- a/packages/core/mesh/network-manager/src/swarm/peer.ts
+++ b/packages/core/mesh/network-manager/src/swarm/peer.ts
@@ -169,7 +169,7 @@ export class Peer {
       connection.openConnection();
       this._callbacks.onAccepted();
     } catch (err: any) {
-      log.warn('initiation error', { topic: this.topic, peerId: this.localPeerId, remoteId: this.id, err });
+      log.warn('initiation error', { err, topic: this.topic, peerId: this.localPeerId, remoteId: this.id, err });
       // Calls `onStateChange` with CLOSED state.
       await this.closeConnection();
       throw err;

--- a/packages/core/mesh/network-manager/src/swarm/peer.ts
+++ b/packages/core/mesh/network-manager/src/swarm/peer.ts
@@ -169,7 +169,7 @@ export class Peer {
       connection.openConnection();
       this._callbacks.onAccepted();
     } catch (err: any) {
-      log.warn('initiation error', { err, topic: this.topic, peerId: this.localPeerId, remoteId: this.id, err });
+      log.warn('initiation error', { err, topic: this.topic, peerId: this.localPeerId, remoteId: this.id });
       // Calls `onStateChange` with CLOSED state.
       await this.closeConnection();
       throw err;

--- a/packages/core/mesh/network-manager/src/swarm/peer.ts
+++ b/packages/core/mesh/network-manager/src/swarm/peer.ts
@@ -169,7 +169,7 @@ export class Peer {
       connection.openConnection();
       this._callbacks.onAccepted();
     } catch (err: any) {
-      log.warn('initiation error', { err, topic: this.topic, peerId: this.localPeerId, remoteId: this.id });
+      log('initiation error', { err, topic: this.topic, peerId: this.localPeerId, remoteId: this.id });
       // Calls `onStateChange` with CLOSED state.
       await this.closeConnection();
       throw err;

--- a/packages/core/mesh/network-manager/src/swarm/swarm.ts
+++ b/packages/core/mesh/network-manager/src/swarm/swarm.ts
@@ -316,7 +316,7 @@ export class Swarm {
           try {
             await this._initiateConnection(peer);
           } catch (err: any) {
-            log.warn('initiation error', err);
+            log('initiation error', err);
           }
         });
       },


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2d4471e</samp>

### Summary
🚀⏱️🗂️

<!--
1.  🚀 This emoji can be used to indicate that the code improves the performance or speed of the network manager, as rockets are associated with fast and powerful movement.
2.  ⏱️ This emoji can be used to indicate that the code adds a timeout mechanism, which is a feature related to time management and efficiency. The stopwatch emoji conveys the idea of measuring or limiting the duration of a task or operation.
3.  🗂️ This emoji can be used to indicate that the code uses a context to manage tasks, which is a feature related to organization and structure. The card index emoji conveys the idea of grouping or sorting related items or information.
-->
Improve offer handling logic in `message-router.ts` by using new modules, timeouts, and context. This improves network manager reliability and performance.

> _`offer` logic_
> _imports, timeouts, context_
> _router breathes in spring_

### Walkthrough
* Add a context and a timeout mechanism to the message router ([link](https://github.com/dxos/dxos/pull/3354/files?diff=unified&w=0#diff-9ee946ec06d758b90b540482281c416ddcc34881d905af3b406114a3b58699f2L7-R9), [link](https://github.com/dxos/dxos/pull/3354/files?diff=unified&w=0#diff-9ee946ec06d758b90b540482281c416ddcc34881d905af3b406114a3b58699f2L28-R35), [link](https://github.com/dxos/dxos/pull/3354/files?diff=unified&w=0#diff-9ee946ec06d758b90b540482281c416ddcc34881d905af3b406114a3b58699f2R98)). This allows the message router to cancel pending tasks and reject offers that take too long to respond, avoiding memory leaks and unnecessary rejections. The context is created and destroyed in the constructor and the `destroy` method of the message router, respectively. The timeout is set by the `OFFER_TIMEOUT` constant and is enforced by scheduling a task with the `@dxos/async` module. The task is associated with the context and is canceled if the offer is resolved or the message router is destroyed.


