### PR TITLE
feat(aurora): `Toolbar`

### DIFF
--- a/packages/devtools/devtools/src/app/Devtools.tsx
+++ b/packages/devtools/devtools/src/app/Devtools.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { HashRouter } from 'react-router-dom';
 
 import { DensityProvider, ThemeMode, ThemeProvider } from '@dxos/aurora';
-import { auroraTx } from '@dxos/aurora-theme';
+import { auroraTheme, bindTheme, toolbarRoot } from '@dxos/aurora-theme';
 import { useTelemetry } from '@dxos/react-appkit';
 import { ClientServices, Client, ClientContext } from '@dxos/react-client';
 
@@ -38,8 +38,17 @@ export const Devtools = ({
     return null;
   }
 
+  const devtoolsTx = bindTheme({
+    ...auroraTheme,
+    toolbar: {
+      root: (props, ...etc) => {
+        return toolbarRoot(props, 'p-2', ...etc);
+      },
+    },
+  });
+
   return (
-    <ThemeProvider {...{ tx: auroraTx, themeMode: state.themeMode }}>
+    <ThemeProvider {...{ tx: devtoolsTx, themeMode: state.themeMode }}>
       <DensityProvider density='fine'>
         <ErrorBoundary>
           <ClientContext.Provider value={context}>

--- a/packages/devtools/devtools/src/components/PublicKeySelector.stories.tsx
+++ b/packages/devtools/devtools/src/components/PublicKeySelector.stories.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 
 import '@dxosTheme';
+import { Toolbar } from '@dxos/aurora';
 import { PublicKey } from '@dxos/keys';
 
 import { PublicKeySelector } from './PublicKeySelector';
@@ -15,5 +16,9 @@ export default {
 };
 
 export const Normal = (props: any) => {
-  return <PublicKeySelector keys={[PublicKey.random(), PublicKey.random()]} {...props} />;
+  return (
+    <Toolbar.Root>
+      <PublicKeySelector keys={[PublicKey.random(), PublicKey.random()]} {...props} />
+    </Toolbar.Root>
+  );
 };

--- a/packages/devtools/devtools/src/components/PublicKeySelector.tsx
+++ b/packages/devtools/devtools/src/components/PublicKeySelector.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { Select } from '@dxos/aurora';
+import { Select, Toolbar } from '@dxos/aurora';
 import { PublicKey } from '@dxos/react-client';
 import { humanize } from '@dxos/util';
 
@@ -30,7 +30,9 @@ export const PublicKeySelector = ({
         id && onChange?.(PublicKey.fromHex(id));
       }}
     >
-      <Select.TriggerButton placeholder={placeholder} />
+      <Toolbar.Button asChild>
+        <Select.TriggerButton placeholder={placeholder} />
+      </Toolbar.Button>
       <Select.Portal>
         <Select.Content>
           <Select.Viewport>

--- a/packages/devtools/devtools/src/components/Select.tsx
+++ b/packages/devtools/devtools/src/components/Select.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { Select as AuroraSelect, SelectRootProps } from '@dxos/aurora';
+import { Select as AuroraSelect, SelectRootProps, Toolbar } from '@dxos/aurora';
 
 export type SelectProps = SelectRootProps & {
   items?: { value: string; label: string }[];
@@ -13,7 +13,9 @@ export type SelectProps = SelectRootProps & {
 export const Select = ({ items = [], ...props }: SelectProps) => {
   return (
     <AuroraSelect.Root {...props}>
-      <AuroraSelect.TriggerButton placeholder={'Select value'} />
+      <Toolbar.Button asChild>
+        <AuroraSelect.TriggerButton placeholder={'Select value'} />
+      </Toolbar.Button>
       <AuroraSelect.Portal>
         <AuroraSelect.Content>
           <AuroraSelect.Viewport>

--- a/packages/devtools/devtools/src/panels/client/ConfigPanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/ConfigPanel.tsx
@@ -16,9 +16,9 @@ const ConfigPanel = () => {
   return (
     <PanelContainer
       toolbar={
-        <Toolbar>
+        <Toolbar.Root>
           <VaultSelector />
-        </Toolbar>
+        </Toolbar.Root>
       }
     >
       <JsonView data={config.values} />

--- a/packages/devtools/devtools/src/panels/client/DiagnosticsPanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/DiagnosticsPanel.tsx
@@ -5,7 +5,7 @@
 import { Download } from '@phosphor-icons/react';
 import React, { useEffect, useState } from 'react';
 
-import { Button, Input, Toolbar } from '@dxos/aurora';
+import { Input, Toolbar } from '@dxos/aurora';
 import { getSize } from '@dxos/aurora-theme';
 import { useFileDownload } from '@dxos/react-appkit';
 import { useAsyncEffect } from '@dxos/react-async';
@@ -55,18 +55,18 @@ const DiagnosticsPanel = () => {
   return (
     <PanelContainer
       toolbar={
-        <Toolbar>
-          <Button onClick={handleRefresh}>Refresh</Button>
-          <Button onClick={handleDownload}>
+        <Toolbar.Root>
+          <Toolbar.Button onClick={handleRefresh}>Refresh</Toolbar.Button>
+          <Toolbar.Button onClick={handleDownload}>
             <Download className={getSize(5)} />
             <span className='m-2'>Download</span>
-          </Button>
-          <Button onClick={handleResetMetrics}>Reset metrics</Button>
+          </Toolbar.Button>
+          <Toolbar.Button onClick={handleResetMetrics}>Reset metrics</Toolbar.Button>
           <Input.Root>
             <Input.Checkbox checked={recording} onCheckedChange={(recording) => handleSetRecording(!!recording)} />
             <Input.Label>Record metrics</Input.Label>
           </Input.Root>
-        </Toolbar>
+        </Toolbar.Root>
       }
     >
       <JsonView data={data} level={5} />

--- a/packages/devtools/devtools/src/panels/client/LoggingPanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/LoggingPanel.tsx
@@ -4,7 +4,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 
-import { Button, Input, Toolbar } from '@dxos/aurora';
+import { Input, Toolbar } from '@dxos/aurora';
 import { levels, parseFilter } from '@dxos/log';
 import { TableColumn } from '@dxos/mosaic';
 import { LogEntry, LogLevel, QueryLogsRequest } from '@dxos/protocols/proto/dxos/client/services';
@@ -94,13 +94,13 @@ const LoggingPanel = () => {
   return (
     <PanelContainer
       toolbar={
-        <Toolbar>
+        <Toolbar.Root>
           <Input.Root>
             <Input.TextInput ref={inputRef} placeholder='Filter (e.g., "info", "client:debug")' />
           </Input.Root>
-          <Button onClick={handleQueryLogs}>Refresh</Button>
-          <Button onClick={() => setLogs([])}>Clear</Button>
-        </Toolbar>
+          <Toolbar.Button onClick={handleQueryLogs}>Refresh</Toolbar.Button>
+          <Toolbar.Button onClick={() => setLogs([])}>Clear</Toolbar.Button>
+        </Toolbar.Root>
       }
     >
       <MasterDetailTable<LogEntry>

--- a/packages/devtools/devtools/src/panels/client/StoragePanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/StoragePanel.tsx
@@ -6,7 +6,7 @@ import { GitCommit, HardDrive, Queue, Rows, Bookmarks, Bookmark, Files, FileArch
 import bytes from 'bytes';
 import React, { FC, ReactNode, useEffect, useMemo, useState } from 'react';
 
-import { Button, Tree, TreeItem, Toolbar } from '@dxos/aurora';
+import { Tree, TreeItem, Toolbar } from '@dxos/aurora';
 import {
   GetBlobsResponse,
   GetSnapshotsResponse,
@@ -240,21 +240,21 @@ const StoragePanel = () => {
     <PanelContainer
       className='flex-row divide-x'
       toolbar={
-        <Toolbar>
-          <Button onClick={refresh} disabled={isRefreshing}>
+        <Toolbar.Root>
+          <Toolbar.Button onClick={refresh} disabled={isRefreshing}>
             Refresh
-          </Button>
+          </Toolbar.Button>
 
           <div className='flex-1' />
-          <Button
+          <Toolbar.Button
             onClick={async () => {
               await services?.SystemService.reset();
               location.reload();
             }}
           >
             Reset Storage
-          </Button>
-        </Toolbar>
+          </Toolbar.Button>
+        </Toolbar.Root>
       }
     >
       <div className='flex w-1/3 overflow-auto p-2'>

--- a/packages/devtools/devtools/src/panels/echo/FeedsPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/FeedsPanel.tsx
@@ -4,7 +4,7 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { Button, Toolbar } from '@dxos/aurora';
+import { Toolbar } from '@dxos/aurora';
 import { PublicKey } from '@dxos/keys';
 import { TableColumn } from '@dxos/mosaic';
 import { SubscribeToFeedBlocksResponse } from '@dxos/protocols/proto/dxos/devtools/host';
@@ -84,7 +84,7 @@ const FeedsPanel = () => {
   return (
     <PanelContainer
       toolbar={
-        <Toolbar>
+        <Toolbar.Root>
           <SpaceSelector />
           <PublicKeySelector
             placeholder='Select feed'
@@ -94,8 +94,8 @@ const FeedsPanel = () => {
             onChange={handleSelect}
           />
 
-          <Button onClick={handleRefresh}>Refresh</Button>
-        </Toolbar>
+          <Toolbar.Button onClick={handleRefresh}>Refresh</Toolbar.Button>
+        </Toolbar.Root>
       }
     >
       <BitfieldDisplay value={meta?.downloaded ?? new Uint8Array()} length={meta?.length ?? 0} />

--- a/packages/devtools/devtools/src/panels/echo/ItemsPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/ItemsPanel.tsx
@@ -64,10 +64,10 @@ const ItemsPanel = () => {
   return (
     <PanelContainer
       toolbar={
-        <Toolbar>
+        <Toolbar.Root>
           <SpaceSelector />
           <Searchbar onSearch={setFilter} />
-        </Toolbar>
+        </Toolbar.Root>
       }
     >
       <MasterDetailTable<TypedObject> columns={columns} data={items.filter(textFilter(filter))} />

--- a/packages/devtools/devtools/src/panels/echo/MembersPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/MembersPanel.tsx
@@ -46,9 +46,9 @@ const MembersPanel = () => {
   return (
     <PanelContainer
       toolbar={
-        <Toolbar>
+        <Toolbar.Root>
           <SpaceSelector />
-        </Toolbar>
+        </Toolbar.Root>
       }
     >
       <MasterDetailTable<SpaceMember> columns={columns} data={members} />

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel.tsx
@@ -7,7 +7,7 @@ import React, { FC, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { MulticastObservable } from '@dxos/async';
-import { Button, Toolbar } from '@dxos/aurora';
+import { Toolbar } from '@dxos/aurora';
 import { getSize, mx } from '@dxos/aurora-theme';
 import { Table, TableColumn } from '@dxos/mosaic';
 import { Space as SpaceProto, SpaceState } from '@dxos/protocols/proto/dxos/client/services';
@@ -83,10 +83,12 @@ const SpaceInfoPanel: FC = () => {
   return (
     <PanelContainer
       toolbar={
-        <Toolbar>
+        <Toolbar.Root>
           <SpaceSelector />
-          <Button onClick={toggleActive}>{space?.state.get() === SpaceState.INACTIVE ? 'Open' : 'Close'}</Button>
-        </Toolbar>
+          <Toolbar.Button onClick={toggleActive}>
+            {space?.state.get() === SpaceState.INACTIVE ? 'Open' : 'Close'}
+          </Toolbar.Button>
+        </Toolbar.Root>
       }
       className='overflow-auto'
     >

--- a/packages/devtools/devtools/src/panels/halo/CredentialsPanel.tsx
+++ b/packages/devtools/devtools/src/panels/halo/CredentialsPanel.tsx
@@ -19,9 +19,9 @@ const CredentialsPanel = () => {
   return (
     <PanelContainer
       toolbar={
-        <Toolbar>
+        <Toolbar.Root>
           <SpaceSelector />
-        </Toolbar>
+        </Toolbar.Root>
       }
     >
       <JsonView data={credentials} />

--- a/packages/devtools/devtools/src/panels/halo/IdentityPanel.tsx
+++ b/packages/devtools/devtools/src/panels/halo/IdentityPanel.tsx
@@ -17,9 +17,9 @@ const IdentityPanel = () => {
   return (
     <PanelContainer
       toolbar={
-        <Toolbar>
+        <Toolbar.Root>
           <VaultSelector />
-        </Toolbar>
+        </Toolbar.Root>
       }
     >
       <JsonView data={{ ...identity, devices }} />

--- a/packages/devtools/devtools/src/panels/mesh/SignalMessages.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SignalMessages.tsx
@@ -6,7 +6,7 @@ import { WifiHigh, WifiSlash } from '@phosphor-icons/react';
 import { format } from 'date-fns';
 import React, { FC, useState } from 'react';
 
-import { Toolbar, Button } from '@dxos/aurora';
+import { Toolbar } from '@dxos/aurora';
 import { getSize, mx } from '@dxos/aurora-theme';
 import { truncateKey } from '@dxos/debug';
 import { TableColumn } from '@dxos/mosaic';
@@ -139,14 +139,18 @@ const ToggleConnection: FC<{ connection: ConnectionState; onToggleConnection: ()
   connection,
   onToggleConnection,
 }) => (
-  <Button title='Toggle connection state.' classNames='mli-2 p-0 px-2 items-center' onClick={onToggleConnection}>
+  <Toolbar.Button
+    title='Toggle connection state.'
+    classNames='mli-2 p-0 px-2 items-center'
+    onClick={onToggleConnection}
+  >
     {connection === ConnectionState.ONLINE ? (
       <WifiHigh className={getSize(6)} />
     ) : (
       <WifiSlash className={mx(getSize(6), 'text-selection-text')} />
     )}
     <span className='pl-2 whitespace-nowrap'>Toggle connection</span>
-  </Button>
+  </Toolbar.Button>
 );
 
 export type SignalMessagesProps = {
@@ -179,7 +183,7 @@ export const SignalMessages = (props: SignalMessagesProps) => {
 
   return (
     <div className='flex flex-col flex-1 overflow-hidden'>
-      <Toolbar>
+      <Toolbar.Root>
         <Select
           items={views.map(({ id, title }) => ({ value: id, label: title }))}
           value={viewType}
@@ -187,7 +191,7 @@ export const SignalMessages = (props: SignalMessagesProps) => {
         />
         <Searchbar onSearch={setSearch} />
         <ToggleConnection connection={connectionState} onToggleConnection={handleToggleConnection} />
-      </Toolbar>
+      </Toolbar.Root>
 
       <div className='flex flex-1 overflow-hidden'>
         {view ? <MasterDetailTable columns={view.columns as any} data={filteredMessages} /> : null}

--- a/packages/ui/aurora-theme/src/styles/components/button.ts
+++ b/packages/ui/aurora-theme/src/styles/components/button.ts
@@ -18,12 +18,12 @@ import {
 // TODO(burdon): Ghost styles should have no border (be really flat).
 
 export const primaryAppButtonColors =
-  'bg-primary-550 dark:bg-primary-550 aria-pressed:bg-primary-500 dark:aria-pressed:bg-primary-500 text-white aria-pressed:text-primary-100 hover:bg-primary-600 dark:hover:bg-primary-600 hover:text-white dark:hover:text-white';
+  'bg-primary-550 dark:bg-primary-550 text-white aria-pressed:bg-primary-500 dark:aria-pressed:bg-primary-500 aria-pressed:text-primary-100 aria-checked:bg-primary-500 dark:aria-checked:bg-primary-500 aria-checked:text-primary-100 hover:bg-primary-600 dark:hover:bg-primary-600 hover:text-white dark:hover:text-white';
 export const defaultAppButtonColors =
-  'bg-white aria-pressed:bg-primary-50 text-neutral-800 aria-pressed:text-primary-800 dark:bg-neutral-800 dark:aria-pressed:bg-primary-800 dark:text-neutral-50 dark:aria-pressed:text-primary-50';
+  'bg-white aria-pressed:bg-primary-50 aria-checked:bg-primary-50 text-neutral-800 aria-pressed:text-primary-800 aria-checked:text-primary-800 dark:bg-neutral-800 dark:aria-pressed:bg-primary-800 dark:aria-checked:bg-primary-800 dark:text-neutral-50 dark:aria-pressed:text-primary-50 dark:aria-checked:text-primary-50';
 export const defaultOsButtonColors = 'bg-white/50 text-neutral-900 dark:bg-neutral-750/50 dark:text-neutral-50';
 export const ghostButtonColors =
-  'hover:bg-transparent dark:hover:bg-transparent hover:text-primary-500 dark:hover:text-primary-300 aria-pressed:text-primary-800 dark:aria-pressed:text-primary-50';
+  'hover:bg-transparent dark:hover:bg-transparent hover:text-primary-500 dark:hover:text-primary-300 aria-pressed:text-primary-800 aria-checked:text-primary-800 dark:aria-pressed:text-primary-50 dark:aria-checked:text-primary-50';
 
 export type ButtonStyleProps = Partial<{
   inGroup?: boolean;

--- a/packages/ui/aurora-theme/src/styles/components/input.ts
+++ b/packages/ui/aurora-theme/src/styles/components/input.ts
@@ -91,7 +91,7 @@ export const inputInput: ComponentFunction<InputStyleProps> = (props, ...etc) =>
     : props.variant === 'static'
     ? mx(...sharedStaticInputStyles(props), !props.disabled && contentElevation(props), ...etc)
     : mx(
-        'rounded text-base bg-white/50 focus-visible:bg-white/50 dark:bg-neutral-700/50 dark:focus-visible:bg-neutral-700/50 border-transparent',
+        'rounded text-base bg-white/50 focus-visible:bg-white/50 dark:bg-neutral-700/50 dark:focus-visible:bg-neutral-700/50 border-transparent focus:border-transparent',
         !props.disabled && focusRing,
         !props.disabled && hoverColors,
         inputValence(props.validationValence) || neutralInputValence,

--- a/packages/ui/aurora-theme/src/styles/components/toolbar.ts
+++ b/packages/ui/aurora-theme/src/styles/components/toolbar.ts
@@ -9,9 +9,8 @@ import { mx } from '../../util';
 
 export type ToolbarStyleProps = Partial<{}>;
 
-// TODO(burdon): Surface?
-export const toolbarRoot: ComponentFunction<ToolbarStyleProps> = (props, ...etc) => {
-  return mx('space-x-2 p-2', ...etc);
+export const toolbarRoot: ComponentFunction<ToolbarStyleProps> = (_props, ...etc) => {
+  return mx('flex items-center gap-2 is-full', ...etc);
 };
 
 export const toolbarTheme: Theme<ToolbarStyleProps> = {

--- a/packages/ui/aurora-theme/src/styles/fragments/ornament.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/ornament.ts
@@ -2,5 +2,5 @@
 // Copyright 2022 DXOS.org
 //
 
-export const inlineSeparator = 'border-ie border-neutral-200 dark:border-neutral-800';
-export const blockSeparator = 'border-be border-neutral-200 dark:border-neutral-800';
+export const inlineSeparator = 'self-stretch border-ie border-neutral-200 dark:border-neutral-800';
+export const blockSeparator = 'self-stretch border-be border-neutral-200 dark:border-neutral-800';

--- a/packages/ui/aurora/package.json
+++ b/packages/ui/aurora/package.json
@@ -37,6 +37,7 @@
     "@radix-ui/react-toast": "^1.1.3",
     "@radix-ui/react-toggle": "^1.0.2",
     "@radix-ui/react-toggle-group": "^1.0.3",
+    "@radix-ui/react-toolbar": "^1.0.3",
     "@radix-ui/react-tooltip": "^1.0.5",
     "@radix-ui/react-use-controllable-state": "^1.0.0",
     "i18next": "^21.10.0",

--- a/packages/ui/aurora/src/components/Buttons/Button.tsx
+++ b/packages/ui/aurora/src/components/Buttons/Button.tsx
@@ -68,16 +68,23 @@ type ButtonGroupProps = ThemedClassName<ComponentPropsWithRef<typeof Primitive.d
   asChild?: boolean;
 };
 
-const ButtonGroup = ({ children, elevation: propsElevation, classNames, asChild, ...props }: ButtonGroupProps) => {
-  const { tx } = useThemeContext();
-  const elevation = useElevationContext(propsElevation);
-  const Root = asChild ? Slot : Primitive.div;
-  return (
-    <Root role='none' {...props} className={tx('button.group', 'button-group', { elevation }, classNames)}>
-      <ButtonGroupProvider inGroup>{children}</ButtonGroupProvider>
-    </Root>
-  );
-};
+const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
+  ({ children, elevation: propsElevation, classNames, asChild, ...props }, forwardedRef) => {
+    const { tx } = useThemeContext();
+    const elevation = useElevationContext(propsElevation);
+    const Root = asChild ? Slot : Primitive.div;
+    return (
+      <Root
+        role='none'
+        {...props}
+        className={tx('button.group', 'button-group', { elevation }, classNames)}
+        ref={forwardedRef}
+      >
+        <ButtonGroupProvider inGroup>{children}</ButtonGroupProvider>
+      </Root>
+    );
+  },
+);
 
 ButtonGroup.displayName = BUTTON_GROUP_NAME;
 

--- a/packages/ui/aurora/src/components/Buttons/ToggleGroup.stories.tsx
+++ b/packages/ui/aurora/src/components/Buttons/ToggleGroup.stories.tsx
@@ -31,6 +31,6 @@ export default {
 
 export const Default = {
   args: {
-    type: 'multiple',
+    type: 'single',
   },
 };

--- a/packages/ui/aurora/src/components/Buttons/ToggleGroup.tsx
+++ b/packages/ui/aurora/src/components/Buttons/ToggleGroup.tsx
@@ -11,7 +11,7 @@ import {
 } from '@radix-ui/react-toggle-group';
 import React, { forwardRef } from 'react';
 
-import { Button, ButtonGroup, ButtonGroupProps } from './Button';
+import { Button, ButtonGroup, ButtonGroupProps, ButtonProps } from './Button';
 
 type ToggleGroupProps = Omit<ToggleGroupSingleProps, 'className'> | Omit<ToggleGroupMultipleProps, 'className'>;
 
@@ -25,15 +25,17 @@ const ToggleGroup = forwardRef<HTMLDivElement, ToggleGroupProps & ButtonGroupPro
   },
 );
 
-type ToggleGroupItemProps = ToggleGroupItemPrimitiveProps;
+type ToggleGroupItemProps = Omit<ToggleGroupItemPrimitiveProps, 'className'> & ButtonProps;
 
-const ToggleGroupItem = forwardRef<HTMLButtonElement, ToggleGroupItemProps>(({ value, ...props }, forwardedRef) => {
-  return (
-    <ToggleGroupItemPrimitive {...{ value, disabled: props.disabled }} asChild>
-      <Button {...props} ref={forwardedRef} />
-    </ToggleGroupItemPrimitive>
-  );
-});
+const ToggleGroupItem = forwardRef<HTMLButtonElement, ToggleGroupItemProps>(
+  ({ variant, elevation, density, classNames, children, ...props }, forwardedRef) => {
+    return (
+      <ToggleGroupItemPrimitive {...props} asChild>
+        <Button {...{ variant, elevation, density, classNames, children }} ref={forwardedRef} />
+      </ToggleGroupItemPrimitive>
+    );
+  },
+);
 
 export { ToggleGroup, ToggleGroupItem };
 export type { ToggleGroupProps, ToggleGroupItemProps };

--- a/packages/ui/aurora/src/components/Dialogs/AlertDialog.stories.tsx
+++ b/packages/ui/aurora/src/components/Dialogs/AlertDialog.stories.tsx
@@ -36,15 +36,15 @@ const StorybookAlertDialog = ({
           <AlertDialog.Title>{title}</AlertDialog.Title>
           <AlertDialog.Description>{description}</AlertDialog.Description>
           <p className='mbs-2 mbe-8'>{body}</p>
-          <Toolbar>
+          <Toolbar.Root>
             <div className='grow' />
             <AlertDialog.Cancel asChild>
-              <Button>{cancelTrigger}</Button>
+              <Toolbar.Button>{cancelTrigger}</Toolbar.Button>
             </AlertDialog.Cancel>
             <AlertDialog.Action asChild>
-              <Button variant='primary'>{actionTrigger}</Button>
+              <Toolbar.Button variant='primary'>{actionTrigger}</Toolbar.Button>
             </AlertDialog.Action>
-          </Toolbar>
+          </Toolbar.Root>
         </AlertDialog.Content>
       </AlertDialog.Overlay>
     </AlertDialog.Root>

--- a/packages/ui/aurora/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/ui/aurora/src/components/Toolbar/Toolbar.stories.tsx
@@ -1,0 +1,76 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import '@dxosTheme';
+import { ArrowClockwise, Bug, FileJs, FileTs, TextB, TextItalic, TextUnderline } from '@phosphor-icons/react';
+import React from 'react';
+
+import { Toggle } from '../Buttons';
+import { Select } from '../Select';
+import { Toolbar } from './Toolbar';
+
+type StorybookToolbarProps = {};
+
+const StorybookToolbar = (props: StorybookToolbarProps) => {
+  return (
+    <Toolbar.Root>
+      {/* TODO(burdon): Should be fixed width (regardless of selection). */}
+      <Select.Root>
+        <Toolbar.Button asChild>
+          <Select.TriggerButton placeholder={'Select value'} />
+        </Toolbar.Button>
+        <Select.Portal>
+          <Select.Content>
+            <Select.Viewport>
+              <Select.Option value={'a'}>A</Select.Option>
+              <Select.Option value={'b'}>B</Select.Option>
+              <Select.Option value={'c'}>C</Select.Option>
+            </Select.Viewport>
+          </Select.Content>
+        </Select.Portal>
+      </Select.Root>
+      {/* TODO(burdon): Highlight is cyan. */}
+      {/* TODO(burdon): Show vertical divider by default. */}
+      {/* TODO(burdon): Icon sizes should adapt to density. */}
+      <Toolbar.ToggleGroup type='multiple'>
+        <Toolbar.ToggleGroupItem value='a'>
+          <TextB />
+        </Toolbar.ToggleGroupItem>
+        <Toolbar.ToggleGroupItem value='b'>
+          <TextItalic />
+        </Toolbar.ToggleGroupItem>
+        <Toolbar.ToggleGroupItem value='c'>
+          <TextUnderline />
+        </Toolbar.ToggleGroupItem>
+      </Toolbar.ToggleGroup>
+      {/* TODO(burdon): Highlight isn't shown. */}
+      <Toolbar.ToggleGroup type='single' defaultValue='a'>
+        <Toolbar.ToggleGroupItem value='a'>
+          <FileTs />
+        </Toolbar.ToggleGroupItem>
+        <Toolbar.ToggleGroupItem value='b'>
+          <FileJs />
+        </Toolbar.ToggleGroupItem>
+      </Toolbar.ToggleGroup>
+      <Toolbar.Button asChild>
+        <Toggle>
+          <Bug />
+        </Toggle>
+      </Toolbar.Button>
+      <Toolbar.Separator />
+      <Toolbar.Button>Test</Toolbar.Button>
+      <Toolbar.Button>
+        <ArrowClockwise />
+      </Toolbar.Button>
+    </Toolbar.Root>
+  );
+};
+
+export default {
+  component: StorybookToolbar,
+};
+
+export const Default = {
+  args: {},
+};

--- a/packages/ui/aurora/src/components/Toolbar/Toolbar.tsx
+++ b/packages/ui/aurora/src/components/Toolbar/Toolbar.tsx
@@ -1,23 +1,99 @@
 //
-// Copyright 2022 DXOS.org
+// Copyright 2023 DXOS.org
 //
 
-import { Primitive } from '@radix-ui/react-primitive';
-import React, { ComponentPropsWithRef, forwardRef } from 'react';
+import * as ToolbarPrimitive from '@radix-ui/react-toolbar';
+import React, { forwardRef } from 'react';
 
 import { useThemeContext } from '../../hooks';
 import { ThemedClassName } from '../../util';
+import { Button, ButtonGroup, ButtonGroupProps, ButtonProps, ToggleGroupItemProps } from '../Buttons';
+import { Link, LinkProps } from '../Link';
+import { Separator, SeparatorProps } from '../Separator';
 
-export type ToolbarProps = ThemedClassName<ComponentPropsWithRef<typeof Primitive.div>> & {};
+type ToolbarRootProps = ThemedClassName<ToolbarPrimitive.ToolbarProps>;
 
-export const Toolbar = forwardRef<HTMLDivElement, ToolbarProps>(({ classNames, ...props }, forwardedRef) => {
+const ToolbarRoot = forwardRef<HTMLDivElement, ToolbarRootProps>(({ classNames, children, ...props }, forwardedRef) => {
   const { tx } = useThemeContext();
-  const Root = Primitive.div;
   return (
-    <Root
-      {...props}
-      className={tx('toolbar.root', 'toolbar', {}, 'flex w-full items-center whitespace-nowrap', classNames)}
-      ref={forwardedRef}
-    />
+    <ToolbarPrimitive.Root {...props} className={tx('toolbar.root', 'toolbar', {}, classNames)} ref={forwardedRef}>
+      {children}
+    </ToolbarPrimitive.Root>
   );
 });
+
+type ToolbarButtonProps = ButtonProps;
+
+const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>((props, forwardedRef) => {
+  return (
+    <ToolbarPrimitive.Button asChild>
+      <Button {...props} ref={forwardedRef} />
+    </ToolbarPrimitive.Button>
+  );
+});
+
+type ToolbarLinkProps = LinkProps;
+
+const ToolbarLink = forwardRef<HTMLAnchorElement, ToolbarLinkProps>((props, forwardedRef) => {
+  return (
+    <ToolbarPrimitive.Link asChild>
+      <Link {...props} ref={forwardedRef} />
+    </ToolbarPrimitive.Link>
+  );
+});
+
+type ToolbarToggleGroupProps = (
+  | Omit<ToolbarPrimitive.ToolbarToggleGroupSingleProps, 'className'>
+  | Omit<ToolbarPrimitive.ToolbarToggleGroupMultipleProps, 'className'>
+) &
+  ButtonGroupProps;
+
+const ToolbarToggleGroup = forwardRef<HTMLDivElement, ToolbarToggleGroupProps>(
+  ({ classNames, children, ...props }, forwardedRef) => {
+    return (
+      <ToolbarPrimitive.ToolbarToggleGroup {...props} asChild>
+        <ButtonGroup {...{ classNames, children }} ref={forwardedRef} />
+      </ToolbarPrimitive.ToolbarToggleGroup>
+    );
+  },
+);
+
+type ToolbarToggleGroupItemProps = ToggleGroupItemProps;
+
+const ToolbarToggleGroupItem = forwardRef<HTMLButtonElement, ToolbarToggleGroupItemProps>(
+  ({ variant, density, elevation, classNames, children, ...props }, forwardedRef) => {
+    return (
+      <ToolbarPrimitive.ToolbarToggleItem {...props} asChild>
+        <Button {...{ variant, density, elevation, classNames, children }} ref={forwardedRef} />
+      </ToolbarPrimitive.ToolbarToggleItem>
+    );
+  },
+);
+
+type ToolbarSeparatorProps = SeparatorProps;
+
+const ToolbarSeparator = (props: SeparatorProps) => {
+  return (
+    <ToolbarPrimitive.Separator asChild>
+      <Separator orientation='vertical' {...props} />
+    </ToolbarPrimitive.Separator>
+  );
+};
+
+export const Toolbar = {
+  Root: ToolbarRoot,
+  Button: ToolbarButton,
+  Link: ToolbarLink,
+  ToggleGroup: ToolbarToggleGroup,
+  ToggleGroupItem: ToolbarToggleGroupItem,
+  Separator: ToolbarSeparator,
+};
+
+export type {
+  ToolbarRootProps,
+  ToolbarButtonProps,
+  ToolbarLinkProps,
+  ToolbarToggleGroupProps,
+  ToolbarToggleGroupItemProps,
+  ToolbarSeparatorProps,
+};

--- a/packages/ui/aurora/src/playground/Controls.stories.tsx
+++ b/packages/ui/aurora/src/playground/Controls.stories.tsx
@@ -3,18 +3,10 @@
 //
 
 import '@dxosTheme';
-import {
-  FileTs,
-  FileJs,
-  ArrowClockwise,
-  Bug,
-  TextAlignLeft,
-  TextAlignRight,
-  TextAlignCenter,
-} from '@phosphor-icons/react';
+import { FileTs, FileJs, ArrowClockwise, Bug, TextUnderline, TextB, TextItalic } from '@phosphor-icons/react';
 import React, { useState } from 'react';
 
-import { Button, Input, Select, Toggle, ToggleGroup, ToggleGroupItem, Toolbar } from '../components';
+import { Input, Select, Toggle, Toolbar } from '../components';
 import { createScenarios } from './helpers';
 
 const Story = () => {
@@ -23,10 +15,12 @@ const Story = () => {
 
   return (
     <div className='flex flex-col gap-2'>
-      <Toolbar classNames='flex'>
+      <Toolbar.Root>
         {/* TODO(burdon): Should be fixed width (regardless of selection). */}
         <Select.Root value={select} onValueChange={setSelect}>
-          <Select.TriggerButton placeholder={'Select value'} />
+          <Toolbar.Button asChild>
+            <Select.TriggerButton placeholder={'Select value'} />
+          </Toolbar.Button>
           <Select.Portal>
             <Select.Content>
               <Select.Viewport>
@@ -40,29 +34,31 @@ const Story = () => {
         {/* TODO(burdon): Highlight is cyan. */}
         {/* TODO(burdon): Show vertical divider by default. */}
         {/* TODO(burdon): Icon sizes should adapt to density. */}
-        <ToggleGroup type='multiple'>
-          <ToggleGroupItem value='a'>
-            <TextAlignLeft />
-          </ToggleGroupItem>
-          <ToggleGroupItem value='b'>
-            <TextAlignCenter />
-          </ToggleGroupItem>
-          <ToggleGroupItem value='c'>
-            <TextAlignRight />
-          </ToggleGroupItem>
-        </ToggleGroup>
+        <Toolbar.ToggleGroup type='multiple'>
+          <Toolbar.ToggleGroupItem value='a'>
+            <TextB />
+          </Toolbar.ToggleGroupItem>
+          <Toolbar.ToggleGroupItem value='b'>
+            <TextItalic />
+          </Toolbar.ToggleGroupItem>
+          <Toolbar.ToggleGroupItem value='c'>
+            <TextUnderline />
+          </Toolbar.ToggleGroupItem>
+        </Toolbar.ToggleGroup>
         {/* TODO(burdon): Highlight isn't shown. */}
-        <ToggleGroup type='single' value='a'>
-          <ToggleGroupItem value='a'>
+        <Toolbar.ToggleGroup type='single' defaultValue='a'>
+          <Toolbar.ToggleGroupItem value='a'>
             <FileTs />
-          </ToggleGroupItem>
-          <ToggleGroupItem value='b'>
+          </Toolbar.ToggleGroupItem>
+          <Toolbar.ToggleGroupItem value='b'>
             <FileJs />
-          </ToggleGroupItem>
-        </ToggleGroup>
-        <Toggle>
-          <Bug />
-        </Toggle>
+          </Toolbar.ToggleGroupItem>
+        </Toolbar.ToggleGroup>
+        <Toolbar.Button asChild>
+          <Toggle>
+            <Bug />
+          </Toggle>
+        </Toolbar.Button>
         {/* TODO(burdon): Should not be 'is-full' by default. */}
         <Input.Root>
           <Input.TextInput placeholder='Enter text...' />
@@ -72,11 +68,11 @@ const Story = () => {
           <Input.Checkbox checked={checked} onCheckedChange={(value) => setChecked(!!value)} />
           <Input.Label>Checkbox</Input.Label>
         </Input.Root>
-        <Button>Test</Button>
-        <Button>
+        <Toolbar.Button>Test</Toolbar.Button>
+        <Toolbar.Button>
           <ArrowClockwise />
-        </Button>
-      </Toolbar>
+        </Toolbar.Button>
+      </Toolbar.Root>
       <Input.Root>
         <Input.TextArea placeholder='Enter text...' rows={3} classNames='resize-none' />
       </Input.Root>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5543,6 +5543,7 @@ importers:
       '@radix-ui/react-toast': ^1.1.3
       '@radix-ui/react-toggle': ^1.0.2
       '@radix-ui/react-toggle-group': ^1.0.3
+      '@radix-ui/react-toolbar': ^1.0.3
       '@radix-ui/react-tooltip': ^1.0.5
       '@radix-ui/react-use-controllable-state': ^1.0.0
       '@types/react': ^18.0.21
@@ -5576,6 +5577,7 @@ importers:
       '@radix-ui/react-toast': 1.1.3_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-toggle': 1.0.2_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-toggle-group': 1.0.3_biqbaboplfbrettd7655fr4n2y
+      '@radix-ui/react-toolbar': 1.0.3_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-tooltip': 1.0.5_rj7ozvcq3uehdlnj3cbwzbi5ce
       '@radix-ui/react-use-controllable-state': 1.0.0_react@18.2.0
       i18next: 21.10.0


### PR DESCRIPTION
This PR finishes the implementation of `Toolbar`.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2725287</samp>

### Summary
🎨🛠️🧰

<!--
1.  🎨 - This emoji represents the changes to the color variables and the input border color, which are related to the UI design and appearance of the components.
2.  🛠️ - This emoji represents the changes to the toolbar root style, the separator style, the button group component, and the toggle group component, which are related to the UI functionality and implementation of the components.
3.  🧰 - This emoji represents the addition of the radix-ui toolbar dependency, the toolbar stories file, the toolbar component file, and the refactoring of the controls stories file, which are related to the UI toolkit and documentation of the components.
-->
This pull request introduces the `Toolbar` component and its subcomponents, which are based on radix-ui primitives and aurora components. It also updates the `Button`, `ToggleGroup`, and `Input` components to improve their appearance and functionality. Additionally, it refactors the `Controls.stories.tsx` file to use the `Toolbar` component and adds the `Toolbar.stories.tsx` file to showcase the new component.

> _`Toolbar` component_
> _Composed of primitives, `Button`_
> _Autumn of UI_

### Walkthrough
*  Add and export toolbar component and its subcomponents, composed of radix-ui toolbar primitives and aurora button, link, and separator components ([link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-a8d121698b9e01dd2b933bbb6ce7bfb96f39de8a145032629545b31712adf381R1-R76), [link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-bcd3546bacb1446810bea59d32f30b682ecc0032d5704fa720d7b857e7859667L2-R99))
*  Update button color variables to include `aria-checked` state for toggle buttons ([link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-395d63617761923cc7940021c201f52df453fa57e7c144bfe041502424de280fL21-R26))
*  Update button group and toggle group item components to use forwardRef and accept button-specific props ([link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-aced895964f57b0286a43561af9dcefee767382c03d29f8ff09dd2c99e0151daL71-R87), [link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-79d5ae42100f1a45a29bf842cbd00222260f78cd2098e95b18952d3b4ae2de54L14-R14), [link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-79d5ae42100f1a45a29bf842cbd00222260f78cd2098e95b18952d3b4ae2de54L28-R38))
*  Update input border color to be transparent on focus ([link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-a192ded1ae528b466e414dcb432135926dae3de90004939937fff8d5264438b9L94-R94))
*  Update toolbar root style to use flex and gap utilities ([link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-8f9cc7871e25b3f05c0d12210544dc86749c67c6619303ea9b8a21b42c37dec7L12-R13))
*  Update separator style to use self-stretch ([link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-015f0e510d4f7149712b621a35361cfb195e9da00ee7ff03007b1be39e268d09L5-R6))
*  Add radix-ui toolbar dependency to `package.json` ([link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-a281489d84c41bfc075f623060a2d0a3177bead5686f51e924af6c324b0d82bcR40))
*  Change default toggle group type from multiple to single in stories ([link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-7b5a0b1dfabb61881670aededed3e47d9dcf42f8cf8ba3556fcf4447e36587e0L34-R34))
*  Add toolbar stories to demonstrate usage and appearance ([link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-a8d121698b9e01dd2b933bbb6ce7bfb96f39de8a145032629545b31712adf381R1-R76))
*  Update controls stories to use toolbar component and its subcomponents instead of button and toggle group components ([link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-1b88bc526bc52e955a0fda14706a60e162af768a8145dd2132faa4d88dd1687fL6-R9), [link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-1b88bc526bc52e955a0fda14706a60e162af768a8145dd2132faa4d88dd1687fL26-R23), [link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-1b88bc526bc52e955a0fda14706a60e162af768a8145dd2132faa4d88dd1687fL43-R61), [link](https://github.com/dxos/dxos/pull/3878/files?diff=unified&w=0#diff-1b88bc526bc52e955a0fda14706a60e162af768a8145dd2132faa4d88dd1687fL75-R75))


