### PR TITLE
feat(plugin-help): Display shortcuts list on FRE pages

### DIFF
--- a/packages/apps/plugins/plugin-help/src/HelpPlugin.tsx
+++ b/packages/apps/plugins/plugin-help/src/HelpPlugin.tsx
@@ -10,7 +10,7 @@ import { type Step } from 'react-joyride';
 import { LayoutAction, type PluginDefinition, parseIntentPlugin, resolvePlugin } from '@dxos/app-framework';
 import { LocalStorageStore } from '@dxos/local-storage';
 
-import { HelpContextProvider, ShortcutsDialogContent, ShortcutsHints } from './components';
+import { HelpContextProvider, ShortcutsDialogContent, ShortcutsHints, ShortcutsList } from './components';
 import meta, { HELP_PLUGIN } from './meta';
 import translations from './translations';
 import { HelpAction, type HelpPluginProvides } from './types';
@@ -85,6 +85,8 @@ export const HelpPlugin = ({ steps = [] }: HelpPluginOptions): PluginDefinition<
               return settings.values.showHints ? (
                 <ShortcutsHints onClose={() => (settings.values.showHints = false)} />
               ) : null;
+            case 'keyshortcuts':
+              return settings.values.showHints ? <ShortcutsList /> : null;
           }
 
           switch (data.component) {

--- a/packages/apps/plugins/plugin-help/src/components/Shortcuts/Key.tsx
+++ b/packages/apps/plugins/plugin-help/src/components/Shortcuts/Key.tsx
@@ -1,0 +1,21 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import React from 'react';
+
+import { keySymbols } from '@dxos/keyboard';
+
+import { shortcutKey } from './styles';
+
+export const Key = ({ binding }: { binding: string }) => {
+  return (
+    <span role='term' className='inline-flex gap-1' aria-label={binding} id={binding}>
+      {keySymbols(binding).map((c, i) => (
+        <span key={i} className={shortcutKey}>
+          {c}
+        </span>
+      ))}
+    </span>
+  );
+};

--- a/packages/apps/plugins/plugin-help/src/components/Shortcuts/ShortcutsDialog.tsx
+++ b/packages/apps/plugins/plugin-help/src/components/Shortcuts/ShortcutsDialog.tsx
@@ -4,56 +4,20 @@
 
 import React from 'react';
 
-import { type Label } from '@dxos/app-graph';
-import { Keyboard, keySymbols } from '@dxos/keyboard';
 import { Button, Dialog, useTranslation } from '@dxos/react-ui';
 
-import { shortcutKey } from './styles';
+import { ShortcutsList } from './ShortcutsList';
 import { HELP_PLUGIN } from '../../meta';
-
-export const Key = ({ binding }: { binding: string }) => {
-  return (
-    <div className='flex gap-1'>
-      {keySymbols(binding).map((c, i) => (
-        <span key={i} className={shortcutKey}>
-          {c}
-        </span>
-      ))}
-    </div>
-  );
-};
 
 export const ShortcutsDialogContent = () => {
   const { t } = useTranslation(HELP_PLUGIN);
 
-  // TODO(burdon): Factor out.
-  const toString = (label: Label) => (Array.isArray(label) ? t(...label) : label);
-
-  // TODO(burdon): Get shortcuts from TextEditor.
-  const bindings = Keyboard.singleton.getBindings();
-  bindings.sort((a, b) => {
-    return toString(a.data)?.toLowerCase().localeCompare(toString(b.data)?.toLowerCase());
-  });
-
   return (
-    <Dialog.Content classNames={['max-bs-[40rem] md:max-is-[30rem] overflow-hidden']}>
+    <Dialog.Content classNames={'max-bs-[40rem] md:is-auto overflow-hidden'}>
       <Dialog.Title>{t('shortcuts dialog title')}</Dialog.Title>
 
       <div className='grow overflow-y-auto py-2'>
-        <table className='table-fixed border-collapse my-4'>
-          <tbody>
-            {bindings.map((binding, i) => (
-              <tr key={i}>
-                <td className='p-1 w-[120px]'>
-                  <Key binding={binding.shortcut} />
-                </td>
-                <td className='p-1'>
-                  <span className='grow truncate'>{toString(binding.data as Label)}</span>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <ShortcutsList />
       </div>
 
       <Dialog.Close asChild>

--- a/packages/apps/plugins/plugin-help/src/components/Shortcuts/ShortcutsHints.tsx
+++ b/packages/apps/plugins/plugin-help/src/components/Shortcuts/ShortcutsHints.tsx
@@ -10,7 +10,7 @@ import { type KeyBinding, Keyboard } from '@dxos/keyboard';
 import { Button, DensityProvider, useTranslation } from '@dxos/react-ui';
 import { fixedBorder, groupSurface, mx } from '@dxos/react-ui-theme';
 
-import { Key } from './ShortcutsDialog';
+import { Key } from './Key';
 
 export const ShortcutsHints = ({ onClose }: { onClose: () => void }) => {
   const { t } = useTranslation('os');

--- a/packages/apps/plugins/plugin-help/src/components/Shortcuts/ShortcutsList.tsx
+++ b/packages/apps/plugins/plugin-help/src/components/Shortcuts/ShortcutsList.tsx
@@ -1,0 +1,38 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import React, { Fragment } from 'react';
+
+import type { Label } from '@dxos/app-graph';
+import { Keyboard } from '@dxos/keyboard';
+import { useTranslation } from '@dxos/react-ui';
+
+import { Key } from './Key';
+import { HELP_PLUGIN } from '../../meta';
+
+export const ShortcutsList = () => {
+  const { t } = useTranslation(HELP_PLUGIN);
+  const bindings = Keyboard.singleton.getBindings();
+
+  // TODO(burdon): Factor out.
+  const toString = (label: Label) => (Array.isArray(label) ? t(...label) : label);
+
+  // TODO(burdon): Get shortcuts from TextEditor.
+  bindings.sort((a, b) => {
+    return toString(a.data)?.toLowerCase().localeCompare(toString(b.data)?.toLowerCase());
+  });
+
+  return (
+    <dl className='is-fit grid grid-cols-[fit-content(100%)_fit-content(100%)] gap-2 mlb-4'>
+      {bindings.map((binding, i) => (
+        <Fragment key={i}>
+          <Key binding={binding.shortcut} />
+          <span role='definition' aria-labelledby={binding.shortcut} className='truncate'>
+            {toString(binding.data as Label)}
+          </span>
+        </Fragment>
+      ))}
+    </dl>
+  );
+};

--- a/packages/apps/plugins/plugin-help/src/components/Shortcuts/ShortcutsSection.tsx
+++ b/packages/apps/plugins/plugin-help/src/components/Shortcuts/ShortcutsSection.tsx
@@ -1,0 +1,16 @@
+//
+// Copyright 2024 DXOS.org
+//
+import React from 'react';
+
+import { descriptionText } from '@dxos/react-ui-theme';
+
+import { ShortcutsList } from './ShortcutsList';
+
+export const ShortcutsSection = () => {
+  return (
+    <section className={descriptionText}>
+      <ShortcutsList />
+    </section>
+  );
+};

--- a/packages/apps/plugins/plugin-help/src/components/Shortcuts/index.ts
+++ b/packages/apps/plugins/plugin-help/src/components/Shortcuts/index.ts
@@ -4,3 +4,6 @@
 
 export * from './ShortcutsDialog';
 export * from './ShortcutsHints';
+export * from './ShortcutsList';
+export * from './ShortcutsSection';
+export * from './Key';

--- a/packages/apps/plugins/plugin-help/src/components/Shortcuts/styles.ts
+++ b/packages/apps/plugins/plugin-help/src/components/Shortcuts/styles.ts
@@ -5,6 +5,6 @@
 import { mx } from '@dxos/react-ui-theme';
 
 export const shortcutKey = mx(
-  'inline-flex w-[24px] h-[24px] justify-center items-center text-xs',
+  'inline-flex min-is-[24px] bs-[24px] pli-0.5 justify-center items-center text-xs',
   'rounded bg-neutral-100 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700',
 );

--- a/packages/apps/plugins/plugin-layout/src/components/ContentEmpty.tsx
+++ b/packages/apps/plugins/plugin-layout/src/components/ContentEmpty.tsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 
+import { Surface } from '@dxos/app-framework';
 import { useTranslation } from '@dxos/react-ui';
 import { descriptionText, mx } from '@dxos/react-ui-theme';
 
@@ -17,15 +18,18 @@ export const ContentEmpty = () => {
       className='min-bs-screen is-full flex items-center justify-center p-8'
       data-testid='layoutPlugin.firstRunMessage'
     >
-      <p
-        role='alert'
-        className={mx(
-          descriptionText,
-          'border border-dashed border-neutral-400/50 rounded-lg flex items-center justify-center p-8 font-normal text-lg',
-        )}
-      >
-        {t('first run message')}
-      </p>
+      <div role='none' className='grid place-items-center grid-rows-[min-content_min-content]'>
+        <p
+          role='alert'
+          className={mx(
+            descriptionText,
+            'place-self-stretch border border-dashed border-neutral-400/50 rounded-lg text-center p-8 font-normal text-lg',
+          )}
+        >
+          {t('first run message')}
+        </p>
+        <Surface role='keyshortcuts' />
+      </div>
     </div>
   );
 };

--- a/packages/apps/plugins/plugin-layout/src/components/MainLayout.tsx
+++ b/packages/apps/plugins/plugin-layout/src/components/MainLayout.tsx
@@ -117,14 +117,6 @@ export const MainLayout = ({ fullscreen, showHintsFooter, showComplementarySideb
           <Surface role='status' limit={1} />
         </div>
 
-        {/* Help hints. */}
-        {/* TODO(burdon): Make surface roles/names fully-qualified. */}
-        {showHintsFooter && (
-          <div className='fixed bottom-0 left-0 right-0 h-[32px] z-[1] flex justify-center'>
-            <Surface role='hints' limit={1} />
-          </div>
-        )}
-
         {/* Global popovers. */}
         <Popover.Portal>
           <Popover.Content

--- a/packages/apps/plugins/plugin-space/src/components/SpaceMain.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/SpaceMain.tsx
@@ -5,7 +5,7 @@
 import React, { useEffect } from 'react';
 
 import { useGraph } from '@braneframe/plugin-graph';
-import { LayoutAction, parseIntentPlugin, useResolvePlugin } from '@dxos/app-framework';
+import { LayoutAction, parseIntentPlugin, Surface, useResolvePlugin } from '@dxos/app-framework';
 import { type Space } from '@dxos/react-client/echo';
 import { useTranslation } from '@dxos/react-ui';
 import { baseSurface, descriptionText, mx } from '@dxos/react-ui-theme';
@@ -37,15 +37,18 @@ export const SpaceMain = ({ space }: { space: Space }) => {
       className={mx(baseSurface, 'min-bs-screen is-full flex items-center justify-center p-8')}
       data-testid='composer.firstRunMessage'
     >
-      <p
-        role='alert'
-        className={mx(
-          descriptionText,
-          'border border-dashed border-neutral-400/50 rounded-lg flex items-center justify-center p-8 font-normal text-lg',
-        )}
-      >
-        {t('first run message')}
-      </p>
+      <div role='none' className='grid place-items-center grid-rows-[min-content_min-content]'>
+        <p
+          role='alert'
+          className={mx(
+            descriptionText,
+            'place-self-stretch border border-dashed border-neutral-400/50 rounded-lg text-center p-8 font-normal text-lg',
+          )}
+        >
+          {t('first run message')}
+        </p>
+        <Surface role='keyshortcuts' />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Resolves #5143. Resolves #5247.

This PR removes the keyboard shortcuts `hints` role from `MainLayout` and adds a `keyshortcuts` role to FRE pages where `HelpPlugin` renders the same `ShortcutsList` it renders in its dialog.

<img width="1139" alt="Screenshot 2024-01-17 at 17 09 56" src="https://github.com/dxos/dxos/assets/855039/6ac1ae63-f972-4c50-8339-9cc816a302c9">
