### PR TITLE
fix: Increase timeout

### DIFF
--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
@@ -67,7 +67,7 @@ export class AutomergeDb {
     if (spaceState.rootUrl) {
       try {
         this._docHandle = this.automerge.repo.find(spaceState.rootUrl as DocumentId);
-        const doc = await asyncTimeout(this._docHandle.doc(), 500);
+        const doc = await asyncTimeout(this._docHandle.doc(), 10_000);
         const ojectIds = Object.keys(doc.objects ?? {});
         this._createObjects(ojectIds);
       } catch (err) {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d87f471</samp>

### Summary
:hourglass_flowing_sand::memo::zap:

<!--
1.  :hourglass_flowing_sand: This emoji represents the increase in the timeout duration, as it suggests a longer waiting time and a sense of patience.
2.  :memo: This emoji represents the document that is being loaded from the Automerge repository, as it suggests a text-based or editable file.
3.  :zap: This emoji represents the improvement in the stability and performance of the echo-schema package, as it suggests speed, efficiency, and energy.
-->
Increased the document loading timeout in `automerge-db.ts` to handle large or slow documents better. This was part of a pull request to improve the echo-schema package.

> _`echo-schema` waits_
> _longer for Automerge docs_
> _winter patience grows_

### Walkthrough
* Increased the timeout for loading documents from Automerge repository to 10 seconds ([link](https://github.com/dxos/dxos/pull/4924/files?diff=unified&w=0#diff-875834e4b70c12d82e4dedc39420f91a998d2d84b6b7b3551a6b6d90335bfa50L70-R70)). This change affects the `automerge-db.ts` file in the `echo-schema` package and aims to improve stability and performance when handling large or slow documents.


