### PR TITLE
fix: teleport controlextension timeouts

### DIFF
--- a/packages/core/mesh/teleport/src/control-extension.ts
+++ b/packages/core/mesh/teleport/src/control-extension.ts
@@ -1,0 +1,130 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { asyncTimeout, scheduleTaskInterval } from '@dxos/async';
+import { Context } from '@dxos/context';
+import { type PublicKey } from '@dxos/keys';
+import { log } from '@dxos/log';
+import { schema } from '@dxos/protocols';
+import { type ControlService } from '@dxos/protocols/proto/dxos/mesh/teleport/control';
+import { createProtoRpcPeer, type ProtoRpcPeer } from '@dxos/rpc';
+import { Callback } from '@dxos/util';
+
+import { type ExtensionContext, type TeleportExtension } from './teleport';
+
+const HEARTBEAT_RTT_WARN_THRESH = 10_000;
+
+type ControlRpcBundle = {
+  Control: ControlService;
+};
+
+type ControlExtensionOpts = {
+  heartbeatInterval: number;
+  heartbeatTimeout: number;
+  onTimeout: () => void;
+};
+
+export class ControlExtension implements TeleportExtension {
+  private readonly _ctx = new Context({
+    onError: (err) => {
+      this._extensionContext.close(err);
+    },
+  });
+
+  public readonly onExtensionRegistered = new Callback<(extensionName: string) => void>();
+
+  private _extensionContext!: ExtensionContext;
+  private _rpc!: ProtoRpcPeer<{ Control: ControlService }>;
+
+  constructor(
+    private readonly opts: ControlExtensionOpts,
+    private readonly localPeerId: PublicKey,
+    private readonly remotePeerId: PublicKey,
+  ) {}
+
+  async registerExtension(name: string) {
+    await this._rpc.rpc.Control.registerExtension({ name });
+  }
+
+  async onOpen(extensionContext: ExtensionContext): Promise<void> {
+    this._extensionContext = extensionContext;
+
+    this._rpc = createProtoRpcPeer<ControlRpcBundle, ControlRpcBundle>({
+      requested: {
+        Control: schema.getService('dxos.mesh.teleport.control.ControlService'),
+      },
+      exposed: {
+        Control: schema.getService('dxos.mesh.teleport.control.ControlService'),
+      },
+      handlers: {
+        Control: {
+          registerExtension: async (request) => {
+            this.onExtensionRegistered.call(request.name);
+          },
+          heartbeat: async (request) => {
+            log('received heartbeat request', {
+              ts: request.requestTimestamp,
+              localPeerId: this.localPeerId.truncate(),
+              remotePeerId: this.remotePeerId.truncate(),
+            });
+            return {
+              requestTimestamp: request.requestTimestamp,
+            };
+          },
+        },
+      },
+      port: await extensionContext.createPort('rpc', {
+        contentType: 'application/x-protobuf; messageType="dxos.rpc.Message"',
+      }),
+      timeout: this.opts.heartbeatTimeout,
+    });
+
+    await this._rpc.open();
+
+    scheduleTaskInterval(
+      this._ctx,
+      async () => {
+        try {
+          const resp = await asyncTimeout(
+            this._rpc.rpc.Control.heartbeat({ requestTimestamp: new Date() }),
+            this.opts.heartbeatTimeout,
+          );
+          const now = Date.now();
+          // TODO(nf): properly instrument
+          if (
+            now - resp.requestTimestamp.getTime() >
+            (HEARTBEAT_RTT_WARN_THRESH < this.opts.heartbeatTimeout
+              ? HEARTBEAT_RTT_WARN_THRESH
+              : this.opts.heartbeatTimeout / 2)
+          ) {
+            log.warn(`heartbeat RTT for Teleport > ${HEARTBEAT_RTT_WARN_THRESH / 1000}s`, {
+              rtt: now - resp.requestTimestamp.getTime(),
+              localPeerId: this.localPeerId.truncate(),
+              remotePeerId: this.remotePeerId.truncate(),
+            });
+          } else {
+            log('heartbeat RTT', {
+              rtt: now - resp.requestTimestamp.getTime(),
+              localPeerId: this.localPeerId.truncate(),
+              remotePeerId: this.remotePeerId.truncate(),
+            });
+          }
+        } catch (err: any) {
+          this.opts.onTimeout();
+        }
+      },
+      this.opts.heartbeatInterval,
+    );
+  }
+
+  async onClose(err?: Error): Promise<void> {
+    await this._ctx.dispose();
+    await this._rpc.close();
+  }
+
+  async onAbort(err?: Error | undefined): Promise<void> {
+    await this._ctx.dispose();
+    await this._rpc.abort();
+  }
+}

--- a/packages/core/mesh/teleport/src/teleport.ts
+++ b/packages/core/mesh/teleport/src/teleport.ts
@@ -4,24 +4,15 @@
 
 import { type Duplex } from 'node:stream';
 
-import {
-  asyncTimeout,
-  scheduleTaskInterval,
-  runInContextAsync,
-  synchronized,
-  scheduleTask,
-  type Event,
-} from '@dxos/async';
+import { runInContextAsync, synchronized, scheduleTask, type Event } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { failUndefined } from '@dxos/debug';
 import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
-import { schema, RpcClosedError, TimeoutError } from '@dxos/protocols';
-import { type ControlService } from '@dxos/protocols/proto/dxos/mesh/teleport/control';
-import { createProtoRpcPeer, type ProtoRpcPeer } from '@dxos/rpc';
-import { Callback } from '@dxos/util';
+import { RpcClosedError, TimeoutError } from '@dxos/protocols';
 
+import { ControlExtension } from './control-extension';
 import { type CreateChannelOpts, Muxer, type MuxerStats, type RpcPort } from './muxing';
 
 export type TeleportParams = {
@@ -51,18 +42,7 @@ export class Teleport {
 
   private readonly _muxer = new Muxer();
 
-  private readonly _control = new ControlExtension({
-    heartbeatInterval: CONTROL_HEARTBEAT_INTERVAL,
-    heartbeatTimeout: CONTROL_HEARTBEAT_TIMEOUT,
-    onTimeout: () => {
-      if (this._destroying || this._aborting) {
-        return;
-      }
-      // TODO(egorgripasov): Evaluate use of abort instead of destroy.
-      log('abort teleport due to onTimeout in ControlExtension');
-      this.abort(new TimeoutError('control extension')).catch((err) => log.catch(err));
-    },
-  });
+  private readonly _control;
 
   private readonly _extensions = new Map<string, TeleportExtension>();
   private readonly _remoteExtensions = new Set<string>();
@@ -78,6 +58,22 @@ export class Teleport {
     this.initiator = initiator;
     this.localPeerId = localPeerId;
     this.remotePeerId = remotePeerId;
+
+    this._control = new ControlExtension(
+      {
+        heartbeatInterval: CONTROL_HEARTBEAT_INTERVAL,
+        heartbeatTimeout: CONTROL_HEARTBEAT_TIMEOUT,
+        onTimeout: () => {
+          if (this._destroying || this._aborting) {
+            return;
+          }
+          log.info('abort teleport due to onTimeout in ControlExtension');
+          this.abort(new TimeoutError('control extension')).catch((err) => log.catch(err));
+        },
+      },
+      this.localPeerId,
+      this.remotePeerId,
+    );
 
     this._control.onExtensionRegistered.set(async (name) => {
       log('remote extension', { name });
@@ -272,85 +268,4 @@ export interface TeleportExtension {
   onOpen(context: ExtensionContext): Promise<void>;
   onClose(err?: Error): Promise<void>;
   onAbort(err?: Error): Promise<void>;
-}
-
-type ControlRpcBundle = {
-  Control: ControlService;
-};
-
-type ControlExtensionOpts = {
-  heartbeatInterval: number;
-  heartbeatTimeout: number;
-  onTimeout: () => void;
-};
-
-class ControlExtension implements TeleportExtension {
-  private readonly _ctx = new Context({
-    onError: (err) => {
-      this._extensionContext.close(err);
-    },
-  });
-
-  public readonly onExtensionRegistered = new Callback<(extensionName: string) => void>();
-
-  private _extensionContext!: ExtensionContext;
-  private _rpc!: ProtoRpcPeer<{ Control: ControlService }>;
-
-  constructor(private readonly opts: ControlExtensionOpts) {}
-
-  async registerExtension(name: string) {
-    await this._rpc.rpc.Control.registerExtension({ name });
-  }
-
-  async onOpen(extensionContext: ExtensionContext): Promise<void> {
-    this._extensionContext = extensionContext;
-
-    // NOTE: Make sure that RPC timeout is greater than the heartbeat timeout.
-    // TODO(dmaretskyi): Allow overwriting the timeout on individual RPC calls?
-    this._rpc = createProtoRpcPeer<ControlRpcBundle, ControlRpcBundle>({
-      requested: {
-        Control: schema.getService('dxos.mesh.teleport.control.ControlService'),
-      },
-      exposed: {
-        Control: schema.getService('dxos.mesh.teleport.control.ControlService'),
-      },
-      handlers: {
-        Control: {
-          registerExtension: async (request) => {
-            this.onExtensionRegistered.call(request.name);
-          },
-          heartbeat: async (request) => {
-            // Ok.
-          },
-        },
-      },
-      port: await extensionContext.createPort('rpc', {
-        contentType: 'application/x-protobuf; messagType="dxos.rpc.Message"',
-      }),
-    });
-
-    await this._rpc.open();
-
-    scheduleTaskInterval(
-      this._ctx,
-      async () => {
-        try {
-          await asyncTimeout(this._rpc.rpc.Control.heartbeat(), this.opts.heartbeatTimeout);
-        } catch (err: any) {
-          this.opts.onTimeout();
-        }
-      },
-      this.opts.heartbeatInterval,
-    );
-  }
-
-  async onClose(err?: Error): Promise<void> {
-    await this._ctx.dispose();
-    await this._rpc.close();
-  }
-
-  async onAbort(err?: Error | undefined): Promise<void> {
-    await this._ctx.dispose();
-    await this._rpc.abort();
-  }
 }

--- a/packages/core/protocols/src/proto/dxos/mesh/teleport/control.proto
+++ b/packages/core/protocols/src/proto/dxos/mesh/teleport/control.proto
@@ -4,6 +4,9 @@
 
 syntax = "proto3";
 
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
 package dxos.mesh.teleport.control;
 
 message RegisterExtensionRequest {
@@ -11,9 +14,17 @@ message RegisterExtensionRequest {
   string name = 1;
 }
 
+message ControlHeartbeatRequest {
+  google.protobuf.Timestamp request_timestamp = 1;
+}
+
+message ControlHeartbeatResponse {
+  google.protobuf.Timestamp request_timestamp = 1;
+}
+
+
 /// Controls the lifycycle of the teleport session and its exentsions.
 service ControlService {
   rpc RegisterExtension (RegisterExtensionRequest) returns (google.protobuf.Empty);
-
-  rpc Heartbeat(google.protobuf.Empty) returns (google.protobuf.Empty);
+  rpc Heartbeat(ControlHeartbeatRequest) returns (ControlHeartbeatResponse);
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7848b34</samp>

### Summary
🎛️🐛⏱️

<!--
1.  🎛️ - This emoji represents the control channel of the teleport session, which is the main feature of the `ControlExtension` class. It also suggests the idea of adjusting or tuning the teleport session parameters.
2.  🐛 - This emoji represents the bug fixes and refactoring of the `Teleport` and `ControlExtension` classes, which improve the logging and error handling of the control channel. It also suggests the idea of finding and fixing issues in the code.
3.  ⏱️ - This emoji represents the improved heartbeat mechanism of the `ControlService`, which uses timestamps to measure latency and detect potential network issues. It also suggests the idea of timing or measuring the performance of the teleport session.
-->
This pull request improves the reliability and performance of the teleport protocol, which enables remote access to DXOS services. It refactors the `Teleport` and `ControlExtension` classes to handle errors and logging better, updates the `control.proto` file to use timestamps for heartbeats, and adds a new file `control-extension.ts` to define the control channel logic.

> _Oh we are the `Teleport` crew and we sail the cyberspace_
> _We manage the control channel with a steady hand and grace_
> _We register extensions and we send a heartbeat too_
> _We measure the latency with a timestamp, me and you_

### Walkthrough
*  Define `ControlExtension` class to manage control channel of teleport session ([link](https://github.com/dxos/dxos/pull/4708/files?diff=unified&w=0#diff-25951f1603019247723a5beff4b22a910c420d4ca114a123bfd811dd95bfa65eR1-R123), [link](https://github.com/dxos/dxos/pull/4708/files?diff=unified&w=0#diff-dca6eddbf8d5a9d0f4757e89710e90775785e32461a5b4b06d022d5bdab144f1L276-L356))
  - Implement `TeleportExtension` interface and handle registration and heartbeat RPCs ([link](https://github.com/dxos/dxos/pull/4708/files?diff=unified&w=0#diff-25951f1603019247723a5beff4b22a910c420d4ca114a123bfd811dd95bfa65eR1-R123))
  - Pass local and remote peer IDs to RPC peer for logging ([link](https://github.com/dxos/dxos/pull/4708/files?diff=unified&w=0#diff-25951f1603019247723a5beff4b22a910c420d4ca114a123bfd811dd95bfa65eR1-R123))
  - Instantiate `ControlExtension` in `Teleport` class constructor after peer IDs are initialized ([link](https://github.com/dxos/dxos/pull/4708/files?diff=unified&w=0#diff-dca6eddbf8d5a9d0f4757e89710e90775785e32461a5b4b06d022d5bdab144f1L54-R45), [link](https://github.com/dxos/dxos/pull/4708/files?diff=unified&w=0#diff-dca6eddbf8d5a9d0f4757e89710e90775785e32461a5b4b06d022d5bdab144f1R62-R77))
  - Abort teleport session and log message if control channel timeout occurs ([link](https://github.com/dxos/dxos/pull/4708/files?diff=unified&w=0#diff-dca6eddbf8d5a9d0f4757e89710e90775785e32461a5b4b06d022d5bdab144f1R62-R77))
* Update imports in `teleport.ts` to reflect new file `control-extension.ts` and remove unused imports ([link](https://github.com/dxos/dxos/pull/4708/files?diff=unified&w=0#diff-dca6eddbf8d5a9d0f4757e89710e90775785e32461a5b4b06d022d5bdab144f1L7-R7), [link](https://github.com/dxos/dxos/pull/4708/files?diff=unified&w=0#diff-dca6eddbf8d5a9d0f4757e89710e90775785e32461a5b4b06d022d5bdab144f1L20-R15))
* Modify `Heartbeat` RPC method in `ControlService` to use timestamp messages ([link](https://github.com/dxos/dxos/pull/4708/files?diff=unified&w=0#diff-70064933432f04445362a5d0265b1e93263c66a4b066daf33681c887063ce7a1L14-R29))
  - Import `Timestamp` type from Google Protobuf library in `control.proto` ([link](https://github.com/dxos/dxos/pull/4708/files?diff=unified&w=0#diff-70064933432f04445362a5d0265b1e93263c66a4b066daf33681c887063ce7a1R7-R9))
  - Define `ControlHeartbeatRequest` and `ControlHeartbeatResponse` messages with timestamp field ([link](https://github.com/dxos/dxos/pull/4708/files?diff=unified&w=0#diff-70064933432f04445362a5d0265b1e93263c66a4b066daf33681c887063ce7a1L14-R29))
  - Measure and log round-trip time of heartbeat and warn if it exceeds threshold ([link](https://github.com/dxos/dxos/pull/4708/files?diff=unified&w=0#diff-70064933432f04445362a5d0265b1e93263c66a4b066daf33681c887063ce7a1L14-R29))


