### PR TITLE
fix(cli): Fix `agent restart` command

### DIFF
--- a/packages/core/agent/src/agent.ts
+++ b/packages/core/agent/src/agent.ts
@@ -51,8 +51,7 @@ export class Agent {
     return this;
   }
 
-  // TODO(mykola): Remove functions flag, and use different ports for different profiles.
-  async start({ functions = false }: { functions?: boolean } = {}) {
+  async start() {
     log('starting...');
 
     // TODO(burdon): Check if running.

--- a/packages/core/agent/src/daemon.ts
+++ b/packages/core/agent/src/daemon.ts
@@ -9,6 +9,10 @@ export type ProcessInfo = {
   started?: number;
 };
 
+export type StartOptions = {
+  config?: string;
+};
+
 /**
  * Manages life cycle of agent processes.
  */
@@ -20,9 +24,9 @@ export interface Daemon {
    * Start agent.
    * @param params.config Path to config file.
    */
-  start: (profile: string, params?: { config?: string }) => Promise<ProcessInfo>;
-  stop: (profile: string, params?: { force?: boolean }) => Promise<ProcessInfo>;
-  restart: (profile: string) => Promise<ProcessInfo>;
+  start: (profile: string, opts?: StartOptions) => Promise<ProcessInfo>;
+  stop: (profile: string, opts?: { force?: boolean }) => Promise<ProcessInfo>;
+  restart: (profile: string, opts?: StartOptions) => Promise<ProcessInfo>;
 
   isRunning: (profile: string) => Promise<boolean>;
   list: () => Promise<ProcessInfo[]>;

--- a/packages/core/agent/src/forever/forever-daemon.ts
+++ b/packages/core/agent/src/forever/forever-daemon.ts
@@ -11,7 +11,7 @@ import { Trigger, asyncTimeout, waitForCondition } from '@dxos/async';
 import { SystemStatus, fromAgent, getUnixSocket } from '@dxos/client';
 import { log } from '@dxos/log';
 
-import { Daemon, ProcessInfo } from '../daemon';
+import { Daemon, ProcessInfo, StartOptions } from '../daemon';
 import { DAEMON_START_TIMEOUT } from '../defs';
 import { lockFilePath, parseAddress, removeSocketFile, waitFor } from '../util';
 
@@ -59,7 +59,7 @@ export class ForeverDaemon implements Daemon {
     });
   }
 
-  async start(profile: string, params?: { config?: string }): Promise<ProcessInfo> {
+  async start(profile: string, params?: StartOptions): Promise<ProcessInfo> {
     if (!(await this.isRunning(profile))) {
       const logDir = path.join(this._rootDir, 'profile', profile, 'logs');
       mkdirSync(logDir, { recursive: true });
@@ -154,9 +154,9 @@ export class ForeverDaemon implements Daemon {
     return proc;
   }
 
-  async restart(profile: string): Promise<ProcessInfo> {
+  async restart(profile: string, params?: StartOptions): Promise<ProcessInfo> {
     await this.stop(profile);
-    return this.start(profile);
+    return this.start(profile, params);
   }
 
   async _getProcess(profile?: string): Promise<ProcessInfo> {

--- a/packages/devtools/cli/bin/dev
+++ b/packages/devtools/cli/bin/dev
@@ -1,6 +1,9 @@
 #!/usr/bin/env -S node --no-warnings
 // NOTE: Specify --no-warnings in production script.
 
+const chalk = require('chalk');
+console.log(chalk`{yellow.bold Warning: Running CLI in dev mode (only for development purposes).}`)
+
 const oclif = require('@oclif/core')
 
 const path = require('path')

--- a/packages/devtools/cli/src/commands/agent/restart.ts
+++ b/packages/devtools/cli/src/commands/agent/restart.ts
@@ -10,7 +10,7 @@ export default class Restart extends BaseCommand<typeof Restart> {
 
   async run(): Promise<any> {
     return await this.execWithDaemon(async (daemon) => {
-      const process = await daemon.restart(this.flags.profile);
+      const process = await daemon.restart(this.flags.profile, { config: this.flags.config });
       this.log('Restarted: ', process);
     });
   }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 00e4aff</samp>

### Summary
🧹🛠️📝

<!--
1.  🧹 for the simplification and cleanup of the `start` method of the `Agent` class.
2.  🛠️ for the improvement and fix of the `run` method of the `restart` command in `devtools/cli`.
3.  📝 for the addition and documentation of the `StartOptions` type in `../daemon` and `forever-daemon.ts`.
-->
Refactored the `Daemon` interface and its implementations to use a new `StartOptions` type for optional parameters. Simplified the `Agent` class and the `restart` command in `devtools/cli` to use the new interface and allow custom config files.

> _We are the agents of the daemon_
> _We start and restart with no fear_
> _We use the `StartOptions` to customize our fate_
> _We refactor the code to make it clear_

### Walkthrough
*  Simplify `start` method of `Agent` class by removing unused `functions` parameter and flag ([link](https://github.com/dxos/dxos/pull/3699/files?diff=unified&w=0#diff-b9f82346256c8e3a09b62d4af127cf173db784b0550b1600dffb6080087a3061L54-R54))
*  Introduce `StartOptions` type to define common interface for optional parameters of `start` and `restart` methods of `Daemon` interface ([link](https://github.com/dxos/dxos/pull/3699/files?diff=unified&w=0#diff-7fc4a7fa0ca0198804872e0101ccd1f763998d2b5df984c9b12611bb743ac7fdR12-R15), [link](https://github.com/dxos/dxos/pull/3699/files?diff=unified&w=0#diff-7fc4a7fa0ca0198804872e0101ccd1f763998d2b5df984c9b12611bb743ac7fdL23-R29))
*  Use `StartOptions` type in `ForeverDaemon` class, which implements `Daemon` interface, and pass it to `forever` module ([link](https://github.com/dxos/dxos/pull/3699/files?diff=unified&w=0#diff-b5dbaf47a6ea38e7795329712ff61bc11c9476aa0260e772e6b456902fc32104L14-R14), [link](https://github.com/dxos/dxos/pull/3699/files?diff=unified&w=0#diff-b5dbaf47a6ea38e7795329712ff61bc11c9476aa0260e772e6b456902fc32104L62-R62), [link](https://github.com/dxos/dxos/pull/3699/files?diff=unified&w=0#diff-b5dbaf47a6ea38e7795329712ff61bc11c9476aa0260e772e6b456902fc32104L157-R159))
*  Allow passing `config` flag as part of `StartOptions` type to `restart` command in `devtools/cli` ([link](https://github.com/dxos/dxos/pull/3699/files?diff=unified&w=0#diff-ada30872837eab8b2136ee5d5c38d7e7bad5156aa49384297b8a2e1a67f20b41L13-R13))


