### PR TITLE
feat: Standardize plugin containers

### DIFF
--- a/packages/apps/plugins/plugin-outliner/src/components/Outliner/Outliner.tsx
+++ b/packages/apps/plugins/plugin-outliner/src/components/Outliner/Outliner.tsx
@@ -145,7 +145,7 @@ const OutlinerItem = ({
   };
 
   return (
-    <div className='flex px-2 group'>
+    <div className='flex group'>
       {(isTasklist && (
         <div className='py-1 mr-1'>
           <Input.Root>

--- a/packages/apps/plugins/plugin-outliner/src/components/OutlinerMain.tsx
+++ b/packages/apps/plugins/plugin-outliner/src/components/OutlinerMain.tsx
@@ -7,7 +7,14 @@ import React, { type FC } from 'react';
 import { Tree as TreeType } from '@braneframe/types';
 import { TextObject, getSpaceForObject } from '@dxos/react-client/echo';
 import { Main } from '@dxos/react-ui';
-import { baseSurface, topbarBlockPaddingStart, textBlockWidth, mx, inputSurface } from '@dxos/react-ui-theme';
+import {
+  baseSurface,
+  topbarBlockPaddingStart,
+  textBlockWidth,
+  mx,
+  surfaceElevation,
+  inputSurface,
+} from '@dxos/react-ui-theme';
 
 import { Outliner } from './Outliner';
 
@@ -20,9 +27,10 @@ export const OutlinerMain: FC<{ tree: TreeType }> = ({ tree }) => {
   return (
     // TODO(burdon): Factor out style (same for markdown, stack plugin).
     <Main.Content classNames={[baseSurface, topbarBlockPaddingStart]}>
-      <div role='none' className={mx(textBlockWidth, inputSurface, 'pli-2')}>
+      <div role='none' className={mx(textBlockWidth, 'pli-2')}>
         <div role='none' className={mx('plb-4 min-bs-[calc(100dvh-var(--topbar-size))] flex flex-col')}>
           <Outliner.Root
+            className={mx(inputSurface, surfaceElevation({ elevation: 'group' }), 'p-4')}
             isTasklist={tree.checkbox}
             root={tree.root}
             onCreate={(text?: string) => new TreeType.Item({ text: new TextObject(text) })}


### PR DESCRIPTION
https://github.com/dxos/dxos/assets/3523355/9672bd94-4a66-4bef-8a99-b13a8e46b70c

- [ ] "Page" plugins should share the same fragments.


<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 565cc62</samp>

### Summary
🎨🌟🔧

<!--
1.  🎨 - This emoji is often used for changes related to UI design, styling, or aesthetics. Adding elevation and border styles to the outliner component falls under this category, as it enhances the appearance and usability of the UI.
2.  🌟 - This emoji is sometimes used for changes that introduce new features, enhancements, or improvements. Adding elevation and border styles to the outliner component could be considered an improvement, as it makes the outliner more noticeable and distinct from the rest of the app layout.
3.  🔧 - This emoji is commonly used for changes that involve configuration, settings, or tools. Adding elevation and border styles to the outliner component could be seen as a configuration change, as it uses utilities from the `surfaceElevation` and `inputSurface` modules to apply the styles.
-->
Improved outliner component appearance with elevation and border styles. Used `surfaceElevation` and `inputSurface` utilities from `@dxos/theme` to apply consistent and responsive styles to `OutlinerMain.tsx`.

> _Sing, O Muse, of the skillful coder who enhanced the outliner_
> _With `surfaceElevation` and `inputSurface`, tools of the crafty Hephaestus_
> _He gave it border and depth, like the shield of the mighty Achilles_
> _That shone brightly among the warriors and dazzled the eyes of the Trojans_

### Walkthrough
* Import and apply elevation styles to outliner component ([link](https://github.com/dxos/dxos/pull/4876/files?diff=unified&w=0#diff-e95d4213c28048cd286d2bac39438b979d1c96fca3e7c4c67db8258fd9b4790bL10-R17), [link](https://github.com/dxos/dxos/pull/4876/files?diff=unified&w=0#diff-e95d4213c28048cd286d2bac39438b979d1c96fca3e7c4c67db8258fd9b4790bL23-R33))


