### PR TITLE
fix: new connection state to differentiate between connections waiting for limiter vs waiting on offer

### DIFF
--- a/packages/core/mesh/network-manager/src/connection-log.ts
+++ b/packages/core/mesh/network-manager/src/connection-log.ts
@@ -50,7 +50,7 @@ export class ConnectionLog {
 
     swarm.connectionAdded.on((connection) => {
       const connectionInfo: ConnectionInfo = {
-        state: ConnectionState.INITIAL,
+        state: ConnectionState.CREATED,
         closeReason: connection.closeReason,
         remotePeerId: connection.remoteId,
         sessionId: connection.sessionId,

--- a/packages/core/mesh/network-manager/src/swarm/connection.test.ts
+++ b/packages/core/mesh/network-manager/src/swarm/connection.test.ts
@@ -63,8 +63,11 @@ describe('Connection', () => {
       createSimplePeerTransportFactory(),
     );
 
+    connection2.initiate();
     await connection2.openConnection();
     await sleep(100);
+
+    connection1.initiate();
     await connection1.openConnection();
     await Promise.all([
       protocol1.testConnection(peerId2, 'test message 1'),

--- a/packages/core/mesh/network-manager/src/swarm/peer.ts
+++ b/packages/core/mesh/network-manager/src/swarm/peer.ts
@@ -139,6 +139,8 @@ export class Peer {
 
         try {
           await this._connectionLimiter.connecting(message.sessionId);
+          connection.initiate();
+
           await connection.openConnection();
         } catch (err: any) {
           if (!(err instanceof CancelledError)) {
@@ -169,6 +171,7 @@ export class Peer {
 
     try {
       await this._connectionLimiter.connecting(sessionId);
+      connection.initiate();
 
       const answer = await this._signalMessaging.offer({
         author: this.localPeerId,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9a10be7</samp>

### Summary
🆕🛠️🧪

<!--
1.  🆕 for the new state and method added to the `Connection` class.
2.  🛠️ for the updates to the `ConnectionLog` and `Peer` classes to use the new method and state.
3.  🧪 for the updates to the `connection.test.ts` file to reflect the changes in the production code.
-->
The pull request introduces a new state and a new method for the `Connection` class, to improve the connection limiter and the alignment of incoming and outgoing connections. It also updates the `ConnectionLog` class and the `connection.test.ts` file to use the new state and method.

> _`Connection` state_
> _New method to initiate_
> _Winter of signals_

### Walkthrough
*  Introduce a new `ConnectionState.CREATED` state for connections that are created but not yet opened ([link](https://github.com/dxos/dxos/pull/4129/files?diff=unified&w=0#diff-722d9fe75c055645087e90a3586cbeba7bf109256b4789aecdcff96a937ff2fbL53-R53), [link](https://github.com/dxos/dxos/pull/4129/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745R47-R51), [link](https://github.com/dxos/dxos/pull/4129/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745L80-R85)).


