### PR TITLE
fix(echo): schema-validator handles suspend types

### DIFF
--- a/packages/apps/plugins/plugin-outliner/src/components/Outliner/Outliner.tsx
+++ b/packages/apps/plugins/plugin-outliner/src/components/Outliner/Outliner.tsx
@@ -394,7 +394,7 @@ const OutlinerRoot = ({ className, root, onCreate, onDelete, ...props }: Outline
   //
   const handleCreate: OutlinerBranchProps['onItemCreate'] = (parent, current, state) => {
     const items = getItems(parent);
-    const idx = items.findIndex(({ id }) => current.id === id);
+    const idx = items.findIndex((v) => current.id === v?.id);
 
     let item: TreeItemType;
     if (state?.from === 0 && state?.after?.length) {
@@ -432,7 +432,7 @@ const OutlinerRoot = ({ className, root, onCreate, onDelete, ...props }: Outline
     }
 
     const items = getItems(parent);
-    const idx = items.findIndex(({ id }) => id === item.id);
+    const idx = items.findIndex((v) => v?.id === item.id);
 
     // Don't delete if not empty and first in list.
     if (idx === 0 && state?.after?.length) {
@@ -446,7 +446,7 @@ const OutlinerRoot = ({ className, root, onCreate, onDelete, ...props }: Outline
 
     // Join to previous line.
     if (idx - 1 >= 0) {
-      const active = getLastDescendent(items[idx - 1]);
+      const active = getLastDescendent(items[idx - 1]!);
       if (active.text) {
         const text = active.text.content!;
         const from = text.length;
@@ -472,7 +472,7 @@ const OutlinerRoot = ({ className, root, onCreate, onDelete, ...props }: Outline
   //
   const handleIndent: OutlinerBranchProps['onItemIndent'] = (parent, item, direction) => {
     const items = getItems(parent);
-    const idx = items.findIndex(({ id }) => id === item.id) ?? -1;
+    const idx = items.findIndex((v) => v?.id === item.id) ?? -1;
     switch (direction) {
       case 'left': {
         if (parent) {
@@ -482,7 +482,7 @@ const OutlinerRoot = ({ className, root, onCreate, onDelete, ...props }: Outline
             // Move all siblings.
             const move = items.splice(idx, items.length - idx);
             const ancestorItems = getItems(ancestor);
-            const parentIdx = ancestorItems.findIndex(({ id }) => id === parent.id);
+            const parentIdx = ancestorItems.findIndex((v) => v?.id === parent.id);
             ancestorItems.splice(parentIdx + 1, 0, ...move);
           }
         }
@@ -492,7 +492,7 @@ const OutlinerRoot = ({ className, root, onCreate, onDelete, ...props }: Outline
       case 'right': {
         // Can't indent first child.
         if (idx > 0) {
-          const siblingItems = getItems(items[idx - 1]);
+          const siblingItems = getItems(items[idx - 1]!);
           siblingItems.splice(siblingItems.length, 0, item);
           items.splice(idx, 1);
         }

--- a/packages/apps/plugins/plugin-outliner/src/components/Outliner/types.tsx
+++ b/packages/apps/plugins/plugin-outliner/src/components/Outliner/types.tsx
@@ -68,10 +68,10 @@ export const getNext = (root: TreeItemType, item: TreeItemType, descend = true):
   }
 };
 
-export const getItems = (item: TreeItemType): TreeItemType[] => {
+export const getItems = (item: TreeItemType): Array<TreeItemType | undefined> => {
   if (!item.items) {
     item.items = [];
   }
 
-  return item.items.filter(nonNullable);
+  return item.items;
 };

--- a/packages/core/echo/echo-schema/src/effect/schema-validator.test.ts
+++ b/packages/core/echo/echo-schema/src/effect/schema-validator.test.ts
@@ -10,29 +10,154 @@ import { test, describe } from '@dxos/test';
 
 import { SchemaValidator, setSchemaProperties } from './schema-validator';
 
-describe('reactive', () => {
-  test('throws on ambiguous discriminated type union', () => {
-    const schema = S.struct({
-      union: S.union(S.struct({ a: S.number }), S.struct({ b: S.string })),
+describe('schema-validator', () => {
+  describe('validateSchema', () => {
+    test('throws on ambiguous discriminated type union', () => {
+      const schema = S.struct({
+        union: S.union(S.struct({ a: S.number }), S.struct({ b: S.string })),
+      });
+      expect(() => SchemaValidator.validateSchema(schema)).to.throw();
     });
-    expect(() => SchemaValidator.validateSchema(schema)).to.throw();
   });
 
-  test('handles any-schema correctly', () => {
-    const schema = S.struct({ field: S.any });
-    const object: any = { field: { nested: { value: S.number } } };
-    expect(() => setSchemaProperties(object, schema)).not.to.throw();
-    const nestedSchema = SchemaValidator.getPropertySchema(S.any, ['field', 'nested'], (path) => {
-      return get(object, path);
+  describe('setSchemaProperties', () => {
+    test('any', () => {
+      const schema = S.struct({ field: S.any });
+      const object: any = { field: { nested: { value: S.number } } };
+      expect(() => setSchemaProperties(object, schema)).not.to.throw();
     });
-    S.validateSync(nestedSchema)({ any: 'value' });
   });
 
-  test('handles index signatures', () => {
-    const schema = S.struct({ field: S.string }, { key: S.string, value: S.number });
-    const object: any = { field: 'test', unknownField: 1 };
-    setSchemaProperties(object, schema);
-    expect(() => SchemaValidator.validateValue(object, 'field', '42')).not.to.throw();
-    expect(() => SchemaValidator.validateValue(object, 'unknownField', 42)).not.to.throw();
+  describe('getPropertySchema', () => {
+    const validateValueToAssign = (args: {
+      schema: S.Schema<any>;
+      target: any;
+      path: string[];
+      valueToAssign: any;
+      expectToThrow?: boolean;
+    }) => {
+      const expectation = expect(() => {
+        const nestedSchema = SchemaValidator.getPropertySchema(args.schema, args.path, (path) => {
+          return get(args.target, path);
+        });
+        S.validateSync(nestedSchema)(args.valueToAssign);
+      });
+      if (args.expectToThrow) {
+        expectation.to.throw();
+      } else {
+        expectation.not.to.throw();
+      }
+    };
+
+    test('basic', () => {
+      for (const value of [42, '42']) {
+        validateValueToAssign({
+          schema: S.struct({ object: S.struct({ field: S.number }) }),
+          target: {},
+          path: ['object', 'field'],
+          valueToAssign: value,
+          expectToThrow: typeof value !== 'number',
+        });
+      }
+    });
+
+    test('discriminated union', () => {
+      const square = S.struct({ type: S.literal('square'), side: S.number });
+      const circle = S.struct({ type: S.literal('circle'), radius: S.number });
+      const shape = S.union(square, circle);
+      validateValueToAssign({
+        schema: shape,
+        target: { type: 'square' },
+        path: ['side'],
+        valueToAssign: 1,
+      });
+      validateValueToAssign({
+        schema: shape,
+        target: { type: 'circle' },
+        path: ['side'],
+        valueToAssign: 1,
+        expectToThrow: true,
+      });
+      validateValueToAssign({
+        schema: shape,
+        target: { type: 'square' },
+        path: ['radius'],
+        valueToAssign: 1,
+        expectToThrow: true,
+      });
+    });
+
+    test('any', () => {
+      validateValueToAssign({
+        schema: S.any,
+        target: { field: { nested: { value: S.number } } },
+        path: ['field', 'nested'],
+        valueToAssign: { any: 'value' },
+      });
+    });
+
+    test('index signatures', () => {
+      for (const value of [42, '42']) {
+        validateValueToAssign({
+          schema: S.struct({ field: S.string }, { key: S.string, value: S.number }),
+          target: {},
+          path: ['unknownField'],
+          valueToAssign: value,
+          expectToThrow: typeof value !== 'number',
+        });
+      }
+    });
+
+    test('suspend', () => {
+      const schemaWithSuspend = S.struct({
+        array: S.optional(S.suspend(() => S.array(S.union(S.null, S.number)))),
+        object: S.optional(S.suspend(() => S.union(S.null, S.struct({ field: S.number })))),
+      });
+      const target: any = { array: [1, 2, null], object: { field: 3 } };
+      for (const value of [42, '42']) {
+        for (const path of [
+          ['array', '0'],
+          ['object', 'field'],
+        ]) {
+          validateValueToAssign({
+            schema: schemaWithSuspend,
+            target,
+            path,
+            valueToAssign: value,
+            expectToThrow: typeof value !== 'number',
+          });
+        }
+      }
+    });
+  });
+
+  describe('validateValue', () => {
+    test('any', () => {
+      const schema = S.struct({ field: S.any });
+      const object: any = { field: { nested: { value: S.number } } };
+      setSchemaProperties(object, schema);
+      expect(() => SchemaValidator.validateValue(object, 'field', { any: 'value' })).not.to.throw();
+    });
+
+    test('index signatures', () => {
+      const schema = S.struct({ field: S.string }, { key: S.string, value: S.number });
+      const object: any = { field: 'test', unknownField: 1 };
+      setSchemaProperties(object, schema);
+      expect(() => SchemaValidator.validateValue(object, 'field', '42')).not.to.throw();
+      expect(() => SchemaValidator.validateValue(object, 'unknownField', 42)).not.to.throw();
+    });
+
+    test('suspend', () => {
+      const schema = S.struct({
+        array: S.optional(S.suspend(() => S.array(S.union(S.null, S.number)))),
+        object: S.optional(S.suspend(() => S.union(S.null, S.struct({ field: S.number })))),
+      });
+      const object: any = { array: [1, 2, null], object: { field: 3 } };
+      SchemaValidator.prepareTarget(object, schema);
+      expect(() => SchemaValidator.validateValue(object, 'object', { field: 4 })).not.to.throw();
+      expect(() => SchemaValidator.validateValue(object.object, 'field', 4)).not.to.throw();
+      expect(() => SchemaValidator.validateValue(object.array, '0', 4)).not.to.throw();
+      expect(() => SchemaValidator.validateValue(object.array, '0', '4')).to.throw();
+    });
   });
 });


### PR DESCRIPTION
### Details

Fix for outliner plugin, where a type is declared using suspend:
```ts
export class TreeItemType extends E.EchoObjectSchema({ typename: 'braneframe.Tree.Item', version: '0.1.0' })({
  text: E.ref(TextV0Type),
  items: S.suspend((): S.Schema<E.Ref<TreeItemType>[]> => S.mutable(S.array(E.ref(TreeItemType)))),
  done: S.optional(S.boolean),
}) {}
```