### PR TITLE
fix: Object.keys on Expandos

### DIFF
--- a/packages/core/echo/echo-schema/src/typed-object.test.ts
+++ b/packages/core/echo/echo-schema/src/typed-object.test.ts
@@ -41,6 +41,11 @@ describe('TypedObject', () => {
     expect(obj3.__meta.keys[0].source).to.equal('dxos.org');
   });
 
+  test('keys', () => {
+    const obj = new Expando({ title: 'hello world', priority: 1 });
+    expect(Object.keys(obj)).to.deep.equal(['title', 'priority']);
+  });
+
   describe('meta', () => {
     test('meta keys', () => {
       const obj = new TypedObject();

--- a/packages/core/echo/echo-schema/src/typed-object.ts
+++ b/packages/core/echo/echo-schema/src/typed-object.ts
@@ -320,7 +320,7 @@ class TypedObjectImpl<T> extends EchoObject<DocumentModel> {
   }
 
   private _properties(key?: string, meta?: boolean) {
-    const state = meta ? this._getState().meta : this._getState();
+    const state = meta ? this._getState().meta : this._getState().data;
 
     const value = key ? get(state, key) : state;
 


### PR DESCRIPTION
closes https://github.com/dxos/dxos/issues/4339