### PR TITLE
fix: encode space keys into invitations

### DIFF
--- a/packages/sdk/client-protocol/project.json
+++ b/packages/sdk/client-protocol/project.json
@@ -46,9 +46,29 @@
       "outputs": [
         "packages/sdk/client-protocol/src/proto/gen"
       ]
+    },
+    "test": {
+      "executor": "@dxos/test:run",
+      "options": {
+        "coveragePath": "coverage/packages/sdk/client-protocol",
+        "outputPath": "tmp/mocha/packages/sdk/client-protocol",
+        "resultsPath": "test-results/packages/sdk/client-protocol",
+        "testPatterns": [
+          "packages/sdk/client-protocol/src/**/*.test.{ts,js}"
+        ],
+        "watchPatterns": [
+          "packages/sdk/client-protocol/src/**/*"
+        ]
+      },
+      "outputs": [
+        "{options.coveragePath}",
+        "{options.outputPath}",
+        "{options.resultsPath}"
+      ]
     }
   },
   "implicitDependencies": [
-    "esbuild"
+    "esbuild",
+    "test"
   ]
 }

--- a/packages/sdk/client-protocol/src/invitations/encoder.test.ts
+++ b/packages/sdk/client-protocol/src/invitations/encoder.test.ts
@@ -19,6 +19,7 @@ describe('Invitation utils', () => {
       authMethod: Invitation.AuthMethod.NONE,
       state: Invitation.State.INIT,
       swarmKey: PublicKey.random(),
+      spaceKey: PublicKey.random(),
     };
 
     const encoded = InvitationEncoder.encode(invitation);
@@ -34,18 +35,17 @@ describe('Invitation utils', () => {
       authMethod: Invitation.AuthMethod.NONE,
       state: Invitation.State.INIT,
       swarmKey: PublicKey.random(),
+      spaceKey: PublicKey.random(),
     };
 
     const encoded = InvitationEncoder.encode({
       ...invitation,
       authCode: 'example',
       identityKey: PublicKey.random(),
-      spaceKey: PublicKey.random(),
     });
     const decoded = InvitationEncoder.decode(encoded);
     expect(decoded.authCode).to.not.exist;
     expect(decoded.identityKey).to.not.exist;
-    expect(decoded.spaceKey).to.not.exist;
     expect(decoded).to.deep.eq(invitation);
   });
 });

--- a/packages/sdk/client-protocol/src/invitations/encoder.ts
+++ b/packages/sdk/client-protocol/src/invitations/encoder.ts
@@ -30,6 +30,7 @@ export class InvitationEncoder {
         swarmKey: invitation.swarmKey,
         state: invitation.state,
         timeout: invitation.timeout,
+        ...(invitation.spaceKey ? { spaceKey: invitation.spaceKey } : {}),
       }),
     );
   }

--- a/packages/sdk/client-services/src/packlets/invitations/invitation-extension.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitation-extension.ts
@@ -115,7 +115,6 @@ export class InvitationHostExtension extends RpcExtension<
 
           log.trace('dxos.sdk.invitation-handler.host.introduce', trace.end({ id: traceId }));
           return {
-            spaceKey: this.invitation.authMethod === Invitation.AuthMethod.NONE ? this.invitation.spaceKey : undefined,
             authMethod: this.invitation.authMethod,
           };
         },

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
@@ -279,9 +279,6 @@ export class InvitationsHandler {
               );
               log('introduce response', { ...protocol.toJSON(), response: introductionResponse });
               invitation.authMethod = introductionResponse.authMethod;
-              if (introductionResponse.spaceKey) {
-                invitation.spaceKey = introductionResponse.spaceKey;
-              }
 
               // 2. Get authentication code.
               if (isAuthenticationRequired(invitation)) {

--- a/packages/sdk/client/src/echo/space-proxy.ts
+++ b/packages/sdk/client/src/echo/space-proxy.ts
@@ -363,7 +363,7 @@ export class SpaceProxy implements Space {
    */
   share(options?: Partial<Invitation>) {
     log('create invitation', options);
-    return this._invitationsProxy.share(options);
+    return this._invitationsProxy.share({ ...options, spaceKey: this.key });
   }
 
   /**


### PR DESCRIPTION
Unblocks https://github.com/dxos/dxos/issues/3886

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 68ff041</samp>

### Summary
🧪🔑🚀

<!--
1.  🧪 - This emoji represents testing, experimentation, or science. It can be used to indicate that a change adds or modifies tests or test-related code. In this case, the first change adds a new test target to the project.json file and the last change updates the encoder.test.ts file.
2. 🔑 - This emoji represents a key, security, or encryption. It can be used to indicate that a change involves cryptography, authentication, or authorization. In this case, the second and third changes add a new spaceKey property to the invitation object and the InvitationEncoder class, which is used to encrypt the invitation data.
3. 🚀 - This emoji represents a rocket, launch, or deployment. It can be used to indicate that a change improves performance, adds a new feature, or releases a new version. In this case, the third change modifies the share method of the SpaceProxy class, which is a core feature of the client-protocol package.
-->
This pull request adds a `spaceKey` property to the invitation encoding and sharing logic in the `client-protocol` and `client` packages. The `spaceKey` is a public key that identifies the space that the invitation is for and enables encryption of the invitation data.

> _We are the inviters, we hold the keys to the space_
> _We encrypt the data, we hide it from their face_
> _We share the secrets, we invite the chosen ones_
> _We are the inviters, we defy the protocol_

### Walkthrough
*  Add spaceKey property to invitation objects and use it to encrypt and decrypt invitation data ([link](https://github.com/dxos/dxos/pull/4566/files?diff=unified&w=0#diff-ab2d88dde87d8462a960c3d82cbb090be15059640cb06e5d78017ab5252dcc69R33), [link](https://github.com/dxos/dxos/pull/4566/files?diff=unified&w=0#diff-19ada7fbeac8661cdd3b56ebe1d888177eaceae4ce5c24799c1ec86177949c14R22), [link](https://github.com/dxos/dxos/pull/4566/files?diff=unified&w=0#diff-19ada7fbeac8661cdd3b56ebe1d888177eaceae4ce5c24799c1ec86177949c14R38), [link](https://github.com/dxos/dxos/pull/4566/files?diff=unified&w=0#diff-ea859fecb296e36346eb115dc1ffe5c0e67d7157b43b4dff2eb05ed5eb58ef73L366-R366)).


