### PR TITLE
chore: revert migrations in effect, causing signals cycles

### DIFF
--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -198,12 +198,8 @@ export const SpacePlugin = ({ onFirstRun }: SpacePluginOptions = {}): PluginDefi
         client.spaces.subscribe((spaces) => {
           spaceSubscriptions.clear();
           spaces.forEach((space) => {
-            spaceSubscriptions.add(
-              effect(() => {
-                introduceRootSpaceFolder(space);
-                combineAndCleanupMultipleRootSpaceFolders(space);
-              }),
-            );
+            introduceRootSpaceFolder(space);
+            combineAndCleanupMultipleRootSpaceFolders(space);
 
             spaceSubscriptions.add(
               space.listen('viewing', (message) => {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 39f9468</samp>

### Summary
🚫🧹🐛

<!--
1.  🚫 The no entry sign emoji, which can mean "stop", "prohibited", or "do not". This emoji conveys that the `effect` function call was removed or deleted from the code.
2.  🧹 The broom emoji, which can mean "clean", "tidy", or "sweep". This emoji conveys that the code was simplified and the memory leak was avoided by removing the `effect` function call.
3.  🐛 The bug emoji, which can mean "error", "fault", or "fix". This emoji conveys that the potential bugs caused by the `effect` function call were prevented or resolved by removing it from the code.
-->
Removed unnecessary and leaky `effect` function call from `SpacePlugin.tsx`. This improves the performance and reliability of the space plugin.

> _`effect` function_
> _removed from space subscription_
> _no more memory leaks_

### Walkthrough
* Remove unnecessary and leaky side effect function from `spaceSubscriptions.add` method ([link](https://github.com/dxos/dxos/pull/4730/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L201-R202)). This simplifies the code and avoids potential errors and leaks when the space object changes. The `SpacePlugin.tsx` file handles the space object changes with the `introduceRootSpaceFolder` and `combineAndCleanupMultipleRootSpaceFolders` functions.


