### PR TITLE
fix(plugin-thread): multiple comments working again

### DIFF
--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -115,7 +115,7 @@ export class AppManager {
     return this.page.getByTestId('spacePlugin.joinSpace').click();
   }
 
-  waitForSpaceReady(params: { interval?: number; timeout?: number } = {}) {
+  waitForSpaceReady(params: { interval?: number; timeout?: number } = { timeout: 30_000 }) {
     return waitFor(() => this.page.getByTestId('spacePlugin.main.name').isEnabled(), params);
   }
 
@@ -228,7 +228,7 @@ export class AppManager {
 // TODO(wittjosiah): Factor out.
 const waitFor = (
   cb: () => Promise<boolean>,
-  { interval: _interval = 1000, timeout: _timeout = 10_000 } = {},
+  { interval: _interval = 1000, timeout: _timeout = 5_000 } = {},
 ): Promise<void> =>
   new Promise<void>((resolve, reject) => {
     const interval = setInterval(async () => {

--- a/packages/apps/composer-app/src/playwright/collaboration.spec.ts
+++ b/packages/apps/composer-app/src/playwright/collaboration.spec.ts
@@ -73,6 +73,7 @@ test.describe('Collaboration tests', () => {
 
     await guest.getObjectLinks().last().click();
     await Markdown.waitForMarkdownTextbox(guest.page);
+    await Markdown.getMarkdownTextbox(guest.page).blur();
     await waitForExpect(async () => {
       expect(await Markdown.getCollaboratorCursors(host.page).count()).to.equal(0);
       expect(await Markdown.getCollaboratorCursors(guest.page).count()).to.equal(0);

--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -88,7 +88,8 @@ const getFolderGraphNodePartials = ({
         ],
         properties: {
           disposition: 'toolbar',
-          mainAreaDisposition: 'in-flow',
+          // TODO(wittjosiah): This is currently a navtree feature. Address this with cmd+k integration.
+          // mainAreaDisposition: 'in-flow',
           menuType: 'searchList',
           testId: 'spacePlugin.createObject',
         },

--- a/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { useLayoutEffect, useRef, useState } from 'react';
+import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { Message as MessageType } from '@braneframe/types';
 import { TextObject, getTextContent, useMembers } from '@dxos/react-client/echo';
@@ -23,6 +23,7 @@ export const ChatContainer = ({ space, thread, context, current, autoFocus }: Th
   const members = useMembers(space.key);
   const activity = useStatus(space, thread.id);
   const { t } = useTranslation(THREAD_PLUGIN);
+  const extensions = useMemo(() => [command], []);
 
   const [nextMessage, setNextMessage] = useState({ text: new TextObject() });
   const nextMessageModel = useTextModel({ text: nextMessage.text, identity, space });
@@ -109,7 +110,7 @@ export const ChatContainer = ({ space, thread, context, current, autoFocus }: Th
             placeholder={t('message placeholder')}
             {...textboxMetadata}
             model={nextMessageModel}
-            extensions={[command]}
+            extensions={extensions}
           />
           <ThreadFooter activity={activity}>{t('activity message')}</ThreadFooter>
         </>

--- a/packages/apps/plugins/plugin-thread/src/components/CommentContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/CommentContainer.tsx
@@ -3,7 +3,7 @@
 //
 
 import { X } from '@phosphor-icons/react';
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import { Message as MessageType } from '@braneframe/types';
 import { TextObject, getTextContent, useMembers } from '@dxos/react-client/echo';
@@ -33,12 +33,13 @@ export const CommentContainer = ({
   const members = useMembers(space.key);
   const activity = useStatus(space, thread.id);
   const { t } = useTranslation(THREAD_PLUGIN);
+  const extensions = useMemo(() => [command], []);
 
   const [nextMessage, setNextMessage] = useState({ text: new TextObject() });
   const nextMessageModel = useTextModel({ text: nextMessage.text, identity, space });
   const autoFocusAfterSend = useRef<boolean>(false);
 
-  const handleCreate: MessageTextboxProps['onSend'] = () => {
+  const handleCreate: MessageTextboxProps['onSend'] = useCallback(() => {
     const content = nextMessage.text;
     if (!getTextContent(content)) {
       return false;
@@ -64,7 +65,7 @@ export const CommentContainer = ({
 
     // TODO(burdon): Scroll to bottom.
     return true;
-  };
+  }, [nextMessage, thread, identity]);
 
   const handleDelete = (id: string, index: number) => {
     const messageIndex = thread.messages.findIndex((message) => message.id === id);
@@ -129,7 +130,7 @@ export const CommentContainer = ({
             placeholder={t('message placeholder')}
             {...textboxMetadata}
             model={nextMessageModel}
-            extensions={[command]}
+            extensions={extensions}
           />
           <ThreadFooter activity={activity}>{t('activity message')}</ThreadFooter>
           <AnchoredOverflow.Anchor />

--- a/packages/apps/plugins/plugin-thread/src/components/MessageContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/MessageContainer.tsx
@@ -3,7 +3,7 @@
 //
 
 import { X } from '@phosphor-icons/react';
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 
 import { type Message as MessageType } from '@braneframe/types';
 import { Surface } from '@dxos/app-framework';
@@ -69,6 +69,7 @@ const TextboxBlock = ({
 }: { text: TextObject } & Pick<MessageBlockProps<MessageType.Block>, 'authorId' | 'onBlockDelete'>) => {
   const identity = useIdentity();
   const model = useTextModel({ text });
+  const extensions = useMemo(() => [command], []);
   const textboxWidth = onBlockDelete ? 'col-span-2' : 'col-span-3';
   const readonly = identity?.identityKey.toHex() !== authorId;
 
@@ -82,7 +83,7 @@ const TextboxBlock = ({
           model={model}
           readonly={readonly}
           slots={{ root: { className: textboxWidth } }}
-          extensions={[command]}
+          extensions={extensions}
         />
       ) : (
         <span className={textboxWidth} />

--- a/packages/ui/react-ui-thread/src/Message/Message.tsx
+++ b/packages/ui/react-ui-thread/src/Message/Message.tsx
@@ -4,7 +4,7 @@
 
 import { X } from '@phosphor-icons/react';
 import { formatDistanceToNow } from 'date-fns/formatDistanceToNow';
-import React, { type ComponentPropsWithRef, type FC, forwardRef } from 'react';
+import React, { type ComponentPropsWithRef, type FC, forwardRef, useMemo } from 'react';
 
 import { Avatar, Button, type ThemedClassName, useJdenticonHref, useTranslation } from '@dxos/react-ui';
 import { TextEditor, type TextEditorProps, keymap, type EditorView, listener } from '@dxos/react-ui-editor';
@@ -140,9 +140,57 @@ export type MessageTextboxProps = {
 
 export const MessageTextbox = forwardRef<EditorView, MessageTextboxProps>(
   (
-    { onSend, onClear, onEditorFocus, authorId, authorName, authorImgSrc, disabled, extensions = [], ...editorProps },
+    {
+      onSend,
+      onClear,
+      onEditorFocus,
+      authorId,
+      authorName,
+      authorImgSrc,
+      disabled,
+      extensions: _extensions,
+      ...editorProps
+    },
     forwardedRef,
   ) => {
+    const extensions = useMemo(
+      () => [
+        ...(_extensions ?? []),
+        keymap.of([
+          {
+            key: 'Enter',
+            run: () => {
+              if (onSend) {
+                onSend();
+                return true;
+              } else {
+                return false;
+              }
+            },
+          },
+          {
+            key: 'Meta+Backspace',
+            run: () => {
+              if (onClear) {
+                onClear();
+                return true;
+              } else {
+                return false;
+              }
+            },
+          },
+        ]),
+        listener({
+          onFocus: (focused) => {
+            if (focused) {
+              onEditorFocus?.();
+            }
+          },
+        }),
+      ],
+      [_extensions, onSend, onClear, onEditorFocus],
+    );
+
     return (
       <MessageMeta
         {...{ id: editorProps.model.id, authorId, authorName, authorImgSrc }}
@@ -152,40 +200,7 @@ export const MessageTextbox = forwardRef<EditorView, MessageTextboxProps>(
         <TextEditor
           slots={{ root: { className: mx('plb-0.5 mie-1 rounded-sm', focusRing, disabled && 'opacity-50') } }}
           readonly={disabled}
-          extensions={[
-            ...extensions,
-            keymap.of([
-              {
-                key: 'Enter',
-                run: () => {
-                  if (onSend) {
-                    onSend();
-                    return true;
-                  } else {
-                    return false;
-                  }
-                },
-              },
-              {
-                key: 'Meta+Backspace',
-                run: () => {
-                  if (onClear) {
-                    onClear();
-                    return true;
-                  } else {
-                    return false;
-                  }
-                },
-              },
-            ]),
-            listener({
-              onFocus: (focused) => {
-                if (focused) {
-                  onEditorFocus?.();
-                }
-              },
-            }),
-          ]}
+          extensions={extensions}
           {...editorProps}
           ref={forwardedRef}
         />


### PR DESCRIPTION

<!-- For shorter PRs, feel free to delete the majority of this description and just use a sentence or two -->

### Motivation / Background

<!--
Describe why this Pull Request exists. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include `Fixes #ISSUE` (replace with the issue number) to link a specific to this PR.
-->

This Pull Request fixes an issue where if multiple comment threads are on screen at the same time the focus always jumps back to the first one.

### Details

- thread message editors needed their extensions memoized too

<!--
Describe the specific changes you made.
-->


<!-- Provide additional information such as references to other repositories, alternative solutions, etc. -->

<!-- If this PR changes something visual, feel free to add a screenshot or a video. -->
