### PR TITLE
feat: Open devtools app hook

### DIFF
--- a/packages/sdk/client/src/devtools/devtools.ts
+++ b/packages/sdk/client/src/devtools/devtools.ts
@@ -26,6 +26,8 @@ export interface DevtoolsHook {
   feeds?: Accessor<FeedWrapper>;
 
   openClientRpcServer: () => Promise<boolean>;
+
+  openDevtoolsApp?: () => void;
 }
 
 export type MountOptions = {
@@ -81,6 +83,24 @@ export const mountDevtoolsHooks = ({ client, host }: MountOptions) => {
           ]),
         ),
     });
+
+    hook.openDevtoolsApp = async () => {
+      const vault = client.config?.values.runtime?.client?.remoteSource ?? 'https://halo.dxos.org';
+
+      // Check if we're serving devtools locally on the usual port.
+      let hasLocalDevtools = false;
+      try {
+        await fetch('http://localhost:5174/');
+        hasLocalDevtools = true;
+      } catch {}
+
+      const isDev = window.location.href.includes('.dev.') || window.location.href.includes('localhost');
+      const devtoolsApp = hasLocalDevtools
+        ? 'http://localhost:5174/'
+        : `https://devtools${isDev ? '.dev.' : '.'}dxos.org/`;
+      const devtoolsUrl = `${devtoolsApp}?target=${vault}`;
+      window.open(devtoolsUrl, '_blank');
+    };
   }
   if (host) {
     hook.spaces = createAccessor({


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c3ea471</samp>

### Summary
🆕🛠️🔗

<!--
1.  🆕 - This emoji can be used to indicate a new feature or addition to the project.
2.  🛠️ - This emoji can be used to indicate a tool or improvement to the development or debugging experience.
3.  🔗 - This emoji can be used to indicate a connection or integration between different components or services.
-->
Added a devtools feature to the client SDK. This feature lets users open the `devtools` app from the browser and inspect the DXOS data stored in the `vault`.

> _To debug the DXOS data_
> _We added a feature that's greater_
> _You can open `devtools`_
> _From the browser, no hoops_
> _And connect to the vault URL later_

### Walkthrough
*  Add and implement `openDevtoolsApp` property on `DXOSDevtoolsHook` interface to open the devtools app in a new window ([link](https://github.com/dxos/dxos/pull/4468/files?diff=unified&w=0#diff-b760e508f5a708c2c45d9a4963c9f9a75ccdb50f98518a4b32392ceca391fe7cR29-R30), [link](https://github.com/dxos/dxos/pull/4468/files?diff=unified&w=0#diff-b760e508f5a708c2c45d9a4963c9f9a75ccdb50f98518a4b32392ceca391fe7cR86-R103))


