### PR TITLE
fix(plugin-github): bad translation ns

### DIFF
--- a/packages/apps/plugins/plugin-github/src/components/EmbeddedMain/EmbeddedMain.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/EmbeddedMain/EmbeddedMain.tsx
@@ -15,7 +15,7 @@ import React, { useCallback, useContext, useRef, useState } from 'react';
 
 import { ClientPluginProvides } from '@braneframe/plugin-client';
 import { IntentPluginProvides } from '@braneframe/plugin-intent';
-import { SpaceAction, getSpaceDisplayName } from '@braneframe/plugin-space';
+import { SPACE_PLUGIN, SpaceAction, getSpaceDisplayName } from '@braneframe/plugin-space';
 import {
   Avatar,
   Button,
@@ -187,12 +187,12 @@ const EmbeddedLayoutImpl = () => {
                       }
                     >
                       <ArrowSquareOut className={mx('shrink-0', getSize(5))} />
-                      <span className='grow'>{t('open in composer label', { ns: 'composer' })}</span>
+                      <span className='grow'>{t('open in composer label', { ns: GITHUB_PLUGIN })}</span>
                     </a>
                   </DropdownMenu.Item>
                   <DropdownMenu.Separator />
                   <DropdownMenu.GroupLabel>
-                    {t('active space label', { ns: 'composer' })}
+                    {t('active space label', { ns: SPACE_PLUGIN })}
                     <Avatar.Root size={5} variant='circle'>
                       <div role='none' className='flex gap-1 mlb-1 items-center'>
                         <Avatar.Frame>
@@ -205,7 +205,7 @@ const EmbeddedLayoutImpl = () => {
                     </Avatar.Root>
                   </DropdownMenu.GroupLabel>
                   <DropdownMenu.Item onClick={() => setRenameDialogOpen(true)}>
-                    <span className='grow'>{t('rename space label', { ns: 'composer' })}</span>
+                    <span className='grow'>{t('rename space label', { ns: SPACE_PLUGIN })}</span>
                     <PencilSimpleLine className={mx('shrink-0', getSize(5))} />
                   </DropdownMenu.Item>
                   <DropdownMenu.Item onClick={() => setResolverDialogOpen(true)}>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 58aaa7c</samp>

### Summary
🌐🔌📦

<!--
1.  🌐 - This emoji represents translation or localization, and can be used to indicate that the pull request updates the translation keys for some labels.
2.  🔌 - This emoji represents plugins or extensions, and can be used to indicate that the pull request affects the GitHub plugin and its namespace.
3.  📦 - This emoji represents dependencies or packages, and can be used to indicate that the pull request imports a constant from a dependency.
-->
This pull request fixes some translation issues in the `plugin-github` app by using proper namespaces for the labels and importing the `SPACE_PLUGIN` constant from `@dxos/plugins`.

> _No more clashes in the dark_
> _We claim our own translation keys_
> _We import the `SPACE_PLUGIN` from afar_
> _We are the masters of our GitHub destinies_

### Walkthrough
* Import `SPACE_PLUGIN` constant from `@braneframe/plugin-space` to use as a namespace for translation keys related to spaces ([link](https://github.com/dxos/dxos/pull/4198/files?diff=unified&w=0#diff-729deb573b5cc8132392ae8f4565e26d5d88f5b5a3f07068efa78bfd4701a03fL17-R17)).


