### PR TITLE
feat: Api to get space from object & query improvements

### DIFF
--- a/packages/core/echo/echo-db/src/packlets/database/queries.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/queries.ts
@@ -56,7 +56,15 @@ export type QueryOptions = {
    * Controls how deleted items are filtered.
    */
   deleted?: ShowDeletedOption;
+
+  /**
+   * Filter by model.
+   * @default * Only DocumentModel.
+   */
+  models?: string[] | null
 };
+
+export const QUERY_ALL_MODELS = null;
 
 //
 // Filters

--- a/packages/core/echo/echo-db/src/packlets/database/queries.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/queries.ts
@@ -61,7 +61,7 @@ export type QueryOptions = {
    * Filter by model.
    * @default * Only DocumentModel.
    */
-  models?: string[] | null
+  models?: string[] | null;
 };
 
 export const QUERY_ALL_MODELS = null;

--- a/packages/core/echo/echo-schema/src/echo-object-base.ts
+++ b/packages/core/echo/echo-schema/src/echo-object-base.ts
@@ -201,4 +201,4 @@ export const forceUpdate = (obj: EchoObjectBase) => {
 
 export const getDatabaseFromObject = (obj: EchoObject): EchoDatabase | undefined => {
   return obj[base]._database;
-}
+};

--- a/packages/core/echo/echo-schema/src/echo-object-base.ts
+++ b/packages/core/echo/echo-schema/src/echo-object-base.ts
@@ -198,3 +198,7 @@ export const setStateFromSnapshot = (obj: EchoObjectBase, snapshot: ObjectSnapsh
 export const forceUpdate = (obj: EchoObjectBase) => {
   obj[base]._itemUpdate();
 };
+
+export const getDatabaseFromObject = (obj: EchoObject): EchoDatabase | undefined => {
+  return obj[base]._database;
+}

--- a/packages/core/echo/echo-schema/src/hyper-graph.ts
+++ b/packages/core/echo/echo-schema/src/hyper-graph.ts
@@ -21,6 +21,7 @@ import { type TypedObject } from './typed-object';
  */
 export class HyperGraph {
   private readonly _databases = new ComplexMap<PublicKey, EchoDatabase>(PublicKey.hash);
+  private readonly _owningObjects = new ComplexMap<PublicKey, unknown>(PublicKey.hash);
   private readonly _types = new TypeCollection();
   private readonly _updateEvent = new Event<UpdateEvent>();
   private readonly _resolveEvents = new ComplexMap<PublicKey, Map<string, Event<EchoObject>>>(PublicKey.hash);
@@ -36,9 +37,11 @@ export class HyperGraph {
 
   /**
    * Register a database in hyper-graph.
+   * @param owningObject Database owner, usually a space.
    */
-  _register(spaceKey: PublicKey, database: EchoDatabase) {
+  _register(spaceKey: PublicKey, database: EchoDatabase, owningObject?: unknown) {
     this._databases.set(spaceKey, database);
+    this._owningObjects.set(spaceKey, owningObject);
     database._updateEvent.on(this._onUpdate.bind(this));
 
     const map = this._resolveEvents.get(spaceKey);
@@ -56,6 +59,10 @@ export class HyperGraph {
 
   _unregister(spaceKey: PublicKey) {
     this._databases.delete(spaceKey);
+  }
+
+  _getOwningObject(spaceKey: PublicKey): unknown | undefined {
+    return this._owningObjects.get(spaceKey);
   }
 
   /**

--- a/packages/core/echo/echo-schema/src/query.test.ts
+++ b/packages/core/echo/echo-schema/src/query.test.ts
@@ -5,12 +5,13 @@
 import { expect } from 'chai';
 
 import { sleep } from '@dxos/async';
-import { ShowDeletedOption } from '@dxos/echo-db';
+import { QUERY_ALL_MODELS, ShowDeletedOption } from '@dxos/echo-db';
 import { beforeAll, beforeEach, describe, test } from '@dxos/test';
 
 import { type EchoDatabase } from './database';
-import { createDatabase } from './testing';
-import { TypedObject } from './typed-object';
+import { TestBuilder, createDatabase } from './testing';
+import { Expando, TypedObject } from './typed-object';
+import { Text } from './text-object';
 
 describe('Queries', () => {
   let db: EchoDatabase;
@@ -179,3 +180,18 @@ describe.skip('Query updates', () => {
     await sleep(10);
   });
 });
+
+test('query with model filters', async () => {
+  const testBuilder = new TestBuilder();
+  const peer = await testBuilder.createPeer();
+
+  const obj = peer.db.add(new Expando({
+    title: 'title',
+    description: new Text('description'),
+  }))
+
+  expect(peer.db.query().objects).to.have.length(1);
+  expect(peer.db.query().objects[0]).to.eq(obj)
+
+  expect(peer.db.query(undefined, { models: QUERY_ALL_MODELS }).objects).to.have.length(2);
+})

--- a/packages/core/echo/echo-schema/src/query.test.ts
+++ b/packages/core/echo/echo-schema/src/query.test.ts
@@ -10,8 +10,8 @@ import { beforeAll, beforeEach, describe, test } from '@dxos/test';
 
 import { type EchoDatabase } from './database';
 import { TestBuilder, createDatabase } from './testing';
-import { Expando, TypedObject } from './typed-object';
 import { Text } from './text-object';
+import { Expando, TypedObject } from './typed-object';
 
 describe('Queries', () => {
   let db: EchoDatabase;
@@ -185,13 +185,15 @@ test('query with model filters', async () => {
   const testBuilder = new TestBuilder();
   const peer = await testBuilder.createPeer();
 
-  const obj = peer.db.add(new Expando({
-    title: 'title',
-    description: new Text('description'),
-  }))
+  const obj = peer.db.add(
+    new Expando({
+      title: 'title',
+      description: new Text('description'),
+    }),
+  );
 
   expect(peer.db.query().objects).to.have.length(1);
-  expect(peer.db.query().objects[0]).to.eq(obj)
+  expect(peer.db.query().objects[0]).to.eq(obj);
 
   expect(peer.db.query(undefined, { models: QUERY_ALL_MODELS }).objects).to.have.length(2);
-})
+});

--- a/packages/core/echo/echo-schema/src/query.ts
+++ b/packages/core/echo/echo-schema/src/query.ts
@@ -4,6 +4,7 @@
 
 import { Event } from '@dxos/async';
 import { Context } from '@dxos/context';
+import { DocumentModel } from '@dxos/document-model';
 import { type QueryOptions, ShowDeletedOption, type UpdateEvent } from '@dxos/echo-db';
 import { invariant } from '@dxos/invariant';
 import { type PublicKey } from '@dxos/keys';
@@ -13,7 +14,6 @@ import { type ComplexMap } from '@dxos/util';
 import { base, type EchoObject } from './defs';
 import { createSignal } from './signal';
 import { isTypedObject, type TypedObject } from './typed-object';
-import { DocumentModel } from '@dxos/document-model';
 
 // TODO(burdon): Test suite.
 // TODO(burdon): Reconcile with echo-db/database/selection.
@@ -131,17 +131,17 @@ const filterDeleted = (option?: ShowDeletedOption) => (object: TypedObject) => {
 
 const filterModels = (options?: QueryOptions) => (object: TypedObject) => {
   let models = options?.models;
-  
-  if(models === undefined) {
+
+  if (models === undefined) {
     models = [DocumentModel.meta.type];
   }
 
-  if(models === null) {
+  if (models === null) {
     return true;
   }
 
   return models.includes(object[base]._modelConstructor.meta.type);
-}
+};
 
 const match = (object: TypedObject, filter: Filter<any>): object is TypedObject => {
   if (typeof filter === 'function') {

--- a/packages/core/echo/echo-schema/src/serializer.test.ts
+++ b/packages/core/echo/echo-schema/src/serializer.test.ts
@@ -11,6 +11,7 @@ import { type SerializedSpace, Serializer } from './serializer';
 import { createDatabase } from './testing';
 import { Text } from './text-object';
 import { TypedObject } from './typed-object';
+import { QUERY_ALL_MODELS } from '@dxos/echo-db';
 
 describe('Serializer', () => {
   test('Basic', async () => {
@@ -117,7 +118,7 @@ describe('Serializer', () => {
       const { db } = await createDatabase();
       await serializer.import(db, data);
 
-      const { objects } = db.query();
+      const { objects } = db.query(undefined, { models: QUERY_ALL_MODELS });
       expect(objects[0] instanceof Text).to.be.true;
       expect(objects).to.have.length(1);
       expect(objects[0].text).to.deep.eq(content);

--- a/packages/core/echo/echo-schema/src/serializer.test.ts
+++ b/packages/core/echo/echo-schema/src/serializer.test.ts
@@ -5,13 +5,13 @@
 import { expect } from 'chai';
 
 import { sleep } from '@dxos/async';
+import { QUERY_ALL_MODELS } from '@dxos/echo-db';
 import { describe, test } from '@dxos/test';
 
 import { type SerializedSpace, Serializer } from './serializer';
 import { createDatabase } from './testing';
 import { Text } from './text-object';
 import { TypedObject } from './typed-object';
-import { QUERY_ALL_MODELS } from '@dxos/echo-db';
 
 describe('Serializer', () => {
   test('Basic', async () => {

--- a/packages/core/echo/echo-schema/src/serializer.ts
+++ b/packages/core/echo/echo-schema/src/serializer.ts
@@ -3,7 +3,7 @@
 //
 
 import { DocumentModel } from '@dxos/document-model';
-import { TYPE_PROPERTIES } from '@dxos/echo-db';
+import { QUERY_ALL_MODELS, TYPE_PROPERTIES } from '@dxos/echo-db';
 import { TextModel } from '@dxos/text-model';
 import { stripUndefinedValues } from '@dxos/util';
 
@@ -31,7 +31,7 @@ export type SerializedSpace = {
 // TODO(burdon): Sort JSON keys (npm canonical serialize util).
 export class Serializer {
   async export(database: EchoDatabase): Promise<SerializedSpace> {
-    const { objects } = database.query();
+    const { objects } = database.query(undefined, { models: QUERY_ALL_MODELS });
     const data = {
       objects: objects.map((object) => {
         return stripUndefinedValues({

--- a/packages/gravity/proto-guard/src/check-snapshot.test.ts
+++ b/packages/gravity/proto-guard/src/check-snapshot.test.ts
@@ -8,7 +8,7 @@ import path from 'node:path';
 
 import { asyncTimeout } from '@dxos/async';
 import { Client } from '@dxos/client';
-import { type Text } from '@dxos/client/echo';
+import { QUERY_ALL_MODELS, type Text } from '@dxos/client/echo';
 import { TestBuilder } from '@dxos/client/testing';
 import { failUndefined } from '@dxos/debug';
 import { invariant } from '@dxos/invariant';
@@ -66,7 +66,7 @@ describe('Tests against old storage', () => {
     {
       // TODO(dmaretskyi): Only needed because waitUntilReady seems to not guarantee that all objects will be present.
       const expectedObjects = 3;
-      if (space.db.query().objects.length < expectedObjects) {
+      if (space.db.query(undefined, { models: QUERY_ALL_MODELS }).objects.length < expectedObjects) {
         const queryPromise = new Promise<void>((resolve) => {
           space.db.query().subscribe((query) => {
             if (query.objects.length >= expectedObjects) {
@@ -88,7 +88,7 @@ describe('Tests against old storage', () => {
 
       // Text.
       // TODO(mykola): add ability to query.
-      const text = space.db.query({ text: data.space.text.content }).objects[0];
+      const text = space.db.query({ text: data.space.text.content }, { models: QUERY_ALL_MODELS }).objects[0];
       expect((text as unknown as Text).text).to.equal(data.space.text.content);
     }
   });

--- a/packages/sdk/client/src/echo/index.ts
+++ b/packages/sdk/client/src/echo/index.ts
@@ -39,4 +39,4 @@ export { TextModel } from '@dxos/text-model';
 
 export { SpaceList } from './space-list';
 export { SpaceProxy } from './space-proxy';
-export { createDefaultModelFactory } from './util';
+export { createDefaultModelFactory, getSpaceForObject } from './util';

--- a/packages/sdk/client/src/echo/index.ts
+++ b/packages/sdk/client/src/echo/index.ts
@@ -8,6 +8,7 @@ export {
   TYPE_SCHEMA,
   Item,
   ShowDeletedOption,
+  QUERY_ALL_MODELS,
   type QueryOptions,
   type SchemaDef,
   type SchemaField,

--- a/packages/sdk/client/src/echo/space-proxy.ts
+++ b/packages/sdk/client/src/echo/space-proxy.ts
@@ -113,7 +113,7 @@ export class SpaceProxy implements Space {
 
     this._error = this._data.error ? decodeError(this._data.error) : undefined;
 
-    graph._register(this.key, this._db);
+    graph._register(this.key, this._db, this);
 
     // Update observables.
     this._stateUpdate.emit(this._currentState);

--- a/packages/sdk/client/src/echo/util.ts
+++ b/packages/sdk/client/src/echo/util.ts
@@ -4,7 +4,7 @@
 //
 
 import { DocumentModel } from '@dxos/document-model';
-import { type EchoObject, base, getDatabaseFromObject } from '@dxos/echo-schema';
+import { type EchoObject, getDatabaseFromObject } from '@dxos/echo-schema';
 import { ModelFactory } from '@dxos/model-factory';
 import { TextModel } from '@dxos/text-model';
 

--- a/packages/sdk/client/src/echo/util.ts
+++ b/packages/sdk/client/src/echo/util.ts
@@ -4,9 +4,24 @@
 //
 
 import { DocumentModel } from '@dxos/document-model';
+import { EchoObject, base } from '@dxos/echo-schema';
 import { ModelFactory } from '@dxos/model-factory';
 import { TextModel } from '@dxos/text-model';
+import { SpaceProxy } from './space-proxy';
 
 export const createDefaultModelFactory = () => {
   return new ModelFactory().registerModel(DocumentModel).registerModel(TextModel);
 };
+
+export const getSpaceForObject = (object: EchoObject): SpaceProxy | undefined => {
+  const key = object[base]._database?._backend.spaceKey
+  if (!key) {
+    return undefined
+  }
+  const owner = object[base]._database?.graph._getOwningObject(key)
+  if (owner instanceof SpaceProxy) {
+    return owner
+  } else {
+    return undefined
+  }
+}

--- a/packages/sdk/client/src/echo/util.ts
+++ b/packages/sdk/client/src/echo/util.ts
@@ -4,9 +4,10 @@
 //
 
 import { DocumentModel } from '@dxos/document-model';
-import { EchoObject, base } from '@dxos/echo-schema';
+import { type EchoObject, base } from '@dxos/echo-schema';
 import { ModelFactory } from '@dxos/model-factory';
 import { TextModel } from '@dxos/text-model';
+
 import { SpaceProxy } from './space-proxy';
 
 export const createDefaultModelFactory = () => {
@@ -14,14 +15,14 @@ export const createDefaultModelFactory = () => {
 };
 
 export const getSpaceForObject = (object: EchoObject): SpaceProxy | undefined => {
-  const key = object[base]._database?._backend.spaceKey
+  const key = object[base]._database?._backend.spaceKey;
   if (!key) {
-    return undefined
+    return undefined;
   }
-  const owner = object[base]._database?.graph._getOwningObject(key)
+  const owner = object[base]._database?.graph._getOwningObject(key);
   if (owner instanceof SpaceProxy) {
-    return owner
+    return owner;
   } else {
-    return undefined
+    return undefined;
   }
-}
+};

--- a/packages/sdk/client/src/echo/util.ts
+++ b/packages/sdk/client/src/echo/util.ts
@@ -4,7 +4,7 @@
 //
 
 import { DocumentModel } from '@dxos/document-model';
-import { type EchoObject, base } from '@dxos/echo-schema';
+import { type EchoObject, base, getDatabaseFromObject } from '@dxos/echo-schema';
 import { ModelFactory } from '@dxos/model-factory';
 import { TextModel } from '@dxos/text-model';
 
@@ -15,11 +15,12 @@ export const createDefaultModelFactory = () => {
 };
 
 export const getSpaceForObject = (object: EchoObject): SpaceProxy | undefined => {
-  const key = object[base]._database?._backend.spaceKey;
+  const db = getDatabaseFromObject(object);
+  const key = db?._backend.spaceKey;
   if (!key) {
     return undefined;
   }
-  const owner = object[base]._database?.graph._getOwningObject(key);
+  const owner = db?.graph._getOwningObject(key);
   if (owner instanceof SpaceProxy) {
     return owner;
   } else {

--- a/packages/sdk/client/src/tests/spaces.test.ts
+++ b/packages/sdk/client/src/tests/spaces.test.ts
@@ -22,7 +22,7 @@ import { Timeframe } from '@dxos/timeframe';
 import { range } from '@dxos/util';
 
 import { Client } from '../client';
-import { SpaceState } from '../echo';
+import { SpaceState, getSpaceForObject } from '../echo';
 import { type SpaceProxy } from '../echo/space-proxy';
 import { TestBuilder, testSpace, waitForSpace } from '../testing';
 
@@ -497,5 +497,21 @@ describe('Spaces', () => {
     space.properties.name = 'example';
     await trigger.wait({ timeout: 500 });
     expect(space.properties.name).to.equal('example');
+  });
+
+  test('objects are owned by spaces', async () => {
+    const testBuilder = new TestBuilder();
+    testBuilder.storage = createStorage({ type: StorageType.RAM });
+
+    const client = new Client({ services: testBuilder.createLocal() });
+    await client.initialize();
+    afterTest(() => client.destroy());
+
+    await client.halo.createIdentity({ displayName: 'test-user' });
+
+    const space = await client.spaces.create();
+
+    const obj = space.db.add(new Expando({ data: 'test' }));
+    expect(getSpaceForObject(obj)).to.equal(space);
   });
 });


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a82d635</samp>

### Summary
🚀🐛✅

<!--
1.  🚀 - This emoji represents a new feature or enhancement, such as adding model filtering or space retrieval options to the echo module.
2.  🐛 - This emoji represents a bug fix or improvement, such as modifying the SpaceProxy class to pass itself as the owning object or updating the serializer.test.ts file to use a constant.
3.  ✅ - This emoji represents a test or verification, such as adding tests for the model filtering or space retrieval features or updating the check-snapshot.test.ts file to use the constant.
-->
This pull request adds features and tests for model filtering and space retrieval in the echo module and its dependencies. It implements the `getSpaceForObject` function in the `hyper-graph.ts` file, which returns the space that owns an object. It also adds a model filtering option to the Query class in the `query.ts` file, which allows querying typed objects from the database. It exports some constants and functions from the echo module as part of the SDK client API. It updates the tests and the serializer to use the new features and constants.

> _To support multiple models in echo-db_
> _We added some features to the SDK_
> _We can filter by type_
> _And get spaces right_
> _With `query` and `getSpaceForObject`_

### Walkthrough
*  Add model filtering feature to echo-db and echo-schema modules ([link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-80c1e22ae1e8d1b13bf352f47ec09dec3d054801605b232fe3badeaf56d94797L59-R68), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-ce9dd63c422567ed0f30ace9d7d4317bbf0a55a9cf9f6e610c5dcb95e3258988L8-R14), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-ce9dd63c422567ed0f30ace9d7d4317bbf0a55a9cf9f6e610c5dcb95e3258988R183-R199), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-90cb7ef308369fe5b2978ef97e5241c5b7b693224435354659681938242520bbR7), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-90cb7ef308369fe5b2978ef97e5241c5b7b693224435354659681938242520bbL13-R14), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-90cb7ef308369fe5b2978ef97e5241c5b7b693224435354659681938242520bbR59), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-90cb7ef308369fe5b2978ef97e5241c5b7b693224435354659681938242520bbR132-R145), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-cae12cca0428742a32cb237844799d5c05ff0f5c438e89e50da93d0e56f2755bR8), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-cae12cca0428742a32cb237844799d5c05ff0f5c438e89e50da93d0e56f2755bL120-R121), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-6ed890fa79b65ee608d1d04aeb0d5bfa81be70964510adf127e48355cc2c3596L6-R6), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-6ed890fa79b65ee608d1d04aeb0d5bfa81be70964510adf127e48355cc2c3596L34-R34), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-d829a1824624c6841edf675c792bb12399c22bc6af290a06d0853a8fc8fdeb13L11-R11), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-d829a1824624c6841edf675c792bb12399c22bc6af290a06d0853a8fc8fdeb13L69-R69), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-d829a1824624c6841edf675c792bb12399c22bc6af290a06d0853a8fc8fdeb13L91-R91), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-ba0c70c7f8386fa487925bdae1b38cbd4936d08912dd605bd5e3d069609d494aR11))
  * Extend `QueryOptions` type with `models` option and export `QUERY_ALL_MODELS` constant ([link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-80c1e22ae1e8d1b13bf352f47ec09dec3d054801605b232fe3badeaf56d94797L59-R68), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-ba0c70c7f8386fa487925bdae1b38cbd4936d08912dd605bd5e3d069609d494aR11))
  * Implement `filterModels` function to create a predicate for model filtering ([link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-90cb7ef308369fe5b2978ef97e5241c5b7b693224435354659681938242520bbR132-R145))
  * Call `filterModels` in `Query` constructor and use `QUERY_ALL_MODELS` in `query.ts`, `query.test.ts`, `serializer.ts`, `serializer.test.ts`, and `check-snapshot.test.ts` ([link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-90cb7ef308369fe5b2978ef97e5241c5b7b693224435354659681938242520bbR59), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-ce9dd63c422567ed0f30ace9d7d4317bbf0a55a9cf9f6e610c5dcb95e3258988L8-R14), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-ce9dd63c422567ed0f30ace9d7d4317bbf0a55a9cf9f6e610c5dcb95e3258988R183-R199), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-cae12cca0428742a32cb237844799d5c05ff0f5c438e89e50da93d0e56f2755bR8), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-cae12cca0428742a32cb237844799d5c05ff0f5c438e89e50da93d0e56f2755bL120-R121), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-6ed890fa79b65ee608d1d04aeb0d5bfa81be70964510adf127e48355cc2c3596L6-R6), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-6ed890fa79b65ee608d1d04aeb0d5bfa81be70964510adf127e48355cc2c3596L34-R34), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-d829a1824624c6841edf675c792bb12399c22bc6af290a06d0853a8fc8fdeb13L11-R11), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-d829a1824624c6841edf675c792bb12399c22bc6af290a06d0853a8fc8fdeb13L69-R69), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-d829a1824624c6841edf675c792bb12399c22bc6af290a06d0853a8fc8fdeb13L91-R91))
* Add `getSpaceForObject` function to echo-schema module and export it in echo module ([link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-347e0fc4776dc57270fab14284c03f084012130bc184765b85e7e8b11887ec13R201-R204), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-093916b4db3aa4169c44ecad336ef7e6989bb9f07cf48a2b499d899b4cf2f8f2R24), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-093916b4db3aa4169c44ecad336ef7e6989bb9f07cf48a2b499d899b4cf2f8f2L39-R44), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-093916b4db3aa4169c44ecad336ef7e6989bb9f07cf48a2b499d899b4cf2f8f2R64-R67), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-ba0c70c7f8386fa487925bdae1b38cbd4936d08912dd605bd5e3d069609d494aL42-R43), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-ea859fecb296e36346eb115dc1ffe5c0e67d7157b43b4dff2eb05ed5eb58ef73L116-R116), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-465d8762203feb853f296bb87002ae73db369b000ba04e8127d7ff3374f123c2L7-R29), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-e80f58650d2ce2f86fe95fd5e364a115f73b8ab6e659b6e3da2c3058800535eeL25-R25), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-e80f58650d2ce2f86fe95fd5e364a115f73b8ab6e659b6e3da2c3058800535eeR501-R516))
  * Add `getDatabaseFromObject` function to `echo-object-base.ts` to return the database of an echo object ([link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-347e0fc4776dc57270fab14284c03f084012130bc184765b85e7e8b11887ec13R201-R204))
  * Add `_owningObjects` map to `HyperGraph` class to store the owning object for each space key ([link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-093916b4db3aa4169c44ecad336ef7e6989bb9f07cf48a2b499d899b4cf2f8f2R24))
  * Modify `_register` method of `HyperGraph` class to accept and store the owning object parameter ([link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-093916b4db3aa4169c44ecad336ef7e6989bb9f07cf48a2b499d899b4cf2f8f2L39-R44))
  * Add `_getOwningObject` method to `HyperGraph` class to return the owning object for a given space key ([link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-093916b4db3aa4169c44ecad336ef7e6989bb9f07cf48a2b499d899b4cf2f8f2R64-R67))
  * Add `getSpaceForObject` function to `util.ts` to return the space proxy for a given echo object ([link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-465d8762203feb853f296bb87002ae73db369b000ba04e8127d7ff3374f123c2L7-R29))
  * Export `getSpaceForObject` function in `index.ts` of echo module ([link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-ba0c70c7f8386fa487925bdae1b38cbd4936d08912dd605bd5e3d069609d494aL42-R43))
  * Modify `SpaceProxy` class to pass itself as the owning object when registering the database ([link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-ea859fecb296e36346eb115dc1ffe5c0e67d7157b43b4dff2eb05ed5eb58ef73L116-R116))
  * Add test case for `getSpaceForObject` function in `spaces.test.ts` ([link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-e80f58650d2ce2f86fe95fd5e364a115f73b8ab6e659b6e3da2c3058800535eeL25-R25), [link](https://github.com/dxos/dxos/pull/4486/files?diff=unified&w=0#diff-e80f58650d2ce2f86fe95fd5e364a115f73b8ab6e659b6e3da2c3058800535eeR501-R516))


