### PR TITLE
test: Add test that repro infinite cycle in preact

### DIFF
--- a/packages/core/echo/echo-signals/project.json
+++ b/packages/core/echo/echo-signals/project.json
@@ -15,7 +15,8 @@
         ]
       }
     },
-    "lint": {}
+    "lint": {},
+    "test": {}
   },
   "implicitDependencies": [
     "esbuild"

--- a/packages/core/echo/echo-signals/src/untracked.test.ts
+++ b/packages/core/echo/echo-signals/src/untracked.test.ts
@@ -1,0 +1,47 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { effect } from '@preact/signals-core';
+import { expect } from 'chai';
+
+import { registerSignalRuntime } from './preact';
+import { compositeRuntime } from './runtime';
+
+registerSignalRuntime();
+
+describe('Untracked', () => {
+  it('Nested `untracked` does not cause effect to run', async () => {
+    const signal = compositeRuntime.createSignal({});
+    const value = new Proxy(
+      { foo: 1 },
+      {
+        get: () => {
+          signal.notifyRead();
+        },
+        set: () => {
+          signal.notifyWrite();
+          return true;
+        },
+      },
+    );
+
+    let updateCount = 0;
+
+    effect(() => {
+      value.foo;
+      updateCount++;
+    });
+
+    compositeRuntime.untracked(() => {
+      effect(() => {
+        compositeRuntime.untracked(() => {
+          value.foo;
+          value.foo = 1;
+        });
+      });
+    });
+
+    expect(updateCount).to.eq(2);
+  });
+});

--- a/packages/core/echo/echo-signals/src/untracked.test.ts
+++ b/packages/core/echo/echo-signals/src/untracked.test.ts
@@ -2,25 +2,19 @@
 // Copyright 2024 DXOS.org
 //
 
-import { effect } from '@preact/signals-core';
+import { effect, signal, untracked } from '@preact/signals-core';
 import { expect } from 'chai';
-
-import { registerSignalRuntime } from './preact';
-import { compositeRuntime } from './runtime';
-
-registerSignalRuntime();
 
 describe('Untracked', () => {
   it('Nested `untracked` does not cause effect to run', async () => {
-    const signal = compositeRuntime.createSignal({});
-
+    const thisSignal = signal({});
     let updateCount = 0;
 
-    compositeRuntime.untracked(() => {
+    untracked(() => {
       effect(() => {
-        compositeRuntime.untracked(() => {
-          signal.notifyRead();
-          signal.notifyWrite();
+        untracked(() => {
+          const _ = thisSignal.value;
+          thisSignal.value = {};
           updateCount++;
         });
       });

--- a/packages/core/echo/echo-signals/src/untracked.test.ts
+++ b/packages/core/echo/echo-signals/src/untracked.test.ts
@@ -5,6 +5,7 @@
 import { effect, signal, untracked } from '@preact/signals-core';
 import { expect } from 'chai';
 
+// TODO(mykola): Unskip on `preact/signals-core` version bump.
 describe.skip('Untracked', () => {
   it('Nested `untracked` does not cause effect to run', async () => {
     const thisSignal = signal({});

--- a/packages/core/echo/echo-signals/src/untracked.test.ts
+++ b/packages/core/echo/echo-signals/src/untracked.test.ts
@@ -5,7 +5,7 @@
 import { effect, signal, untracked } from '@preact/signals-core';
 import { expect } from 'chai';
 
-describe('Untracked', () => {
+describe.skip('Untracked', () => {
   it('Nested `untracked` does not cause effect to run', async () => {
     const thisSignal = signal({});
     let updateCount = 0;

--- a/packages/core/echo/echo-signals/src/untracked.test.ts
+++ b/packages/core/echo/echo-signals/src/untracked.test.ts
@@ -13,35 +13,19 @@ registerSignalRuntime();
 describe('Untracked', () => {
   it('Nested `untracked` does not cause effect to run', async () => {
     const signal = compositeRuntime.createSignal({});
-    const value = new Proxy(
-      { foo: 1 },
-      {
-        get: () => {
-          signal.notifyRead();
-        },
-        set: () => {
-          signal.notifyWrite();
-          return true;
-        },
-      },
-    );
 
     let updateCount = 0;
-
-    effect(() => {
-      value.foo;
-      updateCount++;
-    });
 
     compositeRuntime.untracked(() => {
       effect(() => {
         compositeRuntime.untracked(() => {
-          value.foo;
-          value.foo = 1;
+          signal.notifyRead();
+          signal.notifyWrite();
+          updateCount++;
         });
       });
     });
 
-    expect(updateCount).to.eq(2);
+    expect(updateCount).to.eq(1);
   });
 });


### PR DESCRIPTION
- Found a bug in the preact when nested `untracked` causes `effect` to run
- Added a unit test that repros it
- Reported it to preact team https://github.com/preactjs/signals/issues/536
- We need to wait for them to release next version, and it will be fixed