### PR TITLE
chore: remove batching from editor demo

### DIFF
--- a/packages/sdk/examples/src/examples/Editor.tsx
+++ b/packages/sdk/examples/src/examples/Editor.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { Document } from '@braneframe/types';
 import { MarkdownComposer, useTextModel } from '@dxos/aurora-composer';
@@ -16,6 +16,14 @@ const Editor = ({ spaceKey, id }: { spaceKey: PublicKey; id: number }) => {
   const [doc] = useQuery(space, Document.filter());
 
   const model = useTextModel({ identity, space, text: doc?.content });
+
+  useEffect(() => {
+    if (!space) {
+      return;
+    }
+
+    space.db._backend.maxBatchSize = 0;
+  }, [space]);
 
   return (
     <main className='flex-1 min-w-0'>

--- a/packages/sdk/react-client/src/testing/ClientSpaceDecorator.tsx
+++ b/packages/sdk/react-client/src/testing/ClientSpaceDecorator.tsx
@@ -57,7 +57,7 @@ export const PeersInSpace = ({ count = 1, schema, onCreateSpace, children }: Pee
         fallback={() => <p>Loading</p>}
         services={services}
         onInitialized={async (client) => {
-          await client.halo.createIdentity({ displayName: faker.person.firstName() });
+          await client.halo.createIdentity();
           schema && client.spaces.addSchema(schema);
           const space = await client.spaces.create({ name: faker.animal.bird() });
           await onCreateSpace?.(space);
@@ -98,7 +98,7 @@ export const setupPeersInSpace = async (options: Omit<PeersInSpaceProps, 'childr
   register && registerSignalFactory();
   const clients = [...Array(count)].map((_) => new Client({ services: testBuilder.createLocal() }));
   await Promise.all(clients.map((client) => client.initialize()));
-  await Promise.all(clients.map((client) => client.halo.createIdentity({ displayName: faker.person.firstName() })));
+  await Promise.all(clients.map((client) => client.halo.createIdentity()));
   schema && clients.map((client) => client.spaces.addSchema(schema));
   const space = await clients[0].spaces.create({ name: faker.animal.bird() });
   await onCreateSpace?.(space);


### PR DESCRIPTION
- chore: remove batching from editor demo
- chore: don't use faker display names

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1314eaa</samp>

### Summary
🚀🪝🧹

<!--
1.  🚀 - This emoji represents the improvement in responsiveness of the collaborative editor example, as it suggests speed and performance.
2.  🪝 - This emoji represents the use of the `useEffect` hook, as it is a common symbol for hooks in React.
3.  🧹 - This emoji represents the simplification of the testing code, as it suggests cleaning up or removing unnecessary complexity.
-->
The pull request enhances the collaborative editor example and refactors the testing code. It uses `useEffect` to improve editor performance in `Editor.tsx` and simplifies identity creation in `ClientSpaceDecorator.tsx`.

> _Sing, O Muse, of the agile coder's skill_
> _Who made the editor more swift and smooth_
> _By using `useEffect` to fulfill_
> _The need to stop the batching of each move._

### Walkthrough
* Import `useEffect` hook from React to set `maxBatchSize` of space database backend to zero in `Editor` component ([link](https://github.com/dxos/dxos/pull/4282/files?diff=unified&w=0#diff-687751c472840a8f086ba3e3ec9fb3726ad35ad4d41615414b549d8eb1ced3d2L5-R5),[link](https://github.com/dxos/dxos/pull/4282/files?diff=unified&w=0#diff-687751c472840a8f086ba3e3ec9fb3726ad35ad4d41615414b549d8eb1ced3d2R20-R27)). This ensures immediate updates for collaborative editor example in `packages/sdk/examples/src/examples/Editor.tsx`.


