### PR TITLE
fix: Fix device invitation

### DIFF
--- a/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
+++ b/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
@@ -16,7 +16,6 @@ import {
 } from '@dxos/app-framework';
 import { Config, Defaults, Envs, Local, Storage } from '@dxos/config';
 import { registerSignalFactory } from '@dxos/echo-signals/react';
-import { log } from '@dxos/log';
 import { Client, ClientContext, type ClientOptions, type SystemStatus } from '@dxos/react-client';
 import { type TypeCollection } from '@dxos/react-client/echo';
 

--- a/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
+++ b/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
@@ -16,6 +16,7 @@ import {
 } from '@dxos/app-framework';
 import { Config, Defaults, Envs, Local, Storage } from '@dxos/config';
 import { registerSignalFactory } from '@dxos/echo-signals/react';
+import { log } from '@dxos/log';
 import { Client, ClientContext, type ClientOptions, type SystemStatus } from '@dxos/react-client';
 import { type TypeCollection } from '@dxos/react-client/echo';
 
@@ -92,7 +93,7 @@ export const ClientPlugin = ({
           // TODO(wittjosiah): Ideally this would be per app rather than per identity.
           firstRun = true;
         } else if (deviceInvitationCode) {
-          void client.shell.initializeIdentity({ invitationCode: deviceInvitationCode });
+          await client.shell.initializeIdentity({ invitationCode: deviceInvitationCode });
         }
 
         if (client.halo.identity.get()) {


### PR DESCRIPTION
resolves https://github.com/dxos/dxos/issues/5568
Device invitation would leave composer tree blank because [early return](https://github.com/dxos/dxos/blob/98795677db55a5999563be026ca22ee20568a679/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx#L337)

`client.spaces.isReady.get()` was returning `false`
It all happened because [this line was never reached](https://github.com/dxos/dxos/blob/98795677db55a5999563be026ca22ee20568a679/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx#L99)