### PR TITLE
fix(telemetry): Use localhost to make request to local kube

### DIFF
--- a/packages/common/telemetry/src/tags.ts
+++ b/packages/common/telemetry/src/tags.ts
@@ -10,7 +10,9 @@ import { log } from '@dxos/log';
  * Intention is to use this to tag telemetry events as `internal`.
  */
 export const getLocalTelemetryTags = async (): Promise<string[]> => {
-  const localKubeConfigUrl = 'http://kube.local/.well-known/dx/config';
+  // NOTE: We use the local kube config to get the telemetry tags.
+  // We use localhost and not `kube.local` here because it is allowed to make requests to localhost without CORS.
+  const localKubeConfigUrl = 'http://localhost:80/.well-known/dx/config';
 
   log('fetching config...', { localKubeConfigUrl });
   try {

--- a/packages/ui/react-appkit/src/telemetry/telemetry.ts
+++ b/packages/ui/react-appkit/src/telemetry/telemetry.ts
@@ -90,6 +90,12 @@ export const initializeAppTelemetry = async ({
     BASE_TELEMETRY_PROPERTIES.environment = environment;
     const telemetryDisabled = await isTelemetryDisabled(namespace);
 
+    // Add telemetry tags.
+    const tags = await Telemetry.getLocalTelemetryTags();
+    if (tags) {
+      BASE_TELEMETRY_PROPERTIES.tags = tags.toString();
+    }
+
     const SENTRY_DESTINATION = config.get('runtime.app.env.DX_SENTRY_DESTINATION');
     Sentry.init({
       enable: Boolean(SENTRY_DESTINATION) && !telemetryDisabled,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at adecc20</samp>

### Summary
🛠️📊🐳

<!--
1.  🛠️ - This emoji represents fixing or improving something, which is what the change to `localKubeConfigUrl` does by avoiding CORS errors.
2.  📊 - This emoji represents data or analytics, which is what the change to `initializeAppTelemetry` does by adding telemetry tags to the app.
3.  🐳 - This emoji represents Docker or Kubernetes, which is what the local kube config and the telemetry tags are related to.
-->
Updated the telemetry module to fetch and send local kube config tags. This helps to track the app usage and performance in different local kube environments.

> _`localKubeConfigUrl`_
> _Changed to `localhost` - no CORS_
> _Telemetry tags fetched_

### Walkthrough
*  Use `localhost` instead of `kube.local` for local kube config URL to avoid CORS issues ([link](https://github.com/dxos/dxos/pull/3585/files?diff=unified&w=0#diff-678c44376f0bc653dbd51f602cf5613a21355a68763b4993abe799ec5328bf06L13-R15))
*  Fetch and add local kube telemetry tags to the base telemetry properties for the app ([link](https://github.com/dxos/dxos/pull/3585/files?diff=unified&w=0#diff-3cb02f1a6bbf72baefc80e1cc57f6fd4638751b5ba96ebc31f32b34c1ad07a4dR93-R98))


