### PR TITLE
feat: chunks in teleport

### DIFF
--- a/packages/core/echo/echo-pipeline/src/space/space-protocol.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space-protocol.ts
@@ -17,7 +17,7 @@ import {
 } from '@dxos/network-manager';
 import { ConnectionInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
 import type { FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
-import { Teleport } from '@dxos/teleport';
+import { MuxerStats, Teleport } from '@dxos/teleport';
 import { BlobStore, BlobSync } from '@dxos/teleport-extension-object-sync';
 import { ReplicatorExtension } from '@dxos/teleport-extension-replicator';
 import { ComplexMap } from '@dxos/util';
@@ -206,7 +206,7 @@ export class SpaceProtocolSession implements WireProtocol {
     return this._authStatus;
   }
 
-  get stats(): Event<ConnectionInfo.StreamStats[]> {
+  get stats(): Event<MuxerStats> {
     return this._teleport.stats;
   }
 

--- a/packages/core/echo/echo-pipeline/src/space/space-protocol.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space-protocol.ts
@@ -15,7 +15,6 @@ import {
   WireProtocolParams,
   WireProtocolProvider,
 } from '@dxos/network-manager';
-import { ConnectionInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
 import type { FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
 import { MuxerStats, Teleport } from '@dxos/teleport';
 import { BlobStore, BlobSync } from '@dxos/teleport-extension-object-sync';

--- a/packages/core/mesh/network-manager/src/connection-log.ts
+++ b/packages/core/mesh/network-manager/src/connection-log.ts
@@ -10,6 +10,7 @@ import { ComplexMap } from '@dxos/util';
 
 import { ConnectionState, Swarm } from './swarm';
 import { WireProtocol } from './wire-protocol';
+import { MuxerStats } from '@dxos/teleport';
 
 export enum EventType {
   CONNECTION_STATE_CHANGED = 'CONNECTION_STATE_CHANGED',
@@ -68,8 +69,8 @@ export class ConnectionLog {
         this.update.emit();
       });
 
-      (connection.protocol as WireProtocol & { stats: Event<ConnectionInfo.StreamStats[]> })?.stats?.on((stats) => {
-        connectionInfo.streams = stats;
+      (connection.protocol as WireProtocol & { stats: Event<MuxerStats> })?.stats?.on((stats) => {
+        connectionInfo.streams = stats.channels;
         this.update.emit();
       });
 

--- a/packages/core/mesh/network-manager/src/connection-log.ts
+++ b/packages/core/mesh/network-manager/src/connection-log.ts
@@ -6,11 +6,11 @@ import { Event } from '@dxos/async';
 import { raise } from '@dxos/debug';
 import { PublicKey } from '@dxos/keys';
 import { SwarmInfo, ConnectionInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
+import { MuxerStats } from '@dxos/teleport';
 import { ComplexMap } from '@dxos/util';
 
 import { ConnectionState, Swarm } from './swarm';
 import { WireProtocol } from './wire-protocol';
-import { MuxerStats } from '@dxos/teleport';
 
 export enum EventType {
   CONNECTION_STATE_CHANGED = 'CONNECTION_STATE_CHANGED',

--- a/packages/core/mesh/teleport/src/muxing/balancer.test.ts
+++ b/packages/core/mesh/teleport/src/muxing/balancer.test.ts
@@ -25,26 +25,26 @@ describe('Balancer', () => {
 
   it('should correctly encode and decode a chunk without dataLength', () => {
     const channelId = 1;
-    const data = Uint8Array.from([0x11, 0x22, 0x33]);
+    const chunk = Uint8Array.from([0x11, 0x22, 0x33]);
 
-    const encoded = encodeChunk(data, channelId);
+    const encoded = encodeChunk({ chunk, channelId });
     const decoded = decodeChunk(encoded, () => false);
 
     expect(decoded.channelId).to.equal(channelId);
     expect(decoded.dataLength).to.equal(undefined);
-    expect(decoded.chunk).to.deep.equal(Buffer.from(data));
+    expect(decoded.chunk).to.deep.equal(chunk);
   });
 
   it('should correctly encode and decode a chunk with dataLength', () => {
     const channelId = 2;
-    const data = Uint8Array.from([0x44, 0x55, 0x66]);
-    const dataLength = data.length;
+    const chunk = Uint8Array.from([0x44, 0x55, 0x66]);
+    const dataLength = chunk.length;
 
-    const encoded = encodeChunk(data, channelId, dataLength);
+    const encoded = encodeChunk({ chunk, channelId, dataLength });
     const decoded = decodeChunk(encoded, (channelId) => channelId === 2);
 
     expect(decoded.channelId).to.equal(channelId);
     expect(decoded.dataLength).to.equal(dataLength);
-    expect(decoded.chunk).to.deep.equal(Buffer.from(data));
+    expect(decoded.chunk).to.deep.equal(chunk);
   });
 });

--- a/packages/core/mesh/teleport/src/muxing/balancer.test.ts
+++ b/packages/core/mesh/teleport/src/muxing/balancer.test.ts
@@ -32,7 +32,7 @@ describe('Balancer', () => {
 
     expect(decoded.channelId).to.equal(channelId);
     expect(decoded.dataLength).to.equal(undefined);
-    expect(decoded.data).to.deep.equal(Buffer.from(data));
+    expect(decoded.chunk).to.deep.equal(Buffer.from(data));
   });
 
   it('should correctly encode and decode a chunk with dataLength', () => {
@@ -45,6 +45,6 @@ describe('Balancer', () => {
 
     expect(decoded.channelId).to.equal(channelId);
     expect(decoded.dataLength).to.equal(dataLength);
-    expect(decoded.data).to.deep.equal(Buffer.from(data));
+    expect(decoded.chunk).to.deep.equal(Buffer.from(data));
   });
 });

--- a/packages/core/mesh/teleport/src/muxing/balancer.test.ts
+++ b/packages/core/mesh/teleport/src/muxing/balancer.test.ts
@@ -1,0 +1,50 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { expect } from 'chai';
+import * as varint from 'varint';
+
+import { describe, test } from '@dxos/test';
+
+import { encodeChunk, decodeChunk } from './balancer';
+
+describe('Balancer', () => {
+  test('varints', () => {
+    const values = [0, 1, 5, 127, 128, 255, 256, 257, 1024, 1024 * 1024];
+    for (const value of values) {
+      const encoded = varint.encode(value, Buffer.allocUnsafe(4)).slice(0, varint.encode.bytes);
+      const length = varint.encode.bytes;
+      expect(encoded.length).to.eq(length);
+
+      const decoded = varint.decode(encoded);
+      expect(decoded).to.equal(value);
+      expect(varint.decode.bytes).to.equal(length);
+    }
+  });
+
+  it('should correctly encode and decode a chunk without dataLength', () => {
+    const channelId = 1;
+    const data = Uint8Array.from([0x11, 0x22, 0x33]);
+
+    const encoded = encodeChunk(data, channelId);
+    const decoded = decodeChunk(encoded, () => false);
+
+    expect(decoded.channelId).to.equal(channelId);
+    expect(decoded.dataLength).to.equal(undefined);
+    expect(decoded.data).to.deep.equal(Buffer.from(data));
+  });
+
+  it('should correctly encode and decode a chunk with dataLength', () => {
+    const channelId = 2;
+    const data = Uint8Array.from([0x44, 0x55, 0x66]);
+    const dataLength = data.length;
+
+    const encoded = encodeChunk(data, channelId, dataLength);
+    const decoded = decodeChunk(encoded, (channelId) => channelId === 2);
+
+    expect(decoded.channelId).to.equal(channelId);
+    expect(decoded.dataLength).to.equal(dataLength);
+    expect(decoded.data).to.deep.equal(Buffer.from(data));
+  });
+});

--- a/packages/core/mesh/teleport/src/muxing/balancer.ts
+++ b/packages/core/mesh/teleport/src/muxing/balancer.ts
@@ -9,7 +9,7 @@ import { log } from '@dxos/log';
 
 import { Framer } from './framer';
 
-const MAX_CHUNK_SIZE = 4096;
+const MAX_CHUNK_SIZE = 8192;
 
 type Chunk = {
   msg: Buffer;

--- a/packages/core/mesh/teleport/src/muxing/framer.test.ts
+++ b/packages/core/mesh/teleport/src/muxing/framer.test.ts
@@ -5,7 +5,6 @@
 import { expect } from 'chai';
 import { pipeline } from 'node:stream';
 import randomBytes from 'randombytes';
-import * as varint from 'varint';
 import waitForExpect from 'wait-for-expect';
 
 import { sleep } from '@dxos/async';
@@ -50,19 +49,6 @@ const pipe = (a: NodeJS.ReadWriteStream, b: NodeJS.ReadWriteStream): (() => void
 };
 
 describe('Framer', () => {
-  test('varints', () => {
-    const values = [0, 1, 5, 127, 128, 255, 256, 257, 1024, 1024 * 60];
-    for (const value of values) {
-      const encoded = varint.encode(value, Buffer.allocUnsafe(4)).slice(0, varint.encode.bytes);
-      const length = varint.encode.bytes;
-      expect(encoded.length).to.eq(length);
-
-      const decoded = varint.decode(encoded);
-      expect(decoded).to.equal(value);
-      expect(varint.decode.bytes).to.equal(length);
-    }
-  });
-
   test('frame encoding', () => {
     const sizes = [0, 1, 5, 127, 128, 255, 256, 257, 1024, 1024 * 60];
     for (const size of sizes) {

--- a/packages/core/mesh/teleport/src/muxing/framer.test.ts
+++ b/packages/core/mesh/teleport/src/muxing/framer.test.ts
@@ -51,7 +51,7 @@ const pipe = (a: NodeJS.ReadWriteStream, b: NodeJS.ReadWriteStream): (() => void
 
 describe('Framer', () => {
   test('varints', () => {
-    const values = [0, 1, 5, 127, 128, 255, 256, 257, 1024, 1024 * 1024];
+    const values = [0, 1, 5, 127, 128, 255, 256, 257, 1024, 1024 * 60];
     for (const value of values) {
       const encoded = varint.encode(value, Buffer.allocUnsafe(4)).slice(0, varint.encode.bytes);
       const length = varint.encode.bytes;
@@ -64,7 +64,7 @@ describe('Framer', () => {
   });
 
   test('frame encoding', () => {
-    const sizes = [0, 1, 5, 127, 128, 255, 256, 257, 1024, 1024 * 1024];
+    const sizes = [0, 1, 5, 127, 128, 255, 256, 257, 1024, 1024 * 60];
     for (const size of sizes) {
       const payload = randomBytes(size);
       const frame = encodeFrame(payload);

--- a/packages/core/mesh/teleport/src/muxing/framer.ts
+++ b/packages/core/mesh/teleport/src/muxing/framer.ts
@@ -54,7 +54,7 @@ export class Framer {
         if (!canContinue) {
           this._responseQueue.push(resolve);
         } else {
-          process.nextTick(resolve);
+          resolve();
         }
       });
     },

--- a/packages/core/mesh/teleport/src/muxing/framer.ts
+++ b/packages/core/mesh/teleport/src/muxing/framer.ts
@@ -90,9 +90,6 @@ export class Framer {
     return this._bytesReceived;
   }
 
-  constructor() {
-  }
-
   private _processResponseQueue() {
     const responseQueue = this._sendCallbacks;
     this._sendCallbacks = [];

--- a/packages/core/mesh/teleport/src/muxing/muxer.ts
+++ b/packages/core/mesh/teleport/src/muxing/muxer.ts
@@ -37,7 +37,7 @@ export type MuxerStats = {
   bytesReceived: number;
 }
 
-const STATS_INTERVAL = 100;
+const STATS_INTERVAL = 1000;
 
 const SYSTEM_CHANNEL_ID = 0;
 

--- a/packages/core/mesh/teleport/src/muxing/muxer.ts
+++ b/packages/core/mesh/teleport/src/muxing/muxer.ts
@@ -33,7 +33,7 @@ export type CreateChannelOpts = {
 
 const STATS_INTERVAL = 1000;
 
-const SYSTEM_CHANNEL_ID = -1;
+const SYSTEM_CHANNEL_ID = 0;
 
 /**
  * Channel based multiplexer.
@@ -51,7 +51,7 @@ export class Muxer {
   private readonly _channelsByTag = new Map<string, Channel>();
   private readonly _ctx = new Context();
 
-  private _nextId = 0;
+  private _nextId = 1;
   private _destroyed = false;
   private _destroying = false;
 

--- a/packages/core/mesh/teleport/src/muxing/muxer.ts
+++ b/packages/core/mesh/teleport/src/muxing/muxer.ts
@@ -271,7 +271,7 @@ export class Muxer {
   private async _sendCommand(cmd: Command, channelId = -1) {
     try {
       const trigger = new Trigger<void>();
-      this._balancer.pushChunk(Command.encode(cmd), trigger, channelId);
+      this._balancer.pushData(Command.encode(cmd), trigger, channelId);
       await trigger.wait();
     } catch (err: any) {
       this.destroy(err);

--- a/packages/core/mesh/teleport/src/muxing/muxer.ts
+++ b/packages/core/mesh/teleport/src/muxing/muxer.ts
@@ -35,7 +35,7 @@ export type MuxerStats = {
   channels: ConnectionInfo.StreamStats[];
   bytesSent: number;
   bytesReceived: number;
-}
+};
 
 const STATS_INTERVAL = 1000;
 
@@ -350,7 +350,7 @@ export class Muxer {
         bytesReceived: channel.stats.bytesReceived,
       })),
       bytesSent,
-      bytesReceived, 
+      bytesReceived,
     });
   }
 }

--- a/packages/core/mesh/teleport/src/muxing/muxer.ts
+++ b/packages/core/mesh/teleport/src/muxing/muxer.ts
@@ -39,6 +39,8 @@ export type MuxerStats = {
 
 const STATS_INTERVAL = 1000;
 
+const MAX_SAFE_FRAME_SIZE = 1_000_000;
+
 const SYSTEM_CHANNEL_ID = 0;
 
 /**
@@ -308,6 +310,10 @@ export class Muxer {
   }
 
   private async _sendData(channel: Channel, data: Uint8Array): Promise<void> {
+    if (data.length > MAX_SAFE_FRAME_SIZE) {
+      log.warn('frame size exceeds maximum safe value', { size: data.length, threshold: MAX_SAFE_FRAME_SIZE });
+    }
+
     channel.stats.bytesSent += data.length;
     if (channel.remoteId === null) {
       // Remote side has not opened the channel yet.

--- a/packages/core/mesh/teleport/src/teleport.ts
+++ b/packages/core/mesh/teleport/src/teleport.ts
@@ -11,7 +11,6 @@ import { failUndefined } from '@dxos/debug';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { schema, RpcClosedError } from '@dxos/protocols';
-import { ConnectionInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
 import { ControlService } from '@dxos/protocols/proto/dxos/mesh/teleport/control';
 import { createProtoRpcPeer, ProtoRpcPeer } from '@dxos/rpc';
 import { Callback } from '@dxos/util';
@@ -92,7 +91,7 @@ export class Teleport {
         bytesSent: stats.bytesSent,
         bytesReceived: stats.bytesReceived,
         channels: stats.channels,
-      })
+      });
     });
   }
 

--- a/packages/core/mesh/teleport/src/teleport.ts
+++ b/packages/core/mesh/teleport/src/teleport.ts
@@ -16,7 +16,7 @@ import { ControlService } from '@dxos/protocols/proto/dxos/mesh/teleport/control
 import { createProtoRpcPeer, ProtoRpcPeer } from '@dxos/rpc';
 import { Callback } from '@dxos/util';
 
-import { CreateChannelOpts, Muxer, RpcPort } from './muxing';
+import { CreateChannelOpts, Muxer, MuxerStats, RpcPort } from './muxing';
 
 export type TeleportParams = {
   initiator: boolean;
@@ -84,13 +84,23 @@ export class Teleport {
         await this.destroy(err);
       });
     }
+
+    this._muxer.statsUpdated.on((stats) => {
+      log.trace('dxos.mesh.teleport.stats', {
+        localPeerId,
+        remotePeerId,
+        bytesSent: stats.bytesSent,
+        bytesReceived: stats.bytesReceived,
+        channels: stats.channels,
+      })
+    });
   }
 
   get stream(): Duplex {
     return this._muxer.stream;
   }
 
-  get stats(): Event<ConnectionInfo.StreamStats[]> {
+  get stats(): Event<MuxerStats> {
     return this._muxer.statsUpdated;
   }
 

--- a/packages/core/mesh/teleport/src/testing/test-extension-with-streams.ts
+++ b/packages/core/mesh/teleport/src/testing/test-extension-with-streams.ts
@@ -84,6 +84,11 @@ export class TestExtensionWithStreams implements TeleportExtension {
     networkStream.on('close', () => {
       networkStream.removeAllListeners();
     });
+
+    streamEntry.reportingTimer = setInterval(() => {
+      const { bytesSent, bytesReceived, sendErrors, receiveErrors } = streamEntry;
+      log.info('stream stats', { streamTag, bytesSent, bytesReceived, sendErrors, receiveErrors });
+    }, 1000)
   }
 
   private _closeStream(streamTag: string): Stats {
@@ -92,6 +97,7 @@ export class TestExtensionWithStreams implements TeleportExtension {
     const stream = this._streams.get(streamTag)!;
 
     clearTimeout(stream.timer);
+    clearTimeout(stream.reportingTimer);
 
     const { bytesSent, bytesReceived, sendErrors, receiveErrors, startTimestamp } = stream;
 
@@ -244,4 +250,5 @@ type TestStream = {
   receiveErrors: number;
   timer?: NodeJS.Timer;
   startTimestamp?: number;
+  reportingTimer?: NodeJS.Timer;
 };

--- a/packages/core/mesh/teleport/src/testing/test-extension-with-streams.ts
+++ b/packages/core/mesh/teleport/src/testing/test-extension-with-streams.ts
@@ -88,8 +88,16 @@ export class TestExtensionWithStreams implements TeleportExtension {
     streamEntry.reportingTimer = setInterval(() => {
       const { bytesSent, bytesReceived, sendErrors, receiveErrors } = streamEntry;
       // log.info('stream stats', { streamTag, bytesSent, bytesReceived, sendErrors, receiveErrors });
-        log.trace('dxos.test.stream-stats', { streamTag, bytesSent, bytesReceived, sendErrors, receiveErrors, from: this.extensionContext?.localPeerId, to: this.extensionContext?.remotePeerId });
-    }, 100)
+      log.trace('dxos.test.stream-stats', {
+        streamTag,
+        bytesSent,
+        bytesReceived,
+        sendErrors,
+        receiveErrors,
+        from: this.extensionContext?.localPeerId,
+        to: this.extensionContext?.remotePeerId,
+      });
+    }, 100);
   }
 
   private _closeStream(streamTag: string): Stats {

--- a/packages/core/mesh/teleport/src/testing/test-extension-with-streams.ts
+++ b/packages/core/mesh/teleport/src/testing/test-extension-with-streams.ts
@@ -87,8 +87,9 @@ export class TestExtensionWithStreams implements TeleportExtension {
 
     streamEntry.reportingTimer = setInterval(() => {
       const { bytesSent, bytesReceived, sendErrors, receiveErrors } = streamEntry;
-      log.info('stream stats', { streamTag, bytesSent, bytesReceived, sendErrors, receiveErrors });
-    }, 1000)
+      // log.info('stream stats', { streamTag, bytesSent, bytesReceived, sendErrors, receiveErrors });
+        log.trace('dxos.test.stream-stats', { streamTag, bytesSent, bytesReceived, sendErrors, receiveErrors, from: this.extensionContext?.localPeerId, to: this.extensionContext?.remotePeerId });
+    }, 100)
   }
 
   private _closeStream(streamTag: string): Stats {

--- a/packages/core/protocols/src/proto/dxos/devtools/swarm.proto
+++ b/packages/core/protocols/src/proto/dxos/devtools/swarm.proto
@@ -22,6 +22,7 @@ message ConnectionInfo {
     string tag = 2;
     uint32 bytesSent = 3;
     uint32 bytesReceived = 4;
+    optional string contentType = 5;
   }
 
   string state = 1;

--- a/packages/gravity/kube-testing/src/analysys/plot.ts
+++ b/packages/gravity/kube-testing/src/analysys/plot.ts
@@ -1,0 +1,32 @@
+import { ChartConfiguration } from 'chart.js';
+import { ChartJSNodeCanvas, ChartJSNodeCanvasOptions } from 'chartjs-node-canvas';
+import { exec } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+
+export const renderPNG = async (
+  configuration: ChartConfiguration,
+  opts: ChartJSNodeCanvasOptions = { width: 1920, height: 1080, backgroundColour: 'white' },
+) => {
+  // Uses https://www.w3schools.com/tags/canvas_fillstyle.asp
+  const chartJSNodeCanvas = new ChartJSNodeCanvas(opts);
+
+  const image = await chartJSNodeCanvas.renderToBuffer(configuration as any);
+  return image;
+};
+
+export const showPng = (data: Buffer) => {
+  const filename = `/tmp/${Math.random().toString(36).substring(7)}.png`;
+  writeFileSync(filename, data);
+  exec(`open ${filename}`);
+};
+
+export const BORDER_COLORS = [
+  'rgb(54, 162, 235)', // blue
+  'rgb(255, 99, 132)', // red
+  'rgb(255, 159, 64)', // orange
+  'rgb(255, 205, 86)', // yellow
+  'rgb(75, 192, 192)', // green
+  'rgb(153, 102, 255)', // purple
+  'rgb(201, 203, 207)', // grey
+];

--- a/packages/gravity/kube-testing/src/analysys/plot.ts
+++ b/packages/gravity/kube-testing/src/analysys/plot.ts
@@ -1,8 +1,11 @@
+//
+// Copyright 2023 DXOS.org
+//
+
 import { ChartConfiguration } from 'chart.js';
 import { ChartJSNodeCanvas, ChartJSNodeCanvasOptions } from 'chartjs-node-canvas';
 import { exec } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
-
 
 export const renderPNG = async (
   configuration: ChartConfiguration,

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -71,8 +71,8 @@ const runTransport = () =>
   runPlan({
     plan: new TransportTestPlan(),
     spec: {
-      agents: 2,
-      swarmsPerAgent: 3,
+      agents: 4,
+      swarmsPerAgent: 5,
       duration: 240_000,
       targetSwarmTimeout: 10_000,
       fullSwarmTimeout: 60_000,

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -80,13 +80,13 @@ const runTransport = () =>
       streamsDelay: 60_000,
       signalArguments: ['globalsubserver'],
       repeatInterval: 5_000,
-      streamLoadInterval: 10,
-      streamLoadChunkSize: 100_000,
+      streamLoadInterval: 1,
+      streamLoadChunkSize: 5_000_000,
     },
     options: {
       staggerAgents: 1000,
       randomSeed: PublicKey.random().toHex(),
-      profile: true,
+      // profile: true,
       // repeatAnalysis:
       // '/Users/dmaretskyi/Projects/protocols/packages/gravity/kube-testing/out/results/2023-08-09T11:36:28-784ae212/test.json'
     },

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -73,14 +73,14 @@ const runTransport = () =>
     spec: {
       agents: 2,
       swarmsPerAgent: 1,
-      duration: 120_000,
+      duration: 60_000,
       targetSwarmTimeout: 10_000,
       fullSwarmTimeout: 60_000,
       iterationDelay: 1_000,
       streamsDelay: 60_000,
       signalArguments: ['globalsubserver'],
       repeatInterval: 5_000,
-      streamLoadInterval: 1,
+      streamLoadInterval: 10,
       streamLoadChunkSize: 100_000,
     },
     options: {
@@ -88,7 +88,7 @@ const runTransport = () =>
       randomSeed: PublicKey.random().toHex(),
       profile: true,
       // repeatAnalysis:
-      //   '/Users/dmaretskyi/Projects/protocols/packages/gravity/kube-testing/out/results/2023-05-13T16:08:09-f0ba/test.json'
+      // '/Users/dmaretskyi/Projects/protocols/packages/gravity/kube-testing/out/results/2023-08-09T11:36:28-784ae212/test.json'
     },
   });
 

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -71,17 +71,17 @@ const runTransport = () =>
   runPlan({
     plan: new TransportTestPlan(),
     spec: {
-      agents: 4,
-      swarmsPerAgent: 5,
-      duration: 240_000,
+      agents: 2,
+      swarmsPerAgent: 1,
+      duration: 120_000,
       targetSwarmTimeout: 10_000,
       fullSwarmTimeout: 60_000,
       iterationDelay: 1_000,
-      streamsDelay: 5_000,
+      streamsDelay: 60_000,
       signalArguments: ['globalsubserver'],
       repeatInterval: 5_000,
       streamLoadInterval: 1,
-      streamLoadChunkSize: 50000,
+      streamLoadChunkSize: 100_000,
     },
     options: {
       staggerAgents: 1000,
@@ -93,4 +93,4 @@ const runTransport = () =>
   });
 
 // void runEcho();
-void runEcho();
+void runTransport();

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -81,7 +81,7 @@ const runTransport = () =>
       signalArguments: ['globalsubserver'],
       repeatInterval: 5_000,
       streamLoadInterval: 1,
-      streamLoadChunkSize: 1024,
+      streamLoadChunkSize: 50000,
     },
     options: {
       staggerAgents: 1000,

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -71,8 +71,8 @@ const runTransport = () =>
   runPlan({
     plan: new TransportTestPlan(),
     spec: {
-      agents: 4,
-      swarmsPerAgent: 5,
+      agents: 2,
+      swarmsPerAgent: 3,
       duration: 240_000,
       targetSwarmTimeout: 10_000,
       fullSwarmTimeout: 60_000,

--- a/packages/gravity/kube-testing/src/plan/echo-spec.ts
+++ b/packages/gravity/kube-testing/src/plan/echo-spec.ts
@@ -338,4 +338,3 @@ type SyncTimeLog = {
   agentIdx: number;
   iter: number;
 };
-

--- a/packages/gravity/kube-testing/src/plan/echo-spec.ts
+++ b/packages/gravity/kube-testing/src/plan/echo-spec.ts
@@ -2,11 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ChartConfiguration } from 'chart.js';
-import { ChartJSNodeCanvas, ChartJSNodeCanvasOptions } from 'chartjs-node-canvas';
-import { exec } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
-import { writeFileSync } from 'node:fs';
 
 import { scheduleTaskInterval, sleep } from '@dxos/async';
 import { Client, Config } from '@dxos/client';
@@ -25,6 +21,7 @@ import { Timeframe } from '@dxos/timeframe';
 import { randomInt, range } from '@dxos/util';
 
 import { SerializedLogEntry, getReader } from '../analysys';
+import { BORDER_COLORS, renderPNG, showPng } from '../analysys/plot';
 import { TestBuilder as SignalTestBuilder } from '../test-builder';
 import { AgentEnv } from './agent-env';
 import { PlanResults, TestParams, TestPlan } from './spec-base';
@@ -342,29 +339,3 @@ type SyncTimeLog = {
   iter: number;
 };
 
-const renderPNG = async (
-  configuration: ChartConfiguration,
-  opts: ChartJSNodeCanvasOptions = { width: 1920, height: 1080, backgroundColour: 'white' },
-) => {
-  // Uses https://www.w3schools.com/tags/canvas_fillstyle.asp
-  const chartJSNodeCanvas = new ChartJSNodeCanvas(opts);
-
-  const image = await chartJSNodeCanvas.renderToBuffer(configuration as any);
-  return image;
-};
-
-const showPng = (data: Buffer) => {
-  const filename = `/tmp/${Math.random().toString(36).substring(7)}.png`;
-  writeFileSync(filename, data);
-  exec(`open ${filename}`);
-};
-
-const BORDER_COLORS = [
-  'rgb(54, 162, 235)', // blue
-  'rgb(255, 99, 132)', // red
-  'rgb(255, 159, 64)', // orange
-  'rgb(255, 205, 86)', // yellow
-  'rgb(75, 192, 192)', // green
-  'rgb(153, 102, 255)', // purple
-  'rgb(201, 203, 207)', // grey
-];

--- a/packages/gravity/kube-testing/src/plan/transport-spec.ts
+++ b/packages/gravity/kube-testing/src/plan/transport-spec.ts
@@ -368,15 +368,15 @@ export class TransportTestPlan implements TestPlan<TransportTestSpec, TransportA
               })),
               backgroundColor: BORDER_COLORS[colorIdx++ % BORDER_COLORS.length],
             })),
-            ...Array.from(muxerStats.entries()).map(([key, entries]) => ({
-              label: `${key}-received`,
-              showLine: true,
-              data: entries.map((entry) => ({
-                x: entry.timestamp,
-                y: entry.context.bytesReceived,
-              })),
-              backgroundColor: BORDER_COLORS[colorIdx++ % BORDER_COLORS.length],
-            })),
+            // ...Array.from(muxerStats.entries()).map(([key, entries]) => ({
+            //   label: `${key}-received`,
+            //   showLine: true,
+            //   data: entries.map((entry) => ({
+            //     x: entry.timestamp,
+            //     y: entry.context.bytesReceived,
+            //   })),
+            //   backgroundColor: BORDER_COLORS[colorIdx++ % BORDER_COLORS.length],
+            // })),
             ...Array.from(testStats.entries()).map(([key, entries]) => ({
               label: `${key}-sent`,
               showLine: true,
@@ -387,15 +387,15 @@ export class TransportTestPlan implements TestPlan<TransportTestSpec, TransportA
               backgroundColor: BORDER_COLORS[colorIdx++ % BORDER_COLORS.length],
 
             })),
-            ...Array.from(testStats.entries()).map(([key, entries]) => ({
-              label: `${key}-received`,
-              showLine: true,
-              data: entries.map((entry) => ({
-                x: entry.timestamp,
-                y: entry.context.bytesReceived,
-              })),
-              backgroundColor: BORDER_COLORS[colorIdx++ % BORDER_COLORS.length],
-            })),
+            // ...Array.from(testStats.entries()).map(([key, entries]) => ({
+            //   label: `${key}-received`,
+            //   showLine: true,
+            //   data: entries.map((entry) => ({
+            //     x: entry.timestamp,
+            //     y: entry.context.bytesReceived,
+            //   })),
+            //   backgroundColor: BORDER_COLORS[colorIdx++ % BORDER_COLORS.length],
+            // })),
           ]
         },
         options: {},

--- a/packages/gravity/kube-testing/src/plan/transport-spec.ts
+++ b/packages/gravity/kube-testing/src/plan/transport-spec.ts
@@ -6,7 +6,7 @@ import { asyncTimeout, sleep, scheduleTaskInterval } from '@dxos/async';
 import { cancelWithContext, Context } from '@dxos/context';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
-import { TestBuilder as NetworkManagerTestBuilder } from '@dxos/network-manager/testing';
+import { TestBuilder as NetworkManagerTestBuilder, TestSwarmConnection } from '@dxos/network-manager/testing';
 import { range } from '@dxos/util';
 
 import { TestBuilder as SignalTestBuilder } from '../test-builder';
@@ -155,7 +155,7 @@ export class TransportTestPlan implements TestPlan<TransportTestSpec, TransportA
     /**
      * Iterate over all swarms and all agents.
      */
-    const forEachSwarmAndAgent = async (callback: (swarmIdx: number, swarm: any, agentId: string) => Promise<void>) => {
+    const forEachSwarmAndAgent = async (callback: (swarmIdx: number, swarm: TestSwarmConnection, agentId: string) => Promise<void>) => {
       await Promise.all(
         Object.keys(env.params.agents)
           .filter((agentId) => agentId !== env.params.agentId)
@@ -204,7 +204,7 @@ export class TransportTestPlan implements TestPlan<TransportTestSpec, TransportA
         let actualStreams = 0;
 
         await forEachSwarmAndAgent(async (swarmIdx, swarm, agentId) => {
-          log.info('starting stream', { agentIdx, swarmIdx });
+          log.info('starting stream', { from: agentIdx, to: env.params.agents[agentId].agentIdx, swarmIdx });
           try {
             const streamTag = `stream-test-${testCounter}-${env.params.agentId}-${agentId}-${swarmIdx}`;
             await swarm.protocol.openStream(

--- a/packages/gravity/kube-testing/src/plan/transport-spec.ts
+++ b/packages/gravity/kube-testing/src/plan/transport-spec.ts
@@ -7,11 +7,13 @@ import { cancelWithContext, Context } from '@dxos/context';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { TestBuilder as NetworkManagerTestBuilder, TestSwarmConnection } from '@dxos/network-manager/testing';
-import { range } from '@dxos/util';
+import { defaultMap, range } from '@dxos/util';
 
 import { TestBuilder as SignalTestBuilder } from '../test-builder';
 import { AgentEnv } from './agent-env';
 import { PlanResults, TestParams, TestPlan } from './spec-base';
+import { SerializedLogEntry, getReader } from '../analysys';
+import { BORDER_COLORS, renderPNG, showPng } from '../analysys/plot';
 
 export type TransportTestSpec = {
   agents: number;
@@ -204,9 +206,15 @@ export class TransportTestPlan implements TestPlan<TransportTestSpec, TransportA
         let actualStreams = 0;
 
         await forEachSwarmAndAgent(async (swarmIdx, swarm, agentId) => {
-          log.info('starting stream', { from: agentIdx, to: env.params.agents[agentId].agentIdx, swarmIdx });
+          const to = env.params.agents[agentId].agentIdx;
+          if(agentIdx > to) {
+            return;
+          }
+
+          log.info('starting stream', { from: agentIdx, to, swarmIdx  });
           try {
             const streamTag = `stream-test-${testCounter}-${env.params.agentId}-${agentId}-${swarmIdx}`;
+            log.info('open stream', { streamTag })
             await swarm.protocol.openStream(
               PublicKey.from(agentId),
               streamTag,
@@ -306,7 +314,7 @@ export class TransportTestPlan implements TestPlan<TransportTestSpec, TransportA
       ctx,
       async () => {
         await env.syncBarrier(`iteration-${testCounter}`);
-        await cancelWithContext(ctx, testRun());
+        await testRun();
         testCounter++;
       },
       spec.repeatInterval,
@@ -320,5 +328,95 @@ export class TransportTestPlan implements TestPlan<TransportTestSpec, TransportA
   async finish(params: TestParams<TransportTestSpec>, results: PlanResults): Promise<any> {
     await this.signalBuilder.destroy();
     log.info('finished shutdown');
+
+    const reader = getReader(results);
+
+    const muxerStats = new Map<string, SerializedLogEntry<TeleportStatsLog>[]>()
+    const testStats = new Map<string, SerializedLogEntry<TestStatsLog>[]>();
+
+    for await (const entry of reader) {
+      switch (entry.message) {
+        case 'dxos.mesh.teleport.stats':
+          {
+            const { localPeerId, remotePeerId } = entry.context as TeleportStatsLog;
+            const key = `connection-${PublicKey.from(localPeerId).truncate()}-${PublicKey.from(remotePeerId).truncate()}`;
+            defaultMap(muxerStats, key, []).push(entry);
+          }
+          break;
+        case 'dxos.test.stream-stats':
+          {
+            const { from, to } = entry.context as TestStatsLog;
+            const key = `stream-${PublicKey.from(from).truncate()}-${PublicKey.from(to).truncate()}`;
+            defaultMap(testStats, key, []).push(entry);
+          }
+          break;
+      }
+    }
+
+    let colorIdx = 0;
+    showPng(
+      await renderPNG({
+        type: 'scatter',
+        data: {
+          datasets: [
+            ...Array.from(muxerStats.entries()).map(([key, entries]) => ({
+              label: `${key}-sent`,
+              showLine: true,
+              data: entries.map((entry) => ({
+                x: entry.timestamp,
+                y: entry.context.bytesSent,
+              })),
+              backgroundColor: BORDER_COLORS[colorIdx++ % BORDER_COLORS.length],
+            })),
+            ...Array.from(muxerStats.entries()).map(([key, entries]) => ({
+              label: `${key}-received`,
+              showLine: true,
+              data: entries.map((entry) => ({
+                x: entry.timestamp,
+                y: entry.context.bytesReceived,
+              })),
+              backgroundColor: BORDER_COLORS[colorIdx++ % BORDER_COLORS.length],
+            })),
+            ...Array.from(testStats.entries()).map(([key, entries]) => ({
+              label: `${key}-sent`,
+              showLine: true,
+              data: entries.map((entry) => ({
+                x: entry.timestamp,
+                y: entry.context.bytesSent,
+              })),
+              backgroundColor: BORDER_COLORS[colorIdx++ % BORDER_COLORS.length],
+
+            })),
+            ...Array.from(testStats.entries()).map(([key, entries]) => ({
+              label: `${key}-received`,
+              showLine: true,
+              data: entries.map((entry) => ({
+                x: entry.timestamp,
+                y: entry.context.bytesReceived,
+              })),
+              backgroundColor: BORDER_COLORS[colorIdx++ % BORDER_COLORS.length],
+            })),
+          ]
+        },
+        options: {},
+      }),
+    );
   }
+}
+
+type TeleportStatsLog = {
+  localPeerId: string,
+  remotePeerId: string,
+  bytesSent: number
+  bytesReceived: number,
+};
+
+type TestStatsLog = {
+  streamTag: string
+  bytesSent: number
+  bytesReceived: number
+  sendErrors: number
+  receiveErrors: number
+  from: string
+  to: string
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dd51b96</samp>

### Summary
🧪🚚🔄

<!--
1.  🧪 This emoji represents testing, as the first change adds a new test file for the balancer module and the fourth change updates the framer test file.
2.  🚚 This emoji represents transport, as the second change modifies the runTransport function of the kube-testing module and the fifth change simplifies the framer module.
3.  🔄 This emoji represents balancing, as the third and sixth changes update the balancer and muxer modules to handle data chunking and channel allocation.
-->
This pull request improves the data transmission logic of the `teleport` module by using a new varint module, simplifying the framer module, and updating the balancer module. It also adds tests for the balancer module and adjusts the kube-testing module to use a larger stream load chunk size. These changes aim to enhance the performance and reliability of the transport layer for the `dxos` core mesh.

> _We're coding on the `kube-testing` stream, me hearties, yo ho!_
> _We're chunking and unchunking with the `balancer` module, yo ho!_
> _We're framing and deframing with a fixed length size, yo ho!_
> _We're pulling and pushing on the `muxer` channel, on the count of three!_

### Walkthrough
*  Replace framer module with balancer module for load balancing and chunking of data for multiple channels ([link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-0e09ceb6178d7900eed47073b84ac4dca53d5a48851fba05440f6e8e08c681a7L5-R23), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-0e09ceb6178d7900eed47073b84ac4dca53d5a48851fba05440f6e8e08c681a7L25-R68), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-0e09ceb6178d7900eed47073b84ac4dca53d5a48851fba05440f6e8e08c681a7L36-R75), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-0e09ceb6178d7900eed47073b84ac4dca53d5a48851fba05440f6e8e08c681a7L48-R100), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-0e09ceb6178d7900eed47073b84ac4dca53d5a48851fba05440f6e8e08c681a7R106), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-0e09ceb6178d7900eed47073b84ac4dca53d5a48851fba05440f6e8e08c681a7L98-R148), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-0e09ceb6178d7900eed47073b84ac4dca53d5a48851fba05440f6e8e08c681a7R154-R183), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-5074963ce77ca55847e80862d9f23135badbbab64f304b865c80591975aea1b7L8), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-5074963ce77ca55847e80862d9f23135badbbab64f304b865c80591975aea1b7L53-R53), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-f67b857af489bd83b17ccd9855ddde7a08c34df9a6485adb4cff8c5212cf5150L7-R11), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-f67b857af489bd83b17ccd9855ddde7a08c34df9a6485adb4cff8c5212cf5150L57-R58), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-f67b857af489bd83b17ccd9855ddde7a08c34df9a6485adb4cff8c5212cf5150L121-R146), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66L17), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66L37-R36), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66L50-R65), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66L223), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66L279-R274))
*  Add new test file for balancer module (`balancer.test.ts`) and update existing test cases for framer module (`framer.test.ts`) ([link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-07322d516a17f4bfc4063effcece820597d4e2d8b1eedb97b36b87030e1f8298R1-R50), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-5074963ce77ca55847e80862d9f23135badbbab64f304b865c80591975aea1b7L8), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-5074963ce77ca55847e80862d9f23135badbbab64f304b865c80591975aea1b7L53-R53))
*  Use fixed frame length size and 16-bit unsigned integer for encoding and decoding frame length in framer module ([link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-f67b857af489bd83b17ccd9855ddde7a08c34df9a6485adb4cff8c5212cf5150L7-R11), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-f67b857af489bd83b17ccd9855ddde7a08c34df9a6485adb4cff8c5212cf5150L121-R146))
*  Use different import for varint module and use it for encoding and decoding channel id and data length in balancer module ([link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-0e09ceb6178d7900eed47073b84ac4dca53d5a48851fba05440f6e8e08c681a7L5-R23), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-0e09ceb6178d7900eed47073b84ac4dca53d5a48851fba05440f6e8e08c681a7R106))
*  Use different value for system channel id (0 instead of -1) and start next id from 1 instead of 0 in muxer module ([link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66L37-R36), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66L50-R65))
*  Use resolve callback instead of nextTick callback in framer module ([link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-f67b857af489bd83b17ccd9855ddde7a08c34df9a6485adb4cff8c5212cf5150L57-R58))
*  Use optional dataLength parameter and trigger parameter in balancer module ([link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-0e09ceb6178d7900eed47073b84ac4dca53d5a48851fba05440f6e8e08c681a7L36-R75), [link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-0e09ceb6178d7900eed47073b84ac4dca53d5a48851fba05440f6e8e08c681a7L98-R148))
*  Use larger stream load chunk size in kube-testing module (`main.ts`) ([link](https://github.com/dxos/dxos/pull/3825/files?diff=unified&w=0#diff-07d9a4fe62c5ce84347caf3b0b32a13540ad7cb7704251c7230663f3d92d4958L84-R84))


