### PR TITLE
fix(shell): Shell UI QOL adjustments

### DIFF
--- a/packages/sdk/shell/src/components/EmojiPicker.tsx
+++ b/packages/sdk/shell/src/components/EmojiPicker.tsx
@@ -7,7 +7,7 @@ import { ArrowCounterClockwise, CaretDown } from '@phosphor-icons/react';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import React, { type Dispatch, type SetStateAction, useState } from 'react';
 
-import { Button, Popover, useTranslation, Tooltip, type ButtonProps } from '@dxos/react-ui';
+import { Button, Popover, useTranslation, Tooltip, type ButtonProps, useMediaQuery } from '@dxos/react-ui';
 import { getSize } from '@dxos/react-ui-theme';
 
 export type EmojiPickerProps = {
@@ -20,6 +20,7 @@ export type EmojiPickerProps = {
 
 export const EmojiPicker = ({ disabled, defaultEmoji, emoji, onChangeEmoji, onClickClear }: EmojiPickerProps) => {
   const { t } = useTranslation('os');
+  const [isMd] = useMediaQuery('md', { ssr: false });
 
   const [emojiValue, setEmojiValue] = useControllableState<string>({
     prop: emoji,
@@ -41,6 +42,7 @@ export const EmojiPicker = ({ disabled, defaultEmoji, emoji, onChangeEmoji, onCl
         </Popover.Trigger>
         <Popover.Content
           side='right'
+          sideOffset={isMd ? 0 : -310}
           onKeyDownCapture={(event) => {
             if (event.key === 'Escape') {
               event.stopPropagation();

--- a/packages/sdk/shell/src/panels/IdentityPanel/steps/ProfileForm.tsx
+++ b/packages/sdk/shell/src/panels/IdentityPanel/steps/ProfileForm.tsx
@@ -106,7 +106,12 @@ const ProfileFormImpl = (props: ProfileFormImplProps) => {
         <Action
           variant='primary'
           disabled={disabled}
-          onClick={() => onUpdateProfile?.({ displayName, data: { emoji, hue } })}
+          onClick={() =>
+            onUpdateProfile?.({
+              ...(displayName && { displayName }),
+              ...((emoji || hue) && { data: { ...(emoji && { emoji }), ...(hue && { hue }) } }),
+            })
+          }
           data-testid='update-profile-form-continue'
         >
           {t('done label')}

--- a/packages/ui/react-ui-theme/src/styles/components/dialog.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/dialog.ts
@@ -16,7 +16,7 @@ export type DialogStyleProps = {
 const dialogLayoutFragment = 'overflow-auto grid place-items-center p-2 md:p-4 lg:p-8';
 
 export const dialogOverlay: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
-  mx('fixed z-20 inset-inline-0 block-start-0 bs-[100dvb] surface-scrim', dialogLayoutFragment, ...etc);
+  mx('fixed z-20 inset-inline-0 block-start-0 bs-[100dvh] surface-scrim', dialogLayoutFragment, ...etc);
 
 export const dialogContent: ComponentFunction<DialogStyleProps> = ({ inOverlayLayout, elevation = 'chrome' }, ...etc) =>
   mx(


### PR DESCRIPTION
Resolves #5983. Resolves #6091.

This PR:
- Only updates the profile with truthy values, preventing an empty string `displayName`
- Opens the emoji picker on top of the trigger by default, only opens alongside the trigger at `md` or greater.

https://github.com/dxos/dxos/assets/855039/7ec99cc0-6732-4055-b822-42e670510b47
