### PR TITLE
feat: Typed operator filters

### DIFF
--- a/packages/core/agent/project.json
+++ b/packages/core/agent/project.json
@@ -42,7 +42,7 @@
         "{options.outputFile}"
       ]
     },
-    "test": {
+    "e2e": {
       "executor": "@dxos/test:run",
       "options": {
         "checkLeaks": false,

--- a/packages/core/echo/echo-schema/src/proto/reexports.ts
+++ b/packages/core/echo/echo-schema/src/proto/reexports.ts
@@ -6,5 +6,5 @@
 
 export { type TypedObjectOptions, TextObject, TypedObject } from '../object';
 export { TypeCollection } from '../type-collection';
-export { Filter } from '../query';
+export { Filter, type OperatorFilter } from '../query';
 export { type Schema } from './index';

--- a/packages/core/echo/echo-schema/src/query/filter.ts
+++ b/packages/core/echo/echo-schema/src/query/filter.ts
@@ -106,11 +106,19 @@ export class Filter<T extends EchoObject = EchoObject> {
     });
   }
 
-  static typename(typename: string, properties?: Record<string, any>) {
-    return new Filter({
-      type: Reference.fromLegacyTypename(typename),
-      properties,
-    });
+  static typename(typename: string, filter?: Record<string, any> | OperatorFilter<any>) {
+    const type = Reference.fromLegacyTypename(typename);
+
+    switch (typeof filter) {
+      case 'function':
+        return new Filter({ type, predicate: filter as any });
+      case 'object':
+        return new Filter({ type, properties: filter });
+      case 'undefined':
+        return new Filter({ type });
+      default:
+        throw new TypeError('Invalid filter.');
+    }
   }
 
   static not<T extends EchoObject>(source: Filter<T>): Filter<T> {

--- a/packages/core/echo/echo-schema/src/tests/database.test.ts
+++ b/packages/core/echo/echo-schema/src/tests/database.test.ts
@@ -159,4 +159,14 @@ describe('database', () => {
 
     expect(() => db1.add(task1)).to.throw;
   });
+
+  test('operator-based filters', async () => {
+    const { db: database } = await createDatabase(new Hypergraph().addTypes(types));
+
+    database.add(new Task({ title: 'foo 1' }));
+    database.add(new Task({ title: 'foo 2' }));
+    database.add(new Task({ title: 'bar 3' }));
+
+    expect(database.query(Task.filter((task) => task.title.startsWith('foo'))).objects).to.have.length(2);
+  });
 });

--- a/packages/core/echo/echo-typegen/src/codegen.ts
+++ b/packages/core/echo/echo-typegen/src/codegen.ts
@@ -182,8 +182,8 @@ export const createObjectClass = (type: pb.Type) => {
     export class ${name} extends ${importNamespace}.TypedObject<${name}Props> {
       declare static readonly schema: ${importNamespace}.Schema;
 
-      static filter(opts?: Partial<${name}Props>): ${importNamespace}.Filter<${name}> {
-        return ${importNamespace}.Filter.typename('${fullName}', opts);
+      static filter(filter?: Partial<${name}Props> | ${importNamespace}.OperatorFilter<${name}>): ${importNamespace}.Filter<${name}> {
+        return ${importNamespace}.Filter.typename('${fullName}', filter);
       }
   
       constructor(initValues?: Partial<${name}Props>, opts?: ${importNamespace}.TypedObjectOptions) {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cacb180</samp>

### Summary
🚀🛠️✅

<!--
1.  🚀 - This emoji represents the new feature of exporting the `OperatorFilter` type and allowing it to be used as a filter argument. This emoji conveys the idea of launching or enhancing a functionality.
2.  🛠️ - This emoji represents the modification of the `Filter.typename` method and the `filter` static method of the object classes. This emoji conveys the idea of fixing or improving something.
3.  ✅ - This emoji represents the addition of the new test case. This emoji conveys the idea of verifying or confirming something.
-->
Added support for operator-based filters in `echo-schema` and `echo-typegen`. Modified the `Filter` class and the generated object classes to accept functions as filter arguments. Added a test case for the new feature.

> _`Filter` now accepts_
> _object or function as arg_
> _more ways to query_

### Walkthrough
*  Export `OperatorFilter` type from `query` module to enable filtering objects by operators ([link](https://github.com/dxos/dxos/pull/4534/files?diff=unified&w=0#diff-5216ed1ac57768fe1c45c8d0bce191940170b7ebf788a9795a49aee3921f0c16L9-R9))
*  Modify `Filter.typename` method to accept either an object or a function as filter argument and create a `Filter` instance accordingly ([link](https://github.com/dxos/dxos/pull/4534/files?diff=unified&w=0#diff-fba1cf9cd9c81b2831da307fb377effb65c0e48fdcd73418257363785f8e0a2aL109-R121))
*  Update `filter` static method of generated object classes to match `Filter.typename` signature and expose operator-based filtering ([link](https://github.com/dxos/dxos/pull/4534/files?diff=unified&w=0#diff-7e79d5937010f09f3619776bd506b065a31aa0f03d3dc498d103cf1bc1a2bd6bL185-R186))
*  Add test case to verify operator-based filters work as expected when querying objects from database ([link](https://github.com/dxos/dxos/pull/4534/files?diff=unified&w=0#diff-fc11f77f083589f9845cf7600bba7b6828424cabf299f2ba3acd5125dbbba10cR162-R171))


