### PR TITLE
refactor(plugin-stack,react-ui-stack): Harmonize Stack Section ontology with that of other Mosaic Tiles

### DIFF
--- a/.idea/dxos.iml
+++ b/.idea/dxos.iml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/packages/tools/executors/protobuf-compiler/test/__snapshots__" />
       <excludeFolder url="file://$MODULE_DIR$/packages/core/protocols/proto" />
@@ -9,6 +10,8 @@
       <excludeFolder url="file://$MODULE_DIR$/packages/apps/composer-app/build" />
       <excludeFolder url="file://$MODULE_DIR$/.nx" />
       <excludeFolder url="file://$MODULE_DIR$/.swc" />
+      <excludeFolder url="file://$MODULE_DIR$/**/dist" />
+      <excludeFolder url="file://$MODULE_DIR$/**/out" />
       <excludePattern pattern="gen" />
       <excludePattern pattern="out" />
       <excludePattern pattern="tmp" />

--- a/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
@@ -31,6 +31,7 @@ import {
 import { FileUpload } from './FileUpload';
 import { STACK_PLUGIN } from '../meta';
 import { type StackPluginProvides, isStack } from '../types';
+import { echoSectionToNodeSection } from '../util';
 
 const SectionContent: StackProps['SectionContent'] = ({ data }) => {
   // TODO(wittjosiah): Better section placeholder.
@@ -48,7 +49,8 @@ const StackMain: FC<{ stack: StackType; separation?: boolean }> = ({ stack, sepa
   const items = stack.sections
     // TODO(wittjosiah): Should the database handle this differently?
     // TODO(wittjosiah): Render placeholders for missing objects so they can be removed from the stack?
-    .filter(({ object }) => Boolean(object));
+    .filter(({ object }) => Boolean(object))
+    .map((section) => echoSectionToNodeSection(section, t, metadataPlugin?.provides.metadata.resolver));
   const space = getSpaceForObject(stack);
   const [folder] = useQuery(space, Folder.filter());
 

--- a/packages/apps/plugins/plugin-stack/src/util.ts
+++ b/packages/apps/plugins/plugin-stack/src/util.ts
@@ -1,0 +1,21 @@
+//
+// Copyright 2024 DXOS.org
+//
+import { type Stack as StackType } from '@braneframe/types';
+import { type MetadataResolver } from '@dxos/app-framework';
+import { type TFunction } from '@dxos/react-ui';
+import { type StackSectionItem } from '@dxos/react-ui-stack';
+
+export const echoSectionToNodeSection = (
+  { id, object }: StackType.Section,
+  t: TFunction,
+  resolver?: MetadataResolver,
+): StackSectionItem => {
+  const metadata = resolver?.(object.type) ?? {};
+  return {
+    id,
+    label: metadata.label,
+    icon: metadata.icon,
+    data: object,
+  };
+};

--- a/packages/apps/plugins/plugin-stack/src/util.ts
+++ b/packages/apps/plugins/plugin-stack/src/util.ts
@@ -17,5 +17,8 @@ export const echoSectionToNodeSection = (
     label: metadata.label,
     icon: metadata.icon,
     data: object,
+    actions: [],
+    children: [],
+    properties: {},
   };
 };

--- a/packages/ui/react-ui-stack/package.json
+++ b/packages/ui/react-ui-stack/package.json
@@ -23,6 +23,7 @@
     "src"
   ],
   "dependencies": {
+    "@dxos/app-graph": "workspace:*",
     "@dxos/react-ui": "workspace:*",
     "@dxos/react-ui-mosaic": "workspace:*",
     "@dxos/react-ui-theme": "workspace:*",

--- a/packages/ui/react-ui-stack/src/components/Section.tsx
+++ b/packages/ui/react-ui-stack/src/components/Section.tsx
@@ -12,6 +12,7 @@ import React, {
   type PropsWithChildren,
 } from 'react';
 
+import { type Node } from '@dxos/app-graph';
 import { Button, DensityProvider, DropdownMenu, List, ListItem, useTranslation } from '@dxos/react-ui';
 import {
   type MosaicActiveType,
@@ -51,9 +52,7 @@ export type StackItem = MosaicDataItem &
     items: StackSectionItem[];
   };
 
-export type StackSectionItem = MosaicDataItem & {
-  object: StackSectionContent;
-};
+export type StackSectionItem = Pick<Node, 'id' | 'label' | 'properties' | 'icon' | 'data'>;
 
 export type StackSectionItemWithContext = StackSectionItem & StackContextValue;
 
@@ -187,22 +186,25 @@ export const SectionTile: MosaicTileComponent<StackSectionItemWithContext, HTMLL
         )
       : contentItem;
 
-    // TODO(thure): When `item` is a preview, it is a Graph.Node and has `data` instead of `object`.
-    const itemObject = transformedItem.object ?? (transformedItem as unknown as { data: StackSectionContent }).data;
+    const title = transformedItem?.label
+      ? typeof transformedItem.label === 'string'
+        ? transformedItem.label
+        : t(...transformedItem.label)
+      : t('untitled section title');
 
     const section = (
       <Section
         ref={forwardedRef}
         id={transformedItem.id}
-        title={itemObject?.title ?? t('untitled section title')}
+        title={title}
         separation={separation}
         active={active}
         draggableProps={draggableProps}
         draggableStyle={draggableStyle}
         onDelete={() => onDeleteSection?.(path)}
-        onNavigate={() => onNavigateToSection?.(itemObject.id)}
+        onNavigate={() => onNavigateToSection?.(transformedItem.id)}
       >
-        {SectionContent && <SectionContent data={itemObject} />}
+        {SectionContent && <SectionContent data={transformedItem} />}
       </Section>
     );
 

--- a/packages/ui/react-ui-stack/src/components/Section.tsx
+++ b/packages/ui/react-ui-stack/src/components/Section.tsx
@@ -52,7 +52,7 @@ export type StackItem = MosaicDataItem &
     items: StackSectionItem[];
   };
 
-export type StackSectionItem = Pick<Node, 'id' | 'data'> & Partial<Pick<Node, 'label' | 'properties' | 'icon'>>;
+export type StackSectionItem = Pick<Node, 'id' | 'label' | 'icon' | 'data' | 'actions' | 'children' | 'properties'>;
 
 export type StackSectionItemWithContext = StackSectionItem & StackContextValue;
 

--- a/packages/ui/react-ui-stack/src/components/Section.tsx
+++ b/packages/ui/react-ui-stack/src/components/Section.tsx
@@ -52,7 +52,7 @@ export type StackItem = MosaicDataItem &
     items: StackSectionItem[];
   };
 
-export type StackSectionItem = Pick<Node, 'id' | 'label' | 'properties' | 'icon' | 'data'>;
+export type StackSectionItem = Pick<Node, 'id' | 'data'> & Partial<Pick<Node, 'label' | 'properties' | 'icon'>>;
 
 export type StackSectionItemWithContext = StackSectionItem & StackContextValue;
 
@@ -204,7 +204,7 @@ export const SectionTile: MosaicTileComponent<StackSectionItemWithContext, HTMLL
         onDelete={() => onDeleteSection?.(path)}
         onNavigate={() => onNavigateToSection?.(transformedItem.id)}
       >
-        {SectionContent && <SectionContent data={transformedItem} />}
+        {SectionContent && <SectionContent {...transformedItem} />}
       </Section>
     );
 

--- a/packages/ui/react-ui-stack/src/components/Stack.stories.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack.stories.tsx
@@ -127,7 +127,12 @@ const DemoStack = ({
 }: DemoStackProps) => {
   const [items, setItems] = useState<StackSectionItem[]>(() => {
     const generator = new TestObjectGenerator({ types });
-    return generator.createObjects({ length: count }).map((object) => ({ id: faker.string.uuid(), object }));
+    return generator.createObjects({ length: count }).map((object) => ({
+      id: faker.string.uuid(),
+      label: faker.commerce.productName(),
+      properties: {},
+      data: object,
+    }));
   });
 
   const itemsRef = useRef(items);

--- a/packages/ui/react-ui-stack/src/components/index.ts
+++ b/packages/ui/react-ui-stack/src/components/index.ts
@@ -3,3 +3,4 @@
 //
 
 export * from './Stack';
+export { type StackSectionItem } from './Section';

--- a/packages/ui/react-ui-stack/tsconfig.json
+++ b/packages/ui/react-ui-stack/tsconfig.json
@@ -23,6 +23,9 @@
       "path": "../../core/echo/echo-schema"
     },
     {
+      "path": "../../sdk/app-graph"
+    },
+    {
       "path": "../../sdk/client"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9012,6 +9012,9 @@ importers:
 
   packages/ui/react-ui-stack:
     dependencies:
+      '@dxos/app-graph':
+        specifier: workspace:*
+        version: link:../../sdk/app-graph
       '@dxos/react-ui':
         specifier: workspace:*
         version: link:../react-ui


### PR DESCRIPTION
Resolves #5082.

This PR refactors Stack to use an ontology that is more coherent with that of other patterns in Composer.

### Caveats

This may require changes to Stack ontology that make this not backwards-compatible, since it used to be the case that Stack Sections were not always first-class entities elsewhere in the Graph. I’ll do my best to avoid a backwards-incompatibility of course.