### PR TITLE
fix(plugin-space): Restore device invitation

### DIFF
--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -4,6 +4,7 @@
 
 import {
   ArrowLineLeft,
+  Devices,
   Download,
   EyeSlash,
   Intersect,
@@ -299,7 +300,7 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
           if (!clientPlugin) {
             return [];
           }
-          const indices = getIndices(2);
+          const indices = getIndices(3);
 
           // TODO(wittjosiah): Disable if no identity.
           return [
@@ -324,9 +325,19 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
               },
             },
             {
+              id: 'invite-device',
+              index: indices[2],
+              testId: 'spacePlugin.inviteDevice',
+              label: ['invite device label', { ns: 'os' }],
+              icon: Devices,
+              invoke: async () => {
+                await clientPlugin.provides.setLayout(ShellLayout.DEVICE_INVITATIONS);
+              },
+            },
+            {
               // TODO(wittjosiah): Move to SplitViewPlugin.
               id: 'close-sidebar',
-              index: indices[2],
+              index: indices[3],
               label: ['close sidebar label', { ns: 'os' }],
               icon: ArrowLineLeft,
               invoke: async () => {

--- a/packages/apps/plugins/plugin-theme/src/translations/en-US/os.ts
+++ b/packages/apps/plugins/plugin-theme/src/translations/en-US/os.ts
@@ -25,6 +25,7 @@ export const os = {
   'create identity description': 'Create a new identity.',
   'recover identity label': 'Use a seed phrase',
   'recover identity description': 'Enter your seed phrase to log in manually.',
+  'invite device label': 'Add a device',
   'join identity label': 'Use an authed device',
   'join identity description': 'Add this device to an identity you’re already logged into on another device.',
   'deselect identity label': 'Back to identities',

--- a/packages/sdk/client/project.json
+++ b/packages/sdk/client/project.json
@@ -29,11 +29,11 @@
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "options": {
+        "eslintConfig": "packages/sdk/client/eslint-config.json",
         "format": "unix",
         "lintFilePatterns": [
           "packages/sdk/client/**/*.{ts,tsx,js,jsx}"
-        ],
-        "eslintConfig": "packages/sdk/client/eslint-config.json"
+        ]
       },
       "outputs": [
         "{options.outputFile}"


### PR DESCRIPTION
This PR restores device invitations in apps that use `SpacePlugin` including Composer.

https://github.com/dxos/dxos/assets/855039/2b98484b-7539-4f2a-9415-25660de0a172

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6684d99</samp>

### Summary
🌐🎨📱

<!--
1.  🌐 - This emoji represents the addition of a new translation to the `os` namespace, which is related to internationalization and localization.
2.  🎨 - This emoji represents the minor formatting change to the `lint` target in the `nx.json` file, which is related to code style and aesthetics.
3.  📱 - This emoji represents the addition of a new button to invite devices to the space plugin, which is related to device management and functionality.
-->
Added a feature to invite devices to spaces from the space plugin UI. Updated the translation and linting configuration files accordingly.

> _To invite devices with a click_
> _The `SpacePlugin` got a new trick_
> _A `Devices` icon_
> _From `react-ux` was drawn_
> _And a label was added with `os` pick_

### Walkthrough
* Import `Devices` icon and add `invite-device` button to `SpacePlugin` component ([link](https://github.com/dxos/dxos/pull/3648/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839R7),[link](https://github.com/dxos/dxos/pull/3648/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L302-R303),[link](https://github.com/dxos/dxos/pull/3648/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L327-R340))
* Add `invite device label` translation to `os` namespace in `plugin-theme` package ([link](https://github.com/dxos/dxos/pull/3648/files?diff=unified&w=0#diff-b5df26ba826f13e09d92260b3bab2632c50ba06f44a191e7043397920ca6e8e6R28))
* Move `eslintConfig` option to top of `options` object in `lint` target of `client` project in `nx.json` file ([link](https://github.com/dxos/dxos/pull/3648/files?diff=unified&w=0#diff-cdf74a31fa6134276fed5c33455cd477d209a04b049d7265d7a9415ba5928110L32-R36))


