### PR TITLE
feat: Save error indicator

### DIFF
--- a/packages/apps/plugins/plugin-layout/src/components/SplitView.tsx
+++ b/packages/apps/plugins/plugin-layout/src/components/SplitView.tsx
@@ -78,6 +78,7 @@ export const SplitView = ({ fullscreen, showComplementarySidebar = true }: Split
               <Surface role='heading' limit={2} />
               <div role='none' className='grow' />
               {/* TODO(burdon): Too specific? status? contentinfo? */}
+              <Surface role='save-indicator' limit={1} />
               <Surface role='presence' limit={1} />
               {complementarySidebarOpen !== null && showComplementarySidebar && (
                 <Button

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -246,7 +246,7 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
                 return null;
               }
             case 'save-indicator':
-              return <SaveIndicator />
+              return <SaveIndicator hideSaveIndicator />
             case 'presence':
               return <SpacePresence />;
             case 'settings':

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -34,6 +34,7 @@ import {
   PopoverRenameObject,
   PopoverRenameSpace,
 } from './components';
+import { SaveIndicator } from './components/SaveIndicator';
 import SpaceSettings from './components/SpaceSettings';
 import translations from './translations';
 import {
@@ -45,7 +46,6 @@ import {
   type SpaceState,
 } from './types';
 import { createNodeId, isSpace, spaceToGraphNode } from './util';
-import { SaveIndicator } from './components/SaveIndicator';
 
 // TODO(wittjosiah): This ensures that typed objects are not proxied by deepsignal. Remove.
 // https://github.com/luisherranz/deepsignal/issues/36
@@ -246,7 +246,7 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
                 return null;
               }
             case 'save-indicator':
-              return <SaveIndicator hideSaveIndicator />
+              return <SaveIndicator hideSaveIndicator />;
             case 'presence':
               return <SpacePresence />;
             case 'settings':

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -45,6 +45,7 @@ import {
   type SpaceState,
 } from './types';
 import { createNodeId, isSpace, spaceToGraphNode } from './util';
+import { SaveIndicator } from './components/SaveIndicator';
 
 // TODO(wittjosiah): This ensures that typed objects are not proxied by deepsignal. Remove.
 // https://github.com/luisherranz/deepsignal/issues/36
@@ -244,6 +245,8 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
               } else {
                 return null;
               }
+            case 'save-indicator':
+              return <SaveIndicator />
             case 'presence':
               return <SpacePresence />;
             case 'settings':

--- a/packages/apps/plugins/plugin-space/src/components/SaveIndicator.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/SaveIndicator.tsx
@@ -1,8 +1,14 @@
-import { findPlugin, usePlugins } from '@dxos/app-framework';
-import React, { useEffect, useState } from 'react';
-import { SpacePluginProvides } from '../types';
+//
+// Copyright 2023 DXOS.org
+//
+
 import { Warning } from '@phosphor-icons/react';
+import React, { useEffect, useState } from 'react';
+
+import { findPlugin, usePlugins } from '@dxos/app-framework';
 import { log } from '@dxos/log';
+
+import { type SpacePluginProvides } from '../types';
 
 export type SaveIndicatorProps = {
   hideSaveIndicator?: boolean;
@@ -10,7 +16,11 @@ export type SaveIndicatorProps = {
   clearStatusAfter?: number;
 };
 
-export const SaveIndicator = ({ hideSaveIndicator = false, saveIndicatorDelay = 250, clearStatusAfter = 1000 }: SaveIndicatorProps) => {
+export const SaveIndicator = ({
+  hideSaveIndicator = false,
+  saveIndicatorDelay = 250,
+  clearStatusAfter = 1000,
+}: SaveIndicatorProps) => {
   // TODO(dmaretskyi): useReducer.
   const [batchCount, setBatchCount] = useState(0);
   const [error, setError] = useState<Error | undefined>(undefined);
@@ -29,7 +39,7 @@ export const SaveIndicator = ({ hideSaveIndicator = false, saveIndicatorDelay = 
     const unsubscribe = space.db.pendingBatch.on(({ size, error }) => {
       setBatchCount(size ?? 0);
       setError(error);
-      if(error) {
+      if (error) {
         log.catch(error);
       }
       setMinThresholdReached(false);
@@ -53,13 +63,13 @@ export const SaveIndicator = ({ hideSaveIndicator = false, saveIndicatorDelay = 
     return () => {
       unsubscribe();
       clear();
-    }
+    };
   }, [space]);
 
   if (error) {
     return (
       <div className='inline-flex items-baseline text-gray-400 mx-1 h-5 text-orange-400'>
-        <Warning className='self-center w-5'/>
+        <Warning className='self-center w-5' />
         <span>Error saving changes</span>
       </div>
     );
@@ -89,61 +99,55 @@ export const SaveIndicator = ({ hideSaveIndicator = false, saveIndicatorDelay = 
 
 const SaveIcon = () => (
   <svg className='w-5 h-5 rounded-full animate-spin' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'>
-    <path
-      d='M12 4.75V6.25'
-      stroke='currentColor'
-      stroke-width='1.5'
-      stroke-linecap='round'
-      stroke-linejoin='round'
-    ></path>
+    <path d='M12 4.75V6.25' stroke='currentColor' strokeWidth='1.5' strokeLinecap='round' strokeLinejoin='round'></path>
     <path
       d='M17.1266 6.87347L16.0659 7.93413'
       stroke='currentColor'
-      stroke-width='1.5'
-      stroke-linecap='round'
-      stroke-linejoin='round'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
     ></path>
     <path
       d='M19.25 12L17.75 12'
       stroke='currentColor'
-      stroke-width='1.5'
-      stroke-linecap='round'
-      stroke-linejoin='round'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
     ></path>
     <path
       d='M17.1266 17.1265L16.0659 16.0659'
       stroke='currentColor'
-      stroke-width='1.5'
-      stroke-linecap='round'
-      stroke-linejoin='round'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
     ></path>
     <path
       d='M12 17.75V19.25'
       stroke='currentColor'
-      stroke-width='1.5'
-      stroke-linecap='round'
-      stroke-linejoin='round'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
     ></path>
     <path
       d='M7.9342 16.0659L6.87354 17.1265'
       stroke='currentColor'
-      stroke-width='1.5'
-      stroke-linecap='round'
-      stroke-linejoin='round'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
     ></path>
     <path
       d='M6.25 12L4.75 12'
       stroke='currentColor'
-      stroke-width='1.5'
-      stroke-linecap='round'
-      stroke-linejoin='round'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
     ></path>
     <path
       d='M7.9342 7.93413L6.87354 6.87347'
       stroke='currentColor'
-      stroke-width='1.5'
-      stroke-linecap='round'
-      stroke-linejoin='round'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
     ></path>
   </svg>
 );

--- a/packages/apps/plugins/plugin-space/src/components/SaveIndicator.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/SaveIndicator.tsx
@@ -1,0 +1,149 @@
+import { findPlugin, usePlugins } from '@dxos/app-framework';
+import React, { useEffect, useState } from 'react';
+import { SpacePluginProvides } from '../types';
+import { Warning } from '@phosphor-icons/react';
+import { log } from '@dxos/log';
+
+export type SaveIndicatorProps = {
+  hideSaveIndicator?: boolean;
+  saveIndicatorDelay?: number;
+  clearStatusAfter?: number;
+};
+
+export const SaveIndicator = ({ hideSaveIndicator = false, saveIndicatorDelay = 250, clearStatusAfter = 1000 }: SaveIndicatorProps) => {
+  // TODO(dmaretskyi): useReducer.
+  const [batchCount, setBatchCount] = useState(0);
+  const [error, setError] = useState<Error | undefined>(undefined);
+  const [minThresholdReached, setMinThresholdReached] = useState(true);
+  const [maxThresholdReached, setMaxThresholdReached] = useState(true);
+  const { plugins } = usePlugins();
+  const spacePlugin = findPlugin<SpacePluginProvides>(plugins, 'dxos.org/plugin/space');
+  const space = spacePlugin?.provides.space.active;
+  useEffect(() => {
+    if (!space) {
+      return;
+    }
+
+    let clear = () => {};
+
+    const unsubscribe = space.db.pendingBatch.on(({ size, error }) => {
+      setBatchCount(size ?? 0);
+      setError(error);
+      if(error) {
+        log.catch(error);
+      }
+      setMinThresholdReached(false);
+      setMaxThresholdReached(false);
+      clear();
+
+      const t1 = setTimeout(() => {
+        setMinThresholdReached(true);
+      }, saveIndicatorDelay);
+
+      const t2 = setTimeout(() => {
+        setMaxThresholdReached(true);
+      }, clearStatusAfter);
+
+      clear = () => {
+        clearTimeout(t1);
+        clearTimeout(t2);
+      };
+    });
+
+    return () => {
+      unsubscribe();
+      clear();
+    }
+  }, [space]);
+
+  if (error) {
+    return (
+      <div className='inline-flex items-baseline text-gray-400 mx-1 h-5 text-orange-400'>
+        <Warning className='self-center w-5'/>
+        <span>Error saving changes</span>
+      </div>
+    );
+  }
+
+  if (batchCount > 0 && minThresholdReached && !hideSaveIndicator) {
+    return (
+      <div className='inline-flex items-baseline text-gray-400 mx-1 h-5'>
+        <div className='self-center w-5'>
+          <SaveIcon />
+        </div>
+        <span className='self-center'>Saving...</span>
+      </div>
+    );
+  }
+
+  if (batchCount === 0 && !maxThresholdReached && !hideSaveIndicator) {
+    return (
+      <div className='inline-flex items-baseline text-gray-400 mx-1 h-5'>
+        <span>All changes saved</span>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+const SaveIcon = () => (
+  <svg className='w-5 h-5 rounded-full animate-spin' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'>
+    <path
+      d='M12 4.75V6.25'
+      stroke='currentColor'
+      stroke-width='1.5'
+      stroke-linecap='round'
+      stroke-linejoin='round'
+    ></path>
+    <path
+      d='M17.1266 6.87347L16.0659 7.93413'
+      stroke='currentColor'
+      stroke-width='1.5'
+      stroke-linecap='round'
+      stroke-linejoin='round'
+    ></path>
+    <path
+      d='M19.25 12L17.75 12'
+      stroke='currentColor'
+      stroke-width='1.5'
+      stroke-linecap='round'
+      stroke-linejoin='round'
+    ></path>
+    <path
+      d='M17.1266 17.1265L16.0659 16.0659'
+      stroke='currentColor'
+      stroke-width='1.5'
+      stroke-linecap='round'
+      stroke-linejoin='round'
+    ></path>
+    <path
+      d='M12 17.75V19.25'
+      stroke='currentColor'
+      stroke-width='1.5'
+      stroke-linecap='round'
+      stroke-linejoin='round'
+    ></path>
+    <path
+      d='M7.9342 16.0659L6.87354 17.1265'
+      stroke='currentColor'
+      stroke-width='1.5'
+      stroke-linecap='round'
+      stroke-linejoin='round'
+    ></path>
+    <path
+      d='M6.25 12L4.75 12'
+      stroke='currentColor'
+      stroke-width='1.5'
+      stroke-linecap='round'
+      stroke-linejoin='round'
+    ></path>
+    <path
+      d='M7.9342 7.93413L6.87354 6.87347'
+      stroke='currentColor'
+      stroke-width='1.5'
+      stroke-linecap='round'
+      stroke-linejoin='round'
+    ></path>
+  </svg>
+);

--- a/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
@@ -353,6 +353,7 @@ export class DatabaseProxy {
         (err) => {
           log.warn('batch commit err', { err });
           batch.receiptTrigger!.throw(err);
+          this.pendingBatch.emit({ error: err });
         },
       );
   }
@@ -430,10 +431,12 @@ export class DatabaseProxy {
     for (const batch of this._pendingBatches.values()) {
       batch.processTrigger!.throw(new Error('Service connection closed.'));
     }
-    this.pendingBatch.emit({
-      size: this._pendingBatches.size,
-      error: new Error('Service connection closed.'),
-    });
+    if(this._pendingBatches.size > 0) {
+      this.pendingBatch.emit({
+        size: this._pendingBatches.size,
+        error: new Error('Service connection closed.'),
+      });
+    }
     this._pendingBatches.clear();
   }
 }

--- a/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
+++ b/packages/core/echo/echo-db/src/packlets/database/database-proxy.ts
@@ -431,7 +431,7 @@ export class DatabaseProxy {
     for (const batch of this._pendingBatches.values()) {
       batch.processTrigger!.throw(new Error('Service connection closed.'));
     }
-    if(this._pendingBatches.size > 0) {
+    if (this._pendingBatches.size > 0) {
       this.pendingBatch.emit({
         size: this._pendingBatches.size,
         error: new Error('Service connection closed.'),

--- a/packages/core/echo/echo-schema/src/type-collection.ts
+++ b/packages/core/echo/echo-schema/src/type-collection.ts
@@ -75,7 +75,7 @@ export class TypeCollection {
     }
 
     if (this._types.size !== 0) {
-      throw new Error('Already linked.');
+      return;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1fea790</samp>

### Summary
💾🐛🚀

<!--
1.  💾 - This emoji represents the save indicator feature and the database changes that are being tracked by the component.
2.  🐛 - This emoji represents the bug fix in the link method and the improved error handling in the DatabaseProxy class.
3.  🚀 - This emoji represents the performance and usability improvement of the SplitView component and the SpacePlugin component.
-->
This pull request adds a new feature to the space plugin that shows the save status of the database changes in the active space. It introduces a new `SaveIndicator` component that renders in a `Surface` component inside the `SplitView` component. It also improves the error handling and feedback of the `DatabaseProxy` class and fixes a bug in the `TypeCollection` class.

> _Sing, O Muse, of the skillful coder who devised_
> _A splendid `Surface` with the role of `save-indicator`,_
> _To show the faithful users of the `SplitView` component_
> _The fate of their database changes in the active space._

### Walkthrough
*  Add a new Surface component to render the SaveIndicator component in the SplitView component ([link](https://github.com/dxos/dxos/pull/4517/files?diff=unified&w=0#diff-fb2eacb44c53f674cb89bc629f10661098e055b7a0635f5f0812c55b9739a216R81))
*  Define the SaveIndicator component that shows the status of the database changes in the active space ([link](https://github.com/dxos/dxos/pull/4517/files?diff=unified&w=0#diff-0a27a9679cf3f169b9103afc16e40abc27245b26799e0acce15ed880109beca3R1-R153))
*  Render the SaveIndicator component in the SpacePlugin component with a prop to hide it when the SplitView component is not visible ([link](https://github.com/dxos/dxos/pull/4517/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839R37), [link](https://github.com/dxos/dxos/pull/4517/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839R248-R249))
*  Emit the pendingBatch event from the DatabaseProxy class with the error object when an error occurs while processing the batch or when the connection closes with pending batches ([link](https://github.com/dxos/dxos/pull/4517/files?diff=unified&w=0#diff-b2da0ec452ce09064e0f75805825363a1182da69727f935f402a339f55d85148R356), [link](https://github.com/dxos/dxos/pull/4517/files?diff=unified&w=0#diff-b2da0ec452ce09064e0f75805825363a1182da69727f935f402a339f55d85148L433-R439))
*  Prevent throwing an error from the link method in the TypeCollection class when it is called more than once ([link](https://github.com/dxos/dxos/pull/4517/files?diff=unified&w=0#diff-26310df0e7d181c23b91117677787c018083d6bdd3d83b2e70c386e2fde7233fL78-R78))


