### PR TITLE
fix: simplepeer diagnostics

### DIFF
--- a/packages/core/mesh/network-manager/src/transport/simplepeer-transport.ts
+++ b/packages/core/mesh/network-manager/src/transport/simplepeer-transport.ts
@@ -182,8 +182,8 @@ export class SimplePeerTransport implements Transport {
       return 'unavailable';
     }
 
-    if (rc.relay) {
-      return `${rc.ip}:${rc.port}/${rc.protocol} relay for XXX ${rc.candidateType}`;
+    if (rc.candidateType === 'relay') {
+      return `${rc.ip}:${rc.port}/${rc.protocol} relay for ${rc.relatedAddress}:${rc.relatedPort}`;
     }
     return `${rc.ip}:${rc.port}/${rc.protocol} ${rc.candidateType}`;
   }
@@ -193,7 +193,6 @@ export class SimplePeerTransport implements Transport {
     if (this._closed) {
       return;
     }
-    this._closed = true;
     this._disconnectStreams();
     this._peer!.destroy();
     this._closed = true;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 46adef6</samp>

### Summary
📝🌐🧹

<!--
1.  📝 - This emoji represents the enhancement of the logging, as it is commonly used to indicate writing or documentation.
2.  🌐 - This emoji represents the peer-to-peer communication using WebRTC, as it is commonly used to indicate the internet or networking.
3.  🧹 - This emoji represents the simplification of the state management, as it is commonly used to indicate cleaning or tidying up.
-->
Improve logging and state handling of `SimplePeerTransport`. Refactor `simplepeer-transport.ts` to make the code more readable and robust.

> _We are the SimplePeerTransport_
> _We log our fate and simplify our state_
> _We defy the tyranny of WebRTC_
> _We are the SimplePeerTransport_

### Walkthrough
* Improve logging of relayed candidate address and port ([link](https://github.com/dxos/dxos/pull/4812/files?diff=unified&w=0#diff-cc0cc165bd94f178c1fbbe6ee98250b3db509cacbd5038db986be7b63c3c894eL185-R186))
* Remove redundant assignment of `_closed` property ([link](https://github.com/dxos/dxos/pull/4812/files?diff=unified&w=0#diff-cc0cc165bd94f178c1fbbe6ee98250b3db509cacbd5038db986be7b63c3c894eL196))


