### PR TITLE
ci: checkout code before trying to push to staging

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           branch: ${{ steps.branch.outputs.prefix }}-${{ steps.time.outputs.today }}-${{ steps.git.outputs.sha }}
 
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Checkout all branches
+          token: ${{ secrets.CREATE_PR_TOKEN }}
+
       - name: Push to Staging
         run: |
           BRANCH="${{ steps.branch.outputs.prefix }}-${{ steps.time.outputs.today }}-${{ steps.git.outputs.sha }}"


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2c52965</samp>

### Summary
:sparkles::wrench::rocket:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement to the workflow, which is the ability to create pull requests automatically.
2.  :wrench: This emoji represents the adjustment or improvement of the workflow configuration, which is the use of the actions/checkout action with the appropriate parameters.
3.  :rocket: This emoji represents the deployment or release of the workflow, which is the trigger of the workflow when a new release-candidate branch is pushed.
-->
This pull request adds a checkout step to the `release-candidate` workflow to allow creating pull requests to `main`. This facilitates the release process of the repository.

> _`actions/checkout`_
> _Fetches all branches, creates_
> _Pull requests in fall_

### Walkthrough
*  Add checkout step to release-candidate workflow ([link](https://github.com/dxos/dxos/pull/3460/files?diff=unified&w=0#diff-0ee926c5a249e740fa8422c1d356af17c9ab3f98e150ec8bdf2490aa17320aa7R35-R40))


