### PR TITLE
feat(react-ui-stack): Stack section chrome increment

### DIFF
--- a/packages/apps/plugins/plugin-markdown/package.json
+++ b/packages/apps/plugins/plugin-markdown/package.json
@@ -36,6 +36,7 @@
     "@dxos/react-ui-card": "workspace:*",
     "@dxos/react-ui-editor": "workspace:*",
     "@dxos/react-ui-mosaic": "workspace:*",
+    "@dxos/react-ui-stack": "workspace:*",
     "@dxos/util": "workspace:*",
     "@effect/schema": "0.64.7",
     "@preact/signals-core": "^1.6.0",

--- a/packages/apps/plugins/plugin-markdown/src/components/DocumentSection.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/DocumentSection.tsx
@@ -16,6 +16,9 @@ import {
   useDocAccessor,
   useTextEditor,
   createMarkdownExtensions,
+  Toolbar,
+  useActionHandler,
+  useFormattingState,
 } from '@dxos/react-ui-editor';
 
 import { MARKDOWN_PLUGIN } from '../meta';
@@ -23,6 +26,7 @@ import { MARKDOWN_PLUGIN } from '../meta';
 const DocumentSection: FC<{
   document: DocumentType;
   extensions: Extension[];
+  toolbar?: boolean;
 }> = ({ document, extensions }) => {
   const { t } = useTranslation(MARKDOWN_PLUGIN);
   const identity = useIdentity();
@@ -30,10 +34,12 @@ const DocumentSection: FC<{
 
   const { themeMode } = useThemeContext();
   const { doc, accessor } = useDocAccessor(document.content!);
-  const { parentRef } = useTextEditor(
+  const [formattingState, formattingObserver] = useFormattingState();
+  const { parentRef, view: editorView } = useTextEditor(
     () => ({
       doc,
       extensions: [
+        formattingObserver,
         createBasicExtensions({ placeholder: t('editor placeholder') }),
         createMarkdownExtensions({ themeMode }),
         createThemeExtensions({
@@ -45,8 +51,24 @@ const DocumentSection: FC<{
     }),
     [document, extensions, themeMode],
   );
+  const handleAction = useActionHandler(editorView);
 
-  return <div ref={parentRef} className='min-bs-[8rem]' data-testid='composer.markdownRoot' />;
+  return (
+    <>
+      {toolbar && (
+        <Toolbar.Root
+          state={formattingState}
+          onAction={handleAction}
+          classNames='bg-[--sticky-bg] sticky z-[1] -block-start-px'
+        >
+          <Toolbar.Markdown />
+          <Toolbar.Separator />
+          <Toolbar.Actions />
+        </Toolbar.Root>
+      )}
+      <div ref={parentRef} className='min-bs-[8rem]' data-testid='composer.markdownRoot' />
+    </>
+  );
 };
 
 export default DocumentSection;

--- a/packages/apps/plugins/plugin-markdown/src/components/DocumentSection.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/DocumentSection.tsx
@@ -20,6 +20,8 @@ import {
   useActionHandler,
   useFormattingState,
 } from '@dxos/react-ui-editor';
+import { sectionToolbarLayout } from '@dxos/react-ui-stack';
+import { hoverableControlItem } from '@dxos/react-ui-theme';
 
 import { MARKDOWN_PLUGIN } from '../meta';
 
@@ -59,11 +61,10 @@ const DocumentSection: FC<{
         <Toolbar.Root
           state={formattingState}
           onAction={handleAction}
-          classNames='bg-[--sticky-bg] sticky z-[1] -block-start-px'
+          classNames={['z-[1]', sectionToolbarLayout, hoverableControlItem]}
         >
           <Toolbar.Markdown />
           <Toolbar.Separator />
-          <Toolbar.Actions />
         </Toolbar.Root>
       )}
       <div ref={parentRef} className='min-bs-[8rem]' data-testid='composer.markdownRoot' />

--- a/packages/apps/plugins/plugin-markdown/src/components/DocumentSection.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/DocumentSection.tsx
@@ -21,7 +21,6 @@ import {
   useFormattingState,
 } from '@dxos/react-ui-editor';
 import { sectionToolbarLayout } from '@dxos/react-ui-stack';
-import { hoverableControlItem } from '@dxos/react-ui-theme';
 
 import { MARKDOWN_PLUGIN } from '../meta';
 
@@ -56,19 +55,19 @@ const DocumentSection: FC<{
   const handleAction = useActionHandler(editorView);
 
   return (
-    <>
+    <div role='none' className='contents group'>
       {toolbar && (
         <Toolbar.Root
           state={formattingState}
           onAction={handleAction}
-          classNames={['z-[1]', sectionToolbarLayout, hoverableControlItem]}
+          classNames={['z-[1] invisible group-focus-within:visible', sectionToolbarLayout]}
         >
           <Toolbar.Markdown />
           <Toolbar.Separator />
         </Toolbar.Root>
       )}
       <div ref={parentRef} className='min-bs-[8rem]' data-testid='composer.markdownRoot' />
-    </>
+    </div>
   );
 };
 

--- a/packages/apps/plugins/plugin-markdown/tsconfig.json
+++ b/packages/apps/plugins/plugin-markdown/tsconfig.json
@@ -62,6 +62,9 @@
       "path": "../../../ui/react-ui-mosaic"
     },
     {
+      "path": "../../../ui/react-ui-stack"
+    },
+    {
       "path": "../../../ui/react-ui-theme"
     },
     {

--- a/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
@@ -146,7 +146,7 @@ const StackMain: FC<{ stack: StackType; separation?: boolean }> = ({ stack, sepa
   };
 
   return (
-    <Main.Content classNames={[baseSurface, topbarBlockPaddingStart]}>
+    <Main.Content bounce classNames={[baseSurface, topbarBlockPaddingStart]}>
       <Stack
         id={id}
         data-testid='main.stack'

--- a/packages/ui/react-ui-deck/src/components/Deck/Deck.tsx
+++ b/packages/ui/react-ui-deck/src/components/Deck/Deck.tsx
@@ -7,6 +7,7 @@ import React, { type ComponentPropsWithRef, forwardRef, useCallback, useEffect, 
 import { Main, type MainProps, type ThemedClassName, useMediaQuery, useTranslation } from '@dxos/react-ui';
 import { mx } from '@dxos/react-ui-theme';
 
+import { resizeHandle, resizeHandleVertical } from '../../fragments/resize-handle';
 import { translationKey } from '../../translations';
 
 type DeckRootProps = MainProps;
@@ -14,8 +15,7 @@ type DeckRootProps = MainProps;
 const deckLayout =
   'fixed inset-0 z-0 overflow-x-auto overflow-y-hidden snap-inline snap-proximity grid grid-rows-[var(--rail-size)_[toolbar-start]_var(--rail-action)_[content-start]_1fr_[content-end]] grid-cols-[repeat(99,min-content)]';
 
-const resizeButtonStyles =
-  'hidden sm:grid is-6 row-span-3 p-0 cursor-col-resize touch-none justify-items-center items-stretch plb-2 before:rounded-full before:is-1 before:surface-input hover:before:surface-inputHover before:transition-colors hover:before:surface-accentFocusIndicator focus-visible:before:surface-accentFocusIndicator data-[resizing=true]:before:surface-accentFocusIndicator focus:outline-none';
+const resizeButtonStyles = mx(resizeHandle, resizeHandleVertical, 'hidden sm:grid row-span-3');
 
 const DeckRoot = forwardRef<HTMLDivElement, DeckRootProps>(({ classNames, children, ...props }, forwardedRef) => {
   return (

--- a/packages/ui/react-ui-deck/src/fragments/index.ts
+++ b/packages/ui/react-ui-deck/src/fragments/index.ts
@@ -3,3 +3,4 @@
 //
 
 export * from './layout';
+export * from './resize-handle';

--- a/packages/ui/react-ui-deck/src/fragments/resize-handle.ts
+++ b/packages/ui/react-ui-deck/src/fragments/resize-handle.ts
@@ -1,0 +1,9 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+export const resizeHandle =
+  'grid p-0 touch-none before:rounded-full before:surface-input hover:before:surface-inputHover before:transition-colors hover:before:surface-accentFocusIndicator focus-visible:before:surface-accentFocusIndicator data-[resizing=true]:before:surface-accentFocusIndicator focus:outline-none';
+export const resizeHandleVertical = 'is-6 cursor-col-resize justify-items-center items-stretch plb-2 before:is-1';
+export const resizeHandleHorizontal =
+  'bs-6 cursor-row-resize justify-center items-center pli-2 before:bs-1 before:is-[--rail-size]';

--- a/packages/ui/react-ui-deck/src/index.ts
+++ b/packages/ui/react-ui-deck/src/index.ts
@@ -3,3 +3,4 @@
 //
 
 export * from './components';
+export * from './fragments';

--- a/packages/ui/react-ui-deck/src/translations.ts
+++ b/packages/ui/react-ui-deck/src/translations.ts
@@ -9,6 +9,7 @@ export default [
     'en-US': {
       [translationKey]: {
         'drag handle label': 'Press space or enter to begin dragging this item.',
+        'resize section label': 'Drag to resize section',
       },
     },
   },

--- a/packages/ui/react-ui-stack/src/components/Deck.stories.tsx
+++ b/packages/ui/react-ui-stack/src/components/Deck.stories.tsx
@@ -40,7 +40,6 @@ const rollItems = (n: number): StackSectionItem[] => {
     id: faker.string.uuid(),
     icon: BookBookmark,
     isResizable: true,
-    rendersToolbar: true,
     object: {
       id: faker.string.uuid(),
       title: faker.lorem.words(3),

--- a/packages/ui/react-ui-stack/src/components/Deck.stories.tsx
+++ b/packages/ui/react-ui-stack/src/components/Deck.stories.tsx
@@ -12,23 +12,24 @@ import { AttentionProvider, PlankHeading, plankHeadingIconProps, Deck } from '@d
 import { Mosaic } from '@dxos/react-ui-mosaic';
 import { withTheme } from '@dxos/storybook-utils';
 
-import { type StackSectionItem } from './Section';
+import { SectionToolbar, type StackSectionItem } from './Section';
 import { Stack } from './Stack';
 
 faker.seed(3);
 
 const Toolbar = () => {
   return (
-    <div role='toolbar' className='flex gap-2 pis-[--rail-size]'>
+    <SectionToolbar classNames='flex items-center gap-2'>
       <p>File</p>
       <p>Edit</p>
       <p>View</p>
-    </div>
+    </SectionToolbar>
   );
 };
 
 const SimpleContent = ({ data }: { data: { title?: string; body?: string } }) => (
   <>
+    <Toolbar />
     <div className='text-xl mlb-2'>{data.title}</div>
     <p>{data.body}</p>
   </>
@@ -38,6 +39,8 @@ const rollItems = (n: number): StackSectionItem[] => {
   return [...Array(n)].map(() => ({
     id: faker.string.uuid(),
     icon: BookBookmark,
+    isResizable: true,
+    rendersToolbar: true,
     object: {
       id: faker.string.uuid(),
       title: faker.lorem.words(3),
@@ -87,25 +90,25 @@ export const Simple = {
           <Mosaic.DragOverlay />
           <Deck.Root>
             <Deck.Plank>
-              <DemoStackPlank toolbar />
+              <DemoStackPlank />
             </Deck.Plank>
             <Deck.Plank>
               <DemoStackPlank />
             </Deck.Plank>
             <Deck.Plank>
-              <DemoStackPlank toolbar />
+              <DemoStackPlank />
             </Deck.Plank>
             <Deck.Plank>
               <DemoStackPlank />
             </Deck.Plank>
             <Deck.Plank>
-              <DemoStackPlank toolbar />
+              <DemoStackPlank />
             </Deck.Plank>
             <Deck.Plank>
               <DemoStackPlank />
             </Deck.Plank>
             <Deck.Plank>
-              <DemoStackPlank toolbar />
+              <DemoStackPlank />
             </Deck.Plank>
           </Deck.Root>
         </AttentionProvider>

--- a/packages/ui/react-ui-stack/src/components/Section.tsx
+++ b/packages/ui/react-ui-stack/src/components/Section.tsx
@@ -43,7 +43,14 @@ import {
   type MosaicTileProps,
   useMosaic,
 } from '@dxos/react-ui-mosaic';
-import { focusRing, getSize, mx } from '@dxos/react-ui-theme';
+import {
+  focusRing,
+  getSize,
+  hoverableControlItem,
+  hoverableControls,
+  hoverableFocusedWithinControls,
+  mx,
+} from '@dxos/react-ui-theme';
 
 import { CaretDownUp } from './CaretDownUp';
 import { stackColumns } from './style-fragments';
@@ -153,6 +160,8 @@ export const Section: ForwardRefExoticComponent<SectionProps & RefAttributes<HTM
             role='none'
             className={mx(
               'group grid col-span-2 grid-cols-subgrid outline outline-1 outline-transparent mlb-px surface-base focus-within:s-outline-separator focus-within:surface-attention',
+              hoverableControls,
+              hoverableFocusedWithinControls,
               active && 'surface-attention after:separator-separator s-outline-separator',
               (active === 'origin' || active === 'rearrange' || active === 'destination') && 'opacity-0',
             )}
@@ -165,45 +174,47 @@ export const Section: ForwardRefExoticComponent<SectionProps & RefAttributes<HTM
               {...(!active && sectionActionsToolbar)}
               className='grid grid-cols-subgrid ch-focus-ring rounded-sm grid-rows-[min-content_min-content_1fr] m-1 group-has-[[role=toolbar][aria-orientation=horizontal]]:pbs-[--rail-action]'
             >
-              <DropdownMenu.Root
-                {...{
-                  open: optionsMenuOpen,
-                  onOpenChange: setOptionsMenuOpen,
-                }}
-              >
-                <DropDownMenuDragHandleTrigger active={!!active} variant='ghost' classNames='m-0' {...draggableProps}>
-                  <Icon className={mx(getSize(5), 'transition-opacity')} />
-                </DropDownMenuDragHandleTrigger>
-                <DropdownMenu.Portal>
-                  <DropdownMenu.Content>
-                    <DropdownMenu.Viewport>
-                      <DropdownMenu.Item onClick={onAddBefore} data-testid='section.add-before'>
-                        <ArrowLineUp className={mx(getSize(5), 'mr-2')} />
-                        <span className='grow'>{t('add section before label')}</span>
-                      </DropdownMenu.Item>
-                      <DropdownMenu.Item onClick={onAddAfter} data-testid='section.add-after'>
-                        <ArrowLineDown className={mx(getSize(5), 'mr-2')} />
-                        <span className='grow'>{t('add section after label')}</span>
-                      </DropdownMenu.Item>
-                      <DropdownMenu.Item onClick={onNavigate} data-testid='section.navigate-to'>
-                        <ArrowSquareOut className={mx(getSize(5), 'mr-2')} />
-                        <span className='grow'>{t('navigate to section label')}</span>
-                      </DropdownMenu.Item>
-                      <DropdownMenu.Item onClick={() => onDelete?.()} data-testid='section.remove'>
-                        <X className={mx(getSize(5), 'mr-2')} />
-                        <span className='grow'>{t('remove section label')}</span>
-                      </DropdownMenu.Item>
-                    </DropdownMenu.Viewport>
-                    <DropdownMenu.Arrow />
-                  </DropdownMenu.Content>
-                </DropdownMenu.Portal>
-              </DropdownMenu.Root>
-              <CollapsiblePrimitive.Trigger asChild>
-                <Button variant='ghost' data-state='' classNames={sectionActionDimensions}>
-                  <span className='sr-only'>{t(collapsed ? 'expand label' : 'collapse label')}</span>
-                  {collapsed ? <CaretUpDown className={getSize(4)} /> : <CaretDownUp className={getSize(4)} />}
-                </Button>
-              </CollapsiblePrimitive.Trigger>
+              <div role='none' className='sticky -block-start-px bg-[--sticky-bg]'>
+                <DropdownMenu.Root
+                  {...{
+                    open: optionsMenuOpen,
+                    onOpenChange: setOptionsMenuOpen,
+                  }}
+                >
+                  <DropDownMenuDragHandleTrigger active={!!active} variant='ghost' classNames='m-0' {...draggableProps}>
+                    <Icon className={mx(getSize(5), 'transition-opacity')} />
+                  </DropDownMenuDragHandleTrigger>
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.Content>
+                      <DropdownMenu.Viewport>
+                        <DropdownMenu.Item onClick={onAddBefore} data-testid='section.add-before'>
+                          <ArrowLineUp className={mx(getSize(5), 'mr-2')} />
+                          <span className='grow'>{t('add section before label')}</span>
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Item onClick={onAddAfter} data-testid='section.add-after'>
+                          <ArrowLineDown className={mx(getSize(5), 'mr-2')} />
+                          <span className='grow'>{t('add section after label')}</span>
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Item onClick={onNavigate} data-testid='section.navigate-to'>
+                          <ArrowSquareOut className={mx(getSize(5), 'mr-2')} />
+                          <span className='grow'>{t('navigate to section label')}</span>
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Item onClick={() => onDelete?.()} data-testid='section.remove'>
+                          <X className={mx(getSize(5), 'mr-2')} />
+                          <span className='grow'>{t('remove section label')}</span>
+                        </DropdownMenu.Item>
+                      </DropdownMenu.Viewport>
+                      <DropdownMenu.Arrow />
+                    </DropdownMenu.Content>
+                  </DropdownMenu.Portal>
+                </DropdownMenu.Root>
+                <CollapsiblePrimitive.Trigger asChild>
+                  <Button variant='ghost' data-state='' classNames={sectionActionDimensions}>
+                    <span className='sr-only'>{t(collapsed ? 'expand label' : 'collapse label')}</span>
+                    {collapsed ? <CaretUpDown className={getSize(4)} /> : <CaretDownUp className={getSize(4)} />}
+                  </Button>
+                </CollapsiblePrimitive.Trigger>
+              </div>
             </div>
 
             {/* Main content */}
@@ -243,12 +254,11 @@ export const Section: ForwardRefExoticComponent<SectionProps & RefAttributes<HTM
 
 export type SectionToolbarProps = ThemedClassName<ComponentPropsWithRef<'div'>>;
 
+export const sectionToolbarLayout = 'bs-[--rail-action] bg-[--sticky-bg] sticky -block-start-px transition-opacity';
+
 export const SectionToolbar = ({ children, classNames }: SectionToolbarProps) => {
   return (
-    <Toolbar.Root
-      orientation='horizontal'
-      classNames={['bs-[--rail-action] bg-[--sticky-bg] sticky -block-start-px', classNames]}
-    >
+    <Toolbar.Root orientation='horizontal' classNames={[sectionToolbarLayout, hoverableControlItem, classNames]}>
       {children}
     </Toolbar.Root>
   );

--- a/packages/ui/react-ui-stack/src/components/Section.tsx
+++ b/packages/ui/react-ui-stack/src/components/Section.tsx
@@ -78,7 +78,6 @@ export type StackSectionItem = MosaicDataItem & {
   icon?: FC<IconProps>;
   placeholder?: string | [string, Parameters<TFunction>[1]];
   isResizable?: boolean;
-  rendersToolbar?: boolean;
 };
 
 export type StackSectionItemWithContext = StackSectionItem & StackContextValue;
@@ -98,7 +97,7 @@ export type SectionProps = PropsWithChildren<
     'draggableProps' | 'draggableStyle' | 'onDelete' | 'onNavigate' | 'onAddAfter' | 'onAddBefore'
   > &
     Pick<StackContextValue, 'collapsedSections' | 'onCollapseSection'> &
-    Pick<StackSectionItem, 'isResizable' | 'rendersToolbar'>
+    Pick<StackSectionItem, 'isResizable'>
 >;
 
 const resizeHandleStyles = mx(resizeHandle, resizeHandleHorizontal, 'is-full bs-[--rail-action] col-start-2');
@@ -114,7 +113,6 @@ export const Section: ForwardRefExoticComponent<SectionProps & RefAttributes<HTM
       icon: Icon = DotsNine,
       active,
       isResizable,
-      rendersToolbar,
       draggableProps,
       draggableStyle,
       collapsedSections,
@@ -153,18 +151,18 @@ export const Section: ForwardRefExoticComponent<SectionProps & RefAttributes<HTM
           <div
             role='none'
             className={mx(
-              'grid col-span-2 grid-cols-subgrid outline outline-1 outline-transparent mlb-px surface-base focus-within:s-outline-separator focus-within:surface-attention',
+              'group grid col-span-2 grid-cols-subgrid outline outline-1 outline-transparent mlb-px surface-base focus-within:s-outline-separator focus-within:surface-attention',
               active && 'surface-attention after:separator-separator s-outline-separator',
               (active === 'origin' || active === 'rearrange' || active === 'destination') && 'opacity-0',
             )}
           >
             <div
               role='toolbar'
-              data-clears={!collapsed && rendersToolbar ? 'toolbar' : 'none'}
+              aria-orientation='vertical'
               aria-label={t('section controls label')}
               {...(!active && { tabIndex: 0 })}
               {...(!active && sectionActionsToolbar)}
-              className='grid grid-cols-subgrid ch-focus-ring rounded-sm grid-rows-[min-content_min-content_1fr] m-1 data-[clears=toolbar]:pbs-[--rail-action]'
+              className='grid grid-cols-subgrid ch-focus-ring rounded-sm grid-rows-[min-content_min-content_1fr] m-1 group-has-[[role=toolbar][aria-orientation=horizontal]]:pbs-[--rail-action]'
             >
               <DropdownMenu.Root
                 {...{
@@ -244,7 +242,11 @@ export const Section: ForwardRefExoticComponent<SectionProps & RefAttributes<HTM
 
 export const SectionToolbar = ({ children, classNames }: ThemedClassName<ComponentPropsWithRef<'div'>>) => {
   return (
-    <div role='toolbar' className={mx('bs-[--rail-action] bg-[--sticky-bg] sticky -block-start-px', classNames)}>
+    <div
+      role='toolbar'
+      aria-orientation='horizontal'
+      className={mx('bs-[--rail-action] bg-[--sticky-bg] sticky -block-start-px', classNames)}
+    >
       {children}
     </div>
   );
@@ -264,7 +266,6 @@ export const SectionTile: MosaicTileComponent<StackSectionItemWithContext, HTMLL
       SectionContent,
       collapsedSections,
       onCollapseSection,
-      rendersToolbar,
       isResizable,
       ...contentItem
     } = {
@@ -304,7 +305,6 @@ export const SectionTile: MosaicTileComponent<StackSectionItemWithContext, HTMLL
         draggableStyle={draggableStyle}
         collapsedSections={collapsedSections}
         onCollapseSection={onCollapseSection}
-        rendersToolbar={rendersToolbar}
         isResizable={isResizable}
         onDelete={() => onDeleteSection?.(path)}
         onNavigate={() => onNavigateToSection?.(itemObject.id)}

--- a/packages/ui/react-ui-stack/src/components/Section.tsx
+++ b/packages/ui/react-ui-stack/src/components/Section.tsx
@@ -30,6 +30,7 @@ import {
   DropdownMenu,
   List,
   ListItem,
+  Toolbar,
   useTranslation,
   type TFunction,
   type ThemedClassName,
@@ -240,15 +241,16 @@ export const Section: ForwardRefExoticComponent<SectionProps & RefAttributes<HTM
   },
 );
 
-export const SectionToolbar = ({ children, classNames }: ThemedClassName<ComponentPropsWithRef<'div'>>) => {
+export type SectionToolbarProps = ThemedClassName<ComponentPropsWithRef<'div'>>;
+
+export const SectionToolbar = ({ children, classNames }: SectionToolbarProps) => {
   return (
-    <div
-      role='toolbar'
-      aria-orientation='horizontal'
-      className={mx('bs-[--rail-action] bg-[--sticky-bg] sticky -block-start-px', classNames)}
+    <Toolbar.Root
+      orientation='horizontal'
+      classNames={['bs-[--rail-action] bg-[--sticky-bg] sticky -block-start-px', classNames]}
     >
       {children}
-    </div>
+    </Toolbar.Root>
   );
 };
 

--- a/packages/ui/react-ui-stack/src/components/Stack.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack.tsx
@@ -98,7 +98,7 @@ export const Stack = ({
 
   return (
     // TODO(thure): Can this ref be passed into `SectionTile`? This can’t use `display: contents` because it breaks `useResizeDetector`.
-    <div ref={containerRef} {...props} className={mx(classNames)}>
+    <div role='none' ref={containerRef} {...props} className={mx(classNames)}>
       <Mosaic.Container
         {...{
           id,

--- a/packages/ui/react-ui-stack/src/components/index.ts
+++ b/packages/ui/react-ui-stack/src/components/index.ts
@@ -3,4 +3,4 @@
 //
 
 export * from './Stack';
-export { SectionToolbar, type SectionToolbarProps, type StackSectionItem } from './Section';
+export { SectionToolbar, type SectionToolbarProps, sectionToolbarLayout, type StackSectionItem } from './Section';

--- a/packages/ui/react-ui-stack/src/components/index.ts
+++ b/packages/ui/react-ui-stack/src/components/index.ts
@@ -3,4 +3,4 @@
 //
 
 export * from './Stack';
-export { type StackSectionItem } from './Section';
+export { SectionToolbar, type SectionToolbarProps, type StackSectionItem } from './Section';

--- a/packages/ui/react-ui-theme/src/util/semanticColors.ts
+++ b/packages/ui/react-ui-theme/src/util/semanticColors.ts
@@ -32,9 +32,11 @@ export const semanticColors = plugin(({ addUtilities, theme, e }) => {
       },
       [`.surface-${e(`${key}`)}`]: {
         backgroundColor: `${value.light}`,
+        '--sticky-bg': `${value.light}`,
       },
       [`.dark .surface-${e(`${key}`)}`]: {
         backgroundColor: `${value.dark}`,
+        '--sticky-bg': `${value.dark}`,
       },
       [`.separator-${e(`${key}`)}`]: {
         borderColor: `${value.fg?.light ?? value.light}`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2151,6 +2151,9 @@ importers:
       '@dxos/react-ui-mosaic':
         specifier: workspace:*
         version: link:../../../ui/react-ui-mosaic
+      '@dxos/react-ui-stack':
+        specifier: workspace:*
+        version: link:../../../ui/react-ui-stack
       '@dxos/util':
         specifier: workspace:*
         version: link:../../../common/util

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2150,6 +2150,9 @@ importers:
       '@dxos/react-ui-mosaic':
         specifier: workspace:*
         version: link:../../../ui/react-ui-mosaic
+      '@dxos/react-ui-stack':
+        specifier: workspace:*
+        version: link:../../../ui/react-ui-stack
       '@dxos/util':
         specifier: workspace:*
         version: link:../../../common/util


### PR DESCRIPTION
Resolves #6189.

This PR facilitates for Stack sections:
- resizing along the block axis (not integrated, but available in the UI)
- adjusting the rail content when a toolbar is present

https://github.com/dxos/dxos/assets/855039/9715afff-4a64-478d-be9c-24ebc5636237

https://github.com/dxos/dxos/assets/855039/53e5713b-2cc3-461c-be2a-6c71aa6dc123

https://github.com/dxos/dxos/assets/855039/a11233b4-26ae-47f1-960e-cff8bb3b67c4
