### PR TITLE
fix(react-ui-stack): avoid crash when dropping graph nodes

### DIFF
--- a/packages/ui/react-ui-stack/src/components/Stack.stories.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack.stories.tsx
@@ -93,7 +93,7 @@ export const Copy = {
   render: ({ debug, ...args }: DemoStackProps & { debug: boolean }) => {
     return (
       <Mosaic.Root debug={debug}>
-        <Mosaic.DragOverlay />
+        <Mosaic.DragOverlay debug={debug} />
         <div className='flex grow justify-center p-4'>
           <div className='grid grid-cols-2 gap-4'>
             <DemoStack {...args} id='stack-1' />
@@ -122,7 +122,7 @@ const DemoStack = ({
 }: DemoStackProps) => {
   const [items, setItems] = useState<StackSectionItem[]>(() => {
     const generator = new TestObjectGenerator({ types });
-    return generator.createObjects({ length: count });
+    return generator.createObjects({ length: count }).map((object) => ({ id: faker.datatype.uuid(), object }));
   });
 
   const itemsRef = useRef(items);

--- a/packages/ui/react-ui-stack/src/components/Stack.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack.tsx
@@ -66,7 +66,13 @@ export const Stack = ({
     () =>
       forwardRef(({ path, type, active, draggableStyle, draggableProps, item }, forwardRef) => {
         const { t } = useTranslation(translationKey);
-        const transformedItem = transform ? transform(item, active ? activeItem?.type : type) : item;
+        const transformedItem = transform
+          ? transform(
+              item,
+              // TODO(wittjosiah): `active` doesn't always seem to be accurate here.
+              activeItem?.item.id === item.id ? activeItem?.type : type,
+            )
+          : item;
         const section = (
           <Section
             ref={forwardRef}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2718033</samp>

### Summary
🐛🌟🧪

<!--
1.  🐛 - This emoji represents the bug fix for the `transform` function, as it indicates that a problem was resolved and the component's behavior was improved.
2.  🌟 - This emoji represents the enhancement of the `Mosaic` component by adding the `debug` prop and the `id` property, as it indicates that new features or capabilities were added to the component and that it became more useful or versatile.
3.  🧪 - This emoji represents the improvement of the testability of the component by adding the `id` property, as it indicates that the component can be more easily identified and manipulated in testing scenarios.
-->
This pull request improves the `Mosaic` component of the `react-ui-stack` package by adding a `debug` prop and an `id` property, and fixes a bug in the `transform` prop that affected the active panel state.

> _`Mosaic` of doom, you can't escape the `transform`_
> _`activeItem` is the key, but it's not enough_
> _`debug` the madness, see the colors of your fate_
> _`id` the panels, before it's too late_

### Walkthrough
* Fix bug and improve debugging of mosaic component
  - Add `debug` prop to `Mosaic.DragOverlay` for visual feedback of drag and drop zones ([link](https://github.com/dxos/dxos/pull/4810/files?diff=unified&w=0#diff-5bba912bfd64ce360a1ff7ef49e47a3e86f0a8dc21c1536973fdd02919979482L96-R96))
  - Add unique `id` property to each item in `items` state using `faker` library ([link](https://github.com/dxos/dxos/pull/4810/files?diff=unified&w=0#diff-5bba912bfd64ce360a1ff7ef49e47a3e86f0a8dc21c1536973fdd02919979482L125-R125))
  - Use `activeItem` state instead of `active` parameter in `transform` function and add TODO comment for further investigation ([link](https://github.com/dxos/dxos/pull/4810/files?diff=unified&w=0#diff-6d9916d392111dfbbaea8bee0b2a071c011fadc36b624705046ddd06bb9f5a67L69-R75))


