### PR TITLE
refactor(plugin-treeview): rename select to active

### DIFF
--- a/packages/apps/composer-app/src/plugins/LocalFilesPlugin/LocalFilesPlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/LocalFilesPlugin/LocalFilesPlugin.tsx
@@ -93,8 +93,8 @@ export const LocalFilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, M
       if (treeViewPlugin) {
         const handleUpdate = () => {
           const current =
-            (treeViewPlugin.provides.treeView.selected[0]?.startsWith(LOCAL_FILES_PLUGIN) &&
-              findFile(state.files, treeViewPlugin.provides.treeView.selected)) ||
+            (treeViewPlugin.provides.treeView.active[0]?.startsWith(LOCAL_FILES_PLUGIN) &&
+              findFile(state.files, treeViewPlugin.provides.treeView.active)) ||
             undefined;
 
           if (state.current !== current) {
@@ -157,7 +157,7 @@ export const LocalFilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, M
                   plugin: LOCAL_FILES_PLUGIN,
                   action: LocalFilesAction.OPEN_FILE,
                 },
-                { action: TreeViewAction.SELECT },
+                { action: TreeViewAction.ACTIVATE },
               ],
             },
           ];
@@ -173,7 +173,7 @@ export const LocalFilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, M
                   plugin: LOCAL_FILES_PLUGIN,
                   action: LocalFilesAction.OPEN_DIRECTORY,
                 },
-                { action: TreeViewAction.SELECT },
+                { action: TreeViewAction.ACTIVATE },
               ],
             });
           }

--- a/packages/apps/plugins/plugin-drawing/src/DrawingPlugin.tsx
+++ b/packages/apps/plugins/plugin-drawing/src/DrawingPlugin.tsx
@@ -58,7 +58,7 @@ export const DrawingPlugin = (): PluginDefinition<DrawingPluginProvides> => {
                   data: { spaceKey: parent.data.key.toHex() },
                 },
                 {
-                  action: TreeViewAction.SELECT,
+                  action: TreeViewAction.ACTIVATE,
                 },
               ],
             },

--- a/packages/apps/plugins/plugin-kanban/src/KanbanPlugin.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/KanbanPlugin.tsx
@@ -58,7 +58,7 @@ export const KanbanPlugin = (): PluginDefinition<KanbanPluginProvides> => {
                   data: { spaceKey: parent.data.key.toHex() },
                 },
                 {
-                  action: TreeViewAction.SELECT,
+                  action: TreeViewAction.ACTIVATE,
                 },
               ],
             },

--- a/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -111,7 +111,7 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
                   data: { spaceKey: parent.data.key.toHex() },
                 },
                 {
-                  action: TreeViewAction.SELECT,
+                  action: TreeViewAction.ACTIVATE,
                 },
               ],
             },

--- a/packages/apps/plugins/plugin-markdown/src/components/SpaceMarkdownChooser.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/SpaceMarkdownChooser.tsx
@@ -20,10 +20,10 @@ export const SpaceMarkdownChooser = ({
   // todo(thure): This assumes the best & only way to get the active space is to find it in the graph using treeView, which probably won’t scale well.
   const treeView = useTreeView();
   const { graph } = useGraph();
-  const [plugin] = treeView.selected[0]?.split('/') ?? [];
+  const [plugin] = treeView.active[0]?.split('/') ?? [];
   const nodes =
     Object.values(
-      (graph.pluginChildren ?? {})[plugin].find(({ id }) => id === treeView.selected[0])?.pluginChildren ?? {},
+      (graph.pluginChildren ?? {})[plugin].find(({ id }) => id === treeView.active[0])?.pluginChildren ?? {},
     )
       .flat()
       ?.filter((node) => {

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -67,13 +67,13 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
 
       if (client.services instanceof IFrameClientServicesProxy || client.services instanceof IFrameClientServicesHost) {
         client.services.joinedSpace.on((spaceKey) => {
-          treeView.selected = [getSpaceId(spaceKey)];
+          treeView.active = [getSpaceId(spaceKey)];
         });
       }
 
       const dispose = effect(() => {
         const space = graphPlugin?.provides.graph.pluginChildren?.[SPACE_PLUGIN]?.find(
-          (node) => node.id === treeView.selected[0],
+          (node) => node.id === treeView.active[0],
         )?.data;
         if (
           space instanceof SpaceProxy &&
@@ -251,8 +251,8 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
                     hidden: true,
                   },
                 };
-                if (treeViewPlugin?.provides.treeView.selected[0] === getSpaceId(space.key)) {
-                  treeViewPlugin.provides.treeView.selected = [];
+                if (treeViewPlugin?.provides.treeView.active[0] === getSpaceId(space.key)) {
+                  treeViewPlugin.provides.treeView.active = [];
                 }
                 return true;
               }

--- a/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
+++ b/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
@@ -69,7 +69,7 @@ export const StackPlugin = (): PluginDefinition<StackPluginProvides> => {
                   data: { spaceKey: parent.data.key.toHex() },
                 },
                 {
-                  action: TreeViewAction.SELECT,
+                  action: TreeViewAction.ACTIVATE,
                 },
               ],
             },

--- a/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -58,7 +58,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
                   data: { spaceKey: parent.data.key.toHex() },
                 },
                 {
-                  action: TreeViewAction.SELECT,
+                  action: TreeViewAction.ACTIVATE,
                 },
               ],
             },

--- a/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
@@ -15,7 +15,7 @@ import { TREE_VIEW_PLUGIN, TreeViewAction, TreeViewContextValue, TreeViewPluginP
 import { resolveNodes } from './util';
 
 export const TreeViewPlugin = (): PluginDefinition<TreeViewPluginProvides> => {
-  const state = deepSignal<TreeViewContextValue>({ selected: [] });
+  const state = deepSignal<TreeViewContextValue>({ active: [] });
 
   return {
     meta: {
@@ -30,13 +30,10 @@ export const TreeViewPlugin = (): PluginDefinition<TreeViewPluginProvides> => {
         default: () => {
           const treeView = useTreeView();
           const { graph } = useGraph();
-          const [plugin] = treeView.selected[0]?.split('/') ?? [];
-          const nodes = resolveNodes(
-            Object.values(graph.pluginChildren ?? {}).flat() as GraphNode[],
-            treeView.selected,
-          );
+          const [plugin] = treeView.active[0]?.split('/') ?? [];
+          const active = resolveNodes(Object.values(graph.pluginChildren ?? {}).flat() as GraphNode[], treeView.active);
 
-          if (treeView.selected.length === 0) {
+          if (treeView.active.length === 0) {
             return (
               <Surface
                 component='dxos:splitview/SplitView'
@@ -46,7 +43,7 @@ export const TreeViewPlugin = (): PluginDefinition<TreeViewPluginProvides> => {
                 }}
               />
             );
-          } else if (nodes.length === 0) {
+          } else if (active.length === 0) {
             return <Surface component={`${plugin}/Main`} />;
           } else {
             return (
@@ -54,7 +51,7 @@ export const TreeViewPlugin = (): PluginDefinition<TreeViewPluginProvides> => {
                 component='dxos:splitview/SplitView'
                 surfaces={{
                   sidebar: { component: 'dxos:treeview/TreeView' },
-                  main: { component: `${plugin}/Main`, data: nodes },
+                  main: { component: `${plugin}/Main`, data: { active } },
                 }}
               />
             );
@@ -77,9 +74,9 @@ export const TreeViewPlugin = (): PluginDefinition<TreeViewPluginProvides> => {
       intent: {
         resolver: (intent) => {
           switch (intent.action) {
-            case TreeViewAction.SELECT: {
+            case TreeViewAction.ACTIVATE: {
               if (Array.isArray(intent.data)) {
-                state.selected = intent.data;
+                state.active = intent.data;
                 return true;
               }
               break;

--- a/packages/apps/plugins/plugin-treeview/src/components/LeafTreeItem.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/LeafTreeItem.tsx
@@ -62,7 +62,7 @@ export const LeafTreeItem: ForwardRefExoticComponent<LeafTreeItemProps & RefAttr
   const [isLg] = useMediaQuery('lg', { ssr: false });
   const treeView = useTreeView();
 
-  const active = node.id === treeView.selected.at(-1);
+  const active = node.id === treeView.active.at(-1);
   const modified = node.attributes?.modified ?? false;
   const disabled = node.attributes?.disabled ?? false;
   const error = node.attributes?.error ?? false;
@@ -104,13 +104,15 @@ export const LeafTreeItem: ForwardRefExoticComponent<LeafTreeItemProps & RefAttr
           onKeyDown={(event) => {
             if (event.key === ' ' || event.key === 'Enter') {
               event.stopPropagation();
-              treeView.selected = node.parent ? [node.parent.id, node.id] : [node.id];
+              // TODO(wittjosiah): Intent.
+              treeView.active = node.parent ? [node.parent.id, node.id] : [node.id];
               !isLg && closeSidebar();
             }
           }}
           onClick={(event) => {
+            // TODO(wittjosiah): Intent.
             // TODO(wittjosiah): Make recursive.
-            treeView.selected = node.parent ? [node.parent.id, node.id] : [node.id];
+            treeView.active = node.parent ? [node.parent.id, node.id] : [node.id];
             !isLg && closeSidebar();
           }}
           className='text-start flex gap-2 justify-start'

--- a/packages/apps/plugins/plugin-treeview/src/types.ts
+++ b/packages/apps/plugins/plugin-treeview/src/types.ts
@@ -9,12 +9,12 @@ import { IntentProvides } from '@braneframe/plugin-intent';
 export const TREE_VIEW_PLUGIN = 'dxos:treeview';
 
 export enum TreeViewAction {
-  SELECT = `${TREE_VIEW_PLUGIN}:select`,
+  ACTIVATE = `${TREE_VIEW_PLUGIN}:activate`,
 }
 
 // TODO(wittjosiah): Derive graph nodes from selected.
 export type TreeViewContextValue = DeepSignal<{
-  selected: string[];
+  active: string[];
 }>;
 
 export type TreeViewPluginProvides = IntentProvides & {

--- a/packages/apps/plugins/plugin-url-sync/src/UrlSyncPlugin.tsx
+++ b/packages/apps/plugins/plugin-url-sync/src/UrlSyncPlugin.tsx
@@ -19,14 +19,14 @@ export const UrlSyncPlugin = (): PluginDefinition => ({
         // Update selection based on browser navigation.
         useEffect(() => {
           const handleNavigation = () => {
-            treeView.selected =
+            treeView.active =
               // TODO(wittjosiah): Remove. This is here for backwards compatibility.
               window.location.pathname === '/embedded'
                 ? ['dxos:github/embedded']
                 : uriToSelected(window.location.pathname);
           };
 
-          if (treeView.selected.length === 0 && window.location.pathname.length > 1) {
+          if (treeView.active.length === 0 && window.location.pathname.length > 1) {
             handleNavigation();
           }
 
@@ -38,12 +38,12 @@ export const UrlSyncPlugin = (): PluginDefinition => ({
 
         // Update URL when selection changes.
         useEffect(() => {
-          const selectedPath = selectedToUri(treeView.selected);
+          const selectedPath = selectedToUri(treeView.active);
           if (window.location.pathname !== selectedPath) {
             // TODO(wittjosiah): Better support for search params?
             history.pushState(null, '', `${selectedPath}${window.location.search}`);
           }
-        }, [treeView.selected]);
+        }, [treeView.active]);
 
         return null;
       },


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 650fa0c</samp>

### Summary
🎨🗒️📝

<!--
1.  🎨 - This emoji represents the change in the `DrawingPlugin`, as it is related to the visual aspect of the app and the user's creativity.
2.  🗒️ - This emoji represents the change in the `KanbanPlugin`, as it is related to the organizational aspect of the app and the user's tasks.
3.  📝 - This emoji represents the change in the `SpaceMarkdownChooser` component, as it is related to the textual aspect of the app and the user's notes.
-->
This pull request refactors the tree view plugins and components to use the term `active` instead of `selected` for the current node in the tree view. This improves the consistency and clarity of the code and the user interface. The pull request also updates the dependent plugins to use the `treeView.active` property instead of `treeView.selected` to access and update the tree view state. The pull request also renames the `TreeViewAction.SELECT` enum value to `TreeViewAction.ACTIVATE` to reflect the new terminology.

> _The tree view had nodes that were `selected`_
> _But this term was often misdirected_
> _So they changed it to `active`_
> _Which was more attractive_
> _And the code and the UI connected_

### Walkthrough
*  Rename `selected` to `active` in the tree view context and its consumers ([link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-ae3c609dd132b915ae4ae4e8dc46cdae4ad74bf0a2c22dd811edddae3c999c73L96-R97), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-ae3c609dd132b915ae4ae4e8dc46cdae4ad74bf0a2c22dd811edddae3c999c73L160-R160), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-ae3c609dd132b915ae4ae4e8dc46cdae4ad74bf0a2c22dd811edddae3c999c73L176-R176), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-aaca140d1a823ce6b8f5dbe2aa2275a30cad79dab9466f39491e2e71b768b5deL61-R61), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-fcc42cb616fe84778978fa7e79674e0a44857d88f697f901ef4b18bc4fe5df42L61-R61), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcL114-R114), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-3175d1a68fc5404f24641b269ca711a05c91f0c36c318b76ee51fe2a817790c2L23-R26), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L70-R70), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L76-R76), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L254-R255), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-73f12af5e023ef40bc928d988f0d7626f1db6bf7d07a1d91a2dfd4553a50d9e3L72-R72), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-5feac81bd76b27098feff076ff3502934b47368b7c6cc301d9d167dccd191fefL61-R61), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-9a66c7d56ee624df73971bbd0761d8e07a33294b4945f9a4167d111aa88c6547L18-R18), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-9a66c7d56ee624df73971bbd0761d8e07a33294b4945f9a4167d111aa88c6547L33-R36), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-9a66c7d56ee624df73971bbd0761d8e07a33294b4945f9a4167d111aa88c6547L49-R46), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-9a66c7d56ee624df73971bbd0761d8e07a33294b4945f9a4167d111aa88c6547L57-R54), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-9a66c7d56ee624df73971bbd0761d8e07a33294b4945f9a4167d111aa88c6547L80-R79), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-d45d5bb7773619e374ccc6e568f6131feb68eb58c5c97d68ea6554efeec0b988L65-R65), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-d45d5bb7773619e374ccc6e568f6131feb68eb58c5c97d68ea6554efeec0b988L107-R115), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-34ec5967f40d6078a4c8c860336bcf6510e13c139e4b22ae2af1ea9fa2bd4c9dL12-R17), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-dbcae850d41530e605b32656c7f15ca70db86bc98ad4aa30b55d98cb99651bcfL22-R22), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-dbcae850d41530e605b32656c7f15ca70db86bc98ad4aa30b55d98cb99651bcfL29-R29), [link](https://github.com/dxos/dxos/pull/3727/files?diff=unified&w=0#diff-dbcae850d41530e605b32656c7f15ca70db86bc98ad4aa30b55d98cb99651bcfL41-R46)). The purpose of this change is to use a more consistent and intuitive term for the currently active node in the tree view, rather than the previously selected one. This change affects the following files: `LocalFilesPlugin.tsx`, `DrawingPlugin.tsx`, `KanbanPlugin.tsx`, `MarkdownPlugin.tsx`, `SpaceMarkdownChooser.tsx`, `SpacePlugin.tsx`, `StackPlugin.tsx`, `ThreadPlugin.tsx`, `TreeViewPlugin.tsx`, `types.ts`, and `UrlSyncPlugin.tsx`.


