### PR TITLE
fix(react-ui-editor): Peer highlight colors

### DIFF
--- a/packages/ui/react-ui-theme/src/util/color.ts
+++ b/packages/ui/react-ui-theme/src/util/color.ts
@@ -26,9 +26,9 @@ const hexadecimalPaletteSeries: (keyof typeof configColors)[] = [
 ];
 
 const shadeKeys = {
-  color: '400' as const,
-  highlightDark: '800' as const,
-  highlightLight: '100' as const,
+  color: '450' as const,
+  highlightDark: '900' as const,
+  highlightLight: '50' as const,
 };
 
 /**


### PR DESCRIPTION
Resolves #4604.

This PR reduces the contrast of peer highlight colors.

<img width="1290" alt="Screenshot 2023-11-07 at 14 24 14" src="https://github.com/dxos/dxos/assets/855039/8e88ec21-0559-4eb2-bd35-9340844480ed">
<img width="1290" alt="Screenshot 2023-11-07 at 14 23 48" src="https://github.com/dxos/dxos/assets/855039/0d9e52ca-d531-4579-86ca-82572f6e2270">

---

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5a09ee4</samp>

### Summary
🎨🔆♻️

<!--
1.  🎨 - This emoji represents the color system or palette, and can be used to indicate any changes related to the UI theme, colors, or appearance of the app.
2.  🔆 - This emoji represents the contrast or brightness of the colors, and can be used to indicate any changes that affect the visibility, readability, or accessibility of the UI elements.
3.  ♻️ - This emoji represents the refactor or reorganization of the code, and can be used to indicate any changes that improve the structure, logic, or performance of the codebase.
-->
Refactor color system for UI theme. Adjust `shadeKeys` values in `color.ts` to increase contrast.

> _`shadeKeys` object_
> _Contrast for accessibility_
> _Winter colors sharp_

### Walkthrough
* Increase color contrast for shades by using darker and lighter values ([link](https://github.com/dxos/dxos/pull/4643/files?diff=unified&w=0#diff-5cc74bb774683c9e21a221bb611a75cc2dbe5e3bca82a61cb9638668ffa1b154L29-R31))


