### PR TITLE
fix(react-shell): Implement less provocative auth code state for `InvitationManager`.

### DIFF
--- a/packages/sdk/react-shell/src/steps/InvitationManager.tsx
+++ b/packages/sdk/react-shell/src/steps/InvitationManager.tsx
@@ -7,7 +7,7 @@ import React, { cloneElement, PropsWithChildren, ReactNode, useMemo } from 'reac
 import { QR } from 'react-qr-rounded';
 
 import { useId, useTranslation } from '@dxos/aurora';
-import { chromeSurface, getSize, mx } from '@dxos/aurora-theme';
+import { chromeSurface, descriptionText, getSize, mx } from '@dxos/aurora-theme';
 import type { InvitationStatus } from '@dxos/react-client/invitations';
 
 import { CopyButtonIconOnly, PanelAction, PanelActions, Viewport, ViewportViewProps } from '../components';
@@ -104,9 +104,11 @@ export const InvitationManager = ({
             </span>
           </InvitationManagerView>
           <InvitationManagerView id='showing auth code' emoji={emoji}>
-            <p className='text-[6rem] leading-[6rem] break-all text-center text-success-500 dark:text-success-300 font-mono'>
-              {authCode}
-            </p>
+            <div role='none' className='absolute inset-0 flex flex-col justify-around items-center'>
+              <p className={mx(descriptionText, 'text-center')}>{t('auth code message')}</p>
+              <div role='none' className='bs-14' />
+              <p className='text-xl text-center text-success-500 dark:text-success-300 font-mono'>{authCode}</p>
+            </div>
           </InvitationManagerView>
           <InvitationManagerView
             id='showing final'

--- a/packages/sdk/react-shell/src/translations/locales/en-US.ts
+++ b/packages/sdk/react-shell/src/translations/locales/en-US.ts
@@ -81,4 +81,5 @@ export const os = {
   'device list heading': 'Devices',
   'space member list heading': 'Members in this space',
   'space panel heading': 'Space settings',
+  'auth code message': 'Enter the following auth code on the joining device.',
 };


### PR DESCRIPTION
<img width="469" alt="Screenshot 2023-08-08 at 13 47 03" src="https://github.com/dxos/dxos/assets/855039/d1821d3f-3e7d-451f-8790-9f428f8dd30d">

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8c48c97</samp>

### Summary
🌐📝💅

<!--
1.  🌐 - This emoji represents the addition of the message text to the locale file, which enables internationalization and localization of the app.
2.  📝 - This emoji represents the addition of the message component to the `InvitationManager` component, which informs the user about the purpose and usage of the auth code.
3.  💅 - This emoji represents the improved styling of the auth code in the `InvitationManager` component, which makes it more visible and attractive.
-->
Improved the user experience of the `InvitationManager` component by adding a message explaining how to use the auth code. Added the message text to the `en-US` locale file for translation.

> _`auth code message`_
> _a key for translation_
> _winter invites you_

### Walkthrough
* Import `descriptionText` style from `@dxos/aurora-theme` to use for explanatory text elements ([link](https://github.com/dxos/dxos/pull/3829/files?diff=unified&w=0#diff-3af43445f59986a74a4351ba74ecd39e2125c7ae0194284ac6374e133a33939eL10-R10)).


