### PR TITLE
fix(react-shell): QA bugs

### DIFF
--- a/packages/sdk/react-shell/src/panels/JoinPanel/joinMachine.ts
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/joinMachine.ts
@@ -280,8 +280,14 @@ const joinMachine = createMachine<JoinMachineContext, JoinEvent>(
         ],
       },
       choosingIdentity: {
-        initial: 'choosingAuthMethod',
+        initial: 'unknownAuthMethod',
         states: {
+          unknownAuthMethod: {
+            always: [
+              { cond: 'hasHaloUnredeemedCode', target: 'acceptingHaloInvitation', actions: 'log' },
+              { target: 'choosingAuthMethod', actions: 'log' },
+            ],
+          },
           choosingAuthMethod: {},
           recoveringIdentity: {},
           creatingIdentity: {},
@@ -312,7 +318,7 @@ const joinMachine = createMachine<JoinMachineContext, JoinEvent>(
   {
     guards: {
       noSelectedIdentity: ({ identity }, _event) => !identity,
-      noHaloInvitation: ({ halo }, _event) => !halo.invitation && !halo.unredeemedCode,
+      hasHaloUnredeemedCode: ({ halo }, _event) => !!halo.unredeemedCode,
       noSpaceInvitation: ({ space }, _event) => !space.invitation && !space.unredeemedCode,
     },
     actions: {

--- a/packages/sdk/react-shell/src/panels/SpacePanel/SpacePanel.tsx
+++ b/packages/sdk/react-shell/src/panels/SpacePanel/SpacePanel.tsx
@@ -2,11 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
-import { X } from '@phosphor-icons/react';
-import React, { cloneElement, useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
-import { Button, DensityProvider, Tooltip, useId, useTranslation } from '@dxos/aurora';
-import { getSize, mx } from '@dxos/aurora-theme';
+import { DensityProvider, useId } from '@dxos/aurora';
+import { mx } from '@dxos/aurora-theme';
 import { log } from '@dxos/log';
 import { useInvitationStatus } from '@dxos/react-client/invitations';
 import type { CancellableInvitationObservable } from '@dxos/react-client/invitations';
@@ -19,29 +18,13 @@ import { SpacePanelHeadingProps, SpacePanelImplProps, SpacePanelProps } from './
 import { useSpaceMachine } from './spaceMachine';
 import { SpaceManager } from './steps';
 
-const SpacePanelHeading = ({ titleId, space, doneActionParent, onDone }: SpacePanelHeadingProps) => {
-  const { t } = useTranslation('os');
+const SpacePanelHeading = ({ titleId, space }: SpacePanelHeadingProps) => {
   const name = space.properties.name;
-
-  const doneButton = (
-    <Button variant='ghost' onClick={() => onDone?.()} data-testid='show-all-spaces'>
-      <X className={getSize(4)} weight='bold' />
-    </Button>
-  );
-
+  // TODO(wittjosiah): Label this as the space panel.
   return (
-    <div role='none' className={mx('flex items-center p-2 gap-2')}>
-      {/* TODO(wittjosiah): Label this as the space panel. */}
-      <h2 id={titleId} className={mx('grow font-system-medium', !name && 'font-mono')}>
-        {name ?? space.key.truncate()}
-      </h2>
-      <Tooltip.Root>
-        <Tooltip.Content classNames='z-50'>{t('close label')}</Tooltip.Content>
-        <Tooltip.Trigger asChild>
-          {doneActionParent ? cloneElement(doneActionParent, {}, doneButton) : doneButton}
-        </Tooltip.Trigger>
-      </Tooltip.Root>
-    </div>
+    <h2 id={titleId} className={mx('font-medium text-center', !name && 'font-mono')}>
+      {name ?? space.key.truncate()}
+    </h2>
   );
 };
 

--- a/packages/sdk/react-shell/src/translations/locales/en-US.ts
+++ b/packages/sdk/react-shell/src/translations/locales/en-US.ts
@@ -80,4 +80,5 @@ export const os = {
   'space invitation list heading': 'Pending invitations',
   'device list heading': 'Devices',
   'space member list heading': 'Members in this space',
+  'space panel heading': 'Space settings',
 };


### PR DESCRIPTION
This PR addresses tasks from #3797:
- [x] “when opening a device join invitation url, shell panel opens with "an identity is required to continue" choice, it should proceed directly to the PIN instead”
- [x] Removes close button from non-alert OS dialogs

copilot:all
