### PR TITLE
fix: networking

### DIFF
--- a/packages/core/mesh/network-manager/src/swarm/connection.ts
+++ b/packages/core/mesh/network-manager/src/swarm/connection.ts
@@ -13,6 +13,7 @@ import {
   ProtocolError,
   ConnectionResetError,
   ConnectivityError,
+  TimeoutError,
   UnknownProtocolError,
   trace,
 } from '@dxos/protocols';
@@ -177,8 +178,10 @@ export class Connection {
     scheduleTask(
       this.connectedTimeoutContext,
       async () => {
-        log.info('timeout waiting for transport to connect, aborting');
-        await this.abort().catch((err) => this.errors.raise(err));
+        log.info(`timeout waiting ${TRANSPORT_CONNECTION_TIMEOUT / 1000}s for transport to connect, aborting`);
+        await this.abort(new TimeoutError(`${TRANSPORT_CONNECTION_TIMEOUT / 1000}s for transport to connect`)).catch(
+          (err) => this.errors.raise(err),
+        );
       },
       TRANSPORT_CONNECTION_TIMEOUT,
     );
@@ -308,6 +311,18 @@ export class Connection {
 
       try {
         // After the transport is closed streams are disconnected.
+        await this._transport?.destroy();
+      } catch (err: any) {
+        log.catch(err);
+      }
+    } else {
+      log.info(`graceful close requested when we were in ${lastState} state? aborting`);
+      try {
+        await this._protocol.abort();
+      } catch (err: any) {
+        log.catch(err);
+      }
+      try {
         await this._transport?.destroy();
       } catch (err: any) {
         log.catch(err);

--- a/packages/core/mesh/network-manager/src/transport/simplepeer-transport.ts
+++ b/packages/core/mesh/network-manager/src/transport/simplepeer-transport.ts
@@ -71,6 +71,7 @@ export class SimplePeerTransport implements Transport {
         if (err.errorDetail === 'sctp-failure') {
           this.errors.raise(new ConnectionResetError('sctp-failure from RTCError', err));
         } else {
+          log.info('unknown RTCError', { err });
           this.errors.raise(new UnknownProtocolError('unknown RTCError', err));
         }
         // catch more generic simple-peer errors: https://github.com/feross/simple-peer/blob/master/README.md#error-codes
@@ -80,10 +81,12 @@ export class SimplePeerTransport implements Transport {
           case 'ERR_WEBRTC_SUPPORT':
             this.errors.raise(new ProtocolError('WebRTC not supported', err));
             break;
+          case 'ERR_SIGNALING':
+            this.errors.raise(new ConnectivityError('signaling failure', err));
+            break;
           case 'ERR_ICE_CONNECTION_FAILURE':
           case 'ERR_DATA_CHANNEL':
           case 'ERR_CONNECTION_FAILURE':
-          case 'ERR_SIGNALING':
             this.errors.raise(new ConnectivityError('unknown communication failure', err));
             break;
           // errors due to library issues or improper API usage

--- a/packages/core/mesh/teleport/src/muxing/muxer.ts
+++ b/packages/core/mesh/teleport/src/muxing/muxer.ts
@@ -155,7 +155,15 @@ export class Muxer {
     };
     channel.destroy = (err) => {
       // TODO(dmaretskyi): Call stream.end() instead?
-      stream.destroy(err);
+      if (err) {
+        if (stream.listeners('error').length > 0) {
+          stream.destroy(err);
+        } else {
+          stream.destroy();
+        }
+      } else {
+        stream.destroy();
+      }
     };
 
     // NOTE: Make sure channel.push is set before sending the command.
@@ -265,9 +273,10 @@ export class Muxer {
     ).catch(async (err: any) => {
       log('error sending close command', { err });
 
-      await this.dispose(err);
+      await this._dispose(err);
     });
 
+    // don't return until close is complete or timeout
     await Promise.race([
       new Promise((_resolve, reject) => {
         setTimeout(() => {
@@ -275,7 +284,7 @@ export class Muxer {
         }, GRACEFUL_CLOSE_TIMEOUT);
       }),
       (async () => {
-        await this.dispose(err);
+        await this._dispose(err);
       })(),
     ]);
   }
@@ -307,14 +316,14 @@ export class Muxer {
       });
     }
 
-    this.dispose(err).catch((err) => {
+    this._dispose(err).catch((err) => {
       log('error disposing after destroy', { err });
     });
   }
 
   // complete the termination, graceful or otherwise
 
-  async dispose(err?: Error) {
+  async _dispose(err?: Error) {
     if (this._disposed) {
       log('already destroyed, ignoring dispose request');
       return;
@@ -328,6 +337,7 @@ export class Muxer {
       channel.destroy?.(err);
     }
     this._disposed = true;
+    await this._emitStats();
 
     this.afterClosed.emit(err);
 
@@ -345,7 +355,7 @@ export class Muxer {
     if (cmd.close) {
       if (!this._closing) {
         log('received peer close, initiating my own graceful close');
-        await this.close();
+        await this.close(new Error('received peer close'));
       } else {
         log('received close from peer, already closing');
       }


### PR DESCRIPTION
* signaling timeout logging
* ensure muxer is properly disposed on unexpected graceful close
* muxer stats
* avoid throwing uncaught error when closing channels
* simplepeer signal error reporting

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7534323</samp>

### Summary
🛠️🌐📊

<!--
1.  🛠️ - This emoji represents the general theme of fixing, improving, and enhancing the existing codebase. It can also signify debugging, testing, or refactoring.
2.  🌐 - This emoji represents the specific domain of WebSockets and WebRTC, which are the main technologies used for signaling and transport in this project. It can also signify networking, communication, or connectivity.
3.  📊 - This emoji represents the addition of logging and statistics features, which can help monitor and analyze the behavior and performance of the system. It can also signify data, metrics, or reporting.
-->
This pull request improves the error handling, logging, and reliability of various classes and components in the `dxos` core mesh layer. It introduces custom error classes, such as `TimeoutError` and `SignalingError`, and uses them to handle different failure scenarios. It also adds more statistics and debug information to the logs to help diagnose and monitor the performance of the mesh network.

> _To make WebSockets more stable_
> _They added more logs and were able_
> _To handle each error_
> _With `checkServerFailure`_
> _And avoid any signaling trouble_

### Walkthrough
*  Add more logging and error handling to WebSocket signaling layer ([link](https://github.com/dxos/dxos/pull/4795/files?diff=unified&w=0#diff-d47a5fbdadbc8b50998afe7983dd2333813cfb7a31fbfa4df62d7e0c93d1bff5L138-R143))
*  Use `TimeoutError` class for transport and signaling timeouts ([link](https://github.com/dxos/dxos/pull/4795/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745R16), [link](https://github.com/dxos/dxos/pull/4795/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745L180-R184), [link](https://github.com/dxos/dxos/pull/4795/files?diff=unified&w=0#diff-cc0cc165bd94f178c1fbbe6ee98250b3db509cacbd5038db986be7b63c3c894eL83-R89))
*  Handle graceful close requests when connection is not connected or connecting ([link](https://github.com/dxos/dxos/pull/4795/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745R318-R329))
*  Log unknown RTCError in WebRTC transport layer ([link](https://github.com/dxos/dxos/pull/4795/files?diff=unified&w=0#diff-cc0cc165bd94f178c1fbbe6ee98250b3db509cacbd5038db986be7b63c3c894eR74))
*  Check for error listeners before destroying stream in muxer layer ([link](https://github.com/dxos/dxos/pull/4795/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66L158-R166))
*  Rename `dispose` method to `_dispose` and add `_emitStats` calls in `Muxer` class ([link](https://github.com/dxos/dxos/pull/4795/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66L268-R279), [link](https://github.com/dxos/dxos/pull/4795/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66L278-R287), [link](https://github.com/dxos/dxos/pull/4795/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66L310-R319), [link](https://github.com/dxos/dxos/pull/4795/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66L317-R326), [link](https://github.com/dxos/dxos/pull/4795/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66R340))
*  Pass error object to `close` method when receiving close command from peer in `Muxer` class ([link](https://github.com/dxos/dxos/pull/4795/files?diff=unified&w=0#diff-9e6a5fce74bde3cb2e71fe363f5dac6f158ff9aa189c5783799b4ec8a87dcc66L348-R358))


