### PR TITLE
feat: Plugin registry style fix.

### DIFF
--- a/packages/apps/plugins/plugin-chess/src/meta.tsx
+++ b/packages/apps/plugins/plugin-chess/src/meta.tsx
@@ -12,6 +12,5 @@ export const CHESS_PLUGIN = 'dxos.org/plugin/chess';
 export default pluginMeta({
   id: CHESS_PLUGIN,
   name: 'Chess',
-  description: 'Play games of chess',
   iconComponent: (props) => <ShieldChevron {...props} />,
 });

--- a/packages/apps/plugins/plugin-debug/src/translations.ts
+++ b/packages/apps/plugins/plugin-debug/src/translations.ts
@@ -16,7 +16,7 @@ export default [
         'debug label': 'Debug',
         'show debug panel': 'Show Debug panel',
         'show devtools panel': 'Show DevTools panel',
-        'plugin settings heading': 'DevTools & Debug',
+        'plugin settings heading': 'Debug & DevTools',
       },
     },
   },

--- a/packages/apps/plugins/plugin-files/src/meta.tsx
+++ b/packages/apps/plugins/plugin-files/src/meta.tsx
@@ -14,6 +14,6 @@ export default pluginMeta({
   id: FILES_PLUGIN,
   shortId: FILES_PLUGIN_SHORT_ID,
   name: 'Files',
-  description: 'Open files from the local file system',
+  description: 'Open files from the local file system.',
   iconComponent: (props) => <File {...props} />,
 });

--- a/packages/apps/plugins/plugin-grid/src/meta.tsx
+++ b/packages/apps/plugins/plugin-grid/src/meta.tsx
@@ -11,6 +11,6 @@ export const GRID_PLUGIN = 'dxos.org/plugin/grid';
 
 export default pluginMeta({
   id: GRID_PLUGIN,
-  name: 'Grid',
+  name: 'Grids',
   iconComponent: (props) => <SquaresFour {...props} />,
 });

--- a/packages/apps/plugins/plugin-grid/src/translations.ts
+++ b/packages/apps/plugins/plugin-grid/src/translations.ts
@@ -8,7 +8,7 @@ export default [
   {
     'en-US': {
       [GRID_PLUGIN]: {
-        'plugin name': 'Grid',
+        'plugin name': 'Grids',
         'grid title placeholder': 'New grid',
         'create grid label': 'Create grid',
         'title placeholder': 'Enter title...',

--- a/packages/apps/plugins/plugin-ipfs/src/translations.ts
+++ b/packages/apps/plugins/plugin-ipfs/src/translations.ts
@@ -8,7 +8,7 @@ export default [
   {
     'en-US': {
       [IPFS_PLUGIN]: {
-        'plugin name': 'File',
+        'plugin name': 'Files',
         'object title placeholder': 'New file',
         'delete object label': 'Delete',
       },

--- a/packages/apps/plugins/plugin-map/src/meta.tsx
+++ b/packages/apps/plugins/plugin-map/src/meta.tsx
@@ -11,6 +11,6 @@ export const MAP_PLUGIN = 'dxos.org/plugin/map';
 
 export default pluginMeta({
   id: MAP_PLUGIN,
-  name: 'Map',
+  name: 'Maps',
   iconComponent: (props) => <Compass {...props} />,
 });

--- a/packages/apps/plugins/plugin-map/src/translations.ts
+++ b/packages/apps/plugins/plugin-map/src/translations.ts
@@ -8,7 +8,7 @@ export default [
   {
     'en-US': {
       [MAP_PLUGIN]: {
-        'plugin name': 'Map',
+        'plugin name': 'Maps',
         'object title placeholder': 'New map',
         'create object label': 'Create map',
         'delete object label': 'Delete',

--- a/packages/apps/plugins/plugin-markdown/src/meta.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/meta.tsx
@@ -12,6 +12,6 @@ export const MARKDOWN_PLUGIN = 'dxos.org/plugin/markdown';
 export default pluginMeta({
   id: MARKDOWN_PLUGIN,
   name: 'Markdown',
-  description: 'Edit text in Markdown format',
+  description: 'Markdown text editor.',
   iconComponent: (props) => <ArticleMedium {...props} />,
 });

--- a/packages/apps/plugins/plugin-registry/src/components/PluginList.tsx
+++ b/packages/apps/plugins/plugin-registry/src/components/PluginList.tsx
@@ -41,7 +41,7 @@ export const PluginList = ({ plugins = [], loaded = [], enabled = [], onChange }
                 aria-describedby={descriptionId}
               >
                 <Icon weight='duotone' className={mx(getSize(6), 'mbs-1')} />
-                <div role='none' className={mx(fineBlockSize, 'grow pbs-1')}>
+                <div role='none' className={mx(fineBlockSize, 'grow pbs-1 pl-1')}>
                   <label htmlFor={inputId} id={labelId} className='truncate'>
                     {name ?? id}
                   </label>
@@ -52,7 +52,9 @@ export const PluginList = ({ plugins = [], loaded = [], enabled = [], onChange }
                     </div>
                   )}
                 </div>
-                <Input.Switch classNames='self-center' checked={!!isEnabled} />
+                <div className='pbs-1'>
+                  <Input.Switch classNames='self-center' checked={!!isEnabled} />
+                </div>
               </ListItem.Root>
             </Input.Root>
           );

--- a/packages/apps/plugins/plugin-registry/src/components/Settings.tsx
+++ b/packages/apps/plugins/plugin-registry/src/components/Settings.tsx
@@ -13,16 +13,19 @@ import { REGISTRY_PLUGIN } from '../meta';
 export const Settings = () => {
   const { t } = useTranslation(REGISTRY_PLUGIN);
   const { available, plugins, enabled, enablePlugin, disablePlugin } = usePlugins();
+  const sortedPlugins = available.sort((a, b) => a.name?.localeCompare(b.name ?? '') ?? 0);
 
   return (
     <div role='none' className='space-b-2'>
       <h3 className='text-base font-system-medium'>{t('plugin registry label')}</h3>
-      <PluginList
-        plugins={available}
-        loaded={plugins.map(({ meta }) => meta.id)}
-        enabled={enabled}
-        onChange={(id, enabled) => (enabled ? enablePlugin(id) : disablePlugin(id))}
-      />
+      <div>
+        <PluginList
+          plugins={sortedPlugins}
+          loaded={plugins.map(({ meta }) => meta.id)}
+          enabled={enabled}
+          onChange={(id, enabled) => (enabled ? enablePlugin(id) : disablePlugin(id))}
+        />
+      </div>
     </div>
   );
 };

--- a/packages/apps/plugins/plugin-script/src/meta.tsx
+++ b/packages/apps/plugins/plugin-script/src/meta.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { FileJs } from '@phosphor-icons/react';
+import { Code } from '@phosphor-icons/react';
 import React from 'react';
 
 import { pluginMeta } from '@dxos/app-framework';
@@ -12,5 +12,5 @@ export const SCRIPT_PLUGIN = 'dxos.org/plugin/script';
 export default pluginMeta({
   id: SCRIPT_PLUGIN,
   name: 'Scripts',
-  iconComponent: (props) => <FileJs {...props} />,
+  iconComponent: (props) => <Code {...props} />,
 });

--- a/packages/apps/plugins/plugin-script/src/translations.ts
+++ b/packages/apps/plugins/plugin-script/src/translations.ts
@@ -8,7 +8,7 @@ export default [
   {
     'en-US': {
       [SCRIPT_PLUGIN]: {
-        'plugin name': 'Script',
+        'plugin name': 'Scripts',
         'object title placeholder': 'New script',
         'create object label': 'Create script',
         'create stack section label': 'Create script',

--- a/packages/apps/plugins/plugin-stack/src/meta.tsx
+++ b/packages/apps/plugins/plugin-stack/src/meta.tsx
@@ -9,7 +9,7 @@ export const STACK_PLUGIN = 'dxos.org/plugin/stack';
 
 export default {
   id: STACK_PLUGIN,
-  name: 'Stack',
-  description: 'View and arrange objects in stacks',
+  name: 'Stacks',
+  description: 'View and arrange objects in stacks.',
   iconComponent: (props: IconProps) => <StackSimple {...props} />,
 };

--- a/packages/apps/plugins/plugin-table/src/meta.tsx
+++ b/packages/apps/plugins/plugin-table/src/meta.tsx
@@ -11,6 +11,6 @@ export const TABLE_PLUGIN = 'dxos.org/plugin/table';
 
 export default pluginMeta({
   id: TABLE_PLUGIN,
-  name: 'Table',
+  name: 'Tables',
   iconComponent: (props) => <Table {...props} />,
 });

--- a/packages/apps/plugins/plugin-table/src/translations.ts
+++ b/packages/apps/plugins/plugin-table/src/translations.ts
@@ -8,7 +8,7 @@ export default [
   {
     'en-US': {
       [TABLE_PLUGIN]: {
-        'plugin name': 'Table',
+        'plugin name': 'Tables',
         'object placeholder': 'New table',
         'create object label': 'Create table',
       },

--- a/packages/apps/plugins/plugin-thread/src/meta.tsx
+++ b/packages/apps/plugins/plugin-thread/src/meta.tsx
@@ -11,6 +11,6 @@ export const THREAD_PLUGIN = 'dxos.org/plugin/thread';
 
 export default pluginMeta({
   id: THREAD_PLUGIN,
-  name: 'Thread',
+  name: 'Threads',
   iconComponent: (props) => <Chat {...props} />,
 });

--- a/packages/apps/plugins/plugin-thread/src/translations.ts
+++ b/packages/apps/plugins/plugin-thread/src/translations.ts
@@ -8,7 +8,7 @@ export default [
   {
     'en-US': {
       [THREAD_PLUGIN]: {
-        'plugin name': 'Thread',
+        'plugin name': 'Threads',
         'thread title placeholder': 'New thread',
         'thread title label': 'Title',
         'column title label': 'Column title',

--- a/packages/devtools/devtools/src/panels/agent/DashboardPanel/DashboardPanel.tsx
+++ b/packages/devtools/devtools/src/panels/agent/DashboardPanel/DashboardPanel.tsx
@@ -83,10 +83,11 @@ export const DashboardPanel = () => {
       <div className='flex-1 flex-col w-50%'>
         <AgentStat status={agentState} />
       </div>
+
       {agentState.plugins ? (
         <PluginList plugins={agentState.plugins} togglePlugin={togglePlugin} />
       ) : (
-        <div>No plugins are running in agent</div>
+        <div>No plugins are running on the agent.</div>
       )}
     </PanelContainer>
   );

--- a/packages/sdk/app-framework/src/plugins/PluginHost/PluginHost.tsx
+++ b/packages/sdk/app-framework/src/plugins/PluginHost/PluginHost.tsx
@@ -56,6 +56,7 @@ export const PluginHost = ({
   return {
     meta: {
       id: PLUGIN_HOST,
+      name: 'Plugin host',
     },
     provides: {
       plugins: state.values,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 582cedd</samp>

### Summary
📝🔤🎨

<!--
1.  📝 - This emoji represents the changes to the plugin descriptions, names, and meta objects, which are mostly text edits.
2.  🔤 - This emoji represents the changes to the plugin settings heading and the sorting of the plugin list by name, which are both related to alphabetical order.
3.  🎨 - This emoji represents the changes to the plugin icons, layout, and alignment, which are all related to the visual appearance of the plugin list.
-->
This pull request updates the names, descriptions, icons, and layouts of various plugins and components in the `dxos` app framework. The changes aim to improve the consistency, clarity, and user experience of the plugins and their settings.

> _We are the plugins of the night_
> _We change our names and descriptions to fight_
> _We sort and align to make it right_
> _We are the plugins of the night_

### Walkthrough
*  Pluralize and standardize the names and descriptions of several plugins ([link](https://github.com/dxos/dxos/pull/4674/files?diff=unified&w=0#diff-8ce2db11a6474a081c85d86b93dca2aa28a1e21133901b021b98a6670c765156L14-R14), [link](https://github.com/dxos/dxos/pull/4674/files?diff=unified&w=0#diff-cdcf852dc6e46d42f3825fd1686179aa942883759b952329d975edf4fec74b22L11-R11), [link](https://github.com/dxos/dxos/pull/4674/files?diff=unified&w=0#diff-31c914d0c7d1803a3846bef1ee39780a5e3b960b4a4774b6b2df7a342d3b6c06L11-R11), [link](https://github.com/dxos/dxos/pull/4674/files?diff=unified&w=0#diff-25c939718ac3c7e7371871a316c766eba2c16c50d923c84b738895c799e5cf7aL14-R14), [link](https://github.com/dxos/dxos/pull/4674/files?diff=unified&w=0#diff-23959acafb1ddfecfb4a20c5f4701af7ac0e3eb92fb69ef773407a7ecdfbf5a5L11-R11), [link](https://github.com/dxos/dxos/pull/4674/files?diff=unified&w=0#diff-e3595f50654d2b4079cd0aa56488c1d43a769a15720dcbb2a040f5be3c93fd9aL11-R11), [link](https://github.com/dxos/dxos/pull/4674/files?diff=unified&w=0#diff-06dbab2771d4afb28a01c81f7c0451adf78dbd6d209f709ee7624b9d89c758a7L14-R14), [link](https://github.com/dxos/dxos/pull/4674/files?diff=unified&w=0#diff-df9e8a212077f9543043770f0a6a270bfc3e26af55bf2c5d8e77a0da5be4dac0L11-R11), [link](https://github.com/dxos/dxos/pull/4674/files?diff=unified&w=0#diff-261f93aba9b0391caa3544e4ffa8c975a914f8ccf6b87507b53870b6e1687899L14-R14), [link](https://github.com/dxos/dxos/pull/4674/files?diff=unified&w=0#diff-2ec1a12fabab922339359afeb25c77684377f449e4e010a77ec1342134687b16L11-R11)).


