### PR TITLE
fix: Checkbox styles

### DIFF
--- a/packages/ui/react-ui-editor/src/extensions/markdown/decorate.ts
+++ b/packages/ui/react-ui-editor/src/extensions/markdown/decorate.ts
@@ -48,7 +48,7 @@ class CheckboxWidget extends WidgetType {
 
   override toDOM(view: EditorView) {
     const input = document.createElement('input');
-    input.className = 'cm-task-checkbox';
+    input.className = 'cm-task-checkbox ch-checkbox ch-focus-ring';
     input.type = 'checkbox';
     input.checked = this._checked;
     if (view.state.readOnly) {

--- a/packages/ui/react-ui-editor/src/extensions/markdown/decorate.ts
+++ b/packages/ui/react-ui-editor/src/extensions/markdown/decorate.ts
@@ -48,7 +48,7 @@ class CheckboxWidget extends WidgetType {
 
   override toDOM(view: EditorView) {
     const input = document.createElement('input');
-    input.className = 'cm-task-checkbox ch-checkbox ch-focus-ring';
+    input.className = 'cm-task-checkbox ch-checkbox ch-focus-ring -mbs-0.5';
     input.type = 'checkbox';
     input.checked = this._checked;
     if (view.state.readOnly) {

--- a/packages/ui/react-ui-theme/src/styles/components/button.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/button.ts
@@ -30,7 +30,7 @@ export type ButtonStyleProps = Partial<{
 }>;
 
 export const buttonRoot: ComponentFunction<ButtonStyleProps> = (_props, ...etc) => {
-  return mx('ch-button group', ...etc);
+  return mx('ch-button ch-focus-ring group', ...etc);
 };
 
 export const buttonGroup: ComponentFunction<{ elevation?: Elevation }> = (props, ...etc) => {

--- a/packages/ui/react-ui-theme/src/styles/components/input.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/input.ts
@@ -118,15 +118,8 @@ export const inputInput: ComponentFunction<InputStyleProps> = (props, ...etc) =>
           ...etc,
         );
 
-export const inputCheckbox: ComponentFunction<InputStyleProps> = ({ size = 5, disabled }, ...etc) =>
-  mx(
-    getSize(size),
-    booleanInputSurface,
-    !disabled && booleanInputSurfaceHover,
-    'shrink-0 flex items-center justify-center rounded text-white',
-    focusRing,
-    ...etc,
-  );
+export const inputCheckbox: ComponentFunction<InputStyleProps> = (_props, ...etc) =>
+  mx('ch-checkbox ch-focus-ring', ...etc);
 
 export const inputCheckboxIndicator: ComponentFunction<InputStyleProps> = ({ size = 5 }, ...etc) =>
   mx(getSize(computeSize(sizeValue(size) * 0.7, 4)), ...etc);

--- a/packages/ui/react-ui-theme/src/styles/components/input.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/input.ts
@@ -118,11 +118,11 @@ export const inputInput: ComponentFunction<InputStyleProps> = (props, ...etc) =>
           ...etc,
         );
 
-export const inputCheckbox: ComponentFunction<InputStyleProps> = (_props, ...etc) =>
-  mx('ch-checkbox ch-focus-ring', ...etc);
+export const inputCheckbox: ComponentFunction<InputStyleProps> = ({ size = 5 }, ...etc) =>
+  mx('ch-checkbox ch-focus-ring', getSize(size), ...etc);
 
 export const inputCheckboxIndicator: ComponentFunction<InputStyleProps> = ({ size = 5 }, ...etc) =>
-  mx(getSize(computeSize(sizeValue(size) * 0.7, 4)), ...etc);
+  mx(getSize(computeSize(sizeValue(size) * 0.65, 4)), ...etc);
 
 export const inputSwitch: ComponentFunction<InputStyleProps> = ({ size = 5, disabled }, ...etc) =>
   mx(

--- a/packages/ui/react-ui-theme/src/styles/layers/button.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/button.css
@@ -1,3 +1,4 @@
+/* TODO(thure): Focus is handled by .ch-focus-ring, but should ideally be applied as part of this component.*/
 /* TODO(thure): This should be on the `components` layer, but utility classes like `pli-0` weren’t getting precedence like they should. */
 @layer base {
   /* Base styles */
@@ -14,22 +15,6 @@
     /* Enabled styles */
     &:not([disabled]),
     &[disabled='false'] {
-      /* Focus */
-      &:focus {
-        @apply outline-none;
-      }
-      &:focus-visible {
-        @apply z-[1] ring-2 ring-offset-0 ring-primary-350 ring-offset-white;
-        .dark & {
-          @apply ring-primary-450 ring-offset-black;
-        }
-        &:hover {
-          @apply outline-none;
-          .dark & {
-            @apply outline-none;
-          }
-        }
-      }
       /* Hover */
       &:hover {
         @apply surface-hover;

--- a/packages/ui/react-ui-theme/src/styles/layers/checkbox.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/checkbox.css
@@ -2,20 +2,22 @@
 /* TODO(thure): This should be on the `components` layer, but utility classes like `pli-0` weren’t getting precedence like they should. */
 @layer base {
   .ch-checkbox {
-    @apply is-5 bs-5 shadow-inner transition-colors surface-unAccent shrink-0 grid place-items-center rounded-sm fg-inverse;
+    @apply is-4 bs-4 border-0 shadow-inner transition-colors surface-unAccent s-accent-unAccent shrink-0 inline-grid place-items-center rounded-sm fg-inverse;
     /* Not-unchecked styles */
     &[aria-checked='true'],
-    &[aria-checked='mixed'] {
-      @apply surface-accent;
+    &[aria-checked='mixed'],
+    &:checked {
+      @apply surface-accent s-accent-accent;
     }
     /* Enabled styles */
     &:not([disabled]),
     &[disabled='false'] {
       &:hover {
-        @apply surface-unAccentHover;
+        @apply surface-unAccentHover s-accent-unAccentHover;
         &[aria-checked='true'],
-        &[aria-checked='mixed'] {
-          @apply surface-accentHover;
+        &[aria-checked='mixed'],
+        &:checked {
+          @apply surface-accentHover s-accent-accentHover;
         }
       }
     }

--- a/packages/ui/react-ui-theme/src/styles/layers/checkbox.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/checkbox.css
@@ -1,0 +1,23 @@
+/* TODO(thure): Focus is handled by .ch-focus-ring, but should ideally be applied as part of this component.*/
+/* TODO(thure): This should be on the `components` layer, but utility classes like `pli-0` weren’t getting precedence like they should. */
+@layer base {
+  .ch-checkbox {
+    @apply is-5 bs-5 shadow-inner transition-colors surface-unAccent shrink-0 grid place-items-center rounded-sm fg-inverse;
+    /* Not-unchecked styles */
+    &[aria-checked='true'],
+    &[aria-checked='mixed'] {
+      @apply surface-accent;
+    }
+    /* Enabled styles */
+    &:not([disabled]),
+    &[disabled='false'] {
+      &:hover {
+        @apply surface-unAccentHover;
+        &[aria-checked='true'],
+        &[aria-checked='mixed'] {
+          @apply surface-accentHover;
+        }
+      }
+    }
+  }
+}

--- a/packages/ui/react-ui-theme/src/styles/layers/checkbox.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/checkbox.css
@@ -2,7 +2,7 @@
 /* TODO(thure): This should be on the `components` layer, but utility classes like `pli-0` weren’t getting precedence like they should. */
 @layer base {
   .ch-checkbox {
-    @apply is-4 bs-4 border-0 shadow-inner transition-colors surface-unAccent s-accent-unAccent shrink-0 inline-grid place-items-center rounded-sm fg-inverse;
+    @apply is-4 bs-4 border-0 shadow-inner transition-colors surface-unAccent s-accent-unAccent fg-inverse shrink-0 inline-grid place-items-center rounded-sm;
     /* Not-unchecked styles */
     &[aria-checked='true'],
     &[aria-checked='mixed'],

--- a/packages/ui/react-ui-theme/src/styles/layers/focus-ring.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/focus-ring.css
@@ -1,26 +1,26 @@
 @layer base {
-    .ch-focus-ring {
-        &:not([disabled]),
-        &[disabled='false'] {
-            &:focus {
-                @apply outline-none;
-            }
+  .ch-focus-ring {
+    &:not([disabled]),
+    &[disabled='false'] {
+      &:focus {
+        @apply outline-none;
+      }
 
-            &:focus-visible {
-                @apply z-[1] ring-2 ring-offset-0 ring-primary-350 ring-offset-white;
+      &:focus-visible {
+        @apply z-[1] ring-2 ring-offset-0 ring-primary-350 ring-offset-white;
 
-                .dark & {
-                    @apply ring-primary-450 ring-offset-black;
-                }
-
-                &:hover {
-                    @apply outline-none;
-
-                    .dark & {
-                        @apply outline-none;
-                    }
-                }
-            }
+        .dark & {
+          @apply ring-primary-450 ring-offset-black;
         }
+
+        &:hover {
+          @apply outline-none;
+
+          .dark & {
+            @apply outline-none;
+          }
+        }
+      }
     }
+  }
 }

--- a/packages/ui/react-ui-theme/src/styles/layers/focus-ring.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/focus-ring.css
@@ -1,0 +1,26 @@
+@layer base {
+    .ch-focus-ring {
+        &:not([disabled]),
+        &[disabled='false'] {
+            &:focus {
+                @apply outline-none;
+            }
+
+            &:focus-visible {
+                @apply z-[1] ring-2 ring-offset-0 ring-primary-350 ring-offset-white;
+
+                .dark & {
+                    @apply ring-primary-450 ring-offset-black;
+                }
+
+                &:hover {
+                    @apply outline-none;
+
+                    .dark & {
+                        @apply outline-none;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/ui/react-ui-theme/src/styles/layers/index.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/index.css
@@ -1,6 +1,8 @@
 @import './anchored-overflow.css';
 @import './attention.css';
 @import './button.css';
+@import './checkbox.css';
+@import './focus-ring.css';
 @import './positioning.css';
 @import './surfaces.css';
 @import './typography.css';

--- a/packages/ui/react-ui-theme/src/util/semanticColors.ts
+++ b/packages/ui/react-ui-theme/src/util/semanticColors.ts
@@ -17,11 +17,18 @@ export const semanticColors = plugin(({ addUtilities, theme, e }) => {
   const values: Record<string, SemanticColorValue> = theme('semanticColors');
   const semanticColorUtilities = Object.entries(values).map(([key, value]) => {
     return {
+      // TODO(thure): Refactor all of these tokens to simply prefix the properties they apply with `s-` as with `s-accent`.
       [`.fg-${e(`${key}`)}`]: {
         color: `${value.fg?.light ?? value.light}`,
       },
       [`.dark .fg-${e(`${key}`)}`]: {
         color: `${value.fg?.dark ?? value.dark}`,
+      },
+      [`.s-accent-${e(`${key}`)}`]: {
+        accentColor: `${value.fg?.light ?? value.light}`,
+      },
+      [`.dark .s-accent-${e(`${key}`)}`]: {
+        accentColor: `${value.fg?.dark ?? value.dark}`,
       },
       [`.surface-${e(`${key}`)}`]: {
         backgroundColor: `${value.light}`,


### PR DESCRIPTION
Resolves #5828.

This PR refactors checkbox styles into a utility classname which CM can more easily apply: `ch-checkbox`.

This PR extends the styles defined for checkboxes to apply to `<input type=checkbox/>` elements as well as Radix’s `<button role=checkbox />` elements.

https://github.com/dxos/dxos/assets/855039/81636535-467d-4561-9eb1-3e7944cf3c40