### PR TITLE
ci: add bare monitor

### DIFF
--- a/.github/workflows/scripts/monitor.js
+++ b/.github/workflows/scripts/monitor.js
@@ -4,6 +4,7 @@ const { promisify } = require('node:util');
 
 monitors = [
   './tools/monitors/cli-monitor',
+  './tools/monitors/bare-template-monitor',
   './tools/monitors/hello-template-monitor',
   './tools/monitors/messaging-monitor',
 ];
@@ -35,7 +36,17 @@ const monitor = async (path) => {
   }
 }
 
-void Promise.allSettled(monitors.map(monitor)).then((results) => {
-  const failed = results.some((result) => result.status === 'rejected');
-  process.exit(failed ? 1 : 0);
-});
+// NOTE: Can't run in parallel because of colliding ports.
+let error;
+for (const path of monitors) {
+  try {
+    await monitor(path);
+  } catch (err) {
+    error = err;
+  }
+}
+
+if (error) {
+  console.error(error);
+  process.exit(1);
+}

--- a/tools/monitors/bare-template-monitor/test/playwright.config.ts
+++ b/tools/monitors/bare-template-monitor/test/playwright.config.ts
@@ -24,12 +24,13 @@ export default defineConfig({
         browserName: 'firefox',
       },
     },
-    {
-      name: 'webkit',
-      use: {
-        browserName: 'webkit',
-      },
-    },
+    // TODO(wittjosiah): Setup dependencies for webkit in CI.
+    // {
+    //   name: 'webkit',
+    //   use: {
+    //     browserName: 'webkit',
+    //   },
+    // },
   ],
   webServer: {
     command: 'npm run serve',

--- a/tools/monitors/hello-template-monitor/test/playwright.config.ts
+++ b/tools/monitors/hello-template-monitor/test/playwright.config.ts
@@ -24,12 +24,13 @@ export default defineConfig({
         browserName: 'firefox',
       },
     },
-    {
-      name: 'webkit',
-      use: {
-        browserName: 'webkit',
-      },
-    },
+    // TODO(wittjosiah): Setup dependencies for webkit in CI.
+    // {
+    //   name: 'webkit',
+    //   use: {
+    //     browserName: 'webkit',
+    //   },
+    // },
   ],
   webServer: {
     command: 'npm run serve',


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7dddaf1</samp>

### Summary
🚧🔄➕

<!--
1.  🚧 - This emoji represents the fact that the webkit browser was commented out from the `playwright.config.ts` file for the `bare-template-monitor`, which is a temporary workaround until the webkit dependencies are installed in the CI environment.
2. 🔄 - This emoji represents the fact that the same change as F1L25R25 was applied to the `hello-template-monitor`, which is a way of keeping the monitors consistent and up to date with the latest changes in the templates.
3. ➕ - This emoji represents the fact that a new monitor for the bare template was added, which is a way of expanding the test coverage and ensuring the quality of the template.
-->
Added a new monitor for the `bare` template and fixed the webkit issue for the existing monitors. These changes improve the testing and reliability of the DXOS app templates.

> _We are the playwrights of doom_
> _We test the templates of DXOS_
> _We comment out the webkit browser_
> _We avoid the port conflicts_

### Walkthrough
*  Added `bare-template-monitor` to test the bare template for creating DXOS apps ([link](https://github.com/dxos/dxos/pull/4259/files?diff=unified&w=0#diff-bed163a8fd602a898d098e307078e1552ba2db9a1d76d0ce40f197e7c471aefcR7)).


