### PR TITLE
fix: Port conflict on test signaling

### DIFF
--- a/packages/core/echo/echo-db/project.json
+++ b/packages/core/echo/echo-db/project.json
@@ -44,14 +44,14 @@
       "options": {
         "coveragePath": "coverage/packages/core/echo/echo-db",
         "envVariables": {
-          "SIGNAL_PORT": 4000
+          "SIGNAL_PORT": 12000
         },
         "forceExit": true,
         "outputPath": "tmp/mocha/packages/core/echo/echo-db",
         "resultsPath": "test-results/packages/core/echo/echo-db",
         "setup": "packages/core/mesh/signal/testing/setup.js",
         "setupOptions": {
-          "port": 4000
+          "port": 12000
         },
         "testPatterns": [
           "packages/core/echo/echo-db/src/**/*.test.{ts,js}"

--- a/packages/core/echo/echo-pipeline/project.json
+++ b/packages/core/echo/echo-pipeline/project.json
@@ -44,14 +44,14 @@
       "options": {
         "coveragePath": "coverage/packages/core/echo/echo-pipeline",
         "envVariables": {
-          "SIGNAL_PORT": 4001
+          "SIGNAL_PORT": 12001
         },
         "forceExit": true,
         "outputPath": "tmp/mocha/packages/core/echo/echo-pipeline",
         "resultsPath": "test-results/packages/core/echo/echo-pipeline",
         "setup": "packages/core/mesh/signal/testing/setup.js",
         "setupOptions": {
-          "port": 4001
+          "port": 12001
         },
         "testPatterns": [
           "packages/core/echo/echo-pipeline/src/**/*.test.{ts,js}"

--- a/packages/core/mesh/network-manager/project.json
+++ b/packages/core/mesh/network-manager/project.json
@@ -49,14 +49,14 @@
         ],
         "coveragePath": "coverage/packages/core/mesh/network-manager",
         "envVariables": {
-          "SIGNAL_PORT": 4005
+          "SIGNAL_PORT": 12005
         },
         "forceExit": true,
         "outputPath": "tmp/mocha/packages/core/mesh/network-manager",
         "resultsPath": "test-results/packages/core/mesh/network-manager",
         "setup": "packages/core/mesh/signal/testing/setup.js",
         "setupOptions": {
-          "port": 4005
+          "port": 12005
         },
         "testPatterns": [
           "packages/core/mesh/network-manager/src/**/*.test.{ts,js}"

--- a/packages/gravity/gravity-agent/project.json
+++ b/packages/gravity/gravity-agent/project.json
@@ -48,13 +48,13 @@
           "nodejs"
         ],
         "envVariables": {
-          "SIGNAL_PORT": 4002
+          "SIGNAL_PORT": 12002
         },
         "outputPath": "tmp/mocha/packages/gravity/gravity-agent",
         "resultsPath": "test-results/packages/gravity/gravity-agent",
         "setup": "packages/core/mesh/signal/testing/setup.js",
         "setupOptions": {
-          "port": 4002
+          "port": 12002
         },
         "testPatterns": [
           "packages/gravity/gravity-agent/src/**/*.test.{ts,js}"

--- a/packages/sdk/client-services/project.json
+++ b/packages/sdk/client-services/project.json
@@ -50,14 +50,14 @@
         ],
         "coveragePath": "coverage/packages/sdk/client-services",
         "envVariables": {
-          "SIGNAL_PORT": 4004
+          "SIGNAL_PORT": 12004
         },
         "forceExit": true,
         "outputPath": "tmp/mocha/packages/sdk/client-services",
         "resultsPath": "test-results/packages/sdk/client-services",
         "setup": "packages/core/mesh/signal/testing/setup.js",
         "setupOptions": {
-          "port": 4004
+          "port": 12004
         },
         "testPatterns": [
           "packages/sdk/client-services/src/**/*.test.{ts,js}"

--- a/packages/sdk/client/project.json
+++ b/packages/sdk/client/project.json
@@ -52,14 +52,14 @@
       "options": {
         "coveragePath": "coverage/packages/sdk/client",
         "envVariables": {
-          "SIGNAL_PORT": 4003
+          "SIGNAL_PORT": 12003
         },
         "forceExit": true,
         "outputPath": "tmp/mocha/packages/sdk/client",
         "resultsPath": "test-results/packages/sdk/client",
         "setup": "packages/core/mesh/signal/testing/setup.js",
         "setupOptions": {
-          "port": 4003
+          "port": 12003
         },
         "testPatterns": [
           "packages/sdk/client/src/**/*.test.{ts,js}"


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 49e24f0</samp>

### Summary
🚧🧪📡

<!--
1.  🚧 - This emoji represents the port changes as a construction or maintenance work, indicating that the changes are meant to improve the stability and reliability of the system and avoid potential issues.
2.  🧪 - This emoji represents the testing aspect of the changes, indicating that the changes are meant to enable consistent and reliable testing across different packages and services.
3.  📡 - This emoji represents the signal server as a communication or networking component, indicating that the changes affect the way the different packages and services communicate with each other.
-->
Changed the port numbers for the `signal` servers in various packages from the 4000 range to the 12000 range. This reduces the risk of port conflicts with other services and enhances the testing environment.

> _`signal` ports change_
> _avoiding conflicts and bugs_
> _autumn of testing_

### Walkthrough
*  Change the `SIGNAL_PORT` environment variable and the `port` option for the `setup` script for six packages: `echo-db`, `echo-pipeline`, `network-manager`, `gravity-agent`, `client-services`, and `client`. This is to avoid port conflicts between different packages and services that use the `signal` package for testing and communication. ([link](https://github.com/dxos/dxos/pull/3557/files?diff=unified&w=0#diff-237baf4be6577c7b62d9a1fe382ce395a22cda405b29a20906db980ca3fc22a2L47-R47), [link](https://github.com/dxos/dxos/pull/3557/files?diff=unified&w=0#diff-237baf4be6577c7b62d9a1fe382ce395a22cda405b29a20906db980ca3fc22a2L54-R54), [link](https://github.com/dxos/dxos/pull/3557/files?diff=unified&w=0#diff-7490ef13395d29db588a2fa9fe0f1a789b3e4da63d5d82cffbb572bf5814a36eL47-R47), [link](https://github.com/dxos/dxos/pull/3557/files?diff=unified&w=0#diff-7490ef13395d29db588a2fa9fe0f1a789b3e4da63d5d82cffbb572bf5814a36eL54-R54), [link](https://github.com/dxos/dxos/pull/3557/files?diff=unified&w=0#diff-b256ee83f6070edb3bbd304b931160ac891fd725fea05f8805e382201bbc8e03L52-R52), [link](https://github.com/dxos/dxos/pull/3557/files?diff=unified&w=0#diff-b256ee83f6070edb3bbd304b931160ac891fd725fea05f8805e382201bbc8e03L59-R59), [link](https://github.com/dxos/dxos/pull/3557/files?diff=unified&w=0#diff-cc1b660c31b10865007501d62692d053e9f19d36fc09eb5fd13ef40cf7f2e1a2L51-R51), [link](https://github.com/dxos/dxos/pull/3557/files?diff=unified&w=0#diff-cc1b660c31b10865007501d62692d053e9f19d36fc09eb5fd13ef40cf7f2e1a2L57-R57), [link](https://github.com/dxos/dxos/pull/3557/files?diff=unified&w=0#diff-45c4f6a81e917f28b1f6b996a19771b551e8c4f1d3261b9858fbc075b6eb4ebeL53-R53), [link](https://github.com/dxos/dxos/pull/3557/files?diff=unified&w=0#diff-45c4f6a81e917f28b1f6b996a19771b551e8c4f1d3261b9858fbc075b6eb4ebeL60-R60), [link](https://github.com/dxos/dxos/pull/3557/files?diff=unified&w=0#diff-cdf74a31fa6134276fed5c33455cd477d209a04b049d7265d7a9415ba5928110L55-R55), [link](https://github.com/dxos/dxos/pull/3557/files?diff=unified&w=0#diff-cdf74a31fa6134276fed5c33455cd477d209a04b049d7265d7a9415ba5928110L62-R62))


