### PR TITLE
fix(automerge): Fix AutomergeDb memory leak

### DIFF
--- a/packages/sdk/client/src/echo/space-proxy.ts
+++ b/packages/sdk/client/src/echo/space-proxy.ts
@@ -329,6 +329,7 @@ export class SpaceProxy implements Space {
     log('destroying...');
     await this._ctx.dispose();
     await this._invitationsProxy.close();
+    await this._db.automerge.close();
     await this._dbBackend?.close();
     await this._itemManager?.destroy();
     log('destroyed');


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4dd298c</samp>

### Summary
🛠️🚀🗑️

<!--
1.  🛠️ - This emoji represents the addition of the `close` method to the `onDispose` handler, which is a fix or improvement to the existing code.
2.  🚀 - This emoji represents the addition of lifecycle management for `AutomergeDb` and `DocHandle`, which is a new feature or enhancement that improves the performance and reliability of the code.
3.  🗑️ - This emoji represents the support for deleting the instances when they are no longer needed, which is a cleanup or removal of unused or unnecessary code.
-->
Improved memory management and performance for `AutomergeDb` and `SpaceProxy` classes by using `Context` to handle their lifecycle. Added `close` methods to both classes and integrated them with the `onDispose` handler of `Context`.

> _We're sailing on the `SpaceProxy` ship, with `Context` as our guide_
> _We've got to close the `AutomergeDb` when we reach the other side_
> _So heave away, me hearties, heave away with all your might_
> _And don't forget the `DocHandle`, or we'll be in a plight_

### Walkthrough
*  Import `type DocHandleChangePayload` and `Context` class for managing `DocHandle` and `AutomergeDb` lifecycles ([link](https://github.com/dxos/dxos/pull/4871/files?diff=unified&w=0#diff-875834e4b70c12d82e4dedc39420f91a998d2d84b6b7b3551a6b6d90335bfa50L6-R7)).


