### PR TITLE
feat: Add weak event listeners

### DIFF
--- a/packages/common/async/src/events.ts
+++ b/packages/common/async/src/events.ts
@@ -321,6 +321,7 @@ export class Event<T = void> implements ReadOnlyEvent<T> {
    */
   _removeListener(listener: EventListener<T>) {
     this._listeners.delete(listener);
+    listener.remove();
 
     if (this.listenerCount() === 0) {
       this._cleanupEffects();

--- a/packages/common/async/src/events.ts
+++ b/packages/common/async/src/events.ts
@@ -4,8 +4,6 @@
 
 import { Context } from '@dxos/context';
 
-import { runInContextAsync } from './task-scheduling';
-
 export type UnsubscribeCallback = () => void;
 
 export type Effect = () => UnsubscribeCallback | undefined;
@@ -38,6 +36,11 @@ export class EventSubscriptions {
     this._listeners.length = 0;
   }
 }
+
+export type ListenerOptions = {
+  weak?: boolean;
+  once?: boolean;
+};
 
 /**
  * An EventEmitter variant that does not do event multiplexing and respresents a single event.
@@ -82,8 +85,7 @@ export class Event<T = void> implements ReadOnlyEvent<T> {
     return event;
   }
 
-  private readonly _listeners = new Map<(data: T) => void, (data: T) => void>();
-  private readonly _onceListeners = new Map<(data: T) => void, (data: T) => void>();
+  private readonly _listeners = new Set<EventListener<T>>();
   private readonly _effects = new Set<MaterializedEffect>();
 
   /**
@@ -96,13 +98,19 @@ export class Event<T = void> implements ReadOnlyEvent<T> {
    * @param data param that will be passed to all listeners.
    */
   emit(data: T) {
-    for (const [_key, listener] of this._listeners) {
-      listener(data);
-    }
+    for (const listener of this._listeners) {
+      void (async () => {
+        try {
+          const callback = listener.derefCallback();
+          await callback?.(data);
+        } catch (err: any) {
+          listener.ctx.raise(err);
+        }
+      })();
 
-    for (const [_key, listener] of this._onceListeners) {
-      listener(data);
-      this._onceListeners.delete(_key);
+      if (listener.once) {
+        this._listeners.delete(listener);
+      }
     }
   }
 
@@ -114,38 +122,33 @@ export class Event<T = void> implements ReadOnlyEvent<T> {
    * @returns function that unsubscribes this event listener
    */
   on(callback: (data: T) => void): UnsubscribeCallback;
-  on(ctx: Context, callback: (data: T) => void): UnsubscribeCallback;
-  on(_ctx: any, _callback?: (data: T) => void): UnsubscribeCallback {
+  on(ctx: Context, callback: (data: T) => void, options?: ListenerOptions): UnsubscribeCallback;
+  on(_ctx: any, _callback?: (data: T) => void, options?: ListenerOptions): UnsubscribeCallback {
     const [ctx, callback] = _ctx instanceof Context ? [_ctx, _callback] : [new Context(), _ctx];
+    const weak = !!options?.weak;
+    const once = !!options?.once;
 
-    const runCallback = (data: T) => runInContextAsync(ctx, () => callback(data));
+    const listener = new EventListener(this, callback, ctx, once, weak);
 
-    this._listeners.set(callback, runCallback);
+    this._addListener(listener);
 
-    if (this.listenerCount() === 1) {
-      this._runEffects();
-    }
-
-    const clearDispose = ctx.onDispose(() => this.off(callback));
     return () => {
-      clearDispose();
-      this.off(callback);
+      this._removeListener(listener);
     };
   }
 
   /**
-   * Unsubscribe this callback from new events. Inncludes persistent and once-listeners.
+   * Unsubscribe this callback from new events. Includes persistent and once-listeners.
    * NOTE: It is recommended to use `Event.on`'s return value instead.
    * If the callback is not subscribed this is no-op.
    *
    * @param callback
    */
   off(callback: (data: T) => void) {
-    this._listeners.delete(callback);
-    this._onceListeners.delete(callback);
-
-    if (this.listenerCount() === 0) {
-      this._cleanupEffects();
+    for (const listener of this._listeners) {
+      if (listener.derefCallback() === callback) {
+        this._removeListener(listener);
+      }
     }
   }
 
@@ -160,24 +163,12 @@ export class Event<T = void> implements ReadOnlyEvent<T> {
   once(_ctx: any, _callback?: (data: T) => void): UnsubscribeCallback {
     const [ctx, callback] = _ctx instanceof Context ? [_ctx, _callback] : [new Context(), _ctx];
 
-    if (this._listeners.has(callback)) {
-      return () => {
-        /* No-op. */
-      };
-    }
+    const listener = new EventListener(this, callback, ctx, true, false);
 
-    const runCallback = (data: T) => runInContextAsync(ctx, () => callback(data));
-
-    this._onceListeners.set(callback, runCallback);
-    if (this.listenerCount() === 1) {
-      this._runEffects();
-    }
+    this._addListener(listener);
 
     return () => {
-      this._onceListeners.delete(callback);
-      if (this.listenerCount() === 0) {
-        this._runEffects();
-      }
+      this._removeListener(listener);
     };
   }
 
@@ -233,7 +224,7 @@ export class Event<T = void> implements ReadOnlyEvent<T> {
    * Returns the number of persistent listeners.
    */
   listenerCount() {
-    return this._listeners.size + this._onceListeners.size;
+    return this._listeners.size;
   }
 
   /**
@@ -317,6 +308,25 @@ export class Event<T = void> implements ReadOnlyEvent<T> {
     };
   }
 
+  private _addListener(listener: EventListener<T>) {
+    this._listeners.add(listener);
+
+    if (this.listenerCount() === 1) {
+      this._runEffects();
+    }
+  }
+
+  /**
+   * @internal
+   */
+  _removeListener(listener: EventListener<T>) {
+    this._listeners.delete(listener);
+
+    if (this.listenerCount() === 0) {
+      this._cleanupEffects();
+    }
+  }
+
   private _runEffects() {
     for (const handle of this._effects) {
       handle.cleanup = handle.effect();
@@ -388,3 +398,62 @@ export interface ReadOnlyEvent<T = void> {
    */
   discardParameter(): Event<void>;
 }
+
+class EventListener<T> {
+  public readonly callback: ((data: T) => void) | WeakRef<(data: T) => void>;
+
+  private readonly _clearDispose: () => void;
+
+  constructor(
+    event: Event<T>,
+    listener: (data: T) => void,
+    public readonly ctx: Context,
+    public readonly once: boolean,
+    public readonly weak: boolean,
+  ) {
+    if (weak) {
+      this.callback = new WeakRef(listener);
+      weakListeners().registry.register(
+        listener,
+        {
+          event: new WeakRef(event),
+          listener: this,
+        },
+        this,
+      );
+    } else {
+      this.callback = listener;
+    }
+
+    this._clearDispose = ctx.onDispose(() => {
+      event._removeListener(this);
+    });
+  }
+
+  derefCallback(): ((data: T) => void) | undefined {
+    return this.weak ? (this.callback as WeakRef<(data: T) => void>).deref() : (this.callback as (data: T) => void);
+  }
+
+  remove() {
+    this._clearDispose();
+    weakListeners().registry.unregister(this);
+  }
+}
+
+type HeldValue = {
+  event: WeakRef<Event<any>>;
+  listener: EventListener<any>;
+};
+
+let weakListenersState: FinalizationRegistry<HeldValue> | null = null;
+
+type WeakListeners = {
+  registry: FinalizationRegistry<HeldValue>;
+};
+
+const weakListeners = (): WeakListeners => {
+  weakListenersState ??= new FinalizationRegistry(({ event, listener }) => {
+    event.deref()?._removeListener(listener);
+  });
+  return { registry: weakListenersState };
+};


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 77c6a73</samp>

### Summary
🧪♻️🎛️

<!--
1.  🧪 for adding a new experimental test case
2.  ♻️ for refactoring the `Event` class and its methods
3.  🎛️ for adding a new `ListenerOptions` interface and a `weakListeners` function
-->
This pull request introduces a new feature for the `Event` class in the `async` package, which allows using weak and once listeners that can be garbage collected when they are no longer needed. It also adds a new test case and refactors the `Event` and `EventListener` classes to implement this feature. The changes affect the files `events.ts` and `events.test.ts`.

> _Sing, O Muse, of the cunning coder who reforged the `Event` class_
> _And gave it new powers to wield `weakListeners` and `ListenerOptions`_
> _He faced the dread beast of garbage collection, with `v8` and `vm` as his allies_
> _And crafted a test case to prove his skill, like Hephaestus forging a weapon_

### Walkthrough
*  Add support for weak listeners to `Event` class ([link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-26969a67629c0bebf719d30ae1e8713c7914b9ba9e194ba5df31a03c798fb373R92-R116), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aR40-R44), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aL85-R88), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aL99-R113), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aL117-R141), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aL144-R151), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aL163-R171), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aL236-R227), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aR311-R329), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aR401-R459), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-26969a67629c0bebf719d30ae1e8713c7914b9ba9e194ba5df31a03c798fb373R6-R7))
  * Use a single set of `EventListener` instances to store the callbacks, contexts, and options of the listeners ([link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aL85-R88), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aR401-R459))
  * Use a `FinalizationRegistry` to track and remove the weak listeners when they are garbage collected ([link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aR401-R459), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aR311-R329))
  * Call the callbacks asynchronously and handle errors in the listener's context ([link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aL99-R113))
  * Add a `ListenerOptions` interface to configure the weak and once flags of the listeners ([link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aR40-R44), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aL117-R141), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aL163-R171))
  * Refactor the public methods `on`, `off`, and `once` to use the private methods `_addListener` and `_removeListener` ([link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aL117-R141), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aL144-R151), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aL163-R171), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aR311-R329))
  * Add a test case for weak listeners using the `v8` and `vm` modules ([link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-26969a67629c0bebf719d30ae1e8713c7914b9ba9e194ba5df31a03c798fb373R92-R116), [link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-26969a67629c0bebf719d30ae1e8713c7914b9ba9e194ba5df31a03c798fb373R6-R7))
* Remove unused import of `runInContextAsync` from `task-scheduling` module ([link](https://github.com/dxos/dxos/pull/4318/files?diff=unified&w=0#diff-4f1783260d97fc633b6284445ba8979aceb1c972fd33cb6c88baf86d8f77108aL7-L8))


