### PR TITLE
chore(shell): add missing dep

### DIFF
--- a/packages/sdk/shell/package.json
+++ b/packages/sdk/shell/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@dxos/config": "workspace:*",
+    "@dxos/protocols": "workspace:*",
     "@dxos/random": "workspace:*",
     "@dxos/react-async": "workspace:*",
     "@dxos/react-ui-theme": "workspace:*",

--- a/packages/sdk/shell/tsconfig.json
+++ b/packages/sdk/shell/tsconfig.json
@@ -49,6 +49,9 @@
       "path": "../../core/mesh/rpc-tunnel"
     },
     {
+      "path": "../../core/protocols"
+    },
+    {
       "path": "../../ui/react-ui"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8574,6 +8574,9 @@ importers:
       '@dxos/config':
         specifier: workspace:*
         version: link:../config
+      '@dxos/protocols':
+        specifier: workspace:*
+        version: link:../../core/protocols
       '@dxos/random':
         specifier: workspace:*
         version: link:../../common/random


### PR DESCRIPTION
todomvc app bundling mysteriously started failing with the following error:

> failed to resolve import "@dxos/protocols" from "/home/circleci/project/packages/sdk/shell/dist/bundle/shell.mjs"

this seems to resolve it
