### PR TITLE
fix: Exit `chromatic` on upload complete

### DIFF
--- a/packages/sdk/examples/package.json
+++ b/packages/sdk/examples/package.json
@@ -9,7 +9,7 @@
   "author": "info@dxos.org",
   "type": "module",
   "scripts": {
-    "chromatic": "chromatic --only-changed --project-token=\"chpt_7b7f447ccad9f73\" --storybook-build-dir out --exit-zero-on-changes",
+    "chromatic": "chromatic --only-changed --project-token=\"chpt_7b7f447ccad9f73\" --storybook-build-dir out --exit-once-uploaded",
     "prebuild": "dxtype src/proto/TaskList.proto src/proto/gen/TaskList.ts"
   },
   "devDependencies": {

--- a/packages/sdk/react-shell/package.json
+++ b/packages/sdk/react-shell/package.json
@@ -25,7 +25,7 @@
     "theme-extensions.js"
   ],
   "scripts": {
-    "chromatic": "chromatic --only-changed --project-token=\"chpt_83a397756fbc63f\" --storybook-build-dir out/react-shell --exit-zero-on-changes"
+    "chromatic": "chromatic --only-changed --project-token=\"chpt_83a397756fbc63f\" --storybook-build-dir out/react-shell --exit-once-uploaded"
   },
   "dependencies": {
     "@dxos/async": "workspace:*",

--- a/packages/ui/aurora/package.json
+++ b/packages/ui/aurora/package.json
@@ -15,7 +15,7 @@
     "plugin.d.ts"
   ],
   "scripts": {
-    "chromatic": "chromatic --only-changed --project-token=\"44ade288043a\" --storybook-build-dir out/aurora --exit-zero-on-changes"
+    "chromatic": "chromatic --only-changed --project-token=\"44ade288043a\" --storybook-build-dir out/aurora --exit-once-uploaded"
   },
   "dependencies": {
     "@dxos/aurora-types": "workspace:*",


### PR DESCRIPTION
This project has no reason to wait for snapshots to render, so `chromatic` can exit as soon as it’s finished uploading.