### PR TITLE
feat: add identity to swarm panel in devtools

### DIFF
--- a/packages/core/protocols/src/proto/dxos/devtools/swarm.proto
+++ b/packages/core/protocols/src/proto/dxos/devtools/swarm.proto
@@ -37,6 +37,7 @@ message ConnectionInfo {
   repeated ConnectionEvent events = 6;
   repeated StreamStats streams = 7;
   optional string close_reason = 8;
+  optional string identity = 9;
 }
 
 message ConnectionEvent {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d7134cc</samp>

### Summary
🐝🆔📶

<!--
1.  🐝 - This emoji represents the SwarmPanel component and the mesh network of peers that it displays. Bees are known for their social behavior and communication, which are also essential aspects of a distributed system.
2.  🆔 - This emoji represents the identity and profile of the remote peers, which are now shown in the SwarmPanel component. The ID emoji conveys the idea of a unique identifier and a personal information card.
3.  📶 - This emoji represents the connection state of the remote peers, which is now indicated more clearly by a colored dot and a label. The signal bars emoji suggests the strength and quality of a network connection.
-->
This pull request improves the user interface and functionality of the `SwarmPanel` component, which displays the mesh network status. It adds identity and profile information for the remote peers, and enhances the connection state indicators.

> _We are the SwarmPanel, we see through the mesh_
> _We know your `identity` and your `profile`, we judge your flesh_
> _We are the SwarmPanel, we show the connection state_
> _We are the SwarmPanel, we are your doom and fate_

### Walkthrough
* Import additional modules to observe space members and identities ([link](https://github.com/dxos/dxos/pull/4289/files?diff=unified&w=0#diff-5a74c5baeecf322e5dbbb8f57b9b1078b282693c7d357483cfef2867f2cb0fc0L9-R15)).


