### PR TITLE
fix: Presenter working with sketch

### DIFF
--- a/packages/apps/plugins/plugin-ipfs/src/components/FileMain.tsx
+++ b/packages/apps/plugins/plugin-ipfs/src/components/FileMain.tsx
@@ -60,7 +60,7 @@ export const FileSlide: FC<{ file: TypedObject }> = ({ file }) => {
   // TODO(burdon): Config object-container/-fit.
   return (
     <div className='h-full'>
-      <FilePreview type={file.type} url={url} className='object-fit' />
+      <FilePreview type={file.type} url={url} className='object-cover' />
     </div>
   );
 };

--- a/packages/apps/plugins/plugin-ipfs/src/components/FilePreview.tsx
+++ b/packages/apps/plugins/plugin-ipfs/src/components/FilePreview.tsx
@@ -20,5 +20,5 @@ export const FilePreview: FC<FilePreviewProps> = ({ type, url, className }) => {
     return <iframe className={mx('w-full h-full overflow-auto', className)} src={url} />;
   }
 
-  return <img className={mx('w-full h-full object-contain', className)} src={url} />;
+  return <img className={mx('w-full h-full', className ?? 'object-fit')} src={url} />;
 };

--- a/packages/apps/plugins/plugin-layout/README.md
+++ b/packages/apps/plugins/plugin-layout/README.md
@@ -1,6 +1,6 @@
 # @braneframe/plugin-layout
 
-DXOS Surface plugin for a split view application layout.
+DXOS Surface plugin for the main application layout.
 
 ## DXOS Resources
 

--- a/packages/apps/plugins/plugin-layout/package.json
+++ b/packages/apps/plugins/plugin-layout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@braneframe/plugin-layout",
   "version": "0.3.3",
-  "description": "DXOS Surface plugin for a split view application layout.",
+  "description": "DXOS Surface plugin for the main application layout.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
   "license": "MIT",

--- a/packages/apps/plugins/plugin-layout/src/LayoutPlugin.tsx
+++ b/packages/apps/plugins/plugin-layout/src/LayoutPlugin.tsx
@@ -33,7 +33,7 @@ import { LocalStorageStore } from '@dxos/local-storage';
 import { Mosaic } from '@dxos/react-ui-mosaic';
 
 import { LayoutContext, useLayout } from './LayoutContext';
-import { SplitView, ContextView, ContentEmpty } from './components';
+import { MainLayout, ContextView, ContentEmpty } from './components';
 import { activeToUri, uriToActive } from './helpers';
 import translations from './translations';
 import { LAYOUT_PLUGIN, type LayoutState } from './types';
@@ -168,11 +168,11 @@ export const LayoutPlugin = (options?: LayoutPluginOptions): PluginDefinition<La
         const surfaceProps: SurfaceProps = layout.activeNode
           ? state.values.fullscreen
             ? {
-                data: { component: `${LAYOUT_PLUGIN}/SplitView` },
-                surfaces: { main: { data: layout.activeNode.data } },
+                data: { component: `${LAYOUT_PLUGIN}/MainLayout` },
+                surfaces: { main: { data: { active: layout.activeNode.data } } },
               }
             : {
-                data: { component: `${LAYOUT_PLUGIN}/SplitView` },
+                data: { component: `${LAYOUT_PLUGIN}/MainLayout` },
                 surfaces: {
                   sidebar: {
                     data: { graph, activeId: layout.active, popoverAnchorId: layout.popoverAnchorId },
@@ -188,7 +188,7 @@ export const LayoutPlugin = (options?: LayoutPluginOptions): PluginDefinition<La
                 },
               }
           : {
-              data: { component: `${LAYOUT_PLUGIN}/SplitView` },
+              data: { component: `${LAYOUT_PLUGIN}/MainLayout` },
               surfaces: {
                 sidebar: {
                   data: { graph, activeId: layout.active, popoverAnchorId: layout.popoverAnchorId },
@@ -209,9 +209,9 @@ export const LayoutPlugin = (options?: LayoutPluginOptions): PluginDefinition<La
       surface: {
         component: ({ component }) => {
           switch (component) {
-            case `${LAYOUT_PLUGIN}/SplitView`:
+            case `${LAYOUT_PLUGIN}/MainLayout`:
               return (
-                <SplitView fullscreen={state.values.fullscreen} showComplementarySidebar={showComplementarySidebar} />
+                <MainLayout fullscreen={state.values.fullscreen} showComplementarySidebar={showComplementarySidebar} />
               );
 
             case `${LAYOUT_PLUGIN}/ContentEmpty`:
@@ -230,12 +230,13 @@ export const LayoutPlugin = (options?: LayoutPluginOptions): PluginDefinition<La
           switch (intent.action) {
             case LayoutAction.TOGGLE_FULLSCREEN: {
               state.values.fullscreen =
-                (intent.data as LayoutAction.ToggleFullscreen).state ?? !state.values.fullscreen;
+                (intent.data as LayoutAction.ToggleFullscreen)?.state ?? !state.values.fullscreen;
               return true;
             }
 
             case LayoutAction.TOGGLE_SIDEBAR: {
-              state.values.sidebarOpen = (intent.data as LayoutAction.ToggleSidebar).state ?? !state.values.sidebarOpen;
+              state.values.sidebarOpen =
+                (intent.data as LayoutAction.ToggleSidebar)?.state ?? !state.values.sidebarOpen;
               return true;
             }
 

--- a/packages/apps/plugins/plugin-layout/src/components/MainLayout.tsx
+++ b/packages/apps/plugins/plugin-layout/src/components/MainLayout.tsx
@@ -13,18 +13,22 @@ import { Fallback } from './Fallback';
 import { useLayout } from '../LayoutContext';
 import { LAYOUT_PLUGIN } from '../types';
 
-export type SplitViewProps = {
+export type MainLayoutProps = {
   fullscreen?: boolean;
   showComplementarySidebar?: boolean;
 };
 
-export const SplitView = ({ fullscreen, showComplementarySidebar = true }: SplitViewProps) => {
+export const MainLayout = ({ fullscreen, showComplementarySidebar = true }: MainLayoutProps) => {
   const context = useLayout();
   const { complementarySidebarOpen, dialogOpen, dialogContent, popoverOpen, popoverContent, popoverAnchorId } = context;
   const { t } = useTranslation(LAYOUT_PLUGIN);
 
   if (fullscreen) {
-    return <Surface name='main' role='main' limit={1} />;
+    return (
+      <div className='flex absolute inset-0'>
+        <Surface role='main' limit={1} />
+      </div>
+    );
   }
 
   return (
@@ -40,8 +44,9 @@ export const SplitView = ({ fullscreen, showComplementarySidebar = true }: Split
       }}
     >
       <div role='none' className='sr-only'>
-        <Surface name='documentTitle' role='document-title' limit={1} />
+        <Surface role='document-title' name='documentTitle' limit={1} />
       </div>
+
       <Main.Root
         navigationSidebarOpen={context.sidebarOpen}
         onNavigationSidebarOpenChange={(next) => (context.sidebarOpen = next)}
@@ -50,17 +55,15 @@ export const SplitView = ({ fullscreen, showComplementarySidebar = true }: Split
           onComplementarySidebarOpenChange: (next) => (context.complementarySidebarOpen = next),
         })}
       >
-        {/* TODO(burdon): name vs. role? */}
-
         {/* Left navigation sidebar. */}
         <Main.NavigationSidebar classNames='overflow-hidden'>
-          <Surface name='sidebar' role='navigation' />
+          <Surface role='navigation' name='sidebar' />
         </Main.NavigationSidebar>
 
         {/* Right Complementary sidebar. */}
         {complementarySidebarOpen !== null && showComplementarySidebar && (
           <Main.ComplementarySidebar classNames='overflow-hidden'>
-            <Surface name='complementary' role='context' />
+            <Surface role='context' name='complementary' />
           </Main.ComplementarySidebar>
         )}
 
@@ -75,10 +78,13 @@ export const SplitView = ({ fullscreen, showComplementarySidebar = true }: Split
                 <span className='sr-only'>{t('open navigation sidebar label')}</span>
                 <MenuIcon weight='light' className={getSize(4)} />
               </Button>
+
               <Surface role='heading' limit={2} />
               <div role='none' className='grow' />
+
               {/* TODO(burdon): Too specific? status? contentinfo? */}
               <Surface role='presence' limit={1} />
+
               {complementarySidebarOpen !== null && showComplementarySidebar && (
                 <Button
                   onClick={() => (context.complementarySidebarOpen = !context.complementarySidebarOpen)}

--- a/packages/apps/plugins/plugin-layout/src/components/index.ts
+++ b/packages/apps/plugins/plugin-layout/src/components/index.ts
@@ -5,4 +5,4 @@
 export * from './ContentEmpty';
 export * from './ContextView';
 export * from './Fallback';
-export * from './SplitView';
+export * from './MainLayout';

--- a/packages/apps/plugins/plugin-presenter/src/PresenterPlugin.tsx
+++ b/packages/apps/plugins/plugin-presenter/src/PresenterPlugin.tsx
@@ -73,13 +73,10 @@ export const PresenterPlugin = (): PluginDefinition<PresenterPluginProvides> => 
       surface: {
         component: (data, role) => {
           switch (role) {
-            case 'main': {
+            case 'main':
               return isStack(data.active) && state.presenting ? <PresenterMain stack={data.active} /> : null;
-            }
-
-            case 'presenter-slide': {
+            case 'presenter-slide':
               return isMarkdownContent(data.slide) ? <MarkdownSlideMain slide={data.slide} /> : null;
-            }
           }
 
           return null;

--- a/packages/apps/plugins/plugin-sketch/src/SketchPlugin.tsx
+++ b/packages/apps/plugins/plugin-sketch/src/SketchPlugin.tsx
@@ -101,7 +101,7 @@ export const SketchPlugin = (): PluginDefinition<SketchPluginProvides> => {
             case 'section':
               return isSketch(data.object) ? <SketchSection sketch={data.object} /> : null;
             case 'presenter-slide':
-              return isSketch(data.object) ? <SketchSlide sketch={data.object} /> : null;
+              return isSketch(data.slide) ? <SketchSlide sketch={data.slide} /> : null;
             default:
               return null;
           }

--- a/packages/sdk/app-framework/src/plugins/SurfacePlugin/Surface.tsx
+++ b/packages/sdk/app-framework/src/plugins/SurfacePlugin/Surface.tsx
@@ -21,7 +21,6 @@ export type SurfaceProps = {
 
   /**
    * Names allow nested surfaces to be specified in the parent context, similar to a slot.
-   *
    * Defaults to the value of `role` if not specified.
    */
   name?: string;
@@ -32,7 +31,7 @@ export type SurfaceProps = {
   data?: Record<string, unknown>;
 
   /**
-   * Configure nested surfaces.
+   * Configure nested surfaces (indexed by the surface's `name`).
    */
   surfaces?: Record<string, Pick<SurfaceProps, 'data' | 'surfaces'>>;
 
@@ -49,7 +48,6 @@ export type SurfaceProps = {
 
   /**
    * If more than one component is resolved, the direction determines how they are laid out.
-   *
    * NOTE: This is not yet implemented.
    */
   direction?: Direction;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d60a533</samp>

### Summary
🖼️📝🛠️

<!--
1.  🖼️ - This emoji represents the changes related to the image preview and the object-fit/object-cover styles. It conveys the idea of adjusting the image to fit the layout and the aspect ratio.
2.  📝 - This emoji represents the changes related to the documentation and the description of the package and the plugin. It conveys the idea of editing and updating the text and the information.
3.  🛠️ - This emoji represents the changes related to the refactoring and the improvement of the code and the components. It conveys the idea of fixing and enhancing the functionality and the quality.
-->
Refactored the `plugin-layout` package to use a new `MainLayout` component and improved the code style and consistency of several other plugins. Fixed a minor bug in the `plugin-ipfs` package to display file previews correctly. Updated the descriptions and exports of the `plugin-layout` package.

> _`MainLayout` replaces_
> _`SplitView` for better style_
> _Fall leaves old code behind_

### Walkthrough
*  Refactored the layout plugin to use the `MainLayout` component instead of the `SplitView` component, and updated the package description and README file accordingly ([link](https://github.com/dxos/dxos/pull/4540/files?diff=unified&w=0#diff-303c704cac45b41f8ceab84b85ea626bb6d0c519959c1d2e7184d7b8d8b37a2fL3-R3), [link](https://github.com/dxos/dxos/pull/4540/files?diff=unified&w=0#diff-2ed475bb4873aa98c4b5e8832c7bcfc47c6d248ec63b8fd4ffc0dc01a0df5f83L4-R4), [link](https://github.com/dxos/dxos/pull/4540/files?diff=unified&w=0#diff-f3cdf174792cb84b592044c88d38ed425c3c13bc79304bf253f1a9f2f925c99bL36-R36), [link](https://github.com/dxos/dxos/pull/4540/files?diff=unified&w=0#diff-f3cdf174792cb84b592044c88d38ed425c3c13bc79304bf253f1a9f2f925c99bL171-R175), [link](https://github.com/dxos/dxos/pull/4540/files?diff=unified&w=0#diff-f3cdf174792cb84b592044c88d38ed425c3c13bc79304bf253f1a9f2f925c99bL191-R191), [link](https://github.com/dxos/dxos/pull/4540/files?diff=unified&w=0#diff-f3cdf174792cb84b592044c88d38ed425c3c13bc79304bf253f1a9f2f925c99bL212-R214), [link](https://github.com/dxos/dxos/pull/4540/files?diff=unified&w=0#diff-7e56c4efb2e92f01c3e8c0bf9348a4e40b2cd6e59a42be154f72eeb30dfe0a60L16-R21), [link](https://github.com/dxos/dxos/pull/4540/files?diff=unified&w=0#diff-7e56c4efb2e92f01c3e8c0bf9348a4e40b2cd6e59a42be154f72eeb30dfe0a60L27-R31), [link](https://github.com/dxos/dxos/pull/4540/files?diff=unified&w=0#diff-7e56c4efb2e92f01c3e8c0bf9348a4e40b2cd6e59a42be154f72eeb30dfe0a60L43-R49), [link](https://github.com/dxos/dxos/pull/4540/files?diff=unified&w=0#diff-7e56c4efb2e92f01c3e8c0bf9348a4e40b2cd6e59a42be154f72eeb30dfe0a60L53-R60), [link](https://github.com/dxos/dxos/pull/4540/files?diff=unified&w=0#diff-7e56c4efb2e92f01c3e8c0bf9348a4e40b2cd6e59a42be154f72eeb30dfe0a60L63-R66), [link](https://github.com/dxos/dxos/pull/4540/files?diff=unified&w=0#diff-7e56c4efb2e92f01c3e8c0bf9348a4e40b2cd6e59a42be154f72eeb30dfe0a60L78-R87), [link](https://github.com/dxos/dxos/pull/4540/files?diff=unified&w=0#diff-29415250d2caff50e26560b67c2c2e18ae1d5c15f0345d95a7bf1a887ce614e9L8-R8)).


