### PR TITLE
fix(react-shell,aurora): Shell & `Main`

### DIFF
--- a/packages/apps/composer-app/index.html
+++ b/packages/apps/composer-app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="overscroll-behavior: none">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no">

--- a/packages/apps/labs-app/index.html
+++ b/packages/apps/labs-app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="overscroll-behavior: none">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no">

--- a/packages/apps/plugins/plugin-markdown/src/components/EmbeddedLayout.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/EmbeddedLayout.tsx
@@ -7,5 +7,5 @@ import React, { PropsWithChildren } from 'react';
 import { Main } from '@dxos/aurora';
 
 export const EmbeddedLayout = ({ children }: PropsWithChildren<{}>) => {
-  return <Main.Content classNames='min-bs-[100vh] flex flex-col p-0.5'>{children}</Main.Content>;
+  return <Main.Content classNames='min-bs-[100dvh] flex flex-col p-0.5'>{children}</Main.Content>;
 };

--- a/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
@@ -26,8 +26,8 @@ export const StandaloneLayout = ({
   const { t } = useTranslation(MARKDOWN_PLUGIN);
   const themeContext = useThemeContext();
   return (
-    <Main.Content classNames='min-bs-full'>
-      <div role='none' className='mli-auto max-is-[60rem] min-bs-[100vh] bg-white dark:bg-neutral-925 flex flex-col'>
+    <Main.Content classNames='min-bs-full' bounce>
+      <div role='none' className='mli-auto max-is-[60rem] min-bs-[100dvh] bg-white dark:bg-neutral-925 flex flex-col'>
         <div role='none' className='flex items-center gap-2 pis-0 pointer-fine:pis-8 lg:pis-0 pointer-fine:lg:pis-0'>
           <Input.Root id={`input--${model.id}`}>
             <Input.Label srOnly>{t('document title label')}</Input.Label>

--- a/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
@@ -25,7 +25,7 @@ export const SplitView = () => {
       <div
         role='none'
         className={mx(
-          'fixed z-[1] block-end-0 pointer-fine:block-end-auto pointer-fine:block-start-0 p-2 pointer-fine:p-1.5 transition-[inset-inline-start,opacity] ease-in-out duration-200 inline-start-0',
+          'fixed z-[1] block-end-0 pointer-fine:block-end-auto pointer-fine:block-start-0 p-4 pointer-fine:p-1.5 transition-[inset-inline-start,opacity] ease-in-out duration-200 inline-start-0',
           sidebarOpen && 'opacity-0 pointer-events-none',
         )}
       >

--- a/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
@@ -53,7 +53,7 @@ export const TreeViewContainer = () => {
         <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}>
           <div role='none' className='flex flex-col bs-full'>
             <div role='separator' className='order-1 bs-px mli-2.5 bg-neutral-500/20' />
-            <Tree.Root role='none' classNames='order-1 grow min-bs-0 overflow-y-auto overscroll-contain'>
+            <Tree.Root role='none' classNames='order-1 grow min-bs-0 overflow-y-auto overscroll-contain scroll-smooth'>
               {branches.map(([key, items]) => (
                 <TreeItem.Root key={key} classNames='flex flex-col plb-1.5 pis-1 pie-1.5'>
                   <TreeItem.Heading classNames='pl-2'>{t('plugin name', { ns: key })}</TreeItem.Heading>

--- a/packages/sdk/react-shell/src/components/PanelStepHeading.tsx
+++ b/packages/sdk/react-shell/src/components/PanelStepHeading.tsx
@@ -9,7 +9,7 @@ import { mx } from '@dxos/aurora-theme';
 export const PanelStepHeading = forwardRef<HTMLHeadingElement, ComponentPropsWithRef<'h2'>>(
   ({ children, className, ...props }, forwardedRef) => {
     return (
-      <h2 {...props} className={mx('font-system-normal text-sm mbe-2 mli-1 text-center', className)} ref={forwardedRef}>
+      <h2 {...props} className={mx('font-system-normal text-sm mbe-4 mli-1 text-center', className)} ref={forwardedRef}>
         {children}
       </h2>
     );

--- a/packages/sdk/react-shell/src/composites/JoinDialog/JoinDialog.tsx
+++ b/packages/sdk/react-shell/src/composites/JoinDialog/JoinDialog.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { AlertDialog, AlertDialogContentProps, useId } from '@dxos/aurora';
+import { AlertDialog, AlertDialogContentProps, useId, useVisualViewport } from '@dxos/aurora';
 
 import { JoinPanel, JoinPanelProps } from '../../panels';
 
@@ -14,14 +14,15 @@ export interface JoinDialogProps
 
 export const JoinDialog = (joinPanelProps: JoinDialogProps) => {
   const titleId = useId('joinDialog__title');
-
+  // todo(thure): This doesn’t work within an iframe on iOS Safari.
+  const { height } = useVisualViewport();
   return (
     <AlertDialog.Root
       defaultOpen
       onOpenChange={(open) => open || (joinPanelProps.onExit ? joinPanelProps.onExit() : joinPanelProps.onDone?.(null))}
     >
       <AlertDialog.Portal>
-        <AlertDialog.Overlay>
+        <AlertDialog.Overlay classNames='backdrop-blur' {...(height && { style: { blockSize: `${height}px` } })}>
           <AlertDialog.Content aria-labelledby={titleId}>
             <JoinPanel
               {...{

--- a/packages/sdk/react-shell/src/panels/JoinPanel/JoinHeading.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/JoinHeading.tsx
@@ -19,13 +19,12 @@ export interface JoinSpaceHeadingProps {
   joinState?: JoinState;
   onExit?: () => void;
   exitActionParent?: Parameters<typeof cloneElement>[0];
-  preventExit?: boolean;
 }
 
 // TODO(wittjosiah): Accesses the space properties directly which will trigger ECHO warnings without observer.
 export const JoinHeading = forwardRef(
   (
-    { mode, titleId, joinState, onExit, exitActionParent, preventExit }: JoinSpaceHeadingProps,
+    { mode, titleId, joinState, onExit, exitActionParent }: JoinSpaceHeadingProps,
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
     const { t } = useTranslation('os');
@@ -50,15 +49,13 @@ export const JoinHeading = forwardRef(
 
     return (
       <div role='none' className='pbs-3 pbe-1 relative' ref={ref}>
-        {!preventExit &&
-          mode !== 'halo-only' &&
-          (exitActionParent ? cloneElement(exitActionParent, {}, exitButton) : exitButton)}
+        {mode !== 'halo-only' && (exitActionParent ? cloneElement(exitActionParent, {}, exitButton) : exitButton)}
         <Heading
           level={1}
           className={mx(
             descriptionText,
             'font-body font-system-normal text-center text-sm grow pbe-2',
-            mode === 'halo-only' && (preventExit ? 'sr-only' : 'opacity-0'),
+            mode === 'halo-only' && 'opacity-0',
           )}
           id={titleId}
         >

--- a/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanel.stories.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanel.stories.tsx
@@ -17,7 +17,6 @@ const noOpProps: JoinPanelImplProps = {
   activeView: 'create identity input',
   failed: new Set(),
   pending: false,
-  preventExit: true,
 };
 
 const StorybookJoinPanel = (args: Partial<JoinPanelImplProps>) => {

--- a/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanel.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanel.tsx
@@ -31,7 +31,6 @@ export const JoinPanelImpl = ({
   mode,
   unredeemedCodes,
   invitationStates,
-  preventExit,
   onExit,
   onHaloDone,
   onSpaceDone,
@@ -44,7 +43,7 @@ export const JoinPanelImpl = ({
 }: JoinPanelImplProps) => {
   return (
     <DensityProvider density='fine'>
-      <JoinHeading {...{ titleId, mode, onExit, exitActionParent, preventExit }} />
+      {mode !== 'halo-only' && <JoinHeading {...{ titleId, mode, onExit, exitActionParent }} />}
       <Viewport.Root focusManaged activeView={activeView}>
         <Viewport.Views>
           <Viewport.View classNames={stepStyles} id='addition method chooser'>
@@ -151,7 +150,6 @@ export const JoinPanel = ({
   onExit,
   doneActionParent,
   onDone: propsOnDone,
-  preventExit,
 }: JoinPanelProps) => {
   const client = useClient();
   const identity = useIdentity();
@@ -337,6 +335,7 @@ export const JoinPanel = ({
     <JoinPanelImpl
       {...{
         titleId,
+        mode,
         send: joinSend,
         activeView,
         failed,
@@ -344,7 +343,6 @@ export const JoinPanel = ({
         unredeemedCodes,
         invitationStates,
         identity,
-        preventExit,
         onExit,
         exitActionParent,
         doneActionParent,

--- a/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanelProps.ts
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanelProps.ts
@@ -19,7 +19,6 @@ export interface JoinPanelProps {
   titleId?: string;
   exitActionParent?: Parameters<typeof cloneElement>[0];
   onExit?: () => void;
-  preventExit?: boolean;
   doneActionParent?: Parameters<typeof cloneElement>[0];
   onDone?: (result: InvitationResult | null) => void;
   parseInvitationCodeInput?: (invitationCodeInput: string) => string;
@@ -27,7 +26,7 @@ export interface JoinPanelProps {
 
 export type JoinPanelImplProps = Pick<
   JoinPanelProps,
-  'mode' | 'preventExit' | 'onExit' | 'onDone' | 'exitActionParent' | 'doneActionParent'
+  'mode' | 'onExit' | 'onDone' | 'exitActionParent' | 'doneActionParent'
 > &
   Pick<JoinStepProps, 'send'> & {
     titleId: string;

--- a/packages/ui/aurora-theme/src/styles/components/dialog.ts
+++ b/packages/ui/aurora-theme/src/styles/components/dialog.ts
@@ -16,7 +16,7 @@ export type DialogStyleProps = {
 const dialogLayoutFragment = 'overflow-auto grid place-items-center p-2 md:p-4 lg:p-8';
 
 export const dialogOverlay: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
-  mx('fixed z-20 inset-0', dialogLayoutFragment, ...etc);
+  mx('fixed z-20 inset-inline-0 block-start-0 bs-[100dvb]', dialogLayoutFragment, ...etc);
 
 export const dialogOsOverlay: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
   mx('fixed z-40 inset-0 backdrop-blur', dialogLayoutFragment, ...etc);

--- a/packages/ui/aurora-theme/src/styles/components/main.ts
+++ b/packages/ui/aurora-theme/src/styles/components/main.ts
@@ -10,6 +10,7 @@ import { baseSurface, inlineSeparator } from '../fragments';
 export type MainStyleProps = Partial<{
   isLg: boolean;
   sidebarOpen: boolean;
+  bounce: boolean;
 }>;
 
 export const mainSidebar: ComponentFunction<MainStyleProps> = ({ isLg, sidebarOpen }, ...etc) =>
@@ -31,10 +32,11 @@ export const mainOverlay: ComponentFunction<MainStyleProps> = ({ isLg, sidebarOp
     ...etc,
   );
 
-export const mainContent: ComponentFunction<MainStyleProps> = ({ isLg, sidebarOpen }, ...etc) =>
+export const mainContent: ComponentFunction<MainStyleProps> = ({ isLg, sidebarOpen, bounce }, ...etc) =>
   mx(
     'transition-[padding-inline-start] duration-200 ease-in-out',
     isLg && sidebarOpen ? 'pis-[270px]' : 'pis-0',
+    bounce && 'fixed inset-0 z-0 overflow-auto overscroll-auto scroll-smooth',
     ...etc,
   );
 

--- a/packages/ui/aurora/src/components/Main/Main.tsx
+++ b/packages/ui/aurora/src/components/Main/Main.tsx
@@ -111,17 +111,21 @@ const MainSidebar = forwardRef<HTMLDivElement, MainSidebarProps>(
 
 MainSidebar.displayName = SIDEBAR_NAME;
 
-type MainProps = ThemedClassName<ComponentPropsWithRef<typeof Primitive.div>> & { asChild?: boolean };
+type MainProps = ThemedClassName<ComponentPropsWithRef<typeof Primitive.div>> & { asChild?: boolean; bounce?: boolean };
 
 const MainContent = forwardRef<HTMLDivElement, MainProps>(
-  ({ asChild, classNames, children, ...props }: MainProps, forwardedRef) => {
+  ({ asChild, classNames, bounce, children, ...props }: MainProps, forwardedRef) => {
     const [isLg] = useMediaQuery('lg', { ssr: false });
     const { sidebarOpen } = useMainContext(MAIN_NAME);
     const { tx } = useThemeContext();
     const Root = asChild ? Slot : 'main';
 
     return (
-      <Root {...props} className={tx('main.content', 'main', { isLg, sidebarOpen }, classNames)} ref={forwardedRef}>
+      <Root
+        {...props}
+        className={tx('main.content', 'main', { isLg, sidebarOpen, bounce }, classNames)}
+        ref={forwardedRef}
+      >
         {children}
       </Root>
     );

--- a/packages/ui/aurora/src/hooks/index.ts
+++ b/packages/ui/aurora/src/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './useDensityContext';
 export * from './useElevationContext';
 export * from './useTranslationsContext';
 export * from './useThemeContext';
+export * from './useVisualViewport';

--- a/packages/ui/aurora/src/hooks/useVisualViewport.ts
+++ b/packages/ui/aurora/src/hooks/useVisualViewport.ts
@@ -1,0 +1,24 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { useEffect, useState } from 'react';
+
+export const useVisualViewport = (deps?: Parameters<typeof useEffect>[1]) => {
+  const [width, setWidth] = useState<number | null>(null);
+  const [height, setHeight] = useState<number | null>(null);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.visualViewport) {
+        setWidth(window.visualViewport.width);
+        setHeight(window.visualViewport.height);
+      }
+    };
+    window.visualViewport?.addEventListener('resize', handleResize);
+    handleResize();
+    return () => window.visualViewport?.removeEventListener('resize', handleResize);
+  }, deps ?? []);
+
+  return { width, height };
+};


### PR DESCRIPTION
This PR:
- Adjusts some `react-shell` designs
- Fixes root overscroll behavior on iOS
- Provides a `bounce` option for `Main.Content`
- Adds `useVisualViewport` in case it becomes useful in later iterations

copilot:all
