### PR TITLE
ci: temp change of release account

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Setup Git
         run: |
-          git config user.name "dxos-bot"
-          git config user.email "bot@dxos.org"
+          git config user.name "wittjosiah"
+          git config user.email "josiah@braneframe.com"
 
       - name: Install system dependencies
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e72b456</samp>

### Summary
:bust_in_silhouette::email::wrench:

<!--
1.  :bust_in_silhouette: - This emoji can be used to indicate a change in user name or identity, as it shows a generic human silhouette.
2.  :email: - This emoji can be used to indicate a change in email address or communication, as it shows an envelope with a letter inside.
3.  :wrench: - This emoji can be used to indicate a change in configuration or settings, as it shows a wrench that is often used for adjusting or fixing things.
-->
Updated Git user name and email in `.github/workflows/release-please.yml` to use the pull request author's credentials. This avoids potential issues with the dxos-bot account.

> _`dxos-bot` steps back_
> _User name and email match_
> _Autumn of clarity_

### Walkthrough
* Change the user name and email for Git in the release-please workflow to match the author of the pull request ([link](https://github.com/dxos/dxos/pull/4146/files?diff=unified&w=0#diff-2c84033033d49186c63e6adcd705f63b11ae6814cd76c152c9c486d389fbccf3L38-R39)). This avoids conflicts or confusion with the dxos-bot account that is used for automated tasks.


