### PR TITLE
refactor(examples): editor demo styles

### DIFF
--- a/.circleci/scripts/publish.sh
+++ b/.circleci/scripts/publish.sh
@@ -12,6 +12,7 @@ APPS=(
   ./packages/devtools/devtools
   ./packages/experimental/kai
   ./packages/experimental/kube-console
+  ./packages/sdk/examples
   ./docs
 )
 
@@ -51,7 +52,7 @@ for APP in "${APPS[@]}"; do
   PACKAGE_CAPS=${PACKAGE^^}
   PACKAGE_ENV=${PACKAGE_CAPS//-/_}
 
-  if [[ $BRANCH = "production" || ($BRANCH = "main" && $APP = "./docs") ]]; then
+  if [ $BRANCH = "production" ]; then
     export DX_ENVIRONMENT=production
     DX_CONFIG="$ROOT/packages/devtools/cli/config/config.yml"
     VERSION=$(cat package.json | jq -r ".version")
@@ -87,7 +88,7 @@ for APP in "${APPS[@]}"; do
       --verbose
   fi
 
-  if [[ $BRANCH = "production" || $BRANCH = "staging" || ($BRANCH = "main" && $APP = "./docs") ]]; then
+  if [[ $BRANCH = "production" || $BRANCH = "staging" ]]; then
     if [ $? -eq 0 ]; then
         notifySuccess $PACKAGE
     else

--- a/packages/sdk/examples/.eslintrc.cjs
+++ b/packages/sdk/examples/.eslintrc.cjs
@@ -5,5 +5,8 @@ module.exports = {
   "parserOptions": {
     "project": "tsconfig.json",
     "tsconfigRootDir": __dirname,
-  }
+  },
+  "ignorePatterns": [
+    "tailwind.ts"
+  ]
 }

--- a/packages/sdk/examples/.eslintrc.json
+++ b/packages/sdk/examples/.eslintrc.json
@@ -1,8 +1,0 @@
-{
-  "extends": [
-    "../../../.eslintrc.js"
-  ],
-  "parserOptions": {
-    "project": "packages/sdk/examples/tsconfig.json"
-  }
-}

--- a/packages/sdk/examples/dx.yml
+++ b/packages/sdk/examples/dx.yml
@@ -1,5 +1,14 @@
 version: 1
 
+# TODO: Remove. Temporary workaround for chromatic upload not working.
+package:
+  modules:
+    - name: demo
+      type: dxos:type/app
+      displayName: DXOS Demo
+      build:
+        command: pnpm -w nx bundle examples
+
 runtime:
   services:
     signaling:

--- a/packages/sdk/examples/index.html
+++ b/packages/sdk/examples/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no">
+    <title>DXOS Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/sdk/examples/project.json
+++ b/packages/sdk/examples/project.json
@@ -12,6 +12,15 @@
         "{options.outputPath}"
       ]
     },
+    "bundle": {
+      "executor": "@nx/vite:build",
+      "options": {
+        "outputPath": "packages/sdk/examples/out/demo"
+      },
+      "outputs": [
+        "{options.outputPath}"
+      ]
+    },
     "lint": {
       "executor": "@nx/linter:eslint",
       "options": {
@@ -30,6 +39,12 @@
       "outputs": [
         "packages/sdk/examples/src/proto/gen"
       ]
+    },
+    "serve": {
+      "executor": "@nx/vite:dev-server",
+      "options": {
+        "buildTarget": "examples:bundle"
+      }
     },
     "storybook": {
       "configurations": {

--- a/packages/sdk/examples/src/examples/Editor.css
+++ b/packages/sdk/examples/src/examples/Editor.css
@@ -47,7 +47,7 @@
   content: 'Peer B';
 }
 
-.demo-buttons {
+.demo>.buttons {
   z-index: 20;
   position: absolute;
   left: 70%;

--- a/packages/sdk/examples/src/examples/Editor.css
+++ b/packages/sdk/examples/src/examples/Editor.css
@@ -1,0 +1,56 @@
+/* TODO(wittjosiah): Tailwind plugin complains if css is nested. */
+
+.demo {
+  z-index: 10;
+  flex-grow: 1;
+  height: 32em;
+  position: relative;
+}
+
+.demo>.client {
+  border: 1px solid black;
+  width: 70%;
+  height: 75%;
+  position: absolute;
+  border-radius: 12px;
+  box-shadow: 0px 4px 12px rgba(0,0,0,0.25);
+  background-color: rgba(255,255,255,0.6);
+  backdrop-filter: blur(12px);
+  padding-block-start: 1rem;
+}
+
+.demo>.client::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 0.5em 1.2em;
+  color: gray;
+  font-family: monospace;
+  border-radius: 12px 0 0 0;
+}
+
+.demo>.client-0 {
+  top: 0;
+  left: 0;
+}
+
+.demo>.client-0::before {
+  content: 'Peer A';
+}
+
+.demo>.client-1 {
+  bottom: 0;
+  right: 0;
+}
+
+.demo>.client-1::before {
+  content: 'Peer B';
+}
+
+.demo-buttons {
+  z-index: 20;
+  position: absolute;
+  left: 70%;
+  bottom: 75%;
+  margin: 2em;
+}

--- a/packages/sdk/examples/src/examples/Editor.tsx
+++ b/packages/sdk/examples/src/examples/Editor.tsx
@@ -2,6 +2,8 @@
 // Copyright 2023 DXOS.org
 //
 
+import './Editor.css';
+
 import React, { useEffect } from 'react';
 
 import { Document } from '@braneframe/types';
@@ -26,7 +28,7 @@ const Editor = ({ spaceKey, id }: { spaceKey: PublicKey; id: number }) => {
   }, [space]);
 
   return (
-    <main className='flex-1 min-w-0'>
+    <main className={`client client-${id}`}>
       <MarkdownComposer
         model={model}
         slots={{

--- a/packages/sdk/examples/src/main.tsx
+++ b/packages/sdk/examples/src/main.tsx
@@ -1,0 +1,86 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import '@dxosTheme';
+import { Airplane, Stack } from '@phosphor-icons/react';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { Document } from '@braneframe/types';
+import { Input, ThemeProvider, Tooltip } from '@dxos/aurora';
+import { auroraTx } from '@dxos/aurora-theme';
+import { ClientContext } from '@dxos/react-client';
+import { ConnectionState } from '@dxos/react-client/mesh';
+import { setupPeersInSpace } from '@dxos/react-client/testing';
+
+import { EditorExample } from './examples';
+
+// TODO(wittjosiah): Migrate to story once chromatic publish is fixed.
+const main = async () => {
+  const { clients, spaceKey } = await setupPeersInSpace({
+    count: 2,
+    onCreateSpace: (space) => {
+      space.db.add(new Document());
+    },
+  });
+
+  const handleToggleNetwork = async (checked: boolean) => {
+    const mode = checked ? ConnectionState.OFFLINE : ConnectionState.ONLINE;
+    await Promise.all(clients.map((client) => client.mesh.updateConfig(mode)));
+  };
+
+  const handleToggleBatching = async (checked: boolean) => {
+    const batchSize = checked ? 64 : 0;
+    clients.forEach((client) => {
+      const space = client.spaces.get(spaceKey);
+      if (space) {
+        space.db._backend.maxBatchSize = batchSize;
+      }
+    });
+  };
+
+  createRoot(document.getElementById('root')!).render(
+    <ThemeProvider tx={auroraTx}>
+      <div className='demo'>
+        <Tooltip.Provider>
+          <div className='buttons'>
+            <div className='flex'>
+              <Input.Root>
+                <Tooltip.Root>
+                  <Tooltip.Trigger asChild>
+                    <Input.Label>
+                      <Airplane />
+                    </Input.Label>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content>Toggle Network</Tooltip.Content>
+                </Tooltip.Root>
+                <Input.Switch classNames='me-2' onCheckedChange={handleToggleNetwork} />
+              </Input.Root>
+            </div>
+            <div className='flex'>
+              <Input.Root>
+                <Tooltip.Root>
+                  <Tooltip.Trigger asChild>
+                    <Input.Label>
+                      <Stack />
+                    </Input.Label>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content>Toggle database batching</Tooltip.Content>
+                </Tooltip.Root>
+                <Input.Switch classNames='me-2' onCheckedChange={handleToggleBatching} />
+              </Input.Root>
+            </div>
+          </div>
+        </Tooltip.Provider>
+        {clients.map((client, index) => (
+          <ClientContext.Provider key={index} value={{ client }}>
+            <EditorExample id={index} spaceKey={spaceKey} />
+          </ClientContext.Provider>
+        ))}
+      </div>
+    </ThemeProvider>,
+  );
+};
+
+void main();

--- a/packages/sdk/examples/src/stories/examples.stories.tsx
+++ b/packages/sdk/examples/src/stories/examples.stories.tsx
@@ -2,10 +2,15 @@
 // Copyright 2022 DXOS.org
 //
 
+import { DecoratorFunction } from '@storybook/csf';
+import { ReactRenderer } from '@storybook/react';
 import React from 'react';
 
 import '@dxosTheme';
 import { Document } from '@braneframe/types';
+import { Input } from '@dxos/aurora';
+import { Client, PublicKey } from '@dxos/react-client';
+import { ConnectionState } from '@dxos/react-client/mesh';
 import { ClientDecorator, setupPeersInSpace, ToggleNetworkDecorator } from '@dxos/react-client/testing';
 
 import { EditorExample, TaskListExample } from '../examples';
@@ -28,7 +33,62 @@ const editor = await setupPeersInSpace({
   },
 });
 
+// TODO(wittjosiah): Reconcile with ToggleNetworkDecorator.
+const DemoToggles = ({
+  clients,
+  spaceKey,
+}: {
+  clients: Client[];
+  spaceKey: PublicKey;
+}): DecoratorFunction<ReactRenderer, any> => {
+  const handleToggleNetwork = async (checked: boolean) => {
+    const mode = checked ? ConnectionState.OFFLINE : ConnectionState.ONLINE;
+    await Promise.all(clients.map((client) => client.mesh.updateConfig(mode)));
+  };
+
+  const handleToggleBatching = async (checked: boolean) => {
+    const batchSize = checked ? 64 : 0;
+    clients.forEach((client) => {
+      const space = client.spaces.get(spaceKey);
+      if (space) {
+        space.db._backend.maxBatchSize = batchSize;
+      }
+    });
+  };
+
+  return (Story, context) => (
+    <>
+      <div className='demo-buttons'>
+        <div className='flex'>
+          <Input.Root>
+            <Input.Checkbox classNames='me-2' onCheckedChange={handleToggleNetwork} />
+            <Input.Label>
+              Disable{' '}
+              <a
+                href='https://docs.dxos.org/guide/platform/'
+                target='_blank'
+                rel='noreferrer'
+                className='text-primary-600 dark:text-primary-400'
+              >
+                replication
+              </a>{' '}
+              (go offline)
+            </Input.Label>
+          </Input.Root>
+        </div>
+        <div className='flex'>
+          <Input.Root>
+            <Input.Checkbox classNames='me-2' onCheckedChange={handleToggleBatching} />
+            <Input.Label>Enable mutation batching</Input.Label>
+          </Input.Root>
+        </div>
+      </div>
+      {Story({ args: context.args })}
+    </>
+  );
+};
+
 export const Editor = {
   render: (args: { id: number }) => <EditorExample {...args} spaceKey={editor.spaceKey} />,
-  decorators: [ClientDecorator({ clients: editor.clients }), ToggleNetworkDecorator({ clients: editor.clients })],
+  decorators: [ClientDecorator({ clients: editor.clients, className: 'demo' }), DemoToggles(editor)],
 };

--- a/packages/sdk/examples/src/stories/examples.stories.tsx
+++ b/packages/sdk/examples/src/stories/examples.stories.tsx
@@ -61,7 +61,7 @@ const DemoToggles = ({
       <div className='demo-buttons'>
         <div className='flex'>
           <Input.Root>
-            <Input.Checkbox classNames='me-2' onCheckedChange={handleToggleNetwork} />
+            <Input.Switch classNames='me-2' onCheckedChange={handleToggleNetwork} />
             <Input.Label>
               Disable{' '}
               <a
@@ -78,7 +78,7 @@ const DemoToggles = ({
         </div>
         <div className='flex'>
           <Input.Root>
-            <Input.Checkbox classNames='me-2' onCheckedChange={handleToggleBatching} />
+            <Input.Switch classNames='me-2' onCheckedChange={handleToggleBatching} />
             <Input.Label>Enable mutation batching</Input.Label>
           </Input.Root>
         </div>

--- a/packages/sdk/examples/tailwind.ts
+++ b/packages/sdk/examples/tailwind.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+// Left blank for vscode tooling.

--- a/packages/sdk/examples/tsconfig.node.json
+++ b/packages/sdk/examples/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/packages/sdk/examples/vite.config.ts
+++ b/packages/sdk/examples/vite.config.ts
@@ -1,0 +1,54 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+import ReactPlugin from '@vitejs/plugin-react';
+import { resolve } from 'node:path';
+import { defineConfig, searchForWorkspaceRoot } from 'vite';
+
+import { ThemePlugin } from '@dxos/aurora-theme/plugin';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  server: {
+    host: true,
+    https:
+      process.env.HTTPS === 'true'
+        ? {
+            key: './key.pem',
+            cert: './cert.pem',
+          }
+        : false,
+    fs: {
+      allow: [
+        // TODO(wittjosiah): Not detecting pnpm-workspace?
+        //   https://vitejs.dev/config/server-options.html#server-fs-allow
+        searchForWorkspaceRoot(process.cwd()),
+      ],
+    },
+  },
+  build: {
+    sourcemap: true,
+  },
+  resolve: {
+    alias: {
+      'node-fetch': 'isomorphic-fetch',
+    },
+  },
+  plugins: [
+    ThemePlugin({
+      root: __dirname,
+      content: [
+        resolve(__dirname, './index.html'),
+        resolve(__dirname, './src/**/*.{js,ts,jsx,tsx}'),
+        resolve(__dirname, './node_modules/@dxos/aurora/dist/lib/**/*.mjs'),
+        resolve(__dirname, './node_modules/@dxos/aurora-theme/dist/lib/**/*.mjs'),
+        resolve(__dirname, './node_modules/@dxos/react-client/dist/lib/**/*.mjs'),
+        resolve(__dirname, './node_modules/@dxos/react-shell/dist/lib/**/*.mjs'),
+        resolve(__dirname, './node_modules/@braneframe/plugin-*/dist/lib/**/*.mjs'),
+      ],
+    }),
+    // https://github.com/preactjs/signals/issues/269
+    ReactPlugin({ jsxRuntime: 'classic' }),
+  ],
+});

--- a/packages/sdk/react-client/src/testing/ClientDecorator.tsx
+++ b/packages/sdk/react-client/src/testing/ClientDecorator.tsx
@@ -19,6 +19,7 @@ export type ClientDecoratorOptions = {
   clients?: Client[];
   count?: number;
   registerSignalFactory?: boolean;
+  className?: string;
 };
 
 /**
@@ -29,12 +30,17 @@ export type ClientDecoratorOptions = {
  * @returns {DecoratorFunction}
  */
 export const ClientDecorator = (options: ClientDecoratorOptions = {}): DecoratorFunction<ReactRenderer, any> => {
-  const { clients, count = 1, registerSignalFactory: register = true } = options;
+  const {
+    clients,
+    count = 1,
+    registerSignalFactory: register = true,
+    className = 'flex place-content-evenly',
+  } = options;
   register && registerSignalFactory();
 
   if (clients) {
     return (Story, context) => (
-      <div className='flex place-content-evenly'>
+      <div className={className}>
         {clients.map((client, index) => (
           <ClientContext.Provider key={index} value={{ client }}>
             {Story({ args: { id: index, count: clients.length, ...context.args } })}
@@ -45,7 +51,7 @@ export const ClientDecorator = (options: ClientDecoratorOptions = {}): Decorator
   }
 
   return (Story, context) => (
-    <div className='flex place-content-evenly'>
+    <div className={className}>
       {[...Array(count)].map((_, index) => (
         <ClientProvider key={index} services={services} fallback={() => <p>Loading</p>}>
           {Story({ args: { id: index, count, ...context.args } })}

--- a/packages/ui/aurora/package.json
+++ b/packages/ui/aurora/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-select": "^1.2.1",
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.1",
+    "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-toast": "^1.1.3",
     "@radix-ui/react-toggle": "^1.0.2",
     "@radix-ui/react-toggle-group": "^1.0.3",

--- a/packages/ui/aurora/src/components/Input/Input.stories.tsx
+++ b/packages/ui/aurora/src/components/Input/Input.stories.tsx
@@ -16,7 +16,7 @@ type StoryInputProps = Partial<{
   description: string;
   labelVisuallyHidden: boolean;
   descriptionVisuallyHidden: boolean;
-  type: 'default' | 'pin' | 'textarea' | 'checkbox';
+  type: 'default' | 'pin' | 'textarea' | 'checkbox' | 'switch';
   validationMessage: string;
   validationValence: MessageValence;
 }>;
@@ -38,6 +38,7 @@ const StoryInput = ({
       {type === 'pin' && <Input.PinInput {...props} />}
       {type === 'textarea' && <Input.TextArea {...props} />}
       {type === 'checkbox' && <Input.Checkbox {...props} />}
+      {type === 'switch' && <Input.Switch {...props} />}
       {type === 'default' && <Input.TextInput {...props} />}
       <Input.DescriptionAndValidation srOnly={descriptionVisuallyHidden}>
         {validationMessage && (
@@ -180,6 +181,16 @@ export const Checkbox = {
   args: {
     label: 'This is a checkbox',
     type: 'checkbox',
+    description: 'It’s checked, indeterminate, or unchecked',
+    size: 5,
+    weight: 'bold',
+  },
+};
+
+export const Switch = {
+  args: {
+    label: 'This is a switch',
+    type: 'switch',
     description: 'It’s checked, indeterminate, or unchecked',
     size: 5,
     weight: 'bold',

--- a/packages/ui/aurora/src/components/Input/Input.tsx
+++ b/packages/ui/aurora/src/components/Input/Input.tsx
@@ -8,6 +8,11 @@ import {
   CheckboxProps as CheckboxPrimitiveProps,
   Indicator as CheckboxIndicatorPrimitive,
 } from '@radix-ui/react-checkbox';
+import {
+  Root as SwitchPrimitive,
+  Thumb as SwitchThumbPrimitive,
+  SwitchProps as SwitchPrimitiveProps,
+} from '@radix-ui/react-switch';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import React, { forwardRef, ForwardRefExoticComponent, Fragment, useCallback } from 'react';
 
@@ -288,12 +293,61 @@ const Checkbox: ForwardRefExoticComponent<CheckboxProps> = forwardRef<
   },
 );
 
+type SwitchProps = ThemedClassName<Omit<SwitchPrimitiveProps, 'children'>> & { size?: Size };
+
+const Switch: ForwardRefExoticComponent<SwitchProps> = forwardRef<HTMLButtonElement, InputScopedProps<SwitchProps>>(
+  (
+    {
+      __inputScope,
+      checked: propsChecked,
+      defaultChecked: propsDefaultChecked,
+      onCheckedChange: propsOnCheckedChange,
+      size,
+      classNames,
+      ...props
+    },
+    forwardedRef,
+  ) => {
+    const [checked, onCheckedChange] = useControllableState({
+      prop: propsChecked,
+      defaultProp: propsDefaultChecked,
+      onChange: propsOnCheckedChange,
+    });
+    const { id, validationValence, descriptionId, errorMessageId } = useInputContext(INPUT_NAME, __inputScope);
+    // const { tx } = useThemeContext();
+    return (
+      <SwitchPrimitive
+        {...{
+          ...props,
+          checked,
+          onCheckedChange,
+          id,
+          'aria-describedby': descriptionId,
+          ...(validationValence === 'error' && {
+            'aria-invalid': 'true' as const,
+            'aria-errormessage': errorMessageId,
+          }),
+          // className: tx('input.checkbox', 'input--checkbox', { size }, 'shrink-0', classNames),
+          className:
+            'w-[56px] h-[32px] bg-gray-100 rounded-full px-[4px] border border-black relative data-[state=checked]:bg-black outline-none cursor-default',
+        }}
+        ref={forwardedRef}
+      >
+        {/* TODO(wittjosiah): Embed icons/text for on/off states.
+             e.g., https://codepen.io/alvarotrigo/pen/oNoJePo (#13) */}
+        <SwitchThumbPrimitive className='block w-[21px] h-[21px] bg-white rounded-full shadow-[0_2px_2px] shadow-blackA7 transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[24px]' />
+      </SwitchPrimitive>
+    );
+  },
+);
+
 export const Input = {
   Root: InputRoot,
   PinInput,
   TextInput,
   TextArea,
   Checkbox,
+  Switch,
   Label,
   Description,
   Validation,
@@ -307,6 +361,7 @@ export type {
   TextInputProps,
   TextAreaProps,
   CheckboxProps,
+  SwitchProps,
   LabelProps,
   DescriptionProps,
   ValidationProps,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5859,6 +5859,7 @@ importers:
       '@radix-ui/react-select': ^1.2.1
       '@radix-ui/react-separator': ^1.0.3
       '@radix-ui/react-slot': ^1.0.1
+      '@radix-ui/react-switch': ^1.0.3
       '@radix-ui/react-toast': ^1.1.3
       '@radix-ui/react-toggle': ^1.0.2
       '@radix-ui/react-toggle-group': ^1.0.3
@@ -5895,6 +5896,7 @@ importers:
       '@radix-ui/react-select': 1.2.1_rj7ozvcq3uehdlnj3cbwzbi5ce
       '@radix-ui/react-separator': 1.0.3_5uumaiclxbdbzaqafclbf6maf4
       '@radix-ui/react-slot': 1.0.2_iapumuv4e6jcjznwuxpf4tt22e
+      '@radix-ui/react-switch': 1.0.3_5uumaiclxbdbzaqafclbf6maf4
       '@radix-ui/react-toast': 1.1.3_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-toggle': 1.0.2_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-toggle-group': 1.0.3_biqbaboplfbrettd7655fr4n2y
@@ -12153,6 +12155,7 @@ packages:
     dependencies:
       '@nx/cypress': 16.5.4_qhptqrzqo7bwtm33kpvmsos7ve
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - cypress
@@ -12196,6 +12199,7 @@ packages:
       '@nx/eslint-plugin': 16.8.1_4v7kbp3q3j2n336mr2nodvz57y
       '@typescript-eslint/parser': 6.7.0_rngtr6f3b25lvetpihwplgecf4
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@swc/wasm'
@@ -12214,6 +12218,7 @@ packages:
     dependencies:
       '@nx/jest': 16.5.4_ebxsb5ytaojlvyq6j3l6ecuzii
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@types/node'
@@ -12231,6 +12236,7 @@ packages:
     dependencies:
       '@nx/js': 16.5.4_st3ukm3rnd3xadn2fxesh4boby_eoiemzzyseqzjynwznlrcdpipu
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12245,6 +12251,7 @@ packages:
     dependencies:
       '@nx/js': 16.8.1_ucnxlcwbwhxru7e5ww4bc6yjba
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@swc/wasm'
@@ -12261,6 +12268,7 @@ packages:
     dependencies:
       '@nx/linter': 16.5.4_qhptqrzqo7bwtm33kpvmsos7ve
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12284,6 +12292,7 @@ packages:
     dependencies:
       '@nx/storybook': 16.5.4_qhptqrzqo7bwtm33kpvmsos7ve
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - cypress
@@ -12323,6 +12332,7 @@ packages:
     dependencies:
       '@nx/vite': 16.5.4_xxzhsuqrsbs6wyvhvm37cpe46m_qgit66yh2vyynsv7uxdneek4qa
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12338,6 +12348,7 @@ packages:
     dependencies:
       '@nx/web': 16.5.4_eoiemzzyseqzjynwznlrcdpipu
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12384,6 +12395,7 @@ packages:
       dotenv: 10.0.0
       semver: 7.5.3
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12459,6 +12471,7 @@ packages:
       semver: 7.5.3
       tslib: 2.6.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@swc/wasm'
@@ -12489,6 +12502,7 @@ packages:
       resolve.exports: 1.1.0
       tslib: 2.6.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@types/node'
@@ -12522,7 +12536,7 @@ packages:
       '@phenomnomnominal/tsquery': 5.0.1_typescript@5.2.2
       babel-plugin-const-enum: 1.2.0_@babel+core@7.21.3
       babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2
+      babel-plugin-transform-typescript-metadata: 0.3.2_@babel+core@7.21.3
       chalk: 4.1.2
       detect-port: 1.5.1
       fast-glob: 3.2.7
@@ -12534,6 +12548,7 @@ packages:
       source-map-support: 0.5.19
       tslib: 2.6.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12564,7 +12579,7 @@ packages:
       '@phenomnomnominal/tsquery': 5.0.1_typescript@5.2.2
       babel-plugin-const-enum: 1.2.0_@babel+core@7.22.19
       babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2
+      babel-plugin-transform-typescript-metadata: 0.3.2_@babel+core@7.22.19
       chalk: 4.1.2
       detect-port: 1.5.1
       fast-glob: 3.2.7
@@ -12578,6 +12593,7 @@ packages:
       tsconfig-paths: 4.1.2
       tslib: 2.6.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@swc/wasm'
@@ -12604,6 +12620,7 @@ packages:
       tmp: 0.2.1
       tslib: 2.6.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12806,6 +12823,7 @@ packages:
       dotenv: 10.0.0
       semver: 7.5.3
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - cypress
@@ -12831,6 +12849,7 @@ packages:
       enquirer: 2.3.6
       vite: 4.3.9_@types+node@18.11.9
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12854,6 +12873,7 @@ packages:
       ignore: 5.2.4
       tslib: 2.6.0
     transitivePeerDependencies:
+      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -14550,6 +14570,33 @@ packages:
       '@radix-ui/react-compose-refs': 1.0.1_iapumuv4e6jcjznwuxpf4tt22e
       '@types/react': 18.0.21
       react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-switch/1.0.3_5uumaiclxbdbzaqafclbf6maf4:
+    resolution: {integrity: sha512-mxm87F88HyHztsI7N+ZUmEoARGkC22YVW5CaC+Byc+HRpuvCrOBPTAnXgf+tZ/7i0Sg/eOePGdMhUKhPaQEqow==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1_iapumuv4e6jcjznwuxpf4tt22e
+      '@radix-ui/react-context': 1.0.1_iapumuv4e6jcjznwuxpf4tt22e
+      '@radix-ui/react-primitive': 1.0.3_5uumaiclxbdbzaqafclbf6maf4
+      '@radix-ui/react-use-controllable-state': 1.0.1_iapumuv4e6jcjznwuxpf4tt22e
+      '@radix-ui/react-use-previous': 1.0.1_iapumuv4e6jcjznwuxpf4tt22e
+      '@radix-ui/react-use-size': 1.0.1_iapumuv4e6jcjznwuxpf4tt22e
+      '@types/react': 18.0.21
+      '@types/react-dom': 18.0.6
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
     dev: false
 
   /@radix-ui/react-tabs/1.0.4_5uumaiclxbdbzaqafclbf6maf4:
@@ -20737,7 +20784,7 @@ packages:
   /axios/1.3.4_debug@4.3.4:
     resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2_debug@4.3.4
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -20955,9 +21002,29 @@ packages:
   /babel-plugin-syntax-jsx/6.18.0:
     resolution: {integrity: sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==}
 
-  /babel-plugin-transform-typescript-metadata/0.3.2:
+  /babel-plugin-transform-typescript-metadata/0.3.2_@babel+core@7.21.3:
     resolution: {integrity: sha512-mWEvCQTgXQf48yDqgN7CH50waTyYBeP2Lpqx4nNWab9sxEpdXVeKgfj1qYI2/TgUPQtNFZ85i3PemRtnXVYYJg==}
+    peerDependencies:
+      '@babel/core': ^7
+      '@babel/traverse': ^7
+    peerDependenciesMeta:
+      '@babel/traverse':
+        optional: true
     dependencies:
+      '@babel/core': 7.21.3
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /babel-plugin-transform-typescript-metadata/0.3.2_@babel+core@7.22.19:
+    resolution: {integrity: sha512-mWEvCQTgXQf48yDqgN7CH50waTyYBeP2Lpqx4nNWab9sxEpdXVeKgfj1qYI2/TgUPQtNFZ85i3PemRtnXVYYJg==}
+    peerDependencies:
+      '@babel/core': ^7
+      '@babel/traverse': ^7
+    peerDependenciesMeta:
+      '@babel/traverse':
+        optional: true
+    dependencies:
+      '@babel/core': 7.22.19
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -26316,6 +26383,18 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  /follow-redirects/1.15.2_debug@4.3.4:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+    dev: true
 
   /fontkit/2.0.2:
     resolution: {integrity: sha512-jc4k5Yr8iov8QfS6u8w2CnHWVmbOGtdBtOXMze5Y+QD966Rx6PEVWXSEGwXlsDlKtu1G12cJjcsybnqhSk/+LA==}
@@ -40356,7 +40435,7 @@ packages:
       fast-glob: 3.2.12
       pretty-bytes: 6.0.0
       rollup: 3.23.0
-      vite: 4.3.9_@types+node@18.11.9
+      vite: 4.3.9
       workbox-build: 6.5.4
       workbox-window: 6.5.4
     transitivePeerDependencies:


### PR DESCRIPTION

![image](https://github.com/dxos/dxos/assets/4529818/3a5dfc97-5edb-40f2-a623-8cdbd86eb447)

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fa0a9db</samp>

### Summary
🎨📝🔧

<!--
1.  🎨 - This emoji is often used to indicate changes related to styling, design, or appearance of a component or UI element. It could be used for the first and second changes, which introduce and apply a new CSS file for the Editor example component.
2.  📝 - This emoji is often used to indicate changes related to documentation, writing, or editing. It could be used for the first change, which demonstrates collaborative editing of markdown documents using CRDTs, or for the second change, which updates the Editor example component.
3.  🔧 - This emoji is often used to indicate changes related to configuration, settings, or tools. It could be used for the third change, which adds network and batching toggles to the Editor story in Storybook, using the Input component from Aurora and some logic from React Client and Braneframe. It could also be used for the fourth change, which adds a `className` prop to the `ClientDecoratorOptions` type and the `ClientDecorator` function.
-->
This pull request enhances the Editor example and story in the SDK package, which showcases collaborative markdown editing with CRDTs. It adds a new CSS file for styling the example component, a class name prop for distinguishing users, and network and batching toggles for testing different scenarios. It also removes an unnecessary decorator from the story.

> _We're sailing on the sea of code, with CRDTs and markdown_
> _We're styling up the Editor, with a CSS file of our own_
> _We're adding toggles to the story, to test the network and batching_
> _And on the count of three we'll pull, and merge our changes in_

### Walkthrough
*  Add a new CSS file `Editor.css` for styling the Editor example component, which demonstrates collaborative editing of markdown documents using CRDTs ([link](https://github.com/dxos/dxos/pull/4286/files?diff=unified&w=0#diff-73cee4aca5a507133c98fdfc2af39ba7b7a76579f8780fa9e01483e3cf80f027R1-R56))
* Import the new CSS file and apply a class name based on the id prop to the main element of the Editor example component in `Editor.tsx` ([link](https://github.com/dxos/dxos/pull/4286/files?diff=unified&w=0#diff-687751c472840a8f086ba3e3ec9fb3726ad35ad4d41615414b549d8eb1ced3d2R5-R6), [link](https://github.com/dxos/dxos/pull/4286/files?diff=unified&w=0#diff-687751c472840a8f086ba3e3ec9fb3726ad35ad4d41615414b549d8eb1ced3d2L29-R31))
* Modify the Editor story in `examples.stories.tsx` to use a new DemoToggles decorator, which wraps the story with network and batching toggles, and passes the clients and spaceKey props to the toggles ([link](https://github.com/dxos/dxos/pull/4286/files?diff=unified&w=0#diff-9ce7ab0a39b3bfd00bb06f47642e4788a5f414ad1ab5e15f0c6a0274b6d1db97L5-R13), [link](https://github.com/dxos/dxos/pull/4286/files?diff=unified&w=0#diff-9ce7ab0a39b3bfd00bb06f47642e4788a5f414ad1ab5e15f0c6a0274b6d1db97L31-R93))
* Add a new optional prop className to the ClientDecoratorOptions type and use it in the ClientDecorator function in `ClientDecorator.tsx`, which wraps stories with client providers ([link](https://github.com/dxos/dxos/pull/4286/files?diff=unified&w=0#diff-d2c8867457c73e5f7374a781c1239842f8be61c60af1679bc3b777e35b02e949R22), [link](https://github.com/dxos/dxos/pull/4286/files?diff=unified&w=0#diff-d2c8867457c73e5f7374a781c1239842f8be61c60af1679bc3b777e35b02e949L32-R43), [link](https://github.com/dxos/dxos/pull/4286/files?diff=unified&w=0#diff-d2c8867457c73e5f7374a781c1239842f8be61c60af1679bc3b777e35b02e949L48-R54))


