### PR TITLE
fix(labs): Make `TypedObject`, `EchoDatabase` and `SpaceProxy` not proxied by @deepsignal/react

### DIFF
--- a/packages/apps/labs-app/src/main.tsx
+++ b/packages/apps/labs-app/src/main.tsx
@@ -22,7 +22,7 @@ import { ThemePlugin } from '@braneframe/plugin-theme';
 import { ThreadPlugin } from '@braneframe/plugin-thread';
 import { TreeViewPlugin } from '@braneframe/plugin-treeview';
 import { UrlSyncPlugin } from '@braneframe/plugin-url-sync';
-import { SpaceProxy } from '@dxos/client';
+import { SpaceProxy } from '@dxos/client/echo';
 import { Config, Defaults } from '@dxos/config';
 import { EchoDatabase, TypedObject } from '@dxos/echo-schema';
 import { initializeAppTelemetry } from '@dxos/react-appkit/telemetry';

--- a/packages/apps/labs-app/src/main.tsx
+++ b/packages/apps/labs-app/src/main.tsx
@@ -22,9 +22,17 @@ import { ThemePlugin } from '@braneframe/plugin-theme';
 import { ThreadPlugin } from '@braneframe/plugin-thread';
 import { TreeViewPlugin } from '@braneframe/plugin-treeview';
 import { UrlSyncPlugin } from '@braneframe/plugin-url-sync';
+import { SpaceProxy } from '@dxos/client';
 import { Config, Defaults } from '@dxos/config';
+import { EchoDatabase, TypedObject } from '@dxos/echo-schema';
 import { initializeAppTelemetry } from '@dxos/react-appkit/telemetry';
 import { PluginContextProvider } from '@dxos/react-surface';
+
+// TODO(wittjosiah): This ensures that typed objects and SpaceProxy are not proxied by deepsignal. Remove.
+// https://github.com/luisherranz/deepsignal/issues/36
+(globalThis as any)[TypedObject.name] = TypedObject;
+(globalThis as any)[EchoDatabase.name] = EchoDatabase;
+(globalThis as any)[SpaceProxy.name] = SpaceProxy;
 
 void initializeAppTelemetry({ namespace: 'labs-app', config: new Config(Defaults()) });
 

--- a/packages/sdk/client/src/index.ts
+++ b/packages/sdk/client/src/index.ts
@@ -6,4 +6,6 @@ export { Config, Defaults, Dynamics, Envs, Local } from '@dxos/config';
 export { PublicKey, type PublicKeyLike } from '@dxos/keys';
 export { ApiError } from '@dxos/errors';
 export { Client, ClientOptions } from './client/client';
+
+// TODO(mykola): Do not expose SpaceProxy.
 export { SpaceProxy } from './echo';

--- a/packages/sdk/client/src/index.ts
+++ b/packages/sdk/client/src/index.ts
@@ -6,3 +6,4 @@ export { Config, Defaults, Dynamics, Envs, Local } from '@dxos/config';
 export { PublicKey, type PublicKeyLike } from '@dxos/keys';
 export { ApiError } from '@dxos/errors';
 export { Client, ClientOptions } from './client/client';
+export { SpaceProxy } from './echo';

--- a/packages/sdk/client/src/index.ts
+++ b/packages/sdk/client/src/index.ts
@@ -6,6 +6,3 @@ export { Config, Defaults, Dynamics, Envs, Local } from '@dxos/config';
 export { PublicKey, type PublicKeyLike } from '@dxos/keys';
 export { ApiError } from '@dxos/errors';
 export { Client, ClientOptions } from './client/client';
-
-// TODO(mykola): Do not expose SpaceProxy.
-export { SpaceProxy } from './echo';


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7a7614c</samp>

### Summary
🐛🚚♻️

<!--
1.  🐛 for the bug fix in the `deepsignal` library workaround.
2.  🚚 for the import and export of the `SpaceProxy` class.
3.  ♻️ for the refactoring of the spaces API and implementation.
-->
This pull request fixes a proxying bug in `labs-app` by importing and assigning some classes to global properties, and refactors the `client` package to export the `SpaceProxy` class.

> _`SpaceProxy` moves_
> _from `client` to other modules_
> _refactoring in spring_

### Walkthrough
*  Export `SpaceProxy` class from `@dxos/client` package to enable interaction with spaces from other modules ([link](https://github.com/dxos/dxos/pull/3724/files?diff=unified&w=0#diff-5fb344208cd3ad040e48fba4b60b2e982f0fd977d802dba856fcf5a45115ab36R9)).


