### PR TITLE
fix: allow localStorage.dxlog to override config

### DIFF
--- a/packages/common/log/src/options.ts
+++ b/packages/common/log/src/options.ts
@@ -46,13 +46,7 @@ export const getConfig = (options?: LogOptions): LogConfig => {
         }
       : undefined;
 
-  const mergedOptions: LogOptions = defaultsDeep(
-    {},
-    options,
-    nodeOptions && loadOptions(nodeOptions.file),
-    nodeOptions,
-  );
-
+  const mergedOptions: LogOptions = defaultsDeep({}, loadOptions(nodeOptions?.file), nodeOptions, options);
   return {
     options: mergedOptions,
     filters: parseFilter(mergedOptions.filter ?? LogLevel.INFO),

--- a/packages/common/log/src/platform/browser/index.ts
+++ b/packages/common/log/src/platform/browser/index.ts
@@ -6,6 +6,9 @@ import { type LogOptions } from '../../config';
 
 // NOTE: Implementation for the browser. See `package.json`.
 export const loadOptions = (filepath?: string): LogOptions | undefined => {
+  if (localStorage.getItem('dxlog') === null) {
+    return undefined;
+  }
   try {
     return JSON.parse(localStorage.getItem('dxlog')!);
   } catch (err) {


### PR DESCRIPTION
### Motivation / Background

e.g. so you can `localStorage.dxlog='{ "filter": "messaging:debug,info"}'` in the browser console.