### PR TITLE
fix: handle url for empty selection

### DIFF
--- a/packages/apps/plugins/plugin-treeview/src/util.ts
+++ b/packages/apps/plugins/plugin-treeview/src/util.ts
@@ -6,7 +6,7 @@ import { GraphNode } from '@braneframe/plugin-graph';
 
 export const uriToSelected = (uri: string) => {
   const [_, namespace, type, id, ...rest] = uri.split('/');
-  return [`${namespace}:${type}/${id}`, ...rest];
+  return namespace && type && id ? [`${namespace}:${type}/${id}`, ...rest] : [];
 };
 
 export const selectedToUri = (selected: string[]) => '/' + selected.join('/').replace(':', '/');


### PR DESCRIPTION
fixes #3710 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d441d39</samp>

### Summary
:wrench::bug::test_tube:

<!--
1.  :wrench: for the refactor of the e2e executor
2.  :bug: for the bug fix of the uriToSelected function
3.  :test_tube: for the end-to-end testing setup and configuration
-->
Removed `e2e` executor from `labs-app` and fixed treeview plugin crash. These changes simplify the testing setup and improve the plugin's robustness.

> _`e2e` executor_
> _simplified for all apps_
> _autumn of testing_

### Walkthrough
*  Simplify end-to-end testing setup and use a single executor for all apps ([link](https://github.com/dxos/dxos/pull/3720/files?diff=unified&w=0#diff-8c24eacfa3f3501173cef8b3023d219563ab241e3dd0e170ec52973bd51ffed3L28-L55)). Remove `e2e` executor from `project.json` and move app-specific options to `playwright.config.ts`.


