### PR TITLE
fix: Disable broken presence navtree indicators

### DIFF
--- a/packages/apps/plugins/plugin-theme/src/ThemePlugin.tsx
+++ b/packages/apps/plugins/plugin-theme/src/ThemePlugin.tsx
@@ -46,7 +46,10 @@ export const ThemePlugin = ({ appName, tx: propsTx }: ThemePluginOptions = { app
         return (
           <ThemeProvider {...{ tx: propsTx ?? defaultTx, themeMode: state.themeMode, resourceExtensions: resources }}>
             <Toast.Provider>
-              <Tooltip.Provider>{children}</Tooltip.Provider>
+              {/* TODO(burdon): Add option to disable tooltips. */}
+              <Tooltip.Provider delayDuration={1000} skipDelayDuration={100} disableHoverableContent>
+                {children}
+              </Tooltip.Provider>
               <Toast.Viewport />
             </Toast.Provider>
           </ThemeProvider>

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
@@ -95,11 +95,13 @@ export const NavTreeMosaicComponent: MosaicTileComponent<NavTreeItemData, HTMLLI
 
 export type NavTreeItemData = TreeNode & { level: number };
 
+// TODO(burdon): Disabled until working.
+const presence = false;
+
 export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = forwardRef(
   ({ item, draggableProps, draggableStyle, active, path, position }, forwardedRef) => {
     const { level, ...node } = item;
     const isBranch = node.properties?.role === 'branch' || node.children?.length > 0;
-
     const [primaryAction, ...secondaryActions] = [...node.actions].sort((a, b) =>
       a.properties.disposition === 'toolbar' ? -1 : 1,
     );
@@ -207,7 +209,7 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
                   testId={`navtree.treeItem.actionsLevel${level}`}
                 />
               )}
-              {renderPresence?.(node)}
+              {presence && renderPresence?.(node)}
             </div>
             {!active &&
               isBranch &&


### PR DESCRIPTION
- [x] codeflag to disable non-functional presence indicators in navtree
- [x] increase tooltip timeout and attempt to prevent cascading effect


copilot:all
