### PR TITLE
refactor(aurora,react-list): remove DnD from `List`

### DIFF
--- a/packages/apps/plugins/plugin-dnd/package.json
+++ b/packages/apps/plugins/plugin-dnd/package.json
@@ -17,10 +17,10 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@dxos/observable-object": "workspace:*",
     "@dnd-kit/core": "^6.0.5",
     "@dnd-kit/sortable": "^7.0.1",
-    "@dnd-kit/utilities": "^3.2.0"
+    "@dnd-kit/utilities": "^3.2.0",
+    "@dxos/observable-object": "workspace:*"
   },
   "devDependencies": {
     "@braneframe/plugin-theme": "workspace:*",

--- a/packages/apps/plugins/plugin-dnd/package.json
+++ b/packages/apps/plugins/plugin-dnd/package.json
@@ -1,17 +1,24 @@
 {
-  "name": "@dxos/plugin-dnd",
+  "name": "@braneframe/plugin-dnd",
   "version": "0.1.0",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
   "license": "MIT",
   "author": "info@dxos.org",
-  "main": "dist/src/index.js",
+  "exports": {
+    ".": "./dist/lib/browser/index.mjs"
+  },
+  "types": "dist/types/src/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "build": "tsc"
   },
   "dependencies": {
+    "@dxos/observable-object": "workspace:*",
     "@dnd-kit/core": "^6.0.5",
-    "@dnd-kit/modifiers": "^6.0.0",
     "@dnd-kit/sortable": "^7.0.1",
     "@dnd-kit/utilities": "^3.2.0"
   },
@@ -19,7 +26,6 @@
     "@braneframe/plugin-theme": "workspace:*",
     "@dxos/aurora": "workspace:*",
     "@dxos/aurora-theme": "workspace:*",
-    "@dxos/observable-object": "workspace:*",
     "@dxos/react-surface": "workspace:*",
     "@dxos/util": "workspace:*",
     "@faker-js/faker": "^7.3.0",

--- a/packages/apps/plugins/plugin-dnd/project.json
+++ b/packages/apps/plugins/plugin-dnd/project.json
@@ -6,8 +6,23 @@
       "executor": "@nrwl/js:tsc",
       "options": {
         "main": "packages/apps/plugins/plugin-dnd/src/index.ts",
-        "outputPath": "packages/apps/plugins/plugin-dnd/dist",
+        "outputPath": "packages/apps/plugins/plugin-dnd/dist/types",
         "tsConfig": "packages/apps/plugins/plugin-dnd/tsconfig.json"
+      },
+      "outputs": [
+        "{options.outputPath}"
+      ]
+    },
+    "compile": {
+      "executor": "@dxos/esbuild:build",
+      "options": {
+        "entryPoints": [
+          "packages/apps/plugins/plugin-dnd/src/index.ts"
+        ],
+        "outputPath": "packages/apps/plugins/plugin-dnd/dist/lib",
+        "platforms": [
+          "browser"
+        ]
       },
       "outputs": [
         "{options.outputPath}"

--- a/packages/apps/plugins/plugin-dnd/src/DndPlugin.tsx
+++ b/packages/apps/plugins/plugin-dnd/src/DndPlugin.tsx
@@ -11,7 +11,6 @@ import {
   DragOverlay,
   DragStartEvent,
   DropAnimation,
-  UniqueIdentifier,
 } from '@dnd-kit/core';
 import React, { createContext, DependencyList, useContext, useEffect, useState } from 'react';
 
@@ -169,11 +168,11 @@ export const useDnd = () => useContext(DndPluginContext);
 
 const DndOverlay = observer(() => {
   const dnd = useDnd();
-  const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
-  useDragStart(({ active: { id } }) => setActiveId(id), []);
+  const [activeDatum, setActiveDatum] = useState<unknown | null>(null);
+  useDragStart(({ active: { data } }) => setActiveDatum(data.current?.entity), []);
   return (
     <DragOverlay adjustScale={false} dropAnimation={dropAnimations[dnd.overlayDropAnimation]}>
-      <Surface role='dragoverlay' data={activeId} limit={1} />
+      <Surface role='dragoverlay' data={activeDatum} limit={1} />
     </DragOverlay>
   );
 });

--- a/packages/apps/plugins/plugin-dnd/src/index.ts
+++ b/packages/apps/plugins/plugin-dnd/src/index.ts
@@ -1,3 +1,5 @@
 //
 // Copyright 2023 DXOS.org
 //
+
+export * from './DndPlugin';

--- a/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPlugin.tsx
+++ b/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPlugin.tsx
@@ -46,9 +46,9 @@ const defaultItems = {
   ],
 };
 
-export const StoryItemDragOverlay = ({ data }: { data: string }) => {
+export const StoryItemDragOverlay = ({ data }: { data: { id: string } }) => {
   // (thure) Note that this is rendered as part of DndPlugin’s context, so it may not have access to other contexts.
-  const item = store.items.find(({ id }) => id === data);
+  const item = store.items.find(({ id }) => id === data.id);
   return item ? <CompactStoryItem item={item} dragOverlay /> : null;
 };
 
@@ -62,7 +62,7 @@ export const CompactStoryItem = ({
 }) => {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
     id: item.id,
-    data: item,
+    data: { entity: item },
   });
   return (
     <div
@@ -104,7 +104,7 @@ export const DndPluginDefaultStoryPlugin = () => {
       components: {
         default: DndPluginDefaultStoryPluginDefault,
       },
-      component: (daum: unknown, role?: string) => {
+      component: (datum: unknown, role?: string) => {
         switch (role) {
           case 'dragoverlay':
             return StoryItemDragOverlay;

--- a/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPluginB.tsx
+++ b/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPluginB.tsx
@@ -40,6 +40,8 @@ const DndPluginDefaultStoryPluginBDefault = () => {
             dnd.overlayDropAnimation = 'into';
             item && store.items.splice(store.items.length, 0, item);
             setIter([]);
+          } else {
+            dnd.overlayDropAnimation = 'away';
           }
         }
       }

--- a/packages/apps/plugins/plugin-stack/package.json
+++ b/packages/apps/plugins/plugin-stack/package.json
@@ -15,11 +15,15 @@
     "src"
   ],
   "dependencies": {
+    "@dnd-kit/core": "^6.0.5",
+    "@dnd-kit/sortable": "^7.0.1",
+    "@dnd-kit/utilities": "^3.2.0",
     "@dxos/observable-object": "workspace:*",
     "@dxos/util": "workspace:*",
     "lodash.get": "^4.4.2"
   },
   "devDependencies": {
+    "@braneframe/plugin-dnd": "workspace:*",
     "@braneframe/plugin-markdown": "workspace:*",
     "@braneframe/plugin-space": "workspace:*",
     "@braneframe/plugin-splitview": "workspace:*",
@@ -37,6 +41,7 @@
     "vite": "^4.3.9"
   },
   "peerDependencies": {
+    "@braneframe/plugin-dnd": "workspace:*",
     "@braneframe/plugin-splitview": "workspace:*",
     "@braneframe/types": "workspace:*",
     "@dxos/aurora": "workspace:*",

--- a/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
+++ b/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
@@ -8,7 +8,7 @@ import { Stack } from '@braneframe/types';
 import { createStore } from '@dxos/observable-object';
 import { Plugin, PluginDefinition } from '@dxos/react-surface';
 
-import { StackMain } from './components';
+import { StackMain, StackSectionOverlay } from './components';
 import { isStack, StackPluginProvides, StackProvides, StackSectionChooser, StackSectionCreator } from './props';
 import translations from './translations';
 
@@ -47,6 +47,12 @@ export const StackPlugin = (): PluginDefinition<StackPluginProvides> => ({
         case 'main':
           if (Array.isArray(datum) && isStack(datum[datum.length - 1])) {
             return StackMain;
+          } else {
+            return null;
+          }
+        case 'dragoverlay':
+          if (datum && typeof datum === 'object' && 'object' in datum) {
+            return StackSectionOverlay;
           } else {
             return null;
           }

--- a/packages/apps/plugins/plugin-stack/src/stories/StackPlugin.stories.tsx
+++ b/packages/apps/plugins/plugin-stack/src/stories/StackPlugin.stories.tsx
@@ -5,6 +5,7 @@
 import '@dxosTheme';
 import React from 'react';
 
+import { DndPlugin } from '@braneframe/plugin-dnd';
 import { MarkdownPlugin } from '@braneframe/plugin-markdown';
 import { ThemePlugin } from '@braneframe/plugin-theme';
 import { ObservableArray, ObservableObject } from '@dxos/observable-object';
@@ -33,7 +34,9 @@ const StackPluginStoryPlugin = () => ({
 });
 
 const StackSurfacesApp = () => (
-  <PluginContextProvider plugins={[ThemePlugin(), StackPlugin(), MarkdownPlugin(), StackPluginStoryPlugin()]} />
+  <PluginContextProvider
+    plugins={[ThemePlugin(), DndPlugin(), StackPlugin(), MarkdownPlugin(), StackPluginStoryPlugin()]}
+  />
 );
 
 export default {

--- a/packages/apps/plugins/plugin-stack/tsconfig.json
+++ b/packages/apps/plugins/plugin-stack/tsconfig.json
@@ -39,6 +39,9 @@
       "path": "../../types"
     },
     {
+      "path": "../plugin-dnd"
+    },
+    {
       "path": "../plugin-markdown"
     },
     {

--- a/packages/ui/aurora-theme/src/styles/components/list.ts
+++ b/packages/ui/aurora-theme/src/styles/components/list.ts
@@ -23,11 +23,6 @@ export const listItemEndcap: ComponentFunction<ListStyleProps> = ({ density }, .
 export const listItemHeading: ComponentFunction<ListStyleProps> = ({ density }, ...etc) =>
   mx(densityBlockSize(density), ...etc);
 
-export const listItemAppDragHandle: ComponentFunction<ListStyleProps> = (_props, ...etc) =>
-  mx('bs-10 is-5 rounded touch-none', defaultFocus, ...etc);
-export const listItemOsDragHandle: ComponentFunction<ListStyleProps> = (_props, ...etc) =>
-  mx('bs-10 is-5 rounded touch-none', osFocus, ...etc);
-
 export const listItemDragHandleIcon: ComponentFunction<ListStyleProps> = (_props, ...etc) =>
   mx(getSize(5), 'mbs-2.5', ...etc);
 
@@ -43,7 +38,6 @@ export const listTheme: Theme<ListStyleProps> = {
     root: listItem,
     endcap: listItemEndcap,
     heading: listItemHeading,
-    dragHandle: listItemAppDragHandle,
     dragHandleIcon: listItemDragHandleIcon,
     openTrigger: listItemAppOpenTrigger,
     openTriggerIcon: listItemOpenTriggerIcon,
@@ -54,7 +48,6 @@ export const listOsTheme: Theme<ListStyleProps> = {
   ...listTheme,
   item: {
     ...listTheme.item,
-    dragHandle: listItemOsDragHandle,
     openTrigger: listItemOsOpenTrigger,
   },
 };

--- a/packages/ui/aurora/package.json
+++ b/packages/ui/aurora/package.json
@@ -40,6 +40,9 @@
     "react-i18next": "^11.18.6"
   },
   "devDependencies": {
+    "@dnd-kit/core": "^6.0.5",
+    "@dnd-kit/sortable": "^7.0.1",
+    "@dnd-kit/utilities": "^3.2.0",
     "@dxos/aurora-theme": "workspace:*",
     "@phosphor-icons/react": "^2.0.5",
     "@types/react": "^18.0.21",

--- a/packages/ui/aurora/src/components/Lists/List.tsx
+++ b/packages/ui/aurora/src/components/Lists/List.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { CaretDown, CaretRight, DotsSixVertical } from '@phosphor-icons/react';
+import { CaretDown, CaretRight } from '@phosphor-icons/react';
 import { Slot } from '@radix-ui/react-slot';
 import React, { ComponentPropsWithoutRef, FC, forwardRef, ForwardRefExoticComponent } from 'react';
 
@@ -13,8 +13,6 @@ import {
   ListScopedProps,
   ListItemHeading as ListPrimitiveItemHeading,
   ListItemHeadingProps as ListPrimitiveItemHeadingProps,
-  ListItemDragHandle as ListPrimitiveItemDragHandle,
-  ListItemDragHandleProps as ListPrimitiveItemDragHandleProps,
   ListItemOpenTrigger as ListPrimitiveItemOpenTrigger,
   ListItemOpenTriggerProps as ListPrimitiveItemOpenTriggerProps,
   ListItemCollapsibleContent,
@@ -26,9 +24,6 @@ import {
   useListContext,
   LIST_ITEM_NAME,
   useListItemContext,
-  arrayMove,
-  DragEndEvent,
-  DragOverEvent,
 } from '@dxos/react-list';
 
 import { useDensityContext, useThemeContext } from '../../hooks';
@@ -37,14 +32,9 @@ import { DensityProvider } from '../DensityProvider';
 
 type ListProps = ThemedClassName<ListPrimitiveProps> & { density?: Density };
 
-const useListDensity = ({ density, variant }: Pick<ListProps, 'density' | 'variant'>) => {
-  const contextDensity = useDensityContext(density);
-  return variant === 'ordered-draggable' ? 'coarse' : contextDensity ?? 'coarse';
-};
-
 const List = forwardRef<HTMLOListElement, ListProps>(({ classNames, children, ...props }, forwardedRef) => {
   const { tx } = useThemeContext();
-  const density = useListDensity(props);
+  const density = useDensityContext(props.density);
 
   return (
     <DensityProvider density={density}>
@@ -118,25 +108,6 @@ const ListItemHeading = forwardRef<HTMLParagraphElement, ListItemHeadingProps>(
   },
 );
 
-type ListItemDragHandleProps = ThemedClassName<ListPrimitiveItemDragHandleProps>;
-
-const ListItemDragHandle = forwardRef<HTMLDivElement, ListItemDragHandleProps>(
-  ({ classNames, children, ...props }, forwardedRef) => {
-    const { tx } = useThemeContext();
-    return (
-      <ListPrimitiveItemDragHandle
-        {...props}
-        className={tx('list.item.dragHandle', 'list__listItem__dragHandle', {}, classNames)}
-        ref={forwardedRef}
-      >
-        {children || (
-          <DotsSixVertical className={tx('list.item.dragHandleIcon', 'list__listItem__dragHandle__icon', {})} />
-        )}
-      </ListPrimitiveItemDragHandle>
-    );
-  },
-);
-
 type ListItemOpenTriggerProps = ThemedClassName<ListPrimitiveItemOpenTriggerProps>;
 
 const ListItemOpenTrigger = forwardRef<HTMLButtonElement, ListItemOpenTriggerProps>(
@@ -186,7 +157,6 @@ export const ListItem: {
   Root: ForwardRefExoticComponent<ListItemRootProps>;
   Endcap: ForwardRefExoticComponent<ListItemEndcapProps>;
   Heading: ForwardRefExoticComponent<ListItemHeadingProps>;
-  DragHandle: ForwardRefExoticComponent<ListItemDragHandleProps>;
   OpenTrigger: ForwardRefExoticComponent<ListItemOpenTriggerProps>;
   CollapsibleContent: ForwardRefExoticComponent<ListItemCollapsibleContentProps>;
   MockOpenTrigger: FC<ThemedClassName<Omit<ComponentPropsWithoutRef<'div'>, 'children'>>>;
@@ -195,14 +165,13 @@ export const ListItem: {
   Root: ListItemRoot,
   Endcap: ListItemEndcap,
   Heading: ListItemHeading,
-  DragHandle: ListItemDragHandle,
   OpenTrigger: ListItemOpenTrigger,
   CollapsibleContent: ListItemCollapsibleContent,
   MockOpenTrigger: MockListItemOpenTrigger,
   MockDragHandle: MockListItemDragHandle,
 };
 
-export { List, useListDensity, useListContext, useListItemContext, LIST_NAME, LIST_ITEM_NAME, arrayMove };
+export { List, useListContext, useListItemContext, LIST_NAME, LIST_ITEM_NAME };
 
 export type {
   ListProps,
@@ -211,9 +180,6 @@ export type {
   ListItemScopedProps,
   ListItemEndcapProps,
   ListItemHeadingProps,
-  ListItemDragHandleProps,
   ListItemOpenTriggerProps,
   ListItemCollapsibleContentProps,
-  DragEndEvent,
-  DragOverEvent,
 };

--- a/packages/ui/aurora/src/components/Lists/List.tsx
+++ b/packages/ui/aurora/src/components/Lists/List.tsx
@@ -80,16 +80,6 @@ const MockListItemOpenTrigger = ({
   );
 };
 
-const MockListItemDragHandle = ({
-  classNames,
-  ...props
-}: ThemedClassName<Omit<ComponentPropsWithoutRef<'div'>, 'children'>>) => {
-  const { tx } = useThemeContext();
-  return (
-    <div role='none' {...props} className={tx('list.item.dragHandle', 'list__listItem__dragHandle', {}, classNames)} />
-  );
-};
-
 type ListItemHeadingProps = ThemedClassName<ListPrimitiveItemHeadingProps>;
 
 const ListItemHeading = forwardRef<HTMLParagraphElement, ListItemHeadingProps>(
@@ -160,7 +150,6 @@ export const ListItem: {
   OpenTrigger: ForwardRefExoticComponent<ListItemOpenTriggerProps>;
   CollapsibleContent: ForwardRefExoticComponent<ListItemCollapsibleContentProps>;
   MockOpenTrigger: FC<ThemedClassName<Omit<ComponentPropsWithoutRef<'div'>, 'children'>>>;
-  MockDragHandle: FC<ThemedClassName<Omit<ComponentPropsWithoutRef<'div'>, 'children'>>>;
 } = {
   Root: ListItemRoot,
   Endcap: ListItemEndcap,
@@ -168,7 +157,6 @@ export const ListItem: {
   OpenTrigger: ListItemOpenTrigger,
   CollapsibleContent: ListItemCollapsibleContent,
   MockOpenTrigger: MockListItemOpenTrigger,
-  MockDragHandle: MockListItemDragHandle,
 };
 
 export { List, useListContext, useListItemContext, LIST_NAME, LIST_ITEM_NAME };

--- a/packages/ui/primitives/react-list/package.json
+++ b/packages/ui/primitives/react-list/package.json
@@ -16,10 +16,6 @@
     "src"
   ],
   "dependencies": {
-    "@dnd-kit/core": "^6.0.5",
-    "@dnd-kit/modifiers": "^6.0.0",
-    "@dnd-kit/sortable": "^7.0.1",
-    "@dnd-kit/utilities": "^3.2.0",
     "@dxos/react-hooks": "workspace:*",
     "@radix-ui/react-collapsible": "^1.0.2",
     "@radix-ui/react-compose-refs": "^1.0.0",

--- a/packages/ui/primitives/react-list/package.json
+++ b/packages/ui/primitives/react-list/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@dxos/react-hooks": "workspace:*",
     "@radix-ui/react-collapsible": "^1.0.2",
-    "@radix-ui/react-compose-refs": "^1.0.0",
     "@radix-ui/react-context": "^1.0.0",
     "@radix-ui/react-primitive": "^1.0.2",
     "@radix-ui/react-slot": "^1.0.1",

--- a/packages/ui/primitives/react-list/src/List.tsx
+++ b/packages/ui/primitives/react-list/src/List.tsx
@@ -26,7 +26,9 @@ type ListProps = ComponentPropsWithRef<typeof Primitive.ol> & {
 
 const [createListContext, createListScope] = createContextScope(LIST_NAME, []);
 
-type ListContextValue = Pick<ListProps, 'selectable' | 'variant'> & {
+type ListContextValue = {
+  selectable: Exclude<ListProps['selectable'], undefined>;
+  variant: Exclude<ListProps['variant'], undefined>;
   itemSizes?: ListItemSizes;
 };
 

--- a/packages/ui/primitives/react-list/src/List.tsx
+++ b/packages/ui/primitives/react-list/src/List.tsx
@@ -2,12 +2,9 @@
 // Copyright 2023 DXOS.org
 //
 
-import { DndContext, DragEndEvent, DragStartEvent, DragOverEvent } from '@dnd-kit/core';
-import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
-import { SortableContext, arrayMove, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { createContextScope, Scope } from '@radix-ui/react-context';
 import { Primitive } from '@radix-ui/react-primitive';
-import React, { ComponentPropsWithRef, forwardRef, useCallback, useState } from 'react';
+import React, { ComponentPropsWithRef, forwardRef } from 'react';
 
 // TODO(thure): A lot of the accessible affordances for this kind of thing need to be implemented per https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role
 
@@ -15,79 +12,29 @@ const LIST_NAME = 'List';
 
 type ListScopedProps<P> = P & { __listScope?: Scope };
 
-type ListVariant = 'ordered' | 'unordered' | 'ordered-draggable';
+type ListVariant = 'ordered' | 'unordered';
 
 type ListItemSizes = 'one' | 'many';
 
-type SharedListProps = {
+type ListProps = ComponentPropsWithRef<typeof Primitive.ol> & {
   selectable?: boolean;
   variant?: ListVariant;
-  listItemIds?: string[];
-  onDragEnd?: (event: DragEndEvent) => void;
-  onDragOver?: (event: DragOverEvent) => void;
   itemSizes?: ListItemSizes;
 };
-
-type SharedDraggableListProps = SharedListProps & {
-  listItemIds: Exclude<SharedListProps['listItemIds'], undefined>;
-  variant: 'ordered-draggable';
-};
-
-type HeterogeneousDraggableListProps = Exclude<SharedDraggableListProps, 'itemSizes'> & {
-  itemSizes?: 'many';
-};
-
-type HomogeneousDraggableListProps = Exclude<SharedDraggableListProps, 'itemSizes'> & {
-  itemSizes: 'one';
-};
-
-type BaseListProps = Omit<ComponentPropsWithRef<typeof Primitive.ol>, 'onDragEnd' | 'onDragOver'>;
-
-type ListProps =
-  | (BaseListProps & SharedListProps)
-  | (BaseListProps & HomogeneousDraggableListProps)
-  | (BaseListProps & HeterogeneousDraggableListProps);
 
 // LIST
 
 const [createListContext, createListScope] = createContextScope(LIST_NAME, []);
 
 type ListContextValue = Pick<ListProps, 'selectable' | 'variant'> & {
-  draggingId?: string;
   itemSizes?: ListItemSizes;
 };
 
 const [ListProvider, useListContext] = createListContext<ListContextValue>(LIST_NAME);
 
-const isOrderedDraggable = (props: ListProps): props is SharedDraggableListProps =>
-  props.variant === 'ordered-draggable';
-const _isOrderedDraggableHomogeneous = (props: ListProps): props is HomogeneousDraggableListProps =>
-  isOrderedDraggable(props) && props.itemSizes === 'one';
-const _isOrderedDraggableHeterogeneous = (props: ListProps): props is HeterogeneousDraggableListProps =>
-  isOrderedDraggable(props) && props.itemSizes !== 'one';
-
 const List = forwardRef<HTMLOListElement, ListProps>((props: ListScopedProps<ListProps>, forwardedRef) => {
-  const {
-    __listScope,
-    variant = 'ordered',
-    selectable = false,
-    onDragEnd,
-    onDragOver,
-    listItemIds,
-    itemSizes,
-    children,
-    ...rootProps
-  } = props;
-  const ListRoot = variant === 'ordered' || variant === 'ordered-draggable' ? Primitive.ol : Primitive.ul;
-  const [draggingId, setDraggingId] = useState<string | undefined>(undefined);
-  const onDragStart = useCallback((event: DragStartEvent) => setDraggingId(event.active.id as string), []);
-  const composedOnDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      setDraggingId(undefined);
-      onDragEnd?.(event);
-    },
-    [onDragEnd],
-  );
+  const { __listScope, variant = 'ordered', selectable = false, itemSizes, children, ...rootProps } = props;
+  const ListRoot = variant === 'ordered' ? Primitive.ol : Primitive.ul;
   return (
     <ListRoot {...(selectable && { role: 'listbox', 'aria-multiselectable': true })} {...rootProps} ref={forwardedRef}>
       <ListProvider
@@ -95,24 +42,10 @@ const List = forwardRef<HTMLOListElement, ListProps>((props: ListScopedProps<Lis
           scope: __listScope,
           variant,
           selectable,
-          draggingId,
           itemSizes,
         }}
       >
-        {isOrderedDraggable(props) ? (
-          <DndContext
-            onDragEnd={composedOnDragEnd}
-            onDragOver={onDragOver}
-            onDragStart={onDragStart}
-            modifiers={[restrictToVerticalAxis]}
-          >
-            <SortableContext items={listItemIds!} strategy={verticalListSortingStrategy}>
-              {children}
-            </SortableContext>
-          </DndContext>
-        ) : (
-          <>{children}</>
-        )}
+        {children}
       </ListProvider>
     </ListRoot>
   );
@@ -120,6 +53,6 @@ const List = forwardRef<HTMLOListElement, ListProps>((props: ListScopedProps<Lis
 
 List.displayName = LIST_NAME;
 
-export { List, createListScope, useListContext, LIST_NAME, arrayMove };
+export { List, createListScope, useListContext, LIST_NAME };
 
-export type { ListProps, ListVariant, ListScopedProps, DragEndEvent, DragOverEvent };
+export type { ListProps, ListVariant, ListScopedProps };

--- a/packages/ui/react-appkit/package.json
+++ b/packages/ui/react-appkit/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.0.5",
-    "@dnd-kit/modifiers": "^6.0.0",
     "@dnd-kit/sortable": "^7.0.1",
     "@dnd-kit/utilities": "^3.2.0",
     "@dxos/async": "workspace:*",

--- a/packages/ui/react-appkit/package.json
+++ b/packages/ui/react-appkit/package.json
@@ -44,6 +44,7 @@
     "@dxos/sentry": "workspace:*",
     "@dxos/telemetry": "workspace:*",
     "@dxos/util": "workspace:*",
+    "@radix-ui/react-compose-refs": "^1.0.0",
     "@radix-ui/react-navigation-menu": "^1.1.2",
     "@radix-ui/react-popover": "^1.0.5",
     "@radix-ui/react-portal": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5061,6 +5061,9 @@ importers:
 
   packages/ui/aurora:
     specifiers:
+      '@dnd-kit/core': ^6.0.5
+      '@dnd-kit/sortable': ^7.0.1
+      '@dnd-kit/utilities': ^3.2.0
       '@dxos/aurora-theme': workspace:*
       '@dxos/aurora-types': workspace:*
       '@dxos/react-hooks': workspace:*
@@ -5112,6 +5115,9 @@ importers:
       jdenticon: 3.2.0
       react-i18next: 11.18.6_vfm63zmruocgezzfl2v26zlzpy
     devDependencies:
+      '@dnd-kit/core': 6.0.5_biqbaboplfbrettd7655fr4n2y
+      '@dnd-kit/sortable': 7.0.1_vvd3dzag27tc7rclyb2whqqnpe
+      '@dnd-kit/utilities': 3.2.0_react@18.2.0
       '@dxos/aurora-theme': link:../aurora-theme
       '@phosphor-icons/react': 2.0.5_biqbaboplfbrettd7655fr4n2y
       '@types/react': 18.0.21
@@ -8828,7 +8834,6 @@ packages:
     dependencies:
       react: 18.2.0
       tslib: 2.5.0
-    dev: false
 
   /@dnd-kit/core/6.0.5_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-3nL+Zy5cT+1XwsWdlXIvGIFvbuocMyB4NBxTN74DeBaBqeWdH9JsnKwQv7buZQgAHmAH+eIENfS1ginkvW6bCw==}
@@ -8841,7 +8846,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       tslib: 2.5.0
-    dev: false
 
   /@dnd-kit/modifiers/6.0.0_vvd3dzag27tc7rclyb2whqqnpe:
     resolution: {integrity: sha512-V3+JSo6/BTcgPRHiNUTSKgqVv/doKXg+T4Z0QvKiiXp+uIyJTUtPkQOBRQApUWi3ApBhnoWljyt/3xxY4fTd0Q==}
@@ -8865,7 +8869,6 @@ packages:
       '@dnd-kit/utilities': 3.2.0_react@18.2.0
       react: 18.2.0
       tslib: 2.5.0
-    dev: false
 
   /@dnd-kit/utilities/3.2.0_react@18.2.0:
     resolution: {integrity: sha512-h65/pn2IPCCIWwdlR2BMLqRkDxpTEONA+HQW3n765HBijLYGyrnTCLa2YQt8VVjjSQD6EfFlTE6aS2Q/b6nb2g==}
@@ -8874,7 +8877,6 @@ packages:
     dependencies:
       react: 18.2.0
       tslib: 2.5.0
-    dev: false
 
   /@dxos/benchmark-suite/1.0.0-beta.3:
     resolution: {integrity: sha512-rpHryqIC1sOSWcGLyqnhJdLWDQ2jtidm7K8G/LQr1Xp3ibHO7cRg0w9v1RnYUDgyCtgWh4AWyec5lazNMCpAzw==}
@@ -19747,7 +19749,7 @@ packages:
   /axios/1.3.4_debug@4.3.4:
     resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2_debug@4.3.4
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,11 +591,11 @@ importers:
       '@dnd-kit/core': 6.0.5_biqbaboplfbrettd7655fr4n2y
       '@dnd-kit/sortable': 7.0.1_vvd3dzag27tc7rclyb2whqqnpe
       '@dnd-kit/utilities': 3.2.0_react@18.2.0
+      '@dxos/observable-object': link:../../../common/observable-object
     devDependencies:
       '@braneframe/plugin-theme': link:../plugin-theme
       '@dxos/aurora': link:../../../ui/aurora
       '@dxos/aurora-theme': link:../../../ui/aurora-theme
-      '@dxos/observable-object': link:../../../common/observable-object
       '@dxos/react-surface': link:../../../sdk/react-surface
       '@dxos/util': link:../../../common/util
       '@faker-js/faker': 7.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5325,10 +5325,6 @@ importers:
 
   packages/ui/primitives/react-list:
     specifiers:
-      '@dnd-kit/core': ^6.0.5
-      '@dnd-kit/modifiers': ^6.0.0
-      '@dnd-kit/sortable': ^7.0.1
-      '@dnd-kit/utilities': ^3.2.0
       '@dxos/react-hooks': workspace:*
       '@radix-ui/react-checkbox': ^1.0.3
       '@radix-ui/react-collapsible': ^1.0.2
@@ -5344,10 +5340,6 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
     dependencies:
-      '@dnd-kit/core': 6.0.5_biqbaboplfbrettd7655fr4n2y
-      '@dnd-kit/modifiers': 6.0.0_vvd3dzag27tc7rclyb2whqqnpe
-      '@dnd-kit/sortable': 7.0.1_vvd3dzag27tc7rclyb2whqqnpe
-      '@dnd-kit/utilities': 3.2.0_react@18.2.0
       '@dxos/react-hooks': link:../react-hooks
       '@radix-ui/react-collapsible': 1.0.2_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-compose-refs': 1.0.0_react@18.2.0
@@ -19755,7 +19747,7 @@ packages:
   /axios/1.3.4_debug@4.3.4:
     resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
     dependencies:
-      follow-redirects: 1.15.2_debug@4.3.4
+      follow-redirects: 1.15.2
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5334,7 +5334,6 @@ importers:
       '@dxos/react-hooks': workspace:*
       '@radix-ui/react-checkbox': ^1.0.3
       '@radix-ui/react-collapsible': ^1.0.2
-      '@radix-ui/react-compose-refs': ^1.0.0
       '@radix-ui/react-context': ^1.0.0
       '@radix-ui/react-primitive': ^1.0.2
       '@radix-ui/react-slot': ^1.0.1
@@ -5348,7 +5347,6 @@ importers:
     dependencies:
       '@dxos/react-hooks': link:../react-hooks
       '@radix-ui/react-collapsible': 1.0.2_biqbaboplfbrettd7655fr4n2y
-      '@radix-ui/react-compose-refs': 1.0.0_react@18.2.0
       '@radix-ui/react-context': 1.0.0_react@18.2.0
       '@radix-ui/react-primitive': 1.0.2_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-slot': 1.0.1_react@18.2.0
@@ -5384,6 +5382,7 @@ importers:
       '@dxos/telemetry': workspace:*
       '@dxos/util': workspace:*
       '@phosphor-icons/react': ^2.0.5
+      '@radix-ui/react-compose-refs': ^1.0.0
       '@radix-ui/react-navigation-menu': ^1.1.2
       '@radix-ui/react-popover': ^1.0.5
       '@radix-ui/react-portal': ^1.0.2
@@ -5422,6 +5421,7 @@ importers:
       '@dxos/sentry': link:../../common/sentry
       '@dxos/telemetry': link:../../common/telemetry
       '@dxos/util': link:../../common/util
+      '@radix-ui/react-compose-refs': 1.0.1_iapumuv4e6jcjznwuxpf4tt22e
       '@radix-ui/react-navigation-menu': 1.1.2_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-popover': 1.0.5_rj7ozvcq3uehdlnj3cbwzbi5ce
       '@radix-ui/react-portal': 1.0.2_biqbaboplfbrettd7655fr4n2y

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -575,7 +575,6 @@ importers:
     specifiers:
       '@braneframe/plugin-theme': workspace:*
       '@dnd-kit/core': ^6.0.5
-      '@dnd-kit/modifiers': ^6.0.0
       '@dnd-kit/sortable': ^7.0.1
       '@dnd-kit/utilities': ^3.2.0
       '@dxos/aurora': workspace:*
@@ -590,7 +589,6 @@ importers:
       typescript: ^5.0.4
     dependencies:
       '@dnd-kit/core': 6.0.5_biqbaboplfbrettd7655fr4n2y
-      '@dnd-kit/modifiers': 6.0.0_vvd3dzag27tc7rclyb2whqqnpe
       '@dnd-kit/sortable': 7.0.1_vvd3dzag27tc7rclyb2whqqnpe
       '@dnd-kit/utilities': 3.2.0_react@18.2.0
     devDependencies:
@@ -800,11 +798,15 @@ importers:
 
   packages/apps/plugins/plugin-stack:
     specifiers:
+      '@braneframe/plugin-dnd': workspace:*
       '@braneframe/plugin-markdown': workspace:*
       '@braneframe/plugin-space': workspace:*
       '@braneframe/plugin-splitview': workspace:*
       '@braneframe/plugin-theme': workspace:*
       '@braneframe/types': workspace:*
+      '@dnd-kit/core': ^6.0.5
+      '@dnd-kit/sortable': ^7.0.1
+      '@dnd-kit/utilities': ^3.2.0
       '@dxos/aurora': workspace:*
       '@dxos/aurora-theme': workspace:*
       '@dxos/observable-object': workspace:*
@@ -819,10 +821,14 @@ importers:
       react-dom: ^18.2.0
       vite: ^4.3.9
     dependencies:
+      '@dnd-kit/core': 6.0.5_biqbaboplfbrettd7655fr4n2y
+      '@dnd-kit/sortable': 7.0.1_vvd3dzag27tc7rclyb2whqqnpe
+      '@dnd-kit/utilities': 3.2.0_react@18.2.0
       '@dxos/observable-object': link:../../../common/observable-object
       '@dxos/util': link:../../../common/util
       lodash.get: 4.4.2
     devDependencies:
+      '@braneframe/plugin-dnd': link:../plugin-dnd
       '@braneframe/plugin-markdown': link:../plugin-markdown
       '@braneframe/plugin-space': link:../plugin-space
       '@braneframe/plugin-splitview': link:../plugin-splitview
@@ -5363,7 +5369,6 @@ importers:
   packages/ui/react-appkit:
     specifiers:
       '@dnd-kit/core': ^6.0.5
-      '@dnd-kit/modifiers': ^6.0.0
       '@dnd-kit/sortable': ^7.0.1
       '@dnd-kit/utilities': ^3.2.0
       '@dxos/async': workspace:*
@@ -5404,7 +5409,6 @@ importers:
       vite: ^4.3.9
     dependencies:
       '@dnd-kit/core': 6.0.5_biqbaboplfbrettd7655fr4n2y
-      '@dnd-kit/modifiers': 6.0.0_vvd3dzag27tc7rclyb2whqqnpe
       '@dnd-kit/sortable': 7.0.1_vvd3dzag27tc7rclyb2whqqnpe
       '@dnd-kit/utilities': 3.2.0_react@18.2.0
       '@dxos/async': link:../../common/async


### PR DESCRIPTION
This PR:
- removes DnD-related business from `react-list` and from `aurora`’s `List`.
- augments `react-appkit`’s `EditableList` to support very basic DnD
- fixes as many downstream packages affected by these changes
- prepares `StackPlugin` to support `DndPlugin`
- fixes numerous `DndPlugin` packaging issues

https://github.com/dxos/dxos/assets/855039/2be382a4-a043-4216-8814-b6943a7d082a

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0049aee</samp>

### Summary
🚚🖱️🧹

<!--
1.  🚚 - This emoji represents the moving of files, dependencies, and code from one place to another, such as changing the outputPath, removing unused imports, or adding new paths to tsconfig.json.
2.  🖱️ - This emoji represents the drag and drop functionality that was added or updated using the `dnd-kit` library and the `plugin-dnd` package. This affects the List, Stack, and EditableList components and their stories.
3.  🧹 - This emoji represents the cleaning up and simplifying of code, such as removing unused variants, components, and functions, or renaming variables to avoid confusion. This affects the List, ListItem, and StackMain components.
-->
This pull request updates several packages to use the `dnd-kit` library for drag and drop functionality, and to use the new @braneframe organization name and the observable object API. It also removes unused or unnecessary code and dependencies, and adds some new features and options for the plugin-dnd and plugin-stack apps.

> _`dnd-kit` library_
> _enables drag and drop features_
> _in many packages_

### Walkthrough
No walkthrough available (An error occurred while summarizing these changes: Gave up after 3 retries: Failed to read error response)

