### PR TITLE
fix: docs deploy config

### DIFF
--- a/docs/dx.yml
+++ b/docs/dx.yml
@@ -1,10 +1,5 @@
 version: 1
 
-schema:
-  files:
-    - 'src/proto/*.proto'
-  outdir: 'src/proto/gen'
-
 package:
   modules:
     - name: docs
@@ -12,7 +7,7 @@ package:
       display_name: DXOS Docs
       build:
         command: pnpm -w nx bundle docs
-        outdir: ./docs/.vuepress/dist
+        outdir: ./content/.vuepress/dist
 
 runtime:
   client:


### PR DESCRIPTION
forgot to update `dx.yml` in docs to point to `content` instead of `docs`