### PR TITLE
refactor(halo): make multiuse into a separate flag instead of invitation type

### DIFF
--- a/packages/apps/plugins/plugin-debug/src/components/DebugSpace.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DebugSpace.tsx
@@ -100,8 +100,9 @@ const DebugSpace: FC<{ space: Space; onAddObjects?: (objects: ReactiveObject<any
 
   const handleCreateInvitation = () => {
     const invitation = space.share({
-      type: Invitation.Type.MULTIUSE,
+      type: Invitation.Type.INTERACTIVE,
       authMethod: Invitation.AuthMethod.NONE,
+      multiUse: true,
     });
 
     // TODO(burdon): Refactor.

--- a/packages/apps/plugins/plugin-space/src/components/SpaceMain/SpaceMembersSection.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/SpaceMain/SpaceMembersSection.tsx
@@ -89,8 +89,9 @@ export const SpaceMembersSection = ({ space }: { space: Space }) => {
       icon: UsersThree,
       onClick: useCallback(() => {
         space.share?.({
-          type: Invitation.Type.MULTIUSE,
+          type: Invitation.Type.INTERACTIVE,
           authMethod: Invitation.AuthMethod.NONE,
+          multiUse: true,
         });
       }, [space]),
     },

--- a/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
+++ b/packages/core/echo/echo-pipeline/src/metadata/metadata-store.ts
@@ -350,5 +350,5 @@ export const hasInvitationExpired = (invitation: Invitation): boolean => {
 
 // TODO: remove once "multiuse" type invitations get removed from local metadata of existing profiles
 const isLegacyInvitationFormat = (invitation: Invitation): boolean => {
-  return !Object.values(Invitation.Type).includes(invitation.type);
+  return invitation.type === Invitation.Type.MULTIUSE;
 };

--- a/packages/core/protocols/src/proto/dxos/client/services.proto
+++ b/packages/core/protocols/src/proto/dxos/client/services.proto
@@ -405,10 +405,8 @@ message Invitation {
   enum Type {
     /// Requires both to be online to complete key exchange.
     INTERACTIVE = 0;
-    /// Guest's identity key is known; invitation can be accepted by any valid peer.
+    /// Invitation can be accepted by any valid peer.
     OFFLINE = 1;
-    /// Multiple-use interactive invitation.
-    MULTIUSE = 2;
   }
 
   enum Kind {
@@ -422,6 +420,9 @@ message Invitation {
 
     /// Guest should call `Authenticate` with the shared secret.
     SHARED_SECRET = 1;
+
+    /// Guest should prove they possess a private key corresponding to the known public key recorded in an invitation.
+    KNOWN_PUBLIC_KEY = 2;
   }
 
   enum State {
@@ -480,6 +481,9 @@ message Invitation {
   // TODO(nf): some feedback mechanism or GC for immortal invitations?
   // TODO(nf): should the creator have a way to make an invitation last as long as the client? this was the previous behavior.
   optional int32 lifetime = 14;
+
+  /// Whether an invitation can be used multiple times.
+  optional bool multi_use = 15;
 }
 
 message AcceptInvitationRequest {

--- a/packages/core/protocols/src/proto/dxos/client/services.proto
+++ b/packages/core/protocols/src/proto/dxos/client/services.proto
@@ -407,6 +407,11 @@ message Invitation {
     INTERACTIVE = 0;
     /// Invitation can be accepted by any valid peer.
     OFFLINE = 1;
+    /**
+     * Multi-use interactive invitations.
+     * @deprecated use multiUse flag with type=interactive instead.
+     */
+    MULTIUSE = 2;
   }
 
   enum Kind {

--- a/packages/devtools/cli/src/commands/app/open.ts
+++ b/packages/devtools/cli/src/commands/app/open.ts
@@ -57,8 +57,9 @@ export default class Open extends BaseCommand<typeof Open> {
 
       if (this.flags.invite) {
         const observable = client.halo.share({
-          type: Invitation.Type.MULTIUSE,
+          type: Invitation.Type.INTERACTIVE,
           authMethod: Invitation.AuthMethod.NONE,
+          multiUse: true,
         });
 
         const invitationSuccess = hostInvitation({

--- a/packages/devtools/cli/src/commands/space/share.ts
+++ b/packages/devtools/cli/src/commands/space/share.ts
@@ -55,11 +55,10 @@ export default class Share extends BaseCommand<typeof Share> {
       const space = await this.getSpace(client, key);
 
       // TODO(burdon): Timeout error not propagated.
-      const type = this.flags.multiple ? Invitation.Type.MULTIUSE : undefined;
       const authMethod = this.flags['no-auth'] ? Invitation.AuthMethod.NONE : undefined;
       const observable = space!.share({
-        type,
         authMethod,
+        multiUse: this.flags.multiple,
         timeout: this.flags.timeout,
         persistent: this.flags.persistent,
         lifetime: this.flags.lifetime,

--- a/packages/gravity/kube-testing/src/spec/echo.ts
+++ b/packages/gravity/kube-testing/src/spec/echo.ts
@@ -276,14 +276,16 @@ export class EchoTestPlan implements TestPlan<EchoTestSpec, EchoAgentConfig> {
         this.space.share({
           swarmKey: PublicKey.from(env.params.config.invitationTopic),
           authMethod: Invitation.AuthMethod.NONE,
-          type: Invitation.Type.MULTIUSE,
+          type: Invitation.Type.INTERACTIVE,
+          multiUse: true,
         });
       } else {
         const invitation = this.client.spaces.join({
           swarmKey: PublicKey.from(env.params.config.invitationTopic),
           authMethod: Invitation.AuthMethod.NONE,
-          type: Invitation.Type.MULTIUSE,
+          type: Invitation.Type.INTERACTIVE,
           kind: Invitation.Kind.SPACE,
+          multiUse: true,
         } as any); // TODO(dmaretskyi): Fix types.
         this.space = await new Promise<Space>((resolve) => {
           invitation.subscribe((event) => {

--- a/packages/sdk/client-protocol/src/invitations/encoder.ts
+++ b/packages/sdk/client-protocol/src/invitations/encoder.ts
@@ -5,7 +5,7 @@
 import base from 'base-x';
 
 import { schema } from '@dxos/protocols';
-import { type Invitation } from '@dxos/protocols/proto/dxos/client/services';
+import { Invitation } from '@dxos/protocols/proto/dxos/client/services';
 
 // Encode with URL-safe alpha-numeric characters.
 const base62 = base('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');
@@ -17,7 +17,12 @@ const codec = schema.getCodecForType('dxos.client.services.Invitation');
  */
 export class InvitationEncoder {
   static decode(text: string): Invitation {
-    return codec.decode(base62.decode(text));
+    const decodedInvitation = codec.decode(base62.decode(text));
+    if (decodedInvitation.type === Invitation.Type.MULTIUSE) {
+      decodedInvitation.type = Invitation.Type.INTERACTIVE;
+      decodedInvitation.multiUse = true;
+    }
+    return decodedInvitation;
   }
 
   static encode(invitation: Invitation): string {

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
@@ -76,7 +76,8 @@ export class InvitationsHandler {
       swarmKey = PublicKey.random(),
       persistent = true,
       created = new Date(),
-      lifetime = 86400, // 1 day
+      lifetime = 86400, // 1 day,
+      multiUse = false,
     } = options ?? {};
     const authCode =
       options?.authCode ??
@@ -91,9 +92,10 @@ export class InvitationsHandler {
       swarmKey,
       authCode,
       timeout,
-      persistent,
+      persistent: persistent && type !== Invitation.Type.OFFLINE, // offline invitations are persisted in control feed
       created,
       lifetime,
+      multiUse,
       ...protocol.getInvitationContext(),
     };
 
@@ -162,7 +164,7 @@ export class InvitationsHandler {
               }
               log.trace('dxos.sdk.invitations-handler.host.onOpen', trace.error({ id: traceId, error: err }));
             } finally {
-              if (type !== Invitation.Type.MULTIUSE) {
+              if (!multiUse) {
                 // Wait for graceful close before disposing.
                 await swarmConnection.close();
                 await ctx.dispose();

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
@@ -426,12 +426,3 @@ export class InvitationsHandler {
     return observable;
   }
 }
-
-export const invitationExpired = (invitation: Invitation) => {
-  return (
-    invitation.created &&
-    invitation.lifetime &&
-    invitation.lifetime !== 0 &&
-    invitation.created.getTime() + invitation.lifetime * 1000 < Date.now()
-  );
-};

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-service.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-service.ts
@@ -91,7 +91,7 @@ export class InvitationsServiceImpl implements InvitationsService {
           }
 
           this._createInvitations.delete(invitation.get().invitationId);
-          if (invitation.get().type !== Invitation.Type.MULTIUSE) {
+          if (!invitation.get().multiUse) {
             this._removedCreated.emit(invitation.get());
           }
         },
@@ -148,7 +148,7 @@ export class InvitationsServiceImpl implements InvitationsService {
         () => {
           close();
           this._acceptInvitations.delete(invitation.get().invitationId);
-          if (invitation.get().type !== Invitation.Type.MULTIUSE) {
+          if (!invitation.get().multiUse) {
             this._removedAccepted.emit(invitation.get());
           }
         },

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-service.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-service.ts
@@ -6,7 +6,7 @@ import { Event, scheduleTask } from '@dxos/async';
 import { type AuthenticatingInvitation, type CancellableInvitation } from '@dxos/client-protocol';
 import { Stream } from '@dxos/codec-protobuf';
 import { Context } from '@dxos/context';
-import { type MetadataStore } from '@dxos/echo-pipeline';
+import { hasInvitationExpired, type MetadataStore } from '@dxos/echo-pipeline';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
 import {
@@ -18,7 +18,7 @@ import {
 } from '@dxos/protocols/proto/dxos/client/services';
 
 import { type InvitationProtocol } from './invitation-protocol';
-import { invitationExpired, type InvitationsHandler } from './invitations-handler';
+import { type InvitationsHandler } from './invitations-handler';
 
 /**
  * Adapts invitation service observable to client/service stream.
@@ -103,7 +103,7 @@ export class InvitationsServiceImpl implements InvitationsService {
     const persistentInvitations = this._metadataStore.getInvitations();
 
     // get saved persistent invitations, filter and remove from storage those that have expired.
-    const freshInvitations = persistentInvitations.filter(async (invitation) => !invitationExpired(invitation));
+    const freshInvitations = persistentInvitations.filter(async (invitation) => !hasInvitationExpired(invitation));
 
     const cInvitations = freshInvitations.map((persistentInvitation) => {
       invariant(!this._createInvitations.get(persistentInvitation.invitationId), 'invitation already exists');

--- a/packages/sdk/react-client/src/invitations/useInvitationStatus.ts
+++ b/packages/sdk/react-client/src/invitations/useInvitationStatus.ts
@@ -29,6 +29,7 @@ interface InvitationReducerState {
   id?: string;
   invitationCode?: string;
   authCode?: string;
+  multiUse?: boolean;
 }
 
 export type InvitationAction =
@@ -65,6 +66,7 @@ export type InvitationStatus = {
   type?: Invitation.Type;
   status: Invitation.State;
   haltedAt?: Invitation.State;
+  multiUse?: boolean;
   result: InvitationResult;
   error?: number;
   cancel(): void;
@@ -179,6 +181,7 @@ export const useInvitationStatus = (initialObservable?: CancellableInvitationObs
       connect,
       authenticate,
       id: invitation?.invitationId,
+      multiUse: invitation?.multiUse,
       invitationCode: invitation ? InvitationEncoder.encode(invitation) : undefined,
       authCode: invitation?.authCode,
       authMethod: invitation?.authMethod,

--- a/packages/sdk/shell/src/components/InvitationList/InvitationListItem.tsx
+++ b/packages/sdk/shell/src/components/InvitationList/InvitationListItem.tsx
@@ -96,14 +96,14 @@ export const InvitationListItemImpl = ({
   ...props
 }: InvitationListItemImplProps) => {
   const { t } = useTranslation('os');
-  const { cancel, status: invitationStatus, invitationCode, authCode, type } = propsInvitationStatus;
+  const { cancel, status: invitationStatus, invitationCode, authCode, type, multiUse } = propsInvitationStatus;
 
   const isCancellable = !(
     [Invitation.State.ERROR, Invitation.State.TIMEOUT, Invitation.State.CANCELLED].indexOf(invitationStatus) >= 0
   );
 
   const showShare =
-    type === Invitation.Type.MULTIUSE ||
+    multiUse ||
     [Invitation.State.INIT, Invitation.State.CONNECTING, Invitation.State.CONNECTED].indexOf(invitationStatus) >= 0;
 
   const showAuthCode = invitationStatus === Invitation.State.READY_FOR_AUTHENTICATION;
@@ -147,9 +147,9 @@ export const InvitationListItemImpl = ({
       classNames={['flex gap-2 pis-3 pie-1 items-center relative', props.classNames]}
     >
       <ListItem.Heading classNames='sr-only'>
-        {t(type === Invitation.Type.MULTIUSE ? 'invite many list item label' : 'invite one list item label')}
+        {t(multiUse ? 'invite many list item label' : 'invite one list item label')}
       </ListItem.Heading>
-      {type === Invitation.Type.MULTIUSE && (
+      {multiUse && (
         <AvatarStackEffect status={avatarStatus} animation={avatarAnimation} reverseEffects={reverseEffects} />
       )}
       <Tooltip.Root>
@@ -162,7 +162,7 @@ export const InvitationListItemImpl = ({
         </Avatar.Root>
         <Tooltip.Portal>
           <Tooltip.Content side='left' classNames='z-[70]'>
-            {t(type === Invitation.Type.MULTIUSE ? 'invite many qr label' : 'invite one qr label')}
+            {t(multiUse ? 'invite many qr label' : 'invite one qr label')}
             <Tooltip.Arrow />
           </Tooltip.Content>
         </Tooltip.Portal>

--- a/packages/sdk/shell/src/components/InvitationList/InvitationListItem.tsx
+++ b/packages/sdk/shell/src/components/InvitationList/InvitationListItem.tsx
@@ -96,7 +96,7 @@ export const InvitationListItemImpl = ({
   ...props
 }: InvitationListItemImplProps) => {
   const { t } = useTranslation('os');
-  const { cancel, status: invitationStatus, invitationCode, authCode, type, multiUse } = propsInvitationStatus;
+  const { cancel, status: invitationStatus, invitationCode, authCode, multiUse } = propsInvitationStatus;
 
   const isCancellable = !(
     [Invitation.State.ERROR, Invitation.State.TIMEOUT, Invitation.State.CANCELLED].indexOf(invitationStatus) >= 0

--- a/packages/sdk/shell/src/panels/IdentityPanel/useAgentHandlers.ts
+++ b/packages/sdk/shell/src/panels/IdentityPanel/useAgentHandlers.ts
@@ -67,7 +67,11 @@ export const useAgentHandlers = ({
     invitations.forEach((invitation) => invitation.cancel());
 
     // TODO(nf): do this work in the hosting provider client?
-    const invitation = client.halo.share({ type: Invitation.Type.MULTIUSE, authMethod: Invitation.AuthMethod.NONE });
+    const invitation = client.halo.share({
+      type: Invitation.Type.INTERACTIVE,
+      authMethod: Invitation.AuthMethod.NONE,
+      multiUse: true,
+    });
 
     invitation.subscribe(handleAgentCreate);
   };

--- a/packages/sdk/shell/src/panels/SpacePanel/steps/SpaceManager.tsx
+++ b/packages/sdk/shell/src/panels/SpacePanel/steps/SpaceManager.tsx
@@ -59,6 +59,7 @@ export const SpaceManager = (props: SpaceManagerProps) => {
         const invitation = space.share?.({
           type: Invitation.Type.INTERACTIVE,
           authMethod: Invitation.AuthMethod.SHARED_SECRET,
+          multiUse: false,
           target,
         });
         if (invitation && config.values.runtime?.app?.env?.DX_ENVIRONMENT !== 'production') {
@@ -72,8 +73,9 @@ export const SpaceManager = (props: SpaceManagerProps) => {
       icon: UsersThree,
       onClick: useCallback(() => {
         const invitation = space.share?.({
-          type: Invitation.Type.MULTIUSE,
+          type: Invitation.Type.INTERACTIVE,
           authMethod: Invitation.AuthMethod.NONE,
+          multiUse: true,
           target,
         });
         if (invitation && config.values.runtime?.app?.env?.DX_ENVIRONMENT !== 'production') {

--- a/packages/sdk/shell/src/steps/InvitationManager.tsx
+++ b/packages/sdk/shell/src/steps/InvitationManager.tsx
@@ -43,13 +43,13 @@ export const InvitationManager = ({
   active,
   send,
   status,
-  type,
+  multiUse,
   authCode,
   id = '0',
 }: InvitationManagerProps) => {
   const { t } = useTranslation('os');
   const qrLabel = useId('invitation-manager__qr-code');
-  const statusValue = authCode == null ? 0 : invitationStatusValue.get(status!) ?? 0;
+  const statusValue = multiUse ? 0 : invitationStatusValue.get(status!) ?? 0;
   const showAuthCode = statusValue === 3;
   const emoji = hexToEmoji(id);
   const activeView = useMemo(() => {
@@ -69,7 +69,7 @@ export const InvitationManager = ({
         <Viewport.Views>
           <InvitationManagerView id='showing qr' emoji={emoji}>
             <p className='text-sm mlb-1 font-normal text-center'>
-              {t(authCode == null ? 'invite many qr label' : 'invite one qr label')}
+              {t(multiUse ? 'invite many qr label' : 'invite one qr label')}
             </p>
             <div role='none' className={mx(descriptionText, 'is-full max-is-[14rem] relative')}>
               <QR

--- a/packages/sdk/shell/src/steps/InvitationManager.tsx
+++ b/packages/sdk/shell/src/steps/InvitationManager.tsx
@@ -6,7 +6,7 @@ import { Check, X } from '@phosphor-icons/react';
 import React, { useMemo } from 'react';
 import { QR } from 'react-qr-rounded';
 
-import { type InvitationStatus, Invitation } from '@dxos/react-client/invitations';
+import { type InvitationStatus } from '@dxos/react-client/invitations';
 import { useId, useTranslation } from '@dxos/react-ui';
 import { descriptionText, getSize, mx } from '@dxos/react-ui-theme';
 import { hexToEmoji } from '@dxos/util';
@@ -49,7 +49,7 @@ export const InvitationManager = ({
 }: InvitationManagerProps) => {
   const { t } = useTranslation('os');
   const qrLabel = useId('invitation-manager__qr-code');
-  const statusValue = type === Invitation.Type.MULTIUSE ? 0 : invitationStatusValue.get(status!) ?? 0;
+  const statusValue = authCode == null ? 0 : invitationStatusValue.get(status!) ?? 0;
   const showAuthCode = statusValue === 3;
   const emoji = hexToEmoji(id);
   const activeView = useMemo(() => {
@@ -69,7 +69,7 @@ export const InvitationManager = ({
         <Viewport.Views>
           <InvitationManagerView id='showing qr' emoji={emoji}>
             <p className='text-sm mlb-1 font-normal text-center'>
-              {t(type === Invitation.Type.MULTIUSE ? 'invite many qr label' : 'invite one qr label')}
+              {t(authCode == null ? 'invite many qr label' : 'invite one qr label')}
             </p>
             <div role='none' className={mx(descriptionText, 'is-full max-is-[14rem] relative')}>
               <QR


### PR DESCRIPTION
### Details

A small refactoring: make multiuse into a separate flag instead of invitation type.
Both offline and interactive invitations can be multiuse.
Tested on a local composer build.

re #6301