### PR TITLE
chore: Echo testbench n peers

### DIFF
--- a/packages/core/mesh/teleport-extension-gossip/src/gossip.ts
+++ b/packages/core/mesh/teleport-extension-gossip/src/gossip.ts
@@ -58,6 +58,11 @@ export class Gossip {
       onClose: async (err) => {
         if (err) {
           log.catch(err);
+          log.trace('dxos.mesh.gossip.ConnectionClosedWithError', {
+            ...JSON.parse(process.env.GRAVITY_AGENT_CONTEXT ?? ''),
+            timestamp: Date.now(),
+            err,
+          });
         }
         if (this._connections.has(remotePeerId)) {
           this._connections.delete(remotePeerId);

--- a/packages/core/mesh/teleport-extension-object-sync/src/blob-store.ts
+++ b/packages/core/mesh/teleport-extension-object-sync/src/blob-store.ts
@@ -3,11 +3,11 @@
 //
 
 import path from 'node:path';
-import invariant from 'tiny-invariant';
 
 import { synchronized } from '@dxos/async';
 import { subtleCrypto } from '@dxos/crypto';
 import { PublicKey } from '@dxos/keys';
+import { invariant } from '@dxos/log';
 import { schema } from '@dxos/protocols';
 import { BlobMeta } from '@dxos/protocols/proto/dxos/echo/blob';
 import { BlobChunk } from '@dxos/protocols/proto/dxos/mesh/teleport/blobsync';
@@ -62,7 +62,7 @@ export class BlobStore {
     const endChunk = Math.ceil((offset + length) / metadata.chunkSize);
 
     invariant(metadata.bitfield, 'Bitfield not present');
-    invariant(metadata.bitfield.length >= endChunk, 'Invalid bitfield length');
+    invariant(metadata.bitfield.length * 8 >= endChunk, 'Invalid bitfield length');
 
     const present = BitField.count(metadata.bitfield, beginChunk, endChunk) === endChunk - beginChunk;
 

--- a/packages/core/mesh/teleport-extension-replicator/src/replicator-extension.ts
+++ b/packages/core/mesh/teleport-extension-replicator/src/replicator-extension.ts
@@ -237,6 +237,12 @@ export class ReplicatorExtension implements TeleportExtension {
         return;
       }
 
+      log.trace('dxos.mesh.replicator-extension.ReplicationStreamError', {
+        ...JSON.parse(process.env.GRAVITY_AGENT_CONTEXT ?? ''),
+        timestamp: Date.now(),
+        err,
+        info,
+      });
       log.warn('replication stream error', { err, info });
     });
 

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -45,11 +45,11 @@ const runEcho = () =>
   runPlan({
     plan: new EchoTestPlan(),
     spec: {
-      agents: 2,
+      agents: 3,
       duration: 300_000,
       iterationDelay: 300,
 
-      epochPeriod: 8,
+      epochPeriod: 10,
       measureNewAgentSyncTime: true,
 
       insertionSize: 512,

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -46,13 +46,14 @@ const runEcho = () =>
     plan: new EchoTestPlan(),
     spec: {
       agents: 3,
-      duration: 300_000,
+      duration: 60_000,
       iterationDelay: 300,
 
       epochPeriod: 10,
-      measureNewAgentSyncTime: true,
+      // measureNewAgentSyncTime: true,
 
-      insertionSize: 512,
+      insertionSize: 10,
+      operationsDelay: 10,
       operationCount: 1000,
 
       signalArguments: ['globalsubserver'],

--- a/packages/gravity/kube-testing/src/plan/echo-spec.ts
+++ b/packages/gravity/kube-testing/src/plan/echo-spec.ts
@@ -123,7 +123,7 @@ export class EchoTestPlan implements TestPlan<EchoTestSpec, EchoAgentConfig> {
     }
 
     let iter = 0;
-    const lastTimeframe = this.getSpaceBackend().dataPipeline.pipelineState?.timeframe ?? new Timeframe();
+    let lastTimeframe = this.getSpaceBackend().dataPipeline.pipelineState?.timeframe ?? new Timeframe();
     let lastTime = Date.now();
     const ctx = new Context();
     scheduleTaskInterval(
@@ -149,6 +149,7 @@ export class EchoTestPlan implements TestPlan<EchoTestSpec, EchoAgentConfig> {
           // compute throughput
           const mutationsSinceLastIter =
             this.getSpaceBackend().dataPipeline.pipelineState!.timeframe.newMessages(lastTimeframe);
+          lastTimeframe = this.getSpaceBackend().dataPipeline.pipelineState?.timeframe ?? new Timeframe();
           const timeSinceLastIter = Date.now() - lastTime;
           lastTime = Date.now();
           const mutationsPerSec = Math.round(mutationsSinceLastIter / (timeSinceLastIter / 1000));

--- a/packages/gravity/kube-testing/src/plan/run-plan.ts
+++ b/packages/gravity/kube-testing/src/plan/run-plan.ts
@@ -163,7 +163,7 @@ const runPlanner = async <S, C>({ plan, spec, options }: RunPlanParams<S, C>) =>
 
   let stats: any;
   try {
-    stats = await await plan.finish(
+    stats = await plan.finish(
       {
         spec,
         outDir,

--- a/packages/gravity/kube-testing/src/plan/run-plan.ts
+++ b/packages/gravity/kube-testing/src/plan/run-plan.ts
@@ -204,6 +204,8 @@ const runAgent = async <S, C>(plan: TestPlan<S, C>, params: AgentParams<S, C>) =
     const env = new AgentEnv<S, C>(params);
     await env.open();
 
+    process.env.GRAVITY_AGENT_CONTEXT = JSON.stringify(params);
+
     await plan.run(env);
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2a9c57e</samp>

### Summary
📝🐛⚙️

<!--
1.  📝 This emoji represents the addition of logging and tracing information for the gossip and replication protocols, as well as the echo test plan. It suggests that these changes are documenting and monitoring the system behavior and performance.
2. 🐛 This emoji represents the bug fixes for the assertion library, the bitfield length, and the syntax error. It suggests that these changes are resolving issues and improving the code quality and functionality.
3. ⚙️ This emoji represents the modification and tuning of the test parameters and options for the echo test plan. It suggests that these changes are adjusting and optimizing the system configuration and settings.
-->
This pull request improves the logging, error handling, and testing of the teleport, gossip, and replication protocols in the `dxos` core and gravity packages. It updates the logging and assertion library, fixes some bugs, and modifies some test parameters in various files. It also adds more options and metrics for the echo test plan in the `kube-testing` package.

> _We're logging and testing the code of the day_
> _We're fixing the bugs that get in our way_
> _We're heaving and hauling on the count of three_
> _We're syncing the blobs and the `Gossip` with glee_

### Walkthrough
*  Add more logging and metrics for the gossip and replication protocols ([link](https://github.com/dxos/dxos/pull/3834/files?diff=unified&w=0#diff-8c0d22e91ef78cf597ee52fe4f8f36f1608d2baad932a27bf9d7f097e805101aR61-R65), [link](https://github.com/dxos/dxos/pull/3834/files?diff=unified&w=0#diff-2f9395f42d440a09c4fabb6ee3ff80d21d8a62497e8d8ec8883a43c2b1a3a8d9R240-R245), [link](https://github.com/dxos/dxos/pull/3834/files?diff=unified&w=0#diff-da1ed7e5b6dee07e2cd55ee07005f29842c8957b355854012b4da4eaaff5b678R272), [link](https://github.com/dxos/dxos/pull/3834/files?diff=unified&w=0#diff-da1ed7e5b6dee07e2cd55ee07005f29842c8957b355854012b4da4eaaff5b678L278-R302))
* Fix a bug and use a consistent logging and assertion library in the `BlobStore` class ([link](https://github.com/dxos/dxos/pull/3834/files?diff=unified&w=0#diff-556c4f12c984b1316342932966935bcc7ee258fbe7e3ea634be77909d7433257L6-R10), [link](https://github.com/dxos/dxos/pull/3834/files?diff=unified&w=0#diff-556c4f12c984b1316342932966935bcc7ee258fbe7e3ea634be77909d7433257L65-R65))
* Tune the test parameters and add more options and logging for the echo test plan ([link](https://github.com/dxos/dxos/pull/3834/files?diff=unified&w=0#diff-07d9a4fe62c5ce84347caf3b0b32a13540ad7cb7704251c7230663f3d92d4958L48-R56), [link](https://github.com/dxos/dxos/pull/3834/files?diff=unified&w=0#diff-da1ed7e5b6dee07e2cd55ee07005f29842c8957b355854012b4da4eaaff5b678R43), [link](https://github.com/dxos/dxos/pull/3834/files?diff=unified&w=0#diff-da1ed7e5b6dee07e2cd55ee07005f29842c8957b355854012b4da4eaaff5b678L126-R127), [link](https://github.com/dxos/dxos/pull/3834/files?diff=unified&w=0#diff-da1ed7e5b6dee07e2cd55ee07005f29842c8957b355854012b4da4eaaff5b678R153), [link](https://github.com/dxos/dxos/pull/3834/files?diff=unified&w=0#diff-da1ed7e5b6dee07e2cd55ee07005f29842c8957b355854012b4da4eaaff5b678R180), [link](https://github.com/dxos/dxos/pull/3834/files?diff=unified&w=0#diff-da1ed7e5b6dee07e2cd55ee07005f29842c8957b355854012b4da4eaaff5b678L187-R191))
* Pass the agent context to the log entries in the `runAgent` function ([link](https://github.com/dxos/dxos/pull/3834/files?diff=unified&w=0#diff-658b0da483ec1b73d11d587fa81c489bee16c067d328e9816ee1f082b1eee5f0L166-R166), [link](https://github.com/dxos/dxos/pull/3834/files?diff=unified&w=0#diff-658b0da483ec1b73d11d587fa81c489bee16c067d328e9816ee1f082b1eee5f0R207-R208))


