### PR TITLE
feat(surface): Icons, dialogs, other harmonizations

### DIFF
--- a/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/GithubMarkdownPlugin.tsx
+++ b/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/GithubMarkdownPlugin.tsx
@@ -10,7 +10,7 @@ import { isTypedObject } from '@dxos/react-client';
 
 import { definePlugin, PluginDefinition } from '../../framework';
 import { isSpace } from '../SpacePlugin';
-import { MainAll, MainOne, OctokitProvider } from './components';
+import { MainAll, MainOne, OctokitProvider, PatDialog } from './components';
 
 export const isDocument = (datum: unknown): datum is Document =>
   isTypedObject(datum) && Document.type.name === datum.__typename;
@@ -30,6 +30,8 @@ export const GithubMarkdownPlugin: PluginDefinition = definePlugin({
           default:
             return null;
         }
+      } else if (role === 'dialog' && datum === 'dxos:SplitViewPlugin/ProfileSettings') {
+        return PatDialog;
       } else {
         return null;
       }

--- a/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/components/GithubContext/PatDialog.tsx
+++ b/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/components/GithubContext/PatDialog.tsx
@@ -2,46 +2,32 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
-import { Button, useTranslation } from '@dxos/aurora';
-import { Dialog, Input } from '@dxos/react-appkit';
+import { useTranslation } from '@dxos/aurora';
+import { Input } from '@dxos/react-appkit';
 
+import { useSplitViewContext } from '../../../SplitViewPlugin';
 import { useOctokitContext } from './OctokitProvider';
 
-export type PatDialogProps = {
-  open: boolean;
-  setOpen: Dispatch<SetStateAction<boolean>>;
-  title?: string;
-  description?: string;
-};
-
-export const PatDialog = ({ open, setOpen, title, description }: PatDialogProps) => {
+export const PatDialog = () => {
   const { t } = useTranslation('composer');
   const { pat, setPat } = useOctokitContext();
   const [patValue, setPatValue] = useState(pat);
+  const { dialogOpen } = useSplitViewContext();
 
   useEffect(() => {
     setPatValue(pat);
   }, [pat]);
 
+  useEffect(() => {
+    if (!dialogOpen) {
+      void setPat(patValue);
+    }
+  }, [dialogOpen]);
+
   return (
-    <Dialog
-      title={title ?? t('profile settings label')}
-      {...(description && { description })}
-      open={open}
-      onOpenChange={(nextOpen) => {
-        setOpen(nextOpen);
-        if (!nextOpen) {
-          void setPat(patValue);
-        }
-      }}
-      closeTriggers={[
-        <Button key='a1' variant='primary' data-testid='composer.closeUserSettingsDialog'>
-          {t('done label', { ns: 'os' })}
-        </Button>,
-      ]}
-    >
+    <>
       <Input
         label={t('github pat label')}
         value={patValue}
@@ -52,6 +38,6 @@ export const PatDialog = ({ open, setOpen, title, description }: PatDialogProps)
           input: { autoFocus: true, spellCheck: false, className: 'font-mono' },
         }}
       />
-    </Dialog>
+    </>
   );
 };

--- a/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/components/MainOne/GfmPreview.tsx
+++ b/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/components/MainOne/GfmPreview.tsx
@@ -9,7 +9,8 @@ import React, { useEffect, useState } from 'react';
 import { Button, useTranslation } from '@dxos/aurora';
 import { Loading } from '@dxos/react-appkit';
 
-import { useOctokitContext, PatDialog } from '../../components';
+import { useSplitViewContext } from '../../../SplitViewPlugin';
+import { useOctokitContext } from '../../components';
 
 const defaultOptions: Parameters<typeof DOMPurify.sanitize>[1] = {
   ALLOWED_TAGS: [
@@ -77,7 +78,7 @@ export const GfmPreview = ({ markdown, owner, repo }: GfmPreviewProps) => {
   const [html, setHtml] = useState('');
   const { octokit } = useOctokitContext();
   const { t } = useTranslation('composer');
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const splitViewContext = useSplitViewContext();
 
   useEffect(() => {
     if (octokit && markdown) {
@@ -103,12 +104,18 @@ export const GfmPreview = ({ markdown, owner, repo }: GfmPreviewProps) => {
     </>
   ) : (
     <div role='none' className='mli-auto max-bs-[300px] text-center'>
-      <PatDialog open={dialogOpen} setOpen={setDialogOpen} />
       {!octokit && <p className='mlb-4'>{t('empty github pat message')}</p>}
       {octokit ? (
         <Loading label={t('loading preview message')} />
       ) : (
-        <Button onClick={() => setDialogOpen(true)}>{t('set github pat label')}</Button>
+        <Button
+          onClick={() => {
+            splitViewContext.dialogOpen = true;
+            splitViewContext.dialogContent = 'dxos:SplitViewPlugin/ProfileSettings';
+          }}
+        >
+          {t('set github pat label')}
+        </Button>
       )}
     </div>
   );

--- a/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/components/MainOne/MainOne.tsx
+++ b/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/components/MainOne/MainOne.tsx
@@ -16,11 +16,11 @@ import {
 import React, { HTMLAttributes, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Document } from '@braneframe/types';
-import { Button, Main, Trans, DropdownMenu, useTranslation } from '@dxos/aurora';
+import { Button, Main, Dialog, Trans, DropdownMenu, useTranslation } from '@dxos/aurora';
 import { Composer, MarkdownComposerRef } from '@dxos/aurora-composer';
 import { defaultFocus, getSize, mx } from '@dxos/aurora-theme';
 import { log } from '@dxos/log';
-import { Dialog, Input } from '@dxos/react-appkit';
+import { Dialog as AppkitDialog, Input } from '@dxos/react-appkit';
 import { Space, useIdentity } from '@dxos/react-client';
 
 import { PatDialog, useOctokitContext } from '../GithubContext';
@@ -409,17 +409,22 @@ export const MainOne = ({ data }: { data: [Space, Document] }) => {
           )}
         </StandaloneDocumentPage>
       )}
-      <PatDialog
-        open={staleDialogOpen}
-        setOpen={setStaleDialogOpen}
-        title={t('stale rescue title')}
-        description={t('stale rescue description')}
-      />
-      <Dialog
+      <Dialog.Root open={staleDialogOpen} onOpenChange={setStaleDialogOpen}>
+        <Dialog.Overlay>
+          <Dialog.Portal>
+            <Dialog.Content>
+              <Dialog.Title>{t('stale rescue title')}</Dialog.Title>
+              <Dialog.Description>{t('stale rescue description')}</Dialog.Description>
+              <PatDialog />
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Overlay>
+      </Dialog.Root>
+      <AppkitDialog
         title={t('bind to file in github label')}
         open={ghBindOpen}
         onOpenChange={(nextOpen) => {
-          if (ghId && document?.meta) {
+          if (ghId && document) {
             const key = { source: 'com.github', id: ghId };
             // TODO(wittjosiah): Stop overwriting document.meta.
             document.meta = { keys: [key] };
@@ -444,8 +449,8 @@ export const MainOne = ({ data }: { data: [Space, Document] }) => {
               validationMessage: t('error github markdown path message'),
             })}
         />
-      </Dialog>
-      <Dialog
+      </AppkitDialog>
+      <AppkitDialog
         title={t('confirm import title')}
         open={importConfirmOpen}
         onOpenChange={setImportConfirmOpen}
@@ -462,8 +467,8 @@ export const MainOne = ({ data }: { data: [Space, Document] }) => {
         ]}
       >
         <p className='plb-2'>{t('confirm import body')}</p>
-      </Dialog>
-      <Dialog
+      </AppkitDialog>
+      <AppkitDialog
         title={t('confirm export title')}
         open={!!exportViewState}
         onOpenChange={(nextOpen) => {
@@ -526,7 +531,7 @@ export const MainOne = ({ data }: { data: [Space, Document] }) => {
             </div>
           </div>
         )}
-      </Dialog>
+      </AppkitDialog>
     </Main.Content>
   );
 };

--- a/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/components/MainOne/StandaloneDocumentPage.tsx
+++ b/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/components/MainOne/StandaloneDocumentPage.tsx
@@ -56,7 +56,7 @@ export const StandaloneDocumentPage = observer(
               }}
             />
             <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}>
-              <DropdownMenu.Root>
+              <DropdownMenu.Root modal={false}>
                 <DropdownMenu.Trigger asChild>
                   <Button classNames='p-0 is-10 shrink-0' variant='ghost' density='coarse'>
                     <DotsThreeVertical className={getSize(6)} />

--- a/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/components/MainOne/StandaloneDocumentPage.tsx
+++ b/packages/experimental/surface/src/plugins/GithubMarkdownPlugin/components/MainOne/StandaloneDocumentPage.tsx
@@ -8,7 +8,7 @@ import { FileUploader } from 'react-drag-drop-files';
 
 import { Document } from '@braneframe/types';
 import { Button, DropdownMenu, ThemeContext, useThemeContext, useTranslation } from '@dxos/aurora';
-import { getSize, osTx } from '@dxos/aurora-theme';
+import { defaultBlockSeparator, getSize, mx, osTx } from '@dxos/aurora-theme';
 import { Dialog, Input } from '@dxos/react-appkit';
 import { observer } from '@dxos/react-client';
 
@@ -31,14 +31,8 @@ export const StandaloneDocumentPage = observer(
     const themeContext = useThemeContext();
     return (
       <>
-        <div
-          role='none'
-          className='mli-auto max-is-[60rem] min-bs-[100vh] bg-white/20 dark:bg-neutral-850/20 flex flex-col'
-        >
-          <div
-            role='none'
-            className='flex items-center gap-2 bg-neutral-500/20 pis-0 pointer-fine:pis-8 lg:pis-0 pointer-fine:lg:pis-0'
-          >
+        <div role='none' className='mli-auto max-is-[60rem] min-bs-[100vh] bg-white dark:bg-neutral-925 flex flex-col'>
+          <div role='none' className='flex items-center gap-2 pis-0 pointer-fine:pis-8 lg:pis-0 pointer-fine:lg:pis-0'>
             <Input
               key={document.id}
               variant='subdued'
@@ -48,7 +42,7 @@ export const StandaloneDocumentPage = observer(
               value={document.title ?? ''}
               onChange={({ target: { value } }) => (document.title = value)}
               slots={{
-                root: { className: 'shrink-0 grow pis-6 plb-1' },
+                root: { className: 'shrink-0 grow pis-6 plb-1.5 pointer-fine:plb-0.5' },
                 input: {
                   'data-testid': 'composer.documentTitle',
                   className: 'text-center',
@@ -58,7 +52,7 @@ export const StandaloneDocumentPage = observer(
             <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}>
               <DropdownMenu.Root modal={false}>
                 <DropdownMenu.Trigger asChild>
-                  <Button classNames='p-0 is-10 shrink-0' variant='ghost' density='coarse'>
+                  <Button classNames='p-0 is-10 shrink-0 mie-3' variant='ghost' density='coarse'>
                     <DotsThreeVertical className={getSize(6)} />
                   </Button>
                 </DropdownMenu.Trigger>
@@ -71,6 +65,7 @@ export const StandaloneDocumentPage = observer(
               </DropdownMenu.Root>
             </ThemeContext.Provider>
           </div>
+          <div role='separator' className={mx(defaultBlockSeparator, 'mli-3 opacity-50')} />
           {children}
         </div>
         <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}>

--- a/packages/experimental/surface/src/plugins/GraphPlugin.tsx
+++ b/packages/experimental/surface/src/plugins/GraphPlugin.tsx
@@ -2,6 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
+import { IconProps } from '@phosphor-icons/react';
 import React, { UIEvent, FC, createContext, useContext } from 'react';
 
 import { definePlugin, Plugin } from '../framework';
@@ -23,7 +24,7 @@ export type GraphNode<TDatum = any> = {
 export type GraphNodeAction = {
   id: string;
   label: string;
-  icon?: FC;
+  icon?: FC<IconProps>;
   invoke: (event: UIEvent) => MaybePromise<void>;
 };
 

--- a/packages/experimental/surface/src/plugins/SpacePlugin/DialogRenameSpace.tsx
+++ b/packages/experimental/surface/src/plugins/SpacePlugin/DialogRenameSpace.tsx
@@ -1,0 +1,30 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React from 'react';
+
+import { Button, Dialog, Input, useTranslation } from '@dxos/aurora';
+import { Space } from '@dxos/client';
+
+export const DialogRenameSpace = ({ data: [_, space] }: { data: [string, Space] }) => {
+  const { t } = useTranslation('composer');
+  // todo(thure): Why does the input value need to be uncontrolled to work?
+  return (
+    <>
+      <Dialog.Title tabIndex={-1}>{t('space name label')}</Dialog.Title>
+      <Input.Root>
+        <Input.Label srOnly>{t('space name label')}</Input.Label>
+        <Input.TextInput
+          defaultValue={space.properties.name ?? ''}
+          placeholder={t('untitled space title')}
+          onChange={({ target: { value } }) => (space.properties.name = value)}
+          classNames='mlb-2'
+        />
+      </Input.Root>
+      <Dialog.Close asChild>
+        <Button classNames='mbs-2'>{t('done label', { ns: 'os' })}</Button>
+      </Dialog.Close>
+    </>
+  );
+};

--- a/packages/experimental/surface/src/plugins/SpacePlugin/DialogRenameSpace.tsx
+++ b/packages/experimental/surface/src/plugins/SpacePlugin/DialogRenameSpace.tsx
@@ -12,14 +12,15 @@ export const DialogRenameSpace = ({ data: [_, space] }: { data: [string, Space] 
   // todo(thure): Why does the input value need to be uncontrolled to work?
   return (
     <>
-      <Dialog.Title tabIndex={-1}>{t('space name label')}</Dialog.Title>
+      <Dialog.Title tabIndex={-1} classNames='mbe-1'>
+        {t('space name label')}
+      </Dialog.Title>
       <Input.Root>
         <Input.Label srOnly>{t('space name label')}</Input.Label>
         <Input.TextInput
           defaultValue={space.properties.name ?? ''}
           placeholder={t('untitled space title')}
           onChange={({ target: { value } }) => (space.properties.name = value)}
-          classNames='mlb-2'
         />
       </Input.Root>
       <Dialog.Close asChild>

--- a/packages/experimental/surface/src/plugins/SpacePlugin/FullSpaceTreeItem.tsx
+++ b/packages/experimental/surface/src/plugins/SpacePlugin/FullSpaceTreeItem.tsx
@@ -27,7 +27,7 @@ export const FullSpaceTreeItem = observer(({ data: item }: { data: GraphNode<Spa
 
   const suppressNextTooltip = useRef<boolean>(false);
   const [optionsTooltipOpen, setOptionsTooltipOpen] = useState(false);
-  const [optionsMenuOpen, setOpetionsMenuOpen] = useState(false);
+  const [optionsMenuOpen, setOptionsMenuOpen] = useState(false);
 
   const [open, setOpen] = useState(true /* todo(thure): Open if document within is selected */);
 
@@ -89,7 +89,7 @@ export const FullSpaceTreeItem = observer(({ data: item }: { data: GraphNode<Spa
                 if (!nextOpen) {
                   suppressNextTooltip.current = true;
                 }
-                return setOpetionsMenuOpen(nextOpen);
+                return setOptionsMenuOpen(nextOpen);
               },
             }}
           >
@@ -108,8 +108,17 @@ export const FullSpaceTreeItem = observer(({ data: item }: { data: GraphNode<Spa
             <DropdownMenu.Portal>
               <DropdownMenu.Content classNames='z-[31]'>
                 {actions.map((action) => (
-                  <DropdownMenu.Item key={action.id} onClick={action.invoke} classNames='gap-2'>
-                    <Placeholder className={getSize(4)} />
+                  <DropdownMenu.Item
+                    key={action.id}
+                    onClick={(event) => {
+                      // todo(thure): Why does Dialog’s modal-ness cause issues if we don’t explicitly close the menu here?
+                      suppressNextTooltip.current = true;
+                      setOptionsMenuOpen(false);
+                      void action.invoke(event);
+                    }}
+                    classNames='gap-2'
+                  >
+                    {action.icon && <action.icon className={getSize(4)} />}
                     <span>{action.label}</span>
                   </DropdownMenu.Item>
                 ))}
@@ -135,7 +144,11 @@ export const FullSpaceTreeItem = observer(({ data: item }: { data: GraphNode<Spa
                 {...(!sidebarOpen && { tabIndex: -1 })}
               >
                 <span className='sr-only'>{primaryAction.label}</span>
-                <Placeholder className={getSize(4)} />
+                {primaryAction.icon ? (
+                  <primaryAction.icon className={getSize(4)} />
+                ) : (
+                  <Placeholder className={getSize(4)} />
+                )}
               </Button>
             </Tooltip.Trigger>
           </Tooltip.Root>

--- a/packages/experimental/surface/src/plugins/SpacePlugin/SpacePlugin.tsx
+++ b/packages/experimental/surface/src/plugins/SpacePlugin/SpacePlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Planet } from '@phosphor-icons/react';
+import { EyeSlash, Intersect, PaperPlane, PencilSimple, Planet, Plus } from '@phosphor-icons/react';
 import { FC, useEffect } from 'react';
 import React, { useNavigate, useParams } from 'react-router';
 
@@ -26,7 +26,9 @@ import { ClientPluginProvides } from '../ClientPlugin';
 import { isDocument } from '../GithubMarkdownPlugin';
 import { GraphNode, GraphProvides, useGraphContext } from '../GraphPlugin';
 import { RouterPluginProvides } from '../RoutesPlugin';
+import { SplitViewProvides } from '../SplitViewPlugin';
 import { TreeViewProvides, useTreeView } from '../TreeViewPlugin';
+import { DialogRenameSpace } from './DialogRenameSpace';
 import { DocumentLinkTreeItem } from './DocumentLinkTreeItem';
 import { FullSpaceTreeItem } from './FullSpaceTreeItem';
 
@@ -81,6 +83,7 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
   ready: async (plugins) => {
     const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos:ClientPlugin');
     const treeViewPlugin = findPlugin<TreeViewProvides>(plugins, 'dxos:TreeViewPlugin');
+    const splitViewPlugin = findPlugin<SplitViewProvides>(plugins, 'dxos:SplitViewPlugin');
     if (!clientPlugin) {
       return;
     }
@@ -103,6 +106,7 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
               {
                 id: 'create-doc',
                 label: 'Create document',
+                icon: Plus,
                 invoke: async () => {
                   const document = space.db.add(new Document());
                   if (treeViewPlugin) {
@@ -113,13 +117,18 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
               {
                 id: 'rename-space',
                 label: 'Rename space',
+                icon: PencilSimple,
                 invoke: async () => {
-                  // TODO(wittjosiah): Space meta dialog.
+                  if (splitViewPlugin?.provides.splitView) {
+                    splitViewPlugin.provides.splitView.dialogOpen = true;
+                    splitViewPlugin.provides.splitView.dialogContent = ['dxos:SpacePlugin/RenameSpaceDialog', space];
+                  }
                 },
               },
               {
                 id: 'view-invitations',
                 label: 'View invitations',
+                icon: PaperPlane,
                 invoke: async () => {
                   await clientPlugin.provides.setLayout(ShellLayout.SPACE_INVITATIONS, { spaceKey: space.key });
                 },
@@ -127,6 +136,7 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
               {
                 id: 'hide-space',
                 label: 'Hide space',
+                icon: EyeSlash,
                 invoke: async () => {
                   if (identity) {
                     const identityHex = identity.identityKey.toHex();
@@ -296,6 +306,15 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
             default:
               return null;
           }
+        case 'dialog':
+          switch (true) {
+            case Array.isArray(datum) && datum[0] === 'dxos:SpacePlugin/RenameSpaceDialog':
+              return DialogRenameSpace;
+            default:
+              return null;
+          }
+        default:
+          return null;
       }
     },
     components: {
@@ -314,6 +333,7 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
           {
             id: 'create-space',
             label: 'Create space',
+            icon: Planet,
             invoke: async () => {
               await clientPlugin.provides.client.createSpace();
             },
@@ -321,6 +341,7 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
           {
             id: 'join-space',
             label: 'Join space',
+            icon: Intersect,
             invoke: async () => {
               await clientPlugin.provides.setLayout(ShellLayout.JOIN_SPACE);
             },

--- a/packages/experimental/surface/src/plugins/SpacePlugin/SpacePlugin.tsx
+++ b/packages/experimental/surface/src/plugins/SpacePlugin/SpacePlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { EyeSlash, Intersect, PaperPlane, PencilSimple, Planet, Plus } from '@phosphor-icons/react';
+import { ArrowLineLeft, EyeSlash, Intersect, PaperPlane, PencilSimple, Planet, Plus } from '@phosphor-icons/react';
 import { FC, useEffect } from 'react';
 import React, { useNavigate, useParams } from 'react-router';
 
@@ -324,6 +324,7 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
       nodes: () => nodes,
       actions: (plugins) => {
         const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos:ClientPlugin');
+        const splitViewPlugin = findPlugin<SplitViewProvides>(plugins, 'dxos:SplitViewPlugin');
         if (!clientPlugin) {
           return [];
         }
@@ -344,6 +345,16 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
             icon: Intersect,
             invoke: async () => {
               await clientPlugin.provides.setLayout(ShellLayout.JOIN_SPACE);
+            },
+          },
+          {
+            id: 'close-sidebar',
+            label: 'Close sidebar',
+            icon: ArrowLineLeft,
+            invoke: async () => {
+              if (splitViewPlugin?.provides.splitView) {
+                splitViewPlugin.provides.splitView.sidebarOpen = false;
+              }
             },
           },
         ];

--- a/packages/experimental/surface/src/plugins/SplitViewPlugin.tsx
+++ b/packages/experimental/surface/src/plugins/SplitViewPlugin.tsx
@@ -3,7 +3,7 @@
 //
 
 import { Sidebar as SidebarIcon } from '@phosphor-icons/react';
-import React, { PropsWithChildren, createContext, useContext, useEffect } from 'react';
+import React, { PropsWithChildren, createContext, useContext } from 'react';
 
 import { Button, Main, Dialog, useTranslation, DensityProvider } from '@dxos/aurora';
 import { fineBlockSize, getSize, mx } from '@dxos/aurora-theme';
@@ -33,10 +33,6 @@ export const SplitView = observer(() => {
   const context = useSplitViewContext();
   const { sidebarOpen, dialogOpen, dialogContent } = context;
   const { t } = useTranslation('os');
-
-  useEffect(() => {
-    console.log('[dialogOpen]', dialogOpen);
-  }, [dialogOpen]);
 
   return (
     <Main.Root sidebarOpen={context.sidebarOpen} onSidebarOpenChange={(next) => (context.sidebarOpen = next)}>

--- a/packages/experimental/surface/src/plugins/SplitViewPlugin.tsx
+++ b/packages/experimental/surface/src/plugins/SplitViewPlugin.tsx
@@ -42,13 +42,13 @@ export const SplitView = observer(() => {
       <div
         role='none'
         className={mx(
-          'fixed z-[1] block-end-0 pointer-fine:block-end-auto pointer-fine:block-start-0 p-2 transition-[inset-inline-start,opacity] ease-in-out duration-200 inline-start-0',
+          'fixed z-[1] block-end-0 pointer-fine:block-end-auto pointer-fine:block-start-0 p-2 pointer-fine:p-1.5 transition-[inset-inline-start,opacity] ease-in-out duration-200 inline-start-0',
           sidebarOpen && 'opacity-0 pointer-events-none',
         )}
       >
         <Button
           onClick={() => (context.sidebarOpen = !context.sidebarOpen)}
-          classNames={mx(fineBlockSize, 'aspect-square p-0')}
+          classNames={mx(fineBlockSize, 'aspect-square p-0 shadow-none')}
         >
           <SidebarIcon weight='light' className={getSize(5)} />
         </Button>

--- a/packages/experimental/surface/src/plugins/ThemePlugin/translations/en-US/os.ts
+++ b/packages/experimental/surface/src/plugins/ThemePlugin/translations/en-US/os.ts
@@ -66,4 +66,5 @@ export const os = {
   'close sidebar label': 'Close sidebar',
   'welcome message': 'Welcome',
   'selecting identity heading': 'Selecting identity',
+  'settings dialog title': 'Settings',
 };

--- a/packages/experimental/surface/src/plugins/TreeViewPlugin/TreeViewPlugin.tsx
+++ b/packages/experimental/surface/src/plugins/TreeViewPlugin/TreeViewPlugin.tsx
@@ -25,6 +25,7 @@ import { useIdentity, observer } from '@dxos/react-client';
 
 import { definePlugin } from '../../framework';
 import { useGraphContext } from '../GraphPlugin';
+import { useSplitViewContext } from '../SplitViewPlugin';
 import { TreeView } from './TreeView';
 
 const TREE_VIEW_PLUGIN = 'dxos:TreeViewPlugin';
@@ -48,6 +49,7 @@ export const TreeViewContainer = observer(() => {
   const themeContext = useThemeContext();
   const { t } = useTranslation('composer');
   const { sidebarOpen } = useSidebar(TREE_VIEW_PLUGIN);
+  const splitViewContext = useSplitViewContext();
 
   const actions = Object.values(graph.actions).reduce((acc, actions) => [...acc, ...actions], []);
 
@@ -78,7 +80,7 @@ export const TreeViewContainer = observer(() => {
                       {...(!sidebarOpen && { tabIndex: -1 })}
                     >
                       <span className='sr-only'>{action.label}</span>
-                      <Placeholder className={getSize(4)} />
+                      {action.icon ? <action.icon className={getSize(4)} /> : <Placeholder className={getSize(4)} />}
                     </Button>
                   </Tooltip.Trigger>
                   <Tooltip.Content classNames='z-[31]'>
@@ -106,6 +108,10 @@ export const TreeViewContainer = observer(() => {
                       variant='ghost'
                       classNames='pli-2 pointer-fine:pli-1'
                       {...(!sidebarOpen && { tabIndex: -1 })}
+                      onClick={() => {
+                        splitViewContext.dialogOpen = true;
+                        splitViewContext.dialogContent = 'dxos:SplitViewPlugin/ProfileSettings';
+                      }}
                     >
                       <GearSix className={mx(getSize(4), 'rotate-90')} />
                     </Button>

--- a/packages/experimental/surface/src/plugins/TreeViewPlugin/TreeViewPlugin.tsx
+++ b/packages/experimental/surface/src/plugins/TreeViewPlugin/TreeViewPlugin.tsx
@@ -104,17 +104,26 @@ export const TreeViewContainer = observer(() => {
                     <Avatar.Label classNames='grow text-sm'>
                       {identity.profile?.displayName ?? identity.identityKey.truncate()}
                     </Avatar.Label>
-                    <Button
-                      variant='ghost'
-                      classNames='pli-2 pointer-fine:pli-1'
-                      {...(!sidebarOpen && { tabIndex: -1 })}
-                      onClick={() => {
-                        splitViewContext.dialogOpen = true;
-                        splitViewContext.dialogContent = 'dxos:SplitViewPlugin/ProfileSettings';
-                      }}
-                    >
-                      <GearSix className={mx(getSize(4), 'rotate-90')} />
-                    </Button>
+                    <Tooltip.Root>
+                      <Tooltip.Trigger asChild>
+                        <Button
+                          variant='ghost'
+                          classNames='pli-2 pointer-fine:pli-1'
+                          {...(!sidebarOpen && { tabIndex: -1 })}
+                          onClick={() => {
+                            splitViewContext.dialogOpen = true;
+                            splitViewContext.dialogContent = 'dxos:SplitViewPlugin/ProfileSettings';
+                          }}
+                        >
+                          <span className='sr-only'>{t('settings dialog title', { ns: 'os' })}</span>
+                          <GearSix className={mx(getSize(4), 'rotate-90')} />
+                        </Button>
+                      </Tooltip.Trigger>
+                      <Tooltip.Content>
+                        {t('settings dialog title', { ns: 'os' })}
+                        <Tooltip.Arrow />
+                      </Tooltip.Content>
+                    </Tooltip.Root>
                   </div>
                 </Avatar.Root>
               </>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c0755ca</samp>

### Summary
🎨🔑🚚

<!--
1.  🎨 - This emoji represents the UI and UX improvements made to the dialogs, inputs, menus, and icons of the components.
2.  🔑 - This emoji represents the feature of entering a GitHub personal access token in a dialog to fetch and render GitHub markdown files.
3.  🚚 - This emoji represents the refactoring and renaming of the Dialog and Input components to use the new `@dxos/aurora` package.
-->
The pull request enhances the UI and UX of several plugins in the surface, especially the `GithubMarkdownPlugin` and the `SpacePlugin`. It adds a dialog feature to the `SplitViewPlugin` that allows other plugins to render their dialog content in the split view. It also updates the usage of the `@dxos/aurora` package and improves the typing and styling of some components. It fixes a typo and adds some translation keys.

> _The pull request had many changes_
> _To dialogs, icons, and spaces_
> _It used `aurora` for UI_
> _And `split view` for the side_
> _And fixed some bugs and typos in places_

### Walkthrough
*  Switch to using the `Dialog` component from `@dxos/aurora` for the `PatDialog` component, and render it in the split view plugin when the user clicks on the settings button ([link](https://github.com/dxos/dxos/pull/3373/files?diff=unified&w=0#diff-00cdfe6cd295029df9691587bf8c1d52e465eb3d03118adb9fa54184439b1328L5-R17), [link](https://github.com/dxos/dxos/pull/3373/files?diff=unified&w=0#diff-00cdfe6cd295029df9691587bf8c1d52e465eb3d03118adb9fa54184439b1328L28-R30), [link](https://github.com/dxos/dxos/pull/3373/files?diff=unified&w=0#diff-00cdfe6cd295029df9691587bf8c1d52e465eb3d03118adb9fa54184439b1328L55-R41), [link](https://github.com/dxos/dxos/pull/3373/files?diff=unified&w=0#diff-a732cbcbcf5ce4047d2319d20c152a233431dda32b2a2d995d1188a52578fe72L19-R23), [link](https://github.com/dxos/dxos/pull/3373/files?diff=unified&w=0#diff-a732cbcbcf5ce4047d2319d20c152a233431dda32b2a2d995d1188a52578fe72L412-R427), [link](https://github.com/dxos/dxos/pull/3373/files?diff=unified&w=0#diff-a732cbcbcf5ce4047d2319d20c152a233431dda32b2a2d995d1188a52578fe72L447-R453), [link](https://github.com/dxos/dxos/pull/3373/files?diff=unified&w=0#diff-a732cbcbcf5ce4047d2319d20c152a233431dda32b2a2d995d1188a52578fe72L465-R471), [link](https://github.com/dxos/dxos/pull/3373/files?diff=unified&w=0#diff-a732cbcbcf5ce4047d2319d20c152a233431dda32b2a2d995d1188a52578fe72L529-R534), [link](https://github.com/dxos/dxos/pull/3373/files?diff=unified&w=0#diff-6ac4c3aa7254e0d00b13a329d500d8dd33d5e097a9e7a4d4e844a41676044b69L13-R13), [link](https://github.com/dxos/dxos/pull/3373/files?diff=unified&w=0#diff-6ac4c3aa7254e0d00b13a329d500d8dd33d5e097a9e7a4d4e844a41676044b69R33-R34), [link](https://github.com/dxos/dxos/pull/3373/files?diff=unified&w=0#diff-f588f9083add88ee7b00818ac314e4b7204ee273b2317bd4ff73b0778fb705cdL11-R11), [link](https://github.com/dxos/dxos/pull/3373/files?diff=unified&w=0#diff-f588f9083add88ee7b00818ac314e4b7204ee273b2317bd4ff73b0778fb705cdL59-R55)).


