### PR TITLE
fix: Type comparison in filters

### DIFF
--- a/packages/core/echo/echo-schema/src/index.ts
+++ b/packages/core/echo/echo-schema/src/index.ts
@@ -8,7 +8,7 @@ export * from './array';
 export * from './database';
 export * from './defs';
 export * from './echo-object-base';
-export * from './query';
+export { Query, type QueryContext, type QueryResult, type QuerySource, type Sort, type Subscription } from './query';
 export * from './hypergraph';
 export { TypeCollection } from './type-collection';
 export * from './serializer';


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4b08994</samp>

### Summary
📦🧪🔧

<!--
1.  📦 for re-exporting the `query` module with explicit named exports.
2.  🧪 for adding a new test case for the `compareType` function.
3.  🔧 for refactoring the `filterMatchInner` function to use the new `compareType` function.
-->
Improved and tested the query logic for echo schema. Refactored `filterMatchInner` to use `compareType` for consistent handling of `Reference` objects. Changed the export style of `query` module in `index.ts` to avoid name conflicts.

> _No more conflicts in the query module_
> _We export the names that we choose_
> _We test the types with precision and skill_
> _We compare the references and use them at will_

### Walkthrough
*  Simplify type comparison logic for echo objects and filters using a new helper function `compareType` ([link](https://github.com/dxos/dxos/pull/4519/files?diff=unified&w=0#diff-90cb7ef308369fe5b2978ef97e5241c5b7b693224435354659681938242520bbR247-R262),[link](https://github.com/dxos/dxos/pull/4519/files?diff=unified&w=0#diff-90cb7ef308369fe5b2978ef97e5241c5b7b693224435354659681938242520bbL208-R216),[link](https://github.com/dxos/dxos/pull/4519/files?diff=unified&w=0#diff-90cb7ef308369fe5b2978ef97e5241c5b7b693224435354659681938242520bbR7))
*  Re-export `query` module with explicit named exports instead of wildcard to avoid potential conflicts ([link](https://github.com/dxos/dxos/pull/4519/files?diff=unified&w=0#diff-d216543d254872ed072d18bf2c6ad7f786fc5c02c9226c5adda503a2d23b98f6L11-R11))
*  Add test case for `compareType` function using different scenarios of `Reference` objects ([link](https://github.com/dxos/dxos/pull/4519/files?diff=unified&w=0#diff-ce9dd63c422567ed0f30ace9d7d4317bbf0a55a9cf9f6e610c5dcb95e3258988R207-R239),[link](https://github.com/dxos/dxos/pull/4519/files?diff=unified&w=0#diff-ce9dd63c422567ed0f30ace9d7d4317bbf0a55a9cf9f6e610c5dcb95e3258988L8-R14))


