### PR TITLE
fix(plugin-files): move open actions to group node

### DIFF
--- a/packages/apps/plugins/plugin-files/src/FilesPlugin.tsx
+++ b/packages/apps/plugins/plugin-files/src/FilesPlugin.tsx
@@ -138,7 +138,13 @@ export const FilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, Markdo
             return;
           }
 
-          parent.addAction({
+          const [groupNode] = parent.add({
+            id: 'all-files',
+            label: ['plugin name', { ns: FILES_PLUGIN }],
+            properties: { palette: 'yellow' },
+          });
+
+          groupNode.addAction({
             id: 'open-file-handle',
             label: ['open file label', { ns: FILES_PLUGIN }],
             icon: (props) => <FilePlus {...props} />,
@@ -152,7 +158,7 @@ export const FilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, Markdo
           });
 
           if ('showDirectoryPicker' in window) {
-            parent.addAction({
+            groupNode.addAction({
               id: 'open-directory',
               label: ['open directory label', { ns: FILES_PLUGIN }],
               icon: (props) => <FolderPlus {...props} />,
@@ -165,12 +171,6 @@ export const FilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, Markdo
               ],
             });
           }
-
-          const [groupNode] = parent.add({
-            id: 'all-files',
-            label: ['plugin name', { ns: FILES_PLUGIN }],
-            properties: { palette: 'yellow' },
-          });
 
           const fileIndices = getIndices(state.files.length);
           onFilesUpdate = () => {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3f07a0c</samp>

### Summary
🛠️🎨🔌

<!--
1.  🛠️ for fixing a bug
2.  🎨 for improving the UI or design
3.  🔌 for adding or updating a plugin integration
-->
This pull request adds a new sidebar category for the files plugin and fixes a duplication bug. It modifies the `FilesPlugin.tsx` file in the `plugin-files` package.

> _`files` plugin shines_
> _yellow category in sidebar_
> _bug fixed, no more clones_

### Walkthrough
* Create a new category for the files plugin actions in the app sidebar ([link](https://github.com/dxos/dxos/pull/4179/files?diff=unified&w=0#diff-61ac1b9b8f3415a2884014ea5912948c86639725f90492d7ec4c9686b5bafaaeL141-R147))
* Move the 'open-directory' action under the 'all-files' category ([link](https://github.com/dxos/dxos/pull/4179/files?diff=unified&w=0#diff-61ac1b9b8f3415a2884014ea5912948c86639725f90492d7ec4c9686b5bafaaeL155-R161))
* Remove the redundant code that creates the 'all-files' category again ([link](https://github.com/dxos/dxos/pull/4179/files?diff=unified&w=0#diff-61ac1b9b8f3415a2884014ea5912948c86639725f90492d7ec4c9686b5bafaaeL169-L174))


