### PR TITLE
feat(automerge): Add automerge array

### DIFF
--- a/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
@@ -128,11 +128,7 @@ export class AutomergeArray<T> implements Array<T> {
         }
         const array: any[] = parent[fullPath.at(-1)!];
         invariant(Array.isArray(array));
-        array.splice(
-          start,
-          deleteCount ?? 0,
-          ...items.map((value) => this._object!._encode(this._path!, this._encode(value))),
-        );
+        array.splice(start, deleteCount ?? 0, ...items.map((value) => this._object!._encode(this._encode(value))));
       };
       this._object._change(changeFn);
       return deletedItems;

--- a/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
@@ -294,7 +294,7 @@ export class AutomergeArray<T> implements Array<T> {
         }
         const array: any[] = parent[fullPath.at(-1)!];
         invariant(Array.isArray(array));
-        array.push(...items.map((value) => this._object!._encode(this._path!, this._encode(value))));
+        array.push(...items.map((value) => this._object!._encode(this._encode(value))));
       };
       this._object._change(changeFn);
     } else {
@@ -416,7 +416,7 @@ export class AutomergeArray<T> implements Array<T> {
       }
       const array: any[] = parent[fullPath.at(-1)!];
       invariant(Array.isArray(array));
-      array[index] = this._object!._encode(this._path!, this._encode(value));
+      array[index] = this._object!._encode(this._encode(value));
     };
     this._object._change(changeFn);
   }

--- a/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
@@ -380,7 +380,7 @@ export class AutomergeArray<T> implements Array<T> {
   }
 
   private _getArray(): T[] {
-    // TODO(mykola): Add cache to improve performance.
+    // TODO(mykola): Add cache to improve performance?
     invariant(this._object?.[base] instanceof AutomergeObject);
     const array = this._object._get(this._path!);
     invariant(Array.isArray(array));

--- a/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
@@ -60,6 +60,7 @@ export class AutomergeArray<T> implements Array<T> {
 
   get length(): number {
     if (this._object) {
+      // TODO(mykola) Triggers deserialization. We can avoid it to improve performance.
       const array = this._getArray();
       if (!array) {
         return 0;
@@ -379,6 +380,7 @@ export class AutomergeArray<T> implements Array<T> {
   }
 
   private _getArray(): T[] {
+    // TODO(mykola): Add cache to improve performance.
     invariant(this._object?.[base] instanceof AutomergeObject);
     const array = this._object._get(this._path!);
     invariant(Array.isArray(array));

--- a/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
@@ -118,6 +118,7 @@ export class AutomergeArray<T> implements Array<T> {
 
       const fullPath = [...this._object._path, ...this._path!];
 
+      // TODO(mykola): Do not allow direct access to doc in array.
       const changeFn: ChangeFn<any> = (doc) => {
         let parent = doc;
         for (const key of fullPath.slice(0, -1)) {
@@ -279,6 +280,7 @@ export class AutomergeArray<T> implements Array<T> {
     if (this._object) {
       const fullPath = [...this._object._path, ...this._path!];
 
+      // TODO(mykola): Do not allow direct access to doc in array.
       const changeFn: ChangeFn<any> = (doc) => {
         let parent = doc;
         for (const key of fullPath.slice(0, -1)) {
@@ -363,6 +365,7 @@ export class AutomergeArray<T> implements Array<T> {
 
     const fullPath = [...this._object._path, ...this._path!];
 
+    // TODO(mykola): Do not allow direct access to doc in array.
     const changeFn: ChangeFn<any> = (doc) => {
       let parent = doc;
       for (const key of fullPath.slice(0, -1)) {

--- a/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
@@ -60,7 +60,7 @@ export class AutomergeArray<T> implements Array<T> {
 
   get length(): number {
     if (this._object) {
-      const array = this._getModelArray(false);
+      const array = this._getArray();
       if (!array) {
         return 0;
       }
@@ -243,13 +243,12 @@ export class AutomergeArray<T> implements Array<T> {
     if (this._object) {
       invariant(this._object?.[base] instanceof AutomergeObject);
 
-      const array = this._getModelArray();
+      const array = this._getArray();
       if (!array) {
         return [][Symbol.iterator]();
       }
-      invariant(Array.isArray(array));
 
-      return (array.map((value: string) => this._object!._decode(value)).filter(Boolean) as T[]).values();
+      return (array.filter(Boolean) as T[]).values();
     } else {
       invariant(this._uninitialized);
       return this._uninitialized[Symbol.iterator]();
@@ -356,9 +355,7 @@ export class AutomergeArray<T> implements Array<T> {
   }
 
   private _getModel(index: number): T | undefined {
-    const array = this._getModelArray();
-    invariant(Array.isArray(array));
-    return this._object!._decode(array[index]) as T | undefined;
+    return this._getArray()[index] as T | undefined;
   }
 
   private _setModel(index: number, value: T) {
@@ -378,8 +375,10 @@ export class AutomergeArray<T> implements Array<T> {
     this._object._change(changeFn);
   }
 
-  private _getModelArray(decode = true): any[] | undefined {
+  private _getArray(): T[] {
     invariant(this._object?.[base] instanceof AutomergeObject);
-    return this._object._get(this._path!, decode);
+    const array = this._object._get(this._path!);
+    invariant(Array.isArray(array));
+    return array;
   }
 }

--- a/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
@@ -284,7 +284,6 @@ export class AutomergeArray<T> implements Array<T> {
   }
 
   push(...items: T[]) {
-    log.info('push', { items });
     if (this._object) {
       const fullPath = [...this._object._path, ...this._path!];
 
@@ -424,14 +423,7 @@ export class AutomergeArray<T> implements Array<T> {
 
   private _getModelArray(): any[] | undefined {
     invariant(this._object?.[base] instanceof AutomergeObject);
-
-    const fullPath = [...this._object._path, ...this._path!];
-    let value = this._object._getDoc();
-    for (const key of fullPath) {
-      value = value?.[key];
-    }
-
-    return value as any[];
+    return this._object._get(this._path!);
   }
 }
 

--- a/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-array.ts
@@ -1,0 +1,437 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { inspect, type CustomInspectFunction } from 'node:util';
+
+import { type ChangeFn } from '@dxos/automerge/automerge';
+import { Reference } from '@dxos/document-model';
+import { invariant } from '@dxos/invariant';
+import { log } from '@dxos/log';
+
+import { AutomergeObject } from './automerge-object';
+import { base } from '../object';
+import { AbstractEchoObject } from '../object/object';
+
+const isIndex = (property: string | symbol): property is string =>
+  typeof property === 'string' && parseInt(property).toString() === property;
+
+export class AutomergeArray<T> implements Array<T> {
+  /**
+   * Until this array is attached a document, the items are stored in this array.
+   */
+  private _uninitialized?: T[] = [];
+
+  private _object?: AutomergeObject;
+  private _path?: string[];
+
+  [base]: AutomergeArray<T> = this;
+
+  [n: number]: T;
+
+  [Symbol.iterator](): IterableIterator<T> {
+    return this.values();
+  }
+
+  get [Symbol.unscopables](): any {
+    throw new Error('Method not implemented.');
+  }
+
+  constructor(items: T[] = []) {
+    this._uninitialized = [...items];
+
+    // Change type returned by `new`.
+    return new Proxy(this, {
+      get: (target, property, receiver) => {
+        if (isIndex(property)) {
+          return this._get(+property);
+        } else {
+          return Reflect.get(target, property, receiver);
+        }
+      },
+
+      set: (target, property, value, receiver) => {
+        if (isIndex(property)) {
+          this._set(+property, value);
+          return true;
+        } else {
+          return Reflect.set(target, property, value, receiver);
+        }
+      },
+    });
+  }
+
+  get length(): number {
+    if (this._object) {
+      const array = this._getModelArray();
+      if (!array) {
+        return 0;
+      }
+      return array.length;
+    } else {
+      invariant(this._uninitialized);
+      return this._uninitialized.length;
+    }
+  }
+
+  toString(): string {
+    throw new Error('Method not implemented.');
+  }
+
+  toLocaleString(): string {
+    throw new Error('Method not implemented.');
+  }
+
+  pop(): T | undefined {
+    throw new Error('Method not implemented.');
+  }
+
+  concat(...items: ConcatArray<T>[]): T[];
+  concat(...items: (T | ConcatArray<T>)[]): T[];
+  concat(...items: unknown[]): T[] {
+    throw new Error('Method not implemented.');
+  }
+
+  join(separator?: string | undefined): string {
+    throw new Error('Method not implemented.');
+  }
+
+  reverse(): T[] {
+    throw new Error('Method not implemented.');
+  }
+
+  shift(): T | undefined {
+    throw new Error('Method not implemented.');
+  }
+
+  slice(start?: number | undefined, end?: number | undefined): T[] {
+    return Array.from(this.values()).slice(start, end);
+  }
+
+  sort(compareFn?: ((a: T, b: T) => number) | undefined): this {
+    throw new Error('Method not implemented.');
+  }
+
+  splice(start: number, deleteCount?: number | undefined): T[];
+  splice(start: number, deleteCount: number, ...items: T[]): T[];
+  splice(start: number, deleteCount?: number | undefined, ...items: T[]): T[] {
+    if (this._object) {
+      throw new Error('Method not implemented.');
+    } else {
+      invariant(this._uninitialized);
+      // TODO(burdon): Check param types.
+      return this._uninitialized.splice(start as number, deleteCount as number, ...(items as any[]));
+    }
+
+    // console.log({
+    //   links: (this._orderedList as any)._model.get((this._orderedList as any)._property) ?? {},
+    //   values: this._orderedList.values
+    // })
+  }
+
+  unshift(...items: T[]): number {
+    throw new Error('Method not implemented.');
+  }
+
+  indexOf(searchElement: T, fromIndex?: number | undefined): number {
+    return Array.from(this.values()).indexOf(searchElement, fromIndex);
+  }
+
+  lastIndexOf(searchElement: T, fromIndex?: number | undefined): number {
+    return Array.from(this.values()).lastIndexOf(searchElement, fromIndex);
+  }
+
+  every<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): this is S[];
+  every(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+  every(predicate: any, thisArg?: unknown): boolean {
+    return Array.from(this.values()).every(predicate, thisArg);
+  }
+
+  some(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean {
+    return Array.from(this.values()).some(predicate, thisArg);
+  }
+
+  forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void {
+    Array.from(this.values()).forEach(callbackfn, thisArg);
+  }
+
+  map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[] {
+    return Array.from(this.values()).map(callbackfn, thisArg);
+  }
+
+  filter<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): S[];
+  filter(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T[];
+  filter<S extends T>(predicate: any, thisArg?: unknown): T[] | S[] {
+    return Array.from(this.values()).filter(predicate, thisArg);
+  }
+
+  reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T;
+  reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue: T): T;
+  reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+  reduce<U>(callbackfn: any, initialValue?: any): T | U {
+    return Array.from(this.values()).reduce(callbackfn, initialValue);
+  }
+
+  reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T;
+  reduceRight(
+    callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T,
+    initialValue: T,
+  ): T;
+
+  reduceRight<U>(
+    callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U,
+    initialValue: U,
+  ): U;
+
+  reduceRight<U>(callbackfn: any, initialValue?: any): T | U {
+    return Array.from(this.values()).reduceRight(callbackfn, initialValue);
+  }
+
+  find<S extends T>(
+    predicate: (this: void, value: T, index: number, obj: T[]) => value is S,
+    thisArg?: any,
+  ): S | undefined;
+
+  find(predicate: (value: T, index: number, obj: T[]) => unknown, thisArg?: any): T | undefined;
+  find<S extends T>(predicate: any, thisArg?: any): T | S | undefined {
+    return Array.from(this.values()).find(predicate, thisArg);
+  }
+
+  findIndex(predicate: (value: T, index: number, obj: T[]) => unknown, thisArg?: any): number {
+    return Array.from(this.values()).findIndex(predicate, thisArg);
+  }
+
+  findLast<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): S | undefined;
+  findLast(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T | undefined;
+  findLast(predicate: any, thisArg?: any): T | undefined {
+    return Array.from(this.values()).findLast(predicate, thisArg);
+  }
+
+  findLastIndex(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): number {
+    return Array.from(this.values()).findLastIndex(predicate, thisArg);
+  }
+
+  fill(value: T, start?: number | undefined, end?: number | undefined): this {
+    throw new Error('Method not implemented.');
+  }
+
+  copyWithin(target: number, start: number, end?: number | undefined): this {
+    throw new Error('Method not implemented.');
+  }
+
+  entries(): IterableIterator<[number, T]> {
+    throw new Error('Method not implemented.');
+  }
+
+  keys(): IterableIterator<number> {
+    throw new Error('Method not implemented.');
+  }
+
+  values(): IterableIterator<T> {
+    if (this._object) {
+      invariant(this._object?.[base] instanceof AutomergeObject);
+
+      const array: any[] = this._object[base]._get(this._path!);
+      if (!array) {
+        return [][Symbol.iterator]();
+      }
+      invariant(Array.isArray(array));
+
+      return (array.map((value: string) => this._decode(value)).filter(Boolean) as T[]).values();
+    } else {
+      invariant(this._uninitialized);
+      return this._uninitialized[Symbol.iterator]();
+    }
+  }
+
+  includes(searchElement: T, fromIndex?: number | undefined): boolean {
+    return Array.from(this.values()).includes(searchElement, fromIndex);
+  }
+
+  flatMap<U, This = undefined>(
+    callback: (this: This, value: T, index: number, array: T[]) => U | readonly U[],
+    thisArg?: This | undefined,
+  ): U[] {
+    return Array.from(this.values()).flatMap(callback, thisArg);
+  }
+
+  flat<A, D extends number = 1>(this: A, depth?: D | undefined): FlatArray<A, D>[] {
+    throw new Error('Method not implemented.');
+  }
+
+  at(index: number): T | undefined {
+    const trueIndex = index < 0 ? this.length + index : index;
+    return this._get(trueIndex);
+  }
+
+  push(...items: T[]) {
+    if (this._object) {
+      const fullPath = [...this._object._path, ...this._path!];
+
+      const changeFn: ChangeFn<any> = (doc) => {
+        let parent = doc;
+        for (const key of fullPath.slice(0, -1)) {
+          parent = parent[key];
+        }
+        const array: any[] = parent[fullPath.at(-1)!];
+        invariant(Array.isArray(array));
+        array.push(...items.map((value) => this._object!._encode(this._path!, this._encode(value))));
+      };
+      this._object._change(changeFn);
+    } else {
+      invariant(this._uninitialized);
+      this._uninitialized.push(...items);
+    }
+
+    return this.length;
+  }
+
+  [inspect.custom]: CustomInspectFunction = (depth, options) => {
+    const data = this.slice();
+
+    return inspect(data, { ...options, depth: typeof options.depth === 'number' ? options.depth - 1 : options.depth });
+  };
+
+  toReversed(): T[] {
+    throw new Error('Method not implemented.');
+  }
+
+  toSorted(compareFn?: ((a: T, b: T) => number) | undefined): T[] {
+    throw new Error('Method not implemented.');
+  }
+
+  toSpliced(start: number, deleteCount: number, ...items: T[]): T[];
+  toSpliced(start: number, deleteCount?: number | undefined): T[];
+  toSpliced(start: unknown, deleteCount?: unknown, ...items: unknown[]): T[] {
+    throw new Error('Method not implemented.');
+  }
+
+  with(index: number, value: T): T[] {
+    throw new Error('Method not implemented.');
+  }
+
+  //
+  // Impl.
+  //
+
+  private _decode(value: any): T | undefined {
+    if (value instanceof Reference) {
+      return this._object!._lookupLink(value) as T | undefined;
+    } else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      return decodeRecords(value, this._object!);
+    } else {
+      return value;
+    }
+  }
+
+  private _encode(value: T) {
+    if (value instanceof AbstractEchoObject) {
+      return this._object!._linkObject(value);
+    } else if (
+      typeof value === 'object' &&
+      value !== null &&
+      Object.getOwnPropertyNames(value).length === 1 &&
+      (value as any)['@id']
+    ) {
+      return new Reference((value as any)['@id']);
+    } else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      log('Freezing object before encoding', value);
+      Object.freeze(value);
+      return encodeRecords(value, this._object!);
+    } else {
+      invariant(
+        value === null ||
+          value === undefined ||
+          typeof value === 'boolean' ||
+          typeof value === 'number' ||
+          typeof value === 'string',
+        `Invalid type: ${JSON.stringify(value)}`,
+      );
+      return value;
+    }
+  }
+
+  /**
+   * @internal
+   */
+  _attach(document: AutomergeObject, path: string[]) {
+    this._object = document;
+    this._path = path;
+    this._uninitialized = undefined;
+    return this;
+  }
+
+  private _get(index: number): T | undefined {
+    if (this._object) {
+      return this._getModel(index);
+    } else {
+      invariant(this._uninitialized);
+      return this._uninitialized[index];
+    }
+  }
+
+  private _set(index: number, value: T) {
+    if (this._object) {
+      this._setModel(index, value);
+    } else {
+      invariant(this._uninitialized);
+      this._uninitialized[index] = value;
+    }
+  }
+
+  private _getModel(index: number): T | undefined {
+    const array = this._getModelArray();
+    invariant(Array.isArray(array));
+    return this._decode(array[index]) as T | undefined;
+  }
+
+  private _setModel(index: number, value: T) {
+    invariant(this._object?.[base] instanceof AutomergeObject);
+
+    const fullPath = [...this._object._path, ...this._path!];
+
+    const changeFn: ChangeFn<any> = (doc) => {
+      let parent = doc;
+      for (const key of fullPath.slice(0, -1)) {
+        parent = parent[key];
+      }
+      const array: any[] = parent[fullPath.at(-1)!];
+      invariant(Array.isArray(array));
+      array[index] = this._object!._encode(this._path!, this._encode(value));
+    };
+    this._object._change(changeFn);
+  }
+
+  private _getModelArray(): any[] | undefined {
+    invariant(this._object?.[base] instanceof AutomergeObject);
+
+    const array: any[] = this._object[base]._get(this._path!);
+    return array;
+  }
+}
+
+const encodeRecords = (value: any, document: AutomergeObject): any => {
+  if (value instanceof AbstractEchoObject) {
+    return document!._linkObject(value);
+  } else if (Array.isArray(value)) {
+    return value.map((value) => encodeRecords(value, document));
+  } else if (typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, value]): [string, any] => [key, encodeRecords(value, document)]),
+    );
+  }
+  return value;
+};
+
+const decodeRecords = (value: any, document: AutomergeObject): any => {
+  if (value instanceof Reference) {
+    return document._lookupLink(value);
+  } else if (Array.isArray(value)) {
+    return value.map((value) => decodeRecords(value, document));
+  } else if (typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, value]): [string, any] => [key, decodeRecords(value, document)]),
+    );
+  }
+  return value;
+};

--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -273,7 +273,7 @@ export class AutomergeObject implements TypedObjectProperties {
         return this._encode(val);
       });
       return values;
-    } else if (typeof value === 'object') {
+    } else if (typeof value === 'object' && value !== null) {
       Object.freeze(value);
       return Object.fromEntries(Object.entries(value).map(([key, value]): [string, any] => [key, this._encode(value)]));
     }

--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -94,7 +94,11 @@ export class AutomergeObject implements TypedObjectProperties {
   }
 
   toJSON() {
-    return this._getDoc();
+    let value = this[base]._getDoc();
+    for (const key of this[base]._path) {
+      value = value?.[key];
+    }
+    return value;
   }
 
   get id(): string {
@@ -200,14 +204,14 @@ export class AutomergeObject implements TypedObjectProperties {
   /**
    * @internal
    */
-  _get(path: string[], decode = true) {
+  _get(path: string[]) {
     const fullPath = [...this._path, ...path];
     let value = this._getDoc();
     for (const key of fullPath) {
       value = value?.[key];
     }
 
-    return decode ? this._decode(value) : value;
+    return this._decode(value);
   }
 
   /**

--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -180,7 +180,7 @@ export class AutomergeObject implements TypedObjectProperties {
 
         const value = this._get([...path, key as string]);
 
-        if (typeof value === 'object' && value !== null) {
+        if (typeof value === 'object' && value !== null && !(value instanceof AutomergeArray)) {
           // TODO(dmaretskyi): Check for Reference types.
           return this._createProxy(path);
         }
@@ -256,7 +256,7 @@ export class AutomergeObject implements TypedObjectProperties {
       };
     } else if (value instanceof AutomergeArray) {
       const values: any = value.map((val) => {
-        if (value instanceof AutomergeArray || Array.isArray(value)) {
+        if (val instanceof AutomergeArray || Array.isArray(val)) {
           // TODO(mykola): Add support for nested arrays.
           throw new Error('Nested arrays are not supported');
         }
@@ -279,7 +279,10 @@ export class AutomergeObject implements TypedObjectProperties {
     return value;
   }
 
-  private _getDoc(): Doc<any> {
+  /**
+   * @internal
+   */
+  _getDoc(): Doc<any> {
     return this._doc ?? this._docHandle?.docSync() ?? failedInvariant();
   }
 

--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -258,6 +258,7 @@ export class AutomergeObject implements TypedObjectProperties {
     }
     if (value instanceof AbstractEchoObject || value instanceof AutomergeObject) {
       const reference = this._linkObject(value);
+      // NOTE: Automerge do not support undefined values, so we need to use null instead.
       return {
         '@type': REFERENCE_TYPE_TAG,
         itemId: reference.itemId ?? null,

--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -125,8 +125,8 @@ export class AutomergeObject implements TypedObjectProperties {
       // TODO(dmaretskyi): type: ???.
 
       // TODO(dmaretskyi): Initial values for data.
-      data: this._encode(['data'], initialProps ?? {}),
-      meta: this._encode(['meta'], {
+      data: this._encode(initialProps ?? {}),
+      meta: this._encode({
         keys: [],
         ...opts?.meta,
       }),
@@ -222,7 +222,11 @@ export class AutomergeObject implements TypedObjectProperties {
         parent[key] ??= {};
         parent = parent[key];
       }
-      parent[fullPath.at(-1)!] = this._encode(path, value);
+      parent[fullPath.at(-1)!] = this._encode(value);
+
+      if (value instanceof AutomergeArray) {
+        value._attach(this[base], path);
+      }
     };
 
     this._change(changeFn);
@@ -244,7 +248,7 @@ export class AutomergeObject implements TypedObjectProperties {
   /**
    * @internal
    */
-  _encode(path: string[], value: any) {
+  _encode(value: any) {
     if (value === undefined) {
       return null;
     }
@@ -262,9 +266,8 @@ export class AutomergeObject implements TypedObjectProperties {
           // TODO(mykola): Add support for nested arrays.
           throw new Error('Nested arrays are not supported');
         }
-        return this._encode(path, val);
+        return this._encode(val);
       });
-      value._attach(this[base], path);
       return values;
     }
     return value;

--- a/packages/core/echo/echo-schema/src/object/array.test.ts
+++ b/packages/core/echo/echo-schema/src/object/array.test.ts
@@ -7,11 +7,14 @@ import expect from 'expect'; // TODO(burdon): Can't use chai with wait-for-expec
 import { describe, test } from '@dxos/test';
 
 import { EchoArray } from './array';
-import { Expando, TypedObject } from './typed-object';
+import { Expando, TypedObject, getGlobalAutomergePreference } from './typed-object';
+import { AutomergeArray } from '../automerge/automerge-array';
 import { createDatabase, testWithAutomerge } from '../testing';
 
-describe.only('Arrays', () => {
+describe('Arrays', () => {
   testWithAutomerge(() => {
+    const ArrayConstructor = getGlobalAutomergePreference() ? AutomergeArray : EchoArray;
+
     test('array of tags', async () => {
       const { db } = await createDatabase();
 
@@ -75,7 +78,7 @@ describe.only('Arrays', () => {
       await db.flush();
 
       task.tags = ['red', 'green', 'blue'];
-      // expect(task.tags instanceof EchoArray).toBeTruthy();
+      expect(task.tags instanceof ArrayConstructor).toBeTruthy();
       expect(task.tags.length).toEqual(3);
       expect(task.tags.slice()).toEqual(['red', 'green', 'blue']);
 
@@ -91,7 +94,7 @@ describe.only('Arrays', () => {
       await db.flush();
 
       task.tags = [];
-      expect(task.tags instanceof EchoArray).toBeTruthy();
+      expect(task.tags instanceof ArrayConstructor).toBeTruthy();
       expect(task.tags.length).toEqual(0);
     });
 

--- a/packages/core/echo/echo-schema/src/object/array.test.ts
+++ b/packages/core/echo/echo-schema/src/object/array.test.ts
@@ -8,142 +8,144 @@ import { describe, test } from '@dxos/test';
 
 import { EchoArray } from './array';
 import { Expando, TypedObject } from './typed-object';
-import { createDatabase } from '../testing';
+import { createDatabase, testWithAutomerge } from '../testing';
 
-describe('Arrays', () => {
-  test('array of tags', async () => {
-    const { db } = await createDatabase();
+describe.only('Arrays', () => {
+  testWithAutomerge(() => {
+    test('array of tags', async () => {
+      const { db } = await createDatabase();
 
-    const task = new TypedObject({ title: 'Main task' });
-    db.add(task);
-    await db.flush();
+      const task = new TypedObject({ title: 'Main task' });
+      db.add(task);
+      await db.flush();
 
-    task.tags = new EchoArray();
-    task.tags.push('red');
-    task.tags.push('green');
-    task.tags.push('blue');
-    expect(task.tags.length).toEqual(3);
-    expect(task.tags.slice()).toEqual(['red', 'green', 'blue']);
-    expect(task.tags[0]).toEqual('red');
-    expect(task.tags[1]).toEqual('green');
+      task.tags = new EchoArray();
+      task.tags.push('red');  
+      task.tags.push('green');
+      task.tags.push('blue');
+      expect(task.tags.length).toEqual(3);
+      expect(task.tags.slice()).toEqual(['red', 'green', 'blue']);
+      expect(task.tags[0]).toEqual('red');
+      expect(task.tags[1]).toEqual('green');
 
-    task.tags[1] = 'yellow';
-    expect(task.tags.slice()).toEqual(['red', 'yellow', 'blue']);
+      task.tags[1] = 'yellow';
+      expect(task.tags.slice()).toEqual(['red', 'yellow', 'blue']);
 
-    task.tags.splice(1, 0, 'magenta');
-    expect(task.tags.slice()).toEqual(['red', 'magenta', 'yellow', 'blue']);
+      task.tags.splice(1, 0, 'magenta');
+      expect(task.tags.slice()).toEqual(['red', 'magenta', 'yellow', 'blue']);
 
-    // Move yellow before magenta
-    task.tags.splice(2, 1);
-    task.tags.splice(1, 0, 'yellow');
-    expect(task.tags.slice()).toEqual(['red', 'yellow', 'magenta', 'blue']);
-  });
-  test('array of sub documents', async () => {
-    const { db } = await createDatabase();
+      // Move yellow before magenta
+      task.tags.splice(2, 1);
+      task.tags.splice(1, 0, 'yellow');
+      expect(task.tags.slice()).toEqual(['red', 'yellow', 'magenta', 'blue']);
+    });
+    test('array of sub documents', async () => {
+      const { db } = await createDatabase();
 
-    const task = new TypedObject({ title: 'Main task' });
-    db.add(task);
-    await db.flush();
+      const task = new TypedObject({ title: 'Main task' });
+      db.add(task);
+      await db.flush();
 
-    task.subtasks = new EchoArray();
-    task.subtasks.push(new TypedObject({ title: 'Subtask 1' }));
-    task.subtasks.push(new TypedObject({ title: 'Subtask 2' }));
-    task.subtasks.push(new TypedObject({ title: 'Subtask 3' }));
+      task.subtasks = new EchoArray();
+      task.subtasks.push(new TypedObject({ title: 'Subtask 1' }));
+      task.subtasks.push(new TypedObject({ title: 'Subtask 2' }));
+      task.subtasks.push(new TypedObject({ title: 'Subtask 3' }));
 
-    expect(task.subtasks.length).toEqual(3);
-    expect(task.subtasks[0].title).toEqual('Subtask 1');
-    expect(task.subtasks[1].title).toEqual('Subtask 2');
-    expect(task.subtasks[2].title).toEqual('Subtask 3');
+      expect(task.subtasks.length).toEqual(3);
+      expect(task.subtasks[0].title).toEqual('Subtask 1');
+      expect(task.subtasks[1].title).toEqual('Subtask 2');
+      expect(task.subtasks[2].title).toEqual('Subtask 3');
 
-    const titles = task.subtasks.map((subtask: TypedObject) => subtask.title);
-    expect(titles).toEqual(['Subtask 1', 'Subtask 2', 'Subtask 3']);
+      const titles = task.subtasks.map((subtask: TypedObject) => subtask.title);
+      expect(titles).toEqual(['Subtask 1', 'Subtask 2', 'Subtask 3']);
 
-    task.subtasks[0] = new TypedObject({ title: 'New subtask 1' });
-    expect(task.subtasks.map((subtask: TypedObject) => subtask.title)).toEqual([
-      'New subtask 1',
-      'Subtask 2',
-      'Subtask 3',
-    ]);
-  });
+      task.subtasks[0] = new TypedObject({ title: 'New subtask 1' });
+      expect(task.subtasks.map((subtask: TypedObject) => subtask.title)).toEqual([
+        'New subtask 1',
+        'Subtask 2',
+        'Subtask 3',
+      ]);
+    });
 
-  test('assign a plain array', async () => {
-    const { db } = await createDatabase();
+    test('assign a plain array', async () => {
+      const { db } = await createDatabase();
 
-    const task = new TypedObject({ title: 'Main task' });
-    db.add(task);
-    await db.flush();
+      const task = new TypedObject({ title: 'Main task' });
+      db.add(task);
+      await db.flush();
 
-    task.tags = ['red', 'green', 'blue'];
-    expect(task.tags instanceof EchoArray).toBeTruthy();
-    expect(task.tags.length).toEqual(3);
-    expect(task.tags.slice()).toEqual(['red', 'green', 'blue']);
+      task.tags = ['red', 'green', 'blue'];
+      expect(task.tags instanceof EchoArray).toBeTruthy();
+      expect(task.tags.length).toEqual(3);
+      expect(task.tags.slice()).toEqual(['red', 'green', 'blue']);
 
-    task.tags[1] = 'yellow';
-    expect(task.tags.slice()).toEqual(['red', 'yellow', 'blue']);
-  });
+      task.tags[1] = 'yellow';
+      expect(task.tags.slice()).toEqual(['red', 'yellow', 'blue']);
+    });
 
-  test('empty array', async () => {
-    const { db } = await createDatabase();
+    test('empty array', async () => {
+      const { db } = await createDatabase();
 
-    const task = new TypedObject({ title: 'Main task' });
-    db.add(task);
-    await db.flush();
+      const task = new TypedObject({ title: 'Main task' });
+      db.add(task);
+      await db.flush();
 
-    task.tags = [];
-    expect(task.tags instanceof EchoArray).toBeTruthy();
-    expect(task.tags.length).toEqual(0);
-  });
+      task.tags = [];
+      expect(task.tags instanceof EchoArray).toBeTruthy();
+      expect(task.tags.length).toEqual(0);
+    });
 
-  test('importing arrays into a database', async () => {
-    const { db } = await createDatabase();
+    test('importing arrays into a database', async () => {
+      const { db } = await createDatabase();
 
-    const root = new TypedObject({ title: 'Main task' });
-    root.array = [new TypedObject({ title: 'Subtask 1' }), 'red'];
-    expect(root.array.length).toEqual(2);
-    expect(root.array[0].title).toEqual('Subtask 1');
-    expect(root.array[1]).toEqual('red');
+      const root = new TypedObject({ title: 'Main task' });
+      root.array = [new TypedObject({ title: 'Subtask 1' }), 'red'];
+      expect(root.array.length).toEqual(2);
+      expect(root.array[0].title).toEqual('Subtask 1');
+      expect(root.array[1]).toEqual('red');
 
-    db.add(root);
-    await db.flush();
+      db.add(root);
+      await db.flush();
 
-    expect(root.array.length).toEqual(2);
-    expect(root.array[0].title).toEqual('Subtask 1');
-    expect(root.array[1]).toEqual('red');
+      expect(root.array.length).toEqual(2);
+      expect(root.array[0].title).toEqual('Subtask 1');
+      expect(root.array[1]).toEqual('red');
 
-    const { objects } = db.query();
-    expect(objects).toContain(root.array[0]);
-  });
+      const { objects } = db.query();
+      expect(objects).toContain(root.array[0]);
+    });
 
-  test('importing empty arrays into a database', async () => {
-    const { db } = await createDatabase();
+    test('importing empty arrays into a database', async () => {
+      const { db } = await createDatabase();
 
-    const root = new TypedObject();
-    root.array = [];
-    expect(root.array.length).toEqual(0);
+      const root = new TypedObject();
+      root.array = [];
+      expect(root.array.length).toEqual(0);
 
-    db.add(root);
-    await db.flush();
+      db.add(root);
+      await db.flush();
 
-    expect(root.array.length).toEqual(0);
-  });
+      expect(root.array.length).toEqual(0);
+    });
 
-  test('reset array', async () => {
-    const { db } = await createDatabase();
-    const root = db.add(new Expando());
-    await db.flush();
-    root.records = ['one'];
-    expect(root.records).toHaveLength(1);
+    test('reset array', async () => {
+      const { db } = await createDatabase();
+      const root = db.add(new Expando());
+      await db.flush();
+      root.records = ['one'];
+      expect(root.records).toHaveLength(1);
 
-    root.records = [];
-    expect(root.records).toHaveLength(0);
+      root.records = [];
+      expect(root.records).toHaveLength(0);
 
-    await db.flush();
-    expect(root.records).toHaveLength(0);
+      await db.flush();
+      expect(root.records).toHaveLength(0);
 
-    root.records.push({ title: 'two' });
-    expect(root.records).toHaveLength(1);
+      root.records.push({ title: 'two' });
+      expect(root.records).toHaveLength(1);
 
-    await db.flush();
-    expect(root.records).toHaveLength(1);
+      await db.flush();
+      expect(root.records).toHaveLength(1);
+    });
   });
 });

--- a/packages/core/echo/echo-schema/src/object/array.test.ts
+++ b/packages/core/echo/echo-schema/src/object/array.test.ts
@@ -20,7 +20,7 @@ describe.only('Arrays', () => {
       await db.flush();
 
       task.tags = new EchoArray();
-      task.tags.push('red');  
+      task.tags.push('red');
       task.tags.push('green');
       task.tags.push('blue');
       expect(task.tags.length).toEqual(3);

--- a/packages/core/echo/echo-schema/src/object/array.test.ts
+++ b/packages/core/echo/echo-schema/src/object/array.test.ts
@@ -39,6 +39,7 @@ describe.only('Arrays', () => {
       task.tags.splice(1, 0, 'yellow');
       expect(task.tags.slice()).toEqual(['red', 'yellow', 'magenta', 'blue']);
     });
+
     test('array of sub documents', async () => {
       const { db } = await createDatabase();
 
@@ -50,7 +51,6 @@ describe.only('Arrays', () => {
       task.subtasks.push(new TypedObject({ title: 'Subtask 1' }));
       task.subtasks.push(new TypedObject({ title: 'Subtask 2' }));
       task.subtasks.push(new TypedObject({ title: 'Subtask 3' }));
-
       expect(task.subtasks.length).toEqual(3);
       expect(task.subtasks[0].title).toEqual('Subtask 1');
       expect(task.subtasks[1].title).toEqual('Subtask 2');
@@ -75,7 +75,7 @@ describe.only('Arrays', () => {
       await db.flush();
 
       task.tags = ['red', 'green', 'blue'];
-      expect(task.tags instanceof EchoArray).toBeTruthy();
+      // expect(task.tags instanceof EchoArray).toBeTruthy();
       expect(task.tags.length).toEqual(3);
       expect(task.tags.slice()).toEqual(['red', 'green', 'blue']);
 

--- a/packages/core/echo/echo-schema/src/object/array.ts
+++ b/packages/core/echo/echo-schema/src/object/array.ts
@@ -9,8 +9,9 @@ import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
 
 import { AbstractEchoObject } from './object';
-import { type TypedObject } from './typed-object';
+import { getGlobalAutomergePreference, type AutomergeOptions, type TypedObject } from './typed-object';
 import { base } from './types';
+import { AutomergeArray } from '../automerge/automerge-array';
 
 const isIndex = (property: string | symbol): property is string =>
   typeof property === 'string' && parseInt(property).toString() === property;
@@ -45,7 +46,11 @@ export class EchoArray<T> implements Array<T> {
     throw new Error('Method not implemented.');
   }
 
-  constructor(items: T[] = []) {
+  constructor(items: T[] = [], opts?: AutomergeOptions) {
+    if (opts?.useAutomergeBackend ?? getGlobalAutomergePreference()) {
+      return new AutomergeArray(items) as any;
+    }
+
     this._uninitialized = [...items];
 
     // Change type returned by `new`.

--- a/packages/core/echo/echo-schema/src/object/typed-object.ts
+++ b/packages/core/echo/echo-schema/src/object/typed-object.ts
@@ -72,6 +72,9 @@ export type TypedObjectOptions = {
   type?: Reference;
   meta?: ObjectMeta;
   immutable?: boolean;
+} & AutomergeOptions;
+
+export type AutomergeOptions = {
   useAutomergeBackend?: boolean;
 };
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f486063</samp>

### Summary
📜🧪🔄

<!--
1.  📜 for adding a license header comment to the file `automerge-array.ts`.
2.  🧪 for modifying the test file `array.test.ts` to use the `testWithAutomerge` helper function.
3.  🔄 for adding a type definition for `AutomergeOptions` and enhancing the `AutomergeObject` class to support nested arrays and objects.
-->
This pull request adds support for using `Automerge` as an optional backend for managing array data in the `Echo` schema. It introduces the `AutomergeArray` class, which implements the `EchoArray` interface using the `Automerge` library. It also enhances the `AutomergeObject` class to handle nested arrays and objects. It modifies the test file `array.test.ts` to run the tests with both array implementations, depending on a global or local preference. It adds a type definition for `AutomergeOptions` to the `TypedObject` class.

> _We are the AutomergeArray, we sync the data in the fray_
> _We are the EchoArray, we choose the backend to obey_
> _We are the AutomergeObject, we nest the arrays and the objects_
> _We are the TypedObject, we set the options and the subjects_

### Walkthrough
*  Add license header comment to `automerge-array.ts` ([link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-7a0552e3207e6d028e67617c8df368e22db54f1038c289569e69251318188f94R1-R389))
*  Import `AutomergeArray` class and `getGlobalAutomergePreference` function into `automerge-object.ts` and `array.ts` ([link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48R12), [link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-3ce4fed7c29c414b169c7751cced946eb9c13edd0dd522dc6ea661598c15bf68L12-R14))
*  Make `_path` property of `AutomergeObject` class internal and use it to access and modify values in the Automerge document ([link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48L49-R54), [link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48L92-R101), [link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48L178-R189), [link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48L193-R207), [link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48L203-R220))
*  Refactor `AutomergeObject` class to extract `_change` method for applying change functions to the Automerge document ([link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48L213-R242))
*  Add internal annotations and conditions to `_get`, `_set`, `_encode`, and `_decode` methods of `AutomergeObject` class to handle nested arrays and objects ([link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48L193-R207), [link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48L203-R220), [link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48L224-R255), [link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48L236-R293))
*  Modify `EchoArray` class constructor to take `AutomergeOptions` parameter and return `AutomergeArray` instance if the flag or the global preference is true ([link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-3ce4fed7c29c414b169c7751cced946eb9c13edd0dd522dc6ea661598c15bf68L48-R53))
*  Add type definition for `AutomergeOptions` in `typed-object.ts` ([link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-874cfefd5ce6f29a1bbd0df27acce8a2aa03e20f12db8d444a09c6802006bc92R75-R77))
*  Modify `array.test.ts` to use `testWithAutomerge` helper function and run tests with both `EchoArray` and `AutomergeArray` implementations ([link](https://github.com/dxos/dxos/pull/4779/files?diff=unified&w=0#diff-a1a657dde51e29bbcdf920da59ac4d3cf81fee4009c6a1ecc0384c06afcef73aL10-R152))

