### PR TITLE
fix(cli): Fix lock error on running agent

### DIFF
--- a/packages/devtools/cli/src/commands/agent/start.ts
+++ b/packages/devtools/cli/src/commands/agent/start.ts
@@ -2,6 +2,8 @@
 // Copyright 2023 DXOS.org
 //
 
+import chalk from 'chalk';
+
 import { BaseCommand } from '../../base-command';
 
 export default class Start extends BaseCommand<typeof Start> {
@@ -10,6 +12,10 @@ export default class Start extends BaseCommand<typeof Start> {
 
   async run(): Promise<any> {
     return await this.execWithDaemon(async (daemon) => {
+      const { flags } = await this.parse(Start);
+      if (await daemon.isRunning(flags.profile)) {
+        this.log(chalk`{red Warning}: ${flags.profile} is already running (Maybe run 'dx agent reset')`);
+      }
       await daemon.start(this.flags.profile);
       this.log('Agent started');
     });


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b45e880</samp>

### Summary
🛠️🎨🚫

<!--
1.  🛠️ - This emoji represents fixing or improving something, which is what the changes to the `ForeverDaemon` class did by making it more reliable and consistent.
2.  🎨 - This emoji represents adding or improving the aesthetics or style of something, which is what the changes to the output messages and the `chalk` module did by making them more colorful and informative.
3.  🚫 - This emoji represents preventing or stopping something, which is what the changes to the `start.ts` file did by adding a check for running agents and avoiding unnecessary or conflicting processes.
-->
Improved the `dx agent` functionality by using socket and lock files to detect running agents and by adding better output messages and checks. Refactored and simplified some code in `forever-daemon.ts` and `start.ts`.

> _We're the crew of the `ForeverDaemon`, we keep the agents running smooth_
> _We use the socket and the lock file, to avoid a nasty spoof_
> _We heave and haul on the code base, we trim the sails of fluff_
> _We add some `chalk` to our messages, to make them bright enough_

### Walkthrough
* Improve agent running detection and error handling by checking for socket and lock files in addition to process list ([link](https://github.com/dxos/dxos/pull/3554/files?diff=unified&w=0#diff-b5dbaf47a6ea38e7795329712ff61bc11c9476aa0260e772e6b456902fc32104L31-R36), [link](https://github.com/dxos/dxos/pull/3554/files?diff=unified&w=0#diff-b5dbaf47a6ea38e7795329712ff61bc11c9476aa0260e772e6b456902fc32104L55-L58), [link](https://github.com/dxos/dxos/pull/3554/files?diff=unified&w=0#diff-b5dbaf47a6ea38e7795329712ff61bc11c9476aa0260e772e6b456902fc32104L74))
* Colorize output messages for `start.ts` command using `chalk` module ([link](https://github.com/dxos/dxos/pull/3554/files?diff=unified&w=0#diff-6222175ce7615e14e17217b5e12fba644eb6f2ae31ca1db528cc6c57bedbb08cR5-R6))
* Warn user and suggest `dx agent reset` command if agent profile is already running before starting a new agent ([link](https://github.com/dxos/dxos/pull/3554/files?diff=unified&w=0#diff-6222175ce7615e14e17217b5e12fba644eb6f2ae31ca1db528cc6c57bedbb08cR15-R18))


