### PR TITLE
test(composer-app): update collab e2e tests to handle new space page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,6 @@ jobs:
   publish:
     docker:
       - *docker_image_default
-    # TODO(wittjosiah): Using because of kai bundling memory usage.
     resource_class: xlarge
     steps:
       - checkout

--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -115,6 +115,10 @@ export class AppManager {
     return this.page.getByTestId('spacePlugin.joinSpace').click();
   }
 
+  waitForSpaceReady(params: { interval?: number; timeout?: number } = {}) {
+    return waitFor(() => this.page.getByTestId('spacePlugin.main.name').isEnabled(), params);
+  }
+
   getSpacePresenceMembers() {
     return this.page.getByTestId('spacePlugin.presence.member');
   }
@@ -220,3 +224,24 @@ export class AppManager {
     await this.page.getByTestId('resetDialog').waitFor();
   }
 }
+
+// TODO(wittjosiah): Factor out.
+const waitFor = (
+  cb: () => Promise<boolean>,
+  { interval: _interval = 1000, timeout: _timeout = 10_000 } = {},
+): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    const interval = setInterval(async () => {
+      const res = await cb();
+      if (res) {
+        clearTimeout(timeout);
+        clearInterval(interval);
+        resolve();
+      }
+    }, _interval);
+
+    const timeout = setTimeout(() => {
+      clearInterval(interval);
+      reject(new Error('Timeout waiting for condition.'));
+    }, _timeout);
+  });

--- a/packages/apps/composer-app/src/playwright/collaboration.spec.ts
+++ b/packages/apps/composer-app/src/playwright/collaboration.spec.ts
@@ -46,12 +46,16 @@ test.describe('Collaboration tests', () => {
     await host.createObject('markdownPlugin');
     await perfomInvitation(host, guest);
 
+    await guest.waitForSpaceReady();
+    await waitForExpect(async () => {
+      expect(await guest.getObjectsCount()).to.equal(2);
+    });
+
+    await guest.getObjectLinks().last().click();
     await Markdown.waitForMarkdownTextbox(guest.page);
     await waitForExpect(async () => {
       expect(await host.page.url()).to.equal(await guest.page.url());
-    });
 
-    await waitForExpect(async () => {
       const hostLink = await host.getObjectLinks().last().getAttribute('data-itemid');
       const guestLink = await guest.getObjectLinks().last().getAttribute('data-itemid');
       expect(hostLink).to.equal(guestLink);
@@ -64,7 +68,7 @@ test.describe('Collaboration tests', () => {
     await Markdown.waitForMarkdownTextbox(host.page);
     await perfomInvitation(host, guest);
 
-    await Markdown.waitForMarkdownTextbox(guest.page);
+    await guest.waitForSpaceReady();
     await waitForExpect(async () => {
       expect(await guest.getObjectsCount()).to.equal(2);
     });
@@ -97,7 +101,7 @@ test.describe('Collaboration tests', () => {
     ];
     const allParts = parts.join('');
 
-    await Markdown.waitForMarkdownTextbox(guest.page);
+    await guest.waitForSpaceReady();
     await waitForExpect(async () => {
       expect(await guest.getObjectsCount()).to.equal(2);
     });
@@ -135,6 +139,12 @@ test.describe('Collaboration tests', () => {
     await host.createObject('markdownPlugin');
     await Markdown.waitForMarkdownTextbox(host.page);
     await perfomInvitation(host, guest);
+    await guest.waitForSpaceReady();
+    await waitForExpect(async () => {
+      expect(await guest.getObjectsCount()).to.equal(2);
+    });
+
+    await guest.getObjectLinks().last().click();
     await Markdown.waitForMarkdownTextbox(guest.page);
     // TODO(wittjosiah): Initial viewing state is slow.
     await waitForExpect(async () => {

--- a/packages/apps/composer-app/src/playwright/collaboration.spec.ts
+++ b/packages/apps/composer-app/src/playwright/collaboration.spec.ts
@@ -7,8 +7,6 @@ import { expect } from 'chai';
 import { platform } from 'node:os';
 import waitForExpect from 'wait-for-expect';
 
-import { sleep } from '@dxos/async';
-
 import { AppManager } from './app-manager';
 import { Markdown } from './plugins';
 
@@ -132,9 +130,6 @@ test.describe('Collaboration tests', () => {
   });
 
   test('guest can jump to document host is viewing', async () => {
-    // TODO(wittjosiah): Remove.
-    test.setTimeout(120_000);
-
     await host.createSpace();
     await host.createObject('markdownPlugin');
     await Markdown.waitForMarkdownTextbox(host.page);
@@ -154,12 +149,6 @@ test.describe('Collaboration tests', () => {
     }, 30_000);
 
     await host.createObject('markdownPlugin');
-    // TODO(wittjosiah): Remove. Caused by https://github.com/dxos/dxos/issues/5658.
-    {
-      await sleep(5000); // Wait for replication.
-      await guest.page.reload();
-      await sleep(30_000); // Initial viewing state is slow.
-    }
     await waitForExpect(async () => {
       expect(await host.page.url()).not.to.equal(await guest.page.url());
       expect((await host.getSpacePresenceCount()).active).to.equal(1);

--- a/packages/apps/plugins/plugin-space/src/components/SpaceMain/SpaceMain.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/SpaceMain/SpaceMain.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import { type Action, useGraph } from '@braneframe/plugin-graph';
 import { Surface } from '@dxos/app-framework';
-import { type Space } from '@dxos/react-client/echo';
+import { SpaceState, type Space } from '@dxos/react-client/echo';
 import { Button, Main, useTranslation, Input, DropdownMenu } from '@dxos/react-ui';
 import { getSize, mx, topbarBlockPaddingStart } from '@dxos/react-ui-theme';
 
@@ -80,9 +80,11 @@ const KeyShortcuts = () => {
 };
 
 export const SpaceMain = ({ space }: { space: Space }) => {
+  const { t } = useTranslation(SPACE_PLUGIN);
   const { graph } = useGraph();
   const actionsMap = graph.findNode(space.key.toHex())?.actionsMap;
-  const { t } = useTranslation(SPACE_PLUGIN);
+  const state = space.state.get();
+  const ready = state === SpaceState.READY;
   return (
     <Main.Content
       classNames={[
@@ -91,6 +93,7 @@ export const SpaceMain = ({ space }: { space: Space }) => {
         'grid-cols-[var(--rail-size)_var(--rail-size)_1fr_var(--rail-size)]',
         'md:grid-cols-[var(--rail-size)_var(--rail-size)_minmax(max-content,1fr)_var(--rail-size)_var(--rail-size)_minmax(max-content,2fr)_var(--rail-size)]',
       ]}
+      data-testid='spacePlugin.main'
     >
       <h1 className='contents'>
         <MenuSpaceActions actionsMap={actionsMap} />
@@ -99,14 +102,16 @@ export const SpaceMain = ({ space }: { space: Space }) => {
           <Input.TextInput
             variant='subdued'
             classNames='text-2xl text-light col-span-3 md:col-span-4'
+            data-testid='spacePlugin.main.name'
+            disabled={!ready}
             value={space.properties.name ?? ''}
             onChange={({ target: { value } }) => (space.properties.name = value)}
-            placeholder={space.key.truncate()}
+            placeholder={ready ? t('unnamed space label') : t('loading space label')}
           />
         </Input.Root>
       </h1>
       {actionsMap && <InFlowSpaceActions actionsMap={actionsMap} />}
-      <SpaceMembersSection space={space} />
+      {ready && <SpaceMembersSection space={space} />}
       <KeyShortcuts />
     </Main.Content>
   );

--- a/packages/apps/plugins/plugin-space/src/components/SpaceMain/SpaceMembersSection.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/SpaceMain/SpaceMembersSection.tsx
@@ -182,7 +182,9 @@ export const SpaceMembersSection = ({ space }: { space: Space }) => {
         </DropdownMenu.Root>
       </ButtonGroup>
       {members[Presence.ONLINE].length + members[Presence.OFFLINE].length < 1 ? (
-        <p className={mx(descriptionText, 'text-center is-full mlb-2')}>{t('empty space members message')}</p>
+        <p className={mx(descriptionText, 'text-center is-full mlb-2')}>
+          {t('empty space members message', { ns: 'os' })}
+        </p>
       ) : (
         <>
           <h3 className='col-start-2 col-end-5 text-sm italic fg-description'>

--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -88,6 +88,7 @@ const getFolderGraphNodePartials = ({
         ],
         properties: {
           disposition: 'toolbar',
+          mainAreaDisposition: 'in-flow',
           menuType: 'searchList',
           testId: 'spacePlugin.createObject',
         },

--- a/tools/ridoculous/project.json
+++ b/tools/ridoculous/project.json
@@ -12,8 +12,7 @@
         "tsConfig": "tools/ridoculous/tsconfig.json"
       }
     },
-    "lint": {},
-    "vitest": {}
+    "lint": {}
   },
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "name": "ridoculous"


### PR DESCRIPTION
<!-- For shorter PRs, feel free to delete the majority of this description and just use a sentence or two -->

### Motivation / Background

<!--
Describe why this Pull Request exists. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include `Fixes #ISSUE` (replace with the issue number) to link a specific to this PR.
-->

This Pull Request resolves the current e2e test failures on main.

### Details

<!--
Describe the specific changes you made.
-->

- test changes
  - instead of waiting for a document after an invitation, wait for the space to be ready
  - tell if the space is ready by whether the name input is enabled
  - once space and document has synced, open the document
- include "add to space" on the space page
- hide invitations section until space is ready


<!-- Provide additional information such as references to other repositories, alternative solutions, etc. -->

<!-- If this PR changes something visual, feel free to add a screenshot or a video. -->
