### PR TITLE
fix: Remove unused WASM plugin

### DIFF
--- a/packages/ui/react-ui-editor/.storybook/main.cjs
+++ b/packages/ui/react-ui-editor/.storybook/main.cjs
@@ -1,7 +1,6 @@
 const { mergeConfig } = require('vite');
 const { resolve } = require('path');
 
-const { default: pluginWasm } = require('vite-plugin-wasm');
 const { ConfigPlugin } = require('@dxos/config/vite-plugin');
 const { ThemePlugin } = require('@dxos/react-ui-theme/plugin');
 
@@ -17,7 +16,6 @@ module.exports = {
   viteFinal: async (config) =>
     mergeConfig(config, {
       plugins: [
-        pluginWasm(),
         ConfigPlugin(),
         ThemePlugin({
           root: __dirname,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 18c0001</samp>

### Summary
🗑️🧹🚀

<!--
1.  🗑️ - This emoji conveys the idea of removing or deleting something, which is what happened to the plugin and its configuration.
2.  🧹 - This emoji suggests the act of cleaning or tidying up, which is the effect of simplifying the development setup and avoiding unnecessary loading.
3.  🚀 - This emoji implies speed or improvement, which is the potential benefit of having a simpler and more efficient development environment.
-->
Simplified storybook configuration for `react-ui-editor` by removing unused plugin. This improves the development experience and performance.

> _Sing, O Muse, of the valiant coder who simplified the storybook_
> _And removed the `vite-plugin-wasm` from the config file with skill_
> _No more he needed the web assembly modules, those cunning devices_
> _That loaded like the hundred-headed Hydra, fierce and hard to kill_

### Walkthrough
* Remove `vite-plugin-wasm` dependency and configuration from `.storybook/main.cjs` ([link](https://github.com/dxos/dxos/pull/4835/files?diff=unified&w=0#diff-d1a24081d29d9a6b12a31b7d9555fa5dcc16f78643cde4766838b6c2b2a60a8cL4), [link](https://github.com/dxos/dxos/pull/4835/files?diff=unified&w=0#diff-d1a24081d29d9a6b12a31b7d9555fa5dcc16f78643cde4766838b6c2b2a60a8cL20))


