### PR TITLE
fix(automerge): Gracefully close automerge client-services connection

### DIFF
--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
@@ -46,6 +46,10 @@ export class AutomergeHost {
     return this._repo;
   }
 
+  async close() {
+    await this._clientNetwork.close();
+  }
+
   //
   // Methods for client-services.
   //
@@ -97,8 +101,14 @@ class LocalHostNetworkAdapter extends NetworkAdapter {
     peer.send(message);
   }
 
-  override disconnect(): void {
+  async close() {
     this._peers.forEach((peer) => peer.disconnect());
+    this.emit('close');
+  }
+
+  override disconnect(): void {
+    // TODO(mykola): `disconnect` is not used anywhere in `Repo` from `@automerge/automerge-repo`. Should we remove it?
+    // No-op
   }
 
   syncRepo({ id, syncMessage }: SyncRepoRequest): Stream<SyncRepoResponse> {

--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
@@ -67,8 +67,8 @@ export class AutomergeDb {
     if (spaceState.rootUrl) {
       try {
         this._docHandle = this.automerge.repo.find(spaceState.rootUrl as DocumentId);
-        await asyncTimeout(this._docHandle.whenReady(), 500);
-        const ojectIds = Object.keys((await this._docHandle.doc()).objects ?? {});
+        const doc = await asyncTimeout(this._docHandle.doc(), 500);
+        const ojectIds = Object.keys(doc.objects ?? {});
         this._createObjects(ojectIds);
       } catch (err) {
         log('Error opening document', err);

--- a/packages/sdk/client-services/src/packlets/services/automerge-host.test.ts
+++ b/packages/sdk/client-services/src/packlets/services/automerge-host.test.ts
@@ -8,7 +8,7 @@ import { asyncTimeout, sleep } from '@dxos/async';
 import { AutomergeHost, DataServiceImpl, type DataServiceSubscriptions } from '@dxos/echo-pipeline';
 import { AutomergeContext } from '@dxos/echo-schema';
 import { StorageType, createStorage } from '@dxos/random-access-storage';
-import { describe, test } from '@dxos/test';
+import { afterTest, describe, test } from '@dxos/test';
 
 describe('AutomergeHost', () => {
   test('automerge context is being synced with host', async () => {
@@ -22,11 +22,13 @@ describe('AutomergeHost', () => {
     const storageDirectory = createStorage({ type: StorageType.RAM }).createDirectory();
 
     const host = new AutomergeHost(storageDirectory);
+    afterTest(() => host.close());
     const dataService = new DataServiceImpl(
       {} as DataServiceSubscriptions, // is not used in this test, just required argument
       host,
     );
     const client = new AutomergeContext(dataService);
+    afterTest(() => client.close());
 
     // Create document in repo.
     const handle = host.repo.create();

--- a/packages/sdk/client-services/src/packlets/services/service-context.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-context.ts
@@ -150,6 +150,7 @@ export class ServiceContext {
     if (this._deviceSpaceSync && this.identityManager.identity) {
       await this.identityManager.identity.space.spaceState.removeCredentialProcessor(this._deviceSpaceSync);
     }
+    await this.automergeHost.close();
     await this.dataSpaceManager?.close();
     await this.identityManager.close();
     await this.spaceManager.close();

--- a/packages/sdk/client/src/echo/space-list.ts
+++ b/packages/sdk/client/src/echo/space-list.ts
@@ -171,9 +171,9 @@ export class SpaceList extends MulticastObservable<Space[]> implements Echo {
    */
   async _close() {
     await this._ctx.dispose();
+    await this._automergeContext.close();
     await Promise.all(this.get().map((space) => (space as SpaceProxy)._destroy()));
     this._spacesStream.next([]);
-
     await this._invitationProxy?.close();
     this._invitationProxy = undefined;
   }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e821464</samp>

### Summary
🛠️🔄🧪

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate the refactoring and bug prevention aspects of the changes.
2.  🔄 - This emoji represents a cycle or a refresh, and can be used to indicate the consistency and graceful shutdown aspects of the changes.
3.  🧪 - This emoji represents a test or an experiment, and can be used to indicate the test improvement and reliability aspects of the changes.
-->
This pull request refactors the `AutomergeHost`, `AutomergeContext`, and related classes to support closing the network connections to the data service. It also updates the usage of the `Repo` class from `@automerge/automerge-repo` to avoid deprecated and buggy methods. It also improves the test and disposal logic for the `AutomergeHost` and `AutomergeContext` instances.

> _We're closing down the `AutomergeHost` and the `AutomergeContext`_
> _We're heaving on the ropes to raise the sail_
> _We're using the latest `Repo` API and avoiding bugs_
> _We're sailing on the seas of refactoring_

### Walkthrough
*  Add `close` methods to `AutomergeHost` and `AutomergeContext` classes to allow graceful shutdown of the network connections to the data service ([link](https://github.com/dxos/dxos/pull/4903/files?diff=unified&w=0#diff-52ff990be4c1a08ccf1789a3650692c2275445181a78327d5bf2505ac88d45eaR49-R52), [link](https://github.com/dxos/dxos/pull/4903/files?diff=unified&w=0#diff-71c1cb883af8b4baf88a0142a8750b1b9e81dbe9cf3d2e473b2dcac00ba99cffL17-R27), [link](https://github.com/dxos/dxos/pull/4903/files?diff=unified&w=0#diff-71c1cb883af8b4baf88a0142a8750b1b9e81dbe9cf3d2e473b2dcac00ba99cffR34-R37), [link](https://github.com/dxos/dxos/pull/4903/files?diff=unified&w=0#diff-32609ec40439f8092b97c3e3d20956a8e6651e0c6f70c9989fef4ec774e26f3bR153), [link](https://github.com/dxos/dxos/pull/4903/files?diff=unified&w=0#diff-18f34ae1ad7d375d13ba9d6b2db002a822cdabcfdb1128360d89ad75eb2fd3e5L174-R176)).


