### PR TITLE
docs: swap order of mutations and queries in the guides

### DIFF
--- a/docs/docs/guide/react/mutations.md
+++ b/docs/docs/guide/react/mutations.md
@@ -1,6 +1,6 @@
 ---
 title: Mutations
-order: 5
+order: 4
 ---
 
 Mutating objects in [ECHO](../platform/) is as simple as directly manipulating them like normal JavaScript objects.

--- a/docs/docs/guide/react/queries.md
+++ b/docs/docs/guide/react/queries.md
@@ -1,6 +1,6 @@
 ---
 title: Queries
-order: 4
+order: 5
 ---
 
 # Queries

--- a/docs/docs/guide/typescript/mutations.md
+++ b/docs/docs/guide/typescript/mutations.md
@@ -1,5 +1,5 @@
 ---
-order: 6
+order: 5
 ---
 
 # Mutations

--- a/docs/docs/guide/typescript/queries.md
+++ b/docs/docs/guide/typescript/queries.md
@@ -1,5 +1,5 @@
 ---
-order: 5
+order: 6
 title: Queries
 ---
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d67d36c</samp>

### Summary
🔀🔄📄

<!--
1.  🔀 This emoji represents the swapping of the order of the Mutations and Queries pages in both guides, indicating a change in the sequence or flow of the content.
2.  🔄 This emoji represents the synchronization of the order of the Mutations and Queries pages across both guides, indicating a consistency or alignment of the content.
3.  📄 This emoji represents the pages themselves that were changed, indicating a change in the documentation or text content.
-->
The order of the Mutations and Queries pages in the React and TypeScript guides was swapped, to make them consistent across both guides. This affects the files `docs/docs/guide/react/mutations.md`, `docs/docs/guide/react/queries.md`, `docs/docs/guide/typescript/mutations.md`, and `docs/docs/guide/typescript/queries.md`.

> _`Mutations` and `Queries`_
> _Swap places in two guides_
> _Autumn rearranging_

### Walkthrough
*  Reordered the Mutations and Queries pages in the React and TypeScript guides to make them consistent ([link](https://github.com/dxos/dxos/pull/4343/files?diff=unified&w=0#diff-8887c3bf8333387240c3104356ad0d41f0d321969c19338b97813f1b22e713f1L3-R3), [link](https://github.com/dxos/dxos/pull/4343/files?diff=unified&w=0#diff-01f3249922b19fc2c089dded26113e3a725e3d8019ba3327094486fa4ef5f396L3-R3), [link](https://github.com/dxos/dxos/pull/4343/files?diff=unified&w=0#diff-73098884ed84d8af5e66abaef04db5790e7fc64c15d4e037a073d86ad0b65db8L2-R2), [link](https://github.com/dxos/dxos/pull/4343/files?diff=unified&w=0#diff-d96d406174eaed029af016ae6cc35ea25f4f89025dd00967d7ba24ed11233067L2-R2))


