### PR TITLE
fix(react-ui-navtree): Fix ternary expression typo

### DIFF
--- a/packages/ui/react-ui-navtree/src/components/NavTreeItemAction.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItemAction.tsx
@@ -108,7 +108,7 @@ export const NavTreeItemActionDropdownMenu = ({
 export const NavTreeItemActionContextMenu = (
   props: PropsWithChildren<Pick<NavTreeItemActionProps, 'actions' | 'onAction'>>,
 ) => {
-  return (props.actions?.length ?? 0) > 0 ? <>{props.children}</> : <NavTreeItemActionContextMenuImpl {...props} />;
+  return (props.actions?.length ?? 0) > 0 ? <NavTreeItemActionContextMenuImpl {...props} /> : <>{props.children}</>;
 };
 
 const NavTreeItemActionContextMenuImpl = ({


### PR DESCRIPTION
This PR fixes a typo which reversed conditions in a ternary expression, causing the context menu not to render when it needed to.

<img width="435" alt="Screenshot 2024-01-12 at 09 59 40" src="https://github.com/dxos/dxos/assets/855039/e83f93d3-da7d-4ce3-b7e0-c7bf546fe1e8">

<img width="1399" alt="Screenshot 2024-01-12 at 10 12 50" src="https://github.com/dxos/dxos/assets/855039/9037cf16-14ee-4f0d-8ecd-697caebf3416">

