### PR TITLE
feat(echo-db): Commit batch after if user idling or batch length reaches the threshold

### DIFF
--- a/packages/apps/plugins/plugin-debug/src/components/DebugStatus.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DebugStatus.tsx
@@ -143,9 +143,12 @@ const SavingIndicator: FC<IconProps> = (props) => {
     if (!space) {
       return;
     }
-    const { start, stop } = timer((err) => setState(err ? 2 : 0), { min: 250, max: 2000 });
-    return space.db.pendingBatch.on(({ duration }) => {
-      if (duration === undefined) {
+    const { start, stop } = timer(() => setState(0), { min: 250 });
+    return space.db.pendingBatch.on(({ duration, error }) => {
+      if (error) {
+        setState(2);
+        stop();
+      } else if (duration === undefined) {
         setState(1);
         start();
       } else {

--- a/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
@@ -274,6 +274,8 @@ export class DatabaseProxy {
     }
     this._currentBatch = new Batch();
     this._currentBatch.clientTag = `${this._clientTagPrefix}:${this._clientTagCounter++}`;
+    this.pendingBatch.emit({ size: this._pendingBatches.size + 1 });
+
     return true;
   }
 

--- a/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
@@ -20,7 +20,7 @@ import { ItemManager } from './item-manager';
 
 const FLUSH_TIMEOUT = 5_000;
 
-const BATCH_COMMIT_AFTER = 200;
+export const BATCH_COMMIT_AFTER = 200;
 /**
  * Maximum number of mutations in a batch.
  * Note: It is used only in auto created batches, if user creates/commits batch outside it will be ignored.

--- a/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
@@ -20,7 +20,12 @@ import { ItemManager } from './item-manager';
 
 const FLUSH_TIMEOUT = 5_000;
 
-const BATCH_INTERVAL = 200;
+const BATCH_COMMIT_AFTER = 200;
+/**
+ * Maximum number of mutations in a batch.
+ * Note: It is used only in auto created batches, if user creates/commits batch outside it will be ignored.
+ */
+const BATCH_SIZE_LIMIT = 64;
 
 export type MutateResult = {
   objectsUpdated: Item<any>[];
@@ -276,6 +281,7 @@ export class DatabaseProxy {
   commitBatch() {
     // Discard scheduled commit.
     void this._currentBatchCtx?.dispose();
+    this._currentBatchCtx = undefined;
 
     invariant(this._subscriptionOpen);
     const batch = this._currentBatch;
@@ -341,10 +347,22 @@ export class DatabaseProxy {
         batch,
       };
     } finally {
+      // Note: Commit batch after BATCH_COMMIT_AFTER idling without new mutations.
       if (batchCreated) {
+        // Commit batch after last mutation with delay if there will be no new mutations.
         this._currentBatchCtx = this._ctx.derive();
-        // Commit batch after a delay to allow for batching.
-        scheduleTask(this._currentBatchCtx, () => this.commitBatch(), BATCH_INTERVAL);
+        scheduleTask(this._currentBatchCtx, () => this.commitBatch(), BATCH_COMMIT_AFTER);
+      } else if (this._currentBatchCtx) {
+        // Reset the timer.
+        // If `this._currentBatchCtx` is set then Batch was created by one of the previous calls of `.mutate()`.
+        invariant(this._currentBatch);
+        void this._currentBatchCtx.dispose();
+        if (this._currentBatch.data.objects && this._currentBatch.data.objects.length >= BATCH_SIZE_LIMIT) {
+          this.commitBatch();
+        } else {
+          this._currentBatchCtx = this._ctx.derive();
+          scheduleTask(this._currentBatchCtx, () => this.commitBatch(), BATCH_COMMIT_AFTER);
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0e47546</samp>

### Summary
🐛🚀🧪

<!--
1.  🐛 for fixing a bug in the SavingIndicator component.
2.  🚀 for introducing automatic batching of mutations to improve performance and efficiency.
3.  🧪 for improving the testing of the database proxy functionality.
-->
This pull request enhances the database proxy module in the `echo-db` and `echo-pipeline` packages by adding automatic batching of mutations and testing it. It also fixes a bug in the `plugin-debug` app that affected the SavingIndicator component.

> _To debug a plugin with ease_
> _They fixed a bug in `SavingIndicator`_
> _And added some tests for the `database-proxy`_
> _That batches mutations with a policy_
> _And emits an event for the monitor_

### Walkthrough
* Fix a bug in the SavingIndicator component of the plugin-debug app that showed an error state even when there was no error ([link](https://github.com/dxos/dxos/pull/4088/files?diff=unified&w=0#diff-c60b39f11e625fee534469a79622fa62ea629736147b47789e4014de184806cbL146-R151)).


