### PR TITLE
fix: Moving objects between spaces

### DIFF
--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -35,8 +35,8 @@ export const getSpaceDisplayName = (space: Space): string | [string, { ns: strin
   return (space.properties.name?.length ?? 0) > 0
     ? space.properties.name
     : disabled
-      ? ['loading space title', { ns: SPACE_PLUGIN }]
-      : ['untitled space title', { ns: SPACE_PLUGIN }];
+    ? ['loading space title', { ns: SPACE_PLUGIN }]
+    : ['untitled space title', { ns: SPACE_PLUGIN }];
 };
 
 export const spaceToGraphNode = (

--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -35,8 +35,8 @@ export const getSpaceDisplayName = (space: Space): string | [string, { ns: strin
   return (space.properties.name?.length ?? 0) > 0
     ? space.properties.name
     : disabled
-    ? ['loading space title', { ns: SPACE_PLUGIN }]
-    : ['untitled space title', { ns: SPACE_PLUGIN }];
+      ? ['loading space title', { ns: SPACE_PLUGIN }]
+      : ['untitled space title', { ns: SPACE_PLUGIN }];
 };
 
 export const spaceToGraphNode = (
@@ -75,10 +75,7 @@ export const spaceToGraphNode = (
         // create clone of child and add to migration destination
         const object = clone(child.data, {
           retainId: true,
-          additional: [
-            ...(child.data.content ? [child.data.content] : []),
-            ...(child.data.meta ? [child.data.meta] : []),
-          ],
+          additional: [child.data.content],
         });
         space.db.add(object);
         object.meta.index = nextIndex;

--- a/packages/core/echo/echo-schema/src/clone.ts
+++ b/packages/core/echo/echo-schema/src/clone.ts
@@ -31,7 +31,7 @@ export const clone = <T extends EchoObject>(obj: T, { retainId = true, additiona
     throw new Error("Updating id's is not supported when cloning with nested objects.");
   }
 
-  if(!obj[base]) {
+  if (!obj[base]) {
     throw new TypeError('Object is not an EchoObject.');
   }
 
@@ -42,7 +42,7 @@ export const clone = <T extends EchoObject>(obj: T, { retainId = true, additiona
     if (!obj) {
       continue;
     }
-    if(!obj[base]) {
+    if (!obj[base]) {
       throw new TypeError('Object is not an EchoObject.');
     }
     clones.push(cloneInner(obj[base], retainId ? obj.id : PublicKey.random().toHex()));

--- a/packages/core/echo/echo-schema/src/clone.ts
+++ b/packages/core/echo/echo-schema/src/clone.ts
@@ -31,12 +31,19 @@ export const clone = <T extends EchoObject>(obj: T, { retainId = true, additiona
     throw new Error("Updating id's is not supported when cloning with nested objects.");
   }
 
+  if(!obj[base]) {
+    throw new TypeError('Object is not an EchoObject.');
+  }
+
   const clone = cloneInner(obj[base], retainId ? obj.id : PublicKey.random().toHex()) as T;
 
   const clones: EchoObject[] = [clone];
   for (const obj of additional) {
     if (!obj) {
       continue;
+    }
+    if(!obj[base]) {
+      throw new TypeError('Object is not an EchoObject.');
     }
     clones.push(cloneInner(obj[base], retainId ? obj.id : PublicKey.random().toHex()));
   }

--- a/packages/core/echo/echo-typegen/test/database.test.ts
+++ b/packages/core/echo/echo-typegen/test/database.test.ts
@@ -131,4 +131,27 @@ describe('database', () => {
     expect(task2.description.model!.textContent).to.eq('test');
     expect(task2 !== task1).to.be.true;
   });
+
+  test('clone', async () => {
+    const { db: db1 } = await createDatabase();
+    const { db: db2 } = await createDatabase();
+
+    const task1 = new Task({
+      title: 'Main task',
+    });
+    db1.add(task1);
+    await db1.flush();
+
+    const task2 = clone(task1);
+    expect(task2 !== task1).to.be.true;
+    expect(task2.id).to.equal(task1.id);
+    expect(task2.title).to.equal(task1.title);
+    expect(task2).to.be.instanceOf(Task);
+
+    db2.add(task2);
+    await db2.flush();
+    expect(task2.id).to.equal(task1.id);
+
+    expect(() => db1.add(task1)).to.throw;
+  });
 });

--- a/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
@@ -99,7 +99,7 @@ export class SpacesServiceImpl implements SpacesService {
             subscriptions.add(space.dataPipeline.onNewEpoch.on(ctx, () => scheduler.trigger()));
 
             // Pipeline progress.
-            space.inner.controlPipeline.state.timeframeUpdate.on(ctx, () => scheduler.trigger());
+            subscriptions.add(space.inner.controlPipeline.state.timeframeUpdate.on(ctx, () => scheduler.trigger()));
             if (space.dataPipeline.pipelineState) {
               subscriptions.add(space.dataPipeline.pipelineState.timeframeUpdate.on(ctx, () => scheduler.trigger()));
             }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 99ab67a</samp>

### Summary
🪄🧪🐛

<!--
1.  🪄 - This emoji represents the simplification of the cloning logic and the removal of the unnecessary `meta` property. It suggests magic, transformation, or improvement.
2.  🧪 - This emoji represents the addition of the test case for the `clone` function. It suggests experimentation, testing, or verification.
3.  🐛 - This emoji represents the bug fix in the `SpacesServiceImpl` class. It suggests a bug, an error, or a problem.
-->
This pull request enhances the `clone` function for `EchoObject`s, fixes a memory leak in the `SpacesServiceImpl` class, and adds a test case for the `clone` function. The changes improve the reliability and performance of the echo schema and the spaces service.

> _Sing, O Muse, of the skillful engineers who toiled_
> _To perfect the clone function, that wondrous tool_
> _That copies tasks and spaces with ease and grace_
> _And preserves their ids and properties in place._

### Walkthrough
*  Simplify cloning of child objects in `spaceToGraphNode` by removing `meta` property ([link](https://github.com/dxos/dxos/pull/4210/files?diff=unified&w=0#diff-40c06872035a3fca913d3ecf4b86bab147706b739e5546f25845364df1b60203L78-R78))
*  Add type check to `clone` function to ensure input is an `EchoObject` ([link](https://github.com/dxos/dxos/pull/4210/files?diff=unified&w=0#diff-88b32fe14a69dd43d93971f847b1d48cb6e1833480ad205c6d45d3d5bc46d4faR34-R37), [link](https://github.com/dxos/dxos/pull/4210/files?diff=unified&w=0#diff-88b32fe14a69dd43d93971f847b1d48cb6e1833480ad205c6d45d3d5bc46d4faR45-R47))
*  Fix memory leak in `SpacesServiceImpl` by disposing subscription to `timeframeUpdate` event ([link](https://github.com/dxos/dxos/pull/4210/files?diff=unified&w=0#diff-707121e098bd19a3234ae34cd2c0852dc1a7b9c04addd28d2dbb8affa48f6e66L102-R102))
*  Add test case for `clone` function to verify its functionality and behavior ([link](https://github.com/dxos/dxos/pull/4210/files?diff=unified&w=0#diff-8bafe30cb1cf340f79d8cf1a4372873104c0b8a6e83a835e747ceb322557efdeR134-R156))


