### PR TITLE
fix(plugin-layout): complementary sidebar empty when nothing active

### DIFF
--- a/packages/apps/plugins/plugin-layout/src/LayoutPlugin.tsx
+++ b/packages/apps/plugins/plugin-layout/src/LayoutPlugin.tsx
@@ -250,6 +250,9 @@ export const LayoutPlugin = ({
                   sidebar: {
                     data: { graph, activeId: location.active, popoverAnchorId: layout.values.popoverAnchorId },
                   },
+                  context: {
+                    data: { component: `${LAYOUT_PLUGIN}/ContextView` },
+                  },
                   main: {
                     data: location.active
                       ? { active: location.active }


### PR DESCRIPTION
Addendum to fix for #5159

Ensure that `context` surface is always provided a component when the layout is rendered.