### PR TITLE
feat: Socket supply demo

### DIFF
--- a/packages/apps/labs-app/.gitignore
+++ b/packages/apps/labs-app/.gitignore
@@ -1,0 +1,2 @@
+*.mobileprovision
+

--- a/packages/apps/labs-app/socket.ini
+++ b/packages/apps/labs-app/socket.ini
@@ -53,13 +53,13 @@ flags = "-g"
 [meta]
 
 ; A unique ID that identifies the bundle (used by all app stores).
-bundle_identifier = "com.beepboop"
+bundle_identifier = "org.dxos.labs"
 
 ; A string that gets used in the about dialog and package meta info.
-copyright = "(c) Beep Boop Corp. 1985"
+copyright = "(c) DXOS"
 
 ; A short description of the app.
-description = "A UI for the beep boop network"
+description = "DXOS Labs"
 
 ; Set the limit of files that can be opened by your process.
 file_limit = 1024
@@ -68,10 +68,10 @@ file_limit = 1024
 lang = "en-us"
 
 ; A String used in the about dialog and meta info.
-maintainer = "Beep Boop Corp."
+maintainer = "DXOS"
 
 ; The title of the app used in metadata files. This is NOT a window title. Can contain spaces and special characters. Defaults to name in a [build] section.
-title = "Beep Boop"
+title = "Labs"
 
 ; A string that indicates the version of the application. It should be a semver triple like 1.2.3. Defaults to 1.0.0.
 version = 1.0.0
@@ -104,16 +104,16 @@ sources = ""
 [ios]
 
 ; signing guide: https://sockets.sh/guides/#ios-1
-codesign_identity = "iPhone Distribution: Rich Burdon (7FLXXJ4X29)"
+codesign_identity = "iPhone Distribution: Dmytro Maretskyi (29M3HGJ965)"
 
 ; Describes how Xcode should export the archive. Available options: app-store, package, ad-hoc, enterprise, development, and developer-id.
 distribution_method = "ad-hoc"
 
 ; A path to the provisioning profile used for signing iOS app.
-provisioning_profile = "adhoc.mobileprovision"
+provisioning_profile = "distribution.mobileprovision"
 
 ; which device to target when building for the simulator
-simulator_device = "iPhone 15"
+simulator_device = "iPad 2021"
 
 
 [linux]

--- a/packages/apps/labs-app/socket.ini
+++ b/packages/apps/labs-app/socket.ini
@@ -1,0 +1,213 @@
+
+;  ___  __   ___      __ ____
+; /__  /  / /   /_/  /_   /
+; __/ /__/ /__ /  \ /__  /
+;
+; Socket ⚡︎ Runtime · A modern runtime for Web Apps · v0.4.0 (6409910e)
+;
+
+; The value of the "script" property in a build section will be interpreted as a shell command when
+; you run "ssc build". This is the most important command in this file. It will
+; do all the heavy lifting and should handle 99.9% of your use cases for moving
+; files into place or tweaking platform-specific build artifacts. If you don't
+; specify it, ssc will just copy everything in your project to the build target.
+
+[build]
+
+; ssc will copy everything in this directory to the build output directory.
+; This is useful when you want to avoid bundling or want to use tools like
+; vite, webpack, rollup, etc. to build your project and then copy output to
+; the Socket bundle resources directory.
+; default value: "src"
+copy = "out/labs"
+
+; An list of environment variables, separated by commas.
+env = USER, TMPDIR, PWD
+
+; Advanced Compiler Settings (ie C++ compiler -02, -03, etc).
+flags = -O3
+
+; If true, the window will never be displayed.
+headless = false
+
+; The name of the program and executable to be output. Can't contain spaces or special characters. Required field.
+name = "socket-test"
+
+; The binary output path. It's recommended to add this path to .gitignore.
+output = "build"
+
+; The build script
+; script = "node build.js"
+
+
+[webview]
+; Make root open index.html
+index = "/"
+
+
+[debug]
+; Advanced Compiler Settings for debug purposes (ie C++ compiler -g, etc).
+flags = "-g"
+
+
+[meta]
+
+; A unique ID that identifies the bundle (used by all app stores).
+bundle_identifier = "com.beepboop"
+
+; A string that gets used in the about dialog and package meta info.
+copyright = "(c) Beep Boop Corp. 1985"
+
+; A short description of the app.
+description = "A UI for the beep boop network"
+
+; Set the limit of files that can be opened by your process.
+file_limit = 1024
+
+; Localization
+lang = "en-us"
+
+; A String used in the about dialog and meta info.
+maintainer = "Beep Boop Corp."
+
+; The title of the app used in metadata files. This is NOT a window title. Can contain spaces and special characters. Defaults to name in a [build] section.
+title = "Beep Boop"
+
+; A string that indicates the version of the application. It should be a semver triple like 1.2.3. Defaults to 1.0.0.
+version = 1.0.0
+
+
+[android]
+
+; Extensions of files that will not be stored compressed in the APK.
+aapt_no_compress = ""
+
+; Enables gradle based ndk build rather than using external native build (standard ndk is the old slow way)
+enable_standard_ndk_build = false
+
+; Name of the MainActivity class. Could be overwritten by custom native code.
+main_activity = ""
+
+; Which permissions does your application need: https://developer.android.com/guide/topics/permissions/overview
+manifest_permissions = ""
+
+; To restrict the set of ABIs that your application supports, set them here.
+native_abis = ""
+
+; Used for adding custom source files and related compiler attributes.
+native_cflags = ""
+native_sources = ""
+native_makefile = ""
+sources = ""
+
+
+[ios]
+
+; signing guide: https://sockets.sh/guides/#ios-1
+codesign_identity = "iPhone Distribution: Rich Burdon (7FLXXJ4X29)"
+
+; Describes how Xcode should export the archive. Available options: app-store, package, ad-hoc, enterprise, development, and developer-id.
+distribution_method = "ad-hoc"
+
+; A path to the provisioning profile used for signing iOS app.
+provisioning_profile = "adhoc.mobileprovision"
+
+; which device to target when building for the simulator
+simulator_device = "iPhone 15"
+
+
+[linux]
+; Helps to make your app searchable in Linux desktop environments.
+categories = "Developer Tools"
+
+; The command to execute to spawn the "back-end" process.
+cmd = "beepboop"
+
+; The icon to use for identifying your app in Linux desktop environments.
+icon = "src/icon.png"
+
+
+[mac]
+
+; Mac App Store icon
+appstore_icon = "src/icons/icon.png"
+
+; A category in the App Store
+category = ""
+
+; The command to execute to spawn the "back-end" process.
+cmd = ""
+
+; The icon to use for identifying your app on MacOS.
+icon = ""
+
+; TODO Signing guide: https://socketsupply.co/guides/#code-signing-certificates
+sign = ""
+
+codesign_identity = ""
+
+sign_paths = ""
+
+
+[native]
+
+; Files that should be added to the compile step.
+files = native-module1.cc native-module2.cc
+
+; Extra Headers
+headers = native-module1.hh
+
+
+[win]
+
+; The command to execute to spawn the “back-end” process.
+cmd = "beepboop.exe"
+
+; The icon to use for identifying your app on Windows.
+icon = ""
+
+; The icon to use for identifying your app on Windows.
+logo = "src/icons/icon.png"
+
+; A relative path to the pfx file used for signing.
+pfx = "certs/cert.pfx"
+
+; The signing information needed by the appx api.
+publisher = "CN=Beep Boop Corp., O=Beep Boop Corp., L=San Francisco, S=California, C=US"
+
+
+[window]
+
+; The initial height of the first window.
+height = 50%
+
+; The initial width of the first window.
+width = 50%
+
+[headless]
+
+; The headless runner command. It is used when no OS specific runner is set.
+runner = ""
+; The headless runner command flags. It is used when no OS specific runner is set.
+runner_flags = ""
+; The headless runner command for Android
+runner_android = ""
+; The headless runner command flags for Android
+runner_android_flags = ""
+; The headless runner command for iOS
+runner_ios = ""
+; The headless runner command flags for iOS
+runner_ios_flags = ""
+; The headless runner command for Linux
+runner_linux = ""
+; The headless runner command flags for Linux
+runner_linux_flags = ""
+; The headless runner command for MacOS
+runner_mac = ""
+; The headless runner command flags for MacOS
+runner_mac_flags = ""
+; The headless runner command for Windows
+runner_win32 = ""
+; The headless runner command flags for Windows
+runner_win32_flags = ""
+


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 10c983f</samp>

### Summary
🔒🛠️🌐

<!--
1.  🔒 - This emoji represents the security aspect of ignoring the `*.mobileprovision` files, as they may contain secrets or certificates that should not be exposed.
2.  🛠️ - This emoji represents the configuration aspect of adding the `socket.ini` file, as it allows the developers to tweak the app's settings and features.
3.  🌐 - This emoji represents the cross-platform aspect of using the Socket runtime, as it enables the app to run on different devices and browsers.
-->
This pull request adds some files and settings to support the development of the labs app using Socket. It also updates the `.gitignore` file to exclude the `*.mobileprovision` files for iOS app signing.

> _`*.mobileprovision`_
> _Ignored by `.gitignore` -_
> _Winter's secret files_

### Walkthrough
* Ignore iOS provisioning files in `labs-app` ([link](https://github.com/dxos/dxos/pull/4311/files?diff=unified&w=0#diff-8eb3af7c262cc920343d8cc891ce80cd2e8156790e3c621d76f631d2b1fddc4cR1-R2))
* Add Socket runtime configuration file for `labs-app` ([link](https://github.com/dxos/dxos/pull/4311/files?diff=unified&w=0#diff-3537f7d859b9986c0be505d7888970161db15d0b061f3caa3d19da2e190ddd8dR1-R213))


