### PR TITLE
fix: Fix reset dialog

### DIFF
--- a/packages/apps/composer-app/src/components/ResetDialog.tsx
+++ b/packages/apps/composer-app/src/components/ResetDialog.tsx
@@ -6,7 +6,7 @@ import { CaretDown, CaretRight, Clipboard } from '@phosphor-icons/react';
 import React, { useCallback, useState } from 'react';
 import { useRegisterSW } from 'virtual:pwa-register/react';
 
-import { Config, Defaults } from '@dxos/react-client';
+import { Config, Defaults, Storage } from '@dxos/react-client';
 import {
   AlertDialog,
   type AlertDialogRootProps,
@@ -63,7 +63,7 @@ export const ResetDialog = ({
   }, [error]);
 
   const handleReset = async () => {
-    const config = new Config(Defaults());
+    const config = new Config(await Storage(), Defaults());
 
     const { ClientServicesHost } = await import('@dxos/client-services');
     const services = new ClientServicesHost({ config });

--- a/packages/apps/composer-app/src/components/ResetDialog.tsx
+++ b/packages/apps/composer-app/src/components/ResetDialog.tsx
@@ -6,7 +6,7 @@ import { CaretDown, CaretRight, Clipboard } from '@phosphor-icons/react';
 import React, { useCallback, useState } from 'react';
 import { useRegisterSW } from 'virtual:pwa-register/react';
 
-import { Config, Defaults, Storage } from '@dxos/react-client';
+import { Config, Defaults, Envs, Local, Storage } from '@dxos/react-client';
 import {
   AlertDialog,
   type AlertDialogRootProps,
@@ -63,7 +63,7 @@ export const ResetDialog = ({
   }, [error]);
 
   const handleReset = async () => {
-    const config = new Config(await Storage(), Defaults());
+    const config = new Config(await Storage(), Envs(), Local(), Defaults());
 
     const { ClientServicesHost } = await import('@dxos/client-services');
     const services = new ClientServicesHost({ config });

--- a/packages/sdk/client/src/index.ts
+++ b/packages/sdk/client/src/index.ts
@@ -2,7 +2,7 @@
 // Copyright 2020 DXOS.org
 //
 
-export { Config, Defaults, Dynamics, Envs, Local } from '@dxos/config';
+export { Config, Defaults, Dynamics, Envs, Local, Storage } from '@dxos/config';
 export { PublicKey, type PublicKeyLike } from '@dxos/keys';
 // TODO(wittjosiah): Should all api errors be exported here?
 export {


### PR DESCRIPTION
This pull request is fixing the config for the reset dialog window to use the same storage as the Client