### PR TITLE
fix(plugin-presenter): render documents

### DIFF
--- a/packages/apps/plugins/plugin-github/src/GithubPlugin.tsx
+++ b/packages/apps/plugins/plugin-github/src/GithubPlugin.tsx
@@ -7,7 +7,7 @@ import { effect } from '@preact/signals-react';
 import React, { type RefObject } from 'react';
 
 import { type Node } from '@braneframe/plugin-graph';
-import { isMarkdown, isMarkdownProperties } from '@braneframe/plugin-markdown';
+import { isEditorModel, isMarkdownProperties } from '@braneframe/plugin-markdown';
 import { Folder, type Document } from '@braneframe/types';
 import { type PluginDefinition } from '@dxos/app-framework';
 import { LocalStorageStore } from '@dxos/local-storage';
@@ -90,7 +90,7 @@ export const GithubPlugin = (): PluginDefinition<GithubPluginProvides> => {
                 case 'dxos.org/plugin/github/BindDialog':
                   return isMarkdownProperties(data.properties) ? <UrlDialog properties={data.properties} /> : null;
                 case 'dxos.org/plugin/github/ExportDialog':
-                  return isMarkdown(data.model) ? (
+                  return isEditorModel(data.model) ? (
                     <ExportDialog
                       model={data.model}
                       type={data.type as ExportViewState}
@@ -109,7 +109,7 @@ export const GithubPlugin = (): PluginDefinition<GithubPluginProvides> => {
                   return null;
               }
             case 'menuitem':
-              return isMarkdown(data.model) && isMarkdownProperties(data.properties) && !data.properties.readonly ? (
+              return isEditorModel(data.model) && isMarkdownProperties(data.properties) && !data.properties.readonly ? (
                 <MarkdownActions
                   model={data.model}
                   properties={data.properties}

--- a/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -43,7 +43,7 @@ import {
   type OnChange,
   MarkdownAction,
 } from './types';
-import { getFallbackTitle, isMarkdown, isMarkdownProperties, markdownPlugins } from './util';
+import { getFallbackTitle, isEditorModel, isMarkdownProperties, markdownPlugins } from './util';
 
 // TODO(wittjosiah): This ensures that typed objects are not proxied by deepsignal. Remove.
 // https://github.com/luisherranz/deepsignal/issues/36
@@ -209,7 +209,7 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
                 );
               } else if (
                 'model' in data &&
-                isMarkdown(data.model) &&
+                isEditorModel(data.model) &&
                 'properties' in data &&
                 isMarkdownProperties(data.properties)
               ) {

--- a/packages/apps/plugins/plugin-markdown/src/util.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/util.tsx
@@ -25,16 +25,11 @@ export const __isMarkdown = (object: { [key: string]: any }): object is EditorMo
   }
 };
 
-export const isMarkdown = (data: unknown): data is EditorModel =>
+/** Type-guard for an EditorModel */
+export const isEditorModel = (data: unknown): data is EditorModel =>
   data && typeof data === 'object'
     ? 'id' in data && typeof data.id === 'string' && typeof (data as { [key: string]: any }).text === 'function'
     : false;
-
-export const isMarkdownContent = (data: unknown): data is { content: EditorModel } =>
-  !!data &&
-  typeof data === 'object' &&
-  (data as { [key: string]: any }).content &&
-  isMarkdown((data as { [key: string]: any }).content);
 
 export const isMarkdownPlaceholder = (data: unknown): data is EditorModel =>
   data && typeof data === 'object'

--- a/packages/apps/plugins/plugin-presenter/src/PresenterPlugin.tsx
+++ b/packages/apps/plugins/plugin-presenter/src/PresenterPlugin.tsx
@@ -6,7 +6,7 @@ import { Presentation } from '@phosphor-icons/react';
 import { deepSignal } from 'deepsignal';
 import React from 'react';
 
-import { isMarkdownContent } from '@braneframe/plugin-markdown';
+import { isDocument } from '@braneframe/plugin-markdown';
 import { isStack } from '@braneframe/plugin-stack';
 import { resolvePlugin, type PluginDefinition, parseIntentPlugin, LayoutAction } from '@dxos/app-framework';
 
@@ -77,7 +77,7 @@ export const PresenterPlugin = (): PluginDefinition<PresenterPluginProvides> => 
                 ? { node: <PresenterMain stack={data.active} />, disposition: 'hoist' }
                 : null;
             case 'slide':
-              return isMarkdownContent(data.slide) ? <MarkdownSlideMain slide={data.slide} /> : null;
+              return isDocument(data.slide) ? <MarkdownSlideMain document={data.slide} /> : null;
           }
 
           return null;

--- a/packages/apps/plugins/plugin-presenter/src/components/MarkdownSlideMain.tsx
+++ b/packages/apps/plugins/plugin-presenter/src/components/MarkdownSlideMain.tsx
@@ -11,7 +11,8 @@ import { Container, Slide } from './Markdown';
 export const MarkdownSlideMain: FC<{ document: DocumentType }> = ({ document }) => {
   return (
     <Container>
-      <Slide content={document.content.text} />;
+      {/* TODO: content is a YText object, but should be a string. Update after automerge migration. */}
+      <Slide content={document.content.content as any} />;
     </Container>
   );
 };

--- a/packages/apps/plugins/plugin-presenter/src/components/MarkdownSlideMain.tsx
+++ b/packages/apps/plugins/plugin-presenter/src/components/MarkdownSlideMain.tsx
@@ -4,12 +4,14 @@
 
 import React, { type FC } from 'react';
 
+import { type Document as DocumentType } from '@braneframe/types';
+
 import { Container, Slide } from './Markdown';
 
-export const MarkdownSlideMain: FC<{ slide: any }> = ({ slide }) => {
+export const MarkdownSlideMain: FC<{ document: DocumentType }> = ({ document }) => {
   return (
     <Container>
-      <Slide content={String(slide.content)} />;
+      <Slide content={document.content.text} />;
     </Container>
   );
 };


### PR DESCRIPTION
The type check for Markdown content changed, breaking Documents in presenter plugin. I added an alternative type check, but I'm sure it can be improved.

fixes https://github.com/dxos/dxos/issues/5194