### PR TITLE
fix: updates for echo testbench after breaking api changes

### DIFF
--- a/packages/gravity/kube-testing/src/spec/echo.ts
+++ b/packages/gravity/kube-testing/src/spec/echo.ts
@@ -236,14 +236,14 @@ export class EchoTestPlan implements TestPlan<EchoTestSpec, EchoAgentConfig> {
     if (!this.spaceKey) {
       await this.client.halo.createIdentity({ displayName: `test agent ${env.params.config.agentIdx}` });
       if (env.params.config.creator) {
-        this.space = await this.client.createSpace({ name: 'test space' });
-        this.space.createInvitation({
+        this.space = await this.client.spaces.create({ name: 'test space' });
+        this.space.share({
           swarmKey: PublicKey.from(env.params.config.invitationTopic),
           authMethod: Invitation.AuthMethod.NONE,
           type: Invitation.Type.MULTIUSE,
         });
       } else {
-        const invitation = this.client.acceptInvitation({
+        const invitation = this.client.spaces.join({
           swarmKey: PublicKey.from(env.params.config.invitationTopic),
           authMethod: Invitation.AuthMethod.NONE,
           type: Invitation.Type.MULTIUSE,
@@ -267,7 +267,7 @@ export class EchoTestPlan implements TestPlan<EchoTestSpec, EchoAgentConfig> {
       }
       this.spaceKey = this.space.key;
     } else {
-      this.space = await this.client.getSpace(this.spaceKey)!;
+      this.space = await this.client.spaces.get(this.spaceKey)!;
     }
 
     invariant(


### PR DESCRIPTION
fixes https://github.com/dxos/dxos/issues/4202
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3a52d03</samp>

### Summary
🚀🛠️📝

<!--
1.  🚀 This emoji could represent the improvement of the API and the launch of the new namespace for space-related operations.
2.  🛠️ This emoji could represent the renaming and refactoring of the existing methods to fit the new namespace and the fixing of any potential issues or bugs.
3.  📝 This emoji could represent the documentation and communication of the changes to the users and developers of the API.
-->
Refactored client API methods for space-related operations in `echo.ts` spec. Used `spaces` namespace to group and name the methods more clearly.

> _Sing, O Muse, of the skillful coder who reshaped the client API_
> _And gave new names to the methods that deal with spaces sublime_
> _As `spaces.create` and `spaces.delete` and `spaces.list` he made_
> _And thus he earned the praise of users and the glory of his time_

### Walkthrough
*  Rename client API methods to use namespaces for different resources ([link](https://github.com/dxos/dxos/pull/4205/files?diff=unified&w=0#diff-42545001b42ebe1ffa8b334dee92afe2747f32e4dd465c25c7a520fa0cf3f295L239-R240), [link](https://github.com/dxos/dxos/pull/4205/files?diff=unified&w=0#diff-42545001b42ebe1ffa8b334dee92afe2747f32e4dd465c25c7a520fa0cf3f295L246-R246), [link](https://github.com/dxos/dxos/pull/4205/files?diff=unified&w=0#diff-42545001b42ebe1ffa8b334dee92afe2747f32e4dd465c25c7a520fa0cf3f295L270-R270))

