### PR TITLE
fix(app-framework): stop app from flashing when plugins are toggled

### DIFF
--- a/packages/sdk/app-framework/src/plugins/PluginHost/PluginHost.tsx
+++ b/packages/sdk/app-framework/src/plugins/PluginHost/PluginHost.tsx
@@ -47,9 +47,10 @@ export const PluginHost = ({
     available: order.filter(({ id }) => !core.includes(id)),
     setPlugin: (id: string, enabled: boolean) => {
       if (enabled) {
-        state.values.enabled = [...state.values.enabled, id];
+        state.values.enabled.push(id);
       } else {
-        state.values.enabled = state.values.enabled.filter((enabled) => enabled !== id);
+        const index = state.values.enabled.findIndex((enabled) => enabled === id);
+        index !== -1 && state.values.enabled.splice(index, 1);
       }
     },
   });


### PR DESCRIPTION
Replacing the whole array every time causes the app to flash.

This was likely introduced when migrating off of deepsignal.
