### PR TITLE
refactor: avoid using tuples for datums

### DIFF
--- a/packages/apps/composer-app/src/plugins/GithubPlugin/components/EmbeddedMain/EmbeddedMain.tsx
+++ b/packages/apps/composer-app/src/plugins/GithubPlugin/components/EmbeddedMain/EmbeddedMain.tsx
@@ -239,7 +239,7 @@ const EmbeddedLayoutImpl = () => {
               />
             </Main.Content>
           ) : (
-            <Surface role='main' data={[textModel, document, 'embedded']} />
+            <Surface role='main' data={{ composer: textModel, properties: document, view: 'embedded' }} />
           )
         ) : source && id && identityHex ? (
           <Dialog.Root open onOpenChange={() => true}>

--- a/packages/apps/composer-app/src/plugins/LocalFilesPlugin/components/LocalFileMain.tsx
+++ b/packages/apps/composer-app/src/plugins/LocalFilesPlugin/components/LocalFileMain.tsx
@@ -10,20 +10,23 @@ import { Surface } from '@dxos/react-surface';
 import { LocalFileMainPermissions } from './LocalFileMainPermissions';
 
 export const LocalFileMain: FC<{ data: unknown }> = ({ data }) => {
-  const [parentNode, childNode] = Array.isArray(data) && isGraphNode(data[0]) ? data : [];
+  const [parentNode, childNode] =
+    data && typeof data === 'object' && 'active' in data && Array.isArray(data.active) && isGraphNode(data.active[0])
+      ? [data.active[0], data.active[1]]
+      : [];
   const node = childNode ?? parentNode;
   const transformedData = useMemo(
     () =>
       node?.attributes?.disabled
-        ? [
-            { id: node.id, content: () => <LocalFileMainPermissions data={node} /> },
-            { title: node.data.title, readOnly: true },
-          ]
+        ? {
+            composer: { id: node.id, content: () => <LocalFileMainPermissions data={node} /> },
+            properties: { title: node.data.title, readOnly: true },
+          }
         : node?.data?.text
-        ? [
-            { id: node.id, content: node.data.text },
-            { title: node.data.title, readOnly: true },
-          ]
+        ? {
+            composer: { id: node.id, content: node.data.text },
+            properties: { title: node.data.title, readOnly: true },
+          }
         : node?.data
         ? node.data
         : null,

--- a/packages/apps/plugins/plugin-debug/src/DebugPlugin.tsx
+++ b/packages/apps/plugins/plugin-debug/src/DebugPlugin.tsx
@@ -15,6 +15,16 @@ import translations from './translations';
 export const DebugPlugin = (): PluginDefinition<DebugPluginProvides> => {
   const nodeIds = new Set<string>();
 
+  const isDebug = (datum: unknown) =>
+    datum &&
+    typeof datum === 'object' &&
+    'node' in datum &&
+    datum.node &&
+    typeof datum.node === 'object' &&
+    'id' in datum.node &&
+    typeof datum.node.id === 'string' &&
+    nodeIds.has(datum.node.id);
+
   return {
     meta: {
       id: DEBUG_PANEL,
@@ -65,7 +75,7 @@ export const DebugPlugin = (): PluginDefinition<DebugPluginProvides> => {
       component: (datum, role) => {
         switch (role) {
           case 'main':
-            if (Array.isArray(datum) && nodeIds.has(datum[datum.length - 1].id)) {
+            if (isDebug(datum)) {
               return DebugMain;
             } else {
               return null;

--- a/packages/apps/plugins/plugin-debug/src/components/DebugMain.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DebugMain.tsx
@@ -5,7 +5,7 @@
 import { Play, HandPalm } from '@phosphor-icons/react';
 import React, { FC, useContext, useEffect, useMemo, useState } from 'react';
 
-import { Debug as DebugType } from '@braneframe/types';
+import { GraphNode } from '@braneframe/plugin-graph';
 import { Button, DensityProvider, Input, Main, useTranslation } from '@dxos/aurora';
 import { getSize } from '@dxos/aurora-theme';
 import { diagnostics } from '@dxos/client/diagnostics';
@@ -18,7 +18,7 @@ import { Generator } from '../testing';
 
 export const DEFAULT_PERIOD = 500;
 
-export const DebugMain: FC<{ data: [SpaceProxy, DebugType] }> = ({ data: [space, _] }) => {
+export const DebugMain: FC<{ data: { space: SpaceProxy; node: GraphNode } }> = ({ data: { space } }) => {
   const { t } = useTranslation(DEBUG_PANEL);
 
   const client = useClient();

--- a/packages/apps/plugins/plugin-drawing/src/DrawingPlugin.tsx
+++ b/packages/apps/plugins/plugin-drawing/src/DrawingPlugin.tsx
@@ -66,9 +66,13 @@ export const DrawingPlugin = (): PluginDefinition<DrawingPluginProvides> => {
         },
       },
       component: (datum, role) => {
+        if (!datum || typeof datum !== 'object') {
+          return null;
+        }
+
         switch (role) {
           case 'main':
-            if (Array.isArray(datum) && isDrawing(datum[datum.length - 1])) {
+            if ('object' in datum && isDrawing(datum.object)) {
               return DrawingMain;
             } else {
               return null;

--- a/packages/apps/plugins/plugin-kanban/src/KanbanPlugin.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/KanbanPlugin.tsx
@@ -66,9 +66,13 @@ export const KanbanPlugin = (): PluginDefinition<KanbanPluginProvides> => {
         },
       },
       component: (datum, role) => {
+        if (!datum || typeof datum !== 'object') {
+          return null;
+        }
+
         switch (role) {
           case 'main':
-            if (Array.isArray(datum) && isKanban(datum[datum.length - 1])) {
+            if ('object' in datum && isKanban(datum.object)) {
               return KanbanMain;
             } else {
               return null;

--- a/packages/apps/plugins/plugin-kanban/src/components/KanbanMain.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/components/KanbanMain.tsx
@@ -15,12 +15,12 @@ import type { KanbanModel } from '../props';
 import { KanbanBoard } from './KanbanBoard';
 
 // TODO(burdon): Constructor type? `data` vs. `datum`?
-export const KanbanMain: FC<{ data: [SpaceProxy, KanbanType] }> = ({ data: [space, kanban] }) => {
+export const KanbanMain: FC<{ data: { space: SpaceProxy; object: KanbanType } }> = ({ data: { space, object } }) => {
   const { t } = useTranslation('dxos.org/plugin/kanban');
 
   // TODO(burdon): Should plugin create and pass in model?
   const model: KanbanModel = {
-    root: kanban, // TODO(burdon): How to keep pure?
+    root: object, // TODO(burdon): How to keep pure?
     createColumn: () => space.db.add(new KanbanType.Column()),
     // TODO(burdon): Add metadata from column in the case of projections.
     createItem: (column) =>

--- a/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -49,14 +49,14 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
   const adapter = new GraphNodeAdapter(DocumentType.filter(), documentToGraphNode);
 
   const MarkdownMainStandalone = ({
-    data: [model, properties],
+    data: { composer, properties },
   }: {
-    data: [ComposerModel, MarkdownProperties];
+    data: { composer: ComposerModel; properties: MarkdownProperties };
     role?: string;
   }) => {
     return (
       <MarkdownMain
-        model={model}
+        model={composer}
         properties={properties}
         layout='standalone'
         onChange={(text) => state.onChange.forEach((onChange) => onChange(text))}
@@ -143,15 +143,29 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
       },
       translations,
       component: (datum, role) => {
+        if (!datum || typeof datum !== 'object') {
+          return null;
+        }
+
         switch (role) {
           case 'main':
-            if (Array.isArray(datum) && isMarkdown(datum[0]) && isMarkdownProperties(datum[1])) {
-              if (datum[2] === 'embedded') {
+            if (
+              'composer' in datum &&
+              isMarkdown(datum.composer) &&
+              'properties' in datum &&
+              isMarkdownProperties(datum.properties)
+            ) {
+              if ('view' in datum && datum.view === 'embedded') {
                 return MarkdownMainEmbedded;
               } else {
                 return MarkdownMainStandalone;
               }
-            } else if (Array.isArray(datum) && isMarkdownPlaceholder(datum[0]) && isMarkdownProperties(datum[1])) {
+            } else if (
+              'composer' in datum &&
+              isMarkdownPlaceholder(datum.composer) &&
+              'properties' in datum &&
+              isMarkdownProperties(datum.properties)
+            ) {
               return MarkdownMainEmpty;
             }
             break;

--- a/packages/apps/plugins/plugin-markdown/src/components/MarkdownMainEmbedded.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/MarkdownMainEmbedded.tsx
@@ -10,10 +10,10 @@ import { MarkdownProperties } from '../types';
 import { MarkdownMain } from './MarkdownMain';
 
 export const MarkdownMainEmbedded = ({
-  data: [model, properties, _],
+  data: { composer, properties },
 }: {
-  data: [ComposerModel, MarkdownProperties, 'embedded'];
+  data: { composer: ComposerModel; properties: MarkdownProperties; view: 'embedded' };
   role?: string;
 }) => {
-  return <MarkdownMain model={model} properties={properties} layout='embedded' />;
+  return <MarkdownMain model={composer} properties={properties} layout='embedded' />;
 };

--- a/packages/apps/plugins/plugin-markdown/src/components/MarkdownMainEmpty.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/MarkdownMainEmpty.tsx
@@ -7,10 +7,14 @@ import React from 'react';
 import { MarkdownProperties } from '../types';
 import { StandaloneLayout } from './StandaloneLayout';
 
-export const MarkdownMainEmpty = ({ data: [model, properties] }: { data: [any, MarkdownProperties] }) => {
+export const MarkdownMainEmpty = ({
+  data: { composer, properties },
+}: {
+  data: { composer: any; properties: MarkdownProperties };
+}) => {
   return (
-    <StandaloneLayout model={model} properties={properties}>
-      <model.content />
+    <StandaloneLayout model={composer} properties={properties}>
+      <composer.content />
     </StandaloneLayout>
   );
 };

--- a/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
+++ b/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
@@ -78,15 +78,19 @@ export const StackPlugin = (): PluginDefinition<StackPluginProvides> => {
       },
       translations,
       component: (datum, role) => {
+        if (!datum || typeof datum !== 'object') {
+          return null;
+        }
+
         switch (role) {
           case 'main':
-            if (Array.isArray(datum) && isStack(datum[datum.length - 1])) {
+            if ('object' in datum && isStack(datum.object)) {
               return StackMain;
             } else {
               return null;
             }
           case 'dragoverlay':
-            if (datum && typeof datum === 'object' && 'object' in datum) {
+            if ('object' in datum) {
               return StackSectionOverlay;
             } else {
               return null;

--- a/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
@@ -369,7 +369,7 @@ const StackMainImpl = ({ stack }: { stack: StackModel & StackProperties }) => {
   );
 };
 
-export const StackMain = ({ data }: { data: [unknown, StackModel & StackProperties] }) => {
-  const stack = data[data.length - 1] as StackModel & StackProperties;
+export const StackMain = ({ data }: { data: { object: StackModel & StackProperties } }) => {
+  const stack = data.object as StackModel & StackProperties;
   return <StackMainImpl stack={stack} />;
 };

--- a/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -66,9 +66,13 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
         },
       },
       component: (datum, role) => {
+        if (!datum || typeof datum !== 'object') {
+          return null;
+        }
+
         switch (role) {
           case 'main':
-            if (Array.isArray(datum) && isThread(datum[datum.length - 1])) {
+            if ('object' in datum && isThread(datum.object)) {
               return ThreadMain;
             } else {
               return null;

--- a/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
@@ -20,7 +20,7 @@ import { ThreadChannel } from './ThreadChannel';
 // - Lightweight threads for document comments, inline AI, etc.
 //    (Similar reusable components everywhere; same data structure).
 
-export const ThreadMain: FC<{ data: [SpaceProxy, ThreadType] }> = ({ data: [_, thread] }) => {
+export const ThreadMain: FC<{ data: { space: SpaceProxy; object: ThreadType } }> = ({ data: { object: thread } }) => {
   const identity = useIdentity(); // TODO(burdon): Requires context for storybook?
   const identityKey = identity!.identityKey;
   // const identityKey = PublicKey.random().toHex();


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ce3771c</samp>

### Summary
🔄🛠️📝

<!--
1.  🔄 - This emoji represents the changes that modify the data prop format from an array to an object, which is a kind of refactoring or restructuring of the code.
2.  🛠️ - This emoji represents the changes that fix or improve the logic of checking if a datum is a certain object type, which is a kind of bug fixing or enhancement of the code.
3.  📝 - This emoji represents the changes that update the Markdown components to use the new data prop format, which is a kind of documentation or writing of the code.
-->
This pull request refactors the data prop format for various plugins and components in the dxos composer app. It changes the data prop from an array to an object with descriptive keys, such as `composer`, `properties`, `object`, `space` and `view`. This is done to improve the consistency, readability and type safety of the code and to handle null or invalid data. It also updates the logic of checking the role and type of the data in some plugins. It affects the files `DebugMain.tsx`, `DebugPlugin.tsx`, `MarkdownPlugin.tsx`, `SpaceMain.tsx`, `StackPlugin.tsx`, `EmbeddedMain.tsx`, `LocalFileMain.tsx`, `DrawingPlugin.tsx`, `KanbanMain.tsx`, `KanbanPlugin.tsx`, `MarkdownMainEmbedded.tsx`, `MarkdownMainEmpty.tsx`, `StackMain.tsx`, `ThreadMain.tsx` and `ThreadPlugin.tsx`.

> _`data` prop changes_
> _aligning formats and types_
> _autumn of refactor_

### Walkthrough
*  Change the data prop format from an array to an object with keys composer, properties, view, space, object and node for different plugins and components ([link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-9c1cf8c27afd36ee2155149f5f8e9d55936a4e837dcb494b5c0c8f4716821ea5L242-R242), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-fb8bf0a79538b29858dc5697590cb08a4107da97d1a40c7556bb457b64acc8c8L13-R29), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-3af2dcc1d2d7818d416feb3e49aceb9c1abd5ca1857f5cbdc4054708e5ef1372L21-R21), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-d36cb8c44106ee4e2e3fc3fe686403f0e9ec4a375047ac3f3de633e92d46c343L18-R23), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcL52-R59), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-60f17cc48f1121a02b693ca882d672da2e717bb724625f4cc60041b4e8d8519dL13-R18), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-0c8a57cf6192ebd1dc9b2c73122e3b17f0d594e779496b8d95c189041ea76070L10-R17), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-f731b7eb5a224694d8e2e5b063c134fe55aa1582683d0905400289d1c7e456a4L29-R43), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068L372-R373), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-2e4bdc904e742658fb4ca8645f7d4cd91c01bf36714a4ade5a49946884f735ebL23-R23))
*  Update the logic of checking if a datum is a plugin-specific object or a placeholder to use the new data prop format and handle null or non-object cases ([link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-9c210751898e82a6bd5c22e15a24db5f3ffe6eebeb547cddd8ce90016a38a490R18-R27), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-9c210751898e82a6bd5c22e15a24db5f3ffe6eebeb547cddd8ce90016a38a490L68-R78), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-3af2dcc1d2d7818d416feb3e49aceb9c1abd5ca1857f5cbdc4054708e5ef1372L8-R8), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-aaca140d1a823ce6b8f5dbe2aa2275a30cad79dab9466f39491e2e71b768b5deL69-R75), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-fcc42cb616fe84778978fa7e79674e0a44857d88f697f901ef4b18bc4fe5df42L69-R75), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcL146-R168), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-73f12af5e023ef40bc928d988f0d7626f1db6bf7d07a1d91a2dfd4553a50d9e3L81-R87), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-73f12af5e023ef40bc928d988f0d7626f1db6bf7d07a1d91a2dfd4553a50d9e3L89-R93), [link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-5feac81bd76b27098feff076ff3502934b47368b7c6cc301d9d167dccd191fefL69-R75))
*  Simplify the check for the dragoverlay role in the StackPlugin component to avoid unnecessary nesting ([link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-73f12af5e023ef40bc928d988f0d7626f1db6bf7d07a1d91a2dfd4553a50d9e3L89-R93))
*  Use the correct property name for the composer content in the MarkdownMainEmpty component ([link](https://github.com/dxos/dxos/pull/3728/files?diff=unified&w=0#diff-0c8a57cf6192ebd1dc9b2c73122e3b17f0d594e779496b8d95c189041ea76070L10-R17))


