### PR TITLE
fix(composer-app): Call `setSpaceProvider` correctly

### DIFF
--- a/packages/apps/composer-app/src/plugins/SpacePlugin/SpacePlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/SpacePlugin/SpacePlugin.tsx
@@ -317,9 +317,15 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
     }
 
     const nodeHandle = createSubscription(() => {
-      const [id] = treeView.selected ?? [];
-      if (client.services instanceof IFrameClientServicesProxy || client.services instanceof IFrameClientServicesHost) {
-        client.services.setSpaceProvider(() => PublicKey.safeFrom(id));
+      const [prefixedId] = treeView.selected ?? [''];
+      if (prefixedId) {
+        const [_prefix, id] = prefixedId?.split('/');
+        if (
+          client.services instanceof IFrameClientServicesProxy ||
+          client.services instanceof IFrameClientServicesHost
+        ) {
+          client.services.setSpaceProvider(() => PublicKey.safeFrom(id));
+        }
       }
     });
     nodeHandle.update([treeView]);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f07387a</samp>

### Summary
🐛🔧🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change.
2.  🔧 - This emoji represents a tool or configuration change, which is what the split and check functions are doing to the prefixedId.
3.  🚀 - This emoji represents a performance improvement or a feature enhancement, which is the result of the space provider loading the space correctly.
-->
Fix space provider loading bug in `SpacePlugin`. Pass only node id instead of prefixedId to `setSpaceProvider` and handle empty case.

> _Split `prefixedId`_
> _Pass only id to space_
> _Avoid winter bugs_

### Walkthrough
* Fix bug where space provider fails to load space for selected node by passing only the id without the prefix to setSpaceProvider ([link](https://github.com/dxos/dxos/pull/3509/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L320-R328))
* Add check for prefixedId existence to avoid calling split on an empty string ([link](https://github.com/dxos/dxos/pull/3509/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L320-R328))


