### PR TITLE
fix: getting composer e2e running again

### DIFF
--- a/docs/src/components/Showcase.vue
+++ b/docs/src/components/Showcase.vue
@@ -130,7 +130,7 @@ const handleStackblitz = async () => {
     files: {
       ...template,
       'src/components/Demo.tsx': examples[`../../node_modules/@dxos/examples/src/examples/${props.example}.tsx`],
-      'src/proto/schema.proto': proto[`../../node_modules/@dxos/examples/src/proto/${props.example}.proto`],
+      'src/proto/schema.proto': proto[`../../node_modules/@dxos/examples/src/proto/schema.proto`],
     }
   });
 };

--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -52,7 +52,7 @@ export class AppManager {
   }
 
   async createDocument() {
-    await this.page.getByTestId('spacePlugin.spaceTreeItemActionsLevel2').last().click();
+    await this.page.getByTestId('spacePlugin.spaceTreeItemActionsLevel1').last().click();
     return this.page.getByTestId('spacePlugin.createDocument').last().click();
   }
 

--- a/packages/apps/composer-app/src/playwright/multi-player.spec.ts
+++ b/packages/apps/composer-app/src/playwright/multi-player.spec.ts
@@ -7,8 +7,6 @@ import { expect } from 'chai';
 import { platform } from 'node:os';
 import waitForExpect from 'wait-for-expect';
 
-import { sleep } from '@dxos/async';
-
 import { AppManager } from './app-manager';
 
 const perfomInvitation = async (host: AppManager, guest: AppManager) => {
@@ -45,17 +43,14 @@ test.describe('Basic test', () => {
       await host.createDocument();
       await perfomInvitation(host, guest);
 
-      // TODO(wittjosiah): This should wait for document to be visible in DOM.
-      await sleep(1000); // Wait for document to replicate.
-      await guest.expandSpace();
       await guest.page.getByTestId('spacePlugin.documentTreeItemLink').last().click();
       await guest.waitForMarkdownTextbox();
       await waitForExpect(async () => {
         expect(await host.page.url()).to.include(await guest.page.url());
       });
 
-      const hostLinks = await Promise.all([host.getDocumentLinks().nth(1).getAttribute('data-itemid')]);
-      const guestLinks = await Promise.all([guest.getDocumentLinks().nth(1).getAttribute('data-itemid')]);
+      const hostLinks = await Promise.all([host.getDocumentLinks().first().getAttribute('data-itemid')]);
+      const guestLinks = await Promise.all([guest.getDocumentLinks().first().getAttribute('data-itemid')]);
       expect(hostLinks[0]).to.equal(guestLinks[0]);
     });
 
@@ -66,10 +61,9 @@ test.describe('Basic test', () => {
       await host.createDocument();
       await perfomInvitation(host, guest);
 
-      await guest.expandSpace();
       await Promise.all([
-        host.getDocumentLinks().nth(1).click(),
-        guest.getDocumentLinks().nth(1).click(),
+        host.getDocumentLinks().first().click(),
+        guest.getDocumentLinks().first().click(),
         host.waitForMarkdownTextbox(),
         guest.waitForMarkdownTextbox(),
       ]);
@@ -99,10 +93,9 @@ test.describe('Basic test', () => {
       ];
       const allParts = parts.join('');
 
-      await guest.expandSpace();
       await Promise.all([
-        host.getDocumentLinks().nth(1).click(),
-        guest.getDocumentLinks().nth(1).click(),
+        host.getDocumentLinks().first().click(),
+        guest.getDocumentLinks().first().click(),
         host.waitForMarkdownTextbox(),
         guest.waitForMarkdownTextbox(),
       ]);

--- a/packages/apps/composer-app/src/playwright/single-player.spec.ts
+++ b/packages/apps/composer-app/src/playwright/single-player.spec.ts
@@ -17,14 +17,15 @@ test.describe('Single-player tests', () => {
   });
 
   test('create identity, space is created by default', async () => {
-    expect(await host.getSpaceItemsCount()).to.equal(1);
+    expect(await host.page.getByTestId('spacePlugin.personalSpace').isVisible()).to.be.true;
+    expect(await host.page.getByTestId('spacePlugin.allSpaces').isVisible()).to.be.true;
     expect(await host.getMarkdownTextbox().textContent()).to.exist;
   });
 
   test('create space, which is displayed in tree', async () => {
     await host.createSpace();
     await waitForExpect(async () => {
-      expect(await host.getSpaceItemsCount()).to.equal(2);
+      expect(await host.getSpaceItemsCount()).to.equal(1);
     });
   });
 
@@ -33,7 +34,7 @@ test.describe('Single-player tests', () => {
     await host.createDocument();
     const textBox = await host.getMarkdownTextbox();
     await waitForExpect(async () => {
-      expect(await host.getDocumentItemsCount()).to.equal(2);
+      expect(await host.getDocumentItemsCount()).to.equal(1);
       expect(await textBox.isEditable()).to.be.true;
     });
   });

--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
         manualChunks: {
           react: ['react', 'react-dom'],
           dxos: ['@dxos/react-client'],
-          aurora: ['@dxos/react-appkit', '@dxos/aurora', '@dxos/aurora-theme'],
+          aurora: ['@dxos/aurora', '@dxos/aurora-theme'],
           editor: ['@dxos/aurora-composer'],
         },
       },

--- a/packages/apps/plugins/plugin-files/src/types.ts
+++ b/packages/apps/plugins/plugin-files/src/types.ts
@@ -26,8 +26,8 @@ export type LocalEntity = LocalDirectory | LocalFile;
 export type LocalFile = {
   id: string;
   title: string;
-  handle?: FileSystemFileHandle;
-  permission?: PermissionStatus;
+  handle: FileSystemFileHandle | false;
+  permission: PermissionStatus;
   text?: string;
   // TODO(wittjosiah): Store original text?
   modified?: boolean;

--- a/packages/apps/plugins/plugin-files/src/util.tsx
+++ b/packages/apps/plugins/plugin-files/src/util.tsx
@@ -11,7 +11,7 @@ import { Graph } from '@braneframe/plugin-graph';
 import { FILES_PLUGIN, FILES_PLUGIN_SHORT_ID, LocalDirectory, LocalEntity, LocalFile, LocalFilesAction } from './types';
 
 export const isLocalFile = (data: unknown): data is LocalFile =>
-  data && typeof data === 'object' ? 'title' in data : false;
+  data && typeof data === 'object' ? 'title' in data && 'handle' in data : false;
 
 export const handleToLocalDirectory = async (
   handle: any /* FileSystemDirectoryHandle */,
@@ -42,7 +42,7 @@ export const handleToLocalFile = async (handle: any /* FileSystemFileHandle */, 
   };
 };
 
-export const legacyFileToLocalFile = async (file: File) => {
+export const legacyFileToLocalFile = async (file: File): Promise<LocalFile> => {
   const text = await new Promise<string>((resolve) => {
     const reader = new FileReader();
     reader.addEventListener('loadend', (event) => {
@@ -55,6 +55,8 @@ export const legacyFileToLocalFile = async (file: File) => {
   return {
     id: `${FILES_PLUGIN_SHORT_ID}:${file.name.replaceAll(/\.| /g, '-')}`,
     title: file.name,
+    handle: false,
+    permission: 'granted',
     text,
   };
 };

--- a/packages/apps/plugins/plugin-github/package.json
+++ b/packages/apps/plugins/plugin-github/package.json
@@ -19,7 +19,6 @@
     "@dxos/aurora-composer": "workspace:*",
     "@dxos/local-storage": "workspace:*",
     "@dxos/log": "workspace:*",
-    "@dxos/react-appkit": "workspace:*",
     "@dxos/react-client": "workspace:*",
     "dompurify": "^3.0.3",
     "github-markdown-css": "^5.2.0",

--- a/packages/apps/plugins/plugin-github/tsconfig.json
+++ b/packages/apps/plugins/plugin-github/tsconfig.json
@@ -42,9 +42,6 @@
       "path": "../../../ui/aurora-theme"
     },
     {
-      "path": "../../../ui/react-appkit"
-    },
-    {
       "path": "../../types"
     },
     {

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -166,6 +166,20 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
           });
         }).unsubscribe,
       );
+
+      handleKeyDown = (event) => {
+        const modifier = event.ctrlKey || event.metaKey;
+        if (event.key === '>' && event.shiftKey && modifier) {
+          void client.shell.open();
+        } else if (event.key === '.' && modifier) {
+          const spaceKey = state.active?.key as PublicKey;
+          console.log({ spaceKey: spaceKey?.truncate() });
+          if (spaceKey) {
+            void client.shell.shareSpace({ spaceKey });
+          }
+        }
+      };
+      window.addEventListener('keydown', handleKeyDown);
     },
     unload: async () => {
       graphSubscriptions.clear();
@@ -250,6 +264,7 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
             label: ['shared spaces label', { ns: SPACE_PLUGIN }],
             properties: {
               palette: 'pink', // TODO(burdon): Change palette.
+              'data-testid': 'spacePlugin.allSpaces',
               acceptPersistenceClass: new Set(['appState']),
               childrenPersistenceClass: 'appState',
               onRearrangeChild: (child: Graph.Node<Space>, nextIndex: string) => {
@@ -286,7 +301,7 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
               icon: (props) => <Planet {...props} />,
               properties: {
                 disposition: 'toolbar',
-                testId: 'spacePlugin.spaces.create',
+                testId: 'spacePlugin.createSpace',
               },
               intent: {
                 plugin: SPACE_PLUGIN,
@@ -421,7 +436,6 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
               const splitViewPlugin = findPlugin<SplitViewProvides>(plugins, 'dxos.org/plugin/splitview');
               const object =
                 typeof intent.data.objectId === 'string' ? space?.db.getObjectById(intent.data.objectId) : null;
-              // console.log('[space rename object]', object, splitViewPlugin?.provides.splitView);
               if (object && splitViewPlugin?.provides.splitView) {
                 splitViewPlugin.provides.splitView.popoverOpen = true;
                 splitViewPlugin.provides.splitView.popoverContent = [

--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -60,6 +60,7 @@ export const spaceToGraphNode = (
     data: space,
     properties: {
       palette: parent.id === 'root' ? 'teal' : undefined,
+      'data-testid': parent.id === 'root' ? 'spacePlugin.personalSpace' : 'spacePlugin.space',
       role: 'branch',
       hidden: inactive,
       disabled,

--- a/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTreeItem.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTreeItem.tsx
@@ -113,6 +113,7 @@ export const NavTreeItem: ForwardRefExoticComponent<TreeViewItemProps & RefAttri
     const disabled = !!(node.properties?.disabled ?? node.properties?.isPreview);
     const forceCollapse = isOverlay || isPreview || rearranging || disabled;
     const active = treeViewActive === node.id;
+    const testId = node.properties?.['data-testid'];
 
     useEffect(() => {
       if (treeViewActive && graph.getPath(treeViewActive)?.includes(node.id)) {
@@ -168,6 +169,7 @@ export const NavTreeItem: ForwardRefExoticComponent<TreeViewItemProps & RefAttri
             !isOverlay && (active || isPopoverAnchor) && 'bg-neutral-75 dark:bg-neutral-850',
             'flex items-start rounded',
           )}
+          data-testid={testId}
         >
           {isBranch ? (
             <CollapsibleHeading {...{ open, node, level, active }} />

--- a/packages/sdk/react-client/src/echo/useSpaces.ts
+++ b/packages/sdk/react-client/src/echo/useSpaces.ts
@@ -27,7 +27,13 @@ export const useSpace = (spaceKey?: PublicKeyLike): Space | undefined => {
   }
 
   if (identity) {
-    return client.spaces.default;
+    try {
+      return client.spaces.default;
+    } catch {
+      // TODO(wittjosiah): Shouldn't be necessary. If identity exists, the default space should exist.
+      //   Seems to throw in Shell during the identity creation process.
+      return undefined;
+    }
   }
 };
 

--- a/packages/sdk/react-shell/src/composites/Shell/Shell.tsx
+++ b/packages/sdk/react-shell/src/composites/Shell/Shell.tsx
@@ -21,8 +21,6 @@ export const Shell = ({ runtime, origin }: { runtime: ShellRuntime; origin: stri
 
   const space = useSpace(spaceKey);
 
-  console.log('Shell', { layout, invitationCode, spaceKey, space });
-
   useEffect(() => {
     return runtime.layoutUpdate.on((request) => setLayout(request));
   }, [runtime]);

--- a/packages/sdk/react-shell/src/composites/Shell/Shell.tsx
+++ b/packages/sdk/react-shell/src/composites/Shell/Shell.tsx
@@ -21,6 +21,8 @@ export const Shell = ({ runtime, origin }: { runtime: ShellRuntime; origin: stri
 
   const space = useSpace(spaceKey);
 
+  console.log('Shell', { layout, invitationCode, spaceKey, space });
+
   useEffect(() => {
     return runtime.layoutUpdate.on((request) => setLayout(request));
   }, [runtime]);

--- a/packages/sdk/vault/package.json
+++ b/packages/sdk/vault/package.json
@@ -39,6 +39,7 @@
     "@braneframe/plugin-telemetry": "workspace:*",
     "@dxos/async": "workspace:*",
     "@dxos/aurora": "workspace:*",
+    "@dxos/aurora-theme": "workspace:*",
     "@dxos/client": "workspace:*",
     "@dxos/client-protocol": "workspace:*",
     "@dxos/client-services": "workspace:*",

--- a/packages/sdk/vault/src/iframe.ts
+++ b/packages/sdk/vault/src/iframe.ts
@@ -3,6 +3,7 @@
 //
 
 import { Trigger } from '@dxos/async';
+import { Tooltip } from '@dxos/aurora';
 import { Client, Config, Defaults, Dynamics, Local } from '@dxos/client';
 import { DEFAULT_INTERNAL_CHANNEL } from '@dxos/client-protocol';
 import type { IFrameHostRuntime, IFrameProxyRuntime } from '@dxos/client-services';
@@ -19,6 +20,7 @@ const startShell = async (config: Config, runtime: ShellRuntime, services: Clien
   const { createRoot } = await import('react-dom/client');
   const { registerSignalFactory } = await import('@dxos/echo-signals/react');
   const { ThemeProvider } = await import('@dxos/aurora');
+  const { auroraTx } = await import('@dxos/aurora-theme');
   const { ClientContext } = await import('@dxos/react-client');
   const { osTranslations, Shell } = await import('@dxos/react-shell');
 
@@ -33,9 +35,17 @@ const startShell = async (config: Config, runtime: ShellRuntime, services: Clien
       {},
       createElement(
         ThemeProvider,
-        { resourceExtensions: [osTranslations] },
-        // NOTE: Using context provider directly to avoid duplicate banners being logged.
-        createElement(ClientContext.Provider, { value: { client } }, createElement(Shell, { runtime, origin })),
+        { tx: auroraTx, resourceExtensions: [osTranslations] },
+        createElement(Tooltip.Provider, {
+          delayDuration: 100,
+          skipDelayDuration: 400,
+          children: createElement(
+            // NOTE: Using context provider directly to avoid duplicate banners being logged.
+            ClientContext.Provider,
+            { value: { client } },
+            createElement(Shell, { runtime, origin }),
+          ),
+        }),
       ),
     ),
   );

--- a/packages/sdk/vault/tsconfig.json
+++ b/packages/sdk/vault/tsconfig.json
@@ -50,6 +50,9 @@
       "path": "../../ui/aurora-theme"
     },
     {
+      "path": "../../ui/aurora-theme"
+    },
+    {
       "path": "../client"
     },
     {

--- a/packages/ui/primitives/react-list/src/ListItem.tsx
+++ b/packages/ui/primitives/react-list/src/ListItem.tsx
@@ -95,6 +95,7 @@ const ListItem = forwardRef<ListItemElement, ListItemProps>(
       defaultOpen,
       onOpenChange,
       collapsible,
+      labelId,
       ...listItemProps
     } = props;
     const { selectable } = useListContext(LIST_NAME, __listScope);
@@ -111,7 +112,7 @@ const ListItem = forwardRef<ListItemElement, ListItemProps>(
       onChange: onOpenChange,
     });
 
-    const headingId = useId('listItem__heading', props.labelId);
+    const headingId = useId('listItem__heading', labelId);
 
     const listItem = (
       <Primitive.li

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -851,7 +851,6 @@ importers:
       '@dxos/aurora-theme': workspace:*
       '@dxos/local-storage': workspace:*
       '@dxos/log': workspace:*
-      '@dxos/react-appkit': workspace:*
       '@dxos/react-client': workspace:*
       '@dxos/react-surface': workspace:*
       '@phosphor-icons/react': ^2.0.5
@@ -873,7 +872,6 @@ importers:
       '@dxos/aurora-composer': link:../../../ui/aurora-composer
       '@dxos/local-storage': link:../../../common/local-storage
       '@dxos/log': link:../../../common/log
-      '@dxos/react-appkit': link:../../../ui/react-appkit
       '@dxos/react-client': link:../../../sdk/react-client
       dompurify: 3.0.3
       github-markdown-css: 5.2.0
@@ -5717,6 +5715,7 @@ importers:
       '@braneframe/plugin-telemetry': link:../../apps/plugins/plugin-telemetry
       '@dxos/async': link:../../common/async
       '@dxos/aurora': link:../../ui/aurora
+      '@dxos/aurora-theme': link:../../ui/aurora-theme
       '@dxos/client': link:../client
       '@dxos/client-protocol': link:../client-protocol
       '@dxos/client-services': link:../client-services
@@ -5740,7 +5739,6 @@ importers:
       url-join: 5.0.0
       yargs: 16.2.0
     devDependencies:
-      '@dxos/aurora-theme': link:../../ui/aurora-theme
       '@sentry/vite-plugin': 0.7.2
       '@types/lodash.defaultsdeep': 4.6.7
       '@types/node': 18.11.9
@@ -10753,6 +10751,7 @@ packages:
     dependencies:
       '@nx/cypress': 16.5.4_77fo5nn477ty7cywkqdedkrxey
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - cypress
@@ -10780,6 +10779,7 @@ packages:
       '@nx/eslint-plugin': 16.5.4_2b57dwhe6e7ogoa22cr2cay3k4
       '@typescript-eslint/parser': 6.5.0_walxjw3fmezupdd3r2qqbe42z4
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -10796,6 +10796,7 @@ packages:
     dependencies:
       '@nx/jest': 16.5.4_ebxsb5ytaojlvyq6j3l6ecuzii
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@types/node'
@@ -10813,6 +10814,7 @@ packages:
     dependencies:
       '@nx/js': 16.5.4_st3ukm3rnd3xadn2fxesh4boby_eoiemzzyseqzjynwznlrcdpipu
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -10827,6 +10829,7 @@ packages:
     dependencies:
       '@nx/linter': 16.5.4_77fo5nn477ty7cywkqdedkrxey
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -10850,6 +10853,7 @@ packages:
     dependencies:
       '@nx/storybook': 16.5.4_77fo5nn477ty7cywkqdedkrxey
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - cypress
@@ -10877,6 +10881,7 @@ packages:
     dependencies:
       '@nx/vite': 16.5.4_xxzhsuqrsbs6wyvhvm37cpe46m_qgit66yh2vyynsv7uxdneek4qa
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -10892,6 +10897,7 @@ packages:
     dependencies:
       '@nx/web': 16.5.4_eoiemzzyseqzjynwznlrcdpipu
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -10928,6 +10934,7 @@ packages:
       dotenv: 10.0.0
       semver: 7.5.3
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -10972,6 +10979,7 @@ packages:
       jsonc-eslint-parser: 2.3.0
       semver: 7.5.3
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11000,6 +11008,7 @@ packages:
       resolve.exports: 1.1.0
       tslib: 2.6.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@types/node'
@@ -11033,7 +11042,7 @@ packages:
       '@phenomnomnominal/tsquery': 5.0.1_typescript@5.2.2
       babel-plugin-const-enum: 1.2.0_@babel+core@7.21.3
       babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2
+      babel-plugin-transform-typescript-metadata: 0.3.2_@babel+core@7.21.3
       chalk: 4.1.2
       detect-port: 1.5.1
       fast-glob: 3.2.7
@@ -11045,6 +11054,7 @@ packages:
       source-map-support: 0.5.19
       tslib: 2.6.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11070,6 +11080,7 @@ packages:
       tmp: 0.2.1
       tslib: 2.6.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11182,6 +11193,7 @@ packages:
       dotenv: 10.0.0
       semver: 7.5.3
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - cypress
@@ -11207,6 +11219,7 @@ packages:
       enquirer: 2.3.6
       vite: 4.3.9_@types+node@18.11.9
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11230,6 +11243,7 @@ packages:
       ignore: 5.2.4
       tslib: 2.6.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -19037,7 +19051,7 @@ packages:
   /axios/1.3.4_debug@4.3.4:
     resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2_debug@4.3.4
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -19206,9 +19220,16 @@ packages:
   /babel-plugin-syntax-jsx/6.18.0:
     resolution: {integrity: sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==}
 
-  /babel-plugin-transform-typescript-metadata/0.3.2:
+  /babel-plugin-transform-typescript-metadata/0.3.2_@babel+core@7.21.3:
     resolution: {integrity: sha512-mWEvCQTgXQf48yDqgN7CH50waTyYBeP2Lpqx4nNWab9sxEpdXVeKgfj1qYI2/TgUPQtNFZ85i3PemRtnXVYYJg==}
+    peerDependencies:
+      '@babel/core': ^7
+      '@babel/traverse': ^7
+    peerDependenciesMeta:
+      '@babel/traverse':
+        optional: true
     dependencies:
+      '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -24394,6 +24415,18 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  /follow-redirects/1.15.2_debug@4.3.4:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+    dev: true
 
   /fontkit/2.0.2:
     resolution: {integrity: sha512-jc4k5Yr8iov8QfS6u8w2CnHWVmbOGtdBtOXMze5Y+QD966Rx6PEVWXSEGwXlsDlKtu1G12cJjcsybnqhSk/+LA==}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 28d03fb</samp>

### Summary
📝🚀🎨

<!--
1.  📝 - This emoji can represent the changes related to the schema.proto file, the test ids, the assertions and expectations, and the console log statement. These changes are mostly about writing or editing code or documentation.
2.  🚀 - This emoji can represent the changes related to the vite configuration, the dependencies, the path aliases, and the keyboard shortcuts. These changes are mostly about improving the performance, functionality, or user experience of the code sandbox or the composer app.
3.  🎨 - This emoji can represent the changes related to the aurora theme, the tooltip component, and the type safety. These changes are mostly about enhancing the appearance, design, or quality of the vault package or the LocalFile type.
-->
This pull request introduces several changes to the composer app, the space, files, and github plugins, and the vault package. The main goals are to improve the playwright test reliability, the type safety, the UI consistency, and the vite configuration. Some of the changes involve removing the dependency on `@dxos/react-appkit`, using the `@dxos/aurora` theme and components, and adding test ids and keyboard shortcuts.

> _The pull request had many changes to make_
> _Some were for testing, some for code's sake_
> _It used `aurora-theme`_
> _And fixed the `schema.proto` scheme_
> _And added shortcuts for the space plugin's sake_

### Walkthrough
*  Simplified the code sandbox setup and used a fixed schema.proto file instead of a dynamic one in `Showcase.vue` ([link](https://github.com/dxos/dxos/pull/4214/files?diff=unified&w=0#diff-6e10a40fd53dead6de43a5b144e8c84643bf9fa14c6b0897587ac549ea9187aeL133-R133)).


