### PR TITLE
feat: abbreviate space keys

### DIFF
--- a/packages/apps/composer-app/src/plugins/SpacePlugin/SpacePlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/SpacePlugin/SpacePlugin.tsx
@@ -74,7 +74,7 @@ const objectsToGraphNodes = (parent: GraphNode<Space>, objects: TypedObject[]): 
 // TODO(wittjosiah): Specify and factor out fully qualified names + utils (e.g., subpaths, uris, etc).
 const getSpaceId = (spaceKey: PublicKeyLike) => {
   if (spaceKey instanceof PublicKey) {
-    spaceKey = spaceKey.toHex();
+    spaceKey = spaceKey.truncate();
   }
 
   return `${SpacePlugin.meta.id}/${spaceKey}`;

--- a/packages/apps/composer-app/src/plugins/SpacePlugin/SpacePlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/SpacePlugin/SpacePlugin.tsx
@@ -18,7 +18,7 @@ import {
 } from '@phosphor-icons/react';
 
 import { ClientPluginProvides } from '@braneframe/plugin-client';
-import { GraphNode, GraphProvides } from '@braneframe/plugin-graph';
+import { GraphNode, GraphPluginProvides, GraphProvides } from '@braneframe/plugin-graph';
 import { SplitViewProvides } from '@braneframe/plugin-splitview';
 import { TranslationsProvides } from '@braneframe/plugin-theme';
 import { TreeViewProvides } from '@braneframe/plugin-treeview';
@@ -93,6 +93,7 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
   ready: async (plugins) => {
     const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos:ClientPlugin');
     const treeViewPlugin = findPlugin<TreeViewProvides>(plugins, 'dxos:TreeViewPlugin');
+    const graphPlugin = findPlugin<GraphPluginProvides>(plugins, 'dxos:GraphPlugin');
     const splitViewPlugin = findPlugin<SplitViewProvides>(plugins, 'dxos:SplitViewPlugin');
     if (!clientPlugin) {
       return;
@@ -252,15 +253,14 @@ export const SpacePlugin = definePlugin<SpacePluginProvides>({
     }
 
     const nodeHandle = createSubscription(() => {
-      const [prefixedId] = treeView.selected ?? [''];
-      if (prefixedId) {
-        const [_prefix, id] = prefixedId?.split('/');
-        if (
-          client.services instanceof IFrameClientServicesProxy ||
-          client.services instanceof IFrameClientServicesHost
-        ) {
-          client.services.setSpaceProvider(() => PublicKey.safeFrom(id));
-        }
+      const space: Space = graphPlugin?.provides.graph.roots[SpacePlugin.meta.id]?.find(
+        (node) => node.id === treeView.selected[0],
+      )?.data;
+      if (
+        space &&
+        (client.services instanceof IFrameClientServicesProxy || client.services instanceof IFrameClientServicesHost)
+      ) {
+        client.services.setSpaceProvider(() => space.key);
       }
     });
     nodeHandle.update([treeView]);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a153938</samp>

### Summary
🐛🔗✂️

<!--
1.  🐛 - This emoji represents the bug that was fixed by the change. It is a common way to indicate a bug fix or a problem that was solved in a codebase.
2.  🔗 - This emoji represents the URL feature that was the context of the change. It is a common way to indicate a link, a reference, or a connection between different parts of a codebase or a system.
3.  ✂️ - This emoji represents the truncation operation that was performed on the space key. It is a common way to indicate a cut, a removal, or a shortening of something in a codebase or a system.
-->
Fixed a bug in the `SpacePlugin` that caused the space ID to be too long for the URL format. Changed the `getSpaceId` function to use `truncate` instead of `toHex` on the `spaceKey`.

> _`spaceKey` truncated_
> _URLs can now be shared_
> _Autumn bug is fixed_

### Walkthrough
*  Fixed space ID bug by truncating space key instead of converting to hex ([link](https://github.com/dxos/dxos/pull/3561/files?diff=unified&w=0#diff-4c3644e83729f7f016855b3a60b8f477967bcabac0650be106ffd0e7657ec163L77-R77))


