### PR TITLE
fix: Fix blob store invariant

### DIFF
--- a/packages/core/mesh/teleport-extension-object-sync/src/blob-store.ts
+++ b/packages/core/mesh/teleport-extension-object-sync/src/blob-store.ts
@@ -3,11 +3,11 @@
 //
 
 import path from 'node:path';
-import invariant from 'tiny-invariant';
 
 import { synchronized } from '@dxos/async';
 import { subtleCrypto } from '@dxos/crypto';
 import { PublicKey } from '@dxos/keys';
+import { invariant } from '@dxos/log';
 import { schema } from '@dxos/protocols';
 import { BlobMeta } from '@dxos/protocols/proto/dxos/echo/blob';
 import { BlobChunk } from '@dxos/protocols/proto/dxos/mesh/teleport/blobsync';
@@ -62,7 +62,7 @@ export class BlobStore {
     const endChunk = Math.ceil((offset + length) / metadata.chunkSize);
 
     invariant(metadata.bitfield, 'Bitfield not present');
-    invariant(metadata.bitfield.length >= endChunk, 'Invalid bitfield length');
+    invariant(metadata.bitfield.length * 8 >= endChunk, 'Invalid bitfield length');
 
     const present = BitField.count(metadata.bitfield, beginChunk, endChunk) === endChunk - beginChunk;
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c719326</samp>

### Summary
🐛📝🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is what the bitfield length calculation and chunk presence detection changes are.
2.  📝 - This emoji represents improved documentation or logging, which is what the replacement of `tiny-invariant` with `@dxos/log` does.
3.  🚀 - This emoji represents a performance improvement or optimization, which is what the blob-store.ts changes could potentially achieve by reducing unnecessary network requests or disk reads.
-->
Improved logging, assertions, and chunk presence detection for the teleport extension object sync. Replaced `tiny-invariant` with `@dxos/log` and fixed bitfield length calculation in `blob-store.ts`.

> _Sing, O Muse, of the cunning coder who refined the blob-store_
> _And replaced the tiny-invariant with the log of DXOS fame_
> _To enhance the assertions and the messages of error and success_
> _And to fix the calculation of the bitfield's length and name_

### Walkthrough
* Replace `tiny-invariant` with `@dxos/log` for consistent logging and assertion ([link](https://github.com/dxos/dxos/pull/3835/files?diff=unified&w=0#diff-556c4f12c984b1316342932966935bcc7ee258fbe7e3ea634be77909d7433257L6-R10)).


