### PR TITLE
fix: Labs DnD

### DIFF
--- a/packages/apps/plugins/plugin-chess/src/util.tsx
+++ b/packages/apps/plugins/plugin-chess/src/util.tsx
@@ -24,6 +24,7 @@ export const objectToGraphNode = (
     data: object,
     properties: {
       index: get(object, 'meta.index', index),
+      persistenceClass: 'spaceObject',
     },
   });
 

--- a/packages/apps/plugins/plugin-debug/src/DebugPlugin.tsx
+++ b/packages/apps/plugins/plugin-debug/src/DebugPlugin.tsx
@@ -88,6 +88,9 @@ export const DebugPlugin = (): PluginDefinition<DebugPluginProvides> => {
                     label: ['devtools label', { ns: DEBUG_PLUGIN }],
                     icon: (props) => <Bug {...props} />,
                     data: 'devtools',
+                    properties: {
+                      persistenceClass: 'appState',
+                    },
                   })
                 : parent.remove('devtools');
             });

--- a/packages/apps/plugins/plugin-ipfs/src/util.tsx
+++ b/packages/apps/plugins/plugin-ipfs/src/util.tsx
@@ -25,6 +25,7 @@ export const objectToGraphNode = (
     data: object,
     properties: {
       index: get(object, 'meta.index', index),
+      persistenceClass: 'spaceObject',
     },
   });
 

--- a/packages/apps/plugins/plugin-kanban/src/util.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/util.tsx
@@ -44,6 +44,7 @@ export const objectToGraphNode = (
     data: object,
     properties: {
       index: get(object, 'meta.index', index),
+      persistenceClass: 'spaceObject',
     },
   });
 

--- a/packages/apps/plugins/plugin-map/src/util.tsx
+++ b/packages/apps/plugins/plugin-map/src/util.tsx
@@ -24,6 +24,7 @@ export const objectToGraphNode = (
     data: object,
     properties: {
       index: get(object, 'meta.index', index),
+      persistenceClass: 'spaceObject',
     },
   });
 

--- a/packages/apps/plugins/plugin-sketch/src/SketchPlugin.tsx
+++ b/packages/apps/plugins/plugin-sketch/src/SketchPlugin.tsx
@@ -40,7 +40,7 @@ export const SketchPlugin = (): PluginDefinition<SketchPluginProvides> => {
             id: `${SKETCH_PLUGIN}:${space.key.toHex()}`,
             label: ['plugin name', { ns: SKETCH_PLUGIN }],
             icon: (props) => <Folder {...props} />,
-            properties: { palette: 'pink', childrenPersistenceClass: 'spaceObject' },
+            properties: { palette: 'pink', childrenPersistenceClass: 'spaceObject', persistenceClass: 'appState' },
           });
 
           presentationNode.addAction({

--- a/packages/apps/plugins/plugin-stack/src/util.tsx
+++ b/packages/apps/plugins/plugin-stack/src/util.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Article, IconProps, Trash } from '@phosphor-icons/react';
+import { IconProps, StackSimple, Trash } from '@phosphor-icons/react';
 import get from 'lodash.get';
 import React from 'react';
 
@@ -27,7 +27,7 @@ export const stackToGraphNode = (parent: Graph.Node<Space>, object: StackType, i
   const [child] = parent.add({
     id: object.id,
     label: object.title ?? ['stack title placeholder', { ns: STACK_PLUGIN }],
-    icon: (props: IconProps) => <Article {...props} />,
+    icon: (props: IconProps) => <StackSimple {...props} />,
     data: object,
     properties: {
       index: get(object, 'meta.index', index),

--- a/packages/apps/plugins/plugin-table/src/util.tsx
+++ b/packages/apps/plugins/plugin-table/src/util.tsx
@@ -25,6 +25,7 @@ export const objectToGraphNode = (
     data: object,
     properties: {
       index: get(object, 'meta.index', index),
+      persistenceClass: 'spaceObject',
     },
   });
 

--- a/packages/apps/plugins/plugin-template/src/util.tsx
+++ b/packages/apps/plugins/plugin-template/src/util.tsx
@@ -26,6 +26,7 @@ export const objectToGraphNode = (
     data: object,
     properties: {
       index: get(object, 'meta.index', index),
+      persistenceClass: 'spaceObject',
     },
   });
 

--- a/packages/apps/plugins/plugin-thread/src/util.tsx
+++ b/packages/apps/plugins/plugin-thread/src/util.tsx
@@ -25,6 +25,7 @@ export const objectToGraphNode = (
     data: object,
     properties: {
       index: get(object, 'meta.index', index),
+      persistenceClass: 'spaceObject',
     },
   });
 

--- a/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTreeItem.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTreeItem.tsx
@@ -111,6 +111,7 @@ export const NavTreeItem: ForwardRefExoticComponent<TreeViewItemProps & RefAttri
     const [open, setOpen] = useState(level < 1);
 
     const disabled = !!(node.properties?.disabled ?? node.properties?.isPreview);
+    const forceCollapse = isOverlay || isPreview || rearranging || disabled;
     const active = treeViewActive === node.id;
 
     useEffect(() => {
@@ -142,8 +143,8 @@ export const NavTreeItem: ForwardRefExoticComponent<TreeViewItemProps & RefAttri
     return (
       <TreeItem.Root
         collapsible={isBranch}
-        open={!disabled && open}
-        onOpenChange={(nextOpen) => setOpen(disabled ? false : nextOpen)}
+        open={!forceCollapse && open}
+        onOpenChange={(nextOpen) => setOpen(forceCollapse ? false : nextOpen)}
         classNames={[
           'rounded block',
           hoverableFocusedKeyboardControls,
@@ -255,7 +256,7 @@ export const NavTreeItem: ForwardRefExoticComponent<TreeViewItemProps & RefAttri
             </Tooltip.Root>
           )}
         </HeadingWithActionsRoot>
-        {isBranch && (
+        {isBranch && !forceCollapse && (
           <TreeItem.Body>
             <NavTree items={Object.values(node.children).flat() as Graph.Node[]} node={node} level={level + 1} />
           </TreeItem.Body>


### PR DESCRIPTION
This PR fixes DnD for Labs-only plugins.
Resolves #4163.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f53c93d</samp>

### Summary
🛠️🎨🌲

<!--
1.  🛠️ - This emoji represents the addition of the `persistenceClass` property to the graph node objects, which is a technical improvement that enhances the data management and synchronization of the app framework.
2.  🎨 - This emoji represents the replacement of the `Article` icon with the `StackSimple` icon, which is a cosmetic change that improves the visual appearance of the stack plugin.
3.  🌲 - This emoji represents the modification of the `NavTreeItem` component to use a `forceCollapse` variable, which is a feature change that improves the user experience and performance of the treeview plugin.
-->
This pull request adds a new property `persistenceClass` to the graph node objects created or returned by various plugins, which indicates how the app framework should handle their data synchronization and storage. It also changes the icon of the stack plugin and improves the collapsing logic of the treeview plugin.

> _Sing, O Muse, of the mighty deeds of the app framework_
> _That handles data with skill and grace across the peer network_
> _And of the plugins that adorn it with diverse and splendid features_
> _Each adding a `persistenceClass` to their graph node creatures_

### Walkthrough
*  Add `persistenceClass` property to graph node objects to indicate the type of persistence for data synchronization and storage ([link](https://github.com/dxos/dxos/pull/4162/files?diff=unified&w=0#diff-e39f5674696ac798b776beec2c8a34c7fa244c0575f655a7cf03f99cfee2a2ecR27), [link](https://github.com/dxos/dxos/pull/4162/files?diff=unified&w=0#diff-e2077d60914557ccdf5c7bb9b87f05281cf6c42e22551be99fdbf0bc34b0965dR28), [link](https://github.com/dxos/dxos/pull/4162/files?diff=unified&w=0#diff-701500038e12aee9c73300fce4841da68913c3f7a8dfbff7c339a82cd6dd6c39R47), [link](https://github.com/dxos/dxos/pull/4162/files?diff=unified&w=0#diff-fcbf57c2adf3a28c4d2a4e79210b9bffca8ed603e345566724b7e5a88fb917abR27), [link](https://github.com/dxos/dxos/pull/4162/files?diff=unified&w=0#diff-a0fc6bcd230b61af8b399796388bdd11cb82d712212ce592856cf454df60c1a9R28), [link](https://github.com/dxos/dxos/pull/4162/files?diff=unified&w=0#diff-3bdaa7cadb6148c6e9c95052b79cf20fdd53bd8d5dca3eb883bb57511d1cac12R29), [link](https://github.com/dxos/dxos/pull/4162/files?diff=unified&w=0#diff-9db0bd0de3aef8d268ba1fbdba8250dde380bd4d53d96a3a4fa2a109aaaacff3R28)). The property can have two values: 'spaceObject' for generic objects that belong to a space and can be replicated across peers, or 'appState' for specific objects that represent the state of an app and can be persisted locally or remotely.


