### PR TITLE
fix: cleanup plugin query subscriptions

### DIFF
--- a/packages/apps/plugins/plugin-chain/src/ChainPlugin.tsx
+++ b/packages/apps/plugins/plugin-chain/src/ChainPlugin.tsx
@@ -45,6 +45,7 @@ export const ChainPlugin = (): PluginDefinition<ChainPluginProvides> => {
 
           const subscriptions = new EventSubscriptions();
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
+            subscriptions.clear();
             spaces.forEach((space) => {
               subscriptions.add(
                 updateGraphWithAddObjectAction({

--- a/packages/apps/plugins/plugin-chess/src/ChessPlugin.tsx
+++ b/packages/apps/plugins/plugin-chess/src/ChessPlugin.tsx
@@ -44,6 +44,7 @@ export const ChessPlugin = (): PluginDefinition<ChessPluginProvides> => {
 
           const subscriptions = new EventSubscriptions();
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
+            subscriptions.clear();
             spaces.forEach((space) => {
               subscriptions.add(
                 updateGraphWithAddObjectAction({

--- a/packages/apps/plugins/plugin-explorer/src/ExplorerPlugin.tsx
+++ b/packages/apps/plugins/plugin-explorer/src/ExplorerPlugin.tsx
@@ -44,6 +44,7 @@ export const ExplorerPlugin = (): PluginDefinition<ExplorerPluginProvides> => {
 
           const subscriptions = new EventSubscriptions();
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
+            subscriptions.clear();
             spaces.forEach((space) => {
               subscriptions.add(
                 updateGraphWithAddObjectAction({

--- a/packages/apps/plugins/plugin-grid/src/GridPlugin.tsx
+++ b/packages/apps/plugins/plugin-grid/src/GridPlugin.tsx
@@ -56,6 +56,7 @@ export const GridPlugin = (): PluginDefinition<GridPluginProvides> => {
 
           const subscriptions = new EventSubscriptions();
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
+            subscriptions.clear();
             spaces.forEach((space) => {
               subscriptions.add(
                 updateGraphWithAddObjectAction({

--- a/packages/apps/plugins/plugin-inbox/src/InboxPlugin.tsx
+++ b/packages/apps/plugins/plugin-inbox/src/InboxPlugin.tsx
@@ -53,6 +53,7 @@ export const InboxPlugin = (): PluginDefinition<InboxPluginProvides> => {
 
           const subscriptions = new EventSubscriptions();
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
+            subscriptions.clear();
             spaces.forEach((space) => {
               subscriptions.add(
                 updateGraphWithAddObjectAction({

--- a/packages/apps/plugins/plugin-kanban/src/KanbanPlugin.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/KanbanPlugin.tsx
@@ -42,6 +42,7 @@ export const KanbanPlugin = (): PluginDefinition<KanbanPluginProvides> => {
 
           const subscriptions = new EventSubscriptions();
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
+            subscriptions.clear();
             spaces.forEach((space) => {
               subscriptions.add(
                 updateGraphWithAddObjectAction({

--- a/packages/apps/plugins/plugin-map/src/MapPlugin.tsx
+++ b/packages/apps/plugins/plugin-map/src/MapPlugin.tsx
@@ -44,6 +44,7 @@ export const MapPlugin = (): PluginDefinition<MapPluginProvides> => {
 
           const subscriptions = new EventSubscriptions();
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
+            subscriptions.clear();
             spaces.forEach((space) => {
               subscriptions.add(
                 updateGraphWithAddObjectAction({

--- a/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -122,6 +122,7 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
 
           const subscriptions = new EventSubscriptions();
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
+            subscriptions.clear();
             spaces.forEach((space) => {
               subscriptions.add(
                 updateGraphWithAddObjectAction({

--- a/packages/apps/plugins/plugin-outliner/src/OutlinerPlugin.tsx
+++ b/packages/apps/plugins/plugin-outliner/src/OutlinerPlugin.tsx
@@ -44,6 +44,7 @@ export const OutlinerPlugin = (): PluginDefinition<OutlinerPluginProvides> => {
 
           const subscriptions = new EventSubscriptions();
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
+            subscriptions.clear();
             spaces.forEach((space) => {
               subscriptions.add(
                 updateGraphWithAddObjectAction({

--- a/packages/apps/plugins/plugin-script/src/ScriptPlugin.tsx
+++ b/packages/apps/plugins/plugin-script/src/ScriptPlugin.tsx
@@ -52,6 +52,7 @@ export const ScriptPlugin = ({ containerUrl }: ScriptPluginProps): PluginDefinit
 
           const subscriptions = new EventSubscriptions();
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
+            subscriptions.clear();
             spaces.forEach((space) => {
               subscriptions.add(
                 updateGraphWithAddObjectAction({

--- a/packages/apps/plugins/plugin-sketch/src/SketchPlugin.tsx
+++ b/packages/apps/plugins/plugin-sketch/src/SketchPlugin.tsx
@@ -44,6 +44,7 @@ export const SketchPlugin = (): PluginDefinition<SketchPluginProvides> => {
 
           const subscriptions = new EventSubscriptions();
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
+            subscriptions.clear();
             spaces.forEach((space) => {
               subscriptions.add(
                 updateGraphWithAddObjectAction({

--- a/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
+++ b/packages/apps/plugins/plugin-stack/src/StackPlugin.tsx
@@ -81,6 +81,7 @@ export const StackPlugin = (): PluginDefinition<StackPluginProvides> => {
 
           const subscriptions = new EventSubscriptions();
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
+            subscriptions.clear();
             spaces.forEach((space) => {
               subscriptions.add(
                 updateGraphWithAddObjectAction({

--- a/packages/apps/plugins/plugin-table/src/TablePlugin.tsx
+++ b/packages/apps/plugins/plugin-table/src/TablePlugin.tsx
@@ -46,6 +46,7 @@ export const TablePlugin = (): PluginDefinition<TablePluginProvides> => {
 
           const subscriptions = new EventSubscriptions();
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
+            subscriptions.clear();
             spaces.forEach((space) => {
               subscriptions.add(
                 updateGraphWithAddObjectAction({

--- a/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -146,6 +146,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
 
           const subscriptions = new EventSubscriptions();
           const { unsubscribe } = client.spaces.subscribe((spaces) => {
+            subscriptions.clear();
             spaces.forEach((space) => {
               subscriptions.add(
                 updateGraphWithAddObjectAction({


### PR DESCRIPTION
Cleanup old query subscriptions before resubscribing. Attempt to narrow down some of the current performance issues on dev.
