### PR TITLE
feat(composer-app): GitHub PAT link & description

### DIFF
--- a/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/EmbeddedMain/EmbeddedMain.tsx
+++ b/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/EmbeddedMain/EmbeddedMain.tsx
@@ -63,6 +63,7 @@ const EmbeddedLayoutImpl = () => {
   }, [shell, space]);
 
   const [editorViewState, setEditorViewState] = useState<EditorViewState>('editor');
+  const isPreviewing = editorViewState === 'preview';
 
   const suppressNextTooltip = useRef<boolean>(false);
   const [optionsTooltipOpen, setOptionsTooltipOpen] = useState(false);
@@ -101,19 +102,15 @@ const EmbeddedLayoutImpl = () => {
             <Tooltip.Trigger asChild>
               <Toggle
                 disabled={!(space && document)}
-                pressed={editorViewState === 'preview'}
+                pressed={isPreviewing}
                 onPressedChange={(nextPressed) => setEditorViewState(nextPressed ? 'preview' : 'editor')}
               >
-                <span className='sr-only'>{t('preview gfm label')}</span>
-                {editorViewState === 'preview' ? (
-                  <PencilSimpleLine className={getSize(5)} />
-                ) : (
-                  <Eye className={getSize(5)} />
-                )}
+                <span className='sr-only'>{t(isPreviewing ? 'exit gfm preview label' : 'preview gfm label')}</span>
+                {isPreviewing ? <PencilSimpleLine className={getSize(5)} /> : <Eye className={getSize(5)} />}
               </Toggle>
             </Tooltip.Trigger>
             <Tooltip.Content {...overlayAttrs}>
-              {t('preview gfm label')}
+              {t(isPreviewing ? 'exit gfm preview label' : 'preview gfm label')}
               <Tooltip.Arrow />
             </Tooltip.Content>
           </Tooltip.Root>

--- a/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/GithubApiProviders/PatInput.tsx
+++ b/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/GithubApiProviders/PatInput.tsx
@@ -50,7 +50,7 @@ export const PatInput = () => {
         <Input.TextInput
           autoFocus
           spellCheck={false}
-          classNames='font-mono'
+          classNames='font-mono mlb-1'
           value={patValue}
           onChange={({ target: { value } }) => setPatValue(value)}
         />

--- a/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/GithubApiProviders/PatInput.tsx
+++ b/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/GithubApiProviders/PatInput.tsx
@@ -2,12 +2,30 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { useEffect, useState } from 'react';
+import { ArrowSquareOut } from '@phosphor-icons/react';
+import React, { PropsWithChildren, useEffect, useState } from 'react';
 
-import { Input, useTranslation } from '@dxos/aurora';
+import { Link, Input, Trans, useTranslation, useId } from '@dxos/aurora';
+import { getSize, mx } from '@dxos/aurora-theme';
 import { useSplitViewContext } from '@dxos/react-surface';
 
 import { useOctokitContext } from './OctokitProvider';
+
+const ExternalLink = ({ children }: PropsWithChildren<{}>) => {
+  const { t } = useTranslation('composer');
+  const descriptionId = useId('link--external');
+  return (
+    <>
+      <Link href={t('github pat description href')} target='_blank' rel='noreferrer' aria-describedby={descriptionId}>
+        {children}
+        <ArrowSquareOut weight='bold' className={mx(getSize(3), 'inline-block leading-none -mbs-0.5 mli-px')} />
+      </Link>
+      <span className='sr-only' id={descriptionId}>
+        {t('target blank description', { ns: 'os' })}
+      </span>
+    </>
+  );
+};
 
 export const PatInput = () => {
   const { t } = useTranslation('composer');
@@ -27,7 +45,7 @@ export const PatInput = () => {
 
   return (
     <Input.Root>
-      <div role='none' className='mlb-2'>
+      <div role='none' className='mlb-4 max-is-md text-start'>
         <Input.Label>{t('github pat label')}</Input.Label>
         <Input.TextInput
           autoFocus
@@ -36,6 +54,19 @@ export const PatInput = () => {
           value={patValue}
           onChange={({ target: { value } }) => setPatValue(value)}
         />
+        <Input.DescriptionAndValidation classNames='mbs-0.5'>
+          <Input.Description>
+            <Trans
+              {...{
+                t,
+                i18nKey: 'github pat description',
+                components: {
+                  docsLink: <ExternalLink />,
+                },
+              }}
+            />
+          </Input.Description>
+        </Input.DescriptionAndValidation>
       </div>
     </Input.Root>
   );

--- a/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/MarkdownDocument/GfmPreview.tsx
+++ b/packages/apps/composer-app/src/plugins/GithubMarkdownPlugin/components/MarkdownDocument/GfmPreview.tsx
@@ -101,8 +101,8 @@ export const GfmPreview = ({ markdown, owner, repo }: GfmPreviewProps) => {
       />
     </>
   ) : (
-    <div role='none' className='mli-auto max-bs-[300px] text-center'>
-      {!octokit && <p className='mlb-4'>{t('empty github pat message')}</p>}
+    <div role='none' className='mli-auto max-is-md pli-2 text-center'>
+      {!octokit && <p className='mlb-4 text-lg font-system-medium'>{t('empty github pat message')}</p>}
       {octokit ? <Loading label={t('loading preview message')} /> : <PatInput />}
     </div>
   );

--- a/packages/apps/composer-app/src/plugins/SpacePlugin/FullSpaceTreeItem.tsx
+++ b/packages/apps/composer-app/src/plugins/SpacePlugin/FullSpaceTreeItem.tsx
@@ -55,7 +55,7 @@ export const FullSpaceTreeItem = observer(({ data: item }: { data: GraphNode<Spa
           />
         </TreeItem.OpenTrigger>
         <TreeItem.Heading
-          data-testId='spacePlugin.spaceTreeItemHeading'
+          data-testid='spacePlugin.spaceTreeItemHeading'
           classNames={[
             'grow break-words pis-1 pbs-2.5 pointer-fine:pbs-1.5 text-sm font-medium',
             error && 'text-error-700 dark:text-error-300',

--- a/packages/sdk/react-surface/src/plugins/ThemePlugin/translations/en-US/composer.ts
+++ b/packages/sdk/react-surface/src/plugins/ThemePlugin/translations/en-US/composer.ts
@@ -31,6 +31,10 @@ export const composer = {
   'hide space label': 'Hide this space',
   'profile settings label': 'Profile settings',
   'github pat label': 'GitHub personal access token',
+  'github pat description':
+    'Composer needs this in order to communicate with GitHub. <docsLink>GitHub’s documentation describes how to create a token.</docsLink> Composer only needs write access to issues, contents, and pull requests.',
+  'github pat description href':
+    'https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens',
   'empty github pat message': 'Set a GitHub personal access token to continue',
   'set github pat label': 'Set GitHub token',
   'error github pat message': 'There was a problem authenticating with GitHub using the personal access token provided',

--- a/packages/sdk/react-surface/src/plugins/ThemePlugin/translations/en-US/composer.ts
+++ b/packages/sdk/react-surface/src/plugins/ThemePlugin/translations/en-US/composer.ts
@@ -79,7 +79,7 @@ export const composer = {
   'delete document label': 'Delete',
   'loading preview message': 'Loading preview…',
   'preview gfm label': 'Preview Markdown',
-  'exit gfm preview label': 'Edit Markdown',
+  'exit gfm preview label': 'Exit preview',
   'open in github label': 'Open in GitHub',
   'stale rescue title': 'Set a personal access token',
   'stale rescue description':

--- a/packages/sdk/react-surface/src/plugins/ThemePlugin/translations/en-US/os.ts
+++ b/packages/sdk/react-surface/src/plugins/ThemePlugin/translations/en-US/os.ts
@@ -67,4 +67,5 @@ export const os = {
   'welcome message': 'Welcome',
   'selecting identity heading': 'Selecting identity',
   'settings dialog title': 'Settings',
+  'target blank description': 'Link opens in a new tab.',
 };

--- a/packages/ui/aurora-theme/src/styles/components/dialog.ts
+++ b/packages/ui/aurora-theme/src/styles/components/dialog.ts
@@ -25,7 +25,7 @@ export const dialogContent: ComponentFunction<DialogStyleProps> = ({ inOverlayLa
     'flex flex-col',
     !inOverlayLayout && 'fixed z-20 top-[50%] left-[50%] -translate-x-[50%] -translate-y-[50%]',
     'is-[95vw] md:is-full max-is-md rounded-xl p-4',
-    'shadow-2xl bg-25 dark:bg-neutral-850',
+    'shadow-2xl bg-neutral-50 dark:bg-neutral-850',
     defaultFocus,
     ...etc,
   );

--- a/packages/ui/aurora-theme/src/styles/components/link.ts
+++ b/packages/ui/aurora-theme/src/styles/components/link.ts
@@ -12,8 +12,8 @@ export type LinkStyleProps = {};
 export const linkRoot: ComponentFunction<LinkStyleProps> = (_props, ...etc) =>
   mx(
     'underline decoration-1 underline-offset-2 transition-color rounded-sm',
-    'text-primary-600 hover:text-primary-500 dark:text-primary-400 hover:dark:text-primary-300',
-    'visited:text-teal-600 visited:hover:text-teal-500 visited:dark:text-teal-400 visited:hover:dark:text-teal-300',
+    'text-primary-600 hover:text-primary-500 dark:text-primary-300 hover:dark:text-primary-200',
+    'visited:text-teal-600 visited:hover:text-teal-500 visited:dark:text-teal-300 visited:hover:dark:text-teal-200',
     defaultFocus,
     ...etc,
   );

--- a/packages/ui/aurora-theme/src/styles/components/main.ts
+++ b/packages/ui/aurora-theme/src/styles/components/main.ts
@@ -14,7 +14,7 @@ export type MainStyleProps = Partial<{
 
 export const mainSidebar: ComponentFunction<MainStyleProps> = ({ isLg, sidebarOpen }, ...etc) =>
   mx(
-    'fixed block-start-0 block-end-0 is-[100vw] sm:is-[270px] z-10 overscroll-contain overflow-x-hidden overflow-y-auto bg-neutral-25 dark:bg-neutral-850',
+    'fixed block-start-0 block-end-0 is-[100vw] sm:is-[270px] z-10 overscroll-contain overflow-x-hidden overflow-y-auto bg-neutral-50 dark:bg-neutral-850',
     'transition-[inset-inline-start,inset-inline-end] duration-200 ease-in-out',
     sidebarOpen ? 'inline-start-0' : '-inline-start-[100vw] sm:-inline-start-[270px]',
     sidebarOpen && surfaceElevation({ elevation: 'chrome' }),

--- a/packages/ui/aurora-theme/src/styles/fragments/text.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/text.ts
@@ -4,7 +4,7 @@
 
 export const defaultPlaceholder = 'placeholder-neutral-500 dark:placeholder-neutral-400';
 
-export const defaultDescription = 'text-xs leading-4 font-normal text-neutral-650 dark:text-neutral-300';
+export const defaultDescription = 'text-xs font-normal text-neutral-650 dark:text-neutral-300';
 export const primaryDescription = 'text-xs font-normal text-white/90';
 
 export const defaultTooltip = 'text-xs font-normal text-neutral-900 dark:text-neutral-50';

--- a/packages/ui/aurora-theme/src/theme.css
+++ b/packages/ui/aurora-theme/src/theme.css
@@ -66,7 +66,7 @@
 }
 
 :root {
-  --surface-bg: theme(colors.neutral.50);
+  --surface-bg: theme(colors.neutral.75);
   --surface-text: theme(colors.neutral.900);
 }
 

--- a/packages/ui/aurora/src/components/index.ts
+++ b/packages/ui/aurora/src/components/index.ts
@@ -8,6 +8,7 @@ export * from './Dialogs';
 export * from './DropdownMenu';
 export * from './Input';
 export * from './Lists';
+export * from './Link';
 export * from './Main';
 export * from './Message';
 export * from './Tag';


### PR DESCRIPTION
Resolves #3394.
Resolves #3395.

<img width="807" alt="Screenshot 2023-06-14 at 00 25 25" src="https://github.com/dxos/dxos/assets/855039/14962c4d-7994-4551-a2cc-c183573be175">
<img width="471" alt="Screenshot 2023-06-14 at 00 25 20" src="https://github.com/dxos/dxos/assets/855039/edf4053a-3ea2-43ad-b6a7-59eee1d485e3">
<img width="808" alt="Screenshot 2023-06-14 at 00 25 03" src="https://github.com/dxos/dxos/assets/855039/4401699e-f857-4cf8-b952-472f8c022a40">
<img width="471" alt="Screenshot 2023-06-14 at 00 24 34" src="https://github.com/dxos/dxos/assets/855039/7ca8ca4e-7652-402a-bb70-abf280865959">

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8f1155e</samp>

### Summary
🎨🌐🔗

<!--
1.  🎨 - This emoji represents the changes related to styling, colors, and contrast of the UI elements.
2.  🌐 - This emoji represents the changes related to adding translation texts for different components and keys.
3.  🔗 - This emoji represents the changes related to adding a link and a description to the PAT input dialog.
-->
Improved the UI and UX of the GitHub Markdown plugin in the Composer app. Added a link and a description to the PAT input dialog, styled the preview component, and added translation texts. Also updated the Aurora theme and components to enhance the contrast and visibility of the dialog, the sidebar, and the link.



### Walkthrough
*  Added `ExternalLink` component to render links with icons and accessible descriptions ([link](https://github.com/dxos/dxos/pull/3468/files?diff=unified&w=0#diff-2a00e2fe84c265b9a81a45f05fbccd0b7860dbc07b298a5e11e5ccbda410a897L5-R29), [link](https://github.com/dxos/dxos/pull/3468/files?diff=unified&w=0#diff-1f9abb92f984b59a01189ec7fe6171304c84c41c9428ce69c065b28ef1aa9ce9R70)).


