### PR TITLE
feat: Batched feed reads & storage metrics

### DIFF
--- a/packages/common/async/src/timeout.ts
+++ b/packages/common/async/src/timeout.ts
@@ -41,11 +41,7 @@ export const asyncTimeout = async <T>(
       reject(throwable);
     }, timeout);
 
-    // In Node.JS, `unref` prevents the timeout from blocking the process from exiting. Not available in browsers.
-    // https://nodejs.org/api/timers.html#timeoutunref
-    if (typeof timeoutId === 'object' && 'unref' in timeoutId) {
-      timeoutId.unref();
-    }
+    unrefTimeout(timeoutId);
   });
 
   const conditionTimeout = typeof promise === 'function' ? createPromiseFromCallback<T>(promise) : promise;
@@ -53,3 +49,13 @@ export const asyncTimeout = async <T>(
     clearTimeout(timeoutId);
   });
 };
+
+/**
+ * In Node.JS, `unref` prevents the timeout from blocking the process from exiting. Not available in browsers.
+ * https://nodejs.org/api/timers.html#timeoutunref
+ */
+export const unrefTimeout = (timeoutId: NodeJS.Timeout) => {
+  if (typeof timeoutId === 'object' && 'unref' in timeoutId) {
+    timeoutId.unref();
+  }
+}

--- a/packages/common/async/src/timeout.ts
+++ b/packages/common/async/src/timeout.ts
@@ -58,4 +58,4 @@ export const unrefTimeout = (timeoutId: NodeJS.Timeout) => {
   if (typeof timeoutId === 'object' && 'unref' in timeoutId) {
     timeoutId.unref();
   }
-}
+};

--- a/packages/common/feed-store/src/feed-queue.ts
+++ b/packages/common/feed-store/src/feed-queue.ts
@@ -15,6 +15,7 @@ import { FeedBlock } from './types';
 
 export const defaultReadStreamOptions: ReadStreamOptions = {
   live: true, // Keep reading until closed.
+  batch: 64, // Read in batches.
 };
 
 export type FeedQueueOptions = {};

--- a/packages/common/feed-store/src/feed-wrapper.ts
+++ b/packages/common/feed-store/src/feed-wrapper.ts
@@ -5,13 +5,12 @@
 import { Range } from 'hypercore';
 import { inspect } from 'node:util';
 import { Readable, Transform } from 'streamx';
-import { invariant } from '@dxos/log';
 
 import { Trigger } from '@dxos/async';
 import { inspectObject, StackTrace } from '@dxos/debug';
 import type { Hypercore, HypercoreProperties, ReadStreamOptions } from '@dxos/hypercore';
 import { PublicKey } from '@dxos/keys';
-import { log } from '@dxos/log';
+import { invariant, log } from '@dxos/log';
 import { createBinder } from '@dxos/util';
 
 import { FeedWriter, WriteReceipt } from './feed-writer';
@@ -75,9 +74,10 @@ export class FeedWrapper<T extends {}> {
         });
       },
     });
-    const readStream = opts?.batch !== undefined && opts?.batch > 1
-      ? new BatchedReadStream(this._hypercore, opts)
-      : this._hypercore.createReadStream(opts);
+    const readStream =
+      opts?.batch !== undefined && opts?.batch > 1
+        ? new BatchedReadStream(this._hypercore, opts)
+        : this._hypercore.createReadStream(opts);
 
     readStream.pipe(transform, (err: any) => {
       // Ignore errors.
@@ -205,7 +205,6 @@ class BatchedReadStream extends Readable {
     }
   }
 
-
   private _nonBatchedRead(cb: (err: Error | null) => void) {
     this._feed.get(this._cursor, { wait: true }, (err, data) => {
       if (err) {
@@ -214,7 +213,7 @@ class BatchedReadStream extends Readable {
         this._cursor++;
         this._reading = false;
         this.push(data);
-        cb(null)
+        cb(null);
       }
     });
   }
@@ -229,7 +228,7 @@ class BatchedReadStream extends Readable {
         for (const item of data) {
           this.push(item);
         }
-        cb(null)
+        cb(null);
       }
     });
   }

--- a/packages/common/random-access-storage/src/browser/web-fs.ts
+++ b/packages/common/random-access-storage/src/browser/web-fs.ts
@@ -22,7 +22,7 @@ export class WebFS implements Storage {
   protected readonly _files = new Map<string, File>();
   protected _root?: FileSystemDirectoryHandle;
 
-  constructor(public readonly path: string) { }
+  constructor(public readonly path: string) {}
 
   public get size() {
     return this._files.size;
@@ -176,7 +176,15 @@ export class WebFile extends EventEmitter implements File {
   private readonly _fileHandle: Promise<FileSystemFileHandle>;
   private readonly _destroy: () => Promise<void>;
 
-  constructor({ fileName, file, destroy }: { file: Promise<FileSystemFileHandle>; fileName: string, destroy: () => Promise<void> }) {
+  constructor({
+    fileName,
+    file,
+    destroy,
+  }: {
+    file: Promise<FileSystemFileHandle>;
+    fileName: string;
+    destroy: () => Promise<void>;
+  }) {
     super();
     this._fileName = fileName;
     this._fileHandle = file;
@@ -199,7 +207,7 @@ export class WebFile extends EventEmitter implements File {
 
   @synchronized
   async write(offset: number, data: Buffer) {
-    const metric = STORAGE_MONITOR.beginOp({ resource: this._fileName, type: 'write', size: data.length })
+    const metric = STORAGE_MONITOR.beginOp({ resource: this._fileName, type: 'write', size: data.length });
     try {
       // TODO(mykola): Fix types.
       const fileHandle: any = await this._fileHandle;
@@ -213,7 +221,7 @@ export class WebFile extends EventEmitter implements File {
 
   @synchronized
   async read(offset: number, size: number) {
-    const metric = STORAGE_MONITOR.beginOp({ resource: this._fileName, type: 'read', size })
+    const metric = STORAGE_MONITOR.beginOp({ resource: this._fileName, type: 'read', size });
     try {
       const fileHandle: any = await this._fileHandle;
       const file = await fileHandle.getFile();
@@ -229,7 +237,7 @@ export class WebFile extends EventEmitter implements File {
 
   @synchronized
   async del(offset: number, size: number) {
-    const metric = STORAGE_MONITOR.beginOp({ resource: this._fileName, type: 'delete', size })
+    const metric = STORAGE_MONITOR.beginOp({ resource: this._fileName, type: 'delete', size });
     try {
       if (offset < 0 || size < 0) {
         return;
@@ -250,12 +258,11 @@ export class WebFile extends EventEmitter implements File {
     } finally {
       metric.end();
     }
-
   }
 
   @synchronized
   async stat() {
-    const metric = STORAGE_MONITOR.beginOp({ resource: this._fileName, type: 'stat' })
+    const metric = STORAGE_MONITOR.beginOp({ resource: this._fileName, type: 'stat' });
     try {
       const fileHandle: any = await this._fileHandle;
       const file = await fileHandle.getFile();
@@ -269,7 +276,7 @@ export class WebFile extends EventEmitter implements File {
 
   @synchronized
   async truncate(offset: number) {
-    const metric = STORAGE_MONITOR.beginOp({ resource: this._fileName, type: 'truncate' })
+    const metric = STORAGE_MONITOR.beginOp({ resource: this._fileName, type: 'truncate' });
     try {
       const fileHandle: any = await this._fileHandle;
       const writable = await fileHandle.createWritable({ keepExistingData: true });
@@ -280,12 +287,11 @@ export class WebFile extends EventEmitter implements File {
     }
   }
 
-  async close(): Promise<void> { }
+  async close(): Promise<void> {}
 
   @synchronized
   async destroy() {
     this.destroyed = true;
     return await this._destroy();
   }
-
 }

--- a/packages/common/random-access-storage/src/monitor.ts
+++ b/packages/common/random-access-storage/src/monitor.ts
@@ -38,12 +38,16 @@ const BUCKET_COLLECTION_INTERVAL = 1_000;
  * Storage performance metrics.
  */
 export class StorageMonitor {
+  private _enabled = false;
+  
   /**
    * By resource.
    */
   private readonly _buckets = new Map<string, StatsBucket>();
 
-  constructor() {
+  enable() {
+    this._enabled = true;
+
     const timer = setInterval(() => {
       this._finalizeBuckets();
     }, BUCKET_COLLECTION_INTERVAL);
@@ -51,6 +55,12 @@ export class StorageMonitor {
   }
 
   beginOp(op: StorageOperation): OpHandle {
+    if(!this._enabled) {
+      return {
+        end: () => {}
+      }
+    }
+    
     const beginTime = performance.now();
     return {
       end: () => {
@@ -121,3 +131,6 @@ export class StorageMonitor {
 }
 
 export const STORAGE_MONITOR = new StorageMonitor();
+
+// TODO(dmaretskyi): Disabled due to performance concerns.
+// STORAGE_MONITOR.enable();

--- a/packages/common/random-access-storage/src/monitor.ts
+++ b/packages/common/random-access-storage/src/monitor.ts
@@ -1,14 +1,18 @@
-import { unrefTimeout } from "@dxos/async";
+//
+// Copyright 2023 DXOS.org
+//
+
+import { unrefTimeout } from '@dxos/async';
 
 export type StorageOperation = {
   resource: string;
   type: 'read' | 'write' | 'stat' | 'delete' | 'truncate';
   size?: number;
-}
+};
 
 export type OpHandle = {
   end: () => void;
-}
+};
 
 export type StatsBucket = {
   resource: string;
@@ -30,7 +34,7 @@ export type StatsBucket = {
 
   otherOps: number;
   otherTime: number;
-}
+};
 
 const BUCKET_COLLECTION_INTERVAL = 1_000;
 
@@ -39,7 +43,7 @@ const BUCKET_COLLECTION_INTERVAL = 1_000;
  */
 export class StorageMonitor {
   private _enabled = false;
-  
+
   /**
    * By resource.
    */
@@ -55,12 +59,12 @@ export class StorageMonitor {
   }
 
   beginOp(op: StorageOperation): OpHandle {
-    if(!this._enabled) {
+    if (!this._enabled) {
       return {
-        end: () => {}
-      }
+        end: () => {},
+      };
     }
-    
+
     const beginTime = performance.now();
     return {
       end: () => {
@@ -83,8 +87,8 @@ export class StorageMonitor {
             bucket.otherOps++;
             bucket.otherTime += duration;
         }
-      }
-    }
+      },
+    };
   }
 
   private _getOrInitBucket(resource: string): StatsBucket {
@@ -119,14 +123,14 @@ export class StorageMonitor {
       bucket.usage = (bucket.readTime + bucket.writeTime + bucket.otherTime) / (bucket.endTime - bucket.beginTime);
       toEmit.push(bucket);
     }
-    
+
     // Clear the buckets.
     this._buckets.clear();
-    for(const bucket of toEmit) {
-      this._getOrInitBucket(bucket.resource)
+    for (const bucket of toEmit) {
+      this._getOrInitBucket(bucket.resource);
     }
 
-    ((globalThis as any).__STORAGE_METRICS ??= []).push(...toEmit)
+    ((globalThis as any).__STORAGE_METRICS ??= []).push(...toEmit);
   }
 }
 

--- a/packages/common/random-access-storage/src/monitor.ts
+++ b/packages/common/random-access-storage/src/monitor.ts
@@ -1,0 +1,123 @@
+import { unrefTimeout } from "@dxos/async";
+
+export type StorageOperation = {
+  resource: string;
+  type: 'read' | 'write' | 'stat' | 'delete' | 'truncate';
+  size?: number;
+}
+
+export type OpHandle = {
+  end: () => void;
+}
+
+export type StatsBucket = {
+  resource: string;
+  beginTime: number;
+  endTime: number;
+
+  /**
+   * Fraction of time spent in storage operations.
+   */
+  usage: number;
+
+  readOps: number;
+  readBytes: number;
+  readTime: number;
+
+  writeOps: number;
+  writeBytes: number;
+  writeTime: number;
+
+  otherOps: number;
+  otherTime: number;
+}
+
+const BUCKET_COLLECTION_INTERVAL = 1_000;
+
+/**
+ * Storage performance metrics.
+ */
+export class StorageMonitor {
+  /**
+   * By resource.
+   */
+  private readonly _buckets = new Map<string, StatsBucket>();
+
+  constructor() {
+    const timer = setInterval(() => {
+      this._finalizeBuckets();
+    }, BUCKET_COLLECTION_INTERVAL);
+    unrefTimeout(timer);
+  }
+
+  beginOp(op: StorageOperation): OpHandle {
+    const beginTime = performance.now();
+    return {
+      end: () => {
+        const endTime = performance.now();
+        const duration = endTime - beginTime;
+
+        const bucket = this._getOrInitBucket(op.resource);
+        switch (op.type) {
+          case 'read':
+            bucket.readOps++;
+            bucket.readBytes += op.size ?? 0;
+            bucket.readTime += duration;
+            break;
+          case 'write':
+            bucket.writeOps++;
+            bucket.writeBytes += op.size ?? 0;
+            bucket.writeTime += duration;
+            break;
+          default:
+            bucket.otherOps++;
+            bucket.otherTime += duration;
+        }
+      }
+    }
+  }
+
+  private _getOrInitBucket(resource: string): StatsBucket {
+    const bucket = this._buckets.get(resource);
+    if (bucket) {
+      return bucket;
+    }
+
+    const newBucket = {
+      resource,
+      beginTime: performance.now(),
+      endTime: 0,
+      usage: 0,
+      readOps: 0,
+      readBytes: 0,
+      readTime: 0,
+      writeOps: 0,
+      writeBytes: 0,
+      writeTime: 0,
+      otherOps: 0,
+      otherTime: 0,
+    };
+    this._buckets.set(resource, newBucket);
+    return newBucket;
+  }
+
+  private _finalizeBuckets() {
+    const now = performance.now();
+    const toEmit = [];
+    for (const bucket of this._buckets.values()) {
+      bucket.endTime = now;
+      bucket.usage = (bucket.readTime + bucket.writeTime + bucket.otherTime) / (bucket.endTime - bucket.beginTime);
+      toEmit.push(bucket);
+    }
+    
+    // Clear the buckets.
+    this._buckets.clear();
+    for(const bucket of toEmit) {
+      this._getOrInitBucket(bucket.resource)
+    }
+
+    ((globalThis as any).__STORAGE_METRICS ??= []).push(...toEmit)
+  }
+}
+
+export const STORAGE_MONITOR = new StorageMonitor();

--- a/packages/common/typings/src/hypercore.d.ts
+++ b/packages/common/typings/src/hypercore.d.ts
@@ -174,13 +174,17 @@ declare module 'hypercore' {
     // https://github.com/hypercore-protocol/hypercore/tree/v9.12.0#feedstats
     readonly stats: Stats;
 
-    bitfield?: {
-      data: any; // sparse-bitfield package
-
-      // TODO(dmaretskyi): More props.
-    };
+    bitfield?: HypercoreBitfield;
 
     readonly sparse: boolean;
+  }
+
+  export interface HypercoreBitfield {
+    data: any; // sparse-bitfield package
+
+    total(start: number, end: number): number;
+
+    // TODO(dmaretskyi): More props.
   }
 
   /**

--- a/packages/common/typings/src/streamx.d.ts
+++ b/packages/common/typings/src/streamx.d.ts
@@ -49,6 +49,11 @@ declare module 'streamx' {
   export class Readable extends Stream implements IReadable {
     constructor(args?: any);
 
+    _open(cb: (err: Error | null) => void);
+    _read(cb: (err: Error | null) => void);
+
+    push(chunk: any);
+
     pipe(dest: Writable, cb?: Callback);
   }
 

--- a/packages/common/util/src/tracer.ts
+++ b/packages/common/util/src/tracer.ts
@@ -6,7 +6,7 @@ import { defaultMap } from './map';
 
 const getMicroseconds = () => {
   if (typeof process.hrtime !== 'function') {
-    return 0
+    return 0;
   }
   const [seconds, nano] = process.hrtime();
   return seconds * 1e6 + nano / 1e3;

--- a/packages/common/util/src/tracer.ts
+++ b/packages/common/util/src/tracer.ts
@@ -5,6 +5,9 @@
 import { defaultMap } from './map';
 
 const getMicroseconds = () => {
+  if (typeof process.hrtime !== 'function') {
+    return 0
+  }
   const [seconds, nano] = process.hrtime();
   return seconds * 1e6 + nano / 1e3;
 };

--- a/packages/devtools/devtools/src/containers/SpaceSelector.tsx
+++ b/packages/devtools/devtools/src/containers/SpaceSelector.tsx
@@ -25,7 +25,6 @@ export const SpaceSelector = () => {
       ...state,
       space: spaceKey ? spaces.find((space) => space.key.equals(spaceKey)) : undefined,
       spaceInfo: spaceKey ? spacesInfo.find((spaceInfo) => spaceInfo.key.equals(spaceKey)) : undefined,
-      feedKey: undefined,
     }));
 
     if (spaceKey) {

--- a/packages/devtools/devtools/src/panels/echo/FeedsPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/FeedsPanel.tsx
@@ -42,10 +42,10 @@ const FeedsPanel = () => {
 
   const devtoolsHost = useDevtools();
   const [refreshCount, setRefreshCount] = useState(0);
-  const { feeds = [] } = useStream(() => devtoolsHost.subscribeToFeeds({ feedKeys }), {}, [refreshCount]);
+  const { feeds } = useStream(() => devtoolsHost.subscribeToFeeds({ feedKeys }), {}, [refreshCount]);
 
   const messages = useFeedMessages({ feedKey }).reverse();
-  const meta = feeds.find((feed) => feedKey && feed.feedKey.equals(feedKey));
+  const meta = feeds?.find((feed) => feedKey && feed.feedKey.equals(feedKey));
 
   // Hack to select and refresh first feed.
   const key = feedKey ?? feedKeys[0];
@@ -58,6 +58,12 @@ const FeedsPanel = () => {
     }
   }, [key]);
 
+  useEffect(() => {
+    if(feedKey && feedKeys.length > 0 && !feedKeys.find(feed => feed.equals(feedKey))) {
+      handleSelect(feedKeys[0]);
+    }
+  }, [JSON.stringify(feedKeys), feedKey])
+
   const handleSelect = (feedKey?: PublicKey) => {
     setContext((state) => ({ ...state, feedKey }));
   };
@@ -68,7 +74,7 @@ const FeedsPanel = () => {
 
   const getLabel = (key: PublicKey) => {
     const type = space?.internal.data.pipeline?.controlFeeds?.includes(key) ? 'control' : 'data';
-    const meta = feeds.find((feed) => feed.feedKey.equals(key));
+    const meta = feeds?.find((feed) => feed.feedKey.equals(key));
     if (meta) {
       return `${type} (${meta.length})`;
     } else {

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel.tsx
@@ -18,7 +18,8 @@ import { ComplexSet, humanize } from '@dxos/util';
 
 import { DetailsTable, PanelContainer, Toolbar } from '../../components';
 import { SpaceSelector } from '../../containers';
-import { useDevtoolsState, useSpacesInfo } from '../../hooks';
+import { useDevtoolsDispatch, useDevtoolsState, useSpacesInfo } from '../../hooks';
+import { useNavigate } from 'react-router-dom';
 
 const SpaceInfoPanel: FC = () => {
   const { space } = useDevtoolsState();
@@ -112,7 +113,16 @@ const columns: TableColumn<PipelineTableRow>[] = [
   {
     Header: 'FeedKey',
     width: 80,
-    Cell: ({ value }: any) => <div className='font-mono'>{value}</div>,
+    Cell: ({ value, row }: any) => {
+      const setContext = useDevtoolsDispatch();
+      const navigate = useNavigate();
+      const onClick = () => {
+        setContext(ctx => ({ ...ctx, feedKey: row.original.feedKey }));
+        navigate('/echo/feeds');
+      }
+
+      return <a className='font-mono text-blue-800 cursor-pointer' onClick={onClick}>{value}</a>
+    },
     accessor: (block) => {
       const feedKey = block.feedKey;
       return `${feedKey.truncate()}`;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e1b318d</samp>

### Summary
🚀📊🐛

<!--
1.  🚀 - This emoji represents the performance improvement and efficiency of using the `BatchedReadStream` class and the `unrefTimeout` function.
2.  📊 - This emoji represents the addition of the `StorageMonitor` class and the `STORAGE_MONITOR` instance that measure and emit the storage metrics for the random access storage implementations.
3.  🐛 - This emoji represents the bug fixes and error handling improvements for the `tracer.ts`, `FeedsPanel`, and `SpaceSelector` files.
-->
This pull request introduces several improvements and features to the `dxos` packages, such as:

> _We're sailing on the hypercore, we're reading in a batch_
> _We're monitoring the storage, we're logging every catch_
> _We're fixing all the errors, we're syncing all the state_
> _We're building the devtools, so sing along me mate_

### Walkthrough
*  Refactor `asyncTimeout` function to use `unrefTimeout` helper ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-112588dbd86cfdc37c8d660f6438db8cfa3924e9d6bfc1ca72eb47d8b7a1140fL44-R44))
*  Add `unrefTimeout` function to handle calling `unref` on timeout objects ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-112588dbd86cfdc37c8d660f6438db8cfa3924e9d6bfc1ca72eb47d8b7a1140fR52-R61))
*  Update `defaultReadStreamOptions` to include `batch` property for `BatchedReadStream` ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-a8b9cf688aad506de3104c55cc8ff78bea1ac77de77007fe8d08f68e003e2facR18))
*  Replace `tiny-invariant` import with `@dxos/log` import in `feed-wrapper.ts` ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-64fa5ed50276a5b9c275e0a0c5783bf20564f732925405ced87a10f9fd6dc8d5L8), [link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-64fa5ed50276a5b9c275e0a0c5783bf20564f732925405ced87a10f9fd6dc8d5L14-R13))
*  Use `BatchedReadStream` class in `FeedWrapper.createReadStream` method if `batch` option is specified ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-64fa5ed50276a5b9c275e0a0c5783bf20564f732925405ced87a10f9fd6dc8d5L78-R87))
*  Add `BatchedReadStream` class to implement batched reading from hypercore feeds ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-64fa5ed50276a5b9c275e0a0c5783bf20564f732925405ced87a10f9fd6dc8d5R173-R235))
*  Add `STORAGE_MONITOR` import and `fileName` property to `WebFS` and `WebFile` classes in `web-fs.ts` ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-ccda6ccab8c2365217eb1ce5fb59fee83beca7a5b48b18eeec7d5f189b25abb4R14), [link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-ccda6ccab8c2365217eb1ce5fb59fee83beca7a5b48b18eeec7d5f189b25abb4R94), [link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-ccda6ccab8c2365217eb1ce5fb59fee83beca7a5b48b18eeec7d5f189b25abb4L172-R189))
*  Add `TODO` comment to indicate unused `truncatable` property in `WebFile` class ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-ccda6ccab8c2365217eb1ce5fb59fee83beca7a5b48b18eeec7d5f189b25abb4R196))
*  Use `STORAGE_MONITOR` instance to measure storage performance metrics in `WebFile` methods ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-ccda6ccab8c2365217eb1ce5fb59fee83beca7a5b48b18eeec7d5f189b25abb4L197-R289))
*  Move `truncate` method to a different location in `WebFile` class ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-ccda6ccab8c2365217eb1ce5fb59fee83beca7a5b48b18eeec7d5f189b25abb4L251-L258))
*  Add `monitor.ts` file with `StorageMonitor` class and `STORAGE_MONITOR` instance for storage metrics ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-56d24e508d9c2e94a54bc78a71c6c8fdb403b2faff6ee999b12eca108ccda538R1-R140))
*  Add condition to check `process.hrtime` availability in `tracer.ts` ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-ff3743c6eede4f4c644faa9300d69d513dddc0b3bc17a13664f2388d999d7023R8-R10))
*  Remove `feedKey` prop from `SpaceSelector` component in `devtools` ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-fb463a5a3b6f5a9912c4579a0904784e88ab8af5cf4e0863f00c785930a01405L28))
*  Use optional chaining to handle undefined `feeds` property in `FeedsPanel` component in `devtools` ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-ff312048d36f304aba4238d52665e58147467d4e7cc0e7f75d81f39e0fe03311L45-R48), [link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-ff312048d36f304aba4238d52665e58147467d4e7cc0e7f75d81f39e0fe03311L71-R77))
*  Add `useEffect` hook to sync `feedKey` state with `feedKeys` prop in `FeedsPanel` component in `devtools` ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-ff312048d36f304aba4238d52665e58147467d4e7cc0e7f75d81f39e0fe03311R61-R66))
*  Add imports of `useDevtoolsDispatch` and `useNavigate` to `SpaceInfoPanel` component in `devtools` ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-d9f0e1fd85737e448b28516a01c1fe3febca7b7f8af5da2d23affdc421c4b5feL21-R22))
*  Render clickable links for feed keys in space info table in `SpaceInfoPanel` component in `devtools` ([link](https://github.com/dxos/dxos/pull/3841/files?diff=unified&w=0#diff-d9f0e1fd85737e448b28516a01c1fe3febca7b7f8af5da2d23affdc421c4b5feL115-R125))


