### PR TITLE
fix(react-ui-stack): Spread props onto Stack root

### DIFF
--- a/packages/ui/react-ui-stack/src/components/Stack.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack.tsx
@@ -131,7 +131,7 @@ export const Stack = ({
 };
 
 const StackTile: MosaicTileComponent<StackItem, HTMLOListElement> = forwardRef(
-  ({ classNames, path, isOver, item: { items }, itemContext }, forwardedRef) => {
+  ({ classNames, path, isOver, item: { items }, itemContext, type: _type, ...props }, forwardedRef) => {
     const { t } = useTranslation(translationKey);
     const { Component, type } = useContainer();
     const domAttributes = useArrowNavigationGroup({ axis: 'grid' });
@@ -151,6 +151,7 @@ const StackTile: MosaicTileComponent<StackItem, HTMLOListElement> = forwardRef(
           classNames,
         )}
         {...(!activeItem && domAttributes)}
+        {...props}
       >
         {items.length > 0 ? (
           <Mosaic.SortableContext items={items} direction='vertical'>


### PR DESCRIPTION
This PR fixes an e2e regression caused by not spreading props onto Stack’s root.  This restores e2e testing for `react-ui-stack` and the `stack.spec` of `composer-app`.

<img width="633" alt="Screenshot 2024-04-16 at 16 05 42" src="https://github.com/dxos/dxos/assets/855039/3370c25f-3d1b-4d3c-85ae-46d61d29635f">

<img width="1436" alt="Screenshot 2024-04-16 at 16 03 51" src="https://github.com/dxos/dxos/assets/855039/3316d2b9-e018-4006-803e-876ce554d666">
