### PR TITLE
feat(cli): Add replication progress to `space list` command

### DIFF
--- a/packages/devtools/cli/src/commands/space/list.ts
+++ b/packages/devtools/cli/src/commands/space/list.ts
@@ -7,7 +7,7 @@ import { ux } from '@oclif/core';
 import { Client } from '@dxos/client';
 
 import { BaseCommand } from '../../base-command';
-import { mapSpaces, printSpaces, waitForSpace } from '../../util';
+import { mapSpaces, printSpaces } from '../../util';
 
 export default class List extends BaseCommand<typeof List> {
   static override enableJsonFlag = true;
@@ -20,7 +20,6 @@ export default class List extends BaseCommand<typeof List> {
   async run(): Promise<any> {
     return await this.execWithClient(async (client: Client) => {
       const spaces = client.spaces.get();
-      await Promise.all(spaces.map((space) => waitForSpace(space, (err) => this.error(err))));
       if (!this.flags.json) {
         printSpaces(spaces, this.flags);
       }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 52acf29</samp>

### Summary
🚮🛠️📊

<!--
1.  🚮 - This emoji represents the removal of unused and redundant code, which can be seen as a form of cleaning or decluttering the codebase.
2.  🛠️ - This emoji represents the improvement and refactoring of existing functions, which can be seen as a form of fixing or enhancing the codebase.
3.  📊 - This emoji represents the addition of more details and metrics to the UI, which can be seen as a form of displaying or visualizing the data.
-->
Refactored and improved `space list` command and `SpacesPanel` UI. The command now has cleaner code and shows more space details. The UI now displays epoch stashed mutations and data progress percentage.

> _Oh we're the crew of the `space list` command_
> _We've trimmed the code and we've made it grand_
> _We've mapped and printed the spaces so fine_
> _And we've shown the progress on the pipeline_

### Walkthrough
*  Remove unused imports and functions from `packages/devtools/cli/src/commands/space/list.ts` and `packages/devtools/devtools/src/panels/echo/SpacesPanel.tsx` ([link](https://github.com/dxos/dxos/pull/3810/files?diff=unified&w=0#diff-4d506983059e822e97967df83e0a1179b52f4aa3ebe2a9a54c2439e04b897bbdL10-R10), [link](https://github.com/dxos/dxos/pull/3810/files?diff=unified&w=0#diff-8f4c5ee1e09d086e7bddab96a9dfff8b631186244120b53333ac9b80b31642b5L44-R79), [link](https://github.com/dxos/dxos/pull/3810/files?diff=unified&w=0#diff-e205a671db3f9b7e06c047134206fe951d18609c64d313009d101c79697c373aL10-R10), [link](https://github.com/dxos/dxos/pull/3810/files?diff=unified&w=0#diff-e205a671db3f9b7e06c047134206fe951d18609c64d313009d101c79697c373aL17-R17), [link](https://github.com/dxos/dxos/pull/3810/files?diff=unified&w=0#diff-e205a671db3f9b7e06c047134206fe951d18609c64d313009d101c79697c373aL250-L318))
*  Simplify and optimize the logic of the `List` command by removing the redundant `waitForSpace` function call ([link](https://github.com/dxos/dxos/pull/3810/files?diff=unified&w=0#diff-4d506983059e822e97967df83e0a1179b52f4aa3ebe2a9a54c2439e04b897bbdL23))
*  Enhance the functionality and usability of the `List` command by adding additional properties of the space pipeline to the output ([link](https://github.com/dxos/dxos/pull/3810/files?diff=unified&w=0#diff-8f4c5ee1e09d086e7bddab96a9dfff8b631186244120b53333ac9b80b31642b5R90-R117))
*  Align the UI of the `SpacesPanel` component with the CLI output and fix a potential bug with negative percentages by displaying the epoch stashed mutations property and using the absolute value of the data progress percentage calculation ([link](https://github.com/dxos/dxos/pull/3810/files?diff=unified&w=0#diff-e205a671db3f9b7e06c047134206fe951d18609c64d313009d101c79697c373aL58-R64))


