### PR TITLE
fix(composer-app): PWA manifest

### DIFF
--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -66,16 +66,26 @@ export default defineConfig({
         name: 'DXOS Composer',
         short_name: 'Composer',
         description: 'DXOS Composer Application',
-        theme_color: '#ffffff',
+        theme_color: '#003E70',
         icons: [
           {
-            src: 'icons/icon-32.png',
+            src: 'favicon-16x16.png',
+            sizes: '16x16',
+            type: 'image/png',
+          },
+          {
+            src: 'favicon-32x32.png',
             sizes: '32x32',
             type: 'image/png',
           },
           {
-            src: 'icons/icon-256.png',
-            sizes: '256x256',
+            src: 'android-chrome-192x192.png',
+            sizes: '192x192',
+            type: 'image/png',
+          },
+          {
+            src: 'android-chrome-512x512.png',
+            sizes: '512x512',
             type: 'image/png',
           },
         ],


### PR DESCRIPTION
This PR fixes Composer’s PWA manifest so that it is valid again.

<img width="1209" alt="Screenshot 2023-07-17 at 15 54 34" src="https://github.com/dxos/dxos/assets/855039/93ba45f4-66b9-4ab9-b343-b62a5ef72ad3">

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 572cd4a</samp>

### Summary
🎨📱🚀

<!--
1.  🎨 - This emoji can be used to indicate that the theme_color and icons were changed to match the DXOS branding and colors, which is a visual or aesthetic improvement.
2.  📱 - This emoji can be used to signify that the web app manifest was updated to enhance the user experience and functionality of the web app when installed or added to the home screen of a device, which is a mobile or device-related improvement.
3.  🚀 - This emoji can be used to convey that the web app manifest was updated to improve the performance and speed of the web app when launched from the home screen of a device, which is a launch or delivery-related improvement.
-->
Updated web app manifest for `composer-app` to use DXOS branding and icons. This enhances the user experience and identity of the web app.

> _`theme_color`, icons_
> _match the DXOS branding_
> _web app shines in spring_

### Walkthrough
* Updated the web app manifest to match the DXOS branding and favicon ([link](https://github.com/dxos/dxos/pull/3662/files?diff=unified&w=0#diff-813f00d5c5485f0f83ea1fb6782e90691a233ccb1d82f30a61d1a956f996082eL69-R90)). This affects the `packages/apps/composer-app/vite.config.ts` file and the `packages/apps/composer-app/public/manifest.json` file, which define the metadata and icons of the web app.


