### PR TITLE
fix: remove inacessible space node from parent

### DIFF
--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -65,6 +65,7 @@ export const objectToGraphNode = ({
   let previousObjects: TypedObject[] = [];
   return effect(() => {
     if (isSpaceFolder && space.state.get() === SpaceState.INACTIVE) {
+      parent.removeNode(object.id);
       return;
     }
 


### PR DESCRIPTION
after we close a space, early return on the now inactive space leaves the previously added node hanging in parent. remove it so that UI gets updated

maybe bug #4392

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f77f637</samp>

### Summary
🚚🛠️🌳

<!--
1.  🚚 This emoji can be used to indicate that something was moved or relocated, which is what this change does to the node.
2.  🛠️ This emoji can be used to indicate that something was fixed or improved, which is the goal of this change for issue #1039.
3.  🌳 This emoji can be used to indicate that something relates to a tree or a graph structure, which is what this change affects by modifying the node's parent.
-->
Fix duplicate nodes in graph when moving objects between containers. Update `util.tsx` to detach node from old parent before attaching to new parent.

> _`node` leaves old parent_
> _to join a new container_
> _autumn leaves falling_

### Walkthrough
* Fix issue #1039 by removing node from old parent before adding to new one ([link](https://github.com/dxos/dxos/pull/4717/files?diff=unified&w=0#diff-40c06872035a3fca913d3ecf4b86bab147706b739e5546f25845364df1b60203R68))


