### PR TITLE
fix(plugin-markdown): `EditorMain` grid layout

### DIFF
--- a/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
@@ -75,39 +75,34 @@ const EditorMain = ({ comments, toolbar, extensions: _extensions, ...props }: Ed
       )}
       <div
         role='none'
-        className='overflow-y-auto overscroll-auto scroll-smooth overflow-anchored after:block after:is-px after:bs-px after:overflow-anchor'
+        className={mx(
+          'is-full overflow-y-auto overflow-anchored after:block after:is-px after:bs-px after:overflow-anchor after:-mbs-px',
+        )}
       >
-        <div
-          role='none'
-          className={mx(
-            attentionSurface,
-            textBlockWidth,
-            'pli-0.5 -mbs-0.5 md:border-is md:border-ie separator-separator',
-          )}
-        >
-          <MarkdownEditor
-            ref={editorRef}
-            autoFocus
-            placeholder={t('editor placeholder')}
-            extensions={extensions}
-            slots={{
-              root: {
-                className: focusRing,
-                'data-testid': 'composer.markdownRoot',
-              } as HTMLAttributes<HTMLDivElement>,
-              editor: {
-                className: mx(
-                  'is-full min-bs-[calc(100%-2rem)] pli-2 sm:pli-6 md:pli-8 py-2 pbe-[50dvh]',
-                  !toolbar && 'border-bs',
-                ),
-              },
-              content: {
-                className: focusRing,
-              },
-            }}
-            {...props}
-          />
-        </div>
+        <MarkdownEditor
+          ref={editorRef}
+          autoFocus
+          placeholder={t('editor placeholder')}
+          extensions={extensions}
+          slots={{
+            root: {
+              className: mx(
+                focusRing,
+                attentionSurface,
+                textBlockWidth,
+                'md:border-is md:border-ie separator-separator focus-visible:ring-inset min-bs-full grid grid-rows-subgrid',
+              ),
+              'data-testid': 'composer.markdownRoot',
+            } as HTMLAttributes<HTMLDivElement>,
+            editor: {
+              className: mx('is-full pli-2 sm:pli-6 md:pli-8 py-2 pbe-[50dvh]', !toolbar && 'border-bs'),
+            },
+            content: {
+              className: focusRing,
+            },
+          }}
+          {...props}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
This PR makes some minor adjustments to `EditorMain`:
- uses `ring-inset` so a `div role=none` can be removed
- uses `grid-rows-subgrid` to stretch `.cm-editor` to the block size of the root if it’s smaller
- removes overscroll rules that were causing issues keeping up with the cursor

<img width="1286" alt="Screenshot 2024-02-08 at 10 00 38" src="https://github.com/dxos/dxos/assets/855039/4cb6937c-8840-4b32-aca7-af728d6fb15d">

https://github.com/dxos/dxos/assets/855039/7f11619b-78b6-4856-b72b-b09e90463f52

