### PR TITLE
fix(automerge): Make automerge ECHO Schemas immutable

### DIFF
--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
@@ -173,7 +173,8 @@ export class AutomergeDb {
     invariant(this._docHandle);
     for (const id of objectIds) {
       invariant(!this._objects.has(id));
-      const obj = new AutomergeObject({ id });
+      const obj = new AutomergeObject();
+      obj[base]._id = id;
       this._objects.set(obj.id, obj);
       (obj[base] as AutomergeObject)._bind({
         db: this,

--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -8,13 +8,14 @@ import { type DocHandleChangePayload, type DocHandle } from '@dxos/automerge/aut
 import { Reference } from '@dxos/document-model';
 import { failedInvariant, invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
+import { log } from '@dxos/log';
 import { TextModel } from '@dxos/text-model';
 
 import { AutomergeArray } from './automerge-array';
 import { type AutomergeDb } from './automerge-db';
 import { type DocStructure, type ObjectSystem } from './types';
 import { type EchoDatabase } from '../database';
-import { type TypedObjectOptions } from '../object';
+import { mutationOverride, type TypedObjectOptions } from '../object';
 import { AbstractEchoObject } from '../object/object';
 import {
   type EchoObject,
@@ -42,6 +43,7 @@ export class AutomergeObject implements TypedObjectProperties {
   private _doc?: Doc<any> = undefined;
   private _docHandle?: DocHandle<DocStructure> = undefined;
   private _schema?: Schema = undefined;
+  private readonly _immutable: boolean;
 
   /**
    * @internal
@@ -81,6 +83,7 @@ export class AutomergeObject implements TypedObjectProperties {
     if (type) {
       this.__system.type = type;
     }
+    this._immutable = opts?.immutable ?? false;
 
     return this._createProxy(['data']);
   }
@@ -134,6 +137,10 @@ export class AutomergeObject implements TypedObjectProperties {
 
   get [debug](): string {
     return 'automerge';
+  }
+
+  get [immutable](): boolean {
+    return !!this[base]?._immutable;
   }
 
   [subscribe](callback: (value: AutomergeObject) => void): () => void {
@@ -248,6 +255,10 @@ export class AutomergeObject implements TypedObjectProperties {
       },
 
       set: (_, key, value) => {
+        if (this[base]._immutable && !mutationOverride) {
+          log.warn('Read only access');
+          return false;
+        }
         this._set([...path, key as string], value);
         return true;
       },

--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -62,10 +62,9 @@ export class AutomergeObject implements TypedObjectProperties {
   /**
    * @internal
    */
-  _id: string;
+  _id = PublicKey.random().toHex();
 
-  constructor(initialProps?: Record<string, any>, opts?: TypedObjectOptions) {
-    this._id = initialProps?.id ?? PublicKey.random().toHex();
+  constructor(initialProps?: unknown, opts?: TypedObjectOptions) {
     this._initNewObject(initialProps, opts);
 
     if (opts?.schema) {

--- a/packages/core/echo/echo-schema/src/object/typed-object.ts
+++ b/packages/core/echo/echo-schema/src/object/typed-object.ts
@@ -622,7 +622,7 @@ export const Expando: ExpandoConstructor = TypedObject;
 
 export type Expando = TypedObject;
 
-let mutationOverride = false;
+export let mutationOverride = false;
 
 // TODO(burdon): Document.
 export const dangerouslyMutateImmutableObject = (cb: () => void) => {

--- a/packages/core/echo/echo-schema/src/object/typed-object.ts
+++ b/packages/core/echo/echo-schema/src/object/typed-object.ts
@@ -102,7 +102,7 @@ class TypedObjectImpl<T> extends AbstractEchoObject<DocumentModel> implements Ty
     super(DocumentModel);
 
     if (opts?.useAutomergeBackend ?? getGlobalAutomergePreference()) {
-      return new AutomergeObject(initialProps as Record<string, any>, opts) as any;
+      return new AutomergeObject(initialProps, opts) as any;
     }
 
     invariant(!(opts?.schema && opts?.type), 'Cannot specify both schema and type.');


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5ae8c95</samp>

### Summary
🔧🛡️🎛️

<!--
1.  🔧 - This emoji represents a tool or a fix, and can be used for the first change, which modifies the constructor of the `AutomergeObject` class to avoid a conflict with the Automerge library.
2. 🛡️ - This emoji represents a shield or protection, and can be used for the second change, which adds immutability support to the `AutomergeObject` class and prevents potential conflicts with the `id` property.
3. 🎛️ - This emoji represents a knob or a control, and can be used for the third change, which improves the type handling and flexibility of the `TypedObjectImpl` class and the `AutomergeObject` constructor, and exposes the `mutationOverride` variable.
-->
This pull request enhances the `AutomergeObject` class and its related classes in the `echo-schema` package. It adds immutability, type handling, logging, and conflict resolution features. It also fixes some bugs and improves the testability of the code.

> _Oh we're the coders of the `AutomergeObject` class_
> _We wrap and type and log and make it immutable_
> _We don't mess with the `id` property of Automerge_
> _We heave away and pull the code on the count of three_

### Walkthrough
*  Prevent conflicts with Automerge library by using getter/setter for `id` property on `AutomergeObject` class ([link](https://github.com/dxos/dxos/pull/4887/files?diff=unified&w=0#diff-875834e4b70c12d82e4dedc39420f91a998d2d84b6b7b3551a6b6d90335bfa50L176-R177), [link](https://github.com/dxos/dxos/pull/4887/files?diff=unified&w=0#diff-3515b2ff773cf8bd489c72171f771f97e2f2a47b3c6b2656e485c0c8db3c5b48L63-R67)).


