### PR TITLE
feat(identity): Add device profiles

### DIFF
--- a/packages/core/agent/src/plugins/indexing/indexing-plugin.test.ts
+++ b/packages/core/agent/src/plugins/indexing/indexing-plugin.test.ts
@@ -76,7 +76,7 @@ describe('Indexing', () => {
     }
   });
 
-  test.only('search request/response', async () => {
+  test('search request/response', async () => {
     //
     // 1. Test topology:
     //

--- a/packages/core/echo/echo-schema/project.json
+++ b/packages/core/echo/echo-schema/project.json
@@ -49,7 +49,8 @@
         ]
       },
       "outputs": [
-        "packages/core/echo/echo-schema/src/test/proto/gen"
+        "packages/core/echo/echo-schema/src/test/proto/gen",
+        "packages/core/echo/echo-schema/src/proto/gen"
       ]
     },
     "test": {

--- a/packages/core/echo/echo-schema/src/proto/index.ts
+++ b/packages/core/echo/echo-schema/src/proto/index.ts
@@ -8,5 +8,3 @@ import { dxos } from './gen/schema';
 export import Schema = dxos.schema.Schema;
 
 export { schema$ as schemaBuiltin } from './gen/schema';
-
-// TODO(mykola): break cache

--- a/packages/core/halo/credentials/src/processor/device-state-machine.ts
+++ b/packages/core/halo/credentials/src/processor/device-state-machine.ts
@@ -3,10 +3,11 @@
 //
 
 import { Trigger } from '@dxos/async';
+import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
-import { Chain, Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
-import { ComplexSet } from '@dxos/util';
+import { Chain, Credential, ProfileDocument } from '@dxos/protocols/proto/dxos/halo/credentials';
+import { ComplexMap } from '@dxos/util';
 
 import { CredentialProcessor } from './credential-processor';
 import { getCredentialAssertion, isValidAuthorizedDeviceCredential } from '../credentials';
@@ -22,7 +23,8 @@ export type DeviceStateMachineParams = {
  */
 export class DeviceStateMachine implements CredentialProcessor {
   // TODO(burdon): Return values via getter.
-  public readonly authorizedDeviceKeys = new ComplexSet<PublicKey>(PublicKey.hash);
+  public readonly authorizedDeviceKeys = new ComplexMap<PublicKey, ProfileDocument | undefined>(PublicKey.hash);
+
   public readonly deviceChainReady = new Trigger();
 
   public deviceCredentialChain?: Chain;
@@ -45,13 +47,20 @@ export class DeviceStateMachine implements CredentialProcessor {
     const assertion = getCredentialAssertion(credential);
     switch (assertion['@type']) {
       case 'dxos.halo.credentials.AuthorizedDevice': {
+        invariant(!this.authorizedDeviceKeys.has(assertion.deviceKey), 'Device already added.');
         // TODO(dmaretskyi): Extra validation for the credential?
-        this.authorizedDeviceKeys.add(assertion.deviceKey);
+        this.authorizedDeviceKeys.set(assertion.deviceKey, undefined);
         log('added device', {
           localDeviceKey: this._params.deviceKey,
           deviceKey: assertion.deviceKey,
           size: this.authorizedDeviceKeys.size,
         });
+        this._params.onUpdate?.();
+        break;
+      }
+      case 'dxos.halo.credentials.DeviceProfile': {
+        invariant(this.authorizedDeviceKeys.has(assertion.deviceKey), 'Device not found.');
+        this.authorizedDeviceKeys.set(assertion.deviceKey, assertion.profile);
         this._params.onUpdate?.();
         break;
       }

--- a/packages/core/halo/credentials/src/processor/device-state-machine.ts
+++ b/packages/core/halo/credentials/src/processor/device-state-machine.ts
@@ -23,7 +23,7 @@ export type DeviceStateMachineParams = {
  */
 export class DeviceStateMachine implements CredentialProcessor {
   // TODO(burdon): Return values via getter.
-  public readonly authorizedDeviceKeys = new ComplexMap<PublicKey, ProfileDocument | undefined>(PublicKey.hash);
+  public readonly authorizedDeviceKeys = new ComplexMap<PublicKey, ProfileDocument>(PublicKey.hash);
 
   public readonly deviceChainReady = new Trigger();
 
@@ -49,7 +49,7 @@ export class DeviceStateMachine implements CredentialProcessor {
       case 'dxos.halo.credentials.AuthorizedDevice': {
         invariant(!this.authorizedDeviceKeys.has(assertion.deviceKey), 'Device already added.');
         // TODO(dmaretskyi): Extra validation for the credential?
-        this.authorizedDeviceKeys.set(assertion.deviceKey, undefined);
+        this.authorizedDeviceKeys.set(assertion.deviceKey, {});
         log('added device', {
           localDeviceKey: this._params.deviceKey,
           deviceKey: assertion.deviceKey,

--- a/packages/core/protocols/src/proto/dxos/halo/credentials.proto
+++ b/packages/core/protocols/src/proto/dxos/halo/credentials.proto
@@ -144,6 +144,12 @@ message IdentityProfile {
   ProfileDocument profile = 1;
 }
 
+/// [ASSERTION]: Sets device profile information. 
+message DeviceProfile {
+  dxos.keys.PublicKey device_key = 1;
+  ProfileDocument profile = 2;
+}
+
 // [ASSERTION]: Identity is authorized to access a KUBE.
 message KubeAccess {
   dxos.keys.PublicKey kube_key = 1;

--- a/packages/devtools/cli/src/commands/device/info.ts
+++ b/packages/devtools/cli/src/commands/device/info.ts
@@ -2,11 +2,11 @@
 // Copyright 2022 DXOS.org
 //
 
-import { sleep } from '@dxos/async';
+import chalk from 'chalk';
+
 import { Client } from '@dxos/client';
 
 import { BaseCommand } from '../../base-command';
-import { printDevices } from '../../util';
 
 export default class Info extends BaseCommand<typeof Info> {
   static override enableJsonFlag = true;
@@ -23,9 +23,8 @@ export default class Info extends BaseCommand<typeof Info> {
         return;
       }
 
-      if (!this.flags.json) {
-        printDevices([device], this.flags);
-      }
+      this.log(chalk`{magenta Device label:}`, device.profile?.displayName);
+      this.log(chalk`{magenta Device key:}`, device.deviceKey.toHex());
 
       return device;
     });

--- a/packages/devtools/cli/src/commands/device/info.ts
+++ b/packages/devtools/cli/src/commands/device/info.ts
@@ -2,23 +2,31 @@
 // Copyright 2022 DXOS.org
 //
 
+import { sleep } from '@dxos/async';
 import { Client } from '@dxos/client';
 
 import { BaseCommand } from '../../base-command';
+import { printDevices } from '../../util';
 
-export default class Device extends BaseCommand<typeof Device> {
+export default class Info extends BaseCommand<typeof Info> {
   static override enableJsonFlag = true;
   static override description = 'Show device info.';
 
   async run(): Promise<any> {
     return await this.execWithClient(async (client: Client) => {
+      // TODO(mykola): Hack to wait for identity with `client.halo.identity.wait()`.
+      await client.spaces.isReady.wait();
       const device = client.halo.device;
+
       if (!device) {
         this.log('No device found.');
         return;
       }
 
-      this.logToStderr('Device key:', device.deviceKey.toHex());
+      if (!this.flags.json) {
+        printDevices([device], this.flags);
+      }
+
       return device;
     });
   }

--- a/packages/devtools/cli/src/commands/device/list.ts
+++ b/packages/devtools/cli/src/commands/device/list.ts
@@ -19,6 +19,7 @@ export default class List extends BaseCommand<typeof List> {
 
   async run(): Promise<any> {
     return await this.execWithClient(async (client: Client) => {
+      await client.spaces.isReady.wait();
       const devices = client.halo.devices.get();
       printDevices(devices, this.flags);
       return devices;

--- a/packages/devtools/cli/src/commands/device/rename.ts
+++ b/packages/devtools/cli/src/commands/device/rename.ts
@@ -1,0 +1,37 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { Args, ux } from '@oclif/core';
+import chalk from 'chalk';
+
+import { Client } from '@dxos/client';
+
+import { BaseCommand } from '../../base-command';
+
+export default class Rename extends BaseCommand<typeof Rename> {
+  static override enableJsonFlag = true;
+  static override description = 'Set current device label.';
+
+  static override args = {
+    label: Args.string({ description: 'Device new label.' }),
+  };
+
+  async run(): Promise<any> {
+    return await this.execWithClient(async (client: Client) => {
+      // TODO(mykola): Hack to wait for identity with `client.halo.identity.wait()`.
+      await client.spaces.isReady.wait();
+      let { label } = this.args;
+
+      if (!label) {
+        label = await ux.prompt('Device label');
+      }
+
+      const device = await client.halo.updateDevice({ displayName: label });
+
+      this.log(chalk`{green Renamed:}`, device.profile?.displayName);
+
+      return device;
+    });
+  }
+}

--- a/packages/devtools/cli/src/util/devices.ts
+++ b/packages/devtools/cli/src/util/devices.ts
@@ -12,6 +12,7 @@ export const mapDevices = (devices: Device[], truncateKeys = false) => {
   return devices.map((device) => ({
     key: maybeTruncateKey(device.deviceKey, truncateKeys),
     kind: device.kind,
+    label: device.profile?.displayName,
   }));
 };
 
@@ -24,6 +25,9 @@ export const printDevices = (devices: Device[], flags = {}) => {
       },
       kind: {
         header: 'kind',
+      },
+      label: {
+        header: 'label',
       },
     },
     {

--- a/packages/sdk/client-protocol/src/halo.ts
+++ b/packages/sdk/client-protocol/src/halo.ts
@@ -21,6 +21,7 @@ export interface Halo {
   createIdentity(options?: ProfileDocument): Promise<Identity>;
   recoverIdentity(recoveryKey: Uint8Array): Promise<Identity>;
   updateProfile(profile: ProfileDocument): Promise<Identity>;
+  updateDevice(profile: ProfileDocument): Promise<Device>;
 
   share(): CancellableInvitation;
   join(invitation: Invitation): AuthenticatingInvitation;

--- a/packages/sdk/client-services/src/packlets/devices/devices-service.ts
+++ b/packages/sdk/client-services/src/packlets/devices/devices-service.ts
@@ -4,6 +4,7 @@
 
 import { EventSubscriptions } from '@dxos/async';
 import { Stream } from '@dxos/codec-protobuf';
+import { invariant } from '@dxos/invariant';
 import { Device, DeviceKind, DevicesService, QueryDevicesResponse } from '@dxos/protocols/proto/dxos/client/services';
 import { ProfileDocument } from '@dxos/protocols/proto/dxos/halo/credentials';
 
@@ -12,8 +13,19 @@ import { IdentityManager } from '../identity';
 export class DevicesServiceImpl implements DevicesService {
   constructor(private readonly _identityManager: IdentityManager) {}
 
-  updateDevice(request: ProfileDocument): Promise<Device> {
-    throw new Error('Method not implemented.');
+  async updateDevice(profile: ProfileDocument): Promise<Device> {
+    invariant(this._identityManager.identity, 'Identity not initialized');
+    const deviceKey = this._identityManager.identity.deviceKey;
+    await this._identityManager.updateDevice({
+      deviceKey,
+      profile,
+    });
+
+    return {
+      deviceKey,
+      kind: DeviceKind.CURRENT,
+      profile,
+    };
   }
 
   queryDevices(): Stream<QueryDevicesResponse> {

--- a/packages/sdk/client-services/src/packlets/devices/devices-service.ts
+++ b/packages/sdk/client-services/src/packlets/devices/devices-service.ts
@@ -24,9 +24,10 @@ export class DevicesServiceImpl implements DevicesService {
           next({ devices: [] });
         } else {
           next({
-            devices: Array.from(deviceKeys.values()).map((key) => ({
+            devices: Array.from(deviceKeys.entries()).map(([key, profile]) => ({
               deviceKey: key,
               kind: this._identityManager.identity?.deviceKey.equals(key) ? DeviceKind.CURRENT : DeviceKind.TRUSTED,
+              profile,
             })),
           });
         }

--- a/packages/sdk/client-services/src/packlets/identity/identity-manager.test.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity-manager.test.ts
@@ -151,4 +151,15 @@ describe('identity/identity-manager', () => {
     expect(identity2.space.protocol.sessions.get(identity1.deviceKey)).to.exist;
     expect(identity2.space.protocol.sessions.get(identity1.deviceKey)?.authStatus).to.equal(AuthStatus.SUCCESS);
   });
+
+  test.only('set device profile', async () => {
+    const signalContext = new MemorySignalManagerContext();
+
+    const peer1 = await setupPeer({ signalContext });
+    const identity1 = await peer1.identityManager.createIdentity();
+
+    await peer1.identityManager.updateDevice({ deviceKey: identity1.deviceKey, profile: { displayName: 'Peer1' } });
+
+    expect(identity1.authorizedDeviceKeys.get(identity1.deviceKey)?.displayName).to.equal('Peer1');
+  });
 });

--- a/packages/sdk/client-services/src/packlets/identity/identity-manager.test.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity-manager.test.ts
@@ -152,7 +152,7 @@ describe('identity/identity-manager', () => {
     expect(identity2.space.protocol.sessions.get(identity1.deviceKey)?.authStatus).to.equal(AuthStatus.SUCCESS);
   });
 
-  test.only('set device profile', async () => {
+  test('set device profile', async () => {
     const signalContext = new MemorySignalManagerContext();
 
     const peer1 = await setupPeer({ signalContext });

--- a/packages/sdk/client-services/src/packlets/identity/identity.test.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity.test.ts
@@ -336,7 +336,7 @@ describe('identity/identity', () => {
       await identity2.ready();
     }
 
-    expect(Array.from(identity1.authorizedDeviceKeys.values())).toEqual([identity1.deviceKey, identity2.deviceKey]);
-    expect(Array.from(identity2.authorizedDeviceKeys.values())).toEqual([identity1.deviceKey, identity2.deviceKey]);
+    expect(Array.from(identity1.authorizedDeviceKeys.keys())).toEqual([identity1.deviceKey, identity2.deviceKey]);
+    expect(Array.from(identity2.authorizedDeviceKeys.keys())).toEqual([identity1.deviceKey, identity2.deviceKey]);
   });
 });

--- a/packages/sdk/client-services/src/packlets/identity/identity.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity.ts
@@ -75,7 +75,7 @@ export class Identity {
   }
 
   // TODO(burdon): Expose state object?
-  get authorizedDeviceKeys(): ComplexMap<PublicKey, ProfileDocument | undefined> {
+  get authorizedDeviceKeys(): ComplexMap<PublicKey, ProfileDocument> {
     return this._deviceStateMachine.authorizedDeviceKeys;
   }
 

--- a/packages/sdk/client-services/src/packlets/identity/identity.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity.ts
@@ -23,7 +23,7 @@ import { FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
 import { AdmittedFeed, ProfileDocument } from '@dxos/protocols/proto/dxos/halo/credentials';
 import { DeviceAdmissionRequest } from '@dxos/protocols/proto/dxos/halo/invitations';
 import { trace } from '@dxos/tracing';
-import { ComplexSet } from '@dxos/util';
+import { ComplexMap, ComplexSet } from '@dxos/util';
 
 import { TrustedKeySetAuthVerifier } from './authenticator';
 
@@ -68,14 +68,14 @@ export class Identity {
     });
 
     this.authVerifier = new TrustedKeySetAuthVerifier({
-      trustedKeysProvider: () => this.authorizedDeviceKeys,
+      trustedKeysProvider: () => new ComplexSet(PublicKey.hash, this.authorizedDeviceKeys.keys()),
       update: this.stateUpdate,
       authTimeout: AUTH_TIMEOUT,
     });
   }
 
   // TODO(burdon): Expose state object?
-  get authorizedDeviceKeys(): ComplexSet<PublicKey> {
+  get authorizedDeviceKeys(): ComplexMap<PublicKey, ProfileDocument | undefined> {
     return this._deviceStateMachine.authorizedDeviceKeys;
   }
 

--- a/packages/sdk/client/src/halo/halo-proxy.ts
+++ b/packages/sdk/client/src/halo/halo-proxy.ts
@@ -182,6 +182,13 @@ export class HaloProxy implements Halo {
     return identity;
   }
 
+  async updateDevice(profile: ProfileDocument): Promise<Device> {
+    invariant(this._serviceProvider.services.DevicesService, 'DevicesService not available');
+    // NOTE: Event that device changed will be fired by devicesStream subscription.
+    const device = await this._serviceProvider.services.DevicesService.updateDevice(profile);
+    return device;
+  }
+
   /**
    * Get Halo credentials for the current user.
    */


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8f7d639</samp>

### Summary
📱🏷️🔐

<!--
1.  📱 - This emoji represents the device profile feature, which allows users to assign names and other information to their devices. It also symbolizes the device management and display improvements in the CLI and SDK.
2.  🏷️ - This emoji represents the rename command, which allows users to change the current device label. It also symbolizes the label property and column that are added to the device information.
3.  🔐 - This emoji represents the device authentication and profile management enhancements in the Identity service, which use more secure and efficient data structures. It also symbolizes the device profile assertion that is added to the credential.
-->
This pull request adds and improves the device profile management features in the core, SDK, and CLI packages. It introduces a new `DeviceProfile` protobuf message, a new `rename` command, and new or updated methods for creating, updating, and displaying device profiles. It also fixes some bugs and enhances the data structures and tests related to device keys and profiles.

> _We're updating devices with profiles and keys_
> _We're calling `updateDevice` on the `Halo` API_
> _We're heaving away on the code review_
> _We're sailing the high seas of the SDK_

### Walkthrough
*  Add device profile functionality to store and display device labels ([link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-c6814e79ca19f67e101d8a8a1f3d205905a782a0494923d66f7c746a566151faL6-R10), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-c6814e79ca19f67e101d8a8a1f3d205905a782a0494923d66f7c746a566151faL25-R27), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-c6814e79ca19f67e101d8a8a1f3d205905a782a0494923d66f7c746a566151faL48-R52), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-c6814e79ca19f67e101d8a8a1f3d205905a782a0494923d66f7c746a566151faR61-R66), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-16167047b34f2bba3c82dd62843aae49e31c3e6912d3dc346fb8eec7d1ce7734R147-R152), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-0b35a35963e8ce4ac62766db1c9784bfa8c0cccab394e1a9cf0f701b9aca9a09R15), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-0b35a35963e8ce4ac62766db1c9784bfa8c0cccab394e1a9cf0f701b9aca9a09R29-R31), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-e7f99fd0bd87015fa4dee0555c875779d20d23596607d46145886bed4075b3e0R24), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-b93657071350d7a973a17b15ea4236d8afdb3ad5cec7d29fd60f1d5662d06157L15-R28), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-b93657071350d7a973a17b15ea4236d8afdb3ad5cec7d29fd60f1d5662d06157L27-R42), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-ea8eb3fd950dfaf8b15e4b5b2a3830aa5f849476859ed38df7305bbeba5308a9R215-R234), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-d7e5d277aa93b5e5d4a3dfbaef75b2cea909b68b5383912928ae2505452fb02cL26-R26), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-d7e5d277aa93b5e5d4a3dfbaef75b2cea909b68b5383912928ae2505452fb02cL71-R71), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-d7e5d277aa93b5e5d4a3dfbaef75b2cea909b68b5383912928ae2505452fb02cL78-R78), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-f0dd1c1386db8539a838d499697ff194352e036ee8b263a4be95c0431cd8438fR185-R191))
  * Define a new protobuf message `DeviceProfile` in `credentials.proto` ([link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-16167047b34f2bba3c82dd62843aae49e31c3e6912d3dc346fb8eec7d1ce7734R147-R152))
  * Change the device state machine to use `ComplexMap` instead of `ComplexSet` and handle `DeviceProfile` assertions in `device-state-machine.ts` ([link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-c6814e79ca19f67e101d8a8a1f3d205905a782a0494923d66f7c746a566151faL6-R10), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-c6814e79ca19f67e101d8a8a1f3d205905a782a0494923d66f7c746a566151faL25-R27), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-c6814e79ca19f67e101d8a8a1f3d205905a782a0494923d66f7c746a566151faL48-R52), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-c6814e79ca19f67e101d8a8a1f3d205905a782a0494923d66f7c746a566151faR61-R66))
  * Implement `updateDevice` methods in `Halo`, `DevicesService`, `IdentityManager`, and `HaloProxy` to create and write device profile credentials and update the device map ([link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-e7f99fd0bd87015fa4dee0555c875779d20d23596607d46145886bed4075b3e0R24), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-b93657071350d7a973a17b15ea4236d8afdb3ad5cec7d29fd60f1d5662d06157L15-R28), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-ea8eb3fd950dfaf8b15e4b5b2a3830aa5f849476859ed38df7305bbeba5308a9R215-R234), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-f0dd1c1386db8539a838d499697ff194352e036ee8b263a4be95c0431cd8438fR185-R191))
  * Add `label` property and column to `mapDevices` and `printDevices` functions in `devices.ts` to extract and show the device profile display name ([link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-0b35a35963e8ce4ac62766db1c9784bfa8c0cccab394e1a9cf0f701b9aca9a09R15), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-0b35a35963e8ce4ac62766db1c9784bfa8c0cccab394e1a9cf0f701b9aca9a09R29-R31))
  * Change the `authVerifier` constructor and the `authorizedDeviceKeys` getter in `Identity` to use the device keys from the map ([link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-d7e5d277aa93b5e5d4a3dfbaef75b2cea909b68b5383912928ae2505452fb02cL26-R26), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-d7e5d277aa93b5e5d4a3dfbaef75b2cea909b68b5383912928ae2505452fb02cL71-R71), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-d7e5d277aa93b5e5d4a3dfbaef75b2cea909b68b5383912928ae2505452fb02cL78-R78))
* Add `rename` command to set the current device label in `rename.ts` ([link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-56098c6a6fc6b1a9bf8f163aae858fede64596214142174cda9b29e709ba72afR1-R37))
* Rename `device` command to `info` and show the device label in `info.ts` ([link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-698d639320a28c8ab5faea59e24df52aaff85656fcbb894d30df6dee0b649aecL5-R11), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-698d639320a28c8ab5faea59e24df52aaff85656fcbb894d30df6dee0b649aecL21-R28))
* Add a hack to wait for the identity to be ready before accessing the device information in `info.ts` ([link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-698d639320a28c8ab5faea59e24df52aaff85656fcbb894d30df6dee0b649aecL15-R20))
* Add a test case for the `set device profile` functionality in `identity-manager.test.ts` ([link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-1d7efb244f9f8afa680473ce66d12e266c5c20eaf2d978a410f8b48bfde40d5eR154-R164))
* Change the test case for the `device admission` functionality in `identity.test.ts` to use `keys` instead of `values` to access the device keys from the map ([link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-0de952ae05fa494d9607d9d5ca3bdaa0adda55a3354f680bc55043626009ddb8L339-R340))
* Import `invariant` module for assertions in `device-state-machine.ts` and `devices-service.ts` ([link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-c6814e79ca19f67e101d8a8a1f3d205905a782a0494923d66f7c746a566151faL6-R10), [link](https://github.com/dxos/dxos/pull/4390/files?diff=unified&w=0#diff-b93657071350d7a973a17b15ea4236d8afdb3ad5cec7d29fd60f1d5662d06157R7))

