### PR TITLE
feat: allow accessing diagnostics without reference to a Client

### DIFF
--- a/packages/common/tracing/package.json
+++ b/packages/common/tracing/package.json
@@ -26,7 +26,9 @@
     "@dxos/protocols": "workspace:*",
     "@dxos/util": "workspace:*"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@dxos/test": "workspace:*"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/common/tracing/src/api.ts
+++ b/packages/common/tracing/src/api.ts
@@ -11,14 +11,14 @@ import { TRACE_PROCESSOR } from './trace-processor';
  * Annotates a class as a tracked resource.
  */
 const resource =
-  () =>
+  (annotation?: symbol) =>
   <T extends { new (...args: any[]): {} }>(constructor: T) => {
     // Wrapping class declaration into an IIFE so it doesn't capture the `klass` class name.
     const klass = (() =>
       class extends constructor {
         constructor(...rest: any[]) {
           super(...rest);
-          TRACE_PROCESSOR.traceResourceConstructor({ constructor, instance: this });
+          TRACE_PROCESSOR.traceResourceConstructor({ constructor, annotation, instance: this });
         }
       })();
     Object.defineProperty(klass, 'name', { value: constructor.name });

--- a/packages/common/tracing/tsconfig.json
+++ b/packages/common/tracing/tsconfig.json
@@ -13,6 +13,9 @@
   ],
   "references": [
     {
+      "path": "../../../tools/executors/test"
+    },
+    {
       "path": "../../core/protocols"
     },
     {

--- a/packages/sdk/client-services/package.json
+++ b/packages/sdk/client-services/package.json
@@ -10,6 +10,7 @@
   "browser": {
     "jsondown": false,
     "./src/packlets/locks/node.ts": "./src/packlets/locks/browser.ts",
+    "./src/packlets/diagnostics/diagnostics-broadcast.ts": "./src/packlets/diagnostics/browser-diagnostics-broadcast.ts",
     "./dist/lib/node/index.cjs": "./dist/lib/browser/index.mjs",
     "./testing.js": "./dist/lib/browser/packlets/testing/index.mjs"
   },

--- a/packages/sdk/client-services/src/index.ts
+++ b/packages/sdk/client-services/src/index.ts
@@ -10,3 +10,4 @@ export * from './packlets/spaces';
 export * from './packlets/storage';
 export * from './packlets/vault';
 export * from './packlets/locks';
+export * from './packlets/diagnostics';

--- a/packages/sdk/client-services/src/packlets/diagnostics/browser-diagnostics-broadcast.ts
+++ b/packages/sdk/client-services/src/packlets/diagnostics/browser-diagnostics-broadcast.ts
@@ -1,0 +1,94 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { Trigger } from '@dxos/async';
+import { log } from '@dxos/log';
+import { type SystemService } from '@dxos/protocols/proto/dxos/client/services';
+
+import {
+  type CollectDiagnosticsBroadcastSender,
+  type CollectDiagnosticsBroadcastHandler,
+} from './diagnostics-collector';
+
+const CHANNEL_NAME = 'dxos.diagnostics.broadcast';
+
+enum MessageType {
+  PROBE = 'probe',
+  PROBE_ACK = 'probe-ack',
+  REQUEST_DIAGNOSTICS = 'request-diagnostics',
+  RECEIVE_DIAGNOSTICS = 'receive-diagnostics',
+}
+
+interface Message {
+  type: MessageType;
+  payload?: any;
+}
+
+export const createCollectDiagnosticsBroadcastSender = (): CollectDiagnosticsBroadcastSender => {
+  return {
+    broadcastDiagnosticsRequest: async () => {
+      let expectedResponse = MessageType.PROBE_ACK;
+      let channel: BroadcastChannel | undefined;
+      try {
+        const trigger = new Trigger<Message>();
+        channel = new BroadcastChannel(CHANNEL_NAME);
+        channel.onmessage = (msg) => {
+          if (expectedResponse === msg.data.type) {
+            trigger.wake(msg.data);
+          }
+        };
+        channel.postMessage({ type: MessageType.PROBE });
+        await trigger.wait({ timeout: 200 });
+        expectedResponse = MessageType.RECEIVE_DIAGNOSTICS;
+        trigger.reset();
+        channel.postMessage({ type: MessageType.REQUEST_DIAGNOSTICS });
+        const diagnostics = await trigger.wait({ timeout: 5000 });
+        return diagnostics.payload;
+      } catch (e) {
+        const errorDescription = e instanceof Error ? e.message : JSON.stringify(e);
+        return { expectedResponse, errorDescription };
+      } finally {
+        safeClose(channel);
+      }
+    },
+  };
+};
+
+export const createCollectDiagnosticsBroadcastHandler = (
+  systemService: SystemService,
+): CollectDiagnosticsBroadcastHandler => {
+  let channel: BroadcastChannel | undefined;
+  return {
+    start: () => {
+      channel = new BroadcastChannel(CHANNEL_NAME);
+      channel.onmessage = async (message) => {
+        try {
+          if (message.data.type === MessageType.PROBE) {
+            channel?.postMessage({ type: MessageType.PROBE_ACK });
+          } else if (message.data.type === MessageType.REQUEST_DIAGNOSTICS) {
+            const diagnostics = await systemService.getDiagnostics({});
+            channel?.postMessage({
+              type: MessageType.RECEIVE_DIAGNOSTICS,
+              payload: diagnostics,
+            });
+          }
+        } catch (error) {
+          log.catch(error);
+        }
+      };
+    },
+    stop: () => {
+      safeClose(channel);
+      channel = undefined;
+    },
+  };
+};
+
+const safeClose = (channel?: BroadcastChannel) => {
+  try {
+    channel?.close();
+  } catch (e) {
+    // ignored
+  }
+};

--- a/packages/sdk/client-services/src/packlets/diagnostics/diagnostics-broadcast.ts
+++ b/packages/sdk/client-services/src/packlets/diagnostics/diagnostics-broadcast.ts
@@ -1,0 +1,20 @@
+//
+// Copyright 2024 DXOS.org
+//
+import { type SystemService } from '@dxos/protocols/proto/dxos/client/services';
+
+import {
+  type CollectDiagnosticsBroadcastSender,
+  type CollectDiagnosticsBroadcastHandler,
+} from './diagnostics-collector';
+
+export const createCollectDiagnosticsBroadcastSender = (): CollectDiagnosticsBroadcastSender => {
+  return { broadcastDiagnosticsRequest: async () => undefined };
+};
+
+export const createCollectDiagnosticsBroadcastHandler = (_: SystemService): CollectDiagnosticsBroadcastHandler => {
+  return {
+    start: () => {},
+    stop: () => {},
+  };
+};

--- a/packages/sdk/client-services/src/packlets/diagnostics/diagnostics-collector.ts
+++ b/packages/sdk/client-services/src/packlets/diagnostics/diagnostics-collector.ts
@@ -8,7 +8,7 @@ import { GetDiagnosticsRequest } from '@dxos/protocols/proto/dxos/client/service
 import { TRACE_PROCESSOR } from '@dxos/tracing';
 import { type JsonKeyOptions, jsonKeyReplacer, nonNullable } from '@dxos/util';
 
-import { ClientServicesProviderResource } from './util';
+import { ClientServicesProviderResource } from '../services';
 
 export class DiagnosticsCollector {
   public static async collect(

--- a/packages/sdk/client-services/src/packlets/diagnostics/diagnostics-collector.ts
+++ b/packages/sdk/client-services/src/packlets/diagnostics/diagnostics-collector.ts
@@ -3,7 +3,7 @@
 //
 
 import { type ClientServicesProvider } from '@dxos/client-protocol';
-import { type Config, type ConfigProto, ConfigResource } from '@dxos/config';
+import { type Config, ConfigResource } from '@dxos/config';
 import { GetDiagnosticsRequest } from '@dxos/protocols/proto/dxos/client/services';
 import { TRACE_PROCESSOR } from '@dxos/tracing';
 import { type JsonKeyOptions, jsonKeyReplacer, nonNullable } from '@dxos/util';
@@ -37,7 +37,7 @@ export class DiagnosticsCollector {
     });
 
     const clientDiagnostics = {
-      config: config != null ? (Array.isArray(config) ? mergeConfigs(config) : config.values) : undefined,
+      config,
       trace: TRACE_PROCESSOR.getDiagnostics(),
     };
 
@@ -52,12 +52,6 @@ export class DiagnosticsCollector {
     return JSON.parse(JSON.stringify(diagnostics, jsonKeyReplacer(options)));
   }
 }
-
-const mergeConfigs = (configs: Config[]) =>
-  configs.reduce<{ [idx: number]: ConfigProto }>((acc, v, idx) => {
-    acc[idx] = v.values;
-    return acc;
-  }, {});
 
 const findSystemServiceProvider = (): ClientServicesProvider | null => {
   const serviceProviders = TRACE_PROCESSOR.findByAnnotation(ClientServicesProviderResource);

--- a/packages/sdk/client-services/src/packlets/diagnostics/diagnostics.ts
+++ b/packages/sdk/client-services/src/packlets/diagnostics/diagnostics.ts
@@ -25,9 +25,9 @@ import { type Epoch } from '@dxos/protocols/proto/dxos/halo/credentials';
 import { type Resource, type Span } from '@dxos/protocols/proto/dxos/tracing';
 import { TRACE_PROCESSOR } from '@dxos/tracing';
 
-import { getPlatform } from './platform';
-import { type ServiceContext } from './service-context';
 import { DXOS_VERSION } from '../../version';
+import { type ServiceContext } from '../services';
+import { getPlatform } from '../services/platform';
 import { type DataSpace } from '../spaces';
 
 const DEFAULT_TIMEOUT = 1_000;

--- a/packages/sdk/client-services/src/packlets/diagnostics/index.ts
+++ b/packages/sdk/client-services/src/packlets/diagnostics/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+export * from './diagnostics';
+export * from './diagnostics-collector';

--- a/packages/sdk/client-services/src/packlets/diagnostics/index.ts
+++ b/packages/sdk/client-services/src/packlets/diagnostics/index.ts
@@ -4,3 +4,4 @@
 
 export * from './diagnostics';
 export * from './diagnostics-collector';
+export * from './diagnostics-broadcast';

--- a/packages/sdk/client-services/src/packlets/services/diagnostics-collector.ts
+++ b/packages/sdk/client-services/src/packlets/services/diagnostics-collector.ts
@@ -1,0 +1,56 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type ClientServicesProvider } from '@dxos/client-protocol';
+import { type Config, type ConfigProto, ConfigResource } from '@dxos/config';
+import { GetDiagnosticsRequest } from '@dxos/protocols/proto/dxos/client/services';
+import { TRACE_PROCESSOR } from '@dxos/tracing';
+import { type JsonKeyOptions, jsonKeyReplacer, nonNullable } from '@dxos/util';
+
+import { ClientServicesProviderResource } from './util';
+
+export class DiagnosticsCollector {
+  public static async collect(
+    config: Config | Config[] = findConfigs(),
+    services: ClientServicesProvider | null = findSystemServiceProvider(),
+    options: JsonKeyOptions = {},
+  ): Promise<any> {
+    const serviceDiagnostics = await services?.services?.SystemService?.getDiagnostics({
+      keys: options.humanize
+        ? GetDiagnosticsRequest.KEY_OPTION.HUMANIZE
+        : options.truncate
+          ? GetDiagnosticsRequest.KEY_OPTION.TRUNCATE
+          : undefined,
+    });
+
+    const clientDiagnostics = {
+      config: config != null ? (Array.isArray(config) ? mergeConfigs(config) : config.values) : undefined,
+      trace: TRACE_PROCESSOR.getDiagnostics(),
+    };
+
+    const diagnostics = {
+      client: clientDiagnostics,
+      services: serviceDiagnostics,
+    };
+
+    return JSON.parse(JSON.stringify(diagnostics, jsonKeyReplacer(options)));
+  }
+}
+
+const mergeConfigs = (configs: Config[]) =>
+  configs.reduce<{ [idx: number]: ConfigProto }>((acc, v, idx) => {
+    acc[idx] = v.values;
+    return acc;
+  }, {});
+
+const findSystemServiceProvider = (): ClientServicesProvider | null => {
+  const serviceProviders = TRACE_PROCESSOR.findByAnnotation(ClientServicesProviderResource);
+  const providerResource = serviceProviders.find((r) => r.instance.deref()?.services?.SystemService != null);
+  return providerResource?.instance?.deref() ?? null;
+};
+
+const findConfigs = (): Config[] => {
+  const configs = TRACE_PROCESSOR.findByAnnotation(ConfigResource);
+  return configs.map((r) => r.instance.deref()).filter(nonNullable);
+};

--- a/packages/sdk/client-services/src/packlets/services/index.ts
+++ b/packages/sdk/client-services/src/packlets/services/index.ts
@@ -3,9 +3,7 @@
 //
 
 export * from './client-rpc-server';
-export * from './diagnostics';
 export * from './service-context';
 export * from './service-host';
 export * from './service-registry';
 export { ClientServicesProviderResource } from './util';
-export * from './diagnostics-collector';

--- a/packages/sdk/client-services/src/packlets/services/index.ts
+++ b/packages/sdk/client-services/src/packlets/services/index.ts
@@ -7,3 +7,5 @@ export * from './diagnostics';
 export * from './service-context';
 export * from './service-host';
 export * from './service-registry';
+export { ClientServicesProviderResource } from './util';
+export * from './diagnostics-collector';

--- a/packages/sdk/client-services/src/packlets/services/service-host.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-host.ts
@@ -22,11 +22,11 @@ import { TRACE_PROCESSOR, trace as Trace } from '@dxos/tracing';
 import { assignDeep } from '@dxos/util';
 import { WebsocketRpcClient } from '@dxos/websocket-rpc';
 
-import { createDiagnostics } from './diagnostics';
 import { ServiceContext, type ServiceContextRuntimeParams } from './service-context';
 import { ServiceRegistry } from './service-registry';
 import { DevicesServiceImpl } from '../devices';
 import { DevtoolsHostEvents, DevtoolsServiceImpl } from '../devtools';
+import { createDiagnostics } from '../diagnostics';
 import { IdentityServiceImpl, type CreateIdentityOptions } from '../identity';
 import { InvitationsServiceImpl } from '../invitations';
 import { Lock, type ResourceLock } from '../locks';

--- a/packages/sdk/client-services/src/packlets/services/util.ts
+++ b/packages/sdk/client-services/src/packlets/services/util.ts
@@ -5,6 +5,8 @@
 import { PublicKey } from '@dxos/keys';
 import { humanize } from '@dxos/util';
 
+export const ClientServicesProviderResource = Symbol.for('dxos.resource.ClientServices');
+
 // TODO(burdon): Move to util.
 
 export type JsonStringifyOptions = {

--- a/packages/sdk/client-services/src/packlets/system/system-service.ts
+++ b/packages/sdk/client-services/src/packlets/system/system-service.ts
@@ -16,7 +16,7 @@ import {
 } from '@dxos/protocols/proto/dxos/client/services';
 import { jsonKeyReplacer, type MaybePromise } from '@dxos/util';
 
-import { type Diagnostics } from '../services';
+import { type Diagnostics } from '../diagnostics';
 import { getPlatform } from '../services/platform';
 
 export type SystemServiceOptions = {

--- a/packages/sdk/client/src/services/agent.ts
+++ b/packages/sdk/client/src/services/agent.ts
@@ -12,8 +12,10 @@ import {
   clientServiceBundle,
   getProfilePath,
 } from '@dxos/client-protocol';
+import { ClientServicesProviderResource } from '@dxos/client-services';
 import { log } from '@dxos/log';
 import { type ServiceBundle } from '@dxos/rpc';
+import { trace } from '@dxos/tracing';
 import type { WebsocketRpcClient } from '@dxos/websocket-rpc';
 
 export const getUnixSocket = (profile: string, protocol = 'unix') =>
@@ -32,6 +34,7 @@ export const fromAgent = ({
   return new AgentClientServiceProvider(profile);
 };
 
+@trace.resource(ClientServicesProviderResource)
 export class AgentClientServiceProvider implements ClientServicesProvider {
   // TODO(wittjosiah): Fire an event if the socket disconnects.
   readonly closed = new Event<Error | undefined>();

--- a/packages/sdk/client/src/services/local-client-services.ts
+++ b/packages/sdk/client/src/services/local-client-services.ts
@@ -4,7 +4,11 @@
 
 import { Event, synchronized } from '@dxos/async';
 import { type ClientServices, type ClientServicesProvider, clientServiceBundle } from '@dxos/client-protocol';
-import { type ClientServicesHost, type ClientServicesHostParams } from '@dxos/client-services';
+import {
+  type ClientServicesHost,
+  type ClientServicesHostParams,
+  ClientServicesProviderResource,
+} from '@dxos/client-services';
 import { Config } from '@dxos/config';
 import { Context } from '@dxos/context';
 import { log } from '@dxos/log';
@@ -81,7 +85,7 @@ const setupNetworking = async (
 /**
  * Starts a local instance of the service host.
  */
-@trace.resource()
+@trace.resource(ClientServicesProviderResource)
 export class LocalClientServices implements ClientServicesProvider {
   readonly closed = new Event<Error | undefined>();
   private readonly _ctx = new Context();

--- a/packages/sdk/client/src/services/service-proxy.ts
+++ b/packages/sdk/client/src/services/service-proxy.ts
@@ -4,6 +4,7 @@
 
 import { asyncTimeout, Event } from '@dxos/async';
 import { clientServiceBundle, type ClientServices, type ClientServicesProvider } from '@dxos/client-protocol';
+import { ClientServicesProviderResource } from '@dxos/client-services';
 import { invariant } from '@dxos/invariant';
 import { RemoteServiceConnectionTimeout } from '@dxos/protocols';
 import { createProtoRpcPeer, type ProtoRpcPeer, type RpcPort } from '@dxos/rpc';
@@ -13,7 +14,7 @@ import { trace } from '@dxos/tracing';
  * Implements services that are not local to the app.
  * For example, the services can be located in Wallet Extension.
  */
-@trace.resource()
+@trace.resource(ClientServicesProviderResource)
 export class ClientServicesProxy implements ClientServicesProvider {
   readonly closed = new Event<Error | undefined>();
   private _proxy?: ProtoRpcPeer<ClientServices>;

--- a/packages/sdk/client/src/services/worker-client-services.ts
+++ b/packages/sdk/client/src/services/worker-client-services.ts
@@ -4,7 +4,7 @@
 
 import { Event, Trigger, synchronized } from '@dxos/async';
 import { type ClientServices, type ClientServicesProvider, clientServiceBundle } from '@dxos/client-protocol';
-import type { SharedWorkerConnection } from '@dxos/client-services';
+import { type SharedWorkerConnection } from '@dxos/client-services';
 import type { Stream } from '@dxos/codec-protobuf';
 import { Config } from '@dxos/config';
 import type { PublicKey } from '@dxos/keys';

--- a/packages/sdk/client/src/testing/test-builder.ts
+++ b/packages/sdk/client/src/testing/test-builder.ts
@@ -150,7 +150,7 @@ export class TestBuilder {
 
     // TODO(dmaretskyi): Refactor.
 
-    const client = new Client({ services: new ClientServicesProxy(proxyPort) });
+    const client = new Client({ config: this.config, services: new ClientServicesProxy(proxyPort) });
     this._ctx.onDispose(() => client.destroy());
     return [client, server];
   }

--- a/packages/sdk/client/src/tests/diagnostics.test.ts
+++ b/packages/sdk/client/src/tests/diagnostics.test.ts
@@ -1,0 +1,51 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { expect } from 'chai';
+
+import { DiagnosticsCollector } from '@dxos/client-services';
+import { Context } from '@dxos/context';
+import { afterTest, describe, test } from '@dxos/test';
+
+import { Client } from '../client';
+import { TestBuilder } from '../testing';
+
+describe.only('DiagnosticsCollector', () => {
+  test('collects configs and traces if client was not initialized', async () => {
+    const testBuilder = new TestBuilder();
+    afterTest(() => testBuilder.destroy());
+
+    const diagnostics = await DiagnosticsCollector.collect();
+    expect(diagnostics.client.config).not.to.be.undefined;
+    expect(diagnostics.client.trace).not.to.be.undefined;
+    expect(diagnostics.services).to.be.undefined;
+  });
+
+  test('collects with local services', async () => {
+    const testBuilder = new TestBuilder();
+    afterTest(() => testBuilder.destroy());
+
+    const client = new Client({ config: testBuilder.config, services: testBuilder.createLocal() });
+    await client.initialize();
+
+    const diagnostics = await DiagnosticsCollector.collect();
+    expect(diagnostics.client.config).not.to.be.undefined;
+    expect(diagnostics.services).not.to.be.undefined;
+  });
+
+  test('collects with remote server', async () => {
+    const testBuilder = new TestBuilder();
+    afterTest(() => testBuilder.destroy());
+
+    const peer = testBuilder.createClientServicesHost();
+    await peer.open(new Context());
+    const [client, server] = testBuilder.createClientServer(peer);
+    void server.open();
+    await client.initialize();
+
+    const diagnostics = await DiagnosticsCollector.collect();
+    expect(diagnostics.client.config).not.to.be.undefined;
+    expect(diagnostics.services).not.to.be.undefined;
+  });
+});

--- a/packages/sdk/config/package.json
+++ b/packages/sdk/config/package.json
@@ -32,6 +32,7 @@
     "@dxos/log": "workspace:*",
     "@dxos/node-std": "workspace:*",
     "@dxos/protocols": "workspace:*",
+    "@dxos/tracing": "workspace:*",
     "boolean": "^3.0.1",
     "js-yaml": "^4.1.0",
     "localforage": "^1.10.0",

--- a/packages/sdk/config/src/config.ts
+++ b/packages/sdk/config/src/config.ts
@@ -10,6 +10,7 @@ import set from 'lodash.set';
 
 import { InvalidConfigError, schema } from '@dxos/protocols';
 import { type Config as ConfigProto } from '@dxos/protocols/proto/dxos/config';
+import { trace } from '@dxos/tracing';
 
 import { type ConfigKey, type DeepIndex, type ParseKey } from './types';
 
@@ -115,10 +116,13 @@ export const validateConfig = (config: ConfigProto): ConfigProto => {
   return config;
 };
 
+export const ConfigResource = Symbol.for('dxos.resource.Config');
+
 /**
  * Global configuration object.
  * NOTE: Config objects are immutable.
  */
+@trace.resource(ConfigResource)
 export class Config {
   private readonly _config: any;
 

--- a/packages/sdk/config/tsconfig.json
+++ b/packages/sdk/config/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../../common/node-std"
     },
     {
+      "path": "../../common/tracing"
+    },
+    {
       "path": "../../core/protocols"
     }
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4099,7 +4099,7 @@ importers:
         version: 3.12.0
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@5.5.0)
+        version: 4.3.4(supports-color@8.1.1)
       domain-browser:
         specifier: ^4.22.0
         version: 4.22.0
@@ -4791,6 +4791,10 @@ importers:
       '@dxos/util':
         specifier: workspace:*
         version: link:../util
+    devDependencies:
+      '@dxos/test':
+        specifier: workspace:*
+        version: link:../../../tools/executors/test
 
   packages/common/typings: {}
 
@@ -4975,7 +4979,7 @@ importers:
         version: 1.5.4
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@5.5.0)
+        version: 4.3.4(supports-color@8.1.1)
       eventemitter3:
         specifier: ^5.0.1
         version: 5.0.1
@@ -7554,7 +7558,7 @@ importers:
         version: 1.1.2(seedrandom@3.0.5)
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@5.5.0)
+        version: 4.3.4(supports-color@8.1.1)
       esbuild:
         specifier: ^0.19.6
         version: 0.19.6
@@ -8036,6 +8040,9 @@ importers:
       '@dxos/protocols':
         specifier: workspace:*
         version: link:../../core/protocols
+      '@dxos/tracing':
+        specifier: workspace:*
+        version: link:../../common/tracing
       boolean:
         specifier: ^3.0.1
         version: 3.2.0
@@ -8237,7 +8244,7 @@ importers:
         version: 0.11.1
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@5.5.0)
+        version: 4.3.4(supports-color@8.1.1)
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -10281,7 +10288,7 @@ packages:
     dependencies:
       '@automerge/automerge-repo': 1.1.4(@swc/core@1.4.0)(@types/node@18.11.9)(typescript@5.2.2)
       cbor-x: 1.5.4
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       eventemitter3: 5.0.1
       isomorphic-ws: 5.0.0(ws@8.14.2)
       ws: 8.14.2
@@ -10313,7 +10320,7 @@ packages:
       '@automerge/automerge': 2.1.13
       bs58check: 3.0.1
       cbor-x: 1.5.4
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       eventemitter3: 5.0.1
       fast-sha256: 1.3.0
       tiny-typed-emitter: 2.1.0
@@ -10384,7 +10391,7 @@ packages:
       '@babel/traverse': 7.23.9
       '@babel/types': 7.23.9
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -10404,10 +10411,10 @@ packages:
       '@babel/helpers': 7.21.0
       '@babel/parser': 7.21.3
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.3(supports-color@5.5.0)
+      '@babel/traverse': 7.21.3
       '@babel/types': 7.21.3
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -10429,7 +10436,7 @@ packages:
       '@babel/traverse': 7.23.6
       '@babel/types': 7.23.6
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -10452,7 +10459,7 @@ packages:
       '@babel/traverse': 7.23.9
       '@babel/types': 7.23.9
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -10617,7 +10624,7 @@ packages:
       '@babel/core': 7.21.3
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.5
       semver: 6.3.1
@@ -10632,7 +10639,7 @@ packages:
       '@babel/core': 7.23.9
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.5
     transitivePeerDependencies:
@@ -10713,7 +10720,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.3(supports-color@5.5.0)
+      '@babel/traverse': 7.21.3
       '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
@@ -10955,7 +10962,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.3(supports-color@5.5.0)
+      '@babel/traverse': 7.21.3
       '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
@@ -12944,6 +12951,23 @@ packages:
       '@babel/parser': 7.23.9
       '@babel/types': 7.23.9
 
+  /@babel/traverse@7.21.3:
+    resolution: {integrity: sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.21.3
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/parser': 7.21.3
+      '@babel/types': 7.21.3
+      debug: 4.3.4(supports-color@8.1.1)
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/traverse@7.21.3(supports-color@5.5.0):
     resolution: {integrity: sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==}
     engines: {node: '>=6.9.0'}
@@ -12973,7 +12997,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.6
       '@babel/types': 7.23.6
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -12991,7 +13015,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.23.9
       '@babel/types': 7.23.9
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -13399,7 +13423,7 @@ packages:
       cheerio: 1.0.0-rc.12
       connect-injector: 0.4.4
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       es-module-lexer: 0.10.5
       fast-glob: 3.3.2
       fs-extra: 10.1.0
@@ -13457,7 +13481,7 @@ packages:
       '@devicefarmer/adbkit-monkey': 1.2.1
       bluebird: 3.7.2
       commander: 9.3.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       node-forge: 1.3.1
       split: 1.0.1
     transitivePeerDependencies:
@@ -14265,7 +14289,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.20.0
       ignore: 5.2.4
@@ -14468,7 +14492,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -15524,7 +15548,7 @@ packages:
     dependencies:
       '@libp2p/interface-peer-id': 2.0.2
       '@multiformats/multiaddr': 12.1.14
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       interface-datastore: 8.2.10
       multiformats: 11.0.2
     transitivePeerDependencies:
@@ -16967,7 +16991,7 @@ packages:
     dependencies:
       '@oclif/core': 2.9.4(@swc/core@1.4.0)(@types/node@18.11.9)(typescript@5.2.2)
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       fs-extra: 9.1.0
       http-call: 5.3.0
       lodash: 4.17.21
@@ -17569,7 +17593,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.3.0
@@ -17586,7 +17610,7 @@ packages:
     engines: {node: '>=16.3.0'}
     hasBin: true
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.3.1
@@ -21051,7 +21075,7 @@ packages:
       '@swc-node/sourcemap-support': 0.3.0
       '@swc/core': 1.4.0
       colorette: 2.0.19
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       pirates: 4.0.5
       tslib: 2.6.0
       typescript: 5.2.2
@@ -23021,7 +23045,7 @@ packages:
       '@typescript-eslint/type-utils': 6.20.0(eslint@8.49.0)(typescript@5.2.2)
       '@typescript-eslint/utils': 6.20.0(eslint@8.49.0)(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 6.20.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.49.0
       graphemer: 1.4.0
       ignore: 5.2.4
@@ -23059,7 +23083,7 @@ packages:
       '@typescript-eslint/types': 6.20.0
       '@typescript-eslint/typescript-estree': 6.20.0(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 6.20.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.49.0
       typescript: 5.2.2
     transitivePeerDependencies:
@@ -23092,7 +23116,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.20.0(typescript@5.2.2)
       '@typescript-eslint/utils': 6.20.0(eslint@8.49.0)(typescript@5.2.2)
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.49.0
       ts-api-utils: 1.0.2(typescript@5.2.2)
       typescript: 5.2.2
@@ -23119,7 +23143,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.59.11
       '@typescript-eslint/visitor-keys': 5.59.11
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
@@ -23140,7 +23164,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.20.0
       '@typescript-eslint/visitor-keys': 6.20.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -23724,7 +23748,7 @@ packages:
       '@types/fs-extra': 11.0.4
       '@types/hash-sum': 1.0.2
       '@vuepress/shared': 2.0.0-rc.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       fs-extra: 11.1.1
       globby: 14.0.0
       hash-sum: 2.0.0
@@ -24169,7 +24193,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -24177,7 +24201,7 @@ packages:
     resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -24185,7 +24209,7 @@ packages:
     resolution: {integrity: sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       depd: 1.1.2
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -27648,7 +27672,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@datadog/datadog-api-client': 1.20.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -28041,7 +28065,7 @@ packages:
     hasBin: true
     dependencies:
       address: 1.2.1
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -28178,7 +28202,7 @@ packages:
   /dns-over-http-resolver@2.1.3:
     resolution: {integrity: sha512-zjRYFhq+CsxPAouQWzOsxNMvEN+SHisjzhX8EMxd2Y0EG3thvn6wXQgMJLnTDImkhe4jhLbOQpXtL10nALBOSA==}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       native-fetch: 4.0.2(undici@5.27.2)
       receptacle: 1.3.2
       undici: 5.27.2
@@ -28189,7 +28213,7 @@ packages:
   /dns-over-http-resolver@3.0.2:
     resolution: {integrity: sha512-5batkHOjCkuAfrFa+IPmt3jyeZqLtSMfAo1HQp3hfwtzgUwHooecTFplnYC093u5oRNL4CQHCXh3OfER7+vWrA==}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       receptacle: 1.3.2
     transitivePeerDependencies:
       - supports-color
@@ -28369,7 +28393,7 @@ packages:
   /earljs@0.1.12(typescript@5.2.2):
     resolution: {integrity: sha512-qTuYVJgbGdb1syLeQ/mD/SIm914TGI9kxzVrXQ3a03lzFQsKP202tqsdBFqU9d+J8k7fM41eglmLvzKGt0FJhw==}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       jest-snapshot: 26.6.2
       lodash: 4.17.21
       pretty-format: 26.6.2
@@ -28968,7 +28992,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       esbuild: 0.18.20
     transitivePeerDependencies:
       - supports-color
@@ -29476,7 +29500,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -29850,7 +29874,7 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -30803,7 +30827,7 @@ packages:
     dependencies:
       basic-ftp: 5.0.4
       data-uri-to-buffer: 6.0.1
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -31749,7 +31773,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       content-type: 1.0.4
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       is-retry-allowed: 1.2.0
       is-stream: 2.0.1
       parse-json: 4.0.0
@@ -31785,7 +31809,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -31795,7 +31819,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -31804,7 +31828,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -31882,7 +31906,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -31891,7 +31915,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -31942,7 +31966,7 @@ packages:
     resolution: {integrity: sha512-b5TXhqXUZ+Z7M/5/PlCTgElfufDRa3EzACd7y7BA7owLkxQreaUQ58wUO7nzJppDP1bnC2Hz6Hg7nlRPc75bKw==}
     dependencies:
       abstract-extension: 3.1.1
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       hypercore-crypto: 2.3.2
       inspect-custom-symbol: 1.1.1
       nanoguard: 1.3.0
@@ -32342,7 +32366,7 @@ packages:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -33152,7 +33176,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -36713,7 +36737,7 @@ packages:
     resolution: {integrity: sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.0.6
       micromark-factory-space: 1.0.0
@@ -36736,7 +36760,7 @@ packages:
     resolution: {integrity: sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
@@ -37098,7 +37122,7 @@ packages:
     peerDependencies:
       mocha: '>=3.1.2'
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       lodash: 4.17.21
       mocha: 10.2.0
     transitivePeerDependencies:
@@ -37379,7 +37403,7 @@ packages:
     resolution: {integrity: sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==}
     engines: {node: '>= 10.13'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       json-stringify-safe: 5.0.1
       lodash: 4.17.21
       propagate: 2.0.1
@@ -38047,7 +38071,7 @@ packages:
       '@oclif/plugin-warn-if-update-available': 2.0.32(@swc/core@1.4.0)(@types/node@18.11.9)(typescript@5.2.2)
       aws-sdk: 2.1233.0
       concurrently: 7.6.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       find-yarn-workspace-root: 2.0.0
       fs-extra: 8.1.0
       github-slugger: 1.5.0
@@ -38375,7 +38399,7 @@ packages:
     resolution: {integrity: sha512-UJKdSzgd3KOnXXAtqN5+/eeHcvTn1hBkesEmElVgvO/NAYcxAvmjzIGmnNd3Tb/gRAvMBdNRFD4qAWdHxY6QXg==}
     engines: {node: '>=12.10.0'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       p-queue: 6.6.2
     transitivePeerDependencies:
       - supports-color
@@ -38391,7 +38415,7 @@ packages:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       get-uri: 6.0.2
       http-proxy-agent: 7.0.0
       https-proxy-agent: 7.0.2
@@ -39420,7 +39444,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       http-proxy-agent: 7.0.0
       https-proxy-agent: 7.0.2
       lru-cache: 7.18.3
@@ -39436,7 +39460,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       http-proxy-agent: 7.0.0
       https-proxy-agent: 7.0.2
       lru-cache: 7.18.3
@@ -39510,7 +39534,7 @@ packages:
       '@puppeteer/browsers': 1.4.6(typescript@5.2.2)
       chromium-bidi: 0.4.16(devtools-protocol@0.0.1147663)
       cross-fetch: 4.0.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       devtools-protocol: 0.0.1147663
       typescript: 5.2.2
       ws: 8.13.0
@@ -41808,7 +41832,7 @@ packages:
     resolution: {integrity: sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==}
     dependencies:
       buffer: 6.0.3
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       err-code: 3.0.1
       get-browser-rtc: 1.1.0
       queue-microtask: 1.2.3
@@ -41935,7 +41959,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -41946,7 +41970,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -41957,7 +41981,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -42268,7 +42292,7 @@ packages:
     resolution: {integrity: sha512-Xnt9/HHHYfjZ7NeQLvuQDyL1LnbsbddgMFKCuaQKwGCdJm8LnstZIXop+uOY36UR1UXXoHXfMbC1KlVdVd2JLA==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       strip-ansi: 6.0.1
     transitivePeerDependencies:
       - supports-color
@@ -44644,7 +44668,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.1
       picocolors: 1.0.0
       vite: 5.1.5(@types/node@18.11.9)
@@ -44681,7 +44705,7 @@ packages:
     dependencies:
       '@antfu/utils': 0.7.7
       '@rollup/pluginutils': 5.1.0(rollup@3.23.0)
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
       open: 10.0.3
@@ -44701,7 +44725,7 @@ packages:
       vite: ^3.1.0 || ^4.0.0 || ^5.0.0
       workbox-window: ^7.0.0
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       fast-glob: 3.3.2
       pretty-bytes: 6.1.1
       vite: 5.1.5(@types/node@18.11.9)
@@ -44772,7 +44796,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 3.0.2(typescript@5.2.2)
       vite: 5.1.5(@types/node@18.11.9)
@@ -44887,7 +44911,7 @@ packages:
       '@vitest/utils': 1.3.1
       acorn-walk: 8.3.2
       chai: 4.4.1
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       execa: 8.0.1
       happy-dom: 13.3.4
       jsdom: 20.0.1
@@ -45733,7 +45757,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       commander: 9.3.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -46764,7 +46788,7 @@ packages:
       cli-table: 0.3.11
       commander: 7.1.0
       dateformat: 4.6.3
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       diff: 5.1.0
       error: 10.4.0
       escape-string-regexp: 4.0.0
@@ -46808,7 +46832,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       dargs: 7.0.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4(supports-color@8.1.1)
       execa: 5.1.1
       github-username: 6.0.0
       lodash: 4.17.21


### PR DESCRIPTION
### Details

* Created `DiagnosticsCollector` class that can be used to access diagnostics without a reference to `Client`.
* `Client` uses the new class to generate `diagnostics()` call result.
* `TraceProcessor` supports symbol-annotations for `ResourceEntry` objects.
* `DiagnosticsCollector` finds `ClientServicesProvider` and `Config` instances in `TRACE_PROCESSOR` using corresponding annotations.
* `DiagnosticsCollector` also handles the case of getting diagnostics from a shared-worker when `Client` wasn't initialized using `BroadcastChannel`.

Tests don't cover broadcast flow, tested it manually in chrome. 