### PR TITLE
fix(cli): Finish renaming `path` -> `dataRoot` in configs

### DIFF
--- a/packages/core/agent/src/daemon.ts
+++ b/packages/core/agent/src/daemon.ts
@@ -15,7 +15,6 @@ export type ProcessInfo = {
 export type StartOptions = {
   config?: string;
   metrics?: boolean;
-  monitor?: boolean;
   ws?: number;
 };
 

--- a/packages/core/agent/src/phoenix/phoenix-daemon.ts
+++ b/packages/core/agent/src/phoenix/phoenix-daemon.ts
@@ -19,7 +19,12 @@ import { lockFilePath, removeLockFile, removeSocketFile, waitForAgentToStart } f
  * Manager of daemon processes started with @dxos/phoenix.
  */
 export class PhoenixDaemon implements Daemon {
-  constructor(private readonly _rootDir: string) {}
+  constructor(private readonly _rootDir: string) {
+    const dir = join(this._rootDir, 'profile');
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  }
 
   async connect(): Promise<void> {
     // no-op.

--- a/packages/core/agent/src/phoenix/phoenix-daemon.ts
+++ b/packages/core/agent/src/phoenix/phoenix-daemon.ts
@@ -77,7 +77,6 @@ export class PhoenixDaemon implements Daemon {
           `--profile=${profile}`,
           options?.metrics ? '--metrics' : undefined,
           options?.config ? `--config=${options.config}` : undefined,
-          options?.monitor ? '--monitor' : undefined,
           options?.ws ? `--ws=${options.ws}` : undefined,
         ].filter(Boolean) as string[],
         // TODO(burdon): Make optional.
@@ -128,7 +127,6 @@ export class PhoenixDaemon implements Daemon {
       error: new AgentWaitTimeoutError(),
     });
 
-    removeSocketFile(profile);
     return proc;
   }
 

--- a/packages/core/agent/src/plugins/epoch-monitor/epoch-monitor.ts
+++ b/packages/core/agent/src/plugins/epoch-monitor/epoch-monitor.ts
@@ -91,11 +91,7 @@ class SpaceMonitor {
   private _creatingEpoch = false;
   private _previousEpochNumber = -1;
 
-  constructor(
-    private readonly _client: Client,
-    private readonly _space: Space,
-    private readonly _options: Options,
-  ) {}
+  constructor(private readonly _client: Client, private readonly _space: Space, private readonly _options: Options) {}
 
   async open() {
     await this._space.waitUntilReady();

--- a/packages/core/agent/src/plugins/faas/faas-client.ts
+++ b/packages/core/agent/src/plugins/faas/faas-client.ts
@@ -60,10 +60,7 @@ export type InvocationData = {
  * Wrapper for the OpenFaaS HTTP API.
  */
 export class FaasClient {
-  constructor(
-    private readonly _config: Runtime.Services.Faasd,
-    private readonly _context: InvocationContext = {},
-  ) {
+  constructor(private readonly _config: Runtime.Services.Faasd, private readonly _context: InvocationContext = {}) {
     invariant(this._config.gateway, 'Invalid gateway URL.');
   }
 

--- a/packages/core/agent/src/plugins/functions/dev-dispatcher.ts
+++ b/packages/core/agent/src/plugins/functions/dev-dispatcher.ts
@@ -39,8 +39,8 @@ export class DevFunctionDispatcher implements FunctionDispatcher, FunctionRegist
   }
 
   async invoke(invocation: FunctionInvocation): Promise<FunctionInvocationResult> {
-    const registration = this._registrations.findLast(
-      (registration) => registration.request.functions?.some((func) => func.name === invocation.function),
+    const registration = this._registrations.findLast((registration) =>
+      registration.request.functions?.some((func) => func.name === invocation.function),
     );
     if (!registration) {
       throw new Error(`Function ${invocation.function} not found`);

--- a/packages/devtools/cli/config/config-dev.yml
+++ b/packages/devtools/cli/config/config-dev.yml
@@ -4,7 +4,7 @@ runtime:
   client:
     storage:
       persistent: true
-      path: /tmp/dx/run
+      dataRoot: /tmp/dx/run
 
   services:
     ipfs:

--- a/packages/devtools/cli/config/config-local.yml
+++ b/packages/devtools/cli/config/config-local.yml
@@ -4,7 +4,7 @@ runtime:
   client:
     storage:
       persistent: true
-      path: /tmp/dx/run
+      dataRoot: /tmp/dx/run
 
 
   services:

--- a/packages/devtools/cli/config/config-staging.yml
+++ b/packages/devtools/cli/config/config-staging.yml
@@ -4,7 +4,7 @@ runtime:
   client:
     storage:
       persistent: true
-      path: /tmp/dx/run
+      dataRoot: /tmp/dx/run
 
   services:
     ipfs:

--- a/packages/devtools/cli/config/config.yml
+++ b/packages/devtools/cli/config/config.yml
@@ -4,7 +4,7 @@ runtime:
   client:
     storage:
       persistent: true
-      path: /tmp/dx/run
+      dataRoot: /tmp/dx/run
 
   services:
     ipfs:

--- a/packages/devtools/cli/src/commands/agent/start.ts
+++ b/packages/devtools/cli/src/commands/agent/start.ts
@@ -10,7 +10,6 @@ import { Agent, EchoProxyServer, EpochMonitor, FunctionsPlugin, parseAddress } f
 import { runInContext, scheduleTaskInterval } from '@dxos/async';
 import { DX_RUNTIME, getProfilePath } from '@dxos/client-protocol';
 import { Context } from '@dxos/context';
-import { log } from '@dxos/log';
 import * as Telemetry from '@dxos/telemetry';
 
 import { BaseCommand } from '../../base-command';

--- a/packages/devtools/cli/src/commands/agent/start.ts
+++ b/packages/devtools/cli/src/commands/agent/start.ts
@@ -10,6 +10,7 @@ import { Agent, EchoProxyServer, EpochMonitor, FunctionsPlugin, parseAddress } f
 import { runInContext, scheduleTaskInterval } from '@dxos/async';
 import { DX_RUNTIME, getProfilePath } from '@dxos/client-protocol';
 import { Context } from '@dxos/context';
+import { log } from '@dxos/log';
 import * as Telemetry from '@dxos/telemetry';
 
 import { BaseCommand } from '../../base-command';
@@ -92,11 +93,6 @@ export default class Start extends BaseCommand<typeof Start> {
 
     await agent.start();
     this.log('Agent started... (ctrl-c to exit)');
-    process.on('SIGINT', async () => {
-      void this._ctx.dispose();
-      await agent.stop();
-      process.exit(0);
-    });
 
     this._sendTelemetry();
 
@@ -116,7 +112,6 @@ export default class Start extends BaseCommand<typeof Start> {
         const process = await daemon.start(this.flags.profile, {
           config: this.flags.config,
           metrics: this.flags.metrics,
-          monitor: this.flags.monitor,
           ws: this.flags.ws,
         });
         if (process) {

--- a/packages/devtools/cli/src/commands/reset/index.ts
+++ b/packages/devtools/cli/src/commands/reset/index.ts
@@ -6,7 +6,7 @@ import { Flags, ux } from '@oclif/core';
 import chalk from 'chalk';
 import fs from 'fs';
 
-import { DX_CACHE, DX_DATA, DX_RUNTIME, DX_STATE, getProfilePath } from '@dxos/client-protocol';
+import { DX_CACHE, DX_CONFIG, DX_DATA, DX_RUNTIME, DX_STATE, getProfilePath } from '@dxos/client-protocol';
 
 import { BaseCommand } from '../../base-command';
 
@@ -30,6 +30,7 @@ export default class Reset extends BaseCommand<typeof Reset> {
           getProfilePath(DX_DATA, profile),
           getProfilePath(DX_STATE, profile),
           getProfilePath(DX_RUNTIME, profile),
+          getProfilePath(DX_CONFIG, profile) + '.yml', // TODO(mykola): remove?
           storage,
         ]
           .sort()

--- a/packages/devtools/cli/src/commands/reset/index.ts
+++ b/packages/devtools/cli/src/commands/reset/index.ts
@@ -53,7 +53,11 @@ export default class Reset extends BaseCommand<typeof Reset> {
 
     if (!dryRun) {
       // TODO(burdon): Problem if running manually.
-      await this.execWithDaemon(async (daemon) => daemon.stop(this.flags.profile, { force: this.flags.force }));
+      await this.execWithDaemon(async (daemon) => {
+        if (await daemon.isRunning(this.flags.profile)) {
+          await daemon.stop(this.flags.profile, { force: this.flags.force });
+        }
+      });
       if (this.flags.verbose) {
         this.log(chalk`{red Deleting files...}`);
         paths.forEach((path) => this.log(`- ${path}`));

--- a/packages/devtools/cli/testing/config/user-1.yml
+++ b/packages/devtools/cli/testing/config/user-1.yml
@@ -4,7 +4,7 @@ runtime:
   client:
     storage:
       persistent: true
-      path: '/tmp/dxos/cli/user-1'
+      dataRoot: '/tmp/dxos/cli/user-1'
 
   services:
     ipfs:

--- a/packages/devtools/cli/testing/config/user-2.yml
+++ b/packages/devtools/cli/testing/config/user-2.yml
@@ -4,7 +4,7 @@ runtime:
   client:
     storage:
       persistent: true
-      path: '/tmp/dxos/cli/user-2'
+      dataRoot: '/tmp/dxos/cli/user-2'
 
   services:
     ipfs:


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 449421f</samp>

### Summary
🔥🚀📝

<!--
1.  🔥 - This emoji represents the removal of the `monitor` option and the unused features from the `PhoenixDaemon` class. It conveys the idea of burning or deleting something that is no longer needed or relevant.
2.  🚀 - This emoji represents the simplification and improvement of the agent start command and the logging. It conveys the idea of launching or speeding up something, as well as making it more efficient or reliable.
3.  📝 - This emoji represents the documentation update that reflects the changes in the code. It conveys the idea of writing or editing something, as well as providing information or clarification.
-->
This pull request refactors and simplifies the code for launching and managing the `phoenix` agent process. It removes unused features, improves logging, and cleans up the types and arguments.

> _Sing, O Muse, of the valiant code review_
> _That simplified the agent's start command_
> _And stripped away the monitor option_
> _That PhoenixDaemon needed not to run_

### Walkthrough
*  Remove `monitor` option and flag from agent start command and daemon ([link](https://github.com/dxos/dxos/pull/4250/files?diff=unified&w=0#diff-7fc4a7fa0ca0198804872e0101ccd1f763998d2b5df984c9b12611bb743ac7fdL18), [link](https://github.com/dxos/dxos/pull/4250/files?diff=unified&w=0#diff-3f0df6615fd9fb29f2f06326c7134241ebde0587c36e8fb07ba87d35d3356903L80), [link](https://github.com/dxos/dxos/pull/4250/files?diff=unified&w=0#diff-6222175ce7615e14e17217b5e12fba644eb6f2ae31ca1db528cc6c57bedbb08cL119)).


