### PR TITLE
fix(react-ui-mosaic): Use active DragOverlay when operation is rejected

### DIFF
--- a/.idea/dxos.iml
+++ b/.idea/dxos.iml
@@ -9,6 +9,8 @@
       <excludeFolder url="file://$MODULE_DIR$/packages/apps/composer-app/build" />
       <excludeFolder url="file://$MODULE_DIR$/.nx" />
       <excludeFolder url="file://$MODULE_DIR$/.swc" />
+      <excludeFolder url="file://$MODULE_DIR$/**/dist" />
+      <excludeFolder url="file://$MODULE_DIR$/**/out" />
       <excludePattern pattern="gen" />
       <excludePattern pattern="out" />
       <excludePattern pattern="tmp" />

--- a/.idea/dxos.iml
+++ b/.idea/dxos.iml
@@ -9,7 +9,6 @@
       <excludeFolder url="file://$MODULE_DIR$/packages/apps/composer-app/build" />
       <excludeFolder url="file://$MODULE_DIR$/.nx" />
       <excludeFolder url="file://$MODULE_DIR$/.swc" />
-      <excludePattern pattern="dist" />
       <excludePattern pattern="gen" />
       <excludePattern pattern="out" />
       <excludePattern pattern="tmp" />

--- a/.idea/dxos.iml
+++ b/.idea/dxos.iml
@@ -9,8 +9,7 @@
       <excludeFolder url="file://$MODULE_DIR$/packages/apps/composer-app/build" />
       <excludeFolder url="file://$MODULE_DIR$/.nx" />
       <excludeFolder url="file://$MODULE_DIR$/.swc" />
-      <excludeFolder url="file://$MODULE_DIR$/**/dist" />
-      <excludeFolder url="file://$MODULE_DIR$/**/out" />
+      <excludePattern pattern="dist" />
       <excludePattern pattern="gen" />
       <excludePattern pattern="out" />
       <excludePattern pattern="tmp" />

--- a/packages/ui/react-ui-mosaic/src/mosaic/DragOverlay.tsx
+++ b/packages/ui/react-ui-mosaic/src/mosaic/DragOverlay.tsx
@@ -31,7 +31,7 @@ export const MosaicDragOverlay = ({ delay = 200, debug = false, ...overlayProps 
   const timer = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(() => {
-    if (activeItem) {
+    if (activeItem && operation !== 'reject') {
       let container: MosaicContainerProps<any> | undefined;
       let OverlayComponent: MosaicTileComponent<any> | undefined;
       if (overItem?.path) {

--- a/packages/ui/react-ui-mosaic/src/mosaic/DragOverlay.tsx
+++ b/packages/ui/react-ui-mosaic/src/mosaic/DragOverlay.tsx
@@ -31,6 +31,8 @@ export const MosaicDragOverlay = ({ delay = 200, debug = false, ...overlayProps 
   const timer = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(() => {
+    // Only attempt to resolve a foreign overlay tile if the operation is not rejected, since droppables *should* reject
+    // items they don’t recognize and therefore wouldn’t be able to render a tile for. See dxos/dxos#5082.
     if (activeItem && operation !== 'reject') {
       let container: MosaicContainerProps<any> | undefined;
       let OverlayComponent: MosaicTileComponent<any> | undefined;


### PR DESCRIPTION
Resolves #5082.

This PR adjusts DragOverlay to avoid trying to resolve an overlay for a foreign drop area when the operation is rejected anyway.