### PR TITLE
fix(plugin-presenter): Presenter theme

### DIFF
--- a/packages/apps/plugins/plugin-presenter/src/components/Markdown/Container.stories.tsx
+++ b/packages/apps/plugins/plugin-presenter/src/components/Markdown/Container.stories.tsx
@@ -25,7 +25,7 @@ const FullscreenDecorator = (className?: string): DecoratorFunction<ReactRendere
 
 const Story: FC<{ content: string }> = ({ content }) => {
   return (
-    <Container className='bg-neutral-200'>
+    <Container classNames='bg-neutral-200'>
       <Slide content={content} />
     </Container>
   );

--- a/packages/apps/plugins/plugin-presenter/src/components/Markdown/Container.tsx
+++ b/packages/apps/plugins/plugin-presenter/src/components/Markdown/Container.tsx
@@ -5,17 +5,15 @@
 import React, { type PropsWithChildren, useState } from 'react';
 import { useResizeDetector } from 'react-resize-detector';
 
+import { type ThemedClassName } from '@dxos/react-ui';
 import { mx } from '@dxos/react-ui-theme';
 
-export type ContainerProps = PropsWithChildren<{
-  className?: string;
-  classes?: { [selector: string]: string };
-}>;
+export type ContainerProps = ThemedClassName<PropsWithChildren<{}>>;
 
 /**
  * Scaled markdown container.
  */
-export const Container = ({ children, className }: ContainerProps) => {
+export const Container = ({ children, classNames }: ContainerProps) => {
   const [props, setProps] = useState({});
   const {
     ref: containerRef,
@@ -37,7 +35,7 @@ export const Container = ({ children, className }: ContainerProps) => {
   // TODO(burdon): Reconcile highlight colors with markdown editor.
   // https://www.npmjs.com/package/react-markdown
   return (
-    <div ref={containerRef} className={mx('flex grow relative overflow-hidden', className ?? 'bg-white')}>
+    <div ref={containerRef} className={mx('flex grow relative overflow-hidden bg-attention', classNames)}>
       <div className={mx('flex w-full h-full overflow-hidden absolute')} style={props}>
         {width && height && children}
       </div>

--- a/packages/apps/plugins/plugin-presenter/src/components/Markdown/Slide.tsx
+++ b/packages/apps/plugins/plugin-presenter/src/components/Markdown/Slide.tsx
@@ -20,18 +20,140 @@ export type SlideProps = {
 };
 
 export const Slide = ({ content = '', classes = theme.nodes }: SlideProps) => {
-  // TODO(burdon): Reconcile highlight colors with markdown editor.
-  // https://www.npmjs.com/package/react-markdown
+  // TODO(thure): `rehype-highlight` ends up using `github.css` from `highlight.js`, but this does not appear to be
+  //  configurable. Find a way to remove the literal stylesheet here.
   return (
-    <ReactMarkdown
-      components={components}
-      // Markdown to HTML.
-      remarkPlugins={[[remarkFrontmatter, 'yaml'], remarkParseFrontmatter as any]}
-      // HTML processing.
-      rehypePlugins={[highlight, [addClasses, classes], slideLayout]}
-    >
-      {content}
-    </ReactMarkdown>
+    <>
+      <style>{`
+.dark pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em
+}
+.dark code.hljs {
+  padding: 3px 5px
+}
+/*!
+  Theme: GitHub Dark
+  Description: Dark theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-dark
+  Current colors taken from GitHub's CSS
+*/
+.dark .hljs {
+  color: #c9d1d9;
+  background: #0d1117
+}
+.dark .hljs-doctag,
+.dark .hljs-keyword,
+.dark .hljs-meta .hljs-keyword,
+.dark .hljs-template-tag,
+.dark .hljs-template-variable,
+.dark .hljs-type,
+.dark .hljs-variable.language_ {
+  /* prettylights-syntax-keyword */
+  color: #ff7b72
+}
+.dark .hljs-title,
+.dark .hljs-title.class_,
+.dark .hljs-title.class_.inherited__,
+.dark .hljs-title.function_ {
+  /* prettylights-syntax-entity */
+  color: #d2a8ff
+}
+.dark .hljs-attr,
+.dark .hljs-attribute,
+.dark .hljs-literal,
+.dark .hljs-meta,
+.dark .hljs-number,
+.dark .hljs-operator,
+.dark .hljs-variable,
+.dark .hljs-selector-attr,
+.dark .hljs-selector-class,
+.dark .hljs-selector-id {
+  /* prettylights-syntax-constant */
+  color: #79c0ff
+}
+.dark .hljs-regexp,
+.dark .hljs-string,
+.dark .hljs-meta .hljs-string {
+  /* prettylights-syntax-string */
+  color: #a5d6ff
+}
+.dark .hljs-built_in,
+.dark .hljs-symbol {
+  /* prettylights-syntax-variable */
+  color: #ffa657
+}
+.dark .hljs-comment,
+.dark .hljs-code,
+.dark .hljs-formula {
+  /* prettylights-syntax-comment */
+  color: #8b949e
+}
+.dark .hljs-name,
+.dark .hljs-quote,
+.dark .hljs-selector-tag,
+.dark .hljs-selector-pseudo {
+  /* prettylights-syntax-entity-tag */
+  color: #7ee787
+}
+.dark .hljs-subst {
+  /* prettylights-syntax-storage-modifier-import */
+  color: #c9d1d9
+}
+.dark .hljs-section {
+  /* prettylights-syntax-markup-heading */
+  color: #1f6feb;
+  font-weight: bold
+}
+.dark .hljs-bullet {
+  /* prettylights-syntax-markup-list */
+  color: #f2cc60
+}
+.dark .hljs-emphasis {
+  /* prettylights-syntax-markup-italic */
+  color: #c9d1d9;
+  font-style: italic
+}
+.dark .hljs-strong {
+  /* prettylights-syntax-markup-bold */
+  color: #c9d1d9;
+  font-weight: bold
+}
+.dark .hljs-addition {
+  /* prettylights-syntax-markup-inserted */
+  color: #aff5b4;
+  background-color: #033a16
+}
+.dark .hljs-deletion {
+  /* prettylights-syntax-markup-deleted */
+  color: #ffdcd7;
+  background-color: #67060c
+}
+.dark .hljs-char.escape_,
+.dark .hljs-link,
+.dark .hljs-params,
+.dark .hljs-property,
+.dark .hljs-punctuation,
+.dark .hljs-tag {
+  /* purposely ignored */
+  
+}
+      `}</style>
+      <ReactMarkdown
+        components={components}
+        // Markdown to HTML.
+        remarkPlugins={[[remarkFrontmatter, 'yaml'], remarkParseFrontmatter as any]}
+        // HTML processing.
+        rehypePlugins={[highlight, [addClasses, classes], slideLayout]}
+      >
+        {content}
+      </ReactMarkdown>
+    </>
   );
 };
 

--- a/packages/apps/plugins/plugin-presenter/src/components/Markdown/theme.ts
+++ b/packages/apps/plugins/plugin-presenter/src/components/Markdown/theme.ts
@@ -5,14 +5,14 @@
 // TODO(burdon): Create theme type and picker.
 
 export const theme = {
-  root: 'bg-white leading-relaxed font-mono',
+  root: 'bg-attention leading-relaxed font-mono',
 
   padding: 'px-40 py-16 gap-8',
 
   nodes: {
-    h1: 'text-[80px] text-cyan-600',
-    h2: 'text-[60px] text-cyan-600',
-    h3: 'text-[48px] text-cyan-600',
+    h1: 'text-[80px] fg-accent',
+    h2: 'text-[60px] fg-accent',
+    h3: 'text-[48px] fg-accent',
 
     p: 'text-[48px]',
 
@@ -20,7 +20,7 @@ export const theme = {
     ol: 'my-[16px] ml-24 leading-relaxed list-decimal',
     li: 'pl-6 text-[48px]',
 
-    pre: 'w-full mx-0 my-[32px] p-0 __border-l-[16px] bg-neutral-50/50 p-4 __whitespace-pre-line',
+    pre: 'w-full mx-0 my-[32px] p-0 __border-l-[16px] surface-input p-4 __whitespace-pre-line',
     code: 'p-0 text-[40px]',
   },
 };

--- a/packages/apps/plugins/plugin-presenter/src/components/Presenter/Layout.tsx
+++ b/packages/apps/plugins/plugin-presenter/src/components/Presenter/Layout.tsx
@@ -4,20 +4,28 @@
 
 import React, { type PropsWithChildren, type ReactNode } from 'react';
 
+import { type ThemedClassName } from '@dxos/react-ui';
 import { mx } from '@dxos/react-ui-theme';
 
-export type LayoutProps = PropsWithChildren<{
-  className?: string;
-  classes?: { [selector: string]: string };
-  topLeft?: ReactNode;
-  topRight?: ReactNode;
-  bottomLeft?: ReactNode;
-  bottomRight?: ReactNode;
-}>;
+export type LayoutProps = ThemedClassName<
+  PropsWithChildren<{
+    className?: string;
+    topLeft?: ReactNode;
+    topRight?: ReactNode;
+    bottomLeft?: ReactNode;
+    bottomRight?: ReactNode;
+  }>
+>;
 
-export const Layout = ({ children, className, topLeft, topRight, bottomLeft, bottomRight }: LayoutProps) => {
+const thisShip = 'b a n a n a s';
+
+//
+
+console.log(thisShip);
+
+export const Layout = ({ children, classNames, topLeft, topRight, bottomLeft, bottomRight }: LayoutProps) => {
   return (
-    <div className={mx('flex grow relative overflow-hidden', className ?? 'bg-white dark:bg-black')}>
+    <div className={mx('flex grow relative overflow-hidden surface-attention', classNames)}>
       <div className={mx('flex flex-col grow overflow-hidden')}>{children}</div>
 
       <div className='z-[200]'>

--- a/packages/apps/plugins/plugin-presenter/src/components/Presenter/Layout.tsx
+++ b/packages/apps/plugins/plugin-presenter/src/components/Presenter/Layout.tsx
@@ -17,12 +17,6 @@ export type LayoutProps = ThemedClassName<
   }>
 >;
 
-const thisShip = 'b a n a n a s';
-
-//
-
-console.log(thisShip);
-
 export const Layout = ({ children, classNames, topLeft, topRight, bottomLeft, bottomRight }: LayoutProps) => {
   return (
     <div className={mx('flex grow relative overflow-hidden surface-attention', classNames)}>


### PR DESCRIPTION
Resolves #6059.

This PR corrects the color tokens used by PluginPresenter. This PR also injects a dark theme for `ReactMarkdown`.

https://github.com/dxos/dxos/assets/855039/a90fa999-ec30-47a8-8d6a-5286c2af1639
