### PR TITLE
fix(plugin-treeview): handle invalid active state

### DIFF
--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -59,10 +59,7 @@ export default defineConfig({
       content: [
         resolve(__dirname, './index.html'),
         resolve(__dirname, './src/**/*.{js,ts,jsx,tsx}'),
-        resolve(__dirname, './node_modules/@braneframe/plugin-markdown/dist/lib/**/*.mjs'),
-        resolve(__dirname, './node_modules/@braneframe/plugin-splitview/dist/lib/**/*.mjs'),
-        resolve(__dirname, './node_modules/@braneframe/plugin-theme/dist/lib/**/*.mjs'),
-        resolve(__dirname, './node_modules/@braneframe/plugin-treeview/dist/lib/**/*.mjs'),
+        resolve(__dirname, './node_modules/@braneframe/plugin-*/dist/lib/**/*.mjs'),
       ],
       extensions: [osThemeExtension],
     }),

--- a/packages/apps/composer-extension/src/content.ts
+++ b/packages/apps/composer-extension/src/content.ts
@@ -32,7 +32,7 @@ const getComposerIFrame = (): HTMLIFrameElement => {
     console.log('Creating composer iframe...');
     composer = document.createElement('iframe');
     composer.setAttribute('id', composerId);
-    composer.setAttribute('src', `${baseUrl.href}embedded?location=${window.location.href}`);
+    composer.setAttribute('src', `${baseUrl.href}github/embedded?location=${window.location.href}`);
     composer.setAttribute('style', composerStyles);
     composer.setAttribute('allow', 'clipboard-write *');
   }

--- a/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
@@ -6,7 +6,7 @@ import { deepSignal } from 'deepsignal/react';
 import React from 'react';
 
 import { GraphNode, useGraph } from '@braneframe/plugin-graph';
-import { PluginDefinition, Surface } from '@dxos/react-surface';
+import { PluginDefinition, Surface, findPlugin, usePluginContext } from '@dxos/react-surface';
 
 import { TreeViewContext, useTreeView } from './TreeViewContext';
 import { TreeViewContainer } from './components';
@@ -29,30 +29,32 @@ export const TreeViewPlugin = (): PluginDefinition<TreeViewPluginProvides> => {
       },
       components: {
         default: () => {
+          const { plugins } = usePluginContext();
           const treeView = useTreeView();
           const { graph } = useGraph();
-          const [plugin] = treeView.active[0]?.split('/') ?? [];
+          const [shortId] = treeView.active[0]?.split('/') ?? [];
+          const plugin = findPlugin(plugins, shortId);
           const active = resolveNodes(Object.values(graph.pluginChildren ?? {}).flat() as GraphNode[], treeView.active);
 
-          if (treeView.active.length === 0) {
+          if (active.length === 0 && plugin) {
+            return <Surface component={`${plugin.meta.id}/Main`} />;
+          } else if (active.length > 0) {
             return (
               <Surface
                 component='dxos.org/plugin/splitview/SplitView'
                 surfaces={{
                   sidebar: { component: 'dxos.org/plugin/treeview/TreeView' },
-                  main: { component: 'dxos.org/plugin/splitview/SplitViewMainContentEmpty' },
+                  main: { component: `${shortId}/Main`, data: { active } },
                 }}
               />
             );
-          } else if (active.length === 0) {
-            return <Surface component={`${plugin}/Main`} />;
           } else {
             return (
               <Surface
                 component='dxos.org/plugin/splitview/SplitView'
                 surfaces={{
                   sidebar: { component: 'dxos.org/plugin/treeview/TreeView' },
-                  main: { component: `${plugin}/Main`, data: { active } },
+                  main: { component: 'dxos.org/plugin/splitview/SplitViewMainContentEmpty' },
                 }}
               />
             );

--- a/packages/apps/plugins/plugin-treeview/src/util.ts
+++ b/packages/apps/plugins/plugin-treeview/src/util.ts
@@ -6,7 +6,7 @@ import { GraphNode } from '@braneframe/plugin-graph';
 
 export const uriToActive = (uri: string) => {
   const [_, pluginShortId, nodeId, ...rest] = uri.split('/');
-  return pluginShortId && nodeId ? [`${pluginShortId}/${nodeId}`, ...rest] : [];
+  return pluginShortId && nodeId ? [`${pluginShortId}/${nodeId}`, ...rest] : pluginShortId ? [pluginShortId] : [];
 };
 
 export const activeToUri = (active: string[]) => '/' + active.join('/').split('/').map(encodeURIComponent).join('/');

--- a/packages/sdk/react-surface/src/Plugin.ts
+++ b/packages/sdk/react-surface/src/Plugin.ts
@@ -31,5 +31,7 @@ export type PluginDefinition<TProvides = {}, TInitProvides = {}> = Omit<Plugin, 
 };
 
 export const findPlugin = <T>(plugins: Plugin[], id: string): Plugin<T> | undefined => {
-  return plugins.find((plugin) => plugin.meta.id === id) as Plugin<T>;
+  return plugins.find(
+    (plugin) => plugin.meta.id === id || (typeof plugin.meta.shortId === 'string' && plugin.meta.shortId === id),
+  ) as Plugin<T>;
 };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ca411a0</samp>

### Summary
🛠️🌲🎨

<!--
1.  🛠️ - This emoji represents a bug fix or improvement, and can be used for the first and second changes, which fix the issue of handling plugin short IDs in the URI and the tree view.
2.  🌲 - This emoji represents a tree or a tree view, and can be used for the third change, which improves the rendering of the tree view plugin.
3.  🎨 - This emoji represents a design or UI change, and can be used for the third change as well, since it affects the appearance and functionality of the tree view plugin.
-->
Improved the tree view plugin to use short IDs for plugins and handle different URI formats. Changed the `findPlugin` function in `Plugin.ts` to support short IDs.

> _Sing, O Muse, of the skillful coder who refined the tree view plugin_
> _And made it easier for users to navigate the nodes of their projects_
> _He changed the `uriToActive` function, so that it would not fail_
> _When given only the short ID of a plugin, a simple and clear detail_

### Walkthrough
*  Enable finding and activating plugins by their short IDs ([link](https://github.com/dxos/dxos/pull/3744/files?diff=unified&w=0#diff-9a66c7d56ee624df73971bbd0761d8e07a33294b4945f9a4167d111aa88c6547L9-R9), [link](https://github.com/dxos/dxos/pull/3744/files?diff=unified&w=0#diff-9a66c7d56ee624df73971bbd0761d8e07a33294b4945f9a4167d111aa88c6547L32-R41), [link](https://github.com/dxos/dxos/pull/3744/files?diff=unified&w=0#diff-864b16318d85c5a4b574472ebd18497b7960fe77cff6d8637345b258b94dbb53L34-R36)).


