### PR TITLE
feat(testbench): Add connection metreics

### DIFF
--- a/packages/core/mesh/network-manager/src/swarm/connection.ts
+++ b/packages/core/mesh/network-manager/src/swarm/connection.ts
@@ -91,7 +91,15 @@ export class Connection {
     private readonly _signalMessaging: SignalMessenger,
     private readonly _protocol: WireProtocol,
     private readonly _transportFactory: TransportFactory,
-  ) {}
+  ) {
+    log.trace('dxos.mesh.connection.construct', {
+      sessionId: this.sessionId,
+      topic: this.topic,
+      localPeerId: this.ownId,
+      remotePeerId: this.remoteId,
+      initiator: this.initiator,
+    });
+  }
 
   get state() {
     return this._state;
@@ -111,6 +119,13 @@ export class Connection {
   async openConnection() {
     invariant(this._state === ConnectionState.INITIAL, 'Invalid state.');
     log.trace('dxos.mesh.connection.open-connection', trace.begin({ id: this._instanceId }));
+    log.trace('dxos.mesh.connection.open', {
+      sessionId: this.sessionId,
+      topic: this.topic,
+      localPeerId: this.ownId,
+      remotePeerId: this.remoteId,
+      initiator: this.initiator,
+    });
 
     this._changeState(ConnectionState.CONNECTING);
 

--- a/packages/core/mesh/network-manager/src/swarm/peer.ts
+++ b/packages/core/mesh/network-manager/src/swarm/peer.ts
@@ -226,12 +226,27 @@ export class Peer {
           this._callbacks.onConnected();
 
           this._connectionLimiter.doneConnecting(sessionId);
+          log.trace('dxos.mesh.connection.connected', {
+            topic: this.topic,
+            localPeerId: this.localPeerId,
+            remotePeerId: this.id,
+            sessionId,
+            initiator,
+          });
           break;
         }
 
         case ConnectionState.CLOSED: {
           log('connection closed', { topic: this.topic, peerId: this.localPeerId, remoteId: this.id, initiator });
           invariant(this.connection === connection, 'Connection mismatch (race condition).');
+
+          log.trace('dxos.mesh.connection.closed', {
+            topic: this.topic,
+            localPeerId: this.localPeerId,
+            remotePeerId: this.id,
+            sessionId,
+            initiator,
+          });
 
           if (this._lastConnectionTime && this._lastConnectionTime + CONNECTION_COUNTS_STABLE_AFTER < Date.now()) {
             // If we're closing the connection, and it has been connected for a while, reset the backoff.
@@ -260,6 +275,14 @@ export class Peer {
     });
     connection.errors.handle((err) => {
       log.warn('connection error', { topic: this.topic, peerId: this.localPeerId, remoteId: this.id, initiator, err });
+      log.trace('dxos.mesh.connection.error', {
+        topic: this.topic,
+        localPeerId: this.localPeerId,
+        remotePeerId: this.id,
+        sessionId,
+        initiator,
+        err,
+      });
 
       // Calls `onStateChange` with CLOSED state.
       void this.closeConnection();

--- a/packages/gravity/kube-testing/package.json
+++ b/packages/gravity/kube-testing/package.json
@@ -23,6 +23,7 @@
     "@dxos/context": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/echo-pipeline": "workspace:*",
+    "@dxos/invariant": "workspace:*",
     "@dxos/keys": "workspace:*",
     "@dxos/log": "workspace:*",
     "@dxos/messaging": "workspace:*",

--- a/packages/gravity/kube-testing/src/analysys/logging.ts
+++ b/packages/gravity/kube-testing/src/analysys/logging.ts
@@ -91,6 +91,10 @@ export class LogReader implements AsyncIterable<SerializedLogEntry> {
     reader._logs = [...this._logs];
     return reader;
   }
+
+  reduce<T>(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T) {
+    return this._logs.reduce(callbackfn, initialValue);
+  }
 }
 
 export type SerializedLogEntry<T = any> = {

--- a/packages/gravity/kube-testing/src/analysys/logging.ts
+++ b/packages/gravity/kube-testing/src/analysys/logging.ts
@@ -92,8 +92,8 @@ export class LogReader implements Iterable<SerializedLogEntry> {
     return reader;
   }
 
-  reduce<T>(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T) {
-    return this._logs.reduce(callbackfn, initialValue);
+  forEach<T>(callbackFn: (value: T, index: number, array: T[]) => void): void {
+    this._logs.forEach(callbackFn);
   }
 }
 

--- a/packages/gravity/kube-testing/src/analysys/logging.ts
+++ b/packages/gravity/kube-testing/src/analysys/logging.ts
@@ -59,7 +59,7 @@ export type AddFileOptions = {
   preprocessor?: (entry: any) => SerializedLogEntry;
 };
 
-export class LogReader implements AsyncIterable<SerializedLogEntry> {
+export class LogReader implements Iterable<SerializedLogEntry> {
   private _logs: any[] = [];
 
   addFile(path: string, { preprocessor }: AddFileOptions = {}) {
@@ -79,7 +79,7 @@ export class LogReader implements AsyncIterable<SerializedLogEntry> {
     ];
   }
 
-  async *[Symbol.asyncIterator](): AsyncGenerator<SerializedLogEntry> {
+  *[Symbol.iterator](): Generator<SerializedLogEntry> {
     let idx = 0;
     while (idx < this._logs.length) {
       yield this._logs[idx++];

--- a/packages/gravity/kube-testing/src/analysys/stat-analysys.ts
+++ b/packages/gravity/kube-testing/src/analysys/stat-analysys.ts
@@ -278,8 +278,8 @@ export const getReader = (results: PlanResults) => {
   const start = Date.now();
   const reader = new LogReader();
 
-  for (const { logFile } of Object.values(results.agents)) {
-    reader.addFile(logFile);
+  for (const [agentId, { logFile }] of Object.entries(results.agents)) {
+    reader.addFile(logFile, { preprocessor: (line) => ({ ...line, context: { ...line?.context, agentId } }) });
   }
 
   log.info(`LogReader: ${Date.now() - start}ms`);

--- a/packages/gravity/kube-testing/tsconfig.json
+++ b/packages/gravity/kube-testing/tsconfig.json
@@ -17,9 +17,6 @@
   "include": [
     "src"
   ],
-  "ts-node": {
-    "swc": true
-  },
   "references": [
     {
       "path": "../../common/async"
@@ -29,6 +26,9 @@
     },
     {
       "path": "../../common/debug"
+    },
+    {
+      "path": "../../common/invariant"
     },
     {
       "path": "../../common/keys"
@@ -69,5 +69,8 @@
     {
       "path": "../../sdk/client-services"
     }
-  ]
+  ],
+  "ts-node": {
+    "swc": true
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5007,6 +5007,7 @@ importers:
       '@dxos/context': workspace:*
       '@dxos/debug': workspace:*
       '@dxos/echo-pipeline': workspace:*
+      '@dxos/invariant': workspace:*
       '@dxos/keys': workspace:*
       '@dxos/log': workspace:*
       '@dxos/messaging': workspace:*
@@ -5034,6 +5035,7 @@ importers:
       '@dxos/context': link:../../common/context
       '@dxos/debug': link:../../common/debug
       '@dxos/echo-pipeline': link:../../core/echo/echo-pipeline
+      '@dxos/invariant': link:../../common/invariant
       '@dxos/keys': link:../../common/keys
       '@dxos/log': link:../../common/log
       '@dxos/messaging': link:../../core/mesh/messaging


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f73c82f</samp>

### Summary
📊🐛♻️

<!--
1.  📊 - This emoji represents the feature enhancement of the log analysis module, which allows for more rich and informative log data. The emoji suggests data analysis, statistics, and charts.
2.  🐛 - This emoji represents the addition of trace logs to the `Connection` and `Peer` classes, which improve the debugging of the mesh network connections. The emoji suggests bugs, errors, and troubleshooting.
3.  ♻️ - This emoji represents the refactoring and enhancement of the `LogReader` class, which implements the `Iterable` interface and uses the `Generator` function. The emoji suggests recycling, optimization, and improvement.
-->
This pull request adds trace logs to the `Connection` and `Peer` classes of the mesh network manager module, and improves the log analysis module of the kube-testing package. The changes aim to enhance the debugging and monitoring of the mesh network connectivity and performance.

> _We are the agents of the mesh network_
> _We trace the connections of doom_
> _We parse the logs with the `LogReader`_
> _We reduce the data to the truth_

### Walkthrough
*  Add trace logs to `Connection` and `Peer` classes to improve debugging of mesh network connectivity and topology ([link](https://github.com/dxos/dxos/pull/3894/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745L95-R103), [link](https://github.com/dxos/dxos/pull/3894/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745R123-R129), [link](https://github.com/dxos/dxos/pull/3894/files?diff=unified&w=0#diff-47bc81126b7b4f9732f7ae901368cd7eeada3d95eb37e7e693e1a1b3388be355R230-R236), [link](https://github.com/dxos/dxos/pull/3894/files?diff=unified&w=0#diff-47bc81126b7b4f9732f7ae901368cd7eeada3d95eb37e7e693e1a1b3388be355R244-R251), [link](https://github.com/dxos/dxos/pull/3894/files?diff=unified&w=0#diff-47bc81126b7b4f9732f7ae901368cd7eeada3d95eb37e7e693e1a1b3388be355R279-R286))
*  Refactor `LogReader` class to use `Iterable` and `Generator` instead of `AsyncIterable` and `AsyncGenerator` for simpler and faster log reading and parsing ([link](https://github.com/dxos/dxos/pull/3894/files?diff=unified&w=0#diff-29a798a1c4f54ad8a76ac955f4584fada266863fd5e58cd923fb742210e00b13L62-R62), [link](https://github.com/dxos/dxos/pull/3894/files?diff=unified&w=0#diff-29a798a1c4f54ad8a76ac955f4584fada266863fd5e58cd923fb742210e00b13L82-R82))
*  Add `reduce` method to `LogReader` class to enable more complex and flexible log processing and aggregation ([link](https://github.com/dxos/dxos/pull/3894/files?diff=unified&w=0#diff-29a798a1c4f54ad8a76ac955f4584fada266863fd5e58cd923fb742210e00b13R94-R97))
*  Add optional `preprocessor` parameter to `addFile` method of `LogReader` class to allow modifying log entries before parsing and storing ([link](https://github.com/dxos/dxos/pull/3894/files?diff=unified&w=0#diff-e1100f4b507f7e68d0f7a70f69cccbe93311d1a134f4905ae36a0db4ece8a350L281-R282))
*  Use `preprocessor` parameter to add agent ID to log entry context in `getReader` function ([link](https://github.com/dxos/dxos/pull/3894/files?diff=unified&w=0#diff-e1100f4b507f7e68d0f7a70f69cccbe93311d1a134f4905ae36a0db4ece8a350L281-R282))


