### PR TITLE
feat: Fix schema for chess plugin.

### DIFF
--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -61,8 +61,7 @@ const main = async () => {
           ErrorPlugin(),
           IntentPlugin(),
           GraphPlugin(),
-          // TODO(burdon): Broken if services are not provided.
-          ClientPlugin({ config, services, schema: types }),
+          ClientPlugin({ config, services, types }),
 
           // Core UX.
           DndPlugin(),

--- a/packages/apps/labs-app/src/main.tsx
+++ b/packages/apps/labs-app/src/main.tsx
@@ -94,7 +94,7 @@ const main = async () => {
           ErrorPlugin(),
           IntentPlugin(),
           GraphPlugin(),
-          ClientPlugin({ config, services, debugIdentity: debug, schema: types }),
+          ClientPlugin({ config, services, debugIdentity: debug, types }),
 
           // Core UX.
           DndPlugin(),

--- a/packages/apps/plugins/plugin-chess/src/ChessPlugin.tsx
+++ b/packages/apps/plugins/plugin-chess/src/ChessPlugin.tsx
@@ -5,11 +5,12 @@
 import { Plus } from '@phosphor-icons/react';
 import React from 'react';
 
+import { CLIENT_PLUGIN, type ClientPluginProvides } from '@braneframe/plugin-client';
 import { GraphNodeAdapter, SpaceAction } from '@braneframe/plugin-space';
 import { SplitViewAction } from '@braneframe/plugin-splitview';
-import { Game } from '@dxos/chess-app';
+import { Game, types } from '@dxos/chess-app';
 import { SpaceProxy } from '@dxos/client/echo';
-import { type PluginDefinition } from '@dxos/react-surface';
+import { type PluginDefinition, findPlugin } from '@dxos/react-surface';
 
 import { ChessMain } from './components';
 import translations from './translations';
@@ -22,6 +23,11 @@ export const ChessPlugin = (): PluginDefinition<ChessPluginProvides> => {
   return {
     meta: {
       id: CHESS_PLUGIN,
+    },
+    ready: async (plugins) => {
+      const clientPlugin = findPlugin<ClientPluginProvides>(plugins, CLIENT_PLUGIN);
+      const client = clientPlugin?.provides?.client;
+      client?.addSchema(types);
     },
     unload: async () => {
       adapter.clear();

--- a/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
+++ b/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
@@ -15,12 +15,14 @@ import { type PluginDefinition } from '@dxos/react-surface';
 
 import { type ClientPluginProvides, CLIENT_PLUGIN } from './types';
 
-export type ClientPluginOptions = ClientOptions & { debugIdentity?: boolean; schema?: TypeCollection };
+export type ClientPluginOptions = ClientOptions & { debugIdentity?: boolean; types?: TypeCollection };
 
 export const ClientPlugin = (
   options: ClientPluginOptions = { config: new Config(Envs(), Local(), Defaults()) },
 ): PluginDefinition<{}, ClientPluginProvides> => {
+  // TODO(burdon): Document.
   registerSignalFactory();
+
   const client = new Client(options);
 
   return {
@@ -32,8 +34,8 @@ export const ClientPlugin = (
       let error: unknown = null;
 
       try {
-        if (options.schema) {
-          client.addSchema(options.schema);
+        if (options.types) {
+          client.addTypes(options.types);
         }
 
         await client.initialize();

--- a/packages/core/echo/echo-schema/src/hyper-graph.ts
+++ b/packages/core/echo/echo-schema/src/hyper-graph.ts
@@ -24,8 +24,8 @@ export class HyperGraph {
     return this._types;
   }
 
-  addTypes(schema: TypeCollection) {
-    this._types.mergeSchema(schema);
+  addTypes(types: TypeCollection) {
+    this._types.mergeSchema(types);
     return this;
   }
 

--- a/packages/core/echo/echo-schema/src/type-collection.ts
+++ b/packages/core/echo/echo-schema/src/type-collection.ts
@@ -22,7 +22,7 @@ export class TypeCollection {
 
   mergeSchema(schema: TypeCollection) {
     Array.from(schema._prototypes.entries()).forEach(([name, prototype]) => {
-      invariant(!this._prototypes.has(name), 'Names collision');
+      invariant(!this._prototypes.has(name), `Schema already exists: ${name}`);
       this._prototypes.set(name, prototype);
     });
   }
@@ -49,12 +49,12 @@ export class TypeCollection {
     }
 
     if (this._types.size !== 0) {
-      throw new Error('Already linked');
+      throw new Error('Already linked.');
     }
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { Schema } = require('./proto');
-    invariant(Schema, 'Circular dependency error');
+    invariant(Schema, 'Circular dependency.');
 
     // Create immutable schema objects.
     for (const def of this._schemaDefs.values()) {

--- a/packages/sdk/client/src/client/client.ts
+++ b/packages/sdk/client/src/client/client.ts
@@ -92,8 +92,8 @@ export class Client {
       log.config({ filter, prefix });
     }
 
-    this.addSchema(schemaBuiltin);
-    this.addSchema(clientSchema);
+    this.addTypes(schemaBuiltin);
+    this.addTypes(clientSchema);
   }
 
   [inspect.custom]() {
@@ -313,8 +313,14 @@ export class Client {
   }
 
   // TODO(dmaretskyi): Expose `graph` directly?
-  // TODO(dmaretskyi): Rename to add types.
-  addSchema(schema: TypeCollection) {
-    this._graph.addTypes(schema);
+  addTypes(types: TypeCollection) {
+    this._graph.addTypes(types);
+  }
+
+  /**
+   * @deprecated Replaced by addTypes.
+   */
+  addSchema(types: TypeCollection) {
+    this.addTypes(types);
   }
 }

--- a/packages/sdk/client/src/tests/spaces.test.ts
+++ b/packages/sdk/client/src/tests/spaces.test.ts
@@ -447,8 +447,8 @@ describe('Spaces', () => {
     const host = new Client({ services: testBuilder.createLocal() });
     const guest = new Client({ services: testBuilder.createLocal() });
 
-    host.addSchema(types);
-    guest.addSchema(types);
+    host.addTypes(types);
+    guest.addTypes(types);
 
     await host.initialize();
     await guest.initialize();


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 56f4dcf</samp>

### Summary
🚚🛠️🧩

<!--
1.  🚚 This emoji means "moving" or "renaming" and can be used to indicate that some arguments, methods, or variables were renamed for clarity or consistency.
2.  🛠️ This emoji means "fixing" or "improving" and can be used to indicate that some functionality or error handling was enhanced or refined.
3.  🧩 This emoji means "connecting" or "integrating" and can be used to indicate that some components or modules were linked or registered with each other.
-->
Renamed `schema` to `types` in various classes and methods related to graph data, to avoid confusion with GraphQL schema and to be consistent with the `chess-app` package. Added a `ready` function to the `ChessPlugin` to register the chess game schema. Improved error handling and messaging in `TypeCollection`.

> _Sing, O Muse, of the mighty deeds of the coders_
> _Who labored on the client plugin, the source of many types_
> _And how they changed the names of arguments and methods_
> _To match the logic of their schemas, the models of their graphs_

### Walkthrough
*  Rename `schema` to `types` in several files and methods to avoid confusion and improve consistency ([link](https://github.com/dxos/dxos/pull/4433/files?diff=unified&w=0#diff-9f2aee287f92edd662c13bed460a28a1590c9186b62c98ccc2e00f6877c3d7e6L64-R64), [link](https://github.com/dxos/dxos/pull/4433/files?diff=unified&w=0#diff-9d663519e7a46a19fe4305c8085aa017f51355119fb0fbe545eb37ab8492722cL97-R97), [link](https://github.com/dxos/dxos/pull/4433/files?diff=unified&w=0#diff-2980bfaacf44efa379f06240cc85cd206bc5b09d919e1ecfb8b170c6c4d08cfdL18-R25), [link](https://github.com/dxos/dxos/pull/4433/files?diff=unified&w=0#diff-2980bfaacf44efa379f06240cc85cd206bc5b09d919e1ecfb8b170c6c4d08cfdL35-R38), [link](https://github.com/dxos/dxos/pull/4433/files?diff=unified&w=0#diff-093916b4db3aa4169c44ecad336ef7e6989bb9f07cf48a2b499d899b4cf2f8f2L27-R28), [link](https://github.com/dxos/dxos/pull/4433/files?diff=unified&w=0#diff-785917a9d319e96d99ca9d7921879288a3b0921055c1cb6e0db85a7cc63d2d1bL95-R96), [link](https://github.com/dxos/dxos/pull/4433/files?diff=unified&w=0#diff-785917a9d319e96d99ca9d7921879288a3b0921055c1cb6e0db85a7cc63d2d1bL316-R325), [link](https://github.com/dxos/dxos/pull/4433/files?diff=unified&w=0#diff-e80f58650d2ce2f86fe95fd5e364a115f73b8ab6e659b6e3da2c3058800535eeL450-R451)).


