### PR TITLE
fix(plugin-space): space reordering

### DIFF
--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -380,7 +380,7 @@ export const SpacePlugin = ({ onFirstRun }: SpacePluginOptions = {}): PluginDefi
                   client.spaces.default.db.add(nextObjectOrder);
                   spacesOrder = nextObjectOrder;
                 } else {
-                  spacesOrder.objects = nextOrder;
+                  spacesOrder.order = nextOrder.map(({ key }) => key.toHex());
                 }
                 updateSpacesOrder(spacesOrder);
               },


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 28d95a1</samp>

### Summary
🐛🚚🔑

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change.
2.  🚚 - This emoji represents moving or dragging something, which is the action that triggers the bug and the change in the code.
3.  🔑 - This emoji represents a key or an identifier, which is the type of data that is used to order the spaces in the new format.
-->
Fix spaces order bug in `plugin-space` app. Use hex keys instead of objects for `spacesOrder` state.

> _Drag and drop spaces_
> _`order` replaces `objects`_
> _Autumn leaves fall fast_

### Walkthrough
* Fix bug in spaces order update ([link](https://github.com/dxos/dxos/pull/4752/files?diff=unified&w=0#diff-95bf5a92e22ab689565c90684fed6292b7468d3190963e332afe8ac89dc46839L383-R383))


