### PR TITLE
fix(react-ui-theme): Define and apply `topbar-size`

### DIFF
--- a/packages/apps/plugins/plugin-chess/src/components/ChessMain.tsx
+++ b/packages/apps/plugins/plugin-chess/src/components/ChessMain.tsx
@@ -8,7 +8,7 @@ import React, { useEffect, useState } from 'react';
 import { Chessboard, type ChessModel, type ChessMove, type Game } from '@dxos/chess-app';
 import { invariant } from '@dxos/invariant';
 import { Main } from '@dxos/react-ui';
-import { baseSurface, coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
+import { baseSurface, topbarBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
 
 export const ChessMain = ({ game }: { game: Game }) => {
   const [model, setModel] = useState<ChessModel>();
@@ -37,7 +37,7 @@ export const ChessMain = ({ game }: { game: Game }) => {
   }
 
   return (
-    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, coarseBlockPaddingStart]}>
+    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart]}>
       <div className='flex grow justify-center items-center md:m-8'>
         <div className='flex md:min-w-[600px] md:min-h-[600px]'>
           <Chessboard model={model} onUpdate={handleUpdate} />

--- a/packages/apps/plugins/plugin-debug/src/components/DebugPanel.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DebugPanel.tsx
@@ -7,12 +7,12 @@ import React, { type FC, type PropsWithChildren, type ReactNode } from 'react';
 
 import { useConfig } from '@dxos/react-client';
 import { DensityProvider, Main } from '@dxos/react-ui';
-import { baseSurface, coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
+import { baseSurface, topbarBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
 
 export const DebugPanel: FC<PropsWithChildren<{ menu: ReactNode }>> = ({ menu, children }) => {
   const config = useConfig();
   return (
-    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, coarseBlockPaddingStart]}>
+    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart]}>
       <div className='flex shrink-0 p-2 space-x-2'>
         <DensityProvider density='fine'>{menu}</DensityProvider>
       </div>

--- a/packages/apps/plugins/plugin-debug/src/components/DevtoolsMain.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DevtoolsMain.tsx
@@ -7,13 +7,13 @@ import React from 'react';
 import { Devtools } from '@dxos/devtools';
 import { type ClientServices, useClient } from '@dxos/react-client';
 import { Main } from '@dxos/react-ui';
-import { baseSurface, coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
+import { baseSurface, topbarBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
 
 export const DevtoolsMain = () => {
   const client = useClient();
 
   return (
-    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, coarseBlockPaddingStart]}>
+    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart]}>
       <Devtools client={client} services={client.services.services as ClientServices} />
     </Main.Content>
   );

--- a/packages/apps/plugins/plugin-explorer/src/components/ExplorerMain.tsx
+++ b/packages/apps/plugins/plugin-explorer/src/components/ExplorerMain.tsx
@@ -8,7 +8,7 @@ import { useSearch } from '@braneframe/plugin-search';
 import { type View } from '@braneframe/types';
 import { getSpaceForObject } from '@dxos/react-client/echo';
 import { Main } from '@dxos/react-ui';
-import { baseSurface, coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
+import { baseSurface, topbarBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
 
 import { Explorer } from './Explorer';
 
@@ -20,7 +20,7 @@ export const ExplorerMain = ({ view }: { view: View }) => {
   }
 
   return (
-    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, coarseBlockPaddingStart]}>
+    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart]}>
       <Explorer space={space} match={match} />
     </Main.Content>
   );

--- a/packages/apps/plugins/plugin-grid/src/components/GridMain.tsx
+++ b/packages/apps/plugins/plugin-grid/src/components/GridMain.tsx
@@ -14,7 +14,7 @@ import {
   type MosaicTileAction,
   type Position,
 } from '@dxos/react-ui-mosaic';
-import { baseSurface, coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
+import { baseSurface, topbarBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
 
 import { colors, getObject, GridCard } from './GridCard';
 
@@ -73,7 +73,7 @@ export const GridMain: FC<{ grid: GridType }> = ({ grid }) => {
 
   // TODO(burdon): Accessor to get card values.
   return (
-    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, coarseBlockPaddingStart]}>
+    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart]}>
       <Grid
         id='grid' // TODO(burdon): Namespace.
         items={grid.items}

--- a/packages/apps/plugins/plugin-ipfs/src/components/FileMain.tsx
+++ b/packages/apps/plugins/plugin-ipfs/src/components/FileMain.tsx
@@ -8,7 +8,7 @@ import urlJoin from 'url-join';
 import { type TypedObject } from '@dxos/client/echo';
 import { type Config, useConfig } from '@dxos/react-client';
 import { Main } from '@dxos/react-ui';
-import { baseSurface, coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
+import { baseSurface, topbarBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
 
 import { FilePreview } from './FilePreview';
 
@@ -27,7 +27,7 @@ export const FileMain: FC<{ file: TypedObject }> = ({ file }) => {
   const url = getIpfsUrl(config, file.cid);
 
   return (
-    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, coarseBlockPaddingStart]}>
+    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart]}>
       <FilePreview type={file.type} url={url} />
     </Main.Content>
   );

--- a/packages/apps/plugins/plugin-kanban/src/components/KanbanMain.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/components/KanbanMain.tsx
@@ -7,7 +7,7 @@ import React, { type FC } from 'react';
 import { Kanban as KanbanType } from '@braneframe/types';
 import { getSpaceForObject } from '@dxos/react-client/echo';
 import { Main } from '@dxos/react-ui';
-import { coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
+import { topbarBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
 
 import { KanbanBoard } from './KanbanBoard';
 import { type KanbanModel } from '../types';
@@ -28,7 +28,7 @@ export const KanbanMain: FC<{ kanban: KanbanType }> = ({ kanban }) => {
   };
 
   return (
-    <Main.Content classNames={[fixedInsetFlexLayout, coarseBlockPaddingStart]}>
+    <Main.Content classNames={[fixedInsetFlexLayout, topbarBlockPaddingStart]}>
       <KanbanBoard model={model} />
     </Main.Content>
   );

--- a/packages/apps/plugins/plugin-layout/src/components/MainLayout.tsx
+++ b/packages/apps/plugins/plugin-layout/src/components/MainLayout.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import { Surface } from '@dxos/app-framework';
 import { Button, Main, Dialog, useTranslation, DensityProvider, Popover } from '@dxos/react-ui';
-import { baseSurface, coarseBlockSize, fixedInsetFlexLayout, getSize, mx } from '@dxos/react-ui-theme';
+import { baseSurface, fixedInsetFlexLayout, getSize, mx } from '@dxos/react-ui-theme';
 
 import { ContentFallback } from './ContentFallback';
 import { Fallback } from './Fallback';
@@ -71,7 +71,7 @@ export const MainLayout = ({ fullscreen, showComplementarySidebar = true }: Main
         {/* Top (header) bar. */}
         <Main.Content classNames={['fixed inset-inline-0 block-start-0 z-[1]', baseSurface]} asChild>
           <div aria-label={t('main header label')} role='none'>
-            <div role='none' className={mx('flex gap-1 p-1', coarseBlockSize)}>
+            <div role='none' className={'flex gap-1 p-1 bs-[--topbar-size]'}>
               <DensityProvider density='coarse'>
                 <Button
                   onClick={() => (context.sidebarOpen = !context.sidebarOpen)}

--- a/packages/apps/plugins/plugin-map/src/components/MapMain.tsx
+++ b/packages/apps/plugins/plugin-map/src/components/MapMain.tsx
@@ -7,13 +7,13 @@ import { MapContainer } from 'react-leaflet';
 
 import { type TypedObject } from '@dxos/react-client/echo';
 import { Main } from '@dxos/react-ui';
-import { baseSurface, coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
+import { baseSurface, topbarBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
 
 import { MapControl } from './MapControl';
 
 export const MapMain: FC<{ map: TypedObject }> = ({ map }) => {
   return (
-    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, coarseBlockPaddingStart]}>
+    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart]}>
       <MapContainer className='flex-1 w-full h-screen border-t border-neutral-200 dark:border-neutral-800'>
         <MapControl />
       </MapContainer>

--- a/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/StandaloneLayout.tsx
@@ -6,7 +6,7 @@ import React, { type MutableRefObject, type PropsWithChildren } from 'react';
 
 import { Main } from '@dxos/react-ui';
 import { type EditorModel, type MarkdownEditorRef } from '@dxos/react-ui-editor';
-import { baseSurface, coarseBlockPaddingStart, mx, textBlockWidth } from '@dxos/react-ui-theme';
+import { baseSurface, topbarBlockPaddingStart, mx, textBlockWidth } from '@dxos/react-ui-theme';
 
 import { type MarkdownProperties } from '../types';
 
@@ -19,11 +19,12 @@ export const StandaloneLayout = ({
   editorRef?: MutableRefObject<MarkdownEditorRef>;
 }>) => {
   return (
-    <Main.Content bounce classNames={[baseSurface, coarseBlockPaddingStart]}>
+    <Main.Content bounce classNames={[baseSurface, topbarBlockPaddingStart]}>
       <div role='none' className={mx(textBlockWidth, 'pli-2')}>
-        <div role='none' className={mx('mbs-4 mbe-6', 'min-bs-[calc(100dvh-5rem)] flex flex-col')}>
+        <div role='none' className={mx('pbs-4 pbe-6', 'min-bs-[calc(100dvh-var(--topbar-size))] flex flex-col')}>
           {children}
         </div>
+        <div role='none' className='bs-[50dvh]' />
       </div>
     </Main.Content>
   );

--- a/packages/apps/plugins/plugin-navtree/src/components/TreeViewContainer.tsx
+++ b/packages/apps/plugins/plugin-navtree/src/components/TreeViewContainer.tsx
@@ -180,7 +180,7 @@ export const TreeViewContainer = ({
         <DensityProvider density='coarse'>
           {identity && (
             <>
-              <div role='none' className='shrink-0 flex items-center gap-1 pis-3 pie-1 plb-1'>
+              <div role='none' className='shrink-0 flex items-center gap-1 pis-3 pie-1 plb-1 bs-[--topbar-size]'>
                 <HaloButton
                   size={6}
                   identityKey={identity?.identityKey.toHex()}

--- a/packages/apps/plugins/plugin-presenter/src/components/PresenterMain.tsx
+++ b/packages/apps/plugins/plugin-presenter/src/components/PresenterMain.tsx
@@ -8,7 +8,7 @@ import { useLayout } from '@braneframe/plugin-layout';
 import { type Stack as StackType } from '@braneframe/types';
 import { LayoutAction, Surface, useIntent } from '@dxos/app-framework';
 import { Main } from '@dxos/react-ui';
-import { baseSurface, coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
+import { baseSurface, topbarBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
 
 import { Layout, PageNumber, Pager, StartButton } from './Presenter';
 import { PRESENTER_PLUGIN } from '../meta';
@@ -39,7 +39,7 @@ export const PresenterMain: FC<{ stack: StackType }> = ({ stack }) => {
   };
 
   return (
-    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, !fullscreen && coarseBlockPaddingStart]}>
+    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, !fullscreen && topbarBlockPaddingStart]}>
       <Layout
         topRight={<StartButton running={running} onClick={(running) => handleSetRunning(running)} />}
         bottomRight={<PageNumber index={slide} count={stack.sections.length} />}

--- a/packages/apps/plugins/plugin-script/src/components/ScriptMain.tsx
+++ b/packages/apps/plugins/plugin-script/src/components/ScriptMain.tsx
@@ -9,7 +9,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { type TextObject } from '@dxos/client/echo';
 import { Main, Button, DensityProvider, ToggleGroup, ToggleGroupItem, Toolbar, useThemeContext } from '@dxos/react-ui';
-import { baseSurface, coarseBlockPaddingStart, fixedInsetFlexLayout, getSize, mx } from '@dxos/react-ui-theme';
+import { baseSurface, topbarBlockPaddingStart, fixedInsetFlexLayout, getSize, mx } from '@dxos/react-ui-theme';
 import { type YText } from '@dxos/text-model';
 
 import { FrameContainer } from './FrameContainer';
@@ -30,7 +30,7 @@ export type ScriptMainProps = {
 
 export const ScriptMain = (props: ScriptMainProps) => {
   return (
-    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, coarseBlockPaddingStart]}>
+    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart]}>
       <ScriptSection {...props} />
     </Main.Content>
   );

--- a/packages/apps/plugins/plugin-sketch/src/components/Sketch.tsx
+++ b/packages/apps/plugins/plugin-sketch/src/components/Sketch.tsx
@@ -9,7 +9,7 @@ import { useResizeDetector } from 'react-resize-detector';
 import { type Sketch as SketchType } from '@braneframe/types';
 import { debounce } from '@dxos/async';
 import { Main, useThemeContext } from '@dxos/react-ui';
-import { baseSurface, coarseBlockPaddingStart, fixedInsetFlexLayout, mx } from '@dxos/react-ui-theme';
+import { baseSurface, topbarBlockPaddingStart, fixedInsetFlexLayout, mx } from '@dxos/react-ui-theme';
 
 // TODO(burdon): Vite config: https://github.com/tldraw/examples/tree/main/tldraw-vite-example
 // TODO(burdon): Self-hosted: https://docs.tldraw.dev/usage#Self-hosting-static-assets
@@ -111,7 +111,7 @@ export const SketchComponent: FC<SketchComponentProps> = ({ sketch, autoZoom, ma
 
 export const SketchMain: FC<SketchComponentProps> = (props) => {
   return (
-    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, coarseBlockPaddingStart]}>
+    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart]}>
       <SketchComponent {...props} />{' '}
     </Main.Content>
   );

--- a/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
@@ -11,7 +11,7 @@ import { type TypedObject, getSpaceForObject, isTypedObject, useQuery } from '@d
 import { Main, Button, useTranslation, DropdownMenu, ButtonGroup } from '@dxos/react-ui';
 import { Path, type MosaicDropEvent, type MosaicMoveEvent } from '@dxos/react-ui-mosaic';
 import { Stack, type StackSectionItem } from '@dxos/react-ui-stack';
-import { baseSurface, chromeSurface, coarseBlockPaddingStart, getSize, surfaceElevation } from '@dxos/react-ui-theme';
+import { baseSurface, chromeSurface, topbarBlockPaddingStart, getSize, surfaceElevation } from '@dxos/react-ui-theme';
 
 import { FileUpload } from './FileUpload';
 import { defaultFileTypes } from '../hooks';
@@ -99,7 +99,7 @@ export const StackMain: FC<{ stack: StackType }> = ({ stack }) => {
   };
 
   return (
-    <Main.Content bounce classNames={[baseSurface, coarseBlockPaddingStart]}>
+    <Main.Content bounce classNames={[baseSurface, topbarBlockPaddingStart]}>
       <Stack
         id={id}
         Component={StackContent}

--- a/packages/apps/plugins/plugin-table/src/components/TableMain.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/TableMain.tsx
@@ -5,7 +5,7 @@
 import React, { type FC } from 'react';
 
 import { Main } from '@dxos/react-ui';
-import { baseSurface, coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
+import { baseSurface, topbarBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
 
 import { ObjectTable, type ObjectTableProps } from './ObjectTable';
 
@@ -27,7 +27,7 @@ export const TableSlide: FC<ObjectTableProps> = ({ table }) => {
 
 export const TableMain: FC<ObjectTableProps> = ({ table }) => {
   return (
-    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, coarseBlockPaddingStart]}>
+    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart]}>
       <div className={'flex grow m-4 overflow-hidden'}>
         <ObjectTable table={table} />
       </div>

--- a/packages/apps/plugins/plugin-template/src/components/TemplateMain.tsx
+++ b/packages/apps/plugins/plugin-template/src/components/TemplateMain.tsx
@@ -7,14 +7,14 @@ import React, { type FC } from 'react';
 import { PublicKey } from '@dxos/react-client';
 import { getSpaceForObject, type TypedObject } from '@dxos/react-client/echo';
 import { Main } from '@dxos/react-ui';
-import { baseSurface, coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
+import { baseSurface, topbarBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
 
 export const TemplateMain: FC<{ object: TypedObject }> = ({ object }) => {
   const space = getSpaceForObject(object);
 
   return (
     // TODO(burdon): Boilerplate.
-    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, coarseBlockPaddingStart]}>
+    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart]}>
       <pre className='m-4 p-2 ring'>
         <span>{space?.key.truncate()}</span>/<span>{PublicKey.from(object.id).truncate()}</span>
       </pre>

--- a/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
@@ -7,7 +7,7 @@ import React, { type FC } from 'react';
 import { type Thread as ThreadType } from '@braneframe/types';
 import { getSpaceForObject } from '@dxos/react-client/echo';
 import { Main } from '@dxos/react-ui';
-import { baseSurface, coarseBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
+import { baseSurface, topbarBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
 
 import { ThreadContainer } from './ThreadContainer';
 
@@ -18,7 +18,7 @@ export const ThreadMain: FC<{ thread: ThreadType }> = ({ thread }) => {
   }
 
   return (
-    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, coarseBlockPaddingStart]}>
+    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart]}>
       <ThreadContainer space={space} thread={thread} fullWidth={false} />
     </Main.Content>
   );

--- a/packages/ui/react-ui-theme/src/styles/components/main.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/main.ts
@@ -7,6 +7,9 @@ import { type ComponentFunction } from '@dxos/react-ui-types/src';
 import { mx } from '../../util';
 import { bounceLayout, fixedBorder, fixedSurface } from '../fragments';
 
+// Padding to apply to in-flow elements which need to clear the fixed topbar.
+export const topbarBlockPaddingStart = 'pbs-[--topbar-size]';
+
 export type MainStyleProps = Partial<{
   isLg: boolean;
   inlineStartSidebarOpen: boolean;

--- a/packages/ui/react-ui-theme/src/styles/fragments/density.ts
+++ b/packages/ui/react-ui-theme/src/styles/fragments/density.ts
@@ -5,7 +5,6 @@
 import { type Density } from '@dxos/react-ui-types';
 
 export const coarseBlockSize = 'min-bs-[2.5rem]';
-export const coarseBlockPaddingStart = 'pbs-[2.5rem]';
 export const coarseTextPadding = 'pli-3';
 export const coarseButtonPadding = 'pli-4';
 export const coarseDimensions = `${coarseBlockSize} ${coarseTextPadding}`;

--- a/packages/ui/react-ui-theme/src/theme.css
+++ b/packages/ui/react-ui-theme/src/theme.css
@@ -69,6 +69,7 @@
   --surface-bg: theme(colors.neutral.12);
   --surface-text: theme(colors.neutral.900);
   --description-text: theme(colors.neutral.650);
+  --topbar-size: 3rem;
 }
 
 .dark {

--- a/packages/ui/react-ui-theme/src/theme.css
+++ b/packages/ui/react-ui-theme/src/theme.css
@@ -69,7 +69,7 @@
   --surface-bg: theme(colors.neutral.12);
   --surface-text: theme(colors.neutral.900);
   --description-text: theme(colors.neutral.650);
-  --topbar-size: 3rem;
+  --topbar-size: theme(spacing.12);
 }
 
 .dark {


### PR DESCRIPTION
This PR resolves #4740.

This PR also adds a spacer below Markdown documents so at the end of scrolling the main area, the end-edge of the document will land in the middle of the viewport’s height.

---

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 809c94d</samp>

### Summary
🎨🧹📦

<!--
1.  🎨 This emoji represents the refactoring of the UI style and the use of a new CSS variable for the padding.
2.  🧹 This emoji represents the removal of the unused and outdated padding style from the theme package.
3.  📦 This emoji represents the addition of the new padding style as a named export from the theme package.
-->
Refactored the padding style of various plugin components to use a new named export `topbarBlockPaddingStart` from the `react-ui-theme` package. This improves the consistency and readability of the code and the UI, and removes the unused export `coarseBlockPaddingStart`.

> _We're refactoring the padding style, `topbarBlockPaddingStart` is the name_
> _We'll replace the old `coarseBlockPaddingStart` and make the UI look the same_
> _Heave away, me jolly coders, heave away_
> _Heave away, we'll get this pull request done today_

### Walkthrough
*  Refactor the padding style for the main content area to account for the fixed topbar ([link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-3feb5fd29adeaacde0b908600a918fa13609ececbcd0bb636017b63762ce08beR10-R12), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-404fff46073e55e7f84570e96a11e60c0177c688cdbd46bedad96d68d976824aL8))
  - Replace the import and usage of `coarseBlockPaddingStart` with `topbarBlockPaddingStart` in all plugin components that use `Main.Content` ([link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-11d18f8ffbc50f714f58df501a5c59afb51863713ed38a71e4b82cee2a4aa1dbL11-R11), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-11d18f8ffbc50f714f58df501a5c59afb51863713ed38a71e4b82cee2a4aa1dbL40-R40), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-000ec326db1ff0b81a94e44aecaddf9df533e1acad2c6de8261ca2371ac0a2a4L10-R15), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-83698ec1d6ba73cf4c3b341ea31dd9300a44637228d8b62237a50e32d371dd12L10-R10), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-83698ec1d6ba73cf4c3b341ea31dd9300a44637228d8b62237a50e32d371dd12L16-R16), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-934704723950cadc4dfe245b6e4411f334c9de33cea76e3385c5e8d08f2a3d20L11-R11), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-934704723950cadc4dfe245b6e4411f334c9de33cea76e3385c5e8d08f2a3d20L23-R23), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-67c0b2eb0a5e6e6e52cc6fadc62369646425931154e81f33f345ab693a8b567aL17-R17), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-67c0b2eb0a5e6e6e52cc6fadc62369646425931154e81f33f345ab693a8b567aL76-R76), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-e8d7fd2b1f09e95dcf90494d04cc535507a9b5dc691d023d0c4a1a65a0f17485L11-R11), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-e8d7fd2b1f09e95dcf90494d04cc535507a9b5dc691d023d0c4a1a65a0f17485L30-R30), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-d36cb8c44106ee4e2e3fc3fe686403f0e9ec4a375047ac3f3de633e92d46c343L10-R10), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-d36cb8c44106ee4e2e3fc3fe686403f0e9ec4a375047ac3f3de633e92d46c343L31-R31), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-4653f7d005c699e5f05c7981447554e917ed2857776d51813662b873fdf68b76L10-R10), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-4653f7d005c699e5f05c7981447554e917ed2857776d51813662b873fdf68b76L16-R16), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-2dad9280901d107c07117e32c1eaa07331e303c02d11699a00ec95431dd64eacL9-R9), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-2dad9280901d107c07117e32c1eaa07331e303c02d11699a00ec95431dd64eacL22-R27), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-2f4c702de6b3caa797547e926b4eea1c8838f6c27afd24c84f2256509d71a4f6L11-R11), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-2f4c702de6b3caa797547e926b4eea1c8838f6c27afd24c84f2256509d71a4f6L42-R42), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-a3d91b631f053ea70a66fbb90c008344fa61816fe987c5cf6c90d16656373767L12-R12), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-a3d91b631f053ea70a66fbb90c008344fa61816fe987c5cf6c90d16656373767L33-R33), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-edff19ad67d75c6b9dc3668cb889e0f8256ab9be0fb011219d52a50fcefa5b4dL12-R12), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-edff19ad67d75c6b9dc3668cb889e0f8256ab9be0fb011219d52a50fcefa5b4dL114-R114), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068L14-R14), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068L102-R102), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-17ce87973554ccb740b651cb56b2162cfce947d385aaf8f12bf7f88c41761d66L8-R8), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-17ce87973554ccb740b651cb56b2162cfce947d385aaf8f12bf7f88c41761d66L30-R30), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-42d9af3ed7da4ae5ad92d0fa14edf33f18c1f74e17210e64756dc2c5678fe31aL10-R10), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-42d9af3ed7da4ae5ad92d0fa14edf33f18c1f74e17210e64756dc2c5678fe31aL17-R17), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-2e4bdc904e742658fb4ca8645f7d4cd91c01bf36714a4ade5a49946884f735ebL10-R10), [link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-2e4bdc904e742658fb4ca8645f7d4cd91c01bf36714a4ade5a49946884f735ebL21-R21))
  - Remove the unused import of `coarseBlockPaddingStart` from `MainLayout.tsx` ([link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-7e56c4efb2e92f01c3e8c0bf9348a4e40b2cd6e59a42be154f72eeb30dfe0a60L10-R10))
  - Remove the class name of `coarseBlockPaddingStart` from the `Main.Content` component in `MainLayout.tsx`, and add a new class name of `bs-[--topbar-size]` to the inner div, using a custom CSS variable for the topbar size ([link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-7e56c4efb2e92f01c3e8c0bf9348a4e40b2cd6e59a42be154f72eeb30dfe0a60L74-R74))
  - Add the class name of `bs-[--topbar-size]` to the inner div in the `TreeViewContainer` component in `TreeViewContainer.tsx`, using the same custom CSS variable as above ([link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-a6265a6cedfcc74f332b032e365ccfb081883fb035bc2faa60067a01742bd199L183-R183))
  - Add a new div with a class name of `bs-[50dvh]` after the children of the `Main.Content` component in `StandaloneLayout.tsx`, to avoid the content being cut off by the bounce effect ([link](https://github.com/dxos/dxos/pull/4741/files?diff=unified&w=0#diff-2dad9280901d107c07117e32c1eaa07331e303c02d11699a00ec95431dd64eacL22-R27))


