### PR TITLE
fix: cleanup navtree actions rendering

### DIFF
--- a/packages/apps/plugins/plugin-space/src/translations.ts
+++ b/packages/apps/plugins/plugin-space/src/translations.ts
@@ -46,7 +46,7 @@ export default [
         'missing object message': 'Object not available.',
         'missing object description':
           'TThe requested object has not been found yet. Ensure there are enough peers online in the space with an updated copy.',
-        'add folder label': 'Add folder',
+        'create folder label': 'Create folder',
         'unnamed object label': 'New object',
         'unnamed folder label': 'New folder',
         'create object group label': 'Add to space',

--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -169,7 +169,7 @@ export const objectToGraphNode = ({
         {
           id: 'create-space',
           label: ['create space label', { ns: 'os' }],
-          icon: (props) => <Planet {...props} />,
+          icon: (props) => <Plus {...props} />,
           properties: {
             disposition: 'toolbar',
             testId: 'spacePlugin.createSpace',
@@ -228,7 +228,7 @@ export const objectToGraphNode = ({
     if (isSpaceFolder) {
       node.actionsMap[`${SPACE_PLUGIN}/create`]?.addAction({
         id: 'folder/create',
-        label: ['add folder label', { ns: SPACE_PLUGIN }],
+        label: ['create folder label', { ns: SPACE_PLUGIN }],
         icon: (props) => <FolderPlus {...props} />,
         invoke: () =>
           dispatch({

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
@@ -183,7 +183,19 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
                   testId={primaryAction.properties.testId}
                 />
               )}
-              {actions.length > 0 && (
+              {actions.length === 1 ? (
+                <NavTreeItemActionMenu
+                  id={node.id}
+                  label={Array.isArray(actions[0].label) ? t(...actions[0].label) : actions[0].label}
+                  icon={actions[0].icon ?? Placeholder}
+                  action={actions[0].actions.length === 0 ? actions[0] : undefined}
+                  actions={actions[0].actions}
+                  level={level}
+                  active={active}
+                  popoverAnchorId={popoverAnchorId}
+                  testId={actions[0].properties.testId}
+                />
+              ) : actions.length > 1 ? (
                 <NavTreeItemActionMenu
                   id={node.id}
                   // label={t('tree item actions label')}
@@ -194,7 +206,7 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
                   popoverAnchorId={popoverAnchorId}
                   testId={`navtree.treeItem.actionsLevel${level}`}
                 />
-              )}
+              ) : null}
               {renderPresence?.(node)}
             </div>
             {!active &&


### PR DESCRIPTION

![Screenshot from 2023-11-07 16-51-08](https://github.com/dxos/dxos/assets/4529818/ef52abe4-9917-468f-aa23-2538e1321b56)
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5c86e97</samp>

### Summary
📁🔄🎨

<!--
1.  📁 - This emoji represents the change from 'Add folder' to 'Create folder', as it is a common symbol for folders and implies the creation of a new one.
2.  🔄 - This emoji represents the update of icons and labels for space and folder creation actions, as it suggests a refresh or improvement of the existing elements.
3.  🎨 - This emoji represents the improvement of the rendering of the action menu for tree items, as it implies a visual enhancement or refinement of the UI.
-->
Improved the user interface and usability of the space plugin and the navtree component. Changed some icons, labels, and action menu behaviors to make them more consistent and intuitive.

> _We create and destroy in the space of doom_
> _`Create folder` is our battle cry_
> _We wield the icons of clarity and power_
> _No empty menus shall defy our will_

### Walkthrough
* Change the label and icon for creating a folder in the space plugin ([link](https://github.com/dxos/dxos/pull/4640/files?diff=unified&w=0#diff-7fb1d4092e81509497c35fe93aca7d62efae75ec79e2f6268ed3dfcbc6220087L49-R49), [link](https://github.com/dxos/dxos/pull/4640/files?diff=unified&w=0#diff-40c06872035a3fca913d3ecf4b86bab147706b739e5546f25845364df1b60203L231-R231)).


