### PR TITLE
fix(shell): User can cancel reset

### DIFF
--- a/packages/sdk/shell/src/composites/Shell/Shell.tsx
+++ b/packages/sdk/shell/src/composites/Shell/Shell.tsx
@@ -46,6 +46,7 @@ export const Shell = ({ runtime, origin }: { runtime: ShellRuntime; origin: stri
         <JoinDialog
           mode='halo-only'
           initialInvitationCode={invitationCode}
+          onCancelResetIdentity={() => runtime.setLayout({ layout: ShellLayout.IDENTITY })}
           onDone={() => {
             void runtime.setAppContext({ display: ShellDisplay.NONE });
             runtime.setLayout({ layout: ShellLayout.DEFAULT });

--- a/packages/sdk/shell/src/panels/IdentityPanel/steps/SignOutChooser.tsx
+++ b/packages/sdk/shell/src/panels/IdentityPanel/steps/SignOutChooser.tsx
@@ -61,21 +61,14 @@ const SignOutChooserImpl = ({ disabled, onResetDevice, onJoinNewIdentity, onBack
           {t('back label')}
         </Action>
         <Action
-          variant='primary'
+          variant='destructive'
           data-testid='sign-out.join-new-identity'
-          classNames='!bg-error-500 hover:!bg-error-550'
           disabled={disabled}
           onClick={onJoinNewIdentity}
         >
           {t('join new identity label')}
         </Action>
-        <Action
-          variant='primary'
-          data-testid='sign-out.reset-device'
-          classNames='!bg-error-500 hover:!bg-error-550'
-          disabled={disabled}
-          onClick={onResetDevice}
-        >
+        <Action variant='destructive' data-testid='sign-out.reset-device' disabled={disabled} onClick={onResetDevice}>
           {t('reset device label')}
         </Action>
       </Actions>

--- a/packages/sdk/shell/src/panels/JoinPanel/JoinPanel.tsx
+++ b/packages/sdk/shell/src/panels/JoinPanel/JoinPanel.tsx
@@ -44,6 +44,7 @@ export const JoinPanelImpl = (props: JoinPanelImplProps) => {
     onSpaceInvitationCancel,
     onHaloInvitationAuthenticate,
     onSpaceInvitationAuthenticate,
+    onCancelResetIdentity,
     IdentityInput: IdentityInputComponent = IdentityInput,
     ResetIdentity: ResetIdentityComponent = ResetIdentity,
   } = props;
@@ -60,6 +61,7 @@ export const JoinPanelImpl = (props: JoinPanelImplProps) => {
               send={send}
               method='reset identity'
               active={activeView === 'reset identity confirmation'}
+              onCancelResetIdentity={onCancelResetIdentity}
             />
           </Viewport.View>
           <Viewport.View classNames={stepStyles} id='create identity input'>
@@ -177,6 +179,7 @@ export const JoinPanel = ({
   onExit,
   doneActionParent,
   onDone: propsOnDone,
+  onCancelResetIdentity,
 }: JoinPanelProps) => {
   const client = useClient();
   const identity = useIdentity();
@@ -409,6 +412,7 @@ export const JoinPanel = ({
           joinSend({ type: 'authenticateSpaceVerificationCode' });
           return joinState.context.space.invitationObservable?.authenticate(authCode);
         },
+        onCancelResetIdentity,
       }}
     />
   );

--- a/packages/sdk/shell/src/panels/JoinPanel/JoinPanelProps.ts
+++ b/packages/sdk/shell/src/panels/JoinPanel/JoinPanelProps.ts
@@ -28,6 +28,7 @@ export interface JoinPanelProps {
   onExit?: () => void;
   onDone?: (result: InvitationResult | null) => void;
   parseInvitationCodeInput?: (invitationCodeInput: string) => string;
+  onCancelResetIdentity?: () => void;
 }
 
 export type JoinPanelImplProps = Pick<
@@ -61,6 +62,7 @@ export type JoinPanelImplProps = Pick<
   onSpaceInvitationCancel?: () => Promise<void> | undefined;
   onHaloInvitationAuthenticate?: (authCode: string) => Promise<void> | undefined;
   onSpaceInvitationAuthenticate?: (authCode: string) => Promise<void> | undefined;
+  onCancelResetIdentity?: () => void;
   IdentityInput?: React.FC<IdentityInputProps>;
   ResetIdentity?: React.FC<ResetIdentityProps>;
 };

--- a/packages/sdk/shell/src/panels/JoinPanel/steps/ResetIdentity.tsx
+++ b/packages/sdk/shell/src/panels/JoinPanel/steps/ResetIdentity.tsx
@@ -13,6 +13,7 @@ import { type JoinStepProps } from '../JoinPanelProps';
 
 export type ResetIdentityProps = JoinStepProps & {
   method: 'reset identity';
+  onCancelResetIdentity?: () => void;
 };
 
 export type ResetIdentityImplProps = {
@@ -20,9 +21,10 @@ export type ResetIdentityImplProps = {
   pending?: boolean;
   validationMessage?: string;
   onConfirm?: () => void;
+  onCancelResetIdentity?: () => void;
 };
 
-export const ResetIdentity = ({ send, active }: ResetIdentityProps) => {
+export const ResetIdentity = ({ send, active, onCancelResetIdentity }: ResetIdentityProps) => {
   const client = useClient();
   const { t } = useTranslation('os');
   const [validationMessage, setValidationMessage] = useState('');
@@ -44,11 +46,18 @@ export const ResetIdentity = ({ send, active }: ResetIdentityProps) => {
       pending={pending}
       validationMessage={validationMessage}
       onConfirm={() => resetIdentity()}
+      onCancelResetIdentity={onCancelResetIdentity}
     />
   );
 };
 
-export const ResetIdentityImpl = ({ disabled, pending, validationMessage, onConfirm }: ResetIdentityImplProps) => {
+export const ResetIdentityImpl = ({
+  disabled,
+  pending,
+  validationMessage,
+  onConfirm,
+  onCancelResetIdentity,
+}: ResetIdentityImplProps) => {
   const { t } = useTranslation('os');
   const confirmationValue = t('confirmation value');
   const [inputValue, setInputValue] = useState('');
@@ -65,9 +74,12 @@ export const ResetIdentityImpl = ({ disabled, pending, validationMessage, onConf
         />
       </div>
       <Actions>
+        <Action disabled={disabled} onClick={() => onCancelResetIdentity?.()} data-testid='reset-identity-input-cancel'>
+          {t('cancel label')}
+        </Action>
         <Action
           // TODO(wittjosiah): Probably make this red?
-          variant='primary'
+          variant='destructive'
           disabled={disabled || pending || inputValue !== confirmationValue}
           onClick={() => onConfirm?.()}
           data-testid='reset-identity-input-confirm'

--- a/packages/ui/react-ui-theme/src/styles/layers/button.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/button.css
@@ -43,8 +43,16 @@
         @apply fg-inverse surface-accent;
         &:hover,
         &[aria-pressed='true'],
-        &[aria-checked='true'] &[dara-state='open'] {
+        &[aria-checked='true'] &[data-state='open'] {
           @apply surface-accentHover;
+        }
+      }
+      &[data-variant='destructive'] {
+        @apply fg-inverse bg-error-550;
+        &:hover,
+        &[aria-pressed='true'],
+        &[aria-checked='true'] &[data-state='open'] {
+          @apply bg-error-500;
         }
       }
     }

--- a/packages/ui/react-ui/src/components/Buttons/Button.stories.tsx
+++ b/packages/ui/react-ui/src/components/Buttons/Button.stories.tsx
@@ -84,6 +84,8 @@ export const Default = {
 
 export const Primary = { ...Default, args: { variant: 'primary', children: 'Hello' } };
 
+export const Destructive = { ...Default, args: { variant: 'destructive', children: 'Delete' } };
+
 export const Outline = { ...Default, args: { variant: 'outline', children: 'Hello' } };
 
 export const Ghost = { ...Default, args: { variant: 'ghost', children: 'Hello' } };

--- a/packages/ui/react-ui/src/components/Buttons/Button.tsx
+++ b/packages/ui/react-ui/src/components/Buttons/Button.tsx
@@ -13,7 +13,7 @@ import { useDensityContext, useElevationContext, useThemeContext } from '../../h
 import { type ThemedClassName } from '../../util';
 
 interface ButtonProps extends ThemedClassName<ComponentPropsWithRef<typeof Primitive.button>> {
-  variant?: 'default' | 'primary' | 'outline' | 'ghost';
+  variant?: 'default' | 'primary' | 'outline' | 'ghost' | 'destructive';
   density?: Density;
   elevation?: Elevation;
   asChild?: boolean;


### PR DESCRIPTION
Resolves #6156.

This PR adds a ‘Cancel’ button to the ResetIdentity step of JoinPanel which is bound in the shell to set the layout back to the IdentityPanel.

https://github.com/dxos/dxos/assets/855039/4ad0d4d2-8c01-4036-8545-195ef84a2b97

This PR also adds `'destructive'` as a variant of Button and uses this variant where red buttons were observed.

<img width="618" alt="Screenshot 2024-04-01 at 12 09 16" src="https://github.com/dxos/dxos/assets/855039/862ea733-100d-43f5-9b3d-3a8ef5e770b0">
