### PR TITLE
feat(aurora-theme): Hoverable controls

### DIFF
--- a/packages/apps/plugins/plugin-stack/src/components/StackSection.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackSection.tsx
@@ -10,7 +10,19 @@ import React, { FC, forwardRef } from 'react';
 
 import { SortableProps } from '@braneframe/plugin-dnd';
 import { List, ListItem, Button, useTranslation, DensityProvider, ListScopedProps } from '@dxos/aurora';
-import { fineButtonDimensions, focusRing, getSize, mx, inputSurface, surfaceElevation } from '@dxos/aurora-theme';
+import {
+  fineButtonDimensions,
+  focusRing,
+  getSize,
+  mx,
+  inputSurface,
+  surfaceElevation,
+  hoverableControls,
+  staticHoverableControls,
+  hoverableControlItem,
+  hoverableFocusedControls,
+  hoverableFocusedKeyboardControls,
+} from '@dxos/aurora-theme';
 import { Surface } from '@dxos/react-surface';
 
 import { STACK_PLUGIN, StackSectionModel } from '../types';
@@ -41,9 +53,9 @@ const StackSectionImpl = forwardRef<HTMLLIElement, ListScopedProps<StackSectionP
           classNames={[
             surfaceElevation({ elevation: 'group' }),
             inputSurface,
+            hoverableControls,
             'grow rounded mlb-2',
-            '[--controls-opacity:1] hover-hover:[--controls-opacity:.1] hover-hover:hover:[--controls-opacity:1]',
-            isOverlay && 'hover-hover:[--controls-opacity:1]',
+            isOverlay && staticHoverableControls,
             rearranging ? 'opacity-0' : section.isPreview ? 'opacity-50' : 'opacity-100',
           ]}
           ref={forwardedRef}
@@ -56,7 +68,8 @@ const StackSectionImpl = forwardRef<HTMLLIElement, ListScopedProps<StackSectionP
             className={mx(
               fineButtonDimensions,
               focusRing,
-              'self-stretch flex items-center rounded-is justify-center bs-auto is-auto focus-visible:[--controls-opacity:1]',
+              hoverableFocusedKeyboardControls,
+              'self-stretch flex items-center rounded-is justify-center bs-auto is-auto',
               isOverlay && 'text-primary-600 dark:text-primary-300',
             )}
             {...draggableAttributes}
@@ -64,7 +77,7 @@ const StackSectionImpl = forwardRef<HTMLLIElement, ListScopedProps<StackSectionP
           >
             <DotsSixVertical
               weight={isOverlay ? 'bold' : 'regular'}
-              className={mx(getSize(5), 'transition-opacity opacity-[--controls-opacity]')}
+              className={mx(getSize(5), hoverableControlItem, 'transition-opacity')}
             />
           </div>
           <div role='none' className='flex-1'>
@@ -72,11 +85,11 @@ const StackSectionImpl = forwardRef<HTMLLIElement, ListScopedProps<StackSectionP
           </div>
           <Button
             variant='ghost'
-            classNames='self-stretch justify-start rounded-is-none focus:[--controls-opacity:1]'
+            classNames={['self-stretch justify-start rounded-is-none', hoverableFocusedControls]}
             onClick={onRemove}
           >
             <span className='sr-only'>{t('remove section label')}</span>
-            <X className={mx(getSize(4), 'transition-opacity opacity-[--controls-opacity]')} />
+            <X className={mx(getSize(4), hoverableControlItem, 'transition-opacity')} />
           </Button>
         </ListItem.Root>
       </DensityProvider>

--- a/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTreeItem.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTreeItem.tsx
@@ -17,6 +17,7 @@ import {
   hoverableControls,
   hoverableFocusedKeyboardControls,
   hoverableFocusedWithinControls,
+  hoverableOpenControlItem,
   mx,
 } from '@dxos/aurora-theme';
 
@@ -140,7 +141,7 @@ export const NavTreeItem: ForwardRefExoticComponent<TreeViewItemProps & RefAttri
                 <Tooltip.Trigger asChild>
                   <Button
                     variant='ghost'
-                    classNames={['shrink-0 pli-2 pointer-fine:pli-1', hoverableControlItem]}
+                    classNames={['shrink-0 pli-2 pointer-fine:pli-1', hoverableControlItem, hoverableOpenControlItem]}
                     {...(!navigationSidebarOpen && { tabIndex: -1 })}
                   >
                     <DotsThreeVertical className={getSize(4)} />

--- a/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTreeItem.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTreeItem.tsx
@@ -10,7 +10,15 @@ import React, { FC, forwardRef, ForwardRefExoticComponent, RefAttributes, useEff
 import { SortableProps } from '@braneframe/plugin-dnd';
 import { Graph } from '@braneframe/plugin-graph';
 import { Button, DropdownMenu, Tooltip, TreeItem, useId, useSidebars, useTranslation } from '@dxos/aurora';
-import { focusRing, getSize, mx } from '@dxos/aurora-theme';
+import {
+  focusRing,
+  getSize,
+  hoverableControlItem,
+  hoverableControls,
+  hoverableFocusedKeyboardControls,
+  hoverableFocusedWithinControls,
+  mx,
+} from '@dxos/aurora-theme';
 
 import { useTreeView } from '../../TreeViewContext';
 import { TREE_VIEW_PLUGIN } from '../../types';
@@ -80,6 +88,7 @@ export const NavTreeItem: ForwardRefExoticComponent<TreeViewItemProps & RefAttri
       onOpenChange={(nextOpen) => setOpen(disabled ? false : nextOpen)}
       classNames={[
         'rounded block',
+        hoverableFocusedKeyboardControls,
         focusRing,
         active && 'bg-neutral-75 dark:bg-neutral-850',
         rearranging && 'invisible',
@@ -89,7 +98,10 @@ export const NavTreeItem: ForwardRefExoticComponent<TreeViewItemProps & RefAttri
       style={style}
       ref={forwardedRef}
     >
-      <div role='none' className={mx(levelPadding(level), 'flex items-start')}>
+      <div
+        role='none'
+        className={mx(levelPadding(level), hoverableControls, hoverableFocusedWithinControls, 'flex items-start')}
+      >
         {isBranch ? (
           <CollapsibleHeading {...{ open, node, level, active, id: labelId }} />
         ) : (
@@ -128,7 +140,7 @@ export const NavTreeItem: ForwardRefExoticComponent<TreeViewItemProps & RefAttri
                 <Tooltip.Trigger asChild>
                   <Button
                     variant='ghost'
-                    classNames='shrink-0 pli-2 pointer-fine:pli-1'
+                    classNames={['shrink-0 pli-2 pointer-fine:pli-1', hoverableControlItem]}
                     {...(!navigationSidebarOpen && { tabIndex: -1 })}
                   >
                     <DotsThreeVertical className={getSize(4)} />

--- a/packages/ui/aurora-theme/src/styles/fragments/hover.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/hover.ts
@@ -17,3 +17,4 @@ export const hoverableFocusedControls = 'focus:[--controls-opacity:1]';
 export const staticHoverableControls = 'hover-hover:[--controls-opacity:1]';
 
 export const hoverableControlItem = 'opacity-[--controls-opacity]';
+export const hoverableOpenControlItem = 'hover-hover:data-[state=open]:[--controls-opacity:1]';

--- a/packages/ui/aurora-theme/src/styles/fragments/hover.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/hover.ts
@@ -7,3 +7,13 @@
  */
 export const hoverColors =
   'transition-colors duration-100 linear hover:text-black dark:hover:text-white hover:bg-neutral-25 dark:hover:bg-neutral-750';
+
+export const hoverableControls =
+  '[--controls-opacity:1] hover-hover:[--controls-opacity:.1] hover-hover:hover:[--controls-opacity:1]';
+
+export const hoverableFocusedKeyboardControls = 'focus-visible:[--controls-opacity:1]';
+export const hoverableFocusedWithinControls = 'focus-within:[--controls-opacity:1]';
+export const hoverableFocusedControls = 'focus:[--controls-opacity:1]';
+export const staticHoverableControls = 'hover-hover:[--controls-opacity:1]';
+
+export const hoverableControlItem = 'opacity-[--controls-opacity]';


### PR DESCRIPTION
This PR moves Stack’s hoverable controls upstream and applies them in TreeView.

https://github.com/dxos/dxos/assets/855039/b8e86401-4fb2-4717-a23b-0bfab79506df

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f384ff9</samp>

### Summary
🎨🛠️🌲

<!--
1.  🎨 for the first change, since it is related to styling and theming.
2.  🛠️ for the second change, since it is related to refactoring and improving existing code.
3.  🌲 for the third change, since it is related to the tree view plugin. Alternatively, 🖱️ could be used to indicate the hoverable controls feature.
-->
The pull request improves the style and accessibility of the stack and tree view plugins by using style fragments from the `aurora-theme` package. It refactors the stack section controls and the tree view items to use the hover fragments, and defines the hover fragments in `hover.ts`.

> _Hoverable controls_
> _`aurora-theme` styles them_
> _Trees glow in winter_

### Walkthrough
*  Import and apply style fragments from `aurora-theme` to implement hoverable controls for stack sections and tree items ([link](https://github.com/dxos/dxos/pull/3967/files?diff=unified&w=0#diff-fa811210dd3f7913e00597826eaacecf8519c609181318183780bd9c09402594L13-R25), [link](https://github.com/dxos/dxos/pull/3967/files?diff=unified&w=0#diff-e700eace56b0e8dc83f2925205cefb12dbcf40c101ca6cf27b0b45c7c4bb22d7L13-R22), [link](https://github.com/dxos/dxos/pull/3967/files?diff=unified&w=0#diff-1c9fb58e48b6efbac0a8880c285b4ca52603b9f8341bd53b481ab082362ea081R10-R20)).


