### PR TITLE
fix: data transformation integration bugs

### DIFF
--- a/packages/apps/plugins/plugin-grid/src/components/GridMain.tsx
+++ b/packages/apps/plugins/plugin-grid/src/components/GridMain.tsx
@@ -100,5 +100,5 @@ const GridCard: MosaicTileComponent<GridDataItem> = forwardRef(({ item, ...props
   const parseData = props.type && metadataPlugin?.provides.metadata.resolver(props.type)?.parse;
   const content = parseData ? parseData(item, 'view-object') : item;
 
-  return <Surface role='card' ref={forwardRef} data={{ content }} {...props} />;
+  return <Surface role='card' ref={forwardRef} limit={1} data={{ content }} {...props} />;
 });

--- a/packages/apps/plugins/plugin-markdown/src/components/EditorCard.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/EditorCard.tsx
@@ -35,7 +35,7 @@ export const EditorCard: MosaicTileComponent<EditorCardProps> = forwardRef(
               <Input.TextInput
                 variant='subdued'
                 classNames='p-0'
-                placeholder={t('title placeholder')}
+                placeholder={t('document title placeholder')}
                 value={object.title}
                 onChange={(event) => (object.title = event.target.value)}
               />
@@ -62,7 +62,7 @@ export const EditorCard: MosaicTileComponent<EditorCardProps> = forwardRef(
                     '[&>div]:h-full',
                   ),
                 },
-                editor: { className: 'h-full', placeholder: t('content placeholder') },
+                editor: { className: 'h-full', placeholder: t('editor placeholder') },
               }}
             />
           </Card.Body>

--- a/packages/apps/plugins/plugin-search/src/SearchPlugin.tsx
+++ b/packages/apps/plugins/plugin-search/src/SearchPlugin.tsx
@@ -12,6 +12,7 @@ import { SpaceProxy } from '@dxos/react-client/echo';
 import { SearchMain } from './components';
 import { SearchContextProvider } from './context';
 import meta, { SEARCH_PLUGIN } from './meta';
+import { SEARCH_RESULT, type SearchResult } from './search';
 import translations from './translations';
 import { SearchAction, type SearchPluginProvides } from './types';
 
@@ -20,6 +21,30 @@ export const SearchPlugin = (): PluginDefinition<SearchPluginProvides> => {
     meta,
     provides: {
       translations,
+      metadata: {
+        records: {
+          [SEARCH_RESULT]: {
+            parse: (item: SearchResult, type: string) => {
+              switch (type) {
+                case 'node': {
+                  return { id: item.id, label: item.label, data: item.object };
+                }
+
+                case 'object': {
+                  return item.object;
+                }
+
+                case 'view-object': {
+                  return item;
+                }
+
+                default:
+                  return undefined;
+              }
+            },
+          },
+        },
+      },
       graph: {
         builder: ({ parent, plugins }) => {
           const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);

--- a/packages/apps/plugins/plugin-search/src/SearchPlugin.tsx
+++ b/packages/apps/plugins/plugin-search/src/SearchPlugin.tsx
@@ -11,8 +11,8 @@ import { SpaceProxy } from '@dxos/react-client/echo';
 
 import { SearchMain } from './components';
 import { SearchContextProvider } from './context';
-import meta, { SEARCH_PLUGIN } from './meta';
-import { SEARCH_RESULT, type SearchResult } from './search';
+import meta, { SEARCH_PLUGIN, SEARCH_RESULT } from './meta';
+import type { SearchResult } from './search';
 import translations from './translations';
 import { SearchAction, type SearchPluginProvides } from './types';
 

--- a/packages/apps/plugins/plugin-search/src/components/SearchResults/SearchResults.tsx
+++ b/packages/apps/plugins/plugin-search/src/components/SearchResults/SearchResults.tsx
@@ -9,7 +9,7 @@ import { Card, ScrollArea } from '@dxos/react-ui';
 import { type MosaicTileComponent, Mosaic } from '@dxos/react-ui-mosaic';
 import { groupSurface, mx } from '@dxos/react-ui-theme';
 
-import { type SearchResult } from '../../search';
+import { SEARCH_RESULT, type SearchResult } from '../../search';
 
 // TODO(burdon): Factor out.
 const styles = {
@@ -103,6 +103,7 @@ export const SearchResults = ({ items, selected, onSelect }: SearchResultsProps)
               <Mosaic.DraggableTile
                 key={item.id}
                 path={path}
+                type={SEARCH_RESULT}
                 item={{ ...item, selected: selected === item.id, onSelect }}
                 Component={SearchItem}
               />

--- a/packages/apps/plugins/plugin-search/src/components/SearchResults/SearchResults.tsx
+++ b/packages/apps/plugins/plugin-search/src/components/SearchResults/SearchResults.tsx
@@ -9,7 +9,8 @@ import { Card, ScrollArea } from '@dxos/react-ui';
 import { type MosaicTileComponent, Mosaic } from '@dxos/react-ui-mosaic';
 import { groupSurface, mx } from '@dxos/react-ui-theme';
 
-import { SEARCH_RESULT, type SearchResult } from '../../search';
+import { SEARCH_RESULT } from '../../meta';
+import type { SearchResult } from '../../search';
 
 // TODO(burdon): Factor out.
 const styles = {

--- a/packages/apps/plugins/plugin-search/src/meta.tsx
+++ b/packages/apps/plugins/plugin-search/src/meta.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { pluginMeta } from '@dxos/app-framework';
 
 export const SEARCH_PLUGIN = 'dxos.org/plugin/search';
+export const SEARCH_RESULT = `${SEARCH_PLUGIN}/result`;
 
 export default pluginMeta({
   id: SEARCH_PLUGIN,

--- a/packages/apps/plugins/plugin-search/src/search.ts
+++ b/packages/apps/plugins/plugin-search/src/search.ts
@@ -4,6 +4,8 @@
 
 import { type Schema, TextObject } from '@dxos/react-client/echo';
 
+import { SEARCH_PLUGIN } from './meta';
+
 // TODO(burdon): Type name registry linked to schema?
 const getIcon = (schema: Schema): string | undefined => {
   const keys = schema.props.map((prop) => prop.id);
@@ -23,6 +25,8 @@ const getIcon = (schema: Schema): string | undefined => {
 // Plain text fields.
 // TODO(burdon): Reconcile with agent index.
 export type TextFields = Record<string, string>;
+
+export const SEARCH_RESULT = `${SEARCH_PLUGIN}/result`;
 
 export type SearchResult = {
   id: string;

--- a/packages/apps/plugins/plugin-search/src/search.ts
+++ b/packages/apps/plugins/plugin-search/src/search.ts
@@ -4,8 +4,6 @@
 
 import { type Schema, TextObject } from '@dxos/react-client/echo';
 
-import { SEARCH_PLUGIN } from './meta';
-
 // TODO(burdon): Type name registry linked to schema?
 const getIcon = (schema: Schema): string | undefined => {
   const keys = schema.props.map((prop) => prop.id);
@@ -25,8 +23,6 @@ const getIcon = (schema: Schema): string | undefined => {
 // Plain text fields.
 // TODO(burdon): Reconcile with agent index.
 export type TextFields = Record<string, string>;
-
-export const SEARCH_RESULT = `${SEARCH_PLUGIN}/result`;
 
 export type SearchResult = {
   id: string;

--- a/packages/apps/plugins/plugin-search/src/types.tsx
+++ b/packages/apps/plugins/plugin-search/src/types.tsx
@@ -5,6 +5,7 @@
 import type {
   GraphBuilderProvides,
   IntentResolverProvides,
+  MetadataRecordsProvides,
   SurfaceProvides,
   TranslationsProvides,
 } from '@dxos/app-framework';
@@ -20,4 +21,5 @@ export enum SearchAction {
 export type SearchPluginProvides = SurfaceProvides &
   IntentResolverProvides &
   GraphBuilderProvides &
+  MetadataRecordsProvides &
   TranslationsProvides;

--- a/packages/ui/react-ui-stack/src/components/Stack.stories.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack.stories.tsx
@@ -9,14 +9,14 @@ import React, { useRef, useState } from 'react';
 
 import { Mosaic, type MosaicDropEvent, type MosaicMoveEvent, type MosaicOperation, Path } from '@dxos/react-ui-mosaic';
 
-import { Stack, type StackProps, type StackSectionItem } from './Stack';
+import { Stack, type StackSectionContent, type StackProps, type StackSectionItem } from './Stack';
 import { FullscreenDecorator, TestObjectGenerator } from '../testing';
 
 faker.seed(3);
 
-const SimpleContent = ({ data }: { data: StackSectionItem }) => <div className='p-4 text-center'>{data.title}</div>;
+const SimpleContent = ({ data }: { data: StackSectionContent }) => <div className='p-4 text-center'>{data.title}</div>;
 
-const ComplexContent = ({ data }: { data: StackSectionItem & { body?: string; image?: string } }) => (
+const ComplexContent = ({ data }: { data: StackSectionContent & { body?: string; image?: string } }) => (
   <div className='flex'>
     <div className='grow p-4'>
       <h1>{data.title ?? data.id}</h1>
@@ -40,14 +40,14 @@ export default {
 
 export const Empty = {
   args: {
-    Component: SimpleContent,
+    SectionContent: SimpleContent,
     count: 0,
   },
 };
 
 export const Simple = {
   args: {
-    Component: SimpleContent,
+    SectionContent: SimpleContent,
     types: ['document'],
     debug: true,
   },
@@ -55,7 +55,7 @@ export const Simple = {
 
 export const Complex = {
   args: {
-    Component: ComplexContent,
+    SectionContent: ComplexContent,
     types: ['document', 'image'],
     debug: true,
   },
@@ -63,7 +63,7 @@ export const Complex = {
 
 export const Transfer = {
   args: {
-    Component: SimpleContent,
+    SectionContent: SimpleContent,
     types: ['document'],
     count: 8,
     className: 'w-[400px]',
@@ -86,7 +86,7 @@ export const Transfer = {
 
 export const Copy = {
   args: {
-    Component: SimpleContent,
+    SectionContent: SimpleContent,
     types: ['document'],
     className: 'w-[400px]',
   },
@@ -114,7 +114,7 @@ export type DemoStackProps = StackProps & {
 
 const DemoStack = ({
   id = 'stack',
-  Component,
+  SectionContent,
   types,
   count = 8,
   operation = 'transfer',
@@ -175,7 +175,7 @@ const DemoStack = ({
     <Stack
       id={id}
       className={className}
-      Component={Component}
+      SectionContent={SectionContent}
       items={items}
       onOver={handleOver}
       onDrop={handleDrop}

--- a/packages/ui/react-ui-stack/src/components/Stack.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack.tsx
@@ -30,15 +30,18 @@ type StackItem = MosaicDataItem & {
 };
 
 export type StackSectionItem = MosaicDataItem & {
-  title: string;
+  object: StackSectionContent;
 };
 
-export type StackProps<TData extends StackSectionItem = StackSectionItem> = Omit<
+export type StackSectionContent = MosaicDataItem & { title?: string };
+
+export type StackProps<TData extends StackSectionContent = StackSectionContent> = Omit<
   MosaicContainerProps<TData, number>,
   'debug' | 'Component'
 > & {
-  Component: FC<{ data: TData }>;
-  items?: TData[];
+  SectionContent: FC<{ data: TData }>;
+  items?: StackSectionItem[];
+  transform?: (item: MosaicDataItem, type?: string) => StackSectionItem;
   onRemoveSection?: (path: string) => void;
   onNavigateToSection?: (id: string) => void;
 };
@@ -47,38 +50,41 @@ export const Stack = ({
   id,
   type = DEFAULT_TYPE,
   className,
-  Component: SectionContent,
+  SectionContent,
   items = [],
+  transform,
   onOver,
   onDrop,
   onRemoveSection,
   onNavigateToSection,
 }: StackProps) => {
   const { ref: containerRef, width = 0 } = useResizeDetector({ refreshRate: 200 });
-  const { operation, overItem } = useMosaic();
+  const { operation, activeItem, overItem } = useMosaic();
   const itemsWithPreview = useItemsWithPreview({ path: id, items });
 
   const Component: MosaicTileComponent<StackSectionItem, HTMLLIElement> = useMemo(
     () =>
-      forwardRef(({ path, active, draggableStyle, draggableProps, item }, forwardRef) => {
+      forwardRef(({ path, type, active, draggableStyle, draggableProps, item }, forwardRef) => {
+        const { t } = useTranslation(translationKey);
+        const transformedItem = transform ? transform(item, active ? activeItem?.type : type) : item;
         const section = (
           <Section
             ref={forwardRef}
-            id={item.id}
-            title={item.title}
+            id={transformedItem.id}
+            title={transformedItem.object.title ?? t('untitled section title')}
             active={active}
             draggableProps={draggableProps}
             draggableStyle={draggableStyle}
             onRemove={() => onRemoveSection?.(path)}
-            onNavigate={() => onNavigateToSection?.(item.id)}
+            onNavigate={() => onNavigateToSection?.(transformedItem.id)}
           >
-            <SectionContent data={item} />
+            <SectionContent data={transformedItem.object} />
           </Section>
         );
 
         return active === 'overlay' ? <List>{section}</List> : section;
       }),
-    [id, SectionContent],
+    [id, SectionContent, transform, activeItem],
   );
 
   // TODO(burdon): Create context provider to relay inner section width.

--- a/packages/ui/react-ui-stack/src/translations.ts
+++ b/packages/ui/react-ui-stack/src/translations.ts
@@ -11,6 +11,7 @@ export default [
         'empty stack message': 'Drag items into the stack.',
         'remove section label': 'Remove section',
         'navigate to section label': 'Navigate to item',
+        'untitled section title': 'Untitled section',
       },
     },
   },


### PR DESCRIPTION
- grid surface limit
- add missing search result transforms
- use stack section objects as items in stack mosaic

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 002c52d</samp>

### Summary
🚀🌐🔎

<!--
1.  🚀 - This emoji represents the performance and usability improvement of the grid plugin by adding a `limit` prop to the `Surface` component. It suggests a fast and smooth experience for the users and developers of the grid plugin.
2.  🌐 - This emoji represents the translation entry added to the `translations` file for the stack plugin. It suggests a global and inclusive approach to the localization and accessibility of the stack plugin.
3.  🔎 - This emoji represents the enhancements and updates made to the search plugin and its integration with other plugins. It suggests a powerful and versatile functionality for the search plugin and its consumers.
-->
This pull request enhances and refactors several plugins for the app framework, such as the markdown, search, stack, and grid plugins. It improves the consistency, readability, and usability of the code and the plugin functionality. It also adds support for different data types and metadata records across plugins, using common types and constants. It updates the placeholder texts, translations, and rendering of the plugin components. The main files affected are `EditorCard.tsx`, `SearchResults.tsx`, `search.ts`, `SearchPlugin.tsx`, `types.tsx`, `StackMain.tsx`, `Stack.tsx`, `GridMain.tsx`, and `translations.ts`.

> _We are the masters of the grid, we render what we will_
> _We search and stack the data, we parse the metadata_
> _We import and export the types, we define the constants_
> _We refactor and improve the code, we are the plugin killers_

### Walkthrough
*  Add a `limit` prop to the `Surface` component in the grid plugin to improve performance and usability ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-67c0b2eb0a5e6e6e52cc6fadc62369646425931154e81f33f345ab693a8b567aL103-R103))
*  Change the `placeholder` props of the `Input` and `MarkdownEditor` components in the markdown editor to be more descriptive and consistent ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-0b697508efd3f8e3974e8e5aeea65909bc93b04f0fa3d54ddcd5464b1c0969beL38-R38), [link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-0b697508efd3f8e3974e8e5aeea65909bc93b04f0fa3d54ddcd5464b1c0969beL65-R65))
*  Import the `SEARCH_RESULT` constant and the `SearchResult` type from the `search` file instead of the `types` file in the search plugin to be more consistent with the file structure ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-4cce17637f0c3ae9f1975d6817788a277124dc246a5d1af35672c4ed9edc332bL12-R12))
*  Add a `type` prop to the `Surface` component in the search plugin to use the metadata records to parse the search results ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-4cce17637f0c3ae9f1975d6817788a277124dc246a5d1af35672c4ed9edc332bR106))
*  Add an import statement for the `SEARCH_PLUGIN` constant in the `search` file to represent the plugin ID ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-3f2858fb3937a9ec1cd5fdf361f598c84e6a03dfe142d7bf7aa49e5b73be1f7bR7-R8))
*  Add a constant declaration for the `SEARCH_RESULT` constant in the `search` file to represent the data type of the search results ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-3f2858fb3937a9ec1cd5fdf361f598c84e6a03dfe142d7bf7aa49e5b73be1f7bR29-R30))
*  Import the `SEARCH_RESULT` constant and the `SearchResult` type from the `search` file in the `SearchPlugin` file to represent the search results ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-59e1916286987f051b04a85b1a9d666098d8c92b8beeb6ef8cff09d69ebe8718R15))
*  Add a `metadata` property to the `SearchPlugin` object to provide metadata records for the app framework ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-59e1916286987f051b04a85b1a9d666098d8c92b8beeb6ef8cff09d69ebe8718R24-R47))
*  Import the `MetadataRecordsProvides` type from the app framework in the `types` file to represent the metadata records provided by a plugin ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-e5d089b275319d6f498d43f98ab2b5e375fe1894fcc5ebf53f5204c7853ebc65R8))
*  Extend the `SearchPluginProvides` type with the `MetadataRecordsProvides` type to indicate that the search plugin provides metadata records ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-e5d089b275319d6f498d43f98ab2b5e375fe1894fcc5ebf53f5204c7853ebc65R24))
*  Remove unused imports and add new imports for the `MosaicDataItem` and `StackProps` types in the `StackMain` file ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068L17-R20))
*  Rename the `StackContent` function to `SectionContent` and change the way it accesses the data object from the item argument in the `StackMain` file ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068L28-R28))
*  Remove unnecessary mapping and filtering of the `stack.sections` array and use the `itemsWithPreview` array instead in the `StackMain` file ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068L42-R40))
*  Add a comment to indicate that the creation of new section objects is a temporary workaround in the `StackMain` file ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068R72))
*  Change the way the index of the section to be removed is found using the `id` property instead of the `object.id` property in the `StackMain` file ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068L85-R81))
*  Add a `handleTransform` function to transform the data items into the `StackSectionItem` type and pass it as the `transform` prop to the `Stack` component in the `StackMain` file ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-6214f46afac12a594e277650aed8eb4bc72d5b23efbcf159f40cd318b1f4e068L107-R115))
*  Change the `StackSectionItem` type to use the `object` property instead of the `title` property and change the `StackProps` type to use the `SectionContent` and `transform` properties instead of the `Component` property in the `Stack` file ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-6d9916d392111dfbbaea8bee0b2a071c011fadc36b624705046ddd06bb9f5a67L33-R44))
*  Change the destructuring of the props argument to use the `SectionContent` and `transform` properties instead of the `Component` property in the `Stack` file ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-6d9916d392111dfbbaea8bee0b2a071c011fadc36b624705046ddd06bb9f5a67L50-R55))
*  Change the definition of the `Component` constant to use the `type` parameter and the `transformedItem` constant and add a fallback value for the `title` property in the `Stack` file ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-6d9916d392111dfbbaea8bee0b2a071c011fadc36b624705046ddd06bb9f5a67L58-R81))
*  Change the dependencies of the `useMemo` hook to include the `transform` and `activeItem` properties in the `Stack` file ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-6d9916d392111dfbbaea8bee0b2a071c011fadc36b624705046ddd06bb9f5a67L81-R87))
*  Add a translation entry for the `untitled section title` key in the `translations` file ([link](https://github.com/dxos/dxos/pull/4778/files?diff=unified&w=0#diff-c52ced1a1068fc9e846d3d0e601614f328131e85d5471c70a39b2e34a82b2471R14))


