### PR TITLE
ci: fix role mention

### DIFF
--- a/.circleci/scripts/send-test-report.sh
+++ b/.circleci/scripts/send-test-report.sh
@@ -13,7 +13,7 @@ function notifySuccess() {
 
 function notifyFailure() {
   if [ -z "$DISCORD_TEST_REPORT_WEBHOOK" ]; then return; fi
-  MESSAGE='{ "content": "⚠️ <@'$ROLE_ID'>", "embeds": [{ "title": "Daily testing failed: '$1'", "description": "'$CIRCLE_BUILD_URL'", "color": '$RED' }] }'
+  MESSAGE='{ "content": "⚠️ <@&'$ROLE_ID'>", "embeds": [{ "title": "Daily testing failed: '$1'", "description": "'$CIRCLE_BUILD_URL'", "color": '$RED' }] }'
   echo $MESSAGE
   curl -H "Content-Type: application/json" -d "${MESSAGE}" $DISCORD_TEST_REPORT_WEBHOOK
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2e0146b</samp>

### Summary
🐛🔔🛠️

<!--
1.  🐛 - This emoji represents a bug fix, since the previous syntax for role mentions was incorrect and did not work as intended.
2.  🔔 - This emoji represents a notification, since the function is responsible for sending alerts to a Discord channel when a testing fails.
3.  🛠️ - This emoji represents a tool, since the function is part of a testing pipeline that uses various tools and scripts to automate and monitor the testing process.
-->
Fixed a bug in the `notifyFailure` function that prevented it from mentioning a Discord role. Improved the notification system for the dxos testing pipeline.

> _`notifyFailure`_
> _Pings a role with `&` sign_
> _Autumn tests go wrong_

### Walkthrough
* Fix role mention syntax in `notifyFailure` function ([link](https://github.com/dxos/dxos/pull/4506/files?diff=unified&w=0#diff-d3a4e515b7c9c391753040f87ac5e12fa51cc833af7312fc30d6bd6a31eb4403L16-R16))


