### PR TITLE
refactor: separate create actions in separate action group

### DIFF
--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -40,7 +40,6 @@ export class AppManager {
   }
 
   async createSpace() {
-    await this.page.getByTestId('navtree.treeItem.actionsLevel0').nth(1).click();
     await this.page.getByTestId('spacePlugin.createSpace').click();
     return this.page.getByTestId('navtree.treeItem.openTrigger').last().click();
   }
@@ -56,7 +55,7 @@ export class AppManager {
   }
 
   async createDocument() {
-    await this.page.getByTestId('navtree.treeItem.actionsLevel1').last().click();
+    await this.page.getByTestId('spacePlugin.createObject').last().click();
     return this.page.getByTestId('markdownPlugin.createDocument').last().click();
   }
 

--- a/packages/apps/plugins/plugin-chess/src/ChessPlugin.tsx
+++ b/packages/apps/plugins/plugin-chess/src/ChessPlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Plus } from '@phosphor-icons/react';
+import { ShieldChevron } from '@phosphor-icons/react';
 import React from 'react';
 
 import { CLIENT_PLUGIN, type ClientPluginProvides } from '@braneframe/plugin-client';
@@ -47,10 +47,10 @@ export const ChessPlugin = (): PluginDefinition<ChessPluginProvides> => {
           const space = parent.data;
           const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);
 
-          parent.addAction({
+          parent.actionsMap['create-object-group']?.addAction({
             id: `${CHESS_PLUGIN}/create`,
             label: ['create game label', { ns: CHESS_PLUGIN }],
-            icon: (props) => <Plus {...props} />,
+            icon: (props) => <ShieldChevron {...props} />,
             invoke: () =>
               intentPlugin?.provides.intent.dispatch([
                 {

--- a/packages/apps/plugins/plugin-chess/src/util.tsx
+++ b/packages/apps/plugins/plugin-chess/src/util.tsx
@@ -13,7 +13,7 @@ import { CHESS_PLUGIN } from './types';
 export const objectToGraphNode = (parent: Node<Space>, object: TypedObject): Node<TypedObject> => {
   const [child] = parent.addNode(CHESS_PLUGIN, {
     id: object.id,
-    label: object.title ?? ['game title placeholder', { ns: CHESS_PLUGIN }],
+    label: object.title || ['game title placeholder', { ns: CHESS_PLUGIN }],
     icon: (props) => <ShieldChevron {...props} />,
     data: object,
     properties: {

--- a/packages/apps/plugins/plugin-explorer/src/ExplorerPlugin.tsx
+++ b/packages/apps/plugins/plugin-explorer/src/ExplorerPlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Plus } from '@phosphor-icons/react';
+import { Graph } from '@phosphor-icons/react';
 import React from 'react';
 
 import { GraphNodeAdapter, SpaceAction } from '@braneframe/plugin-space';
@@ -41,10 +41,10 @@ export const ExplorerPlugin = (): PluginDefinition<ExplorerPluginProvides> => {
           const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);
 
           // TODO(burdon): Util.
-          parent.addAction({
+          parent.actionsMap['create-object-group']?.addAction({
             id: `${EXPLORER_PLUGIN}/create`,
             label: ['create object label', { ns: EXPLORER_PLUGIN }],
-            icon: (props) => <Plus {...props} />,
+            icon: (props) => <Graph {...props} />,
             invoke: () =>
               intentPlugin?.provides.intent.dispatch([
                 {

--- a/packages/apps/plugins/plugin-explorer/src/util.tsx
+++ b/packages/apps/plugins/plugin-explorer/src/util.tsx
@@ -14,7 +14,7 @@ import { EXPLORER_PLUGIN } from './types';
 export const objectToGraphNode = (parent: Node<Space>, object: ViewType): Node<ViewType> => {
   const [child] = parent.addNode(EXPLORER_PLUGIN, {
     id: object.id,
-    label: object.title ?? ['object title placeholder', { ns: EXPLORER_PLUGIN }],
+    label: object.title || ['object title placeholder', { ns: EXPLORER_PLUGIN }],
     icon: (props) => <Graph {...props} />,
     data: object,
     properties: {

--- a/packages/apps/plugins/plugin-grid/src/GridPlugin.tsx
+++ b/packages/apps/plugins/plugin-grid/src/GridPlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Plus } from '@phosphor-icons/react';
+import { SquaresFour } from '@phosphor-icons/react';
 import React from 'react';
 
 import { GraphNodeAdapter, SpaceAction } from '@braneframe/plugin-space';
@@ -43,10 +43,10 @@ export const GridPlugin = (): PluginDefinition<GridPluginProvides> => {
           const space = parent.data;
           const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);
 
-          parent.addAction({
+          parent.actionsMap['create-object-group']?.addAction({
             id: `${GRID_PLUGIN}/create`,
             label: ['create grid label', { ns: GRID_PLUGIN }],
-            icon: (props) => <Plus {...props} />,
+            icon: (props) => <SquaresFour {...props} />,
             invoke: () =>
               intentPlugin?.provides.intent.dispatch([
                 {

--- a/packages/apps/plugins/plugin-grid/src/util.tsx
+++ b/packages/apps/plugins/plugin-grid/src/util.tsx
@@ -14,7 +14,7 @@ import { GRID_PLUGIN } from './types';
 export const objectToGraphNode = (parent: Node<Space>, object: GridType): Node<GridType> => {
   const [child] = parent.addNode(GRID_PLUGIN, {
     id: object.id,
-    label: object.title ?? ['grid title placeholder', { ns: GRID_PLUGIN }],
+    label: object.title || ['grid title placeholder', { ns: GRID_PLUGIN }],
     icon: (props) => <SquaresFour {...props} />,
     data: object,
     properties: {

--- a/packages/apps/plugins/plugin-ipfs/src/util.tsx
+++ b/packages/apps/plugins/plugin-ipfs/src/util.tsx
@@ -13,7 +13,7 @@ import { IPFS_PLUGIN } from './types';
 export const objectToGraphNode = (parent: Node<Space>, object: TypedObject) => {
   const [child] = parent.addNode(IPFS_PLUGIN, {
     id: object.id,
-    label: object.title ?? ['object title placeholder', { ns: IPFS_PLUGIN }],
+    label: object.title || ['object title placeholder', { ns: IPFS_PLUGIN }],
     icon: (props) => <Image {...props} />,
     data: object,
     properties: {

--- a/packages/apps/plugins/plugin-kanban/src/KanbanPlugin.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/KanbanPlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Plus } from '@phosphor-icons/react';
+import { Kanban } from '@phosphor-icons/react';
 import React from 'react';
 
 import { GraphNodeAdapter, SpaceAction } from '@braneframe/plugin-space';
@@ -43,10 +43,10 @@ export const KanbanPlugin = (): PluginDefinition<KanbanPluginProvides> => {
           const space = parent.data;
           const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);
 
-          parent.addAction({
+          parent.actionsMap['create-object-group']?.addAction({
             id: `${KANBAN_PLUGIN}/create`,
             label: ['create kanban label', { ns: KANBAN_PLUGIN }],
-            icon: (props) => <Plus {...props} />,
+            icon: (props) => <Kanban {...props} />,
             invoke: () =>
               intentPlugin?.provides.intent.dispatch([
                 {

--- a/packages/apps/plugins/plugin-kanban/src/util.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/util.tsx
@@ -32,7 +32,7 @@ export const findLocation = (columns: KanbanType.Column[], id: string): Location
 export const objectToGraphNode = (parent: Node<Space>, object: KanbanType): Node<KanbanType> => {
   const [child] = parent.addNode(KANBAN_PLUGIN, {
     id: object.id,
-    label: object.title ?? ['kanban title placeholder', { ns: KANBAN_PLUGIN }],
+    label: object.title || ['kanban title placeholder', { ns: KANBAN_PLUGIN }],
     icon: (props) => <Kanban {...props} />,
     data: object,
     properties: {

--- a/packages/apps/plugins/plugin-map/src/MapPlugin.tsx
+++ b/packages/apps/plugins/plugin-map/src/MapPlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Plus } from '@phosphor-icons/react';
+import { Compass } from '@phosphor-icons/react';
 import React from 'react';
 
 import { GraphNodeAdapter, SpaceAction } from '@braneframe/plugin-space';
@@ -49,10 +49,10 @@ export const MapPlugin = (): PluginDefinition<MapPluginProvides> => {
           const space = parent.data;
           const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);
 
-          parent.addAction({
+          parent.actionsMap['create-object-group']?.addAction({
             id: `${MAP_PLUGIN}/create`,
             label: ['create object label', { ns: MAP_PLUGIN }],
-            icon: (props) => <Plus {...props} />,
+            icon: (props) => <Compass {...props} />,
             invoke: () =>
               intentPlugin?.provides.intent.dispatch([
                 {

--- a/packages/apps/plugins/plugin-map/src/util.tsx
+++ b/packages/apps/plugins/plugin-map/src/util.tsx
@@ -13,7 +13,7 @@ import { MAP_PLUGIN } from './types';
 export const objectToGraphNode = (parent: Node<Space>, object: TypedObject): Node<TypedObject> => {
   const [child] = parent.addNode(MAP_PLUGIN, {
     id: object.id,
-    label: object.title ?? ['object title placeholder', { ns: MAP_PLUGIN }],
+    label: object.title || ['object title placeholder', { ns: MAP_PLUGIN }],
     icon: (props) => <Compass {...props} />,
     data: object,
     properties: {

--- a/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ArticleMedium, Plus } from '@phosphor-icons/react';
+import { ArticleMedium } from '@phosphor-icons/react';
 import { deepSignal } from 'deepsignal';
 import get from 'lodash.get';
 import React, { type FC, type MutableRefObject, type RefCallback, useCallback } from 'react';
@@ -214,14 +214,10 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
           const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);
           const space = parent.data;
 
-          parent.addAction({
+          parent.actionsMap['create-object-group']?.addAction({
             id: `${MARKDOWN_PLUGIN}/create`,
             label: ['create document label', { ns: MARKDOWN_PLUGIN }],
-            icon: (props) => <Plus {...props} />,
-            properties: {
-              testId: 'markdownPlugin.createDocument',
-              disposition: 'toolbar',
-            },
+            icon: (props) => <ArticleMedium {...props} />,
             invoke: () =>
               intentPlugin?.provides.intent.dispatch([
                 {
@@ -236,6 +232,9 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
                   action: LayoutAction.ACTIVATE,
                 },
               ]),
+            properties: {
+              testId: 'markdownPlugin.createDocument',
+            },
           });
 
           return adapter?.createNodes(space, parent);

--- a/packages/apps/plugins/plugin-markdown/src/util.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/util.tsx
@@ -76,7 +76,7 @@ export const documentToGraphNode = (parent: Node<Space>, document: Document): No
     data: document,
     properties: {
       persistenceClass: 'spaceObject',
-      'data-testid': 'markdownPlugin.document',
+      testId: 'markdownPlugin.document',
     },
   });
 

--- a/packages/apps/plugins/plugin-markdown/src/util.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/util.tsx
@@ -70,7 +70,7 @@ const getFallbackTitle = (document: Document) => {
 export const documentToGraphNode = (parent: Node<Space>, document: Document): Node => {
   const [child] = parent.addNode(MARKDOWN_PLUGIN, {
     id: document.id,
-    label: document.title ?? getFallbackTitle(document) ?? ['document title placeholder', { ns: MARKDOWN_PLUGIN }],
+    label: document.title || getFallbackTitle(document) || ['document title placeholder', { ns: MARKDOWN_PLUGIN }],
     icon: (props) =>
       document.content?.kind === TextKind.PLAIN ? <ArticleMedium {...props} /> : <Article {...props} />,
     data: document,

--- a/packages/apps/plugins/plugin-sketch/src/SketchPlugin.tsx
+++ b/packages/apps/plugins/plugin-sketch/src/SketchPlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { CompassTool, Plus } from '@phosphor-icons/react';
+import { CompassTool } from '@phosphor-icons/react';
 import React from 'react';
 
 import { GraphNodeAdapter, SpaceAction } from '@braneframe/plugin-space';
@@ -53,10 +53,10 @@ export const SketchPlugin = (): PluginDefinition<SketchPluginProvides> => {
           const space = parent.data;
           const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);
 
-          parent.addAction({
+          parent.actionsMap['create-object-group']?.addAction({
             id: `${SKETCH_PLUGIN}/create`,
             label: ['create object label', { ns: SKETCH_PLUGIN }],
-            icon: (props) => <Plus {...props} />,
+            icon: (props) => <CompassTool {...props} />,
             invoke: () =>
               intentPlugin?.provides.intent.dispatch([
                 {

--- a/packages/apps/plugins/plugin-sketch/src/util.tsx
+++ b/packages/apps/plugins/plugin-sketch/src/util.tsx
@@ -14,7 +14,7 @@ import { SKETCH_PLUGIN } from './types';
 export const objectToGraphNode = (parent: Node<Space>, object: SketchType): Node<SketchType> => {
   const [child] = parent.addNode(SKETCH_PLUGIN, {
     id: object.id,
-    label: object.title ?? ['object title placeholder', { ns: SKETCH_PLUGIN }],
+    label: object.title || ['object title placeholder', { ns: SKETCH_PLUGIN }],
     icon: (props) => <CompassTool {...props} />,
     data: object,
     properties: {

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -287,7 +287,7 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
             properties: {
               // TODO(burdon): Factor out palette constants.
               palette: 'pink',
-              'data-testid': 'spacePlugin.allSpaces',
+              testId: 'spacePlugin.allSpaces',
               acceptPersistenceClass: new Set(['appState']),
               childrenPersistenceClass: 'appState',
               onRearrangeChildren: (nextOrder: string[]) => {

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Intersect, Planet } from '@phosphor-icons/react';
+import { Intersect, Plus } from '@phosphor-icons/react';
 import { effect } from '@preact/signals-react';
 import { type RevertDeepSignal, deepSignal } from 'deepsignal/react';
 import React from 'react';
@@ -339,7 +339,7 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
             {
               id: 'create-space',
               label: ['create space label', { ns: 'os' }],
-              icon: (props) => <Planet {...props} />,
+              icon: (props) => <Plus {...props} />,
               properties: {
                 disposition: 'toolbar',
                 testId: 'spacePlugin.createSpace',
@@ -355,7 +355,6 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
               label: ['join space label', { ns: 'os' }],
               icon: (props) => <Intersect {...props} />,
               properties: {
-                disposition: 'toolbar',
                 testId: 'spacePlugin.joinSpace',
               },
               invoke: () =>

--- a/packages/apps/plugins/plugin-space/src/components/PopoverRenameObject.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/PopoverRenameObject.tsx
@@ -14,7 +14,7 @@ export const PopoverRenameObject = ({ object }: { object: TypedObject }) => {
   const doneButton = useRef<HTMLButtonElement>(null);
   // TODO(wittjosiah): Normalize title vs name.
   // TODO(burdon): Field should not be hard-code 'title' field.
-  const [name, setName] = useState(object.title ?? '');
+  const [name, setName] = useState(object.title || '');
 
   const handleDone = useCallback(() => {
     object.title = name;

--- a/packages/apps/plugins/plugin-space/src/translations.ts
+++ b/packages/apps/plugins/plugin-space/src/translations.ts
@@ -33,6 +33,7 @@ export default [
         'show hidden spaces label': 'Show hidden spaces',
         'rename object label': 'Rename',
         'delete object label': 'Delete',
+        'create object group label': 'Add to space',
       },
     },
   },

--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -92,13 +92,14 @@ export const spaceToGraphNode = ({
           properties: {
             disposition: 'toolbar',
             disabled: disabled || error,
+            testId: 'spacePlugin.createObject',
           },
         },
       ],
       properties: {
         // TODO(burdon): Factor out palette constants.
         palette: parent.id === 'root' ? 'teal' : undefined,
-        'data-testid': parent.id === 'root' ? 'spacePlugin.personalSpace' : 'spacePlugin.space',
+        testId: parent.id === 'root' ? 'spacePlugin.personalSpace' : 'spacePlugin.space',
         role: 'branch',
         hidden: settings.showHidden ? false : inactive,
         disabled,

--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -2,7 +2,16 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ClockCounterClockwise, Download, Users, PencilSimpleLine, Planet, Upload, X } from '@phosphor-icons/react';
+import {
+  ClockCounterClockwise,
+  Download,
+  Users,
+  PencilSimpleLine,
+  Planet,
+  Upload,
+  X,
+  Plus,
+} from '@phosphor-icons/react';
 import { batch } from '@preact/signals-react';
 import React from 'react';
 
@@ -72,6 +81,20 @@ export const spaceToGraphNode = ({
       description: space.properties.description,
       ...(parent.id !== 'root' && { icon: (props) => <Planet {...props} /> }),
       data: space,
+      actions: [
+        {
+          id: 'create-object-group',
+          label: ['create object group label', { ns: SPACE_PLUGIN }],
+          icon: (props) => <Plus {...props} />,
+          invoke: () => {
+            // No-op.
+          },
+          properties: {
+            disposition: 'toolbar',
+            disabled: disabled || error,
+          },
+        },
+      ],
       properties: {
         // TODO(burdon): Factor out palette constants.
         palette: parent.id === 'root' ? 'teal' : undefined,

--- a/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
+++ b/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Plus } from '@phosphor-icons/react';
+import { StackSimple } from '@phosphor-icons/react';
 import { deepSignal } from 'deepsignal/react';
 import React from 'react';
 
@@ -65,10 +65,10 @@ export const StackPlugin = (): PluginDefinition<StackPluginProvides> => {
           const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);
           const space = parent.data;
 
-          parent.addAction({
+          parent.actionsMap['create-object-group']?.addAction({
             id: `${STACK_PLUGIN}/create`,
             label: ['create stack label', { ns: STACK_PLUGIN }],
-            icon: (props) => <Plus {...props} />,
+            icon: (props) => <StackSimple {...props} />,
             invoke: () =>
               intentPlugin?.provides.intent.dispatch([
                 {

--- a/packages/apps/plugins/plugin-stack/src/util.tsx
+++ b/packages/apps/plugins/plugin-stack/src/util.tsx
@@ -23,7 +23,7 @@ export const isStack = (data: unknown): data is StackType =>
 export const stackToGraphNode = (parent: Node<Space>, object: StackType): Node => {
   const [child] = parent.addNode(STACK_PLUGIN, {
     id: object.id,
-    label: object.title ?? ['stack title placeholder', { ns: STACK_PLUGIN }],
+    label: object.title || ['stack title placeholder', { ns: STACK_PLUGIN }],
     icon: (props: IconProps) => <StackSimple {...props} />,
     data: object,
     properties: {

--- a/packages/apps/plugins/plugin-table/src/TablePlugin.tsx
+++ b/packages/apps/plugins/plugin-table/src/TablePlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Plus } from '@phosphor-icons/react';
+import { Table } from '@phosphor-icons/react';
 import React from 'react';
 
 import { GraphNodeAdapter, SpaceAction } from '@braneframe/plugin-space';
@@ -51,10 +51,10 @@ export const TablePlugin = (): PluginDefinition<TablePluginProvides> => {
           const space = parent.data;
           const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);
 
-          parent.addAction({
+          parent.actionsMap['create-object-group']?.addAction({
             id: `${TABLE_PLUGIN}/create`,
             label: ['create object label', { ns: TABLE_PLUGIN }],
-            icon: (props) => <Plus {...props} />,
+            icon: (props) => <Table {...props} />,
             invoke: () =>
               intentPlugin?.provides.intent.dispatch([
                 {

--- a/packages/apps/plugins/plugin-table/src/util.tsx
+++ b/packages/apps/plugins/plugin-table/src/util.tsx
@@ -13,7 +13,7 @@ import { TABLE_PLUGIN } from './types';
 export const objectToGraphNode = (parent: Node<Space>, object: TypedObject): Node<TypedObject> => {
   const [child] = parent.addNode(TABLE_PLUGIN, {
     id: object.id,
-    label: object.title ?? ['object placeholder', { ns: TABLE_PLUGIN }],
+    label: object.title || ['object placeholder', { ns: TABLE_PLUGIN }],
     icon: (props) => <Table {...props} />,
     data: object,
     properties: {

--- a/packages/apps/plugins/plugin-template/src/TemplatePlugin.tsx
+++ b/packages/apps/plugins/plugin-template/src/TemplatePlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Plus } from '@phosphor-icons/react';
+import { Asterisk } from '@phosphor-icons/react';
 import React from 'react';
 
 import { GraphNodeAdapter, SpaceAction } from '@braneframe/plugin-space';
@@ -49,10 +49,10 @@ export const TemplatePlugin = (): PluginDefinition<TemplatePluginProvides> => {
           const space = parent.data;
           const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);
 
-          parent.addAction({
+          parent.actionsMap['create-object-group']?.addAction({
             id: `${TEMPLATE_PLUGIN}/create`, // TODO(burdon): Uniformly "create".
             label: ['create object label', { ns: TEMPLATE_PLUGIN }], // TODO(burdon): "object"
-            icon: (props) => <Plus {...props} />,
+            icon: (props) => <Asterisk {...props} />,
             // TODO(burdon): Factor out helper.
             invoke: () =>
               intentPlugin?.provides.intent.dispatch([

--- a/packages/apps/plugins/plugin-template/src/util.tsx
+++ b/packages/apps/plugins/plugin-template/src/util.tsx
@@ -15,7 +15,7 @@ import { TEMPLATE_PLUGIN } from './types';
 export const objectToGraphNode = (parent: Node<Space>, object: TypedObject): Node<TypedObject> => {
   const [child] = parent.addNode(TEMPLATE_PLUGIN, {
     id: object.id,
-    label: object.title ?? ['object title placeholder', { ns: TEMPLATE_PLUGIN }],
+    label: object.title || ['object title placeholder', { ns: TEMPLATE_PLUGIN }],
     icon: (props) => <Asterisk {...props} />,
     data: object,
     properties: {

--- a/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Plus } from '@phosphor-icons/react';
+import { Chat } from '@phosphor-icons/react';
 import React from 'react';
 
 import { GraphNodeAdapter, SpaceAction } from '@braneframe/plugin-space';
@@ -47,10 +47,10 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
           const space = parent.data;
           const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);
 
-          parent.addAction({
+          parent.actionsMap['create-object-group']?.addAction({
             id: `${THREAD_PLUGIN}/create`,
             label: ['create thread label', { ns: THREAD_PLUGIN }],
-            icon: (props) => <Plus {...props} />,
+            icon: (props) => <Chat {...props} />,
             invoke: () =>
               intentPlugin?.provides.intent.dispatch([
                 {

--- a/packages/apps/plugins/plugin-thread/src/util.tsx
+++ b/packages/apps/plugins/plugin-thread/src/util.tsx
@@ -14,7 +14,7 @@ import { THREAD_PLUGIN } from './types';
 export const objectToGraphNode = (parent: Node<Space>, object: ThreadType): Node<ThreadType> => {
   const [child] = parent.addNode(THREAD_PLUGIN, {
     id: object.id,
-    label: object.title ?? ['thread title placeholder', { ns: THREAD_PLUGIN }],
+    label: object.title || ['thread title placeholder', { ns: THREAD_PLUGIN }],
     icon: (props) => <Chat {...props} />,
     data: object,
     properties: {

--- a/packages/sdk/app-graph/src/action.ts
+++ b/packages/sdk/app-graph/src/action.ts
@@ -63,7 +63,13 @@ export type Action<TProperties extends Record<string, any> = Record<string, any>
   removeProperty(key: string): void;
 
   addAction<TActionProperties extends Record<string, any> = Record<string, any>>(
-    ...action: (Pick<Action, 'id' | 'label' | 'invoke'> & Partial<Action<TActionProperties>>)[]
+    ...action: ActionArg<TActionProperties>[]
   ): Action<TActionProperties>[];
   removeAction(id: string): Action;
 };
+
+export type ActionArg<TProperties extends Record<string, any> = Record<string, any>> = Pick<
+  Action,
+  'id' | 'label' | 'invoke'
+> &
+  Partial<Omit<Action<TProperties>, 'id' | 'label' | 'invoke' | 'actions'>> & { actions?: ActionArg[] };

--- a/packages/sdk/app-graph/src/node.ts
+++ b/packages/sdk/app-graph/src/node.ts
@@ -7,7 +7,7 @@ import { type FC } from 'react';
 
 import type { UnsubscribeCallback } from '@dxos/async';
 
-import { type Action, type Label } from './action';
+import { type ActionArg, type Action, type Label } from './action';
 
 /**
  * Called when a node is added to the graph, allowing other node builders to add children, actions or properties.
@@ -88,15 +88,21 @@ export type Node<TData = any, TProperties extends Record<string, any> = Record<s
 
   addNode<TChildData = null, TChildProperties extends Record<string, any> = Record<string, any>>(
     id: string,
-    ...node: (Pick<Node, 'id' | 'label'> & Partial<Node<TChildData, TChildProperties>>)[]
+    ...node: NodeArg<TChildData, TChildProperties>[]
   ): Node<TChildData, TChildProperties>[];
   removeNode(id: string): Node;
 
   addAction<TActionProperties extends Record<string, any> = Record<string, any>>(
-    ...action: (Pick<Action, 'id' | 'label' | 'invoke'> & Partial<Action<TActionProperties>>)[]
+    ...action: ActionArg<TActionProperties>[]
   ): Action<TActionProperties>[];
   removeAction(id: string): Action;
 };
+
+export type NodeArg<TData = null, TProperties extends Record<string, any> = Record<string, any>> = Pick<
+  Node,
+  'id' | 'label'
+> &
+  Partial<Omit<Node<TData, TProperties>, 'id' | 'label' | 'actions'>> & { actions?: ActionArg[] };
 
 export const isGraphNode = (data: unknown): data is Node =>
   data && typeof data === 'object' ? 'id' in data && 'label' in data : false;

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
@@ -2,39 +2,26 @@
 // Copyright 2023 DXOS.org
 //
 
-import { DotsThreeVertical } from '@phosphor-icons/react';
-import React, { forwardRef, Fragment, useEffect, useRef, useState } from 'react';
+import { DotsThreeVertical, Placeholder } from '@phosphor-icons/react';
+import React, { forwardRef, Fragment, useEffect, useState } from 'react';
 
-import {
-  Button,
-  DensityProvider,
-  DropdownMenu,
-  Popover,
-  Tooltip,
-  Tree,
-  TreeItem as TreeItemComponent,
-  TreeItem,
-  useTranslation,
-} from '@dxos/react-ui';
+import { DensityProvider, Tree, TreeItem as TreeItemComponent, TreeItem, useTranslation } from '@dxos/react-ui';
 import { Mosaic, useContainer, type MosaicTileComponent, Path, useItemsWithOrigin } from '@dxos/react-ui-mosaic';
 import {
   dropRing,
   focusRing,
-  getSize,
-  hoverableControlItem,
   hoverableControls,
   hoverableFocusedKeyboardControls,
   hoverableFocusedWithinControls,
-  hoverableOpenControlItem,
   mx,
 } from '@dxos/react-ui-theme';
 
 import { useNavTree } from './NavTreeContext';
+import { NavTreeItemActionMenu } from './NavTreeItemAction';
 import { NavTreeItemHeading } from './NavTreeItemHeading';
 import { levelPadding, topLevelCollapsibleSpacing } from './navtree-fragments';
 import { translationKey } from '../translations';
-import type { TreeNode, TreeNodeAction } from '../types';
-import { keyString } from '../util';
+import type { TreeNode } from '../types';
 
 const hoverableDescriptionIcons =
   '[--icons-color:inherit] hover-hover:[--icons-color:var(--description-text)] hover-hover:hover:[--icons-color:inherit] focus-within:[--icons-color:inherit]';
@@ -67,18 +54,16 @@ const NavTreeBranch = ({ path, nodes, level }: { path: string; nodes: TreeNode[]
 export type NavTreeItemData = { id: TreeNode['id']; node: TreeNode; level: number };
 
 export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = forwardRef(
-  ({ item, draggableProps, draggableStyle, operation, active, path, position }, forwardedRef) => {
+  ({ item, draggableProps, draggableStyle, active, path, position }, forwardedRef) => {
     const { node, level } = item;
     const isBranch = node.properties?.role === 'branch' || node.children?.length > 0;
 
-    const actions = node.actions ?? [];
+    const [primaryAction, ...secondaryActions] = [...node.actions].sort((a, b) =>
+      a.properties.disposition === 'toolbar' ? -1 : 1,
+    );
+    const actions = primaryAction?.properties.disposition === 'toolbar' ? secondaryActions : node.actions;
     const { t } = useTranslation(translationKey);
     const { current, popoverAnchorId, onSelect, isOver } = useNavTree();
-
-    const suppressNextTooltip = useRef<boolean>(false);
-    const [optionsTooltipOpen, setOptionsTooltipOpen] = useState(false);
-    const [optionsMenuOpen, setOptionsMenuOpen] = useState(false);
-
     const [open, setOpen] = useState(level < 1);
 
     useEffect(() => {
@@ -92,23 +77,6 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
     const testId = node.properties?.['data-testid'];
 
     const Root = active === 'overlay' ? Tree.Root : Fragment;
-
-    const ActionRoot = popoverAnchorId === `dxos.org/ui/navtree/${node.id}` ? Popover.Anchor : Fragment;
-
-    // TODO(burdon): Factor out heuristic to group actions.
-    const actionGroups =
-      level === 1
-        ? actions.reduce<{ id: string; actions: TreeNodeAction[] }[]>((groups, action) => {
-            const id = action.id.split(/[/-]/).at(-1)!;
-            let group = groups.find((group) => group.id === id);
-            if (!group) {
-              group = { id, actions: [] };
-              groups.push(group);
-            }
-            group.actions.push(action);
-            return groups;
-          }, [])
-        : [{ id: '', actions }];
 
     return (
       <DensityProvider density='fine'>
@@ -161,97 +129,31 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
                   onSelect: () => onSelect?.({ path, node, level, position: position as number }),
                 }}
               />
-              {actionGroups.length > 0 && (
-                <ActionRoot>
-                  <Tooltip.Root
-                    open={optionsTooltipOpen}
-                    onOpenChange={(nextOpen) => {
-                      if (suppressNextTooltip.current) {
-                        setOptionsTooltipOpen(false);
-                        suppressNextTooltip.current = false;
-                      } else {
-                        setOptionsTooltipOpen(nextOpen);
-                      }
-                    }}
-                  >
-                    <Tooltip.Portal>
-                      <Tooltip.Content classNames='z-[31]' side='bottom'>
-                        {t('tree item options label')}
-                        <Tooltip.Arrow />
-                      </Tooltip.Content>
-                    </Tooltip.Portal>
-                    <DropdownMenu.Root
-                      {...{
-                        open: optionsMenuOpen,
-                        onOpenChange: (nextOpen: boolean) => {
-                          if (!nextOpen) {
-                            suppressNextTooltip.current = true;
-                          }
-                          return setOptionsMenuOpen(nextOpen);
-                        },
-                      }}
-                    >
-                      <DropdownMenu.Trigger asChild>
-                        <Tooltip.Trigger asChild>
-                          <Button
-                            variant='ghost'
-                            classNames={[
-                              'shrink-0 pli-2 pointer-fine:pli-1',
-                              hoverableControlItem,
-                              hoverableOpenControlItem,
-                              active === 'overlay' && 'invisible',
-                            ]}
-                            data-testid={`navtree.treeItem.actionsLevel${level}`}
-                          >
-                            <DotsThreeVertical className={getSize(4)} />
-                          </Button>
-                        </Tooltip.Trigger>
-                      </DropdownMenu.Trigger>
-                      <DropdownMenu.Portal>
-                        <DropdownMenu.Content classNames='z-[31]'>
-                          <DropdownMenu.Viewport>
-                            {actionGroups.map(({ id, actions }, i) => (
-                              <Fragment key={id}>
-                                {actions.map((action) => (
-                                  <DropdownMenu.Item
-                                    key={action.id}
-                                    onClick={(event) => {
-                                      if (action.properties.disabled) {
-                                        return;
-                                      }
-                                      event.stopPropagation();
-                                      // TODO(thure): Why does Dialog’s modal-ness cause issues if we don’t explicitly close the menu here?
-                                      suppressNextTooltip.current = true;
-                                      setOptionsMenuOpen(false);
-                                      void action.invoke();
-                                    }}
-                                    classNames='gap-2'
-                                    disabled={action.properties.disabled}
-                                    {...(action.properties?.testId && { 'data-testid': action.properties.testId })}
-                                  >
-                                    {action.icon && (
-                                      <div className='shrink-0'>
-                                        <action.icon className={getSize(4)} />
-                                      </div>
-                                    )}
-                                    <div className='grow truncate'>
-                                      {Array.isArray(action.label) ? t(...action.label) : action.label}
-                                    </div>
-                                    {action.keyBinding && (
-                                      <div className='shrink-0 opacity-50'>{keyString(action.keyBinding)}</div>
-                                    )}
-                                  </DropdownMenu.Item>
-                                ))}
-                                {i < actionGroups.length - 1 && <DropdownMenu.Separator />}
-                              </Fragment>
-                            ))}
-                          </DropdownMenu.Viewport>
-                          <DropdownMenu.Arrow />
-                        </DropdownMenu.Content>
-                      </DropdownMenu.Portal>
-                    </DropdownMenu.Root>
-                  </Tooltip.Root>
-                </ActionRoot>
+              {/*
+              TODO(wittjosiah): Primary action should come at the end.
+              However, currently if it does then the triple dots menus don't line up for nodes without primary actions. */}
+              {primaryAction?.properties.disposition === 'toolbar' && (
+                <NavTreeItemActionMenu
+                  id={node.id}
+                  label={Array.isArray(primaryAction.label) ? t(...primaryAction.label) : primaryAction.label}
+                  icon={primaryAction.icon ?? Placeholder}
+                  action={primaryAction.actions.length === 0 ? primaryAction : undefined}
+                  actions={primaryAction.actions}
+                  level={level}
+                  active={active}
+                  popoverAnchorId={popoverAnchorId}
+                />
+              )}
+              {actions.length > 0 && (
+                <NavTreeItemActionMenu
+                  id={node.id}
+                  label={t('tree item actions label')}
+                  icon={DotsThreeVertical}
+                  actions={actions}
+                  level={level}
+                  active={active}
+                  popoverAnchorId={popoverAnchorId}
+                />
               )}
             </div>
             {!active && isBranch && <NavTreeBranch path={path} nodes={node.children} level={level + 1} />}

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
@@ -74,7 +74,6 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
 
     const disabled = !!(node.properties?.disabled ?? node.properties?.isPreview);
     const forceCollapse = active === 'overlay' || active === 'destination' || active === 'rearrange' || disabled;
-    const testId = node.properties?.['data-testid'];
 
     const Root = active === 'overlay' ? Tree.Root : Fragment;
 
@@ -96,7 +95,7 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
             ]}
             {...draggableProps}
             data-itemid={item.id}
-            data-testid={testId}
+            data-testid={node.properties.testId}
             style={draggableStyle}
             ref={forwardedRef}
             role='treeitem'
@@ -142,6 +141,7 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
                   level={level}
                   active={active}
                   popoverAnchorId={popoverAnchorId}
+                  testId={primaryAction.properties.testId}
                 />
               )}
               {actions.length > 0 && (
@@ -153,6 +153,7 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
                   level={level}
                   active={active}
                   popoverAnchorId={popoverAnchorId}
+                  testId={`navtree.treeItem.actionsLevel${level}`}
                 />
               )}
             </div>

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItemAction.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItemAction.tsx
@@ -22,6 +22,7 @@ type NavTreeItemActionMenuProps = {
   level: number;
   active?: MosaicActiveType;
   popoverAnchorId?: string;
+  testId?: string;
 };
 
 export const NavTreeItemActionMenu = ({
@@ -33,6 +34,7 @@ export const NavTreeItemActionMenu = ({
   active,
   level,
   popoverAnchorId,
+  testId,
 }: NavTreeItemActionMenuProps) => {
   const { t } = useTranslation(translationKey);
 
@@ -78,7 +80,7 @@ export const NavTreeItemActionMenu = ({
                 event.stopPropagation();
                 void action.invoke();
               }}
-              data-testid={`navtree.treeItem.actionsLevel${level}`}
+              data-testid={testId}
             >
               <Icon className={getSize(4)} />
             </Button>
@@ -105,7 +107,7 @@ export const NavTreeItemActionMenu = ({
                     hoverableOpenControlItem,
                     active === 'overlay' && 'invisible',
                   ]}
-                  data-testid={`navtree.treeItem.actionsLevel${level}`}
+                  data-testid={testId}
                 >
                   <Icon className={getSize(4)} />
                 </Button>

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItemAction.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItemAction.tsx
@@ -1,0 +1,154 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { type IconProps } from '@phosphor-icons/react';
+import React, { type FC, Fragment, useRef, useState } from 'react';
+
+import { Button, DropdownMenu, Popover, Tooltip, useTranslation } from '@dxos/react-ui';
+import { type MosaicActiveType } from '@dxos/react-ui-mosaic';
+import { getSize, hoverableControlItem, hoverableOpenControlItem } from '@dxos/react-ui-theme';
+
+import { translationKey } from '../translations';
+import type { TreeNodeAction } from '../types';
+import { keyString } from '../util';
+
+type NavTreeItemActionMenuProps = {
+  id: string;
+  label: string;
+  icon: FC<IconProps>;
+  action?: TreeNodeAction;
+  actions?: TreeNodeAction[];
+  level: number;
+  active?: MosaicActiveType;
+  popoverAnchorId?: string;
+};
+
+export const NavTreeItemActionMenu = ({
+  id,
+  label,
+  icon: Icon,
+  action,
+  actions,
+  active,
+  level,
+  popoverAnchorId,
+}: NavTreeItemActionMenuProps) => {
+  const { t } = useTranslation(translationKey);
+
+  const suppressNextTooltip = useRef<boolean>(false);
+  const [optionsTooltipOpen, setOptionsTooltipOpen] = useState(false);
+  const [optionsMenuOpen, setOptionsMenuOpen] = useState(false);
+
+  const ActionRoot = popoverAnchorId === `dxos.org/ui/navtree/${id}` ? Popover.Anchor : Fragment;
+
+  return (
+    <ActionRoot>
+      <Tooltip.Root
+        open={optionsTooltipOpen}
+        onOpenChange={(nextOpen) => {
+          if (suppressNextTooltip.current) {
+            setOptionsTooltipOpen(false);
+            suppressNextTooltip.current = false;
+          } else {
+            setOptionsTooltipOpen(nextOpen);
+          }
+        }}
+      >
+        <Tooltip.Portal>
+          <Tooltip.Content classNames='z-[31]' side='bottom'>
+            {label}
+            <Tooltip.Arrow />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+        {action ? (
+          <Tooltip.Trigger asChild>
+            <Button
+              variant='ghost'
+              classNames={[
+                'shrink-0 pli-2 pointer-fine:pli-1',
+                hoverableControlItem,
+                hoverableOpenControlItem,
+                active === 'overlay' && 'invisible',
+              ]}
+              onClick={(event) => {
+                if (action.properties.disabled) {
+                  return;
+                }
+                event.stopPropagation();
+                void action.invoke();
+              }}
+              data-testid={`navtree.treeItem.actionsLevel${level}`}
+            >
+              <Icon className={getSize(4)} />
+            </Button>
+          </Tooltip.Trigger>
+        ) : (
+          <DropdownMenu.Root
+            {...{
+              open: optionsMenuOpen,
+              onOpenChange: (nextOpen: boolean) => {
+                if (!nextOpen) {
+                  suppressNextTooltip.current = true;
+                }
+                return setOptionsMenuOpen(nextOpen);
+              },
+            }}
+          >
+            <DropdownMenu.Trigger asChild>
+              <Tooltip.Trigger asChild>
+                <Button
+                  variant='ghost'
+                  classNames={[
+                    'shrink-0 pli-2 pointer-fine:pli-1',
+                    hoverableControlItem,
+                    hoverableOpenControlItem,
+                    active === 'overlay' && 'invisible',
+                  ]}
+                  data-testid={`navtree.treeItem.actionsLevel${level}`}
+                >
+                  <Icon className={getSize(4)} />
+                </Button>
+              </Tooltip.Trigger>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Portal>
+              <DropdownMenu.Content classNames='z-[31]'>
+                <DropdownMenu.Viewport>
+                  {actions?.map((action) => (
+                    <DropdownMenu.Item
+                      key={action.id}
+                      onClick={(event) => {
+                        if (action.properties.disabled) {
+                          return;
+                        }
+                        event.stopPropagation();
+                        // TODO(thure): Why does Dialog’s modal-ness cause issues if we don’t explicitly close the menu here?
+                        suppressNextTooltip.current = true;
+                        setOptionsMenuOpen(false);
+                        void action.invoke();
+                      }}
+                      classNames='gap-2'
+                      disabled={action.properties.disabled}
+                      {...(action.properties?.testId && { 'data-testid': action.properties.testId })}
+                    >
+                      {action.icon && (
+                        <div className='shrink-0'>
+                          <action.icon className={getSize(4)} />
+                        </div>
+                      )}
+                      <div className='grow truncate'>
+                        {Array.isArray(action.label) ? t(...action.label) : action.label}
+                      </div>
+                      {action.keyBinding && <div className='shrink-0 opacity-50'>{keyString(action.keyBinding)}</div>}
+                    </DropdownMenu.Item>
+                  ))}
+                </DropdownMenu.Viewport>
+                <DropdownMenu.Arrow />
+              </DropdownMenu.Content>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Root>
+        )}
+      </Tooltip.Root>
+    </ActionRoot>
+  );
+};

--- a/packages/ui/react-ui-navtree/src/translations.ts
+++ b/packages/ui/react-ui-navtree/src/translations.ts
@@ -8,7 +8,7 @@ export default [
   {
     'en-US': {
       [translationKey]: {
-        'tree item options label': 'More options',
+        'tree item actions label': 'More actions',
       },
     },
   },


### PR DESCRIPTION

![Screenshot from 2023-10-26 13-55-02](https://github.com/dxos/dxos/assets/4529818/276251a3-acd3-4ef7-8e1f-ef83a4060012)


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9d22924</samp>

### Summary
🛠️🌐🎨

<!--
1.  🛠️ - This emoji represents the changes that involve replacing the nullish coalescing operator with the logical OR operator, as well as removing unused imports and properties. These changes are mainly related to fixing or improving the code quality and compatibility of the app.
2. 🌐 - This emoji represents the changes that involve adding a new translation key and value for the create object group label. This change is related to providing localization and accessibility for the app interface.
3. 🎨 - This emoji represents the changes that involve changing the icons and the toolbar structure for creating different object types in the app. These changes are related to enhancing the user interface and the visual design of the app.
-->
This pull request updates the icons, toolbar layouts, and create actions for various object types in different app plugins. It also replaces the nullish coalescing operator with the logical OR operator in several util functions and components to improve browser compatibility. Additionally, it adds a new icon and a new action for creating object groups in the space app, and a new translation key and value for the corresponding label. These changes aim to improve the consistency, usability, and code quality of the app plugins.

> _We're changing icons and actions for the app_
> _We're using logical OR for fallback values_
> _We're grouping create buttons under one tab_
> _We're heaving away on the count of three_

### Walkthrough
*  Replaced the Plus icon with different icons for different object types in the app ([link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-c434839cd4727f761281b1b09d73385d6aefd4c10fd365be8e106393c339eb83L5-R5), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-c434839cd4727f761281b1b09d73385d6aefd4c10fd365be8e106393c339eb83L50-R53), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-863c4dd98ebe3f4ea4b0dc7cfac77c921030acf7a86aff81a07cbb125715f105L5-R5), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-863c4dd98ebe3f4ea4b0dc7cfac77c921030acf7a86aff81a07cbb125715f105L44-R47), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-5c9fde0c8e96e1e2d2fba66754743c68e96e5ec868fedbfb3e7dbbf2d0ba92f0L5-R5), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-5c9fde0c8e96e1e2d2fba66754743c68e96e5ec868fedbfb3e7dbbf2d0ba92f0L46-R49), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-fcc42cb616fe84778978fa7e79674e0a44857d88f697f901ef4b18bc4fe5df42L5-R5), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-fcc42cb616fe84778978fa7e79674e0a44857d88f697f901ef4b18bc4fe5df42L46-R49), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-df2d060ba290955534c46707ff60bd53a2f12dab723b120b393c6643dbc22233L5-R5), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-df2d060ba290955534c46707ff60bd53a2f12dab723b120b393c6643dbc22233L52-R55), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-4d53bb710b39a0d80a584d6ab63b7b2fb89608698c12a8d5ac55795dad60d0fcL217-R220), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-1f158f67824d4766e0a4df22f107e6f1f2133836a579a756eddaf076d873ee89L56-R59), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L5-R5), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L318-R318), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-40c06872035a3fca913d3ecf4b86bab147706b739e5546f25845364df1b60203L5-R14), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-73f12af5e023ef40bc928d988f0d7626f1db6bf7d07a1d91a2dfd4553a50d9e3L5-R5), [link](https://github.com/dxos/dxos/pull/4518/files?diff=unified&w=0#diff-73f12af5e023ef40bc928d988f0d7626f1db6bf7d07a1d91a2dfd4553a50d9e3L68-R71)). This affects the files `ChessPlugin.tsx`, `ExplorerPlugin.tsx`, `GridPlugin.tsx`, `KanbanPlugin.tsx`, `MapPlugin.tsx`, `MarkdownPlugin.tsx`, `SketchPlugin.tsx`, `SpacePlugin.tsx`, `StackPlugin.tsx`, and `util.tsx`.


