### PR TITLE
fix(plugin-navtree): cleanup

### DIFF
--- a/packages/apps/plugins/plugin-navtree/src/components/TreeViewContainer.tsx
+++ b/packages/apps/plugins/plugin-navtree/src/components/TreeViewContainer.tsx
@@ -6,10 +6,18 @@ import { CaretDoubleLeft, GearSix } from '@phosphor-icons/react';
 import React, { useCallback } from 'react';
 
 import { LayoutAction, useIntent } from '@dxos/app-framework';
-import { type Graph } from '@dxos/app-graph';
+import type { Node, Graph } from '@dxos/app-graph';
 import { useClient, useConfig } from '@dxos/react-client';
 import { useIdentity } from '@dxos/react-client/halo';
-import { Button, DensityProvider, ElevationProvider, Tooltip, useSidebars, useTranslation } from '@dxos/react-ui';
+import {
+  Button,
+  DensityProvider,
+  ElevationProvider,
+  Tooltip,
+  useMediaQuery,
+  useSidebars,
+  useTranslation,
+} from '@dxos/react-ui';
 import { Path, type MosaicDropEvent, type MosaicMoveEvent } from '@dxos/react-ui-mosaic';
 import { NavTree, type NavTreeContextType, type TreeNode, type NavTreeProps } from '@dxos/react-ui-navtree';
 import { getSize, mx } from '@dxos/react-ui-theme';
@@ -39,18 +47,25 @@ export const TreeViewContainer = ({
   const identity = useIdentity();
 
   const { t } = useTranslation(NAVTREE_PLUGIN);
-  const { navigationSidebarOpen } = useSidebars(NAVTREE_PLUGIN);
+  const { navigationSidebarOpen, closeNavigationSidebar } = useSidebars(NAVTREE_PLUGIN);
+  const [isLg] = useMediaQuery('lg', { ssr: false });
   const { dispatch } = useIntent();
 
   const handleSelect: NavTreeContextType['onSelect'] = async ({ node }: { node: TreeNode }) => {
+    if (!(node as Node).data) {
+      return;
+    }
+
     await dispatch({
       action: LayoutAction.ACTIVATE,
       data: {
         id: node.id,
       },
     });
-    // void defaultAction?.invoke();
-    // !isLg && closeNavigationSidebar();
+
+    const defaultAction = node.actions.find((action) => action.properties.disposition === 'default');
+    void defaultAction?.invoke();
+    !isLg && closeNavigationSidebar();
   };
 
   const currentPath = (activeId && getMosaicPath(graph, activeId)) ?? 'never';

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItemHeading.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItemHeading.tsx
@@ -37,10 +37,7 @@ export const NavTreeItemHeading = forwardRef<HTMLButtonElement, NavTreeItemHeadi
     { id, level, label, icon: Icon, open, current, branch, disabled, error, modified, palette, onSelect },
     forwardedRef,
   ) => {
-    // const [isLg] = useMediaQuery('lg', { ssr: false });
-
     const OpenTriggerIcon = open ? CaretDown : CaretRight;
-    // const defaultAction = node.actions.find((action) => action.properties.disposition === 'default');
 
     return (
       <div


### PR DESCRIPTION
- don't select nodes with no data
- close sidebar on selection on mobile
- trigger default action on selection

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 62a304c</samp>

### Summary
🗑️🛠️📱

<!--
1.  🗑️ for removing unused code
2.  🛠️ for fixing and enhancing the navigation sidebar functionality
3.  📱 for improving the user experience on smaller screens
-->
Improved the navigation sidebar functionality and user experience in the `plugin-navtree` app by using the correct types and modules for the Node and Graph entities, and by adding a hook to close the sidebar on smaller screens. Removed some unused code from the `NavTreeItemHeading` component in the `react-ui-navtree` package.

> _Sing, O Muse, of the skillful coder who refined_
> _The sidebar of the graph, where many a node is mined_
> _He cleared the useless lines, `isLg` and `defaultAction`_
> _And made the types and modules fit with keen abstraction_

### Walkthrough
*  Update import statements and use useMediaQuery hook in TreeViewContainer component ([link](https://github.com/dxos/dxos/pull/4575/files?diff=unified&w=0#diff-a6265a6cedfcc74f332b032e365ccfb081883fb035bc2faa60067a01742bd199L9-R20))
*  Add closeNavigationSidebar function and modify handleSelect logic in TreeViewContainer component ([link](https://github.com/dxos/dxos/pull/4575/files?diff=unified&w=0#diff-a6265a6cedfcc74f332b032e365ccfb081883fb035bc2faa60067a01742bd199L42-R58), [link](https://github.com/dxos/dxos/pull/4575/files?diff=unified&w=0#diff-a6265a6cedfcc74f332b032e365ccfb081883fb035bc2faa60067a01742bd199L52-R68))
*  Remove unused variables in NavTreeItemHeading component ([link](https://github.com/dxos/dxos/pull/4575/files?diff=unified&w=0#diff-dcbc9cc2d3f71b67b0197651c6e34e224bc366eab90d35e6620c1ce81ac171ccL40-R40))


