### PR TITLE
fix(cli-monitor): Use `tmp` dir if HOME is not defined

### DIFF
--- a/packages/sdk/client-protocol/src/config.ts
+++ b/packages/sdk/client-protocol/src/config.ts
@@ -19,7 +19,7 @@ export const defaultConfig: ConfigProto = { version: 1 };
 // https://wiki.archlinux.org/title/XDG_Base_Directory
 // TODO(burdon): Change to ~/.config or XDG_CONFIG_HOME
 
-const HOME = typeof process !== 'undefined' ? process?.env?.HOME : '';
+const HOME = typeof process !== 'undefined' ? process?.env?.HOME : 'tmp';
 
 // TODO(burdon): Generalize since currently NodeJS only.
 export const DX_CONFIG = `${HOME}/.config/dx`;

--- a/tools/monitors/cli-monitor/test/cli.test.ts
+++ b/tools/monitors/cli-monitor/test/cli.test.ts
@@ -5,6 +5,7 @@
 import { expect } from 'chai';
 import { exec } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
 import pkgUp from 'pkg-up';
 
@@ -15,9 +16,18 @@ const throwError = (err: Error) => {
 describe('CLI', () => {
   it('prints config', async () => {
     const packagePath = pkgUp.sync({ cwd: __dirname }) ?? throwError(new Error('package.json not found'));
-    console.log('package.json', readFileSync(packagePath, { encoding: 'utf-8' }));
+    console.log('package.json devDeps', JSON.parse(readFileSync(packagePath, { encoding: 'utf-8' })).devDependencies);
+    console.log(
+      'cli version',
+      JSON.parse(
+        readFileSync(join(dirname(packagePath), 'node_modules', '@dxos/cli', 'package.json'), { encoding: 'utf-8' }),
+      ).version,
+    );
 
-    const { stdout } = await promisify(exec)('npm exec dx config', { cwd: __dirname });
+    console.log('HOME', typeof process !== 'undefined' ? process?.env?.HOME : 'tmp');
+
+    const { stdout, stderr } = await promisify(exec)('npm exec dx config', { cwd: __dirname });
+    console.log('stderr', stderr);
     expect(stdout).to.contain('"version": 1');
   }).timeout(5000);
 });


### PR DESCRIPTION
copilot:all
