### PR TITLE
fix(plugin-space): graph reactivity

### DIFF
--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -167,10 +167,10 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
 
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
             subscriptions.clear();
-            const spaceIndices = getIndices(spaces.length);
+            const indices = getIndices(spaces.length);
             spaces.forEach((space, index) => {
               const handle = createSubscription(() => {
-                spaceToGraphNode(space, groupNode, spaceIndices[index]);
+                spaceToGraphNode(space, groupNode, indices[index]);
               });
               handle.update([space.properties]);
               subscriptions.add(handle.unsubscribe);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6e8f880</samp>

### Summary
🔡🐛💡

<!--
1.  🔡 for renaming a variable
2.  🐛 for fixing a bug in the subscription key
3.  💡 for adding a comment with a suggestion
-->
This pull request improves the graph visualization of spaces by fixing a subscription bug and renaming a variable. It affects the files `helpers.ts` and `SpacePlugin.tsx` in the `plugin-space` package.

> _We're building a graph of nodes and spaces_
> _We're fixing the keys and the `indices`_
> _We're heaving away on the count of three_
> _We're coding the best that we can be_

### Walkthrough
*  Use composite key for object subscriptions in `GraphNodeAdapter` to avoid conflicts and leaks ([link](https://github.com/dxos/dxos/pull/3964/files?diff=unified&w=0#diff-885591696a06e2e9b3d491f2ad2b5867329cd8520dded3a459eeb0aa839f2901L52-R82))
*  Add comment to indicate that `indices` should be provided by the graph ([link](https://github.com/dxos/dxos/pull/3964/files?diff=unified&w=0#diff-885591696a06e2e9b3d491f2ad2b5867329cd8520dded3a459eeb0aa839f2901R44-R46))
*  Rename `spaceIndices` to `indices` in `SpacePlugin` for consistency ([link](https://github.com/dxos/dxos/pull/3964/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L170-R173))


