### PR TITLE
fix(react-shell): Restore invitation cancellation

### DIFF
--- a/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanel.tsx
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanel.tsx
@@ -33,6 +33,7 @@ export const JoinPanelImpl = (props: JoinPanelImplProps) => {
     unredeemedCodes,
     invitationStates,
     succeededKeys,
+    failReasons,
     onExit,
     onHaloDone,
     onSpaceDone,
@@ -82,6 +83,7 @@ export const JoinPanelImpl = (props: JoinPanelImplProps) => {
               active={activeView === 'halo invitation rescuer'}
               invitationState={invitationStates?.Halo}
               onInvitationCancel={onHaloInvitationCancel}
+              failReason={failReasons?.Halo}
             />
           </Viewport.View>
           <Viewport.View classNames={stepStyles} id='halo invitation authenticator'>
@@ -128,6 +130,7 @@ export const JoinPanelImpl = (props: JoinPanelImplProps) => {
               active={activeView === 'space invitation rescuer'}
               invitationState={invitationStates?.Space}
               onInvitationCancel={onSpaceInvitationCancel}
+              failReason={failReasons?.Space}
             />
           </Viewport.View>
           <Viewport.View classNames={stepStyles} id='space invitation authenticator'>
@@ -333,8 +336,16 @@ export const JoinPanel = ({
 
   const invitationStates = useMemo(
     () => ({
-      Halo: joinState.context.halo.invitation?.state,
-      Space: joinState.context.space.invitation?.state,
+      Halo: joinState.context.halo.invitationObservable?.get().state,
+      Space: joinState.context.space.invitationObservable?.get().state,
+    }),
+    [joinState],
+  );
+
+  const failReasons = useMemo(
+    () => ({
+      Halo: joinState.context.halo.failReason,
+      Space: joinState.context.space.failReason,
     }),
     [joinState],
   );
@@ -363,6 +374,7 @@ export const JoinPanel = ({
         send: joinSend,
         activeView,
         failed,
+        failReasons,
         pending: ['connecting', 'authenticating'].some((str) => joinState?.configuration[0].id.includes(str)),
         unredeemedCodes,
         invitationStates,

--- a/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanelProps.ts
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/JoinPanelProps.ts
@@ -10,6 +10,7 @@ import type { Invitation, AuthenticatingInvitationObservable, InvitationResult }
 import { type JoinSend } from './joinMachine';
 import { type IdentityInputProps } from './steps';
 import { type StepProps } from '../../steps';
+import { type FailReason } from '../../types';
 
 export type JoinPanelMode = 'default' | 'halo-only';
 
@@ -49,6 +50,10 @@ export type JoinPanelImplProps = Pick<
   succeededKeys?: Partial<{
     Halo: Set<string>;
     Space: Set<string>;
+  }>;
+  failReasons?: Partial<{
+    Halo: FailReason | null;
+    Space: FailReason | null;
   }>;
   onHaloDone?: () => void;
   onSpaceDone?: () => void;

--- a/packages/sdk/react-shell/src/panels/JoinPanel/joinMachine.ts
+++ b/packages/sdk/react-shell/src/panels/JoinPanel/joinMachine.ts
@@ -20,8 +20,7 @@ import { type Identity } from '@dxos/react-client/halo';
 import { type AuthenticatingInvitationObservable, Invitation, InvitationEncoder } from '@dxos/react-client/invitations';
 
 import { type JoinPanelMode } from './JoinPanelProps';
-
-type FailReason = 'error' | 'timeout' | 'cancelled' | 'badVerificationCode';
+import { type FailReason } from '../../types';
 
 type InvitationKindContext = Partial<{
   failReason: FailReason | null;

--- a/packages/sdk/react-shell/src/types/FailReason.ts
+++ b/packages/sdk/react-shell/src/types/FailReason.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+export type FailReason = 'error' | 'timeout' | 'cancelled';

--- a/packages/sdk/react-shell/src/types/index.ts
+++ b/packages/sdk/react-shell/src/types/index.ts
@@ -2,4 +2,5 @@
 // Copyright 2023 DXOS.org
 //
 
+export * from './FailReason';
 export * from './IInvitation';


### PR DESCRIPTION
This PR resolves #3488.

https://github.com/dxos/dxos/assets/855039/39e59d47-cdbf-4d0d-ae06-3363632127fd

---

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 60648c7</samp>

### Summary
🔄🚧📦

<!--
1.  🔄 - This emoji represents the change of the import statement and the removal of the redundant type declaration for the `FailReason` type, as these are refactoring changes that update the code to use the new location of the type definition.
2.  🚧 - This emoji represents the change of the props type and the logic of the `InvitationRescuer` and `InvitationActions` components, as these are feature changes that add new functionality to the join panel UI to handle and display different failure reasons.
3.  📦 - This emoji represents the addition of the new file `FailReason.ts` and the export statement for the `FailReason` type, as these are code changes that create a new module and export a new type.
-->
This pull request improves the join panel UI to handle and display different failure reasons for joining a halo or a space. It adds a `failReasons` prop to the join panel UI components, and uses the `invitationObservable` to track the invitation state more accurately. It also defines and exports a new `FailReason` type in the `types` folder, and updates the import statements and type declarations accordingly.

> _Oh, we're the jolly joiners of the halo and the space_
> _We use the `FailReason` type to show the user's case_
> _We heave and ho and pull the code to make the UI shine_
> _And when we're done we sing this song and celebrate online_

### Walkthrough
*  Move `FailReason` type to a separate file `types/FailReason.ts` and export it from `types/index.ts` ([link](https://github.com/dxos/dxos/pull/4639/files?diff=unified&w=0#diff-5c2c685c495c5ff80dc2c80da38bc598e72c5a3e083604dd151a9b3b27726f03R1-R5), [link](https://github.com/dxos/dxos/pull/4639/files?diff=unified&w=0#diff-0bdddcc3d3413eb95f180d0cc488999c8a880894f0fe6fa9fe8fe80cf0bef5adR5))
*  Change import statements for `FailReason` type to use `types` folder instead of local file ([link](https://github.com/dxos/dxos/pull/4639/files?diff=unified&w=0#diff-8b97ca18fa4009f62a48fd7616336015f49a55cb54ac7c4c1c353e0b44fe7de4L23-R24), [link](https://github.com/dxos/dxos/pull/4639/files?diff=unified&w=0#diff-2a8cb485d8ae9d1e6f7e7b9c71a157c83ae9992c2659d67e7d6ae9c44ab54623L7-R79))
*  Add `failReasons` prop to `JoinPanelImpl` component to display failure status and actions for joining a halo or a space ([link](https://github.com/dxos/dxos/pull/4639/files?diff=unified&w=0#diff-2d39365b754c6a396cbee16332fda4338cbd7f5f39ae25b329d5a8973889443fR36), [link](https://github.com/dxos/dxos/pull/4639/files?diff=unified&w=0#diff-85ed9ffe64898ce8d3eaba66f94b56a6c2b18c0f5282d29ef341a26a1533500dR54-R57))
*  Pass `failReasons.Halo` and `failReasons.Space` props to `InvitationRescuer` components to override `invitationState` prop in case of failure ([link](https://github.com/dxos/dxos/pull/4639/files?diff=unified&w=0#diff-2d39365b754c6a396cbee16332fda4338cbd7f5f39ae25b329d5a8973889443fR86), [link](https://github.com/dxos/dxos/pull/4639/files?diff=unified&w=0#diff-2d39365b754c6a396cbee16332fda4338cbd7f5f39ae25b329d5a8973889443fR133))
*  Change `JoinPanel` component to compute `invitationStates` prop from `invitationObservable` and `failReasons` prop from `failReason` property of join machine context ([link](https://github.com/dxos/dxos/pull/4639/files?diff=unified&w=0#diff-2d39365b754c6a396cbee16332fda4338cbd7f5f39ae25b329d5a8973889443fL336-R352))
*  Pass `failReasons` prop to `onDone` callback of `JoinPanel` component to inform caller of failure reasons ([link](https://github.com/dxos/dxos/pull/4639/files?diff=unified&w=0#diff-2d39365b754c6a396cbee16332fda4338cbd7f5f39ae25b329d5a8973889443fR377))


