### PR TITLE
feat: Multi-space query hook

### DIFF
--- a/packages/sdk/react-client/src/echo/useQuery.ts
+++ b/packages/sdk/react-client/src/echo/useQuery.ts
@@ -36,7 +36,7 @@ export const useQuery: UseQuery = <T extends TypedObject>(...args: any[]) => {
 
   const query = useMemo(
     () => client.spaces.query(filter, options) as Query<T> | undefined,
-    [client.spaces, ...(typeof filter === 'function' ? [] : filterToDepsArray(filter)), ...(deps ?? [])],
+    [space, ...(typeof filter === 'function' ? [] : filterToDepsArray(filter)), ...(deps ?? [])],
   );
 
   // https://beta.reactjs.org/reference/react/useSyncExternalStore

--- a/packages/sdk/react-client/src/echo/useQuery.ts
+++ b/packages/sdk/react-client/src/echo/useQuery.ts
@@ -20,7 +20,8 @@ type UseQuery = {
 export const useQuery: UseQuery = <T extends TypedObject>(...args: any[]) => {
   let space: Space | undefined;
 
-  if (args.length === 4) {
+  // args[0] === space heuristic
+  if (typeof args[0].db === 'object') {
     space = args[0];
     args.shift();
   }

--- a/packages/sdk/react-client/src/echo/useQuery.ts
+++ b/packages/sdk/react-client/src/echo/useQuery.ts
@@ -6,23 +6,37 @@ import { useMemo, useSyncExternalStore } from 'react';
 
 import type { QueryOptions, TypedObject, Query, FilterSource, Space } from '@dxos/client/echo';
 
+import { useClient } from '../client';
+
 type UseQuery = {
   <T extends TypedObject>(space?: Space, filter?: FilterSource<T>, options?: QueryOptions, deps?: any[]): T[];
+  <T extends TypedObject>(filter?: FilterSource<T>, options?: QueryOptions, deps?: any[]): T[];
 };
 
 /**
  * Create subscription.
  */
 // TODO(burdon): Support typed operator filters (e.g., Note.filter(note => ...)).
-export const useQuery: UseQuery = <T extends TypedObject>(
-  space?: Space,
-  filter?: FilterSource<T>,
-  options?: QueryOptions,
-  deps?: any[],
-) => {
+export const useQuery: UseQuery = <T extends TypedObject>(...args: any[]) => {
+  let space: Space | undefined;
+
+  if (args.length === 4) {
+    space = args[0];
+    args.shift();
+  }
+
+  let [filter, options, deps] = args as [filter?: FilterSource<T>, options?: QueryOptions, deps?: any[]];
+
+  options ??= {};
+  if (space) {
+    options.spaces = [space];
+  }
+
+  const client = useClient();
+
   const query = useMemo(
-    () => space?.db.query(filter, options) as Query<T> | undefined,
-    [space?.db, ...(typeof filter === 'function' ? [] : filterToDepsArray(filter)), ...(deps ?? [])],
+    () => client.spaces.query(filter, options) as Query<T> | undefined,
+    [client.spaces, ...(typeof filter === 'function' ? [] : filterToDepsArray(filter)), ...(deps ?? [])],
   );
 
   // https://beta.reactjs.org/reference/react/useSyncExternalStore


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8085c49</samp>

### Summary
:sparkles::recycle::memo:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, which is the overload of `useQuery` hook to support multiple spaces and default space.
2.  :recycle: This emoji represents the refactoring of code, which is the hook implementation using `client.spaces.query` method.
3.  :memo: This emoji represents the documentation or comments, which are needed to explain the new overload and the hook behavior.
-->
Enhanced `useQuery` hook to allow querying across multiple or default spaces. Simplified hook code by using existing `client.spaces.query` method.

> _Oh we're the coders of the sea, and we query with a hook_
> _We can handle many spaces, or just one with a look_
> _So heave away, me hearties, heave away with glee_
> _We'll use the `client.spaces.query` method on the count of three_

### Walkthrough
* Overload `useQuery` type to allow omitting `space` parameter and use default space from client ([link](https://github.com/dxos/dxos/pull/4522/files?diff=unified&w=0#diff-ce4de75a52c8f72ff79916fd8d91fe6090d591eb22cf606e3d2d47e5d32d16f8L9-R13)).


