### PR TITLE
feat: Add testing invitations

### DIFF
--- a/packages/sdk/react-shell/src/panels/SpacePanel/SpacePanel.tsx
+++ b/packages/sdk/react-shell/src/panels/SpacePanel/SpacePanel.tsx
@@ -55,8 +55,11 @@ const CurrentSpaceView = observer(({ space, createInvitationUrl, titleId }: Spac
         />
         <Button
           classNames='is-full flex gap-2 mbs-2'
-          onClick={() => {
-            const invitation = space?.createInvitation();
+          onClick={(e) => {
+            const testing = e.altKey && e.shiftKey;
+            const invitation = space?.createInvitation(
+              testing ? { type: Invitation.Type.MULTIUSE, authMethod: Invitation.AuthMethod.NONE } : undefined,
+            );
             // TODO(wittjosiah): Don't depend on NODE_ENV.
             if (process.env.NODE_ENV !== 'production') {
               invitation.subscribe(onInvitationEvent);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 98d7a46</samp>

### Summary
🖱️🗝️💌

<!--
1.  🖱️ - This emoji represents the mouse click event that triggers the `onClick` handler of the `Button` component. It also suggests the idea of clicking with different modifier keys to create different invitations.
2.  🗝️ - This emoji represents the alt and shift keys that are used to modify the type of invitation that is created. It also suggests the idea of security and authentication, which are relevant concepts for the invitation flow.
3.  💌 - This emoji represents the invitation itself, which is the main outcome of the `createInvitation` method. It also suggests the idea of sending and receiving messages, which are part of the invitation flow.
-->
Added a way to create different types of invitations for spaces by holding alt and shift keys when clicking the invite button. Modified `SpacePanel.tsx` to handle the key events and call `createInvitation` with different arguments.

> _`onClick` handler_
> _alt and shift keys create_
> _different invites_

### Walkthrough
*  Enable creating different types of invitations by holding alt and shift keys ([link](https://github.com/dxos/dxos/pull/3670/files?diff=unified&w=0#diff-edbaf604d79d86cbe45401c32e8d5cc44bab1727f1f341494f436c3781d1075eL58-R62))


