### PR TITLE
fix(echo): no callback invoked on separate-automerge doc resolution

### DIFF
--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
@@ -43,7 +43,7 @@ export class AutomergeDb {
   readonly _objects = new Map<string, AutomergeObject>();
   readonly _objectsSystem = new Map<string, EchoObject>();
 
-  readonly _updateEvent = new Event<{ spaceKey: PublicKey; itemsUpdated: { id: string }[] }>();
+  readonly _updateEvent = new Event<ItemsUpdatedEvent>();
 
   private _ctx?: Context = undefined;
 
@@ -308,3 +308,8 @@ const getInlineAndLinkChanges = (event: DocHandleChangePayload<SpaceDoc>) => {
     linkedDocuments,
   };
 };
+
+export interface ItemsUpdatedEvent {
+  spaceKey: PublicKey;
+  itemsUpdated: Array<{ id: string }>;
+}

--- a/packages/core/echo/echo-schema/src/hypergraph.ts
+++ b/packages/core/echo/echo-schema/src/hypergraph.ts
@@ -5,7 +5,6 @@
 import { Event } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { type Reference } from '@dxos/document-model';
-import { type UpdateEvent } from '@dxos/echo-db';
 import { compositeRuntime } from '@dxos/echo-signals/runtime';
 import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
@@ -13,7 +12,7 @@ import { log } from '@dxos/log';
 import { QueryOptions } from '@dxos/protocols/proto/dxos/echo/filter';
 import { ComplexMap, WeakDictionary, entry } from '@dxos/util';
 
-import { type AutomergeDb } from './automerge';
+import { type AutomergeDb, type ItemsUpdatedEvent } from './automerge';
 import { type EchoDatabaseImpl, type EchoDatabase } from './database';
 import { type EchoObject, type TypedObject } from './object';
 import {
@@ -35,7 +34,7 @@ export class Hypergraph {
   // TODO(burdon): Rename.
   private readonly _owningObjects = new ComplexMap<PublicKey, unknown>(PublicKey.hash);
   private readonly _types = new TypeCollection();
-  private readonly _updateEvent = new Event<UpdateEvent>();
+  private readonly _updateEvent = new Event<ItemsUpdatedEvent>();
   private readonly _resolveEvents = new ComplexMap<PublicKey, Map<string, Event<EchoObject>>>(PublicKey.hash);
   private readonly _queryContexts = new WeakDictionary<{}, GraphQueryContext>();
   private readonly _querySourceProviders: QuerySourceProvider[] = [];
@@ -58,6 +57,7 @@ export class Hypergraph {
     this._databases.set(spaceKey, database);
     this._owningObjects.set(spaceKey, owningObject);
     database._updateEvent.on(this._onUpdate.bind(this));
+    database.automerge._updateEvent.on(this._onUpdate.bind(this));
 
     const map = this._resolveEvents.get(spaceKey);
     if (map) {
@@ -110,19 +110,16 @@ export class Hypergraph {
       }
     }
 
-    if (!ref.host) {
-      // No space key.
-      log('no space key', { ref });
-      return undefined;
-    }
+    const spaceKey = ref.host ? PublicKey.from(ref.host) : from?.spaceKey;
 
-    const spaceKey = PublicKey.from(ref.host);
-    const remoteDb = this._databases.get(spaceKey);
-    if (remoteDb) {
-      // Resolve remote reference.
-      const remote = remoteDb.getObjectById(ref.itemId);
-      if (remote) {
-        return remote;
+    if (ref.host) {
+      const remoteDb = this._databases.get(spaceKey);
+      if (remoteDb) {
+        // Resolve remote reference.
+        const remote = remoteDb.getObjectById(ref.itemId);
+        if (remote) {
+          return remote;
+        }
       }
     }
 
@@ -141,7 +138,7 @@ export class Hypergraph {
     }
   }
 
-  private _onUpdate(updateEvent: UpdateEvent) {
+  private _onUpdate(updateEvent: ItemsUpdatedEvent) {
     const listenerMap = this._resolveEvents.get(updateEvent.spaceKey);
     if (listenerMap) {
       compositeRuntime.batch(() => {
@@ -165,7 +162,6 @@ export class Hypergraph {
         }
       });
     }
-
     this._updateEvent.emit(updateEvent);
   }
 
@@ -215,7 +211,7 @@ class SpaceQuerySource implements QuerySource {
     return this._database.spaceKey;
   }
 
-  private _onUpdate = (updateEvent: { spaceKey: PublicKey; itemsUpdated: { id: string }[] }) => {
+  private _onUpdate = (updateEvent: ItemsUpdatedEvent) => {
     if (!this._filter) {
       return;
     }


### PR DESCRIPTION
### Details

* hypergraph wasn't subscribing to automerge update events, only to legacy echo db events
* lookupLink wasn't registering resolution callback for local references, only cross-space references
