### PR TITLE
feat(client-services): Throw error on metadata version mismatch

### DIFF
--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -5,7 +5,7 @@
 import CRC32 from 'crc-32';
 import assert from 'node:assert';
 
-import { synchronized } from '@dxos/async';
+import { synchronized, Event } from '@dxos/async';
 import { DataCorruptionError } from '@dxos/errors';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
@@ -28,6 +28,7 @@ const emptyEchoMetadata = (): EchoMetadata => ({
 
 export class MetadataStore {
   private _metadata: EchoMetadata = emptyEchoMetadata();
+  public readonly update = new Event<EchoMetadata>();
 
   // prettier-ignore
   constructor(
@@ -90,6 +91,7 @@ export class MetadataStore {
       created: this._metadata.created ?? new Date(),
       updated: new Date(),
     };
+    this.update.emit(data);
 
     const file = this._directory.getOrCreateFile('EchoMetadata');
 

--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -35,6 +35,10 @@ export class MetadataStore {
     private readonly _directory: Directory
   ) {}
 
+  get metadata(): EchoMetadata {
+    return this._metadata;
+  }
+
   get version(): number {
     return this._metadata.version ?? 0;
   }

--- a/packages/core/protocols/src/proto/dxos/devtools/host.proto
+++ b/packages/core/protocols/src/proto/dxos/devtools/host.proto
@@ -9,6 +9,7 @@ import "google/protobuf/timestamp.proto";
 
 import "dxos/devtools/swarm.proto";
 import "dxos/echo/feed.proto";
+import "dxos/echo/metadata.proto";
 import "dxos/echo/snapshot.proto";
 import "dxos/echo/timeframe.proto";
 import "dxos/halo/keyring.proto";
@@ -58,6 +59,7 @@ service DevtoolsHost {
   rpc SubscribeToItems(SubscribeToItemsRequest) returns (stream SubscribeToItemsResponse);
   rpc SubscribeToFeeds(SubscribeToFeedsRequest) returns (stream SubscribeToFeedsResponse);
   rpc SubscribeToFeedBlocks(SubscribeToFeedBlocksRequest) returns (stream SubscribeToFeedBlocksResponse);
+  rpc SubscribeToMetadata(google.protobuf.Empty) returns (stream SubscribeToMetadataResponse);
 
   rpc GetSpaceSnapshot(GetSpaceSnapshotRequest) returns (GetSpaceSnapshotResponse);
   rpc SaveSpaceSnapshot(SaveSpaceSnapshotRequest) returns (SaveSpaceSnapshotResponse);
@@ -149,6 +151,14 @@ message StoredSnapshotInfo {
 
 message GetSnapshotsResponse {
   repeated StoredSnapshotInfo snapshots = 1;
+}
+
+//
+// Metadata
+//
+
+message SubscribeToMetadataResponse {
+  dxos.echo.metadata.EchoMetadata metadata = 1;
 }
 
 //

--- a/packages/devtools/devtools/src/hooks/index.ts
+++ b/packages/devtools/devtools/src/hooks/index.ts
@@ -5,6 +5,7 @@
 export * from './useCredentials';
 export * from './useDevtoolsContext';
 export * from './useFeedMessages';
+export * from './useMetadata';
 export * from './useProxiedClient';
 export * from './useRemoteClient';
 export * from './useRoutes';

--- a/packages/devtools/devtools/src/hooks/useMetadata.tsx
+++ b/packages/devtools/devtools/src/hooks/useMetadata.tsx
@@ -1,0 +1,12 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { SubscribeToMetadataResponse } from '@dxos/protocols/proto/dxos/devtools/host';
+import { useDevtools, useStream } from '@dxos/react-client';
+
+export const useMetadata = () => {
+  const devtoolsHost = useDevtools();
+  const metadata = useStream(() => devtoolsHost.subscribeToMetadata(), {} as SubscribeToMetadataResponse).metadata;
+  return metadata;
+};

--- a/packages/devtools/devtools/src/hooks/useRoutes.tsx
+++ b/packages/devtools/devtools/src/hooks/useRoutes.tsx
@@ -18,8 +18,9 @@ import {
   SignalPanel,
   SpacesPanel,
   StoragePanel,
-  SwarmPanel
+  SwarmPanel,
 } from '../panels';
+import MetadataPanel from '../panels/echo/MetadataPanel';
 
 export const namespace = 'devtools';
 
@@ -38,70 +39,74 @@ export const useRoutes = () => {
           children: [
             {
               path: '/client/config',
-              element: <ConfigPanel />
+              element: <ConfigPanel />,
             },
             {
               path: '/client/storage',
-              element: <StoragePanel />
+              element: <StoragePanel />,
             },
             {
               path: '/client/logs',
-              element: <LoggingPanel />
+              element: <LoggingPanel />,
             },
-          ]
+          ],
         },
         {
           path: '/halo',
           children: [
             {
               path: '/halo/identity',
-              element: <IdentityPanel />
+              element: <IdentityPanel />,
             },
             {
               path: '/halo/keyring',
-              element: <KeyringPanel />
+              element: <KeyringPanel />,
             },
             {
               path: '/halo/credentials',
-              element: <CredentialsPanel />
-            }
-          ]
+              element: <CredentialsPanel />,
+            },
+          ],
         },
         {
           path: '/echo',
           children: [
             {
               path: '/echo/spaces',
-              element: <SpacesPanel />
+              element: <SpacesPanel />,
             },
             {
               path: '/echo/feeds',
-              element: <FeedsPanel />
+              element: <FeedsPanel />,
             },
             {
               path: '/echo/items',
-              element: <ItemsPanel />
+              element: <ItemsPanel />,
             },
             {
               path: '/echo/members',
-              element: <MembersPanel />
-            }
-          ]
+              element: <MembersPanel />,
+            },
+            {
+              path: '/echo/metadata',
+              element: <MetadataPanel />,
+            },
+          ],
         },
         {
           path: '/mesh',
           children: [
             {
               path: '/mesh/swarm',
-              element: <SwarmPanel />
+              element: <SwarmPanel />,
             },
             {
               path: '/mesh/signal',
-              element: <SignalPanel />
-            }
-          ]
-        }
-      ]
-    }
+              element: <SignalPanel />,
+            },
+          ],
+        },
+      ],
+    },
   ]);
 };

--- a/packages/devtools/devtools/src/hooks/useSections.tsx
+++ b/packages/devtools/devtools/src/hooks/useSections.tsx
@@ -15,7 +15,7 @@ import {
   Queue,
   Receipt,
   Users,
-  UsersThree
+  UsersThree,
 } from '@phosphor-icons/react';
 import { FC } from 'react';
 
@@ -39,7 +39,7 @@ export const useSections = (): SectionItem[] => {
         {
           id: '/client/config',
           title: 'Config',
-          Icon: Gear
+          Icon: Gear,
         },
         {
           id: '/client/storage',
@@ -49,9 +49,9 @@ export const useSections = (): SectionItem[] => {
         {
           id: '/client/logs',
           title: 'Logs',
-          Icon: Receipt
-        }
-      ]
+          Icon: Receipt,
+        },
+      ],
     },
     {
       id: '/halo',
@@ -61,19 +61,19 @@ export const useSections = (): SectionItem[] => {
         {
           id: '/halo/identity',
           title: 'Identity',
-          Icon: IdentificationBadge
+          Icon: IdentificationBadge,
         },
         {
           id: '/halo/keyring',
           title: 'Keyring',
-          Icon: Key
+          Icon: Key,
         },
         {
           id: '/halo/credentials',
           title: 'Credentials',
-          Icon: CreditCard
-        }
-      ]
+          Icon: CreditCard,
+        },
+      ],
     },
     {
       id: '/echo',
@@ -83,29 +83,34 @@ export const useSections = (): SectionItem[] => {
         {
           id: '/echo/spaces',
           title: 'Spaces',
-          Icon: HardDrive
+          Icon: HardDrive,
         },
         {
           id: '/echo/feeds',
           title: 'Feeds',
-          Icon: Queue
+          Icon: Queue,
         },
         {
           id: '/echo/items',
           title: 'Items',
-          Icon: Database
+          Icon: Database,
         },
         {
           id: '/echo/members',
           title: 'Members',
-          Icon: Users
-        }
+          Icon: Users,
+        },
+        {
+          id: '/echo/metadata',
+          title: 'Metadata',
+          Icon: HardDrive,
+        },
         // {
         //   id: '/echo/snapshots',
         //   title: 'Snapshots',
         //   Icon: <SnapshotsIcon />
         // }
-      ]
+      ],
     },
     {
       id: 'mesh',
@@ -120,15 +125,15 @@ export const useSections = (): SectionItem[] => {
         {
           id: '/mesh/swarm',
           title: 'Swarm',
-          Icon: UsersThree
+          Icon: UsersThree,
         },
         {
           id: '/mesh/signal',
           title: 'Signal',
-          Icon: PaperPlane
-        }
-      ]
-    }
+          Icon: PaperPlane,
+        },
+      ],
+    },
     // {
     //   id: '/dmg',
     //   title: 'DMG',

--- a/packages/devtools/devtools/src/panels/echo/MetadataPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/MetadataPanel.tsx
@@ -1,0 +1,16 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React from 'react';
+
+import { JsonView } from '../../components';
+import { useMetadata } from '../../hooks';
+
+const MetadataPanel = () => {
+  const metadata = useMetadata();
+
+  return <JsonView data={metadata} />;
+};
+
+export default MetadataPanel;

--- a/packages/devtools/devtools/src/panels/echo/index.ts
+++ b/packages/devtools/devtools/src/panels/echo/index.ts
@@ -8,3 +8,4 @@ export const FeedsPanel = React.lazy(() => import('./FeedsPanel'));
 export const ItemsPanel = React.lazy(() => import('./ItemsPanel'));
 export const MembersPanel = React.lazy(() => import('./MembersPanel'));
 export const SpacesPanel = React.lazy(() => import('./SpacesPanel'));
+export const MetadataPanel = React.lazy(() => import('./MetadataPanel'));

--- a/packages/sdk/client-services/src/packlets/devtools/devtools.ts
+++ b/packages/sdk/client-services/src/packlets/devtools/devtools.ts
@@ -37,11 +37,13 @@ import {
   SubscribeToSwarmInfoResponse,
   StorageInfo,
   GetSnapshotsResponse,
+  SubscribeToMetadataResponse,
 } from '@dxos/protocols/proto/dxos/devtools/host';
 
 import { ServiceContext } from '../services';
 import { subscribeToFeedBlocks, subscribeToFeeds } from './feeds';
 import { subscribeToKeyringKeys } from './keys';
+import { subscribeToMetadata } from './metadata';
 import { subscribeToNetworkStatus, subscribeToSignal, subscribeToSwarmInfo } from './network';
 import { subscribeToSpaces } from './spaces';
 
@@ -160,5 +162,9 @@ export class DevtoolsServiceImpl implements DevtoolsHost {
 
   subscribeToSwarmInfo(): Stream<SubscribeToSwarmInfoResponse> {
     return subscribeToSwarmInfo({ networkManager: this.params.context.networkManager });
+  }
+
+  subscribeToMetadata(): Stream<SubscribeToMetadataResponse> {
+    return subscribeToMetadata({ context: this.params.context });
   }
 }

--- a/packages/sdk/client-services/src/packlets/devtools/metadata.ts
+++ b/packages/sdk/client-services/src/packlets/devtools/metadata.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Stream } from '@dxos/codec-protobuf';
+import { SubscribeToMetadataResponse } from '@dxos/protocols/proto/dxos/devtools/host';
+
+import { ServiceContext } from '../services';
+
+export const subscribeToMetadata = ({ context }: { context: ServiceContext }) =>
+  new Stream<SubscribeToMetadataResponse>(({ next, ctx }) => {
+    context.metadataStore.update.on(ctx, (data) => next({ metadata: data }));
+    next({ metadata: (context.metadataStore as any)._metadata });
+  });

--- a/packages/sdk/client-services/src/packlets/devtools/metadata.ts
+++ b/packages/sdk/client-services/src/packlets/devtools/metadata.ts
@@ -10,5 +10,5 @@ import { ServiceContext } from '../services';
 export const subscribeToMetadata = ({ context }: { context: ServiceContext }) =>
   new Stream<SubscribeToMetadataResponse>(({ next, ctx }) => {
     context.metadataStore.update.on(ctx, (data) => next({ metadata: data }));
-    next({ metadata: (context.metadataStore as any)._metadata });
+    next({ metadata: context.metadataStore.metadata });
   });

--- a/packages/sdk/client-services/src/packlets/services/service-context.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-context.ts
@@ -168,9 +168,8 @@ export class ServiceContext {
   private async _checkStorageVersion() {
     await this.metadataStore.load();
     if (this.metadataStore.version !== STORAGE_VERSION) {
-      log.error('Invalid storage version', { current: this.metadataStore.version, expected: STORAGE_VERSION });
+      throw new Error(`Invalid storage version: current=${this.metadataStore.version}, expected=${STORAGE_VERSION}`);
       // TODO(mykola): Migrate storage to a new version if incompatibility is detected.
-      await this.metadataStore.clear();
     }
   }
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b10913d</samp>

### Summary
🚫💥🔄

<!--
1.  🚫 - This emoji conveys the idea of stopping or blocking something, which is what throwing an error does. It also implies a negative or undesirable outcome, which is the case when the storage version is incompatible.
2.  💥 - This emoji conveys the idea of something exploding or breaking, which is what could happen to the data if the service context continues with an invalid state. It also implies a serious or critical issue, which is the case when the storage version is incompatible.
3.  🔄 - This emoji conveys the idea of something changing or updating, which is what needs to happen to the data if the storage version is incompatible. It also implies a process or action, which is the case when the data needs to be migrated or cleared.
-->
Throw an error when storage version is incompatible in `service-context.ts`. This prevents data corruption and enforces data consistency.

> _`storageVersion` mismatch_
> _throw error, stop the context_
> _autumn leaves falling_

### Walkthrough
*  Throw an error when the storage version is incompatible with the expected version ([link](https://github.com/dxos/dxos/pull/3503/files?diff=unified&w=0#diff-32609ec40439f8092b97c3e3d20956a8e6651e0c6f70c9989fef4ec774e26f3bL171-R172)). This prevents the service context from continuing with an invalid state and potentially corrupting the data. The storage version is defined in `service-context.ts` and should match the constant `STORAGE_VERSION`.


