### PR TITLE
chore: Ignore `dist` in IntelliJ module config

### DIFF
--- a/.idea/dxos.iml
+++ b/.idea/dxos.iml
@@ -9,6 +9,7 @@
       <excludeFolder url="file://$MODULE_DIR$/packages/apps/composer-app/build" />
       <excludeFolder url="file://$MODULE_DIR$/.nx" />
       <excludeFolder url="file://$MODULE_DIR$/.swc" />
+      <excludePattern pattern="dist" />
       <excludePattern pattern="gen" />
       <excludePattern pattern="out" />
       <excludePattern pattern="tmp" />


### PR DESCRIPTION
This PR adds `dist` as an `excludePattern` in `dxos.iml`.