### PR TITLE
fix(plugin-thread): Refine scrollIntoView

### DIFF
--- a/packages/apps/plugins/plugin-thread/src/components/CommentContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/CommentContainer.tsx
@@ -131,9 +131,7 @@ export const CommentContainer = ({
             model={nextMessageModel}
             extensions={[command]}
           />
-          <ThreadFooter activity={activity} data-landmark='comment-footer'>
-            {t('activity message')}
-          </ThreadFooter>
+          <ThreadFooter activity={activity}>{t('activity message')}</ThreadFooter>
           <AnchoredOverflow.Anchor />
         </>
       )}

--- a/packages/apps/plugins/plugin-thread/src/components/CommentContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/CommentContainer.tsx
@@ -131,7 +131,9 @@ export const CommentContainer = ({
             model={nextMessageModel}
             extensions={[command]}
           />
-          <ThreadFooter activity={activity}>{t('activity message')}</ThreadFooter>
+          <ThreadFooter activity={activity} data-landmark='comment-footer'>
+            {t('activity message')}
+          </ThreadFooter>
           <AnchoredOverflow.Anchor />
         </>
       )}

--- a/packages/apps/plugins/plugin-thread/src/components/CommentsContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/CommentsContainer.tsx
@@ -37,10 +37,7 @@ export const CommentsContainer = ({
 }: ThreadsContainerProps) => {
   useEffect(() => {
     if (currentId) {
-      document
-        .getElementById(currentId)
-        ?.querySelector('[data-landmark="comment-footer"]')
-        ?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+      document.getElementById(currentId)?.scrollIntoView({ behavior: 'smooth', block: 'end' });
     }
   }, [currentId]);
 

--- a/packages/apps/plugins/plugin-thread/src/components/CommentsContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/CommentsContainer.tsx
@@ -37,8 +37,10 @@ export const CommentsContainer = ({
 }: ThreadsContainerProps) => {
   useEffect(() => {
     if (currentId) {
-      const threadElement = document.getElementById(currentId);
-      threadElement?.scrollIntoView({ behavior: 'smooth' });
+      document
+        .getElementById(currentId)
+        ?.querySelector('[data-landmark="comment-footer"]')
+        ?.scrollIntoView({ behavior: 'smooth', block: 'end' });
     }
   }, [currentId]);
 


### PR DESCRIPTION
This PR adjusts the target position of CommentContainer’s call to `scrollIntoView`.

Resolves [#5401](https://github.com/dxos/dxos/issues/5401).

https://github.com/dxos/dxos/assets/855039/0c674100-8394-49b8-9510-7140a19e236b

