### PR TITLE
refactor(echo-schema): make text helpers generic

### DIFF
--- a/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -344,8 +344,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
                 doc.comments?.forEach(({ thread, cursor }) => {
                   if (thread instanceof ThreadType && cursor) {
                     const [start, end] = cursor.split(':');
-                    // TODO(wittjosiah): Don't cast.
-                    const title = getTextInRange(doc.content, start, end);
+                    const title = doc.content && getTextInRange({ object: doc.content, path: ['content'], start, end });
                     // TODO(burdon): This seems unsafe; review.
                     // Only update if the title has changed, otherwise this will cause an infinite loop.
                     // Skip if the title is empty - this means comment text was deleted, but thread title should remain.
@@ -361,8 +360,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
               onCreate: ({ cursor, location }) => {
                 // Create comment thread.
                 const [start, end] = cursor.split(':');
-                // TODO(wittjosiah): Don't cast.
-                const title = getTextInRange(doc.content, start, end);
+                const title = doc.content && getTextInRange({ object: doc.content, path: ['content'], start, end });
                 const thread = space.db.add(E.object(ThreadType, { title, messages: [], context: { object: doc.id } }));
                 if (doc.comments) {
                   doc.comments.push({ thread, cursor });
@@ -394,9 +392,10 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
               },
               onUpdate: ({ id, cursor }) => {
                 const comment = doc.comments?.find(({ thread }) => thread?.id === id);
-                if (comment && comment.thread) {
+                if (comment && comment.thread instanceof ThreadType) {
                   const [start, end] = cursor.split(':');
-                  (comment.thread as ThreadType).title = getTextInRange(doc.content, start, end);
+                  comment.thread.title =
+                    doc.content && getTextInRange({ object: doc.content, path: ['content'], start, end });
                   comment.cursor = cursor;
                 }
               },

--- a/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -22,7 +22,7 @@ import {
 } from '@dxos/app-framework';
 import { EventSubscriptions, type UnsubscribeCallback } from '@dxos/async';
 import * as E from '@dxos/echo-schema';
-import { type EchoReactiveObject } from '@dxos/echo-schema';
+import { createDocAccessor, type EchoReactiveObject } from '@dxos/echo-schema';
 import { LocalStorageStore } from '@dxos/local-storage';
 import { getSpace, getTextInRange, SpaceProxy, Filter } from '@dxos/react-client/echo';
 import { ScrollArea } from '@dxos/react-ui';
@@ -344,7 +344,8 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
                 doc.comments?.forEach(({ thread, cursor }) => {
                   if (thread instanceof ThreadType && cursor) {
                     const [start, end] = cursor.split(':');
-                    const title = doc.content && getTextInRange({ object: doc.content, path: ['content'], start, end });
+                    const title =
+                      doc.content && getTextInRange(createDocAccessor(doc.content, ['content']), start, end);
                     // TODO(burdon): This seems unsafe; review.
                     // Only update if the title has changed, otherwise this will cause an infinite loop.
                     // Skip if the title is empty - this means comment text was deleted, but thread title should remain.
@@ -360,7 +361,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
               onCreate: ({ cursor, location }) => {
                 // Create comment thread.
                 const [start, end] = cursor.split(':');
-                const title = doc.content && getTextInRange({ object: doc.content, path: ['content'], start, end });
+                const title = doc.content && getTextInRange(createDocAccessor(doc.content, ['content']), start, end);
                 const thread = space.db.add(E.object(ThreadType, { title, messages: [], context: { object: doc.id } }));
                 if (doc.comments) {
                   doc.comments.push({ thread, cursor });
@@ -395,7 +396,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
                 if (comment && comment.thread instanceof ThreadType) {
                   const [start, end] = cursor.split(':');
                   comment.thread.title =
-                    doc.content && getTextInRange({ object: doc.content, path: ['content'], start, end });
+                    doc.content && getTextInRange(createDocAccessor(doc.content, ['content']), start, end);
                   comment.cursor = cursor;
                 }
               },

--- a/packages/core/echo/echo-schema/src/automerge/index.ts
+++ b/packages/core/echo/echo-schema/src/automerge/index.ts
@@ -7,5 +7,4 @@ export * from './automerge-object';
 export * from './automerge-db';
 export * from './automerge-object-core';
 export * from './automerge-types';
-export * from './key-path';
 export * from './types';

--- a/packages/core/echo/echo-schema/src/automerge/index.ts
+++ b/packages/core/echo/echo-schema/src/automerge/index.ts
@@ -7,4 +7,5 @@ export * from './automerge-object';
 export * from './automerge-db';
 export * from './automerge-object-core';
 export * from './automerge-types';
+export * from './key-path';
 export * from './types';

--- a/packages/core/echo/echo-schema/src/text.ts
+++ b/packages/core/echo/echo-schema/src/text.ts
@@ -6,28 +6,16 @@ import get from 'lodash.get';
 
 import { next as A } from '@dxos/automerge/automerge';
 
-import { type DocAccessor, createDocAccessor, type KeyPath } from './automerge';
-import { type EchoReactiveObject } from './effect/reactive';
+import { type DocAccessor } from './automerge';
 
 /**
  * @deprecated
  */
 export const LEGACY_TEXT_TYPE = 'dxos.Text.v0';
 
-export const toCursor = <T>({
-  object,
-  path,
-  accessor: _accessor,
-  position: pos,
-}: {
-  object?: EchoReactiveObject<T>;
-  path?: KeyPath;
-  accessor?: DocAccessor;
-  position: number;
-}) => {
-  const accessor = _accessor ?? (object && path ? createDocAccessor(object, path) : undefined);
-  const doc = accessor?.handle.docSync();
-  if (!accessor || !doc) {
+export const toCursor = (accessor: DocAccessor, pos: number) => {
+  const doc = accessor.handle.docSync();
+  if (!doc) {
     return '';
   }
 
@@ -40,24 +28,13 @@ export const toCursor = <T>({
   return A.getCursor(doc, accessor.path.slice(), pos);
 };
 
-export const fromCursor = <T>({
-  object,
-  path,
-  accessor: _accessor,
-  cursor,
-}: {
-  object?: EchoReactiveObject<T>;
-  path?: KeyPath;
-  accessor?: DocAccessor;
-  cursor: string;
-}) => {
+export const fromCursor = (accessor: DocAccessor, cursor: string) => {
   if (cursor === '') {
     return 0;
   }
 
-  const accessor = _accessor ?? (object && path ? createDocAccessor(object, path) : undefined);
-  const doc = accessor?.handle.docSync();
-  if (!accessor || !doc) {
+  const doc = accessor.handle.docSync();
+  if (!doc) {
     return 0;
   }
 
@@ -74,22 +51,11 @@ export const fromCursor = <T>({
   return A.getCursorPosition(doc, accessor.path.slice(), cursor);
 };
 
-export const getTextInRange = <T>({
-  object,
-  path,
-  start,
-  end,
-}: {
-  object: EchoReactiveObject<T>;
-  path: KeyPath;
-  start: string;
-  end: string;
-}) => {
-  const accessor = createDocAccessor(object, path);
-  const beginIdx = fromCursor({ accessor, cursor: start });
-  const endIdx = fromCursor({ accessor, cursor: end });
+export const getTextInRange = (accessor: DocAccessor, start: string, end: string) => {
   const doc = accessor.handle.docSync();
   const value = get(doc, accessor.path);
+  const beginIdx = fromCursor(accessor, start);
+  const endIdx = fromCursor(accessor, end);
   if (typeof value === 'string') {
     return value.slice(beginIdx, endIdx);
   } else {

--- a/packages/experimental/labs-functions/src/functions/chat/context.ts
+++ b/packages/experimental/labs-functions/src/functions/chat/context.ts
@@ -63,6 +63,6 @@ const getReferencedText = (document: DocumentType, comment: DocumentCommentType)
     return '';
   }
 
-  const [begin, end] = comment.cursor.split(':');
-  return document.content ? getTextInRange(document.content, begin, end) : '';
+  const [start, end] = comment.cursor.split(':');
+  return document.content ? getTextInRange({ object: document.content, path: ['content'], start, end }) : '';
 };

--- a/packages/experimental/labs-functions/src/functions/chat/context.ts
+++ b/packages/experimental/labs-functions/src/functions/chat/context.ts
@@ -7,6 +7,7 @@ import { type Space } from '@dxos/client/echo';
 import {
   type DynamicEchoSchema,
   type EchoReactiveObject,
+  createDocAccessor,
   effectToJsonSchema,
   getTextInRange,
   loadObjectReferences,
@@ -64,5 +65,5 @@ const getReferencedText = (document: DocumentType, comment: DocumentCommentType)
   }
 
   const [start, end] = comment.cursor.split(':');
-  return document.content ? getTextInRange({ object: document.content, path: ['content'], start, end }) : '';
+  return document.content ? getTextInRange(createDocAccessor(document.content, ['content']), start, end) : '';
 };

--- a/packages/ui/react-ui-editor/src/extensions/automerge/cursor.ts
+++ b/packages/ui/react-ui-editor/src/extensions/automerge/cursor.ts
@@ -11,7 +11,7 @@ export const cursorConverter = (accessor: DocAccessor): CursorConverter => ({
   // TODO(burdon): Handle assoc to associate with a previous character.
   toCursor: (pos) => {
     try {
-      return toCursor({ accessor, position: pos });
+      return toCursor(accessor, pos);
     } catch (err) {
       log.catch(err);
       return ''; // In case of invalid request (e.g., wrong document).
@@ -20,7 +20,7 @@ export const cursorConverter = (accessor: DocAccessor): CursorConverter => ({
 
   fromCursor: (cursor) => {
     try {
-      return fromCursor({ accessor, cursor });
+      return fromCursor(accessor, cursor);
     } catch (err) {
       log.catch(err);
       return 0; // In case of invalid request (e.g., wrong document).

--- a/packages/ui/react-ui-editor/src/extensions/automerge/cursor.ts
+++ b/packages/ui/react-ui-editor/src/extensions/automerge/cursor.ts
@@ -2,30 +2,16 @@
 // Copyright 2024 DXOS.org
 //
 
-import get from 'lodash.get';
-
-import { next as A } from '@dxos/automerge/automerge';
-import { type DocAccessor } from '@dxos/echo-schema';
+import { toCursor, type DocAccessor, fromCursor } from '@dxos/echo-schema';
 import { log } from '@dxos/log';
 
 import { type CursorConverter } from '../cursor';
 
-export const cursorConverter = ({ handle, path }: DocAccessor): CursorConverter => ({
+export const cursorConverter = (accessor: DocAccessor): CursorConverter => ({
   // TODO(burdon): Handle assoc to associate with a previous character.
   toCursor: (pos) => {
-    const doc = handle.docSync();
-    if (!doc) {
-      return '';
-    }
-
-    const value = get(doc, path);
-    if (typeof value === 'string' && value.length <= pos) {
-      return 'end';
-    }
-
     try {
-      // NOTE: Slice is needed because getCursor mutates the array.
-      return A.getCursor(doc, path.slice(), pos);
+      return toCursor({ accessor, position: pos });
     } catch (err) {
       log.catch(err);
       return ''; // In case of invalid request (e.g., wrong document).
@@ -33,27 +19,8 @@ export const cursorConverter = ({ handle, path }: DocAccessor): CursorConverter 
   },
 
   fromCursor: (cursor) => {
-    if (cursor === '') {
-      return 0;
-    }
-
-    const doc = handle.docSync();
-    if (!doc) {
-      return 0;
-    }
-
-    if (cursor === 'end') {
-      const value = get(doc, path);
-      if (typeof value === 'string') {
-        return value.length;
-      } else {
-        return 0;
-      }
-    }
-
     try {
-      // NOTE: Slice is needed because getCursor mutates the array.
-      return A.getCursorPosition(doc, path.slice(), cursor);
+      return fromCursor({ accessor, cursor });
     } catch (err) {
       log.catch(err);
       return 0; // In case of invalid request (e.g., wrong document).


### PR DESCRIPTION
Stop hardcoding the 'content' path in all of the text helpers and reconcile with editor cursor converter.

Part of #4745
