### PR TITLE
chore(react-ui-theme): Use fork of `colors`

### DIFF
--- a/packages/ui/react-ui-theme/package.json
+++ b/packages/ui/react-ui-theme/package.json
@@ -15,8 +15,8 @@
     "plugin.d.ts"
   ],
   "dependencies": {
+    "@ch-ui/colors": "^0.4.2",
     "@dxos/node-std": "workspace:*",
-    "@fluent-blocks/colors": "^9.2.0",
     "@fontsource-variable/inter": "^5.0.16",
     "@fontsource-variable/jetbrains-mono": "^5.0.16",
     "@tailwindcss/forms": "^0.5.3",

--- a/packages/ui/react-ui-theme/package.json
+++ b/packages/ui/react-ui-theme/package.json
@@ -15,7 +15,7 @@
     "plugin.d.ts"
   ],
   "dependencies": {
-    "@ch-ui/colors": "^0.4.2",
+    "@ch-ui/colors": "^0.4.3",
     "@dxos/node-std": "workspace:*",
     "@fontsource-variable/inter": "^5.0.16",
     "@fontsource-variable/jetbrains-mono": "^5.0.16",

--- a/packages/ui/react-ui-theme/src/config/colors.ts
+++ b/packages/ui/react-ui-theme/src/config/colors.ts
@@ -7,7 +7,7 @@ import {
   paletteShadesFromCurve,
   hex_to_LCH as hexToLch,
   Lab_to_hex as labToHex,
-} from '@fluent-blocks/colors';
+} from '@ch-ui/colors';
 
 export type PaletteConfig = {
   keyColor: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9003,8 +9003,8 @@ importers:
   packages/ui/react-ui-theme:
     dependencies:
       '@ch-ui/colors':
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: ^0.4.3
+        version: 0.4.3
       '@dxos/node-std':
         specifier: workspace:*
         version: link:../../common/node-std
@@ -13479,9 +13479,9 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@ch-ui/colors@0.4.2:
-    resolution: {integrity: sha512-b+7LjFS60RWOdIYJsPd/8Tr2mlia306phiM0Vi3jFAEopJDxhb/fFQV61nWHVgDFNb/jx2eI8TKyZ4WMZEOp9g==}
-    engines: {node: '>=12.0.0', pnpm: '>=7.0.0'}
+  /@ch-ui/colors@0.4.3:
+    resolution: {integrity: sha512-m9trw6Y26vwreTgbaWJTr2XAoyoa7gOP7NRLE42Kp2A1Xhl8Q55KZCnuWJXU1bHMz0ylwJmMq35jUWeoTS4qAQ==}
+    engines: {node: '>=12.0.0'}
     dev: false
 
   /@cnakazawa/watch@1.0.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9002,12 +9002,12 @@ importers:
 
   packages/ui/react-ui-theme:
     dependencies:
+      '@ch-ui/colors':
+        specifier: ^0.4.2
+        version: 0.4.2
       '@dxos/node-std':
         specifier: workspace:*
         version: link:../../common/node-std
-      '@fluent-blocks/colors':
-        specifier: ^9.2.0
-        version: 9.2.0
       '@fontsource-variable/inter':
         specifier: ^5.0.16
         version: 5.0.16
@@ -13479,6 +13479,11 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@ch-ui/colors@0.4.2:
+    resolution: {integrity: sha512-b+7LjFS60RWOdIYJsPd/8Tr2mlia306phiM0Vi3jFAEopJDxhb/fFQV61nWHVgDFNb/jx2eI8TKyZ4WMZEOp9g==}
+    engines: {node: '>=12.0.0', pnpm: '>=7.0.0'}
+    dev: false
+
   /@cnakazawa/watch@1.0.4:
     resolution: {integrity: sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==}
     engines: {node: '>=0.1.95'}
@@ -14698,11 +14703,6 @@ packages:
       '@floating-ui/dom': 1.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
-
-  /@fluent-blocks/colors@9.2.0:
-    resolution: {integrity: sha512-NgK+n4IHRj35ttJjN3UBF8oqk2ZT8xwCdT52+nTXvVSL5yHDtKwQlgb+zvrNFhYNajbqEeqYdj4QA3XSkytLww==}
-    engines: {node: '>=12.0.0 <17.0.0', pnpm: ^7}
     dev: false
 
   /@fluentui/keyboard-keys@9.0.7:


### PR DESCRIPTION
This PR changes the procedural color dependency of `react-ui-theme` to use a package we control. Resolves #5487.