### PR TITLE
fix(react-client): ClientRepeater should not render component until setup is complete

### DIFF
--- a/packages/sdk/react-client/src/testing/ClientRepeater.tsx
+++ b/packages/sdk/react-client/src/testing/ClientRepeater.tsx
@@ -65,7 +65,6 @@ export const ClientRepeater = <P extends RepeatedComponentProps>(props: ClientRe
       const clients = [...Array(count)].map((_) => new Client({ services: testBuilder.createLocal() }));
       await Promise.all(clients.map((client) => client.initialize()));
       types && clients.map((client) => client.spaces.addSchema(types));
-      setClients(clients);
 
       if (createIdentity || createSpace) {
         await Promise.all(clients.map((client) => client.halo.createIdentity()));
@@ -79,6 +78,8 @@ export const ClientRepeater = <P extends RepeatedComponentProps>(props: ClientRe
           clients.slice(1).map((client) => performInvitation({ host: space as SpaceProxy, guest: client.spaces })),
         );
       }
+
+      setClients(clients);
     });
 
     return () => clearTimeout(timeout);


### PR DESCRIPTION
Child components were being rendered to early because clients were being set as soon as clients were initialized even if identity and spaces are being created. This works fine if child components handle the cases where those aren't available, but they shouldn't have to do that since this is a utility for testing intermediate components.
