### PR TITLE
feat(util): Add WeakDictionary

### DIFF
--- a/packages/common/util/src/index.ts
+++ b/packages/common/util/src/index.ts
@@ -23,3 +23,4 @@ export * from './types';
 export * from './uint8array';
 export * from './instance-id';
 export * from './sum';
+export * from './weak';

--- a/packages/common/util/src/tracer.test.ts
+++ b/packages/common/util/src/tracer.test.ts
@@ -58,7 +58,7 @@ describe('Tracer', () => {
     expect(events).to.have.length(n / objectIds.length);
   });
 
-  test.only('numerical values', async () => {
+  test('numerical values', async () => {
     const tracer = new Tracer().start();
     const key = 'test';
 

--- a/packages/common/util/src/weak.test.ts
+++ b/packages/common/util/src/weak.test.ts
@@ -1,0 +1,39 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { expect } from 'chai';
+import waitForExpect from 'wait-for-expect';
+
+import { test, describe } from '@dxos/test';
+
+import { WeakDictionary } from './weak';
+
+describe.only('WeakDictionary', () => {
+  test('unref item gets garbage collected', async () => {
+    const map = new WeakDictionary<string, any>();
+    const key = 'key';
+
+    {
+      const value = { test: 'test' };
+      map.set(key, value);
+      expect(map.get(key)).to.equal(value);
+      expect(map.size).to.equal(1);
+      expect(map.has(key)).to.equal(true);
+      expect([...map.keys()]).to.deep.equal([key]);
+      expect([...map.values()]).to.deep.equal([value]);
+
+      for (const [k, v] of map) {
+        expect(k).to.equal(key);
+        expect(v).to.equal(value);
+      }
+    }
+
+    // Garbage collection should remove the item because no references exist.
+    await waitForExpect(() => {
+      expect(map.size).to.equal(0);
+    }, 1000);
+
+    expect(map.has(key)).to.equal(false);
+  });
+});

--- a/packages/common/util/src/weak.test.ts
+++ b/packages/common/util/src/weak.test.ts
@@ -9,31 +9,35 @@ import { test, describe } from '@dxos/test';
 
 import { WeakDictionary } from './weak';
 
-describe.only('WeakDictionary', () => {
-  test('unref item gets garbage collected', async () => {
-    const map = new WeakDictionary<string, any>();
-    const key = 'key';
+describe('WeakDictionary', () => {
+  // Skipped because it takes a long time for garbage collection to kick in. But it works otherwise.
+  test
+    .skip('unref item gets garbage collected', async () => {
+      const map = new WeakDictionary<string, any>();
+      const key = 'key';
 
-    {
-      const value = { test: 'test' };
-      map.set(key, value);
-      expect(map.get(key)).to.equal(value);
-      expect(map.size).to.equal(1);
-      expect(map.has(key)).to.equal(true);
-      expect([...map.keys()]).to.deep.equal([key]);
-      expect([...map.values()]).to.deep.equal([value]);
+      const setValue = () => {
+        const value = { test: 'test' };
+        map.set(key, value);
+        expect(map.get(key)).to.equal(value);
+        expect(map.size).to.equal(1);
+        expect(map.has(key)).to.equal(true);
+        expect([...map.keys()]).to.deep.equal([key]);
+        expect([...map.values()]).to.deep.equal([value]);
 
-      for (const [k, v] of map) {
-        expect(k).to.equal(key);
-        expect(v).to.equal(value);
-      }
-    }
+        for (const [k, v] of map) {
+          expect(k).to.equal(key);
+          expect(v).to.equal(value);
+        }
+      };
 
-    // Garbage collection should remove the item because no references exist.
-    await waitForExpect(() => {
-      expect(map.size).to.equal(0);
-    }, 1000);
+      setValue();
+      // Garbage collection should remove the item because no references exist.
+      await waitForExpect(() => {
+        expect(map.size).to.equal(0);
+      }, 100000);
 
-    expect(map.has(key)).to.equal(false);
-  });
+      expect(map.has(key)).to.equal(false);
+    })
+    .timeout(100000);
 });

--- a/packages/common/util/src/weak.test.ts
+++ b/packages/common/util/src/weak.test.ts
@@ -10,7 +10,8 @@ import { test, describe } from '@dxos/test';
 import { WeakDictionary } from './weak';
 
 describe('WeakDictionary', () => {
-  // Skipped because it takes a long time for garbage collection to kick in. But it works otherwise.
+  // Skipped because it takes a long time for garbage collection to kick in (~8 sec)
+  // but it works otherwise.
   test
     .skip('unref item gets garbage collected', async () => {
       const map = new WeakDictionary<string, any>();
@@ -35,9 +36,9 @@ describe('WeakDictionary', () => {
       // Garbage collection should remove the item because no references exist.
       await waitForExpect(() => {
         expect(map.size).to.equal(0);
-      }, 100000);
+      }, 20000);
 
       expect(map.has(key)).to.equal(false);
     })
-    .timeout(100000);
+    .timeout(20000);
 });

--- a/packages/common/util/src/weak.ts
+++ b/packages/common/util/src/weak.ts
@@ -1,0 +1,108 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+/**
+ * Weak dictionary. It is a map that holds weak references to its values and allows garbage collection of values and keys.
+ */
+export class WeakDictionary<K, V extends object> implements Map<K, V> {
+  private readonly _internal = new Map<K, WeakRef<V>>();
+  private readonly _finalization = new FinalizationRegistry((cleanUpCallback: () => void) => {
+    cleanUpCallback();
+  });
+
+  constructor(entries?: [K, V][]) {
+    this._internal = new Map(entries?.map(([key, value]) => [key, new WeakRef(value)]));
+    entries?.forEach(([key, value]) => this._register(key, value));
+  }
+
+  *entries(): IterableIterator<[K, V]> {
+    for (const [key, value] of this._internal) {
+      yield [key, value.deref()!];
+    }
+  }
+
+  keys(): IterableIterator<K> {
+    return this._internal.keys();
+  }
+
+  *values(): IterableIterator<V> {
+    for (const value of this._internal.values()) {
+      yield value.deref()!;
+    }
+  }
+
+  *[Symbol.iterator](): IterableIterator<[K, V]> {
+    for (const [key, value] of this._internal) {
+      yield [key, value.deref()!];
+    }
+  }
+
+  get [Symbol.toStringTag](): string {
+    return 'WeakDictionary';
+  }
+
+  get size(): number {
+    return this._internal.size;
+  }
+
+  get(key: K): V | undefined {
+    return this._internal.get(key)?.deref();
+  }
+
+  set(key: K, value: V): this {
+    this._internal.set(key, new WeakRef(value));
+    this._register(key, value);
+    return this;
+  }
+
+  has(key: K): boolean {
+    return this._internal.has(key) && this._internal.get(key)!.deref() !== undefined;
+  }
+
+  delete(key: K): boolean {
+    const value = this._internal.get(key)?.deref();
+    if (value) {
+      this._unregister(value);
+    }
+    return this._internal.delete(key);
+  }
+
+  clear(): void {
+    this._internal.forEach((value) => {
+      const v = value.deref();
+      if (v) {
+        this._unregister(v);
+      }
+    });
+
+    this._internal.clear();
+  }
+
+  forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any): void {
+    if (thisArg) {
+      callbackfn = callbackfn.bind(thisArg);
+    }
+
+    this._internal.forEach((value, key) => {
+      const v = value.deref();
+      if (v) {
+        callbackfn(v, key, this);
+      }
+    });
+  }
+
+  private _register(key: K, value: V) {
+    this._finalization.register(
+      value,
+      () => {
+        this._internal.delete(key);
+      },
+      value,
+    );
+  }
+
+  private _unregister(value: V) {
+    this._finalization.unregister(value);
+  }
+}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f5f0faa</samp>

### Summary
📦🐛✅

<!--
1.  📦 for exporting the `weak` module from the `@dxos/util` package.
2.  🐛 for fixing the `.only` modifier in the `tracer.test.ts` file.
3.  ✅ for adding a new test file `weak.test.ts` for the `WeakDictionary` class.
-->
This pull request introduces a new `WeakDictionary` class in the `@dxos/util` package, which is used to refactor the `EchoDatabase` class in the `@dxos/echo-schema` package. The `WeakDictionary` class is a map that holds weak references to its values and allows garbage collection of values and keys. The pull request also adds tests for the new class and fixes a minor issue in the `tracer.test.ts` file.

> _We're sailing on the digital sea, with `WeakDictionary` in our hold_
> _We've cleared the code of memory leaks, and made it strong and bold_
> _Heave away, me hearties, heave away with glee_
> _We've refactored `EchoDatabase` on the count of three_

### Walkthrough
*  Export `weak` module from `@dxos/util` package ([link](https://github.com/dxos/dxos/pull/4109/files?diff=unified&w=0#diff-734266ae5d53345b869d7517ea2cc7eea92ee577b49360b36c1cb669ee6cfef9R26))
*  Add `WeakDictionary` class to `weak` module, which is a map that holds weak references to its values and allows garbage collection of values and keys ([link](https://github.com/dxos/dxos/pull/4109/files?diff=unified&w=0#diff-08cb35597008b125e3c5a4b1504e85894a623cea528c6d3e91b7ef80bf351681R1-R108))
*  Add tests for `WeakDictionary` class in `weak.test.ts` file, which test its behavior with garbage collection and weak references ([link](https://github.com/dxos/dxos/pull/4109/files?diff=unified&w=0#diff-295e234c995986d68f69e03a6075afc23efa940d020f86cfc6474e026d5bb924R1-R44))
*  Replace `Map` with `WeakDictionary` for `_removed` property of `EchoDatabase` class in `database.ts` file, which simplifies the logic of handling removed objects ([link](https://github.com/dxos/dxos/pull/4109/files?diff=unified&w=0#diff-86b6148b95be2f77ac6eff05a19c3bf6926da19271cd10a1db4d9148ce39b9d2L29-R30), [link](https://github.com/dxos/dxos/pull/4109/files?diff=unified&w=0#diff-86b6148b95be2f77ac6eff05a19c3bf6926da19271cd10a1db4d9148ce39b9d2L260-L277))
*  Remove unnecessary calls to `_saveRemovedObject` and `_popRemovedObject` methods from `EchoDatabase` class, which are handled by `WeakDictionary` internally ([link](https://github.com/dxos/dxos/pull/4109/files?diff=unified&w=0#diff-86b6148b95be2f77ac6eff05a19c3bf6926da19271cd10a1db4d9148ce39b9d2L99-R97), [link](https://github.com/dxos/dxos/pull/4109/files?diff=unified&w=0#diff-86b6148b95be2f77ac6eff05a19c3bf6926da19271cd10a1db4d9148ce39b9d2L162-R160), [link](https://github.com/dxos/dxos/pull/4109/files?diff=unified&w=0#diff-86b6148b95be2f77ac6eff05a19c3bf6926da19271cd10a1db4d9148ce39b9d2L197-R196), [link](https://github.com/dxos/dxos/pull/4109/files?diff=unified&w=0#diff-86b6148b95be2f77ac6eff05a19c3bf6926da19271cd10a1db4d9148ce39b9d2L221-R220))
*  Remove `.only` modifier from `numerical values` test in `tracer.test.ts` file, which was preventing other tests from running ([link](https://github.com/dxos/dxos/pull/4109/files?diff=unified&w=0#diff-24219334abb6784266bf5c40bc213148a555515a768501f40eb7ead9b8b5a6c1L61-R61))


