### PR TITLE
feat(plugin-space): separate personal space in graph

### DIFF
--- a/packages/apps/plugins/plugin-files/src/FilesPlugin.tsx
+++ b/packages/apps/plugins/plugin-files/src/FilesPlugin.tsx
@@ -169,7 +169,7 @@ export const FilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, Markdo
           const [groupNode] = parent.add({
             id: 'all-files',
             label: ['plugin name', { ns: FILES_PLUGIN }],
-            properties: { palette: 'teal' },
+            properties: { palette: 'yellow' },
           });
 
           const fileIndices = getIndices(state.files.length);

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -83,12 +83,19 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
         });
 
         state.active = space;
+        const defaultSpace = client.getSpace();
 
         if (
           space instanceof SpaceProxy &&
           (client.services instanceof IFrameClientServicesProxy || client.services instanceof IFrameClientServicesHost)
         ) {
-          client.services.setSpaceProvider(() => space.key);
+          client.services.setSpaceProvider(() => {
+            if (defaultSpace && space.key.equals(defaultSpace.key)) {
+              return undefined;
+            } else {
+              return space.key;
+            }
+          });
         }
       });
     },
@@ -163,29 +170,32 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
             return;
           }
 
+          const client = clientPlugin.provides.client;
+          const defaultSpace = client.getSpace();
+          if (defaultSpace) {
+            // Ensure default space is always first.
+            spaceToGraphNode(defaultSpace, parent);
+          }
+
           const [groupNode] = parent.add({
             id: getSpaceId('all-spaces'),
             label: ['plugin name', { ns: SPACE_PLUGIN }],
             properties: { palette: 'blue' },
           });
 
-          const client = clientPlugin.provides.client;
-          const spaces = client.spaces.get();
-          const indices = spaces?.length ? getIndices(spaces.length) : [];
-
-          spaces.forEach((space, index) => spaceToGraphNode(space, groupNode, indices[index]));
-
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
             subscriptions.clear();
             const indices = getIndices(spaces.length);
             spaces.forEach((space, index) => {
-              const handle = createSubscription(() => {
-                spaceToGraphNode(space, groupNode, indices[index]);
-              });
+              const update = () => {
+                const isDefaultSpace = defaultSpace && defaultSpace.key.equals(space.key);
+                isDefaultSpace ? spaceToGraphNode(space, parent) : spaceToGraphNode(space, groupNode, indices[index]);
+              };
+
+              const handle = createSubscription(() => update());
               handle.update([space.properties]);
               subscriptions.add(handle.unsubscribe);
-
-              spaceToGraphNode(space, groupNode, indices[index]);
+              update();
             });
           });
 

--- a/packages/apps/plugins/plugin-space/src/translations.ts
+++ b/packages/apps/plugins/plugin-space/src/translations.ts
@@ -26,6 +26,7 @@ export default [
         'upload file message': 'Drag file here or click to browse',
         'presence label': 'Members viewing this item',
         'object title placeholder': 'Type a title here…',
+        'personal space label': 'Personal Space',
       },
     },
   },

--- a/packages/sdk/client/src/services/shell-controller.ts
+++ b/packages/sdk/client/src/services/shell-controller.ts
@@ -114,7 +114,9 @@ export class ShellController {
       await this.setLayout(ShellLayout.DEVICE_INVITATIONS);
     } else if (event.key === '.' && modifier) {
       const spaceKey = await this._spaceProvider?.();
-      await this.setLayout(ShellLayout.SPACE_INVITATIONS, { spaceKey });
+      if (spaceKey) {
+        await this.setLayout(ShellLayout.SPACE_INVITATIONS, { spaceKey });
+      }
     }
   }
 }


### PR DESCRIPTION

![image](https://github.com/dxos/dxos/assets/4529818/c3695188-5cfb-4704-9ad8-ccef92fd0f47)


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cc4e82c</samp>

### Summary
🎨🌐🛠️

<!--
1.  🎨 for changing the palette property of the all-files node
2. 🌐 for adding the translation for the personal space label
3. 🛠️ for improving the graph rendering, handling, and logic of spaces
-->
This pull request enhances the graph view of spaces and files in the DXOS apps. It introduces a `defaultSpace` variable to represent the personal space of the user, which is different from other workspaces and has special properties and behaviors. It also changes the color of the all-files node to avoid confusion with the default space node. It adds a translation for the personal space label and prevents the user from opening space invitations for the default space.

> _`defaultSpace` node_
> _a special workspace for you_
> _no invitations_

### Walkthrough
*  Changed the color of the all-files node to yellow to match the files icon ([link](https://github.com/dxos/dxos/pull/4094/files?diff=unified&w=0#diff-61ac1b9b8f3415a2884014ea5912948c86639725f90492d7ec4c9686b5bafaaeL172-R172)).


