### PR TITLE
feat: allow localStorage.dxlog to override config

### DIFF
--- a/REPOSITORY_GUIDE.md
+++ b/REPOSITORY_GUIDE.md
@@ -140,6 +140,15 @@ This is appropriate when `nx` caching is not suitable or necessary for the task,
 | `docs/docs/design`      | Design documents for future features in research and development                               |
 | `docs/docs/specs`       | Descriptions of features currently being built                                                 |
 
+## Logging
+Logging should use the `@dxos/log` package, which can be controlled using using `runtime.client.log` in `@dxos/config`.
+
+For local development, the log filter can be set using the [`LOG_FILTER` environment variable, e.g.](./packages/apps/composer-app/dx-env.yml).
+
+For hosted apps, it can be set in the browser using `localStorage.dxlog`, e.g. `localStorage.dxlog='{ "filter": "messaging:debug,info"}'`.
+
+The filter consists of a series of filename pattern/level tuples separated by commas. For example, `echo:debug,info` will set the log level to `debug` for any filename matching "echo", and `info` for everything else.
+
 ## Branches
 
 *   In general, features are developed on feature branches starting with the author's nickname e.g.: `alice/some-feature`.
@@ -158,7 +167,7 @@ This is appropriate when `nx` caching is not suitable or necessary for the task,
 
 ## Publishing
 
-*   All merges to `main` automatically publish apps to dev.kube.dxos.org.
+*   All merges to `main` automatically publish apps to dev.kube.dxos.org and publish npm packages under the `main` tag.
 *   All merges to `staging` automatically publish apps to staging.kube.dxos.org and publish npm packages under the `next` tag.
 *   All merges to `production` automatically publish apps to kube.dxos.org and publish npm packages under the `latest` tag.
 
@@ -239,12 +248,7 @@ Alternatively to autofix all lint errors on save add the following config:
 alias px="pnpm -w nx"
 ```
 
-More custom shell aliases can be included in your shell config via:
-
-```bash
-source $DXOS_ROOT/dxos/tools/zsh/tools-alias.zsh
-```
-
+More custom shell aliases can be included in your shell config by utilizing the [oh-my-zsh](https://ohmyz.sh) [plugin](./tools/zsh)/
 ## Mobile development
 
 Modern browsers treat `localhost` as a secure context, allowing secure apis such a `SubtleCrypto` to be used in an application served from `localhost`, however sometimes this is not enough. 

--- a/packages/common/log/src/options.ts
+++ b/packages/common/log/src/options.ts
@@ -46,13 +46,7 @@ export const getConfig = (options?: LogOptions): LogConfig => {
         }
       : undefined;
 
-  const mergedOptions: LogOptions = defaultsDeep(
-    {},
-    options,
-    nodeOptions && loadOptions(nodeOptions.file),
-    nodeOptions,
-  );
-
+  const mergedOptions: LogOptions = defaultsDeep({}, loadOptions(nodeOptions?.file), nodeOptions, options);
   return {
     options: mergedOptions,
     filters: parseFilter(mergedOptions.filter ?? LogLevel.INFO),

--- a/packages/common/log/src/platform/browser/index.ts
+++ b/packages/common/log/src/platform/browser/index.ts
@@ -6,9 +6,21 @@ import { type LogOptions } from '../../config';
 
 // NOTE: Implementation for the browser. See `package.json`.
 export const loadOptions = (filepath?: string): LogOptions | undefined => {
+  let dxlog: string | undefined;
+  if (typeof localStorage === 'undefined') {
+    if ((globalThis as any).localStorage_dxlog) {
+      dxlog = (globalThis as any).localStorage_dxlog;
+    }
+  } else {
+    dxlog = localStorage.getItem('dxlog') ?? undefined;
+  }
+  if (!dxlog) {
+    return undefined;
+  }
   try {
-    return JSON.parse(localStorage.getItem('dxlog')!);
+    return JSON.parse(dxlog);
   } catch (err) {
+    console.info("can't parse dxlog config", err);
     return undefined;
   }
 };

--- a/packages/common/log/src/platform/browser/index.ts
+++ b/packages/common/log/src/platform/browser/index.ts
@@ -7,6 +7,8 @@ import { type LogOptions } from '../../config';
 // NOTE: Implementation for the browser. See `package.json`.
 export const loadOptions = (filepath?: string): LogOptions | undefined => {
   let dxlog: string | undefined;
+  // if running in a worker, use the localStorage.dxlog setting forwarded on worker initilization in
+  // @dxos/client/src/worker/onconnect.ts
   if (typeof localStorage === 'undefined') {
     if ((globalThis as any).localStorage_dxlog) {
       dxlog = (globalThis as any).localStorage_dxlog;

--- a/packages/sdk/client/src/services/worker-client-services.ts
+++ b/packages/sdk/client/src/services/worker-client-services.ts
@@ -77,6 +77,7 @@ export class WorkerClientServices implements ClientServicesProvider {
 
     const ports = new Trigger<{ systemPort: MessagePort; appPort: MessagePort }>();
     const worker = this._createWorker();
+    worker.port.postMessage({ dxlog: localStorage.getItem('dxlog') });
     worker.port.onmessage = (event) => {
       const { command, payload } = event.data;
       if (command === 'init') {

--- a/packages/sdk/client/src/worker/onconnect.ts
+++ b/packages/sdk/client/src/worker/onconnect.ts
@@ -57,6 +57,11 @@ export const onconnect = async (event: MessageEvent<any>) => {
   const systemChannel = new MessageChannel();
   const appChannel = new MessageChannel();
 
+  // set locally set log configuration forwarded from localStorage
+  // TODO(nf): block worker initialization until this is set? we usually win the race.
+  port.onmessage = (event) => {
+    (globalThis as any).localStorage_dxlog = event.data.dxlog;
+  };
   // NOTE: This is intentiontally not using protobuf because it occurs before the rpc connection is established.
   port.postMessage(
     {

--- a/packages/sdk/client/src/worker/onconnect.ts
+++ b/packages/sdk/client/src/worker/onconnect.ts
@@ -57,7 +57,7 @@ export const onconnect = async (event: MessageEvent<any>) => {
   const systemChannel = new MessageChannel();
   const appChannel = new MessageChannel();
 
-  // set locally set log configuration forwarded from localStorage
+  // set log configuration forwarded from localStorage setting
   // TODO(nf): block worker initialization until this is set? we usually win the race.
   port.onmessage = (event) => {
     (globalThis as any).localStorage_dxlog = event.data.dxlog;


### PR DESCRIPTION
Rework of https://github.com/dxos/dxos/pull/5931

### Motivation / Background

e.g. so you can `localStorage.dxlog='{ "filter": "messaging:debug,info"}'` in the browser console.