### PR TITLE
refactor(surface): use store for selection state

### DIFF
--- a/packages/experimental/surface/src/plugins/RoutesPlugin.tsx
+++ b/packages/experimental/surface/src/plugins/RoutesPlugin.tsx
@@ -6,6 +6,8 @@ import React from 'react';
 import { Outlet, RouteObject, useRoutes } from 'react-router';
 import { HashRouter } from 'react-router-dom';
 
+import { observer } from '@dxos/observable-object/react';
+
 import { definePlugin, Plugin, usePluginContext } from '../framework';
 
 export type RouterPluginProvides = {
@@ -21,10 +23,10 @@ const routerPlugins = (plugins: Plugin[]): RouterPlugin[] => {
   return (plugins as RouterPlugin[]).filter((p) => p.provides?.router);
 };
 
-const Root = ({ plugins }: { plugins: RouterPlugin[] }) => {
+const Root = observer(({ plugins }: { plugins: RouterPlugin[] }) => {
   plugins.map((plugin) => plugin.provides.router.useNavigator?.());
   return <Outlet />;
-};
+});
 
 export const RoutesPlugin = definePlugin({
   meta: {

--- a/packages/experimental/surface/src/plugins/SpacePlugin/DocumentLinkTreeItem.tsx
+++ b/packages/experimental/surface/src/plugins/SpacePlugin/DocumentLinkTreeItem.tsx
@@ -20,9 +20,9 @@ export const DocumentLinkTreeItem = observer(({ data: item }: { data: GraphNode<
   const { t } = useTranslation('composer');
   const density = useDensityContext();
   const [isLg] = useMediaQuery('lg', { ssr: false });
-  const { selected, setSelected } = useTreeView();
+  const treeView = useTreeView();
 
-  const active = document.id === selected?.data?.id;
+  const active = document.id === treeView.selected?.data?.id;
   const Icon = document.content?.kind === TextKind.PLAIN ? ArticleMedium : Article;
 
   return (
@@ -39,7 +39,7 @@ export const DocumentLinkTreeItem = observer(({ data: item }: { data: GraphNode<
         <button
           {...(!sidebarOpen && { tabIndex: -1 })}
           onClick={() => {
-            setSelected(item);
+            treeView.selected = item;
             !isLg && closeSidebar();
           }}
           className='text-start flex gap-2'

--- a/packages/experimental/surface/src/plugins/TreeViewPlugin/TreeViewPlugin.tsx
+++ b/packages/experimental/surface/src/plugins/TreeViewPlugin/TreeViewPlugin.tsx
@@ -3,7 +3,7 @@
 //
 
 import { GearSix, Placeholder } from '@phosphor-icons/react';
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext } from 'react';
 
 import {
   Avatar,
@@ -20,6 +20,7 @@ import {
   useTranslation,
 } from '@dxos/aurora';
 import { getSize, mx, osTx } from '@dxos/aurora-theme';
+import { createStore } from '@dxos/observable-object';
 import { useIdentity, observer } from '@dxos/react-client';
 
 import { definePlugin } from '../../framework';
@@ -30,15 +31,15 @@ const TREE_VIEW_PLUGIN = 'dxos:TreeViewPlugin';
 
 export type TreeViewContextValue = {
   selected: GraphNode | null;
-  setSelected(item: GraphNode | null): any;
 };
 
 const Context = createContext<TreeViewContextValue>({
   selected: null,
-  setSelected: () => {},
 });
 
 export const useTreeView = () => useContext(Context);
+
+const store = createStore<TreeViewContextValue>({ selected: null });
 
 export const TreeViewContainer = observer(() => {
   const graph = useGraphContext();
@@ -120,20 +121,18 @@ export const TreeViewContainer = observer(() => {
   );
 });
 
-export const TreeViewPlugin = definePlugin({
+export type TreeViewProvides = {
+  treeView: TreeViewContextValue;
+};
+
+export const TreeViewPlugin = definePlugin<TreeViewProvides, {}>({
   meta: {
     id: TREE_VIEW_PLUGIN,
   },
   provides: {
+    treeView: store,
     context: ({ children }) => {
-      const [selected, setSelected] = useState<GraphNode | null>(null);
-
-      const context: TreeViewContextValue = {
-        selected,
-        setSelected,
-      };
-
-      return <Context.Provider value={context}>{children}</Context.Provider>;
+      return <Context.Provider value={store}>{children}</Context.Provider>;
     },
     components: { TreeView: TreeViewContainer },
   },


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 598c13d</samp>

### Summary
🔧🧠🌲

<!--
1.  🔧 - This emoji represents refactoring or improving code quality, which is the main theme of these changes.
2.  🧠 - This emoji represents using MobX or observables for state management, which is a smart and efficient way of handling complex and dynamic data.
3.  🌲 - This emoji represents the tree view component and plugin, which are the main features affected by these changes.
-->
This pull request introduces a major refactoring of the state management logic in several components and plugins of the `surface` package. It replaces the use of React hooks with MobX observables from the `@dxos/observable-object` package, which simplifies the code and improves the reactivity of the UI. It also adds some type annotations and imports to support the new approach.

> _`observer` wraps_
> _components with MobX state_
> _autumn leaves react_

### Walkthrough
*  Refactor state management to use `@dxos/observable-object` package instead of React hooks ([link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-3a3d8fcaff708960fef03fa481b2ea141183c92f879440f655e0745b031d6b27R9-R10), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-3a3d8fcaff708960fef03fa481b2ea141183c92f879440f655e0745b031d6b27L24-R29), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-b1aa6cd28970df833225f71a14374f479a60476b33a3d1a217a193f8ef1a74b9L23-R25), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-b1aa6cd28970df833225f71a14374f479a60476b33a3d1a217a193f8ef1a74b9L42-R42), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-a4a1e2ea0d3ca92b09b3dec82d1e971cb6f26581f3e86252c771a698ed6df4a6R12), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-a4a1e2ea0d3ca92b09b3dec82d1e971cb6f26581f3e86252c771a698ed6df4a6L30-R38), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-a4a1e2ea0d3ca92b09b3dec82d1e971cb6f26581f3e86252c771a698ed6df4a6L140-R170), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-af7da38b312dd2755c2b868e32f33174cc968df75229b7ae914422ba0f5f962bL6-R6), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-af7da38b312dd2755c2b868e32f33174cc968df75229b7ae914422ba0f5f962bR23), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-af7da38b312dd2755c2b868e32f33174cc968df75229b7ae914422ba0f5f962bL33-R43), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-af7da38b312dd2755c2b868e32f33174cc968df75229b7ae914422ba0f5f962bL123-R135))
  * Import `observer` function from `@dxos/observable-object/react` and wrap components with it to make them reactive to observable objects ([link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-3a3d8fcaff708960fef03fa481b2ea141183c92f879440f655e0745b031d6b27R9-R10), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-3a3d8fcaff708960fef03fa481b2ea141183c92f879440f655e0745b031d6b27L24-R29), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-a4a1e2ea0d3ca92b09b3dec82d1e971cb6f26581f3e86252c771a698ed6df4a6R12), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-a4a1e2ea0d3ca92b09b3dec82d1e971cb6f26581f3e86252c771a698ed6df4a6L30-R38))
  * Create `store` object using `createStore` function from `@dxos/observable-object` and use it to hold the `selected` property for the tree view ([link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-af7da38b312dd2755c2b868e32f33174cc968df75229b7ae914422ba0f5f962bR23), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-af7da38b312dd2755c2b868e32f33174cc968df75229b7ae914422ba0f5f962bL33-R43), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-af7da38b312dd2755c2b868e32f33174cc968df75229b7ae914422ba0f5f962bL123-R135))
  * Rename `selected` and `setSelected` variables to `treeView` and `treeView.selected` and update references to them in components and logic ([link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-b1aa6cd28970df833225f71a14374f479a60476b33a3d1a217a193f8ef1a74b9L23-R25), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-b1aa6cd28970df833225f71a14374f479a60476b33a3d1a217a193f8ef1a74b9L42-R42), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-a4a1e2ea0d3ca92b09b3dec82d1e971cb6f26581f3e86252c771a698ed6df4a6L30-R38), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-a4a1e2ea0d3ca92b09b3dec82d1e971cb6f26581f3e86252c771a698ed6df4a6L140-R170))
  * Simplify `TreeViewContextValue` type and `Context` value to only include the `store` object ([link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-af7da38b312dd2755c2b868e32f33174cc968df75229b7ae914422ba0f5f962bL33-R43), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-af7da38b312dd2755c2b868e32f33174cc968df75229b7ae914422ba0f5f962bL123-R135))
  * Remove `useState` and `context` logic as they are no longer needed ([link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-af7da38b312dd2755c2b868e32f33174cc968df75229b7ae914422ba0f5f962bL6-R6), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-af7da38b312dd2755c2b868e32f33174cc968df75229b7ae914422ba0f5f962bL123-R135))
* Add `FC` type alias from `react` to the import statement and type `SpaceMain` component as a `FC<{}>` ([link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-a4a1e2ea0d3ca92b09b3dec82d1e971cb6f26581f3e86252c771a698ed6df4a6L6-R6), [link](https://github.com/dxos/dxos/pull/3370/files?diff=unified&w=0#diff-a4a1e2ea0d3ca92b09b3dec82d1e971cb6f26581f3e86252c771a698ed6df4a6L30-R38))


