### PR TITLE
fix(aurora-theme,plugin-splitview): Polish items

### DIFF
--- a/packages/apps/plugins/plugin-ipfs/src/components/FileMain.tsx
+++ b/packages/apps/plugins/plugin-ipfs/src/components/FileMain.tsx
@@ -6,7 +6,7 @@ import React, { FC, useState } from 'react';
 import urlJoin from 'url-join';
 
 import { Main } from '@dxos/aurora';
-import { coarseBlockPaddingStart } from '@dxos/aurora-theme';
+import { coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/aurora-theme';
 import { TypedObject } from '@dxos/client/echo';
 import { Config, useConfig } from '@dxos/react-client';
 
@@ -27,7 +27,7 @@ export const FileMain: FC<{ data: TypedObject }> = ({ data: file }) => {
   const url = getIpfsUrl(config, file.cid);
 
   return (
-    <Main.Content classNames={['flex flex-col min-bs-[calc(100dvh-2.5rem)] overflow-hidden', coarseBlockPaddingStart]}>
+    <Main.Content classNames={[fixedInsetFlexLayout, coarseBlockPaddingStart]}>
       <FilePreview type={file.type} url={url} />
     </Main.Content>
   );

--- a/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
@@ -6,7 +6,7 @@ import React, { MutableRefObject, PropsWithChildren } from 'react';
 
 import { Main } from '@dxos/aurora';
 import { ComposerModel, MarkdownComposerRef } from '@dxos/aurora-composer';
-import { coarseBlockPaddingStart } from '@dxos/aurora-theme';
+import { coarseBlockPaddingStart, mx, textBlockWidth } from '@dxos/aurora-theme';
 
 import { MarkdownProperties } from '../types';
 
@@ -20,7 +20,7 @@ export const StandaloneLayout = ({
 }>) => {
   return (
     <Main.Content bounce classNames={coarseBlockPaddingStart}>
-      <div role='none' className='mli-auto max-is-[60rem] min-bs-[calc(100dvh-2.5rem)] flex flex-col'>
+      <div role='none' className={mx(textBlockWidth, 'min-bs-[calc(100dvh-2.5rem)] flex flex-col')}>
         {children}
       </div>
     </Main.Content>

--- a/packages/apps/plugins/plugin-markdown/src/components/StandaloneMenu.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/StandaloneMenu.tsx
@@ -2,12 +2,12 @@
 // Copyright 2023 DXOS.org
 //
 
-import { DotsSixVertical } from '@phosphor-icons/react';
+import { DotsThreeVertical } from '@phosphor-icons/react';
 import React, { PropsWithChildren, RefObject } from 'react';
 
 import { Button, DropdownMenu } from '@dxos/aurora';
 import { ComposerModel, MarkdownComposerRef } from '@dxos/aurora-composer';
-import { getSize } from '@dxos/aurora-theme';
+import { fineButtonDimensions, getSize } from '@dxos/aurora-theme';
 import { Surface } from '@dxos/react-surface';
 
 import { MarkdownProperties } from '../types';
@@ -25,12 +25,12 @@ export const StandaloneMenu = ({
   return (
     <DropdownMenu.Root modal={false}>
       <DropdownMenu.Trigger asChild>
-        <Button variant='ghost'>
-          <DotsSixVertical className={getSize(4)} />
+        <Button variant='ghost' classNames={fineButtonDimensions}>
+          <DotsThreeVertical className={getSize(4)} />
         </Button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Portal>
-        <DropdownMenu.Content sideOffset={10} classNames='z-10'>
+        <DropdownMenu.Content sideOffset={8} classNames='z-10'>
           <Surface data={[model, properties, editorRef]} role='menuitem' />
           <DropdownMenu.Arrow />
         </DropdownMenu.Content>

--- a/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
@@ -6,7 +6,7 @@ import { Chats, List as MenuIcon } from '@phosphor-icons/react';
 import React from 'react';
 
 import { Button, Main, Dialog, useTranslation, DensityProvider } from '@dxos/aurora';
-import { coarseBlockSize, getSize } from '@dxos/aurora-theme';
+import { coarseBlockSize, fixedSurface, getSize } from '@dxos/aurora-theme';
 import { Surface } from '@dxos/react-surface';
 
 import { useSplitView } from '../SplitViewContext';
@@ -37,7 +37,7 @@ export const SplitView = () => {
       <Main.Overlay />
       <Main.Content
         asChild
-        classNames={['fixed inset-inline-0 block-start-0 z-[1] flex gap-1 plb-1.5', coarseBlockSize]}
+        classNames={['fixed inset-inline-0 block-start-0 z-[1] flex gap-1 plb-1.5', coarseBlockSize, fixedSurface]}
       >
         <div role='none' aria-label={t('main header label')}>
           <DensityProvider density='fine'>

--- a/packages/apps/plugins/plugin-stack/src/components/StackSectionsPanel.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackSectionsPanel.tsx
@@ -10,6 +10,7 @@ import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useDnd, useDragEnd, useDragOver, useDragStart } from '@braneframe/plugin-dnd';
 import { File as FileProto } from '@braneframe/types';
 import { List, useTranslation } from '@dxos/aurora';
+import { textBlockWidth } from '@dxos/aurora-theme';
 import { arrayMove } from '@dxos/util';
 
 import { defaultFileTypes } from '../hooks';
@@ -121,7 +122,7 @@ export const StackSectionsPanel: FC<{
   );
 
   return (
-    <List variant='ordered' itemSizes='many' classNames='pli-2'>
+    <List variant='ordered' itemSizes='many' classNames={[textBlockWidth, 'pli-2']}>
       <SortableContext items={sectionModels} strategy={verticalListSortingStrategy}>
         {sectionModels.map((sectionModel, start) => {
           return (

--- a/packages/ui/aurora-theme/src/styles/components/main.ts
+++ b/packages/ui/aurora-theme/src/styles/components/main.ts
@@ -5,7 +5,7 @@
 import { ComponentFunction } from '@dxos/aurora-types/src';
 
 import { mx } from '../../util';
-import { baseSurface, bounceLayout } from '../fragments';
+import { bounceLayout, fixedSurface } from '../fragments';
 
 export type MainStyleProps = Partial<{
   isLg: boolean;
@@ -31,7 +31,7 @@ export const mainSidebar: ComponentFunction<MainStyleProps> = (
       ? 'inline-end-0'
       : '-inline-end-[100vw] sm:-inline-end-[270px]',
     side === 'inline-start' ? 'border-ie' : 'border-is',
-    baseSurface,
+    fixedSurface,
     ...etc,
   );
 

--- a/packages/ui/aurora-theme/src/styles/fragments/dimensions.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/dimensions.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+export const textBlockWidth = 'mli-auto max-is-[60rem]';

--- a/packages/ui/aurora-theme/src/styles/fragments/index.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/index.ts
@@ -4,6 +4,7 @@
 
 export * from './arrow';
 export * from './density';
+export * from './dimensions';
 export * from './disabled';
 export * from './elevation';
 export * from './focus';

--- a/packages/ui/aurora-theme/src/styles/fragments/surface.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/surface.ts
@@ -5,11 +5,14 @@
 // Main background.
 export const baseSurface = 'bg-neutral-75 dark:bg-neutral-900';
 
-// Control panel.
+// Sidebars, main heading (“topbar”), and nothing else.
+export const fixedSurface = 'bg-neutral-75/95 dark:bg-neutral-900/95 backdrop-blur';
+
+// Cards, dialogs, other such groups.
 export const groupSurface = 'bg-neutral-25 dark:bg-neutral-850';
 
-// Popovers.
+// Tooltips, popovers, menus, etc. – not dialogs.
 export const chromeSurface = 'bg-white dark:bg-neutral-800';
 
-// Surfaces needing higher contrast, esp. inputs, textareas, etc
+// Elements that benefit from higher contrast, e.g. inputs, textareas, etc
 export const inputSurface = 'bg-white dark:bg-neutral-925';


### PR DESCRIPTION
https://github.com/dxos/dxos/assets/855039/caeab30a-d1fb-4efd-bdea-b206f93268a6

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0a6ae25</samp>

### Summary
🎨📝📐

<!--
1.  🎨 - This emoji represents the improvement of the UI appearance and consistency using the utility classes from `@dxos/aurora-theme`.
2.  📝 - This emoji represents the enhancement of the text-based components such as the markdown editor and the file preview using the `textBlockWidth` utility class.
3.  📐 - This emoji represents the adjustment of the layout and alignment of the components using the `fixedInsetFlexLayout` and other utility classes.
-->
This pull request improves the layout and appearance of various components in the IPFS, Markdown, SplitView, and Stack plugins by using utility classes from `@dxos/aurora-theme`. It also defines and exports new utility classes for common surface and text styles in `@dxos/aurora-theme`.

> _Sing, O Muse, of the skillful coder who refined the theme_
> _Of Aurora, the shining framework of the DXOS project,_
> _And how he crafted many utility classes, such as `fixedSurface`,_
> _To adorn the components with consistent backgrounds and widths._

### Walkthrough
*  Define and apply consistent width style for text-based components using `textBlockWidth` utility class ([link](https://github.com/dxos/dxos/pull/3955/files?diff=unified&w=0#diff-cb1ed1e3e39a701f1f6944515635998298e0ac9e6791d5dd500af8d5e5f8da5fR1-R5), [link](https://github.com/dxos/dxos/pull/3955/files?diff=unified&w=0#diff-8d49cae4ae0c0b1c2d4d7e0346e53f26f0c69f33e91502370c10d429fb115d92R7), [link](https://github.com/dxos/dxos/pull/3955/files?diff=unified&w=0#diff-2dad9280901d107c07117e32c1eaa07331e303c02d11699a00ec95431dd64eacL9-R9), [link](https://github.com/dxos/dxos/pull/3955/files?diff=unified&w=0#diff-2dad9280901d107c07117e32c1eaa07331e303c02d11699a00ec95431dd64eacL23-R23), [link](https://github.com/dxos/dxos/pull/3955/files?diff=unified&w=0#diff-820b5c8aec29e0cc05cead441158c916ced9aaa88460dd8917f64792e0dce5ebR13), [link](https://github.com/dxos/dxos/pull/3955/files?diff=unified&w=0#diff-820b5c8aec29e0cc05cead441158c916ced9aaa88460dd8917f64792e0dce5ebL124-R125)).


