### PR TITLE
fix: add metadata plugin to labs

### DIFF
--- a/packages/apps/labs-app/package.json
+++ b/packages/apps/labs-app/package.json
@@ -23,6 +23,7 @@
     "@braneframe/plugin-layout": "workspace:*",
     "@braneframe/plugin-map": "workspace:*",
     "@braneframe/plugin-markdown": "workspace:*",
+    "@braneframe/plugin-metadata": "workspace:*",
     "@braneframe/plugin-navtree": "workspace:*",
     "@braneframe/plugin-presenter": "workspace:*",
     "@braneframe/plugin-pwa": "workspace:*",

--- a/packages/apps/labs-app/src/main.tsx
+++ b/packages/apps/labs-app/src/main.tsx
@@ -21,6 +21,7 @@ import { KanbanPlugin } from '@braneframe/plugin-kanban';
 import { LayoutPlugin } from '@braneframe/plugin-layout';
 import { MapPlugin } from '@braneframe/plugin-map';
 import { MarkdownPlugin } from '@braneframe/plugin-markdown';
+import { MetadataPlugin } from '@braneframe/plugin-metadata';
 import { NavTreePlugin } from '@braneframe/plugin-navtree';
 import { PresenterPlugin } from '@braneframe/plugin-presenter';
 import { PwaPlugin } from '@braneframe/plugin-pwa';
@@ -92,6 +93,7 @@ const main = async () => {
       // Core framework.
       ErrorPlugin(),
       GraphPlugin(),
+      MetadataPlugin(),
       ClientPlugin({ config, services, debugIdentity: debug, types }),
 
       // Core UX.

--- a/packages/apps/labs-app/tsconfig.json
+++ b/packages/apps/labs-app/tsconfig.json
@@ -97,6 +97,9 @@
       "path": "../plugins/plugin-markdown"
     },
     {
+      "path": "../plugins/plugin-metadata"
+    },
+    {
       "path": "../plugins/plugin-navtree"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -751,6 +751,9 @@ importers:
       '@braneframe/plugin-markdown':
         specifier: workspace:*
         version: link:../plugins/plugin-markdown
+      '@braneframe/plugin-metadata':
+        specifier: workspace:*
+        version: link:../plugins/plugin-metadata
       '@braneframe/plugin-navtree':
         specifier: workspace:*
         version: link:../plugins/plugin-navtree


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8958eb4</samp>

### Summary
📦🔧🏷️

<!--
1.  📦 - This emoji represents adding a new package or dependency to a project. It can also be used for packaging or bundling code.
2.  🔧 - This emoji represents configuring or setting up a project, tool, or environment. It can also be used for fixing or tweaking something.
3.  🏷️ - This emoji represents labeling, tagging, or annotating something. It can also be used for metadata, categories, or attributes.
-->
This pull request adds a new feature to the `labs-app` that enables users to view and edit the metadata of the items in the app. It does so by integrating the `@braneframe/plugin-metadata` package as a dependency and a plugin.

> _Sing, O Muse, of the skillful labs app, the work of DXOS_
> _That lets the users create and share many kinds of items_
> _And how they added the metadata plugin, a gift from BraneFrame_
> _To show and change the hidden properties of each item_

### Walkthrough
*  Add `@braneframe/plugin-metadata` as a dependency to enable metadata editing for DXOS items ([link](https://github.com/dxos/dxos/pull/4564/files?diff=unified&w=0#diff-a711168030ca629db7bb8532552b66ff3ef655d814f774320de6d8225abd4c93R26))
*  Import and register `MetadataPlugin` component to render the metadata plugin in the app ([link](https://github.com/dxos/dxos/pull/4564/files?diff=unified&w=0#diff-9d663519e7a46a19fe4305c8085aa017f51355119fb0fbe545eb37ab8492722cR24), [link](https://github.com/dxos/dxos/pull/4564/files?diff=unified&w=0#diff-9d663519e7a46a19fe4305c8085aa017f51355119fb0fbe545eb37ab8492722cR96))
*  Add path mapping for `@braneframe/plugin-metadata` in `tsconfig.json` to resolve the package from the local workspace ([link](https://github.com/dxos/dxos/pull/4564/files?diff=unified&w=0#diff-7d99c8ccbf4bbd583481ce1733c44208a3506d2d2ea49ccad8e325da769a7a85R100-R102))


