### PR TITLE
fix(react-shell): Purity

### DIFF
--- a/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanel.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanel.tsx
@@ -4,7 +4,7 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 
 import { log } from '@dxos/log';
-import { useClient } from '@dxos/react-client';
+import { useClient, useMulticastObservable } from '@dxos/react-client';
 import { useIdentity } from '@dxos/react-client/halo';
 import { DensityProvider, useId, useThemeContext } from '@dxos/react-ui';
 
@@ -32,6 +32,7 @@ export const JoinPanelImpl = (props: JoinPanelImplProps) => {
     mode,
     unredeemedCodes,
     invitationStates,
+    succeededKeys,
     onExit,
     onHaloDone,
     onSpaceDone,
@@ -71,6 +72,7 @@ export const JoinPanelImpl = (props: JoinPanelImplProps) => {
               Kind='Halo'
               active={activeView === 'halo invitation input'}
               {...(unredeemedCodes?.Halo && { unredeemedCode: unredeemedCodes.Halo })}
+              {...(succeededKeys?.Halo && { succeededKeys: succeededKeys.Halo })}
             />
           </Viewport.View>
           <Viewport.View classNames={stepStyles} id='halo invitation rescuer'>
@@ -114,6 +116,7 @@ export const JoinPanelImpl = (props: JoinPanelImplProps) => {
               Kind='Space'
               active={activeView === 'space invitation input'}
               {...(unredeemedCodes?.Space && { unredeemedCode: unredeemedCodes.Space })}
+              {...(succeededKeys?.Space && { succeededKeys: succeededKeys.Space })}
               onExit={onExit}
               exitActionParent={exitActionParent}
             />
@@ -319,6 +322,15 @@ export const JoinPanel = ({
     [joinState],
   );
 
+  const spaces = useMulticastObservable(client.spaces);
+
+  const succeededKeys = useMemo(
+    () => ({
+      Space: spaces ? new Set(spaces.map(({ key }) => key.toHex())) : undefined,
+    }),
+    [spaces],
+  );
+
   const invitationStates = useMemo(
     () => ({
       Halo: joinState.context.halo.invitation?.state,
@@ -354,6 +366,7 @@ export const JoinPanel = ({
         pending: ['connecting', 'authenticating'].some((str) => joinState?.configuration[0].id.includes(str)),
         unredeemedCodes,
         invitationStates,
+        succeededKeys,
         identity,
         onExit,
         exitActionParent,

--- a/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanelProps.ts
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanelProps.ts
@@ -46,6 +46,10 @@ export type JoinPanelImplProps = Pick<
     Halo: Invitation.State;
     Space: Invitation.State;
   }>;
+  succeededKeys?: Partial<{
+    Halo: Set<string>;
+    Space: Set<string>;
+  }>;
   onHaloDone?: () => void;
   onSpaceDone?: () => void;
   onHaloInvitationCancel?: () => Promise<void> | undefined;

--- a/packages/sdk/react-shell/src/panels/JoinPanel/steps/InvitationInput.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/steps/InvitationInput.tsx
@@ -5,7 +5,6 @@
 import React, { useState, useEffect, cloneElement } from 'react';
 
 import { log } from '@dxos/log';
-import { useClient } from '@dxos/react-client';
 import { useTranslation } from '@dxos/react-ui';
 
 import { Actions, StepHeading, Action, Input } from '../../../components';
@@ -14,6 +13,7 @@ import { type JoinPanelProps, type JoinStepProps } from '../JoinPanelProps';
 export interface InvitationInputProps extends JoinStepProps, Pick<JoinPanelProps, 'onExit' | 'exitActionParent'> {
   Kind: 'Space' | 'Halo';
   unredeemedCode?: string;
+  succeededKeys?: Set<string>;
 }
 
 const invitationCodeFromUrl = (text: string) => {
@@ -28,10 +28,10 @@ const invitationCodeFromUrl = (text: string) => {
 };
 
 export const InvitationInput = (props: InvitationInputProps) => {
-  const { Kind, active, send, unredeemedCode, onExit, exitActionParent, onDone, doneActionParent } = props;
+  const { Kind, active, send, unredeemedCode, onExit, exitActionParent, onDone, doneActionParent, succeededKeys } =
+    props;
   const disabled = !active;
   const { t } = useTranslation('os');
-  const client = useClient();
 
   const [inputValue, setInputValue] = useState(unredeemedCode ?? '');
 
@@ -43,7 +43,7 @@ export const InvitationInput = (props: InvitationInputProps) => {
     send({
       type: `set${Kind}InvitationCode`,
       code: invitationCodeFromUrl(inputValue),
-      ...(Kind === 'Space' && { succeededKeys: new Set(client.spaces.get().map(({ key }) => key.toHex())) }),
+      ...(Kind === 'Space' && { succeededKeys }),
     });
 
   const exitAction = (


### PR DESCRIPTION
I did a bad and forgot where shell’s purity line was. This PR puts it back where it belongs. The original feature still works as it did before.

---

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 702b8da</samp>

### Summary
🆕📡♻️

<!--
1.  🆕 - This emoji represents the addition of a new prop (`succeededKeys`) to the components and the type definition.
2.  📡 - This emoji represents the use of the `useMulticastObservable` hook to observe the client spaces and update the component state accordingly.
3.  ♻️ - This emoji represents the refactoring of the `InvitationInput` component to simplify its logic and remove unnecessary code.
-->
Refactored the `JoinPanel` and `InvitationInput` components to use a new `succeededKeys` prop to track the joined spaces and identities. Simplified the `InvitationInput` logic and removed unnecessary variables. Updated the `JoinPanelImplProps` type to include the new prop.

> _We're joining spaces and identities_
> _With `succeededKeys` prop we see_
> _Heave away and haul, me hearties_
> _We've simplified the `InvitationInput` logic_

### Walkthrough
* Import `useMulticastObservable` hook to observe client spaces ([link](https://github.com/dxos/dxos/pull/4616/files?diff=unified&w=0#diff-2d39365b754c6a396cbee16332fda4338cbd7f5f39ae25b329d5a8973889443fL7-R7)).


