### PR TITLE
feat: add signal & swarm info to diagnostics

### DIFF
--- a/packages/core/mesh/network-manager/src/connection-log.ts
+++ b/packages/core/mesh/network-manager/src/connection-log.ts
@@ -72,6 +72,8 @@ export class ConnectionLog {
       });
 
       (connection.protocol as WireProtocol & { stats: Event<MuxerStats> })?.stats?.on((stats) => {
+        connectionInfo.readBufferSize = stats.readBufferSize;
+        connectionInfo.writeBufferSize = stats.writeBufferSize;
         connectionInfo.streams = stats.channels;
         this.update.emit();
       });

--- a/packages/core/mesh/teleport/src/muxing/muxer.ts
+++ b/packages/core/mesh/teleport/src/muxing/muxer.ts
@@ -38,6 +38,8 @@ export type MuxerStats = {
   bytesReceived: number;
   bytesSentRate?: number;
   bytesReceivedRate?: number;
+  readBufferSize?: number;
+  writeBufferSize?: number;
 };
 
 const STATS_INTERVAL = 1_000;
@@ -416,6 +418,7 @@ export class Muxer {
           id: channel.id,
           tag: channel.tag,
           contentType: channel.contentType,
+          writeBufferSize: channel.buffer.length,
           bytesSent: channel.stats.bytesSent,
           bytesReceived: channel.stats.bytesReceived,
           ...calculateThroughput(channel.stats, this._lastChannelStats.get(channel.id)),
@@ -427,6 +430,8 @@ export class Muxer {
       bytesSent,
       bytesReceived,
       ...calculateThroughput({ bytesSent, bytesReceived }, this._lastStats),
+      readBufferSize: this._balancer.stream.readableLength,
+      writeBufferSize: this._balancer.stream.writableLength,
     };
 
     this.statsUpdated.emit(this._lastStats);

--- a/packages/core/protocols/src/proto/dxos/devtools/swarm.proto
+++ b/packages/core/protocols/src/proto/dxos/devtools/swarm.proto
@@ -27,6 +27,7 @@ message ConnectionInfo {
     uint32 bytesReceived = 4;
     optional uint32 bytesSentRate = 6; // bytes per second.
     optional uint32 bytesReceivedRate = 7;
+    optional uint32 writeBufferSize = 8;
   }
 
   string state = 1;
@@ -38,6 +39,8 @@ message ConnectionInfo {
   repeated StreamStats streams = 7;
   optional string close_reason = 8;
   optional string identity = 9;
+  optional uint32 readBufferSize = 10;
+  optional uint32 writeBufferSize = 11;
 }
 
 message ConnectionEvent {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 24515b3</samp>

### Summary
📊🌐🔎

<!--
1.  📊 This emoji represents the addition of network diagnostics information to the connection log and the muxer module. It suggests data analysis, statistics, and performance measurement, which are relevant to the feature.
2.  🌐 This emoji represents the update of the `swarm.proto` file to include buffer size information for peers and swarms. It suggests networking, communication, and connectivity, which are relevant to the feature.
3.  🔎 This emoji represents the feature to query and stream network status and swarm information using triggers. It suggests searching, inspecting, and monitoring, which are relevant to the feature.
-->
This pull request adds a feature to expose network diagnostics information to the client services. It enhances the `muxer` module and the `swarm.proto` file to track and report buffer sizes for connections and swarms. It also adds a feature to the `diagnostics` service module to query and stream network status and swarm information. It updates the `connection-log` class to include buffer size properties in the connection info object.

> _Sing, O Muse, of the cunning engineers who devised_
> _A wondrous feature to reveal the hidden network state,_
> _How they added buffer sizes to the `connection log` and `muxer`,_
> _And how they made the `diagnostics service` stream and query._

### Walkthrough
*  Add read and write buffer size properties to network diagnostics information ([link](https://github.com/dxos/dxos/pull/4461/files?diff=unified&w=0#diff-722d9fe75c055645087e90a3586cbeba7bf109256b4789aecdcff96a937ff2fbR75-R76), [link](https://github.com/dxos/dxos/pull/4461/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R41-R42), [link](https://github.com/dxos/dxos/pull/4461/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R421), [link](https://github.com/dxos/dxos/pull/4461/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R433-R434), [link](https://github.com/dxos/dxos/pull/4461/files?diff=unified&w=0#diff-93f54b61119fb85788de2b99044227edbc6593159f45cb7a166ef45ff8a2b82dR30), [link](https://github.com/dxos/dxos/pull/4461/files?diff=unified&w=0#diff-93f54b61119fb85788de2b99044227edbc6593159f45cb7a166ef45ff8a2b82dR42-R43), [link](https://github.com/dxos/dxos/pull/4461/files?diff=unified&w=0#diff-29f4d8588e6fbac8ac28316d33e335cedf7368dc90121e7cb618c5763dd4a4acR48-R49))
*  Query network status and swarms from network service and connection log in `diagnostics.ts` ([link](https://github.com/dxos/dxos/pull/4461/files?diff=unified&w=0#diff-29f4d8588e6fbac8ac28316d33e335cedf7368dc90121e7cb618c5763dd4a4acR130-R147))
*  Use triggers to wait for network diagnostics information updates and return them in diagnostics stream in `diagnostics.ts` ([link](https://github.com/dxos/dxos/pull/4461/files?diff=unified&w=0#diff-29f4d8588e6fbac8ac28316d33e335cedf7368dc90121e7cb618c5763dd4a4acR5), [link](https://github.com/dxos/dxos/pull/4461/files?diff=unified&w=0#diff-29f4d8588e6fbac8ac28316d33e335cedf7368dc90121e7cb618c5763dd4a4acL19-R25))


