### PR TITLE
feat: debug plugin AM space fragmentation toggle

### DIFF
--- a/packages/apps/plugins/plugin-debug/src/components/DebugSettings.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DebugSettings.tsx
@@ -114,16 +114,12 @@ export const DebugSettings = ({ settings }: { settings: DebugSettingsProps }) =>
           }
           onValueChange={(value) => {
             if (confirm(t('settings storage adapter changed alert'))) {
-              const storageConfigCopy = JSON.parse(JSON.stringify(storageConfig ?? {}));
-              assignDeep(
-                storageConfigCopy,
+              updateConfig(
+                storageConfig,
+                setStorageConfig,
                 ['runtime', 'client', 'storage', 'dataStore'],
                 StorageAdapters[value as keyof typeof StorageAdapters],
               );
-              setStorageConfig(storageConfigCopy);
-              queueMicrotask(async () => {
-                await SaveConfig(storageConfigCopy);
-              });
             }
           }}
         >
@@ -141,6 +137,29 @@ export const DebugSettings = ({ settings }: { settings: DebugSettingsProps }) =>
           </Select.Portal>
         </Select.Root>
       </SettingsValue>
+
+      <SettingsValue label={t('settings space fragmentation')}>
+        <Input.Switch
+          checked={storageConfig?.runtime?.client?.storage?.spaceFragmentation}
+          onCheckedChange={(checked) => {
+            updateConfig(
+              storageConfig,
+              setStorageConfig,
+              ['runtime', 'client', 'storage', 'spaceFragmentation'],
+              !!checked,
+            );
+          }}
+        />
+      </SettingsValue>
     </>
   );
+};
+
+const updateConfig = (config: ConfigProto, setConfig: (newConfig: ConfigProto) => void, path: string[], value: any) => {
+  const storageConfigCopy = JSON.parse(JSON.stringify(config ?? {}));
+  assignDeep(storageConfigCopy, path, value);
+  setConfig(storageConfigCopy);
+  queueMicrotask(async () => {
+    await SaveConfig(storageConfigCopy);
+  });
 };

--- a/packages/apps/plugins/plugin-debug/src/translations.ts
+++ b/packages/apps/plugins/plugin-debug/src/translations.ts
@@ -28,6 +28,7 @@ export default [
         'settings data store label': 'Data Store',
         'settings storage adapter changed alert':
           'Warning: Swapping the storage adapter will make your data unavailable.',
+        'settings space fragmentation': 'Enable AM space fragmentation',
       },
     },
   },

--- a/packages/core/echo/echo-schema/src/automerge/automerge-context.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-context.ts
@@ -26,8 +26,12 @@ export class AutomergeContext {
   @trace.info()
   private readonly _peerId: string;
 
-  constructor(dataService: DataService | undefined = undefined) {
+  @trace.info()
+  public readonly spaceFragmentationEnabled: boolean;
+
+  constructor(dataService: DataService | undefined = undefined, config: AutomergeContextConfig = {}) {
     this._peerId = `client-${PublicKey.random().toHex()}` as PeerId;
+    this.spaceFragmentationEnabled = config.spaceFragmentationEnabled ?? false;
     if (dataService) {
       this._adapter = new LocalClientNetworkAdapter(dataService);
       this._repo = new Repo({
@@ -175,4 +179,8 @@ class LocalClientNetworkAdapter extends NetworkAdapter {
     // TODO(mykola): `disconnect` is not used anywhere in `Repo` from `@automerge/automerge-repo`. Should we remove it?
     // No-op
   }
+}
+
+export interface AutomergeContextConfig {
+  spaceFragmentationEnabled?: boolean;
 }

--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.test.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.test.ts
@@ -14,8 +14,21 @@ import { TestBuilder, type TestPeer } from '../testing';
 
 describe('AutomergeDb', () => {
   describe('space fragmentation', () => {
-    test('non-text objects are created inline in space root doc', async () => {
+    const createSpaceFragmentationTestBuilder = () => new TestBuilder({ spaceFragmentationEnabled: true });
+
+    test('text objects are created inline if space fragmentation is disabled', async () => {
       const testBuilder = new TestBuilder();
+      const testPeer = await testBuilder.createPeer();
+      const object = new TextObject();
+      testPeer.db.add(object);
+      const docHandles = getDocHandles(testPeer);
+      expect(docHandles.linkedDocHandles.length).to.eq(0);
+      const rootDoc = docHandles.spaceRootHandle.docSync();
+      expect(rootDoc?.objects[object.id]).not.to.be.undefined;
+    });
+
+    test('non-text objects are created inline in space root doc', async () => {
+      const testBuilder = createSpaceFragmentationTestBuilder();
       const testPeer = await testBuilder.createPeer();
       const object = new TypedObject();
       testPeer.db.add(object);
@@ -26,7 +39,7 @@ describe('AutomergeDb', () => {
     });
 
     test('text objects are created in a separate doc and link from the root doc is added', async () => {
-      const testBuilder = new TestBuilder();
+      const testBuilder = createSpaceFragmentationTestBuilder();
       const testPeer = await testBuilder.createPeer();
       const object = new TextObject();
       testPeer.db.add(object);
@@ -36,7 +49,7 @@ describe('AutomergeDb', () => {
     });
 
     test("separate-doc object is treated as inline if it's both linked and inline", async () => {
-      const testBuilder = new TestBuilder();
+      const testBuilder = createSpaceFragmentationTestBuilder();
       const firstPeer = await testBuilder.createPeer();
       const object = new TextObject();
       firstPeer.db.add(object);

--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
@@ -142,7 +142,7 @@ export class AutomergeDb {
     // All objects should be created linked to root space doc after query indexing is ready to make them
     // discoverable.
     let spaceDocHandle: DocHandle<SpaceDoc>;
-    if (obj.__typename === LEGACY_TEXT_TYPE) {
+    if (obj.__typename === LEGACY_TEXT_TYPE && this.automerge.spaceFragmentationEnabled) {
       spaceDocHandle = this._automergeDocLoader.createDocumentForObject(obj.id);
       spaceDocHandle.on('change', this._onDocumentUpdate);
     } else {

--- a/packages/core/echo/echo-schema/src/testing/testing.ts
+++ b/packages/core/echo/echo-schema/src/testing/testing.ts
@@ -15,7 +15,7 @@ import { ModelFactory } from '@dxos/model-factory';
 import { TextModel } from '@dxos/text-model';
 import { ComplexMap } from '@dxos/util';
 
-import { AutomergeContext } from '../automerge';
+import { AutomergeContext, type AutomergeContextConfig } from '../automerge';
 import { EchoDatabaseImpl } from '../database';
 import { Hypergraph } from '../hypergraph';
 import { schemaBuiltin } from '../proto';
@@ -46,12 +46,14 @@ export const createDatabase = async (graph = new Hypergraph()) => {
 
 export class TestBuilder {
   public readonly defaultSpaceKey = PublicKey.random();
-  public readonly automergeContext = new AutomergeContext();
+  public readonly graph = new Hypergraph();
+  public readonly base = new DatabaseTestBuilder();
 
-  constructor(
-    public readonly graph = new Hypergraph(),
-    public readonly base = new DatabaseTestBuilder(),
-  ) {}
+  public readonly automergeContext;
+
+  constructor(automergeConfig?: AutomergeContextConfig) {
+    this.automergeContext = new AutomergeContext(undefined, automergeConfig);
+  }
 
   public readonly peers = new ComplexMap<PublicKey, TestPeer>(PublicKey.hash);
 

--- a/packages/core/protocols/src/proto/dxos/config.proto
+++ b/packages/core/protocols/src/proto/dxos/config.proto
@@ -103,6 +103,7 @@ message Runtime {
       optional StorageDriver key_store = 2;
       optional StorageDriver data_store = 3;
       optional string data_root = 4;
+      optional bool space_fragmentation = 5;
     }
 
     message Log {

--- a/packages/sdk/client/src/client/client.ts
+++ b/packages/sdk/client/src/client/client.ts
@@ -346,6 +346,7 @@ export class Client {
     const mesh = new MeshProxy(this._services, this._instanceId);
     const halo = new HaloProxy(this._services, this._instanceId);
     const spaces = new SpaceList(
+      this._config,
       this._services,
       modelFactory,
       this._graph,

--- a/packages/sdk/client/src/echo/space-list.ts
+++ b/packages/sdk/client/src/echo/space-list.ts
@@ -14,6 +14,7 @@ import {
   type PropertiesProps,
   type Space,
 } from '@dxos/client-protocol';
+import { type Config } from '@dxos/config';
 import { Context } from '@dxos/context';
 import { failUndefined, inspectObject, todo } from '@dxos/debug';
 import {
@@ -56,6 +57,7 @@ export class SpaceList extends MulticastObservable<Space[]> implements Echo {
   }
 
   constructor(
+    private readonly _config: Config | undefined,
     private readonly _serviceProvider: ClientServicesProvider,
     private readonly _modelFactory: ModelFactory,
     private readonly _graph: Hypergraph,
@@ -68,7 +70,9 @@ export class SpaceList extends MulticastObservable<Space[]> implements Echo {
     const spacesStream = new PushStream<Space[]>();
     super(spacesStream.observable, []);
     this._spacesStream = spacesStream;
-    this._automergeContext = new AutomergeContext(_serviceProvider.services.DataService);
+    this._automergeContext = new AutomergeContext(_serviceProvider.services.DataService, {
+      spaceFragmentationEnabled: this._config?.values?.runtime?.client?.storage?.spaceFragmentation ?? false,
+    });
   }
 
   [inspect.custom]() {


### PR DESCRIPTION
### Motivation / Background

Adds a toggle in debug plugin that enables automerge space fragmentation. 
When enabled and reloaded new text objects will be created in separate automerge documents. 