### PR TITLE
fix(plugin-treeview): handle another invalid active state

### DIFF
--- a/packages/apps/plugins/plugin-github/src/GithubPlugin.tsx
+++ b/packages/apps/plugins/plugin-github/src/GithubPlugin.tsx
@@ -59,7 +59,7 @@ export const GithubPlugin = (): PluginDefinition<TranslationsProvides> => ({
 
         return null;
       },
-      Main: EmbeddedMain,
+      embedded: EmbeddedMain,
     },
   },
 });

--- a/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
@@ -32,12 +32,12 @@ export const TreeViewPlugin = (): PluginDefinition<TreeViewPluginProvides> => {
           const { plugins } = usePluginContext();
           const treeView = useTreeView();
           const { graph } = useGraph();
-          const [shortId] = treeView.active[0]?.split('/') ?? [];
+          const [shortId, component] = treeView.active[0]?.split('/') ?? [];
           const plugin = findPlugin(plugins, shortId);
           const active = resolveNodes(Object.values(graph.pluginChildren ?? {}).flat() as GraphNode[], treeView.active);
 
-          if (active.length === 0 && plugin) {
-            return <Surface component={`${plugin.meta.id}/Main`} />;
+          if (plugin && plugin.provides.components?.[component]) {
+            return <Surface component={`${plugin.meta.id}/${component}`} />;
           } else if (active.length > 0) {
             return (
               <Surface


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f976cac</samp>

### Summary
🔧🌲🧩

<!--
1.  🔧 - This emoji conveys the idea of renaming or refactoring something, which is what the first change does to the `Main` component.
2.  🌲 - This emoji conveys the idea of a tree or a hierarchy, which is what the second change affects by modifying the logic of the `TreeViewPlugin`.
3.  🧩 - This emoji conveys the idea of a plugin or a modular piece of functionality, which is what the second change enables by allowing the plugin to provide different components.
-->
This pull request enhances the plugin system of the app by allowing plugins to provide multiple components for the tree view. It also renames the `Main` component of the `GithubPlugin` to `embedded` for consistency.

> _`Main` becomes `embedded`_
> _Tree view renders components_
> _A new spring for plugins_

### Walkthrough
*  Rename `Main` component of `GithubPlugin` to `embedded` to follow convention and enable future components ([link](https://github.com/dxos/dxos/pull/3762/files?diff=unified&w=0#diff-454e23ec82f76a0b34a7c74a7d68d92bea5779ec1b3bfabc3836512c0472aef8L62-R62)).


