### PR TITLE
fix: Increase messaging timeouts

### DIFF
--- a/packages/core/mesh/messaging/src/messenger.ts
+++ b/packages/core/mesh/messaging/src/messenger.ts
@@ -45,7 +45,7 @@ export class Messenger {
   private _closed = true;
   private readonly _retryDelay: number;
 
-  constructor({ signalManager, retryDelay = 100 }: MessengerOptions) {
+  constructor({ signalManager, retryDelay = 300 }: MessengerOptions) {
     this._signalManager = signalManager;
     this._retryDelay = retryDelay;
 

--- a/packages/core/mesh/messaging/src/timeouts.ts
+++ b/packages/core/mesh/messaging/src/timeouts.ts
@@ -5,4 +5,4 @@
 /**
  * Timeout for retrying messages.
  */
-export const MESSAGE_TIMEOUT = 3_000;
+export const MESSAGE_TIMEOUT = 10_000;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9f5fdf3</samp>

### Summary
🕒🔄📶

<!--
1.  🕒 This emoji represents a clock face showing three o'clock, and it can be used to indicate the changes related to time, such as the increased `retryDelay` and `MESSAGE_TIMEOUT` values. It can also suggest the idea of waiting or patience, which are relevant to the retry logic of the `Messenger`.
2.  🔄 This emoji represents an arrow forming a circle, and it can be used to indicate the changes related to retrying, such as the increased frequency and duration of resending messages that did not receive an acknowledgment. It can also suggest the idea of repetition or looping, which are relevant to the retry logic of the `Messenger`.
3.  📶 This emoji represents a signal strength indicator, and it can be used to indicate the changes related to network issues or performance, such as the reduced congestion or improved reliability of the mesh messaging system. It can also suggest the idea of communication or connectivity, which are relevant to the purpose of the `Messenger`.
-->
Increased the `retryDelay` and `MESSAGE_TIMEOUT` values in the `Messenger` class and the `timeouts.ts` file to improve the mesh messaging reliability and performance. These changes allow more time for messages to be delivered and acknowledged in case of network issues or errors.

> _`Messenger` waits more_
> _To avoid failed messages_
> _Winter patience grows_

### Walkthrough
* Increase the default retry delay and message timeout for the mesh messaging system ([link](https://github.com/dxos/dxos/pull/3500/files?diff=unified&w=0#diff-676a81f432e0060295f1801178be4e7edfde44c2fe059ceaf2712b0718270a24L48-R48), [link](https://github.com/dxos/dxos/pull/3500/files?diff=unified&w=0#diff-affcafb4a7abd93a1d589f3a6ce3659208a6236d7e61fefff4a67d31b39b7053L8-R8))


