### PR TITLE
fix: Encode unknown types as null

### DIFF
--- a/packages/common/codec-protobuf/src/substitutions/struct.ts
+++ b/packages/common/codec-protobuf/src/substitutions/struct.ts
@@ -30,7 +30,7 @@ const encodeStructValue = (structValue: any): any => {
       return { structValue: encodeStruct(structValue) };
     }
     default: {
-      throw new Error(`Unsupported type: ${valueType}`);
+      return { nullValue: 0 };
     }
   }
 };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 43056a0</samp>

### Summary
🐛🚧🙈

<!--
1.  🐛 - This emoji represents a bug fix, since the change fixes a potential crash when encoding unsupported types.
2.  🚧 - This emoji represents a work in progress, since the change is not a complete solution for encoding and decoding all possible types, but rather a temporary workaround to avoid errors.
3.  🙈 - This emoji represents ignoring or hiding something, since the change silently returns a null value instead of throwing an error or warning when encountering an unsupported type.
-->
Fixed a bug in `encodeStructValue` that caused encoding errors for some messages. Changed the function to return null for unsupported value types instead of throwing an error.

> _`encodeStructValue`_
> _Returns null for unknown types_
> _Autumn of errors_

### Walkthrough
*  Return null instead of throwing error for unsupported types in `encodeStructValue` function ([link](https://github.com/dxos/dxos/pull/3369/files?diff=unified&w=0#diff-af495e814c86e169e0b6211f11f31d028e48ae91ba9e98cd85f2058e3b6e4ab7L33-R33)). This fixes the issue of encoding and decoding messages with unknown or undefined values in a struct, as reported in https://github.com/dxos/dxos/issues/101. The file `packages/common/codec-protobuf/src/substitutions/struct.ts` contains this change.


