### PR TITLE
fix: ignore errors sent to closed transport

### DIFF
--- a/packages/core/mesh/network-manager/src/transport/simplepeer-transport-service.ts
+++ b/packages/core/mesh/network-manager/src/transport/simplepeer-transport-service.ts
@@ -115,7 +115,7 @@ export class SimplePeerTransportService implements BridgeService {
 
   async sendData({ proxyId, payload }: DataRequest): Promise<void> {
     if (this.transports.get(proxyId)?.state !== 'OPEN') {
-      log.warn('transport is closed');
+      log.debug('transport is closed');
     }
     invariant(this.transports.has(proxyId));
     const state = this.transports.get(proxyId)!;

--- a/packages/core/mesh/network-manager/src/transport/simplepeer-transport-service.ts
+++ b/packages/core/mesh/network-manager/src/transport/simplepeer-transport-service.ts
@@ -25,6 +25,7 @@ type TransportState = {
   transport: SimplePeerTransport;
   stream: Duplex;
   writeCallbacks: (() => void)[];
+  state: 'OPEN' | 'CLOSED';
 };
 
 export class SimplePeerTransportService implements BridgeService {
@@ -96,6 +97,7 @@ export class SimplePeerTransportService implements BridgeService {
         transport,
         stream: duplex,
         writeCallbacks: [],
+        state: 'OPEN',
       };
 
       ready();
@@ -112,6 +114,9 @@ export class SimplePeerTransportService implements BridgeService {
   }
 
   async sendData({ proxyId, payload }: DataRequest): Promise<void> {
+    if (this.transports.get(proxyId)?.state !== 'OPEN') {
+      log.warn('transport is closed');
+    }
     invariant(this.transports.has(proxyId));
     const state = this.transports.get(proxyId)!;
     const bufferHasSpace = state.stream.push(payload);
@@ -125,7 +130,9 @@ export class SimplePeerTransportService implements BridgeService {
   async close({ proxyId }: CloseRequest) {
     await this.transports.get(proxyId)?.transport.destroy();
     await this.transports.get(proxyId)?.stream.end();
-    this.transports.delete(proxyId);
+    if (this.transports.get(proxyId)) {
+      this.transports.get(proxyId)!.state = 'CLOSED';
+    }
     log('Closed.');
   }
 }


### PR DESCRIPTION
closes https://github.com/dxos/dxos/issues/4006

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 465cd7a</samp>

### Summary
🔌🛡️🔄

<!--
1.  🔌 - This emoji represents the concept of connections or plugs, and can be used to indicate the addition of a `state` property to the `TransportState` type.
2.  🛡️ - This emoji represents the concept of protection or security, and can be used to indicate the use of the `state` property to verify the status of peer-to-peer connections and prevent errors or attacks.
3.  🔄 - This emoji represents the concept of updating or refreshing, and can be used to indicate the use of the `state` property to reflect the actual state of the network and the connections.
-->
This pull request improves the reliability of peer-to-peer communication in the `SimplePeerTransportService` by adding and checking a `state` property for each connection. This prevents errors and inconsistencies caused by closed or invalid connections.

> _Oh we are the coders of the `SimplePeerTransportService`_
> _And we keep our connections in a `state` of readiness_
> _We don't send our messages over broken links_
> _So haul away and pull the code, me hearties, one, two, three!_

### Walkthrough
*  Add `state` property to `TransportState` type to track connection status ([link](https://github.com/dxos/dxos/pull/4232/files?diff=unified&w=0#diff-3e1d9e03a56df222e806ec0ed5e7094e73277a4c46497659b8f06959cdecd39dR28)).


