### PR TITLE
refactor(surface): store selection state as ids

### DIFF
--- a/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/GithubMarkdownPlugin.tsx
+++ b/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/GithubMarkdownPlugin.tsx
@@ -23,7 +23,7 @@ export const GithubMarkdownPlugin: PluginDefinition = definePlugin({
     context: (props) => <OctokitProvider {...props} />,
     component: (datum, role) => {
       if (Array.isArray(datum) && role === 'main') {
-        const [childDatum, parentDatum] = datum;
+        const [parentDatum, childDatum] = datum;
         switch (true) {
           case isDocument(childDatum) && isSpace(parentDatum):
             return MainOne;

--- a/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/components/MainOne/MainOne.tsx
+++ b/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/components/MainOne/MainOne.tsx
@@ -46,8 +46,8 @@ type GhIdentifier = GhFileIdentifier | GhIssueIdentifier;
 
 type ExportViewState = 'create-pr' | 'pending' | 'response' | null;
 
-export const MainOne = ({ data }: { data: [Document, Space] }) => {
-  const [document, space]: [Document, Space] = data;
+export const MainOne = ({ data }: { data: [Space, Document] }) => {
+  const [space, document]: [Space, Document] = data;
   const [editorViewState, setEditorViewState] = useState<'editor' | 'preview'>('editor');
   const [layout, _setLayout] = useState<'standalone' | 'embedded'>('standalone');
 

--- a/packages/experimental/surface/src/plugins/SpacePlugin/DocumentLinkTreeItem.tsx
+++ b/packages/experimental/surface/src/plugins/SpacePlugin/DocumentLinkTreeItem.tsx
@@ -22,7 +22,7 @@ export const DocumentLinkTreeItem = observer(({ data: item }: { data: GraphNode<
   const [isLg] = useMediaQuery('lg', { ssr: false });
   const treeView = useTreeView();
 
-  const active = document.id === treeView.selected?.data?.id;
+  const active = document.id === treeView.selected[1];
   const Icon = document.content?.kind === TextKind.PLAIN ? ArticleMedium : Article;
 
   return (
@@ -39,7 +39,7 @@ export const DocumentLinkTreeItem = observer(({ data: item }: { data: GraphNode<
         <button
           {...(!sidebarOpen && { tabIndex: -1 })}
           onClick={() => {
-            treeView.selected = item;
+            treeView.selected = [item.parent!.id, item.id];
             !isLg && closeSidebar();
           }}
           className='text-start flex gap-2'

--- a/packages/experimental/surface/src/plugins/TreeViewPlugin/TreeViewPlugin.tsx
+++ b/packages/experimental/surface/src/plugins/TreeViewPlugin/TreeViewPlugin.tsx
@@ -24,22 +24,21 @@ import { createStore } from '@dxos/observable-object';
 import { useIdentity, observer } from '@dxos/react-client';
 
 import { definePlugin } from '../../framework';
-import { GraphNode, useGraphContext } from '../GraphPlugin';
+import { useGraphContext } from '../GraphPlugin';
 import { TreeView } from './TreeView';
 
 const TREE_VIEW_PLUGIN = 'dxos:TreeViewPlugin';
 
+// TODO(wittjosiah): Derive graph nodes from selected.
 export type TreeViewContextValue = {
-  selected: GraphNode | null;
+  selected: string[];
 };
 
-const Context = createContext<TreeViewContextValue>({
-  selected: null,
-});
+const store = createStore<TreeViewContextValue>({ selected: [] });
+
+const Context = createContext<TreeViewContextValue>(store);
 
 export const useTreeView = () => useContext(Context);
-
-const store = createStore<TreeViewContextValue>({ selected: null });
 
 export const TreeViewContainer = observer(() => {
   const graph = useGraphContext();


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bd3d41c</samp>

### Summary
🔄🛠️🆔

<!--
1.  🔄 - This emoji can be used to indicate that the order of some elements was swapped or reversed, such as the data array and the destructuring of [space, document].
2.  🛠️ - This emoji can be used to indicate that some code was refactored or improved, such as the TreeViewContextValue type, the store and context declaration, and the SpaceMain component logic.
3.  🆔 - This emoji can be used to indicate that some identifiers were changed or added, such as the treeView.selected array and the document link tree items.
-->
Refactored the SpacePlugin and the GithubMarkdownPlugin to use consistent and unique identifiers for the tree items and the data array. Changed the TreeViewContextValue type to use an array of strings. Fixed some type checks and circular dependencies.

> _Sing, O Muse, of the skillful coder who changed the order_
> _of data arrays and destructured them with care, `space` and `document`_
> _matching the new design of `F0L24R24`, a work of art sublime and clever._
> _He also altered the `TreeViewContextValue` type, using strings as identifiers_

### Walkthrough
*  Swap the order of the data array in `GithubMarkdownPlugin.tsx` and `MainOne.tsx` to match the expected order of [parentDatum, childDatum] in the Surface component. ([link](https://github.com/dxos/dxos/pull/3371/files?diff=unified&w=0#diff-6ac4c3aa7254e0d00b13a329d500d8dd33d5e097a9e7a4d4e844a41676044b69L26-R26), [link](https://github.com/dxos/dxos/pull/3371/files?diff=unified&w=0#diff-a732cbcbcf5ce4047d2319d20c152a233431dda32b2a2d995d1188a52578fe72L49-R50))
* Change the selection logic in `DocumentLinkTreeItem.tsx` and `SpacePlugin.tsx` to use an array of ids instead of node objects and parent properties, to simplify the logic and avoid storing references to graph nodes. ([link](https://github.com/dxos/dxos/pull/3371/files?diff=unified&w=0#diff-b1aa6cd28970df833225f71a14374f479a60476b33a3d1a217a193f8ef1a74b9L25-R25), [link](https://github.com/dxos/dxos/pull/3371/files?diff=unified&w=0#diff-b1aa6cd28970df833225f71a14374f479a60476b33a3d1a217a193f8ef1a74b9L42-R42), [link](https://github.com/dxos/dxos/pull/3371/files?diff=unified&w=0#diff-a4a1e2ea0d3ca92b09b3dec82d1e971cb6f26581f3e86252c771a698ed6df4a6L33-R40), [link](https://github.com/dxos/dxos/pull/3371/files?diff=unified&w=0#diff-a4a1e2ea0d3ca92b09b3dec82d1e971cb6f26581f3e86252c771a698ed6df4a6L148-R154), [link](https://github.com/dxos/dxos/pull/3371/files?diff=unified&w=0#diff-a4a1e2ea0d3ca92b09b3dec82d1e971cb6f26581f3e86252c771a698ed6df4a6L159-R173))
* Update the TreeViewContextValue type and the default value in `TreeViewPlugin.tsx` to use an array of strings instead of a GraphNode or null, to match the changes in the selection logic. ([link](https://github.com/dxos/dxos/pull/3371/files?diff=unified&w=0#diff-af7da38b312dd2755c2b868e32f33174cc968df75229b7ae914422ba0f5f962bL27-R42))
* Remove the unused import of isTypedObject and add the import of useGraphContext in `SpacePlugin.tsx` to access the graph nodes in the SpaceMain component. ([link](https://github.com/dxos/dxos/pull/3371/files?diff=unified&w=0#diff-a4a1e2ea0d3ca92b09b3dec82d1e971cb6f26581f3e86252c771a698ed6df4a6L13-R18))
* Remove the unreliable type checks for isSpace and isTypedObject in `SpacePlugin.tsx` and add TODO comments for future improvement. ([link](https://github.com/dxos/dxos/pull/3371/files?diff=unified&w=0#diff-a4a1e2ea0d3ca92b09b3dec82d1e971cb6f26581f3e86252c771a698ed6df4a6L159-R173))


