### PR TITLE
fix(react-ui-editor): fix markdown headings

### DIFF
--- a/packages/ui/react-ui-editor/src/extensions/markdown/decorate.ts
+++ b/packages/ui/react-ui-editor/src/extensions/markdown/decorate.ts
@@ -88,7 +88,7 @@ const editingRange = (state: EditorState, range: { from: number; to: number }, f
       main: { head },
     },
   } = state;
-  return focus && !readOnly && head >= range.from && head < range.to;
+  return focus && !readOnly && head >= range.from && head <= range.to;
 };
 
 const MarksByParent = new Set(['CodeMark', 'EmphasisMark', 'StrikethroughMark', 'SubscriptMark', 'SuperscriptMark']);


### PR DESCRIPTION
Reverts one line from #5820 which was causing heading control characters no to be rendered in the editor when starting a new line.
