### PR TITLE
feat: CLI open/close space.

### DIFF
--- a/packages/devtools/cli/src/base-command.ts
+++ b/packages/devtools/cli/src/base-command.ts
@@ -382,8 +382,8 @@ export abstract class BaseCommand<T extends typeof Command = any> extends Comman
   /**
    * Get or select space.
    */
-  async getSpace(client: Client, key?: string): Promise<Space> {
-    const spaces = await this.getSpaces(client);
+  async getSpace(client: Client, key?: string, wait = true): Promise<Space> {
+    const spaces = await this.getSpaces(client, wait);
     if (!key) {
       key = await selectSpace(spaces);
     }
@@ -392,7 +392,10 @@ export abstract class BaseCommand<T extends typeof Command = any> extends Comman
     if (!space) {
       this.error(`Invalid key: ${key}`);
     } else {
-      await waitForSpace(space, this.flags.timeout, (err) => this.error(err));
+      if (wait && !this.flags['no-wait']) {
+        await waitForSpace(space, this.flags.timeout, (err) => this.error(err));
+      }
+
       return space;
     }
   }

--- a/packages/devtools/cli/src/base-command.ts
+++ b/packages/devtools/cli/src/base-command.ts
@@ -309,7 +309,7 @@ export abstract class BaseCommand<T extends typeof Command = any> extends Comman
     if (err instanceof SpaceWaitTimeoutError) {
       this.logToStderr(chalk`{red Error}: ${err.message} [still processing?]`);
     } else if (err instanceof AgentWaitTimeoutError) {
-      this.logToStderr(chalk`{red Error}: Agent is stale (restart with \n'dx agent restart --force')`);
+      this.logToStderr(chalk`{red Error}: Agent is stale (to restart: 'dx agent restart --force')`);
     } else {
       // Handle unknown errors with default method.
       super.error(err, options as any);

--- a/packages/devtools/cli/src/commands/reset/index.ts
+++ b/packages/devtools/cli/src/commands/reset/index.ts
@@ -29,7 +29,7 @@ export default class Reset extends BaseCommand<typeof Reset> {
           path.join(DX_CACHE, profile),
           path.join(DX_DATA, profile),
           path.join(DX_STATE, profile),
-          path.join(DX_RUNTIME, profile),
+          path.join(DX_RUNTIME, 'profile', profile),
           this.clientConfig?.get('runtime.client.storage.path'), // TODO(burdon): Duplicate of DX_RUNTIME?
         ].filter(Boolean) as string[],
       ),

--- a/packages/devtools/cli/src/commands/reset/index.ts
+++ b/packages/devtools/cli/src/commands/reset/index.ts
@@ -30,7 +30,7 @@ export default class Reset extends BaseCommand<typeof Reset> {
           path.join(DX_DATA, profile),
           path.join(DX_STATE, profile),
           path.join(DX_RUNTIME, 'profile', profile),
-          this.clientConfig?.get('runtime.client.storage.path'), // TODO(burdon): Duplicate of DX_RUNTIME?
+          this.clientConfig?.get('runtime.client.storage.path'),
         ].filter(Boolean) as string[],
       ),
     ];

--- a/packages/devtools/cli/src/commands/space/close.ts
+++ b/packages/devtools/cli/src/commands/space/close.ts
@@ -15,7 +15,7 @@ export default class Close extends BaseCommand<typeof Close> {
   async run(): Promise<any> {
     const { key } = this.args;
     return await this.execWithClient(async (client: Client) => {
-      const space = await this.getSpace(client, key);
+      const space = await this.getSpace(client, key, false);
       await space.internal.deactivate();
     });
   }

--- a/packages/devtools/cli/src/commands/space/close.ts
+++ b/packages/devtools/cli/src/commands/space/close.ts
@@ -16,7 +16,7 @@ export default class Close extends BaseCommand<typeof Close> {
     const { key } = this.args;
     return await this.execWithClient(async (client: Client) => {
       const space = await this.getSpace(client, key, false);
-      await space.internal.deactivate();
+      await space.internal.close();
     });
   }
 }

--- a/packages/devtools/cli/src/commands/space/close.ts
+++ b/packages/devtools/cli/src/commands/space/close.ts
@@ -16,7 +16,7 @@ export default class Close extends BaseCommand<typeof Close> {
     const { key } = this.args;
     return await this.execWithClient(async (client: Client) => {
       const space = await this.getSpace(client, key);
-      await space.close();
+      await space.internal.deactivate();
     });
   }
 }

--- a/packages/devtools/cli/src/commands/space/close.ts
+++ b/packages/devtools/cli/src/commands/space/close.ts
@@ -1,0 +1,22 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+import { Args } from '@oclif/core';
+
+import { Client } from '@dxos/client';
+
+import { BaseCommand } from '../../base-command';
+
+export default class Close extends BaseCommand<typeof Close> {
+  static override description = 'Close space.';
+  static override args = { key: Args.string() };
+
+  async run(): Promise<any> {
+    const { key } = this.args;
+    return await this.execWithClient(async (client: Client) => {
+      const space = await this.getSpace(client, key);
+      await space.close();
+    });
+  }
+}

--- a/packages/devtools/cli/src/commands/space/info.ts
+++ b/packages/devtools/cli/src/commands/space/info.ts
@@ -1,0 +1,30 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+import { Args } from '@oclif/core';
+
+import { Client } from '@dxos/client';
+
+import { BaseCommand } from '../../base-command';
+
+export default class Info extends BaseCommand<typeof Info> {
+  static override enableJsonFlag = true;
+  static override description = 'Show space info.';
+  static override args = { key: Args.string() };
+
+  async run(): Promise<any> {
+    const { key } = this.args;
+    return await this.execWithClient(async (client: Client) => {
+      const space = await this.getSpace(client, key);
+      await space.waitUntilReady();
+      // TODO(burdon): Factor out info (from diagnostics).
+      const data = space.internal.data.metrics;
+      if (this.flags.json) {
+        return data;
+      } else {
+        this.log(JSON.stringify(data, undefined, 2));
+      }
+    });
+  }
+}

--- a/packages/devtools/cli/src/commands/space/info.ts
+++ b/packages/devtools/cli/src/commands/space/info.ts
@@ -16,8 +16,8 @@ export default class Info extends BaseCommand<typeof Info> {
   async run(): Promise<any> {
     const { key } = this.args;
     return await this.execWithClient(async (client: Client) => {
-      const space = await this.getSpace(client, key);
-      await space.waitUntilReady();
+      const space = await this.getSpace(client, key, false);
+      // await space.waitUntilReady();
       // TODO(burdon): Factor out info (from diagnostics).
       const data = space.internal.data.metrics;
       if (this.flags.json) {

--- a/packages/devtools/cli/src/commands/space/open.ts
+++ b/packages/devtools/cli/src/commands/space/open.ts
@@ -16,7 +16,7 @@ export default class Open extends BaseCommand<typeof Open> {
     const { key } = this.args;
     return await this.execWithClient(async (client: Client) => {
       const space = await this.getSpace(client, key);
-      await space.open();
+      await space.internal.activate();
     });
   }
 }

--- a/packages/devtools/cli/src/commands/space/open.ts
+++ b/packages/devtools/cli/src/commands/space/open.ts
@@ -15,7 +15,7 @@ export default class Open extends BaseCommand<typeof Open> {
   async run(): Promise<any> {
     const { key } = this.args;
     return await this.execWithClient(async (client: Client) => {
-      const space = await this.getSpace(client, key);
+      const space = await this.getSpace(client, key, false);
       await space.internal.activate();
     });
   }

--- a/packages/devtools/cli/src/commands/space/open.ts
+++ b/packages/devtools/cli/src/commands/space/open.ts
@@ -1,0 +1,22 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+import { Args } from '@oclif/core';
+
+import { Client } from '@dxos/client';
+
+import { BaseCommand } from '../../base-command';
+
+export default class Open extends BaseCommand<typeof Open> {
+  static override description = 'Open space.';
+  static override args = { key: Args.string() };
+
+  async run(): Promise<any> {
+    const { key } = this.args;
+    return await this.execWithClient(async (client: Client) => {
+      const space = await this.getSpace(client, key);
+      await space.open();
+    });
+  }
+}

--- a/packages/devtools/cli/src/commands/space/open.ts
+++ b/packages/devtools/cli/src/commands/space/open.ts
@@ -16,7 +16,7 @@ export default class Open extends BaseCommand<typeof Open> {
     const { key } = this.args;
     return await this.execWithClient(async (client: Client) => {
       const space = await this.getSpace(client, key, false);
-      await space.internal.activate();
+      await space.internal.open();
     });
   }
 }

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel.tsx
@@ -52,7 +52,6 @@ const SpaceInfoPanel: FC = () => {
     const { open, ready } = space?.internal.data?.metrics ?? {};
     const startupTime = open && ready && ready.getTime() - open.getTime();
 
-    // TODO(burdon): List feeds and nav.
     return {
       id: metadata.key.truncate(),
       name: space.properties.name ?? humanize(metadata?.key),
@@ -72,15 +71,11 @@ const SpaceInfoPanel: FC = () => {
   }, [metadata, pipelineState, space]);
 
   const toggleActive = async () => {
-    if (!space) {
-      return;
-    }
-
-    const state = space.state.get();
+    const state = space!.state.get();
     if (state === SpaceState.INACTIVE) {
-      await space.internal.activate();
+      await space!.internal.open();
     } else {
-      await space.internal.deactivate();
+      await space!.internal.close();
     }
   };
 

--- a/packages/devtools/devtools/src/panels/echo/SpacesPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpacesPanel.tsx
@@ -23,9 +23,6 @@ const SpacesPanel: FC = () => {
   const setState = useDevtoolsDispatch();
 
   const handleSelect = (spaceKey: PublicKey) => {
-    const space = spaces.find((space) => space.key.equals(spaceKey));
-    console.log(space?.internal.data?.metrics);
-
     setState((state) => ({
       ...state,
       space: spaces.find((space) => space.key.equals(spaceKey))!,
@@ -36,9 +33,9 @@ const SpacesPanel: FC = () => {
   const handleToggleOpen = async (spaceKey: PublicKey) => {
     const space = spaces.find((space) => space.key.equals(spaceKey))!;
     if (space.isOpen) {
-      await space.internal.deactivate();
+      await space.internal.close();
     } else {
-      await space.internal.activate();
+      await space.internal.open();
     }
   };
 

--- a/packages/sdk/client-protocol/src/config.ts
+++ b/packages/sdk/client-protocol/src/config.ts
@@ -21,6 +21,8 @@ const HOME = typeof process !== 'undefined' ? process?.env?.HOME ?? '' : '';
 // https://wiki.archlinux.org/title/XDG_Base_Directory
 // Each `/dx` directory should contain `/profile/<DX_PROFILE>` subdirectories.
 
+// TODO(burdon): Add 'profile' to each path?
+
 // XDG_CONFIG_HOME (Analogous to /etc.)
 export const DX_CONFIG = `${HOME}/.config/dx`;
 

--- a/packages/sdk/client-protocol/src/space.ts
+++ b/packages/sdk/client-protocol/src/space.ts
@@ -75,6 +75,7 @@ export interface Space {
 
   // TODO(wittjosiah): Gather into messaging abstraction?
   postMessage: (channel: string, message: any) => Promise<void>;
+
   listen: (channel: string, callback: (message: GossipMessage) => void) => UnsubscribeCallback;
 
   createInvitation(options?: Partial<Invitation>): CancellableInvitationObservable;

--- a/packages/sdk/client-protocol/src/space.ts
+++ b/packages/sdk/client-protocol/src/space.ts
@@ -20,6 +20,7 @@ export interface SpaceInternal {
    * Activates the space enabling the use of the database and starts replication with peers.
    * The setting is persisted on the local device.
    */
+  // TODO(burdon): Rename open.
   activate(): Promise<void>;
 
   /**
@@ -27,6 +28,7 @@ export interface SpaceInternal {
    * The space will not auto-open on the next app launch.
    * The setting is persisted on the local device.
    */
+  // TODO(burdon): Rename Close.
   deactivate(): Promise<void>;
 
   // TODO(dmaretskyi): Return epoch info.

--- a/packages/sdk/client-protocol/src/space.ts
+++ b/packages/sdk/client-protocol/src/space.ts
@@ -20,16 +20,14 @@ export interface SpaceInternal {
    * Activates the space enabling the use of the database and starts replication with peers.
    * The setting is persisted on the local device.
    */
-  // TODO(burdon): Rename open.
-  activate(): Promise<void>;
+  open(): Promise<void>;
 
   /**
    * Deactivates the space stopping replication with other peers.
    * The space will not auto-open on the next app launch.
    * The setting is persisted on the local device.
    */
-  // TODO(burdon): Rename Close.
-  deactivate(): Promise<void>;
+  close(): Promise<void>;
 
   // TODO(dmaretskyi): Return epoch info.
   createEpoch(): Promise<void>;

--- a/packages/sdk/client-services/src/packlets/spaces/data-space.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space.ts
@@ -190,7 +190,7 @@ export class DataSpace {
         await this.initializeDataPipeline();
       } catch (err) {
         if (err instanceof CancelledError) {
-          log('Data pipeline initialization cancelled', err);
+          log('data pipeline initialization cancelled', err);
           return;
         }
 
@@ -205,7 +205,6 @@ export class DataSpace {
   }
 
   async initializeDataPipeline() {
-    console.log('>>>>', this._state);
     if (this._state !== SpaceState.CONTROL_ONLY) {
       throw new SystemError('Invalid operation');
     }
@@ -219,7 +218,7 @@ export class DataSpace {
     this.metrics.controlPipelineReady = new Date();
 
     await this._createWritableFeeds();
-    log('Writable feeds created');
+    log('writable feeds created');
     this.stateUpdate.emit();
 
     if (!this.notarizationPlugin.hasWriter) {
@@ -334,7 +333,6 @@ export class DataSpace {
 
   @synchronized
   async activate() {
-    console.log('>>>>', this._state);
     if (this._state !== SpaceState.INACTIVE) {
       return;
     }
@@ -346,7 +344,6 @@ export class DataSpace {
 
   @synchronized
   async deactivate() {
-    console.log('>>>>', this._state);
     if (this._state === SpaceState.INACTIVE) {
       return;
     }

--- a/packages/sdk/client-services/src/packlets/spaces/data-space.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space.ts
@@ -205,11 +205,12 @@ export class DataSpace {
   }
 
   async initializeDataPipeline() {
+    console.log('>>>>', this._state);
     if (this._state !== SpaceState.CONTROL_ONLY) {
       throw new SystemError('Invalid operation');
     }
-    this._state = SpaceState.INITIALIZING;
 
+    this._state = SpaceState.INITIALIZING;
     await this._inner.controlPipeline.state.waitUntilReachedTargetTimeframe({
       ctx: this._ctx,
       breakOnStall: false,
@@ -323,7 +324,6 @@ export class DataSpace {
     });
 
     await this.inner.controlPipeline.state.waitUntilTimeframe(new Timeframe([[receipt.feedKey, receipt.seq]]));
-
     for (const feed of this.inner.dataPipeline.pipelineState?.feeds ?? []) {
       const indexBeforeEpoch = epoch.timeframe.get(feed.key);
       if (indexBeforeEpoch) {
@@ -334,8 +334,9 @@ export class DataSpace {
 
   @synchronized
   async activate() {
+    console.log('>>>>', this._state);
     if (this._state !== SpaceState.INACTIVE) {
-      throw new SystemError('Invalid operation');
+      return;
     }
 
     await this._metadataStore.setSpaceState(this.key, SpaceState.ACTIVE);
@@ -345,11 +346,12 @@ export class DataSpace {
 
   @synchronized
   async deactivate() {
+    console.log('>>>>', this._state);
     if (this._state === SpaceState.INACTIVE) {
-      throw new SystemError('Invalid operation');
+      return;
     }
 
-    // de-register from data service
+    // Unregister from data service.
     await this._metadataStore.setSpaceState(this.key, SpaceState.INACTIVE);
     await this._close();
     this._state = SpaceState.INACTIVE;

--- a/packages/sdk/client/src/echo/space-proxy.ts
+++ b/packages/sdk/client/src/echo/space-proxy.ts
@@ -97,8 +97,8 @@ export class SpaceProxy implements Space {
         return self._data;
       },
       createEpoch: this._createEpoch.bind(this),
-      activate: this._activate.bind(this),
-      deactivate: this._deactivate.bind(this),
+      open: this._activate.bind(this),
+      close: this._deactivate.bind(this),
     };
 
     this._error = this._data.error ? decodeError(this._data.error) : undefined;

--- a/packages/sdk/client/src/tests/spaces.test.ts
+++ b/packages/sdk/client/src/tests/spaces.test.ts
@@ -221,13 +221,13 @@ describe('Spaces', () => {
     const { id } = space.db.add(new Expando({ data: 'test' }));
     await space.db.flush();
 
-    await space.internal.deactivate();
+    await space.internal.close();
     // Since updates are throttled we need to wait for the state to change.
     await waitForExpect(() => {
       expect(space.state.get()).to.equal(SpaceState.INACTIVE);
     }, 1000);
 
-    await space.internal.activate();
+    await space.internal.open();
     await space.waitUntilReady();
     await waitForExpect(() => {
       expect(space.state.get()).to.equal(SpaceState.READY);


### PR DESCRIPTION
- [ ] open/close
- [ ] show info
- [ ] factor out info from diagnostics, etc.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1bec6fc</samp>

### Summary
🔒📊🔓

<!--
1.  🔒 for `space:close`, since it locks the space and prevents further operations on it.
2.  📊 for `space:info`, since it shows statistics and data about the space.
3.  🔓 for `space:open`, since it unlocks the space and allows operations on it.
-->
This pull request adds three new commands to the `dxos` CLI for managing spaces: `space:open`, `space:close`, and `space:info`. These commands enable users to control the lifecycle and inspect the status of spaces.

> _`space` commands added_
> _open, close, and info_
> _autumn cleaning time_

### Walkthrough
*  Add commands for opening, closing, and showing information about spaces ([link](https://github.com/dxos/dxos/pull/3817/files?diff=unified&w=0#diff-5163ae4aee6537c875f6f8382cdc60544bea2e0e2dfb19d2484c4abfc0090fbcR1-R22), [link](https://github.com/dxos/dxos/pull/3817/files?diff=unified&w=0#diff-8b14e12b9b5f0e94b4083ef3e924cf9c6db3457e86b7d859dd333b823a3d6412R1-R30), [link](https://github.com/dxos/dxos/pull/3817/files?diff=unified&w=0#diff-abef606f9e56f397fb5292fcc7231ecdcba4401c96e60358a30e565c91ebb5f8R1-R22))


