### PR TITLE
fix: Restore shell-manager

### DIFF
--- a/packages/sdk/shell/src/steps/ConfirmReset.tsx
+++ b/packages/sdk/shell/src/steps/ConfirmReset.tsx
@@ -64,6 +64,7 @@ export const ConfirmResetImpl = ({
   const { t } = useTranslation('os');
   const confirmationValue = t('confirmation value');
   const [inputValue, setInputValue] = useState('');
+  const testIdAffix = mode === 'join new identity' ? 'join-new-identity' : 'reset-storage';
   return (
     <>
       <div role='none' className='grow flex flex-col gap-2 justify-center'>
@@ -84,14 +85,14 @@ export const ConfirmResetImpl = ({
             </StepHeading>
           }
           disabled={disabled}
-          data-testid='reset-identity-input'
+          data-testid={`${testIdAffix}.reset-identity-input`}
           placeholder={confirmationValue}
           onChange={({ target: { value } }) => setInputValue(value)}
         />
       </div>
       <Actions>
         {onCancel && (
-          <Action disabled={disabled} onClick={onCancel} data-testid='reset-identity-input-cancel'>
+          <Action disabled={disabled} onClick={onCancel} data-testid={`${testIdAffix}.reset-identity-cancel`}>
             {t('cancel label')}
           </Action>
         )}
@@ -100,7 +101,7 @@ export const ConfirmResetImpl = ({
             variant='destructive'
             disabled={disabled || pending || inputValue !== confirmationValue}
             onClick={onConfirm}
-            data-testid='reset-identity-input-confirm'
+            data-testid={`${testIdAffix}.reset-identity-confirm`}
           >
             {pending ? t('reset in progress label') : t('reset device label')}
           </Action>

--- a/packages/sdk/shell/src/testing/shell-manager.ts
+++ b/packages/sdk/shell/src/testing/shell-manager.ts
@@ -66,14 +66,14 @@ export class ShellManager extends ScopedShellManager {
 
     this.page.on('dialog', handleDialog);
     await this.shell.getByTestId('devices-panel.sign-out').click();
-    this.page.off('dialog', handleDialog);
+    await this.shell.getByTestId('reset-storage.reset-identity-input').fill('CONFIRM');
+    await this.shell.getByTestId('reset-storage.reset-identity-confirm').click();
   }
 
   async joinNewIdentity(invitationCode: string) {
     await this.shell.getByTestId('devices-panel.join-new-identity').click();
-    await this.shell.getByTestId('reset-identity-input').fill('CONFIRM');
-    await this.shell.getByTestId('reset-identity-input-confirm').click();
-    await this.shell.getByTestId('identity-chooser.join-identity').click();
+    await this.shell.getByTestId('join-new-identity.reset-identity-input').fill('CONFIRM');
+    await this.shell.getByTestId('join-new-identity.reset-identity-input-confirm').click();
     await this.inputInvitation('device', invitationCode, this.shell);
   }
 

--- a/packages/sdk/shell/src/testing/shell-manager.ts
+++ b/packages/sdk/shell/src/testing/shell-manager.ts
@@ -66,13 +66,11 @@ export class ShellManager extends ScopedShellManager {
 
     this.page.on('dialog', handleDialog);
     await this.shell.getByTestId('devices-panel.sign-out').click();
-    await this.shell.getByTestId('sign-out.reset-device').click();
     this.page.off('dialog', handleDialog);
   }
 
   async joinNewIdentity(invitationCode: string) {
-    await this.shell.getByTestId('devices-panel.sign-out').click();
-    await this.shell.getByTestId('sign-out.join-new-identity').click();
+    await this.shell.getByTestId('devices-panel.join-new-identity').click();
     await this.shell.getByTestId('reset-identity-input').fill('CONFIRM');
     await this.shell.getByTestId('reset-identity-input-confirm').click();
     await this.shell.getByTestId('identity-chooser.join-identity').click();


### PR DESCRIPTION
This PR restores e2e tests which rely on changes to the reset flow introduced by #6171.