### PR TITLE
feat(aurora,plugin-splitview): Two sidebars

### DIFF
--- a/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
@@ -13,9 +13,14 @@ import { SplitView, SplitViewMainContentEmpty } from './components';
 import translations from './translations';
 import { SPLITVIEW_PLUGIN, SplitViewAction, SplitViewProvides } from './types';
 
-export const SplitViewPlugin = (): PluginDefinition<SplitViewProvides> => {
+export const SplitViewPlugin = ({
+  enableComplementarySidebar,
+}: {
+  enableComplementarySidebar?: boolean;
+}): PluginDefinition<SplitViewProvides> => {
   const state = deepSignal({
     sidebarOpen: true,
+    complementarySidebarOpen: enableComplementarySidebar ? false : null,
     dialogContent: 'never',
     dialogOpen: false,
   });

--- a/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
@@ -13,11 +13,13 @@ import { SplitView, SplitViewMainContentEmpty } from './components';
 import translations from './translations';
 import { SPLITVIEW_PLUGIN, SplitViewAction, SplitViewProvides } from './types';
 
+export type SplitViewPluginConfig = Partial<{
+  enableComplementarySidebar: boolean;
+}>;
+
 export const SplitViewPlugin = ({
   enableComplementarySidebar,
-}: {
-  enableComplementarySidebar?: boolean;
-}): PluginDefinition<SplitViewProvides> => {
+}: SplitViewPluginConfig = {}): PluginDefinition<SplitViewProvides> => {
   const state = deepSignal({
     sidebarOpen: true,
     complementarySidebarOpen: enableComplementarySidebar ? false : null,

--- a/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
@@ -14,17 +14,26 @@ import { SPLITVIEW_PLUGIN } from '../types';
 
 export const SplitView = () => {
   const context = useSplitView();
-  const { sidebarOpen, dialogOpen, dialogContent } = context;
+  const { sidebarOpen, complementarySidebarOpen, dialogOpen, dialogContent } = context;
   const { t } = useTranslation(SPLITVIEW_PLUGIN);
 
   return (
     <Main.Root
       navigationSidebarOpen={context.sidebarOpen}
       onNavigationSidebarOpenChange={(next) => (context.sidebarOpen = next)}
+      {...(complementarySidebarOpen !== null && {
+        complementarySidebarOpen: context.complementarySidebarOpen as boolean,
+        onComplementarySidebarOpenChange: (next) => (context.complementarySidebarOpen = next),
+      })}
     >
       <Main.NavigationSidebar classNames='overflow-hidden'>
         <Surface name='sidebar' />
       </Main.NavigationSidebar>
+      {complementarySidebarOpen !== null && (
+        <Main.ComplementarySidebar classNames='overflow-hidden'>
+          <Surface name='complementary-sidebar' />
+        </Main.ComplementarySidebar>
+      )}
       <div
         role='none'
         className={mx(
@@ -39,6 +48,22 @@ export const SplitView = () => {
           <SidebarIcon weight='light' className={getSize(5)} />
         </Button>
       </div>
+      {complementarySidebarOpen !== null && (
+        <div
+          role='none'
+          className={mx(
+            'fixed z-[1] block-end-0 pointer-fine:block-end-auto pointer-fine:block-start-0 p-4 pointer-fine:p-1.5 transition-[inset-inline-start,opacity] ease-in-out duration-200 inline-end-0',
+            complementarySidebarOpen && 'opacity-0 pointer-events-none',
+          )}
+        >
+          <Button
+            onClick={() => (context.complementarySidebarOpen = !context.complementarySidebarOpen)}
+            classNames={mx(fineBlockSize, 'aspect-square p-0 shadow-none')}
+          >
+            <SidebarIcon mirrored weight='light' className={getSize(5)} />
+          </Button>
+        </div>
+      )}
       <Main.Overlay />
       <Surface name='main' />
       {/* TODO(burdon): Move dialog to settings-plugin. */}

--- a/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
@@ -18,10 +18,13 @@ export const SplitView = () => {
   const { t } = useTranslation(SPLITVIEW_PLUGIN);
 
   return (
-    <Main.Root sidebarOpen={context.sidebarOpen} onSidebarOpenChange={(next) => (context.sidebarOpen = next)}>
-      <Main.Sidebar classNames='overflow-hidden'>
+    <Main.Root
+      navigationSidebarOpen={context.sidebarOpen}
+      onNavigationSidebarOpenChange={(next) => (context.sidebarOpen = next)}
+    >
+      <Main.NavigationSidebar classNames='overflow-hidden'>
         <Surface name='sidebar' />
-      </Main.Sidebar>
+      </Main.NavigationSidebar>
       <div
         role='none'
         className={mx(

--- a/packages/apps/plugins/plugin-splitview/src/types.ts
+++ b/packages/apps/plugins/plugin-splitview/src/types.ts
@@ -17,6 +17,7 @@ export enum SplitViewAction {
 
 export type SplitViewContextValue = DeepSignal<{
   sidebarOpen: boolean;
+  complementarySidebarOpen: boolean | null;
   dialogContent: any;
   dialogOpen: boolean;
 }>;

--- a/packages/apps/plugins/plugin-treeview/src/components/BranchTreeItem.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/BranchTreeItem.tsx
@@ -9,7 +9,7 @@ import React, { FC, forwardRef, ForwardRefExoticComponent, RefAttributes, useEff
 
 import { SortableProps } from '@braneframe/plugin-dnd';
 import { GraphNode, getActions, useGraph } from '@braneframe/plugin-graph';
-import { Button, DropdownMenu, Tooltip, TreeItem, useSidebar, useTranslation } from '@dxos/aurora';
+import { Button, DropdownMenu, Tooltip, TreeItem, useSidebars, useTranslation } from '@dxos/aurora';
 import { staticDisabled, focusRing, getSize, mx } from '@dxos/aurora-theme';
 
 import { TREE_VIEW_PLUGIN } from '../types';
@@ -51,7 +51,7 @@ export const BranchTreeItem: ForwardRefExoticComponent<BranchTreeItemProps & Ref
   const hasActiveDocument = false;
   const disabled = node.attributes?.disabled;
   const error = node.attributes?.error;
-  const { sidebarOpen } = useSidebar();
+  const { navigationSidebarOpen } = useSidebars();
 
   const suppressNextTooltip = useRef<boolean>(false);
   const [optionsTooltipOpen, setOptionsTooltipOpen] = useState(false);
@@ -81,7 +81,7 @@ export const BranchTreeItem: ForwardRefExoticComponent<BranchTreeItemProps & Ref
           disabled={disabled}
           classNames={['grow flex', disabled && staticDisabled]}
           {...(disabled && { 'aria-disabled': true })}
-          {...(!sidebarOpen && { tabIndex: -1 })}
+          {...(!navigationSidebarOpen && { tabIndex: -1 })}
         >
           <OpenTriggerIcon
             weight='fill'
@@ -138,7 +138,7 @@ export const BranchTreeItem: ForwardRefExoticComponent<BranchTreeItemProps & Ref
                   <Button
                     variant='ghost'
                     classNames='shrink-0 pli-2 pointer-fine:pli-1'
-                    {...(!sidebarOpen && { tabIndex: -1 })}
+                    {...(!navigationSidebarOpen && { tabIndex: -1 })}
                   >
                     <DotsThreeVertical className={getSize(4)} />
                   </Button>
@@ -194,7 +194,7 @@ export const BranchTreeItem: ForwardRefExoticComponent<BranchTreeItemProps & Ref
                   void invokeAction(primaryAction);
                 }}
                 {...(primaryAction.testId && { 'data-testid': primaryAction.testId })}
-                {...(!sidebarOpen && { tabIndex: -1 })}
+                {...(!navigationSidebarOpen && { tabIndex: -1 })}
               >
                 <span className='sr-only'>
                   {Array.isArray(primaryAction.label) ? t(...primaryAction.label) : primaryAction.label}

--- a/packages/apps/plugins/plugin-treeview/src/components/LeafTreeItem.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/LeafTreeItem.tsx
@@ -17,7 +17,7 @@ import {
   TreeItem,
   useDensityContext,
   useMediaQuery,
-  useSidebar,
+  useSidebars,
   useTranslation,
 } from '@dxos/aurora';
 import { auroraTx, staticDisabled, focusRing, getSize, mx } from '@dxos/aurora-theme';
@@ -56,7 +56,7 @@ export const LeafTreeItem: ForwardRefExoticComponent<LeafTreeItemProps & RefAttr
   // todo(thure): Handle `sortable`
 
   const { invokeAction } = useGraph();
-  const { sidebarOpen, closeSidebar } = useSidebar();
+  const { navigationSidebarOpen, closeNavigationSidebar } = useSidebars();
   const { t } = useTranslation(TREE_VIEW_PLUGIN);
   const density = useDensityContext();
   const [isLg] = useMediaQuery('lg', { ssr: false });
@@ -99,21 +99,21 @@ export const LeafTreeItem: ForwardRefExoticComponent<LeafTreeItemProps & RefAttr
       >
         <button
           role='link'
-          {...(!sidebarOpen && { tabIndex: -1 })}
+          {...(!navigationSidebarOpen && { tabIndex: -1 })}
           data-itemid={node.id}
           onKeyDown={(event) => {
             if (event.key === ' ' || event.key === 'Enter') {
               event.stopPropagation();
               // TODO(wittjosiah): Intent.
               treeView.active = node.parent ? [node.parent.id, node.id] : [node.id];
-              !isLg && closeSidebar();
+              !isLg && closeNavigationSidebar();
             }
           }}
           onClick={(event) => {
             // TODO(wittjosiah): Intent.
             // TODO(wittjosiah): Make recursive.
             treeView.active = node.parent ? [node.parent.id, node.id] : [node.id];
-            !isLg && closeSidebar();
+            !isLg && closeNavigationSidebar();
           }}
           className='text-start flex gap-2 justify-start'
         >
@@ -157,7 +157,7 @@ export const LeafTreeItem: ForwardRefExoticComponent<LeafTreeItemProps & RefAttr
                 <Button
                   variant='ghost'
                   classNames='shrink-0 pli-2 pointer-fine:pli-1 self-start'
-                  {...(!sidebarOpen && { tabIndex: -1 })}
+                  {...(!navigationSidebarOpen && { tabIndex: -1 })}
                 >
                   <DotsThreeVertical className={getSize(4)} />
                 </Button>
@@ -203,7 +203,7 @@ export const LeafTreeItem: ForwardRefExoticComponent<LeafTreeItemProps & RefAttr
               classNames='shrink-0 pli-2 pointer-fine:pli-1'
               onClick={() => invokeAction(primaryAction)}
               {...(primaryAction.testId && { 'data-testid': primaryAction.testId })}
-              {...(!sidebarOpen && { tabIndex: -1 })}
+              {...(!navigationSidebarOpen && { tabIndex: -1 })}
             >
               <span className='sr-only'>
                 {Array.isArray(primaryAction.label) ? t(...primaryAction.label) : primaryAction.label}

--- a/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
@@ -16,7 +16,7 @@ import {
   ElevationProvider,
   Tooltip,
   useJdenticonHref,
-  useSidebar,
+  useSidebars,
   useTranslation,
   DropdownMenu,
 } from '@dxos/aurora';
@@ -32,7 +32,7 @@ export const TreeViewContainer = () => {
   const identity = useIdentity({ login: true });
   const jdenticon = useJdenticonHref(identity?.identityKey.toHex() ?? '', 24);
   const { t } = useTranslation(TREE_VIEW_PLUGIN);
-  const { sidebarOpen } = useSidebar(TREE_VIEW_PLUGIN);
+  const { navigationSidebarOpen } = useSidebars(TREE_VIEW_PLUGIN);
   const splitViewContext = useSplitView();
 
   const suppressNextTooltip = useRef<boolean>(false);
@@ -68,7 +68,7 @@ export const TreeViewContainer = () => {
                     {...(action.testId && { 'data-testid': action.testId })}
                     onClick={() => invokeAction(action)}
                     classNames='pli-2 pointer-fine:pli-1'
-                    {...(!sidebarOpen && { tabIndex: -1 })}
+                    {...(!navigationSidebarOpen && { tabIndex: -1 })}
                   >
                     <span className='sr-only'>{Array.isArray(action.label) ? t(...action.label) : action.label}</span>
                     {action.icon ? <action.icon className={getSize(4)} /> : <Placeholder className={getSize(4)} />}
@@ -113,7 +113,7 @@ export const TreeViewContainer = () => {
                     <Button
                       variant='ghost'
                       classNames='shrink-0 pli-2 pointer-fine:pli-1'
-                      {...(!sidebarOpen && { tabIndex: -1 })}
+                      {...(!navigationSidebarOpen && { tabIndex: -1 })}
                     >
                       <DotsThreeVertical className={getSize(4)} />
                     </Button>
@@ -161,7 +161,7 @@ export const TreeViewContainer = () => {
                       <Button
                         variant='ghost'
                         classNames='pli-2 pointer-fine:pli-1'
-                        {...(!sidebarOpen && { tabIndex: -1 })}
+                        {...(!navigationSidebarOpen && { tabIndex: -1 })}
                         onClick={() => {
                           splitViewContext.dialogOpen = true;
                           splitViewContext.dialogContent = 'dxos.org/plugin/splitview/ProfileSettings';

--- a/packages/experimental/kai-framework/src/containers/Sidebar/Sidebar.stories.tsx
+++ b/packages/experimental/kai-framework/src/containers/Sidebar/Sidebar.stories.tsx
@@ -6,7 +6,7 @@ import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { withRouter } from 'storybook-addon-react-router-v6';
 
-import { Button, Main, useSidebar } from '@dxos/aurora';
+import { Button, Main, useSidebars } from '@dxos/aurora';
 import { frameDefs, frameModules, FrameRegistryContextProvider } from '@dxos/kai-frames';
 import { MetagraphClientFake } from '@dxos/metagraph';
 import { useSpaces } from '@dxos/react-client/echo';
@@ -19,8 +19,8 @@ import { AppStateProvider, createPath, defaultFrames } from '../../hooks';
 import { Sidebar } from './Sidebar';
 
 const SidebarInvoker = () => {
-  const { openSidebar } = useSidebar();
-  return <Button onClick={openSidebar}>Open</Button>;
+  const { openNavigationSidebar } = useSidebars();
+  return <Button onClick={openNavigationSidebar}>Open</Button>;
 };
 
 const Test = () => {

--- a/packages/experimental/kai-framework/src/containers/Sidebar/Sidebar.tsx
+++ b/packages/experimental/kai-framework/src/containers/Sidebar/Sidebar.tsx
@@ -6,7 +6,7 @@ import { CaretLeft, Info, Function, Graph, PuzzlePiece, Users, WifiHigh, WifiSla
 import React, { useEffect, useState, Suspense } from 'react';
 import invariant from 'tiny-invariant';
 
-import { Button, DensityProvider, Main, ClassNameValue, useSidebar } from '@dxos/aurora';
+import { Button, DensityProvider, Main, ClassNameValue, useSidebars } from '@dxos/aurora';
 import { getSize, mx } from '@dxos/aurora-theme';
 import { searchMeta } from '@dxos/kai-frames';
 import { ConnectionState } from '@dxos/protocols/proto/dxos/client/services';
@@ -73,7 +73,7 @@ export const Sidebar = ({ className, onNavigate }: SidebarProps) => {
   // App state
   //
 
-  const { toggleSidebar, sidebarOpen } = useSidebar(SIDEBAR_NAME);
+  const { toggleNavigationSidebar, navigationSidebarOpen } = useSidebars(SIDEBAR_NAME);
   const { swarm: connectionState } = useNetworkStatus();
   const [showSpacePanel, setShowSpacePanel] = useState(false);
 
@@ -154,7 +154,7 @@ export const Sidebar = ({ className, onNavigate }: SidebarProps) => {
   const Icon = getIcon(space.properties.icon);
 
   return (
-    <Main.Sidebar classNames={className}>
+    <Main.NavigationSidebar classNames={className}>
       <DensityProvider density='fine'>
         <div role='none' className={mx('flex flex-col w-full h-full overflow-hidden min-bs-full bg-sidebar-bg')}>
           {/* Header */}
@@ -176,8 +176,8 @@ export const Sidebar = ({ className, onNavigate }: SidebarProps) => {
                 >
                   <Info className={getSize(5)} />
                 </Button>
-                <Button variant='ghost' classNames='p-0 pr-2' onClick={toggleSidebar}>
-                  {sidebarOpen && <CaretLeft className={getSize(6)} />}
+                <Button variant='ghost' classNames='p-0 pr-2' onClick={toggleNavigationSidebar}>
+                  {navigationSidebarOpen && <CaretLeft className={getSize(6)} />}
                 </Button>
               </div>
             </div>
@@ -309,7 +309,7 @@ export const Sidebar = ({ className, onNavigate }: SidebarProps) => {
           </div>
         </div>
       </DensityProvider>
-    </Main.Sidebar>
+    </Main.NavigationSidebar>
   );
 };
 

--- a/packages/experimental/kai-framework/src/containers/Surface/Surface.stories.tsx
+++ b/packages/experimental/kai-framework/src/containers/Surface/Surface.stories.tsx
@@ -7,7 +7,7 @@ import React, { FC, ReactNode, Suspense, useContext, useEffect, useState } from 
 import { createMemoryRouter, RouterProvider, useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { Event } from '@dxos/async';
-import { Button, Main, ThemeProvider, useSidebar } from '@dxos/aurora';
+import { Button, Main, ThemeProvider, useSidebars } from '@dxos/aurora';
 import { getSize, mx, auroraTx } from '@dxos/aurora-theme';
 import { raise } from '@dxos/debug';
 import { FullscreenDecorator } from '@dxos/kai-frames';
@@ -113,7 +113,7 @@ const SurfaceOutlet = () => {
 const SIDEBAR_SURFACE_NAME = 'KaiFrameworkSidebarSurface';
 
 const SidebarSurface = () => {
-  const { toggleSidebar } = useSidebar(SIDEBAR_SURFACE_NAME);
+  const { toggleNavigationSidebar } = useSidebars(SIDEBAR_SURFACE_NAME);
   const { controller } = useContext(SurfaceControllerContext);
 
   return (
@@ -128,7 +128,7 @@ const SidebarSurface = () => {
           </Button>
         </div>
         <div>
-          <Button variant='ghost' onClick={toggleSidebar}>
+          <Button variant='ghost' onClick={toggleNavigationSidebar}>
             <CaretLeft className={getSize(5)} />
           </Button>
         </div>
@@ -271,13 +271,13 @@ const Component3 = () => (
 const PANEL_SIDEBAR_CONTENT_NAME = 'PanelSidebarContent';
 
 const PanelSidebarContent: FC<{ children: ReactNode }> = ({ children }) => {
-  const { sidebarOpen, openSidebar } = useSidebar(PANEL_SIDEBAR_CONTENT_NAME);
+  const { navigationSidebarOpen, openNavigationSidebar } = useSidebars(PANEL_SIDEBAR_CONTENT_NAME);
   return (
     <div className='flex grow overflow-hidden'>
-      {!sidebarOpen && (
+      {!navigationSidebarOpen && (
         <div className='flex flex-col h-full px-2'>
           <div className='flex h-[32px] items-center'>
-            <Button variant='ghost' onClick={openSidebar}>
+            <Button variant='ghost' onClick={openNavigationSidebar}>
               <CaretRight className={getSize(5)} />
             </Button>
           </div>
@@ -303,9 +303,9 @@ const Layout = () => {
   return (
     <Main.Root>
       <Main.Overlay />
-      <Main.Sidebar>
+      <Main.NavigationSidebar>
         <Surface id='sidebar' element={<SidebarSurface />} />
-      </Main.Sidebar>
+      </Main.NavigationSidebar>
       <Main.Content>
         <PanelSidebarContent>
           <Surface id='main' element={<MainSurface />} />

--- a/packages/experimental/kai-framework/src/pages/SpacePage.tsx
+++ b/packages/experimental/kai-framework/src/pages/SpacePage.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 
-import { Main, useSidebar } from '@dxos/aurora';
+import { Main, useSidebars } from '@dxos/aurora';
 import { useTelemetry } from '@dxos/react-appkit';
 import { SpaceState, useSpaces } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
@@ -26,7 +26,7 @@ const SpacePage = () => {
   const navigate = useNavigate(); // TODO(burdon): Factor out router (party of app state).
   const [searchParams] = useSearchParams();
   const spaceInvitationCode = searchParams.get('spaceInvitationCode');
-  const { sidebarOpen } = useSidebar();
+  const { navigationSidebarOpen } = useSidebars();
 
   if (!space && spaces.length > 0 && !spaceInvitationCode) {
     return <Navigate to={createPath({ spaceKey: spaces[0].key, frame: frame?.module.id ?? defaultFrameId })} />;
@@ -47,10 +47,10 @@ const SpacePage = () => {
     //  Also, `<main>` should be the content not the container that contains the sidebar.
     <div className='flex flex-col h-full overflow-hidden'>
       <Sidebar
-        className={['!block-start-appbar md:is-sidebar', !sidebarOpen && 'md:-inline-start-sidebar']}
+        className={['!block-start-appbar md:is-sidebar', !navigationSidebarOpen && 'md:-inline-start-sidebar']}
         onNavigate={(path) => navigate(path)}
       />
-      <Main.Content classNames={['flex flex-col bs-full overflow-hidden', sidebarOpen && 'md:pis-sidebar']}>
+      <Main.Content classNames={['flex flex-col bs-full overflow-hidden', navigationSidebarOpen && 'md:pis-sidebar']}>
         <SpacePanel />
       </Main.Content>
     </div>

--- a/packages/experimental/kai-framework/src/pages/SpacePanel.tsx
+++ b/packages/experimental/kai-framework/src/pages/SpacePanel.tsx
@@ -6,7 +6,7 @@ import { CaretRight } from '@phosphor-icons/react';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
-import { Button, useSidebar } from '@dxos/aurora';
+import { Button, useSidebars } from '@dxos/aurora';
 import { getSize, mx } from '@dxos/aurora-theme';
 import { FrameDef, useFrameRegistry } from '@dxos/kai-frames';
 import { SpaceState } from '@dxos/react-client/echo';
@@ -22,7 +22,7 @@ export const SpacePanel = () => {
   const { chat, dev, fullscreen } = useAppState();
   const { space, frame, objectId } = useAppRouter();
   const { section } = useParams();
-  const { sidebarOpen, toggleSidebar } = useSidebar(SPACE_PANEL_NAME);
+  const { navigationSidebarOpen, toggleNavigationSidebar } = useSidebars(SPACE_PANEL_NAME);
 
   const frameRegistry = useFrameRegistry();
   let sidebarFrameDef: FrameDef<any> | undefined;
@@ -38,8 +38,8 @@ export const SpacePanel = () => {
     <div className='flex flex-col bs-full overflow-hidden'>
       {space?.state.get() === SpaceState.READY && (
         <div className={mx('flex shrink-0 h-[40px] p-2 items-center', theme.classes.header)}>
-          {!sidebarOpen && (
-            <Button variant='ghost' onClick={toggleSidebar}>
+          {!navigationSidebarOpen && (
+            <Button variant='ghost' onClick={toggleNavigationSidebar}>
               {<CaretRight className={getSize(6)} />}
             </Button>
           )}

--- a/packages/experimental/kube-console/src/containers/ModuleContainer.tsx
+++ b/packages/experimental/kube-console/src/containers/ModuleContainer.tsx
@@ -28,9 +28,9 @@ export const ModuleContainer = () => {
   return (
     <Main.Root>
       <Main.Overlay />
-      <Main.Sidebar>
+      <Main.NavigationSidebar>
         <Sidebar modules={modules} active={active.id} onActiveChange={handleActiveChange} />
-      </Main.Sidebar>
+      </Main.NavigationSidebar>
       <Main.Content classNames='flex overflow-hidden'>
         <Component />
       </Main.Content>

--- a/packages/ui/aurora-theme/src/styles/components/main.ts
+++ b/packages/ui/aurora-theme/src/styles/components/main.ts
@@ -5,7 +5,7 @@
 import { ComponentFunction } from '@dxos/aurora-types/src';
 
 import { mx } from '../../util';
-import { baseSurface, inlineSeparator } from '../fragments';
+import { baseSurface } from '../fragments';
 
 export type MainStyleProps = Partial<{
   isLg: boolean;
@@ -22,10 +22,15 @@ export const mainSidebar: ComponentFunction<MainStyleProps> = (
   mx(
     'fixed block-start-0 block-end-0 is-[100vw] sm:is-[270px] z-10 overscroll-contain overflow-x-hidden overflow-y-auto',
     'transition-[inset-inline-start,inset-inline-end] duration-200 ease-in-out',
-    side === 'inline-start' &&
-      (inlineStartSidebarOpen ? 'inline-start-0' : '-inline-start-[100vw] sm:-inline-start-[270px]'),
-    side === 'inline-end' && (inlineEndSidebarOpen ? 'inline-end-0' : '-inline-end-[100vw] sm:-inline-end-[270px]'),
-    inlineSeparator,
+    'border-neutral-200 dark:border-neutral-800',
+    side === 'inline-start'
+      ? inlineStartSidebarOpen
+        ? 'inline-start-0'
+        : '-inline-start-[100vw] sm:-inline-start-[270px]'
+      : inlineEndSidebarOpen
+      ? 'inline-end-0'
+      : '-inline-end-[100vw] sm:-inline-end-[270px]',
+    side === 'inline-start' ? 'border-ie' : 'border-is',
     baseSurface,
     ...etc,
   );
@@ -47,7 +52,7 @@ export const mainContent: ComponentFunction<MainStyleProps> = (
   ...etc
 ) =>
   mx(
-    'transition-[padding-inline-start] duration-200 ease-in-out',
+    'transition-[padding-inline-start,padding-inline-end] duration-200 ease-in-out',
     isLg && inlineStartSidebarOpen ? 'pis-[270px]' : 'pis-0',
     isLg && inlineEndSidebarOpen ? 'pie-[270px]' : 'pie-0',
     bounce && 'fixed inset-0 z-0 overflow-auto overscroll-auto scroll-smooth',

--- a/packages/ui/aurora-theme/src/styles/components/main.ts
+++ b/packages/ui/aurora-theme/src/styles/components/main.ts
@@ -9,33 +9,47 @@ import { baseSurface, inlineSeparator } from '../fragments';
 
 export type MainStyleProps = Partial<{
   isLg: boolean;
-  sidebarOpen: boolean;
+  inlineStartSidebarOpen: boolean;
+  inlineEndSidebarOpen: boolean;
+  side: 'inline-start' | 'inline-end';
   bounce: boolean;
 }>;
 
-export const mainSidebar: ComponentFunction<MainStyleProps> = ({ isLg, sidebarOpen }, ...etc) =>
+export const mainSidebar: ComponentFunction<MainStyleProps> = (
+  { inlineStartSidebarOpen, inlineEndSidebarOpen, side },
+  ...etc
+) =>
   mx(
     'fixed block-start-0 block-end-0 is-[100vw] sm:is-[270px] z-10 overscroll-contain overflow-x-hidden overflow-y-auto',
     'transition-[inset-inline-start,inset-inline-end] duration-200 ease-in-out',
-    sidebarOpen ? 'inline-start-0' : '-inline-start-[100vw] sm:-inline-start-[270px]',
+    side === 'inline-start' &&
+      (inlineStartSidebarOpen ? 'inline-start-0' : '-inline-start-[100vw] sm:-inline-start-[270px]'),
+    side === 'inline-end' && (inlineEndSidebarOpen ? 'inline-end-0' : '-inline-end-[100vw] sm:-inline-end-[270px]'),
     inlineSeparator,
     baseSurface,
     ...etc,
   );
 
-export const mainOverlay: ComponentFunction<MainStyleProps> = ({ isLg, sidebarOpen }, ...etc) =>
+export const mainOverlay: ComponentFunction<MainStyleProps> = (
+  { isLg, inlineStartSidebarOpen, inlineEndSidebarOpen, side },
+  ...etc
+) =>
   mx(
     'fixed inset-0 z-[9] bg-transparent',
     'transition-opacity duration-200 ease-in-out',
-    !isLg && sidebarOpen ? 'opacity-100' : 'opacity-0',
-    !isLg && sidebarOpen ? 'block' : 'hidden',
+    !isLg && (inlineStartSidebarOpen || inlineEndSidebarOpen) ? 'opacity-100' : 'opacity-0',
+    !isLg && (inlineStartSidebarOpen || inlineEndSidebarOpen) ? 'block' : 'hidden',
     ...etc,
   );
 
-export const mainContent: ComponentFunction<MainStyleProps> = ({ isLg, sidebarOpen, bounce }, ...etc) =>
+export const mainContent: ComponentFunction<MainStyleProps> = (
+  { isLg, inlineStartSidebarOpen, inlineEndSidebarOpen, bounce },
+  ...etc
+) =>
   mx(
     'transition-[padding-inline-start] duration-200 ease-in-out',
-    isLg && sidebarOpen ? 'pis-[270px]' : 'pis-0',
+    isLg && inlineStartSidebarOpen ? 'pis-[270px]' : 'pis-0',
+    isLg && inlineEndSidebarOpen ? 'pie-[270px]' : 'pie-0',
     bounce && 'fixed inset-0 z-0 overflow-auto overscroll-auto scroll-smooth',
     ...etc,
   );

--- a/packages/ui/aurora/.storybook/preview.cjs
+++ b/packages/ui/aurora/.storybook/preview.cjs
@@ -9,7 +9,8 @@ export const parameters = {
       color: /(background|color)$/i,
       date: /Date$/,
     },
-  }
+  },
+  layout: 'fullscreen'
 }
 
 export const globalTypes = {

--- a/packages/ui/aurora/src/components/Main/Main.stories.tsx
+++ b/packages/ui/aurora/src/components/Main/Main.stories.tsx
@@ -10,23 +10,35 @@ import { Main, useSidebars } from './Main';
 
 type StoryMainArgs = {};
 
-const SidebarToggle = () => {
+const NavigationSidebarToggle = () => {
   const { toggleNavigationSidebar } = useSidebars('StoryMain__SidebarToggle');
-  return <Button onClick={toggleNavigationSidebar}>Toggle sidebar</Button>;
+  return <Button onClick={toggleNavigationSidebar}>Toggle navigation sidebar</Button>;
+};
+
+const ComplementarySidebarToggle = () => {
+  const { toggleComplementarySidebar } = useSidebars('StoryMain__SidebarToggle');
+  return <Button onClick={toggleComplementarySidebar}>Toggle complementary sidebar</Button>;
 };
 
 const StoryMain = (_args: StoryMainArgs) => {
   return (
-    <Main.Root defaultNavigationSidebarOpen>
+    <Main.Root defaultComplementarySidebarOpen>
       <Main.Overlay />
-      <Main.NavigationSidebar swipeToDismiss>
-        <p>Sidebar content, hi!</p>
-        <SidebarToggle />
+      <Main.NavigationSidebar classNames='p-4'>
+        <p>Navigation sidebar content, hi!</p>
+        <NavigationSidebarToggle />
       </Main.NavigationSidebar>
       <Main.Content>
-        <p>Main content, hello!</p>
-        <SidebarToggle />
+        <div role='group' className='m-4 p-4 bg-neutral-950 rounded'>
+          <ComplementarySidebarToggle />
+          <p>Main content, hello!</p>
+          <NavigationSidebarToggle />
+        </div>
       </Main.Content>
+      <Main.ComplementarySidebar classNames='p-4'>
+        <p>Complementary sidebar content, hello!</p>
+        <ComplementarySidebarToggle />
+      </Main.ComplementarySidebar>
     </Main.Root>
   );
 };
@@ -35,4 +47,5 @@ export default { component: StoryMain };
 
 export const Default = {
   args: {},
+  layout: 'fullscreen',
 };

--- a/packages/ui/aurora/src/components/Main/Main.stories.tsx
+++ b/packages/ui/aurora/src/components/Main/Main.stories.tsx
@@ -6,23 +6,23 @@ import '@dxosTheme';
 import React from 'react';
 
 import { Button } from '../Buttons';
-import { Main, useSidebar } from './Main';
+import { Main, useSidebars } from './Main';
 
 type StoryMainArgs = {};
 
 const SidebarToggle = () => {
-  const { toggleSidebar } = useSidebar('StoryMain__SidebarToggle');
-  return <Button onClick={toggleSidebar}>Toggle sidebar</Button>;
+  const { toggleNavigationSidebar } = useSidebars('StoryMain__SidebarToggle');
+  return <Button onClick={toggleNavigationSidebar}>Toggle sidebar</Button>;
 };
 
 const StoryMain = (_args: StoryMainArgs) => {
   return (
-    <Main.Root defaultSidebarOpen>
+    <Main.Root defaultNavigationSidebarOpen>
       <Main.Overlay />
-      <Main.Sidebar swipeToDismiss>
+      <Main.NavigationSidebar swipeToDismiss>
         <p>Sidebar content, hi!</p>
         <SidebarToggle />
-      </Main.Sidebar>
+      </Main.NavigationSidebar>
       <Main.Content>
         <p>Main content, hello!</p>
         <SidebarToggle />

--- a/packages/ui/aurora/src/components/Main/Main.tsx
+++ b/packages/ui/aurora/src/components/Main/Main.tsx
@@ -167,7 +167,6 @@ const MainNavigationSidebar = forwardRef<HTMLDivElement, MainNavigationSidebarPr
   const { navigationSidebarOpen, setNavigationSidebarOpen } = useMainContext(NAVIGATION_SIDEBAR_NAME);
   return (
     <MainSidebar
-      role='navigation'
       {...props}
       open={navigationSidebarOpen}
       setOpen={setNavigationSidebarOpen}
@@ -185,7 +184,6 @@ const MainComplementarySidebar = forwardRef<HTMLDivElement, MainComplementarySid
   const { complementarySidebarOpen, setComplementarySidebarOpen } = useMainContext(COMPLEMENTARY_SIDEBAR_NAME);
   return (
     <MainSidebar
-      role='complementary'
       {...props}
       open={complementarySidebarOpen}
       setOpen={setComplementarySidebarOpen}

--- a/packages/ui/aurora/src/components/Main/Main.tsx
+++ b/packages/ui/aurora/src/components/Main/Main.tsx
@@ -167,6 +167,7 @@ const MainNavigationSidebar = forwardRef<HTMLDivElement, MainNavigationSidebarPr
   const { navigationSidebarOpen, setNavigationSidebarOpen } = useMainContext(NAVIGATION_SIDEBAR_NAME);
   return (
     <MainSidebar
+      role='navigation'
       {...props}
       open={navigationSidebarOpen}
       setOpen={setNavigationSidebarOpen}
@@ -184,6 +185,7 @@ const MainComplementarySidebar = forwardRef<HTMLDivElement, MainComplementarySid
   const { complementarySidebarOpen, setComplementarySidebarOpen } = useMainContext(COMPLEMENTARY_SIDEBAR_NAME);
   return (
     <MainSidebar
+      role='complementary'
       {...props}
       open={complementarySidebarOpen}
       setOpen={setComplementarySidebarOpen}


### PR DESCRIPTION
This PR makes it so there are two sidebars.

https://github.com/dxos/dxos/assets/855039/c863b0e6-8de1-4609-b114-211a2da44f1d

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0180e81</samp>

### Summary
🎨🚀♿

<!--
1.  🎨 - This emoji represents the changes related to the UI and styling of the sidebars, such as using the new `Main` component and the `Main.NavigationSidebar` component from `@dxos/aurora`, refactoring the `MainStyleProps` type and the `mainSidebar`, `mainOverlay`, and `mainContent` functions, and adding the `layout: 'fullscreen'` property to the storybook parameters.
2.  🚀 - This emoji represents the changes related to the functionality and performance of the sidebars, such as adding the `enableComplementarySidebar` prop and the `complementarySidebarOpen` state to the `SplitViewPlugin` function, using the new `useSidebars` hook instead of the deprecated `useSidebar` hook, and updating the `SplitView` component to support a complementary sidebar that can be toggled by a button.
3.  ♿ - This emoji represents the changes related to the accessibility and usability of the sidebars, such as disabling the tree item buttons when the navigation sidebar is closed, opening a dialog when a button is clicked, and improving the icon and label of the sidebar toggle button.
-->
Updated various components and plugins to use the new `useSidebars` hook and `Main` component from `@dxos/aurora` for managing multiple sidebars in the UI. Refactored the `@dxos/aurora` and `@dxos/aurora-theme` packages to support both navigation and complementary sidebars with consistent and flexible styles and props. Added an optional prop `enableComplementarySidebar` to the `SplitViewPlugin` function to enable a complementary sidebar feature.

> _Sing, O Muse, of the mighty `SplitViewPlugin`, the wondrous work of skillful coders,_
> _Who added a new prop to render a `complementarySidebar`, a helpful feature for the users,_
> _And refactored the `Main` component and its hooks and types, to support both sidebars with grace,_
> _Like Hephaestus, who forged the shield of Achilles, with many scenes and shapes._

### Walkthrough
*  Refactor the `Main` component and related hooks and types to support both navigation and complementary sidebars ([link](https://github.com/dxos/dxos/pull/3879/files?diff=unified&w=0#diff-6cb9ca47f40030efd387c6b913991939307763cd606e18959254290504ded3a8L8-R57), [link](https://github.com/dxos/dxos/pull/3879/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL28-R116), [link](https://github.com/dxos/dxos/pull/3879/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL86-R128), [link](https://github.com/dxos/dxos/pull/3879/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL93-R197), [link](https://github.com/dxos/dxos/pull/3879/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL123-R203), [link](https://github.com/dxos/dxos/pull/3879/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL130-R220), [link](https://github.com/dxos/dxos/pull/3879/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL145-R251), [link](https://github.com/dxos/dxos/pull/3879/files?diff=unified&w=0#diff-777969c98b8bbbc163490c9c02c7665b5b0eeb6166cb5bba150212ec7ee9acbcL160-R269)).


