### PR TITLE
ci: revert temp change of release account

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Setup Git
         run: |
-          git config user.name "wittjosiah"
-          git config user.email "josiah@braneframe.com"
+          git config user.name "dxos-bot"
+          git config user.email "bot@dxos.org"
 
       - name: Install system dependencies
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
This reverts commit 87315b3e96c1af000458d257d9c373b505bad7a2.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 80160b1</samp>

### Summary
🤖🚚🏷️

<!--
1.  🤖 - This emoji represents the dxos-bot account and the change to use its user and email for the Setup Git step.
2.  🚚 - This emoji represents the migration of the release-please workflow from the wittjosiah fork to the dxos/dxos repository.
3.  🏷️ - This emoji represents the commits and tags created by the release-please action.
-->
Updated the release-please workflow to use the dxos-bot account for creating commits and tags. This is part of migrating the workflow from the wittjosiah fork to the dxos/dxos repository.

> _`dxos-bot` commits_
> _release-please workflow moves_
> _autumn migration_

### Walkthrough
* Update the release-please workflow to use the dxos-bot user and email for Git operations ([link](https://github.com/dxos/dxos/pull/4156/files?diff=unified&w=0#diff-2c84033033d49186c63e6adcd705f63b11ae6814cd76c152c9c486d389fbccf3L38-R39)). This allows the workflow to run on the dxos/dxos repository instead of the wittjosiah fork, and ensures that the commits and tags are attributed to the dxos-bot account.


