### PR TITLE
test(plugin-treeview): add navtree story

### DIFF
--- a/packages/apps/plugins/plugin-graph/package.json
+++ b/packages/apps/plugins/plugin-graph/package.json
@@ -7,9 +7,27 @@
   "license": "MIT",
   "author": "DXOS.org",
   "exports": {
-    ".": "./dist/lib/browser/index.mjs"
+    ".": {
+      "browser": "./dist/lib/browser/index.mjs",
+      "import": "./dist/lib/browser/index.mjs",
+      "require": "./dist/lib/node/index.cjs",
+      "node": "./dist/lib/node/index.cjs"
+    },
+    "./testing": {
+      "browser": "./dist/lib/browser/testing.mjs",
+      "import": "./dist/lib/browser/testing.mjs",
+      "require": "./dist/lib/node/testing.cjs",
+      "node": "./dist/lib/node/testing.cjs"
+    }
   },
   "types": "dist/types/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "testing": [
+        "dist/types/src/testing.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist",
     "src"

--- a/packages/apps/plugins/plugin-graph/project.json
+++ b/packages/apps/plugins/plugin-graph/project.json
@@ -17,12 +17,10 @@
       "executor": "@dxos/esbuild:build",
       "options": {
         "entryPoints": [
-          "packages/apps/plugins/plugin-graph/src/index.ts"
+          "packages/apps/plugins/plugin-graph/src/index.ts",
+          "packages/apps/plugins/plugin-graph/src/testing.ts"
         ],
-        "outputPath": "packages/apps/plugins/plugin-graph/dist/lib",
-        "platforms": [
-          "browser"
-        ]
+        "outputPath": "packages/apps/plugins/plugin-graph/dist/lib"
       },
       "outputs": [
         "{options.outputPath}"

--- a/packages/apps/plugins/plugin-graph/src/graph/graph.test.ts
+++ b/packages/apps/plugins/plugin-graph/src/graph/graph.test.ts
@@ -7,9 +7,9 @@ import { expect } from 'chai';
 import { describe, test } from '@dxos/test';
 
 import { GraphStore } from './graph';
-import { Graph } from './types';
+import { createTestNodeBuilder } from './test-node-builder';
 
-describe.only('SessionGraph', () => {
+describe('SessionGraph', () => {
   test('returns root node', () => {
     const graph = new GraphStore();
     expect(graph.root).to.not.be.undefined;
@@ -216,94 +216,3 @@ describe.only('SessionGraph', () => {
     expect(nodes).to.deep.equal(['root-test2-test1', 'root-test2', 'root']);
   });
 });
-
-const checkDepth = (node: Graph.Node, depth = 0): number => {
-  if (!node.parent) {
-    return depth;
-  }
-
-  return checkDepth(node.parent, depth + 1);
-};
-
-const createTestNodeBuilder = (id: string, depth = 1) => {
-  const nodes = new Map<string, Graph.Node>();
-  const builder: Graph.NodeBuilder = (parent) => {
-    if (checkDepth(parent) >= depth) {
-      return;
-    }
-
-    const [child] = parent.add({
-      id: `${parent.id}-${id}`,
-      label: `${parent.id}-${id}`,
-      data: null,
-      parent,
-    });
-
-    parent.addAction({
-      id: `${parent.id}-${id}`,
-      label: `${parent.id}-${id}`,
-      intent: { action: 'test' },
-    });
-
-    nodes.set(parent.id, parent);
-    nodes.set(child.id, child);
-  };
-
-  const addNode = (parentId: string, node: Pick<Graph.Node, 'id' | 'label'> & Partial<Graph.Node>) => {
-    const parent = nodes.get(parentId);
-    if (!parent) {
-      return;
-    }
-
-    const [child] = parent.add(node);
-    nodes.set(child.id, child);
-    return child;
-  };
-
-  const removeNode = (parentId: string, id: string) => {
-    const parent = nodes.get(parentId);
-    if (!parent) {
-      return;
-    }
-
-    return parent.remove(id);
-  };
-
-  const addAction = (parentId: string, action: Pick<Graph.Action, 'id' | 'label'> & Partial<Graph.Action>) => {
-    const parent = nodes.get(parentId);
-    if (!parent) {
-      return;
-    }
-
-    return parent.addAction(action);
-  };
-
-  const removeAction = (parentId: string, id: string) => {
-    const parent = nodes.get(parentId);
-    if (!parent) {
-      return;
-    }
-
-    return parent.removeAction(id);
-  };
-
-  const addProperty = (parentId: string, key: string, value: any) => {
-    const parent = nodes.get(parentId);
-    if (!parent) {
-      return;
-    }
-
-    return parent.addProperty(key, value);
-  };
-
-  const removeProperty = (parentId: string, key: string) => {
-    const parent = nodes.get(parentId);
-    if (!parent) {
-      return;
-    }
-
-    return parent.removeProperty(key);
-  };
-
-  return { builder, addNode, removeNode, addAction, removeAction, addProperty, removeProperty };
-};

--- a/packages/apps/plugins/plugin-graph/src/graph/test-node-builder.ts
+++ b/packages/apps/plugins/plugin-graph/src/graph/test-node-builder.ts
@@ -1,0 +1,147 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Graph } from './types';
+
+const checkDepth = (node: Graph.Node, depth = 0): number => {
+  if (!node.parent) {
+    return depth;
+  }
+
+  return checkDepth(node.parent, depth + 1);
+};
+
+/**
+ * Create a test node builder that always adds nodes and actions to the specified depth.
+ *
+ * @param id The id of the node builder, used to identify nodes created by this builder.
+ * @param depth The depth at which to add nodes and actions.
+ * @default 1
+ *
+ * @returns A test node builder
+ */
+export const createTestNodeBuilder = (id: string, depth = 1) => {
+  const nodes = new Map<string, Graph.Node>();
+  const builder: Graph.NodeBuilder = (parent) => {
+    if (checkDepth(parent) >= depth) {
+      return;
+    }
+
+    const [child] = parent.add({
+      id: `${parent.id}-${id}`,
+      label: `${parent.id}-${id}`,
+      data: null,
+      parent,
+    });
+
+    parent.addAction({
+      id: `${parent.id}-${id}`,
+      label: `${parent.id}-${id}`,
+      intent: { action: 'test' },
+    });
+
+    nodes.set(parent.id, parent);
+    nodes.set(child.id, child);
+  };
+
+  const addNode = (parentId: string, node: Pick<Graph.Node, 'id' | 'label'> & Partial<Graph.Node>) => {
+    const parent = nodes.get(parentId);
+    if (!parent) {
+      return;
+    }
+
+    const [child] = parent.add(node);
+    nodes.set(child.id, child);
+    return child;
+  };
+
+  const removeNode = (parentId: string, id: string) => {
+    const parent = nodes.get(parentId);
+    if (!parent) {
+      return;
+    }
+
+    return parent.remove(id);
+  };
+
+  const addAction = (parentId: string, action: Pick<Graph.Action, 'id' | 'label'> & Partial<Graph.Action>) => {
+    const parent = nodes.get(parentId);
+    if (!parent) {
+      return;
+    }
+
+    return parent.addAction(action);
+  };
+
+  const removeAction = (parentId: string, id: string) => {
+    const parent = nodes.get(parentId);
+    if (!parent) {
+      return;
+    }
+
+    return parent.removeAction(id);
+  };
+
+  const addProperty = (parentId: string, key: string, value: any) => {
+    const parent = nodes.get(parentId);
+    if (!parent) {
+      return;
+    }
+
+    return parent.addProperty(key, value);
+  };
+
+  const removeProperty = (parentId: string, key: string) => {
+    const parent = nodes.get(parentId);
+    if (!parent) {
+      return;
+    }
+
+    return parent.removeProperty(key);
+  };
+
+  return { builder, addNode, removeNode, addAction, removeAction, addProperty, removeProperty };
+};
+
+/**
+ * Build a graph from a nested list of nodes.
+ *
+ * @param graph Graph to add nodes to.
+ * @param nodes Nodes to add to the graph.
+ *
+ * @example
+ * const graph = new GraphStore();
+ * buildGraph(graph, [
+ *   {
+ *     id: 'test1',
+ *     label: 'test1',
+ *     children: [
+ *       {
+ *         id: 'test1.1',
+ *         label: 'test1.1',
+ *       },
+ *       {
+ *         id: 'test1.2',
+ *         label: 'test1.2',
+ *       },
+ *     ],
+ *   },
+ *   {
+ *     id: 'test2',
+ *     label: 'test2',
+ *   },
+ * ]);
+ */
+// TODO(wittjosiah): Type nodes.
+export const buildGraph = (graph: Graph, nodes: any[]) => {
+  addNodes(graph.root, nodes);
+};
+
+const addNodes = (root: Graph.Node, nodes: any[]) => {
+  nodes.forEach((node) => {
+    const [child] = root.add(node);
+    addNodes(child, node.children || []);
+    node.actions?.forEach((action: any) => child.addAction(action));
+  });
+};

--- a/packages/apps/plugins/plugin-graph/src/testing.ts
+++ b/packages/apps/plugins/plugin-graph/src/testing.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+export * from './graph/test-node-builder';

--- a/packages/apps/plugins/plugin-treeview/.storybook/main.cjs
+++ b/packages/apps/plugins/plugin-treeview/.storybook/main.cjs
@@ -1,0 +1,32 @@
+const { mergeConfig } = require('vite');
+const { resolve } = require('path');
+
+const { ThemePlugin } = require('@dxos/aurora-theme/plugin');
+
+module.exports = {
+  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions'
+  ],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {}
+  },
+  viteFinal: async (config) =>
+    mergeConfig(config, {
+      define: {
+        // TODO(thure): Why is this necessary?
+        'process.env.NODE_DEBUG': false,
+      },
+      plugins: [
+        ThemePlugin({
+          root: __dirname,
+          content: [
+            resolve(__dirname, '../src/**/*.{js,ts,jsx,tsx}'),
+          ]
+        })
+      ]
+    })
+};

--- a/packages/apps/plugins/plugin-treeview/.storybook/preview-head.html
+++ b/packages/apps/plugins/plugin-treeview/.storybook/preview-head.html
@@ -1,0 +1,9 @@
+<script>
+  window.global = window;
+</script>
+<style>
+  html, body {
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+</style>

--- a/packages/apps/plugins/plugin-treeview/.storybook/preview.cjs
+++ b/packages/apps/plugins/plugin-treeview/.storybook/preview.cjs
@@ -1,0 +1,41 @@
+import React, { createElement, useEffect } from 'react';
+import { ThemeProvider } from '@dxos/aurora';
+
+export const parameters = {
+  actions: { argTypesRegex: '^on[A-Z].*' },
+  controls: {
+    matchers: {
+      color: /(background|color)$/i,
+      date: /Date$/
+    }
+  }
+};
+
+export const globalTypes = {
+  theme: {
+    name: 'Theme',
+    description: 'Global theme for components',
+    defaultValue: 'light',
+    toolbar: {
+      // The icon for the toolbar item
+      icon: 'circlehollow',
+      // Array of options
+      items: [
+        { value: 'light', icon: 'circlehollow', title: 'light' },
+        { value: 'dark', icon: 'circle', title: 'dark' },
+      ],
+      // Property that specifies if the name of the item will be displayed
+      showName: true,
+    },
+  },
+}
+
+const withTheme = (StoryFn, context) => {
+  const theme = context?.parameters?.theme || context?.globals?.theme;
+  useEffect(()=>{
+    document.documentElement.classList[theme === 'dark' ? 'add' : 'remove']('dark')
+  }, [theme])
+  return createElement(ThemeProvider, {children: createElement(StoryFn)})
+}
+
+export const decorators = [withTheme];

--- a/packages/apps/plugins/plugin-treeview/project.json
+++ b/packages/apps/plugins/plugin-treeview/project.json
@@ -40,6 +40,17 @@
       "outputs": [
         "{options.outputFile}"
       ]
+    },
+    "storybook": {
+      "configurations": {
+        "ci": {
+          "quiet": true
+        }
+      },
+      "executor": "@nx/storybook:storybook",
+      "options": {
+        "configDir": "packages/apps/plugins/plugin-treeview/.storybook"
+      }
     }
   },
   "implicitDependencies": [

--- a/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTree.stories.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTree.stories.tsx
@@ -1,0 +1,90 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import '@dxosTheme';
+
+import { RevertDeepSignal, deepSignal } from 'deepsignal/react';
+import React from 'react';
+
+import { DndPluginContext, DndPluginStoreValue } from '@braneframe/plugin-dnd';
+import { GraphContext, GraphStore } from '@braneframe/plugin-graph';
+import { buildGraph } from '@braneframe/plugin-graph/testing';
+import { SplitViewContext, SplitViewState } from '@braneframe/plugin-splitview';
+import { Tooltip, Tree } from '@dxos/aurora';
+
+import { TreeViewSortableImpl } from './NavTree';
+import { TreeViewContext } from '../../TreeViewContext';
+import { TreeViewContextValue } from '../../types';
+
+export default {
+  component: TreeViewSortableImpl,
+};
+
+const graph = new GraphStore();
+buildGraph(graph, [
+  {
+    id: 'test1',
+    label: 'test1',
+    children: [
+      {
+        id: 'test1.1',
+        label: 'test1.1',
+      },
+      {
+        id: 'test1.2',
+        label: 'test1.2',
+      },
+    ],
+  },
+  {
+    id: 'test2',
+    label: 'test2',
+  },
+]);
+
+const dndState = deepSignal<DndPluginStoreValue>({
+  overlayDropAnimation: 'away',
+});
+
+const splitViewState = deepSignal<SplitViewState>({
+  sidebarOpen: true,
+  complementarySidebarOpen: true,
+  dialogContent: 'never',
+  dialogOpen: false,
+});
+
+const treeViewState = deepSignal<TreeViewContextValue>({
+  active: undefined,
+  previous: undefined,
+  get activeNode() {
+    return this.active && graph.find(this.active);
+  },
+  get previousNode() {
+    return this.previous && graph.find(this.previous);
+  },
+  appState: undefined,
+}) as RevertDeepSignal<TreeViewContextValue>;
+
+export const Default = {
+  render: () => (
+    <Tree.Root>
+      <TreeViewSortableImpl {...{ node: graph.root, items: graph.root.children, level: 0 }} />
+    </Tree.Root>
+  ),
+  decorators: [
+    (Story: any) => (
+      <Tooltip.Provider>
+        <DndPluginContext.Provider value={dndState}>
+          <GraphContext.Provider value={{ graph }}>
+            <SplitViewContext.Provider value={splitViewState}>
+              <TreeViewContext.Provider value={treeViewState}>
+                <Story />
+              </TreeViewContext.Provider>
+            </SplitViewContext.Provider>
+          </GraphContext.Provider>
+        </DndPluginContext.Provider>
+      </Tooltip.Provider>
+    ),
+  ],
+};

--- a/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTree.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTree.tsx
@@ -39,7 +39,18 @@ export const NavTree = (props: TreeViewProps) => {
 
 type NavTreeDropType = 'rearrange' | 'migrate-origin' | 'migrate-destination' | null;
 
-const TreeViewSortableImpl = ({ node, items, level }: { node: Graph.Node; items: Graph.Node[]; level: number }) => {
+/**
+ * @internal Storybook only
+ */
+export const TreeViewSortableImpl = ({
+  node,
+  items,
+  level,
+}: {
+  node: Graph.Node;
+  items: Graph.Node[];
+  level: number;
+}) => {
   const dnd = useDnd();
 
   const [activeNode, setActiveNode] = useState<Graph.Node | null>(null);

--- a/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTreeItem.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/NavTree/NavTreeItem.tsx
@@ -102,7 +102,9 @@ export const NavTreeItem: ForwardRefExoticComponent<TreeViewItemProps & RefAttri
     const actions = sortActions(node.actions);
     const { t } = useTranslation(TREE_VIEW_PLUGIN);
     const { navigationSidebarOpen } = useSidebars();
+    // TODO(wittjosiah): Pass in as prop.
     const { active: treeViewActive } = useTreeView();
+    // TODO(wittjosiah): Pass in as prop.
     const { popoverAnchorId } = useSplitView();
     const { graph } = useGraph();
 
@@ -118,6 +120,7 @@ export const NavTreeItem: ForwardRefExoticComponent<TreeViewItemProps & RefAttri
     const testId = node.properties?.['data-testid'];
 
     useEffect(() => {
+      // TODO(wittjosiah): Factor out as callback so that this doesn't depend on graph context.
       // Excludes selected node from being opened by selection.
       if (treeViewActive && graph.getPath(treeViewActive)?.slice(0, -2).includes(node.id)) {
         setOpen(true);


### PR DESCRIPTION

![image](https://github.com/dxos/dxos/assets/4529818/a03bc898-b122-44b7-b62a-add188842ad5)


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3ea9670</samp>

### Summary
📦🧪📚

<!--
1.  📦 - This emoji represents the changes related to the `exports` and `entryPoints` fields of the `plugin-graph` package, which affect how the package is packaged and imported by other modules.
2.  🧪 - This emoji represents the changes related to the testing utilities of the `plugin-graph` package, which affect how the package is tested and how it provides testing helpers to other packages.
3.  📚 - This emoji represents the changes related to the Storybook tool of the `plugin-treeview` package, which affect how the package develops and documents its UI components.
-->
This pull request refactors some components and tests in the `plugin-graph` and `plugin-treeview` packages, and adds Storybook support for the `plugin-treeview` package. The main changes are:

> _We are the masters of the graph, we export our power to the world_
> _We use the Storybook to tell our tales, we show our components in the light_
> _We refactor and improve our code, we test our logic and our nodes_
> _We are the plugin-treeview, we render the tree of doom and glory_

### Walkthrough
*  Update `exports` field in `package.json` to support different module formats and entry points for browser and node environments ([link](https://github.com/dxos/dxos/pull/4238/files?diff=unified&w=0#diff-12132ff5f40ad790922d7afe36c3c858e243e075af7ebf71c7cba4944d991c47L10-R30))
*  Add `src/testing.ts` file as a new entry point for testing utilities and export `test-node-builder.ts` file from it ([link](https://github.com/dxos/dxos/pull/4238/files?diff=unified&w=0#diff-95bd1ce5038f21700f60949e62c800aa6b6a27acf23c6c8392d9d793c0b7f622R1-R5), [link](https://github.com/dxos/dxos/pull/4238/files?diff=unified&w=0#diff-468e61a0cb12e482d6100a8c252a1c26a3ff865a6c509283fe6e01ab89cf18adR1-R147))
*  Move `createTestNodeBuilder` function and its dependencies from `graph.test.ts` to `test-node-builder.ts` and add `buildGraph` function to create a graph from a nested list of nodes ([link](https://github.com/dxos/dxos/pull/4238/files?diff=unified&w=0#diff-297703948494cd3f8703ab7810c73b83133a88ff3b723ec6a4efc8242782602fL219-L309), [link](https://github.com/dxos/dxos/pull/4238/files?diff=unified&w=0#diff-468e61a0cb12e482d6100a8c252a1c26a3ff865a6c509283fe6e01ab89cf18adR1-R147))
*  Remove `describe.only` call from `graph.test.ts` to run all tests as expected ([link](https://github.com/dxos/dxos/pull/4238/files?diff=unified&w=0#diff-297703948494cd3f8703ab7810c73b83133a88ff3b723ec6a4efc8242782602fL10-R12))
*  Add Storybook configuration and stories for `plugin-treeview` package to showcase its components and their functionality ([link](https://github.com/dxos/dxos/pull/4238/files?diff=unified&w=0#diff-ee891f3dd0a0efcdb76fa5550ee7ca75fd51236b2f5fd7cede07cbd0c1697442R1-R32), [link](https://github.com/dxos/dxos/pull/4238/files?diff=unified&w=0#diff-45605d3be6d4513fb39a22b85d8c5100bf0162c4d4672c93a00cf5cc2e60d1e8R1-R9), [link](https://github.com/dxos/dxos/pull/4238/files?diff=unified&w=0#diff-634a186a4271eaccbd7747c4c7bf2907083a9a626991f22223dbd87706c35f59R1-R41), [link](https://github.com/dxos/dxos/pull/4238/files?diff=unified&w=0#diff-46b31b622a78eeaa6bf655854fe9d233d2a9b45595fbd88b5890140acc7a9771R43-R53), [link](https://github.com/dxos/dxos/pull/4238/files?diff=unified&w=0#diff-e09cf187a55b8a634bebdb1c6eb420262e2f5c7668a77c894a3f62fb9742c604R1-R90))
*  Export and annotate `TreeViewSortableImpl` component as internal in `NavTree.tsx` to use it in stories without exposing it to other packages ([link](https://github.com/dxos/dxos/pull/4238/files?diff=unified&w=0#diff-ed496088285c2f0f92b5984d04cd924edf3151b521719e1632bc7175e2b95607L42-R53))
*  Add `TODO` comments to `NavTreeItem.tsx` to indicate that the component should be decoupled from specific contexts and graphs and use props instead of hooks ([link](https://github.com/dxos/dxos/pull/4238/files?diff=unified&w=0#diff-e700eace56b0e8dc83f2925205cefb12dbcf40c101ca6cf27b0b45c7c4bb22d7L105-R107), [link](https://github.com/dxos/dxos/pull/4238/files?diff=unified&w=0#diff-e700eace56b0e8dc83f2925205cefb12dbcf40c101ca6cf27b0b45c7c4bb22d7R123))


