### PR TITLE
feat(composer): Cmd-shift-delete to delete objects

### DIFF
--- a/packages/apps/plugins/plugin-navtree/src/components/CommandsDialog.tsx
+++ b/packages/apps/plugins/plugin-navtree/src/components/CommandsDialog.tsx
@@ -5,7 +5,7 @@
 import { DotOutline } from '@phosphor-icons/react';
 import React, { useMemo, useRef, useState } from 'react';
 
-import { type Action, type Graph, type Label } from '@dxos/app-graph';
+import { KEY_BINDING, type Action, type Graph, type Label } from '@dxos/app-graph';
 import { Keyboard, keySymbols } from '@dxos/keyboard';
 import { Button, Dialog, useTranslation } from '@dxos/react-ui';
 import { SearchList } from '@dxos/react-ui-searchlist';
@@ -83,7 +83,7 @@ export const CommandsDialogContent = ({ graph, selected: initial }: { graph?: Gr
                   // TODO(burdon): Remove hack to close dialog (via hook?)
                   buttonRef.current?.click();
                   setTimeout(() => {
-                    void action.invoke();
+                    void action.invoke({ caller: KEY_BINDING });
                   });
                 }}
                 classNames='flex items-center gap-2'

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -270,9 +270,16 @@ export const SpacePlugin = ({
                 return <PopoverRenameObject object={data.subject} />;
               } else if (
                 data.component === 'dxos.org/plugin/space/RemoveObjectPopover' &&
-                isTypedObject(data.subject.object)
+                data.subject &&
+                typeof data.subject === 'object' &&
+                isTypedObject((data.subject as Record<string, any>)?.object)
               ) {
-                return <PopoverRemoveObject object={data.subject.object} folder={data.subject.folder} />;
+                return (
+                  <PopoverRemoveObject
+                    object={(data.subject as Record<string, any>)?.object}
+                    folder={(data.subject as Record<string, any>)?.folder}
+                  />
+                );
               } else {
                 return null;
               }

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -28,7 +28,7 @@ import { LocalStorageStore } from '@dxos/local-storage';
 import { log } from '@dxos/log';
 import { Migrations } from '@dxos/migrations';
 import { type Client, PublicKey } from '@dxos/react-client';
-import { type Space, SpaceProxy, getSpaceForObject } from '@dxos/react-client/echo';
+import { type Space, SpaceProxy } from '@dxos/react-client/echo';
 import { useFileDownload } from '@dxos/react-ui';
 import { inferRecordOrder } from '@dxos/util';
 
@@ -270,9 +270,9 @@ export const SpacePlugin = ({
                 return <PopoverRenameObject object={data.subject} />;
               } else if (
                 data.component === 'dxos.org/plugin/space/RemoveObjectPopover' &&
-                isTypedObject(data.subject)
+                isTypedObject(data.subject.object)
               ) {
-                return <PopoverRemoveObject object={data.subject} />;
+                return <PopoverRemoveObject object={data.subject.object} folder={data.subject.folder} />;
               } else {
                 return null;
               }
@@ -574,40 +574,13 @@ export const SpacePlugin = ({
                 data: {
                   anchorId: `dxos.org/ui/${intent.data.caller}/${intent.data.object.id}`,
                   component: 'dxos.org/plugin/space/RemoveObjectPopover',
-                  subject: intent.data.object,
+                  subject: {
+                    object: intent.data.object,
+                    folder: intent.data.folder,
+                  },
                   caller: intent.data.caller,
                 },
               });
-              // if (!(intent.data.object instanceof TypedObject)) {
-              //   return;
-              // }
-
-              // const layoutPlugin = resolvePlugin(plugins, parseLayoutPlugin);
-              // const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);
-              // if (layoutPlugin?.provides.layout.active === intent.data.object.id) {
-              //   await intentPlugin?.provides.intent.dispatch({
-              //     action: LayoutAction.ACTIVATE,
-              //     data: { id: undefined },
-              //   });
-              // }
-
-              // if (intent.data.folder instanceof Folder) {
-              //   const index = intent.data.folder.objects.indexOf(intent.data.object);
-              //   index !== -1 && intent.data.folder.objects.splice(index, 1);
-              // }
-
-              // const space = getSpaceForObject(intent.data.object);
-
-              // const folder = space?.properties[Folder.schema.typename];
-              // if (folder instanceof Folder) {
-              //   const index = folder.objects.indexOf(intent.data.object);
-              //   index !== -1 && folder.objects.splice(index, 1);
-              // }
-
-              // if (space) {
-              //   space.db.remove(intent.data.object);
-              //   return true;
-              // }
               // break;
             }
 

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -40,6 +40,7 @@ import {
   EmptyTree,
   FolderMain,
   MissingObject,
+  PopoverRemoveObject,
   PopoverRenameObject,
   PopoverRenameSpace,
   SpaceMain,
@@ -267,6 +268,11 @@ export const SpacePlugin = ({
                 isTypedObject(data.subject)
               ) {
                 return <PopoverRenameObject object={data.subject} />;
+              } else if (
+                data.component === 'dxos.org/plugin/sipace/RemoveObjectPopover' &&
+                isTypedObject(data.subject)
+              ) {
+                return <PopoverRemoveObject object={data.subject} />;
               } else {
                 return null;
               }
@@ -562,37 +568,47 @@ export const SpacePlugin = ({
             }
 
             case SpaceAction.REMOVE_OBJECT: {
-              if (!(intent.data.object instanceof TypedObject)) {
-                return;
-              }
-
-              const layoutPlugin = resolvePlugin(plugins, parseLayoutPlugin);
               const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);
-              if (layoutPlugin?.provides.layout.active === intent.data.object.id) {
-                await intentPlugin?.provides.intent.dispatch({
-                  action: LayoutAction.ACTIVATE,
-                  data: { id: undefined },
-                });
-              }
+              return intentPlugin?.provides.intent.dispatch({
+                action: LayoutAction.OPEN_POPOVER,
+                data: {
+                  anchorId: `dxos.org/ui/${intent.data.caller}/${intent.data.object.id}`,
+                  component: 'dxos.org/plugin/space/RemoveObjectPopover',
+                  subject: intent.data.object,
+                  caller: intent.data.caller,
+                },
+              });
+              // if (!(intent.data.object instanceof TypedObject)) {
+              //   return;
+              // }
 
-              if (intent.data.folder instanceof Folder) {
-                const index = intent.data.folder.objects.indexOf(intent.data.object);
-                index !== -1 && intent.data.folder.objects.splice(index, 1);
-              }
+              // const layoutPlugin = resolvePlugin(plugins, parseLayoutPlugin);
+              // const intentPlugin = resolvePlugin(plugins, parseIntentPlugin);
+              // if (layoutPlugin?.provides.layout.active === intent.data.object.id) {
+              //   await intentPlugin?.provides.intent.dispatch({
+              //     action: LayoutAction.ACTIVATE,
+              //     data: { id: undefined },
+              //   });
+              // }
 
-              const space = getSpaceForObject(intent.data.object);
+              // if (intent.data.folder instanceof Folder) {
+              //   const index = intent.data.folder.objects.indexOf(intent.data.object);
+              //   index !== -1 && intent.data.folder.objects.splice(index, 1);
+              // }
 
-              const folder = space?.properties[Folder.schema.typename];
-              if (folder instanceof Folder) {
-                const index = folder.objects.indexOf(intent.data.object);
-                index !== -1 && folder.objects.splice(index, 1);
-              }
+              // const space = getSpaceForObject(intent.data.object);
 
-              if (space) {
-                space.db.remove(intent.data.object);
-                return true;
-              }
-              break;
+              // const folder = space?.properties[Folder.schema.typename];
+              // if (folder instanceof Folder) {
+              //   const index = folder.objects.indexOf(intent.data.object);
+              //   index !== -1 && folder.objects.splice(index, 1);
+              // }
+
+              // if (space) {
+              //   space.db.remove(intent.data.object);
+              //   return true;
+              // }
+              // break;
             }
 
             case SpaceAction.RENAME_OBJECT: {

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -269,7 +269,7 @@ export const SpacePlugin = ({
               ) {
                 return <PopoverRenameObject object={data.subject} />;
               } else if (
-                data.component === 'dxos.org/plugin/sipace/RemoveObjectPopover' &&
+                data.component === 'dxos.org/plugin/space/RemoveObjectPopover' &&
                 isTypedObject(data.subject)
               ) {
                 return <PopoverRemoveObject object={data.subject} />;

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -588,7 +588,6 @@ export const SpacePlugin = ({
                   caller: intent.data.caller,
                 },
               });
-              // break;
             }
 
             case SpaceAction.RENAME_OBJECT: {

--- a/packages/apps/plugins/plugin-space/src/components/PopoverRemoveObject.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/PopoverRemoveObject.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useRef } from 'react';
 import { Folder } from '@braneframe/types';
 import { LayoutAction, parseIntentPlugin, parseLayoutPlugin, useResolvePlugin } from '@dxos/app-framework';
 import { TypedObject, getSpaceForObject } from '@dxos/react-client/echo';
-import { Button, Input, Popover, useTranslation } from '@dxos/react-ui';
+import { Button, Popover, useTranslation } from '@dxos/react-ui';
 
 import { SPACE_PLUGIN } from '../meta';
 
@@ -55,13 +55,9 @@ export const PopoverRemoveObject = ({ object, folder: propsFolder }: { object: T
 
   return (
     <div role='none' className='p-1'>
-      <div role='none'>
-        <Input.Root>
-          <Input.DescriptionAndValidation>Delete this item?</Input.DescriptionAndValidation>
-        </Input.Root>
-      </div>
+      <p className='mlb-1 mli-2'>Delete this item?</p>
       <Popover.Close asChild>
-        <Button ref={deleteButton} classNames='self-stretch' onClick={handleDelete}>
+        <Button ref={deleteButton} classNames='is-full' onClick={handleDelete}>
           {t('delete label', { ns: 'os' })}
         </Button>
       </Popover.Close>

--- a/packages/apps/plugins/plugin-space/src/components/PopoverRemoveObject.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/PopoverRemoveObject.tsx
@@ -18,10 +18,10 @@ export const PopoverRemoveObject = ({ object }: { object: TypedObject }) => {
   }, [object]);
 
   return (
-    <div role='none' className='p-1 flex'>
+    <div role='none' className='p-1'>
       <div role='none'>
         <Input.Root>
-          <Input.Description>Are you sure you want to delete this item?</Input.Description>
+          <Input.DescriptionAndValidation>Delete this item?</Input.DescriptionAndValidation>
         </Input.Root>
       </div>
       <Popover.Close asChild>

--- a/packages/apps/plugins/plugin-space/src/components/PopoverRemoveObject.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/PopoverRemoveObject.tsx
@@ -1,0 +1,34 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React, { useCallback, useRef } from 'react';
+
+import { type TypedObject } from '@dxos/react-client/echo';
+import { Button, Input, Popover, useTranslation } from '@dxos/react-ui';
+
+import { SPACE_PLUGIN } from '../meta';
+
+export const PopoverRemoveObject = ({ object }: { object: TypedObject }) => {
+  const { t } = useTranslation(SPACE_PLUGIN);
+  const deleteButton = useRef<HTMLButtonElement>(null);
+
+  const handleDelete = useCallback(() => {
+    console.log('delete');
+  }, [object]);
+
+  return (
+    <div role='none' className='p-1 flex'>
+      <div role='none'>
+        <Input.Root>
+          <Input.Description>Are you sure you want to delete this item?</Input.Description>
+        </Input.Root>
+      </div>
+      <Popover.Close asChild>
+        <Button ref={deleteButton} classNames='self-stretch' onClick={handleDelete}>
+          {t('delete label', { ns: 'os' })}
+        </Button>
+      </Popover.Close>
+    </div>
+  );
+};

--- a/packages/apps/plugins/plugin-space/src/components/PopoverRemoveObject.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/PopoverRemoveObject.tsx
@@ -31,7 +31,7 @@ export const PopoverRemoveObject = ({ object, folder: propsFolder }: { object: T
       });
     }
 
-    // remove a folder
+    // remove object from folder it's in
     if (propsFolder instanceof Folder) {
       const index = propsFolder.objects.indexOf(object);
       index !== -1 && propsFolder.objects.splice(index, 1);
@@ -39,14 +39,14 @@ export const PopoverRemoveObject = ({ object, folder: propsFolder }: { object: T
 
     const space = getSpaceForObject(object);
 
-    // remove the folder from the graph?
+    // remove the folder from the root folder - may be handled by previous condition
     const folder = space?.properties[Folder.schema.typename];
     if (folder instanceof Folder) {
       const index = folder.objects.indexOf(object);
       index !== -1 && folder.objects.splice(index, 1);
     }
 
-    // remove the object
+    // remove the object from the space
     if (space) {
       space.db.remove(object);
       return true;
@@ -55,7 +55,7 @@ export const PopoverRemoveObject = ({ object, folder: propsFolder }: { object: T
 
   return (
     <div role='none' className='p-1'>
-      <p className='mlb-1 mli-2'>Delete this item?</p>
+      <p className='mlb-1 mli-2'>{t('delete object description', { ns: 'os' })}</p>
       <Popover.Close asChild>
         <Button ref={deleteButton} classNames='is-full' onClick={handleDelete}>
           {t('delete label', { ns: 'os' })}

--- a/packages/apps/plugins/plugin-space/src/components/index.ts
+++ b/packages/apps/plugins/plugin-space/src/components/index.ts
@@ -8,6 +8,7 @@ export * from './EmptySpace';
 export * from './EmptyTree';
 export * from './FolderMain';
 export * from './MissingObject';
+export * from './PopoverRemoveObject';
 export * from './PopoverRenameObject';
 export * from './PopoverRenameSpace';
 export * from './SpaceMain';

--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -331,11 +331,11 @@ export const objectToGraphNode = ({
         label: ['delete object label', { ns: SPACE_PLUGIN }],
         icon: (props) => <Trash {...props} />,
         keyBinding: 'shift+meta+Backspace',
-        invoke: () =>
+        invoke: (params) =>
           dispatch([
             {
               action: SpaceAction.REMOVE_OBJECT,
-              data: { object, folder: parent.data },
+              data: { object, folder: parent.data, ...params },
             },
           ]),
       },

--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -330,7 +330,7 @@ export const objectToGraphNode = ({
         id: 'delete',
         label: ['delete object label', { ns: SPACE_PLUGIN }],
         icon: (props) => <Trash {...props} />,
-        keyBinding: 'meta+Backspace',
+        keyBinding: 'shift+meta+Backspace',
         invoke: () =>
           dispatch([
             {

--- a/packages/apps/plugins/plugin-theme/src/translations/en-US/os.ts
+++ b/packages/apps/plugins/plugin-theme/src/translations/en-US/os.ts
@@ -49,6 +49,7 @@ export const os = {
   'reconnect label': 'Reconnect',
   'cancel label': 'Cancel',
   'done label': 'Done',
+  'delete label': 'Delete',
   'reset label': 'Start over',
   'auth code input label': 'Enter the verification code',
   'invitation input label': 'Paste an invitation code or URL',

--- a/packages/apps/plugins/plugin-theme/src/translations/en-US/os.ts
+++ b/packages/apps/plugins/plugin-theme/src/translations/en-US/os.ts
@@ -50,6 +50,7 @@ export const os = {
   'cancel label': 'Cancel',
   'done label': 'Done',
   'delete label': 'Delete',
+  'delete object description': 'Delete this item?',
   'reset label': 'Start over',
   'auth code input label': 'Enter the verification code',
   'invitation input label': 'Paste an invitation code or URL',


### PR DESCRIPTION
### Motivation

The keyboard shortcut of command-delete to delete an item has no confirmation or recovery. Very easy to accidentally delete an item and have no way of getting it back. command-delete is also the shortcut for "delete this line to the beginning of the line" in macOS, so I use it often.

### Details

- [x] changed shortcut to command-shift-delete
- [x] added a confirmation dialog box copying from the rename object pattern

### Visuals

https://github.com/dxos/dxos/assets/27258/1cd35766-8b26-487a-974b-ffb7974cb718

