### PR TITLE
refactor: factor out mosaic data item transformations

### DIFF
--- a/packages/apps/plugins/plugin-graph/src/GraphPlugin.tsx
+++ b/packages/apps/plugins/plugin-graph/src/GraphPlugin.tsx
@@ -4,12 +4,7 @@
 
 import React from 'react';
 
-import {
-  filterPlugins,
-  type GraphPluginProvides,
-  type PluginDefinition,
-  parseGraphBuilderPlugin,
-} from '@dxos/app-framework';
+import { filterPlugins, type GraphProvides, type PluginDefinition, parseGraphBuilderPlugin } from '@dxos/app-framework';
 import { GraphBuilder } from '@dxos/app-graph';
 
 import { GraphContext } from './GraphContext';
@@ -20,7 +15,7 @@ import meta from './meta';
  * Enables other plugins to register node builders to add nodes to the graph.
  * This includes actions and annotation each other's nodes.
  */
-export const GraphPlugin = (): PluginDefinition<GraphPluginProvides> => {
+export const GraphPlugin = (): PluginDefinition<GraphProvides> => {
   const builder = new GraphBuilder();
   const graph = builder.build();
 
@@ -34,8 +29,8 @@ export const GraphPlugin = (): PluginDefinition<GraphPluginProvides> => {
       builder.build(graph);
     },
     provides: {
-      context: ({ children }) => <GraphContext.Provider value={{ graph }}>{children}</GraphContext.Provider>,
       graph,
+      context: ({ children }) => <GraphContext.Provider value={{ graph }}>{children}</GraphContext.Provider>,
     },
   };
 };

--- a/packages/apps/plugins/plugin-layout/src/LayoutPlugin.tsx
+++ b/packages/apps/plugins/plugin-layout/src/LayoutPlugin.tsx
@@ -22,7 +22,7 @@ import {
   type PluginDefinition,
   type LayoutProvides,
   type IntentResolverProvides,
-  type GraphPluginProvides,
+  type GraphProvides,
   type GraphBuilderProvides,
   type SurfaceProvides,
   type TranslationsProvides,
@@ -45,7 +45,7 @@ export type LayoutPluginProvides = SurfaceProvides &
   LayoutProvides;
 
 export const LayoutPlugin = (): PluginDefinition<LayoutPluginProvides> => {
-  let graphPlugin: Plugin<GraphPluginProvides> | undefined;
+  let graphPlugin: Plugin<GraphProvides> | undefined;
   const state = new LocalStorageStore<LayoutState>(LAYOUT_PLUGIN, {
     fullscreen: false,
     sidebarOpen: true,

--- a/packages/apps/plugins/plugin-navtree/src/NavTreePlugin.tsx
+++ b/packages/apps/plugins/plugin-navtree/src/NavTreePlugin.tsx
@@ -4,19 +4,42 @@
 
 import React from 'react';
 
-import type { PluginDefinition, SurfaceProvides, TranslationsProvides } from '@dxos/app-framework';
+import type {
+  MetadataRecordsProvides,
+  PluginDefinition,
+  SurfaceProvides,
+  TranslationsProvides,
+} from '@dxos/app-framework';
 import { Graph, type Node } from '@dxos/app-graph';
 
-import { TreeItemMainHeading, TreeViewContainer, TreeViewDocumentTitle } from './components';
+import { NODE_TYPE, TreeItemMainHeading, TreeViewContainer, TreeViewDocumentTitle } from './components';
 import meta from './meta';
 import translations from './translations';
 
-export type NavTreePluginProvides = SurfaceProvides & TranslationsProvides;
+export type NavTreePluginProvides = SurfaceProvides & MetadataRecordsProvides & TranslationsProvides;
 
 export const NavTreePlugin = (): PluginDefinition<NavTreePluginProvides> => {
   return {
     meta,
     provides: {
+      metadata: {
+        records: {
+          [NODE_TYPE]: {
+            parse: (node: Node, type: string) => {
+              switch (type) {
+                case 'node':
+                  return node;
+
+                case 'object':
+                  return node.data;
+
+                default:
+                  return undefined;
+              }
+            },
+          },
+        },
+      },
       surface: {
         component: ({ data, role }) => {
           switch (role) {

--- a/packages/apps/plugins/plugin-navtree/src/components/TreeViewContainer.tsx
+++ b/packages/apps/plugins/plugin-navtree/src/components/TreeViewContainer.tsx
@@ -34,6 +34,8 @@ import { VersionInfo } from './VersionInfo';
 import { NAVTREE_PLUGIN } from '../meta';
 import { getPersistenceParent } from '../util';
 
+export const NODE_TYPE = 'dxos/app-graph/node';
+
 const getMosaicPath = (graph: Graph, id: string) => {
   const parts = graph.getPath(id)?.filter((part) => part !== 'childrenMap');
   return parts ? Path.create('root', ...parts) : undefined;
@@ -245,6 +247,7 @@ export const TreeViewContainer = ({
             <NavTree
               node={graph.root}
               current={currentPath}
+              type={NODE_TYPE}
               onSelect={handleSelect}
               isOver={isOver}
               onOver={handleOver}

--- a/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
+++ b/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
@@ -49,6 +49,22 @@ export const StackPlugin = (): PluginDefinition<StackPluginProvides> => {
             placeholder: ['stack title placeholder', { ns: STACK_PLUGIN }],
             icon: (props: IconProps) => <StackSimple {...props} />,
           },
+          [StackType.Section.schema.typename]: {
+            parse: ({ object }: StackType.Section, type: string) => {
+              switch (type) {
+                case 'object': {
+                  return object;
+                }
+
+                case 'node': {
+                  return { id: object.id, label: object.title, data: object };
+                }
+
+                default:
+                  return undefined;
+              }
+            },
+          },
         },
       },
       translations,

--- a/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -9,7 +9,7 @@ import { getActiveSpace, SPACE_PLUGIN, SpaceAction } from '@braneframe/plugin-sp
 import { Folder, Thread as ThreadType } from '@braneframe/types';
 import {
   LayoutAction,
-  type GraphPluginProvides,
+  type GraphProvides,
   type LayoutProvides,
   type Plugin,
   type PluginDefinition,
@@ -30,7 +30,7 @@ import { ThreadAction, type ThreadPluginProvides, isThread } from './types';
 (globalThis as any)[ThreadType.name] = ThreadType;
 
 export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
-  let graphPlugin: Plugin<GraphPluginProvides> | undefined;
+  let graphPlugin: Plugin<GraphProvides> | undefined;
   let layoutPlugin: Plugin<LayoutProvides> | undefined; // TODO(burdon): LayoutPluginProvides or LayoutProvides.
 
   return {

--- a/packages/sdk/app-framework/src/plugins/common/graph.ts
+++ b/packages/sdk/app-framework/src/plugins/common/graph.ts
@@ -10,7 +10,7 @@ import type { Plugin } from '../PluginHost';
 /**
  * Provides for a plugin that exposes the application graph.
  */
-export type GraphPluginProvides = {
+export type GraphProvides = {
   graph: Graph;
 };
 
@@ -24,7 +24,7 @@ export type GraphBuilderProvides = {
  * Type guard for graph plugins.
  */
 export const parseGraphPlugin = (plugin: Plugin) =>
-  (plugin.provides as any).graph?.root ? (plugin as Plugin<GraphPluginProvides>) : undefined;
+  (plugin.provides as any).graph?.root ? (plugin as Plugin<GraphProvides>) : undefined;
 
 /**
  * Type guard for graph builder plugins.

--- a/packages/ui/react-ui-mosaic/src/mosaic/Container.tsx
+++ b/packages/ui/react-ui-mosaic/src/mosaic/Container.tsx
@@ -15,7 +15,13 @@ import { type MosaicTileComponent } from './Tile';
 import { useMosaic } from './hooks';
 import { type MosaicDataItem, type MosaicDraggedItem } from './types';
 
+// TODO(wittjosiah): Factor out.
+type WithRequiredProperty<Type, Key extends keyof Type> = Type & {
+  [Property in Key]-?: Type[Property];
+};
+
 export const DEFAULT_TRANSITION = 200;
+export const DEFAULT_TYPE = 'unknown';
 
 export type MosaicTileOverlayProps = {
   grow?: boolean;
@@ -58,6 +64,11 @@ export type MosaicContainerProps<TData extends MosaicDataItem = MosaicDataItem, 
     Component?: MosaicTileComponent<TData, any>;
 
     /**
+     * Default type of tiles.
+     */
+    type?: string;
+
+    /**
      * Length of transition when moving tiles in milliseconds.
      *
      * @default 200
@@ -92,9 +103,15 @@ export type MosaicContainerProps<TData extends MosaicDataItem = MosaicDataItem, 
     onDrop?: (event: MosaicDropEvent<TPosition>) => void;
   }>;
 
-export type MosaicContainerContextType = Omit<MosaicContainerProps<any>, 'children'>;
+export type MosaicContainerContextType<
+  TData extends MosaicDataItem = MosaicDataItem,
+  TPosition = unknown,
+> = WithRequiredProperty<Omit<MosaicContainerProps<TData, TPosition>, 'children'>, 'type'>;
 
-export const MosaicContainerContext = createContext<MosaicContainerContextType | undefined>(undefined);
+export const MosaicContainerContext = createContext<MosaicContainerContextType<any>>({
+  id: 'never',
+  type: DEFAULT_TYPE,
+});
 
 /**
  * Root Container that manages the layout of tiles.
@@ -103,6 +120,7 @@ export const MosaicContainer = ({
   children,
   id,
   debug,
+  type = DEFAULT_TYPE,
   Component,
   transitionDuration = DEFAULT_TRANSITION,
   modifier,
@@ -115,6 +133,7 @@ export const MosaicContainer = ({
   const container = {
     id,
     debug,
+    type,
     Component,
     transitionDuration,
     modifier,

--- a/packages/ui/react-ui-mosaic/src/mosaic/Root.tsx
+++ b/packages/ui/react-ui-mosaic/src/mosaic/Root.tsx
@@ -133,13 +133,13 @@ export const MosaicRoot: FC<MosaicRootProps> = ({ Component = DefaultComponent, 
   //
 
   const handleDragStart = (event: DragStartEvent) => {
-    setActiveItem(pick(event.active.data.current as MosaicDraggedItem, 'path', 'item', 'position'));
+    setActiveItem(pick(event.active.data.current as MosaicDraggedItem, 'path', 'type', 'item', 'position'));
   };
 
   const handleDragMove = (event: DragMoveEvent) => {};
 
   const handleDragOver = (event: DragOverEvent) => {
-    const overItem = pick(event.over?.data.current as MosaicDraggedItem, 'path', 'item', 'position');
+    const overItem = pick(event.over?.data.current as MosaicDraggedItem, 'path', 'type', 'item', 'position');
 
     // If the over item is the same as the active item, do nothing.
     // This happens when moving between containers where a placeholder of itself is rendered where it will be dropped.
@@ -241,11 +241,13 @@ const MosaicDebug: FC<{
         active: {
           id: activeItem?.item?.id.slice(0, 16),
           path: activeItem?.path && Path.create(...Path.parts(activeItem.path).map((part) => part.slice(0, 16))),
+          type: activeItem?.type,
           position: activeItem?.position,
         },
         over: {
           id: overItem?.item?.id.slice(0, 16),
           path: overItem?.path && Path.create(...Path.parts(overItem.path).map((part) => part.slice(0, 16))),
+          type: overItem?.type,
           position: overItem?.position,
         },
       }}

--- a/packages/ui/react-ui-mosaic/src/mosaic/Tile.tsx
+++ b/packages/ui/react-ui-mosaic/src/mosaic/Tile.tsx
@@ -7,7 +7,7 @@ import { defaultAnimateLayoutChanges, useSortable } from '@dnd-kit/sortable';
 import React from 'react';
 import type { CSSProperties, ForwardRefExoticComponent, HTMLAttributes, RefAttributes } from 'react';
 
-import type { MosaicOperation, MosaicTileOverlayProps } from './Container';
+import { DEFAULT_TYPE, type MosaicOperation, type MosaicTileOverlayProps } from './Container';
 import { DefaultComponent } from './DefaultComponent';
 import { useContainer, useMosaic } from './hooks';
 import type { MosaicDataItem, MosaicDraggedItem } from './types';
@@ -29,6 +29,7 @@ export type MosaicTileProps<TData extends MosaicDataItem = MosaicDataItem, TPosi
     item: TData;
     Component?: MosaicTileComponent<TData, any>;
     position?: TPosition;
+    type?: string;
     operation?: MosaicOperation;
     active?: MosaicActiveType; // TODO(burdon): Rename state?
 
@@ -62,6 +63,7 @@ export type MosaicTileComponent<
  */
 export const DraggableTile = ({
   path: parentPath,
+  type = DEFAULT_TYPE,
   item,
   Component = DefaultComponent,
   position,
@@ -72,7 +74,7 @@ export const DraggableTile = ({
   const path = Path.create(parentPath, item.id);
   const { setNodeRef, attributes, listeners, /* transform, */ isDragging } = useDraggable({
     id: path,
-    data: { path, item, position } satisfies MosaicDraggedItem,
+    data: { path, type, item, position } satisfies MosaicDraggedItem,
   });
 
   return (
@@ -80,6 +82,7 @@ export const DraggableTile = ({
       ref={setNodeRef}
       item={item}
       path={path}
+      type={type}
       position={position}
       operation={operation}
       isDragging={isDragging}
@@ -99,6 +102,7 @@ export const DraggableTile = ({
  */
 export const DroppableTile = ({
   path: parentPath,
+  type = DEFAULT_TYPE,
   item,
   Component = DefaultComponent,
   position,
@@ -111,7 +115,7 @@ export const DroppableTile = ({
       : Path.create(parentPath, item.id);
   const { setNodeRef, isOver } = useDroppable({
     id: path,
-    data: { path, item, position } satisfies MosaicDraggedItem,
+    data: { path, type, item, position } satisfies MosaicDraggedItem,
   });
 
   return (
@@ -119,6 +123,7 @@ export const DroppableTile = ({
       ref={setNodeRef}
       item={item}
       path={path}
+      type={type}
       position={position}
       operation={operation}
       isOver={isOver}
@@ -132,6 +137,7 @@ export const DroppableTile = ({
  */
 export const SortableTile = ({
   path: parentPath,
+  type = DEFAULT_TYPE,
   item,
   Component: OverrideComponent,
   position,
@@ -154,7 +160,7 @@ export const SortableTile = ({
 
   const { setNodeRef, attributes, listeners, transform, isDragging, isOver } = useSortable({
     id: isPreview ? activeItem.path : path,
-    data: { path, item, position } satisfies MosaicDraggedItem,
+    data: { path, type, item, position } satisfies MosaicDraggedItem,
     animateLayoutChanges: (args) =>
       defaultAnimateLayoutChanges({ ...args, wasDragging: item.id !== activeItem?.item.id }),
   });
@@ -177,6 +183,7 @@ export const SortableTile = ({
       ref={setNodeRef}
       item={item}
       path={path}
+      type={type}
       position={position}
       operation={operation}
       active={active}

--- a/packages/ui/react-ui-mosaic/src/mosaic/hooks/useContainer.ts
+++ b/packages/ui/react-ui-mosaic/src/mosaic/hooks/useContainer.ts
@@ -4,13 +4,10 @@
 
 import { useContext } from 'react';
 
-import { raise } from '@dxos/debug';
-
-import { MosaicContainerContext, type MosaicContainerProps } from '../Container';
+import { MosaicContainerContext, type MosaicContainerContextType } from '../Container';
 import { type MosaicDataItem } from '../types';
 
 export const useContainer = <
   TData extends MosaicDataItem = MosaicDataItem,
   TPosition = unknown,
->(): MosaicContainerProps<TData, TPosition> =>
-  useContext(MosaicContainerContext) ?? raise(new Error('Missing MosaicContainerContext'));
+>(): MosaicContainerContextType<TData, TPosition> => useContext(MosaicContainerContext);

--- a/packages/ui/react-ui-mosaic/src/mosaic/types.ts
+++ b/packages/ui/react-ui-mosaic/src/mosaic/types.ts
@@ -2,10 +2,12 @@
 // Copyright 2023 DXOS.org
 //
 
+// TODO(wittjosiah): Rename MosiacDataItem to MosaicItemData?
 export type MosaicDataItem = { id: string };
 
 export type MosaicDraggedItem<TPosition = unknown> = {
   path: string;
+  type: string;
   // TODO(wittjosiah): Rename data? Otherwise item within item.
   item: MosaicDataItem;
   // Index or layout-specific positional information (stored separately from the item).

--- a/packages/ui/react-ui-navtree/src/components/NavTree.stories.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTree.stories.tsx
@@ -118,9 +118,9 @@ const StorybookNavTree = ({ id = ROOT_ID, ...props }: StorybookNavTreeProps) => 
               children.splice(active.position!, 1);
             }
             if (Path.last(Path.parent(over.path)) === item.id) {
-              children.splice(over.position!, 0, (active.item as NavTreeItemData).node);
+              children.splice(over.position!, 0, active.item as NavTreeItemData);
             } else if (Path.last(over.path) === item.id) {
-              children.splice(item.children.length, 0, (active.item as NavTreeItemData).node);
+              children.splice(item.children.length, 0, active.item as NavTreeItemData);
             }
             return { ...item, children };
           }),

--- a/packages/ui/react-ui-navtree/src/components/NavTree.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTree.tsx
@@ -12,16 +12,19 @@ import { NavTreeProvider, type NavTreeProviderProps } from './NavTreeContext';
 import { NavTreeMosaicComponent } from './NavTreeItem';
 import type { TreeNode } from '../types';
 
+export const DEFAULT_TYPE = 'tree-item';
+
 const NavTreeImpl = ({ node }: { node: TreeNode }) => {
-  const { id, Component } = useContainer();
+  const { id, Component, type } = useContainer();
 
   return (
     <Mosaic.SortableContext id={id} items={node.children} direction='vertical'>
       {node.children.map((node, index) => (
         <Mosaic.SortableTile
           key={node.id}
-          item={{ id: node.id, node, level: 0 }}
+          item={{ ...node, level: 0 }}
           path={id}
+          type={type}
           position={index}
           Component={Component!}
         />
@@ -45,6 +48,7 @@ export type NavTreeProps = {
 export const NavTree = ({
   node,
   current,
+  type = DEFAULT_TYPE,
   popoverAnchorId,
   onSelect,
   isOver = defaultIsOver,
@@ -58,6 +62,7 @@ export const NavTree = ({
       {...{
         id: node.id,
         Component: NavTreeMosaicComponent,
+        type,
         onOver,
         onDrop,
       }}

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
@@ -32,10 +32,15 @@ const hoverableDescriptionIcons =
 export const emptyBranchDroppableId = '__placeholder__';
 
 const NavTreeEmptyBranch = ({ path, level }: { path: string; level: number }) => {
-  const { Component } = useContainer();
+  const { Component, type } = useContainer();
   return (
     <TreeItemComponent.Body>
-      <Mosaic.DroppableTile path={path} item={{ id: emptyBranchDroppableId, level }} Component={Component!} />
+      <Mosaic.DroppableTile
+        path={path}
+        type={type}
+        item={{ id: emptyBranchDroppableId, level }}
+        Component={Component!}
+      />
     </TreeItemComponent.Body>
   );
 };
@@ -56,7 +61,7 @@ const NavTreeEmptyBranchPlaceholder: MosaicTileComponent<NavTreeItemData, HTMLDi
 );
 
 const NavTreeBranch = ({ path, nodes, level }: { path: string; nodes: TreeNode[]; level: number }) => {
-  const { Component } = useContainer();
+  const { Component, type } = useContainer();
 
   const items = useItemsWithOrigin(path, nodes);
 
@@ -67,8 +72,9 @@ const NavTreeBranch = ({ path, nodes, level }: { path: string; nodes: TreeNode[]
           {items.map((node, index) => (
             <Mosaic.SortableTile
               key={node.id}
-              item={{ id: node.id, node, level }}
+              item={{ ...node, level }}
               path={path}
+              type={type}
               position={index}
               Component={Component!}
             />
@@ -87,12 +93,11 @@ export const NavTreeMosaicComponent: MosaicTileComponent<NavTreeItemData, HTMLLI
   }
 });
 
-// TODO(wittjosiah): Spread node?
-export type NavTreeItemData = { id: TreeNode['id']; node: TreeNode; level: number };
+export type NavTreeItemData = TreeNode & { level: number };
 
 export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = forwardRef(
   ({ item, draggableProps, draggableStyle, active, path, position }, forwardedRef) => {
-    const { node, level } = item;
+    const { level, ...node } = item;
     const isBranch = node.properties?.role === 'branch' || node.children?.length > 0;
 
     const [primaryAction, ...secondaryActions] = [...node.actions].sort((a, b) =>

--- a/packages/ui/react-ui-navtree/src/testing/DropZone.tsx
+++ b/packages/ui/react-ui-navtree/src/testing/DropZone.tsx
@@ -17,7 +17,7 @@ export const DropZone = () => {
 
   return (
     <Mosaic.Container id='dropzone' onOver={handleOver} onDrop={handleDrop}>
-      <Mosaic.DroppableTile Component={DropComponent} path='dropzone' item={{ id: 'dropzone', node: item?.node }} />
+      <Mosaic.DroppableTile Component={DropComponent} path='dropzone' item={{ id: 'dropzone', node: item }} />
     </Mosaic.Container>
   );
 };
@@ -32,10 +32,10 @@ const DropComponent: MosaicTileComponent<NavTreeItemData> = forwardRef(({ isOver
         isOver && 'bg-gray-200 border-solid',
       )}
     >
-      {item.node ? (
+      {item ? (
         <>
-          {item.node.icon && <item.node.icon />}
-          {Array.isArray(item.node.label) ? t(...item.node.label) : item.node.label}
+          {item.icon && <item.icon />}
+          {Array.isArray(item.label) ? t(...item.label) : item.label}
         </>
       ) : (
         'Drop Zone'

--- a/packages/ui/react-ui-stack/src/components/Stack.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack.tsx
@@ -23,6 +23,8 @@ import { translationKey } from '../translations';
 
 export type Direction = 'horizontal' | 'vertical';
 
+export const DEFAULT_TYPE = 'stack-section';
+
 type StackItem = MosaicDataItem & {
   items: StackSectionItem[];
 };
@@ -43,6 +45,7 @@ export type StackProps<TData extends StackSectionItem = StackSectionItem> = Omit
 
 export const Stack = ({
   id,
+  type = DEFAULT_TYPE,
   className,
   Component: SectionContent,
   items = [],
@@ -83,9 +86,10 @@ export const Stack = ({
 
   return (
     <div ref={containerRef}>
-      <Mosaic.Container {...{ id, Component, getOverlayStyle, onOver, onDrop }}>
+      <Mosaic.Container {...{ id, type, Component, getOverlayStyle, onOver, onDrop }}>
         <Mosaic.DroppableTile
           path={id}
+          type={type}
           className={className}
           item={{ id, items: itemsWithPreview }}
           isOver={overItem && Path.hasRoot(overItem.path, id) && (operation === 'copy' || operation === 'transfer')}
@@ -99,7 +103,7 @@ export const Stack = ({
 const StackTile: MosaicTileComponent<StackItem, HTMLOListElement> = forwardRef(
   ({ className, path, isOver, item: { items } }, forwardedRef) => {
     const { t } = useTranslation(translationKey);
-    const { Component } = useContainer();
+    const { Component, type } = useContainer();
 
     // NOTE: Keep outer padding the same as MarkdownMain.
     return (
@@ -107,7 +111,14 @@ const StackTile: MosaicTileComponent<StackItem, HTMLOListElement> = forwardRef(
         {items.length > 0 ? (
           <Mosaic.SortableContext items={items} direction='vertical'>
             {items.map((item, index) => (
-              <Mosaic.SortableTile key={item.id} item={item} path={path} position={index} Component={Component!} />
+              <Mosaic.SortableTile
+                key={item.id}
+                item={item}
+                path={path}
+                type={type}
+                position={index}
+                Component={Component!}
+              />
             ))}
           </Mosaic.SortableContext>
         ) : (


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2761760</samp>

### Summary
🧩🖼️📊

<!--
1.  🧩 - This emoji represents the addition of the `parse` function for the `StackType.Section` type to the `metadata` property of the `StackPlugin`. This is because the emoji conveys the idea of fitting pieces together, which is what the metadata resolver does with the `parse` functions.
2.  🖼️ - This emoji represents the addition of the `type` property to the `MosaicDraggedItem` type and the mosaic tiles. This is because the emoji depicts a picture frame, which is similar to a mosaic tile that displays some content.
3.  📊 - This emoji represents the support for metadata records and intent system for graph nodes and stack sections. This is because the emoji depicts a chart, which is a common way of visualizing graph data and stack sections.
-->
This pull request adds a `type` property to various components and types related to the mosaic layout, the navtree, and the stack. This enables the metadata resolver plugin to handle different types of data and share them with other plugins. It also updates some plugins to use the new `GraphProvides` type from the app-framework SDK, and renames a type in the graph plugin module.

> _We are the masters of the mosaic_
> _We parse the types with metal force_
> _We share the data with the resolver_
> _We drag and drop the tiles of doom_

### Walkthrough
*  Rename `GraphPluginProvides` type to `GraphProvides` and update imports and usages ([link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-93bf3cf06a0c1cea035e8647088f2523ff84452883582dabc6e93e7cbcc8cb97L7-R7),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-93bf3cf06a0c1cea035e8647088f2523ff84452883582dabc6e93e7cbcc8cb97L23-R18),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-f3cdf174792cb84b592044c88d38ed425c3c13bc79304bf253f1a9f2f925c99bL25-R25),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-f3cdf174792cb84b592044c88d38ed425c3c13bc79304bf253f1a9f2f925c99bL48-R48),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-5feac81bd76b27098feff076ff3502934b47368b7c6cc301d9d167dccd191fefL12-R12),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-5feac81bd76b27098feff076ff3502934b47368b7c6cc301d9d167dccd191fefL32-R32),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-262477b93afddcddace1301a38b5385353b542751b4b905b4158499259d9a4adL13-R13),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-262477b93afddcddace1301a38b5385353b542751b4b905b4158499259d9a4adL27-R27))
*  Add `type` property to mosaic components and context to pass the type of the dragged or dropped item and use the metadata resolver accordingly ([link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-a6265a6cedfcc74f332b032e365ccfb081883fb035bc2faa60067a01742bd199R37-R38),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-a6265a6cedfcc74f332b032e365ccfb081883fb035bc2faa60067a01742bd199R250),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-badb2161a3579b10c86c3504f3dd54863a5426a1f5d0abf5aea7a3627ebf3141L18-R24),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-badb2161a3579b10c86c3504f3dd54863a5426a1f5d0abf5aea7a3627ebf3141R67-R71),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-badb2161a3579b10c86c3504f3dd54863a5426a1f5d0abf5aea7a3627ebf3141L95-R114),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-badb2161a3579b10c86c3504f3dd54863a5426a1f5d0abf5aea7a3627ebf3141R123),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-badb2161a3579b10c86c3504f3dd54863a5426a1f5d0abf5aea7a3627ebf3141R136),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-fc137c02f24542482061272952dbef59ddcf80816bb0c014728f84ae6f28bdbfL136-R136),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-fc137c02f24542482061272952dbef59ddcf80816bb0c014728f84ae6f28bdbfL142-R142),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-fc137c02f24542482061272952dbef59ddcf80816bb0c014728f84ae6f28bdbfR244),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-fc137c02f24542482061272952dbef59ddcf80816bb0c014728f84ae6f28bdbfR250),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-81b2d4751a64ec4947208d07467456fed2f939488d56310cd4c55c850f5e39caL10-R10),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-81b2d4751a64ec4947208d07467456fed2f939488d56310cd4c55c850f5e39caR32),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-81b2d4751a64ec4947208d07467456fed2f939488d56310cd4c55c850f5e39caR65),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-81b2d4751a64ec4947208d07467456fed2f939488d56310cd4c55c850f5e39caL74-R76),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-81b2d4751a64ec4947208d07467456fed2f939488d56310cd4c55c850f5e39caR84),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-81b2d4751a64ec4947208d07467456fed2f939488d56310cd4c55c850f5e39caR104),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-81b2d4751a64ec4947208d07467456fed2f939488d56310cd4c55c850f5e39caL113-R117),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-81b2d4751a64ec4947208d07467456fed2f939488d56310cd4c55c850f5e39caR125),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-81b2d4751a64ec4947208d07467456fed2f939488d56310cd4c55c850f5e39caR139),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-81b2d4751a64ec4947208d07467456fed2f939488d56310cd4c55c850f5e39caL156-R162),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-81b2d4751a64ec4947208d07467456fed2f939488d56310cd4c55c850f5e39caR185),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-fef0c23aae77abf4de3fe5d536562e9990d9535d9e325ccec8cd63768428e241L7-R7),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-fef0c23aae77abf4de3fe5d536562e9990d9535d9e325ccec8cd63768428e241L15-R13),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-955e05157fc071ace828c4f05ccdd402f29af7548b42e5a515d150c4b01f0f53L5-R10),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-b3dac2c6117b2687313d8bc5b34d0d113b0cd7a24422754939892ddf37636717L15-R18),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-b3dac2c6117b2687313d8bc5b34d0d113b0cd7a24422754939892ddf37636717L23-R27),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-b3dac2c6117b2687313d8bc5b34d0d113b0cd7a24422754939892ddf37636717R51),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-b3dac2c6117b2687313d8bc5b34d0d113b0cd7a24422754939892ddf37636717R65),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-7727cdae18ccb85b3d8f9be83b7977ccb6efc19d93efc80836d0509d44563381L35-R43),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-7727cdae18ccb85b3d8f9be83b7977ccb6efc19d93efc80836d0509d44563381L59-R64),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-7727cdae18ccb85b3d8f9be83b7977ccb6efc19d93efc80836d0509d44563381L70-R77),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-6d9916d392111dfbbaea8bee0b2a071c011fadc36b624705046ddd06bb9f5a67R26-R27),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-6d9916d392111dfbbaea8bee0b2a071c011fadc36b624705046ddd06bb9f5a67R47),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-6d9916d392111dfbbaea8bee0b2a071c011fadc36b624705046ddd06bb9f5a67L83-R89),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-6d9916d392111dfbbaea8bee0b2a071c011fadc36b624705046ddd06bb9f5a67L99-R103),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-6d9916d392111dfbbaea8bee0b2a071c011fadc36b624705046ddd06bb9f5a67L107-R118))
*  Add `metadata` property to `NavTreePlugin` and `StackPlugin` to provide metadata records for the tree and stack items ([link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-96f1ace9a87a316b859e5158feab5a66cb5421c24b07deb4b82c214a0b5b6687L7-R19),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-96f1ace9a87a316b859e5158feab5a66cb5421c24b07deb4b82c214a0b5b6687R25-R42),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-73f12af5e023ef40bc928d988f0d7626f1db6bf7d07a1d91a2dfd4553a50d9e3R51-R66))
*  Add imports and variables to `StackMain` component to use the metadata resolver and the intent system ([link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068L9-R9),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068R31),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068L42-R48))
*  Change `object` variable in `StackMain` component to use the `parseData` function instead of reading the graph data directly ([link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068L69-R72),[link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068R98))
*  Change `NavTreeItemData` type to extend the `TreeNode` type instead of having a separate `node` property ([link](https://github.com/dxos/dxos/pull/4696/files?diff=unified&w=0#diff-7727cdae18ccb85b3d8f9be83b7977ccb6efc19d93efc80836d0509d44563381L90-R100))


