### PR TITLE
chore: update GitHub PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,20 @@
-copilot:all
+### Motivation / Background
+
+<!--
+Describe why this Pull Request exists. What bug have you fixed? What feature have you added? Why is it important?
+If you are fixing a specific issue, include `Fixes #ISSUE` (replace with the issue number) to link a specific to this PR.
+-->
+
+This Pull Request ...
+
+### Details
+
+<!--
+Describe the specific changes you made.
+-->
+
+### Additional information
+
+<!-- Provide additional information such as references to other repositories, alternative solutions, etc. -->
+
+<!-- If this PR changes something visual, feel free to add a screenshot or a video. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- For shorter PRs, feel free to delete the majority of this description and just use a sentence or two -->
+
 ### Motivation / Background
 
 <!--


### PR DESCRIPTION
### Motivation

Now that [Copilot for PRs has been sunset](https://gist.github.com/idan/325676d192b32f169b032fde2d866c2c#github-next--technical-preview-sunsets), we need to write our own PR descriptions.

Good PR descriptions aid internal PR review and make the project more approachable for outsiders who want to dive in. While some of us can just click over to "Files Changed" and get the gist of a PR, a new contributor cannot.

### Details

This pull request updates the PR template to remove `copilot:all` and add some simple sections.