### PR TITLE
fix(telemetry): Add segment telemetry back to apps

### DIFF
--- a/packages/apps/composer-app/src/plugins/GithubPlugin/GithubPlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/GithubPlugin/GithubPlugin.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 
 import { isMarkdown, isMarkdownProperties } from '@braneframe/plugin-markdown';
 import { TranslationsProvides } from '@braneframe/plugin-theme';
+import { useTelemetry } from '@dxos/react-appkit';
 import { PluginDefinition } from '@dxos/react-surface';
 
 import {
@@ -51,6 +52,12 @@ export const GithubPlugin = (): PluginDefinition<TranslationsProvides> => ({
       }
     },
     components: {
+      default: () => {
+        // TODO(wittjosiah): Factor out to a telemetry plugin.
+        useTelemetry({ namespace: 'composer-app', router: false });
+
+        return null;
+      },
       Main: EmbeddedMain,
     },
   },

--- a/packages/experimental/kai-framework/src/pages/SpacePage.tsx
+++ b/packages/experimental/kai-framework/src/pages/SpacePage.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { Main, useSidebar } from '@dxos/aurora';
+import { useTelemetry } from '@dxos/react-appkit';
 import { SpaceState, useSpaces, useIdentity } from '@dxos/react-client';
 
 import { Surface, Sidebar } from '../containers';
@@ -16,6 +17,7 @@ import { SpacePanel } from './SpacePanel';
  * Home page with current space.
  */
 const SpacePage = () => {
+  useTelemetry({ namespace: 'kai' });
   useIdentity();
   const { fullscreen } = useAppState();
   const { space, frame, objectId } = useAppRouter();


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3dbba3b</samp>

### Summary
📊🔌🚀

<!--
1.  📊 - This emoji represents data analysis or statistics, which is related to the telemetry feature that tracks the usage of the components.
2.  🔌 - This emoji represents a plugin or an extension, which is related to the `GithubPlugin` component that integrates with GitHub.
3.  🚀 - This emoji represents innovation or experimentation, which is related to the `kai-framework` features that are still in development.
-->
Added telemetry support to various components using `useTelemetry` hook. This enables tracking and analyzing user behavior and feature usage in the `composer-app` and the `kai-framework`.

> _To track how the users behave_
> _We added some `useTelemetry` rave_
> _To `GithubPlugin` and `SpacePage`_
> _With `kai-framework` as the stage_
> _And hope that the data will save_

### Walkthrough
*  Import and invoke `useTelemetry` hook to track component usage in `composer-app` and `kai-framework` packages ([link](https://github.com/dxos/dxos/pull/3592/files?diff=unified&w=0#diff-aea39d106265440ec4ddf616421a86cb54f3f68c14c88956a8a5a63c5e4953eaR10), [link](https://github.com/dxos/dxos/pull/3592/files?diff=unified&w=0#diff-aea39d106265440ec4ddf616421a86cb54f3f68c14c88956a8a5a63c5e4953eaR55-R60), [link](https://github.com/dxos/dxos/pull/3592/files?diff=unified&w=0#diff-43691288024d72197136adef91b80cf9f0677b75240fd229b5ac084e72032256R9), [link](https://github.com/dxos/dxos/pull/3592/files?diff=unified&w=0#diff-43691288024d72197136adef91b80cf9f0677b75240fd229b5ac084e72032256R20)).


