### PR TITLE
fix(client): flush default space properties to cache

### DIFF
--- a/packages/apps/plugins/plugin-thread/src/components/ThreadChannel.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadChannel.tsx
@@ -74,7 +74,8 @@ export const ThreadChannel: FC<{
         {/* TODO(burdon): Break into days. */}
         <div className='flex flex-col-reverse grow overflow-auto px-2 pt-4'>
           <div ref={bottomRef} />
-          {thread.blocks
+          {/* TODO(wittjosiah): This shouldn't ever be undefined, but it is. */}
+          {(thread.blocks ?? [])
             .map((block) => (
               <div key={block.id} className='my-1'>
                 <ThreadBlock identityKey={identityKey} block={block} getBlockProperties={getBlockProperties} />

--- a/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
@@ -384,6 +384,7 @@ export class DatabaseProxy {
     } else {
       await promise;
     }
+    await this._service.flush({ spaceKey: this._spaceKey });
   }
 
   private _abortBatches() {

--- a/packages/core/echo/echo-pipeline/src/db-host/data-service-host.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/data-service-host.ts
@@ -29,6 +29,7 @@ export class DataServiceHost {
   constructor(
     private readonly _itemManager: ItemManager,
     private readonly _itemDemuxer: ItemDemuxer,
+    private readonly _flush: () => Promise<void>,
     private readonly _writeStream?: FeedWriter<DataMessage>,
   ) {}
 
@@ -111,6 +112,10 @@ export class DataServiceHost {
     });
 
     return receipt;
+  }
+
+  async flush(): Promise<void> {
+    await this._flush();
   }
 }
 

--- a/packages/core/echo/echo-pipeline/src/db-host/data-service.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/data-service.ts
@@ -13,6 +13,7 @@ import {
   SubscribeRequest,
   EchoEvent,
   WriteRequest,
+  FlushRequest,
 } from '@dxos/protocols/proto/dxos/echo/service';
 import { ComplexMap } from '@dxos/util';
 
@@ -65,5 +66,12 @@ export class DataServiceImpl implements DataService {
     const host =
       this._subscriptions.getDataService(request.spaceKey) ?? raise(new Error(`space not found: ${request.spaceKey}`));
     return host.write(request);
+  }
+
+  flush(request: FlushRequest): Promise<void> {
+    invariant(request.spaceKey);
+    const host =
+      this._subscriptions.getDataService(request.spaceKey) ?? raise(new Error(`space not found: ${request.spaceKey}`));
+    return host.flush();
   }
 }

--- a/packages/core/echo/echo-pipeline/src/db-host/database-host.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/database-host.ts
@@ -6,6 +6,7 @@ import { EchoProcessor, ItemDemuxer, ItemManager } from '@dxos/echo-db';
 import { FeedWriter } from '@dxos/feed-store';
 import { ModelFactory } from '@dxos/model-factory';
 import { DataMessage } from '@dxos/protocols/proto/dxos/echo/feed';
+import { EchoSnapshot } from '@dxos/protocols/proto/dxos/echo/snapshot';
 
 import { DataServiceHost } from './data-service-host';
 
@@ -19,7 +20,10 @@ export class DatabaseHost {
   private _itemManager!: ItemManager;
   public _itemDemuxer!: ItemDemuxer;
 
-  constructor(private readonly _outboundStream: FeedWriter<DataMessage> | undefined) {}
+  constructor(
+    private readonly _outboundStream: FeedWriter<DataMessage> | undefined,
+    private readonly _flush: () => Promise<void>,
+  ) {}
 
   get isReadOnly(): boolean {
     return !!this._outboundStream;
@@ -43,11 +47,11 @@ export class DatabaseHost {
     return this._outboundStream;
   }
 
-  createSnapshot() {
+  createSnapshot(): EchoSnapshot {
     return this._itemDemuxer.createSnapshot();
   }
 
   createDataServiceHost() {
-    return new DataServiceHost(this._itemManager, this._itemDemuxer, this._outboundStream ?? undefined);
+    return new DataServiceHost(this._itemManager, this._itemDemuxer, this._flush, this._outboundStream ?? undefined);
   }
 }

--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -115,7 +115,7 @@ export class MetadataStore {
   }
 
   async close() {
-    await this._directory.flush();
+    await this.flush();
     await this._metadataFile?.close();
     this._metadataFile = undefined;
     this._metadata = emptyEchoMetadata();
@@ -194,7 +194,7 @@ export class MetadataStore {
     await this._writeFile(file, LargeSpaceMetadata, data);
   }
 
-  private async _flush() {
+  async flush() {
     await this._directory.flush();
   }
 
@@ -238,7 +238,7 @@ export class MetadataStore {
 
     this._metadata.identity = record;
     await this._save();
-    await this._flush();
+    await this.flush();
   }
 
   async addSpace(record: SpaceMetadata) {
@@ -249,7 +249,7 @@ export class MetadataStore {
 
     (this._metadata.spaces ??= []).push(record);
     await this._save();
-    await this._flush();
+    await this.flush();
   }
 
   async setSpaceDataLatestTimeframe(spaceKey: PublicKey, timeframe: Timeframe) {
@@ -260,7 +260,7 @@ export class MetadataStore {
   async setSpaceControlLatestTimeframe(spaceKey: PublicKey, timeframe: Timeframe) {
     this._getSpace(spaceKey).controlTimeframe = timeframe;
     await this._save();
-    await this._flush();
+    await this.flush();
   }
 
   async setCache(spaceKey: PublicKey, cache: SpaceCache) {
@@ -273,13 +273,13 @@ export class MetadataStore {
     space.controlFeedKey = controlFeedKey;
     space.dataFeedKey = dataFeedKey;
     await this._save();
-    await this._flush();
+    await this.flush();
   }
 
   async setSpaceState(spaceKey: PublicKey, state: SpaceState) {
     this._getSpace(spaceKey).state = state;
     await this._save();
-    await this._flush();
+    await this.flush();
   }
 
   getSpaceControlPipelineSnapshot(spaceKey: PublicKey): ControlPipelineSnapshot | undefined {
@@ -289,7 +289,7 @@ export class MetadataStore {
   async setSpaceControlPipelineSnapshot(spaceKey: PublicKey, snapshot: ControlPipelineSnapshot) {
     this._getLargeSpaceMetadata(spaceKey).controlPipelineSnapshot = snapshot;
     await this._saveSpaceLargeMetadata(spaceKey);
-    await this._flush();
+    await this.flush();
   }
 }
 

--- a/packages/core/echo/echo-pipeline/src/testing/database-test-rig.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/database-test-rig.ts
@@ -78,29 +78,34 @@ export class DatabaseTestPeer {
 
   async open() {
     this.hostItems = new ItemManager(this.modelFactory);
-    this.host = new DatabaseHost({
-      write: async (message, { afterWrite }: WriteOptions) => {
-        const seq =
-          this.feedMessages.push({
-            timeframe: this.timeframe,
-            payload: {
-              data: message,
-            },
-          }) - 1;
+    this.host = new DatabaseHost(
+      {
+        write: async (message, { afterWrite }: WriteOptions) => {
+          const seq =
+            this.feedMessages.push({
+              timeframe: this.timeframe,
+              payload: {
+                data: message,
+              },
+            }) - 1;
 
-        const request: WriteRequest = {
-          receipt: {
-            seq,
-            feedKey: this.key,
-          },
-          options: { afterWrite },
-          trigger: new Trigger(),
-        };
-        this._writes.add(request);
-        await request.trigger.wait();
-        return request.receipt;
+          const request: WriteRequest = {
+            receipt: {
+              seq,
+              feedKey: this.key,
+            },
+            options: { afterWrite },
+            trigger: new Trigger(),
+          };
+          this._writes.add(request);
+          await request.trigger.wait();
+          return request.receipt;
+        },
       },
-    });
+      async () => {
+        // No-op.
+      },
+    );
 
     await this.host.open(this.hostItems, this.modelFactory);
     if (this.snapshot) {

--- a/packages/core/echo/echo-pipeline/src/testing/util.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/util.ts
@@ -16,7 +16,9 @@ import { DataPipeline } from '../space';
 
 export const createMemoryDatabase = async (modelFactory: ModelFactory) => {
   const feed = new MockFeedWriter<DataMessage>();
-  const backend = new DatabaseHost(feed);
+  const backend = new DatabaseHost(feed, async () => {
+    // No-op.
+  });
 
   feed.written.on(([data, meta]) =>
     backend.echoProcessor({

--- a/packages/core/echo/echo-pipeline/src/tests/database.test.ts
+++ b/packages/core/echo/echo-pipeline/src/tests/database.test.ts
@@ -35,7 +35,9 @@ const createDatabaseWithFeeds = async () => {
   const feed = await feedStore.openFeed(await feedTestBuilder.keyring.createKey(), { writable: true });
 
   const writer = createMappedFeedWriter((data: DataMessage) => ({ data }), feed.createFeedWriter());
-  const host = new DatabaseHost(writer);
+  const host = new DatabaseHost(writer, async () => {
+    /* No-op. */
+  });
   await host.open(new ItemManager(modelFactory), new ModelFactory().registerModel(DocumentModel));
 
   const dataServiceSubscriptions = new DataServiceSubscriptions();

--- a/packages/core/protocols/src/proto/dxos/echo/service.proto
+++ b/packages/core/protocols/src/proto/dxos/echo/service.proto
@@ -46,7 +46,12 @@ message MutationReceipt {
   int32 seq = 2;
 }
 
+message FlushRequest {
+  dxos.keys.PublicKey space_key = 1;
+}
+
 service DataService {
   rpc Subscribe(SubscribeRequest) returns (stream EchoEvent);
   rpc Write(WriteRequest) returns (MutationReceipt); // TODO(burdon): Rename SubmitMutation.
+  rpc Flush(FlushRequest) returns (google.protobuf.Empty);
 }

--- a/packages/sdk/client/src/client/client.ts
+++ b/packages/sdk/client/src/client/client.ts
@@ -242,6 +242,8 @@ export class Client {
     const handleIdentityCreated = async ({ identityKey }: Identity) => {
       const defaultSpace = await this.createSpace();
       defaultSpace.properties[defaultKey] = identityKey.toHex();
+      // Ensure space properties are cached.
+      await defaultSpace.db.flush();
     };
 
     const modelFactory = this._options.modelFactory ?? createDefaultModelFactory();

--- a/packages/sdk/client/src/client/client.ts
+++ b/packages/sdk/client/src/client/client.ts
@@ -30,7 +30,7 @@ import {
 } from '@dxos/protocols/proto/dxos/client/services';
 import { isNode, jsonKeyReplacer, JsonKeyOptions, MaybePromise } from '@dxos/util';
 
-import type { EchoProxy } from '../echo';
+import { defaultKey, type EchoProxy } from '../echo';
 import type { HaloProxy, Identity } from '../halo';
 import type { MeshProxy } from '../mesh';
 import type { PropertiesProps } from '../proto';
@@ -185,6 +185,11 @@ export class Client {
    * If no key is specified the default space is returned.
    */
   getSpace(spaceKey?: PublicKey): Space | undefined {
+    if (!spaceKey) {
+      const identityKey = this.halo.identity.get()?.identityKey.toHex();
+      return this.spaces.get().find((space) => space.properties[defaultKey] === identityKey);
+    }
+
     return this._echo.getSpace(spaceKey);
   }
 
@@ -302,7 +307,6 @@ export class Client {
     }
 
     await this._runtime!.close();
-
     this._statusTimeout && clearTimeout(this._statusTimeout);
     await this._statusStream!.close();
     await this.services.close(new Context());

--- a/packages/sdk/client/src/echo/echo-proxy.ts
+++ b/packages/sdk/client/src/echo/echo-proxy.ts
@@ -187,14 +187,8 @@ export class EchoProxy implements Echo {
 
   /**
    * Returns an individual space by its key.
-   *
-   * If no key is specified the default space is returned.
    */
-  getSpace(spaceKey?: PublicKey): Space | undefined {
-    if (!spaceKey) {
-      return this.spaces.get().find((space) => space.properties[defaultKey]);
-    }
-
+  getSpace(spaceKey: PublicKey): Space | undefined {
     return this._spaces.get().find(({ key }) => key.equals(spaceKey));
   }
 


### PR DESCRIPTION
Fixes issue in composer where the default space is present when the app first loads, but disappears if refreshed.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4dcb549</samp>

### Summary

No summary available (Limit exceeded: required to process 84597 tokens, but only 50000 are allowed per call)



### Walkthrough
No walkthrough available (Limit exceeded: required to process 84597 tokens, but only 50000 are allowed per call)


