### PR TITLE
fix: smooth transition to folders

### DIFF
--- a/packages/apps/halo-app/src/main.tsx
+++ b/packages/apps/halo-app/src/main.tsx
@@ -23,6 +23,8 @@ import translations from './translations';
 // https://github.com/luisherranz/deepsignal/issues/36
 (globalThis as any)[TypedObject.name] = TypedObject;
 
+const APP = 'halo.dxos.org';
+
 const App = createApp({
   fallback: (
     <div className='flex h-screen justify-center items-center'>
@@ -36,7 +38,7 @@ const App = createApp({
     PwaPlugin(),
     // Inside theme provider so that errors are styled.
     ErrorPlugin(),
-    ClientPlugin(),
+    ClientPlugin({ appKey: APP }),
     {
       meta: {
         id: 'dxos.org/plugin/halo-app',

--- a/packages/apps/labs-app/src/main.tsx
+++ b/packages/apps/labs-app/src/main.tsx
@@ -57,6 +57,8 @@ import {
 (globalThis as any)[EchoDatabase.name] = EchoDatabase;
 (globalThis as any)[SpaceProxy.name] = SpaceProxy;
 
+const APP = 'labs.dxos.org';
+
 const main = async () => {
   const searchParams = new URLSearchParams(window.location.search);
   // TODO(burdon): Add monolithic flag. Currently, can set `target=file://local`.
@@ -84,7 +86,7 @@ const main = async () => {
 
   const App = createApp({
     plugins: [
-      TelemetryPlugin({ namespace: 'labs.dxos.org', config: new Config(Defaults()) }),
+      TelemetryPlugin({ namespace: APP, config: new Config(Defaults()) }),
       ThemePlugin({ appName: 'Labs', tx: labsTx }),
 
       // Outside of error boundary so that updates are not blocked by errors.
@@ -94,7 +96,7 @@ const main = async () => {
       ErrorPlugin(),
       GraphPlugin(),
       MetadataPlugin(),
-      ClientPlugin({ config, services, debugIdentity: debug, types }),
+      ClientPlugin({ appKey: APP, config, services, debugIdentity: debug, types }),
 
       // Core UX.
       LayoutPlugin({ showComplementarySidebar: true }),

--- a/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
+++ b/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
@@ -14,39 +14,42 @@ import { Client, ClientContext, type ClientOptions, type SystemStatus } from '@d
 
 import { type ClientPluginProvides, CLIENT_PLUGIN } from './types';
 
-export type ClientPluginOptions = ClientOptions & { debugIdentity?: boolean; types?: TypeCollection };
+const WAIT_FOR_DEFAULT_SPACE_TIMEOUT = 10_000;
+
+export type ClientPluginOptions = ClientOptions & { debugIdentity?: boolean; types?: TypeCollection; appKey: string };
 
 export const parseClientPlugin = (plugin?: Plugin) =>
   (plugin?.provides as any).client instanceof Client ? (plugin as Plugin<ClientPluginProvides>) : undefined;
 
-export const ClientPlugin = (
-  options: ClientPluginOptions = { config: new Config(Envs(), Local(), Defaults()) },
-): PluginDefinition<{}, ClientPluginProvides> => {
+export const ClientPlugin = ({
+  debugIdentity,
+  types,
+  appKey,
+  ...options
+}: ClientPluginOptions): PluginDefinition<{}, ClientPluginProvides> => {
   // TODO(burdon): Document.
   registerSignalFactory();
 
-  const client = new Client(options);
+  const client = new Client({ config: new Config(Envs(), Local(), Defaults()), ...options });
 
   return {
     meta: {
       id: CLIENT_PLUGIN,
     },
     initialize: async () => {
-      let firstRun = false;
       let error: unknown = null;
 
       try {
         await client.initialize();
 
-        if (options.types) {
-          client.addTypes(options.types);
+        if (types) {
+          client.addTypes(types);
         }
 
         // TODO(burdon): Factor out invitation logic since depends on path routing?
         const searchParams = new URLSearchParams(location.search);
         const deviceInvitationCode = searchParams.get('deviceInvitationCode');
         if (!client.halo.identity.get() && !deviceInvitationCode) {
-          firstRun = true;
           await client.halo.createIdentity();
         } else if (client.halo.identity.get() && deviceInvitationCode) {
           // Ignore device invitation if identity already exists.
@@ -61,7 +64,7 @@ export const ClientPlugin = (
       }
 
       // Debugging (e.g., for monolithic mode).
-      if (options.debugIdentity) {
+      if (debugIdentity) {
         if (!client.halo.identity.get()) {
           await client.halo.createIdentity();
         }
@@ -80,10 +83,9 @@ export const ClientPlugin = (
         }
       }
 
-      // TODO(burdon): Timeout.
-      if (client.halo.identity.get()) {
-        await client.spaces.isReady.wait();
-      }
+      await client.spaces.isReady.wait({ timeout: WAIT_FOR_DEFAULT_SPACE_TIMEOUT });
+      const firstRun = !client.spaces.default.properties[appKey];
+      client.spaces.default.properties[appKey] = true;
 
       return {
         client,

--- a/packages/apps/plugins/plugin-client/src/types.ts
+++ b/packages/apps/plugins/plugin-client/src/types.ts
@@ -10,8 +10,7 @@ export type ClientPluginProvides = {
   client: Client;
 
   /**
-   * True if this is the first time this device has been used.
-   * Indicates that the identity was created during startup.
+   * True if this is the first time the current app has been used by this identity.
    */
   firstRun: boolean;
 };

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -56,7 +56,7 @@ import { ROOT, SHARED, getActiveSpace, hiddenSpacesToGraphNodes, isSpace, object
 
 export type SpacePluginOptions = {
   /**
-   * Root folder structure is created on identity first run.
+   * Root folder structure is created on application first run if it does not yet exist.
    * This callback is invoked immediately following the creation of the root folder structure.
    *
    * @param params.client DXOS Client
@@ -105,7 +105,9 @@ export const SpacePlugin = ({ onFirstRun }: SpacePluginOptions = {}): PluginDefi
       const dispatch = intentPlugin.provides.intent.dispatch;
 
       // Create root folder structure.
-      if (clientPlugin.provides.firstRun) {
+      const defaultSpace = client.spaces.default;
+      const query = defaultSpace.db.query(Folder.filter({ name: ROOT }));
+      if (clientPlugin.provides.firstRun && query.objects.length === 0) {
         const personalSpaceFolder = new Folder({ name: client.spaces.default.key.toHex() });
         const sharedSpacesFolder = new Folder({ name: SHARED });
         const rootFolder = new Folder({ name: ROOT, objects: [personalSpaceFolder, sharedSpacesFolder] });
@@ -291,7 +293,7 @@ export const SpacePlugin = ({ onFirstRun }: SpacePluginOptions = {}): PluginDefi
           const dispatch = intentPlugin?.provides.intent.dispatch;
           const resolve = metadataPlugin?.provides.metadata.resolver;
 
-          if (!dispatch || !resolve || !client || !client.spaces.isReady.get()) {
+          if (!dispatch || !resolve || !client) {
             return;
           }
 

--- a/packages/common/async/src/observable.ts
+++ b/packages/common/async/src/observable.ts
@@ -78,8 +78,8 @@ export class MulticastObservable<T> extends Observable<T> {
    *
    * @returns Promise that resolves to the value of the observable at the time of completion.
    */
-  async wait(): Promise<T> {
-    await this._completed.wait();
+  async wait({ timeout }: { timeout?: number } = {}): Promise<T> {
+    await this._completed.wait({ timeout });
     return this.get();
   }
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 32f11f5</samp>

### Summary
📝🚀♻️

<!--
1.  📝 - This emoji represents the changes that update or fix the comments in the code, such as the first and the seventh change.
2.  🚀 - This emoji represents the changes that add new features or improve the performance of the code, such as the second, the fourth, and the eighth change.
3.  ♻️ - This emoji represents the changes that refactor or clean up the code, such as the third, the fifth, and the sixth change.
-->
This pull request refactors and improves the plugin configuration and functionality for the composer, halo, and labs apps. It uses constants for the app keys and domains, and passes them to the client, telemetry, graph, metadata, and intent plugins. It also fixes some bugs and enhances the performance and readability of the code. Additionally, it adds a timeout option to the `wait` method of the `multicast` observable class.

> _Sing, O Muse, of the skillful code review_
> _That refined the plugins of the apps divine,_
> _The apps that connect to the network sublime_
> _And manage the data with wisdom and truth._

### Walkthrough
*  Define `APP` constant for app domain name and use it for client and telemetry plugins in composer, halo, and labs apps ([link](https://github.com/dxos/dxos/pull/4565/files?diff=unified&w=0#diff-9f2aee287f92edd662c13bed460a28a1590c9186b62c98ccc2e00f6877c3d7e6R44-R45), [link](https://github.com/dxos/dxos/pull/4565/files?diff=unified&w=0#diff-8412cb8580ea2ea6f5755bea44d5e5c8860d2a2a745d68ec307276ee8144d96bR26-R27), [link](https://github.com/dxos/dxos/pull/4565/files?diff=unified&w=0#diff-9d663519e7a46a19fe4305c8085aa017f51355119fb0fbe545eb37ab8492722cR60-R61), [link](https://github.com/dxos/dxos/pull/4565/files?diff=unified&w=0#diff-9f2aee287f92edd662c13bed460a28a1590c9186b62c98ccc2e00f6877c3d7e6L54-R60), [link](https://github.com/dxos/dxos/pull/4565/files?diff=unified&w=0#diff-9d663519e7a46a19fe4305c8085aa017f51355119fb0fbe545eb37ab8492722cL87-R89), [link](https://github.com/dxos/dxos/pull/4565/files?diff=unified&w=0#diff-9f2aee287f92edd662c13bed460a28a1590c9186b62c98ccc2e00f6877c3d7e6R74-R75), [link](https://github.com/dxos/dxos/pull/4565/files?diff=unified&w=0#diff-8412cb8580ea2ea6f5755bea44d5e5c8860d2a2a745d68ec307276ee8144d96bL39-R41), [link](https://github.com/dxos/dxos/pull/4565/files?diff=unified&w=0#diff-9d663519e7a46a19fe4305c8085aa017f51355119fb0fbe545eb37ab8492722cL97-R99)).


