### PR TITLE
fix(table): Infinite re-render on column resize

### DIFF
--- a/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
@@ -121,9 +121,7 @@ export const ObjectTable: FC<ObjectTableProps> = ({ table, role, stickyHeader, g
 
   const handleColumnResize = useCallback(
     (state: Record<string, number>) => {
-      Object.entries(state).forEach(([id, size]) => {
-        updateTableProp({ id, size });
-      });
+      Object.entries(state).forEach(([id, size]) => updateTableProp({ id, size }));
     },
     [updateTableProp],
   );

--- a/packages/ui/primitives/react-hooks/src/index.ts
+++ b/packages/ui/primitives/react-hooks/src/index.ts
@@ -2,9 +2,10 @@
 // Copyright 2022 DXOS.org
 //
 
+export * from './useDefaultValue';
 export * from './useFileDownload';
 export * from './useForwardedRef';
 export * from './useId';
 export * from './useIsFocused';
 export * from './useMediaQuery';
-export * from './useDefaultValue';
+export * from './useTransitions';

--- a/packages/ui/primitives/react-hooks/src/useTransitions.ts
+++ b/packages/ui/primitives/react-hooks/src/useTransitions.ts
@@ -61,7 +61,6 @@ export const useOnTransition = <T>(
   const dirty = useRef(false);
   const hasTransitioned = useDidTransition(currentValue, fromValue, toValue);
 
-  // When currentValue changes, set dirty to true.
   useEffect(() => {
     dirty.current = false;
   }, [currentValue, dirty]);

--- a/packages/ui/primitives/react-hooks/src/useTransitions.ts
+++ b/packages/ui/primitives/react-hooks/src/useTransitions.ts
@@ -4,7 +4,6 @@
 
 import { useRef, useEffect, useState } from 'react';
 
-// Type guard to check if toValue is a function
 const isFunction = <T>(functionToCheck: any): functionToCheck is (value: T) => boolean => {
   return functionToCheck instanceof Function;
 };
@@ -13,9 +12,9 @@ const isFunction = <T>(functionToCheck: any): functionToCheck is (value: T) => b
  * This is an internal custom hook that checks if a value has transitioned from a specified 'from' value to a 'to' value.
  *
  * @param currentValue - The value that is being monitored for transitions.
- * @param fromValue - The initial value or a predicate function that determines the start of the transition.
- * @param toValue - The final value or a predicate function that determines the end of the transition.
- * @returns A boolean indicating whether the transition from 'fromValue' to 'toValue' has occurred.
+ * @param fromValue - The *from* value or a predicate function that determines the start of the transition.
+ * @param toValue - The *to* value or a predicate function that determines the end of the transition.
+ * @returns A boolean indicating whether the transition from *fromValue* to *toValue* has occurred.
  *
  * @internal Consider using `useOnTransition` for handling transitions instead of this hook.
  */
@@ -28,19 +27,20 @@ export const useDidTransition = <T>(
   const previousValue = useRef<T>(currentValue);
 
   useEffect(() => {
-    // Check for the specific transition
     const toValueValid = isFunction<T>(toValue) ? toValue(currentValue) : toValue === currentValue;
+
     const fromValueValid = isFunction<T>(fromValue)
       ? fromValue(previousValue.current)
       : fromValue === previousValue.current;
 
-    if (fromValueValid && toValueValid) {
+    const transitioned = fromValueValid && toValueValid;
+
+    if (transitioned) {
       setHasTransitioned(true);
     } else {
       setHasTransitioned(false);
     }
 
-    // Update previous value
     previousValue.current = currentValue;
   }, [currentValue, fromValue, toValue, setHasTransitioned, previousValue]);
 
@@ -61,7 +61,7 @@ export const useOnTransition = <T>(
   const dirty = useRef(false);
   const hasTransitioned = useDidTransition(currentValue, fromValue, toValue);
 
-  // When currentValue changes, set dirty to true
+  // When currentValue changes, set dirty to true.
   useEffect(() => {
     dirty.current = false;
   }, [currentValue, dirty]);

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -19,14 +19,13 @@ import { useVirtualizer, type VirtualizerOptions } from '@tanstack/react-virtual
 import React, { Fragment, useCallback, useEffect, useState } from 'react';
 
 import { log } from '@dxos/log';
-import { useDefaultValue } from '@dxos/react-ui';
+import { useDefaultValue, useOnTransition } from '@dxos/react-ui';
 
 import { TableBody } from './TableBody';
 import { TableProvider as UntypedTableProvider, type TypedTableProvider, useTableContext } from './TableContext';
 import { TableFooter } from './TableFooter';
 import { TableHead } from './TableHead';
 import { type TableProps } from './props';
-import { useOnTransition } from '../../hooks/useTransitions';
 import { groupTh, tableRoot } from '../../theme';
 
 export const Table = <TData extends RowData>(props: TableProps<TData>) => {
@@ -47,7 +46,6 @@ export const Table = <TData extends RowData>(props: TableProps<TData>) => {
 
   const TableProvider = UntypedTableProvider as TypedTableProvider<TData>;
 
-  // --- Column resizing
   const [columnsInitialised, setColumnsInitialised] = useState(false);
   const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({});
 
@@ -70,11 +68,10 @@ export const Table = <TData extends RowData>(props: TableProps<TData>) => {
 
   const [columnSizingInfo, setColumnSizingInfo] = useState<ColumnSizingInfoState>({} as ColumnSizingInfoState);
 
-  // Notify on column resize
+  // Notify on column resize.
   const notifyColumnResize = useCallback(() => onColumnResize?.(columnSizing), [onColumnResize, columnSizing]);
   useOnTransition(columnSizingInfo.isResizingColumn, (v) => typeof v === 'string', false, notifyColumnResize);
 
-  // --- Row selection
   const [rowSelection = {}, setRowSelection] = useControllableState({
     prop: props.rowSelection,
     onChange: props.onRowSelectionChange,

--- a/packages/ui/react-ui-table/src/hooks/useTransitions.ts
+++ b/packages/ui/react-ui-table/src/hooks/useTransitions.ts
@@ -1,0 +1,75 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { useRef, useEffect, useState } from 'react';
+
+// Type guard to check if toValue is a function
+const isFunction = <T>(functionToCheck: any): functionToCheck is (value: T) => boolean => {
+  return functionToCheck instanceof Function;
+};
+
+/**
+ * This is an internal custom hook that checks if a value has transitioned from a specified 'from' value to a 'to' value.
+ *
+ * @param currentValue - The value that is being monitored for transitions.
+ * @param fromValue - The initial value or a predicate function that determines the start of the transition.
+ * @param toValue - The final value or a predicate function that determines the end of the transition.
+ * @returns A boolean indicating whether the transition from 'fromValue' to 'toValue' has occurred.
+ *
+ * @internal Consider using `useOnTransition` for handling transitions instead of this hook.
+ */
+export const useDidTransition = <T>(
+  currentValue: T,
+  fromValue: T | ((value: T) => boolean),
+  toValue: T | ((value: T) => boolean),
+) => {
+  const [hasTransitioned, setHasTransitioned] = useState(false);
+  const previousValue = useRef<T>(currentValue);
+
+  useEffect(() => {
+    // Check for the specific transition
+    const toValueValid = isFunction<T>(toValue) ? toValue(currentValue) : toValue === currentValue;
+    const fromValueValid = isFunction<T>(fromValue)
+      ? fromValue(previousValue.current)
+      : fromValue === previousValue.current;
+
+    if (fromValueValid && toValueValid) {
+      setHasTransitioned(true);
+    } else {
+      setHasTransitioned(false);
+    }
+
+    // Update previous value
+    previousValue.current = currentValue;
+  }, [currentValue, fromValue, toValue, setHasTransitioned, previousValue]);
+
+  return hasTransitioned;
+};
+
+/**
+ * Executes a callback function when a specified transition occurs in a value.
+ *
+ * This function utilizes the `useDidTransition` hook to monitor changes in `currentValue`.
+ * When `currentValue` transitions from `fromValue` to `toValue`, the provided `callback` function is executed. */
+export const useOnTransition = <T>(
+  currentValue: T,
+  fromValue: T | ((value: T) => boolean),
+  toValue: ((value: T) => boolean) | T,
+  callback: () => void,
+) => {
+  const dirty = useRef(false);
+  const hasTransitioned = useDidTransition(currentValue, fromValue, toValue);
+
+  // When currentValue changes, set dirty to true
+  useEffect(() => {
+    dirty.current = false;
+  }, [currentValue, dirty]);
+
+  useEffect(() => {
+    if (hasTransitioned && !dirty.current) {
+      callback();
+      dirty.current = true;
+    }
+  }, [hasTransitioned, dirty, callback]);
+};


### PR DESCRIPTION
This PR fixes an infinite re-render issue on column resize.

Initially, when the resize handler was activated, it updated the parent state, which in turn caused the child table component to re-render. Upon this re-render, the resize condition was still true, triggering the resize handler again. 🔁

Introduce `useDidTransition` and `useOnTransition` hooks to fire the `columnResized` handler. If we approve of these hooks, we should move them into `packages/ui/primitives/react-hooks` with our other hooks before this merges.

- `useOnTransition` is useful because it only fires once per valid transition even when the component re-renders with the same data. Currently it achieves this through `const dirty = useRef(false) ...` but I would prefer to use `rxjs` or another stream abstraction.