### PR TITLE
feat: Update expando to set meta/schema via options.

### DIFF
--- a/docs/docs/guide/react/snippets/schema.ts
+++ b/docs/docs/guide/react/snippets/schema.ts
@@ -5,11 +5,12 @@
 import { TypedObject, TypeFilter, EchoSchema } from '@dxos/react-client/echo';
 
 export const schema = EchoSchema.fromJson(
-  '{ "protobuf generated json here": true }'
+  '{ "protobuf generated json here": true }',
 );
 
 export class Task extends TypedObject {
-  static readonly type: ReturnType<typeof schema.getType> = schema.getType('example.tasks.Task');
+  static readonly type: ReturnType<typeof schema.getType> =
+    schema.getType('example.tasks.Task');
 
   static filter(opts?: {
     title?: string;
@@ -19,7 +20,7 @@ export class Task extends TypedObject {
   }
 
   constructor(opts?: { title?: string; completed?: boolean }) {
-    super({ ...opts, '@type': Task.type.name }, Task.type);
+    super({ ...opts, '@type': Task.type.name }, { schema: Task.type });
   }
 
   declare title: string;

--- a/docs/docs/guide/typescript/snippets/schema.ts
+++ b/docs/docs/guide/typescript/snippets/schema.ts
@@ -5,11 +5,12 @@
 import { TypedObject, TypeFilter, EchoSchema } from '@dxos/client/echo';
 
 export const schema = EchoSchema.fromJson(
-  '{ "protobuf generated json here": true }'
+  '{ "protobuf generated json here": true }',
 );
 
 export class Task extends TypedObject {
-  static readonly type: ReturnType<typeof schema.getType> = schema.getType('example.tasks.Task');
+  static readonly type: ReturnType<typeof schema.getType> =
+    schema.getType('example.tasks.Task');
 
   static filter(opts?: {
     title?: string;
@@ -19,7 +20,7 @@ export class Task extends TypedObject {
   }
 
   constructor(opts?: { title?: string; completed?: boolean }) {
-    super({ ...opts, '@type': Task.type.name }, Task.type);
+    super({ ...opts, '@type': Task.type.name }, { schema: Task.type });
   }
 
   declare title: string;

--- a/packages/apps/plugins/plugin-debug/src/testing/Generator.tsx
+++ b/packages/apps/plugins/plugin-debug/src/testing/Generator.tsx
@@ -59,7 +59,7 @@ export class Generator {
           name,
           website: this._faker!.datatype.boolean({ probability: 0.3 }) ? this._faker!.internet.url() : undefined,
         });
-        obj.meta.schema = org;
+        obj.__meta.schema = org;
         return this._space.db.add(obj);
       },
     );
@@ -90,7 +90,7 @@ export class Generator {
           name,
           repo: this._faker!.datatype.boolean({ probability: 0.3 }) ? this._faker!.internet.url() : undefined,
         });
-        obj.meta.schema = project;
+        obj.__meta.schema = project;
         return this._space.db.add(obj);
       },
     );
@@ -129,7 +129,7 @@ export class Generator {
           ? this._faker!.helpers.arrayElement(organizations)
           : undefined,
       });
-      obj.meta.schema = person;
+      obj.__meta.schema = person;
       return this._space.db.add(obj);
     });
 

--- a/packages/apps/plugins/plugin-github/src/GithubPlugin.tsx
+++ b/packages/apps/plugins/plugin-github/src/GithubPlugin.tsx
@@ -39,7 +39,7 @@ export type GithubPluginProvides = TranslationsProvides &
     settings: GithubSettingsProps;
   };
 
-const filter = (obj: Document) => obj.meta?.keys?.find((key) => key?.source?.includes('github'));
+const filter = (obj: Document) => obj.__meta?.keys?.find((key) => key?.source?.includes('github'));
 
 export const GithubPlugin = (): PluginDefinition<GithubPluginProvides> => {
   let adapter: GraphNodeAdapter<Document> | undefined;

--- a/packages/apps/plugins/plugin-github/src/components/EmbeddedMain/EmbeddedMain.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/EmbeddedMain/EmbeddedMain.tsx
@@ -100,7 +100,7 @@ const EmbeddedLayoutImpl = () => {
     text: document ? document.content : undefined,
   });
 
-  const docGhId = useDocGhId(document?.meta?.keys ?? []);
+  const docGhId = useDocGhId(document?.__meta?.keys ?? []);
   const name = space && getSpaceDisplayName(space);
 
   return (

--- a/packages/apps/plugins/plugin-github/src/components/GithubEchoResolverProviders/ResolverContext.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/GithubEchoResolverProviders/ResolverContext.tsx
@@ -72,7 +72,7 @@ const DocumentResolverProviderImpl = ({
   const defaultDisplayName = displayName(source, id);
 
   const documents = useQuery(space, (obj) => {
-    const keys = obj.meta?.keys;
+    const keys = obj.__meta?.keys;
     return keys?.find((key: any) => key.source === source && key.id === id);
   });
 
@@ -83,12 +83,15 @@ const DocumentResolverProviderImpl = ({
       }
 
       if (event.data.type === 'initial-data') {
-        const nextDocument = new Document({
-          content: new Text(event.data.content),
-          title: defaultDisplayName,
-        }).setMeta({
-          keys: [{ source, id }],
-        });
+        const nextDocument = new Document(
+          {
+            content: new Text(event.data.content),
+            title: defaultDisplayName,
+          },
+          {
+            meta: { keys: [{ source, id }] },
+          },
+        );
         space.db.add(nextDocument);
         setDocument(nextDocument);
       }

--- a/packages/apps/plugins/plugin-github/src/components/GithubEchoResolverProviders/spaceResolvers.ts
+++ b/packages/apps/plugins/plugin-github/src/components/GithubEchoResolverProviders/spaceResolvers.ts
@@ -18,7 +18,7 @@ export const matchSpace = (space: Space, identityHex: string, source?: string, i
     return false;
   }
   switch (source) {
-    case 'com.github':
+    case 'github.com':
       return ghMatch(space, identityHex, id);
     default:
       return false;
@@ -36,7 +36,7 @@ const ghBind = (space: Space, identityHex: string, id: string): string[] => {
 
 export const bindSpace = (space: Space, identityHex: string, source: string, id: string): string[] => {
   switch (source) {
-    case 'com.github':
+    case 'github.com':
       return ghBind(space, identityHex, id);
     default:
       return [];
@@ -59,7 +59,7 @@ const ghUnbind = (space: Space, identityHex: string, id: string): string[] => {
 
 export const unbindSpace = (space: Space, identityHex: string, source: string, id: string): string[] => {
   switch (source) {
-    case 'com.github':
+    case 'github.com':
       return ghUnbind(space, identityHex, id);
     default:
       return [];
@@ -78,7 +78,7 @@ const ghDisplayName = (id: string): string => {
 
 export const displayName = (source: string, id: string): string => {
   switch (source) {
-    case 'com.github':
+    case 'github.com':
       return ghDisplayName(id);
     default:
       return id;

--- a/packages/apps/plugins/plugin-github/src/components/MarkdownActions.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/MarkdownActions.tsx
@@ -1,6 +1,7 @@
 //
 // Copyright 2023 DXOS.org
 //
+
 import { ArrowSquareOut, FileArrowDown, FileArrowUp, Link, LinkBreak } from '@phosphor-icons/react';
 import React, { RefObject, useCallback } from 'react';
 
@@ -15,19 +16,19 @@ import { useOctokitContext } from './GithubApiProviders';
 import { useDocGhId } from '../hooks';
 import { GITHUB_PLUGIN, GhIssueIdentifier } from '../props';
 
-// TODO(burdon): Where do "properties" come from?
+// TODO(burdon): Where do "properties" come from? Is this the graph node datum?
 export const MarkdownActions = ({
   data: [model, properties, editorRef],
 }: {
   data: [ComposerModel, MarkdownProperties, RefObject<MarkdownComposerRef>];
 }) => {
-  // TODO(burdon): Adhoc assumption that underlying object is ECHO.
-  const ghId = properties.meta?.keys?.find((key) => key.source === 'github.com')?.id;
+  // TODO(burdon): Ad hoc assumption that underlying object is ECHO?
+  const ghId = properties.__meta?.keys?.find((key) => key.source === 'github.com')?.id;
   const { octokit } = useOctokitContext();
   const { t } = useTranslation(GITHUB_PLUGIN);
   const splitView = useSplitView();
 
-  const docGhId = useDocGhId(properties.meta?.keys ?? []);
+  const docGhId = useDocGhId(properties.__meta?.keys ?? []);
 
   const updateIssueContent = useCallback(() => {
     const { owner, repo, issueNumber } = docGhId as GhIssueIdentifier;
@@ -95,8 +96,8 @@ export const MarkdownActions = ({
           <DropdownMenu.Item
             classNames='gap-2'
             onClick={() => {
-              const index = properties.meta?.keys?.findIndex((key) => key.source === 'github.com');
-              typeof index !== 'undefined' && index >= 0 && properties.meta?.keys?.splice(index, 1);
+              const index = properties.__meta?.keys?.findIndex((key) => key.source === 'github.com');
+              typeof index !== 'undefined' && index >= 0 && properties.__meta?.keys?.splice(index, 1);
             }}
           >
             <LinkBreak className={getSize(4)} />

--- a/packages/apps/plugins/plugin-github/src/components/MarkdownActions.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/MarkdownActions.tsx
@@ -15,6 +15,7 @@ import { useOctokitContext } from './GithubApiProviders';
 import { useDocGhId } from '../hooks';
 import { GITHUB_PLUGIN, GhIssueIdentifier } from '../props';
 
+// TODO(burdon): Where do "properties" come from?
 export const MarkdownActions = ({
   data: [model, properties, editorRef],
 }: {

--- a/packages/apps/plugins/plugin-github/src/components/MarkdownActions.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/MarkdownActions.tsx
@@ -20,7 +20,8 @@ export const MarkdownActions = ({
 }: {
   data: [ComposerModel, MarkdownProperties, RefObject<MarkdownComposerRef>];
 }) => {
-  const ghId = properties.meta?.keys?.find((key) => key.source === 'com.github')?.id;
+  // TODO(burdon): Adhoc assumption that underlying object is ECHO.
+  const ghId = properties.meta?.keys?.find((key) => key.source === 'github.com')?.id;
   const { octokit } = useOctokitContext();
   const { t } = useTranslation(GITHUB_PLUGIN);
   const splitView = useSplitView();
@@ -93,7 +94,7 @@ export const MarkdownActions = ({
           <DropdownMenu.Item
             classNames='gap-2'
             onClick={() => {
-              const index = properties.meta?.keys?.findIndex((key) => key.source === 'com.github');
+              const index = properties.meta?.keys?.findIndex((key) => key.source === 'github.com');
               typeof index !== 'undefined' && index >= 0 && properties.meta?.keys?.splice(index, 1);
             }}
           >

--- a/packages/apps/plugins/plugin-github/src/components/UrlDialog.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/UrlDialog.tsx
@@ -7,7 +7,7 @@ import React, { useState } from 'react';
 import { MarkdownProperties } from '@braneframe/plugin-markdown';
 import { Dialog, Button, useTranslation, Input } from '@dxos/aurora';
 
-import { useGhIdFromUrl } from '../hooks/useGhIdFromUrl';
+import { useGhIdFromUrl } from '../hooks';
 import { GITHUB_PLUGIN } from '../props';
 
 export const UrlDialog = ({ data: [_, properties] }: { data: [string, MarkdownProperties] }) => {
@@ -39,7 +39,7 @@ export const UrlDialog = ({ data: [_, properties] }: { data: [string, MarkdownPr
             classNames='mbs-2'
             onClick={() => {
               if (ghId && document) {
-                properties.meta.keys.push({ source: 'github.com', id: ghId });
+                properties.__meta.keys.push({ source: 'github.com', id: ghId });
               }
             }}
           >

--- a/packages/apps/plugins/plugin-github/src/components/UrlDialog.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/UrlDialog.tsx
@@ -39,7 +39,7 @@ export const UrlDialog = ({ data: [_, properties] }: { data: [string, MarkdownPr
             classNames='mbs-2'
             onClick={() => {
               if (ghId && document) {
-                properties.meta.keys.push({ source: 'com.github', id: ghId });
+                properties.meta.keys.push({ source: 'github.com', id: ghId });
               }
             }}
           >

--- a/packages/apps/plugins/plugin-github/src/hooks/index.ts
+++ b/packages/apps/plugins/plugin-github/src/hooks/index.ts
@@ -3,3 +3,4 @@
 //
 
 export * from './useDocGhId';
+export * from './useGhIdFromUrl';

--- a/packages/apps/plugins/plugin-github/src/hooks/useDocGhId.ts
+++ b/packages/apps/plugins/plugin-github/src/hooks/useDocGhId.ts
@@ -11,7 +11,7 @@ import { GhIdentifier } from '../props';
 export const useDocGhId = (keys: { source?: string; id?: string }[]) => {
   return useMemo<GhIdentifier | null>(() => {
     try {
-      const key = keys?.find((key) => key.source === 'com.github');
+      const key = keys?.find((key) => key.source === 'github.com');
       const [owner, repo, type, ...rest] = key?.id?.split('/') ?? [];
       if (type === 'issues') {
         return {

--- a/packages/apps/plugins/plugin-graph/src/graph/graph.ts
+++ b/packages/apps/plugins/plugin-graph/src/graph/graph.ts
@@ -10,9 +10,13 @@ import { EventSubscriptions } from '@dxos/async';
 
 import { Graph } from './types';
 
+/**
+ *
+ */
 export class GraphStore implements Graph {
   private readonly _nodeBuilders = new Set<Graph.NodeBuilder>();
   private readonly _unsubscribe = new Map<string, EventSubscriptions>();
+
   private readonly _root: Graph.Node = this._createNode({ id: 'root', label: 'Root' });
   // TODO(wittjosiah): Should this support multiple paths to the same node?
   private readonly _index = deepSignal<{ [key: string]: string[] }>({});
@@ -67,6 +71,7 @@ export class GraphStore implements Graph {
         const unsubscribe = builder(this._filterBuilders(from, path, [...ignoreBuilders, builder]));
         unsubscribe && subscriptions.add(unsubscribe);
       });
+
     this._unsubscribe.set(from.id, subscriptions);
   }
 

--- a/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -58,20 +58,22 @@ export const isDocument = (data: unknown): data is Document =>
 export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
   const settings = new LocalStorageStore<MarkdownSettingsProps>('braneframe.plugin-markdown');
   const state = deepSignal<{ onChange: NonNullable<MarkdownComposerProps['onChange']>[] }>({ onChange: [] });
+
+  // TODO(burdon): Document.
   const pluginMutableRef: MutableRefObject<MarkdownComposerRef> = {
     current: { editor: null },
   };
   const pluginRefCallback: RefCallback<MarkdownComposerRef> = (nextRef: MarkdownComposerRef) => {
     pluginMutableRef.current = { ...nextRef };
   };
+
   let adapter: GraphNodeAdapter<Document> | undefined;
 
-  const EditorMainStandalone = ({
-    data: { composer, properties },
-  }: {
+  // TODO(burdon): Rationalize EditorMainStandalone vs EditorMainEmbedded, etc. Should these components be inline or external?
+  const EditorMainStandalone: FC<{
     data: { composer: ComposerModel; properties: MarkdownProperties };
     role?: string;
-  }) => {
+  }> = ({ data: { composer, properties } }) => {
     const onChange: NonNullable<MarkdownComposerProps['onChange']> = useCallback(
       (content) => state.onChange.forEach((onChange) => onChange(content)),
       [state.onChange],
@@ -89,6 +91,7 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
     );
   };
 
+  // TODO(burdon): Is `data` expected to be a Document (TypedObject) or MarkdownProperties?
   const MarkdownMain: FC<{ data: Document }> = ({ data }) => {
     const identity = useIdentity();
     const spacePlugin = usePlugin<SpacePluginProvides>('dxos.org/plugin/space');
@@ -129,7 +132,6 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
     const identity = useIdentity();
     const spacePlugin = usePlugin<SpacePluginProvides>('dxos.org/plugin/space');
     const space = spacePlugin?.provides.space.active;
-
     const textModel = useTextModel({
       identity,
       space,

--- a/packages/apps/plugins/plugin-markdown/src/types.ts
+++ b/packages/apps/plugins/plugin-markdown/src/types.ts
@@ -7,6 +7,7 @@ import { IntentProvides } from '@braneframe/plugin-intent';
 import { TranslationsProvides } from '@braneframe/plugin-theme';
 import { Document } from '@braneframe/types';
 import { EditorMode, MarkdownComposerProps } from '@dxos/aurora-composer';
+import { ObjectMeta } from '@dxos/client/echo';
 
 export const MARKDOWN_PLUGIN = 'dxos.org/plugin/markdown';
 
@@ -16,9 +17,11 @@ export enum MarkdownAction {
   CREATE = `${MARKDOWN_ACTION}/create`,
 }
 
-// TODO(burdon): This is just pretending not to be an ECHO object.
 export type MarkdownProperties = {
   title: string;
+
+  // TODO(burdon): Since this is always very precisely an ECHO object why obfuscate it?
+  __meta: ObjectMeta;
   readOnly?: boolean;
 };
 

--- a/packages/apps/plugins/plugin-markdown/src/types.ts
+++ b/packages/apps/plugins/plugin-markdown/src/types.ts
@@ -7,7 +7,7 @@ import { IntentProvides } from '@braneframe/plugin-intent';
 import { TranslationsProvides } from '@braneframe/plugin-theme';
 import { Document } from '@braneframe/types';
 import { EditorMode, MarkdownComposerProps } from '@dxos/aurora-composer';
-import { ObjectMeta } from '@dxos/react-client/echo';
+// import { ObjectMeta } from '@dxos/react-client/echo';
 
 export const MARKDOWN_PLUGIN = 'dxos.org/plugin/markdown';
 
@@ -20,7 +20,7 @@ export enum MarkdownAction {
 export type MarkdownProperties = {
   title: string;
   // TODO(burdon): Factor out (type system).
-  meta: ObjectMeta;
+  // meta: ObjectMeta;
   readOnly?: boolean;
 };
 

--- a/packages/apps/plugins/plugin-markdown/src/types.ts
+++ b/packages/apps/plugins/plugin-markdown/src/types.ts
@@ -7,7 +7,6 @@ import { IntentProvides } from '@braneframe/plugin-intent';
 import { TranslationsProvides } from '@braneframe/plugin-theme';
 import { Document } from '@braneframe/types';
 import { EditorMode, MarkdownComposerProps } from '@dxos/aurora-composer';
-// import { ObjectMeta } from '@dxos/react-client/echo';
 
 export const MARKDOWN_PLUGIN = 'dxos.org/plugin/markdown';
 
@@ -17,17 +16,16 @@ export enum MarkdownAction {
   CREATE = `${MARKDOWN_ACTION}/create`,
 }
 
+// TODO(burdon): This is just pretending not to be an ECHO object.
 export type MarkdownProperties = {
   title: string;
-  // TODO(burdon): Factor out (type system).
-  // meta: ObjectMeta;
   readOnly?: boolean;
 };
 
 export type MarkdownProvides = {
   markdown: {
-    onChange?: MarkdownComposerProps['onChange'];
     filter?: (document: Document) => boolean;
+    onChange?: MarkdownComposerProps['onChange'];
   };
 };
 

--- a/packages/apps/plugins/plugin-space/src/helpers.tsx
+++ b/packages/apps/plugins/plugin-space/src/helpers.tsx
@@ -15,7 +15,7 @@ import { defaultMap } from '@dxos/util';
 
 import { SPACE_PLUGIN, SpaceAction } from './types';
 
-export { getIndices } from '@tldraw/indices';
+export { getIndices } from '@tldraw/indices'; // TODO(burdon): Wrap?
 
 export type GraphNodeAdapterOptions<T extends TypedObject> = {
   filter: Filter<T>;

--- a/packages/core/echo/echo-schema/src/database.test.ts
+++ b/packages/core/echo/echo-schema/src/database.test.ts
@@ -148,9 +148,9 @@ describe('Database', () => {
       '@id': obj.id,
       '@type': undefined,
       '@model': 'dxos.org/model/document',
+      '@meta': { keys: [] },
       title: 'Test title',
       description: 'Test description',
-      meta: { keys: [] },
     });
   });
 
@@ -240,12 +240,12 @@ describe('Database', () => {
       '@id': task.id,
       '@type': undefined,
       '@model': 'dxos.org/model/document',
+      '@meta': { keys: [] },
       title: 'Main task',
       tags: ['red', 'green'],
       assignee: {
         '@id': task.assignee.id,
       },
-      meta: { keys: [] },
     });
   });
 
@@ -253,19 +253,19 @@ describe('Database', () => {
     const { db } = await createDatabase();
 
     const obj = new TypedObject();
-    expect(Array.from(obj.meta.keys)).toEqual([]);
-    obj.meta.keys = [{ id: 'test-key', source: 'test' }];
-    expect(Array.from(obj.meta.keys)).toEqual([{ id: 'test-key', source: 'test' }]);
+    expect(Array.from(obj.__meta.keys)).toEqual([]);
+    obj.__meta.keys = [{ id: 'test-key', source: 'test' }];
+    expect(Array.from(obj.__meta.keys)).toEqual([{ id: 'test-key', source: 'test' }]);
 
     db.add(obj);
     await db.flush();
 
-    expect(Array.from(obj.meta.keys)).toEqual([{ id: 'test-key', source: 'test' }]);
+    expect(Array.from(obj.__meta.keys)).toEqual([{ id: 'test-key', source: 'test' }]);
     expect(obj[data]).toEqual({
       '@id': obj.id,
       '@type': undefined,
       '@model': 'dxos.org/model/document',
-      meta: {
+      '@meta': {
         keys: [{ id: 'test-key', source: 'test' }],
       },
     });

--- a/packages/core/echo/echo-schema/src/serializer.test.ts
+++ b/packages/core/echo/echo-schema/src/serializer.test.ts
@@ -31,8 +31,8 @@ describe('Serializer', () => {
       expect(data.objects[0]).to.deep.eq({
         '@id': obj.id,
         '@model': 'dxos.org/model/document',
+        '@meta': { keys: [] },
         title: 'Test',
-        meta: { keys: [] },
       });
     }
 

--- a/packages/core/echo/echo-schema/src/typed-object.test.ts
+++ b/packages/core/echo/echo-schema/src/typed-object.test.ts
@@ -4,6 +4,7 @@
 
 import { expect } from 'chai';
 
+import { PublicKey } from '@dxos/keys';
 import { describe, test } from '@dxos/test';
 
 import { Expando, TypedObject } from './typed-object';
@@ -15,22 +16,37 @@ describe('TypedObject', () => {
   });
 
   test('instance of Expando', async () => {
-    const obj = new Expando();
-    expect(obj instanceof Expando).to.be.true;
+    const obj1 = new Expando();
+    expect(obj1 instanceof Expando).to.be.true;
+
+    const obj2 = new Expando({ title: 'hello world' });
+    expect(obj2.title).to.equal('hello world');
+
+    const obj3 = new Expando(
+      { title: 'hello world' },
+      {
+        meta: {
+          keys: [
+            {
+              source: 'dxos.org',
+              id: PublicKey.random().toHex(),
+            },
+          ],
+        },
+      },
+    );
+
+    console.log(obj3.__meta);
+    console.log(JSON.stringify(obj3, null, 2));
+    expect(obj3.__meta.keys[0].source).to.equal('dxos.org');
   });
 
   describe('meta', () => {
     test('meta keys', () => {
       const obj = new TypedObject();
-      expect(Object.keys(obj.meta)).to.deep.equal(['keys']);
-      obj.meta.index = '5';
-      expect(Object.keys(obj.meta)).to.deep.equal(['keys', 'index']);
-    });
-
-    test('can assign meta', async () => {
-      const obj = new TypedObject();
-      obj.meta = { keys: [{ id: 'foo' }] };
-      expect(obj.meta.keys).to.have.length(1);
+      expect(Object.keys(obj.__meta)).to.deep.equal(['keys']);
+      obj.__meta.index = '5';
+      expect(Object.keys(obj.__meta)).to.deep.equal(['keys', 'index']);
     });
   });
 });

--- a/packages/core/echo/echo-schema/src/typed-object.ts
+++ b/packages/core/echo/echo-schema/src/typed-object.ts
@@ -155,9 +155,7 @@ class TypedObjectImpl<T> extends EchoObject<DocumentModel> {
     return this[base]._createProxy({}, undefined, true);
   }
 
-  /**
-   * Returns boolean. If `true`, read only access is activated.
-   */
+  // TODO(burdon): Standardize properties/getters/__fields, etc.
   get [readOnly](): boolean {
     return !!this[base]?._readOnly;
   }

--- a/packages/core/echo/echo-schema/src/typed-object.ts
+++ b/packages/core/echo/echo-schema/src/typed-object.ts
@@ -5,7 +5,7 @@
 import get from 'lodash.get';
 import { inspect, InspectOptionsStylized } from 'node:util';
 
-import { DocumentModel, MutationBuilder, OrderedArray, Reference } from '@dxos/document-model';
+import { DocumentModel, OrderedArray, Reference } from '@dxos/document-model';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
 import { TextModel } from '@dxos/text-model';
@@ -27,9 +27,9 @@ const isValidKey = (key: string | symbol) =>
     key === 'toJSON' ||
     key === 'id' ||
     key === '__deleted' ||
-    key === '__typename' ||
-    key === 'meta' ||
-    key === 'setMeta'
+    key === '__meta' ||
+    key === '__schema' ||
+    key === '__typename'
   );
 
 export const isTypedObject = (object: unknown): object is TypedObject =>
@@ -49,6 +49,30 @@ export const DEFAULT_VISITORS: ConvertVisitors = {
  */
 type NoInfer<T> = [T][T extends any ? 0 : never];
 
+//
+// TypedObject
+// Generic base class for strongly-typed schema-generated classes.
+//
+
+// TODO(dmaretskyi): Document.
+export type ForeignKey = {
+  source?: string;
+  id?: string;
+};
+
+// TODO(dmaretskyi): Document.
+export type ObjectMeta = {
+  keys: ForeignKey[];
+  index?: string;
+  schema?: Expando;
+};
+
+export type TypedObjectOpts = {
+  schema?: EchoSchemaType;
+  meta?: ObjectMeta;
+  readOnly?: boolean;
+};
+
 /**
  * Base class for generated document types and dynamic objects.
  *
@@ -62,26 +86,25 @@ class TypedObjectImpl<T> extends EchoObject<DocumentModel> {
    */
   _linkCache: Map<string, EchoObject> | undefined = new Map<string, EchoObject>();
 
-  // TODO(burdon): Remove undefined keys.
-  constructor(
-    initialProps?: T,
-    private readonly _schemaType?: EchoSchemaType,
-    private readonly _opts?: TypedObjectOpts,
-  ) {
+  private _schema?: EchoSchemaType = undefined;
+
+  private _readOnly = false;
+
+  constructor(initialProps?: T, opts?: TypedObjectOpts) {
     super(DocumentModel);
 
-    // TODO(burdon): Strip keys.
-    // stripKeys(initialProps);
+    this._schema = opts?.schema;
+    this._readOnly = opts?.readOnly ?? false;
 
     // Assign initial meta fields.
-    this._mutate(new MutationBuilder().set('keys', OrderedArray.fromValues([])).build(true));
+    this._updateMeta({ keys: [], ...opts?.meta });
 
     // Assign initial values, those will be overridden by the initialProps and later by the ECHO state when the object is bound to the database.
-    if (this._schemaType) {
+    if (this.__schema) {
       // Set type.
-      this._mutate({ type: this._schemaType.name });
+      this._mutate({ type: this.__schema.name });
 
-      for (const field of this._schemaType.fields) {
+      for (const field of this.__schema.fields) {
         if (field.type.kind === 'array') {
           this._set(field.name, new EchoArray());
         } else if (field.type.kind === 'ref' && field.type.modelType === TextModel.meta.type) {
@@ -93,7 +116,9 @@ class TypedObjectImpl<T> extends EchoObject<DocumentModel> {
     if (initialProps) {
       for (const field in initialProps) {
         const value = initialProps[field];
-        this._set(field, value);
+        if (value !== undefined) {
+          this._set(field, value);
+        }
       }
     }
 
@@ -101,7 +126,21 @@ class TypedObjectImpl<T> extends EchoObject<DocumentModel> {
   }
 
   get [Symbol.toStringTag]() {
-    return this[base]?._schemaType?.name ?? 'TypedObject';
+    return this[base]?._schema?.name ?? 'TypedObject';
+  }
+
+  // TODO(burdon): Reconcile with meta schema.
+  get __schema(): EchoSchemaType | undefined {
+    return this[base]._schema;
+  }
+
+  /**
+   * Returns the schema type descriptor for the object.
+   * @deprecated
+   */
+  // TODO(burdon): Method on TypedObject vs EchoObject?
+  get [schema](): EchoSchemaType | undefined {
+    return this[base]._schema;
   }
 
   /**
@@ -109,30 +148,18 @@ class TypedObjectImpl<T> extends EchoObject<DocumentModel> {
    * @example "example.kai.Task"
    */
   get __typename(): string | undefined {
-    return this[base]?._schemaType?.name ?? this[base]._model?.type ?? undefined;
+    return this[base]._schema?.name ?? this[base]._model?.type ?? undefined;
   }
 
-  get meta(): ObjectMeta {
+  get __meta(): ObjectMeta {
     return this[base]._createProxy({}, undefined, true);
-  }
-
-  set meta(value: Partial<ObjectMeta>) {
-    this.setMeta(value);
-  }
-
-  /**
-   * Returns the schema type descriptor for the object.
-   */
-  // TODO(burdon): Method on TypedObject vs EchoObject?
-  get [schema](): EchoSchemaType | undefined {
-    return this[base]?._schemaType;
   }
 
   /**
    * Returns boolean. If `true`, read only access is activated.
    */
   get [readOnly](): boolean {
-    return !!this[base]?._opts?.readOnly;
+    return !!this[base]?._readOnly;
   }
 
   /** Deletion. */
@@ -162,12 +189,13 @@ class TypedObjectImpl<T> extends EchoObject<DocumentModel> {
    * space.db.add(new Expando().setMeta({ keys: [{ source: 'example.com' }] }));
    * ```
    */
-  setMeta(meta: Partial<ObjectMeta>): this {
+  private _updateMeta(meta: Partial<ObjectMeta>): this {
     this[base]._inBatch(() => {
       for (const key in meta) {
-        this.meta[key as keyof ObjectMeta] = meta[key as keyof ObjectMeta] as any;
+        this.__meta[key as keyof ObjectMeta] = meta[key as keyof ObjectMeta] as any;
       }
     });
+
     return this;
   }
 
@@ -211,9 +239,11 @@ class TypedObjectImpl<T> extends EchoObject<DocumentModel> {
     return {
       '@id': this.id,
       '@type': this.__typename,
+      // '@schema': this.__schema,
       '@model': DocumentModel.meta.type,
+      '@meta': this._transform(this._getState().meta, visitors),
+      ...(this.__deleted ? { '@deleted': this.__deleted } : {}),
       ...this._transform(this._model?.toObject(), visitors),
-      meta: this._transform(this._getState().meta, visitors),
     };
   }
 
@@ -252,8 +282,8 @@ class TypedObjectImpl<T> extends EchoObject<DocumentModel> {
     let type;
     const value = meta ? this._model.getMeta(key) : this._model.get(key);
 
-    if (!type && this._schemaType) {
-      const field = this._schemaType.fields.find((field) => field.name === key);
+    if (!type && this.__schema) {
+      const field = this.__schema.fields.find((field) => field.name === key);
       if (field?.type.kind === 'array') {
         type = 'array';
       }
@@ -371,8 +401,8 @@ class TypedObjectImpl<T> extends EchoObject<DocumentModel> {
      */
     return new Proxy(object, {
       ownKeys: (target) => {
-        if (this._schemaType && !parent && !meta) {
-          return target._schemaType?.fields.map(({ name }: EchoSchemaField) => name) ?? [];
+        if (this.__schema && !parent && !meta) {
+          return this.__schema.fields.map(({ name }: EchoSchemaField) => name) ?? [];
         } else {
           return this._properties(parent, meta);
         }
@@ -391,8 +421,8 @@ class TypedObjectImpl<T> extends EchoObject<DocumentModel> {
           return false;
         }
 
-        if (this._schemaType && !parent && !meta) {
-          return !!this._schemaType?.fields.find(({ name }: EchoSchemaField) => name === property);
+        if (this.__schema && !parent && !meta) {
+          return !!this.__schema?.fields.find(({ name }: EchoSchemaField) => name === property);
         } else {
           return this._properties(parent, meta).includes(property);
         }
@@ -437,7 +467,7 @@ class TypedObjectImpl<T> extends EchoObject<DocumentModel> {
       },
 
       set: (target, property, value, receiver) => {
-        if (this._opts?.readOnly) {
+        if (this[base]._readOnly && !parent && !meta) {
           log.warn('Read only access');
           return false;
         }
@@ -493,59 +523,28 @@ class TypedObjectImpl<T> extends EchoObject<DocumentModel> {
 // Set stringified name for constructor.
 Object.defineProperty(TypedObjectImpl, 'name', { value: 'TypedObject' });
 
-//
-// TypedObject
-// Generic base class for strongly-typed schema-generated classes.
-//
-
-export type ForeignKey = {
-  source?: string;
-  id?: string;
-};
-
-// TODO(dmaretskyi): Document.
-export type ObjectMeta = {
-  keys: ForeignKey[];
-  index?: string;
-  schema?: Expando;
-};
-
 /**
  * Base class for generated document types and expando objects.
  */
 export type TypedObject<T extends Record<string, any> = Record<string, any>> = TypedObjectImpl<T> & T;
 
-export type TypedObjectOpts = {
-  readOnly?: boolean;
-};
-
+/**
+ * Strongly typed object.
+ */
 type TypedObjectConstructor = {
-  /**
-   * Create a new document.
-   * @param initialProps Initial properties.
-   * @param _schemaType Schema type for generated types.
-   * @param opts
-   */
   new <T extends Record<string, any> = Record<string, any>>(
     initialProps?: NoInfer<Partial<T>>,
-    _schemaType?: EchoSchemaType,
     opts?: TypedObjectOpts,
   ): TypedObject<T>;
 };
 
 export const TypedObject: TypedObjectConstructor = TypedObjectImpl as any;
 
-//
-// Expando
-// Schema-less expandable object.
-//
-
+/**
+ *
+ */
 type ExpandoConstructor = {
-  /**
-   * Create a new document.
-   * @param initialProps Initial properties.
-   */
-  new (initialProps?: Record<string, any>): Expando;
+  new (initialProps?: Record<string, any>, options?: TypedObjectOpts): Expando;
 };
 
 export const Expando: ExpandoConstructor = TypedObject;

--- a/packages/core/echo/echo-typegen/src/codegen.ts
+++ b/packages/core/echo/echo-typegen/src/codegen.ts
@@ -189,9 +189,9 @@ export const createObjectClass = (type: pb.Type) => {
       static filter(opts?: Partial<${name}Props>): ${importNamespace}.TypeFilter<${name}> {
       return ${name}.type.createFilter(opts);
       }
-
+  
       constructor(initValues?: Partial<${name}Props>, opts?: ${importNamespace}.TypedObjectOpts) {
-        super({ ...initValues}, ${name}.type, opts);
+        super({ ...initValues}, { schema: ${name}.type, ...opts });
       }
       ${fields}
     }

--- a/packages/core/echo/echo-typegen/test/database.test.ts
+++ b/packages/core/echo/echo-typegen/test/database.test.ts
@@ -109,11 +109,11 @@ describe('database', () => {
 
     task.title = 'test';
     expect(task.title).to.eq('test');
-    expect(task.meta.keys).to.exist;
-    expect(task.meta.keys).to.have.length(0);
+    expect(task.__meta.keys).to.exist;
+    expect(task.__meta.keys).to.have.length(0);
 
-    task.meta.keys.push({ source: 'example', id: 'test' });
-    expect(task.meta.keys).to.have.length(1);
+    task.__meta.keys.push({ source: 'example', id: 'test' });
+    expect(task.__meta.keys).to.have.length(1);
   });
 
   test('text objects are auto-created on schema', async () => {

--- a/packages/core/echo/echo-typegen/test/schema.test.ts
+++ b/packages/core/echo/echo-typegen/test/schema.test.ts
@@ -39,17 +39,21 @@ describe('schema', () => {
     task1.assignee = contact;
     expect(task1.assignee.name).to.eq('User 1');
     expect(task1.toJSON()).to.deep.contain({ title: 'Task 1', assignee: { '@id': contact.id } });
-    expect(JSON.stringify(task1)).to.equal(
-      JSON.stringify({
-        '@id': task1.id,
-        '@type': task1.__typename,
-        '@model': 'dxos.org/model/document',
-        subTasks: [],
-        description: { '@id': task1.description.id },
-        title: 'Task 1',
-        assignee: { '@id': contact.id },
-        meta: { keys: [] },
-      }),
+    expect(JSON.stringify(task1, null, 4)).to.equal(
+      JSON.stringify(
+        {
+          '@id': task1.id,
+          '@type': task1.__typename,
+          '@model': 'dxos.org/model/document',
+          '@meta': { keys: [] },
+          subTasks: [],
+          description: { '@id': task1.description.id },
+          title: 'Task 1',
+          assignee: { '@id': contact.id },
+        },
+        null,
+        4,
+      ),
     );
   });
 
@@ -62,6 +66,7 @@ describe('schema', () => {
       '@id': contact.id,
       '@type': contact.__typename,
       '@model': 'dxos.org/model/document',
+      '@meta': { keys: [] },
       name: 'User 1',
       tasks: [
         {
@@ -71,7 +76,6 @@ describe('schema', () => {
           '@id': contact.tasks[1].id,
         },
       ],
-      meta: { keys: [] },
     });
   });
 

--- a/packages/experimental/kai-functions/src/functions/chatgpt/handler.ts
+++ b/packages/experimental/kai-functions/src/functions/chatgpt/handler.ts
@@ -48,7 +48,7 @@ export default async (event: HandlerProps, context: FunctionContext) => {
       const block = thread.blocks[thread.blocks.length - 1];
 
       // TODO(burdon): Use to distinguish generated messages.
-      if (!block.meta) {
+      if (!block.__meta) {
         const model = new ChatModel({
           // TODO(burdon): Normalize env.
           orgId: process.env.COM_OPENAI_ORG_ID ?? getKey(config, 'openai.com/org_id')!,
@@ -59,7 +59,7 @@ export default async (event: HandlerProps, context: FunctionContext) => {
           thread: thread?.id.slice(0, 8),
           block: block.id.slice(0, 8),
           messages: block.messages.length,
-          meta: block.meta, // TODO(burdon): Use to distinguish generated messages.
+          meta: block.__meta, // TODO(burdon): Use to distinguish generated messages.
         });
 
         // TODO(burdon): Pass in history.
@@ -85,12 +85,17 @@ export default async (event: HandlerProps, context: FunctionContext) => {
           }
 
           const response = space.db.add(
-            new Thread.Block({
-              identityKey,
-              messages,
-            }).setMeta({
-              keys: [{ source: 'openai.com' }],
-            }),
+            new Thread.Block(
+              {
+                identityKey,
+                messages,
+              },
+              {
+                meta: {
+                  keys: [{ source: 'openai.com' }],
+                },
+              },
+            ),
           );
 
           thread.blocks.push(response);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3154fb2</samp>

### Summary
🔧📝🔐

<!--
1.  🔧 - This emoji represents the refactoring and fixing of the code, which is a common theme in these changes. It also implies some improvement or enhancement of the existing functionality.
2.  📝 - This emoji represents the renaming and simplification of the code, which is another common theme in these changes. It also implies some clarity or documentation of the code.
3.  🔐 - This emoji represents the use of the `TypedObject` class and its internal `__meta` property for storing and passing the schema type information of the typed objects, which is a key feature in these changes. It also implies some security or encryption of the data.
-->
The pull request refactors the `TypedObject` class and its subclasses to use a consistent and simplified interface for creating and manipulating typed objects with schemas and meta fields. It also renames some properties and fixes some bugs in the code and tests that use the `TypedObject` class. The affected files include `schema.ts` snippets in the docs, the `plugin-debug` and `plugin-markdown` packages, the `echo-schema`, `echo-typegen`, and `kai-functions` packages, and the `serializer.test.ts` file.

> _We are the `TypedObject`s, we have the power of schemas_
> _We use the `__meta` field to store our secrets and keys_
> _We refactor and simplify, we fix the bugs and errors_
> _We are the `TypedObject`s, we are the masters of the code_

### Walkthrough
*  Refactor the way of passing schema type information to the `TypedObject` base class using a single `opts` parameter with a `schema` property ([link](https://github.com/dxos/dxos/pull/4287/files?diff=unified&w=0#diff-b9b9ca0d1db5b722f779b39557a7788e55054c621cb0fe5a2e6d579be6af390eL22-R23), [link](https://github.com/dxos/dxos/pull/4287/files?diff=unified&w=0#diff-da78c3cd254a2c97bb910dd1daca19edb9be7e5d5d609fedf0468d8692f183ebL22-R23), [link](https://github.com/dxos/dxos/pull/4287/files?diff=unified&w=0#diff-fb4678018340b303901f83cebbdcb241f8b6b85798bdff391c01dda993aae24eL65-R107), [link](https://github.com/dxos/dxos/pull/4287/files?diff=unified&w=0#diff-fb4678018340b303901f83cebbdcb241f8b6b85798bdff391c01dda993aae24eL518-R536), [link](https://github.com/dxos/dxos/pull/4287/files?diff=unified&w=0#diff-fb4678018340b303901f83cebbdcb241f8b6b85798bdff391c01dda993aae24eL538-R547), [link](https://github.com/dxos/dxos/pull/4287/files?diff=unified&w=0#diff-7e79d5937010f09f3619776bd506b065a31aa0f03d3dc498d103cf1bc1a2bd6bL192-R194), [link](https://github.com/dxos/dxos/pull/4287/files?diff=unified&w=0#diff-03df0599a16900681fb98f0f9bf2e2a55df29d940b8edf133101ec5a35d58cceL42-R56), [link](https://github.com/dxos/dxos/pull/4287/files?diff=unified&w=0#diff-81f957adb0f79cf5d3660100adec34b4b31e90f342e85c85a5d0570cb5d81871L88-R98)).


