### PR TITLE
feat(echo): enabled text object lazy loading

### DIFF
--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.test.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.test.ts
@@ -2,14 +2,17 @@
 // Copyright 2024 DXOS.org
 //
 
+import { effect } from '@preact/signals-core';
 import { expect } from 'chai';
 
+import { Trigger } from '@dxos/async';
 import { type DocHandle } from '@dxos/automerge/automerge-repo';
+import { registerSignalRuntime } from '@dxos/echo-signals';
 import { describe, test } from '@dxos/test';
 
 import { getAutomergeObjectCore } from './automerge-object';
 import { type SpaceDoc } from './types';
-import { TextObject, TypedObject } from '../object';
+import { type EchoObject, Expando, TextObject, TypedObject } from '../object';
 import { TestBuilder, type TestPeer } from '../testing';
 
 describe('AutomergeDb', () => {
@@ -48,25 +51,58 @@ describe('AutomergeDb', () => {
       expect(docHandles.spaceRootHandle.docSync()?.links[object.id]).to.eq(docHandles.linkedDocHandles[0].url);
     });
 
-    test("separate-doc object is treated as inline if it's both linked and inline", async () => {
-      const testBuilder = createSpaceFragmentationTestBuilder();
-      const firstPeer = await testBuilder.createPeer();
-      const object = new TextObject();
-      firstPeer.db.add(object);
-      const docHandles = getDocHandles(firstPeer);
+    test('effect nested reference access triggers document loading', async () => {
+      registerSignalRuntime();
 
-      const textHandle = docHandles.linkedDocHandles[0]!;
-      expect(getAutomergeObjectCore(object).docHandle?.url).to.eq(textHandle.url);
-      docHandles.spaceRootHandle.change((newDocument: SpaceDoc) => {
-        newDocument.objects = textHandle.docSync()?.objects;
+      const document = new Expando({ text: new TextObject('Hello, world!') });
+      const peer = await createPeerInSpaceWithObject(document);
+      const peerDocument = peer.db.getObjectById<typeof document>(document.id)!;
+      expect(peerDocument).not.to.be.undefined;
+
+      let isFirstInvocation = true;
+      const onPropertyLoaded = new Trigger();
+      const clearEffect = effect(() => {
+        if (isFirstInvocation) {
+          expect(peerDocument.text).to.be.undefined;
+        } else {
+          expect(peerDocument.text.content).to.eq(document.text.content);
+          onPropertyLoaded.wake();
+        }
+        isFirstInvocation = false;
       });
+      await onPropertyLoaded.wait();
+      clearEffect();
+    });
 
+    test('reference access triggers document loading', async () => {
+      const textObject = new TextObject('Hello, world!');
+      const peer = await createPeerInSpaceWithObject(textObject);
+      const onObjectLoaded = new Trigger();
+      const unsubscribe = peer.db.query({ id: textObject.id }).subscribe(() => {
+        onObjectLoaded.wake();
+      });
+      const peerTextObject = peer.db.getObjectById<typeof textObject>(textObject.id);
+      expect(peerTextObject).to.be.undefined;
+      await onObjectLoaded.wait();
+      unsubscribe();
+    });
+
+    test("separate-doc object is treated as inline if it's both linked and inline", async () => {
+      const object = new TextObject();
       // The second peer treats text as inline right after opening the document
-      const secondPeer = await testBuilder.createPeer(firstPeer.spaceKey, firstPeer.automergeDocId);
-      const secondPeerText = secondPeer.db.getObjectById(object.id)!;
-      expect(getAutomergeObjectCore(secondPeerText).docHandle?.url).to.eq(docHandles.spaceRootHandle.url);
+      const peer = await createPeerInSpaceWithObject(object, (handles) => {
+        const textHandle = handles.linkedDocHandles[0]!;
+        expect(getAutomergeObjectCore(object).docHandle?.url).to.eq(textHandle.url);
+        handles.spaceRootHandle.change((newDocument: SpaceDoc) => {
+          newDocument.objects = textHandle.docSync()?.objects;
+        });
+      });
+      const peerText = peer.db.getObjectById(object.id)!;
+      expect(peerText).not.to.be.undefined;
+      const spaceRootHandle = getDocHandles(peer).spaceRootHandle;
+      expect(getAutomergeObjectCore(peerText).docHandle?.url).to.eq(spaceRootHandle.url);
       // The first peer rebinds its object to space root too
-      expect(getAutomergeObjectCore(object).docHandle?.url).to.eq(docHandles.spaceRootHandle.url);
+      expect(getAutomergeObjectCore(object).docHandle?.url).to.eq(spaceRootHandle.url);
     });
   });
 });
@@ -76,6 +112,17 @@ const getDocHandles = (peer: TestPeer): DocumentHandles => {
   const spaceRootHandle = handles.find((h) => h.url === peer.automergeDocId)!;
   const linkedDocHandles = handles.filter((h) => h.url !== peer.automergeDocId);
   return { spaceRootHandle, linkedDocHandles };
+};
+
+const createPeerInSpaceWithObject = async (
+  object: EchoObject,
+  onDocumentSavedInSpace?: (handles: DocumentHandles) => void,
+): Promise<TestPeer> => {
+  const testBuilder = new TestBuilder({ spaceFragmentationEnabled: true });
+  const firstPeer = await testBuilder.createPeer();
+  firstPeer.db.add(object);
+  onDocumentSavedInSpace?.(getDocHandles(firstPeer));
+  return testBuilder.createPeer(firstPeer.spaceKey, firstPeer.automergeDocId);
 };
 
 interface DocumentHandles {

--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
@@ -84,7 +84,6 @@ export class AutomergeDb {
       invariant(spaceRootDoc);
       const objectIds = Object.keys(spaceRootDoc.objects ?? {});
       this._createInlineObjects(spaceRootDocHandle, objectIds);
-      this._automergeDocLoader.loadLinkedObjects(spaceRootDoc.links);
       spaceRootDocHandle.on('change', this._onDocumentUpdate);
     } catch (err) {
       if (err instanceof ContextDisposedError) {
@@ -114,6 +113,7 @@ export class AutomergeDb {
   getObjectById(id: string): EchoObject | undefined {
     const obj = this._objects.get(id) ?? this._echoDatabase._objects.get(id);
     if (!obj) {
+      this._automergeDocLoader.loadObjectDocument(id);
       return undefined;
     }
 
@@ -200,7 +200,7 @@ export class AutomergeDb {
   private readonly _onDocumentUpdate = (event: DocHandleChangePayload<SpaceDoc>) => {
     const documentChanges = this._processDocumentUpdate(event);
     this._rebindObjects(event.handle, documentChanges.objectsToRebind);
-    this._automergeDocLoader.loadLinkedObjects(documentChanges.linkedDocuments);
+    this._automergeDocLoader.onObjectLinksUpdated(documentChanges.linkedDocuments);
     this._createInlineObjects(event.handle, documentChanges.createdObjectIds);
     this._emitUpdateEvent(documentChanges.updatedObjectIds);
   };

--- a/packages/core/echo/echo-schema/src/automerge/automerge-doc-loader.test.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-doc-loader.test.ts
@@ -41,7 +41,7 @@ describe('AutomergeDocumentLoader', () => {
     const { loader, automerge } = await setupTest();
     const handle = automerge.repo.create<SpaceDoc>();
     const docLoadInfo = waitForDocumentLoad(loader, { objectId, handle });
-    loader.loadLinkedObjects({ [objectId]: handle.url });
+    loadLinkedObjects(loader, { [objectId]: handle.url });
     await sleep(10);
     expect(docLoadInfo.loaded).to.be.true;
   });
@@ -52,7 +52,7 @@ describe('AutomergeDocumentLoader', () => {
     const oldDocHandle = automerge.repo.create<SpaceDoc>();
     const newDocHandle = automerge.repo.create<SpaceDoc>();
     const docLoadInfo = waitForDocumentLoad(loader, { objectId, handle: oldDocHandle });
-    loader.loadLinkedObjects({ [objectId]: oldDocHandle.url });
+    loadLinkedObjects(loader, { [objectId]: oldDocHandle.url });
     loader.onObjectBoundToDocument(newDocHandle, objectId);
     await sleep(10);
     expect(docLoadInfo.loaded).to.be.false;
@@ -65,7 +65,7 @@ describe('AutomergeDocumentLoader', () => {
     loader.onObjectBoundToDocument(existingHandle, objectId);
     const newDocHandle = automerge.repo.create<SpaceDoc>();
     const docLoadInfo = waitForDocumentLoad(loader, { objectId, handle: newDocHandle });
-    loader.loadLinkedObjects({ [objectId]: existingHandle.url });
+    loadLinkedObjects(loader, { [objectId]: existingHandle.url });
     await sleep(10);
     expect(docLoadInfo.loaded).to.be.false;
   });
@@ -78,6 +78,11 @@ describe('AutomergeDocumentLoader', () => {
       rootUrl: spaceRootDocHandle.url,
     });
     return { loader, spaceRootDocHandle, automerge };
+  };
+
+  const loadLinkedObjects = (loader: AutomergeDocumentLoader, links: SpaceDoc['links']) => {
+    Object.keys(links ?? {}).forEach((objectId) => loader.loadObjectDocument(objectId));
+    loader.onObjectLinksUpdated(links);
   };
 
   const waitForDocumentLoad = (loader: AutomergeDocumentLoader, expected: ObjectDocumentLoaded) => {

--- a/packages/core/echo/echo-schema/src/legacy-database.ts
+++ b/packages/core/echo/echo-schema/src/legacy-database.ts
@@ -72,7 +72,7 @@ export class EchoLegacyDatabase {
   }
 
   getObjectById<T extends EchoObject>(id: string): T | undefined {
-    const obj = this._objects.get(id) ?? this.automerge._objects.get(id);
+    const obj = this._objects.get(id) ?? this.automerge.getObjectById(id);
 
     if (!obj) {
       return undefined;


### PR DESCRIPTION
### Motivation / Background

Partially addresses https://github.com/dxos/dxos/issues/5557

Stop loading all automerge documents eagerly on startup, instead:
* Try to load a document when an object is referenced but not present.
* When a link appears in space root, start loading the linked document if the object linked to it was previously requested. 
