### PR TITLE
fix: Flush keyring file after saving the key

### DIFF
--- a/packages/common/random-access-storage/src/common/file.ts
+++ b/packages/common/random-access-storage/src/common/file.ts
@@ -31,6 +31,11 @@ export interface File extends RandomAccessStorageProperties {
   close(): Promise<Error | void>;
   destroy(): Promise<Error | void>;
 
+  /**
+   * Save changes to disk.
+   */
+  flush?(): Promise<void>;
+
   // Not supported in node, memory.
   truncate?(offset: number): Promise<void>;
 

--- a/packages/core/halo/keyring/src/keyring.ts
+++ b/packages/core/halo/keyring/src/keyring.ts
@@ -118,6 +118,7 @@ export class Keyring implements Signer {
     const file = this._storage.getOrCreateFile(publicKey.toHex());
     await file.write(0, arrayToBuffer(KeyRecord.encode(record)));
     await file.close();
+    await file.flush?.();
     this.keysUpdate.emit();
   }
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b352518</samp>

### Summary
📝💾🔒

<!--
1.  📝 - This emoji represents writing or editing data, which is what the `flush` method does.
2.  💾 - This emoji represents saving or persisting data, which is the goal of calling the `flush` method.
3.  🔒 - This emoji represents security or protection, which is the benefit of ensuring data consistency and durability.
-->
This pull request adds a `flush` method to the `File` interface and calls it after writing the keyring data. This improves the data consistency and durability of file-based storage backends.

> _`File` interface_
> _adds `flush` method for disk_
> _autumn leaves falling_

### Walkthrough
*  Add `flush` method to `File` interface to allow saving changes to disk ([link](https://github.com/dxos/dxos/pull/4169/files?diff=unified&w=0#diff-b1f5ae445af1d502015e2efca87e7512fda7ace5246832a818356da902b29095R34-R38)).


