### PR TITLE
fix: Add missing e2e target config

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -132,6 +132,12 @@
       ]
     },
     "e2e": {
+      "executor": "@dxos/test:run",
+      "options": {
+        "coveragePath": "coverage/{projectRoot}",
+        "outputPath": "tmp/playwright/{projectRoot}",
+        "resultsPath": "test-results/{projectRoot}"
+      },
       "inputs": [
         "default",
         "^production",

--- a/packages/apps/composer-app/project.json
+++ b/packages/apps/composer-app/project.json
@@ -22,7 +22,6 @@
       ]
     },
     "e2e": {
-      "executor": "@dxos/test:run",
       "options": {
         "playwrightConfigPath": "packages/apps/composer-app/src/playwright/playwright.config.ts",
         "serve": "composer-app:serve-with-vault",

--- a/packages/apps/halo-app/project.json
+++ b/packages/apps/halo-app/project.json
@@ -19,7 +19,6 @@
       ]
     },
     "e2e": {
-      "executor": "@dxos/test:run",
       "options": {
         "ciEnvironments": [
           "android",

--- a/packages/apps/todomvc/project.json
+++ b/packages/apps/todomvc/project.json
@@ -22,7 +22,6 @@
       ]
     },
     "e2e": {
-      "executor": "@dxos/test:run",
       "options": {
         "playwrightConfigPath": "packages/apps/todomvc/src/playwright/playwright.config.ts",
         "serve": "todomvc:serve-with-vault",

--- a/packages/devtools/devtools-extension/project.json
+++ b/packages/devtools/devtools-extension/project.json
@@ -17,7 +17,6 @@
         "bundle",
         "prebuild"
       ],
-      "executor": "@dxos/test:run",
       "options": {
         "extensionPath": "packages/devtools/devtools-extension/out/devtools-extension",
         "headless": false,

--- a/packages/e2e/rpc-tunnel-e2e/project.json
+++ b/packages/e2e/rpc-tunnel-e2e/project.json
@@ -22,7 +22,6 @@
       ]
     },
     "e2e": {
-      "executor": "@dxos/test:run",
       "options": {
         "playwrightConfigPath": "packages/e2e/rpc-tunnel-e2e/src/playwright/playwright.config.ts",
         "serve": "rpc-tunnel-e2e:serve",

--- a/packages/gravity/kube-testing/project.json
+++ b/packages/gravity/kube-testing/project.json
@@ -11,7 +11,6 @@
       }
     },
     "e2e": {
-      "executor": "@dxos/test:run",
       "options": {
         "ciEnvironments": [
           "nodejs"

--- a/packages/sdk/react-client/project.json
+++ b/packages/sdk/react-client/project.json
@@ -17,7 +17,6 @@
       }
     },
     "e2e": {
-      "executor": "@dxos/test:run",
       "options": {
         "playwrightConfigPath": "packages/sdk/react-client/src/playwright/playwright.config.ts",
         "serve": "react-client:storybook",

--- a/packages/sdk/react-shell/project.json
+++ b/packages/sdk/react-shell/project.json
@@ -15,7 +15,6 @@
       }
     },
     "e2e": {
-      "executor": "@dxos/test:run",
       "options": {
         "playwrightConfigPath": "packages/sdk/react-shell/src/playwright/playwright.config.ts",
         "serve": "react-shell:storybook",

--- a/packages/sdk/vault/project.json
+++ b/packages/sdk/vault/project.json
@@ -78,7 +78,6 @@
       ]
     },
     "e2e": {
-      "executor": "@dxos/test:run",
       "options": {
         "playwrightConfigPath": "packages/sdk/vault/src/playwright/playwright.config.ts",
         "serve": "vault:serve-test",


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9a18318</samp>

### Summary
🎭🗑️📊

<!--
1.  🎭 - This emoji represents the playwright testing framework, which is the main topic of the changes. It also conveys the idea of running tests in different browsers and scenarios.
2.  🗑️ - This emoji represents the removal of unnecessary or unused code, which is another aspect of the changes. It also conveys the idea of cleaning up and simplifying the configuration.
3.  📊 - This emoji represents the coverage, output, and results files that are added as options for the executor. It also conveys the idea of measuring and reporting the test performance and quality.
-->
This pull request removes the unused `@dxos/test:run` executor from several projects that do not have playwright tests, and modifies the `toolbox.ts` script to add a new method for printing project stats. The purpose of these changes is to simplify the configuration and maintenance of the projects and the test executor.

> _No more `@dxos/test:run` for the projects that don't need it_
> _We clean up the code and make it more efficient_
> _We add a new option for the coverage of the playwright tests_
> _We `inspect` and `printStats` to see the effects_

### Walkthrough
*  Add `coveragePath`, `outputPath`, and `resultsPath` options to `@dxos/test:run` executor ([link](https://github.com/dxos/dxos/pull/4742/files?diff=unified&w=0#diff-15552e50b1b7c05b05b7ffe08ee47b5ed62b8d2039229c58972a42fd22a7381cR135-R140))
*  Remove `@dxos/test:run` executor from projects that do not have playwright tests ([link](https://github.com/dxos/dxos/pull/4742/files?diff=unified&w=0#diff-305064e5650658acc533706323113181b31fa246d06b6d28dbb047dd44f8578cL25), [link](https://github.com/dxos/dxos/pull/4742/files?diff=unified&w=0#diff-ce2831652ff192fb7a22424b24c8e2e8a9c2ba14fbcc09f5d9e7c3e674a0a31bL22), [link](https://github.com/dxos/dxos/pull/4742/files?diff=unified&w=0#diff-b31010079f226a3ae5c30b8f4276342141245176f0f095be273ef495e52fe400L25), [link](https://github.com/dxos/dxos/pull/4742/files?diff=unified&w=0#diff-a2720ca27823b117f2fb9c9d9f279afa39b42345514a563094e682edf098da71L20), [link](https://github.com/dxos/dxos/pull/4742/files?diff=unified&w=0#diff-970f9909440600bab862fb4d9bf494e1ca7dfd825759a46c4c6bc8b8c60353d8L20), [link](https://github.com/dxos/dxos/pull/4742/files?diff=unified&w=0#diff-61551fbaee4d4bfef4f05249588c26fec31f9fe60a3e178b0a889a8d8dac43e6L18), [link](https://github.com/dxos/dxos/pull/4742/files?diff=unified&w=0#diff-2618d356c2f89ca9ecb11f6548f1c6e389cc9b7e9bca4dde6517b4a88a3eb9feL81))
*  Remove `@dxos/test:run` executor from projects that use different executors for testing ([link](https://github.com/dxos/dxos/pull/4742/files?diff=unified&w=0#diff-571ccfef37052f8e7499133f9233c075541af78716724d13908ce93755efbb50L25), [link](https://github.com/dxos/dxos/pull/4742/files?diff=unified&w=0#diff-2b1270dadc0bb722d87791be320e2863353ce645d5131b7917ecbc302aa28206L14))
*  Import `inspect` function from `node:util` module in `toolbox.ts` ([link](https://github.com/dxos/dxos/pull/4742/files?diff=unified&w=0#diff-655a4ededf1ce76a5117a8354a67f795fd89c52d330eb1af6601a5a5e2e70e05R12))
*  Add `printStats` method to `Toolbox` class in `toolbox.ts` to collect and print stats of projects and executors ([link](https://github.com/dxos/dxos/pull/4742/files?diff=unified&w=0#diff-655a4ededf1ce76a5117a8354a67f795fd89c52d330eb1af6601a5a5e2e70e05R327-R353))
*  Comment out the call to `printStats` method in `toolbox.ts` ([link](https://github.com/dxos/dxos/pull/4742/files?diff=unified&w=0#diff-655a4ededf1ce76a5117a8354a67f795fd89c52d330eb1af6601a5a5e2e70e05R371-R372))


