### PR TITLE
feat: add --inspectBrk option for test executor

### DIFF
--- a/tools/executors/test/schema.json
+++ b/tools/executors/test/schema.json
@@ -140,6 +140,11 @@
       "description": "Enable node inspector",
       "default": false
     },
+    "inspectBrk": {
+      "type": "boolean",
+      "description": "Enable node inspector and break at start",
+      "default": false
+    },
     "grep": {
       "type": "string",
       "description": "Name of test for debugging"

--- a/tools/executors/test/src/run-node.ts
+++ b/tools/executors/test/src/run-node.ts
@@ -45,6 +45,7 @@ export type NodeOptions = {
   executorResult?: object;
   reporter?: string;
   inspect?: boolean;
+  inspectBrk?: boolean;
   trackLeakedResources: boolean;
   grep?: string;
   bail?: boolean;
@@ -119,6 +120,7 @@ const getNodeArgs = async (context: ExecutorContext, options: NodeOptions) => {
       '--checkLeaks': options.checkLeaks,
       '--exit': options.forceExit,
       '--inspect': options.inspect,
+      '--inspect-brk': options.inspectBrk,
       '--bail': options.bail,
     },
     options.grep && ['--grep', options.grep],


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 877043a</samp>

### Summary
🕵️🛠️🧪

<!--
1.  🕵️ - This emoji represents the debugging aspect of the `inspectBrk` option, as it is commonly used to indicate detective or investigative work.
2.  🛠️ - This emoji represents the modification or improvement of the `test` executor and the `NodeOptions` interface, as it is commonly used to indicate tools or fixing something.
3.  🧪 - This emoji represents the testing aspect of the `inspectBrk` option, as it is commonly used to indicate experiments or scientific tests.
-->
This pull request adds a new `inspectBrk` option to the `test` executor, which enables debugging node tests with the `--inspect-brk` flag. It updates the schema and the logic of the executor in `schema.json` and `run-node.ts` accordingly.

> _Sing, O Muse, of the cunning code review_
> _That added a new option to the test schema_
> _`inspectBrk`, the breaker of the node_
> _That pauses the execution at the start._

### Walkthrough
*  Add `inspectBrk` option to enable node inspector and break at the start of the test execution ([link](https://github.com/dxos/dxos/pull/4706/files?diff=unified&w=0#diff-ed1d56e390e9b2defd1763b20a22c5462c676fda351a991ee4608b6c41d02a68R143-R147), [link](https://github.com/dxos/dxos/pull/4706/files?diff=unified&w=0#diff-cbb71288c0b92a022edac68ae8a2b393641cca98c4c45146706cbb95775d02c9R48), [link](https://github.com/dxos/dxos/pull/4706/files?diff=unified&w=0#diff-cbb71288c0b92a022edac68ae8a2b393641cca98c4c45146706cbb95775d02c9R123))


