### PR TITLE
refactor(halo): extracted invitation management into serviceContext from serviceHost

### DIFF
--- a/packages/core/protocols/src/proto/dxos/client/services.proto
+++ b/packages/core/protocols/src/proto/dxos/client/services.proto
@@ -551,7 +551,6 @@ service InvitationsService {
   rpc Authenticate(AuthenticationRequest) returns (google.protobuf.Empty);
   rpc CancelInvitation(CancelInvitationRequest) returns (google.protobuf.Empty);
   rpc QueryInvitations(google.protobuf.Empty) returns (stream QueryInvitationsResponse);
-  rpc LoadPersistentInvitations(google.protobuf.Empty) returns (LoadPersistentInvitationsResponse);
 }
 
 //

--- a/packages/sdk/client-services/src/packlets/invitations/index.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/index.ts
@@ -7,3 +7,4 @@ export * from './invitation-protocol';
 export * from './invitations-handler';
 export * from './invitations-service';
 export * from './space-invitation-protocol';
+export * from './invitations-manager';

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
@@ -193,7 +193,7 @@ export class InvitationsHandler {
       return extension;
     };
 
-    if (invitation.lifetime && invitation.created && invitation.lifetime !== 0) {
+    if (invitation.lifetime && invitation.created) {
       if (invitation.created.getTime() + invitation.lifetime * 1000 < Date.now()) {
         log.warn('invitation has already expired');
       } else {
@@ -251,7 +251,6 @@ export class InvitationsHandler {
     const { timeout = INVITATION_TIMEOUT } = invitation;
     invariant(protocol);
 
-    // TODO(nf): duplicate check in InvitationsService
     if (deviceProfile) {
       invariant(invitation.kind === Invitation.Kind.DEVICE, 'deviceProfile provided for non-device invitation');
     }

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-manager.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-manager.ts
@@ -1,0 +1,197 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { Event } from '@dxos/async';
+import type { AuthenticatingInvitation, CancellableInvitation } from '@dxos/client-protocol';
+import { type Context } from '@dxos/context';
+import { hasInvitationExpired, type MetadataStore } from '@dxos/echo-pipeline';
+import { invariant } from '@dxos/invariant';
+import { log } from '@dxos/log';
+import {
+  type AcceptInvitationRequest,
+  type Invitation,
+  type AuthenticationRequest,
+} from '@dxos/protocols/proto/dxos/client/services';
+
+import type { InvitationProtocol } from './invitation-protocol';
+import type { InvitationsHandler } from './invitations-handler';
+
+/**
+ * Entry point for creating and accepting invitations, keeps track of existing invitation set and
+ * emits events when the set changes.
+ */
+export class InvitationsManager {
+  private readonly _createInvitations = new Map<string, CancellableInvitation>();
+  private readonly _acceptInvitations = new Map<string, AuthenticatingInvitation>();
+
+  public readonly invitationCreated = new Event<Invitation>();
+  public readonly invitationAccepted = new Event<Invitation>();
+  public readonly removedCreated = new Event<Invitation>();
+  public readonly removedAccepted = new Event<Invitation>();
+  public readonly saved = new Event<Invitation>();
+
+  private readonly _persistentInvitationsLoadedEvent = new Event();
+  private _persistentInvitationsLoaded = false;
+
+  constructor(
+    private readonly _invitationsHandler: InvitationsHandler,
+    private readonly _getHandler: (invitation: Invitation) => InvitationProtocol,
+    private readonly _metadataStore: MetadataStore,
+  ) {}
+
+  createInvitation(options: Invitation): CancellableInvitation {
+    const existingInvitation = this._createInvitations.get(options.invitationId);
+    if (existingInvitation) {
+      return existingInvitation;
+    }
+
+    const handler = this._getHandler(options);
+    const invitation = this._invitationsHandler.createInvitation(handler, options);
+    this._createInvitations.set(invitation.get().invitationId, invitation);
+    this.invitationCreated.emit(invitation.get());
+
+    const saveInvitationTask = invitation.get().persistent
+      ? this._safePersistInBackground(invitation)
+      : Promise.resolve();
+
+    // onComplete is called on cancel, expiration, or redemption of a single-use invitation
+    this._onInvitationComplete(invitation, async () => {
+      this._createInvitations.delete(invitation.get().invitationId);
+      this.removedCreated.emit(invitation.get());
+      if (invitation.get().persistent) {
+        await saveInvitationTask;
+        await this._safeDeleteInvitation(invitation.get());
+      }
+    });
+
+    return invitation;
+  }
+
+  async loadPersistentInvitations(): Promise<{ invitations: Invitation[] }> {
+    if (this._persistentInvitationsLoaded) {
+      const invitations = this.getCreatedInvitations().filter((i) => i.persistent);
+      return { invitations };
+    }
+    try {
+      const persistentInvitations = this._metadataStore.getInvitations();
+      // get saved persistent invitations, filter and remove from storage those that have expired.
+      const freshInvitations = persistentInvitations.filter((invitation) => !hasInvitationExpired(invitation));
+
+      const cInvitations = freshInvitations.map((persistentInvitation) => {
+        invariant(!this._createInvitations.get(persistentInvitation.invitationId), 'invitation already exists');
+        return this.createInvitation({ ...persistentInvitation, persistent: false }).get();
+      });
+
+      return { invitations: cInvitations };
+    } catch (err) {
+      log.catch(err);
+      return { invitations: [] };
+    } finally {
+      this._persistentInvitationsLoadedEvent.emit();
+      this._persistentInvitationsLoaded = true;
+    }
+  }
+
+  acceptInvitation(request: AcceptInvitationRequest): AuthenticatingInvitation {
+    const options = request.invitation;
+    const existingInvitation = this._acceptInvitations.get(options.invitationId);
+    if (existingInvitation) {
+      return existingInvitation;
+    }
+
+    const handler = this._getHandler(options);
+    const invitation = this._invitationsHandler.acceptInvitation(handler, options, request.deviceProfile);
+    this._acceptInvitations.set(invitation.get().invitationId, invitation);
+    this.invitationAccepted.emit(invitation.get());
+
+    this._onInvitationComplete(invitation, () => {
+      this._acceptInvitations.delete(invitation.get().invitationId);
+      this.removedAccepted.emit(invitation.get());
+    });
+
+    return invitation;
+  }
+
+  async authenticate({ invitationId, authCode }: AuthenticationRequest): Promise<void> {
+    log('authenticating...');
+    invariant(invitationId);
+    const observable = this._acceptInvitations.get(invitationId);
+    if (!observable) {
+      log.warn('invalid invitation', { invitationId });
+    } else {
+      await observable.authenticate(authCode);
+    }
+  }
+
+  async cancelInvitation({ invitationId }: { invitationId: string }): Promise<void> {
+    log('cancelInvitation...', { invitationId });
+    invariant(invitationId);
+    const created = this._createInvitations.get(invitationId);
+    if (created) {
+      // remove from storage before modifying in-memory state, higher chance of failing
+      if (created.get().persistent) {
+        await this._metadataStore.removeInvitation(invitationId);
+      }
+      await created.cancel();
+      this._createInvitations.delete(invitationId);
+      this.removedCreated.emit(created.get());
+      return;
+    }
+
+    const accepted = this._acceptInvitations.get(invitationId);
+    if (accepted) {
+      await accepted.cancel();
+      this._acceptInvitations.delete(invitationId);
+      this.removedAccepted.emit(accepted.get());
+    }
+  }
+
+  getCreatedInvitations(): Invitation[] {
+    return [...this._createInvitations.values()].map((i) => i.get());
+  }
+
+  getAcceptedInvitations(): Invitation[] {
+    return [...this._acceptInvitations.values()].map((i) => i.get());
+  }
+
+  onPersistentInvitationsLoaded(ctx: Context, callback: () => void) {
+    if (this._persistentInvitationsLoaded) {
+      callback();
+    } else {
+      this._persistentInvitationsLoadedEvent.once(ctx, () => callback());
+    }
+  }
+
+  private _safePersistInBackground(invitation: CancellableInvitation): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(async () => {
+        try {
+          await this._metadataStore.addInvitation(invitation.get());
+          this.saved.emit(invitation.get());
+        } catch (err: any) {
+          log.catch(err);
+          await invitation.cancel();
+        } finally {
+          resolve();
+        }
+      });
+    });
+  }
+
+  private async _safeDeleteInvitation(invitation: Invitation): Promise<void> {
+    try {
+      await this._metadataStore.removeInvitation(invitation.invitationId);
+    } catch (err) {
+      log.catch(err);
+    }
+  }
+
+  private _onInvitationComplete(invitation: CancellableInvitation, callback: () => void) {
+    invitation.subscribe(
+      () => {},
+      () => {},
+      callback,
+    );
+  }
+}

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-service.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-service.ts
@@ -2,43 +2,22 @@
 // Copyright 2022 DXOS.org
 //
 
-import { Event, scheduleTask } from '@dxos/async';
-import { type AuthenticatingInvitation, type CancellableInvitation } from '@dxos/client-protocol';
 import { Stream } from '@dxos/codec-protobuf';
-import { Context } from '@dxos/context';
-import { hasInvitationExpired, type MetadataStore } from '@dxos/echo-pipeline';
-import { invariant } from '@dxos/invariant';
-import { log } from '@dxos/log';
 import {
   type AuthenticationRequest,
   type AcceptInvitationRequest,
-  Invitation,
+  type Invitation,
   type InvitationsService,
   QueryInvitationsResponse,
 } from '@dxos/protocols/proto/dxos/client/services';
 
-import { type InvitationProtocol } from './invitation-protocol';
-import { type InvitationsHandler } from './invitations-handler';
+import { type InvitationsManager } from './invitations-manager';
 
 /**
  * Adapts invitation service observable to client/service stream.
  */
 export class InvitationsServiceImpl implements InvitationsService {
-  private readonly _createInvitations = new Map<string, CancellableInvitation>();
-  private readonly _acceptInvitations = new Map<string, AuthenticatingInvitation>();
-  private readonly _invitationCreated = new Event<Invitation>();
-  private readonly _invitationAccepted = new Event<Invitation>();
-  private readonly _removedCreated = new Event<Invitation>();
-  private readonly _removedAccepted = new Event<Invitation>();
-  private readonly _saved = new Event<Invitation>();
-  private readonly _persistentInvitationsLoadedEvent = new Event();
-  private _persistentInvitationsLoaded = false;
-
-  constructor(
-    private readonly _invitationsHandler: InvitationsHandler,
-    private readonly _getHandler: (invitation: Invitation) => InvitationProtocol,
-    private readonly _metadataStore: MetadataStore,
-  ) {}
+  constructor(private readonly _invitationsManager: InvitationsManager) {}
 
   // TODO(burdon): Guest/host label.
   getLoggingContext() {
@@ -48,148 +27,31 @@ export class InvitationsServiceImpl implements InvitationsService {
   }
 
   createInvitation(options: Invitation): Stream<Invitation> {
-    let invitation: CancellableInvitation;
-
-    const savePersistentInvitationCtx = new Context();
-    const existingInvitation = this._createInvitations.get(options.invitationId);
-    if (existingInvitation) {
-      invitation = existingInvitation;
-    } else {
-      const handler = this._getHandler(options);
-      invitation = this._invitationsHandler.createInvitation(handler, options);
-      this._createInvitations.set(invitation.get().invitationId, invitation);
-      this._invitationCreated.emit(invitation.get());
-    }
-
+    const invitation = this._invitationsManager.createInvitation(options);
     return new Stream<Invitation>(({ next, close }) => {
-      if (invitation.get().persistent) {
-        scheduleTask(savePersistentInvitationCtx, async () => {
-          try {
-            await this._metadataStore.addInvitation(invitation.get());
-            this._saved.emit(invitation.get());
-          } catch (err: any) {
-            close(err);
-          }
-        });
-      }
-      invitation.subscribe(
-        (invitation) => {
-          next(invitation);
-        },
-        async (err: Error) => {
-          await savePersistentInvitationCtx.dispose();
-
-          // TODO(nf): also remove from storage?
-          close(err);
-        },
-        async () => {
-          close();
-          if (invitation.get().persistent) {
-            await savePersistentInvitationCtx.dispose();
-            // TODO(nf): remove on all complete conditions?
-            await this._metadataStore.removeInvitation(invitation.get().invitationId);
-          }
-
-          this._createInvitations.delete(invitation.get().invitationId);
-          if (!invitation.get().multiUse) {
-            this._removedCreated.emit(invitation.get());
-          }
-        },
-      );
+      invitation.subscribe(next, close, close);
     });
   }
 
-  async loadPersistentInvitations() {
-    const persistentInvitations = this._metadataStore.getInvitations();
-
-    // get saved persistent invitations, filter and remove from storage those that have expired.
-    const freshInvitations = persistentInvitations.filter(async (invitation) => !hasInvitationExpired(invitation));
-
-    const cInvitations = freshInvitations.map((persistentInvitation) => {
-      invariant(!this._createInvitations.get(persistentInvitation.invitationId), 'invitation already exists');
-
-      const handler = this._getHandler(persistentInvitation);
-      const invitation = this._invitationsHandler.createInvitation(handler, persistentInvitation);
-      this._createInvitations.set(invitation.get().invitationId, invitation);
-      this._invitationCreated.emit(invitation.get());
-      return persistentInvitation;
-    });
-    this._persistentInvitationsLoadedEvent.emit();
-    this._persistentInvitationsLoaded = true;
-    return { invitations: cInvitations };
-  }
-
-  acceptInvitation({ invitation: options, deviceProfile }: AcceptInvitationRequest): Stream<Invitation> {
-    let invitation: AuthenticatingInvitation;
-
-    // TODO(nf): duplicate check in InvitationHandler
-    if (deviceProfile) {
-      invariant(options.kind === Invitation.Kind.DEVICE, 'deviceProfile provided for non-device invitation');
-    }
-
-    const existingInvitation = this._acceptInvitations.get(options.invitationId);
-    if (existingInvitation) {
-      invitation = existingInvitation;
-    } else {
-      const handler = this._getHandler(options);
-      invitation = this._invitationsHandler.acceptInvitation(handler, options, deviceProfile);
-      this._acceptInvitations.set(invitation.get().invitationId, invitation);
-      this._invitationAccepted.emit(invitation.get());
-    }
-
+  acceptInvitation(request: AcceptInvitationRequest): Stream<Invitation> {
+    const invitation = this._invitationsManager.acceptInvitation(request);
     return new Stream<Invitation>(({ next, close }) => {
-      invitation.subscribe(
-        (invitation) => {
-          next(invitation);
-        },
-        (err: Error) => {
-          close(err);
-        },
-        () => {
-          close();
-          this._acceptInvitations.delete(invitation.get().invitationId);
-          if (!invitation.get().multiUse) {
-            this._removedAccepted.emit(invitation.get());
-          }
-        },
-      );
+      invitation.subscribe(next, close, close);
     });
   }
 
-  async authenticate({ invitationId, authCode }: AuthenticationRequest): Promise<void> {
-    log('authenticating...');
-    invariant(invitationId);
-    const observable = this._acceptInvitations.get(invitationId);
-    if (!observable) {
-      log.warn('invalid invitation', { invitationId });
-    } else {
-      await observable.authenticate(authCode);
-    }
+  async authenticate(request: AuthenticationRequest): Promise<void> {
+    return this._invitationsManager.authenticate(request);
   }
 
-  async cancelInvitation({ invitationId }: { invitationId: string }): Promise<void> {
-    log('cancelInvitation...', { invitationId });
-    invariant(invitationId);
-    const created = this._createInvitations.get(invitationId);
-    const accepted = this._acceptInvitations.get(invitationId);
-    if (created) {
-      await created.cancel();
-      this._createInvitations.delete(invitationId);
-      this._removedCreated.emit(created.get());
-      if (created.get().persistent) {
-        await this._metadataStore.removeInvitation(created.get().invitationId);
-      }
-    } else if (accepted) {
-      await accepted.cancel();
-      this._acceptInvitations.delete(invitationId);
-      this._removedAccepted.emit(accepted.get());
-    }
+  async cancelInvitation(request: { invitationId: string }): Promise<void> {
+    return this._invitationsManager.cancelInvitation(request);
   }
 
   queryInvitations(): Stream<QueryInvitationsResponse> {
     return new Stream<QueryInvitationsResponse>(({ next, ctx }) => {
       // Push added invitations to the stream.
-      this._invitationCreated.on(ctx, (invitation) => {
+      this._invitationsManager.invitationCreated.on(ctx, (invitation) => {
         next({
           action: QueryInvitationsResponse.Action.ADDED,
           type: QueryInvitationsResponse.Type.CREATED,
@@ -197,7 +59,7 @@ export class InvitationsServiceImpl implements InvitationsService {
         });
       });
 
-      this._invitationAccepted.on(ctx, (invitation) => {
+      this._invitationsManager.invitationAccepted.on(ctx, (invitation) => {
         next({
           action: QueryInvitationsResponse.Action.ADDED,
           type: QueryInvitationsResponse.Type.ACCEPTED,
@@ -206,7 +68,7 @@ export class InvitationsServiceImpl implements InvitationsService {
       });
 
       // Push removed invitations to the stream.
-      this._removedCreated.on(ctx, (invitation) => {
+      this._invitationsManager.removedCreated.on(ctx, (invitation) => {
         next({
           action: QueryInvitationsResponse.Action.REMOVED,
           type: QueryInvitationsResponse.Type.CREATED,
@@ -214,7 +76,7 @@ export class InvitationsServiceImpl implements InvitationsService {
         });
       });
 
-      this._removedAccepted.on(ctx, (invitation) => {
+      this._invitationsManager.removedAccepted.on(ctx, (invitation) => {
         next({
           action: QueryInvitationsResponse.Action.REMOVED,
           type: QueryInvitationsResponse.Type.ACCEPTED,
@@ -223,7 +85,7 @@ export class InvitationsServiceImpl implements InvitationsService {
       });
 
       // used only for testing
-      this._saved.on(ctx, (invitation) => {
+      this._invitationsManager.saved.on(ctx, (invitation) => {
         next({
           action: QueryInvitationsResponse.Action.SAVED,
           type: QueryInvitationsResponse.Type.CREATED,
@@ -235,33 +97,24 @@ export class InvitationsServiceImpl implements InvitationsService {
       next({
         action: QueryInvitationsResponse.Action.ADDED,
         type: QueryInvitationsResponse.Type.CREATED,
-        invitations: Array.from(this._createInvitations.values()).map((invitation) => invitation.get()),
+        invitations: this._invitationsManager.getCreatedInvitations(),
         existing: true,
       });
 
       next({
         action: QueryInvitationsResponse.Action.ADDED,
         type: QueryInvitationsResponse.Type.ACCEPTED,
-        invitations: Array.from(this._acceptInvitations.values()).map((invitation) => invitation.get()),
+        invitations: this._invitationsManager.getAcceptedInvitations(),
         existing: true,
       });
 
-      if (this._persistentInvitationsLoaded) {
+      this._invitationsManager.onPersistentInvitationsLoaded(ctx, () => {
         next({
           action: QueryInvitationsResponse.Action.LOAD_COMPLETE,
           type: QueryInvitationsResponse.Type.CREATED,
           // TODO(nf): populate with invitations
         });
-      } else {
-        this._persistentInvitationsLoadedEvent.on(ctx, () => {
-          next({
-            action: QueryInvitationsResponse.Action.LOAD_COMPLETE,
-            type: QueryInvitationsResponse.Type.CREATED,
-            // TODO(nf): populate with invitations
-          });
-        });
-      }
-
+      });
       // TODO(nf): expired invitations?
     });
   }

--- a/packages/sdk/client-services/src/packlets/services/service-host.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-host.ts
@@ -272,11 +272,7 @@ export class ClientServicesHost {
         (profile) => this._serviceContext.broadcastProfileUpdate(profile),
       ),
 
-      InvitationsService: new InvitationsServiceImpl(
-        this._serviceContext.invitations,
-        (invitation) => this._serviceContext.getInvitationHandler(invitation),
-        this._serviceContext.metadataStore,
-      ),
+      InvitationsService: new InvitationsServiceImpl(this._serviceContext.invitationsManager),
 
       DevicesService: new DevicesServiceImpl(this._serviceContext.identityManager),
 
@@ -310,11 +306,6 @@ export class ClientServicesHost {
     });
 
     await this._serviceContext.open(ctx);
-    // TODO(nf): move to InvitationManager in ServiceContext?
-    invariant(this.serviceRegistry.services.InvitationsService);
-    const loadedInvitations = await this.serviceRegistry.services.InvitationsService.loadPersistentInvitations();
-
-    log('loaded persistent invitations', { count: loadedInvitations.invitations?.length });
 
     const devtoolsProxy = this._config?.get('runtime.client.devtoolsProxy');
     if (devtoolsProxy) {


### PR DESCRIPTION
### Motivation

Services use Managers to manage data (Service -> Manager). 
All spaces are created through DataSpaceManager. On space creation, DataSpaceManager will attach a listener of spaceState to handle delegated invitations.
DataSpaceManager shouldn't have access to InvitationService (Service <- Manager). 
Create a class that'll be used by both DataSpaceManager and InvitationService, and that'll manage invitations preventing duplicates.

### Details

* Created `InvitationsManager` and pulled the majority of code from `InvitationsService` there.
* Fixed duplicated subscriptions on `existingInvitation` return (added early return for existing invitations).
* Fixed missing subscription for invitations created in `loadPersistentInvitations` (for `_createInvitations` updates) and `.filter(async (invitation)` always returning true.
* Reordered operations in `cancelInvitation` (remove persistent invitation from metadata store first).