### PR TITLE
fix(plugin-native): app starts up on iOS

### DIFF
--- a/packages/apps/plugins/plugin-native/src/NativePlugin.tsx
+++ b/packages/apps/plugins/plugin-native/src/NativePlugin.tsx
@@ -6,7 +6,6 @@ import { HELP_PLUGIN } from '@braneframe/plugin-help/meta';
 import { NAVTREE_PLUGIN } from '@braneframe/plugin-navtree/meta';
 import type { Plugin, PluginDefinition } from '@dxos/app-framework';
 import { NavigationAction, SettingsAction, LayoutAction, parseIntentPlugin, resolvePlugin } from '@dxos/app-framework';
-import { log } from '@dxos/log';
 import { safeParseJson } from '@dxos/util';
 
 import meta from './meta';
@@ -79,7 +78,9 @@ const initializeNativeApp = async (plugins: Plugin[]) => {
     ;
   `;
 
-  await app.setSystemMenu({ index: 0, value: menu });
+  // TODO(wittjosiah): Not awaiting because this never resolves on iOS.
+  //  It should probably throw on iOS and be gated behind a platform check (https://github.com/dxos/dxos/issues/5689).
+  void app.setSystemMenu({ index: 0, value: menu });
 
   window.addEventListener('menuItemSelected', async (event: any) => {
     const id = `${event.detail.parent}:${event.detail.title}`;
@@ -124,7 +125,6 @@ const initializeNativeApp = async (plugins: Plugin[]) => {
   });
 
   // TODO(burdon): Initial url has index.html, which must be caught/redirected.
-  log.info('native setup complete');
 };
 
 export const NativePlugin = (): PluginDefinition => ({


### PR DESCRIPTION
Resolves an issue where the app wasn't starting up on iOS because the set menu call never resolved.
