### PR TITLE
refactor(react-surface): make plugins closures

### DIFF
--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -26,16 +26,16 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <PluginContextProvider
       plugins={[
-        ThemePlugin,
-        ClientPlugin,
-        GraphPlugin,
-        TreeViewPlugin,
-        UrlSyncPlugin,
-        SplitViewPlugin,
-        SpacePlugin,
-        MarkdownPlugin,
-        GithubPlugin,
-        LocalFilesPlugin,
+        ThemePlugin(),
+        ClientPlugin(),
+        GraphPlugin(),
+        TreeViewPlugin(),
+        UrlSyncPlugin(),
+        SplitViewPlugin(),
+        SpacePlugin(),
+        MarkdownPlugin(),
+        GithubPlugin(),
+        LocalFilesPlugin(),
       ]}
     />
   </StrictMode>,

--- a/packages/apps/composer-app/src/plugins/GithubPlugin/GithubPlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/GithubPlugin/GithubPlugin.tsx
@@ -6,7 +6,8 @@
 import React from 'react';
 
 import { isMarkdown, isMarkdownProperties } from '@braneframe/plugin-markdown';
-import { definePlugin, PluginDefinition } from '@dxos/react-surface';
+import { TranslationsProvides } from '@braneframe/plugin-theme';
+import { PluginDefinition } from '@dxos/react-surface';
 
 import {
   MarkdownActions,
@@ -19,7 +20,7 @@ import {
 } from './components';
 import translations from './translations';
 
-export const GithubPlugin: PluginDefinition = definePlugin({
+export const GithubPlugin = (): PluginDefinition<TranslationsProvides> => ({
   meta: {
     id: 'dxos:github',
   },

--- a/packages/apps/composer-app/src/plugins/GithubPlugin/components/MarkdownActions.tsx
+++ b/packages/apps/composer-app/src/plugins/GithubPlugin/components/MarkdownActions.tsx
@@ -5,7 +5,7 @@ import { ArrowSquareOut, FileArrowDown, FileArrowUp, Link, LinkBreak } from '@ph
 import React, { RefObject, useCallback } from 'react';
 
 import { MarkdownProperties } from '@braneframe/plugin-markdown';
-import { useSplitViewContext } from '@braneframe/plugin-splitview';
+import { useSplitView } from '@braneframe/plugin-splitview';
 import { DropdownMenu, useTranslation } from '@dxos/aurora';
 import { ComposerModel, MarkdownComposerRef } from '@dxos/aurora-composer';
 import { getSize } from '@dxos/aurora-theme';
@@ -23,7 +23,7 @@ export const MarkdownActions = ({
   const ghId = properties.meta?.keys?.find((key) => key.source === 'com.github')?.id;
   const { octokit } = useOctokitContext();
   const { t } = useTranslation('dxos:github');
-  const splitView = useSplitViewContext();
+  const splitView = useSplitView();
 
   const docGhId = useDocGhId(properties.meta?.keys ?? []);
 

--- a/packages/apps/composer-app/src/plugins/LocalFilesPlugin/LocalFilesPlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/LocalFilesPlugin/LocalFilesPlugin.tsx
@@ -10,26 +10,17 @@ import { MarkdownProvides } from '@braneframe/plugin-markdown';
 import { TranslationsProvides } from '@braneframe/plugin-theme';
 import { TreeViewProvides } from '@braneframe/plugin-treeview';
 import { createStore, createSubscription } from '@dxos/observable-object';
-import { definePlugin, findPlugin } from '@dxos/react-surface';
+import { findPlugin, PluginDefinition } from '@dxos/react-surface';
 
 import { LocalFileMain, LocalFileMainPermissions } from './components';
 import translations from './translations';
+
+export const LOCAL_FILES_PLUGIN = 'dxos:local';
 
 export type LocalFile = {
   handle?: FileSystemFileHandle | FileSystemDirectoryHandle;
   title: string;
   text?: string;
-};
-
-const nodes = createStore<GraphNode<LocalFile>[]>([]);
-const store = createStore<{ current: GraphNode<LocalFile> | undefined }>();
-
-const handleKeyDown = async (event: KeyboardEvent) => {
-  const modifier = event.ctrlKey || event.metaKey;
-  if (event.key === 's' && modifier && store.current) {
-    event.preventDefault();
-    await handleSave(store.current);
-  }
 };
 
 const handleSave = async (node: GraphNode<LocalFile>) => {
@@ -57,354 +48,366 @@ const handleLegacySave = (node: GraphNode<LocalFile>) => {
   document.body.removeChild(a);
 };
 
-export type LocalFilesPluginProvides = GraphProvides & TranslationsProvides;
-
 const isLocalFile = (datum: unknown): datum is LocalFile =>
   datum && typeof datum === 'object' ? 'title' in datum : false;
 
-export const LocalFilesPlugin = definePlugin<LocalFilesPluginProvides, MarkdownProvides>({
-  meta: {
-    id: 'dxos:local',
-  },
-  init: async () => {
-    return {
-      markdown: {
-        onChange: (text) => {
-          if (store.current) {
-            store.current.data!.text = text.toString();
-            store.current.attributes = { ...store.current.attributes, modified: true };
-          }
-        },
+export type LocalFilesPluginProvides = GraphProvides & TranslationsProvides;
+
+export const LocalFilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, MarkdownProvides> => {
+  const nodes = createStore<GraphNode<LocalFile>[]>([]);
+  const store = createStore<{ current: GraphNode<LocalFile> | undefined }>();
+
+  const handleKeyDown = async (event: KeyboardEvent) => {
+    const modifier = event.ctrlKey || event.metaKey;
+    if (event.key === 's' && modifier && store.current) {
+      event.preventDefault();
+      await handleSave(store.current);
+    }
+  };
+
+  const handleDirectory = async (handle: any /* FileSystemDirectoryHandle */) => {
+    const node = createStore<GraphNode<LocalFile>>({
+      id: `${LOCAL_FILES_PLUGIN}/${handle.name.replaceAll(/\.| /g, '-')}`,
+      label: handle.name,
+      data: {
+        handle,
+        title: handle.name,
+      },
+    });
+
+    const closeAction: GraphNodeAction = {
+      id: 'close-directory',
+      label: ['close directory label', { ns: LOCAL_FILES_PLUGIN }],
+      icon: X,
+      invoke: async () => {
+        const index = nodes.indexOf(node);
+        nodes.splice(index, 1);
       },
     };
-  },
-  ready: async (plugins) => {
-    window.addEventListener('keydown', handleKeyDown);
 
-    const value = await localforage.getItem<FileSystemHandle[]>(LocalFilesPlugin.meta.id);
-    if (Array.isArray(value)) {
-      await Promise.all(
-        value.map(async (handle) => {
-          if (handle.kind === 'file') {
-            const node = await handleFile(handle);
-            nodes.unshift(node);
-          } else if (handle.kind === 'directory') {
-            const node = await handleDirectory(handle);
-            nodes.push(node);
+    const grantedActions = [closeAction];
+
+    const defaultActions: GraphNodeAction[] = [
+      {
+        id: 're-open',
+        label: ['re-open directory label', { ns: LOCAL_FILES_PLUGIN }],
+        icon: Plugs,
+        invoke: async () => {
+          const result = await handle.requestPermission({ mode: 'readwrite' });
+          if (result === 'granted' && node.actions) {
+            node.actions = grantedActions;
+            node.attributes = {};
+            node.children = await handleDirectoryChildren(handle, node);
           }
-        }),
-      );
+        },
+      },
+      closeAction,
+    ];
+
+    const permission = await handle.queryPermission({ mode: 'readwrite' });
+    if (permission === 'granted') {
+      node.actions = grantedActions;
+      node.attributes = {};
+      node.children = await handleDirectoryChildren(handle, node);
+    } else {
+      node.actions = defaultActions;
+      node.attributes = { disabled: true };
+      node.children = [];
     }
 
-    const handle = createSubscription(async () => {
-      await localforage.setItem(
-        LocalFilesPlugin.meta.id,
-        Array.from(nodes)
-          .map((node) => node.data?.handle)
-          .filter(Boolean),
-      );
-    });
-    handle.update([nodes]);
+    return node;
+  };
 
-    const treeViewPlugin = findPlugin<TreeViewProvides>(plugins, 'dxos:TreeViewPlugin');
-    if (treeViewPlugin) {
-      const handle = createSubscription(() => {
-        store.current =
-          (treeViewPlugin.provides.treeView.selected[0]?.startsWith(LocalFilesPlugin.meta.id) &&
-            findGraphNode(nodes, treeViewPlugin.provides.treeView.selected)) ||
-          undefined;
-      });
-      handle.update([treeViewPlugin.provides.treeView, nodes, ...Array.from(nodes)]);
-    }
-  },
-  unload: async () => {
-    window.removeEventListener('keydown', handleKeyDown);
-  },
-  provides: {
-    translations,
-    component: (datum, role) => {
-      switch (role) {
-        case 'main':
-          if (isGraphNode(datum) && isLocalFile(datum.data) && datum.attributes?.disabled) {
-            return LocalFileMainPermissions;
-          }
-          break;
+  const handleDirectoryChildren = async (handle: any /* FileSystemDirectoryHandle */, parent: GraphNode<LocalFile>) => {
+    const children: GraphNode<LocalFile>[] = [];
+
+    for await (const child of handle.values()) {
+      if (child.kind !== 'file' || !child.name.endsWith('.md')) {
+        continue;
       }
 
-      return null;
-    },
-    components: {
-      Main: LocalFileMain,
-    },
-    graph: {
-      nodes: () => nodes,
-      actions: (plugins) => {
-        const treeViewPlugin = findPlugin<TreeViewProvides>(plugins, 'dxos:TreeViewPlugin');
-
-        const actions: GraphNodeAction[] = [
+      const file = await child.getFile();
+      const node = createStore<GraphNode<LocalFile>>({
+        id: child.name.replaceAll(/\.| /g, '-'),
+        label: child.name,
+        icon: FileIcon,
+        parent,
+        data: {
+          handle: child,
+          title: child.name,
+          text: await file.text(),
+        },
+        actions: [
           {
-            id: 'open-file-handle',
-            label: ['open file label', { ns: LocalFilesPlugin.meta.id }],
-            icon: FilePlus,
+            id: 'save',
+            label: ['save label', { ns: LOCAL_FILES_PLUGIN }],
+            icon: FloppyDisk,
             invoke: async () => {
-              if ('showOpenFilePicker' in window) {
-                const [handle]: FileSystemFileHandle[] = await (window as any).showOpenFilePicker({
-                  mode: 'readwrite',
-                  types: [
-                    {
-                      description: 'Markdown',
-                      accept: { 'text/markdown': ['.md'] },
-                    },
-                  ],
-                });
-                const node = await handleFile(handle);
-                nodes.unshift(node);
-                if (treeViewPlugin) {
-                  treeViewPlugin.provides.treeView.selected = [node.id];
-                }
-
-                return;
-              }
-
-              const input = document.createElement('input');
-              input.type = 'file';
-              input.accept = '.md,text/markdown';
-              input.onchange = async () => {
-                const [file] = input.files ? Array.from(input.files) : [];
-                if (file) {
-                  const node = await handleLegacyFile(file);
-                  nodes.unshift(node);
-                  if (treeViewPlugin) {
-                    treeViewPlugin.provides.treeView.selected = [node.id];
-                  }
-                }
-              };
-              input.click();
+              await handleSave(node);
             },
           },
-        ];
-
-        if ('showDirectoryPicker' in window) {
-          actions.push({
-            id: 'open-directory',
-            label: ['open directory label', { ns: LocalFilesPlugin.meta.id }],
-            icon: FolderPlus,
-            invoke: async () => {
-              const handle = await (window as any).showDirectoryPicker({ mode: 'readwrite' });
-              const node = await handleDirectory(handle);
-              nodes.push(node);
-              if (treeViewPlugin) {
-                treeViewPlugin.provides.treeView.selected = [node.id, node.children![0]?.id];
-              }
-            },
-          });
-        }
-
-        return actions;
-      },
-    },
-  },
-});
-
-const handleDirectory = async (handle: any /* FileSystemDirectoryHandle */) => {
-  const node = createStore<GraphNode<LocalFile>>({
-    id: `${LocalFilesPlugin.meta.id}/${handle.name.replaceAll(/\.| /g, '-')}`,
-    label: handle.name,
-    data: {
-      handle,
-      title: handle.name,
-    },
-  });
-
-  const closeAction: GraphNodeAction = {
-    id: 'close-directory',
-    label: ['close directory label', { ns: LocalFilesPlugin.meta.id }],
-    icon: X,
-    invoke: async () => {
-      const index = nodes.indexOf(node);
-      nodes.splice(index, 1);
-    },
-  };
-
-  const grantedActions = [closeAction];
-
-  const defaultActions: GraphNodeAction[] = [
-    {
-      id: 're-open',
-      label: ['re-open directory label', { ns: LocalFilesPlugin.meta.id }],
-      icon: Plugs,
-      invoke: async () => {
-        const result = await handle.requestPermission({ mode: 'readwrite' });
-        if (result === 'granted' && node.actions) {
-          node.actions = grantedActions;
-          node.attributes = {};
-          node.children = await handleDirectoryChildren(handle, node);
-        }
-      },
-    },
-    closeAction,
-  ];
-
-  const permission = await handle.queryPermission({ mode: 'readwrite' });
-  if (permission === 'granted') {
-    node.actions = grantedActions;
-    node.attributes = {};
-    node.children = await handleDirectoryChildren(handle, node);
-  } else {
-    node.actions = defaultActions;
-    node.attributes = { disabled: true };
-    node.children = [];
-  }
-
-  return node;
-};
-
-const handleDirectoryChildren = async (handle: any /* FileSystemDirectoryHandle */, parent: GraphNode<LocalFile>) => {
-  const children: GraphNode<LocalFile>[] = [];
-
-  for await (const child of handle.values()) {
-    if (child.kind !== 'file' || !child.name.endsWith('.md')) {
-      continue;
+        ],
+      });
+      children.push(node);
     }
 
-    const file = await child.getFile();
+    return children;
+  };
+
+  const handleFile = async (handle: any /* FileSystemFileHandle */) => {
+    const id = `${LOCAL_FILES_PLUGIN}/${handle.name.replaceAll(/\.| /g, '-')}`;
+
+    const permission = await handle.queryPermission({ mode: 'readwrite' });
+    const data: LocalFile = {
+      handle,
+      title: handle.name,
+    };
+
     const node = createStore<GraphNode<LocalFile>>({
-      id: child.name.replaceAll(/\.| /g, '-'),
-      label: child.name,
+      id,
+      label: handle.name,
       icon: FileIcon,
-      parent,
-      data: {
-        handle: child,
-        title: child.name,
-        text: await file.text(),
-      },
-      actions: [
-        {
-          id: 'save',
-          label: ['save label', { ns: LocalFilesPlugin.meta.id }],
-          icon: FloppyDisk,
-          invoke: async () => {
-            await handleSave(node);
-          },
-        },
-      ],
+      data,
     });
-    children.push(node);
-  }
 
-  return children;
-};
-
-const handleFile = async (handle: any /* FileSystemFileHandle */) => {
-  const id = `${LocalFilesPlugin.meta.id}/${handle.name.replaceAll(/\.| /g, '-')}`;
-
-  const permission = await handle.queryPermission({ mode: 'readwrite' });
-  const data: LocalFile = {
-    handle,
-    title: handle.name,
-  };
-
-  const node = createStore<GraphNode<LocalFile>>({
-    id,
-    label: handle.name,
-    icon: FileIcon,
-    data,
-  });
-
-  const closeAction: GraphNodeAction = {
-    id: 'close-directory',
-    label: ['close file label', { ns: LocalFilesPlugin.meta.id }],
-    icon: X,
-    invoke: async () => {
-      const index = nodes.indexOf(node);
-      nodes.splice(index, 1);
-    },
-  };
-
-  const grantedActions: GraphNodeAction[] = [
-    {
-      id: 'save',
-      label: ['save label', { ns: LocalFilesPlugin.meta.id }],
-      icon: FloppyDisk,
+    const closeAction: GraphNodeAction = {
+      id: 'close-directory',
+      label: ['close file label', { ns: LOCAL_FILES_PLUGIN }],
+      icon: X,
       invoke: async () => {
-        await handleSave(node);
+        const index = nodes.indexOf(node);
+        nodes.splice(index, 1);
       },
-    },
-    closeAction,
-  ];
+    };
 
-  const defaultActions: GraphNodeAction[] = [
-    {
-      id: 're-open',
-      label: ['re-open file label', { ns: LocalFilesPlugin.meta.id }],
-      icon: Plugs,
-      invoke: async () => {
-        const result = await handle.requestPermission({ mode: 'readwrite' });
-        if (result === 'granted' && node.actions) {
-          const file = await handle.getFile();
-          node.data = { ...node.data!, text: await file.text() };
-          node.actions = grantedActions;
-          node.attributes = {};
-          node.children = undefined;
-        }
-      },
-    },
-    closeAction,
-  ];
-
-  if (permission === 'granted') {
-    const file = await handle.getFile();
-    node.data = { ...node.data!, text: await file.text() };
-    node.actions = grantedActions;
-    node.attributes = {};
-  } else {
-    node.actions = defaultActions;
-    node.attributes = { disabled: true };
-    node.children = [];
-  }
-
-  return node;
-};
-
-const handleLegacyFile = async (file: File) => {
-  const id = `${LocalFilesPlugin.meta.id}/${file.name.replaceAll(/\.| /g, '-')}`;
-  const text = await new Promise<string>((resolve) => {
-    const reader = new FileReader();
-    reader.addEventListener('loadend', (event) => {
-      const text = event.target?.result;
-      resolve(String(text));
-    });
-    reader.readAsText(file);
-  });
-
-  const node = createStore<GraphNode<LocalFile>>({
-    id,
-    label: file.name,
-    icon: FileIcon,
-    data: {
-      title: file.name,
-      text,
-    },
-    actions: [
+    const grantedActions: GraphNodeAction[] = [
       {
-        id: 'save-as',
-        label: ['save as label', { ns: LocalFilesPlugin.meta.id }],
+        id: 'save',
+        label: ['save label', { ns: LOCAL_FILES_PLUGIN }],
         icon: FloppyDisk,
         invoke: async () => {
           await handleSave(node);
         },
       },
+      closeAction,
+    ];
+
+    const defaultActions: GraphNodeAction[] = [
       {
-        id: 'close-directory',
-        label: ['close file label', { ns: LocalFilesPlugin.meta.id }],
-        icon: X,
+        id: 're-open',
+        label: ['re-open file label', { ns: LOCAL_FILES_PLUGIN }],
+        icon: Plugs,
         invoke: async () => {
-          const index = nodes.indexOf(node);
-          nodes.splice(index, 1);
+          const result = await handle.requestPermission({ mode: 'readwrite' });
+          if (result === 'granted' && node.actions) {
+            const file = await handle.getFile();
+            node.data = { ...node.data!, text: await file.text() };
+            node.actions = grantedActions;
+            node.attributes = {};
+            node.children = undefined;
+          }
         },
       },
-    ],
-  });
+      closeAction,
+    ];
 
-  return node;
+    if (permission === 'granted') {
+      const file = await handle.getFile();
+      node.data = { ...node.data!, text: await file.text() };
+      node.actions = grantedActions;
+      node.attributes = {};
+    } else {
+      node.actions = defaultActions;
+      node.attributes = { disabled: true };
+      node.children = [];
+    }
+
+    return node;
+  };
+
+  const handleLegacyFile = async (file: File) => {
+    const id = `${LOCAL_FILES_PLUGIN}/${file.name.replaceAll(/\.| /g, '-')}`;
+    const text = await new Promise<string>((resolve) => {
+      const reader = new FileReader();
+      reader.addEventListener('loadend', (event) => {
+        const text = event.target?.result;
+        resolve(String(text));
+      });
+      reader.readAsText(file);
+    });
+
+    const node = createStore<GraphNode<LocalFile>>({
+      id,
+      label: file.name,
+      icon: FileIcon,
+      data: {
+        title: file.name,
+        text,
+      },
+      actions: [
+        {
+          id: 'save-as',
+          label: ['save as label', { ns: LOCAL_FILES_PLUGIN }],
+          icon: FloppyDisk,
+          invoke: async () => {
+            await handleSave(node);
+          },
+        },
+        {
+          id: 'close-directory',
+          label: ['close file label', { ns: LOCAL_FILES_PLUGIN }],
+          icon: X,
+          invoke: async () => {
+            const index = nodes.indexOf(node);
+            nodes.splice(index, 1);
+          },
+        },
+      ],
+    });
+
+    return node;
+  };
+  return {
+    meta: {
+      id: LOCAL_FILES_PLUGIN,
+    },
+    init: async () => {
+      return {
+        markdown: {
+          onChange: (text) => {
+            if (store.current) {
+              store.current.data!.text = text.toString();
+              store.current.attributes = { ...store.current.attributes, modified: true };
+            }
+          },
+        },
+      };
+    },
+    ready: async (plugins) => {
+      window.addEventListener('keydown', handleKeyDown);
+
+      const value = await localforage.getItem<FileSystemHandle[]>(LOCAL_FILES_PLUGIN);
+      if (Array.isArray(value)) {
+        await Promise.all(
+          value.map(async (handle) => {
+            if (handle.kind === 'file') {
+              const node = await handleFile(handle);
+              nodes.unshift(node);
+            } else if (handle.kind === 'directory') {
+              const node = await handleDirectory(handle);
+              nodes.push(node);
+            }
+          }),
+        );
+      }
+
+      const handle = createSubscription(async () => {
+        await localforage.setItem(
+          LOCAL_FILES_PLUGIN,
+          Array.from(nodes)
+            .map((node) => node.data?.handle)
+            .filter(Boolean),
+        );
+      });
+      handle.update([nodes]);
+
+      const treeViewPlugin = findPlugin<TreeViewProvides>(plugins, 'dxos:TreeViewPlugin');
+      if (treeViewPlugin) {
+        const handle = createSubscription(() => {
+          store.current =
+            (treeViewPlugin.provides.treeView.selected[0]?.startsWith(LOCAL_FILES_PLUGIN) &&
+              findGraphNode(nodes, treeViewPlugin.provides.treeView.selected)) ||
+            undefined;
+        });
+        handle.update([treeViewPlugin.provides.treeView, nodes, ...Array.from(nodes)]);
+      }
+    },
+    unload: async () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    },
+    provides: {
+      translations,
+      component: (datum, role) => {
+        switch (role) {
+          case 'main':
+            if (isGraphNode(datum) && isLocalFile(datum.data) && datum.attributes?.disabled) {
+              return LocalFileMainPermissions;
+            }
+            break;
+        }
+
+        return null;
+      },
+      components: {
+        Main: LocalFileMain,
+      },
+      graph: {
+        nodes: () => nodes,
+        actions: (plugins) => {
+          const treeViewPlugin = findPlugin<TreeViewProvides>(plugins, 'dxos:TreeViewPlugin');
+
+          const actions: GraphNodeAction[] = [
+            {
+              id: 'open-file-handle',
+              label: ['open file label', { ns: LOCAL_FILES_PLUGIN }],
+              icon: FilePlus,
+              invoke: async () => {
+                if ('showOpenFilePicker' in window) {
+                  const [handle]: FileSystemFileHandle[] = await (window as any).showOpenFilePicker({
+                    mode: 'readwrite',
+                    types: [
+                      {
+                        description: 'Markdown',
+                        accept: { 'text/markdown': ['.md'] },
+                      },
+                    ],
+                  });
+                  const node = await handleFile(handle);
+                  nodes.unshift(node);
+                  if (treeViewPlugin) {
+                    treeViewPlugin.provides.treeView.selected = [node.id];
+                  }
+
+                  return;
+                }
+
+                const input = document.createElement('input');
+                input.type = 'file';
+                input.accept = '.md,text/markdown';
+                input.onchange = async () => {
+                  const [file] = input.files ? Array.from(input.files) : [];
+                  if (file) {
+                    const node = await handleLegacyFile(file);
+                    nodes.unshift(node);
+                    if (treeViewPlugin) {
+                      treeViewPlugin.provides.treeView.selected = [node.id];
+                    }
+                  }
+                };
+                input.click();
+              },
+            },
+          ];
+
+          if ('showDirectoryPicker' in window) {
+            actions.push({
+              id: 'open-directory',
+              label: ['open directory label', { ns: LOCAL_FILES_PLUGIN }],
+              icon: FolderPlus,
+              invoke: async () => {
+                const handle = await (window as any).showDirectoryPicker({ mode: 'readwrite' });
+                const node = await handleDirectory(handle);
+                nodes.push(node);
+                if (treeViewPlugin) {
+                  treeViewPlugin.provides.treeView.selected = [node.id, node.children![0]?.id];
+                }
+              },
+            });
+          }
+
+          return actions;
+        },
+      },
+    },
+  };
 };

--- a/packages/apps/composer-app/src/plugins/LocalFilesPlugin/components/LocalFileMainPermissions.tsx
+++ b/packages/apps/composer-app/src/plugins/LocalFilesPlugin/components/LocalFileMainPermissions.tsx
@@ -8,10 +8,10 @@ import { GraphNode } from '@braneframe/plugin-graph';
 import { Button, useTranslation } from '@dxos/aurora';
 import { defaultDescription, mx } from '@dxos/aurora-theme';
 
-import { LocalFile, LocalFilesPlugin } from '../LocalFilesPlugin';
+import { LOCAL_FILES_PLUGIN, LocalFile } from '../LocalFilesPlugin';
 
 export const LocalFileMainPermissions = ({ data }: { data: GraphNode<LocalFile> }) => {
-  const { t } = useTranslation(LocalFilesPlugin.meta.id);
+  const { t } = useTranslation(LOCAL_FILES_PLUGIN);
   const action = data.actions?.find(({ id }) => id === 're-open');
   return (
     <div role='none' className='min-bs-screen is-full flex items-center justify-center p-8'>

--- a/packages/apps/composer-app/src/plugins/SpacePlugin/SpacePlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/SpacePlugin/SpacePlugin.tsx
@@ -18,7 +18,7 @@ import {
 } from '@phosphor-icons/react';
 
 import { ClientPluginProvides } from '@braneframe/plugin-client';
-import { GraphNode, GraphPluginProvides, GraphProvides } from '@braneframe/plugin-graph';
+import { GraphNode, GraphProvides, GraphPluginProvides, isGraphNode } from '@braneframe/plugin-graph';
 import { SplitViewProvides } from '@braneframe/plugin-splitview';
 import { TranslationsProvides } from '@braneframe/plugin-theme';
 import { TreeViewProvides } from '@braneframe/plugin-treeview';
@@ -36,14 +36,14 @@ import {
   SpaceState,
   TypedObject,
 } from '@dxos/react-client';
-import { definePlugin, findPlugin } from '@dxos/react-surface';
+import { PluginDefinition, findPlugin } from '@dxos/react-surface';
 
 import { backupSpace } from './backup';
 import { DialogRenameSpace, DialogRestoreSpace, EmptySpace, EmptyTree, SpaceMain, SpaceMainEmpty } from './components';
 import { getSpaceDisplayName } from './getSpaceDisplayName';
 import translations from './translations';
 
-export type SpacePluginProvides = GraphProvides & TranslationsProvides;
+const SPACE_PLUGIN = 'dxos:space';
 
 export const isSpace = (datum: unknown): datum is Space =>
   datum && typeof datum === 'object'
@@ -77,280 +77,284 @@ const getSpaceId = (spaceKey: PublicKeyLike) => {
     spaceKey = spaceKey.truncate();
   }
 
-  return `${SpacePlugin.meta.id}/${spaceKey}`;
+  return `${SPACE_PLUGIN}/${spaceKey}`;
 };
 
-const nodes = createStore<GraphNode<Space>[]>([]);
-const rootNodes = new Map<string, GraphNode<Space>>();
-const nodeAttributes = new Map<string, { [key: string]: any }>();
-const rootObjects = new Map<string, GraphNode[]>();
-const subscriptions = new EventSubscriptions();
+export type SpacePluginProvides = GraphProvides & TranslationsProvides;
 
-export const SpacePlugin = definePlugin<SpacePluginProvides>({
-  meta: {
-    id: 'dxos:space',
-  },
-  ready: async (plugins) => {
-    const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos:ClientPlugin');
-    const treeViewPlugin = findPlugin<TreeViewProvides>(plugins, 'dxos:TreeViewPlugin');
-    const graphPlugin = findPlugin<GraphPluginProvides>(plugins, 'dxos:GraphPlugin');
-    const splitViewPlugin = findPlugin<SplitViewProvides>(plugins, 'dxos:SplitViewPlugin');
-    if (!clientPlugin) {
-      return;
-    }
+export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
+  const nodes = createStore<GraphNode<Space>[]>([]);
+  const rootNodes = new Map<string, GraphNode<Space>>();
+  const nodeAttributes = new Map<string, { [key: string]: any }>();
+  const rootObjects = new Map<string, GraphNode[]>();
+  const subscriptions = new EventSubscriptions();
 
-    const client = clientPlugin.provides.client;
-    const identity = client.halo.identity.get();
-    const subscription = client.spaces.subscribe((spaces) => {
-      nodes.splice(
-        0,
-        nodes.length,
-        ...spaces.map((space) => {
-          const id = getSpaceId(space.key);
-          let node = rootNodes.get(id);
-          if (node) {
-            node.label = getSpaceDisplayName(space);
-            node.description = space.properties.description;
-          } else {
-            node = createStore<GraphNode<Space>>({
-              id,
-              label: getSpaceDisplayName(space),
-              description: space.properties.description,
-              icon: Planet,
-              data: space,
-              actions: [
-                {
-                  id: 'create-doc',
-                  testId: 'spacePlugin.createDocument',
-                  label: ['create document label', { ns: 'composer' }],
-                  icon: Plus,
-                  invoke: async () => {
-                    const document = space.db.add(new Document());
-                    if (treeViewPlugin) {
-                      treeViewPlugin.provides.treeView.selected = [id, document.id];
-                    }
-                  },
-                },
-                {
-                  id: 'rename-space',
-                  label: ['rename space label', { ns: 'composer' }],
-                  icon: PencilSimpleLine,
-                  invoke: async () => {
-                    if (splitViewPlugin?.provides.splitView) {
-                      splitViewPlugin.provides.splitView.dialogOpen = true;
-                      splitViewPlugin.provides.splitView.dialogContent = ['dxos:space/RenameSpaceDialog', space];
-                    }
-                  },
-                },
-                {
-                  id: 'view-invitations',
-                  label: ['view invitations label', { ns: 'composer' }],
-                  icon: PaperPlane,
-                  invoke: async () => {
-                    await clientPlugin.provides.setLayout(ShellLayout.SPACE_INVITATIONS, { spaceKey: space.key });
-                  },
-                },
-                {
-                  id: 'hide-space',
-                  label: ['hide space label', { ns: 'composer' }],
-                  icon: EyeSlash,
-                  invoke: async () => {
-                    if (identity) {
-                      const identityHex = identity.identityKey.toHex();
-                      space.properties.members = {
-                        ...space.properties.members,
-                        [identityHex]: {
-                          ...space.properties.members?.[identityHex],
-                          hidden: true,
-                        },
-                      };
-                      if (treeViewPlugin?.provides.treeView.selected[0] === id) {
-                        treeViewPlugin.provides.treeView.selected = [];
-                      }
-                    }
-                  },
-                },
-                {
-                  id: 'backup-space',
-                  label: ['download all docs in space label', { ns: 'composer' }],
-                  icon: Download,
-                  invoke: async (t) => {
-                    const backupBlob = await backupSpace(space, t('untitled document title'));
-                    const url = URL.createObjectURL(backupBlob);
-                    const element = document.createElement('a');
-                    element.setAttribute('href', url);
-                    element.setAttribute('download', `${node!.label} backup.zip`);
-                    element.setAttribute('target', 'download');
-                    element.click();
-                  },
-                },
-                {
-                  id: 'restore-space',
-                  label: ['upload all docs in space label', { ns: 'composer' }],
-                  icon: Upload,
-                  invoke: async () => {
-                    if (splitViewPlugin?.provides.splitView) {
-                      splitViewPlugin.provides.splitView.dialogOpen = true;
-                      splitViewPlugin.provides.splitView.dialogContent = ['dxos:space/RestoreSpaceDialog', space];
-                    }
-                  },
-                },
-              ],
-            });
-            rootNodes.set(id, node);
-          }
-
-          let attributes = nodeAttributes.get(id);
-          if (!attributes) {
-            attributes = createStore<{ hidden: boolean }>();
-            const handle = createSubscription(() => {
-              if (!identity) {
-                return;
-              }
-              attributes!.hidden = space.properties.members?.[identity.identityKey.toHex()]?.hidden === true;
-              node!.label = getSpaceDisplayName(space);
-              node!.description = space.properties.description;
-            });
-            handle.update([space.properties]);
-            subscriptions.add(handle.unsubscribe);
-          }
-          attributes.disabled = space.state.get() !== SpaceState.READY;
-          attributes.error = space.state.get() === SpaceState.ERROR;
-          node.attributes = attributes ?? {};
-
-          let children = rootObjects.get(id);
-          if (!children) {
-            const query = space.db.query(Document.filter());
-            const objects = createStore(objectsToGraphNodes(node, query.objects));
-            subscriptions.add(
-              query.subscribe((query) => {
-                objects.splice(0, objects.length, ...objectsToGraphNodes(node!, query.objects));
-              }),
-            );
-
-            children = objects;
-            rootObjects.set(id, children);
-          }
-          node.children = children ?? [];
-
-          return node;
-        }),
-      );
-    });
-
-    subscriptions.add(subscription.unsubscribe);
-
-    if (!treeViewPlugin) {
-      return;
-    }
-
-    const treeView = treeViewPlugin.provides.treeView;
-
-    if (client.services instanceof IFrameClientServicesProxy || client.services instanceof IFrameClientServicesHost) {
-      client.services.joinedSpace.on((spaceKey) => {
-        treeView.selected = [getSpaceId(spaceKey)];
-      });
-    }
-
-    const nodeHandle = createSubscription(() => {
-      const space: Space = graphPlugin?.provides.graph.roots[SpacePlugin.meta.id]?.find(
-        (node) => node.id === treeView.selected[0],
-      )?.data;
-      if (
-        space &&
-        (client.services instanceof IFrameClientServicesProxy || client.services instanceof IFrameClientServicesHost)
-      ) {
-        client.services.setSpaceProvider(() => space.key);
+  return {
+    meta: {
+      id: SPACE_PLUGIN,
+    },
+    ready: async (plugins) => {
+      const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos:ClientPlugin');
+      const treeViewPlugin = findPlugin<TreeViewProvides>(plugins, 'dxos:TreeViewPlugin');
+      const graphPlugin = findPlugin<GraphPluginProvides>(plugins, 'dxos:GraphPlugin');
+      const splitViewPlugin = findPlugin<SplitViewProvides>(plugins, 'dxos:SplitViewPlugin');
+      if (!clientPlugin) {
+        return;
       }
-    });
-    nodeHandle.update([treeView]);
-    subscriptions.add(nodeHandle.unsubscribe);
-  },
-  unload: async () => {
-    subscriptions.clear();
-  },
-  provides: {
-    translations,
-    component: (datum, role) => {
-      switch (role) {
-        case 'main':
-          switch (true) {
-            case isSpace(datum):
-              return SpaceMainEmpty;
-            default:
-              return null;
-          }
-        case 'tree--empty':
-          switch (true) {
-            case datum === SpacePlugin.meta.id:
-              return EmptyTree;
-            case isSpace(datum?.data):
-              return EmptySpace;
-            default:
-              return null;
-          }
-        case 'dialog':
-          if (Array.isArray(datum)) {
-            switch (datum[0]) {
-              case 'dxos:space/RenameSpaceDialog':
-                return DialogRenameSpace;
-              case 'dxos:space/RestoreSpaceDialog':
-                return DialogRestoreSpace;
+
+      const client = clientPlugin.provides.client;
+      const identity = client.halo.identity.get();
+      const subscription = client.spaces.subscribe((spaces) => {
+        nodes.splice(
+          0,
+          nodes.length,
+          ...spaces.map((space) => {
+            const id = getSpaceId(space.key);
+            let node = rootNodes.get(id);
+            if (node) {
+              node.label = getSpaceDisplayName(space);
+              node.description = space.properties.description;
+            } else {
+              node = createStore<GraphNode<Space>>({
+                id,
+                label: getSpaceDisplayName(space),
+                description: space.properties.description,
+                icon: Planet,
+                data: space,
+                actions: [
+                  {
+                    id: 'create-doc',
+                    testId: 'spacePlugin.createDocument',
+                    label: ['create document label', { ns: 'composer' }],
+                    icon: Plus,
+                    invoke: async () => {
+                      const document = space.db.add(new Document());
+                      if (treeViewPlugin) {
+                        treeViewPlugin.provides.treeView.selected = [id, document.id];
+                      }
+                    },
+                  },
+                  {
+                    id: 'rename-space',
+                    label: ['rename space label', { ns: 'composer' }],
+                    icon: PencilSimpleLine,
+                    invoke: async () => {
+                      if (splitViewPlugin?.provides.splitView) {
+                        splitViewPlugin.provides.splitView.dialogOpen = true;
+                        splitViewPlugin.provides.splitView.dialogContent = ['dxos:space/RenameSpaceDialog', space];
+                      }
+                    },
+                  },
+                  {
+                    id: 'view-invitations',
+                    label: ['view invitations label', { ns: 'composer' }],
+                    icon: PaperPlane,
+                    invoke: async () => {
+                      await clientPlugin.provides.setLayout(ShellLayout.SPACE_INVITATIONS, { spaceKey: space.key });
+                    },
+                  },
+                  {
+                    id: 'hide-space',
+                    label: ['hide space label', { ns: 'composer' }],
+                    icon: EyeSlash,
+                    invoke: async () => {
+                      if (identity) {
+                        const identityHex = identity.identityKey.toHex();
+                        space.properties.members = {
+                          ...space.properties.members,
+                          [identityHex]: {
+                            ...space.properties.members?.[identityHex],
+                            hidden: true,
+                          },
+                        };
+                        if (treeViewPlugin?.provides.treeView.selected[0] === id) {
+                          treeViewPlugin.provides.treeView.selected = [];
+                        }
+                      }
+                    },
+                  },
+                  {
+                    id: 'backup-space',
+                    label: ['download all docs in space label', { ns: 'composer' }],
+                    icon: Download,
+                    invoke: async (t) => {
+                      const backupBlob = await backupSpace(space, t('untitled document title'));
+                      const url = URL.createObjectURL(backupBlob);
+                      const element = document.createElement('a');
+                      element.setAttribute('href', url);
+                      element.setAttribute('download', `${node!.label} backup.zip`);
+                      element.setAttribute('target', 'download');
+                      element.click();
+                    },
+                  },
+                  {
+                    id: 'restore-space',
+                    label: ['upload all docs in space label', { ns: 'composer' }],
+                    icon: Upload,
+                    invoke: async () => {
+                      if (splitViewPlugin?.provides.splitView) {
+                        splitViewPlugin.provides.splitView.dialogOpen = true;
+                        splitViewPlugin.provides.splitView.dialogContent = ['dxos:space/RestoreSpaceDialog', space];
+                      }
+                    },
+                  },
+                ],
+              });
+              rootNodes.set(id, node);
+            }
+
+            let attributes = nodeAttributes.get(id);
+            if (!attributes) {
+              attributes = createStore<{ hidden: boolean }>();
+              const handle = createSubscription(() => {
+                if (!identity) {
+                  return;
+                }
+                attributes!.hidden = space.properties.members?.[identity.identityKey.toHex()]?.hidden === true;
+                node!.label = getSpaceDisplayName(space);
+                node!.description = space.properties.description;
+              });
+              handle.update([space.properties]);
+              subscriptions.add(handle.unsubscribe);
+            }
+            attributes.disabled = space.state.get() !== SpaceState.READY;
+            attributes.error = space.state.get() === SpaceState.ERROR;
+            node.attributes = attributes ?? {};
+
+            let children = rootObjects.get(id);
+            if (!children) {
+              const query = space.db.query(Document.filter());
+              const objects = createStore(objectsToGraphNodes(node, query.objects));
+              subscriptions.add(
+                query.subscribe((query) => {
+                  objects.splice(0, objects.length, ...objectsToGraphNodes(node!, query.objects));
+                }),
+              );
+
+              children = objects;
+              rootObjects.set(id, children);
+            }
+            node.children = children ?? [];
+
+            return node;
+          }),
+        );
+      });
+
+      subscriptions.add(subscription.unsubscribe);
+
+      if (!treeViewPlugin) {
+        return;
+      }
+
+      const treeView = treeViewPlugin.provides.treeView;
+
+      if (client.services instanceof IFrameClientServicesProxy || client.services instanceof IFrameClientServicesHost) {
+        client.services.joinedSpace.on((spaceKey) => {
+          treeView.selected = [getSpaceId(spaceKey)];
+        });
+      }
+
+      const nodeHandle = createSubscription(() => {
+        const space: Space = graphPlugin?.provides.graph.roots[SPACE_PLUGIN]?.find(
+          (node) => node.id === treeView.selected[0],
+        )?.data;
+        if (
+          space &&
+          (client.services instanceof IFrameClientServicesProxy || client.services instanceof IFrameClientServicesHost)
+        ) {
+          client.services.setSpaceProvider(() => space.key);
+        }
+      });
+      nodeHandle.update([treeView]);
+      subscriptions.add(nodeHandle.unsubscribe);
+    },
+    unload: async () => {
+      subscriptions.clear();
+    },
+    provides: {
+      translations,
+      component: (datum, role) => {
+        switch (role) {
+          case 'main':
+            switch (true) {
+              case isSpace(datum):
+                return SpaceMainEmpty;
               default:
                 return null;
             }
-          } else {
-            return null;
-          }
-        default:
-          return null;
-      }
-    },
-    components: {
-      Main: SpaceMain,
-    },
-    graph: {
-      nodes: () => nodes,
-      actions: (plugins) => {
-        const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos:ClientPlugin');
-        const splitViewPlugin = findPlugin<SplitViewProvides>(plugins, 'dxos:SplitViewPlugin');
-        if (!clientPlugin) {
-          return [];
-        }
-
-        // TODO(wittjosiah): Disable if no identity.
-        return [
-          {
-            id: 'create-space',
-            testId: 'spacePlugin.createSpace',
-            label: ['create space label', { ns: 'os' }],
-            icon: Planet,
-            invoke: async () => {
-              await clientPlugin.provides.client.createSpace();
-            },
-          },
-          {
-            id: 'join-space',
-            testId: 'spacePlugin.joinSpace',
-            label: ['join space label', { ns: 'os' }],
-            icon: Intersect,
-            invoke: async () => {
-              await clientPlugin.provides.setLayout(ShellLayout.JOIN_SPACE);
-            },
-          },
-          {
-            // TODO(wittjosiah): Move to SplitViewPlugin.
-            id: 'close-sidebar',
-            label: ['close sidebar label', { ns: 'os' }],
-            icon: ArrowLineLeft,
-            invoke: async () => {
-              if (splitViewPlugin?.provides.splitView) {
-                splitViewPlugin.provides.splitView.sidebarOpen = false;
+          case 'tree--empty':
+            switch (true) {
+              case datum === SPACE_PLUGIN:
+                return EmptyTree;
+              case isGraphNode(datum) && isSpace(datum?.data):
+                return EmptySpace;
+              default:
+                return null;
+            }
+          case 'dialog':
+            if (Array.isArray(datum)) {
+              switch (datum[0]) {
+                case 'dxos:space/RenameSpaceDialog':
+                  return DialogRenameSpace;
+                case 'dxos:space/RestoreSpaceDialog':
+                  return DialogRestoreSpace;
+                default:
+                  return null;
               }
+            } else {
+              return null;
+            }
+          default:
+            return null;
+        }
+      },
+      components: {
+        Main: SpaceMain,
+      },
+      graph: {
+        nodes: () => nodes,
+        actions: (plugins) => {
+          const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos:ClientPlugin');
+          const splitViewPlugin = findPlugin<SplitViewProvides>(plugins, 'dxos:SplitViewPlugin');
+          if (!clientPlugin) {
+            return [];
+          }
+
+          // TODO(wittjosiah): Disable if no identity.
+          return [
+            {
+              id: 'create-space',
+              testId: 'spacePlugin.createSpace',
+              label: ['create space label', { ns: 'os' }],
+              icon: Planet,
+              invoke: async () => {
+                await clientPlugin.provides.client.createSpace();
+              },
             },
-          },
-        ];
+            {
+              id: 'join-space',
+              testId: 'spacePlugin.joinSpace',
+              label: ['join space label', { ns: 'os' }],
+              icon: Intersect,
+              invoke: async () => {
+                await clientPlugin.provides.setLayout(ShellLayout.JOIN_SPACE);
+              },
+            },
+            {
+              // TODO(wittjosiah): Move to SplitViewPlugin.
+              id: 'close-sidebar',
+              label: ['close sidebar label', { ns: 'os' }],
+              icon: ArrowLineLeft,
+              invoke: async () => {
+                if (splitViewPlugin?.provides.splitView) {
+                  splitViewPlugin.provides.splitView.sidebarOpen = false;
+                }
+              },
+            },
+          ];
+        },
       },
     },
-  },
-});
+  };
+};

--- a/packages/apps/composer-app/src/plugins/SpacePlugin/components/DialogRestoreSpace.tsx
+++ b/packages/apps/composer-app/src/plugins/SpacePlugin/components/DialogRestoreSpace.tsx
@@ -6,7 +6,7 @@ import { FilePlus } from '@phosphor-icons/react';
 import React from 'react';
 import { FileUploader } from 'react-drag-drop-files';
 
-import { useSplitViewContext } from '@braneframe/plugin-splitview';
+import { useSplitView } from '@braneframe/plugin-splitview';
 import { Button, Dialog, useTranslation } from '@dxos/aurora';
 import { getSize } from '@dxos/aurora-theme';
 import { Space } from '@dxos/client';
@@ -15,7 +15,7 @@ import { restoreSpace } from '../backup';
 
 export const DialogRestoreSpace = ({ data: [_, space] }: { data: [string, Space] }) => {
   const { t } = useTranslation('composer');
-  const splitViewContext = useSplitViewContext();
+  const splitViewContext = useSplitView();
   return (
     <>
       <Dialog.Title>{t('confirm restore title')}</Dialog.Title>

--- a/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
+++ b/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
@@ -8,54 +8,59 @@ import { Config, Defaults, Envs, Local } from '@dxos/config';
 import {
   Client,
   ClientContext,
+  ClientOptions,
   IFrameClientServicesHost,
   IFrameClientServicesProxy,
   ShellController,
   SystemStatus,
 } from '@dxos/react-client';
-import { definePlugin } from '@dxos/react-surface';
+import { PluginDefinition } from '@dxos/react-surface';
 
 export type ClientPluginProvides = {
   client: Client;
   setLayout: ShellController['setLayout'];
 };
 
-const client = new Client({ config: new Config(Envs(), Local(), Defaults()) });
+export const ClientPlugin = (
+  options: ClientOptions = { config: new Config(Envs(), Local(), Defaults()) },
+): PluginDefinition<{}, ClientPluginProvides> => {
+  const client = new Client(options);
 
-export const ClientPlugin = definePlugin<{}, ClientPluginProvides>({
-  meta: {
-    id: 'dxos:ClientPlugin',
-  },
-  init: async () => {
-    await client.initialize();
+  return {
+    meta: {
+      id: 'dxos:ClientPlugin',
+    },
+    init: async () => {
+      await client.initialize();
 
-    return {
-      client,
-      setLayout: async (layout, options) => {
-        if (
-          client.services instanceof IFrameClientServicesProxy ||
-          client.services instanceof IFrameClientServicesHost
-        ) {
-          await client.services.setLayout(layout, options);
-        }
-      },
-      context: ({ children }) => {
-        const [status, setStatus] = useState<SystemStatus | null>(null);
-
-        useEffect(() => {
-          if (!client) {
-            return;
+      return {
+        client,
+        setLayout: async (layout, options) => {
+          if (
+            client.services instanceof IFrameClientServicesProxy ||
+            client.services instanceof IFrameClientServicesHost
+          ) {
+            await client.services.setLayout(layout, options);
           }
+        },
+        context: ({ children }) => {
+          const [status, setStatus] = useState<SystemStatus | null>(null);
 
-          const subscription = client.status.subscribe((status) => setStatus(status));
-          return () => subscription.unsubscribe();
-        }, [client, setStatus]);
+          useEffect(() => {
+            if (!client) {
+              return;
+            }
 
-        return <ClientContext.Provider value={{ client, status }}>{children}</ClientContext.Provider>;
-      },
-    };
-  },
-  unload: async () => {
-    await client.destroy();
-  },
-});
+            const subscription = client.status.subscribe((status) => setStatus(status));
+            return () => subscription.unsubscribe();
+          }, [client, setStatus]);
+
+          return <ClientContext.Provider value={{ client, status }}>{children}</ClientContext.Provider>;
+        },
+      };
+    },
+    unload: async () => {
+      await client.destroy();
+    },
+  };
+};

--- a/packages/apps/plugins/plugin-markdown/package.json
+++ b/packages/apps/plugins/plugin-markdown/package.json
@@ -20,6 +20,7 @@
     "@dxos/text-model": "workspace:*"
   },
   "devDependencies": {
+    "@braneframe/plugin-theme": "workspace:*",
     "@dxos/aurora": "workspace:*",
     "@dxos/aurora-theme": "workspace:*",
     "@dxos/react-surface": "workspace:*",
@@ -31,6 +32,7 @@
     "vite": "^4.3.9"
   },
   "peerDependencies": {
+    "@braneframe/plugin-theme": "workspace:*",
     "@dxos/aurora": "workspace:*",
     "@dxos/aurora-theme": "workspace:*",
     "@dxos/react-surface": "workspace:*",

--- a/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -4,47 +4,16 @@
 
 import React from 'react';
 
+import { TranslationsProvides } from '@braneframe/plugin-theme';
 import { ComposerModel, MarkdownComposerProps } from '@dxos/aurora-composer';
 import { createStore } from '@dxos/observable-object';
 import { observer } from '@dxos/observable-object/react';
-import { definePlugin, Plugin, PluginDefinition } from '@dxos/react-surface';
+import { Plugin, PluginDefinition } from '@dxos/react-surface';
 
-import { MarkdownMain, StandaloneLayout } from './components';
+import { MarkdownMain, MarkdownMainEmbedded, MarkdownMainEmpty } from './components';
 import { MarkdownSection } from './components/MarkdownSection';
 import { MarkdownProperties, isMarkdown, isMarkdownPlaceholder, isMarkdownProperties } from './props';
 import translations from './translations';
-
-const store = createStore<{ onChange: NonNullable<MarkdownComposerProps['onChange']>[] }>({ onChange: [] });
-
-const MarkdownMainStandalone = observer(
-  ({ data: [model, properties] }: { data: [ComposerModel, MarkdownProperties]; role?: string }) => {
-    return (
-      <MarkdownMain
-        model={model}
-        properties={properties}
-        layout='standalone'
-        onChange={(text) => store.onChange.forEach((onChange) => onChange(text))}
-      />
-    );
-  },
-);
-
-const MarkdownMainEmbedded = ({
-  data: [model, properties, _],
-}: {
-  data: [ComposerModel, MarkdownProperties, 'embedded'];
-  role?: string;
-}) => {
-  return <MarkdownMain model={model} properties={properties} layout='embedded' />;
-};
-
-const MarkdownMainEmpty = ({ data: [model, properties] }: { data: [any, MarkdownProperties] }) => {
-  return (
-    <StandaloneLayout model={model} properties={properties}>
-      <model.content />
-    </StandaloneLayout>
-  );
-};
 
 export type MarkdownProvides = {
   markdown: {
@@ -52,47 +21,61 @@ export type MarkdownProvides = {
   };
 };
 
-type MarkdownPlugin = Plugin<MarkdownProvides>;
+export type MarkdownPlugin = Plugin<MarkdownProvides>;
 
 export const markdownPlugins = (plugins: Plugin[]): MarkdownPlugin[] => {
   return (plugins as MarkdownPlugin[]).filter((p) => Boolean(p.provides?.markdown));
 };
 
-// TODO(wittjosiah): This explicit type should not be necessary, should be inferred from `definePlugin`.
-export const MarkdownPlugin: PluginDefinition = definePlugin({
-  meta: {
-    id: 'dxos:markdown',
-  },
-  ready: async (plugins) => {
-    markdownPlugins(plugins).forEach((plugin) => {
-      if (plugin.provides.markdown.onChange) {
-        store.onChange.push(plugin.provides.markdown.onChange);
-      }
-    });
-  },
-  provides: {
-    translations,
-    // TODO(wittjosiah): Type unknown in framework.
-    component: (datum: unknown, role) => {
-      switch (role) {
-        case 'main':
-          if (Array.isArray(datum) && isMarkdown(datum[0]) && isMarkdownProperties(datum[1])) {
-            if (datum[2] === 'embedded') {
-              return MarkdownMainEmbedded;
-            } else {
-              return MarkdownMainStandalone;
-            }
-          } else if (Array.isArray(datum) && isMarkdownPlaceholder(datum[0]) && isMarkdownProperties(datum[1])) {
-            return MarkdownMainEmpty;
-          }
-          break;
-        case 'section':
-          if (datum && typeof datum === 'object' && 'object' in datum && isMarkdown(datum.object)) {
-            return MarkdownSection;
-          }
-      }
+export const MarkdownPlugin = (): PluginDefinition<TranslationsProvides> => {
+  const store = createStore<{ onChange: NonNullable<MarkdownComposerProps['onChange']>[] }>({ onChange: [] });
 
-      return null;
+  const MarkdownMainStandalone = observer(
+    ({ data: [model, properties] }: { data: [ComposerModel, MarkdownProperties]; role?: string }) => {
+      return (
+        <MarkdownMain
+          model={model}
+          properties={properties}
+          layout='standalone'
+          onChange={(text) => store.onChange.forEach((onChange) => onChange(text))}
+        />
+      );
     },
-  },
-});
+  );
+  return {
+    meta: {
+      id: 'dxos:markdown',
+    },
+    ready: async (plugins) => {
+      markdownPlugins(plugins).forEach((plugin) => {
+        if (plugin.provides.markdown.onChange) {
+          store.onChange.push(plugin.provides.markdown.onChange);
+        }
+      });
+    },
+    provides: {
+      translations,
+      component: (datum, role) => {
+        switch (role) {
+          case 'main':
+            if (Array.isArray(datum) && isMarkdown(datum[0]) && isMarkdownProperties(datum[1])) {
+              if (datum[2] === 'embedded') {
+                return MarkdownMainEmbedded;
+              } else {
+                return MarkdownMainStandalone;
+              }
+            } else if (Array.isArray(datum) && isMarkdownPlaceholder(datum[0]) && isMarkdownProperties(datum[1])) {
+              return MarkdownMainEmpty;
+            }
+            break;
+          case 'section':
+            if (datum && typeof datum === 'object' && 'object' in datum && isMarkdown(datum.object)) {
+              return MarkdownSection;
+            }
+        }
+
+        return null;
+      },
+    },
+  };
+};

--- a/packages/apps/plugins/plugin-markdown/src/components/MarkdownMainEmbedded.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/MarkdownMainEmbedded.tsx
@@ -1,0 +1,19 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React from 'react';
+
+import { ComposerModel } from '@dxos/aurora-composer';
+
+import { MarkdownProperties } from '../props';
+import { MarkdownMain } from './MarkdownMain';
+
+export const MarkdownMainEmbedded = ({
+  data: [model, properties, _],
+}: {
+  data: [ComposerModel, MarkdownProperties, 'embedded'];
+  role?: string;
+}) => {
+  return <MarkdownMain model={model} properties={properties} layout='embedded' />;
+};

--- a/packages/apps/plugins/plugin-markdown/src/components/MarkdownMainEmpty.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/MarkdownMainEmpty.tsx
@@ -1,0 +1,16 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React from 'react';
+
+import { MarkdownProperties } from '../props';
+import { StandaloneLayout } from './StandaloneLayout';
+
+export const MarkdownMainEmpty = ({ data: [model, properties] }: { data: [any, MarkdownProperties] }) => {
+  return (
+    <StandaloneLayout model={model} properties={properties}>
+      <model.content />
+    </StandaloneLayout>
+  );
+};

--- a/packages/apps/plugins/plugin-markdown/src/components/index.ts
+++ b/packages/apps/plugins/plugin-markdown/src/components/index.ts
@@ -2,5 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
+export * from './MarkdownMainEmbedded';
+export * from './MarkdownMainEmpty';
 export * from './MarkdownMain';
 export * from './StandaloneLayout';

--- a/packages/apps/plugins/plugin-markdown/tsconfig.json
+++ b/packages/apps/plugins/plugin-markdown/tsconfig.json
@@ -37,6 +37,9 @@
     },
     {
       "path": "../../../ui/aurora-theme"
+    },
+    {
+      "path": "../plugin-theme"
     }
   ]
 }

--- a/packages/apps/plugins/plugin-splitview/src/SplitViewContext.ts
+++ b/packages/apps/plugins/plugin-splitview/src/SplitViewContext.ts
@@ -1,0 +1,21 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Context, createContext, useContext } from 'react';
+
+export type SplitViewContextValue = {
+  sidebarOpen: boolean;
+  dialogContent: any;
+  dialogOpen: boolean;
+};
+
+export const defaultValues: SplitViewContextValue = {
+  sidebarOpen: true,
+  dialogContent: 'never',
+  dialogOpen: false,
+};
+
+export const SplitViewContext: Context<SplitViewContextValue> = createContext(defaultValues);
+
+export const useSplitView = () => useContext(SplitViewContext);

--- a/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
@@ -2,113 +2,31 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Sidebar as SidebarIcon } from '@phosphor-icons/react';
-import React, { PropsWithChildren, createContext, useContext } from 'react';
+import React, { PropsWithChildren } from 'react';
 
-import { Button, Main, Dialog, useTranslation, DensityProvider } from '@dxos/aurora';
-import { defaultDescription, fineBlockSize, getSize, mx } from '@dxos/aurora-theme';
 import { createStore } from '@dxos/observable-object';
-import { observer } from '@dxos/observable-object/react';
-import { Surface, definePlugin } from '@dxos/react-surface';
+import { PluginDefinition } from '@dxos/react-surface';
 
-export type SplitViewContextValue = {
-  sidebarOpen: boolean;
-  dialogContent: any;
-  dialogOpen: boolean;
-};
-
-const store = createStore<SplitViewContextValue>({
-  sidebarOpen: true,
-  dialogContent: 'never',
-  dialogOpen: false,
-});
-
-const Context = createContext(store);
-
-export const useSplitViewContext = () => useContext(Context);
-
-export const SplitView = observer(() => {
-  const context = useSplitViewContext();
-  const { sidebarOpen, dialogOpen, dialogContent } = context;
-  const { t } = useTranslation('os');
-
-  return (
-    <Main.Root sidebarOpen={context.sidebarOpen} onSidebarOpenChange={(next) => (context.sidebarOpen = next)}>
-      <Main.Sidebar swipeToDismiss>
-        <Surface name='sidebar' />
-      </Main.Sidebar>
-      <div
-        role='none'
-        className={mx(
-          'fixed z-[1] block-end-0 pointer-fine:block-end-auto pointer-fine:block-start-0 p-2 pointer-fine:p-1.5 transition-[inset-inline-start,opacity] ease-in-out duration-200 inline-start-0',
-          sidebarOpen && 'opacity-0 pointer-events-none',
-        )}
-      >
-        <Button
-          onClick={() => (context.sidebarOpen = !context.sidebarOpen)}
-          classNames={mx(fineBlockSize, 'aspect-square p-0 shadow-none')}
-        >
-          <SidebarIcon weight='light' className={getSize(5)} />
-        </Button>
-      </div>
-      <Main.Overlay />
-      <Surface name='main' />
-      <Dialog.Root open={dialogOpen} onOpenChange={(nextOpen) => (context.dialogOpen = nextOpen)}>
-        <DensityProvider density='fine'>
-          <Dialog.Overlay>
-            {dialogContent === 'dxos:SplitViewPlugin/ProfileSettings' ? (
-              <Dialog.Content>
-                <Dialog.Title>{t('settings dialog title', { ns: 'os' })}</Dialog.Title>
-                <Surface role='dialog' data={dialogContent} />
-                <Dialog.Close asChild>
-                  <Button variant='primary' classNames='mbs-2'>
-                    {t('done label', { ns: 'os' })}
-                  </Button>
-                </Dialog.Close>
-              </Dialog.Content>
-            ) : (
-              <Dialog.Content>
-                <Surface role='dialog' data={dialogContent} />
-              </Dialog.Content>
-            )}
-          </Dialog.Overlay>
-        </DensityProvider>
-      </Dialog.Root>
-    </Main.Root>
-  );
-});
+import { defaultValues, SplitViewContext, SplitViewContextValue } from './SplitViewContext';
+import { SplitView, SplitViewMainContentEmpty } from './components';
 
 export type SplitViewProvides = {
   splitView: SplitViewContextValue;
 };
 
-export const SplitViewMainContentEmpty = () => {
-  const { t } = useTranslation('composer');
-  return (
-    <div
-      role='none'
-      className='min-bs-screen is-full flex items-center justify-center p-8'
-      data-testid='splitViewPlugin.firstRunMessage'
-    >
-      <p
-        role='alert'
-        className={mx(
-          defaultDescription,
-          'border border-dashed border-neutral-400/50 rounded-xl flex items-center justify-center p-8 font-system-normal text-lg',
-        )}
-      >
-        {t('first run message')}
-      </p>
-    </div>
-  );
+export const SplitViewPlugin = (): PluginDefinition<SplitViewProvides> => {
+  const store = createStore(defaultValues);
+
+  return {
+    meta: {
+      id: 'dxos:SplitViewPlugin',
+    },
+    provides: {
+      context: (props: PropsWithChildren) => (
+        <SplitViewContext.Provider value={store}>{props.children}</SplitViewContext.Provider>
+      ),
+      components: { SplitView, SplitViewMainContentEmpty },
+      splitView: store,
+    },
+  };
 };
-export const SplitViewPlugin = definePlugin<SplitViewProvides>({
-  meta: {
-    id: 'dxos:SplitViewPlugin',
-  },
-  provides: {
-    context: (props: PropsWithChildren) => <Context.Provider value={store}>{props.children}</Context.Provider>,
-    components: { SplitView, SplitViewMainContentEmpty },
-    splitView: store,
-  },
-});

--- a/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
@@ -1,0 +1,64 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Sidebar as SidebarIcon } from '@phosphor-icons/react';
+import React from 'react';
+
+import { Button, Main, Dialog, useTranslation, DensityProvider } from '@dxos/aurora';
+import { fineBlockSize, getSize, mx } from '@dxos/aurora-theme';
+import { observer } from '@dxos/observable-object/react';
+import { Surface } from '@dxos/react-surface';
+
+import { useSplitView } from '../SplitViewContext';
+
+export const SplitView = observer(() => {
+  const context = useSplitView();
+  const { sidebarOpen, dialogOpen, dialogContent } = context;
+  const { t } = useTranslation('os');
+
+  return (
+    <Main.Root sidebarOpen={context.sidebarOpen} onSidebarOpenChange={(next) => (context.sidebarOpen = next)}>
+      <Main.Sidebar swipeToDismiss>
+        <Surface name='sidebar' />
+      </Main.Sidebar>
+      <div
+        role='none'
+        className={mx(
+          'fixed z-[1] block-end-0 pointer-fine:block-end-auto pointer-fine:block-start-0 p-2 pointer-fine:p-1.5 transition-[inset-inline-start,opacity] ease-in-out duration-200 inline-start-0',
+          sidebarOpen && 'opacity-0 pointer-events-none',
+        )}
+      >
+        <Button
+          onClick={() => (context.sidebarOpen = !context.sidebarOpen)}
+          classNames={mx(fineBlockSize, 'aspect-square p-0 shadow-none')}
+        >
+          <SidebarIcon weight='light' className={getSize(5)} />
+        </Button>
+      </div>
+      <Main.Overlay />
+      <Surface name='main' />
+      <Dialog.Root open={dialogOpen} onOpenChange={(nextOpen) => (context.dialogOpen = nextOpen)}>
+        <DensityProvider density='fine'>
+          <Dialog.Overlay>
+            {dialogContent === 'dxos:SplitViewPlugin/ProfileSettings' ? (
+              <Dialog.Content>
+                <Dialog.Title>{t('settings dialog title', { ns: 'os' })}</Dialog.Title>
+                <Surface role='dialog' data={dialogContent} />
+                <Dialog.Close asChild>
+                  <Button variant='primary' classNames='mbs-2'>
+                    {t('done label', { ns: 'os' })}
+                  </Button>
+                </Dialog.Close>
+              </Dialog.Content>
+            ) : (
+              <Dialog.Content>
+                <Surface role='dialog' data={dialogContent} />
+              </Dialog.Content>
+            )}
+          </Dialog.Overlay>
+        </DensityProvider>
+      </Dialog.Root>
+    </Main.Root>
+  );
+});

--- a/packages/apps/plugins/plugin-splitview/src/components/SplitViewMainContentEmpty.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/components/SplitViewMainContentEmpty.tsx
@@ -1,0 +1,29 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React from 'react';
+
+import { useTranslation } from '@dxos/aurora';
+import { defaultDescription, mx } from '@dxos/aurora-theme';
+
+export const SplitViewMainContentEmpty = () => {
+  const { t } = useTranslation('composer');
+  return (
+    <div
+      role='none'
+      className='min-bs-screen is-full flex items-center justify-center p-8'
+      data-testid='splitViewPlugin.firstRunMessage'
+    >
+      <p
+        role='alert'
+        className={mx(
+          defaultDescription,
+          'border border-dashed border-neutral-400/50 rounded-xl flex items-center justify-center p-8 font-system-normal text-lg',
+        )}
+      >
+        {t('first run message')}
+      </p>
+    </div>
+  );
+};

--- a/packages/apps/plugins/plugin-splitview/src/components/index.ts
+++ b/packages/apps/plugins/plugin-splitview/src/components/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+export * from './SplitView';
+export * from './SplitViewMainContentEmpty';

--- a/packages/apps/plugins/plugin-splitview/src/index.ts
+++ b/packages/apps/plugins/plugin-splitview/src/index.ts
@@ -2,4 +2,5 @@
 // Copyright 2023 DXOS.org
 //
 
+export * from './SplitViewContext';
 export * from './SplitViewPlugin';

--- a/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
+++ b/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
@@ -2,13 +2,14 @@
 // Copyright 2023 DXOS.org
 //
 
-import { definePlugin, PluginDefinition } from '@dxos/react-surface';
+import { TranslationsProvides } from '@braneframe/plugin-theme';
+import { PluginDefinition } from '@dxos/react-surface';
 
 import { StackMain } from './components';
 import { isStack } from './props';
 import translations from './translations';
 
-export const StackPlugin: PluginDefinition = definePlugin({
+export const StackPlugin = (): PluginDefinition<TranslationsProvides> => ({
   meta: {
     id: 'dxos:stack',
   },

--- a/packages/apps/plugins/plugin-stack/src/stories/StackPlugin.stories.tsx
+++ b/packages/apps/plugins/plugin-stack/src/stories/StackPlugin.stories.tsx
@@ -21,7 +21,7 @@ const DefaultStackPluginStory = () => {
   return <Surface role='main' data={[stack, stack]} />;
 };
 
-const StackPluginStoryPlugin = {
+const StackPluginStoryPlugin = () => ({
   meta: {
     id: 'dxos:stackStoryPlugin',
   },
@@ -30,10 +30,10 @@ const StackPluginStoryPlugin = {
       default: DefaultStackPluginStory,
     },
   },
-};
+});
 
 const StackSurfacesApp = () => (
-  <PluginContextProvider plugins={[ThemePlugin, StackPlugin, MarkdownPlugin, StackPluginStoryPlugin]} />
+  <PluginContextProvider plugins={[ThemePlugin(), StackPlugin(), MarkdownPlugin(), StackPluginStoryPlugin()]} />
 );
 
 export default {

--- a/packages/apps/plugins/plugin-treeview/src/TreeViewContext.ts
+++ b/packages/apps/plugins/plugin-treeview/src/TreeViewContext.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Context, createContext, useContext } from 'react';
+
+// TODO(wittjosiah): Derive graph nodes from selected.
+export type TreeViewContextValue = {
+  selected: string[];
+};
+
+export const TreeViewContext: Context<TreeViewContextValue> = createContext<TreeViewContextValue>({ selected: [] });
+
+export const useTreeView = () => useContext(TreeViewContext);

--- a/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
@@ -2,45 +2,17 @@
 // Copyright 2023 DXOS.org
 //
 
-import { DotsThreeVertical, GearSix, Placeholder } from '@phosphor-icons/react';
-import React, { createContext, useContext, useRef, useState } from 'react';
+import React from 'react';
 
 import { GraphNode, useGraphContext } from '@braneframe/plugin-graph';
-import { useSplitViewContext } from '@braneframe/plugin-splitview';
-import {
-  Avatar,
-  Tree,
-  TreeItem,
-  Button,
-  DensityProvider,
-  ElevationProvider,
-  ThemeContext,
-  Tooltip,
-  useJdenticonHref,
-  useSidebar,
-  useThemeContext,
-  useTranslation,
-  DropdownMenu,
-} from '@dxos/aurora';
-import { getSize, mx, osTx } from '@dxos/aurora-theme';
 import { createStore } from '@dxos/observable-object';
-import { observer, useIdentity } from '@dxos/react-client';
-import { Surface, definePlugin } from '@dxos/react-surface';
+import { observer } from '@dxos/react-client';
+import { PluginDefinition, Surface } from '@dxos/react-surface';
 
-import { TreeView } from './components';
+import { TreeViewContext, TreeViewContextValue, useTreeView } from './TreeViewContext';
+import { TreeViewContainer } from './components';
 
-const TREE_VIEW_PLUGIN = 'dxos:TreeViewPlugin';
-
-// TODO(wittjosiah): Derive graph nodes from selected.
-export type TreeViewContextValue = {
-  selected: string[];
-};
-
-const store = createStore<TreeViewContextValue>({ selected: [] });
-
-const Context = createContext<TreeViewContextValue>(store);
-
-export const useTreeView = () => useContext(Context);
+export const TREE_VIEW_PLUGIN = 'dxos:TreeViewPlugin';
 
 export const uriToSelected = (uri: string) => {
   const [_, namespace, type, id, ...rest] = uri.split('/');
@@ -48,170 +20,6 @@ export const uriToSelected = (uri: string) => {
 };
 
 export const selectedToUri = (selected: string[]) => '/' + selected.join('/').replace(':', '/');
-
-export const TreeViewContainer = observer(() => {
-  const graph = useGraphContext();
-
-  const identity = useIdentity({ login: true });
-  const jdenticon = useJdenticonHref(identity?.identityKey.toHex() ?? '', 24);
-  const themeContext = useThemeContext();
-  const { t } = useTranslation('composer');
-  const { sidebarOpen } = useSidebar(TREE_VIEW_PLUGIN);
-  const splitViewContext = useSplitViewContext();
-
-  const suppressNextTooltip = useRef<boolean>(false);
-  const [optionsTooltipOpen, setOptionsTooltipOpen] = useState(false);
-  const [optionsMenuOpen, setOptionsMenuOpen] = useState(false);
-
-  const [primary, secondary, ...actions] = Object.values(graph.actions).reduce(
-    (acc, actions) => [...acc, ...actions],
-    [],
-  );
-  const hoistedActions = [primary, secondary].filter(Boolean);
-
-  return (
-    <ElevationProvider elevation='chrome'>
-      <DensityProvider density='fine'>
-        <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}>
-          <div role='none' className='flex flex-col bs-full'>
-            <div role='separator' className='order-1 bs-px mli-2.5 bg-neutral-500/20' />
-            <Tree.Root role='none' classNames='order-1 grow min-bs-0 overflow-y-auto overscroll-contain'>
-              {Object.entries(graph.roots).map(([key, items]) => (
-                <TreeItem.Root key={key} classNames='flex flex-col plb-1.5 pis-1 pie-1.5'>
-                  <TreeItem.Heading classNames='pl-2'>{t('plugin name', { ns: key })}</TreeItem.Heading>
-                  <TreeView key={key} items={items} parent={key} />
-                </TreeItem.Root>
-              ))}
-            </Tree.Root>
-            <div role='none' className='order-first shrink-0 flex items-center pli-1.5 plb-1.5 order-0'>
-              <h1 className={mx('grow font-system-medium text-lg pli-1.5')}>{t('current app name')}</h1>
-              {hoistedActions?.map((action) => (
-                <Tooltip.Root key={action.id}>
-                  <Tooltip.Trigger asChild>
-                    <Button
-                      variant='ghost'
-                      key={action.id}
-                      {...(action.testId && { 'data-testid': action.testId })}
-                      onClick={(event) => action.invoke(t, event)}
-                      classNames='pli-2 pointer-fine:pli-1'
-                      {...(!sidebarOpen && { tabIndex: -1 })}
-                    >
-                      <span className='sr-only'>{Array.isArray(action.label) ? t(...action.label) : action.label}</span>
-                      {action.icon ? <action.icon className={getSize(4)} /> : <Placeholder className={getSize(4)} />}
-                    </Button>
-                  </Tooltip.Trigger>
-                  <Tooltip.Content classNames='z-[31]'>
-                    {Array.isArray(action.label) ? t(...action.label) : action.label}
-                    <Tooltip.Arrow />
-                  </Tooltip.Content>
-                </Tooltip.Root>
-              ))}
-              <Tooltip.Root
-                open={optionsTooltipOpen}
-                onOpenChange={(nextOpen) => {
-                  if (suppressNextTooltip.current) {
-                    setOptionsTooltipOpen(false);
-                    suppressNextTooltip.current = false;
-                  } else {
-                    setOptionsTooltipOpen(nextOpen);
-                  }
-                }}
-              >
-                <Tooltip.Portal>
-                  <Tooltip.Content classNames='z-[31]' side='bottom'>
-                    {t('tree options label')}
-                    <Tooltip.Arrow />
-                  </Tooltip.Content>
-                </Tooltip.Portal>
-                <DropdownMenu.Root
-                  {...{
-                    open: optionsMenuOpen,
-                    onOpenChange: (nextOpen: boolean) => {
-                      if (!nextOpen) {
-                        suppressNextTooltip.current = true;
-                      }
-                      return setOptionsMenuOpen(nextOpen);
-                    },
-                  }}
-                >
-                  <DropdownMenu.Trigger asChild>
-                    <Tooltip.Trigger asChild>
-                      <Button
-                        variant='ghost'
-                        classNames='shrink-0 pli-2 pointer-fine:pli-1'
-                        {...(!sidebarOpen && { tabIndex: -1 })}
-                      >
-                        <DotsThreeVertical className={getSize(4)} />
-                      </Button>
-                    </Tooltip.Trigger>
-                  </DropdownMenu.Trigger>
-                  <DropdownMenu.Portal>
-                    <DropdownMenu.Content classNames='z-[31]'>
-                      {actions.map((action) => (
-                        <DropdownMenu.Item
-                          key={action.id}
-                          onClick={(event) => {
-                            // todo(thure): Why does Dialog’s modal-ness cause issues if we don’t explicitly close the menu here?
-                            suppressNextTooltip.current = true;
-                            setOptionsMenuOpen(false);
-                            void action.invoke(t, event);
-                          }}
-                          classNames='gap-2'
-                        >
-                          {action.icon && <action.icon className={getSize(4)} />}
-                          <span>{Array.isArray(action.label) ? t(...action.label) : action.label}</span>
-                        </DropdownMenu.Item>
-                      ))}
-                      <DropdownMenu.Arrow />
-                    </DropdownMenu.Content>
-                  </DropdownMenu.Portal>
-                </DropdownMenu.Root>
-              </Tooltip.Root>
-            </div>
-            {identity && (
-              <>
-                <div role='separator' className='order-last bs-px mli-2.5 bg-neutral-500/20' />
-                <Avatar.Root size={6} variant='circle' status='active'>
-                  <div
-                    role='none'
-                    className='order-last shrink-0 flex items-center gap-1 pis-3 pie-1.5 plb-3 pointer-fine:pie-1.5 pointer-fine:plb-1.5'
-                  >
-                    <Avatar.Frame>
-                      <Avatar.Fallback href={jdenticon} />
-                    </Avatar.Frame>
-                    <Avatar.Label classNames='grow text-sm'>
-                      {identity.profile?.displayName ?? identity.identityKey.truncate()}
-                    </Avatar.Label>
-                    <Tooltip.Root>
-                      <Tooltip.Trigger asChild>
-                        <Button
-                          variant='ghost'
-                          classNames='pli-2 pointer-fine:pli-1'
-                          {...(!sidebarOpen && { tabIndex: -1 })}
-                          onClick={() => {
-                            splitViewContext.dialogOpen = true;
-                            splitViewContext.dialogContent = 'dxos:SplitViewPlugin/ProfileSettings';
-                          }}
-                        >
-                          <span className='sr-only'>{t('settings dialog title', { ns: 'os' })}</span>
-                          <GearSix className={mx(getSize(4), 'rotate-90')} />
-                        </Button>
-                      </Tooltip.Trigger>
-                      <Tooltip.Content>
-                        {t('settings dialog title', { ns: 'os' })}
-                        <Tooltip.Arrow />
-                      </Tooltip.Content>
-                    </Tooltip.Root>
-                  </div>
-                </Avatar.Root>
-              </>
-            )}
-          </div>
-        </ThemeContext.Provider>
-      </DensityProvider>
-    </ElevationProvider>
-  );
-});
 
 export type TreeViewProvides = {
   treeView: TreeViewContextValue;
@@ -226,47 +34,51 @@ const resolveNodes = (graph: GraphNode[], [id, ...path]: string[], nodes: GraphN
   return resolveNodes(node.children ?? [], path, [...nodes, node]);
 };
 
-export const TreeViewPlugin = definePlugin<TreeViewProvides, {}>({
-  meta: {
-    id: TREE_VIEW_PLUGIN,
-  },
-  provides: {
-    treeView: store,
-    context: ({ children }) => {
-      return <Context.Provider value={store}>{children}</Context.Provider>;
-    },
-    components: {
-      default: observer(() => {
-        const treeView = useTreeView();
-        const graph = useGraphContext();
-        const [plugin] = treeView.selected[0]?.split('/') ?? [];
-        const nodes = resolveNodes(graph.roots[plugin] ?? [], treeView.selected);
+export const TreeViewPlugin = (): PluginDefinition<TreeViewProvides> => {
+  const store = createStore<TreeViewContextValue>({ selected: [] });
 
-        if (treeView.selected.length === 0) {
-          return (
-            <Surface
-              component='dxos:SplitViewPlugin/SplitView'
-              surfaces={{
-                sidebar: { component: 'dxos:TreeViewPlugin/TreeView' },
-                main: { component: 'dxos:SplitViewPlugin/SplitViewMainContentEmpty' },
-              }}
-            />
-          );
-        } else if (nodes.length === 0) {
-          return <Surface component={`${plugin}/Main`} />;
-        } else {
-          return (
-            <Surface
-              component='dxos:SplitViewPlugin/SplitView'
-              surfaces={{
-                sidebar: { component: 'dxos:TreeViewPlugin/TreeView' },
-                main: { component: `${plugin}/Main`, data: nodes },
-              }}
-            />
-          );
-        }
-      }),
-      TreeView: TreeViewContainer,
+  return {
+    meta: {
+      id: TREE_VIEW_PLUGIN,
     },
-  },
-});
+    provides: {
+      treeView: store,
+      context: ({ children }) => {
+        return <TreeViewContext.Provider value={store}>{children}</TreeViewContext.Provider>;
+      },
+      components: {
+        default: observer(() => {
+          const treeView = useTreeView();
+          const graph = useGraphContext();
+          const [plugin] = treeView.selected[0]?.split('/') ?? [];
+          const nodes = resolveNodes(graph.roots[plugin] ?? [], treeView.selected);
+
+          if (treeView.selected.length === 0) {
+            return (
+              <Surface
+                component='dxos:SplitViewPlugin/SplitView'
+                surfaces={{
+                  sidebar: { component: 'dxos:TreeViewPlugin/TreeView' },
+                  main: { component: 'dxos:SplitViewPlugin/SplitViewMainContentEmpty' },
+                }}
+              />
+            );
+          } else if (nodes.length === 0) {
+            return <Surface component={`${plugin}/Main`} />;
+          } else {
+            return (
+              <Surface
+                component='dxos:SplitViewPlugin/SplitView'
+                surfaces={{
+                  sidebar: { component: 'dxos:TreeViewPlugin/TreeView' },
+                  main: { component: `${plugin}/Main`, data: nodes },
+                }}
+              />
+            );
+          }
+        }),
+        TreeView: TreeViewContainer,
+      },
+    },
+  };
+};

--- a/packages/apps/plugins/plugin-treeview/src/components/LeafTreeItem.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/LeafTreeItem.tsx
@@ -20,7 +20,7 @@ import {
 import { appTx, getSize, mx } from '@dxos/aurora-theme';
 import { observer } from '@dxos/observable-object/react';
 
-import { useTreeView } from '../TreeViewPlugin';
+import { useTreeView } from '../TreeViewContext';
 
 const spaceExp = /\s/g;
 

--- a/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
@@ -1,0 +1,193 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { DotsThreeVertical, GearSix, Placeholder } from '@phosphor-icons/react';
+import React, { useRef, useState } from 'react';
+
+import { useGraphContext } from '@braneframe/plugin-graph';
+import { useSplitView } from '@braneframe/plugin-splitview';
+import {
+  Avatar,
+  Tree,
+  TreeItem,
+  Button,
+  DensityProvider,
+  ElevationProvider,
+  ThemeContext,
+  Tooltip,
+  useJdenticonHref,
+  useSidebar,
+  useThemeContext,
+  useTranslation,
+  DropdownMenu,
+} from '@dxos/aurora';
+import { getSize, mx, osTx } from '@dxos/aurora-theme';
+import { observer, useIdentity } from '@dxos/react-client';
+
+import { TREE_VIEW_PLUGIN } from '../TreeViewPlugin';
+import { TreeView } from './TreeView';
+
+export const TreeViewContainer = observer(() => {
+  const graph = useGraphContext();
+
+  const identity = useIdentity({ login: true });
+  const jdenticon = useJdenticonHref(identity?.identityKey.toHex() ?? '', 24);
+  const themeContext = useThemeContext();
+  const { t } = useTranslation('composer');
+  const { sidebarOpen } = useSidebar(TREE_VIEW_PLUGIN);
+  const splitViewContext = useSplitView();
+
+  const suppressNextTooltip = useRef<boolean>(false);
+  const [optionsTooltipOpen, setOptionsTooltipOpen] = useState(false);
+  const [optionsMenuOpen, setOptionsMenuOpen] = useState(false);
+
+  const [primary, secondary, ...actions] = Object.values(graph.actions).reduce(
+    (acc, actions) => [...acc, ...actions],
+    [],
+  );
+  const hoistedActions = [primary, secondary].filter(Boolean);
+
+  return (
+    <ElevationProvider elevation='chrome'>
+      <DensityProvider density='fine'>
+        <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}>
+          <div role='none' className='flex flex-col bs-full'>
+            <div role='separator' className='order-1 bs-px mli-2.5 bg-neutral-500/20' />
+            <Tree.Root role='none' classNames='order-1 grow min-bs-0 overflow-y-auto overscroll-contain'>
+              {Object.entries(graph.roots).map(([key, items]) => (
+                <TreeItem.Root key={key} classNames='flex flex-col plb-1.5 pis-1 pie-1.5'>
+                  <TreeItem.Heading classNames='pl-2'>{t('plugin name', { ns: key })}</TreeItem.Heading>
+                  <TreeView key={key} items={items} parent={key} />
+                </TreeItem.Root>
+              ))}
+            </Tree.Root>
+            <div role='none' className='order-first shrink-0 flex items-center pli-1.5 plb-1.5 order-0'>
+              <h1 className={mx('grow font-system-medium text-lg pli-1.5')}>{t('current app name')}</h1>
+              {hoistedActions?.map((action) => (
+                <Tooltip.Root key={action.id}>
+                  <Tooltip.Trigger asChild>
+                    <Button
+                      variant='ghost'
+                      key={action.id}
+                      {...(action.testId && { 'data-testid': action.testId })}
+                      onClick={(event) => action.invoke(t, event)}
+                      classNames='pli-2 pointer-fine:pli-1'
+                      {...(!sidebarOpen && { tabIndex: -1 })}
+                    >
+                      <span className='sr-only'>{Array.isArray(action.label) ? t(...action.label) : action.label}</span>
+                      {action.icon ? <action.icon className={getSize(4)} /> : <Placeholder className={getSize(4)} />}
+                    </Button>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content classNames='z-[31]'>
+                    {Array.isArray(action.label) ? t(...action.label) : action.label}
+                    <Tooltip.Arrow />
+                  </Tooltip.Content>
+                </Tooltip.Root>
+              ))}
+              <Tooltip.Root
+                open={optionsTooltipOpen}
+                onOpenChange={(nextOpen) => {
+                  if (suppressNextTooltip.current) {
+                    setOptionsTooltipOpen(false);
+                    suppressNextTooltip.current = false;
+                  } else {
+                    setOptionsTooltipOpen(nextOpen);
+                  }
+                }}
+              >
+                <Tooltip.Portal>
+                  <Tooltip.Content classNames='z-[31]' side='bottom'>
+                    {t('tree options label')}
+                    <Tooltip.Arrow />
+                  </Tooltip.Content>
+                </Tooltip.Portal>
+                <DropdownMenu.Root
+                  {...{
+                    open: optionsMenuOpen,
+                    onOpenChange: (nextOpen: boolean) => {
+                      if (!nextOpen) {
+                        suppressNextTooltip.current = true;
+                      }
+                      return setOptionsMenuOpen(nextOpen);
+                    },
+                  }}
+                >
+                  <DropdownMenu.Trigger asChild>
+                    <Tooltip.Trigger asChild>
+                      <Button
+                        variant='ghost'
+                        classNames='shrink-0 pli-2 pointer-fine:pli-1'
+                        {...(!sidebarOpen && { tabIndex: -1 })}
+                      >
+                        <DotsThreeVertical className={getSize(4)} />
+                      </Button>
+                    </Tooltip.Trigger>
+                  </DropdownMenu.Trigger>
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.Content classNames='z-[31]'>
+                      {actions.map((action) => (
+                        <DropdownMenu.Item
+                          key={action.id}
+                          onClick={(event) => {
+                            // todo(thure): Why does Dialog’s modal-ness cause issues if we don’t explicitly close the menu here?
+                            suppressNextTooltip.current = true;
+                            setOptionsMenuOpen(false);
+                            void action.invoke(t, event);
+                          }}
+                          classNames='gap-2'
+                        >
+                          {action.icon && <action.icon className={getSize(4)} />}
+                          <span>{Array.isArray(action.label) ? t(...action.label) : action.label}</span>
+                        </DropdownMenu.Item>
+                      ))}
+                      <DropdownMenu.Arrow />
+                    </DropdownMenu.Content>
+                  </DropdownMenu.Portal>
+                </DropdownMenu.Root>
+              </Tooltip.Root>
+            </div>
+            {identity && (
+              <>
+                <div role='separator' className='order-last bs-px mli-2.5 bg-neutral-500/20' />
+                <Avatar.Root size={6} variant='circle' status='active'>
+                  <div
+                    role='none'
+                    className='order-last shrink-0 flex items-center gap-1 pis-3 pie-1.5 plb-3 pointer-fine:pie-1.5 pointer-fine:plb-1.5'
+                  >
+                    <Avatar.Frame>
+                      <Avatar.Fallback href={jdenticon} />
+                    </Avatar.Frame>
+                    <Avatar.Label classNames='grow text-sm'>
+                      {identity.profile?.displayName ?? identity.identityKey.truncate()}
+                    </Avatar.Label>
+                    <Tooltip.Root>
+                      <Tooltip.Trigger asChild>
+                        <Button
+                          variant='ghost'
+                          classNames='pli-2 pointer-fine:pli-1'
+                          {...(!sidebarOpen && { tabIndex: -1 })}
+                          onClick={() => {
+                            splitViewContext.dialogOpen = true;
+                            splitViewContext.dialogContent = 'dxos:SplitViewPlugin/ProfileSettings';
+                          }}
+                        >
+                          <span className='sr-only'>{t('settings dialog title', { ns: 'os' })}</span>
+                          <GearSix className={mx(getSize(4), 'rotate-90')} />
+                        </Button>
+                      </Tooltip.Trigger>
+                      <Tooltip.Content>
+                        {t('settings dialog title', { ns: 'os' })}
+                        <Tooltip.Arrow />
+                      </Tooltip.Content>
+                    </Tooltip.Root>
+                  </div>
+                </Avatar.Root>
+              </>
+            )}
+          </div>
+        </ThemeContext.Provider>
+      </DensityProvider>
+    </ElevationProvider>
+  );
+});

--- a/packages/apps/plugins/plugin-treeview/src/components/index.ts
+++ b/packages/apps/plugins/plugin-treeview/src/components/index.ts
@@ -5,3 +5,4 @@
 export * from './BranchTreeItem';
 export * from './LeafTreeItem';
 export * from './TreeView';
+export * from './TreeViewContainer';

--- a/packages/apps/plugins/plugin-treeview/src/index.ts
+++ b/packages/apps/plugins/plugin-treeview/src/index.ts
@@ -2,4 +2,5 @@
 // Copyright 2023 DXOS.org
 //
 
+export * from './TreeViewContext';
 export * from './TreeViewPlugin';

--- a/packages/apps/plugins/plugin-url-sync/src/UrlSyncPlugin.tsx
+++ b/packages/apps/plugins/plugin-url-sync/src/UrlSyncPlugin.tsx
@@ -6,9 +6,9 @@ import { useEffect } from 'react';
 
 import { selectedToUri, uriToSelected, useTreeView } from '@braneframe/plugin-treeview';
 import { observer } from '@dxos/observable-object/react';
-import { definePlugin, PluginDefinition } from '@dxos/react-surface';
+import { PluginDefinition } from '@dxos/react-surface';
 
-export const UrlSyncPlugin: PluginDefinition = definePlugin({
+export const UrlSyncPlugin = (): PluginDefinition => ({
   meta: {
     id: 'dxos:url-sync',
   },

--- a/packages/sdk/react-surface/src/Plugin.ts
+++ b/packages/sdk/react-surface/src/Plugin.ts
@@ -7,7 +7,7 @@ import { FC, PropsWithChildren } from 'react';
 export type PluginProvides<TProvides> = TProvides & {
   context?: FC<PropsWithChildren>;
   component?: <P extends PropsWithChildren = PropsWithChildren>(
-    datum: any,
+    datum: unknown,
     role?: string,
     props?: Partial<P>,
   ) => FC<PropsWithChildren<{ data: any; role?: string }>> | undefined | null | false | 0;
@@ -26,12 +26,6 @@ export type PluginDefinition<TProvides = {}, TInitProvides = {}> = Omit<Plugin, 
   init?: () => Promise<PluginProvides<TInitProvides>>;
   ready?: (plugins: Plugin[]) => Promise<void>;
   unload?: () => Promise<void>;
-};
-
-export const definePlugin = <TProvides = {}, TInitProvides = {}>(
-  plugin: PluginDefinition<TProvides, TInitProvides>,
-) => {
-  return plugin;
 };
 
 export const findPlugin = <T>(plugins: Plugin[], id: string): Plugin<T> | undefined => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,6 +597,7 @@ importers:
 
   packages/apps/plugins/plugin-markdown:
     specifiers:
+      '@braneframe/plugin-theme': workspace:*
       '@dxos/aurora': workspace:*
       '@dxos/aurora-composer': workspace:*
       '@dxos/aurora-theme': workspace:*
@@ -614,6 +615,7 @@ importers:
       '@dxos/observable-object': link:../../../common/observable-object
       '@dxos/text-model': link:../../../core/echo/text-model
     devDependencies:
+      '@braneframe/plugin-theme': link:../plugin-theme
       '@dxos/aurora': link:../../../ui/aurora
       '@dxos/aurora-theme': link:../../../ui/aurora-theme
       '@dxos/react-surface': link:../../../sdk/react-surface


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bf89f4f</samp>

### Summary
🛠️🌐📝

<!--
1.  🛠️ - This emoji represents the refactoring and improvement of the code quality and modularity.
2.  🌐 - This emoji represents the addition of localization and translation support for some plugins.
3.  📝 - This emoji represents the enhancement of the markdown plugin and editor.
-->
This pull request refactors several plugins in the `composer-app` and the `plugins` packages to use a new way of defining plugins with options and translations. It also extracts some components and hooks into separate modules for better modularity and readability. It updates the dependencies and the TypeScript configuration for the `plugin-markdown` package. It simplifies the use of the `useSplitView` hook from the `plugin-splitview` package in some components.

> _We are the plugins of the night_
> _We take the options and we fight_
> _We split the view and render markdown_
> _We are the `PluginDefinition`_

### Walkthrough
*  Refactored the plugin definitions to use functions that return `PluginDefinition` objects and accept options as parameters, instead of using the `definePlugin` function and relying on global variables. This allows more flexibility and customization for the plugins. ([link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-9f2aee287f92edd662c13bed460a28a1590c9186b62c98ccc2e00f6877c3d7e6L29-R38), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-aea39d106265440ec4ddf616421a86cb54f3f68c14c88956a8a5a63c5e4953eaL22-R23), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-15b4b90f8dd36dd22e5c39505234f42035120fbeedff4c196ddcbc7b6141bbc0L8-R8), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-15b4b90f8dd36dd22e5c39505234f42035120fbeedff4c196ddcbc7b6141bbc0L26-R26), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-98f0022554ff912e061aa7dd2697abe11577aa9cd51cca3397012071b9c43ee7L11-R14), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-14fc30ee2bdca55ef0efdd64b77d7562f47879a85bb361c6fbaf19f1d8cbee8dL9-R9), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-14fc30ee2bdca55ef0efdd64b77d7562f47879a85bb361c6fbaf19f1d8cbee8dL18-R18), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-2980bfaacf44efa379f06240cc85cd206bc5b09d919e1ecfb8b170c6c4d08cfdL23-R66), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-93bf3cf06a0c1cea035e8647088f2523ff84452883582dabc6e93e7cbcc8cb97L82-R107), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcL55-R24), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcL61-R81))
* Added the `TranslationsProvides` type to the plugins that provide translations for their components and messages, and added the `@braneframe/plugin-theme` package as a dependency for the `plugin-markdown` package, which uses the type. ([link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-aea39d106265440ec4ddf616421a86cb54f3f68c14c88956a8a5a63c5e4953eaL9-R10), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-e6d1d345821614148e5995e27dd43e3d23acd9c585a2ae3ef5911c496baf2ccdR23), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-e6d1d345821614148e5995e27dd43e3d23acd9c585a2ae3ef5911c496baf2ccdR35), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcL7-R17), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcL61-R81), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-030b5ff97a574c02bff3adfca5fc77e04e1d3f363554e532c6215bfa437c849fR40-R42))
* Extracted the `SplitViewContext` and the `useSplitView` hook from the `SplitViewPlugin` module to the `SplitViewContext` module, and renamed the hook to `useSplitView` for consistency and conciseness. The context and the hook provide the state and actions for the split view plugin. ([link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-fe01b6a7f487804ef4ffb91b14bbae55cd195ad142ec1fe023883ee31b00628eR1-R21), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-7ad9be5adb3c67069c1985ba4f8cc9bfd38cfae726a52c14dd88f464a75e3707L5-R32), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-15b4b90f8dd36dd22e5c39505234f42035120fbeedff4c196ddcbc7b6141bbc0L8-R8), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-15b4b90f8dd36dd22e5c39505234f42035120fbeedff4c196ddcbc7b6141bbc0L26-R26), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-14fc30ee2bdca55ef0efdd64b77d7562f47879a85bb361c6fbaf19f1d8cbee8dL9-R9), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-14fc30ee2bdca55ef0efdd64b77d7562f47879a85bb361c6fbaf19f1d8cbee8dL18-R18))
* Extracted the `SplitView`, `SplitViewMainContentEmpty`, `MarkdownMainEmbedded`, and `MarkdownMainEmpty` components from the `SplitViewPlugin` and `MarkdownPlugin` modules to separate modules, and exported them from the `index.ts` files of their respective packages. These components render the layouts and messages for the split view and markdown plugins. ([link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-e86be8a443d075eaa84629958372f8cde37821571c30d382fc579e5d63b132deR1-R64), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-0039de6c4ff5147aad39abf7a87f478360c1733e39fa353ac1b82c15948d5c8aR1-R29), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-ce1cec8cec5c14937048cb9cfa20c17cb3f652e2daeb4b112b7542a17ff1b65cR1-R6), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-60f17cc48f1121a02b693ca882d672da2e717bb724625f4cc60041b4e8d8519dR1-R19), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-0c8a57cf6192ebd1dc9b2c73122e3b17f0d594e779496b8d95c189041ea76070R1-R16), [link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-b9aab9fdb1841909f655db51abd09eff9ab87434b18748dd731cc36caec0b823R5-R6))
* Simplified the initialization of the `graph` object in the `GraphPlugin` module, which holds the root nodes and actions for the graph plugin. ([link](https://github.com/dxos/dxos/pull/3570/files?diff=unified&w=0#diff-93bf3cf06a0c1cea035e8647088f2523ff84452883582dabc6e93e7cbcc8cb97L69-R70))


