### PR TITLE
feat(aurora): `Link`

### DIFF
--- a/packages/ui/aurora-theme/src/styles/components/index.ts
+++ b/packages/ui/aurora-theme/src/styles/components/index.ts
@@ -7,6 +7,7 @@ export * from './button';
 export * from './dialog';
 export * from './dropdown-menu';
 export * from './input';
+export * from './link';
 export * from './list';
 export * from './main';
 export * from './message';

--- a/packages/ui/aurora-theme/src/styles/components/link.ts
+++ b/packages/ui/aurora-theme/src/styles/components/link.ts
@@ -1,0 +1,23 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { ComponentFunction, Theme } from '@dxos/aurora-types';
+
+import { mx } from '../../util';
+import { defaultFocus } from '../fragments';
+
+export type LinkStyleProps = {};
+
+export const linkRoot: ComponentFunction<LinkStyleProps> = (_props, ...etc) =>
+  mx(
+    'underline decoration-1 underline-offset-2 transition-color rounded-sm',
+    'text-primary-600 hover:text-primary-500 dark:text-primary-400 hover:dark:text-primary-300',
+    'visited:text-teal-600 visited:hover:text-teal-500 visited:dark:text-teal-400 visited:hover:dark:text-teal-300',
+    defaultFocus,
+    ...etc,
+  );
+
+export const linkTheme: Theme<LinkStyleProps> = {
+  root: linkRoot,
+};

--- a/packages/ui/aurora-theme/src/styles/theme.ts
+++ b/packages/ui/aurora-theme/src/styles/theme.ts
@@ -21,6 +21,7 @@ import {
   toastTheme,
   tooltipTheme,
   tagTheme,
+  linkTheme,
 } from './components';
 
 export const theme: Theme<Record<string, any>> = {
@@ -31,6 +32,7 @@ export const theme: Theme<Record<string, any>> = {
   dialog: dialogTheme,
   dropdownMenu: dropdownMenuTheme,
   input: inputTheme,
+  link: linkTheme,
   list: listTheme,
   main: mainTheme,
   message: messageTheme,

--- a/packages/ui/aurora/src/components/Link/Link.stories.tsx
+++ b/packages/ui/aurora/src/components/Link/Link.stories.tsx
@@ -1,0 +1,13 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+import '@dxosTheme';
+
+import { Link } from './Link';
+
+export default {
+  component: Link,
+} as any;
+
+export const Default = { args: { children: 'Hello', href: '#' } };

--- a/packages/ui/aurora/src/components/Link/Link.tsx
+++ b/packages/ui/aurora/src/components/Link/Link.tsx
@@ -1,0 +1,20 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+import { Primitive } from '@radix-ui/react-primitive';
+import { Slot } from '@radix-ui/react-slot';
+import React, { ComponentPropsWithRef, forwardRef } from 'react';
+
+import { useThemeContext } from '../../hooks';
+import { ThemedClassName } from '../../util';
+
+export type LinkProps = ThemedClassName<ComponentPropsWithRef<typeof Primitive.a>> & {
+  asChild?: boolean;
+};
+
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(({ asChild, classNames, ...props }, forwardedRef) => {
+  const { tx } = useThemeContext();
+  const Root = asChild ? Slot : Primitive.a;
+  return <Root {...props} className={tx('link.root', 'link', {}, classNames)} ref={forwardedRef} />;
+});

--- a/packages/ui/aurora/src/components/Link/index.ts
+++ b/packages/ui/aurora/src/components/Link/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+export * from './Link';


### PR DESCRIPTION
This PR adds `Link` to aurora.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ea02c4b</samp>

### Summary
🎨🔗📚

<!--
1.  🎨 - This emoji represents the addition of the link component styles to the aurora-theme package, as it is related to the visual appearance and design of the component.
2. 🔗 - This emoji represents the creation and export of the link component from the aurora package, as it is related to the functionality and behavior of the component.
3. 📚 - This emoji represents the creation of the storybook file for the link component in the aurora package, as it is related to the documentation and demonstration of the component.
-->
This pull request adds a link component to the aurora and aurora-theme packages, with consistent styles and props. It also creates a storybook file for the link component and updates the theme object with the link styles.

> _Sing, O Muse, of the skillful coder who devised_
> _The link component, a shining adornment for the web,_
> _And the theme that gave it beauty and grace, like a star_
> _That guides the sailors through the dark and stormy sea._

### Walkthrough
*  Export link component styles from `aurora-theme` package ([link](https://github.com/dxos/dxos/pull/3467/files?diff=unified&w=0#diff-6717dc8c34c2b5550dda33499aa5cb6877d28d65cdfc39790eb914faeec857a8R10))
*  Define link component styles in `aurora-theme` package using aurora-types and util modules ([link](https://github.com/dxos/dxos/pull/3467/files?diff=unified&w=0#diff-558f483ea481a644521b99f1808328a87035be23950f57033ae42a3969777a5dR1-R23))
*  Add linkTheme object to theme object in `aurora-theme` package for use by useThemeContext hook and tx function ([link](https://github.com/dxos/dxos/pull/3467/files?diff=unified&w=0#diff-69241f25f1647f6105233f677788a042089cb28715f9649a78636af9e554b8f5R24), [link](https://github.com/dxos/dxos/pull/3467/files?diff=unified&w=0#diff-69241f25f1647f6105233f677788a042089cb28715f9649a78636af9e554b8f5R35))
*  Export link component from `aurora` package ([link](https://github.com/dxos/dxos/pull/3467/files?diff=unified&w=0#diff-7464f20a5ffb4263c00c117e018a0ede865ae807846f22b5de1e4eb9c75b1b5fR1-R5))
*  Define link component in `aurora` package using Primitive, Slot, and ThemedClassName modules from radix-ui and aurora packages ([link](https://github.com/dxos/dxos/pull/3467/files?diff=unified&w=0#diff-ce017c45cfd61fecbf404c014dbc2b260cb233bf82fb75d8184a73fb0b342148R1-R20))
*  Create storybook file for link component in `aurora` package using @dxosTheme alias and Link component ([link](https://github.com/dxos/dxos/pull/3467/files?diff=unified&w=0#diff-bd0b9da39fe7aacf824ddccddcaf851c1ab49154a5b16300c3672ad628a69185R1-R13))


