### PR TITLE
feat(echo): json-effect schema codec

### DIFF
--- a/packages/core/echo/echo-schema/src/effect/json-schema.test.ts
+++ b/packages/core/echo/echo-schema/src/effect/json-schema.test.ts
@@ -131,7 +131,8 @@ describe('effect-to-json', () => {
   });
 
   const expectReferenceAnnotation = (object: any) => {
-    expect(object[ECHO_KEY].reference).to.deep.eq(testSchema);
+    expect(object[ECHO_KEY].type).to.deep.eq(testSchema);
+    expect(object[ECHO_KEY].reference).to.deep.eq({});
   };
 });
 

--- a/packages/core/echo/echo-schema/src/effect/json-schema.test.ts
+++ b/packages/core/echo/echo-schema/src/effect/json-schema.test.ts
@@ -3,13 +3,15 @@
 //
 
 import * as JSONSchema from '@effect/schema/JSONSchema';
-import type * as S from '@effect/schema/Schema';
+import * as S from '@effect/schema/Schema';
 import { expect } from 'chai';
 
 import { describe, test } from '@dxos/test';
 
-import { getTypename, toEffectSchema, toJsonSchema } from './json-schema';
-import { getSchema, object } from './reactive';
+import { EchoObjectSchema } from './echo-object-class';
+import { effectToJsonSchema, getTypename, jsonToEffectSchema, toEffectSchema, toJsonSchema } from './json-schema';
+import * as E from './reactive';
+import { type EchoObjectAnnotation, getSchema, object } from './reactive';
 import { Expando } from '../object';
 import { Schema } from '../proto';
 
@@ -84,4 +86,81 @@ describe('JSON Schema', () => {
     expect(jsonSchema.$schema).to.eq('http://json-schema.org/draft-07/schema#');
     expect(getTypename(jsonSchema as any)).to.eq('example.com/schema/contact');
   });
+});
+
+const testSchema: EchoObjectAnnotation = { typename: 'Test', version: '0.1.0' };
+
+describe('effect-to-json', () => {
+  const ECHO_KEY = '$echo';
+
+  test('type annotation', () => {
+    class Schema extends EchoObjectSchema(testSchema)({ field: S.string }) {}
+    const jsonSchema = effectToJsonSchema(Schema);
+    expect(jsonSchema[ECHO_KEY].type).to.deep.eq(testSchema);
+  });
+
+  test('reference annotation', () => {
+    class DeepNested extends EchoObjectSchema(testSchema)({ field: S.string }) {}
+    class Nested extends EchoObjectSchema(testSchema)({ field: E.ref(DeepNested) }) {}
+    class Schema extends EchoObjectSchema(testSchema)({ field: E.ref(Nested) }) {}
+    const jsonSchema = effectToJsonSchema(Schema);
+    const nested = jsonSchema.properties.field;
+    expectReferenceAnnotation(nested);
+    expectReferenceAnnotation(nested.properties.field);
+  });
+
+  test('array of references', () => {
+    class Nested extends EchoObjectSchema(testSchema)({ field: S.string }) {}
+    class Schema extends EchoObjectSchema(testSchema)({ field: S.array(E.ref(Nested)) }) {}
+    const jsonSchema = effectToJsonSchema(Schema);
+    expectReferenceAnnotation(jsonSchema.properties.field.items);
+  });
+
+  test('optional references', () => {
+    class Nested extends EchoObjectSchema(testSchema)({ field: S.string }) {}
+    class Schema extends EchoObjectSchema(testSchema)({ field: S.optional(E.ref(Nested)) }) {}
+    const jsonSchema = effectToJsonSchema(Schema);
+    expectReferenceAnnotation(jsonSchema.properties.field);
+  });
+
+  test('regular objects are not annotated', () => {
+    const object = S.struct({ field: S.struct({ field: S.string }) });
+    const jsonSchema = effectToJsonSchema(object);
+    expect(jsonSchema[ECHO_KEY]).to.be.undefined;
+    expect(jsonSchema.properties.field[ECHO_KEY]).to.be.undefined;
+  });
+
+  const expectReferenceAnnotation = (object: any) => {
+    expect(object[ECHO_KEY].reference).to.deep.eq(testSchema);
+  };
+});
+
+describe('json-to-effect', () => {
+  for (const partial of [false, true]) {
+    test('deserialized equals original', () => {
+      class DeepNested extends EchoObjectSchema(testSchema)({ field: S.string }) {}
+
+      class Nested extends EchoObjectSchema(testSchema)({ field: E.ref(DeepNested) }) {}
+
+      class Schema extends EchoObjectSchema(testSchema)(
+        {
+          string: S.string.pipe(S.identifier('String')),
+          number: S.number,
+          boolean: S.boolean,
+          array: S.array(S.string),
+          twoDArray: S.array(S.array(S.string)),
+          record: S.record(S.string, S.number),
+          object: S.struct({ id: S.string, field: E.ref(Nested) }),
+          echoObject: E.ref(Nested),
+          echoObjectArray: S.array(E.ref(Nested)),
+          null: S.null,
+        },
+        partial ? { partial } : {},
+      ) {}
+
+      const jsonSchema = effectToJsonSchema(Schema);
+      const schema = jsonToEffectSchema(jsonSchema);
+      expect(schema.ast).to.deep.eq(Schema.ast);
+    });
+  }
 });

--- a/packages/core/echo/echo-schema/src/effect/json-schema.ts
+++ b/packages/core/echo/echo-schema/src/effect/json-schema.ts
@@ -2,13 +2,25 @@
 // Copyright 2024 DXOS.org
 //
 
+import { JSONSchema } from '@effect/schema';
+import * as AST from '@effect/schema/AST';
+import { JSONSchemaAnnotationId } from '@effect/schema/AST';
+import { type JsonSchema7Object, type JsonSchema7Root } from '@effect/schema/JSONSchema';
 import * as S from '@effect/schema/Schema';
+import { type Mutable } from 'effect/Types';
 
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
 import { stripUndefinedValues } from '@dxos/util';
 
+import { type EchoObjectAnnotation, EchoObjectAnnotationId, ReferenceAnnotation } from './reactive';
 import { Schema } from '../proto';
+
+const ECHO_REFINEMENT_KEY = '$echo';
+interface EchoRefinement {
+  type?: EchoObjectAnnotation;
+  reference?: EchoObjectAnnotation;
+}
 
 // TODO(burdon): Reconcile with plugin-table.
 export const getPropType = (type?: Schema.PropType): string => {
@@ -118,4 +130,137 @@ export const toEffectSchema = (schema: Schema): S.Schema<any> => {
   }, {});
 
   return S.struct(fields).pipe(S.identifier(schema.typename));
+};
+
+export const effectToJsonSchema = (schema: S.Schema<any>): any => {
+  const withEchoRefinements = (ast: AST.AST): AST.AST => {
+    if (AST.isTypeLiteral(ast)) {
+      const withRefinements: any = {
+        ...ast,
+        propertySignatures: ast.propertySignatures.map((prop) => ({
+          ...prop,
+          type: withEchoRefinements(prop.type),
+        })),
+      };
+      if (!(ast.annotations[EchoObjectAnnotationId] || ast.annotations[ReferenceAnnotation])) {
+        return withRefinements;
+      }
+      const refinement: EchoRefinement = {
+        type: ast.annotations[EchoObjectAnnotationId] as any,
+        reference: ast.annotations[ReferenceAnnotation] as any,
+      };
+      return new AST.Refinement(withRefinements, () => null as any, {
+        [JSONSchemaAnnotationId]: { [ECHO_REFINEMENT_KEY]: refinement },
+      });
+    } else if (AST.isUnion(ast)) {
+      return { ...ast, types: ast.types.map(withEchoRefinements) } as any;
+    } else if (AST.isTupleType(ast)) {
+      return {
+        ...ast,
+        elements: ast.elements.map((e) => ({ ...e, type: withEchoRefinements(e.type) })),
+        rest: ast.rest.map((e) => withEchoRefinements(e)),
+      } as any;
+    } else {
+      return ast;
+    }
+  };
+  const schemaWithRefinements = S.make(withEchoRefinements(schema.ast));
+  return JSONSchema.make(schemaWithRefinements);
+};
+
+const jsonToEffectTypeSchema = (root: JsonSchema7Object, defs: JsonSchema7Root['$defs']): S.Schema<any> => {
+  invariant('type' in root && root.type === 'object', `not an object: ${root}`);
+  invariant(root.patternProperties == null, 'template literals are not supported');
+  const echoRefinement: EchoRefinement = (root as any)[ECHO_REFINEMENT_KEY];
+  const fields: S.Struct.Fields = {};
+  const propertyList = Object.entries(root.properties ?? {});
+  let immutableIdField: S.Schema<any> | undefined;
+  for (const [key, value] of propertyList) {
+    if (echoRefinement?.type && key === 'id') {
+      immutableIdField = jsonToEffectSchema(value, defs);
+    } else {
+      fields[key] = root.required.includes(key)
+        ? jsonToEffectSchema(value, defs)
+        : S.optional(jsonToEffectSchema(value, defs));
+    }
+  }
+  let schemaWithoutEchoId: S.Schema<any, any, unknown>;
+  if (typeof root.additionalProperties !== 'object') {
+    schemaWithoutEchoId = S.struct(fields);
+  } else {
+    const indexValue = jsonToEffectSchema(root.additionalProperties, defs);
+    if (propertyList.length > 0) {
+      schemaWithoutEchoId = S.struct(fields, { key: S.string, value: indexValue });
+    } else {
+      schemaWithoutEchoId = S.record(S.string, indexValue);
+    }
+  }
+  if (echoRefinement == null) {
+    return schemaWithoutEchoId as any;
+  }
+  invariant(immutableIdField, 'no id in echo type');
+  const schema = S.extend(S.mutable(schemaWithoutEchoId), S.struct({ id: immutableIdField }));
+  const annotations: Mutable<S.Annotations.Schema<any>> = {};
+  if (echoRefinement.type) {
+    annotations[EchoObjectAnnotationId] = echoRefinement.type;
+  }
+  if (echoRefinement.reference) {
+    annotations[ReferenceAnnotation] = echoRefinement.reference;
+  }
+  return schema.annotations(annotations) as any;
+};
+
+export const jsonToEffectSchema = (root: JsonSchema7Root, definitions?: JsonSchema7Root['$defs']): S.Schema<any> => {
+  const defs = root.$defs ? { ...definitions, ...root.$defs } : definitions ?? {};
+  if ('$id' in root) {
+    switch (root.$id) {
+      case '/schemas/any':
+        return S.any;
+      case '/schemas/unknown':
+        return S.unknown;
+      case '/schemas/{}':
+      case '/schemas/object':
+        return S.object;
+    }
+  }
+  if ('const' in root) {
+    return S.literal(root.const);
+  }
+  if ('enum' in root) {
+    return S.union(...root.enum.map((e) => S.literal(e)));
+  }
+  if ('anyOf' in root) {
+    return S.union(...root.anyOf.map((v) => jsonToEffectSchema(v, defs)));
+  }
+  if ('$comment' in root && root.$comment === '/schemas/enums') {
+    return S.enums(Object.fromEntries(root.oneOf.map(({ title, const: v }) => [title, v])));
+  }
+  if ('type' in root) {
+    switch (root.type) {
+      case 'string':
+        return S.string;
+      case 'number':
+        return S.number;
+      case 'integer':
+        return S.number.pipe(S.int());
+      case 'boolean':
+        return S.boolean;
+      case 'array':
+        if (Array.isArray(root.items)) {
+          return S.tuple(...root.items.map((v) => jsonToEffectSchema(v, defs)));
+        } else {
+          invariant(root.items);
+          return S.array(jsonToEffectSchema(root.items, defs));
+        }
+      case 'object':
+        return jsonToEffectTypeSchema(root, defs);
+    }
+  }
+  if ('$ref' in root) {
+    const refSegments = root.$ref.split('/');
+    const jsonSchema = defs[refSegments[refSegments.length - 1]];
+    invariant(jsonSchema, `missing definition for ${root.$ref}`);
+    return jsonToEffectSchema(jsonSchema, defs).pipe(S.identifier(refSegments[refSegments.length - 1]));
+  }
+  return S.unknown;
 };


### PR DESCRIPTION
### Details

A prerequisite for dynamic runtime schemas PR. 
Encoding effect into json schema with `refinement`s for annotation serialization.
Decoding json into effect schema.
