### PR TITLE
feat: sort viewers

### DIFF
--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -196,7 +196,7 @@ export const SpacePlugin = ({ onFirstRun }: SpacePluginOptions = {}): PluginDefi
                 const identityKey = PublicKey.safeFrom(message.payload.identityKey);
                 const spaceKey = PublicKey.safeFrom(message.payload.spaceKey);
                 if (identityKey && spaceKey && Array.isArray(added) && Array.isArray(removed)) {
-                  state.viewers = [
+                  const newViewers = [
                     ...state.viewers.filter(
                       (viewer) =>
                         !viewer.identityKey.equals(identityKey) ||
@@ -213,6 +213,8 @@ export const SpacePlugin = ({ onFirstRun }: SpacePluginOptions = {}): PluginDefi
                       lastSeen: Date.now(),
                     })),
                   ];
+                  newViewers.sort((a, b) => b.lastSeen - a.lastSeen);
+                  state.viewers = newViewers;
                 }
               }),
             );


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 61d2e13</samp>

### Summary
🛠️🔄🕑

<!--
1.  🛠️ - This emoji conveys the idea of refactoring or improving the code quality, as a wrench is a common tool for fixing or adjusting things.
2.  🔄 - This emoji suggests the idea of sorting or rearranging the order of elements, as the arrows form a circular motion that implies rotation or movement.
3.  🕑 - This emoji indicates the concept of recency or time, as a clock shows the current or past hour and minute.
-->
Improved state and UI of `SpacePlugin` by refactoring `state.viewers`. This prevents state mutation and shows viewers in order of recency.

> _To improve the state and the view_
> _We refactored `state.viewers` too_
> _We sorted by recency_
> _Avoided state mutancy_
> _And made the UI look fresh and new_

### Walkthrough
*  Sort viewers by last seen time in descending order to show the most recent ones first in the UI (`[link](https://github.com/dxos/dxos/pull/4648/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L199-R199)`, `[link](https://github.com/dxos/dxos/pull/4648/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839R216-R217)` in `SpacePlugin.tsx`)


