### PR TITLE
ci: automatically push release candidates to staging

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -31,3 +31,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CREATE_PR_TOKEN }}
         with:
           branch: ${{ steps.branch.outputs.prefix }}-${{ steps.time.outputs.today }}-${{ steps.git.outputs.sha }}
+
+      - name: Push to Staging
+        run: |
+          BRANCH="${{ steps.branch.outputs.prefix }}-${{ steps.time.outputs.today }}-${{ steps.git.outputs.sha }}"
+          git checkout $BRANCH
+          git checkout staging
+          git reset --hard $BRANCH
+          git push --force staging


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0389a7d</samp>

### Summary
🚀🔀🧪

<!--
1.  🚀 This emoji represents the deployment of the release candidate to the staging environment, which is a key step in the release process. It also conveys a sense of excitement and readiness for testing and feedback.
2.  🔀 This emoji represents the push of the current branch to the staging branch, which is a merge operation that updates the staging environment with the latest changes. It also conveys a sense of synchronization and alignment between the branches.
3.  🧪 This emoji represents the testing and verification of the release candidate in the staging environment, which is a crucial step to ensure the quality and functionality of the changes. It also conveys a sense of experimentation and discovery.
-->
Added a step to `release-candidate.yml` to deploy release candidates to staging. This allows testing and verification of the changes before merging to master.

> _`release-candidate`_
> _pushes to `staging` branch_
> _autumn testing time_

### Walkthrough
* Add a step to deploy the release candidate to the staging environment ([link](https://github.com/dxos/dxos/pull/3441/files?diff=unified&w=0#diff-0ee926c5a249e740fa8422c1d356af17c9ab3f98e150ec8bdf2490aa17320aa7R34-R41))


