### PR TITLE
refactor: fully qualified plugin ids

### DIFF
--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -10,7 +10,7 @@ import { createRoot } from 'react-dom/client';
 import { ClientPlugin } from '@braneframe/plugin-client';
 import { DndPlugin } from '@braneframe/plugin-dnd';
 import { ErrorPlugin } from '@braneframe/plugin-error';
-import { LocalFilesPlugin } from '@braneframe/plugin-files';
+import { FilesPlugin } from '@braneframe/plugin-files';
 import { GithubPlugin } from '@braneframe/plugin-github';
 import { GraphPlugin } from '@braneframe/plugin-graph';
 import { IntentPlugin } from '@braneframe/plugin-intent';
@@ -53,7 +53,7 @@ createRoot(document.getElementById('root')!).render(
         MarkdownPlugin(),
         StackPlugin(),
         GithubPlugin(),
-        LocalFilesPlugin(),
+        FilesPlugin(),
       ]}
     />
   </StrictMode>,

--- a/packages/apps/labs-app/src/main.tsx
+++ b/packages/apps/labs-app/src/main.tsx
@@ -12,7 +12,7 @@ import { DebugPlugin } from '@braneframe/plugin-debug';
 import { DndPlugin } from '@braneframe/plugin-dnd';
 import { DrawingPlugin } from '@braneframe/plugin-drawing';
 import { ErrorPlugin } from '@braneframe/plugin-error';
-import { LocalFilesPlugin } from '@braneframe/plugin-files';
+import { FilesPlugin } from '@braneframe/plugin-files';
 import { GithubPlugin } from '@braneframe/plugin-github';
 import { GraphPlugin } from '@braneframe/plugin-graph';
 import { IntentPlugin } from '@braneframe/plugin-intent';
@@ -64,7 +64,7 @@ createRoot(document.getElementById('root')!).render(
         MarkdownPlugin(),
         StackPlugin(),
         GithubPlugin(),
-        LocalFilesPlugin(),
+        FilesPlugin(),
         DrawingPlugin(),
         KanbanPlugin(),
         ThreadPlugin(),

--- a/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
+++ b/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
@@ -27,7 +27,7 @@ export const ClientPlugin = (
 
   return {
     meta: {
-      id: 'dxos:client',
+      id: 'dxos.org/plugin/client',
     },
     init: async () => {
       await client.initialize();

--- a/packages/apps/plugins/plugin-dnd/src/DndPlugin.tsx
+++ b/packages/apps/plugins/plugin-dnd/src/DndPlugin.tsx
@@ -177,7 +177,7 @@ const DndOverlay = () => {
 export const DndPlugin = (): PluginDefinition<DndPluginProvides> => {
   return {
     meta: {
-      id: 'dxos:dnd',
+      id: 'dxos.org/plugin/dnd',
     },
     provides: {
       components: {

--- a/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPlugin.tsx
+++ b/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPlugin.tsx
@@ -95,7 +95,7 @@ const DndPluginDefaultStoryPluginDefault = () => {
 export const DndPluginDefaultStoryPlugin = (): PluginDefinition<{ dndStory: DndPluginDefaultStoryContextValue }> => {
   return {
     meta: {
-      id: 'dxos:dndStoryPluginA',
+      id: 'example.com/plugin/dndStoryPluginA',
     },
     provides: {
       context: ({ children }: PropsWithChildren) => (

--- a/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPluginA.tsx
+++ b/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPluginA.tsx
@@ -61,7 +61,7 @@ const DefaultDndPluginStoryPluginA = () => {
 export const DndPluginDefaultStoryPluginA = (): PluginDefinition => {
   return {
     meta: {
-      id: 'dxos:dndPluginDefaultStoryPluginA',
+      id: 'example.com/plugin/dndPluginDefaultStoryPluginA',
     },
     provides: {
       component: (datum, role) => {

--- a/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPluginB.tsx
+++ b/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPluginB.tsx
@@ -80,7 +80,7 @@ const DndPluginDefaultStoryPluginBDefault = () => {
 export const DndPluginDefaultStoryPluginB = (): PluginDefinition => {
   return {
     meta: {
-      id: 'dxos:dndPluginDefaultStoryPluginB',
+      id: 'example.com/plugin/dndPluginDefaultStoryPluginB',
     },
     provides: {
       component: (datum, role) => {

--- a/packages/apps/plugins/plugin-drawing/src/props.tsx
+++ b/packages/apps/plugins/plugin-drawing/src/props.tsx
@@ -16,8 +16,9 @@ import { isTypedObject } from '@dxos/client/echo';
 
 export const DRAWING_PLUGIN = 'dxos.org/plugin/drawing';
 
+const DRAWING_ACTION = `${DRAWING_PLUGIN}/action`;
 export enum DrawingAction {
-  CREATE = `${DRAWING_PLUGIN}/create`,
+  CREATE = `${DRAWING_ACTION}/create`,
 }
 
 export type DrawingPluginProvides = GraphProvides & IntentProvides & TranslationsProvides;

--- a/packages/apps/plugins/plugin-error/src/ErrorPlugin.tsx
+++ b/packages/apps/plugins/plugin-error/src/ErrorPlugin.tsx
@@ -13,7 +13,7 @@ export const ErrorPlugin = (
   { config }: { config: Config } = { config: new Config(Envs(), Local(), Defaults()) },
 ): PluginDefinition => ({
   meta: {
-    id: 'dxos:error',
+    id: 'dxos.org/plugin/error',
   },
   provides: {
     context: ({ children }) => (

--- a/packages/apps/plugins/plugin-files/src/FilesPlugin.tsx
+++ b/packages/apps/plugins/plugin-files/src/FilesPlugin.tsx
@@ -16,7 +16,14 @@ import { findPlugin, PluginDefinition } from '@dxos/react-surface';
 
 import { LocalFileMain, LocalFileMainPermissions } from './components';
 import translations from './translations';
-import { LOCAL_FILES_PLUGIN, LocalEntity, LocalFile, LocalFilesAction, LocalFilesPluginProvides } from './types';
+import {
+  FILES_PLUGIN,
+  FILES_PLUGIN_SHORT_ID,
+  LocalEntity,
+  LocalFile,
+  LocalFilesAction,
+  LocalFilesPluginProvides,
+} from './types';
 import {
   findFile,
   getDirectoryChildren,
@@ -28,7 +35,7 @@ import {
   localEntityToGraphNode,
 } from './util';
 
-export const LocalFilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, MarkdownProvides> => {
+export const FilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, MarkdownProvides> => {
   let onFilesUpdate: ((node?: GraphNode<LocalEntity>) => void) | undefined;
   const state = deepSignal<{ files: LocalEntity[]; current: LocalFile | undefined }>({
     files: [],
@@ -48,7 +55,8 @@ export const LocalFilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, M
 
   return {
     meta: {
-      id: LOCAL_FILES_PLUGIN,
+      id: FILES_PLUGIN,
+      shortId: FILES_PLUGIN_SHORT_ID,
     },
     init: async () => {
       return {
@@ -66,7 +74,7 @@ export const LocalFilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, M
     ready: async (plugins) => {
       window.addEventListener('keydown', handleKeyDown);
 
-      const value = await localforage.getItem<FileSystemHandle[]>(LOCAL_FILES_PLUGIN);
+      const value = await localforage.getItem<FileSystemHandle[]>(FILES_PLUGIN);
       if (Array.isArray(value)) {
         await Promise.all(
           value.map(async (handle, index) => {
@@ -83,16 +91,16 @@ export const LocalFilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, M
 
       subscriptions.add(
         state.$files!.subscribe(async (files) => {
-          await localforage.setItem(LOCAL_FILES_PLUGIN, files.map((file) => file.handle).filter(Boolean));
+          await localforage.setItem(FILES_PLUGIN, files.map((file) => file.handle).filter(Boolean));
           onFilesUpdate?.();
         }),
       );
 
-      const treeViewPlugin = findPlugin<TreeViewPluginProvides>(plugins, 'dxos:treeview');
+      const treeViewPlugin = findPlugin<TreeViewPluginProvides>(plugins, 'dxos.org/plugin/treeview');
       if (treeViewPlugin) {
         const handleUpdate = () => {
           const current =
-            (treeViewPlugin.provides.treeView.active[0]?.startsWith(LOCAL_FILES_PLUGIN) &&
+            (treeViewPlugin.provides.treeView.active[0]?.startsWith(FILES_PLUGIN) &&
               findFile(state.files, treeViewPlugin.provides.treeView.active)) ||
             undefined;
 
@@ -147,11 +155,11 @@ export const LocalFilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, M
             {
               id: 'open-file-handle',
               index: actionIndices[0],
-              label: ['open file label', { ns: LOCAL_FILES_PLUGIN }],
+              label: ['open file label', { ns: FILES_PLUGIN }],
               icon: (props) => <FilePlus {...props} />,
               intent: [
                 {
-                  plugin: LOCAL_FILES_PLUGIN,
+                  plugin: FILES_PLUGIN,
                   action: LocalFilesAction.OPEN_FILE,
                 },
                 { action: TreeViewAction.ACTIVATE },
@@ -163,11 +171,11 @@ export const LocalFilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, M
             actions.push({
               id: 'open-directory',
               index: actionIndices[1],
-              label: ['open directory label', { ns: LOCAL_FILES_PLUGIN }],
+              label: ['open directory label', { ns: FILES_PLUGIN }],
               icon: (props) => <FolderPlus {...props} />,
               intent: [
                 {
-                  plugin: LOCAL_FILES_PLUGIN,
+                  plugin: FILES_PLUGIN,
                   action: LocalFilesAction.OPEN_DIRECTORY,
                 },
                 { action: TreeViewAction.ACTIVATE },

--- a/packages/apps/plugins/plugin-files/src/components/LocalFileMainPermissions.tsx
+++ b/packages/apps/plugins/plugin-files/src/components/LocalFileMainPermissions.tsx
@@ -8,12 +8,12 @@ import { GraphNode, useGraph } from '@braneframe/plugin-graph';
 import { Button, useTranslation } from '@dxos/aurora';
 import { descriptionText, mx } from '@dxos/aurora-theme';
 
-import { LOCAL_FILES_PLUGIN, LocalEntity } from '../types';
+import { FILES_PLUGIN, LocalEntity } from '../types';
 
 export const LocalFileMainPermissions = ({ data }: { data: GraphNode<LocalEntity> }) => {
-  const { t } = useTranslation(LOCAL_FILES_PLUGIN);
+  const { t } = useTranslation(FILES_PLUGIN);
   const { invokeAction } = useGraph();
-  const action = data.pluginActions?.[LOCAL_FILES_PLUGIN]?.find(({ id }) => id === 're-open');
+  const action = data.pluginActions?.[FILES_PLUGIN]?.find(({ id }) => id === 're-open');
   return (
     <div role='none' className='min-bs-screen is-full flex items-center justify-center p-8'>
       <p

--- a/packages/apps/plugins/plugin-files/src/index.ts
+++ b/packages/apps/plugins/plugin-files/src/index.ts
@@ -2,4 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './LocalFilesPlugin';
+export * from './FilesPlugin';

--- a/packages/apps/plugins/plugin-files/src/translations.ts
+++ b/packages/apps/plugins/plugin-files/src/translations.ts
@@ -2,10 +2,12 @@
 // Copyright 2023 DXOS.org
 //
 
+import { FILES_PLUGIN } from './types';
+
 export default [
   {
     'en-US': {
-      'dxos:local': {
+      [FILES_PLUGIN]: {
         'plugin name': 'Local Files',
         'missing file permissions': 'Permission required to view the currently selected file',
         'open file label': 'Open file',

--- a/packages/apps/plugins/plugin-files/src/types.ts
+++ b/packages/apps/plugins/plugin-files/src/types.ts
@@ -6,14 +6,17 @@ import { GraphProvides } from '@braneframe/plugin-graph';
 import { IntentProvides } from '@braneframe/plugin-intent';
 import { TranslationsProvides } from '@braneframe/plugin-theme';
 
-export const LOCAL_FILES_PLUGIN = 'dxos:local';
+export const FILES_PLUGIN = 'dxos.org/plugin/files';
 
+export const FILES_PLUGIN_SHORT_ID = 'fs';
+
+const FILES_ACTION = `${FILES_PLUGIN}/action`;
 export enum LocalFilesAction {
-  OPEN_FILE = `${LOCAL_FILES_PLUGIN}:open-file`,
-  OPEN_DIRECTORY = `${LOCAL_FILES_PLUGIN}:open-directory`,
-  RECONNECT = `${LOCAL_FILES_PLUGIN}:reconnect`,
-  CLOSE = `${LOCAL_FILES_PLUGIN}:close`,
-  SAVE = `${LOCAL_FILES_PLUGIN}:save`,
+  OPEN_FILE = `${FILES_ACTION}/open-file`,
+  OPEN_DIRECTORY = `${FILES_ACTION}/open-directory`,
+  RECONNECT = `${FILES_ACTION}/reconnect`,
+  CLOSE = `${FILES_ACTION}/close`,
+  SAVE = `${FILES_ACTION}/save`,
 }
 
 type PermissionStatus = 'granted' | 'denied' | 'prompt';

--- a/packages/apps/plugins/plugin-files/src/util.tsx
+++ b/packages/apps/plugins/plugin-files/src/util.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import { GraphNode, GraphNodeAction } from '@braneframe/plugin-graph';
 
-import { LOCAL_FILES_PLUGIN, LocalDirectory, LocalEntity, LocalFile, LocalFilesAction } from './types';
+import { FILES_PLUGIN, FILES_PLUGIN_SHORT_ID, LocalDirectory, LocalEntity, LocalFile, LocalFilesAction } from './types';
 
 export const isLocalFile = (datum: unknown): datum is LocalFile =>
   datum && typeof datum === 'object' ? 'title' in datum : false;
@@ -17,7 +17,7 @@ export const handleToLocalDirectory = async (handle: any /* FileSystemDirectoryH
   const permission = await handle.queryPermission({ mode: 'readwrite' });
   const children = permission === 'granted' ? await getDirectoryChildren(handle) : [];
   return {
-    id: `${LOCAL_FILES_PLUGIN}/${handle.name.replaceAll(/\./g, '-')}`,
+    id: `${FILES_PLUGIN_SHORT_ID}/${handle.name.replaceAll(/\./g, '-')}`,
     title: handle.name,
     handle,
     permission,
@@ -34,7 +34,7 @@ export const handleToLocalFile = async (
   const text = permission === 'granted' ? await handle.getFile().then((file: any) => file.text()) : undefined;
   const id = handle.name.replaceAll(/\./g, '-');
   return {
-    id: hasParent ? id : `${LOCAL_FILES_PLUGIN}/${id}`,
+    id: hasParent ? id : `${FILES_PLUGIN_SHORT_ID}/${id}`,
     title: handle.name,
     handle,
     permission,
@@ -53,7 +53,7 @@ export const legacyFileToLocalFile = async (file: File) => {
   });
 
   return {
-    id: `${LOCAL_FILES_PLUGIN}/${file.name.replaceAll(/\.| /g, '-')}`,
+    id: `${FILES_PLUGIN_SHORT_ID}/${file.name.replaceAll(/\.| /g, '-')}`,
     title: file.name,
     text,
   };
@@ -131,10 +131,10 @@ const localDirectoryToGraphNode = (directory: LocalDirectory, index: string, par
   const closeAction: GraphNodeAction = {
     id: 'close-directory',
     index: 'a1',
-    label: ['close directory label', { ns: LOCAL_FILES_PLUGIN }],
+    label: ['close directory label', { ns: FILES_PLUGIN }],
     icon: (props) => <X {...props} />,
     intent: {
-      plugin: LOCAL_FILES_PLUGIN,
+      plugin: FILES_PLUGIN,
       action: LocalFilesAction.CLOSE,
       data: { id: directory.id },
     },
@@ -146,11 +146,11 @@ const localDirectoryToGraphNode = (directory: LocalDirectory, index: string, par
     {
       id: 're-open',
       index: 'a0',
-      label: ['re-open directory label', { ns: LOCAL_FILES_PLUGIN }],
+      label: ['re-open directory label', { ns: FILES_PLUGIN }],
       icon: (props) => <Plugs {...props} />,
       disposition: 'toolbar',
       intent: {
-        plugin: LOCAL_FILES_PLUGIN,
+        plugin: FILES_PLUGIN,
         action: LocalFilesAction.RECONNECT,
         data: { id: directory.id },
       },
@@ -158,10 +158,10 @@ const localDirectoryToGraphNode = (directory: LocalDirectory, index: string, par
     closeAction,
   ];
 
-  node.pluginActions = { [LOCAL_FILES_PLUGIN]: directory.permission === 'granted' ? grantedActions : defaultActions };
+  node.pluginActions = { [FILES_PLUGIN]: directory.permission === 'granted' ? grantedActions : defaultActions };
   const childIndices = getIndices(directory.children.length);
   node.pluginChildren = {
-    [LOCAL_FILES_PLUGIN]: directory.children.map((entity, index) => {
+    [FILES_PLUGIN]: directory.children.map((entity, index) => {
       if ('children' in entity) {
         return localDirectoryToGraphNode(entity, childIndices[index], node);
       } else {
@@ -190,10 +190,10 @@ const localFileToGraphNode = (file: LocalFile, index: string, parent?: GraphNode
   const closeAction: GraphNodeAction = {
     id: 'close-directory',
     index: 'a1',
-    label: ['close file label', { ns: LOCAL_FILES_PLUGIN }],
+    label: ['close file label', { ns: FILES_PLUGIN }],
     icon: (props) => <X {...props} />,
     intent: {
-      plugin: LOCAL_FILES_PLUGIN,
+      plugin: FILES_PLUGIN,
       action: LocalFilesAction.CLOSE,
       data: { id: file.id },
     },
@@ -203,10 +203,10 @@ const localFileToGraphNode = (file: LocalFile, index: string, parent?: GraphNode
     {
       id: 'save',
       index: 'a2',
-      label: [file.handle ? 'save label' : 'save as label', { ns: LOCAL_FILES_PLUGIN }],
+      label: [file.handle ? 'save label' : 'save as label', { ns: FILES_PLUGIN }],
       icon: (props) => <FloppyDisk {...props} />,
       intent: {
-        plugin: LOCAL_FILES_PLUGIN,
+        plugin: FILES_PLUGIN,
         action: LocalFilesAction.SAVE,
         data: { id: file.id },
       },
@@ -218,11 +218,11 @@ const localFileToGraphNode = (file: LocalFile, index: string, parent?: GraphNode
     {
       id: 're-open',
       index: 'a0',
-      label: ['re-open file label', { ns: LOCAL_FILES_PLUGIN }],
+      label: ['re-open file label', { ns: FILES_PLUGIN }],
       icon: (props) => <Plugs {...props} />,
       disposition: 'toolbar',
       intent: {
-        plugin: LOCAL_FILES_PLUGIN,
+        plugin: FILES_PLUGIN,
         action: LocalFilesAction.RECONNECT,
         data: { id: file.id },
       },
@@ -230,7 +230,7 @@ const localFileToGraphNode = (file: LocalFile, index: string, parent?: GraphNode
     closeAction,
   ];
 
-  node.pluginActions = { [LOCAL_FILES_PLUGIN]: file.permission === 'granted' ? grantedActions : defaultActions };
+  node.pluginActions = { [FILES_PLUGIN]: file.permission === 'granted' ? grantedActions : defaultActions };
 
   return node;
 };

--- a/packages/apps/plugins/plugin-github/src/GithubPlugin.tsx
+++ b/packages/apps/plugins/plugin-github/src/GithubPlugin.tsx
@@ -23,7 +23,8 @@ import translations from './translations';
 
 export const GithubPlugin = (): PluginDefinition<TranslationsProvides> => ({
   meta: {
-    id: 'dxos:github',
+    id: 'dxos.org/plugin/github',
+    shortId: 'github',
   },
   provides: {
     translations,
@@ -32,13 +33,13 @@ export const GithubPlugin = (): PluginDefinition<TranslationsProvides> => ({
       switch (role) {
         case 'dialog':
           switch (true) {
-            case datum === 'dxos:splitview/ProfileSettings':
+            case datum === 'dxos.org/plugin/splitview/ProfileSettings':
               return PatInput;
-            case Array.isArray(datum) && datum[0] === 'dxos:github/BindDialog':
+            case Array.isArray(datum) && datum[0] === 'dxos.org/plugin/github/BindDialog':
               return UrlDialog;
-            case Array.isArray(datum) && datum[0] === 'dxos:github/ExportDialog':
+            case Array.isArray(datum) && datum[0] === 'dxos.org/plugin/github/ExportDialog':
               return ExportDialog;
-            case Array.isArray(datum) && datum[0] === 'dxos:github/ImportDialog':
+            case Array.isArray(datum) && datum[0] === 'dxos.org/plugin/github/ImportDialog':
               return ImportDialog;
             default:
               return null;

--- a/packages/apps/plugins/plugin-github/src/components/EmbeddedMain/EmbeddedMain.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/EmbeddedMain/EmbeddedMain.tsx
@@ -35,7 +35,7 @@ import { useIdentity } from '@dxos/react-client/halo';
 import { Surface, findPlugin, usePluginContext } from '@dxos/react-surface';
 
 import { useDocGhId } from '../../hooks';
-import { EditorViewState } from '../../props';
+import { EditorViewState, GITHUB_PLUGIN } from '../../props';
 import {
   DocumentResolverProvider,
   DocumentResolverContext,
@@ -50,11 +50,11 @@ const overlayAttrs = { side: 'top' as const, sideOffset: 4 };
 
 const EmbeddedLayoutImpl = () => {
   const identity = useIdentity();
-  const { t } = useTranslation('dxos:github');
+  const { t } = useTranslation(GITHUB_PLUGIN);
   const { space, source, id, identityHex } = useContext(SpaceResolverContext);
   const { document } = useContext(DocumentResolverContext);
   const { plugins } = usePluginContext();
-  const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos:client');
+  const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos.org/plugin/client');
 
   const handleCloseEmbed = useCallback(() => {
     window.parent.postMessage({ type: 'close-embed' }, 'https://github.com');
@@ -263,7 +263,7 @@ const EmbeddedLayoutImpl = () => {
           <Dialog.Root open={renameDialogOpen} onOpenChange={setRenameDialogOpen}>
             <Dialog.Overlay classNames='backdrop-blur'>
               <Dialog.Content>
-                <Surface role='dialog' data={['dxos:space/RenameSpaceDialog', space]} />
+                <Surface role='dialog' data={['dxos.org/plugin/space/RenameSpaceDialog', space]} />
               </Dialog.Content>
             </Dialog.Overlay>
           </Dialog.Root>

--- a/packages/apps/plugins/plugin-github/src/components/EmbeddedMain/GfmPreview.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/EmbeddedMain/GfmPreview.tsx
@@ -9,6 +9,7 @@ import React, { useEffect, useState } from 'react';
 import { useTranslation } from '@dxos/aurora';
 import { Loading } from '@dxos/react-appkit';
 
+import { GITHUB_PLUGIN } from '../../props';
 import { PatInput, useOctokitContext } from '../GithubApiProviders';
 
 const defaultOptions: Parameters<typeof DOMPurify.sanitize>[1] = {
@@ -76,7 +77,7 @@ export type GfmPreviewProps = {
 export const GfmPreview = ({ markdown, owner, repo }: GfmPreviewProps) => {
   const [html, setHtml] = useState('');
   const { octokit } = useOctokitContext();
-  const { t } = useTranslation('dxos:github');
+  const { t } = useTranslation(GITHUB_PLUGIN);
 
   useEffect(() => {
     if (octokit && markdown) {

--- a/packages/apps/plugins/plugin-github/src/components/ExportDialog.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/ExportDialog.tsx
@@ -9,7 +9,7 @@ import { ComposerModel } from '@dxos/aurora-composer';
 import { log } from '@dxos/log';
 import { Input } from '@dxos/react-appkit';
 
-import { ExportViewState, GhFileIdentifier, GhIdentifier } from '../props';
+import { ExportViewState, GITHUB_PLUGIN, GhFileIdentifier, GhIdentifier } from '../props';
 import { useOctokitContext } from './GithubApiProviders';
 
 export const ExportDialog = ({
@@ -20,7 +20,7 @@ export const ExportDialog = ({
   const content = model.content;
 
   const { octokit } = useOctokitContext();
-  const { t } = useTranslation('dxos:github');
+  const { t } = useTranslation(GITHUB_PLUGIN);
   const [exportViewState, setExportViewState] = useState<ExportViewState>(initialExportViewState);
   const [ghResponseUrl, setGhResponseUrl] = useState<string | null>(initialResponseUrl);
   const [ghBranchValue, setGhBranchValue] = useState('');

--- a/packages/apps/plugins/plugin-github/src/components/GithubApiProviders/PatInput.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/GithubApiProviders/PatInput.tsx
@@ -8,6 +8,7 @@ import React, { PropsWithChildren, useEffect, useState } from 'react';
 import { Link, Input, Trans, useTranslation, useId } from '@dxos/aurora';
 import { getSize, mx } from '@dxos/aurora-theme';
 
+import { GITHUB_PLUGIN } from '../../props';
 import { useOctokitContext } from './OctokitProvider';
 
 const ExternalLink = ({ children }: PropsWithChildren<{}>) => {
@@ -27,7 +28,7 @@ const ExternalLink = ({ children }: PropsWithChildren<{}>) => {
 };
 
 export const PatInput = () => {
-  const { t } = useTranslation('dxos:github');
+  const { t } = useTranslation(GITHUB_PLUGIN);
   const { pat, setPat } = useOctokitContext();
   const [patValue, setPatValue] = useState(pat);
 

--- a/packages/apps/plugins/plugin-github/src/components/ImportDialog.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/ImportDialog.tsx
@@ -8,7 +8,7 @@ import { Button, Dialog, useTranslation } from '@dxos/aurora';
 import { MarkdownComposerRef } from '@dxos/aurora-composer';
 import { log } from '@dxos/log';
 
-import { GhFileIdentifier, GhIdentifier, GhIssueIdentifier } from '../props';
+import { GITHUB_PLUGIN, GhFileIdentifier, GhIdentifier, GhIssueIdentifier } from '../props';
 import { useOctokitContext } from './GithubApiProviders';
 
 export const ImportDialog = ({
@@ -16,7 +16,7 @@ export const ImportDialog = ({
 }: {
   data: [string, GhIdentifier, RefObject<MarkdownComposerRef>];
 }) => {
-  const { t } = useTranslation('dxos:github');
+  const { t } = useTranslation(GITHUB_PLUGIN);
   const { octokit } = useOctokitContext();
 
   const importGhIssueContent = useCallback(async () => {

--- a/packages/apps/plugins/plugin-github/src/components/MarkdownActions.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/MarkdownActions.tsx
@@ -12,7 +12,7 @@ import { getSize } from '@dxos/aurora-theme';
 import { log } from '@dxos/log';
 
 import { useDocGhId } from '../hooks';
-import { GhIssueIdentifier } from '../props';
+import { GITHUB_PLUGIN, GhIssueIdentifier } from '../props';
 import { useOctokitContext } from './GithubApiProviders';
 
 export const MarkdownActions = ({
@@ -22,7 +22,7 @@ export const MarkdownActions = ({
 }) => {
   const ghId = properties.meta?.keys?.find((key) => key.source === 'com.github')?.id;
   const { octokit } = useOctokitContext();
-  const { t } = useTranslation('dxos:github');
+  const { t } = useTranslation(GITHUB_PLUGIN);
   const splitView = useSplitView();
 
   const docGhId = useDocGhId(properties.meta?.keys ?? []);
@@ -43,7 +43,7 @@ export const MarkdownActions = ({
         const {
           data: { html_url: issueUrl },
         } = await updateIssueContent();
-        splitView.dialogContent = ['dxos:github/ExportDialog', ['response', issueUrl], model, docGhId];
+        splitView.dialogContent = ['dxos.org/plugin/github/ExportDialog', ['response', issueUrl], model, docGhId];
         splitView.dialogOpen = true;
       } catch (err) {
         log.error('Failed to export to Github issue');
@@ -57,7 +57,7 @@ export const MarkdownActions = ({
     if ('issueNumber' in docGhId!) {
       void exportGhIssueContent();
     } else if ('path' in docGhId!) {
-      splitView.dialogContent = ['dxos:github/ExportDialog', ['create-pr', null], model, docGhId];
+      splitView.dialogContent = ['dxos.org/plugin/github/ExportDialog', ['create-pr', null], model, docGhId];
       splitView.dialogOpen = true;
     }
   }, [exportGhIssueContent, docGhId]);
@@ -71,7 +71,7 @@ export const MarkdownActions = ({
             classNames='gap-2'
             disabled={!docGhId}
             onClick={() => {
-              splitView.dialogContent = ['dxos:github/ImportDialog', docGhId, editorRef];
+              splitView.dialogContent = ['dxos.org/plugin/github/ImportDialog', docGhId, editorRef];
               splitView.dialogOpen = true;
             }}
           >
@@ -105,7 +105,7 @@ export const MarkdownActions = ({
         <DropdownMenu.Item
           classNames='gap-2'
           onClick={() => {
-            splitView.dialogContent = ['dxos:github/BindDialog', properties];
+            splitView.dialogContent = ['dxos.org/plugin/github/BindDialog', properties];
             splitView.dialogOpen = true;
           }}
         >

--- a/packages/apps/plugins/plugin-github/src/components/UrlDialog.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/UrlDialog.tsx
@@ -10,9 +10,10 @@ import { Dialog, Button, useTranslation } from '@dxos/aurora';
 import { Input } from '@dxos/react-appkit';
 
 import { useGhIdFromUrl } from '../hooks/useGhIdFromUrl';
+import { GITHUB_PLUGIN } from '../props';
 
 export const UrlDialog = ({ data: [_, properties] }: { data: [string, MarkdownProperties] }) => {
-  const { t } = useTranslation('dxos:github');
+  const { t } = useTranslation(GITHUB_PLUGIN);
   const [ghUrlValue, setGhUrlValue] = useState('');
 
   const ghId = useGhIdFromUrl(ghUrlValue);

--- a/packages/apps/plugins/plugin-github/src/props.ts
+++ b/packages/apps/plugins/plugin-github/src/props.ts
@@ -7,6 +7,8 @@ import { Dispatch, SetStateAction } from 'react';
 import { Document } from '@braneframe/types';
 import { Space } from '@dxos/react-client/echo';
 
+export const GITHUB_PLUGIN = 'dxos.org/plugin/github';
+
 export type EditorViewState = 'editor' | 'preview';
 
 export type MarkdownDocumentProps = {

--- a/packages/apps/plugins/plugin-graph/src/GraphPlugin.tsx
+++ b/packages/apps/plugins/plugin-graph/src/GraphPlugin.tsx
@@ -31,7 +31,7 @@ export const GraphPlugin = (): PluginDefinition<GraphPluginProvides> => {
 
   return {
     meta: {
-      id: 'dxos:graph',
+      id: 'dxos.org/plugin/graph',
     },
     ready: async (plugins) => {
       const result = buildGraph({ from: ROOT, plugins, onUpdate: (path, nodes) => set(graph, path, nodes) });

--- a/packages/apps/plugins/plugin-intent/src/IntentPlugin.tsx
+++ b/packages/apps/plugins/plugin-intent/src/IntentPlugin.tsx
@@ -12,7 +12,7 @@ export const IntentPlugin = (): PluginDefinition<IntentPluginProvides> => {
 
   return {
     meta: {
-      id: 'dxos:intent',
+      id: 'dxos.org/plugin/intent',
     },
     ready: async (plugins) => {
       state.sendIntent = (intent: Intent) => {

--- a/packages/apps/plugins/plugin-kanban/src/props.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/props.tsx
@@ -25,8 +25,9 @@ import { isTypedObject } from '@dxos/client/echo';
 // TODO(burdon): Make id consistent with other plugins.
 export const KANBAN_PLUGIN = 'dxos.org/plugin/kanban';
 
+const KANBAN_ACTION = `${KANBAN_PLUGIN}/action`;
 export enum KanbanAction {
-  CREATE = `${KANBAN_PLUGIN}/create`,
+  CREATE = `${KANBAN_ACTION}/create`,
 }
 
 export type KanbanPluginProvides = GraphProvides & IntentProvides & TranslationsProvides;

--- a/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -176,7 +176,10 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
             break;
           // TODO(burdon): Can this be decoupled from this plugin?
           case 'dialog':
-            if (get(datum, 'subject') === 'dxos:stack/chooser' && get(datum, 'id') === 'choose-section-space-doc') {
+            if (
+              get(datum, 'subject') === 'dxos.org/plugin/stack/chooser' &&
+              get(datum, 'id') === 'choose-section-space-doc'
+            ) {
               return SpaceMarkdownChooser;
             }
             break;

--- a/packages/apps/plugins/plugin-markdown/src/components/SpaceMarkdownChooser.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/SpaceMarkdownChooser.tsx
@@ -9,6 +9,7 @@ import { useGraph } from '@braneframe/plugin-graph';
 import { useTreeView } from '@braneframe/plugin-treeview';
 import { Button, Dialog, Input, useTranslation } from '@dxos/aurora';
 
+import { MARKDOWN_PLUGIN } from '../types';
 import { isMarkdown } from '../util';
 
 export const SpaceMarkdownChooser = ({
@@ -16,7 +17,7 @@ export const SpaceMarkdownChooser = ({
 }: {
   data: { onDone: (items: { id: string }[]) => void; chooser: 'one' | 'many'; omit: Set<string> };
 }) => {
-  const { t } = useTranslation('dxos:markdown');
+  const { t } = useTranslation(MARKDOWN_PLUGIN);
   // todo(thure): This assumes the best & only way to get the active space is to find it in the graph using treeView, which probably won’t scale well.
   const treeView = useTreeView();
   const { graph } = useGraph();

--- a/packages/apps/plugins/plugin-markdown/src/types.ts
+++ b/packages/apps/plugins/plugin-markdown/src/types.ts
@@ -4,10 +4,11 @@
 
 import { MarkdownComposerProps } from '@dxos/aurora-composer';
 
-export const MARKDOWN_PLUGIN = 'dxos:markdown';
+export const MARKDOWN_PLUGIN = 'dxos.org/plugin/markdown';
 
+const MARKDOWN_ACTION = `${MARKDOWN_PLUGIN}/action`;
 export enum MarkdownAction {
-  CREATE = `${MARKDOWN_PLUGIN}/create`,
+  CREATE = `${MARKDOWN_ACTION}/create`,
 }
 
 export type MarkdownProperties = {

--- a/packages/apps/plugins/plugin-pwa/src/PwaPlugin.tsx
+++ b/packages/apps/plugins/plugin-pwa/src/PwaPlugin.tsx
@@ -12,7 +12,7 @@ import { captureException } from '@dxos/sentry';
 
 export const PwaPlugin = (): PluginDefinition => ({
   meta: {
-    id: 'dxos:pwa',
+    id: 'dxos.org/plugin/pwa',
   },
   provides: {
     context: ({ children }) => {

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -22,7 +22,7 @@ import { PluginDefinition, findPlugin } from '@dxos/react-surface';
 import { backupSpace } from './backup';
 import { DialogRenameSpace, DialogRestoreSpace, EmptySpace, EmptyTree, SpaceMain, SpaceMainEmpty } from './components';
 import translations from './translations';
-import { SPACE_PLUGIN, SpaceAction } from './types';
+import { SPACE_PLUGIN, SPACE_PLUGIN_SHORT_ID, SpaceAction } from './types';
 import { getSpaceId, isSpace, spaceToGraphNode } from './util';
 
 type SpacePluginProvides = GraphProvides & IntentProvides & TranslationsProvides;
@@ -34,11 +34,12 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
   return {
     meta: {
       id: SPACE_PLUGIN,
+      shortId: SPACE_PLUGIN_SHORT_ID,
     },
     ready: async (plugins) => {
-      const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos:client');
-      const treeViewPlugin = findPlugin<TreeViewPluginProvides>(plugins, 'dxos:treeview');
-      const graphPlugin = findPlugin<GraphPluginProvides>(plugins, 'dxos:graph');
+      const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos.org/plugin/client');
+      const treeViewPlugin = findPlugin<TreeViewPluginProvides>(plugins, 'dxos.org/plugin/treeview');
+      const graphPlugin = findPlugin<GraphPluginProvides>(plugins, 'dxos.org/plugin/graph');
       if (!clientPlugin) {
         return;
       }
@@ -112,9 +113,9 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
           case 'dialog':
             if (Array.isArray(datum)) {
               switch (datum[0]) {
-                case 'dxos:space/RenameSpaceDialog':
+                case 'dxos.org/plugin/space/RenameSpaceDialog':
                   return DialogRenameSpace;
-                case 'dxos:space/RestoreSpaceDialog':
+                case 'dxos.org/plugin/space/RestoreSpaceDialog':
                   return DialogRestoreSpace;
                 default:
                   return null;
@@ -136,7 +137,7 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
           }
 
           onSpaceUpdate = emit;
-          const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos:client');
+          const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos.org/plugin/client');
           const spaces = clientPlugin?.provides.client.spaces.get();
           const indices = spaces?.length ? getIndices(spaces.length) : [];
           return spaces?.map((space, index) => spaceToGraphNode(space, plugins, indices[index])) ?? [];
@@ -190,7 +191,7 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
       },
       intent: {
         resolver: async (intent, plugins) => {
-          const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos:client');
+          const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos.org/plugin/client');
           switch (intent.action) {
             case SpaceAction.CREATE: {
               return clientPlugin?.provides.client.createSpace(intent.data);
@@ -229,17 +230,17 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
             }
 
             case SpaceAction.RENAME: {
-              const splitViewPlugin = findPlugin<SplitViewProvides>(plugins, 'dxos:splitview');
+              const splitViewPlugin = findPlugin<SplitViewProvides>(plugins, 'dxos.org/plugin/splitview');
               if (space && splitViewPlugin?.provides.splitView) {
                 splitViewPlugin.provides.splitView.dialogOpen = true;
-                splitViewPlugin.provides.splitView.dialogContent = ['dxos:space/RenameSpaceDialog', space];
+                splitViewPlugin.provides.splitView.dialogContent = ['dxos.org/plugin/space/RenameSpaceDialog', space];
                 return true;
               }
               break;
             }
 
             case SpaceAction.HIDE: {
-              const treeViewPlugin = findPlugin<TreeViewPluginProvides>(plugins, 'dxos:treeview');
+              const treeViewPlugin = findPlugin<TreeViewPluginProvides>(plugins, 'dxos.org/plugin/treeview');
               const client = clientPlugin?.provides.client;
               const identity = client?.halo.identity.get();
               if (identity && space) {
@@ -276,10 +277,10 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
             }
 
             case SpaceAction.RESTORE: {
-              const splitViewPlugin = findPlugin<SplitViewProvides>(plugins, 'dxos:splitview');
+              const splitViewPlugin = findPlugin<SplitViewProvides>(plugins, 'dxos.org/plugin/splitview');
               if (space && splitViewPlugin?.provides.splitView) {
                 splitViewPlugin.provides.splitView.dialogOpen = true;
-                splitViewPlugin.provides.splitView.dialogContent = ['dxos:space/RestoreSpaceDialog', space];
+                splitViewPlugin.provides.splitView.dialogContent = ['dxos.org/plugin/space/RestoreSpaceDialog', space];
                 return true;
               }
               break;

--- a/packages/apps/plugins/plugin-space/src/types.ts
+++ b/packages/apps/plugins/plugin-space/src/types.ts
@@ -2,16 +2,18 @@
 // Copyright 2023 DXOS.org
 //
 
-export const SPACE_PLUGIN = 'dxos:space';
+export const SPACE_PLUGIN = 'dxos.org/plugin/space';
+export const SPACE_PLUGIN_SHORT_ID = 'space';
 
+const SPACE_ACTION = `${SPACE_PLUGIN}/action`;
 export enum SpaceAction {
-  CREATE = `${SPACE_PLUGIN}/create`,
-  JOIN = `${SPACE_PLUGIN}/join`,
-  SHARE = `${SPACE_PLUGIN}/share`,
-  RENAME = `${SPACE_PLUGIN}/rename`,
-  HIDE = `${SPACE_PLUGIN}/hide`,
-  BACKUP = `${SPACE_PLUGIN}/backup`,
-  RESTORE = `${SPACE_PLUGIN}/restore`,
-  ADD_OBJECT = `${SPACE_PLUGIN}/add-object`,
-  REMOVE_OBJECT = `${SPACE_PLUGIN}/remove-object`,
+  CREATE = `${SPACE_ACTION}/create`,
+  JOIN = `${SPACE_ACTION}/join`,
+  SHARE = `${SPACE_ACTION}/share`,
+  RENAME = `${SPACE_ACTION}/rename`,
+  HIDE = `${SPACE_ACTION}/hide`,
+  BACKUP = `${SPACE_ACTION}/backup`,
+  RESTORE = `${SPACE_ACTION}/restore`,
+  ADD_OBJECT = `${SPACE_ACTION}/add-object`,
+  REMOVE_OBJECT = `${SPACE_ACTION}/remove-object`,
 }

--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -13,20 +13,19 @@ import { log } from '@dxos/log';
 import { EchoDatabase, Space, SpaceState, TypedObject } from '@dxos/react-client/echo';
 import { Plugin, findPlugin } from '@dxos/react-surface';
 
-import { SPACE_PLUGIN, SpaceAction } from './types';
+import { SPACE_PLUGIN, SPACE_PLUGIN_SHORT_ID, SpaceAction } from './types';
 
 export const isSpace = (datum: unknown): datum is Space =>
   datum && typeof datum === 'object'
     ? 'key' in datum && datum.key instanceof PublicKey && 'db' in datum && datum.db instanceof EchoDatabase
     : false;
 
-// TODO(wittjosiah): Specify and factor out fully qualified names + utils (e.g., subpaths, uris, etc).
 export const getSpaceId = (spaceKey: PublicKeyLike) => {
   if (spaceKey instanceof PublicKey) {
-    spaceKey = spaceKey.truncate();
+    spaceKey = spaceKey.toHex();
   }
 
-  return `${SPACE_PLUGIN}/${spaceKey}`;
+  return `${SPACE_PLUGIN_SHORT_ID}/${spaceKey}`;
 };
 
 export const getSpaceDisplayName = (space: Space): string | [string, { ns: string }] => {
@@ -39,7 +38,7 @@ export const getSpaceDisplayName = (space: Space): string | [string, { ns: strin
 };
 
 export const spaceToGraphNode = (space: Space, plugins: Plugin[], index: string): GraphNode<Space> => {
-  const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos:client');
+  const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos.org/plugin/client');
   if (!clientPlugin) {
     throw new Error('Client plugin not found');
   }

--- a/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
@@ -42,7 +42,7 @@ export const SplitView = () => {
       <Dialog.Root open={dialogOpen} onOpenChange={(nextOpen) => (context.dialogOpen = nextOpen)}>
         <DensityProvider density='fine'>
           <Dialog.Overlay>
-            {dialogContent === 'dxos:splitview/ProfileSettings' ? (
+            {dialogContent === 'dxos.org/plugin/splitview/ProfileSettings' ? (
               <Dialog.Content>
                 <Dialog.Title>{t('settings dialog title', { ns: 'os' })}</Dialog.Title>
                 <Surface role='dialog' data={dialogContent} />

--- a/packages/apps/plugins/plugin-splitview/src/types.ts
+++ b/packages/apps/plugins/plugin-splitview/src/types.ts
@@ -7,10 +7,11 @@ import type { DeepSignal } from 'deepsignal';
 import type { GraphProvides } from '@braneframe/plugin-graph';
 import type { IntentProvides } from '@braneframe/plugin-intent';
 
-export const SPLITVIEW_PLUGIN = 'dxos:splitview';
+export const SPLITVIEW_PLUGIN = 'dxos.org/plugin/splitview';
 
+const SPLITVIEW_ACTION = `${SPLITVIEW_PLUGIN}/action`;
 export enum SplitViewAction {
-  TOGGLE_SIDEBAR = `${SPLITVIEW_PLUGIN}:toggle-sidebar`,
+  TOGGLE_SIDEBAR = `${SPLITVIEW_ACTION}/toggle-sidebar`,
 }
 
 export type SplitViewContextValue = DeepSignal<{

--- a/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
@@ -29,7 +29,14 @@ import { Surface } from '@dxos/react-surface';
 import { arrayMove } from '@dxos/util';
 
 import { stackState } from '../stores';
-import { GenericStackObject, StackModel, StackProperties, StackSectionModel, StackSections } from '../types';
+import {
+  GenericStackObject,
+  STACK_PLUGIN,
+  StackModel,
+  StackProperties,
+  StackSectionModel,
+  StackSections,
+} from '../types';
 
 type StackSectionProps = {
   onRemove?: () => void;
@@ -49,7 +56,7 @@ const StackSectionImpl = forwardRef<HTMLLIElement, ListScopedProps<StackSectionP
     { onRemove = () => {}, section, draggableAttributes, draggableListeners, style, rearranging, isOverlay },
     forwardedRef,
   ) => {
-    const { t } = useTranslation('dxos:stack');
+    const { t } = useTranslation(STACK_PLUGIN);
     return (
       <DensityProvider density='fine'>
         <ListItem.Root
@@ -138,7 +145,7 @@ const StackSectionsImpl = ({
   id: string;
   onAdd: (start: number, nextSectionObject: GenericStackObject) => StackSectionModel[];
 }) => {
-  const { t } = useTranslation('dxos:stack');
+  const { t } = useTranslation(STACK_PLUGIN);
   const dnd = useDnd();
   const [sectionModels, setSectionModels] = useState(getSectionModels(sections));
   const sectionIds = useMemo(() => new Set(Array.from(sectionModels).map(({ object: { id } }) => id)), [sectionModels]);
@@ -261,7 +268,7 @@ const StackSectionsImpl = ({
 };
 
 const StackMainImpl = ({ stack }: { stack: StackModel & StackProperties }) => {
-  const { t } = useTranslation('dxos:stack');
+  const { t } = useTranslation(STACK_PLUGIN);
   const { sendIntent } = useIntent();
   const splitView = useSplitView();
   const handleAdd = useCallback(
@@ -341,7 +348,7 @@ const StackMainImpl = ({ stack }: { stack: StackModel & StackProperties }) => {
                         splitView.dialogContent = {
                           id,
                           chooser: 'many',
-                          subject: 'dxos:stack/chooser',
+                          subject: 'dxos.org/plugin/stack/chooser',
                           omit: new Set(
                             stack.sections.filter((section) => !!section?.object?.id).map(({ object: { id } }) => id),
                           ),

--- a/packages/apps/plugins/plugin-stack/src/stories/StackPlugin.stories.tsx
+++ b/packages/apps/plugins/plugin-stack/src/stories/StackPlugin.stories.tsx
@@ -24,7 +24,7 @@ const DefaultStackPluginStory = () => {
 
 const StackPluginStoryPlugin = () => ({
   meta: {
-    id: 'dxos:stackStoryPlugin',
+    id: 'example.com/plugin/stackStoryPlugin',
   },
   provides: {
     components: {

--- a/packages/apps/plugins/plugin-stack/src/types.ts
+++ b/packages/apps/plugins/plugin-stack/src/types.ts
@@ -10,10 +10,11 @@ import type { GraphProvides } from '@braneframe/plugin-graph';
 import { Intent, IntentProvides } from '@braneframe/plugin-intent';
 import type { TranslationsProvides } from '@braneframe/plugin-theme';
 
-export const STACK_PLUGIN = 'dxos:stack';
+export const STACK_PLUGIN = 'dxos.org/plugin/stack';
 
+const STACK_ACTION = `${STACK_PLUGIN}/action`;
 export enum StackAction {
-  CREATE = `${STACK_PLUGIN}/create`,
+  CREATE = `${STACK_ACTION}/create`,
 }
 
 // TODO(wittjosiah): Creators/choosers likely aren't stack-specific.

--- a/packages/apps/plugins/plugin-theme/src/ThemePlugin.tsx
+++ b/packages/apps/plugins/plugin-theme/src/ThemePlugin.tsx
@@ -25,7 +25,7 @@ export const ThemePlugin = (): PluginDefinition => {
 
   return {
     meta: {
-      id: 'dxos:theme',
+      id: 'dxos.org/plugin/theme',
     },
     ready: async (plugins) => {
       modeQuery = window.matchMedia('(prefers-color-scheme: dark)');

--- a/packages/apps/plugins/plugin-thread/src/props.tsx
+++ b/packages/apps/plugins/plugin-thread/src/props.tsx
@@ -15,8 +15,9 @@ import { isTypedObject } from '@dxos/react-client/echo';
 
 export const THREAD_PLUGIN = 'dxos.org/plugin/thread';
 
+const THREAD_ACTION = `${THREAD_PLUGIN}/action`;
 export enum ThreadAction {
-  CREATE = `${THREAD_PLUGIN}/create`,
+  CREATE = `${THREAD_ACTION}/create`,
 }
 
 export type ThreadPluginProvides = GraphProvides & IntentProvides & TranslationsProvides;

--- a/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
@@ -36,10 +36,10 @@ export const TreeViewPlugin = (): PluginDefinition<TreeViewPluginProvides> => {
           if (treeView.active.length === 0) {
             return (
               <Surface
-                component='dxos:splitview/SplitView'
+                component='dxos.org/plugin/splitview/SplitView'
                 surfaces={{
-                  sidebar: { component: 'dxos:treeview/TreeView' },
-                  main: { component: 'dxos:splitview/SplitViewMainContentEmpty' },
+                  sidebar: { component: 'dxos.org/plugin/treeview/TreeView' },
+                  main: { component: 'dxos.org/plugin/splitview/SplitViewMainContentEmpty' },
                 }}
               />
             );
@@ -48,9 +48,9 @@ export const TreeViewPlugin = (): PluginDefinition<TreeViewPluginProvides> => {
           } else {
             return (
               <Surface
-                component='dxos:splitview/SplitView'
+                component='dxos.org/plugin/splitview/SplitView'
                 surfaces={{
-                  sidebar: { component: 'dxos:treeview/TreeView' },
+                  sidebar: { component: 'dxos.org/plugin/treeview/TreeView' },
                   main: { component: `${plugin}/Main`, data: { active } },
                 }}
               />

--- a/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
@@ -168,7 +168,7 @@ export const TreeViewContainer = () => {
                           {...(!sidebarOpen && { tabIndex: -1 })}
                           onClick={() => {
                             splitViewContext.dialogOpen = true;
-                            splitViewContext.dialogContent = 'dxos:splitview/ProfileSettings';
+                            splitViewContext.dialogContent = 'dxos.org/plugin/splitview/ProfileSettings';
                           }}
                         >
                           <span className='sr-only'>{t('settings dialog title', { ns: 'os' })}</span>

--- a/packages/apps/plugins/plugin-treeview/src/types.ts
+++ b/packages/apps/plugins/plugin-treeview/src/types.ts
@@ -6,10 +6,11 @@ import { DeepSignal } from 'deepsignal';
 
 import { IntentProvides } from '@braneframe/plugin-intent';
 
-export const TREE_VIEW_PLUGIN = 'dxos:treeview';
+export const TREE_VIEW_PLUGIN = 'dxos.org/plugin/treeview';
 
+const TREE_VIEW_ACTION = `${TREE_VIEW_PLUGIN}/action`;
 export enum TreeViewAction {
-  ACTIVATE = `${TREE_VIEW_PLUGIN}:activate`,
+  ACTIVATE = `${TREE_VIEW_ACTION}/activate`,
 }
 
 // TODO(wittjosiah): Derive graph nodes from selected.

--- a/packages/apps/plugins/plugin-treeview/src/util.ts
+++ b/packages/apps/plugins/plugin-treeview/src/util.ts
@@ -4,12 +4,12 @@
 
 import { GraphNode } from '@braneframe/plugin-graph';
 
-export const uriToSelected = (uri: string) => {
-  const [_, namespace, type, id, ...rest] = uri.split('/');
-  return namespace && type && id ? [`${namespace}:${type}/${id}`, ...rest] : [];
+export const uriToActive = (uri: string) => {
+  const [_, pluginShortId, nodeId, ...rest] = uri.split('/');
+  return pluginShortId && nodeId ? [`${pluginShortId}/${nodeId}`, ...rest] : [];
 };
 
-export const selectedToUri = (selected: string[]) => '/' + selected.join('/').replace(':', '/');
+export const activeToUri = (active: string[]) => '/' + active.join('/').split('/').map(encodeURIComponent).join('/');
 
 export const resolveNodes = (graph: GraphNode[], [id, ...path]: string[], nodes: GraphNode[] = []): GraphNode[] => {
   const node = graph.find((node) => node.id === id);

--- a/packages/apps/plugins/plugin-url-sync/src/UrlSyncPlugin.tsx
+++ b/packages/apps/plugins/plugin-url-sync/src/UrlSyncPlugin.tsx
@@ -4,12 +4,12 @@
 
 import { useEffect } from 'react';
 
-import { selectedToUri, uriToSelected, useTreeView } from '@braneframe/plugin-treeview';
+import { activeToUri, uriToActive, useTreeView } from '@braneframe/plugin-treeview';
 import { PluginDefinition } from '@dxos/react-surface';
 
 export const UrlSyncPlugin = (): PluginDefinition => ({
   meta: {
-    id: 'dxos:url-sync',
+    id: 'dxos.org/plugin/url-sync',
   },
   provides: {
     components: {
@@ -20,10 +20,8 @@ export const UrlSyncPlugin = (): PluginDefinition => ({
         useEffect(() => {
           const handleNavigation = () => {
             treeView.active =
-              // TODO(wittjosiah): Remove. This is here for backwards compatibility.
-              window.location.pathname === '/embedded'
-                ? ['dxos:github/embedded']
-                : uriToSelected(window.location.pathname);
+              // TODO(wittjosiah): Remove condition. This is here for backwards compatibility.
+              window.location.pathname === '/embedded' ? ['github/embedded'] : uriToActive(window.location.pathname);
           };
 
           if (treeView.active.length === 0 && window.location.pathname.length > 1) {
@@ -38,7 +36,7 @@ export const UrlSyncPlugin = (): PluginDefinition => ({
 
         // Update URL when selection changes.
         useEffect(() => {
-          const selectedPath = selectedToUri(treeView.active);
+          const selectedPath = activeToUri(treeView.active);
           if (window.location.pathname !== selectedPath) {
             // TODO(wittjosiah): Better support for search params?
             history.pushState(null, '', `${selectedPath}${window.location.search}`);

--- a/packages/sdk/react-surface/src/Plugin.ts
+++ b/packages/sdk/react-surface/src/Plugin.ts
@@ -17,6 +17,8 @@ export type PluginProvides<TProvides> = TProvides & {
 export type Plugin<TProvides = {}> = {
   meta: {
     id: string;
+    // TODO(wittjosiah): How should these be managed?
+    shortId?: string;
   };
   provides: PluginProvides<TProvides>;
 };

--- a/packages/sdk/react-surface/src/Surface.tsx
+++ b/packages/sdk/react-surface/src/Surface.tsx
@@ -75,8 +75,11 @@ const resolveComponents = (plugins: Plugin[], props: SurfaceProps, context: Surf
 };
 
 const findComponent = (plugins: Plugin[], name: string): FC<PropsWithChildren<any>> | undefined => {
-  const [pluginId, componentId] = name.split('/');
-  return plugins.find((plugin) => plugin.meta.id === pluginId)?.provides.components?.[componentId];
+  const nameParts = name.split('/');
+  const componentId = nameParts.at(-1) ?? '';
+  const pluginId = nameParts.slice(0, -1).join('/');
+  return plugins.find((plugin) => plugin.meta.id === pluginId || plugin.meta.shortId === pluginId)?.provides
+    .components?.[componentId];
 };
 
 export const Surface = (props: SurfaceProps) => {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0a0599a</samp>

### Summary
🆔🗂️🌐

<!--
1.  🆔 - This emoji represents the change of the plugin ids to use a more consistent and descriptive format based on the domain name `dxos.org`.
2. 🗂️ - This emoji represents the change of the plugin names and translation namespaces to use a more consistent and descriptive format based on the plugin functionality and features.
3. 🌐 - This emoji represents the change of the story plugin ids to use a more realistic domain name `example.com` to illustrate the possibility of using different domains for different plugins.
-->
This pull request renames and standardizes the ids, labels, and translation namespaces of several plugins and their components. It also updates the references and imports of these plugins in the app code. The main purpose of these changes is to improve the readability, clarity, and compatibility of the plugin code and configuration. The affected plugins are `FilesPlugin`, `GitHubPlugin`, `ClientPlugin`, `DndPlugin`, `DrawingPlugin`, and `ErrorPlugin`.

> _We're changing the plugin ids, me hearties, yo ho ho_
> _To make them more consistent and descriptive, don't you know_
> _So grab your `dxos.org` and your `example.com` too_
> _And heave away on the count of three, there's work for us to do_

### Walkthrough
*  Rename `LocalFilesPlugin` to `FilesPlugin` and update its id, shortId, label namespace, intent plugin, local storage key, and dialog data keys to use a more consistent and descriptive format. ([link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-9f2aee287f92edd662c13bed460a28a1590c9186b62c98ccc2e00f6877c3d7e6L13-R13),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-9f2aee287f92edd662c13bed460a28a1590c9186b62c98ccc2e00f6877c3d7e6L56-R56),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-9d663519e7a46a19fe4305c8085aa017f51355119fb0fbe545eb37ab8492722cL15-R15),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-9d663519e7a46a19fe4305c8085aa017f51355119fb0fbe545eb37ab8492722cL67-R67),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-61ac1b9b8f3415a2884014ea5912948c86639725f90492d7ec4c9686b5bafaaeL19-R27),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-61ac1b9b8f3415a2884014ea5912948c86639725f90492d7ec4c9686b5bafaaeL31-R38),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-61ac1b9b8f3415a2884014ea5912948c86639725f90492d7ec4c9686b5bafaaeL51-R59),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-61ac1b9b8f3415a2884014ea5912948c86639725f90492d7ec4c9686b5bafaaeL69-R77),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-61ac1b9b8f3415a2884014ea5912948c86639725f90492d7ec4c9686b5bafaaeL86-R103),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-61ac1b9b8f3415a2884014ea5912948c86639725f90492d7ec4c9686b5bafaaeL150-R162),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-61ac1b9b8f3415a2884014ea5912948c86639725f90492d7ec4c9686b5bafaaeL166-R178),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-b7319489ebe73aaea94381a92337cb252180f18b0bc8564b6b525e105ec83ef7L11-R16),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-1ab7858ac71bdabf57cbc53cfced865681538f0952cd92ba11ca59edcc7960e5L5-R5),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-2072d6e42bac1cb6196109765fd05427772fac73f140d49f3351b43a25108391L5-R10),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-53b56822e137a32808637cfc5c04d4e69cbb1fce79452ccb374e530509d4a91cL9-R19),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL11-R11),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL20-R20),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL37-R37),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL56-R56),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL134-R137),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL149-R153),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL161-R164),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL193-R196),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL206-R209),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL221-R225),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL233-R233))
* Change the id, shortId, label namespace, and intent plugin of the `DndPlugin` to use a more consistent and descriptive format. ([link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-2980bfaacf44efa379f06240cc85cd206bc5b09d919e1ecfb8b170c6c4d08cfdL30-R30),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-cbca02af1f492dc4c896354f1769840c877c6907c77ee1863943757db35821cdL180-R180))
* Change the id of the `ClientPlugin` to use a more consistent and descriptive format. ([link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-2980bfaacf44efa379f06240cc85cd206bc5b09d919e1ecfb8b170c6c4d08cfdL30-R30),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-729deb573b5cc8132392ae8f4565e26d5d88f5b5a3f07068efa78bfd4701a03fL53-R57))
* Change the id of the `ErrorPlugin` to use a more consistent and descriptive format. ([link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-b5df89addacc638e7ce1595677118ba23ac0401618a22bbf46f09e961d05de97L16-R16))
* Change the id of the `TreeViewPlugin` to use a more consistent and descriptive format. ([link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-61ac1b9b8f3415a2884014ea5912948c86639725f90492d7ec4c9686b5bafaaeL86-R103))
* Change the id of the `GithubPlugin` and its dialog data keys to use a more consistent and descriptive format. ([link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-454e23ec82f76a0b34a7c74a7d68d92bea5779ec1b3bfabc3836512c0472aef8L26-R27),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-454e23ec82f76a0b34a7c74a7d68d92bea5779ec1b3bfabc3836512c0472aef8L35-R42),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-729deb573b5cc8132392ae8f4565e26d5d88f5b5a3f07068efa78bfd4701a03fL266-R266))
* Change the id of the `DrawingPlugin` and add a constant for the `DrawingAction` enum values. ([link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-ac13eba3c50775cc5b3af34a1dc671f9bff21697339d09c4fb9674d719c13b01L19-R21))
* Change the id of the story plugins for the `DndPlugin` to use a more realistic domain. ([link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-3b3fbaceee2b207ec935441d399a88aeb228ba4b87f7ac356eceb731da181592L98-R98),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-f524ea6451449cc5c3d9bae439008208e44a7972fcde0f7369e99bc2d806ba32L64-R64),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-09fa3c7d503733c226b3afa0a85ad2bc13fb6eb33dbabffca6f61890e2024fcbL83-R83))
* Use the `GITHUB_PLUGIN` constant for the translation namespace of the `GithubPlugin` components. ([link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-729deb573b5cc8132392ae8f4565e26d5d88f5b5a3f07068efa78bfd4701a03fL38-R38),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-729deb573b5cc8132392ae8f4565e26d5d88f5b5a3f07068efa78bfd4701a03fL53-R57),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-15b3e343a1f843bb8efd59c12bdca696ea78804888c987dc4c04be0719642089R12),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-15b3e343a1f843bb8efd59c12bdca696ea78804888c987dc4c04be0719642089L79-R80),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-1e98123476eb9f70fb01f63934aae337a9cfe54251be93c2726f7241ac6486feL12-R12),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-1e98123476eb9f70fb01f63934aae337a9cfe54251be93c2726f7241ac6486feL23-R23),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-ca01b63bc43b4fdeee8353208a523acc404af818d0ad577ecd4871e639eb27e3R11),[link](https://github.com/dxos/dxos/pull/3734/files?diff=unified&w=0#diff-ca01b63bc43b4fdeee8353208a523acc404af818d0ad577ecd4871e639eb27e3L30-R31))


