### PR TITLE
Fix(docs): "Edit this page" button broken link #6370

### DIFF
--- a/docs/vuepress.config.ts
+++ b/docs/vuepress.config.ts
@@ -51,7 +51,7 @@ const config: UserConfig = defineUserConfig({
     repo: 'dxos/dxos',
     // TODO(wittjosiah): Use release tag?
     docsBranch: 'main',
-    docsDir: 'docs/docs',
+    docsDir: 'docs/content',
     sidebar: sidebar({
       '/guide/': 'structure',
       '/api/': await apiSidebar(),


### PR DESCRIPTION
One-word change so that "Edit this page" goes to the right place, tested locally on a few pages.
