### PR TITLE
fix: use deepsignal shallow util

### DIFF
--- a/packages/apps/composer-app/package.json
+++ b/packages/apps/composer-app/package.json
@@ -35,7 +35,7 @@
     "@phosphor-icons/react": "^2.0.5",
     "@preact/signals-react": "^1.3.3",
     "@tldraw/indices": "2.0.0-alpha.14",
-    "deepsignal": "^1.3.3",
+    "deepsignal": "^1.4.0-shallow.0",
     "dompurify": "^3.0.3",
     "github-markdown-css": "^5.2.0",
     "isomorphic-fetch": "^3.0.0",

--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -19,15 +19,10 @@ import { ThemePlugin } from '@braneframe/plugin-theme';
 import { TreeViewPlugin } from '@braneframe/plugin-treeview';
 import { UrlSyncPlugin } from '@braneframe/plugin-url-sync';
 import { Config, Defaults } from '@dxos/config';
-import { TypedObject } from '@dxos/echo-schema';
 import { initializeAppTelemetry } from '@dxos/react-appkit/telemetry';
 import { PluginContextProvider } from '@dxos/react-surface';
 
 import { GithubPlugin, LocalFilesPlugin } from './plugins';
-
-// TODO(wittjosiah): This ensures that typed objects are not proxied by deepsignal. Remove.
-// https://github.com/luisherranz/deepsignal/issues/36
-(globalThis as any)[TypedObject.name] = TypedObject;
 
 void initializeAppTelemetry({ namespace: 'composer-app', config: new Config(Defaults()) });
 

--- a/packages/apps/labs-app/src/main.tsx
+++ b/packages/apps/labs-app/src/main.tsx
@@ -22,17 +22,9 @@ import { ThemePlugin } from '@braneframe/plugin-theme';
 import { ThreadPlugin } from '@braneframe/plugin-thread';
 import { TreeViewPlugin } from '@braneframe/plugin-treeview';
 import { UrlSyncPlugin } from '@braneframe/plugin-url-sync';
-import { SpaceProxy } from '@dxos/client/echo';
 import { Config, Defaults } from '@dxos/config';
-import { EchoDatabase, TypedObject } from '@dxos/echo-schema';
 import { initializeAppTelemetry } from '@dxos/react-appkit/telemetry';
 import { PluginContextProvider } from '@dxos/react-surface';
-
-// TODO(wittjosiah): This ensures that typed objects and SpaceProxy are not proxied by deepsignal. Remove.
-// https://github.com/luisherranz/deepsignal/issues/36
-(globalThis as any)[TypedObject.name] = TypedObject;
-(globalThis as any)[EchoDatabase.name] = EchoDatabase;
-(globalThis as any)[SpaceProxy.name] = SpaceProxy;
 
 void initializeAppTelemetry({ namespace: 'labs-app', config: new Config(Defaults()) });
 

--- a/packages/apps/plugins/plugin-dnd/package.json
+++ b/packages/apps/plugins/plugin-dnd/package.json
@@ -20,7 +20,7 @@
     "@dnd-kit/core": "^6.0.5",
     "@dnd-kit/sortable": "^7.0.1",
     "@dnd-kit/utilities": "^3.2.0",
-    "deepsignal": "^1.3.3"
+    "deepsignal": "^1.4.0-shallow.0"
   },
   "devDependencies": {
     "@braneframe/plugin-theme": "workspace:*",

--- a/packages/apps/plugins/plugin-graph/package.json
+++ b/packages/apps/plugins/plugin-graph/package.json
@@ -18,7 +18,7 @@
     "@dxos/async": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/util": "workspace:*",
-    "deepsignal": "^1.3.3",
+    "deepsignal": "^1.4.0-shallow.0",
     "lodash.set": "^4.3.2"
   },
   "devDependencies": {

--- a/packages/apps/plugins/plugin-graph/src/GraphPlugin.tsx
+++ b/packages/apps/plugins/plugin-graph/src/GraphPlugin.tsx
@@ -11,7 +11,7 @@ import { PluginDefinition } from '@dxos/react-surface';
 
 import { GraphContext } from './GraphContext';
 import { GraphNode, GraphNodeAction, GraphPluginProvides } from './types';
-import { ROOT, buildGraph } from './util';
+import { ROOT, buildGraph, deepSignalGraphNode, transformGraph } from './util';
 
 export const GraphPlugin = (): PluginDefinition<GraphPluginProvides> => {
   const graph: DeepSignal<GraphNode> = deepSignal({
@@ -21,12 +21,6 @@ export const GraphPlugin = (): PluginDefinition<GraphPluginProvides> => {
     description: 'Root node',
     pluginChildren: {},
     pluginActions: {},
-    // get children(): GraphNode[] {
-    //   return [];
-    // },
-    // get actions(): GraphNodeAction[] {
-    //   return [];
-    // },
   });
 
   return {
@@ -34,7 +28,18 @@ export const GraphPlugin = (): PluginDefinition<GraphPluginProvides> => {
       id: 'dxos:graph',
     },
     ready: async (plugins) => {
-      const result = buildGraph({ from: ROOT, plugins, onUpdate: (path, nodes) => set(graph, path, nodes) });
+      const result = buildGraph({
+        from: ROOT,
+        plugins,
+        onUpdate: (path, nodes) =>
+          set(
+            graph,
+            path,
+            Array.isArray(nodes)
+              ? nodes.map((node) => transformGraph(node, deepSignalGraphNode))
+              : transformGraph(nodes, deepSignalGraphNode),
+          ),
+      });
       graph.pluginChildren = deepSignal(result.pluginChildren ?? {});
       graph.pluginActions = deepSignal(result.pluginActions ?? {});
     },

--- a/packages/apps/plugins/plugin-graph/src/types.ts
+++ b/packages/apps/plugins/plugin-graph/src/types.ts
@@ -27,9 +27,8 @@ export type GraphNode<TDatum = any> = {
   attributes?: { [key: string]: any };
   pluginChildren?: { [key: string]: GraphNode[] };
   pluginActions?: { [key: string]: GraphNodeAction[] };
-  // TODO(wittjosiah): https://github.com/luisherranz/deepsignal/issues/32
-  // readonly children?: GraphNode[];
-  // readonly actions?: GraphNodeAction[];
+  readonly children?: GraphNode[];
+  readonly actions?: GraphNodeAction[];
 };
 
 export type GraphNodeAction = {

--- a/packages/apps/plugins/plugin-graph/src/util.test.ts
+++ b/packages/apps/plugins/plugin-graph/src/util.test.ts
@@ -10,7 +10,7 @@ import { describe, test } from '@dxos/test';
 import { jsonify } from '@dxos/util';
 
 import { GraphNode, GraphProvides } from './types';
-import { ROOT, buildGraph } from './util';
+import { ROOT, buildGraph, transformGraph } from './util';
 
 const checkDepth = (node: GraphNode, depth = 0): number => {
   if (!node.parent) {
@@ -190,5 +190,30 @@ describe('buildGraph', () => {
       testPlugin1.meta.id,
     ]);
     expect(await nodesRecieved.wait()).to.deep.equal([newNode]);
+  });
+});
+
+describe('transformGraph', () => {
+  test('returns transformed graph', () => {
+    const graph: GraphNode = { id: 'test', label: 'test', index: '0' };
+    const transformed = transformGraph(graph, (node) => {
+      node.id = 'transformed';
+      return node;
+    });
+
+    expect(transformed).to.equal(graph);
+    expect(transformed).to.deep.equal({ ...graph, id: 'transformed' });
+  });
+
+  test('transforms children', () => {
+    const [testPlugin1] = testPlugin(1);
+    const graph = buildGraph({ from: ROOT, plugins: [testPlugin1] });
+
+    const transformed = transformGraph(graph, (node) => {
+      node.id += '-transformed';
+      return node;
+    });
+
+    expect(transformed.pluginChildren![testPlugin1.meta.id][0].id).to.equal('root-node1-transformed');
   });
 });

--- a/packages/apps/plugins/plugin-intent/package.json
+++ b/packages/apps/plugins/plugin-intent/package.json
@@ -15,7 +15,7 @@
     "src"
   ],
   "dependencies": {
-    "deepsignal": "^1.3.3"
+    "deepsignal": "^1.4.0-shallow.0"
   },
   "devDependencies": {
     "@dxos/react-surface": "workspace:*",

--- a/packages/apps/plugins/plugin-markdown/package.json
+++ b/packages/apps/plugins/plugin-markdown/package.json
@@ -22,7 +22,7 @@
     "@dxos/aurora-composer": "workspace:*",
     "@dxos/client": "workspace:*",
     "@dxos/text-model": "workspace:*",
-    "deepsignal": "^1.3.3",
+    "deepsignal": "^1.4.0-shallow.0",
     "lodash.get": "^4.4.2"
   },
   "devDependencies": {

--- a/packages/apps/plugins/plugin-splitview/package.json
+++ b/packages/apps/plugins/plugin-splitview/package.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "@dxos/debug": "workspace:*",
-    "deepsignal": "^1.3.3"
+    "deepsignal": "^1.4.0-shallow.0"
   },
   "devDependencies": {
     "@braneframe/plugin-graph": "workspace:*",

--- a/packages/apps/plugins/plugin-stack/package.json
+++ b/packages/apps/plugins/plugin-stack/package.json
@@ -22,7 +22,7 @@
     "@dnd-kit/utilities": "^3.2.0",
     "@dxos/client": "workspace:*",
     "@dxos/util": "workspace:*",
-    "deepsignal": "^1.3.3",
+    "deepsignal": "^1.4.0-shallow.0",
     "lodash.get": "^4.4.2"
   },
   "devDependencies": {

--- a/packages/apps/plugins/plugin-theme/package.json
+++ b/packages/apps/plugins/plugin-theme/package.json
@@ -15,7 +15,7 @@
     "src"
   ],
   "dependencies": {
-    "deepsignal": "^1.3.3",
+    "deepsignal": "^1.4.0-shallow.0",
     "i18next": "^21.10.0"
   },
   "devDependencies": {

--- a/packages/apps/plugins/plugin-treeview/package.json
+++ b/packages/apps/plugins/plugin-treeview/package.json
@@ -22,7 +22,7 @@
     "@dxos/react-client": "workspace:*",
     "@preact/signals-react": "^1.3.3",
     "@tldraw/indices": "2.0.0-alpha.14",
-    "deepsignal": "^1.3.3",
+    "deepsignal": "^1.4.0-shallow.0",
     "lodash.get": "^4.4.2"
   },
   "devDependencies": {

--- a/packages/apps/plugins/plugin-treeview/src/components/BranchTreeItem.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/BranchTreeItem.tsx
@@ -8,7 +8,7 @@ import { CaretDown, CaretRight, DotsThreeVertical, Placeholder } from '@phosphor
 import React, { FC, forwardRef, ForwardRefExoticComponent, RefAttributes, useEffect, useRef, useState } from 'react';
 
 import { SortableProps } from '@braneframe/plugin-dnd';
-import { GraphNode, getActions, useGraph } from '@braneframe/plugin-graph';
+import { GraphNode, useGraph } from '@braneframe/plugin-graph';
 import { Button, DropdownMenu, Tooltip, TreeItem, useSidebar, useTranslation } from '@dxos/aurora';
 import { staticDisabled, focusRing, getSize } from '@dxos/aurora-theme';
 
@@ -45,7 +45,7 @@ export const BranchTreeItem: ForwardRefExoticComponent<BranchTreeItemProps & Ref
   // todo(thure): Handle `sortable`
 
   const { invokeAction } = useGraph();
-  const [primaryAction, ...actions] = getActions(node);
+  const [primaryAction, ...actions] = node.actions ?? [];
   // TODO(wittjosiah): Update namespace.
   const { t } = useTranslation('composer');
   const hasActiveDocument = false;
@@ -203,7 +203,7 @@ export const BranchTreeItem: ForwardRefExoticComponent<BranchTreeItemProps & Ref
         )}
       </div>
       <TreeItem.Body>
-        <TreeView items={Object.values(node.pluginChildren ?? {}).flat() as GraphNode[]} parent={node} />
+        <TreeView items={node.children} parent={node} />
       </TreeItem.Body>
     </TreeItem.Root>
   );

--- a/packages/apps/plugins/plugin-treeview/src/components/LeafTreeItem.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/LeafTreeItem.tsx
@@ -8,7 +8,7 @@ import { Circle, DotsThreeVertical, Placeholder } from '@phosphor-icons/react';
 import React, { FC, forwardRef, ForwardRefExoticComponent, RefAttributes, useRef, useState } from 'react';
 
 import { SortableProps } from '@braneframe/plugin-dnd';
-import { GraphNode, getActions, useGraph } from '@braneframe/plugin-graph';
+import { GraphNode, useGraph } from '@braneframe/plugin-graph';
 import {
   Button,
   DropdownMenu,
@@ -67,7 +67,7 @@ export const LeafTreeItem: ForwardRefExoticComponent<LeafTreeItemProps & RefAttr
   const disabled = node.attributes?.disabled ?? false;
   const error = node.attributes?.error ?? false;
   const Icon = node.icon ?? Placeholder;
-  const allActions = getActions(node);
+  const allActions = node.actions ?? [];
   const [primaryAction, ...actions] = allActions;
   const menuActions = disabled ? actions : allActions;
 

--- a/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
@@ -5,7 +5,7 @@
 import { DotsThreeVertical, GearSix, Placeholder } from '@phosphor-icons/react';
 import React, { useRef, useState } from 'react';
 
-import { GraphNode, getActions, useGraph } from '@braneframe/plugin-graph';
+import { GraphNode, useGraph } from '@braneframe/plugin-graph';
 import { useSplitView } from '@braneframe/plugin-splitview';
 import {
   Avatar,
@@ -44,7 +44,7 @@ export const TreeViewContainer = () => {
 
   const branches = Object.entries(graph.pluginChildren ?? {}).filter(([, items]) => (items as []).length > 0);
 
-  const [primary, secondary, ...actions] = getActions(graph as GraphNode);
+  const [primary, secondary, ...actions] = (graph as GraphNode).actions ?? [];
   const hoistedActions = [primary, secondary].filter(Boolean);
 
   return (

--- a/packages/apps/plugins/plugin-treeview/src/util.ts
+++ b/packages/apps/plugins/plugin-treeview/src/util.ts
@@ -17,6 +17,6 @@ export const resolveNodes = (graph: GraphNode[], [id, ...path]: string[], nodes:
     return nodes;
   }
 
-  const children = Object.values(node.pluginChildren ?? {}).flat() as GraphNode[];
+  const children = node.children ?? [];
   return resolveNodes(children, path, [...nodes, node]);
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,7 +376,7 @@ importers:
       '@types/showdown': ^2.0.0
       '@types/turndown': ^5.0.1
       '@vitejs/plugin-react': ^3.0.1
-      deepsignal: ^1.3.3
+      deepsignal: ^1.4.0-shallow.0
       dompurify: ^3.0.3
       github-markdown-css: ^5.2.0
       isomorphic-fetch: ^3.0.0
@@ -417,7 +417,7 @@ importers:
       '@phosphor-icons/react': 2.0.5_biqbaboplfbrettd7655fr4n2y
       '@preact/signals-react': 1.3.4_react@18.2.0
       '@tldraw/indices': 2.0.0-alpha.14
-      deepsignal: 1.3.4_react@18.2.0
+      deepsignal: 1.4.0-shallow.0_react@18.2.0
       dompurify: 3.0.3
       github-markdown-css: 5.2.0
       isomorphic-fetch: 3.0.0
@@ -745,7 +745,7 @@ importers:
       '@dxos/util': workspace:*
       '@faker-js/faker': ^7.3.0
       '@phosphor-icons/react': ^2.0.5
-      deepsignal: ^1.3.3
+      deepsignal: ^1.4.0-shallow.0
       react: ^18.2.0
       react-dom: ^18.2.0
       typescript: ^5.0.4
@@ -753,7 +753,7 @@ importers:
       '@dnd-kit/core': 6.0.5_biqbaboplfbrettd7655fr4n2y
       '@dnd-kit/sortable': 7.0.1_vvd3dzag27tc7rclyb2whqqnpe
       '@dnd-kit/utilities': 3.2.0_react@18.2.0
-      deepsignal: 1.3.4_react@18.2.0
+      deepsignal: 1.4.0-shallow.0_react@18.2.0
     devDependencies:
       '@braneframe/plugin-theme': link:../plugin-theme
       '@dxos/aurora': link:../../../ui/aurora
@@ -841,7 +841,7 @@ importers:
       '@types/lodash.set': ^4.3.7
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
-      deepsignal: ^1.3.3
+      deepsignal: ^1.4.0-shallow.0
       lodash.set: ^4.3.2
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -850,7 +850,7 @@ importers:
       '@dxos/async': link:../../../common/async
       '@dxos/debug': link:../../../common/debug
       '@dxos/util': link:../../../common/util
-      deepsignal: 1.3.4_react@18.2.0
+      deepsignal: 1.4.0-shallow.0_react@18.2.0
       lodash.set: 4.3.2
     devDependencies:
       '@braneframe/plugin-intent': link:../plugin-intent
@@ -870,11 +870,11 @@ importers:
     specifiers:
       '@dxos/react-surface': workspace:*
       '@types/react': ^18.0.21
-      deepsignal: ^1.3.3
+      deepsignal: ^1.4.0-shallow.0
       react: ^18.2.0
       vite: ^4.3.9
     dependencies:
-      deepsignal: 1.3.4_react@18.2.0
+      deepsignal: 1.4.0-shallow.0_react@18.2.0
     devDependencies:
       '@dxos/react-surface': link:../../../sdk/react-surface
       '@types/react': 18.0.21
@@ -966,7 +966,7 @@ importers:
       '@types/lodash.get': ^4.4.7
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
-      deepsignal: ^1.3.3
+      deepsignal: ^1.4.0-shallow.0
       lodash.get: ^4.4.2
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -979,7 +979,7 @@ importers:
       '@dxos/aurora-composer': link:../../../ui/aurora-composer
       '@dxos/client': link:../../../sdk/client
       '@dxos/text-model': link:../../../core/echo/text-model
-      deepsignal: 1.3.4_react@18.2.0
+      deepsignal: 1.4.0-shallow.0_react@18.2.0
       lodash.get: 4.4.2
     devDependencies:
       '@braneframe/plugin-client': link:../plugin-client
@@ -1073,13 +1073,13 @@ importers:
       '@phosphor-icons/react': ^2.0.5
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
-      deepsignal: ^1.3.3
+      deepsignal: ^1.4.0-shallow.0
       react: ^18.2.0
       react-dom: ^18.2.0
       vite: ^4.3.9
     dependencies:
       '@dxos/debug': link:../../../common/debug
-      deepsignal: 1.3.4_react@18.2.0
+      deepsignal: 1.4.0-shallow.0_react@18.2.0
     devDependencies:
       '@braneframe/plugin-graph': link:../plugin-graph
       '@braneframe/plugin-intent': link:../plugin-intent
@@ -1116,7 +1116,7 @@ importers:
       '@types/lodash.get': ^4.4.7
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
-      deepsignal: ^1.3.3
+      deepsignal: ^1.4.0-shallow.0
       lodash.get: ^4.4.2
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -1129,7 +1129,7 @@ importers:
       '@dnd-kit/utilities': 3.2.0_react@18.2.0
       '@dxos/client': link:../../../sdk/client
       '@dxos/util': link:../../../common/util
-      deepsignal: 1.3.4_react@18.2.0
+      deepsignal: 1.4.0-shallow.0_react@18.2.0
       lodash.get: 4.4.2
     devDependencies:
       '@braneframe/plugin-dnd': link:../plugin-dnd
@@ -1157,13 +1157,13 @@ importers:
       '@dxos/react-surface': workspace:*
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
-      deepsignal: ^1.3.3
+      deepsignal: ^1.4.0-shallow.0
       i18next: ^21.10.0
       react: ^18.2.0
       react-dom: ^18.2.0
       vite: ^4.3.9
     dependencies:
-      deepsignal: 1.3.4_react@18.2.0
+      deepsignal: 1.4.0-shallow.0_react@18.2.0
       i18next: 21.10.0
     devDependencies:
       '@dxos/aurora': link:../../../ui/aurora
@@ -1252,7 +1252,7 @@ importers:
       '@types/lodash.get': ^4.4.7
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
-      deepsignal: ^1.3.3
+      deepsignal: ^1.4.0-shallow.0
       lodash.get: ^4.4.2
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -1265,7 +1265,7 @@ importers:
       '@dxos/react-client': link:../../../sdk/react-client
       '@preact/signals-react': 1.3.4_react@18.2.0
       '@tldraw/indices': 2.0.0-alpha.14
-      deepsignal: 1.3.4_react@18.2.0
+      deepsignal: 1.4.0-shallow.0_react@18.2.0
       lodash.get: 4.4.2
     devDependencies:
       '@braneframe/plugin-dnd': link:../plugin-dnd
@@ -12711,14 +12711,6 @@ packages:
       use-sync-external-store: 1.2.0_react@18.2.0
     dev: false
 
-  /@preact/signals/1.1.5:
-    resolution: {integrity: sha512-OWr9TjuNh9ol/B5rNbLANEA940MvbYDMGcSAjPaKzAHBPhnTpuFCWhBB8vSm9lfy1BxKx6DKJLSs3Cz24otdkw==}
-    peerDependencies:
-      preact: 10.x
-    dependencies:
-      '@preact/signals-core': 1.3.1
-    dev: false
-
   /@preact/signals/1.1.5_preact@10.11.2:
     resolution: {integrity: sha512-OWr9TjuNh9ol/B5rNbLANEA940MvbYDMGcSAjPaKzAHBPhnTpuFCWhBB8vSm9lfy1BxKx6DKJLSs3Cz24otdkw==}
     peerDependencies:
@@ -23274,10 +23266,9 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
-  /deepsignal/1.3.4_react@18.2.0:
-    resolution: {integrity: sha512-yZEhFIZPnCN6uq07XykaeLRqqgBltF1sf4wvaucOhqb6w+ynoKZSpI00XKfvn6qMF8BRB9FFOttgAH1ljom3JA==}
+  /deepsignal/1.4.0-shallow.0_react@18.2.0:
+    resolution: {integrity: sha512-xMLJPVks5Z/2xWoUuj3YCZXpvtWRWme1kxGmwTV4AsX0EYYtFtXW55NiHmL5xZcco9m6TqVCtl2UsW2bq53Lhg==}
     dependencies:
-      '@preact/signals': 1.1.5
       '@preact/signals-core': 1.3.1
       '@preact/signals-react': 1.3.4_react@18.2.0
     transitivePeerDependencies:


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9577f5b</samp>

### Summary
🚀🧹🛠️

<!--
1.  🚀 - This emoji represents the performance improvement and the new shallow feature of `deepsignal`.
2.  🧹 - This emoji represents the removal of unused or redundant code and dependencies.
3.  🛠️ - This emoji represents the refactoring and simplification of the code and the utility functions.
-->
This pull request updates the `deepsignal` dependency to use its new shallow feature and removes unnecessary proxying of objects and properties in various plugins and apps. It also improves the performance and reactivity of the `GraphPlugin` component and simplifies the code and API of the `plugin-graph` and `plugin-treeview` packages.

> _The graph plugin was slow and complex_
> _So we gave it a major refresh_
> _We used `deepsignal` shallow_
> _And removed some code that was hollow_
> _Now the graph nodes are reactive and fresh_

### Walkthrough
*  Updated `deepsignal` dependency version to `^1.4.0-shallow.0` in several `package.json` files to use the new shallow feature ([link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-47b84ac128e4ba47b697389d563eb2770189956b67cea33857501b520432a1e1L38-R38), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-c624f3dd4e570e219143411d2ff97861c9fe6349ee287ceb18a174cd327885faL23-R23), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-12132ff5f40ad790922d7afe36c3c858e243e075af7ebf71c7cba4944d991c47L21-R21), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-269d91d6dc8b8b60f06ba298a1e2e1e8e00544fff90174b5859493b31f946049L18-R18), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-e6d1d345821614148e5995e27dd43e3d23acd9c585a2ae3ef5911c496baf2ccdL25-R25), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-a6323478ad3792664ebc285bb24026d9c0ff0bd484abae56596e57a0cc364601L19-R19), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-b0988acb4500e2e188ebdfee4ad90811c200cd24700f45e3534f33ebe048cdf3L25-R25), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-5beb288c5c43d119b127366e47f215230953a158a1d8468c5b2dd044039dab8bL18-R18), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-1c7dabfe1a501f5ad5b6105e2e13b1938322b0c6429ecc4b16f776342b9763eeL25-R25))
* Removed unused imports and assignments of `TypedObject`, `SpaceProxy`, and `EchoDatabase` from `main.tsx` files in `composer-app` and `labs-app` ([link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-9f2aee287f92edd662c13bed460a28a1590c9186b62c98ccc2e00f6877c3d7e6L22), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-9f2aee287f92edd662c13bed460a28a1590c9186b62c98ccc2e00f6877c3d7e6L28-L31), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-9d663519e7a46a19fe4305c8085aa017f51355119fb0fbe545eb37ab8492722cL25-R28))
* Added new utility functions `transformGraph` and `deepSignalGraphNode` to `util.ts` in `plugin-graph` to transform graph nodes and apply `deepsignal` with shallow options for `data`, `children`, and `actions` properties ([link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-4db66d5892d11016d7b49265f21136773c7d4ae0562b242dc842045544b5a92fR97-R132))
* Removed commented out code that defined `children` and `actions` properties of `GraphNode` type from `GraphPlugin.tsx` and `types.ts` in `plugin-graph` ([link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-93bf3cf06a0c1cea035e8647088f2523ff84452883582dabc6e93e7cbcc8cb97L24-L29), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-97606d5b4c2d306818d15063f51eb3092ae21b2a8026e0dfb01e2126f4e8119eL30-R31))
* Modified code that called `buildGraph` and assigned the result to `graph.pluginChildren` and `graph.pluginActions` in `GraphPlugin.tsx` in `plugin-graph` to use `transformGraph` and `deepSignalGraphNode` instead ([link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-93bf3cf06a0c1cea035e8647088f2523ff84452883582dabc6e93e7cbcc8cb97L37-R42))
* Added import of `transformGraph` and `deepSignalGraphNode` to `GraphPlugin.tsx` in `plugin-graph` ([link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-93bf3cf06a0c1cea035e8647088f2523ff84452883582dabc6e93e7cbcc8cb97L14-R14))
* Added new test suite for `transformGraph` function to `util.test.ts` in `plugin-graph` ([link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-3f355dafb9c0d647d5edbe9015f9ec690022b76f0a2b66690890d2e098b1a77bR195-R219))
* Added import of `transformGraph` to `util.test.ts` in `plugin-graph` ([link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-3f355dafb9c0d647d5edbe9015f9ec690022b76f0a2b66690890d2e098b1a77bL13-R13))
* Added import of `deepSignal` and `shallow` to `util.ts` in `plugin-graph` ([link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-4db66d5892d11016d7b49265f21136773c7d4ae0562b242dc842045544b5a92fR5-R6))
* Removed `getActions` function from `util.ts` in `plugin-graph` ([link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-4db66d5892d11016d7b49265f21136773c7d4ae0562b242dc842045544b5a92fL25-L39))
* Removed imports and calls of `getActions` from `BranchTreeItem.tsx`, `LeafTreeItem.tsx`, and `TreeViewContainer.tsx` in `plugin-treeview` and used `actions` property of nodes directly ([link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-d8fe3582ac5bc2be54db38bd9beb7a593e75d133291001e28c84c47ec1c1e456L11-R11), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-d8fe3582ac5bc2be54db38bd9beb7a593e75d133291001e28c84c47ec1c1e456L48-R48), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-d45d5bb7773619e374ccc6e568f6131feb68eb58c5c97d68ea6554efeec0b988L11-R11), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-d45d5bb7773619e374ccc6e568f6131feb68eb58c5c97d68ea6554efeec0b988L70-R70), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-5d68768eb04820eb8435d0b29071f52fe7cac46252e1527ffae2d7db10938815L8-R8), [link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-5d68768eb04820eb8435d0b29071f52fe7cac46252e1527ffae2d7db10938815L47-R47))
* Modified code that passed `Object.values(node.pluginChildren ?? {}).flat() as GraphNode[]` as `items` prop to `TreeView` component in `BranchTreeItem.tsx` in `plugin-treeview` to pass `node.children` instead ([link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-d8fe3582ac5bc2be54db38bd9beb7a593e75d133291001e28c84c47ec1c1e456L206-R206))
* Modified code that assigned `Object.values(node.pluginChildren ?? {}).flat() as GraphNode[]` to `children` in `util.ts` in `plugin-treeview` to assign `node.children ?? []` instead ([link](https://github.com/dxos/dxos/pull/3730/files?diff=unified&w=0#diff-ceaabd9b6d91c1ed9d4a26c192a70208416b5f8edd25deb9cbd9e836b228abdfL20-R20))


