### PR TITLE
ci: run chromatic upload after e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,6 @@ jobs:
       - run: pnpm install-playwright
       - *cache_save
       - nx/set-shas
-      - run: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD --target=chromatic
       # TODO(wittjosiah): Apps can't be bundled in parallel currently due to memory usage.
       - run:
           command: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD --target=bundle --parallel=1
@@ -117,6 +116,7 @@ jobs:
             REMOTE_SOURCE: http://localhost:3967/vault.html
             # TODO(wittjosiah): Remove. Currently need because e2e seems to be re-running bundling.
             NODE_OPTIONS: --max_old_space_size=10240
+      - run: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD --target=chromatic
       - *codecov_upload
       - *store_test_results
       - store_artifacts:


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b01f52b</samp>

### Summary
🚀🎨🛠️

<!--
1.  🚀 - This emoji represents the optimization of the CI pipeline, which can improve the speed and efficiency of the development process.
2.  🎨 - This emoji represents the chromatic tests, which are related to the visual appearance and style of the components.
3.  🛠️ - This emoji represents the workflow configuration, which is a technical and maintenance-related task.
-->
Optimize CI pipeline by separating `chromatic` tests from `publish` workflow. This improves performance and avoids conflicts in `.circleci/config.yml`.

> _To optimize the CI pipeline_
> _We moved `chromatic` to a new line_
> _In the `test` workflow_
> _It runs on its own, phew!_
> _And avoids conflicts with `publish` fine_

### Walkthrough
* Move chromatic tests to a separate job in the `test` workflow (`[link](https://github.com/dxos/dxos/pull/3784/files?diff=unified&w=0#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L106)`, `[link](https://github.com/dxos/dxos/pull/3784/files?diff=unified&w=0#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R119)`)


