### PR TITLE
refactor(cli): Use client-protocol config dir

### DIFF
--- a/packages/devtools/cli/src/base-command.ts
+++ b/packages/devtools/cli/src/base-command.ts
@@ -14,7 +14,7 @@ import pkgUp from 'pkg-up';
 
 import { Agent, ForeverDaemon } from '@dxos/agent';
 import { Client, fromAgent, Config, DX_DATA } from '@dxos/client';
-import { ENV_DX_CONFIG, ENV_DX_PROFILE, ENV_DX_PROFILE_DEFAULT } from '@dxos/client-protocol';
+import { DX_CONFIG, ENV_DX_CONFIG, ENV_DX_PROFILE, ENV_DX_PROFILE_DEFAULT } from '@dxos/client-protocol';
 import { ConfigProto } from '@dxos/config';
 import { raise } from '@dxos/debug';
 import { log } from '@dxos/log';
@@ -70,9 +70,6 @@ export abstract class BaseCommand<T extends typeof Command = any> extends Comman
 
   public static override enableJsonFlag = true;
 
-  // Hack required to provide access to flags parser.
-  private static _configDir: string;
-
   static override flags = {
     profile: Flags.string({
       description: 'User profile.',
@@ -86,7 +83,7 @@ export abstract class BaseCommand<T extends typeof Command = any> extends Comman
       async default({ flags }: { flags: any }) {
         // TODO(burdon): Create if doesn't exist?
         const profile = flags?.profile ?? ENV_DX_PROFILE_DEFAULT;
-        return join(BaseCommand._configDir, `profile/${profile}.yml`);
+        return join(DX_CONFIG, `profile/${profile}.yml`);
       },
       dependsOn: ['profile'],
       aliases: ['c'],
@@ -103,7 +100,6 @@ export abstract class BaseCommand<T extends typeof Command = any> extends Comman
 
   constructor(argv: string[], config: OclifConfig) {
     super(argv, config);
-    BaseCommand._configDir = config.configDir;
 
     try {
       this._stdin = fs.readFileSync(0, 'utf8');
@@ -148,7 +144,7 @@ export abstract class BaseCommand<T extends typeof Command = any> extends Comman
   }
 
   private async _initTelemetry() {
-    this._telemetryContext = await getTelemetryContext(this.config.configDir);
+    this._telemetryContext = await getTelemetryContext(DX_DATA);
     const { mode, installationId, group, environment, release } = this._telemetryContext;
     if (group === 'dxos') {
       this.log(chalk`✨ {bgMagenta Running as internal user} ✨\n`);
@@ -170,7 +166,7 @@ export abstract class BaseCommand<T extends typeof Command = any> extends Comman
     }
 
     if (TELEMETRY_API_KEY) {
-      mode === 'disabled' && (await disableTelemetry(this.config.configDir));
+      mode === 'disabled' && (await disableTelemetry(DX_DATA));
 
       Telemetry.init({
         apiKey: TELEMETRY_API_KEY,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ab17699</samp>

### Summary
🛠️🚀📊

<!--
1.  🛠️ - This emoji represents refactoring or fixing code, which is the main purpose of this pull request.
2.  🚀 - This emoji represents improving performance or reliability, which is a secondary benefit of this pull request since it ensures consistent access to the DXOS directories and avoids potential errors or conflicts.
3.  📊 - This emoji represents adding or improving analytics or telemetry, which is another secondary benefit of this pull request since it improves the telemetry initialization and avoids unnecessary calls to `ensureDir`.
-->
Refactor `BaseCommand` class to use `@dxos/client-protocol` constants and simplify telemetry setup.

> _`BaseCommand` is the master of the DXOS realm_
> _It wields the power of `DX_CONFIG` and `DX_DATA`_
> _No more redundant code, no more telemetry hell_
> _Refactoring the code is the way to rebel_

### Walkthrough
* Imported `DX_CONFIG` from `@dxos/client-protocol` to use as a common source of the configuration directory path ([link](https://github.com/dxos/dxos/pull/3475/files?diff=unified&w=0#diff-eac56b1110e7935c817484ab1eb0b16951aac365450a32573ac651409bdf64aeL17-R17)).


