### PR TITLE
feat(cli): Add `force` flag to `agent stop` command improve CLI lifecycle managment

### DIFF
--- a/packages/common/typings/src/forever.d.ts
+++ b/packages/common/typings/src/forever.d.ts
@@ -122,4 +122,6 @@ declare module 'forever' {
   export const list: (format: boolean, callback: (err: Error, processes: ForeverProcess[]) => void) => void;
 
   export const kill: (pid: number, killTree?: boolean, signal?: string, callback?: () => any) => void;
+
+  export const cleanUp: (cleanUpLogs: boolean, allowManager: boolean) => void;
 }

--- a/packages/core/agent/src/forever/forever-daemon.ts
+++ b/packages/core/agent/src/forever/forever-daemon.ts
@@ -89,7 +89,7 @@ export class ForeverDaemon implements Daemon {
           params?.config ? `--config=${params.config}` : '',
         ],
         uid: profile,
-        max: 1,
+        max: 0,
         logFile, // Forever daemon process.
         outFile, // Child stdout.
         errFile, // Child stderr.

--- a/packages/core/agent/src/forever/forever-daemon.ts
+++ b/packages/core/agent/src/forever/forever-daemon.ts
@@ -141,7 +141,7 @@ export class ForeverDaemon implements Daemon {
     // This is necessary when somehow few processes are started with the same profile.
     (await this.list()).forEach((process) => {
       if (process.profile === profile) {
-        if (force) {
+        if (force && process.running) {
           forever.stop(process.profile!);
         } else {
           forever.kill(proc.pid!, true, 'SIGINT');

--- a/packages/core/agent/src/forever/forever-daemon.ts
+++ b/packages/core/agent/src/forever/forever-daemon.ts
@@ -60,6 +60,12 @@ export class ForeverDaemon implements Daemon {
 
   async start(profile: string, params?: StartOptions): Promise<ProcessInfo> {
     if (!(await this.isRunning(profile))) {
+      // Check if there is stopped process.
+      if ((await this._getProcess(profile)).running === false) {
+        // NOTE: This kills forever watchdog process. We do not try to restart it in case if arguments changed.
+        await this.stop(profile);
+      }
+
       const logDir = path.join(this._rootDir, 'profile', profile, 'logs');
       mkdirSync(logDir, { recursive: true });
       log('starting...', { profile, logDir });

--- a/packages/core/agent/src/forever/forever-daemon.ts
+++ b/packages/core/agent/src/forever/forever-daemon.ts
@@ -47,7 +47,6 @@ export class ForeverDaemon implements Daemon {
     });
 
     return result.map(({ uid, foreverPid, ctime, running, restarts, logFile, ..._rest }: ForeverProcess) => {
-      // console.log(Object.keys(_rest));
       return {
         profile: uid,
         pid: foreverPid,
@@ -135,9 +134,7 @@ export class ForeverDaemon implements Daemon {
     return proc;
   }
 
-  async stop(profile: string, { force = true }: { force?: boolean } = {}): Promise<ProcessInfo | undefined> {
-    log.info('stopping', { profile, running });
-
+  async stop(profile: string, { force = false }: { force?: boolean } = {}): Promise<ProcessInfo | undefined> {
     const proc = await this._getProcess(profile);
 
     // NOTE: Kill all processes with the given profile.
@@ -145,7 +142,6 @@ export class ForeverDaemon implements Daemon {
     (await this.list()).forEach((process) => {
       if (process.profile === profile) {
         if (force) {
-          console.log('Killing process force');
           forever.stop(process.profile!);
         } else {
           forever.kill(proc.pid!, true, 'SIGINT');
@@ -158,7 +154,6 @@ export class ForeverDaemon implements Daemon {
     });
 
     removeSocketFile(profile);
-    log.info('stopped', { profile });
     return proc;
   }
 

--- a/packages/devtools/cli/src/commands/agent/agent.test.ts
+++ b/packages/devtools/cli/src/commands/agent/agent.test.ts
@@ -10,7 +10,7 @@ import { dirname, join } from 'node:path';
 
 import { Trigger, asyncTimeout } from '@dxos/async';
 import { log } from '@dxos/log';
-import { afterAll, beforeAll, describe, test } from '@dxos/test';
+import { describe, test } from '@dxos/test';
 
 import { BIN_PATH, runCommand } from '../../util';
 
@@ -19,7 +19,7 @@ describe('agent', () => {
   const HOST_CONFIG_PATH = join(TEST_FOLDER, 'config-host.yml');
   const GUEST_CONFIG_PATH = join(TEST_FOLDER, 'config-guest.yml');
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     // Create config files.
     [
       [HOST_CONFIG_PATH, join(TEST_FOLDER, 'host')],
@@ -63,7 +63,7 @@ describe('agent', () => {
     });
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     // Cleanup.
     rmSync(TEST_FOLDER, { recursive: true, force: true });
   });
@@ -112,6 +112,18 @@ describe('agent', () => {
   })
     .timeout(120_000)
     .tag('flaky');
+
+  test('stop command', async () => {
+    const profile1 = 'test-profile-1';
+    const profile2 = 'test-profile-2';
+    await runCommand(`agent start --profile=${profile1} --config=${HOST_CONFIG_PATH}`, __dirname);
+    await runCommand(`create halo FIRST --profile=${profile1} --config=${HOST_CONFIG_PATH}`, __dirname);
+    await runCommand(`agent start --profile=${profile2} --config=${HOST_CONFIG_PATH}`, __dirname);
+    await runCommand(`create halo SECOND --profile=${profile2} --config=${HOST_CONFIG_PATH}`, __dirname);
+    await runCommand('agent stop --all --force', __dirname);
+    const listAfterStop = await runCommand('agent list --json', __dirname);
+    expect(JSON.parse(listAfterStop)).to.equal([]);
+  }).tag('flaky');
 });
 
 type AgentDescription = {

--- a/packages/devtools/cli/src/commands/agent/list.ts
+++ b/packages/devtools/cli/src/commands/agent/list.ts
@@ -44,7 +44,9 @@ export default class List extends BaseCommand<typeof List> {
   async run(): Promise<any> {
     return await this.execWithDaemon(async (daemon) => {
       const result = await daemon.list();
-      printAgents(result);
+      if (!this.flags.json) {
+        printAgents(result);
+      }
       return result;
     });
   }

--- a/packages/devtools/cli/src/commands/agent/list.ts
+++ b/packages/devtools/cli/src/commands/agent/list.ts
@@ -25,7 +25,12 @@ export const printAgents = (daemons: any[], flags = {}) => {
       },
       uptime: {
         header: 'uptime',
-        get: (row) => formatDistance(new Date(), new Date(row.started)),
+        get: (row) => {
+          if (!row.running) {
+            return 'stopped';
+          }
+          return formatDistance(new Date(), new Date(row.started));
+        },
       },
       logFile: {
         header: 'logFile',

--- a/packages/devtools/cli/src/commands/agent/stop.ts
+++ b/packages/devtools/cli/src/commands/agent/stop.ts
@@ -13,8 +13,8 @@ export default class Stop extends BaseCommand<typeof Stop> {
 
   static override flags = {
     ...BaseCommand.flags,
-    all: Flags.boolean({ char: 'a', description: 'Stop all agents.' }),
-    force: Flags.boolean({ char: 'f', description: 'Force stop.' }),
+    all: Flags.boolean({ description: 'Stop all agents.' }),
+    force: Flags.boolean({ description: 'Force stop.' }),
   };
 
   async run(): Promise<any> {

--- a/packages/devtools/cli/src/commands/agent/stop.ts
+++ b/packages/devtools/cli/src/commands/agent/stop.ts
@@ -3,6 +3,7 @@
 //
 
 import { Flags } from '@oclif/core';
+import chalk from 'chalk';
 
 import { BaseCommand } from '../../base-command';
 
@@ -19,6 +20,9 @@ export default class Stop extends BaseCommand<typeof Stop> {
   async run(): Promise<any> {
     return await this.execWithDaemon(async (daemon) => {
       const stop = async (profile: string) => {
+        if (this.flags.force) {
+          this.log(chalk`Force stopping agent {yellow ${profile}}`);
+        }
         const process = await daemon.stop(profile, { force: this.flags.force });
         if (process) {
           this.log('Agent stopped');
@@ -27,15 +31,9 @@ export default class Stop extends BaseCommand<typeof Stop> {
 
       if (this.flags.all) {
         const processes = await daemon.list();
-        await Promise.all(
-          processes.map(async ({ profile }) => {
-            await daemon.stop(profile!, { force: this.flags.force });
-            this.log(`Agent stopped: ${profile}`);
-          }),
-        );
+        await Promise.all(processes.map((process) => stop(process.profile!)));
       } else {
-        await daemon.stop(this.flags.profile, { force: this.flags.force });
-        this.log('Agent stopped');
+        await stop(this.flags.profile);
       }
     });
   }

--- a/packages/devtools/cli/src/commands/agent/stop.ts
+++ b/packages/devtools/cli/src/commands/agent/stop.ts
@@ -12,8 +12,8 @@ export default class Stop extends BaseCommand<typeof Stop> {
 
   static override flags = {
     ...BaseCommand.flags,
-    all: Flags.boolean({ description: 'Stop all agents.' }),
-    force: Flags.boolean({ description: 'Force stop.' }),
+    all: Flags.boolean({ char: 'a', description: 'Stop all agents.' }),
+    force: Flags.boolean({ char: 'f', description: 'Force stop.' }),
   };
 
   async run(): Promise<any> {
@@ -29,11 +29,13 @@ export default class Stop extends BaseCommand<typeof Stop> {
         const processes = await daemon.list();
         await Promise.all(
           processes.map(async ({ profile }) => {
-            await stop(profile!);
+            await daemon.stop(profile!, { force: this.flags.force });
+            this.log(`Agent stopped: ${profile}`);
           }),
         );
       } else {
-        await stop(this.flags.profile);
+        await daemon.stop(this.flags.profile, { force: this.flags.force });
+        this.log('Agent stopped');
       }
     });
   }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fd8e9f2</samp>

### Summary
🐛🧪✨

<!--
1.  🐛 for fixing a bug in the `ForeverDaemon` class
2.  🧪 for adding a new test case and improving the test structure
3.  ✨ for adding new features and enhancing the user interface of the agent commands
-->
This pull request enhances the agent management features in the `dxos` devtools CLI and the `dxos/core` package. It improves the reliability, performance, and usability of the `ForeverDaemon` class and the `list`, `start`, and `stop` commands. It also adds more test coverage and code quality improvements.

> _Oh we are the `dxos` crew and we work on the agent_
> _We make it run and stop and list with logic and intent_
> _We heave and ho and pull the code, we test it and we fix it_
> _And when we're done we sing this song, we're proud of our `ForeverDaemon`_

### Walkthrough
*  Simplify and improve the logic of the `ForeverDaemon` class in `forever-daemon.ts` ([link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-b5dbaf47a6ea38e7795329712ff61bc11c9476aa0260e772e6b456902fc32104L34-R34), [link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-b5dbaf47a6ea38e7795329712ff61bc11c9476aa0260e772e6b456902fc32104L53), [link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-b5dbaf47a6ea38e7795329712ff61bc11c9476aa0260e772e6b456902fc32104R63-R68), [link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-b5dbaf47a6ea38e7795329712ff61bc11c9476aa0260e772e6b456902fc32104L92-R94), [link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-b5dbaf47a6ea38e7795329712ff61bc11c9476aa0260e772e6b456902fc32104R129), [link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-b5dbaf47a6ea38e7795329712ff61bc11c9476aa0260e772e6b456902fc32104L140-R143), [link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-b5dbaf47a6ea38e7795329712ff61bc11c9476aa0260e772e6b456902fc32104L153-R150), [link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-b5dbaf47a6ea38e7795329712ff61bc11c9476aa0260e772e6b456902fc32104L166))
* Add a new test case for the `stop` command in `agent.test.ts` ([link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-87ee433815d4f0150e954f526bf7676536a6f25c2241c2882cf50b3ff15f7211R115-R126))
* Replace `beforeAll` and `afterAll` with `beforeEach` and `afterEach` in `agent.test.ts` to ensure isolated and clean test environments ([link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-87ee433815d4f0150e954f526bf7676536a6f25c2241c2882cf50b3ff15f7211L22-R22), [link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-87ee433815d4f0150e954f526bf7676536a6f25c2241c2882cf50b3ff15f7211L66-R66))
* Modify the `printAgents` function in `list.ts` to show 'stopped' instead of the time difference for non-running processes ([link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-2824870355274f70b55c8b976bb5a907ff57a903aa4b050f341f284fd6497b2fL28-R33))
* Add the `--json` flag to the `list` command in `list.ts` to return the agent process information as a JSON object ([link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-2824870355274f70b55c8b976bb5a907ff57a903aa4b050f341f284fd6497b2fL47-R54))
* Add the `char` option to the `all` and `force` flags of the `stop` command in `stop.ts` to allow single letter shorthands ([link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-0744ced50f0aec549ba17f95ae3b2efd2db397186ef0044c1fab999fececc8aeL15-R17))
* Add a log statement to the `stop` command in `stop.ts` to indicate when the `force` flag is set ([link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-0744ced50f0aec549ba17f95ae3b2efd2db397186ef0044c1fab999fececc8aeR23-R25))
* Simplify the logic of the `stop` command in `stop.ts` by removing unnecessary async/await keywords ([link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-0744ced50f0aec549ba17f95ae3b2efd2db397186ef0044c1fab999fececc8aeL30-R34))
* Remove unused import of `afterAll` and `beforeAll` in `agent.test.ts` ([link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-87ee433815d4f0150e954f526bf7676536a6f25c2241c2882cf50b3ff15f7211L13-R13))
* Add import of `chalk` module to `stop.ts` for colorizing log output ([link](https://github.com/dxos/dxos/pull/3715/files?diff=unified&w=0#diff-0744ced50f0aec549ba17f95ae3b2efd2db397186ef0044c1fab999fececc8aeR6))

