### PR TITLE
fix: Agent liveness & blob sync rounding errors

### DIFF
--- a/packages/common/util/src/bitfield.ts
+++ b/packages/common/util/src/bitfield.ts
@@ -71,12 +71,16 @@ export class BitField {
   }
 
   static ones(count: number): Uint8Array {
-    const res = new Uint8Array(Math.ceil(count / 8)).fill(0xff);
+    const res = new Uint8Array(Math.ceil(Math.ceil(count) / 8)).fill(0xff);
 
     // Note: We need to calculate last byte of bitfield.
     const bitInLastByte = Math.ceil(count % 8);
     res[res.length - 1] = 0xff << (8 - bitInLastByte);
 
     return res;
+  }
+
+  static zeros(count: number): Uint8Array {
+    return new Uint8Array(Math.ceil(Math.ceil(count) / 8)).fill(0);
   }
 }

--- a/packages/core/agent/src/forever/forever-daemon.ts
+++ b/packages/core/agent/src/forever/forever-daemon.ts
@@ -28,9 +28,7 @@ export class ForeverDaemon implements Daemon {
   }
 
   async isRunning(profile: string): Promise<boolean> {
-    const { path: socketFile } = parseAddress(getUnixSocket(profile));
     return (
-      fs.existsSync(socketFile) ||
       isLocked(lockFilePath(profile)) ||
       (await this.list()).some((process) => process.profile === profile && process.running)
     );

--- a/packages/core/mesh/teleport-extension-object-sync/src/blob-store.ts
+++ b/packages/core/mesh/teleport-extension-object-sync/src/blob-store.ts
@@ -130,14 +130,14 @@ export class BlobStore {
         chunkSize: chunk.chunkSize ?? DEFAULT_CHUNK_SIZE,
         created: new Date(),
       };
-      meta.bitfield = new Uint8Array(Math.ceil(meta.length / meta.chunkSize / 8)).fill(0);
+      meta.bitfield = BitField.zeros(meta.length / meta.chunkSize);
     }
 
     if (chunk.chunkSize && chunk.chunkSize !== meta.chunkSize) {
       throw new Error('Invalid chunk size');
     }
 
-    assert(meta.bitfield, 'Bitfield not present');
+  assert(meta.bitfield, 'Bitfield not present');
     assert(chunk.chunkOffset !== undefined, 'chunkOffset is not present');
 
     // Write chunk.

--- a/packages/core/mesh/teleport-extension-object-sync/src/blob-store.ts
+++ b/packages/core/mesh/teleport-extension-object-sync/src/blob-store.ts
@@ -137,7 +137,7 @@ export class BlobStore {
       throw new Error('Invalid chunk size');
     }
 
-  assert(meta.bitfield, 'Bitfield not present');
+    assert(meta.bitfield, 'Bitfield not present');
     assert(chunk.chunkOffset !== undefined, 'chunkOffset is not present');
 
     // Write chunk.


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3018d6b</samp>

### Summary
🐛🧹✨

<!--
1.  🐛 for the bug fix in `BitField.ones`
2.  🧹 for the code cleanup and simplification in `ForeverDaemon.isRunning` and `BlobStore`
3.  ✨ for the new feature of `BitField.zeros`
-->
This pull request fixes a bug in `BitField.ones`, adds a new method `BitField.zeros`, simplifies the `isRunning` logic of `ForeverDaemon`, and refactors the bitfield creation for blob metadata in `BlobStore`. These changes improve the reliability and readability of the code.

> _We're the crew of the `ForeverDaemon`, we keep the process running_
> _We don't need no socket file, we know when it's done_
> _We heave and ho on the lock file, and check the process list_
> _And when we find a bitfield, we use the `zeros` method_

### Walkthrough
* Fix bug in `BitField.ones` method that could create bitfields with fewer bits than expected ([link](https://github.com/dxos/dxos/pull/3627/files?diff=unified&w=0#diff-3ff1910495103aafe16ff8013ba8f3600f98633970d44cb671d63ad7a4e1d019L74-R74))
* Add new `BitField.zeros` method to create bitfields with all bits set to zero ([link](https://github.com/dxos/dxos/pull/3627/files?diff=unified&w=0#diff-3ff1910495103aafe16ff8013ba8f3600f98633970d44cb671d63ad7a4e1d019R82-R85))
* Simplify logic of `isRunning` method in `ForeverDaemon` class by removing unreliable socket file check ([link](https://github.com/dxos/dxos/pull/3627/files?diff=unified&w=0#diff-b5dbaf47a6ea38e7795329712ff61bc11c9476aa0260e772e6b456902fc32104L31-R31))
* Refactor bitfield creation for blob metadata objects in `BlobStore` class by using `BitField.zeros` method and removing redundant division ([link](https://github.com/dxos/dxos/pull/3627/files?diff=unified&w=0#diff-556c4f12c984b1316342932966935bcc7ee258fbe7e3ea634be77909d7433257L133-R133))


