### PR TITLE
fix: disable CircleCI ramdisk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,16 +92,13 @@ jobs:
 
     # Run the job on ramdisk for optimal performance.
     # https://support.circleci.com/hc/en-us/articles/360056323651-How-to-optimize-the-restore-cache-step-for-Node-projects
-    working_directory: /mnt/ramdisk/work
-
     steps:
-      - *ram_cache_configure
       - checkout
-      - *ram_cache_restore
+      - *cache_restore
       - run: pnpm set verify-store-integrity false
       - run: pnpm install --prefer-offline
       - run: pnpm install-playwright
-      - *ram_cache_save
+      - *cache_save
       - nx/set-shas
       - run: pnpm check-dependencies
       - run: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD --target=lint


### PR DESCRIPTION
### Motivation / Background

Ramdisk counts against CircleCI memory limit. CircleCI documentation suggests that disk IO contention may slow down builds, which page cache doesn't help with apparently.
