### PR TITLE
feat(automerge): Fix basic queries

### DIFF
--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
@@ -26,7 +26,7 @@ export class AutomergeDb {
   /**
    * @internal
    */
-  readonly _objects = new Map<string, EchoObject>();
+  _objects = new Map<string, EchoObject>();
   readonly _objectsSystem = new Map<string, EchoObject>();
 
   getObjectById(id: string): EchoObject | undefined {
@@ -48,7 +48,6 @@ export class AutomergeDb {
   remove<T extends EchoObject>(obj: T) {
     invariant(obj[base] instanceof AutomergeObject);
     invariant(this._objects.has(obj.id));
-    this._objects.delete(obj.id);
     (obj[base] as AutomergeObject).__system!.deleted = true;
   }
 }

--- a/packages/core/echo/echo-schema/src/query/query.test.ts
+++ b/packages/core/echo/echo-schema/src/query/query.test.ts
@@ -11,120 +11,122 @@ import { afterTest, beforeAll, beforeEach, describe, test } from '@dxos/test';
 import { Filter } from './filter';
 import { type EchoDatabase } from '../database';
 import { Expando, TypedObject, TextObject } from '../object';
-import { TestBuilder, createDatabase } from '../testing';
+import { TestBuilder, createDatabase, testWithAutomerge } from '../testing';
 import { Contact, types } from '../tests/proto';
 
 describe('Queries', () => {
-  let db: EchoDatabase;
-  beforeAll(async () => {
-    ({ db } = await createDatabase());
+  testWithAutomerge(() => {
+    let db: EchoDatabase;
+    beforeAll(async () => {
+      ({ db } = await createDatabase());
 
-    // TODO(burdon): Factor out common dataset. Change to Expando.
-    const objects = [
-      new TypedObject({ idx: 0, title: 'Task 0', label: 'red' }),
-      new TypedObject({ idx: 1, title: 'Task 1', label: 'red' }),
-      new TypedObject({ idx: 2, title: 'Task 2', label: 'red' }),
-      new TypedObject({ idx: 3, title: 'Task 3', label: 'green' }),
-      new TypedObject({ idx: 4, title: 'Task 4', label: 'green' }),
-      new TypedObject({ idx: 5, title: 'Task 5', label: 'blue' }),
-      new TypedObject({ idx: 6, title: 'Task 6', label: 'blue' }),
-      new TypedObject({ idx: 7, title: 'Task 7', label: 'blue' }),
-      new TypedObject({ idx: 8, title: 'Task 8', label: 'blue' }),
-      new TypedObject({ idx: 9, title: 'Task 9' }),
-    ];
+      // TODO(burdon): Factor out common dataset. Change to Expando.
+      const objects = [
+        new TypedObject({ idx: 0, title: 'Task 0', label: 'red' }),
+        new TypedObject({ idx: 1, title: 'Task 1', label: 'red' }),
+        new TypedObject({ idx: 2, title: 'Task 2', label: 'red' }),
+        new TypedObject({ idx: 3, title: 'Task 3', label: 'green' }),
+        new TypedObject({ idx: 4, title: 'Task 4', label: 'green' }),
+        new TypedObject({ idx: 5, title: 'Task 5', label: 'blue' }),
+        new TypedObject({ idx: 6, title: 'Task 6', label: 'blue' }),
+        new TypedObject({ idx: 7, title: 'Task 7', label: 'blue' }),
+        new TypedObject({ idx: 8, title: 'Task 8', label: 'blue' }),
+        new TypedObject({ idx: 9, title: 'Task 9' }),
+      ];
 
-    for (const object of objects) {
-      db.add(object);
-    }
+      for (const object of objects) {
+        db.add(object);
+      }
 
-    await db.flush();
-  });
+      await db.flush();
+    });
 
-  test('filter properties', async () => {
-    {
-      const { objects } = db.query();
-      expect(objects).to.have.length(10);
-    }
+    test('filter properties', async () => {
+      {
+        const { objects } = db.query();
+        expect(objects).to.have.length(10);
+      }
 
-    {
-      const { objects, results } = db.query({ label: undefined });
-      expect(objects).to.have.length(1);
-      expect(results).to.have.length(1);
-      expect(results[0].object).to.eq(objects[0]);
-      expect(results[0].id).to.eq(objects[0].id);
-      expect(results[0].spaceKey).to.eq(db._backend.spaceKey);
-    }
+      {
+        const { objects, results } = db.query({ label: undefined });
+        expect(objects).to.have.length(1);
+        expect(results).to.have.length(1);
+        expect(results[0].object).to.eq(objects[0]);
+        expect(results[0].id).to.eq(objects[0].id);
+        expect(results[0].spaceKey).to.eq(db._backend.spaceKey);
+      }
 
-    {
-      const { objects } = db.query({ label: 'red' });
-      expect(objects).to.have.length(3);
-    }
+      {
+        const { objects } = db.query({ label: 'red' });
+        expect(objects).to.have.length(3);
+      }
 
-    {
-      const { objects } = db.query({ label: 'pink' });
-      expect(objects).to.have.length(0);
-    }
-  });
+      {
+        const { objects } = db.query({ label: 'pink' });
+        expect(objects).to.have.length(0);
+      }
+    });
 
-  test('filter operators', async () => {
-    {
-      const { objects } = db.query(() => false);
-      expect(objects).to.have.length(0);
-    }
+    test('filter operators', async () => {
+      {
+        const { objects } = db.query(() => false);
+        expect(objects).to.have.length(0);
+      }
 
-    {
-      const { objects } = db.query(() => true);
-      expect(objects).to.have.length(10);
-    }
+      {
+        const { objects } = db.query(() => true);
+        expect(objects).to.have.length(10);
+      }
 
-    {
-      const { objects } = db.query((object) => object.label === 'red' || object.label === 'green');
-      expect(objects).to.have.length(5);
-    }
-  });
+      {
+        const { objects } = db.query((object) => object.label === 'red' || object.label === 'green');
+        expect(objects).to.have.length(5);
+      }
+    });
 
-  test('filter chaining', async () => {
-    {
-      // prettier-ignore
-      const { objects } = db.query([
+    test('filter chaining', async () => {
+      {
+        // prettier-ignore
+        const { objects } = db.query([
         () => true,
         { label: 'blue' },
         (object: any) => object.idx > 6
       ]);
-      expect(objects).to.have.length(2);
-    }
-  });
-
-  test('options', async () => {
-    {
-      const { objects } = db.query({ label: 'red' });
-      expect(objects).to.have.length(3);
-
-      for (const object of objects) {
-        db.remove(object);
+        expect(objects).to.have.length(2);
       }
-      await db.flush();
-    }
+    });
 
-    {
-      const { objects } = db.query();
-      expect(objects).to.have.length(7);
-    }
+    test('options', async () => {
+      {
+        const { objects } = db.query({ label: 'red' });
+        expect(objects).to.have.length(3);
 
-    {
-      const { objects } = db.query(undefined, { deleted: QueryOptions.ShowDeletedOption.HIDE_DELETED });
-      expect(objects).to.have.length(7);
-    }
+        for (const object of objects) {
+          db.remove(object);
+        }
+        await db.flush();
+      }
 
-    {
-      const { objects } = db.query(undefined, { deleted: QueryOptions.ShowDeletedOption.SHOW_DELETED });
-      expect(objects).to.have.length(10);
-    }
+      {
+        const { objects } = db.query();
+        expect(objects).to.have.length(7);
+      }
 
-    {
-      const { objects } = db.query(undefined, { deleted: QueryOptions.ShowDeletedOption.SHOW_DELETED_ONLY });
-      expect(objects).to.have.length(3);
-    }
+      {
+        const { objects } = db.query(undefined, { deleted: QueryOptions.ShowDeletedOption.HIDE_DELETED });
+        expect(objects).to.have.length(7);
+      }
+
+      {
+        const { objects } = db.query(undefined, { deleted: QueryOptions.ShowDeletedOption.SHOW_DELETED });
+        expect(objects).to.have.length(10);
+      }
+
+      {
+        const { objects } = db.query(undefined, { deleted: QueryOptions.ShowDeletedOption.SHOW_DELETED_ONLY });
+        expect(objects).to.have.length(3);
+      }
+    });
   });
 });
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 07f2708</samp>

### Summary
🧪🚀🐛

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate the addition of a new test helper function or a new test suite.
2.  🚀 - This emoji represents speed, performance, or launch, and can be used to indicate the improvement of the `AutomergeDb` class's performance and consistency by making its `_objects` property mutable and avoiding deleting objects from the map.
3.  🐛 - This emoji represents a bug, an error, or a fix, and can be used to indicate the fixing of a bug that caused deleted objects to disappear from the database and the UI.
-->
Improved the `AutomergeDb` class by making it more efficient and reliable, and added more tests for it. The main changes were to avoid deleting objects from the map in `automerge-db.ts` and to use a helper function for testing different backends in `query.test.ts`.

> _We're testing the `AutomergeDb` with different backends_
> _To make sure it works well and no data it offends_
> _We've made the `_objects` mutable and fixed a nasty bug_
> _So heave away, me hearties, and give the code a hug_

### Walkthrough
*  Make `_objects` property of `AutomergeDb` mutable to support backend updates ([link](https://github.com/dxos/dxos/pull/4789/files?diff=unified&w=0#diff-875834e4b70c12d82e4dedc39420f91a998d2d84b6b7b3551a6b6d90335bfa50L29-R29)).


