### PR TITLE
feat: Threads in side bar

### DIFF
--- a/packages/apps/labs-app/src/main.tsx
+++ b/packages/apps/labs-app/src/main.tsx
@@ -69,7 +69,7 @@ const main = async () => {
           GraphPlugin(),
           TreeViewPlugin(),
           UrlSyncPlugin(),
-          SplitViewPlugin({ enableComplementarySidebar: true }),
+          SplitViewPlugin(),
           SpacePlugin(),
 
           // Composer

--- a/packages/apps/plugins/plugin-debug/src/DebugPlugin.tsx
+++ b/packages/apps/plugins/plugin-debug/src/DebugPlugin.tsx
@@ -18,7 +18,7 @@ import translations from './translations';
 export const SETTINGS_KEY = DEBUG_PLUGIN + '/settings';
 
 export const DebugPlugin = (): PluginDefinition<DebugPluginProvides> => {
-  const settings = new LocalStorageStore<DebugSettingsProps>();
+  const settings = new LocalStorageStore<DebugSettingsProps>('braneframe.plugin-debug');
 
   const nodeIds: string[] = [];
   const isDebug = (data: unknown) =>
@@ -34,8 +34,8 @@ export const DebugPlugin = (): PluginDefinition<DebugPluginProvides> => {
     },
     ready: async (plugins) => {
       settings
-        .bind(settings.values.$debug!, 'braneframe.plugin-debug.debug', LocalStorageStore.bool)
-        .bind(settings.values.$devtools!, 'braneframe.plugin-debug.devtools', LocalStorageStore.bool);
+        .prop(settings.values.$debug!, 'debug', LocalStorageStore.bool)
+        .prop(settings.values.$devtools!, 'devtools', LocalStorageStore.bool);
     },
     unload: async () => {
       settings.close();

--- a/packages/apps/plugins/plugin-github/src/GithubPlugin.tsx
+++ b/packages/apps/plugins/plugin-github/src/GithubPlugin.tsx
@@ -30,7 +30,7 @@ export type GithubPluginProvides = TranslationsProvides & {
 };
 
 export const GithubPlugin = (): PluginDefinition<GithubPluginProvides> => {
-  const settings = new LocalStorageStore<GithubSettingsProps>();
+  const settings = new LocalStorageStore<GithubSettingsProps>('braneframe.plugin-github');
 
   return {
     meta: {
@@ -38,7 +38,7 @@ export const GithubPlugin = (): PluginDefinition<GithubPluginProvides> => {
       shortId: 'github',
     },
     ready: async () => {
-      settings.bind(settings.values.$pat!, 'braneframe.plugin-github.pat', LocalStorageStore.string);
+      settings.prop(settings.values.$pat!, 'pat', LocalStorageStore.string);
     },
     unload: async () => {
       settings.close();

--- a/packages/apps/plugins/plugin-space/src/components/DialogRestoreSpace.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/DialogRestoreSpace.tsx
@@ -16,7 +16,7 @@ import { SPACE_PLUGIN } from '../types';
 
 export const DialogRestoreSpace = ({ data: [_, space] }: { data: [string, Space] }) => {
   const { t } = useTranslation(SPACE_PLUGIN);
-  const splitViewContext = useSplitView();
+  const splitView = useSplitView();
   return (
     <>
       <Dialog.Title>{t('confirm restore title')}</Dialog.Title>
@@ -26,13 +26,13 @@ export const DialogRestoreSpace = ({ data: [_, space] }: { data: [string, Space]
         classes='block mlb-4 p-8 border-2 border-dashed border-neutral-500/50 rounded flex items-center justify-center gap-2 cursor-pointer'
         dropMessageStyle={{ border: 'none', backgroundColor: '#EEE' }}
         handleChange={(backupFile: File) =>
-          restoreSpace(space, backupFile).finally(() => (splitViewContext.dialogOpen = false))
+          restoreSpace(space, backupFile).finally(() => (splitView.dialogOpen = false))
         }
       >
         <FilePlus weight='duotone' className={getSize(8)} />
         <span>{t('upload file message')}</span>
       </FileUploader>
-      <Button classNames='block is-full' onClick={() => (splitViewContext.dialogOpen = false)}>
+      <Button classNames='block is-full' onClick={() => (splitView.dialogOpen = false)}>
         {t('cancel label', { ns: 'appkit' })}
       </Button>
     </>

--- a/packages/apps/plugins/plugin-splitview/package.json
+++ b/packages/apps/plugins/plugin-splitview/package.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "@dxos/debug": "workspace:*",
+    "@dxos/local-storage": "workspace:*",
     "deepsignal": "^1.3.3"
   },
   "devDependencies": {

--- a/packages/apps/plugins/plugin-splitview/src/SplitViewContext.ts
+++ b/packages/apps/plugins/plugin-splitview/src/SplitViewContext.ts
@@ -6,11 +6,9 @@ import { Context, createContext, useContext } from 'react';
 
 import { raise } from '@dxos/debug';
 
-import { SplitViewContextValue } from './types';
+import { SplitViewState } from './types';
 
-export const SplitViewContext: Context<SplitViewContextValue | null> = createContext<SplitViewContextValue | null>(
-  null,
-);
+export const SplitViewContext: Context<SplitViewState | null> = createContext<SplitViewState | null>(null);
 
-export const useSplitView = (): SplitViewContextValue =>
-  useContext(SplitViewContext) ?? raise(new Error('SplitViewContext not found'));
+export const useSplitView = (): SplitViewState =>
+  useContext(SplitViewContext) ?? raise(new Error('Missing SplitViewContext'));

--- a/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
@@ -6,12 +6,13 @@ import { ArrowLineLeft } from '@phosphor-icons/react';
 import { deepSignal } from 'deepsignal/react';
 import React, { PropsWithChildren } from 'react';
 
+import { LocalStorageStore } from '@dxos/local-storage';
 import { PluginDefinition } from '@dxos/react-surface';
 
 import { SplitViewContext } from './SplitViewContext';
 import { SplitView, SplitViewMainContentEmpty } from './components';
 import translations from './translations';
-import { SPLITVIEW_PLUGIN, SplitViewAction, SplitViewProvides } from './types';
+import { SPLITVIEW_PLUGIN, SplitViewAction, SplitViewProvides, SplitViewState } from './types';
 
 export type SplitViewPluginConfig = Partial<{
   enableComplementarySidebar: boolean;
@@ -23,20 +24,42 @@ export type SplitViewPluginConfig = Partial<{
 export const SplitViewPlugin = ({
   enableComplementarySidebar,
 }: SplitViewPluginConfig = {}): PluginDefinition<SplitViewProvides> => {
-  const state = deepSignal({
-    sidebarOpen: true,
-    complementarySidebarOpen: enableComplementarySidebar ? true : null, // TODO(burdon): Store state in local storage.
-    dialogContent: 'never',
-    dialogOpen: false,
-  });
+  const settings = new LocalStorageStore<SplitViewState>(
+    deepSignal({
+      dialogContent: 'never',
+      dialogOpen: false,
+    }),
+  );
+
+  // const state = deepSignal({
+  // TODO(burdon): Proxy.
+  // sidebarOpen: settings.values.$sidebarOpen,
+  // complementarySidebarOpen: settings.values.$complementarySidebarOpen,
+  // sidebarOpen: true,
+  // complementarySidebarOpen: enableComplementarySidebar ? false : undefined, // TODO(burdon): Store state in local storage.
+  // dialogContent: 'never',
+  // dialogOpen: false,
+  // });
 
   return {
     meta: {
       id: SPLITVIEW_PLUGIN,
     },
+    ready: async () => {
+      settings
+        .bind(settings.values.$sidebarOpen!, 'braneframe.plugin-splitview.sidebarOpen', LocalStorageStore.bool)
+        .bind(
+          settings.values.$complementarySidebarOpen!,
+          'braneframe.plugin-splitview.complementarySidebarOpen',
+          LocalStorageStore.bool,
+        );
+    },
+    unload: async () => {
+      settings.close();
+    },
     provides: {
       context: (props: PropsWithChildren) => (
-        <SplitViewContext.Provider value={state}>{props.children}</SplitViewContext.Provider>
+        <SplitViewContext.Provider value={settings.values}>{props.children}</SplitViewContext.Provider>
       ),
       components: { SplitView, SplitViewMainContentEmpty },
       graph: {
@@ -61,13 +84,13 @@ export const SplitViewPlugin = ({
         resolver: (intent) => {
           switch (intent.action) {
             case SplitViewAction.TOGGLE_SIDEBAR: {
-              state.sidebarOpen = intent.data.state ?? !state.sidebarOpen;
+              settings.values.sidebarOpen = intent.data.state ?? !settings.values.sidebarOpen;
               return true;
             }
           }
         },
       },
-      splitView: state,
+      splitView: settings.values,
       translations,
     },
   };

--- a/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
@@ -25,7 +25,7 @@ export const SplitViewPlugin = ({
 }: SplitViewPluginConfig = {}): PluginDefinition<SplitViewProvides> => {
   const state = deepSignal({
     sidebarOpen: true,
-    complementarySidebarOpen: enableComplementarySidebar ? false : null,
+    complementarySidebarOpen: enableComplementarySidebar ? true : null, // TODO(burdon): Store state in local storage.
     dialogContent: 'never',
     dialogOpen: false,
   });

--- a/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/SplitViewPlugin.tsx
@@ -3,7 +3,6 @@
 //
 
 import { ArrowLineLeft } from '@phosphor-icons/react';
-import { deepSignal } from 'deepsignal/react';
 import React, { PropsWithChildren } from 'react';
 
 import { LocalStorageStore } from '@dxos/local-storage';
@@ -14,32 +13,15 @@ import { SplitView, SplitViewMainContentEmpty } from './components';
 import translations from './translations';
 import { SPLITVIEW_PLUGIN, SplitViewAction, SplitViewProvides, SplitViewState } from './types';
 
-export type SplitViewPluginConfig = Partial<{
-  enableComplementarySidebar: boolean;
-}>;
-
 /**
  * Root application layout that controls sidebars, popovers, and dialogs.
  */
-export const SplitViewPlugin = ({
-  enableComplementarySidebar,
-}: SplitViewPluginConfig = {}): PluginDefinition<SplitViewProvides> => {
-  const settings = new LocalStorageStore<SplitViewState>(
-    deepSignal({
-      dialogContent: 'never',
-      dialogOpen: false,
-    }),
-  );
-
-  // const state = deepSignal({
-  // TODO(burdon): Proxy.
-  // sidebarOpen: settings.values.$sidebarOpen,
-  // complementarySidebarOpen: settings.values.$complementarySidebarOpen,
-  // sidebarOpen: true,
-  // complementarySidebarOpen: enableComplementarySidebar ? false : undefined, // TODO(burdon): Store state in local storage.
-  // dialogContent: 'never',
-  // dialogOpen: false,
-  // });
+export const SplitViewPlugin = (): PluginDefinition<SplitViewProvides> => {
+  const settings = new LocalStorageStore<SplitViewState>('braneframe.plugin-splitview', {
+    sidebarOpen: true,
+    dialogContent: 'never',
+    dialogOpen: false,
+  });
 
   return {
     meta: {
@@ -47,12 +29,8 @@ export const SplitViewPlugin = ({
     },
     ready: async () => {
       settings
-        .bind(settings.values.$sidebarOpen!, 'braneframe.plugin-splitview.sidebarOpen', LocalStorageStore.bool)
-        .bind(
-          settings.values.$complementarySidebarOpen!,
-          'braneframe.plugin-splitview.complementarySidebarOpen',
-          LocalStorageStore.bool,
-        );
+        .prop(settings.values.$sidebarOpen!, 'sidebar-open', LocalStorageStore.bool)
+        .prop(settings.values.$complementarySidebarOpen!, 'complementary-sidebar-open', LocalStorageStore.bool);
     },
     unload: async () => {
       settings.close();

--- a/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
+++ b/packages/apps/plugins/plugin-splitview/src/components/SplitView.tsx
@@ -86,6 +86,7 @@ export const SplitView = () => {
         </Main.Content>
 
         {/* Status info. */}
+        {/* TODO(burdon): Currently covered by complementary sidebar. */}
         <div role='none' aria-label={t('status label')} className={mx('fixed bottom-0 right-0 z-[1]', fixedSurface)}>
           <Surface name='status' role='status' />
         </div>

--- a/packages/apps/plugins/plugin-splitview/src/types.ts
+++ b/packages/apps/plugins/plugin-splitview/src/types.ts
@@ -2,8 +2,6 @@
 // Copyright 2023 DXOS.org
 //
 
-import type { DeepSignal } from 'deepsignal';
-
 import type { GraphProvides } from '@braneframe/plugin-graph';
 import type { IntentProvides } from '@braneframe/plugin-intent';
 import type { TranslationsProvides } from '@braneframe/plugin-theme';
@@ -15,18 +13,18 @@ export enum SplitViewAction {
   TOGGLE_SIDEBAR = `${SPLITVIEW_ACTION}/toggle-sidebar`,
 }
 
-export type SplitViewContextValue = DeepSignal<{
-  sidebarOpen: boolean;
-  complementarySidebarOpen: boolean | null;
-  dialogContent: any;
-  dialogOpen: boolean;
+export type SplitViewState = {
+  sidebarOpen?: boolean;
+  complementarySidebarOpen?: boolean;
+  dialogContent?: any;
+  dialogOpen?: boolean;
   popoverContent?: any;
   popoverOpen?: boolean;
   popoverAnchorId?: string;
-}>;
+};
 
 export type SplitViewProvides = GraphProvides &
   TranslationsProvides &
   IntentProvides & {
-    splitView: SplitViewContextValue;
+    splitView: SplitViewState;
   };

--- a/packages/apps/plugins/plugin-splitview/tsconfig.json
+++ b/packages/apps/plugins/plugin-splitview/tsconfig.json
@@ -24,6 +24,9 @@
       "path": "../../../common/debug"
     },
     {
+      "path": "../../../common/local-storage"
+    },
+    {
       "path": "../../../sdk/react-surface"
     },
     {

--- a/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -2,18 +2,16 @@
 // Copyright 2023 DXOS.org
 //
 
-import { List, Plus } from '@phosphor-icons/react';
+import { Plus } from '@phosphor-icons/react';
 import React from 'react';
 
 import { GraphNodeAdapter, SpaceAction } from '@braneframe/plugin-space';
 import { TreeViewAction } from '@braneframe/plugin-treeview';
 import { Thread as ThreadType } from '@braneframe/types';
-import { Button, Toolbar } from '@dxos/aurora';
-import { getSize } from '@dxos/aurora-theme';
 import { SpaceProxy } from '@dxos/react-client/echo';
 import { PluginDefinition } from '@dxos/react-surface';
 
-import { ThreadMain } from './components';
+import { ThreadMain, ThreadSidebar } from './components';
 import translations from './translations';
 import { isThread, THREAD_PLUGIN, ThreadAction, ThreadPluginProvides } from './types';
 import { objectToGraphNode } from './util';
@@ -76,7 +74,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
           }
 
           case 'complementary':
-            return Test;
+            return ThreadSidebar;
         }
       },
       components: {
@@ -93,19 +91,4 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
       },
     },
   };
-};
-
-// TODO(burdon): Get current space.
-const Test = (props: any) => {
-  // console.log(props);
-  return (
-    <div>
-      <Toolbar.Root>
-        <div role='none' className='grow' />
-        <Button variant='ghost'>
-          <List weight='light' className={getSize(4)} />
-        </Button>
-      </Toolbar.Root>
-    </div>
-  );
 };

--- a/packages/apps/plugins/plugin-thread/src/components/ThreadBlock.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadBlock.tsx
@@ -13,7 +13,7 @@ import { PublicKey } from '@dxos/react-client';
 import { useSubscription } from './util';
 
 export type BlockProperties = {
-  displayName: string;
+  displayName?: string;
   classes: string;
 };
 

--- a/packages/apps/plugins/plugin-thread/src/components/ThreadBlock.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadBlock.tsx
@@ -37,17 +37,17 @@ export const ThreadBlock: FC<{
     <div
       key={block.id}
       className={mx(
-        'flex flex-col overflow-hidden shadow',
+        'flex flex-col overflow-hidden rounded shadow',
         inputSurface,
-        !PublicKey.equals(identityKey, PublicKey.from(block.identityKey)) && 'rounded shadow',
+        // !PublicKey.equals(identityKey, PublicKey.from(block.identityKey)) && 'rounded shadow',
       )}
     >
-      <div className='flex __divide-x'>
+      <div className='flex'>
         <div className='flex shrink-0 w-[40px] h-[40px] items-center justify-center'>
           <UserCircle weight='duotone' className={mx(getSize(7), classes)} />
         </div>
         <div className='flex flex-col w-full overflow-hidden'>
-          <div className='flex text-sm px-2 py-1 space-x-1 __rounded-tl __rounded-tr truncate'>
+          <div className='flex text-sm px-2 py-1 space-x-1 truncate'>
             <span className={mx('flex grow whitespace-nowrap truncate font-thin text-zinc-500')}>{displayName}</span>
             {date && (
               <>
@@ -57,7 +57,7 @@ export const ThreadBlock: FC<{
             )}
           </div>
 
-          <div className='overflow-hidden __divide-y pb-1'>
+          <div className='overflow-hidden pb-1'>
             {block.messages.map((message, i) => (
               <div key={i} className='flex overflow-hidden px-2 py-1 group'>
                 {message.text && <div className='grow overflow-hidden break-words mr-2 text-sm'>{message.text}</div>}

--- a/packages/apps/plugins/plugin-thread/src/components/ThreadChannel.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadChannel.tsx
@@ -8,25 +8,10 @@ import { Thread as ThreadType } from '@braneframe/types';
 import { Input, useTranslation } from '@dxos/aurora';
 import { groupSurface, mx } from '@dxos/aurora-theme';
 import { PublicKey } from '@dxos/client';
-import { humanize } from '@dxos/util';
 
 import { THREAD_PLUGIN } from '../types';
-import { ThreadBlock } from './ThreadBlock';
+import { BlockProperties, ThreadBlock } from './ThreadBlock';
 import { ThreadInput } from './ThreadInput';
-
-// TODO(burdon): Resolve username (and avatar) from identityKey/members.
-const colors = [
-  'text-blue-300',
-  'text-green-300',
-  'text-teal-300',
-  'text-red-300',
-  'text-orange-300',
-  'text-purple-300',
-];
-const getBlockProperties = (identityKey: PublicKey) => ({
-  displayName: humanize(identityKey),
-  classes: [colors[Number('0x' + identityKey) % colors.length]].join(' '),
-});
 
 // type DailyBlock = {
 //   date?: Date;
@@ -49,8 +34,9 @@ const getBlockProperties = (identityKey: PublicKey) => ({
 export const ThreadChannel: FC<{
   identityKey: PublicKey;
   thread: ThreadType;
+  getBlockProperties: (identityKey: PublicKey) => BlockProperties;
   onAddMessage: (text: string) => boolean | undefined;
-}> = ({ identityKey, thread, onAddMessage }) => {
+}> = ({ identityKey, thread, getBlockProperties, onAddMessage }) => {
   const { t } = useTranslation(THREAD_PLUGIN);
   const bottomRef = useRef<HTMLDivElement>(null);
 
@@ -63,12 +49,14 @@ export const ThreadChannel: FC<{
     }
   };
 
-  // TODO(burdon): Different width form factors.
   return (
     <div
-      className={mx('flex flex-col h-full w-full min-w-[300px] md:max-w-[600px] overflow-hidden m-4 p-2', groupSurface)}
+      className={mx(
+        'flex flex-col h-full w-full min-w-[300px] md:max-w-[600px] overflow-hidden m-0 lg:m-auto',
+        groupSurface,
+      )}
     >
-      <div className='flex px-6 pb-4'>
+      <div className='flex px-2'>
         <Input.Root>
           <Input.Label srOnly>{t('thread name placeholder')}</Input.Label>
           <Input.TextInput
@@ -84,7 +72,7 @@ export const ThreadChannel: FC<{
       <div className='flex flex-grow overflow-hidden'>
         {/* TODO(burdon): Scroll panel. */}
         {/* TODO(burdon): Break into days. */}
-        <div className='flex flex-col-reverse grow overflow-auto px-6 pt-4'>
+        <div className='flex flex-col-reverse grow overflow-auto px-2 pt-4'>
           <div ref={bottomRef} />
           {thread.blocks
             .map((block) => (
@@ -95,7 +83,7 @@ export const ThreadChannel: FC<{
             .reverse()}
         </div>
       </div>
-      <div className='flex px-6 pt-2 pb-4'>
+      <div className='flex px-2 py-2'>
         <ThreadInput onMessage={handleAddMessage} />
       </div>
     </div>

--- a/packages/apps/plugins/plugin-thread/src/components/ThreadInput.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadInput.tsx
@@ -36,7 +36,7 @@ export const ThreadInput: FC<{ onMessage: (text: string) => boolean | undefined 
   };
 
   return (
-    <div className={mx('flex w-full shadow p-2', inputSurface)}>
+    <div className={mx('flex w-full p-2 shadow rounded', inputSurface)}>
       <Input.Root>
         <Input.Label srOnly>{t('block input label')}</Input.Label>
         <Input.TextArea

--- a/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
@@ -59,8 +59,6 @@ export const ThreadContainer: FC<{ space: Space; thread: ThreadType }> = ({ spac
 
   const getBlockProperties = (identityKey: PublicKey) => {
     const member = members.find((member) => PublicKey.equals(member.identity.identityKey, identityKey));
-    console.log(members);
-    console.log(identity);
     return {
       displayName: member?.identity.profile?.displayName ?? humanize(identityKey.toHex()),
       classes: colorHash(identityKey),

--- a/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
@@ -13,7 +13,6 @@ import { PublicKey } from '@dxos/react-client';
 import { Space, useMembers } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
 import { findPlugin, usePlugins } from '@dxos/react-surface';
-import { humanize } from '@dxos/util';
 
 import { ThreadChannel } from './ThreadChannel';
 
@@ -26,15 +25,18 @@ import { ThreadChannel } from './ThreadChannel';
 const colors = [
   'text-blue-300',
   'text-green-300',
-  'text-teal-300',
   'text-red-300',
+  'text-cyan-300',
+  'text-indigo-300',
+  'text-teal-300',
   'text-orange-300',
   'text-purple-300',
 ];
 
 // TODO(burdon): Move to key.
 const colorHash = (key: PublicKey) => {
-  return colors[Number('0x' + key) % colors.length];
+  const num = Number('0x' + key.toHex().slice(0, 8));
+  return colors[num % colors.length];
 };
 
 export const ThreadMain: FC<{ data: ThreadType }> = ({ data: object }) => {
@@ -53,15 +55,17 @@ export const ThreadMain: FC<{ data: ThreadType }> = ({ data: object }) => {
 };
 
 export const ThreadContainer: FC<{ space: Space; thread: ThreadType }> = ({ space, thread }) => {
-  const identity = useIdentity(); // TODO(burdon): Requires context for storybook? No profile in personal space?
+  const identity = useIdentity()!; // TODO(burdon): Requires context for storybook? No profile in personal space?
   const members = useMembers(space.key);
   const identityKey = identity!.identityKey;
 
   const getBlockProperties = (identityKey: PublicKey) => {
-    const member = members.find((member) => PublicKey.equals(member.identity.identityKey, identityKey));
+    const author = PublicKey.equals(identityKey, identity.identityKey)
+      ? identity
+      : members.find((member) => PublicKey.equals(member.identity.identityKey, identityKey))!.identity;
     return {
-      displayName: member?.identity.profile?.displayName ?? humanize(identityKey.toHex()),
-      classes: colorHash(identityKey),
+      displayName: author.profile?.displayName ?? author.identityKey.toHex(),
+      classes: colorHash(author.identityKey),
     };
   };
 

--- a/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
@@ -3,13 +3,17 @@
 //
 
 import differenceInSeconds from 'date-fns/differenceInSeconds';
-import React, { FC } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 
+import { SpacePluginProvides } from '@braneframe/plugin-space';
 import { Thread as ThreadType } from '@braneframe/types';
 import { Main } from '@dxos/aurora';
 import { coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/aurora-theme';
 import { PublicKey } from '@dxos/react-client';
+import { Space, useMembers } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
+import { findPlugin, usePlugins } from '@dxos/react-surface';
+import { humanize } from '@dxos/util';
 
 import { ThreadChannel } from './ThreadChannel';
 
@@ -19,10 +23,49 @@ import { ThreadChannel } from './ThreadChannel';
 // - Lightweight threads for document comments, inline AI, etc.
 //    (Similar reusable components everywhere; same data structure).
 
-export const ThreadMain: FC<{ data: ThreadType }> = ({ data: thread }) => {
-  const identity = useIdentity(); // TODO(burdon): Requires context for storybook?
+const colors = [
+  'text-blue-300',
+  'text-green-300',
+  'text-teal-300',
+  'text-red-300',
+  'text-orange-300',
+  'text-purple-300',
+];
+
+// TODO(burdon): Move to key.
+const colorHash = (key: PublicKey) => {
+  return colors[Number('0x' + key) % colors.length];
+};
+
+export const ThreadMain: FC<{ data: ThreadType }> = ({ data: object }) => {
+  const { plugins } = usePlugins();
+  const spacePlugin = findPlugin<SpacePluginProvides>(plugins, 'dxos.org/plugin/space');
+  const space = spacePlugin?.provides.space.active;
+  if (!space) {
+    return null;
+  }
+
+  return (
+    <Main.Content classNames={[fixedInsetFlexLayout, coarseBlockPaddingStart]}>
+      <ThreadContainer space={space} thread={object} />
+    </Main.Content>
+  );
+};
+
+export const ThreadContainer: FC<{ space: Space; thread: ThreadType }> = ({ space, thread }) => {
+  const identity = useIdentity(); // TODO(burdon): Requires context for storybook? No profile in personal space?
+  const members = useMembers(space.key);
   const identityKey = identity!.identityKey;
-  // const identityKey = PublicKey.random().toHex();
+
+  const getBlockProperties = (identityKey: PublicKey) => {
+    const member = members.find((member) => PublicKey.equals(member.identity.identityKey, identityKey));
+    console.log(members);
+    console.log(identity);
+    return {
+      displayName: member?.identity.profile?.displayName ?? humanize(identityKey.toHex()),
+      classes: colorHash(identityKey),
+    };
+  };
 
   // TODO(burdon): Change to model.
   const handleAddMessage = (text: string) => {
@@ -57,8 +100,33 @@ export const ThreadMain: FC<{ data: ThreadType }> = ({ data: thread }) => {
   };
 
   return (
-    <Main.Content classNames={[fixedInsetFlexLayout, coarseBlockPaddingStart]}>
-      <ThreadChannel identityKey={identityKey} thread={thread} onAddMessage={handleAddMessage} />
-    </Main.Content>
+    <ThreadChannel
+      identityKey={identityKey}
+      thread={thread}
+      getBlockProperties={getBlockProperties}
+      onAddMessage={handleAddMessage}
+    />
   );
+};
+
+export const ThreadSidebar: FC<{ data: ThreadType }> = ({ data: object }) => {
+  const [thread, setThread] = useState<ThreadType | null>(object);
+  const { plugins } = usePlugins();
+  const spacePlugin = findPlugin<SpacePluginProvides>(plugins, 'dxos.org/plugin/space');
+  const space = spacePlugin?.provides.space.active;
+  useEffect(() => {
+    if (space) {
+      // TODO(burdon): Get thread appropriate for context.
+      const { objects: threads } = space.db.query(ThreadType.filter());
+      if (threads.length) {
+        setThread(threads[0] as ThreadType);
+      }
+    }
+  }, [space, object]);
+
+  if (!space || !thread) {
+    return null;
+  }
+
+  return <ThreadContainer space={space} thread={thread} />;
 };

--- a/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
@@ -39,7 +39,7 @@ export const TreeViewContainer = () => {
   const jdenticon = useJdenticonHref(identity?.identityKey.toHex() ?? '', 24);
   const { t } = useTranslation(TREE_VIEW_PLUGIN);
   const { navigationSidebarOpen } = useSidebars(TREE_VIEW_PLUGIN);
-  const splitViewContext = useSplitView();
+  const splitView = useSplitView();
 
   const branches = graph.root.children;
   const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos.org/plugin/client');
@@ -76,8 +76,8 @@ export const TreeViewContainer = () => {
                         classNames='pli-2 pointer-fine:pli-1'
                         {...(!navigationSidebarOpen && { tabIndex: -1 })}
                         onClick={() => {
-                          splitViewContext.dialogOpen = true;
-                          splitViewContext.dialogContent = 'dxos.org/plugin/splitview/ProfileSettings';
+                          splitView.dialogOpen = true;
+                          splitView.dialogContent = 'dxos.org/plugin/splitview/ProfileSettings';
                         }}
                       >
                         <span className='sr-only'>{t('settings dialog title', { ns: 'os' })}</span>

--- a/packages/ui/aurora-theme/src/styles/components/main.ts
+++ b/packages/ui/aurora-theme/src/styles/components/main.ts
@@ -15,6 +15,20 @@ export type MainStyleProps = Partial<{
   bounce: boolean;
 }>;
 
+// TODO(burdon): Review with will (was 270).
+// Sidebar constants (used by main and complementary sidebar).
+const sidebarSlots = {
+  width: 'sm:is-[270px]',
+  sidebar: {
+    inlineStartSidebarOpen: 'sm:-inline-start-[270px]',
+    inlineEndSidebarOpen: 'sm:-inline-end-[270px]',
+  },
+  content: {
+    inlineStartSidebarOpen: 'pis-[270px]',
+    inlineEndSidebarOpen: 'pie-[270px]',
+  },
+};
+
 export const mainSidebar: ComponentFunction<MainStyleProps> = (
   { inlineStartSidebarOpen, inlineEndSidebarOpen, side },
   ...etc
@@ -35,6 +49,27 @@ export const mainSidebar: ComponentFunction<MainStyleProps> = (
     ...etc,
   );
 
+export const mainSidebar2: ComponentFunction<MainStyleProps> = (
+  { inlineStartSidebarOpen, inlineEndSidebarOpen, side },
+  ...etc
+) =>
+  mx(
+    'fixed block-start-0 block-end-0 is-[100vw] z-10 overscroll-contain overflow-x-hidden overflow-y-auto',
+    'transition-[inset-inline-start,inset-inline-end] duration-200 ease-in-out',
+    'border-neutral-200 dark:border-neutral-800',
+    sidebarSlots.width,
+    side === 'inline-start'
+      ? inlineStartSidebarOpen
+        ? 'inline-start-0'
+        : mx('-inline-start-[100vw]', sidebarSlots.sidebar.inlineStartSidebarOpen)
+      : inlineEndSidebarOpen
+      ? 'inline-end-0'
+      : mx('-inline-end-[100vw]', sidebarSlots.sidebar.inlineEndSidebarOpen),
+    side === 'inline-start' ? 'border-ie' : 'border-is',
+    fixedSurface,
+    ...etc,
+  );
+
 export const mainOverlay: ComponentFunction<MainStyleProps> = (
   { isLg, inlineStartSidebarOpen, inlineEndSidebarOpen, side },
   ...etc
@@ -44,6 +79,18 @@ export const mainOverlay: ComponentFunction<MainStyleProps> = (
     'transition-opacity duration-200 ease-in-out',
     !isLg && (inlineStartSidebarOpen || inlineEndSidebarOpen) ? 'opacity-100' : 'opacity-0',
     !isLg && (inlineStartSidebarOpen || inlineEndSidebarOpen) ? 'block' : 'hidden',
+    ...etc,
+  );
+
+export const mainContent2: ComponentFunction<MainStyleProps> = (
+  { isLg, inlineStartSidebarOpen, inlineEndSidebarOpen, bounce },
+  ...etc
+) =>
+  mx(
+    'transition-[padding-inline-start,padding-inline-end] duration-200 ease-in-out',
+    isLg && inlineStartSidebarOpen ? sidebarSlots.content.inlineStartSidebarOpen : 'pis-0',
+    isLg && inlineEndSidebarOpen ? sidebarSlots.content.inlineEndSidebarOpen : 'pie-0',
+    bounce && bounceLayout,
     ...etc,
   );
 

--- a/packages/ui/aurora-theme/src/styles/components/main.ts
+++ b/packages/ui/aurora-theme/src/styles/components/main.ts
@@ -15,17 +15,18 @@ export type MainStyleProps = Partial<{
   bounce: boolean;
 }>;
 
-// TODO(burdon): Review with will (was 270).
-// Sidebar constants (used by main and complementary sidebar).
+// Sidebar widths (used by main and complementary sidebar).
 const sidebarSlots = {
-  width: 'sm:is-[270px]',
-  sidebar: {
-    inlineStartSidebarOpen: 'sm:-inline-start-[270px]',
-    inlineEndSidebarOpen: 'sm:-inline-end-[270px]',
+  start: {
+    width: 'sm:is-[270px]',
+    sidebar: 'sm:-inline-start-[270px]',
+    content: 'pis-[270px]',
   },
-  content: {
-    inlineStartSidebarOpen: 'pis-[270px]',
-    inlineEndSidebarOpen: 'pie-[270px]',
+  // TODO(burdon): Maximal size for phone.
+  end: {
+    width: 'sm:is-[360px]',
+    sidebar: 'sm:-inline-end-[360px]',
+    content: 'pie-[360px]',
   },
 };
 
@@ -34,39 +35,31 @@ export const mainSidebar: ComponentFunction<MainStyleProps> = (
   ...etc
 ) =>
   mx(
-    'fixed block-start-0 block-end-0 is-[100vw] sm:is-[270px] z-10 overscroll-contain overflow-x-hidden overflow-y-auto',
+    'fixed block-start-0 block-end-0 is-[100vw] z-10 overscroll-contain overflow-x-hidden overflow-y-auto',
     'transition-[inset-inline-start,inset-inline-end] duration-200 ease-in-out',
     'border-neutral-200 dark:border-neutral-800',
+    side === 'inline-start' ? sidebarSlots.start.width : sidebarSlots.end.width,
     side === 'inline-start'
       ? inlineStartSidebarOpen
         ? 'inline-start-0'
-        : '-inline-start-[100vw] sm:-inline-start-[270px]'
+        : mx('-inline-start-[100vw]', sidebarSlots.start.sidebar)
       : inlineEndSidebarOpen
       ? 'inline-end-0'
-      : '-inline-end-[100vw] sm:-inline-end-[270px]',
+      : mx('-inline-end-[100vw]', sidebarSlots.end.sidebar),
     side === 'inline-start' ? 'border-ie' : 'border-is',
     fixedSurface,
     ...etc,
   );
 
-export const mainSidebar2: ComponentFunction<MainStyleProps> = (
-  { inlineStartSidebarOpen, inlineEndSidebarOpen, side },
+export const mainContent: ComponentFunction<MainStyleProps> = (
+  { isLg, inlineStartSidebarOpen, inlineEndSidebarOpen, bounce },
   ...etc
 ) =>
   mx(
-    'fixed block-start-0 block-end-0 is-[100vw] z-10 overscroll-contain overflow-x-hidden overflow-y-auto',
-    'transition-[inset-inline-start,inset-inline-end] duration-200 ease-in-out',
-    'border-neutral-200 dark:border-neutral-800',
-    sidebarSlots.width,
-    side === 'inline-start'
-      ? inlineStartSidebarOpen
-        ? 'inline-start-0'
-        : mx('-inline-start-[100vw]', sidebarSlots.sidebar.inlineStartSidebarOpen)
-      : inlineEndSidebarOpen
-      ? 'inline-end-0'
-      : mx('-inline-end-[100vw]', sidebarSlots.sidebar.inlineEndSidebarOpen),
-    side === 'inline-start' ? 'border-ie' : 'border-is',
-    fixedSurface,
+    'transition-[padding-inline-start,padding-inline-end] duration-200 ease-in-out',
+    isLg && inlineStartSidebarOpen ? sidebarSlots.start.content : 'pis-0',
+    isLg && inlineEndSidebarOpen ? sidebarSlots.end.content : 'pie-0',
+    bounce && bounceLayout,
     ...etc,
   );
 
@@ -79,30 +72,6 @@ export const mainOverlay: ComponentFunction<MainStyleProps> = (
     'transition-opacity duration-200 ease-in-out',
     !isLg && (inlineStartSidebarOpen || inlineEndSidebarOpen) ? 'opacity-100' : 'opacity-0',
     !isLg && (inlineStartSidebarOpen || inlineEndSidebarOpen) ? 'block' : 'hidden',
-    ...etc,
-  );
-
-export const mainContent2: ComponentFunction<MainStyleProps> = (
-  { isLg, inlineStartSidebarOpen, inlineEndSidebarOpen, bounce },
-  ...etc
-) =>
-  mx(
-    'transition-[padding-inline-start,padding-inline-end] duration-200 ease-in-out',
-    isLg && inlineStartSidebarOpen ? sidebarSlots.content.inlineStartSidebarOpen : 'pis-0',
-    isLg && inlineEndSidebarOpen ? sidebarSlots.content.inlineEndSidebarOpen : 'pie-0',
-    bounce && bounceLayout,
-    ...etc,
-  );
-
-export const mainContent: ComponentFunction<MainStyleProps> = (
-  { isLg, inlineStartSidebarOpen, inlineEndSidebarOpen, bounce },
-  ...etc
-) =>
-  mx(
-    'transition-[padding-inline-start,padding-inline-end] duration-200 ease-in-out',
-    isLg && inlineStartSidebarOpen ? 'pis-[270px]' : 'pis-0',
-    isLg && inlineEndSidebarOpen ? 'pie-[270px]' : 'pie-0',
-    bounce && bounceLayout,
     ...etc,
   );
 

--- a/packages/ui/aurora/src/components/Main/Main.tsx
+++ b/packages/ui/aurora/src/components/Main/Main.tsx
@@ -120,6 +120,10 @@ const MainRoot = ({
 
 MainRoot.displayName = MAIN_ROOT_NAME;
 
+const handleOpenAutoFocus = (event: Event) => {
+  !document.body.hasAttribute('data-is-keyboard') && event.preventDefault();
+};
+
 type MainSidebarProps = ThemedClassName<ComponentPropsWithRef<typeof DialogContent>> & {
   swipeToDismiss?: boolean;
   open: boolean;
@@ -127,10 +131,8 @@ type MainSidebarProps = ThemedClassName<ComponentPropsWithRef<typeof DialogConte
   side: 'inline-start' | 'inline-end';
 };
 
-const handleOpenAutoFocus = (e: Event) => {
-  !document.body.hasAttribute('data-is-keyboard') && e.preventDefault();
-};
-
+// TODO(burdon): Factor out Sidebar?
+// TODO(burdon): Style left/right sidebar differently.
 const MainSidebar = forwardRef<HTMLDivElement, MainSidebarProps>(
   ({ classNames, children, swipeToDismiss, onOpenAutoFocus, open, setOpen, side, ...props }, forwardedRef) => {
     const [isLg] = useMediaQuery('lg', { ssr: false });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1343,6 +1343,7 @@ importers:
       '@dxos/aurora': workspace:*
       '@dxos/aurora-theme': workspace:*
       '@dxos/debug': workspace:*
+      '@dxos/local-storage': workspace:*
       '@dxos/react-surface': workspace:*
       '@phosphor-icons/react': ^2.0.5
       '@types/react': ^18.0.21
@@ -1353,6 +1354,7 @@ importers:
       vite: ^4.3.9
     dependencies:
       '@dxos/debug': link:../../../common/debug
+      '@dxos/local-storage': link:../../../common/local-storage
       deepsignal: 1.3.4_react@18.2.0
     devDependencies:
       '@braneframe/plugin-graph': link:../plugin-graph


### PR DESCRIPTION
- [x] Threads in sidebar.
- [x] Styles for complementary sidebar (different width).
- [x] Persistent properties.

<img width="1728" alt="Screenshot 2023-09-02 at 4 35 38 PM" src="https://github.com/dxos/dxos/assets/3523355/bee4f8c9-52fd-4762-b74e-50988b82c418">



<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 479ab3b</samp>

### Summary
🛠️💾🎨

<!--
1.  🛠️ - This emoji represents the refactoring and improvement of the code and the components, as well as the removal of unnecessary or unused code and dependencies.
2.  💾 - This emoji represents the use of local storage as the state store for the split view feature, and the addition of a dependency on the `@dxos/local-storage` package.
3.  🎨 - This emoji represents the changes in the user interface and the styling of the components, such as the rounded input container, the sidebar accessibility, and the layout of the thread plugin.
-->
Refactored several plugins and components to use a local storage store for managing the split view state and other settings, and to improve the UI and code quality. Extracted common styles and functions into modules. Removed unused or unnecessary imports, parameters, and dependencies.

> _Oh, we're the crew of the `SplitViewPlugin`_
> _And we work with local storage all day_
> _We refactor and improve the code we write_
> _And we make the UI look nice and bright_

### Walkthrough
*  Removed `enableComplementarySidebar` option from `SplitViewPlugin` configuration and used local storage store to manage split view state ([link](https://github.com/dxos/dxos/pull/4104/files?diff=unified&w=0#diff-9d663519e7a46a19fe4305c8085aa017f51355119fb0fbe545eb37ab8492722cL72-R72), [link](https://github.com/dxos/dxos/pull/4104/files?diff=unified&w=0#diff-7ad9be5adb3c67069c1985ba4f8cc9bfd38cfae726a52c14dd88f464a75e3707L14-R21), [link](https://github.com/dxos/dxos/pull/4104/files?diff=unified&w=0#diff-7ad9be5adb3c67069c1985ba4f8cc9bfd38cfae726a52c14dd88f464a75e3707L37-R40), [link](https://github.com/dxos/dxos/pull/4104/files?diff=unified&w=0#diff-7ad9be5adb3c67069c1985ba4f8cc9bfd38cfae726a52c14dd88f464a75e3707L64-R65), [link](https://github.com/dxos/dxos/pull/4104/files?diff=unified&w=0#diff-7ad9be5adb3c67069c1985ba4f8cc9bfd38cfae726a52c14dd88f464a75e3707L70-R71), [link](https://github.com/dxos/dxos/pull/4104/files?diff=unified&w=0#diff-a6323478ad3792664ebc285bb24026d9c0ff0bd484abae56596e57a0cc364601R19), [link](https://github.com/dxos/dxos/pull/4104/files?diff=unified&w=0#diff-7ad9be5adb3c67069c1985ba4f8cc9bfd38cfae726a52c14dd88f464a75e3707L6-R8), [link](https://github.com/dxos/dxos/pull/4104/files?diff=unified&w=0#diff-e4c4de16a46eab1c092579827264d1296ad0ae533f41b0b1a5cd8d5e64e640c5L5-L6), [link](https://github.com/dxos/dxos/pull/4104/files?diff=unified&w=0#diff-e4c4de16a46eab1c092579827264d1296ad0ae533f41b0b1a5cd8d5e64e640c5L18-R29), [link](https://github.com/dxos/dxos/pull/4104/files?diff=unified&w=0#diff-0e8499a187f74ca92f8cf08199897a2a71656229e61dc119edb12637ae768322R27-R29), [link](https://github.com/dxos/dxos/pull/4104/files?diff=unified&w=0#diff-fe01b6a7f487804ef4ffb91b14bbae55cd195ad142ec1fe023883ee31b00628eL9-R14), [link](https://github.com/dxos/dxos/pull/4104/files?diff=unified&w=0#diff-13d5e3ca1996933a243d08b89d6400b405f3f9365d855c9b9ad92536e591869dL10-R10), [link](https://github.com/dxos/dxos/pull/4104/files?diff=unified&w=0#diff-13d5e3ca1996933a243d08b89d6400b405f3f9365d855c9b9ad92536e591869dL17-R21), [link](https://github.com/dxos/dxos/pull/4104/files?diff=unified&w=0#diff-13d5e3ca1996933a243d08b89d6400b405f3f9365d855c9b9ad92536e591869dL33-R35), [link](https://github.com/dxos/dxos/pull/4104/files?diff=unified&w=0#diff-13d5e3ca1996933a243d08b89d6400b405f3f9365d855c9b9ad92536e591869dL47-R89)).


