### PR TITLE
fix: Increase on close delay

### DIFF
--- a/packages/sdk/client-protocol/src/invitations/invitations.ts
+++ b/packages/sdk/client-protocol/src/invitations/invitations.ts
@@ -12,7 +12,7 @@ export const AUTHENTICATION_CODE_LENGTH = 6;
 export const INVITATION_TIMEOUT = 3 * 60_000; // 3 mins.
 
 // TODO(burdon): Don't close until RPC has complete (bug).
-export const ON_CLOSE_DELAY = 1000;
+export const ON_CLOSE_DELAY = 3000;
 
 export interface Invitations {
   created: MulticastObservable<CancellableInvitationObservable[]>;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b31c12e</samp>

### Summary
🕒🐛🗣️

<!--
1.  🕒 This emoji represents a clock face showing three o'clock, and it can be used to indicate the increase of the delay from one to three seconds. It also suggests that this change is related to time and waiting.
2.  🐛 This emoji represents a bug, and it can be used to indicate that this change is a workaround for a bug that causes the RPC to fail. It also suggests that this change is not a permanent solution and that the bug needs to be fixed.
3.  🗣️ This emoji represents a speaking head, and it can be used to indicate that this change is related to an RPC, which is a form of communication between different processes or systems. It also suggests that this change affects the user interface and the dialog that shows the invitation.
-->
Increased the delay for closing invitation dialogs in `invitations.ts` to avoid RPC failures. This is a temporary fix for a bug in the client protocol.

> _`ON_CLOSE_DELAY`_
> _Longer wait for dialog_
> _Autumn of RPC_

### Walkthrough
* Increase the delay for closing invitation dialog after user action ([link](https://github.com/dxos/dxos/pull/3504/files?diff=unified&w=0#diff-d76401ad68eae1fb5293274f4e5c900281f274b64342ac16163b4224f7c2d926L15-R15)). This is a temporary workaround for a bug that causes the RPC to fail sometimes. The delay is defined by the constant `ON_CLOSE_DELAY` in `invitations.ts`.


