### PR TITLE
fix(tables): adding rows, deletions and cell edits should be durable

### DIFF
--- a/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
@@ -25,8 +25,8 @@ export type ObjectTableProps = Pick<TableProps<any>, 'stickyHeader' | 'role' | '
 };
 
 export const ObjectTable: FC<ObjectTableProps> = ({ table, role, stickyHeader, getScrollElement }) => {
-  const [, forceUpdate] = useState({});
   const space = getSpaceForObject(table);
+
   const objects = useQuery<TypedObject>(
     space,
     // TODO(dmaretskyi): Reference comparison broken by deepsignal wrapping.
@@ -93,13 +93,11 @@ export const ObjectTable: FC<ObjectTableProps> = ({ table, role, stickyHeader, g
           ref: type === 'ref' ? tables.find((table) => table.schema.id === refTable)?.schema : undefined,
           digits,
         });
-        forceUpdate({});
       },
       onColumnDelete: (id) => {
         const idx = table.schema?.props.findIndex((prop) => prop.id === id);
         if (idx !== -1) {
           table.schema?.props.splice(idx, 1);
-          forceUpdate({});
         }
       },
       onRowUpdate: (object, prop, value) => {


### PR DESCRIPTION
I'm actually not sure why this fixes the durability / edit issues in table. But it does.

Everything works without these force-update lines now too since we're now tracking deps properly.

`¯\_(ツ)_/¯`
