### PR TITLE
chore: Tag WebRTC tests as flaky

### DIFF
--- a/packages/core/mesh/network-manager/src/tests/basic-test-suite.ts
+++ b/packages/core/mesh/network-manager/src/tests/basic-test-suite.ts
@@ -34,7 +34,7 @@ export const basicTestSuite = (testBuilder: TestBuilder, runTests = true) => {
     const [swarm1, swarm2] = await joinSwarm([peer1, peer2], topic, () => new FullyConnectedTopology());
     await exchangeMessages(swarm1, swarm2);
     await leaveSwarm([peer1, peer2], topic);
-  });
+  }).tag('flaky');
 
   // TODO(burdon): Test with more peers (configure and test messaging).
   test('joins swarm with star topology', async () => {
@@ -48,7 +48,7 @@ export const basicTestSuite = (testBuilder: TestBuilder, runTests = true) => {
     const [swarm1, swarm2] = await joinSwarm([peer1, peer2], topic, () => new StarTopology(peer1.peerId)); // NOTE: Same peer.
     await exchangeMessages(swarm1, swarm2);
     await leaveSwarm([peer1, peer2], topic);
-  });
+  }).tag('flaky');
 
   // TODO(burdon): Fails when trying to reconnect to same topic.
   test('joins swarm multiple times', async () => {
@@ -75,7 +75,7 @@ export const basicTestSuite = (testBuilder: TestBuilder, runTests = true) => {
       await exchangeMessages(swarm1, swarm2);
       await leaveSwarm([peer1, peer2], topic2);
     }
-  });
+  }).tag('flaky');
 
   test('joins multiple swarms', async () => {
     // TODO(burdon): N peers.
@@ -87,7 +87,7 @@ export const basicTestSuite = (testBuilder: TestBuilder, runTests = true) => {
     const numSwarms = 5;
     const topics = Array.from(Array(numSwarms)).map(() => PublicKey.random());
     expect(topics).to.have.length(numSwarms);
-  });
+  }).tag('flaky');
 
   test('joins multiple swarms concurrently', async () => {
     const createSwarm = async () => {
@@ -109,7 +109,7 @@ export const basicTestSuite = (testBuilder: TestBuilder, runTests = true) => {
       test1.swarm1a.protocol.testConnection(test1.peer2a.peerId),
       test2.swarm1a.protocol.testConnection(test2.peer2a.peerId),
     ]);
-  });
+  }).tag('flaky');
 
   test('peers reconnect after and error in connection', async () => {
     const peer1 = testBuilder.createPeer();
@@ -131,7 +131,7 @@ export const basicTestSuite = (testBuilder: TestBuilder, runTests = true) => {
     await exchangeMessages(swarm1, swarm2);
 
     await leaveSwarm([peer1, peer2], topic);
-  });
+  }).tag('flaky');
 
   test('going offline and back online', async () => {
     const peer1 = testBuilder.createPeer();


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f0cd1b7</samp>

### Summary
🐛🚧🚨

<!--
1.  🐛 - This emoji represents a bug or an issue that needs to be fixed. Marking test cases as flaky indicates that there is some underlying problem with the code or the test setup that causes them to fail intermittently.
2.  🚧 - This emoji represents work in progress or something that is under construction. Marking test cases as flaky also implies that they are not fully reliable or stable, and that they need further investigation or improvement.
3.  🚨 - This emoji represents a warning or an alert that something is wrong or needs attention. Marking test cases as flaky also signals that there is a potential risk of false negatives or false positives in the test results, and that they should be treated with caution.
-->
Marked some network manager test cases as flaky to improve test reliability. These test cases deal with `basic-test-suite.ts` in the `network-manager` package.

> _`basic-test-suite`_
> _Mark some cases as flaky - kire_
> _Network manager_

### Walkthrough
* Mark several test cases as flaky to allow retries or skips ([link](https://github.com/dxos/dxos/pull/3453/files?diff=unified&w=0#diff-9b2d2a71d2cf908aaa27bdf27639ddfe16514ed27785926fe8a26aff08a8d49eL37-R37), [link](https://github.com/dxos/dxos/pull/3453/files?diff=unified&w=0#diff-9b2d2a71d2cf908aaa27bdf27639ddfe16514ed27785926fe8a26aff08a8d49eL51-R51), [link](https://github.com/dxos/dxos/pull/3453/files?diff=unified&w=0#diff-9b2d2a71d2cf908aaa27bdf27639ddfe16514ed27785926fe8a26aff08a8d49eL78-R78), [link](https://github.com/dxos/dxos/pull/3453/files?diff=unified&w=0#diff-9b2d2a71d2cf908aaa27bdf27639ddfe16514ed27785926fe8a26aff08a8d49eL90-R90), [link](https://github.com/dxos/dxos/pull/3453/files?diff=unified&w=0#diff-9b2d2a71d2cf908aaa27bdf27639ddfe16514ed27785926fe8a26aff08a8d49eL112-R112), [link](https://github.com/dxos/dxos/pull/3453/files?diff=unified&w=0#diff-9b2d2a71d2cf908aaa27bdf27639ddfe16514ed27785926fe8a26aff08a8d49eL134-R134)) in `basic-test-suite.ts`.


