### PR TITLE
feat: Grid styles.

### DIFF
--- a/packages/devtools/devtools/src/components/ConnectionInfoView.tsx
+++ b/packages/devtools/devtools/src/components/ConnectionInfoView.tsx
@@ -4,7 +4,7 @@
 
 import React, { FC } from 'react';
 
-import { createColumnBuilder, defaultGridSlots, Grid, GridColumnDef } from '@dxos/aurora-grid';
+import { createColumnBuilder, Grid, GridColumnDef } from '@dxos/aurora-grid';
 import { ConnectionInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
 
 import { DetailsTable } from './DetailsTable';
@@ -34,7 +34,7 @@ export const ConnectionInfoView: FC<{ connection?: ConnectionInfo }> = ({ connec
         }}
       />
 
-      <Grid<ConnectionInfo.StreamStats> columns={columns} data={connection.streams ?? []} slots={defaultGridSlots} />
+      <Grid<ConnectionInfo.StreamStats> columns={columns} data={connection.streams ?? []} />
     </div>
   );
 };

--- a/packages/devtools/devtools/src/components/MasterDetailTable.tsx
+++ b/packages/devtools/devtools/src/components/MasterDetailTable.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState } from 'react';
 
-import { defaultGridSlots, Grid, GridColumnDef } from '@dxos/aurora-grid';
+import { Grid, GridColumnDef } from '@dxos/aurora-grid';
 
 import { JsonView } from './JsonView';
 
@@ -25,7 +25,6 @@ export const MasterDetailTable = <T extends {}>({ columns, data, pinToBottom }: 
           data={data}
           selected={selected}
           onSelectedChange={setSelected}
-          slots={defaultGridSlots}
           pinToBottom={pinToBottom}
         />
       </div>

--- a/packages/devtools/devtools/src/panels/client/TracingPanel/TracingPanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/TracingPanel/TracingPanel.tsx
@@ -7,7 +7,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { FlameGraph } from 'react-flame-graph';
 import { useResizeDetector } from 'react-resize-detector';
 
-import { createColumnBuilder, defaultGridSlots, Grid, GridColumnDef } from '@dxos/aurora-grid';
+import { createColumnBuilder, Grid, GridColumnDef } from '@dxos/aurora-grid';
 import { Resource, Span } from '@dxos/protocols/proto/dxos/tracing';
 import { useClient } from '@dxos/react-client';
 
@@ -61,11 +61,7 @@ export const TracingPanel = () => {
   return (
     <PanelContainer>
       <div className='h-1/2 overflow-auto'>
-        <Grid<Resource>
-          columns={columns}
-          data={Array.from(state.current.resources.values())}
-          slots={defaultGridSlots}
-        />
+        <Grid<Resource> columns={columns} data={Array.from(state.current.resources.values())} />
       </div>
       <div ref={containerRef} className='border-t'>
         <div className='flex flex-row items-baseline justify-items-center p-2'>

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/PipelineTable.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/PipelineTable.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { createColumnBuilder, defaultGridSlots, Grid, GridColumnDef } from '@dxos/aurora-grid';
+import { createColumnBuilder, Grid, GridColumnDef } from '@dxos/aurora-grid';
 import { Space as SpaceProto } from '@dxos/protocols/proto/dxos/client/services';
 import { SubscribeToSpacesResponse } from '@dxos/protocols/proto/dxos/devtools/host';
 import { PublicKey } from '@dxos/react-client';
@@ -122,7 +122,5 @@ export const PipelineTable = ({
     navigate('/echo/feeds');
   };
 
-  return (
-    <Grid<PipelineTableRow> columns={columns} data={data} onSelectedChange={handleSelect} slots={defaultGridSlots} />
-  );
+  return <Grid<PipelineTableRow> columns={columns} data={data} onSelectedChange={handleSelect} />;
 };

--- a/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
@@ -5,7 +5,7 @@
 import React, { FC } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { Grid, GridColumnDef, defaultGridSlots, createColumnBuilder } from '@dxos/aurora-grid';
+import { Grid, GridColumnDef, createColumnBuilder } from '@dxos/aurora-grid';
 import { PublicKey } from '@dxos/keys';
 import { Space, useSpaces } from '@dxos/react-client/echo';
 
@@ -68,7 +68,7 @@ export const SpaceListPanel: FC = () => {
 
   return (
     <PanelContainer className='overflow-auto'>
-      <Grid<Space> columns={columns} data={spaces} onSelectedChange={handleSelect} slots={defaultGridSlots} />
+      <Grid<Space> columns={columns} data={spaces} onSelectedChange={handleSelect} />
     </PanelContainer>
   );
 };

--- a/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalStatusInfo.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalStatusInfo.tsx
@@ -6,7 +6,7 @@ import { formatDistance } from 'date-fns';
 import React, { useEffect, useState } from 'react';
 
 import { scheduleTaskInterval } from '@dxos/async';
-import { createColumnBuilder, defaultGridSlots, Grid, GridColumnDef } from '@dxos/aurora-grid';
+import { createColumnBuilder, Grid, GridColumnDef } from '@dxos/aurora-grid';
 import { Context } from '@dxos/context';
 import { SignalStatus } from '@dxos/messaging';
 import { SubscribeToSignalStatusResponse } from '@dxos/protocols/proto/dxos/devtools/host';
@@ -84,7 +84,7 @@ export const SignalStatusInfo = () => {
 
   return (
     <div>
-      <Grid<SignalStatus> columns={columns} data={status} slots={defaultGridSlots} />
+      <Grid<SignalStatus> columns={columns} data={status} />
     </div>
   );
 };

--- a/packages/devtools/devtools/src/panels/mesh/SwarmPanel/SwarmPanel.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SwarmPanel/SwarmPanel.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState } from 'react';
 
-import { createColumnBuilder, defaultGridSlots, Grid, GridColumnDef } from '@dxos/aurora-grid';
+import { createColumnBuilder, Grid, GridColumnDef } from '@dxos/aurora-grid';
 import { ConnectionInfo, SwarmInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
 import { useDevtools, useStream } from '@dxos/react-client/devtools';
 
@@ -56,12 +56,7 @@ export const SwarmPanel = () => {
   return (
     <PanelContainer>
       <div className='h-1/2 overflow-auto'>
-        <Grid<SwarmConnection>
-          columns={columns}
-          data={items}
-          onSelectedChange={handleSelect}
-          slots={defaultGridSlots}
-        />
+        <Grid<SwarmConnection> columns={columns} data={items} onSelectedChange={handleSelect} />
       </div>
       <div className='h-1/2 overflow-auto'>{connection && <ConnectionInfoView connection={connection} />}</div>
     </PanelContainer>

--- a/packages/ui/aurora-grid/src/Grid.tsx
+++ b/packages/ui/aurora-grid/src/Grid.tsx
@@ -225,7 +225,6 @@ export const Grid = <TData extends RowData>({
   return (
     <div ref={containerRef} className={mx('grow overflow-auto', slots?.root?.className)}>
       <table className='table-fixed w-full'>
-        {/* TODO(burdon): Must have header group for widths. */}
         <thead className={mx(showHeader ? ['sticky top-0 z-10', slots?.header?.className] : 'collapse')}>
           {table.getHeaderGroups().map((headerGroup) => {
             return (

--- a/packages/ui/aurora-grid/src/Grid.tsx
+++ b/packages/ui/aurora-grid/src/Grid.tsx
@@ -15,6 +15,8 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { mx } from '@dxos/aurora-theme';
 
+import { defaultGridSlots } from './helpers';
+
 export type GridColumnDef<TData extends RowData, TValue = unknown> = ColumnDef<TData, TValue>;
 
 // TODO(burdon): Editable.
@@ -121,7 +123,7 @@ export type GridProps<TData extends RowData> = {
 export const Grid = <TData extends RowData>({
   columns = [],
   data = [],
-  slots,
+  slots = defaultGridSlots,
   select,
   selected,
   onSelectedChange,

--- a/packages/ui/aurora-grid/src/helpers.tsx
+++ b/packages/ui/aurora-grid/src/helpers.tsx
@@ -136,10 +136,10 @@ export class ColumnBuilder<TData extends RowData> {
   }
 }
 
-// TODO(burdon): Compact mode.
 // TODO(burdon): Integrate with aurora theme (direct dependency -- see aurora-composer, tailwind.ts).
 //  See Link.tsx const { tx } = useThemeContext();
 //  Reuse button fragments for hoverColors, selected, primary, etc.
+// TODO(burdon): Compact mode (smaller than density fine).
 export const defaultGridSlots: GridSlots = {
   root: { className: chromeSurface },
   header: { className: [chromeSurface, 'border-b p-1 text-left font-thin opacity-90'] },

--- a/packages/ui/aurora-grid/src/helpers.tsx
+++ b/packages/ui/aurora-grid/src/helpers.tsx
@@ -136,11 +136,10 @@ export class ColumnBuilder<TData extends RowData> {
   }
 }
 
-// TODO(burdon): Move to theme? Compact mode (small font).
-// TODO(burdon): See Link.tsx const { tx } = useThemeContext();
-// TODO(burdon): Use aurora-theme directly (see aurora-composer).
-// TODO(burdon): Reuse button fragments for hoverColors, selected, primary, etc.
-// TODO(burdon): See tailwind.ts
+// TODO(burdon): Compact mode.
+// TODO(burdon): Integrate with aurora theme (direct dependency -- see aurora-composer, tailwind.ts).
+//  See Link.tsx const { tx } = useThemeContext();
+//  Reuse button fragments for hoverColors, selected, primary, etc.
 export const defaultGridSlots: GridSlots = {
   root: { className: chromeSurface },
   header: { className: [chromeSurface, 'border-b p-1 text-left font-thin opacity-90'] },
@@ -148,6 +147,6 @@ export const defaultGridSlots: GridSlots = {
   cell: { className: 'p-1' },
   row: { className: 'cursor-pointer hover:bg-neutral-50' },
   focus: { className: 'ring-1 ring-teal-500 ring-inset' },
-  selected: { className: '!bg-green-100' },
+  selected: { className: '!bg-teal-100' },
   margin: { style: { width: 8 } },
 };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1dcc4cf</samp>

### Summary
🧹🎨🛠️

<!--
1.  🧹 for simplifying and removing unused code.
2.  🎨 for improving the visual appearance and consistency of the grid component.
3.  🛠️ for adding a new prop to the grid component to allow customization.
-->
Simplified the grid layouts of several devtools components by removing unused and redundant code and props. Added a `slots` prop to the `Grid` component from `@dxos/aurora-grid` to allow customizing the grid layout. Improved the visual consistency of the grid component with the aurora theme.

> _Grid layout refined_
> _`@dxos/aurora-grid` shines_
> _Teal slot marks the spring_

### Walkthrough
*  Removed unused imports of `defaultGridSlots` from `@dxos/aurora-grid` in several components ([link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-1229733d275547fca130b4c9737b0970e95d769e7990419e73f31edc7f1a287bL7-R7), [link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-83203d64e59d8a6d88a60cb78e24da1b5f391e92634bfcfdd46bb53269d0aa36L7-R7), [link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-11ebc1d7386eb2adedf5187a9087f72055ecbf56e306c10833b24f56da45450eL10-R10), [link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-5c6f550e8d8beba8f22f589b1da82fb7ca6292f395918d7a9a4fe4dedca6d73dL8-R8), [link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-bf5f3f312ecbe59ff02fb2ecb3634f997713e8ce53359fbed1ce8b32add2cc7dL8-R8), [link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-648429f5723aa3c21261bcec29164b7214b9089a9f185d744b68f5865f2d7cadL9-R9), [link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-5a74c5baeecf322e5dbbb8f57b9b1078b282693c7d357483cfef2867f2cb0fc0L7-R7))
* Removed `slots` prop from `Grid` components that used `defaultGridSlots`, as they are now provided by default ([link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-1229733d275547fca130b4c9737b0970e95d769e7990419e73f31edc7f1a287bL37-R37), [link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-83203d64e59d8a6d88a60cb78e24da1b5f391e92634bfcfdd46bb53269d0aa36L28), [link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-11ebc1d7386eb2adedf5187a9087f72055ecbf56e306c10833b24f56da45450eL64-R64), [link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-5c6f550e8d8beba8f22f589b1da82fb7ca6292f395918d7a9a4fe4dedca6d73dL125-R125), [link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-bf5f3f312ecbe59ff02fb2ecb3634f997713e8ce53359fbed1ce8b32add2cc7dL71-R71), [link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-648429f5723aa3c21261bcec29164b7214b9089a9f185d744b68f5865f2d7cadL87-R87), [link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-5a74c5baeecf322e5dbbb8f57b9b1078b282693c7d357483cfef2867f2cb0fc0L59-R59))
* Added `defaultGridSlots` import and `slots` prop to `Grid` component in `packages/ui/aurora-grid/src/Grid.tsx`, to provide the default slots for the grid ([link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-1a938a1f05e724cfc8ca576870b20836d39cf6fa1095f57df571e13e950f24bdR18-R19), [link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-1a938a1f05e724cfc8ca576870b20836d39cf6fa1095f57df571e13e950f24bdL124-R126))
* Changed `selected` slot color from `!bg-green-100` to `!bg-teal-100` in `defaultGridSlots` in `packages/ui/aurora-grid/src/helpers.tsx`, to match the aurora theme color scheme ([link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-8572bd412908b8a9933b94704940fe3f14b09ac0d6dfd27028ab59c476d041bfL151-R150))
* Updated TODO comments in `packages/ui/aurora-grid/src/helpers.tsx`, to reflect the current status of integrating the grid with the aurora theme and the compact mode ([link](https://github.com/dxos/dxos/pull/3946/files?diff=unified&w=0#diff-8572bd412908b8a9933b94704940fe3f14b09ac0d6dfd27028ab59c476d041bfL139-R142))


