### PR TITLE
fix(tools): force ligth mode in composer devtools

### DIFF
--- a/packages/devtools/devtools/src/app/Devtools.tsx
+++ b/packages/devtools/devtools/src/app/Devtools.tsx
@@ -70,6 +70,17 @@ export const Devtools: FC<{
     },
   });
 
+  // TODO: remove hardcoded themeMode when Devtools dark mode support is ready
+  useEffect(() => {
+    const isDarkMode = document.documentElement.classList.contains('dark');
+    if (isDarkMode) {
+      document.documentElement.classList.remove('dark');
+      return () => {
+        document.documentElement.classList.add('dark');
+      };
+    }
+  });
+
   return (
     <ThemeProvider {...{ tx: devtoolsTx, themeMode: state.themeMode }}>
       <DensityProvider density='fine'>


### PR DESCRIPTION
### Motivation / Background

Composer devtools aren't usable with dark mode system preference and implementing proper dark mode support doesn't seem like an easy task, so a quickfix suggestion here.

Here's how dark mode looks:

<img width="1002" alt="image" src="https://github.com/dxos/dxos/assets/9644546/651aa170-f1cc-4ed2-8de6-fa61c6c1797b">
