### PR TITLE
fix: remove log and stats for stale connections

### DIFF
--- a/packages/core/mesh/network-manager/src/connection-log.ts
+++ b/packages/core/mesh/network-manager/src/connection-log.ts
@@ -12,6 +12,8 @@ import { ComplexMap } from '@dxos/util';
 import { ConnectionState, type Swarm } from './swarm';
 import { type WireProtocol } from './wire-protocol';
 
+const CONNECTION_GC_THRESHOLD = 1000 * 60 * 15;
+
 export enum EventType {
   CONNECTION_STATE_CHANGED = 'CONNECTION_STATE_CHANGED',
   PROTOCOL_ERROR = 'PROTOCOL_ERROR',
@@ -57,6 +59,7 @@ export class ConnectionLog {
         transport: connection.transport && Object.getPrototypeOf(connection.transport).constructor.name,
         protocolExtensions: [], // TODO(dmaretskyi): Fix.
         events: [],
+        lastUpdate: new Date(),
       };
       info.connections!.push(connectionInfo);
       this.update.emit();
@@ -64,6 +67,7 @@ export class ConnectionLog {
       connection.stateChanged.on((state) => {
         connectionInfo.state = state;
         connectionInfo.closeReason = connection.closeReason;
+        connectionInfo.lastUpdate = new Date();
         connectionInfo.events!.push({
           type: EventType.CONNECTION_STATE_CHANGED,
           newState: state,
@@ -75,8 +79,11 @@ export class ConnectionLog {
         connectionInfo.readBufferSize = stats.readBufferSize;
         connectionInfo.writeBufferSize = stats.writeBufferSize;
         connectionInfo.streams = stats.channels;
+        connectionInfo.lastUpdate = new Date();
         this.update.emit();
       });
+
+      gcSwarm(info);
 
       // connection.protocol.protocol?.error.on((error) => {
       //   connectionInfo.events!.push({
@@ -111,3 +118,9 @@ export class ConnectionLog {
     this.update.emit();
   }
 }
+
+const gcSwarm = (swarm: SwarmInfo) => {
+  swarm.connections = swarm.connections?.filter((connection) => {
+    return connection.lastUpdate ? Date.now() - connection.lastUpdate.getTime() < CONNECTION_GC_THRESHOLD : true;
+  });
+};

--- a/packages/core/mesh/teleport/src/muxing/muxer.ts
+++ b/packages/core/mesh/teleport/src/muxing/muxer.ts
@@ -458,7 +458,21 @@ export class Muxer {
 
   private async _emitStats() {
     if (this._disposed || this._destroying) {
+      if (!this._lastStats) {
+        return;
+      }
+
+      // zero out counting stats to not skew metrics.
+      const lastStats = this._lastStats;
       this._lastStats = undefined;
+
+      lastStats.readBufferSize = 0;
+      lastStats.writeBufferSize = 0;
+      for (const c of lastStats.channels) {
+        c.writeBufferSize = 0;
+      }
+      this.statsUpdated.emit(lastStats);
+
       this._lastChannelStats.clear();
       return;
     }

--- a/packages/core/protocols/src/proto/dxos/devtools/swarm.proto
+++ b/packages/core/protocols/src/proto/dxos/devtools/swarm.proto
@@ -41,6 +41,7 @@ message ConnectionInfo {
   optional string identity = 9;
   optional uint32 readBufferSize = 10;
   optional uint32 writeBufferSize = 11;
+  optional google.protobuf.Timestamp last_update = 12;
 }
 
 message ConnectionEvent {


### PR DESCRIPTION
* gc stale connections from connection log
* zero out counting stats on connection close

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a6ecaf1</samp>

### Summary
📊🕒🗑️

<!--
1.  📊 - This emoji represents the stats or metrics of the connection, which are modified by the first change.
2.  🕒 - This emoji represents the time or timestamp of the last update of the connection, which is added by the second change.
3.  🗑️ - This emoji represents the garbage collection or removal of stale connections, which is implemented by the third change.
-->
This pull request adds a garbage collection feature for old connections in the network manager, and fixes a bug in the stats emission of the multiplexed connection. It also updates the `swarm.proto` file to include a `last_update` field in the `ConnectionInfo` message.

> _Sing, O Muse, of the cunning network manager_
> _Who, by his skill, kept the swarm of connections alive_
> _And of the wise Muxer, who measured the stats of each link_
> _And cleared the buffers of those that were doomed to die_

### Walkthrough
*  Add `last_update` field to `ConnectionInfo` message in `swarm.proto` to store the date of the last update of the connection stats. ([link](https://github.com/dxos/dxos/pull/4762/files?diff=unified&w=0#diff-93f54b61119fb85788de2b99044227edbc6593159f45cb7a166ef45ff8a2b82dR44))
*  Define `CONNECTION_GC_THRESHOLD` constant in `connection-log.ts` to represent the time interval after which a connection is considered stale and can be garbage collected. ([link](https://github.com/dxos/dxos/pull/4762/files?diff=unified&w=0#diff-722d9fe75c055645087e90a3586cbeba7bf109256b4789aecdcff96a937ff2fbR15-R16))
*  Add `lastUpdate` property to `ConnectionInfo` class in `connection-log.ts` and assign it the current date whenever the connection stats are updated. ([link](https://github.com/dxos/dxos/pull/4762/files?diff=unified&w=0#diff-722d9fe75c055645087e90a3586cbeba7bf109256b4789aecdcff96a937ff2fbR62), [link](https://github.com/dxos/dxos/pull/4762/files?diff=unified&w=0#diff-722d9fe75c055645087e90a3586cbeba7bf109256b4789aecdcff96a937ff2fbR70))
*  Add `gcSwarm` function in `connection-log.ts` to filter out the stale connections from the swarm based on the `lastUpdate` property and the `CONNECTION_GC_THRESHOLD` constant. ([link](https://github.com/dxos/dxos/pull/4762/files?diff=unified&w=0#diff-722d9fe75c055645087e90a3586cbeba7bf109256b4789aecdcff96a937ff2fbR121-R126))
*  Call `gcSwarm` function after updating the connection stats and before emitting the update event in `connection-log.ts`. ([link](https://github.com/dxos/dxos/pull/4762/files?diff=unified&w=0#diff-722d9fe75c055645087e90a3586cbeba7bf109256b4789aecdcff96a937ff2fbL78-R87))
*  Modify `_emitStats` method of `Muxer` class in `muxer.ts` to reset the buffer sizes of the disposed or destroying connection and its channels before emitting the stats and setting the `_lastStats` property to undefined. ([link](https://github.com/dxos/dxos/pull/4762/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66L461-R475))


