### PR TITLE
feat(echo): in-memory effect schema registration for lookups on restore

### DIFF
--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
@@ -20,7 +20,7 @@ import {
 } from './automerge-doc-loader';
 import { getAutomergeObjectCore } from './automerge-object';
 import { AutomergeObjectCore } from './automerge-object-core';
-import { type SpaceDoc } from './types';
+import { decodeReference, type SpaceDoc } from './types';
 import { type EchoDatabase } from '../database';
 import { isReactiveProxy } from '../effect/proxy';
 import { type Hypergraph } from '../hypergraph';
@@ -53,7 +53,7 @@ export class AutomergeDb {
     public readonly graph: Hypergraph,
     public readonly automerge: AutomergeContext,
     public readonly spaceKey: PublicKey,
-    private readonly _constructObj: () => OpaqueEchoObject,
+    private readonly _constructObj: (typeReference: Reference | null) => OpaqueEchoObject,
     dbApi: EchoDatabase, // TODO(dmaretskyi): Remove.
   ) {
     this._automergeDocLoader = new AutomergeDocumentLoaderImpl(this.spaceKey, automerge);
@@ -256,7 +256,9 @@ export class AutomergeDb {
   private _createObjectInDocument(docHandle: DocHandle<SpaceDoc>, objectId: string) {
     invariant(!this._objects.get(objectId));
 
-    const obj = this._constructObj();
+    const encodedType = docHandle.docSync()?.objects?.[objectId]?.system?.type ?? null;
+    const typeReference = encodedType != null ? decodeReference(encodedType) : null;
+    const obj = this._constructObj(typeReference);
     const core = getAutomergeObjectCore(obj);
     core.id = objectId;
 

--- a/packages/core/echo/echo-schema/src/effect/reactive.ts
+++ b/packages/core/echo/echo-schema/src/effect/reactive.ts
@@ -4,7 +4,10 @@
 
 import * as AST from '@effect/schema/AST';
 import * as S from '@effect/schema/Schema';
+import { pipe } from 'effect';
+import * as Option from 'effect/Option';
 
+import { Reference } from '@dxos/document-model';
 import { invariant } from '@dxos/invariant';
 
 import { type ReactiveHandler, createReactiveProxy, isValidProxyTarget } from './proxy';
@@ -14,6 +17,23 @@ import { UntypedReactiveHandler } from './untyped-handler';
 
 export const IndexAnnotation = Symbol.for('@dxos/schema/annotation/Index');
 export const getIndexAnnotation = AST.getAnnotation<boolean>(IndexAnnotation);
+
+export const EchoObjectAnnotationId = Symbol.for('@dxos/echo-schema/annotation/NamedSchema');
+export type EchoObjectAnnotation = {
+  typename: string;
+  version: string;
+};
+
+export const echoObject =
+  (typename: string, version: string) =>
+  <A, I, R>(self: S.Schema<A, I, R>): S.Schema<A, I, R> =>
+    S.make(AST.setAnnotation(self.ast, EchoObjectAnnotationId, { typename, version }));
+
+export const getEchoObjectAnnotation = (schema: S.Schema<any>) =>
+  pipe(
+    AST.getAnnotation<EchoObjectAnnotation>(EchoObjectAnnotationId)(schema.ast),
+    Option.getOrElse(() => undefined),
+  );
 
 // https://github.com/Effect-TS/effect/blob/main/packages/schema/README.md#introduction
 // https://effect-ts.github.io/effect/schema/Schema.ts.html
@@ -62,6 +82,14 @@ export const getSchema = <T extends {}>(obj: T): S.Schema<T> | undefined => {
 
   invariant(S.isSchema(schema), 'Invalid schema.');
   return schema as S.Schema<T>;
+};
+
+export const getTypeReference = (schema: S.Schema<any>): Reference | undefined => {
+  const annotation = getEchoObjectAnnotation(schema);
+  if (annotation == null) {
+    return undefined;
+  }
+  return Reference.fromLegacyTypename(annotation.typename);
 };
 
 export type PropertyVisitor<T> = (property: AST.PropertySignature, path: PropertyKey[]) => T;

--- a/packages/core/echo/echo-schema/src/testing/testing.ts
+++ b/packages/core/echo/echo-schema/src/testing/testing.ts
@@ -44,7 +44,7 @@ export const createDatabase = async (graph = new Hypergraph(), { useReactiveObje
     rootUrl: automergeContext.repo.create().url,
   });
   graph._register(proxy.backend.spaceKey, db); // TODO(burdon): Database should have random id?
-  return { db, host };
+  return { db, host, graph };
 };
 
 export class TestBuilder {


### PR DESCRIPTION
### Motivation / Background

When we're restoring saved objects we need to be able to attach effect Schema objects to them.
For this we maintain an in-memory map of typename -> schema, forcing users to register their types through Hypergraph types object. 

### Details

* Expose an API for registering effect schema in `Hypergraph`
* Store schema in automerge doc as a legacy encoded `Reference` under `[objects, id, system, type]` for compatibility with old objects
* Decode the `Reference` and use it for `Schema` lookup in `Hypergraph` when we're constructing an object on startup
* throw if a `Schema` is not annotated with `EchoObjectAnnotation`