### PR TITLE
test(gravity): Run available specs in browser

### DIFF
--- a/packages/gravity/kube-testing/project.json
+++ b/packages/gravity/kube-testing/project.json
@@ -15,19 +15,6 @@
         "{options.outputPath}"
       ]
     },
-    "lint": {
-      "executor": "@nx/linter:eslint",
-      "options": {
-        "format": "unix",
-        "lintFilePatterns": [
-          "packages/gravity/kube-testing/**/*.{ts,tsx,js,jsx}"
-        ],
-        "quiet": true
-      },
-      "outputs": [
-        "{options.outputFile}"
-      ]
-    },
     "e2e": {
       "executor": "@dxos/test:run",
       "options": {
@@ -48,6 +35,19 @@
         "{options.coveragePath}",
         "{options.outputPath}",
         "{options.resultsPath}"
+      ]
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "options": {
+        "format": "unix",
+        "lintFilePatterns": [
+          "packages/gravity/kube-testing/**/*.{ts,tsx,js,jsx}"
+        ],
+        "quiet": true
+      },
+      "outputs": [
+        "{options.outputFile}"
       ]
     }
   }

--- a/packages/gravity/kube-testing/src/plan/env/websocket-redis-proxy.ts
+++ b/packages/gravity/kube-testing/src/plan/env/websocket-redis-proxy.ts
@@ -76,7 +76,8 @@ export class WebSocketRedisProxy {
       });
 
       ws.on('error', (err: Error) => {
-        log.error('REDIS proxy WebSocket connection error', { err });
+        // Not critical error.
+        log('REDIS proxy WebSocket connection error', { err });
         void ctx.dispose();
       });
 

--- a/packages/gravity/kube-testing/src/plan/env/websocket-redis-proxy.ts
+++ b/packages/gravity/kube-testing/src/plan/env/websocket-redis-proxy.ts
@@ -3,7 +3,7 @@
 //
 
 import type WebSocket from 'isomorphic-ws';
-import { createConnection, type NetConnectOpts } from 'node:net';
+import { createConnection, type NetConnectOpts, type Socket } from 'node:net';
 import { type Duplex } from 'node:stream';
 import { createServer, type Server, type WebSocketDuplex } from 'websocket-stream';
 
@@ -36,6 +36,7 @@ export const DEFAULT_REDIS_TCP_CONNECTION: NetConnectOpts = {
 
 export class WebSocketRedisProxy {
   private readonly _ctx = new Context();
+  private readonly _connections = new Set<{ ws: WebSocketDuplex; tcp: Socket }>();
 
   /**
    * WebSocket server to enable connection from playwright browser.
@@ -50,37 +51,50 @@ export class WebSocketRedisProxy {
   constructor(private readonly _params?: WebSocketRedisProxyParams) {
     this._wsServer = createServer(this._params?.websocketServer ?? DEFAULT_WEBSOCKET);
     this._wsServer.on('stream', (ws) => {
-      log.info('New WebSocket connection');
-      ws.on('error', (err) => {
-        log.error('REDIS proxy WebSocket connection error', { err });
-      });
+      log('New WebSocket connection');
+      const ctx = this._ctx.derive();
 
       /**
        * TCP stream to Redis server.
        */
       const stream = createConnection(this._params?.redisTCPConnection ?? DEFAULT_REDIS_TCP_CONNECTION);
-      this._ctx.onDispose(() => {
-        stream.destroy();
-      });
 
       stream.once('ready', () => {
-        log.info('TCP connection ready');
-        runInContext(this._ctx, () => this._pipeStreams(ws, stream));
+        log('TCP connection ready');
+        runInContext(ctx, () => this._pipeStreams(ctx, ws, stream));
+      });
+
+      const connection = { ws, tcp: stream };
+      this._connections.add(connection);
+
+      ctx.onDispose(() => {
+        ws.removeAllListeners();
+        stream.removeAllListeners();
+        ws.destroy();
+        stream.destroy();
+        this._connections.delete(connection);
+      });
+
+      ws.on('error', (err: Error) => {
+        log.error('REDIS proxy WebSocket connection error', { err });
+        void ctx.dispose();
       });
 
       stream.on('error', (err) => {
         log.error('REDIS proxy TCP connection error', { err });
+        void ctx.dispose();
       });
     });
   }
 
   async destroy() {
     this._wsServer.close();
+    await this._ctx.dispose();
   }
 
-  private _pipeStreams(first: Duplex, second: Duplex) {
+  private _pipeStreams(ctx: Context, first: Duplex, second: Duplex) {
     first.pipe(second).pipe(first);
-    this._ctx.onDispose(() => {
+    ctx.onDispose(() => {
       first.unpipe(second).unpipe(first);
     });
   }

--- a/packages/gravity/kube-testing/src/plan/run-agent.ts
+++ b/packages/gravity/kube-testing/src/plan/run-agent.ts
@@ -55,7 +55,7 @@ const initLogProcessor = <S, C>(params: AgentParams<S, C>) => {
   } else {
     // NOTE: `dxgravity_log` is being exposed by playwright `.exposeFunction()` API. Log chattiness can cause playwright connection overload so we limit it to only trace logs and info and above.
     log.addProcessor((config, entry) => {
-      if (entry.level === LogLevel.TRACE || entry.level > LogLevel.INFO) {
+      if (entry.level === LogLevel.TRACE || entry.level >= LogLevel.INFO) {
         (window as any).dxgravity_log?.(config, entry);
       }
     });

--- a/packages/gravity/kube-testing/src/plan/run-agent.ts
+++ b/packages/gravity/kube-testing/src/plan/run-agent.ts
@@ -53,8 +53,12 @@ const initLogProcessor = <S, C>(params: AgentParams<S, C>) => {
       }),
     );
   } else {
-    // NOTE: `dxgravity_log` is being exposed by playwright `.exposeFunction()` API.
-    log.addProcessor((config, entry) => (window as any).dxgravity_log?.(config, entry));
+    // NOTE: `dxgravity_log` is being exposed by playwright `.exposeFunction()` API. Log chattiness can cause playwright connection overload so we limit it to only trace logs and info and above.
+    log.addProcessor((config, entry) => {
+      if (entry.level === LogLevel.TRACE || entry.level > LogLevel.INFO) {
+        (window as any).dxgravity_log?.(config, entry);
+      }
+    });
   }
 };
 

--- a/packages/gravity/kube-testing/src/plan/run-plan.ts
+++ b/packages/gravity/kube-testing/src/plan/run-plan.ts
@@ -150,8 +150,8 @@ const runPlanner = async <S, C>(name: string, { plan, spec, options }: RunPlanPa
 
       const { result, kill } =
         agentParams.runtime.platform === 'nodejs'
-          ? await runNode(name, agentParams, options)
-          : await runBrowser(name, agentParams, options);
+          ? runNode(name, agentParams, options)
+          : runBrowser(name, agentParams, options);
       killCallbacks.push(kill);
       promises.push(
         result.then((result) => {

--- a/packages/gravity/kube-testing/src/plan/run-process.ts
+++ b/packages/gravity/kube-testing/src/plan/run-process.ts
@@ -103,6 +103,7 @@ export const runBrowser = <S, C>(
   const ctx = new Context();
 
   scheduleMicroTask(ctx, async () => {
+    const start = Date.now();
     invariant(agentParams.runtime.platform);
 
     const { page, context } = await getNewBrowserContext(agentParams.runtime.platform, { headless: true });
@@ -170,6 +171,11 @@ export const runBrowser = <S, C>(
 
     const port = (server.address() as AddressInfo).port;
     await page.goto(`http://localhost:${port}`);
+
+    log.info('browser started and page loaded', {
+      agentIdx: agentParams.agentIdx,
+      time: Date.now() - start,
+    });
   });
 
   return {

--- a/packages/gravity/kube-testing/src/plan/run-process.ts
+++ b/packages/gravity/kube-testing/src/plan/run-process.ts
@@ -105,7 +105,7 @@ export const runBrowser = <S, C>(
   scheduleMicroTask(ctx, async () => {
     invariant(agentParams.runtime.platform);
 
-    const { page, context } = await getNewBrowserContext(agentParams.runtime.platform, { headless: false });
+    const { page, context } = await getNewBrowserContext(agentParams.runtime.platform, { headless: true });
     ctx.onDispose(async () => {
       await page.close();
       await context.close();

--- a/packages/gravity/kube-testing/src/plan/run-process.ts
+++ b/packages/gravity/kube-testing/src/plan/run-process.ts
@@ -105,7 +105,7 @@ export const runBrowser = <S, C>(
   scheduleMicroTask(ctx, async () => {
     invariant(agentParams.runtime.platform);
 
-    const { page, context } = await getNewBrowserContext(agentParams.runtime.platform, { headless: true });
+    const { page, context } = await getNewBrowserContext(agentParams.runtime.platform, { headless: false });
     ctx.onDispose(async () => {
       await page.close();
       await context.close();
@@ -119,6 +119,7 @@ export const runBrowser = <S, C>(
     const apis: EposedApis = {
       dxgravity_done: (code) => {
         doneTrigger.wake(code);
+        void ctx.dispose();
       },
       // Expose log hook for playwright.
       dxgravity_log: (config, entry) => {
@@ -161,6 +162,10 @@ export const runBrowser = <S, C>(
         contentType: 'text/javascript',
         data: await readFile(join(agentParams.planRunDir, 'browser.js'), 'utf8'),
       },
+    });
+
+    ctx.onDispose(() => {
+      server.close();
     });
 
     const port = (server.address() as AddressInfo).port;

--- a/packages/gravity/kube-testing/src/spec/echo.ts
+++ b/packages/gravity/kube-testing/src/spec/echo.ts
@@ -20,7 +20,7 @@ import { TransportKind } from '@dxos/network-manager';
 import { TextKind } from '@dxos/protocols/proto/dxos/echo/model/text';
 import { StorageType, createStorage } from '@dxos/random-access-storage';
 import { Timeframe } from '@dxos/timeframe';
-import { randomInt, range } from '@dxos/util';
+import { isNode, randomInt, range } from '@dxos/util';
 
 import { type SerializedLogEntry, getReader, BORDER_COLORS, renderPNG, showPNG } from '../analysys';
 import {
@@ -138,7 +138,7 @@ export class EchoTestPlan implements TestPlan<EchoTestSpec, EchoAgentConfig> {
     this.builder.storage = !spec.withReconnects
       ? createStorage({ type: StorageType.RAM })
       : createStorage({
-          type: StorageType.NODE,
+          type: isNode() ? StorageType.NODE : StorageType.WEBFS,
           root: `/tmp/dxos/gravity/${env.params.testId}/${env.params.agentId}`,
         });
     await this._init(env);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a60aaf9</samp>

### Summary
🚀🧹🛠️

<!--
1.  🚀 - This emoji represents the change to limit the log entries sent to the playwright exposed function, as it improves the performance and stability of the agent communication.
2.  🧹 - This emoji represents the change to remove the async and await keywords from the runPlanner function, as it cleans up the code and avoids unnecessary complexity.
3.  🛠️ - This emoji represents the changes to the linting configuration, the run-process.ts file, and the echo test plan, as they are all related to fixing or improving some aspects of the code or the testing functionality.
-->
This pull request improves the `gravity/kube-testing` package by aligning the linting configuration, refactoring the browser agent execution, updating the echo test plan, and optimizing the log processing and the runPlanner function. These changes aim to enhance the code quality, readability, and performance of the test framework.

> _Oh we are the brave coders of the `gravity` crew_
> _We run our agents in the browser and the Node.js too_
> _We limit logs and lint our code and refactor as we go_
> _And we heave ho on the count of three to make our test plans flow_

### Walkthrough
*  Simplify and optimize the run-process.ts file by removing unnecessary async/await keywords ([link](https://github.com/dxos/dxos/pull/4725/files?diff=unified&w=0#diff-658b0da483ec1b73d11d587fa81c489bee16c067d328e9816ee1f082b1eee5f0L153-R154), [link](https://github.com/dxos/dxos/pull/4725/files?diff=unified&w=0#diff-c0be25e2a4dd1ed0123e6479bfb09e39fff12a9dc1d2a1c737a3adaa71aa33ebL32-R37)), using a context and microtask approach for running browser agents ([link](https://github.com/dxos/dxos/pull/4725/files?diff=unified&w=0#diff-c0be25e2a4dd1ed0123e6479bfb09e39fff12a9dc1d2a1c737a3adaa71aa33ebL12-R15), [link](https://github.com/dxos/dxos/pull/4725/files?diff=unified&w=0#diff-c0be25e2a4dd1ed0123e6479bfb09e39fff12a9dc1d2a1c737a3adaa71aa33ebL96-R138), [link](https://github.com/dxos/dxos/pull/4725/files?diff=unified&w=0#diff-c0be25e2a4dd1ed0123e6479bfb09e39fff12a9dc1d2a1c737a3adaa71aa33ebL143-R175), [link](https://github.com/dxos/dxos/pull/4725/files?diff=unified&w=0#diff-c0be25e2a4dd1ed0123e6479bfb09e39fff12a9dc1d2a1c737a3adaa71aa33ebL164-R183)), and logging browser agent entries to both file and console ([link](https://github.com/dxos/dxos/pull/4725/files?diff=unified&w=0#diff-c0be25e2a4dd1ed0123e6479bfb09e39fff12a9dc1d2a1c737a3adaa71aa33ebL96-R138)).


