### PR TITLE
feat: Update header and sidebar layout.

### DIFF
--- a/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
@@ -6,7 +6,7 @@ import React, { MutableRefObject, PropsWithChildren } from 'react';
 
 import { Main } from '@dxos/aurora';
 import { ComposerModel, MarkdownComposerRef } from '@dxos/aurora-composer';
-import { coarseBlockPaddingStart, mx, textBlockWidth } from '@dxos/aurora-theme';
+import { coarseBlockPaddingStart, inputSurface, mx, surfaceElevation, textBlockWidth } from '@dxos/aurora-theme';
 
 import { MarkdownProperties } from '../types';
 
@@ -20,8 +20,18 @@ export const StandaloneLayout = ({
 }>) => {
   return (
     <Main.Content bounce classNames={coarseBlockPaddingStart}>
-      <div role='none' className={mx(textBlockWidth, 'min-bs-[calc(100dvh-2.5rem)] flex flex-col')}>
-        {children}
+      <div role='none' className={mx(textBlockWidth, 'pli-2')}>
+        <div
+          role='none'
+          className={mx(
+            inputSurface,
+            surfaceElevation({ elevation: 'group' }),
+            'mbs-2 mbe-6 pli-6 rounded',
+            'min-bs-[calc(100dvh-4.5rem)] flex flex-col',
+          )}
+        >
+          {children}
+        </div>
       </div>
     </Main.Content>
   );

--- a/packages/apps/plugins/plugin-space/src/components/SpacePresence.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/SpacePresence.tsx
@@ -9,13 +9,14 @@ import { useIdentity } from '@dxos/react-client/halo';
 
 import { SPACE_PLUGIN } from '../types';
 
+// TODO(burdon): Wire up to presence.
 export const SpacePresence = () => {
   const identity = useIdentity();
   const fallbackHref = useJdenticonHref(identity?.identityKey.toHex() ?? '', 4);
   const { t } = useTranslation(SPACE_PLUGIN);
   return identity ? (
     <Tooltip.Root>
-      <Tooltip.Trigger>
+      <Tooltip.Trigger className='flex items-center'>
         <AvatarGroup.Root size={4} classNames='mie-5'>
           <AvatarGroup.Label classNames='text-xs font-system-semibold'>1</AvatarGroup.Label>
           <AvatarGroupItem.Root>

--- a/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
@@ -17,6 +17,9 @@ export type SplitViewPluginConfig = Partial<{
   enableComplementarySidebar: boolean;
 }>;
 
+/**
+ * Root application layout that controls sidebars, popovers, and dialogs.
+ */
 export const SplitViewPlugin = ({
   enableComplementarySidebar,
 }: SplitViewPluginConfig = {}): PluginDefinition<SplitViewProvides> => {

--- a/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Chats, List as MenuIcon } from '@phosphor-icons/react';
+import { CaretDoubleLeft, List as MenuIcon } from '@phosphor-icons/react';
 import React from 'react';
 
 import { Button, Main, Dialog, useTranslation, DensityProvider, Popover } from '@dxos/aurora';
@@ -37,20 +37,24 @@ export const SplitView = () => {
           onComplementarySidebarOpenChange: (next) => (context.complementarySidebarOpen = next),
         })}
       >
+        {/* Left navigation sidebar. */}
         <Main.NavigationSidebar classNames='overflow-hidden'>
           <Surface name='sidebar' />
         </Main.NavigationSidebar>
+
+        {/* Right Complementary sidebar. */}
         {complementarySidebarOpen !== null && (
           <Main.ComplementarySidebar classNames='overflow-hidden'>
-            <Surface name='complementary-sidebar' />
+            <Surface name='complementary' role='complementary' />
           </Main.ComplementarySidebar>
         )}
-        <Main.Overlay />
+
+        {/* Top (header) bar. */}
         <Main.Content
           asChild
           classNames={['fixed inset-inline-0 block-start-0 z-[1] flex gap-1 plb-1.5', coarseBlockSize, fixedSurface]}
         >
-          <div role='none' aria-label={t('main header label')}>
+          <div role='none' aria-label={t('main header label')} className='__border-b'>
             <DensityProvider density='fine'>
               <Button onClick={() => (context.sidebarOpen = !context.sidebarOpen)} variant='ghost' classNames='mli-1'>
                 <span className='sr-only'>{t('open navigation sidebar label')}</span>
@@ -58,6 +62,7 @@ export const SplitView = () => {
               </Button>
               <Surface name='heading' role='heading' limit={2} />
               <div role='none' className='grow' />
+              {/* TODO(burdon): Too specific? status? contentinfo? */}
               <Surface name='presence' role='presence' limit={1} />
               {complementarySidebarOpen !== null && (
                 <Button
@@ -65,13 +70,24 @@ export const SplitView = () => {
                   variant='ghost'
                 >
                   <span className='sr-only'>{t('open complementary sidebar label')}</span>
-                  <Chats weight='light' className={getSize(4)} />
+                  <CaretDoubleLeft
+                    mirrored={!!context.complementarySidebarOpen}
+                    weight='light'
+                    className={getSize(4)}
+                  />
                 </Button>
               )}
             </DensityProvider>
           </div>
         </Main.Content>
+
+        {/* Dialog overlay to dismiss dialogs. */}
+        <Main.Overlay />
+
+        {/* Main content surface. */}
         <Surface name='main' role='main' />
+
+        {/* Global popovers. */}
         <Popover.Portal>
           <Popover.Content
             classNames='z-[60]'
@@ -86,6 +102,8 @@ export const SplitView = () => {
             <Popover.Arrow />
           </Popover.Content>
         </Popover.Portal>
+
+        {/* Global dialog. */}
         <Dialog.Root open={dialogOpen} onOpenChange={(nextOpen) => (context.dialogOpen = nextOpen)}>
           <DensityProvider density='fine'>
             <Dialog.Overlay>

--- a/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
@@ -54,7 +54,7 @@ export const SplitView = () => {
           asChild
           classNames={['fixed inset-inline-0 block-start-0 z-[1] flex gap-1 plb-1.5', coarseBlockSize, fixedSurface]}
         >
-          <div role='none' aria-label={t('main header label')} className='__border-b'>
+          <div role='none' aria-label={t('main header label')}>
             <DensityProvider density='fine'>
               <Button onClick={() => (context.sidebarOpen = !context.sidebarOpen)} variant='ghost' classNames='mli-1'>
                 <span className='sr-only'>{t('open navigation sidebar label')}</span>

--- a/packages/apps/plugins/plugin-thread/src/components/ThreadChannel.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadChannel.tsx
@@ -88,7 +88,7 @@ export const ThreadChannel: FC<{
           <div ref={bottomRef} />
           {thread.blocks
             .map((block) => (
-              <div key={block.id} className='my-1 __divide-y __border-b'>
+              <div key={block.id} className='my-1'>
                 <ThreadBlock identityKey={identityKey} block={block} getBlockProperties={getBlockProperties} />
               </div>
             ))

--- a/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
@@ -54,6 +54,7 @@ export const TreeViewPlugin = (): PluginDefinition<TreeViewPluginProvides> => {
                 component='dxos.org/plugin/splitview/SplitView'
                 surfaces={{
                   sidebar: { component: 'dxos.org/plugin/treeview/TreeView' },
+                  complementary: { data: treeView.activeNode.data },
                   main: { fallback: Fallback, data: treeView.activeNode.data },
                   heading: { data: treeView.activeNode /* (thure): Intentionally the node. */ },
                   presence: { data: treeView.activeNode.data },

--- a/packages/experimental/mosaic/src/components/Card/util.tsx
+++ b/packages/experimental/mosaic/src/components/Card/util.tsx
@@ -9,8 +9,8 @@ import { mx } from '@dxos/aurora-theme';
 // TODO(burdon): Factor out as hook.
 export const styles = {
   bg: 'bg-white dark:bg-neutral-800',
-  frame: 'md:shadow md:rounded __border __border-neutral-300',
-  divide: 'divide-y divide-y-reverse __divide-neutral-300',
+  frame: 'md:shadow md:rounded',
+  divide: 'divide-y divide-y-reverse',
   heading: 'text-black dark:text-white',
   body: 'text-neutral-600',
 };

--- a/packages/sdk/react-shell/src/components/IdentityList/IdentityListItem.tsx
+++ b/packages/sdk/react-shell/src/components/IdentityList/IdentityListItem.tsx
@@ -1,7 +1,8 @@
 //
 // Copyright 2023 DXOS.org
 //
-import React from 'react';
+
+import React, { forwardRef } from 'react';
 
 import { ListItem, Avatar, useJdenticonHref, useId } from '@dxos/aurora';
 import { mx } from '@dxos/aurora-theme';
@@ -9,32 +10,33 @@ import { generateName } from '@dxos/display-name';
 import { SpaceMember } from '@dxos/react-client/echo';
 import { Identity } from '@dxos/react-client/halo';
 
-export const IdentityListItem = ({
-  identity,
-  presence,
-  onClick,
-}: {
+type IdentityListItemProps = {
   identity: Identity;
   presence?: SpaceMember['presence'];
   onClick?: () => void;
-}) => {
-  const fallbackValue = identity.identityKey.toHex();
-  const labelId = useId('identityListItem__label');
-  const jdenticon = useJdenticonHref(fallbackValue ?? '', 12);
-  const displayName = identity.profile?.displayName ?? generateName(identity.identityKey.toHex());
-  return (
-    <ListItem.Root
-      classNames={mx('rounded p-2 flex gap-2 items-center', onClick && 'cursor-pointer')}
-      onClick={() => onClick?.()}
-      data-testid='identity-list-item'
-      labelId={labelId}
-    >
-      <Avatar.Root status={presence === SpaceMember.PresenceState.ONLINE ? 'active' : 'inactive'} labelId={labelId}>
-        <Avatar.Frame>
-          <Avatar.Fallback href={jdenticon} />
-        </Avatar.Frame>
-        <Avatar.Label classNames='text-sm truncate pli-2'>{displayName}</Avatar.Label>
-      </Avatar.Root>
-    </ListItem.Root>
-  );
 };
+
+export const IdentityListItem = forwardRef<HTMLLIElement, IdentityListItemProps>(
+  ({ identity, presence, onClick }: IdentityListItemProps, forwardedRef) => {
+    const fallbackValue = identity.identityKey.toHex();
+    const labelId = useId('identityListItem__label');
+    const jdenticon = useJdenticonHref(fallbackValue ?? '', 12);
+    const displayName = identity.profile?.displayName ?? generateName(identity.identityKey.toHex());
+    return (
+      <ListItem.Root
+        classNames={mx('rounded p-2 flex gap-2 items-center', onClick && 'cursor-pointer')}
+        onClick={() => onClick?.()}
+        data-testid='identity-list-item'
+        labelId={labelId}
+        ref={forwardedRef}
+      >
+        <Avatar.Root status={presence === SpaceMember.PresenceState.ONLINE ? 'active' : 'inactive'} labelId={labelId}>
+          <Avatar.Frame>
+            <Avatar.Fallback href={jdenticon} />
+          </Avatar.Frame>
+          <Avatar.Label classNames='text-sm truncate pli-2'>{displayName}</Avatar.Label>
+        </Avatar.Root>
+      </ListItem.Root>
+    );
+  },
+);

--- a/packages/sdk/react-shell/src/components/Panel/Action.tsx
+++ b/packages/sdk/react-shell/src/components/Panel/Action.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { ButtonProps, Button } from '@dxos/aurora';
 
@@ -10,11 +10,11 @@ export type LargeButtonProps = ButtonProps & {
   isFull?: boolean;
 };
 
-export const Action = (props: LargeButtonProps) => {
+export const Action = forwardRef<HTMLButtonElement, LargeButtonProps>((props, forwardedRef) => {
   const { children, classNames, isFull = true, ...rest } = props;
   return (
-    <Button classNames={[isFull && 'is-full', 'flex gap-2 plb-3 mbs-2', classNames]} {...rest}>
+    <Button {...rest} classNames={[isFull && 'is-full', 'flex gap-2 plb-3 mbs-2', classNames]} ref={forwardedRef}>
       {children}
     </Button>
   );
-};
+});

--- a/packages/ui/aurora-theme/src/styles/fragments/focus.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/focus.ts
@@ -11,7 +11,7 @@ export const focusRing =
 /**
  * @deprecated
  */
-export const subduedFocus = 'focus:outline-none focus-visible:outline-none focus:ring-0 focus:border-0';
+export const subduedFocus = 'focus:outline-none focus-visible:outline-none focus:ring-0 ring-0 focus:border-0 border-0';
 
 /**
  * @deprecated

--- a/packages/ui/aurora-theme/src/styles/fragments/focus.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/focus.ts
@@ -11,7 +11,7 @@ export const focusRing =
 /**
  * @deprecated
  */
-export const subduedFocus = 'focus:outline-none focus-visible:outline-none';
+export const subduedFocus = 'focus:outline-none focus-visible:outline-none focus:ring-0 focus:border-0';
 
 /**
  * @deprecated

--- a/packages/ui/aurora-theme/src/styles/fragments/surface.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/surface.ts
@@ -3,13 +3,13 @@
 //
 
 // Main background.
-export const baseSurface = 'bg-neutral-50 dark:bg-neutral-900';
+export const baseSurface = 'bg-white dark:bg-neutral-900';
 
 // Sidebars, main heading (“topbar”), and nothing else.
 export const fixedSurface = 'bg-neutral-50/95 dark:bg-neutral-900/95 backdrop-blur';
 
 // Cards, dialogs, other such groups.
-export const groupSurface = 'bg-neutral-50 dark:bg-neutral-850';
+export const groupSurface = 'bg-neutral-25 dark:bg-neutral-850';
 
 // Tooltips, popovers, menus, etc. – not dialogs.
 export const chromeSurface = 'bg-neutral-12 dark:bg-neutral-800';

--- a/packages/ui/aurora-theme/src/styles/fragments/surface.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/surface.ts
@@ -3,7 +3,7 @@
 //
 
 // Main background.
-export const baseSurface = 'bg-white dark:bg-neutral-900';
+export const baseSurface = 'bg-neutral-50 dark:bg-neutral-900';
 
 // Sidebars, main heading (“topbar”), and nothing else.
 export const fixedSurface = 'bg-neutral-50/95 dark:bg-neutral-900/95 backdrop-blur';


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f65c63f</samp>

### Summary
📝🎨🚀

<!--
1.  📝 - This emoji can be used to represent the addition of comments or documentation to the code, as well as the improvement of the standalone markdown editor.
2.  🎨 - This emoji can be used to represent the improvement of the UI and appearance of various components, such as the `SpacePresence`, `SplitView`, and `IdentityListItem` components, as well as the contrast and readability of surfaces in light mode.
3.  🚀 - This emoji can be used to represent the enhancement of the functionality and performance of various components, such as the `TreeViewPlugin`, `SplitView`, and `Action` components, as well as the support for forwarding refs.
-->
This pull request improves the appearance and functionality of various components and plugins in the dxos apps and UI packages. It applies theme styles, adds ref forwarding, changes icons and buttons, and adds comments and props. It affects files such as `StandaloneLayout.tsx`, `SpacePresence.tsx`, `SplitView.tsx`, `IdentityListItem.tsx`, `Action.tsx`, `surface.ts`, `SplitViewPlugin.tsx`, `TreeViewPlugin.tsx`, and `focus.ts`.

> _Sing, O Muse, of the skillful coder who refined the app_
> _With many a clever change and comment, pleasing to the eye_
> _He made the `SplitView` and `TreeView` shine like Hephaestus' work_
> _And gave the `Action` and `IdentityListItem` power to forward refs_

### Walkthrough
*  Refactor `IdentityListItem` and `Action` components to use `forwardRef` and pass `ref` prop to their root elements ([link](https://github.com/dxos/dxos/pull/3990/files?diff=unified&w=0#diff-35fdcd372b41e1b68ad32eb8edac6b632bf60e77236fa7993e1dbffe6321fc1eL4-R6),[link](https://github.com/dxos/dxos/pull/3990/files?diff=unified&w=0#diff-35fdcd372b41e1b68ad32eb8edac6b632bf60e77236fa7993e1dbffe6321fc1eL12-R42),[link](https://github.com/dxos/dxos/pull/3990/files?diff=unified&w=0#diff-7fe4da9577079692c74c85e436e71ecc6b1d19ece2a80b4c0ec5dde93d832280L5-R5),[link](https://github.com/dxos/dxos/pull/3990/files?diff=unified&w=0#diff-7fe4da9577079692c74c85e436e71ecc6b1d19ece2a80b4c0ec5dde93d832280L13-R20)).


