### PR TITLE
fix: downgrade RpcClosedError severity for gossip

### DIFF
--- a/packages/core/mesh/teleport-extension-gossip/src/gossip.ts
+++ b/packages/core/mesh/teleport-extension-gossip/src/gossip.ts
@@ -111,7 +111,7 @@ export class Gossip {
         .catch(async (err) => {
           // TODO(nf): handle here or in the Extension?
           if (err instanceof RpcClosedError) {
-            log.warn('sendAnnounce failed because of RpcClosedError', { err });
+            log('sendAnnounce failed because of RpcClosedError', { err });
           } else {
             log.catch(err);
           }

--- a/packages/core/mesh/teleport-extension-gossip/src/gossip.ts
+++ b/packages/core/mesh/teleport-extension-gossip/src/gossip.ts
@@ -109,7 +109,6 @@ export class Gossip {
         })
 
         .catch(async (err) => {
-          // TODO(nf): handle here or in the Extension?
           if (err instanceof RpcClosedError) {
             log('sendAnnounce failed because of RpcClosedError', { err });
           } else {

--- a/packages/core/mesh/teleport-extension-gossip/src/gossip.ts
+++ b/packages/core/mesh/teleport-extension-gossip/src/gossip.ts
@@ -6,6 +6,7 @@ import { scheduleTask, Event, scheduleTaskInterval } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
+import { RpcClosedError } from '@dxos/protocols';
 import { GossipMessage } from '@dxos/protocols/proto/dxos/mesh/teleport/gossip';
 import { ComplexMap, ComplexSet } from '@dxos/util';
 
@@ -108,7 +109,12 @@ export class Gossip {
         })
 
         .catch(async (err) => {
-          log.catch(err);
+          // TODO(nf): handle here or in the Extension?
+          if (err instanceof RpcClosedError) {
+            log.warn('sendAnnounce failed because of RpcClosedError', { err });
+          } else {
+            log.catch(err);
+          }
         });
     }
   }


### PR DESCRIPTION
should help with https://github.com/dxos/dxos/issues/4226

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 67fc0a3</samp>

### Summary
📦🛠️🙌

<!--
1.  📦 This emoji represents importing or adding a new dependency or module, which is what we did with `RpcClosedError`.
2.  🛠️ This emoji represents fixing or improving something, which is what we did with the error handling logic in `sendAnnounce`.
3.  🙌 This emoji represents achieving a goal or overcoming a challenge, which is what we did by making the `Gossip` class more robust and resilient.
-->
Improved error handling for `Gossip` class in `teleport-extension-gossip` package. Used `RpcClosedError` to detect and handle RPC channel closures in `sendAnnounce` method.

> _`RpcClosedError`_
> _Gives `Gossip` more resilience_
> _Autumn leaves falling_

### Walkthrough
* Import `RpcClosedError` class from `@dxos/protocols` package to handle RPC channel closure errors ([link](https://github.com/dxos/dxos/pull/4234/files?diff=unified&w=0#diff-8c0d22e91ef78cf597ee52fe4f8f36f1608d2baad932a27bf9d7f097e805101aR13)).


