### PR TITLE
fix(react-ui-editor): don't recreate editor when initial text value changes

### DIFF
--- a/packages/apps/plugins/plugin-markdown/src/components/DocumentMain.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/DocumentMain.tsx
@@ -31,7 +31,7 @@ const DocumentMain = ({ document: doc, extensions: _extensions = [], ...props }:
       }),
       state(localStorageStateStoreAdapter),
     ],
-    [doc],
+    [doc, _extensions, identity],
   );
 
   const { scrollTo, selection } = useMemo(() => {

--- a/packages/ui/react-ui-editor/src/components/TextEditor/TextEditor.tsx
+++ b/packages/ui/react-ui-editor/src/components/TextEditor/TextEditor.tsx
@@ -52,6 +52,7 @@ export const TextEditor = forwardRef<EditorView | null, TextEditorProps>(
   (
     {
       id,
+      // TODO(wittjosiah): Rename initialText?
       doc,
       selection,
       extensions,
@@ -152,7 +153,7 @@ export const TextEditor = forwardRef<EditorView | null, TextEditorProps>(
         log('destroy', { id, instanceId });
         view?.destroy();
       };
-    }, [doc, selection, extensions]);
+    }, [id, selection, scrollTo, editorMode, extensions]);
 
     // Focus editor on Enter (e.g., when tabbing to this component).
     const handleKeyUp = useCallback<KeyboardEventHandler<HTMLDivElement>>(


### PR DESCRIPTION
Fixes the following issue:

https://github.com/dxos/dxos/assets/4529818/76d5099d-4c72-45de-a24f-dcb8d00f9450

The key fix was removing `doc` from the effect dependencies. Given the automerge transition doc ends up just being a plain string which is updated reactively and depending on that causes the editor to remount on every keystroke.
