### PR TITLE
fix: logging

### DIFF
--- a/packages/common/log/src/platform/node/index.ts
+++ b/packages/common/log/src/platform/node/index.ts
@@ -19,7 +19,7 @@ export const loadOptions = (filepath?: string): LogOptions | undefined => {
         return yaml.load(text) as LogOptions;
       }
     } catch (err) {
-      console.warn(`Invalid log file: ${fullpath}`);
+      console.warn(`Invalid log file: ${filepath}`);
     }
   }
 };

--- a/packages/common/log/src/platform/node/index.ts
+++ b/packages/common/log/src/platform/node/index.ts
@@ -13,10 +13,9 @@ import { LogOptions } from '../../config';
  */
 export const loadOptions = (filepath?: string): LogOptions | undefined => {
   if (filepath) {
-    const fullpath = path.join(process.cwd(), filepath);
     // console.log(`Log file: ${fullpath}`);
     try {
-      const text = fs.readFileSync(fullpath, 'utf-8');
+      const text = fs.readFileSync(filepath, 'utf-8');
       if (text) {
         return yaml.load(text) as LogOptions;
       }

--- a/packages/common/log/src/platform/node/index.ts
+++ b/packages/common/log/src/platform/node/index.ts
@@ -4,7 +4,6 @@
 
 import yaml from 'js-yaml';
 import fs from 'node:fs';
-import path from 'node:path';
 
 import { LogOptions } from '../../config';
 

--- a/packages/core/mesh/network-manager/src/swarm/connection.ts
+++ b/packages/core/mesh/network-manager/src/swarm/connection.ts
@@ -255,7 +255,7 @@ export class Connection {
 
     try {
       // Forcefully close the stream flushing any unsent data packets.
-      log('aborting protocol... ', { proto: this._protocol });
+      log('aborting protocol... ');
       await this._protocol.abort();
     } catch (err: any) {
       log.catch(err);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ffecd05</samp>

### Summary
🐛🧹📝

<!--
1.  🐛 for the bug fix in the `log` function call in the `network-manager` package.
2.  🧹 for the cleanup and simplification of the `loadOptions` function in the `log` package.
3.  📝 for the documentation update in the `log` package.
-->
Simplified `loadOptions` function in `log` package and removed unused parameter in `log` call in `network-manager` package. These changes improve the usability and readability of the logging functionality.

> _`loadOptions` fixed_
> _`log` function simplified_
> _Spring cleaning the code_

### Walkthrough
*  Simplify `loadOptions` function in `log` package to use given `filepath` directly ([link](https://github.com/dxos/dxos/pull/4361/files?diff=unified&w=0#diff-62ea19dc18973d13ed4022fffa35f2409d38054616157e0389965a9dcf0643a2L16-R18))
*  Remove redundant `proto` parameter from `log` function call in `Connection` class in `network-manager` package ([link](https://github.com/dxos/dxos/pull/4361/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745L258-R258))


