### PR TITLE
fix(react-ui-editor): Export layout fragments, remove unneeded styles

### DIFF
--- a/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
@@ -16,6 +16,9 @@ import {
   useEditorView,
   useActionHandler,
   useFormattingState,
+  editorHalfViewportOverscrollContent,
+  editorFillLayoutEditor,
+  editorFillLayoutRoot,
 } from '@dxos/react-ui-editor';
 import { attentionSurface, focusRing, mx, textBlockWidth } from '@dxos/react-ui-theme';
 
@@ -90,15 +93,16 @@ const EditorMain = ({ comments, toolbar, extensions: _extensions, ...props }: Ed
                 focusRing,
                 attentionSurface,
                 textBlockWidth,
-                'md:border-is md:border-ie separator-separator focus-visible:ring-inset min-bs-full grid grid-rows-subgrid',
+                editorFillLayoutRoot,
+                'md:border-is md:border-ie separator-separator focus-visible:ring-inset',
               ),
               'data-testid': 'composer.markdownRoot',
             } as HTMLAttributes<HTMLDivElement>,
             editor: {
-              className: mx('is-full pli-2 sm:pli-6 md:pli-8 py-2 pbe-[50dvh]', !toolbar && 'border-bs'),
+              className: mx(editorFillLayoutEditor, 'is-full pli-2 sm:pli-6 md:pli-8 py-2', !toolbar && 'border-bs'),
             },
             content: {
-              className: focusRing,
+              className: editorHalfViewportOverscrollContent,
             },
           }}
           {...props}

--- a/packages/ui/react-ui-editor/src/components/TextEditor/hooks.stories.tsx
+++ b/packages/ui/react-ui-editor/src/components/TextEditor/hooks.stories.tsx
@@ -7,7 +7,7 @@ import '@dxosTheme';
 import React from 'react';
 
 import { useThemeContext } from '@dxos/react-ui';
-import { mx, textBlockWidth } from '@dxos/react-ui-theme';
+import { attentionSurface, mx, textBlockWidth } from '@dxos/react-ui-theme';
 import { withTheme } from '@dxos/storybook-utils';
 
 import { TextEditor } from './TextEditor';
@@ -24,7 +24,7 @@ import {
   useFormattingState,
 } from '../../extensions';
 import { createDataExtensions, createThemeExtensions, useActionHandler, useTextEditor } from '../../hooks';
-import { editorWithToolbarLayout } from '../../styles/layout';
+import { editorFillLayoutEditor, editorFillLayoutRoot, editorWithToolbarLayout } from '../../styles';
 import { markdownTheme } from '../../themes';
 import translations from '../../translations';
 import { Toolbar } from '../Toolbar';
@@ -55,7 +55,7 @@ const Story = ({ autoFocus, placeholder, doc, readonly }: StoryProps) => {
         themeMode,
         theme: markdownTheme,
         slots: {
-          editor: { className: 'min-bs-full' },
+          editor: { className: editorFillLayoutEditor },
         },
       }),
       // TODO(burdon): Move lineWrapping.
@@ -85,7 +85,7 @@ const Story = ({ autoFocus, placeholder, doc, readonly }: StoryProps) => {
       <div role='none' className='overflow-y-auto'>
         <div
           role='textbox'
-          className={mx(textBlockWidth, 'min-bs-full p-4 surface-attention fg-base')}
+          className={mx(textBlockWidth, attentionSurface, editorFillLayoutRoot, 'p-4')}
           ref={parentRef}
         />
       </div>

--- a/packages/ui/react-ui-editor/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/ui/react-ui-editor/src/components/Toolbar/Toolbar.stories.tsx
@@ -25,7 +25,7 @@ import {
   useFormattingState,
 } from '../../extensions';
 import { type Comment, useActionHandler, useEditorView, useTextModel } from '../../hooks';
-import { editorWithToolbarLayout } from '../../styles';
+import { editorFillLayoutEditor, editorFillLayoutRoot, editorWithToolbarLayout } from '../../styles';
 import translations from '../../translations';
 import { MarkdownEditor } from '../TextEditor';
 
@@ -75,7 +75,10 @@ const Story: FC<{ content: string }> = ({ content }) => {
         ref={editorRef}
         model={model}
         extensions={extensions}
-        slots={{ root: { className: mx(textBlockWidth, 'pli-2') } }}
+        slots={{
+          root: { className: mx(textBlockWidth, editorFillLayoutRoot, 'pli-2') },
+          editor: { className: editorFillLayoutEditor },
+        }}
       />
     </div>
   );

--- a/packages/ui/react-ui-editor/src/index.ts
+++ b/packages/ui/react-ui-editor/src/index.ts
@@ -11,6 +11,12 @@ export { Doc, YText, YXmlFragment } from '@dxos/text-model';
 export * from './components';
 export * from './extensions';
 export * from './hooks';
-export { getToken, editorWithToolbarLayout } from './styles';
+export {
+  getToken,
+  editorWithToolbarLayout,
+  editorFillLayoutEditor,
+  editorFillLayoutRoot,
+  editorHalfViewportOverscrollContent,
+} from './styles';
 export * from './themes';
 export * from './util';

--- a/packages/ui/react-ui-editor/src/styles/layout.ts
+++ b/packages/ui/react-ui-editor/src/styles/layout.ts
@@ -3,4 +3,9 @@
 //
 
 export const editorWithToolbarLayout =
-  'fixed inset-0 grid grid-cols-1 grid-rows-[min-content_1fr] justify-center content-start overflow-hidden';
+  'grid grid-cols-1 grid-rows-[min-content_1fr] justify-center content-start overflow-hidden';
+
+export const editorFillLayoutRoot = 'min-bs-full grid';
+export const editorFillLayoutEditor = 'min-bs-full';
+
+export const editorHalfViewportOverscrollContent = 'after:block after:min-bs-[50dvh] after:pointer-events-none';


### PR DESCRIPTION
Resolves #5620.

https://github.com/dxos/dxos/assets/855039/a644792c-2e9d-42a3-ab48-23813b7a05ea


https://github.com/dxos/dxos/assets/855039/ca634c96-781d-450f-9427-b2fadcb78ad0


https://github.com/dxos/dxos/assets/855039/2efc99da-a871-4036-84aa-d8cb3ac2080f

<img width="1078" alt="Screenshot 2024-02-08 at 12 30 51" src="https://github.com/dxos/dxos/assets/855039/512f6058-c8c1-4a20-8213-ed0c0ee1497c">