### PR TITLE
fix(plugin-treeview): TreeItem inherent size

### DIFF
--- a/packages/apps/plugins/plugin-treeview/src/components/NavTree/CollapsibleHeading.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/NavTree/CollapsibleHeading.tsx
@@ -45,7 +45,7 @@ export const CollapsibleHeading = ({ open, node, level, active }: SharedTreeItem
     <TreeItem.OpenTrigger
       {...(disabled && { disabled, 'aria-disabled': true })}
       {...(!navigationSidebarOpen && { tabIndex: -1 })}
-      classNames={['grow flex items-center gap-1 pie-1', ghostButtonColors, disabled && staticDisabled]}
+      classNames={['flex items-center gap-1 pie-1', navTreeHeading, ghostButtonColors, disabled && staticDisabled]}
     >
       <OpenTriggerIcon weight='fill' className={mx('shrink-0', getSize(2))} />
       {node.icon && <node.icon className={getSize(4)} />}

--- a/packages/apps/plugins/plugin-treeview/src/components/NavTree/navtree-fragments.ts
+++ b/packages/apps/plugins/plugin-treeview/src/components/NavTree/navtree-fragments.ts
@@ -19,7 +19,7 @@ export const levelPadding = (level: number) => {
   }
 };
 
-export const navTreeHeading = 'flex-1 min-is-0 truncate text-start';
+export const navTreeHeading = 'flex-1 is-0 truncate text-start';
 
 export const collapsibleSpacing = 'pbs-2.5 pointer-fine:pbs-1.5';
 export const topLevelCollapsibleSpacing = 'pbs-2.5 pointer-fine:pbs-1.5';


### PR DESCRIPTION
<img width="291" alt="Screenshot 2023-08-24 at 00 59 12" src="https://github.com/dxos/dxos/assets/855039/9d6ab1d3-5147-4b73-a9cd-9497cd53e61f">

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 412ef81</samp>

### Summary
🐛🎨🚫

<!--
1.  🐛 - This emoji represents a bug fix, which is what the change to the `is-0` class was intended to do.
2.  🎨 - This emoji represents a style or design improvement, which is what the change to the `navTreeHeading` class was intended to do.
3.  🚫 - This emoji represents a removal or deletion, which is what the change to the `grow` class was intended to do.
-->
Fixed layout issues with the `CollapsibleHeading` component in the `plugin-treeview` app. Adjusted the CSS classes to prevent the heading from expanding or overflowing its container when the sidebar is collapsed.

> _`grow` class is gone_
> _`navTreeHeading` adjusts_
> _to sidebar's width - fall_

### Walkthrough
*  Prevent heading from expanding beyond container when sidebar is collapsed by removing `grow` class and adding `navTreeHeading` class ([link](https://github.com/dxos/dxos/pull/3973/files?diff=unified&w=0#diff-afc3fa3dd0c7631c7729d69fc8203e200167b752e767503034c125da5f49d93bL48-R48))
*  Fix heading text overflow by replacing `min-is-0` with `is-0` in `navTreeHeading` class in `navtree-fragments.ts` ([link](https://github.com/dxos/dxos/pull/3973/files?diff=unified&w=0#diff-27875280e223374457f5093a9ae3863f351346383c1c557bcb521e986841fa89L22-R22))


