### PR TITLE
refactor(surface): use selected as source of truth for state

### DIFF
--- a/packages/experimental/surface/project.json
+++ b/packages/experimental/surface/project.json
@@ -45,8 +45,7 @@
       },
       "executor": "@nrwl/storybook:storybook",
       "options": {
-        "configDir": "packages/experimental/surface/.storybook",
-        "uiFramework": "@storybook/react"
+        "configDir": "packages/experimental/surface/.storybook"
       }
     },
     "test": {

--- a/packages/experimental/surface/src/plugins/ListViewPlugin.tsx
+++ b/packages/experimental/surface/src/plugins/ListViewPlugin.tsx
@@ -2,8 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { UIEvent, FC, createContext, useContext, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import React, { UIEvent, FC, createContext, useContext, useState } from 'react';
 
 import { Button } from '@dxos/aurora';
 import { observer } from '@dxos/observable-object/react';
@@ -81,15 +80,7 @@ const Context = createContext<ListViewContextValue>({
 export const useListViewContext = () => useContext(Context);
 
 export const ListViewContainer = () => {
-  const { items, actions, selected, setSelected } = useListViewContext();
-
-  const { spaceId } = useParams();
-  const navigate = useNavigate();
-  useEffect(() => {
-    if (selected && selected?.id !== spaceId) {
-      navigate(`/space/${selected.id}`);
-    }
-  }, [selected, spaceId]);
+  const { items, actions, setSelected } = useListViewContext();
 
   return (
     <div>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dfb65ff</samp>

### Summary
🚚🐛🚀

<!--
1.  🚚 - This emoji represents the removal of the `uiFramework` option from the `storybook` executor, as it implies that something was moved or deleted.
2.  🐛 - This emoji represents the bug fix and code cleanup in `ListViewPlugin.tsx`, as it implies that something was fixed or improved.
3.  🚀 - This emoji represents the addition of navigation logic and URL synchronization to `SpacePlugin.tsx`, as it implies that something was enhanced or launched.
-->
This pull request enhances the navigation and UI of the `ListViewPlugin` and `SpacePlugin` components in the `surface` package. It also removes an unnecessary option from the `storybook` executor in the `project.json` file.

> _Sing, O Muse, of the valiant deeds of the code warriors_
> _Who with skill and wisdom refined their storybook tales_
> _And removed the needless `uiFramework` from their settings_
> _As easily as Zeus hurls his thunderbolts from Olympus._

### Walkthrough
*  Remove `uiFramework` option from `storybook` executor ([link](https://github.com/dxos/dxos/pull/3356/files?diff=unified&w=0#diff-24b1c2eb50f779b4227d7f9eb16ea5ae1802f571a7965e2f0674212f294b4869L48-R48))
  *  Remove unused imports and hook from `ListViewPlugin.tsx` ([link](https://github.com/dxos/dxos/pull/3356/files?diff=unified&w=0#diff-2ac1fdc4bb96e09c22b7e8f1ce8a3fc1925a2f950e83db086bc406d8cf6d613aL5-R5), [link](https://github.com/dxos/dxos/pull/3356/files?diff=unified&w=0#diff-2ac1fdc4bb96e09c22b7e8f1ce8a3fc1925a2f950e83db086bc406d8cf6d613aL84-R84))
  *  Add imports and hook to `SpacePlugin.tsx` and update `isSpace` function and `SpaceMain` component ([link](https://github.com/dxos/dxos/pull/3356/files?diff=unified&w=0#diff-5060139124608a14e7663d87535ada95214df00d68da9f02f390cc156e4c9d14L5-R23))
  *  Add `default` component to `SpacePlugin.tsx` to synchronize URL and selected node ([link](https://github.com/dxos/dxos/pull/3356/files?diff=unified&w=0#diff-5060139124608a14e7663d87535ada95214df00d68da9f02f390cc156e4c9d14L66-R96))


