### PR TITLE
fix(aurora-composer): Prevent editor doubling

### DIFF
--- a/packages/ui/aurora-composer/src/components/Markdown/Markdown.tsx
+++ b/packages/ui/aurora-composer/src/components/Markdown/Markdown.tsx
@@ -194,14 +194,13 @@ export const MarkdownComposer = forwardRef<MarkdownComposerRef, MarkdownComposer
       // NOTE: This repaints the editor.
       // If the new state is derived from the old state, it will likely not be visible other than the cursor resetting.
       // Ideally this should not be hit except when changing between text objects.
+      view?.destroy();
       setView(new EditorView({ state, parent }));
 
       return () => {
-        if (view) {
-          view.destroy();
-          setView(undefined);
-          setState(undefined);
-        }
+        view?.destroy();
+        setView(undefined);
+        setState(undefined);
       };
     }, [parent, content, provider?.awareness, themeMode]);
 


### PR DESCRIPTION
This PR fixes an issue where we’d see composer editors doubling.

https://github.com/dxos/dxos/assets/855039/b726d273-0b35-45ad-a811-dd4cf618866f

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 383dc5d</samp>

### Summary
🐛🚀🧹

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change. It conveys that the memory leak issue was a bug that needed to be fixed.
2.  🚀 - This emoji represents a performance improvement, which is a secondary benefit of this change. It conveys that the change will make the editor faster and more responsive by freeing up memory and resources.
3.  🧹 - This emoji represents a cleanup or refactoring, which is a tertiary aspect of this change. It conveys that the change will make the code more readable and maintainable by removing unnecessary or redundant code.
-->
Fixed a memory leak issue in the `MarkdownComposer` component by destroying the old ProseMirror view before creating a new one. This improves the performance and stability of the collaborative markdown editor.

> _`MarkdownComposer`_
> _View destroyed before new one_
> _Memory leak fixed_

### Walkthrough
* Fix memory leak issue by destroying previous view before creating new one ([link](https://github.com/dxos/dxos/pull/3792/files?diff=unified&w=0#diff-a269f70d7fda84a1ea5891d7de3839f5a2666aa681edbecfa5db118ab05112a6L197-R203))


