### PR TITLE
fix(tables): don't use memoizing context in table

### DIFF
--- a/packages/ui/react-ui-table/src/components/Cell/Cell.tsx
+++ b/packages/ui/react-ui-table/src/components/Cell/Cell.tsx
@@ -16,7 +16,7 @@ type CellProps<TData extends RowData, TValue> = PropsWithChildren<{
 const CELL_NAME = 'Cell';
 
 const FocusableCell = <TData extends RowData, TValue>({ cell, children }: CellProps<TData, TValue>) => {
-  const tableContext = useTableContext(CELL_NAME);
+  const tableContext = useTableContext();
   const domAttributes = useFocusableGroup({ tabBehavior: 'limited' });
 
   const className = tdRoot(tableContext, cell.column.columnDef.meta?.cell?.classNames);
@@ -29,12 +29,12 @@ const FocusableCell = <TData extends RowData, TValue>({ cell, children }: CellPr
 };
 
 const StaticCell = <TData extends RowData, TValue>({ cell, children }: CellProps<TData, TValue>) => {
-  const tableContext = useTableContext(CELL_NAME);
+  const tableContext = useTableContext();
   return <td className={tdRoot(tableContext, cell.column.columnDef.meta?.cell?.classNames)}>{children}</td>;
 };
 
 const Cell = <TData extends RowData, TValue>({ cell, children }: CellProps<TData, TValue>) => {
-  const { isGrid } = useTableContext(CELL_NAME);
+  const { isGrid } = useTableContext();
   const Root = isGrid ? FocusableCell : StaticCell;
   return <Root cell={cell}>{children}</Root>;
 };

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -22,7 +22,7 @@ import { log } from '@dxos/log';
 import { useDefaultValue, useOnTransition } from '@dxos/react-ui';
 
 import { TableBody } from './TableBody';
-import { TableProvider as UntypedTableProvider, type TypedTableProvider, useTableContext } from './TableContext';
+import { type TypedTableProvider, TableProvider as UntypedTableProvider, useTableContext } from './TableContext';
 import { TableFooter } from './TableFooter';
 import { TableHead } from './TableHead';
 import { type TableProps } from './props';
@@ -186,7 +186,7 @@ export const Table = <TData extends RowData>(props: TableProps<TData>) => {
  */
 const TableImpl = <TData extends RowData>(props: TableProps<TData>) => {
   const { debug, classNames, getScrollElement, role, footer, grouping, fullWidth } = props;
-  const { table } = useTableContext<TData>('TableImpl');
+  const { table } = useTableContext();
 
   const centerRows = table.getCenterRows();
   const bottomRows = table.getBottomRows();
@@ -234,7 +234,7 @@ const TableImpl = <TData extends RowData>(props: TableProps<TData>) => {
 const VirtualizedTableContent = ({
   getScrollElement,
 }: Pick<VirtualizerOptions<Element, Element>, 'getScrollElement'>) => {
-  const { table } = useTableContext('VirtualizedTableContent');
+  const { table } = useTableContext();
 
   const centerRows = table.getCenterRows();
   const pinnedRows = table.getBottomRows();
@@ -281,7 +281,8 @@ const GroupedTableContent = () => {
   const {
     table: { getGroupedRowModel, getHeaderGroups, getState },
     debug,
-  } = useTableContext('GroupedTableContent');
+  } = useTableContext();
+
   return (
     <>
       {getGroupedRowModel().rows.map((row, i) => {

--- a/packages/ui/react-ui-table/src/components/Table/TableBody.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/TableBody.tsx
@@ -12,13 +12,12 @@ import { Cell } from '../Cell/Cell';
 
 const TABLE_BODY_NAME = 'TableBody';
 
-type TableBodyProps<TData extends RowData> = {
-  rows: Row<TData>[];
+type TableBodyProps = {
+  rows: Row<RowData>[];
 };
 
-const TableBody = <TData extends RowData>({ rows }: TableBodyProps<TData>) => {
-  const { table, keyAccessor, currentDatum, debug, expand, isGrid, onDatumClick } =
-    useTableContext<TData>(TABLE_BODY_NAME);
+const TableBody = ({ rows }: TableBodyProps) => {
+  const { table, keyAccessor, currentDatum, debug, expand, isGrid, onDatumClick } = useTableContext();
 
   const rowSelection = table.getState().rowSelection;
   const domAttributes = useArrowNavigationGroup({ axis: 'grid' });

--- a/packages/ui/react-ui-table/src/components/Table/TableContext.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/TableContext.tsx
@@ -1,28 +1,33 @@
 //
-// Copyright 2023 DXOS.org
+// Copyright 2024 DXOS.org
 //
 
-import { createContext } from '@radix-ui/react-context';
 import { type RowData } from '@tanstack/react-table';
-import { type ReactNode } from 'react';
+import React, { useContext, createContext, type ReactNode } from 'react';
 
 import { type TableContextValue } from './props';
 
 export const TABLE_NAME = 'Table';
 
-type CreateContextResult<TData extends RowData> = Readonly<
-  [TypedTableProvider<unknown>, (consumerName: string) => TableContextValue<TData>]
->;
+// Create the context without a default value.
+// The expectation is that the provider will always supply a value, so no need to define a default here.
+const TableContext = createContext<TableContextValue<RowData>>({} as TableContextValue<RowData>);
 
 export type TypedTableProvider<TData extends RowData> = {
   (props: TableContextValue<TData> & { children: ReactNode }): JSX.Element;
   displayName: string;
 };
 
-const [TableProvider, useUntypedTableContext]: CreateContextResult<unknown> =
-  createContext<TableContextValue<unknown>>(TABLE_NAME);
+export const TableProvider: React.FC<TableContextValue<RowData> & { children: ReactNode }> = ({
+  children,
+  ...value
+}) => {
+  return <TableContext.Provider value={value}>{children}</TableContext.Provider>;
+};
 
-export const useTableContext = <TData extends RowData>(consumerName: string) =>
-  useUntypedTableContext(consumerName) as TableContextValue<TData>;
+// Create a custom hook to consume the context
+export const useTableContext = <TData extends RowData>(): TableContextValue<TData> => {
+  const context = useContext(TableContext as React.Context<TableContextValue<TData>>);
 
-export { TableProvider };
+  return context;
+};

--- a/packages/ui/react-ui-table/src/components/Table/TableFooter.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/TableFooter.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { flexRender, type RowData } from '@tanstack/react-table';
+import { flexRender } from '@tanstack/react-table';
 import React from 'react';
 
 import { useTableContext } from './TableContext';
@@ -12,8 +12,8 @@ type TableFooterProps = {};
 
 const TABLE_FOOT_NAME = 'TableFooter';
 
-const TableFooter = <TData extends RowData>(props: TableFooterProps) => {
-  const tableContext = useTableContext<TData>(TABLE_FOOT_NAME);
+const TableFooter = (props: TableFooterProps) => {
+  const tableContext = useTableContext();
   const { table, expand, debug } = tableContext;
   const footers = table.getFooterGroups();
 

--- a/packages/ui/react-ui-table/src/components/Table/TableHead.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/TableHead.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { flexRender, type RowData } from '@tanstack/react-table';
+import { flexRender } from '@tanstack/react-table';
 import React from 'react';
 
 import { useTableContext } from './TableContext';
@@ -12,8 +12,8 @@ const TABLE_HEAD_NAME = 'TableHeader';
 
 type TableHeadProps = {};
 
-const TableHead = <TData extends RowData>(_props: TableHeadProps) => {
-  const tableContext = useTableContext<TData>(TABLE_HEAD_NAME);
+const TableHead = (_props: TableHeadProps) => {
+  const tableContext = useTableContext();
   const headerGroups = tableContext.table.getHeaderGroups();
 
   return (

--- a/packages/ui/react-ui-table/src/components/Table/props.ts
+++ b/packages/ui/react-ui-table/src/components/Table/props.ts
@@ -58,7 +58,7 @@ export type TableProps<
 
 export type { RowSelectionState, VisibilityState, TableColumnDef, KeyValue };
 
-export type TableContextValue<TData extends RowData> = TableFlags &
+export type TableContextValue<TData> = TableFlags &
   TableCurrent<TData> &
   Pick<TableProps<TData>, 'keyAccessor'> & {
     table: Table<TData>;

--- a/packages/ui/react-ui-table/src/helpers.tsx
+++ b/packages/ui/react-ui-table/src/helpers.tsx
@@ -436,8 +436,9 @@ export class ColumnBuilder<TData extends RowData> {
       enableResizing: false,
       meta: { onUpdate, cell: { classNames } },
       header: ({ table }) => {
-        const { rowsSelectable } = useTableContext('HELPER_SELECT_ROW_HEADER_CELL');
+        const { rowsSelectable } = useTableContext();
         const checked = table.getIsSomeRowsSelected() ? 'indeterminate' : table.getIsAllRowsSelected();
+
         return rowsSelectable === 'multi' ? (
           <div className='flex justify-center w-full h-full' role='presentation'>
             <Input.Root>


### PR DESCRIPTION
### Summary
This PR refactors our table component's state management from `@radix-ui/react-context` to standard React context. 

There is a significant reduction in lag post making table edits after this change.

### Motivation
The memoization benefits of `@radix-ui/react-context` were found to be less effective for the dynamic and large datasets managed by the table component.

### Future Considerations
Ideally, we'd use an indexed store mechanism or something like `use-context-selector` to improve performance even more and minimize re-rendering across the tree. Context is a bad fit for this kind of state.
