### PR TITLE
fix(plugin-thread): Chat layout

### DIFF
--- a/packages/apps/plugins/plugin-layout/src/components/ContextPanel.tsx
+++ b/packages/apps/plugins/plugin-layout/src/components/ContextPanel.tsx
@@ -6,7 +6,7 @@ import { X } from '@phosphor-icons/react';
 import React from 'react';
 
 import { Surface } from '@dxos/app-framework';
-import { Button, ScrollArea } from '@dxos/react-ui';
+import { Button } from '@dxos/react-ui';
 
 import { useLayout } from '../LayoutContext';
 
@@ -29,14 +29,7 @@ export const ContextPanel = () => {
           <X />
         </Button>
       </div>
-      <ScrollArea.Root classNames='anchored-overflow'>
-        <ScrollArea.Viewport classNames='pbe-10'>
-          <Surface role={Role.THREAD} />
-          <ScrollArea.Scrollbar>
-            <ScrollArea.Thumb />
-          </ScrollArea.Scrollbar>
-        </ScrollArea.Viewport>
-      </ScrollArea.Root>
+      <Surface role={Role.THREAD} />
     </div>
   );
 };

--- a/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -35,7 +35,7 @@ import { comments, listener } from '@dxos/react-ui-editor';
 import { translations as threadTranslations } from '@dxos/react-ui-thread';
 import { nonNullable } from '@dxos/util';
 
-import { ThreadContainer, ThreadMain, ThreadSettings, ThreadsContainer } from './components';
+import { ThreadMain, ThreadSettings, CommentsContainer, ChatContainer } from './components';
 import meta, { THREAD_ITEM, THREAD_PLUGIN } from './meta';
 import translations from './translations';
 import { ThreadAction, type ThreadPluginProvides, isThread, type ThreadSettingsProps } from './types';
@@ -159,7 +159,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
                   .filter(nonNullable);
 
                 return (
-                  <ThreadsContainer
+                  <CommentsContainer
                     space={space}
                     threads={threads}
                     detached={detached}
@@ -200,7 +200,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
               const { objects: threads } = space.db.query(ThreadType.filter((thread) => !thread.context));
               if (threads.length) {
                 const thread = threads[0];
-                return <ThreadContainer space={space} thread={thread} currentRelatedId={location?.active} />;
+                return <ChatContainer space={space} thread={thread} currentRelatedId={location?.active} />;
               }
 
               break;

--- a/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -31,6 +31,7 @@ import {
   getTextInRange,
   isTypedObject,
 } from '@dxos/react-client/echo';
+import { ScrollArea } from '@dxos/react-ui';
 import { comments, listener } from '@dxos/react-ui-editor';
 import { translations as threadTranslations } from '@dxos/react-ui-thread';
 import { nonNullable } from '@dxos/util';
@@ -159,32 +160,40 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
                   .filter(nonNullable);
 
                 return (
-                  <CommentsContainer
-                    space={space}
-                    threads={threads}
-                    detached={detached}
-                    currentId={state.current}
-                    currentRelatedId={location?.active}
-                    autoFocusCurrentTextbox={state.focus}
-                    onThreadAttend={(thread: ThreadType) => {
-                      if (state.current !== thread.id) {
-                        state.current = thread.id;
-                        void intentPlugin?.provides.intent.dispatch({
-                          action: LayoutAction.FOCUS,
-                          data: {
-                            object: thread.id,
-                          },
-                        });
-                      }
-                    }}
-                    onThreadDelete={(thread: ThreadType) =>
-                      dispatch?.({
-                        plugin: THREAD_PLUGIN,
-                        action: ThreadAction.DELETE,
-                        data: { document: active, thread },
-                      })
-                    }
-                  />
+                  <ScrollArea.Root>
+                    <ScrollArea.Viewport>
+                      <CommentsContainer
+                        space={space}
+                        threads={threads}
+                        detached={detached}
+                        currentId={state.current}
+                        currentRelatedId={location?.active}
+                        autoFocusCurrentTextbox={state.focus}
+                        onThreadAttend={(thread: ThreadType) => {
+                          if (state.current !== thread.id) {
+                            state.current = thread.id;
+                            void intentPlugin?.provides.intent.dispatch({
+                              action: LayoutAction.FOCUS,
+                              data: {
+                                object: thread.id,
+                              },
+                            });
+                          }
+                        }}
+                        onThreadDelete={(thread: ThreadType) =>
+                          dispatch?.({
+                            plugin: THREAD_PLUGIN,
+                            action: ThreadAction.DELETE,
+                            data: { document: active, thread },
+                          })
+                        }
+                      />
+                      <div role='none' className='bs-10' />
+                      <ScrollArea.Scrollbar>
+                        <ScrollArea.Thumb />
+                      </ScrollArea.Scrollbar>
+                    </ScrollArea.Viewport>
+                  </ScrollArea.Root>
                 );
               }
 

--- a/packages/apps/plugins/plugin-thread/src/components/Chat.stories.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/Chat.stories.tsx
@@ -55,7 +55,9 @@ const Story = () => {
       }}
     >
       <Mosaic.Root debug>
-        <main className='max-is-prose mli-auto'>{space && <ChatContainer thread={thread} space={space} />}</main>
+        <main className='max-is-prose mli-auto bs-dvh overflow-hidden'>
+          {space && <ChatContainer thread={thread} space={space} />}
+        </main>
         <Mosaic.DragOverlay />
       </Mosaic.Root>
     </SurfaceProvider>

--- a/packages/apps/plugins/plugin-thread/src/components/Chat.stories.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/Chat.stories.tsx
@@ -17,7 +17,7 @@ import { Mosaic } from '@dxos/react-ui-mosaic';
 import { Thread } from '@dxos/react-ui-thread';
 import { withTheme } from '@dxos/storybook-utils';
 
-import { ThreadContainer } from './ThreadContainer';
+import { ChatContainer } from './ChatContainer';
 import { createChatThread } from './testing';
 import translations from '../translations';
 
@@ -55,7 +55,7 @@ const Story = () => {
       }}
     >
       <Mosaic.Root debug>
-        <main className='max-is-prose mli-auto'>{space && <ThreadContainer thread={thread} space={space} />}</main>
+        <main className='max-is-prose mli-auto'>{space && <ChatContainer thread={thread} space={space} />}</main>
         <Mosaic.DragOverlay />
       </Mosaic.Root>
     </SurfaceProvider>

--- a/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
@@ -9,6 +9,7 @@ import { TextObject, getTextContent, useMembers } from '@dxos/react-client/echo'
 import { useIdentity } from '@dxos/react-client/halo';
 import { ScrollArea, useTranslation } from '@dxos/react-ui';
 import { useTextModel } from '@dxos/react-ui-editor';
+import { mx } from '@dxos/react-ui-theme';
 import { MessageTextbox, type MessageTextboxProps, Thread, ThreadFooter, threadLayout } from '@dxos/react-ui-thread';
 
 import { MessageContainer } from './MessageContainer';
@@ -93,8 +94,8 @@ export const ChatContainer = ({ space, thread, currentRelatedId, current, autoFo
       classNames='bs-full grid-rows-[1fr_min-content_min-content] overflow-hidden'
     >
       <ScrollArea.Root classNames='col-span-2'>
-        <ScrollArea.Viewport classNames='overflow-anchored after:overflow-anchor after:block after:bs-px after:-mbs-px'>
-          <div role='none' className={threadLayout}>
+        <ScrollArea.Viewport classNames='overflow-anchored after:overflow-anchor after:block after:bs-px after:-mbs-px [&>div]:min-bs-full [&>div]:!grid [&>div]:grid-rows-[1fr_0]'>
+          <div role='none' className={mx(threadLayout, 'place-self-end')}>
             {thread.messages.map((message) => (
               <MessageContainer key={message.id} message={message} members={members} onDelete={handleDelete} />
             ))}

--- a/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
@@ -18,15 +18,6 @@ import { type ThreadContainerProps } from './types';
 import { useStatus, useMessageMetadata } from '../hooks';
 import { THREAD_PLUGIN } from '../meta';
 
-/**
- * Component for connecting an ECHO Thread object to the UI component Thread.
- * @param space - the containing Space entity
- * @param thread - the Thread entity
- * @param currentRelatedId - an entity’s id that this thread is related to
- * @param current - whether this thread is current (wrt ARIA) in the app
- * @param autoFocusTextBox - whether to set `autoFocus` on the thread’s textbox
- * @constructor
- */
 export const ChatContainer = ({ space, thread, currentRelatedId, current, autoFocusTextBox }: ThreadContainerProps) => {
   const identity = useIdentity()!;
   const members = useMembers(space.key);

--- a/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
@@ -2,14 +2,14 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { useRef, useState } from 'react';
+import React, { useLayoutEffect, useRef, useState } from 'react';
 
 import { Message as MessageType } from '@braneframe/types';
 import { TextObject, getTextContent, useMembers } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
-import { useTranslation } from '@dxos/react-ui';
+import { ScrollArea, useTranslation } from '@dxos/react-ui';
 import { useTextModel } from '@dxos/react-ui-editor';
-import { MessageTextbox, type MessageTextboxProps, Thread, ThreadFooter } from '@dxos/react-ui-thread';
+import { MessageTextbox, type MessageTextboxProps, Thread, ThreadFooter, threadLayout } from '@dxos/react-ui-thread';
 
 import { MessageContainer } from './MessageContainer';
 import { command } from './command-extension';
@@ -35,6 +35,14 @@ export const ChatContainer = ({ space, thread, currentRelatedId, current, autoFo
   const [nextMessage, setNextMessage] = useState({ text: new TextObject() });
   const nextMessageModel = useTextModel({ text: nextMessage.text, identity, space });
   const autoFocusAfterSend = useRef<boolean>(false);
+  const textboxMetadata = useMessageMetadata(thread.id, identity);
+  const threadScrollRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    // TODO(thure): `flex-col-reverse` does not work to start the container scrolled to the end while also using
+    //  `ScrollArea`. This is the least-bad way I found to scroll to the end on mount.
+    setTimeout(() => threadScrollRef.current?.scrollIntoView({ behavior: 'instant', block: 'end' }), 0);
+  }, []);
 
   // TODO(burdon): Change to model.
   const handleCreate: MessageTextboxProps['onSend'] = () => {
@@ -76,15 +84,25 @@ export const ChatContainer = ({ space, thread, currentRelatedId, current, autoFo
     }
   };
 
-  const textboxMetadata = useMessageMetadata(thread.id, identity);
-
   return (
-    <Thread current={current} id={thread.id} classNames='bs-full grid-rows-[1fr_min-content_min-content]'>
-      <div className='grid grid-cols-subgrid col-span-2 overflow-anchored overflow-y after:block after:overflow-anchor after:is-px after:bs-px after:-mbs-px'>
-        {thread.messages.map((message) => (
-          <MessageContainer key={message.id} message={message} members={members} onDelete={handleDelete} />
-        ))}
-      </div>
+    <Thread
+      current={current}
+      id={thread.id}
+      classNames='bs-full grid-rows-[1fr_min-content_min-content] overflow-hidden'
+    >
+      <ScrollArea.Root classNames='col-span-2'>
+        <ScrollArea.Viewport classNames='overflow-anchored after:overflow-anchor after:block after:bs-px'>
+          <div role='none' className={threadLayout}>
+            {thread.messages.map((message) => (
+              <MessageContainer key={message.id} message={message} members={members} onDelete={handleDelete} />
+            ))}
+          </div>
+          <div role='none' className='bs-px -mbs-px' ref={threadScrollRef} />
+          <ScrollArea.Scrollbar>
+            <ScrollArea.Thumb />
+          </ScrollArea.Scrollbar>
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>
       {nextMessageModel && (
         <>
           <MessageTextbox

--- a/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
@@ -40,8 +40,9 @@ export const ChatContainer = ({ space, thread, currentRelatedId, current, autoFo
 
   useLayoutEffect(() => {
     // TODO(thure): `flex-col-reverse` does not work to start the container scrolled to the end while also using
-    //  `ScrollArea`. This is the least-bad way I found to scroll to the end on mount.
-    setTimeout(() => threadScrollRef.current?.scrollIntoView({ behavior: 'instant', block: 'end' }), 0);
+    //  `ScrollArea`. This is the least-bad way I found to scroll to the end on mount. Note that 0ms was insufficient
+    //  for the desired effect; this is likely hardware-dependent and should be reevaluated.
+    setTimeout(() => threadScrollRef.current?.scrollIntoView({ behavior: 'instant', block: 'end' }), 10);
   }, []);
 
   // TODO(burdon): Change to model.
@@ -69,7 +70,8 @@ export const ChatContainer = ({ space, thread, currentRelatedId, current, autoFo
       return { text: new TextObject() };
     });
 
-    // TODO(burdon): Scroll to bottom.
+    setTimeout(() => threadScrollRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' }), 10);
+
     return true;
   };
 
@@ -91,12 +93,13 @@ export const ChatContainer = ({ space, thread, currentRelatedId, current, autoFo
       classNames='bs-full grid-rows-[1fr_min-content_min-content] overflow-hidden'
     >
       <ScrollArea.Root classNames='col-span-2'>
-        <ScrollArea.Viewport classNames='overflow-anchored after:overflow-anchor after:block after:bs-px'>
+        <ScrollArea.Viewport classNames='overflow-anchored after:overflow-anchor after:block after:bs-px after:-mbs-px'>
           <div role='none' className={threadLayout}>
             {thread.messages.map((message) => (
               <MessageContainer key={message.id} message={message} members={members} onDelete={handleDelete} />
             ))}
           </div>
+          {/* NOTE(thure): This can’t also be the `overflow-anchor` because `ScrollArea` injects an interceding node that contains this necessary ref’d element. */}
           <div role='none' className='bs-px -mbs-px' ref={threadScrollRef} />
           <ScrollArea.Scrollbar>
             <ScrollArea.Thumb />

--- a/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
@@ -30,11 +30,14 @@ export const ChatContainer = ({ space, thread, currentRelatedId, current, autoFo
   const textboxMetadata = useMessageMetadata(thread.id, identity);
   const threadScrollRef = useRef<HTMLDivElement | null>(null);
 
+  // TODO(thure): `flex-col-reverse` does not work to start the container scrolled to the end while also using
+  //  `ScrollArea`. This is the least-bad way I found to scroll to the end on mount. Note that 0ms was insufficient
+  //  for the desired effect; this is likely hardware-dependent and should be reevaluated.
+  const scrollToEnd = (behavior: ScrollBehavior) =>
+    setTimeout(() => threadScrollRef.current?.scrollIntoView({ behavior, block: 'end' }), 10);
+
   useLayoutEffect(() => {
-    // TODO(thure): `flex-col-reverse` does not work to start the container scrolled to the end while also using
-    //  `ScrollArea`. This is the least-bad way I found to scroll to the end on mount. Note that 0ms was insufficient
-    //  for the desired effect; this is likely hardware-dependent and should be reevaluated.
-    setTimeout(() => threadScrollRef.current?.scrollIntoView({ behavior: 'instant', block: 'end' }), 10);
+    scrollToEnd('instant');
   }, []);
 
   // TODO(burdon): Change to model.
@@ -62,7 +65,7 @@ export const ChatContainer = ({ space, thread, currentRelatedId, current, autoFo
       return { text: new TextObject() };
     });
 
-    setTimeout(() => threadScrollRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' }), 10);
+    scrollToEnd('smooth');
 
     return true;
   };

--- a/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
@@ -1,0 +1,103 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React, { useRef, useState } from 'react';
+
+import { Message as MessageType } from '@braneframe/types';
+import { TextObject, getTextContent, useMembers } from '@dxos/react-client/echo';
+import { useIdentity } from '@dxos/react-client/halo';
+import { useTranslation } from '@dxos/react-ui';
+import { useTextModel } from '@dxos/react-ui-editor';
+import { MessageTextbox, type MessageTextboxProps, Thread, ThreadFooter } from '@dxos/react-ui-thread';
+
+import { MessageContainer } from './MessageContainer';
+import { command } from './command-extension';
+import { type ThreadContainerProps } from './types';
+import { useStatus, useMessageMetadata } from '../hooks';
+import { THREAD_PLUGIN } from '../meta';
+
+/**
+ * Component for connecting an ECHO Thread object to the UI component Thread.
+ * @param space - the containing Space entity
+ * @param thread - the Thread entity
+ * @param currentRelatedId - an entity’s id that this thread is related to
+ * @param current - whether this thread is current (wrt ARIA) in the app
+ * @param autoFocusTextBox - whether to set `autoFocus` on the thread’s textbox
+ * @constructor
+ */
+export const ChatContainer = ({ space, thread, currentRelatedId, current, autoFocusTextBox }: ThreadContainerProps) => {
+  const identity = useIdentity()!;
+  const members = useMembers(space.key);
+  const activity = useStatus(space, thread.id);
+  const { t } = useTranslation(THREAD_PLUGIN);
+
+  const [nextMessage, setNextMessage] = useState({ text: new TextObject() });
+  const nextMessageModel = useTextModel({ text: nextMessage.text, identity, space });
+  const autoFocusAfterSend = useRef<boolean>(false);
+
+  // TODO(burdon): Change to model.
+  const handleCreate: MessageTextboxProps['onSend'] = () => {
+    const content = nextMessage.text;
+    if (!getTextContent(content)) {
+      return false;
+    }
+
+    const block = {
+      timestamp: new Date().toISOString(),
+      content,
+    };
+
+    thread.messages.push(
+      new MessageType({
+        from: { identityKey: identity.identityKey.toHex() },
+        context: { object: currentRelatedId },
+        blocks: [block],
+      }),
+    );
+
+    setNextMessage(() => {
+      autoFocusAfterSend.current = true;
+      return { text: new TextObject() };
+    });
+
+    // TODO(burdon): Scroll to bottom.
+    return true;
+  };
+
+  const handleDelete = (id: string, index: number) => {
+    const messageIndex = thread.messages.findIndex((message) => message.id === id);
+    if (messageIndex !== -1) {
+      const message = thread.messages[messageIndex];
+      message.blocks.splice(index, 1);
+      if (message.blocks.length === 0) {
+        thread.messages.splice(messageIndex, 1);
+      }
+    }
+  };
+
+  const textboxMetadata = useMessageMetadata(thread.id, identity);
+
+  return (
+    <Thread current={current} id={thread.id} classNames='bs-full grid-rows-[1fr_min-content_min-content]'>
+      <div className='grid grid-cols-subgrid col-span-2 overflow-anchored overflow-y after:block after:overflow-anchor after:is-px after:bs-px after:-mbs-px'>
+        {thread.messages.map((message) => (
+          <MessageContainer key={message.id} message={message} members={members} onDelete={handleDelete} />
+        ))}
+      </div>
+      {nextMessageModel && (
+        <>
+          <MessageTextbox
+            onSend={handleCreate}
+            autoFocus={autoFocusAfterSend.current || autoFocusTextBox}
+            placeholder={t('message placeholder')}
+            {...textboxMetadata}
+            model={nextMessageModel}
+            extensions={[command]}
+          />
+          <ThreadFooter activity={activity}>{t('activity message')}</ThreadFooter>
+        </>
+      )}
+    </Thread>
+  );
+};

--- a/packages/apps/plugins/plugin-thread/src/components/CommentContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/CommentContainer.tsx
@@ -5,36 +5,19 @@
 import { X } from '@phosphor-icons/react';
 import React, { useRef, useState } from 'react';
 
-import { type Thread as ThreadType, Message as MessageType } from '@braneframe/types';
-import { TextObject, getTextContent } from '@dxos/react-client/echo';
-import { type Space, useMembers } from '@dxos/react-client/echo';
+import { Message as MessageType } from '@braneframe/types';
+import { TextObject, getTextContent, useMembers } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
 import { AnchoredOverflow, Button, Tooltip, useTranslation } from '@dxos/react-ui';
 import { useTextModel } from '@dxos/react-ui-editor';
 import { hoverableControlItem, hoverableControls, hoverableFocusedWithinControls, mx } from '@dxos/react-ui-theme';
-import {
-  MessageTextbox,
-  type MessageTextboxProps,
-  Thread,
-  ThreadFooter,
-  ThreadHeading,
-  type ThreadProps,
-} from '@dxos/react-ui-thread';
+import { MessageTextbox, type MessageTextboxProps, Thread, ThreadFooter, ThreadHeading } from '@dxos/react-ui-thread';
 
 import { MessageContainer } from './MessageContainer';
 import { command } from './command-extension';
+import { type ThreadContainerProps } from './types';
 import { useStatus, useMessageMetadata } from '../hooks';
 import { THREAD_PLUGIN } from '../meta';
-
-export type ThreadContainerProps = {
-  space: Space;
-  thread: ThreadType;
-  currentRelatedId?: string;
-  autoFocusTextBox?: boolean;
-  detached?: boolean;
-  onAttend?: () => void;
-  onDelete?: () => void;
-} & Pick<ThreadProps, 'current'>;
 
 /**
  * Component for connecting an ECHO Thread object to the UI component Thread.
@@ -48,11 +31,7 @@ export type ThreadContainerProps = {
  * @param onDelete - callback for deleting the thread
  * @constructor
  */
-// TODO(wittjosiah): Decide if chat & comment threads are similar enough to share a container.
-//  Either way they will be built with the same pure @dxos/react-ui-thread components.
-//  Currently this container is used for both, but is focused on comments.
-//  Comments-specific things right now are primarily how the header is setup.
-export const ThreadContainer = ({
+export const CommentContainer = ({
   space,
   thread,
   detached,

--- a/packages/apps/plugins/plugin-thread/src/components/CommentContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/CommentContainer.tsx
@@ -19,18 +19,6 @@ import { type ThreadContainerProps } from './types';
 import { useStatus, useMessageMetadata } from '../hooks';
 import { THREAD_PLUGIN } from '../meta';
 
-/**
- * Component for connecting an ECHO Thread object to the UI component Thread.
- * @param space - the containing Space entity
- * @param thread - the Thread entity
- * @param detached - whether this thread is detached from the object
- * @param currentRelatedId - an entity’s id that this thread is related to
- * @param current - whether this thread is current (wrt ARIA) in the app
- * @param autoFocusTextBox - whether to set `autoFocus` on the thread’s textbox
- * @param onAttend - combined callback for `onClickCapture` and `onFocusCapture` within the thread
- * @param onDelete - callback for deleting the thread
- * @constructor
- */
 export const CommentContainer = ({
   space,
   thread,

--- a/packages/apps/plugins/plugin-thread/src/components/Comments.stories.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/Comments.stories.tsx
@@ -16,7 +16,7 @@ import { Tooltip } from '@dxos/react-ui';
 import { Thread } from '@dxos/react-ui-thread';
 import { withTheme } from '@dxos/storybook-utils';
 
-import { ThreadsContainer } from './ThreadsContainer';
+import { CommentsContainer } from './CommentsContainer';
 import { createCommentThread } from './testing';
 import translations from '../translations';
 
@@ -45,7 +45,7 @@ const Story = ({ spaceKey }: { spaceKey: PublicKey }) => {
   // TODO(wittjosiah): Include Tooltip.Provider in `withTheme` decorator?
   return (
     <Tooltip.Provider>
-      <ThreadsContainer threads={threads} detached={detached} space={space} onThreadDelete={console.log} />
+      <CommentsContainer threads={threads} detached={detached} space={space} onThreadDelete={console.log} />
     </Tooltip.Provider>
   );
 };

--- a/packages/apps/plugins/plugin-thread/src/components/CommentsContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/CommentsContainer.tsx
@@ -5,7 +5,7 @@ import React, { useEffect } from 'react';
 
 import { type Thread as ThreadType } from '@braneframe/types';
 
-import { ThreadContainer, type ThreadContainerProps } from './ThreadContainer';
+import { CommentContainer, type ThreadContainerProps } from './CommentContainer';
 
 export type ThreadsContainerProps = Omit<
   ThreadContainerProps,
@@ -25,7 +25,7 @@ export type ThreadsContainerProps = Omit<
 /**
  * Comment threads.
  */
-export const ThreadsContainer = ({
+export const CommentsContainer = ({
   threads,
   detached = [],
   currentId,
@@ -44,7 +44,7 @@ export const ThreadsContainer = ({
   return (
     <>
       {threads.map((thread) => (
-        <ThreadContainer
+        <CommentContainer
           key={thread.id}
           thread={thread}
           current={currentId === thread.id}

--- a/packages/apps/plugins/plugin-thread/src/components/CommentsContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/CommentsContainer.tsx
@@ -5,7 +5,8 @@ import React, { useEffect } from 'react';
 
 import { type Thread as ThreadType } from '@braneframe/types';
 
-import { CommentContainer, type ThreadContainerProps } from './CommentContainer';
+import { CommentContainer } from './CommentContainer';
+import { type ThreadContainerProps } from './types';
 
 export type ThreadsContainerProps = Omit<
   ThreadContainerProps,

--- a/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ThreadMain.tsx
@@ -9,7 +9,7 @@ import { getSpaceForObject } from '@dxos/react-client/echo';
 import { Main } from '@dxos/react-ui';
 import { baseSurface, topbarBlockPaddingStart, fixedInsetFlexLayout } from '@dxos/react-ui-theme';
 
-import { ThreadContainer } from './ThreadContainer';
+import { ChatContainer } from './ChatContainer';
 
 const ThreadMain: FC<{ thread: ThreadType }> = ({ thread }) => {
   const space = getSpaceForObject(thread);
@@ -20,7 +20,7 @@ const ThreadMain: FC<{ thread: ThreadType }> = ({ thread }) => {
   // TODO(burdon): Factor out Main container across plugins?
   return (
     <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart]}>
-      <ThreadContainer space={space} thread={thread} />
+      <ChatContainer space={space} thread={thread} />
     </Main.Content>
   );
 };

--- a/packages/apps/plugins/plugin-thread/src/components/index.ts
+++ b/packages/apps/plugins/plugin-thread/src/components/index.ts
@@ -9,6 +9,7 @@ export const ThreadMain = React.lazy(() => import('./ThreadMain'));
 
 // TODO(wittjosiah): Suspense boundary for sidebar?
 export * from './ThreadSettings';
-export * from './ThreadContainer';
+export * from './CommentContainer';
 export * from './MessageContainer';
-export * from './ThreadsContainer';
+export * from './CommentsContainer';
+export * from './ChatContainer';

--- a/packages/apps/plugins/plugin-thread/src/components/types.ts
+++ b/packages/apps/plugins/plugin-thread/src/components/types.ts
@@ -6,6 +6,17 @@ import type { Thread as ThreadType } from '@braneframe/types';
 import { type Space } from '@dxos/react-client/echo';
 import type { ThreadProps } from '@dxos/react-ui-thread';
 
+/**
+ * Props for components which connect an ECHO Thread object to the UI component Thread.
+ * @param space - the containing Space entity
+ * @param thread - the Thread entity
+ * @param detached - whether this thread is detached from the object
+ * @param currentRelatedId - an entity’s id that this thread is related to
+ * @param current - whether this thread is current (wrt ARIA) in the app
+ * @param autoFocusTextBox - whether to set `autoFocus` on the thread’s textbox
+ * @param onAttend - combined callback for `onClickCapture` and `onFocusCapture` within the thread
+ * @param onDelete - callback for deleting the thread
+ */
 export type ThreadContainerProps = {
   space: Space;
   thread: ThreadType;

--- a/packages/apps/plugins/plugin-thread/src/components/types.ts
+++ b/packages/apps/plugins/plugin-thread/src/components/types.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import type { Thread as ThreadType } from '@braneframe/types';
+import { type Space } from '@dxos/react-client/echo';
+import type { ThreadProps } from '@dxos/react-ui-thread';
+
+export type ThreadContainerProps = {
+  space: Space;
+  thread: ThreadType;
+  currentRelatedId?: string;
+  autoFocusTextBox?: boolean;
+  detached?: boolean;
+  onAttend?: () => void;
+  onDelete?: () => void;
+} & Pick<ThreadProps, 'current'>;

--- a/packages/ui/react-ui-thread/src/Thread/Thread.tsx
+++ b/packages/ui/react-ui-thread/src/Thread/Thread.tsx
@@ -14,6 +14,8 @@ import type { ThreadEntity } from '../types';
 export type ThreadProps = ThemedClassName<ComponentPropsWithRef<'div'>> &
   ThreadEntity & { current?: boolean | ComponentProps<'div'>['aria-current'] };
 
+export const threadLayout = 'is-full place-self-start grid grid-cols-[3rem_1fr]';
+
 export const Thread = forwardRef<HTMLDivElement, ThreadProps>(
   ({ current, children, classNames, ...props }, forwardedRef) => {
     return (
@@ -23,9 +25,9 @@ export const Thread = forwardRef<HTMLDivElement, ThreadProps>(
         {...(current && { 'aria-current': typeof current === 'string' ? current : 'location' })}
         {...props}
         className={mx(
-          'is-full place-self-start grid grid-cols-[3rem_1fr] bg-[var(--surface-bg)]',
-          'border-[color:var(--surface-separator)] border-bs border-be plb-1.5 attention attention-within attention-current [--controls-opacity:0]',
+          threadLayout,
           hoverableFocusedWithinControls,
+          'bg-[var(--surface-bg)] border-[color:var(--surface-separator)] border-bs border-be plb-1.5 attention attention-within attention-current [--controls-opacity:0]',
           classNames,
         )}
         ref={forwardedRef}


### PR DESCRIPTION
Resolves #5608.

This PR devolves `ThreadContainer` into `ChatContainer` and `CommentContainer` (likewise renaming `ThreadsContainer` to `CommentsContainer`) since the design diverges.

The new `ChatContainer` gets the expected layout: messages scroll backwards from a compose box pinned to the bottom.

Getting scroll to reverse is still a nuanced affair, so please let me know if you encounter issues.

https://github.com/dxos/dxos/assets/855039/38c6ceb9-ad1a-4370-9653-9aed3c7a7e42

https://github.com/dxos/dxos/assets/855039/26688a30-3cfe-443e-947e-8e73765aa533

https://github.com/dxos/dxos/assets/855039/67481b46-d069-482e-b7b7-963e3b823a19
