### PR TITLE
feat(plugin-treeview): optional default action

### DIFF
--- a/packages/apps/plugins/plugin-files/src/components/LocalFileMain.tsx
+++ b/packages/apps/plugins/plugin-files/src/components/LocalFileMain.tsx
@@ -26,5 +26,10 @@ export const LocalFileMain: FC<{ data: LocalFile }> = ({ data }) => {
     [data.id, Boolean(data.text)],
   );
 
+  // TODO(wittjosiah): Render file list.
+  if ('children' in data) {
+    return null;
+  }
+
   return <Surface role='main' data={transformedData} />;
 };

--- a/packages/apps/plugins/plugin-files/src/util.tsx
+++ b/packages/apps/plugins/plugin-files/src/util.tsx
@@ -128,7 +128,6 @@ const localDirectoryToGraphNode = (directory: LocalDirectory, index: string, par
     data: directory,
     properties: {
       index,
-      disabled: directory.permission !== 'granted',
     },
   });
 
@@ -143,7 +142,7 @@ const localDirectoryToGraphNode = (directory: LocalDirectory, index: string, par
         data: { id: directory.id },
       },
       properties: {
-        disposition: 'toolbar',
+        disposition: 'default',
       },
     });
   }
@@ -173,7 +172,6 @@ const localFileToGraphNode = (file: LocalFile, index: string, parent: Graph.Node
     data: file,
     properties: {
       index,
-      disabled: file.permission !== 'granted',
       modified: file.modified,
     },
   });
@@ -200,7 +198,7 @@ const localFileToGraphNode = (file: LocalFile, index: string, parent: Graph.Node
         data: { id: file.id },
       },
       properties: {
-        disposition: 'toolbar',
+        disposition: 'default',
       },
     });
   }

--- a/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTreeItemHeading.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTreeItemHeading.tsx
@@ -32,6 +32,19 @@ export const NavTreeItemHeading = forwardRef<HTMLButtonElement, SharedTreeItemHe
     const error = !!node.properties?.error;
     const modified = node.properties?.modified ?? false;
     const OpenTriggerIcon = open ? CaretDown : CaretRight;
+    const defaultAction = node.actions.find((action) => action.properties.disposition === 'default');
+
+    const handleSelect = async () => {
+      await sendIntent({
+        plugin: TREE_VIEW_PLUGIN,
+        action: TreeViewAction.ACTIVATE,
+        data: {
+          id: node.id,
+        },
+      });
+      void defaultAction?.invoke();
+      !isLg && closeNavigationSidebar();
+    };
 
     return (
       <div
@@ -69,27 +82,10 @@ export const NavTreeItemHeading = forwardRef<HTMLButtonElement, SharedTreeItemHe
             onKeyDown={async (event) => {
               if (event.key === ' ' || event.key === 'Enter') {
                 event.stopPropagation();
-
-                await sendIntent({
-                  plugin: TREE_VIEW_PLUGIN,
-                  action: TreeViewAction.ACTIVATE,
-                  data: {
-                    id: node.id,
-                  },
-                });
-                !isLg && closeNavigationSidebar();
+                void handleSelect();
               }
             }}
-            onClick={async () => {
-              await sendIntent({
-                plugin: TREE_VIEW_PLUGIN,
-                action: TreeViewAction.ACTIVATE,
-                data: {
-                  id: node.id,
-                },
-              });
-              !isLg && closeNavigationSidebar();
-            }}
+            onClick={handleSelect}
             density='fine'
             variant='ghost'
             classNames={['grow gap-1', isBranch && '-mis-6']}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6e181ff</samp>

### Summary
📁🗃️🖱️

<!--
1.  📁 - This emoji represents a folder or a directory, and can be used to indicate the conditional rendering logic for the local file system data.
2.  🗃️ - This emoji represents a file cabinet or a storage unit, and can be used to indicate the simplification of the UI and logic for the file explorer app.
3.  🖱️ - This emoji represents a mouse or a pointer, and can be used to indicate the improvement of the user experience and the code quality of the tree node selection feature.
-->
This pull request improves the file explorer app by using the native file system API, simplifying the UI and logic of the file actions, and adding a selection feature to the tree view. It also prepares the app for displaying the local file list component.

> _`LocalFileMain` hides_
> _directories for now - wait_
> _for file list soon_

### Walkthrough
*  Add conditional rendering logic to `LocalFileMain` component to return null for directories ([link](https://github.com/dxos/dxos/pull/4228/files?diff=unified&w=0#diff-5350ef65ab51f92974b9ac33af65f334d6aac49a688fd20cf9d6e201b7676195R29-R33))
*  Remove `disabled` property from `localDirectoryToGraphNode` and `localFileToGraphNode` functions, as it is no longer needed with the native file system API ([link](https://github.com/dxos/dxos/pull/4228/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL131), [link](https://github.com/dxos/dxos/pull/4228/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL176))
*  Change `disposition` property of `open` action to `default` for both directories and files, to allow opening them by clicking on the node ([link](https://github.com/dxos/dxos/pull/4228/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL146-R145), [link](https://github.com/dxos/dxos/pull/4228/files?diff=unified&w=0#diff-6beceef5ad0210f48b96b8322eb500f1ac3042decf53921b30c3717c6cf763cdL203-R201))
*  Add `defaultAction` variable and `handleSelect` function to `NavTreeItemHeading` component, to invoke the default action and close the sidebar when a node is selected ([link](https://github.com/dxos/dxos/pull/4228/files?diff=unified&w=0#diff-a6a367b130bafe13d6c4c1edfbe3bd2c0e82edba1498ef1ce78ce68eefc3686eL35-R48))
*  Simplify `onClick` and `onKeyDown` handlers of the node element in `NavTreeItemHeading` component, by using `handleSelect` function ([link](https://github.com/dxos/dxos/pull/4228/files?diff=unified&w=0#diff-a6a367b130bafe13d6c4c1edfbe3bd2c0e82edba1498ef1ce78ce68eefc3686eL72-R88))


