### PR TITLE
fix(plugin-space): make awaiting object toast less aggressive

### DIFF
--- a/packages/apps/plugins/plugin-space/src/components/AwaitingObject.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/AwaitingObject.tsx
@@ -5,7 +5,7 @@
 import { CheckCircle, CircleDashed, CircleNotch } from '@phosphor-icons/react';
 import React, { useEffect, useMemo, useState, useSyncExternalStore } from 'react';
 
-import { LayoutAction, parseIntentPlugin, useResolvePlugin } from '@dxos/app-framework';
+import { LayoutAction, parseIntentPlugin, useResolvePlugin, parseLayoutPlugin } from '@dxos/app-framework';
 import { useClient } from '@dxos/react-client';
 import { Button, Toast, useTranslation } from '@dxos/react-ui';
 import { getSize, mx } from '@dxos/react-ui-theme';
@@ -17,10 +17,12 @@ const WAIT_FOR_OBJECT_TIMEOUT = 180e3; // 3 minutes
 const TOAST_TIMEOUT = 240e3; // 4 minutes
 
 export const AwaitingObject = ({ id }: { id: string }) => {
+  const [open, setOpen] = useState(true);
   const [waiting, setWaiting] = useState(true);
   const [found, setFound] = useState(false);
   const { t } = useTranslation(SPACE_PLUGIN);
   const intentPlugin = useResolvePlugin(parseIntentPlugin);
+  const layoutPlugin = useResolvePlugin(parseLayoutPlugin);
 
   const client = useClient();
   const query = useMemo(() => client.spaces.query(), []);
@@ -44,6 +46,10 @@ export const AwaitingObject = ({ id }: { id: string }) => {
   useEffect(() => {
     if (objects.findIndex((object) => object.id === id) > -1) {
       setFound(true);
+
+      if (layoutPlugin?.provides.layout.active === id) {
+        setOpen(false);
+      }
     }
   }, [id, objects, intentPlugin]);
 
@@ -63,7 +69,7 @@ export const AwaitingObject = ({ id }: { id: string }) => {
   };
 
   return (
-    <Toast.Root defaultOpen duration={TOAST_TIMEOUT}>
+    <Toast.Root open={open} duration={TOAST_TIMEOUT} onOpenChange={setOpen}>
       <Toast.Body>
         <Toast.Title classNames='flex items-center gap-2'>
           {found ? (

--- a/packages/apps/plugins/plugin-space/src/components/MissingObject.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/MissingObject.tsx
@@ -11,6 +11,8 @@ import { baseSurface, descriptionText, mx } from '@dxos/react-ui-theme';
 import { SPACE_PLUGIN } from '../meta';
 import { SpaceAction } from '../types';
 
+const WAIT_FOR_OBJECT_TIMEOUT = 1_000;
+
 export const MissingObject = ({ id }: { id: string }) => {
   const { t } = useTranslation(SPACE_PLUGIN);
   const intentPlugin = useResolvePlugin(parseIntentPlugin);
@@ -20,11 +22,17 @@ export const MissingObject = ({ id }: { id: string }) => {
       return;
     }
 
-    void intentPlugin.provides.intent.dispatch({
-      plugin: SPACE_PLUGIN,
-      action: SpaceAction.WAIT_FOR_OBJECT,
-      data: { id },
-    });
+    const timeout = setTimeout(
+      () =>
+        intentPlugin.provides.intent.dispatch({
+          plugin: SPACE_PLUGIN,
+          action: SpaceAction.WAIT_FOR_OBJECT,
+          data: { id },
+        }),
+      WAIT_FOR_OBJECT_TIMEOUT,
+    );
+
+    return () => clearTimeout(timeout);
   }, [intentPlugin, id]);
 
   return (


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ff0bc5f</samp>

### Summary
🚫🚀⏲️

<!--
1.  🚫 - This emoji can be used to represent the hiding of the toast notification, as it implies something is being blocked or removed from view.
2.  🚀 - This emoji can be used to represent the performance and reliability improvement, as it implies something is faster or more efficient.
3.  ⏲️ - This emoji can be used to represent the timeout for the action, as it implies something is time-sensitive or has a limit.
-->
Improved the user experience and stability of the `plugin-space` app by handling toast notifications and network requests for missing data. Fixed a bug where the toast notification would persist even after the awaited object was shown in the `AwaitingObject` component. Added a timeout for the `WAIT_FOR_OBJECT` action in the `MissingObject` component to avoid waiting indefinitely for data that may not be available.

> _Oh we are the coders of the sea, we write the logic and the UI_
> _We hide the toast and wait for data, we make the app run smooth and faster_
> _Heave away, heave away, on the count of three_
> _Heave away, heave away, with the `parseLayoutPlugin` we agree_

### Walkthrough
* Import `parseLayoutPlugin` function to resolve layout plugin for awaited object ([link](https://github.com/dxos/dxos/pull/4683/files?diff=unified&w=0#diff-c6495e3d5fccf6f162af94b705bccf3c2b9e5dcdbb95303c5cd44cf82c62ce83L8-R8))
* Add `open` state and `layoutPlugin` variable to `AwaitingObject` component ([link](https://github.com/dxos/dxos/pull/4683/files?diff=unified&w=0#diff-c6495e3d5fccf6f162af94b705bccf3c2b9e5dcdbb95303c5cd44cf82c62ce83L20-R25))
* Hide toast when layout plugin's active layout matches awaited object id ([link](https://github.com/dxos/dxos/pull/4683/files?diff=unified&w=0#diff-c6495e3d5fccf6f162af94b705bccf3c2b9e5dcdbb95303c5cd44cf82c62ce83R49-R52))
* Pass `open` state as prop to `Toast.Root` component to override default behavior ([link](https://github.com/dxos/dxos/pull/4683/files?diff=unified&w=0#diff-c6495e3d5fccf6f162af94b705bccf3c2b9e5dcdbb95303c5cd44cf82c62ce83L66-R72))
* Add `WAIT_FOR_OBJECT_TIMEOUT` constant to `MissingObject` component to define delay before dispatching action ([link](https://github.com/dxos/dxos/pull/4683/files?diff=unified&w=0#diff-28ee9b98ed2d6b149085d4f71d0adf3fea1a1c6a331c7b8ac9b8c8264309fc49R14-R15))
* Wrap `WAIT_FOR_OBJECT` action dispatch in `setTimeout` and clear timeout on unmount ([link](https://github.com/dxos/dxos/pull/4683/files?diff=unified&w=0#diff-28ee9b98ed2d6b149085d4f71d0adf3fea1a1c6a331c7b8ac9b8c8264309fc49L23-R35))


