### PR TITLE
feat(automerge): Add automerge text support in ECHO

### DIFF
--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -15,7 +15,7 @@ import { AutomergeArray } from './automerge-array';
 import { type AutomergeDb } from './automerge-db';
 import { type DocStructure, type ObjectSystem } from './types';
 import { type EchoDatabase } from '../database';
-import { mutationOverride, type TypedObjectOptions } from '../object';
+import { TextObject, mutationOverride, type TypedObjectOptions } from '../object';
 import { AbstractEchoObject } from '../object/object';
 import {
   type EchoObject,
@@ -283,6 +283,11 @@ export class AutomergeObject implements TypedObjectProperties {
    * @internal
    */
   _set(path: string[], value: any) {
+    // TODO(mykola): Remove this once TextObject is removed.
+    if (value instanceof TextObject) {
+      throw new Error('TextObject is not supported');
+    }
+
     const fullPath = [...this._path, ...path];
 
     const changeFn: ChangeFn<any> = (doc) => {

--- a/packages/core/echo/echo-schema/src/object/text-object.ts
+++ b/packages/core/echo/echo-schema/src/object/text-object.ts
@@ -8,6 +8,9 @@ import { TextModel, type YText, type YXmlFragment, type Doc } from '@dxos/text-m
 
 import { AbstractEchoObject } from './object';
 
+/**
+ * @deprecated Will be deleted as ECHO transition to automerge CRDTs will be completed.
+ */
 export class TextObject extends AbstractEchoObject<TextModel> {
   // TODO(mykola): Add immutable option.
   constructor(text?: string, kind?: TextKind, field?: string) {

--- a/packages/core/echo/echo-typegen/src/codegen.ts
+++ b/packages/core/echo/echo-typegen/src/codegen.ts
@@ -42,6 +42,10 @@ export function* iterTypes(ns: pb.NamespaceBase): IterableIterator<pb.Type> {
 export const createType = (field: pb.Field): string => {
   const scalar = () => {
     if (field.resolvedType) {
+      // TODO(mykola): Remove once TextObject is removed. Automerge implementation uses `string` and YJs uses `TextObject`.
+      if (field.resolvedType.fullName === '.dxos.schema.Text') {
+        return `${importNamespace}.${field.resolvedType.name} | string`;
+      }
       if (injectedTypes.includes(field.resolvedType.fullName)) {
         return `${importNamespace}.${field.resolvedType.name}`;
       }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 944c05f</samp>

### Summary
:warning::wrench::arrows_counterclockwise:

<!--
1.  :warning: for marking the `TextObject` class as deprecated with a comment.
2.  :wrench: for adding a special case for the `.dxos.schema.Text` type in the code generator function.
3.  :arrows_counterclockwise: for enforcing the use of Automerge `Text` type in the `AutomergeObject` class.
-->
The pull request updates the ECHO schema code to support Automerge as the CRDT library instead of Yjs. It modifies the `AutomergeObject` class, deprecates the `TextObject` class, and adjusts the code generator to handle the `.dxos.schema.Text` type.

> _We're sailing away from Yjs to Automerge_
> _We're marking `TextObject` as deprecated_
> _We're changing the types in the code generator_
> _We're heaving away on the count of three_

### Walkthrough
*  Throw error if `TextObject` is used with `AutomergeObject` ([link](https://github.com/dxos/dxos/pull/4877/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48L17-R17), [link](https://github.com/dxos/dxos/pull/4877/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48R270-R274))
  - Import `TextObject` from `../object` module in `automerge-object.ts` ([link](https://github.com/dxos/dxos/pull/4877/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48L17-R17))
  - Add condition to `setValue` method in `AutomergeObject` class to check if value is `TextObject` and throw error ([link](https://github.com/dxos/dxos/pull/4877/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48R270-R274))
* Mark `TextObject` as deprecated in `text-object.ts` ([link](https://github.com/dxos/dxos/pull/4877/files?diff=unified&w=0#diff-cb02d960130d98c4aeb32386c5603e3964aab969002a3c0df9e17ce1fa802d3eR11-R13))
  - Add comment to `TextObject` class to indicate that it will be removed once the transition is completed and to discourage its use in new code ([link](https://github.com/dxos/dxos/pull/4877/files?diff=unified&w=0#diff-cb02d960130d98c4aeb32386c5603e3964aab969002a3c0df9e17ce1fa802d3eR11-R13))
* Allow union type of `TextObject | string` for `.dxos.schema.Text` in code generator ([link](https://github.com/dxos/dxos/pull/4877/files?diff=unified&w=0#diff-7e79d5937010f09f3619776bd506b065a31aa0f03d3dc498d103cf1bc1a2bd6bR45-R48))
  - Add special case for `.dxos.schema.Text` type in `createType` function in `codegen.ts` ([link](https://github.com/dxos/dxos/pull/4877/files?diff=unified&w=0#diff-7e79d5937010f09f3619776bd506b065a31aa0f03d3dc498d103cf1bc1a2bd6bR45-R48))


