### PR TITLE
chore(plugin-dnd): add publish config

### DIFF
--- a/packages/apps/plugins/plugin-dnd/package.json
+++ b/packages/apps/plugins/plugin-dnd/package.json
@@ -38,5 +38,8 @@
     "@dxos/react-surface": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5effc1e</samp>

### Summary
📦🔓🚀

<!--
1.  📦 This emoji can be used to indicate that a package or dependency was added, updated, or published. In this case, it represents the publishConfig property that enables publishing the package on npm.
2.  🔓 This emoji can be used to indicate that something was made public, accessible, or unlocked. In this case, it represents the public access level that the package will have on the npm registry.
3.  🚀 This emoji can be used to indicate that something was deployed, released, or launched. In this case, it represents the goal of making the plugin-dnd package available for external use.
-->
Added `publishConfig` to `plugin-dnd` package to enable public publishing on npm. This is part of a pull request to make the plugin-dnd package usable by external applications.

> _`publishConfig` set_
> _plugin-dnd goes public now_
> _a spring of sharing_

### Walkthrough
*  Add `publishConfig` property to `package.json` file to enable public publishing of the package ([link](https://github.com/dxos/dxos/pull/4097/files?diff=unified&w=0#diff-c624f3dd4e570e219143411d2ff97861c9fe6349ee287ceb18a174cd327885faR41-R43))


