### PR TITLE
fix: Fix diagnostics

### DIFF
--- a/packages/sdk/client/src/diagnostics/platform.ts
+++ b/packages/sdk/client/src/diagnostics/platform.ts
@@ -8,7 +8,7 @@ export type Platform = {
   runtime?: string;
 };
 
-export const getPlatform = async (): Promise<Platform> => {
+export const getPlatform = (): Platform => {
   if (typeof window !== 'undefined') {
     const { userAgent } = window.navigator;
     return {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5b56c67</samp>

### Summary
:truck::alarm_clock::zap:

<!--
1.  :truck: for moving the `getPlatform` function to a different file.
2.  :alarm_clock: for adding timeouts to some async operations.
3.  :zap: for changing `getPlatform` to a sync function.
-->
Improved the reliability and performance of the diagnostics module by adding timeouts and simplifying the platform detection logic. Moved the `getPlatform` function to the `diagnostics.ts` file to avoid unnecessary exports.

> _To improve the diagnostics module_
> _We moved `getPlatform` to its cubicle_
> _We added some timeouts_
> _To handle the dropouts_
> _And used `asyncTimeout` to be suitable_

### Walkthrough
* Import `asyncTimeout` function from `@dxos/async` to set timeouts for async operations in diagnostics module ([link](https://github.com/dxos/dxos/pull/3850/files?diff=unified&w=0#diff-75743e11fcfd6e8a341512a35696a42d7b1a91a6f660f803051a70a164c20655L7-R7)).


