### PR TITLE
fix: ICE servers for agent

### DIFF
--- a/packages/core/agent/src/agent.ts
+++ b/packages/core/agent/src/agent.ts
@@ -65,10 +65,14 @@ export class Agent {
     let transportFactory: TransportFactory;
     if (process.env.WEBRTCLIBRARY === 'LibDataChannel') {
       log.info('using LibDataChannel');
-      transportFactory = createLibDataChannelTransportFactory();
+      transportFactory = createLibDataChannelTransportFactory({
+        iceServers: this._options.config.get('runtime.services.ice'),
+      });
     } else {
       log.info('using SimplePeer');
-      transportFactory = createSimplePeerTransportFactory();
+      transportFactory = createSimplePeerTransportFactory({
+        iceServers: this._options.config.get('runtime.services.ice'),
+      });
     }
 
     // Create client services.

--- a/packages/core/mesh/network-manager/src/transport/libdatachannel-transport.test.ts
+++ b/packages/core/mesh/network-manager/src/transport/libdatachannel-transport.test.ts
@@ -2,10 +2,6 @@
 // Copyright 2023 DXOS.org
 //
 
-//
-// Copyright 2020 DXOS.org
-//
-
 import { Duplex } from 'stream';
 
 import { sleep, TestStream } from '@dxos/async';

--- a/packages/core/mesh/network-manager/src/transport/simplepeer-transport.ts
+++ b/packages/core/mesh/network-manager/src/transport/simplepeer-transport.ts
@@ -37,6 +37,9 @@ export class SimplePeerTransport implements Transport {
 
   private readonly _instanceId = PublicKey.random().toHex();
 
+  /**
+   * @params opts.config formatted as per https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection
+   */
   constructor(private readonly params: SimplePeerTransportParams) {
     log.trace('dxos.mesh.webrtc-transport.constructor', trace.begin({ id: this._instanceId }));
     log('created connection', params);


### PR DESCRIPTION
* use configured ICE servers
* parse properly for libdatachannel

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at bc79a5e</samp>

### Summary
🧊🗑️📝

<!--
1.  🧊 - This emoji represents ice, which is a common term for the Interactive Connectivity Establishment (ICE) protocol that WebRTC uses to establish peer-to-peer connections. This emoji is suitable for the first and second changes, which involve passing and converting the iceServers option for WebRTC transports.
2. 🗑️ - This emoji represents a wastebasket, which is used to indicate the removal or deletion of something. This emoji is suitable for the third change, which removes the license header from the test file.
3. 📝 - This emoji represents a memo, which is used to indicate the addition or modification of documentation or comments. This emoji is suitable for the fourth change, which adds a comment to document the config option for the SimplePeerTransport constructor.
-->
This pull request adds support for custom ICE servers for WebRTC transports in the agent and network manager packages. It also fixes the format of the iceServers option for the LibDataChannel transport and removes a redundant license header from a test file.

> _`iceServers` passed_
> _to WebRTC transports_
> _configuring winter_

### Walkthrough
*  Enable custom ICE servers for WebRTC transports ([link](https://github.com/dxos/dxos/pull/4802/files?diff=unified&w=0#diff-b9f82346256c8e3a09b62d4af127cf173db784b0550b1600dffb6080087a3061L68-R75), [link](https://github.com/dxos/dxos/pull/4802/files?diff=unified&w=0#diff-0fef1af9e7cf067eb944d6e387e1cbe9bd8cfb10deb2c4ec48fee97e2ff960b0L48-R58), [link](https://github.com/dxos/dxos/pull/4802/files?diff=unified&w=0#diff-cc0cc165bd94f178c1fbbe6ee98250b3db509cacbd5038db986be7b63c3c894eR40-R42))
  - Pass the iceServers option from the agent configuration to the transport factory in `agent.ts` ([link](https://github.com/dxos/dxos/pull/4802/files?diff=unified&w=0#diff-b9f82346256c8e3a09b62d4af127cf173db784b0550b1600dffb6080087a3061L68-R75))
  - Convert the iceServers option to the LibDataChannel format in `rtc-peer-connection.ts` ([link](https://github.com/dxos/dxos/pull/4802/files?diff=unified&w=0#diff-0fef1af9e7cf067eb944d6e387e1cbe9bd8cfb10deb2c4ec48fee97e2ff960b0L48-R58))
  - Document the expected format of the config option for the SimplePeerTransport constructor in `simplepeer-transport.ts` ([link](https://github.com/dxos/dxos/pull/4802/files?diff=unified&w=0#diff-cc0cc165bd94f178c1fbbe6ee98250b3db509cacbd5038db986be7b63c3c894eR40-R42))
* Remove license header from test file ([link](https://github.com/dxos/dxos/pull/4802/files?diff=unified&w=0#diff-834b413a81e78fdc920651e4a83da45a2db02147fb0a669474f61a6597af287fL5-L8))
  - Delete the redundant and inconsistent license header from `libdatachannel-transport.test.ts` ([link](https://github.com/dxos/dxos/pull/4802/files?diff=unified&w=0#diff-834b413a81e78fdc920651e4a83da45a2db02147fb0a669474f61a6597af287fL5-L8))


