### PR TITLE
feat: Status indicators and share button

### DIFF
--- a/packages/apps/plugins/plugin-debug/src/components/DebugStatus.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DebugStatus.tsx
@@ -2,8 +2,8 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Circle, IconProps, WifiHigh, WifiSlash } from '@phosphor-icons/react';
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import { Circle, IconProps, Lightning, LightningSlash } from '@phosphor-icons/react';
+import React, { FC, useEffect, useMemo, useRef, useState } from 'react';
 
 import { SpacePluginProvides } from '@braneframe/plugin-space';
 import { TimeoutError } from '@dxos/async';
@@ -13,16 +13,18 @@ import { useNetworkStatus } from '@dxos/react-client/mesh';
 import { findPlugin, usePlugins } from '@dxos/react-surface';
 
 const styles = {
-  success: 'text-green-400 dark:text-green-600',
-  warning: 'text-red-400 dark:text-red-600',
+  success: 'text-green-500 dark:text-green-600',
+  warning: 'text-orange-500 dark:text-orange-600',
+  error: 'text-red-500 dark:text-red-600',
 };
 
-// TODO(burdon): Make pluggable.
-// TODO(burdon): Connected to Swarm (global scope)?
-// TODO(burdon): Vault heartbeat (global scope)?
-// TODO(burdon): Error handling (global scope)?
+// TODO(burdon): Make pluggable (move indicators to relevant plugins).
+// TODO(burdon): Vault heartbeat indicator (global scope)?
 
-// TODO(burdon): Move to @dxos/async.
+/**
+ * Ensure light doesn't flicker immediately after start.
+ */
+// TODO(burdon): Move to @dxos/async (debounce?)
 const timer = (cb: (err?: Error) => void, options?: { min?: number; max?: number }) => {
   const min = options?.min ?? 500;
   let start: number;
@@ -51,6 +53,62 @@ const timer = (cb: (err?: Error) => void, options?: { min?: number; max?: number
   };
 };
 
+/**
+ * Global error handler.
+ */
+// TODO(burdon): Integrate with Sentry?
+const ErrorIndicator: FC<IconProps> = (props) => {
+  const [, forceUpdate] = useState({});
+  const error = useRef<Error>();
+  const debug = true; // TODO(burdon): From config?
+  useEffect(() => {
+    const errorListener = (event: any) => {
+      event.preventDefault();
+      // Handler is called twice.
+      if (error.current !== event.error) {
+        error.current = event.error;
+        if (debug) {
+          console.error(event.error);
+        }
+        forceUpdate({});
+      }
+    };
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/Window/error_event
+    window.addEventListener('error', errorListener);
+
+    // https://developer.mozilla.org/en-US/docs/Web/API/Window/unhandledrejection_event
+    window.addEventListener('unhandledrejection', errorListener);
+
+    return () => {
+      window.removeEventListener('error', errorListener);
+      window.removeEventListener('unhandledrejection', errorListener);
+    };
+  }, []);
+
+  const handleReset = () => {
+    error.current = undefined;
+    forceUpdate({});
+  };
+
+  if (error.current) {
+    return (
+      <span title={error.current.message} onClick={handleReset}>
+        <Circle weight='fill' className={mx(styles.error, getSize(3))} {...props} />
+      </span>
+    );
+  } else {
+    return (
+      <span title='No errors.'>
+        <Circle weight='fill' className={getSize(3)} {...props} />
+      </span>
+    );
+  }
+};
+
+/**
+ * Swarm connection handler.
+ */
 const SwarmIndicator: FC<IconProps> = (props) => {
   const [state, setState] = useState(0);
   const { swarm } = useNetworkStatus();
@@ -59,12 +117,23 @@ const SwarmIndicator: FC<IconProps> = (props) => {
   }, [swarm]);
 
   if (state === 0) {
-    return <WifiHigh className={getSize(5)} {...props} />;
+    return (
+      <span title='Connected to swarm.'>
+        <Lightning className={getSize(5)} {...props} />
+      </span>
+    );
   } else {
-    return <WifiSlash className={mx(styles.warning, getSize(5))} {...props} />;
+    return (
+      <span title='Disconnected from swarm.'>
+        <LightningSlash className={mx(styles.warning, getSize(5))} {...props} />
+      </span>
+    );
   }
 };
 
+/**
+ * Space saving indicator.
+ */
 const SavingIndicator: FC<IconProps> = (props) => {
   const [state, setState] = useState(0);
   const { plugins } = usePlugins();
@@ -87,17 +156,29 @@ const SavingIndicator: FC<IconProps> = (props) => {
 
   switch (state) {
     case 2:
-      return <Circle weight='fill' className={mx(styles.warning, getSize(4))} {...props} />;
+      return (
+        <span title='Edit not saved.'>
+          <Circle weight='fill' className={mx(styles.warning, getSize(3))} {...props} />
+        </span>
+      );
     case 1:
-      return <Circle weight='fill' className={mx(styles.success, getSize(4))} {...props} />;
+      return (
+        <span title='Saving...'>
+          <Circle weight='fill' className={mx(styles.success, getSize(3))} {...props} />
+        </span>
+      );
     case 0:
     default:
-      return <Circle weight='fill' className={getSize(4)} {...props} />;
+      return (
+        <span title='Modified indicator.'>
+          <Circle weight='fill' className={getSize(3)} {...props} />
+        </span>
+      );
   }
 };
 
-export const DebugStatus: FC<{}> = () => {
-  const indicators = useMemo(() => [SavingIndicator, SwarmIndicator], []);
+export const DebugStatus = () => {
+  const indicators = useMemo(() => [SavingIndicator, ErrorIndicator, SwarmIndicator], []);
   return (
     <div className='flex items-center p-2 gap-1 h-8 text-neutral-300 dark:text-neutral-700'>
       {indicators.map((Indicator) => (

--- a/packages/apps/plugins/plugin-graph/src/graph/graph.ts
+++ b/packages/apps/plugins/plugin-graph/src/graph/graph.ts
@@ -156,9 +156,9 @@ export class GraphStore implements Graph {
       },
       invoke: async () => {
         if (Array.isArray(action.intent)) {
-          return await this._sendIntent?.(...action.intent);
+          return this._sendIntent?.(...action.intent);
         } else if (action.intent) {
-          return await this._sendIntent?.(action.intent);
+          return this._sendIntent?.(action.intent);
         }
       },
       add: (...partials) => {

--- a/packages/apps/plugins/plugin-space/src/components/SpacePresence.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/SpacePresence.tsx
@@ -2,48 +2,73 @@
 // Copyright 2023 DXOS.org
 //
 
-import { PaperPlaneRight } from '@phosphor-icons/react';
+import { Users } from '@phosphor-icons/react';
 import React, { FC } from 'react';
 
-import { Avatar, AvatarGroup, AvatarGroupItem, Button, Tooltip, useJdenticonHref, useTranslation } from '@dxos/aurora';
+import { IntentPluginProvides } from '@braneframe/plugin-intent';
+import { Avatar, AvatarGroup, AvatarGroupItem, Button, Tooltip, useTranslation } from '@dxos/aurora';
 import { getSize } from '@dxos/aurora-theme';
-// import { Space } from '@dxos/react-client/echo';
+import { useMembers, Space } from '@dxos/react-client/echo';
 import { Identity, useIdentity } from '@dxos/react-client/halo';
+import { findPlugin, usePlugins } from '@dxos/react-surface';
 
-import { SPACE_PLUGIN } from '../types';
+import { SPACE_PLUGIN, SpaceAction, SpacePluginProvides } from '../types';
 
-// TODO(burdon): Use FC signature throughout?
-export const SpacePresence: FC<{ data: any }> = ({ data, ...rest }) => {
+export const SpacePresence = () => {
+  const { plugins } = usePlugins();
+  const spacePlugin = findPlugin<SpacePluginProvides>(plugins, 'dxos.org/plugin/space');
+  const intentPlugin = findPlugin<IntentPluginProvides>(plugins, 'dxos.org/plugin/intent');
+  const space = spacePlugin?.provides.space.current;
   const identity = useIdentity();
   if (!identity) {
     return null;
   }
 
+  // TODO(burdon): Error when popup appears (BUT DOES NOT GET CAUGHT BY DebugStatus!)
+  //  Warning: React does not recognize the `labelId` prop on a DOM element.
+  //  If you intentionally want it to appear in the DOM as a custom attribute,
+  //  spell it as lowercase `labelid` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
+  const handleShare = () => {
+    void intentPlugin!.provides.intent.sendIntent({
+      plugin: SPACE_PLUGIN,
+      action: SpaceAction.SHARE,
+      data: { spaceKey: space!.key.toHex() },
+    });
+  };
+
+  if (!space) {
+    return null;
+  }
+
   return (
     <div className='flex items-center'>
-      {/* TODO(burdon): Reuse SpaceAction.SHARE action/intent. */}
-      <Button variant='ghost'>
-        <PaperPlaneRight className={getSize(5)} />
-      </Button>
-      <SpaceMembers identity={identity} />
+      {intentPlugin && (
+        <Button variant='ghost' onClick={handleShare}>
+          <Users className={getSize(5)} />
+        </Button>
+      )}
+      <SpaceMembers space={space} identity={identity} />
     </div>
   );
 };
 
-// TODO(burdon): Wire up to presence (for space).
-const SpaceMembers: FC<{ identity: Identity }> = ({ identity }) => {
-  const fallbackHref = useJdenticonHref(identity?.identityKey.toHex() ?? '', 4);
+// TODO(burdon): Don't include current user.
+const SpaceMembers: FC<{ space: Space; identity: Identity }> = ({ space, identity }) => {
+  const members = useMembers(space.key);
   const { t } = useTranslation(SPACE_PLUGIN);
   return (
     <Tooltip.Root>
       <Tooltip.Trigger className='flex items-center'>
         <AvatarGroup.Root size={4} classNames='mie-5'>
-          <AvatarGroup.Label classNames='text-xs font-system-semibold'>1</AvatarGroup.Label>
-          <AvatarGroupItem.Root>
-            <Avatar.Frame>
-              <Avatar.Fallback href={fallbackHref} />
-            </Avatar.Frame>
-          </AvatarGroupItem.Root>
+          <AvatarGroup.Label classNames='text-xs font-system-semibold'>{members.length}</AvatarGroup.Label>
+          {members.map((member) => (
+            <AvatarGroupItem.Root key={member.identity.identityKey.toHex()}>
+              <Avatar.Frame>
+                {/* TODO(burdon): Why `href`? */}
+                <Avatar.Fallback href={member.identity.profile?.displayName ?? member.identity.identityKey.toHex()} />
+              </Avatar.Frame>
+            </AvatarGroupItem.Root>
+          ))}
         </AvatarGroup.Root>
       </Tooltip.Trigger>
       <Tooltip.Content collisionPadding={4}>


### PR DESCRIPTION
- [x] Global error handler.
- [x] Share button.
- [x] Space presence.
- [ ] Presence icons do not match mocks.

<img width="227" alt="Screenshot 2023-08-29 at 10 45 58 PM" src="https://github.com/dxos/dxos/assets/3523355/705bc05b-23cf-44e2-9f09-c900fdb8e5b9">

<br/>
<img width="98" alt="Screenshot 2023-08-29 at 10 46 09 PM" src="https://github.com/dxos/dxos/assets/3523355/d539bb51-3517-408a-b176-a5562aefeba7">


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3e89d35</samp>

### Summary
🔄🐛🎨

<!--
1.  🔄 - This emoji represents the refactoring of the SpacePresence and SpaceMembers components, as well as the simplification of the invoke method. It conveys the idea of changing or updating something without altering its functionality or purpose.
2. 🐛 - This emoji represents the improvement of the debug status indicators by adding error handling, which could help fix or prevent bugs or issues in the code. It conveys the idea of debugging or resolving problems.
3. 🎨 - This emoji represents the change of the icons and styles in the debug status indicators and the share button, as well as the addition of title attributes. It conveys the idea of improving the appearance or design of something.
-->
This pull request enhances the user interface and performance of some plugins in the dxos apps package. It improves the debug status, space sharing, and graph invocation features by refactoring the components, updating the icons, and simplifying the code. It also fixes some minor issues with imports, styles, and comments.

> _We're coding on the high seas, me hearties, yo ho ho_
> _We're fixing up the `GraphStore` and the debug status quo_
> _We're sharing and displaying all the space members we know_
> _We're heaving on the line, me lads, one, two, three, let's go_

### Walkthrough
*  Simplify invoke method in GraphStore class by removing unnecessary await keywords ([link](https://github.com/dxos/dxos/pull/4030/files?diff=unified&w=0#diff-95c66a49579b77fde184619153f6649453cf5cd813760c61050fb6cc75a638b1L159-R161))
*  Add ErrorIndicator component to handle global error events and display a red circle icon when an error occurs (`DebugStatus.tsx`, [link](https://github.com/dxos/dxos/pull/4030/files?diff=unified&w=0#diff-c60b39f11e625fee534469a79622fa62ea629736147b47789e4014de184806cbR56-R111))
*  Modify SwarmIndicator and SavingIndicator components to use lightning and circle icons, and add title attributes to indicate connection and saving status (`DebugStatus.tsx`, [link](https://github.com/dxos/dxos/pull/4030/files?diff=unified&w=0#diff-c60b39f11e625fee534469a79622fa62ea629736147b47789e4014de184806cbL16-R27), [link](https://github.com/dxos/dxos/pull/4030/files?diff=unified&w=0#diff-c60b39f11e625fee534469a79622fa62ea629736147b47789e4014de184806cbL62-R136), [link](https://github.com/dxos/dxos/pull/4030/files?diff=unified&w=0#diff-c60b39f11e625fee534469a79622fa62ea629736147b47789e4014de184806cbL90-R181))
*  Modify SpacePresence component to use space and intent plugins to get current space and send share intents, and replace PaperPlaneRight icon with Users icon for share button (`SpacePresence.tsx`, [link](https://github.com/dxos/dxos/pull/4030/files?diff=unified&w=0#diff-7eaaf77f42f83a3e3ee55e3bc710b90d55f1c14fff0f924c69ef8e641a613994L5-R21), [link](https://github.com/dxos/dxos/pull/4030/files?diff=unified&w=0#diff-7eaaf77f42f83a3e3ee55e3bc710b90d55f1c14fff0f924c69ef8e641a613994L22-R57))
*  Modify SpaceMembers component to use useMembers hook to get space members and render their avatars, and remove hardcoded label and avatar for current user (`SpacePresence.tsx`, [link](https://github.com/dxos/dxos/pull/4030/files?diff=unified&w=0#diff-7eaaf77f42f83a3e3ee55e3bc710b90d55f1c14fff0f924c69ef8e641a613994L41-R71))


