### PR TITLE
feat(plugin-stack): Add anywhere, remove, drag and drop

### DIFF
--- a/packages/apps/plugins/plugin-stack/package.json
+++ b/packages/apps/plugins/plugin-stack/package.json
@@ -15,7 +15,8 @@
     "src"
   ],
   "dependencies": {
-    "@dxos/observable-object": "workspace:*"
+    "@dxos/observable-object": "workspace:*",
+    "lodash.get": "^4.4.2"
   },
   "devDependencies": {
     "@braneframe/plugin-markdown": "workspace:*",
@@ -23,6 +24,7 @@
     "@dxos/aurora-theme": "workspace:*",
     "@dxos/react-surface": "workspace:*",
     "@phosphor-icons/react": "^2.0.5",
+    "@types/lodash.get": "^4.4.7",
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",
     "react": "^18.2.0",

--- a/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
@@ -2,53 +2,137 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { Fragment, useEffect, useState } from 'react';
+import { CaretRight, Minus, Plus } from '@phosphor-icons/react';
+import get from 'lodash.get';
+import React, { useCallback, useEffect, useState } from 'react';
 
-import { Main, Input, List, Button, useTranslation, randomString } from '@dxos/aurora';
-import { defaultBlockSeparator, mx } from '@dxos/aurora-theme';
+import {
+  Main,
+  Input,
+  List,
+  ListItem,
+  Button,
+  useTranslation,
+  randomString,
+  DensityProvider,
+  DragEndEvent,
+} from '@dxos/aurora';
+import { defaultBlockSeparator, getSize, mx, surfaceElevation } from '@dxos/aurora-theme';
 import { subscribe } from '@dxos/observable-object';
 import { Surface } from '@dxos/react-surface';
 
 import { StackModel, StackProperties, StackSectionModel, StackSections } from '../props';
+import { arrayMoveInPlace } from '../util';
+
+type StackSectionProps = {
+  onAdd: () => void;
+  onRemove: () => void;
+  section: StackSectionModel;
+};
+
+const AddSection = ({ onClick }: { onClick: StackSectionProps['onAdd'] }) => {
+  const { t } = useTranslation('dxos:stack');
+  return (
+    <Button variant='ghost' onClick={onClick} classNames='plb-0 pli-0.5 -mlb-1'>
+      <span className='sr-only'>{t('add section label')}</span>
+      <Plus className={getSize(4)} />
+      <CaretRight className={getSize(3)} />
+    </Button>
+  );
+};
+
+const StackSection = ({ onAdd, onRemove, section }: StackSectionProps) => {
+  const { t } = useTranslation('dxos:stack');
+  return (
+    <DensityProvider density='fine'>
+      <AddSection onClick={onAdd} />
+      <ListItem.Root id={section.object.id} classNames='flex gap-2 items-start justify-start'>
+        <ListItem.Heading classNames='sr-only'>
+          {get(section, 'object.title', t('generic section heading'))}
+        </ListItem.Heading>
+        <div role='none' className='p-1 -m-1 self-stretch flex flex-col'>
+          <Button variant='ghost' classNames='p-0' onClick={onRemove}>
+            <span className='sr-only'>{t('remove section label')}</span>
+            <Minus className={getSize(4)} />
+          </Button>
+          <ListItem.DragHandle classNames='grow' />
+        </div>
+        <div
+          role='none'
+          className={mx(surfaceElevation({ elevation: 'group' }), 'bg-white dark:bg-neutral-925 grow rounded')}
+        >
+          <Surface role='section' data={section} />
+        </div>
+      </ListItem.Root>
+    </DensityProvider>
+  );
+};
 
 // todo(thure): `observer` causes infinite rerenders if used here.
 const StackMainImpl = ({ sections }: { sections: StackSections }) => {
-  const { t } = useTranslation('dxos:stack');
   const [_, setIter] = useState([]);
+
   useEffect(() => {
     // todo(thure): TypeScript seems to get the wrong return value from `ObservableArray.subscribe`
     return sections[subscribe](() => setIter([])) as () => void;
   }, []);
+
+  const handleAdd = useCallback(
+    (start: number) => {
+      const section: StackSectionModel = {
+        source: { resolver: 'dxos:markdown', guid: randomString() },
+        object: {
+          id: randomString(),
+          content: '',
+        },
+      };
+      sections.splice(start, 0, section);
+    },
+    [sections],
+  );
+
+  const handleRemove = useCallback(
+    (start: number) => {
+      sections.splice(start, 1);
+    },
+    [sections],
+  );
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    if (active.id !== over?.id) {
+      const oldIndex = sections.findIndex((section) => section.object.id === active.id);
+      const newIndex = sections.findIndex((section) => section.object.id === over?.id);
+      arrayMoveInPlace<StackSectionModel>(sections, oldIndex, newIndex);
+    }
+  }, []);
+
   return (
-    <article>
-      {sections
-        // todo(thure): This filter should be unnecessary; why is the first (or only?) value sometimes some sort of array-like object?
-        .filter((section) => 'source' in section)
-        .map((section, o) => {
-          return (
-            <Fragment key={section.source.guid}>
-              <Surface role='section' data={section} />
-            </Fragment>
-          );
-        })}
-      <div role='none' className='p-4'>
-        <Button
-          onClick={() => {
-            const section: StackSectionModel = {
-              source: { resolver: 'dxos:markdown', guid: randomString() },
-              object: {
-                id: randomString(),
-                content: '',
-                title: '',
-              },
-            };
-            sections.splice(sections.length, 0, section);
-          }}
-        >
-          {t('add section label')}
-        </Button>
+    <>
+      <List
+        variant='ordered-draggable'
+        onDragEnd={handleDragEnd}
+        listItemIds={sections.map(({ object: { id } }) => id)}
+        classNames='pis-1 pie-2'
+      >
+        {sections
+          // todo(thure): This filter should be unnecessary; why is the first (or only?) value sometimes some sort of array-like object?
+          .filter((section) => 'source' in section)
+          .map((section, start) => {
+            return (
+              <StackSection
+                key={section.object.id}
+                onAdd={() => handleAdd(start)}
+                onRemove={() => handleRemove(start)}
+                section={section}
+              />
+            );
+          })}
+      </List>
+      <div role='none' className='pis-1 pie-2'>
+        <AddSection onClick={() => handleAdd(sections.length)} />
       </div>
-    </article>
+    </>
   );
 };
 
@@ -59,7 +143,7 @@ export const StackMain = ({
 }) => {
   const { t } = useTranslation('dxos:stack');
   return (
-    <Main.Content classNames='min-bs-[100vh] mli-auto max-is-[60rem] bg-white dark:bg-neutral-925'>
+    <Main.Content classNames='min-bs-[100vh] mli-auto max-is-[60rem]'>
       <Input.Root>
         <Input.Label srOnly>{t('stack title label')}</Input.Label>
         <Input.TextInput
@@ -69,10 +153,8 @@ export const StackMain = ({
           onChange={({ target: { value } }) => (properties.title = value)}
         />
       </Input.Root>
-      <div role='separator' className={mx(defaultBlockSeparator, 'mli-3 opacity-50')} />
-      <List>
-        <StackMainImpl sections={stack.sections} />
-      </List>
+      <div role='separator' className={mx(defaultBlockSeparator, 'mli-3 mbe-2 opacity-50')} />
+      <StackMainImpl sections={stack.sections} />
     </Main.Content>
   );
 };

--- a/packages/apps/plugins/plugin-stack/src/props.ts
+++ b/packages/apps/plugins/plugin-stack/src/props.ts
@@ -4,23 +4,27 @@
 
 import { subscribe, ObservableArray } from '@dxos/observable-object';
 
-export type StackSections = ObservableArray<StackSectionModel>;
+export type StackSections = ObservableArray<StackSectionModel<any>>;
 
-export type StackSectionModel = {
+export type StackObject = { id: string };
+
+export type GenericStackObject = StackObject & { [key: string]: any };
+
+export type StackSectionModel<T extends StackObject = GenericStackObject> = {
   source: { resolver: string; guid: string };
-  object: unknown;
+  object: T;
 };
 
-export type StackModel = {
+export type StackModel<T extends StackObject = GenericStackObject> = {
   id: string;
-  sections: ObservableArray<StackSectionModel>;
+  sections: ObservableArray<StackSectionModel<T>>;
 };
 
 export type StackProperties = {
   title?: string;
 };
 
-export const isStack = (datum: unknown): datum is StackModel =>
+export const isStack = <T extends StackObject = GenericStackObject>(datum: unknown): datum is StackModel<T> =>
   datum && typeof datum === 'object'
     ? 'id' in datum &&
       typeof datum.id === 'string' &&

--- a/packages/apps/plugins/plugin-stack/src/util/arrayMoveInPlace.ts
+++ b/packages/apps/plugins/plugin-stack/src/util/arrayMoveInPlace.ts
@@ -1,0 +1,8 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+// todo(thure): This almost certainly should move upstream.
+export const arrayMoveInPlace = <T>(array: Array<T>, from: number, to: number) => {
+  return array.splice(to < 0 ? array.length + to : to, 0, array.splice(from, 1)[0]);
+};

--- a/packages/apps/plugins/plugin-stack/src/util/index.ts
+++ b/packages/apps/plugins/plugin-stack/src/util/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+export * from './arrayMoveInPlace';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -600,19 +600,23 @@ importers:
       '@dxos/observable-object': workspace:*
       '@dxos/react-surface': workspace:*
       '@phosphor-icons/react': ^2.0.5
+      '@types/lodash.get': ^4.4.7
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
+      lodash.get: ^4.4.2
       react: ^18.2.0
       react-dom: ^18.2.0
       vite: ^4.3.9
     dependencies:
       '@dxos/observable-object': link:../../../common/observable-object
+      lodash.get: 4.4.2
     devDependencies:
       '@braneframe/plugin-markdown': link:../plugin-markdown
       '@dxos/aurora': link:../../../ui/aurora
       '@dxos/aurora-theme': link:../../../ui/aurora-theme
       '@dxos/react-surface': link:../../../sdk/react-surface
       '@phosphor-icons/react': 2.0.5_biqbaboplfbrettd7655fr4n2y
+      '@types/lodash.get': 4.4.7
       '@types/react': 18.0.21
       '@types/react-dom': 18.0.6
       react: 18.2.0


### PR DESCRIPTION
One quirk/caveat is the items stretch when they hover over a differently-sized slot. [There is a solution](https://github.com/clauderic/dnd-kit/issues/117#issuecomment-789863258), though I’m not sure if it will have major caveats given how our system currently work. I'll investigate.

https://github.com/dxos/dxos/assets/855039/008755ef-c020-49ce-ae61-b0be4cc98b8d

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at df8b891</samp>

### Summary
📁🔄🧩

<!--
1.  📁 - This emoji represents the creation of new files and folders, such as `arrayMoveInPlace.ts` and `index.ts`.
2.  🔄 - This emoji represents the reordering and mutation of arrays, such as the `arrayMoveInPlace` function and the drag-and-drop feature.
3.  🧩 - This emoji represents the refactoring and modularization of components, such as the `StackSection` component and the generics.
-->
This pull request enhances the `plugin-stack` app by adding a custom `StackSection` component that supports drag-and-drop reordering and add/remove buttons. It also improves the type safety and flexibility of the stack sections data structures by using generics. Additionally, it adds some utility functions and dependencies to facilitate the implementation.

> _We're moving in place, we're changing the order_
> _We're dragging and dropping, we're crossing the border_
> _We're using generics, we're typing the sections_
> _We're stacking the objects, we're mutating the collections_

### Walkthrough
*  Refactor `StackMain` component to use `StackSection` component and enable adding, removing, and reordering sections ([link](https://github.com/dxos/dxos/pull/3532/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068L5-R135),[link](https://github.com/dxos/dxos/pull/3532/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068L62-R146),[link](https://github.com/dxos/dxos/pull/3532/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068L72-R157)).


