### PR TITLE
chore(react-ui-theme): Upgrade colors to fix a CJS issue

### DIFF
--- a/packages/ui/react-ui-theme/package.json
+++ b/packages/ui/react-ui-theme/package.json
@@ -15,7 +15,7 @@
     "plugin.d.ts"
   ],
   "dependencies": {
-    "@ch-ui/colors": "^0.4.3",
+    "@ch-ui/colors": "^0.4.4",
     "@dxos/node-std": "workspace:*",
     "@fontsource-variable/inter": "^5.0.16",
     "@fontsource-variable/jetbrains-mono": "^5.0.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9003,8 +9003,8 @@ importers:
   packages/ui/react-ui-theme:
     dependencies:
       '@ch-ui/colors':
-        specifier: ^0.4.3
-        version: 0.4.3
+        specifier: ^0.4.4
+        version: 0.4.4
       '@dxos/node-std':
         specifier: workspace:*
         version: link:../../common/node-std
@@ -13479,8 +13479,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@ch-ui/colors@0.4.3:
-    resolution: {integrity: sha512-m9trw6Y26vwreTgbaWJTr2XAoyoa7gOP7NRLE42Kp2A1Xhl8Q55KZCnuWJXU1bHMz0ylwJmMq35jUWeoTS4qAQ==}
+  /@ch-ui/colors@0.4.4:
+    resolution: {integrity: sha512-x1RGeg+Kxc5wPLI6Mn7eqTuG8LEbiHRbcuWzzTGV6VjcqPq6U5hfhVSso5UNcPfKVT2EMkW5l88r3RaX2zdmpw==}
     engines: {node: '>=12.0.0'}
     dev: false
 


### PR DESCRIPTION
This PR follows-up on #5525, which used a fork of `colors` but that fork did not provide CJS which is needed for the `nx` dev server. Upgrading fixes the issue.