### PR TITLE
feat(echo): Merge mutations before writing them into feed

### DIFF
--- a/packages/core/echo/echo-db/package.json
+++ b/packages/core/echo/echo-db/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@dxos/feed-store": "workspace:*",
+    "@dxos/text-model": "workspace:*",
     "@dxos/typings": "workspace:*"
   },
   "publishConfig": {

--- a/packages/core/echo/echo-db/src/packlets/database/builder.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/builder.ts
@@ -12,11 +12,11 @@ import { EchoObject, EchoObjectBatch, MutationMeta } from '@dxos/protocols/proto
 export const tagMutationsInBatch = (batch: EchoObjectBatch, tag: string, startingIndex: number) => {
   batch.objects?.forEach((object, objectIndex) => {
     object.meta ??= {};
-    object.meta.clientTag = `${tag}:${objectIndex}`;
+    object.meta.clientTag = [`${tag}:${objectIndex}`];
 
     object.mutations?.forEach((mutation, mutationIndex) => {
       mutation.meta ??= {};
-      mutation.meta.clientTag = `${tag}:${objectIndex + startingIndex}:${mutationIndex}`;
+      mutation.meta.clientTag = [`${tag}:${objectIndex + startingIndex}:${mutationIndex}`];
     });
   });
 };

--- a/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
@@ -289,7 +289,7 @@ export class DatabaseProxy {
 
     this._service
       .write({
-        batch: batch.data,
+        batch: this._itemManager.mergeMutations(batch.data),
         spaceKey: this._spaceKey,
         clientTag: batch.clientTag!,
       })

--- a/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
@@ -308,14 +308,16 @@ export class DatabaseProxy {
   }
 
   async batchCycle() {
+    let created = false;
     if (!this._currentBatch) {
-      this.beginBatch();
+      created = this.beginBatch();
     }
 
     await cancelWithContext(this._ctx, sleep(BATCH_INTERVAL));
 
-    if (this._currentBatch?.data.objects?.length !== 0) {
+    if (this._currentBatch?.data.objects?.length !== 0 && created) {
       this.commitBatch();
+      created = false;
     }
   }
 

--- a/packages/core/echo/echo-db/src/packlets/database/item-manager.test.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/item-manager.test.ts
@@ -39,6 +39,7 @@ describe('ItemManager', () => {
       expect(itemManager.entities.size).toEqual(0);
     });
   });
+
   describe.skip('parent-child relationship', () => {
     test('can be constructed and will have correct references', async () => {
       const modelFactory = new ModelFactory().registerModel(DocumentModel);

--- a/packages/core/echo/echo-db/src/packlets/database/item-manager.test.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/item-manager.test.ts
@@ -8,7 +8,9 @@ import { DocumentModel } from '@dxos/document-model';
 import { PublicKey } from '@dxos/keys';
 import { ModelFactory } from '@dxos/model-factory';
 import { describe, test } from '@dxos/test';
+import { Doc, TextModel } from '@dxos/text-model';
 
+import { createModelMutation, encodeModelMutation } from './builder';
 import { ItemConstructionOptions, ItemManager } from './item-manager';
 
 describe('ItemManager', () => {
@@ -37,6 +39,25 @@ describe('ItemManager', () => {
 
       itemManager.deconstructItem(item.id);
       expect(itemManager.entities.size).toEqual(0);
+    });
+  });
+
+  describe('mutations merging', () => {
+    test('merge two EchoObjects with single mutation in them', async () => {
+      const modelFactory = new ModelFactory().registerModel(TextModel);
+      const itemManager = new ItemManager(modelFactory);
+
+      const itemId = PublicKey.random().toHex();
+
+      const item = itemManager.constructItem({
+        itemId,
+        modelType: TextModel.meta.type,
+      });
+
+      doc = new Doc();
+      doc.
+
+      const batch = createModelMutation(itemId, encodeModelMutation(item.modelMeta!, mutation));
     });
   });
 

--- a/packages/core/echo/echo-db/src/packlets/database/item-manager.test.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/item-manager.test.ts
@@ -8,9 +8,7 @@ import { DocumentModel } from '@dxos/document-model';
 import { PublicKey } from '@dxos/keys';
 import { ModelFactory } from '@dxos/model-factory';
 import { describe, test } from '@dxos/test';
-import { Doc, TextModel } from '@dxos/text-model';
 
-import { createModelMutation, encodeModelMutation } from './builder';
 import { ItemConstructionOptions, ItemManager } from './item-manager';
 
 describe('ItemManager', () => {
@@ -41,26 +39,6 @@ describe('ItemManager', () => {
       expect(itemManager.entities.size).toEqual(0);
     });
   });
-
-  describe('mutations merging', () => {
-    test('merge two EchoObjects with single mutation in them', async () => {
-      const modelFactory = new ModelFactory().registerModel(TextModel);
-      const itemManager = new ItemManager(modelFactory);
-
-      const itemId = PublicKey.random().toHex();
-
-      const item = itemManager.constructItem({
-        itemId,
-        modelType: TextModel.meta.type,
-      });
-
-      doc = new Doc();
-      doc.
-
-      const batch = createModelMutation(itemId, encodeModelMutation(item.modelMeta!, mutation));
-    });
-  });
-
   describe.skip('parent-child relationship', () => {
     test('can be constructed and will have correct references', async () => {
       const modelFactory = new ModelFactory().registerModel(DocumentModel);

--- a/packages/core/echo/echo-db/src/packlets/database/item-manager.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/item-manager.ts
@@ -140,9 +140,6 @@ export class ItemManager {
     if (!mutations.objects) {
       return mutations;
     }
-
-    log.info('Merging mutations:', { objects: mutations.objects });
-
     // Get batch of mutations per item.
     // [(objectId=1), (objectId=1), (objectId=2), (objectId=1)] -> [[(objectId=1), (objectId=1)], [(objectId=2)], [(objectId=1)]]
     const itemsMutations: EchoObject[][] = mutations.objects?.reduce(
@@ -190,7 +187,7 @@ export class ItemManager {
                       invariant(!m.meta!.memberKey);
                       invariant(!m.meta!.seq);
                       invariant(!m.meta!.timeframe);
-                      invariant(m.meta!.clientTag && m.meta?.clientTag?.length !== 0);
+                      invariant(m.meta!.clientTag && m.meta!.clientTag.length === 1);
                       return m.meta!.clientTag!;
                     }),
                   )
@@ -200,7 +197,7 @@ export class ItemManager {
             },
           ],
         };
-
+        log.info('merged mutation:', { newMutation });
         mutations[index] = newMutation;
       }
     }

--- a/packages/core/echo/echo-db/src/packlets/database/item-manager.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/item-manager.ts
@@ -2,12 +2,13 @@
 // Copyright 2020 DXOS.org
 //
 
+import { ProtoCodec } from '@dxos/codec-protobuf';
 import { failUndefined } from '@dxos/debug';
 import { invariant } from '@dxos/invariant';
 import { log, logInfo } from '@dxos/log';
 import { Model, ModelFactory, ModelType } from '@dxos/model-factory';
 import { ItemID } from '@dxos/protocols';
-import { EchoObject } from '@dxos/protocols/proto/dxos/echo/object';
+import { EchoObject, EchoObjectBatch } from '@dxos/protocols/proto/dxos/echo/object';
 
 import { Item } from './item';
 
@@ -130,5 +131,83 @@ export class ItemManager {
     invariant(model, 'Model not registered');
 
     item.initialize(model.constructor);
+  }
+
+  /**
+   * Merge mutations for the same items.
+   */
+  mergeMutations(mutations: EchoObjectBatch): EchoObjectBatch {
+    if (!mutations.objects) {
+      return mutations;
+    }
+
+    log.info('Merging mutations:', { objects: mutations.objects });
+
+    // Get batch of mutations per item.
+    // [(objectId=1), (objectId=1), (objectId=2), (objectId=1)] -> [[(objectId=1), (objectId=1)], [(objectId=2)], [(objectId=1)]]
+    const itemsMutations: EchoObject[][] = mutations.objects?.reduce(
+      (acc, mutation) => {
+        const itemMutations = acc.at(-1);
+        if (mutation.genesis || mutation.snapshot) {
+          acc.push([mutation]);
+        } else if (itemMutations?.[0]?.objectId === mutation.objectId) {
+          itemMutations.push(mutation);
+        } else {
+          acc.push([mutation]);
+        }
+        return acc;
+      },
+      [[]] as EchoObject[][],
+    );
+
+    // Merge mutations for each item.
+    for (const index in itemsMutations) {
+      const mutations = itemsMutations[index];
+      const item = this._entities.get(mutations[0]?.objectId);
+
+      if (typeof item?.modelMeta?.mergeMutations === 'function') {
+        const mergedMutation = (item.modelMeta.snapshotCodec as ProtoCodec).encodeAsAny(
+          item.modelMeta.mergeMutations(
+            mutations
+              .filter((mutation) => mutation.mutations)
+              .map((mutation) => mutation.mutations!.map((m) => item.modelMeta!.mutationCodec.decode(m.model.value)))
+              .flat(),
+          ),
+        );
+
+        const newMutation: EchoObject = {
+          genesis: mutations[0].genesis,
+          snapshot: mutations[0].snapshot,
+          objectId: mutations[0].objectId,
+          meta: mutations[0].meta,
+          mutations: [
+            {
+              meta: {
+                clientTag: mutations
+                  .map((mutation) =>
+                    mutation.mutations!.map((m) => {
+                      invariant(!m.meta!.feedKey);
+                      invariant(!m.meta!.memberKey);
+                      invariant(!m.meta!.seq);
+                      invariant(!m.meta!.timeframe);
+                      invariant(m.meta!.clientTag && m.meta?.clientTag?.length !== 0);
+                      return m.meta!.clientTag!;
+                    }),
+                  )
+                  .flat(2),
+              },
+              model: mergedMutation,
+            },
+          ],
+        };
+
+        mutations[index] = newMutation;
+      }
+    }
+
+    // Return flattened mutations.
+    return {
+      objects: itemsMutations.flat(),
+    };
   }
 }

--- a/packages/core/echo/echo-db/src/packlets/database/ordering.test.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/ordering.test.ts
@@ -123,7 +123,7 @@ const createMutation = (
       memberKey: feedKey,
       seq,
       timeframe,
-      clientTag,
+      clientTag: clientTag ? [clientTag] : undefined,
     },
     model: {
       type_url: 'test',
@@ -135,7 +135,7 @@ const createMutation = (
 const createOptimisticMutation = (clientTag: string): MutationInQueue => ({
   mutation: {
     meta: {
-      clientTag,
+      clientTag: [clientTag],
     },
     model: {
       type_url: 'test',

--- a/packages/core/echo/echo-db/src/packlets/database/ordering.test.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/ordering.test.ts
@@ -108,6 +108,30 @@ describe('Ordering', () => {
 
       expect(queue.getMutations().length).toEqual(2);
     });
+
+    test('pushing mutation with same tag throws', async () => {
+      const queue = new MutationQueue();
+
+      queue.pushOptimistic(createOptimisticMutation(['1', '2', '3', '4']));
+      expect(() => queue.pushOptimistic(createOptimisticMutation(['5', '6', '2', '7']))).toThrowError('2');
+    });
+
+    test('confirming mutation with more than one tag throws', async () => {
+      const queue = new MutationQueue();
+
+      queue.pushOptimistic(createOptimisticMutation(['1', '2', '3', '4']));
+      expect(() => queue.pushConfirmed(createMutation(feedA, 0, new Timeframe(), ['1', '2']))).toThrow();
+    });
+
+    test('mutation is confirmed if at one tag matches', async () => {
+      const queue = new MutationQueue();
+
+      const mutation = createOptimisticMutation(['1', '2', '3', '4']);
+      queue.pushOptimistic(mutation);
+      expect(queue.getConfirmedMutations().length).toEqual(0);
+      queue.pushConfirmed(createMutation(feedA, 0, new Timeframe(), ['2']));
+      expect(queue.getConfirmedMutations().length).toEqual(1);
+    });
   });
 });
 

--- a/packages/core/echo/echo-db/src/packlets/database/ordering.test.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/ordering.test.ts
@@ -69,7 +69,7 @@ describe('Ordering', () => {
 
       expect(queue.pushConfirmed(createMutation(feedA, 0, new Timeframe()))).toEqual({ reorder: false, apply: true });
       expect(queue.pushConfirmed(createMutation(feedA, 1, new Timeframe()))).toEqual({ reorder: false, apply: true });
-      expect(queue.pushConfirmed(createMutation(feedB, 0, new Timeframe(), 'unk'))).toEqual({
+      expect(queue.pushConfirmed(createMutation(feedB, 0, new Timeframe(), ['unk']))).toEqual({
         reorder: false,
         apply: true,
       });
@@ -81,14 +81,14 @@ describe('Ordering', () => {
     test('confirming optimistic mutations', () => {
       const queue = new MutationQueue();
 
-      queue.pushOptimistic(createOptimisticMutation('1'));
-      expect(queue.pushConfirmed(createMutation(feedA, 0, new Timeframe(), '1'))).toEqual({
+      queue.pushOptimistic(createOptimisticMutation(['1']));
+      expect(queue.pushConfirmed(createMutation(feedA, 0, new Timeframe(), ['1']))).toEqual({
         reorder: false,
         apply: false,
       });
 
-      queue.pushOptimistic(createOptimisticMutation('2'));
-      expect(queue.pushConfirmed(createMutation(feedA, 1, new Timeframe(), '2'))).toEqual({
+      queue.pushOptimistic(createOptimisticMutation(['2']));
+      expect(queue.pushConfirmed(createMutation(feedA, 1, new Timeframe(), ['2']))).toEqual({
         reorder: false,
         apply: false,
       });
@@ -99,9 +99,9 @@ describe('Ordering', () => {
     test('push confirmed under optimistic', () => {
       const queue = new MutationQueue();
 
-      queue.pushOptimistic(createOptimisticMutation('1'));
+      queue.pushOptimistic(createOptimisticMutation(['1']));
       expect(queue.pushConfirmed(createMutation(feedA, 0, new Timeframe()))).toEqual({ reorder: true, apply: true });
-      expect(queue.pushConfirmed(createMutation(feedB, 0, new Timeframe(), '1'))).toEqual({
+      expect(queue.pushConfirmed(createMutation(feedB, 0, new Timeframe(), ['1']))).toEqual({
         reorder: false,
         apply: false,
       });
@@ -115,7 +115,7 @@ const createMutation = (
   feedKey: PublicKey,
   seq: number,
   timeframe: Timeframe,
-  clientTag?: string,
+  clientTag?: string[],
 ): MutationInQueue => ({
   mutation: {
     meta: {
@@ -123,7 +123,7 @@ const createMutation = (
       memberKey: feedKey,
       seq,
       timeframe,
-      clientTag: clientTag ? [clientTag] : undefined,
+      clientTag,
     },
     model: {
       type_url: 'test',
@@ -132,10 +132,10 @@ const createMutation = (
   },
 });
 
-const createOptimisticMutation = (clientTag: string): MutationInQueue => ({
+const createOptimisticMutation = (clientTag: string[]): MutationInQueue => ({
   mutation: {
     meta: {
-      clientTag: [clientTag],
+      clientTag,
     },
     model: {
       type_url: 'test',

--- a/packages/core/echo/echo-db/src/packlets/database/ordering.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/ordering.ts
@@ -101,7 +101,10 @@ export class MutationQueue<T> {
     // Remove optimistic mutation from the queue.
     let optimisticIndex = -1;
     if (entry.mutation.meta!.clientTag) {
-      invariant(entry.mutation.meta!.clientTag.length === 1);
+      invariant(
+        entry.mutation.meta!.clientTag.length === 1,
+        `Multiple tags are not supported: ${entry.mutation.meta!.clientTag}`,
+      );
       optimisticIndex = this._optimistic.findIndex(
         (message) =>
           message.mutation.meta!.clientTag &&

--- a/packages/core/echo/echo-db/src/packlets/database/ordering.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/ordering.ts
@@ -100,7 +100,7 @@ export class MutationQueue<T> {
 
     // Remove optimistic mutation from the queue.
     let optimisticIndex = -1;
-    if (entry.mutation.meta!.clientTag) {
+    if (entry.mutation.meta!.clientTag && entry.mutation.meta!.clientTag.length > 0) {
       invariant(
         entry.mutation.meta!.clientTag.length === 1,
         `Multiple tags are not supported: ${entry.mutation.meta!.clientTag}`,

--- a/packages/core/echo/echo-db/src/packlets/database/ordering.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/ordering.ts
@@ -78,9 +78,11 @@ export class MutationQueue<T> {
    */
   pushOptimistic(entry: MutationInQueue<T>) {
     invariant(entry.mutation.meta!.clientTag);
+    invariant(entry.mutation.meta!.clientTag!.length !== 0);
     invariant(
-      this._optimistic.findIndex((message) => message.mutation.meta!.clientTag === entry.mutation.meta!.clientTag) ===
-        -1,
+      this._optimistic.findIndex((message) =>
+        message.mutation.meta!.clientTag!.find((tag) => entry.mutation.meta!.clientTag!.find((t) => t === tag)),
+      ) === -1,
       `Mutation with the same tag already exists: ${entry.mutation.meta!.clientTag}}`,
     );
     this._optimistic.push(entry);
@@ -97,12 +99,16 @@ export class MutationQueue<T> {
     invariant(entry.mutation.meta!.timeframe);
 
     // Remove optimistic mutation from the queue.
-    const optimisticIndex = !entry.mutation.meta!.clientTag
-      ? -1
-      : this._optimistic.findIndex(
-          (message) =>
-            message.mutation.meta!.clientTag && message.mutation.meta!.clientTag === entry.mutation.meta!.clientTag,
-        );
+    let optimisticIndex = -1;
+    if (entry.mutation.meta!.clientTag) {
+      invariant(entry.mutation.meta!.clientTag.length === 1);
+      optimisticIndex = this._optimistic.findIndex(
+        (message) =>
+          message.mutation.meta!.clientTag &&
+          message.mutation.meta!.clientTag.find((tag) => tag === entry.mutation.meta!.clientTag![0]),
+      );
+    }
+
     if (optimisticIndex !== -1) {
       this._optimistic.splice(optimisticIndex, 1);
     }

--- a/packages/core/echo/echo-db/tsconfig.json
+++ b/packages/core/echo/echo-db/tsconfig.json
@@ -59,6 +59,9 @@
     },
     {
       "path": "../model-factory"
+    },
+    {
+      "path": "../text-model"
     }
   ]
 }

--- a/packages/core/echo/echo-pipeline/src/tests/database-unit.test.ts
+++ b/packages/core/echo/echo-pipeline/src/tests/database-unit.test.ts
@@ -6,8 +6,10 @@ import expect from 'expect';
 
 import { DocumentModel, MutationBuilder, OrderedArray } from '@dxos/document-model';
 import { Item, createModelMutation, encodeModelMutation, genesisMutation } from '@dxos/echo-db';
+import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
 import { describe, test } from '@dxos/test';
+import { Doc, TextModel } from '@dxos/text-model';
 import { Timeframe } from '@dxos/timeframe';
 
 import { DatabaseTestBuilder } from '../testing/database-test-rig';
@@ -156,6 +158,42 @@ describe('database (unit)', () => {
       );
       await peer1.confirm();
       expect(model.get('tags').toArray()).toHaveLength(1);
+    });
+  });
+
+  describe('TextModel', () => {
+    test('insert', async () => {
+      const rig = new DatabaseTestBuilder();
+      const peer1 = await rig.createPeer();
+      const peer2 = await rig.createPeer();
+
+      const mutations = [];
+      const doc = new Doc();
+      doc.on('update', (update) => {
+        mutations.push(update);
+      });
+
+      const id = PublicKey.random().toHex();
+      peer1.proxy.mutate(genesisMutation(id, TextModel.meta.type));
+      const model = peer1.getModel(id);
+      invariant(model instanceof TextModel);
+      model.insert('Hello World!', 0);
+
+      await peer1.confirm();
+      await peer1.proxy.flush();
+
+      peer2.replicate(peer1.timeframe);
+      const replicatedItem = peer2.items.entities.get(id);
+      expect(replicatedItem).toBeDefined();
+      const replicatedModel = peer2.getModel(id)! as TextModel;
+      expect(replicatedModel.textContent).toBe('Hello World!');
+
+      replicatedModel.insert(' DXOS', 5);
+      await peer2.confirm();
+      await peer2.proxy.flush();
+
+      peer1.replicate(peer2.timeframe);
+      expect(model.textContent).toBe('Hello DXOS World!');
     });
   });
 

--- a/packages/core/echo/echo-pipeline/src/tests/database.test.ts
+++ b/packages/core/echo/echo-pipeline/src/tests/database.test.ts
@@ -58,6 +58,7 @@ describe('database', () => {
       const result = database.backend.mutate(genesisMutation(PublicKey.random().toHex(), DocumentModel.meta.type));
       expect(result.objectsUpdated.length).toEqual(1);
       expect(database.itemManager.entities.has(result.objectsUpdated[0].id));
+      database.backend.commitBatch();
 
       await result.batch.waitToBeProcessed();
       expect(database.itemManager.entities.has(result.objectsUpdated[0].id));
@@ -72,6 +73,7 @@ describe('database', () => {
         createModelMutation(id, encodeModelMutation(DocumentModel.meta, new MutationBuilder().set('test', 42).build())),
       );
       expect(database.itemManager.getItem(id)!.state.data.test).toEqual(42);
+      database.backend.commitBatch();
 
       await result.batch.waitToBeProcessed();
       expect(database.itemManager.getItem(id)!.state.data.test).toEqual(42);

--- a/packages/core/echo/model-factory/src/types.ts
+++ b/packages/core/echo/model-factory/src/types.ts
@@ -72,6 +72,9 @@ export type ModelMeta<TState = any, TMutation = any, TSnasphot = any> = {
   // Snapshot codecs are distinct from the mutation codecs.
   snapshotCodec?: Codec<TSnasphot>;
 
+  // Merge Mutations
+  mergeMutations?: (mutations: TMutation[]) => TMutation[];
+
   // Manages state and state transitions vis mutations.
   stateMachine: () => StateMachine<TState, TMutation, TSnasphot>;
 };

--- a/packages/core/echo/model-factory/src/types.ts
+++ b/packages/core/echo/model-factory/src/types.ts
@@ -73,7 +73,7 @@ export type ModelMeta<TState = any, TMutation = any, TSnasphot = any> = {
   snapshotCodec?: Codec<TSnasphot>;
 
   // Merge Mutations
-  mergeMutations?: (mutations: TMutation[]) => TMutation[];
+  mergeMutations?: (mutations: TMutation[]) => TMutation;
 
   // Manages state and state transitions vis mutations.
   stateMachine: () => StateMachine<TState, TMutation, TSnasphot>;

--- a/packages/core/echo/text-model/package.json
+++ b/packages/core/echo/text-model/package.json
@@ -19,7 +19,6 @@
   ],
   "dependencies": {
     "@dxos/codec-protobuf": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/invariant": "workspace:*",
     "@dxos/keys": "workspace:*",
     "@dxos/log": "workspace:*",

--- a/packages/core/echo/text-model/src/text-model.test.ts
+++ b/packages/core/echo/text-model/src/text-model.test.ts
@@ -4,6 +4,7 @@
 
 import { faker } from '@faker-js/faker';
 import expect from 'expect';
+import { Doc, applyUpdate } from 'yjs';
 
 import { MockFeedWriter } from '@dxos/feed-store/testing';
 import { PublicKey } from '@dxos/keys';
@@ -13,8 +14,42 @@ import { describe, test } from '@dxos/test';
 
 import { TextModel } from './text-model';
 
-describe.skip('TextModel', () => {
-  test('insert', async () => {
+describe('TextModel', () => {
+  test('mutations merging', async () => {
+    const updates: Uint8Array[] = [];
+    const field = 'content';
+
+    // Atomic updates.
+    {
+      const doc = new Doc();
+      doc.on('update', (update) => {
+        updates.push(update);
+      });
+
+      const content = doc.getText(field);
+      doc.transact(() => {
+        content.insert(0, 'Hello ');
+      });
+
+      doc.transact(() => {
+        content.insert(6, 'World!');
+      });
+
+      expect(updates.length).toBe(2);
+      expect(content.toString()).toBe('Hello World!');
+    }
+
+    // Merged updates.
+    {
+      const doc = new Doc();
+      const mergedMutation = TextModel.meta.mergeMutations!(updates.map((update) => ({ update })));
+      applyUpdate(doc, mergedMutation.update);
+      const content = doc.getText(field);
+      expect(content.toString()).toBe('Hello World!');
+    }
+  });
+
+  test.skip('insert', async () => {
     const rig = new TestBuilder(new ModelFactory().registerModel(TextModel), TextModel);
     const peer1 = rig.createPeer();
     const peer2 = rig.createPeer();
@@ -31,7 +66,7 @@ describe.skip('TextModel', () => {
     expect(peer1.model.textContent).toBe('Hello DXOS World!');
   });
 
-  test('insert a new text node', async () => {
+  test.skip('insert a new text node', async () => {
     const rig = new TestBuilder(new ModelFactory().registerModel(TextModel), TextModel);
     const peer1 = rig.createPeer();
 
@@ -50,7 +85,7 @@ describe.skip('TextModel', () => {
     expect(strigified2).toBe(`"<paragraph>${text1}</paragraph><paragraph>${text2}</paragraph>"`);
   });
 
-  test('snapshot', async () => {
+  test.skip('snapshot', async () => {
     const modelFactory = new ModelFactory().registerModel(TextModel);
     const model1 = modelFactory.createModel(
       TextModel.meta.type,
@@ -74,7 +109,7 @@ describe.skip('TextModel', () => {
     // expect(model2.model.textContent).toBe(text);
   });
 
-  test('conflict', async () => {
+  test.skip('conflict', async () => {
     const rig = new TestBuilder(new ModelFactory().registerModel(TextModel), TextModel);
     const peer1 = rig.createPeer();
     const peer2 = rig.createPeer();

--- a/packages/core/echo/text-model/src/text-model.test.ts
+++ b/packages/core/echo/text-model/src/text-model.test.ts
@@ -49,23 +49,7 @@ describe('TextModel', () => {
     }
   });
 
-  test.skip('insert', async () => {
-    const rig = new TestBuilder(new ModelFactory().registerModel(TextModel), TextModel);
-    const peer1 = rig.createPeer();
-    const peer2 = rig.createPeer();
-
-    peer1.model.insert('Hello World!', 0);
-
-    // await peer2.model.update.waitForCount(1);
-    expect(peer2.model.textContent).toBe('Hello World!');
-
-    // TODO(burdon): Test delete.
-    const words = peer1.model.textContent.split(' ');
-    peer2.model.insert(' DXOS', words[0].length);
-    // await peer1.model.update.waitForCount(1);
-    expect(peer1.model.textContent).toBe('Hello DXOS World!');
-  });
-
+  // TODO(mykola): transfer to @dxos/echo-pipeline database unit test
   test.skip('insert a new text node', async () => {
     const rig = new TestBuilder(new ModelFactory().registerModel(TextModel), TextModel);
     const peer1 = rig.createPeer();

--- a/packages/core/echo/text-model/tsconfig.json
+++ b/packages/core/echo/text-model/tsconfig.json
@@ -35,9 +35,6 @@
       "path": "../document-model"
     },
     {
-      "path": "../echo-db"
-    },
-    {
       "path": "../model-factory"
     }
   ]

--- a/packages/core/protocols/src/proto/dxos/echo/object.proto
+++ b/packages/core/protocols/src/proto/dxos/echo/object.proto
@@ -72,7 +72,7 @@ message MutationMeta {
   optional timeframe.TimeframeVector timeframe = 4;
 
   /// If this mutation was created by this client, this field will be set to the tag in the mutation.
-  optional string client_tag = 5;
+  repeated string client_tag = 5;
 }
 
 message EchoObjectBatch {

--- a/packages/sdk/client/src/testing/test-builder.ts
+++ b/packages/sdk/client/src/testing/test-builder.ts
@@ -133,6 +133,7 @@ export const testSpace = async (create: DatabaseProxy, check: DatabaseProxy = cr
   const objectId = PublicKey.random().toHex();
 
   const result = create.mutate(genesisMutation(objectId, DocumentModel.meta.type));
+  create.commitBatch();
 
   await result.batch.getReceipt();
   // TODO(dmaretskiy): await result.waitToBeProcessed()

--- a/packages/sdk/client/src/testing/test-builder.ts
+++ b/packages/sdk/client/src/testing/test-builder.ts
@@ -6,6 +6,7 @@ import { asyncTimeout, Trigger } from '@dxos/async';
 import { ClientServices } from '@dxos/client-protocol';
 import { ClientServicesHost } from '@dxos/client-services';
 import { Config } from '@dxos/config';
+import { Context } from '@dxos/context';
 import { raise } from '@dxos/debug';
 import { DocumentModel } from '@dxos/document-model';
 import { DatabaseProxy, genesisMutation } from '@dxos/echo-db';
@@ -40,6 +41,8 @@ export const testConfigWithLocalSignal = new Config({
  * Client builder supports different configurations, incl. signaling, transports, storage.
  */
 export class TestBuilder {
+  private readonly _ctx = new Context();
+
   public config: Config;
 
   public storage?: Storage;
@@ -78,24 +81,28 @@ export class TestBuilder {
    * Create backend service handlers.
    */
   createClientServicesHost() {
-    return new ClientServicesHost({
+    const services = new ClientServicesHost({
       config: this.config,
       modelFactory: this._modelFactory,
       storage: this.storage,
       ...this.networking,
     });
+    this._ctx.onDispose(() => services.close());
+    return services;
   }
 
   /**
    * Create local services host.
    */
   createLocal() {
-    return new LocalClientServices({
+    const services = new LocalClientServices({
       config: this.config,
       modelFactory: this._modelFactory,
       storage: this.storage,
       ...this.networking,
     });
+    this._ctx.onDispose(() => services.close());
+    return services;
   }
 
   /**
@@ -108,10 +115,17 @@ export class TestBuilder {
       handlers: host.services as ClientServices,
       port: hostPort,
     });
+    this._ctx.onDispose(() => server.close());
+
     // TODO(dmaretskyi): Refactor.
 
     const client = new Client({ services: new ClientServicesProxy(proxyPort) });
+    this._ctx.onDispose(() => client.destroy());
     return [client, server];
+  }
+
+  destroy() {
+    void this._ctx.dispose();
   }
 }
 

--- a/packages/sdk/client/src/tests/client-services.test.ts
+++ b/packages/sdk/client/src/tests/client-services.test.ts
@@ -24,6 +24,7 @@ import { syncItems, TestBuilder } from '../testing';
 describe('Client services', () => {
   test('creates client with local host', async () => {
     const testBuilder = new TestBuilder();
+    afterTest(() => testBuilder.destroy());
 
     const servicesProvider = testBuilder.createLocal();
     await servicesProvider.open();
@@ -37,6 +38,7 @@ describe('Client services', () => {
 
   test('creates client with remote server', async () => {
     const testBuilder = new TestBuilder();
+    afterTest(() => testBuilder.destroy());
 
     const peer = testBuilder.createClientServicesHost();
     await peer.open(new Context());
@@ -53,6 +55,7 @@ describe('Client services', () => {
 
   test('creates clients with multiple peers connected via memory transport', async () => {
     const testBuilder = new TestBuilder();
+    afterTest(() => testBuilder.destroy());
 
     {
       const peer1 = testBuilder.createClientServicesHost();
@@ -107,6 +110,7 @@ describe('Client services', () => {
 
   test('creates identity and invites peer', async () => {
     const testBuilder = new TestBuilder();
+    afterTest(() => testBuilder.destroy());
 
     const peer1 = testBuilder.createClientServicesHost();
     const peer2 = testBuilder.createClientServicesHost();
@@ -153,6 +157,7 @@ describe('Client services', () => {
 
   test('synchronizes data between two spaces after completing invitation', async () => {
     const testBuilder = new TestBuilder();
+    afterTest(() => testBuilder.destroy());
 
     const peer1 = testBuilder.createClientServicesHost();
     const peer2 = testBuilder.createClientServicesHost();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
       '@types/sharedworker': 0.0.80
       '@types/uuid': 8.3.4
       '@types/zen-observable': 0.8.3
-      '@typescript-eslint/eslint-plugin': 5.62.0_ocsyp7ifj5dgcbu27725e4v2iq
-      '@typescript-eslint/parser': 5.62.0_typescript@5.0.4
+      '@typescript-eslint/eslint-plugin': 5.62.0_fpxx7vup4htmnnlsdn7ctz5pge
+      '@typescript-eslint/parser': 5.62.0_opaykosi7ysrbskpnffskmbrki
       '@vuepress/client': 2.0.0-beta.61
       chai: 4.3.6
       chai-as-promised: 7.1.1_chai@4.3.6
@@ -330,7 +330,7 @@ importers:
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
       vuepress-plugin-check-md: 0.0.3
-      vuepress-theme-hope: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-theme-hope: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
 
   packages/apps/composer-app:
     specifiers:
@@ -404,7 +404,7 @@ importers:
       '@types/react-dom': 18.0.6
       '@vitejs/plugin-react': 3.0.1_vite@4.3.9
       vite: 4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/apps/composer-extension:
@@ -418,7 +418,7 @@ importers:
       '@types/webextension-polyfill': 0.10.0
       typescript: 5.0.4
       vite: 4.3.9
-      vite-plugin-web-extension: 3.0.7
+      vite-plugin-web-extension: 3.0.7_vite@4.3.9
       webextension-polyfill: 0.10.0
 
   packages/apps/halo-app:
@@ -495,7 +495,7 @@ importers:
       '@vitejs/plugin-react': 3.0.1_vite@4.3.9
       typescript: 5.0.4
       vite: 4.3.9_@types+node@18.11.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/apps/labs-app:
@@ -590,7 +590,7 @@ importers:
       '@vitejs/plugin-react': 3.1.0_vite@4.3.9
       vite: 4.3.9
       vite-plugin-mkcert: 1.16.0_vite@4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/apps/plugins/plugin-chess:
@@ -2472,6 +2472,7 @@ importers:
       '@dxos/model-factory': workspace:*
       '@dxos/node-std': workspace:*
       '@dxos/protocols': workspace:*
+      '@dxos/text-model': workspace:*
       '@dxos/timeframe': workspace:*
       '@dxos/typings': workspace:*
       '@dxos/util': workspace:*
@@ -2492,6 +2493,7 @@ importers:
       '@dxos/util': link:../../../common/util
     devDependencies:
       '@dxos/feed-store': link:../../../common/feed-store
+      '@dxos/text-model': link:../text-model
       '@dxos/typings': link:../../../common/typings
 
   packages/core/echo/echo-pipeline:
@@ -2704,7 +2706,6 @@ importers:
     specifiers:
       '@dxos/codec-protobuf': workspace:*
       '@dxos/document-model': workspace:*
-      '@dxos/echo-db': workspace:*
       '@dxos/feed-store': workspace:*
       '@dxos/invariant': workspace:*
       '@dxos/keys': workspace:*
@@ -2717,7 +2718,6 @@ importers:
       yjs: ^13.6.7
     dependencies:
       '@dxos/codec-protobuf': link:../../../common/codec-protobuf
-      '@dxos/echo-db': link:../echo-db
       '@dxos/invariant': link:../../../common/invariant
       '@dxos/keys': link:../../../common/keys
       '@dxos/log': link:../../../common/log
@@ -3431,7 +3431,7 @@ importers:
       typescript: 5.0.4
       vite: 4.3.9
       vite-plugin-fonts: 0.7.0_vite@4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/devtools/devtools-extension:
@@ -3836,7 +3836,7 @@ importers:
       vite-plugin-fonts: 0.7.0_vite@4.3.9
       vite-plugin-inspect: 0.7.15_vite@4.3.9
       vite-plugin-mkcert: 1.16.0_vite@4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/experimental/kai-bots:
@@ -4069,7 +4069,7 @@ importers:
       vite: 4.3.9
       vite-plugin-fonts: 0.7.0_vite@4.3.9
       vite-plugin-inspect: 0.7.15_vite@4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/experimental/kai-framework:
@@ -4234,7 +4234,7 @@ importers:
       vite-plugin-fonts: 0.7.0_vite@4.3.9
       vite-plugin-inspect: 0.7.15_vite@4.3.9
       vite-plugin-mkcert: 1.16.0_vite@4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/experimental/kai-functions:
@@ -4777,7 +4777,7 @@ importers:
       vite: 4.3.9
       vite-plugin-fonts: 0.7.0_vite@4.3.9
       vite-plugin-inspect: 0.7.15_vite@4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/experimental/plexus:
@@ -4846,7 +4846,7 @@ importers:
       vite: 4.3.9
       vite-plugin-fonts: 0.7.0_vite@4.3.9
       vite-plugin-inspect: 0.7.15_vite@4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/experimental/react-metagraph:
@@ -5732,11 +5732,11 @@ importers:
       y-protocols: ^1.0.5
       yjs: ^13.6.7
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/commands': 6.2.2
       '@codemirror/lang-markdown': 6.1.0
       '@codemirror/language': 6.6.0
-      '@codemirror/language-data': 6.1.0
+      '@codemirror/language-data': 6.1.0_252h5dwvsiu2pnu2vr7ql3rya4
       '@codemirror/lint': 6.2.0
       '@codemirror/search': 6.3.0
       '@codemirror/state': 6.2.0
@@ -5764,7 +5764,7 @@ importers:
       '@tiptap/pm': 2.0.0-beta.220_7w7m52asdh3tod4ocz57yex63q
       '@tiptap/react': 2.0.0-beta.220_xig6hpp4glylmgjqbtp4uwsv5e
       '@tiptap/starter-kit': 2.0.0-beta.220_@tiptap+pm@2.0.0-beta.220
-      codemirror: 6.0.1
+      codemirror: 6.0.1_@lezer+common@1.0.2
       lib0: 0.2.65
       lodash.get: 4.4.2
       prosemirror-model: 1.19.0
@@ -6197,8 +6197,8 @@ importers:
       '@dxos/eslint-plugin-rules': link:../eslint-rules
       '@rushstack/eslint-plugin-packlets': 0.4.1_opaykosi7ysrbskpnffskmbrki
       '@stayradiated/eslint-plugin-prefer-arrow-functions': 4.4.0_eslint@8.41.0
-      '@typescript-eslint/eslint-plugin': 5.62.0_ocsyp7ifj5dgcbu27725e4v2iq
-      '@typescript-eslint/parser': 5.62.0_typescript@5.0.4
+      '@typescript-eslint/eslint-plugin': 5.62.0_fpxx7vup4htmnnlsdn7ctz5pge
+      '@typescript-eslint/parser': 5.62.0_opaykosi7ysrbskpnffskmbrki
       eslint-config-semistandard: 16.0.0_tiga5h7i4vhmdmzsybhvux25pi
       eslint-config-standard: 17.0.0_rkx46stinwuf5crngfitnv7g2m
       eslint-plugin-import: 2.26.0_jwowtzypdqj6tkjv7gflothgzy
@@ -9107,8 +9107,13 @@ packages:
       minimist: 1.2.8
     dev: true
 
-  /@codemirror/autocomplete/6.4.2:
+  /@codemirror/autocomplete/6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e:
     resolution: {integrity: sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==}
+    peerDependencies:
+      '@codemirror/language': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+      '@lezer/common': ^1.0.0
     dependencies:
       '@codemirror/language': 6.6.0
       '@codemirror/state': 6.2.0
@@ -9132,20 +9137,23 @@ packages:
       '@lezer/cpp': 1.1.0
     dev: false
 
-  /@codemirror/lang-css/6.1.1:
+  /@codemirror/lang-css/6.1.1_i3aqn63zftbgivbr4riltn5mqe:
     resolution: {integrity: sha512-P6jdNEHyRcqqDgbvHYyC9Wxkek0rnG3a9aVSRi4a7WrjPbQtBTaOmvYpXmm13zZMAatO4Oqpac+0QZs7sy+LnQ==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/language': 6.6.0
       '@codemirror/state': 6.2.0
       '@lezer/css': 1.1.1
+    transitivePeerDependencies:
+      - '@codemirror/view'
+      - '@lezer/common'
     dev: false
 
   /@codemirror/lang-html/6.4.2:
     resolution: {integrity: sha512-bqCBASkteKySwtIbiV/WCtGnn/khLRbbiV5TE+d9S9eQJD7BA4c5dTRm2b3bVmSpilff5EYxvB4PQaZzM/7cNw==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
-      '@codemirror/lang-css': 6.1.1
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
+      '@codemirror/lang-css': 6.1.1_i3aqn63zftbgivbr4riltn5mqe
       '@codemirror/lang-javascript': 6.1.4
       '@codemirror/language': 6.6.0
       '@codemirror/state': 6.2.0
@@ -9165,7 +9173,7 @@ packages:
   /@codemirror/lang-javascript/6.1.4:
     resolution: {integrity: sha512-OxLf7OfOZBTMRMi6BO/F72MNGmgOd9B0vetOLvHsDACFXayBzW8fm8aWnDM0yuy68wTK03MBf4HbjSBNRG5q7A==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/language': 6.6.0
       '@codemirror/lint': 6.2.0
       '@codemirror/state': 6.2.0
@@ -9202,12 +9210,16 @@ packages:
       '@lezer/php': 1.0.1
     dev: false
 
-  /@codemirror/lang-python/6.1.2:
+  /@codemirror/lang-python/6.1.2_252h5dwvsiu2pnu2vr7ql3rya4:
     resolution: {integrity: sha512-nbQfifLBZstpt6Oo4XxA2LOzlSp4b/7Bc5cmodG1R+Cs5PLLCTUvsMNWDnziiCfTOG/SW1rVzXq/GbIr6WXlcw==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/language': 6.6.0
       '@lezer/python': 1.1.2
+    transitivePeerDependencies:
+      - '@codemirror/state'
+      - '@codemirror/view'
+      - '@lezer/common'
     dev: false
 
   /@codemirror/lang-rust/6.0.1:
@@ -9217,14 +9229,17 @@ packages:
       '@lezer/rust': 1.0.0
     dev: false
 
-  /@codemirror/lang-sql/6.4.0:
+  /@codemirror/lang-sql/6.4.0_i3aqn63zftbgivbr4riltn5mqe:
     resolution: {integrity: sha512-UWGK1+zc9+JtkiT+XxHByp4N6VLgLvC2x0tIudrJG26gyNtn0hWOVoB0A8kh/NABPWkKl3tLWDYf2qOBJS9Zdw==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/language': 6.6.0
       '@codemirror/state': 6.2.0
       '@lezer/highlight': 1.1.3
       '@lezer/lr': 1.3.3
+    transitivePeerDependencies:
+      - '@codemirror/view'
+      - '@lezer/common'
     dev: false
 
   /@codemirror/lang-wast/6.0.1:
@@ -9235,34 +9250,40 @@ packages:
       '@lezer/lr': 1.3.3
     dev: false
 
-  /@codemirror/lang-xml/6.0.2:
+  /@codemirror/lang-xml/6.0.2_@codemirror+view@6.9.2:
     resolution: {integrity: sha512-JQYZjHL2LAfpiZI2/qZ/qzDuSqmGKMwyApYmEUUCTxLM4MWS7sATUEfIguZQr9Zjx/7gcdnewb039smF6nC2zw==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/language': 6.6.0
       '@codemirror/state': 6.2.0
       '@lezer/common': 1.0.2
       '@lezer/xml': 1.0.1
+    transitivePeerDependencies:
+      - '@codemirror/view'
     dev: false
 
-  /@codemirror/language-data/6.1.0:
+  /@codemirror/language-data/6.1.0_252h5dwvsiu2pnu2vr7ql3rya4:
     resolution: {integrity: sha512-g9V23fuLRI9AEbpM6bDy1oquqgpFlIDHTihUhL21NPmxp+x67ZJbsKk+V71W7/Bj8SCqEO1PtqQA/tDGgt1nfw==}
     dependencies:
       '@codemirror/lang-cpp': 6.0.2
-      '@codemirror/lang-css': 6.1.1
+      '@codemirror/lang-css': 6.1.1_i3aqn63zftbgivbr4riltn5mqe
       '@codemirror/lang-html': 6.4.2
       '@codemirror/lang-java': 6.0.1
       '@codemirror/lang-javascript': 6.1.4
       '@codemirror/lang-json': 6.0.1
       '@codemirror/lang-markdown': 6.1.0
       '@codemirror/lang-php': 6.0.1
-      '@codemirror/lang-python': 6.1.2
+      '@codemirror/lang-python': 6.1.2_252h5dwvsiu2pnu2vr7ql3rya4
       '@codemirror/lang-rust': 6.0.1
-      '@codemirror/lang-sql': 6.4.0
+      '@codemirror/lang-sql': 6.4.0_i3aqn63zftbgivbr4riltn5mqe
       '@codemirror/lang-wast': 6.0.1
-      '@codemirror/lang-xml': 6.0.2
+      '@codemirror/lang-xml': 6.0.2_@codemirror+view@6.9.2
       '@codemirror/language': 6.6.0
       '@codemirror/legacy-modes': 6.3.1
+    transitivePeerDependencies:
+      - '@codemirror/state'
+      - '@codemirror/view'
+      - '@lezer/common'
     dev: false
 
   /@codemirror/language/6.6.0:
@@ -12036,7 +12057,7 @@ packages:
       '@nrwl/eslint-plugin-nx': 16.5.4_f5sjyg6hkkwzmez5q6ml55qszi
       '@nx/devkit': 16.5.4_nx@16.5.4
       '@nx/js': 16.5.4_kco6wocfncyehzbvd6faof7n2y_wcxuhe4tvwpsd3renjlc7ah6mu
-      '@typescript-eslint/parser': 5.62.0_typescript@5.0.4
+      '@typescript-eslint/parser': 5.62.0_opaykosi7ysrbskpnffskmbrki
       '@typescript-eslint/type-utils': 5.62.0_opaykosi7ysrbskpnffskmbrki
       '@typescript-eslint/utils': 5.62.0_opaykosi7ysrbskpnffskmbrki
       chalk: 4.1.2
@@ -16372,7 +16393,7 @@ packages:
       '@emotion/react': ^11
       react: '>16'
     dependencies:
-      '@emotion/react': 11.10.4_b6k74wvxdvqypha4emuv7fd2ke
+      '@emotion/react': 11.10.4_bjroym7kxlcs2vvwnej4p3gzwu
       '@theme-ui/core': 0.14.7_gyryel6m34lsxtsejhafetjriq
       '@theme-ui/css': 0.14.7_@emotion+react@11.10.4
       deepmerge: 4.3.1
@@ -16385,7 +16406,7 @@ packages:
       '@emotion/react': ^11
       react: '>16'
     dependencies:
-      '@emotion/react': 11.10.4_b6k74wvxdvqypha4emuv7fd2ke
+      '@emotion/react': 11.10.4_bjroym7kxlcs2vvwnej4p3gzwu
       '@styled-system/color': 5.1.2
       '@styled-system/should-forward-prop': 5.1.5
       '@styled-system/space': 5.1.2
@@ -16400,7 +16421,7 @@ packages:
       '@emotion/react': ^11
       react: '>16'
     dependencies:
-      '@emotion/react': 11.10.4_b6k74wvxdvqypha4emuv7fd2ke
+      '@emotion/react': 11.10.4_bjroym7kxlcs2vvwnej4p3gzwu
       '@theme-ui/css': 0.14.7_@emotion+react@11.10.4
       '@theme-ui/parse-props': 0.14.7_gyryel6m34lsxtsejhafetjriq
       deepmerge: 4.3.1
@@ -16412,7 +16433,7 @@ packages:
     peerDependencies:
       '@emotion/react': ^11
     dependencies:
-      '@emotion/react': 11.10.4_b6k74wvxdvqypha4emuv7fd2ke
+      '@emotion/react': 11.10.4_bjroym7kxlcs2vvwnej4p3gzwu
       csstype: 3.1.2
     dev: true
 
@@ -16423,7 +16444,7 @@ packages:
       '@mdx-js/react': ^1 || ^2
       react: '>16'
     dependencies:
-      '@emotion/react': 11.10.4_b6k74wvxdvqypha4emuv7fd2ke
+      '@emotion/react': 11.10.4_bjroym7kxlcs2vvwnej4p3gzwu
       '@mdx-js/react': 2.1.5_react@18.2.0
       '@theme-ui/core': 0.14.7_gyryel6m34lsxtsejhafetjriq
       '@theme-ui/css': 0.14.7_@emotion+react@11.10.4
@@ -16436,7 +16457,7 @@ packages:
       '@emotion/react': ^11
       react: '>16'
     dependencies:
-      '@emotion/react': 11.10.4_b6k74wvxdvqypha4emuv7fd2ke
+      '@emotion/react': 11.10.4_bjroym7kxlcs2vvwnej4p3gzwu
       '@theme-ui/css': 0.14.7_@emotion+react@11.10.4
       react: 18.2.0
     dev: true
@@ -16447,7 +16468,7 @@ packages:
       '@emotion/react': ^11
       react: '>16'
     dependencies:
-      '@emotion/react': 11.10.4_b6k74wvxdvqypha4emuv7fd2ke
+      '@emotion/react': 11.10.4_bjroym7kxlcs2vvwnej4p3gzwu
       '@theme-ui/color-modes': 0.14.7_gyryel6m34lsxtsejhafetjriq
       '@theme-ui/core': 0.14.7_gyryel6m34lsxtsejhafetjriq
       '@theme-ui/css': 0.14.7_@emotion+react@11.10.4
@@ -18183,18 +18204,19 @@ packages:
     resolution: {integrity: sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.62.0_ocsyp7ifj5dgcbu27725e4v2iq:
+  /@typescript-eslint/eslint-plugin/5.62.0_fpxx7vup4htmnnlsdn7ctz5pge:
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.62.0_typescript@5.0.4
+      '@typescript-eslint/parser': 5.62.0_opaykosi7ysrbskpnffskmbrki
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0_opaykosi7ysrbskpnffskmbrki
       '@typescript-eslint/utils': 5.62.0_opaykosi7ysrbskpnffskmbrki
@@ -18222,10 +18244,11 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/parser/5.62.0_typescript@5.0.4:
+  /@typescript-eslint/parser/5.62.0_opaykosi7ysrbskpnffskmbrki:
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -18421,7 +18444,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.21.3
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.3.9
+      vite: 4.3.9_@types+node@18.11.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -20096,7 +20119,7 @@ packages:
   /axios/1.3.4_debug@4.3.4:
     resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
     dependencies:
-      follow-redirects: 1.15.2_debug@4.3.4
+      follow-redirects: 1.15.2
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -21784,16 +21807,18 @@ packages:
     resolution: {integrity: sha512-LuO8/7LW6XuR5ERn1yavXAfodGRhuY2yP60JTZIw5yNYMCE5lUVbk3NFUCJxjnphQH+Xemp5hOGb1LgUXm00Xw==}
     dev: true
 
-  /codemirror/6.0.1:
+  /codemirror/6.0.1_@lezer+common@1.0.2:
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/commands': 6.2.2
       '@codemirror/language': 6.6.0
       '@codemirror/lint': 6.2.0
       '@codemirror/search': 6.3.0
       '@codemirror/state': 6.2.0
       '@codemirror/view': 6.9.2
+    transitivePeerDependencies:
+      - '@lezer/common'
     dev: false
 
   /codepage/1.15.0:
@@ -24433,7 +24458,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0_typescript@5.0.4
+      '@typescript-eslint/parser': 5.62.0_opaykosi7ysrbskpnffskmbrki
       debug: 3.2.7
       eslint: 8.41.0
       eslint-import-resolver-node: 0.3.6
@@ -24473,7 +24498,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0_typescript@5.0.4
+      '@typescript-eslint/parser': 5.62.0_opaykosi7ysrbskpnffskmbrki
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
@@ -24603,7 +24628,7 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0_ocsyp7ifj5dgcbu27725e4v2iq
+      '@typescript-eslint/eslint-plugin': 5.62.0_fpxx7vup4htmnnlsdn7ctz5pge
       eslint: 8.41.0
       eslint-rule-composer: 0.3.0
     dev: false
@@ -25708,18 +25733,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-
-  /follow-redirects/1.15.2_debug@4.3.4:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.4
-    dev: true
 
   /fontkit/2.0.2:
     resolution: {integrity: sha512-jc4k5Yr8iov8QfS6u8w2CnHWVmbOGtdBtOXMze5Y+QD966Rx6PEVWXSEGwXlsDlKtu1G12cJjcsybnqhSk/+LA==}
@@ -27438,7 +27451,7 @@ packages:
       ink: '>=3.0.0'
       react: '>=16.8.0'
     dependencies:
-      ink: 3.2.0_iapumuv4e6jcjznwuxpf4tt22e
+      ink: 3.2.0_react@18.2.0
       object-hash: 2.2.0
       react: 18.2.0
     dev: false
@@ -28788,7 +28801,7 @@ packages:
       sane: 4.1.0
       walker: 1.0.8
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -36197,7 +36210,7 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /rollup/3.19.1:
@@ -36205,7 +36218,7 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /rollup/3.20.4:
@@ -39659,10 +39672,11 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-pwa/0.14.1_vite@4.3.9:
+  /vite-plugin-pwa/0.14.1_hjemcocyspwkenofjo4wnksrci:
     resolution: {integrity: sha512-5zx7yhQ8RTLwV71+GA9YsQQ63ALKG8XXIMqRJDdZkR8ZYftFcRgnzM7wOWmQZ/DATspyhPih5wCdcZnAIsM+mA==}
     peerDependencies:
       vite: ^3.1.0 || ^4.0.0
+      workbox-window: ^6.5.4
     dependencies:
       '@rollup/plugin-replace': 5.0.2_rollup@3.23.0
       debug: 4.3.4
@@ -39681,8 +39695,10 @@ packages:
     resolution: {integrity: sha512-irjKcKXRn7v5bPAg4mAbsS6DgibpP1VUFL9tlgxU6lloK6V9yw9qCZkS+s2PtbkZpWNzr3TN3zVJAc6J7gJZmA==}
     dev: true
 
-  /vite-plugin-web-extension/3.0.7:
+  /vite-plugin-web-extension/3.0.7_vite@4.3.9:
     resolution: {integrity: sha512-zi+Dd0WV7tiqqWM2kTowV5D1s+jy5rB76R6uN0gaoUDaz2QAhVcmBg/T7qF5p1g7SBjtvgclQggQ8uxglk+moQ==}
+    peerDependencies:
+      vite: ^4
     dependencies:
       ajv: 8.12.0
       async-lock: 1.4.0
@@ -39697,17 +39713,11 @@ packages:
       webextension-polyfill: 0.10.0
       yaml: 2.2.2
     transitivePeerDependencies:
-      - '@types/node'
       - body-parser
       - bufferutil
       - express
-      - less
       - safe-compare
-      - sass
-      - stylus
-      - sugarss
       - supports-color
-      - terser
       - utf-8-validate
     dev: true
 
@@ -39740,7 +39750,7 @@ packages:
       postcss: 8.4.24
       rollup: 3.23.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /vite/4.3.9_@types+node@18.11.9:
@@ -39889,10 +39899,11 @@ packages:
       '@vue/shared': 3.2.47
     dev: true
 
-  /vuepress-plugin-auto-catalog/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-auto-catalog/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-imWdtiliNOrYZmJhjZnH3YU7VuR0FFtzZ7vyzHTQLZlRc9N5yryiYgYhmQbK4WCSNEdxfYRZbbFCEnSiHLbzpg==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -39922,18 +39933,19 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-components: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-components: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-blog2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-blog2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-0OmYfWd6mxG2X1DUagd5sOhTjG65l0L8RV3L8Vhj9j/36If3UttRU7g6VdUjfIfxAWmInsIIwhUAskEez9PUfQ==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
       vuepress-webpack: 2.0.0-beta.61
@@ -39957,7 +39969,7 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
@@ -39971,10 +39983,11 @@ packages:
       - supports-color
     dev: true
 
-  /vuepress-plugin-comment2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-comment2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-AXvAmvRNdBEVsx105ykjB5EvNj0vIb4ny7RgM2BM0mXcWImxdKWaO8GGdzIu5Eqk/Aiv7FXJoBIJ6uhkxIfPuQ==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -40005,17 +40018,18 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-components/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-components/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-pJd1oKVwHW/4eO2NeY9FSQWHo1pF8c0/rSrQLXPcnAaQojHG6QiLDdZ+EM4eGL3dHXixyIvT8wPU3IEOPlStqA==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -40053,18 +40067,19 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-reading-time2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-reading-time2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-copy-code2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-copy-code2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-kWPye53Bxsy7BxxcTOglsBjjAmOuzq6niHUAeqnEokhPeDcBEwwFcXIDDI1yj94e0fPcfKf1iKxH2C18VKFgow==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -40093,17 +40108,18 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-copyright2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-copyright2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-QCnu8BUy6SW3YTHgK8kU4WfKcrYfIOBTUG0D7HSqR/54y5ItKng4VsLG5hqruzwnRJoRPCnulJfoS7cGeEoBIQ==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
       vuepress-webpack: 2.0.0-beta.61
@@ -40126,13 +40142,13 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-feed2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-feed2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-tBNMyPWgPf71HIOlEvqEbb2Oq/WwYNzu9/imlMSyw4N+hnDuO3tSOPV/jOllhjMHG67KVR58YatrIDjE8PWatA==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
@@ -40151,17 +40167,19 @@ packages:
       '@vuepress/utils': 2.0.0-beta.61
       cheerio: 1.0.0-rc.12
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
       xml-js: 1.6.11
     transitivePeerDependencies:
       - '@vue/composition-api'
+      - '@vuepress/client'
       - supports-color
     dev: true
 
-  /vuepress-plugin-md-enhance/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-md-enhance/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-k5pfWW/xZCg7wEYrXFLHSUr5Laqc0nlfUg+IFYDbBXbKpbN53UgGwe05mcctZUSXokBDNJDRX62+kb4wFq4xTw==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -40219,17 +40237,18 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-photo-swipe/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-photo-swipe/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-yQICqlkEXC/PCkWVyqPkWSoT2FJ3yM1FQSNVNvAwP1WBIWlaCLnW896dVbCbwFfIStdgkfQW5//svqMI73l8sQ==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -40258,17 +40277,18 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-pwa2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-pwa2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-P7DCMxNuTyj1P1BY+Wmkz9dtVPtrzwO3SSjSSan+f2d31ak7H4mWa16s8+6YzwNkkXViUW+YrOo19lwxZHRrRQ==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -40298,8 +40318,8 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
       workbox-build: 6.5.4
     transitivePeerDependencies:
       - '@types/babel__core'
@@ -40307,7 +40327,7 @@ packages:
       - supports-color
     dev: true
 
-  /vuepress-plugin-reading-time2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-reading-time2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-SrtJHCfFmKxYhJK+pvvnC8RyjM7CHsCa3egNyBLYqs1oLlypCFS2ocb0UE1k1EHhSOyKuA9MigO+W95E3esg+A==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
@@ -40325,9 +40345,10 @@ packages:
         optional: true
     dependencies:
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
+      - '@vuepress/client'
       - supports-color
     dev: true
 
@@ -40351,13 +40372,13 @@ packages:
       '@vuepress/utils': 2.0.0-beta.61
       vue: 3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-sass-palette/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-sass-palette/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-xXA3fTD44W9pahejX79FQ0B9dIHbz5PzJ/8n7q0F4uep1/6j4BCKFDk1eyh+J9pBoTmZH+f9QxGxNZceGeOv2A==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
@@ -40382,13 +40403,14 @@ packages:
       chokidar: 3.5.3
       sass: 1.59.3
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
+      - '@vuepress/client'
       - supports-color
     dev: true
 
-  /vuepress-plugin-seo2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-seo2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-xaDGK2+XA/pQA9RGBuvjhzgHm1+Bmo9FzPxrDe6WQa/7S3qJfyYhkEqEApDzPzHaIIKBjUB9fHyUb7N+MWOLfg==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
@@ -40406,13 +40428,14 @@ packages:
       '@vuepress/shared': 2.0.0-beta.61
       '@vuepress/utils': 2.0.0-beta.61
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
+      - '@vuepress/client'
       - supports-color
     dev: true
 
-  /vuepress-plugin-sitemap2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-sitemap2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-yhLTRG67Sm0esVJHp+niS6CGUFBMoucxD7ul4D29fI0GIkK6634z5UDLD3TiJXbsRH32pbvURNGAHeZrJ1kYnA==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
@@ -40433,16 +40456,18 @@ packages:
       '@vuepress/utils': 2.0.0-beta.61
       sitemap: 7.1.1
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
+      - '@vuepress/client'
       - supports-color
     dev: true
 
-  /vuepress-shared/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-shared/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-eTs6AT9w0djzsxNPPXiWK6lHcsS5AVnwRdu90/YthGkpPY2pGarN9KrtGX7+qVr+G4HS8v4Qu43+X+iDInNBgg==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
       vuepress-webpack: 2.0.0-beta.61
@@ -40475,10 +40500,11 @@ packages:
       - supports-color
     dev: true
 
-  /vuepress-theme-hope/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-theme-hope/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-1mRhF4uk8bQaSYFjcJ+1hUHJ5OCHxHJVEzNWBHcgsDf4eqM/IYz+KXePwC9ndXAOOKPoKk6c1XAk5Nu5F3U7wA==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -40565,22 +40591,22 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-auto-catalog: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-blog2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-comment2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-components: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-copy-code2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-copyright2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-feed2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-md-enhance: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-photo-swipe: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-pwa2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-reading-time2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-auto-catalog: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-blog2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-comment2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-components: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-copy-code2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-copyright2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-feed2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-md-enhance: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-photo-swipe: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-pwa2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-reading-time2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
       vuepress-plugin-rtl: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-seo2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-sitemap2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-seo2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-sitemap2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@types/babel__core'
       - '@vue/composition-api'


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 520e0e1</samp>

### Summary
🚀📝🧪

<!--
1.  🚀 - This emoji represents the performance and efficiency improvement of the echo-db service by batching and merging mutations.
2. 📝 - This emoji represents the text model and its meta data, which are used and modified in the echo-db package.
3. 🧪 - This emoji represents the testing and reliability improvement of the database and text model modules.
-->
This pull request improves the performance and efficiency of the echo database by implementing a batching and merging mechanism for mutations. It also updates the text model to use `yjs` for merging text mutations and removes the circular dependency between the text-model and the echo-db packages. Additionally, it updates the tests, the proto definition, and the package dependencies to reflect the changes.

> _We merge the mutations in the dark_
> _We use the `TextModel` to leave our mark_
> _We test the database with the rig_
> _We avoid the circular dependency_

### Walkthrough
*  Add support for text models and merging mutations in the echo-db package.

