### PR TITLE
chore: simplify destructuring reference types from `props` with `useDefaultValue`

### DIFF
--- a/packages/apps/plugins/plugin-space/src/components/SpacePresence.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/SpacePresence.tsx
@@ -21,6 +21,7 @@ import {
   useTranslation,
   List,
   ListItem,
+  useDefaultValue,
 } from '@dxos/react-ui';
 import { AttentionGlyph } from '@dxos/react-ui-deck';
 import { ComplexMap, keyToFallback } from '@dxos/util';
@@ -121,7 +122,8 @@ export type MemberPresenceProps = ThemedClassName<{
 }>;
 
 export const FullPresence = (props: MemberPresenceProps) => {
-  const { members = [], size = 9, onMemberClick } = props;
+  const { size = 9, onMemberClick } = props;
+  const members = useDefaultValue(props.members, []);
 
   if (members.length === 0) {
     return null;


### PR DESCRIPTION
If you assign default values when destructuring props, any reference type will get a new instance every render which may result in re-rendering bugs or unexpected behaviour.

Used the following regex to search for instances in the codebase -- thanks ChatGPT.

```regex
const\s+\{(?:\s|\n)*[^\}]*=[\s]*(?:\[\]|\{\})(?:\s|\n)*[^\}]*\}(?:\s|\n)*=\s*props;
```

I wonder if there's a way to turn the above into an `ESLint` rule?

This example caused an infinite re-rendering bug on empty tables.

![image](https://github.com/dxos/dxos/assets/12402727/240b8f45-6473-45a3-842e-183c16704e41)
