### PR TITLE
feat: add operations to mosaic

### DIFF
--- a/packages/ui/aurora-grid/src/mosaic/Container.tsx
+++ b/packages/ui/aurora-grid/src/mosaic/Container.tsx
@@ -14,7 +14,8 @@ export type MosaicTileOverlayProps = {
   debug?: boolean;
 };
 
-export type MosaicOperation = 'adopt' | 'copy' | 'rearrange' | 'refuse';
+// TODO(wittjosiah): Add delete.
+export type MosaicOperation = 'adopt' | 'copy' | 'rearrange' | 'reject';
 
 export type MosaicMoveEvent<TPosition = unknown> = {
   active: MosaicDraggedItem<TPosition>;
@@ -65,7 +66,6 @@ export type MosaicContainerProps<
   /**
    * Called when a tile is dropped on the container.
    */
-  // TODO(burdon): Handle copy, delete, etc.
   onDrop?: (event: MosaicDropEvent<TPosition>) => void;
 
   /**

--- a/packages/ui/aurora-grid/src/mosaic/Container.tsx
+++ b/packages/ui/aurora-grid/src/mosaic/Container.tsx
@@ -7,12 +7,25 @@ import React, { createContext, useEffect, CSSProperties, HTMLAttributes, PropsWi
 
 import { MosaicTileComponent } from './Tile';
 import { useMosaic } from './hooks';
-import { MosaicDataItem, MosaicDraggedItem, MosaicMoveEvent } from './types';
+import { MosaicDataItem, MosaicDraggedItem } from './types';
 
 export type MosaicTileOverlayProps = {
   grow?: boolean;
   debug?: boolean;
 };
+
+export type MosaicOperation = 'adopt' | 'copy' | 'rearrange' | 'refuse';
+
+export type MosaicMoveEvent<TPosition = unknown> = {
+  active: MosaicDraggedItem<TPosition>;
+  over: MosaicDraggedItem<TPosition>;
+};
+
+export type MosaicDropEvent<TPosition = unknown> = MosaicMoveEvent<TPosition> & {
+  operation: MosaicOperation;
+};
+
+export type MosaicCompareDataItem = Parameters<typeof Array.prototype.sort>[0];
 
 export type MosaicContainerProps<
   TData extends MosaicDataItem = MosaicDataItem,
@@ -47,13 +60,18 @@ export type MosaicContainerProps<
    * Called when a tile is dragged over the container.
    * Returns true if the tile can be dropped.
    */
-  onOver?: (event: MosaicMoveEvent<TPosition>) => boolean;
+  onOver?: (event: MosaicMoveEvent<TPosition>) => MosaicOperation;
 
   /**
    * Called when a tile is dropped on the container.
    */
   // TODO(burdon): Handle copy, delete, etc.
-  onDrop?: (event: MosaicMoveEvent<TPosition>) => void;
+  onDrop?: (event: MosaicDropEvent<TPosition>) => void;
+
+  /**
+   * Used to sort items within the container.
+   */
+  compare?: MosaicCompareDataItem;
 
   /**
    * Custom properties (available to event handlers).

--- a/packages/ui/aurora-grid/src/mosaic/DragOverlay.tsx
+++ b/packages/ui/aurora-grid/src/mosaic/DragOverlay.tsx
@@ -23,7 +23,8 @@ export type MosaicDragOverlayProps = { delay?: number; debug?: boolean } & Omit<
  * Render the currently dragged item of the Mosaic.
  */
 export const MosaicDragOverlay = ({ delay = 200, debug = false, ...overlayProps }: MosaicDragOverlayProps) => {
-  const { containers, activeItem, overItem } = useContext(MosaicContext) ?? raise(new Error('Missing MosaicContext'));
+  const { containers, operation, activeItem, overItem } =
+    useContext(MosaicContext) ?? raise(new Error('Missing MosaicContext'));
 
   // Get the overlay component from the over container, otherwise default to the original.
   const [{ container, OverlayComponent }, setContainer] = useState<{
@@ -66,6 +67,7 @@ export const MosaicDragOverlay = ({ delay = 200, debug = false, ...overlayProps 
                 {...container.getOverlayProps?.()}
                 item={activeItem.item}
                 path={activeItem.path}
+                operation={operation}
                 isActive={true}
               />
               {debug && (

--- a/packages/ui/aurora-grid/src/mosaic/Mosaic.ts
+++ b/packages/ui/aurora-grid/src/mosaic/Mosaic.ts
@@ -4,7 +4,14 @@
 
 import { FC } from 'react';
 
-import { MosaicContainer, MosaicContainerProps as NaturalMosaicContainerProps } from './Container';
+import {
+  MosaicContainer,
+  MosaicContainerProps as NaturalMosaicContainerProps,
+  MosaicMoveEvent as NaturalMosaicMoveEvent,
+  MosaicDropEvent as NaturalMosaicDropEvent,
+  MosaicOperation as NaturalMosaicOperation,
+  MosaicCompareDataItem as NaturalMosaicCompareDataItem,
+} from './Container';
 import { Debug, DebugProps } from './Debug';
 import { DefaultComponent } from './DefaultComponent';
 import { MosaicDragOverlay, MosaicDragOverlayProps } from './DragOverlay';
@@ -62,3 +69,9 @@ export type MosaicTileProps<
 export type MosaicTileComponent<TData extends MosaicDataItem = MosaicDataItem> = NaturalMosaicTileComponent<TData>;
 
 export type MosaicDebugProps = DebugProps;
+
+export type MosaicMoveEvent<TPosition = unknown> = NaturalMosaicMoveEvent<TPosition>;
+export type MosaicDropEvent<TPosition = unknown> = NaturalMosaicDropEvent<TPosition>;
+export type MosaicOperation = NaturalMosaicOperation;
+
+export type MosaicCompareDataItem = NaturalMosaicCompareDataItem;

--- a/packages/ui/aurora-grid/src/mosaic/Root.tsx
+++ b/packages/ui/aurora-grid/src/mosaic/Root.tsx
@@ -24,7 +24,7 @@ import pick from 'lodash.pick';
 import React, { createContext, FC, PropsWithChildren, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-import { MosaicContainerProps } from './Container';
+import { MosaicContainerProps, MosaicMoveEvent, MosaicOperation } from './Container';
 import { Debug } from './Debug';
 import { DefaultComponent } from './DefaultComponent';
 import { MosaicTileComponent } from './Tile';
@@ -38,6 +38,7 @@ export type MosaicContextType = {
   setContainer: (id: string, container?: MosaicContainerProps<any>) => void;
   activeItem: MosaicDraggedItem | undefined;
   overItem: MosaicDraggedItem | undefined;
+  operation: MosaicOperation;
 };
 
 export const MosaicContext = createContext<MosaicContextType | undefined>(undefined);
@@ -72,6 +73,7 @@ export const MosaicRoot: FC<MosaicRootProps> = ({ Component = DefaultComponent, 
 
   const [activeItem, setActiveItem] = useState<MosaicDraggedItem>();
   const [overItem, setOverItem] = useState<MosaicDraggedItem>();
+  const [operation, setOperation] = useState<MosaicOperation>('refuse');
 
   //
   // DndKit Defaults
@@ -149,40 +151,58 @@ export const MosaicRoot: FC<MosaicRootProps> = ({ Component = DefaultComponent, 
     const activeContainer = activeItem && containers.get(Path.first(activeItem.path));
     const overContainer = overItem?.path && containers.get(Path.first(overItem.path));
     if (!event.over || !overItem || !overContainer || !activeItem || !activeContainer) {
+      setOperation('refuse');
       setOverItem(undefined);
       return;
     }
 
-    const onOver = overContainer.onOver ?? (() => true);
-    const item = onOver({ active: activeItem, over: overItem }) ? overItem : undefined;
-    setOverItem(item);
+    const onOver = ({ active, over }: MosaicMoveEvent) => {
+      if (Path.parent(active.path) === Path.parent(over.path)) {
+        return 'rearrange';
+      } else if (overContainer.onOver) {
+        return overContainer.onOver({ active, over });
+      } else {
+        // TODO(wittjosiah): Default to refuse.
+        return 'adopt';
+      }
+    };
+
+    setOperation(onOver({ active: activeItem, over: overItem }));
+    setOverItem(overItem);
   };
 
   const handleDragCancel = (event: DragCancelEvent) => {
+    setOperation('refuse');
     setActiveItem(undefined);
     setOverItem(undefined);
   };
 
   // TODO(burdon): Add event type (e.g., copy vs. move).
   const handleDragEnd = (event: DragEndEvent) => {
-    if (activeItem && overItem && (activeItem.path !== overItem.path || activeItem.position !== overItem.position)) {
+    if (
+      operation !== 'refuse' &&
+      activeItem &&
+      overItem &&
+      (activeItem.path !== overItem.path || activeItem.position !== overItem.position)
+    ) {
       const activeContainer = containers.get(Path.first(activeItem.path));
       if (activeContainer) {
-        activeContainer.onDrop?.({ active: activeItem, over: overItem });
+        activeContainer.onDrop?.({ operation, active: activeItem, over: overItem });
 
-        const overContainer = containers.get(Path.first(overItem?.path));
+        const overContainer = containers.get(Path.first(overItem.path));
         if (overContainer && overContainer !== activeContainer) {
-          overContainer.onDrop?.({ active: activeItem, over: overItem });
+          overContainer.onDrop?.({ operation, active: activeItem, over: overItem });
         }
       }
     }
 
+    setOperation('refuse');
     setActiveItem(undefined);
     setOverItem(undefined);
   };
 
   return (
-    <MosaicContext.Provider value={{ containers, setContainer: handleSetContainer, activeItem, overItem }}>
+    <MosaicContext.Provider value={{ containers, setContainer: handleSetContainer, activeItem, overItem, operation }}>
       <DndContext
         collisionDetection={collisionDetection}
         modifiers={[modifiers]}
@@ -198,7 +218,7 @@ export const MosaicRoot: FC<MosaicRootProps> = ({ Component = DefaultComponent, 
         {children}
         {debug &&
           createPortal(
-            <MosaicDebug containers={containers} activeItem={activeItem} overItem={overItem} />,
+            <MosaicDebug containers={containers} operation={operation} activeItem={activeItem} overItem={overItem} />,
             document.body,
           )}
       </DndContext>
@@ -208,14 +228,16 @@ export const MosaicRoot: FC<MosaicRootProps> = ({ Component = DefaultComponent, 
 
 const MosaicDebug: FC<{
   containers: Map<string, MosaicContainerProps<any>>;
+  operation: MosaicOperation;
   activeItem?: MosaicDraggedItem;
   overItem?: MosaicDraggedItem;
-}> = ({ containers, activeItem, overItem }) => {
+}> = ({ containers, operation, activeItem, overItem }) => {
   return (
     <Debug
       position='bottom-right'
       data={{
         containers: Array.from(containers.keys()).map((id) => id),
+        operation,
         active: {
           id: activeItem?.item?.id,
           path: activeItem?.path,

--- a/packages/ui/aurora-grid/src/mosaic/Root.tsx
+++ b/packages/ui/aurora-grid/src/mosaic/Root.tsx
@@ -73,7 +73,7 @@ export const MosaicRoot: FC<MosaicRootProps> = ({ Component = DefaultComponent, 
 
   const [activeItem, setActiveItem] = useState<MosaicDraggedItem>();
   const [overItem, setOverItem] = useState<MosaicDraggedItem>();
-  const [operation, setOperation] = useState<MosaicOperation>('refuse');
+  const [operation, setOperation] = useState<MosaicOperation>('reject');
 
   //
   // DndKit Defaults
@@ -151,7 +151,7 @@ export const MosaicRoot: FC<MosaicRootProps> = ({ Component = DefaultComponent, 
     const activeContainer = activeItem && containers.get(Path.first(activeItem.path));
     const overContainer = overItem?.path && containers.get(Path.first(overItem.path));
     if (!event.over || !overItem || !overContainer || !activeItem || !activeContainer) {
-      setOperation('refuse');
+      setOperation('reject');
       setOverItem(undefined);
       return;
     }
@@ -162,7 +162,7 @@ export const MosaicRoot: FC<MosaicRootProps> = ({ Component = DefaultComponent, 
       } else if (overContainer.onOver) {
         return overContainer.onOver({ active, over });
       } else {
-        // TODO(wittjosiah): Default to refuse.
+        // TODO(wittjosiah): Default to reject.
         return 'adopt';
       }
     };
@@ -172,7 +172,7 @@ export const MosaicRoot: FC<MosaicRootProps> = ({ Component = DefaultComponent, 
   };
 
   const handleDragCancel = (event: DragCancelEvent) => {
-    setOperation('refuse');
+    setOperation('reject');
     setActiveItem(undefined);
     setOverItem(undefined);
   };
@@ -180,7 +180,7 @@ export const MosaicRoot: FC<MosaicRootProps> = ({ Component = DefaultComponent, 
   // TODO(burdon): Add event type (e.g., copy vs. move).
   const handleDragEnd = (event: DragEndEvent) => {
     if (
-      operation !== 'refuse' &&
+      operation !== 'reject' &&
       activeItem &&
       overItem &&
       (activeItem.path !== overItem.path || activeItem.position !== overItem.position)
@@ -196,7 +196,7 @@ export const MosaicRoot: FC<MosaicRootProps> = ({ Component = DefaultComponent, 
       }
     }
 
-    setOperation('refuse');
+    setOperation('reject');
     setActiveItem(undefined);
     setOverItem(undefined);
   };

--- a/packages/ui/aurora-grid/src/mosaic/Tile.tsx
+++ b/packages/ui/aurora-grid/src/mosaic/Tile.tsx
@@ -6,10 +6,10 @@ import { useDraggable } from '@dnd-kit/core';
 import { defaultAnimateLayoutChanges, useSortable } from '@dnd-kit/sortable';
 import React, { ForwardRefExoticComponent, HTMLAttributes, RefAttributes } from 'react';
 
-import { MosaicTileOverlayProps } from './Container';
+import { MosaicOperation, MosaicTileOverlayProps } from './Container';
 import { DefaultComponent } from './DefaultComponent';
 import { useMosaic } from './hooks';
-import { CompareMosaicDataItem, MosaicDataItem, MosaicDraggedItem } from './types';
+import { MosaicDataItem, MosaicDraggedItem } from './types';
 import { getTransformCSS, Path } from './util';
 
 /**
@@ -24,7 +24,7 @@ export type MosaicTileProps<TData extends MosaicDataItem = MosaicDataItem, TPosi
     path: string;
     item: TData;
 
-    compare?: CompareMosaicDataItem;
+    operation?: MosaicOperation;
     position?: TPosition;
     isActive?: boolean;
     isDragging?: boolean;
@@ -40,7 +40,8 @@ export type MosaicTileProps<TData extends MosaicDataItem = MosaicDataItem, TPosi
  * Mosaic Tile component.
  */
 export type MosaicTileComponent<TData extends MosaicDataItem = MosaicDataItem> = ForwardRefExoticComponent<
-  RefAttributes<HTMLDivElement> & Omit<MosaicTileProps<TData>, 'Component'>
+  RefAttributes<HTMLDivElement> &
+    Omit<MosaicTileProps<TData>, 'Component' | 'operation'> & { operation: MosaicOperation }
 >;
 
 /**
@@ -54,6 +55,7 @@ export const DraggableTile = ({
   draggableStyle,
   ...props
 }: MosaicTileProps<any>) => {
+  const { operation } = useMosaic();
   const path = Path.create(parentPath, item.id);
   const { setNodeRef, attributes, listeners, /* transform, */ isDragging } = useDraggable({
     id: path,
@@ -65,6 +67,7 @@ export const DraggableTile = ({
       ref={setNodeRef}
       item={item}
       path={path}
+      operation={operation}
       position={position}
       isDragging={isDragging}
       draggableStyle={{
@@ -89,7 +92,7 @@ export const SortableTile = ({
   draggableStyle,
   ...props
 }: MosaicTileProps<any, number>) => {
-  const { activeItem, overItem } = useMosaic();
+  const { operation, activeItem, overItem } = useMosaic();
   // TODO(wittjosiah): If this is the active item, then use the same id.
   const path = Path.create(parentPath, item.id);
   const {
@@ -112,7 +115,8 @@ export const SortableTile = ({
   // - this tile is being dragged from another path
   const isDragging =
     isDraggingLocal ||
-    (activeItem?.item.id === item.id &&
+    (operation !== 'refuse' &&
+      activeItem?.item.id === item.id &&
       overItem &&
       (Path.hasChild(Path.parent(path), overItem.path) ||
         Path.parent(path) === overItem.path ||
@@ -123,6 +127,7 @@ export const SortableTile = ({
       ref={setNodeRef}
       item={item}
       path={path}
+      operation={operation}
       position={position}
       isDragging={isDragging}
       isOver={isOver}

--- a/packages/ui/aurora-grid/src/mosaic/Tile.tsx
+++ b/packages/ui/aurora-grid/src/mosaic/Tile.tsx
@@ -26,6 +26,7 @@ export type MosaicTileProps<TData extends MosaicDataItem = MosaicDataItem, TPosi
 
     operation?: MosaicOperation;
     position?: TPosition;
+    // TODO(wittjosiah): active?: 'overlay' | 'rearrange' | 'origin' | 'destination';
     isActive?: boolean;
     isDragging?: boolean;
     isOver?: boolean;
@@ -115,7 +116,7 @@ export const SortableTile = ({
   // - this tile is being dragged from another path
   const isDragging =
     isDraggingLocal ||
-    (operation !== 'refuse' &&
+    (operation !== 'reject' &&
       activeItem?.item.id === item.id &&
       overItem &&
       (Path.hasChild(Path.parent(path), overItem.path) ||

--- a/packages/ui/aurora-grid/src/mosaic/hooks/index.ts
+++ b/packages/ui/aurora-grid/src/mosaic/hooks/index.ts
@@ -3,5 +3,6 @@
 //
 
 export * from './useContainer';
+export * from './useItemsWithPreview';
 export * from './useMosaic';
 export * from './useSortedItems';

--- a/packages/ui/aurora-grid/src/mosaic/hooks/useContainer.ts
+++ b/packages/ui/aurora-grid/src/mosaic/hooks/useContainer.ts
@@ -6,7 +6,12 @@ import { useContext } from 'react';
 
 import { raise } from '@dxos/debug';
 
-import { MosaicContainerContext, MosaicContainerContextType } from '../Container';
+import { MosaicContainerContext, MosaicContainerProps } from '../Container';
+import { MosaicDataItem } from '../types';
 
-export const useContainer = (): MosaicContainerContextType =>
+export const useContainer = <
+  TData extends MosaicDataItem = MosaicDataItem,
+  TPosition = unknown,
+  TCustom = any,
+>(): MosaicContainerProps<TData, TPosition, TCustom> =>
   useContext(MosaicContainerContext) ?? raise(new Error('Missing MosaicContainerContext'));

--- a/packages/ui/aurora-grid/src/mosaic/hooks/useItemsWithPreview.ts
+++ b/packages/ui/aurora-grid/src/mosaic/hooks/useItemsWithPreview.ts
@@ -1,0 +1,46 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { useMosaic } from './useMosaic';
+import { MosaicDataItem } from '../types';
+import { Path } from '../util';
+
+/**
+ * Returns a spliced collection of items including a placeholder if items that could drop,
+ * and removing any item that is currently being dragged out.
+ */
+export const useItemsWithPreview = <T extends MosaicDataItem>({ path, items }: { path: string; items: T[] }): T[] => {
+  const { operation, activeItem, overItem } = useMosaic();
+
+  if (operation !== 'adopt' && operation !== 'copy') {
+    return items;
+  }
+
+  // Insert placeholder item being dragged in.
+  // TODO(burdon): This currently isn't animated (e.g., dragging into new kanban column vs. same column).
+  if (
+    // Item is being dragged
+    activeItem &&
+    // From a different path
+    !Path.hasChild(path, activeItem.path) &&
+    // Over an item
+    overItem &&
+    // Which is this item (but only if it's not a sibling of the active item which indicates a reorder)
+    ((path === overItem.path && Path.parent(activeItem.path) !== Path.parent(overItem.path)) ||
+      // Or which is a child of this item
+      Path.hasChild(path, overItem.path))
+  ) {
+    const itemsWithPreview = [...items];
+    const position = path === overItem.path ? itemsWithPreview.length : (overItem.position as number);
+    itemsWithPreview.splice(position, 0, activeItem.item as T);
+    return itemsWithPreview;
+  }
+
+  // Remove item being dragged out.
+  if (activeItem && Path.hasChild(path, activeItem.path) && overItem && !Path.hasChild(path, overItem.path)) {
+    return items.filter((item) => item.id !== activeItem.item.id);
+  }
+
+  return items;
+};

--- a/packages/ui/aurora-grid/src/mosaic/hooks/useMosaic.ts
+++ b/packages/ui/aurora-grid/src/mosaic/hooks/useMosaic.ts
@@ -10,6 +10,7 @@ import { MosaicContext } from '../Root';
 
 export const useMosaic = () => {
   // NOTE: Omit `containers`, for internal use only.
-  const { setContainer, activeItem, overItem } = useContext(MosaicContext) ?? raise(new Error('Missing MosaicContext'));
-  return { setContainer, activeItem, overItem };
+  const { setContainer, operation, activeItem, overItem } =
+    useContext(MosaicContext) ?? raise(new Error('Missing MosaicContext'));
+  return { setContainer, operation, activeItem, overItem };
 };

--- a/packages/ui/aurora-grid/src/mosaic/hooks/useSortedItems.ts
+++ b/packages/ui/aurora-grid/src/mosaic/hooks/useSortedItems.ts
@@ -2,50 +2,13 @@
 // Copyright 2023 DXOS.org
 //
 
-import { useMosaic } from './useMosaic';
-import { CompareMosaicDataItem, MosaicDataItem } from '../types';
-import { Path } from '../util';
+import { useContainer } from './useContainer';
+import { MosaicDataItem } from '../types';
 
 /**
- * Returns a spliced collection of items including a placeholder if items that could drop,
- * and removing any item that is currently being dragged out.
+ * Returns a sorted collection of items if a compare function is provided.
  */
-export const useSortedItems = <T extends MosaicDataItem>({
-  path,
-  items,
-  compare,
-}: {
-  path: string;
-  items: T[];
-  compare?: CompareMosaicDataItem;
-}): T[] => {
-  const { activeItem, overItem } = useMosaic();
-
-  // Insert placeholder item being dragged in.
-  // TODO(burdon): This currently isn't animated (e.g., dragging into new kanban column vs. same column).
-  if (
-    // Item is being dragged
-    activeItem &&
-    // From a different path
-    !Path.hasChild(path, activeItem.path) &&
-    // Over an item
-    overItem &&
-    // Which is this item (but only if it's not a sibling of the active item which indicates a reorder)
-    ((path === overItem.path && Path.parent(activeItem.path) !== Path.parent(overItem.path)) ||
-      // Or which is a child of this item
-      Path.hasChild(path, overItem.path))
-  ) {
-    const sortedItems = compare ? [...items].sort(compare) : [...items];
-    const position = path === overItem.path ? sortedItems.length : (overItem.position as number);
-    sortedItems.splice(position, 0, activeItem.item as T);
-    return sortedItems;
-  }
-
-  // Remove item being dragged out.
-  if (activeItem && Path.hasChild(path, activeItem.path) && overItem && !Path.hasChild(path, overItem.path)) {
-    const filteredItems = items.filter((item) => item.id !== activeItem.item.id);
-    return compare ? filteredItems.sort(compare) : filteredItems;
-  }
-
+export const useSortedItems = <T extends MosaicDataItem>(items: T[]): T[] => {
+  const { compare } = useContainer();
   return compare ? [...items].sort(compare) : items;
 };

--- a/packages/ui/aurora-grid/src/mosaic/types.ts
+++ b/packages/ui/aurora-grid/src/mosaic/types.ts
@@ -2,18 +2,12 @@
 // Copyright 2023 DXOS.org
 //
 
-export type CompareMosaicDataItem = Parameters<typeof Array.prototype.sort>[0];
-
 export type MosaicDataItem = { id: string };
 
 export type MosaicDraggedItem<TPosition = unknown> = {
   path: string;
+  // TODO(wittjosiah): Rename data? Otherwise item within item.
   item: MosaicDataItem;
   // Index or layout-specific positional information (stored separately from the item).
   position?: TPosition;
-};
-
-export type MosaicMoveEvent<TPosition = unknown> = {
-  active: MosaicDraggedItem<TPosition>;
-  over: MosaicDraggedItem<TPosition>;
 };

--- a/packages/ui/aurora-grid/src/views/Grid/Grid.stories.tsx
+++ b/packages/ui/aurora-grid/src/views/Grid/Grid.stories.tsx
@@ -30,7 +30,7 @@ export default {
     return (
       <Mosaic.Root debug={debug}>
         <Mosaic.DragOverlay />
-        <DemoGrid id='grid' size={size} initialItems={testItems} initialLayout={testLayout} debug={debug} />
+        <DemoGrid id='grid' size={size} initialItems={testItems} initialLayout={testLayout} />
       </Mosaic.Root>
     );
   },

--- a/packages/ui/aurora-grid/src/views/Grid/Grid.tsx
+++ b/packages/ui/aurora-grid/src/views/Grid/Grid.tsx
@@ -148,7 +148,6 @@ export const Grid = ({
         Component,
         getOverlayProps: () => ({ grow: true }),
         getOverlayStyle: () => getDimension(cellBounds, spacing),
-        onOver: () => true,
         onDrop,
       }}
     >

--- a/packages/ui/aurora-grid/src/views/Grid/testing.tsx
+++ b/packages/ui/aurora-grid/src/views/Grid/testing.tsx
@@ -7,7 +7,7 @@ import React, { useState } from 'react';
 
 import { Grid, GridLayout, GridProps } from './Grid';
 import { Position } from './layout';
-import { MosaicDataItem, MosaicMoveEvent } from '../../mosaic';
+import { MosaicDataItem, MosaicDropEvent } from '../../mosaic';
 import { ComplexCard, TestObjectGenerator } from '../../testing';
 
 export type DemoGridProps = GridProps & {
@@ -46,7 +46,7 @@ export const DemoGrid = ({
         }, {})),
   );
 
-  const handleDrop = ({ active, over }: MosaicMoveEvent<Position>) => {
+  const handleDrop = ({ active, over }: MosaicDropEvent<Position>) => {
     if (over.path !== id) {
       setItems((items) => items.filter((item) => item.id !== active.item.id));
     } else {

--- a/packages/ui/aurora-grid/src/views/Kanban/Kanban.stories.tsx
+++ b/packages/ui/aurora-grid/src/views/Kanban/Kanban.stories.tsx
@@ -34,7 +34,7 @@ export const Default = {
   args: {
     Component: SimpleCard,
     count: 3,
-    debug: false,
+    debug: true,
   },
 };
 

--- a/packages/ui/aurora-grid/src/views/Kanban/Kanban.tsx
+++ b/packages/ui/aurora-grid/src/views/Kanban/Kanban.tsx
@@ -50,7 +50,7 @@ export const Kanban = ({
           path === Path.create(id, item.id) ? { ...transform, y: 0 } : transform,
         // Restrict to objects from other columns.
         // TODO(burdon): Consider objects from other containers.
-        onOver: ({ active, over }) => (Path.length(active.path) >= Path.length(over.path) ? 'adopt' : 'refuse'),
+        onOver: ({ active, over }) => (Path.length(active.path) >= Path.length(over.path) ? 'adopt' : 'reject'),
         onDrop,
       }}
     >

--- a/packages/ui/aurora-grid/src/views/Kanban/Kanban.tsx
+++ b/packages/ui/aurora-grid/src/views/Kanban/Kanban.tsx
@@ -13,7 +13,7 @@ import {
   MosaicDataItem,
   MosaicTileComponent,
   Path,
-  useSortedItems,
+  useItemsWithPreview,
   useContainer,
 } from '../../mosaic';
 
@@ -50,7 +50,7 @@ export const Kanban = ({
           path === Path.create(id, item.id) ? { ...transform, y: 0 } : transform,
         // Restrict to objects from other columns.
         // TODO(burdon): Consider objects from other containers.
-        onOver: ({ active, over }) => Path.length(active.path) >= Path.length(over.path),
+        onOver: ({ active, over }) => (Path.length(active.path) >= Path.length(over.path) ? 'adopt' : 'refuse'),
         onDrop,
       }}
     >
@@ -93,7 +93,7 @@ const KanbanColumnComponent: MosaicTileComponent<KanbanColumn> = forwardRef(
   ({ path, item, isDragging, draggableStyle, draggableProps, debug }, forwardRef) => {
     const { id, title, children } = item;
     const { Component } = useContainer();
-    const sortedItems = useSortedItems({ path, items: children });
+    const itemsWithPreview = useItemsWithPreview({ path, items: children });
 
     return (
       <div role='none' className='grow flex flex-col' ref={forwardRef}>
@@ -115,8 +115,8 @@ const KanbanColumnComponent: MosaicTileComponent<KanbanColumn> = forwardRef(
 
           <div className={mx('flex flex-col grow overflow-y-scroll')}>
             <div className='flex flex-col my-1'>
-              <Mosaic.SortableContext id={path} items={sortedItems} direction='vertical'>
-                {sortedItems.map((item, index) => (
+              <Mosaic.SortableContext id={path} items={itemsWithPreview} direction='vertical'>
+                {itemsWithPreview.map((item, index) => (
                   <Mosaic.SortableTile
                     key={item.id}
                     item={item}
@@ -130,7 +130,7 @@ const KanbanColumnComponent: MosaicTileComponent<KanbanColumn> = forwardRef(
               </Mosaic.SortableContext>
             </div>
           </div>
-          {debug && <Mosaic.Debug data={{ path, id, items: sortedItems.length }} />}
+          {debug && <Mosaic.Debug data={{ path, id, items: itemsWithPreview.length }} />}
         </div>
       </div>
     );

--- a/packages/ui/aurora-grid/src/views/Kanban/testing.tsx
+++ b/packages/ui/aurora-grid/src/views/Kanban/testing.tsx
@@ -12,7 +12,7 @@ import { Schema, TypedObject, useQuery, useSpace } from '@dxos/react-client/echo
 import { arrayMove } from '@dxos/util';
 
 import { Kanban, KanbanColumn, KanbanProps } from './Kanban';
-import { Mosaic, MosaicMoveEvent, Path, swapItems } from '../../mosaic';
+import { Mosaic, MosaicDropEvent, Path, swapItems } from '../../mosaic';
 import { TestObjectGenerator, SimpleCard, Priority, Status, TestItem } from '../../testing';
 
 const createKanban = ({ types, columns = 3 }: { types?: string[]; columns?: number }) => {
@@ -44,7 +44,7 @@ export const DemoKanban: FC<DemoKanbanProps> = ({
   // };
 
   // TODO(burdon): Reconcile with DemoKanban.
-  const handleDrop = ({ active, over }: MosaicMoveEvent<number>) => {
+  const handleDrop = ({ active, over }: MosaicDropEvent<number>) => {
     // Reorder columns.
     // TODO(burdon): Buggy dragging empty column.
     if (active.path === Path.create(id, active.item.id)) {
@@ -146,7 +146,7 @@ export const EchoKanban = ({
   };
 
   // TODO(burdon): Currently broken: factor out with demo story.
-  const handleDrop = ({ active, over }: MosaicMoveEvent) => {
+  const handleDrop = ({ active, over }: MosaicDropEvent<number>) => {
     // Reorder columns.
     // TODO(burdon): Factor out util.
     if (active.path === Path.create(id, active.item.id)) {

--- a/packages/ui/aurora-grid/src/views/Stack/Columns.stories.tsx
+++ b/packages/ui/aurora-grid/src/views/Stack/Columns.stories.tsx
@@ -36,7 +36,7 @@ export default {
   },
 };
 
-export const Move = {
+export const Adopt = {
   args: {
     Component: SimpleCard,
     debug: true,
@@ -52,10 +52,10 @@ export const Copy = {
   },
 };
 
-export const Disallow = {
+export const Refuse = {
   args: {
     Component: SimpleCard,
     debug: true,
-    behavior: 'disallow',
+    behavior: 'refuse',
   },
 };

--- a/packages/ui/aurora-grid/src/views/Stack/Columns.stories.tsx
+++ b/packages/ui/aurora-grid/src/views/Stack/Columns.stories.tsx
@@ -52,10 +52,10 @@ export const Copy = {
   },
 };
 
-export const Refuse = {
+export const Reject = {
   args: {
     Component: SimpleCard,
     debug: true,
-    behavior: 'refuse',
+    behavior: 'reject',
   },
 };

--- a/packages/ui/aurora-grid/src/views/Stack/Stack.stories.tsx
+++ b/packages/ui/aurora-grid/src/views/Stack/Stack.stories.tsx
@@ -23,7 +23,7 @@ export default {
     },
   ) => {
     return (
-      <Mosaic.Root>
+      <Mosaic.Root debug={args.debug}>
         <Mosaic.DragOverlay />
         <DemoStack {...args} />
       </Mosaic.Root>

--- a/packages/ui/aurora-grid/src/views/Stack/Stack.tsx
+++ b/packages/ui/aurora-grid/src/views/Stack/Stack.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { mx } from '@dxos/aurora-theme';
 
-import { Mosaic, MosaicContainerProps, MosaicDataItem, useSortedItems } from '../../mosaic';
+import { Mosaic, MosaicContainerProps, MosaicDataItem, useItemsWithPreview } from '../../mosaic';
 
 export type Direction = 'horizontal' | 'vertical';
 
@@ -26,11 +26,11 @@ export const Stack = ({
   direction = 'vertical',
   debug,
 }: StackProps) => {
-  const sortedItems = useSortedItems({ path: id, items });
+  const itemsWithPreview = useItemsWithPreview({ path: id, items });
 
   return (
     <Mosaic.Container {...{ id, Component, onOver, onDrop }}>
-      <Mosaic.SortableContext items={sortedItems} direction={direction}>
+      <Mosaic.SortableContext items={itemsWithPreview} direction={direction}>
         <div className={mx('flex overflow-hidden', direction === 'vertical' && 'w-[300px]')}>
           <div
             className={mx(
@@ -39,7 +39,7 @@ export const Stack = ({
             )}
           >
             <div className={mx('flex', direction === 'vertical' && 'flex-col')}>
-              {sortedItems.map((item, index) => (
+              {itemsWithPreview.map((item, index) => (
                 <Mosaic.SortableTile
                   key={item.id}
                   item={item}
@@ -54,7 +54,7 @@ export const Stack = ({
 
             {debug && (
               <div className='grow'>
-                <Mosaic.Debug data={{ id, items: sortedItems.length }} />
+                <Mosaic.Debug data={{ id, items: itemsWithPreview.length }} />
               </div>
             )}
           </div>

--- a/packages/ui/aurora-grid/src/views/Stack/testing.tsx
+++ b/packages/ui/aurora-grid/src/views/Stack/testing.tsx
@@ -32,8 +32,8 @@ export const DemoStack = ({
 
   const handleOver = ({ active, over }: MosaicMoveEvent<number>) => {
     // TODO(wittjosiah): Items is stale here for some inexplicable reason, so ref helps.
-    if (behavior === 'refuse') {
-      return 'refuse';
+    if (behavior === 'reject') {
+      return 'reject';
     }
 
     const exists = itemsRef.current.findIndex((item) => item.id === active.item.id) >= 0;
@@ -41,7 +41,7 @@ export const DemoStack = ({
     if (!exists) {
       return behavior;
     } else {
-      return 'refuse';
+      return 'reject';
     }
   };
 

--- a/packages/ui/aurora-grid/src/views/Stack/testing.tsx
+++ b/packages/ui/aurora-grid/src/views/Stack/testing.tsx
@@ -5,13 +5,13 @@
 import React, { useRef, useState } from 'react';
 
 import { Stack, StackProps } from './Stack';
-import { MosaicDataItem, MosaicMoveEvent, Path } from '../../mosaic';
+import { MosaicDataItem, MosaicDropEvent, MosaicMoveEvent, MosaicOperation, Path } from '../../mosaic';
 import { TestObjectGenerator } from '../../testing';
 
 export type DemoStackProps = StackProps & {
   types?: string[];
   count?: number;
-  behavior?: 'move' | 'copy' | 'disallow';
+  behavior?: MosaicOperation;
 };
 
 export const DemoStack = ({
@@ -20,7 +20,7 @@ export const DemoStack = ({
   types,
   count = 8,
   direction = 'vertical',
-  behavior = 'move',
+  behavior = 'adopt',
   debug,
 }: DemoStackProps) => {
   const [items, setItems] = useState<MosaicDataItem[]>(() => {
@@ -31,19 +31,25 @@ export const DemoStack = ({
   const itemsRef = useRef(items);
 
   const handleOver = ({ active, over }: MosaicMoveEvent<number>) => {
-    return (
-      // TODO(wittjosiah): Items is stale here for some inexplicable reason, so ref helps.
-      (itemsRef.current.findIndex((item) => item.id === active.item.id) === -1 ||
-        Path.parent(active.path) === Path.parent(over.path)) &&
-      (active.path === id || behavior !== 'disallow')
-    );
+    // TODO(wittjosiah): Items is stale here for some inexplicable reason, so ref helps.
+    if (behavior === 'refuse') {
+      return 'refuse';
+    }
+
+    const exists = itemsRef.current.findIndex((item) => item.id === active.item.id) >= 0;
+
+    if (!exists) {
+      return behavior;
+    } else {
+      return 'refuse';
+    }
   };
 
-  const handleDrop = ({ active, over }: MosaicMoveEvent<number>) => {
+  const handleDrop = ({ operation, active, over }: MosaicDropEvent<number>) => {
     setItems((items) => {
       if (
         active.path === Path.create(id, active.item.id) &&
-        (behavior !== 'copy' || over.path === Path.create(id, over.item.id))
+        (operation !== 'copy' || over.path === Path.create(id, over.item.id))
       ) {
         items.splice(active.position!, 1);
       }

--- a/packages/ui/aurora-grid/src/views/Tree/Tree.tsx
+++ b/packages/ui/aurora-grid/src/views/Tree/Tree.tsx
@@ -15,8 +15,8 @@ import {
   useContainer,
   useMosaic,
   Path,
-  CompareMosaicDataItem,
   useSortedItems,
+  MosaicCompareDataItem,
 } from '../../mosaic';
 
 // TODO(burdon): Tree data model that provides a pure abstraction of the plugin Graph.
@@ -27,7 +27,7 @@ import {
 export type TreeProps<TData extends MosaicDataItem = TreeData> = MosaicContainerProps<TData, number> & {
   items?: TData[];
   debug?: boolean;
-  compare?: CompareMosaicDataItem;
+  compare?: MosaicCompareDataItem;
 };
 
 export type TreeData = {
@@ -38,27 +38,35 @@ export type TreeData = {
 
 // TODO(burdon): Make generic (and forwardRef).
 export const Tree = ({ id, Component = TreeItem, onOver, onDrop, items = [], debug, compare }: TreeProps) => {
-  const sortedItems = useSortedItems({ path: id, items, compare });
+  return (
+    <Mosaic.Container
+      {...{
+        id,
+        debug,
+        Component,
+        onOver,
+        onDrop,
+        compare,
+      }}
+    >
+      <TreeRoot items={items} />
+    </Mosaic.Container>
+  );
+};
+
+const TreeRoot = ({ items }: { items: TreeData[] }) => {
+  const { id, Component } = useContainer();
+  const sortedItems = useSortedItems(items);
 
   return (
     <TreeComponent.Root classNames='flex flex-col'>
-      <Mosaic.Container
-        {...{
-          id,
-          debug,
-          Component,
-          onOver,
-          onDrop,
-        }}
-      >
-        <Mosaic.SortableContext id={id} items={items} direction='vertical'>
-          {sortedItems.map((item, index) => (
-            <TreeItemComponent.Root key={item.id} collapsible defaultOpen>
-              <Mosaic.SortableTile item={item} path={id} position={index} Component={Component} compare={compare} />
-            </TreeItemComponent.Root>
-          ))}
-        </Mosaic.SortableContext>
-      </Mosaic.Container>
+      <Mosaic.SortableContext id={id} items={items} direction='vertical'>
+        {sortedItems.map((item, index) => (
+          <TreeItemComponent.Root key={item.id} collapsible defaultOpen>
+            <Mosaic.SortableTile item={item} path={id} position={index} Component={Component!} />
+          </TreeItemComponent.Root>
+        ))}
+      </Mosaic.SortableContext>
     </TreeComponent.Root>
   );
 };
@@ -67,30 +75,36 @@ export const Tree = ({ id, Component = TreeItem, onOver, onDrop, items = [], deb
  * Pure component that is used by the mosaic overlay.
  */
 const TreeItem: MosaicTileComponent<TreeData> = forwardRef(
-  ({ path, draggableStyle, draggableProps, item, isActive, isOver, isDragging, className, compare }, forwardedRef) => {
+  (
+    { path, draggableStyle, draggableProps, item, operation, isActive, isOver, isDragging, className },
+    forwardedRef,
+  ) => {
     return (
       <div
         ref={forwardedRef}
         style={draggableStyle}
-        className={mx('flex flex-col rounded', className, isDragging && 'opacity-0', isOver && dropRing)}
+        className={mx(
+          'flex flex-col rounded',
+          className,
+          isDragging && 'opacity-0',
+          isOver && (operation === 'adopt' || operation === 'copy') && dropRing,
+        )}
       >
         <Card.Header>
           <Card.DragHandle {...draggableProps} />
           <Card.Title title={item.label ?? path} classNames='truncate' />
         </Card.Header>
 
-        {!isActive && !isDragging && item.children && (
-          <TreeBranch path={path} items={item.children} compare={compare} />
-        )}
+        {!isActive && !isDragging && item.children && <TreeBranch path={path} items={item.children} />}
       </div>
     );
   },
 );
 
-const TreeBranch = ({ path, items, compare }: { path: string; items: TreeData[]; compare?: CompareMosaicDataItem }) => {
+const TreeBranch = ({ path, items }: { path: string; items: TreeData[] }) => {
   const { overItem } = useMosaic();
   const { Component } = useContainer();
-  const sortedItems = useSortedItems({ path, items, compare });
+  const sortedItems = useSortedItems(items);
 
   return (
     <TreeItemComponent.Body className='pis-4'>
@@ -103,7 +117,6 @@ const TreeBranch = ({ path, items, compare }: { path: string; items: TreeData[];
                 path={path}
                 position={index}
                 Component={Component!}
-                compare={compare}
                 isOver={overItem?.path === Path.create(path, child.id)}
               />
             </TreeItemComponent.Root>

--- a/packages/ui/aurora-grid/src/views/Tree/Tree.tsx
+++ b/packages/ui/aurora-grid/src/views/Tree/Tree.tsx
@@ -60,7 +60,7 @@ const TreeRoot = ({ items }: { items: TreeData[] }) => {
 
   return (
     <TreeComponent.Root classNames='flex flex-col'>
-      <Mosaic.SortableContext id={id} items={items} direction='vertical'>
+      <Mosaic.SortableContext id={id} items={sortedItems} direction='vertical'>
         {sortedItems.map((item, index) => (
           <TreeItemComponent.Root key={item.id} collapsible defaultOpen>
             <Mosaic.SortableTile item={item} path={id} position={index} Component={Component!} />
@@ -108,7 +108,7 @@ const TreeBranch = ({ path, items }: { path: string; items: TreeData[] }) => {
 
   return (
     <TreeItemComponent.Body className='pis-4'>
-      <Mosaic.SortableContext id={path} items={items} direction='vertical'>
+      <Mosaic.SortableContext id={path} items={sortedItems} direction='vertical'>
         {sortedItems.map((child, index) => (
           <TreeComponent.Branch key={child.id}>
             <TreeItemComponent.Root collapsible defaultOpen>

--- a/packages/ui/aurora-grid/src/views/Tree/testing.tsx
+++ b/packages/ui/aurora-grid/src/views/Tree/testing.tsx
@@ -136,7 +136,7 @@ export const GraphTree = ({ id, graph = createGraph(), debug }: { id: string; gr
         operation === 'rearrange'
       ) {
         // This is a rearrange operation
-        const nextIndex = nextRearrangeIndex(activeParent.children, activeNode.id, overNode.id);
+        const nextIndex = nextRearrangeIndex(activeParent.children.sort(graphNodeCompare), activeNode.id, overNode.id);
         console.log({ nextIndex });
         activeNode.properties.index = nextIndex ?? 'a0';
       } else if (activeNode && activeParent && overParent && operation === 'adopt') {

--- a/packages/ui/aurora-grid/src/views/Tree/testing.tsx
+++ b/packages/ui/aurora-grid/src/views/Tree/testing.tsx
@@ -48,7 +48,7 @@ export const DemoTree = ({ id = 'tree', initialItems, types, debug }: DemoTreePr
   );
 
   const handleOver = useCallback(({ active, over }: MosaicMoveEvent<number>) => {
-    return !(active.path === id && over.path !== id) ? 'adopt' : 'refuse';
+    return !(active.path === id && over.path !== id) ? 'adopt' : 'reject';
   }, []);
 
   // NOTE: Does not handle deep operations.
@@ -119,7 +119,6 @@ const graphNodeCompare = (a: Node, b: Node) => {
 export const GraphTree = ({ id, graph = createGraph(), debug }: { id: string; graph?: Graph; debug: boolean }) => {
   // TODO(wittjosiah): This graph does not handle order currently.
   const handleDrop = ({ operation, active, over }: MosaicDropEvent<number>) => {
-    console.log({ operation, active, over });
     // Moving within the tree.
     if (Path.hasDescendent(id, active.path) && Path.hasDescendent(id, over.path)) {
       const activeNode = graph.findNode(active.item.id);
@@ -137,7 +136,6 @@ export const GraphTree = ({ id, graph = createGraph(), debug }: { id: string; gr
       ) {
         // This is a rearrange operation
         const nextIndex = nextRearrangeIndex(activeParent.children.sort(graphNodeCompare), activeNode.id, overNode.id);
-        console.log({ nextIndex });
         activeNode.properties.index = nextIndex ?? 'a0';
       } else if (activeNode && activeParent && overParent && operation === 'adopt') {
         activeParent.removeNode(active.item.id);
@@ -150,7 +148,6 @@ export const GraphTree = ({ id, graph = createGraph(), debug }: { id: string; gr
     <Tree
       id={id}
       items={graph.root.children as TreeData[]}
-      // onOver={handleOver}
       onDrop={handleDrop}
       debug={debug}
       compare={graphNodeCompare}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 376267f</samp>

### Summary
🎨🚀🧹

<!--
1.  🎨 - This emoji represents the changes related to the visual appearance and rendering of the grid components, such as adding the debug overlay, the preview item, and the different mosaic operations.
2.  🚀 - This emoji represents the changes related to the performance and functionality of the grid components, such as adding the custom sorting and the drag and drop operations.
3.  🧹 - This emoji represents the changes related to the code quality and maintenance of the grid components, such as removing unused props and types, simplifying import statements, and renaming variables.
-->
This pull request adds support for different drag and drop operations and custom sorting of items in the `aurora-grid` package. It introduces a new hook called `useItemsWithPreview` that handles the preview and rearrangement of items in the mosaic container. It also updates the `Stack`, `Grid`, and `Kanban` views and their stories to use the new hook and the `MosaicOperation` type. It removes some unused types and props and simplifies some import statements. It enables the debug overlay for some stories to demonstrate the new features.

> _`Mosaic` changes_
> _Drag and drop with preview_
> _Autumn leaves sorting_

### Walkthrough
*  Add new types and re-export them from the `Mosaic` namespace to support different drag and drop operations and sorting of items within containers ([link](https://github.com/dxos/dxos/pull/4417/files?diff=unified&w=0#diff-a0e23bacd3ccca35f5d39c83197975c8ffee79617a575fe0c46e30857ff41611L7-R14),[link](https://github.com/dxos/dxos/pull/4417/files?diff=unified&w=0#diff-a0e23bacd3ccca35f5d39c83197975c8ffee79617a575fe0c46e30857ff41611R72-R77),[link](https://github.com/dxos/dxos/pull/4417/files?diff=unified&w=0#diff-4788a5361aafa9aeeacdf5855fff3169f4ca6aae20b4b20981fe528650fe0a01R17-R29),[link](https://github.com/dxos/dxos/pull/4417/files?diff=unified&w=0#diff-e88f8f7ff7854dedcd54d6c50fadd0ab5ecc58ac56aa3341711d716bb0ab0820R6),[link](https://github.com/dxos/dxos/pull/4417/files?diff=unified&w=0#diff-6946803befd05be24ba6f76d2ed0391c382c98f0cb00e506c885e07b2e80b15dL5-R13)).


