### PR TITLE
feat: Fix outliner bug

### DIFF
--- a/packages/apps/plugins/plugin-outliner/src/components/Outliner/Outliner.tsx
+++ b/packages/apps/plugins/plugin-outliner/src/components/Outliner/Outliner.tsx
@@ -153,7 +153,7 @@ const OutlinerItem = ({
   return (
     <div className='flex group' onKeyDownCapture={handleKeyDown}>
       {(isTasklist && (
-        <div className='py-1 mr-1'>
+        <div className='mt-0.5 mr-2.5'>
           <Input.Root>
             <Input.Checkbox
               checked={item.done}
@@ -164,7 +164,7 @@ const OutlinerItem = ({
           </Input.Root>
         </div>
       )) || (
-        <div className='px-1 py-1 cursor-pointer' title={item.id.slice(0, 8)} onClick={() => onSelect?.()}>
+        <div className='mr-1 cursor-pointer' title={item.id.slice(0, 8)} onClick={() => onSelect?.()}>
           <DotOutline
             weight={focus ? 'fill' : undefined}
             className={mx('shrink-0', getSize(6), active && 'text-primary-500')}
@@ -375,14 +375,15 @@ const OutlinerRoot = ({ className, root, onCreate, onDelete, ...props }: Outline
     switch (direction) {
       case 'left': {
         if (parent) {
-          // Move all siblings.
-          const move = items.splice(idx, items.length - idx);
-
           // Get parent's parent.
           const ancestor = getParent(root, parent)!;
-          const ancestorItems = getItems(ancestor);
-          const parentIdx = ancestorItems.findIndex(({ id }) => id === parent.id);
-          ancestorItems.splice(parentIdx + 1, 0, ...move);
+          if (ancestor) {
+            // Move all siblings.
+            const move = items.splice(idx, items.length - idx);
+            const ancestorItems = getItems(ancestor);
+            const parentIdx = ancestorItems.findIndex(({ id }) => id === parent.id);
+            ancestorItems.splice(parentIdx + 1, 0, ...move);
+          }
         }
         break;
       }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4dd0fea</samp>

### Summary
🐛🎨🚸

<!--
1.  🐛 for fixing a potential error when moving nodes. This emoji conveys the idea of squashing a bug or resolving an issue in the code.
2.  🎨 for adjusting the styling of the checkbox and dot outline elements. This emoji conveys the idea of improving the appearance or design of the component.
3.  🚸 for improving the user experience and accessibility of the outliner component. This emoji conveys the idea of making the component easier to use and navigate for different types of users.
-->
Improve outliner component in `plugin-outliner` app. Fix node moving bug and enhance checkbox and dot outline appearance.

> _The outliner component was fine_
> _But it had a small bug in its spine_
> _When moving a node_
> _It might overflowed_
> _So this pull request fixed the `moveNode` line_

### Walkthrough
* Improve the alignment and spacing of the outliner item component ([link](https://github.com/dxos/dxos/pull/4925/files?diff=unified&w=0#diff-762ce388eaf7b5edfc8c3f61c59260ee80250616b84eb99d1f13a4bd23b0fd40L156-R156), [link](https://github.com/dxos/dxos/pull/4925/files?diff=unified&w=0#diff-762ce388eaf7b5edfc8c3f61c59260ee80250616b84eb99d1f13a4bd23b0fd40L167-R167)) in `Outliner.tsx`.


