### PR TITLE
feat(echo-pipeline): Make ECHO load only last epoch

### DIFF
--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -162,8 +162,10 @@ export class MetadataStore {
   async setSpaceControlLatestTimeframe(spaceKey: PublicKey, timeframe: Timeframe) {
     if (this._metadata.identity?.haloSpace.key.equals(spaceKey)) {
       this._metadata.identity.haloSpace.controlTimeframe = timeframe;
-    } else {
+    } else if (this._metadata.spaces?.length !== 0) {
       this._getSpace(spaceKey).controlTimeframe = timeframe;
+    } else {
+      return;
     }
     await this._save();
   }

--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -160,7 +160,11 @@ export class MetadataStore {
   }
 
   async setSpaceControlLatestTimeframe(spaceKey: PublicKey, timeframe: Timeframe) {
-    this._getSpace(spaceKey).controlTimeframe = timeframe;
+    if (this._metadata.identity?.haloSpace.key.equals(spaceKey)) {
+      this._metadata.identity.haloSpace.controlTimeframe = timeframe;
+    } else {
+      this._getSpace(spaceKey).controlTimeframe = timeframe;
+    }
     await this._save();
   }
 
@@ -176,4 +180,5 @@ export class MetadataStore {
     await this._save();
   }
 }
+
 const fromBytesInt32 = (buf: Buffer) => buf.readInt32LE(0);

--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -154,7 +154,7 @@ export class MetadataStore {
     await this._save();
   }
 
-  async setSpaceLatestTimeframe(spaceKey: PublicKey, timeframe: Timeframe) {
+  async setSpaceDataLatestTimeframe(spaceKey: PublicKey, timeframe: Timeframe) {
     this._getSpace(spaceKey).dataTimeframe = timeframe;
     await this._save();
   }

--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -119,6 +119,11 @@ export class MetadataStore {
   }
 
   _getSpace(spaceKey: PublicKey): SpaceMetadata {
+    if (this._metadata.identity?.haloSpace.key.equals(spaceKey)) {
+      // Check if the space is the identity space.
+      return this._metadata.identity.haloSpace;
+    }
+
     const space = this.spaces.find((space) => space.key === spaceKey);
     assert(space, 'Space not found');
     return space;
@@ -160,13 +165,7 @@ export class MetadataStore {
   }
 
   async setSpaceControlLatestTimeframe(spaceKey: PublicKey, timeframe: Timeframe) {
-    if (this._metadata.identity?.haloSpace.key.equals(spaceKey)) {
-      this._metadata.identity.haloSpace.controlTimeframe = timeframe;
-    } else if (this._metadata.spaces?.length !== 0) {
-      this._getSpace(spaceKey).controlTimeframe = timeframe;
-    } else {
-      return;
-    }
+    this._getSpace(spaceKey).controlTimeframe = timeframe;
     await this._save();
   }
 

--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -159,6 +159,11 @@ export class MetadataStore {
     await this._save();
   }
 
+  async setSpaceControlLatestTimeframe(spaceKey: PublicKey, timeframe: Timeframe) {
+    this._getSpace(spaceKey).controlTimeframe = timeframe;
+    await this._save();
+  }
+
   async setCache(spaceKey: PublicKey, cache: SpaceCache) {
     this._getSpace(spaceKey).cache = cache;
     await this._save();

--- a/packages/core/echo/echo-pipeline/src/space/control-pipeline.test.ts
+++ b/packages/core/echo/echo-pipeline/src/space/control-pipeline.test.ts
@@ -45,11 +45,13 @@ describe('space/control-pipeline', () => {
     const storage = createStorage({ type: StorageType.RAM });
     const directory = storage.createDirectory();
     const genesisFeed = await createFeed();
+    const metadata = new MetadataStore(directory);
+    await metadata.addSpace({ key: spaceKey, genesisFeedKey: genesisFeed.key, controlFeedKey: genesisFeed.key });
     const controlPipeline = new ControlPipeline({
       spaceKey,
       genesisFeed,
       feedProvider: (key) => feedStore.openFeed(key),
-      metadataStore: new MetadataStore(directory),
+      metadataStore: metadata,
     });
 
     const admittedFeeds: PublicKey[] = [];

--- a/packages/core/echo/echo-pipeline/src/space/control-pipeline.test.ts
+++ b/packages/core/echo/echo-pipeline/src/space/control-pipeline.test.ts
@@ -16,6 +16,7 @@ import { describe, test, afterTest } from '@dxos/test';
 import { Timeframe } from '@dxos/timeframe';
 
 import { valueEncoding } from '../common';
+import { MetadataStore } from '../metadata';
 import { ControlPipeline } from './control-pipeline';
 
 describe('space/control-pipeline', () => {
@@ -41,11 +42,14 @@ describe('space/control-pipeline', () => {
     };
 
     // TODO(dmaretskyi): Separate test for cold start after genesis.
+    const storage = createStorage({ type: StorageType.RAM });
+    const directory = storage.createDirectory();
     const genesisFeed = await createFeed();
     const controlPipeline = new ControlPipeline({
       spaceKey,
       genesisFeed,
       feedProvider: (key) => feedStore.openFeed(key),
+      metadataStore: new MetadataStore(directory),
     });
 
     const admittedFeeds: PublicKey[] = [];

--- a/packages/core/echo/echo-pipeline/src/space/control-pipeline.test.ts
+++ b/packages/core/echo/echo-pipeline/src/space/control-pipeline.test.ts
@@ -42,10 +42,8 @@ describe('space/control-pipeline', () => {
     };
 
     // TODO(dmaretskyi): Separate test for cold start after genesis.
-    const storage = createStorage({ type: StorageType.RAM });
-    const directory = storage.createDirectory();
     const genesisFeed = await createFeed();
-    const metadata = new MetadataStore(directory);
+    const metadata = new MetadataStore(createStorage({ type: StorageType.RAM }).createDirectory());
     await metadata.addSpace({ key: spaceKey, genesisFeedKey: genesisFeed.key, controlFeedKey: genesisFeed.key });
     const controlPipeline = new ControlPipeline({
       spaceKey,

--- a/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
@@ -130,7 +130,7 @@ export class ControlPipeline {
       await this._metadata.setSpaceControlLatestTimeframe(this._spaceKey, newTimeframe);
       this._targetTimeframe = newTimeframe;
     } catch (err: any) {
-      log.catch(err);
+      log(err);
     }
   }
 }

--- a/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
@@ -125,8 +125,12 @@ export class ControlPipeline {
   }
 
   private async _saveTargetTimeframe(timeframe: Timeframe) {
-    const newTimeframe = Timeframe.merge(this._targetTimeframe ?? new Timeframe(), timeframe);
-    await this._metadata.setSpaceControlLatestTimeframe(this._spaceKey, newTimeframe);
-    this._targetTimeframe = newTimeframe;
+    try {
+      const newTimeframe = Timeframe.merge(this._targetTimeframe ?? new Timeframe(), timeframe);
+      await this._metadata.setSpaceControlLatestTimeframe(this._spaceKey, newTimeframe);
+      this._targetTimeframe = newTimeframe;
+    } catch (err: any) {
+      log.catch(err);
+    }
   }
 }

--- a/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
@@ -111,7 +111,7 @@ export class ControlPipeline {
 
   private async _saveTargetTimeframe(timeframe: Timeframe) {
     const newTimeframe = Timeframe.merge(this._targetTimeframe ?? new Timeframe(), timeframe);
-    await this._metadata.setSpaceDataLatestTimeframe(this._spaceKey, newTimeframe);
+    await this._metadata.setSpaceControlLatestTimeframe(this._spaceKey, newTimeframe);
     this._targetTimeframe = newTimeframe;
   }
 }

--- a/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
@@ -233,7 +233,7 @@ export class DataPipeline {
 
   private async _saveTargetTimeframe(timeframe: Timeframe) {
     const newTimeframe = Timeframe.merge(this._targetTimeframe ?? new Timeframe(), timeframe);
-    await this._params.metadataStore.setSpaceLatestTimeframe(this._params.spaceKey, newTimeframe);
+    await this._params.metadataStore.setSpaceDataLatestTimeframe(this._params.spaceKey, newTimeframe);
     this._targetTimeframe = newTimeframe;
   }
 

--- a/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
@@ -110,8 +110,8 @@ export class DataPipeline {
         if (this._isOpen) {
           // process epoch
           log('new epoch', { credential });
-          await this._processEpoch(credential.subject.assertion);
           this.currentEpoch = credential;
+          await this._processEpoch(credential.subject.assertion);
           this.onNewEpoch.emit(credential);
         } else {
           // remember epoch

--- a/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
@@ -187,7 +187,6 @@ export class DataPipeline {
   }
 
   private async _consumePipeline() {
-    // Load epoch if it is not genesis epoch.
     if (this.currentEpoch) {
       await this._processEpoch(this.currentEpoch.subject.assertion);
       this.onNewEpoch.emit(this.currentEpoch);

--- a/packages/core/echo/echo-pipeline/src/space/space.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space.ts
@@ -245,8 +245,8 @@ export class Space {
   async initializeDataPipeline() {
     log('initializeDataPipeline');
     assert(this._isOpen, 'Space must be open to initialize data pipeline.');
-    await this._dataPipeline.open();
     assert(this._dataPipelineCredentialConsumer);
     await this._dataPipelineCredentialConsumer.open();
+    await this._dataPipeline.open();
   }
 }

--- a/packages/core/echo/echo-pipeline/src/space/space.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space.ts
@@ -219,6 +219,8 @@ export class Space {
       this._dataPipeline.createCredentialProcessor(),
     );
 
+    await this._dataPipelineCredentialConsumer.open();
+
     this._isOpen = true;
     log('opened');
   }
@@ -246,8 +248,6 @@ export class Space {
   async initializeDataPipeline() {
     log('initializeDataPipeline');
     assert(this._isOpen, 'Space must be open to initialize data pipeline.');
-    assert(this._dataPipelineCredentialConsumer);
-    await this._dataPipelineCredentialConsumer.open();
     await this._dataPipeline.open();
   }
 }

--- a/packages/core/echo/echo-pipeline/src/space/space.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space.ts
@@ -81,6 +81,7 @@ export class Space {
       spaceKey: params.spaceKey,
       genesisFeed: params.genesisFeed,
       feedProvider: params.feedProvider,
+      metadataStore: params.metadataStore,
     });
 
     // TODO(dmaretskyi): Feed set abstraction.

--- a/packages/sdk/client-services/src/packlets/identity/identity.test.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity.test.ts
@@ -180,6 +180,8 @@ describe('identity/identity', () => {
         }),
       });
 
+      const metadata = new MetadataStore(createStorage({ type: StorageType.RAM }).createDirectory());
+      await metadata.setIdentityRecord({ haloSpace: { key: spaceKey }, identityKey, deviceKey });
       const space = new Space({
         spaceKey,
         protocol,
@@ -187,7 +189,7 @@ describe('identity/identity', () => {
         feedProvider: (feedKey) => feedStore.openFeed(feedKey),
         memberKey: identityKey,
         modelFactory: createDefaultModelFactory(),
-        metadataStore: new MetadataStore(createStorage({ type: StorageType.RAM }).createDirectory()),
+        metadataStore: metadata,
         snapshotManager: new SnapshotManager(
           new SnapshotStore(createStorage({ type: StorageType.RAM }).createDirectory()),
         ),
@@ -265,6 +267,8 @@ describe('identity/identity', () => {
         }),
       });
 
+      const metadata = new MetadataStore(createStorage({ type: StorageType.RAM }).createDirectory());
+      await metadata.setIdentityRecord({ haloSpace: { key: spaceKey }, identityKey: identity1.identityKey, deviceKey });
       const space = new Space({
         spaceKey,
         protocol,
@@ -272,7 +276,7 @@ describe('identity/identity', () => {
         feedProvider: (feedKey) => feedStore.openFeed(feedKey),
         memberKey: identityKey,
         modelFactory: createDefaultModelFactory(),
-        metadataStore: new MetadataStore(createStorage({ type: StorageType.RAM }).createDirectory()),
+        metadataStore: metadata,
         snapshotManager: new SnapshotManager(
           new SnapshotStore(createStorage({ type: StorageType.RAM }).createDirectory()),
         ),

--- a/packages/sdk/client-services/src/packlets/identity/identity.test.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity.test.ts
@@ -66,6 +66,8 @@ describe('identity/identity', () => {
       }),
     });
 
+    const metadata = new MetadataStore(createStorage({ type: StorageType.RAM }).createDirectory());
+    await metadata.setIdentityRecord({ haloSpace: { key: spaceKey }, identityKey, deviceKey });
     const space: Space = new Space({
       spaceKey,
       protocol,
@@ -73,7 +75,7 @@ describe('identity/identity', () => {
       feedProvider: (feedKey) => feedStore.openFeed(feedKey),
       memberKey: identityKey,
       modelFactory: createDefaultModelFactory(),
-      metadataStore: new MetadataStore(createStorage({ type: StorageType.RAM }).createDirectory()),
+      metadataStore: metadata,
       snapshotManager: new SnapshotManager(
         new SnapshotStore(createStorage({ type: StorageType.RAM }).createDirectory()),
       ),

--- a/packages/sdk/client-services/src/packlets/spaces/data-space-manager.test.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space-manager.test.ts
@@ -262,12 +262,9 @@ describe('DataSpaceManager', () => {
         spaceKey = space.key;
         await space.inner.controlPipeline.state.waitUntilTimeframe(space.inner.controlPipeline.state.endTimeframe);
 
-        for (const index of range(epochsNumber)) {
+        for (const _ of range(epochsNumber)) {
           await testLocalDatabase(space.dataPipeline);
           await space.createEpoch();
-          await space.dataPipeline.onNewEpoch.waitForCondition(
-            () => space.dataPipeline.currentEpoch?.subject?.assertion?.number === index + 1,
-          );
         }
         await space.close();
         await dataSpaceManager.close();

--- a/packages/sdk/client-services/src/packlets/spaces/data-space.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space.ts
@@ -189,7 +189,6 @@ export class DataSpace {
     }
     this._state = SpaceState.INITIALIZING;
 
-    // TODO(dmaretskyi): Cancel with context.
     await this._inner.controlPipeline.state.waitUntilReachedTargetTimeframe({
       ctx: this._ctx,
       breakOnStall: false,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at efd3b7f</samp>

### Summary
🔄🚦🚀

<!--
1.  🔄 This emoji represents the changes related to the metadata store and the different timeframes for data and control messages. It suggests the idea of updating and synchronizing the metadata for each space and pipeline.
2.  🚦 This emoji represents the changes related to the control pipeline and its role in managing the status and progress of the spaces. It suggests the idea of signaling and coordinating the data pipeline and the epoch creation process.
3.  🚀 This emoji represents the changes related to the data pipeline and its improved efficiency and reliability. It suggests the idea of speeding up and optimizing the data processing and loading.
-->
This pull request enhances the echo pipeline functionality and reliability by using a metadata store to track the progress and status of data and control messages in echo spaces. It also fixes some bugs and improves the test coverage for the identity and data space modules. It affects the files `metadata-store.ts`, `control-pipeline.ts`, `control-pipeline.test.ts`, `data-pipeline.ts`, `space.ts`, `identity.test.ts`, `data-space-manager.test.ts`, and `data-space.ts`.

> _We are the masters of the echo spaces_
> _We control the data and the messages_
> _We track the timeframes with the metadata_
> _We face the challenges of the pipelines_

### Walkthrough
*  Rename `setSpaceLatestTimeframe` to `setSpaceDataLatestTimeframe` in `MetadataStore` class and `DataPipeline` class to distinguish from new `setSpaceControlLatestTimeframe` method ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-ad1c28ba5710e2ea59c29b77568da4f157118487250877e42876eca69494a42cL157-R172), [link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-0e718439dcb670515a37fa6bd2c8409cdad48857580582122ed27e37b72460b3L226-R238))
* Add `setSpaceControlLatestTimeframe` method to `MetadataStore` class to update control timeframe for each space and check if it belongs to identity halo space ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-ad1c28ba5710e2ea59c29b77568da4f157118487250877e42876eca69494a42cR185))
* Add `metadataStore` parameter to `ControlPipeline` constructor and class fields, and import `Timeframe` and `MetadataStore` modules in `control-pipeline.ts` ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-e114ce2da53e9b886ff8dfee0e839dd07ef3720ed2c515782f28030b870a04c0L11-R14), [link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-e114ce2da53e9b886ff8dfee0e839dd07ef3720ed2c515782f28030b870a04c0L19-R25), [link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-e114ce2da53e9b886ff8dfee0e839dd07ef3720ed2c515782f28030b870a04c0L28-R44))
* Add `_noteTargetStateIfNeeded` method to `ControlPipeline` class to save target control timeframe to metadata store with debouncing and error handling, and invoke it after processing credential ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-e114ce2da53e9b886ff8dfee0e839dd07ef3720ed2c515782f28030b870a04c0R96-R97))
* Add call to `_saveTargetTimeframe` method in `ControlPipeline` stop method to ensure latest control timeframe is saved before closing ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-e114ce2da53e9b886ff8dfee0e839dd07ef3720ed2c515782f28030b870a04c0L96-R135))
* Add `metadataStore` parameter to `ControlPipeline` constructor call in `Space` class `open` method ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-863b14285a11ec21fd44fe41e630f84b8609a6239e679688b4850004ef6c491bR84))
* Add `_lastProcessedEpoch` field to `DataPipeline` class to avoid processing same epoch multiple times ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-0e718439dcb670515a37fa6bd2c8409cdad48857580582122ed27e37b72460b3R83), [link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-0e718439dcb670515a37fa6bd2c8409cdad48857580582122ed27e37b72460b3R282-R285))
* Add condition in `DataPipeline` class `_processCredential` method to check if data pipeline is open before processing epoch credential, and set `currentEpoch` field otherwise ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-0e718439dcb670515a37fa6bd2c8409cdad48857580582122ed27e37b72460b3L109-R120))
* Add block of code in `DataPipeline` class `open` method to process and emit `currentEpoch` if set ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-0e718439dcb670515a37fa6bd2c8409cdad48857580582122ed27e37b72460b3R190-R194))
* Change order of `open` calls for `dataPipeline` and `dataPipelineCredentialConsumer` in `Space` class `initializeDataPipeline` method to ensure data pipeline receives latest epoch credential when opening ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-863b14285a11ec21fd44fe41e630f84b8609a6239e679688b4850004ef6c491bL248-R251))
* Create storage, directory, and metadata store instances and populate identity record before creating identity service instance in `identity.test.ts` ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-0de952ae05fa494d9607d9d5ca3bdaa0adda55a3354f680bc55043626009ddb8R69-R70), [link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-0de952ae05fa494d9607d9d5ca3bdaa0adda55a3354f680bc55043626009ddb8R183-R184), [link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-0de952ae05fa494d9607d9d5ca3bdaa0adda55a3354f680bc55043626009ddb8R270-R271))
* Pass existing metadata store instance to `DataSpaceManager` constructor call instead of creating new one in `identity.test.ts` ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-0de952ae05fa494d9607d9d5ca3bdaa0adda55a3354f680bc55043626009ddb8L76-R78), [link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-0de952ae05fa494d9607d9d5ca3bdaa0adda55a3354f680bc55043626009ddb8L188-R192), [link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-0de952ae05fa494d9607d9d5ca3bdaa0adda55a3354f680bc55043626009ddb8L273-R279))
* Import `SpecificCredential`, `PublicKey`, `Epoch`, and `Timeframe` modules in `data-space-manager.test.ts` ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-1cc613a11bb526d6f2316c82be2991bf133e8cf8df85e5b3d446ac4ee0973f82L9-R15))
* Add test case `test('Loads only last epoch')` in `data-space-manager.test.ts` to test data pipeline functionality to load only last epoch when opening space with multiple epochs ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-1cc613a11bb526d6f2316c82be2991bf133e8cf8df85e5b3d446ac4ee0973f82R238-R298))
* Remove TODO comment in `data-space.ts` `createEpoch` method ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-c17bc7f7884d49b4cbcdce4bb1ff4ec783c7b397b92c9661d78bc3517092ab3dL192))
* Assign return value of `write` method to `receipt` constant in `data-space.ts` `createEpoch` method ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-c17bc7f7884d49b4cbcdce4bb1ff4ec783c7b397b92c9661d78bc3517092ab3dL288-R288))
* Add call to `waitUntilTimeframe` method with new timeframe that covers written message in `data-space.ts` `createEpoch` method ([link](https://github.com/dxos/dxos/pull/3586/files?diff=unified&w=0#diff-c17bc7f7884d49b4cbcdce4bb1ff4ec783c7b397b92c9661d78bc3517092ab3dR300-R301))

