### PR TITLE
fix(plugin-stack): filter dangling object references from sections

### DIFF
--- a/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
@@ -29,7 +29,11 @@ export const StackMain: FC<{ stack: StackType }> = ({ stack }) => {
   const stackPlugin = usePlugin<StackPluginProvides>(STACK_PLUGIN);
 
   const id = `stack-${stack.id}`;
-  const items = stack.sections.map(({ object }) => object as TypedObject<StackSectionItem>);
+  const items = stack.sections
+    .map(({ object }) => object as TypedObject<StackSectionItem>)
+    // TODO(wittjosiah): Should the database handle this differently?
+    // TODO(wittjosiah): Render placeholders for missing objects so they can be removed from the stack?
+    .filter((object) => Boolean(object));
 
   const handleOver = ({ active }: MosaicMoveEvent<number>) => {
     // TODO(wittjosiah): This is a hack to read graph data. Needs to use a lens.


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e112e68</samp>

### Summary
🐛🧹📝

<!--
1.  🐛 - This emoji represents a bug fix, as the filtering of null or undefined objects prevents errors and crashes that would otherwise occur.
2.  🧹 - This emoji represents a cleanup or refactoring, as the filtering of null or undefined objects simplifies the logic and readability of the code that renders the mosaic layout.
3.  📝 - This emoji represents a documentation or comment, as the two TODO comments explain the rationale for the filtering and suggest possible enhancements for the future.
-->
Fixed a bug that caused the stack app to crash when rendering items with missing data. Added TODO comments for future error handling in `StackMain.tsx`.

> _`items` array cleansed_
> _No nulls or undefineds_
> _Winter of errors_

### Walkthrough
*  Filter out null or undefined objects from the `items` array to prevent errors and crashes when rendering the mosaic layout of the stack items ([link](https://github.com/dxos/dxos/pull/4577/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068L32-R36)). Add TODO comments to suggest possible improvements for handling missing objects in the future ().


