### PR TITLE
fix: multiuse invitations

### DIFF
--- a/packages/sdk/client-services/src/packlets/invitations/invitations-service.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-service.ts
@@ -64,7 +64,9 @@ export class InvitationsServiceImpl implements InvitationsService {
         () => {
           close();
           this._createInvitations.delete(invitation.get().invitationId);
-          this._removedCreated.emit(invitation.get());
+          if (invitation.get().type !== Invitation.Type.MULTIUSE) {
+            this._removedCreated.emit(invitation.get());
+          }
         },
       );
     });
@@ -94,7 +96,9 @@ export class InvitationsServiceImpl implements InvitationsService {
         () => {
           close();
           this._acceptInvitations.delete(invitation.get().invitationId);
-          this._removedAccepted.emit(invitation.get());
+          if (invitation.get().type !== Invitation.Type.MULTIUSE) {
+            this._removedAccepted.emit(invitation.get());
+          }
         },
       );
     });


### PR DESCRIPTION
don't emit removal event for completion of multiuse invitations introduced in https://github.com/dxos/dxos/pull/4177

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 17742b9</samp>

### Summary
🐛🎟️♻️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this pull request.
2.  🎟️ - This emoji represents an invitation or ticket, which is the feature that is being fixed by this pull request.
3.  ♻️ - This emoji represents recycling or reusing, which is the effect of this pull request on multiuse invitations.
-->
Fixes a bug in the `invitations-service.ts` file that prevents multiuse invitations from being reused. Updates the event handling logic for multiuse invitations to avoid removing them from the created or accepted lists.

> _We'll fix the bug in the `invitations-service.ts`_
> _We'll make the multiuse invites work as they should_
> _We'll heave away and haul away with all our might and main_
> _We'll stop the `removed` events from firing again_

### Walkthrough
*  Add conditions to check invitation type before emitting events for created and accepted invitations ([link](https://github.com/dxos/dxos/pull/4183/files?diff=unified&w=0#diff-2a4dbb238c06bc6b25c60ddf0f5527492506263980a735eded1c7632643e4053L67-R69), [link](https://github.com/dxos/dxos/pull/4183/files?diff=unified&w=0#diff-2a4dbb238c06bc6b25c60ddf0f5527492506263980a735eded1c7632643e4053L97-R101))


