### PR TITLE
fix: Memory leaks

### DIFF
--- a/packages/common/feed-store/package.json
+++ b/packages/common/feed-store/package.json
@@ -33,6 +33,7 @@
     "@dxos/random-access-storage": "workspace:*",
     "@dxos/util": "workspace:*",
     "lodash.defaultsdeep": "^4.6.1",
+    "race-as-promised": "^0.0.2",
     "random-access-storage": "^3.0.0",
     "streamx": "^2.12.5"
   },

--- a/packages/common/feed-store/src/feed-iterator.ts
+++ b/packages/common/feed-store/src/feed-iterator.ts
@@ -2,10 +2,11 @@
 // Copyright 2020 DXOS.org
 //
 
+import safeRace from 'race-as-promised';
+
 import { Trigger } from '@dxos/async';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
-import safeRace from 'race-as-promised';
 
 import { FeedQueue } from './feed-queue';
 import { FeedWrapper } from './feed-wrapper';

--- a/packages/common/feed-store/src/feed-iterator.ts
+++ b/packages/common/feed-store/src/feed-iterator.ts
@@ -5,6 +5,7 @@
 import { Trigger } from '@dxos/async';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
+import safeRace from 'race-as-promised';
 
 import { FeedQueue } from './feed-queue';
 import { FeedWrapper } from './feed-wrapper';
@@ -82,7 +83,8 @@ export abstract class AbstractFeedIterator<T> implements AsyncIterable<FeedBlock
   async *_generator() {
     log('started');
     while (this._running) {
-      const block = await Promise.race([this._stopTrigger.wait(), this._nextBlock()]);
+      // https://github.com/nodejs/node/issues/17469
+      const block = await safeRace([this._stopTrigger.wait(), this._nextBlock()]);
 
       if (block === undefined) {
         break;

--- a/packages/common/feed-store/src/feed-queue.ts
+++ b/packages/common/feed-store/src/feed-queue.ts
@@ -13,7 +13,6 @@ import { log } from '@dxos/log';
 
 import { FeedWrapper } from './feed-wrapper';
 import { FeedBlock } from './types';
-import { Context } from '@dxos/context';
 
 export const defaultReadStreamOptions: ReadStreamOptions = {
   live: true, // Keep reading until closed.
@@ -122,7 +121,7 @@ export class FeedQueue<T extends {}> {
       this._feedConsumer?.off('error', onError);
 
       this._destroyConsumer();
-    }
+    };
 
     const onError = (err?: Error) => {
       if (!err) {
@@ -150,7 +149,6 @@ export class FeedQueue<T extends {}> {
       }
       this._destroyConsumer();
     });
-
 
     log('opened');
   }

--- a/packages/common/typings/src/index.d.ts
+++ b/packages/common/typings/src/index.d.ts
@@ -17,3 +17,4 @@ import './nanoresource-promise';
 import './random-access-storage';
 import './streamx';
 import './zen-push';
+import './race-as-promised';

--- a/packages/common/typings/src/race-as-promised.d.ts
+++ b/packages/common/typings/src/race-as-promised.d.ts
@@ -1,0 +1,5 @@
+declare module 'race-as-promised' {
+  type raceFn = typeof Promise.race;
+  declare const race: raceFn;
+  export default race;
+}

--- a/packages/common/typings/src/race-as-promised.d.ts
+++ b/packages/common/typings/src/race-as-promised.d.ts
@@ -1,4 +1,5 @@
 declare module 'race-as-promised' {
+  // https://github.com/digitalloggers/race-as-promised/pull/4
   type raceFn = typeof Promise.race;
   declare const race: raceFn;
   export default race;

--- a/packages/core/mesh/messaging/src/messenger.ts
+++ b/packages/core/mesh/messaging/src/messenger.ts
@@ -84,9 +84,13 @@ export class Messenger {
     );
 
     // Clear the map periodically.
-    scheduleTaskInterval(this._ctx, async () => {
-      this._performGc();
-    }, RECEIVED_MESSAGES_GC_INTERVAL);
+    scheduleTaskInterval(
+      this._ctx,
+      async () => {
+        this._performGc();
+      },
+      RECEIVED_MESSAGES_GC_INTERVAL,
+    );
 
     this._closed = false;
     log.trace('dxos.mesh.messenger.open', trace.end({ id: traceId }));

--- a/packages/core/mesh/messaging/src/messenger.ts
+++ b/packages/core/mesh/messaging/src/messenger.ts
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import { TimeoutError, scheduleExponentialBackoffTaskInterval, scheduleTask } from '@dxos/async';
+import { TimeoutError, scheduleExponentialBackoffTaskInterval, scheduleTask, scheduleTaskInterval } from '@dxos/async';
 import { Any } from '@dxos/codec-protobuf';
 import { Context } from '@dxos/context';
 import { TimeoutError as ProtocolTimeoutError } from '@dxos/errors';
@@ -30,6 +30,8 @@ const Acknowledgement = schema.getCodecForType('dxos.mesh.messaging.Acknowledgem
 const ERROR_LIMIT = 5;
 const NETWORK_REBOOT_DELAY = 3_000;
 
+const RECEIVED_MESSAGES_GC_INTERVAL = 120_000;
+
 /**
  * Reliable messenger that works trough signal network.
  */
@@ -45,7 +47,12 @@ export class Messenger {
 
   private readonly _onAckCallbacks = new ComplexMap<PublicKey, () => void>(PublicKey.hash);
 
-  private readonly _receivedMessages = new ComplexSet<PublicKey>((key) => key.toHex());
+  private readonly _receivedMessages = new ComplexSet<PublicKey>(PublicKey.hash);
+
+  /**
+   * Keys scheduled to be cleared from _receivedMessages on the next iteration.
+   */
+  private readonly _toClear = new ComplexSet<PublicKey>(PublicKey.hash);
 
   private _ctx!: Context;
   private _closed = true;
@@ -75,6 +82,12 @@ export class Messenger {
         await this._handleMessage(message);
       }),
     );
+
+    // Clear the map periodically.
+    scheduleTaskInterval(this._ctx, async () => {
+      this._performGc();
+    }, RECEIVED_MESSAGES_GC_INTERVAL);
+
     this._closed = false;
     log.trace('dxos.mesh.messenger.open', trace.end({ id: traceId }));
   }
@@ -316,6 +329,23 @@ export class Messenger {
           await listener(message);
         }
       }
+    }
+  }
+
+  private _performGc() {
+    const start = performance.now();
+
+    for (const key of this._toClear.keys()) {
+      this._receivedMessages.delete(key);
+    }
+    this._toClear.clear();
+    for (const key of this._receivedMessages.keys()) {
+      this._toClear.add(key);
+    }
+
+    const elapsed = performance.now() - start;
+    if (elapsed > 100) {
+      log.warn('GC took too long', { elapsed });
     }
   }
 }

--- a/packages/core/mesh/teleport-extension-gossip/src/gossip.ts
+++ b/packages/core/mesh/teleport-extension-gossip/src/gossip.ts
@@ -45,7 +45,7 @@ export class Gossip {
 
   public readonly connectionClosed = new Event<PublicKey>();
 
-  constructor(private readonly _params: GossipParams) { }
+  constructor(private readonly _params: GossipParams) {}
 
   get localPeerId() {
     return this._params.localPeerId;
@@ -53,11 +53,14 @@ export class Gossip {
 
   async open() {
     // Clear the map periodically.
-    scheduleTaskInterval(this._ctx, async () => {
-      this._performGc();
-    }, RECEIVED_MESSAGES_GC_INTERVAL);
+    scheduleTaskInterval(
+      this._ctx,
+      async () => {
+        this._performGc();
+      },
+      RECEIVED_MESSAGES_GC_INTERVAL,
+    );
   }
-
 
   async close() {
     await this._ctx.dispose();

--- a/packages/core/mesh/teleport-extension-gossip/src/gossip.ts
+++ b/packages/core/mesh/teleport-extension-gossip/src/gossip.ts
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { scheduleTask, Event } from '@dxos/async';
+import { scheduleTask, Event, scheduleTaskInterval } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
@@ -15,6 +15,8 @@ import { GossipExtension } from './gossip-extension';
 export type GossipParams = {
   localPeerId: PublicKey;
 };
+
+const RECEIVED_MESSAGES_GC_INTERVAL = 120_000;
 
 /**
  * Gossip extensions manager.
@@ -31,17 +33,44 @@ export class Gossip {
 
   private readonly _listeners = new Map<string, Set<(message: GossipMessage) => void>>();
 
-  private readonly _receivedMessages = new ComplexSet<PublicKey>(PublicKey.hash); // TODO(mykola): Memory leak. Never cleared.
+  private readonly _receivedMessages = new ComplexSet<PublicKey>(PublicKey.hash);
+
+  private readonly _toClear = new ComplexSet<PublicKey>(PublicKey.hash);
 
   // remotePeerId -> PresenceExtension
   private readonly _connections = new ComplexMap<PublicKey, GossipExtension>(PublicKey.hash);
 
   public readonly connectionClosed = new Event<PublicKey>();
 
-  constructor(private readonly _params: GossipParams) {}
+  constructor(private readonly _params: GossipParams) { }
 
   get localPeerId() {
     return this._params.localPeerId;
+  }
+
+  async open() {
+    // Clear the map periodically.
+    scheduleTaskInterval(this._ctx, async () => {
+      const start = performance.now();
+
+      for (const key of this._toClear.keys()) {
+        this._receivedMessages.delete(key);
+      }
+      this._toClear.clear();
+      for (const key of this._receivedMessages.keys()) {
+        this._toClear.add(key);
+      }
+
+      const elapsed = performance.now() - start;
+      if(elapsed > 100) {
+        log.warn('GC took too long', { elapsed });
+      }
+    }, RECEIVED_MESSAGES_GC_INTERVAL);
+  }
+
+
+  async close() {
+    await this._ctx.dispose();
   }
 
   getConnections() {
@@ -75,10 +104,6 @@ export class Gossip {
     return extension;
   }
 
-  async destroy() {
-    await this._ctx.dispose();
-  }
-
   postMessage(channel: string, payload: any) {
     for (const extension of this._connections.values()) {
       void extension
@@ -95,7 +120,7 @@ export class Gossip {
           // TODO(nf): always destroy on RpcClosedError?
 
           if (err instanceof RpcClosedError) {
-            await this.destroy();
+            await this.close();
             throw err;
           }
         });

--- a/packages/core/mesh/teleport-extension-gossip/src/testing.ts
+++ b/packages/core/mesh/teleport-extension-gossip/src/testing.ts
@@ -25,6 +25,7 @@ export class TestAgent extends TestPeerBase {
     this.gossip = new Gossip({
       localPeerId: peerId,
     });
+    void this.gossip.open();
     this.presence = new Presence({
       announceInterval,
       offlineTimeout,
@@ -52,7 +53,7 @@ export class TestAgent extends TestPeerBase {
 
   override async destroy() {
     await super.destroy();
-    await this.gossip.destroy();
+    await this.gossip.close();
     await this.presence.destroy();
   }
 }

--- a/packages/sdk/client-services/src/packlets/spaces/data-space.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space.ts
@@ -151,6 +151,7 @@ export class DataSpace {
   }
 
   private async _open() {
+    await this._gossip.open();
     await this._notarizationPlugin.open();
     await this._inner.spaceState.addCredentialProcessor(this._notarizationPlugin);
     await this._inner.open(new Context());
@@ -180,6 +181,7 @@ export class DataSpace {
     await this._notarizationPlugin.close();
 
     await this._presence.destroy();
+    await this._gossip.close();
   }
 
   async postMessage(channel: string, message: any) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2006,6 +2006,7 @@ importers:
       '@faker-js/faker': ^8.0.2
       '@types/lodash.defaultsdeep': ^4.6.6
       lodash.defaultsdeep: ^4.6.1
+      race-as-promised: ^0.0.2
       random-access-storage: ^3.0.0
       streamx: ^2.12.5
     dependencies:
@@ -2023,6 +2024,7 @@ importers:
       '@dxos/random-access-storage': link:../random-access-storage
       '@dxos/util': link:../util
       lodash.defaultsdeep: 4.6.1
+      race-as-promised: 0.0.2
       random-access-storage: 3.0.0
       streamx: 2.12.5
     optionalDependencies:
@@ -33518,6 +33520,10 @@ packages:
     hasBin: true
     dependencies:
       utf8: 2.1.2
+    dev: false
+
+  /race-as-promised/0.0.2:
+    resolution: {integrity: sha512-7BLWiZMSVJDxMTT/QUuEEdd/f/pYDkusGvU0p3NUCDAc6HSlhPpvRS42/GmK79p3Kw4aDA+l+sD8wNpxQdOYTQ==}
     dev: false
 
   /raf/3.4.1:


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4be1f0c</samp>

### Summary
🐛🧹🔄

<!--
1.  🐛 - This emoji represents the bug fix in the feed iterator and the `Promise.race` method. It conveys the idea of squashing a bug or resolving an issue.
2.  🧹 - This emoji represents the code quality and style improvements, as well as the garbage collection mechanisms. It conveys the idea of cleaning up the code, removing unnecessary or redundant parts, and preventing memory leaks or waste.
3.  🔄 - This emoji represents the refactoring of the `Gossip` class and the API changes in the `TestAgent` and `DataSpace` classes. It conveys the idea of changing or updating the code structure, logic, or interface without altering the functionality or behavior.
-->
This pull request fixes a bug in the `feed-store` package, improves the code quality and style of several classes, and adds a garbage collection mechanism to the `messenger` and `gossip` classes. It also updates the tests and the dependent classes to use the new APIs and methods. It modifies six TypeScript files and one `package.json` file.

> _Sing, O Muse, of the valiant code review_
> _That fixed the bugs and improved the style_
> _Of the `feed-store` and its modules true_
> _And made the `gossip` more versatile._

### Walkthrough
*  Add `race-as-promised` dependency to fix `Promise.race` bug in `feed-store` package ([link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-b61df366c52f452d49c6a479e47aef3c33a642e65c87da080208a5d330f79320R36), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-a79fb5a5b71b21b1b4ed6289712d0169b2f60399afaf26799c4406a503e001f2R8), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-a79fb5a5b71b21b1b4ed6289712d0169b2f60399afaf26799c4406a503e001f2L85-R87))
*  Refactor and format `FeedQueue` class to improve readability and maintainability ([link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-a8b9cf688aad506de3104c55cc8ff78bea1ac77de77007fe8d08f68e003e2facL43-R43), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-a8b9cf688aad506de3104c55cc8ff78bea1ac77de77007fe8d08f68e003e2facL119-R143), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-a8b9cf688aad506de3104c55cc8ff78bea1ac77de77007fe8d08f68e003e2facL150-R152), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-a8b9cf688aad506de3104c55cc8ff78bea1ac77de77007fe8d08f68e003e2facR200-R209))
*  Implement periodic garbage collection of received messages in `Messenger` and `Gossip` classes to prevent memory leaks and duplicate processing ([link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-676a81f432e0060295f1801178be4e7edfde44c2fe059ceaf2712b0718270a24L5-R5), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-676a81f432e0060295f1801178be4e7edfde44c2fe059ceaf2712b0718270a24R33-R34), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-676a81f432e0060295f1801178be4e7edfde44c2fe059ceaf2712b0718270a24L48-R56), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-676a81f432e0060295f1801178be4e7edfde44c2fe059ceaf2712b0718270a24R85-R94), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-676a81f432e0060295f1801178be4e7edfde44c2fe059ceaf2712b0718270a24R338-R354), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-8c0d22e91ef78cf597ee52fe4f8f36f1608d2baad932a27bf9d7f097e805101aL5-R5), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-8c0d22e91ef78cf597ee52fe4f8f36f1608d2baad932a27bf9d7f097e805101aR19-R20), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-8c0d22e91ef78cf597ee52fe4f8f36f1608d2baad932a27bf9d7f097e805101aL34-R42), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-8c0d22e91ef78cf597ee52fe4f8f36f1608d2baad932a27bf9d7f097e805101aR54-R68), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-8c0d22e91ef78cf597ee52fe4f8f36f1608d2baad932a27bf9d7f097e805101aL78-L81), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-8c0d22e91ef78cf597ee52fe4f8f36f1608d2baad932a27bf9d7f097e805101aL98-R116), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-8c0d22e91ef78cf597ee52fe4f8f36f1608d2baad932a27bf9d7f097e805101aR154-R170))
*  Add `open` and `close` methods to `Gossip` class to make it consistent with `Messenger` class and allow user to control its lifecycle ([link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-8c0d22e91ef78cf597ee52fe4f8f36f1608d2baad932a27bf9d7f097e805101aR54-R68), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-8c0d22e91ef78cf597ee52fe4f8f36f1608d2baad932a27bf9d7f097e805101aL78-L81), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-8c0d22e91ef78cf597ee52fe4f8f36f1608d2baad932a27bf9d7f097e805101aL98-R116))
*  Remove `destroy` method from `Gossip` class to avoid confusion and redundancy in its API ([link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-8c0d22e91ef78cf597ee52fe4f8f36f1608d2baad932a27bf9d7f097e805101aL78-L81))
*  Call `open` and `close` methods of `gossip` instances in `TestAgent`, `DataSpace` and `gossip.ts` to ensure proper initialization and cleanup ([link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-a0461036e5b36729701b4d61b08ffd7e8932c019cc86c0bc69670367a1acfc17R28), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-a0461036e5b36729701b4d61b08ffd7e8932c019cc86c0bc69670367a1acfc17L55-R56), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-c17bc7f7884d49b4cbcdce4bb1ff4ec783c7b397b92c9661d78bc3517092ab3dR154), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-c17bc7f7884d49b4cbcdce4bb1ff4ec783c7b397b92c9661d78bc3517092ab3dR184), [link](https://github.com/dxos/dxos/pull/4188/files?diff=unified&w=0#diff-8c0d22e91ef78cf597ee52fe4f8f36f1608d2baad932a27bf9d7f097e805101aL98-R116))


