### PR TITLE
chore: lint

### DIFF
--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -14,6 +14,7 @@ export class AppManager {
   private readonly _inIframe: boolean | undefined = undefined;
   private _initialized = false;
 
+  // prettier-ignore
   constructor(
     private readonly _browser: Browser,
     inIframe?: boolean,

--- a/packages/common/codec-protobuf/src/schema.ts
+++ b/packages/common/codec-protobuf/src/schema.ts
@@ -23,6 +23,7 @@ export class Schema<T, S extends {} = {}> {
 
   private readonly _codecCache = new Map<string, ProtoCodec>();
 
+  // prettier-ignore
   constructor(
     private _typesRoot: protobufjs.Root,
     substitutions: Substitutions,

--- a/packages/common/codec-protobuf/src/service.ts
+++ b/packages/common/codec-protobuf/src/service.ts
@@ -25,6 +25,7 @@ export type ServiceProvider<Service> = Service | (() => Service) | (() => Promis
  * Client/server service wrapper.
  */
 export class ServiceDescriptor<S> {
+  // prettier-ignore
   constructor(
     private readonly _service: pb.Service,
     private readonly _schema: Schema<any>,

--- a/packages/common/feed-store/src/feed-queue.ts
+++ b/packages/common/feed-store/src/feed-queue.ts
@@ -36,6 +36,7 @@ export class FeedQueue<T extends {}> {
   private _currentBlock?: FeedBlock<T> = undefined;
   private _index = -1;
 
+  // prettier-ignore
   constructor(
     private readonly _feed: FeedWrapper<T>,
     private readonly _options: FeedQueueOptions = {},

--- a/packages/common/feed-store/src/feed-set-iterator.test.ts
+++ b/packages/common/feed-store/src/feed-set-iterator.test.ts
@@ -104,31 +104,28 @@ describe('FeedSetIterator', () => {
     const iterator = new FeedSetIterator(randomFeedBlockSelector);
 
     // Write blocks.
-    setTimeout(
-      async () => {
-        // Create feeds.
-        // TODO(burdon): Test adding feeds on-the-fly.
-        const writers = await Promise.all(
-          Array.from(Array(numFeeds)).map(async () => {
-            const key = await builder.keyring.createKey();
-            const feed = await feedStore.openFeed(key, { writable: true });
-            await iterator.addFeed(feed);
-            return feed.createFeedWriter();
-          }),
-        );
+    setTimeout(async () => {
+      // Create feeds.
+      // TODO(burdon): Test adding feeds on-the-fly.
+      const writers = await Promise.all(
+        Array.from(Array(numFeeds)).map(async () => {
+          const key = await builder.keyring.createKey();
+          const feed = await feedStore.openFeed(key, { writable: true });
+          await iterator.addFeed(feed);
+          return feed.createFeedWriter();
+        }),
+      );
 
-        expect(iterator.size).to.eq(numFeeds);
+      expect(iterator.size).to.eq(numFeeds);
 
-        for (const _ of Array.from(Array(numBlocks))) {
-          const writer = faker.helpers.arrayElement(writers);
-          const receipts = await builder.generator.writeBlocks(writer, {
-            count: 1,
-          });
-          log('wrote', receipts);
-        }
-      },
-      faker.number.int({ min: 0, max: 100 }),
-    );
+      for (const _ of Array.from(Array(numBlocks))) {
+        const writer = faker.helpers.arrayElement(writers);
+        const receipts = await builder.generator.writeBlocks(writer, {
+          count: 1,
+        });
+        log('wrote', receipts);
+      }
+    }, faker.number.int({ min: 0, max: 100 }));
 
     // Open and start iterator.
     await iterator.open();
@@ -137,19 +134,16 @@ describe('FeedSetIterator', () => {
 
     // Read blocks.
     const [readAll, read] = latch({ count: numBlocks });
-    setTimeout(
-      async () => {
-        for await (const block of iterator) {
-          const { feedKey, seq } = block;
-          const count = read();
-          log('read', { feedKey, seq, count });
-          if (count === numBlocks) {
-            await iterator.stop();
-          }
+    setTimeout(async () => {
+      for await (const block of iterator) {
+        const { feedKey, seq } = block;
+        const count = read();
+        log('read', { feedKey, seq, count });
+        if (count === numBlocks) {
+          await iterator.stop();
         }
-      },
-      faker.number.int({ min: 0, max: 100 }),
-    );
+      }
+    }, faker.number.int({ min: 0, max: 100 }));
 
     // Wait until all written and read.
     const count = await readAll();

--- a/packages/common/hypercore/src/replicate.test.ts
+++ b/packages/common/hypercore/src/replicate.test.ts
@@ -176,12 +176,9 @@ describe('Replication', () => {
         }
 
         // Random delay.
-        setTimeout(
-          () => {
-            next(size);
-          },
-          faker.number.int({ min: 0, max: 100 }),
-        );
+        setTimeout(() => {
+          next(size);
+        }, faker.number.int({ min: 0, max: 100 }));
       }, numBlocks);
 
       // Done.

--- a/packages/common/protobuf-compiler/src/module-specifier.ts
+++ b/packages/common/protobuf-compiler/src/module-specifier.ts
@@ -18,6 +18,7 @@ export class ModuleSpecifier {
     return new ModuleSpecifier(pathWithDot, context);
   }
 
+  // prettier-ignore
   constructor(
     public readonly name: string,
     public readonly contextPath: string,

--- a/packages/common/util/src/complex.ts
+++ b/packages/common/util/src/complex.ts
@@ -23,6 +23,7 @@ const MAX_SERIALIZATION_LENGTH = 10;
 export class ComplexSet<T> implements Set<T> {
   private readonly _values = new Map<Primitive, T>();
 
+  // prettier-ignore
   constructor(
     private readonly _projection: PrimitiveProjection<T>,
     values?: Iterable<T> | null,
@@ -123,6 +124,7 @@ export class ComplexMap<K, V> implements Map<K, V> {
   private readonly _keys = new Map<Primitive, K>();
   private readonly _values = new Map<Primitive, V>();
 
+  // prettier-ignore
   constructor(
     private readonly _keyProjection: PrimitiveProjection<K>,
     entries?: readonly (readonly [K, V])[] | null,

--- a/packages/common/util/src/entry.ts
+++ b/packages/common/util/src/entry.ts
@@ -11,6 +11,7 @@ export class MapEntry<K, V, U> {
   /**
    * @internal
    */
+  // prettier-ignore
   constructor(
     private readonly _map: Map<K, V>,
     private readonly _key: K,

--- a/packages/core/functions/src/runtime/dev-server.ts
+++ b/packages/core/functions/src/runtime/dev-server.ts
@@ -30,6 +30,7 @@ export class DevServer {
   private _port?: number;
   private _registrationId?: string;
 
+  // prettier-ignore
   constructor(
     private readonly _client: Client,
     private readonly _options: DevServerOptions,

--- a/packages/core/mesh/teleport-extension-replicator/src/stress.test.ts
+++ b/packages/core/mesh/teleport-extension-replicator/src/stress.test.ts
@@ -27,6 +27,7 @@ class TestAgent {
 
   readonly replicator = new ReplicatorExtension().setOptions({ upload: true });
 
+  // prettier-ignore
   constructor(
     readonly keyring: Keyring,
     readonly peer: Teleport,
@@ -85,6 +86,7 @@ const assertState = async (model: Model, real: Real) => {
 };
 
 class OpenFeedCommand implements fc.AsyncCommand<Model, Real> {
+  // prettier-ignore
   constructor(
     readonly agent: AgentName,
     readonly feedKey: PublicKey,
@@ -111,6 +113,7 @@ class OpenFeedCommand implements fc.AsyncCommand<Model, Real> {
 }
 
 class WriteToFeedCommand implements fc.AsyncCommand<Model, Real> {
+  // prettier-ignore
   constructor(
     readonly agent: AgentName,
     readonly feedKey: PublicKey,

--- a/packages/experimental/gem-core/src/context/context.ts
+++ b/packages/experimental/gem-core/src/context/context.ts
@@ -18,6 +18,7 @@ export class SVGContext {
   private _size?: Size;
   private _center?: Point;
 
+  // prettier-ignore
   constructor(
     private readonly _scale: Scale = new Scale(),
     private readonly _centered: boolean = true,

--- a/packages/experimental/gem-spore/src/graph/projector.ts
+++ b/packages/experimental/gem-spore/src/graph/projector.ts
@@ -18,6 +18,7 @@ export abstract class Projector<DATA, LAYOUT, OPTIONS extends ProjectorOptions> 
 
   private readonly _options: OPTIONS;
 
+  // prettier-ignore
   constructor(
     private readonly _context: SVGContext,
     options?: Partial<OPTIONS>,

--- a/packages/experimental/gem-spore/src/testing/builder.ts
+++ b/packages/experimental/gem-spore/src/testing/builder.ts
@@ -12,6 +12,7 @@ import { defaultIdAccessor, emptyGraph, GraphData, GraphLink } from '../graph';
 export class GraphBuilder<N> {
   readonly updated = new EventEmitter<GraphData<N>>();
 
+  // prettier-ignore
   constructor(
     private readonly _idAccessor = defaultIdAccessor,
     private readonly _graph = emptyGraph,

--- a/packages/experimental/kai-functions/src/bots/kai-bot/generators/stack-resolver.ts
+++ b/packages/experimental/kai-functions/src/bots/kai-bot/generators/stack-resolver.ts
@@ -24,6 +24,7 @@ const parseJson = (content: string) => {
 };
 
 export class ContactStackResolver implements Resolver<DocumentStack> {
+  // prettier-ignore
   constructor(
     private readonly _id: string,
     private readonly _chatModel: ChatModel,

--- a/packages/experimental/kai-functions/src/bots/mail-bot/imap-processor.ts
+++ b/packages/experimental/kai-functions/src/bots/mail-bot/imap-processor.ts
@@ -24,6 +24,7 @@ const blacklist = [/noreply/, /no-reply/, /notifications/, /billing/, /support/]
 export class ImapProcessor {
   private _connection?: ImapSimple;
 
+  // prettier-ignore
   constructor(
     private readonly _id: string,
     private readonly _config: ImapConfig,

--- a/packages/experimental/kai-functions/src/bots/mail-bot/mail-bot.ts
+++ b/packages/experimental/kai-functions/src/bots/mail-bot/mail-bot.ts
@@ -18,6 +18,7 @@ const POLLING_INTERVAL = 10_000;
 class Poller {
   _timeout?: ReturnType<typeof setTimeout>;
 
+  // prettier-ignore
   constructor(
     private readonly _callback: () => Promise<void>,
     private readonly _interval: number,

--- a/packages/gravity/gravity-dashboard/stories/experimental.stories.tsx
+++ b/packages/gravity/gravity-dashboard/stories/experimental.stories.tsx
@@ -106,6 +106,7 @@ class CircularLayout {
   private _map = new Map<string, number>();
   private _radius: Fraction = [1, 1];
 
+  // prettier-ignore
   constructor(
     private readonly _context: SVGContext,
     private readonly _duraction = 1000,
@@ -250,10 +251,7 @@ class MeshLayout {
   private readonly _circleLayout: CircularLayout;
   private readonly _kubeLayout: KubeLayout;
 
-  constructor(
-    private readonly _context: SVGContext,
-    private readonly _radius: Fraction = [5, 2],
-  ) {
+  constructor(private readonly _context: SVGContext, private readonly _radius: Fraction = [5, 2]) {
     this._circleLayout = useMemo(() => new CircularLayout(this._context).initialize(this._radius), []);
     this._kubeLayout = useMemo(() => new KubeLayout(this._context).initialize([3, 5]), []);
   }

--- a/packages/sdk/vault/src/testing/shell-manager.ts
+++ b/packages/sdk/vault/src/testing/shell-manager.ts
@@ -11,6 +11,7 @@ export class ShellManager extends NaturalShellManager {
   private _invitationCode = new Trigger<string>();
   private _authCode = new Trigger<string>();
 
+  // prettier-ignore
   constructor(
     override readonly page: Page,
     readonly inIFrame = true,

--- a/tools/beast/src/mermaid/flowchart.ts
+++ b/tools/beast/src/mermaid/flowchart.ts
@@ -48,6 +48,7 @@ class SubgraphImpl implements Subgraph, SubgraphBuilder {
   private readonly _nodes = new Set<Node>();
   private readonly _subGraphs = new Set<SubgraphBuilder>();
 
+  // prettier-ignore
   constructor(
     readonly id: string,
     readonly label?: string,

--- a/tools/beast/src/nx/project-processor.ts
+++ b/tools/beast/src/nx/project-processor.ts
@@ -13,6 +13,7 @@ import { WorkspaceProcessor } from '../nx';
 export class ProjectProcessor {
   private readonly _project: Project;
 
+  // prettier-ignore
   constructor(
     private readonly _workspace: WorkspaceProcessor,
     packageName: string,

--- a/tools/beast/src/nx/workspace-processor.ts
+++ b/tools/beast/src/nx/workspace-processor.ts
@@ -23,6 +23,7 @@ export class WorkspaceProcessor {
   private readonly _projectsByName = new Map<string, Project>();
   private readonly _projectsByPackage = new Map<string, Project>();
 
+  // prettier-ignore
   constructor(
     private readonly _baseDir: string,
     private readonly _options: WorkspaceProcessorOptions = {},

--- a/tools/log-hook/src/hook/preprocessor.ts
+++ b/tools/log-hook/src/hook/preprocessor.ts
@@ -60,6 +60,7 @@ class TraceInjector extends Visitor {
 
   private _sourceMap?: SourceMapConsumer;
 
+  // prettier-ignore
   constructor(
     private readonly filename: string,
     private readonly code: string,

--- a/tools/x/src/util/parser.ts
+++ b/tools/x/src/util/parser.ts
@@ -175,6 +175,7 @@ export type LogOptions = {
 };
 
 export class LogPrinter {
+  // prettier-ignore
   constructor(
     private readonly _logger: (...args: any[]) => void,
     private readonly _filePrefix: string,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at abb3440</samp>

### Summary
📝🧹🎨

<!--
1.  📝 - This emoji represents the addition of comments to disable the prettier code formatter for some classes and functions. It suggests that the changes are related to documentation or code style preferences.
2.  🧹 - This emoji represents the removal of extra parentheses or line breaks to simplify the code and follow the prettier code style. It suggests that the changes are related to cleaning or refactoring the code.
3.  🎨 - This emoji represents the improvement of the code style and formatting of the `experimental.stories.tsx` file. It suggests that the changes are related to enhancing the appearance or design of the code.
-->
This pull request makes minor code style and formatting changes to several files across different packages and tools. Most of the changes involve adding comments to disable the prettier code formatter for certain classes or functions that may require custom or original formatting. One change simplifies the arrow function syntax in a test file, and another removes extra parentheses in a test file. The purpose of these changes is to improve the readability and consistency of the code.

> _Sing, O Muse, of the code review that vexed the noble devs_
> _Who sought to tame the beast of prettier with comments and with tests_
> _They faced the wrath of many files, from `AppManager` to `ShellManager`_
> _And strove to keep their style intact, like heroes of the olden days_

### Walkthrough
*  Add comments to disable prettier code formatter for several classes and functions that may have custom formatting or style rules ([link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-b295c0687b736b4159c9f82185a761df55201a2638d4a9ce708ca7b7b90b9b46R17), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-9adf0ad77fa90a0858cbfffcbc713dc0956b846adfa9b5dd9d932dfa11e63b96R26), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-7c09e5dd507ceceaffe4350f47b5ca011dd3b952f22b6a5425a2762a70b3d37aR28), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-a8b9cf688aad506de3104c55cc8ff78bea1ac77de77007fe8d08f68e003e2facR39), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-946393595efa2c9657f5105665e52a257e17f608c03bba2d19e359bb8aa88cafR21), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-f73a6ec889b1737924475d1bc01a6c28358ad16b62568727a0243a0f9535bbdfR26), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-f73a6ec889b1737924475d1bc01a6c28358ad16b62568727a0243a0f9535bbdfR127), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-4ea7959be351a30bfd3b1339622cc022879ee9591e71bfe9ab74ff7d4de5bdc7R14), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-b97024f7b5b6c79eb7a0039b1bc1d340381958fee6921303c1de8dc5a82b6695R33), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-0df849295b41c99e69766e175e04abe2315ab4c3badeca2d6656628999aa6256R30), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-0df849295b41c99e69766e175e04abe2315ab4c3badeca2d6656628999aa6256R89), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-0df849295b41c99e69766e175e04abe2315ab4c3badeca2d6656628999aa6256R116), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-a08fa5a2d29a46ded46f3a83997225888f2955d192b90c98af9488c8406f57b6R21), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-d992240457b8d4a7e130f46c94aef450bb40194fe1a56efb26e02b81ff587713R21), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-82855231c6fab873fb933a837923c4a7a9d7a0a6455cdeb1bc0871a400a2e8e3R15), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-dbc3c7ac34c67bf02c609de0bc5a9751680951c0c7e699e155eb6950735ede56R27), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-47e22047e41933a5e3f0f1642eb48f6a2fc56903a449fc9a3bdc2f23685dbe66R27), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-33e5ec6a809fecbc60d0a9aa70ff0ece15abda0602a0bcf6f8a03fc239138465R21), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-1bb6f179c171670ec82c92cc9025b43b7287795f31cf6a75e6a56e4db049f250R109), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-454d51dc832c49a81674a1ff9305989e012e93d4e053d79f6785c87eacfe66a1R14), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-cb0acf529ab20bf8a4c468918343d0bdf6ffc6a51b772935223d5b6d56d0bd02R51))
* Remove extra parentheses around arrow functions passed to `setTimeout` in tests for `FeedSetIterator`, `replicate`, and `feed-queue` ([link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-6f79fce3ed12a2908201bab40bb301d82e0bb0ec6080ce57990b187b4b76b653L107-R128), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-6f79fce3ed12a2908201bab40bb301d82e0bb0ec6080ce57990b187b4b76b653L140-R146), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-60f62c40c1ef6e38ee331e993ee7c7598f710cda5d6df98ea98c1b0c41e14309L179-R181), [link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-a8b9cf688aad506de3104c55cc8ff78bea1ac77de77007fe8d08f68e003e2facR39))
* Remove extra line break before constructor of `MeshLayout` class in `experimental.stories.tsx` ([link](https://github.com/dxos/dxos/pull/4267/files?diff=unified&w=0#diff-1bb6f179c171670ec82c92cc9025b43b7287795f31cf6a75e6a56e4db049f250L253-R254))


