### PR TITLE
feat(cli): Improve errors output on `dx agent start`

### DIFF
--- a/packages/devtools/cli/src/commands/agent/start.ts
+++ b/packages/devtools/cli/src/commands/agent/start.ts
@@ -4,8 +4,9 @@
 
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
+import { rmSync } from 'node:fs';
 
-import { AgentOptions, Agent, EchoProxyServer, EpochMonitor, FunctionsPlugin } from '@dxos/agent';
+import { AgentOptions, Agent, EchoProxyServer, EpochMonitor, FunctionsPlugin, parseAddress } from '@dxos/agent';
 import { runInContext, scheduleTaskInterval } from '@dxos/async';
 import { DX_RUNTIME } from '@dxos/client-protocol';
 import { Context } from '@dxos/context';
@@ -49,9 +50,16 @@ export default class Start extends BaseCommand<typeof Start> {
   }
 
   private async _runInForeground() {
+    const socket = `unix://${DX_RUNTIME}/profile/${this.flags.profile}/agent.sock`;
+    {
+      // Clear out old socket file.
+      const { path } = parseAddress(socket);
+      rmSync(path, { force: true });
+    }
+
     const options: AgentOptions = {
       profile: this.flags.profile,
-      socket: `unix://${DX_RUNTIME}/profile/${this.flags.profile}/agent.sock`,
+      socket,
       webSocket: this.flags['web-socket'],
     };
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a154ea7</samp>

### Summary
🛠️🚀🔌

<!--
1.  🛠️ - This emoji represents fixing or improving something, which is what the utility functions and logic do for the agent.
2.  🚀 - This emoji represents launching or deploying something, which is what starting the agent in foreground mode does.
3.  🔌 - This emoji represents connecting or disconnecting something, which is what the socket file and binding errors are related to.
-->
Improved agent start command to handle socket option. Fixed socket file cleanup in `start.ts` to prevent binding errors.

> _`socket` option_
> _needs utility functions_
> _clean up old file_

### Walkthrough
* Import `rmSync` and `parseAddress` functions to handle socket file deletion and parsing ([link](https://github.com/dxos/dxos/pull/3684/files?diff=unified&w=0#diff-6222175ce7615e14e17217b5e12fba644eb6f2ae31ca1db528cc6c57bedbb08cL7-R9))
* Extract `socket` option and create a block scope to remove any existing socket file before starting the agent ([link](https://github.com/dxos/dxos/pull/3684/files?diff=unified&w=0#diff-6222175ce7615e14e17217b5e12fba644eb6f2ae31ca1db528cc6c57bedbb08cL52-R62))
* Pass `socket` option to the agent constructor in `start.ts` ([link](https://github.com/dxos/dxos/pull/3684/files?diff=unified&w=0#diff-6222175ce7615e14e17217b5e12fba644eb6f2ae31ca1db528cc6c57bedbb08cL52-R62))


