### PR TITLE
fix(react-ui-editor): Don't hide widget buffers

### DIFF
--- a/packages/ui/react-ui-editor/src/themes/default.ts
+++ b/packages/ui/react-ui-editor/src/themes/default.ts
@@ -161,14 +161,6 @@ export const defaultTheme: ThemeStyles = {
   },
 
   //
-  // widgets
-  //
-  '.cm-widgetBuffer': {
-    display: 'none',
-    height: 0,
-  },
-
-  //
   // table
   //
   '.cm-table *': {


### PR DESCRIPTION
Widget buffers are a thing CodeMirror inserts into the editable DOM to prevent a bunch of browser-contenteditable misbehaviors when the cursor is next to uneditable content, such as invisible cursors, weird cursor motion, and IME input weirdly interacting with the widgets. They should not be set to `display: none`.

Issue https://github.com/dxos/dxos/issues/5184