### PR TITLE
chore: Better way to inject globals polyfills

### DIFF
--- a/packages/common/node-std/package.json
+++ b/packages/common/node-std/package.json
@@ -11,6 +11,7 @@
     "./crypto": "./dist/lib/browser/crypto.mjs",
     "./events": "./dist/lib/browser/events.mjs",
     "./globals": "./dist/lib/browser/globals.mjs",
+    "./inject-globals": "./dist/lib/browser/inject-globals.mjs",
     "./path": "./dist/lib/browser/path.mjs",
     "./stream": "./dist/lib/browser/stream.mjs",
     "./util": "./dist/lib/browser/util.mjs",

--- a/packages/common/node-std/project.json
+++ b/packages/common/node-std/project.json
@@ -44,6 +44,7 @@
           "packages/common/node-std/src/events.js",
           "packages/common/node-std/src/fs.js",
           "packages/common/node-std/src/globals.js",
+          "packages/common/node-std/src/inject-globals.js",
           "packages/common/node-std/src/path.js",
           "packages/common/node-std/src/stream.js",
           "packages/common/node-std/src/util.js"

--- a/packages/common/node-std/src/inject-globals.js
+++ b/packages/common/node-std/src/inject-globals.js
@@ -1,0 +1,14 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+// To be used with esbuild's inject option.
+
+import { Buffer } from 'buffer/';
+
+import { process } from './process';
+
+const global = globalThis;
+
+// Keep in sync with tools/executors/esbuild/src/main.ts
+export { global, Buffer, process };

--- a/packages/common/node-std/src/process.js
+++ b/packages/common/node-std/src/process.js
@@ -8,8 +8,6 @@
 // shim for using process in browser
 // based off https://github.com/defunctzombie/node-process/blob/master/browser.js
 
-globalThis.global = globalThis;
-
 /* eslint-disable */
 
 function nextTick (fun, ...args) {
@@ -94,7 +92,7 @@ function uptime () {
   return dif / 1000;
 }
 
-export var process = (globalThis.process ??= {
+export var process = {
   nextTick: nextTick,
   title: title,
   browser: browser,
@@ -118,7 +116,7 @@ export var process = (globalThis.process ??= {
   release: release,
   config: config,
   uptime: uptime,
-});
+};
 
 // replace process.env.VAR with define
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f2269e5</samp>

### Summary
🌐💉🧹

<!--
1.  🌐 - This emoji represents the global scope and the global variables that are injected by esbuild for the browser platform.
2.  💉 - This emoji represents the injection of global variables into the source code using the `inject` option of esbuild and the `@inject-globals` module.
3.  🧹 - This emoji represents the simplification and cleanup of the `process.js` file and the removal of redundant or erroneous code.
-->
This pull request refactors the `@dxos/node-std` package to use a more consistent and reliable way of injecting global variables for the browser platform. It introduces a new `@inject-globals` module and uses esbuild's inject option to replace the global references with imports. It also removes some unnecessary code from the `process.js` file.

> _Oh we're the crew of the node-std ship_
> _And we sail the web with skill and wit_
> _We inject the globals with `@inject-globals`_
> _And we bundle our code with esbuild_

### Walkthrough
*  Add a new entry point for the `@dxos/node-std` package that exports the global variables injected by esbuild ([link](https://github.com/dxos/dxos/pull/4836/files?diff=unified&w=0#diff-801e60efdb476f9a90e236ab98b9c033fa71e4cce24ddac568716d19f5df6567R14), [link](https://github.com/dxos/dxos/pull/4836/files?diff=unified&w=0#diff-23465bddeb6db0d95f2be21dbda2d2753bfcb195c7f8dbf9c98b06e1a1b718d9R47), [link](https://github.com/dxos/dxos/pull/4836/files?diff=unified&w=0#diff-4901291368af8b258f3e004f8e3406fd6db9d9d54080278c522deb6cf62ca819R1-R14))
*  Remove unnecessary or invalid assignments and operators from the `process.js` file of the `@dxos/node-std` package ([link](https://github.com/dxos/dxos/pull/4836/files?diff=unified&w=0#diff-12f2731fa609b1f1b53ab00b37210390658d8a8ff46a4249d94c378443f510a0L11-L12), [link](https://github.com/dxos/dxos/pull/4836/files?diff=unified&w=0#diff-12f2731fa609b1f1b53ab00b37210390658d8a8ff46a4249d94c378443f510a0L97-R95), [link](https://github.com/dxos/dxos/pull/4836/files?diff=unified&w=0#diff-12f2731fa609b1f1b53ab00b37210390658d8a8ff46a4249d94c378443f510a0L121-R119))
*  Use the `inject` option of esbuild to replace the references to the global variables with imports from the `@inject-globals` module ([link](https://github.com/dxos/dxos/pull/4836/files?diff=unified&w=0#diff-2e83c141910d129760ef80f9ddd052decd9ba61007062b42121b46b81e0179e2L84-R109))
*  Define the global variable names in a constant array and generate the contents of the `@inject-globals` module that re-exports them from the `@dxos/node-std/inject-globals` module ([link](https://github.com/dxos/dxos/pull/4836/files?diff=unified&w=0#diff-2e83c141910d129760ef80f9ddd052decd9ba61007062b42121b46b81e0179e2R32-R34), [link](https://github.com/dxos/dxos/pull/4836/files?diff=unified&w=0#diff-2e83c141910d129760ef80f9ddd052decd9ba61007062b42121b46b81e0179e2L78-R81))
*  Mark the `@dxos/node-std/inject-globals` module as external in the `node-external` plugin of the esbuild executor ([link](https://github.com/dxos/dxos/pull/4836/files?diff=unified&w=0#diff-2e83c141910d129760ef80f9ddd052decd9ba61007062b42121b46b81e0179e2L84-R109))


