### PR TITLE
feat: Devtools swarm panel

### DIFF
--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/SpaceInfoPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/SpaceInfoPanel.tsx
@@ -73,10 +73,6 @@ export const SpaceInfoPanel: FC = () => {
     }
   };
 
-  if (!space || !metadata) {
-    return null;
-  }
-
   return (
     <PanelContainer
       toolbar={

--- a/packages/devtools/devtools/src/panels/mesh/SwarmPanel/ConnectionInfoView.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SwarmPanel/ConnectionInfoView.tsx
@@ -43,7 +43,7 @@ export const ConnectionInfoView: FC<{ connection?: ConnectionInfo }> = ({ connec
         }}
       />
 
-      <Grid<ConnectionInfo.StreamStats> columns={columns} data={connection.streams ?? []} />
+      <Grid<ConnectionInfo.StreamStats> columns={columns} data={connection.streams ?? []} keyAccessor={row => row.id.toString()} />
     </>
   );
 };

--- a/packages/ui/aurora-grid/src/Grid.tsx
+++ b/packages/ui/aurora-grid/src/Grid.tsx
@@ -19,7 +19,6 @@ import {
 import React, { Fragment, useEffect, useRef, useState } from 'react';
 
 import { inputSurface, mx } from '@dxos/aurora-theme';
-import { invariant } from '@dxos/invariant';
 
 import { defaultGridSlots, GridSlots } from './theme';
 import { GridColumnDef, KeyValue } from './types';
@@ -98,7 +97,6 @@ export type GridProps<TData extends RowData> = {
 // TODO(burdon): Rename Table.
 export const Grid = <TData extends RowData>({ slots = defaultGridSlots, ...props }: GridProps<TData>) => {
   const {
-    keyAccessor,
     data = [],
     columns = [],
     onColumnResize,

--- a/packages/ui/aurora-grid/src/Grid.tsx
+++ b/packages/ui/aurora-grid/src/Grid.tsx
@@ -112,7 +112,6 @@ export const Grid = <TData extends RowData>({ slots = defaultGridSlots, ...props
     pinToBottom,
     debug,
   } = props;
-  invariant(keyAccessor);
 
   // Update controlled selection.
   // https://tanstack.com/table/v8/docs/api/features/row-selection


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e67bf31</samp>

### Summary
🚫🔑📊

<!--
1.  🚫 - This emoji represents the removal of the early return condition from the `SpaceInfoPanel` component, which could also imply a negative or prohibitive action.
2. 🔑 - This emoji represents the addition of the `keyAccessor` prop to the `Grid` component, which could also imply a concept of identity, access, or uniqueness.
3. 📊 - This emoji represents the enhancement of the `SwarmPanel` and the `SpaceInfoPanel` components to show more information and statistics, which could also imply a concept of data, analysis, or visualization.
-->
This pull request improves the `devtools` package by enhancing the `SwarmPanel` and the `SpaceInfoPanel` components to display more swarm and stream data, and refactors the `Grid` component to make the `keyAccessor` prop optional. It also extracts a reusable `PanelContainer` component and adds some imports and types.

> _Sing, O Muse, of the mighty pull request_
> _That enhanced the `SwarmPanel` and the `SpaceInfoPanel`_
> _And showed the glorious deeds of the swarm connections and streams_
> _With icons, colors, grouping, and sorting, like the stars in the sky._

### Walkthrough
*  Remove early return condition from `SpaceInfoPanel` component to render loading or empty state when space or metadata is not available ([link](https://github.com/dxos/dxos/pull/4144/files?diff=unified&w=0#diff-60ea151f0a407444efd5d4b1a9125a7c08b9e7abb5aafad0639bd49b39236d19L76-L79)).


