### PR TITLE
fix(echo): effect schema fixes and discriminated union support

### DIFF
--- a/packages/core/echo/echo-schema/src/effect/echo-handler.ts
+++ b/packages/core/echo/echo-schema/src/effect/echo-handler.ts
@@ -551,6 +551,7 @@ const validateSchema = (schema: S.Schema<any>) => {
     throw new Error('"id" property name is reserved');
   }
   getSchemaTypeRefOrThrow(schema);
+  SchemaValidator.validateSchema(schema);
 };
 
 const saveTypeInAutomerge = (handler: EchoReactiveHandler, schema: S.Schema<any> | undefined) => {

--- a/packages/core/echo/echo-schema/src/effect/proxy.test.ts
+++ b/packages/core/echo/echo-schema/src/effect/proxy.test.ts
@@ -16,8 +16,10 @@ import { createDatabase } from '../testing';
 
 registerSignalRuntime();
 
-for (const schema of [undefined, TestSchema]) {
-  for (const useDatabase of [false, true]) {
+test('', () => {});
+
+for (const schema of [TestSchema]) {
+  for (const useDatabase of [false]) {
     const testSetup = useDatabase ? createDatabase(new Hypergraph(), { useReactiveObjectApi: true }) : undefined;
     const createObject = async (props: Partial<TestSchema> = {}): Promise<TestSchema> => {
       const testSchema = useDatabase && schema ? schema.pipe(R.echoObject('TestSchema', '1.0.0')) : schema;
@@ -37,7 +39,7 @@ for (const schema of [undefined, TestSchema]) {
       continue;
     }
 
-    describe(`Proxy properties${schema == null ? '' : ' with schema'}`, () => {
+    describe.only(`Proxy properties${schema == null ? '' : ' with schema'}`, () => {
       test('object initializer', async () => {
         const obj = await createObject({ string: 'bar' });
         expect(obj.string).to.eq('bar');
@@ -83,11 +85,11 @@ for (const schema of [undefined, TestSchema]) {
       test('can assign array values', async () => {
         const obj = await createObject();
 
-        obj.numberArray = [1, 2, 3];
-        expect(obj.numberArray).to.deep.eq([1, 2, 3]);
+        obj.stringArray = ['1', '2', '3'];
+        expect(obj.stringArray).to.deep.eq(['1', '2', '3']);
 
-        obj.numberArray[0] = 4;
-        expect(obj.numberArray).to.deep.eq([4, 2, 3]);
+        obj.stringArray[0] = '4';
+        expect(obj.stringArray).to.deep.eq(['4', '2', '3']);
       });
 
       test('can assign arrays with objects', async () => {
@@ -169,17 +171,17 @@ for (const schema of [undefined, TestSchema]) {
       });
 
       test('Array.isArray', async () => {
-        const obj = await createObject({ numberArray: [1, 2, 3] });
-        expect(Array.isArray(obj.numberArray)).to.be.true;
+        const obj = await createObject({ stringArray: ['1', '2', '3'] });
+        expect(Array.isArray(obj.stringArray)).to.be.true;
       });
 
       test('instanceof', async () => {
-        const obj = await createObject({ numberArray: [1, 2, 3], object: { field: 'foo' } });
+        const obj = await createObject({ stringArray: ['1', '2', '3'], object: { field: 'foo' } });
 
         expect(obj instanceof Object).to.be.true;
         expect(obj instanceof Array).to.be.false;
-        expect(obj.numberArray instanceof Object).to.be.true;
-        expect(obj.numberArray instanceof Array).to.be.true;
+        expect(obj.stringArray instanceof Object).to.be.true;
+        expect(obj.stringArray instanceof Array).to.be.true;
         expect(obj.object instanceof Object).to.be.true;
         expect(obj.object instanceof Array).to.be.false;
       });
@@ -265,14 +267,14 @@ for (const schema of [undefined, TestSchema]) {
         });
 
         test('in nested arrays', async () => {
-          const obj = await createObject({ numberArray: [7] });
+          const obj = await createObject({ stringArray: ['7'] });
 
           using updates = updateCounter(() => {
-            obj.numberArray![0];
+            obj.stringArray![0];
           });
           expect(updates.count, 'update count').to.eq(0);
 
-          obj.numberArray![0] = 42;
+          obj.stringArray![0] = '42';
           expect(updates.count, 'update count').to.eq(1);
         });
 
@@ -302,36 +304,36 @@ for (const schema of [undefined, TestSchema]) {
       });
 
       describe('array operations', () => {
-        const createReactiveArray = async (numberArray: number[]): Promise<number[]> => {
-          const obj = await createObject({ numberArray });
-          return obj.numberArray!;
+        const createReactiveArray = async (stringArray: string[]): Promise<string[]> => {
+          const obj = await createObject({ stringArray });
+          return obj.stringArray!;
         };
 
         test('set by index', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(() => {
             array[0];
           });
 
-          array[0] = 2;
-          expect(array[0]).to.eq(2);
+          array[0] = '2';
+          expect(array[0]).to.eq('2');
           expect(updates.count, 'update count').to.eq(1);
         });
 
         test('length', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(() => {
             array[0];
           });
           expect(array.length).to.eq(3);
 
-          array.push(4);
+          array.push('4');
           expect(array.length).to.eq(4);
           expect(updates.count, 'update count').to.eq(1);
         });
 
         test('set length', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(() => {
             array[0];
           });
@@ -342,117 +344,117 @@ for (const schema of [undefined, TestSchema]) {
         });
 
         test('push', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(() => {
             array[0];
           });
 
-          array.push(4);
-          expect(array).to.deep.eq([1, 2, 3, 4]);
+          array.push('4');
+          expect(array).to.deep.eq(['1', '2', '3', '4']);
           expect(updates.count, 'update count').to.eq(1);
         });
 
         test('pop', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(() => {
             array[0];
           });
 
           const value = array.pop();
-          expect(value).to.eq(3);
-          expect(array).to.deep.eq([1, 2]);
+          expect(value).to.eq('3');
+          expect(array).to.deep.eq(['1', '2']);
           expect(updates.count, 'update count').to.eq(1);
         });
 
         test('shift', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(() => {
             array[0];
           });
 
           const value = array.shift();
-          expect(value).to.eq(1);
-          expect(array).to.deep.eq([2, 3]);
+          expect(value).to.eq('1');
+          expect(array).to.deep.eq(['2', '3']);
           expect(updates.count, 'update count').to.eq(1);
         });
 
         test('unshift', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(() => {
             array[0];
           });
 
-          const newLength = array.unshift(0);
+          const newLength = array.unshift('0');
           expect(newLength).to.eq(4);
-          expect(array).to.deep.eq([0, 1, 2, 3]);
+          expect(array).to.deep.eq(['0', '1', '2', '3']);
           expect(updates.count, 'update count').to.eq(1);
         });
 
         test('splice', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(() => {
             array[0];
           });
 
-          const removed = array.splice(1, 1, 4);
-          expect(removed).to.deep.eq([2]);
-          expect(array).to.deep.eq([1, 4, 3]);
+          const removed = array.splice(1, 1, '4');
+          expect(removed).to.deep.eq(['2']);
+          expect(array).to.deep.eq(['1', '4', '3']);
           expect(updates.count, 'update count').to.eq(1);
         });
 
         test('sort', async () => {
-          const array = await createReactiveArray([3, 2, 1]);
+          const array = await createReactiveArray(['3', '2', '1']);
           using updates = updateCounter(() => {
             array[0];
           });
 
           const returnValue = array.sort();
           expect(returnValue === array).to.be.true;
-          expect(array).to.deep.eq([1, 2, 3]);
+          expect(array).to.deep.eq(['1', '2', '3']);
           expect(updates.count, 'update count').to.eq(1);
         });
 
         test('filter', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
-          const returnValue = array.filter((v) => v & 1);
-          expect(returnValue).to.deep.eq([1, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
+          const returnValue = array.filter((v) => Number(v) & 1);
+          expect(returnValue).to.deep.eq(['1', '3']);
         });
 
         test('reverse', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(() => {
             array[0];
           });
 
           const returnValue = array.reverse();
           expect(returnValue === array).to.be.true;
-          expect(array).to.deep.eq([3, 2, 1]);
+          expect(array).to.deep.eq(['3', '2', '1']);
           expect(updates.count, 'update count').to.eq(1);
         });
 
         test('map', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(() => {
             array[0];
           });
 
-          const result = array.map((value) => value * 2);
+          const result = array.map((value) => String(Number(value) * 2));
           expect(Array.isArray(result)).to.be.true;
           expect(Object.getPrototypeOf(result)).to.eq(Array.prototype);
-          expect(result).to.deep.eq([2, 4, 6]);
+          expect(result).to.deep.eq(['2', '4', '6']);
           expect(updates.count, 'update count').to.eq(0);
         });
 
         test('flatMap', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(() => {
             array[0];
           });
 
-          const result = array.flatMap((value) => [value, value * 2]);
+          const result = array.flatMap((value) => [value, String(Number(value) * 2)]);
           expect(Array.isArray(result)).to.be.true;
           expect(Object.getPrototypeOf(result)).to.eq(Array.prototype);
-          expect(result).to.deep.eq([1, 2, 2, 4, 3, 6]);
+          expect(result).to.deep.eq(['1', '2', '2', '4', '3', '6']);
           expect(updates.count, 'update count').to.eq(0);
         });
 
@@ -471,21 +473,21 @@ for (const schema of [undefined, TestSchema]) {
         });
 
         test('forEach', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(() => {
             array[0];
           });
 
           let sum = 0;
           array.forEach((value) => {
-            sum += value;
+            sum += Number(value);
           });
           expect(sum).to.eq(6);
           expect(updates.count, 'update count').to.eq(0);
         });
 
         test('spreading', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(() => {
             array[0];
           });
@@ -493,33 +495,33 @@ for (const schema of [undefined, TestSchema]) {
           const result = [...array];
           expect(Array.isArray(result)).to.be.true;
           expect(Object.getPrototypeOf(result)).to.eq(Array.prototype);
-          expect(result).to.deep.eq([1, 2, 3]);
+          expect(result).to.deep.eq(['1', '2', '3']);
           expect(updates.count, 'update count').to.eq(0);
         });
 
         test('values', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(() => {
             array[0];
           });
 
           const result = array.values();
-          expect(result.next().value).to.eq(1);
-          expect(result.next().value).to.eq(2);
-          expect(result.next().value).to.eq(3);
+          expect(result.next().value).to.eq('1');
+          expect(result.next().value).to.eq('2');
+          expect(result.next().value).to.eq('3');
           expect(result.next().done).to.be.true;
           expect(updates.count, 'update count').to.eq(0);
         });
 
         test('for loop', async () => {
-          const array = await createReactiveArray([1, 2, 3]);
+          const array = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(() => {
             array[0];
           });
 
           let sum = 0;
           for (const value of array) {
-            sum += value;
+            sum += Number(value);
           }
           expect(sum).to.eq(6);
           expect(updates.count, 'update count').to.eq(0);
@@ -534,6 +536,6 @@ const TEST_OBJECT: TestSchema = {
   number: 42,
   boolean: true,
   null: null,
-  numberArray: [1, 2, 3],
+  stringArray: ['1', '2', '3'],
   object: { field: 'bar' },
 };

--- a/packages/core/echo/echo-schema/src/effect/proxy.test.ts
+++ b/packages/core/echo/echo-schema/src/effect/proxy.test.ts
@@ -6,7 +6,6 @@ import { expect } from 'chai';
 import jestExpect from 'expect';
 
 import { registerSignalRuntime } from '@dxos/echo-signals';
-import { log } from '@dxos/log';
 import { describe, test } from '@dxos/test';
 
 import * as R from './reactive';
@@ -17,10 +16,8 @@ import { createDatabase } from '../testing';
 
 registerSignalRuntime();
 
-test('', () => {});
-
-for (const schema of [TestSchema]) {
-  for (const useDatabase of [true]) {
+for (const schema of [undefined, TestSchema]) {
+  for (const useDatabase of [false, true]) {
     const testSetup = useDatabase ? createDatabase(new Hypergraph(), { useReactiveObjectApi: true }) : undefined;
     const createObject = async (props: Partial<TestSchema> = {}): Promise<TestSchema> => {
       const testSchema = useDatabase && schema ? schema.pipe(R.echoObject('TestSchema', '1.0.0')) : schema;
@@ -89,7 +86,6 @@ for (const schema of [TestSchema]) {
       });
 
       test('can work with complex types', async () => {
-        log.info('schema', { schema: schema != null, useDatabase });
         const circle: any = { type: 'circle', radius: 42 };
         const obj = await createObject({ nullableShapeArray: [circle] });
 
@@ -116,9 +112,11 @@ for (const schema of [TestSchema]) {
         obj.object = { field: 'bar' };
         expect(() => (obj.object!.field = 1 as any)).to.throw();
         expect(() => obj.objectArray?.push({ field: 1 } as any)).to.throw();
+        expect(() => obj.objectArray?.unshift({ field: 1 } as any)).to.throw();
         expect(() => (obj.objectArray![0] = { field: 1 } as any)).to.throw();
         expect(() => (obj.objectArray![0].field = 1 as any)).to.throw();
         obj.objectArray?.push({ field: 'bar' });
+        expect(() => obj.objectArray?.splice(1, 0, { field: 1 } as any)).to.throw();
         expect(() => (obj.objectArray![1].field = 1 as any)).to.throw();
       });
 

--- a/packages/core/echo/echo-schema/src/effect/proxy.test.ts
+++ b/packages/core/echo/echo-schema/src/effect/proxy.test.ts
@@ -32,7 +32,7 @@ for (const schema of [undefined, TestSchema]) {
       return db.add(obj);
     };
 
-    describe.only(`Proxy properties${schema == null ? '' : ' with schema'}`, () => {
+    describe(`Proxy properties${schema == null ? '' : ' with schema'}`, () => {
       test('object initializer', async () => {
         const obj = await createObject({ string: 'bar' });
         expect(obj.string).to.eq('bar');

--- a/packages/core/echo/echo-schema/src/effect/proxy.test.ts
+++ b/packages/core/echo/echo-schema/src/effect/proxy.test.ts
@@ -92,6 +92,22 @@ for (const schema of [TestSchema]) {
         expect(obj.stringArray).to.deep.eq(['4', '2', '3']);
       });
 
+      test('validation failures', async () => {
+        if (schema == null) {
+          return;
+        }
+        const obj = await createObject({ objectArray: [{ field: 'foo' }] });
+        expect(() => (obj.string = 1 as any)).to.throw();
+        expect(() => (obj.object = { field: 1 } as any)).to.throw();
+        obj.object = { field: 'bar' };
+        expect(() => (obj.object!.field = 1 as any)).to.throw();
+        expect(() => obj.objectArray?.push({ field: 1 } as any)).to.throw();
+        expect(() => (obj.objectArray![0] = { field: 1 } as any)).to.throw();
+        expect(() => (obj.objectArray![0].field = 1 as any)).to.throw();
+        obj.objectArray?.push({ field: 'bar' });
+        expect(() => (obj.objectArray![1].field = 1 as any)).to.throw();
+      });
+
       test('can assign arrays with objects', async () => {
         const obj = await createObject();
 

--- a/packages/core/echo/echo-schema/src/effect/schema-validator.test.ts
+++ b/packages/core/echo/echo-schema/src/effect/schema-validator.test.ts
@@ -1,0 +1,19 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import * as S from '@effect/schema/Schema';
+import { expect } from 'chai';
+
+import { test, describe } from '@dxos/test';
+
+import { SchemaValidator } from './schema-validator';
+
+describe('reactive', () => {
+  test('throws on ambiguous discriminated type union', () => {
+    const schema = S.struct({
+      union: S.union(S.struct({ a: S.number }), S.struct({ b: S.string })),
+    });
+    expect(() => SchemaValidator.validateSchema(schema)).to.throw();
+  });
+});

--- a/packages/core/echo/echo-schema/src/effect/testing/schema.ts
+++ b/packages/core/echo/echo-schema/src/effect/testing/schema.ts
@@ -12,16 +12,21 @@ export class TestClass {
   }
 }
 
+const Circle = S.struct({ type: S.literal('circle'), radius: S.number });
+const Square = S.struct({ type: S.literal('square'), side: S.number });
+const Shape = S.union(Circle, Square);
+
 const TestNestedSchema = S.mutable(S.struct({ field: S.string }));
 export const TestSchema = S.mutable(
   S.partial(
     S.struct({
       string: S.string,
       number: S.number,
+      nullableShapeArray: S.mutable(S.array(S.union(Shape, S.null))),
       boolean: S.boolean,
       null: S.null,
       undefined: S.undefined,
-      numberArray: S.mutable(S.array(S.number)),
+      stringArray: S.mutable(S.array(S.string)),
       twoDimNumberArray: S.mutable(S.array(S.mutable(S.array(S.number)))),
       object: TestNestedSchema,
       objectArray: S.mutable(S.array(TestNestedSchema)),

--- a/packages/core/echo/echo-schema/src/effect/typed-handler.ts
+++ b/packages/core/echo/echo-schema/src/effect/typed-handler.ts
@@ -5,9 +5,10 @@
 import { inspect, type InspectOptionsStylized } from 'node:util';
 
 import { compositeRuntime } from '@dxos/echo-signals/runtime';
+import { invariant } from '@dxos/invariant';
 
 import { type ReactiveHandler, createReactiveProxy, isValidProxyTarget } from './proxy';
-import { SchemaValidator } from './schema-validator';
+import { SchemaValidator, symbolSchema } from './schema-validator';
 import { defineHiddenProperty } from '../util/property';
 
 export class TypedReactiveHandler<T extends object> implements ReactiveHandler<T> {
@@ -15,7 +16,7 @@ export class TypedReactiveHandler<T extends object> implements ReactiveHandler<T
   _signal = compositeRuntime.createSignal();
 
   _init(target: any): void {
-    SchemaValidator.initTypedTarget(target);
+    invariant(target[symbolSchema]);
     defineHiddenProperty(target, inspect.custom, this._inspect.bind(target));
   }
 

--- a/packages/core/echo/echo-schema/src/effect/untyped-handler.ts
+++ b/packages/core/echo/echo-schema/src/effect/untyped-handler.ts
@@ -81,7 +81,7 @@ export class UntypedReactiveHandler implements ReactiveHandler<ProxyTarget> {
   set(target: ProxyTarget, prop: string | symbol, value: any, receiver: any): boolean {
     // Convert arrays to reactive arrays on write.
     if (Array.isArray(value)) {
-      value = new ReactiveArray(...value);
+      value = ReactiveArray.from(value);
     }
 
     const result = Reflect.set(target, prop, value);


### PR DESCRIPTION
### Motivation / Background

* Make all schema tests pass
* Add support for discriminated unions
* Added element validation for array-mutating methods
* Fixed non-number arrays length update broken
* A test for failing validations 
* Add schema validation on reactive & echo object creation (throws if we can't handle the provided schema correctly)