### PR TITLE
fix: diagnostics timeout

### DIFF
--- a/packages/sdk/client-services/src/packlets/services/diagnostics.ts
+++ b/packages/sdk/client-services/src/packlets/services/diagnostics.ts
@@ -2,7 +2,6 @@
 // Copyright 2022 DXOS.org
 //
 
-import { Trigger } from '@dxos/async';
 import { type ClientServices } from '@dxos/client-protocol';
 import { getFirstStreamValue } from '@dxos/codec-protobuf';
 import { type Config, type ConfigProto } from '@dxos/config';

--- a/packages/sdk/client-services/src/packlets/services/diagnostics.ts
+++ b/packages/sdk/client-services/src/packlets/services/diagnostics.ts
@@ -137,14 +137,7 @@ export const createDiagnostics = async (
 
     // Networking.
 
-    const swarmInfoDone = new Trigger();
-    serviceContext.networkManager.connectionLog?.update.on(async () => {
-      const swarms = serviceContext.networkManager.connectionLog?.swarms;
-      diagnostics.swarms = swarms;
-      await swarmInfoDone.wake();
-    });
-
-    await swarmInfoDone.wait({ timeout: DEFAULT_TIMEOUT });
+    diagnostics.swarms = serviceContext.networkManager.connectionLog?.swarms;
   }
 
   diagnostics.config = config.values;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1c010c3</samp>

### Summary
🐝🧹🚀

<!--
1.  🐝 - This emoji represents the swarm concept, which is central to the change. It also conveys the idea of improving the connection and communication between peers in the network.
2.  🧹 - This emoji represents the simplification and cleanup of the code, as well as the removal of unnecessary complexity and potential bugs. It also suggests a refactoring process that aims to make the code more organized and tidy.
3.  🚀 - This emoji represents the improvement of the performance and reliability of the diagnostics module, as well as the overall goal of enhancing the user experience and satisfaction. It also implies a sense of speed, efficiency, and innovation.
-->
Simplify swarm information logic in `diagnostics.ts`. Use connection log instead of trigger and event listener to avoid race conditions and timeouts. Part of diagnostics refactoring.

> _`swarms` from log now_
> _simpler, faster diagnostics_
> _no more race or time_

### Walkthrough
*  Simplify logic of getting swarm information for diagnostics ([link](https://github.com/dxos/dxos/pull/4474/files?diff=unified&w=0#diff-29f4d8588e6fbac8ac28316d33e335cedf7368dc90121e7cb618c5763dd4a4acL140-R140)). Directly assign `swarms` property from `connectionLog` instead of using trigger and event listener. Improve performance, reliability, and readability of `diagnostics.ts`.


