### PR TITLE
feat(automerge): Implement database.delete method

### DIFF
--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
@@ -29,6 +29,7 @@ export class AutomergeDb {
    * @internal
    */
   readonly _objects = new Map<string, EchoObject>();
+  readonly _objectsSystem = new Map<string, EchoObject>();
 
   getObjectById(id: string): EchoObject | undefined {
     return this._objects.get(id);
@@ -47,6 +48,9 @@ export class AutomergeDb {
   }
 
   remove<T extends EchoObject>(obj: T) {
-    throw new Error('Not implemented');
+    invariant(obj[base] instanceof AutomergeObject);
+    invariant(this._objects.has(obj.id));
+    this._objects.delete(obj.id);
+    (obj[base] as AutomergeObject).__system.deleted = true;
   }
 }

--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
@@ -51,6 +51,6 @@ export class AutomergeDb {
     invariant(obj[base] instanceof AutomergeObject);
     invariant(this._objects.has(obj.id));
     this._objects.delete(obj.id);
-    (obj[base] as AutomergeObject).__system.deleted = true;
+    (obj[base] as AutomergeObject).__system!.deleted = true;
   }
 }

--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -22,6 +22,7 @@ import {
   db,
   debug,
   subscribe,
+  type ObjectSystem,
 } from '../object/types';
 import { type dxos } from '../proto/gen/schema';
 import { compositeRuntime } from '../util';
@@ -31,6 +32,18 @@ export type BindOptions = {
   docHandle: DocHandle<any>;
   path: string[];
 };
+
+/**
+ * Automerge object system properties.
+ * (Is automerge specific.)
+ */
+export type ObjectSystem = {
+  /**
+   * Deletion marker.
+   */
+  deleted: boolean;
+};
+
 export class AutomergeObject implements TypedObjectProperties {
   private _database?: AutomergeDb;
   private _doc?: Doc<any>;
@@ -69,8 +82,12 @@ export class AutomergeObject implements TypedObjectProperties {
     return this._createProxy(['meta']);
   }
 
+  get __system(): ObjectSystem | undefined {
+    return this._createProxy(['system']);
+  }
+
   get __deleted(): boolean {
-    return this._getDoc().deleted;
+    return this.__system?.deleted ?? false;
   }
 
   toJSON() {

--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -77,11 +77,11 @@ export class AutomergeObject implements TypedObjectProperties {
     return undefined;
   }
 
-  get __meta(): ObjectMeta | undefined {
+  get __meta(): ObjectMeta {
     return this._createProxy(['meta']);
   }
 
-  get __system(): ObjectSystem | undefined {
+  get __system(): ObjectSystem {
     return this._createProxy(['system']);
   }
 

--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -22,7 +22,6 @@ import {
   db,
   debug,
   subscribe,
-  type ObjectSystem,
 } from '../object/types';
 import { type dxos } from '../proto/gen/schema';
 import { compositeRuntime } from '../util';

--- a/packages/core/echo/echo-schema/src/database.test.ts
+++ b/packages/core/echo/echo-schema/src/database.test.ts
@@ -55,31 +55,29 @@ describe('Database', () => {
       expect(objects).toHaveLength(n);
     });
 
-    if (!getGlobalAutomergePreference()) {
-      test('removing objects', async () => {
-        const { db } = await createDatabase();
+    test('removing objects', async () => {
+      const { db } = await createDatabase();
 
-        const n = 10;
-        for (const _ of Array.from({ length: n })) {
-          const obj = new TypedObject();
-          db.add(obj);
-        }
-        await db.flush();
+      const n = 10;
+      for (const _ of Array.from({ length: n })) {
+        const obj = new TypedObject();
+        db.add(obj);
+      }
+      await db.flush();
 
-        {
-          const { objects } = db.query();
-          expect(objects).toHaveLength(n);
-        }
+      {
+        const { objects } = db.query();
+        expect(objects).toHaveLength(n);
+      }
 
-        db.remove(db.query().objects[0]);
-        await db.flush();
+      db.remove(db.query().objects[0]);
+      await db.flush();
 
-        {
-          const { objects } = db.query();
-          expect(objects).toHaveLength(n - 1);
-        }
-      });
-    }
+      {
+        const { objects } = db.query();
+        expect(objects).toHaveLength(n - 1);
+      }
+    });
 
     // TODO(burdon): 100 times (not batched).
     test.skip('flush callback', async () => {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 16ab7cf</samp>

### Summary
🗑️🛠️🏷️

<!--
1.  🗑️ - This emoji represents the removal or deletion of something, which is the main feature of this pull request. It also conveys the idea of freeing up space or cleaning up the database.
2.  🛠️ - This emoji represents the addition or improvement of a tool or functionality, which is what the `remove` method and the `_objectsSystem` property provide. It also conveys the idea of fixing or enhancing something that was previously missing or incomplete.
3.  🏷️ - This emoji represents the introduction or modification of a type or a label, which is what the type parameter and the `deleted` property do. It also conveys the idea of categorizing or organizing something more clearly or precisely.
-->
This pull request adds the ability to delete objects from an `AutomergeDb` instance, which is a wrapper around an Automerge document. It modifies the `AutomergeObject` and `AutomergeDb` classes to store and handle the deletion status of the objects. It also updates the corresponding test case to cover the new functionality.

> _`AutomergeDb` grows_
> _Adding `remove` method_
> _Fall leaves are swept away_

### Walkthrough
*  Add a new property `_objectsSystem` to store system-level information about objects in the `AutomergeDb` class ([link](https://github.com/dxos/dxos/pull/4768/files?diff=unified&w=0#diff-875834e4b70c12d82e4dedc39420f91a998d2d84b6b7b3551a6b6d90335bfa50R32))
* Implement the `remove` method of the `AutomergeDb` class to delete objects from the database and mark them as deleted in the Automerge document ([link](https://github.com/dxos/dxos/pull/4768/files?diff=unified&w=0#diff-875834e4b70c12d82e4dedc39420f91a998d2d84b6b7b3551a6b6d90335bfa50L50-R54))
* Add a type parameter `ObjectSystem` to the `AutomergeObject` class to represent the system-level properties of the object ([link](https://github.com/dxos/dxos/pull/4768/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48R25))
* Define the `ObjectSystem` type as an object with a boolean property `deleted` ([link](https://github.com/dxos/dxos/pull/4768/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48R35-R46))
* Modify the `__deleted` getter of the `AutomergeObject` class to return the value of the `deleted` property of the `__system` proxy ([link](https://github.com/dxos/dxos/pull/4768/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48L72-R90))
* Update the test case for removing objects from the database to run for both Automerge and non-Automerge databases in `database.test.ts` ([link](https://github.com/dxos/dxos/pull/4768/files?diff=unified&w=0#diff-972ea93450f88acb9c27693868aa246ad14f5a22b55198ed115d960019406b77L58-R80))


