### PR TITLE
fix: black avatars

### DIFF
--- a/packages/ui/react-ui/src/components/Avatars/Avatar.tsx
+++ b/packages/ui/react-ui/src/components/Avatars/Avatar.tsx
@@ -149,6 +149,7 @@ const AvatarFrame = forwardRef<HTMLSpanElement, AvatarFrameProps>(
             <circle
               className='avatarFrameStroke fill-transparent stroke-[var(--surface-bg)]'
               strokeWidth={strokeWidth}
+              fill='none'
               cx={imageSizeNumber / 2}
               cy={imageSizeNumber / 2}
               r={imageSizeNumber / 2 - strokeWidth / 4}
@@ -159,6 +160,7 @@ const AvatarFrame = forwardRef<HTMLSpanElement, AvatarFrameProps>(
               strokeWidth={strokeWidth}
               x={strokeWidth / 4}
               y={strokeWidth / 4}
+              fill='none'
               rx={rx}
               width={imageSizeNumber - strokeWidth / 4}
               height={imageSizeNumber - strokeWidth / 4}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2c9e9a1</samp>

### Summary
🐛🖼️🎨

<!--
1.  🐛 - This emoji represents a bug or an issue that was fixed or resolved. It is commonly used in changelogs or commit messages to indicate that a bug was fixed or a problem was solved.
2.  🖼️ - This emoji represents a picture or an image, especially one that is framed or displayed. It is often used to indicate that something related to graphics, design, or visual appearance was changed or improved. In this case, it relates to the custom avatar images and the avatar frame component.
3.  🎨 - This emoji represents a palette or a paintbrush, and it is usually used to indicate that something related to colors, styles, or aesthetics was changed or updated. In this case, it relates to the fill attribute of the SVG elements that affect the color of the avatar frame.
-->
Fixed custom avatar image bug and improved avatar frame appearance in `Avatar.tsx`.

> _`AvatarFrame` fixed_
> _No more color fills the shape_
> _Winter snowflakes show_

### Walkthrough
*  Fix avatar frame bug that obscures custom avatar image ([link](https://github.com/dxos/dxos/pull/4549/files?diff=unified&w=0#diff-327856683407b9830f26ef30add6639a8f88cc32c5eb287bf86d4c22d048ae21R152), [link](https://github.com/dxos/dxos/pull/4549/files?diff=unified&w=0#diff-327856683407b9830f26ef30add6639a8f88cc32c5eb287bf86d4c22d048ae21R163))


