### PR TITLE
test(react-shell): fix invitations tests

### DIFF
--- a/packages/sdk/react-client/src/invitations/useInvitationStatus.ts
+++ b/packages/sdk/react-client/src/invitations/useInvitationStatus.ts
@@ -180,14 +180,6 @@ export const useInvitationStatus = (initialObservable?: CancellableInvitationObs
       authMethod: invitation?.authMethod,
     };
 
-    // TODO(wittjosiah): Remove. Playwright currently only supports reading clipboard in chromium.
-    //   https://github.com/microsoft/playwright/issues/13037
-    if (result.status === Invitation.State.READY_FOR_AUTHENTICATION && result.authCode) {
-      log.info(JSON.stringify({ authCode: result.authCode }));
-    } else if (result.status === Invitation.State.INIT && result.invitationCode) {
-      log.info(JSON.stringify({ invitationCode: result.invitationCode }));
-    }
-
     return result;
   }, [state, cancel, connect, authenticate]);
 };

--- a/packages/sdk/react-shell/project.json
+++ b/packages/sdk/react-shell/project.json
@@ -70,8 +70,7 @@
       },
       "executor": "@nrwl/storybook:storybook",
       "options": {
-        "configDir": "packages/sdk/react-shell/.storybook",
-        "uiFramework": "@storybook/react"
+        "configDir": "packages/sdk/react-shell/.storybook"
       }
     }
   },

--- a/packages/sdk/react-shell/src/panels/SpacePanel/SpacePanel.tsx
+++ b/packages/sdk/react-shell/src/panels/SpacePanel/SpacePanel.tsx
@@ -28,17 +28,14 @@ const CurrentSpaceView = observer(({ space, createInvitationUrl, titleId }: Spac
   const invitations = useSpaceInvitations(space?.key);
   const name = space?.properties.name;
 
-  console.log('[space panel]', process.env.NODE_ENV);
-
   if (!space) {
     return null;
   }
 
   const onInvitationEvent = useCallback((invitation: Invitation) => {
     const invitationCode = InvitationEncoder.encode(invitation);
-    console.log(JSON.stringify({ invitationCode }));
-    if (invitation.authCode) {
-      console.log(JSON.stringify({ authCode: invitation.authCode }));
+    if (invitation.state === Invitation.State.CONNECTING) {
+      console.log(JSON.stringify({ invitationCode, authCode: invitation.authCode }));
     }
   }, []);
 
@@ -60,6 +57,7 @@ const CurrentSpaceView = observer(({ space, createInvitationUrl, titleId }: Spac
           classNames='is-full flex gap-2 mbs-2'
           onClick={() => {
             const invitation = space?.createInvitation();
+            // TODO(wittjosiah): Don't depend on NODE_ENV.
             if (process.env.NODE_ENV !== 'production') {
               invitation.subscribe(onInvitationEvent);
             }

--- a/packages/sdk/react-shell/src/playwright/invitations.spec.ts
+++ b/packages/sdk/react-shell/src/playwright/invitations.spec.ts
@@ -30,9 +30,11 @@ test.describe('Invitations', () => {
       await manager.createIdentity(0);
       await manager.openPanel(0, 'devices');
       const invitation = await manager.createInvitation(0, 'device');
+      const authCode = await manager.getAuthCode();
 
       await manager.openPanel(1, 'identity');
-      const [authCode] = await Promise.all([manager.getAuthCode(), manager.acceptInvitation(1, 'device', invitation)]);
+      await manager.acceptInvitation(1, 'device', invitation);
+      await manager.readyToAuthenticate('device', manager.peer(1));
       await manager.authenticateInvitation('device', authCode, manager.peer(1));
       await manager.doneInvitation('device', manager.peer(1));
 
@@ -57,9 +59,10 @@ test.describe('Invitations', () => {
       await manager.createIdentity(0);
       await manager.openPanel(0, 'devices');
       const invitation = await manager.createInvitation(0, 'device');
+      const authCode = await manager.getAuthCode();
 
       await manager.openPanel(1, 'identity');
-      const [authCode] = await Promise.all([manager.getAuthCode(), manager.acceptInvitation(1, 'device', invitation)]);
+      await manager.acceptInvitation(1, 'device', invitation);
       await manager.authenticateInvitation('device', '000000', manager.peer(1));
       await manager.clearAuthCode('device', manager.peer(1));
       await manager.authenticateInvitation('device', authCode, manager.peer(1));
@@ -74,6 +77,7 @@ test.describe('Invitations', () => {
       await manager.createIdentity(0);
       await manager.openPanel(0, 'devices');
       const invitation = await manager.createInvitation(0, 'device');
+      const authCode = await manager.getAuthCode();
 
       await manager.openPanel(1, 'identity');
       await manager.acceptInvitation(1, 'device', invitation);
@@ -88,9 +92,7 @@ test.describe('Invitations', () => {
 
       await manager.resetInvitation(manager.peer(1));
       await manager.invitationInputContinue('device', manager.peer(1));
-
-      const [authCode] = await Promise.all([manager.getAuthCode(), manager.clearAuthCode('device', manager.peer(1))]);
-
+      await manager.clearAuthCode('device', manager.peer(1));
       await manager.authenticateInvitation('device', authCode, manager.peer(1));
       await manager.doneInvitation('device', manager.peer(1));
 
@@ -125,13 +127,14 @@ test.describe('Invitations', () => {
       await manager.createIdentity(0);
       await manager.openPanel(0, 'devices');
       const invitation = await manager.createInvitation(0, 'device');
+      const authCode = await manager.getAuthCode();
 
       await manager.openPanel(1, 'identity');
       await manager.acceptInvitation(1, 'device', invitation);
       await manager.cancelInvitation('device', 'guest', manager.peer(1));
       await manager.resetInvitation(manager.peer(1));
       await manager.invitationInputContinue('device', manager.peer(1));
-      const [authCode] = await Promise.all([manager.getAuthCode(), manager.clearAuthCode('device', manager.peer(1))]);
+      await manager.clearAuthCode('device', manager.peer(1));
       await manager.authenticateInvitation('device', authCode, manager.peer(1));
       await manager.doneInvitation('device', manager.peer(1));
 
@@ -144,6 +147,7 @@ test.describe('Invitations', () => {
       await manager.createIdentity(0);
       await manager.openPanel(0, 'devices');
       const invitation = await manager.createInvitation(0, 'device');
+      const authCode = await manager.getAuthCode();
 
       await manager.openPanel(1, 'identity');
       await manager.acceptInvitation(1, 'device', invitation);
@@ -154,7 +158,7 @@ test.describe('Invitations', () => {
       expect(await manager.getNetworkStatus(0)).to.equal(ConnectionState.ONLINE);
       await manager.resetInvitation(manager.peer(1));
       await manager.invitationInputContinue('device', manager.peer(1));
-      const [authCode] = await Promise.all([manager.getAuthCode(), manager.clearAuthCode('device', manager.peer(1))]);
+      await manager.clearAuthCode('device', manager.peer(1));
       await manager.authenticateInvitation('device', authCode, manager.peer(1));
       await manager.doneInvitation('device', manager.peer(1));
 
@@ -171,16 +175,14 @@ test.describe('Invitations', () => {
 
       // TODO(wittjosiah): Improve auth code fetching to make it easier to disambiguate them.
       const invitation1 = await manager.createInvitation(0, 'device');
-      const [authCode1] = await Promise.all([
-        manager.getAuthCode(),
-        manager.acceptInvitation(1, 'device', invitation1),
-      ]);
+      const authCode1 = await manager.getAuthCode();
+      await manager.acceptInvitation(1, 'device', invitation1);
+      await manager.readyToAuthenticate('space', manager.peer(1));
 
       const invitation2 = await manager.createInvitation(0, 'device');
-      const [authCode2] = await Promise.all([
-        manager.getAuthCode(),
-        manager.acceptInvitation(2, 'device', invitation2),
-      ]);
+      const authCode2 = await manager.getAuthCode();
+      await manager.acceptInvitation(2, 'device', invitation2);
+      await manager.readyToAuthenticate('space', manager.peer(2));
 
       await manager.authenticateInvitation('device', authCode1, manager.peer(1));
       // TODO(wittjosiah): Managing focus in tests is flaky.
@@ -202,10 +204,12 @@ test.describe('Invitations', () => {
       await manager.createSpace(0);
       await manager.openPanel(0, 0);
       const invitation = await manager.createInvitation(0, 'space');
+      const authCode = await manager.getAuthCode();
 
       await manager.createIdentity(1);
       await manager.openPanel(1, 'join');
-      const [authCode] = await Promise.all([manager.getAuthCode(), manager.acceptInvitation(1, 'space', invitation)]);
+      await manager.acceptInvitation(1, 'space', invitation);
+      await manager.readyToAuthenticate('space', manager.peer(1));
       await manager.authenticateInvitation('space', authCode, manager.peer(1));
       await manager.doneInvitation('space', manager.peer(1));
 
@@ -235,10 +239,11 @@ test.describe('Invitations', () => {
       await manager.createSpace(0);
       await manager.openPanel(0, 0);
       const invitation = await manager.createInvitation(0, 'space');
+      const authCode = await manager.getAuthCode();
 
       await manager.createIdentity(1);
       await manager.openPanel(1, 'join');
-      const [authCode] = await Promise.all([manager.getAuthCode(), manager.acceptInvitation(1, 'space', invitation)]);
+      await manager.acceptInvitation(1, 'space', invitation);
       await manager.authenticateInvitation('space', '000000', manager.peer(1));
 
       expect(await manager.authenticatorIsVisible('space', manager.peer(1))).to.be.true;
@@ -258,6 +263,7 @@ test.describe('Invitations', () => {
       await manager.createSpace(0);
       await manager.openPanel(0, 0);
       const invitation = await manager.createInvitation(0, 'space');
+      const authCode = await manager.getAuthCode();
 
       await manager.createIdentity(1);
       await manager.openPanel(1, 'join');
@@ -273,9 +279,7 @@ test.describe('Invitations', () => {
 
       await manager.resetInvitation(manager.peer(1));
       await manager.invitationInputContinue('space', manager.peer(1));
-
-      const [authCode] = await Promise.all([manager.getAuthCode(), manager.clearAuthCode('space', manager.peer(1))]);
-
+      await manager.clearAuthCode('space', manager.peer(1));
       await manager.authenticateInvitation('space', authCode, manager.peer(1));
       await manager.doneInvitation('space', manager.peer(1));
 
@@ -316,6 +320,7 @@ test.describe('Invitations', () => {
       await manager.createSpace(0);
       await manager.openPanel(0, 0);
       const invitation = await manager.createInvitation(0, 'space');
+      const authCode = await manager.getAuthCode();
 
       await manager.createIdentity(1);
       await manager.openPanel(1, 'join');
@@ -323,9 +328,7 @@ test.describe('Invitations', () => {
       await manager.cancelInvitation('space', 'guest', manager.peer(1));
       await manager.resetInvitation(manager.peer(1));
       await manager.invitationInputContinue('space', manager.peer(1));
-
-      const [authCode] = await Promise.all([manager.getAuthCode(), manager.clearAuthCode('space', manager.peer(1))]);
-
+      await manager.clearAuthCode('space', manager.peer(1));
       await manager.authenticateInvitation('space', authCode, manager.peer(1));
       await manager.doneInvitation('space', manager.peer(1));
 
@@ -340,6 +343,7 @@ test.describe('Invitations', () => {
       await manager.createSpace(0);
       await manager.openPanel(0, 0);
       const invitation = await manager.createInvitation(0, 'space');
+      const authCode = await manager.getAuthCode();
 
       await manager.createIdentity(1);
       await manager.openPanel(1, 'join');
@@ -351,7 +355,7 @@ test.describe('Invitations', () => {
       expect(await manager.getNetworkStatus(0)).to.equal(ConnectionState.ONLINE);
       await manager.resetInvitation(manager.peer(1));
       await manager.invitationInputContinue('space', manager.peer(1));
-      const [authCode] = await Promise.all([manager.getAuthCode(), manager.clearAuthCode('space', manager.peer(1))]);
+      await manager.clearAuthCode('space', manager.peer(1));
       await manager.authenticateInvitation('space', authCode, manager.peer(1));
       await manager.doneInvitation('space', manager.peer(1));
 
@@ -372,12 +376,17 @@ test.describe('Invitations', () => {
       await manager.openPanel(2, 'join');
 
       const invitation1 = await manager.createInvitation(0, 'space');
-      const [authCode1] = await Promise.all([manager.getAuthCode(), manager.acceptInvitation(1, 'space', invitation1)]);
+      const authCode1 = await manager.getAuthCode();
+      await manager.acceptInvitation(1, 'space', invitation1);
+      await manager.readyToAuthenticate('space', manager.peer(1));
 
       const invitation2 = await manager.createInvitation(0, 'space');
-      const [authCode2] = await Promise.all([manager.getAuthCode(), manager.acceptInvitation(2, 'space', invitation2)]);
+      const authCode2 = await manager.getAuthCode();
+      await manager.acceptInvitation(2, 'space', invitation2);
+      await manager.readyToAuthenticate('space', manager.peer(2));
 
       await manager.authenticateInvitation('space', authCode1, manager.peer(1));
+      // TODO(wittjosiah): Managing focus in tests is flaky.
       // Helps to ensure both auth codes are fully input (especially in webkit).
       await sleep(100);
       await manager.authenticateInvitation('space', authCode2, manager.peer(2));


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cd33296</samp>

### Summary
🗑️🔧📝

<!--
1.  🗑️ - This emoji represents the removal of temporary or unused code, such as the logging code and the Storybook option. It conveys the idea of cleaning up or deleting something.
2.  🔧 - This emoji represents the addition or modification of logic or functionality, such as the invitation creation and subscription in the DevicesPanel, the console handler in the browser, and the test cases in Playwright. It conveys the idea of fixing or improving something.
3.  📝 - This emoji represents the documentation or comment of code, such as the comment in the CurrentSpaceView component and the use of types and hooks in the Invitations story. It conveys the idea of writing or explaining something.
-->
This pull request improves the invitation process for device authentication in the `react-shell` package. It adds logic to create and subscribe to invitations in non-production environments, cleans up and documents the code, updates the Playwright tests and the Storybook story, and removes some unnecessary logging and configuration.

> _We're testing invitations for the devices and spaces_
> _We're cleaning up the logging and the storybook cases_
> _We're heaving on the code with the `Playwright` tool_
> _We're sailing to production with the `react-shell` crew_

### Walkthrough
*  Remove temporary logging code and unused option from react-client and react-shell packages ([link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-84e9274d409976705203542e74f34a4438c268b9d52bef68371b5f44c0a53964L183-L190), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-61551fbaee4d4bfef4f05249588c26fec31f9fe60a3e178b0a889a8d8dac43e6L73-R73), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-edbaf604d79d86cbe45401c32e8d5cc44bab1727f1f341494f436c3781d1075eL31-L32))
*  Add missing imports and callback function for invitation events to DevicesPanel component ([link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-15b29e4cc5d29c17ccd9baf5aed3b87f8b1e04c1f95b09c7966fcc17c20bc7e4L6-R18), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-15b29e4cc5d29c17ccd9baf5aed3b87f8b1e04c1f95b09c7966fcc17c20bc7e4R44-R50))
*  Modify click handler for create invitation button in DeviceListView component to use client.halo.createInvitation and onInvitationEvent ([link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-15b29e4cc5d29c17ccd9baf5aed3b87f8b1e04c1f95b09c7966fcc17c20bc7e4L65-R85))
*  Modify callback function for invitation events in CurrentSpaceView component to log codes only when state is CONNECTING ([link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-edbaf604d79d86cbe45401c32e8d5cc44bab1727f1f341494f436c3781d1075eL39-R38))
*  Add comment to CurrentSpaceView component to indicate temporary solution and technical debt for NODE_ENV check ([link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-edbaf604d79d86cbe45401c32e8d5cc44bab1727f1f341494f436c3781d1075eR60))
*  Remove unused property and modify createInvitation method and onConsole handler of InvitationsManager class to align with browser logic and simplify communication ([link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-0053cf11150ff6583dacdfad2ade49c57238e280a30cab19e986c4e4b1e420b1L73), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-0053cf11150ff6583dacdfad2ade49c57238e280a30cab19e986c4e4b1e420b1L124-R137), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-0053cf11150ff6583dacdfad2ade49c57238e280a30cab19e986c4e4b1e420b1L160-R161))
*  Modify Playwright test cases for device and space invitations to wait for authentication code and invitation state after creating invitation, and remove parallel waiting and clearing of authentication code ([link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48L33-R37), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48L60-R65), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48R80), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48L91-R95), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48R130), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48L134-R137), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48R150), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48L157-R161), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48L174-R185), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48L205-R212), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48L238-R246), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48R266), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48L276-R282), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48R323), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48L326-R331), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48R346), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48L354-R358), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-e55496245609a6b91e2ca46c24bd313928f3979e51bed6ced35f684bdefece48L375-R389))
*  Add missing imports and define functions on window object for invitation creation and subscription in Panel and Invitations components of Invitations story ([link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-6c8185a1cee3d2c5921f5a83f2cb626f3f9c343f4349da31f32e8778cc9f3a5aL12-R22), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-6c8185a1cee3d2c5921f5a83f2cb626f3f9c343f4349da31f32e8778cc9f3a5aL34-R51), [link](https://github.com/dxos/dxos/pull/3587/files?diff=unified&w=0#diff-6c8185a1cee3d2c5921f5a83f2cb626f3f9c343f4349da31f32e8778cc9f3a5aL107-R133))


