### PR TITLE
fix: Drop connection if signal fails

### DIFF
--- a/packages/core/mesh/messaging/src/messenger.ts
+++ b/packages/core/mesh/messaging/src/messenger.ts
@@ -117,7 +117,7 @@ export class Messenger {
       () => {
         log('message not delivered', { messageId: reliablePayload.messageId });
         this._onAckCallbacks.delete(reliablePayload.messageId!);
-        timeoutHit(new Error(`message not delivered: ${reliablePayload.messageId.toHex()}`));
+        timeoutHit(new Error('Message not delivered'));
         void messageContext.dispose();
       },
       MESSAGE_TIMEOUT,

--- a/packages/core/mesh/messaging/src/messenger.ts
+++ b/packages/core/mesh/messaging/src/messenger.ts
@@ -103,11 +103,9 @@ export class Messenger {
       messageContext,
       async () => {
         log('retrying message', { messageId: reliablePayload.messageId });
-        try {
-          await this._encodeAndSend({ author, recipient, reliablePayload });
-        } catch (error) {
-          log.error('failed to send message', { error });
-        }
+        await this._encodeAndSend({ author, recipient, reliablePayload }).catch((err) =>
+          log.error('failed to send message', { err }),
+        );
       },
       this._retryDelay,
     );

--- a/packages/core/mesh/network-manager/src/signal/swarm-messenger.ts
+++ b/packages/core/mesh/network-manager/src/signal/swarm-messenger.ts
@@ -68,17 +68,17 @@ export class SwarmMessenger implements SignalMessenger {
     log('received', { from: author, to: recipient, msg: message });
 
     if (message.data?.offer) {
-      return this._handleOffer({ author, recipient, message });
+      await this._handleOffer({ author, recipient, message });
     } else if (message.data?.answer) {
-      return this._resolveAnswers(message);
+      await this._resolveAnswers(message);
     } else if (message.data?.signal) {
-      return this._handleSignal({ author, recipient, message });
+      await this._handleSignal({ author, recipient, message });
     }
   }
 
   async signal(message: SignalMessage): Promise<void> {
     assert(message.data?.signal);
-    return this._sendReliableMessage({
+    await this._sendReliableMessage({
       author: message.author,
       recipient: message.recipient,
       message,
@@ -116,7 +116,7 @@ export class SwarmMessenger implements SignalMessenger {
     };
 
     log('sending', { from: author, to: recipient, msg: networkMessage });
-    return this._sendMessage({
+    await this._sendMessage({
       author,
       recipient,
       payload: {
@@ -155,7 +155,7 @@ export class SwarmMessenger implements SignalMessenger {
     };
     const answer = await this._onOffer(offerMessage);
     answer.offerMessageId = message.messageId;
-    return this._sendReliableMessage({
+    await this._sendReliableMessage({
       author: recipient,
       recipient: author,
       message: {
@@ -184,6 +184,6 @@ export class SwarmMessenger implements SignalMessenger {
       data: { signal: message.data.signal },
     };
 
-    return this._onSignal(signalMessage);
+    await this._onSignal(signalMessage);
   }
 }

--- a/packages/core/mesh/network-manager/src/signal/swarm-messenger.ts
+++ b/packages/core/mesh/network-manager/src/signal/swarm-messenger.ts
@@ -68,11 +68,11 @@ export class SwarmMessenger implements SignalMessenger {
     log('received', { from: author, to: recipient, msg: message });
 
     if (message.data?.offer) {
-      await this._handleOffer({ author, recipient, message });
+      return this._handleOffer({ author, recipient, message });
     } else if (message.data?.answer) {
-      await this._resolveAnswers(message);
+      return this._resolveAnswers(message);
     } else if (message.data?.signal) {
-      await this._handleSignal({ author, recipient, message });
+      return this._handleSignal({ author, recipient, message });
     }
   }
 
@@ -155,7 +155,7 @@ export class SwarmMessenger implements SignalMessenger {
     };
     const answer = await this._onOffer(offerMessage);
     answer.offerMessageId = message.messageId;
-    await this._sendReliableMessage({
+    return this._sendReliableMessage({
       author: recipient,
       recipient: author,
       message: {
@@ -163,7 +163,7 @@ export class SwarmMessenger implements SignalMessenger {
         sessionId: message.sessionId,
         data: { answer },
       },
-    }).catch((err) => log.catch(err));
+    });
   }
 
   private async _handleSignal({
@@ -184,6 +184,6 @@ export class SwarmMessenger implements SignalMessenger {
       data: { signal: message.data.signal },
     };
 
-    await this._onSignal(signalMessage);
+    return this._onSignal(signalMessage);
   }
 }

--- a/packages/core/mesh/network-manager/src/signal/swarm-messenger.ts
+++ b/packages/core/mesh/network-manager/src/signal/swarm-messenger.ts
@@ -82,7 +82,7 @@ export class SwarmMessenger implements SignalMessenger {
       author: message.author,
       recipient: message.recipient,
       message,
-    }).catch((err) => log.catch(err));
+    });
   }
 
   async offer(message: OfferMessage): Promise<Answer> {

--- a/packages/core/mesh/network-manager/src/swarm/connection.ts
+++ b/packages/core/mesh/network-manager/src/swarm/connection.ts
@@ -109,13 +109,19 @@ export class Connection {
       initiator: this.initiator,
       stream: this._protocol.stream,
       sendSignal: async (signal) =>
-        this._signalMessaging.signal({
-          author: this.ownId,
-          recipient: this.remoteId,
-          sessionId: this.sessionId,
-          topic: this.topic,
-          data: { signal },
-        }),
+        this._signalMessaging
+          .signal({
+            author: this.ownId,
+            recipient: this.remoteId,
+            sessionId: this.sessionId,
+            topic: this.topic,
+            data: { signal },
+          })
+          .catch(async (err) => {
+            // If signal fails treat connection as failed
+            log('Signal failed', { err });
+            await this.close();
+          }),
     });
 
     this._transport.connected.once(() => {

--- a/packages/core/mesh/network-manager/src/swarm/connection.ts
+++ b/packages/core/mesh/network-manager/src/swarm/connection.ts
@@ -108,20 +108,21 @@ export class Connection {
     this._transport = this._transportFactory.createTransport({
       initiator: this.initiator,
       stream: this._protocol.stream,
-      sendSignal: async (signal) =>
-        this._signalMessaging
-          .signal({
+      sendSignal: async (signal) => {
+        try {
+          await this._signalMessaging.signal({
             author: this.ownId,
             recipient: this.remoteId,
             sessionId: this.sessionId,
             topic: this.topic,
             data: { signal },
-          })
-          .catch(async (err) => {
-            // If signal fails treat connection as failed
-            log('Signal failed', { err });
-            await this.close();
-          }),
+          });
+        } catch (err) {
+          // If signal fails treat connection as failed
+          log('Signal failed', { err });
+          await this.close();
+        }
+      },
     });
 
     this._transport.connected.once(() => {

--- a/packages/core/mesh/network-manager/src/swarm/swarm.ts
+++ b/packages/core/mesh/network-manager/src/swarm/swarm.ts
@@ -99,8 +99,11 @@ export class Swarm {
       .listen({
         peerId: this._ownPeerId,
         payloadType: 'dxos.mesh.swarm.SwarmMessage',
-        onMessage: async (message) =>
-          this._swarmMessenger.receiveMessage(message).catch((err) => log('Error while receiving message', { err })),
+        onMessage: async (message) => {
+          await this._swarmMessenger
+            .receiveMessage(message)
+            .catch((err) => log('Error while receiving message', { err }));
+        },
       })
       .catch((error) => log.catch(error));
 

--- a/packages/core/mesh/network-manager/src/swarm/swarm.ts
+++ b/packages/core/mesh/network-manager/src/swarm/swarm.ts
@@ -99,7 +99,8 @@ export class Swarm {
       .listen({
         peerId: this._ownPeerId,
         payloadType: 'dxos.mesh.swarm.SwarmMessage',
-        onMessage: async (message) => await this._swarmMessenger.receiveMessage(message),
+        onMessage: async (message) =>
+          this._swarmMessenger.receiveMessage(message).catch((err) => log('Error while receiving message', { err })),
       })
       .catch((error) => log.catch(error));
 

--- a/packages/devtools/cli/src/util/print.ts
+++ b/packages/devtools/cli/src/util/print.ts
@@ -46,6 +46,7 @@ export const mapMembers = (members: SpaceMember[], truncateKeys = false) => {
   return members.map((member) => ({
     key: maybeTruncateKey(member.identity.identityKey, truncateKeys),
     name: member.identity.profile?.displayName,
+    presence: member.presence === SpaceMember.PresenceState.ONLINE ? 'Online' : 'Offline',
   }));
 };
 
@@ -58,6 +59,9 @@ export const printMembers = (members: SpaceMember[], flags = {}) => {
       },
       name: {
         header: 'Display name',
+      },
+      presence: {
+        header: 'Presence state',
       },
     },
     {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4336ba9</samp>

### Summary
📞🐛🚀

<!--
1.  📞 - This emoji represents the `sendSignal` function of the `Connection` class, which is responsible for sending signal messages to establish a peer-to-peer connection. The emoji suggests communication, calling, and signaling.
2.  🐛 - This emoji represents the `onMessage` function of the `Swarm` class, which is responsible for receiving and handling messages from the swarm network. The emoji suggests bug fixing, debugging, and error handling.
3.  🚀 - This emoji represents the `SwarmMessenger` class, which is responsible for the signal messaging service that enables peer discovery and connection negotiation. The emoji suggests performance, improvement, and launching.
-->
The pull request improves the error handling and logging of the signal messaging and swarm services in `network-manager`. It makes the `SwarmMessenger` methods return promises instead of awaiting them, and adds error catching and connection closing logic to the `Connection` and `Swarm` classes.

> _Sing, O Muse, of the valiant code warriors who strove_
> _To mend the flaws of their swift connection and swarm,_
> _That they might not suffer the wrath of the fickle gods_
> _Who rule the realms of signal and message, fraught with storms._

### Walkthrough
*  Return promises instead of awaiting them in `SwarmMessenger` methods to allow error handling by the caller (`receiveMessage`) ([link](https://github.com/dxos/dxos/pull/3445/files?diff=unified&w=0#diff-0f792d9fa647782aacc1bf0e840eef0cca91263bcb62dd9e2fc04b3c0aa82d8fL71-R75), [link](https://github.com/dxos/dxos/pull/3445/files?diff=unified&w=0#diff-0f792d9fa647782aacc1bf0e840eef0cca91263bcb62dd9e2fc04b3c0aa82d8fL158-R158), [link](https://github.com/dxos/dxos/pull/3445/files?diff=unified&w=0#diff-0f792d9fa647782aacc1bf0e840eef0cca91263bcb62dd9e2fc04b3c0aa82d8fL187-R187))
*  Remove catch clauses from `_sendReliableMessage` calls in `SwarmMessenger` methods to propagate errors to the caller (`receiveMessage`) ([link](https://github.com/dxos/dxos/pull/3445/files?diff=unified&w=0#diff-0f792d9fa647782aacc1bf0e840eef0cca91263bcb62dd9e2fc04b3c0aa82d8fL85-R85), [link](https://github.com/dxos/dxos/pull/3445/files?diff=unified&w=0#diff-0f792d9fa647782aacc1bf0e840eef0cca91263bcb62dd9e2fc04b3c0aa82d8fL166-R166))
*  Catch and close connection on errors when sending signal messages using `_signalMessaging` service in `Connection` class (`sendSignal`) ([link](https://github.com/dxos/dxos/pull/3445/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745L112-R124))
*  Catch and log errors when receiving messages using `_swarmMessenger` service in `Swarm` class (`onMessage`) ([link](https://github.com/dxos/dxos/pull/3445/files?diff=unified&w=0#diff-719498fb2d70860e5ed9738f14b6fe4a8e85ef40011b0f8e96eb1dfba9005b1fL102-R103))


