### PR TITLE
fix(test-bench): Table virtualiser height estimate

### DIFF
--- a/packages/apps/testbench-app/src/components/ItemTable.tsx
+++ b/packages/apps/testbench-app/src/components/ItemTable.tsx
@@ -42,6 +42,7 @@ export const ItemTable = <T extends EchoReactiveObject<any>>({ schema, objects =
         stickyHeader
         border
         getScrollElement={() => containerRef.current}
+        estimatedRowHeight={29}
       />
     </div>
   );

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -232,7 +232,7 @@ const UnvirtualizedTableContent = () => {
 const VirtualizedTableContent = ({
   getScrollElement,
 }: Pick<VirtualizerOptions<Element, Element>, 'getScrollElement'>) => {
-  const { table } = useTableContext();
+  const { table, estimatedRowHeight } = useTableContext();
 
   const centerRows = table.getCenterRows();
   let pinnedRows = [] as Row<unknown>[];
@@ -249,7 +249,7 @@ const VirtualizedTableContent = ({
     getScrollElement,
     count: centerRows.length,
     overscan: 8,
-    estimateSize: () => 40,
+    estimateSize: () => estimatedRowHeight ?? 40,
   });
 
   const virtualRows = getVirtualItems();

--- a/packages/ui/react-ui-table/src/components/Table/props.ts
+++ b/packages/ui/react-ui-table/src/components/Table/props.ts
@@ -53,6 +53,7 @@ export type TableProps<
       // `table` element props
       classNames: ClassNameValue;
       pinLastRow: boolean;
+      estimatedRowHeight: number;
     } & Pick<VirtualizerOptions<ScrollElement, ItemElement>, 'getScrollElement'>
   >;
 
@@ -60,7 +61,7 @@ export type { RowSelectionState, VisibilityState, TableColumnDef, KeyValue };
 
 export type TableContextValue<TData> = TableFlags &
   TableCurrent<TData> &
-  Pick<TableProps<TData>, 'keyAccessor'> & {
+  Pick<TableProps<TData>, 'keyAccessor' | 'estimatedRowHeight'> & {
     table: Table<TData>;
     isGrid: boolean;
   };


### PR DESCRIPTION
Provide an option to set the estimated row height for the table virtualiser.

Fixes an issue in the testbench where the rows start to drift and offset.

We should probably sample rows and measure them in JS but this is a quick fix for now.