### PR TITLE
fix(react-shell): Visual adjustments

### DIFF
--- a/packages/sdk/react-shell/src/components/AuthCode.tsx
+++ b/packages/sdk/react-shell/src/components/AuthCode.tsx
@@ -2,17 +2,18 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { type HTMLProps, type PropsWithChildren } from 'react';
+import React, { type ComponentPropsWithoutRef, type PropsWithChildren } from 'react';
 
+import { type ThemedClassName } from '@dxos/react-ui';
 import { mx } from '@dxos/react-ui-theme';
 
-export type AuthCodeProps = HTMLProps<HTMLSpanElement> & {
+export type AuthCodeProps = ThemedClassName<ComponentPropsWithoutRef<'span'>> & {
   code?: string;
   large?: boolean;
 };
 
 export const AuthCode = (props: PropsWithChildren<AuthCodeProps>) => {
-  const { code, large, className } = props;
+  const { code, large, classNames } = props;
   const l = code?.length ?? 0;
   const left = code?.slice(0, l / 2);
   const right = code?.slice(l / 2);
@@ -24,7 +25,7 @@ export const AuthCode = (props: PropsWithChildren<AuthCodeProps>) => {
       className={mx(
         large ? 'text-6xl' : 'text-2xl',
         'font-mono pli-2.5 flex gap-1.5 rounded cursor-pointer',
-        className,
+        classNames,
       )}
       onClick={handleCopy}
     >

--- a/packages/sdk/react-shell/src/components/IdentityList/IdentityListItem.tsx
+++ b/packages/sdk/react-shell/src/components/IdentityList/IdentityListItem.tsx
@@ -24,7 +24,7 @@ export const IdentityListItem = forwardRef<HTMLLIElement, IdentityListItemProps>
     const displayName = identity.profile?.displayName ?? generateName(identity.identityKey.toHex());
     return (
       <ListItem.Root
-        classNames={mx('rounded p-2 flex gap-2 items-center', onClick && 'cursor-pointer')}
+        classNames={mx('flex gap-2 pli-1 items-center', onClick && 'cursor-pointer')}
         onClick={() => onClick?.()}
         data-testid='identity-list-item'
         labelId={labelId}

--- a/packages/sdk/react-shell/src/components/InvitationList/InvitationListItem.tsx
+++ b/packages/sdk/react-shell/src/components/InvitationList/InvitationListItem.tsx
@@ -11,7 +11,7 @@ import {
   useInvitationStatus,
 } from '@dxos/react-client/invitations';
 import { Button, ListItem, useTranslation, Avatar } from '@dxos/react-ui';
-import { chromeSurface, getSize } from '@dxos/react-ui-theme';
+import { getSize } from '@dxos/react-ui-theme';
 
 import { type SharedInvitationListProps } from './InvitationListProps';
 import { toEmoji } from '../../util';
@@ -75,7 +75,7 @@ export const InvitationListItemImpl = ({
   ].includes(status);
 
   return (
-    <ListItem.Root id={invitationCode} classNames={['rounded p-2 flex gap-2 items-center', chromeSurface]}>
+    <ListItem.Root id={invitationCode} classNames='flex gap-2 pli-1 items-center'>
       <ListItem.Heading classNames='sr-only'>
         {t('invitation heading') /* todo(thure): Make this more accessible. */}
       </ListItem.Heading>
@@ -91,7 +91,7 @@ export const InvitationListItemImpl = ({
         <>
           <Button
             variant='ghost'
-            classNames='grow justify-start'
+            classNames='grow justify-start font-system-medium'
             onClick={() => send({ type: 'selectInvitation', invitation })}
             data-testid='show-qrcode'
           >
@@ -100,9 +100,7 @@ export const InvitationListItemImpl = ({
           <CopyButtonIconOnly variant='ghost' value={invitationUrl} />
         </>
       ) : showAuthCode ? (
-        <span className='flex grow'>
-          <AuthCode code={authCode} />
-        </span>
+        <AuthCode code={authCode} classNames='grow' />
       ) : status === Invitation.State.CONNECTING ? (
         <span className='pli-2 grow text-neutral-500'>Connecting...</span>
       ) : status === Invitation.State.AUTHENTICATING ? (

--- a/packages/sdk/react-shell/src/panels/SpacePanel/steps/SpaceManager.tsx
+++ b/packages/sdk/react-shell/src/panels/SpacePanel/steps/SpaceManager.tsx
@@ -8,7 +8,7 @@ import React, { useCallback } from 'react';
 import { useSpaceInvitations } from '@dxos/react-client/echo';
 import { type CancellableInvitationObservable, Invitation, InvitationEncoder } from '@dxos/react-client/invitations';
 import { ScrollArea, useTranslation } from '@dxos/react-ui';
-import { getSize } from '@dxos/react-ui-theme';
+import { descriptionText, getSize, mx } from '@dxos/react-ui-theme';
 
 import {
   InvitationList,
@@ -60,6 +60,8 @@ export const SpaceManager = (props: SpaceManagerProps) => {
   );
 };
 
+const headingFragment = 'p-1 mbe-1 font-system-medium';
+
 export const SpaceManagerImpl = (props: SpaceManagerImplProps) => {
   const {
     active,
@@ -85,13 +87,17 @@ export const SpaceManagerImpl = (props: SpaceManagerImplProps) => {
       <ScrollArea.Root classNames='grow shrink basis-28 -mli-2'>
         <ScrollArea.Viewport classNames='is-full pli-2'>
           {!!visibleInvitations?.length && (
-            <InvitationListComponent
-              className='mb-2'
-              send={send}
-              invitations={visibleInvitations ?? []}
-              onClickRemove={(invitation) => invitation.cancel()}
-              createInvitationUrl={createInvitationUrl}
-            />
+            <>
+              <h3 className={mx(headingFragment, descriptionText)}>{t('invitation list heading')}</h3>
+              <InvitationListComponent
+                className='mb-2'
+                send={send}
+                invitations={visibleInvitations ?? []}
+                onClickRemove={(invitation) => invitation.cancel()}
+                createInvitationUrl={createInvitationUrl}
+              />
+              <h3 className={mx(headingFragment, descriptionText, 'mbs-2')}>{t('space member list heading')}</h3>
+            </>
           )}
           <SpaceMemberListComponent spaceKey={space.key} includeSelf />
         </ScrollArea.Viewport>

--- a/packages/sdk/react-shell/src/steps/InvitationManager.tsx
+++ b/packages/sdk/react-shell/src/steps/InvitationManager.tsx
@@ -95,7 +95,7 @@ export const InvitationManager = ({ invitationUrl, active, send, status, authCod
           <InvitationManagerView id='showing auth code'>
             <div role='none' className='absolute inset-0 flex flex-col justify-between items-center'>
               <Label>{t('auth code message')}</Label>
-              <AuthCode code={authCode} large className='text-black dark:text-white' />
+              <AuthCode code={authCode} large classNames='text-black dark:text-white' />
               <Label>Be sure the other device is showing this symbol:</Label>
               {emoji && <Emoji text={emoji} />}
             </div>

--- a/packages/sdk/react-shell/src/translations/locales/en-US.ts
+++ b/packages/sdk/react-shell/src/translations/locales/en-US.ts
@@ -79,7 +79,7 @@ export const os = {
   'device invitation list heading': 'Pending device invitations',
   'space invitation list heading': 'Pending invitations',
   'device list heading': 'Devices',
-  'space member list heading': 'Members in this space',
+  'space member list heading': 'Members',
   'space panel heading': 'Space membership',
   'auth code message': 'Enter the following auth code on the joining device.',
   'display name input label': 'Display name',

--- a/packages/ui/react-ui-theme/src/styles/components/avatar.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/avatar.ts
@@ -17,7 +17,7 @@ export type AvatarStyleProps = Partial<{
 }>;
 
 export const avatarRoot: ComponentFunction<AvatarStyleProps> = ({ size = 10, inGroup }, ...etc) =>
-  mx('relative inline-flex', getSize(size), inGroup && '-mie-2', ...etc);
+  mx('relative inline-flex shrink-0', getSize(size), inGroup && '-mie-2', ...etc);
 
 export const avatarLabel: ComponentFunction<AvatarStyleProps> = ({ srOnly }, ...etc) => mx(srOnly && 'sr-only', ...etc);
 


### PR DESCRIPTION
This PR adjusts spacing & layout rules in `react-shell` as part of a slate of design changes we want to investigate.

- Fix an issue where Avatar was experiencing unwatend shrinking
- Add headings to better distinguish between invitations and members
- Other minor housekeeping

<img width="364" alt="Screenshot 2023-10-30 at 16 34 53" src="https://github.com/dxos/dxos/assets/855039/b7ef3a69-3b05-403d-a100-c69439a2e122">
<img width="271" alt="Screenshot 2023-10-30 at 16 34 26" src="https://github.com/dxos/dxos/assets/855039/2ee26b16-3eb8-4901-95b7-03d7b206a2be">

---

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cf5e356</samp>

### Summary
🎨🌐♻️

<!--
1.  🎨 - This emoji is used for changes that improve the style or appearance of the UI, such as adding or updating utility classes, themes, or colors.
2.  🌐 - This emoji is used for changes that affect the localization or translation of the UI, such as updating or adding text keys or languages.
3.  ♻️ - This emoji is used for changes that refactor or improve the code quality or structure of the UI, such as using utility types, constants, or functions, or simplifying the logic or props.
-->
Refactored several components in `react-shell` to use utility types, classes, and functions from `react-ui-theme` for better type safety, consistency, and appearance. Updated some translation texts and styles for avatars.

> _We are the masters of the code, we make it clean and tight_
> _We use the utilities and the themes, we make it shine and bright_
> _We refactor and we update, we keep the design in sight_
> _We are the masters of the code, we rock the app with might_

### Walkthrough
*  Update `AuthCode` component to use utility types and `classNames` prop ([link](https://github.com/dxos/dxos/pull/4546/files?diff=unified&w=0#diff-927d053403c512ad5ff5fdb6659acd53ca723677902cbdbb3fc81114d65e1d4cL5-R10), [link](https://github.com/dxos/dxos/pull/4546/files?diff=unified&w=0#diff-927d053403c512ad5ff5fdb6659acd53ca723677902cbdbb3fc81114d65e1d4cL15-R16), [link](https://github.com/dxos/dxos/pull/4546/files?diff=unified&w=0#diff-927d053403c512ad5ff5fdb6659acd53ca723677902cbdbb3fc81114d65e1d4cL27-R28), [link](https://github.com/dxos/dxos/pull/4546/files?diff=unified&w=0#diff-3af43445f59986a74a4351ba74ecd39e2125c7ae0194284ac6374e133a33939eL98-R98), [link](https://github.com/dxos/dxos/pull/4546/files?diff=unified&w=0#diff-0fe64b41c9018e1fe72267e8ee04871dfb4c84ed9d7cbaa879c0f80e2fa7680bL103-R103)).


