### PR TITLE
fix(echo): removed unnecessary cancelWithContext

### DIFF
--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
@@ -13,7 +13,7 @@ import {
 } from '@dxos/automerge/automerge-repo';
 import { IndexedDBStorageAdapter } from '@dxos/automerge/automerge-repo-storage-indexeddb';
 import { type Stream } from '@dxos/codec-protobuf';
-import { Context, cancelWithContext } from '@dxos/context';
+import { Context } from '@dxos/context';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { idCodec } from '@dxos/protocols';
@@ -31,7 +31,7 @@ import { MeshNetworkAdapter } from './mesh-network-adapter';
 export type { DocumentId };
 
 export interface MetadataMethods {
-  markDirty(id: string, lastAvailableHash: string): Promise<void>;
+  markDirty(idToLastHash: Map<string, string>): Promise<void>;
 }
 
 export type AutomergeHostParams = {
@@ -162,8 +162,8 @@ export class AutomergeHost {
   }
 
   private _onUpdate(event: DocHandleChangePayload<any>) {
-    const spaceKey = event.doc.access?.spaceKey;
-    if (!spaceKey) {
+    const spaceKey = getSpaceKeyFromDoc(event.doc);
+    if (!spaceKey || this._metadata == null) {
       return;
     }
 
@@ -178,28 +178,18 @@ export class AutomergeHost {
       return;
     }
 
-    const markingDirtyPromise = Promise.all(
-      objectIds.map(async (objectId) => {
-        const spaceKey = getSpaceKeyFromDoc(event.doc);
-        if (!spaceKey) {
-          return;
-        }
-        await cancelWithContext(
-          this._ctx,
-          this._metadata!.markDirty(
-            idCodec.encode({ documentId: event.handle.documentId, objectId, spaceKey }),
-            lastAvailableHash,
-          ),
-        );
-      }),
-    )
+    const encodedIds = objectIds.map((objectId) =>
+      idCodec.encode({ documentId: event.handle.documentId, objectId, spaceKey }),
+    );
+    const idToLastHash = new Map(encodedIds.map((id) => [id, lastAvailableHash]));
+    const markingDirtyPromise = this._metadata
+      .markDirty(idToLastHash)
       .then(() => {
         this._updatingMetadata.delete(event.handle.documentId);
       })
       .catch((err: Error) => {
-        !this._ctx.disposed && log.catch(err);
+        this._ctx.disposed && log.catch(err);
       });
-
     this._updatingMetadata.set(event.handle.documentId, markingDirtyPromise);
   }
 

--- a/packages/core/echo/indexing/src/index-metadata-store.test.ts
+++ b/packages/core/echo/indexing/src/index-metadata-store.test.ts
@@ -17,7 +17,8 @@ describe('IndexMetadataStore', () => {
     const metadataStore = new IndexMetadataStore({ directory });
 
     const ids = ['1', '2', '3'];
-    await Promise.all(ids.map((id) => metadataStore.markDirty(id, `hash-${id}`)));
+    const dirtyMap = new Map(ids.map((id) => [id, `hash-${id}`]));
+    await metadataStore.markDirty(dirtyMap);
     expect(await metadataStore.getDirtyDocuments()).to.deep.equal(ids);
 
     await metadataStore.markClean('1', 'hash-1');

--- a/packages/core/echo/indexing/src/index-metadata-store.ts
+++ b/packages/core/echo/indexing/src/index-metadata-store.ts
@@ -32,11 +32,13 @@ export class IndexMetadataStore implements MetadataMethods {
     this._directory = directory;
   }
 
-  async markDirty(id: string, lastAvailableHash: string) {
-    const metadata = await this._getMetadata(id);
-    metadata.lastAvailableHash = lastAvailableHash;
-    await this._setMetadata(id, metadata);
-    this.dirty.emit();
+  async markDirty(idToLastHash: Map<string, string>) {
+    for (const [id, lastAvailableHash] of idToLastHash.entries()) {
+      const metadata = await this._getMetadata(id);
+      metadata.lastAvailableHash = lastAvailableHash;
+      await this._setMetadata(id, metadata);
+      this.dirty.emit();
+    }
   }
 
   async getDirtyDocuments(): Promise<string[]> {

--- a/packages/core/echo/indexing/src/index-metadata-store.ts
+++ b/packages/core/echo/indexing/src/index-metadata-store.ts
@@ -33,12 +33,13 @@ export class IndexMetadataStore implements MetadataMethods {
   }
 
   async markDirty(idToLastHash: Map<string, string>) {
-    for (const [id, lastAvailableHash] of idToLastHash.entries()) {
+    const tasks = [...idToLastHash.entries()].map(async ([id, lastAvailableHash]) => {
       const metadata = await this._getMetadata(id);
       metadata.lastAvailableHash = lastAvailableHash;
       await this._setMetadata(id, metadata);
       this.dirty.emit();
-    }
+    });
+    await Promise.all(tasks);
   }
 
   async getDirtyDocuments(): Promise<string[]> {

--- a/packages/core/echo/indexing/src/indexer.test.ts
+++ b/packages/core/echo/indexing/src/indexer.test.ts
@@ -41,7 +41,8 @@ describe('Indexer', () => {
     }
 
     {
-      await Promise.all(objects.map((object) => metadataStore.markDirty(object.id, 'hash')));
+      const dirtyMap = new Map(objects.map((object) => [object.id, 'hash']));
+      await metadataStore.markDirty(dirtyMap);
     }
 
     await doneIndexing;


### PR DESCRIPTION
### Motivation / Background

* Remove unnecessary `cancelWithContext` that gets lots of listeners assigned (on every update we add a listener. No point in cancelling on context dispose as we're not performing operations that can hang indefinitely. And IO will anyway complete once it's started.
<img width="575" alt="image" src="https://github.com/dxos/dxos/assets/9644546/b28d653e-a183-4016-bfec-b062ec97cf70">

* Refactored `markDirty` into a batch API. Easier to change the internal implementation when we need to optimize io + more convenient usages on call sites.