### PR TITLE
feat(automerge): Automerge/MESH integration

### DIFF
--- a/packages/core/agent/project.json
+++ b/packages/core/agent/project.json
@@ -20,11 +20,11 @@
     "lint": {},
     "test": {
       "options": {
-        "forceExit": true,
         "checkLeaks": false,
         "ciEnvironments": [
           "nodejs"
-        ]
+        ],
+        "forceExit": true
       }
     }
   },

--- a/packages/core/agent/project.json
+++ b/packages/core/agent/project.json
@@ -20,6 +20,7 @@
     "lint": {},
     "test": {
       "options": {
+        "forceExit": true,
         "checkLeaks": false,
         "ciEnvironments": [
           "nodejs"

--- a/packages/core/agent/src/plugins/query/plugin.test.ts
+++ b/packages/core/agent/src/plugins/query/plugin.test.ts
@@ -165,7 +165,7 @@ describe('QueryPlugin', () => {
 
       {
         // Wait for client to be ready.
-        await asyncTimeout(client.spaces.isReady.wait(), 1000);
+        await asyncTimeout(client.spaces.isReady.wait(), 2000);
         await asyncTimeout(client.spaces.default.waitUntilReady(), 1000);
       }
     });

--- a/packages/core/echo/echo-pipeline/package.json
+++ b/packages/core/echo/echo-pipeline/package.json
@@ -58,6 +58,7 @@
     "@dxos/random-access-storage": "workspace:*",
     "@dxos/rpc": "workspace:*",
     "@dxos/teleport": "workspace:*",
+    "@dxos/teleport-extension-automerge-replicator": "workspace:*",
     "@dxos/teleport-extension-gossip": "workspace:*",
     "@dxos/teleport-extension-object-sync": "workspace:*",
     "@dxos/teleport-extension-replicator": "workspace:*",

--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
@@ -188,9 +188,7 @@ class MeshNetworkAdapter extends NetworkAdapter {
     const receiverId = message.targetId;
     const extension = this._extensions.get(receiverId);
     invariant(extension, 'Extension not found.');
-    extension
-      .sendSyncMessage({ id: message.senderId, syncMessage: cbor.encode(message) })
-      .catch((err) => log.catch(err));
+    extension.sendSyncMessage({ payload: cbor.encode(message) }).catch((err) => log.catch(err));
   }
 
   override disconnect(): void {
@@ -214,13 +212,8 @@ class MeshNetworkAdapter extends NetworkAdapter {
             peerId: info.id as PeerId,
           });
         },
-        onStopReplication: async (info) => {
-          this.emit('peer-disconnected', {
-            peerId: info.id as PeerId,
-          });
-        },
-        onSyncMessage: async ({ syncMessage }) => {
-          const message = cbor.decode(syncMessage) as Message;
+        onSyncMessage: async ({ payload }) => {
+          const message = cbor.decode(payload) as Message;
           this.emit('message', message);
         },
         onClose: async () => {

--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
@@ -14,8 +14,11 @@ import {
 } from '@dxos/automerge/automerge-repo';
 import { Stream } from '@dxos/codec-protobuf';
 import { invariant } from '@dxos/invariant';
+import { log } from '@dxos/log';
 import { type HostInfo, type SyncRepoRequest, type SyncRepoResponse } from '@dxos/protocols/proto/dxos/echo/service';
+import { type PeerInfo } from '@dxos/protocols/proto/dxos/mesh/teleport/automerge';
 import { type Directory } from '@dxos/random-access-storage';
+import { AutomergeReplicator } from '@dxos/teleport-extension-automerge-replicator';
 import { arrayToBuffer, bufferToArray } from '@dxos/util';
 
 export class AutomergeHost {
@@ -29,17 +32,14 @@ export class AutomergeHost {
     this._clientNetwork = new LocalHostNetworkAdapter();
     this._storage = new AutomergeStorageAdapter(storageDirectory);
     this._repo = new Repo({
-      network: [
-        // this._meshNetwork,
-        this._clientNetwork,
-      ],
-
+      network: [this._clientNetwork, this._meshNetwork],
       storage: this._storage,
 
       // TODO(dmaretskyi): Share based on HALO permissions and space affinity.
       sharePolicy: async (peerId, documentId) => true, // Share everything.
     });
     this._clientNetwork.ready();
+    this._meshNetwork.ready();
   }
 
   get repo(): Repo {
@@ -64,6 +64,14 @@ export class AutomergeHost {
 
   getHostInfo(): HostInfo {
     return this._clientNetwork.getHostInfo();
+  }
+
+  //
+  // Mesh replication.
+  //
+
+  createExtension(): AutomergeReplicator {
+    return this._meshNetwork.createExtension();
   }
 }
 
@@ -159,16 +167,71 @@ class LocalHostNetworkAdapter extends NetworkAdapter {
  * Used to replicate with other peers over the network.
  */
 class MeshNetworkAdapter extends NetworkAdapter {
+  private readonly _extensions: Map<string, AutomergeReplicator> = new Map();
+
+  /**
+   * Emits `ready` event. That signals to `Repo` that it can start using the adapter.
+   */
+  ready() {
+    // NOTE: Emitting `ready` event in NetworkAdapter`s constructor causes a race condition
+    //       because `Repo` waits for `ready` event (which it never receives) before it starts using the adapter.
+    this.emit('ready', {
+      network: this,
+    });
+  }
+
   override connect(peerId: PeerId): void {
-    throw new Error('Method not implemented.');
+    this.peerId = peerId;
   }
 
   override send(message: Message): void {
-    throw new Error('Method not implemented.');
+    const receiverId = message.targetId;
+    const extension = this._extensions.get(receiverId);
+    invariant(extension, 'Extension not found.');
+    extension
+      .sendSyncMessage({ id: message.senderId, syncMessage: cbor.encode(message) })
+      .catch((err) => log.catch(err));
   }
 
   override disconnect(): void {
-    throw new Error('Method not implemented.');
+    // No-op
+  }
+
+  createExtension(): AutomergeReplicator {
+    invariant(this.peerId, 'Peer id not set.');
+
+    let peerInfo: PeerInfo;
+    const extension = new AutomergeReplicator(
+      {
+        peerId: this.peerId,
+      },
+      {
+        onStartReplication: async (info) => {
+          peerInfo = info;
+          // TODO(mykola): Fix race condition?
+          this._extensions.set(info.id, extension);
+          this.emit('peer-candidate', {
+            peerId: info.id as PeerId,
+          });
+        },
+        onStopReplication: async (info) => {
+          this.emit('peer-disconnected', {
+            peerId: info.id as PeerId,
+          });
+        },
+        onSyncMessage: async ({ syncMessage }) => {
+          const message = cbor.decode(syncMessage) as Message;
+          this.emit('message', message);
+        },
+        onClose: async () => {
+          peerInfo &&
+            this.emit('peer-disconnected', {
+              peerId: peerInfo.id as PeerId,
+            });
+        },
+      },
+    );
+    return extension;
   }
 }
 

--- a/packages/core/echo/echo-pipeline/src/space/space-manager.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space-manager.ts
@@ -39,6 +39,9 @@ export type ConstructSpaceParams = {
   metadata: SpaceMetadata;
   swarmIdentity: SwarmIdentity;
   memberKey: PublicKey;
+  /**
+   * Called when connection auth passed successful.
+   */
   onNetworkConnection: (session: Teleport) => void;
   onAuthFailure?: (session: Teleport) => void;
 };

--- a/packages/core/echo/echo-pipeline/tsconfig.json
+++ b/packages/core/echo/echo-pipeline/tsconfig.json
@@ -79,6 +79,9 @@
       "path": "../../mesh/teleport"
     },
     {
+      "path": "../../mesh/teleport-extension-automerge-replicator"
+    },
+    {
       "path": "../../mesh/teleport-extension-gossip"
     },
     {

--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
@@ -67,7 +67,7 @@ export class AutomergeDb {
     if (spaceState.rootUrl) {
       try {
         this._docHandle = this.automerge.repo.find(spaceState.rootUrl as DocumentId);
-        const doc = await asyncTimeout(this._docHandle.doc(), 10_000);
+        const doc = await asyncTimeout(this._docHandle.doc(), 1_000);
         const ojectIds = Object.keys(doc.objects ?? {});
         this._createObjects(ojectIds);
       } catch (err) {

--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -317,6 +317,7 @@ export class AutomergeObject implements TypedObjectProperties {
   _change(changeFn: ChangeFn<any>) {
     if (this._docHandle) {
       this._docHandle.change(changeFn);
+      // Note: We don't need to notify listeners here, since `change` event is already emitted by the doc handle.
     } else if (this._doc) {
       this._doc = automerge.change(this._doc, changeFn);
       this._notifyUpdate();
@@ -472,11 +473,12 @@ export class AutomergeObject implements TypedObjectProperties {
             } else {
               this._doc = automerge.change(this._doc!, callback);
             }
+            this._notifyUpdate();
           } else {
             invariant(this._docHandle);
             this._docHandle.change(callback, options);
+            // Note: We don't need to notify listeners here, since `change` event is already emitted by the doc handle.
           }
-          this._notifyUpdate();
         },
         changeAt: (heads, callback, options) => {
           let result: Heads | undefined;
@@ -485,16 +487,16 @@ export class AutomergeObject implements TypedObjectProperties {
               const { newDoc, newHeads } = automerge.changeAt(this._doc!, heads, options, callback);
               this._doc = newDoc;
               result = newHeads ?? undefined;
-              this._notifyUpdate();
             } else {
               const { newDoc, newHeads } = automerge.changeAt(this._doc!, heads, callback);
               this._doc = newDoc;
               result = newHeads ?? undefined;
-              this._notifyUpdate();
             }
+            this._notifyUpdate();
           } else {
             invariant(this._docHandle);
             result = this._docHandle.changeAt(heads, callback, options);
+            // Note: We don't need to notify listeners here, since `change` event is already emitted by the doc handle.
           }
 
           return result;

--- a/packages/core/mesh/teleport-extension-automerge-replicator/.eslintrc.js
+++ b/packages/core/mesh/teleport-extension-automerge-replicator/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  "extends": [
+    "../../../../.eslintrc.js"
+  ],
+  "parserOptions": {
+    "project": "tsconfig.json",
+    "tsconfigRootDir": __dirname,
+  }
+}

--- a/packages/core/mesh/teleport-extension-automerge-replicator/LICENSE
+++ b/packages/core/mesh/teleport-extension-automerge-replicator/LICENSE
@@ -1,0 +1,8 @@
+MIT License 
+Copyright (c) 2023 DXOS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/core/mesh/teleport-extension-automerge-replicator/package.json
+++ b/packages/core/mesh/teleport-extension-automerge-replicator/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@dxos/teleport-extension-automerge-replicator",
+  "version": "0.3.8",
+  "description": "",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "license": "MIT",
+  "author": "DXOS.org",
+  "main": "dist/lib/node/index.cjs",
+  "browser": {
+    "./dist/lib/node/index.cjs": "./dist/lib/browser/index.mjs"
+  },
+  "types": "src/index.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "check": "true"
+  },
+  "dependencies": {
+    "@dxos/async": "workspace:*",
+    "@dxos/codec-protobuf": "workspace:*",
+    "@dxos/context": "workspace:*",
+    "@dxos/invariant": "workspace:*",
+    "@dxos/keys": "workspace:*",
+    "@dxos/log": "workspace:*",
+    "@dxos/node-std": "workspace:*",
+    "@dxos/protocols": "workspace:*",
+    "@dxos/rpc": "workspace:*",
+    "@dxos/teleport": "workspace:*",
+    "@dxos/util": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  },
+  "publishConfig": {
+    "access": "public",
+    "types": "dist/types/src/index.d.ts"
+  }
+}

--- a/packages/core/mesh/teleport-extension-automerge-replicator/project.json
+++ b/packages/core/mesh/teleport-extension-automerge-replicator/project.json
@@ -1,0 +1,30 @@
+{
+  "sourceRoot": "packages/core/mesh/teleport-extension-automerge-replicator/src",
+  "projectType": "library",
+  "targets": {
+    "build": {},
+    "compile": {
+      "options": {
+        "entryPoints": [
+          "packages/core/mesh/teleport-extension-automerge-replicator/src/index.ts"
+        ],
+        "platforms": [
+          "browser",
+          "node"
+        ]
+      }
+    },
+    "lint": {},
+    "test": {
+      "options": {
+        "ciEnvironments": [
+          "nodejs"
+        ]
+      }
+    }
+  },
+  "implicitDependencies": [
+    "esbuild",
+    "test"
+  ]
+}

--- a/packages/core/mesh/teleport-extension-automerge-replicator/src/automerge-replicator.test.ts
+++ b/packages/core/mesh/teleport-extension-automerge-replicator/src/automerge-replicator.test.ts
@@ -1,0 +1,46 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+import expect from 'expect';
+
+import { Trigger } from '@dxos/async';
+import { type PeerInfo } from '@dxos/protocols/proto//dxos/mesh/teleport/automerge';
+import { TestBuilder, TestPeer } from '@dxos/teleport/testing';
+import { afterTest, describe, test } from '@dxos/test';
+
+import { AutomergeReplicator } from './automerge-replicator';
+
+describe('AutomergeReplicator', () => {
+  test('Two peers discover each other', async () => {
+    const builder = new TestBuilder();
+    afterTest(() => builder.destroy());
+    const [peer1, peer2] = builder.createPeers({ factory: () => new TestPeer() });
+    const [connection1, connection2] = await builder.connect(peer1, peer2);
+
+    const trigger1 = new Trigger<PeerInfo>();
+    const extension1 = new AutomergeReplicator(
+      { peerId: peer1.peerId.toHex() },
+      {
+        onStartReplication: async (info) => {
+          trigger1.wake(info);
+        },
+      },
+    );
+    connection1.teleport.addExtension('dxos.mesh.teleport.automerge', extension1);
+
+    const trigger2 = new Trigger<PeerInfo>();
+    const extension2 = new AutomergeReplicator(
+      { peerId: peer2.peerId.toHex() },
+      {
+        onStartReplication: async (info) => {
+          trigger2.wake(info);
+        },
+      },
+    );
+    connection2.teleport.addExtension('dxos.mesh.teleport.automerge', extension2);
+
+    expect((await trigger1.wait({ timeout: 50 })).id).toEqual(peer2.peerId.toHex());
+    expect((await trigger2.wait({ timeout: 50 })).id).toEqual(peer1.peerId.toHex());
+  });
+});

--- a/packages/core/mesh/teleport-extension-automerge-replicator/src/automerge-replicator.ts
+++ b/packages/core/mesh/teleport-extension-automerge-replicator/src/automerge-replicator.ts
@@ -114,6 +114,10 @@ export class AutomergeReplicator implements TeleportExtension {
     invariant(this._rpc, 'RPC not initialized');
     await this._rpc.rpc.AutomergeReplicatorService.sendSyncMessage(message);
   }
+
+  async disconnect() {
+    await this._rpc?.rpc.AutomergeReplicatorService.stopReplication({ id: this._params.peerId });
+  }
 }
 
 type ServiceBundle = {

--- a/packages/core/mesh/teleport-extension-automerge-replicator/src/automerge-replicator.ts
+++ b/packages/core/mesh/teleport-extension-automerge-replicator/src/automerge-replicator.ts
@@ -2,6 +2,120 @@
 // Copyright 2023 DXOS.org
 //
 
-import { type TeleportExtension } from '@dxos/teleport';
+import { Trigger } from '@dxos/async';
+import { invariant } from '@dxos/invariant';
+import { log } from '@dxos/log';
+import { schema } from '@dxos/protocols';
+import {
+  type PeerInfo,
+  type AutomergeReplicatorService,
+  type SyncMessage,
+} from '@dxos/protocols/proto/dxos/mesh/teleport/automerge';
+import { createProtoRpcPeer, type ProtoRpcPeer } from '@dxos/rpc';
+import { type ExtensionContext, type TeleportExtension } from '@dxos/teleport';
 
-export class AutomergeReplicator implements TeleportExtension {}
+export type AutomergeReplicatorParams = {
+  /**
+   * The peerId of local automerge repo.
+   */
+  peerId: string;
+};
+
+export type AutomergeReplicatorCallbacks = {
+  /**
+   * Callback to be called when remote peer starts replication.
+   */
+  onStartReplication?: (info: PeerInfo) => Promise<void>;
+
+  /**
+   * Callback to be called when remote peer stops replication.
+   */
+  onStopReplication?: (info: PeerInfo) => Promise<void>;
+
+  /**
+   * Callback to be called when a sync message is received.
+   */
+  onSyncMessage?: (message: SyncMessage) => Promise<void>;
+
+  /**
+   * Callback to be called when the extension is closed.
+   */
+  onClose?: (err?: Error) => Promise<void>;
+};
+
+/**
+ * Sends automerge messages between two peers for a single teleport session.
+ */
+export class AutomergeReplicator implements TeleportExtension {
+  private readonly _opened = new Trigger();
+  private _rpc?: ProtoRpcPeer<ServiceBundle>;
+
+  constructor(
+    private readonly _params: AutomergeReplicatorParams,
+    private readonly _callbacks: AutomergeReplicatorCallbacks = {},
+  ) {}
+
+  async onOpen(context: ExtensionContext): Promise<void> {
+    log('onOpen', { localPeerId: context.localPeerId, remotePeerId: context.remotePeerId });
+
+    this._rpc = createProtoRpcPeer<ServiceBundle, ServiceBundle>({
+      requested: {
+        AutomergeReplicatorService: schema.getService('dxos.mesh.teleport.automerge.AutomergeReplicatorService'),
+      },
+      exposed: {
+        AutomergeReplicatorService: schema.getService('dxos.mesh.teleport.automerge.AutomergeReplicatorService'),
+      },
+      handlers: {
+        AutomergeReplicatorService: {
+          startReplication: async (info: PeerInfo): Promise<void> => {
+            log('startReplication', { localPeerId: context.localPeerId, remotePeerId: context.remotePeerId, info });
+            await this._callbacks.onStartReplication?.(info);
+          },
+          stopReplication: async (info: PeerInfo): Promise<void> => {
+            log('startReplication', { localPeerId: context.localPeerId, remotePeerId: context.remotePeerId, info });
+            await this._callbacks.onStopReplication?.(info);
+          },
+          sendSyncMessage: async (message: SyncMessage): Promise<void> => {
+            log('sendSyncMessage', { localPeerId: context.localPeerId, remotePeerId: context.remotePeerId, message });
+            await this._callbacks.onSyncMessage?.(message);
+          },
+        },
+      },
+      port: await context.createPort('rpc', { contentType: 'application/x-protobuf; messageType="dxos.rpc.Message"' }),
+    });
+    await this._rpc.open();
+    // Announce to remote peer that we are ready to start replication.
+    await this._rpc.rpc.AutomergeReplicatorService.startReplication({ id: this._params.peerId });
+    this._opened.wake();
+  }
+
+  async onClose(err?: Error): Promise<void> {
+    this._opened.reset();
+    await this._rpc?.rpc.AutomergeReplicatorService.stopReplication({ id: this._params.peerId });
+    await this._rpc?.close();
+    this._rpc = undefined;
+    await this._callbacks.onClose?.(err);
+  }
+
+  async onAbort(err?: Error): Promise<void> {
+    log('abort', { err });
+    try {
+      await this._rpc?.rpc.AutomergeReplicatorService.stopReplication({ id: this._params.peerId });
+      await this._rpc?.abort();
+    } catch (err) {
+      log.catch(err);
+    } finally {
+      await this._callbacks.onClose?.(err);
+    }
+  }
+
+  async sendSyncMessage(message: SyncMessage) {
+    await this._opened.wait();
+    invariant(this._rpc, 'RPC not initialized');
+    await this._rpc.rpc.AutomergeReplicatorService.sendSyncMessage(message);
+  }
+}
+
+type ServiceBundle = {
+  AutomergeReplicatorService: AutomergeReplicatorService;
+};

--- a/packages/core/mesh/teleport-extension-automerge-replicator/src/automerge-replicator.ts
+++ b/packages/core/mesh/teleport-extension-automerge-replicator/src/automerge-replicator.ts
@@ -1,0 +1,7 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { type TeleportExtension } from '@dxos/teleport';
+
+export class AutomergeReplicator implements TeleportExtension {}

--- a/packages/core/mesh/teleport-extension-automerge-replicator/src/index.ts
+++ b/packages/core/mesh/teleport-extension-automerge-replicator/src/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+export * from './automerge-replicator';

--- a/packages/core/mesh/teleport-extension-automerge-replicator/tsconfig.json
+++ b/packages/core/mesh/teleport-extension-automerge-replicator/tsconfig.json
@@ -1,0 +1,52 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/types",
+    "types": [
+      "@dxos/typings",
+      "node"
+    ]
+  },
+  "exclude": [
+    "node_modules"
+  ],
+  "include": [
+    "src",
+    "test"
+  ],
+  "references": [
+    {
+      "path": "../../../common/async"
+    },
+    {
+      "path": "../../../common/codec-protobuf"
+    },
+    {
+      "path": "../../../common/context"
+    },
+    {
+      "path": "../../../common/invariant"
+    },
+    {
+      "path": "../../../common/keys"
+    },
+    {
+      "path": "../../../common/log"
+    },
+    {
+      "path": "../../../common/node-std"
+    },
+    {
+      "path": "../../../common/util"
+    },
+    {
+      "path": "../../protocols"
+    },
+    {
+      "path": "../rpc"
+    },
+    {
+      "path": "../teleport"
+    }
+  ]
+}

--- a/packages/core/protocols/src/proto/dxos/mesh/teleport/automerge.proto
+++ b/packages/core/protocols/src/proto/dxos/mesh/teleport/automerge.proto
@@ -1,0 +1,27 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package dxos.mesh.teleport.automerge;
+
+message PeerInfo {
+  string id = 1;
+}
+
+
+message SyncMessage {
+  string id = 1;
+
+  optional bytes sync_message = 2;
+}
+
+
+service AutomergeReplicatorService {
+  rpc StartReplication(PeerInfo) returns (google.protobuf.Empty);
+  rpc StopReplication(PeerInfo) returns (google.protobuf.Empty);
+  rpc SendSyncMessage(SyncMessage) returns (google.protobuf.Empty);
+}

--- a/packages/core/protocols/src/proto/dxos/mesh/teleport/automerge.proto
+++ b/packages/core/protocols/src/proto/dxos/mesh/teleport/automerge.proto
@@ -14,14 +14,11 @@ message PeerInfo {
 
 
 message SyncMessage {
-  string id = 1;
-
-  bytes sync_message = 2;
+  bytes payload = 2;
 }
 
 
 service AutomergeReplicatorService {
   rpc StartReplication(PeerInfo) returns (google.protobuf.Empty);
-  rpc StopReplication(PeerInfo) returns (google.protobuf.Empty);
   rpc SendSyncMessage(SyncMessage) returns (google.protobuf.Empty);
 }

--- a/packages/core/protocols/src/proto/dxos/mesh/teleport/automerge.proto
+++ b/packages/core/protocols/src/proto/dxos/mesh/teleport/automerge.proto
@@ -16,7 +16,7 @@ message PeerInfo {
 message SyncMessage {
   string id = 1;
 
-  optional bytes sync_message = 2;
+  bytes sync_message = 2;
 }
 
 

--- a/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
@@ -228,6 +228,7 @@ export class DataSpaceManager {
           gossip.createExtension({ remotePeerId: session.remotePeerId }),
         );
         session.addExtension('dxos.mesh.teleport.notarization', dataSpace.notarizationPlugin.createExtension());
+        session.addExtension('dxos.mesh.teleport.automerge', this._automergeHost.createExtension());
       },
       onAuthFailure: () => {
         log.warn('auth failure');

--- a/packages/sdk/client/src/tests/client.test.ts
+++ b/packages/sdk/client/src/tests/client.test.ts
@@ -5,8 +5,9 @@
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { rmSync } from 'node:fs';
+import waitForExpect from 'wait-for-expect';
 
-import { Contact } from '@braneframe/types';
+import { Message, Thread } from '@braneframe/types';
 import { Trigger } from '@dxos/async';
 import { Config } from '@dxos/config';
 import { testWithAutomerge } from '@dxos/echo-schema/testing';
@@ -131,47 +132,38 @@ describe('Client', () => {
       await client1.halo.createIdentity();
       await client2.halo.createIdentity();
 
-      const firstContactQueried = new Trigger<Contact>();
-      const secondContactQueried = new Trigger<Contact>();
-      const firstContactName = 'Rich Ivanov';
-      const secondContactName = 'Dmytro Veremchuk';
+      const threadQueried = new Trigger<Thread>();
 
       // Create space and invite second client.
-      const space = await client1.spaces.create();
-      await space.waitUntilReady();
-      const spaceKey = space.key;
-      await Promise.all(performInvitation({ host: space, guest: client2.spaces }));
+      const space1 = await client1.spaces.create();
+      await space1.waitUntilReady();
+      const spaceKey = space1.key;
 
-      const query = space.db.query(Contact.filter());
+      const query = space1.db.query(Thread.filter());
       query.subscribe(({ objects }) => {
-        if (objects.length === 1 && objects[0].name === firstContactName) {
-          firstContactQueried.wake(objects[0]);
-        }
-        if (objects.length === 2 && objects.some((obj) => obj.name === secondContactName)) {
-          secondContactQueried.wake(objects.find((obj) => obj.name === secondContactName)!);
+        if (objects.length === 1) {
+          threadQueried.wake(objects[0]);
         }
       });
+      await Promise.all(performInvitation({ host: space1, guest: client2.spaces }));
 
-      {
-        // Create contact on first client.
-        const space = client1.spaces.get(spaceKey)!;
-        await space.waitUntilReady();
-        const contact = space.db.add(new Contact());
-        contact.name = firstContactName;
-        await space.db.flush();
-      }
+      // Create Thread on second client.
+      const space2 = client2.spaces.get(spaceKey)!;
+      await space2.waitUntilReady();
+      const thread2 = space2.db.add(new Thread());
+      await space2.db.flush();
 
-      {
-        // Create contact on second client.
-        const space = client2.spaces.get(spaceKey)!;
-        await space.waitUntilReady();
-        const contact = space.db.add(new Contact());
-        contact.name = secondContactName;
-        await space.db.flush();
-      }
+      const thread1 = await threadQueried.wait({ timeout: 1000 });
 
-      expect((await firstContactQueried.wait({ timeout: 1000 })).name).to.eq(firstContactName);
-      expect((await secondContactQueried.wait({ timeout: 1000 })).name).to.eq(secondContactName);
+      const text = 'Hello, Dmytro';
+      const message = space2.db.add(new Message({ blocks: [{ text }] }));
+      await space2.db.flush();
+      thread2.messages.push(message);
+
+      await waitForExpect(() => {
+        expect(thread1.messages.length).to.eq(1);
+        expect(thread1.messages[0].blocks[0].text).to.eq(text);
+      }, 1000);
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4381,6 +4381,9 @@ importers:
       '@dxos/teleport':
         specifier: workspace:*
         version: link:../../mesh/teleport
+      '@dxos/teleport-extension-automerge-replicator':
+        specifier: workspace:*
+        version: link:../../mesh/teleport-extension-automerge-replicator
       '@dxos/teleport-extension-gossip':
         specifier: workspace:*
         version: link:../../mesh/teleport-extension-gossip
@@ -5161,6 +5164,46 @@ importers:
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
+
+  packages/core/mesh/teleport-extension-automerge-replicator:
+    dependencies:
+      '@dxos/async':
+        specifier: workspace:*
+        version: link:../../../common/async
+      '@dxos/codec-protobuf':
+        specifier: workspace:*
+        version: link:../../../common/codec-protobuf
+      '@dxos/context':
+        specifier: workspace:*
+        version: link:../../../common/context
+      '@dxos/invariant':
+        specifier: workspace:*
+        version: link:../../../common/invariant
+      '@dxos/keys':
+        specifier: workspace:*
+        version: link:../../../common/keys
+      '@dxos/log':
+        specifier: workspace:*
+        version: link:../../../common/log
+      '@dxos/node-std':
+        specifier: workspace:*
+        version: link:../../../common/node-std
+      '@dxos/protocols':
+        specifier: workspace:*
+        version: link:../../protocols
+      '@dxos/rpc':
+        specifier: workspace:*
+        version: link:../rpc
+      '@dxos/teleport':
+        specifier: workspace:*
+        version: link:../teleport
+      '@dxos/util':
+        specifier: workspace:*
+        version: link:../../../common/util
+    devDependencies:
+      typescript:
+        specifier: ^5.2.2
+        version: 5.2.2
 
   packages/core/mesh/teleport-extension-gossip:
     dependencies:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -484,6 +484,11 @@
         },
         {
           "type": "json",
+          "path": "packages/core/mesh/teleport-extension-automerge-replicator/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "packages/core/mesh/teleport-extension-gossip/package.json",
           "jsonpath": "$.version"
         },


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2c48493</samp>

### Summary
🔄🚀🛠️

<!--
1.  🔄 This emoji represents the automerge replication feature, which enables data synchronization between peers. It also implies the circular and bidirectional nature of the replication process.
2. 🚀 This emoji represents the teleport extension, which enables additional functionality over the teleport mesh network. It also implies the speed and efficiency of the network communication.
3. 🛠️ This emoji represents the various fixes and improvements that are done to the code quality, style, and testing. It also implies the maintenance and development work that is done on the project.
-->
This pull request adds a new package, `teleport-extension-automerge-replicator`, which provides a teleport extension that enables automerge replication between peers. It also updates the `echo-pipeline` package to use the new extension and to improve the `AutomergeHost` and `AutomergeObject` classes. Additionally, it adds and updates some unit tests, comments, and configurations for the new and existing packages.

> _Sing, O Muse, of the mighty `DXOS` team, who forged new tools for the data space_
> _And of the `teleport-extension-automerge-replicator`, the swift and subtle messenger_
> _That carried the changes of the `AutomergeHost`, the keeper of the documents_
> _Across the `TeleportSession`, the bridge of peers, that spanned the mesh network_

### Walkthrough
*  Add `teleport-extension-automerge-replicator` package, which provides a teleport extension for automerge replication between peers (F5-F13, F19).

