### PR TITLE
feat(devtools): Make debug link congruent with env

### DIFF
--- a/packages/sdk/vault/src/iframe.ts
+++ b/packages/sdk/vault/src/iframe.ts
@@ -92,8 +92,12 @@ export const startIFrameRuntime = async (createWorker: () => SharedWorker): Prom
 
     return;
   } else {
+    const isDev = window.location.href.includes('.dev.') || window.location.href.includes('localhost');
+
     console.log(
-      `%cTo inspect this application, click here:\nhttps://devtools.dxos.org/?target=vault:${window.location.href}`,
+      `%cTo inspect this application, click here:\nhttps://devtools${isDev ? '.dev.' : '.'}dxos.org/?target=vault:${
+        window.location.href
+      }`,
       cssStyle,
     );
   }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 653a29d</samp>

### Summary
🛠️🔗🌐

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate that the function was modified to use a different URL for the devtools based on the environment.
2.  🔗 - This emoji represents a link or a connection, and can be used to indicate that the function was modified to append the same suffix to the devtools URL to connect to the correct vault instance.
3.  🌐 - This emoji represents the web or the internet, and can be used to indicate that the function was modified to handle different environments for the vault and the devtools.
-->
Updated `startIFrameRuntime` to use environment-specific devtools URL. This enables the devtools to work with different vault instances in development and production.

> _`startIFrameRuntime`_
> _Changes devtools URL by env_
> _Winter debugging_

### Walkthrough
*  Modify `startIFrameRuntime` function to use different devtools URL based on vault environment ([link](https://github.com/dxos/dxos/pull/3455/files?diff=unified&w=0#diff-ab250f2acd4b584871491e81ca9ce20acfdf156949461d59dca74bac55130a7bL95-R100))


