### PR TITLE
feat: Expand devtools for pipeline and feeds

### DIFF
--- a/packages/common/typings/src/hypercore.d.ts
+++ b/packages/common/typings/src/hypercore.d.ts
@@ -172,6 +172,12 @@ declare module 'hypercore' {
 
     // https://github.com/hypercore-protocol/hypercore/tree/v9.12.0#feedstats
     readonly stats: Stats;
+
+    bitfield?: {
+      data: any; // sparse-bitfield package
+
+      // TODO(dmaretskyi): More props.
+    };
   }
 
   /**

--- a/packages/core/echo/echo-pipeline/src/pipeline/pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/pipeline/pipeline.ts
@@ -42,6 +42,11 @@ export class PipelineState {
   public readonly stalled = new Event();
 
   /**
+   * @internal
+   */
+  _startTimeframe: Timeframe = new Timeframe();
+
+  /**
    * Target timeframe we are waiting to reach.
    */
   private _targetTimeframe: Timeframe | undefined;
@@ -68,6 +73,10 @@ export class PipelineState {
           index: feed.length - 1,
         })),
     );
+  }
+
+  get startTimeframe() {
+    return this._startTimeframe;
   }
 
   get timeframe() {
@@ -275,6 +284,7 @@ export class Pipeline implements PipelineAccessor {
   async setCursor(timeframe: Timeframe) {
     assert(!this._isStarted || this._isPaused, 'Invalid state.');
 
+    this._state._startTimeframe = timeframe;
     this._timeframeClock.setTimeframe(timeframe);
 
     if (this._feedSetIterator) {

--- a/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
@@ -81,7 +81,16 @@ export class DataPipeline {
   public itemManager!: ItemManager;
   public databaseHost?: DatabaseHost;
 
+  /**
+   * Current epoch. Might be still processing.
+   */
   public currentEpoch?: SpecificCredential<Epoch>;
+
+  /**
+   * Epoch currently applied.
+   */
+  public appliedEpoch?: SpecificCredential<Epoch>;
+
   private _lastProcessedEpoch = -1;
   public onNewEpoch = new Event<Credential>();
   private _epochCtx?: Context;
@@ -185,7 +194,7 @@ export class DataPipeline {
 
   private async _consumePipeline() {
     if (this.currentEpoch) {
-      const waitForOneEpoch = this.onNewEpoch.waitFor(() => true);
+      const waitForOneEpoch = this.onNewEpoch.waitForCount(1);
       await this._processEpochInSeparateTask(this.currentEpoch);
       await waitForOneEpoch;
     }
@@ -303,6 +312,8 @@ export class DataPipeline {
       }
       log('process epoch', { epoch });
       await this._processEpoch(ctx, epoch.subject.assertion);
+      
+      this.appliedEpoch = epoch;
       this.onNewEpoch.emit(epoch);
     });
   }

--- a/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/data-pipeline.ts
@@ -312,7 +312,7 @@ export class DataPipeline {
       }
       log('process epoch', { epoch });
       await this._processEpoch(ctx, epoch.subject.assertion);
-      
+
       this.appliedEpoch = epoch;
       this.onNewEpoch.emit(epoch);
     });

--- a/packages/core/protocols/src/proto/dxos/client/services.proto
+++ b/packages/core/protocols/src/proto/dxos/client/services.proto
@@ -176,8 +176,11 @@ message Space {
     repeated dxos.keys.PublicKey control_feeds = 18;
     repeated dxos.keys.PublicKey data_feeds = 19;
 
-    /// Last processed epoch.
+    /// Last processed epoch. Might now have been applied yet.
     optional dxos.halo.Credential current_epoch = 20;
+
+    /// Epoch that is currently applied.
+    optional dxos.halo.Credential applied_epoch = 21;
 
     /// Mutations already processed.
     optional timeframe.TimeframeVector current_control_timeframe = 10;
@@ -190,6 +193,9 @@ message Space {
 
     /// All mutations known to exist on the network.
     optional timeframe.TimeframeVector known_control_timeframe = 15;
+
+    /// Start timeframe of the pipeline.
+    optional timeframe.TimeframeVector start_data_timeframe = 100;
 
     /// Mutations already processed.
     optional timeframe.TimeframeVector current_data_timeframe = 12;

--- a/packages/core/protocols/src/proto/dxos/devtools/host.proto
+++ b/packages/core/protocols/src/proto/dxos/devtools/host.proto
@@ -208,6 +208,9 @@ message SubscribeToFeedsResponse {
     dxos.keys.PublicKey feed_key = 1;
     int32 length = 2;
     int32 bytes = 3;
+
+    /// Bitfield of downloaded blocks.
+    bytes downloaded = 4;
   }
 
   repeated Feed feeds = 1;

--- a/packages/devtools/devtools/src/components/JsonView.tsx
+++ b/packages/devtools/devtools/src/components/JsonView.tsx
@@ -22,7 +22,9 @@ export const JsonView: FC<{ data?: Object; className?: string }> = ({ data, clas
 
 const replacer = (key: string, value: any) => {
   if(typeof value === 'object') {
-    if(value?.type === 'Buffer') {
+    if(value instanceof Uint8Array) {
+      return Buffer.from(value).toString('hex');
+    } if(value?.type === 'Buffer') {
       return Buffer.from(value.data).toString('hex');
     } else if(value?.['@type'] === 'google.protobuf.Any') {
       try {

--- a/packages/devtools/devtools/src/components/PublicKeySelector.tsx
+++ b/packages/devtools/devtools/src/components/PublicKeySelector.tsx
@@ -13,11 +13,12 @@ export type PublicKeySelectorProps = {
   defaultValue?: PublicKey;
   placeholder?: string;
   Icon?: FC;
+  getLabel?: (key: PublicKey) => string;
   onChange?: (value: PublicKey) => any;
 };
 
 export const PublicKeySelector = (props: PublicKeySelectorProps) => {
-  const { placeholder, keys, defaultValue, Icon, onChange } = props;
+  const { placeholder, keys, defaultValue, Icon, onChange, getLabel = humanize } = props;
   return (
     <Select
       defaultValue={defaultValue?.toHex()}
@@ -34,7 +35,7 @@ export const PublicKeySelector = (props: PublicKeySelectorProps) => {
                 <Icon />
               </div>
             )}
-            {humanize(key)}
+            {getLabel(key)}
             <span className='text-neutral-250'>{key.truncate()}</span>
           </div>
         </Select.Item>

--- a/packages/devtools/devtools/src/containers/SpaceSelector.tsx
+++ b/packages/devtools/devtools/src/containers/SpaceSelector.tsx
@@ -68,7 +68,7 @@ export const SpaceToolbar: FC<{ children?: ReactNode }> = ({ children }) => {
       <div className='flex-shrink w-[400px] p-2'>
         <SpaceSelector />
       </div>
-      <div className='flex-1 p-2 mr-2'>{children}</div>
+      <div className='flex-1 p-2 mr-2 flex-row'>{children}</div>
     </div>
   );
 };

--- a/packages/devtools/devtools/src/panels/echo/FeedsPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/FeedsPanel.tsx
@@ -3,16 +3,18 @@
 //
 
 import { Rows } from '@phosphor-icons/react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { PublicKey } from '@dxos/keys';
 import { TableColumn } from '@dxos/mosaic';
 import { SubscribeToFeedBlocksResponse } from '@dxos/protocols/proto/dxos/devtools/host';
-import { humanize } from '@dxos/util';
+import { humanize, range } from '@dxos/util';
 
 import { MasterTable, PublicKeySelector } from '../../components';
 import { SpaceToolbar } from '../../containers';
 import { useDevtoolsDispatch, useDevtoolsState, useFeedMessages, useSpacesInfo } from '../../hooks';
+import { Button } from '@dxos/aurora';
+import { useDevtools, useStream } from '@dxos/react-client';
 
 const columns: TableColumn<SubscribeToFeedBlocksResponse.Block>[] = [
   {
@@ -33,16 +35,12 @@ const columns: TableColumn<SubscribeToFeedBlocksResponse.Block>[] = [
 const FeedsPanel = () => {
   const setContext = useDevtoolsDispatch();
   const { space, feedKey } = useDevtoolsState();
+  const feedKeys = [...space?.internal.data.pipeline?.controlFeeds ?? [], ...space?.internal.data.pipeline?.dataFeeds ?? []];
+  const devtoolsHost = useDevtools();
   const spacesInfo = useSpacesInfo();
-  const metadata = space?.key && spacesInfo.find((info) => info.key.equals(space?.key));
-  const [feeds, setFeeds] = useState<PublicKey[]>([]);
-  useEffect(() => {
-    if (!metadata) {
-      return;
-    }
+  const [refreshCount, setRefreshCount] = useState(0);
 
-    setFeeds([metadata.genesisFeed, metadata.controlFeed, metadata.dataFeed]);
-  }, [metadata]);
+  const {feeds = []} = useStream(() => devtoolsHost.subscribeToFeeds({feedKeys}), {}, [refreshCount])
 
   const messages = useFeedMessages({ feedKey });
 
@@ -50,24 +48,97 @@ const FeedsPanel = () => {
     setContext((state) => ({ ...state, feedKey }));
   };
 
+  const refresh = () => {
+    setRefreshCount(refreshCount + 1);
+  }
+
+  const getLabel = (key: PublicKey) => {
+    const type = space?.internal.data.pipeline?.controlFeeds?.includes(key) ? 'control' : 'data';
+
+    const meta = feeds.find(feed => feed.feedKey.equals(key));
+
+    if(meta) {
+      return `${type} (${meta.length})`
+    } else {
+      return type
+    }
+  }
+
+  const meta = feeds.find(feed => feedKey && feed.feedKey.equals(feedKey));
+
   return (
     <div className='flex flex-col overflow-hidden'>
       <SpaceToolbar>
         <div className='w-[400px]'>
           <PublicKeySelector
-            keys={feeds}
+            keys={feedKeys}
             Icon={Rows}
             defaultValue={feedKey}
             placeholder={'Select feed'}
+            getLabel={getLabel}
             onChange={handleSelect}
           />
+          <Button onClick={refresh}>Refresh</Button>
         </div>
       </SpaceToolbar>
+      <BitfieldDisplay value={meta?.downloaded ?? new Uint8Array()} length={meta?.length ?? 0} />
       <div className='flex flex-1 overflow-hidden'>
         <MasterTable<SubscribeToFeedBlocksResponse.Block> columns={columns} data={messages} />
       </div>
     </div>
   );
 };
+
+const MIN_SUBDIVISION_PIXELS = 10;
+const MAX_SUBDIVISIONS = 100;
+
+const BitfieldDisplay = ({ value, length }: { value: Uint8Array, length: number }) => {
+  const container = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState<number>(0);
+
+  useEffect(() => {
+    if (!container.current) return;
+      const resizeObserver = new ResizeObserver(() => {
+        if(!container.current) return;
+
+        const width = container.current.clientWidth;
+        setWidth(width);
+      });
+      resizeObserver.observe(container.current);
+      return () => resizeObserver.disconnect(); // clean up 
+  }, []);
+
+  const subdivisions = Math.min(Math.min(Math.floor(width / MIN_SUBDIVISION_PIXELS), MAX_SUBDIVISIONS), length);
+
+  const getColor = (index: number): string => {
+    const feedBegin = Math.floor(index * length / subdivisions);
+    let feedEnd = Math.ceil((index + 1) * length / subdivisions);
+    if(feedEnd === feedBegin) feedEnd = feedBegin + 1;
+
+    let count = 0;
+    for (let i = feedBegin; i < feedEnd; i++) {
+      const bit = (value[Math.floor(i / 8)] >> (7 - i % 8)) & 0x1;
+      if(bit) count++;
+    }
+
+    const percent = count / (feedEnd - feedBegin);
+
+    if(percent === 1) {
+      return 'darkgreen'
+    } else if(percent > 0) {
+      return 'green'
+    } else {
+      return 'gray'
+    }
+  }
+
+  return (
+    <div ref={container} className='h-10 m-2 flex flex-row'>
+      {range(subdivisions).map((index) => (
+        <div key={index} className='h-full flex-1' style={{ backgroundColor: getColor(index), minWidth: 1 }} />
+      ))}
+    </div>
+  )
+}
 
 export default FeedsPanel;

--- a/packages/devtools/devtools/src/panels/echo/SpacesPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpacesPanel.tsx
@@ -26,8 +26,6 @@ const SpacesPanel = () => {
 
   const pipelineState = useMulticastObservable(space?.pipeline ?? MulticastObservable.empty());
 
-  console.log(space);
-
   const object = useMemo(() => {
     if (!metadata) {
       return undefined;

--- a/packages/sdk/client-services/src/packlets/devtools/feeds.ts
+++ b/packages/sdk/client-services/src/packlets/devtools/feeds.ts
@@ -40,6 +40,7 @@ export const subscribeToFeeds = (
           feedKey: feed.key,
           length: feed.properties.length,
           bytes: feed.core.byteLength,
+          downloaded: feed.core.bitfield?.data.toBuffer() ?? new Uint8Array(),
         })),
       });
     };

--- a/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
@@ -74,6 +74,7 @@ export class SpacesServiceImpl implements SpacesService {
           for (const space of dataSpaceManager.spaces.values()) {
             subscriptions.add(space.stateUpdate.on(ctx, onUpdate));
             subscriptions.add(space.presence.updated.on(ctx, onUpdate));
+            subscriptions.add(space.dataPipeline.onNewEpoch.on(ctx, onUpdate));
 
             // Pipeline progress.
             space.inner.controlPipeline.state.timeframeUpdate
@@ -157,6 +158,7 @@ export class SpacesServiceImpl implements SpacesService {
       error: space.error ? encodeError(space.error) : undefined,
       pipeline: {
         currentEpoch: space.dataPipeline.currentEpoch,
+        appliedEpoch: space.dataPipeline.appliedEpoch,
 
         controlFeeds: space.inner.controlPipeline.state.feeds.map((feed) => feed.key),
         currentControlTimeframe: space.inner.controlPipeline.state.timeframe,
@@ -164,6 +166,7 @@ export class SpacesServiceImpl implements SpacesService {
         totalControlTimeframe: space.inner.controlPipeline.state.endTimeframe,
 
         dataFeeds: space.dataPipeline.pipelineState?.feeds.map((feed) => feed.key) ?? [],
+        startDataTimeframe: space.dataPipeline.pipelineState?.startTimeframe,
         currentDataTimeframe: space.dataPipeline.pipelineState?.timeframe,
         targetDataTimeframe: space.dataPipeline.pipelineState?.targetTimeframe,
         totalDataTimeframe: space.dataPipeline.pipelineState?.endTimeframe,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f265a9a</samp>

### Summary
📥🕑🏷️

<!--
1.  📥 This emoji represents the concept of downloading or receiving data, which is relevant for the changes related to the `downloaded` field and the `BitfieldDisplay` component.
2.  🕑 This emoji represents the concept of time or timing, which is relevant for the changes related to the epoch, timeframe, and start mutation of the data pipeline.
3.  🏷️ This emoji represents the concept of labeling or naming, which is relevant for the changes related to the custom label function for public keys and the space name display.
-->
This pull request adds and improves features related to the data pipeline and the devtools UI. It tracks and exposes the epoch and timeframe of the data pipeline for each space, using new fields in the `services.proto` and `host.proto` files. It also enhances the display of the spaces and feeds information in the `FeedsPanel` and `SpacesPanel` components, using new components and hooks. Additionally, it fixes some minor issues and adds some usability improvements to the `PublicKeySelector` and `JsonView` components.

> _This pull request is quite a feat_
> _It shows the progress of each feed_
> _With bitfields and spaces_
> _And pipeline timeframes_
> _The devtools UI is complete_

### Walkthrough
*  Add new properties to track the applied epoch and the start timeframe of the pipeline state for each space ([link](https://github.com/dxos/dxos/pull/3599/files?diff=unified&w=0#diff-1df1310cca796382869c882d8f953732c5ea557af4f9e4219223c7eada3fb9b3R45-R49),[link](https://github.com/dxos/dxos/pull/3599/files?diff=unified&w=0#diff-1df1310cca796382869c882d8f953732c5ea557af4f9e4219223c7eada3fb9b3R78-R81),[link](https://github.com/dxos/dxos/pull/3599/files?diff=unified&w=0#diff-1df1310cca796382869c882d8f953732c5ea557af4f9e4219223c7eada3fb9b3R287),[link](https://github.com/dxos/dxos/pull/3599/files?diff=unified&w=0#diff-0e718439dcb670515a37fa6bd2c8409cdad48857580582122ed27e37b72460b3L84-R93),[link](https://github.com/dxos/dxos/pull/3599/files?diff=unified&w=0#diff-0e718439dcb670515a37fa6bd2c8409cdad48857580582122ed27e37b72460b3R315-R316),[link](https://github.com/dxos/dxos/pull/3599/files?diff=unified&w=0#diff-1f246514dbba8145aea2c94eadcc3265b76da0f434106ef87e58db92bdaf5aa0L179-R184),[link](https://github.com/dxos/dxos/pull/3599/files?diff=unified&w=0#diff-1f246514dbba8145aea2c94eadcc3265b76da0f434106ef87e58db92bdaf5aa0R197-R199),[link](https://github.com/dxos/dxos/pull/3599/files?diff=unified&w=0#diff-707121e098bd19a3234ae34cd2c0852dc1a7b9c04addd28d2dbb8affa48f6e66R77),[link](https://github.com/dxos/dxos/pull/3599/files?diff=unified&w=0#diff-707121e098bd19a3234ae34cd2c0852dc1a7b9c04addd28d2dbb8affa48f6e66R161),[link](https://github.com/dxos/dxos/pull/3599/files?diff=unified&w=0#diff-707121e098bd19a3234ae34cd2c0852dc1a7b9c04addd28d2dbb8affa48f6e66R169)).


