### PR TITLE
fix(examples): demo schema

### DIFF
--- a/packages/sdk/examples/src/main.tsx
+++ b/packages/sdk/examples/src/main.tsx
@@ -8,7 +8,7 @@ import { Airplane, Stack } from '@phosphor-icons/react';
 import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import { Document } from '@braneframe/types';
+import { schema$, Document } from '@braneframe/types';
 import { Input, ThemeProvider, Tooltip, ProgressBar, Center } from '@dxos/aurora';
 import { auroraTx } from '@dxos/aurora-theme';
 import { ClientContext } from '@dxos/react-client';
@@ -24,6 +24,7 @@ const root = createRoot(document.getElementById('root')!);
 const main = async () => {
   const { clients, spaceKey } = await setupPeersInSpace({
     count: 2,
+    schema: schema$,
     onCreateSpace: (space) => {
       space.db.add(
         new Document({


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5753a06</samp>

### Summary
🧠📄🔗

<!--
1.  🧠 - This emoji represents the braneframe library, which is a tool for creating and manipulating document models based on schemas.
2.  📄 - This emoji represents the Document component, which is the main UI component for displaying and editing document models in the aurora app.
3.  🔗 - This emoji represents the integration or connection between the braneframe library and the Document component, which enables the component to use the schema$ observable as a source of truth for the document model.
-->
This pull request adds braneframe support to the aurora UI example. It uses the `schema$` observable to render the document model with the `Document` component.

> _To show the document model with flair_
> _We import and pass `schema$` with care_
> _To the `Document` component_
> _From the braneframe library sent_
> _And the aurora UI does the rest there_

### Walkthrough
* Import schema observable from `@braneframe/types` to provide document model schema ([link](https://github.com/dxos/dxos/pull/4373/files?diff=unified&w=0#diff-f35d5176eec4322c2f3cd030aec3bfcc2628337cbad4bae7970d157334c20e60L11-R11))
* Pass schema observable to `Document` component as a prop to render document fields ([link](https://github.com/dxos/dxos/pull/4373/files?diff=unified&w=0#diff-f35d5176eec4322c2f3cd030aec3bfcc2628337cbad4bae7970d157334c20e60R27))


