### PR TITLE
fix(react-shell): Improvements

### DIFF
--- a/packages/sdk/react-shell/src/panels/JoinPanel/joinMachine.ts
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/joinMachine.ts
@@ -410,6 +410,7 @@ const useJoinMachine = (client: Client, options?: Parameters<typeof useMachine<J
           ...halo,
           invitationObservable,
           invitationSubscribable: getInvitationSubscribable('Halo', invitationObservable),
+          unredeemedCode: undefined,
         };
       } else {
         return halo;
@@ -428,6 +429,7 @@ const useJoinMachine = (client: Client, options?: Parameters<typeof useMachine<J
           ...space,
           invitationObservable,
           invitationSubscribable: getInvitationSubscribable('Space', invitationObservable),
+          unredeemedCode: undefined,
         };
       } else {
         return space;


### PR DESCRIPTION
This PR resolves:
- [x] #3887 
- ~~#3886~~
- ~~#3863~~ 

<img width="1046" alt="Screenshot 2023-08-15 at 23 53 58" src="https://github.com/dxos/dxos/assets/855039/2c18f417-e389-4230-b377-5fac5aba08cc">

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 406357c</samp>

### Summary
🛠️🔄➕

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate that the pull request improves the code quality and logic of the join machine.
2.  🔄 - This emoji represents a refresh or an update, and can be used to indicate that the pull request restores and modifies a previous transition that was removed.
3.  ➕ - This emoji represents an addition or a plus, and can be used to indicate that the pull request adds a new property to the initial context of the space and halo objects.
-->
This pull request refactors and enhances the join machine logic for joining spaces and halos. It introduces a common `Kind` type, simplifies the code with the `Lowercase` utility type, and enables automatic redemption of invitation codes. It also adds a new context property `unredeemedCode` to the `space` and `halo` objects in `joinMachine.ts`.



### Walkthrough
* Extract and use `Kind` type alias for `'Space' | 'Halo'` to improve readability and maintainability ([link](https://github.com/dxos/dxos/pull/3888/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4L74-R77), [link](https://github.com/dxos/dxos/pull/3888/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4L134-R136), [link](https://github.com/dxos/dxos/pull/3888/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4L159-R160), [link](https://github.com/dxos/dxos/pull/3888/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4L167-R168), [link](https://github.com/dxos/dxos/pull/3888/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4L219-R221), [link](https://github.com/dxos/dxos/pull/3888/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4L238-R237))
* Restore and modify transition to redeem invitation code on init if present in context, to avoid user input duplication ([link](https://github.com/dxos/dxos/pull/3888/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4L145-R154))
* Add `unredeemedCode` property to initial context of `space` and `halo` objects, to store the code for automatic redemption ([link](https://github.com/dxos/dxos/pull/3888/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4R413), [link](https://github.com/dxos/dxos/pull/3888/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4R432))

