### PR TITLE
chore: rename datum to data

### DIFF
--- a/docs/docs/specs/v0.2/composer.md
+++ b/docs/docs/specs/v0.2/composer.md
@@ -60,7 +60,7 @@ The framework should design for these, but doesn't have to build them. We can bu
 
 ## Definitions
 
-- **Surface**: A way of delegating the concrete presentation of a piece of UI to external plugins. A surface is a React component which accepts a data context (datum), a set of plugins, and other props which are used to resolve and instantiate concrete components to 'fulfill' that surface. Some surfaces render one component at a time, others can render more than one with a specific layout rule (i.e. arranging them horizontally or vertically).
+- **Surface**: A way of delegating the concrete presentation of a piece of UI to external plugins. A surface is a React component which accepts a data context, a set of plugins, and other props which are used to resolve and instantiate concrete components to 'fulfill' that surface. Some surfaces render one component at a time, others can render more than one with a specific layout rule (i.e. arranging them horizontally or vertically).
 - **Component**: A regular react component. Components are free to nest as many Surfaces within them as necessary.
 - **Application**: A component which can assume it owns the whole screen.
 - **Plugin**: A unit of containment of modular functionality that can be statically compiled into an application (in later versions, loaded dynamically). Plugins provide things like components and other data to the Application.
@@ -81,7 +81,7 @@ The framework should design for these, but doesn't have to build them. We can bu
 
 - The application is just a component `<App />`.
 - A component can have any number of `<Surface />` as children inside it.
-- A Surface figures out what Component(s) to render given a set of `loaded plugins`, a `data context`, and `other control props`. It can be understood as the the developer intention to render/visualize the given `data context` (datum) using whatever appropriate component(s) as provided by Plugins and configured by the the end user and/or the developer.
+- A Surface figures out what Component(s) to render given a set of `loaded plugins`, a `data context`, and `other control props`. It can be understood as the the developer intention to render/visualize the given `data context` using whatever appropriate component(s) as provided by Plugins and configured by the the end user and/or the developer.
 - The main `<App />` component defines a single, full-screen `<Surface />` for rendering "anything". i.e.: does not opine about what it is, delegates that to plugins and initial configuration entirely.
 - The main `<App />` component also wraps the main `Surface` with an `PluginContext` provider which gives all nested components access to the list of plugins.
 
@@ -116,7 +116,7 @@ export const Plugin = {
 - Several interfaces are to be established by the first few plugins:
   - `context` - `PluginContext` uses this to construct a nesting of all contexts from all plugins for wrapping the entire application with.
   - `components` - `Surface` uses this to select components by name.
-  - `component` - `Surface` uses this when presented with a datum, and no specific desired component by name.
+  - `component` - `Surface` uses this when presented with data, and no specific desired component by name.
   - `routes` - `RoutesPlugin` defines a router via `provides.context` and collects `routes` from other plugins for display.
   - `graph` - `TreePlugin` and any others can use this interface to build up the application's main navigation tree.
 

--- a/packages/apps/plugins/plugin-debug/src/DebugPlugin.tsx
+++ b/packages/apps/plugins/plugin-debug/src/DebugPlugin.tsx
@@ -15,15 +15,15 @@ import translations from './translations';
 export const DebugPlugin = (): PluginDefinition<DebugPluginProvides> => {
   const nodeIds = new Set<string>();
 
-  const isDebug = (datum: unknown) =>
-    datum &&
-    typeof datum === 'object' &&
-    'node' in datum &&
-    datum.node &&
-    typeof datum.node === 'object' &&
-    'id' in datum.node &&
-    typeof datum.node.id === 'string' &&
-    nodeIds.has(datum.node.id);
+  const isDebug = (data: unknown) =>
+    data &&
+    typeof data === 'object' &&
+    'node' in data &&
+    data.node &&
+    typeof data.node === 'object' &&
+    'id' in data.node &&
+    typeof data.node.id === 'string' &&
+    nodeIds.has(data.node.id);
 
   return {
     meta: {
@@ -72,10 +72,10 @@ export const DebugPlugin = (): PluginDefinition<DebugPluginProvides> => {
           ];
         },
       },
-      component: (datum, role) => {
+      component: (data, role) => {
         switch (role) {
           case 'main':
-            if (isDebug(datum)) {
+            if (isDebug(data)) {
               return DebugMain;
             }
         }

--- a/packages/apps/plugins/plugin-dnd/src/DndPlugin.tsx
+++ b/packages/apps/plugins/plugin-dnd/src/DndPlugin.tsx
@@ -167,11 +167,11 @@ export const useDnd = () => useContext(DndPluginContext);
 
 const DndOverlay = () => {
   const dnd = useDnd();
-  const [activeDatum, setActiveDatum] = useState<unknown | null>(null);
-  useDragStart(({ active: { data } }) => setActiveDatum(data.current?.dragoverlay), []);
+  const [activeData, setActiveData] = useState<unknown | null>(null);
+  useDragStart(({ active: { data } }) => setActiveData(data.current?.dragoverlay), []);
   return (
     <DragOverlay adjustScale={false} dropAnimation={dropAnimations[dnd.overlayDropAnimation]}>
-      <Surface role='dragoverlay' data={activeDatum} limit={1} />
+      <Surface role='dragoverlay' data={activeData} limit={1} />
     </DragOverlay>
   );
 };

--- a/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPlugin.tsx
+++ b/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPlugin.tsx
@@ -104,7 +104,7 @@ export const DndPluginDefaultStoryPlugin = (): PluginDefinition<{ dndStory: DndP
       components: {
         default: DndPluginDefaultStoryPluginDefault,
       },
-      component: (datum: unknown, role?: string) => {
+      component: (data: unknown, role?: string) => {
         switch (role) {
           case 'dragoverlay':
             return StoryItemDragOverlay;

--- a/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPluginA.tsx
+++ b/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPluginA.tsx
@@ -64,7 +64,7 @@ export const DndPluginDefaultStoryPluginA = (): PluginDefinition => {
       id: 'example.com/plugin/dndPluginDefaultStoryPluginA',
     },
     provides: {
-      component: (datum, role) => {
+      component: (data, role) => {
         switch (role) {
           case 'dndpluginstory':
             return DefaultDndPluginStoryPluginA;

--- a/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPluginB.tsx
+++ b/packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPluginB.tsx
@@ -83,7 +83,7 @@ export const DndPluginDefaultStoryPluginB = (): PluginDefinition => {
       id: 'example.com/plugin/dndPluginDefaultStoryPluginB',
     },
     provides: {
-      component: (datum, role) => {
+      component: (data, role) => {
         if (role === 'dndpluginstory') {
           return DndPluginDefaultStoryPluginBDefault;
         } else {

--- a/packages/apps/plugins/plugin-drawing/src/DrawingPlugin.tsx
+++ b/packages/apps/plugins/plugin-drawing/src/DrawingPlugin.tsx
@@ -65,14 +65,14 @@ export const DrawingPlugin = (): PluginDefinition<DrawingPluginProvides> => {
           ];
         },
       },
-      component: (datum, role) => {
-        if (!datum || typeof datum !== 'object') {
+      component: (data, role) => {
+        if (!data || typeof data !== 'object') {
           return null;
         }
 
         switch (role) {
           case 'main':
-            if ('object' in datum && isDrawing(datum.object)) {
+            if ('object' in data && isDrawing(data.object)) {
               return DrawingMain;
             } else {
               return null;

--- a/packages/apps/plugins/plugin-drawing/src/props.tsx
+++ b/packages/apps/plugins/plugin-drawing/src/props.tsx
@@ -28,8 +28,8 @@ export interface DrawingModel {
   store: TLStore;
 }
 
-export const isDrawing = (datum: unknown): datum is DrawingType => {
-  return isTypedObject(datum) && DrawingType.type.name === datum.__typename;
+export const isDrawing = (data: unknown): data is DrawingType => {
+  return isTypedObject(data) && DrawingType.type.name === data.__typename;
 };
 
 export const drawingToGraphNode = (parent: GraphNode, object: DrawingType, index: string): GraphNode => ({

--- a/packages/apps/plugins/plugin-files/src/FilesPlugin.tsx
+++ b/packages/apps/plugins/plugin-files/src/FilesPlugin.tsx
@@ -121,10 +121,10 @@ export const FilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, Markdo
     },
     provides: {
       translations,
-      component: (datum, role) => {
+      component: (data, role) => {
         switch (role) {
           case 'main':
-            if (isGraphNode(datum) && isLocalFile(datum.data) && datum.attributes?.disabled) {
+            if (isGraphNode(data) && isLocalFile(data.data) && data.attributes?.disabled) {
               return LocalFileMainPermissions;
             }
             break;

--- a/packages/apps/plugins/plugin-files/src/util.tsx
+++ b/packages/apps/plugins/plugin-files/src/util.tsx
@@ -10,8 +10,8 @@ import { GraphNode, GraphNodeAction } from '@braneframe/plugin-graph';
 
 import { FILES_PLUGIN, FILES_PLUGIN_SHORT_ID, LocalDirectory, LocalEntity, LocalFile, LocalFilesAction } from './types';
 
-export const isLocalFile = (datum: unknown): datum is LocalFile =>
-  datum && typeof datum === 'object' ? 'title' in datum : false;
+export const isLocalFile = (data: unknown): data is LocalFile =>
+  data && typeof data === 'object' ? 'title' in data : false;
 
 export const handleToLocalDirectory = async (handle: any /* FileSystemDirectoryHandle */): Promise<LocalDirectory> => {
   const permission = await handle.queryPermission({ mode: 'readwrite' });

--- a/packages/apps/plugins/plugin-github/src/GithubPlugin.tsx
+++ b/packages/apps/plugins/plugin-github/src/GithubPlugin.tsx
@@ -29,23 +29,23 @@ export const GithubPlugin = (): PluginDefinition<TranslationsProvides> => ({
   provides: {
     translations,
     context: (props) => <OctokitProvider {...props} />,
-    component: (datum, role) => {
+    component: (data, role) => {
       switch (role) {
         case 'dialog':
           switch (true) {
-            case datum === 'dxos.org/plugin/splitview/ProfileSettings':
+            case data === 'dxos.org/plugin/splitview/ProfileSettings':
               return PatInput;
-            case Array.isArray(datum) && datum[0] === 'dxos.org/plugin/github/BindDialog':
+            case Array.isArray(data) && data[0] === 'dxos.org/plugin/github/BindDialog':
               return UrlDialog;
-            case Array.isArray(datum) && datum[0] === 'dxos.org/plugin/github/ExportDialog':
+            case Array.isArray(data) && data[0] === 'dxos.org/plugin/github/ExportDialog':
               return ExportDialog;
-            case Array.isArray(datum) && datum[0] === 'dxos.org/plugin/github/ImportDialog':
+            case Array.isArray(data) && data[0] === 'dxos.org/plugin/github/ImportDialog':
               return ImportDialog;
             default:
               return null;
           }
         case 'menuitem':
-          return Array.isArray(datum) && isMarkdown(datum[0]) && isMarkdownProperties(datum[1]) && !datum[1].readOnly
+          return Array.isArray(data) && isMarkdown(data[0]) && isMarkdownProperties(data[1]) && !data[1].readOnly
             ? MarkdownActions
             : null;
         default:

--- a/packages/apps/plugins/plugin-graph/src/types.ts
+++ b/packages/apps/plugins/plugin-graph/src/types.ts
@@ -14,13 +14,13 @@ type Index = ReturnType<typeof getIndices>[number];
 
 export type MaybePromise<T> = T | Promise<T>;
 
-export type GraphNode<TDatum = any> = {
+export type GraphNode<TData = any> = {
   id: string;
   index: Index;
   label: string | [string, { ns: string; count?: number }];
   description?: string;
   icon?: FC;
-  data?: TDatum; // nit about naming this
+  data?: TData;
   parent?: GraphNode;
   onChildrenRearrange?: (child: GraphNode, nextIndex: Index) => void;
   onMoveNode?: (source: GraphNode, target: GraphNode, child: GraphNode, nextIndex: Index) => void;

--- a/packages/apps/plugins/plugin-graph/src/util.ts
+++ b/packages/apps/plugins/plugin-graph/src/util.ts
@@ -13,8 +13,8 @@ export const ROOT: GraphNode = {
   description: 'Root node',
 };
 
-export const isGraphNode = (datum: unknown): datum is GraphNode =>
-  datum && typeof datum === 'object' ? 'id' in datum && 'label' in datum : false;
+export const isGraphNode = (data: unknown): data is GraphNode =>
+  data && typeof data === 'object' ? 'id' in data && 'label' in data : false;
 
 type GraphPlugin = Plugin<GraphProvides>;
 export const graphPlugins = (plugins: Plugin[]): GraphPlugin[] =>

--- a/packages/apps/plugins/plugin-kanban/src/KanbanPlugin.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/KanbanPlugin.tsx
@@ -65,14 +65,14 @@ export const KanbanPlugin = (): PluginDefinition<KanbanPluginProvides> => {
           ];
         },
       },
-      component: (datum, role) => {
-        if (!datum || typeof datum !== 'object') {
+      component: (data, role) => {
+        if (!data || typeof data !== 'object') {
           return null;
         }
 
         switch (role) {
           case 'main':
-            if ('object' in datum && isKanban(datum.object)) {
+            if ('object' in data && isKanban(data.object)) {
               return KanbanMain;
             } else {
               return null;

--- a/packages/apps/plugins/plugin-kanban/src/props.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/props.tsx
@@ -35,7 +35,7 @@ export type KanbanPluginProvides = GraphProvides & IntentProvides & Translations
 // TODO(burdon): Undo?
 // TODO(burdon): Typescript types (replace proto with annotations?)
 // TODO(burdon): Should pure components depend on ECHO? Relationship between ECHO object/array and Observable.
-// TODO(burdon): Can the plugin configure the object based on the datum? E.g., how are the models constructed?
+// TODO(burdon): Can the plugin configure the object based on the data? E.g., how are the models constructed?
 // TODO(burdon): Create models. Simple first based on actual data.
 //  Model is always a projection since the dragging state is tentative.
 
@@ -46,8 +46,8 @@ export interface KanbanModel {
   createItem(column: KanbanType.Column): KanbanType.Item;
 }
 
-export const isKanban = (datum: unknown): datum is KanbanType => {
-  return isTypedObject(datum) && KanbanType.type.name === datum.__typename;
+export const isKanban = (data: unknown): data is KanbanType => {
+  return isTypedObject(data) && KanbanType.type.name === data.__typename;
 };
 
 export type Location = {

--- a/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -142,43 +142,43 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
         ],
       },
       translations,
-      component: (datum, role) => {
-        if (!datum || typeof datum !== 'object') {
+      component: (data, role) => {
+        if (!data || typeof data !== 'object') {
           return null;
         }
 
         switch (role) {
           case 'main':
             if (
-              'composer' in datum &&
-              isMarkdown(datum.composer) &&
-              'properties' in datum &&
-              isMarkdownProperties(datum.properties)
+              'composer' in data &&
+              isMarkdown(data.composer) &&
+              'properties' in data &&
+              isMarkdownProperties(data.properties)
             ) {
-              if ('view' in datum && datum.view === 'embedded') {
+              if ('view' in data && data.view === 'embedded') {
                 return MarkdownMainEmbedded;
               } else {
                 return MarkdownMainStandalone;
               }
             } else if (
-              'composer' in datum &&
-              isMarkdownPlaceholder(datum.composer) &&
-              'properties' in datum &&
-              isMarkdownProperties(datum.properties)
+              'composer' in data &&
+              isMarkdownPlaceholder(data.composer) &&
+              'properties' in data &&
+              isMarkdownProperties(data.properties)
             ) {
               return MarkdownMainEmpty;
             }
             break;
           case 'section':
-            if (isMarkdown(get(datum, 'object.content', {}))) {
+            if (isMarkdown(get(data, 'object.content', {}))) {
               return MarkdownSection;
             }
             break;
           // TODO(burdon): Can this be decoupled from this plugin?
           case 'dialog':
             if (
-              get(datum, 'subject') === 'dxos.org/plugin/stack/chooser' &&
-              get(datum, 'id') === 'choose-section-space-doc'
+              get(data, 'subject') === 'dxos.org/plugin/stack/chooser' &&
+              get(data, 'id') === 'choose-section-space-doc'
             ) {
               return SpaceMarkdownChooser;
             }

--- a/packages/apps/plugins/plugin-markdown/src/util.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/util.tsx
@@ -15,30 +15,30 @@ import { Plugin } from '@dxos/react-surface';
 
 import { MARKDOWN_PLUGIN, MarkdownProperties, MarkdownProvides } from './types';
 
-export const isMarkdown = (datum: unknown): datum is ComposerModel =>
-  datum && typeof datum === 'object'
-    ? 'id' in datum &&
-      typeof datum.id === 'string' &&
-      (typeof (datum as { [key: string]: any }).content === 'string' ||
-        (datum as { [key: string]: any }).content instanceof YText)
+export const isMarkdown = (data: unknown): data is ComposerModel =>
+  data && typeof data === 'object'
+    ? 'id' in data &&
+      typeof data.id === 'string' &&
+      (typeof (data as { [key: string]: any }).content === 'string' ||
+        (data as { [key: string]: any }).content instanceof YText)
     : false;
 
-export const isMarkdownContent = (datum: unknown): datum is { content: ComposerModel } =>
-  !!datum &&
-  typeof datum === 'object' &&
-  (datum as { [key: string]: any }).content &&
-  isMarkdown((datum as { [key: string]: any }).content);
+export const isMarkdownContent = (data: unknown): data is { content: ComposerModel } =>
+  !!data &&
+  typeof data === 'object' &&
+  (data as { [key: string]: any }).content &&
+  isMarkdown((data as { [key: string]: any }).content);
 
-export const isMarkdownPlaceholder = (datum: unknown): datum is ComposerModel =>
-  datum && typeof datum === 'object'
-    ? 'id' in datum && typeof datum.id === 'string' && 'content' in datum && typeof datum.content === 'function'
+export const isMarkdownPlaceholder = (data: unknown): data is ComposerModel =>
+  data && typeof data === 'object'
+    ? 'id' in data && typeof data.id === 'string' && 'content' in data && typeof data.content === 'function'
     : false;
 
-export const isMarkdownProperties = (datum: unknown): datum is MarkdownProperties =>
-  datum instanceof EchoObject
+export const isMarkdownProperties = (data: unknown): data is MarkdownProperties =>
+  data instanceof EchoObject
     ? true
-    : datum && typeof datum === 'object'
-    ? 'title' in datum && typeof datum.title === 'string'
+    : data && typeof data === 'object'
+    ? 'title' in data && typeof data.title === 'string'
     : false;
 
 type MarkdownPlugin = Plugin<MarkdownProvides>;

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -92,27 +92,27 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
     },
     provides: {
       translations,
-      component: (datum, role) => {
+      component: (data, role) => {
         switch (role) {
           case 'main':
             switch (true) {
-              case isSpace(datum):
+              case isSpace(data):
                 return SpaceMainEmpty;
               default:
                 return null;
             }
           case 'tree--empty':
             switch (true) {
-              case datum === SPACE_PLUGIN:
+              case data === SPACE_PLUGIN:
                 return EmptyTree;
-              case isGraphNode(datum) && isSpace(datum?.data):
+              case isGraphNode(data) && isSpace(data?.data):
                 return EmptySpace;
               default:
                 return null;
             }
           case 'dialog':
-            if (Array.isArray(datum)) {
-              switch (datum[0]) {
+            if (Array.isArray(data)) {
+              switch (data[0]) {
                 case 'dxos.org/plugin/space/RenameSpaceDialog':
                   return DialogRenameSpace;
                 case 'dxos.org/plugin/space/RestoreSpaceDialog':

--- a/packages/apps/plugins/plugin-space/src/components/SpaceMain.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/SpaceMain.tsx
@@ -11,8 +11,8 @@ import { isTypedObject, SpaceProxy } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
 import { Surface } from '@dxos/react-surface';
 
-export const isDocument = (datum: unknown): datum is Document =>
-  isTypedObject(datum) && Document.type.name === datum.__typename;
+export const isDocument = (data: unknown): data is Document =>
+  isTypedObject(data) && Document.type.name === data.__typename;
 
 export const SpaceMain: FC<{ data: unknown }> = ({ data }) => {
   const [parentNode, childNode] =

--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -15,9 +15,9 @@ import { Plugin, findPlugin } from '@dxos/react-surface';
 
 import { SPACE_PLUGIN, SPACE_PLUGIN_SHORT_ID, SpaceAction } from './types';
 
-export const isSpace = (datum: unknown): datum is Space =>
-  datum && typeof datum === 'object'
-    ? 'key' in datum && datum.key instanceof PublicKey && 'db' in datum && datum.db instanceof EchoDatabase
+export const isSpace = (data: unknown): data is Space =>
+  data && typeof data === 'object'
+    ? 'key' in data && data.key instanceof PublicKey && 'db' in data && data.db instanceof EchoDatabase
     : false;
 
 export const getSpaceId = (spaceKey: PublicKeyLike) => {

--- a/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
+++ b/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
@@ -77,20 +77,20 @@ export const StackPlugin = (): PluginDefinition<StackPluginProvides> => {
         },
       },
       translations,
-      component: (datum, role) => {
-        if (!datum || typeof datum !== 'object') {
+      component: (data, role) => {
+        if (!data || typeof data !== 'object') {
           return null;
         }
 
         switch (role) {
           case 'main':
-            if ('object' in datum && isStack(datum.object)) {
+            if ('object' in data && isStack(data.object)) {
               return StackMain;
             } else {
               return null;
             }
           case 'dragoverlay':
-            if ('object' in datum) {
+            if ('object' in data) {
               return StackSectionOverlay;
             } else {
               return null;

--- a/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
@@ -165,9 +165,9 @@ const StackSectionsImpl = ({
         setActiveId(nextActiveId);
         setActiveAddableObject(null);
       } else {
-        const chooserDatum = get(data.current, 'treeitem.data', null);
-        const validChooser = chooserDatum && stackState.choosers?.find((chooser) => chooser?.filter(chooserDatum));
-        setActiveAddableObject(validChooser && !sectionIds.has(get(chooserDatum, 'id')) ? chooserDatum : null);
+        const chooserData = get(data.current, 'treeitem.data', null);
+        const validChooser = chooserData && stackState.choosers?.find((chooser) => chooser?.filter(chooserData));
+        setActiveAddableObject(validChooser && !sectionIds.has(get(chooserData, 'id')) ? chooserData : null);
       }
     },
     [sectionIds],

--- a/packages/apps/plugins/plugin-stack/src/types.ts
+++ b/packages/apps/plugins/plugin-stack/src/types.ts
@@ -33,7 +33,7 @@ export type StackSectionCreator = StackSectionAction & {
 
 // TODO(wittjosiah): Make filter serializable.
 export type StackSectionChooser = StackSectionAction & {
-  filter: (datum: unknown) => boolean;
+  filter: (data: unknown) => boolean;
 };
 
 export type StackProvides = {

--- a/packages/apps/plugins/plugin-stack/src/util.tsx
+++ b/packages/apps/plugins/plugin-stack/src/util.tsx
@@ -13,15 +13,15 @@ import { EchoObject, Space } from '@dxos/client/echo';
 
 import { GenericStackObject, STACK_PLUGIN, StackModel, StackObject, StackProperties } from './types';
 
-export const isStack = <T extends StackObject = GenericStackObject>(datum: unknown): datum is StackModel<T> =>
-  datum && typeof datum === 'object'
-    ? 'id' in datum &&
-      typeof datum.id === 'string' &&
-      typeof (datum as { [key: string]: any }).sections === 'object' &&
-      typeof (datum as { [key: string]: any }).sections?.length === 'number'
+export const isStack = <T extends StackObject = GenericStackObject>(data: unknown): data is StackModel<T> =>
+  data && typeof data === 'object'
+    ? 'id' in data &&
+      typeof data.id === 'string' &&
+      typeof (data as { [key: string]: any }).sections === 'object' &&
+      typeof (data as { [key: string]: any }).sections?.length === 'number'
     : false;
 
-export const isStackProperties = (datum: unknown): datum is StackProperties => datum instanceof EchoObject;
+export const isStackProperties = (data: unknown): data is StackProperties => data instanceof EchoObject;
 
 export const stackToGraphNode = (parent: GraphNode<Space>, obj: Stack, index: string): GraphNode => ({
   id: obj.id,

--- a/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -65,14 +65,14 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
           ];
         },
       },
-      component: (datum, role) => {
-        if (!datum || typeof datum !== 'object') {
+      component: (data, role) => {
+        if (!data || typeof data !== 'object') {
           return null;
         }
 
         switch (role) {
           case 'main':
-            if ('object' in datum && isThread(datum.object)) {
+            if ('object' in data && isThread(data.object)) {
               return ThreadMain;
             } else {
               return null;

--- a/packages/apps/plugins/plugin-thread/src/props.tsx
+++ b/packages/apps/plugins/plugin-thread/src/props.tsx
@@ -26,8 +26,8 @@ export interface ThreadModel {
   root: ThreadType;
 }
 
-export const isThread = (datum: unknown): datum is ThreadType => {
-  return isTypedObject(datum) && ThreadType.type.name === datum.__typename;
+export const isThread = (data: unknown): data is ThreadType => {
+  return isTypedObject(data) && ThreadType.type.name === data.__typename;
 };
 
 export const threadToGraphNode = (parent: GraphNode, object: ThreadType, index: string): GraphNode => ({

--- a/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
@@ -62,10 +62,10 @@ export const TreeViewPlugin = (): PluginDefinition<TreeViewPluginProvides> => {
         },
         TreeView: TreeViewContainer,
       },
-      component: (datum, role) => {
+      component: (data, role) => {
         switch (role) {
           case 'dragoverlay':
-            if (!!datum && typeof datum === 'object' && 'id' in datum && 'label' in datum && 'index' in datum) {
+            if (!!data && typeof data === 'object' && 'id' in data && 'label' in data && 'index' in data) {
               return TreeItemDragOverlay;
             } else {
               return null;

--- a/packages/sdk/react-surface/src/Plugin.ts
+++ b/packages/sdk/react-surface/src/Plugin.ts
@@ -7,7 +7,7 @@ import { FC, PropsWithChildren } from 'react';
 export type PluginProvides<TProvides> = TProvides & {
   context?: FC<PropsWithChildren>;
   component?: <P extends PropsWithChildren = PropsWithChildren>(
-    datum: unknown,
+    data: unknown,
     role?: string,
     props?: Partial<P>,
   ) => FC<PropsWithChildren<{ data: any; role?: string }>> | undefined | null | false | 0;

--- a/packages/sdk/react-surface/src/Surface.tsx
+++ b/packages/sdk/react-surface/src/Surface.tsx
@@ -29,7 +29,7 @@ const SurfaceContext = createContext<SurfaceContextValue | null>(null);
 export const useSurfaceContext = () => useContext(SurfaceContext);
 
 // If component is specified in props or context, grab a component by name.
-// Otherwise iterate through plugins where plugin.provides.component(datum) returns something.
+// Otherwise iterate through plugins where plugin.provides.component(data) returns something.
 const resolveComponents = (plugins: Plugin[], props: SurfaceProps, context: SurfaceContextValue | null) => {
   const componentName = props.component ?? (props.name && context?.surfaces?.[props.name]?.component);
   const data = props.data ?? (props.name && context?.surfaces?.[props.name]?.data);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d0204cf</samp>

### Summary
📝🔧🐛

<!--
1.  📝 - This emoji represents the changes that involve updating the documentation, comments, and specifications to use consistent and clear terminology.
2.  🔧 - This emoji represents the changes that involve refactoring the code, renaming variables, and improving readability and coherence of the component functions.
3.  🐛 - This emoji represents the changes that involve fixing potential bugs or confusion caused by using the singular form of data, which could lead to unexpected behavior or errors.
-->
This pull request replaces the term `datum` with `data` or `data context` in various files and functions across the dxos apps plugins, to improve the consistency and clarity of the terminology. This affects the documentation, the component interface specifications, and the plugin code.

> _`datum` is no more_
> _`data` brings clarity now_
> _a spring cleaning code_

### Walkthrough
*  Replace the term datum with data or data context for consistency and clarity in the following files: 
  - `docs/docs/specs/v0.2/composer.md` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-d039d4e67240e4db67ff9f20739aa53271b2a4a15660e09a55c132ce4e9aa136L63-R63), [link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-d039d4e67240e4db67ff9f20739aa53271b2a4a15660e09a55c132ce4e9aa136L84-R84), [link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-d039d4e67240e4db67ff9f20739aa53271b2a4a15660e09a55c132ce4e9aa136L119-R119))
  - `packages/apps/plugins/plugin-debug/src/DebugPlugin.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-9c210751898e82a6bd5c22e15a24db5f3ffe6eebeb547cddd8ce90016a38a490L18-R26), [link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-9c210751898e82a6bd5c22e15a24db5f3ffe6eebeb547cddd8ce90016a38a490L75-R78))
  - `packages/apps/plugins/plugin-dnd/src/DndPlugin.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-cbca02af1f492dc4c896354f1769840c877c6907c77ee1863943757db35821cdL170-R174))
  - `packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPlugin.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-3b3fbaceee2b207ec935441d399a88aeb228ba4b87f7ac356eceb731da181592L107-R107))
  - `packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPluginA.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-f524ea6451449cc5c3d9bae439008208e44a7972fcde0f7369e99bc2d806ba32L67-R67))
  - `packages/apps/plugins/plugin-dnd/src/stories/DndPluginDefaultStoryPluginB.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-09fa3c7d503733c226b3afa0a85ad2bc13fb6eb33dbabffca6f61890e2024fcbL86-R86))
  - `packages/apps/plugins/plugin-drawing/src/DrawingPlugin.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-aaca140d1a823ce6b8f5dbe2aa2275a30cad79dab9466f39491e2e71b768b5deL68-R69), [link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-aaca140d1a823ce6b8f5dbe2aa2275a30cad79dab9466f39491e2e71b768b5deL75-R75))
  - `packages/apps/plugins/plugin-drawing/src/props.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-ac13eba3c50775cc5b3af34a1dc671f9bff21697339d09c4fb9674d719c13b01L31-R32))
  - `packages/apps/plugins/plugin-files/src/FilesPlugin.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-61ac1b9b8f3415a2884014ea5912948c86639725f90492d7ec4c9686b5bafaaeL124-R127))
  - `packages/apps/plugins/plugin-files/src/util.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL13-R14))
  - `packages/apps/plugins/plugin-github/src/GithubPlugin.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-454e23ec82f76a0b34a7c74a7d68d92bea5779ec1b3bfabc3836512c0472aef8L32-R42), [link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-454e23ec82f76a0b34a7c74a7d68d92bea5779ec1b3bfabc3836512c0472aef8L48-R48))
  - `packages/apps/plugins/plugin-graph/src/types.ts` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-97606d5b4c2d306818d15063f51eb3092ae21b2a8026e0dfb01e2126f4e8119eL17-R17), [link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-97606d5b4c2d306818d15063f51eb3092ae21b2a8026e0dfb01e2126f4e8119eL23-R23))
  - `packages/apps/plugins/plugin-graph/src/util.ts` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-4db66d5892d11016d7b49265f21136773c7d4ae0562b242dc842045544b5a92fL16-R17))
  - `packages/apps/plugins/plugin-kanban/src/KanbanPlugin.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-fcc42cb616fe84778978fa7e79674e0a44857d88f697f901ef4b18bc4fe5df42L68-R69), [link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-fcc42cb616fe84778978fa7e79674e0a44857d88f697f901ef4b18bc4fe5df42L75-R75))
  - `packages/apps/plugins/plugin-kanban/src/props.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-8e88376b6977a5c931d006624dc07b91d17b68c7a6889256e6a9251098b5ff96L38-R38), [link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-8e88376b6977a5c931d006624dc07b91d17b68c7a6889256e6a9251098b5ff96L49-R50))
  - `packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcL145-R146), [link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcL153-R158), [link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcL164-R167), [link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcL173-R173), [link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcL180-R181))
  - `packages/apps/plugins/plugin-markdown/src/util.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-b57a1df4ed8db9d33351793b1766010a697c8c33a8b56bca4a98d5ee8d896725L18-R41))
  - `packages/apps/plugins/plugin-space/src/SpacePlugin.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L95-R99), [link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L106-R108), [link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L114-R115))
  - `packages/apps/plugins/plugin-space/src/components/SpaceMain.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-f731b7eb5a224694d8e2e5b063c134fe55aa1582683d0905400289d1c7e456a4L14-R15))
  - `packages/apps/plugins/plugin-space/src/util.tsx` ([link](https://github.com/dxos/dxos/pull/3746/files?diff=unified&w=0#diff-40c06872035a3fca913d3ecf4b86bab147706b739e5546f25845364df1b60203L18-R20))


