### PR TITLE
feat(plugins): Main area increment

### DIFF
--- a/packages/apps/labs-app/vite.config.ts
+++ b/packages/apps/labs-app/vite.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
         resolve(__dirname, './node_modules/@braneframe/plugin-drawing/dist/lib/**/*.mjs'),
         resolve(__dirname, './node_modules/@braneframe/plugin-kanban/dist/lib/**/*.mjs'),
         resolve(__dirname, './node_modules/@braneframe/plugin-markdown/dist/lib/**/*.mjs'),
+        resolve(__dirname, './node_modules/@braneframe/plugin-space/dist/lib/**/*.mjs'),
         resolve(__dirname, './node_modules/@braneframe/plugin-splitview/dist/lib/**/*.mjs'),
         resolve(__dirname, './node_modules/@braneframe/plugin-template/dist/lib/**/*.mjs'),
         resolve(__dirname, './node_modules/@braneframe/plugin-theme/dist/lib/**/*.mjs'),

--- a/packages/apps/plugins/plugin-chess/src/components/ChessMain.tsx
+++ b/packages/apps/plugins/plugin-chess/src/components/ChessMain.tsx
@@ -37,9 +37,7 @@ export const ChessMain = ({ data: object }: { data: Game }) => {
   }
 
   return (
-    <Main.Content
-      classNames={['flex flex-col grow min-bs-[calc(100dvh-2.5rem)] overflow-hidden', coarseBlockPaddingStart]}
-    >
+    <Main.Content classNames={['flex flex-col min-bs-[calc(100dvh-2.5rem)] overflow-hidden', coarseBlockPaddingStart]}>
       <div className='flex grow justify-center items-center md:m-8'>
         <div className='flex md:min-w-[600px] md:min-h-[600px]'>
           <Chessboard model={model} onUpdate={handleUpdate} />

--- a/packages/apps/plugins/plugin-chess/src/components/ChessMain.tsx
+++ b/packages/apps/plugins/plugin-chess/src/components/ChessMain.tsx
@@ -6,7 +6,7 @@ import { Chess } from 'chess.js';
 import React, { useEffect, useState } from 'react';
 
 import { Main } from '@dxos/aurora';
-import { baseSurface, mx } from '@dxos/aurora-theme';
+import { coarseBlockPaddingStart } from '@dxos/aurora-theme';
 import { Chessboard, ChessModel, ChessMove, Game } from '@dxos/chess-app';
 import { invariant } from '@dxos/invariant';
 
@@ -37,7 +37,9 @@ export const ChessMain = ({ data: object }: { data: Game }) => {
   }
 
   return (
-    <Main.Content classNames={mx('flex flex-col grow min-bs-[100vh] overflow-hidden', baseSurface)}>
+    <Main.Content
+      classNames={['flex flex-col grow min-bs-[calc(100dvh-2.5rem)] overflow-hidden', coarseBlockPaddingStart]}
+    >
       <div className='flex grow justify-center items-center md:m-8'>
         <div className='flex md:min-w-[600px] md:min-h-[600px]'>
           <Chessboard model={model} onUpdate={handleUpdate} />

--- a/packages/apps/plugins/plugin-debug/src/components/DebugMain.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DebugMain.tsx
@@ -12,7 +12,7 @@ import styleDark from 'react-syntax-highlighter/dist/esm/styles/hljs/a11y-dark';
 import styleLight from 'react-syntax-highlighter/dist/esm/styles/hljs/a11y-light';
 
 import { Button, DensityProvider, Input, Main, useThemeContext, useTranslation } from '@dxos/aurora';
-import { fixedFullLayout, getSize } from '@dxos/aurora-theme';
+import { coarseBlockPaddingStart, fixedInsetFlexLayout, getSize } from '@dxos/aurora-theme';
 import { Space } from '@dxos/client/echo';
 import { useClient, useConfig } from '@dxos/react-client';
 import { arrayToBuffer } from '@dxos/util';
@@ -83,7 +83,7 @@ export const DebugMain: FC<{ data: { space: Space } }> = ({ data: { space } }) =
   };
 
   return (
-    <Main.Content classNames={fixedFullLayout}>
+    <Main.Content classNames={[fixedInsetFlexLayout, coarseBlockPaddingStart]}>
       <div className='flex shrink-0 p-2 space-x-2'>
         <DensityProvider density='fine'>
           <Button onClick={handleCreateObject}>Create</Button>

--- a/packages/apps/plugins/plugin-debug/src/components/DebugMain.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DebugMain.tsx
@@ -12,7 +12,7 @@ import styleDark from 'react-syntax-highlighter/dist/esm/styles/hljs/a11y-dark';
 import styleLight from 'react-syntax-highlighter/dist/esm/styles/hljs/a11y-light';
 
 import { Button, DensityProvider, Input, Main, useThemeContext, useTranslation } from '@dxos/aurora';
-import { baseSurface, fixedFullLayout, getSize } from '@dxos/aurora-theme';
+import { fixedFullLayout, getSize } from '@dxos/aurora-theme';
 import { Space } from '@dxos/client/echo';
 import { useClient, useConfig } from '@dxos/react-client';
 import { arrayToBuffer } from '@dxos/util';
@@ -83,7 +83,7 @@ export const DebugMain: FC<{ data: { space: Space } }> = ({ data: { space } }) =
   };
 
   return (
-    <Main.Content classNames={[fixedFullLayout, baseSurface]}>
+    <Main.Content classNames={fixedFullLayout}>
       <div className='flex shrink-0 p-2 space-x-2'>
         <DensityProvider density='fine'>
           <Button onClick={handleCreateObject}>Create</Button>

--- a/packages/apps/plugins/plugin-drawing/src/components/DrawingMain.tsx
+++ b/packages/apps/plugins/plugin-drawing/src/components/DrawingMain.tsx
@@ -9,7 +9,7 @@ import { useResizeDetector } from 'react-resize-detector';
 import { Drawing as DrawingType } from '@braneframe/types';
 import { debounce } from '@dxos/async';
 import { Main, useThemeContext } from '@dxos/aurora';
-import { fixedFullLayout, mx } from '@dxos/aurora-theme';
+import { coarseBlockPaddingStart, fixedInsetFlexLayout, mx } from '@dxos/aurora-theme';
 
 import '@tldraw/tldraw/tldraw.css';
 
@@ -45,7 +45,7 @@ export const DrawingMain: FC<DrawingMainParams> = ({ data: drawing }) => {
   // TODO(burdon): Customize by using hooks directly: https://tldraw.dev/docs/editor
   // TODO(burdon): Customize assets: https://tldraw.dev/docs/assets
   return (
-    <Main.Content classNames={fixedFullLayout}>
+    <Main.Content classNames={[fixedInsetFlexLayout, coarseBlockPaddingStart]}>
       <div
         className={mx(
           'h-full',

--- a/packages/apps/plugins/plugin-github/src/components/EmbeddedMain/EmbeddedMain.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/EmbeddedMain/EmbeddedMain.tsx
@@ -233,7 +233,7 @@ const EmbeddedLayoutImpl = () => {
         </div>
         {space && document ? (
           editorViewState === 'preview' ? (
-            <Main.Content classNames='min-bs-[100vh] flex flex-col p-0.5'>
+            <Main.Content classNames='min-bs-[100dvh] flex flex-col p-0.5'>
               <GfmPreview
                 markdown={document.content?.toString() ?? ''}
                 {...(docGhId && { owner: docGhId.owner, repo: docGhId.repo })}

--- a/packages/apps/plugins/plugin-grid/src/components/GridMain.tsx
+++ b/packages/apps/plugins/plugin-grid/src/components/GridMain.tsx
@@ -6,7 +6,7 @@ import React, { FC } from 'react';
 
 import { SpacePluginProvides } from '@braneframe/plugin-space';
 import { Main } from '@dxos/aurora';
-import { baseSurface, mx } from '@dxos/aurora-theme';
+import { coarseBlockPaddingStart } from '@dxos/aurora-theme';
 import { PublicKey } from '@dxos/client';
 import { TypedObject } from '@dxos/client/echo';
 import { findPlugin, usePluginContext } from '@dxos/react-surface';
@@ -19,7 +19,9 @@ export const GridMain: FC<{ data: TypedObject }> = ({ data: object }) => {
   const space = spacePlugin?.provides?.space.current;
 
   return (
-    <Main.Content classNames={mx('flex flex-col grow min-bs-[100vh] overflow-hidden', baseSurface)}>
+    <Main.Content
+      classNames={['flex flex-col grow min-bs-[calc(100dvh-2.5rem)] overflow-hidden', coarseBlockPaddingStart]}
+    >
       <pre className='m-4 p-2 ring'>
         <span>{space?.key.truncate()}</span>/<span>{PublicKey.from(object.id).truncate()}</span>
       </pre>

--- a/packages/apps/plugins/plugin-grid/src/components/GridMain.tsx
+++ b/packages/apps/plugins/plugin-grid/src/components/GridMain.tsx
@@ -19,9 +19,7 @@ export const GridMain: FC<{ data: TypedObject }> = ({ data: object }) => {
   const space = spacePlugin?.provides?.space.current;
 
   return (
-    <Main.Content
-      classNames={['flex flex-col grow min-bs-[calc(100dvh-2.5rem)] overflow-hidden', coarseBlockPaddingStart]}
-    >
+    <Main.Content classNames={['flex flex-col min-bs-[calc(100dvh-2.5rem)] overflow-hidden', coarseBlockPaddingStart]}>
       <pre className='m-4 p-2 ring'>
         <span>{space?.key.truncate()}</span>/<span>{PublicKey.from(object.id).truncate()}</span>
       </pre>

--- a/packages/apps/plugins/plugin-ipfs/src/components/FileMain.tsx
+++ b/packages/apps/plugins/plugin-ipfs/src/components/FileMain.tsx
@@ -6,7 +6,7 @@ import React, { FC, useState } from 'react';
 import urlJoin from 'url-join';
 
 import { Main } from '@dxos/aurora';
-import { baseSurface, mx } from '@dxos/aurora-theme';
+import { coarseBlockPaddingStart } from '@dxos/aurora-theme';
 import { TypedObject } from '@dxos/client/echo';
 import { Config, useConfig } from '@dxos/react-client';
 
@@ -27,7 +27,7 @@ export const FileMain: FC<{ data: TypedObject }> = ({ data: file }) => {
   const url = getIpfsUrl(config, file.cid);
 
   return (
-    <Main.Content classNames={mx('flex flex-col h-screen overflow-hidden', baseSurface)}>
+    <Main.Content classNames={['flex flex-col min-bs-[calc(100dvh-2.5rem)] overflow-hidden', coarseBlockPaddingStart]}>
       <FilePreview type={file.type} url={url} />
     </Main.Content>
   );

--- a/packages/apps/plugins/plugin-kanban/src/components/KanbanItem.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/components/KanbanItem.tsx
@@ -10,7 +10,7 @@ import React, { FC } from 'react';
 import type { Kanban as KanbanType } from '@braneframe/types';
 import { Button, useTranslation } from '@dxos/aurora';
 import { MarkdownComposer, useTextModel } from '@dxos/aurora-composer';
-import { getSize, mx, paperSurface } from '@dxos/aurora-theme';
+import { getSize, mx, inputSurface } from '@dxos/aurora-theme';
 
 import { KANBAN_PLUGIN } from '../types';
 
@@ -44,7 +44,7 @@ export const KanbanItemComponent: FC<{
       style={{ transform: CSS.Transform.toString(tx), transition }}
       className={mx('flex grow', isDragging && 'border border-neutral-300 dark:border-neutral-800 border-dashed')}
     >
-      <div className={mx('flex items-start grow p-1', paperSurface, isDragging && 'opacity-10')}>
+      <div className={mx('flex items-start grow p-1', inputSurface, isDragging && 'opacity-10')}>
         {/* TODO(burdon): Standardize height (and below); e.g., via toolbar. */}
         <button className='flex h-[40px] items-center' {...attributes} {...listeners}>
           <DotsSixVertical className={getSize(5)} />

--- a/packages/apps/plugins/plugin-kanban/src/components/KanbanMain.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/components/KanbanMain.tsx
@@ -7,7 +7,7 @@ import React, { FC } from 'react';
 import { SpacePluginProvides } from '@braneframe/plugin-space';
 import { Kanban as KanbanType } from '@braneframe/types';
 import { Input, Main, useTranslation } from '@dxos/aurora';
-import { baseSurface, blockSeparator, fixedFullLayout, mx } from '@dxos/aurora-theme';
+import { blockSeparator, fixedFullLayout, mx } from '@dxos/aurora-theme';
 import { findPlugin, usePluginContext } from '@dxos/react-surface';
 
 import { KANBAN_PLUGIN, type KanbanModel } from '../types';
@@ -39,7 +39,7 @@ export const KanbanMain: FC<{ data: KanbanType }> = ({ data: object }) => {
   };
 
   return (
-    <Main.Content classNames={[fixedFullLayout, baseSurface]}>
+    <Main.Content classNames={fixedFullLayout}>
       <div>
         <Input.Root>
           <Input.Label srOnly>{t('kanban title label')}</Input.Label>

--- a/packages/apps/plugins/plugin-kanban/src/components/KanbanMain.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/components/KanbanMain.tsx
@@ -7,7 +7,7 @@ import React, { FC } from 'react';
 import { SpacePluginProvides } from '@braneframe/plugin-space';
 import { Kanban as KanbanType } from '@braneframe/types';
 import { Input, Main, useTranslation } from '@dxos/aurora';
-import { blockSeparator, fixedFullLayout, mx } from '@dxos/aurora-theme';
+import { blockSeparator, coarseBlockPaddingStart, fixedInsetFlexLayout, mx } from '@dxos/aurora-theme';
 import { findPlugin, usePluginContext } from '@dxos/react-surface';
 
 import { KANBAN_PLUGIN, type KanbanModel } from '../types';
@@ -39,7 +39,7 @@ export const KanbanMain: FC<{ data: KanbanType }> = ({ data: object }) => {
   };
 
   return (
-    <Main.Content classNames={fixedFullLayout}>
+    <Main.Content classNames={[fixedInsetFlexLayout, coarseBlockPaddingStart]}>
       <div>
         <Input.Root>
           <Input.Label srOnly>{t('kanban title label')}</Input.Label>

--- a/packages/apps/plugins/plugin-markdown/package.json
+++ b/packages/apps/plugins/plugin-markdown/package.json
@@ -22,6 +22,7 @@
     "@dxos/aurora-composer": "workspace:*",
     "@dxos/react-client": "workspace:*",
     "@dxos/text-model": "workspace:*",
+    "@preact/signals-react": "^1.3.3",
     "deepsignal": "^1.3.3",
     "lodash.get": "^4.4.2"
   },

--- a/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
@@ -4,10 +4,11 @@
 
 import React, { HTMLAttributes, RefCallback } from 'react';
 
+import { useTranslation } from '@dxos/aurora';
 import { ComposerModel, MarkdownComposer, MarkdownComposerProps, MarkdownComposerRef } from '@dxos/aurora-composer';
 import { focusRing, mx } from '@dxos/aurora-theme';
 
-import { MarkdownProperties } from '../types';
+import { MARKDOWN_PLUGIN, MarkdownProperties } from '../types';
 import { EmbeddedLayout } from './EmbeddedLayout';
 import { StandaloneLayout } from './StandaloneLayout';
 
@@ -25,6 +26,7 @@ export const EditorMain = ({
   onChange?: MarkdownComposerProps['onChange'];
   editorRefCb: RefCallback<MarkdownComposerRef>;
 }) => {
+  const { t } = useTranslation(MARKDOWN_PLUGIN);
   const Root = layout === 'embedded' ? EmbeddedLayout : StandaloneLayout;
 
   return (
@@ -50,6 +52,7 @@ export const EditorMain = ({
               '& .cm-content': { flex: '1 0 auto', inlineSize: '100%', paddingBlock: '1rem' },
               '& .cm-line': { paddingInline: '1.5rem' },
             },
+            placeholder: t('editor placeholder'),
           },
         }}
       />

--- a/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
@@ -50,7 +50,7 @@ export const EditorMain = ({
                 inlineSize: '100%',
               },
               '& .cm-content': { flex: '1 0 auto', inlineSize: '100%', paddingBlock: '1rem' },
-              '& .cm-line': { paddingInline: '1.5rem' },
+              '& .cm-line': { paddingInline: '1rem' },
             },
             placeholder: t('editor placeholder'),
           },

--- a/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { HTMLAttributes, useRef } from 'react';
+import React, { HTMLAttributes, RefCallback } from 'react';
 
 import { ComposerModel, MarkdownComposer, MarkdownComposerProps, MarkdownComposerRef } from '@dxos/aurora-composer';
 import { focusRing, mx } from '@dxos/aurora-theme';
@@ -17,19 +17,20 @@ export const EditorMain = ({
   properties,
   layout,
   onChange,
+  editorRefCb,
 }: {
   model: ComposerModel;
   properties: MarkdownProperties;
   layout: 'standalone' | 'embedded';
   onChange?: MarkdownComposerProps['onChange'];
+  editorRefCb: RefCallback<MarkdownComposerRef>;
 }) => {
-  const editorRef = useRef<MarkdownComposerRef>(null);
   const Root = layout === 'embedded' ? EmbeddedLayout : StandaloneLayout;
 
   return (
-    <Root properties={properties} model={model} editorRef={editorRef}>
+    <Root properties={properties} model={model}>
       <MarkdownComposer
-        ref={editorRef}
+        ref={editorRefCb}
         model={model}
         onChange={onChange}
         slots={{

--- a/packages/apps/plugins/plugin-markdown/src/components/EditorMainEmbedded.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/EditorMainEmbedded.tsx
@@ -15,5 +15,5 @@ export const EditorMainEmbedded = ({
   data: { composer: ComposerModel; properties: MarkdownProperties; view: 'embedded' };
   role?: string;
 }) => {
-  return <EditorMain model={composer} properties={properties} layout='embedded' />;
+  return <EditorMain model={composer} properties={properties} layout='embedded' editorRefCb={() => {}} />;
 };

--- a/packages/apps/plugins/plugin-markdown/src/components/EmbeddedLayout.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/EmbeddedLayout.tsx
@@ -5,7 +5,12 @@
 import React, { PropsWithChildren } from 'react';
 
 import { Main } from '@dxos/aurora';
+import { coarseBlockPaddingStart } from '@dxos/aurora-theme';
 
 export const EmbeddedLayout = ({ children }: PropsWithChildren<{}>) => {
-  return <Main.Content classNames='min-bs-[100dvh] flex flex-col p-0.5'>{children}</Main.Content>;
+  return (
+    <Main.Content classNames={['min-bs-[100dvh] flex flex-col p-0.5', coarseBlockPaddingStart]}>
+      {children}
+    </Main.Content>
+  );
 };

--- a/packages/apps/plugins/plugin-markdown/src/components/EmbeddedLayout.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/EmbeddedLayout.tsx
@@ -5,12 +5,7 @@
 import React, { PropsWithChildren } from 'react';
 
 import { Main } from '@dxos/aurora';
-import { coarseBlockPaddingStart } from '@dxos/aurora-theme';
 
 export const EmbeddedLayout = ({ children }: PropsWithChildren<{}>) => {
-  return (
-    <Main.Content classNames={['min-bs-[100dvh] flex flex-col p-0.5', coarseBlockPaddingStart]}>
-      {children}
-    </Main.Content>
-  );
+  return <Main.Content classNames='min-bs-[100dvh] flex flex-col p-0.5'>{children}</Main.Content>;
 };

--- a/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
@@ -6,6 +6,7 @@ import React, { MutableRefObject, PropsWithChildren } from 'react';
 
 import { Main } from '@dxos/aurora';
 import { ComposerModel, MarkdownComposerRef } from '@dxos/aurora-composer';
+import { coarseBlockPaddingStart } from '@dxos/aurora-theme';
 
 import { MarkdownProperties } from '../types';
 
@@ -18,7 +19,7 @@ export const StandaloneLayout = ({
   editorRef?: MutableRefObject<MarkdownComposerRef>;
 }>) => {
   return (
-    <Main.Content bounce>
+    <Main.Content bounce classNames={coarseBlockPaddingStart}>
       <div role='none' className='mli-auto max-is-[60rem] min-bs-[calc(100dvh-2.5rem)] flex flex-col'>
         {children}
       </div>

--- a/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
@@ -6,7 +6,6 @@ import React, { MutableRefObject, PropsWithChildren } from 'react';
 
 import { Main } from '@dxos/aurora';
 import { ComposerModel, MarkdownComposerRef } from '@dxos/aurora-composer';
-import { coarseBlockPaddingStart } from '@dxos/aurora-theme';
 
 import { MarkdownProperties } from '../types';
 
@@ -19,7 +18,7 @@ export const StandaloneLayout = ({
   editorRef?: MutableRefObject<MarkdownComposerRef>;
 }>) => {
   return (
-    <Main.Content classNames={['min-bs-[calc(100dvh-2.5rem)]', coarseBlockPaddingStart]} bounce>
+    <Main.Content bounce>
       <div role='none' className='mli-auto max-is-[60rem] min-bs-[calc(100dvh-2.5rem)] flex flex-col'>
         {children}
       </div>

--- a/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
@@ -2,87 +2,27 @@
 // Copyright 2023 DXOS.org
 //
 
-import { DotsThreeVertical } from '@phosphor-icons/react';
-import React, { PropsWithChildren, RefObject } from 'react';
+import React, { MutableRefObject, PropsWithChildren } from 'react';
 
-import { Button, DropdownMenu, Main, Input, useTranslation } from '@dxos/aurora';
+import { Main } from '@dxos/aurora';
 import { ComposerModel, MarkdownComposerRef } from '@dxos/aurora-composer';
-import { blockSeparator, getSize, mx, paperSurface } from '@dxos/aurora-theme';
-import { Surface } from '@dxos/react-surface';
+import { coarseBlockPaddingStart } from '@dxos/aurora-theme';
 
-import { MARKDOWN_PLUGIN, MarkdownProperties } from '../types';
+import { MarkdownProperties } from '../types';
 
 export const StandaloneLayout = ({
   children,
-  model,
-  properties,
-  editorRef,
 }: PropsWithChildren<{
   model: ComposerModel;
   properties: MarkdownProperties;
   // TODO(wittjosiah): ForwardRef.
-  editorRef?: RefObject<MarkdownComposerRef>;
+  editorRef?: MutableRefObject<MarkdownComposerRef>;
 }>) => {
-  const { t } = useTranslation(MARKDOWN_PLUGIN);
   return (
-    <Main.Content classNames='min-bs-full' bounce>
-      <div role='none' className={mx('mli-auto max-is-[60rem] min-bs-[100dvh] flex flex-col', paperSurface)}>
-        <div role='none' className='flex items-center gap-2 pis-0 pointer-fine:pis-8 lg:pis-0 pointer-fine:lg:pis-0'>
-          <Input.Root id={`input--${model.id}`}>
-            <Input.Label srOnly>{t('document title label')}</Input.Label>
-            <Input.TextInput
-              variant='subdued'
-              disabled={properties.readOnly}
-              placeholder={t('document title placeholder')}
-              value={properties.title ?? ''}
-              onChange={({ target: { value } }) => (properties.title = value)}
-              classNames='flex-1 min-is-0 is-auto pis-4 plb-3.5 pointer-fine:plb-2.5'
-              data-testid='composer.documentTitle'
-            />
-          </Input.Root>
-          {!properties.readOnly && (
-            <DropdownMenu.Root modal={false}>
-              <DropdownMenu.Trigger asChild>
-                <Button classNames='p-0 is-10 shrink-0 mie-3' variant='ghost' density='coarse'>
-                  <DotsThreeVertical className={getSize(6)} />
-                </Button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content sideOffset={10} classNames='z-10'>
-                  <Surface data={[model, properties, editorRef]} role='menuitem' />
-                  <DropdownMenu.Arrow />
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Root>
-          )}
-        </div>
-        <div role='separator' className={mx(blockSeparator, 'mli-4 opacity-50')} />
+    <Main.Content classNames={['min-bs-[calc(100dvh-2.5rem)]', coarseBlockPaddingStart]} bounce>
+      <div role='none' className='mli-auto max-is-[60rem] min-bs-[calc(100dvh-2.5rem)] flex flex-col'>
         {children}
       </div>
-      {/* <ThemeContext.Provider value={{ ...themeContext, tx: osTx }}> */}
-      {/*  {handleFileImport && ( */}
-      {/*    <Dialog */}
-      {/*      open={fileImportDialogOpen} */}
-      {/*      onOpenChange={setFileImportDialogOpen} */}
-      {/*      title={t('confirm import title')} */}
-      {/*      slots={{ overlay: { classNames: 'backdrop-blur-sm' } }} */}
-      {/*    > */}
-      {/*      <p className='mlb-4'>{t('confirm import body')}</p> */}
-      {/*      <FileUploader */}
-      {/*        types={['md']} */}
-      {/*        classes='block mlb-4 p-8 border-2 border-dashed border-neutral-500/50 rounded flex items-center justify-center gap-2 cursor-pointer' */}
-      {/*        dropMessageStyle={{ border: 'none', backgroundColor: '#EEE' }} */}
-      {/*        handleChange={handleFileImport} */}
-      {/*      > */}
-      {/*        <FilePlus weight='duotone' className={getSize(8)} /> */}
-      {/*        <span>{t('upload file message')}</span> */}
-      {/*      </FileUploader> */}
-      {/*      <Button classNames='block is-full' onClick={() => setFileImportDialogOpen?.(false)}> */}
-      {/*        {t('cancel label', { ns: 'appkit' })} */}
-      {/*      </Button> */}
-      {/*    </Dialog> */}
-      {/*  )} */}
-      {/* </ThemeContext.Provider> */}
     </Main.Content>
   );
 };

--- a/packages/apps/plugins/plugin-markdown/src/components/StandaloneMenu.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/StandaloneMenu.tsx
@@ -1,0 +1,40 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { DotsSixVertical } from '@phosphor-icons/react';
+import React, { PropsWithChildren, RefObject } from 'react';
+
+import { Button, DropdownMenu } from '@dxos/aurora';
+import { ComposerModel, MarkdownComposerRef } from '@dxos/aurora-composer';
+import { getSize } from '@dxos/aurora-theme';
+import { Surface } from '@dxos/react-surface';
+
+import { MarkdownProperties } from '../types';
+
+export const StandaloneMenu = ({
+  model,
+  properties,
+  editorRef,
+}: PropsWithChildren<{
+  model: ComposerModel;
+  properties: MarkdownProperties;
+  // TODO(wittjosiah): ForwardRef.
+  editorRef?: RefObject<MarkdownComposerRef>;
+}>) => {
+  return (
+    <DropdownMenu.Root modal={false}>
+      <DropdownMenu.Trigger asChild>
+        <Button variant='ghost'>
+          <DotsSixVertical className={getSize(4)} />
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content sideOffset={10} classNames='z-10'>
+          <Surface data={[model, properties, editorRef]} role='menuitem' />
+          <DropdownMenu.Arrow />
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+};

--- a/packages/apps/plugins/plugin-markdown/src/translations.ts
+++ b/packages/apps/plugins/plugin-markdown/src/translations.ts
@@ -18,6 +18,7 @@ export default [
         'chooser done label': 'Add selected',
         'create document label': 'Create document',
         'delete document label': 'Delete',
+        'editor placeholder': 'Start typing here…',
       },
     },
   },

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -19,7 +19,15 @@ import { Space, SpaceProxy } from '@dxos/react-client/echo';
 import { PluginDefinition, findPlugin } from '@dxos/react-surface';
 
 import { backupSpace } from './backup';
-import { DialogRenameSpace, DialogRestoreSpace, EmptySpace, EmptyTree, SpaceMain, SpaceMainEmpty } from './components';
+import {
+  DialogRenameSpace,
+  DialogRestoreSpace,
+  EmptySpace,
+  EmptyTree,
+  SpaceMain,
+  SpaceMainEmpty,
+  SpacePresence,
+} from './components';
 import translations from './translations';
 import { SPACE_PLUGIN, SPACE_PLUGIN_SHORT_ID, SpaceAction, SpacePluginProvides, SpaceState } from './types';
 import { getSpaceId, isSpace, spaceToGraphNode } from './util';
@@ -126,6 +134,8 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
             } else {
               return null;
             }
+          case 'presence':
+            return SpacePresence;
           default:
             return null;
         }

--- a/packages/apps/plugins/plugin-space/src/components/SpacePresence.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/SpacePresence.tsx
@@ -1,0 +1,34 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React from 'react';
+
+import { Avatar, AvatarGroup, AvatarGroupItem, Tooltip, useJdenticonHref, useTranslation } from '@dxos/aurora';
+import { useIdentity } from '@dxos/react-client/halo';
+
+import { SPACE_PLUGIN } from '../types';
+
+export const SpacePresence = () => {
+  const identity = useIdentity();
+  const fallbackHref = useJdenticonHref(identity?.identityKey.toHex() ?? '', 4);
+  const { t } = useTranslation(SPACE_PLUGIN);
+  return identity ? (
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <AvatarGroup.Root size={4} classNames='mie-5'>
+          <AvatarGroup.Label classNames='text-xs'>1</AvatarGroup.Label>
+          <AvatarGroupItem.Root>
+            <Avatar.Frame>
+              <Avatar.Fallback href={fallbackHref} />
+            </Avatar.Frame>
+          </AvatarGroupItem.Root>
+        </AvatarGroup.Root>
+      </Tooltip.Trigger>
+      <Tooltip.Content collisionPadding={4}>
+        <span>{t('presence label')}</span>
+        <Tooltip.Arrow />
+      </Tooltip.Content>
+    </Tooltip.Root>
+  ) : null;
+};

--- a/packages/apps/plugins/plugin-space/src/components/index.ts
+++ b/packages/apps/plugins/plugin-space/src/components/index.ts
@@ -8,3 +8,4 @@ export * from './EmptySpace';
 export * from './EmptyTree';
 export * from './SpaceMain';
 export * from './SpaceMainEmpty';
+export * from './SpacePresence';

--- a/packages/apps/plugins/plugin-space/src/translations.ts
+++ b/packages/apps/plugins/plugin-space/src/translations.ts
@@ -24,6 +24,7 @@ export default [
         'confirm restore title': 'Overwrite files in this space?',
         'confirm restore body': 'Restoring from a backup will overwrite the contents of any documents that match.',
         'upload file message': 'Drag file here or click to browse',
+        'presence label': 'Members viewing this item',
       },
     },
   },

--- a/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
@@ -2,6 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
+import { ArrowLineLeft } from '@phosphor-icons/react';
 import { deepSignal } from 'deepsignal/react';
 import React, { PropsWithChildren } from 'react';
 
@@ -35,6 +36,24 @@ export const SplitViewPlugin = ({
         <SplitViewContext.Provider value={state}>{props.children}</SplitViewContext.Provider>
       ),
       components: { SplitView, SplitViewMainContentEmpty },
+      graph: {
+        nodes: (parent) => {
+          if (parent.id !== 'root') {
+            return;
+          }
+
+          parent.addAction({
+            id: 'close-sidebar',
+            label: ['close sidebar label', { ns: 'os' }],
+            icon: (props) => <ArrowLineLeft {...props} />,
+            intent: {
+              plugin: SPLITVIEW_PLUGIN,
+              action: SplitViewAction.TOGGLE_SIDEBAR,
+              data: { state: false },
+            },
+          });
+        },
+      },
       intent: {
         resolver: (intent) => {
           switch (intent.action) {

--- a/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
@@ -2,7 +2,6 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ArrowLineLeft } from '@phosphor-icons/react';
 import { deepSignal } from 'deepsignal/react';
 import React, { PropsWithChildren } from 'react';
 
@@ -36,24 +35,6 @@ export const SplitViewPlugin = ({
         <SplitViewContext.Provider value={state}>{props.children}</SplitViewContext.Provider>
       ),
       components: { SplitView, SplitViewMainContentEmpty },
-      graph: {
-        nodes: (parent) => {
-          if (parent.id !== 'root') {
-            return;
-          }
-
-          parent.addAction({
-            id: 'close-sidebar',
-            label: ['close sidebar label', { ns: 'os' }],
-            icon: (props) => <ArrowLineLeft {...props} />,
-            intent: {
-              plugin: SPLITVIEW_PLUGIN,
-              action: SplitViewAction.TOGGLE_SIDEBAR,
-              data: { state: false },
-            },
-          });
-        },
-      },
       intent: {
         resolver: (intent) => {
           switch (intent.action) {

--- a/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
@@ -14,7 +14,7 @@ import { SPLITVIEW_PLUGIN } from '../types';
 
 export const SplitView = () => {
   const context = useSplitView();
-  const { sidebarOpen, complementarySidebarOpen, dialogOpen, dialogContent } = context;
+  const { complementarySidebarOpen, dialogOpen, dialogContent } = context;
   const { t } = useTranslation(SPLITVIEW_PLUGIN);
 
   return (

--- a/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
@@ -2,11 +2,11 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Sidebar as SidebarIcon } from '@phosphor-icons/react';
+import { Chats, List as MenuIcon } from '@phosphor-icons/react';
 import React from 'react';
 
 import { Button, Main, Dialog, useTranslation, DensityProvider } from '@dxos/aurora';
-import { fineBlockSize, getSize, mx } from '@dxos/aurora-theme';
+import { coarseBlockSize, getSize } from '@dxos/aurora-theme';
 import { Surface } from '@dxos/react-surface';
 
 import { useSplitView } from '../SplitViewContext';
@@ -34,41 +34,33 @@ export const SplitView = () => {
           <Surface name='complementary-sidebar' />
         </Main.ComplementarySidebar>
       )}
-      <div
-        role='none'
-        className={mx(
-          'fixed z-[1] block-end-0 pointer-fine:block-end-auto pointer-fine:block-start-0 p-4 pointer-fine:p-1.5 transition-[inset-inline-start,opacity] ease-in-out duration-200 inline-start-0',
-          sidebarOpen && 'opacity-0 pointer-events-none',
-        )}
-      >
-        <Button
-          onClick={() => (context.sidebarOpen = !context.sidebarOpen)}
-          classNames={mx(fineBlockSize, 'aspect-square p-0 shadow-none')}
-        >
-          <SidebarIcon weight='light' className={getSize(5)} />
-        </Button>
-      </div>
-      {complementarySidebarOpen !== null && (
-        <div
-          role='none'
-          className={mx(
-            'fixed z-[1] block-end-0 pointer-fine:block-end-auto pointer-fine:block-start-0 p-4 pointer-fine:p-1.5 transition-[inset-inline-start,opacity] ease-in-out duration-200 inline-end-0',
-            complementarySidebarOpen && 'opacity-0 pointer-events-none',
-          )}
-        >
-          <Button
-            onClick={() => (context.complementarySidebarOpen = !context.complementarySidebarOpen)}
-            classNames={mx(fineBlockSize, 'aspect-square p-0 shadow-none')}
-          >
-            <SidebarIcon mirrored weight='light' className={getSize(5)} />
-          </Button>
-        </div>
-      )}
       <Main.Overlay />
-      <Main.Content asChild classNames='fixed inset-inline-0 block-start-0 z-[1] flex'>
+      <Main.Content
+        asChild
+        classNames={['fixed inset-inline-0 block-start-0 z-[1] flex gap-1 plb-1.5', coarseBlockSize]}
+      >
         <div role='none' aria-label={t('main header label')}>
-          <Surface name='heading' role='heading' limit={1} />
-          <Surface name='presence' role='heading' limit={1} />
+          <DensityProvider density='fine'>
+            <Button
+              onClick={() => (context.sidebarOpen = !context.sidebarOpen)}
+              variant='ghost'
+              classNames='mis-1 mie-2'
+            >
+              <span className='sr-only'>{t('open navigation sidebar label')}</span>
+              <MenuIcon weight='light' className={getSize(4)} />
+            </Button>
+            <Surface name='heading' role='heading' limit={2} />
+            <Surface name='presence' role='presence' limit={1} />
+            {complementarySidebarOpen !== null && (
+              <Button
+                onClick={() => (context.complementarySidebarOpen = !context.complementarySidebarOpen)}
+                variant='ghost'
+              >
+                <span className='sr-only'>{t('open complementary sidebar label')}</span>
+                <Chats weight='light' className={getSize(4)} />
+              </Button>
+            )}
+          </DensityProvider>
         </div>
       </Main.Content>
       <Surface name='main' role='main' />

--- a/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
@@ -46,6 +46,7 @@ export const SplitView = () => {
               <MenuIcon weight='light' className={getSize(4)} />
             </Button>
             <Surface name='heading' role='heading' limit={2} />
+            <div role='none' className='grow' />
             <Surface name='presence' role='presence' limit={1} />
             {complementarySidebarOpen !== null && (
               <Button

--- a/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
@@ -67,8 +67,8 @@ export const SplitView = () => {
       <Main.Overlay />
       <Main.Content asChild classNames='fixed inset-inline-0 block-start-0 z-[1] flex'>
         <div role='none' aria-label={t('main header label')}>
-          <Surface name='heading' limit={1} />
-          <Surface name='presence' limit={1} />
+          <Surface name='heading' role='heading' limit={1} />
+          <Surface name='presence' role='heading' limit={1} />
         </div>
       </Main.Content>
       <Surface name='main' role='main' />

--- a/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
@@ -41,11 +41,7 @@ export const SplitView = () => {
       >
         <div role='none' aria-label={t('main header label')}>
           <DensityProvider density='fine'>
-            <Button
-              onClick={() => (context.sidebarOpen = !context.sidebarOpen)}
-              variant='ghost'
-              classNames='mis-1 mie-2'
-            >
+            <Button onClick={() => (context.sidebarOpen = !context.sidebarOpen)} variant='ghost' classNames='mli-1'>
               <span className='sr-only'>{t('open navigation sidebar label')}</span>
               <MenuIcon weight='light' className={getSize(4)} />
             </Button>

--- a/packages/apps/plugins/plugin-splitview/src/translations.ts
+++ b/packages/apps/plugins/plugin-splitview/src/translations.ts
@@ -10,6 +10,8 @@ export default [
       [SPLITVIEW_PLUGIN]: {
         'first run message': 'Choose a document or create one to get started',
         'main header label': 'Main header',
+        'open navigation sidebar label': 'Open navigation sidebar',
+        'open complementary sidebar label': 'Open complementary sidebar',
       },
     },
   },

--- a/packages/apps/plugins/plugin-splitview/src/types.ts
+++ b/packages/apps/plugins/plugin-splitview/src/types.ts
@@ -4,6 +4,7 @@
 
 import type { DeepSignal } from 'deepsignal';
 
+import type { GraphProvides } from '@braneframe/plugin-graph';
 import type { IntentProvides } from '@braneframe/plugin-intent';
 import type { TranslationsProvides } from '@braneframe/plugin-theme';
 
@@ -21,7 +22,8 @@ export type SplitViewContextValue = DeepSignal<{
   dialogOpen: boolean;
 }>;
 
-export type SplitViewProvides = TranslationsProvides &
+export type SplitViewProvides = GraphProvides &
+  TranslationsProvides &
   IntentProvides & {
     splitView: SplitViewContextValue;
   };

--- a/packages/apps/plugins/plugin-splitview/src/types.ts
+++ b/packages/apps/plugins/plugin-splitview/src/types.ts
@@ -4,7 +4,6 @@
 
 import type { DeepSignal } from 'deepsignal';
 
-import type { GraphProvides } from '@braneframe/plugin-graph';
 import type { IntentProvides } from '@braneframe/plugin-intent';
 import type { TranslationsProvides } from '@braneframe/plugin-theme';
 
@@ -22,8 +21,7 @@ export type SplitViewContextValue = DeepSignal<{
   dialogOpen: boolean;
 }>;
 
-export type SplitViewProvides = GraphProvides &
-  TranslationsProvides &
+export type SplitViewProvides = TranslationsProvides &
   IntentProvides & {
     splitView: SplitViewContextValue;
   };

--- a/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
@@ -7,7 +7,7 @@ import React, { FC, useCallback } from 'react';
 
 import { useIntent } from '@braneframe/plugin-intent';
 import { Main, Button, useTranslation, DropdownMenu, ButtonGroup } from '@dxos/aurora';
-import { chromeSurface, getSize, coarseBlockPaddingStart, surfaceElevation } from '@dxos/aurora-theme';
+import { chromeSurface, getSize, surfaceElevation } from '@dxos/aurora-theme';
 
 import { stackState } from '../stores';
 import {
@@ -33,7 +33,7 @@ export const StackMain: FC<{ data: StackModel & StackProperties }> = ({ data: st
   );
 
   return (
-    <Main.Content classNames={['min-bs-[calc(100dvh-2.5rem)]', coarseBlockPaddingStart]} bounce>
+    <Main.Content bounce>
       <StackSectionsPanel sections={stack.sections} id={stack.id} onAdd={handleAdd} />
 
       <div role='none' className='flex gap-4 justify-center items-center pbe-4'>

--- a/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
@@ -7,7 +7,7 @@ import React, { FC, useCallback } from 'react';
 
 import { useIntent } from '@braneframe/plugin-intent';
 import { Main, Button, useTranslation, DropdownMenu, ButtonGroup } from '@dxos/aurora';
-import { chromeSurface, getSize, surfaceElevation } from '@dxos/aurora-theme';
+import { chromeSurface, coarseBlockPaddingStart, getSize, surfaceElevation } from '@dxos/aurora-theme';
 
 import { stackState } from '../stores';
 import {
@@ -33,7 +33,7 @@ export const StackMain: FC<{ data: StackModel & StackProperties }> = ({ data: st
   );
 
   return (
-    <Main.Content bounce>
+    <Main.Content bounce classNames={coarseBlockPaddingStart}>
       <StackSectionsPanel sections={stack.sections} id={stack.id} onAdd={handleAdd} />
 
       <div role='none' className='flex gap-4 justify-center items-center pbe-4'>

--- a/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
@@ -6,8 +6,8 @@ import { Plus, Placeholder } from '@phosphor-icons/react';
 import React, { FC, useCallback } from 'react';
 
 import { useIntent } from '@braneframe/plugin-intent';
-import { Main, Input, Button, useTranslation, DropdownMenu, ButtonGroup } from '@dxos/aurora';
-import { blockSeparator, chromeSurface, getSize, mx, surfaceElevation } from '@dxos/aurora-theme';
+import { Main, Button, useTranslation, DropdownMenu, ButtonGroup } from '@dxos/aurora';
+import { chromeSurface, getSize, coarseBlockPaddingStart, surfaceElevation } from '@dxos/aurora-theme';
 
 import { stackState } from '../stores';
 import {
@@ -33,54 +33,39 @@ export const StackMain: FC<{ data: StackModel & StackProperties }> = ({ data: st
   );
 
   return (
-    <Main.Content classNames='min-bs-[100vh]' bounce>
-      <div role='none' className='mli-auto max-is-[60rem]'>
-        {/* TODO(burdon): Factor out header. */}
-        <Input.Root>
-          <Input.Label srOnly>{t('stack title label')}</Input.Label>
-          <Input.TextInput
-            variant='subdued'
-            classNames='flex-1 min-is-0 is-auto pis-4 pointer-fine:pis-12 lg:pis-4 pointer-fine:lg:pis-4 plb-3.5 pointer-fine:plb-2.5'
-            placeholder={t('stack title placeholder')}
-            value={stack.title ?? ''}
-            onChange={({ target: { value } }) => (stack.title = value)}
-          />
-        </Input.Root>
-        <div role='separator' className={mx(blockSeparator, 'mli-4 opacity-50')} />
+    <Main.Content classNames={['min-bs-[calc(100dvh-2.5rem)]', coarseBlockPaddingStart]} bounce>
+      <StackSectionsPanel sections={stack.sections} id={stack.id} onAdd={handleAdd} />
 
-        <StackSectionsPanel sections={stack.sections} id={stack.id} onAdd={handleAdd} />
-
-        <div role='none' className='flex gap-4 justify-center items-center pbe-4'>
-          <ButtonGroup classNames={[surfaceElevation({ elevation: 'group' }), chromeSurface]}>
-            <DropdownMenu.Root modal={false}>
-              <DropdownMenu.Trigger asChild>
-                <Button variant='ghost'>
-                  <Plus className={getSize(5)} />
-                </Button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Content>
-                <DropdownMenu.Arrow />
-                {stackState.creators?.map(({ id, testId, intent, icon, label }) => {
-                  const Icon = icon ?? Placeholder;
-                  return (
-                    <DropdownMenu.Item
-                      key={id}
-                      id={id}
-                      data-testid={testId}
-                      onClick={async () => {
-                        const { object: nextSection } = await sendIntent(intent);
-                        handleAdd(nextSection, stack.sections.length);
-                      }}
-                    >
-                      <Icon className={getSize(4)} />
-                      <span>{typeof label === 'string' ? label : t(...(label as [string, { ns: string }]))}</span>
-                    </DropdownMenu.Item>
-                  );
-                })}
-              </DropdownMenu.Content>
-            </DropdownMenu.Root>
-          </ButtonGroup>
-        </div>
+      <div role='none' className='flex gap-4 justify-center items-center pbe-4'>
+        <ButtonGroup classNames={[surfaceElevation({ elevation: 'group' }), chromeSurface]}>
+          <DropdownMenu.Root modal={false}>
+            <DropdownMenu.Trigger asChild>
+              <Button variant='ghost'>
+                <Plus className={getSize(5)} />
+              </Button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+              <DropdownMenu.Arrow />
+              {stackState.creators?.map(({ id, testId, intent, icon, label }) => {
+                const Icon = icon ?? Placeholder;
+                return (
+                  <DropdownMenu.Item
+                    key={id}
+                    id={id}
+                    data-testid={testId}
+                    onClick={async () => {
+                      const { object: nextSection } = await sendIntent(intent);
+                      handleAdd(nextSection, stack.sections.length);
+                    }}
+                  >
+                    <Icon className={getSize(4)} />
+                    <span>{typeof label === 'string' ? label : t(...(label as [string, { ns: string }]))}</span>
+                  </DropdownMenu.Item>
+                );
+              })}
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+        </ButtonGroup>
       </div>
     </Main.Content>
   );

--- a/packages/apps/plugins/plugin-stack/src/components/StackSection.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackSection.tsx
@@ -10,7 +10,7 @@ import React, { FC, forwardRef } from 'react';
 
 import { SortableProps } from '@braneframe/plugin-dnd';
 import { List, ListItem, Button, useTranslation, DensityProvider, ListScopedProps } from '@dxos/aurora';
-import { fineButtonDimensions, focusRing, getSize, mx, paperSurface, surfaceElevation } from '@dxos/aurora-theme';
+import { fineButtonDimensions, focusRing, getSize, mx, inputSurface, surfaceElevation } from '@dxos/aurora-theme';
 import { Surface } from '@dxos/react-surface';
 
 import { STACK_PLUGIN, StackSectionModel } from '../types';
@@ -40,7 +40,7 @@ const StackSectionImpl = forwardRef<HTMLLIElement, ListScopedProps<StackSectionP
           id={section.object.id}
           classNames={[
             surfaceElevation({ elevation: 'group' }),
-            paperSurface,
+            inputSurface,
             'grow rounded mlb-2',
             '[--controls-opacity:1] hover-hover:[--controls-opacity:.1] hover-hover:hover:[--controls-opacity:1]',
             isOverlay && 'hover-hover:[--controls-opacity:1]',

--- a/packages/apps/plugins/plugin-template/src/components/TemplateMain.tsx
+++ b/packages/apps/plugins/plugin-template/src/components/TemplateMain.tsx
@@ -6,7 +6,7 @@ import React, { FC } from 'react';
 
 import { SpacePluginProvides } from '@braneframe/plugin-space';
 import { Main } from '@dxos/aurora';
-import { baseSurface, mx } from '@dxos/aurora-theme';
+import { coarseBlockPaddingStart } from '@dxos/aurora-theme';
 import { PublicKey } from '@dxos/client';
 import { TypedObject } from '@dxos/client/echo';
 import { findPlugin, usePluginContext } from '@dxos/react-surface';
@@ -18,7 +18,7 @@ export const TemplateMain: FC<{ data: TypedObject }> = ({ data: object }) => {
 
   return (
     // TODO(burdon): Boilerplate.
-    <Main.Content classNames={mx('flex flex-col grow min-bs-[100vh] overflow-hidden', baseSurface)}>
+    <Main.Content classNames={coarseBlockPaddingStart}>
       <pre className='m-4 p-2 ring'>
         <span>{space?.key.truncate()}</span>/<span>{PublicKey.from(object.id).truncate()}</span>
       </pre>

--- a/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
@@ -7,7 +7,7 @@ import React, { FC } from 'react';
 
 import { Thread as ThreadType } from '@braneframe/types';
 import { Main } from '@dxos/aurora';
-import { fixedFullLayout } from '@dxos/aurora-theme';
+import { coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/aurora-theme';
 import { PublicKey } from '@dxos/react-client';
 import { useIdentity } from '@dxos/react-client/halo';
 
@@ -57,7 +57,7 @@ export const ThreadMain: FC<{ data: ThreadType }> = ({ data: thread }) => {
   };
 
   return (
-    <Main.Content classNames={fixedFullLayout}>
+    <Main.Content classNames={[fixedInsetFlexLayout, coarseBlockPaddingStart]}>
       <ThreadChannel identityKey={identityKey} thread={thread} onAddMessage={handleAddMessage} />
     </Main.Content>
   );

--- a/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
@@ -7,7 +7,7 @@ import React, { FC } from 'react';
 
 import { Thread as ThreadType } from '@braneframe/types';
 import { Main } from '@dxos/aurora';
-import { baseSurface, fixedFullLayout } from '@dxos/aurora-theme';
+import { fixedFullLayout } from '@dxos/aurora-theme';
 import { PublicKey } from '@dxos/react-client';
 import { useIdentity } from '@dxos/react-client/halo';
 
@@ -57,7 +57,7 @@ export const ThreadMain: FC<{ data: ThreadType }> = ({ data: thread }) => {
   };
 
   return (
-    <Main.Content classNames={[fixedFullLayout, baseSurface]}>
+    <Main.Content classNames={fixedFullLayout}>
       <ThreadChannel identityKey={identityKey} thread={thread} onAddMessage={handleAddMessage} />
     </Main.Content>
   );

--- a/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
@@ -9,7 +9,7 @@ import { GraphPluginProvides } from '@braneframe/plugin-graph';
 import { Plugin, PluginDefinition, Surface, findPlugin, usePluginContext } from '@dxos/react-surface';
 
 import { TreeViewContext, useTreeView } from './TreeViewContext';
-import { Fallback, TreeViewContainer } from './components';
+import { Fallback, TreeItemHeading, TreeViewContainer } from './components';
 import { TreeItemDragOverlay } from './components/TreeItemDragOverlay';
 import translations from './translations';
 import { TREE_VIEW_PLUGIN, TreeViewAction, TreeViewContextValue, TreeViewPluginProvides } from './types';
@@ -55,6 +55,8 @@ export const TreeViewPlugin = (): PluginDefinition<TreeViewPluginProvides> => {
                 surfaces={{
                   sidebar: { component: 'dxos.org/plugin/treeview/TreeView' },
                   main: { fallback: Fallback, data: treeView.activeNode.data },
+                  heading: { data: treeView.activeNode /* (thure): Intentionally the node. */ },
+                  presence: { data: treeView.activeNode.data },
                 }}
               />
             );
@@ -77,6 +79,12 @@ export const TreeViewPlugin = (): PluginDefinition<TreeViewPluginProvides> => {
           case 'dragoverlay':
             if (!!data && typeof data === 'object' && 'id' in data && 'label' in data) {
               return TreeItemDragOverlay;
+            } else {
+              return null;
+            }
+          case 'heading':
+            if (!!data && typeof data === 'object' && 'label' in data && 'parent' in data) {
+              return TreeItemHeading;
             } else {
               return null;
             }

--- a/packages/apps/plugins/plugin-treeview/src/components/TreeItemHeading.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/TreeItemHeading.tsx
@@ -11,15 +11,17 @@ import { TREE_VIEW_PLUGIN } from '../types';
 export const TreeItemHeading = ({ data: node }: { data: Graph.Node }) => {
   const { t } = useTranslation(TREE_VIEW_PLUGIN);
   return (
-    <Breadcrumb.Root aria-label={t('breadcrumb label')}>
+    <Breadcrumb.Root aria-label={t('breadcrumb label')} classNames='shrink min-is-0'>
       <Breadcrumb.List>
         {node.parent && (
           <>
             <Breadcrumb.ListItem>
               <Breadcrumb.Link asChild>
-                <Button variant='ghost' classNames='text-sm pli-0 gap-1'>
-                  {node.parent.icon && <node.parent.icon />}
-                  <span>{Array.isArray(node.parent.label) ? t(...node.parent.label) : node.parent.label}</span>
+                <Button variant='ghost' classNames='shrink text-sm pli-0 gap-1 overflow-hidden'>
+                  {node.parent.icon && <node.parent.icon className='shrink-0' />}
+                  <span className='min-is-0  flex-1 truncate'>
+                    {Array.isArray(node.parent.label) ? t(...node.parent.label) : node.parent.label}
+                  </span>
                 </Button>
               </Breadcrumb.Link>
             </Breadcrumb.ListItem>
@@ -27,9 +29,11 @@ export const TreeItemHeading = ({ data: node }: { data: Graph.Node }) => {
           </>
         )}
         <Breadcrumb.ListItem>
-          <Breadcrumb.Current classNames='text-sm font-medium flex items-center gap-1'>
-            {node.icon && <node.icon />}
-            <span>{Array.isArray(node.label) ? t(...node.label) : node.label}</span>
+          <Breadcrumb.Current classNames='shrink text-sm font-medium flex items-center gap-1 overflow-hidden'>
+            {node.icon && <node.icon className='shrink-0' />}
+            <span className='min-is-0 flex-1 truncate'>
+              {Array.isArray(node.label) ? t(...node.label) : node.label}
+            </span>
           </Breadcrumb.Current>
         </Breadcrumb.ListItem>
       </Breadcrumb.List>

--- a/packages/apps/plugins/plugin-treeview/src/components/TreeItemHeading.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/TreeItemHeading.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 
 import { Graph } from '@braneframe/plugin-graph';
-import { Breadcrumb, useTranslation } from '@dxos/aurora';
+import { Breadcrumb, Button, useTranslation } from '@dxos/aurora';
 
 import { TREE_VIEW_PLUGIN } from '../types';
 
@@ -13,8 +13,24 @@ export const TreeItemHeading = ({ data: node }: { data: Graph.Node }) => {
   return (
     <Breadcrumb.Root aria-label={t('breadcrumb label')}>
       <Breadcrumb.List>
+        {node.parent && (
+          <>
+            <Breadcrumb.ListItem>
+              <Breadcrumb.Link asChild>
+                <Button variant='ghost' classNames='text-sm pli-0 gap-1'>
+                  {node.parent.icon && <node.parent.icon />}
+                  <span>{Array.isArray(node.parent.label) ? t(...node.parent.label) : node.parent.label}</span>
+                </Button>
+              </Breadcrumb.Link>
+            </Breadcrumb.ListItem>
+            <Breadcrumb.Separator />
+          </>
+        )}
         <Breadcrumb.ListItem>
-          <Breadcrumb.Current>{Array.isArray(node.label) ? t(...node.label) : node.label}</Breadcrumb.Current>
+          <Breadcrumb.Current classNames='text-sm font-medium flex items-center gap-1'>
+            {node.icon && <node.icon />}
+            <span>{Array.isArray(node.label) ? t(...node.label) : node.label}</span>
+          </Breadcrumb.Current>
         </Breadcrumb.ListItem>
       </Breadcrumb.List>
     </Breadcrumb.Root>

--- a/packages/apps/plugins/plugin-treeview/src/components/TreeItemHeading.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/TreeItemHeading.tsx
@@ -1,0 +1,22 @@
+//
+// Copyright 2023 DXOS.org
+//
+import React from 'react';
+
+import { Graph } from '@braneframe/plugin-graph';
+import { Breadcrumb, useTranslation } from '@dxos/aurora';
+
+import { TREE_VIEW_PLUGIN } from '../types';
+
+export const TreeItemHeading = ({ data: node }: { data: Graph.Node }) => {
+  const { t } = useTranslation(TREE_VIEW_PLUGIN);
+  return (
+    <Breadcrumb.Root aria-label={t('breadcrumb label')}>
+      <Breadcrumb.List>
+        <Breadcrumb.ListItem>
+          <Breadcrumb.Current>{Array.isArray(node.label) ? t(...node.label) : node.label}</Breadcrumb.Current>
+        </Breadcrumb.ListItem>
+      </Breadcrumb.List>
+    </Breadcrumb.Root>
+  );
+};

--- a/packages/apps/plugins/plugin-treeview/src/components/index.ts
+++ b/packages/apps/plugins/plugin-treeview/src/components/index.ts
@@ -5,5 +5,6 @@
 export * from './BranchTreeItem';
 export * from './Fallback';
 export * from './LeafTreeItem';
+export * from './TreeItemHeading';
 export * from './TreeView';
 export * from './TreeViewContainer';

--- a/packages/ui/aurora-theme/src/styles/components/breadcrumb.ts
+++ b/packages/ui/aurora-theme/src/styles/components/breadcrumb.ts
@@ -15,6 +15,8 @@ export const breadcrumbList: ComponentFunction<breadcrumbStyleProps> = (_props, 
 
 export const breadcrumbListItem: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) => mx('contents', ...etc);
 
+export const breadcrumbCurrent: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) => mx(...etc);
+
 export const breadcrumbSeparator: ComponentFunction<breadcrumbStyleProps> = (_props, ...etc) =>
   mx('opacity-50', ...etc);
 
@@ -22,5 +24,6 @@ export const breadcrumbTheme: Theme<breadcrumbStyleProps> = {
   root: breadcrumbRoot,
   list: breadcrumbList,
   listItem: breadcrumbListItem,
+  current: breadcrumbCurrent,
   separator: breadcrumbSeparator,
 };

--- a/packages/ui/aurora-theme/src/styles/fragments/density.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/density.ts
@@ -4,12 +4,13 @@
 
 import { Density } from '@dxos/aurora-types';
 
-export const coarseBlockSize = 'min-bs-[40px]';
+export const coarseBlockSize = 'min-bs-[2.5rem]';
+export const coarseBlockPaddingStart = 'pbs-[2.5rem]';
 export const coarseTextPadding = 'pli-3';
 export const coarseButtonPadding = 'pli-4';
 export const coarseDimensions = `${coarseBlockSize} ${coarseTextPadding}`;
 export const coarseButtonDimensions = `${coarseBlockSize} ${coarseButtonPadding}`;
-export const fineBlockSize = 'min-bs-[40px] pointer-fine:min-bs-[32px]';
+export const fineBlockSize = 'min-bs-[2.5rem] pointer-fine:min-bs-[2rem]';
 export const fineTextPadding = 'pli-2';
 export const fineButtonPadding = 'pli-2.5';
 export const fineDimensions = `${fineBlockSize} ${fineTextPadding}`;

--- a/packages/ui/aurora-theme/src/styles/fragments/layout.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/layout.ts
@@ -2,6 +2,8 @@
 // Copyright 2023 DXOS.org
 //
 
-export const bounceLayout = 'fixed inset-0 z-0 overflow-auto overscroll-auto scroll-smooth';
+export const bounceLayout =
+  'fixed inset-inline-0 block-end-0 block-start-[2.5rem] z-0 overflow-auto overscroll-auto scroll-smooth';
 
-export const fixedFullLayout = 'flex flex-col h-full fixed inset-0 overflow-hidden overscroll-none';
+export const fixedFullLayout =
+  'flex flex-col h-full fixed inset-inline-0 block-end-0 block-start-[2.5rem] overflow-hidden overscroll-none';

--- a/packages/ui/aurora-theme/src/styles/fragments/layout.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/layout.ts
@@ -2,8 +2,6 @@
 // Copyright 2023 DXOS.org
 //
 
-export const bounceLayout =
-  'fixed inset-inline-0 block-end-0 block-start-[2.5rem] z-0 overflow-auto overscroll-auto scroll-smooth';
+export const bounceLayout = 'fixed inset-0 z-0 overflow-auto overscroll-auto scroll-smooth';
 
-export const fixedFullLayout =
-  'flex flex-col h-full fixed inset-inline-0 block-end-0 block-start-[2.5rem] overflow-hidden overscroll-none';
+export const fixedInsetFlexLayout = 'flex flex-col fixed inset-0 overflow-hidden overscroll-none';

--- a/packages/ui/aurora-theme/src/styles/fragments/surface.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/surface.ts
@@ -6,14 +6,10 @@
 export const baseSurface = 'bg-neutral-75 dark:bg-neutral-900';
 
 // Control panel.
-export const groupSurface = 'bg-neutral-50 dark:bg-neutral-850';
+export const groupSurface = 'bg-neutral-25 dark:bg-neutral-850';
 
 // Popovers.
 export const chromeSurface = 'bg-white dark:bg-neutral-800';
 
-// Content (document, canvas, etc.)
-export const paperSurface = 'bg-white dark:bg-neutral-925';
-
-// TODO(burdon): Temp for main surfaces to prevent bounce/scroll. Test with Kanban and Drawing.
-// todo(thure): These are layout rules rather than background colors; this fragment
-export const fullSurface = 'flex flex-col h-full fixed inset-0 overflow-hidden overscroll-none';
+// Surfaces needing higher contrast, esp. inputs, textareas, etc
+export const inputSurface = 'bg-white dark:bg-neutral-925';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1187,6 +1187,7 @@ importers:
       '@dxos/react-surface': workspace:*
       '@dxos/text-model': workspace:*
       '@phosphor-icons/react': ^2.0.5
+      '@preact/signals-react': ^1.3.3
       '@types/lodash.get': ^4.4.7
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
@@ -1203,6 +1204,7 @@ importers:
       '@dxos/aurora-composer': link:../../../ui/aurora-composer
       '@dxos/react-client': link:../../../sdk/react-client
       '@dxos/text-model': link:../../../core/echo/text-model
+      '@preact/signals-react': 1.3.4_react@18.2.0
       deepsignal: 1.3.4_react@18.2.0
       lodash.get: 4.4.2
     devDependencies:


### PR DESCRIPTION
This PR resolves:
- #3905 
- #3904
- #3906 

https://github.com/dxos/dxos/assets/855039/408ac14b-fbbd-4440-8680-24b730e53b6d

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 488df05</samp>

### Summary
📝🎨🐛

<!--
1.  📝 - This emoji represents the changes related to the markdown editor, such as adding the placeholder text, the standalone menu, and the presence indicator.
2.  🎨 - This emoji represents the changes related to the layout and spacing of the plugins, such as using the new design system variables and components, and adjusting the minimum heights and paddings.
3.  🐛 - This emoji represents the changes related to fixing bugs and typos, such as adding the `optimizeDeps.include` option, replacing the `min-bs-[100vh]` class, and removing unused code and imports.
-->
This pull request updates the layout and spacing of several plugins to match the new design system, adds the functionality for the standalone markdown editor and the presence indicator for the space plugin, and fixes some typos and unused code in various files. It also adds or updates some dependencies, imports, and translations related to these changes. The affected files include `plugin-chess`, `plugin-debug`, `plugin-grid`, `plugin-ipfs`, `plugin-kanban`, `plugin-markdown`, `plugin-space`, `plugin-splitview`, `plugin-github`, and `labs-app`.

> _Sing, O Muse, of the glorious deeds of the `plugin-markdown` team,_
> _Who with skill and wisdom updated the layout and spacing of their apps,_
> _Using the `coarseBlockPaddingStart` and the `inputSurface` from the `aurora-theme`,_
> _And the `DropdownMenu` and the `Surface` from the `react-surface`._

### Walkthrough
*  Fix build error by adding `@braneframe/plugin-space` to `optimizeDeps.include` in `vite.config.ts` ([link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-bc212f565dc607eb0c92c7eedd5fe1f829b3d48811fa472c870cb1337e5f39d4R61))
*  Adjust layout and spacing of plugins according to new design system by replacing `baseSurface` with `coarseBlockPaddingStart` and `min-bs-[100vh]` with `min-bs-[calc(100dvh-2.5rem)]` in `Main.Content` elements ([link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-11d18f8ffbc50f714f58df501a5c59afb51863713ed38a71e4b82cee2a4aa1dbL9-R9), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-11d18f8ffbc50f714f58df501a5c59afb51863713ed38a71e4b82cee2a4aa1dbL40-R40), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-67c0b2eb0a5e6e6e52cc6fadc62369646425931154e81f33f345ab693a8b567aL9-R9), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-67c0b2eb0a5e6e6e52cc6fadc62369646425931154e81f33f345ab693a8b567aL22-R22), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-e8d7fd2b1f09e95dcf90494d04cc535507a9b5dc691d023d0c4a1a65a0f17485L9-R9), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-e8d7fd2b1f09e95dcf90494d04cc535507a9b5dc691d023d0c4a1a65a0f17485L30-R30))
*  Remove unused `baseSurface` imports and classes from `DebugMain.tsx` and `KanbanMain.tsx` ([link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-3af2dcc1d2d7818d416feb3e49aceb9c1abd5ca1857f5cbdc4054708e5ef1372L15-R15), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-3af2dcc1d2d7818d416feb3e49aceb9c1abd5ca1857f5cbdc4054708e5ef1372L86-R86), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-d36cb8c44106ee4e2e3fc3fe686403f0e9ec4a375047ac3f3de633e92d46c343L10-R10), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-d36cb8c44106ee4e2e3fc3fe686403f0e9ec4a375047ac3f3de633e92d46c343L42-R42))
*  Fix typo in `min-bs-[100dvh]` class in `EmbeddedMain.tsx` ([link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-729deb573b5cc8132392ae8f4565e26d5d88f5b5a3f07068efa78bfd4701a03fL236-R236))
*  Use `inputSurface` instead of `paperSurface` for kanban items in `KanbanItem.tsx` ([link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-e6074340854f088b038f7c21020b30b845bc3d08b3dbb282aa1bbe1b06ce61adL13-R13), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-e6074340854f088b038f7c21020b30b845bc3d08b3dbb282aa1bbe1b06ce61adL47-R47))
*  Add `@preact/signals-react` dependency and use `useSignal` hook for reactive signals in `plugin-markdown` ([link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-e6d1d345821614148e5995e27dd43e3d23acd9c585a2ae3ef5911c496baf2ccdR25), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-f10ade0613626f3a9e7336637d00783abd99bf3a62e10925baa0bf1252700729L5-R11), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-f10ade0613626f3a9e7336637d00783abd99bf3a62e10925baa0bf1252700729L50-R55))
*  Use ref callback pattern for passing editor ref to `MarkdownPlugin` and `EditorMain` components ([link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcL8-R14), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcR41-R46), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcR61), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-f10ade0613626f3a9e7336637d00783abd99bf3a62e10925baa0bf1252700729R21), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-423332bc470bcc79a08a2d67690ae2269754da18935122e73bb3d11e4479230dL18-R18))
*  Add `StandaloneMenu` component and use it for rendering menu for standalone markdown editor ([link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcR20), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcL83-R115), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcR223-R229), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-2dad9280901d107c07117e32c1eaa07331e303c02d11699a00ec95431dd64eacL5-R24), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-8948ecb2de6ea4c190de1b95ca1854b3574f3636dee3bd56d0f388d7a06394f1R1-R40))
*  Add translation for editor placeholder text in `translations.ts` ([link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-f10ade0613626f3a9e7336637d00783abd99bf3a62e10925baa0bf1252700729L5-R11), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-f10ade0613626f3a9e7336637d00783abd99bf3a62e10925baa0bf1252700729L50-R55), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-dc3d59bfba77ba544a381fce29ae64058128ea2abec1aec79da6b8a487b02049R21))
*  Add `SpacePresence` component and use it for rendering presence indicator for space plugin ([link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L22-R30), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839R137-R138), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-7eaaf77f42f83a3e3ee55e3bc710b90d55f1c14fff0f924c69ef8e641a613994R1-R34), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-2b571a109fc6db0ed0979c3a6d2c47731321ccbf472723c33da56998ff2c5144R11), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-7fb1d4092e81509497c35fe93aca7d62efae75ec79e2f6268ed3dfcbc6220087R27))
*  Update icons and sizes for sidebar buttons in `SplitView` component ([link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-e86be8a443d075eaa84629958372f8cde37821571c30d382fc579e5d63b132deL5-R9), [link](https://github.com/dxos/dxos/pull/3942/files?diff=unified&w=0#diff-e86be8a443d075eaa84629958372f8cde37821571c30d382fc579e5d63b132deL37-R60))


