### PR TITLE
fix: log severity

### DIFF
--- a/packages/core/mesh/teleport-extension-replicator/src/replicator-extension.ts
+++ b/packages/core/mesh/teleport-extension-replicator/src/replicator-extension.ts
@@ -264,7 +264,8 @@ export class ReplicatorExtension implements TeleportExtension {
         return;
       }
 
-      log.warn('replication stream error', { err, info });
+      // TODO(nf): WARN on first error?
+      log.info('replication stream error', { err, info });
     });
 
     this._streams.set(info.feedKey, {

--- a/packages/core/mesh/teleport/src/muxing/balancer.ts
+++ b/packages/core/mesh/teleport/src/muxing/balancer.ts
@@ -77,7 +77,7 @@ export class Balancer {
 
   destroy() {
     if (this._sendBuffers.size !== 0) {
-      log.warn('destroying balancer with pending calls');
+      log.info('destroying balancer with pending calls');
     }
     this._sendBuffers.clear();
     this._framer.destroy();

--- a/packages/core/mesh/teleport/src/muxing/framer.ts
+++ b/packages/core/mesh/teleport/src/muxing/framer.ts
@@ -137,7 +137,7 @@ export class Framer {
   destroy() {
     // TODO(dmaretskyi): Call stream.end() instead?
     if (this._stream.readableLength > 0) {
-      log.warn('framer destroyed while there are still read bytes in the buffer.');
+      log.info('framer destroyed while there are still read bytes in the buffer.');
     }
     if (this._stream.writableLength > 0) {
       log.warn('framer destroyed while there are still write bytes in the buffer.');


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 05b3629</samp>

### Summary
📉🔄🎚️

<!--
1.  📉 - This emoji can be used to represent the log level change from warn to info, as it suggests a decrease in severity or importance.
2.  🔄 - This emoji can be used to represent the replication stream, as it suggests a cyclic or continuous process of data transfer or synchronization.
3.  🎚️ - This emoji can be used to represent the balancer and the framer, as they both involve adjusting or regulating some aspect of the communication, such as the distribution of calls or the format of messages.
-->
Lowered the log level of some non-critical messages in the `teleport` and `teleport-extension-replicator` packages. These messages are related to stream errors, balancer destruction, and framer destruction, and do not indicate major failures or bugs.

> _`replicator` errs_
> _log level lowered to info_
> _autumn of warnings_

### Walkthrough
*  Lowered the log level of some messages that are not critical or expected in the teleport and replicator extensions ([link](https://github.com/dxos/dxos/pull/4723/files?diff=unified&w=0#diff-2f9395f42d440a09c4fabb6ee3ff80d21d8a62497e8d8ec8883a43c2b1a3a8d9L267-R268), [link](https://github.com/dxos/dxos/pull/4723/files?diff=unified&w=0#diff-0e09ceb6178d7900eed47073b84ac4dca53d5a48851fba05440f6e8e08c681a7L80-R80), [link](https://github.com/dxos/dxos/pull/4723/files?diff=unified&w=0#diff-f67b857af489bd83b17ccd9855ddde7a08c34df9a6485adb4cff8c5212cf5150L140-R140)).


