### PR TITLE
chore: Upgrade `date-fns`

### DIFF
--- a/packages/apps/plugins/plugin-debug/package.json
+++ b/packages/apps/plugins/plugin-debug/package.json
@@ -42,7 +42,7 @@
     "@dxos/util": "workspace:*",
     "@faker-js/faker": "^8.3.1",
     "@preact/signals-react": "^1.3.6",
-    "date-fns": "^2.29.3",
+    "date-fns": "^3.3.1",
     "lodash.get": "^4.4.2",
     "react-json-tree": "^0.18.0",
     "react-syntax-highlighter": "^15.5.0"

--- a/packages/apps/plugins/plugin-inbox/package.json
+++ b/packages/apps/plugins/plugin-inbox/package.json
@@ -27,7 +27,7 @@
     "@dxos/display-name": "workspace:*",
     "@dxos/react-client": "workspace:*",
     "@dxos/util": "workspace:*",
-    "date-fns": "^2.29.3",
+    "date-fns": "^3.3.1",
     "lodash.get": "^4.4.2"
   },
   "devDependencies": {

--- a/packages/apps/plugins/plugin-navtree/package.json
+++ b/packages/apps/plugins/plugin-navtree/package.json
@@ -36,7 +36,7 @@
     "@dxos/react-ui-searchlist": "workspace:*",
     "@dxos/util": "workspace:*",
     "@preact/signals-react": "^1.3.6",
-    "date-fns": "^2.29.3",
+    "date-fns": "^3.3.1",
     "deepsignal": "1.4.0-shallow.0",
     "lodash.get": "^4.4.2"
   },

--- a/packages/apps/plugins/plugin-navtree/src/components/VersionInfo.tsx
+++ b/packages/apps/plugins/plugin-navtree/src/components/VersionInfo.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import formatDistance from 'date-fns/formatDistance';
+import { formatDistance } from 'date-fns/formatDistance';
 import React, { type FC } from 'react';
 
 import { type Config } from '@dxos/react-client';

--- a/packages/apps/plugins/plugin-thread/package.json
+++ b/packages/apps/plugins/plugin-thread/package.json
@@ -34,7 +34,7 @@
     "@dxos/react-ui-theme": "workspace:*",
     "@dxos/util": "workspace:*",
     "@preact/signals-react": "^1.3.6",
-    "date-fns": "^2.29.3",
+    "date-fns": "^3.3.1",
     "deepsignal": "1.4.0-shallow.0",
     "lodash.get": "^4.4.2"
   },

--- a/packages/apps/plugins/plugin-thread/src/components/Chat/ChatContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/Chat/ChatContainer.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import differenceInSeconds from 'date-fns/differenceInSeconds';
+import { differenceInSeconds } from 'date-fns/differenceInSeconds';
 import React from 'react';
 
 import { type Thread as ThreadType, Message as MessageType } from '@braneframe/types';

--- a/packages/apps/plugins/plugin-thread/src/components/MessageCard/MessageCard.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/MessageCard/MessageCard.tsx
@@ -3,7 +3,7 @@
 //
 
 import { UserCircle, X } from '@phosphor-icons/react';
-import format from 'date-fns/format';
+import { format } from 'date-fns/format';
 import React, { forwardRef, useId } from 'react';
 
 import { type Message as MessageType } from '@braneframe/types';

--- a/packages/apps/plugins/plugin-thread/src/testing/testing.ts
+++ b/packages/apps/plugins/plugin-thread/src/testing/testing.ts
@@ -3,7 +3,7 @@
 //
 
 import { faker } from '@faker-js/faker';
-import sub from 'date-fns/sub';
+import { sub } from 'date-fns/sub';
 
 import { Thread as ThreadType, Message as MessageType } from '@braneframe/types';
 import { PublicKey } from '@dxos/react-client';

--- a/packages/core/agent/package.json
+++ b/packages/core/agent/package.json
@@ -44,7 +44,7 @@
     "@dxos/rpc": "workspace:*",
     "@dxos/util": "workspace:*",
     "@dxos/websocket-rpc": "workspace:*",
-    "date-fns": "^2.29.3",
+    "date-fns": "^3.3.1",
     "express": "^4.17.1",
     "hnswlib-node": "^1.4.2",
     "isomorphic-ws": "^4.0.1",

--- a/packages/devtools/cli/package.json
+++ b/packages/devtools/cli/package.json
@@ -55,7 +55,7 @@
     "@octokit/core": "^4.0.4",
     "chalk": "^4.1.0",
     "cli-progress": "^3.11.2",
-    "date-fns": "^2.29.3",
+    "date-fns": "^3.3.1",
     "do-wrapper": "^4.5.1",
     "fs-extra": "^8.1.0",
     "get-folder-size": "^2.0.1",

--- a/packages/devtools/devtools/package.json
+++ b/packages/devtools/devtools/package.json
@@ -45,7 +45,7 @@
     "@types/bytes": "^3.1.1",
     "bytes": "^3.1.2",
     "change-case": "^4.1.2",
-    "date-fns": "^2.29.3",
+    "date-fns": "^3.3.1",
     "deepsignal": "1.4.0-shallow.0",
     "flame-chart-js": "^2.3.1",
     "isomorphic-ws": "^4.0.1",

--- a/packages/devtools/devtools/src/components/PropertiesTable.tsx
+++ b/packages/devtools/devtools/src/components/PropertiesTable.tsx
@@ -3,8 +3,8 @@
 //
 
 import { sentenceCase } from 'change-case';
-import format from 'date-fns/format';
-import formatDistance from 'date-fns/formatDistance';
+import { format } from 'date-fns/format';
+import { formatDistance } from 'date-fns/formatDistance';
 import React, { type FC, type ReactNode } from 'react';
 
 import { type PublicKey } from '@dxos/keys';

--- a/packages/experimental/labs-functions/package.json
+++ b/packages/experimental/labs-functions/package.json
@@ -43,7 +43,7 @@
     "chess.js": "1.0.0-alpha.0",
     "cross-fetch": "^3.1.5",
     "csv-parse": "^5.3.6",
-    "date-fns": "^2.29.3",
+    "date-fns": "^3.3.1",
     "discord.js": "^14.14.1",
     "email-addresses": "^5.0.0",
     "faiss-node": "^0.5.1",

--- a/packages/experimental/labs-functions/src/functions/calendar/handler.ts
+++ b/packages/experimental/labs-functions/src/functions/calendar/handler.ts
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import sub from 'date-fns/sub';
+import { sub } from 'date-fns/sub';
 import { google } from 'googleapis';
 import path from 'node:path';
 import process from 'node:process';

--- a/packages/experimental/labs-functions/src/functions/email/imap-processor.ts
+++ b/packages/experimental/labs-functions/src/functions/email/imap-processor.ts
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import sub from 'date-fns/sub';
+import { sub } from 'date-fns/sub';
 import { type Config as ImapConfig } from 'imap';
 import imaps, { type Message as ImapMessage, type ImapSimple } from 'imap-simple';
 import { simpleParser, type EmailAddress } from 'mailparser';

--- a/packages/ui/react-ui-table/package.json
+++ b/packages/ui/react-ui-table/package.json
@@ -29,7 +29,7 @@
     "@radix-ui/react-use-controllable-state": "^1.0.0",
     "@tanstack/react-table": "^8.9.3",
     "@tanstack/react-virtual": "^3.0.1",
-    "date-fns": "^2.29.3"
+    "date-fns": "^3.3.1"
   },
   "devDependencies": {
     "@dxos/react-ui-theme": "workspace:*",

--- a/packages/ui/react-ui-table/src/helpers.tsx
+++ b/packages/ui/react-ui-table/src/helpers.tsx
@@ -12,8 +12,8 @@ import {
   type ColumnHelper,
   type CellContext,
 } from '@tanstack/react-table';
-import format from 'date-fns/format';
-import formatDistanceToNow from 'date-fns/formatDistanceToNow';
+import { format } from 'date-fns/format';
+import { formatDistanceToNow } from 'date-fns/formatDistanceToNow';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { type PublicKey } from '@dxos/keys';

--- a/packages/ui/react-ui/package.json
+++ b/packages/ui/react-ui/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-toolbar": "^1.0.3",
     "@radix-ui/react-tooltip": "^1.0.5",
     "@radix-ui/react-use-controllable-state": "^1.0.0",
+    "date-fns": "^3.3.1",
     "i18next": "^21.10.0",
     "jdenticon": "^3.2.0",
     "keyborg": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1058,8 +1058,8 @@ importers:
         specifier: ^1.3.6
         version: 1.3.6(react@18.2.0)
       date-fns:
-        specifier: ^2.29.3
-        version: 2.29.3
+        specifier: ^3.3.1
+        version: 3.3.1
       lodash.get:
         specifier: ^4.4.2
         version: 4.4.2
@@ -1563,8 +1563,8 @@ importers:
         specifier: workspace:*
         version: link:../../../common/util
       date-fns:
-        specifier: ^2.29.3
-        version: 2.29.3
+        specifier: ^3.3.1
+        version: 3.3.1
       lodash.get:
         specifier: ^4.4.2
         version: 4.4.2
@@ -2087,8 +2087,8 @@ importers:
         specifier: ^1.3.6
         version: 1.3.6(react@18.2.0)
       date-fns:
-        specifier: ^2.29.3
-        version: 2.29.3
+        specifier: ^3.3.1
+        version: 3.3.1
       deepsignal:
         specifier: 1.4.0-shallow.0
         version: 1.4.0-shallow.0(react@18.2.0)
@@ -3086,8 +3086,8 @@ importers:
         specifier: ^1.3.6
         version: 1.3.6(react@18.2.0)
       date-fns:
-        specifier: ^2.29.3
-        version: 2.29.3
+        specifier: ^3.3.1
+        version: 3.3.1
       deepsignal:
         specifier: 1.4.0-shallow.0
         version: 1.4.0-shallow.0(react@18.2.0)
@@ -4475,8 +4475,8 @@ importers:
         specifier: workspace:*
         version: link:../mesh/websocket-rpc
       date-fns:
-        specifier: ^2.29.3
-        version: 2.29.3
+        specifier: ^3.3.1
+        version: 3.3.1
       express:
         specifier: ^4.17.1
         version: 4.18.2
@@ -5886,8 +5886,8 @@ importers:
         specifier: ^3.11.2
         version: 3.12.0
       date-fns:
-        specifier: ^2.29.3
-        version: 2.29.3
+        specifier: ^3.3.1
+        version: 3.3.1
       do-wrapper:
         specifier: ^4.5.1
         version: 4.5.1
@@ -6060,8 +6060,8 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2
       date-fns:
-        specifier: ^2.29.3
-        version: 2.29.3
+        specifier: ^3.3.1
+        version: 3.3.1
       deepsignal:
         specifier: 1.4.0-shallow.0
         version: 1.4.0-shallow.0(react@18.2.0)
@@ -6671,8 +6671,8 @@ importers:
         specifier: ^5.3.6
         version: 5.5.2
       date-fns:
-        specifier: ^2.29.3
-        version: 2.29.3
+        specifier: ^3.3.1
+        version: 3.3.1
       discord.js:
         specifier: ^14.14.1
         version: 14.14.1
@@ -8206,6 +8206,9 @@ importers:
       '@radix-ui/react-use-controllable-state':
         specifier: ^1.0.0
         version: 1.0.1(@types/react@18.0.21)(react@18.2.0)
+      date-fns:
+        specifier: ^3.3.1
+        version: 3.3.1
       i18next:
         specifier: ^21.10.0
         version: 21.10.0
@@ -8784,8 +8787,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(react-dom@18.2.0)(react@18.2.0)
       date-fns:
-        specifier: ^2.29.3
-        version: 2.29.3
+        specifier: ^3.3.1
+        version: 3.3.1
     devDependencies:
       '@dxos/storybook-utils':
         specifier: workspace:*
@@ -12076,6 +12079,12 @@ packages:
     dependencies:
       regenerator-runtime: 0.14.0
     dev: true
+
+  /@babel/runtime@7.23.8:
+    resolution: {integrity: sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.1
 
   /@babel/template@7.20.7:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
@@ -25105,7 +25114,7 @@ packages:
     hasBin: true
     dependencies:
       chalk: 4.1.2
-      date-fns: 2.29.3
+      date-fns: 2.30.0
       lodash: 4.17.21
       rxjs: 7.8.1
       shell-quote: 1.7.4
@@ -26003,9 +26012,16 @@ packages:
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
 
-  /date-fns@2.29.3:
-    resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
+  /date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
+    dependencies:
+      '@babel/runtime': 7.23.8
+    dev: true
+
+  /date-fns@3.3.1:
+    resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
+    dev: false
 
   /dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
@@ -38525,7 +38541,7 @@ packages:
   /redux@4.2.0:
     resolution: {integrity: sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==}
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.8
     dev: false
 
   /reflect.getprototypeof@1.0.4:
@@ -38562,10 +38578,13 @@ packages:
   /regenerator-runtime@0.14.0:
     resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
 
+  /regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
   /regenerator-transform@0.15.0:
     resolution: {integrity: sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==}
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.8
 
   /regenerator-transform@0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
@@ -39175,7 +39194,7 @@ packages:
   /rtl-css-js@1.16.1:
     resolution: {integrity: sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==}
     dependencies:
-      '@babel/runtime': 7.22.15
+      '@babel/runtime': 7.23.8
     dev: false
 
   /run-applescript@5.0.0:


### PR DESCRIPTION
`date-fns` v3 is available, and, since it updated packaging to better support ESM and tree shaking, an upgrade seemed prudent ahead of providing some upstream support for it in `react-ui`.