### PR TITLE
fix: Polish NavBar and NavTree content

### DIFF
--- a/packages/apps/plugins/plugin-navtree/src/components/NavBarStart.tsx
+++ b/packages/apps/plugins/plugin-navtree/src/components/NavBarStart.tsx
@@ -47,13 +47,13 @@ export const NavBarStart = ({ activeNode, popoverAnchorId }: { activeNode: Node;
             <>
               <Breadcrumb.ListItem>
                 <Breadcrumb.Link asChild onClick={() => activeNode.parent && handleActivate(activeNode.parent)}>
-                  <Button variant='ghost' classNames='shrink text-sm pli-1 -mli-1 gap-1 overflow-hidden'>
+                  <Button variant='ghost' classNames='hidden sm:flex shrink text-sm pli-1 -mli-1 gap-1 overflow-hidden'>
                     {activeNode.parent.icon && <activeNode.parent.icon className='shrink-0' />}
                     <span className='min-is-0  flex-1 truncate'>{getTreeItemLabel(activeNode.parent, t)}</span>
                   </Button>
                 </Breadcrumb.Link>
               </Breadcrumb.ListItem>
-              <Breadcrumb.Separator />
+              <Breadcrumb.Separator classNames='hidden sm:flex' />
             </>
           )}
           <Breadcrumb.ListItem>

--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -8,7 +8,6 @@ import {
   FloppyDisk,
   FolderPlus,
   PencilSimpleLine,
-  Planet,
   Plus,
   Placeholder,
   Trash,
@@ -175,7 +174,6 @@ export const spaceToGraphNode = ({
       id: space.key.toHex(),
       label: isPersonalSpace ? ['personal space label', { ns: SPACE_PLUGIN }] : getSpaceDisplayName(space),
       description: space.properties.description,
-      icon: (props) => <Planet {...props} />,
       data: space,
       ...partials,
       properties: {


### PR DESCRIPTION
Resolves #5141. Resolves #5240.

This PR hides the parent space in the `NavBarStart` in `sm` breakpoints, and also removes the icon for Personal Space.

<img width="346" alt="Screenshot 2024-01-18 at 17 28 59" src="https://github.com/dxos/dxos/assets/855039/bb217086-a7d8-46d7-b673-1f524b20990a">
<img width="341" alt="Screenshot 2024-01-18 at 17 28 52" src="https://github.com/dxos/dxos/assets/855039/677294c8-7584-4e7b-b117-6744c4b74c2e">
