### PR TITLE
fix: protobuf sync with kube repo

### DIFF
--- a/packages/core/protocols/src/proto/dxos/error.proto
+++ b/packages/core/protocols/src/proto/dxos/error.proto
@@ -4,6 +4,8 @@
 
 syntax = "proto3";
 
+import "google/protobuf/struct.proto";
+
 package dxos.error;
 
 option go_package = "github.com/dxos/kube/proto/def/dxos/error";


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9503baa</samp>

### Summary
📄🧰🚨

<!--
1.  📄 This emoji represents the import of a new file or document, in this case the `struct.proto` file.
2.  🧰 This emoji represents the addition of a new tool or resource, in this case the `Struct` message type, which can be used to store dynamic values.
3.  🚨 This emoji represents the definition of a new error or exception, in this case the `Error` message, which can be used to communicate failures or problems.
-->
Added `Struct` type to `Error` message in `error.proto` to support dynamic error details. Imported `struct.proto` from Google Protobuf library.

> _`Struct` holds details_
> _Dynamic values in errors_
> _Imported in fall_

### Walkthrough
* Import the `Struct` message type from `google/protobuf/struct.proto` to store dynamic error details in the `Error` message ([link](https://github.com/dxos/dxos/pull/4306/files?diff=unified&w=0#diff-3321b270f8c3019bdef4d78e40fa65174da3612bdaffef457ff1956659ced97fR7-R8))


