### PR TITLE
feat(devtools): add proxy for debugging mobile devices

### DIFF
--- a/packages/apps/composer-app/dx-local.yml
+++ b/packages/apps/composer-app/dx-local.yml
@@ -2,9 +2,9 @@ version: 1
 
 runtime:
   client:
-    remoteSource: https://192.168.50.25:3967/vault.html
-    devtoolsProxy: wss://192.168.50.25:8080/host
+    remoteSource: http://localhost:3967/vault.html
+    # devtoolsProxy: wss://192.168.50.25:8080/host
 
-  # services:
-  #   signaling:
-  #     - server: ws://localhost:8888/.well-known/dx/signal
+  services:
+    signaling:
+      - server: ws://localhost:8888/.well-known/dx/signal

--- a/packages/apps/composer-app/dx-local.yml
+++ b/packages/apps/composer-app/dx-local.yml
@@ -2,8 +2,9 @@ version: 1
 
 runtime:
   client:
-    remoteSource: http://localhost:3967/vault.html
+    remoteSource: https://192.168.50.25:3967/vault.html
+    devtoolsProxy: wss://192.168.50.25:8080/host
 
-  services:
-    signaling:
-      - server: ws://localhost:8888/.well-known/dx/signal
+  # services:
+  #   signaling:
+  #     - server: ws://localhost:8888/.well-known/dx/signal

--- a/packages/core/protocols/src/proto/dxos/config.proto
+++ b/packages/core/protocols/src/proto/dxos/config.proto
@@ -122,6 +122,9 @@ message Runtime {
     /// Location of the remote client host.
     // TODO(burdon): Rename vault_endpoint (generalize http/ws; drop vault.html).
     optional string remote_source = 6;
+
+    /// Connect to and serve client services to a remote proxy.
+    optional string devtools_proxy = 7;
   }
 
   message App {

--- a/packages/devtools/devtools/README.md
+++ b/packages/devtools/devtools/README.md
@@ -9,9 +9,34 @@ It is configured to listen for halo-app shared worker (`pnpm nx serve halo-app`)
 
 Serve the devtools app:
 
-`pnpm -w nx serve devtools`
+```bash
+pnpm -w nx serve devtools
+```
 
 Then open the testbench: `http://localhost:5173/testbench.html`
 
 Alternatively, connect devtools to a remote client, 
 e.g., `http://localhost:5173?target=vault:http://localhost:3967/vault.html`
+
+## Connect to mobile browser
+
+First ensure that local certs are available by following [these instructions](../../../REPOSITORY_GUIDE.md#mobile-development).
+
+The config of the application also needs to be updated to point to the proxy:
+
+```yaml
+runtime:
+  client:
+    remoteSource: https://192.168.0.18:3967/vault.html
+    devtoolsProxy: wss://192.168.0.18:8080/host
+```
+
+Next, run the proxy socket:
+
+```bash
+pnpm -w nx proxy devtools
+```
+
+Once the socket is running both devtools and the app can connect to it in order to connect to each other.
+The app will know how to connect based on the provided config.
+For devtools a target will need to be provided: `https://devtools.dev.dxos.org/?target=wss://192.168.0.18:8080`.

--- a/packages/devtools/devtools/package.json
+++ b/packages/devtools/devtools/package.json
@@ -12,6 +12,9 @@
     "./dist/lib/node/index.cjs": "./dist/lib/browser/index.mjs"
   },
   "types": "dist/types/src/index.d.ts",
+  "scripts": {
+    "proxy": "ts-node scripts/proxy.ts"
+  },
   "dependencies": {
     "@dxos/async": "workspace:*",
     "@dxos/aurora": "workspace:*",
@@ -42,6 +45,7 @@
     "date-fns": "^2.29.3",
     "deepsignal": "^1.3.3",
     "flame-chart-js": "^2.3.1",
+    "isomorphic-ws": "^4.0.1",
     "localforage": "^1.10.0",
     "lodash.defaultsdeep": "^4.6.1",
     "react": "^18.2.0",
@@ -52,7 +56,8 @@
     "react-router-dom": "^6.4.0",
     "react-syntax-highlighter": "^15.5.0",
     "react-vis": "^1.11.12",
-    "use-resize-observer": "^9.0.0"
+    "use-resize-observer": "^9.0.0",
+    "ws": "^7.4.4"
   },
   "devDependencies": {
     "@dxos/aurora-theme": "workspace:*",

--- a/packages/devtools/devtools/scripts/proxy.ts
+++ b/packages/devtools/devtools/scripts/proxy.ts
@@ -1,0 +1,64 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import WebSocket from 'isomorphic-ws';
+import { readFile } from 'node:fs/promises';
+import type { IncomingMessage } from 'node:http';
+import https from 'node:https';
+
+import { log } from '@dxos/log';
+
+log.config({ filter: 'warn' });
+
+const main = async () => {
+  const server = https.createServer({
+    key: await readFile('../../../key.pem'),
+    cert: await readFile('../../../cert.pem'),
+  });
+  const ws = new WebSocket.Server({ server });
+
+  let host: WebSocket | undefined;
+  let devtools: WebSocket | undefined;
+
+  const handleHost = (socket: WebSocket, request: IncomingMessage) => {
+    host = socket;
+    socket.on('message', (data) => {
+      log('from host', { data });
+      if (devtools) {
+        devtools.send(data);
+      }
+    });
+  };
+
+  const handleDevtools = (socket: WebSocket, request: IncomingMessage) => {
+    devtools = socket;
+    socket.on('message', (data) => {
+      log('from devtools', { data });
+      if (host) {
+        host.send(data);
+      }
+    });
+  };
+
+  ws.on('listening', () => {
+    log('Listening...');
+  });
+
+  ws.on('connection', (socket, request) => {
+    log('connection', { url: request.url });
+
+    switch (request.url) {
+      case '/host':
+        handleHost(socket, request);
+        break;
+
+      default:
+        handleDevtools(socket, request);
+    }
+  });
+
+  server.listen(parseInt(process.env.PORT ?? '8080'));
+};
+
+void main();

--- a/packages/devtools/devtools/scripts/proxy.ts
+++ b/packages/devtools/devtools/scripts/proxy.ts
@@ -22,6 +22,10 @@ const main = async () => {
   let devtools: WebSocket | undefined;
 
   const handleHost = (socket: WebSocket, request: IncomingMessage) => {
+    if (host) {
+      host?.removeAllListeners('message');
+    }
+
     host = socket;
     socket.on('message', (data) => {
       log('from host', { data });

--- a/packages/devtools/devtools/tsconfig.json
+++ b/packages/devtools/devtools/tsconfig.json
@@ -14,6 +14,7 @@
     ]
   },
   "include": [
+    "scripts",
     "src"
   ],
   "references": [

--- a/packages/sdk/client-services/package.json
+++ b/packages/sdk/client-services/package.json
@@ -52,7 +52,8 @@
     "@dxos/text-model": "workspace:*",
     "@dxos/timeframe": "workspace:*",
     "@dxos/tracing": "workspace:*",
-    "@dxos/util": "workspace:*"
+    "@dxos/util": "workspace:*",
+    "@dxos/websocket-rpc": "workspace:*"
   },
   "devDependencies": {
     "@dxos/signal": "workspace:*",

--- a/packages/sdk/client-services/src/packlets/services/service-host.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-host.ts
@@ -108,7 +108,7 @@ export class ClientServicesHost {
     this._callbacks = callbacks;
 
     if (config) {
-      void this.initialize({ config, transportFactory, signalManager });
+      this.initialize({ config, transportFactory, signalManager });
     }
 
     if (lockKey) {
@@ -180,7 +180,7 @@ export class ClientServicesHost {
    * Config can also be provided in the constructor.
    * Can only be called once.
    */
-  async initialize({ config, ...options }: InitializeOptions) {
+  initialize({ config, ...options }: InitializeOptions) {
     invariant(!this._open, 'service host is open');
     log('initializing...');
 
@@ -282,7 +282,6 @@ export class ClientServicesHost {
     await this._serviceContext.open(ctx);
 
     const devtoolsProxy = this._config?.get('runtime.client.devtoolsProxy');
-    console.log('devtoolsProxy', devtoolsProxy);
     if (devtoolsProxy) {
       this._devtoolsProxy = new WebsocketRpcClient({
         url: devtoolsProxy,
@@ -291,7 +290,6 @@ export class ClientServicesHost {
         handlers: this.services as ClientServices,
       });
       void this._devtoolsProxy.open();
-      console.log('opening devtools proxy');
     }
 
     this._opening = false;

--- a/packages/sdk/client-services/tsconfig.json
+++ b/packages/sdk/client-services/tsconfig.json
@@ -104,6 +104,9 @@
       "path": "../../core/mesh/teleport-extension-object-sync"
     },
     {
+      "path": "../../core/mesh/websocket-rpc"
+    },
+    {
       "path": "../../core/protocols"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3358,6 +3358,7 @@ importers:
       date-fns: ^2.29.3
       deepsignal: ^1.3.3
       flame-chart-js: ^2.3.1
+      isomorphic-ws: ^4.0.1
       localforage: ^1.10.0
       lodash.defaultsdeep: ^4.6.1
       postcss: ^8.4.21
@@ -3376,6 +3377,7 @@ importers:
       vite-plugin-fonts: ^0.7.0
       vite-plugin-pwa: ^0.14.1
       workbox-window: ^6.5.4
+      ws: ^7.4.4
     dependencies:
       '@dxos/async': link:../../common/async
       '@dxos/aurora': link:../../ui/aurora
@@ -3406,6 +3408,7 @@ importers:
       date-fns: 2.29.3
       deepsignal: 1.3.4_react@18.2.0
       flame-chart-js: 2.3.1
+      isomorphic-ws: 4.0.1_ws@7.5.9
       localforage: 1.10.0
       lodash.defaultsdeep: 4.6.1
       react: 18.2.0
@@ -3417,6 +3420,7 @@ importers:
       react-syntax-highlighter: 15.5.0_react@18.2.0
       react-vis: 1.11.12_biqbaboplfbrettd7655fr4n2y
       use-resize-observer: 9.1.0_biqbaboplfbrettd7655fr4n2y
+      ws: 7.5.9
     devDependencies:
       '@dxos/config': link:../../sdk/config
       '@dxos/react-shell': link:../../sdk/react-shell
@@ -5270,6 +5274,7 @@ importers:
       '@dxos/timeframe': workspace:*
       '@dxos/tracing': workspace:*
       '@dxos/util': workspace:*
+      '@dxos/websocket-rpc': workspace:*
       '@types/readable-stream': ^2.3.9
     dependencies:
       '@dxos/async': link:../../common/async
@@ -5304,6 +5309,7 @@ importers:
       '@dxos/timeframe': link:../../common/timeframe
       '@dxos/tracing': link:../../common/tracing
       '@dxos/util': link:../../common/util
+      '@dxos/websocket-rpc': link:../../core/mesh/websocket-rpc
     devDependencies:
       '@dxos/signal': link:../../core/mesh/signal
       '@types/readable-stream': 2.3.14
@@ -11848,6 +11854,7 @@ packages:
     dependencies:
       '@nx/cypress': 16.5.4_ira35blaljp6ziq6rkbxh2c3im
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - cypress
@@ -11872,6 +11879,7 @@ packages:
     dependencies:
       '@nx/eslint-plugin': 16.5.4_f5sjyg6hkkwzmez5q6ml55qszi
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@typescript-eslint/parser'
@@ -11889,6 +11897,7 @@ packages:
     dependencies:
       '@nx/jest': 16.5.4_dwxsgwctamj3e4zqclpyae4gcu
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@types/node'
@@ -11906,6 +11915,7 @@ packages:
     dependencies:
       '@nx/js': 16.5.4_kco6wocfncyehzbvd6faof7n2y_wcxuhe4tvwpsd3renjlc7ah6mu
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11920,6 +11930,7 @@ packages:
     dependencies:
       '@nx/linter': 16.5.4_ira35blaljp6ziq6rkbxh2c3im
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11943,6 +11954,7 @@ packages:
     dependencies:
       '@nx/storybook': 16.5.4_ira35blaljp6ziq6rkbxh2c3im
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - cypress
@@ -11970,6 +11982,7 @@ packages:
     dependencies:
       '@nx/vite': 16.5.4_xxzhsuqrsbs6wyvhvm37cpe46m_3dw4w4asrgslkotzjeholo4g7a
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11985,6 +11998,7 @@ packages:
     dependencies:
       '@nx/web': 16.5.4_wcxuhe4tvwpsd3renjlc7ah6mu
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12021,6 +12035,7 @@ packages:
       dotenv: 10.0.0
       semver: 7.5.3
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12065,6 +12080,7 @@ packages:
       jsonc-eslint-parser: 2.3.0
       semver: 7.5.3
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12093,6 +12109,7 @@ packages:
       resolve.exports: 1.1.0
       tslib: 2.5.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@types/node'
@@ -12126,7 +12143,7 @@ packages:
       '@phenomnomnominal/tsquery': 5.0.1_typescript@5.0.4
       babel-plugin-const-enum: 1.2.0_@babel+core@7.21.3
       babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2
+      babel-plugin-transform-typescript-metadata: 0.3.2_@babel+core@7.21.3
       chalk: 4.1.2
       detect-port: 1.5.1
       fast-glob: 3.2.7
@@ -12138,6 +12155,7 @@ packages:
       source-map-support: 0.5.19
       tslib: 2.5.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12163,6 +12181,7 @@ packages:
       tmp: 0.2.1
       tslib: 2.5.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12275,6 +12294,7 @@ packages:
       dotenv: 10.0.0
       semver: 7.5.3
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - cypress
@@ -12300,6 +12320,7 @@ packages:
       enquirer: 2.3.6
       vite: 4.3.9_@types+node@18.11.9
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12323,6 +12344,7 @@ packages:
       ignore: 5.2.0
       tslib: 2.5.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -15630,7 +15652,7 @@ packages:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
       watchpack: 2.4.0
-      ws: 8.9.0
+      ws: 8.13.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -20119,7 +20141,7 @@ packages:
   /axios/1.3.4_debug@4.3.4:
     resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2_debug@4.3.4
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -20324,9 +20346,16 @@ packages:
   /babel-plugin-syntax-jsx/6.18.0:
     resolution: {integrity: sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==}
 
-  /babel-plugin-transform-typescript-metadata/0.3.2:
+  /babel-plugin-transform-typescript-metadata/0.3.2_@babel+core@7.21.3:
     resolution: {integrity: sha512-mWEvCQTgXQf48yDqgN7CH50waTyYBeP2Lpqx4nNWab9sxEpdXVeKgfj1qYI2/TgUPQtNFZ85i3PemRtnXVYYJg==}
+    peerDependencies:
+      '@babel/core': ^7
+      '@babel/traverse': ^7
+    peerDependenciesMeta:
+      '@babel/traverse':
+        optional: true
     dependencies:
+      '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -25734,6 +25763,18 @@ packages:
       debug:
         optional: true
 
+  /follow-redirects/1.15.2_debug@4.3.4:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+    dev: true
+
   /fontkit/2.0.2:
     resolution: {integrity: sha512-jc4k5Yr8iov8QfS6u8w2CnHWVmbOGtdBtOXMze5Y+QD966Rx6PEVWXSEGwXlsDlKtu1G12cJjcsybnqhSk/+LA==}
     dependencies:
@@ -29628,7 +29669,7 @@ packages:
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
-      ws: 8.9.0
+      ws: 8.13.0
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -41327,19 +41368,6 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: true
-
-  /ws/8.9.0:
-    resolution: {integrity: sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
     peerDependenciesMeta:
       bufferutil:
         optional: true


### PR DESCRIPTION
In support of #3861 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2a23534</samp>

### Summary
🔧🛠️🕵️

<!--
1.  🔧 - This emoji represents the modification of the `dx-local.yml` file to use a different remote source and a devtools proxy for the client runtime configuration. This is a configuration change that affects how the client is set up and debugged.
2.  🛠️ - This emoji represents the update of the `config.proto` file to add a new optional field `devtools_proxy` to the `ClientConfig` message. This is a schema change that affects how the client configuration is defined and parsed.
3.  🕵️ - This emoji represents the addition of the `proxy.ts` file, the WebSocket proxy script and dependency, and the support for devtools proxy in `ClientServicesHost` class. These are new features that enable the client to connect to a local vault and a remote proxy for debugging purposes. This is a debugging enhancement that improves the developer experience.
-->
Added a WebSocket proxy feature to the `devtools` and `client-services` packages. This allows the client to connect to a remote devtools server for debugging purposes. The proxy server is implemented in `scripts/proxy.ts` and the client configuration is updated in `config.proto` and `dx-local.yml`. The `@dxos/websocket-rpc` package is used for the WebSocket communication.

> _We're sailing on the `dx-local` ship, with a proxy in our hold_
> _We've got a new field in our `config`, and a WebSocket to behold_
> _Heave away, me hearties, heave away with all your might_
> _We're debugging with the `devtools`, and we'll code until the night_

### Walkthrough
*  Add a new optional field `devtools_proxy` to the `ClientConfig` message in the `config.proto` file to specify the URL of the devtools proxy that the client can connect to ([link](https://github.com/dxos/dxos/pull/4025/files?diff=unified&w=0#diff-7b25da92f05be146eca962e82fa434f8f7a7f4cbf50f2b8b17bafed85191dab1R125-R127)).


