### PR TITLE
fix: use space icon phosphor instead of square avatar in shell

### DIFF
--- a/packages/sdk/react-shell/src/panels/SpacePanel/SpacePanel.tsx
+++ b/packages/sdk/react-shell/src/panels/SpacePanel/SpacePanel.tsx
@@ -2,12 +2,13 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Planet } from '@phosphor-icons/react';
 import React, { useEffect, useMemo } from 'react';
 
 import { log } from '@dxos/log';
 import { useInvitationStatus } from '@dxos/react-client/invitations';
 import type { CancellableInvitationObservable } from '@dxos/react-client/invitations';
-import { Avatar, DensityProvider, useId, useJdenticonHref, useTranslation } from '@dxos/react-ui';
+import { DensityProvider, useId, useJdenticonHref, useTranslation } from '@dxos/react-ui';
 
 import { type SpacePanelHeadingProps, type SpacePanelImplProps, type SpacePanelProps } from './SpacePanelProps';
 import { useSpaceMachine } from './spaceMachine';
@@ -19,21 +20,16 @@ import { stepStyles } from '../../styles';
 const SpacePanelHeading = ({ titleId, space, onDone }: SpacePanelHeadingProps) => {
   const { t } = useTranslation('os');
   const name = space.properties.name;
-  const fallbackHref = useJdenticonHref(space.key.toHex(), 8);
   return (
     <Heading
       titleId={titleId}
       title={t('space panel heading')}
       corner={<CloseButton data-testid='identity-panel-done' onDone={onDone} />}
     >
-      <Avatar.Root variant='square' size={8} status='active'>
-        <div role='none' className='flex gap-4 items-center justify-center mlb-4'>
-          <Avatar.Frame>
-            <Avatar.Fallback href={fallbackHref} />
-          </Avatar.Frame>
-          <Avatar.Label classNames='block text-start font-light text-xl'>{name ?? space.key.truncate()}</Avatar.Label>
-        </div>
-      </Avatar.Root>
+      <div role='none' className='flex gap-4 items-center justify-center mlb-4'>
+        <Planet size={32} />
+        <div className='block text-start font-light text-xl'>{name ?? space.key.truncate()}</div>
+      </div>
     </Heading>
   );
 };

--- a/packages/sdk/react-shell/src/panels/SpacePanel/SpacePanel.tsx
+++ b/packages/sdk/react-shell/src/panels/SpacePanel/SpacePanel.tsx
@@ -8,7 +8,7 @@ import React, { useEffect, useMemo } from 'react';
 import { log } from '@dxos/log';
 import { useInvitationStatus } from '@dxos/react-client/invitations';
 import type { CancellableInvitationObservable } from '@dxos/react-client/invitations';
-import { DensityProvider, useId, useJdenticonHref, useTranslation } from '@dxos/react-ui';
+import { DensityProvider, useId, useTranslation } from '@dxos/react-ui';
 
 import { type SpacePanelHeadingProps, type SpacePanelImplProps, type SpacePanelProps } from './SpacePanelProps';
 import { useSpaceMachine } from './spaceMachine';


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4dd3dc3</samp>

### Summary
🪐🔄🎨

<!--
1.  🪐 - This emoji represents the planet icon that was used to replace the avatar components for space identity. It conveys the idea of a space or a group of people with a shared interest or purpose.
2.  🔄 - This emoji represents the change or replacement that was made in the code. It conveys the idea of switching or updating something to a different or better version.
3.  🎨 - This emoji represents the visual improvement or enhancement that was achieved by using the planet icon. It conveys the idea of creativity, design, or aesthetics.
-->
Updated space panel UI to use `Planet` icon for spaces. This change affects the `SpacePanel` component in `packages/sdk/react-shell/src/panels/SpacePanel/SpacePanel.tsx`.

> _`Avatar` falls, `Planet` rises_
> _Space panel shines with cosmic power_
> _We defy the old design_
> _We are the masters of the `SpacePanelHeading`_

### Walkthrough
*  Replace `Avatar` component with `Planet` icon for space identity in `SpacePanelHeading` component (`packages/sdk/react-shell/src/panels/SpacePanel/SpacePanel.tsx`, [link](https://github.com/dxos/dxos/pull/4645/files?diff=unified&w=0#diff-edbaf604d79d86cbe45401c32e8d5cc44bab1727f1f341494f436c3781d1075eR5), [link](https://github.com/dxos/dxos/pull/4645/files?diff=unified&w=0#diff-edbaf604d79d86cbe45401c32e8d5cc44bab1727f1f341494f436c3781d1075eL10-R11), [link](https://github.com/dxos/dxos/pull/4645/files?diff=unified&w=0#diff-edbaf604d79d86cbe45401c32e8d5cc44bab1727f1f341494f436c3781d1075eL22), [link](https://github.com/dxos/dxos/pull/4645/files?diff=unified&w=0#diff-edbaf604d79d86cbe45401c32e8d5cc44bab1727f1f341494f436c3781d1075eL29-R32))


