### PR TITLE
feat(cli): Add unit test to test agent device join flow

### DIFF
--- a/packages/core/agent/src/daemon.ts
+++ b/packages/core/agent/src/daemon.ts
@@ -16,7 +16,11 @@ export interface Daemon {
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
 
-  start: (profile: string) => Promise<ProcessInfo>;
+  /**
+   * Start agent.
+   * @param params.config Path to config file.
+   */
+  start: (profile: string, params?: { config?: string }) => Promise<ProcessInfo>;
   stop: (profile: string, params?: { force?: boolean }) => Promise<ProcessInfo>;
   restart: (profile: string) => Promise<ProcessInfo>;
 

--- a/packages/core/agent/src/forever/forever-daemon.ts
+++ b/packages/core/agent/src/forever/forever-daemon.ts
@@ -59,7 +59,7 @@ export class ForeverDaemon implements Daemon {
     });
   }
 
-  async start(profile: string): Promise<ProcessInfo> {
+  async start(profile: string, params?: { config?: string }): Promise<ProcessInfo> {
     if (!(await this.isRunning(profile))) {
       const logDir = path.join(this._rootDir, 'profile', profile, 'logs');
       mkdirSync(logDir, { recursive: true });
@@ -78,7 +78,13 @@ export class ForeverDaemon implements Daemon {
       // https://github.com/foreversd/forever-monitor
       // TODO(burdon): Call local run services binary directly (not via CLI)?
       forever.startDaemon(process.argv[1], {
-        args: ['agent', 'start', '--foreground', `--profile=${profile}`],
+        args: [
+          'agent',
+          'start',
+          '--foreground',
+          `--profile=${profile}`,
+          params?.config ? `--config=${params.config}` : '',
+        ],
         uid: profile,
         max: 1,
         logFile, // Forever daemon process.

--- a/packages/devtools/cli/src/base-command.ts
+++ b/packages/devtools/cli/src/base-command.ts
@@ -304,7 +304,7 @@ export abstract class BaseCommand<T extends typeof Command = any> extends Comman
         const running = await daemon.isRunning(this.flags.profile);
         if (!running) {
           this.log(`Starting agent (${this.flags.profile})`);
-          await daemon.start(this.flags.profile);
+          await daemon.start(this.flags.profile, { config: this.flags.config });
         }
       });
     }
@@ -316,7 +316,6 @@ export abstract class BaseCommand<T extends typeof Command = any> extends Comman
   async getClient() {
     assert(this._clientConfig);
     if (!this._client) {
-      assert(this._clientConfig);
       if (this.flags['no-agent']) {
         this._client = new Client({ config: this._clientConfig });
       } else {

--- a/packages/devtools/cli/src/commands/agent/agent.test.ts
+++ b/packages/devtools/cli/src/commands/agent/agent.test.ts
@@ -11,7 +11,7 @@ import { describe, test } from '@dxos/test';
 
 import { BIN_PATH, runCommand } from '../../util';
 
-describe.only('agent', () => {
+describe('agent', () => {
   test('join two agent profiles', async () => {
     const haloName = 'TEST_NAME';
 

--- a/packages/devtools/cli/src/commands/agent/agent.test.ts
+++ b/packages/devtools/cli/src/commands/agent/agent.test.ts
@@ -76,14 +76,14 @@ describe('agent', () => {
 
     {
       log.info('Starting first test profile agent.');
-      await runCommand(`reset --profile=${host} --force --config=${HOST_CONFIG_PATH}`, __dirname);
+      await runCommand(`agent start --profile=${host} --config=${HOST_CONFIG_PATH}`, __dirname);
       log.info('Creating halo identity.');
       await runCommand(`halo create ${haloName} --profile=${host} --config=${HOST_CONFIG_PATH}`, __dirname);
     }
 
     {
       log.info('Starting second test profile agent.');
-      await runCommand(`reset --profile=${guest} --force --config=${GUEST_CONFIG_PATH}`, __dirname);
+      await runCommand(`agent start --profile=${guest} --config=${GUEST_CONFIG_PATH}`, __dirname);
     }
 
     {

--- a/packages/devtools/cli/src/commands/agent/agent.test.ts
+++ b/packages/devtools/cli/src/commands/agent/agent.test.ts
@@ -47,7 +47,7 @@ describe('agent', () => {
       await runCommand(`agent stop --profile=${firstProfile}`, __dirname);
       await runCommand(`agent stop --profile=${secondProfile}`, __dirname);
     }
-  }).timeout(60_000);
+  }).timeout(120_000);
 });
 
 const performHaloCLIInvitation = async (hostProfile: string, guestProfile: string) => {

--- a/packages/devtools/cli/src/commands/agent/agent.test.ts
+++ b/packages/devtools/cli/src/commands/agent/agent.test.ts
@@ -5,7 +5,7 @@
 import { expect } from 'chai';
 import yaml from 'js-yaml';
 import { spawn } from 'node:child_process';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import { Trigger, asyncTimeout } from '@dxos/async';

--- a/packages/devtools/cli/src/commands/agent/agent.test.ts
+++ b/packages/devtools/cli/src/commands/agent/agent.test.ts
@@ -15,24 +15,38 @@ describe.only('agent', () => {
   test('join two agent profiles', async () => {
     const haloName = 'TEST_NAME';
 
-    log.info('Starting first test profile agent.');
-    await runCommand('reset --profile=test-profile-1 --force', __dirname);
-    log.info('Creating halo identity.');
-    await runCommand(`halo create ${haloName} --profile=test-profile-1`, __dirname);
+    const firstProfile = 'test-profile-1';
+    const secondProfile = 'test-profile-2';
 
-    log.info('Starting second test profile agent.');
-    await runCommand('reset --profile=test-profile-2 --force', __dirname);
+    {
+      log.info('Starting first test profile agent.');
+      await runCommand(`reset --profile=${firstProfile} --force`, __dirname);
+      log.info('Creating halo identity.');
+      await runCommand(`halo create ${haloName} --profile=${firstProfile}`, __dirname);
+    }
 
-    log.info('Inviting second profile to join first profile halo.');
-    await performHaloCLIInvitation('test-profile-1', 'test-profile-2');
-    log.info('Invitation successful.');
+    {
+      log.info('Starting second test profile agent.');
+      await runCommand(`reset --profile=${secondProfile} --force`, __dirname);
+    }
 
-    // TODO(mykola): Remove fancy colorful output from the CLI.
-    const firstIdentity = await runCommand('halo --profile=test-profile-1 --json', __dirname);
-    const secondIdentity = await runCommand('halo --profile=test-profile-2 --json', __dirname);
-    expect(secondIdentity).to.equal(firstIdentity);
-    await runCommand('agent stop --profile=test-profile-1', __dirname);
-    await runCommand('agent stop --profile=test-profile-2', __dirname);
+    {
+      log.info('Inviting second profile to join first profile halo.');
+      await performHaloCLIInvitation(firstProfile, secondProfile);
+      log.info('Invitation successful.');
+    }
+
+    {
+      // TODO(mykola): Remove fancy colorful output from the CLI.
+      const firstIdentity = await runCommand(`halo --profile=${firstProfile} --json`, __dirname);
+      const secondIdentity = await runCommand(`halo --profile=${secondProfile} --json`, __dirname);
+      expect(secondIdentity).to.equal(firstIdentity);
+    }
+
+    {
+      await runCommand(`agent stop --profile=${firstProfile}`, __dirname);
+      await runCommand(`agent stop --profile=${secondProfile}`, __dirname);
+    }
   }).timeout(60_000);
 });
 

--- a/packages/devtools/cli/src/commands/agent/agent.test.ts
+++ b/packages/devtools/cli/src/commands/agent/agent.test.ts
@@ -3,58 +3,128 @@
 //
 
 import { expect } from 'chai';
+import yaml from 'js-yaml';
 import { spawn } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 import { Trigger, asyncTimeout } from '@dxos/async';
 import { log } from '@dxos/log';
-import { describe, test } from '@dxos/test';
+import { afterAll, beforeAll, describe, test } from '@dxos/test';
 
 import { BIN_PATH, runCommand } from '../../util';
 
 describe('agent', () => {
+  const TEST_FOLDER = '/tmp/dxos/testing/cli';
+  const HOST_CONFIG_PATH = join(TEST_FOLDER, 'config-host.yml');
+  const GUEST_CONFIG_PATH = join(TEST_FOLDER, 'config-guest.yml');
+
+  beforeAll(async () => {
+    // Create config files.
+    [
+      [HOST_CONFIG_PATH, join(TEST_FOLDER, 'host')],
+      [GUEST_CONFIG_PATH, join(TEST_FOLDER, 'guest')],
+    ].forEach(([configPath, storagePath]) => {
+      mkdirSync(dirname(configPath), { recursive: true });
+      writeFileSync(
+        configPath,
+        yaml.dump({
+          version: 1,
+          runtime: {
+            client: {
+              storage: {
+                persistent: true,
+                path: storagePath,
+              },
+            },
+            services: {
+              signaling: [
+                {
+                  server: 'wss://dev.kube.dxos.org/.well-known/dx/signal',
+                },
+                {
+                  server: 'wss://kube.dxos.org/.well-known/dx/signal',
+                },
+              ],
+              ice: [
+                {
+                  urls: 'stun:kube.dxos.org:3478',
+                },
+                {
+                  urls: 'turn:kube.dxos.org:3478',
+                  username: 'dxos',
+                  credential: 'dxos',
+                },
+              ],
+            },
+          },
+        }),
+      );
+    });
+  });
+
+  afterAll(async () => {
+    // Cleanup.
+    rmSync(TEST_FOLDER, { recursive: true, force: true });
+  });
+
   test('join two agent profiles', async () => {
     const haloName = 'TEST_NAME';
 
-    const firstProfile = 'test-profile-1';
-    const secondProfile = 'test-profile-2';
+    const host = 'test-profile-1';
+    const guest = 'test-profile-2';
 
     {
       log.info('Starting first test profile agent.');
-      await runCommand(`reset --profile=${firstProfile} --force`, __dirname);
+      await runCommand(`reset --profile=${host} --force --config=${HOST_CONFIG_PATH}`, __dirname);
       log.info('Creating halo identity.');
-      await runCommand(`halo create ${haloName} --profile=${firstProfile}`, __dirname);
+      await runCommand(`halo create ${haloName} --profile=${host} --config=${HOST_CONFIG_PATH}`, __dirname);
     }
 
     {
       log.info('Starting second test profile agent.');
-      await runCommand(`reset --profile=${secondProfile} --force`, __dirname);
+      await runCommand(`reset --profile=${guest} --force --config=${GUEST_CONFIG_PATH}`, __dirname);
     }
 
     {
       log.info('Inviting second profile to join first profile halo.');
-      await performHaloCLIInvitation(firstProfile, secondProfile);
+      await performHaloCLIInvitation({
+        host: { profile: host, config: HOST_CONFIG_PATH },
+        guest: { profile: guest, config: GUEST_CONFIG_PATH },
+      });
       log.info('Invitation successful.');
     }
 
     {
       // TODO(mykola): Remove fancy colorful output from the CLI.
-      const firstIdentity = await runCommand(`halo --profile=${firstProfile} --json`, __dirname);
-      const secondIdentity = await runCommand(`halo --profile=${secondProfile} --json`, __dirname);
+      const firstIdentity = await runCommand(`halo --profile=${host} --json --config=${HOST_CONFIG_PATH}`, __dirname);
+      const secondIdentity = await runCommand(
+        `halo --profile=${guest} --json --config=${GUEST_CONFIG_PATH}`,
+        __dirname,
+      );
       expect(secondIdentity).to.equal(firstIdentity);
     }
 
     {
-      await runCommand(`agent stop --profile=${firstProfile}`, __dirname);
-      await runCommand(`agent stop --profile=${secondProfile}`, __dirname);
+      await runCommand(`agent stop --profile=${host} --config=${HOST_CONFIG_PATH}`, __dirname);
+      await runCommand(`agent stop --profile=${guest} --config=${GUEST_CONFIG_PATH}`, __dirname);
     }
   }).timeout(120_000);
 });
 
-const performHaloCLIInvitation = async (hostProfile: string, guestProfile: string) => {
+type AgentDescription = {
+  profile: string;
+  config: string;
+};
+
+const performHaloCLIInvitation = async ({ host, guest }: { host: AgentDescription; guest: AgentDescription }) => {
   const invitation = new Trigger<string>();
   const secret = new Trigger<string>();
   const hostClosed = new Trigger();
-  const host = spawn(BIN_PATH, ['halo', 'share', `--profile=${hostProfile}`], { shell: true });
+  const hostProcess = spawn(BIN_PATH, ['halo', 'share', `--profile=${host.profile}`, `--config=${host.config}`], {
+    shell: true,
+    cwd: __dirname,
+  });
 
   {
     const handleHost = (data: Buffer) => {
@@ -73,13 +143,13 @@ const performHaloCLIInvitation = async (hostProfile: string, guestProfile: strin
           // });
         });
     };
-    host.stdout.on('data', handleHost);
-    host.stderr.on('data', handleHost);
-    host.on('error', (err) => {
+    hostProcess.stdout.on('data', handleHost);
+    hostProcess.stderr.on('data', handleHost);
+    hostProcess.on('error', (err) => {
       throw err;
     });
 
-    host.on('exit', (code) => {
+    hostProcess.on('exit', (code) => {
       if (code !== 0) {
         throw new Error(`Host process exited with code ${code}`);
       }
@@ -89,7 +159,10 @@ const performHaloCLIInvitation = async (hostProfile: string, guestProfile: strin
 
   const guestReadyForInvitation = new Trigger();
   const guestReadyForSecret = new Trigger();
-  const guest = spawn(BIN_PATH, ['halo', 'join', `--profile=${guestProfile}`], { shell: true });
+  const guestProcess = spawn(BIN_PATH, ['halo', 'join', `--profile=${guest.profile}`, `--config=${guest.config}`], {
+    shell: true,
+    cwd: __dirname,
+  });
 
   {
     const handleGuest = (data: Buffer) => {
@@ -108,20 +181,20 @@ const performHaloCLIInvitation = async (hostProfile: string, guestProfile: strin
         });
     };
 
-    guest.stdout.on('data', handleGuest);
+    guestProcess.stdout.on('data', handleGuest);
 
-    guest.stderr.on('data', handleGuest);
-    guest.on('error', (err) => {
+    guestProcess.stderr.on('data', handleGuest);
+    guestProcess.on('error', (err) => {
       throw err;
     });
   }
 
   await asyncTimeout(guestReadyForInvitation.wait(), 10_000);
-  guest.stdin.write(`${await invitation.wait()}\n`);
+  guestProcess.stdin.write(`${await invitation.wait()}\n`);
   await asyncTimeout(guestReadyForSecret.wait(), 10_000);
-  guest.stdin!.write(`${await secret.wait()}\n`);
+  guestProcess.stdin!.write(`${await secret.wait()}\n`);
 
   await asyncTimeout(hostClosed.wait(), 10_000);
-  host.kill();
-  guest.kill();
+  hostProcess.kill();
+  guestProcess.kill();
 };

--- a/packages/devtools/cli/src/commands/agent/agent.test.ts
+++ b/packages/devtools/cli/src/commands/agent/agent.test.ts
@@ -1,0 +1,113 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { expect } from 'chai';
+import { spawn } from 'node:child_process';
+
+import { Trigger, asyncTimeout } from '@dxos/async';
+import { log } from '@dxos/log';
+import { describe, test } from '@dxos/test';
+
+import { BIN_PATH, runCommand } from '../../util';
+
+describe.only('agent', () => {
+  test('join two agent profiles', async () => {
+    const haloName = 'TEST_NAME';
+
+    log.info('Starting first test profile agent.');
+    await runCommand('reset --profile=test-profile-1 --force', __dirname);
+    log.info('Creating halo identity.');
+    await runCommand(`halo create ${haloName} --profile=test-profile-1`, __dirname);
+
+    log.info('Starting second test profile agent.');
+    await runCommand('reset --profile=test-profile-2 --force', __dirname);
+
+    log.info('Inviting second profile to join first profile halo.');
+    await performHaloCLIInvitation('test-profile-1', 'test-profile-2');
+    log.info('Invitation successful.');
+
+    // TODO(mykola): Remove fancy colorful output from the CLI.
+    const firstIdentity = await runCommand('halo --profile=test-profile-1 --json', __dirname);
+    const secondIdentity = await runCommand('halo --profile=test-profile-2 --json', __dirname);
+    expect(secondIdentity).to.equal(firstIdentity);
+    await runCommand('agent stop --profile=test-profile-1', __dirname);
+    await runCommand('agent stop --profile=test-profile-2', __dirname);
+  }).timeout(60_000);
+});
+
+const performHaloCLIInvitation = async (hostProfile: string, guestProfile: string) => {
+  const invitation = new Trigger<string>();
+  const secret = new Trigger<string>();
+  const hostClosed = new Trigger();
+  const host = spawn(BIN_PATH, ['halo', 'share', `--profile=${hostProfile}`], { shell: true });
+
+  {
+    const handleHost = (data: Buffer) => {
+      data
+        .toString()
+        .split('\n')
+        .forEach((line: string) => {
+          if (line.includes('Invitation')) {
+            log('Invitation:', line.split(': ')[1]);
+            invitation.wake(line.split(': ')[1]);
+          }
+          if (line.includes('Secret')) {
+            log('Secret:', line.split(': ')[1]);
+            secret.wake(line.split(': ')[1]);
+          }
+          // });
+        });
+    };
+    host.stdout.on('data', handleHost);
+    host.stderr.on('data', handleHost);
+    host.on('error', (err) => {
+      throw err;
+    });
+
+    host.on('exit', (code) => {
+      if (code !== 0) {
+        throw new Error(`Host process exited with code ${code}`);
+      }
+      hostClosed.wake();
+    });
+  }
+
+  const guestReadyForInvitation = new Trigger();
+  const guestReadyForSecret = new Trigger();
+  const guest = spawn(BIN_PATH, ['halo', 'join', `--profile=${guestProfile}`], { shell: true });
+
+  {
+    const handleGuest = (data: Buffer) => {
+      data
+        .toString()
+        .split('\n')
+        .forEach((line: string) => {
+          if (line.includes('Invitation')) {
+            log('Ready for invitation');
+            guestReadyForInvitation.wake();
+          }
+          if (line.includes('Invitation code')) {
+            log('Ready for secret');
+            guestReadyForSecret.wake();
+          }
+        });
+    };
+
+    guest.stdout.on('data', handleGuest);
+
+    guest.stderr.on('data', handleGuest);
+    guest.on('error', (err) => {
+      throw err;
+    });
+  }
+
+  await asyncTimeout(guestReadyForInvitation.wait(), 10_000);
+  guest.stdin.write(`${await invitation.wait()}\n`);
+  await asyncTimeout(guestReadyForSecret.wait(), 10_000);
+  guest.stdin!.write(`${await secret.wait()}\n`);
+
+  await asyncTimeout(hostClosed.wait(), 10_000);
+  host.kill();
+  guest.kill();
+};

--- a/packages/devtools/cli/src/commands/agent/start.ts
+++ b/packages/devtools/cli/src/commands/agent/start.ts
@@ -109,7 +109,7 @@ export default class Start extends BaseCommand<typeof Start> {
       }
 
       try {
-        await daemon.start(this.flags.profile);
+        await daemon.start(this.flags.profile, { config: this.flags.config });
         this.log('Agent started.');
       } catch (err) {
         this.log(chalk`{red Failed to start daemon}: ${err}`);

--- a/packages/devtools/cli/src/commands/reset/index.ts
+++ b/packages/devtools/cli/src/commands/reset/index.ts
@@ -40,7 +40,7 @@ export default class Reset extends BaseCommand<typeof Reset> {
       // TODO(burdon): Problem if running manually.
       await this.execWithDaemon(async (daemon) => daemon.stop(this.flags.profile, { force: this.flags.force }));
 
-      this.warn('Deleting files...');
+      this.log(chalk`{red Deleting files...}`);
       paths.forEach((path) => {
         fs.rmSync(path, { recursive: true, force: true });
       });

--- a/packages/devtools/cli/src/util/test-util.ts
+++ b/packages/devtools/cli/src/util/test-util.ts
@@ -15,7 +15,7 @@ export const BIN_PATH = join(dirname(pkgUp.sync({ cwd: __dirname }) ?? failUndef
 
 export const runCommand = async (command: string, cwd: string) => {
   mkdirSync(cwd, { recursive: true });
-  const { stdout, stderr } = await asyncTimeout(promisify(exec)(`${BIN_PATH} ${command}`, { cwd: __dirname }), 10_000);
+  const { stdout, stderr } = await asyncTimeout(promisify(exec)(`${BIN_PATH} ${command}`, { cwd: __dirname }), 20_000);
   if (stderr) {
     throw new Error(stderr);
   }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 795fae9</samp>

### Summary
🧪🚨🛠️

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate the addition of a new test file for the agent command.
2.  🚨 - This emoji represents alert, warning, or emergency, and can be used to indicate the modification of the reset command to use the log method with a red color for the message about deleting files.
3.  🛠️ - This emoji represents tools, repair, or construction, and can be used to indicate the modification of the runCommand helper function to use the exec function and other utilities for better handling of interactive CLI commands.
-->
This pull request adds a new test file for the agent command, which creates and joins halo identities across different profiles using the CLI. It also modifies the reset command and the runCommand helper function to use different methods for printing messages and executing commands. It also adds some dependencies and fixes some imports.

> _New test for `agent`_
> _Spawns processes, checks halos_
> _Autumn of identities_

### Walkthrough
*  Add a new test file for the agent command ([link](https://github.com/dxos/dxos/pull/3691/files?diff=unified&w=0#diff-87ee433815d4f0150e954f526bf7676536a6f25c2241c2882cf50b3ff15f7211R1-R113)) that uses `node:child_process`, `@dxos/async`, `chai`, and `util` modules to create and join halo identities across different profiles.


