### PR TITLE
chore: cleanup bundle issues

### DIFF
--- a/packages/apps/halo-app/vite.config.ts
+++ b/packages/apps/halo-app/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
       },
       output: {
         manualChunks: {
-          vendor: ['react', 'react-router-dom', 'react-dom'],
+          vendor: ['react', 'react-dom'],
         },
       },
     },

--- a/packages/core/mesh/network-manager/package.json
+++ b/packages/core/mesh/network-manager/package.json
@@ -8,7 +8,7 @@
   "author": "DXOS.org",
   "main": "dist/lib/node/index.cjs",
   "browser": {
-    "./src/transport/tcp-transport.ts": false,
+    "./src/transport/tcp-transport.ts": "./src/transport/tcp-transport.browser.ts",
     "./dist/lib/node/index.cjs": "./dist/lib/browser/index.mjs",
     "./dist/lib/node/testing/index.cjs": "./dist/lib/browser/testing/index.mjs",
     "./src/transport/datachannel/index.ts": "./src/transport/datachannel/index.browser.ts"

--- a/packages/core/mesh/network-manager/src/transport/tcp-transport.browser.ts
+++ b/packages/core/mesh/network-manager/src/transport/tcp-transport.browser.ts
@@ -1,0 +1,28 @@
+//
+// Copyright 2020 DXOS.org
+//
+
+import { Event } from '@dxos/async';
+import { ErrorStream } from '@dxos/debug';
+
+import { Transport, TransportFactory } from './transport';
+
+// NOTE: Browser stub.
+
+export const TcpTransportFactory: TransportFactory = {
+  createTransport: () => new TcpTransport(),
+};
+
+export class TcpTransport implements Transport {
+  public readonly closed = new Event<void>();
+  public readonly connected = new Event<void>();
+  public readonly errors = new ErrorStream();
+
+  async destroy() {
+    throw new Error('Method not implemented.');
+  }
+
+  signal() {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/packages/ui/aurora-grid/package.json
+++ b/packages/ui/aurora-grid/package.json
@@ -16,7 +16,7 @@
     "src"
   ],
   "scripts": {
-    "chromatic": "chromatic --only-changed --project-token=\"44ade288043a\" --storybook-build-dir out/aurora --exit-zero-on-changes"
+    "chromatic": "true"
   },
   "dependencies": {
     "@dxos/aurora": "workspace:*",

--- a/packages/ui/aurora-table/package.json
+++ b/packages/ui/aurora-table/package.json
@@ -16,7 +16,7 @@
     "src"
   ],
   "scripts": {
-    "chromatic": "chromatic --only-changed --project-token=\"44ade288043a\" --storybook-build-dir out/aurora --exit-zero-on-changes"
+    "chromatic": "true"
   },
   "dependencies": {
     "@dxos/async": "workspace:*",


### PR DESCRIPTION
Based on errors observed here https://app.circleci.com/pipelines/github/dxos/dxos/15212/workflows/5bd2da47-e4ba-4ada-8c12-37a0e64d1686/jobs/33462

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2f92611</samp>

### Summary
📦🌐🚫

<!--
1.  📦 - This emoji represents the removal of a dependency from a package or bundle, as in the first change.
2.  🌐 - This emoji represents the modification of a package or module to support different environments, such as node and browser, as in the second and third changes.
3.  🚫 - This emoji represents the disabling of a feature or tool, as in the fourth and fifth changes.
-->
This pull request removes unnecessary dependencies, fixes browser compatibility issues, and disables problematic testing tools for some packages. The main affected files are `vite.config.ts`, `package.json`, and `tcp-transport.browser.ts` in the `halo-app`, `network-manager`, `aurora-grid`, and `aurora-table` packages.

> _`react-router-dom`_
> _Gone from vendor bundle now_
> _Lighter and conflict-free_

### Walkthrough
*  Remove `react-router-dom` from vendor bundle to reduce size and avoid conflicts ([link](https://github.com/dxos/dxos/pull/4247/files?diff=unified&w=0#diff-a745999da1e2bed73f69f9a92baaad22d02ded554612912cb17f5727cfdb516eL45-R45))
*  Modify `browser` field in `network-manager` package.json to use browser stub for `tcp-transport` module ([link](https://github.com/dxos/dxos/pull/4247/files?diff=unified&w=0#diff-e727f83f076fefab87dcde1fe16acac7ef4a6311bf70a41beeae3752aa5c7841L11-R11))
*  Add `tcp-transport.browser.ts` file to `network-manager` package as a dummy class that implements Transport interface but throws errors ([link](https://github.com/dxos/dxos/pull/4247/files?diff=unified&w=0#diff-9d01856a9fc95fe4505c7e9849f1e67359cc871f0fef86146c9dca8e67a7f33fR1-R28))
*  Change `chromatic` scripts in `aurora-grid` and `aurora-table` package.json files to no-op commands to disable visual testing ([link](https://github.com/dxos/dxos/pull/4247/files?diff=unified&w=0#diff-6ed2f04c06cadb1014a8f8eb9a9de58730e9127cf471159ff6512f1f1a48ce5cL19-R19), [link](https://github.com/dxos/dxos/pull/4247/files?diff=unified&w=0#diff-c9fcd442fd0c40a0a84ca8bd8d85430b511dba3df8d6a412c416821bc8dc67fdL19-R19))


