### PR TITLE
fix: Increase timeout in `testLocalDatabase`

### DIFF
--- a/packages/core/echo/echo-pipeline/src/testing/util.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/util.ts
@@ -73,6 +73,6 @@ export const testLocalDatabase = async (create: DataPipeline, check: DataPipelin
 
   await asyncTimeout(
     check.databaseHost!._itemDemuxer.mutation.waitForCondition(() => check.itemManager.entities.has(objectId)),
-    1000,
+    2000,
   );
 };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1c3cb0f</samp>

### Summary
:zap::wrench::white_check_mark:

<!--
1.  :zap: This emoji can be used to indicate a performance improvement or a speed-related change. In this case, the change is intended to make the tests more resilient to slow performance, so :zap: could convey that idea.
2.  :wrench: This emoji can be used to indicate a tooling or configuration change. In this case, the change is related to the test configuration and the timeout parameter, so :wrench: could convey that idea.
3.  :white_check_mark: This emoji can be used to indicate a test-related change or an improvement in test coverage or quality. In this case, the change is part of a pull request that aims to improve the reliability and stability of the tests, so :white_check_mark: could convey that idea.
-->
Increased timeout for item manager tests in `echo-pipeline`. This improves the test reliability and avoids false negatives due to slow database operations.

> _`echo-pipeline` tests_
> _more reliable in winter_
> _timeout increased_

### Walkthrough
* Increase the timeout for waiting for the item manager to have the object id in the echo-pipeline tests ([link](https://github.com/dxos/dxos/pull/3603/files?diff=unified&w=0#diff-6bf2c705e106622cc93a498e0e585d09099174eb3d4e91b052a7ef3d8737e14cL76-R76)). This avoids flaky tests due to slow database operations in `util.ts`.


