### PR TITLE
fix: ignore offer if connection not initial

### DIFF
--- a/packages/core/mesh/network-manager/src/swarm/peer.ts
+++ b/packages/core/mesh/network-manager/src/swarm/peer.ts
@@ -108,6 +108,10 @@ export class Peer {
   async onOffer(message: OfferMessage): Promise<Answer> {
     const remoteId = message.author;
 
+    if (this.connection && this.connection.state !== ConnectionState.INITIAL) {
+      log.info(`received offer when connection already in ${this.connection.state} state`);
+      return { accept: false };
+    }
     // Check if we are already trying to connect to that peer.
     if (this.connection || this.initiating) {
       // Peer with the highest Id closes its connection, and accepts remote peer's offer.

--- a/packages/core/mesh/network-manager/src/swarm/peer.ts
+++ b/packages/core/mesh/network-manager/src/swarm/peer.ts
@@ -108,7 +108,7 @@ export class Peer {
   async onOffer(message: OfferMessage): Promise<Answer> {
     const remoteId = message.author;
 
-    if (this.connection && this.connection.state !== ConnectionState.INITIAL) {
+    if (this.connection && ![ConnectionState.CREATED, ConnectionState.INITIAL].includes(this.connection.state)) {
       log.info(`received offer when connection already in ${this.connection.state} state`);
       return { accept: false };
     }


### PR DESCRIPTION
This should avoid the misleading "Connection displaced by remote initiator." errors from closed/aborted connections.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 000bbb7</samp>

### Summary
🚫📞🔄

<!--
1.  🚫 - This emoji conveys the idea of rejection or denial, which is what the peer does when it receives an offer while already having a connection or being busy with another offer.
2.  📞 - This emoji represents a phone call or a connection, which is the main subject of the change. It also suggests that the peer can only handle one connection at a time, and that it needs to hang up before accepting another offer.
3.  🔄 - This emoji signifies a cycle or a process, which is what the peer's state indicates. It also implies that the peer needs to finish its current process before starting a new one, and that the process can change depending on the offer.
-->
Prevent multiple connection offers from interfering with peer state. Add a condition to `handleOffer` in `peer.ts` to reject offers if the peer is already busy.

> _`handleOffer` checks_
> _if peer is busy or not_
> _rejects in autumn_

### Walkthrough
*  Add condition to reject connection offers if peer is busy ([link](https://github.com/dxos/dxos/pull/4233/files?diff=unified&w=0#diff-47bc81126b7b4f9732f7ae901368cd7eeada3d95eb37e7e693e1a1b3388be355R111-R114))


