### PR TITLE
chore: clean output path before running tsc

### DIFF
--- a/patches/@nx__js@16.5.4.patch
+++ b/patches/@nx__js@16.5.4.patch
@@ -1,8 +1,14 @@
 diff --git a/src/executors/tsc/tsc.impl.js b/src/executors/tsc/tsc.impl.js
-index 824e8e4e0338c5c51c086a40085b02d24e6490eb..39df4c6f6470d37f7b64eac7b400ab3e1f965ca2 100644
+index 824e8e4e0338c5c51c086a40085b02d24e6490eb..aa38e803867405840dde19937dbf217aed9a1c29 100644
 --- a/src/executors/tsc/tsc.impl.js
 +++ b/src/executors/tsc/tsc.impl.js
-@@ -6,9 +6,9 @@ const copy_assets_handler_1 = require("../../utils/assets/copy-assets-handler");
+@@ -1,14 +1,15 @@
+ "use strict";
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.tscExecutor = exports.createTypeScriptCompilationOptions = void 0;
++const fs = require('node:fs');
+ const tslib_1 = require("tslib");
+ const copy_assets_handler_1 = require("../../utils/assets/copy-assets-handler");
  const check_dependencies_1 = require("../../utils/check-dependencies");
  const compiler_helper_dependency_1 = require("../../utils/compiler-helper-dependency");
  const inline_1 = require("../../utils/inline");
@@ -14,7 +20,19 @@ index 824e8e4e0338c5c51c086a40085b02d24e6490eb..39df4c6f6470d37f7b64eac7b400ab3e
  const lib_1 = require("./lib");
  function createTypeScriptCompilationOptions(normalizedOptions, context) {
      return {
-@@ -48,16 +48,16 @@ function tscExecutor(_options, context) {
+@@ -35,6 +36,11 @@ function tscExecutor(_options, context) {
+         if (tsLibDependency) {
+             dependencies.push(tsLibDependency);
+         }
++        // Clean output path before build.
++        try {
++            fs.readdir(_options.outputPath);
++            fs.rm(_options.outputPath, { recursive: true });
++        } catch {}
+         const assetHandler = new copy_assets_handler_1.CopyAssetsHandler({
+             projectDir: projectRoot,
+             rootDir: context.root,
+@@ -48,16 +54,16 @@ function tscExecutor(_options, context) {
          }
          const typescriptCompilation = (0, compile_typescript_files_1.compileTypeScriptFiles)(options, tsCompilationOptions, () => tslib_1.__awaiter(this, void 0, void 0, function* () {
              yield assetHandler.processAllAssetsOnce();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.4
 
 patchedDependencies:
   '@nx/js@16.5.4':
-    hash: kco6wocfncyehzbvd6faof7n2y
+    hash: st3ukm3rnd3xadn2fxesh4boby
     path: patches/@nx__js@16.5.4.patch
   '@nx/vite@16.5.4':
     hash: xxzhsuqrsbs6wyvhvm37cpe46m
@@ -152,7 +152,7 @@ importers:
       '@nx/devkit': 16.5.4_nx@16.5.4
       '@nx/eslint-plugin': 16.5.4_2b57dwhe6e7ogoa22cr2cay3k4
       '@nx/jest': 16.5.4_ebxsb5ytaojlvyq6j3l6ecuzii
-      '@nx/js': 16.5.4_kco6wocfncyehzbvd6faof7n2y_eoiemzzyseqzjynwznlrcdpipu
+      '@nx/js': 16.5.4_st3ukm3rnd3xadn2fxesh4boby_eoiemzzyseqzjynwznlrcdpipu
       '@nx/linter': 16.5.4_77fo5nn477ty7cywkqdedkrxey
       '@nx/storybook': 16.5.4_77fo5nn477ty7cywkqdedkrxey
       '@nx/vite': 16.5.4_xxzhsuqrsbs6wyvhvm37cpe46m_qgit66yh2vyynsv7uxdneek4qa
@@ -10824,7 +10824,7 @@ packages:
   /@nrwl/js/16.5.4_eoiemzzyseqzjynwznlrcdpipu:
     resolution: {integrity: sha512-j4CjEvukVykevw9Pj85Fo+uMarkLT7kytPVKN28Mpv8hk2ePSyLBa3S48jWjaUT25Z42USUIdMhAau2JuL7ZNg==}
     dependencies:
-      '@nx/js': 16.5.4_kco6wocfncyehzbvd6faof7n2y_eoiemzzyseqzjynwznlrcdpipu
+      '@nx/js': 16.5.4_st3ukm3rnd3xadn2fxesh4boby_eoiemzzyseqzjynwznlrcdpipu
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -10939,7 +10939,7 @@ packages:
     dependencies:
       '@nrwl/cypress': 16.5.4_77fo5nn477ty7cywkqdedkrxey
       '@nx/devkit': 16.5.4_nx@16.5.4
-      '@nx/js': 16.5.4_kco6wocfncyehzbvd6faof7n2y_eoiemzzyseqzjynwznlrcdpipu
+      '@nx/js': 16.5.4_st3ukm3rnd3xadn2fxesh4boby_eoiemzzyseqzjynwznlrcdpipu
       '@nx/linter': 16.5.4_77fo5nn477ty7cywkqdedkrxey
       '@phenomnomnominal/tsquery': 5.0.1_typescript@5.2.2
       detect-port: 1.5.1
@@ -10982,7 +10982,7 @@ packages:
     dependencies:
       '@nrwl/eslint-plugin-nx': 16.5.4_2b57dwhe6e7ogoa22cr2cay3k4
       '@nx/devkit': 16.5.4_nx@16.5.4
-      '@nx/js': 16.5.4_kco6wocfncyehzbvd6faof7n2y_eoiemzzyseqzjynwznlrcdpipu
+      '@nx/js': 16.5.4_st3ukm3rnd3xadn2fxesh4boby_eoiemzzyseqzjynwznlrcdpipu
       '@typescript-eslint/parser': 6.5.0_walxjw3fmezupdd3r2qqbe42z4
       '@typescript-eslint/type-utils': 5.62.0_walxjw3fmezupdd3r2qqbe42z4
       '@typescript-eslint/utils': 5.62.0_walxjw3fmezupdd3r2qqbe42z4
@@ -11009,7 +11009,7 @@ packages:
       '@jest/test-result': 29.5.0
       '@nrwl/jest': 16.5.4_ebxsb5ytaojlvyq6j3l6ecuzii
       '@nx/devkit': 16.5.4_nx@16.5.4
-      '@nx/js': 16.5.4_kco6wocfncyehzbvd6faof7n2y_eoiemzzyseqzjynwznlrcdpipu
+      '@nx/js': 16.5.4_st3ukm3rnd3xadn2fxesh4boby_eoiemzzyseqzjynwznlrcdpipu
       '@phenomnomnominal/tsquery': 5.0.1_typescript@5.2.2
       chalk: 4.1.2
       dotenv: 10.0.0
@@ -11033,7 +11033,7 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/js/16.5.4_kco6wocfncyehzbvd6faof7n2y_eoiemzzyseqzjynwznlrcdpipu:
+  /@nx/js/16.5.4_st3ukm3rnd3xadn2fxesh4boby_eoiemzzyseqzjynwznlrcdpipu:
     resolution: {integrity: sha512-7SOge4g+o8xr6yV5a0HCCm5EmhXwpupOZoXH9C+iE22WY5Mv8c55Q/F7RbyfHvjvtG812SNN8XwatXLE6RJ7GQ==}
     peerDependencies:
       verdaccio: ^5.0.4
@@ -11086,7 +11086,7 @@ packages:
     dependencies:
       '@nrwl/linter': 16.5.4_77fo5nn477ty7cywkqdedkrxey
       '@nx/devkit': 16.5.4_nx@16.5.4
-      '@nx/js': 16.5.4_kco6wocfncyehzbvd6faof7n2y_eoiemzzyseqzjynwznlrcdpipu
+      '@nx/js': 16.5.4_st3ukm3rnd3xadn2fxesh4boby_eoiemzzyseqzjynwznlrcdpipu
       '@phenomnomnominal/tsquery': 5.0.1_typescript@5.2.2
       eslint: 8.41.0
       tmp: 0.2.1
@@ -11198,7 +11198,7 @@ packages:
       '@nrwl/storybook': 16.5.4_77fo5nn477ty7cywkqdedkrxey
       '@nx/cypress': 16.5.4_77fo5nn477ty7cywkqdedkrxey
       '@nx/devkit': 16.5.4_nx@16.5.4
-      '@nx/js': 16.5.4_kco6wocfncyehzbvd6faof7n2y_eoiemzzyseqzjynwznlrcdpipu
+      '@nx/js': 16.5.4_st3ukm3rnd3xadn2fxesh4boby_eoiemzzyseqzjynwznlrcdpipu
       '@nx/linter': 16.5.4_77fo5nn477ty7cywkqdedkrxey
       '@nx/workspace': 16.5.4_fadq7qjtdssl5ciytqq3qdvfum
       '@phenomnomnominal/tsquery': 5.0.1_typescript@5.2.2
@@ -11224,7 +11224,7 @@ packages:
     dependencies:
       '@nrwl/vite': 16.5.4_qgit66yh2vyynsv7uxdneek4qa
       '@nx/devkit': 16.5.4_nx@16.5.4
-      '@nx/js': 16.5.4_kco6wocfncyehzbvd6faof7n2y_eoiemzzyseqzjynwznlrcdpipu
+      '@nx/js': 16.5.4_st3ukm3rnd3xadn2fxesh4boby_eoiemzzyseqzjynwznlrcdpipu
       '@phenomnomnominal/tsquery': 5.0.1_typescript@5.2.2
       '@swc/helpers': 0.5.1
       dotenv: 10.0.0
@@ -11247,7 +11247,7 @@ packages:
     dependencies:
       '@nrwl/web': 16.5.4_eoiemzzyseqzjynwznlrcdpipu
       '@nx/devkit': 16.5.4_nx@16.5.4
-      '@nx/js': 16.5.4_kco6wocfncyehzbvd6faof7n2y_eoiemzzyseqzjynwznlrcdpipu
+      '@nx/js': 16.5.4_st3ukm3rnd3xadn2fxesh4boby_eoiemzzyseqzjynwznlrcdpipu
       chalk: 4.1.2
       chokidar: 3.5.3
       detect-port: 1.5.1


### PR DESCRIPTION
We ran into a situation where errors.ts was refactored into errors directory but errors.ts output was never deleted and was subsequently cached as valid build output and kept being brought back without breaking the cache with another change

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a2c8620</samp>

### Summary
🧹🛠️📁

<!--
1.  🧹 - This emoji can represent the cleaning of the output path, as it is a common symbol for sweeping or tidying up.
2.  🛠️ - This emoji can represent the building process, as it is a common symbol for tools or construction.
3.  📁 - This emoji can represent the output directory, as it is a common symbol for folders or files.
-->
Applied a patch to `@nx__js` package to enable `fs` module and output cleaning. This improves the reliability and consistency of the build process.

> _We'll build our ship with `fs` module_
> _And clean the output path before we sail_
> _We'll heave away and haul the code along_
> _And avoid the errors from the old files' trail_

### Walkthrough
* Import `fs` module to clean output path before building ([link](https://github.com/dxos/dxos/pull/4201/files?diff=unified&w=0#diff-ffb077a25b1340eff2bd15c0aa78a81e9260ceb5a4803f94a13c4fbd7b07fc09L2-R11))
* Add try-catch block to remove output directory and its contents if it exists ([link](https://github.com/dxos/dxos/pull/4201/files?diff=unified&w=0#diff-ffb077a25b1340eff2bd15c0aa78a81e9260ceb5a4803f94a13c4fbd7b07fc09L17-R36))


