### PR TITLE
chore: revert npmrc change

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,4 +4,3 @@ auto-install-peers=false
 # https://github.com/storybookjs/storybook/issues/13428
 # https://github.com/storybookjs/builder-vite/issues/55
 public-hoist-pattern[]=*storybook*
-prefer-workspace-packages=true


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cb75d32</samp>

### Summary
🗑️🛠️🧶

<!--
1.  🗑️ - This emoji represents the removal or deletion of something, in this case the `prefer-workspace-packages` option.
2.  🛠️ - This emoji represents the fixing or repairing of something, in this case the installation of dependencies and the resolution of packages.
3.  🧶 - This emoji represents the use of yarn as the package manager and the tool for managing the workspaces.
-->
Remove `prefer-workspace-packages` option from `.npmrc` to fix dependency issues in monorepo.

> _`prefer-workspace-packages`_
> _gone from `.npmrc` file_
> _monorepo happy_

### Walkthrough
* Remove `prefer-workspace-packages` option from `.npmrc` to fix dependency issues in monorepo ([link](https://github.com/dxos/dxos/pull/4148/files?diff=unified&w=0#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deR7-R5))


