### PR TITLE
fix: Layout for iOS devices

### DIFF
--- a/packages/apps/composer-app/index.html
+++ b/packages/apps/composer-app/index.html
@@ -2,15 +2,18 @@
 <html lang="en" style="overscroll-behavior: none">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no,interactive-widget=resizes-content" />
     <title>Composer</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no,interactive-widget=resizes-content,viewport-fit=cover" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <link rel="manifest" href="/site.webmanifest">
     <meta name="description" content="DXOS Composer Application" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#003E70" />
     <meta name="msapplication-TileColor" content="#003E70" />
-    <meta name="theme-color" content="#003E70" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f7f8f9" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#252529" />
     <meta
       http-equiv="Content-Security-Policy"
       content="

--- a/packages/apps/plugins/plugin-layout/src/components/MainLayout.tsx
+++ b/packages/apps/plugins/plugin-layout/src/components/MainLayout.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { CaretDoubleLeft, List as MenuIcon, X } from '@phosphor-icons/react';
+import { Sidebar as MenuIcon, X } from '@phosphor-icons/react';
 import React from 'react';
 
 import { Surface, type Toast as ToastSchema } from '@dxos/app-framework';
@@ -81,7 +81,7 @@ export const MainLayout = ({ fullscreen, showHintsFooter, toasts, onDismissToast
             classNames='p-0 is-[--rail-action] border-bs-4 border-be-4 border-transparent bg-clip-padding'
           >
             <span className='sr-only'>{t('open navigation sidebar label')}</span>
-            <MenuIcon weight='light' className={getSize(4)} />
+            <MenuIcon weight='light' className={getSize(5)} />
           </Button>
           <Surface role='notch-end' />
         </Main.Notch>
@@ -113,7 +113,7 @@ export const MainLayout = ({ fullscreen, showHintsFooter, toasts, onDismissToast
                     classNames='p-0 bs-[var(--rail-action)] is-[var(--rail-action)]'
                   >
                     <span className='sr-only'>{t('open complementary sidebar label')}</span>
-                    <CaretDoubleLeft mirrored={context.complementarySidebarOpen} className={getSize(4)} />
+                    <MenuIcon weight='light' mirrored className={getSize(5)} />
                   </Button>
                 )}
               </DensityProvider>

--- a/packages/apps/plugins/plugin-navtree/src/components/NavTreeFooter.tsx
+++ b/packages/apps/plugins/plugin-navtree/src/components/NavTreeFooter.tsx
@@ -30,7 +30,10 @@ export const NavTreeFooter = () => {
       : `${repo}/commit/${commitHash}`;
 
   return (
-    <div role='none' className='bs-[--rail-size] box-content separator-separator border-bs pli-1 flex justify-end'>
+    <div
+      role='none'
+      className='bs-[--rail-size] pbe-[env(safe-area-inset-bottom)] box-content separator-separator border-bs pli-1 flex justify-end'
+    >
       <div role='none' className='grid grid-cols-[repeat(2,minmax(var(--rail-action),min-content))]'>
         <Popover.Root>
           <Popover.Trigger asChild>

--- a/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -48,6 +48,9 @@ type ThreadState = {
   focus?: boolean;
 };
 
+// TODO(thure): Get source of truth from `react-ui-theme`.
+const isMinSm = () => window.matchMedia('(min-width:768px)').matches;
+
 export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
   const settings = new LocalStorageStore<ThreadSettingsProps>(THREAD_PLUGIN);
   const state = deepSignal<ThreadState>({ threads: {} });
@@ -79,12 +82,20 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
           if (activeNode && isDocument(activeNode?.data) && activeNode.data.comments.length > 0) {
             void intentPlugin?.provides.intent.dispatch({
               action: LayoutAction.SET_LAYOUT,
-              data: { element: 'complementary', subject: activeNode.data, state: true },
+              data: {
+                element: 'complementary',
+                subject: activeNode.data,
+                state: isMinSm(),
+              },
             });
           } else if (settings.values.standalone && thread && !isThread(activeNode?.data)) {
             void intentPlugin?.provides.intent.dispatch({
               action: LayoutAction.SET_LAYOUT,
-              data: { element: 'complementary', subject: thread, state: true },
+              data: {
+                element: 'complementary',
+                subject: thread,
+                state: isMinSm(),
+              },
             });
           } else {
             void intentPlugin?.provides.intent.dispatch({
@@ -320,7 +331,11 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
                   },
                   {
                     action: LayoutAction.SET_LAYOUT,
-                    data: { element: 'complementary', subject: doc, state: true },
+                    data: {
+                      element: 'complementary',
+                      subject: doc,
+                      state: true,
+                    },
                   },
                 ]);
 

--- a/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/ChatContainer.tsx
@@ -26,7 +26,7 @@ export const ChatHeading = () => {
       role='none'
       className='grid grid-cols-[var(--rail-size)_1fr_var(--rail-size)] items-center border-be separator-separator -mbe-px'
     >
-      <Button variant='primary' classNames='m-1 pli-0 is-[--rail-action] bs-[--rail-action] rounded-sm'>
+      <Button variant='primary' classNames='m-1 pli-0 min-bs-0 is-[--rail-action] bs-[--rail-action] rounded-sm'>
         <Chat weight='duotone' className={getSize(5)} />
       </Button>
       <h1 className='font-medium fg-accent pli-1 truncate'>{t('chat heading')}</h1>

--- a/packages/apps/plugins/plugin-thread/src/components/CommentsContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/CommentsContainer.tsx
@@ -34,7 +34,7 @@ export const CommentsHeading = () => {
       role='none'
       className='grid grid-cols-[var(--rail-size)_1fr_var(--rail-size)] items-center border-be separator-separator -mbe-px'
     >
-      <Button variant='primary' classNames='m-1 pli-0 is-[--rail-action] bs-[--rail-action] rounded-sm'>
+      <Button variant='primary' classNames='m-1 pli-0 min-bs-0 is-[--rail-action] bs-[--rail-action] rounded-sm'>
         <Quotes weight='duotone' className={getSize(5)} />
       </Button>
       <h1 className='font-medium fg-accent pli-1 truncate'>{t('comments heading')}</h1>

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItemAction.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItemAction.tsx
@@ -65,7 +65,7 @@ export const NavTreeItemActionDropdownMenu = ({
               'shrink-0 pli-2 pointer-fine:pli-1',
               hoverableControlItem,
               hoverableOpenControlItem,
-              variant === 'plank-heading' && 'is-[--rail-action] rounded-sm pli-0',
+              variant === 'plank-heading' && 'min-bs-0 is-[--rail-action] bs-[--rail-action] rounded-sm pli-0',
               active === 'overlay' && 'invisible',
             ]}
             data-testid={testId}

--- a/packages/ui/react-ui-theme/src/styles/components/main.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/main.ts
@@ -32,7 +32,7 @@ const sidebarSlots = {
 
 export const mainSidebar: ComponentFunction<MainStyleProps> = (_, ...etc) =>
   mx(
-    'fixed block-start-0 block-end-0 is-[100vw] z-10 overscroll-contain overflow-x-hidden overflow-y-auto',
+    'fixed block-start-0 block-end-0 is-[100vw] z-10 data-[side=ie]:z-20 overscroll-contain overflow-x-hidden overflow-y-auto',
     'transition-[inset-inline-start,inset-inline-end] duration-0 data-[resizing=false]:duration-200 ease-in-out',
     `data-[side=is]:-inline-start-[100vw] ${sidebarSlots.start.width} ${sidebarSlots.start.sidebar}`,
     `data-[side=ie]:-inline-end-[100vw] ${sidebarSlots.end.width} ${sidebarSlots.end.sidebar}`,

--- a/packages/ui/react-ui-theme/src/styles/components/main.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/main.ts
@@ -63,7 +63,7 @@ export const mainOverlay: ComponentFunction<MainStyleProps> = (_, ...etc) =>
 
 export const mainNotch: ComponentFunction<MainStyleProps> = (_, ...etc) =>
   mx(
-    'fixed z-[11] block-end-0 inline-start-0 rounded-se-lg min-bs-[var(--rail-size)] is-fit separator-separator surface-base',
+    'fixed z-[11] block-end-0 inline-start-0 pbe-[env(safe-area-inset-bottom)] rounded-se-lg min-bs-[var(--rail-size)] is-fit separator-separator surface-base',
     'transition-[border-width] box-content border-bs border-ie data-[nav-sidebar-state=open]:border-bs-0 data-[nav-sidebar-state=open]:border-ie-0',
     'pli-1 grid grid-cols-[repeat(auto-fit,var(--rail-action))]',
     sidebarSlots.start.notch,


### PR DESCRIPTION
Resolves #5794. Resolves #5795. Resolves #5801. Resolves #5242.

This PR makes various improvements for mobile devices:
- Changes theme color to respond to preferred palette, using same color as applied to `html`
- Adds extra spacing to the notch and to NavTreePlugin’s footer for the navigational sidebar
- Harmonizes both sidebar icons.
- Fixes a z-index issue.
- Only opens c11y sidebar implicitly if viewport min-width is 768px.

<img width="407" alt="Screenshot 2024-02-28 at 14 07 13" src="https://github.com/dxos/dxos/assets/855039/c7bdec85-ec87-4869-bbba-5bcc8eb2d492">

https://github.com/dxos/dxos/assets/855039/b5c4cba7-d4e1-44ba-8cdf-8e334f1c05ac

https://github.com/dxos/dxos/assets/855039/c5caaa32-693f-4595-b668-c7d498ed53b4
