### PR TITLE
ci: fix bare monitor app create

### DIFF
--- a/tools/monitors/bare-template-monitor/scripts/setup.js
+++ b/tools/monitors/bare-template-monitor/scripts/setup.js
@@ -20,7 +20,7 @@ const setup = async () => {
   await exec('npm exec playwright install');
 
   console.log('Creating app...');
-  await exec('npm exec dx app create --template bare tmp');
+  await exec('npm exec dx app create tmp -- --template bare');
 
   console.log('Installing app dependencies...');
   await exec('npm install --no-package-lock', {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cb3b3d2</samp>

### Summary
🐛🔄📝

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change.
2.  🔄 - This emoji represents a change in the order or format of something, which is what happened to the arguments for the `dx app create` command.
3.  📝 - This emoji represents a documentation update, which is what happened to the README file to reflect the change.
-->
Fixed app creation bug in `bare-template-monitor` script. Changed the order of the `dx app create` command arguments to match the expected format.

> _`dx app create`_
> _order of arguments changed_
> _bug fixed in autumn_

### Walkthrough
* Fix app creation command by passing the correct arguments order ([link](https://github.com/dxos/dxos/pull/4261/files?diff=unified&w=0#diff-357378e3b79668dea46db5e00bbe9e1cba01b7263b69481763a01e2006fa93eeL23-R23))


