### PR TITLE
refactor(aurora-theme): Remove OS variant

### DIFF
--- a/packages/apps/plugins/plugin-github/src/components/EmbeddedMain/EmbeddedMain.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/EmbeddedMain/EmbeddedMain.tsx
@@ -29,7 +29,7 @@ import {
   useJdenticonHref,
 } from '@dxos/aurora';
 import { useTextModel } from '@dxos/aurora-composer';
-import { descriptionText, getSize, mx, osTx } from '@dxos/aurora-theme';
+import { auroraTx, descriptionText, getSize, mx } from '@dxos/aurora-theme';
 import { ShellLayout } from '@dxos/react-client';
 import { useIdentity } from '@dxos/react-client/halo';
 import { Surface, findPlugin, usePluginContext } from '@dxos/react-surface';
@@ -244,10 +244,10 @@ const EmbeddedLayoutImpl = () => {
           )
         ) : source && id && identityHex ? (
           <Dialog.Root open onOpenChange={() => true}>
-            <div role='none' className={osTx('dialog.overlay', 'dialog--resolver__overlay', {}, 'static bs-full')}>
+            <div role='none' className={auroraTx('dialog.overlay', 'dialog--resolver__overlay', {}, 'static bs-full')}>
               <div
                 role='none'
-                className={osTx(
+                className={auroraTx(
                   'dialog.content',
                   'dialog--resolver__content',
                   {},

--- a/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
@@ -5,9 +5,9 @@
 import { DotsThreeVertical } from '@phosphor-icons/react';
 import React, { PropsWithChildren, RefObject } from 'react';
 
-import { Button, DropdownMenu, ThemeContext, Main, Input, useThemeContext, useTranslation } from '@dxos/aurora';
+import { Button, DropdownMenu, Main, Input, useTranslation } from '@dxos/aurora';
 import { ComposerModel, MarkdownComposerRef } from '@dxos/aurora-composer';
-import { blockSeparator, getSize, mx, osTx, paperSurface } from '@dxos/aurora-theme';
+import { blockSeparator, getSize, mx, paperSurface } from '@dxos/aurora-theme';
 import { Surface } from '@dxos/react-surface';
 
 import { MARKDOWN_PLUGIN, MarkdownProperties } from '../types';
@@ -24,7 +24,6 @@ export const StandaloneLayout = ({
   editorRef?: RefObject<MarkdownComposerRef>;
 }>) => {
   const { t } = useTranslation(MARKDOWN_PLUGIN);
-  const themeContext = useThemeContext();
   return (
     <Main.Content classNames='min-bs-full' bounce>
       <div role='none' className={mx('mli-auto max-is-[60rem] min-bs-[100dvh] flex flex-col', paperSurface)}>
@@ -42,21 +41,19 @@ export const StandaloneLayout = ({
             />
           </Input.Root>
           {!properties.readOnly && (
-            <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}>
-              <DropdownMenu.Root modal={false}>
-                <DropdownMenu.Trigger asChild>
-                  <Button classNames='p-0 is-10 shrink-0 mie-3' variant='ghost' density='coarse'>
-                    <DotsThreeVertical className={getSize(6)} />
-                  </Button>
-                </DropdownMenu.Trigger>
-                <DropdownMenu.Portal>
-                  <DropdownMenu.Content sideOffset={10} classNames='z-10'>
-                    <Surface data={[model, properties, editorRef]} role='menuitem' />
-                    <DropdownMenu.Arrow />
-                  </DropdownMenu.Content>
-                </DropdownMenu.Portal>
-              </DropdownMenu.Root>
-            </ThemeContext.Provider>
+            <DropdownMenu.Root modal={false}>
+              <DropdownMenu.Trigger asChild>
+                <Button classNames='p-0 is-10 shrink-0 mie-3' variant='ghost' density='coarse'>
+                  <DotsThreeVertical className={getSize(6)} />
+                </Button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content sideOffset={10} classNames='z-10'>
+                  <Surface data={[model, properties, editorRef]} role='menuitem' />
+                  <DropdownMenu.Arrow />
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
           )}
         </div>
         <div role='separator' className={mx(blockSeparator, 'mli-4 opacity-50')} />

--- a/packages/apps/plugins/plugin-theme/src/ThemePlugin.tsx
+++ b/packages/apps/plugins/plugin-theme/src/ThemePlugin.tsx
@@ -7,7 +7,7 @@ import type { Resource } from 'i18next';
 import React from 'react';
 
 import { ThemeMode, ThemeProvider, Toast, Tooltip } from '@dxos/aurora';
-import { appTx } from '@dxos/aurora-theme';
+import { auroraTx } from '@dxos/aurora-theme';
 import { PluginDefinition } from '@dxos/react-surface';
 
 import compositeEnUs from './translations/en-US';
@@ -44,7 +44,7 @@ export const ThemePlugin = ({ appName }: ThemePluginOptions = { appName: 'test' 
     },
     provides: {
       context: ({ children }) => (
-        <ThemeProvider {...{ tx: appTx, themeMode: state.themeMode, resourceExtensions: resources }}>
+        <ThemeProvider {...{ tx: auroraTx, themeMode: state.themeMode, resourceExtensions: resources }}>
           <Toast.Provider>
             <Tooltip.Provider>{children}</Tooltip.Provider>
             <Toast.Viewport />

--- a/packages/apps/plugins/plugin-treeview/src/components/LeafTreeItem.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/LeafTreeItem.tsx
@@ -20,7 +20,7 @@ import {
   useSidebar,
   useTranslation,
 } from '@dxos/aurora';
-import { appTx, staticDisabled, focusRing, getSize, mx } from '@dxos/aurora-theme';
+import { auroraTx, staticDisabled, focusRing, getSize, mx } from '@dxos/aurora-theme';
 
 import { useTreeView } from '../TreeViewContext';
 import { TREE_VIEW_PLUGIN } from '../types';
@@ -86,7 +86,7 @@ export const LeafTreeItem: ForwardRefExoticComponent<LeafTreeItemProps & RefAttr
       <TreeItem.Heading
         asChild
         data-testid='spacePlugin.documentTreeItemHeading'
-        classNames={appTx(
+        classNames={auroraTx(
           'button.root',
           'tree-item__heading--link',
           { variant: 'ghost', density },

--- a/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
@@ -14,15 +14,13 @@ import {
   Button,
   DensityProvider,
   ElevationProvider,
-  ThemeContext,
   Tooltip,
   useJdenticonHref,
   useSidebar,
-  useThemeContext,
   useTranslation,
   DropdownMenu,
 } from '@dxos/aurora';
-import { getSize, mx, osTx } from '@dxos/aurora-theme';
+import { getSize, mx } from '@dxos/aurora-theme';
 import { useIdentity } from '@dxos/react-client/halo';
 
 import { TREE_VIEW_PLUGIN } from '../types';
@@ -33,7 +31,6 @@ export const TreeViewContainer = () => {
 
   const identity = useIdentity({ login: true });
   const jdenticon = useJdenticonHref(identity?.identityKey.toHex() ?? '', 24);
-  const themeContext = useThemeContext();
   const { t } = useTranslation(TREE_VIEW_PLUGIN);
   const { sidebarOpen } = useSidebar(TREE_VIEW_PLUGIN);
   const splitViewContext = useSplitView();
@@ -50,144 +47,140 @@ export const TreeViewContainer = () => {
   return (
     <ElevationProvider elevation='chrome'>
       <DensityProvider density='fine'>
-        <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}>
-          <div role='none' className='flex flex-col bs-full'>
-            <div role='separator' className='order-1 bs-px mli-2.5 bg-neutral-500/20' />
-            <Tree.Root role='none' classNames='order-1 grow min-bs-0 overflow-y-auto overscroll-contain scroll-smooth'>
-              {branches.map(([key, items]) => (
-                <TreeItem.Root key={key} classNames='flex flex-col plb-1.5 pis-1 pie-1.5'>
-                  <TreeItem.Heading classNames='pl-2'>{t('plugin name', { ns: key })}</TreeItem.Heading>
-                  <TreeView items={items as GraphNode[]} parent={graph.id} />
-                </TreeItem.Root>
-              ))}
-            </Tree.Root>
-            <div role='none' className='order-first shrink-0 flex items-center pli-1.5 plb-1.5 order-0'>
-              <h1 className={mx('grow font-system-medium text-lg pli-1.5')}>
-                {t('current app name', { ns: 'appkit' })}
-              </h1>
-              {hoistedActions?.map((action) => (
-                <Tooltip.Root key={action.id}>
+        <div role='none' className='flex flex-col bs-full'>
+          <div role='separator' className='order-1 bs-px mli-2.5 bg-neutral-500/20' />
+          <Tree.Root role='none' classNames='order-1 grow min-bs-0 overflow-y-auto overscroll-contain scroll-smooth'>
+            {branches.map(([key, items]) => (
+              <TreeItem.Root key={key} classNames='flex flex-col plb-1.5 pis-1 pie-1.5'>
+                <TreeItem.Heading classNames='pl-2'>{t('plugin name', { ns: key })}</TreeItem.Heading>
+                <TreeView items={items as GraphNode[]} parent={graph.id} />
+              </TreeItem.Root>
+            ))}
+          </Tree.Root>
+          <div role='none' className='order-first shrink-0 flex items-center pli-1.5 plb-1.5 order-0'>
+            <h1 className={mx('grow font-system-medium text-lg pli-1.5')}>{t('current app name', { ns: 'appkit' })}</h1>
+            {hoistedActions?.map((action) => (
+              <Tooltip.Root key={action.id}>
+                <Tooltip.Trigger asChild>
+                  <Button
+                    variant='ghost'
+                    key={action.id}
+                    {...(action.testId && { 'data-testid': action.testId })}
+                    onClick={() => invokeAction(action)}
+                    classNames='pli-2 pointer-fine:pli-1'
+                    {...(!sidebarOpen && { tabIndex: -1 })}
+                  >
+                    <span className='sr-only'>{Array.isArray(action.label) ? t(...action.label) : action.label}</span>
+                    {action.icon ? <action.icon className={getSize(4)} /> : <Placeholder className={getSize(4)} />}
+                  </Button>
+                </Tooltip.Trigger>
+                <Tooltip.Content classNames='z-[31]'>
+                  {Array.isArray(action.label) ? t(...action.label) : action.label}
+                  <Tooltip.Arrow />
+                </Tooltip.Content>
+              </Tooltip.Root>
+            ))}
+            <Tooltip.Root
+              open={optionsTooltipOpen}
+              onOpenChange={(nextOpen) => {
+                if (suppressNextTooltip.current) {
+                  setOptionsTooltipOpen(false);
+                  suppressNextTooltip.current = false;
+                } else {
+                  setOptionsTooltipOpen(nextOpen);
+                }
+              }}
+            >
+              <Tooltip.Portal>
+                <Tooltip.Content classNames='z-[31]' side='bottom'>
+                  {t('tree options label')}
+                  <Tooltip.Arrow />
+                </Tooltip.Content>
+              </Tooltip.Portal>
+              <DropdownMenu.Root
+                {...{
+                  open: optionsMenuOpen,
+                  onOpenChange: (nextOpen: boolean) => {
+                    if (!nextOpen) {
+                      suppressNextTooltip.current = true;
+                    }
+                    return setOptionsMenuOpen(nextOpen);
+                  },
+                }}
+              >
+                <DropdownMenu.Trigger asChild>
                   <Tooltip.Trigger asChild>
                     <Button
                       variant='ghost'
-                      key={action.id}
-                      {...(action.testId && { 'data-testid': action.testId })}
-                      onClick={() => invokeAction(action)}
-                      classNames='pli-2 pointer-fine:pli-1'
+                      classNames='shrink-0 pli-2 pointer-fine:pli-1'
                       {...(!sidebarOpen && { tabIndex: -1 })}
                     >
-                      <span className='sr-only'>{Array.isArray(action.label) ? t(...action.label) : action.label}</span>
-                      {action.icon ? <action.icon className={getSize(4)} /> : <Placeholder className={getSize(4)} />}
+                      <DotsThreeVertical className={getSize(4)} />
                     </Button>
                   </Tooltip.Trigger>
-                  <Tooltip.Content classNames='z-[31]'>
-                    {Array.isArray(action.label) ? t(...action.label) : action.label}
-                    <Tooltip.Arrow />
-                  </Tooltip.Content>
-                </Tooltip.Root>
-              ))}
-              <Tooltip.Root
-                open={optionsTooltipOpen}
-                onOpenChange={(nextOpen) => {
-                  if (suppressNextTooltip.current) {
-                    setOptionsTooltipOpen(false);
-                    suppressNextTooltip.current = false;
-                  } else {
-                    setOptionsTooltipOpen(nextOpen);
-                  }
-                }}
-              >
-                <Tooltip.Portal>
-                  <Tooltip.Content classNames='z-[31]' side='bottom'>
-                    {t('tree options label')}
-                    <Tooltip.Arrow />
-                  </Tooltip.Content>
-                </Tooltip.Portal>
-                <DropdownMenu.Root
-                  {...{
-                    open: optionsMenuOpen,
-                    onOpenChange: (nextOpen: boolean) => {
-                      if (!nextOpen) {
-                        suppressNextTooltip.current = true;
-                      }
-                      return setOptionsMenuOpen(nextOpen);
-                    },
-                  }}
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Portal>
+                  <DropdownMenu.Content classNames='z-[31]'>
+                    {actions.map((action) => (
+                      <DropdownMenu.Item
+                        key={action.id}
+                        onClick={(event) => {
+                          // todo(thure): Why does Dialog’s modal-ness cause issues if we don’t explicitly close the menu here?
+                          suppressNextTooltip.current = true;
+                          setOptionsMenuOpen(false);
+                          void invokeAction(action);
+                        }}
+                        classNames='gap-2'
+                      >
+                        {action.icon && <action.icon className={getSize(4)} />}
+                        <span>{Array.isArray(action.label) ? t(...action.label) : action.label}</span>
+                      </DropdownMenu.Item>
+                    ))}
+                    <DropdownMenu.Arrow />
+                  </DropdownMenu.Content>
+                </DropdownMenu.Portal>
+              </DropdownMenu.Root>
+            </Tooltip.Root>
+          </div>
+          {identity && (
+            <>
+              <div role='separator' className='order-last bs-px mli-2.5 bg-neutral-500/20' />
+              <Avatar.Root size={6} variant='circle' status='active'>
+                <div
+                  role='none'
+                  className='order-last shrink-0 flex items-center gap-1 pis-3 pie-1.5 plb-3 pointer-fine:pie-1.5 pointer-fine:plb-1.5'
                 >
-                  <DropdownMenu.Trigger asChild>
+                  <Avatar.Frame>
+                    <Avatar.Fallback href={jdenticon} />
+                  </Avatar.Frame>
+                  <Avatar.Label classNames='grow text-sm'>
+                    {identity.profile?.displayName ?? identity.identityKey.truncate()}
+                  </Avatar.Label>
+                  <Tooltip.Root>
                     <Tooltip.Trigger asChild>
                       <Button
                         variant='ghost'
-                        classNames='shrink-0 pli-2 pointer-fine:pli-1'
+                        classNames='pli-2 pointer-fine:pli-1'
                         {...(!sidebarOpen && { tabIndex: -1 })}
+                        onClick={() => {
+                          splitViewContext.dialogOpen = true;
+                          splitViewContext.dialogContent = 'dxos.org/plugin/splitview/ProfileSettings';
+                        }}
                       >
-                        <DotsThreeVertical className={getSize(4)} />
+                        <span className='sr-only'>{t('settings dialog title', { ns: 'os' })}</span>
+                        <GearSix className={mx(getSize(4), 'rotate-90')} />
                       </Button>
                     </Tooltip.Trigger>
-                  </DropdownMenu.Trigger>
-                  <DropdownMenu.Portal>
-                    <DropdownMenu.Content classNames='z-[31]'>
-                      {actions.map((action) => (
-                        <DropdownMenu.Item
-                          key={action.id}
-                          onClick={(event) => {
-                            // todo(thure): Why does Dialog’s modal-ness cause issues if we don’t explicitly close the menu here?
-                            suppressNextTooltip.current = true;
-                            setOptionsMenuOpen(false);
-                            void invokeAction(action);
-                          }}
-                          classNames='gap-2'
-                        >
-                          {action.icon && <action.icon className={getSize(4)} />}
-                          <span>{Array.isArray(action.label) ? t(...action.label) : action.label}</span>
-                        </DropdownMenu.Item>
-                      ))}
-                      <DropdownMenu.Arrow />
-                    </DropdownMenu.Content>
-                  </DropdownMenu.Portal>
-                </DropdownMenu.Root>
-              </Tooltip.Root>
-            </div>
-            {identity && (
-              <>
-                <div role='separator' className='order-last bs-px mli-2.5 bg-neutral-500/20' />
-                <Avatar.Root size={6} variant='circle' status='active'>
-                  <div
-                    role='none'
-                    className='order-last shrink-0 flex items-center gap-1 pis-3 pie-1.5 plb-3 pointer-fine:pie-1.5 pointer-fine:plb-1.5'
-                  >
-                    <Avatar.Frame>
-                      <Avatar.Fallback href={jdenticon} />
-                    </Avatar.Frame>
-                    <Avatar.Label classNames='grow text-sm'>
-                      {identity.profile?.displayName ?? identity.identityKey.truncate()}
-                    </Avatar.Label>
-                    <Tooltip.Root>
-                      <Tooltip.Trigger asChild>
-                        <Button
-                          variant='ghost'
-                          classNames='pli-2 pointer-fine:pli-1'
-                          {...(!sidebarOpen && { tabIndex: -1 })}
-                          onClick={() => {
-                            splitViewContext.dialogOpen = true;
-                            splitViewContext.dialogContent = 'dxos.org/plugin/splitview/ProfileSettings';
-                          }}
-                        >
-                          <span className='sr-only'>{t('settings dialog title', { ns: 'os' })}</span>
-                          <GearSix className={mx(getSize(4), 'rotate-90')} />
-                        </Button>
-                      </Tooltip.Trigger>
-                      <Tooltip.Content>
-                        {t('settings dialog title', { ns: 'os' })}
-                        <Tooltip.Arrow />
-                      </Tooltip.Content>
-                    </Tooltip.Root>
-                  </div>
-                </Avatar.Root>
-              </>
-            )}
-          </div>
-        </ThemeContext.Provider>
+                    <Tooltip.Content>
+                      {t('settings dialog title', { ns: 'os' })}
+                      <Tooltip.Arrow />
+                    </Tooltip.Content>
+                  </Tooltip.Root>
+                </div>
+              </Avatar.Root>
+            </>
+          )}
+        </div>
       </DensityProvider>
     </ElevationProvider>
   );

--- a/packages/experimental/kai-framework/src/containers/Surface/Surface.stories.tsx
+++ b/packages/experimental/kai-framework/src/containers/Surface/Surface.stories.tsx
@@ -8,7 +8,7 @@ import { createMemoryRouter, RouterProvider, useLocation, useNavigate, useParams
 
 import { Event } from '@dxos/async';
 import { Button, Main, ThemeProvider, useSidebar } from '@dxos/aurora';
-import { getSize, mx, appTx } from '@dxos/aurora-theme';
+import { getSize, mx, auroraTx } from '@dxos/aurora-theme';
 import { raise } from '@dxos/debug';
 import { FullscreenDecorator } from '@dxos/kai-frames';
 import { appkitTranslations, Input } from '@dxos/react-appkit';
@@ -329,7 +329,12 @@ const TestApp = () => {
   };
 
   const Root = () => (
-    <ThemeProvider appNs='kai' rootDensity='fine' resourceExtensions={[osTranslations, appkitTranslations]} tx={appTx}>
+    <ThemeProvider
+      appNs='kai'
+      rootDensity='fine'
+      resourceExtensions={[osTranslations, appkitTranslations]}
+      tx={auroraTx}
+    >
       <SurfaceControllerContextProvider components={components}>
         <Layout />
       </SurfaceControllerContextProvider>

--- a/packages/sdk/examples/src/template/src/App.tsx
+++ b/packages/sdk/examples/src/template/src/App.tsx
@@ -5,14 +5,14 @@
 import React from 'react';
 
 import { ThemeProvider } from '@dxos/aurora';
-import { appTx } from '@dxos/aurora-theme';
+import { auroraTx } from '@dxos/aurora-theme';
 import { Client, ClientProvider, PublicKey } from '@dxos/react-client';
 
 import { Demo } from './components';
 
 const App = ({ spaceKey, clients }: { spaceKey: PublicKey; clients: Client[] }) => {
   return (
-    <ThemeProvider tx={appTx}>
+    <ThemeProvider tx={auroraTx}>
       <div className='flex place-content-evenly'>
         {clients.map((client, id) => (
           <ClientProvider key={id} client={client}>

--- a/packages/sdk/react-client/.storybook/preview.cjs
+++ b/packages/sdk/react-client/.storybook/preview.cjs
@@ -1,6 +1,6 @@
 import { createElement, useEffect } from 'react';
 import { ThemeProvider } from '@dxos/aurora';
-import { appTx } from '@dxos/aurora-theme';
+import { auroraTx } from '@dxos/aurora-theme';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -38,7 +38,7 @@ const withTheme = (StoryFn, context) => {
     document.documentElement.classList[theme === 'dark' ? 'add' : 'remove']('dark');
   }, [theme]);
 
-  return createElement(ThemeProvider, { tx: appTx, children: StoryFn() });
+  return createElement(ThemeProvider, { tx: auroraTx, children: StoryFn() });
 };
 
 export const decorators = [withTheme];

--- a/packages/ui/aurora-theme/src/styles/components/button.ts
+++ b/packages/ui/aurora-theme/src/styles/components/button.ts
@@ -11,9 +11,7 @@ import {
   fineButtonDimensions,
   openOutline,
   staticDisabled,
-  osOpenColors,
   focusRing,
-  osFocusRing,
   contentElevation,
 } from '../fragments';
 
@@ -51,7 +49,7 @@ const sharedButtonStyles: ComponentFragment<AppButtonStyleProps | OsButtonStyleP
   ];
 };
 
-export const buttonAppRoot: ComponentFunction<AppButtonStyleProps> = (props, ...etc) => {
+export const buttonRoot: ComponentFunction<AppButtonStyleProps> = (props, ...etc) => {
   const resolvedVariant = props.variant ?? 'default';
   return mx(
     'font-medium text-sm',
@@ -74,21 +72,6 @@ export const buttonAppRoot: ComponentFunction<AppButtonStyleProps> = (props, ...
   );
 };
 
-export const buttonOsRoot: ComponentFunction<OsButtonStyleProps> = (props, ...etc) => {
-  const resolvedVariant = props.variant ?? 'default';
-  return mx(
-    'font-system-medium text-xs shadow-none',
-    !props.inGroup && 'rounded',
-    !props.disabled && hoverColors,
-    resolvedVariant === 'default' && defaultOsButtonColors,
-    !props.disabled && resolvedVariant === 'ghost' && ghostButtonColors,
-    !props.disabled && osFocusRing,
-    ...osOpenColors({ side: props.sideInset ?? 'be' }),
-    ...sharedButtonStyles(props),
-    ...etc,
-  );
-};
-
 export const buttonGroup: ComponentFunction<{ elevation?: Elevation }> = (props, ...etc) => {
   return mx(
     'inline-flex rounded-md [&>:first-child]:rounded-is-md [&>:last-child]:rounded-ie-md [&>button]:relative',
@@ -98,11 +81,6 @@ export const buttonGroup: ComponentFunction<{ elevation?: Elevation }> = (props,
 };
 
 export const buttonTheme: Theme<AppButtonStyleProps> = {
-  root: buttonAppRoot,
+  root: buttonRoot,
   group: buttonGroup,
-};
-
-export const buttonOsTheme: Theme<OsButtonStyleProps> = {
-  ...buttonTheme,
-  root: buttonOsRoot,
 };

--- a/packages/ui/aurora-theme/src/styles/components/dialog.ts
+++ b/packages/ui/aurora-theme/src/styles/components/dialog.ts
@@ -18,9 +18,6 @@ const dialogLayoutFragment = 'overflow-auto grid place-items-center p-2 md:p-4 l
 export const dialogOverlay: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
   mx('fixed z-20 inset-inline-0 block-start-0 bs-[100dvb]', dialogLayoutFragment, ...etc);
 
-export const dialogOsOverlay: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
-  mx('fixed z-40 inset-0 backdrop-blur', dialogLayoutFragment, ...etc);
-
 export const dialogContent: ComponentFunction<DialogStyleProps> = ({ inOverlayLayout, elevation = 'chrome' }, ...etc) =>
   mx(
     'flex flex-col',
@@ -31,9 +28,6 @@ export const dialogContent: ComponentFunction<DialogStyleProps> = ({ inOverlayLa
     focusRing,
     ...etc,
   );
-
-export const dialogOsContent: ComponentFunction<DialogStyleProps> = (props, ...etc) =>
-  mx('is-full min-is-[260px] max-is-[320px] rounded-md shadow-md backdrop-blur-md', ...etc);
 
 export const dialogTitle: ComponentFunction<DialogStyleProps> = ({ srOnly }, ...etc) =>
   mx(
@@ -49,13 +43,6 @@ export const dialogDescription: ComponentFunction<DialogStyleProps> = ({ srOnly 
 export const dialogTheme: Theme<DialogStyleProps> = {
   overlay: dialogOverlay,
   content: dialogContent,
-  title: dialogTitle,
-  description: dialogDescription,
-};
-
-export const dialogOsTheme: Theme<DialogStyleProps> = {
-  overlay: dialogOsOverlay,
-  content: dialogOsContent,
   title: dialogTitle,
   description: dialogDescription,
 };

--- a/packages/ui/aurora-theme/src/styles/components/input.ts
+++ b/packages/ui/aurora-theme/src/styles/components/input.ts
@@ -12,8 +12,6 @@ import {
   placeholderText,
   focusRing,
   hoverColors,
-  osFocusRing,
-  osHoverColors,
   subduedFocus,
   fineBlockSize,
   coarseBlockSize,
@@ -85,7 +83,7 @@ const sharedStaticInputStyles: ComponentFragment<InputStyleProps> = (props) => [
   props.focused && staticFocusRing,
 ];
 
-export const inputAppInput: ComponentFunction<InputStyleProps> = (props, ...etc) =>
+export const inputInput: ComponentFunction<InputStyleProps> = (props, ...etc) =>
   props.variant === 'subdued'
     ? mx(...sharedSubduedInputStyles(props), ...etc)
     : props.variant === 'static'
@@ -100,36 +98,12 @@ export const inputAppInput: ComponentFunction<InputStyleProps> = (props, ...etc)
         ...etc,
       );
 
-export const inputOsInput: ComponentFunction<InputStyleProps> = (props, ...etc) =>
-  props.variant === 'subdued'
-    ? mx(...sharedSubduedInputStyles(props), ...etc)
-    : props.variant === 'static'
-    ? mx(...sharedStaticInputStyles(props), ...etc)
-    : mx(
-        'rounded-sm text-sm bg-white/50 dark:bg-neutral-750/50',
-        !props.disabled && osFocusRing,
-        !props.disabled && osHoverColors,
-        inputValence(props.validationValence) ||
-          'border-transparent focus-visible:border-transparent dark:focus-visible:border-transparent',
-        ...sharedDefaultInputStyles(props),
-        ...etc,
-      );
-
-export const inputAppCheckbox: ComponentFunction<InputStyleProps> = ({ size = 5 }, ...etc) =>
+export const inputCheckbox: ComponentFunction<InputStyleProps> = ({ size = 5 }, ...etc) =>
   mx(
     getSize(size),
     'flex items-center justify-center rounded text-white',
     'radix-state-checked:bg-primary-600 radix-state-unchecked:bg-neutral-200 dark:radix-state-unchecked:bg-neutral-700',
     focusRing,
-    ...etc,
-  );
-
-export const inputOsCheckbox: ComponentFunction<InputStyleProps> = ({ size = 5 }, ...etc) =>
-  mx(
-    getSize(size),
-    'flex items-center justify-center rounded text-white',
-    'radix-state-checked:bg-primary-600 radix-state-unchecked:bg-neutral-200 dark:radix-state-unchecked:bg-neutral-700',
-    osFocusRing,
     ...etc,
   );
 
@@ -152,18 +126,12 @@ export const inputValidation: ComponentFunction<InputMetaStyleProps> = (props, .
   mx(descriptionText, props.srOnly ? 'sr-only' : valenceColorText(props.validationValence), ...etc);
 
 export const inputTheme = {
-  input: inputAppInput,
+  input: inputInput,
   inputWithSegments: inputWithSegmentsInput,
-  checkbox: inputAppCheckbox,
+  checkbox: inputCheckbox,
   checkboxIndicator: inputCheckboxIndicator,
   label: inputLabel,
   description: inputDescription,
   validation: inputValidation,
   descriptionAndValidation: inputDescriptionAndValidation,
-};
-
-export const inputOsTheme = {
-  ...inputTheme,
-  input: inputOsInput,
-  checkbox: inputOsCheckbox,
 };

--- a/packages/ui/aurora-theme/src/styles/components/list.ts
+++ b/packages/ui/aurora-theme/src/styles/components/list.ts
@@ -5,7 +5,7 @@
 import { ComponentFunction, Density, Theme } from '@dxos/aurora-types';
 
 import { mx } from '../../util';
-import { focusRing, densityBlockSize, getSize, osFocusRing } from '../fragments';
+import { focusRing, densityBlockSize, getSize } from '../fragments';
 
 export type ListStyleProps = Partial<{
   density: Density;
@@ -26,10 +26,8 @@ export const listItemHeading: ComponentFunction<ListStyleProps> = ({ density }, 
 export const listItemDragHandleIcon: ComponentFunction<ListStyleProps> = (_props, ...etc) =>
   mx(getSize(5), 'mbs-2.5', ...etc);
 
-export const listItemAppOpenTrigger: ComponentFunction<ListStyleProps> = ({ density }, ...etc) =>
+export const listItemOpenTrigger: ComponentFunction<ListStyleProps> = ({ density }, ...etc) =>
   mx('is-5 rounded flex justify-center items-center', densityBlockSize(density), focusRing, ...etc);
-export const listItemOsOpenTrigger: ComponentFunction<ListStyleProps> = ({ density }, ...etc) =>
-  mx('is-5 rounded flex justify-center items-center', densityBlockSize(density), osFocusRing, ...etc);
 export const listItemOpenTriggerIcon: ComponentFunction<ListStyleProps> = (_props, ...etc) => mx(getSize(3.5), ...etc);
 
 export const listTheme: Theme<ListStyleProps> = {
@@ -39,15 +37,7 @@ export const listTheme: Theme<ListStyleProps> = {
     endcap: listItemEndcap,
     heading: listItemHeading,
     dragHandleIcon: listItemDragHandleIcon,
-    openTrigger: listItemAppOpenTrigger,
+    openTrigger: listItemOpenTrigger,
     openTriggerIcon: listItemOpenTriggerIcon,
-  },
-};
-
-export const listOsTheme: Theme<ListStyleProps> = {
-  ...listTheme,
-  item: {
-    ...listTheme.item,
-    openTrigger: listItemOsOpenTrigger,
   },
 };

--- a/packages/ui/aurora-theme/src/styles/fragments/focus.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/focus.ts
@@ -16,11 +16,5 @@ export const subduedFocus = 'focus:outline-none focus-visible:outline-none';
 /**
  * @deprecated
  */
-export const osFocusRing =
-  'focus:outline-none focus-visible:z-[1] focus-visible:hover:outline-none dark:focus-visible:hover:outline-none focus-visible:ring-2 focus-visible:ring-offset-0 focus-visible:ring-primary-350 focus-visible:ring-offset-white dark:focus-visible:ring-primary-450 dark:focus-visible:ring-offset-black';
-
-/**
- * @deprecated
- */
 export const staticFocusRing =
   'ring-2 ring-offset-0 ring-primary-350 ring-offset-white dark:ring-primary-450 dark:ring-offset-black';

--- a/packages/ui/aurora-theme/src/styles/fragments/hover.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/hover.ts
@@ -7,7 +7,3 @@
  */
 export const hoverColors =
   'transition-colors duration-100 linear hover:text-black dark:hover:text-white hover:bg-neutral-25 dark:hover:bg-neutral-750';
-/**
- * @deprecated
- */
-export const osHoverColors = 'transition-colors duration-100 linear hover:bg-white/75 dark:hover:bg-neutral-750/75';

--- a/packages/ui/aurora-theme/src/styles/theme.ts
+++ b/packages/ui/aurora-theme/src/styles/theme.ts
@@ -8,15 +8,11 @@ import { ComponentFunction, Theme } from '@dxos/aurora-types';
 import {
   avatarTheme,
   buttonTheme,
-  buttonOsTheme,
   dialogTheme,
-  dialogOsTheme,
   dropdownMenuTheme,
   inputTheme,
-  inputOsTheme,
   linkTheme,
   listTheme,
-  listOsTheme,
   mainTheme,
   messageTheme,
   popoverTheme,
@@ -27,7 +23,7 @@ import {
   tagTheme,
 } from './components';
 
-export const theme: Theme<Record<string, any>> = {
+export const auroraTheme: Theme<Record<string, any>> = {
   themeName: () => 'aurora',
 
   avatar: avatarTheme,
@@ -47,16 +43,6 @@ export const theme: Theme<Record<string, any>> = {
   tooltip: tooltipTheme,
 };
 
-export const osTheme: Theme<Record<string, any>> = {
-  ...theme,
-  themeName: () => 'dxos',
-
-  button: buttonOsTheme,
-  dialog: dialogOsTheme,
-  input: inputOsTheme,
-  list: listOsTheme,
-};
-
 export const bindTheme = <P extends Record<string, any>>(theme: Theme<Record<string, any>>) => {
   return (path: string, defaultClassName: string, styleProps: P, ...options: any[]): string => {
     const result: Theme<P> | ComponentFunction<P> = get(theme, path);
@@ -64,6 +50,4 @@ export const bindTheme = <P extends Record<string, any>>(theme: Theme<Record<str
   };
 };
 
-export const appTx = bindTheme(theme);
-
-export const osTx = bindTheme(osTheme);
+export const auroraTx = bindTheme(auroraTheme);

--- a/packages/ui/aurora/.storybook/preview.cjs
+++ b/packages/ui/aurora/.storybook/preview.cjs
@@ -1,6 +1,6 @@
 import React, {createElement, useEffect} from 'react';
 import {ThemeProvider} from '../src';
-import {appTx} from '@dxos/aurora-theme';
+import {auroraTx} from '@dxos/aurora-theme';
 
 export const parameters = {
   actions: {argTypesRegex: "^on[A-Z].*"},
@@ -36,7 +36,7 @@ const withTheme = (StoryFn, context) => {
   useEffect(()=>{
     document.documentElement.classList[theme === 'dark' ? 'add' : 'remove']('dark')
   }, [theme])
-  return createElement(ThemeProvider, {children: createElement(StoryFn), tx: appTx})
+  return createElement(ThemeProvider, {children: createElement(StoryFn), tx: auroraTx})
 }
 
 export const decorators = [withTheme];

--- a/packages/ui/react-appkit/src/components/Menubar/SpaceMenu.tsx
+++ b/packages/ui/react-appkit/src/components/Menubar/SpaceMenu.tsx
@@ -6,7 +6,7 @@ import { Gear, UserPlus, UsersThree } from '@phosphor-icons/react';
 import React from 'react';
 
 import { Button, useTranslation } from '@dxos/aurora';
-import { inlineSeparator, getSize, mx, appTx } from '@dxos/aurora-theme';
+import { inlineSeparator, getSize, mx, auroraTx } from '@dxos/aurora-theme';
 import { Space, useMembers } from '@dxos/react-client/echo';
 
 import { Popover } from '../Popover';
@@ -33,7 +33,7 @@ export const SpaceMenu = ({ space, onClickManageSpace }: SpaceMenuProps) => {
       slots={{
         content: { collisionPadding: 8, sideOffset: 4, className: 'flex flex-col gap-4 items-center z-[2]' },
         trigger: {
-          className: appTx(
+          className: auroraTx(
             'button.root',
             'button button--popover-trigger',
             {},

--- a/packages/ui/react-appkit/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/ui/react-appkit/src/components/ThemeProvider/ThemeProvider.tsx
@@ -13,7 +13,7 @@ import {
   ToastProviderProps,
   ToastViewportProps,
 } from '@dxos/aurora';
-import { appTx } from '@dxos/aurora-theme';
+import { auroraTx } from '@dxos/aurora-theme';
 
 export type ThemeProviderProps = AuroraThemeProviderProps &
   PropsWithChildren<{
@@ -31,7 +31,7 @@ export const ThemeProvider = ({
   ...auroraThemeProviderProps
 }: ThemeProviderProps) => {
   return (
-    <AuroraThemeProvider tx={appTx} {...auroraThemeProviderProps}>
+    <AuroraThemeProvider tx={auroraTx} {...auroraThemeProviderProps}>
       <Toast.Provider {...toastProviderProps}>
         <Tooltip.Provider delayDuration={100} skipDelayDuration={400} {...tooltipProviderProps}>
           {children}


### PR DESCRIPTION
This PR removes the unused/unuseful OS variant of `aurora-theme`.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3e45841</samp>

### Summary
🎨🗑️♻️

<!--
1.  🎨 - This emoji represents the theme and style changes that were made to the UI components, such as using the new `auroraTx` function and removing the OS theme functions.
2.  🗑️ - This emoji represents the removal of unused and redundant code, such as the `osFocusRing` and `osHoverColors` functions, and the `ThemeContext.Provider` component.
3.  ♻️ - This emoji represents the refactoring and simplification of the code, such as renaming the theme functions and variables, and removing unused imports.
-->
This pull request updates various components and plugins to use the new `auroraTx` theme function from the `@dxos/aurora-theme` package. This function provides a consistent and customizable theme for the DXOS apps and UI components. It also removes unused and redundant code related to the OS theme, which simplifies the codebase and reduces dependencies.

> _`osTx` is no more_
> _`auroraTx` shines brightly_
> _theme of winter snow_

### Walkthrough
*  Simplify and unify the theme function and theme object names for the aurora theme and components ([link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-395d63617761923cc7940021c201f52df453fa57e7c144bfe041502424de280fL54-R52), [link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-395d63617761923cc7940021c201f52df453fa57e7c144bfe041502424de280fL77-L91), [link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-395d63617761923cc7940021c201f52df453fa57e7c144bfe041502424de280fL101-R86), [link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-6314d4eb7c3ff475be63dfc2237fc2a473f6ff4fe05c30609daf7ff3c01c242fL21-L23), [link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-6314d4eb7c3ff475be63dfc2237fc2a473f6ff4fe05c30609daf7ff3c01c242fL35-L37), [link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-6314d4eb7c3ff475be63dfc2237fc2a473f6ff4fe05c30609daf7ff3c01c242fL55-L61), [link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-a192ded1ae528b466e414dcb432135926dae3de90004939937fff8d5264438b9L88-R86), [link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-a192ded1ae528b466e414dcb432135926dae3de90004939937fff8d5264438b9L103-R101), [link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-a192ded1ae528b466e414dcb432135926dae3de90004939937fff8d5264438b9L127-L135), [link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-a192ded1ae528b466e414dcb432135926dae3de90004939937fff8d5264438b9L155-R131), [link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-a192ded1ae528b466e414dcb432135926dae3de90004939937fff8d5264438b9L164-L169), [link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-d91396b5f2e9d8ccc1f0f6e47aa666fe99e5edc98d8013b96a20eee2236c4759L29-R30), [link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-d91396b5f2e9d8ccc1f0f6e47aa666fe99e5edc98d8013b96a20eee2236c4759L42-R43), [link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-69241f25f1647f6105233f677788a042089cb28715f9649a78636af9e554b8f5L30-R26), [link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-69241f25f1647f6105233f677788a042089cb28715f9649a78636af9e554b8f5L50-L59), [link](https://github.com/dxos/dxos/pull/3830/files?diff=unified&w=0#diff-69241f25f1647f6105233f677788a042089cb28715f9649a78636af9e554b8f5L67-R53)).


