### PR TITLE
feat: Storage adapter for automerge

### DIFF
--- a/packages/common/log/src/decorators.ts
+++ b/packages/common/log/src/decorators.ts
@@ -7,6 +7,8 @@ import { inspect } from 'node:util';
 import type { LogMethods } from './log';
 import { type CallMetadata } from './meta';
 
+let nextPromiseId = 0;
+
 export const createMethodLogDecorator =
   (log: LogMethods) =>
   (arg0?: never, arg1?: never, meta?: CallMetadata): MethodDecorator =>
@@ -21,8 +23,28 @@ export const createMethodLogDecorator =
       const formattedArgs = args.map((arg: any) => inspect(arg, false, 1, true)).join(', ');
 
       try {
+        const startTime = performance.now();
         const result = method.apply(this, args);
-        log.info(`${propertyKey as string}(${formattedArgs}) => ${inspect(result, false, 1, true)}`, {}, combinedMeta);
+        
+        if (isThenable(result)) {
+          const id = nextPromiseId++;
+          log.info(`${propertyKey as string}(${formattedArgs}) => Promise { #${id} }`, {}, combinedMeta);
+          result.then(
+            resolvedValue => {
+              if(resolvedValue !== undefined) {
+                log.info(`✅ resolve #${id} ${(performance.now() - startTime).toFixed(0)}ms => ${inspect(resolvedValue, false, 1, true)}`, {}, combinedMeta);
+              } else {
+                log.info(`✅ resolve #${id} ${(performance.now() - startTime).toFixed(0)}ms`, {}, combinedMeta);
+              }
+            },
+            err => {
+              log.info(`🔥 reject #${id} #${(performance.now() - startTime).toFixed(0)}ms => ${err}`, {}, combinedMeta);
+            }
+          )
+        } else {
+          log.info(`${propertyKey as string}(${formattedArgs}) => ${inspect(result, false, 1, true)}`, {}, combinedMeta);
+        }
+
         return result;
       } catch (err) {
         log.error(`${propertyKey as string}(${formattedArgs}) 🔥 ${err}`, {}, combinedMeta);
@@ -31,3 +53,5 @@ export const createMethodLogDecorator =
     };
     Object.defineProperty(descriptor.value, 'name', { value: (propertyKey as string) + '$log' });
   };
+
+const isThenable = (obj: any): obj is Promise<unknown> => obj && typeof obj.then === 'function';

--- a/packages/common/log/src/decorators.ts
+++ b/packages/common/log/src/decorators.ts
@@ -25,24 +25,37 @@ export const createMethodLogDecorator =
       try {
         const startTime = performance.now();
         const result = method.apply(this, args);
-        
+
         if (isThenable(result)) {
           const id = nextPromiseId++;
           log.info(`${propertyKey as string}(${formattedArgs}) => Promise { #${id} }`, {}, combinedMeta);
           result.then(
-            resolvedValue => {
-              if(resolvedValue !== undefined) {
-                log.info(`✅ resolve #${id} ${(performance.now() - startTime).toFixed(0)}ms => ${inspect(resolvedValue, false, 1, true)}`, {}, combinedMeta);
+            (resolvedValue) => {
+              if (resolvedValue !== undefined) {
+                log.info(
+                  `✅ resolve #${id} ${(performance.now() - startTime).toFixed(0)}ms => ${inspect(
+                    resolvedValue,
+                    false,
+                    1,
+                    true,
+                  )}`,
+                  {},
+                  combinedMeta,
+                );
               } else {
                 log.info(`✅ resolve #${id} ${(performance.now() - startTime).toFixed(0)}ms`, {}, combinedMeta);
               }
             },
-            err => {
+            (err) => {
               log.info(`🔥 reject #${id} #${(performance.now() - startTime).toFixed(0)}ms => ${err}`, {}, combinedMeta);
-            }
-          )
+            },
+          );
         } else {
-          log.info(`${propertyKey as string}(${formattedArgs}) => ${inspect(result, false, 1, true)}`, {}, combinedMeta);
+          log.info(
+            `${propertyKey as string}(${formattedArgs}) => ${inspect(result, false, 1, true)}`,
+            {},
+            combinedMeta,
+          );
         }
 
         return result;

--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.test.ts
@@ -1,9 +1,8 @@
-import { describe, test } from "@dxos/test";
-import { AutomergeHost } from "./automerge-host";
-import expect from 'expect';
-import { StorageType, createStorage } from "@dxos/random-access-storage";
 import { sleep } from "@dxos/async";
-import { log } from "@dxos/log";
+import { StorageType, createStorage } from "@dxos/random-access-storage";
+import { describe, test } from "@dxos/test";
+import expect from 'expect';
+import { AutomergeHost } from "./automerge-host";
 
 describe('AutomergeHost', () => {
   test('can create documents', () => {

--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.test.ts
@@ -1,0 +1,16 @@
+import { describe, test } from "@dxos/test";
+import { AutomergeHost } from "./automerge-host";
+import expect from 'expect';
+
+describe('AutomergeHost', () => {
+  test('can create documents', () => {
+    const host = new AutomergeHost();
+
+    const handle = host.repo.create<any>();
+    handle.change((doc: any) => {
+      doc.text = 'Hello world';
+    });
+
+    expect(handle.docSync().text).toEqual('Hello world');
+  })
+});

--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.test.ts
@@ -1,16 +1,37 @@
 import { describe, test } from "@dxos/test";
 import { AutomergeHost } from "./automerge-host";
 import expect from 'expect';
+import { StorageType, createStorage } from "@dxos/random-access-storage";
+import { sleep } from "@dxos/async";
+import { log } from "@dxos/log";
 
 describe('AutomergeHost', () => {
   test('can create documents', () => {
-    const host = new AutomergeHost();
+    const host = new AutomergeHost(createStorage({ type: StorageType.RAM }).createDirectory());
 
-    const handle = host.repo.create<any>();
+    const handle = host.repo.create();
     handle.change((doc: any) => {
       doc.text = 'Hello world';
     });
-
     expect(handle.docSync().text).toEqual('Hello world');
+  });
+
+  test('changes are preserved in storage', async () => {
+    const storageDirectory = createStorage({ type: StorageType.RAM }).createDirectory();
+
+    const host = new AutomergeHost(storageDirectory);
+    const handle = host.repo.create();
+    handle.change((doc: any) => {
+      doc.text = 'Hello world';
+    });
+    const url = handle.url;
+
+    // TODO(dmaretskyi): Is there a way to know when automerge has finished saving?
+    await sleep(100);
+
+    const host2 = new AutomergeHost(storageDirectory);
+    const handle2 = host2.repo.find(url);
+    await handle2.whenReady();
+    expect(handle2.docSync().text).toEqual('Hello world');
   })
 });

--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.test.ts
@@ -1,8 +1,14 @@
-import { sleep } from "@dxos/async";
-import { StorageType, createStorage } from "@dxos/random-access-storage";
-import { describe, test } from "@dxos/test";
+//
+// Copyright 2023 DXOS.org
+//
+
 import expect from 'expect';
-import { AutomergeHost } from "./automerge-host";
+
+import { sleep } from '@dxos/async';
+import { StorageType, createStorage } from '@dxos/random-access-storage';
+import { describe, test } from '@dxos/test';
+
+import { AutomergeHost } from './automerge-host';
 
 describe('AutomergeHost', () => {
   test('can create documents', () => {
@@ -32,5 +38,5 @@ describe('AutomergeHost', () => {
     const handle2 = host2.repo.find(url);
     await handle2.whenReady();
     expect(handle2.docSync().text).toEqual('Hello world');
-  })
+  });
 });

--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
@@ -14,7 +14,10 @@ import {
 } from '@dxos/automerge/automerge-repo';
 import { Stream } from '@dxos/codec-protobuf';
 import { invariant } from '@dxos/invariant';
+import { log } from '@dxos/log';
 import { type SyncRepoRequest, type SyncRepoResponse } from '@dxos/protocols/proto/dxos/echo/service';
+import { Directory } from '@dxos/random-access-storage';
+import { arrayToBuffer, bufferToArray, getDebugName, getPrototypeSpecificInstanceId } from '@dxos/util';
 
 export class AutomergeHost {
   private readonly _repo: Repo;
@@ -22,17 +25,19 @@ export class AutomergeHost {
   private readonly _clientNetwork: LocalHostNetworkAdapter;
   private readonly _storage: AutomergeStorageAdapter;
 
-  constructor() {
+  constructor(
+    storageDirectory: Directory,
+  ) {
     this._meshNetwork = new MeshNetworkAdapter();
     this._clientNetwork = new LocalHostNetworkAdapter();
-    this._storage = new AutomergeStorageAdapter();
+    this._storage = new AutomergeStorageAdapter(storageDirectory);
     this._repo = new Repo({
       network: [
         // this._meshNetwork,
         this._clientNetwork,
       ],
 
-      // storage: this._storage,
+      storage: this._storage,
 
       // TODO(dmaretskyi): Share based on HALO permissions and space affinity.
       sharePolicy: async (peerId, documentId) => true, // Share everything.
@@ -141,23 +146,64 @@ class MeshNetworkAdapter extends NetworkAdapter {
 }
 
 class AutomergeStorageAdapter extends StorageAdapter {
-  override load(key: StorageKey): Promise<Uint8Array | undefined> {
-    throw new Error('Method not implemented.');
+  constructor(private readonly _directory: Directory) {
+    super();
   }
 
-  override save(key: StorageKey, data: Uint8Array): Promise<void> {
-    throw new Error('Method not implemented.');
+  override async load(key: StorageKey): Promise<Uint8Array | undefined> {
+    const filename = this._getFilename(key);
+    const file = this._directory.getOrCreateFile(filename);
+    const { size } = await file.stat();
+    const buffer = await file.read(0, size);
+    return bufferToArray(buffer);
   }
 
-  override remove(key: StorageKey): Promise<void> {
-    throw new Error('Method not implemented.');
+  override async save(key: StorageKey, data: Uint8Array): Promise<void> {
+    const filename = this._getFilename(key);
+    const file = this._directory.getOrCreateFile(filename);
+    await file.write(0, arrayToBuffer(data));
+    await file.truncate?.(data.length);
+
+    await file.flush?.();
   }
 
-  override loadRange(keyPrefix: StorageKey): Promise<Chunk[]> {
-    throw new Error('Method not implemented.');
+  override async remove(key: StorageKey): Promise<void> {
+    // TODO(dmaretskyi): Better deletion.
+    const filename = this._getFilename(key);
+    const file = this._directory.getOrCreateFile(filename);
+    await file.truncate?.(0);
   }
 
-  override removeRange(keyPrefix: StorageKey): Promise<void> {
-    throw new Error('Method not implemented.');
+  override async loadRange(keyPrefix: StorageKey): Promise<Chunk[]> {
+    const filename = this._getFilename(keyPrefix);
+    const entries = await this._directory.list();
+    return Promise.all(entries.filter(entry => entry.startsWith(filename))
+      .map(async (entry): Promise<Chunk> => {
+        const file = this._directory.getOrCreateFile(entry);
+        const { size } = await file.stat();
+        const buffer = await file.read(0, size);
+        return {
+          key: this._getKeyFromFilename(entry),
+          data: bufferToArray(buffer),
+        }
+      }))
+  }
+
+  override async removeRange(keyPrefix: StorageKey): Promise<void> {
+    const filename = this._getFilename(keyPrefix);
+    const entries = await this._directory.list();
+    await Promise.all(entries.filter(entry => entry.startsWith(filename))
+      .map(async (entry): Promise<void> => {
+        const file = this._directory.getOrCreateFile(filename);
+        await file.truncate?.(0);
+      }))
+  }
+
+  private _getFilename(key: StorageKey): string {
+    return key.map((k) => k.replaceAll('%', '%25').replaceAll('-', '%2D')).join('-');
+  }
+
+  private _getKeyFromFilename(filename: string): StorageKey {
+    return filename.split('-').map((k) => k.replaceAll('%2D', '-').replaceAll('%25', '%'));
   }
 }

--- a/packages/core/echo/echo-pipeline/src/testing/util.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/util.ts
@@ -9,6 +9,7 @@ import { MockFeedWriter } from '@dxos/feed-store/testing';
 import { PublicKey } from '@dxos/keys';
 import { ModelFactory } from '@dxos/model-factory';
 import { type DataMessage } from '@dxos/protocols/proto/dxos/echo/feed';
+import { StorageType, createStorage } from '@dxos/random-access-storage';
 import { Timeframe } from '@dxos/timeframe';
 
 import { AutomergeHost } from '../automerge';
@@ -45,7 +46,7 @@ export const createRemoteDatabaseFromDataServiceHost = async (
   dataServiceHost: DataServiceHost,
 ) => {
   const dataServiceSubscriptions = new DataServiceSubscriptions();
-  const automergeHost = new AutomergeHost();
+  const automergeHost = new AutomergeHost(createStorage({ type: StorageType.RAM }).createDirectory());
   const dataService = new DataServiceImpl(dataServiceSubscriptions, automergeHost);
 
   const spaceKey = PublicKey.random();

--- a/packages/core/echo/echo-pipeline/src/tests/database.test.ts
+++ b/packages/core/echo/echo-pipeline/src/tests/database.test.ts
@@ -10,6 +10,7 @@ import { TestBuilder as FeedTestBuilder } from '@dxos/feed-store/testing';
 import { PublicKey } from '@dxos/keys';
 import { ModelFactory } from '@dxos/model-factory';
 import { type DataMessage } from '@dxos/protocols/proto/dxos/echo/feed';
+import { createStorage, StorageType } from '@dxos/random-access-storage';
 import { test } from '@dxos/test';
 
 import { AutomergeHost } from '../automerge';
@@ -42,7 +43,7 @@ const createDatabaseWithFeeds = async () => {
   await host.open(new ItemManager(modelFactory), new ModelFactory().registerModel(DocumentModel));
 
   const dataServiceSubscriptions = new DataServiceSubscriptions();
-  const automergeHost = new AutomergeHost();
+  const automergeHost = new AutomergeHost(createStorage({ type: StorageType.RAM }).createDirectory());
   const dataService = new DataServiceImpl(dataServiceSubscriptions, automergeHost);
 
   const spaceKey = PublicKey.random();

--- a/packages/core/mesh/network-manager/src/topology/mmst-topology.ts
+++ b/packages/core/mesh/network-manager/src/topology/mmst-topology.ts
@@ -57,7 +57,7 @@ export class MMSTTopology implements Topology {
     const { connected, candidates } = this._controller.getState();
     // Run the algorithms if we have first candidates, ran it before, or have more connections than needed.
     if (this._sampleCollected || connected.length > this._maxPeers || candidates.length > 0) {
-      log.info('Running the algorithm.');
+      log('Running the algorithm.');
       this._sampleCollected = true;
       this._runAlgorithm();
     }
@@ -82,7 +82,7 @@ export class MMSTTopology implements Topology {
     // TODO(nf): does this rate limiting/flap dampening logic belong here or in the SwarmController?
     if (connected.length > this._maxPeers) {
       // Disconnect extra peers.
-      log.info(`disconnect ${connected.length - this._maxPeers} peers.`);
+      log(`disconnect ${connected.length - this._maxPeers} peers.`);
       const sorted = sortByXorDistance(connected, ownPeerId)
         .reverse()
         .slice(0, this._maxPeers - connected.length);
@@ -94,16 +94,16 @@ export class MMSTTopology implements Topology {
 
       if (Date.now() - this._lastAction.getTime() > MIN_UPDATE_INTERVAL) {
         for (const peer of sorted.slice(0, MAX_CHANGES_PER_UPDATE)) {
-          log.info(`Disconnect ${peer}.`);
+          log(`Disconnect ${peer}.`);
           this._controller.disconnect(peer);
         }
         this._lastAction = new Date();
       } else {
-        log.info('rate limited discconnect');
+        log('rate limited discconnect');
       }
     } else if (connected.length < this._originateConnections) {
       // Connect new peers to reach desired quota.
-      log.info(`connect ${this._originateConnections - connected.length} peers.`);
+      log(`connect ${this._originateConnections - connected.length} peers.`);
       const sample = candidates.sort(() => Math.random() - 0.5).slice(0, this._sampleSize);
       const sorted = sortByXorDistance(sample, ownPeerId).slice(0, this._originateConnections - connected.length);
 
@@ -112,12 +112,12 @@ export class MMSTTopology implements Topology {
       }
       if (Date.now() - this._lastAction.getTime() > MIN_UPDATE_INTERVAL) {
         for (const peer of sorted.slice(0, MAX_CHANGES_PER_UPDATE)) {
-          log.info(`Connect ${peer}.`);
+          log(`Connect ${peer}.`);
           this._controller.connect(peer);
         }
         this._lastAction = new Date();
       } else {
-        log.info('rate limited connect');
+        log('rate limited connect');
       }
     }
   }

--- a/packages/sdk/client-services/src/packlets/services/service-context.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-context.ts
@@ -109,7 +109,7 @@ export class ServiceContext {
 
     this.identityManager = new IdentityManager(this.metadataStore, this.keyring, this.feedStore, this.spaceManager);
 
-    this.automergeHost = new AutomergeHost();
+    this.automergeHost = new AutomergeHost(storage.createDirectory('automerge'));
 
     this.invitations = new InvitationsHandler(this.networkManager);
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0935079</samp>

### Summary
🧪💾🐛

<!--
1.  🧪 for adding a new test file
2.  💾 for modifying the storage logic and using a custom storage adapter
3.  🐛 for fixing the logging function in the `MMSTTopology` class
-->
This pull request improves the logging and storage capabilities of the `AutomergeHost` class, which is used to manage automerge documents for the data service. It adds support for logging async methods, using custom file-based storage, and testing with in-memory storage. It also updates the `ServiceContext` class to use the file-based storage and fixes a logging issue in the `MMSTTopology` class. It includes new and updated tests for the `AutomergeHost` class.

> _We store the documents in the `automerge` dir_
> _We test the changes with promises and `log`_
> _We use the `Directory` adapter for persistence_
> _We are the masters of the `AutomergeHost`_

### Walkthrough
*  Enable custom storage for `AutomergeHost` class using `Directory` and `AutomergeStorageAdapter` ([link](https://github.com/dxos/dxos/pull/4817/files?diff=unified&w=0#diff-52ff990be4c1a08ccf1789a3650692c2275445181a78327d5bf2505ac88d45eaR18-R19), [link](https://github.com/dxos/dxos/pull/4817/files?diff=unified&w=0#diff-52ff990be4c1a08ccf1789a3650692c2275445181a78327d5bf2505ac88d45eaL25-R30), [link](https://github.com/dxos/dxos/pull/4817/files?diff=unified&w=0#diff-52ff990be4c1a08ccf1789a3650692c2275445181a78327d5bf2505ac88d45eaL35-R37), [link](https://github.com/dxos/dxos/pull/4817/files?diff=unified&w=0#diff-52ff990be4c1a08ccf1789a3650692c2275445181a78327d5bf2505ac88d45eaL144-R211)).


