### PR TITLE
fix: Add bundle command in publish script for extensions

### DIFF
--- a/.circleci/scripts/publish-extension.sh
+++ b/.circleci/scripts/publish-extension.sh
@@ -18,6 +18,10 @@ if [ $BRANCH = "production" ]; then
     PACKAGE_CAPS=${PACKAGE^^}
     PACKAGE_ENV=${PACKAGE_CAPS//-/_}
 
+    echo ---------------------------------------------------
+    echo "${PACKAGE_ENV}: bundel"
+    eval "pnpm -w nx bundle $PACKAGE"
+    
     eval "CLIENT_ID=$"${PACKAGE_ENV}_CLIENT_ID""
     eval "CLIENT_SECRET=$"${PACKAGE_ENV}_CLIENT_SECRET""
     eval "REFRESH_TOKEN=$"${PACKAGE_ENV}_REFRESH_TOKEN""


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3f93f1d</samp>

### Summary
📦🚀🛠️

<!--
1.  📦 - This emoji represents the bundling of the extension package, which is a significant change that affects the output and distribution of the extension. It also implies that the extension is ready to be shipped or delivered to the users or the marketplace.
2.  🚀 - This emoji represents the improvement of the performance and compatibility of the extension, which is a positive and desirable outcome for the extension users and developers. It also implies that the extension is faster and more reliable than before.
3.  🛠️ - This emoji represents the fixing of some issues with the extension loading, which is a maintenance and bug-fixing change that enhances the quality and stability of the extension. It also implies that the extension is more robust and error-free than before.
-->
Bundles extension packages with `nx` and logs package info in `publish-extension.sh`. This improves the extension publishing and loading process.

> _`publish-extension`_
> _Bundles package with `nx` tool_
> _Winter of bugs ends_

### Walkthrough
* Bundle extension package using nx tool to improve performance and compatibility ([link](https://github.com/dxos/dxos/pull/3367/files?diff=unified&w=0#diff-93c772872a267e00ca5e36929beaf255965dc20845625d046877fb26634d484aR21-R24))
* Print package environment and name for logging purposes ([link](https://github.com/dxos/dxos/pull/3367/files?diff=unified&w=0#diff-93c772872a267e00ca5e36929beaf255965dc20845625d046877fb26634d484aR21-R24))


