### PR TITLE
feat: Grid with images

### DIFF
--- a/packages/apps/plugins/plugin-grid/package.json
+++ b/packages/apps/plugins/plugin-grid/package.json
@@ -19,6 +19,7 @@
     "@braneframe/plugin-markdown": "workspace:*",
     "@braneframe/plugin-stack": "workspace:*",
     "@dxos/client": "workspace:*",
+    "@dxos/react-client": "workspace:*",
     "deepsignal": "1.4.0-shallow.0",
     "lodash.get": "^4.4.2",
     "react-markdown": "^8.0.5"

--- a/packages/apps/plugins/plugin-grid/src/components/GridCard.tsx
+++ b/packages/apps/plugins/plugin-grid/src/components/GridCard.tsx
@@ -36,8 +36,9 @@ export const GridCard: MosaicTileComponent<GridCardProps> = forwardRef(
     const { t } = useTranslation(GRID_PLUGIN);
 
     // TODO(burdon): Factor out images. Use surface?
-    const cid = (item as any).object?.cid;
+    const cid = getObject(item)?.cid;
     const config = useConfig();
+
     const url = cid ? config.values.runtime!.services!.ipfs!.gateway + '/' + cid : undefined;
 
     const titleAccessor: ValueAccessor<GridCardProps, string> = {

--- a/packages/apps/plugins/plugin-grid/tsconfig.json
+++ b/packages/apps/plugins/plugin-grid/tsconfig.json
@@ -27,6 +27,9 @@
       "path": "../../../sdk/client"
     },
     {
+      "path": "../../../sdk/react-client"
+    },
+    {
       "path": "../../../ui/react-ui"
     },
     {

--- a/packages/ui/react-ui-mosaic/src/views/Grid/Grid.tsx
+++ b/packages/ui/react-ui-mosaic/src/views/Grid/Grid.tsx
@@ -238,9 +238,9 @@ const GridCell: FC<{
       <div
         className={mx(
           'group/cell flex group-hover:flex w-full h-full items-center justify-center',
-          'box-border border-dashed border-4 border-neutral-100/50 rounded-lg',
+          'box-border border-dashed border-4 border-neutral-75 dark:border-neutral-850 rounded-lg',
           'transition ease-in-out duration-300',
-          isOver && 'flex bg-neutral-100 border-neutral-400',
+          isOver && 'flex bg-neutral-75 dark:bg-neutral-850 border-neutral-400 dark:border-neutral-800',
         )}
       >
         <div

--- a/packages/ui/react-ui-theme/src/styles/components/card.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/card.ts
@@ -83,7 +83,7 @@ export const cardBody: ComponentFunction<CardStyleProps & { gutter?: boolean }> 
 
 export const cardMedia: ComponentFunction<CardStyleProps & { contain?: boolean }> = ({ contain }, ...etc) =>
   mx(
-    'grow max-h-[256px]',
+    'grow max-h-[300px]', // TODO(burdon): ???
     // Hide broken image links (e.g., if offline).
     "before:content-[' '] before:block before:w-full before:h-full before:border-0",
     contain ? 'object-contain' : 'object-cover',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1408,6 +1408,9 @@ importers:
       '@dxos/client':
         specifier: workspace:*
         version: link:../../../sdk/client
+      '@dxos/react-client':
+        specifier: workspace:*
+        version: link:../../../sdk/react-client
       deepsignal:
         specifier: 1.4.0-shallow.0
         version: 1.4.0-shallow.0(react@18.2.0)


### PR DESCRIPTION
<img width="1728" alt="Screenshot 2023-10-31 at 10 45 27 PM" src="https://github.com/dxos/dxos/assets/3523355/5004a12f-3536-4495-89d1-f34397467bb3">

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e97b3b4</samp>

### Summary
📦🔧🖼️

<!--
1.  📦 for adding a dependency on the `@dxos/react-client` package.
2.  🔧 for adding a path mapping for the `@dxos/react-client` package in the `tsconfig.json` file.
3.  🖼️ for adding support for displaying images stored on IPFS in the grid plugin.
-->
This pull request enhances the grid plugin to support IPFS images. It adds a dependency on the `@dxos/react-client` package and configures TypeScript to use the local version of it. It also updates the `GridCard` component to render different UI elements based on the item type.

> _We are the grid, we are the plugin_
> _We use the hooks, we use the components_
> _We show the images, we access the IPFS_
> _We are the grid, we defy the limits_

### Walkthrough
*  Add dependency on `@dxos/react-client` package to access configuration and IPFS gateway for grid plugin ([link](https://github.com/dxos/dxos/pull/4558/files?diff=unified&w=0#diff-7ea01f6a42acff9feab246620a80d4b6268f4299c0d068a17ab008b1c57f6896R22), [link](https://github.com/dxos/dxos/pull/4558/files?diff=unified&w=0#diff-36a7cab608e0a3c187537a48355df4250a502d3ba86b71e00b33d494a79fc121R30-R32)).



