### PR TITLE
test(proto-guard): Enable force exit

### DIFF
--- a/packages/gravity/proto-guard/project.json
+++ b/packages/gravity/proto-guard/project.json
@@ -26,7 +26,8 @@
       "options": {
         "environments": [
           "nodejs"
-        ]
+        ],
+        "forceExit": true
       }
     }
   }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b63ee58</samp>

### Summary
🐛🚀🛠️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of adding the `forceExit` option.
2.  🚀 - This emoji represents a performance improvement, which is a possible benefit of ensuring that Jest exits promptly and does not waste resources on hanging processes or open handles.
3.  🛠️ - This emoji represents a tooling or configuration change, which is the type of change that modifying the `jest` configuration is.
-->
Added `forceExit` option to Jest config in `proto-guard` project to fix CI hanging issue.

> _`forceExit` option_
> _Jest can now leave gracefully_
> _No more hanging tests_

### Walkthrough
* Add `forceExit` option to Jest configuration to fix hanging processes on CI ([link](https://github.com/dxos/dxos/pull/4807/files?diff=unified&w=0#diff-3278089e8277e03845fc81002e944e6a8ba201e6a4abefc87338c17bc51e41c9L29-R30))


