### PR TITLE
feat(automerge): Add schema support in automerge database

### DIFF
--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
@@ -23,7 +23,6 @@ export class AutomergeDb {
   constructor(public readonly graph: Hypergraph, private readonly _echoDatabase: EchoDatabase) {}
 
   async open() {
-    // eslint-disable-next-line no-eval
     this._repo = new AutomergeRepo({
       network: [],
     });

--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
@@ -42,7 +42,16 @@ export class AutomergeDb {
   readonly _objectsSystem = new Map<string, EchoObject>();
 
   getObjectById(id: string): EchoObject | undefined {
-    return this._objects.get(id);
+    const obj = this._objects.get(id) ?? this._echoDatabase._objects.get(id);
+
+    if (!obj) {
+      return undefined;
+    }
+    if ((obj as any).__deleted === true) {
+      return undefined;
+    }
+
+    return obj;
   }
 
   add<T extends EchoObject>(obj: T): T {

--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -192,8 +192,9 @@ export class AutomergeObject implements TypedObjectProperties {
     }
 
     if (this._doc) {
-      this._set([], this._doc);
+      const doc = this._doc;
       this._doc = undefined;
+      this._set([], doc);
     }
   }
 

--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -23,8 +23,9 @@ import {
   debug,
   subscribe,
   proxy,
+  immutable,
 } from '../object/types';
-import { type dxos } from '../proto/gen/schema';
+import { type Schema } from '../proto';
 import { compositeRuntime } from '../util';
 
 export type BindOptions = {
@@ -42,12 +43,23 @@ export type ObjectSystem = {
    * Deletion marker.
    */
   deleted: boolean;
+
+  /**
+   * Object type. Reference to the schema.
+   */
+  schema: Schema;
+
+  /**
+   * Object reference ('protobuf' protocol) type.
+   */
+  type: Reference;
 };
 
 export class AutomergeObject implements TypedObjectProperties {
   private _database?: AutomergeDb;
   private _doc?: Doc<any>;
   private _docHandle?: DocHandle<any>;
+  private _schema?: Schema;
 
   /**
    * @internal
@@ -71,15 +83,40 @@ export class AutomergeObject implements TypedObjectProperties {
   constructor(initialProps?: unknown, opts?: TypedObjectOptions) {
     this._initNewObject(initialProps, opts);
 
+    if (opts?.schema) {
+      this._schema = opts.schema;
+      this.__system.schema = opts.schema;
+    }
+    // TODO(mykola): Delete this once we clean up Reference 'protobuf' protocols types. References should not leak outside of the AutomergeObject, It should be internal concept.
+    const type =
+      opts?.type ??
+      (this._schema
+        ? this._schema[immutable]
+          ? Reference.fromLegacyTypename(opts!.schema!.typename)
+          : this._linkObject(this._schema)
+        : undefined);
+    if (type) {
+      this.__system.type = type;
+    }
+
     return this._createProxy(['data']);
   }
 
   get __typename(): string | undefined {
-    return undefined;
+    if (this.__schema) {
+      return this.__schema?.typename;
+    }
+    // TODO(mykola): Delete this once we clean up Reference 'protobuf' protocols types.
+    const typeRef = this.__system.type;
+    if (typeRef?.protocol === 'protobuf') {
+      return typeRef?.itemId;
+    } else {
+      return undefined;
+    }
   }
 
-  get __schema(): dxos.schema.Schema | undefined {
-    return undefined;
+  get __schema(): Schema | undefined {
+    return this[base]._getSchema();
   }
 
   get __meta(): ObjectMeta {
@@ -189,11 +226,18 @@ export class AutomergeObject implements TypedObjectProperties {
         }
 
         const value = this._get([...path, key as string]);
+
         if (value instanceof AbstractEchoObject || value instanceof AutomergeObject) {
           return value;
-        } else if (Array.isArray(value)) {
+        }
+        if (value instanceof Reference && value.protocol === 'protobuf') {
+          // TODO(mykola): Delete this once we clean up Reference 'protobuf' protocols types.
+          return value;
+        }
+        if (Array.isArray(value)) {
           return new AutomergeArray()._attach(this[base], [...path, key as string]);
-        } else if (typeof value === 'object' && value !== null) {
+        }
+        if (typeof value === 'object' && value !== null) {
           return this._createProxy([...path, key as string]);
         }
 
@@ -264,23 +308,23 @@ export class AutomergeObject implements TypedObjectProperties {
     }
     if (value instanceof AbstractEchoObject || value instanceof AutomergeObject) {
       const reference = this._linkObject(value);
-      // NOTE: Automerge do not support undefined values, so we need to use null instead.
-      return {
-        '@type': REFERENCE_TYPE_TAG,
-        itemId: reference.itemId ?? null,
-        protocol: reference.protocol ?? null,
-        host: reference.host ?? null,
-      };
-    } else if (value instanceof AutomergeArray || Array.isArray(value)) {
+      return encodeReference(reference);
+    }
+    if (value instanceof Reference && value.protocol === 'protobuf') {
+      // TODO(mykola): Delete this once we clean up Reference 'protobuf' protocols types.
+      return encodeReference(value);
+    }
+    if (value instanceof AutomergeArray || Array.isArray(value)) {
       const values: any = value.map((val) => {
         if (val instanceof AutomergeArray || Array.isArray(val)) {
-          // s TODO(mykola): Add support for nested arrays.
+          // TODO(mykola): Add support for nested arrays.
           throw new Error('Nested arrays are not supported');
         }
         return this._encode(val);
       });
       return values;
-    } else if (typeof value === 'object' && value !== null) {
+    }
+    if (typeof value === 'object' && value !== null) {
       Object.freeze(value);
       return Object.fromEntries(Object.entries(value).map(([key, value]): [string, any] => [key, this._encode(value)]));
     }
@@ -293,10 +337,17 @@ export class AutomergeObject implements TypedObjectProperties {
   _decode(value: any): any {
     if (Array.isArray(value)) {
       return value.map((val) => this._decode(val));
-    } else if (typeof value === 'object' && value !== null && value['@type'] === REFERENCE_TYPE_TAG) {
-      const reference = new Reference(value.itemId, value.protocol ?? undefined, value.host ?? undefined);
+    }
+    if (typeof value === 'object' && value !== null && value['@type'] === REFERENCE_TYPE_TAG) {
+      if (value.protocol === 'protobuf') {
+        // TODO(mykola): Delete this once we clean up Reference 'protobuf' protocols types.
+        return decodeReference(value);
+      }
+
+      const reference = decodeReference(value);
       return this._lookupLink(reference);
-    } else if (typeof value === 'object') {
+    }
+    if (typeof value === 'object') {
       return Object.fromEntries(Object.entries(value).map(([key, value]): [string, any] => [key, this._decode(value)]));
     }
 
@@ -348,6 +399,24 @@ export class AutomergeObject implements TypedObjectProperties {
     this._signal.notifyWrite();
     this._updates.emit();
   };
+
+  /**
+   * @internal
+   */
+  // TODO(dmaretskyi): Make public.
+  _getType() {
+    return this.__system.type;
+  }
+
+  private _getSchema(): Schema | undefined {
+    if (!this._schema && this._database) {
+      const type = this.__system.type;
+      if (type) {
+        this._schema = this._database._resolveSchema(type);
+      }
+    }
+    return this._schema;
+  }
 }
 
 const isValidKey = (key: string | symbol) => {
@@ -365,5 +434,16 @@ const isValidKey = (key: string | symbol) => {
     key === '__deleted'
   );
 };
+
+const encodeReference = (reference: Reference) => ({
+  '@type': REFERENCE_TYPE_TAG,
+  // NOTE: Automerge do not support undefined values, so we need to use null instead.
+  itemId: reference.itemId ?? null,
+  protocol: reference.protocol ?? null,
+  host: reference.host ?? null,
+});
+
+const decodeReference = (value: any) =>
+  new Reference(value.itemId, value.protocol ?? undefined, value.host ?? undefined);
 
 const REFERENCE_TYPE_TAG = 'dxos.echo.model.document.Reference';

--- a/packages/core/echo/echo-schema/src/database.ts
+++ b/packages/core/echo/echo-schema/src/database.ts
@@ -41,7 +41,7 @@ export class EchoDatabase {
 
   public readonly pendingBatch: ReadOnlyEvent<BatchUpdate> = this._backend.pendingBatch;
 
-  public readonly automerge = new AutomergeDb(this._graph);
+  public readonly automerge = new AutomergeDb(this._graph, this);
 
   constructor(
     /**
@@ -66,7 +66,8 @@ export class EchoDatabase {
   }
 
   getObjectById<T extends EchoObject>(id: string): T | undefined {
-    const obj = this._objects.get(id);
+    const obj = this._objects.get(id) ?? this.automerge.getObjectById(id);
+
     if (!obj) {
       return undefined;
     }

--- a/packages/core/echo/echo-schema/src/database.ts
+++ b/packages/core/echo/echo-schema/src/database.ts
@@ -66,7 +66,7 @@ export class EchoDatabase {
   }
 
   getObjectById<T extends EchoObject>(id: string): T | undefined {
-    const obj = this._objects.get(id) ?? this.automerge.getObjectById(id);
+    const obj = this._objects.get(id) ?? this.automerge._objects.get(id);
 
     if (!obj) {
       return undefined;

--- a/packages/core/echo/echo-schema/src/hypergraph.ts
+++ b/packages/core/echo/echo-schema/src/hypergraph.ts
@@ -225,8 +225,10 @@ class SpaceQuerySource implements QuerySource {
       return (
         !this._results ||
         this._results.find((result) => result.id === object.id) ||
-        ((this._database._objects.has(object.id) || this._database.automerge._objects.has(object.id)) &&
-          filterMatch(this._filter!, this._database.getObjectById(object.id)!))
+        (this._database._objects.has(object.id) &&
+          filterMatch(this._filter!, this._database._objects.get(object.id)!)) ||
+        (this._database.automerge._objects.has(object.id) &&
+          filterMatch(this._filter!, this._database.automerge._objects.get(object.id)!))
       );
     });
 

--- a/packages/core/echo/echo-schema/src/hypergraph.ts
+++ b/packages/core/echo/echo-schema/src/hypergraph.ts
@@ -215,7 +215,7 @@ class SpaceQuerySource implements QuerySource {
     return this._database._backend.spaceKey;
   }
 
-  private _onUpdate = (updateEvent: UpdateEvent) => {
+  private _onUpdate = (updateEvent: { spaceKey: PublicKey; itemsUpdated: { id: string }[] }) => {
     if (!this._filter) {
       return;
     }
@@ -225,7 +225,8 @@ class SpaceQuerySource implements QuerySource {
       return (
         !this._results ||
         this._results.find((result) => result.id === object.id) ||
-        (this._database._objects.has(object.id) && filterMatch(this._filter!, this._database._objects.get(object.id)!))
+        ((this._database._objects.has(object.id) || this._database.automerge._objects.has(object.id)) &&
+          filterMatch(this._filter!, this._database.getObjectById(object.id)!))
       );
     });
 
@@ -274,6 +275,7 @@ class SpaceQuerySource implements QuerySource {
 
     // TODO(dmaretskyi): Allow to specify a retainer.
     this._database._updateEvent.on(new Context(), this._onUpdate, { weak: true });
+    this._database.automerge._updateEvent.on(new Context(), this._onUpdate, { weak: true });
 
     this._results = undefined;
     this.changed.emit();

--- a/packages/core/echo/echo-schema/src/object/typed-object.ts
+++ b/packages/core/echo/echo-schema/src/object/typed-object.ts
@@ -128,7 +128,7 @@ class TypedObjectImpl<T> extends AbstractEchoObject<DocumentModel> implements Ty
     if (this._schema) {
       for (const field of this._schema.props) {
         if (field.repeated) {
-          this._set(field.id!, new EchoArray());
+          this._set(field.id!, new EchoArray([], { useAutomergeBackend: false }));
         } else if (field.type === getSchemaProto().PropType.REF && field.refModelType === TextModel.meta.type) {
           // eslint-disable-next-line @typescript-eslint/no-var-requires
           const { TextObject } = require('./text-object');
@@ -345,7 +345,7 @@ class TypedObjectImpl<T> extends AbstractEchoObject<DocumentModel> implements Ty
       case 'object':
         return this._createProxy({}, key, meta);
       case 'array':
-        return new EchoArray()._attach(this[base], key, meta);
+        return new EchoArray([], { useAutomergeBackend: false })._attach(this[base], key, meta);
       default:
         return value;
     }

--- a/packages/core/echo/echo-schema/src/query/filter.ts
+++ b/packages/core/echo/echo-schema/src/query/filter.ts
@@ -5,6 +5,7 @@
 import { DocumentModel, Reference } from '@dxos/document-model';
 import { invariant } from '@dxos/invariant';
 import { type PublicKey } from '@dxos/keys';
+import { log } from '@dxos/log';
 import { QueryOptions, type Filter as FilterProto } from '@dxos/protocols/proto/dxos/echo/filter';
 
 import { AutomergeObject } from '../automerge/automerge-object';

--- a/packages/core/echo/echo-schema/src/query/filter.ts
+++ b/packages/core/echo/echo-schema/src/query/filter.ts
@@ -5,7 +5,6 @@
 import { DocumentModel, Reference } from '@dxos/document-model';
 import { invariant } from '@dxos/invariant';
 import { type PublicKey } from '@dxos/keys';
-import { log } from '@dxos/log';
 import { QueryOptions, type Filter as FilterProto } from '@dxos/protocols/proto/dxos/echo/filter';
 
 import { AutomergeObject } from '../automerge/automerge-object';

--- a/packages/core/echo/echo-schema/src/query/filter.ts
+++ b/packages/core/echo/echo-schema/src/query/filter.ts
@@ -236,7 +236,7 @@ const filterMatchInner = (filter: Filter, object: EchoObject): boolean => {
       }
 
       // TODO(burdon): Comment.
-      if (!compareType(filter.type, type, getDatabaseFromObject(object)?._backend.spaceKey)) {
+      if (!compareType(filter.type, type, getDatabaseFromObject(object)?._backend?.spaceKey)) {
         return false;
       }
     }

--- a/packages/core/echo/echo-schema/src/query/query.test.ts
+++ b/packages/core/echo/echo-schema/src/query/query.test.ts
@@ -5,7 +5,6 @@
 import { expect } from 'chai';
 
 import { Trigger, asyncTimeout, sleep } from '@dxos/async';
-import { log } from '@dxos/log';
 import { QueryOptions } from '@dxos/protocols/proto/dxos/echo/filter';
 import { afterTest, beforeAll, beforeEach, describe, test } from '@dxos/test';
 
@@ -207,7 +206,7 @@ test('query with model filters', async () => {
 });
 
 testWithAutomerge(() => {
-  test.only('query by typename receives updates', async () => {
+  test('query by typename receives updates', async () => {
     const testBuilder = new TestBuilder();
     testBuilder.graph.addTypes(types);
     const peer = await testBuilder.createPeer();
@@ -221,7 +220,6 @@ testWithAutomerge(() => {
     const nameUpdate = new Trigger();
     const anotherContactAdded = new Trigger();
     const unsub = query.subscribe(({ objects }) => {
-      log.info('query', { objects: objects.map((obj) => obj.toJSON()) });
       if (objects.some((obj) => obj.name === name)) {
         nameUpdate.wake();
       }
@@ -233,6 +231,7 @@ testWithAutomerge(() => {
 
     contact.name = name;
     peer.db.add(new Contact());
+
     await asyncTimeout(nameUpdate.wait(), 1000);
     await asyncTimeout(anotherContactAdded.wait(), 1000);
   });


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6a5dd03</samp>

### Summary
🛠️🚀🧪

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used for the first, fourth, and fifth changes, which modify or fix some existing functionality or logic in the codebase.
2.  🚀 - This emoji represents a launch or a new feature, and can be used for the third and sixth changes, which enhance or add new functionality or integration to the codebase.
3.  🧪 - This emoji represents a test or an experiment, and can be used for the second and seventh changes, which add or modify test cases or use different backends for testing or implementation purposes.
-->
This pull request improves the echo-schema package by enhancing the AutomergeDb class, integrating it with the EchoDatabase and the SpaceQuerySource classes, supporting protobuf schema references, and using the Echo backend for repeated fields. It also fixes a bug in the EchoDatabase class, adds optional chaining to the filter module, and updates the query test module to run with both backends.

> _We're breaking the chains of the Automerge backend_
> _We're using the Echo to store and query our objects_
> _We're resolving the schemas from different protocols_
> _We're emitting the events when the document changes_

### Walkthrough
*  Add and use _updateEvent property to AutomergeDb class to notify listeners about changes in the Automerge document ([link](https://github.com/dxos/dxos/pull/4799/files?diff=unified&w=0#diff-875834e4b70c12d82e4dedc39420f91a998d2d84b6b7b3551a6b6d90335bfa50L16-R35), [link](https://github.com/dxos/dxos/pull/4799/files?diff=unified&w=0#diff-ea3963e9e0ef0e8fb4bff94dc35f8655e5f0f297acc6c55625ce53e072a35b3bL218-R218), [link](https://github.com/dxos/dxos/pull/4799/files?diff=unified&w=0#diff-ea3963e9e0ef0e8fb4bff94dc35f8655e5f0f297acc6c55625ce53e072a35b3bR280)).

