### PR TITLE
chore(react-ui-stack): fix storybook build

### DIFF
--- a/packages/ui/react-ui-stack/.storybook/main.cjs
+++ b/packages/ui/react-ui-stack/.storybook/main.cjs
@@ -19,6 +19,10 @@ module.exports = {
     options: {}
   },
   viteFinal: async (config) => mergeConfig(config, {
+    build: {
+      // NOTE: Browsers which support top-level await.
+      target: ['es2022', 'edge89', 'firefox89', 'chrome89', 'safari15']
+    },
     plugins: [
       ThemePlugin({
         root: __dirname,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 587e64f</samp>

### Summary
🚀🎨🆕

<!--
1.  🚀 - This emoji conveys the idea of launching or upgrading something, which fits the theme of updating the UI stack to use Vite and React 18, a modern and fast toolchain for web development.
2.  🎨 - This emoji conveys the idea of creativity or design, which fits the theme of using Storybook, a tool for developing and showcasing UI components.
3.  🆕 - This emoji conveys the idea of something new or fresh, which fits the theme of using top-level await syntax, a new feature of JavaScript that allows writing asynchronous code more easily.
-->
This change updates the Storybook configuration to enable top-level await syntax in the stories. It sets the target browsers for the Vite output to those that support ES modules.

> _`viteFinal` builds_
> _for browsers that await_
> _autumn of React_

### Walkthrough
* Enable top-level await syntax in stories by setting target browsers for Vite output ([link](https://github.com/dxos/dxos/pull/4893/files?diff=unified&w=0#diff-29e983678ce52f95a068c4db654cca815e3eb419d7f81141cfb14dc129a39727R22-R25))


