### PR TITLE
feat(echo-pipeline): Cancel Epoch download if there is new Epoch detected

### DIFF
--- a/packages/core/echo/echo-pipeline/src/dbhost/snapshot-manager.ts
+++ b/packages/core/echo/echo-pipeline/src/dbhost/snapshot-manager.ts
@@ -64,7 +64,7 @@ export class SnapshotManager {
       return local;
     }
 
-    const remote = await cancelWithContext(ctx, this._objectSync.download(id));
+    const remote = await cancelWithContext(ctx, this._objectSync.download({ id, ctx }));
     return schema.getCodecForType('dxos.echo.snapshot.SpaceSnapshot').decode((remote.payload as Any).value);
   }
 

--- a/packages/core/echo/echo-pipeline/src/dbhost/snapshot-manager.ts
+++ b/packages/core/echo/echo-pipeline/src/dbhost/snapshot-manager.ts
@@ -4,6 +4,7 @@
 
 import { trackLeaks } from '@dxos/async';
 import { Any } from '@dxos/codec-protobuf';
+import { Context, cancelWithContext } from '@dxos/context';
 import { timed } from '@dxos/debug';
 import { log } from '@dxos/log';
 import { schema } from '@dxos/protocols';
@@ -57,13 +58,13 @@ export class SnapshotManager {
   }
 
   @timed(10_000)
-  async load(id: string): Promise<SpaceSnapshot> {
-    const local = await this._snapshotStore.loadSnapshot(id);
+  async load(ctx: Context, id: string): Promise<SpaceSnapshot> {
+    const local = await cancelWithContext(ctx, this._snapshotStore.loadSnapshot(id));
     if (local) {
       return local;
     }
 
-    const remote = await this._objectSync.download(id);
+    const remote = await cancelWithContext(ctx, this._objectSync.download(id));
     return schema.getCodecForType('dxos.echo.snapshot.SpaceSnapshot').decode((remote.payload as Any).value);
   }
 

--- a/packages/core/echo/echo-pipeline/src/dbhost/snapshot-manager.ts
+++ b/packages/core/echo/echo-pipeline/src/dbhost/snapshot-manager.ts
@@ -64,7 +64,7 @@ export class SnapshotManager {
       return local;
     }
 
-    const remote = await cancelWithContext(ctx, this._objectSync.download({ id, ctx }));
+    const remote = await cancelWithContext(ctx, this._objectSync.download(ctx, id));
     return schema.getCodecForType('dxos.echo.snapshot.SpaceSnapshot').decode((remote.payload as Any).value);
   }
 

--- a/packages/core/echo/echo-pipeline/src/space/space.test.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space.test.ts
@@ -16,7 +16,7 @@ import { TestAgentBuilder, testLocalDatabase } from '../testing';
 const run = <T>(cb: () => Promise<T>): Promise<T> => cb();
 
 describe('space/space', () => {
-  test('crates a database with object model', async () => {
+  test.only('creates a database with object model', async () => {
     const builder = new TestAgentBuilder();
     afterTest(async () => await builder.close());
     const agent = await builder.createPeer();

--- a/packages/core/echo/echo-pipeline/src/space/space.test.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space.test.ts
@@ -7,7 +7,6 @@ import assert from 'node:assert';
 import { promisify } from 'node:util';
 
 import { createCredential, CredentialGenerator } from '@dxos/credentials';
-import { log } from '@dxos/log';
 import { afterTest, describe, test } from '@dxos/test';
 
 import { TestAgentBuilder, testLocalDatabase } from '../testing';
@@ -16,7 +15,7 @@ import { TestAgentBuilder, testLocalDatabase } from '../testing';
 const run = <T>(cb: () => Promise<T>): Promise<T> => cb();
 
 describe('space/space', () => {
-  test.only('creates a database with object model', async () => {
+  test('creates a database with object model', async () => {
     const builder = new TestAgentBuilder();
     afterTest(async () => await builder.close());
     const agent = await builder.createPeer();
@@ -210,8 +209,6 @@ describe('space/space', () => {
     // Clear the data feed - epoch snapshot should have the data.
     const feed = await agent.feedStore.openFeed(space1.dataFeedKey!);
     await promisify(feed.core.clear.bind(feed.core))(0, feed.length);
-
-    log.break();
 
     // Re-open.
     const space2 = await agent.createSpace(agent.identityKey, space1.key, space1.genesisFeedKey, space1.dataFeedKey);

--- a/packages/core/echo/echo-pipeline/src/testing/util.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/util.ts
@@ -73,6 +73,6 @@ export const testLocalDatabase = async (create: DataPipeline, check: DataPipelin
 
   await asyncTimeout(
     check.databaseHost!._itemDemuxer.mutation.waitForCondition(() => check.itemManager.entities.has(objectId)),
-    500,
+    1000,
   );
 };

--- a/packages/core/mesh/teleport-extension-object-sync/src/object-sync.test.ts
+++ b/packages/core/mesh/teleport-extension-object-sync/src/object-sync.test.ts
@@ -177,7 +177,7 @@ describe('ObjectSync', () => {
         ),
     });
 
-    await testBuilder.connzwect(peer1, peer2);
+    await testBuilder.connect(peer1, peer2);
 
     const ctx1 = new Context();
     const obj1 = peer2.objectSync.download({ id: 'test', ctx: ctx1 });

--- a/packages/core/mesh/teleport-extension-object-sync/src/object-sync.test.ts
+++ b/packages/core/mesh/teleport-extension-object-sync/src/object-sync.test.ts
@@ -70,7 +70,7 @@ describe('ObjectSync', () => {
 
     await testBuilder.connect(peer1, peer2);
 
-    const obj = await peer2.objectSync.download({ id: 'test' });
+    const obj = await peer2.objectSync.download(new Context(), 'test');
     expect(obj).toEqual({
       id: 'test',
       payload: {
@@ -128,7 +128,7 @@ describe('ObjectSync', () => {
 
     // Start the test.
     const ctx1 = new Context();
-    const obj1 = peer2.objectSync.download({ id: 'test', ctx: ctx1 });
+    const obj1 = peer2.objectSync.download(ctx1, 'test');
     await ctx1.dispose();
     startTrigger.wake();
     await expect(async () => asyncTimeout(obj1, 500)).rejects.toThrow();
@@ -180,10 +180,10 @@ describe('ObjectSync', () => {
     await testBuilder.connect(peer1, peer2);
 
     const ctx1 = new Context();
-    const obj1 = peer2.objectSync.download({ id: 'test', ctx: ctx1 });
+    const obj1 = peer2.objectSync.download(ctx1, 'test');
 
     const ctx2 = new Context();
-    const obj2 = peer2.objectSync.download({ id: 'test', ctx: ctx2 });
+    const obj2 = peer2.objectSync.download(ctx2, 'test');
 
     // Start the test.
     await ctx1.dispose();

--- a/packages/core/mesh/teleport-extension-object-sync/src/object-sync.test.ts
+++ b/packages/core/mesh/teleport-extension-object-sync/src/object-sync.test.ts
@@ -138,7 +138,7 @@ describe('ObjectSync', () => {
     const testBuilder = new TestBuilder();
     afterTest(() => testBuilder.destroy());
 
-    // Trigger to start the test.s
+    // Trigger to start replication.
     const startTrigger = new Trigger();
 
     const peer1 = await testBuilder.createPeer({
@@ -177,7 +177,7 @@ describe('ObjectSync', () => {
         ),
     });
 
-    await testBuilder.connect(peer1, peer2);
+    await testBuilder.connzwect(peer1, peer2);
 
     const ctx1 = new Context();
     const obj1 = peer2.objectSync.download({ id: 'test', ctx: ctx1 });

--- a/packages/core/mesh/teleport-extension-object-sync/src/object-sync.ts
+++ b/packages/core/mesh/teleport-extension-object-sync/src/object-sync.ts
@@ -15,11 +15,16 @@ export type ObjectSyncParams = {
   setObject: (data: DataObject) => Promise<void>;
 };
 
+type DownloadRequest = {
+  trigger: Trigger<DataObject>;
+  counter: number;
+};
+
 @trackLeaks('open', 'close')
 export class ObjectSync {
   private readonly _ctx = new Context();
 
-  private readonly _downloadRequests = new Map<string, { trigger: Trigger<DataObject>; counter: number }>();
+  private readonly _downloadRequests = new Map<string, DownloadRequest>();
   private readonly _extensions = new Set<ObjectSyncExtension>();
 
   constructor(private readonly _params: ObjectSyncParams) {}

--- a/packages/core/mesh/teleport-extension-object-sync/src/object-sync.ts
+++ b/packages/core/mesh/teleport-extension-object-sync/src/object-sync.ts
@@ -30,7 +30,7 @@ export class ObjectSync {
     await this._ctx.dispose();
   }
 
-  download({ id, ctx }: { id: string; ctx?: Context }): Promise<DataObject> {
+  download(ctx: Context, id: string): Promise<DataObject> {
     log('download', { id });
 
     const existingRequest = this._downloadRequests.get(id);

--- a/packages/core/mesh/teleport-extension-object-sync/src/object-sync.ts
+++ b/packages/core/mesh/teleport-extension-object-sync/src/object-sync.ts
@@ -50,9 +50,7 @@ export class ObjectSync {
 
     this._downloadRequests.set(id, request);
 
-    for (const extension of this._extensions) {
-      extension.updateWantListInASeparateTask(new Set(this._downloadRequests.keys()));
-    }
+    this._updateExtensionsWantList();
 
     ctx?.onDispose(() => {
       // Remove request if context is disposed and nobody else requests it.
@@ -63,9 +61,7 @@ export class ObjectSync {
       if (--request.counter === 0) {
         this._downloadRequests.delete(id);
       }
-      for (const extension of this._extensions) {
-        extension.updateWantListInASeparateTask(new Set(this._downloadRequests.keys()));
-      }
+      this._updateExtensionsWantList();
     });
 
     return ctx ? cancelWithContext(ctx, request.trigger.wait()) : request.trigger.wait();
@@ -110,5 +106,11 @@ export class ObjectSync {
       },
     });
     return extension;
+  }
+
+  private _updateExtensionsWantList() {
+    for (const extension of this._extensions) {
+      extension.updateWantListInASeparateTask(new Set(this._downloadRequests.keys()));
+    }
   }
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2dfb281</samp>

### Summary
🚀🛠️🔄

<!--
1.  🚀 - This emoji conveys the idea of improving performance, responsiveness, and reliability, as well as adding a new feature or enhancement.
2.  🛠️ - This emoji conveys the idea of fixing or improving something, as well as working with tools or code.
3.  🔄 - This emoji conveys the idea of changing, updating, or refreshing something, as well as dealing with cycles or loops.
-->
Improved snapshot loading in `echo-pipeline` by adding cancellation support. This allows `SnapshotManager` to abort loading when the context is cancelled or the host is closed.

> _The snapshot of doom is loading_
> _But we can cancel it with `Context`_
> _We won't let it crash our system_
> _We are the masters of `SnapshotManager`_

### Walkthrough
*  Add cancellation support for loading snapshots using `Context` and `cancelWithContext` ([link](https://github.com/dxos/dxos/pull/3589/files?diff=unified&w=0#diff-bcb3805db9fb8df2d1dd3cc8aba301356a57e030fc1e534cf6e9d7b18754b51aR7), [link](https://github.com/dxos/dxos/pull/3589/files?diff=unified&w=0#diff-bcb3805db9fb8df2d1dd3cc8aba301356a57e030fc1e534cf6e9d7b18754b51aL60-R67))
  - Import `Context` and `cancelWithContext` from `@dxos/context` in `snapshot-manager.ts` ([link](https://github.com/dxos/dxos/pull/3589/files?diff=unified&w=0#diff-bcb3805db9fb8df2d1dd3cc8aba301356a57e030fc1e534cf6e9d7b18754b51aR7))
  - Modify `load` method of `SnapshotManager` class to accept a `Context` parameter and use `cancelWithContext` to wrap snapshot loading and downloading operations ([link](https://github.com/dxos/dxos/pull/3589/files?diff=unified&w=0#diff-bcb3805db9fb8df2d1dd3cc8aba301356a57e030fc1e534cf6e9d7b18754b51aL60-R67))
  - Pass the `Context` parameter to the underlying `this._snapshotStore.loadSnapshot` and `this._objectSync.download` methods, which can use it for additional options or information ([link](https://github.com/dxos/dxos/pull/3589/files?diff=unified&w=0#diff-bcb3805db9fb8df2d1dd3cc8aba301356a57e030fc1e534cf6e9d7b18754b51aL60-R67))


