### PR TITLE
fix: drop only connections that are being initiated

### DIFF
--- a/packages/core/mesh/network-manager/src/swarm/peer.ts
+++ b/packages/core/mesh/network-manager/src/swarm/peer.ts
@@ -109,7 +109,7 @@ export class Peer {
     const remoteId = message.author;
 
     // Check if we are already trying to connect to that peer.
-    if (this.connection || this.initiating) {
+    if (this.connection && this.initiating) {
       // Peer with the highest Id closes its connection, and accepts remote peer's offer.
       if (remoteId.toHex() < this.localPeerId.toHex()) {
         // TODO(burdon): Too verbose.


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8996d96</samp>

### Summary
🐛🔄🌐

<!--
1.  🐛 - This emoji represents a bug fix, since the change was made to resolve a bug that caused peers to disconnect randomly.
2.  🔄 - This emoji represents a change in logic or behavior, since the change altered the condition for closing and accepting a connection, which affects how the peer-to-peer communication works.
3.  🌐 - This emoji represents a change related to networking, since the change involves the peer-to-peer connection and the mesh network.
-->
Fixed a bug that caused peers to disconnect randomly by changing the condition for closing the existing connection in `peer.ts`. This ensures that the connection is only closed when the peer is initiating the offer, not when receiving it.

> _`Peer` connection fix_
> _No more random disconnects_
> _Winter bug is gone_

### Walkthrough
* Fix a bug that causes peers to disconnect randomly by changing the condition for closing the existing connection and accepting the remote offer ([link](https://github.com/dxos/dxos/pull/4145/files?diff=unified&w=0#diff-47bc81126b7b4f9732f7ae901368cd7eeada3d95eb37e7e693e1a1b3388be355L112-R112)). This change affects the `Peer` class in the file `peer.ts`, which handles the peer-to-peer connection logic in the mesh network.


