### PR TITLE
fix(plugin-space): Fix nondeterministic rearrange updates

### DIFF
--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -20,7 +20,7 @@ import {
   LayoutAction,
 } from '@dxos/app-framework';
 import { EventSubscriptions, type UnsubscribeCallback } from '@dxos/async';
-import { isTypedObject, type Query, subscribe } from '@dxos/echo-schema';
+import { isTypedObject, subscribe } from '@dxos/echo-schema';
 import { LocalStorageStore } from '@dxos/local-storage';
 import { PublicKey } from '@dxos/react-client';
 import { type Space, SpaceProxy } from '@dxos/react-client/echo';
@@ -297,9 +297,11 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
                     order: nextOrder,
                   });
                   client.spaces.default.db.add(nextObjectOrder);
+                  spacesOrder = nextObjectOrder;
                 } else {
                   spacesOrder.order = nextOrder;
                 }
+                updateSpacesOrder({ objects: [spacesOrder] });
               },
             },
           });
@@ -369,7 +371,7 @@ export const SpacePlugin = (): PluginDefinition<SpacePluginProvides> => {
             },
           );
 
-          const updateSpacesOrder = ({ objects: spacesOrders }: Query<ObjectOrder>) => {
+          const updateSpacesOrder = ({ objects: spacesOrders }: { objects: ObjectOrder[] }) => {
             spacesOrder = spacesOrders[0];
             groupNode.childrenMap = inferRecordOrder(groupNode.childrenMap, spacesOrder?.order);
           };

--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -10,7 +10,7 @@ import { type Node } from '@braneframe/plugin-graph';
 import { ObjectOrder } from '@braneframe/types';
 import { type DispatchIntent } from '@dxos/app-framework';
 import { type UnsubscribeCallback } from '@dxos/async';
-import { clone, type Query } from '@dxos/echo-schema';
+import { clone } from '@dxos/echo-schema';
 import { PublicKey, type PublicKeyLike } from '@dxos/keys';
 import { EchoDatabase, type Space, SpaceState, type TypedObject } from '@dxos/react-client/echo';
 import { inferRecordOrder } from '@dxos/util';
@@ -87,9 +87,11 @@ export const spaceToGraphNode = ({
               order: nextOrder,
             });
             space.db.add(nextObjectOrder);
+            spaceOrder = nextObjectOrder;
           } else {
             spaceOrder.order = nextOrder;
           }
+          updateSpaceOrder({ objects: [spaceOrder] });
         },
         persistenceClass: 'appState',
         acceptPersistenceClass: new Set(['spaceObject']),
@@ -110,7 +112,7 @@ export const spaceToGraphNode = ({
     });
   });
 
-  const updateSpaceOrder = ({ objects: spacesOrders }: Query<ObjectOrder>) => {
+  const updateSpaceOrder = ({ objects: spacesOrders }: { objects: ObjectOrder[] }) => {
     spaceOrder = spacesOrders[0];
     node.childrenMap = inferRecordOrder(node.childrenMap, spaceOrder?.order);
   };


### PR DESCRIPTION
This PR fixes a problem where rearrange would not always update the order in the tree.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d655450</samp>

### Summary
🐛🗑️♻️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of both changes. It indicates that a problem or error was resolved in the code.
2. 🗑️ - This emoji represents removing something, such as an unused import or a redundant code. It indicates that the code was cleaned up or simplified.
3. ♻️ - This emoji represents refactoring or improving the code quality, such as using a more specific type or a better query. It indicates that the code was made more readable, maintainable, or efficient.
-->
Fixed a bug with space order persistence in `plugin-space` and improved the query type for object order. Refactored some code and removed unused imports in `SpacePlugin.tsx` and `util.tsx`.

> _`SpaceOrder` fixed_
> _Query type refactored too_
> _Autumn leaves unused_

### Walkthrough
*  Fix bug where spaces and apps order was not persisted correctly by updating the order object in the database and calling the update functions ([link](https://github.com/dxos/dxos/pull/4526/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L300-R304), [link](https://github.com/dxos/dxos/pull/4526/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L372-R374), [link](https://github.com/dxos/dxos/pull/4526/files?diff=unified&w=0#diff-40c06872035a3fca913d3ecf4b86bab147706b739e5546f25845364df1b60203L90-R94), [link](https://github.com/dxos/dxos/pull/4526/files?diff=unified&w=0#diff-40c06872035a3fca913d3ecf4b86bab147706b739e5546f25845364df1b60203L113-R115))
* Remove unused and erroneous `Query` import from `@dxos/echo-schema` in `SpacePlugin.tsx` and `util.tsx` ([link](https://github.com/dxos/dxos/pull/4526/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L23-R23), [link](https://github.com/dxos/dxos/pull/4526/files?diff=unified&w=0#diff-40c06872035a3fca913d3ecf4b86bab147706b739e5546f25845364df1b60203L13-R13))


