### PR TITLE
docs: watch command

### DIFF
--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -30,11 +30,19 @@ pnpm build
 
 > Don't forget to install and build when switching branches
 
-Run all unit tests
+Run all unit tests:
 
 ```
 pnpm test
 ```
+
+Recompile any package within the monorepo when changes are detected:
+
+```
+pnpm watch
+```
+
+> Run watch alongside a vite dev server to get monorepo-wide hot module reloading
 
 ## Run commands:
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "nx": "nx",
     "prepare": "husky install",
     "serve": "serve",
-    "test": "nx run-many --target=test"
+    "test": "nx run-many --target=test",
+    "watch": "./node_modules/.bin/nx watch --all -- pnpm -w nx compile \"\\$NX_PROJECT_NAME\""
   },
   "dependencies": {
     "@dxos/conform": "workspace:^0.1.0",


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2d8893e</samp>

### Summary
🆕📝🚀

<!--
1.  🆕 for adding a new script
2.  📝 for improving the documentation
3.  🚀 for enhancing the development experience
-->
This pull request adds a `watch` script to the `package.json` file that enables faster development of the dxos monorepo packages. It also updates the `REPOSITORY_GUIDE.md` file with documentation on how to use the script.

> _To speed up the dev of dxos_
> _A new script called `watch` was proposed_
> _It uses `nx` and `pnpm`_
> _To compile with `esbuild` then_
> _And the docs got a colon and some prose_

### Walkthrough
*  Add `watch` script to recompile packages on changes ([link](https://github.com/dxos/dxos/pull/3537/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L27-R28))
* Document how to use `watch` script in `REPOSITORY_GUIDE.md` ([link](https://github.com/dxos/dxos/pull/3537/files?diff=unified&w=0#diff-fe358a8c0cd3d8f92b63c85fc3faea1a8536ff9ae395d45e49f01317fcb76c45R39-R46))
* Fix punctuation in `REPOSITORY_GUIDE.md` ([link](https://github.com/dxos/dxos/pull/3537/files?diff=unified&w=0#diff-fe358a8c0cd3d8f92b63c85fc3faea1a8536ff9ae395d45e49f01317fcb76c45L33-R33))


