### PR TITLE
perf: avoid unnecessary stacktrace capture

### DIFF
--- a/packages/common/async/src/chain.ts
+++ b/packages/common/async/src/chain.ts
@@ -10,7 +10,7 @@ type Transform = (...args: any) => Promise<any>;
 export const asyncChain =
   <T>(chain: Transform[]) =>
   async (elements: Promise<T[]>) => {
-    let result = await Promise.resolve(elements);
+    let result = await elements;
     for (const part of chain) {
       result = await Promise.all(result.map(async (element) => await part(element)));
     }

--- a/packages/common/async/src/task-scheduling.ts
+++ b/packages/common/async/src/task-scheduling.ts
@@ -67,10 +67,10 @@ export const scheduleMicroTask = (ctx: Context, fn: () => MaybePromise<void>) =>
 };
 
 export const scheduleTask = (ctx: Context, fn: () => MaybePromise<void>, afterMs?: number) => {
-  const clearTracking = trackResource({
+  const clearTracking = trackResource(() => ({
     name: `task (${fn.name || 'anonymous'})`,
     openStack: new StackTrace(),
-  });
+  }));
 
   const timeout = setTimeout(async () => {
     clearDispose();
@@ -88,10 +88,10 @@ export const scheduleTask = (ctx: Context, fn: () => MaybePromise<void>, afterMs
  * Run the task in the next event loop iteration, and then repeat in `interval` ms after the previous iteration completes.
  */
 export const scheduleTaskInterval = (ctx: Context, task: () => Promise<void>, interval: number) => {
-  const clearTracking = trackResource({
+  const clearTracking = trackResource(() => ({
     name: `repeating task (${task.name || 'anonymous'})`,
     openStack: new StackTrace(),
-  });
+  }));
 
   let timeoutId: NodeJS.Timeout;
 
@@ -115,10 +115,10 @@ export const scheduleExponentialBackoffTaskInterval = (
   task: () => Promise<void>,
   initialInterval: number,
 ) => {
-  const clearTracking = trackResource({
+  const clearTracking = trackResource(() => ({
     name: `repeating task (${task.name || 'anonymous'})`,
     openStack: new StackTrace(),
-  });
+  }));
 
   let timeoutId: NodeJS.Timeout;
 

--- a/packages/common/debug/src/stack-trace.ts
+++ b/packages/common/debug/src/stack-trace.ts
@@ -6,9 +6,10 @@
  * Allows to capture stack-traces.
  *
  * Will capture the stack trace at the point where the class is created.
- * Stack traces are captured lazily only when `getStack` is called.
+ * Stack traces are formatted lazily only when `getStack` is called.
  *
- * Stack traces are expesive to capture so only call getStack when you need them.
+ * Formatting is significantly more expensive than capture so only call
+ * getStack when you need them.
  */
 export class StackTrace {
   private _stack: Error;

--- a/packages/common/lock-file/src/lock-file.ts
+++ b/packages/common/lock-file/src/lock-file.ts
@@ -42,7 +42,6 @@ export class LockFile {
     try {
       const handle = await LockFile.acquire(filename);
       await LockFile.release(handle);
-      await handle.close();
 
       return false;
     } catch (e) {


### PR DESCRIPTION
Was checking which utilities the project has, noticed stack trace captures that can be avoided. 
Stack trace is captured when an error is created and formatted on the first access. 

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3599bb0</samp>

### Summary
🧹📝🔥

<!--
1.  🧹 for simplifying the code by removing an unnecessary `Promise.resolve` call.
2.  📝 for updating the documentation of the `StackTrace` class to reflect the eager capture and lazy format of the stack trace.
3.  🔥 for removing an unnecessary `close` call on the `handle` object, which is a file descriptor for the lock file.
-->
This pull request improves the `async` and `lock-file` modules of the `common` package. It refactors the task scheduling functions to use lazy evaluation of resources, adds a feature to track resource leaks, simplifies the chain function, updates the stack trace documentation, and removes a redundant close call.

> _This pull request has some nice changes_
> _It simplifies code and rearranges_
> _It tracks `OpenResource`_
> _And avoids some remorse_
> _By reporting the leaks it exchanges_

### Walkthrough
*  Simplify code by removing unnecessary `Promise.resolve` calls ([link](https://github.com/dxos/dxos/pull/4837/files?diff=unified&w=0#diff-5f2d69badc1d0a21bd37d44aa64ca79222a4aa09cc8ac2527648c5f761be3111L13-R13))
*  Modify `trackResource` and related functions to accept a function that returns an `OpenResource` object instead of an object directly, to defer the creation of the object until needed ([link](https://github.com/dxos/dxos/pull/4837/files?diff=unified&w=0#diff-419d338550d2cf3ae202487044e45acd83f2e79e640d2e9cf9c475ea80347ec1L70-R73), [link](https://github.com/dxos/dxos/pull/4837/files?diff=unified&w=0#diff-419d338550d2cf3ae202487044e45acd83f2e79e640d2e9cf9c475ea80347ec1L91-R94), [link](https://github.com/dxos/dxos/pull/4837/files?diff=unified&w=0#diff-419d338550d2cf3ae202487044e45acd83f2e79e640d2e9cf9c475ea80347ec1L118-R121), [link](https://github.com/dxos/dxos/pull/4837/files?diff=unified&w=0#diff-93f1e0a15ec09640318e3a3d7ac6dda2f6ca504d082ca89e7ab731a9e7de6623L18-R22), [link](https://github.com/dxos/dxos/pull/4837/files?diff=unified&w=0#diff-93f1e0a15ec09640318e3a3d7ac6dda2f6ca504d082ca89e7ab731a9e7de6623L55-R59))
*  Add `skipFrames` argument to `getStack` method of `StackTrace` class, to skip the first frame of the stack trace when dumping leaks ([link](https://github.com/dxos/dxos/pull/4837/files?diff=unified&w=0#diff-93f1e0a15ec09640318e3a3d7ac6dda2f6ca504d082ca89e7ab731a9e7de6623L83-R84))
*  Update documentation of `StackTrace` class to reflect eager capture and lazy format of stack trace ([link](https://github.com/dxos/dxos/pull/4837/files?diff=unified&w=0#diff-28b1c5e962424ed0d154b747e6ee9e2e049fa4996b64e0c8d60e05d2a711959cL9-R12))
*  Remove redundant `close` call on file descriptor for lock file in `lock-file.ts` ([link](https://github.com/dxos/dxos/pull/4837/files?diff=unified&w=0#diff-84818a62ffc94127fad615b52621ab59174fd2200db8ba36abc66b44e1a65c23L45))


