### PR TITLE
feat: networking diagnostics

### DIFF
--- a/packages/core/echo/echo-pipeline/src/space/space-protocol.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space-protocol.ts
@@ -62,6 +62,8 @@ export class SpaceProtocol {
   @logInfo
   private readonly _topic: Promise<PublicKey>;
 
+  private readonly _spaceKey: PublicKey;
+
   private readonly _feeds = new Set<FeedWrapper<FeedMessage>>();
   private readonly _sessions = new ComplexMap<PublicKey, SpaceProtocolSession>(PublicKey.hash);
 
@@ -81,6 +83,7 @@ export class SpaceProtocol {
   }
 
   constructor({ topic, swarmIdentity, networkManager, onSessionAuth, onAuthFailure, blobStore }: SpaceProtocolOptions) {
+    this._spaceKey = topic;
     this._networkManager = networkManager;
     this._swarmIdentity = swarmIdentity;
     this._onSessionAuth = onSessionAuth;
@@ -126,7 +129,7 @@ export class SpaceProtocol {
       peerId: this._swarmIdentity.peerKey,
       topic,
       topology: new MMSTTopology(topologyConfig),
-      label: `space swarm ${topic.truncate()}`,
+      label: `swarm ${topic.truncate()} for space ${this._spaceKey.truncate()}`,
     });
 
     log('started');
@@ -227,8 +230,8 @@ export class SpaceProtocolSession implements WireProtocol {
     return this._teleport.stream;
   }
 
-  async open(): Promise<void> {
-    await this._teleport.open();
+  async open(sessionId?: PublicKey): Promise<void> {
+    await this._teleport.open(sessionId);
     this._teleport.addExtension(
       'dxos.mesh.teleport.auth',
       new AuthExtension({

--- a/packages/core/mesh/network-manager/src/swarm/connection.ts
+++ b/packages/core/mesh/network-manager/src/swarm/connection.ts
@@ -2,12 +2,12 @@
 // Copyright 2021 DXOS.org
 //
 
-import { DeferredTask, Event, sleep, scheduleTask, synchronized } from '@dxos/async';
+import { DeferredTask, Event, sleep, scheduleTask, scheduleTaskInterval, synchronized } from '@dxos/async';
 import { Context, cancelWithContext } from '@dxos/context';
 import { ErrorStream } from '@dxos/debug';
 import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
-import { log } from '@dxos/log';
+import { log, logInfo } from '@dxos/log';
 import {
   CancelledError,
   ProtocolError,
@@ -19,7 +19,7 @@ import {
 import { type Signal } from '@dxos/protocols/proto/dxos/mesh/swarm';
 
 import { type SignalMessage, type SignalMessenger } from '../signal';
-import { type Transport, type TransportFactory } from '../transport';
+import { type Transport, type TransportFactory, type TransportStats } from '../transport';
 import { type WireProtocol } from '../wire-protocol';
 
 /**
@@ -32,6 +32,8 @@ const STARTING_SIGNALLING_DELAY = 10;
  * How long to wait for the transport to establish connectivity, i.e. for the connection to move between CONNECTING and CONNECTED.
  */
 const TRANSPORT_CONNECTION_TIMEOUT = 10_000;
+
+const TRANSPORT_STATS_INTERVAL = 5_000;
 
 /**
  * Maximum delay between signal batches.
@@ -109,6 +111,8 @@ export class Connection {
 
   public _instanceId = PublicKey.random().toHex();
 
+  public readonly transportStats = new Event<TransportStats>();
+
   private readonly _signalSendTask = new DeferredTask(this._ctx, async () => {
     await this._flushSignalBuffer();
   });
@@ -133,6 +137,11 @@ export class Connection {
       remotePeerId: this.remoteId,
       initiator: this.initiator,
     });
+  }
+
+  @logInfo
+  get sessionIdString(): string {
+    return this.sessionId.truncate();
   }
 
   get state() {
@@ -164,7 +173,7 @@ export class Connection {
     this._changeState(ConnectionState.CONNECTING);
 
     // TODO(dmaretskyi): Initialize only after the transport has established connection.
-    this._protocol.open().catch((err) => {
+    this._protocol.open(this.sessionId).catch((err) => {
       this.errors.raise(err);
     });
 
@@ -188,12 +197,15 @@ export class Connection {
       initiator: this.initiator,
       stream: this._protocol.stream,
       sendSignal: async (signal) => this._sendSignal(signal),
+      sessionId: this.sessionId,
     });
 
     this._transport.connected.once(async () => {
       this._changeState(ConnectionState.CONNECTED);
       await this.connectedTimeoutContext.dispose();
       this._callbacks?.onConnected?.();
+
+      scheduleTaskInterval(this._ctx, async () => this._emitTransportStats(), TRANSPORT_STATS_INTERVAL);
     });
 
     this._transport.closed.once(() => {
@@ -396,5 +408,12 @@ export class Connection {
     invariant(state !== this._state, 'Already in this state.');
     this._state = state;
     this.stateChanged.emit(state);
+  }
+
+  private async _emitTransportStats() {
+    const stats = await this.transport?.getStats();
+    if (stats) {
+      this.transportStats.emit(stats);
+    }
   }
 }

--- a/packages/core/mesh/network-manager/src/transport/datachannel/rtc-peer-connection.ts
+++ b/packages/core/mesh/network-manager/src/transport/datachannel/rtc-peer-connection.ts
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import node from 'node-datachannel';
+import node, { type SelectedCandidateInfo } from 'node-datachannel';
 import defer, { type DeferredPromise } from 'p-defer';
 
 import { DataChannel } from './rtc-data-channel';
@@ -188,6 +188,10 @@ export class PeerConnection extends EventTarget implements RTCPeerConnection {
     this.#peerConnection.addRemoteCandidate(candidate.candidate, candidate.sdpMid ?? '0');
   }
 
+  getSelectedCandidatePair(): { local: SelectedCandidateInfo; remote: SelectedCandidateInfo } | null {
+    return this.#peerConnection.getSelectedCandidatePair();
+  }
+
   addTrack(track: MediaStreamTrack, ...streams: MediaStream[]): RTCRtpSender {
     throw new Error('addTrack Not implemented');
   }
@@ -204,6 +208,14 @@ export class PeerConnection extends EventTarget implements RTCPeerConnection {
 
     this.#peerConnection.close();
     this.#peerConnection.destroy();
+  }
+
+  bytesSent(): number {
+    return this.#peerConnection.bytesSent();
+  }
+
+  bytesReceived(): number {
+    return this.#peerConnection.bytesReceived();
   }
 
   createDataChannel(label: string, dataChannelDict: RTCDataChannelInit = {}): RTCDataChannel {

--- a/packages/core/mesh/network-manager/src/transport/libdatachannel-transport.ts
+++ b/packages/core/mesh/network-manager/src/transport/libdatachannel-transport.ts
@@ -10,7 +10,7 @@ import { log } from '@dxos/log';
 import { type Signal } from '@dxos/protocols/proto/dxos/mesh/swarm';
 
 import { type PeerConnection } from './datachannel/rtc-peer-connection';
-import { type Transport, type TransportFactory } from './transport';
+import { type Transport, type TransportFactory, type TransportStats } from './transport';
 
 export type LibDataChannelTransportParams = {
   initiator: boolean;
@@ -234,6 +234,42 @@ export class LibDataChannelTransport implements Transport {
       })
       .catch((err) => {
         log.catch(err);
+      });
+  }
+
+  async getDetails(): Promise<string> {
+    return this._peer
+      .then(async (peer) => {
+        const cp = await peer.getSelectedCandidatePair();
+        if (!cp) {
+          return 'unavailable';
+        }
+        return `${cp.remote.address}:${cp.remote.port}/${cp.remote.transportType} ${cp.remote.type}`;
+      })
+      .catch((err) => {
+        log.catch(err);
+        return 'unavailable';
+      });
+  }
+
+  async getStats(): Promise<TransportStats> {
+    return this._peer
+      .then((peer) => {
+        return {
+          bytesSent: peer.bytesSent(),
+          bytesReceived: peer.bytesReceived(),
+          packetsSent: 0,
+          packetsReceived: 0,
+        };
+      })
+      .catch((err) => {
+        log.catch(err);
+        return {
+          bytesSent: 0,
+          bytesReceived: 0,
+          packetsSent: 0,
+          packetsReceived: 0,
+        };
       });
   }
 

--- a/packages/core/mesh/network-manager/src/transport/memory-transport.ts
+++ b/packages/core/mesh/network-manager/src/transport/memory-transport.ts
@@ -12,7 +12,7 @@ import { log, logInfo } from '@dxos/log';
 import { type Signal } from '@dxos/protocols/proto/dxos/mesh/swarm';
 import { ComplexMap } from '@dxos/util';
 
-import { type Transport, type TransportFactory, type TransportOptions } from './transport';
+import { type Transport, type TransportFactory, type TransportOptions, type TransportStats } from './transport';
 
 // TODO(burdon): Make configurable.
 // Delay (in milliseconds) for data being sent through in-memory connections to simulate network latency.
@@ -165,5 +165,18 @@ export class MemoryTransport implements Transport {
       const remoteId = PublicKey.fromHex(transportId);
       this._remote.wake(remoteId);
     }
+  }
+
+  async getDetails(): Promise<string> {
+    return this._instanceId.toHex();
+  }
+
+  async getStats(): Promise<TransportStats> {
+    return {
+      bytesSent: 0,
+      bytesReceived: 0,
+      packetsSent: 0,
+      packetsReceived: 0,
+    };
   }
 }

--- a/packages/core/mesh/network-manager/src/transport/simplepeer-transport-proxy.ts
+++ b/packages/core/mesh/network-manager/src/transport/simplepeer-transport-proxy.ts
@@ -22,7 +22,7 @@ import { ConnectionState, type BridgeEvent, type BridgeService } from '@dxos/pro
 import { type Signal } from '@dxos/protocols/proto/dxos/mesh/swarm';
 import { arrayToBuffer } from '@dxos/util';
 
-import { type Transport, type TransportFactory, type TransportOptions } from './transport';
+import { type Transport, type TransportFactory, type TransportOptions, type TransportStats } from './transport';
 
 const RESP_MIN_THRESHOLD = 500;
 const TIMEOUT_THRESHOLD = 10;
@@ -143,6 +143,14 @@ export class SimplePeerTransportProxy implements Transport {
         signal,
       })
       .catch((err) => this.errors.raise(decodeError(err)));
+  }
+
+  async getDetails(): Promise<string> {
+    return (await this._params.bridgeService.getDetails({ proxyId: this._proxyId })).details;
+  }
+
+  async getStats(): Promise<TransportStats> {
+    return (await this._params.bridgeService.getStats({ proxyId: this._proxyId })).stats as TransportStats;
   }
 
   // TODO(burdon): Move open from constructor.

--- a/packages/core/mesh/network-manager/src/transport/simplepeer-transport-service.ts
+++ b/packages/core/mesh/network-manager/src/transport/simplepeer-transport-service.ts
@@ -16,6 +16,10 @@ import {
   type BridgeEvent,
   ConnectionState,
   type CloseRequest,
+  type DetailsRequest,
+  type DetailsResponse,
+  type StatsRequest,
+  type StatsResponse,
 } from '@dxos/protocols/proto/dxos/mesh/bridge';
 import { ComplexMap } from '@dxos/util';
 
@@ -111,6 +115,16 @@ export class SimplePeerTransportService implements BridgeService {
   async sendSignal({ proxyId, signal }: SignalRequest): Promise<void> {
     invariant(this.transports.has(proxyId));
     await this.transports.get(proxyId)!.transport.signal(signal);
+  }
+
+  async getDetails({ proxyId }: DetailsRequest): Promise<DetailsResponse> {
+    invariant(this.transports.has(proxyId));
+    return { details: await this.transports.get(proxyId)!.transport.getDetails() };
+  }
+
+  async getStats({ proxyId }: StatsRequest): Promise<StatsResponse> {
+    invariant(this.transports.has(proxyId));
+    return { stats: await this.transports.get(proxyId)!.transport.getStats() };
   }
 
   async sendData({ proxyId, payload }: DataRequest): Promise<void> {

--- a/packages/core/mesh/network-manager/src/transport/simplepeer-transport.ts
+++ b/packages/core/mesh/network-manager/src/transport/simplepeer-transport.ts
@@ -13,7 +13,7 @@ import { log } from '@dxos/log';
 import { ConnectionResetError, ConnectivityError, ProtocolError, UnknownProtocolError, trace } from '@dxos/protocols';
 import { type Signal } from '@dxos/protocols/proto/dxos/mesh/swarm';
 
-import { type Transport, type TransportFactory } from './transport';
+import { type Transport, type TransportFactory, type TransportStats } from './transport';
 import { wrtc } from './webrtc';
 
 export type SimplePeerTransportParams = {
@@ -109,7 +109,7 @@ export class SimplePeerTransport implements Transport {
           (this._peer as any)._pc.getStats().then((stats: any) => {
             log.info('report after webrtc error', {
               config: this.params.webrtcConfig,
-              stats,
+              stats: Object.fromEntries((stats as any).entries()),
             });
           });
         }
@@ -119,7 +119,67 @@ export class SimplePeerTransport implements Transport {
 
       await this.destroy();
     });
+
     log.trace('dxos.mesh.webrtc-transport.constructor', trace.end({ id: this._instanceId }));
+  }
+
+  async getStats(): Promise<TransportStats> {
+    const stats = await this._getStats();
+    if (!stats) {
+      return {
+        bytesSent: 0,
+        bytesReceived: 0,
+        packetsSent: 0,
+        packetsReceived: 0,
+        rawStats: {},
+      };
+    }
+
+    // TODO(nf): transport or candidatePair?
+    return {
+      bytesSent: stats.transport.bytesSent,
+      bytesReceived: stats.transport.bytesReceived,
+      packetsSent: stats.transport.messagesSent,
+      packetsReceived: stats.transport.messagesReceived,
+      rawStats: stats.raw,
+    };
+  }
+
+  async _getStats(): Promise<any> {
+    if (typeof (this._peer as any)?._pc?.getStats !== 'function') {
+      return null;
+    }
+    return await (this._peer as any)._pc.getStats().then((stats: any) => {
+      const statsEntries = Array.from(stats.entries() as any[]);
+      const transport = statsEntries.filter((s: any) => s[1].type === 'transport')[0][1];
+      const candidatePair = statsEntries.filter((s: any) => s[0] === transport.selectedCandidatePairId);
+      let selectedCandidatePair: any;
+      let remoteCandidate: any;
+      if (candidatePair.length > 0) {
+        selectedCandidatePair = candidatePair[0][1];
+        remoteCandidate = statsEntries.filter((s: any) => s[0] === selectedCandidatePair.remoteCandidateId)[0][1];
+      }
+      return {
+        datachannel: statsEntries.filter((s: any) => s[1].type === 'data-channel')[0][1],
+        transport,
+        selectedCandidatePair,
+        remoteCandidate,
+        raw: Object.fromEntries(stats.entries()),
+      };
+    });
+  }
+
+  async getDetails(): Promise<string> {
+    const stats = await this._getStats();
+    const rc = stats?.remoteCandidate;
+    if (!rc) {
+      return 'unavailable';
+    }
+
+    if (rc.relay) {
+      return `${rc.ip}:${rc.port}/${rc.protocol} relay for XXX ${rc.candidateType}`;
+    }
+    return `${rc.ip}:${rc.port}/${rc.protocol} ${rc.candidateType}`;
   }
 
   async destroy() {
@@ -130,6 +190,7 @@ export class SimplePeerTransport implements Transport {
     this._closed = true;
     this._disconnectStreams();
     this._peer!.destroy();
+    this._closed = true;
     this.closed.emit();
     log('closed');
   }

--- a/packages/core/mesh/network-manager/src/transport/tcp-transport.browser.ts
+++ b/packages/core/mesh/network-manager/src/transport/tcp-transport.browser.ts
@@ -5,7 +5,7 @@
 import { Event } from '@dxos/async';
 import { ErrorStream } from '@dxos/debug';
 
-import { type Transport, type TransportFactory } from './transport';
+import { type Transport, type TransportFactory, type TransportStats } from './transport';
 
 // NOTE: Browser stub.
 
@@ -23,6 +23,14 @@ export class TcpTransport implements Transport {
   }
 
   signal() {
+    throw new Error('Method not implemented.');
+  }
+
+  async getStats(): Promise<TransportStats> {
+    throw new Error('Method not implemented.');
+  }
+
+  async getDetails(): Promise<string> {
     throw new Error('Method not implemented.');
   }
 }

--- a/packages/core/mesh/network-manager/src/transport/tcp-transport.ts
+++ b/packages/core/mesh/network-manager/src/transport/tcp-transport.ts
@@ -9,7 +9,7 @@ import { ErrorStream } from '@dxos/debug';
 import { log } from '@dxos/log';
 import { type Signal } from '@dxos/protocols/proto/dxos/mesh/swarm';
 
-import { type Transport, type TransportFactory, type TransportOptions } from './transport';
+import { type Transport, type TransportFactory, type TransportOptions, type TransportStats } from './transport';
 
 export const TcpTransportFactory: TransportFactory = {
   createTransport: (params) => new TcpTransport(params),
@@ -85,6 +85,24 @@ export class TcpTransport implements Transport {
     const socket = new Socket();
     this._handleSocket(socket);
     socket.connect({ port: payload.port, host: 'localhost' });
+  }
+
+  async getDetails(): Promise<string> {
+    if (this.options.initiator) {
+      const { port, address } = this._server?.address() as AddressInfo;
+      return `LISTEN ${address}:${port}`;
+    }
+    const { port, address } = this._socket?.address() as AddressInfo;
+    return `ACCEPT ${address}:${port}`;
+  }
+
+  async getStats(): Promise<TransportStats> {
+    return {
+      bytesSent: 0,
+      bytesReceived: 0,
+      packetsSent: 0,
+      packetsReceived: 0,
+    };
   }
 
   private _handleSocket(socket: Socket) {

--- a/packages/core/mesh/network-manager/src/transport/transport.ts
+++ b/packages/core/mesh/network-manager/src/transport/transport.ts
@@ -4,6 +4,7 @@
 
 import { type Event } from '@dxos/async';
 import { type ErrorStream } from '@dxos/debug';
+import { type PublicKey } from '@dxos/keys';
 import { type Signal } from '@dxos/protocols/proto/dxos/mesh/swarm';
 
 export enum TransportKind {
@@ -22,6 +23,14 @@ export interface Transport {
   connected: Event;
   errors: ErrorStream;
 
+  /**
+   * Transport-specfic stats.
+   */
+  getStats(): Promise<TransportStats>;
+  /**
+   * Transport-specfic connection details.
+   */
+  getDetails(): Promise<string>;
   destroy(): Promise<void>;
   signal(signal: Signal): void;
 }
@@ -43,6 +52,8 @@ export type TransportOptions = {
   sendSignal: (signal: Signal) => Promise<void>; // TODO(burdon): Remove async?
 
   timeout?: number;
+
+  sessionId?: PublicKey;
 };
 
 /**
@@ -51,3 +62,11 @@ export type TransportOptions = {
 export interface TransportFactory {
   createTransport(options: TransportOptions): Transport;
 }
+
+export type TransportStats = {
+  bytesSent: number;
+  bytesReceived: number;
+  packetsSent: number;
+  packetsReceived: number;
+  rawStats?: any;
+};

--- a/packages/core/mesh/network-manager/src/wire-protocol.ts
+++ b/packages/core/mesh/network-manager/src/wire-protocol.ts
@@ -23,7 +23,7 @@ export type WireProtocolProvider = (params: WireProtocolParams) => WireProtocol;
 export interface WireProtocol {
   stream: Duplex;
 
-  open(): Promise<void>;
+  open(sessionId?: PublicKey): Promise<void>;
   close(): Promise<void>;
   abort(): Promise<void>;
 }
@@ -40,8 +40,8 @@ export const createTeleportProtocolFactory = (
     const teleport = new Teleport(params);
     return {
       stream: teleport.stream,
-      open: async () => {
-        await teleport.open();
+      open: async (sessionId?: PublicKey) => {
+        await teleport.open(sessionId);
         await onConnection(teleport);
       },
       close: async () => {

--- a/packages/core/mesh/teleport/src/muxing/muxer.ts
+++ b/packages/core/mesh/teleport/src/muxing/muxer.ts
@@ -8,7 +8,8 @@ import { scheduleTaskInterval, Event, Trigger } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { failUndefined } from '@dxos/debug';
 import { invariant } from '@dxos/invariant';
-import { log } from '@dxos/log';
+import { type PublicKey } from '@dxos/keys';
+import { log, logInfo } from '@dxos/log';
 import { schema, TimeoutError } from '@dxos/protocols';
 import { type ConnectionInfo } from '@dxos/protocols/proto/dxos/devtools/swarm';
 import { Command } from '@dxos/protocols/proto/dxos/mesh/muxer';
@@ -104,6 +105,7 @@ export class Muxer {
   private readonly _channelsByLocalId = new Map<number, Channel>();
   private readonly _channelsByTag = new Map<string, Channel>();
   private readonly _ctx = new Context();
+  private _sessionId?: PublicKey;
 
   private _nextId = 1;
 
@@ -124,6 +126,15 @@ export class Muxer {
     this._balancer.incomingData.on(async (msg) => {
       await this._handleCommand(Command.decode(msg));
     });
+  }
+
+  setSessionId(sessionId: PublicKey) {
+    this._sessionId = sessionId;
+  }
+
+  @logInfo
+  get sessionIdString(): string {
+    return this._sessionId ? this._sessionId.truncate() : 'none';
   }
 
   /**

--- a/packages/core/mesh/teleport/src/testing/test-builder.ts
+++ b/packages/core/mesh/teleport/src/testing/test-builder.ts
@@ -82,7 +82,7 @@ export class TestPeer {
 
   async openConnection(connection: TestConnection) {
     invariant(this.connections.has(connection));
-    await connection.teleport.open();
+    await connection.teleport.open(PublicKey.random());
     await this.onOpen(connection);
   }
 

--- a/packages/core/protocols/src/proto/dxos/devtools/swarm.proto
+++ b/packages/core/protocols/src/proto/dxos/devtools/swarm.proto
@@ -42,6 +42,12 @@ message ConnectionInfo {
   optional uint32 readBufferSize = 10;
   optional uint32 writeBufferSize = 11;
   optional google.protobuf.Timestamp last_update = 12;
+  optional string transport_details = 13;
+  // TODO(nf): uint64?
+  optional uint32 transport_bytes_sent = 14;
+  optional uint32 transport_bytes_received = 15;
+  optional uint32 transport_packets_sent = 16;
+  optional uint32 transport_packets_received = 17;
 }
 
 message ConnectionEvent {

--- a/packages/core/protocols/src/proto/dxos/mesh/bridge.proto
+++ b/packages/core/protocols/src/proto/dxos/mesh/bridge.proto
@@ -7,6 +7,7 @@ syntax = "proto3";
 import "dxos/keys.proto";
 import "dxos/mesh/swarm.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
 
 package dxos.mesh.bridge;
 
@@ -26,6 +27,13 @@ service BridgeService {
 
   ///
   rpc Close(CloseRequest) returns (google.protobuf.Empty);
+
+  ///
+  rpc GetDetails(DetailsRequest) returns (DetailsResponse);
+
+  ///
+  rpc GetStats(StatsRequest) returns (StatsResponse);
+
 }
 
 enum ConnectionState {
@@ -73,4 +81,19 @@ message DataRequest {
 
 message CloseRequest{
   dxos.keys.PublicKey  proxy_id = 1;
+}
+
+message DetailsRequest{
+  dxos.keys.PublicKey  proxy_id = 1;
+}
+
+message DetailsResponse{
+  string details = 1;
+}
+
+message StatsRequest{
+  dxos.keys.PublicKey  proxy_id = 1;
+}
+message StatsResponse{
+  google.protobuf.Struct stats = 1;
 }

--- a/packages/devtools/devtools/src/panels/mesh/SwarmPanel/ConnectionInfoView.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SwarmPanel/ConnectionInfoView.tsx
@@ -16,6 +16,7 @@ const columns: TableColumnDef<ConnectionInfo.StreamStats, any>[] = [
   helper.accessor('bytesReceived', builder.number({ header: 'received' })),
   helper.accessor('bytesSentRate', builder.number({ header: 'sent b/s' })),
   helper.accessor('bytesReceivedRate', builder.number({ header: 'received b/s' })),
+  helper.accessor('writeBufferSize', builder.number({ header: 'write buffer' })),
   helper.accessor('tag', { meta: { cell: { classNames: textPadding } } }),
 ];
 
@@ -36,6 +37,8 @@ export const ConnectionInfoView: FC<{ connection?: ConnectionInfo }> = ({ connec
         schema={schema}
         object={{
           state: connection.state,
+          transportBytesSent: connection.transportBytesSent,
+          transportBytesReceived: connection.transportBytesReceived,
           closeReason: connection.closeReason,
           session: connection.sessionId,
           remotePeer: connection.remotePeerId,

--- a/packages/devtools/devtools/src/panels/mesh/SwarmPanel/SwarmPanel.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SwarmPanel/SwarmPanel.tsx
@@ -55,6 +55,16 @@ const columns: TableColumnDef<SwarmConnection, any>[] = [
     meta: { cell: { classNames: textPadding } },
     cell: (cell) => <span className={stateFormat[cell.getValue()]?.className}>{cell.getValue()}</span>,
   }),
+  helper.accessor(
+    (connection) =>
+      (connection.connection?.readBufferSize ?? 0) + ' / ' + (connection.connection?.writeBufferSize ?? 0),
+    {
+      id: 'buffer (r/w)',
+    },
+  ),
+  helper.accessor((connection) => connection.connection?.transportDetails, {
+    id: 'details',
+  }),
   helper.accessor((connection) => connection.connection && getStats(connection.connection), {
     id: 'stats',
     meta: { cell: { classNames: textPadding } },


### PR DESCRIPTION
* add sessionId to teleport/muxer
* add connection details
* add spaceKey to connection info
* add stream buffer to devtools

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6182625</samp>

### Summary
🚀📊🛠️

<!--
1.  🚀 This emoji represents the new feature of passing session ids to the teleport protocol, which enables faster and more reliable peer-to-peer communication across different connections.
2.  📊 This emoji represents the enhancement of exposing more information about the transport layer performance and statistics, which allows better monitoring and debugging of the network.
3.  🛠️ This emoji represents the improvement of the type safety and logging of the transport and wire protocols, which makes the code more robust and maintainable.
-->
This pull request adds support for session ids and transport stats to the mesh network and the echo pipeline. It introduces new fields, methods, and types to the `Transport`, `WireProtocol`, `SpaceProtocol`, and `Teleport` classes, and their implementations. It also updates the `bridge.proto` and `swarm.proto` files to define new RPC methods and messages for querying the transport details and statistics. Finally, it enhances the `ConnectionLog` and `ConnectionInfoView` components to collect and display more information about the connections and their performance.

> _`Teleport` sessions_
> _More stats and details shown_
> _Winter debugging_

### Walkthrough
*  Add transport-specific connection details and statistics to various transport classes and interfaces ([link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745L5-R10),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745L22-R22),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745R36-R37),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745R114-R115),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745R142-R146),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745R200),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745R207-R208),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-8fd5aaf7614ff1002b55a9d55308ab71bf42144d7246e3c8d68852c93cfc8745R412-R418),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-0fef1af9e7cf067eb944d6e387e1cbe9bd8cfb10deb2c4ec48fee97e2ff960b0L5-R5),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-0fef1af9e7cf067eb944d6e387e1cbe9bd8cfb10deb2c4ec48fee97e2ff960b0R191-R194),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-0fef1af9e7cf067eb944d6e387e1cbe9bd8cfb10deb2c4ec48fee97e2ff960b0R213-R220),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-74e405ef8f260064af959933bf80ef17755b246ae3cd5bc8a180678b50d59a40L13-R13),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-74e405ef8f260064af959933bf80ef17755b246ae3cd5bc8a180678b50d59a40R240-R275),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-12402f77165719f0d933a76b88fddc110017059ba79249f29266ed02184bb772L15-R15),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-12402f77165719f0d933a76b88fddc110017059ba79249f29266ed02184bb772R169-R181),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-1fd018bb9c3139a2516ce6464b265c212ef3a1751dc3e9844c544a694384250bL25-R25),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-1fd018bb9c3139a2516ce6464b265c212ef3a1751dc3e9844c544a694384250bR148-R155),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-cc0cc165bd94f178c1fbbe6ee98250b3db509cacbd5038db986be7b63c3c894eL16-R16),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-cc0cc165bd94f178c1fbbe6ee98250b3db509cacbd5038db986be7b63c3c894eL112-R112),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-cc0cc165bd94f178c1fbbe6ee98250b3db509cacbd5038db986be7b63c3c894eL122-R198),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-cc0cc165bd94f178c1fbbe6ee98250b3db509cacbd5038db986be7b63c3c894eR207),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-9d01856a9fc95fe4505c7e9849f1e67359cc871f0fef86146c9dca8e67a7f33fL8-R8),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-9d01856a9fc95fe4505c7e9849f1e67359cc871f0fef86146c9dca8e67a7f33fR28-R35),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-1689355b9e0e02e847bc9fe69297cccdf019ccd2db289aaf15fe51a17df8c068L12-R12),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-1689355b9e0e02e847bc9fe69297cccdf019ccd2db289aaf15fe51a17df8c068R90-R107),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-18621cba3ac79ffd89d262f7d42a79192df2b924126febe2f90fca627a98ed3fR7),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-18621cba3ac79ffd89d262f7d42a79192df2b924126febe2f90fca627a98ed3fR26-R33),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-18621cba3ac79ffd89d262f7d42a79192df2b924126febe2f90fca627a98ed3fR55-R56),[link](https://github.com/dxos/dxos/pull/4796/files?diff=unified&w=0#diff-18621cba3ac79ffd89d262f7d42a79192df2b924126febe2f90fca627a98ed3fR65-R72)).


