### PR TITLE
fix(client): only use worker client services if shared worker is available

### DIFF
--- a/packages/sdk/client/src/services/client-services-factory.tsx
+++ b/packages/sdk/client/src/services/client-services-factory.tsx
@@ -61,5 +61,5 @@ export const createClientServices = (
     }
   }
 
-  return createWorker ? fromWorker(config, { createWorker }) : fromHost(config);
+  return createWorker && typeof SharedWorker !== 'undefined' ? fromWorker(config, { createWorker }) : fromHost(config);
 };


### PR DESCRIPTION
This PR ensures that if `SharedWorker` is not available that the client falls back to monolithic mode. This should only affect Android devices, worker mode appears functional now on iOS 🎉

