### PR TITLE
fix(react-shell): `JoinDialog` should call its callbacks `onOpenChange`

### DIFF
--- a/packages/sdk/react-shell/src/composites/JoinDialog/JoinDialog.tsx
+++ b/packages/sdk/react-shell/src/composites/JoinDialog/JoinDialog.tsx
@@ -16,7 +16,10 @@ export const JoinDialog = (joinPanelProps: JoinDialogProps) => {
   const titleId = useId('joinDialog__title');
 
   return (
-    <AlertDialog.Root defaultOpen>
+    <AlertDialog.Root
+      defaultOpen
+      onOpenChange={(open) => open || (joinPanelProps.onExit ? joinPanelProps.onExit() : joinPanelProps.onDone?.(null))}
+    >
       <AlertDialog.Portal>
         <AlertDialog.Overlay>
           <AlertDialog.Content aria-labelledby={titleId}>


### PR DESCRIPTION
Resolves #3742.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ebb34ce</samp>

### Summary
🎉🚪🔗

<!--
1.  🎉 - This emoji represents the celebration of joining a party, which is the main purpose of the `JoinDialog` component. It also conveys a sense of fun and excitement, which are appropriate emotions for a party-themed app.
2.  🚪 - This emoji represents the exit or done actions that the user can take after joining a party or closing the dialog. It also suggests the idea of moving to a different location or state, which is what the parent component might do depending on the callbacks.
3.  🔗 - This emoji represents the link or connection that the `joinPanelProps` prop creates between the `JoinDialog` and the parent component. It also implies the idea of joining or attaching something, which is relevant for the party theme.
-->
Added `joinPanelProps` prop to `JoinDialog` component to enable custom actions after joining a party. Updated `onOpenChange` handler to call the appropriate callback from `joinPanelProps`.

> _`JoinDialog` changes_
> _Pass callbacks for exit, done_
> _Autumn leaves the page_

### Walkthrough
* Add a `joinPanelProps` prop to `JoinDialog` component to allow parent component to handle dialog closing logic ([link](https://github.com/dxos/dxos/pull/3743/files?diff=unified&w=0#diff-961b424fee95fc33ece4ec4937f2e516112ed11224576c3b00ec96c01e51569bL19-R22)).


