### PR TITLE
chore: adjust bundling parallelism for e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
       - run: pnpm install-playwright
       - *cache_save
       - nx/set-shas
-      - run: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD --target=bundle
+      - run: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD --target=bundle --parallel=2
       - run: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD --target=e2e --parallel=1 --xmlReport
       - run:
           command: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD --target=chromatic


### PR DESCRIPTION
### Motivation / Background
bundle errors on e2e jobs like https://app.circleci.com/pipelines/github/dxos/dxos/20822/workflows/57450701-8e4d-4607-8401-f23744f179bf/jobs/43804 presumably failing due to OOM