### PR TITLE
chore: Change default storage path

### DIFF
--- a/packages/devtools/cli/config/config-default.yml
+++ b/packages/devtools/cli/config/config-default.yml
@@ -4,7 +4,6 @@ runtime:
   client:
     storage:
       persistent: true
-      path: /tmp/dx/run/profile
 
   services:
     ipfs:

--- a/packages/devtools/cli/src/base-command.ts
+++ b/packages/devtools/cli/src/base-command.ts
@@ -212,9 +212,15 @@ export abstract class BaseCommand<T extends typeof Command = any> extends Comman
       );
 
       const yamlConfig = yaml.load(await readFile(defaultConfigPath, 'utf-8')) as ConfigProto;
-      if (yamlConfig.runtime?.client?.storage?.path) {
+      {
         // Isolate DX_PROFILE storages.
-        yamlConfig.runtime.client.storage.path = join(yamlConfig.runtime.client.storage.path, this.flags.profile);
+        yamlConfig.runtime ??= {};
+        yamlConfig.runtime.client ??= {};
+        yamlConfig.runtime.client.storage ??= {};
+        yamlConfig.runtime.client.storage.path = join(
+          yamlConfig.runtime.client.storage.path ?? DX_DATA,
+          this.flags.profile,
+        );
       }
 
       await mkdir(dirname(configFile), { recursive: true });

--- a/packages/sdk/client-protocol/src/config.ts
+++ b/packages/sdk/client-protocol/src/config.ts
@@ -17,7 +17,7 @@ export const EXPECTED_CONFIG_VERSION = 1;
 export const defaultConfig: ConfigProto = { version: 1 };
 
 // TODO(burdon): Allow override via env? Generalize since currently NodeJS only.
-const HOME = typeof process !== 'undefined' ? process?.env?.HOME : '';
+const HOME = typeof process !== 'undefined' ? process?.env?.HOME ?? '' : '';
 
 // Base directories.
 // TODO(burdon): Consider Windows, Linux, OSX.

--- a/packages/sdk/client-services/src/packlets/storage/storage.ts
+++ b/packages/sdk/client-services/src/packlets/storage/storage.ts
@@ -13,12 +13,7 @@ import StorageDriver = Runtime.Client.Storage.StorageDriver;
 
 // TODO(burdon): Factor out.
 export const createStorageObjects = (config: Runtime.Client.Storage) => {
-  const {
-    path = DX_DATA, // TODO(burdon): Factor out const.
-    storageType,
-    keyStorage,
-    persistent = false,
-  } = config ?? {};
+  const { path = DX_DATA, storageType, keyStorage, persistent = false } = config ?? {};
 
   if (persistent && storageType === StorageDriver.RAM) {
     throw new InvalidConfigError('RAM storage cannot be used in persistent mode.');

--- a/packages/sdk/client-services/src/packlets/storage/storage.ts
+++ b/packages/sdk/client-services/src/packlets/storage/storage.ts
@@ -4,6 +4,7 @@
 // Copyright 2023 DXOS.org
 //
 
+import { DX_DATA } from '@dxos/client-protocol';
 import { InvalidConfigError } from '@dxos/errors';
 import { Runtime } from '@dxos/protocols/proto/dxos/config';
 import { createStorage, StorageType } from '@dxos/random-access-storage';
@@ -13,7 +14,7 @@ import StorageDriver = Runtime.Client.Storage.StorageDriver;
 // TODO(burdon): Factor out.
 export const createStorageObjects = (config: Runtime.Client.Storage) => {
   const {
-    path = 'dxos/storage', // TODO(burdon): Factor out const.
+    path = DX_DATA, // TODO(burdon): Factor out const.
     storageType,
     keyStorage,
     persistent = false,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d72059e</samp>

### Summary
:wrench::sparkles::recycle:

<!--
1.  :wrench: - This emoji represents the removal of the default path from the config file, as this is a configuration-related change that affects how the tool is set up and customized by the user.
2.  :sparkles: - This emoji represents the modification of the logic for setting the client storage path in the base command class, as this is a feature-related change that enhances the functionality and usability of the tool by allowing the user to specify different profiles and fallback to a sensible default value.
3.  :recycle: - This emoji represents the refactoring of the storage module to use a constant for the storage path, as this is a code quality-related change that improves the maintainability and readability of the code by avoiding duplication and magic strings.
-->
Refactor client storage path to use a constant and a profile flag. Remove hardcoded strings and redundant config values from `storage.ts`, `config-default.yml`, and `base-command.ts`.

> _Sing, O Muse, of the cunning code review_
> _That changed the client storage path with skill_
> _And made it follow the profile flag's cue_
> _And the DX_DATA constant, firm and still._

### Walkthrough
* Remove the default client storage path from the config file, as it is now dynamically determined by the profile flag and the DX_DATA constant ([link](https://github.com/dxos/dxos/pull/3559/files?diff=unified&w=0#diff-955d158a005d3278bc3d54e81366813b8ac0949e9e0fc0cac34da8fa623f3c1cL7)).


