### PR TITLE
fix(react-ui-theme): Fix Avatar rings with inactive status

### DIFF
--- a/packages/ui/react-ui-theme/src/styles/components/avatar.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/avatar.ts
@@ -47,7 +47,6 @@ export const avatarStatusIcon: ComponentFunction<AvatarStyleProps> = ({ status, 
 export const avatarRing: ComponentFunction<AvatarStyleProps> = ({ status, variant, animation }, ...etc) =>
   mx(
     'absolute inset-0 border-2',
-    'border-[color:var(--surface-bg)]',
     variant === 'circle' ? 'rounded-full' : 'rounded',
     status === 'active'
       ? 'border-success-400 dark:border-success-400'
@@ -55,7 +54,9 @@ export const avatarRing: ComponentFunction<AvatarStyleProps> = ({ status, varian
       ? 'border-error-400 dark:border-error-500'
       : status === 'warning'
       ? 'border-warning-400 dark:border-warning-500'
-      : '',
+      : status === 'inactive'
+      ? 'border-neutral-400 dark:border-neutral-500'
+      : 'border-[color:var(--surface-bg)]',
     animation === 'pulse' ? 'animate-halo-pulse' : '',
     ...etc,
   );


### PR DESCRIPTION
Resolves #4633.

Does what it says on the tin, without affecting avatars that don’t use status.

<img width="691" alt="Screenshot 2023-11-07 at 17 04 46" src="https://github.com/dxos/dxos/assets/855039/775666c4-e141-4607-b111-01a10701a288">

https://github.com/dxos/dxos/assets/855039/f2b63e5e-38b3-48ab-8c65-a53bfd9a3ac3

---

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7429811</samp>

### Summary
🎨➕🔄

<!--
1.  🎨 - This emoji represents the removal of the default border color, which is a visual or aesthetic change to the component.
2.  ➕ - This emoji represents the addition of a new 'inactive' status option, which is a feature or functionality enhancement to the component.
3.  🔄 - This emoji represents the update or modification of the existing status options, which is a change to the component's behavior or logic.
-->
This pull request enhances the `avatar` component in the `react-ui-theme` package by allowing more customization of the ring status and appearance. It also removes an unnecessary default border color.

> _No more borders on the avatar ring_
> _We choose our own colors, we are the kings_
> _Inactive status for the ones who fall_
> _We don't need them, we stand tall_

### Walkthrough
* Remove default border color for avatar ring to allow status prop to determine it ([link](https://github.com/dxos/dxos/pull/4649/files?diff=unified&w=0#diff-0042c5ce3a3ad6368f704d2eae93d03d7383be03858580480d33c74d374d1943L50)).


