### PR TITLE
fix(aurora-theme): Fix Labs theme override, remove redundant style

### DIFF
--- a/packages/apps/labs-app/src/main.tsx
+++ b/packages/apps/labs-app/src/main.tsx
@@ -35,6 +35,7 @@ import {
   auroraTheme,
   bindTheme,
   focusRing,
+  groupBorder,
   groupSurface,
   mx,
   popperMotion,
@@ -63,12 +64,14 @@ const main = async () => {
   const labsTx = bindTheme({
     ...auroraTheme,
     popover: {
+      ...auroraTheme.popover,
       content: (_props, ...etc) =>
         mx(
           'z-[30] rounded-xl',
           popperMotion,
           // 'bg-orange-200',
           groupSurface,
+          groupBorder,
           surfaceElevation({ elevation: 'group' }),
           focusRing,
           ...etc,

--- a/packages/ui/aurora-theme/src/styles/fragments/surface.ts
+++ b/packages/ui/aurora-theme/src/styles/fragments/surface.ts
@@ -15,7 +15,7 @@ export const baseSurface = 'bg-neutral-12 dark:bg-neutral-900';
 export const fixedSurface = 'bg-neutral-50/95 dark:bg-neutral-900/95 backdrop-blur';
 
 // Cards, dialogs, other such groups.
-export const groupSurface = 'bg-neutral-50 dark:bg-neutral-850 border';
+export const groupSurface = 'bg-neutral-50 dark:bg-neutral-850';
 
 // Tooltips, popovers, menus, etc. – not dialogs.
 export const chromeSurface = 'bg-neutral-12 dark:bg-neutral-800';


### PR DESCRIPTION
This PR fixes Labs’ theme override which was mangling PopoverContent.
This PR also removes `'border'` from `groupSurface` since this is available as `groupBorder` and is already applied to DialogContent and PopoverContent.

<img width="1419" alt="Screenshot 2023-09-20 at 13 22 33" src="https://github.com/dxos/dxos/assets/855039/b2e70764-762f-4165-9323-0e8d67befa39">

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5ad7419</samp>

### Summary
🎨🗑️🔗

<!--
1.  🎨 - This emoji is often used to indicate changes related to styling, design, or appearance of UI elements or themes.
2.  🗑️ - This emoji is often used to indicate changes that involve removing, deleting, or cleaning up something, such as unused code, styles, or files.
3.  🔗 - This emoji is often used to indicate changes that involve linking, referencing, or importing something from another source, such as a library, a module, or a theme.
-->
Updated the labs app theme to use some aurora style fragments and removed the border from the groupSurface fragment. This improves the UI consistency and appearance of the labs app.

> _Sing, O Muse, of the skillful coder who refined the labs app's theme_
> _And made it match the aurora's radiant style, pleasing to the eye_
> _He stripped the `groupSurface` of its border, lest it clash with `groupBorder`_
> _And borrowed `popover` and other fragments from the aurora's splendid array_

### Walkthrough
* Imported `groupBorder` style fragment from `@dxos/ui/aurora-theme` to use in custom theme for labs app ([link](https://github.com/dxos/dxos/pull/4296/files?diff=unified&w=0#diff-9d663519e7a46a19fe4305c8085aa017f51355119fb0fbe545eb37ab8492722cR38)).


