### PR TITLE
test(metadata): Add ability to change storage version on disk for testing purposes

### DIFF
--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -48,7 +48,14 @@ export class MetadataStore {
 
   public readonly update = new Event<EchoMetadata>();
 
-  constructor(private readonly _directory: Directory) {}
+  /**
+   * @internal
+   */
+  readonly _directory: Directory;
+
+  constructor(directory: Directory) {
+    this._directory = directory;
+  }
 
   get metadata(): EchoMetadata {
     return this._metadata;
@@ -94,7 +101,10 @@ export class MetadataStore {
     }
   }
 
-  private async _writeFile<T>(file: File, codec: Codec<T>, data: T): Promise<void> {
+  /**
+   * @internal
+   */
+  async _writeFile<T>(file: File, codec: Codec<T>, data: T): Promise<void> {
     const encoded = arrayToBuffer(codec.encode(data));
     const checksum = CRC32.buf(encoded);
 

--- a/packages/core/echo/echo-pipeline/src/testing/change-metadata.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/change-metadata.ts
@@ -15,7 +15,7 @@ const EchoMetadata = schema.getCodecForType('dxos.echo.metadata.EchoMetadata');
  * Use this only for testing purposes.
  */
 export const changeStorageVersionInMetadata = async (metadata: MetadataStore, version: number) => {
-  log.info('Changing storage version in metadata. USE ONLY FOR TESTING');
+  log.info('Changing storage version in metadata. USE ONLY FOR TESTING.');
   await metadata.load();
   const echoMetadata = metadata.metadata;
   echoMetadata.version = version;

--- a/packages/core/echo/echo-pipeline/src/testing/change-metadata.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/change-metadata.ts
@@ -1,0 +1,25 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { log } from '@dxos/log';
+import { schema } from '@dxos/protocols';
+
+import { type MetadataStore } from '../metadata';
+
+const EchoMetadata = schema.getCodecForType('dxos.echo.metadata.EchoMetadata');
+
+/**
+ * This function will change the storage version in the metadata.
+ * This will break your storage and make it unusable.
+ * Use this only for testing purposes.
+ */
+export const changeStorageVersionInMetadata = async (metadata: MetadataStore, version: number) => {
+  log.info('Changing storage version in metadata. USE ONLY FOR TESTING');
+  await metadata.load();
+  const echoMetadata = metadata.metadata;
+  echoMetadata.version = version;
+  const file = metadata._directory.getOrCreateFile('EchoMetadata');
+  await metadata._writeFile(file, EchoMetadata, echoMetadata);
+  await metadata._directory.flush();
+};


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 37564d5</samp>

### Summary
🧪🛠️⚠️

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate that the changes are related to adding a testing function or modifying the code to enable testing.
2.  🛠️ - This emoji represents tools, fixing, or construction, and can be used to indicate that the changes are related to making some internal properties and methods public or accessible for testing purposes.
3.  ⚠️ - This emoji represents warning, danger, or caution, and can be used to indicate that the changes involve modifying the storage version in the metadata file, which could potentially cause data loss or corruption if not done carefully or for testing purposes only.
-->
Added a testing function to modify the storage version in the metadata file and expose some internal methods of the `MetadataStore` class. This is to simulate and test the system's behavior when a breaking change in the storage format occurs.

> _`changeStorageVersion`_
> _Testing breaking changes now_
> _`@internal` warns_

### Walkthrough
* Make `MetadataStore` constructor parameter `directory` public and rename it from `_directory` ([link](https://github.com/dxos/dxos/pull/4561/files?diff=unified&w=0#diff-ad1c28ba5710e2ea59c29b77568da4f157118487250877e42876eca69494a42cL51-R59)). Mark it as `@internal` to discourage external use.


