### PR TITLE
fix(plugin-treeview,react-ui-navtree): Polish items & tech debt

### DIFF
--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -493,7 +493,7 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
                   'dxos.org/plugin/space/RenameObjectPopover',
                   object,
                 ];
-                splitViewPlugin.provides.splitView.popoverAnchorId = `dxos.org/plugin/treeview/NavTreeItem/${intent.data.objectId}`;
+                splitViewPlugin.provides.splitView.popoverAnchorId = `dxos.org/ui/navtree/${intent.data.objectId}`;
                 return true;
               }
               break;

--- a/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
+++ b/packages/apps/plugins/plugin-treeview/src/components/TreeViewContainer.tsx
@@ -168,7 +168,7 @@ export const TreeViewContainer = ({
                   identityKey={identity?.identityKey.toHex()}
                   onClick={() => client.shell.shareIdentity()}
                 />
-                <div className='grow'></div>
+                <div className='grow' />
                 <Tooltip.Root>
                   <Tooltip.Trigger asChild>
                     <Button
@@ -221,7 +221,7 @@ export const TreeViewContainer = ({
               {/* <Separator orientation='horizontal' /> */}
             </>
           )}
-          <div role='none' className='grow min-bs-0 overflow-y-auto'>
+          <div role='none' className='grow min-bs-0 overflow-y-auto p-0.5'>
             <NavTree
               node={graph.root}
               current={currentPath}

--- a/packages/apps/plugins/plugin-treeview/src/translations.ts
+++ b/packages/apps/plugins/plugin-treeview/src/translations.ts
@@ -2,17 +2,17 @@
 // Copyright 2023 DXOS.org
 //
 
+import { translations as navtreeTranslations } from '@dxos/react-ui-navtree';
+
 import { TREE_VIEW_PLUGIN } from './types';
 
 export default [
   {
     'en-US': {
       [TREE_VIEW_PLUGIN]: {
-        'tree options label': 'More options',
-        'tree branch options label': 'More options',
-        'tree leaf options label': 'More options',
         'plugin error message': 'Content failed to render',
       },
     },
   },
+  ...navtreeTranslations,
 ];

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
@@ -174,7 +174,7 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
                   >
                     <Tooltip.Portal>
                       <Tooltip.Content classNames='z-[31]' side='bottom'>
-                        {t('tree branch options label')}
+                        {t('tree item options label')}
                         <Tooltip.Arrow />
                       </Tooltip.Content>
                     </Tooltip.Portal>

--- a/packages/ui/react-ui-navtree/src/translations.ts
+++ b/packages/ui/react-ui-navtree/src/translations.ts
@@ -7,7 +7,9 @@ export const translationKey = 'react-ui-navtree';
 export default [
   {
     'en-US': {
-      [translationKey]: {},
+      [translationKey]: {
+        'tree item options label': 'More options',
+      },
     },
   },
 ];

--- a/packages/ui/react-ui-theme/src/styles/components/dropdown-menu.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/dropdown-menu.ts
@@ -27,7 +27,7 @@ export const dropdownMenuContent: ComponentFunction<DropdownMenuStyleProps> = (_
 
 export const dropdownMenuItem: ComponentFunction<DropdownMenuStyleProps> = (_props, ...etc) =>
   mx(
-    'flex cursor-pointer select-none items-center gap-2 rounded-md px-2 py-2 text-sm whitespace-nowrap overflow-hidden',
+    'flex cursor-pointer select-none items-center gap-2 rounded-md px-2 py-2 text-sm',
     'text-neutral-900 data-[highlighted]:bg-neutral-50 dark:text-neutral-100 dark:data-[highlighted]:bg-neutral-900',
     subduedFocus,
     dataDisabled,


### PR DESCRIPTION
This PR tidies up a number of small bugs observed in either `plugin-treeview` or `react-ui-navtree`.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cc0fc07</samp>

### Summary
🌲🌐🎨

<!--
1.  🌲 - This emoji represents the tree view plugin and the navtree component, which are the main subjects of these changes.
2.  🌐 - This emoji represents the localization and translation changes, which affect the display of the navtree component in different languages.
3.  🎨 - This emoji represents the style and layout changes, which improve the appearance and usability of the navtree and dropdown menu components.
-->
Refactored the treeview plugin and the navtree component to use shared translations and UI elements. Improved the layout and accessibility of the treeview plugin and the dropdown menu component. Fixed a JSX syntax issue in `TreeViewContainer.tsx`.

> _Oh, we're the crew of the split view plugin_
> _And we work on the code with care_
> _We update the `popoverAnchorId` and the `navtree` translations_
> _And we fix the styles and the syntax there_

### Walkthrough
*  Update the popover anchor ID for the split view plugin to use the shared UI namespace ([link](https://github.com/dxos/dxos/pull/4467/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L496-R496)).

