### PR TITLE
feat: fix drawing plugin dragging

### DIFF
--- a/packages/apps/plugins/plugin-drawing/src/DrawingPlugin.tsx
+++ b/packages/apps/plugins/plugin-drawing/src/DrawingPlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { CompassTool, Plus } from '@phosphor-icons/react';
+import { ArticleMedium, CompassTool, Plus } from '@phosphor-icons/react';
 import React from 'react';
 
 import { GraphNodeAdapter, SpaceAction } from '@braneframe/plugin-space';
@@ -36,7 +36,14 @@ export const DrawingPlugin = (): PluginDefinition<DrawingPluginProvides> => {
 
           const space = parent.data;
 
-          parent.addAction({
+          const [presentationNode] = parent.add({
+            id: `${DRAWING_PLUGIN}:${space.key.toHex()}`,
+            label: ['plugin name', { ns: DRAWING_PLUGIN }],
+            icon: (props) => <ArticleMedium {...props} />,
+            properties: { palette: 'pink', childrenPersistenceClass: 'spaceObject' },
+          });
+
+          presentationNode.addAction({
             id: `${DRAWING_PLUGIN}/create`,
             label: ['create drawing label', { ns: DRAWING_PLUGIN }],
             icon: (props) => <Plus {...props} />,
@@ -58,7 +65,7 @@ export const DrawingPlugin = (): PluginDefinition<DrawingPluginProvides> => {
             },
           });
 
-          return adapter.createNodes(space, parent);
+          return adapter.createNodes(space, presentationNode);
         },
       },
       stack: {

--- a/packages/apps/plugins/plugin-drawing/src/DrawingPlugin.tsx
+++ b/packages/apps/plugins/plugin-drawing/src/DrawingPlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ArticleMedium, CompassTool, Plus } from '@phosphor-icons/react';
+import { CompassTool, Folder, Plus } from '@phosphor-icons/react';
 import React from 'react';
 
 import { GraphNodeAdapter, SpaceAction } from '@braneframe/plugin-space';
@@ -39,7 +39,7 @@ export const DrawingPlugin = (): PluginDefinition<DrawingPluginProvides> => {
           const [presentationNode] = parent.add({
             id: `${DRAWING_PLUGIN}:${space.key.toHex()}`,
             label: ['plugin name', { ns: DRAWING_PLUGIN }],
-            icon: (props) => <ArticleMedium {...props} />,
+            icon: (props) => <Folder {...props} />,
             properties: { palette: 'pink', childrenPersistenceClass: 'spaceObject' },
           });
 

--- a/packages/apps/plugins/plugin-drawing/src/components/DrawingMain.tsx
+++ b/packages/apps/plugins/plugin-drawing/src/components/DrawingMain.tsx
@@ -13,33 +13,31 @@ import { coarseBlockPaddingStart, fixedInsetFlexLayout, mx } from '@dxos/aurora-
 
 import '@tldraw/tldraw/tldraw.css';
 
-import { useDrawingModel } from '../hooks';
+import { useDrawingStore } from '../hooks';
 
 export type DrawingMainParams = {
   readonly?: boolean;
   data: DrawingType;
 };
 
-export const DrawingMain: FC<DrawingMainParams> = ({ data: drawing }) => {
-  const { store } = useDrawingModel(drawing.data);
+export const DrawingMain: FC<DrawingMainParams> = ({ data: object }) => {
   const { themeMode } = useThemeContext();
+  const store = useDrawingStore(object.data);
+
   const [editor, setEditor] = useState<Editor>();
   useEffect(() => {
     if (editor) {
       editor.setDarkMode(themeMode === 'dark');
 
-      // TODO(burdon): Config.
+      // TODO(burdon): Config options.
       editor.setSnapMode(true);
       editor.setGridMode(true);
     }
   }, [editor, themeMode]);
 
-  // Tool events.
-  const handleUiEvent = (name: string, data: any) => {
-    // console.log('handleUiEvent', name, data);
-  };
-
-  // TODO(burdon): Error if switch DIRECTLY between drawings (store changed).
+  if (!store) {
+    return null;
+  }
 
   // https://github.com/tldraw/tldraw/blob/main/packages/ui/src/lib/TldrawUi.tsx
   // TODO(burdon): Customize by using hooks directly: https://tldraw.dev/docs/editor
@@ -49,7 +47,7 @@ export const DrawingMain: FC<DrawingMainParams> = ({ data: drawing }) => {
       <div
         className={mx(
           'h-full',
-          // TODO(burdon): Hack to override z-index.
+          // TODO(burdon): Override z-index.
           '[&>div>span>div]:z-0',
           // TODO(burdon): Hide .tlui-menu-zone
           '[&>div>main>div:nth-child(1)>div:nth-child(1)]:hidden',
@@ -61,15 +59,15 @@ export const DrawingMain: FC<DrawingMainParams> = ({ data: drawing }) => {
           '[&>div>main>div:nth-child(2)>div:nth-child(2)]:hidden',
         )}
       >
-        <Tldraw autoFocus store={store} onUiEvent={handleUiEvent} onMount={setEditor} />
+        <Tldraw autoFocus store={store} onMount={setEditor} />
       </div>
     </Main.Content>
   );
 };
 
 export const DrawingSection: FC<DrawingMainParams> = ({ data: drawing }) => {
-  const { store } = useDrawingModel(drawing.data);
   const { themeMode } = useThemeContext();
+  const store = useDrawingStore(drawing.data);
   const [editor, setEditor] = useState<Editor>();
   useEffect(() => {
     if (editor) {
@@ -110,7 +108,7 @@ export const DrawingSection: FC<DrawingMainParams> = ({ data: drawing }) => {
 
   return (
     <div ref={containerRef} style={{ height, visibility: ready ? 'visible' : 'hidden' }}>
-      <Tldraw store={store} hideUi={true} onMount={setEditor} />
+      <Tldraw store={store} onMount={setEditor} hideUi={true} />
     </div>
   );
 };

--- a/packages/apps/plugins/plugin-drawing/src/hooks/index.ts
+++ b/packages/apps/plugins/plugin-drawing/src/hooks/index.ts
@@ -2,4 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './useDrawingModel';
+export * from './useDrawingStore';

--- a/packages/apps/plugins/plugin-drawing/src/hooks/useDrawingStore.tsx
+++ b/packages/apps/plugins/plugin-drawing/src/hooks/useDrawingStore.tsx
@@ -12,58 +12,65 @@ import {
   TLPageId,
   TLRecord,
 } from '@tldraw/tldraw';
+import { TLStore } from '@tldraw/tlschema';
 import { useEffect, useMemo } from 'react';
 import { Transaction, YEvent } from 'yjs';
 
 import { Text } from '@dxos/client/echo';
 
-import { DrawingModel } from '../types';
+type Unsubscribe = () => void;
 
 /**
- * Constructs model from ECHO object.
+ * Constructs store from ECHO object.
  * Derived from tldraw example: https://github.com/tldraw/tldraw/blob/main/apps/examples/src/yjs/useYjsStore.ts
  */
-export const useDrawingModel = (data: Text, options = { timeout: 250 }): DrawingModel => {
-  const store = useMemo(() => {
-    return createTLStore({ shapes: defaultShapes });
-  }, [data]);
+export class EchoStore {
+  private readonly _subscriptions: Unsubscribe[] = [];
+  private readonly _store: TLStore;
 
-  useEffect(() => {
+  constructor(private readonly _data: Text, private readonly _options = { timeout: 250 }) {
+    this._store = createTLStore({ shapes: defaultShapes });
+  }
+
+  get store() {
+    return this._store;
+  }
+
+  open() {
+    if (this._subscriptions.length) {
+      return this;
+    }
+
     // TODO(burdon): Schema document type.
     // TODO(burdon): Garbage collection (gc)?
-    const doc = data.doc!; // ?? new Doc({ gc: true });
+    const doc = this._data.doc!; // ?? new Doc({ gc: true });
     const yRecords = doc.getMap<TLRecord>('content');
+
+    // TODO(burdon): Capture mouse-up event to trigger save.
 
     // Initialize the store with the yjs doc records.
     // If the yjs doc is empty, initialize the yjs doc with the default store records.
     if (yRecords.size === 0) {
       // Create the initial store records.
       transact(() => {
-        store.clear();
-        store.put([
-          DocumentRecordType.create({
-            id: 'document:document' as TLDocument['id'],
-          }),
-          // TODO(burdon): Manage pages?
-          PageRecordType.create({
-            id: 'page:page' as TLPageId,
-            name: 'Page 1',
-            index: 'a1',
-          }),
+        this._store.clear();
+        this._store.put([
+          PageRecordType.create({ id: 'page:page' as TLPageId, name: 'Page 1', index: 'a1' }),
+          DocumentRecordType.create({ id: 'document:document' as TLDocument['id'] }),
         ]);
       });
 
       // Sync the store records to the yjs doc.
       doc.transact(() => {
-        for (const record of store.allRecords()) {
+        for (const record of this._store.allRecords()) {
           yRecords.set(record.id, record);
         }
       });
     } else {
       // Replace the store records with the yjs doc records.
       transact(() => {
-        store.clear();
-        store.put([...yRecords.values()]);
+        this._store.clear();
+        this._store.put([...yRecords.values()]);
       });
     }
 
@@ -95,20 +102,19 @@ export const useDrawingModel = (data: Text, options = { timeout: 250 }): Drawing
       });
 
       // Update/remove the records in the store.
-      store.mergeRemoteChanges(() => {
+      this._store.mergeRemoteChanges(() => {
         if (removed.length) {
-          store.remove(removed);
+          this._store.remove(removed);
         }
         if (updated.length) {
-          store.put(updated);
+          this._store.put(updated);
         }
       });
     };
 
     yRecords.observeDeep(handleChange);
 
-    const subscriptions: (() => void)[] = [];
-    subscriptions.push(() => yRecords.unobserveDeep(handleChange));
+    this._subscriptions.push(() => yRecords.unobserveDeep(handleChange));
 
     //
     // Subscribe to changes from component's store (model).
@@ -117,8 +123,8 @@ export const useDrawingModel = (data: Text, options = { timeout: 250 }): Drawing
     //
     let timeout: ReturnType<typeof setTimeout>;
     const mutations = new Map();
-    subscriptions.push(
-      store.listen(
+    this._subscriptions.push(
+      this._store.listen(
         ({ changes }) => {
           doc.transact(() => {
             clearTimeout(timeout);
@@ -154,7 +160,7 @@ export const useDrawingModel = (data: Text, options = { timeout: 250 }): Drawing
               });
 
               mutations.clear();
-            }, options.timeout);
+            }, this._options.timeout);
           });
         },
         // Only sync user's document changes.
@@ -162,13 +168,24 @@ export const useDrawingModel = (data: Text, options = { timeout: 250 }): Drawing
       ),
     );
 
+    return this;
+  }
+
+  close() {
+    this._subscriptions.forEach((unsubscribe) => unsubscribe());
+    this._subscriptions.length = 0;
+    return this;
+  }
+}
+
+export const useDrawingStore = (data: Text, options = { timeout: 250 }): TLStore => {
+  const store = useMemo(() => new EchoStore(data, options), [data.id]);
+  useEffect(() => {
+    store.open();
     return () => {
-      subscriptions.forEach((unsubscribe) => unsubscribe());
-      subscriptions.length = 0;
+      store.close();
     };
   }, [store]);
 
-  return {
-    store,
-  };
+  return store?.store;
 };

--- a/packages/apps/plugins/plugin-drawing/src/translations.ts
+++ b/packages/apps/plugins/plugin-drawing/src/translations.ts
@@ -11,6 +11,7 @@ export default [
         'plugin name': 'Drawing',
         'drawing title placeholder': 'New drawing',
         'create drawing label': 'Create drawing',
+        'rename drawing label': 'Rename',
         'delete drawing label': 'Delete',
         'create stack section label': 'Create drawing',
         'choose stack section label': 'Select drawing from this Space',

--- a/packages/apps/plugins/plugin-drawing/src/util.tsx
+++ b/packages/apps/plugins/plugin-drawing/src/util.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import type { Graph } from '@braneframe/plugin-graph';
 import { SpaceAction } from '@braneframe/plugin-space';
-import { getPersistenceParent } from '@braneframe/plugin-treeview'; // TODO(burdon): Move to graph.
+import { getPersistenceParent } from '@braneframe/plugin-treeview'; // TODO(burdon): Move to graph?
 import { Drawing as DrawingType } from '@braneframe/types';
 import { Space } from '@dxos/client/echo';
 
@@ -25,17 +25,19 @@ export const objectToGraphNode = (
     icon: (props) => <CompassTool {...props} />,
     data: object,
     properties: {
-      index: get(object, 'meta.index', index), // TODO(burdon): Data should not be on object?
+      index: get(object, 'meta.index', index),
+      persistenceClass: 'spaceObject',
     },
   });
 
+  // TODO(burdon): Add create/rename/delete by default (or helper).
   child.addAction({
     id: 'rename',
-    label: ['rename document label', { ns: DRAWING_PLUGIN }],
+    label: ['rename drawing label', { ns: DRAWING_PLUGIN }],
     icon: (props) => <PencilSimpleLine {...props} />,
     intent: {
       action: SpaceAction.RENAME_OBJECT,
-      data: { spaceKey: getPersistenceParent(child, 'spaceObject')?.data?.key.toHex(), objectId: document.id },
+      data: { spaceKey: getPersistenceParent(child, 'spaceObject')?.data?.key.toHex(), objectId: object.id },
     },
   });
 

--- a/packages/apps/plugins/plugin-drawing/src/util.tsx
+++ b/packages/apps/plugins/plugin-drawing/src/util.tsx
@@ -2,12 +2,13 @@
 // Copyright 2023 DXOS.org
 //
 
-import { CompassTool, Trash } from '@phosphor-icons/react';
+import { CompassTool, PencilSimpleLine, Trash } from '@phosphor-icons/react';
 import get from 'lodash.get';
 import React from 'react';
 
 import type { Graph } from '@braneframe/plugin-graph';
 import { SpaceAction } from '@braneframe/plugin-space';
+import { getPersistenceParent } from '@braneframe/plugin-treeview'; // TODO(burdon): Move to graph.
 import { Drawing as DrawingType } from '@braneframe/types';
 import { Space } from '@dxos/client/echo';
 
@@ -25,6 +26,16 @@ export const objectToGraphNode = (
     data: object,
     properties: {
       index: get(object, 'meta.index', index), // TODO(burdon): Data should not be on object?
+    },
+  });
+
+  child.addAction({
+    id: 'rename',
+    label: ['rename document label', { ns: DRAWING_PLUGIN }],
+    icon: (props) => <PencilSimpleLine {...props} />,
+    intent: {
+      action: SpaceAction.RENAME_OBJECT,
+      data: { spaceKey: getPersistenceParent(child, 'spaceObject')?.data?.key.toHex(), objectId: document.id },
     },
   });
 

--- a/packages/apps/plugins/plugin-theme/src/translations/en-US/appkit.ts
+++ b/packages/apps/plugins/plugin-theme/src/translations/en-US/appkit.ts
@@ -33,8 +33,8 @@ export const appkit = (appName?: string) => ({
   'validate seed phrase label': 'Validate seed phrase',
   'fatal error label_one': 'The app encountered an error',
   'fatal error label_other': 'The app encountered some errors',
-  // TODO(burdon): Don't expose in production.
-  'fatal error message': 'Reloading the app might fix the issue. If it doesn’t, consider resetting the app.',
+  'fatal error message':
+    'Please refresh the page to continue. If you keep seeing this error, please create a GitHub issue or ask for help on Discord.',
   'reset dialog label': 'Reload or reset',
   'reset dialog message':
     'If you’re encountering issues, reloading may fix the issue. If reloading doesn’t help, consider resetting the app.',

--- a/packages/apps/plugins/plugin-thread/src/util.tsx
+++ b/packages/apps/plugins/plugin-thread/src/util.tsx
@@ -24,7 +24,7 @@ export const objectToGraphNode = (
     icon: (props) => <Chat {...props} />,
     data: object,
     properties: {
-      index: get(object, 'meta.index', index), // TODO(burdon): Data should not be on object?
+      index: get(object, 'meta.index', index),
     },
   });
 

--- a/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTree.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTree.tsx
@@ -180,15 +180,15 @@ const TreeViewSortableImpl = ({ parent, items, level }: { parent: Graph.Node; it
 
 const branchIsSortable = (node: TreeViewProps['parent']) => {
   if (typeof node !== 'object') {
-    console.log('[branch is sortable]', 'node not object');
+    // console.log('[branch is sortable]', 'node not object');
     return false;
   }
   const persistenceClass = node?.properties?.childrenPersistenceClass;
   if (!persistenceClass) {
-    console.log('[branch is sortable]', 'no persistence class', node?.properties);
+    // console.log('[branch is sortable]', 'no persistence class', node?.properties);
     return false;
   }
-  console.log('[branch is sortable]', persistenceClass, getPersistenceParent(node!, persistenceClass));
+  // console.log('[branch is sortable]', persistenceClass, getPersistenceParent(node!, persistenceClass));
   return !!getPersistenceParent(node!, persistenceClass);
 };
 

--- a/packages/devtools/devtools/src/components/Tree.stories.tsx
+++ b/packages/devtools/devtools/src/components/Tree.stories.tsx
@@ -1,0 +1,27 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React from 'react';
+
+import '@dxosTheme';
+
+import { Tree } from './Tree';
+
+export default {
+  component: Tree,
+  argTypes: {},
+};
+
+export const Default = {
+  render: () => {
+    return (
+      <div>
+        <Tree data={JSON.parse(data)} />
+      </div>
+    );
+  },
+};
+
+const data =
+  '{"runtime":{"client":{"remoteSource":"https://halo.dev.dxos.org/vault.html","storage":{"persistent":true}},"services":{"signaling":[{"server":"wss://kube.dxos.org/.well-known/dx/signal"},{"server":"wss://dev.kube.dxos.org/.well-known/dx/signal"}],"ice":[{"urls":"turn:kube.dxos.org:3478","username":"dxos","credential":"dxos"}],"ipfs":{"server":"http://dx.dev.kube.dxos.org:5001","gateway":"http://dx.dev.kube.dxos.org:8888/ipfs"}},"app":{"env":{"DX_ENVIRONMENT":"development","DX_IPDATA_API_KEY":"ccc5f0cd66dd34a7c31c2ddc61c2bbca2db73892a993982bb3a5f0e2"},"build":{"timestamp":"2023-09-01T19:26:43.561Z","commitHash":"d07039ec3","version":"0.1.56"}}},"version":1,"package":{"modules":[{"name":"labs","type":"dxos:type/app","displayName":"Labs","description":"DXOS Labs Plugins","tags":["showcase"],"build":{"command":"pnpm -w nx bundle labs-app"}}]}}';

--- a/packages/devtools/devtools/src/components/Tree.tsx
+++ b/packages/devtools/devtools/src/components/Tree.tsx
@@ -1,0 +1,73 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React, { FC, HTMLAttributes, useState } from 'react';
+
+import { mx } from '@dxos/aurora-theme';
+
+export const Tree: FC<{ data?: object }> = ({ data }) => {
+  return (
+    <div className='flex overflow-auto ml-2 border-l-2 border-blue-500'>
+      <Node data={data} root />
+    </div>
+  );
+};
+
+export const Node: FC<{ data?: any; root?: boolean }> = ({ data, root }) => {
+  if (typeof data !== 'object' || data === undefined || data === null) {
+    return <Scalar value={data} />;
+  }
+
+  if (Array.isArray(data)) {
+    return (
+      <div className='flex flex-col space-y-2'>
+        {data.map((value, index) => (
+          <KeyValue key={index} label={String(index)} data={value} className='bg-teal-50' />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex flex-col space-y-2'>
+      {Object.entries(data).map(([key, value]) => (
+        <KeyValue key={key} label={key} data={value} className='bg-blue-50' />
+      ))}
+    </div>
+  );
+};
+
+export const KeyValue: FC<{ label: string; data?: any; className?: string }> = ({ label, data, className }) => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className='flex'>
+      <Box
+        className={mx('border-blue-200 text-sm select-none cursor-pointer', className)}
+        onClick={() => setOpen((open) => !open)}
+      >
+        {label}
+      </Box>
+      {open && <Node data={data} />}
+    </div>
+  );
+};
+
+const Scalar: FC<{ value: any }> = ({ value }) => {
+  return (
+    <Box className='bg-green-50 border-green-200 rounded-r text-sm font-thin'>
+      {(value === undefined && 'undefined') ||
+        (value === null && 'null') ||
+        (typeof value === 'string' && value) ||
+        JSON.stringify(value)}
+    </Box>
+  );
+};
+
+const Box: FC<HTMLAttributes<HTMLDivElement>> = ({ children, className, ...props }) => {
+  return (
+    <div className={mx('flex px-2 border border-l-0 font-mono truncate', className)} {...props}>
+      {children}
+    </div>
+  );
+};

--- a/packages/devtools/devtools/src/components/index.ts
+++ b/packages/devtools/devtools/src/components/index.ts
@@ -13,3 +13,4 @@ export * from './PropertiesTable';
 export * from './PublicKeySelector';
 export * from './Searchbar';
 export * from './Select';
+export * from './Tree';

--- a/packages/devtools/devtools/src/panels/client/DiagnosticsPanel/DiagnosticsPanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/DiagnosticsPanel/DiagnosticsPanel.tsx
@@ -11,7 +11,7 @@ import { useFileDownload } from '@dxos/react-appkit';
 import { useAsyncEffect } from '@dxos/react-async';
 import { useClient } from '@dxos/react-client';
 
-import { JsonView, PanelContainer } from '../../../components';
+import { JsonView, PanelContainer, Tree } from '../../../components';
 
 export const DiagnosticsPanel = () => {
   const client = useClient();
@@ -93,7 +93,7 @@ export const DiagnosticsPanel = () => {
         )
       }
     >
-      <JsonView data={data} />
+      {(false && <JsonView data={data} />) || <Tree data={data} />}
     </PanelContainer>
   );
 };

--- a/packages/ui/react-appkit/src/translations/en-US.ts
+++ b/packages/ui/react-appkit/src/translations/en-US.ts
@@ -32,7 +32,6 @@ export const appkit = {
   'validate seed phrase label': 'Validate seed phrase',
   'fatal error label_one': 'The app encountered an error',
   'fatal error label_other': 'The app encountered some errors',
-  // TODO(burdon): Don't expose in production.
   'fatal error message': 'Reloading the app might fix the issue. If it doesn’t, consider resetting the app.',
   'reset dialog label': 'Reload or reset',
   'reset dialog message':


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 842a25b</samp>

### Summary
🌳🎨🏷️

<!--
1.  🌳 - This emoji represents the `Tree` component, which is a major feature added in these changes. It also conveys the idea of a nested structure, which is what the component renders.
2.  🎨 - This emoji represents the drawing plugin, which was refactored and enhanced in these changes. It also conveys the idea of creativity and visual expression, which are the goals of the plugin.
3.  🏷️ - This emoji represents the `rename` action and the `rename drawing label` translation, which were added in these changes. It also conveys the idea of labeling and naming, which are important for organizing and identifying drawing objects.
-->
Refactored the drawing plugin UI and added rename and delete actions for drawing objects. Replaced `JsonView` with `Tree` component for better diagnostics visualization and added a storybook example for it. Removed an outdated comment from the thread plugin.

> _To improve the drawing plugin's UI_
> _We added a `rename` action and a `Tree`_
> _The `Tree` component shows nested data_
> _With colors and icons that are not bad_
> _And the `JsonView` component had to flee_

### Walkthrough
*  Import `Folder` and `PencilSimpleLine` icons from `@phosphor-icons/react` for drawing plugin presentation node and rename action ([link](https://github.com/dxos/dxos/pull/4099/files?diff=unified&w=0#diff-aaca140d1a823ce6b8f5dbe2aa2275a30cad79dab9466f39491e2e71b768b5deL5-R5), [link](https://github.com/dxos/dxos/pull/4099/files?diff=unified&w=0#diff-63f912c1056e77b6b0931ea14075b00bd9574478d5b9cdd5496c910954db7850L5-R5))
*  Create `presentationNode` as a child of `parent` node with drawing plugin properties and move `create` action from `parent` to `presentationNode` in `DrawingPlugin.tsx` ([link](https://github.com/dxos/dxos/pull/4099/files?diff=unified&w=0#diff-aaca140d1a823ce6b8f5dbe2aa2275a30cad79dab9466f39491e2e71b768b5deL39-R46), [link](https://github.com/dxos/dxos/pull/4099/files?diff=unified&w=0#diff-aaca140d1a823ce6b8f5dbe2aa2275a30cad79dab9466f39491e2e71b768b5deL61-R68))
*  Add `persistenceClass` property and `rename` action to drawing object node and move `delete` action after `rename` in `util.tsx` ([link](https://github.com/dxos/dxos/pull/4099/files?diff=unified&w=0#diff-63f912c1056e77b6b0931ea14075b00bd9574478d5b9cdd5496c910954db7850L27-R44))
*  Add `rename drawing label` translation to `translations.ts` for `rename` action ([link](https://github.com/dxos/dxos/pull/4099/files?diff=unified&w=0#diff-c3cc57b9171a5fd9cda188d8ec6ffe3277189629b8a1363e82dccdac4eaa6667R14))
*  Remove obsolete comment from `util.tsx` in `plugin-thread` ([link](https://github.com/dxos/dxos/pull/4099/files?diff=unified&w=0#diff-9db0bd0de3aef8d268ba1fbdba8250dde380bd4d53d96a3a4fa2a109aaaacff3L27-R27))
*  Implement and export `Tree` component in `Tree.tsx` and `components/index.ts` to render nested objects as collapsible trees ([link](https://github.com/dxos/dxos/pull/4099/files?diff=unified&w=0#diff-ae97504b776eb34768c87b22f12e522e9492cbe7776bd5f52c6aa2108a828613R1-R73), [link](https://github.com/dxos/dxos/pull/4099/files?diff=unified&w=0#diff-d3bc98a087574e6bcbd91fe1c346114e99e0077014d44b1a9c26c8cf7a57791eR16))
*  Add storybook example of `Tree` component in `Tree.stories.tsx` with mock data ([link](https://github.com/dxos/dxos/pull/4099/files?diff=unified&w=0#diff-9e77f79bf25084c24fb10dbf2ae68a064656a14ee3d07624240a79ec52c657fcR1-R27))
*  Replace `JsonView` with `Tree` component in `DiagnosticsPanel.tsx` to display diagnostics data in `devtools` ([link](https://github.com/dxos/dxos/pull/4099/files?diff=unified&w=0#diff-e13648b4047b7425be439084bc2a18c07863af65e0c58c0ab8a55287a6abc8d2L14-R14), [link](https://github.com/dxos/dxos/pull/4099/files?diff=unified&w=0#diff-e13648b4047b7425be439084bc2a18c07863af65e0c58c0ab8a55287a6abc8d2L96-R96))


