### PR TITLE
fix: networking error reporting and logging

### DIFF
--- a/packages/core/mesh/network-manager/src/swarm/connection.ts
+++ b/packages/core/mesh/network-manager/src/swarm/connection.ts
@@ -353,7 +353,7 @@ export class Connection {
 
       // If signal fails treat connection as failed
       log.info('signal message failed to deliver', { err });
-      await this.close();
+      await this.close(new ConnectivityError('signal message failed to deliver', err));
     }
   }
 

--- a/packages/core/mesh/teleport-extension-gossip/src/gossip.ts
+++ b/packages/core/mesh/teleport-extension-gossip/src/gossip.ts
@@ -111,7 +111,7 @@ export class Gossip {
         .catch(async (err) => {
           if (err instanceof RpcClosedError) {
             log('sendAnnounce failed because of RpcClosedError', { err });
-          } else if (err instanceof TimeoutError) {
+          } else if (err instanceof TimeoutError || err.constructor.name === 'TimeoutError') {
             log('sendAnnounce failed because of TimeoutError', { err });
           } else {
             log.catch(err);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 87d353f</samp>

### Summary
🛠️🕐📡

<!--
1.  🛠️ - This emoji represents the idea of fixing or improving something, which is relevant for both changes as they aim to address some issues or bugs in the code.
2.  🕐 - This emoji represents the concept of time or timing, which is relevant for both changes as they involve handling timeouts or delays in the network communication.
3.  📡 - This emoji represents the concept of communication or signaling, which is relevant for both changes as they involve sending or receiving messages over a WebRTC connection.
-->
The pull request improves the error handling and reporting of the `Connection` and `Gossip` classes in the `network-manager` and `teleport-extension-gossip` packages. It adds more details to the `close` method of `Connection` and fixes a potential bug in the `sendAnnounce` method of `Gossip`.

> _`close` with error_
> _more details for WebRTC_
> _debugging in fall_

### Walkthrough
*  Add more information to connection closing errors ([link](https://github.com/dxos/dxos/pull/4595/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745L356-R356))
*  Handle different forms of timeout errors in gossip messages ([link](https://github.com/dxos/dxos/pull/4595/files?diff=unified&w=0#diff-8c0d22e91ef78cf597ee52fe4f8f36f1608d2baad932a27bf9d7f097e805101aL114-R114))


