### PR TITLE
fix(devtools-extension): missed client imports

### DIFF
--- a/packages/devtools/devtools-extension/src/sandbox.tsx
+++ b/packages/devtools/devtools-extension/src/sandbox.tsx
@@ -7,12 +7,11 @@ import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { asyncTimeout } from '@dxos/async';
-import { Client, ClientServicesProxy, Config } from '@dxos/client';
 import { Defaults } from '@dxos/config';
 import { Devtools } from '@dxos/devtools';
 import { log } from '@dxos/log';
 import { useAsyncEffect } from '@dxos/react-async';
-import { ClientContextProps } from '@dxos/react-client';
+import { Client, ClientServicesProxy, Config, ClientContextProps } from '@dxos/react-client';
 import { RpcPort } from '@dxos/rpc';
 
 import { initSentry } from './utils';


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 81d86bd</samp>

### Summary
📦🚚🧹

<!--
1.  📦 This emoji can be used to indicate that the imports were grouped together or packaged into one line.
2.  🚚 This emoji can be used to indicate that the imports were moved to a different location or order in the code.
3.  🧹 This emoji can be used to indicate that the imports were cleaned up or simplified.
-->
Refactored imports from `@dxos/react-client` in `sandbox.tsx` to improve code style.

> _`react-client` imports_
> _consolidated and moved_
> _a tidy spring cleaning_

### Walkthrough
*  Consolidate and reorder imports from `@dxos/react-client` in `sandbox.tsx` ([link](https://github.com/dxos/dxos/pull/3705/files?diff=unified&w=0#diff-2c2e71e68184817f5c61116bbbd3cf2c9b7abf011cf785e7a1c49ce945a35507L10-R14))


