### PR TITLE
fix: Polish app settings dialog and surface contributors

### DIFF
--- a/packages/apps/plugins/plugin-debug/src/components/DebugSettings.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DebugSettings.tsx
@@ -20,7 +20,8 @@ export const DebugSettings = () => {
   const settings = debugPlugin.provides.settings;
 
   return (
-    <div role='none' className='space-y-2'>
+    <div role='none' className='space-b-2'>
+      <h3 className='text-base font-system-medium'>{t('plugin settings heading')}</h3>
       <div role='none' className='flex items-center gap-2'>
         <Input.Root>
           <Input.Checkbox checked={settings.debug} onCheckedChange={(checked) => (settings.debug = !!checked)} />

--- a/packages/apps/plugins/plugin-debug/src/translations.ts
+++ b/packages/apps/plugins/plugin-debug/src/translations.ts
@@ -16,6 +16,7 @@ export default [
         'debug label': 'Debug',
         'show debug panel': 'Show Debug panel',
         'show devtools panel': 'Show DevTools panel',
+        'plugin settings heading': 'DevTools & Debug',
       },
     },
   },

--- a/packages/apps/plugins/plugin-github/src/components/GithubApiProviders/PatInput.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/GithubApiProviders/PatInput.tsx
@@ -42,8 +42,10 @@ export const PatInput = () => {
 
   return (
     <Input.Root>
-      <div role='none' className='max-is-md text-start'>
-        <Input.Label>{t('github pat label')}</Input.Label>
+      <div role='none' className='text-start'>
+        <Input.Label classNames='text-base font-system-medium' asChild>
+          <h3>{t('github pat label')}</h3>
+        </Input.Label>
         <Input.TextInput
           autoFocus
           spellCheck={false}

--- a/packages/apps/plugins/plugin-layout/src/components/MainLayout.tsx
+++ b/packages/apps/plugins/plugin-layout/src/components/MainLayout.tsx
@@ -142,10 +142,10 @@ export const MainLayout = ({ fullscreen, showComplementarySidebar = true }: Main
             <Dialog.Overlay>
               {/* TODO(burdon): Move (thure)[ProfileSettings dialog in particular] dialog to settings-plugin. */}
               {dialogContent.component === 'dxos.org/plugin/layout/ProfileSettings' ? (
-                <Dialog.Content>
+                <Dialog.Content classNames='max-is-[32rem]'>
                   <Dialog.Title>{t('settings dialog title', { ns: 'os' })}</Dialog.Title>
                   {/* TODO(burdon): Standardize layout of section components (e.g., checkbox padding). */}
-                  <div className='flex flex-col my-2 gap-4'>
+                  <div className='mlb-4 space-b-4'>
                     <Surface role='settings' data={dialogContent} />
                   </div>
                   <Dialog.Close asChild>

--- a/packages/apps/plugins/plugin-markdown/src/components/MarkdownSettings.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/MarkdownSettings.tsx
@@ -32,9 +32,11 @@ export const MarkdownSettings = () => {
 
   // TODO(wittjosiah): Add skill test confirmation for entering vim mode.
   return (
-    <div>
+    <div role='none' className='space-b-2'>
       <Input.Root>
-        <Input.Label>{t('editor mode label')}</Input.Label>
+        <Input.Label classNames='text-base font-system-medium' asChild>
+          <h3>{t('editor mode label')}</h3>
+        </Input.Label>
         <Select.Root value={settings.editorMode} onValueChange={handleValueChange}>
           <Select.TriggerButton classNames='mbs-0.5' placeholder={t('select editor mode placeholder')} />
           <Select.Portal>

--- a/packages/apps/plugins/plugin-registry/src/components/PluginList.tsx
+++ b/packages/apps/plugins/plugin-registry/src/components/PluginList.tsx
@@ -6,15 +6,10 @@ import { Circle } from '@phosphor-icons/react';
 import React from 'react';
 
 import type { Plugin } from '@dxos/app-framework';
-import { DensityProvider, Input, List, ListItem, useTranslation } from '@dxos/react-ui';
-import { getSize, mx } from '@dxos/react-ui-theme';
+import { DensityProvider, Input, List, ListItem, useId, useTranslation } from '@dxos/react-ui';
+import { descriptionText, fineBlockSize, getSize, ghostHover, mx } from '@dxos/react-ui-theme';
 
 import { REGISTRY_PLUGIN } from '../meta';
-
-// TODO(burdon): Factor out.
-const styles = {
-  hover: 'hover:bg-neutral-75 dark:hover:bg-neutral-850',
-};
 
 export type PluginListProps = {
   plugins?: Plugin['meta'][];
@@ -27,38 +22,40 @@ export const PluginList = ({ plugins = [], loaded = [], enabled = [], onChange }
   const { t } = useTranslation(REGISTRY_PLUGIN);
 
   return (
-    <div className={mx('flex flex-col w-full overflow-x-hidden overflow-y-auto')}>
-      <DensityProvider density={'fine'}>
-        <List classNames='divide-y'>
-          {plugins.map(({ id, name, description, iconComponent: Icon = Circle }) => {
-            const isEnabled = enabled.includes(id);
-            const isLoaded = loaded.includes(id);
-            const reloadRequired = isEnabled !== isLoaded;
+    <DensityProvider density='fine'>
+      <List classNames='select-none'>
+        {plugins.map(({ id, name, description, iconComponent: Icon = Circle }) => {
+          const isEnabled = enabled.includes(id);
+          const isLoaded = loaded.includes(id);
+          const reloadRequired = isEnabled !== isLoaded;
+          const inputId = useId('plugin');
+          const labelId = useId('pluginName');
+          const descriptionId = useId('pluginDescription');
 
-            return (
+          return (
+            <Input.Root key={id} id={inputId}>
               <ListItem.Root
-                key={id}
-                classNames={mx('flex is-full cursor-pointer p-1', styles.hover)}
+                labelId={labelId}
+                classNames={['flex gap-2 cursor-pointer plb-1 pli-2 -mli-2 rounded', ghostHover]}
                 onClick={() => onChange?.(id, !isEnabled)}
+                aria-describedby={descriptionId}
               >
-                <ListItem.Endcap classNames={'items-center mr-4'}>
-                  <Icon className={getSize(6)} />
-                </ListItem.Endcap>
-                <div className='flex flex-col grow'>
-                  <ListItem.Heading classNames='flex grow truncate items-center'>{name ?? id}</ListItem.Heading>
-                  {description && <div className='text-sm pb-1 font-thin'>{description}</div>}
-                  {reloadRequired && <div className='text-sm font-bold'>{t('reload required message')}</div>}
+                <Icon weight='duotone' className={mx(getSize(6), 'mbs-1')} />
+                <div role='none' className={mx(fineBlockSize, 'grow pbs-1')}>
+                  <label htmlFor={inputId} id={labelId} className='truncate'>
+                    {name ?? id}
+                  </label>
+                  <div id={descriptionId} className='space-b-1'>
+                    <p className={descriptionText}>{description}</p>
+                    {reloadRequired && <p className='text-sm font-system-medium'>{t('reload required message')}</p>}
+                  </div>
                 </div>
-                <ListItem.Endcap classNames='items-center'>
-                  <Input.Root>
-                    <Input.Checkbox checked={!!isEnabled} />
-                  </Input.Root>
-                </ListItem.Endcap>
+                <Input.Switch classNames='self-center' checked={!!isEnabled} />
               </ListItem.Root>
-            );
-          })}
-        </List>
-      </DensityProvider>
-    </div>
+            </Input.Root>
+          );
+        })}
+      </List>
+    </DensityProvider>
   );
 };

--- a/packages/apps/plugins/plugin-registry/src/components/PluginList.tsx
+++ b/packages/apps/plugins/plugin-registry/src/components/PluginList.tsx
@@ -45,10 +45,12 @@ export const PluginList = ({ plugins = [], loaded = [], enabled = [], onChange }
                   <label htmlFor={inputId} id={labelId} className='truncate'>
                     {name ?? id}
                   </label>
-                  <div id={descriptionId} className='space-b-1'>
-                    <p className={descriptionText}>{description}</p>
-                    {reloadRequired && <p className='text-sm font-system-medium'>{t('reload required message')}</p>}
-                  </div>
+                  {(description || reloadRequired) && (
+                    <div id={descriptionId} className='space-b-1 pbe-1'>
+                      <p className={descriptionText}>{description}</p>
+                      {reloadRequired && <p className='text-sm font-system-medium'>{t('reload required message')}</p>}
+                    </div>
+                  )}
                 </div>
                 <Input.Switch classNames='self-center' checked={!!isEnabled} />
               </ListItem.Root>

--- a/packages/apps/plugins/plugin-registry/src/components/Settings.tsx
+++ b/packages/apps/plugins/plugin-registry/src/components/Settings.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 
 import { usePlugins } from '@dxos/app-framework';
-import { Input, useTranslation } from '@dxos/react-ui';
+import { useTranslation } from '@dxos/react-ui';
 
 import { PluginList } from './PluginList';
 import { REGISTRY_PLUGIN } from '../meta';
@@ -15,14 +15,14 @@ export const Settings = () => {
   const { available, plugins, enabled, enablePlugin, disablePlugin } = usePlugins();
 
   return (
-    <Input.Root>
-      <Input.Label>{t('plugin registry label')}</Input.Label>
+    <div role='none' className='space-b-2'>
+      <h3 className='text-base font-system-medium'>{t('plugin registry label')}</h3>
       <PluginList
         plugins={available}
         loaded={plugins.map(({ meta }) => meta.id)}
         enabled={enabled}
         onChange={(id, enabled) => (enabled ? enablePlugin(id) : disablePlugin(id))}
       />
-    </Input.Root>
+    </div>
   );
 };

--- a/packages/apps/plugins/plugin-stack/src/meta.tsx
+++ b/packages/apps/plugins/plugin-stack/src/meta.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { StackSimple } from '@phosphor-icons/react';
+import { type IconProps, StackSimple } from '@phosphor-icons/react';
 import React from 'react';
 
 export const STACK_PLUGIN = 'dxos.org/plugin/stack';
@@ -11,5 +11,5 @@ export default {
   id: STACK_PLUGIN,
   name: 'Stack',
   description: 'View and arrange objects in stacks',
-  iconComponent: () => <StackSimple />,
+  iconComponent: (props: IconProps) => <StackSimple {...props} />,
 };

--- a/packages/sdk/examples/src/stories/examples.stories.tsx
+++ b/packages/sdk/examples/src/stories/examples.stories.tsx
@@ -61,7 +61,7 @@ const DemoToggles = ({
 
   return (Story, context) => (
     <>
-      <div className='demo-buttons'>
+      <div className='demo-buttons space-b-2'>
         <div className='flex'>
           <Input.Root>
             <Input.Switch classNames='me-2' onCheckedChange={handleToggleNetwork} />

--- a/packages/ui/react-appkit/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/react-appkit/src/components/Dialog/Dialog.tsx
@@ -15,7 +15,7 @@ import {
   type DialogRootProps,
   type DialogTitleProps,
 } from '@dxos/react-ui';
-import { focusRing, hoverColors, getSize, mx } from '@dxos/react-ui-theme';
+import { focusRing, getSize, ghostHover, mx } from '@dxos/react-ui-theme';
 
 import { TooltipRoot, TooltipContent, TooltipTrigger } from '../Tooltip';
 
@@ -90,7 +90,7 @@ export const Dialog = ({
                 className={mx(
                   'absolute top-3.5 right-3.5 inline-flex items-center justify-center rounded-sm p-1',
                   focusRing,
-                  hoverColors,
+                  ghostHover,
                   slots.close?.className,
                 )}
               >

--- a/packages/ui/react-appkit/src/components/NavMenu/NavMenu.tsx
+++ b/packages/ui/react-appkit/src/components/NavMenu/NavMenu.tsx
@@ -8,12 +8,12 @@ import React, { type ComponentProps, type ForwardedRef, forwardRef, type ReactNo
 import { Tooltip, type TooltipContentProps } from '@dxos/react-ui';
 import {
   focusRing,
-  hoverColors,
   inlineSeparator,
   mx,
   defaultAppButtonColors,
   primaryAppButtonColors,
   surfaceElevation,
+  ghostHover,
 } from '@dxos/react-ui-theme';
 
 interface NavMenuItemSharedProps {
@@ -69,7 +69,7 @@ const NavMenuInvokerItem = forwardRef(
             'px-3 py-2 text-sm rounded-md text-sm font-medium transition-color',
             active ? primaryAppButtonColors : defaultAppButtonColors,
             focusRing,
-            hoverColors,
+            ghostHover,
           )}
         >
           {children}
@@ -101,7 +101,7 @@ const NavMenuLinkItem = forwardRef(
           active ? primaryAppButtonColors : defaultAppButtonColors,
           active ? 'font-medium' : 'font-normal',
           focusRing,
-          hoverColors,
+          ghostHover,
           triggerLinkProps.className,
         )}
       >
@@ -126,7 +126,7 @@ const NavMenuTooltipLinkItem = forwardRef(
               active ? primaryAppButtonColors : defaultAppButtonColors,
               active ? 'font-medium' : 'font-normal',
               focusRing,
-              hoverColors,
+              ghostHover,
               triggerLinkProps.className,
             )}
           >

--- a/packages/ui/react-appkit/src/components/Popover/Popover.tsx
+++ b/packages/ui/react-appkit/src/components/Popover/Popover.tsx
@@ -7,7 +7,7 @@ import * as PopoverPrimitive from '@radix-ui/react-popover';
 import { Button as ToolbarButtonItem } from '@radix-ui/react-toolbar';
 import React, { type ComponentProps, type ReactNode, useCallback, useState } from 'react';
 
-import { openOutline, focusRing, hoverColors, getSize, mx } from '@dxos/react-ui-theme';
+import { openOutline, focusRing, getSize, mx, ghostHover } from '@dxos/react-ui-theme';
 
 export interface PopoverSlots {
   content?: Omit<ComponentProps<typeof PopoverPrimitive.Content>, 'children'>;
@@ -70,7 +70,7 @@ export const Popover = ({
           className={mx(
             'absolute top-3.5 right-3.5 inline-flex items-center justify-center rounded-sm p-1',
             focusRing,
-            hoverColors,
+            ghostHover,
             slots.close?.className,
           )}
           aria-label={closeLabel}
@@ -94,7 +94,7 @@ export const Popover = ({
       {...slots.trigger}
       onKeyUp={onKeyUp}
       data-keyupid='open'
-      className={mx(hoverColors, focusRing, openOutline, slots.trigger?.className)}
+      className={mx(ghostHover, focusRing, openOutline, slots.trigger?.className)}
     >
       {openTrigger}
     </PopoverPrimitive.Trigger>

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
@@ -16,6 +16,7 @@ import {
   hoverableFocusedKeyboardControls,
   hoverableFocusedWithinControls,
   mx,
+  subtleHover,
 } from '@dxos/react-ui-theme';
 
 import { useNavTree } from './NavTreeContext';
@@ -149,7 +150,7 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
                 level < 1 && topLevelCollapsibleSpacing,
                 (active && active !== 'overlay') || path === current
                   ? 'bg-neutral-75 dark:bg-neutral-850'
-                  : 'hover:bg-neutral-450/5 dark:hover:bg-25/5',
+                  : subtleHover,
               )}
             >
               <NavTreeItemHeading

--- a/packages/ui/react-ui-theme/src/styles/components/button.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/button.ts
@@ -13,6 +13,7 @@ import {
   staticDisabled,
   focusRing,
   contentElevation,
+  ghostHover,
 } from '../fragments';
 
 // TODO(burdon): Ghost styles should have no border (be really flat).
@@ -23,7 +24,8 @@ export const defaultAppButtonColors =
   'bg-white aria-pressed:bg-primary-100 aria-checked:bg-primary-100 text-neutral-800 aria-pressed:text-primary-800 aria-checked:text-primary-800 dark:bg-neutral-800 dark:aria-pressed:bg-primary-700 dark:aria-checked:bg-primary-700 dark:text-neutral-50 dark:aria-pressed:text-primary-50 dark:aria-checked:text-primary-50';
 export const defaultOsButtonColors = 'bg-white/50 text-neutral-900 dark:bg-neutral-750/50 dark:text-neutral-50';
 export const ghostButtonColors =
-  'hover:bg-neutral-450/10 dark:hover:bg-25/10 hover:text-inherit dark:hover:text-inherit aria-pressed:text-primary-800 aria-checked:text-primary-800 dark:aria-pressed:text-primary-100 dark:aria-checked:text-primary-100';
+  ghostHover +
+  'hover:text-inherit dark:hover:text-inherit aria-pressed:text-primary-800 aria-checked:text-primary-800 dark:aria-pressed:text-primary-100 dark:aria-checked:text-primary-100';
 
 export type ButtonStyleProps = Partial<{
   inGroup?: boolean;

--- a/packages/ui/react-ui-theme/src/styles/components/button.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/button.ts
@@ -25,7 +25,7 @@ export const defaultAppButtonColors =
 export const defaultOsButtonColors = 'bg-white/50 text-neutral-900 dark:bg-neutral-750/50 dark:text-neutral-50';
 export const ghostButtonColors =
   ghostHover +
-  'hover:text-inherit dark:hover:text-inherit aria-pressed:text-primary-800 aria-checked:text-primary-800 dark:aria-pressed:text-primary-100 dark:aria-checked:text-primary-100';
+  ' hover:text-inherit dark:hover:text-inherit aria-pressed:text-primary-800 aria-checked:text-primary-800 dark:aria-pressed:text-primary-100 dark:aria-checked:text-primary-100';
 
 export type ButtonStyleProps = Partial<{
   inGroup?: boolean;

--- a/packages/ui/react-ui-theme/src/styles/components/input.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/input.ts
@@ -29,6 +29,8 @@ import {
   getSize,
   computeSize,
   sizeValue,
+  getSizeHeight,
+  getSizeWidth,
 } from '../fragments';
 
 export type InputStyleProps = Partial<{
@@ -119,6 +121,21 @@ export const inputCheckbox: ComponentFunction<InputStyleProps> = ({ size = 5 }, 
 export const inputCheckboxIndicator: ComponentFunction<InputStyleProps> = ({ size = 5 }, ...etc) =>
   mx(getSize(computeSize(sizeValue(size) * 0.7, 4)), ...etc);
 
+export const inputSwitch: ComponentFunction<InputStyleProps> = ({ size = 5 }, ...etc) =>
+  mx(
+    getSizeHeight(size),
+    getSizeWidth(computeSize(sizeValue(size) * 1.75, 9)),
+    'cursor-pointer shrink-0 bg-transparent rounded-full pli-0.5 border-2 border-neutral-500 relative data-[state=checked]:border-primary-500 data-[state=checked]:bg-primary-500 outline-none cursor-default',
+    ...etc,
+  );
+
+export const inputSwitchThumb: ComponentFunction<InputStyleProps> = ({ size = 5 }, ...etc) =>
+  mx(
+    getSize(size === 'px' ? 'px' : ((size - 2) as Size)),
+    'block bg-neutral-500 rounded-full border-neutral-100 transition-transform duration-100 will-change-transform data-[state=checked]:translate-x-[100%] data-[state=checked]:bg-white',
+    ...etc,
+  );
+
 export const inputWithSegmentsInput: ComponentFunction<InputStyleProps> = (props, ...etc) =>
   mx('font-mono selection:bg-transparent mli-auto', props.disabled && 'cursor-not-allowed', ...etc);
 
@@ -142,5 +159,7 @@ export const inputTheme = {
   label: inputLabel,
   description: inputDescription,
   validation: inputValidation,
+  switch: inputSwitch,
+  switchThumb: inputSwitchThumb,
   descriptionAndValidation: inputDescriptionAndValidation,
 };

--- a/packages/ui/react-ui-theme/src/styles/fragments/hover.ts
+++ b/packages/ui/react-ui-theme/src/styles/fragments/hover.ts
@@ -8,6 +8,9 @@
 export const hoverColors =
   'transition-colors duration-100 linear hover:text-black dark:hover:text-white hover:bg-neutral-25 dark:hover:bg-neutral-750';
 
+export const ghostHover = 'hover:bg-neutral-450/10 dark:hover:bg-25/10';
+export const subtleHover = 'hover:bg-neutral-450/5 dark:hover:bg-25/5';
+
 export const hoverableControls =
   '[--controls-opacity:1] hover-hover:[--controls-opacity:0] hover-hover:hover:[--controls-opacity:1]';
 

--- a/packages/ui/react-ui/src/components/Input/Input.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.tsx
@@ -302,19 +302,21 @@ const Switch: ForwardRefExoticComponent<SwitchProps> = forwardRef<HTMLButtonElem
       checked: propsChecked,
       defaultChecked: propsDefaultChecked,
       onCheckedChange: propsOnCheckedChange,
-      size,
+      size = 5,
       classNames,
       ...props
     },
     forwardedRef,
   ) => {
+    const { tx } = useThemeContext();
+
     const [checked, onCheckedChange] = useControllableState({
       prop: propsChecked,
       defaultProp: propsDefaultChecked,
       onChange: propsOnCheckedChange,
     });
+
     const { id, validationValence, descriptionId, errorMessageId } = useInputContext(INPUT_NAME, __inputScope);
-    // const { tx } = useThemeContext();
     return (
       <SwitchPrimitive
         {...{
@@ -327,15 +329,13 @@ const Switch: ForwardRefExoticComponent<SwitchProps> = forwardRef<HTMLButtonElem
             'aria-invalid': 'true' as const,
             'aria-errormessage': errorMessageId,
           }),
-          // className: tx('input.checkbox', 'input--checkbox', { size }, 'shrink-0', classNames),
-          className:
-            'w-[56px] h-[32px] bg-transparent rounded-full px-[4px] border-2 border-neutral-500 relative data-[state=checked]:border-primary-500 data-[state=checked]:bg-primary-500 outline-none cursor-default',
+          className: tx('input.switch', 'input--switch', { size }, classNames),
         }}
         ref={forwardedRef}
       >
         {/* TODO(wittjosiah): Embed icons/text for on/off states.
              e.g., https://codepen.io/alvarotrigo/pen/oNoJePo (#13) */}
-        <SwitchThumbPrimitive className='block w-[22px] h-[22px] bg-neutral-500 rounded-full border-neutral-100 transition-transform duration-100 will-change-transform data-[state=checked]:translate-x-[22px] data-[state=checked]:bg-white'></SwitchThumbPrimitive>
+        <SwitchThumbPrimitive className={tx('input.switchThumb', 'input--switch__thumb', { size })} />
       </SwitchPrimitive>
     );
   },


### PR DESCRIPTION
This PR:
- fixes Switch input styles, makes size configurable
- improves a11y and markup in the app settings dialog
- polishes the styles for the new `PluginList`

<img width="528" alt="Screenshot 2023-11-09 at 13 13 37" src="https://github.com/dxos/dxos/assets/855039/658690dc-1483-45c3-831b-b7ccf6868ef0">

---

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 974cbd9</samp>

### Summary

This pull request improves the UI design, accessibility, and consistency of various components in the dxos apps and UI packages. It introduces a new `ghostHover` fragment for hover effects, a new input switch component, and unique IDs for input elements. It also updates some components to use headings instead of labels, and adjusts the layout and spacing of some dialogs.



### Walkthrough
*  Add and use ghostHover and subtleHover fragments to style the hover state of UI elements with a subtle or ghost effect ([link](https://github.com/dxos/dxos/pull/4673/files?diff=unified&w=0#diff-200b7b6f42faef2a2e5d5ffd23853e2802e7462dce661e7c1058a882995c2cccL18-R18), [link](https://github.com/dxos/dxos/pull/4673/files?diff=unified&w=0#diff-200b7b6f42faef2a2e5d5ffd23853e2802e7462dce661e7c1058a882995c2cccL93-R93), [link](https://github.com/dxos/dxos/pull/4673/files?diff=unified&w=0#diff-8da8701448a3e863576fb923b243bf1af9e2e810fbf5242eb2ff38ee771f04f9R16), [link](https://github.com/dxos/dxos/pull/4673/files?diff=unified&w=0#diff-8da8701448a3e863576fb923b243bf1af9e2e810fbf5242eb2ff38ee771f04f9L72-R72), [link](https://github.com/dxos/dxos/pull/4673/files?diff=unified&w=0#diff-8da8701448a3e863576fb923b243bf1af9e2e810fbf5242eb2ff38ee771f04f9L104-R104), [link](https://github.com/dxos/dxos/pull/4673/files?diff=unified&w=0#diff-8da8701448a3e863576fb923b243bf1af9e2e810fbf5242eb2ff38ee771f04f9L129-R129), [link](https://github.com/dxos/dxos/pull/4673/files?diff=unified&w=0#diff-3c085ee4fd301647d0242a170f074667a6267568dfa500d4ac83ce599ebbd436L10-R10), [link](https://github.com/dxos/dxos/pull/4673/files?diff=unified&w=0#diff-3c085ee4fd301647d0242a170f074667a6267568dfa500d4ac83ce599ebbd436L73-R73), [link](https://github.com/dxos/dxos/pull/4673/files?diff=unified&w=0#diff-3c085ee4fd301647d0242a170f074667a6267568dfa500d4ac83ce599ebbd436L97-R97), [link](https://github.com/dxos/dxos/pull/4673/files?diff=unified&w=0#diff-783c4b0b530888d53202c557c83f22a45064463343fc1ca87b6b0047921221a0R16), [link](https://github.com/dxos/dxos/pull/4673/files?diff=unified&w=0#diff-783c4b0b530888d53202c557c83f22a45064463343fc1ca87b6b0047921221a0L26-R28), [link](https://github.com/dxos/dxos/pull/4673/files?diff=unified&w=0#diff-44219be5087e379e8bc75d4a688caeb0cc630ba7e5c20094aa305f420a637bb8R11-R13)).

