### PR TITLE
feat: progressive multiplayer

### DIFF
--- a/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
+++ b/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
@@ -40,6 +40,9 @@ export const ClientPlugin = (
     },
     init: async () => {
       await client.initialize();
+      if (!client.halo.identity.get()) {
+        await client.halo.createIdentity();
+      }
 
       return {
         client,

--- a/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
@@ -29,7 +29,7 @@ import { NavTreeItem } from './NavTree';
 export const TreeViewContainer = () => {
   const { graph } = useGraph();
 
-  const identity = useIdentity({ login: true });
+  const identity = useIdentity();
   const jdenticon = useJdenticonHref(identity?.identityKey.toHex() ?? '', 24);
   const { t } = useTranslation(TREE_VIEW_PLUGIN);
   const { navigationSidebarOpen } = useSidebars(TREE_VIEW_PLUGIN);

--- a/packages/sdk/react-client/src/client/useShellProvider.ts
+++ b/packages/sdk/react-client/src/client/useShellProvider.ts
@@ -2,14 +2,14 @@
 // Copyright 2023 DXOS.org
 //
 
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { PublicKey } from '@dxos/client';
 import { IFrameClientServicesHost, IFrameClientServicesProxy } from '@dxos/client/services';
 
 import { useClient } from './ClientContext';
 
-export type UseShellProviderOptions = {
+export type UseShellOptions = {
   /**
    * The key of the current space.
    *
@@ -28,10 +28,14 @@ export type UseShellProviderOptions = {
   onInvalidatedInvitationCode?: (code?: string) => void;
 };
 
+type UseShellResult = {
+  setLayout: IFrameClientServicesProxy['setLayout'];
+};
+
 /**
  * Use this hook to fully integrate an app with the shell.
  */
-export const useShellProvider = ({ spaceKey, onJoinedSpace, onInvalidatedInvitationCode }: UseShellProviderOptions) => {
+export const useShell = ({ spaceKey, onJoinedSpace, onInvalidatedInvitationCode }: UseShellOptions): UseShellResult => {
   const client = useClient();
 
   useEffect(() => {
@@ -57,4 +61,17 @@ export const useShellProvider = ({ spaceKey, onJoinedSpace, onInvalidatedInvitat
       client.services.setSpaceProvider(() => spaceKey);
     }
   }, [spaceKey]);
+
+  const setLayout: IFrameClientServicesProxy['setLayout'] = useCallback(
+    async (layout, options = {}) => {
+      if (client.services instanceof IFrameClientServicesProxy || client.services instanceof IFrameClientServicesHost) {
+        await client.services.setLayout(layout, options);
+      }
+    },
+    [client],
+  );
+
+  return {
+    setLayout,
+  };
 };

--- a/packages/sdk/react-client/src/halo/useIdentity.ts
+++ b/packages/sdk/react-client/src/halo/useIdentity.ts
@@ -2,9 +2,7 @@
 // Copyright 2020 DXOS.org
 //
 
-import { useEffect, useSyncExternalStore } from 'react';
-
-import { ShellLayout, IFrameClientServicesHost, IFrameClientServicesProxy } from '@dxos/client/services';
+import { useSyncExternalStore } from 'react';
 
 import { useClient } from '../client';
 
@@ -12,9 +10,7 @@ import { useClient } from '../client';
  * Hook returning DXOS identity object.
  * Requires ClientContext to be set via ClientProvider.
  */
-export const useIdentity = (options?: { login?: boolean }) => {
-  const { login } = { login: true, ...options };
-
+export const useIdentity = () => {
   const client = useClient();
   const identity = useSyncExternalStore(
     (listener) => {
@@ -23,23 +19,6 @@ export const useIdentity = (options?: { login?: boolean }) => {
     },
     () => client.halo.identity.get(),
   );
-
-  useEffect(() => {
-    // TODO(wittjosiah): Allow path/params for invitations to be customizable.
-    const searchParams = new URLSearchParams(window.location.search);
-    const spaceInvitationCode = searchParams.get('spaceInvitationCode');
-    const deviceInvitationCode = searchParams.get('deviceInvitationCode');
-
-    if (
-      login &&
-      !identity &&
-      !spaceInvitationCode &&
-      !deviceInvitationCode &&
-      (client.services instanceof IFrameClientServicesProxy || client.services instanceof IFrameClientServicesHost)
-    ) {
-      void client.services.setLayout(ShellLayout.INITIALIZE_IDENTITY);
-    }
-  }, [client, identity, login]);
 
   return identity;
 };

--- a/packages/sdk/react-shell/src/composites/Shell/ShellContext.tsx
+++ b/packages/sdk/react-shell/src/composites/Shell/ShellContext.tsx
@@ -21,7 +21,7 @@ import {
   ShellLayout,
   IFrameClientServicesHost,
   useClient,
-  useShellProvider,
+  useShell as useShellNatural,
   LayoutRequest,
 } from '@dxos/react-client';
 import type { Space } from '@dxos/react-client/echo';
@@ -87,7 +87,7 @@ export const ShellProvider = ({
   // IFrame Shell
   //
 
-  useShellProvider({ spaceKey: space?.key, onJoinedSpace });
+  useShellNatural({ spaceKey: space?.key, onJoinedSpace });
 
   //
   // Component Shell

--- a/packages/sdk/react-shell/src/panels/IdentityPanel/IdentityPanelProps.ts
+++ b/packages/sdk/react-shell/src/panels/IdentityPanel/IdentityPanelProps.ts
@@ -13,7 +13,7 @@ import { IdentityEvent } from './identityMachine';
 
 export type IdentityPanelImplProps = {
   titleId: string;
-  activeView: 'device manager' | 'device invitation manager' | 'identity action chooser';
+  activeView: 'device manager' | 'update profile input' | 'device invitation manager' | 'identity action chooser';
   identity: Identity;
   createInvitationUrl: (invitationCode: string) => string;
   send?: (event: SingleOrArray<Event<IdentityEvent>>) => void;

--- a/packages/sdk/react-shell/src/panels/IdentityPanel/identityMachine.ts
+++ b/packages/sdk/react-shell/src/panels/IdentityPanel/identityMachine.ts
@@ -82,8 +82,8 @@ const identityMachine = createMachine<IdentityMachineContext, IdentityEvent>(
       noProfile: ({ identity }, _event) => !identity?.profile,
     },
     actions: {
-      setIdentity: assign<IdentityMachineContext, SetIdentityEvent>({
-        identity: (context, event) => event.identity,
+      setIdentity: assign<IdentityMachineContext, IdentityEvent>({
+        identity: (context, event) => (event as SetIdentityEvent)?.identity ?? null,
       }),
       setInvitation: assign<IdentityMachineContext, IdentityEvent>({
         invitation: (context, event) => (event as IdentitySelectDeviceInvitationEvent)?.invitation ?? null,

--- a/packages/sdk/react-shell/src/panels/IdentityPanel/steps/IdentityActionChooser.tsx
+++ b/packages/sdk/react-shell/src/panels/IdentityPanel/steps/IdentityActionChooser.tsx
@@ -44,6 +44,7 @@ export type IdentityActionChooserImplProps = IdentityActionChooserProps & {
 export const IdentityActionChooserImpl = ({
   onCreateInvitationClick,
   active,
+  send,
   onDone,
   doneActionParent,
 }: IdentityActionChooserImplProps) => {
@@ -68,12 +69,7 @@ export const IdentityActionChooserImpl = ({
             <span className='grow mli-3'>{t('choose devices label')}</span>
             <CaretRight weight='bold' className={getSize(4)} />
           </Button>
-          <Button
-            disabled
-            data-testid='manage-profile'
-            onClick={() => {} /* send({ type: 'chooseProfile' }) */}
-            classNames='plb-4'
-          >
+          <Button data-testid='manage-profile' onClick={() => send?.({ type: 'chooseProfile' })} classNames='plb-4'>
             <UserGear className={getSize(6)} />
             <span className='grow mli-3'>{t('choose profile label')}</span>
             <CaretRight weight='bold' className={getSize(4)} />

--- a/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanel.stories.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanel.stories.tsx
@@ -6,9 +6,9 @@ import '@dxosTheme';
 import React from 'react';
 
 import { StorybookDialog } from '../../components/StorybookDialog';
+import { IdentityInputImpl } from '../../steps';
 import { JoinPanelImpl } from './JoinPanel';
 import { JoinPanelImplProps } from './JoinPanelProps';
-import { IdentityInputImpl } from './steps';
 
 const noOpProps: JoinPanelImplProps = {
   titleId: 'storybookJoinPanel__title',

--- a/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanelProps.ts
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanelProps.ts
@@ -8,9 +8,8 @@ import type { Identity } from '@dxos/react-client/halo';
 import type { Invitation } from '@dxos/react-client/invitations';
 import { type AuthenticatingInvitationObservable, InvitationResult } from '@dxos/react-client/invitations';
 
-import { StepProps } from '../../steps';
+import { StepProps, IdentityInputProps } from '../../steps';
 import { JoinSend } from './joinMachine';
-import { IdentityInputProps } from './steps';
 
 export type JoinPanelMode = 'default' | 'halo-only';
 

--- a/packages/sdk/react-shell/src/panels/JoinPanel/index.ts
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/index.ts
@@ -2,5 +2,5 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './JoinPanel';
+export { JoinPanel } from './JoinPanel';
 export * from './JoinPanelProps';

--- a/packages/sdk/react-shell/src/panels/JoinPanel/joinMachine.ts
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/joinMachine.ts
@@ -18,7 +18,7 @@ import { JoinPanelMode } from './JoinPanelProps';
 type JoinMachineContext = {
   mode: JoinPanelMode;
   identity: Identity | null;
-  identitySubscribable: Subscribable<IdentityEvent> | null;
+  identitySubscribable: Subscribable<SetIdentityEvent> | null;
   halo: InvitationKindContext;
   space: InvitationKindContext;
 };

--- a/packages/sdk/react-shell/src/panels/JoinPanel/joinMachine.ts
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/joinMachine.ts
@@ -504,12 +504,12 @@ const useJoinMachine = (
     },
     actions: {
       ...options?.actions,
-      redeemHaloInvitationCode: assign<JoinMachineContext>({ halo: redeemHaloInvitationCode }),
-      redeemSpaceInvitationCode: assign<JoinMachineContext>({ space: redeemSpaceInvitationCode }),
-      invalidateHaloInvitationCode: assign<JoinMachineContext>({
+      redeemHaloInvitationCode: assign<JoinMachineContext, JoinEvent>({ halo: redeemHaloInvitationCode }),
+      redeemSpaceInvitationCode: assign<JoinMachineContext, JoinEvent>({ space: redeemSpaceInvitationCode }),
+      invalidateHaloInvitationCode: assign<JoinMachineContext, JoinEvent>({
         halo: invalidateHaloInvitationCode,
       }),
-      invalidateSpaceInvitationCode: assign<JoinMachineContext>({
+      invalidateSpaceInvitationCode: assign<JoinMachineContext, JoinEvent>({
         space: invalidateSpaceInvitationCode,
       }),
     },

--- a/packages/sdk/react-shell/src/panels/JoinPanel/steps/IdentityAdded.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/steps/IdentityAdded.tsx
@@ -60,7 +60,7 @@ export const IdentityAdded = (props: IdentityAddedProps) => {
           <Action
             variant='primary'
             disabled={disabled || !addedIdentity}
-            onClick={() => addedIdentity && send({ type: 'selectIdentity', identity: addedIdentity })}
+            onClick={() => addedIdentity && send({ type: 'setIdentity', identity: addedIdentity })}
             data-autofocus='confirmingAddedIdentity'
           >
             {t('continue label')}

--- a/packages/sdk/react-shell/src/panels/JoinPanel/steps/index.ts
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/steps/index.ts
@@ -4,7 +4,6 @@
 
 export * from './AdditionMethodChooser';
 export * from './IdentityAdded';
-export * from './IdentityInput';
 export * from './InvitationAccepted';
 export * from './InvitationInput';
 export * from './InvitationRescuer';

--- a/packages/sdk/react-shell/src/panels/SpacePanel/spaceMachine.ts
+++ b/packages/sdk/react-shell/src/panels/SpacePanel/spaceMachine.ts
@@ -72,8 +72,8 @@ const spaceMachine = createMachine<SpaceMachineContext, SpaceEvent>(
       noProfile: ({ identity }, _event) => !identity?.profile,
     },
     actions: {
-      setIdentity: assign<SpaceMachineContext, SetIdentityEvent>({
-        identity: (context, event) => event.identity,
+      setIdentity: assign<SpaceMachineContext, SpaceEvent>({
+        identity: (context, event) => (event as SetIdentityEvent)?.identity ?? null,
       }),
       setInvitation: assign<SpaceMachineContext, SpaceEvent>({
         invitation: (context, event) => (event as SpaceSelectInvitationEvent)?.invitation ?? null,

--- a/packages/sdk/react-shell/src/steps/IdentityInput.tsx
+++ b/packages/sdk/react-shell/src/steps/IdentityInput.tsx
@@ -25,7 +25,7 @@ export type SetDisplayNameEvent = {
 };
 
 export interface IdentityCreatorProps extends Omit<StepProps, 'send'> {
-  send: (event: SingleOrArray<Event<IdentityEvent>>) => void;
+  send?: (event: SingleOrArray<Event<IdentityEvent>>) => void;
   method: 'recover identity' | 'create identity';
 }
 
@@ -44,7 +44,7 @@ export const IdentityInput = (props: IdentityInputProps) => {
   const { t } = useTranslation('os');
   const [validationMessage, setValidationMessage] = useState('');
   const createIdentity = (displayName: string) => {
-    send({ type: 'setDisplayName' });
+    send?.({ type: 'setDisplayName' });
 
     const result = identity
       ? client.halo.updateProfile({ displayName })

--- a/packages/sdk/react-shell/src/steps/index.ts
+++ b/packages/sdk/react-shell/src/steps/index.ts
@@ -2,5 +2,6 @@
 // Copyright 2023 DXOS.org
 //
 
+export * from './IdentityInput';
 export * from './InvitationManager';
 export * from './StepProps';

--- a/packages/sdk/react-shell/src/stories/Invitations.stories.tsx
+++ b/packages/sdk/react-shell/src/stories/Invitations.stories.tsx
@@ -9,6 +9,7 @@ import React, { useMemo, useState } from 'react';
 
 import { Button, ButtonGroup, List } from '@dxos/aurora';
 import { getSize } from '@dxos/aurora-theme';
+import { log } from '@dxos/log';
 import { Group } from '@dxos/react-appkit';
 import { useClient } from '@dxos/react-client';
 import { Space, SpaceMember, SpaceProxy, useSpaces } from '@dxos/react-client/echo';
@@ -19,6 +20,8 @@ import { ClientDecorator } from '@dxos/react-client/testing';
 
 import { IdentityListItem, SpaceListItem } from '../components';
 import { IdentityPanel, JoinPanel, SpacePanel } from '../panels';
+
+log.config({ filter: 'debug' });
 
 export default {
   title: 'Invitations',
@@ -133,7 +136,7 @@ const Invitations = ({ id }: { id: number }) => {
     <ButtonGroup classNames='mbe-4'>
       {/* <Tooltip content='Create Identity'> */}
       <Button
-        onClick={() => client.halo.createIdentity({ displayName: faker.person.firstName() })}
+        onClick={() => client.halo.createIdentity()}
         disabled={Boolean(identity)}
         data-testid='invitations.create-identity'
       >


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7cf6e7c</samp>

### Summary
🎨🐛♻️

<!--
1.  🎨 - This emoji represents changes related to improving the UI or UX of the app, such as moving or refactoring components, changing the layout or design, or adding new features. This emoji could apply to the changes that moved the `IdentityInput` component to a separate view, refactored the `useShell` hook, or reordered the imports.
2. 🐛 - This emoji represents changes related to fixing bugs or errors in the app, such as removing unused imports, simplifying the `useIdentity` hook, or adding logging for debugging. This emoji could apply to the changes that removed the `IdentityInput` export from the `steps` folder, simplified the `useIdentity` hook, or added logging in `Invitations.stories.tsx`.
3. ♻️ - This emoji represents changes related to refactoring or improving the code quality or performance of the app, such as renaming or replacing hooks, using `useCallback` to optimize the hook performance, or using a `Subscribable` of `IdentityEvent` instead of a single `identity` property. This emoji could apply to the changes that renamed and replaced the `useShell` hook, used `useCallback` in the `useIdentity` hook, or refactored the join machine and the identity selection logic.
-->
This pull request improves the identity management and shell layout features of the `react-client` and `react-shell` packages. It renames and refactors some hooks and components, such as `useShell`, `useIdentity`, and `IdentityInput`, to make them more consistent and efficient. It also adds a new state and view for updating the profile of the selected identity in the `JoinPanel`. Additionally, it fixes some minor issues with imports, exports, and logging.

> _We're refactoring the code, me hearties, yo ho ho_
> _We're moving `IdentityInput` to and fro_
> _We're simplifying the hooks and the events, one, two, three_
> _We're making the shell layout more flexible, yo ho ho_

### Walkthrough
*  Simplify `useIdentity` hook to not accept any options and remove layout setting ([link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-987a2a923f8ae8e26fa29a4d252adb81a01c7de98baeba46a8930433f192144aL5-R6),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-987a2a923f8ae8e26fa29a4d252adb81a01c7de98baeba46a8930433f192144aL15-R13),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-987a2a923f8ae8e26fa29a4d252adb81a01c7de98baeba46a8930433f192144aL27-L43),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-2d39365b754c6a396cbee16332fda4338cbd7f5f39ae25b329d5a8973889443fL18),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-2d39365b754c6a396cbee16332fda4338cbd7f5f39ae25b329d5a8973889443fL168),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-2d39365b754c6a396cbee16332fda4338cbd7f5f39ae25b329d5a8973889443fL175),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-2d39365b754c6a396cbee16332fda4338cbd7f5f39ae25b329d5a8973889443fL359),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-4fe995e770811fb1d5b454e94f4e1139813726495b97449fc121681d5889ebb6L6-R28),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-4fe995e770811fb1d5b454e94f4e1139813726495b97449fc121681d5889ebb6L29-R56))
* Rename `useShellProvider` hook to `useShell` and add `setLayout` function to set shell layout from app ([link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-0c6fbddd4b4f8f2ade0fbac825d5454cf5970358a0159dc5f00c58ab87e6a02eL5-R5),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-0c6fbddd4b4f8f2ade0fbac825d5454cf5970358a0159dc5f00c58ab87e6a02eL12-R12),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-0c6fbddd4b4f8f2ade0fbac825d5454cf5970358a0159dc5f00c58ab87e6a02eL31-R38),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-0c6fbddd4b4f8f2ade0fbac825d5454cf5970358a0159dc5f00c58ab87e6a02eR64-R76),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-a82d8cbfffaf2844695ea76779d9beb58ebc739a2ff03775e714503694771b89L24-R24),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-a82d8cbfffaf2844695ea76779d9beb58ebc739a2ff03775e714503694771b89L90-R90))
* Change `joinMachine` to invoke `identitySubscribable` from context and add `managingProfile` state to handle identity events ([link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4L15-R24),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4L27-R35),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4L261-R258),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4L270-R279),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4R299),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4R311-R321),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4L320-R341),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4R497-R504))
* Add `IdentityInput` component to root of `react-shell` package and use it to render identity input view in `JoinPanel` ([link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-2d39365b754c6a396cbee16332fda4338cbd7f5f39ae25b329d5a8973889443fL9-R12),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-2d39365b754c6a396cbee16332fda4338cbd7f5f39ae25b329d5a8973889443fR51-R53),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-2d39365b754c6a396cbee16332fda4338cbd7f5f39ae25b329d5a8973889443fR204-R205),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-64b7ce2768821faee44e83c757f9c0a752c598baa2e641849d51d21bca26b66cL7),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-4fe995e770811fb1d5b454e94f4e1139813726495b97449fc121681d5889ebb6L6-R28),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-4fe995e770811fb1d5b454e94f4e1139813726495b97449fc121681d5889ebb6L29-R56),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-4fe995e770811fb1d5b454e94f4e1139813726495b97449fc121681d5889ebb6L47-R63),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-4fe995e770811fb1d5b454e94f4e1139813726495b97449fc121681d5889ebb6L70-R86),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-6a00f880ba4756849f592a7e7018f5305b846b0328c565821d5fdbec537932fbR5))
* Change `JoinPanel` export to a named export instead of a wildcard export ([link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-78ff8def99b63e542956dbce9768c3241f4c0b8241f20450449ad31a3f4dd1cbL5-R5))
* Reorder imports alphabetically in `JoinPanel.stories.tsx` ([link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-9912049b4906c3a58dbee26892246ef1d9cb32e00ad547cc7e38a955d6f53fe0L9-R11))
* Add empty line to `JoinPanel.tsx` for formatting ([link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-2d39365b754c6a396cbee16332fda4338cbd7f5f39ae25b329d5a8973889443fR4))
* Simplify `useIdentity` hook in `plugin-treeview` to not require `login` option ([link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-5d68768eb04820eb8435d0b29071f52fe7cac46252e1527ffae2d7db10938815L32-R32))
* Add `log` import and `log.config` function to `Invitations.stories.tsx` for debugging ([link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-6c8185a1cee3d2c5921f5a83f2cb626f3f9c343f4349da31f32e8778cc9f3a5aR12),[link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-6c8185a1cee3d2c5921f5a83f2cb626f3f9c343f4349da31f32e8778cc9f3a5aR24-R25))
* Change `onClick` handler for create identity button in `Invitations` component to not pass display name ([link](https://github.com/dxos/dxos/pull/3976/files?diff=unified&w=0#diff-6c8185a1cee3d2c5921f5a83f2cb626f3f9c343f4349da31f32e8778cc9f3a5aL136-R139))


