### PR TITLE
feat(plugin-debug): add devtools panel & reactivity

### DIFF
--- a/packages/apps/plugins/plugin-debug/package.json
+++ b/packages/apps/plugins/plugin-debug/package.json
@@ -20,6 +20,7 @@
     "@braneframe/plugin-space": "workspace:*",
     "@dxos/async": "workspace:*",
     "@dxos/client": "workspace:*",
+    "@dxos/devtools": "workspace:*",
     "@dxos/echo-schema": "workspace:*",
     "@dxos/invariant": "workspace:*",
     "@dxos/keys": "workspace:*",
@@ -30,6 +31,7 @@
     "@dxos/util": "workspace:*",
     "@faker-js/faker": "^8.0.2",
     "date-fns": "^2.29.3",
+    "deepsignal": "^1.3.3",
     "lodash.get": "^4.4.2",
     "react-json-tree": "^0.18.0",
     "react-syntax-highlighter": "^15.5.0"

--- a/packages/apps/plugins/plugin-debug/src/components/DebugSettings.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DebugSettings.tsx
@@ -5,28 +5,29 @@
 import React from 'react';
 
 import { Input, useTranslation } from '@dxos/aurora';
-import { useKeyStore } from '@dxos/react-client/halo';
+import { usePlugin } from '@dxos/react-surface';
 
-import { DEBUG_PLUGIN } from '../props';
+import { DEBUG_PLUGIN, DebugPluginProvides } from '../props';
 
 // TODO(burdon): Standardize key name (see GH plugin).
 export const DebugPanelKey = 'dxos.org/settings/debug';
 
 export const DebugSettings = () => {
   const { t } = useTranslation(DEBUG_PLUGIN);
-  // TODO(burdon): Factor out.
-  const [keyMap, setKey] = useKeyStore([DebugPanelKey]);
-  const visible = !!keyMap.get(DebugPanelKey);
-  const handleSetVisible = (checked: boolean) => {
-    setKey(DebugPanelKey, checked ? 'true' : '');
-  };
+  const debugPlugin = usePlugin<DebugPluginProvides>(DEBUG_PLUGIN);
+
+  if (!debugPlugin) {
+    return null;
+  }
+
+  const settings = debugPlugin.provides.debug;
 
   return (
     <Input.Root>
       {/* TODO(burdon): Requires custom CSS. */}
       <Input.Root>
         <div className='flex gap-2'>
-          <Input.Checkbox checked={visible} onCheckedChange={(checked) => handleSetVisible(!!checked)} />
+          <Input.Checkbox checked={settings.debug} onCheckedChange={(checked) => (settings.debug = !!checked)} />
           <Input.Label>{t('show debug panel')}</Input.Label>
         </div>
       </Input.Root>

--- a/packages/apps/plugins/plugin-debug/src/components/DevtoolsMain.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DevtoolsMain.tsx
@@ -1,0 +1,18 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React from 'react';
+
+import { Devtools } from '@dxos/devtools';
+import { ClientServices, useClient } from '@dxos/react-client';
+
+export const DevtoolsMain = () => {
+  const client = useClient();
+
+  return (
+    <div className='mbs-12'>
+      <Devtools client={client} services={client.services.services as ClientServices} />
+    </div>
+  );
+};

--- a/packages/apps/plugins/plugin-debug/src/components/index.ts
+++ b/packages/apps/plugins/plugin-debug/src/components/index.ts
@@ -5,3 +5,4 @@
 export * from './DebugMain';
 export * from './DebugSettings';
 export * from './DebugStatus';
+export * from './DevtoolsMain';

--- a/packages/apps/plugins/plugin-debug/src/props.ts
+++ b/packages/apps/plugins/plugin-debug/src/props.ts
@@ -23,4 +23,10 @@ export const DebugContext: Context<DebugContextType> = createContext<DebugContex
   stop: () => {},
 });
 
-export type DebugPluginProvides = IntentProvides & GraphProvides & TranslationsProvides;
+export type DebugState = { nodeIds: string[]; debug: boolean };
+
+export type DebugPluginProvides = IntentProvides &
+  GraphProvides &
+  TranslationsProvides & {
+    debug: DebugState;
+  };

--- a/packages/apps/plugins/plugin-debug/src/translations.ts
+++ b/packages/apps/plugins/plugin-debug/src/translations.ts
@@ -12,6 +12,7 @@ export default [
         'mutation count': 'Number of mutations',
         'mutation period': 'Mutation period',
         'open devtools label': 'Open DevTools',
+        'devtools label': 'DevTools',
         'show debug panel': 'Show debug panel',
       },
     },

--- a/packages/apps/plugins/plugin-debug/tsconfig.json
+++ b/packages/apps/plugins/plugin-debug/tsconfig.json
@@ -45,6 +45,9 @@
       "path": "../../../core/protocols"
     },
     {
+      "path": "../../../devtools/devtools"
+    },
+    {
       "path": "../../../sdk/client"
     },
     {

--- a/packages/devtools/devtools-extension/src/sandbox.tsx
+++ b/packages/devtools/devtools-extension/src/sandbox.tsx
@@ -11,7 +11,7 @@ import { Defaults } from '@dxos/config';
 import { Devtools } from '@dxos/devtools';
 import { log } from '@dxos/log';
 import { useAsyncEffect } from '@dxos/react-async';
-import { Client, ClientServicesProxy, Config, ClientContextProps } from '@dxos/react-client';
+import { Client, ClientServicesProxy, Config, ClientServices } from '@dxos/react-client';
 import { RpcPort } from '@dxos/rpc';
 
 import { initSentry } from './utils';
@@ -66,7 +66,7 @@ void initSentry(namespace, new Config(Defaults()));
 const App = () => {
   log('initializing...');
 
-  const [context, setContext] = useState<ClientContextProps>();
+  const [context, setContext] = useState<{ client: Client; services: ClientServices }>();
 
   useAsyncEffect(async () => {
     const rpcPort = windowPort();
@@ -82,7 +82,11 @@ const App = () => {
     log('client initialized');
   }, []);
 
-  return <Devtools context={context} namespace={namespace} />;
+  if (!context) {
+    return null;
+  }
+
+  return <Devtools services={context.services} client={context.client} namespace={namespace} />;
 };
 
 const init = async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -683,6 +683,7 @@ importers:
       '@dxos/aurora': workspace:*
       '@dxos/aurora-theme': workspace:*
       '@dxos/client': workspace:*
+      '@dxos/devtools': workspace:*
       '@dxos/echo-schema': workspace:*
       '@dxos/invariant': workspace:*
       '@dxos/keys': workspace:*
@@ -699,6 +700,7 @@ importers:
       '@types/react-dom': ^18.0.6
       '@types/react-syntax-highlighter': ^15.5.5
       date-fns: ^2.29.3
+      deepsignal: ^1.3.3
       lodash.get: ^4.4.2
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -711,6 +713,7 @@ importers:
       '@braneframe/plugin-space': link:../plugin-space
       '@dxos/async': link:../../../common/async
       '@dxos/client': link:../../../sdk/client
+      '@dxos/devtools': link:../../../devtools/devtools
       '@dxos/echo-schema': link:../../../core/echo/echo-schema
       '@dxos/invariant': link:../../../common/invariant
       '@dxos/keys': link:../../../common/keys
@@ -721,6 +724,7 @@ importers:
       '@dxos/util': link:../../../common/util
       '@faker-js/faker': 8.0.2
       date-fns: 2.29.3
+      deepsignal: 1.3.4_react@18.2.0
       lodash.get: 4.4.2
       react-json-tree: 0.18.0_iapumuv4e6jcjznwuxpf4tt22e
       react-syntax-highlighter: 15.5.0_react@18.2.0
@@ -11848,6 +11852,7 @@ packages:
     dependencies:
       '@nx/cypress': 16.5.4_ira35blaljp6ziq6rkbxh2c3im
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - cypress
@@ -11872,6 +11877,7 @@ packages:
     dependencies:
       '@nx/eslint-plugin': 16.5.4_f5sjyg6hkkwzmez5q6ml55qszi
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@typescript-eslint/parser'
@@ -11889,6 +11895,7 @@ packages:
     dependencies:
       '@nx/jest': 16.5.4_dwxsgwctamj3e4zqclpyae4gcu
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@types/node'
@@ -11906,6 +11913,7 @@ packages:
     dependencies:
       '@nx/js': 16.5.4_kco6wocfncyehzbvd6faof7n2y_wcxuhe4tvwpsd3renjlc7ah6mu
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11920,6 +11928,7 @@ packages:
     dependencies:
       '@nx/linter': 16.5.4_ira35blaljp6ziq6rkbxh2c3im
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11943,6 +11952,7 @@ packages:
     dependencies:
       '@nx/storybook': 16.5.4_ira35blaljp6ziq6rkbxh2c3im
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - cypress
@@ -11970,6 +11980,7 @@ packages:
     dependencies:
       '@nx/vite': 16.5.4_xxzhsuqrsbs6wyvhvm37cpe46m_3dw4w4asrgslkotzjeholo4g7a
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11985,6 +11996,7 @@ packages:
     dependencies:
       '@nx/web': 16.5.4_wcxuhe4tvwpsd3renjlc7ah6mu
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12021,6 +12033,7 @@ packages:
       dotenv: 10.0.0
       semver: 7.5.3
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12065,6 +12078,7 @@ packages:
       jsonc-eslint-parser: 2.3.0
       semver: 7.5.3
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12093,6 +12107,7 @@ packages:
       resolve.exports: 1.1.0
       tslib: 2.5.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@types/node'
@@ -12126,7 +12141,7 @@ packages:
       '@phenomnomnominal/tsquery': 5.0.1_typescript@5.0.4
       babel-plugin-const-enum: 1.2.0_@babel+core@7.21.3
       babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2
+      babel-plugin-transform-typescript-metadata: 0.3.2_@babel+core@7.21.3
       chalk: 4.1.2
       detect-port: 1.5.1
       fast-glob: 3.2.7
@@ -12138,6 +12153,7 @@ packages:
       source-map-support: 0.5.19
       tslib: 2.5.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12163,6 +12179,7 @@ packages:
       tmp: 0.2.1
       tslib: 2.5.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12275,6 +12292,7 @@ packages:
       dotenv: 10.0.0
       semver: 7.5.3
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - cypress
@@ -12300,6 +12318,7 @@ packages:
       enquirer: 2.3.6
       vite: 4.3.9_@types+node@18.11.9
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12323,6 +12342,7 @@ packages:
       ignore: 5.2.0
       tslib: 2.5.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -20119,7 +20139,7 @@ packages:
   /axios/1.3.4_debug@4.3.4:
     resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2_debug@4.3.4
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -20324,9 +20344,16 @@ packages:
   /babel-plugin-syntax-jsx/6.18.0:
     resolution: {integrity: sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==}
 
-  /babel-plugin-transform-typescript-metadata/0.3.2:
+  /babel-plugin-transform-typescript-metadata/0.3.2_@babel+core@7.21.3:
     resolution: {integrity: sha512-mWEvCQTgXQf48yDqgN7CH50waTyYBeP2Lpqx4nNWab9sxEpdXVeKgfj1qYI2/TgUPQtNFZ85i3PemRtnXVYYJg==}
+    peerDependencies:
+      '@babel/core': ^7
+      '@babel/traverse': ^7
+    peerDependenciesMeta:
+      '@babel/traverse':
+        optional: true
     dependencies:
+      '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -25733,6 +25760,18 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  /follow-redirects/1.15.2_debug@4.3.4:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+    dev: true
 
   /fontkit/2.0.2:
     resolution: {integrity: sha512-jc4k5Yr8iov8QfS6u8w2CnHWVmbOGtdBtOXMze5Y+QD966Rx6PEVWXSEGwXlsDlKtu1G12cJjcsybnqhSk/+LA==}


### PR DESCRIPTION
looks a little janky but it works
![Screenshot from 2023-08-31 15-35-54](https://github.com/dxos/dxos/assets/4529818/05a41d0b-71a6-42f9-bad1-c66bda80c5a8)

For debugging #3861 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7cedaa7</samp>

### Summary
🛠️🌐🚀

<!--
1.  🛠️ - This emoji represents the addition of the `DevtoolsMain.tsx` file and the export of the `DevtoolsMain` component. It suggests that this change is related to building or fixing something.
2. 🌐 - This emoji represents the translation for the `devtools label` key and the path mapping for the `@dxos/devtools` package. It suggests that this change is related to internationalization or web development.
3. 🚀 - This emoji represents the new feature of toggling the debug mode and displaying the `DevtoolsMain` component. It suggests that this change is related to launching or improving something.
-->
This pull request adds a new feature to the `plugin-debug` package that enables the use of the `@dxos/devtools` package for debugging the `react-client` nodes. It refactors the code to use a reactive state object for the debug settings and updates the UI components accordingly. It also fixes some import and rendering issues in the `devtools-extension` package.

> _We're breaking the code with devtools of doom_
> _We're changing the state with deepsignal's gloom_
> _We're importing the packages with tsconfig's map_
> _We're debugging the nodes with DevtoolsMain's trap_

### Walkthrough
*  Add `@dxos/devtools` and `deepsignal` packages as dependencies for `plugin-debug` package ([link](https://github.com/dxos/dxos/pull/4085/files?diff=unified&w=0#diff-9d7c761af6f52ac3088160c56da2d94a888f41bd030fd3baaf75b50abcb06049R23), [link](https://github.com/dxos/dxos/pull/4085/files?diff=unified&w=0#diff-9d7c761af6f52ac3088160c56da2d94a888f41bd030fd3baaf75b50abcb06049R34)).


