### PR TITLE
docs: Add jsdoc to surface and plugins

### DIFF
--- a/packages/apps/plugins/plugin-debug/src/components/DebugStatus.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DebugStatus.tsx
@@ -138,7 +138,7 @@ const SavingIndicator: FC<IconProps> = (props) => {
   const [state, setState] = useState(0);
   const { plugins } = usePlugins();
   const spacePlugin = findPlugin<SpacePluginProvides>(plugins, 'dxos.org/plugin/space');
-  const space = spacePlugin?.provides.space.current;
+  const space = spacePlugin?.provides.space.active;
   useEffect(() => {
     if (!space) {
       return;

--- a/packages/apps/plugins/plugin-graph/src/GraphPlugin.tsx
+++ b/packages/apps/plugins/plugin-graph/src/GraphPlugin.tsx
@@ -12,6 +12,11 @@ import { Graph, GraphStore } from './graph';
 import { GraphPluginProvides, WithPlugins } from './types';
 import { graphPlugins } from './util';
 
+/**
+ * Manages the state of the graph for the application.
+ * Enables other plugins to register node builders to add nodes to the graph.
+ * This includes actions and annotation each other's nodes.
+ */
 export const GraphPlugin = (): PluginDefinition<GraphPluginProvides> => {
   const graph = new GraphStore();
 

--- a/packages/apps/plugins/plugin-graph/src/graph/types.ts
+++ b/packages/apps/plugins/plugin-graph/src/graph/types.ts
@@ -77,14 +77,23 @@ export namespace Graph {
     onVisitNode?: (node: Node) => void;
   };
 
+  /**
+   * Represents a node in the graph.
+   */
   export type Node<TData = any, TProperties extends { [key: string]: any } = { [key: string]: any }> = {
     /**
-     * Globally unique identifier for the node.
+     * Globally unique ID.
      */
     id: string;
 
     /**
+     * Parent node in the graph.
+     */
+    parent: Node | null;
+
+    /**
      * Label to be used when displaying the node.
+     * For default labels, use a translated string.
      *
      * @example 'My Node'
      * @example ['unknown node label, { ns: 'example-plugin' }]
@@ -94,6 +103,7 @@ export namespace Graph {
 
     /**
      * Description to be used when displaying a detailed view of the node.
+     * For default descriptions, use a translated string.
      */
     description?: string | [string, { ns: string; count?: number }];
 
@@ -106,11 +116,6 @@ export namespace Graph {
      * Data the node represents.
      */
     data: TData;
-
-    /**
-     * Parent node in the graph.
-     */
-    parent: Node | null;
 
     /**
      * Properties of the node relevant to displaying the node.
@@ -151,14 +156,18 @@ export namespace Graph {
     removeProperty(key: string): void;
   };
 
+  /**
+   * An action on a node in the graph which may be invoked by sending the associated intent.
+   */
   export type Action<TProperties extends { [key: string]: any } = { [key: string]: any }> = {
     /**
-     * Locally unique identifier for the action.
+     * Locally unique ID.
      */
     id: string;
 
     /**
      * Label to be used when displaying the node.
+     * For default labels, use a translated string.
      *
      * @example 'My Action'
      * @example ['unknown action label, { ns: 'example-plugin' }]

--- a/packages/apps/plugins/plugin-graph/src/graph/types.ts
+++ b/packages/apps/plugins/plugin-graph/src/graph/types.ts
@@ -185,7 +185,7 @@ export namespace Graph {
     intent?: Intent | Intent[];
 
     /**
-     * Properties of the node relevant to displaying the node.
+     * Properties of the node relevant to displaying the action.
      *
      * @example { index: 'a1' }
      */

--- a/packages/apps/plugins/plugin-graph/src/graph/types.ts
+++ b/packages/apps/plugins/plugin-graph/src/graph/types.ts
@@ -8,39 +8,137 @@ import { FC } from 'react';
 import type { Intent } from '@braneframe/plugin-intent';
 import type { UnsubscribeCallback } from '@dxos/async';
 
+/**
+ * Contract for UI affordances which present, organize and navigate over the graph of user knowledge.
+ */
 export interface Graph {
+  /**
+   * The root node of the graph which is the entry point for all knowledge.
+   */
   get root(): Graph.Node;
+
+  /**
+   * Get the path through the graph from the root to the node with the given id.
+   */
   getPath(id: string): string[] | undefined;
+
+  /**
+   * Find the node with the given id in the graph.
+   */
   find(id: string): Graph.Node | undefined;
+
+  /**
+   * Traverse the graph from the given node.
+   */
   traverse(options: Graph.TraverseOptions): void;
+
+  /**
+   * Register a node builder which will be called in order to construct the graph.
+   */
   registerNodeBuilder(builder: Graph.NodeBuilder): void;
+
+  /**
+   * Remove a node builder from the graph.
+   */
   removeNodeBuilder(builder: Graph.NodeBuilder): void;
+
+  /**
+   * Construct the graph, starting by calling all registered node builders on the root node.
+   * Node builders will be filtered out as they are used such that they are only used once on any given path.
+   */
   construct(): void;
 }
 
 export namespace Graph {
+  /**
+   * Called when a node is added to the graph, allowing other node builders to add children, actions or properties.
+   */
   export type NodeBuilder = (parent: Node) => UnsubscribeCallback | void;
 
   export type TraverseOptions = {
+    /**
+     * The node to start traversing from. Defaults to the root node.
+     */
     from?: Node;
+
+    /**
+     * The direction to traverse the graph. Defaults to 'down'.
+     */
     direction?: 'up' | 'down';
+
+    /**
+     * A predicate to filter nodes which are passed to the `onVisitNode` callback.
+     */
     predicate?: (node: Node) => boolean;
+
+    /**
+     * A callback which is called for each node visited during traversal.
+     */
     onVisitNode?: (node: Node) => void;
   };
 
   export type Node<TData = any, TProperties extends { [key: string]: any } = { [key: string]: any }> = {
+    /**
+     * Globally unique identifier for the node.
+     */
     id: string;
+
+    /**
+     * Label to be used when displaying the node.
+     *
+     * @example 'My Node'
+     * @example ['unknown node label, { ns: 'example-plugin' }]
+     */
     // TODO(thure): `Parameters<TFunction>` causes typechecking issues because `TFunction` has so many signatures.
     label: string | [string, { ns: string; count?: number }];
+
+    /**
+     * Description to be used when displaying a detailed view of the node.
+     */
     description?: string | [string, { ns: string; count?: number }];
+
+    /**
+     * Icon to be used when displaying the node.
+     */
     icon?: FC<IconProps>;
+
+    /**
+     * Data the node represents.
+     */
     data: TData;
+
+    /**
+     * Parent node in the graph.
+     */
     parent: Node | null;
+
+    /**
+     * Properties of the node relevant to displaying the node.
+     *
+     * @example { index: 'a1' }
+     */
     properties: TProperties;
+
+    /**
+     * Children of the node stored by their id.
+     */
     childrenMap: { [key: string]: Node };
+
+    /**
+     * Actions of the node stored by their id.
+     */
     actionsMap: { [key: string]: Action };
+
+    /**
+     * Children of the node in default order.
+     */
     get children(): Node[];
+
+    /**
+     * Actions of the node in default order.
+     */
     get actions(): Action[];
+
     add<TChildData = null, TChildProperties extends { [key: string]: any } = { [key: string]: any }>(
       ...node: (Pick<Node, 'id' | 'label'> & Partial<Node<TChildData, TChildProperties>>)[]
     ): Node<TChildData, TChildProperties>[];
@@ -54,13 +152,46 @@ export namespace Graph {
   };
 
   export type Action<TProperties extends { [key: string]: any } = { [key: string]: any }> = {
+    /**
+     * Locally unique identifier for the action.
+     */
     id: string;
+
+    /**
+     * Label to be used when displaying the node.
+     *
+     * @example 'My Action'
+     * @example ['unknown action label, { ns: 'example-plugin' }]
+     */
     label: string | [string, { ns: string; count?: number }];
+
+    /**
+     * Icon to be used when displaying the node.
+     */
     icon?: FC<IconProps>;
+
+    /**
+     * Intent(s) to be invoked when the action is invoked.
+     */
     intent?: Intent | Intent[];
+
+    /**
+     * Properties of the node relevant to displaying the node.
+     *
+     * @example { index: 'a1' }
+     */
     properties: TProperties;
+
+    /**
+     * Sub-actions of the node stored by their id.
+     */
     actionsMap: { [key: string]: Action };
+
+    /**
+     * Actions of the node in default order.
+     */
     get actions(): Action[];
+
     invoke: () => Promise<any>;
     add<TActionProperties extends { [key: string]: any } = { [key: string]: any }>(
       ...action: (Pick<Action, 'id' | 'label'> & Partial<Action<TActionProperties>>)[]

--- a/packages/apps/plugins/plugin-grid/src/components/GridMain.tsx
+++ b/packages/apps/plugins/plugin-grid/src/components/GridMain.tsx
@@ -16,7 +16,7 @@ import { findPlugin, usePlugins } from '@dxos/react-surface';
 export const GridMain: FC<{ data: TypedObject }> = ({ data: object }) => {
   const { plugins } = usePlugins();
   const spacePlugin = findPlugin<SpacePluginProvides>(plugins, 'dxos.org/plugin/space');
-  const space = spacePlugin?.provides?.space.current;
+  const space = spacePlugin?.provides?.space.active;
 
   return (
     <Main.Content classNames={['flex flex-col min-bs-[calc(100dvh-2.5rem)] overflow-hidden', coarseBlockPaddingStart]}>

--- a/packages/apps/plugins/plugin-intent/src/IntentPlugin.tsx
+++ b/packages/apps/plugins/plugin-intent/src/IntentPlugin.tsx
@@ -50,13 +50,32 @@ export const IntentPlugin = (): PluginDefinition<IntentPluginProvides> => {
 
 export type IntentPluginProvides = {
   intent: {
+    /**
+     * Trigger one or more intents to be sent.
+     * If multiple intents are specified, the result of each will be merged with the data to the next.
+     *
+     * @returns The result of the last intent.
+     */
     sendIntent: SendIntent;
   };
 };
 
 export type Intent = {
+  /**
+   * Plugin ID.
+   * If specified, the intent will be sent explicitly to the plugin.
+   * Otherwise, the intent will be sent to all plugins, in order and the first to resolve a non-null value will be used.
+   */
   plugin?: string;
+
+  /**
+   * The action to perform.
+   */
   action: string;
+
+  /**
+   * Any data needed to perform the desired action.
+   */
   data?: any;
 };
 

--- a/packages/apps/plugins/plugin-intent/src/IntentPlugin.tsx
+++ b/packages/apps/plugins/plugin-intent/src/IntentPlugin.tsx
@@ -7,6 +7,11 @@ import React, { createContext, useContext } from 'react';
 
 import { Plugin, PluginDefinition, findPlugin } from '@dxos/react-surface';
 
+// Intents inspired by https://developer.android.com/reference/android/content/Intent.
+
+/**
+ * Allows plugins to register intent handlers and routes sent intents to the appropriate plugin.
+ */
 export const IntentPlugin = (): PluginDefinition<IntentPluginProvides> => {
   const state = deepSignal<{ sendIntent: SendIntent }>({ sendIntent: async () => {} });
 
@@ -60,6 +65,10 @@ export type IntentPluginProvides = {
   };
 };
 
+/**
+ * An intent is an abstract description of an operation to be performed.
+ * Intents allow actions to be performed across plugins.
+ */
 export type Intent = {
   /**
    * Plugin ID.

--- a/packages/apps/plugins/plugin-kanban/src/components/KanbanMain.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/components/KanbanMain.tsx
@@ -18,7 +18,7 @@ export const KanbanMain: FC<{ data: KanbanType }> = ({ data: object }) => {
 
   const { plugins } = usePlugins();
   const spacePlugin = findPlugin<SpacePluginProvides>(plugins, 'dxos.org/plugin/space');
-  const space = spacePlugin?.provides?.space.current;
+  const space = spacePlugin?.provides?.space.active;
 
   if (!space) {
     return null;

--- a/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -69,7 +69,7 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
     const identity = useIdentity();
     const { plugins } = usePlugins();
     const spacePlugin = findPlugin<SpacePluginProvides>(plugins, 'dxos.org/plugin/space');
-    const space = spacePlugin?.provides.space.current;
+    const space = spacePlugin?.provides.space.active;
 
     const textModel = useTextModel({
       identity,
@@ -100,7 +100,7 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
     const identity = useIdentity();
     const { plugins } = usePlugins();
     const spacePlugin = findPlugin<SpacePluginProvides>(plugins, 'dxos.org/plugin/space');
-    const space = spacePlugin?.provides.space.current;
+    const space = spacePlugin?.provides.space.active;
 
     const textModel = useTextModel({
       identity,

--- a/packages/apps/plugins/plugin-markdown/src/components/MarkdownMain.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/MarkdownMain.tsx
@@ -25,7 +25,7 @@ export const MarkdownMain: FC<{ data: unknown }> = ({ data }) => {
 
   const textModel = useTextModel({
     identity,
-    space: spacePlugin?.provides.space.current,
+    space: spacePlugin?.provides.space.active,
     text: document?.content,
   });
 

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -38,7 +38,7 @@ import { getSpaceId, isSpace, spaceToGraphNode } from './util';
 (globalThis as any)[SpaceProxy.name] = SpaceProxy;
 
 export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
-  const state = deepSignal<SpaceState>({ current: undefined });
+  const state = deepSignal<SpaceState>({ active: undefined });
   const subscriptions = new EventSubscriptions();
   let disposeSetSpaceProvider: () => void;
 
@@ -82,7 +82,7 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
           resolve(undefined);
         });
 
-        state.current = space;
+        state.active = space;
 
         if (
           space instanceof SpaceProxy &&

--- a/packages/apps/plugins/plugin-space/src/components/SpacePresence.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/SpacePresence.tsx
@@ -18,7 +18,7 @@ export const SpacePresence = () => {
   const { plugins } = usePlugins();
   const spacePlugin = findPlugin<SpacePluginProvides>(plugins, 'dxos.org/plugin/space');
   const intentPlugin = findPlugin<IntentPluginProvides>(plugins, 'dxos.org/plugin/intent');
-  const space = spacePlugin?.provides.space.current;
+  const space = spacePlugin?.provides.space.active;
   const identity = useIdentity();
   if (!identity) {
     return null;

--- a/packages/apps/plugins/plugin-space/src/types.ts
+++ b/packages/apps/plugins/plugin-space/src/types.ts
@@ -25,6 +25,12 @@ export enum SpaceAction {
 }
 
 export type SpaceState = {
+  /**
+   * The space which is associated with the currently active graph node.
+   * If the current graph node does not itself represent a space, then it is the space of the nearest ancestor.
+   * If no ancestor represents a space, then it is undefined.
+   */
+  // TODO(wittjosiah): Rename active to align with treeview.
   current: Space | undefined;
 };
 

--- a/packages/apps/plugins/plugin-space/src/types.ts
+++ b/packages/apps/plugins/plugin-space/src/types.ts
@@ -24,14 +24,16 @@ export enum SpaceAction {
   RENAME_OBJECT = `${SPACE_ACTION}/rename-object`,
 }
 
+/**
+ * The state of the space plugin.
+ */
 export type SpaceState = {
   /**
-   * The space which is associated with the currently active graph node.
+   * The space that is associated with the currently active graph node.
    * If the current graph node does not itself represent a space, then it is the space of the nearest ancestor.
    * If no ancestor represents a space, then it is undefined.
    */
-  // TODO(wittjosiah): Rename active to align with treeview.
-  current: Space | undefined;
+  active: Space | undefined;
 };
 
 export type SpacePluginProvides = GraphProvides &

--- a/packages/apps/plugins/plugin-template/src/components/TemplateMain.tsx
+++ b/packages/apps/plugins/plugin-template/src/components/TemplateMain.tsx
@@ -14,7 +14,7 @@ import { findPlugin, usePlugins } from '@dxos/react-surface';
 export const TemplateMain: FC<{ data: TypedObject }> = ({ data: object }) => {
   const { plugins } = usePlugins();
   const spacePlugin = findPlugin<SpacePluginProvides>(plugins, 'dxos.org/plugin/space');
-  const space = spacePlugin?.provides?.space.current;
+  const space = spacePlugin?.provides?.space.active;
 
   return (
     // TODO(burdon): Boilerplate.

--- a/packages/sdk/react-surface/src/Plugin.ts
+++ b/packages/sdk/react-surface/src/Plugin.ts
@@ -7,11 +7,15 @@ import { FC, PropsWithChildren } from 'react';
 /**
  * Props passed to a component by the `Surface` resolver.
  */
-export type ComponentProps = PropsWithChildren<{
+export type PluginComponentProps = PropsWithChildren<{
   data: any;
   role?: string;
 }>;
 
+/**
+ * Capabilities provided by a plugin.
+ * The base surface capabilities are always included.
+ */
 export type PluginProvides<TProvides> = TProvides & {
   /**
    * React Context which is wrapped around the application to enable any hooks the plugin may provide.
@@ -25,18 +29,22 @@ export type PluginProvides<TProvides> = TProvides & {
     data: unknown,
     role?: string,
     props?: Partial<P>,
-  ) => FC<ComponentProps> | undefined | null | false | 0;
+  ) => FC<PluginComponentProps> | undefined | null | false | 0;
 
   /**
    * Used by the `Surface` resolver to find a component by name.
    */
-  components?: Record<string, FC<ComponentProps>> & { default?: FC };
+  components?: Record<string, FC<PluginComponentProps>> & { default?: FC };
 };
 
+/**
+ * A unit of containment of modular functionality that can be provided to an application.
+ * Plugins provide things like components, state, actions, etc. to the application.
+ */
 export type Plugin<TProvides = {}> = {
   meta: {
     /**
-     * Globally unique identifier for the plugin.
+     * Globally unique ID.
      *
      * Expected to be in the form of a valid URL.
      *
@@ -59,6 +67,9 @@ export type Plugin<TProvides = {}> = {
   provides: PluginProvides<TProvides>;
 };
 
+/**
+ * Plugin definitions extend the base `Plugin` interface with additional lifecycle methods.
+ */
 export type PluginDefinition<TProvides = {}, TInitializeProvides = {}> = Omit<Plugin, 'provides'> & {
   /**
    * Capabilities provided by the plugin.

--- a/packages/sdk/react-surface/src/Plugin.ts
+++ b/packages/sdk/react-surface/src/Plugin.ts
@@ -4,37 +4,92 @@
 
 import { FC, PropsWithChildren } from 'react';
 
+/**
+ * Props passed to a component by the `Surface` resolver.
+ */
 export type ComponentProps = PropsWithChildren<{
   data: any;
   role?: string;
 }>;
 
 export type PluginProvides<TProvides> = TProvides & {
+  /**
+   * React Context which is wrapped around the application to enable any hooks the plugin may provide.
+   */
   context?: FC<PropsWithChildren>;
+
+  /**
+   * Used by the `Surface` resolver to find a component to render when presented with data but no component name.
+   */
   component?: <P extends PropsWithChildren = PropsWithChildren>(
     data: unknown,
     role?: string,
     props?: Partial<P>,
   ) => FC<ComponentProps> | undefined | null | false | 0;
+
+  /**
+   * Used by the `Surface` resolver to find a component by name.
+   */
   components?: Record<string, FC<ComponentProps>> & { default?: FC };
 };
 
 export type Plugin<TProvides = {}> = {
   meta: {
+    /**
+     * Globally unique identifier for the plugin.
+     *
+     * Expected to be in the form of a valid URL.
+     *
+     * @example dxos.org/plugin/example
+     */
     id: string;
+
+    /**
+     * Short ID for use in URLs.
+     *
+     * NOTE: This is especially experimental and likely to change.
+     */
     // TODO(wittjosiah): How should these be managed?
     shortId?: string;
   };
+
+  /**
+   * Capabilities provided by the plugin.
+   */
   provides: PluginProvides<TProvides>;
 };
 
 export type PluginDefinition<TProvides = {}, TInitializeProvides = {}> = Omit<Plugin, 'provides'> & {
+  /**
+   * Capabilities provided by the plugin.
+   */
   provides?: Plugin<TProvides>['provides'];
+
+  /**
+   * Initialize any async behavior required by the plugin.
+   *
+   * @return Capabilities provided by the plugin which are merged with base capabilities.
+   */
   initialize?: () => Promise<PluginProvides<TInitializeProvides>>;
+
+  /**
+   * Called once all plugins have been initialized.
+   * This is the place to do any initialization which requires other plugins to be ready.
+   *
+   * @param plugins All plugins which successfully initialized.
+   */
   ready?: (plugins: Plugin[]) => Promise<void>;
+
+  /**
+   * Called when the plugin is unloaded.
+   * This is the place to do any cleanup required by the plugin.
+   */
   unload?: () => Promise<void>;
 };
 
+/**
+ * Find a plugin by ID.
+ */
 export const findPlugin = <T>(plugins: Plugin[], id: string): Plugin<T> | undefined => {
   return plugins.find(
     (plugin) => plugin.meta.id === id || (typeof plugin.meta.shortId === 'string' && plugin.meta.shortId === id),

--- a/packages/sdk/react-surface/src/PluginContext.tsx
+++ b/packages/sdk/react-surface/src/PluginContext.tsx
@@ -9,7 +9,7 @@ import { log } from '@dxos/log';
 import { composeContext } from './Context';
 import { Plugin, PluginDefinition, PluginProvides, findPlugin } from './Plugin';
 
-export type PluginContextValue = {
+type PluginContextValue = {
   plugins: Plugin[];
 };
 
@@ -17,13 +17,37 @@ const defaultContext: PluginContextValue = { plugins: [] };
 
 const PluginContext = createContext<PluginContextValue>(defaultContext);
 
-export const usePlugins = () => useContext(PluginContext);
+/**
+ * Get all plugins.
+ */
+export const usePlugins = (): PluginContextValue => useContext(PluginContext);
 
+/**
+ * Get a plugin by ID.
+ */
 export const usePlugin = <T,>(id: string): Plugin<T> | undefined => {
   const { plugins } = usePlugins();
   return findPlugin<T>(plugins, id);
 };
 
+/**
+ * This provider initializes plugins and provides them to the application.
+ * It also provides a `PluginContext` which can be used to access plugins.
+ * Expected usage is for this to be the entrypoint of the application.
+ *
+ * @example
+ * createRoot(document.getElementById('root')!).render(
+ *   <StrictMode>
+ *     <PluginProvider
+ *       fallback={<div>Initializing Plugins...</div>}
+ *       plugins={[...]}
+ *     />
+ *   </StrictMode>,
+ * );
+ *
+ * @param options.plugins List of plugin definitions to initialize.
+ * @param options.fallback Fallback component to render while plugins are initializing.
+ */
 export const PluginProvider = ({
   plugins: definitions,
   fallback,
@@ -68,6 +92,9 @@ export const PluginProvider = ({
   );
 };
 
+/**
+ * Resolve a `PluginDefinition` into a fully initialized `Plugin`.
+ */
 export const initializePlugin = async <T, U>(pluginDefinition: PluginDefinition<T, U>): Promise<Plugin<T & U>> => {
   const provides = await pluginDefinition.initialize?.();
   return {

--- a/packages/sdk/react-surface/src/Surface.tsx
+++ b/packages/sdk/react-surface/src/Surface.tsx
@@ -8,16 +8,53 @@ import { ErrorBoundary } from './ErrorBoundary';
 import { Plugin } from './Plugin';
 import { usePlugins } from './PluginContext';
 
+/**
+ * Direction determines how multiple components are laid out.
+ */
 export type Direction = 'inline' | 'inline-reverse' | 'block' | 'block-reverse';
 
 export type SurfaceProps = PropsWithChildren<{
+  /**
+   * Names allow nested surfaces to be specified in the parent context, similar to a slot.
+   */
   name?: string;
-  data?: any;
-  component?: string | string[];
-  fallback?: ErrorBoundary['props']['fallback'];
+
+  /**
+   * Role defines how the data should be rendered.
+   */
   role?: string;
+
+  /**
+   * The data to be rendered by the surface.
+   */
+  data?: any;
+
+  /**
+   * If specified, the Surface will lookup the component(s) by name and only render if found.
+   */
+  component?: string | string[];
+
+  /**
+   * If specified, the Surface will be wrapped in an error boundary.
+   * The fallback component will be rendered if an error occurs.
+   */
+  fallback?: ErrorBoundary['props']['fallback'];
+
+  /**
+   * Configure nested surfaces.
+   */
   surfaces?: Record<string, Partial<SurfaceProps>>;
+
+  /**
+   * If more than one component is resolved, the limit determines how many are rendered.
+   */
   limit?: number | undefined;
+
+  /**
+   * If more than one component is resolved, the direction determines how they are laid out.
+   *
+   * NOTE: This is not yet implemented.
+   */
   direction?: Direction;
 }>;
 
@@ -27,8 +64,6 @@ type SurfaceContextValue = SurfaceProps & {
 };
 
 const SurfaceContext = createContext<SurfaceContextValue | null>(null);
-
-export const useSurfaceContext = () => useContext(SurfaceContext);
 
 // If component is specified in props or context, grab a component by name.
 // Otherwise, iterate through plugins where `plugin.provides.component(data)` returns something.
@@ -84,8 +119,11 @@ const findComponent = (plugins: Plugin[], name: string): FC<PropsWithChildren<an
     .components?.[componentId];
 };
 
+/**
+ * A surface is a named region of the screen that can be populated by plugins.
+ */
 export const Surface = (props: SurfaceProps) => {
-  const context = useSurfaceContext();
+  const context = useContext(SurfaceContext);
   const data = props.data ?? (props.name && context?.surfaces?.[props.name]?.data);
   const fallback = props.fallback ?? (props.name && context?.surfaces?.[props.name]?.fallback);
 
@@ -104,7 +142,7 @@ export const Surface = (props: SurfaceProps) => {
 
 const SurfaceResolver = (props: SurfaceProps) => {
   const { plugins } = usePlugins();
-  const parent = useSurfaceContext();
+  const parent = useContext(SurfaceContext);
   const components = resolveComponents(plugins, props, parent);
   const currentContext = {
     ...((props.name && parent?.surfaces?.[props.name]) ?? {}),

--- a/packages/sdk/react-surface/src/index.ts
+++ b/packages/sdk/react-surface/src/index.ts
@@ -2,8 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './Context';
-export * from './ErrorBoundary';
-export * from './PluginContext';
-export * from './Plugin';
-export * from './Surface';
+export { ErrorBoundary } from './ErrorBoundary';
+export { usePlugins, usePlugin, PluginProvider, initializePlugin } from './PluginContext';
+export { ComponentProps, PluginDefinition, PluginProvides, Plugin, findPlugin } from './Plugin';
+export { Direction, SurfaceProps, Surface } from './Surface';

--- a/packages/sdk/react-surface/src/index.ts
+++ b/packages/sdk/react-surface/src/index.ts
@@ -4,5 +4,5 @@
 
 export { ErrorBoundary } from './ErrorBoundary';
 export { usePlugins, usePlugin, PluginProvider, initializePlugin } from './PluginContext';
-export { ComponentProps, PluginDefinition, PluginProvides, Plugin, findPlugin } from './Plugin';
+export { PluginComponentProps, PluginDefinition, PluginProvides, Plugin, findPlugin } from './Plugin';
 export { Direction, SurfaceProps, Surface } from './Surface';


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 954f9f7</samp>

### Summary
📝📦🧹

<!--
1.  📝 This emoji represents documentation, comments, or writing. It is suitable for changes that add or improve documentation comments, or explain the logic or purpose of the code.
2. 📦 This emoji represents packaging, bundling, or exporting. It is suitable for changes that affect the way the code is exported, imported, or structured, or that improve the encapsulation or modularity of the code.
3. 🧹 This emoji represents cleaning, tidying, or simplifying. It is suitable for changes that remove unused or unnecessary code, or that refactor or simplify the code.
-->
This pull request improves the documentation, code quality, and modularity of various types and components related to plugins in the `dxos` repository. It adds documentation comments to several types and properties in the `plugin-graph`, `plugin-intent`, and `plugin-space` packages, as well as the `react-surface` package. It also simplifies and cleans up some code in the `Surface.tsx` and `PluginContext.tsx` modules, and changes the exports from the `index.ts` file to be more selective and consistent.

> _The code in this pull request is fine_
> _It adds comments to make it shine_
> _It exports what it should_
> _And removes what it could_
> _And simplifies hooks like `useLine`_

### Walkthrough
*  Add documentation comments to various types, properties, methods, functions, and components to improve readability, maintainability, and information for consumers. ([link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-c3627baa8917066852bedbbedcc8aa28433af0b953d1713a2042d1398ab1be0eL11-R141), [link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-c3627baa8917066852bedbbedcc8aa28433af0b953d1713a2042d1398ab1be0eL57-R194), [link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-1c00cc8f7b3a5db7b5430f97db5f272a87d7bd690f7b1461fa4051f8a67543f0R53-R58), [link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-1c00cc8f7b3a5db7b5430f97db5f272a87d7bd690f7b1461fa4051f8a67543f0L58-R78), [link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-2bbe42f0e3e95ee23effd7b45ef36b44310334660399930229f4fb6524b943dfR28-R33), [link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-864b16318d85c5a4b574472ebd18497b7960fe77cff6d8637345b258b94dbb53R7-R9), [link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-864b16318d85c5a4b574472ebd18497b7960fe77cff6d8637345b258b94dbb53L13-R23), [link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-864b16318d85c5a4b574472ebd18497b7960fe77cff6d8637345b258b94dbb53R29-R32), [link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-864b16318d85c5a4b574472ebd18497b7960fe77cff6d8637345b258b94dbb53L24-R92), [link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-a699a90c0d67a98a7bb8907df938bcc44b7989579c15d062857add5f6f6cebd1L20-R27), [link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-a699a90c0d67a98a7bb8907df938bcc44b7989579c15d062857add5f6f6cebd1R33-R50), [link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-a699a90c0d67a98a7bb8907df938bcc44b7989579c15d062857add5f6f6cebd1R95-R97), [link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-cded385be5b331e0c7e6f4d63c1789fd2afee4e7b00427522ba380b846801e42L11-R57), [link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-cded385be5b331e0c7e6f4d63c1789fd2afee4e7b00427522ba380b846801e42L107-R145))
* Change the exports from the `index.ts` file in `react-surface` to export only the relevant types and components, improving encapsulation, modularity, and API surface area. ([link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-7d55845de672aa1c405e7f73b954a3fe03540b7f9ba989b3e9332515e1682340L5-R8))
* Change the `PluginContextValue` type in `PluginContext.tsx` to a local type, as it is only used internally and does not need to be exposed, improving encapsulation, modularity, and API surface area. ([link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-a699a90c0d67a98a7bb8907df938bcc44b7989579c15d062857add5f6f6cebd1L12-R12))
* Remove the `useSurfaceContext` hook from `Surface.tsx`, as it is not used anywhere and does not need to be exposed, improving encapsulation, modularity, and API surface area. ([link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-cded385be5b331e0c7e6f4d63c1789fd2afee4e7b00427522ba380b846801e42L31-L32))
* Change the `useSurfaceContext` hook to the `useContext` hook with the `SurfaceContext` argument in `Surface.tsx`, as it is equivalent and more concise, improving readability and simplicity. ([link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-cded385be5b331e0c7e6f4d63c1789fd2afee4e7b00427522ba380b846801e42L87-R126))
* Add a TODO comment to the `activeSpace` property of the `SpacePluginProvides` type in `types.ts` to indicate a possible renaming of the property to align with the treeview component. ([link](https://github.com/dxos/dxos/pull/4014/files?diff=unified&w=0#diff-2bbe42f0e3e95ee23effd7b45ef36b44310334660399930229f4fb6524b943dfR28-R33))


