### PR TITLE
feat: show identity/device key in devtools footer

### DIFF
--- a/packages/devtools/devtools/src/containers/RootContainer.tsx
+++ b/packages/devtools/devtools/src/containers/RootContainer.tsx
@@ -6,6 +6,7 @@ import React, { Suspense } from 'react';
 import { Link, Outlet, useLocation } from 'react-router-dom';
 
 import { getSize, mx } from '@dxos/aurora-theme';
+import { useDevices, useIdentity } from '@dxos/react-client/halo';
 
 import { ErrorBoundary } from '../components';
 import { useSections } from '../hooks';
@@ -13,7 +14,11 @@ import { useSections } from '../hooks';
 const Footer = () => {
   return (
     <div className='flex justify-center p-2'>
-      <span className='text-xs text-gray-500'>Version: {process.env.PACKAGE_VERSION ?? 'DEV'}</span>
+      <span className='text-xs text-gray-500'>
+        <div>Identity: {useIdentity()?.identityKey.truncate()}</div>
+        <div>Device: {useDevices()[0].deviceKey.truncate()}</div>
+        <div>Version: {process.env.PACKAGE_VERSION ?? 'DEV'}</div>
+      </span>
     </div>
   );
 };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 89e012e</samp>

### Summary
👥📱🦶

<!--
1.  👥 - This emoji conveys the idea of identity and self-awareness, which is relevant for showing the user their own keys and verifying their identity.
2.  📱 - This emoji represents a device or a gadget, which is related to the device information that is added to the `Footer` component.
3.  🦶 - This emoji depicts a foot or a footer, which is the part of the UI that is modified by the code.
-->
Add identity and device info to `Footer` component. This enhances the user experience and security of the devtools app.

> _In the shadows of the halo_
> _We reveal our hidden keys_
> _No one can deny our identity_
> _We are the masters of our devices_

### Walkthrough
*  Import and use custom hooks to access identity and device data ([link](https://github.com/dxos/dxos/pull/4307/files?diff=unified&w=0#diff-1b97468f70ecbd45ecc1837bc4de9c729a8859fec1ff72a8f6a434ec5727a9cbR9), [link](https://github.com/dxos/dxos/pull/4307/files?diff=unified&w=0#diff-1b97468f70ecbd45ecc1837bc4de9c729a8859fec1ff72a8f6a434ec5727a9cbL16-R21))


