### PR TITLE
fix(react-ui-stack): fix navigate to item

### DIFF
--- a/packages/ui/react-ui-stack/src/components/Stack.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack.tsx
@@ -82,7 +82,7 @@ export const Stack = ({
             draggableProps={draggableProps}
             draggableStyle={draggableStyle}
             onRemove={() => onRemoveSection?.(path)}
-            onNavigate={() => onNavigateToSection?.(transformedItem.id)}
+            onNavigate={() => onNavigateToSection?.(transformedItem.object.id)}
           >
             <SectionContent data={transformedItem.object} />
           </Section>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c1ffd80</samp>

### Summary
🐛🛠️🚚

<!--
1.  🐛 - This emoji represents a bug fix, since the change fixes a navigation issue that was not working as expected.
2.  🛠️ - This emoji represents a tool or improvement, since the change improves the functionality of the `onNavigateToSection` prop and makes it more consistent with the expected data structure.
3.  🚚 - This emoji represents a move or rename, since the change moves the source of the `id` value from one field to another within the same object.
-->
Fixed navigation bug in `Stack` component. Changed `onNavigateToSection` prop to use the original item `id` from the `object` field of the `transformedItem`.

> _`onNavigateToSection`_
> _Changed to use `object.id`_
> _Spring bug is fixed now_

### Walkthrough
* Fix navigation bug for nested sections by using the original item id instead of the generated path id ([link](https://github.com/dxos/dxos/pull/4875/files?diff=unified&w=0#diff-6d9916d392111dfbbaea8bee0b2a071c011fadc36b624705046ddd06bb9f5a67L85-R85))



fixes #4839 