### PR TITLE
fix(feed-store): change hypercore types imports

### DIFF
--- a/docs/docs/specs/v0.2/qa.md
+++ b/docs/docs/specs/v0.2/qa.md
@@ -48,6 +48,7 @@ Use your normal, default profile in the browser, falling back to anonymous/guest
 - `npm init @dxos@next` (staging)
 - `pnpm install`
 - `pnpm serve`
+- `pnpm build`
 - observe that the app loads and presents the "click to login" button
 - login and use the counter, observe counter working between two windows
 

--- a/packages/apps/plugins/plugin-markdown/package.json
+++ b/packages/apps/plugins/plugin-markdown/package.json
@@ -34,7 +34,6 @@
     "@dxos/aurora": "workspace:*",
     "@dxos/aurora-theme": "workspace:*",
     "@dxos/react-surface": "workspace:*",
-    "@dxos/surface": "workspace:*",
     "@phosphor-icons/react": "^2.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/apps/plugins/plugin-stack/package.json
+++ b/packages/apps/plugins/plugin-stack/package.json
@@ -35,7 +35,6 @@
     "@dxos/aurora": "workspace:*",
     "@dxos/aurora-theme": "workspace:*",
     "@dxos/react-surface": "workspace:*",
-    "@dxos/surface": "workspace:*",
     "@phosphor-icons/react": "^2.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/apps/templates/bare-template/src/package.json.t.ts
+++ b/packages/apps/templates/bare-template/src/package.json.t.ts
@@ -80,7 +80,7 @@ export const base = ({ name, monorepo, version, depVersion }: Context): Partial<
     description: `${name}${monorepo ? '' : ' - a DXOS application'}`,
     private: true,
     scripts: {
-      build: 'NODE_OPTIONS="--max-old-space-size=4096" tsc --noEmit && vite build',
+      build: 'tsc --noEmit && NODE_OPTIONS="--max-old-space-size=4096" vite build',
       deploy: 'NODE_OPTIONS="--max-old-space-size=4096" dx app publish',
       preview: 'vite preview',
       serve: 'vite'

--- a/packages/apps/templates/bare-template/src/tsconfig.json.t.ts
+++ b/packages/apps/templates/bare-template/src/tsconfig.json.t.ts
@@ -18,6 +18,7 @@ export default defineTemplate<typeof config>(async ({ input, outputDirectory }) 
     emitDeclarationOnly: false,
     lib: ['DOM', 'ESNext'],
     outDir: 'dist',
+    skipLibCheck: true,
     types: ['node', ...(pwa ? ['vite-plugin-pwa/client'] : [])]
   };
 

--- a/packages/common/feed-store/package.json
+++ b/packages/common/feed-store/package.json
@@ -45,7 +45,6 @@
     "@dxos/benchmark-suite": "^1.0.0-beta.1",
     "@dxos/browser-runner": "^1.0.0-beta.13",
     "@dxos/keys": "workspace:*",
-    "@dxos/typings": "workspace:*",
     "@faker-js/faker": "^7.3.0",
     "@types/debug": "^4.1.7",
     "@types/faker": "^5.5.9"

--- a/packages/common/feed-store/src/feed-factory.ts
+++ b/packages/common/feed-store/src/feed-factory.ts
@@ -2,11 +2,11 @@
 // Copyright 2022 DXOS.org
 //
 
-import type { Hypercore, HypercoreOptions } from 'hypercore';
 import { RandomAccessStorageConstructor } from 'random-access-storage';
 
 import { sha256, Signer } from '@dxos/crypto';
 import { failUndefined } from '@dxos/debug';
+import type { Hypercore, HypercoreOptions } from '@dxos/hypercore';
 import { createCrypto, hypercore } from '@dxos/hypercore';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';

--- a/packages/common/feed-store/src/feed-queue.ts
+++ b/packages/common/feed-store/src/feed-queue.ts
@@ -2,13 +2,13 @@
 // Copyright 2022 DXOS.org
 //
 
-import type { ReadStreamOptions } from 'hypercore';
 import assert from 'node:assert';
 import { inspect } from 'node:util';
 import { Writable } from 'streamx';
 
 import { Event, latch, Trigger } from '@dxos/async';
 import { inspectObject } from '@dxos/debug';
+import type { ReadStreamOptions } from '@dxos/hypercore';
 import { log } from '@dxos/log';
 
 import { FeedWrapper } from './feed-wrapper';

--- a/packages/common/feed-store/src/feed-wrapper.ts
+++ b/packages/common/feed-store/src/feed-wrapper.ts
@@ -2,13 +2,13 @@
 // Copyright 2022 DXOS.org
 //
 
-import type { Hypercore, HypercoreProperties, ReadStreamOptions } from 'hypercore';
 import assert from 'node:assert';
 import { inspect } from 'node:util';
 import { Readable, Transform } from 'streamx';
 
 import { Trigger } from '@dxos/async';
 import { inspectObject, StackTrace } from '@dxos/debug';
+import type { Hypercore, HypercoreProperties, ReadStreamOptions } from '@dxos/hypercore';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { createBinder } from '@dxos/util';

--- a/packages/common/feed-store/tsconfig.json
+++ b/packages/common/feed-store/tsconfig.json
@@ -49,9 +49,6 @@
       "path": "../random-access-storage"
     },
     {
-      "path": "../typings"
-    },
-    {
       "path": "../util"
     }
   ]

--- a/packages/common/hypercore/package.json
+++ b/packages/common/hypercore/package.json
@@ -23,6 +23,7 @@
     "@dxos/keys": "workspace:*",
     "@dxos/node-std": "workspace:*",
     "@dxos/random-access-storage": "workspace:*",
+    "@dxos/typings": "workspace:*",
     "readable-stream": "^3.6.0",
     "sodium-native": "^3.2.0",
     "sodium-universal": "^3.0.2",

--- a/packages/common/hypercore/src/index.ts
+++ b/packages/common/hypercore/src/index.ts
@@ -3,6 +3,7 @@
 //
 
 export { default as hypercore } from 'hypercore';
+export type { Hypercore, HypercoreOptions, HypercoreProperties, ReadStreamOptions } from 'hypercore';
 
 export * from './crypto';
 export * from './defaults';

--- a/packages/common/hypercore/tsconfig.json
+++ b/packages/common/hypercore/tsconfig.json
@@ -36,6 +36,9 @@
       "path": "../random-access-storage"
     },
     {
+      "path": "../typings"
+    },
+    {
       "path": "../util"
     }
   ]

--- a/packages/sdk/react-surface/README.md
+++ b/packages/sdk/react-surface/README.md
@@ -1,11 +1,11 @@
-# @dxos/surface
+# @dxos/react-surface
 
 A react framework for making extensible interfaces.
 
 ## Installation
 
 ```bash
-pnpm i @dxos/surface
+pnpm i @dxos/react-surface
 ```
 
 ## Usage
@@ -13,7 +13,7 @@ pnpm i @dxos/surface
 Run with
 
 ```bash
-pnpm nx storybook surface
+pnpm nx storybook react-surface
 ```
 
 ## DXOS Resources

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1079,7 +1079,6 @@ importers:
       '@dxos/log': workspace:*
       '@dxos/node-std': workspace:*
       '@dxos/random-access-storage': workspace:*
-      '@dxos/typings': workspace:*
       '@dxos/util': workspace:*
       '@faker-js/faker': ^7.3.0
       '@types/debug': ^4.1.7
@@ -1107,7 +1106,6 @@ importers:
     devDependencies:
       '@dxos/benchmark-suite': 1.0.0-beta.3
       '@dxos/browser-runner': 1.0.0-beta.13
-      '@dxos/typings': link:../typings
       '@types/debug': 4.1.7
       '@types/faker': 5.5.9
 
@@ -1121,6 +1119,7 @@ importers:
       '@dxos/log': workspace:*
       '@dxos/node-std': workspace:*
       '@dxos/random-access-storage': workspace:*
+      '@dxos/typings': workspace:*
       '@dxos/util': workspace:*
       '@faker-js/faker': ^7.3.0
       '@types/debug': ^4.1.7
@@ -1144,6 +1143,7 @@ importers:
       '@dxos/keys': link:../keys
       '@dxos/node-std': link:../node-std
       '@dxos/random-access-storage': link:../random-access-storage
+      '@dxos/typings': link:../typings
       readable-stream: 3.6.0
       sodium-native: 3.4.1
       sodium-universal: 3.1.0


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a27564d</samp>

### Summary
📝🔧♻️

<!--
1.  📝 for adding a step to the documentation.
2.  🔧 for fixing the circular dependency issue and updating the imports and path mappings.
3.  ♻️ for simplifying the type imports and exports.
-->
This pull request simplifies and standardizes the type imports for the `feed-store` and `hypercore` packages. It removes unused and circular dependencies, and exports the types from the custom `@dxos/hypercore` fork. It also updates the documentation to include a build step.

> _We're building up the project with `pnpm build`_
> _We're fixing all the circular deps that we could_
> _We're switching to the fork of `hypercore`_
> _Heave away, me hearties, heave away on three_

### Walkthrough
*  Add build step to installation documentation ([link](https://github.com/dxos/dxos/pull/3538/files?diff=unified&w=0#diff-1bf1a23924cd5d6222402e728d4c083ec070be0802fb56b77370f881bd172adaR51))
*  Replace `hypercore` dependency with `@dxos/hypercore` fork in `feed-store` package ([link](https://github.com/dxos/dxos/pull/3538/files?diff=unified&w=0#diff-b61df366c52f452d49c6a479e47aef3c33a642e65c87da080208a5d330f79320L48), [link](https://github.com/dxos/dxos/pull/3538/files?diff=unified&w=0#diff-bfb339b43f46301885ddb880d1ae51608ec169343465aef336751501a4953758L5-R9), [link](https://github.com/dxos/dxos/pull/3538/files?diff=unified&w=0#diff-a8b9cf688aad506de3104c55cc8ff78bea1ac77de77007fe8d08f68e003e2facL5), [link](https://github.com/dxos/dxos/pull/3538/files?diff=unified&w=0#diff-a8b9cf688aad506de3104c55cc8ff78bea1ac77de77007fe8d08f68e003e2facR11), [link](https://github.com/dxos/dxos/pull/3538/files?diff=unified&w=0#diff-64fa5ed50276a5b9c275e0a0c5783bf20564f732925405ced87a10f9fd6dc8d5L5), [link](https://github.com/dxos/dxos/pull/3538/files?diff=unified&w=0#diff-64fa5ed50276a5b9c275e0a0c5783bf20564f732925405ced87a10f9fd6dc8d5R11), [link](https://github.com/dxos/dxos/pull/3538/files?diff=unified&w=0#diff-aac75b772c723cac7599dab6e12fb377efff5b29d329b5f3cd56448fd618f2f2L52-L54))
*  Export types and add `@dxos/typings` dependency in `hypercore` package ([link](https://github.com/dxos/dxos/pull/3538/files?diff=unified&w=0#diff-a3a2619a636984fdad5165222558a1cd8aa1d83ce3cf8a8fcde69919184f57c3R26), [link](https://github.com/dxos/dxos/pull/3538/files?diff=unified&w=0#diff-5b1ef372e93e2d3961870b6a36624613cc51eb42ee9cbcc6f9cdda86d7e0c249R6), [link](https://github.com/dxos/dxos/pull/3538/files?diff=unified&w=0#diff-0e208028b53f56bbfbdc2a07dee8cc281b301402671ffd96a8438fe97e8ea100R39-R41))


