### PR TITLE
fix(client-services): always pass through whole profile

### DIFF
--- a/packages/apps/plugins/plugin-navtree/src/components/HaloButton.tsx
+++ b/packages/apps/plugins/plugin-navtree/src/components/HaloButton.tsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 
-import { type Identity } from '@dxos/react-client/halo';
 import { Avatar, type Size } from '@dxos/react-ui';
 import { focusRing, mx } from '@dxos/react-ui-theme';
 import { hexToFallback } from '@dxos/util';
@@ -14,9 +13,11 @@ const INTERNAL = 'https://avatars.githubusercontent.com/u/57182821';
 export type HaloButtonProps = {
   size?: Size;
   identityKey?: string;
+  hue?: string;
+  emoji?: string;
   internal?: boolean;
   onClick?: () => void;
-} & Pick<NonNullable<Identity['profile']>, 'hue' | 'emoji'>;
+};
 
 export const HaloButton = (props: HaloButtonProps) => {
   const { onClick, identityKey, internal, size = 8 } = props;

--- a/packages/apps/plugins/plugin-navtree/src/components/NotchStart.tsx
+++ b/packages/apps/plugins/plugin-navtree/src/components/NotchStart.tsx
@@ -20,8 +20,8 @@ export const NotchStart = () => {
     <HaloButton
       size={8}
       identityKey={identity?.identityKey.toHex()}
-      hue={identity?.profile?.hue}
-      emoji={identity?.profile?.emoji}
+      hue={identity?.profile?.data?.hue}
+      emoji={identity?.profile?.data?.emoji}
       internal={observabilityPlugin?.provides?.observability?.group === 'dxos'}
       onClick={() => client.shell.shareIdentity()}
     />

--- a/packages/apps/plugins/plugin-space/src/components/SpacePresence.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/SpacePresence.tsx
@@ -181,21 +181,21 @@ type PresenceAvatarProps = {
   group?: boolean;
   index?: number;
   onClick?: () => void;
-} & Pick<NonNullable<Identity['profile']>, 'hue' | 'emoji'>;
+};
 
-const PrensenceAvatar = ({ identity, showName, match, group, index, onClick, hue, emoji }: PresenceAvatarProps) => {
+const PrensenceAvatar = ({ identity, showName, match, group, index, onClick }: PresenceAvatarProps) => {
   const Root = group ? AvatarGroupItem.Root : Avatar.Root;
   const status = match ? 'current' : 'active';
   const fallbackValue = keyToFallback(identity.identityKey);
   return (
-    <Root status={status} hue={hue || fallbackValue.hue}>
+    <Root status={status} hue={identity.profile?.data?.hue || fallbackValue.hue}>
       <Avatar.Frame
         data-testid='spacePlugin.presence.member'
         data-status={status}
         {...(index ? { style: { zIndex: index } } : {})}
         onClick={() => onClick?.()}
       >
-        <Avatar.Fallback text={emoji || fallbackValue.emoji} />
+        <Avatar.Fallback text={identity.profile?.data?.emoji || fallbackValue.emoji} />
       </Avatar.Frame>
       {showName && <Avatar.Label classNames='text-sm truncate pli-2'>{getName(identity)}</Avatar.Label>}
     </Root>
@@ -215,7 +215,7 @@ export const SmallPresence = (props: MemberPresenceProps) => {
             {members.slice(0, 3).map((viewer, i) => {
               const viewerHex = viewer.identity.identityKey.toHex();
               return (
-                <AvatarGroupItem.Root key={viewerHex} hue={viewer.identity.profile?.hue || hexToHue(viewerHex)}>
+                <AvatarGroupItem.Root key={viewerHex} hue={viewer.identity.profile?.data?.hue || hexToHue(viewerHex)}>
                   <Avatar.Frame style={{ zIndex: members.length - i }} />
                 </AvatarGroupItem.Root>
               );

--- a/packages/core/protocols/src/proto/dxos/halo/credentials.proto
+++ b/packages/core/protocols/src/proto/dxos/halo/credentials.proto
@@ -143,8 +143,8 @@ message IdentityRecovery {
 message ProfileDocument {
   optional string display_name = 1;
   optional string avatar_cid = 2;
-  optional string emoji = 3;
-  optional string hue = 4;
+  /// Custom user data.
+  optional google.protobuf.Struct data = 10;
 }
 
 /// [ASSERTION]: Sets profile information.

--- a/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
@@ -215,9 +215,7 @@ export class SpacesServiceImpl implements SpacesService {
         return {
           identity: {
             identityKey: member.key,
-            profile: {
-              displayName: member.profile?.displayName,
-            },
+            profile: member.profile ?? {},
           },
           presence: member.removed
             ? SpaceMember.PresenceState.REMOVED

--- a/packages/sdk/shell/src/components/IdentityList/IdentityListItem.tsx
+++ b/packages/sdk/shell/src/components/IdentityList/IdentityListItem.tsx
@@ -36,10 +36,10 @@ export const IdentityListItem = forwardRef<
       <Avatar.Root
         status={presence === SpaceMember.PresenceState.ONLINE ? 'active' : 'inactive'}
         labelId={labelId}
-        hue={identity.profile?.hue || fallbackValue.hue}
+        hue={identity.profile?.data?.hue || fallbackValue.hue}
       >
         <Avatar.Frame classNames='place-self-center'>
-          <Avatar.Fallback text={identity.profile?.emoji || fallbackValue.emoji} />
+          <Avatar.Fallback text={identity.profile?.data?.emoji || fallbackValue.emoji} />
         </Avatar.Frame>
         <Avatar.Label classNames='text-sm truncate pli-2'>{displayName}</Avatar.Label>
       </Avatar.Root>

--- a/packages/sdk/shell/src/panels/IdentityPanel/IdentityPanel.tsx
+++ b/packages/sdk/shell/src/panels/IdentityPanel/IdentityPanel.tsx
@@ -29,9 +29,9 @@ const IdentityHeading = ({ titleId, title, identity, onDone }: IdentityPanelHead
   const fallbackValue = keyToFallback(identity.identityKey);
   return (
     <Heading titleId={titleId} title={title} corner={<CloseButton onDone={onDone} />}>
-      <Avatar.Root size={12} variant='circle' status='active' hue={identity.profile?.hue || fallbackValue.hue}>
+      <Avatar.Root size={12} variant='circle' status='active' hue={identity.profile?.data?.hue || fallbackValue.hue}>
         <Avatar.Frame classNames='block mbs-4 mbe-2 mli-auto chromatic-ignore'>
-          <Avatar.Fallback text={identity.profile?.emoji || fallbackValue.emoji} />
+          <Avatar.Fallback text={identity.profile?.data?.emoji || fallbackValue.emoji} />
         </Avatar.Frame>
         <Avatar.Label classNames='block text-center font-light text-xl' data-testid='identityHeading.displayName'>
           {identity.profile?.displayName ?? generateName(identity.identityKey.toHex())}

--- a/packages/sdk/shell/src/panels/IdentityPanel/steps/ProfileForm.tsx
+++ b/packages/sdk/shell/src/panels/IdentityPanel/steps/ProfileForm.tsx
@@ -37,9 +37,10 @@ export const ProfileForm = (props: ProfileFormProps) => {
   return <ProfileFormImpl {...props} onUpdateProfile={handleUpdateProfile} validationMessage={validationMessage} />;
 };
 
-const getHueValue = (identity?: Identity) => identity?.profile?.hue || hexToHue(identity?.identityKey.toHex() ?? '0');
+const getHueValue = (identity?: Identity) =>
+  identity?.profile?.data?.hue || hexToHue(identity?.identityKey.toHex() ?? '0');
 const getEmojiValue = (identity?: Identity) =>
-  identity?.profile?.emoji || hexToEmoji(identity?.identityKey.toHex() ?? '0');
+  identity?.profile?.data?.emoji || hexToEmoji(identity?.identityKey.toHex() ?? '0');
 
 // TODO(zhenyasav): impl shouldn't need send()
 const ProfileFormImpl = (props: ProfileFormImplProps) => {
@@ -105,7 +106,7 @@ const ProfileFormImpl = (props: ProfileFormImplProps) => {
         <Action
           variant='primary'
           disabled={disabled}
-          onClick={() => onUpdateProfile?.({ displayName, emoji, hue })}
+          onClick={() => onUpdateProfile?.({ displayName, data: { emoji, hue } })}
           data-testid='update-profile-form-continue'
         >
           {t('done label')}

--- a/packages/sdk/shell/src/panels/JoinPanel/steps/IdentityAdded.tsx
+++ b/packages/sdk/shell/src/panels/JoinPanel/steps/IdentityAdded.tsx
@@ -43,9 +43,9 @@ export const IdentityAdded = (props: IdentityAddedProps) => {
     <>
       <StepHeading>{t('identity added label')}</StepHeading>
       <div role='none' className='grow flex flex-col items-center justify-center text-center gap-2'>
-        <Avatar.Root status='active' labelId={labelId} hue={addedIdentity?.profile?.hue || fallbackValue.hue}>
+        <Avatar.Root status='active' labelId={labelId} hue={addedIdentity?.profile?.data?.hue || fallbackValue.hue}>
           <Avatar.Frame>
-            <Avatar.Fallback text={addedIdentity?.profile?.emoji || fallbackValue.emoji} />
+            <Avatar.Fallback text={addedIdentity?.profile?.data?.emoji || fallbackValue.emoji} />
           </Avatar.Frame>
           <Avatar.Label classNames={mx('text-lg truncate', !addedIdentity?.profile?.displayName && 'font-mono')}>
             {displayName}


### PR DESCRIPTION
Followup to #5811 which fixes a couple small issues:
- always pass through whole profile from the space service
- don't hardcode emoji/hue in profile proto
