### PR TITLE
fix(halo-app): ensure plugins are enabled

### DIFF
--- a/packages/sdk/app-framework/src/App.tsx
+++ b/packages/sdk/app-framework/src/App.tsx
@@ -36,7 +36,7 @@ import SurfaceMeta from './plugins/SurfacePlugin/meta';
  * @param params.default Default plugins are enabled by default but can be disabled by the user.
  * @param params.fallback Fallback component to render while plugins are initializing.
  */
-export const createApp = ({ order, plugins, core = [], ...params }: BootstrapPluginsParams) => {
+export const createApp = ({ order, plugins, core = order.map(({ id }) => id), ...params }: BootstrapPluginsParams) => {
   const host = PluginHost({
     order: [SurfaceMeta, IntentMeta, ...order],
     plugins: {

--- a/packages/sdk/app-framework/src/plugins/PluginHost/PluginHost.tsx
+++ b/packages/sdk/app-framework/src/plugins/PluginHost/PluginHost.tsx
@@ -34,7 +34,7 @@ const PLUGIN_HOST = 'dxos.org/plugin/host';
 export const PluginHost = ({
   order,
   plugins: definitions,
-  core = order.map(({ id }) => id),
+  core = [],
   defaults = [],
   fallback = null,
 }: BootstrapPluginsParams): PluginDefinition<PluginHostProvides> => {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 92fe817</samp>

### Summary
🔄🚚🎛️

<!--
1.  🔄 - This emoji represents the change of moving the default value of the `core` parameter from one component to another, which is a kind of refactoring or reorganization of the code.
2.  🚚 - This emoji represents the removal of the default value of the `core` parameter from the `PluginHost` component, which is a kind of deletion or simplification of the code.
3.  🎛️ - This emoji represents the change of making the `createApp` function more flexible and consistent with the `BootstrapPluginsParams` type, which is a kind of improvement or enhancement of the code.
-->
Refactor the `createApp` and `PluginHost` components to handle core plugins more efficiently. This change simplifies the `PluginHost` component and makes the `createApp` function more flexible and consistent with the `BootstrapPluginsParams` type.

> _`createApp` sets `core`_
> _based on `order` of plugins_
> _autumn leaves falling_

### Walkthrough
* Move the default value of the `core` parameter from the `PluginHost` component to the `createApp` function ([link](https://github.com/dxos/dxos/pull/4682/files?diff=unified&w=0#diff-ae299ff540b1636712c3a59cd8936afc2c44aaef1a1ee2718458680771ffbb8cL39-R39), [link](https://github.com/dxos/dxos/pull/4682/files?diff=unified&w=0#diff-d140d46ac4b3f2a2934b5642cefc5a1da66c57d41700751f4b2b1c5d74ad58d1L37-R37))


