### PR TITLE
fix(plugin-grid): default to copy

### DIFF
--- a/packages/apps/plugins/plugin-grid/src/components/GridMain.tsx
+++ b/packages/apps/plugins/plugin-grid/src/components/GridMain.tsx
@@ -9,7 +9,13 @@ import { Grid as GridType } from '@braneframe/types';
 import { findPlugin, usePlugins } from '@dxos/app-framework';
 import { Expando } from '@dxos/client/echo';
 import { Main } from '@dxos/react-ui';
-import { type MosaicTileAction, Grid, type MosaicDropEvent, type Position } from '@dxos/react-ui-mosaic';
+import {
+  type MosaicTileAction,
+  Grid,
+  type MosaicDropEvent,
+  type Position,
+  type MosaicOperation,
+} from '@dxos/react-ui-mosaic';
 import { baseSurface, coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
 
 import { colors, GridCard } from './GridCard';
@@ -51,6 +57,8 @@ export const GridMain: FC<{ grid: GridType }> = ({ grid }) => {
     }
   };
 
+  const handleOver = (): MosaicOperation => 'copy';
+
   const handleDrop = ({ active, over }: MosaicDropEvent<Position>) => {
     if (!grid.items.includes(active.item as any)) {
       grid.items.push(active.item as any);
@@ -75,6 +83,7 @@ export const GridMain: FC<{ grid: GridType }> = ({ grid }) => {
         onAction={handleAction}
         onCreate={handleCreate}
         onDrop={handleDrop}
+        onOver={handleOver}
         Component={GridCard}
       />
     </Main.Content>

--- a/packages/ui/react-ui-mosaic/src/views/Grid/Grid.tsx
+++ b/packages/ui/react-ui-mosaic/src/views/Grid/Grid.tsx
@@ -90,6 +90,7 @@ export const Grid = ({
   Component = Mosaic.DefaultComponent,
   className,
   onDrop,
+  onOver,
   onSelect,
   onCreate,
   onAction,
@@ -155,6 +156,7 @@ export const Grid = ({
         getOverlayProps: () => ({ grow: true }),
         getOverlayStyle: () => getDimension(cellBounds, options.spacing),
         onDrop,
+        onOver,
       }}
     >
       <div className={mx('flex grow overflow-auto', className)}>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2a7d1ef</samp>

### Summary
🖱️🔄🎛️

<!--
1.  🖱️ - This emoji represents the drag and drop functionality, as it is a common symbol for a mouse cursor that is used to drag and drop items on a screen.
2.  🔄 - This emoji represents the swapping or rearranging of the grid items, as it is a common symbol for refreshing or changing the order of something.
3.  🎛️ - This emoji represents the customization of the drop effect, as it is a common symbol for a control panel or settings that allow users to adjust or modify something.
-->
This pull request enhances the plugin-grid app by enabling drag and drop functionality for the grid items. It also updates the `Grid` component in the `react-ui-mosaic` package to support custom drop effects for the grid items.

> _The plugin-grid app has a new feature_
> _To make the grid items more fun to maneuver_
> _You can drag and drop them_
> _With a `handleOver` stem_
> _And the `Grid` component can change their drop behavior_

### Walkthrough
*  Define and pass `handleOver` function to control drag and drop behavior of grid items in `plugin-grid` app ([link](https://github.com/dxos/dxos/pull/4502/files?diff=unified&w=0#diff-67c0b2eb0a5e6e6e52cc6fadc62369646425931154e81f33f345ab693a8b567aR54-R55), [link](https://github.com/dxos/dxos/pull/4502/files?diff=unified&w=0#diff-67c0b2eb0a5e6e6e52cc6fadc62369646425931154e81f33f345ab693a8b567aR80))
*  Add and use `onOver` prop in `Grid` and `GridItem` components in `react-ui-mosaic` to set drop effect of grid items ([link](https://github.com/dxos/dxos/pull/4502/files?diff=unified&w=0#diff-1a61ab5a13bc01a7ac6a602389c7fa02b444b8dba149972cdd40fb6927669778R93), [link](https://github.com/dxos/dxos/pull/4502/files?diff=unified&w=0#diff-1a61ab5a13bc01a7ac6a602389c7fa02b444b8dba149972cdd40fb6927669778R159))


