### PR TITLE
feat(plugin-layout): add setting for native app redirect

### DIFF
--- a/packages/apps/plugins/plugin-layout/src/LayoutPlugin.tsx
+++ b/packages/apps/plugins/plugin-layout/src/LayoutPlugin.tsx
@@ -38,10 +38,14 @@ import { Mosaic } from '@dxos/react-ui-mosaic';
 
 import { LayoutContext } from './LayoutContext';
 import { MainLayout, ContextPanel, ContentEmpty, LayoutSettings, ContentFallback } from './components';
-import { activeToUri, uriToActive } from './helpers';
+import { activeToUri, checkAppScheme, uriToActive } from './helpers';
 import meta, { LAYOUT_PLUGIN } from './meta';
 import translations from './translations';
 import { type LayoutPluginProvides, type LayoutSettingsProps } from './types';
+
+const isSocket = !!(globalThis as any).__args;
+// TODO(mjamesderocher): Can we get this directly from Socket?
+const appScheme = 'composer://';
 
 type NavigationState = Location & {
   activeNode: Node | undefined;
@@ -60,6 +64,7 @@ export const LayoutPlugin = ({
 
   const settings = new LocalStorageStore<LayoutSettingsProps>(LAYOUT_PLUGIN, {
     showFooter: false,
+    enableNativeRedirect: false,
   });
 
   const layout = new LocalStorageStore<Layout>(LAYOUT_PLUGIN, {
@@ -131,29 +136,6 @@ export const LayoutPlugin = ({
     }
   };
 
-  const isSocket = !!(globalThis as any).__args;
-
-  // TODO factor out as part of NavigationPlugin.
-  const checkAppScheme = (url: string) => {
-    const iframe = document.createElement('iframe');
-    iframe.style.display = 'none';
-    document.body.appendChild(iframe);
-
-    iframe.src = url + window.location.pathname.replace(/^\/+/, '');
-
-    const timer = setTimeout(() => {
-      document.body.removeChild(iframe);
-    }, 3000);
-
-    window.addEventListener('pagehide', (event) => {
-      clearTimeout(timer);
-      document.body.removeChild(iframe);
-    });
-  };
-
-  // TODO(mjamesderocher) can we get this directly from Socket?
-  const appScheme = 'composer://';
-
   return {
     meta,
     ready: async (plugins) => {
@@ -164,12 +146,14 @@ export const LayoutPlugin = ({
         .prop(layout.values.$sidebarOpen!, 'sidebar-open', LocalStorageStore.bool)
         .prop(layout.values.$complementarySidebarOpen!, 'complementary-sidebar-open', LocalStorageStore.bool);
 
-      settings.prop(settings.values.$showFooter!, 'show-footer', LocalStorageStore.bool);
+      settings
+        .prop(settings.values.$showFooter!, 'show-footer', LocalStorageStore.bool)
+        .prop(settings.values.$enableNativeRedirect!, 'enable-native-redirect', LocalStorageStore.bool);
 
       // TODO(burdon): Create context and plugin.
       Keyboard.singleton.initialize();
 
-      if (!isSocket) {
+      if (!isSocket && settings.values.enableNativeRedirect) {
         checkAppScheme(appScheme);
       }
     },

--- a/packages/apps/plugins/plugin-layout/src/components/LayoutSettings.tsx
+++ b/packages/apps/plugins/plugin-layout/src/components/LayoutSettings.tsx
@@ -14,8 +14,16 @@ export const LayoutSettings = ({ settings }: { settings: LayoutSettingsProps }) 
   const { t } = useTranslation(LAYOUT_PLUGIN);
 
   return (
-    <SettingsValue label={t('settings show footer label')}>
-      <Input.Switch checked={settings.showFooter} onCheckedChange={(checked) => (settings.showFooter = !!checked)} />
-    </SettingsValue>
+    <>
+      <SettingsValue label={t('settings show footer label')}>
+        <Input.Switch checked={settings.showFooter} onCheckedChange={(checked) => (settings.showFooter = !!checked)} />
+      </SettingsValue>
+      <SettingsValue label={t('settings native redirect label')}>
+        <Input.Switch
+          checked={settings.enableNativeRedirect}
+          onCheckedChange={(checked) => (settings.enableNativeRedirect = !!checked)}
+        />
+      </SettingsValue>
+    </>
   );
 };

--- a/packages/apps/plugins/plugin-layout/src/helpers.ts
+++ b/packages/apps/plugins/plugin-layout/src/helpers.ts
@@ -9,3 +9,21 @@ export const uriToActive = (uri: string) => {
 
 export const activeToUri = (active?: string) =>
   '/' + (active ? active.split(':').map(encodeURIComponent).join('/') : '');
+
+// TODO(mjamesderocher): Factor out as part of NavigationPlugin.
+export const checkAppScheme = (url: string) => {
+  const iframe = document.createElement('iframe');
+  iframe.style.display = 'none';
+  document.body.appendChild(iframe);
+
+  iframe.src = url + window.location.pathname.replace(/^\/+/, '');
+
+  const timer = setTimeout(() => {
+    document.body.removeChild(iframe);
+  }, 3000);
+
+  window.addEventListener('pagehide', (event) => {
+    clearTimeout(timer);
+    document.body.removeChild(iframe);
+  });
+};

--- a/packages/apps/plugins/plugin-layout/src/translations.ts
+++ b/packages/apps/plugins/plugin-layout/src/translations.ts
@@ -19,6 +19,7 @@ export default [
           'No plugin had a response for the address you navigated to. Double-check the URL, and ensure you’ve enabled a plugin that supports the object.',
         'toggle fullscreen label': 'Toggle fullscreen',
         'settings show footer label': '[Experimental] Show footer',
+        'settings native redirect label': '[Experimental] Enable native url redirect',
         'undo available label': 'Click to undo previous action.',
         'undo action label': 'Undo',
         'undo action alt': 'Undo previous action',

--- a/packages/apps/plugins/plugin-layout/src/types.ts
+++ b/packages/apps/plugins/plugin-layout/src/types.ts
@@ -14,6 +14,7 @@ import type {
 
 export type LayoutSettingsProps = {
   showFooter: boolean;
+  enableNativeRedirect: boolean;
 };
 
 export type LayoutPluginProvides = SurfaceProvides &


### PR DESCRIPTION
This PR hides the native app redirect behind a setting. It didn't seem consequential to land that change given that we haven't shipped the app yet, but if you've built the app locally it's hard to avoid. Until the app is stable and we have ways of avoiding this in dev, etc. it should be disabled by default.

