### PR TITLE
feat: Add backpressure to webrtc-proxy transport

### DIFF
--- a/packages/common/node-std/src/stream.js
+++ b/packages/common/node-std/src/stream.js
@@ -2,4 +2,4 @@
 // Copyright 2022 DXOS.org
 //
 
-export { Duplex, PassThrough, pipeline, Stream, Transform } from 'readable-stream';
+export { Duplex, PassThrough, pipeline, Stream, Transform, Readable, Writable } from 'readable-stream';

--- a/packages/core/mesh/network-manager/src/transport/webrtc-transport-proxy.ts
+++ b/packages/core/mesh/network-manager/src/transport/webrtc-transport-proxy.ts
@@ -2,6 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
+import { Writable } from 'node:stream';
 import invariant from 'tiny-invariant';
 
 import { Event } from '@dxos/async';
@@ -15,7 +16,6 @@ import { Signal } from '@dxos/protocols/proto/dxos/mesh/swarm';
 import { arrayToBuffer } from '@dxos/util';
 
 import { Transport, TransportFactory, TransportOptions } from './transport';
-import { Writable } from 'node:stream';
 
 export type WebRTCTransportProxyParams = {
   initiator: boolean;
@@ -70,7 +70,7 @@ export class WebRTCTransportProxy implements Transport {
               }
             );
           },
-        }))
+        }));
       },
       (error) => log.catch(error)
     );

--- a/packages/core/mesh/network-manager/src/transport/webrtc-transport-service.ts
+++ b/packages/core/mesh/network-manager/src/transport/webrtc-transport-service.ts
@@ -21,20 +21,30 @@ import { ComplexMap } from '@dxos/util';
 
 import { WebRTCTransport } from './webrtc-transport';
 
+type TransportState = {
+  transport: WebRTCTransport;
+  stream: Duplex;
+  writeCallbacks: (() => void)[]
+};
+
 export class WebRTCTransportService implements BridgeService {
-  private readonly transports = new ComplexMap<PublicKey, { transport: WebRTCTransport; stream: Duplex }>(
-    PublicKey.hash,
-  );
+  private readonly transports = new ComplexMap<PublicKey, TransportState>(PublicKey.hash);
 
   // prettier-ignore
   constructor(
     private readonly _webrtcConfig?: any
-  ) {}
+  ) { }
 
   open(request: ConnectionRequest): Stream<BridgeEvent> {
     const rpcStream: Stream<BridgeEvent> = new Stream(({ ready, next, close }) => {
       const duplex: Duplex = new Duplex({
-        read: () => {},
+        read: () => {
+          const callbacks = [...transportState.writeCallbacks];
+          transportState.writeCallbacks.length = 0;
+          for (const cb of callbacks) {
+            cb();
+          }
+        },
         write: function (chunk, _, callback) {
           next({ data: { payload: chunk } });
           callback();
@@ -85,8 +95,15 @@ export class WebRTCTransportService implements BridgeService {
         close();
       });
 
+      const transportState: TransportState = {
+        transport,
+        stream: duplex,
+        writeCallbacks: [],
+      };
+
       ready();
-      this.transports.set(request.proxyId, { transport, stream: duplex });
+
+      this.transports.set(request.proxyId, transportState);
     });
 
     return rpcStream;
@@ -99,7 +116,13 @@ export class WebRTCTransportService implements BridgeService {
 
   async sendData({ proxyId, payload }: DataRequest): Promise<void> {
     invariant(this.transports.has(proxyId));
-    await this.transports.get(proxyId)!.stream.push(payload);
+    const state = this.transports.get(proxyId)!;
+    const bufferHasSpace = state.stream.push(payload);
+    if (!bufferHasSpace) {
+      await new Promise<void>(resolve => {
+        state.writeCallbacks.push(resolve);
+      });
+    }
   }
 
   async close({ proxyId }: CloseRequest) {

--- a/packages/core/mesh/network-manager/src/transport/webrtc-transport-service.ts
+++ b/packages/core/mesh/network-manager/src/transport/webrtc-transport-service.ts
@@ -24,7 +24,7 @@ import { WebRTCTransport } from './webrtc-transport';
 type TransportState = {
   transport: WebRTCTransport;
   stream: Duplex;
-  writeCallbacks: (() => void)[]
+  writeCallbacks: (() => void)[];
 };
 
 export class WebRTCTransportService implements BridgeService {
@@ -119,7 +119,7 @@ export class WebRTCTransportService implements BridgeService {
     const state = this.transports.get(proxyId)!;
     const bufferHasSpace = state.stream.push(payload);
     if (!bufferHasSpace) {
-      await new Promise<void>(resolve => {
+      await new Promise<void>((resolve) => {
         state.writeCallbacks.push(resolve);
       });
     }

--- a/packages/core/mesh/teleport/src/muxing/muxer.ts
+++ b/packages/core/mesh/teleport/src/muxing/muxer.ts
@@ -240,6 +240,10 @@ export class Muxer {
     log('Received command', { cmd });
 
     if (this._destroyed || this._destroying) {
+      if(cmd.destroy)  {
+        return;
+      }
+
       log.warn('Received command after destroy', { cmd });
       return;
     }

--- a/packages/core/mesh/teleport/src/muxing/muxer.ts
+++ b/packages/core/mesh/teleport/src/muxing/muxer.ts
@@ -240,7 +240,7 @@ export class Muxer {
     log('Received command', { cmd });
 
     if (this._destroyed || this._destroying) {
-      if(cmd.destroy)  {
+      if (cmd.destroy) {
         return;
       }
 

--- a/packages/gravity/kube-testing/package.json
+++ b/packages/gravity/kube-testing/package.json
@@ -14,7 +14,7 @@
   },
   "types": "dist/types/src/index.d.ts",
   "scripts": {
-    "run-tests": "node -r ts-node/register ./src/main.ts"
+    "run-tests": "SWC_PLUGINS=$(cat swc-plugins.json) node -r ts-node/register ./src/main.ts"
   },
   "dependencies": {
     "@dxos/async": "workspace:*",

--- a/packages/gravity/kube-testing/src/main.ts
+++ b/packages/gravity/kube-testing/src/main.ts
@@ -74,6 +74,9 @@ const runTransport = () =>
       agents: 2,
       swarmsPerAgent: 1,
       duration: 60_000,
+
+      transport: 'webrtc-proxy',
+
       targetSwarmTimeout: 10_000,
       fullSwarmTimeout: 60_000,
       iterationDelay: 1_000,

--- a/packages/gravity/kube-testing/src/plan/transport-spec.ts
+++ b/packages/gravity/kube-testing/src/plan/transport-spec.ts
@@ -20,7 +20,7 @@ export type TransportTestSpec = {
   swarmsPerAgent: number;
   duration: number;
 
-  transport: 'webrtc' | 'webrtc-proxy'
+  transport: 'webrtc' | 'webrtc-proxy';
 
   streamLoadInterval: number;
   streamLoadChunkSize: number;
@@ -68,7 +68,7 @@ export class TransportTestPlan implements TestPlan<TransportTestSpec, TransportA
 
     const networkManagerBuilder = new NetworkManagerTestBuilder({
       signalHosts: [{ server: signalUrl }],
-      bridge: spec.transport === 'webrtc-proxy'
+      bridge: spec.transport === 'webrtc-proxy',
     });
 
     const peer = networkManagerBuilder.createPeer(PublicKey.from(env.params.agentId));

--- a/packages/gravity/kube-testing/src/plan/transport-spec.ts
+++ b/packages/gravity/kube-testing/src/plan/transport-spec.ts
@@ -20,6 +20,8 @@ export type TransportTestSpec = {
   swarmsPerAgent: number;
   duration: number;
 
+  transport: 'webrtc' | 'webrtc-proxy'
+
   streamLoadInterval: number;
   streamLoadChunkSize: number;
 
@@ -66,6 +68,7 @@ export class TransportTestPlan implements TestPlan<TransportTestSpec, TransportA
 
     const networkManagerBuilder = new NetworkManagerTestBuilder({
       signalHosts: [{ server: signalUrl }],
+      bridge: spec.transport === 'webrtc-proxy'
     });
 
     const peer = networkManagerBuilder.createPeer(PublicKey.from(env.params.agentId));

--- a/packages/gravity/kube-testing/swc-plugins.json
+++ b/packages/gravity/kube-testing/swc-plugins.json
@@ -1,0 +1,23 @@
+[
+  [
+    "@dxos/swc-log-plugin",
+    {
+      "symbols": [
+        {
+          "function": "log",
+          "package": "@dxos/log",
+          "param_index": 2,
+          "include_args": false,
+          "include_call_site": true
+        },
+        {
+          "function": "invariant",
+          "package": "@dxos/log",
+          "param_index": 2,
+          "include_args": true,
+          "include_call_site": false
+        }
+      ]
+    }
+  ]
+]

--- a/packages/gravity/kube-testing/tsconfig.json
+++ b/packages/gravity/kube-testing/tsconfig.json
@@ -17,6 +17,9 @@
   "include": [
     "src"
   ],
+  "ts-node": {
+    "swc": true
+  },
   "references": [
     {
       "path": "../../common/async"


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 37e1885</samp>

### Summary
🛠️📝🚀

<!--
1.  🛠️ for fixing the `destroy` command handling in the `Muxer` class.
2.  📝 for adding the `SWC_PLUGINS` environment variable and the `swc-plugins.json` file to the `kube-testing` package.
3.  🚀 for improving the performance and reliability of the WebRTC transport service and adding support for testing it in the `kube-testing` package.
-->
This pull request improves the WebRTC transport implementation and testing in the `dxos` packages. It refactors the `WebRTCTransportProxy` class to use a stream API, adds backpressure handling to the `WebRTCTransportService` class, and adds a test plan for the `webrtc-proxy` transport option in the `kube-testing` package. It also uses the `@dxos/swc-log-plugin` to enhance the logging and debugging capabilities of the `@dxos/log` package.

> _We are the masters of the WebRTC_
> _We send the data through the proxy_
> _We use the streams and the plugins_
> _We test the transport with the muxer_

### Walkthrough
*  Import `Writable` class from `node:stream` module and use it to create a stream that sends data to the bridge service in `WebRTCTransportProxy` class ([link](https://github.com/dxos/dxos/pull/3893/files?diff=unified&w=0#diff-7982c37c1cb1cb1bc7ca853f536141dfbda15758d88059786ae6e3797fbec2d2R5), [link](https://github.com/dxos/dxos/pull/3893/files?diff=unified&w=0#diff-7982c37c1cb1cb1bc7ca853f536141dfbda15758d88059786ae6e3797fbec2d2L60-R73)).


