### PR TITLE
refactor: generalize navigation logic and collect in routes plugin

### DIFF
--- a/packages/apps/composer-app/package.json
+++ b/packages/apps/composer-app/package.json
@@ -16,6 +16,7 @@
     "@dxos/client-services": "workspace:*",
     "@dxos/config": "workspace:*",
     "@dxos/echo-schema": "workspace:*",
+    "@dxos/keys": "workspace:*",
     "@dxos/log": "workspace:*",
     "@dxos/observable-object": "workspace:*",
     "@dxos/react-appkit": "workspace:*",

--- a/packages/apps/composer-app/tsconfig.json
+++ b/packages/apps/composer-app/tsconfig.json
@@ -18,6 +18,9 @@
   ],
   "references": [
     {
+      "path": "../../common/keys"
+    },
+    {
       "path": "../../common/log"
     },
     {

--- a/packages/sdk/react-surface/src/plugins/RoutesPlugin.tsx
+++ b/packages/sdk/react-surface/src/plugins/RoutesPlugin.tsx
@@ -2,18 +2,20 @@
 // Copyright 2023 DXOS.org
 //
 
-import React from 'react';
-import { Outlet, RouteObject, useRoutes } from 'react-router';
+import React, { useEffect } from 'react';
+import { Outlet, Params, RouteObject, useLocation, useNavigate, useParams, useRoutes } from 'react-router';
 import { BrowserRouter } from 'react-router-dom';
 
 import { observer } from '@dxos/observable-object/react';
 
 import { definePlugin, Plugin, usePluginContext } from '../framework';
+import { selectedToUri, useTreeView } from './TreeViewPlugin';
 
 export type RouterPluginProvides = {
   router: {
-    routes?: () => RouteObject[];
-    useNavigator?: () => void;
+    routes: () => RouteObject[];
+    current?: (params: Params<string>) => string[] | null;
+    next?: (path: string, params: Params<string>) => string[] | null;
   };
 };
 
@@ -24,13 +26,41 @@ const routerPlugins = (plugins: Plugin[]): RouterPlugin[] => {
 };
 
 const Root = observer(({ plugins }: { plugins: RouterPlugin[] }) => {
-  plugins.map((plugin) => plugin.provides.router.useNavigator?.());
+  const navigate = useNavigate();
+  const location = useLocation();
+  const params = useParams();
+  const treeView = useTreeView();
+
+  useEffect(() => {
+    const [current] = plugins
+      .map((plugin) => plugin.provides.router.current?.(params))
+      .filter((current): current is string[] => Boolean(current));
+
+    if (!current && treeView.selected.length === 0) {
+      return;
+    }
+
+    if (!current || selectedToUri(current) !== selectedToUri(treeView.selected)) {
+      navigate(selectedToUri(treeView.selected));
+    }
+  }, [treeView.selected]);
+
+  useEffect(() => {
+    const [current] = plugins
+      .map((plugin) => plugin.provides.router.next?.(location.pathname, params))
+      .filter((current): current is string[] => Boolean(current));
+
+    if (current && selectedToUri(current) !== selectedToUri(treeView.selected)) {
+      treeView.selected = current;
+    }
+  }, [location.pathname, params]);
+
   return <Outlet />;
 });
 
 export const RoutesPlugin = definePlugin({
   meta: {
-    id: 'RoutesPlugin',
+    id: 'dxos:routes',
   },
   provides: {
     // TODO(wittjosiah): Should be BrowserRouter.

--- a/packages/sdk/react-surface/src/plugins/TreeViewPlugin/LeafTreeItem.tsx
+++ b/packages/sdk/react-surface/src/plugins/TreeViewPlugin/LeafTreeItem.tsx
@@ -30,7 +30,7 @@ export const LeafTreeItem = observer(({ node }: { node: GraphNode }) => {
   const [isLg] = useMediaQuery('lg', { ssr: false });
   const treeView = useTreeView();
 
-  const active = node.id === treeView.selected[1];
+  const active = node.id === treeView.selected.at(-1);
   const Icon = node.icon ?? Placeholder;
 
   const suppressNextTooltip = useRef<boolean>(false);
@@ -54,7 +54,8 @@ export const LeafTreeItem = observer(({ node }: { node: GraphNode }) => {
           {...(!sidebarOpen && { tabIndex: -1 })}
           data-itemid={node.id}
           onClick={() => {
-            treeView.selected = [node.parent!.id, node.id];
+            // TODO(wittjosiah): Make recursive.
+            treeView.selected = node.parent ? [node.parent.id, node.id] : [node.id];
             !isLg && closeSidebar();
           }}
           className='text-start flex gap-2'

--- a/packages/sdk/react-surface/src/plugins/TreeViewPlugin/TreeViewPlugin.tsx
+++ b/packages/sdk/react-surface/src/plugins/TreeViewPlugin/TreeViewPlugin.tsx
@@ -41,6 +41,8 @@ const Context = createContext<TreeViewContextValue>(store);
 
 export const useTreeView = () => useContext(Context);
 
+export const selectedToUri = (selected: string[]) => selected.join('/').replace(':', '/');
+
 export const TreeViewContainer = observer(() => {
   const graph = useGraphContext();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,6 +346,7 @@ importers:
       '@dxos/client-services': workspace:*
       '@dxos/config': workspace:*
       '@dxos/echo-schema': workspace:*
+      '@dxos/keys': workspace:*
       '@dxos/log': workspace:*
       '@dxos/observable-object': workspace:*
       '@dxos/react-appkit': workspace:*
@@ -392,6 +393,7 @@ importers:
       '@dxos/client-services': link:../../sdk/client-services
       '@dxos/config': link:../../sdk/config
       '@dxos/echo-schema': link:../../core/echo/echo-schema
+      '@dxos/keys': link:../../common/keys
       '@dxos/log': link:../../common/log
       '@dxos/observable-object': link:../../common/observable-object
       '@dxos/react-appkit': link:../../ui/react-appkit


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 72472c0</samp>

### Summary
📦🐛🚀

<!--
1.  📦 for adding a dependency and a path mapping.
2.  🐛 for fixing a typo and a bug.
3.  🚀 for enhancing and improving the plugins and the components.
-->
This pull request updates and improves the code of the `SpacePlugin`, the `RoutesPlugin`, and the `TreeViewPlugin` in the `composer-app` and the `react-surface` packages. It also adds a dependency on the `@dxos/keys` package and fixes some minor issues. The main purpose of these changes is to enhance the navigation and identification of spaces and other items in the composer app.

> _We're the masters of the tree, we navigate with skill_
> _We use the keys of destiny, we bend the space to our will_
> _We fix the bugs and typos, we refactor and enhance_
> _We're the `composer-app` heroes, we make the plugins dance_

### Walkthrough
*  Add `@dxos/keys` dependency and path mapping to use `PublicKey` and `PublicKeyLike` types and utilities in `SpacePlugin` ([link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-47b84ac128e4ba47b697389d563eb2770189956b67cea33857501b520432a1e1R19), [link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-aa01c591cecab0e1f8665cacbf254fc9a9418559a3649b0e930ec007c34e2d8cR21-R23), [link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163R26), [link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L33), [link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L154-R164))
*  Refactor plugin ids to use consistent and lowercase format `dxos:<name>` across `SpacePlugin` and `RoutesPlugin` ([link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L200-R208), [link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L253-R261), [link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L324-R332), [link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L330-R338), [link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L336-R344), [link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L342-R350), [link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L420-R405), [link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-cad446bf397e9510c17156072300917bc9cc499a1cbc67168365634f3907e57dL33-R63))
*  Implement navigation logic based on tree view selection and route params in `RoutesPlugin` using `current` and `next` functions from router plugins ([link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-cad446bf397e9510c17156072300917bc9cc499a1cbc67168365634f3907e57dL5-R6), [link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-cad446bf397e9510c17156072300917bc9cc499a1cbc67168365634f3907e57dL12-R18), [link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-cad446bf397e9510c17156072300917bc9cc499a1cbc67168365634f3907e57dL27-R57))
*  Add helper function `selectedToUri` to `TreeViewPlugin` to convert tree view selection to route path ([link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-c6b3be175cba28e8b2e900c7d5e8c5714dab30ad9db669c850640fcaf7f7b4b0R44-R45))
*  Replace direct use of `space.key.toHex()` with `getSpaceId` function in `SpacePlugin` to generate consistent and unique ids for spaces ([link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L173-R181))
*  Remove unused imports and functions from `SpacePlugin` ([link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L19-R19), [link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L348-R372))
*  Update `active` variable and `onClick` handler in `LeafTreeItem` to use `at` method and node id for different levels of nesting ([link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-b957168b3898d8b7e8ed56403576e46f6d9fa817284fe1e26c8236a046890f26L33-R33), [link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-b957168b3898d8b7e8ed56403576e46f6d9fa817284fe1e26c8236a046890f26L55-R58))
*  Fix typo in `data-testid` attribute of `TreeItem.Heading` component in `BranchTreeItem` ([link](https://github.com/dxos/dxos/pull/3474/files?diff=unified&w=0#diff-23f8265189ba0730fb709c284cfc2c0a4cca862e9465f37abdf6a89ad4885ae9L54-R54))


