### PR TITLE
fix(plugin-space): deselect object if deleted while active

### DIFF
--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -510,6 +510,15 @@ export const SpacePlugin = ({ onFirstRun }: SpacePluginOptions = {}): PluginDefi
               const folder = intent.data.folder;
               const object = intent.data.object;
               if (folder instanceof Folder && object instanceof TypedObject) {
+                const layoutPlugin = resolvePlugin(plugins, parseLayoutPlugin);
+                const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);
+                if (layoutPlugin?.provides.layout.active === intent.data.object.id) {
+                  await intentPlugin?.provides.intent.dispatch({
+                    action: LayoutAction.ACTIVATE,
+                    data: { id: undefined },
+                  });
+                }
+
                 const index = folder.objects.indexOf(object);
                 folder.objects.splice(index, 1);
                 return true;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 62219dc</samp>

### Summary
🛠️🚫🔄

<!--
1.  🛠️ - This emoji represents the addition of logic or functionality to the component, which is a common type of change in software development.
2.  🚫 - This emoji represents the deactivation or removal of something, in this case the layout plugin, which is another common type of change that affects the behavior or state of the component.
3.  🔄 - This emoji represents the switching or changing of something, in this case the space, which is the main purpose of the component and the change.
-->
Fixed a bug where layout and intent plugins could interfere with each other when changing spaces. Added logic to `SpacePlugin` to deactivate the current layout plugin if it matches the intent data object.

> _`SpacePlugin` checks_
> _layout plugin activity_
> _deactivates if so_

### Walkthrough
*  Add logic to deactivate layout plugin when switching spaces ([link](https://github.com/dxos/dxos/pull/4576/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839R513-R521))


