### PR TITLE
fix(composer): handle client being uninitialized

### DIFF
--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -276,6 +276,9 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
           }
 
           const client = clientPlugin.provides.client;
+          if (!client.spaces.isReady.get()) {
+            return;
+          }
 
           // Ensure default space is always first.
           spaceToGraphNode({ space: client.spaces.default, parent, settings: settings.values });

--- a/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/TreeViewPlugin.tsx
@@ -52,15 +52,13 @@ export const TreeViewPlugin = (): PluginDefinition<TreeViewPluginProvides> => {
       graphPlugin = findPlugin<GraphPluginProvides>(plugins, 'dxos.org/plugin/graph');
 
       const clientPlugin = findPlugin<ClientPluginProvides>(plugins, 'dxos.org/plugin/client');
-      if (!clientPlugin) {
+      const client = clientPlugin?.provides.client;
+      if (!client?.spaces.isReady.get()) {
         return;
       }
 
-      const client = clientPlugin.provides.client;
-      const defaultSpace = client.spaces.default;
-      await defaultSpace.waitUntilReady();
-
       // Ensure defaultSpace has the app state persistor
+      const defaultSpace = client.spaces.default;
       const appStates = defaultSpace.db.query(AppState.filter()).objects;
       if (appStates.length < 1) {
         const appState = new AppState();


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7e23125</samp>

### Summary
🛡️🧹🚀

<!--
1.  🛡️ - This emoji represents protection or security, which is related to the first change of adding a condition to prevent errors or unexpected behavior.
2.  🧹 - This emoji represents cleaning or simplifying, which is related to the second change of using optional chaining and removing redundant code.
3.  🚀 - This emoji represents speed or performance, which is related to the overall improvement of the space plugin rendering by avoiding unnecessary waits or checks.
-->
This pull request improves the rendering logic of the `SpacePlugin` and the `TreeViewPlugin` by checking the readiness of the client spaces and using optional chaining. It also removes some unnecessary code and fixes potential errors.

> _`client` plugin waits_
> _for spaces to be ready_
> _autumn leaves falling_

### Walkthrough
*  Prevent rendering space plugin until client spaces are ready ([link](https://github.com/dxos/dxos/pull/4246/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839R279-R281))
*  Simplify code by using optional chaining for client plugin and client object in treeview plugin ([link](https://github.com/dxos/dxos/pull/4246/files?diff=unified&w=0#diff-9a66c7d56ee624df73971bbd0761d8e07a33294b4945f9a4167d111aa88c6547L55-R61))


