### PR TITLE
fix: handle indexing folder for joined space

### DIFF
--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -23,7 +23,7 @@ import type { Graph, Node } from '@braneframe/plugin-graph';
 import { Folder } from '@braneframe/types';
 import { LayoutAction, type DispatchIntent, type MetadataResolver } from '@dxos/app-framework';
 import { EventSubscriptions, type UnsubscribeCallback } from '@dxos/async';
-import { clone } from '@dxos/echo-schema';
+import { type Query, clone } from '@dxos/echo-schema';
 import { PublicKey } from '@dxos/keys';
 import { EchoDatabase, type Space, SpaceState, TypedObject, getSpaceForObject } from '@dxos/react-client/echo';
 
@@ -365,4 +365,24 @@ export const getActiveSpace = (graph: Graph, active?: string) => {
   }
 
   return getSpaceForObject(node.data);
+};
+
+export const indexSpaceFolder = ({ space, defaultSpace }: { space: Space; defaultSpace: Space }) => {
+  const {
+    objects: [sharedSpacesFolder],
+  } = defaultSpace.db.query(Folder.filter({ name: SHARED }));
+  const query = space.db.query(Folder.filter({ name: space.key.toHex() }));
+  return new Promise<Folder>((resolve) => {
+    const push = ({ objects: [folder] }: Query<Folder>) => {
+      console.log({ folder });
+      if (folder) {
+        sharedSpacesFolder.objects.push(folder);
+        subscription?.();
+        resolve(folder);
+      }
+    };
+
+    const subscription = query.subscribe(push);
+    push(query);
+  });
 };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3f6ee48</samp>

### Summary
🚀📁🗃️

<!--
1.  🚀 - This emoji conveys the idea of improvement, enhancement, or launching something new. It could be used to represent the improved integration of the `SpacePlugin` component and the replacement of the deprecated object.
2. 📁 - This emoji represents a folder, which is relevant to the creation and sharing of folders for spaces. It could be used to indicate the addition of the utility function `indexSpaceFolder`.
3. 🗃️ - This emoji represents a file cabinet or a database, which is related to the query results from the echo database. It could be used to signify the import of the `Query` type.
-->
Enhanced the functionality and performance of the `SpacePlugin` component for creating and joining shared spaces. Added a utility function to manage space folders and used a more robust type for database queries. Updated the code to use the latest `client` object instead of the deprecated `clientPlugin`.

> _`SpacePlugin` joins_
> _client and shared folders now_
> _cutting old code out_

### Walkthrough
* Import and use `indexSpaceFolder` function to create and activate folders for joined spaces ([link](https://github.com/dxos/dxos/pull/4568/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L49-R57), [link](https://github.com/dxos/dxos/pull/4568/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L142-R154), [link](https://github.com/dxos/dxos/pull/4568/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L367-R386), [link](https://github.com/dxos/dxos/pull/4568/files?diff=unified&w=0#diff-40c06872035a3fca913d3ecf4b86bab147706b739e5546f25845364df1b60203L26-R26), [link](https://github.com/dxos/dxos/pull/4568/files?diff=unified&w=0#diff-40c06872035a3fca913d3ecf4b86bab147706b739e5546f25845364df1b60203R369-R388))
* Remove unused `defaultSpace` variable and use `client` object instead of deprecated `clientPlugin` object in `SpacePlugin` component ([link](https://github.com/dxos/dxos/pull/4568/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L117-R125), [link](https://github.com/dxos/dxos/pull/4568/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L367-R386))


