### PR TITLE
fix(plugin-space): Set an index when a Space or SpaceObject is created

### DIFF
--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -14,7 +14,7 @@ import { type IntentPluginProvides } from '@braneframe/plugin-intent';
 import { SPLITVIEW_PLUGIN, type SplitViewPluginProvides, SplitViewAction } from '@braneframe/plugin-splitview';
 import { AppState } from '@braneframe/types';
 import { EventSubscriptions } from '@dxos/async';
-import { type EchoObject, subscribe, type TypedObject } from '@dxos/echo-schema';
+import { type EchoObject, subscribe, TypedObject } from '@dxos/echo-schema';
 import { LocalStorageStore } from '@dxos/local-storage';
 import { PublicKey } from '@dxos/react-client';
 import { type Space, SpaceProxy } from '@dxos/react-client/echo';
@@ -49,7 +49,8 @@ import { createNodeId, isSpace, spaceToGraphNode } from './util';
 (globalThis as any)[SpaceProxy.name] = SpaceProxy;
 (globalThis as any)[PublicKey.name] = PublicKey;
 
-const hasIndex = (object: EchoObject): object is TypedObject => object instanceof TypedObject && object.meta.index !== undefined;
+const hasIndex = (object: EchoObject): object is TypedObject =>
+  object instanceof TypedObject && (object as TypedObject).meta.index !== undefined;
 
 const echoObjectCompare = (a: EchoObject, b: EchoObject) => {
   if (hasIndex(a) && hasIndex(b)) {

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -49,7 +49,7 @@ import { createNodeId, isSpace, spaceToGraphNode } from './util';
 (globalThis as any)[SpaceProxy.name] = SpaceProxy;
 (globalThis as any)[PublicKey.name] = PublicKey;
 
-const hasIndex = (object: EchoObject): object is TypedObject => !!(object as any)?.meta?.index;
+const hasIndex = (object: EchoObject): object is TypedObject => object instanceof TypedObject && object.meta.index !== undefined;
 
 const echoObjectCompare = (a: EchoObject, b: EchoObject) => {
   if (hasIndex(a) && hasIndex(b)) {


### PR DESCRIPTION
This PR aims to resolve issues observed when DnD rearrange fails due to indexes not being set.

This applies only to new objects, however, and does not solve for existing objects which are missing indexes, the solution for which remains an outstanding question.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e44fafe</samp>

### Summary
🚀🗂️🎨

<!--
1.  🚀 - This emoji could represent the improvement in performance and user experience that comes from index-based sorting and ordering, as well as the use of external libraries that provide useful functionality.
2.  🗂️ - This emoji could represent the concept of indexing and organizing spaces and objects in a structured way, as well as the use of the echo-schema library that defines the data model and schema for the space plugin.
3.  🎨 - This emoji could represent the visual aspect of sorting and ordering spaces and objects, as well as the use of the tldraw library that provides a drawing canvas and tools for the space plugin.
-->
Improved space plugin UI with index-based sorting and ordering. Used external libraries to handle index logic and object updates. Modified `SpacePlugin.tsx` and added dependencies.

> _To sort and order spaces and objects_
> _The space plugin some new code injects_
> _It uses `indices`_
> _And `echo-schema`_
> _To generate and subscribe to the effects_

### Walkthrough
* Import and use `getIndexBelow` function to generate next index for space or object ([link](https://github.com/dxos/dxos/pull/4475/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L7-R7), [link](https://github.com/dxos/dxos/pull/4475/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839R433-R437), [link](https://github.com/dxos/dxos/pull/4475/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L471-R523))
* Import and use `EchoObject`, `subscribe`, and `TypedObject` types to handle echo objects in spaces ([link](https://github.com/dxos/dxos/pull/4475/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L17-R17), [link](https://github.com/dxos/dxos/pull/4475/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L471-R523))
* Import and use `getAppStateIndex` function to get index of space from app state ([link](https://github.com/dxos/dxos/pull/4475/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L35-R35), [link](https://github.com/dxos/dxos/pull/4475/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839R433-R437))
* Add and use `hasIndex`, `echoObjectCompare`, `getNextSpaceIndex`, and `getNextSpaceObjectIndex` functions to sort and index spaces and objects ([link](https://github.com/dxos/dxos/pull/4475/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839R52-R91), [link](https://github.com/dxos/dxos/pull/4475/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839R433-R437), [link](https://github.com/dxos/dxos/pull/4475/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L471-R523))


