### PR TITLE
fix: simplepeer transport error cleanup

### DIFF
--- a/packages/core/mesh/network-manager/src/transport/simplepeer-transport.ts
+++ b/packages/core/mesh/network-manager/src/transport/simplepeer-transport.ts
@@ -72,12 +72,9 @@ export class SimplePeerTransport implements Transport {
         } else {
           this.errors.raise(new UnknownProtocolError('unknown RTCError', err));
         }
-
-        // Safari specific? are all errors of code: "DATA_CHANNEL_ERROR" connection aborts?
-      } else if (err.name === 'InvalidStateError') {
-        this.errors.raise(new ConnectionResetError('safari WebRTC error', err));
         // catch more generic simple-peer errors: https://github.com/feross/simple-peer/blob/master/README.md#error-codes
       } else if ('code' in err) {
+        log.info('simple-peer error', err);
         switch (err.code) {
           case 'ERR_WEBRTC_SUPPORT':
             this.errors.raise(new ProtocolError('WebRTC not supported', err));
@@ -96,6 +93,7 @@ export class SimplePeerTransport implements Transport {
             this.errors.raise(new Error('unknown simple-peer error'));
         }
       } else {
+        log.info('unknown peer connection error', err);
         this.errors.raise(err);
       }
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1482ec3</samp>

### Summary
🐛📝🚧

<!--
1.  🐛 - This emoji represents a bug fix, since the pull request is addressing peer connection errors that were previously unhandled or not logged properly.
2.  📝 - This emoji represents documentation, since the pull request is adding more logging messages that can help developers understand and debug the peer connection issues.
3.  🚧 - This emoji represents work in progress, since the pull request is not a complete solution for all possible peer connection errors, and may require further testing and refinement.
-->
Improved error logging for `simple-peer-transport.ts`. Added simple-peer error code and message, and handled unknown errors.

> _We face the doom of peer connection errors_
> _We need to log the simple-peer code and message_
> _We don't know what lurks in the unknown errors_
> _We debug with fire and rage_

### Walkthrough
*  Log simple-peer errors and unknown errors during peer connection ([link](https://github.com/dxos/dxos/pull/4216/files?diff=unified&w=0#diff-cc0cc165bd94f178c1fbbe6ee98250b3db509cacbd5038db986be7b63c3c894eL75-R77), [link](https://github.com/dxos/dxos/pull/4216/files?diff=unified&w=0#diff-cc0cc165bd94f178c1fbbe6ee98250b3db509cacbd5038db986be7b63c3c894eR96)) in `simplepeer-transport.ts`. This improves the debugging and visibility of the errors that occur when using the simple-peer library to establish WebRTC connections between peers in the mesh network.


