### PR TITLE
fix!: force minor bump

### DIFF
--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -52,11 +52,11 @@ createRoot(document.getElementById('root')!).render(
         ClientPlugin(),
         GraphPlugin(),
         DndPlugin(),
-        TreeViewPlugin(),
-        UrlSyncPlugin(),
         SplitViewPlugin({
           showComplementarySidebar: false,
         }),
+        TreeViewPlugin(),
+        UrlSyncPlugin(),
         SpacePlugin(),
         MarkdownPlugin(),
         StackPlugin(),


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b64a25c</samp>

### Summary
🐛🔧🌲

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the changes.
2.  🔧 - This emoji represents a configuration or settings change, which is what the plugin order adjustment is.
3.  🌲 - This emoji represents a tree, which is the feature that the tree view plugin provides.
-->
Fixed a bug in `composer-app` that affected the tree view plugin. Changed the plugin loading order in `main.tsx` to ensure the split view plugin is loaded before the tree view plugin.

> _`tree view` plugin_
> _broken by `split view` order_
> _fixed in the spring_

### Walkthrough
* Changed the order of plugins to fix tree view rendering bug ([link](https://github.com/dxos/dxos/pull/4322/files?diff=unified&w=0#diff-9f2aee287f92edd662c13bed460a28a1590c9186b62c98ccc2e00f6877c3d7e6L55-R59))


