### PR TITLE
fix(plugin-markdown): Move spacing to `cm-scroller`, make its overflow visible.

### DIFF
--- a/packages/apps/composer-app/index.html
+++ b/packages/apps/composer-app/index.html
@@ -2,7 +2,7 @@
 <html lang="en" style="overscroll-behavior: none">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no,interactive-widget=resizes-content" />
     <title>Composer</title>
     <meta name="description" content="DXOS Composer Application" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />

--- a/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
@@ -79,9 +79,7 @@ const EditorMain = ({ model, comments, toolbar, extensions: _extensions, ...prop
       <div
         role='none'
         data-toolbar={toolbar ? 'enabled' : 'disabled'}
-        className={mx(
-          'is-full overflow-y-auto overflow-anchored after:block after:is-px after:bs-px after:overflow-anchor after:-mbs-px data-[toolbar=disabled]:pbs-8',
-        )}
+        className='is-full overflow-y-auto overflow-anchored after:block after:is-px after:bs-px after:overflow-anchor after:-mbs-px data-[toolbar=disabled]:pbs-8'
       >
         <MarkdownEditor
           ref={editorRef}
@@ -101,7 +99,11 @@ const EditorMain = ({ model, comments, toolbar, extensions: _extensions, ...prop
               'data-testid': 'composer.markdownRoot',
             } as HTMLAttributes<HTMLDivElement>,
             editor: {
-              className: mx(editorFillLayoutEditor, 'is-full pli-2 sm:pli-6 md:pli-8 py-2', !toolbar && 'border-bs'),
+              className: mx(
+                editorFillLayoutEditor,
+                'is-full [&>.cm-scroller]:overflow-visible [&>.cm-scroller]:p-2 [&>.cm-scroller]:sm:p-6 [&>.cm-scroller]:md:p-8',
+                !toolbar && 'border-bs',
+              ),
             },
             content: {
               className: editorHalfViewportOverscrollContent,


### PR DESCRIPTION
Resolves #5659.

This PR moves `EditorMain`’s spacing to `cm-scroller` from its parent `cm-editor`.

This PR also sets `overflow-visible` on `cm-scroller`
- this was preventing presence names from fully displaying even when there was space
  - other child elements may have similar needs and are unable to portal out of the editor
- `overflow-hidden` should have no other effects since `cm-scroller` does not need to fill its parent’s height
  - clicking in the overscroll still focuses the contenteditable in testing, including in iOS
  
This PR also adds `interactive-widget=resizes-content` to the viewport meta, which should improve the experience for users of devices with a virtual keyboard that support it (not iOS unfortunately). [More info here](https://drafts.csswg.org/css-viewport/#interactive-widget-section).

<img width="480" alt="Screenshot 2024-02-13 at 18 22 11" src="https://github.com/dxos/dxos/assets/855039/5398a209-b49c-4d5d-b04d-a1112f2b9ee9">
<img width="431" alt="Screenshot 2024-02-13 at 18 17 19" src="https://github.com/dxos/dxos/assets/855039/c9f02117-6513-49e4-a671-ec1761f14dda">
![IMG_8534](https://github.com/dxos/dxos/assets/855039/fe1c18b3-c607-4ac8-9fbe-a43a14957965)