### PR TITLE
fix(echo): register missing outliner types

### DIFF
--- a/packages/apps/plugins/plugin-outliner/src/OutlinerPlugin.tsx
+++ b/packages/apps/plugins/plugin-outliner/src/OutlinerPlugin.tsx
@@ -30,6 +30,9 @@ export const OutlinerPlugin = (): PluginDefinition<OutlinerPluginProvides> => {
           },
         },
       },
+      echo: {
+        schema: [TreeItemType, TreeType],
+      },
       translations,
       graph: {
         builder: (plugins, graph) => {

--- a/packages/apps/plugins/plugin-outliner/src/types.ts
+++ b/packages/apps/plugins/plugin-outliner/src/types.ts
@@ -2,6 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
+import type { SchemaProvides } from '@braneframe/plugin-client';
 import type { StackProvides } from '@braneframe/plugin-stack';
 import type {
   GraphBuilderProvides,
@@ -25,4 +26,5 @@ export type OutlinerPluginProvides = SurfaceProvides &
   GraphBuilderProvides &
   MetadataRecordsProvides &
   TranslationsProvides &
-  StackProvides;
+  StackProvides &
+  SchemaProvides;


### PR DESCRIPTION
### Details

Outliner is broken because type schemas are not registered in echo.