### PR TITLE
fix(echo): Restore objects when they are re-added to the database

### DIFF
--- a/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
+++ b/packages/core/echo/echo-schema/src/automerge/automerge-db.ts
@@ -223,7 +223,16 @@ export class AutomergeDb {
 
   addCore(core: AutomergeObjectCore) {
     if (core.database) {
-      return; // Already in the database.
+      // Already in the database.
+      if (core.database !== this) {
+        throw new Error('Object already belongs to another database');
+      }
+
+      if (core.isDeleted()) {
+        core.setDeleted(false);
+      }
+
+      return;
     }
 
     invariant(!this._objects.has(core.id));

--- a/packages/core/echo/echo-schema/src/echo-handler/echo-handler.test.ts
+++ b/packages/core/echo/echo-schema/src/echo-handler/echo-handler.test.ts
@@ -205,6 +205,31 @@ describe('Reactive Object with ECHO database', () => {
         expect(query.objects.length).to.eq(1);
       }
     });
+
+    test.only('does not return deleted objects', async () => {
+      const graph = new Hypergraph();
+      graph.runtimeSchemaRegistry.registerSchema(TypedObject);
+      const { db } = await createDatabase(graph);
+      const obj = db.add(create(TypedObject, { string: 'foo' }));
+      const query = db.query(Filter.schema(TypedObject));
+      expect(query.objects.length).to.eq(1);
+
+      db.remove(obj);
+      expect(query.objects.length).to.eq(0);
+    });
+
+    test.only('deleted objects are returned when re-added', async () => {
+      const graph = new Hypergraph();
+      graph.runtimeSchemaRegistry.registerSchema(TypedObject);
+      const { db } = await createDatabase(graph);
+      const obj = db.add(create(TypedObject, { string: 'foo' }));
+      db.remove(obj);
+      const query = db.query(Filter.schema(TypedObject));
+      expect(query.objects.length).to.eq(0);
+
+      db.add(obj);
+      expect(query.objects.length).to.eq(1);
+    });
   });
 
   test('data symbol', async () => {

--- a/packages/core/echo/echo-schema/src/echo-handler/echo-handler.test.ts
+++ b/packages/core/echo/echo-schema/src/echo-handler/echo-handler.test.ts
@@ -206,7 +206,7 @@ describe('Reactive Object with ECHO database', () => {
       }
     });
 
-    test.only('does not return deleted objects', async () => {
+    test('does not return deleted objects', async () => {
       const graph = new Hypergraph();
       graph.runtimeSchemaRegistry.registerSchema(TypedObject);
       const { db } = await createDatabase(graph);
@@ -218,7 +218,7 @@ describe('Reactive Object with ECHO database', () => {
       expect(query.objects.length).to.eq(0);
     });
 
-    test.only('deleted objects are returned when re-added', async () => {
+    test('deleted objects are returned when re-added', async () => {
       const graph = new Hypergraph();
       graph.runtimeSchemaRegistry.registerSchema(TypedObject);
       const { db } = await createDatabase(graph);


### PR DESCRIPTION
This functionality is needed to fix some of the bad behaviour around deleting threads where they end up visible in the navtree.