### PR TITLE
feat: Cross-space references

### DIFF
--- a/packages/core/echo/echo-schema/src/array.ts
+++ b/packages/core/echo/echo-schema/src/array.ts
@@ -341,7 +341,7 @@ export class EchoArray<T> implements Array<T> {
 
   private _decode(value: any): T | undefined {
     if (value instanceof Reference) {
-      return this._object!._lookupLink(value.itemId) as T | undefined;
+      return this._object!._lookupLink(value) as T | undefined;
     } else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
       return decodeRecords(value, this._object!);
     } else {
@@ -351,8 +351,7 @@ export class EchoArray<T> implements Array<T> {
 
   private _encode(value: T) {
     if (value instanceof EchoObjectBase) {
-      void this._object!._linkObject(value);
-      return new Reference(value.id);
+      return this._object!._linkObject(value);
     } else if (
       typeof value === 'object' &&
       value !== null &&
@@ -427,8 +426,7 @@ export class EchoArray<T> implements Array<T> {
 
 const encodeRecords = (value: any, document: TypedObject): any => {
   if (value instanceof EchoObjectBase) {
-    void document!._linkObject(value);
-    return new Reference(value.id);
+    return document!._linkObject(value);
   } else if (Array.isArray(value)) {
     return value.map((value) => encodeRecords(value, document));
   } else if (typeof value === 'object') {
@@ -441,7 +439,7 @@ const encodeRecords = (value: any, document: TypedObject): any => {
 
 const decodeRecords = (value: any, document: TypedObject): any => {
   if (value instanceof Reference) {
-    return document._lookupLink(value.itemId);
+    return document._lookupLink(value);
   } else if (Array.isArray(value)) {
     return value.map((value) => decodeRecords(value, document));
   } else if (typeof value === 'object') {

--- a/packages/core/echo/echo-schema/src/database.ts
+++ b/packages/core/echo/echo-schema/src/database.ts
@@ -63,9 +63,6 @@ export class EchoDatabase {
     return Array.from(this._objects.values());
   }
 
-  /**
-   * @deprecated
-   */
   get graph() {
     return this._graph;
   }

--- a/packages/core/echo/echo-schema/src/database.ts
+++ b/packages/core/echo/echo-schema/src/database.ts
@@ -56,6 +56,8 @@ export class EchoDatabase {
     private readonly _graph: HyperGraph,
   ) {
     this._backend.itemUpdate.on(this._update.bind(this));
+
+    // Load all existing objects.
     this._update(new UpdateEvent(this._backend.spaceKey)); // TODO: Seems hacky.
   }
 

--- a/packages/core/echo/echo-schema/src/echo-object-base.ts
+++ b/packages/core/echo/echo-schema/src/echo-object-base.ts
@@ -114,6 +114,10 @@ export abstract class EchoObjectBase<T extends Model = any> implements EchoObjec
    * @internal
    */
   _itemUpdate(): void {
+    this._emitUpdate();
+  }
+
+  protected _emitUpdate(): void {
     for (const callback of this._callbacks) {
       callback(this);
     }

--- a/packages/core/echo/echo-schema/src/hyper-graph.test.ts
+++ b/packages/core/echo/echo-schema/src/hyper-graph.test.ts
@@ -7,9 +7,9 @@ import { expect } from 'chai';
 import { PublicKey } from '@dxos/keys';
 import { describe, test } from '@dxos/test';
 
+import { subscribe } from './defs';
 import { TestBuilder } from './testing';
 import { Expando } from './typed-object';
-import { subscribe } from './defs';
 
 describe('HyperGraph', () => {
   test('cross-space query', async () => {
@@ -92,13 +92,13 @@ describe('HyperGraph', () => {
 
     obj1.link = obj2;
     expect(obj1.link.title).to.eq('B');
-    
+
     await builder.flushAll();
     expect(obj1.link.title).to.eq('B');
 
     await space1.reload();
     expect(obj1.link.title).to.eq('B');
-  })
+  });
 
   test('cross-space references get resolved on database load', async () => {
     const builder = new TestBuilder();
@@ -127,10 +127,12 @@ describe('HyperGraph', () => {
     expect(obj1.link).to.eq(undefined);
 
     let called = false;
-    obj1[subscribe](() => { called = true });
+    obj1[subscribe](() => {
+      called = true;
+    });
 
     await space2.reload();
     expect(obj1.link.title).to.eq('B');
     expect(called).to.eq(true);
-  })
+  });
 });

--- a/packages/core/echo/echo-schema/src/hyper-graph.test.ts
+++ b/packages/core/echo/echo-schema/src/hyper-graph.test.ts
@@ -68,4 +68,34 @@ describe('HyperGraph', () => {
     expect(updated).to.eq(true);
     expect(query.objects.map((obj) => obj.id)).to.deep.eq([obj1.id, obj3.id]);
   });
+
+  test('cross-space references', async () => {
+    const builder = new TestBuilder();
+    const [spaceKey1, spaceKey2] = PublicKey.randomSequence();
+
+    const space1 = await builder.createPeer(spaceKey1);
+    const space2 = await builder.createPeer(spaceKey2);
+
+    const obj1 = space1.db.add(
+      new Expando({
+        type: 'task',
+        title: 'A',
+      }),
+    );
+    const obj2 = space2.db.add(
+      new Expando({
+        type: 'task',
+        title: 'B',
+      }),
+    );
+
+    obj1.link = obj2;
+    expect(obj1.link.title).to.eq('B');
+    
+    await builder.flushAll();
+    expect(obj1.link.title).to.eq('B');
+
+    await space1.reload();
+    expect(obj1.link.title).to.eq('B');
+  })
 });

--- a/packages/core/echo/echo-schema/src/testing.ts
+++ b/packages/core/echo/echo-schema/src/testing.ts
@@ -65,7 +65,11 @@ export class TestBuilder {
 export class TestPeer {
   public db = new EchoDatabase(this.base.items, this.base.proxy, this.builder.graph);
 
-  constructor(public readonly builder: TestBuilder, public readonly base: BasePeer, public readonly spaceKey: PublicKey) {}
+  constructor(
+    public readonly builder: TestBuilder,
+    public readonly base: BasePeer,
+    public readonly spaceKey: PublicKey,
+  ) {}
 
   async reload() {
     await this.base.reload();

--- a/packages/core/echo/echo-schema/src/testing.ts
+++ b/packages/core/echo/echo-schema/src/testing.ts
@@ -49,7 +49,7 @@ export class TestBuilder {
 
   async createPeer(spaceKey = this.defaultSpaceKey): Promise<TestPeer> {
     const base = await this.base.createPeer(spaceKey);
-    const peer = new TestPeer(this, base);
+    const peer = new TestPeer(this, base, spaceKey);
     this.peers.set(peer.base.key, peer);
     this.graph._register(spaceKey, peer.db);
     return peer;
@@ -65,11 +65,12 @@ export class TestBuilder {
 export class TestPeer {
   public db = new EchoDatabase(this.base.items, this.base.proxy, this.builder.graph);
 
-  constructor(public readonly builder: TestBuilder, public readonly base: BasePeer) {}
+  constructor(public readonly builder: TestBuilder, public readonly base: BasePeer, public readonly spaceKey: PublicKey) {}
 
   async reload() {
     await this.base.reload();
     this.db = new EchoDatabase(this.base.items, this.base.proxy, this.builder.graph);
+    this.builder.graph._register(this.spaceKey, this.db);
   }
 
   async flush() {

--- a/packages/core/echo/echo-schema/src/testing.ts
+++ b/packages/core/echo/echo-schema/src/testing.ts
@@ -73,6 +73,10 @@ export class TestPeer {
     this.builder.graph._register(this.spaceKey, this.db);
   }
 
+  async unload() {
+    this.builder.graph._unregister(this.spaceKey);
+  }
+
   async flush() {
     if (this.db._backend.currentBatch) {
       this.db._backend.commitBatch();

--- a/packages/core/echo/echo-schema/src/typed-object.ts
+++ b/packages/core/echo/echo-schema/src/typed-object.ts
@@ -487,21 +487,20 @@ class TypedObjectImpl<T> extends EchoObjectBase<DocumentModel> implements TypedO
    */
   _linkObject(obj: EchoObjectBase): Reference {
     if (this._database) {
-      if(!obj[base]._database) {
+      if (!obj[base]._database) {
         this._database.add(obj as TypedObject);
-        return new Reference(obj.id)
+        return new Reference(obj.id);
       } else {
-        if(obj[base]._database !== this._database) {
+        if (obj[base]._database !== this._database) {
           return new Reference(obj.id, undefined, obj[base]._database._backend.spaceKey.toHex());
         } else {
-          return new Reference(obj.id)
+          return new Reference(obj.id);
         }
       }
-
     } else {
       invariant(this._linkCache);
       this._linkCache.set(obj.id, obj);
-      return new Reference(obj.id)
+      return new Reference(obj.id);
     }
   }
 
@@ -522,7 +521,7 @@ class TypedObjectImpl<T> extends EchoObjectBase<DocumentModel> implements TypedO
   private _onLinkResolved = () => {
     this._signal?.notifyWrite();
     this._emitUpdate();
-  }
+  };
 }
 
 // Set stringified name for constructor.

--- a/packages/core/echo/echo-schema/src/typed-object.ts
+++ b/packages/core/echo/echo-schema/src/typed-object.ts
@@ -227,7 +227,7 @@ class TypedObjectImpl<T> extends EchoObjectBase<DocumentModel> implements TypedO
     if (value instanceof EchoObjectBase) {
       return visitorsWithDefaults.onRef!(value.id, value);
     } else if (value instanceof Reference) {
-      return visitorsWithDefaults.onRef!(value.itemId, this._lookupLink(value.itemId));
+      return visitorsWithDefaults.onRef!(value.itemId, this._lookupLink(value));
     } else if (value instanceof OrderedArray) {
       return value.toArray().map(convert);
     } else if (value instanceof EchoArray) {
@@ -292,7 +292,7 @@ class TypedObjectImpl<T> extends EchoObjectBase<DocumentModel> implements TypedO
 
     switch (type) {
       case 'ref':
-        return this._lookupLink((value as Reference).itemId);
+        return this._lookupLink(value as Reference);
       case 'object':
         return this._createProxy({}, key, meta);
       case 'array':
@@ -324,13 +324,12 @@ class TypedObjectImpl<T> extends EchoObjectBase<DocumentModel> implements TypedO
   private _set(key: string, value: any, meta?: boolean) {
     this._inBatch(() => {
       if (value instanceof EchoObjectBase) {
-        this._linkObject(value);
-        this._mutate(this._model.builder().set(key, new Reference(value.id)).build(meta));
+        const ref = this._linkObject(value);
+        this._mutate(this._model.builder().set(key, ref).build(meta));
       } else if (value instanceof EchoArray) {
         const values = value.map((item) => {
           if (item instanceof EchoObjectBase) {
-            this._linkObject(item);
-            return new Reference(item.id);
+            return this._linkObject(item);
           } else if (isReferenceLike(item)) {
             return new Reference(item['@id']);
           } else {
@@ -486,12 +485,23 @@ class TypedObjectImpl<T> extends EchoObjectBase<DocumentModel> implements TypedO
    * Store referenced object.
    * @internal
    */
-  _linkObject(obj: EchoObjectBase) {
+  _linkObject(obj: EchoObjectBase): Reference {
     if (this._database) {
-      this._database.add(obj as TypedObject);
+      if(!obj[base]._database) {
+        this._database.add(obj as TypedObject);
+        return new Reference(obj.id)
+      } else {
+        if(obj[base]._database !== this._database) {
+          return new Reference(obj.id, undefined, obj[base]._database._backend.spaceKey.toHex());
+        } else {
+          return new Reference(obj.id)
+        }
+      }
+
     } else {
       invariant(this._linkCache);
       this._linkCache.set(obj.id, obj);
+      return new Reference(obj.id)
     }
   }
 
@@ -499,13 +509,18 @@ class TypedObjectImpl<T> extends EchoObjectBase<DocumentModel> implements TypedO
    * Lookup referenced object.
    * @internal
    */
-  _lookupLink(id: string): EchoObject | undefined {
+  _lookupLink(ref: Reference): EchoObject | undefined {
     if (this._database) {
-      return this._database.getObjectById(id);
+      // This doesn't cleanup properly if the ref at key gets changed, but it doesn't matter since `_onLinkResolved` is idempotent.
+      return this._database.graph._lookupLink(ref, this._database, this._onLinkResolved);
     } else {
       invariant(this._linkCache);
-      return this._linkCache.get(id);
+      return this._linkCache.get(ref.itemId);
     }
+  }
+
+  private _onLinkResolved = () => {
+    this._signal?.notifyWrite();
   }
 }
 

--- a/packages/core/echo/echo-schema/src/typed-object.ts
+++ b/packages/core/echo/echo-schema/src/typed-object.ts
@@ -521,6 +521,7 @@ class TypedObjectImpl<T> extends EchoObjectBase<DocumentModel> implements TypedO
 
   private _onLinkResolved = () => {
     this._signal?.notifyWrite();
+    this._emitUpdate();
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -583,6 +583,34 @@ importers:
       vite-plugin-pwa: 0.14.1_hjemcocyspwkenofjo4wnksrci
       workbox-window: 6.5.4
 
+  packages/apps/labs-app/build/ios/socket-test-dev.app/ui/socket:
+    specifiers:
+      '@socketsupply/socket-darwin-arm64': 0.4.0
+      '@socketsupply/socket-darwin-x64': 0.4.0
+      '@socketsupply/socket-linux-arm64': 0.4.0
+      '@socketsupply/socket-linux-x64': 0.4.0
+      '@socketsupply/socket-win32-x64': 0.4.0
+    optionalDependencies:
+      '@socketsupply/socket-darwin-arm64': 0.4.0
+      '@socketsupply/socket-darwin-x64': 0.4.0
+      '@socketsupply/socket-linux-arm64': 0.4.0
+      '@socketsupply/socket-linux-x64': 0.4.0
+      '@socketsupply/socket-win32-x64': 0.4.0
+
+  packages/apps/labs-app/build/ios/ui/socket:
+    specifiers:
+      '@socketsupply/socket-darwin-arm64': 0.4.0
+      '@socketsupply/socket-darwin-x64': 0.4.0
+      '@socketsupply/socket-linux-arm64': 0.4.0
+      '@socketsupply/socket-linux-x64': 0.4.0
+      '@socketsupply/socket-win32-x64': 0.4.0
+    optionalDependencies:
+      '@socketsupply/socket-darwin-arm64': 0.4.0
+      '@socketsupply/socket-darwin-x64': 0.4.0
+      '@socketsupply/socket-linux-arm64': 0.4.0
+      '@socketsupply/socket-linux-x64': 0.4.0
+      '@socketsupply/socket-win32-x64': 0.4.0
+
   packages/apps/plugins/plugin-chess:
     specifiers:
       '@braneframe/plugin-client': workspace:*
@@ -11395,7 +11423,6 @@ packages:
     dependencies:
       '@nx/cypress': 16.5.4_qhptqrzqo7bwtm33kpvmsos7ve
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - cypress
@@ -11439,7 +11466,6 @@ packages:
       '@nx/eslint-plugin': 16.8.1_4v7kbp3q3j2n336mr2nodvz57y
       '@typescript-eslint/parser': 6.7.0_rngtr6f3b25lvetpihwplgecf4
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@swc/wasm'
@@ -11458,7 +11484,6 @@ packages:
     dependencies:
       '@nx/jest': 16.5.4_ebxsb5ytaojlvyq6j3l6ecuzii
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@types/node'
@@ -11476,7 +11501,6 @@ packages:
     dependencies:
       '@nx/js': 16.5.4_st3ukm3rnd3xadn2fxesh4boby_eoiemzzyseqzjynwznlrcdpipu
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11491,7 +11515,6 @@ packages:
     dependencies:
       '@nx/js': 16.8.1_ucnxlcwbwhxru7e5ww4bc6yjba
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@swc/wasm'
@@ -11508,7 +11531,6 @@ packages:
     dependencies:
       '@nx/linter': 16.5.4_qhptqrzqo7bwtm33kpvmsos7ve
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11532,7 +11554,6 @@ packages:
     dependencies:
       '@nx/storybook': 16.5.4_qhptqrzqo7bwtm33kpvmsos7ve
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - cypress
@@ -11572,7 +11593,6 @@ packages:
     dependencies:
       '@nx/vite': 16.5.4_xxzhsuqrsbs6wyvhvm37cpe46m_qgit66yh2vyynsv7uxdneek4qa
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11588,7 +11608,6 @@ packages:
     dependencies:
       '@nx/web': 16.5.4_eoiemzzyseqzjynwznlrcdpipu
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11635,7 +11654,6 @@ packages:
       dotenv: 10.0.0
       semver: 7.5.3
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11711,7 +11729,6 @@ packages:
       semver: 7.5.3
       tslib: 2.6.0
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@swc/wasm'
@@ -11742,7 +11759,6 @@ packages:
       resolve.exports: 1.1.0
       tslib: 2.6.0
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@types/node'
@@ -11776,7 +11792,7 @@ packages:
       '@phenomnomnominal/tsquery': 5.0.1_typescript@5.2.2
       babel-plugin-const-enum: 1.2.0_@babel+core@7.21.3
       babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2_@babel+core@7.21.3
+      babel-plugin-transform-typescript-metadata: 0.3.2
       chalk: 4.1.2
       detect-port: 1.5.1
       fast-glob: 3.2.7
@@ -11788,7 +11804,6 @@ packages:
       source-map-support: 0.5.19
       tslib: 2.6.0
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -11819,7 +11834,7 @@ packages:
       '@phenomnomnominal/tsquery': 5.0.1_typescript@5.2.2
       babel-plugin-const-enum: 1.2.0_@babel+core@7.22.19
       babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2_@babel+core@7.22.19
+      babel-plugin-transform-typescript-metadata: 0.3.2
       chalk: 4.1.2
       detect-port: 1.5.1
       fast-glob: 3.2.7
@@ -11833,7 +11848,6 @@ packages:
       tsconfig-paths: 4.1.2
       tslib: 2.6.0
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - '@swc/wasm'
@@ -11860,7 +11874,6 @@ packages:
       tmp: 0.2.1
       tslib: 2.6.0
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12063,7 +12076,6 @@ packages:
       dotenv: 10.0.0
       semver: 7.5.3
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - cypress
@@ -12089,7 +12101,6 @@ packages:
       enquirer: 2.3.6
       vite: 4.3.9_@types+node@18.11.9
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -12113,7 +12124,6 @@ packages:
       ignore: 5.2.4
       tslib: 2.6.0
     transitivePeerDependencies:
-      - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
       - debug
@@ -14868,6 +14878,46 @@ packages:
       lodash.union: 4.6.0
       lodash.values: 4.3.0
     dev: true
+
+  /@socketsupply/socket-darwin-arm64/0.4.0:
+    resolution: {integrity: sha512-0lap/Mj3fj85RY8jsex7AYNXjJnmY09mKwi7+4U0SjvsBktSyGiYywEmiosTHRh/4cUXYcqZwmiPxU5p9lbV3g==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@socketsupply/socket-darwin-x64/0.4.0:
+    resolution: {integrity: sha512-GfAgfUSej3GOJijD58jWuEtno73R489gctqJQmnvS9qjcaDXb2+ifgCyhw6UQ/xI8UALjJbxxDMnX62ssq43hw==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@socketsupply/socket-linux-arm64/0.4.0:
+    resolution: {integrity: sha512-32RngxA2BMfWlX0KbhTsnpzZMMbTsmyjdKmcq73+vXIplrHwRev5dZe/sC3nWCYcLBsBWk6kv5Ke/FRAHtraGQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@socketsupply/socket-linux-x64/0.4.0:
+    resolution: {integrity: sha512-AE2ri6MwhptGrj3i7lcGAdd43bFGIhdoWv3UvjMyI2sHVpUwd/mmMiLp13nIzTyQlyQ1fewttuxcDbcR4iOnWQ==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@socketsupply/socket-win32-x64/0.4.0:
+    resolution: {integrity: sha512-vecVtpNNgbE+lL/FvJFY2U0BwP31beg3VgrC6XfmsRWa+Sem8Y5o4c5Q4P78Ejfux2YZuTU8pQtp94PkAwA2dA==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@stackblitz/sdk/1.9.0:
     resolution: {integrity: sha512-3m6C7f8pnR5KXys/Hqx2x6ylnpqOak6HtnZI6T5keEO0yT+E4Spkw37VEbdwuC+2oxmjdgq6YZEgiKX7hM1GmQ==}
@@ -19895,7 +19945,7 @@ packages:
   /axios/1.3.4_debug@4.3.4:
     resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
     dependencies:
-      follow-redirects: 1.15.2_debug@4.3.4
+      follow-redirects: 1.15.2
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -20113,29 +20163,9 @@ packages:
   /babel-plugin-syntax-jsx/6.18.0:
     resolution: {integrity: sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==}
 
-  /babel-plugin-transform-typescript-metadata/0.3.2_@babel+core@7.21.3:
+  /babel-plugin-transform-typescript-metadata/0.3.2:
     resolution: {integrity: sha512-mWEvCQTgXQf48yDqgN7CH50waTyYBeP2Lpqx4nNWab9sxEpdXVeKgfj1qYI2/TgUPQtNFZ85i3PemRtnXVYYJg==}
-    peerDependencies:
-      '@babel/core': ^7
-      '@babel/traverse': ^7
-    peerDependenciesMeta:
-      '@babel/traverse':
-        optional: true
     dependencies:
-      '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /babel-plugin-transform-typescript-metadata/0.3.2_@babel+core@7.22.19:
-    resolution: {integrity: sha512-mWEvCQTgXQf48yDqgN7CH50waTyYBeP2Lpqx4nNWab9sxEpdXVeKgfj1qYI2/TgUPQtNFZ85i3PemRtnXVYYJg==}
-    peerDependencies:
-      '@babel/core': ^7
-      '@babel/traverse': ^7
-    peerDependenciesMeta:
-      '@babel/traverse':
-        optional: true
-    dependencies:
-      '@babel/core': 7.22.19
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -25343,18 +25373,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-
-  /follow-redirects/1.15.2_debug@4.3.4:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.4
-    dev: true
 
   /fontkit/2.0.2:
     resolution: {integrity: sha512-jc4k5Yr8iov8QfS6u8w2CnHWVmbOGtdBtOXMze5Y+QD966Rx6PEVWXSEGwXlsDlKtu1G12cJjcsybnqhSk/+LA==}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8b30d38</samp>

### Summary
🛠️🚀📝

<!--
1.  🛠️ - This emoji represents a bug fix or a minor improvement to existing functionality. It can be used for the changes that fix bugs and simplify functions in the `EchoArray` class and the `echo-schema` module, and the change that fixes bugs and adds support for cross-space references in the `TypedObjectImpl` class.
2.  🚀 - This emoji represents a new feature or a major enhancement to existing functionality. It can be used for the changes that add a new feature and tests for the `HyperGraph` class, and the changes that add support for cross-space references in the `HyperGraph` module, the `TestBuilder` and `TestPeer` classes, and the `EchoDatabase` class.
3.  📝 - This emoji represents a documentation update or a comment addition. It can be used for the change that updates the `EchoDatabase` class to reflect the current functionality and document model, and adds a comment to explain how the constructor loads existing objects.
-->
This pull request adds support for cross-space references in the `echo-schema` module, which enables linking and resolving objects across different spaces in the echo protocol. It fixes bugs and simplifies code in the `EchoArray` and `TypedObjectImpl` classes, and updates the `EchoDatabase` and `EchoObjectBase` classes to reflect the current functionality. It also adds a new feature and tests for the `HyperGraph` class, which handles the cross-space reference logic, and updates the `TestBuilder` and `TestPeer` classes to use the new API.

> _We're coding for the echo protocol_
> _Linking objects across the spaces_
> _We'll resolve and track them with `HyperGraph`_
> _Heave away, me lads and lasses_

### Walkthrough
*  Fix and simplify encoding and decoding of references and arrays in `EchoArray` and `TypedObjectImpl` classes ([link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-f3c522bb57a50b43a6828fb9a5ad908d06685b6ec823cf3512862928f84727b7L344-R344), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-f3c522bb57a50b43a6828fb9a5ad908d06685b6ec823cf3512862928f84727b7L354-R354), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-f3c522bb57a50b43a6828fb9a5ad908d06685b6ec823cf3512862928f84727b7L430-R429), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-f3c522bb57a50b43a6828fb9a5ad908d06685b6ec823cf3512862928f84727b7L444-R442), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-fb4678018340b303901f83cebbdcb241f8b6b85798bdff391c01dda993aae24eL230-R230), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-fb4678018340b303901f83cebbdcb241f8b6b85798bdff391c01dda993aae24eL295-R295), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-fb4678018340b303901f83cebbdcb241f8b6b85798bdff391c01dda993aae24eL327-R332), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-fb4678018340b303901f83cebbdcb241f8b6b85798bdff391c01dda993aae24eL489-R503), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-fb4678018340b303901f83cebbdcb241f8b6b85798bdff391c01dda993aae24eL502-R524))
* Add logic and methods for handling cross-space references in `HyperGraph` class, using a complex map of events and callbacks ([link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-093916b4db3aa4169c44ecad336ef7e6989bb9f07cf48a2b499d899b4cf2f8f2L6-R14), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-093916b4db3aa4169c44ecad336ef7e6989bb9f07cf48a2b499d899b4cf2f8f2R26), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-093916b4db3aa4169c44ecad336ef7e6989bb9f07cf48a2b499d899b4cf2f8f2L37-R60), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-093916b4db3aa4169c44ecad336ef7e6989bb9f07cf48a2b499d899b4cf2f8f2R78-R139), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-fb4678018340b303901f83cebbdcb241f8b6b85798bdff391c01dda993aae24eL502-R524))
* Add tests for cross-space references in `hyper-graph.test.ts`, using the `subscribe` symbol and the `TestBuilder` and `TestPeer` classes ([link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-2b00192313e01959294db04b1ab229a424f6dd80f7510952b7bc49a109211141R10), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-2b00192313e01959294db04b1ab229a424f6dd80f7510952b7bc49a109211141R72-R137), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-d1a7b3c7cfae022e9070cd58437ffded4817a7009aec37db5e7947588444bb0dL52-R52), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-d1a7b3c7cfae022e9070cd58437ffded4817a7009aec37db5e7947588444bb0dL68-R83))
* Fix a bug in the `EchoObjectBase` class, where the `_database` property change was not emitted to subscribers ([link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-347e0fc4776dc57270fab14284c03f084012130bc184765b85e7e8b11887ec13R117-R120))
* Remove a deprecated annotation from the `EchoDatabase` class and add a comment to the constructor ([link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-86b6148b95be2f77ac6eff05a19c3bf6926da19271cd10a1db4d9148ce39b9d2R59-R60), [link](https://github.com/dxos/dxos/pull/4435/files?diff=unified&w=0#diff-86b6148b95be2f77ac6eff05a19c3bf6926da19271cd10a1db4d9148ce39b9d2L66-L68))


