### PR TITLE
fix(aurora): Button and checkbox layout rules.

### DIFF
--- a/packages/ui/aurora-theme/src/styles/components/button.ts
+++ b/packages/ui/aurora-theme/src/styles/components/button.ts
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import type { Density, Elevation, ComponentFunction, ComponentFragment, Theme } from '@dxos/aurora-types';
+import type { Density, Elevation, ComponentFunction, Theme } from '@dxos/aurora-types';
 
 import { mx } from '../../util';
 import {
@@ -34,22 +34,14 @@ export type ButtonStyleProps = Partial<{
   variant: 'default' | 'primary' | 'ghost' | 'outline';
 }>;
 
-export const sharedButtonStyles: ComponentFragment<ButtonStyleProps> = (props) => {
-  return [
-    'inline-flex select-none items-center justify-center transition-color duration-100',
-    props.density === 'fine' ? fineButtonDimensions : coarseButtonDimensions,
-    // Register all radix states
-    'group',
-    props.disabled && staticDisabled,
-  ];
-};
-
 export const buttonRoot: ComponentFunction<ButtonStyleProps> = (props, ...etc) => {
   const resolvedVariant = props.variant ?? 'default';
   return mx(
-    'font-medium text-sm',
+    'font-medium text-sm shrink-0 inline-flex select-none items-center justify-center transition-color duration-100',
+    props.density === 'fine' ? fineButtonDimensions : coarseButtonDimensions,
+    props.disabled && staticDisabled,
     !props.inGroup && 'rounded-md',
-    !props.textWrap && 'truncate',
+    !props.textWrap && 'text-ellipsis whitespace-nowrap',
     !props.disabled &&
       !props.inGroup &&
       (resolvedVariant === 'default' || resolvedVariant === 'primary') &&
@@ -63,7 +55,8 @@ export const buttonRoot: ComponentFunction<ButtonStyleProps> = (props, ...etc) =
       'text-neutral-700 border border-neutral-600 dark:border-neutral-300 dark:text-neutral-150',
     !props.disabled && focusRing,
     openOutline,
-    ...sharedButtonStyles(props),
+    // Register all radix states
+    'group',
     ...etc,
   );
 };

--- a/packages/ui/aurora-theme/src/styles/components/input.ts
+++ b/packages/ui/aurora-theme/src/styles/components/input.ts
@@ -103,7 +103,7 @@ export const inputInput: ComponentFunction<InputStyleProps> = (props, ...etc) =>
 export const inputCheckbox: ComponentFunction<InputStyleProps> = ({ size = 5 }, ...etc) =>
   mx(
     getSize(size),
-    'flex items-center justify-center rounded text-white',
+    'shrink-0 flex items-center justify-center rounded text-white',
     'radix-state-checked:bg-primary-600 radix-state-unchecked:bg-neutral-200 dark:radix-state-unchecked:bg-neutral-700',
     focusRing,
     ...etc,

--- a/packages/ui/aurora/src/playground/Controls.stories.tsx
+++ b/packages/ui/aurora/src/playground/Controls.stories.tsx
@@ -22,7 +22,7 @@ const Story = () => {
   const [select, setSelect] = useState<string>();
 
   return (
-    <div className='flex flex-col space-y-2'>
+    <div className='flex flex-col gap-2'>
       <Toolbar classNames='flex'>
         {/* TODO(burdon): Should be fixed width (regardless of selection). */}
         <Select.Root value={select} onValueChange={setSelect}>
@@ -77,11 +77,9 @@ const Story = () => {
           <ArrowClockwise />
         </Button>
       </Toolbar>
-      <div>
-        <Input.Root>
-          <Input.TextArea placeholder='Enter text...' rows={3} classNames='resize-none' />
-        </Input.Root>
-      </div>
+      <Input.Root>
+        <Input.TextArea placeholder='Enter text...' rows={3} classNames='resize-none' />
+      </Input.Root>
     </div>
   );
 };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2bad1f4</samp>

### Summary
📦🧹🌟

<!--
1.  📦 for updating the `inputCheckbox` function with a new class.
2.  🧹 for simplifying the button styles and removing unused code.
3.  🌟 for using the latest tailwindcss features and improving the Controls story markup.
-->
This pull request improves the UI components and stories by simplifying the styles and markup, and using the latest tailwindcss features. It also fixes a layout issue with the `inputCheckbox` function in `input.ts`.

> _We are the masters of the flex layout_
> _We shrink and grow with `shrink-0` and `gap-2`_
> _We purge the redundant and the obsolete_
> _We simplify the markup with tailwindcss_

### Walkthrough
* Remove unused import of `ComponentFragment` type ([link](https://github.com/dxos/dxos/pull/3875/files?diff=unified&w=0#diff-395d63617761923cc7940021c201f52df453fa57e7c144bfe041502424de280fL5-R5))
* Simplify button styles by merging `sharedButtonStyles` and `buttonRoot` functions and moving `group` class ([link](https://github.com/dxos/dxos/pull/3875/files?diff=unified&w=0#diff-395d63617761923cc7940021c201f52df453fa57e7c144bfe041502424de280fL37-R44), [link](https://github.com/dxos/dxos/pull/3875/files?diff=unified&w=0#diff-395d63617761923cc7940021c201f52df453fa57e7c144bfe041502424de280fL66-R59))
* Prevent checkbox from resizing with flex layout by adding `shrink-0` class ([link](https://github.com/dxos/dxos/pull/3875/files?diff=unified&w=0#diff-a192ded1ae528b466e414dcb432135926dae3de90004939937fff8d5264438b9L106-R106))
* Use `gap-2` class instead of `space-y-2` class for consistent spacing between flex items ([link](https://github.com/dxos/dxos/pull/3875/files?diff=unified&w=0#diff-1b88bc526bc52e955a0fda14706a60e162af768a8145dd2132faa4d88dd1687fL25-R25))
* Remove unnecessary `div` element around `Input.Root` element in `Controls.stories.tsx` ([link](https://github.com/dxos/dxos/pull/3875/files?diff=unified&w=0#diff-1b88bc526bc52e955a0fda14706a60e162af768a8145dd2132faa4d88dd1687fL80-R82))


