### PR TITLE
fix: increase test timeout

### DIFF
--- a/tools/executors/test/schema.json
+++ b/tools/executors/test/schema.json
@@ -90,7 +90,7 @@
     "timeout": {
       "type": "number",
       "description": "Mocha timeout in ms",
-      "default": 15000
+      "default": 20000
     },
     "trackLeakedResource": {
       "type": "boolean",


### PR DESCRIPTION
workaround for https://github.com/dxos/dxos/issues/4705

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ea9e86b</samp>

### Summary
:clock10::white_check_mark::zap:

<!--
1.  :clock10: This emoji represents the concept of time or duration, which is relevant to the `timeout` property and the change in its value.
2.  :white_check_mark: This emoji represents the concept of success or passing, which is the desired outcome of the test suite and the motivation for the change.
3.  :zap: This emoji represents the concept of speed or performance, which is also related to the `timeout` property and the goal of avoiding timeouts.
-->
Increased the default test timeout in `tools/executors/test/schema.json` to reduce test failures. This is part of a pull request to improve the test suite reliability and stability.

> _Slow tests need more time_
> _`timeout` is now longer_
> _Winter patience grows_

### Walkthrough
* Increase the default test timeout to 20 seconds ([link](https://github.com/dxos/dxos/pull/4707/files?diff=unified&w=0#diff-ed1d56e390e9b2defd1763b20a22c5462c676fda351a991ee4608b6c41d02a68L93-R93)). This helps avoid failures in slow or flaky tests in `tools/executors/test/schema.json`.


