### PR TITLE
docs: reactivity

### DIFF
--- a/docs/docs/guide/react/hooks.md
+++ b/docs/docs/guide/react/hooks.md
@@ -1,6 +1,6 @@
 ---
 title: Other Hooks
-order: 6
+order: 7
 ---
 
 The following are react hooks which ensure the reactivity of the underlying data sources and re-render consuming components when the data changes. Use all of these in a `<ClientProvider />` context.

--- a/docs/docs/guide/react/reactivity.md
+++ b/docs/docs/guide/react/reactivity.md
@@ -1,0 +1,31 @@
+---
+title: Reactivity
+order: 6
+---
+
+# Reactivity
+
+By default `@dxos/react-client` uses a reactivity model built on top of [`@preact/signals`](https://github.com/preactjs/signals).
+Each ECHO object has a signal associated with it and any reads and writes to properties on the ECHO object notify the signal as well.
+The [Signals React integration](https://github.com/preactjs/signals/blob/main/packages/react/README.md#react-integration) automatically instruments React to track all those reads and writes so the components are automatically reactive.
+
+::: note Learn More
+To learn more about the `signal` primitive, check out the [introductory blog post](https://preactjs.com/blog/introducing-signals).
+:::
+
+## ECHO
+
+ECHO itself does not depend directly on `@preact/signals` but exposes an interface which allows any third-party signals library to integrate with it:
+
+:::apidoc[@dxos/echo-schema.SignalsFactory]
+:::
+
+:::apidoc[@dxos/echo-schema.registerSignalsFactory]
+:::
+
+DXOS provides a `SignalsFactory` implementation for `@preact/signals` in the package `@dxos/echo-signals`.
+That signals factory is automatically registered by `ClientProvider` to automatically provide reactivity.
+
+::: tip Tip
+The Signals integration can be disabled by passing `registerSignalsFactory={false}` as a prop to `ClientProvider`.
+:::

--- a/packages/core/echo/echo-schema/src/object.ts
+++ b/packages/core/echo/echo-schema/src/object.ts
@@ -15,7 +15,7 @@ import { base, db } from './defs';
 
 export const subscribe = Symbol.for('dxos.echo-object.subscribe');
 
-type SignalFactory = () => { notifyRead(): void; notifyWrite(): void };
+export type SignalFactory = () => { notifyRead(): void; notifyWrite(): void };
 let createSignal: SignalFactory | undefined;
 export const registerSignalFactory = (factory: SignalFactory) => {
   createSignal = factory;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 514c5e8</samp>

### Summary
🚚📄📦

<!--
1.  🚚 for moving the Other Hooks page to a different position in the guide.
2.  📄 for adding a new page on Reactivity to the guide.
3.  📦 for exporting the SignalFactory type from the echo-schema package.
-->
Added a new page on Reactivity to the React guide and updated the order of the Other Hooks page. Exported the `SignalFactory` type from the `echo-schema` package for documentation purposes.

> _Reactivity_
> _`SignalFactory` exports_
> _Autumn of ECHO_

### Walkthrough
* Added a new page on Reactivity to the React guide ([link](https://github.com/dxos/dxos/pull/3737/files?diff=unified&w=0#diff-aa023401a9baa792f36f27739bff017dfb8d420458b192fff5cf05a532c84077R1-R31)) that explains how the DXOS React client uses signals to provide automatic reactivity for ECHO objects.


