### PR TITLE
feat: Menu annotation

### DIFF
--- a/packages/apps/plugins/plugin-github/src/components/GithubEchoResolverProviders/DocumentTreeItem.tsx
+++ b/packages/apps/plugins/plugin-github/src/components/GithubEchoResolverProviders/DocumentTreeItem.tsx
@@ -2,23 +2,21 @@
 // Copyright 2023 DXOS.org
 //
 
-import { Article, ArticleMedium } from '@phosphor-icons/react';
+import { TextAa } from '@phosphor-icons/react';
 import React from 'react';
 
 import { type Document } from '@braneframe/types';
 import { useTranslation, TreeItem } from '@dxos/react-ui';
-import { TextKind } from '@dxos/react-ui-editor';
 import { getSize, mx } from '@dxos/react-ui-theme';
 
 import { GITHUB_PLUGIN } from '../../meta';
 
 export const DocumentTreeItem = ({ document }: { document: Document }) => {
   const { t } = useTranslation(GITHUB_PLUGIN);
-  const Icon = document.content.kind === TextKind.PLAIN ? ArticleMedium : Article;
   return (
     <TreeItem.Root classNames='flex gap-2'>
       <TreeItem.Heading classNames='contents'>
-        <Icon weight='regular' className={mx(getSize(4), 'shrink-0 mbs-2')} />
+        <TextAa weight='regular' className={mx(getSize(4), 'shrink-0 mbs-2')} />
         <span className='grow mbs-2 text-sm no-leading'>
           {document.title || t('document title placeholder', { ns: 'dxos.org/plugin/markdown' })}
         </span>

--- a/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ArticleMedium, type IconProps } from '@phosphor-icons/react';
+import { type IconProps, TextAa } from '@phosphor-icons/react';
 import { batch, effect } from '@preact/signals-core';
 import { deepSignal } from 'deepsignal/react';
 import React, { useMemo, type Ref } from 'react';
@@ -105,7 +105,7 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
         records: {
           [DocumentType.schema.typename]: {
             placeholder: ['document title placeholder', { ns: MARKDOWN_PLUGIN }],
-            icon: (props: IconProps) => <ArticleMedium {...props} />,
+            icon: (props: IconProps) => <TextAa {...props} />,
           },
         },
       },
@@ -130,7 +130,7 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
                   action: MarkdownAction.CREATE,
                   properties: {
                     label: ['create document label', { ns: MARKDOWN_PLUGIN }],
-                    icon: (props: IconProps) => <ArticleMedium {...props} />,
+                    icon: (props: IconProps) => <TextAa {...props} />,
                     testId: 'markdownPlugin.createObject',
                   },
                 }),
@@ -159,7 +159,7 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
                               getFallbackTitle(object) || ['document title placeholder', { ns: MARKDOWN_PLUGIN }]
                             );
                           },
-                          icon: (props: IconProps) => <ArticleMedium {...props} />,
+                          icon: (props: IconProps) => <TextAa {...props} />,
                           testId: 'spacePlugin.object',
                           persistenceClass: 'echo',
                           persistenceKey: space?.key.toHex(),
@@ -179,7 +179,7 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
                               ]),
                             properties: {
                               label: ['toggle view mode label', { ns: MARKDOWN_PLUGIN }],
-                              icon: (props: IconProps) => <ArticleMedium {...props} />,
+                              icon: (props: IconProps) => <TextAa {...props} />,
                               keyBinding: 'shift+F5',
                             },
                           },
@@ -204,7 +204,7 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
             id: 'create-stack-section-doc',
             testId: 'markdownPlugin.createSection',
             label: ['create stack section label', { ns: MARKDOWN_PLUGIN }],
-            icon: (props: any) => <ArticleMedium {...props} />,
+            icon: (props: any) => <TextAa {...props} />,
             intent: {
               plugin: MARKDOWN_PLUGIN,
               action: MarkdownAction.CREATE,

--- a/packages/apps/plugins/plugin-markdown/src/meta.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/meta.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ArticleMedium, type IconProps } from '@phosphor-icons/react';
+import { type IconProps, TextAa } from '@phosphor-icons/react';
 import React from 'react';
 
 import { pluginMeta } from '@dxos/app-framework';
@@ -14,5 +14,5 @@ export default pluginMeta({
   name: 'Editor',
   description: 'Markdown text editor.',
   homePage: 'https://github.com/dxos/dxos/tree/main/packages/apps/plugins/plugin-markdown',
-  iconComponent: (props: IconProps) => <ArticleMedium {...props} />,
+  iconComponent: (props: IconProps) => <TextAa {...props} />,
 });

--- a/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.stories.tsx
+++ b/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.stories.tsx
@@ -4,7 +4,7 @@
 
 import '@dxosTheme';
 
-import { BookBookmark } from '@phosphor-icons/react';
+import { Chat, ImageSquare, StackSimple, TextAa } from '@phosphor-icons/react';
 import React from 'react';
 
 import { withTheme } from '@dxos/storybook-utils';
@@ -29,7 +29,25 @@ const StorybookPlankHeading = ({
     <AttentionProvider attended={storybookAttended}>
       <div role='none' className={plankHeadingLayout}>
         <PlankHeading.Button attendableId={attendableId}>
-          <BookBookmark {...plankHeadingIconProps} />
+          <Chat {...plankHeadingIconProps} />
+        </PlankHeading.Button>
+        <PlankHeading.Label attendableId={attendableId}>{label}</PlankHeading.Label>
+      </div>
+      <div role='none' className={plankHeadingLayout}>
+        <PlankHeading.Button attendableId={attendableId}>
+          <StackSimple {...plankHeadingIconProps} />
+        </PlankHeading.Button>
+        <PlankHeading.Label attendableId={attendableId}>{label}</PlankHeading.Label>
+      </div>
+      <div role='none' className={plankHeadingLayout}>
+        <PlankHeading.Button attendableId={attendableId}>
+          <TextAa {...plankHeadingIconProps} />
+        </PlankHeading.Button>
+        <PlankHeading.Label attendableId={attendableId}>{label}</PlankHeading.Label>
+      </div>
+      <div role='none' className={plankHeadingLayout}>
+        <PlankHeading.Button attendableId={attendableId}>
+          <ImageSquare {...plankHeadingIconProps} />
         </PlankHeading.Button>
         <PlankHeading.Label attendableId={attendableId}>{label}</PlankHeading.Label>
       </div>

--- a/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
+++ b/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
@@ -31,16 +31,40 @@ const plankHeadingIconProps: IconProps = {
   weight: 'duotone',
 };
 
+const MenuSignifierHorizontal = () => (
+  <svg className='absolute block-end-2' width={20} height={2} viewBox='0 0 20 2' stroke='currentColor'>
+    <line
+      x1={0.5}
+      y1={0.75}
+      x2={19}
+      y2={0.75}
+      strokeWidth={1.25}
+      strokeLinecap='round'
+      strokeDasharray='6 20'
+      strokeDashoffset='-6.5'
+    />
+  </svg>
+);
+
+const MenuSignifierVertical = () => (
+  <svg className='absolute inline-start-1' width={2} height={18} viewBox='0 0 2 18' stroke='currentColor'>
+    <line x1={1} y1={3} x2={1} y2={18} strokeWidth={1.5} strokeLinecap='round' strokeDasharray='0 6' />
+  </svg>
+);
+
 const PlankHeadingButton = forwardRef<HTMLButtonElement, PlankHeadingButtonProps>(
-  ({ attendableId, classNames, ...props }, forwardedRef) => {
+  ({ attendableId, classNames, children, ...props }, forwardedRef) => {
     const hasAttention = useHasAttention(attendableId);
     return (
       <Button
         {...props}
         variant={hasAttention ? 'primary' : 'ghost'}
-        classNames={['m-1 shrink-0 pli-0 min-bs-0 is-[--rail-action] bs-[--rail-action]', classNames]}
+        classNames={['m-1 shrink-0 pli-0 min-bs-0 is-[--rail-action] bs-[--rail-action] relative', classNames]}
         ref={forwardedRef}
-      />
+      >
+        <MenuSignifierHorizontal />
+        {children}
+      </Button>
     );
   },
 );

--- a/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
+++ b/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
@@ -32,7 +32,7 @@ const plankHeadingIconProps: IconProps = {
 };
 
 const MenuSignifierHorizontal = () => (
-  <svg className='absolute block-end-2' width={20} height={2} viewBox='0 0 20 2' stroke='currentColor'>
+  <svg className='absolute block-end-2' width={20} height={2} viewBox='0 0 20 2' stroke='currentColor' opacity={0.5}>
     <line
       x1={0.5}
       y1={0.75}

--- a/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
+++ b/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
@@ -46,7 +46,7 @@ const MenuSignifierHorizontal = () => (
   </svg>
 );
 
-const MenuSignifierVertical = () => (
+const _MenuSignifierVertical = () => (
   <svg className='absolute inline-start-1' width={2} height={18} viewBox='0 0 2 18' stroke='currentColor'>
     <line x1={1} y1={3} x2={1} y2={18} strokeWidth={1.5} strokeLinecap='round' strokeDasharray='0 6' />
   </svg>


### PR DESCRIPTION
Resolves #5885.

This PR adds a small, partly opaque horizontal bar to `PlankHeading.Button` to indicate it has a menu.

This PR also changes all Document icons to use `TextAa`.

<img width="520" alt="Screenshot 2024-03-08 at 18 25 29" src="https://github.com/dxos/dxos/assets/855039/5da1e729-2bd0-43fa-924e-34af7c002c6c">

We also explored ways this signifier could be added to the tree:

<img width="1280" alt="attending stack section" src="https://github.com/dxos/dxos/assets/855039/e7ec54af-67a7-4f3d-afaf-79cd279d1e6c">
