### PR TITLE
fix(halo-app): vault styles

### DIFF
--- a/packages/apps/halo-app/vault.html
+++ b/packages/apps/halo-app/vault.html
@@ -11,6 +11,14 @@
       }
     </style>
     <script>
+      function setTheme(darkMode) {
+        document.documentElement.classList[darkMode ? 'add' : 'remove']('dark')
+      }
+      setTheme(window.matchMedia('(prefers-color-scheme: dark)').matches)
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
+        setTheme(e.matches)
+      });
+
       const handler = (event) => {
         if (event.source !== window.parent) {
           return;

--- a/packages/apps/halo-app/vite.config.ts
+++ b/packages/apps/halo-app/vite.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
       content: [
         resolve(__dirname, './*.html'),
         resolve(__dirname, './src/**/*.{js,ts,jsx,tsx}'),
+        resolve(__dirname, './node_modules/@dxos/vault/dist/lib/**/*.mjs'),
         resolve(__dirname, './node_modules/@braneframe/plugin-*/dist/lib/**/*.mjs'),
       ],
     }),


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f7050d6</samp>

### Summary
🌗🛠️🔒

<!--
1.  🌗 - This emoji represents the theme switching feature, as it shows both the dark and light sides of the moon.
2.  🛠️ - This emoji represents the vite config fix, as it shows a tool that can be used to adjust or repair something.
3.  🔒 - This emoji represents the vault library, as it shows a lock that can be used to secure or encrypt something.
-->
This pull request adds dark mode support and fixes module resolution for the `halo-app` vault page. It modifies `vault.html` to apply the user's preferred theme and `vite.config.ts` to import the `@dxos/vault` library correctly.

> _`vault.html` theme_
> _changes with user's preference_
> _a kireji: but_

### Walkthrough
*  Add theme function and listener to vault.html page to support dark and light mode preferences ([link](https://github.com/dxos/dxos/pull/4288/files?diff=unified&w=0#diff-22215fde389d390af11625098493a3bfc9ea93a61a0463e704e7a6f4d752bfb3R14-R21))
*  Resolve mjs modules from @dxos/vault package in vite config file to avoid import errors in halo-app ([link](https://github.com/dxos/dxos/pull/4288/files?diff=unified&w=0#diff-a745999da1e2bed73f69f9a92baaad22d02ded554612912cb17f5727cfdb516eR59))


