### PR TITLE
fix: debug-plugin devtools clash with entrypoint

### DIFF
--- a/packages/apps/plugins/plugin-debug/src/DebugPlugin.tsx
+++ b/packages/apps/plugins/plugin-debug/src/DebugPlugin.tsx
@@ -96,7 +96,7 @@ export const DebugPlugin = (): PluginDefinition<DebugPluginProvides> => {
             settings.values.$devtools!.subscribe((debug) => {
               if (debug) {
                 parent.addNode(DEBUG_PLUGIN, {
-                  id: 'devtools',
+                  id: 'devtools-debug-plugin',
                   label: ['devtools label', { ns: DEBUG_PLUGIN }],
                   icon: (props) => <Bug {...props} />,
                   data: 'devtools',


### PR DESCRIPTION
### Motivation / Background

A browser visiting DevTools as provided by `plugin-debug` if reloaded will go to the devtools entrypoint as they shared the same name.