### PR TITLE
refactor: move tree node impl to tree plugin

### DIFF
--- a/packages/apps/composer-app/src/plugins/SpacePlugin/SpacePlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/SpacePlugin/SpacePlugin.tsx
@@ -33,6 +33,7 @@ import {
   PublicKey,
   ShellLayout,
   Space,
+  SpaceState,
   TypedObject,
 } from '@dxos/react-client';
 import {
@@ -269,6 +270,8 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
             handle.update([space.properties]);
             subscriptions.add(handle.unsubscribe);
           }
+          attributes.disabled = space.state.get() !== SpaceState.READY;
+          attributes.error = space.state.get() === SpaceState.ERROR;
           node.attributes = attributes ?? {};
 
           let children = rootObjects.get(id);

--- a/packages/apps/composer-app/src/plugins/SpacePlugin/SpacePlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/SpacePlugin/SpacePlugin.tsx
@@ -4,6 +4,8 @@
 
 import {
   ArrowLineLeft,
+  Article,
+  ArticleMedium,
   Download,
   EyeSlash,
   Intersect,
@@ -20,6 +22,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { Document } from '@braneframe/types';
 import { EventSubscriptions } from '@dxos/async';
 import { useTranslation } from '@dxos/aurora';
+import { TextKind } from '@dxos/aurora-composer';
 import { defaultDescription, mx } from '@dxos/aurora-theme';
 import { createStore, createSubscription } from '@dxos/observable-object';
 import { observer } from '@dxos/observable-object/react';
@@ -46,11 +49,9 @@ import {
   useTreeView,
 } from '@dxos/react-surface';
 
-import { isDocument } from '../GithubMarkdownPlugin';
 import { DialogRenameSpace } from './DialogRenameSpace';
 import { DialogRestoreSpace } from './DialogRestoreSpace';
-import { DocumentLinkTreeItem } from './DocumentLinkTreeItem';
-import { FullSpaceTreeItem } from './FullSpaceTreeItem';
+import { SpaceTreeItem } from './SpaceTreeItem';
 import { backupSpace } from './backup';
 import { getSpaceDisplayName } from './getSpaceDisplayName';
 
@@ -99,7 +100,7 @@ const objectsToGraphNodes = (parent: GraphNode<Space>, objects: TypedObject[]): 
     id: obj.id,
     label: obj.title ?? 'Untitled',
     description: obj.description,
-    icon: obj.icon,
+    icon: obj.content?.kind === TextKind.PLAIN ? ArticleMedium : Article,
     data: obj,
     parent,
     actions: [
@@ -400,9 +401,7 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
         case 'treeitem':
           switch (true) {
             case isSpace(datum?.data):
-              return FullSpaceTreeItem;
-            case isDocument(datum?.data):
-              return DocumentLinkTreeItem;
+              return SpaceTreeItem;
             default:
               return null;
           }
@@ -465,6 +464,7 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
             },
           },
           {
+            // TODO(wittjosiah): Move to SplitViewPlugin.
             id: 'close-sidebar',
             label: ['close sidebar label', { ns: 'os' }],
             icon: ArrowLineLeft,

--- a/packages/apps/composer-app/src/plugins/SpacePlugin/SpaceTreeItem.tsx
+++ b/packages/apps/composer-app/src/plugins/SpacePlugin/SpaceTreeItem.tsx
@@ -1,0 +1,23 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React from 'react';
+
+import { useTranslation } from '@dxos/aurora';
+import { SpaceState } from '@dxos/client';
+import { useMulticastObservable } from '@dxos/react-async';
+import { Space, observer } from '@dxos/react-client';
+import { GraphNode } from '@dxos/react-surface';
+
+import { getSpaceDisplayName } from './getSpaceDisplayName';
+
+export const SpaceTreeItem = observer(({ data: item }: { data: GraphNode<Space> }) => {
+  const space = item.data!;
+  const { t } = useTranslation('composer');
+  const spaceSate = useMulticastObservable(space.state);
+  const disabled = spaceSate !== SpaceState.READY;
+  const spaceDisplayName = getSpaceDisplayName(t, space, disabled);
+
+  return <>{spaceDisplayName}</>;
+});

--- a/packages/sdk/react-surface/src/plugins/TreeViewPlugin/BranchTreeItem.tsx
+++ b/packages/sdk/react-surface/src/plugins/TreeViewPlugin/BranchTreeItem.tsx
@@ -5,23 +5,21 @@
 import { CaretDown, CaretRight, DotsThreeVertical, Placeholder } from '@phosphor-icons/react';
 import React, { useEffect, useRef, useState } from 'react';
 
-import { useSidebar, useTranslation, TreeItem, Tooltip, DropdownMenu, Button } from '@dxos/aurora';
+import { Button, DropdownMenu, Tooltip, TreeItem, useSidebar, useTranslation } from '@dxos/aurora';
 import { defaultDisabled, getSize } from '@dxos/aurora-theme';
-import { SpaceState } from '@dxos/client';
-import { useMulticastObservable } from '@dxos/react-async';
-import { Space, observer } from '@dxos/react-client';
-import { GraphNode, TreeView } from '@dxos/react-surface';
+import { observer } from '@dxos/react-client';
 
-import { getSpaceDisplayName } from './getSpaceDisplayName';
+import { Surface } from '../../framework';
+import { GraphNode } from '../GraphPlugin';
+import { TreeView } from './TreeView';
 
-export const FullSpaceTreeItem = observer(({ data: item }: { data: GraphNode<Space> }) => {
-  const space = item.data!;
-  const [primaryAction, ...actions] = item.actions ?? [];
+export const BranchTreeItem = observer(({ node }: { node: GraphNode }) => {
+  const [primaryAction, ...actions] = node.actions ?? [];
+  // TODO(wittjosiah): Update namespace.
   const { t } = useTranslation('composer');
   const hasActiveDocument = false;
-  const spaceSate = useMulticastObservable(space.state);
-  const disabled = spaceSate !== SpaceState.READY;
-  const error = spaceSate === SpaceState.ERROR;
+  const disabled = node.attributes?.disabled;
+  const error = node.attributes?.error;
   const { sidebarOpen } = useSidebar();
 
   const suppressNextTooltip = useRef<boolean>(false);
@@ -31,10 +29,8 @@ export const FullSpaceTreeItem = observer(({ data: item }: { data: GraphNode<Spa
   const [open, setOpen] = useState(true /* todo(thure): Open if document within is selected */);
 
   useEffect(() => {
-    // todo(thure): Open if document within is selected
+    // todo(thure): Open if child within is selected
   }, []);
-
-  const spaceDisplayName = getSpaceDisplayName(t, space, disabled);
 
   const OpenTriggerIcon = open ? CaretDown : CaretRight;
 
@@ -63,7 +59,7 @@ export const FullSpaceTreeItem = observer(({ data: item }: { data: GraphNode<Spa
           ]}
           onClick={() => setOpen(!open)}
         >
-          {spaceDisplayName}
+          <Surface role='treeitem' data={node} />
         </TreeItem.Heading>
         <Tooltip.Root
           open={optionsTooltipOpen}
@@ -154,7 +150,7 @@ export const FullSpaceTreeItem = observer(({ data: item }: { data: GraphNode<Spa
         )}
       </div>
       <TreeItem.Body>
-        <TreeView items={item.children} parent={item} />
+        <TreeView items={node.children} parent={node} />
       </TreeItem.Body>
     </TreeItem.Root>
   );

--- a/packages/sdk/react-surface/src/plugins/TreeViewPlugin/LeafTreeItem.tsx
+++ b/packages/sdk/react-surface/src/plugins/TreeViewPlugin/LeafTreeItem.tsx
@@ -2,36 +2,36 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Article, ArticleMedium, Circle, DotsThreeVertical } from '@phosphor-icons/react';
+import { Circle, DotsThreeVertical, Placeholder } from '@phosphor-icons/react';
 import React, { useRef, useState } from 'react';
 
-import { Document } from '@braneframe/types';
 import {
-  useTranslation,
-  ListItem,
-  useSidebar,
-  useDensityContext,
-  TreeItem,
-  useMediaQuery,
-  Tooltip,
-  DropdownMenu,
   Button,
+  DropdownMenu,
+  ListItem,
+  Tooltip,
+  TreeItem,
+  useDensityContext,
+  useMediaQuery,
+  useSidebar,
+  useTranslation,
 } from '@dxos/aurora';
-import { TextKind } from '@dxos/aurora-composer';
-import { getSize, mx, appTx } from '@dxos/aurora-theme';
+import { appTx, getSize, mx } from '@dxos/aurora-theme';
 import { observer } from '@dxos/react-client';
-import { GraphNode, useTreeView } from '@dxos/react-surface';
 
-export const DocumentLinkTreeItem = observer(({ data: item }: { data: GraphNode<Document> }) => {
-  const document = item.data!;
+import { GraphNode } from '../GraphPlugin';
+import { useTreeView } from './TreeViewPlugin';
+
+export const LeafTreeItem = observer(({ node }: { node: GraphNode }) => {
   const { sidebarOpen, closeSidebar } = useSidebar();
+  // TODO(wittjosiah): Update namespace.
   const { t } = useTranslation('composer');
   const density = useDensityContext();
   const [isLg] = useMediaQuery('lg', { ssr: false });
   const treeView = useTreeView();
 
-  const active = document.id === treeView.selected[1];
-  const Icon = document.content?.kind === TextKind.PLAIN ? ArticleMedium : Article;
+  const active = node.id === treeView.selected[1];
+  const Icon = node.icon ?? Placeholder;
 
   const suppressNextTooltip = useRef<boolean>(false);
   const [optionsTooltipOpen, setOptionsTooltipOpen] = useState(false);
@@ -54,13 +54,13 @@ export const DocumentLinkTreeItem = observer(({ data: item }: { data: GraphNode<
           {...(!sidebarOpen && { tabIndex: -1 })}
           data-itemid={item.id}
           onClick={() => {
-            treeView.selected = [item.parent!.id, item.id];
+            treeView.selected = [node.parent!.id, node.id];
             !isLg && closeSidebar();
           }}
           className='text-start flex gap-2'
         >
           <Icon weight='regular' className={mx(getSize(4), 'shrink-0 mbs-2')} />
-          <p className='grow mbs-1'>{document.title || t('untitled document title')}</p>
+          <p className='grow mbs-1'>{node.label || t('untitled document title')}</p>
         </button>
       </TreeItem.Heading>
       <Tooltip.Root
@@ -104,7 +104,7 @@ export const DocumentLinkTreeItem = observer(({ data: item }: { data: GraphNode<
           </DropdownMenu.Trigger>
           <DropdownMenu.Portal>
             <DropdownMenu.Content classNames='z-[31]'>
-              {item.actions?.map((action) => (
+              {node.actions?.map((action) => (
                 <DropdownMenu.Item
                   key={action.id}
                   onClick={(event) => {

--- a/packages/sdk/react-surface/src/plugins/TreeViewPlugin/LeafTreeItem.tsx
+++ b/packages/sdk/react-surface/src/plugins/TreeViewPlugin/LeafTreeItem.tsx
@@ -52,7 +52,7 @@ export const LeafTreeItem = observer(({ node }: { node: GraphNode }) => {
         <button
           role='link'
           {...(!sidebarOpen && { tabIndex: -1 })}
-          data-itemid={item.id}
+          data-itemid={node.id}
           onClick={() => {
             treeView.selected = [node.parent!.id, node.id];
             !isLg && closeSidebar();

--- a/packages/sdk/react-surface/src/plugins/TreeViewPlugin/TreeView.tsx
+++ b/packages/sdk/react-surface/src/plugins/TreeViewPlugin/TreeView.tsx
@@ -9,6 +9,8 @@ import { observer } from '@dxos/observable-object/react';
 
 import { Surface } from '../../framework';
 import { GraphNode } from '../GraphPlugin';
+import { BranchTreeItem } from './BranchTreeItem';
+import { LeafTreeItem } from './LeafTreeItem';
 
 export type TreeViewProps = {
   items?: GraphNode[];
@@ -22,7 +24,9 @@ export const TreeView = observer((props: TreeViewProps) => {
       {items?.length ? ( // TODO(wittjosiah): Without `Array.from` we get an infinite render loop.
         Array.from(items)
           .filter((item) => !item.attributes?.hidden)
-          .map((item) => <Surface key={item.id} role='treeitem' data={item} />)
+          .map((item) =>
+            item.children ? <BranchTreeItem key={item.id} node={item} /> : <LeafTreeItem key={item.id} node={item} />,
+          )
       ) : (
         <Surface role='tree--empty' data={props.parent} />
       )}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 25c2ad1</samp>

### Summary
🌲🚀📄

<!--
1.  🌲 - This emoji represents the tree view plugin and the changes related to it, such as adding new components, refactoring existing ones, and improving the rendering logic. It also conveys the idea of a hierarchical structure and navigation.
2.  🚀 - This emoji represents the space plugin and the changes related to it, such as using the tree view and split view plugins, and enhancing the document icons. It also conveys the idea of innovation, exploration, and performance.
3.  📄 - This emoji represents the document-related changes, such as the content kind icons, the document link component, and the node attributes. It also conveys the idea of information, communication, and writing.
-->
This pull request improves the space plugin and the tree view plugin for the composer app. It refactors the components for rendering different types of nodes in the tree view, and makes them more generic and reusable. It also enhances the document icons and removes some unused code.

> _Sing, O Muse, of the skillful coder who refashioned_
> _The space plugin with the tree view and the split view,_
> _And made the nodes more elegant and diverse in function,_
> _Using the surface plugins and the content kind as clues._

### Walkthrough
*  Refactor the space plugin to use the generic tree view plugin and the surface component for rendering the nodes ([link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163R7-R8), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163R25), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L49-R54), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L102-R103), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L403-R404), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163R467), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-794973edaf0272c31de7da1707bdcacdbef36b3cf36d9cb49f203d2de7fdf1a5R1-R23), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-23f8265189ba0730fb709c284cfc2c0a4cca862e9465f37abdf6a89ad4885ae9L8-R22), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-23f8265189ba0730fb709c284cfc2c0a4cca862e9465f37abdf6a89ad4885ae9L34-R34), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-23f8265189ba0730fb709c284cfc2c0a4cca862e9465f37abdf6a89ad4885ae9L66-R62), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-23f8265189ba0730fb709c284cfc2c0a4cca862e9465f37abdf6a89ad4885ae9L157-R153), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-b957168b3898d8b7e8ed56403576e46f6d9fa817284fe1e26c8236a046890f26L5-R27), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-b957168b3898d8b7e8ed56403576e46f6d9fa817284fe1e26c8236a046890f26L33-R34), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-b957168b3898d8b7e8ed56403576e46f6d9fa817284fe1e26c8236a046890f26L57-R57), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-b957168b3898d8b7e8ed56403576e46f6d9fa817284fe1e26c8236a046890f26L63-R63), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-b957168b3898d8b7e8ed56403576e46f6d9fa817284fe1e26c8236a046890f26L107-R107), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-32bdda0886c39f8ce6618561297d70397bbe151f928a4c3b57c2e7aa241e5214R12-R13), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-32bdda0886c39f8ce6618561297d70397bbe151f928a4c3b57c2e7aa241e5214L25-R29))
  * Import icons from `aurora` and use the `TextKind` enum from `aurora-composer` to differentiate plain text and rich text documents in the space plugin ([link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163R7-R8), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163R25), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L102-R103))
  * Rename and move the `FullSpaceTreeItem` and `DocumentLinkTreeItem` components to the tree view plugin as `BranchTreeItem` and `LeafTreeItem`, and remove unused imports and dependencies ([link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L49-R54), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-23f8265189ba0730fb709c284cfc2c0a4cca862e9465f37abdf6a89ad4885ae9L8-R22), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-b957168b3898d8b7e8ed56403576e46f6d9fa817284fe1e26c8236a046890f26L5-R27))
  * Simplify the switch case for selecting the tree item component based on the node data, and use the `icon` attribute of the node instead of a fixed icon ([link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L403-R404), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-b957168b3898d8b7e8ed56403576e46f6d9fa817284fe1e26c8236a046890f26L33-R34))
  * Use the `surface` component to render the node label and data using the registered surface plugins, instead of using the `getSpaceDisplayName` function or the document title ([link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-23f8265189ba0730fb709c284cfc2c0a4cca862e9465f37abdf6a89ad4885ae9L34-R34), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-23f8265189ba0730fb709c284cfc2c0a4cca862e9465f37abdf6a89ad4885ae9L66-R62), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-b957168b3898d8b7e8ed56403576e46f6d9fa817284fe1e26c8236a046890f26L63-R63))
  * Update the variables and constants to use the `node` instead of the `item` or `document`, and use the `node.id` instead of the `item.id` for the onClick handler ([link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-23f8265189ba0730fb709c284cfc2c0a4cca862e9465f37abdf6a89ad4885ae9L157-R153), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-b957168b3898d8b7e8ed56403576e46f6d9fa817284fe1e26c8236a046890f26L33-R34), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-b957168b3898d8b7e8ed56403576e46f6d9fa817284fe1e26c8236a046890f26L57-R57))
  * Update the dropdown menu items to use the `node.actions` instead of the `item.actions` for the leaf nodes ([link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-b957168b3898d8b7e8ed56403576e46f6d9fa817284fe1e26c8236a046890f26L107-R107))
  * Add a TODO comment to indicate that the split view plugin should handle the logic for opening and closing the sidebar, instead of the space plugin ([link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163R467))
  * Add a new file for the `SpaceTreeItem` component, which renders the display name of a space node in the tree view ([link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-794973edaf0272c31de7da1707bdcacdbef36b3cf36d9cb49f203d2de7fdf1a5R1-R23))
  * Update the tree view rendering to use the `BranchTreeItem` and `LeafTreeItem` components based on the presence of children in the node, instead of using the `surface` component for all nodes ([link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-32bdda0886c39f8ce6618561297d70397bbe151f928a4c3b57c2e7aa241e5214R12-R13), [link](https://github.com/dxos/dxos/pull/3473/files?diff=unified&w=0#diff-32bdda0886c39f8ce6618561297d70397bbe151f928a4c3b57c2e7aa241e5214L25-R29))


