### PR TITLE
feat: Make batching configurable

### DIFF
--- a/packages/core/echo/echo-pipeline/src/testing/database-test-rig.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/database-test-rig.ts
@@ -113,7 +113,11 @@ export class DatabaseTestPeer {
     }
 
     this.items = new ItemManager(this.modelFactory);
-    this.proxy = new DatabaseProxy(this.host.createDataServiceHost(), this.items, SPACE_KEY);
+    this.proxy = new DatabaseProxy({
+      service: this.host.createDataServiceHost(),
+      itemManager: this.items,
+      spaceKey: SPACE_KEY,
+    });
     await this.proxy.open(this.modelFactory);
   }
 

--- a/packages/core/echo/echo-pipeline/src/testing/util.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/util.ts
@@ -50,7 +50,7 @@ export const createRemoteDatabaseFromDataServiceHost = async (
   await dataServiceSubscriptions.registerSpace(spaceKey, dataServiceHost);
 
   const itemManager = new ItemManager(modelFactory);
-  const backend = new DatabaseProxy(dataService, itemManager, spaceKey);
+  const backend = new DatabaseProxy({ service: dataService, itemManager, spaceKey });
   await backend.open(new ModelFactory().registerModel(DocumentModel));
   return {
     itemManager,

--- a/packages/core/echo/echo-pipeline/src/tests/database-unit.test.ts
+++ b/packages/core/echo/echo-pipeline/src/tests/database-unit.test.ts
@@ -6,7 +6,13 @@ import expect from 'expect';
 
 import { sleep } from '@dxos/async';
 import { DocumentModel, MutationBuilder, OrderedArray } from '@dxos/document-model';
-import { BATCH_COMMIT_AFTER, Item, createModelMutation, encodeModelMutation, genesisMutation } from '@dxos/echo-db';
+import {
+  COMMIT_BATCH_INACTIVITY_DEFAULT,
+  Item,
+  createModelMutation,
+  encodeModelMutation,
+  genesisMutation,
+} from '@dxos/echo-db';
 import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
 import { describe, test } from '@dxos/test';
@@ -260,7 +266,7 @@ describe('database (unit)', () => {
       model.insert('Hello', 0);
       model.insert(' World!', 5);
       // Wait for batch commit.
-      await sleep(BATCH_COMMIT_AFTER + 10);
+      await sleep(COMMIT_BATCH_INACTIVITY_DEFAULT + 10);
 
       // Mutations got merged.
       expect(peer.feedMessages.length).toEqual(1);
@@ -268,7 +274,7 @@ describe('database (unit)', () => {
       model.insert(' DXOS', 5);
       // New batch is still not committed.
       expect(peer.feedMessages.length).toEqual(1);
-      await sleep(BATCH_COMMIT_AFTER + 10);
+      await sleep(COMMIT_BATCH_INACTIVITY_DEFAULT + 10);
       // New batch is committed.
       expect(peer.feedMessages.length).toEqual(2);
     });

--- a/packages/core/echo/echo-pipeline/src/tests/database.test.ts
+++ b/packages/core/echo/echo-pipeline/src/tests/database.test.ts
@@ -46,7 +46,7 @@ const createDatabaseWithFeeds = async () => {
   const spaceKey = PublicKey.random();
   await dataServiceSubscriptions.registerSpace(spaceKey, host.createDataServiceHost());
 
-  const proxy = new DatabaseProxy(dataService, new ItemManager(modelFactory), spaceKey);
+  const proxy = new DatabaseProxy({ service: dataService, itemManager: new ItemManager(modelFactory), spaceKey });
   await proxy.open(new ModelFactory().registerModel(DocumentModel));
 
   return { proxy, host };

--- a/packages/sdk/client/src/echo/space-proxy.ts
+++ b/packages/sdk/client/src/echo/space-proxy.ts
@@ -86,7 +86,11 @@ export class SpaceProxy implements Space {
 
     invariant(this._clientServices.services.DataService, 'DataService not available');
     this._itemManager = new ItemManager(this._modelFactory);
-    this._dbBackend = new DatabaseProxy(this._clientServices.services.DataService, this._itemManager, this.key);
+    this._dbBackend = new DatabaseProxy({
+      service: this._clientServices.services.DataService,
+      itemManager: this._itemManager,
+      spaceKey: this.key,
+    });
     this._db = new EchoDatabase(this._itemManager, this._dbBackend, databaseRouter);
 
     // eslint-disable-next-line @typescript-eslint/no-this-alias


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 618906b</samp>

### Summary
🚚🛠️🧪

<!--
1.  🚚 This emoji can be used to indicate that the constructor parameters of the `DatabaseProxy` class were moved into an object parameter, which is a common refactoring technique to reduce the number of arguments and improve readability and maintainability of the code.
2.  🛠️ This emoji can be used to indicate that the `DatabaseProxy` class was refactored to allow more control over the batch size and commit frequency of mutations, which is a feature enhancement that improves the performance and flexibility of the class.
3.  🧪 This emoji can be used to indicate that the tests were updated to reflect the changes in the `DatabaseProxy` class, which is a quality assurance activity that ensures the code is working as expected and meets the requirements.
-->
Refactored the `DatabaseProxy` class to accept an object parameter for batch configuration and updated all constructor calls in the codebase. This change allows more flexibility and consistency in managing the batch size and commit frequency of mutations in the echo database.

> _The `DatabaseProxy` class got a tweak_
> _To make its mutation logic more sleek_
> _It takes an object param_
> _With options to cram_
> _And commits batches faster or meek_

### Walkthrough
*  Remove unused constants and add new constant for default commit batch inactivity time in `database-proxy.ts` ([link](https://github.com/dxos/dxos/pull/4280/files?diff=unified&w=0#diff-b2da0ec452ce09064e0f75805825363a1182da69727f935f402a339f55d85148L23-L29), [link](https://github.com/dxos/dxos/pull/4280/files?diff=unified&w=0#diff-b2da0ec452ce09064e0f75805825363a1182da69727f935f402a339f55d85148R28-R29))
*  Change constructor of `DatabaseProxy` class to accept an object parameter with required and optional properties instead of individual parameters in `database-proxy.ts` ([link](https://github.com/dxos/dxos/pull/4280/files?diff=unified&w=0#diff-b2da0ec452ce09064e0f75805825363a1182da69727f935f402a339f55d85148R36-R51), [link](https://github.com/dxos/dxos/pull/4280/files?diff=unified&w=0#diff-b2da0ec452ce09064e0f75805825363a1182da69727f935f402a339f55d85148L66-R98))
*  Add getter and setter methods for `maxBatchSize` property of `DatabaseProxy` class in `database-proxy.ts` ([link](https://github.com/dxos/dxos/pull/4280/files?diff=unified&w=0#diff-b2da0ec452ce09064e0f75805825363a1182da69727f935f402a339f55d85148L89-R121))
*  Modify `mutate` method of `DatabaseProxy` class to check and commit batch size limit before inactivity timer in `database-proxy.ts` ([link](https://github.com/dxos/dxos/pull/4280/files?diff=unified&w=0#diff-b2da0ec452ce09064e0f75805825363a1182da69727f935f402a339f55d85148L356-R398), [link](https://github.com/dxos/dxos/pull/4280/files?diff=unified&w=0#diff-b2da0ec452ce09064e0f75805825363a1182da69727f935f402a339f55d85148L366-R406))
*  Update constructor calls of `DatabaseProxy` class to use object parameter in `database-test-rig.ts`, `util.ts`, `database.test.ts`, and `space-proxy.ts` ([link](https://github.com/dxos/dxos/pull/4280/files?diff=unified&w=0#diff-a0c9ec72c792eb1381f81ed2f123c68d7c2bcfcd7958ee9f974a3281d803d48fL116-R120), [link](https://github.com/dxos/dxos/pull/4280/files?diff=unified&w=0#diff-6bf2c705e106622cc93a498e0e585d09099174eb3d4e91b052a7ef3d8737e14cL53-R53), [link](https://github.com/dxos/dxos/pull/4280/files?diff=unified&w=0#diff-96f8054baaab1576f5bc5ea740b8096d38c743cb66604e2289eb8fd782108d1fL49-R49), [link](https://github.com/dxos/dxos/pull/4280/files?diff=unified&w=0#diff-ea859fecb296e36346eb115dc1ffe5c0e67d7157b43b4dff2eb05ed5eb58ef73L89-R93))
*  Replace usage of removed constant with new constant for default commit batch inactivity time in `database-unit.test.ts` ([link](https://github.com/dxos/dxos/pull/4280/files?diff=unified&w=0#diff-a10f4bf985a2860dd7ff8a1889427bc45afd4885a585e60b645ab7d87154b6d3L9-R15), [link](https://github.com/dxos/dxos/pull/4280/files?diff=unified&w=0#diff-a10f4bf985a2860dd7ff8a1889427bc45afd4885a585e60b645ab7d87154b6d3L263-R269), [link](https://github.com/dxos/dxos/pull/4280/files?diff=unified&w=0#diff-a10f4bf985a2860dd7ff8a1889427bc45afd4885a585e60b645ab7d87154b6d3L271-R277))


