### PR TITLE
feat: Anfang tool daemonizer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
     }
   ],
   "cSpell.words": [
+    "anfang",
     "bitfield",
     "burdon",
     "dxos",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@dxos/anfang": "workspace:*",
     "@dxos/async": "workspace:*",
     "@dxos/beast": "workspace:*",
     "@dxos/client": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,7 @@ importers:
 
   .:
     specifiers:
+      '@dxos/anfang': workspace:*
       '@dxos/async': workspace:*
       '@dxos/beast': workspace:*
       '@dxos/client': workspace:*
@@ -130,6 +131,7 @@ importers:
       execa: 5.1.1
       tslib: 2.6.0
     devDependencies:
+      '@dxos/anfang': link:tools/anfang
       '@dxos/async': link:packages/common/async
       '@dxos/beast': link:tools/beast
       '@dxos/client': link:packages/sdk/client
@@ -332,7 +334,7 @@ importers:
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
       vuepress-plugin-check-md: 0.0.3
-      vuepress-theme-hope: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-theme-hope: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
 
   packages/apps/composer-app:
     specifiers:
@@ -406,7 +408,7 @@ importers:
       '@types/react-dom': 18.0.6
       '@vitejs/plugin-react': 3.1.0_vite@4.3.9
       vite: 4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/apps/composer-extension:
@@ -420,7 +422,7 @@ importers:
       '@types/webextension-polyfill': 0.10.0
       typescript: 5.2.2
       vite: 4.3.9
-      vite-plugin-web-extension: 3.0.7
+      vite-plugin-web-extension: 3.0.7_vite@4.3.9
       webextension-polyfill: 0.10.0
 
   packages/apps/halo-app:
@@ -473,7 +475,7 @@ importers:
       '@vitejs/plugin-react': 3.1.0_vite@4.3.9
       typescript: 5.2.2
       vite: 4.3.9_@types+node@18.11.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/apps/labs-app:
@@ -572,7 +574,7 @@ importers:
       '@vitejs/plugin-react': 3.1.0_vite@4.3.9
       vite: 4.3.9
       vite-plugin-mkcert: 1.16.0_vite@4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/apps/plugins/plugin-chess:
@@ -3602,7 +3604,7 @@ importers:
       typescript: 5.2.2
       vite: 4.3.9
       vite-plugin-fonts: 0.7.0_vite@4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/devtools/devtools-extension:
@@ -4007,7 +4009,7 @@ importers:
       vite-plugin-fonts: 0.7.0_vite@4.3.9
       vite-plugin-inspect: 0.7.15_vite@4.3.9
       vite-plugin-mkcert: 1.16.0_vite@4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/experimental/kai-bots:
@@ -4240,7 +4242,7 @@ importers:
       vite: 4.3.9
       vite-plugin-fonts: 0.7.0_vite@4.3.9
       vite-plugin-inspect: 0.7.15_vite@4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/experimental/kai-framework:
@@ -4405,7 +4407,7 @@ importers:
       vite-plugin-fonts: 0.7.0_vite@4.3.9
       vite-plugin-inspect: 0.7.15_vite@4.3.9
       vite-plugin-mkcert: 1.16.0_vite@4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/experimental/kai-functions:
@@ -4944,7 +4946,7 @@ importers:
       vite: 4.3.9
       vite-plugin-fonts: 0.7.0_vite@4.3.9
       vite-plugin-inspect: 0.7.15_vite@4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/experimental/plexus:
@@ -5013,7 +5015,7 @@ importers:
       vite: 4.3.9
       vite-plugin-fonts: 0.7.0_vite@4.3.9
       vite-plugin-inspect: 0.7.15_vite@4.3.9
-      vite-plugin-pwa: 0.14.1_vite@4.3.9
+      vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
   packages/experimental/react-metagraph:
@@ -5893,11 +5895,11 @@ importers:
       y-protocols: ^1.0.5
       yjs: ^13.6.7
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/commands': 6.2.2
       '@codemirror/lang-markdown': 6.1.0
       '@codemirror/language': 6.6.0
-      '@codemirror/language-data': 6.1.0
+      '@codemirror/language-data': 6.1.0_252h5dwvsiu2pnu2vr7ql3rya4
       '@codemirror/lint': 6.2.0
       '@codemirror/search': 6.3.0
       '@codemirror/state': 6.2.0
@@ -5926,7 +5928,7 @@ importers:
       '@tiptap/pm': 2.0.0-beta.220_7w7m52asdh3tod4ocz57yex63q
       '@tiptap/react': 2.0.0-beta.220_xig6hpp4glylmgjqbtp4uwsv5e
       '@tiptap/starter-kit': 2.0.0-beta.220_@tiptap+pm@2.0.0-beta.220
-      codemirror: 6.0.1
+      codemirror: 6.0.1_@lezer+common@1.0.2
       lib0: 0.2.78
       lodash.get: 4.4.2
       prosemirror-model: 1.19.0
@@ -6254,6 +6256,18 @@ importers:
       '@storybook/theming': 7.0.7_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+
+  tools/anfang:
+    specifiers:
+      '@dxos/async': 0.1.56
+      '@dxos/invariant': 0.1.56
+      '@dxos/lock-file': 0.1.56
+      '@dxos/log': 0.1.56
+    dependencies:
+      '@dxos/async': 0.1.56
+      '@dxos/invariant': 0.1.56
+      '@dxos/lock-file': 0.1.56
+      '@dxos/log': 0.1.56
 
   tools/apidoc:
     specifiers:
@@ -9317,8 +9331,13 @@ packages:
       minimist: 1.2.8
     dev: true
 
-  /@codemirror/autocomplete/6.4.2:
+  /@codemirror/autocomplete/6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e:
     resolution: {integrity: sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==}
+    peerDependencies:
+      '@codemirror/language': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+      '@lezer/common': ^1.0.0
     dependencies:
       '@codemirror/language': 6.6.0
       '@codemirror/state': 6.2.0
@@ -9342,20 +9361,23 @@ packages:
       '@lezer/cpp': 1.1.0
     dev: false
 
-  /@codemirror/lang-css/6.1.1:
+  /@codemirror/lang-css/6.1.1_i3aqn63zftbgivbr4riltn5mqe:
     resolution: {integrity: sha512-P6jdNEHyRcqqDgbvHYyC9Wxkek0rnG3a9aVSRi4a7WrjPbQtBTaOmvYpXmm13zZMAatO4Oqpac+0QZs7sy+LnQ==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/language': 6.6.0
       '@codemirror/state': 6.2.0
       '@lezer/css': 1.1.1
+    transitivePeerDependencies:
+      - '@codemirror/view'
+      - '@lezer/common'
     dev: false
 
   /@codemirror/lang-html/6.4.2:
     resolution: {integrity: sha512-bqCBASkteKySwtIbiV/WCtGnn/khLRbbiV5TE+d9S9eQJD7BA4c5dTRm2b3bVmSpilff5EYxvB4PQaZzM/7cNw==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
-      '@codemirror/lang-css': 6.1.1
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
+      '@codemirror/lang-css': 6.1.1_i3aqn63zftbgivbr4riltn5mqe
       '@codemirror/lang-javascript': 6.1.4
       '@codemirror/language': 6.6.0
       '@codemirror/state': 6.2.0
@@ -9375,7 +9397,7 @@ packages:
   /@codemirror/lang-javascript/6.1.4:
     resolution: {integrity: sha512-OxLf7OfOZBTMRMi6BO/F72MNGmgOd9B0vetOLvHsDACFXayBzW8fm8aWnDM0yuy68wTK03MBf4HbjSBNRG5q7A==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/language': 6.6.0
       '@codemirror/lint': 6.2.0
       '@codemirror/state': 6.2.0
@@ -9412,12 +9434,16 @@ packages:
       '@lezer/php': 1.0.1
     dev: false
 
-  /@codemirror/lang-python/6.1.2:
+  /@codemirror/lang-python/6.1.2_252h5dwvsiu2pnu2vr7ql3rya4:
     resolution: {integrity: sha512-nbQfifLBZstpt6Oo4XxA2LOzlSp4b/7Bc5cmodG1R+Cs5PLLCTUvsMNWDnziiCfTOG/SW1rVzXq/GbIr6WXlcw==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/language': 6.6.0
       '@lezer/python': 1.1.2
+    transitivePeerDependencies:
+      - '@codemirror/state'
+      - '@codemirror/view'
+      - '@lezer/common'
     dev: false
 
   /@codemirror/lang-rust/6.0.1:
@@ -9427,14 +9453,17 @@ packages:
       '@lezer/rust': 1.0.0
     dev: false
 
-  /@codemirror/lang-sql/6.4.0:
+  /@codemirror/lang-sql/6.4.0_i3aqn63zftbgivbr4riltn5mqe:
     resolution: {integrity: sha512-UWGK1+zc9+JtkiT+XxHByp4N6VLgLvC2x0tIudrJG26gyNtn0hWOVoB0A8kh/NABPWkKl3tLWDYf2qOBJS9Zdw==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/language': 6.6.0
       '@codemirror/state': 6.2.0
       '@lezer/highlight': 1.1.3
       '@lezer/lr': 1.3.3
+    transitivePeerDependencies:
+      - '@codemirror/view'
+      - '@lezer/common'
     dev: false
 
   /@codemirror/lang-wast/6.0.1:
@@ -9445,34 +9474,40 @@ packages:
       '@lezer/lr': 1.3.3
     dev: false
 
-  /@codemirror/lang-xml/6.0.2:
+  /@codemirror/lang-xml/6.0.2_@codemirror+view@6.9.2:
     resolution: {integrity: sha512-JQYZjHL2LAfpiZI2/qZ/qzDuSqmGKMwyApYmEUUCTxLM4MWS7sATUEfIguZQr9Zjx/7gcdnewb039smF6nC2zw==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/language': 6.6.0
       '@codemirror/state': 6.2.0
       '@lezer/common': 1.0.2
       '@lezer/xml': 1.0.1
+    transitivePeerDependencies:
+      - '@codemirror/view'
     dev: false
 
-  /@codemirror/language-data/6.1.0:
+  /@codemirror/language-data/6.1.0_252h5dwvsiu2pnu2vr7ql3rya4:
     resolution: {integrity: sha512-g9V23fuLRI9AEbpM6bDy1oquqgpFlIDHTihUhL21NPmxp+x67ZJbsKk+V71W7/Bj8SCqEO1PtqQA/tDGgt1nfw==}
     dependencies:
       '@codemirror/lang-cpp': 6.0.2
-      '@codemirror/lang-css': 6.1.1
+      '@codemirror/lang-css': 6.1.1_i3aqn63zftbgivbr4riltn5mqe
       '@codemirror/lang-html': 6.4.2
       '@codemirror/lang-java': 6.0.1
       '@codemirror/lang-javascript': 6.1.4
       '@codemirror/lang-json': 6.0.1
       '@codemirror/lang-markdown': 6.1.0
       '@codemirror/lang-php': 6.0.1
-      '@codemirror/lang-python': 6.1.2
+      '@codemirror/lang-python': 6.1.2_252h5dwvsiu2pnu2vr7ql3rya4
       '@codemirror/lang-rust': 6.0.1
-      '@codemirror/lang-sql': 6.4.0
+      '@codemirror/lang-sql': 6.4.0_i3aqn63zftbgivbr4riltn5mqe
       '@codemirror/lang-wast': 6.0.1
-      '@codemirror/lang-xml': 6.0.2
+      '@codemirror/lang-xml': 6.0.2_@codemirror+view@6.9.2
       '@codemirror/language': 6.6.0
       '@codemirror/legacy-modes': 6.3.1
+    transitivePeerDependencies:
+      - '@codemirror/state'
+      - '@codemirror/view'
+      - '@lezer/common'
     dev: false
 
   /@codemirror/language/6.6.0:
@@ -9651,6 +9686,36 @@ packages:
       react: 18.2.0
       tslib: 2.6.0
 
+  /@dxos/async/0.1.56:
+    resolution: {integrity: sha512-Nader81JPBGoHam0a8tNjAnZN4ToN6Rb3BQJyCCz6nR2r3gEYkD6zMnrapeEFP6XgcKjiE70n9E2vBrkRG+YPg==}
+    dependencies:
+      '@dxos/context': 0.1.56
+      '@dxos/debug': 0.1.56
+      '@dxos/invariant': 0.1.56
+      '@dxos/node-std': 0.1.56
+      '@dxos/util': 0.1.56
+      zen-observable: 0.10.0
+      zen-push: 0.3.1
+    dev: false
+
+  /@dxos/context/0.1.56:
+    resolution: {integrity: sha512-JKEUwzhedi+BijH5Dl8SqvXfubNGx+jbm/k+0ljCzFm+vypr0oilmxUkusBVXfQlYa3G3+/cANTwD+Ex8MB2vA==}
+    dependencies:
+      '@dxos/errors': 0.1.56
+      '@dxos/log': 0.1.56
+      '@dxos/util': 0.1.56
+    dev: false
+
+  /@dxos/debug/0.1.56:
+    resolution: {integrity: sha512-MaUZCY0Z4ArV9PffdJIPl46ZS3qgYEik28Z9eRfmjhWs8xu9p/22/J9rPHedyCtGhjQdbwTX3wyFUlZRWWQ2+w==}
+    dependencies:
+      '@dxos/node-std': 0.1.56
+    dev: false
+
+  /@dxos/errors/0.1.56:
+    resolution: {integrity: sha512-I2p6kbMCAsEe/RamdwJavBw85YsT8fDlAkU0jBXwa4qG9t/6Rm5+yGLklbCwuGoUnBo3un0epBf/2Llw6bunhA==}
+    dev: false
+
   /@dxos/esbuild-book-knobs/2.28.12_6ekedun2gj3yzkfjv5ysqycysy:
     resolution: {integrity: sha512-io/I+4uKdotdiIpE7OAYWtIUOhx4VWP7yGweprM1flQZXmDfwglAavxKlEcqafEoimquX+K5UWYGnBPYh+a0RQ==}
     deprecated: Versions published prior to open sourcing are no longer supported
@@ -9731,8 +9796,66 @@ packages:
       - supports-color
     dev: true
 
+  /@dxos/invariant/0.1.56:
+    resolution: {integrity: sha512-PpyeeY9xhubMgTxd/2ZGwgSxAkvg/o1tcpCTNT1uaNrGcyqL9FkktUiYUKB0JDA3wQZApOIQv6CxM/++WyqrhA==}
+    dependencies:
+      '@dxos/node-std': 0.1.56
+    dev: false
+
+  /@dxos/keys/0.1.56:
+    resolution: {integrity: sha512-DYCMjNwecq0fU1+Ymsefzy7gMGHKZV4B01YFF5zS87yyzJzzywB5fNRWF0RG3MF8nJcqm25xRDuY1G2pxyC91g==}
+    dependencies:
+      '@dxos/debug': 0.1.56
+      '@dxos/invariant': 0.1.56
+      '@dxos/node-std': 0.1.56
+      randombytes: 2.1.0
+    dev: false
+
+  /@dxos/lock-file/0.1.56:
+    resolution: {integrity: sha512-mQNcZrWF+dWy4s9xfoeT45rCN+MknEUCXRJJloTrOsr+K6N+4pvmo4R4XPuEQVJ3IsFB1Xy/CFyeZxInY3p3bg==}
+    dependencies:
+      '@dxos/async': 0.1.56
+      '@dxos/log': 0.1.56
+      '@dxos/node-std': 0.1.56
+      fs-ext: 2.0.0
+    dev: false
+
+  /@dxos/log/0.1.56:
+    resolution: {integrity: sha512-F1B9KzzNr0miDXMGdt9dn5mg7c0eBCLUufiAWjA07LQulTsjNtP40Z/UI4/eh8V5XD8eocsL1DDowhxtermFRA==}
+    dependencies:
+      '@dxos/node-std': 0.1.56
+      '@dxos/util': 0.1.56
+      chalk: 4.1.2
+      js-yaml: 4.1.0
+      lodash.defaultsdeep: 4.6.1
+      lodash.omit: 4.5.0
+      lodash.pick: 4.4.0
+      lodash.pickby: 4.6.0
+    dev: false
+
+  /@dxos/node-std/0.1.56:
+    resolution: {integrity: sha512-blD22HMeQTUz/tqcYHnSCHlDQbv3XDZ9kaa29d6Qs2QgJ7QlKolI9zKznB8oZr1va7YiuSbbv/931hEwlelGLg==}
+    dependencies:
+      assert: 2.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      path-browserify: 1.0.1
+      process: 0.11.10
+      readable-stream: 3.6.0
+      util: 0.12.5
+    dev: false
+
   /@dxos/testutils/0.1.13:
     resolution: {integrity: sha512-oTJOmR5iWZQB8wWXPJFq7jOlzRr5343zrvjAcf2VZNMR4oJs1iBEykhmoyOMuc6OtJUPgjBIA4SoiU5h680whQ==}
+    dev: false
+
+  /@dxos/util/0.1.56:
+    resolution: {integrity: sha512-hCZ6ev5m/5x82DeDcxPelB8AnB0KvJF6crMwACeNCcMWGJ4YCk/gu9ld9ExfFgujJ766Y+sZwQ4QdW6bDVYz1w==}
+    dependencies:
+      '@dxos/debug': 0.1.56
+      '@dxos/invariant': 0.1.56
+      '@dxos/keys': 0.1.56
+      '@dxos/node-std': 0.1.56
     dev: false
 
   /@emotion/babel-plugin/11.10.2_@babel+core@7.21.3:
@@ -16805,7 +16928,7 @@ packages:
       '@emotion/react': ^11
       react: '>16'
     dependencies:
-      '@emotion/react': 11.10.4_ogvc6ewgr3qq5z6tmbtquhqyui
+      '@emotion/react': 11.10.4_qikmzbpbtkvyqr7q6j4irlhsle
       '@theme-ui/core': 0.14.7_gyryel6m34lsxtsejhafetjriq
       '@theme-ui/css': 0.14.7_@emotion+react@11.10.4
       deepmerge: 4.3.1
@@ -16818,7 +16941,7 @@ packages:
       '@emotion/react': ^11
       react: '>16'
     dependencies:
-      '@emotion/react': 11.10.4_ogvc6ewgr3qq5z6tmbtquhqyui
+      '@emotion/react': 11.10.4_qikmzbpbtkvyqr7q6j4irlhsle
       '@styled-system/color': 5.1.2
       '@styled-system/should-forward-prop': 5.1.5
       '@styled-system/space': 5.1.2
@@ -16833,7 +16956,7 @@ packages:
       '@emotion/react': ^11
       react: '>16'
     dependencies:
-      '@emotion/react': 11.10.4_ogvc6ewgr3qq5z6tmbtquhqyui
+      '@emotion/react': 11.10.4_qikmzbpbtkvyqr7q6j4irlhsle
       '@theme-ui/css': 0.14.7_@emotion+react@11.10.4
       '@theme-ui/parse-props': 0.14.7_gyryel6m34lsxtsejhafetjriq
       deepmerge: 4.3.1
@@ -16845,7 +16968,7 @@ packages:
     peerDependencies:
       '@emotion/react': ^11
     dependencies:
-      '@emotion/react': 11.10.4_ogvc6ewgr3qq5z6tmbtquhqyui
+      '@emotion/react': 11.10.4_qikmzbpbtkvyqr7q6j4irlhsle
       csstype: 3.1.2
     dev: true
 
@@ -16856,7 +16979,7 @@ packages:
       '@mdx-js/react': ^1 || ^2
       react: '>16'
     dependencies:
-      '@emotion/react': 11.10.4_ogvc6ewgr3qq5z6tmbtquhqyui
+      '@emotion/react': 11.10.4_qikmzbpbtkvyqr7q6j4irlhsle
       '@mdx-js/react': 2.1.5_react@18.2.0
       '@theme-ui/core': 0.14.7_gyryel6m34lsxtsejhafetjriq
       '@theme-ui/css': 0.14.7_@emotion+react@11.10.4
@@ -16869,7 +16992,7 @@ packages:
       '@emotion/react': ^11
       react: '>16'
     dependencies:
-      '@emotion/react': 11.10.4_ogvc6ewgr3qq5z6tmbtquhqyui
+      '@emotion/react': 11.10.4_qikmzbpbtkvyqr7q6j4irlhsle
       '@theme-ui/css': 0.14.7_@emotion+react@11.10.4
       react: 18.2.0
     dev: true
@@ -16880,7 +17003,7 @@ packages:
       '@emotion/react': ^11
       react: '>16'
     dependencies:
-      '@emotion/react': 11.10.4_ogvc6ewgr3qq5z6tmbtquhqyui
+      '@emotion/react': 11.10.4_qikmzbpbtkvyqr7q6j4irlhsle
       '@theme-ui/color-modes': 0.14.7_gyryel6m34lsxtsejhafetjriq
       '@theme-ui/core': 0.14.7_gyryel6m34lsxtsejhafetjriq
       '@theme-ui/css': 0.14.7_@emotion+react@11.10.4
@@ -18914,7 +19037,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.21.3
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.3.9
+      vite: 4.3.9_@types+node@18.11.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -20587,7 +20710,7 @@ packages:
   /axios/1.3.4_debug@4.3.4:
     resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
     dependencies:
-      follow-redirects: 1.15.2_debug@4.3.4
+      follow-redirects: 1.15.2
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -22215,16 +22338,18 @@ packages:
     resolution: {integrity: sha512-LuO8/7LW6XuR5ERn1yavXAfodGRhuY2yP60JTZIw5yNYMCE5lUVbk3NFUCJxjnphQH+Xemp5hOGb1LgUXm00Xw==}
     dev: true
 
-  /codemirror/6.0.1:
+  /codemirror/6.0.1_@lezer+common@1.0.2:
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/autocomplete': 6.4.2_lc2v3dpzp2l5pdzwtgfaudkm3e
       '@codemirror/commands': 6.2.2
       '@codemirror/language': 6.6.0
       '@codemirror/lint': 6.2.0
       '@codemirror/search': 6.3.0
       '@codemirror/state': 6.2.0
       '@codemirror/view': 6.9.2
+    transitivePeerDependencies:
+      - '@lezer/common'
     dev: false
 
   /codepage/1.15.0:
@@ -26094,18 +26219,6 @@ packages:
       debug:
         optional: true
 
-  /follow-redirects/1.15.2_debug@4.3.4:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.4
-    dev: true
-
   /fontkit/2.0.2:
     resolution: {integrity: sha512-jc4k5Yr8iov8QfS6u8w2CnHWVmbOGtdBtOXMze5Y+QD966Rx6PEVWXSEGwXlsDlKtu1G12cJjcsybnqhSk/+LA==}
     dependencies:
@@ -27791,7 +27904,7 @@ packages:
       ink: '>=3.0.0'
       react: '>=16.8.0'
     dependencies:
-      ink: 3.2.0_iapumuv4e6jcjznwuxpf4tt22e
+      ink: 3.2.0_react@18.2.0
       object-hash: 2.2.0
       react: 18.2.0
     dev: false
@@ -40040,17 +40153,18 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-pwa/0.14.1_vite@4.3.9:
+  /vite-plugin-pwa/0.14.1_hjemcocyspwkenofjo4wnksrci:
     resolution: {integrity: sha512-5zx7yhQ8RTLwV71+GA9YsQQ63ALKG8XXIMqRJDdZkR8ZYftFcRgnzM7wOWmQZ/DATspyhPih5wCdcZnAIsM+mA==}
     peerDependencies:
       vite: ^3.1.0 || ^4.0.0
+      workbox-window: ^6.5.4
     dependencies:
       '@rollup/plugin-replace': 5.0.2_rollup@3.23.0
       debug: 4.3.4
       fast-glob: 3.2.12
       pretty-bytes: 6.0.0
       rollup: 3.23.0
-      vite: 4.3.9
+      vite: 4.3.9_@types+node@18.11.9
       workbox-build: 6.5.4
       workbox-window: 6.5.4
     transitivePeerDependencies:
@@ -40062,8 +40176,10 @@ packages:
     resolution: {integrity: sha512-irjKcKXRn7v5bPAg4mAbsS6DgibpP1VUFL9tlgxU6lloK6V9yw9qCZkS+s2PtbkZpWNzr3TN3zVJAc6J7gJZmA==}
     dev: true
 
-  /vite-plugin-web-extension/3.0.7:
+  /vite-plugin-web-extension/3.0.7_vite@4.3.9:
     resolution: {integrity: sha512-zi+Dd0WV7tiqqWM2kTowV5D1s+jy5rB76R6uN0gaoUDaz2QAhVcmBg/T7qF5p1g7SBjtvgclQggQ8uxglk+moQ==}
+    peerDependencies:
+      vite: ^4
     dependencies:
       ajv: 8.12.0
       async-lock: 1.4.0
@@ -40078,17 +40194,11 @@ packages:
       webextension-polyfill: 0.10.0
       yaml: 2.2.2
     transitivePeerDependencies:
-      - '@types/node'
       - body-parser
       - bufferutil
       - express
-      - less
       - safe-compare
-      - sass
-      - stylus
-      - sugarss
       - supports-color
-      - terser
       - utf-8-validate
     dev: true
 
@@ -40270,10 +40380,11 @@ packages:
       '@vue/shared': 3.2.47
     dev: true
 
-  /vuepress-plugin-auto-catalog/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-auto-catalog/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-imWdtiliNOrYZmJhjZnH3YU7VuR0FFtzZ7vyzHTQLZlRc9N5yryiYgYhmQbK4WCSNEdxfYRZbbFCEnSiHLbzpg==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -40303,18 +40414,19 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-components: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-components: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-blog2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-blog2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-0OmYfWd6mxG2X1DUagd5sOhTjG65l0L8RV3L8Vhj9j/36If3UttRU7g6VdUjfIfxAWmInsIIwhUAskEez9PUfQ==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
       vuepress-webpack: 2.0.0-beta.61
@@ -40338,7 +40450,7 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
@@ -40352,10 +40464,11 @@ packages:
       - supports-color
     dev: true
 
-  /vuepress-plugin-comment2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-comment2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-AXvAmvRNdBEVsx105ykjB5EvNj0vIb4ny7RgM2BM0mXcWImxdKWaO8GGdzIu5Eqk/Aiv7FXJoBIJ6uhkxIfPuQ==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -40386,17 +40499,18 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-components/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-components/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-pJd1oKVwHW/4eO2NeY9FSQWHo1pF8c0/rSrQLXPcnAaQojHG6QiLDdZ+EM4eGL3dHXixyIvT8wPU3IEOPlStqA==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -40434,18 +40548,19 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-reading-time2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-reading-time2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-copy-code2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-copy-code2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-kWPye53Bxsy7BxxcTOglsBjjAmOuzq6niHUAeqnEokhPeDcBEwwFcXIDDI1yj94e0fPcfKf1iKxH2C18VKFgow==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -40474,17 +40589,18 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-copyright2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-copyright2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-QCnu8BUy6SW3YTHgK8kU4WfKcrYfIOBTUG0D7HSqR/54y5ItKng4VsLG5hqruzwnRJoRPCnulJfoS7cGeEoBIQ==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
       vuepress-webpack: 2.0.0-beta.61
@@ -40507,13 +40623,13 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-feed2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-feed2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-tBNMyPWgPf71HIOlEvqEbb2Oq/WwYNzu9/imlMSyw4N+hnDuO3tSOPV/jOllhjMHG67KVR58YatrIDjE8PWatA==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
@@ -40532,17 +40648,19 @@ packages:
       '@vuepress/utils': 2.0.0-beta.61
       cheerio: 1.0.0-rc.12
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
       xml-js: 1.6.11
     transitivePeerDependencies:
       - '@vue/composition-api'
+      - '@vuepress/client'
       - supports-color
     dev: true
 
-  /vuepress-plugin-md-enhance/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-md-enhance/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-k5pfWW/xZCg7wEYrXFLHSUr5Laqc0nlfUg+IFYDbBXbKpbN53UgGwe05mcctZUSXokBDNJDRX62+kb4wFq4xTw==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -40600,17 +40718,18 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-photo-swipe/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-photo-swipe/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-yQICqlkEXC/PCkWVyqPkWSoT2FJ3yM1FQSNVNvAwP1WBIWlaCLnW896dVbCbwFfIStdgkfQW5//svqMI73l8sQ==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -40639,17 +40758,18 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-pwa2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-pwa2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-P7DCMxNuTyj1P1BY+Wmkz9dtVPtrzwO3SSjSSan+f2d31ak7H4mWa16s8+6YzwNkkXViUW+YrOo19lwxZHRrRQ==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -40679,8 +40799,8 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
       workbox-build: 6.5.4
     transitivePeerDependencies:
       - '@types/babel__core'
@@ -40688,7 +40808,7 @@ packages:
       - supports-color
     dev: true
 
-  /vuepress-plugin-reading-time2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-reading-time2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-SrtJHCfFmKxYhJK+pvvnC8RyjM7CHsCa3egNyBLYqs1oLlypCFS2ocb0UE1k1EHhSOyKuA9MigO+W95E3esg+A==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
@@ -40706,9 +40826,10 @@ packages:
         optional: true
     dependencies:
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
+      - '@vuepress/client'
       - supports-color
     dev: true
 
@@ -40732,13 +40853,13 @@ packages:
       '@vuepress/utils': 2.0.0-beta.61
       vue: 3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
     dev: true
 
-  /vuepress-plugin-sass-palette/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-sass-palette/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-xXA3fTD44W9pahejX79FQ0B9dIHbz5PzJ/8n7q0F4uep1/6j4BCKFDk1eyh+J9pBoTmZH+f9QxGxNZceGeOv2A==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
@@ -40763,13 +40884,14 @@ packages:
       chokidar: 3.5.3
       sass: 1.59.3
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
+      - '@vuepress/client'
       - supports-color
     dev: true
 
-  /vuepress-plugin-seo2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-seo2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-xaDGK2+XA/pQA9RGBuvjhzgHm1+Bmo9FzPxrDe6WQa/7S3qJfyYhkEqEApDzPzHaIIKBjUB9fHyUb7N+MWOLfg==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
@@ -40787,13 +40909,14 @@ packages:
       '@vuepress/shared': 2.0.0-beta.61
       '@vuepress/utils': 2.0.0-beta.61
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
+      - '@vuepress/client'
       - supports-color
     dev: true
 
-  /vuepress-plugin-sitemap2/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-plugin-sitemap2/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-yhLTRG67Sm0esVJHp+niS6CGUFBMoucxD7ul4D29fI0GIkK6634z5UDLD3TiJXbsRH32pbvURNGAHeZrJ1kYnA==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
@@ -40814,16 +40937,18 @@ packages:
       '@vuepress/utils': 2.0.0-beta.61
       sitemap: 7.1.1
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@vue/composition-api'
+      - '@vuepress/client'
       - supports-color
     dev: true
 
-  /vuepress-shared/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-shared/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-eTs6AT9w0djzsxNPPXiWK6lHcsS5AVnwRdu90/YthGkpPY2pGarN9KrtGX7+qVr+G4HS8v4Qu43+X+iDInNBgg==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
       vuepress-webpack: 2.0.0-beta.61
@@ -40856,10 +40981,11 @@ packages:
       - supports-color
     dev: true
 
-  /vuepress-theme-hope/2.0.0-beta.197_vuepress@2.0.0-beta.61:
+  /vuepress-theme-hope/2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe:
     resolution: {integrity: sha512-1mRhF4uk8bQaSYFjcJ+1hUHJ5OCHxHJVEzNWBHcgsDf4eqM/IYz+KXePwC9ndXAOOKPoKk6c1XAk5Nu5F3U7wA==}
     engines: {node: ^14.18.0 || >=16.0.0, npm: '>=8', pnpm: '>=7'}
     peerDependencies:
+      '@vuepress/client': 2.0.0-beta.61
       sass-loader: ^13.2.0
       vuepress: 2.0.0-beta.61
       vuepress-vite: 2.0.0-beta.61
@@ -40946,22 +41072,22 @@ packages:
       vue: 3.2.47
       vue-router: 4.1.6_vue@3.2.47
       vuepress: 2.0.0-beta.61_mxasr7fx7twrhhnursmb25rlzi
-      vuepress-plugin-auto-catalog: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-blog2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-comment2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-components: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-copy-code2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-copyright2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-feed2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-md-enhance: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-photo-swipe: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-pwa2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-reading-time2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-auto-catalog: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-blog2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-comment2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-components: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-copy-code2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-copyright2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-feed2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-md-enhance: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-photo-swipe: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-pwa2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-reading-time2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
       vuepress-plugin-rtl: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-sass-palette: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-seo2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-plugin-sitemap2: 2.0.0-beta.197_vuepress@2.0.0-beta.61
-      vuepress-shared: 2.0.0-beta.197_vuepress@2.0.0-beta.61
+      vuepress-plugin-sass-palette: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-seo2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-plugin-sitemap2: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
+      vuepress-shared: 2.0.0-beta.197_44bug2q4gvgfsg4b36ccgweufe
     transitivePeerDependencies:
       - '@types/babel__core'
       - '@vue/composition-api'

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -679,6 +679,11 @@
         },
         {
           "type": "json",
+          "path": "tools/anfang/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "tools/apidoc/package.json",
           "jsonpath": "$.version"
         },

--- a/tools/anfang/.eslintrc.js
+++ b/tools/anfang/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  "extends": [
+    "../../../../.eslintrc.js"
+  ],
+  "parserOptions": {
+    "project": "tsconfig.json",
+    "tsconfigRootDir": __dirname,
+  }
+}

--- a/tools/anfang/.eslintrc.js
+++ b/tools/anfang/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   "extends": [
-    "../../../../.eslintrc.js"
+    "../../.eslintrc.js"
   ],
   "parserOptions": {
     "project": "tsconfig.json",

--- a/tools/anfang/LICENSE
+++ b/tools/anfang/LICENSE
@@ -1,0 +1,8 @@
+MIT License 
+Copyright (c) 2022 DXOS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/tools/anfang/README.md
+++ b/tools/anfang/README.md
@@ -1,0 +1,21 @@
+# @dxos/anfang
+
+ECHO database.
+
+## Installation
+
+```bash
+pnpm i @dxos/anfang
+```
+
+## DXOS Resources
+
+- [Website](https://dxos.org)
+- [Developer Documentation](https://docs.dxos.org)
+- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+
+## Contributions
+
+Your ideas, issues, and code are most welcome. Please take a look at our [community code of conduct](https://github.com/dxos/dxos/blob/main/CODE_OF_CONDUCT.md), the [issue guide](https://github.com/dxos/dxos/blob/main/CONTRIBUTING.md#submitting-issues), and the [PR contribution guide](https://github.com/dxos/dxos/blob/main/CONTRIBUTING.md#submitting-prs).
+
+License: [MIT](./LICENSE) Copyright 2022 © DXOS

--- a/tools/anfang/docs/README.md
+++ b/tools/anfang/docs/README.md
@@ -1,0 +1,426 @@
+# @dxos/anfang
+
+ECHO database.
+
+## Class Diagrams
+
+```mermaid
+classDiagram
+direction TB
+
+class Space {
+  key
+  isOpen
+  database
+  genesisFeedKey
+  controlFeedKey
+  dataFeedKey
+  spaceState
+  controlPipeline
+  open()
+  close()
+}
+Space --> ControlPipeline : _controlPipeline
+Space --> SpaceProtocol : _protocol
+Space --> Pipeline : _dataPipeline
+Space --> DatabaseBackendHost : _databaseBackend
+Space --> Database : _database
+class ControlPipeline {
+  spaceState
+  pipeline
+  setWriteFeed()
+  start()
+  stop()
+}
+ControlPipeline --> Pipeline : _pipeline
+class Pipeline {
+  state
+  writer
+  addFeed()
+  setWriteFeed()
+  start()
+  stop()
+  consume()
+}
+Pipeline *-- TimeframeClock : _timeframeClock
+Pipeline *-- PipelineState : _state
+class TimeframeClock {
+  timeframe
+  updateTimeframe()
+  hasGaps()
+  waitUntilReached()
+}
+class PipelineState {
+  endTimeframe
+  timeframe
+  waitUntilTimeframe()
+}
+PipelineState --> TimeframeClock : _timeframeClock
+class SpaceProtocol {
+  peers
+  addFeed()
+  start()
+  stop()
+}
+SpaceProtocol *-- ReplicatorPlugin : _replicator
+SpaceProtocol --> SwarmIdentity : _swarmIdentity
+SpaceProtocol --> AuthPlugin : _authPlugin
+SpaceProtocol --> "Map" SpaceProtocolSession : _sessions
+class ReplicatorPlugin {
+  addFeed()
+}
+class SwarmIdentity {
+  <interface>
+  peerKey
+  credentialProvider
+  credentialAuthenticator
+}
+class AuthPlugin {
+  createExtension()
+}
+AuthPlugin --> SwarmIdentity : _swarmIdentity
+class SpaceProtocolSession {
+  stream
+  initialize()
+  destroy()
+}
+class DatabaseBackendHost {
+  isReadOnly
+  echoProcessor
+  open()
+  close()
+  getWriteStream()
+  createSnapshot()
+  createDataServiceHost()
+}
+DatabaseBackendHost --> ItemManager : _itemManager
+DatabaseBackendHost --> ItemDemuxer : _itemDemuxer
+DatabaseBackendHost *-- ItemDemuxerOptions : _options
+class ItemManager {
+  entities
+  items
+  links
+  createItem()
+  createLink()
+  constructItem()
+  constructLink()
+  processModelMessage()
+  getItem()
+  getUninitializedEntities()
+  deconstructItem()
+  initializeModel()
+}
+ItemManager *-- "Map" Entity : _entities
+class Entity {
+  id
+  type
+  modelType
+  modelMeta
+  model
+  subscribe()
+}
+Entity --> ItemManager : _itemManager
+class ItemDemuxer {
+  open()
+  createSnapshot()
+  createItemSnapshot()
+  createLinkSnapshot()
+  restoreFromSnapshot()
+}
+ItemDemuxer --> ItemManager : _itemManager
+ItemDemuxer *-- ItemDemuxerOptions : _options
+class ItemDemuxerOptions {
+  <interface>
+  snapshots
+}
+class Database {
+  addType()
+  create()
+}
+```
+```mermaid
+classDiagram
+direction TB
+
+class Database {
+  state
+  isReadOnly
+  update
+  entityUpdate
+  initialize()
+  destroy()
+  createItem()
+  createLink()
+  getItem()
+  waitForItem()
+  select()
+  reduce()
+  createSnapshot()
+  createDataServiceHost()
+}
+Database --> ItemManager : _itemManager
+Database --> DatabaseBackend : _backend
+class ItemManager {
+  entities
+  items
+  links
+  createItem()
+  createLink()
+  constructItem()
+  constructLink()
+  processModelMessage()
+  getItem()
+  getUninitializedEntities()
+  deconstructItem()
+  initializeModel()
+}
+ItemManager *-- "Map" Entity : _entities
+class Entity {
+  id
+  type
+  modelType
+  modelMeta
+  model
+  subscribe()
+}
+Entity --> ItemManager : _itemManager
+class DatabaseBackend {
+  <interface>
+  isReadOnly
+  open()
+  close()
+  getWriteStream()
+  createSnapshot()
+  createDataServiceHost()
+}
+```
+```mermaid
+classDiagram
+direction TB
+
+class DatabaseBackendHost {
+  isReadOnly
+  echoProcessor
+  open()
+  close()
+  getWriteStream()
+  createSnapshot()
+  createDataServiceHost()
+}
+DatabaseBackendHost --> ItemManager : _itemManager
+DatabaseBackendHost --> ItemDemuxer : _itemDemuxer
+DatabaseBackendHost *-- ItemDemuxerOptions : _options
+class ItemManager {
+  entities
+  items
+  links
+  createItem()
+  createLink()
+  constructItem()
+  constructLink()
+  processModelMessage()
+  getItem()
+  getUninitializedEntities()
+  deconstructItem()
+  initializeModel()
+}
+ItemManager *-- "Map" Entity : _entities
+class Entity {
+  id
+  type
+  modelType
+  modelMeta
+  model
+  subscribe()
+}
+Entity --> ItemManager : _itemManager
+class ItemDemuxer {
+  open()
+  createSnapshot()
+  createItemSnapshot()
+  createLinkSnapshot()
+  restoreFromSnapshot()
+}
+ItemDemuxer --> ItemManager : _itemManager
+ItemDemuxer *-- ItemDemuxerOptions : _options
+class ItemDemuxerOptions {
+  <interface>
+  snapshots
+}
+class DatabaseBackendProxy {
+  isReadOnly
+  open()
+  close()
+  getWriteStream()
+  createSnapshot()
+  createDataServiceHost()
+}
+DatabaseBackendProxy --> ItemManager : _itemManager
+```
+
+## Dependency Graph
+
+```mermaid
+%%{ init: {'flowchart':{'curve':'basis'}} }%%
+
+flowchart LR
+
+%% Classes
+
+
+
+%% Nodes
+
+subgraph core [core]
+  style core fill:transparent
+  dxos/protocols("@dxos/protocols"):::def
+  click dxos/protocols "dxos/dxos/tree/main/packages/core/protocols/docs"
+
+  subgraph echo [echo]
+    style echo fill:transparent
+    dxos/anfang("@dxos/anfang"):::root
+    click dxos/anfang "dxos/dxos/tree/main/tools/anfang/docs"
+    dxos/model-factory("@dxos/model-factory"):::def
+    click dxos/model-factory "dxos/dxos/tree/main/packages/core/echo/model-factory/docs"
+    dxos/document-model("@dxos/document-model"):::def
+    click dxos/document-model "dxos/dxos/tree/main/packages/core/echo/document-model/docs"
+  end
+
+  subgraph halo [halo]
+    style halo fill:transparent
+    dxos/credentials("@dxos/credentials"):::def
+    click dxos/credentials "dxos/dxos/tree/main/packages/core/halo/credentials/docs"
+    dxos/keyring("@dxos/keyring"):::def
+    click dxos/keyring "dxos/dxos/tree/main/packages/core/halo/keyring/docs"
+  end
+
+  subgraph mesh [mesh]
+    style mesh fill:transparent
+    dxos/mesh-protocol("@dxos/mesh-protocol"):::def
+    click dxos/mesh-protocol "dxos/dxos/tree/main/packages/core/mesh/mesh-protocol/docs"
+    dxos/messaging("@dxos/messaging"):::def
+    click dxos/messaging "dxos/dxos/tree/main/packages/core/mesh/messaging/docs"
+    dxos/rpc("@dxos/rpc"):::def
+    click dxos/rpc "dxos/dxos/tree/main/packages/core/mesh/rpc/docs"
+    dxos/network-manager("@dxos/network-manager"):::def
+    click dxos/network-manager "dxos/dxos/tree/main/packages/core/mesh/network-manager/docs"
+    dxos/protocol-plugin-presence("@dxos/protocol-plugin-presence"):::def
+    click dxos/protocol-plugin-presence "dxos/dxos/tree/main/packages/core/mesh/protocol-plugin-presence/docs"
+    dxos/broadcast("@dxos/broadcast"):::def
+    click dxos/broadcast "dxos/dxos/tree/main/packages/core/mesh/broadcast/docs"
+    dxos/protocol-plugin-replicator("@dxos/protocol-plugin-replicator"):::def
+    click dxos/protocol-plugin-replicator "dxos/dxos/tree/main/packages/core/mesh/protocol-plugin-replicator/docs"
+    dxos/network-generator("@dxos/network-generator"):::def
+    click dxos/network-generator "dxos/dxos/tree/main/packages/core/mesh/network-generator/docs"
+    dxos/protocol-plugin-rpc("@dxos/protocol-plugin-rpc"):::def
+    click dxos/protocol-plugin-rpc "dxos/dxos/tree/main/packages/core/mesh/protocol-plugin-rpc/docs"
+    dxos/teleport("@dxos/teleport"):::def
+    click dxos/teleport "dxos/dxos/tree/main/packages/core/mesh/teleport/docs"
+    dxos/teleport-plugin-replicator("@dxos/teleport-plugin-replicator"):::def
+    click dxos/teleport-plugin-replicator "dxos/dxos/tree/main/packages/core/mesh/teleport-plugin-replicator/docs"
+  end
+end
+
+subgraph common [common]
+  style common fill:transparent
+  dxos/context("@dxos/context"):::def
+  click dxos/context "dxos/dxos/tree/main/packages/common/context/docs"
+  dxos/codec-protobuf("@dxos/codec-protobuf"):::def
+  click dxos/codec-protobuf "dxos/dxos/tree/main/packages/common/codec-protobuf/docs"
+  dxos/crypto("@dxos/crypto"):::def
+  click dxos/crypto "dxos/dxos/tree/main/packages/common/crypto/docs"
+  dxos/feed-store("@dxos/feed-store"):::def
+  click dxos/feed-store "dxos/dxos/tree/main/packages/common/feed-store/docs"
+  dxos/hypercore("@dxos/hypercore"):::def
+  click dxos/hypercore "dxos/dxos/tree/main/packages/common/hypercore/docs"
+  dxos/random-access-storage("@dxos/random-access-storage"):::def
+  click dxos/random-access-storage "dxos/dxos/tree/main/packages/common/random-access-storage/docs"
+  dxos/timeframe("@dxos/timeframe"):::def
+  click dxos/timeframe "dxos/dxos/tree/main/packages/common/timeframe/docs"
+
+  subgraph _ [ ]
+    style _ fill:transparent
+    dxos/async("@dxos/async"):::def
+    click dxos/async "dxos/dxos/tree/main/packages/common/async/docs"
+    dxos/log("@dxos/log"):::def
+    click dxos/log "dxos/dxos/tree/main/packages/common/log/docs"
+    dxos/util("@dxos/util"):::def
+    click dxos/util "dxos/dxos/tree/main/packages/common/util/docs"
+    dxos/debug("@dxos/debug"):::def
+    click dxos/debug "dxos/dxos/tree/main/packages/common/debug/docs"
+    dxos/keys("@dxos/keys"):::def
+    click dxos/keys "dxos/dxos/tree/main/packages/common/keys/docs"
+  end
+end
+
+%% Links
+dxos/async --> dxos/context
+dxos/credentials --> dxos/feed-store
+dxos/feed-store --> dxos/hypercore
+dxos/hypercore --> dxos/codec-protobuf
+dxos/hypercore --> dxos/crypto
+dxos/hypercore --> dxos/random-access-storage
+dxos/credentials --> dxos/keyring
+dxos/keyring --> dxos/protocols
+dxos/protocols --> dxos/hypercore
+dxos/protocols --> dxos/timeframe
+dxos/credentials --> dxos/mesh-protocol
+dxos/mesh-protocol --> dxos/codec-protobuf
+dxos/messaging --> dxos/rpc
+dxos/rpc --> dxos/protocols
+dxos/model-factory --> dxos/feed-store
+dxos/model-factory --> dxos/protocols
+dxos/anfang --> dxos/network-manager
+dxos/network-manager --> dxos/credentials
+dxos/network-manager --> dxos/messaging
+dxos/network-manager --> dxos/protocol-plugin-presence
+dxos/protocol-plugin-presence --> dxos/broadcast
+dxos/broadcast --> dxos/protocols
+dxos/protocol-plugin-presence --> dxos/mesh-protocol
+dxos/anfang --> dxos/document-model
+dxos/document-model --> dxos/model-factory
+dxos/anfang --> dxos/protocol-plugin-replicator
+dxos/protocol-plugin-replicator --> dxos/keyring
+dxos/protocol-plugin-replicator --> dxos/mesh-protocol
+dxos/protocol-plugin-replicator --> dxos/network-generator
+dxos/anfang --> dxos/protocol-plugin-rpc
+dxos/protocol-plugin-rpc --> dxos/mesh-protocol
+dxos/protocol-plugin-rpc --> dxos/messaging
+dxos/teleport --> dxos/rpc
+dxos/anfang --> dxos/teleport-plugin-replicator
+dxos/teleport-plugin-replicator --> dxos/feed-store
+dxos/teleport-plugin-replicator --> dxos/teleport
+```
+
+## Dependencies
+
+| Module | Direct |
+|---|---|
+| [`@dxos/async`](../../../../common/async/docs/README.md) | &check; |
+| [`@dxos/broadcast`](../../../mesh/broadcast/docs/README.md) |  |
+| [`@dxos/codec-protobuf`](../../../../common/codec-protobuf/docs/README.md) | &check; |
+| [`@dxos/context`](../../../../common/context/docs/README.md) |  |
+| [`@dxos/credentials`](../../../halo/credentials/docs/README.md) | &check; |
+| [`@dxos/crypto`](../../../../common/crypto/docs/README.md) | &check; |
+| [`@dxos/debug`](../../../../common/debug/docs/README.md) | &check; |
+| [`@dxos/feed-store`](../../../../common/feed-store/docs/README.md) | &check; |
+| [`@dxos/hypercore`](../../../../common/hypercore/docs/README.md) | &check; |
+| [`@dxos/keyring`](../../../halo/keyring/docs/README.md) | &check; |
+| [`@dxos/keys`](../../../../common/keys/docs/README.md) | &check; |
+| [`@dxos/log`](../../../../common/log/docs/README.md) | &check; |
+| [`@dxos/mesh-protocol`](../../../mesh/mesh-protocol/docs/README.md) | &check; |
+| [`@dxos/messaging`](../../../mesh/messaging/docs/README.md) | &check; |
+| [`@dxos/model-factory`](../../model-factory/docs/README.md) | &check; |
+| [`@dxos/network-generator`](../../../mesh/network-generator/docs/README.md) |  |
+| [`@dxos/network-manager`](../../../mesh/network-manager/docs/README.md) | &check; |
+| [`@dxos/document-model`](../../document-model/docs/README.md) | &check; |
+| [`@dxos/protocol-plugin-presence`](../../../mesh/protocol-plugin-presence/docs/README.md) | &check; |
+| [`@dxos/protocol-plugin-replicator`](../../../mesh/protocol-plugin-replicator/docs/README.md) | &check; |
+| [`@dxos/protocol-plugin-rpc`](../../../mesh/protocol-plugin-rpc/docs/README.md) | &check; |
+| [`@dxos/protocols`](../../../protocols/docs/README.md) | &check; |
+| [`@dxos/random-access-storage`](../../../../common/random-access-storage/docs/README.md) | &check; |
+| [`@dxos/rpc`](../../../mesh/rpc/docs/README.md) | &check; |
+| [`@dxos/teleport`](../../../mesh/teleport/docs/README.md) | &check; |
+| [`@dxos/teleport-plugin-replicator`](../../../mesh/teleport-plugin-replicator/docs/README.md) | &check; |
+| [`@dxos/timeframe`](../../../../common/timeframe/docs/README.md) | &check; |
+| [`@dxos/util`](../../../../common/util/docs/README.md) | &check; |

--- a/tools/anfang/eslint-config.json
+++ b/tools/anfang/eslint-config.json
@@ -1,0 +1,14 @@
+// TODO(wittjosiah): This is not currently being used because testing packlet breaks the packlet lint.
+{
+  // This eslint config intentionally uses a non-standard name so that IDEs ignore it.
+  // The parserOptions config specified here only works with the Nx linter and
+  //   not IDEs because the tsconfig path is relative to the root of the repo.
+  // This is only required in order to do packlet linting, otherwise rules will
+  //   automatically be applied from the root config.
+  "extends": [
+    "../../../../.eslintrc.packlets.js"
+  ],
+  "parserOptions": {
+    "project": "./tools/anfang/tsconfig.json"
+  }
+}

--- a/tools/anfang/package.json
+++ b/tools/anfang/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@dxos/anfang",
+  "version": "0.1.57",
+  "description": "Tool daemonizer.",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "license": "MIT",
+  "author": "info@dxos.org",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@dxos/async": "0.1.56",
+    "@dxos/invariant": "0.1.56",
+    "@dxos/lock-file": "0.1.56",
+    "@dxos/log": "0.1.56"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/tools/anfang/project.json
+++ b/tools/anfang/project.json
@@ -1,0 +1,31 @@
+{
+  "sourceRoot": "tools/anfang/src",
+  "projectType": "library",
+  "targets": {
+    "compile": {
+      "dependsOn": [],
+      "executor": "@nx/js:tsc",
+      "options": {
+        "main": "tools/anfang/src/index.ts",
+        "outputPath": "tools/anfang/dist",
+        "tsConfig": "tools/anfang/tsconfig.json"
+      },
+      "outputs": [
+        "{options.outputPath}"
+      ]
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "options": {
+        "format": "unix",
+        "lintFilePatterns": [
+          "tools/anfang/src/**/*.{ts,js}?(x)"
+        ],
+        "quiet": true
+      },
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/tools/anfang/src/framer.ts
+++ b/tools/anfang/src/framer.ts
@@ -9,13 +9,12 @@ const invariant = (condition: any, message: string) => {
   if (!condition) {
     throw new Error(message);
   }
-}
+};
 
 export interface RpcPort {
   send: (msg: Uint8Array) => Promise<void>;
   subscribe: (cb: (msg: Uint8Array) => void) => (() => void) | void;
 }
-
 
 const FRAME_LENGTH_SIZE = 4;
 

--- a/tools/anfang/src/framer.ts
+++ b/tools/anfang/src/framer.ts
@@ -1,0 +1,169 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+import { Duplex } from 'node:stream';
+
+// import { invariant } from '@dxos/invariant';
+const invariant = (condition: any, message: string) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+export interface RpcPort {
+  send: (msg: Uint8Array) => Promise<void>;
+  subscribe: (cb: (msg: Uint8Array) => void) => (() => void) | void;
+}
+
+
+const FRAME_LENGTH_SIZE = 4;
+
+/**
+ * Converts a stream of binary messages into a framed RpcPort.
+ * Buffers are written prefixed by their length encoded as a varint.
+ */
+export class Framer {
+  // private readonly _tagBuffer = Buffer.alloc(4)
+  private _messageCb?: (msg: Uint8Array) => void = undefined;
+  private _subscribeCb?: () => void = undefined;
+  private _buffer?: Buffer = undefined; // The rest of the bytes from the previous write call.
+  private _sendCallbacks: (() => void)[] = [];
+
+  private _bytesSent = 0;
+  private _bytesReceived = 0;
+
+  private readonly _stream = new Duplex({
+    objectMode: false,
+    read: () => {
+      this._processResponseQueue();
+    },
+    write: (chunk, encoding, callback) => {
+      invariant(!this._subscribeCb, 'Internal Framer bug. Concurrent writes detected.');
+
+      this._bytesReceived += chunk.length;
+
+      if (this._buffer && this._buffer.length > 0) {
+        this._buffer = Buffer.concat([this._buffer, chunk]);
+      } else {
+        this._buffer = chunk;
+      }
+
+      if (this._messageCb) {
+        this._popFrames();
+        callback();
+      } else {
+        this._subscribeCb = () => {
+          // Schedule the processing of the chunk after the peer subscribes to the messages.
+          this._popFrames();
+          this._subscribeCb = undefined;
+          callback();
+        };
+      }
+    },
+  });
+
+  public readonly port: RpcPort = {
+    send: (message) => {
+      // log('write', { len: message.length, frame: Buffer.from(message).toString('hex') })
+      return new Promise<void>((resolve) => {
+        const frame = encodeFrame(message);
+        this._bytesSent += frame.length;
+        const canContinue = this._stream.push(frame);
+        if (!canContinue) {
+          this._sendCallbacks.push(resolve);
+        } else {
+          resolve();
+        }
+      });
+    },
+    subscribe: (callback) => {
+      invariant(!this._messageCb, 'Rpc port already has a message listener.');
+      this._messageCb = callback;
+      this._subscribeCb?.();
+      return () => {
+        this._messageCb = undefined;
+      };
+    },
+  };
+
+  get stream(): Duplex {
+    return this._stream;
+  }
+
+  get bytesSent() {
+    return this._bytesSent;
+  }
+
+  get bytesReceived() {
+    return this._bytesReceived;
+  }
+
+  private _processResponseQueue() {
+    const responseQueue = this._sendCallbacks;
+    this._sendCallbacks = [];
+    responseQueue.forEach((cb) => cb());
+  }
+
+  /**
+   * Attempts to pop frames from the buffer and call the message callback.
+   */
+  private _popFrames() {
+    let offset = 0;
+    while (offset < this._buffer!.length) {
+      const frame = decodeFrame(this._buffer!, offset);
+
+      if (!frame) {
+        break; // Couldn't read frame but there are still bytes left in the buffer.
+      }
+      offset += frame.bytesConsumed;
+      // TODO(dmaretskyi): Possible bug if the peer unsubscribes while we're reading frames.
+      // log('read', { len: frame.payload.length, frame: Buffer.from(frame.payload).toString('hex') })
+      this._messageCb!(frame.payload);
+    }
+
+    if (offset < this._buffer!.length) {
+      // Save the rest of the bytes for the next write call.
+      this._buffer = this._buffer!.subarray(offset);
+    } else {
+      this._buffer = undefined;
+    }
+  }
+
+  destroy() {
+    // TODO(dmaretskyi): Call stream.end() instead?
+    this._stream.destroy();
+  }
+}
+
+/**
+ * Attempts to read a frame from the input buffer.
+ */
+export const decodeFrame = (buffer: Buffer, offset: number): { payload: Buffer; bytesConsumed: number } | undefined => {
+  if (buffer.length < offset + FRAME_LENGTH_SIZE) {
+    // Not enough bytes to read the frame length.
+    return undefined;
+  }
+
+  const frameLength = buffer.readUInt32BE(offset);
+  const bytesConsumed = FRAME_LENGTH_SIZE + frameLength;
+
+  if (buffer.length < offset + bytesConsumed) {
+    // Not enough bytes to read the frame.
+    return undefined;
+  }
+
+  const payload = buffer.subarray(offset + FRAME_LENGTH_SIZE, offset + bytesConsumed);
+
+  return {
+    payload,
+    bytesConsumed,
+  };
+};
+
+export const encodeFrame = (payload: Uint8Array): Buffer => {
+  const frame = Buffer.allocUnsafe(FRAME_LENGTH_SIZE + payload.length);
+  frame.writeUInt32BE(payload.length, 0);
+  frame.set(payload, FRAME_LENGTH_SIZE);
+  return frame;
+};

--- a/tools/anfang/src/index.ts
+++ b/tools/anfang/src/index.ts
@@ -1,0 +1,270 @@
+import { LockFile } from "@dxos/lock-file";
+import { log } from "@dxos/log";
+import { stat, mkdir, rm, FileHandle } from "node:fs/promises";
+import { createServer, Socket } from "node:net";
+import { basename, join } from "node:path";
+import { subtle } from 'node:crypto';
+import { Trigger } from "@dxos/async";
+import { Framer } from './framer';
+import { fork } from "node:child_process";
+import { existsSync } from "node:fs";
+
+export type ForkParams = {
+  script: string
+}
+
+export const forkDaemon = (params: ForkParams) => {
+  const daemon = new Daemon(params);
+  return daemon;
+}
+
+type Request = {
+  id: number;
+  function: string;
+  args: any[];
+}
+
+type Response = {
+  id: number;
+  result?: any;
+  error?: {
+    message: string;
+    stack?: string;
+  }
+  time: number
+}
+
+type OutgoingRequest = {
+  id: number;
+  trigger: Trigger<Response>;
+}
+
+const MAX_CONNECT_RETRIES = 10;
+
+export class Daemon {
+  private _initialized!: Promise<void>;
+  private _key: string = undefined as any;
+  private _lockFile: string = undefined as any;
+  private _rpcFile: string = undefined as any;
+  private _connected = new Trigger();
+  private _mode: 'server' | 'client' = undefined as any;
+  private _registeredFunctions = new Map<string, (...args: any[]) => Promise<any>>();
+  private _nextId = 0;
+  private _framer?: Framer = undefined;
+  private _outgoingRequests = new Map<number, OutgoingRequest>();
+  private _lockFd: FileHandle | undefined = undefined
+  private _connectRetries = 0;
+  private _connectTimeout = 10;
+  private _socket?: Socket = undefined;
+  private _disabled = false;
+
+  private _startTs: number;
+
+  constructor(private readonly _params: ForkParams) {
+    this._disabled = !!process.env.ANFANG_DISABLE;
+    this._startTs = performance.now();
+    if(!this._disabled) {
+      this._initialized = this._open();
+    }
+  }
+
+  get isWorker() {
+    if(this._disabled) {
+      return false;
+    }
+    return this._mode === 'server';
+  }
+
+  function<T extends any[], R>(fn: (...args: T) => Promise<R>): (...args: T) => Promise<R> {
+    if(this._disabled) {
+      return fn;
+    }
+
+    const functionId = `fun-${this._registeredFunctions.size}`;
+    this._registeredFunctions.set(functionId, fn as any);
+
+    return async (...args: T) => {
+      await this._initialized;
+      if (this._mode === 'server') {
+        return fn(...args);
+      } else {
+        await this._connected.wait();
+
+        const start = performance.now();
+        const request: Request = {
+          id: this._nextId++,
+          function: functionId,
+          args,
+        };
+        // log('sending request', { request: JSON.stringify(request) })
+        this._outgoingRequests.set(request.id, {
+          id: request.id,
+          trigger: new Trigger(),
+        });
+        const message = Buffer.from(JSON.stringify(request));
+        this._framer!.port.send(message);
+        this._socket!.ref();
+        const response: Response = await this._outgoingRequests.get(request.id)!.trigger.wait();
+
+        const time = performance.now() - start;
+        log.info('request finished', {
+          totalTime: time,
+          executionTime: response.time,
+          overhead: `${((time - response.time) / response.time * 100).toFixed(0)}%`,
+          requestLength: message.length,
+          error: !!response.error
+        })
+
+        if (response.error) {
+          const error = new Error(response.error.message);
+          error.stack = response.error.stack;
+          throw error;
+        } else {
+          return response.result;
+        }
+      }
+    }
+  }
+
+  /**
+   * @internal
+   */
+  async _open() {
+    const scriptStat = await stat(this._params.script);
+    const hashComponents: string[] = [
+      this._params.script,
+      scriptStat.mtimeMs.toString(),
+    ];
+    const digest = await subtle.digest('SHA-256', new TextEncoder().encode(hashComponents.join(':')));
+    this._key = basename(this._params.script) + '-' + Buffer.from(digest).toString('hex').slice(0, 8);
+    this._lockFile = join('/tmp/anfang', this._key + '.lock');
+    this._rpcFile = join('/tmp/anfang', this._key + '.rpc');
+
+    log.info('daemon initializing', {
+      script: this._params.script,
+      key: this._key,
+      lockFile: this._lockFile,
+      rpcFile: this._rpcFile,
+    })
+
+    try {
+      await mkdir('/tmp/anfang');
+    } catch { }
+
+    if (!!process.env.ANFANG_WORKER) {
+      try {
+        this._lockFd = await LockFile.acquire(this._lockFile);
+        await this._runServer();
+      } catch (err) {
+        log.warn('locking error', { err })
+        log.warn('worker exiting')
+      }
+      return;
+    } else {
+      if (!existsSync(this._rpcFile)) {
+        this._startWorker();
+      }
+      await this._runClient();
+    }
+  }
+
+  private _startWorker() {
+    const child = fork(this._params.script, {
+      env: {
+        ...process.env,
+        ANFANG_WORKER: '1',
+      }
+    })
+    log.info('forked worker process', { pid: child.pid })
+  }
+
+  private async _runServer() {
+    log.info('running as server')
+    this._mode = 'server';
+    try {
+      await rm(this._rpcFile);
+    } catch { }
+    const server = createServer(socket => {
+      const framer = new Framer();
+      framer.stream.pipe(socket).pipe(framer.stream);
+      framer.port.subscribe(async message => {
+        const request: Request = JSON.parse(message.toString());
+        // log('got request', { request })
+        this._execRequest(request).then(response => {
+          // log('sending response', { response })
+          framer.port.send(Buffer.from(JSON.stringify(response)));
+        })
+      });
+      log('got connection')
+    });
+    server.listen(this._rpcFile);
+  }
+
+  private async _runClient() {
+    log('running as client')
+    this._mode = 'client';
+    this._socket = new Socket()
+    this._socket.connect(this._rpcFile);
+    this._framer = new Framer();
+    this._framer.stream.pipe(this._socket).pipe(this._framer.stream);
+    this._framer.port.subscribe(async message => {
+      const response: Response = JSON.parse(message.toString());
+      // log('got response', { response })
+      const request = this._outgoingRequests.get(response.id);
+      if (request) {
+        this._outgoingRequests.delete(response.id);
+        request.trigger.wake(response);
+      }
+      if (this._outgoingRequests.size === 0) {
+        this._socket!.unref();
+      }
+    });
+
+    this._socket.on('connect', () => {
+      log.info('connected to server', { time: performance.now() - this._startTs })
+      this._connected.wake();
+    });
+    this._socket.on('error', () => {
+      if (this._connectRetries++ > MAX_CONNECT_RETRIES) {
+        throw new Error('Max retries exceeded');
+      }
+      if (this._connectRetries === 1) {
+        this._startWorker();
+      }
+      setTimeout(() => {
+        this._runClient();
+      }, this._connectTimeout)
+      this._connectTimeout *= 2;
+    })
+    if (this._outgoingRequests.size === 0) {
+      this._socket.unref();
+    }
+  }
+
+  private async _execRequest(request: Request): Promise<Response> {
+    try {
+      const start = performance.now();
+      const fn = this._registeredFunctions.get(request.function);
+      if (!fn) {
+        throw new Error(`Function not found: ${request.function}`);
+      }
+
+      const res = await fn(...request.args);
+
+      return {
+        id: request.id,
+        result: res,
+        time: performance.now() - start,
+      }
+    } catch (err: any) {
+      return {
+        id: request.id,
+        error: {
+          message: err.message,
+          stack: err.stack,
+        },
+        time: performance.now() - this._startTs,
+      }
+    }
+  }
+}

--- a/tools/anfang/src/test.ts
+++ b/tools/anfang/src/test.ts
@@ -1,9 +1,12 @@
-import { randomBytes } from "crypto";
-import { forkDaemon } from ".";
+//
+// Copyright 2023 DXOS.org
+//
+
+import { forkDaemon } from '.';
 
 const daemon = forkDaemon({
   script: __filename,
-})
+});
 
 let invocations = 0;
 
@@ -14,18 +17,17 @@ const add = daemon.function(async (a, b) => {
   };
 });
 
-const length = daemon.function(async (str) => {
+const _length = daemon.function(async (str) => {
   return {
     result: str.length,
     invocations: ++invocations,
   };
 });
 
-if(!daemon.isWorker) {
-  (async () => {
+if (!daemon.isWorker) {
+  void (async () => {
     console.log(await add(1, 2));
 
     // console.log(await length(randomBytes(16_000).toString('hex')));
-
-  })()
+  })();
 }

--- a/tools/anfang/src/test.ts
+++ b/tools/anfang/src/test.ts
@@ -1,0 +1,31 @@
+import { randomBytes } from "crypto";
+import { forkDaemon } from ".";
+
+const daemon = forkDaemon({
+  script: __filename,
+})
+
+let invocations = 0;
+
+const add = daemon.function(async (a, b) => {
+  return {
+    result: a + b,
+    invocations: ++invocations,
+  };
+});
+
+const length = daemon.function(async (str) => {
+  return {
+    result: str.length,
+    invocations: ++invocations,
+  };
+});
+
+if(!daemon.isWorker) {
+  (async () => {
+    console.log(await add(1, 2));
+
+    // console.log(await length(randomBytes(16_000).toString('hex')));
+
+  })()
+}

--- a/tools/anfang/tsconfig.json
+++ b/tools/anfang/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "outDir": "dist/types",
+    "types": [
+      "@dxos/test",
+      "@dxos/typings",
+      "node"
+    ]
+  },
+  "exclude": [],
+  "include": [
+    "src"
+  ],
+  "references": []
+}

--- a/tools/executors/esbuild/src/main.ts
+++ b/tools/executors/esbuild/src/main.ts
@@ -3,7 +3,8 @@
 //
 
 import type { ExecutorContext } from '@nx/devkit';
-import type { Format, Platform, Plugin } from 'esbuild'
+import type { Format, Platform, Plugin } from 'esbuild';
+
 import { forkDaemon } from '@dxos/anfang';
 
 export interface EsbuildExecutorOptions {
@@ -23,139 +24,140 @@ export interface EsbuildExecutorOptions {
 
 const daemon = forkDaemon({
   script: __filename,
-})
+});
 
 type BuildContext = {
   projectRoot: string;
   isVerbose: boolean;
-}
+};
 
-const runBuild = daemon.function(async (options: EsbuildExecutorOptions, context: BuildContext): Promise<{ success: boolean }> => {
-  const { build } = await import('esbuild');
-  const { default: RawPlugin } = await import('esbuild-plugin-raw');
-  const { yamlPlugin } = await import('esbuild-plugin-yaml');
-  const { readFile, writeFile, readdir, rm } = await import('node:fs/promises');
-  const { dirname, join } = await import('node:path');
+const runBuild = daemon.function(
+  async (options: EsbuildExecutorOptions, context: BuildContext): Promise<{ success: boolean }> => {
+    const { build } = await import('esbuild');
+    const { default: RawPlugin } = await import('esbuild-plugin-raw');
+    const { yamlPlugin } = await import('esbuild-plugin-yaml');
+    const { readFile, writeFile, readdir, rm } = await import('node:fs/promises');
+    const { dirname, join } = await import('node:path');
 
-  const { bundleDepsPlugin } = await import('./bundle-deps-plugin');
-  const { fixRequirePlugin } = await import('./fix-require-plugin');
-  const { LogTransformer } = await import('./log-transform-plugin');
+    const { bundleDepsPlugin } = await import('./bundle-deps-plugin');
+    const { fixRequirePlugin } = await import('./fix-require-plugin');
+    const { LogTransformer } = await import('./log-transform-plugin');
 
-  console.info('Executing esbuild...');
-  if (context.isVerbose) {
-    console.info(`Options: ${JSON.stringify(options, null, 2)}`);
-  }
+    console.info('Executing esbuild...');
+    if (context.isVerbose) {
+      console.info(`Options: ${JSON.stringify(options, null, 2)}`);
+    }
 
-  try {
-    await readdir(options.outputPath);
-    await rm(options.outputPath, { recursive: true });
-  } catch { }
+    try {
+      await readdir(options.outputPath);
+      await rm(options.outputPath, { recursive: true });
+    } catch {}
 
-  // TODO(wittjosiah): Workspace from context is deprecated.
-  const packagePath = join(context.projectRoot, 'package.json');
-  const packageJson = JSON.parse(await readFile(packagePath, 'utf-8'));
+    // TODO(wittjosiah): Workspace from context is deprecated.
+    const packagePath = join(context.projectRoot, 'package.json');
+    const packageJson = JSON.parse(await readFile(packagePath, 'utf-8'));
 
-  const logTransformer = new LogTransformer({ isVerbose: context.isVerbose });
+    const logTransformer = new LogTransformer({ isVerbose: context.isVerbose });
 
-  const errors = await Promise.all(
-    options.platforms.map(async (platform) => {
-      const format = options.format ?? (platform !== 'node' ? 'esm' : 'cjs');
-      const extension = format === 'esm' ? '.mjs' : '.cjs';
-      const outdir = `${options.outputPath}/${platform}`;
+    const errors = await Promise.all(
+      options.platforms.map(async (platform) => {
+        const format = options.format ?? (platform !== 'node' ? 'esm' : 'cjs');
+        const extension = format === 'esm' ? '.mjs' : '.cjs';
+        const outdir = `${options.outputPath}/${platform}`;
 
-      const start = Date.now();
-      const result = await build({
-        entryPoints: options.entryPoints,
-        outdir,
-        outExtension: { '.js': extension },
-        format,
-        write: true,
-        splitting: format === 'esm',
-        sourcemap: options.sourcemap,
-        metafile: options.metafile,
-        bundle: options.bundle,
-        // watch: options.watch,
-        alias: options.alias,
-        platform,
-        // https://esbuild.github.io/api/#log-override
-        logOverride: {
-          // The log transform was generating this warning.
-          'this-is-undefined-in-esm': 'info',
-        },
-        plugins: [
-          // TODO(wittjosiah): Factor out plugin and use for running browser tests as well.
-          {
-            name: 'node-external',
-            setup: ({ initialOptions, onResolve }) => {
-              if (options.injectGlobals && platform === 'browser') {
-                if (!packageJson.dependencies['@dxos/node-std']) {
-                  throw new Error('Missing @dxos/node-std dependency.');
+        const start = Date.now();
+        const result = await build({
+          entryPoints: options.entryPoints,
+          outdir,
+          outExtension: { '.js': extension },
+          format,
+          write: true,
+          splitting: format === 'esm',
+          sourcemap: options.sourcemap,
+          metafile: options.metafile,
+          bundle: options.bundle,
+          // watch: options.watch,
+          alias: options.alias,
+          platform,
+          // https://esbuild.github.io/api/#log-override
+          logOverride: {
+            // The log transform was generating this warning.
+            'this-is-undefined-in-esm': 'info',
+          },
+          plugins: [
+            // TODO(wittjosiah): Factor out plugin and use for running browser tests as well.
+            {
+              name: 'node-external',
+              setup: ({ initialOptions, onResolve }) => {
+                if (options.injectGlobals && platform === 'browser') {
+                  if (!packageJson.dependencies['@dxos/node-std']) {
+                    throw new Error('Missing @dxos/node-std dependency.');
+                  }
+
+                  initialOptions.banner ||= {};
+                  initialOptions.banner.js = 'import "@dxos/node-std/globals";';
                 }
 
-                initialOptions.banner ||= {};
-                initialOptions.banner.js = 'import "@dxos/node-std/globals";';
-              }
+                onResolve({ filter: /^node:.*/ }, (args) => {
+                  if (platform !== 'browser') {
+                    return null;
+                  }
 
-              onResolve({ filter: /^node:.*/ }, (args) => {
-                if (platform !== 'browser') {
-                  return null;
-                }
+                  if (!packageJson.dependencies['@dxos/node-std']) {
+                    return { errors: [{ text: 'Missing @dxos/node-std dependency.' }] };
+                  }
 
-                if (!packageJson.dependencies['@dxos/node-std']) {
-                  return { errors: [{ text: 'Missing @dxos/node-std dependency.' }] };
-                }
+                  const module = args.path.replace(/^node:/, '');
+                  return { external: true, path: `@dxos/node-std/${module}` };
+                });
+              },
+            } satisfies Plugin,
+            fixRequirePlugin(),
+            bundleDepsPlugin({
+              packages: options.bundlePackages,
+              packageDir: dirname(packagePath),
+              ignore: options.ignorePackages,
+              alias: options.alias,
+            }),
+            logTransformer.createPlugin(),
+            RawPlugin(),
+            // Substitute '/*?url' imports with empty string.
+            {
+              name: 'url',
+              setup: ({ onResolve, onLoad }) => {
+                onResolve({ filter: /\?url$/ }, (args) => {
+                  return {
+                    path: args.path.replace(/\?url$/, '/empty-url'),
+                    namespace: 'url',
+                  };
+                });
 
-                const module = args.path.replace(/^node:/, '');
-                return { external: true, path: `@dxos/node-std/${module}` };
-              });
-            },
-          } satisfies Plugin,
-          fixRequirePlugin(),
-          bundleDepsPlugin({
-            packages: options.bundlePackages,
-            packageDir: dirname(packagePath),
-            ignore: options.ignorePackages,
-            alias: options.alias,
-          }),
-          logTransformer.createPlugin(),
-          RawPlugin(),
-          // Substitute '/*?url' imports with empty string.
-          {
-            name: 'url',
-            setup: ({ onResolve, onLoad }) => {
-              onResolve({ filter: /\?url$/ }, (args) => {
-                return {
-                  path: args.path.replace(/\?url$/, '/empty-url'),
-                  namespace: 'url',
-                };
-              });
+                onLoad({ filter: /\/empty-url/, namespace: 'url' }, async (args) => {
+                  return { contents: 'export default ""' };
+                });
+              },
+            } satisfies Plugin,
+            yamlPlugin({}),
+          ],
+        });
 
-              onLoad({ filter: /\/empty-url/, namespace: 'url' }, async (args) => {
-                return { contents: 'export default ""' };
-              });
-            },
-          } satisfies Plugin,
-          yamlPlugin({}),
-        ],
-      });
+        await writeFile(`${outdir}/meta.json`, JSON.stringify(result.metafile), 'utf-8');
 
-      await writeFile(`${outdir}/meta.json`, JSON.stringify(result.metafile), 'utf-8');
+        if (context.isVerbose) {
+          console.log(`Build took ${Date.now() - start}ms.`);
+        }
 
-      if (context.isVerbose) {
-        console.log(`Build took ${Date.now() - start}ms.`);
-      }
+        return result.errors;
+      }),
+    );
 
-      return result.errors;
-    }),
-  );
+    if (options.watch) {
+      await new Promise(() => {}); // Wait indefinitely.
+    }
 
-  if (options.watch) {
-    await new Promise(() => { }); // Wait indefinitely.
-  }
-
-  return { success: errors.flat().length === 0 };
-});
-
+    return { success: errors.flat().length === 0 };
+  },
+);
 
 export default async (options: EsbuildExecutorOptions, context: ExecutorContext): Promise<{ success: boolean }> => {
   const projectRoot = context.workspace!.projects[context.projectName!].root;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bba0b10</samp>

### Summary
🚀🛠️📦

<!--
1.  🚀 - This emoji represents the performance improvement and the new feature of using a daemon process for the `esbuild` executor.
2.  🛠️ - This emoji represents the reliability improvement and the bug fixes for the `esbuild` executor and the type imports and assertions.
3.  📦 - This emoji represents the addition of the `anfang` package and its dependencies, files, and configuration.
-->
This pull request introduces a new package called `anfang`, which is a tool for daemonizing Node.js scripts and communicating with them using RPC. It also improves the `esbuild` executor by using `anfang` to run a daemon process and dynamic imports. Additionally, it updates some configuration files for VSCode, release-please, ESLint, and TypeScript.

> _Oh, we're the crew of the `esbuild` ship_
> _And we sail the code with speed and zip_
> _We fork the daemons with `anfang` tool_
> _And we heave away on the count of three, pull!_

### Walkthrough
*  Add `anfang` package to provide a utility for forking Node.js scripts as daemon processes and communicating with them using RPC over a Unix socket ([link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R36), [link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-c55d4dcb68c348b2c06d263819702fbce72eeeb35b662956d02049a5a18fcf2bR682-R686), [link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-165035ecd3ac4b7d2b0b6ea830c27f3da6c1b7f5f1a71a926983a5768fb95960R1-R9), [link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-195b96f24686196cbe47db9561d862b8f742952829de54489e7bdf8cdc77b995L1-R7), [link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-56014ef56def4a4a50b4f7c71b2afee6faf253ed8c5541f9c54bbf4097984407R1-R21), [link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-80a40c80e08660ee09e50e73b828be9c1e577c998fe7514fa0ee5d537c9fd4e1R1-R14), [link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-75ecffccd01881a7e882beba18a57e4d7220cc95f9d12ec82d89f147a34bd83cR1-R24), [link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-0328a969f48d8cbaf93732c3d0e360de46a71dc45e96a54d4b6b4682dd5ef957R1-R31), [link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-186df33b30c1d2654b7575f11acd6f04cca54972f265853ddf8b1d558ef6a173R1-R168), [link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-34df9a3fb9287201d09c9b1df23c95f1714d6a6fca202e6c070be6f5434a242fR1-R272), [link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-656bc82a9a603c645991c72a6c974a8985673cd85638ba0353a92ddb67496032R1-R33), [link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-6f6d6be3951ba915eab3cf738f04790c82de2b3c22ef58f80be416859ee46eefR1-R17))
*  Modify `esbuild` executor to use `anfang` package to run the `build` function in a daemon process and dynamically import the dependencies and modules for the build ([link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-2e83c141910d129760ef80f9ddd052decd9ba61007062b42121b46b81e0179e2L6-R8), [link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-2e83c141910d129760ef80f9ddd052decd9ba61007062b42121b46b81e0179e2L31-R164))
*  Add `tools/anfang/.eslintrc.js` file to enable linting and type checking for `anfang` package ([link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-165035ecd3ac4b7d2b0b6ea830c27f3da6c1b7f5f1a71a926983a5768fb95960R1-R9))
*  Add `tools/anfang/eslint-config.json` file to enable `packlet` linting rules for `anfang` package ([link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-80a40c80e08660ee09e50e73b828be9c1e577c998fe7514fa0ee5d537c9fd4e1R1-R14))
*  Add `tools/anfang/LICENSE` file to specify the MIT license terms for `anfang` package ([link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-195b96f24686196cbe47db9561d862b8f742952829de54489e7bdf8cdc77b995L1-R7))
*  Add `tools/anfang/README.md` file to provide documentation for `anfang` package ([link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-56014ef56def4a4a50b4f7c71b2afee6faf253ed8c5541f9c54bbf4097984407R1-R21))
*  Add `tools/anfang/src/test.ts` file to demonstrate the usage of `anfang` package ([link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-656bc82a9a603c645991c72a6c974a8985673cd85638ba0353a92ddb67496032R1-R33))
*  Add `anfang` folder to the list of folders that are excluded from the VSCode search ([link](https://github.com/dxos/dxos/pull/4237/files?diff=unified&w=0#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R9))


