### PR TITLE
fix: Shared worker missing connect event

### DIFF
--- a/packages/sdk/vault/src/iframe.ts
+++ b/packages/sdk/vault/src/iframe.ts
@@ -160,7 +160,11 @@ export const startIFrameRuntime = async (createWorker: () => SharedWorker): Prom
     // info.push(`%cDXOS vault (shared worker) connection: ${window.location.origin}`);
     info.push('%cTo inspect/reset the vault (shared worker) copy the URL: chrome://inspect/#workers');
     const ports = new Trigger<{ systemPort: MessagePort; shellPort: MessagePort; appPort: MessagePort }>();
-    createWorker().port.onmessage = (event) => {
+    const worker = createWorker();
+    worker.onerror = (event) => {
+      log.error('worker error', { event });
+    };
+    worker.port.onmessage = (event) => {
       const { command, payload } = event.data;
       if (command === 'init') {
         ports.wake(payload);

--- a/packages/sdk/vault/src/shared-worker.ts
+++ b/packages/sdk/vault/src/shared-worker.ts
@@ -2,70 +2,9 @@
 // Copyright 2022 DXOS.org
 //
 
-import { initializeAppTelemetry } from '@braneframe/plugin-telemetry/headless';
-import { mountDevtoolsHooks } from '@dxos/client/devtools';
-import { WorkerRuntime } from '@dxos/client-services';
-import { Config, Defaults, Dynamics, Envs, Local } from '@dxos/config';
-import { log } from '@dxos/log';
-import { createWorkerPort } from '@dxos/rpc-tunnel';
-
-import { namespace } from './util';
-
-// TODO(burdon): Make configurable (NOTE: levels lower than info affect performance).
-const LOG_FILTER = 'info';
-
-void initializeAppTelemetry({
-  namespace,
-  config: new Config(Defaults()),
-  sentryOptions: { tracing: false, replay: false },
-  telemetryOptions: { enable: false },
-});
-
-const workerRuntime = new WorkerRuntime(async () => {
-  const config = new Config(await Dynamics(), await Envs(), Local(), Defaults());
-  log.config({ filter: LOG_FILTER, prefix: config.get('runtime.client.log.prefix') });
-  return config;
-});
-
-// Allow to access host from console.
-mountDevtoolsHooks({
-  host: workerRuntime.host,
-});
-
-const start = Date.now();
-void workerRuntime.start().then(
-  () => {
-    log.info('worker ready', { initTimeMs: Date.now() - start });
-  },
-  (err) => {
-    log.catch(err);
-  },
-);
-
 onconnect = async (event) => {
-  log.info('onconnect', { event });
-  const port = event.ports[0];
-
-  const systemChannel = new MessageChannel();
-  const shellChannel = new MessageChannel();
-  const appChannel = new MessageChannel();
-
-  // NOTE: This is intentiontally not using protobuf because it occurs before the rpc connection is established.
-  port.postMessage(
-    {
-      command: 'init',
-      payload: {
-        systemPort: systemChannel.port1,
-        shellPort: shellChannel.port1,
-        appPort: appChannel.port1,
-      },
-    },
-    [systemChannel.port1, shellChannel.port1, appChannel.port1],
-  );
-
-  await workerRuntime.createSession({
-    systemPort: createWorkerPort({ port: systemChannel.port2 }),
-    shellPort: createWorkerPort({ port: shellChannel.port2 }),
-    appPort: createWorkerPort({ port: appChannel.port2 }),
-  });
+  // All worker code & imports have been moved behind an async import due to WASM + top-level await breaking the connect even somehow.
+  // See: https://github.com/Menci/vite-plugin-wasm/issues/37
+  const { onconnect } = await import('./worker-main');
+  await onconnect(event);
 };

--- a/packages/sdk/vault/src/worker-main.ts
+++ b/packages/sdk/vault/src/worker-main.ts
@@ -1,0 +1,71 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+import { initializeAppTelemetry } from '@braneframe/plugin-telemetry/headless';
+import { mountDevtoolsHooks } from '@dxos/client/devtools';
+import { WorkerRuntime } from '@dxos/client-services';
+import { Config, Defaults, Dynamics, Envs, Local } from '@dxos/config';
+import { log } from '@dxos/log';
+import { createWorkerPort } from '@dxos/rpc-tunnel';
+
+import { namespace } from './util';
+
+// TODO(burdon): Make configurable (NOTE: levels lower than info affect performance).
+const LOG_FILTER = 'info';
+
+void initializeAppTelemetry({
+  namespace,
+  config: new Config(Defaults()),
+  sentryOptions: { tracing: false, replay: false },
+  telemetryOptions: { enable: false },
+});
+
+const workerRuntime = new WorkerRuntime(async () => {
+  const config = new Config(await Dynamics(), await Envs(), Local(), Defaults());
+  log.config({ filter: LOG_FILTER, prefix: config.get('runtime.client.log.prefix') });
+  return config;
+});
+
+// Allow to access host from console.
+mountDevtoolsHooks({
+  host: workerRuntime.host,
+});
+
+const start = Date.now();
+void workerRuntime.start().then(
+  () => {
+    log.info('worker ready', { initTimeMs: Date.now() - start });
+  },
+  (err) => {
+    log.catch(err);
+  },
+);
+
+export const onconnect = async (event: MessageEvent<any>) => {
+  log.info('onconnect', { event });
+  const port = event.ports[0];
+
+  const systemChannel = new MessageChannel();
+  const shellChannel = new MessageChannel();
+  const appChannel = new MessageChannel();
+
+  // NOTE: This is intentiontally not using protobuf because it occurs before the rpc connection is established.
+  port.postMessage(
+    {
+      command: 'init',
+      payload: {
+        systemPort: systemChannel.port1,
+        shellPort: shellChannel.port1,
+        appPort: appChannel.port1,
+      },
+    },
+    [systemChannel.port1, shellChannel.port1, appChannel.port1],
+  );
+
+  await workerRuntime.createSession({
+    systemPort: createWorkerPort({ port: systemChannel.port2 }),
+    shellPort: createWorkerPort({ port: shellChannel.port2 }),
+    appPort: createWorkerPort({ port: appChannel.port2 }),
+  });
+};


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5544edc</samp>

### Summary
🐛🚚📦

<!--
1.  🐛 - This emoji represents the bug fix that adds the error handler for the worker instance. It conveys the idea of catching and resolving a problem in the code.
2.  🚚 - This emoji represents the refactor that moves the worker code to a separate file. It conveys the idea of relocating or reorganizing the code without changing its functionality.
3.  📦 - This emoji represents the new file that contains the worker code. It conveys the idea of adding or creating a new module or component in the codebase.
-->
This pull request fixes a bug that prevents the vault logic from running in an iframe using a shared worker and WASM. It adds an error handler for the worker instance, splits the worker code into a separate file, and imports it asynchronously when the worker connects.

> _Worker errors caught_
> _`onconnect` bug fixed with_
> _Import in winter_

### Walkthrough
*  Work around a worker bug by splitting the worker code into a separate file and importing it asynchronously ([link](https://github.com/dxos/dxos/pull/4756/files?diff=unified&w=0#diff-e19deeac50d7fc405b10d260f559ce6bf36783ab4da62478b551cd91d874d94aL5-R9), [link](https://github.com/dxos/dxos/pull/4756/files?diff=unified&w=0#diff-a5c067ccedd71a5231fe6b9e2127496a2f474c6e9f82372b703cb7b59ef7a43bR1-R71)).


