### PR TITLE
feat: Remove eslint toolbox script

### DIFF
--- a/tools/executors/toolbox/src/toolbox.ts
+++ b/tools/executors/toolbox/src/toolbox.ts
@@ -282,25 +282,6 @@ class Toolbox {
     }
   }
 
-  async updateEslintConfig() {
-    for (const project of this.projects) {
-      if (['.eslintrc.json', '.eslintrc.js'].some((file) => fs.existsSync(join(project.path, file)))) {
-        continue;
-      }
-
-      await saveJson(
-        join(project.path, '.eslintrc.json'),
-        {
-          extends: [relative(project.path, join(this.rootDir, '.eslintrc.js'))],
-          parserOptions: {
-            project: relative(this.rootDir, join(project.path, 'tsconfig.json')),
-          },
-        },
-        this.options.verbose,
-      );
-    }
-  }
-
   _getProjectByPackageName(name: string): Project {
     return this.projects.find((project) => project.name === name) ?? raise(new Error(`Package not found: ${name}`));
   }
@@ -318,7 +299,6 @@ const run = async () => {
   await toolbox.updateProjects();
   await toolbox.updatePackages();
   await toolbox.updateTsConfig();
-  await toolbox.updateEslintConfig();
 };
 
 void run();


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6f02b82</samp>

### Summary
:wastebasket::recycle::sparkles:

<!--
1.  :wastebasket: - This emoji represents the removal of the `updateEslintConfig` method and its usage, which is no longer needed.
2.  :recycle: - This emoji represents the refactoring of the linting configuration to use a single `.eslintrc.js` file, which simplifies and reuses the existing settings.
3.  :sparkles: - This emoji represents the improvement of the linting experience by using a consistent and unified configuration across the project.
-->
This pull request simplifies the linting setup by deleting the `updateEslintConfig` method and removing its calls from `toolbox.ts`. This way, all the tools use the same `.eslintrc.js` file in the root directory.

> _No more `updateEslintConfig`, no more chaos in the code_
> _We follow one rule, one `.eslintrc.js` to guide us all_
> _We streamline our linting, we purge the errors and the bugs_
> _We write clean and consistent code, we are the masters of the code_

### Walkthrough
*  Remove `updateEslintConfig` method from `Toolbox` class and its invocation from `run` method ([link](https://github.com/dxos/dxos/pull/4225/files?diff=unified&w=0#diff-655a4ededf1ce76a5117a8354a67f795fd89c52d330eb1af6601a5a5e2e70e05L285-L303), [link](https://github.com/dxos/dxos/pull/4225/files?diff=unified&w=0#diff-655a4ededf1ce76a5117a8354a67f795fd89c52d330eb1af6601a5a5e2e70e05L321)). This simplifies the linting configuration and avoids conflicts with `eslint-plugin-import` and TypeScript project references. The linting rules are now defined in a single `.eslintrc.js` file in the root directory.


