### PR TITLE
fix: Script plugin in prod

### DIFF
--- a/packages/apps/labs-app/script-frame/index.html
+++ b/packages/apps/labs-app/script-frame/index.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script type="module" src="main.tsx"></script>
+</body>
+</html>

--- a/packages/apps/labs-app/script-frame/index.html
+++ b/packages/apps/labs-app/script-frame/index.html
@@ -1,4 +1,5 @@
 <html>
+  <!-- Iframe for the script plugin sandbox -->
 <head>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>

--- a/packages/apps/labs-app/script-frame/main.tsx
+++ b/packages/apps/labs-app/script-frame/main.tsx
@@ -9,7 +9,6 @@ import { ClientServicesProxy } from '@dxos/client/services';
 import { ClientProvider } from '@dxos/react-client';
 import { createIFramePort } from '@dxos/rpc-tunnel';
 
-
 // TODO(burdon): The script main frame currently must be part of the vite applications.
 //  Import file as resource from package?
 

--- a/packages/apps/labs-app/script-frame/main.tsx
+++ b/packages/apps/labs-app/script-frame/main.tsx
@@ -9,6 +9,7 @@ import { ClientServicesProxy } from '@dxos/client/services';
 import { ClientProvider } from '@dxos/react-client';
 import { createIFramePort } from '@dxos/rpc-tunnel';
 
+
 // TODO(burdon): The script main frame currently must be part of the vite applications.
 //  Import file as resource from package?
 

--- a/packages/apps/labs-app/src/main.tsx
+++ b/packages/apps/labs-app/src/main.tsx
@@ -53,7 +53,6 @@ import {
 } from '@dxos/react-ui-theme';
 
 // @ts-ignore
-import mainUrl from './frame?url';
 
 // TODO(wittjosiah): This ensures that typed objects and SpaceProxy are not proxied by deepsignal. Remove.
 // https://github.com/luisherranz/deepsignal/issues/36
@@ -121,7 +120,7 @@ const main = async () => {
       GridPlugin(),
       KanbanPlugin(),
       MapPlugin(),
-      ScriptPlugin({ mainUrl }),
+      ScriptPlugin({ mainUrl: '/script-frame/index.html' }),
       SketchPlugin(),
       StackPlugin(),
       TablePlugin(),

--- a/packages/apps/labs-app/src/main.tsx
+++ b/packages/apps/labs-app/src/main.tsx
@@ -120,7 +120,7 @@ const main = async () => {
       GridPlugin(),
       KanbanPlugin(),
       MapPlugin(),
-      ScriptPlugin({ mainUrl: '/script-frame/index.html' }),
+      ScriptPlugin({ containerUrl: '/script-frame/index.html' }),
       SketchPlugin(),
       StackPlugin(),
       TablePlugin(),

--- a/packages/apps/labs-app/tsconfig.json
+++ b/packages/apps/labs-app/tsconfig.json
@@ -15,7 +15,8 @@
     "vite.config.ts"
   ],
   "include": [
-    "src"
+    "src",
+    "script-frame"
   ],
   "references": [
     {

--- a/packages/apps/labs-app/vite.config.ts
+++ b/packages/apps/labs-app/vite.config.ts
@@ -24,9 +24,9 @@ export default defineConfig({
     https:
       process.env.HTTPS === 'true'
         ? {
-            key: './key.pem',
-            cert: './cert.pem',
-          }
+          key: './key.pem',
+          cert: './cert.pem',
+        }
         : false,
     fs: {
       allow: [
@@ -38,6 +38,12 @@ export default defineConfig({
   },
   build: {
     sourcemap: true,
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, './index.html'),
+        'script-frame': resolve(__dirname, './script-frame/index.html'),
+      }
+    }
   },
   resolve: {
     alias: {
@@ -45,6 +51,29 @@ export default defineConfig({
     },
   },
   plugins: [
+    {
+      name: "sandbox-importmap-integration",
+      transformIndexHtml() {
+        return [{
+          tag: 'script',
+          injectTo: 'head-prepend',
+          children: `
+            if(window.location.hash.includes('importMap')) {
+              const urlParams = new URLSearchParams(window.location.hash.slice(1));
+              if(urlParams.get('importMap')) {
+                const importMap = JSON.parse(decodeURIComponent(urlParams.get('importMap')));
+                
+                const mapElement = document.createElement('script');
+                mapElement.type = 'importmap';
+                mapElement.textContent = JSON.stringify(importMap, null, 2);
+                document.head.appendChild(mapElement);
+              }
+            }
+          `
+        }];
+      }
+    },
+
     // mkcert(),
     ConfigPlugin({
       env: [

--- a/packages/apps/labs-app/vite.config.ts
+++ b/packages/apps/labs-app/vite.config.ts
@@ -51,12 +51,13 @@ export default defineConfig({
     },
   },
   plugins: [
-    {
+    { 
+      // Required for the script plugin.
       name: "sandbox-importmap-integration",
       transformIndexHtml() {
         return [{
           tag: 'script',
-          injectTo: 'head-prepend',
+          injectTo: 'head-prepend', // Inject before vite's built-in scripts.
           children: `
             if(window.location.hash.includes('importMap')) {
               const urlParams = new URLSearchParams(window.location.hash.slice(1));

--- a/packages/apps/plugins/plugin-script/src/ScriptPlugin.tsx
+++ b/packages/apps/plugins/plugin-script/src/ScriptPlugin.tsx
@@ -20,10 +20,10 @@ const isObject = <T extends EchoObject>(object: unknown, schema: Schema, filter:
 };
 
 export type ScriptPluginProps = {
-  mainUrl: string;
+  containerUrl: string;
 };
 
-export const ScriptPlugin = ({ mainUrl }: ScriptPluginProps): PluginDefinition<ScriptPluginProvides> => {
+export const ScriptPlugin = ({ containerUrl }: ScriptPluginProps): PluginDefinition<ScriptPluginProvides> => {
   return {
     meta: {
       id: SCRIPT_PLUGIN,
@@ -89,20 +89,24 @@ export const ScriptPlugin = ({ mainUrl }: ScriptPluginProps): PluginDefinition<S
           switch (role) {
             case 'main':
               return isObject(data.active, ScriptType.schema, ScriptType.filter()) ? (
-                <ScriptMain source={(data.active as any).source} mainUrl={mainUrl} />
+                <ScriptMain source={(data.active as any).source} containerUrl={containerUrl} />
               ) : null;
             case 'slide':
               return isObject(data.slide, ScriptType.schema, ScriptType.filter()) ? (
                 <ScriptMain
                   source={(data.slide as any).source}
-                  mainUrl={mainUrl}
+                  containerUrl={containerUrl}
                   view={'preview-only'}
                   className={'p-24'}
                 />
               ) : null;
             case 'section':
               return isObject(data.object, ScriptType.schema, ScriptType.filter()) ? (
-                <ScriptSection source={(data.object as any).source} mainUrl={mainUrl} className={'h-[500px] py-2'} />
+                <ScriptSection
+                  source={(data.object as any).source}
+                  containerUrl={containerUrl}
+                  className={'h-[500px] py-2'}
+                />
               ) : null;
           }
         },

--- a/packages/apps/plugins/plugin-script/src/compiler/compiler.ts
+++ b/packages/apps/plugins/plugin-script/src/compiler/compiler.ts
@@ -35,7 +35,7 @@ export const initializeCompiler = async (options: { wasmURL: string }) => {
  * ESBuild compiler.
  */
 export class Compiler {
-  constructor(private readonly _options: CompilerOptions) { }
+  constructor(private readonly _options: CompilerOptions) {}
 
   // TODO(burdon): Error handling.
   async compile(source: string): Promise<CompilerResult> {

--- a/packages/apps/plugins/plugin-script/src/compiler/compiler.ts
+++ b/packages/apps/plugins/plugin-script/src/compiler/compiler.ts
@@ -35,7 +35,7 @@ export const initializeCompiler = async (options: { wasmURL: string }) => {
  * ESBuild compiler.
  */
 export class Compiler {
-  constructor(private readonly _options: CompilerOptions) {}
+  constructor(private readonly _options: CompilerOptions) { }
 
   // TODO(burdon): Error handling.
   async compile(source: string): Promise<CompilerResult> {

--- a/packages/apps/plugins/plugin-script/src/components/FrameContainer/FrameContainer.tsx
+++ b/packages/apps/plugins/plugin-script/src/components/FrameContainer/FrameContainer.tsx
@@ -12,14 +12,14 @@ import { createIFramePort } from '@dxos/rpc-tunnel';
 import { type CompilerResult } from '../../compiler';
 
 export type FrameContainerProps = {
-  mainUrl: string;
+  containerUrl: string;
   result: CompilerResult;
 };
 
 /**
  * IFrame container for the compiled script.
  */
-export const FrameContainer = ({ mainUrl, result }: FrameContainerProps) => {
+export const FrameContainer = ({ containerUrl, result }: FrameContainerProps) => {
   const client = useClient();
   const iframeRef = useRef<HTMLIFrameElement>(null);
   useEffect(() => {
@@ -42,9 +42,11 @@ export const FrameContainer = ({ mainUrl, result }: FrameContainerProps) => {
     }
   }, [iframeRef]);
 
-  const src = `${mainUrl}#importMap=${encodeURIComponent(JSON.stringify({
-    imports: createImportMap(result),
-  }))}`
+  const src = `${containerUrl}#importMap=${encodeURIComponent(
+    JSON.stringify({
+      imports: createImportMap(result),
+    }),
+  )}`;
 
   return <iframe ref={iframeRef} sandbox='allow-scripts' src={src} style={{ width: '100%', height: '100%' }} />;
 };

--- a/packages/apps/plugins/plugin-script/src/components/FrameContainer/FrameContainer.tsx
+++ b/packages/apps/plugins/plugin-script/src/components/FrameContainer/FrameContainer.tsx
@@ -9,8 +9,6 @@ import { useClient } from '@dxos/react-client';
 import { createProtoRpcPeer } from '@dxos/rpc';
 import { createIFramePort } from '@dxos/rpc-tunnel';
 
-// @ts-ignore
-import frameSrc from './frame.html?raw';
 import { type CompilerResult } from '../../compiler';
 
 export type FrameContainerProps = {
@@ -44,14 +42,11 @@ export const FrameContainer = ({ mainUrl, result }: FrameContainerProps) => {
     }
   }, [iframeRef]);
 
-  const html = frameSrc.replace(
-    '__IMPORT_MAP__',
-    JSON.stringify({
-      imports: createImportMap(mainUrl, result),
-    }),
-  );
+  const src = `${mainUrl}#importMap=${encodeURIComponent(JSON.stringify({
+    imports: createImportMap(result),
+  }))}`
 
-  return <iframe ref={iframeRef} sandbox='allow-scripts' srcDoc={html} style={{ width: '100%', height: '100%' }} />;
+  return <iframe ref={iframeRef} sandbox='allow-scripts' src={src} style={{ width: '100%', height: '100%' }} />;
 };
 
 /**
@@ -60,7 +55,7 @@ export const FrameContainer = ({ mainUrl, result }: FrameContainerProps) => {
  * @param mainUrl
  * @param result
  */
-const createImportMap = (mainUrl: string, result: CompilerResult) => {
+const createImportMap = (result: CompilerResult) => {
   const createReexportingModule = (namedImports: string[], key: string) => {
     const code = `
       const { ${namedImports.join(',')} } = window.__DXOS_SANDBOX_MODULES__[${JSON.stringify(key)}];
@@ -72,7 +67,6 @@ const createImportMap = (mainUrl: string, result: CompilerResult) => {
   };
 
   return {
-    '@frame/main': mainUrl,
     '@frame/bundle': `data:text/javascript;base64,${btoa(result.bundle)}`,
     ...Object.fromEntries(
       result.imports

--- a/packages/apps/plugins/plugin-script/src/components/ScriptMain.stories.tsx
+++ b/packages/apps/plugins/plugin-script/src/components/ScriptMain.stories.tsx
@@ -44,9 +44,10 @@ const Story = () => {
     return null;
   }
 
+  // TODO(dmaretskyi): Not sure how to provide `containerUrl` here since the html now lives in labs-app.
   return (
     <div className={'flex fixed inset-0'}>
-      <ScriptSection source={source} mainUrl={mainUrl} />
+      <ScriptSection source={source} containerUrl={mainUrl} />
     </div>
   );
 };

--- a/packages/apps/plugins/plugin-script/src/components/ScriptMain.tsx
+++ b/packages/apps/plugins/plugin-script/src/components/ScriptMain.tsx
@@ -21,7 +21,9 @@ export type View = 'editor' | 'preview' | 'split' | 'preview-only';
 export type ScriptMainProps = {
   view?: View;
   source: TextObject;
-  mainUrl: string;
+
+  // Url to the page used to host the script in the iframe.
+  containerUrl: string;
   className?: string;
 };
 
@@ -33,7 +35,7 @@ export const ScriptMain = (props: ScriptMainProps) => {
   );
 };
 
-export const ScriptSection = ({ view: controlledView, source, mainUrl, className }: ScriptMainProps) => {
+export const ScriptSection = ({ view: controlledView, source, containerUrl, className }: ScriptMainProps) => {
   const [result, setResult] = useState<CompilerResult>();
 
   const { themeMode } = useThemeContext();
@@ -94,7 +96,7 @@ export const ScriptSection = ({ view: controlledView, source, mainUrl, className
         )}
         {view !== 'editor' && result && (
           <div className='flex flex-1 shrink-0 overflow-hidden'>
-            <FrameContainer result={result} mainUrl={mainUrl} />
+            <FrameContainer result={result} containerUrl={containerUrl} />
           </div>
         )}
       </div>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2d58793</samp>

### Summary
📄🔧🚀

<!--
1.  📄 for adding a new HTML file for the script plugin sandbox iframe.
2.  🔧 for refactoring and improving the configuration and loading of the script plugin and its components.
3.  🚀 for enabling multiple entry points and dynamic import maps for the vite build and the iframe sandbox.
-->
This pull request refactors the script plugin and the labs-app to use a new HTML file as the iframe source for the script sandbox. This allows the plugin to support scripts from different domains or protocols, and simplifies the loading of the script modules. It also improves the vite.config.ts file and fixes some formatting and unused code issues. It updates the relevant components, props, and stories to use the new `containerUrl` instead of the `mainUrl`.

> _We're refactoring the script plugin, me hearties_
> _To use the `containerUrl` for the iframe_
> _We'll heave away and haul away with TypeScript and vite_
> _And load the modules from the import map in the hash_

### Walkthrough
*  Add a new HTML file for the script plugin sandbox iframe that imports tailwindcss and the main.tsx module ([link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-abcdf53f74cc733b7fab290790d3f8294a70dfdd1621c71ff69867236a327e1dR1-R11))
* Rename the frame.tsx file to main.tsx and move it to the script-frame folder ([link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-1226ff11f840903d1442a0c1fe9b48c4df6c7ae7613cf454a0b1087778d09129))
* Replace the mainUrl prop with the containerUrl prop in the ScriptPlugin, ScriptMain, ScriptSection, and FrameContainer components, and use the containerUrl as the src of the iframe ([link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-9d663519e7a46a19fe4305c8085aa017f51355119fb0fbe545eb37ab8492722cL124-R123), [link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-849bd99dd377603ad654f96fc8654230d7fed024ae96c2acbe255fd8b3cf90e3L23-R26), [link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-849bd99dd377603ad654f96fc8654230d7fed024ae96c2acbe255fd8b3cf90e3L92-R92), [link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-849bd99dd377603ad654f96fc8654230d7fed024ae96c2acbe255fd8b3cf90e3L98-R98), [link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-849bd99dd377603ad654f96fc8654230d7fed024ae96c2acbe255fd8b3cf90e3L105-R109), [link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-2115e49f5bc050cb81864ed2531be3c8bae594c65e4b9a98394a708a885353c5L12-R15), [link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-2115e49f5bc050cb81864ed2531be3c8bae594c65e4b9a98394a708a885353c5L24-R22), [link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-2115e49f5bc050cb81864ed2531be3c8bae594c65e4b9a98394a708a885353c5L47-R51), [link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-a3d91b631f053ea70a66fbb90c008344fa61816fe987c5cf6c90d16656373767L24-R26), [link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-a3d91b631f053ea70a66fbb90c008344fa61816fe987c5cf6c90d16656373767L36-R38), [link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-a3d91b631f053ea70a66fbb90c008344fa61816fe987c5cf6c90d16656373767L97-R99))
* Remove the unused import of the mainUrl from the frame.html file and the '@frame/main' entry from the import map ([link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-9d663519e7a46a19fe4305c8085aa017f51355119fb0fbe545eb37ab8492722cL56), [link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-2115e49f5bc050cb81864ed2531be3c8bae594c65e4b9a98394a708a885353c5L63-R60), [link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-2115e49f5bc050cb81864ed2531be3c8bae594c65e4b9a98394a708a885353c5L75))
* Add the script-frame folder to the TypeScript compilation and the Vite bundling ([link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-7d99c8ccbf4bbd583481ce1733c44208a3506d2d2ea49ccad8e325da769a7a85L18-R19), [link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-bc212f565dc607eb0c92c7eedd5fe1f829b3d48811fa472c870cb1337e5f39d4R41-R46))
* Fix the indentation of the HTTPS options in the Vite config file ([link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-bc212f565dc607eb0c92c7eedd5fe1f829b3d48811fa472c870cb1337e5f39d4L27-R29))
* Add a custom plugin to the Vite config file that injects a script tag in the head of the HTML file, that parses the importMap parameter from the URL hash and appends it as a script type="importmap" element ([link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-bc212f565dc607eb0c92c7eedd5fe1f829b3d48811fa472c870cb1337e5f39d4R54-R77))
* Update the Story component to use the containerUrl prop for the ScriptSection component and add a TODO comment ([link](https://github.com/dxos/dxos/pull/4594/files?diff=unified&w=0#diff-21460b6a7566b47c156cedc6b0b0c27bc5ae01af0743127d55585ee0cf9bf7c5L47-R50))


