### PR TITLE
chore: cleanup textbox role

### DIFF
--- a/packages/apps/composer-app/src/playwright/comments.spec.ts
+++ b/packages/apps/composer-app/src/playwright/comments.spec.ts
@@ -52,9 +52,10 @@ test.describe('Comments tests', () => {
 
     const editedText = 'Edited';
     await message.fill(editedText);
-    const editedMessage = Thread.getMessage(thread, editedText).getByRole('textbox');
+    const newText = messageText + editedText;
+    const editedMessage = Thread.getMessage(thread, newText).getByRole('textbox');
     await waitForExpect(async () => {
-      expect((await editedMessage.innerText()).trim()).to.equal(editedText);
+      expect((await editedMessage.innerText()).trim()).to.equal(newText);
     });
   });
 

--- a/packages/apps/plugins/plugin-chain/src/components/PromptTemplate/PromptTemplate.tsx
+++ b/packages/apps/plugins/plugin-chain/src/components/PromptTemplate/PromptTemplate.tsx
@@ -148,7 +148,7 @@ export const PromptTemplate = ({ prompt }: PromptTemplateProps) => {
         </Section>
 
         <Section title='Template'>
-          <div role='textbox' ref={parentRef} className={attentionSurface} />
+          <div ref={parentRef} className={attentionSurface} />
         </Section>
 
         {prompt.inputs?.length > 0 && (

--- a/packages/apps/plugins/plugin-kanban/src/components/KanbanCard.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/components/KanbanCard.tsx
@@ -69,7 +69,7 @@ export const KanbanCardComponent: FC<{
           <DotsSixVertical className={getSize(5)} />
         </button>
         <div className='flex flex-col grow pt-1'>
-          <div role='textbox' className={mx(focusRing, 'p-1')} ref={parentRef} />
+          <div className={mx(focusRing, 'p-1')} ref={parentRef} />
           {debug && <div className='text-xs text-red-800'>{item.id.slice(0, 9)}</div>}
         </div>
         {onDelete && (

--- a/packages/apps/plugins/plugin-markdown/src/components/DocumentSection.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/DocumentSection.tsx
@@ -54,7 +54,6 @@ const DocumentSection: FC<{
 
   return (
     <div
-      role='textbox'
       ref={parentRef}
       className={mx('flex flex-col grow m-0.5 min-bs-[8rem]', attentionSurface, focusRing)}
       {...{ 'data-testid': 'composer.markdownRoot' }}

--- a/packages/apps/plugins/plugin-outliner/src/components/Outliner/Outliner.tsx
+++ b/packages/apps/plugins/plugin-outliner/src/components/Outliner/Outliner.tsx
@@ -286,7 +286,7 @@ const OutlinerItem = (props: OutlinerItemProps) => {
         )}
       </div>
 
-      <div role='textbox' ref={parentRef} className='flex grow pt-1' />
+      <div ref={parentRef} className='flex grow pt-1' />
 
       <DropdownMenu.Root>
         <DropdownMenu.Trigger asChild>

--- a/packages/apps/plugins/plugin-thread/src/components/MessageContainer.tsx
+++ b/packages/apps/plugins/plugin-thread/src/components/MessageContainer.tsx
@@ -91,7 +91,7 @@ const TextboxBlock = ({
       role='none'
       className={mx('col-span-3 grid grid-cols-subgrid', hoverableControls, hoverableFocusedWithinControls)}
     >
-      <div role='textbox' ref={parentRef} className={textboxWidth} />
+      <div ref={parentRef} className={textboxWidth} />
       {onBlockDelete && (
         <Button
           variant='ghost'

--- a/packages/ui/react-ui-editor/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/ui/react-ui-editor/src/components/Toolbar/Toolbar.stories.tsx
@@ -76,7 +76,7 @@ const Story: FC<{ content: string }> = ({ content }) => {
         <Toolbar.Separator />
         <Toolbar.Extended />
       </Toolbar.Root>
-      <div role='textbox' ref={parentRef} className={textBlockWidth} />;
+      <div ref={parentRef} className={textBlockWidth} />;
     </div>
   );
 };

--- a/packages/ui/react-ui-editor/src/hooks/useTextEditor.stories.tsx
+++ b/packages/ui/react-ui-editor/src/hooks/useTextEditor.stories.tsx
@@ -67,7 +67,7 @@ const Story = ({ autoFocus, placeholder, doc, readonly }: StoryProps) => {
         <EditorModeToolbar editorMode={editorMode} setEditorMode={setEditorMode} />
       </Toolbar.Root>
       <div role='none' className='grow overflow-hidden'>
-        <div role='textbox' className={mx(textBlockWidth, attentionSurface)} ref={parentRef} />
+        <div className={mx(textBlockWidth, attentionSurface)} ref={parentRef} />
       </div>
     </div>
   );
@@ -117,7 +117,7 @@ export default {
 export const Default = {
   render: () => {
     const { parentRef } = useTextEditor();
-    return <div role='textbox' className={mx(textBlockWidth, attentionSurface)} ref={parentRef} />;
+    return <div className={mx(textBlockWidth, attentionSurface)} ref={parentRef} />;
   },
 };
 
@@ -127,7 +127,7 @@ export const Basic = {
     const { parentRef } = useTextEditor(() => ({
       extensions: [createBasicExtensions({ placeholder: 'Enter text...' }), createThemeExtensions({ themeMode })],
     }));
-    return <div role='textbox' className={mx(textBlockWidth, attentionSurface)} ref={parentRef} />;
+    return <div className={mx(textBlockWidth, attentionSurface)} ref={parentRef} />;
   },
 };
 

--- a/packages/ui/react-ui-searchlist/src/components/SearchList.tsx
+++ b/packages/ui/react-ui-searchlist/src/components/SearchList.tsx
@@ -78,7 +78,6 @@ const SearchListInput = forwardRef<HTMLInputElement, SearchListInputProps>(
 
     return (
       <CommandInput
-        role='textbox'
         {...props}
         className={tx(
           'input.input',


### PR DESCRIPTION
Fixes e2e tests by removing superfluous `role='textbox'` attributes that got added during recent editor refactor.
