### PR TITLE
fix(proto-guard): Use random temp directory in test

### DIFF
--- a/packages/gravity/proto-guard/src/check-snapshot.test.ts
+++ b/packages/gravity/proto-guard/src/check-snapshot.test.ts
@@ -23,7 +23,7 @@ import { contains, getConfig, getStorageDir } from './util';
 describe('Tests against old storage', () => {
   let testStoragePath: string;
 
-  beforeAll(async () => {
+  beforeAll(() => {
     // Copy storage image to tmp folder against which tests will be run.
     log.info(`Storage version ${STORAGE_VERSION}`);
 

--- a/packages/gravity/proto-guard/src/check-snapshot.test.ts
+++ b/packages/gravity/proto-guard/src/check-snapshot.test.ts
@@ -4,6 +4,7 @@
 
 import { expect } from 'chai';
 import fse from 'fs-extra';
+import os from 'node:os';
 import path from 'node:path';
 
 import { asyncTimeout } from '@dxos/async';
@@ -20,12 +21,13 @@ import { data } from './testing';
 import { contains, getConfig, getStorageDir } from './util';
 
 describe('Tests against old storage', () => {
-  const testStoragePath = path.join('/tmp/dxos/proto-guard/storage/', STORAGE_VERSION.toString());
+  let testStoragePath: string;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     // Copy storage image to tmp folder against which tests will be run.
     log.info(`Storage version ${STORAGE_VERSION}`);
 
+    testStoragePath = fse.mkdtempSync(path.join(os.tmpdir(), 'proto-guard-'));
     fse.mkdirSync(testStoragePath, { recursive: true });
     const storagePath = path.join(getStorageDir(), STORAGE_VERSION.toString());
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ef22177</samp>

### Summary
🧪🚚🗂️

<!--
1.  🧪 This emoji represents testing, experimentation, or science, and can be used to indicate that the changes are related to improving the test suite or code quality.
2.  🚚 This emoji represents moving, transporting, or delivering something, and can be used to indicate that the changes are related to refactoring, reorganizing, or relocating code or files.
3.  🗂️ This emoji represents a card index or a file cabinet, and can be used to indicate that the changes are related to managing, storing, or organizing data or files.
-->
Improved test setup for `check-snapshot.test.ts` by using system temp directory and unique subdirs.

> _Sing, O Muse, of the skillful coder who refactored_
> _The test setup for `check-snapshot.test.ts`, a task of great renown_
> _He shunned the fixed and fragile paths, and sought instead the temp dir_
> _That each system grants, and there he made a subdirectory for each run_

### Walkthrough
*  Refactor the use of temporary directories in tests to avoid hard-coding `/tmp` and to ensure isolation ([link](https://github.com/dxos/dxos/pull/4785/files?diff=unified&w=0#diff-d829a1824624c6841edf675c792bb12399c22bc6af290a06d0853a8fc8fdeb13R7), [link](https://github.com/dxos/dxos/pull/4785/files?diff=unified&w=0#diff-d829a1824624c6841edf675c792bb12399c22bc6af290a06d0853a8fc8fdeb13L23-R30)).


