### PR TITLE
fix(react-ui-theme): Subtler open state style & popover border

### DIFF
--- a/packages/ui/react-appkit/src/components/Popover/Popover.stories.tsx
+++ b/packages/ui/react-appkit/src/components/Popover/Popover.stories.tsx
@@ -7,7 +7,7 @@ import '@dxosTheme';
 import React from 'react';
 
 import { Button } from '@dxos/react-ui';
-import { focusRing, hoverColors, openOutline } from '@dxos/react-ui-theme';
+import { focusRing, hoverColors } from '@dxos/react-ui-theme';
 
 import { Popover } from './Popover';
 import { Avatar } from '../Avatar';
@@ -30,7 +30,7 @@ export const AvatarTrigger = {
         slots={{
           root: {
             tabIndex: 0,
-            classNames: ['shadow-md cursor-pointer rounded-md', hoverColors, focusRing, openOutline],
+            classNames: ['shadow-md cursor-pointer rounded-md', hoverColors, focusRing],
           },
         }}
         label={<span className='sr-only'>Open popover</span>}

--- a/packages/ui/react-appkit/src/components/Popover/Popover.tsx
+++ b/packages/ui/react-appkit/src/components/Popover/Popover.tsx
@@ -7,7 +7,7 @@ import * as PopoverPrimitive from '@radix-ui/react-popover';
 import { Button as ToolbarButtonItem } from '@radix-ui/react-toolbar';
 import React, { type ComponentProps, type ReactNode, useCallback, useState } from 'react';
 
-import { openOutline, focusRing, getSize, mx, ghostHover } from '@dxos/react-ui-theme';
+import { focusRing, getSize, mx, ghostHover } from '@dxos/react-ui-theme';
 
 export interface PopoverSlots {
   content?: Omit<ComponentProps<typeof PopoverPrimitive.Content>, 'children'>;
@@ -94,7 +94,7 @@ export const Popover = ({
       {...slots.trigger}
       onKeyUp={onKeyUp}
       data-keyupid='open'
-      className={mx(ghostHover, focusRing, openOutline, slots.trigger?.className)}
+      className={mx(ghostHover, focusRing, slots.trigger?.className)}
     >
       {openTrigger}
     </PopoverPrimitive.Trigger>

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItemHeading.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItemHeading.tsx
@@ -51,20 +51,17 @@ export const NavTreeItemHeading = forwardRef<HTMLButtonElement, NavTreeItemHeadi
         )}
       >
         {branch && (
-          <TreeItem.OpenTrigger asChild>
-            <Button
-              classNames='-translate-x-3 pli-1.5'
-              variant='ghost'
-              disabled={disabled}
-              data-testid={!open ? 'navtree.treeItem.openTrigger' : 'navtree.treeItem.closeTrigger'}
-              onKeyDown={(event) => {
-                if (event.key === ' ' || event.key === 'Enter') {
-                  event.stopPropagation();
-                }
-              }}
-            >
-              <OpenTriggerIcon className={mx('shrink-0 text-[--icons-color]', getSize(3))} />
-            </Button>
+          <TreeItem.OpenTrigger
+            classNames='-translate-x-3 pli-1.5'
+            disabled={disabled}
+            data-testid={!open ? 'navtree.treeItem.openTrigger' : 'navtree.treeItem.closeTrigger'}
+            onKeyDown={(event) => {
+              if (event.key === ' ' || event.key === 'Enter') {
+                event.stopPropagation();
+              }
+            }}
+          >
+            <OpenTriggerIcon className={mx('shrink-0 text-[--icons-color]', getSize(3))} />
           </TreeItem.OpenTrigger>
         )}
         <TreeItem.Heading data-testid='navtree.treeItem.heading' title={id} asChild>

--- a/packages/ui/react-ui-theme/src/styles/components/button.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/button.ts
@@ -9,23 +9,21 @@ import {
   hoverColors,
   coarseButtonDimensions,
   fineButtonDimensions,
-  openOutline,
   staticDisabled,
   focusRing,
   contentElevation,
   ghostHover,
 } from '../fragments';
 
-// TODO(burdon): Ghost styles should have no border (be really flat).
-
 export const primaryAppButtonColors =
-  'bg-primary-550 dark:bg-primary-550 text-white aria-pressed:bg-primary-500 dark:aria-pressed:bg-primary-500 aria-pressed:text-primary-100 aria-checked:bg-primary-500 dark:aria-checked:bg-primary-500 aria-checked:text-primary-100 hover:bg-primary-600 dark:hover:bg-primary-600 hover:text-white dark:hover:text-white';
+  'bg-primary-550 dark:bg-primary-550 text-white aria-pressed:bg-primary-500 dark:aria-pressed:bg-primary-500 aria-pressed:text-primary-100 data-[state=open]:bg-primary-500 dark:data-[state=open]:bg-primary-500 data-[state=open]:text-primary-100 aria-checked:bg-primary-500 dark:aria-checked:bg-primary-500 aria-checked:text-primary-100 hover:bg-primary-600 dark:hover:bg-primary-600 hover:text-white dark:hover:text-white';
+
 export const defaultAppButtonColors =
-  'bg-white aria-pressed:bg-primary-100 aria-checked:bg-primary-100 text-neutral-800 aria-pressed:text-primary-800 aria-checked:text-primary-800 dark:bg-neutral-800 dark:aria-pressed:bg-primary-700 dark:aria-checked:bg-primary-700 dark:text-neutral-50 dark:aria-pressed:text-primary-50 dark:aria-checked:text-primary-50';
-export const defaultOsButtonColors = 'bg-white/50 text-neutral-900 dark:bg-neutral-750/50 dark:text-neutral-50';
+  'text-neutral-800 dark:text-neutral-50 bg-white dark:bg-neutral-800 aria-pressed:text-primary-800 aria-pressed:bg-primary-100 dark:aria-pressed:text-primary-50 dark:aria-pressed:bg-primary-700 data-[state=open]:text-primary-800 data-[state=open]:bg-primary-100 dark:data-[state=open]:text-primary-50 dark:data-[state=open]:bg-primary-700 aria-checked:text-primary-800 aria-checked:bg-primary-100 dark:aria-checked:text-primary-50 dark:aria-checked:bg-primary-700';
+
 export const ghostButtonColors =
   ghostHover +
-  ' hover:text-inherit dark:hover:text-inherit aria-pressed:text-primary-800 aria-checked:text-primary-800 dark:aria-pressed:text-primary-100 dark:aria-checked:text-primary-100';
+  ' hover:text-inherit dark:hover:text-inherit aria-pressed:bg-neutral-450/5 dark:aria-pressed:bg-neutral-25/5 data-[state=open]:bg-neutral-450/5 dark:data-[state=open]:bg-neutral-25/5 aria-checked:bg-neutral-450/5 dark:aria-checked:bg-neutral-25/5';
 
 export type ButtonStyleProps = Partial<{
   inGroup?: boolean;
@@ -57,7 +55,6 @@ export const buttonRoot: ComponentFunction<ButtonStyleProps> = (props, ...etc) =
     resolvedVariant === 'outline' &&
       'text-neutral-700 border border-neutral-600 dark:border-neutral-300 dark:text-neutral-150',
     !props.disabled && focusRing,
-    openOutline,
     // Register all radix states
     'group',
     ...etc,

--- a/packages/ui/react-ui-theme/src/styles/components/list.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/list.ts
@@ -5,7 +5,7 @@
 import { type ComponentFunction, type Density, type Theme } from '@dxos/react-ui-types';
 
 import { mx } from '../../util';
-import { focusRing, densityBlockSize, getSize } from '../fragments';
+import { focusRing, densityBlockSize, getSize, ghostHover } from '../fragments';
 
 export type ListStyleProps = Partial<{
   density: Density;
@@ -27,7 +27,7 @@ export const listItemDragHandleIcon: ComponentFunction<ListStyleProps> = (_props
   mx(getSize(5), 'mbs-2.5', ...etc);
 
 export const listItemOpenTrigger: ComponentFunction<ListStyleProps> = ({ density }, ...etc) =>
-  mx('is-5 rounded flex justify-center items-center', densityBlockSize(density), focusRing, ...etc);
+  mx('is-5 rounded flex justify-center items-center', densityBlockSize(density), ghostHover, focusRing, ...etc);
 
 export const listItemOpenTriggerIcon: ComponentFunction<ListStyleProps> = (_props, ...etc) => {
   return mx(getSize(5), ...etc);

--- a/packages/ui/react-ui-theme/src/styles/components/popover.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/popover.ts
@@ -5,7 +5,7 @@
 import { type ComponentFunction, type Theme } from '@dxos/react-ui-types';
 
 import { mx } from '../../util';
-import { focusRing, surfaceElevation, popperMotion, groupSurface, groupArrow, groupBorder } from '../fragments';
+import { focusRing, surfaceElevation, popperMotion, groupSurface, groupArrow } from '../fragments';
 
 export type PopoverStyleProps = Partial<{
   constrainInline?: boolean;
@@ -21,15 +21,7 @@ export const popoverViewport: ComponentFunction<PopoverStyleProps> = ({ constrai
   );
 
 export const popoverContent: ComponentFunction<PopoverStyleProps> = (_props, ...etc) =>
-  mx(
-    'z-[30] rounded-xl',
-    popperMotion,
-    groupSurface,
-    groupBorder,
-    surfaceElevation({ elevation: 'group' }),
-    focusRing,
-    ...etc,
-  );
+  mx('z-[30] rounded-xl', popperMotion, groupSurface, surfaceElevation({ elevation: 'group' }), focusRing, ...etc);
 
 export const popoverArrow: ComponentFunction<PopoverStyleProps> = (_props, ...etc) => mx(groupArrow, ...etc);
 

--- a/packages/ui/react-ui-theme/src/styles/fragments/border.ts
+++ b/packages/ui/react-ui-theme/src/styles/fragments/border.ts
@@ -1,5 +1,0 @@
-//
-// Copyright 2023 DXOS.org
-//
-
-export const groupBorder = 'border border-neutral-100 dark:border-neutral-800';

--- a/packages/ui/react-ui-theme/src/styles/fragments/index.ts
+++ b/packages/ui/react-ui-theme/src/styles/fragments/index.ts
@@ -3,7 +3,6 @@
 //
 
 export * from './arrow';
-export * from './border';
 export * from './density';
 export * from './dimensions';
 export * from './disabled';
@@ -13,7 +12,6 @@ export * from './group';
 export * from './hover';
 export * from './layout';
 export * from './motion';
-export * from './open';
 export * from './ornament';
 export * from './shimmer';
 export * from './surface';

--- a/packages/ui/react-ui-theme/src/styles/fragments/open.ts
+++ b/packages/ui/react-ui-theme/src/styles/fragments/open.ts
@@ -1,6 +1,0 @@
-//
-// Copyright 2022 DXOS.org
-//
-
-export const openOutline =
-  'relative after:content-[""] after:absolute after:bg-primary-300 dark:after:bg-primary-400 after:opacity-0 after:transition-opacity after:duration-100 after:linear overflow-hidden after:rounded-be after:bs-[2px] after:block-end-0 after:inline-start-0 after:inline-end-0 data-[state=open]:after:opacity-100';

--- a/packages/ui/react-ui-theme/src/styles/fragments/surface.ts
+++ b/packages/ui/react-ui-theme/src/styles/fragments/surface.ts
@@ -17,6 +17,7 @@ export const fixedBorder = 'border-neutral-50 dark:border-neutral-800';
 
 // Cards, dialogs, other such groups.
 export const groupSurface = 'group-surface';
+export const groupBorder = 'border-neutral-50 dark:border-neutral-800';
 
 // Tooltips, popovers, menus, etc. – not dialogs.
 export const chromeSurface = 'chrome-surface';


### PR DESCRIPTION
Does what it says on the tin!

<img width="408" alt="Screenshot 2023-11-15 at 11 41 01" src="https://github.com/dxos/dxos/assets/855039/fc300ccc-ea5e-477a-9efa-330c8081ec85">

---

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 995391d</samp>

### Summary
🔄🎨♿

<!--
1.  🔄 - This emoji represents the refactoring of the `Button` component and the popover component style, as well as the removal of unused or redundant style fragments. It indicates that the code was reorganized or improved without changing its functionality.
2.  🎨 - This emoji represents the addition of the `groupBorder` fragment and the hover effect for the list item open trigger icon. It indicates that the code was enhanced with some visual or aesthetic changes.
3.  ♿ - This emoji represents the improvement of the accessibility of the `TreeItem.OpenTrigger` component by avoiding nested buttons. It indicates that the code was made more user-friendly or compliant with web standards.
-->
This pull request refactors and simplifies the styles for the `react-ui-theme` and `react-ui-navtree` packages. It removes unused or redundant style fragments, updates the button and list components to use a new state attribute, and improves the accessibility and consistency of the popover and tree item components.

> _Sing, O Muse, of the skillful coder who refined the style_
> _Of the tree and the popover, the button and the icon,_
> _And who removed the fragments that cluttered the theme file,_
> _Like a gardener who prunes the branches of a golden apple tree._

### Walkthrough
*  Simplify `NavTreeItemHeading` markup and improve accessibility by replacing nested `Button` component with `TreeItem.OpenTrigger` component ([link](https://github.com/dxos/dxos/pull/4718/files?diff=unified&w=0#diff-dcbc9cc2d3f71b67b0197651c6e34e224bc366eab90d35e6620c1ce81ac171ccL54-R64))
*  Remove unused `openOutline` and `defaultOsButtonColors` fragments from `button.ts` file ([link](https://github.com/dxos/dxos/pull/4718/files?diff=unified&w=0#diff-783c4b0b530888d53202c557c83f22a45064463343fc1ca87b6b0047921221a0L12), [link](https://github.com/dxos/dxos/pull/4718/files?diff=unified&w=0#diff-783c4b0b530888d53202c557c83f22a45064463343fc1ca87b6b0047921221a0L60))
*  Update button color fragments to use `data-[state=open]` attribute selector instead of `aria-pressed` and `aria-checked` selectors, to match new state management of `TreeItem.OpenTrigger` component ([link](https://github.com/dxos/dxos/pull/4718/files?diff=unified&w=0#diff-783c4b0b530888d53202c557c83f22a45064463343fc1ca87b6b0047921221a0L19-R26))
*  Add `ghostHover` fragment to `listItemOpenTrigger` function to provide hover effect for open trigger icon in list item ([link](https://github.com/dxos/dxos/pull/4718/files?diff=unified&w=0#diff-891d58bedfab1feca621d8ba0abb99553cb004aeabfe93258fc752240b4c2fb9L8-R8), [link](https://github.com/dxos/dxos/pull/4718/files?diff=unified&w=0#diff-891d58bedfab1feca621d8ba0abb99553cb004aeabfe93258fc752240b4c2fb9L30-R30))
*  Remove redundant `groupBorder` fragment from `popover.ts` file and `popoverContent` function, as it is already applied by `groupSurface` fragment ([link](https://github.com/dxos/dxos/pull/4718/files?diff=unified&w=0#diff-b4297d3575f54debc9c3cf617c780886a93c6bf27399bda8dbd9ba1ae5df5553L8-R8), [link](https://github.com/dxos/dxos/pull/4718/files?diff=unified&w=0#diff-b4297d3575f54debc9c3cf617c780886a93c6bf27399bda8dbd9ba1ae5df5553L24-R24))
*  Move `groupBorder` fragment from `border.ts` file to `surface.ts` file, as it is a common style for surfaces with a border ([link](https://github.com/dxos/dxos/pull/4718/files?diff=unified&w=0#diff-7ce96a0d48174719ffb04e32d57778b9bf61c1d05ea2dbdf6d6ed94c5e35e2bcR20), [link](https://github.com/dxos/dxos/pull/4718/files?diff=unified&w=0#diff-b7fd4095f6d85dbb0af9cb8ac61355703283d45262f096441e556bae74754493))
*  Delete `border.ts` and `open.ts` files from `fragments` folder, as they are no longer used by any component ([link](https://github.com/dxos/dxos/pull/4718/files?diff=unified&w=0#diff-0820d9e9f0a37a87c5d564521ad049891037568edcbae64b7e98de8cae9b6e71L6), [link](https://github.com/dxos/dxos/pull/4718/files?diff=unified&w=0#diff-0820d9e9f0a37a87c5d564521ad049891037568edcbae64b7e98de8cae9b6e71L16), [link](https://github.com/dxos/dxos/pull/4718/files?diff=unified&w=0#diff-326450190264a554bdb71cbb3652ab67591014bd8ba93b65a34910897149acbe))


