### PR TITLE
fix: don't crash exposing types

### DIFF
--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -42,7 +42,7 @@ import { INITIAL_CONTENT, INITIAL_TITLE } from './initialContent';
 (globalThis as any)[SpaceProxy.name] = SpaceProxy;
 
 // TODO(wittjosiah): Remove. Used to be able to access types from the console.
-(window as any).dxos.types = {
+(window as any).dxos_types = {
   Document,
   File,
   Folder,

--- a/packages/apps/labs-app/src/main.tsx
+++ b/packages/apps/labs-app/src/main.tsx
@@ -53,7 +53,7 @@ import {
 } from '@dxos/react-ui-theme';
 
 // TODO(wittjosiah): Remove. Used to be able to access types from the console.
-(window as any).dxos.types = {
+(window as any).dxos_types = {
   Document,
   File,
   Folder,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d881ce1</samp>

### Summary
🔄📝🧪

<!--
1.  🔄 - This emoji represents the renaming of the global variable, which is a change that affects the compatibility and usage of the composer-app and the labs-app. It also implies that the change was done to avoid a conflict or collision with another library or namespace.
2. 📝 - This emoji represents the composer-app, which is an editor for creating and editing documents and other data types. It also implies that the change affects the functionality and user interface of the composer-app.
3. 🧪 - This emoji represents the labs-app, which is a playground for experimenting with different data types and features. It also implies that the change affects the functionality and user interface of the labs-app.
-->
Renamed `dxos.types` to `dxos_types` in the composer-app and labs-app to avoid a global variable conflict. This change prevents potential errors and bugs when using the DXOS web apps.

> _`dxos_types` now_
> _Avoids global conflict with_
> _Another library_

### Walkthrough
*  Rename `dxos.types` global variable to `dxos_types` to avoid naming conflict ([link](https://github.com/dxos/dxos/pull/4602/files?diff=unified&w=0#diff-9f2aee287f92edd662c13bed460a28a1590c9186b62c98ccc2e00f6877c3d7e6L45-R45), [link](https://github.com/dxos/dxos/pull/4602/files?diff=unified&w=0#diff-9d663519e7a46a19fe4305c8085aa017f51355119fb0fbe545eb37ab8492722cL56-R56))


