### PR TITLE
feat(react-surface): add error boundary to Surface

### DIFF
--- a/packages/apps/plugins/plugin-client/package.json
+++ b/packages/apps/plugins/plugin-client/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@dxos/config": "workspace:*",
     "@dxos/echo-signals": "workspace:*",
-    "@dxos/react-appkit": "workspace:*",
     "@dxos/react-client": "workspace:*"
   },
   "devDependencies": {

--- a/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
+++ b/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
@@ -6,7 +6,6 @@ import React, { useEffect, useState } from 'react';
 
 import { Config, Defaults, Envs, Local } from '@dxos/config';
 import { registerSignalFactory } from '@dxos/echo-signals/react';
-import { ErrorProvider } from '@dxos/react-appkit';
 import {
   Client,
   ClientContext,
@@ -54,11 +53,7 @@ export const ClientPlugin = (
             return () => subscription.unsubscribe();
           }, [client, setStatus]);
 
-          return (
-            <ClientContext.Provider value={{ client, status }}>
-              <ErrorProvider config={options.config}>{children}</ErrorProvider>
-            </ClientContext.Provider>
-          );
+          return <ClientContext.Provider value={{ client, status }}>{children}</ClientContext.Provider>;
         },
       };
     },

--- a/packages/apps/plugins/plugin-client/tsconfig.json
+++ b/packages/apps/plugins/plugin-client/tsconfig.json
@@ -31,9 +31,6 @@
     },
     {
       "path": "../../../sdk/react-surface"
-    },
-    {
-      "path": "../../../ui/react-appkit"
     }
   ]
 }

--- a/packages/apps/plugins/plugin-error/package.json
+++ b/packages/apps/plugins/plugin-error/package.json
@@ -16,8 +16,7 @@
   ],
   "dependencies": {
     "@dxos/config": "workspace:*",
-    "@dxos/react-appkit": "workspace:*",
-    "@sentry/react": "^7.41.0"
+    "@dxos/react-appkit": "workspace:*"
   },
   "devDependencies": {
     "@dxos/react-surface": "workspace:*",

--- a/packages/apps/plugins/plugin-error/src/ErrorPlugin.tsx
+++ b/packages/apps/plugins/plugin-error/src/ErrorPlugin.tsx
@@ -2,13 +2,15 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ErrorBoundary } from '@sentry/react';
 import React from 'react';
 
 import { Config, Defaults, Envs, Local } from '@dxos/config';
 import { ResetDialog } from '@dxos/react-appkit';
-import { PluginDefinition } from '@dxos/react-surface';
+import { ErrorBoundary, PluginDefinition } from '@dxos/react-surface';
 
+// TODO(wittjosiah): This is probably too naive and probably needs to be better integrated with the framework.
+//   For example, if client fails to initialize during plugin initialization and then the client plugin is missing,
+//   how is this reflected in the UI?
 export const ErrorPlugin = (
   { config }: { config: Config } = { config: new Config(Envs(), Local(), Defaults()) },
 ): PluginDefinition => ({

--- a/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
@@ -9,7 +9,7 @@ import { GraphNode, useGraph } from '@braneframe/plugin-graph';
 import { PluginDefinition, Surface, findPlugin, usePluginContext } from '@dxos/react-surface';
 
 import { TreeViewContext, useTreeView } from './TreeViewContext';
-import { TreeViewContainer } from './components';
+import { Fallback, TreeViewContainer } from './components';
 import { TreeItemDragOverlay } from './components/TreeItemDragOverlay';
 import translations from './translations';
 import { TREE_VIEW_PLUGIN, TreeViewAction, TreeViewContextValue, TreeViewPluginProvides } from './types';
@@ -44,7 +44,7 @@ export const TreeViewPlugin = (): PluginDefinition<TreeViewPluginProvides> => {
                 component='dxos.org/plugin/splitview/SplitView'
                 surfaces={{
                   sidebar: { component: 'dxos.org/plugin/treeview/TreeView' },
-                  main: { component: `${shortId}/Main`, data: { active } },
+                  main: { component: `${shortId}/Main`, fallback: Fallback, data: { active } },
                 }}
               />
             );

--- a/packages/apps/plugins/plugin-treeview/src/components/Fallback.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/Fallback.tsx
@@ -1,0 +1,28 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React from 'react';
+
+import { useTranslation } from '@dxos/aurora';
+import { errorText, mx } from '@dxos/aurora-theme';
+
+import { TREE_VIEW_PLUGIN } from '../types';
+
+export const Fallback = () => {
+  const { t } = useTranslation(TREE_VIEW_PLUGIN);
+
+  return (
+    <div role='none' className='min-bs-screen is-full flex items-center justify-center p-8'>
+      <p
+        role='alert'
+        className={mx(
+          errorText,
+          'border border-error-400/50 rounded-xl flex items-center justify-center p-8 font-system-normal text-lg',
+        )}
+      >
+        {t('plugin error message')}
+      </p>
+    </div>
+  );
+};

--- a/packages/apps/plugins/plugin-treeview/src/components/index.ts
+++ b/packages/apps/plugins/plugin-treeview/src/components/index.ts
@@ -3,6 +3,7 @@
 //
 
 export * from './BranchTreeItem';
+export * from './Fallback';
 export * from './LeafTreeItem';
 export * from './TreeView';
 export * from './TreeViewContainer';

--- a/packages/apps/plugins/plugin-treeview/src/translations.ts
+++ b/packages/apps/plugins/plugin-treeview/src/translations.ts
@@ -11,6 +11,7 @@ export default [
         'tree options label': 'More options',
         'tree branch options label': 'More options',
         'tree leaf options label': 'More options',
+        'plugin error message': 'Content failed to render',
       },
     },
   },

--- a/packages/sdk/react-surface/src/ErrorBoundary.tsx
+++ b/packages/sdk/react-surface/src/ErrorBoundary.tsx
@@ -1,0 +1,45 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React, { Component, FC, PropsWithChildren } from 'react';
+
+type Props = PropsWithChildren<{ data?: any; fallback: FC<{ error: Error; reset: () => void }> }>;
+type State = { error: Error | undefined };
+
+/**
+ * Surface error boundary.
+ *
+ * For basic usage prefer providing a fallback component to `Surface`.
+ *
+ * For more information on error boundaries, see:
+ * https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { error: undefined };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  override componentDidUpdate(prevProps: Props): void {
+    if (prevProps.data !== this.props.data) {
+      this.resetError();
+    }
+  }
+
+  override render() {
+    if (this.state.error) {
+      return <this.props.fallback error={this.state.error} reset={this.resetError} />;
+    }
+
+    return this.props.children;
+  }
+
+  private resetError() {
+    this.setState({ error: undefined });
+  }
+}

--- a/packages/sdk/react-surface/src/PluginContext.tsx
+++ b/packages/sdk/react-surface/src/PluginContext.tsx
@@ -21,7 +21,16 @@ export const PluginContextProvider = ({ plugins: definitions }: { plugins: Plugi
   const [plugins, setPlugins] = useState<Plugin[]>();
   useEffect(() => {
     const timeout = setTimeout(async () => {
-      const plugins = await Promise.all(definitions.map(initializePlugin));
+      const plugins = await Promise.all(
+        definitions.map(async (definition) => {
+          try {
+            return initializePlugin(definition);
+          } catch (err) {
+            console.error('Failed to initialize plugin:', definition.meta.id, err);
+            return undefined;
+          }
+        }),
+      ).then((plugins) => plugins.filter((plugin): plugin is Plugin => Boolean(plugin)));
       await Promise.all(definitions.map((pluginDefinition) => pluginDefinition.ready?.(plugins)));
       setPlugins(plugins);
     });

--- a/packages/sdk/react-surface/src/index.ts
+++ b/packages/sdk/react-surface/src/index.ts
@@ -3,6 +3,7 @@
 //
 
 export * from './Context';
+export * from './ErrorBoundary';
 export * from './PluginContext';
 export * from './Plugin';
 export * from './Surface';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -587,7 +587,6 @@ importers:
     specifiers:
       '@dxos/config': workspace:*
       '@dxos/echo-signals': workspace:*
-      '@dxos/react-appkit': workspace:*
       '@dxos/react-client': workspace:*
       '@dxos/react-surface': workspace:*
       '@types/react': ^18.0.21
@@ -598,7 +597,6 @@ importers:
     dependencies:
       '@dxos/config': link:../../../sdk/config
       '@dxos/echo-signals': link:../../../core/echo/echo-signals
-      '@dxos/react-appkit': link:../../../ui/react-appkit
       '@dxos/react-client': link:../../../sdk/react-client
     devDependencies:
       '@dxos/react-surface': link:../../../sdk/react-surface
@@ -766,14 +764,12 @@ importers:
       '@dxos/config': workspace:*
       '@dxos/react-appkit': workspace:*
       '@dxos/react-surface': workspace:*
-      '@sentry/react': ^7.41.0
       '@types/react': ^18.0.21
       react: ^18.2.0
       vite: ^4.3.9
     dependencies:
       '@dxos/config': link:../../../sdk/config
       '@dxos/react-appkit': link:../../../ui/react-appkit
-      '@sentry/react': 7.42.0_react@18.2.0
     devDependencies:
       '@dxos/react-surface': link:../../../sdk/react-surface
       '@types/react': 18.0.21


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 920a2ea</samp>

### Summary
🗑️🛠️🆕

<!--
1.  🗑️ - This emoji represents the removal of unused or unnecessary dependencies, references, or components, such as `@dxos/react-appkit`, `@sentry/react`, and `ErrorProvider`.
2.  🛠️ - This emoji represents the modification or improvement of existing logic, components, or UI elements, such as `ErrorBoundary`, `PluginContextProvider`, and `ClientPlugin`.
3.  🆕 - This emoji represents the addition of new features, components, or translations, such as `Fallback`, `ErrorBoundary` export, and error message localization.
-->
Improved error handling and UI consistency for plugins and surfaces. Added `ErrorBoundary` and `Fallback` components to `@dxos/react-surface` and used them in `plugin-client` and `plugin-treeview`. Removed unused dependencies and references from `plugin-client` and `plugin-error`.

> _Oh we're the crew of the `plugin-client`_
> _And we work hard to make it shine_
> _We've removed the old dependencies_
> _And we've added the `ErrorBoundary` line_

### Walkthrough
*  Remove unused dependencies and references from `plugin-client` and `plugin-error` packages ([link](https://github.com/dxos/dxos/pull/3752/files?diff=unified&w=0#diff-4789b3ee5b3e63f0181c552c1e9723e927d3e9a1cdca65aa1109c542fc087d17L20), [link](https://github.com/dxos/dxos/pull/3752/files?diff=unified&w=0#diff-e56910f2262fdeae3091d92ab8065942ae5b436d28156b7b554e0a37c9c88132L34-L36), [link](https://github.com/dxos/dxos/pull/3752/files?diff=unified&w=0#diff-0977c6dba126cdc281b98a2290025501d7ecb602a63eed40f6005d1c0ab14070L19-R19)).


