### PR TITLE
refactor(surface): introduce graph plugin

### DIFF
--- a/packages/experimental/surface/src/plugins/ClientPlugin.tsx
+++ b/packages/experimental/surface/src/plugins/ClientPlugin.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { Client, ClientProvider, Config } from '@dxos/react-client';
 
 import { definePlugin } from '../framework';
-import { GraphPluginProvides } from './ListViewPlugin';
+import { GraphPluginProvides } from './GraphPlugin';
 
 export type ClientPluginProvides = GraphPluginProvides & {
   client: Client;
@@ -27,10 +27,7 @@ export const ClientPlugin = definePlugin<{}, ClientPluginProvides>({
       client,
       context: ({ children }) => <ClientProvider client={client}>{children}</ClientProvider>,
       graph: {
-        actions: (_, parent) => {
-          if (parent) {
-            return [];
-          }
+        actions: () => {
           // TODO(wittjosiah): This is probably not a graph node action, just to expose it in the story for the moment.
           return [
             {

--- a/packages/experimental/surface/src/plugins/GraphPlugin.tsx
+++ b/packages/experimental/surface/src/plugins/GraphPlugin.tsx
@@ -1,0 +1,79 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React, { UIEvent, FC, createContext, useContext } from 'react';
+
+import { definePlugin, Plugin } from '../framework';
+
+export type MaybePromise<T> = T | Promise<T>;
+
+export type GraphNode<TDatum = any> = {
+  id: string;
+  label: string;
+  description?: string;
+  icon?: FC;
+  data?: TDatum; // nit about naming this
+  parent?: GraphNode;
+  children?: GraphNode[];
+  actions?: GraphNodeAction[];
+};
+
+export type GraphNodeAction = {
+  id: string;
+  label: string;
+  icon?: FC;
+  invoke: (event: UIEvent) => MaybePromise<void>;
+};
+
+export type GraphPluginProvides = {
+  graph: {
+    nodes?: (plugins: Plugin[]) => GraphNode[];
+    actions?: (plugins: Plugin[]) => GraphNodeAction[];
+  };
+};
+
+export type GraphPlugin = Plugin<GraphPluginProvides>;
+
+// TODO(wittjosiah): State can be a GraphNode.
+export type GraphContextValue = {
+  roots: { [key: string]: GraphNode[] };
+  actions: { [key: string]: GraphNodeAction[] };
+};
+
+const graph: GraphContextValue = {
+  roots: {},
+  actions: {},
+};
+
+const GraphContext = createContext<GraphContextValue>(graph);
+
+export const useGraphContext = () => useContext(GraphContext);
+
+export const graphPlugins = (plugins: Plugin[]): GraphPlugin[] => {
+  return (plugins as GraphPlugin[]).filter((p) => p.provides?.graph);
+};
+
+export const GraphPlugin = definePlugin({
+  meta: {
+    id: 'dxos:GraphPlugin',
+  },
+  ready: async (plugins) => {
+    for (const plugin of graphPlugins(plugins)) {
+      const nodes = plugin.provides.graph.nodes?.(plugins);
+      if (nodes) {
+        graph.roots[plugin.meta.id] = nodes;
+      }
+
+      const actions = plugin.provides.graph.actions?.(plugins);
+      if (actions) {
+        graph.actions[plugin.meta.id] = actions;
+      }
+    }
+  },
+  provides: {
+    context: ({ children }) => {
+      return <GraphContext.Provider value={graph}>{children}</GraphContext.Provider>;
+    },
+  },
+});

--- a/packages/experimental/surface/src/plugins/ListViewPlugin.tsx
+++ b/packages/experimental/surface/src/plugins/ListViewPlugin.tsx
@@ -2,14 +2,13 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { UIEvent, FC, createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState } from 'react';
 
 import { Button } from '@dxos/aurora';
 import { observer } from '@dxos/observable-object/react';
 
-import { definePlugin, usePluginContext, Plugin } from '../framework';
-
-export type MaybePromise<T> = T | Promise<T>;
+import { definePlugin } from '../framework';
+import { GraphNode, useGraphContext } from './GraphPlugin';
 
 export type ListViewItem = {
   id: string;
@@ -36,51 +35,23 @@ export const ListView = (props: ListViewProps) => {
   );
 };
 
-export type GraphNode<TDatum = any> = {
-  id: string;
-  label: string;
-  description?: string;
-  icon?: FC;
-  data?: TDatum; // nit about naming this
-  actions?: GraphNodeAction[];
-  children?: GraphNode[];
-  parent?: GraphNode;
-};
-
-export type GraphNodeAction = {
-  id: string;
-  label: string;
-  icon?: FC;
-  invoke: (event: UIEvent) => MaybePromise<void>;
-};
-
-export type GraphPluginProvides = {
-  graph: {
-    nodes?: (plugins: Plugin[], parent?: GraphNode) => GraphNode[];
-    actions?: (plugins: Plugin[], parent?: GraphNode) => GraphNodeAction[];
-  };
-};
-
-export type GraphPlugin = Plugin<GraphPluginProvides>;
-
 export type ListViewContextValue = {
-  items: GraphNode[];
-  actions: GraphNodeAction[];
   selected: GraphNode | null;
   setSelected(item: GraphNode | null): any;
 };
 
 const Context = createContext<ListViewContextValue>({
-  items: [],
-  actions: [],
   selected: null,
   setSelected: () => {},
 });
 
 export const useListViewContext = () => useContext(Context);
 
-export const ListViewContainer = () => {
-  const { items, actions, setSelected } = useListViewContext();
+export const ListViewContainer = observer(() => {
+  const graph = useGraphContext();
+  const { setSelected } = useListViewContext();
+
+  const actions = Object.values(graph.actions).reduce((acc, actions) => [...acc, ...actions], []);
 
   return (
     <div>
@@ -91,43 +62,32 @@ export const ListViewContainer = () => {
           </Button>
         ))}
       </div>
-      <ListView
-        items={items?.map((item) => ({ id: item.id, text: item.label }))}
-        onSelect={(id) => setSelected(items.find((item) => item.id === id) ?? null)}
-      />
+      {Object.entries(graph.roots).map(([key, items]) => (
+        <ListView
+          key={key}
+          items={items?.map((item) => ({ id: item.id, text: item.label }))}
+          onSelect={(id) => setSelected(items.find((item) => item.id === id) ?? null)}
+        />
+      ))}
     </div>
   );
-};
+});
 
-const graphPlugins = (plugins: Plugin[]): GraphPlugin[] => {
-  return (plugins as GraphPlugin[]).filter((p) => p.provides?.graph);
-};
 export const ListViewPlugin = definePlugin({
   meta: {
     id: 'dxos:ListViewPlugin',
   },
   provides: {
-    context: observer(({ children }) => {
-      const { plugins } = usePluginContext();
+    context: ({ children }) => {
       const [selected, setSelected] = useState<GraphNode | null>(null);
 
-      const items = graphPlugins(plugins)
-        .flatMap((plugin) => plugin.provides.graph.nodes?.(plugins))
-        .filter((node): node is GraphNode => Boolean(node));
-
-      const actions = graphPlugins(plugins)
-        .flatMap((plugin) => plugin.provides.graph.actions?.(plugins))
-        .filter((node): node is GraphNodeAction => Boolean(node));
-
       const context: ListViewContextValue = {
-        items,
-        actions,
         selected,
         setSelected,
       };
 
       return <Context.Provider value={context}>{children}</Context.Provider>;
-    }),
+    },
     components: { ListView: ListViewContainer },
   },
 });

--- a/packages/experimental/surface/src/plugins/SpacePlugin.tsx
+++ b/packages/experimental/surface/src/plugins/SpacePlugin.tsx
@@ -10,7 +10,8 @@ import { EchoDatabase, PublicKey, Space, useSpace } from '@dxos/react-client';
 
 import { Surface, definePlugin, findPlugin } from '../framework';
 import { ClientPluginProvides } from './ClientPlugin';
-import { GraphNode, GraphPluginProvides, useListViewContext } from './ListViewPlugin';
+import { GraphNode, GraphPluginProvides } from './GraphPlugin';
+import { useListViewContext } from './ListViewPlugin';
 import { RouterPluginProvides } from './RoutesPlugin';
 
 export type SpacePluginProvides = GraphPluginProvides & RouterPluginProvides;
@@ -92,20 +93,10 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
       },
     },
     graph: {
-      nodes: (_plugins, parent) => {
-        if (parent) {
-          return [];
-        }
-
-        return nodes;
-      },
-      actions: (plugins, parent) => {
+      nodes: () => nodes,
+      actions: (plugins) => {
         const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos:ClientPlugin');
         if (!clientPlugin) {
-          return [];
-        }
-
-        if (parent) {
           return [];
         }
 

--- a/packages/experimental/surface/src/plugins/index.ts
+++ b/packages/experimental/surface/src/plugins/index.ts
@@ -2,8 +2,12 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './SplitViewPlugin';
-export * from './ListViewPlugin';
 export * from './ClientPlugin';
-export * from './ThemePlugin';
+export * from './GithubMarkdownPlugin';
+export * from './GraphPlugin';
+export * from './ListViewPlugin';
 export * from './RoutesPlugin';
+export * from './SpacePlugin';
+export * from './SplitViewPlugin';
+export * from './StackPlugin';
+export * from './ThemePlugin';

--- a/packages/experimental/surface/src/stories/TestApp.tsx
+++ b/packages/experimental/surface/src/stories/TestApp.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 
 import { PluginContextProvider } from '../framework';
-import { ThemePlugin, ClientPlugin, SplitViewPlugin, ListViewPlugin, RoutesPlugin } from '../plugins';
+import { ThemePlugin, ClientPlugin, SplitViewPlugin, ListViewPlugin, RoutesPlugin, GraphPlugin } from '../plugins';
 import { GithubMarkdownPlugin } from '../plugins/GithubMarkdownPlugin';
 import { SpacePlugin } from '../plugins/SpacePlugin';
 
@@ -16,6 +16,7 @@ export const TestApp = () => {
         RoutesPlugin,
         ThemePlugin,
         ClientPlugin,
+        GraphPlugin,
         ListViewPlugin,
         SplitViewPlugin,
         SpacePlugin,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f021919</samp>

### Summary
📊♻️🧪

<!--
1.  📊 - This emoji represents the graph functionality and the new `GraphPlugin` that abstracts the graph logic from other plugins.
2.  ♻️ - This emoji represents the refactoring and simplification of the existing plugins that use graph nodes and actions, such as the `ClientPlugin`, the `ListViewPlugin`, and the `SpacePlugin`.
3.  🧪 - This emoji represents the testing and integration of the `GraphPlugin` with the `TestApp` and other plugins.
-->
Refactored several plugins in `dxos/dxos` to use a new `GraphPlugin` that provides a graph context and actions. This reduces code duplication and complexity and improves the integration of graph-based plugins. Added `GraphPlugin` to `TestApp` to enable graph functionality.

> _We are the masters of the graph_
> _We plug in nodes and actions_
> _We refactor and simplify_
> _We unleash the graph's attraction_

### Walkthrough
*  Add `GraphPlugin.tsx` to provide a graph context and collect graph nodes and actions from other plugins ([link](https://github.com/dxos/dxos/pull/3357/files?diff=unified&w=0#diff-d71ca65ed3292ab6e0ad2387f466e37d79597bcdcb3aaf82e45cb77ea9aa0811R1-R79), [link](https://github.com/dxos/dxos/pull/3357/files?diff=unified&w=0#diff-0720911895d23a1cf4a1edf12540d2a2fea40526fc4f3550bc2170ac43302bbaL5-R13), [link](https://github.com/dxos/dxos/pull/3357/files?diff=unified&w=0#diff-2b50cca6230575175f094462109f9f421ab964c71ca47eb2af1fbe9a71613822L8-R8), [link](https://github.com/dxos/dxos/pull/3357/files?diff=unified&w=0#diff-2b50cca6230575175f094462109f9f421ab964c71ca47eb2af1fbe9a71613822R19)).


