### PR TITLE
fix(cli): Implement UX changes from Jess's feedback

### DIFF
--- a/packages/devtools/cli/package.json
+++ b/packages/devtools/cli/package.json
@@ -30,7 +30,6 @@
     "readme": "oclif readme"
   },
   "dependencies": {
-    "@braneframe/types": "workspace:*",
     "@dxos/agent": "workspace:*",
     "@dxos/async": "workspace:*",
     "@dxos/bare-template": "workspace:*",

--- a/packages/devtools/cli/package.json
+++ b/packages/devtools/cli/package.json
@@ -104,8 +104,29 @@
     "helpClass": "./dist/src/help",
     "topicSeparator": " ",
     "topics": {
-      "config": {
-        "description": "Configuration information."
+      "agent": {
+        "description": "DXOS Daemon with client services, which is constantly backuping your data. Agent can be extended with plugins (e.g. search plugin, epoch monitor). Also agent has an ability to run functions."
+      },
+      "app": {
+        "description": "Control apps that are published to KUBE specified in DXOS config."
+      },
+      "debug": {
+        "description": "Commands to help debug stuff (contains data generation to imitate high load, database metrics, etc.)."
+      },
+      "device": {
+        "description": "Devices in your HALO."
+      },
+      "function": {
+        "description": "Runtime plugable code with data/event specific triggers."
+      },
+      "halo": {
+        "description": "HALO is a system of components for implementing decentralized identity designed around privacy, security, and collaboration requirements."
+      },
+      "kube": {
+        "description": "KUBE is a set of runtime services for static web apps and peer-to-peer applications. "
+      },
+      "space": {
+        "description": "A space is an instance of an ECHO database which can be replicated by a number of peers."
       }
     }
   }

--- a/packages/devtools/cli/src/base-command.ts
+++ b/packages/devtools/cli/src/base-command.ts
@@ -12,7 +12,6 @@ import { dirname, join } from 'node:path';
 import readline from 'node:readline';
 import pkgUp from 'pkg-up';
 
-import { types } from '@braneframe/types'; // TODO(burdon): Remove.
 import {
   AgentIsNotStartedByCLIError,
   AgentWaitTimeoutError,
@@ -393,9 +392,6 @@ export abstract class BaseCommand<T extends typeof Command = any> extends Comman
         await this.maybeStartDaemon();
         this._client = new Client({ config: this._clientConfig, services: fromAgent({ profile: this.flags.profile }) });
       }
-
-      // TODO(burdon): Remove app-specific dependencies (function should add this).
-      this._client.addTypes(types);
 
       await this._client.initialize();
       log('Client initialized', { profile: this.flags.profile });

--- a/packages/devtools/cli/src/base-command.ts
+++ b/packages/devtools/cli/src/base-command.ts
@@ -42,7 +42,7 @@ import * as Sentry from '@dxos/sentry';
 import { captureException } from '@dxos/sentry';
 import * as Telemetry from '@dxos/telemetry';
 
-import { PublisherConnectionError, SpaceWaitTimeoutError } from './errors';
+import { IdentityWaitTimeoutError, PublisherConnectionError, SpaceWaitTimeoutError } from './errors';
 import {
   IPDATA_API_KEY,
   SENTRY_DESTINATION,
@@ -128,7 +128,7 @@ export abstract class BaseCommand<T extends typeof Command = any> extends Comman
 
     // TODO(burdon): '--no-' prefix is not working.
     'no-agent': Flags.boolean({
-      description: 'Run command without agent.',
+      description: 'Run command without using or starting agent.',
       default: false,
     }),
 
@@ -345,6 +345,8 @@ export abstract class BaseCommand<T extends typeof Command = any> extends Comman
       );
     } else if (err instanceof PublisherConnectionError) {
       this.logToStderr(chalk`{red Error}: Could not connect to publisher.`);
+    } else if (err instanceof IdentityWaitTimeoutError) {
+      this.logToStderr(chalk`{red Error}: Identity not initialized.`);
     } else {
       // Handle unknown errors with default method.
       super.error(err, options as any);

--- a/packages/devtools/cli/src/commands/device/info.ts
+++ b/packages/devtools/cli/src/commands/device/info.ts
@@ -4,9 +4,12 @@
 
 import chalk from 'chalk';
 
+import { asyncTimeout } from '@dxos/async';
 import { type Client } from '@dxos/client';
 
 import { BaseCommand } from '../../base-command';
+import { IdentityWaitTimeoutError } from '../../errors';
+import { IDENTITY_WAIT_TIMEOUT } from '../../timeouts';
 
 export default class Info extends BaseCommand<typeof Info> {
   static override enableJsonFlag = true;
@@ -15,7 +18,7 @@ export default class Info extends BaseCommand<typeof Info> {
   async run(): Promise<any> {
     return await this.execWithClient(async (client: Client) => {
       // TODO(mykola): Hack to wait for identity with `client.halo.identity.wait()`.
-      await client.spaces.isReady.wait();
+      await asyncTimeout(client.spaces.isReady.wait(), IDENTITY_WAIT_TIMEOUT, new IdentityWaitTimeoutError());
       const device = client.halo.device;
 
       if (!device) {

--- a/packages/devtools/cli/src/commands/device/list.ts
+++ b/packages/devtools/cli/src/commands/device/list.ts
@@ -4,9 +4,12 @@
 
 import { ux } from '@oclif/core';
 
+import { asyncTimeout } from '@dxos/async';
 import { type Client } from '@dxos/client';
 
 import { BaseCommand } from '../../base-command';
+import { IdentityWaitTimeoutError } from '../../errors';
+import { IDENTITY_WAIT_TIMEOUT } from '../../timeouts';
 import { printDevices } from '../../util';
 
 export default class List extends BaseCommand<typeof List> {
@@ -19,7 +22,7 @@ export default class List extends BaseCommand<typeof List> {
 
   async run(): Promise<any> {
     return await this.execWithClient(async (client: Client) => {
-      await client.spaces.isReady.wait();
+      await asyncTimeout(client.spaces.isReady.wait(), IDENTITY_WAIT_TIMEOUT, new IdentityWaitTimeoutError());
       const devices = client.halo.devices.get();
       printDevices(devices, this.flags);
       return devices;

--- a/packages/devtools/cli/src/commands/halo/join.ts
+++ b/packages/devtools/cli/src/commands/halo/join.ts
@@ -58,7 +58,7 @@ export default class Join extends BaseCommand<typeof Join> {
       await done.wait();
 
       ux.log();
-      ux.log(chalk`{green Joined}: ${invitation.identityKey!.truncate()}`);
+      ux.log(chalk`{green Joined successfully.}`);
 
       return {
         identityKey: invitation.identityKey,

--- a/packages/devtools/cli/src/commands/halo/share.ts
+++ b/packages/devtools/cli/src/commands/halo/share.ts
@@ -47,6 +47,7 @@ export default class Share extends BaseCommand<typeof Share> {
       ux.action.start('Waiting for peer to connect');
       await invitationSuccess;
       ux.action.stop();
+      ux.log(chalk`{green Joined successfully.}`);
     });
   }
 }

--- a/packages/devtools/cli/src/commands/space/join.ts
+++ b/packages/devtools/cli/src/commands/space/join.ts
@@ -56,7 +56,7 @@ export default class Join extends BaseCommand<typeof Join> {
       const space = client.spaces.get(invitation.spaceKey!)!;
 
       ux.log();
-      ux.log(chalk`{green Joined}: ${space.key.truncate()}`);
+      ux.log(chalk`{green Joined successfully.}`);
 
       return {
         key: space.key,

--- a/packages/devtools/cli/src/commands/space/list.ts
+++ b/packages/devtools/cli/src/commands/space/list.ts
@@ -25,7 +25,7 @@ export default class List extends BaseCommand<typeof List> {
 
   async run(): Promise<any> {
     return await this.execWithClient(async (client: Client) => {
-      const spaces = await this.getSpaces(client);
+      const spaces = await this.getSpaces(client, false);
       if (this.flags.json) {
         return mapSpaces(spaces);
       } else {

--- a/packages/devtools/cli/src/commands/space/share.ts
+++ b/packages/devtools/cli/src/commands/space/share.ts
@@ -57,6 +57,7 @@ export default class Share extends BaseCommand<typeof Share> {
       ux.action.start('Waiting for peer to connect');
       await invitationSuccess;
       ux.action.stop();
+      ux.log(chalk`{green Joined successfully.}`);
     });
   }
 }

--- a/packages/devtools/cli/src/errors.ts
+++ b/packages/devtools/cli/src/errors.ts
@@ -13,3 +13,9 @@ export class PublisherConnectionError extends Error {
     super('Error while connecting to kube publisher.');
   }
 }
+
+export class IdentityWaitTimeoutError extends Error {
+  constructor() {
+    super('Timeout waiting for identity.');
+  }
+}

--- a/packages/devtools/cli/src/errors.ts
+++ b/packages/devtools/cli/src/errors.ts
@@ -7,3 +7,9 @@ export class SpaceWaitTimeoutError extends Error {
     super(`Timeout waiting for space to be ready: ${timeout.toLocaleString()}ms`);
   }
 }
+
+export class PublisherConnectionError extends Error {
+  constructor() {
+    super('Error while connecting to kube publisher.');
+  }
+}

--- a/packages/devtools/cli/src/timeouts.ts
+++ b/packages/devtools/cli/src/timeouts.ts
@@ -4,3 +4,5 @@
 
 // TODO(burdon): Global CLI flag.
 export const SPACE_WAIT_TIMEOUT = 60_000;
+
+export const IDENTITY_WAIT_TIMEOUT = 1_000;

--- a/packages/devtools/cli/tsconfig.json
+++ b/packages/devtools/cli/tsconfig.json
@@ -33,9 +33,6 @@
       "path": "../../apps/templates/tasks-template"
     },
     {
-      "path": "../../apps/types"
-    },
-    {
       "path": "../../common/async"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5024,9 +5024,6 @@ importers:
 
   packages/devtools/cli:
     dependencies:
-      '@braneframe/types':
-        specifier: workspace:*
-        version: link:../../apps/types
       '@dxos/agent':
         specifier: workspace:*
         version: link:../../core/agent


### PR DESCRIPTION
Changes from https://github.com/dxos/dxos/issues/3740
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 01b3a48</samp>

### Summary
🚀🛠️🔐

<!--
1.  🚀 - This emoji represents the improvement in performance and responsiveness of the command line tool, as well as the alignment with the latest DXOS platform developments. It conveys a sense of speed, progress, and innovation.
2.  🛠️ - This emoji represents the improvement in error handling and user feedback of the command line tool, as well as the removal of unused or outdated code. It conveys a sense of fixing, refining, and updating.
3.  🔐 - This emoji represents the improvement in user experience and security of the command line tool, as well as the use of the `@dxos` namespace. It conveys a sense of privacy, protection, and identity.
-->
This pull request updates the `cli` package of the `dxos/devtools` repository to use the `@dxos` namespace, improve the error handling and feedback of the command line tool, and add timeout mechanisms for some commands. It also removes an unused dependency and updates the subcommands of the `dx` tool in the `package.json` file. It modifies the log messages of some commands to simplify them and reduce the exposure of sensitive information. It affects several files in the `src/commands` folder, as well as the `base-command.ts`, `errors.ts`, `timeouts.ts`, and `tsconfig.json` files.

> _The `cli` package got a makeover_
> _With better errors and feedback to show for_
> _It uses `@dxos` now_
> _And has timeouts somehow_
> _For the `dx device` commands to run smoother_

### Walkthrough
*  Remove dependency on `@braneframe/types` and update `topics` field in `package.json` ([link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-bf31499da78c3e8f3b80ee4241c95bcfd0db93d297c495a7e838bfbd4a307938L33), [link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-bf31499da78c3e8f3b80ee4241c95bcfd0db93d297c495a7e838bfbd4a307938L108-R129), [link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-b23aae00b90cfc22ffedaa6af5ad0af2ea848ee29f119d560b866ec1813f4ba5L36-L38))
*  Remove import of `@braneframe/types` and add import of new error classes in `base-command.ts` ([link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-eac56b1110e7935c817484ab1eb0b16951aac365450a32573ac651409bdf64aeL15), [link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-eac56b1110e7935c817484ab1eb0b16951aac365450a32573ac651409bdf64aeL46-R45))
*  Add `else if` branches to handle `PublisherConnectionError` and `IdentityWaitTimeoutError` in `execWithClient` method of `BaseCommand` class in `base-command.ts` ([link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-eac56b1110e7935c817484ab1eb0b16951aac365450a32573ac651409bdf64aeR346-R349))
*  Replace generic error with `PublisherConnectionError` in `execWithAgent` method of `BaseCommand` class in `base-command.ts` ([link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-eac56b1110e7935c817484ab1eb0b16951aac365450a32573ac651409bdf64aeL502-R502))
*  Remove line that adds types from `@braneframe/types` to DXOS client instance in `execWithClient` method of `BaseCommand` class in `base-command.ts` ([link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-eac56b1110e7935c817484ab1eb0b16951aac365450a32573ac651409bdf64aeL397-L399))
*  Add timeout mechanism for waiting for identity to be initialized in `info.ts` and `list.ts` files of `device` and `space` commands ([link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-698d639320a28c8ab5faea59e24df52aaff85656fcbb894d30df6dee0b649aecL7-R12), [link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-698d639320a28c8ab5faea59e24df52aaff85656fcbb894d30df6dee0b649aecL18-R21), [link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-301d1922be304c5ce397395987d3e2ee4b46dc7a0a0865a643a84a0ce3432393L7-R12), [link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-301d1922be304c5ce397395987d3e2ee4b46dc7a0a0865a643a84a0ce3432393L22-R25), [link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-4d506983059e822e97967df83e0a1179b52f4aa3ebe2a9a54c2439e04b897bbdL28-R28), [link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-2ccb74ff7541e77fc620233f280dc1bd423d81d07cb9e268ccaae84704a4e70dR7-R8))
*  Simplify log messages after joining HALO or space by removing identity or space key in `join.ts` files of `halo` and `space` commands ([link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-4c9766721a0452fa7a5c3a618793f3865ed7891a4dd75a937d08ab524530dd1dL61-R61), [link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-d178cdf1502554bbb2c133ee6b6830141381f83c09c4c3d02731ac763619b3b6L59-R59))
*  Add log messages after joining HALO or space by accepting invitation in `share.ts` files of `halo` and `space` commands ([link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-3c54c7dd6386f4012ec668cff7539bf6607a2bd0100279a4ec67c7386807b3eeR50), [link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-eee522743de96a8fc37a048b0e92f2c38ede192a0aded89ea203064e5f1eddddR60))
*  Add new error classes, `PublisherConnectionError` and `IdentityWaitTimeoutError`, to `errors.ts` file ([link](https://github.com/dxos/dxos/pull/4508/files?diff=unified&w=0#diff-a71bfe14e32fe495eec6cf2280f2b89010dfb01a6cc73eaae64d6b25997bc0e7R10-R21))


