### PR TITLE
feat(composer-extension): Space management increment

### DIFF
--- a/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/EmbeddedMain/EmbeddedMain.tsx
+++ b/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/EmbeddedMain/EmbeddedMain.tsx
@@ -26,7 +26,7 @@ import {
   Tooltip,
   useJdenticonHref,
 } from '@dxos/aurora';
-import { defaultDescription, getSize, mx } from '@dxos/aurora-theme';
+import { defaultDescription, getSize, mx, osTx } from '@dxos/aurora-theme';
 import { ShellLayout } from '@dxos/client';
 import { useShell } from '@dxos/react-shell';
 
@@ -69,6 +69,7 @@ const EmbeddedLayoutImpl = () => {
   const [optionsMenuOpen, setOptionsMenuOpen] = useState(false);
 
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
+  const [resolverDialogOpen, setResolverDialogOpen] = useState(false);
 
   const spaceJdenticon = useJdenticonHref(space?.key.toHex() ?? '', 6);
 
@@ -180,14 +181,7 @@ const EmbeddedLayoutImpl = () => {
                   <span className='grow'>{t('rename space label')}</span>
                   <PencilSimpleLine className={mx('shrink-0', getSize(5))} />
                 </DropdownMenu.Item>
-                <DropdownMenu.Item
-                  onClick={() => {
-                    // if (space && identityHex && source && id) {
-                    //   unbindSpace(space, identityHex, source, id);
-                    //   setSpace(null);
-                    // }
-                  }}
-                >
+                <DropdownMenu.Item onClick={() => setResolverDialogOpen(true)}>
                   <span className='grow'>{t('unset repo space label')}</span>
                   <Option className={mx('shrink-0', getSize(5))} />
                 </DropdownMenu.Item>
@@ -228,7 +222,21 @@ const EmbeddedLayoutImpl = () => {
         {space && document ? (
           <MarkdownDocument {...{ layout: 'embedded', space, document, editorViewState, setEditorViewState }} />
         ) : source && id && identityHex ? (
-          <ResolverDialog />
+          <DensityProvider density='fine'>
+            <div role='none' className={osTx('dialog.overlay', 'dialog--resolver__overlay', {}, 'static bs-full')}>
+              <div
+                role='none'
+                className={osTx(
+                  'dialog.content',
+                  'dialog--resolver__content',
+                  {},
+                  'p-2 bs-72 flex flex-col shadow-none bg-transparent',
+                )}
+              >
+                <ResolverDialog />
+              </div>
+            </div>
+          </DensityProvider>
         ) : null}
         {space && (
           <Dialog.Root open={renameDialogOpen} onOpenChange={setRenameDialogOpen}>
@@ -239,6 +247,13 @@ const EmbeddedLayoutImpl = () => {
             </Dialog.Overlay>
           </Dialog.Root>
         )}
+        <Dialog.Root open={resolverDialogOpen} onOpenChange={setResolverDialogOpen}>
+          <Dialog.Overlay>
+            <Dialog.Content>
+              <ResolverDialog />
+            </Dialog.Content>
+          </Dialog.Overlay>
+        </Dialog.Root>
       </DensityProvider>
     </>
   );

--- a/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/EmbeddedMain/EmbeddedMain.tsx
+++ b/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/EmbeddedMain/EmbeddedMain.tsx
@@ -84,7 +84,7 @@ const EmbeddedLayoutImpl = () => {
         }
       `}</style>
       <DensityProvider density='fine'>
-        <div role='none' className='fixed inline-end-2 block-end-2 z-[70] flex gap-2'>
+        <div role='none' className='fixed inline-end-2 block-end-2 z-10 flex gap-2'>
           <Tooltip.Root>
             <Tooltip.Trigger asChild>
               <Button disabled={!space} onClick={handleInvite}>
@@ -222,7 +222,7 @@ const EmbeddedLayoutImpl = () => {
         {space && document ? (
           <MarkdownDocument {...{ layout: 'embedded', space, document, editorViewState, setEditorViewState }} />
         ) : source && id && identityHex ? (
-          <DensityProvider density='fine'>
+          <Dialog.Root open onOpenChange={() => true}>
             <div role='none' className={osTx('dialog.overlay', 'dialog--resolver__overlay', {}, 'static bs-full')}>
               <div
                 role='none'
@@ -236,11 +236,11 @@ const EmbeddedLayoutImpl = () => {
                 <ResolverDialog />
               </div>
             </div>
-          </DensityProvider>
+          </Dialog.Root>
         ) : null}
         {space && (
           <Dialog.Root open={renameDialogOpen} onOpenChange={setRenameDialogOpen}>
-            <Dialog.Overlay>
+            <Dialog.Overlay classNames='backdrop-blur'>
               <Dialog.Content>
                 <DialogRenameSpace data={['dxos:SpacePlugin/RenameSpaceDialog', space]} />
               </Dialog.Content>
@@ -248,7 +248,7 @@ const EmbeddedLayoutImpl = () => {
           </Dialog.Root>
         )}
         <Dialog.Root open={resolverDialogOpen} onOpenChange={setResolverDialogOpen}>
-          <Dialog.Overlay>
+          <Dialog.Overlay classNames='backdrop-blur'>
             <Dialog.Content>
               <ResolverDialog />
             </Dialog.Content>

--- a/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/GithubEchoResolverProviders/ResolverDialog.tsx
+++ b/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/GithubEchoResolverProviders/ResolverDialog.tsx
@@ -2,20 +2,16 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { useContext } from 'react';
+import React from 'react';
 
-import { Button, DensityProvider, useTranslation } from '@dxos/aurora';
-import { osTx } from '@dxos/aurora-theme';
+import { Button, useTranslation } from '@dxos/aurora';
 import { ShellLayout } from '@dxos/client';
-import { Loading } from '@dxos/react-appkit';
 import { useClient } from '@dxos/react-client';
 import { useShell } from '@dxos/react-shell';
 
-import { SpaceResolverContext } from './ResolverContext';
 import { ResolverTree } from './ResolverTree';
 
 export const ResolverDialog = () => {
-  const { space } = useContext(SpaceResolverContext);
   const { t } = useTranslation('composer');
   const client = useClient();
   const shell = useShell();
@@ -29,34 +25,16 @@ export const ResolverDialog = () => {
   };
 
   return (
-    <DensityProvider density='fine'>
-      <div role='none' className={osTx('dialog.overlay', 'dialog--resolver__overlay', {}, 'static bs-full')}>
-        <div
-          role='none'
-          className={osTx(
-            'dialog.content',
-            'dialog--resolver__content',
-            {},
-            'p-2 bs-72 flex flex-col shadow-none bg-transparent',
-          )}
-        >
-          {!space ? (
-            <>
-              <ResolverTree />
-              <div role='group' className='shrink-0 flex is-full gap-2'>
-                <Button classNames='grow' onClick={handleCreateSpace}>
-                  {t('create space label', { ns: 'appkit' })}
-                </Button>
-                <Button classNames='grow' onClick={handleJoinSpace}>
-                  {t('join space label', { ns: 'appkit' })}
-                </Button>
-              </div>
-            </>
-          ) : (
-            <Loading label={t('resolver init document message')} />
-          )}
-        </div>
+    <>
+      <ResolverTree />
+      <div role='group' className='shrink-0 flex is-full gap-2'>
+        <Button classNames='grow' onClick={handleCreateSpace}>
+          {t('create space label', { ns: 'appkit' })}
+        </Button>
+        <Button classNames='grow' onClick={handleJoinSpace}>
+          {t('join space label', { ns: 'appkit' })}
+        </Button>
       </div>
-    </DensityProvider>
+    </>
   );
 };

--- a/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/GithubEchoResolverProviders/ResolverTree.tsx
+++ b/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/GithubEchoResolverProviders/ResolverTree.tsx
@@ -4,7 +4,7 @@
 
 import React, { useCallback, useContext } from 'react';
 
-import { Button, Tree, useId, useTranslation } from '@dxos/aurora';
+import { Button, Dialog, Tree, useId, useTranslation } from '@dxos/aurora';
 import { observer, useClient, useSpaces, Space } from '@dxos/react-client';
 
 import { SpaceResolverContext } from './ResolverContext';
@@ -36,14 +36,13 @@ export const ResolverTree = observer(() => {
   return spaces.length ? (
     <>
       {' '}
-      <h1 className='shrink-0 text-lg font-system-normal' id={treeLabel}>
-        {t('resolver tree label')}
-      </h1>
-      <div role='separator' className='shrink-0 bs-px bg-neutral-500/20 mlb-2' />
+      <Dialog.Title classNames='shrink-0'>{t('resolver tree label')}</Dialog.Title>
+      <Dialog.Description>{t('resolver tree description')}</Dialog.Description>
+      <div role='separator' className='shrink-0 bs-px bg-neutral-500/20 mlb-1' />
       <Tree.Root
-        aria-labelledby={treeLabel}
+        aria-label={t('resolver tree label')}
         data-testid='composer.sidebarTree'
-        classNames='overflow-y-auto -mli-2 pli-2'
+        classNames='overflow-y-auto -mli-2 p-2'
       >
         {spaces.map((space) => {
           return (

--- a/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/GithubEchoResolverProviders/ResolverTree.tsx
+++ b/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/GithubEchoResolverProviders/ResolverTree.tsx
@@ -36,7 +36,9 @@ export const ResolverTree = observer(() => {
   return spaces.length ? (
     <>
       {' '}
-      <Dialog.Title classNames='shrink-0'>{t('resolver tree label')}</Dialog.Title>
+      <Dialog.Title tabIndex={-1} classNames='shrink-0'>
+        {t('resolver tree label')}
+      </Dialog.Title>
       <Dialog.Description>{t('resolver tree description')}</Dialog.Description>
       <div role='separator' className='shrink-0 bs-px bg-neutral-500/20 mlb-1' />
       <Tree.Root

--- a/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/GithubEchoResolverProviders/SpacePickerTreeItem.tsx
+++ b/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/GithubEchoResolverProviders/SpacePickerTreeItem.tsx
@@ -92,7 +92,7 @@ export const SpacePickerTreeItem = observer(
             {t(selected ? 'selected label' : 'select label')}
           </Button>
         </div>
-        <TreeItem.Body>
+        <TreeItem.Body className='pis-4'>
           {hasDocuments && (
             <Tree.Branch>
               {documents.map((document) => (

--- a/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/GithubEchoResolverProviders/SpacePickerTreeItem.tsx
+++ b/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/GithubEchoResolverProviders/SpacePickerTreeItem.tsx
@@ -14,8 +14,7 @@ import { observer, useQuery } from '@dxos/react-client';
 
 import { getSpaceDisplayName } from '../../../SpacePlugin/getSpaceDisplayName';
 import { DocumentTreeItem } from './DocumentTreeItem';
-import { ResolverProps } from './ResolverProps';
-import { bindSpace, matchSpace } from './spaceResolvers';
+import { matchSpace } from './spaceResolvers';
 
 export const SpacePickerTreeItem = observer(
   ({
@@ -24,7 +23,15 @@ export const SpacePickerTreeItem = observer(
     source,
     id,
     setSpace,
-  }: Pick<ResolverProps, 'setSpace'> & { identityHex: string; space: Space; source: string; id: string }) => {
+    selected,
+  }: {
+    identityHex: string;
+    space: Space;
+    setSpace: (nextSpace: Space | null) => void;
+    source: string;
+    id: string;
+    selected?: boolean;
+  }) => {
     const { t } = useTranslation('composer');
     const spaceSate = useMulticastObservable(space.state);
     const disabled = spaceSate !== SpaceState.READY;
@@ -81,17 +88,8 @@ export const SpacePickerTreeItem = observer(
               </Tooltip.Portal>
             </Tooltip.Root>
           )}
-          <Button
-            density='fine'
-            classNames='shrink-0'
-            onClick={() => {
-              if (identityHex) {
-                bindSpace(space, identityHex, source, id);
-                setSpace(space);
-              }
-            }}
-          >
-            Select
+          <Button disabled={selected} density='fine' classNames='shrink-0' onClick={() => setSpace(space)}>
+            {t(selected ? 'selected label' : 'select label')}
           </Button>
         </div>
         <TreeItem.Body>

--- a/packages/apps/composer-app/src/plugins/SpacePlugin/SpacePlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/SpacePlugin/SpacePlugin.tsx
@@ -8,7 +8,7 @@ import {
   EyeSlash,
   Intersect,
   PaperPlane,
-  PencilSimple,
+  PencilSimpleLine,
   Planet,
   Plus,
   Trash,
@@ -192,7 +192,7 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
               {
                 id: 'rename-space',
                 label: ['rename space label', { ns: 'composer' }],
-                icon: PencilSimple,
+                icon: PencilSimpleLine,
                 invoke: async () => {
                   if (splitViewPlugin?.provides.splitView) {
                     splitViewPlugin.provides.splitView.dialogOpen = true;

--- a/packages/sdk/react-surface/src/plugins/ThemePlugin/translations/en-US/composer.ts
+++ b/packages/sdk/react-surface/src/plugins/ThemePlugin/translations/en-US/composer.ts
@@ -82,4 +82,6 @@ export const composer = {
   'unset repo space label': 'Select a different space for this repository',
   'rename space label': 'Rename space',
   'active space label': 'Active space:',
+  'select label': 'Select',
+  'selected label': 'Selected',
 };

--- a/packages/sdk/react-surface/src/plugins/ThemePlugin/translations/en-US/composer.ts
+++ b/packages/sdk/react-surface/src/plugins/ThemePlugin/translations/en-US/composer.ts
@@ -56,7 +56,9 @@ export const composer = {
   'unhide space label': 'Un-hide space',
   'empty space message': 'No documents – click plus ☝ to get started',
   'empty tree message': 'No spaces – click the planet ☝ to get started',
-  'resolver tree label': 'Choose a Space to collaborate on documents in this repository',
+  'resolver tree label': 'Choose a Space',
+  'resolver tree description':
+    'To collaborate on documents in this repository, choose the Space that will store and control access to the documents.',
   'resolver no spaces message': 'You aren’t in any spaces yet',
   'resolver create space label': 'Create a space for this repository',
   'save and close label': 'Save & close',

--- a/packages/sdk/react-surface/src/plugins/ThemePlugin/translations/en-US/composer.ts
+++ b/packages/sdk/react-surface/src/plugins/ThemePlugin/translations/en-US/composer.ts
@@ -81,4 +81,5 @@ export const composer = {
   'embedded options label': 'Options',
   'unset repo space label': 'Select a different space for this repository',
   'rename space label': 'Rename space',
+  'active space label': 'Active space:',
 };

--- a/packages/ui/aurora-theme/src/styles/components/button.ts
+++ b/packages/ui/aurora-theme/src/styles/components/button.ts
@@ -18,12 +18,12 @@ import {
 } from '../fragments';
 
 export const primaryAppButtonColors =
-  'bg-primary-550 dark:bg-primary-550 data-[state=on]:bg-primary-500 dark:data-[state=on]:bg-primary-500 text-white data-[state=on]:text-primary-100 hover:bg-primary-600 dark:hover:bg-primary-600 hover:text-white dark:hover:text-white';
+  'bg-primary-550 dark:bg-primary-550 aria-pressed:bg-primary-500 dark:aria-pressed:bg-primary-500 text-white aria-pressed:text-primary-100 hover:bg-primary-600 dark:hover:bg-primary-600 hover:text-white dark:hover:text-white';
 export const defaultAppButtonColors =
-  'bg-white data-[state=on]:bg-primary-50 text-neutral-800 data-[state=on]:text-primary-800 dark:bg-neutral-800 dark:data-[state=on]:bg-primary-800 dark:text-neutral-50 dark:data-[state=on]:text-primary-50';
+  'bg-white aria-pressed:bg-primary-50 text-neutral-800 aria-pressed:text-primary-800 dark:bg-neutral-800 dark:aria-pressed:bg-primary-800 dark:text-neutral-50 dark:aria-pressed:text-primary-50';
 export const defaultOsButtonColors = 'bg-white/50 text-neutral-900 dark:bg-neutral-750/50 dark:text-neutral-50';
 export const ghostButtonColors =
-  'hover:bg-transparent dark:hover:bg-transparent hover:text-primary-500 dark:hover:text-primary-300 data-[state=on]:text-primary-800 dark:data-[state=on]:text-primary-50';
+  'hover:bg-transparent dark:hover:bg-transparent hover:text-primary-500 dark:hover:text-primary-300 aria-pressed:text-primary-800 dark:aria-pressed:text-primary-50';
 
 export type AppButtonStyleProps = Partial<{
   inGroup?: boolean;

--- a/packages/ui/aurora-theme/src/styles/components/dialog.ts
+++ b/packages/ui/aurora-theme/src/styles/components/dialog.ts
@@ -25,7 +25,7 @@ export const dialogContent: ComponentFunction<DialogStyleProps> = ({ inOverlayLa
     'flex flex-col',
     !inOverlayLayout && 'fixed z-20 top-[50%] left-[50%] -translate-x-[50%] -translate-y-[50%]',
     'is-[95vw] md:is-full max-is-md rounded-xl p-4',
-    'shadow-2xl bg-white dark:bg-neutral-800',
+    'shadow-2xl bg-25 dark:bg-neutral-850',
     defaultFocus,
     ...etc,
   );

--- a/packages/ui/aurora-theme/src/styles/components/dropdown-menu.ts
+++ b/packages/ui/aurora-theme/src/styles/components/dropdown-menu.ts
@@ -5,7 +5,7 @@
 import { ComponentFunction, Theme } from '@dxos/aurora-types';
 
 import { mx } from '../../util';
-import { arrow, dataDisabled, minorSurfaceElevation, subduedFocus } from '../fragments';
+import { arrow, dataDisabled, defaultDescription, minorSurfaceElevation, subduedFocus } from '../fragments';
 
 export type DropdownMenuStyleProps = {};
 
@@ -20,7 +20,7 @@ export const dropdownMenuContent: ComponentFunction<DropdownMenuStyleProps> = (_
 
 export const dropdownMenuItem: ComponentFunction<DropdownMenuStyleProps> = (_props, ...etc) =>
   mx(
-    'flex cursor-pointer select-none items-center rounded-md px-2 py-2 text-sm',
+    'flex cursor-pointer select-none items-center gap-2 rounded-md px-2 py-2 text-sm',
     'text-neutral-900 data-[highlighted]:bg-neutral-50 dark:text-neutral-100 dark:data-[highlighted]:bg-neutral-900',
     subduedFocus,
     dataDisabled,
@@ -31,7 +31,7 @@ export const dropdownMenuSeparator: ComponentFunction<DropdownMenuStyleProps> = 
   mx('mlb-1 mli-2 bs-px bg-neutral-200 dark:bg-neutral-700', ...etc);
 
 export const dropdownMenuGroupLabel: ComponentFunction<DropdownMenuStyleProps> = (_props, ...etc) =>
-  mx('select-none pli-2 plb-2 text-sm text-neutral-900 dark:text-neutral-100', ...etc);
+  mx(defaultDescription, 'select-none pli-2 plb-2', ...etc);
 
 export const dropdownMenuArrow: ComponentFunction<DropdownMenuStyleProps> = (_props, ...etc) => mx(arrow, ...etc);
 

--- a/packages/ui/aurora-theme/src/styles/fragments/text.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/text.ts
@@ -4,7 +4,7 @@
 
 export const defaultPlaceholder = 'placeholder-neutral-500 dark:placeholder-neutral-400';
 
-export const defaultDescription = 'text-xs leading-3 font-normal text-neutral-650 dark:text-neutral-300';
+export const defaultDescription = 'text-xs leading-4 font-normal text-neutral-650 dark:text-neutral-300';
 export const primaryDescription = 'text-xs font-normal text-white/90';
 
 export const defaultTooltip = 'text-xs font-normal text-neutral-900 dark:text-neutral-50';


### PR DESCRIPTION
This PR:
- Resolves #3398 
- Resolves #3400 
- Resolves #3401 

https://github.com/dxos/dxos/assets/855039/3eddccf1-f714-48b2-aed7-455349132413

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f48c313</samp>

### Summary
🎨🛠️🌐

<!--
1.  🎨 - This emoji is often used for changes related to the user interface, design, or appearance of the app. It could apply to the first, second, fourth, seventh, and ninth changes in the list.
2.  🛠️ - This emoji is often used for changes related to fixing, improving, or refactoring the code or functionality of the app. It could apply to the third, fifth, sixth, and eighth changes in the list.
3.  🌐 - This emoji is often used for changes related to localization, translation, or internationalization of the app. It could apply to the tenth change in the list.
-->
This pull request improves the user interface and functionality of the Github Markdown plugin and the space plugin in the `composer-app` package, and updates the aurora theme in the `ui` package. It adds icons, dialogs, and conditional buttons to the embedded layout component, simplifies and enhances the resolver dialog and tree components, and enables renaming and resolving spaces and documents. It also changes some icons, colors, and translations to improve the consistency and clarity of the user interface.

> _`aurora` theme glows_
> _user interface enhanced_
> _`react-surface` blooms_

### Walkthrough
*  Add state variables, icons, and components for the rename and resolver dialogs in the embedded layout component ([link](https://github.com/dxos/dxos/pull/3466/files?diff=unified&w=0#diff-cc8942c02e04afc89cc51d6497e02aeb61c7d29ac59a9e507f8e3ad6d519dcc6L6-R34), [link](https://github.com/dxos/dxos/pull/3466/files?diff=unified&w=0#diff-cc8942c02e04afc89cc51d6497e02aeb61c7d29ac59a9e507f8e3ad6d519dcc6R71-R75), [link](https://github.com/dxos/dxos/pull/3466/files?diff=unified&w=0#diff-cc8942c02e04afc89cc51d6497e02aeb61c7d29ac59a9e507f8e3ad6d519dcc6L184-R256), [link](https://github.com/dxos/dxos/pull/3466/files?diff=unified&w=0#diff-cc8942c02e04afc89cc51d6497e02aeb61c7d29ac59a9e507f8e3ad6d519dcc6L136-R184), [link](https://github.com/dxos/dxos/pull/3466/files?diff=unified&w=0#diff-cc8942c02e04afc89cc51d6497e02aeb61c7d29ac59a9e507f8e3ad6d519dcc6L160-R202), [link](https://github.com/dxos/dxos/pull/3466/files?diff=unified&w=0#diff-cc8942c02e04afc89cc51d6497e02aeb61c7d29ac59a9e507f8e3ad6d519dcc6L114-R145), [link](https://github.com/dxos/dxos/pull/3466/files?diff=unified&w=0#diff-cc8942c02e04afc89cc51d6497e02aeb61c7d29ac59a9e507f8e3ad6d519dcc6L83-R112), [link](https://github.com/dxos/dxos/pull/3466/files?diff=unified&w=0#diff-cc8942c02e04afc89cc51d6497e02aeb61c7d29ac59a9e507f8e3ad6d519dcc6R133), [link](https://github.com/dxos/dxos/pull/3466/files?diff=unified&w=0#diff-cc8942c02e04afc89cc51d6497e02aeb61c7d29ac59a9e507f8e3ad6d519dcc6L128-R158)) in `EmbeddedMain.tsx`.


