### PR TITLE
feat(vault): Make worker close itself on reset

### DIFF
--- a/packages/common/random-access-storage/src/common/abstract-storage.ts
+++ b/packages/common/random-access-storage/src/common/abstract-storage.ts
@@ -56,7 +56,7 @@ export abstract class AbstractStorage implements Storage {
    */
   async reset() {
     try {
-      log('Erasing all data...');
+      log.info('Erasing all data...');
       await this._closeFilesInPath('');
       await this._delete('');
       await this._destroy();

--- a/packages/common/random-access-storage/src/common/abstract-storage.ts
+++ b/packages/common/random-access-storage/src/common/abstract-storage.ts
@@ -56,7 +56,7 @@ export abstract class AbstractStorage implements Storage {
    */
   async reset() {
     try {
-      log.warn('Erasing all data...');
+      log('Erasing all data...');
       await this._closeFilesInPath('');
       await this._delete('');
       await this._destroy();

--- a/packages/devtools/devtools/src/panels/client/StoragePanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/StoragePanel.tsx
@@ -204,7 +204,8 @@ const StoragePanel = () => {
           <div className='flex-1' />
           <Button
             onClick={async () => {
-              // await services?.SystemService.reset();
+              await services?.SystemService.reset();
+              location.reload();
             }}
           >
             Reset Storage

--- a/packages/sdk/client-services/src/packlets/services/service-host.test.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-host.test.ts
@@ -2,17 +2,21 @@
 // Copyright 2023 DXOS.org
 //
 
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
-import { latch, Trigger } from '@dxos/async';
+import { asyncTimeout, latch, Trigger } from '@dxos/async';
 import { Config } from '@dxos/config';
 import { verifyPresentation } from '@dxos/credentials';
 import { PublicKey } from '@dxos/keys';
 import { MemorySignalManagerContext } from '@dxos/messaging';
+import { Identity } from '@dxos/protocols/proto/dxos/client/services';
 import { Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
 import { afterTest, describe, test } from '@dxos/test';
 
 import { createMockCredential, createServiceHost } from '../testing';
+
+chai.use(chaiAsPromised);
 
 describe('ClientServicesHost', () => {
   test('queryCredentials', async () => {
@@ -97,4 +101,39 @@ describe('ClientServicesHost', () => {
       kind: 'pass',
     });
   });
+
+  test('storage reset', async () => {
+    const config = new Config({
+      runtime: { client: { storage: { persistent: true, path: '/tmp/dxos/client-services/storage' } } },
+    });
+    {
+      const host = createServiceHost(config, new MemorySignalManagerContext());
+      await host.open();
+
+      await host.services.IdentityService?.createIdentity({});
+
+      expect(host._serviceContext.storage.size).to.exist;
+
+      await asyncTimeout(host.reset(), 1000);
+      await host.close();
+    }
+
+    {
+      const host = createServiceHost(config, new MemorySignalManagerContext());
+      await host.open();
+      const trigger = new Trigger<Identity>();
+
+      const stream = host.services.IdentityService?.queryIdentity();
+      await stream?.waitUntilReady();
+
+      stream?.subscribe((identity) => {
+        if (identity.identity) {
+          trigger.wake(identity.identity);
+        }
+      });
+      await expect(asyncTimeout(trigger.wait(), 200)).to.be.rejectedWith();
+      stream?.close();
+      await host.close();
+    }
+  }).onlyEnvironments('nodejs', 'chromium', 'firefox');
 });

--- a/packages/sdk/client-services/src/packlets/services/service-host.test.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-host.test.ts
@@ -4,6 +4,7 @@
 
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import { rmSync } from 'node:fs';
 
 import { asyncTimeout, latch, Trigger } from '@dxos/async';
 import { Config } from '@dxos/config';
@@ -13,12 +14,20 @@ import { MemorySignalManagerContext } from '@dxos/messaging';
 import { Identity } from '@dxos/protocols/proto/dxos/client/services';
 import { Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
 import { afterTest, describe, test } from '@dxos/test';
+import { isNode } from '@dxos/util';
 
 import { createMockCredential, createServiceHost } from '../testing';
 
 chai.use(chaiAsPromised);
 
 describe('ClientServicesHost', () => {
+  const persistentStoragePath = '/tmp/dxos/client-services/service-host/storage';
+
+  afterEach(async () => {
+    // Clean up.
+    isNode() && rmSync(persistentStoragePath, { recursive: true, force: true });
+  });
+
   test('queryCredentials', async () => {
     const host = createServiceHost(new Config(), new MemorySignalManagerContext());
     await host.open();
@@ -104,7 +113,7 @@ describe('ClientServicesHost', () => {
 
   test('storage reset', async () => {
     const config = new Config({
-      runtime: { client: { storage: { persistent: true, path: '/tmp/dxos/client-services/storage' } } },
+      runtime: { client: { storage: { persistent: true, path: persistentStoragePath } } },
     });
     {
       const host = createServiceHost(config, new MemorySignalManagerContext());

--- a/packages/sdk/client-services/src/packlets/services/service-host.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-host.ts
@@ -48,6 +48,11 @@ export type ClientServicesHostParams = {
   connectionLog?: boolean;
   storage?: Storage;
   lockKey?: string;
+  callbacks?: ClientServicesHostCallbacks;
+};
+
+export type ClientServicesHostCallbacks = {
+  onReset?: () => Promise<void>;
 };
 
 export type InitializeOptions = {
@@ -72,6 +77,7 @@ export class ClientServicesHost {
   private _signalManager?: SignalManager;
   private _networkManager?: NetworkManager;
   private _storage?: Storage;
+  private _callbacks?: ClientServicesHostCallbacks;
 
   _serviceContext!: ServiceContext;
   private _opening = false;
@@ -87,9 +93,11 @@ export class ClientServicesHost {
     storage,
     // TODO(wittjosiah): Turn this on by default.
     lockKey,
+    callbacks,
   }: ClientServicesHostParams = {}) {
     this._storage = storage;
     this._modelFactory = modelFactory;
+    this._callbacks = callbacks;
 
     if (config) {
       this.initialize({ config, transportFactory, signalManager });
@@ -284,5 +292,6 @@ export class ClientServicesHost {
     await this._storage!.reset();
     log('reset');
     log.trace('dxos.sdk.client-services-host.reset', trace.end({ id: traceId }));
+    await this._callbacks?.onReset?.();
   }
 }

--- a/packages/sdk/client-services/src/packlets/vault/worker-runtime.ts
+++ b/packages/sdk/client-services/src/packlets/vault/worker-runtime.ts
@@ -37,7 +37,7 @@ export class WorkerRuntime {
   constructor(
     private readonly _configProvider: () => MaybePromise<Config>
   ) {
-    this._clientServices = new ClientServicesHost();
+    this._clientServices = new ClientServicesHost({ callbacks: { onReset: async () => { self.close(); } } });
   }
 
   get host() {

--- a/packages/sdk/client/src/tests/client.test.ts
+++ b/packages/sdk/client/src/tests/client.test.ts
@@ -4,11 +4,11 @@
 
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import { rmSync } from 'node:fs';
 
 import { Config } from '@dxos/config';
-import { Runtime } from '@dxos/protocols/proto/dxos/config';
-import { createStorage, StorageType } from '@dxos/random-access-storage';
 import { describe, test, afterTest } from '@dxos/test';
+import { isNode } from '@dxos/util';
 
 import { Client } from '../client';
 import { TestBuilder } from '../testing';
@@ -16,6 +16,13 @@ import { TestBuilder } from '../testing';
 chai.use(chaiAsPromised);
 
 describe('Client', () => {
+  const persistentStoragePath = '/tmp/dxos/client/storage';
+
+  afterEach(async () => {
+    // Clean up.
+    isNode() && rmSync(persistentStoragePath, { recursive: true, force: true });
+  });
+
   test('creates client with embedded services', async () => {
     const testBuilder = new TestBuilder();
 
@@ -64,77 +71,49 @@ describe('Client', () => {
     await expect(client.createSpace()).to.eventually.be.rejectedWith('This device has no HALO identity available.');
   }).timeout(1_000);
 
-  // TODO(burdon): Memory store is reset on close (feed store is closed).
-  test.skip('creates identity then resets the memory storage', async () => {
-    const config = new Config();
-    const testBuilder = new TestBuilder(config);
-    await runTest(testBuilder);
-  });
-
-  test('creates identity then resets the node storage', async () => {
-    const config = await getNodeConfig(true);
-    const testBuilder = new TestBuilder(config);
-    await runTest(testBuilder);
-  }).onlyEnvironments('nodejs');
-});
-
-// TODO(burdon): Factor out.
-const getNodeConfig = async (reset = false) => {
-  const path = '/tmp/dxos/client/test/packlets/test';
-  if (reset) {
-    // TODO(burdon): Reconcile StorageType and ConfigProto types.
-    const storage = createStorage({ type: StorageType.NODE, root: path });
-    await storage.reset();
-  }
-
-  // TODO(burdon): Update API.
-  // TODO(burdon): Config not required if remote.
-  return new Config({
-    version: 1,
-    runtime: {
-      client: {
-        storage: {
-          persistent: true,
-          storageType: Runtime.Client.Storage.StorageDriver.NODE,
-          path, // TODO(burdon): Change to root.
+  test
+    .only('creates identity then resets', async () => {
+      const config = new Config({
+        version: 1,
+        runtime: {
+          client: {
+            storage: { persistent: true, path: persistentStoragePath },
+          },
         },
-      },
-    },
-  });
-};
+      });
+      const testBuilder = new TestBuilder(config);
+      const client = new Client({ services: testBuilder.createLocal() });
+      const displayName = 'test-user';
+      {
+        // Create identity.
+        await client.initialize();
+        expect(client.halo.identity.get()).not.to.exist;
+        const identity = await client.halo.createIdentity({ displayName });
+        expect(client.halo.identity.get()).to.deep.eq(identity);
+        await client.destroy();
+      }
 
-// TODO(burdon): Develop test-suite.
-const runTest = async (testBuilder: TestBuilder) => {
-  const client = new Client({ services: testBuilder.createLocal() });
-  const displayName = 'test-user';
-  {
-    // Create identity.
-    await client.initialize();
-    expect(client.halo.identity.get()).not.to.exist;
-    const identity = await client.halo.createIdentity({ displayName });
-    expect(client.halo.identity.get()).to.deep.eq(identity);
-    await client.destroy();
-  }
+      {
+        // Should throw trying to create another.
+        await client.initialize();
+        expect(client.halo.identity).to.exist;
+        // TODO(burdon): Error type.
+        await expect(client.halo.createIdentity({ displayName })).to.be.rejected;
+      }
 
-  {
-    // Should throw trying to create another.
-    await client.initialize();
-    expect(client.halo.identity).to.exist;
-    // TODO(burdon): Error type.
-    await expect(client.halo.createIdentity({ displayName })).to.be.rejected;
-  }
+      {
+        // Reset storage.
+        await client.reset();
+      }
 
-  {
-    // Reset storage.
-    // TODO(burdon): Reset doesn't work in memory (create store test).
-    await client.reset();
-  }
-
-  {
-    // Start again.
-    await client.initialize();
-    await client.halo.createIdentity({ displayName });
-    expect(client.halo.identity).to.exist;
-    await client.destroy();
-  }
-};
+      {
+        // Start again.
+        await client.initialize();
+        expect(client.halo.identity.get()).to.eq(null);
+        await client.halo.createIdentity({ displayName });
+        expect(client.halo.identity).to.exist;
+        await client.destroy();
+      }
+    })
+    .onlyEnvironments('nodejs', 'chromium', 'firefox');
+});

--- a/packages/sdk/client/src/tests/client.test.ts
+++ b/packages/sdk/client/src/tests/client.test.ts
@@ -71,49 +71,47 @@ describe('Client', () => {
     await expect(client.createSpace()).to.eventually.be.rejectedWith('This device has no HALO identity available.');
   }).timeout(1_000);
 
-  test
-    .only('creates identity then resets', async () => {
-      const config = new Config({
-        version: 1,
-        runtime: {
-          client: {
-            storage: { persistent: true, path: persistentStoragePath },
-          },
+  test('creates identity then resets', async () => {
+    const config = new Config({
+      version: 1,
+      runtime: {
+        client: {
+          storage: { persistent: true, path: persistentStoragePath },
         },
-      });
-      const testBuilder = new TestBuilder(config);
-      const client = new Client({ services: testBuilder.createLocal() });
-      const displayName = 'test-user';
-      {
-        // Create identity.
-        await client.initialize();
-        expect(client.halo.identity.get()).not.to.exist;
-        const identity = await client.halo.createIdentity({ displayName });
-        expect(client.halo.identity.get()).to.deep.eq(identity);
-        await client.destroy();
-      }
+      },
+    });
+    const testBuilder = new TestBuilder(config);
+    const client = new Client({ services: testBuilder.createLocal() });
+    const displayName = 'test-user';
+    {
+      // Create identity.
+      await client.initialize();
+      expect(client.halo.identity.get()).not.to.exist;
+      const identity = await client.halo.createIdentity({ displayName });
+      expect(client.halo.identity.get()).to.deep.eq(identity);
+      await client.destroy();
+    }
 
-      {
-        // Should throw trying to create another.
-        await client.initialize();
-        expect(client.halo.identity).to.exist;
-        // TODO(burdon): Error type.
-        await expect(client.halo.createIdentity({ displayName })).to.be.rejected;
-      }
+    {
+      // Should throw trying to create another.
+      await client.initialize();
+      expect(client.halo.identity).to.exist;
+      // TODO(burdon): Error type.
+      await expect(client.halo.createIdentity({ displayName })).to.be.rejected;
+    }
 
-      {
-        // Reset storage.
-        await client.reset();
-      }
+    {
+      // Reset storage.
+      await client.reset();
+    }
 
-      {
-        // Start again.
-        await client.initialize();
-        expect(client.halo.identity.get()).to.eq(null);
-        await client.halo.createIdentity({ displayName });
-        expect(client.halo.identity).to.exist;
-        await client.destroy();
-      }
-    })
-    .onlyEnvironments('nodejs', 'chromium', 'firefox');
+    {
+      // Start again.
+      await client.initialize();
+      expect(client.halo.identity.get()).to.eq(null);
+      await client.halo.createIdentity({ displayName });
+      expect(client.halo.identity).to.exist;
+      await client.destroy();
+    }
+  }).onlyEnvironments('nodejs', 'chromium', 'firefox');
 });


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at befb16f</samp>

### Summary
🔄🗑️🧪

<!--
1.  🔄 This emoji represents the reload action that was added to the button onClick handler, as well as the closing and reopening of the worker after resetting the storage. It conveys the idea of refreshing or restarting something.
2. 🗑️ This emoji represents the deletion or erasing of all data from the storage, which is the main purpose of the reset functionality. It conveys the idea of discarding or removing something.
3. 🧪 This emoji represents the testing or verification of the storage reset functionality, which was added or improved in both the ClientServicesHost and the Client classes. It conveys the idea of experimenting or testing something.
-->
Added and tested storage reset functionality for client services and devtools. This allows users to erase all data from the persistent storage and restart the services and the UI. Added custom callbacks to `ClientServicesHost` to handle additional actions after resetting the storage, such as closing the worker or reloading the page.

> _Sing, O Muse, of the valiant code review_
> _That changed the log and button of the `Client`_
> _And made the `WorkerRuntime` close anew_
> _When `ClientServicesHost` reset its content._

### Walkthrough
*  Change log level of erasing message from warn to info ([link](https://github.com/dxos/dxos/pull/3735/files?diff=unified&w=0#diff-918202b67f4127d175e0f9cf985a159a62ed2c6e0253a882726828b0491da9d0L59-R59))
*  Enable storage reset functionality in devtools and reload page after reset ([link](https://github.com/dxos/dxos/pull/3735/files?diff=unified&w=0#diff-7fea40e022e2b42465d533caf5c77ce86cd4dbc20582172ba8e39715d9cd3b4fL207-R208))
*  Add optional callbacks to `ClientServicesHost` constructor and store them in `_callbacks` property ([link](https://github.com/dxos/dxos/pull/3735/files?diff=unified&w=0#diff-428c756de00c4abe2ea87923e6692247b6d3c07051fab795a5385d36954ff93eL51-R57), [link](https://github.com/dxos/dxos/pull/3735/files?diff=unified&w=0#diff-428c756de00c4abe2ea87923e6692247b6d3c07051fab795a5385d36954ff93eR80), [link](https://github.com/dxos/dxos/pull/3735/files?diff=unified&w=0#diff-428c756de00c4abe2ea87923e6692247b6d3c07051fab795a5385d36954ff93eL90-R100))
*  Await `onReset` callback in `ClientServicesHost.reset` method after resetting storage and closing services ([link](https://github.com/dxos/dxos/pull/3735/files?diff=unified&w=0#diff-428c756de00c4abe2ea87923e6692247b6d3c07051fab795a5385d36954ff93eR295))
*  Pass callback to `ClientServicesHost` constructor in `WorkerRuntime` that closes worker after storage reset ([link](https://github.com/dxos/dxos/pull/3735/files?diff=unified&w=0#diff-17bb03dfcd8aabb87bd39e2b3a46bf711c5beb84ccd7e4e91cda09d5bf40cfc0L40-R40))
*  Add and modify imports in `service-host.test.ts` and `client.test.ts` to enable testing storage reset functionality in different environments ([link](https://github.com/dxos/dxos/pull/3735/files?diff=unified&w=0#diff-cf9a8a7088067324a6868a0608b6a753089dcc1048a663ea5d03a920ee5283daL5-R30), [link](https://github.com/dxos/dxos/pull/3735/files?diff=unified&w=0#diff-a192f3838f294f31944de834e6552759b7ddef4e82d7f3953c112a7a1db8bbc0L7-R11))
*  Add test case in `service-host.test.ts` that creates host with persistent storage, creates identity, resets storage, and verifies identity is gone ([link](https://github.com/dxos/dxos/pull/3735/files?diff=unified&w=0#diff-cf9a8a7088067324a6868a0608b6a753089dcc1048a663ea5d03a920ee5283daR113-R147))
*  Simplify and consolidate test cases in `client.test.ts` that use `Config` object to specify persistent storage path, create identity, reset storage, and verify identity is gone ([link](https://github.com/dxos/dxos/pull/3735/files?diff=unified&w=0#diff-a192f3838f294f31944de834e6552759b7ddef4e82d7f3953c112a7a1db8bbc0L67-R119))


