### PR TITLE
fix: improve graceful close behavior

### DIFF
--- a/packages/core/mesh/teleport/src/muxing/muxer.ts
+++ b/packages/core/mesh/teleport/src/muxing/muxer.ts
@@ -338,7 +338,7 @@ export class Muxer {
 
   private async _handleCommand(cmd: Command) {
     if (this._disposed) {
-      log.warn('Received command after destroy', { cmd });
+      log.warn('Received command after disposed', { cmd });
       return;
     }
 
@@ -384,6 +384,10 @@ export class Muxer {
   }
 
   private async _sendCommand(cmd: Command, channelId = -1, timeout = DEFAULT_SEND_COMMAND_TIMEOUT) {
+    if (this._disposed) {
+      log.info('ignoring sendCommand after disposed', { cmd });
+      return;
+    }
     try {
       const trigger = new Trigger<void>();
       this._balancer.pushData(Command.encode(cmd), trigger, channelId);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f251c8a</samp>

### Summary
🐛📝🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is appropriate for improving the error handling of the `Muxer` class and avoiding sending commands to disposed instances, which could have caused unexpected behavior or crashes.
2.  📝 - This emoji represents documentation, which is appropriate for improving the logging of the `Muxer` class, which could help with debugging and understanding the code.
3.  🚀 - This emoji represents a performance improvement, which is appropriate for avoiding unnecessary network traffic and resource consumption by not sending commands to disposed `Muxer` instances, which could have improved the efficiency and speed of the teleport package.
-->
Enhanced the reliability and debuggability of the `Muxer` class in the `teleport` package. Prevented potential memory leaks and crashes by avoiding sending commands to disposed `Muxer` instances.

> _The `Muxer` class had a flaw_
> _It logged errors with too much awe_
> _So they added a check_
> _To avoid a wreck_
> _When sending commands to a straw_

### Walkthrough
*  Prevent sending commands to disposed muxers ([link](https://github.com/dxos/dxos/pull/4728/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R387-R390))
*  Update log message to use 'disposed' instead of 'destroy' ([link](https://github.com/dxos/dxos/pull/4728/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66L341-R341))


