### PR TITLE
fix: temp increase max connections limit

### DIFF
--- a/packages/core/mesh/network-manager/src/swarm/connection-limiter.ts
+++ b/packages/core/mesh/network-manager/src/swarm/connection-limiter.ts
@@ -10,7 +10,7 @@ import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { ComplexMap } from '@dxos/util';
 
-export const MAX_CONCURRENT_INITIATING_CONNECTIONS = 3;
+export const MAX_CONCURRENT_INITIATING_CONNECTIONS = 10;
 
 export type ConnectionLimiterOptions = {
   maxConcurrentInitConnections?: number;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at add5c16</samp>

### Summary
:zap::wrench::bug:

<!--
1.  :zap: This emoji represents the improvement in performance and speed that may result from increasing the number of concurrent initiating connections.
2.  :wrench: This emoji represents the adjustment or fine-tuning of the connection limiter parameter, which is a technical or configuration change.
3.  :bug: This emoji represents the potential fix or prevention of bugs or errors that may occur in the swarm connection logic or edge cases.
-->
Increased the limit of concurrent initiating connections in `connection-limiter.ts` to improve swarm network performance. Part of a pull request to enhance swarm connection logic.

> _`MAX_CONCURRENT_INITIATING_CONNECTIONS`_
> _More parallelism_
> _Swarm network improves in spring_

### Walkthrough
* Increase the maximum number of concurrent initiating connections from 3 to 10 to improve swarm performance and reliability ([link](https://github.com/dxos/dxos/pull/4009/files?diff=unified&w=0#diff-5b42d7ec3157b221ac30190dbd5ec52ab9f21ae3d872e74f53c4b4b9b2143256L13-R13)).


