### PR TITLE
fix(plugin-space): hide space status in personal space

### DIFF
--- a/packages/apps/plugins/plugin-space/src/components/SpacePresence.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/SpacePresence.tsx
@@ -8,7 +8,7 @@ import React, { FC } from 'react';
 import { IntentPluginProvides } from '@braneframe/plugin-intent';
 import { Avatar, AvatarGroup, AvatarGroupItem, Button, Tooltip, useTranslation } from '@dxos/aurora';
 import { getSize } from '@dxos/aurora-theme';
-import { useMembers, Space } from '@dxos/react-client/echo';
+import { useMembers, Space, useSpace } from '@dxos/react-client/echo';
 import { Identity, useIdentity } from '@dxos/react-client/halo';
 import { findPlugin, usePlugins } from '@dxos/react-surface';
 
@@ -19,6 +19,7 @@ export const SpacePresence = () => {
   const spacePlugin = findPlugin<SpacePluginProvides>(plugins, 'dxos.org/plugin/space');
   const intentPlugin = findPlugin<IntentPluginProvides>(plugins, 'dxos.org/plugin/intent');
   const space = spacePlugin?.provides.space.active;
+  const defaultSpace = useSpace();
   const identity = useIdentity();
   if (!identity) {
     return null;
@@ -36,7 +37,7 @@ export const SpacePresence = () => {
     });
   };
 
-  if (!space) {
+  if (!space || defaultSpace?.key.equals(space.key)) {
     return null;
   }
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1c2bc0a</samp>

### Summary
🚀🙈🪝

<!--
1.  🚀 - This emoji could represent the concept of space and the improvement to the space presence indicator.
2.  🙈 - This emoji could represent the idea of hiding something or making it invisible, which is what the change does for the default space.
3.  🪝 - This emoji could represent the use of a hook, which is a common term for a custom function that uses React state and effects, such as the `useSpace` hook.
-->
Improved the UI of the space plugin by hiding the presence indicator for the default space. Refactored the code to use the `useSpace` hook instead of the `useSpaceKey` prop.

> _Oh we're the coders of the high seas_
> _We write the hooks and the APIs_
> _We hide the `defaultSpace` from view_
> _And we'll improve the indicator too_

### Walkthrough
* Import the `useSpace` hook from `@dxos/react-client/echo` to access the current default space. ([link](https://github.com/dxos/dxos/pull/4096/files?diff=unified&w=0#diff-7eaaf77f42f83a3e3ee55e3bc710b90d55f1c14fff0f924c69ef8e641a613994L11-R11))
* Declare the `defaultSpace` variable using the `useSpace` hook inside the `SpacePresence` component. ([link](https://github.com/dxos/dxos/pull/4096/files?diff=unified&w=0#diff-7eaaf77f42f83a3e3ee55e3bc710b90d55f1c14fff0f924c69ef8e641a613994R22))


