### PR TITLE
fix(client-services): emit removal event when invitation completes

### DIFF
--- a/packages/sdk/client-services/src/packlets/invitations/invitations-service.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-service.ts
@@ -64,6 +64,7 @@ export class InvitationsServiceImpl implements InvitationsService {
         () => {
           close();
           this._createInvitations.delete(invitation.get().invitationId);
+          this._removedCreated.emit(invitation.get());
         },
       );
     });
@@ -93,6 +94,7 @@ export class InvitationsServiceImpl implements InvitationsService {
         () => {
           close();
           this._acceptInvitations.delete(invitation.get().invitationId);
+          this._removedAccepted.emit(invitation.get());
         },
       );
     });

--- a/packages/sdk/react-shell/src/components/InvitationList/InvitationListItem.tsx
+++ b/packages/sdk/react-shell/src/components/InvitationList/InvitationListItem.tsx
@@ -74,8 +74,6 @@ export const InvitationListItemImpl = ({
     Invitation.State.SUCCESS,
   ].includes(status);
 
-  console.log({ avatarError, status });
-
   return (
     <ListItem.Root id={invitationCode} classNames={['rounded p-2 flex gap-2 items-center', chromeSurface]}>
       <ListItem.Heading classNames='sr-only'>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cd7a844</samp>

### Summary
🗑️🐛📣

<!--
1.  🗑️ - This emoji represents the removal or deletion of something, such as the console log statement or the invitation. It can also convey a sense of cleaning up or tidying the code.
2.  🐛 - This emoji represents a bug or an error, such as the avatar error that was logged. It can also convey a sense of fixing or debugging something.
3.  📣 - This emoji represents an announcement or a notification, such as the events that are emitted by the invitations service. It can also convey a sense of communication or broadcasting something.
-->
This pull request improves the invitations feature by adding events for invitation removals in the `invitations-service.ts` and removing a debug log statement in the `InvitationListItem.tsx` component.

> _We're sailing on the code sea, me hearties_
> _We're fixing bugs and adding features_
> _We're removing `console.log` statements_
> _And adding events for `invitation` changes_

### Walkthrough
*  Emit events when invitations created or accepted by current user are removed ([link](https://github.com/dxos/dxos/pull/4177/files?diff=unified&w=0#diff-2a4dbb238c06bc6b25c60ddf0f5527492506263980a735eded1c7632643e4053R67), [link](https://github.com/dxos/dxos/pull/4177/files?diff=unified&w=0#diff-2a4dbb238c06bc6b25c60ddf0f5527492506263980a735eded1c7632643e4053R97))
* Remove console log statement from `InvitationListItem.tsx` ([link](https://github.com/dxos/dxos/pull/4177/files?diff=unified&w=0#diff-0fe64b41c9018e1fe72267e8ee04871dfb4c84ed9d7cbaa879c0f80e2fa7680bL77-L78))


