### PR TITLE
feat(react-ui-navtree): Add context menu to `NavTreeItem`s

### DIFF
--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -46,7 +46,7 @@ export class AppManager {
   }
 
   async joinSpace() {
-    await this.page.getByTestId('navtree.treeItem.actionsLevel0').nth(1).click();
+    await this.page.getByTestId('navtree.treeItem.actionsLevel0').nth(1).click({ button: 'right' });
     return this.page.getByTestId('spacePlugin.joinSpace').click();
   }
 

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
@@ -2,10 +2,17 @@
 // Copyright 2023 DXOS.org
 //
 
-import { DotsThreeVertical, Placeholder } from '@phosphor-icons/react';
+import { Placeholder } from '@phosphor-icons/react';
 import React, { type ForwardedRef, forwardRef, Fragment, useEffect, useState } from 'react';
 
-import { DensityProvider, Tree, TreeItem as TreeItemComponent, TreeItem, useTranslation } from '@dxos/react-ui';
+import {
+  DensityProvider,
+  Popover,
+  Tree,
+  TreeItem as TreeItemComponent,
+  TreeItem,
+  useTranslation,
+} from '@dxos/react-ui';
 import { Mosaic, useContainer, type MosaicTileComponent, Path, useItemsWithOrigin } from '@dxos/react-ui-mosaic';
 import {
   descriptionText,
@@ -20,7 +27,7 @@ import {
 } from '@dxos/react-ui-theme';
 
 import { useNavTree } from './NavTreeContext';
-import { NavTreeItemAction } from './NavTreeItemAction';
+import { NavTreeItemAction, NavTreeItemActionContextMenu } from './NavTreeItemAction';
 import { NavTreeItemHeading } from './NavTreeItemHeading';
 import { levelPadding, topLevelCollapsibleSpacing } from './navtree-fragments';
 import { translationKey } from '../translations';
@@ -120,6 +127,8 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
     const forceCollapse = active === 'overlay' || active === 'destination' || active === 'rearrange' || disabled;
 
     const Root = active === 'overlay' ? Tree.Root : Fragment;
+    const ContextMenuTriggerRoot = actions.length > 0 ? NavTreeItemActionContextMenu : Fragment;
+    const ActionRoot = popoverAnchorId === `dxos.org/ui/navtree/${node.id}` ? Popover.Anchor : Fragment;
 
     const isOverCurrent = isOver(path);
 
@@ -146,71 +155,54 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
             ref={forwardedRef}
             role='treeitem'
           >
-            <div
-              role='none'
-              className={mx(
-                'flex items-start rounded',
-                levelPadding(level),
-                hoverableControls,
-                hoverableFocusedWithinControls,
-                hoverableDescriptionIcons,
-                level < 1 && topLevelCollapsibleSpacing,
-                staticGhostSelectedCurrent({ current: (active && active !== 'overlay') || path === current }),
-              )}
-            >
-              <NavTreeItemHeading
-                {...{
-                  id: node.id,
-                  level,
-                  label: Array.isArray(node.label) ? t(...node.label) : node.label,
-                  icon: node.icon,
-                  open,
-                  current: path === current,
-                  branch: node.properties?.role === 'branch' || node.children?.length > 0,
-                  disabled: !!node.properties?.disabled,
-                  error: !!node.properties?.error,
-                  modified: node.properties?.modified ?? false,
-                  palette: node.properties?.palette,
-                  onSelect: () => onSelect?.({ path, node, level, position: position as number }),
-                }}
-              />
-              {/*
+            <ActionRoot>
+              <ContextMenuTriggerRoot actions={actions} onAction={(action) => action.invoke?.()}>
+                <div
+                  role='none'
+                  className={mx(
+                    'flex items-start rounded',
+                    levelPadding(level),
+                    hoverableControls,
+                    hoverableFocusedWithinControls,
+                    hoverableDescriptionIcons,
+                    level < 1 && topLevelCollapsibleSpacing,
+                    staticGhostSelectedCurrent({ current: (active && active !== 'overlay') || path === current }),
+                  )}
+                >
+                  <NavTreeItemHeading
+                    {...{
+                      id: node.id,
+                      level,
+                      label: Array.isArray(node.label) ? t(...node.label) : node.label,
+                      icon: node.icon,
+                      open,
+                      current: path === current,
+                      branch: node.properties?.role === 'branch' || node.children?.length > 0,
+                      disabled: !!node.properties?.disabled,
+                      error: !!node.properties?.error,
+                      modified: node.properties?.modified ?? false,
+                      palette: node.properties?.palette,
+                      onSelect: () => onSelect?.({ path, node, level, position: position as number }),
+                    }}
+                  />
+                  {/*
               TODO(wittjosiah): Primary action should come at the end.
               However, currently if it does then the triple dots menus don't line up for nodes without primary actions. */}
-              {primaryAction?.properties.disposition === 'toolbar' && (
-                <NavTreeItemAction
-                  id={node.id}
-                  label={Array.isArray(primaryAction.label) ? t(...primaryAction.label) : primaryAction.label}
-                  icon={primaryAction.icon ?? Placeholder}
-                  action={primaryAction.actions.length === 0 ? primaryAction : undefined}
-                  actions={primaryAction.actions}
-                  level={level}
-                  active={active}
-                  popoverAnchorId={popoverAnchorId}
-                  testId={primaryAction.properties.testId}
-                  menuType={primaryAction.properties.menuType}
-                />
-              )}
-              {actions.length > 0 && (
-                <NavTreeItemAction
-                  id={node.id}
-                  label={
-                    node.properties?.actionMenuLabel
-                      ? Array.isArray(node.properties?.actionMenuLabel)
-                        ? t(...(node.properties.actionMenuLabel as [string, { ns: string; count?: number }]))
-                        : node.properties.actionMenuLabel
-                      : t('tree item actions label')
-                  }
-                  icon={DotsThreeVertical}
-                  actions={actions}
-                  level={level}
-                  active={active}
-                  popoverAnchorId={popoverAnchorId}
-                  testId={`navtree.treeItem.actionsLevel${level}`}
-                />
-              )}
-              {presence && renderPresence?.(node)}
-            </div>
+                  {primaryAction?.properties.disposition === 'toolbar' && (
+                    <NavTreeItemAction
+                      label={Array.isArray(primaryAction.label) ? t(...primaryAction.label) : primaryAction.label}
+                      icon={primaryAction.icon ?? Placeholder}
+                      action={primaryAction.actions.length === 0 ? primaryAction : undefined}
+                      actions={primaryAction.actions}
+                      active={active}
+                      testId={primaryAction.properties.testId}
+                      menuType={primaryAction.properties.menuType}
+                    />
+                  )}
+                  {presence && renderPresence?.(node)}
+                </div>
+              </ContextMenuTriggerRoot>
+            </ActionRoot>
             {!active &&
               isBranch &&
               (node.children?.length > 0 ? (

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
@@ -168,6 +168,7 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
                     level < 1 && topLevelCollapsibleSpacing,
                     staticGhostSelectedCurrent({ current: (active && active !== 'overlay') || path === current }),
                   )}
+                  data-testId={`navtree.treeItem.actionsLevel${level}`}
                 >
                   <NavTreeItemHeading
                     {...{

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItemAction.stories.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItemAction.stories.tsx
@@ -57,9 +57,7 @@ export const Default = {
     // TODO(burdon): Goal: Factor-out CMD-K like dialog.
     return (
       <NavTreeItemAction
-        id='test'
         icon={List}
-        level={0}
         actions={actions}
         menuType='searchList'
         label='Select action'

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItemAction.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItemAction.tsx
@@ -3,11 +3,11 @@
 //
 
 import { type IconProps } from '@phosphor-icons/react';
-import React, { type FC, Fragment, type MutableRefObject, useRef, useState } from 'react';
+import React, { type FC, type MutableRefObject, type PropsWithChildren, useRef, useState } from 'react';
 
 import { type Label } from '@dxos/app-graph';
 import { keySymbols } from '@dxos/keyboard';
-import { Button, Dialog, DropdownMenu, Popover, Tooltip, useTranslation } from '@dxos/react-ui';
+import { Button, Dialog, DropdownMenu, ContextMenu, Tooltip, useTranslation } from '@dxos/react-ui';
 import { type MosaicActiveType } from '@dxos/react-ui-mosaic';
 import { SearchList } from '@dxos/react-ui-searchlist';
 import { descriptionText, getSize, hoverableControlItem, hoverableOpenControlItem, mx } from '@dxos/react-ui-theme';
@@ -16,14 +16,11 @@ import { translationKey } from '../translations';
 import type { TreeNodeAction } from '../types';
 
 type NavTreeItemActionProps = {
-  id: string;
   label?: string;
   icon: FC<IconProps>;
   action?: TreeNodeAction;
   actions?: TreeNodeAction[];
-  level: number;
   active?: MosaicActiveType;
-  popoverAnchorId?: string;
   testId?: string;
   menuType?: 'searchList' | 'dropdown';
   onAction?: (action: TreeNodeAction) => void;
@@ -104,6 +101,49 @@ export const NavTreeItemActionDropdownMenu = ({
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>
+  );
+};
+
+export const NavTreeItemActionContextMenu = ({
+  actions,
+  onAction,
+  children,
+}: PropsWithChildren<Pick<NavTreeItemActionProps, 'actions' | 'onAction'>>) => {
+  const { t } = useTranslation(translationKey);
+  const getLabel = (label: Label) => (Array.isArray(label) ? t(...label) : label);
+
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger asChild>{children}</ContextMenu.Trigger>
+      <ContextMenu.Portal>
+        <ContextMenu.Content classNames='z-[31]'>
+          <ContextMenu.Viewport>
+            {actions?.map((action) => (
+              <ContextMenu.Item
+                key={action.id}
+                onClick={(event) => {
+                  if (action.properties.disabled) {
+                    return;
+                  }
+                  event.stopPropagation();
+                  onAction?.(action);
+                }}
+                classNames='gap-2'
+                disabled={action.properties.disabled}
+                {...(action.properties?.testId && { 'data-testid': action.properties.testId })}
+              >
+                {action.icon && <action.icon className={mx(getSize(4), 'shrink-0')} />}
+                <span className='grow truncate'>{getLabel(action.label)}</span>
+                {action.keyBinding && (
+                  <span className={mx('shrink-0', descriptionText)}>{keySymbols(action.keyBinding).join('')}</span>
+                )}
+              </ContextMenu.Item>
+            ))}
+          </ContextMenu.Viewport>
+          <ContextMenu.Arrow />
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu.Root>
   );
 };
 
@@ -223,86 +263,79 @@ export const NavTreeItemActionSearchList = ({
 };
 
 export const NavTreeItemAction = ({
-  id,
   label,
   icon: Icon,
   action,
   actions,
   active,
-  level,
-  popoverAnchorId,
   testId,
   menuType,
 }: NavTreeItemActionProps) => {
   const suppressNextTooltip = useRef<boolean>(false);
   const [triggerTooltipOpen, setTriggerTooltipOpen] = useState(false);
 
-  const ActionRoot = popoverAnchorId === `dxos.org/ui/navtree/${id}` ? Popover.Anchor : Fragment;
-
   return (
-    <ActionRoot>
-      <Tooltip.Root
-        open={triggerTooltipOpen}
-        onOpenChange={(nextOpen) => {
-          if (suppressNextTooltip.current) {
-            setTriggerTooltipOpen(false);
-            suppressNextTooltip.current = false;
-          } else {
-            setTriggerTooltipOpen(nextOpen);
-          }
-        }}
-      >
-        {label && (
-          <Tooltip.Portal>
-            <Tooltip.Content classNames='z-[31]' side='bottom'>
-              {label}
-              <Tooltip.Arrow />
-            </Tooltip.Content>
-          </Tooltip.Portal>
-        )}
-        {action ? (
-          <Tooltip.Trigger asChild>
-            <Button
-              variant='ghost'
-              classNames={[
-                'shrink-0 pli-2 pointer-fine:pli-1',
-                hoverableControlItem,
-                hoverableOpenControlItem,
-                active === 'overlay' && 'invisible',
-              ]}
-              onClick={(event) => {
-                if (action.properties.disabled) {
-                  return;
-                }
-                event.stopPropagation();
-                void action.invoke();
-              }}
-              data-testid={testId}
-            >
-              <Icon className={getSize(4)} />
-            </Button>
-          </Tooltip.Trigger>
-        ) : menuType === 'searchList' ? (
-          <NavTreeItemActionSearchList
-            actions={actions}
-            testId={testId}
-            active={active}
-            suppressNextTooltip={suppressNextTooltip}
-            icon={Icon}
-            label={label}
-            onAction={(action) => action.invoke()}
-          />
-        ) : (
-          <NavTreeItemActionDropdownMenu
-            actions={actions}
-            testId={testId}
-            active={active}
-            suppressNextTooltip={suppressNextTooltip}
-            icon={Icon}
-            onAction={(action) => action.invoke()}
-          />
-        )}
-      </Tooltip.Root>
-    </ActionRoot>
+    <Tooltip.Root
+      open={triggerTooltipOpen}
+      onOpenChange={(nextOpen) => {
+        if (suppressNextTooltip.current) {
+          setTriggerTooltipOpen(false);
+          suppressNextTooltip.current = false;
+        } else {
+          setTriggerTooltipOpen(nextOpen);
+        }
+      }}
+    >
+      {label && (
+        <Tooltip.Portal>
+          <Tooltip.Content classNames='z-[31]' side='bottom'>
+            {label}
+            <Tooltip.Arrow />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      )}
+      {action ? (
+        <Tooltip.Trigger asChild>
+          <Button
+            variant='ghost'
+            classNames={[
+              'shrink-0 pli-2 pointer-fine:pli-1',
+              hoverableControlItem,
+              hoverableOpenControlItem,
+              active === 'overlay' && 'invisible',
+            ]}
+            onClick={(event) => {
+              if (action.properties.disabled) {
+                return;
+              }
+              event.stopPropagation();
+              void action.invoke();
+            }}
+            data-testid={testId}
+          >
+            <Icon className={getSize(4)} />
+          </Button>
+        </Tooltip.Trigger>
+      ) : menuType === 'searchList' ? (
+        <NavTreeItemActionSearchList
+          actions={actions}
+          testId={testId}
+          active={active}
+          suppressNextTooltip={suppressNextTooltip}
+          icon={Icon}
+          label={label}
+          onAction={(action) => action.invoke()}
+        />
+      ) : (
+        <NavTreeItemActionDropdownMenu
+          actions={actions}
+          testId={testId}
+          active={active}
+          suppressNextTooltip={suppressNextTooltip}
+          icon={Icon}
+          onAction={(action) => action.invoke()}
+        />
+      )}
+    </Tooltip.Root>
   );
 };


### PR DESCRIPTION
Resolves #4858.

This PR moves non-toolbar actions into a `ContextMenu` for which `NavTreeItemHeading` is the trigger, replacing the `DropdownMenu` with the `DotsThreeVertical` trigger.

https://github.com/dxos/dxos/assets/855039/847bd492-0f4e-4acf-9de9-fd0962425734

https://github.com/dxos/dxos/assets/855039/190c2c50-2257-4acc-937d-4c6bf5d0ce56

<img width="1406" alt="Screenshot 2024-01-05 at 16 22 51" src="https://github.com/dxos/dxos/assets/855039/fca018a4-01c8-4d21-9e80-b0c6abd1d65f">