### PR TITLE
test(composer-app): fix multiplayer e2e tests

### DIFF
--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -44,7 +44,8 @@ export class AppManager {
     return this.page.getByTestId('navtree.treeItem.openTrigger').last().click();
   }
 
-  joinSpace() {
+  async joinSpace() {
+    await this.page.getByTestId('navtree.treeItem.actionsLevel0').nth(1).click();
     return this.page.getByTestId('spacePlugin.joinSpace').click();
   }
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 559acce</samp>

### Summary
🖱️🌐🆕

<!--
1.  🖱️ - This emoji can be used to indicate a mouse click action, which is what the method does to expand the Spaces plugin and join a space.
2.  🌐 - This emoji can be used to represent the Spaces plugin, which is a feature that allows users to collaborate and communicate across different composer apps and devices.
3.  🆕 - This emoji can be used to signify that the change was made to adapt to a new UI layout or design, which is the reason why the method had to be modified.
-->
Updated the `joinSpace` method in the playwright test helper to work with the new composer UI. The method now expands the `Spaces` plugin from the navtree before joining a space.

> _`joinSpace` changes_
> _navtree click for Spaces plugin_
> _autumn leaves the old_

### Walkthrough
*  Adapt `joinSpace` method to new UI layout by clicking on Spaces plugin before joining space ([link](https://github.com/dxos/dxos/pull/4703/files?diff=unified&w=0#diff-b295c0687b736b4159c9f82185a761df55201a2638d4a9ce708ca7b7b90b9b46L47-R48))


