### PR TITLE
test(echo-schema): add failing query test

### DIFF
--- a/packages/core/echo/echo-schema/src/object/array.test.ts
+++ b/packages/core/echo/echo-schema/src/object/array.test.ts
@@ -11,6 +11,7 @@ import { Expando, TypedObject } from './typed-object';
 import { AutomergeArray } from '../automerge';
 import { getGlobalAutomergePreference } from '../automerge-preference';
 import { createDatabase, testWithAutomerge } from '../testing';
+import { log } from '@dxos/log';
 
 describe('Arrays', () => {
   testWithAutomerge(() => {
@@ -148,8 +149,46 @@ describe('Arrays', () => {
       root.records.push({ title: 'two' });
       expect(root.records).toHaveLength(1);
 
-      await db.flush();
-      expect(root.records).toHaveLength(1);
-    });
+    await db.flush();
+    expect(root.records).toHaveLength(1);
   });
+
+  test.only('Array.isArray', async () => {
+    console.log(Array.isArray(new Proxy([], {
+      get(target, prop, receiver) {
+        log.info('get', { target, prop, receiver });
+        return Reflect.get(target, prop, receiver);
+      },
+      getOwnPropertyDescriptor(target, p) {
+        log.info('getOwnPropertyDescriptor', { target, p });
+        return Reflect.getOwnPropertyDescriptor(target, p);
+      },
+      getPrototypeOf(target) {
+        log.info('getPrototypeOf', { target });
+        return Reflect.getPrototypeOf(target);
+      },
+      apply(target, thisArg, argArray) {
+        log.info('apply', { target, thisArg, argArray });
+        return Reflect.apply(target as any, thisArg, argArray);
+      },
+      has(target, p) {
+        log.info('has', { target, p });
+        return Reflect.has(target, p);
+      },
+      ownKeys(target) {
+        log.info('ownKeys', { target });
+        return Reflect.ownKeys(target);
+      },
+      isExtensible(target) {
+        log.info('isExtensible', { target });
+        return Reflect.isExtensible(target);
+      },
+    })))
+
+
+    // const root = new TypedObject();
+    // root.array = [];
+
+    // expect(Array.isArray(root.array)).toEqual(true);
+  })
 });

--- a/packages/core/echo/echo-schema/src/object/array.test.ts
+++ b/packages/core/echo/echo-schema/src/object/array.test.ts
@@ -158,40 +158,40 @@ describe('Arrays', () => {
         Array.isArray(
           new Proxy([], {
             get: (target, prop, receiver) => {
-        log.info('get', { target, prop, receiver });
-        return Reflect.get(target, prop, receiver);
-      },
+              log.info('get', { target, prop, receiver });
+              return Reflect.get(target, prop, receiver);
+            },
             getOwnPropertyDescriptor: (target, p) => {
-        log.info('getOwnPropertyDescriptor', { target, p });
-        return Reflect.getOwnPropertyDescriptor(target, p);
-      },
+              log.info('getOwnPropertyDescriptor', { target, p });
+              return Reflect.getOwnPropertyDescriptor(target, p);
+            },
             getPrototypeOf: (target) => {
-        log.info('getPrototypeOf', { target });
-        return Reflect.getPrototypeOf(target);
-      },
+              log.info('getPrototypeOf', { target });
+              return Reflect.getPrototypeOf(target);
+            },
             apply: (target, thisArg, argArray) => {
-        log.info('apply', { target, thisArg, argArray });
-        return Reflect.apply(target as any, thisArg, argArray);
-      },
+              log.info('apply', { target, thisArg, argArray });
+              return Reflect.apply(target as any, thisArg, argArray);
+            },
             has: (target, p) => {
-        log.info('has', { target, p });
-        return Reflect.has(target, p);
-      },
+              log.info('has', { target, p });
+              return Reflect.has(target, p);
+            },
             ownKeys: (target) => {
-        log.info('ownKeys', { target });
-        return Reflect.ownKeys(target);
-      },
+              log.info('ownKeys', { target });
+              return Reflect.ownKeys(target);
+            },
             isExtensible: (target) => {
-        log.info('isExtensible', { target });
-        return Reflect.isExtensible(target);
-      },
+              log.info('isExtensible', { target });
+              return Reflect.isExtensible(target);
+            },
           }),
-        ),;
+        ),
       );
       // const root = new TypedObject();
       // root.array = [];
 
       // expect(Array.isArray(root.array)).toEqual(true);
-    });;
+    });
   });
 });

--- a/packages/core/echo/echo-schema/src/object/array.test.ts
+++ b/packages/core/echo/echo-schema/src/object/array.test.ts
@@ -9,6 +9,7 @@ import { describe, test } from '@dxos/test';
 
 import { EchoArray } from './array';
 import { Expando, TypedObject } from './typed-object';
+import { base } from './types';
 import { AutomergeArray } from '../automerge';
 import { getGlobalAutomergePreference } from '../automerge-preference';
 import { createDatabase, testWithAutomerge } from '../testing';
@@ -161,37 +162,42 @@ describe('Arrays', () => {
               log.info('get', { target, prop, receiver });
               return Reflect.get(target, prop, receiver);
             },
-            getOwnPropertyDescriptor: (target, p) => {
-              log.info('getOwnPropertyDescriptor', { target, p });
-              return Reflect.getOwnPropertyDescriptor(target, p);
-            },
-            getPrototypeOf: (target) => {
-              log.info('getPrototypeOf', { target });
-              return Reflect.getPrototypeOf(target);
-            },
-            apply: (target, thisArg, argArray) => {
-              log.info('apply', { target, thisArg, argArray });
-              return Reflect.apply(target as any, thisArg, argArray);
-            },
-            has: (target, p) => {
-              log.info('has', { target, p });
-              return Reflect.has(target, p);
-            },
-            ownKeys: (target) => {
-              log.info('ownKeys', { target });
-              return Reflect.ownKeys(target);
-            },
-            isExtensible: (target) => {
-              log.info('isExtensible', { target });
-              return Reflect.isExtensible(target);
-            },
+            //   getOwnPropertyDescriptor: (target, p) => {
+            //     log.info('getOwnPropertyDescriptor', { target, p });
+            //     return Reflect.getOwnPropertyDescriptor(target, p);
+            //   },
+            //   getPrototypeOf: (target) => {
+            //     log.info('getPrototypeOf', { target });
+            //     return Reflect.getPrototypeOf(target);
+            //   },
+            //   apply: (target, thisArg, argArray) => {
+            //     log.info('apply', { target, thisArg, argArray });
+            //     return Reflect.apply(target as any, thisArg, argArray);
+            //   },
+            //   has: (target, p) => {
+            //     log.info('has', { target, p });
+            //     return Reflect.has(target, p);
+            //   },
+            //   ownKeys: (target) => {
+            //     log.info('ownKeys', { target });
+            //     return Reflect.ownKeys(target);
+            //   },
+            //   isExtensible: (target) => {
+            //     log.info('isExtensible', { target });
+            //     return Reflect.isExtensible(target);
+            //   },
           }),
         ),
       );
-      // const root = new TypedObject();
-      // root.array = [];
+      const root = new TypedObject();
+      root.array = [];
 
-      // expect(Array.isArray(root.array)).toEqual(true);
+      log.info('isArray', {
+        isArray: Array.isArray(root.array),
+        array: root.array,
+        isArrayBase: Array.isArray(root.array[base]),
+      });
+      // expect(root.array instanceof Array).toEqual(true);
     });
   });
 });

--- a/packages/core/echo/echo-schema/src/object/array.test.ts
+++ b/packages/core/echo/echo-schema/src/object/array.test.ts
@@ -4,6 +4,7 @@
 
 import expect from 'expect'; // TODO(burdon): Can't use chai with wait-for-expect?
 
+import { log } from '@dxos/log';
 import { describe, test } from '@dxos/test';
 
 import { EchoArray } from './array';
@@ -11,7 +12,6 @@ import { Expando, TypedObject } from './typed-object';
 import { AutomergeArray } from '../automerge';
 import { getGlobalAutomergePreference } from '../automerge-preference';
 import { createDatabase, testWithAutomerge } from '../testing';
-import { log } from '@dxos/log';
 
 describe('Arrays', () => {
   testWithAutomerge(() => {
@@ -149,46 +149,49 @@ describe('Arrays', () => {
       root.records.push({ title: 'two' });
       expect(root.records).toHaveLength(1);
 
-    await db.flush();
-    expect(root.records).toHaveLength(1);
-  });
+      await db.flush();
+      expect(root.records).toHaveLength(1);
+    });
 
-  test.only('Array.isArray', async () => {
-    console.log(Array.isArray(new Proxy([], {
-      get(target, prop, receiver) {
+    test.only('Array.isArray', async () => {
+      console.log(
+        Array.isArray(
+          new Proxy([], {
+            get: (target, prop, receiver) => {
         log.info('get', { target, prop, receiver });
         return Reflect.get(target, prop, receiver);
       },
-      getOwnPropertyDescriptor(target, p) {
+            getOwnPropertyDescriptor: (target, p) => {
         log.info('getOwnPropertyDescriptor', { target, p });
         return Reflect.getOwnPropertyDescriptor(target, p);
       },
-      getPrototypeOf(target) {
+            getPrototypeOf: (target) => {
         log.info('getPrototypeOf', { target });
         return Reflect.getPrototypeOf(target);
       },
-      apply(target, thisArg, argArray) {
+            apply: (target, thisArg, argArray) => {
         log.info('apply', { target, thisArg, argArray });
         return Reflect.apply(target as any, thisArg, argArray);
       },
-      has(target, p) {
+            has: (target, p) => {
         log.info('has', { target, p });
         return Reflect.has(target, p);
       },
-      ownKeys(target) {
+            ownKeys: (target) => {
         log.info('ownKeys', { target });
         return Reflect.ownKeys(target);
       },
-      isExtensible(target) {
+            isExtensible: (target) => {
         log.info('isExtensible', { target });
         return Reflect.isExtensible(target);
       },
-    })))
+          }),
+        ),;
+      );
+      // const root = new TypedObject();
+      // root.array = [];
 
-
-    // const root = new TypedObject();
-    // root.array = [];
-
-    // expect(Array.isArray(root.array)).toEqual(true);
-  })
+      // expect(Array.isArray(root.array)).toEqual(true);
+    });;
+  });
 });

--- a/packages/core/echo/echo-schema/src/query/query.test.ts
+++ b/packages/core/echo/echo-schema/src/query/query.test.ts
@@ -255,3 +255,25 @@ testWithAutomerge(() => {
     });
   });
 });
+
+test('map over refs in query result', async () => {
+  const testBuilder = new TestBuilder();
+  const peer = await testBuilder.createPeer();
+
+  const folder = peer.db.add(new TypedObject({ name: 'folder', objects: [] }));
+  const objects = [
+    new TypedObject({ idx: 0, title: 'Task 0' }),
+    new TypedObject({ idx: 1, title: 'Task 1' }),
+    new TypedObject({ idx: 2, title: 'Task 2' }),
+  ];
+  for (const object of objects) {
+    folder.objects.push(object);
+  }
+
+  const query = peer.db.query({ name: 'folder' });
+  const result = query.objects.flatMap(({ objects }) => objects);
+
+  for (const i in objects) {
+    expect(result[i]).to.eq(objects[i]);
+  }
+});

--- a/packages/core/echo/echo-schema/src/query/query.test.ts
+++ b/packages/core/echo/echo-schema/src/query/query.test.ts
@@ -269,9 +269,9 @@ test('map over refs in query result', async () => {
   for (const object of objects) {
     folder.objects.push(object);
   }
-
+  
   const query = peer.db.query({ name: 'folder' });
-  const result = query.objects.flatMap(({ objects }) => objects);
+  const result = query.objects.flatMap(({ objects }) => Array.from(objects));
 
   for (const i in objects) {
     expect(result[i]).to.eq(objects[i]);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0aba93a</samp>

### Summary
🧪🔗📁

<!--
1.  🧪 - This emoji represents testing, as the change adds a new test case for the query module.
2.  🔗 - This emoji represents references, as the change involves mapping over refs in the queried objects.
3.  📁 - This emoji represents folders, as the change creates and queries a folder object that contains task objects.
-->
Added a new test case for `query` module of `echo-schema` package. The test case verifies that query results can handle refs to other objects.

> _`echo-schema` tests_
> _querying refs with flatMap_
> _autumn leaves scattered_

### Walkthrough
* Add a test case for mapping over refs in query results ([link](https://github.com/dxos/dxos/pull/4757/files?diff=unified&w=0#diff-718d737fa6b5a5f359faaa930b144180f7fd8dc9e3592b1ea2cc696aa2028a0cR234-R255)). The test case uses the `query` and `flatMap` methods of the `QueryResult` class to get the task objects from the folder object's ref array. The test case asserts that the result matches the expected task objects. This improves the test coverage and functionality of the `query` module of the `echo-schema` package, which provides a schema system for the `echo` database.


