### PR TITLE
fix(plugin-treeview,plugin-thread): Close sidebar buttons up to `lg`

### DIFF
--- a/packages/apps/plugins/plugin-thread/src/components/ThreadChannel.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadChannel.tsx
@@ -52,7 +52,7 @@ export const ThreadChannel: FC<{
   return (
     <div
       className={mx(
-        'flex flex-col h-full w-full min-w-[300px] md:max-w-[600px] overflow-hidden m-0 lg:m-auto',
+        'grow flex flex-col w-full min-w-[300px] md:max-w-[600px] overflow-hidden m-0 md:m-auto',
         groupSurface,
       )}
     >

--- a/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
@@ -2,19 +2,21 @@
 // Copyright 2023 DXOS.org
 //
 
+import { CaretDoubleRight } from '@phosphor-icons/react';
 import differenceInSeconds from 'date-fns/differenceInSeconds';
 import React, { FC, useEffect, useState } from 'react';
 
 import { SpacePluginProvides } from '@braneframe/plugin-space';
 import { Thread as ThreadType } from '@braneframe/types';
-import { Main } from '@dxos/aurora';
-import { coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/aurora-theme';
+import { Button, Main, Tooltip, useSidebars, useTranslation } from '@dxos/aurora';
+import { coarseBlockPaddingStart, fixedInsetFlexLayout, getSize } from '@dxos/aurora-theme';
 import { generateName } from '@dxos/display-name';
 import { PublicKey } from '@dxos/react-client';
 import { Space, useMembers } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
 import { findPlugin, usePlugins } from '@dxos/react-surface';
 
+import { THREAD_PLUGIN } from '../types';
 import { ThreadChannel } from './ThreadChannel';
 
 // TODO(burdon): Goals.
@@ -119,6 +121,8 @@ export const ThreadSidebar: FC<{ data: ThreadType }> = ({ data: object }) => {
   const [thread, setThread] = useState<ThreadType | null>(object);
   const { plugins } = usePlugins();
   const spacePlugin = findPlugin<SpacePluginProvides>(plugins, 'dxos.org/plugin/space');
+  const { closeComplementarySidebar, complementarySidebarOpen } = useSidebars(THREAD_PLUGIN);
+  const { t } = useTranslation('os');
   const space = spacePlugin?.provides.space.active;
   useEffect(() => {
     if (space) {
@@ -134,5 +138,28 @@ export const ThreadSidebar: FC<{ data: ThreadType }> = ({ data: object }) => {
     return null;
   }
 
-  return <ThreadContainer space={space} thread={thread} />;
+  return (
+    <div role='none' className='flex flex-col align-start is-full bs-full'>
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          <Button
+            variant='ghost'
+            classNames='shrink-0 is-10 lg:hidden pli-2 pointer-fine:pli-1'
+            {...(!complementarySidebarOpen && { tabIndex: -1 })}
+            onClick={closeComplementarySidebar}
+          >
+            <span className='sr-only'>{t('close sidebar label')}</span>
+            <CaretDoubleRight className={getSize(4)} />
+          </Button>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content classNames='z-[70]'>
+            {t('close sidebar label', { ns: 'os' })}
+            <Tooltip.Arrow />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+      <ThreadContainer space={space} thread={thread} />
+    </div>
+  );
 };

--- a/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { GearSix } from '@phosphor-icons/react';
+import { CaretDoubleLeft, GearSix } from '@phosphor-icons/react';
 import React from 'react';
 
 import type { ClientPluginProvides } from '@braneframe/plugin-client';
@@ -84,6 +84,27 @@ export const TreeViewContainer = () => {
                     <Tooltip.Portal>
                       <Tooltip.Content classNames='z-[70]'>
                         {t('settings dialog title', { ns: 'os' })}
+                        <Tooltip.Arrow />
+                      </Tooltip.Content>
+                    </Tooltip.Portal>
+                  </Tooltip.Root>
+                  <Tooltip.Root>
+                    <Tooltip.Trigger asChild>
+                      <Button
+                        variant='ghost'
+                        classNames='lg:hidden pli-2 pointer-fine:pli-1'
+                        {...(!navigationSidebarOpen && { tabIndex: -1 })}
+                        onClick={() => {
+                          splitView.sidebarOpen = false;
+                        }}
+                      >
+                        <span className='sr-only'>{t('close sidebar label', { ns: 'os' })}</span>
+                        <CaretDoubleLeft className={getSize(4)} />
+                      </Button>
+                    </Tooltip.Trigger>
+                    <Tooltip.Portal>
+                      <Tooltip.Content classNames='z-[70]'>
+                        {t('close sidebar label', { ns: 'os' })}
                         <Tooltip.Arrow />
                       </Tooltip.Content>
                     </Tooltip.Portal>


### PR DESCRIPTION
This PR resolves #4021.

https://github.com/dxos/dxos/assets/855039/c761a772-aa10-469f-847d-e8daea5cf62a

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 16ede75</samp>

### Summary
🚀🎨🌐

<!--
1.  🚀 This emoji can be used to indicate a new feature or enhancement, such as adding a button to close the complementary sidebar or toggle the navigation sidebar.
2.  🎨 This emoji can be used to indicate an improvement to the UI or layout, such as making the thread channel component grow to fill the space or using a new icon for the button.
3.  🌐 This emoji can be used to indicate an addition or update to the localization or internationalization, such as adding labels for the buttons in different languages.
-->
Added buttons to toggle sidebars in thread and tree view plugins. These buttons improve the user experience by allowing more control over the layout and visibility of the sidebars. Used icons, tooltips, and localization from `@dxos` packages.

> _`grow` class expands_
> _thread channel with close button_
> _autumn leaves fall off_

### Walkthrough
*  Add `grow` class to thread channel component to fill available space ([link](https://github.com/dxos/dxos/pull/4166/files?diff=unified&w=0#diff-6114b143aea79d06dc8a75dae663856948a1e4e443feb9510a9c9c29315ac0bbL55-R55)).


