### PR TITLE
fix(functions): Fix auto-deletion of queries in TriggerManager

### DIFF
--- a/packages/core/echo/echo-schema/src/query/filter.ts
+++ b/packages/core/echo/echo-schema/src/query/filter.ts
@@ -50,6 +50,9 @@ export class Filter<T extends EchoObject = EchoObject> {
         },
         options,
       );
+    } else if (typeof source === 'object' && source['@type']) {
+      const { '@type': typename, ...properties } = source;
+      return Filter.typename(typename, properties);
     } else if (typeof source === 'object') {
       return new Filter(
         {

--- a/packages/core/echo/echo-schema/src/query/filter.ts
+++ b/packages/core/echo/echo-schema/src/query/filter.ts
@@ -50,9 +50,6 @@ export class Filter<T extends EchoObject = EchoObject> {
         },
         options,
       );
-    } else if (typeof source === 'object' && source['@type']) {
-      const { '@type': typename, ...properties } = source;
-      return Filter.typename(typename, properties);
     } else if (typeof source === 'object') {
       return new Filter(
         {

--- a/packages/core/echo/echo-schema/src/query/query.test.ts
+++ b/packages/core/echo/echo-schema/src/query/query.test.ts
@@ -216,7 +216,7 @@ test('query by typename receives updates', async () => {
   const trigger = new Trigger();
 
   const unsub = query.subscribe(({ objects }) => {
-    if ((objects[0].name = name)) {
+    if (objects[0].name === name) {
       trigger.wake();
     }
   });

--- a/packages/core/echo/echo-schema/src/query/query.test.ts
+++ b/packages/core/echo/echo-schema/src/query/query.test.ts
@@ -4,13 +4,15 @@
 
 import { expect } from 'chai';
 
-import { sleep } from '@dxos/async';
+import { Trigger, asyncTimeout, sleep } from '@dxos/async';
 import { QueryOptions } from '@dxos/protocols/proto/dxos/echo/filter';
-import { beforeAll, beforeEach, describe, test } from '@dxos/test';
+import { afterTest, beforeAll, beforeEach, describe, test } from '@dxos/test';
 
+import { Filter } from './filter';
 import { type EchoDatabase } from '../database';
 import { Expando, TypedObject, TextObject } from '../object';
 import { TestBuilder, createDatabase } from '../testing';
+import { Contact, types } from '../tests/proto';
 
 describe('Queries', () => {
   let db: EchoDatabase;
@@ -199,4 +201,27 @@ test('query with model filters', async () => {
   expect(peer.db.query().objects[0]).to.eq(obj);
 
   expect(peer.db.query(undefined, { models: ['*'] }).objects).to.have.length(2);
+});
+
+test('query by typename receives updates', async () => {
+  const testBuilder = new TestBuilder();
+  testBuilder.graph.addTypes(types);
+  const peer = await testBuilder.createPeer();
+  const contact = peer.db.add(new Contact());
+  const name = 'Rich Ivanov';
+
+  const query = peer.db.query(Filter.typename('example.test.Contact'));
+  expect(query.objects).to.have.length(1);
+  expect(query.objects[0]).to.eq(contact);
+  const trigger = new Trigger();
+
+  const unsub = query.subscribe(({ objects }) => {
+    if ((objects[0].name = name)) {
+      trigger.wake();
+    }
+  });
+  afterTest(() => unsub());
+
+  contact.name = name;
+  await asyncTimeout(trigger.wait(), 1000);
 });

--- a/packages/core/echo/echo-schema/src/query/query.ts
+++ b/packages/core/echo/echo-schema/src/query/query.ts
@@ -102,7 +102,7 @@ export class Query<T extends TypedObject = TypedObject> {
 
     this._queryContext.added.on((source) => {
       this._sources.add(source);
-      source.changed.on(() => {
+      source.changed.on(this._ctx, () => {
         this._resultCache = undefined;
         this._objectCache = undefined;
         this._signal?.notifyWrite();

--- a/packages/core/functions/src/runtime/trigger-manager.ts
+++ b/packages/core/functions/src/runtime/trigger-manager.ts
@@ -96,8 +96,7 @@ export class TriggerManager {
       this._queries.add(query);
       const unsubscribe = query.subscribe(({ objects }) => {
         subscription.update(objects);
-      });
-      subscription.update(query.objects);
+      }, true);
 
       ctx.onDispose(() => {
         subscription.unsubscribe();

--- a/packages/core/functions/src/runtime/trigger-manager.ts
+++ b/packages/core/functions/src/runtime/trigger-manager.ts
@@ -4,7 +4,7 @@
 
 import { DeferredTask } from '@dxos/async';
 import { type Client, type PublicKey } from '@dxos/client';
-import type { Space } from '@dxos/client/echo';
+import type { Query, Space } from '@dxos/client/echo';
 import { Context } from '@dxos/context';
 import { Filter, createSubscription } from '@dxos/echo-schema';
 import { invariant } from '@dxos/invariant';
@@ -24,6 +24,8 @@ export class TriggerManager {
     { name: string; spaceKey: PublicKey },
     { ctx: Context; trigger: FunctionTrigger }
   >(({ name, spaceKey }) => `${spaceKey.toHex()}:${name}`);
+
+  private readonly _queries = new Set<Query>();
 
   constructor(
     private readonly _client: Client,
@@ -89,19 +91,19 @@ export class TriggerManager {
         task.schedule();
         count++;
       });
-
-      ctx.onDispose(() => subscription.unsubscribe());
-
       // TODO(burdon): DSL for query (replace props).
       const query = space.db.query(Filter.typename(trigger.subscription.type, trigger.subscription.props));
+      this._queries.add(query);
       const unsubscribe = query.subscribe(({ objects }) => {
         subscription.update(objects);
       });
+      subscription.update(query.objects);
 
-      // TODO(burdon): Option to trigger on first subscription.
-      // TODO(burdon): After restart not triggered.
-
-      ctx.onDispose(() => unsubscribe());
+      ctx.onDispose(() => {
+        subscription.unsubscribe();
+        unsubscribe();
+        this._queries.delete(query);
+      });
     }
   }
 

--- a/packages/devtools/cli/src/commands/function/dev-server.ts
+++ b/packages/devtools/cli/src/commands/function/dev-server.ts
@@ -62,7 +62,7 @@ export default class Dev extends BaseCommand<typeof Dev> {
 
       this.log(`Function dev-server: ${server.endpoint} (ctrl-c to exit)`);
       process.on('SIGINT', async () => {
-        await triggers.start();
+        await triggers.stop();
         await server.stop();
         process.exit();
       });

--- a/packages/experimental/labs-functions/package.json
+++ b/packages/experimental/labs-functions/package.json
@@ -21,6 +21,7 @@
     "@dxos/client": "workspace:*",
     "@dxos/client-services": "workspace:*",
     "@dxos/config": "workspace:*",
+    "@dxos/context": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/echo-schema": "workspace:*",
     "@dxos/functions": "workspace:*",

--- a/packages/experimental/labs-functions/src/functions/chess/handler.ts
+++ b/packages/experimental/labs-functions/src/functions/chess/handler.ts
@@ -2,6 +2,8 @@
 // Copyright 2023 DXOS.org
 //
 
+import { scheduleTask } from '@dxos/async';
+import { Context } from '@dxos/context';
 import { type FunctionHandler, type FunctionSubscriptionEvent } from '@dxos/functions';
 import { PublicKey } from '@dxos/keys';
 
@@ -10,7 +12,7 @@ export const handler: FunctionHandler<FunctionSubscriptionEvent> = async ({ even
   const space = context.client.spaces.get(PublicKey.from(event.space))!;
 
   return new Promise<void>((resolve) => {
-    setTimeout(async () => {
+    scheduleTask(new Context(), async () => {
       const { Chess } = await import('chess.js');
       for (const objectId of event.objects) {
         const game = space.db.query({ id: objectId }).objects[0];
@@ -32,7 +34,7 @@ export const handler: FunctionHandler<FunctionSubscriptionEvent> = async ({ even
         }
       }
 
-      return context.status(200).succeed({});
+      context.status(200).succeed({});
     });
   });
 };

--- a/packages/experimental/labs-functions/src/functions/chess/handler.ts
+++ b/packages/experimental/labs-functions/src/functions/chess/handler.ts
@@ -11,30 +11,28 @@ export const handler: FunctionHandler<FunctionSubscriptionEvent> = async ({ even
   // TODO(burdon): client.spaces.get() is a more natural API.
   const space = context.client.spaces.get(PublicKey.from(event.space))!;
 
-  return new Promise<void>((resolve) => {
-    scheduleTask(new Context(), async () => {
-      const { Chess } = await import('chess.js');
-      for (const objectId of event.objects) {
-        const game = space.db.query({ id: objectId }).objects[0];
-        if (game && game.pgn) {
-          // TODO(burdon): Trivial engine: https://github.com/josefjadrny/js-chess-engine
-          const chess = new Chess();
-          // TODO(burdon): Rename pgn (isn't pgn).
-          chess.loadPgn(game.pgn);
-          // TODO(burdon): Only trigger if has player credential.
-          if (chess.turn() === 'b') {
-            const moves = chess.moves();
-            if (moves.length) {
-              const move = moves[Math.floor(Math.random() * moves.length)];
-              chess.move(move);
-              game.pgn = chess.pgn();
-              console.log(`move: ${chess.history().length}\n` + chess.ascii());
-            }
+  scheduleTask(new Context(), async () => {
+    const { Chess } = await import('chess.js');
+    for (const objectId of event.objects) {
+      const game = space.db.query({ id: objectId }).objects[0];
+      if (game && game.pgn) {
+        // TODO(burdon): Trivial engine: https://github.com/josefjadrny/js-chess-engine
+        const chess = new Chess();
+        // TODO(burdon): Rename pgn (isn't pgn).
+        chess.loadPgn(game.pgn);
+        // TODO(burdon): Only trigger if has player credential.
+        if (chess.turn() === 'b') {
+          const moves = chess.moves();
+          if (moves.length) {
+            const move = moves[Math.floor(Math.random() * moves.length)];
+            chess.move(move);
+            game.pgn = chess.pgn();
+            console.log(`move: ${chess.history().length}\n` + chess.ascii());
           }
         }
       }
+    }
 
-      context.status(200).succeed({});
-    });
+    context.status(200).succeed({});
   });
 };

--- a/packages/experimental/labs-functions/tsconfig.json
+++ b/packages/experimental/labs-functions/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../../common/async"
     },
     {
+      "path": "../../common/context"
+    },
+    {
       "path": "../../common/debug"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5875,6 +5875,9 @@ importers:
       '@dxos/config':
         specifier: workspace:*
         version: link:../../sdk/config
+      '@dxos/context':
+        specifier: workspace:*
+        version: link:../../common/context
       '@dxos/debug':
         specifier: workspace:*
         version: link:../../common/debug


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 958e1d7</samp>

### Summary
🐛🚀✨

<!--
1.  🐛 for the bug fix in dev-server.ts
2.  🚀 for the performance and reliability improvement in the chess function handler
3.  ✨ for the new feature of query management in the TriggerManager class
-->
This pull request adds query management and query by typename functionality to the echo-schema and functions packages, and improves the chess function handler and the dev-server command. It also fixes a bug in the trigger manager and updates some dependencies and path mappings in the labs-functions package.

> _The pull request had some changes to make_
> _To fix bugs and leaks for goodness sake_
> _It added `Query` and `Context` too_
> _And improved the chess function's queue_
> _With `scheduleTask` and `Trigger` in its wake_

### Walkthrough
*  Added and updated queries and triggers for echo-schema ([link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-718d737fa6b5a5f359faaa930b144180f7fd8dc9e3592b1ea2cc696aa2028a0cL7-R15), [link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-718d737fa6b5a5f359faaa930b144180f7fd8dc9e3592b1ea2cc696aa2028a0cR205-R233), [link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-786f42f6e60b94ab68fa74289bb879371a4b0cbca1f9af2a6279600e6c01b6efL105-R105), [link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-f9638baf083820b4fb98b23e5a82e1d408a33ff27a6cdc801d0dcd9e3ca68780L7-R7), [link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-f9638baf083820b4fb98b23e5a82e1d408a33ff27a6cdc801d0dcd9e3ca68780R28-R29), [link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-f9638baf083820b4fb98b23e5a82e1d408a33ff27a6cdc801d0dcd9e3ca68780L92-R106))
  - Implemented a new test case for query by typename in `query.test.ts` using Trigger, asyncTimeout, Query, and Contact ([link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-718d737fa6b5a5f359faaa930b144180f7fd8dc9e3592b1ea2cc696aa2028a0cR205-R233))
  - Passed the context to the source.changed.on callback in `query.ts` to avoid memory leaks and ensure proper disposal ([link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-786f42f6e60b94ab68fa74289bb879371a4b0cbca1f9af2a6279600e6c01b6efL105-R105))
  - Added a new property _queries to the TriggerManager class in `trigger-manager.ts` to store and manage Query instances ([link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-f9638baf083820b4fb98b23e5a82e1d408a33ff27a6cdc801d0dcd9e3ca68780R28-R29))
  - Added the query to the _queries set, updated the subscription with the initial query objects, and removed the query from the set on disposal in `trigger-manager.ts` ([link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-f9638baf083820b4fb98b23e5a82e1d408a33ff27a6cdc801d0dcd9e3ca68780L92-R106))
* Fixed a bug in the dev-server command for functions ([link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-3e3b2db2dc8e553f1bb7a0e165c4e785049885b280372fc7ddaf4fd9e99f8e49L65-R65))
  - Called triggers.stop() instead of triggers.start() on SIGINT in `dev-server.ts` to stop the trigger manager when the server is stopped ([link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-3e3b2db2dc8e553f1bb7a0e165c4e785049885b280372fc7ddaf4fd9e99f8e49L65-R65))
* Added the context package as a dependency and a path mapping for the labs-functions package ([link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-9cdc8e0cb041bc87b2b9f9463c4696bbc74b898850820cf3f0c06371c6eea85aR24), [link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-e4c4587423f7a0398291362ac5c223bd5e4f9f3e538be97e8ec74442e37bb6c5R25-R27))
  - Updated the package.json file in the labs-functions package to include the context package as a dependency ([link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-9cdc8e0cb041bc87b2b9f9463c4696bbc74b898850820cf3f0c06371c6eea85aR24))
  - Updated the tsconfig.json file in the labs-functions package to include the context package as a path mapping ([link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-e4c4587423f7a0398291362ac5c223bd5e4f9f3e538be97e8ec74442e37bb6c5R25-R27))
* Improved the chess function handler to use scheduleTask and Context ([link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-599b87990dc7d38396bf1c659573b8f327f007136e1268d41ee06231258b6fafR5-R6), [link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-599b87990dc7d38396bf1c659573b8f327f007136e1268d41ee06231258b6fafL12-R36))
  - Imported the scheduleTask function from the async package and the Context class from the context package in the handler.ts file in the chess function ([link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-599b87990dc7d38396bf1c659573b8f327f007136e1268d41ee06231258b6fafR5-R6))
  - Used the scheduleTask function instead of a setTimeout to run the chess logic asynchronously and with a context and a cancellation token in the handler.ts file in the chess function ([link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-599b87990dc7d38396bf1c659573b8f327f007136e1268d41ee06231258b6fafL12-R36))
  - Moved the context.status(200).succeed({}) call outside of the scheduled task in the handler.ts file in the chess function ([link](https://github.com/dxos/dxos/pull/4567/files?diff=unified&w=0#diff-599b87990dc7d38396bf1c659573b8f327f007136e1268d41ee06231258b6fafL12-R36))


