### PR TITLE
feat(react-client): add useShellProvider hook

### DIFF
--- a/packages/sdk/react-client/src/client/index.ts
+++ b/packages/sdk/react-client/src/client/index.ts
@@ -5,4 +5,5 @@
 export * from './ClientContext';
 export * from './useClientServices';
 export * from './useConfig';
+export * from './useShellProvider';
 export * from './useStatus';

--- a/packages/sdk/react-client/src/client/useShellProvider.ts
+++ b/packages/sdk/react-client/src/client/useShellProvider.ts
@@ -1,0 +1,46 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { useEffect } from 'react';
+
+import { PublicKey } from '@dxos/client';
+import { IFrameClientServicesHost, IFrameClientServicesProxy } from '@dxos/client/services';
+
+import { useClient } from './ClientContext';
+
+export type UseShellProviderOptions = {
+  /**
+   * The key of the current space.
+   *
+   * This is passed to the shell when the user presses the keyboard shortcut to open space invitations.
+   */
+  spaceKey?: PublicKey;
+
+  /**
+   * This is called when a user joins a space.
+   */
+  onJoinedSpace?: (spaceKey?: PublicKey) => void;
+};
+
+/**
+ * Use this hook to fully integrate an app with the shell.
+ */
+export const useShellProvider = ({ spaceKey, onJoinedSpace }: UseShellProviderOptions) => {
+  const client = useClient();
+
+  useEffect(() => {
+    if (
+      (client.services instanceof IFrameClientServicesProxy || client.services instanceof IFrameClientServicesHost) &&
+      onJoinedSpace
+    ) {
+      return client.services.joinedSpace.on(onJoinedSpace);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (client.services instanceof IFrameClientServicesProxy || client.services instanceof IFrameClientServicesHost) {
+      client.services.setSpaceProvider(() => spaceKey);
+    }
+  }, [spaceKey]);
+};

--- a/packages/sdk/react-shell/src/composites/Shell/ShellContext.tsx
+++ b/packages/sdk/react-shell/src/composites/Shell/ShellContext.tsx
@@ -22,6 +22,7 @@ import {
   ShellLayout,
   IFrameClientServicesHost,
   useClient,
+  useShellProvider,
 } from '@dxos/react-client';
 import type { Space } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
@@ -62,6 +63,7 @@ export const useShell = (): {
     setLayout,
   };
 };
+
 export type ShellProviderProps = PropsWithChildren<{
   space?: Space;
   deviceInvitationCode?: string | null;
@@ -85,20 +87,7 @@ export const ShellProvider = ({
   // IFrame Shell
   //
 
-  useEffect(() => {
-    if (
-      (client.services instanceof IFrameClientServicesProxy || client.services instanceof IFrameClientServicesHost) &&
-      onJoinedSpace
-    ) {
-      return client.services.joinedSpace.on(onJoinedSpace);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (client.services instanceof IFrameClientServicesProxy || client.services instanceof IFrameClientServicesHost) {
-      client.services.setSpaceProvider(() => space?.key);
-    }
-  }, [space]);
+  useShellProvider({ spaceKey: space?.key, onJoinedSpace });
 
   //
   // Component Shell


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 952db2e</samp>

### Summary
🪝🚀♻️

<!--
1.  🪝 - This emoji represents the hook that is exported and used by different modules.
2.  🚀 - This emoji represents the communication with the shell and the space provider logic that the hook handles.
3.  ♻️ - This emoji represents the refactoring of the `ShellProvider` component to use the hook.
-->
This pull request introduces a new `useShellProvider` hook in the `client` module, which simplifies the integration with the shell and the space provider logic. The hook is used by the `ShellProvider` component in the `react-shell` module, which is refactored accordingly.

> _We're sailing with the `ShellProvider` on the React sea_
> _We've hooked it to the `client` module for consistency_
> _We'll use the `useShellProvider` to join the space we need_
> _And heave away, me hearties, heave away on three_

### Walkthrough
* Export `useShellProvider` hook from `client` module ([link](https://github.com/dxos/dxos/pull/3751/files?diff=unified&w=0#diff-33512ea21f4286e616e3db883ee5e50581db1b1b280bd9e84daf7a3aca36afd4R8))
* Add `useShellProvider` hook to `client` module, which takes an options object with the current space key and a callback for when a user joins a space, and uses the client services to communicate with the shell and set the space provider and listen to the joined space event ([link](https://github.com/dxos/dxos/pull/3751/files?diff=unified&w=0#diff-0c6fbddd4b4f8f2ade0fbac825d5454cf5970358a0159dc5f00c58ab87e6a02eR1-R46))
* Use `useShellProvider` hook in `ShellProvider` component in `ShellContext` module, replacing the previous `useEffect` hooks that did the same thing ([link](https://github.com/dxos/dxos/pull/3751/files?diff=unified&w=0#diff-a82d8cbfffaf2844695ea76779d9beb58ebc739a2ff03775e714503694771b89R25), [link](https://github.com/dxos/dxos/pull/3751/files?diff=unified&w=0#diff-a82d8cbfffaf2844695ea76779d9beb58ebc739a2ff03775e714503694771b89L88-R91))
* Remove an empty line from `ShellContext` module for code style consistency ([link](https://github.com/dxos/dxos/pull/3751/files?diff=unified&w=0#diff-a82d8cbfffaf2844695ea76779d9beb58ebc739a2ff03775e714503694771b89R66))


