### PR TITLE
fix(composer-app): Visual polish

### DIFF
--- a/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
@@ -28,7 +28,7 @@ export const StandaloneLayout = ({
   return (
     <Main.Content classNames='min-bs-full'>
       <div role='none' className='mli-auto max-is-[60rem] min-bs-[100vh] bg-white dark:bg-neutral-925 flex flex-col'>
-        <div role='none' className='flex items-center gap-2 pis-0 pointer-fine:pis-6 lg:pis-0 pointer-fine:lg:pis-0'>
+        <div role='none' className='flex items-center gap-2 pis-0 pointer-fine:pis-8 lg:pis-0 pointer-fine:lg:pis-0'>
           <Input.Root id={`input--${model.id}`}>
             <Input.Label srOnly>{t('document title label')}</Input.Label>
             <Input.TextInput

--- a/packages/apps/plugins/plugin-markdown/src/translations.ts
+++ b/packages/apps/plugins/plugin-markdown/src/translations.ts
@@ -13,6 +13,7 @@ export default [
         'choose markdown from space dialog title': 'Choose one or more Documents to add',
         'empty choose markdown from space message': 'None available; try creating a new one instead?',
         'chooser done label': 'Add selected',
+        'create document label': 'Create new document',
       },
     },
   },

--- a/packages/apps/plugins/plugin-treeview/src/components/BranchTreeItem.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/BranchTreeItem.tsx
@@ -90,7 +90,7 @@ export const BranchTreeItem: ForwardRefExoticComponent<BranchTreeItemProps & Ref
           <TreeItem.Heading
             data-testid='spacePlugin.spaceTreeItemHeading'
             classNames={[
-              'grow text-start break-words pis-1 pbs-2.5 pointer-fine:pbs-1.5 text-sm font-medium',
+              'grow min-is-0 truncate text-start pis-1 pbs-2.5 pointer-fine:pbs-1.5 text-sm font-medium',
               error && 'text-error-700 dark:text-error-300',
               !disabled && 'cursor-pointer',
               disabled && staticDisabled,

--- a/packages/apps/plugins/plugin-treeview/src/components/LeafTreeItem.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/LeafTreeItem.tsx
@@ -24,8 +24,6 @@ import { appTx, staticDisabled, focusRing, getSize, mx } from '@dxos/aurora-them
 
 import { useTreeView } from '../TreeViewContext';
 
-const spaceExp = /\s/g;
-
 type SortableLeafTreeItemProps = { node: GraphNode } & Pick<SortableProps, 'rearranging'>;
 
 export const SortableLeafTreeItem: FC<SortableLeafTreeItemProps> = ({
@@ -76,9 +74,6 @@ export const LeafTreeItem: ForwardRefExoticComponent<LeafTreeItemProps & RefAttr
   const [optionsTooltipOpen, setOptionsTooltipOpen] = useState(false);
   const [optionsMenuOpen, setOptionsMenuOpen] = useState(false);
 
-  const label = Array.isArray(node.label) ? t(...node.label) : node.label;
-  const wrap = spaceExp.test(label);
-
   return (
     <TreeItem.Root
       classNames={['pis-7 pointer-fine:pis-6 pointer-fine:pie-0 flex rounded', focusRing, rearranging && 'invisible']}
@@ -120,7 +115,7 @@ export const LeafTreeItem: ForwardRefExoticComponent<LeafTreeItemProps & RefAttr
           className='text-start flex gap-2 justify-start'
         >
           <Icon weight='regular' className={mx(getSize(4), 'shrink-0 mbs-2')} />
-          <p className={mx(modified && 'italic', 'flex-1 min-is-0 mbs-1', wrap ? 'break-words' : 'truncate')}>
+          <p className={mx(modified && 'italic', 'flex-1 min-is-0 mbs-1 truncate')}>
             {Array.isArray(node.label) ? t(...node.label) : node.label}
           </p>
         </button>

--- a/packages/ui/aurora-theme/src/styles/components/main.ts
+++ b/packages/ui/aurora-theme/src/styles/components/main.ts
@@ -5,7 +5,7 @@
 import { ComponentFunction } from '@dxos/aurora-types/src';
 
 import { mx } from '../../util';
-import { baseSurface } from '../fragments';
+import { baseSurface, inlineSeparator } from '../fragments';
 
 export type MainStyleProps = Partial<{
   isLg: boolean;
@@ -17,6 +17,7 @@ export const mainSidebar: ComponentFunction<MainStyleProps> = ({ isLg, sidebarOp
     'fixed block-start-0 block-end-0 is-[100vw] sm:is-[270px] z-10 overscroll-contain overflow-x-hidden overflow-y-auto',
     'transition-[inset-inline-start,inset-inline-end] duration-200 ease-in-out',
     sidebarOpen ? 'inline-start-0' : '-inline-start-[100vw] sm:-inline-start-[270px]',
+    inlineSeparator,
     baseSurface,
     ...etc,
   );

--- a/packages/ui/aurora-theme/src/styles/components/tooltip.ts
+++ b/packages/ui/aurora-theme/src/styles/components/tooltip.ts
@@ -11,7 +11,7 @@ export type TooltipStyleProps = {};
 
 export const tooltipContent: ComponentFunction<TooltipStyleProps> = (_props, ...etc) =>
   mx(
-    'inline-flex items-center rounded-md plb-1 pli-2',
+    'inline-flex items-center rounded-md plb-2 pli-3',
     chromeSurface,
     surfaceElevation({ elevation: 'group' }),
     chromeText,

--- a/packages/ui/aurora-theme/src/styles/fragments/ornament.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/ornament.ts
@@ -2,5 +2,5 @@
 // Copyright 2022 DXOS.org
 //
 
-export const inlineSeparator = 'border-is border-neutral-200 dark:border-neutral-800';
-export const blockSeparator = 'border-bs border-neutral-200 dark:border-neutral-800';
+export const inlineSeparator = 'border-ie border-neutral-200 dark:border-neutral-800';
+export const blockSeparator = 'border-be border-neutral-200 dark:border-neutral-800';


### PR DESCRIPTION
This PR addresses minor but very noticeable issues in Composer:
- treeitems no longer wrap, only truncate headings
- minor spacing issues
- a border on the sidebar
- a missing translation

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 29b2c86</samp>

### Summary
🎨🌐♻️

<!--
1.  🎨 - This emoji is often used for changes related to UI design, layout, or styling. It could apply to the first, fourth, and sixth changes, which all involve adjusting the appearance or spacing of UI elements.
2.  🌐 - This emoji is often used for changes related to internationalization, localization, or translations. It could apply to the second change, which adds a new translation key for a UI label.
3.  ♻️ - This emoji is often used for changes related to refactoring, simplifying, or improving the code quality or logic. It could apply to the third and fifth changes, which both involve changing the way the code handles text overflow and border directions, as well as the seventh change, which removes unnecessary code and improves performance.
-->
This pull request updates the UI and code of the treeview and markdown plugins, as well as the aurora theme. It improves the visual design, readability, performance, and compatibility of the components and styles.

> _The markdown editor got some tweaks_
> _To polish its buttons and peaks_
> _The tree items truncate_
> _The tooltip looks great_
> _And the sidebar has `inlineSeparator` streaks_

### Walkthrough
* Increase the padding of the document title input in the standalone markdown editor ([link](https://github.com/dxos/dxos/pull/3692/files?diff=unified&w=0#diff-2dad9280901d107c07117e32c1eaa07331e303c02d11699a00ec95431dd64eacL31-R31)) and add a translation key for the create document button ([link](https://github.com/dxos/dxos/pull/3692/files?diff=unified&w=0#diff-dc3d59bfba77ba544a381fce29ae64058128ea2abec1aec79da6b8a487b02049R16)) in `plugin-markdown`.


