### PR TITLE
fix(plugin-treeview): Revert use of `ScrollArea` with draggable content (for now)

### DIFF
--- a/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
@@ -13,7 +13,6 @@ import {
   Button,
   DensityProvider,
   ElevationProvider,
-  ScrollArea,
   Tooltip,
   useJdenticonHref,
   useSidebars,
@@ -94,20 +93,15 @@ export const TreeViewContainer = () => {
               <Separator orientation='horizontal' />
             </>
           )}
-          <ScrollArea.Root classNames='grow min-bs-0'>
-            <ScrollArea.Viewport>
-              <NavTree
-                level={0}
-                role='tree'
-                classNames='pbs-1 pbe-4 pli-1'
-                node={graph.root}
-                items={graph.root.children}
-              />
-              <ScrollArea.Scrollbar orientation='vertical' classNames='pointer-events-none'>
-                <ScrollArea.Thumb />
-              </ScrollArea.Scrollbar>
-            </ScrollArea.Viewport>
-          </ScrollArea.Root>
+          <div role='none' className='grow min-bs-0 overflow-y-auto'>
+            <NavTree
+              level={0}
+              role='tree'
+              classNames='pbs-1 pbe-4 pli-1'
+              node={graph.root}
+              items={graph.root.children}
+            />
+          </div>
           <VersionInfo config={config} />
         </div>
       </DensityProvider>


### PR DESCRIPTION
Resolves #4130.

https://github.com/dxos/dxos/assets/855039/90db6aaa-50c9-476a-a3d9-214ce4261d15

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7678e62</samp>

### Summary
🚮🎨🚀

<!--
1.  🚮 - This emoji means "waste basket" or "trash can" and can be used to indicate that something was removed or deleted, such as a component or a feature.
2.  🎨 - This emoji means "artist palette" or "art" and can be used to indicate that something was improved or enhanced in terms of design, style, or appearance, such as a layout or a UI element.
3.  🚀 - This emoji means "rocket" or "launch" and can be used to indicate that something was improved or enhanced in terms of performance, speed, or efficiency, such as a component or a feature.
-->
Improved tree view layout and performance by replacing `ScrollArea` with CSS scrolling in `TreeViewContainer.tsx`.

> _`ScrollArea` gone_
> _`div` with CSS scrolls well_
> _Tree view breathes in spring_

### Walkthrough
* Remove `ScrollArea` component and use a simple `div` element with vertical scrolling instead, to simplify the layout and improve the performance of the tree view ([link](https://github.com/dxos/dxos/pull/4165/files?diff=unified&w=0#diff-5d68768eb04820eb8435d0b29071f52fe7cac46252e1527ffae2d7db10938815L16), [link](https://github.com/dxos/dxos/pull/4165/files?diff=unified&w=0#diff-5d68768eb04820eb8435d0b29071f52fe7cac46252e1527ffae2d7db10938815L97-R104))


