### PR TITLE
refactor(plugin-space): rename on enter

### DIFF
--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -16,7 +16,7 @@ import { AppState } from '@braneframe/types';
 import { EventSubscriptions } from '@dxos/async';
 import { subscribe } from '@dxos/echo-schema';
 import { IFrameClientServicesHost, IFrameClientServicesProxy, PublicKey, ShellLayout } from '@dxos/react-client';
-import { Properties, Space, SpaceProxy } from '@dxos/react-client/echo';
+import { Space, SpaceProxy } from '@dxos/react-client/echo';
 import { PluginDefinition, findPlugin } from '@dxos/react-surface';
 
 import { backupSpace } from './backup';
@@ -37,7 +37,6 @@ import { getSpaceId, isSpace, spaceToGraphNode } from './util';
 // TODO(wittjosiah): This ensures that typed objects are not proxied by deepsignal. Remove.
 // https://github.com/luisherranz/deepsignal/issues/36
 (globalThis as any)[SpaceProxy.name] = SpaceProxy;
-(globalThis as any)[Properties.name] = Properties;
 
 export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
   const state = deepSignal<SpaceState>({ active: undefined });
@@ -197,31 +196,21 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
             },
           });
 
-          let prev: Space[] = [];
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
             subscriptions.clear();
             const indices = getIndices(spaces.length);
             spaces.forEach((space, index) => {
               const update = () => {
                 const isDefaultSpace = defaultSpace && defaultSpace.key.equals(space.key);
-                console.log('update', space.key.truncate());
                 isDefaultSpace
                   ? spaceToGraphNode(space, parent, treeViewPlugin?.provides.treeView?.appState)
                   : spaceToGraphNode(space, groupNode, treeViewPlugin?.provides.treeView?.appState, indices[index]);
               };
 
-              // if (!prev.some((s) => s.key.equals(space.key))) {
-              console.log('sub', {
-                key: space.key.truncate(),
-                state: space.state.get(),
-                properties: space.properties,
-              });
               const unsubscribe = space.properties[subscribe](() => update());
               subscriptions.add(unsubscribe);
               update();
             });
-            console.log('prev', prev.length, spaces.length);
-            prev = [...spaces];
           });
 
           groupNode.addAction(

--- a/packages/apps/plugins/plugin-space/src/components/PopoverRenameSpace.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/PopoverRenameSpace.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 
 import { Button, Input, Popover, useTranslation } from '@dxos/aurora';
 import { Space } from '@dxos/react-client/echo';
@@ -11,6 +11,13 @@ import { SPACE_PLUGIN } from '../types';
 
 export const PopoverRenameSpace = ({ data: [_, space] }: { data: [string, Space] }) => {
   const { t } = useTranslation(SPACE_PLUGIN);
+  const doneButton = useRef<HTMLButtonElement>(null);
+  const [name, setName] = useState(space.properties.name ?? '');
+
+  const handleDone = useCallback(() => {
+    space.properties.name = name;
+  }, [space, name]);
+
   // todo(thure): Why does the input value need to be uncontrolled to work?
   return (
     <div role='none' className='p-1 flex gap-2'>
@@ -20,12 +27,15 @@ export const PopoverRenameSpace = ({ data: [_, space] }: { data: [string, Space]
           <Input.TextInput
             defaultValue={space.properties.name ?? ''}
             placeholder={t('untitled space title')}
-            onChange={({ target: { value } }) => (space.properties.name = value)}
+            onChange={({ target: { value } }) => setName(value)}
+            onKeyDown={({ key }) => key === 'Enter' && doneButton.current?.click()}
           />
         </Input.Root>
       </div>
       <Popover.Close asChild>
-        <Button classNames='self-stretch'>{t('done label', { ns: 'os' })}</Button>
+        <Button ref={doneButton} classNames='self-stretch' onClick={handleDone}>
+          {t('done label', { ns: 'os' })}
+        </Button>
       </Popover.Close>
     </div>
   );

--- a/packages/apps/plugins/plugin-space/src/components/PopoverRenameSpace.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/PopoverRenameSpace.tsx
@@ -28,6 +28,8 @@ export const PopoverRenameSpace = ({ data: [_, space] }: { data: [string, Space]
             defaultValue={space.properties.name ?? ''}
             placeholder={t('untitled space title')}
             onChange={({ target: { value } }) => setName(value)}
+            // TODO(wittjosiah): Ideally this should access the popover context to close the popover.
+            //   Currently this is not possible because Radix does not expose the popover context.
             onKeyDown={({ key }) => key === 'Enter' && doneButton.current?.click()}
           />
         </Input.Root>

--- a/packages/sdk/client/src/echo/space-proxy.ts
+++ b/packages/sdk/client/src/echo/space-proxy.ts
@@ -131,6 +131,7 @@ export class SpaceProxy implements Space {
     if (this._properties) {
       return this._properties;
     } else {
+      log('Using cached properties');
       return this._cachedProperties;
     }
   }

--- a/packages/sdk/client/src/echo/space-proxy.ts
+++ b/packages/sdk/client/src/echo/space-proxy.ts
@@ -269,14 +269,19 @@ export class SpaceProxy implements Space {
     this._databaseInitialized.wake();
 
     // Set properties document when it's available.
+    // NOTE: Emits state update event when properties are first available.
+    //   This is needed to ensure reactivity for newly created spaces.
+    // TODO(wittjosiah): Transfer subscriptions from cached properties to the new properties object.
     {
       const query = this._db.query(Properties.filter());
       if (query.objects.length === 1) {
         this._properties = query.objects[0];
+        this._stateUpdate.emit(this._currentState);
       } else {
         const subscription = query.subscribe((query) => {
           if (query.objects.length === 1) {
             this._properties = query.objects[0];
+            this._stateUpdate.emit(this._currentState);
             subscription();
           }
         });

--- a/packages/sdk/client/src/echo/space-proxy.ts
+++ b/packages/sdk/client/src/echo/space-proxy.ts
@@ -131,7 +131,7 @@ export class SpaceProxy implements Space {
     if (this._properties) {
       return this._properties;
     } else {
-      log('Using cached properties');
+      log('using cached properties');
       return this._cachedProperties;
     }
   }

--- a/packages/sdk/client/src/tests/spaces.test.ts
+++ b/packages/sdk/client/src/tests/spaces.test.ts
@@ -471,7 +471,7 @@ describe('Spaces', () => {
     });
   });
 
-  test('space properties are reactive', async () => {
+  test.only('space properties are reactive', async () => {
     const testBuilder = new TestBuilder();
     testBuilder.storage = createStorage({ type: StorageType.RAM });
 

--- a/packages/sdk/client/src/tests/spaces.test.ts
+++ b/packages/sdk/client/src/tests/spaces.test.ts
@@ -471,7 +471,7 @@ describe('Spaces', () => {
     });
   });
 
-  test.only('space properties are reactive', async () => {
+  test('space properties are reactive', async () => {
     const testBuilder = new TestBuilder();
     testBuilder.storage = createStorage({ type: StorageType.RAM });
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9408dcc</samp>

### Summary
🔧🔄📝

<!--
1.  🔧 - This emoji represents the refactoring of the `PopoverRenameSpace` component, which is a type of maintenance or improvement task.
2.  🔄 - This emoji represents the replacement of `createSubscription` with `subscribe`, which is a type of change or update that affects the functionality or behavior of the code.
3.  📝 - This emoji represents the improved logging and reactivity for `SpaceProxy` class, which is a type of enhancement or addition that affects the documentation or communication of the code.
-->
Refactored and improved space renaming UI, space property subscription logic, and space proxy logging and reactivity. `PopoverRenameSpace` now uses hooks and local state, `SpacePlugin` now uses `subscribe` instead of `createSubscription`, and `SpaceProxy` now emits an event and logs a message for property document availability and caching.

> _To rename a space with a click_
> _`PopoverRenameSpace` got a fix_
> _With hooks and a state_
> _And keyboard and mouse traits_
> _It's now a much smoother UX_

### Walkthrough
*  Refactor `PopoverRenameSpace` component to use hooks and handle renaming action ([link](https://github.com/dxos/dxos/pull/4151/files?diff=unified&w=0#diff-9bcdd47f0bdbafe2a8cfa2ba2e682347c8a55bb8def0d0e3026996b62cf0bcb9L5-R5),[link](https://github.com/dxos/dxos/pull/4151/files?diff=unified&w=0#diff-9bcdd47f0bdbafe2a8cfa2ba2e682347c8a55bb8def0d0e3026996b62cf0bcb9R14-R20),[link](https://github.com/dxos/dxos/pull/4151/files?diff=unified&w=0#diff-9bcdd47f0bdbafe2a8cfa2ba2e682347c8a55bb8def0d0e3026996b62cf0bcb9L23-R38)).


