### PR TITLE
fix: Context derive memory leak

### DIFF
--- a/packages/common/context/src/context.ts
+++ b/packages/common/context/src/context.ts
@@ -142,7 +142,8 @@ export class Context {
         }
       },
     });
-    this.onDispose(() => newCtx.dispose());
+    const clearDispose = this.onDispose(() => newCtx.dispose());
+    newCtx.onDispose(clearDispose);
     return newCtx;
   }
 }

--- a/packages/core/mesh/messaging/src/messenger.ts
+++ b/packages/core/mesh/messaging/src/messenger.ts
@@ -117,7 +117,7 @@ export class Messenger {
       () => {
         log('message not delivered', { messageId: reliablePayload.messageId });
         this._onAckCallbacks.delete(reliablePayload.messageId!);
-        timeoutHit(new Error(`message not delivered ${reliablePayload.messageId.toHex()}`));
+        timeoutHit(new Error(`message not delivered: ${reliablePayload.messageId.toHex()}`));
         void messageContext.dispose();
       },
       MESSAGE_TIMEOUT,

--- a/packages/sdk/vault/src/shared-worker.ts
+++ b/packages/sdk/vault/src/shared-worker.ts
@@ -11,7 +11,7 @@ import { createWorkerPort } from '@dxos/rpc-tunnel';
 import { namespace } from './util';
 
 // NOTE: Verbose logging enabled in the shared worker for the time being.
-const LOG_FILTER = 'debug';
+const LOG_FILTER = 'warn';
 
 void initializeAppTelemetry({
   namespace,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6ba8b90</samp>

### Summary
🐛📝🔇

<!--
1.  🐛 for the memory leak fix, since this is a bug fix that improves the functionality and stability of the code.
2.  📝 for the error message improvement, since this is a documentation change that enhances the clarity and consistency of the code.
3.  🔇 for the log level reduction, since this is a performance change that silences the unnecessary and verbose output of the code.
-->
This pull request fixes a memory leak issue in the `Context` class, improves the error message for a failed message delivery in the `Messenger` class, and reduces the log level for the shared worker in the `vault` package. These changes enhance the reliability, readability, and performance of the codebase.

> _`Context` frees memory_
> _Fixing leak with callback_
> _A fresh spring cleaning_

### Walkthrough
* Fix memory leak in `Context` class by registering dispose callback of new context with parent context ([link](https://github.com/dxos/dxos/pull/3446/files?diff=unified&w=0#diff-9c01791d40e657e125e1d3ce1c3e848a80251a0074a8a2b2387be63472cc85bdL145-R146))
* Improve error message for failed message delivery in `Messenger` class by adding colon to separate message ID ([link](https://github.com/dxos/dxos/pull/3446/files?diff=unified&w=0#diff-676a81f432e0060295f1801178be4e7edfde44c2fe059ceaf2712b0718270a24L120-R120))
* Reduce log level for shared worker in `vault` package by setting log filter to `warn` ([link](https://github.com/dxos/dxos/pull/3446/files?diff=unified&w=0#diff-e19deeac50d7fc405b10d260f559ce6bf36783ab4da62478b551cd91d874d94aL14-R14))


