### PR TITLE
fix: nested echo objects update notifications

### DIFF
--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -188,7 +188,7 @@ export class AutomergeObject implements TypedObjectProperties {
 
   [subscribe](callback: (value: AutomergeObject) => void): () => void {
     const listener = (event: DocHandleChangePayload<DocStructure>) => {
-      if (objectIsUpdated(this[base]._id, event)) {
+      if (objectIsUpdated(this._id, event)) {
         callback(this);
       }
     };
@@ -232,7 +232,7 @@ export class AutomergeObject implements TypedObjectProperties {
     this._database = options.db;
     this._docHandle = options.docHandle;
     this._docHandle.on('change', async (event) => {
-      if (objectIsUpdated(this[base]._id, event)) {
+      if (objectIsUpdated(this._id, event)) {
         // Note: We need to notify listeners only after _docHandle initialization with cached _doc.
         //       Without it there was race condition in SpacePlugin on Folder creation.
         //       Folder was being accessed during bind process before _docHandle was initialized and after _doc was set to undefined.
@@ -603,6 +603,7 @@ const isValidKey = (key: string | symbol) => {
     key === 'toString' ||
     key === 'toJSON' ||
     key === 'id' ||
+    key === '_id' ||
     key === '__meta' ||
     key === '__schema' ||
     key === '__typename' ||

--- a/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-object.ts
@@ -188,7 +188,7 @@ export class AutomergeObject implements TypedObjectProperties {
 
   [subscribe](callback: (value: AutomergeObject) => void): () => void {
     const listener = (event: DocHandleChangePayload<DocStructure>) => {
-      if (objectIsUpdated(this._id, event)) {
+      if (objectIsUpdated(this[base]._id, event)) {
         callback(this);
       }
     };
@@ -232,7 +232,7 @@ export class AutomergeObject implements TypedObjectProperties {
     this._database = options.db;
     this._docHandle = options.docHandle;
     this._docHandle.on('change', async (event) => {
-      if (objectIsUpdated(this._id, event)) {
+      if (objectIsUpdated(this[base]._id, event)) {
         // Note: We need to notify listeners only after _docHandle initialization with cached _doc.
         //       Without it there was race condition in SpacePlugin on Folder creation.
         //       Folder was being accessed during bind process before _docHandle was initialized and after _doc was set to undefined.

--- a/packages/core/echo/echo-schema/src/object/subscription.test.ts
+++ b/packages/core/echo/echo-schema/src/object/subscription.test.ts
@@ -83,6 +83,18 @@ describe('create subscription', () => {
       task.nested.title = 'New title';
       expect(counter.value).to.equal(2);
     });
+
+    test('updates for array objects', async () => {
+      const { db } = await createDatabase();
+      const task = new Expando({ array: ['Test value'] });
+      db.add(task);
+
+      const counter = createUpdateCounter(task);
+
+      expect(counter.value).to.equal(1);
+      task.array[0] = 'New value';
+      expect(counter.value).to.equal(2);
+    });
   });
 });
 

--- a/packages/core/echo/echo-schema/src/object/subscription.test.ts
+++ b/packages/core/echo/echo-schema/src/object/subscription.test.ts
@@ -9,69 +9,88 @@ import { describe, test } from '@dxos/test';
 
 import { createSubscription } from './subscription';
 import { Expando } from './typed-object';
-import { createDatabase } from '../testing';
+import { createDatabase, testWithAutomerge } from '../testing';
 
 describe('create subscription', () => {
-  test('updates are propagated', async () => {
-    const { db } = await createDatabase();
-    const task = new Expando();
-    db.add(task);
+  testWithAutomerge(() => {
+    test('updates are propagated', async () => {
+      const { db } = await createDatabase();
+      const task = new Expando();
+      db.add(task);
 
-    let counter = 0;
-    const selection = createSubscription(() => {
-      counter++;
+      const counter = createUpdateCounter(task);
+
+      task.title = 'Test title';
+      expect(counter.value).to.equal(2);
+
+      task.title = 'Test title revision';
+      expect(counter.value).to.equal(3);
     });
-    selection.update([task]);
 
-    task.title = 'Test title';
-    expect(counter).to.equal(2);
+    test('updates are synchronous', async () => {
+      const { db } = await createDatabase();
+      const task = new Expando();
+      db.add(task);
 
-    task.title = 'Test title revision';
-    expect(counter).to.equal(3);
-  });
+      const actions: string[] = [];
+      const selection = createSubscription(() => {
+        actions.push('update');
+      });
+      selection.update([task]);
+      // Initial update caused by changed selection.
+      expect(actions).to.deep.equal(['update']);
 
-  test('updates are synchronous', async () => {
-    const { db } = await createDatabase();
-    const task = new Expando();
-    db.add(task);
+      actions.push('before');
+      task.title = 'Test title';
+      actions.push('after');
 
-    const actions: string[] = [];
-    const selection = createSubscription(() => {
-      actions.push('update');
+      // NOTE: This order is required for input components in react to function properly when directly bound to ECHO objects.
+      expect(actions).to.deep.equal(['update', 'before', 'update', 'after']);
     });
-    selection.update([task]);
-    // Initial update caused by changed selection.
-    expect(actions).to.deep.equal(['update']);
 
-    actions.push('before');
-    task.title = 'Test title';
-    actions.push('after');
+    test('latest value is available in subscription', async () => {
+      const { db } = await createDatabase();
+      const task = new Expando();
+      db.add(task);
 
-    // NOTE: This order is required for input components in react to function properly when directly bound to ECHO objects.
-    expect(actions).to.deep.equal(['update', 'before', 'update', 'after']);
-  });
+      let counter = 0;
+      const title = new Trigger<string>();
+      const selection = createSubscription(() => {
+        if (counter === 1) {
+          title.wake(task.title);
+        }
+        counter++;
+      });
+      selection.update([task]);
 
-  test('latest value is available in subscription', async () => {
-    const { db } = await createDatabase();
-    const task = new Expando();
-    db.add(task);
-
-    let counter = 0;
-    const title = new Trigger<string>();
-    const selection = createSubscription(() => {
-      if (counter === 1) {
-        title.wake(task.title);
-      }
-      counter++;
+      task.title = 'Test title';
+      expect(await title.wait()).to.equal('Test title');
     });
-    selection.update([task]);
 
-    task.title = 'Test title';
-    expect(await title.wait()).to.equal('Test title');
-  });
+    test('accepts arbitrary selection', async () => {
+      const selection = createSubscription(() => {});
+      selection.update(['example', null, -1]);
+    });
 
-  test('accepts arbitrary selection', async () => {
-    const selection = createSubscription(() => {});
-    selection.update(['example', null, -1]);
+    test('updates for nested objects', async () => {
+      const { db } = await createDatabase();
+      const task = new Expando({ nested: { title: 'Test title' } });
+      db.add(task);
+
+      const counter = createUpdateCounter(task);
+
+      expect(counter.value).to.equal(1);
+      task.nested.title = 'New title';
+      expect(counter.value).to.equal(2);
+    });
   });
 });
+
+const createUpdateCounter = (object: any) => {
+  const counter = { value: 0 };
+  const selection = createSubscription(() => {
+    counter.value++;
+  });
+  selection.update([object]);
+  return counter;
+};

--- a/packages/core/echo/echo-schema/src/object/typed-object.ts
+++ b/packages/core/echo/echo-schema/src/object/typed-object.ts
@@ -290,7 +290,7 @@ class TypedObjectImpl<T> extends AbstractEchoObject<DocumentModel> implements Ty
    * @internal
    */
   override _itemUpdate(): void {
-    if (this._updateDepth === 1) {
+    if (this._updateDepth <= 1) {
       super._itemUpdate();
       this._signal.notifyWrite();
     }

--- a/packages/core/echo/echo-schema/src/object/typed-object.ts
+++ b/packages/core/echo/echo-schema/src/object/typed-object.ts
@@ -113,6 +113,8 @@ class TypedObjectImpl<T> extends AbstractEchoObject<DocumentModel> implements Ty
   private _schema?: Schema;
   private readonly _immutable;
 
+  private _updateDepth = 0;
+
   constructor(initialProps?: T, opts?: TypedObjectOptions) {
     super(DocumentModel);
 
@@ -288,8 +290,10 @@ class TypedObjectImpl<T> extends AbstractEchoObject<DocumentModel> implements Ty
    * @internal
    */
   override _itemUpdate(): void {
-    super._itemUpdate();
-    this._signal.notifyWrite();
+    if (this._updateDepth === 1) {
+      super._itemUpdate();
+      this._signal.notifyWrite();
+    }
   }
 
   private _transform(value: any, visitors: ConvertVisitors = {}) {
@@ -404,50 +408,55 @@ class TypedObjectImpl<T> extends AbstractEchoObject<DocumentModel> implements Ty
    * @internal
    */
   private _set(key: string, value: any, meta?: boolean) {
-    this._inBatch(() => {
-      if (value instanceof AbstractEchoObject || value instanceof AutomergeObject) {
-        const ref = this._linkObject(value);
-        this._mutate(this._model.builder().set(key, ref).build(meta));
-      } else if (value instanceof EchoArray) {
-        const values = value.map((item) => {
-          if (item instanceof AbstractEchoObject) {
-            return this._linkObject(item);
-          } else if (isReferenceLike(item)) {
+    try {
+      this._updateDepth++;
+      this._inBatch(() => {
+        if (value instanceof AbstractEchoObject || value instanceof AutomergeObject) {
+          const ref = this._linkObject(value);
+          this._mutate(this._model.builder().set(key, ref).build(meta));
+        } else if (value instanceof EchoArray) {
+          const values = value.map((item) => {
+            if (item instanceof AbstractEchoObject) {
+              return this._linkObject(item);
+            } else if (isReferenceLike(item)) {
+              // Old reference format.
+              return new Reference(item['@id']);
+            } else if (typeof item === 'object' && item !== null && item['@type'] === REFERENCE_TYPE_TAG) {
+              return new Reference(item.itemId, item.protocol, item.host);
+            } else {
+              return item;
+            }
+          });
+          this._mutate(this._model.builder().set(key, OrderedArray.fromValues(values)).build(meta));
+          value._attach(this[base], key);
+        } else if (Array.isArray(value)) {
+          // TODO(dmaretskyi): Make a single mutation.
+          this._mutate(this._model.builder().set(key, OrderedArray.fromValues([])).build(meta));
+          this._get(key, meta).push(...value);
+        } else if (typeof value === 'object' && value !== null) {
+          if (Object.getOwnPropertyNames(value).length === 1 && value['@id']) {
+            // Special case for assigning unresolved references in the form of { '@id': '0x123' }
             // Old reference format.
-            return new Reference(item['@id']);
-          } else if (typeof item === 'object' && item !== null && item['@type'] === REFERENCE_TYPE_TAG) {
-            return new Reference(item.itemId, item.protocol, item.host);
+            this._mutate(this._model.builder().set(key, new Reference(value['@id'])).build(meta));
+          } else if (value['@type'] === REFERENCE_TYPE_TAG) {
+            // Special case for assigning unresolved references in the form of { '@id': '0x123' }
+            this._mutate(
+              this._model.builder().set(key, new Reference(value.itemId, value.protocol, value.host)).build(meta),
+            );
           } else {
-            return item;
+            const sub = this._createProxy({}, key);
+            this._mutate(this._model.builder().set(key, {}).build(meta));
+            for (const [subKey, subValue] of Object.entries(value)) {
+              sub[subKey] = subValue;
+            }
           }
-        });
-        this._mutate(this._model.builder().set(key, OrderedArray.fromValues(values)).build(meta));
-        value._attach(this[base], key);
-      } else if (Array.isArray(value)) {
-        // TODO(dmaretskyi): Make a single mutation.
-        this._mutate(this._model.builder().set(key, OrderedArray.fromValues([])).build(meta));
-        this._get(key, meta).push(...value);
-      } else if (typeof value === 'object' && value !== null) {
-        if (Object.getOwnPropertyNames(value).length === 1 && value['@id']) {
-          // Special case for assigning unresolved references in the form of { '@id': '0x123' }
-          // Old reference format.
-          this._mutate(this._model.builder().set(key, new Reference(value['@id'])).build(meta));
-        } else if (value['@type'] === REFERENCE_TYPE_TAG) {
-          // Special case for assigning unresolved references in the form of { '@id': '0x123' }
-          this._mutate(
-            this._model.builder().set(key, new Reference(value.itemId, value.protocol, value.host)).build(meta),
-          );
         } else {
-          const sub = this._createProxy({}, key);
-          this._mutate(this._model.builder().set(key, {}).build(meta));
-          for (const [subKey, subValue] of Object.entries(value)) {
-            sub[subKey] = subValue;
-          }
+          this._mutate(this._model.builder().set(key, value).build(meta));
         }
-      } else {
-        this._mutate(this._model.builder().set(key, value).build(meta));
-      }
-    });
+      });
+    } finally {
+      this._updateDepth--;
+    }
   }
 
   private _inBatch(cb: () => void) {


### PR DESCRIPTION
### Motivation / Background

Echo object update notification fixes #4882

### Details

* Automerge object update notification was broken because `objectIsUpdated` was getting undefined when accessing `_id`, added the key to the "invalid" key set.
* Automerge wasn't tested with subscriptions, updated the test file. Also added two new tests for nested object and array mutation updates.
* TypedObject nested object update was triggering notification multiple times, fixed with an update depth counter.
