### PR TITLE
feat(devtools): Add stream stats

### DIFF
--- a/packages/core/echo/echo-pipeline/src/space/space-protocol.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space-protocol.ts
@@ -2,6 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
+import { Event } from '@dxos/async';
 import { discoveryKey, sha256 } from '@dxos/crypto';
 import { FeedWrapper } from '@dxos/feed-store';
 import { PublicKey } from '@dxos/keys';
@@ -14,6 +15,7 @@ import {
   WireProtocolParams,
   WireProtocolProvider,
 } from '@dxos/network-manager';
+import { ConnectionInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
 import type { FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
 import { Teleport } from '@dxos/teleport';
 import { BlobStore, BlobSync } from '@dxos/teleport-extension-object-sync';
@@ -202,6 +204,10 @@ export class SpaceProtocolSession implements WireProtocol {
   @logInfo
   get authStatus() {
     return this._authStatus;
+  }
+
+  get stats(): Event<ConnectionInfo.StreamStats[]> {
+    return this._teleport.stats;
   }
 
   // TODO(dmaretskyi): Allow to pass in extra extensions.

--- a/packages/core/mesh/network-manager/src/connection-log.ts
+++ b/packages/core/mesh/network-manager/src/connection-log.ts
@@ -68,7 +68,7 @@ export class ConnectionLog {
         this.update.emit();
       });
 
-      (connection.protocol as WireProtocol & { stats: Event<ConnectionInfo.StreamStats[]> }).stats.on((stats) => {
+      (connection.protocol as WireProtocol & { stats: Event<ConnectionInfo.StreamStats[]> })?.stats?.on((stats) => {
         connectionInfo.streams = stats;
         this.update.emit();
       });

--- a/packages/core/mesh/network-manager/src/connection-log.ts
+++ b/packages/core/mesh/network-manager/src/connection-log.ts
@@ -9,6 +9,7 @@ import { SwarmInfo, ConnectionInfo } from '@dxos/protocols/proto/dxos/devtools/s
 import { ComplexMap } from '@dxos/util';
 
 import { ConnectionState, Swarm } from './swarm';
+import { WireProtocol } from './wire-protocol';
 
 export enum EventType {
   CONNECTION_STATE_CHANGED = 'CONNECTION_STATE_CHANGED',
@@ -64,6 +65,11 @@ export class ConnectionLog {
           type: EventType.CONNECTION_STATE_CHANGED,
           newState: state,
         });
+        this.update.emit();
+      });
+
+      (connection.protocol as WireProtocol & { stats: Event<ConnectionInfo.StreamStats[]> }).stats.on((stats) => {
+        connectionInfo.streams = stats;
         this.update.emit();
       });
 

--- a/packages/core/mesh/teleport/src/teleport.ts
+++ b/packages/core/mesh/teleport/src/teleport.ts
@@ -5,12 +5,13 @@
 import assert from 'node:assert';
 import { Duplex } from 'node:stream';
 
-import { asyncTimeout, scheduleTaskInterval, runInContextAsync, synchronized, scheduleTask } from '@dxos/async';
+import { asyncTimeout, scheduleTaskInterval, runInContextAsync, synchronized, scheduleTask, Event } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { failUndefined } from '@dxos/debug';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { schema, RpcClosedError } from '@dxos/protocols';
+import { ConnectionInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
 import { ControlService } from '@dxos/protocols/proto/dxos/mesh/teleport/control';
 import { createProtoRpcPeer, ProtoRpcPeer } from '@dxos/rpc';
 import { Callback } from '@dxos/util';
@@ -88,6 +89,10 @@ export class Teleport {
 
   get stream(): Duplex {
     return this._muxer.stream;
+  }
+
+  get stats(): Event<ConnectionInfo.StreamStats[]> {
+    return this._muxer.statsUpdated;
   }
 
   /**

--- a/packages/core/protocols/src/proto/dxos/devtools/swarm.proto
+++ b/packages/core/protocols/src/proto/dxos/devtools/swarm.proto
@@ -17,12 +17,20 @@ message SwarmInfo {
 }
 
 message ConnectionInfo {
+  message StreamStats {
+    uint32 id = 1;
+    string tag = 2;
+    uint32 bytesSent = 3;
+    uint32 bytesReceived = 4;
+  }
+
   string state = 1;
   dxos.keys.PublicKey session_id = 2;
   dxos.keys.PublicKey remote_peer_id = 3;
   optional string transport = 4;
   repeated string protocol_extensions = 5;
   repeated ConnectionEvent events = 6;
+  repeated StreamStats streams = 7;
 }
 
 message ConnectionEvent {

--- a/packages/devtools/devtools/src/components/ConnectionInfoView.tsx
+++ b/packages/devtools/devtools/src/components/ConnectionInfoView.tsx
@@ -2,12 +2,15 @@
 // Copyright 2021 DXOS.org
 //
 
+import { Upload } from '@phosphor-icons/react';
 import React from 'react';
 
 import { ConnectionInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
+import { TreeView } from '@dxos/react-appkit';
 
 import { DetailsTable } from './DetailsTable';
 import { JsonView } from './JsonView';
+import { TreeItemText } from './TreeItemText';
 
 export interface ConnectionInfoViewProps {
   connectionInfo: ConnectionInfo;
@@ -30,6 +33,28 @@ export const ConnectionInfoView = ({ connectionInfo, onReturn }: ConnectionInfoV
         <JsonView
           data={{
             events: connectionInfo.events,
+          }}
+        />
+      ),
+      streams: (
+        <TreeView
+          items={
+            connectionInfo.streams?.map((streamStat) => ({
+              id: streamStat.id.toString(),
+              Icon: Upload,
+              Element: (
+                <TreeItemText
+                  primary={`| Up: ${streamStat.bytesSent} | Down: ${streamStat.bytesReceived} |`}
+                  secondary={streamStat.tag}
+                />
+              ),
+            })) ?? []
+          }
+          expanded={connectionInfo.streams?.map((streamStat) => streamStat.id.toString())}
+          slots={{
+            value: {
+              className: 'overflow-hidden text-gray-400 truncate pl-2',
+            },
           }}
         />
       ),

--- a/packages/devtools/devtools/src/components/ConnectionInfoView.tsx
+++ b/packages/devtools/devtools/src/components/ConnectionInfoView.tsx
@@ -3,6 +3,7 @@
 //
 
 import { Upload } from '@phosphor-icons/react';
+import bytes from 'bytes';
 import React from 'react';
 
 import { ConnectionInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
@@ -13,7 +14,7 @@ import { JsonView } from './JsonView';
 import { TreeItemText } from './TreeItemText';
 
 export interface ConnectionInfoViewProps {
-  connectionInfo: ConnectionInfo;
+  connectionInfo?: ConnectionInfo;
   /**
    * @deprecated
    */
@@ -21,43 +22,51 @@ export interface ConnectionInfoViewProps {
 }
 
 // TODO(burdon): Convert to table.
-export const ConnectionInfoView = ({ connectionInfo, onReturn }: ConnectionInfoViewProps) => (
-  <DetailsTable
-    object={{
-      state: connectionInfo.state,
-      sessionId: connectionInfo.sessionId.toHex(),
-      remotePeerId: connectionInfo.remotePeerId.toHex(),
-      transport: connectionInfo.transport,
-      protocolExtensions: connectionInfo.protocolExtensions?.join(','),
-      events: (
-        <JsonView
-          data={{
-            events: connectionInfo.events,
-          }}
-        />
-      ),
-      streams: (
-        <TreeView
-          items={
-            connectionInfo.streams?.map((streamStat) => ({
-              id: streamStat.id.toString(),
-              Icon: Upload,
-              Element: (
-                <TreeItemText
-                  primary={`| Up: ${streamStat.bytesSent} | Down: ${streamStat.bytesReceived} |`}
-                  secondary={streamStat.tag}
-                />
-              ),
-            })) ?? []
-          }
-          expanded={connectionInfo.streams?.map((streamStat) => streamStat.id.toString())}
-          slots={{
-            value: {
-              className: 'overflow-hidden text-gray-400 truncate pl-2',
-            },
-          }}
-        />
-      ),
-    }}
-  />
-);
+export const ConnectionInfoView = ({ connectionInfo, onReturn }: ConnectionInfoViewProps) => {
+  if (!connectionInfo) {
+    return null;
+  }
+
+  return (
+    <DetailsTable
+      object={{
+        state: connectionInfo.state,
+        sessionId: connectionInfo.sessionId.toHex(),
+        remotePeerId: connectionInfo.remotePeerId.toHex(),
+        transport: connectionInfo.transport,
+        protocolExtensions: connectionInfo.protocolExtensions?.join(','),
+        events: (
+          <JsonView
+            data={{
+              events: connectionInfo.events,
+            }}
+          />
+        ),
+        streams: (
+          <TreeView
+            items={
+              connectionInfo.streams?.map((streamStat) => ({
+                id: streamStat.id.toString(),
+                Icon: Upload,
+                Element: (
+                  <TreeItemText
+                    primary={`| Up: ${bytes.format(streamStat.bytesSent)} | Down: ${bytes.format(
+                      streamStat.bytesReceived,
+                    )} |`}
+                    secondary={streamStat.tag}
+                  />
+                ),
+              })) ?? []
+            }
+            expanded={connectionInfo.streams?.map((streamStat) => streamStat.id.toString())}
+            slots={{
+              value: {
+                className: 'overflow-hidden text-gray-400 truncate pl-2',
+              },
+            }}
+          />
+        ),
+      }}
+    />
+  );
+};

--- a/packages/devtools/devtools/src/components/TreeItemText.tsx
+++ b/packages/devtools/devtools/src/components/TreeItemText.tsx
@@ -1,3 +1,7 @@
+//
+// Copyright 2023 DXOS.org
+//
+
 import React, { ReactNode } from 'react';
 
 export type TreeItemTextProps = {

--- a/packages/devtools/devtools/src/panels/mesh/SwarmPanel.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SwarmPanel.tsx
@@ -5,7 +5,7 @@
 import { LinkBreak, LinkSimple, LinkSimpleBreak, ShareNetwork } from '@phosphor-icons/react';
 import React, { useState } from 'react';
 
-import { ConnectionInfo, SwarmInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
+import { SwarmInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
 import { TreeView, TreeViewItem } from '@dxos/react-appkit';
 import { useDevtools, useStream } from '@dxos/react-client';
 import { humanize } from '@dxos/util';
@@ -34,7 +34,7 @@ const getSwarmInfoTree = (swarms: SwarmInfo[]): TreeViewItem[] =>
 const SwarmPanel = () => {
   const devtoolsHost = useDevtools();
   const { data } = useStream(() => devtoolsHost.subscribeToSwarmInfo({}), {});
-  const [selectedItem, setSelectedItem] = useState<ConnectionInfo | undefined>();
+  const [selectedItem, setSelectedItem] = useState<string | undefined>();
 
   return (
     <PanelContainer className='flex-row'>
@@ -46,13 +46,17 @@ const SwarmPanel = () => {
               className: 'overflow-hidden text-gray-400 truncate pl-2',
             },
           }}
-          onSelect={(item: any) => setSelectedItem(item.value)}
-          selected={selectedItem?.sessionId.toHex()}
+          onSelect={(item: any) => setSelectedItem(item.id)}
+          selected={selectedItem}
         />
       </div>
       {selectedItem && (
         <div className='flex flex-1 flex-col w-2/3 overflow-auto'>
-          <ConnectionInfoView connectionInfo={selectedItem} />
+          <ConnectionInfoView
+            connectionInfo={data
+              ?.flatMap((swarm) => swarm.connections)
+              .find((connection) => connection?.sessionId.toHex() === selectedItem)}
+          />
         </div>
       )}
     </PanelContainer>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ec2cec9</samp>

### Summary
📊🌐🚀

<!--
1.  📊 - This emoji represents statistics, data, and charts, which are relevant to the main feature of this pull request.
2.  🌐 - This emoji represents networking, connections, and protocols, which are the domains that this pull request affects and enhances.
3.  🚀 - This emoji represents speed, performance, and optimization, which are some of the benefits and goals of this pull request.
-->
This pull request adds stream statistics to various classes and protocols that deal with connections and multiplexing in the core package. The statistics are exposed as events or properties that can be consumed by users or devtools. The pull request modifies the `SpaceProtocol`, `ConnectionLog`, `Muxer`, and `Teleport` classes, as well as the `swarm.proto` file.

> _`StreamStats` added_
> _To monitor connections_
> _Winter of debugging_

### Walkthrough
*  Add stream statistics to the `SpaceProtocolSession` class, which represents a session of the space protocol over a connection. ([link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-7faa4685f9eaaadf783ef564171100e0dac6e8c1308198606a99059d38be43c0R5), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-7faa4685f9eaaadf783ef564171100e0dac6e8c1308198606a99059d38be43c0R18), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-7faa4685f9eaaadf783ef564171100e0dac6e8c1308198606a99059d38be43c0R209-R212))
*  Import and use the `Event` class from `@dxos/async` to emit stream statistics as an array of `ConnectionInfo.StreamStats` objects, which are defined in the `swarm.proto` file. ([link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-7faa4685f9eaaadf783ef564171100e0dac6e8c1308198606a99059d38be43c0R5), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-7faa4685f9eaaadf783ef564171100e0dac6e8c1308198606a99059d38be43c0R209-R212), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-dca6eddbf8d5a9d0f4757e89710e90775785e32461a5b4b06d022d5bdab144f1L8-R8), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-dca6eddbf8d5a9d0f4757e89710e90775785e32461a5b4b06d022d5bdab144f1R94-R97), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-93f54b61119fb85788de2b99044227edbc6593159f45cb7a166ef45ff8a2b82dR20-R26), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-93f54b61119fb85788de2b99044227edbc6593159f45cb7a166ef45ff8a2b82dR33))
*  Import and use the `ConnectionInfo` message from `@dxos/protocols/proto/dxos/devtools/swarm` to represent the connection information of a space protocol session, including the stream statistics. ([link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-7faa4685f9eaaadf783ef564171100e0dac6e8c1308198606a99059d38be43c0R18), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R12), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-dca6eddbf8d5a9d0f4757e89710e90775785e32461a5b4b06d022d5bdab144f1R14), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-93f54b61119fb85788de2b99044227edbc6593159f45cb7a166ef45ff8a2b82dR33))
*  Delegate the `stats` property of the `SpaceProtocolSession` class to the underlying `Teleport` instance, which wraps the `Muxer` class and provides a higher-level abstraction for creating and managing streams over a connection. ([link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-7faa4685f9eaaadf783ef564171100e0dac6e8c1308198606a99059d38be43c0R209-R212), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-dca6eddbf8d5a9d0f4757e89710e90775785e32461a5b4b06d022d5bdab144f1R94-R97))
*  Add stream statistics to the `Muxer` class, which handles the multiplexing of streams over a single connection. ([link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R56-R57), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R87-R88), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R126-R127), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R254-R257), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R266-R267), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R280-R294), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R324-R328))
*  Initialize and update the `stats` property of each channel in the `Muxer` class, which is an object that has `bytesSent` and `bytesReceived` properties, which track the number of bytes sent and received for the channel. ([link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R254-R257), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R87-R88), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R126-R127), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R266-R267))
*  Add a public property `statsUpdated` to the `Muxer` class, which is an `Event` that emits an array of `ConnectionInfo.StreamStats` objects, representing the statistics of each channel in the multiplexer. ([link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R56-R57), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R280-R294))
*  Add a private method `_emitStats` to the `Muxer` class, which emits the latest stream statistics to the `statsUpdated` event, and checks if the multiplexer is destroyed or destroying before emitting the event. ([link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R280-R294))
*  Add an interface `StreamStats` to the `Muxer` class, which matches the `ConnectionInfo.StreamStats` message definition and has `id`, `tag`, `bytesSent`, and `bytesReceived` properties, representing the identifier, tag, and statistics of a stream in the multiplexer. ([link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R324-R328))
*  Add a listener for the `stats` event of the `connection.protocol` property in the `ConnectionLog` class, which implements the `WireProtocol` interface and also exposes a `stats` property that emits stream statistics. ([link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-722d9fe75c055645087e90a3586cbeba7bf109256b4789aecdcff96a937ff2fbR12), [link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-722d9fe75c055645087e90a3586cbeba7bf109256b4789aecdcff96a937ff2fbR71-R75))
*  Update the `connectionInfo.streams` property with the latest stream statistics and emit an `update` event to notify the listeners of the `ConnectionLog` instance. ([link](https://github.com/dxos/dxos/pull/3656/files?diff=unified&w=0#diff-722d9fe75c055645087e90a3586cbeba7bf109256b4789aecdcff96a937ff2fbR71-R75))


