### PR TITLE
fix(aurora-table): Popover content & borders

### DIFF
--- a/packages/ui/aurora-table/src/ColumnMenu.tsx
+++ b/packages/ui/aurora-table/src/ColumnMenu.tsx
@@ -6,7 +6,7 @@ import { Check, CaretDown, Trash, X } from '@phosphor-icons/react';
 import { HeaderContext, RowData } from '@tanstack/react-table';
 import React, { FC, PropsWithChildren, useRef, useState } from 'react';
 
-import { Button, DensityProvider, Input, Popover, Select, useId } from '@dxos/aurora';
+import { Button, DensityProvider, Input, Popover, Select, Separator, useId } from '@dxos/aurora';
 import { getSize, mx } from '@dxos/aurora-theme';
 import { safeParseInt } from '@dxos/util';
 
@@ -45,8 +45,13 @@ export const ColumnMenu = <TData extends RowData, TValue>({ column, ...props }: 
   );
 };
 
+const Section: FC<PropsWithChildren & { className?: string }> = ({ children, className }) => (
+  <div role='none' className={mx('p-2', className)}>
+    {children}
+  </div>
+);
+
 export const ColumnPanel = <TData extends RowData, TValue>({
-  context,
   schemas,
   schema,
   column,
@@ -69,8 +74,6 @@ export const ColumnPanel = <TData extends RowData, TValue>({
   };
 
   const handleSave = () => {
-    console.log('!!!!!!!!!!!');
-
     // Check valid and unique.
     if (!prop.length || !prop.match(/^[a-zA-Z_].+/i) || schema.props.find((c) => c.id !== column.id && c.id === prop)) {
       propRef.current?.focus();
@@ -90,12 +93,6 @@ export const ColumnPanel = <TData extends RowData, TValue>({
     setOpen(false);
   };
 
-  const Section: FC<PropsWithChildren & { className?: string }> = ({ children, className }) => (
-    <div role='none' className={mx('p-2', className)}>
-      {children}
-    </div>
-  );
-
   return (
     <Popover.Root open={open} onOpenChange={(nextOpen) => setOpen(nextOpen)}>
       <Popover.Trigger asChild>
@@ -107,7 +104,7 @@ export const ColumnPanel = <TData extends RowData, TValue>({
         <Popover.Content>
           <Popover.Viewport classNames='w-60'>
             <DensityProvider density='fine'>
-              <div className='flex flex-col space-y-1 divide-y'>
+              <div className='flex flex-col gap-1'>
                 <Section>
                   <Input.Root>
                     <Input.Label classNames='mbe-1'>Label</Input.Label>
@@ -207,6 +204,8 @@ export const ColumnPanel = <TData extends RowData, TValue>({
                     </Section>
                   </>
                 )}
+
+                <Separator classNames='mli-2' />
 
                 <Section className='space-b-1.5'>
                   {/* TODO(burdon): Style as DropdownMenuItem. */}

--- a/packages/ui/aurora-table/src/Table.tsx
+++ b/packages/ui/aurora-table/src/Table.tsx
@@ -20,7 +20,7 @@ import {
 import React, { Fragment, useEffect, useRef, useState } from 'react';
 
 import { debounce } from '@dxos/async';
-import { inputSurface, mx } from '@dxos/aurora-theme';
+import { groupBorder, inputSurface, mx } from '@dxos/aurora-theme';
 
 import { defaultTableSlots, TableSlots } from './theme';
 import { TableColumnDef, KeyValue } from './types';
@@ -376,7 +376,7 @@ const TableHead = <TData extends RowData>({
                   //  https://stackoverflow.com/questions/50361698/border-style-do-not-work-with-sticky-position-element
                   className={mx(
                     'relative text-left',
-                    border && 'border',
+                    border && groupBorder,
                     slots?.header?.className,
                     header.column.columnDef.meta?.slots?.header?.className,
                   )}
@@ -491,7 +491,7 @@ const TableBody = <TData extends RowData>({
                 <td
                   key={cell.id}
                   className={mx(
-                    border && 'border',
+                    border && groupBorder,
                     slots?.cell?.className,
                     cell.column.columnDef.meta?.slots?.cell?.className,
                   )}
@@ -532,7 +532,7 @@ const TableFoot = <TData extends RowData>({ footers, expand, slots, debug, borde
               <th
                 key={footer.id}
                 className={mx(
-                  border && 'border',
+                  border && groupBorder,
                   'text-left',
                   slots?.footer?.className,
                   footer.column.columnDef.meta?.slots?.footer?.className,


### PR DESCRIPTION
This PR fixes `aurora-table`’s popover content and borders.

https://github.com/dxos/dxos/assets/855039/687ca9f9-92c3-4873-a103-3db257c5daad

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0777d98</samp>

### Summary
🎨🔥📦

<!--
1.  🎨 - This emoji is often used for changes related to UI design, styling, or layout. The refactoring of the column menu component and the use of the `groupBorder` utility fall under this category.
2.  🔥 - This emoji is often used for changes that remove or delete code, such as unused code or debugging statements. The removal of these parts of the column menu component could be represented by this emoji.
3.  📦 - This emoji is often used for changes that involve adding or updating dependencies, such as packages or modules. The import of the `groupBorder` utility from the `@dxos/aurora-theme` package could be represented by this emoji.
-->
The pull request improves the appearance and code quality of the `aurora-table` package by using components and utilities from the `@dxos/aurora` and `@dxos/aurora-theme` packages. It refactors the `ColumnMenu` component and applies consistent border styling to the `Table` component.

> _`ColumnMenu` shines_
> _Using `Separator`, `Section`_
> _Clean and consistent_

### Walkthrough
* Import `Separator` component from `@dxos/aurora` and use it to create a visual separation between column name and column type sections in the column menu ([link](https://github.com/dxos/dxos/pull/4299/files?diff=unified&w=0#diff-04bf72b224114a23bdceaa1860e0aae8f431201f8ed5d1fd20a09132a21a22efL9-R9), [link](https://github.com/dxos/dxos/pull/4299/files?diff=unified&w=0#diff-04bf72b224114a23bdceaa1860e0aae8f431201f8ed5d1fd20a09132a21a22efR208-R209)).


