### PR TITLE
feat(halo): delegated invitations

### DIFF
--- a/packages/apps/plugins/plugin-debug/src/components/SchemaList.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/SchemaList.tsx
@@ -22,13 +22,16 @@ export const SchemaList: FC<{ space: Space; onCreate?: (schema: any /* Schema */
 }) => {
   const [schemaCount, setSchemaCount] = useState<Record<string, number>>({});
   const [data, setData] = useState<SchemaRecord[]>([]);
-  space.db.schemaRegistry.getAll().then((objects) => {
-    setData(
-      objects
-        .filter((object) => object.typename)
-        .map((schema) => ({ id: schema.id, typename: schema.typename, count: schemaCount[schema.id] ?? 1 })),
-    );
-  });
+  void space.db.schemaRegistry
+    .getAll()
+    .then((objects) => {
+      setData(
+        objects
+          .filter((object) => object.typename)
+          .map((schema) => ({ id: schema.id, typename: schema.typename, count: schemaCount[schema.id] ?? 1 })),
+      );
+    })
+    .catch();
 
   const handleUpdateCount = (record: SchemaRecord, _: string, count: number | undefined) => {
     setSchemaCount((schemaCount) => Object.assign({}, schemaCount, { [record.id]: count }));

--- a/packages/apps/plugins/plugin-debug/src/testing/generator.ts
+++ b/packages/apps/plugins/plugin-debug/src/testing/generator.ts
@@ -55,7 +55,7 @@ export class Generator {
   }
 
   createObjects(count: Partial<Record<TestSchemaType, number>> = defaultCount) {
-    this._generator.createObjects(count).catch();
+    void this._generator.createObjects(count).catch();
   }
 
   createDocument() {

--- a/packages/apps/plugins/plugin-explorer/src/components/Graph/Graph.stories.tsx
+++ b/packages/apps/plugins/plugin-explorer/src/components/Graph/Graph.stories.tsx
@@ -27,7 +27,7 @@ const Story = () => {
 
     const generator = createSpaceObjectGenerator(space);
     generator.addSchemas();
-    generator.createObjects({ [TestSchemaType.organization]: 20, [TestSchemaType.contact]: 50 }).catch();
+    void generator.createObjects({ [TestSchemaType.organization]: 20, [TestSchemaType.contact]: 50 }).catch();
 
     const view = space.db.add(create(ViewType, { title: '', type: '' }));
 

--- a/packages/apps/plugins/plugin-grid/src/components/Grid.stories.tsx
+++ b/packages/apps/plugins/plugin-grid/src/components/Grid.stories.tsx
@@ -51,19 +51,22 @@ const DemoGrid = ({
   const [items, setItems] = useState<GridDataItem[]>(
     initialItems ??
       (() => {
-        generator.createObjects(types).then((objects) => {
-          setItems(
-            objects.map((object: any) => {
-              return create(GridItemType, {
-                object,
-                position: {
-                  x: faker.number.int({ min: 0, max: (options.size?.x ?? 1) - 1 }),
-                  y: faker.number.int({ min: 0, max: (options.size?.y ?? 1) - 1 }),
-                },
-              });
-            }),
-          );
-        });
+        void generator
+          .createObjects(types)
+          .then((objects) => {
+            setItems(
+              objects.map((object: any) => {
+                return create(GridItemType, {
+                  object,
+                  position: {
+                    x: faker.number.int({ min: 0, max: (options.size?.x ?? 1) - 1 }),
+                    y: faker.number.int({ min: 0, max: (options.size?.y ?? 1) - 1 }),
+                  },
+                });
+              }),
+            );
+          })
+          .catch();
         // TODO(wittjosiah): Use generator to create positions.
         return [];
       }),

--- a/packages/apps/plugins/plugin-script/src/components/ScriptBlock.stories.tsx
+++ b/packages/apps/plugins/plugin-script/src/components/ScriptBlock.stories.tsx
@@ -35,7 +35,7 @@ const Story = () => {
   useEffect(() => {
     const generator = createSpaceObjectGenerator(client.spaces.default);
     generator.addSchemas();
-    generator.createObjects({ [TestSchemaType.organization]: 20, [TestSchemaType.contact]: 50 }).catch();
+    void generator.createObjects({ [TestSchemaType.organization]: 20, [TestSchemaType.contact]: 50 }).catch();
   }, []);
 
   // TODO(dmaretskyi): Not sure how to provide `containerUrl` here since the html now lives in composer-app.

--- a/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.stories.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.stories.tsx
@@ -27,7 +27,7 @@ const useTable = () => {
     const space = client.spaces.default;
     const generator = createSpaceObjectGenerator(space);
     generator.addSchemas();
-    generator.createObjects({ [TestSchemaType.project]: 6 }).catch();
+    void generator.createObjects({ [TestSchemaType.project]: 6 }).catch();
 
     const graph = (client as any)._graph as Hypergraph;
 

--- a/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
@@ -50,7 +50,7 @@ export const ObjectTable: FC<ObjectTableProps> = ({ table, role, stickyHeader, g
 
   useEffect(() => {
     if (space) {
-      space.db.schemaRegistry.getAll().then(setSchemas);
+      void space.db.schemaRegistry.getAll().then(setSchemas).catch();
     }
   }, [showSettings, space]);
 

--- a/packages/apps/plugins/plugin-table/src/components/TableSettings/TableSettings.stories.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/TableSettings/TableSettings.stories.tsx
@@ -38,7 +38,7 @@ const Story = () => {
 
     setTable(space.db.add(create(TableType, { title: 'Table', props: [] })));
 
-    space.db.schemaRegistry.getAll().then(setSchemas);
+    void space.db.schemaRegistry.getAll().then(setSchemas).catch();
   }, []);
 
   const handleClose = (success: boolean) => {

--- a/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
@@ -4,8 +4,13 @@
 
 import { DeferredTask, sleepWithContext, trackLeaks } from '@dxos/async';
 import { Context } from '@dxos/context';
-import { SpaceStateMachine, type SpaceState, type MemberInfo, type FeedInfo } from '@dxos/credentials';
-import { type DelegateInvitationCredential } from '@dxos/credentials/dist/types/src/state-machine/invitation-state-machine';
+import {
+  SpaceStateMachine,
+  type SpaceState,
+  type MemberInfo,
+  type FeedInfo,
+  type DelegateInvitationCredential,
+} from '@dxos/credentials';
 import { type FeedWrapper } from '@dxos/feed-store';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';

--- a/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
@@ -12,6 +12,7 @@ import { type FeedMessageBlock } from '@dxos/protocols';
 import type { FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
 import { type ControlPipelineSnapshot } from '@dxos/protocols/proto/dxos/echo/metadata';
 import { AdmittedFeed, type Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
+import { type DelegateSpaceInvitation } from '@dxos/protocols/proto/dxos/halo/invitations';
 import { Timeframe } from '@dxos/timeframe';
 import { TimeSeriesCounter, TimeUsageCounter, trace } from '@dxos/tracing';
 import { type AsyncCallback, Callback, tracer } from '@dxos/util';
@@ -50,6 +51,8 @@ export class ControlPipeline {
   public readonly onFeedAdmitted = new Callback<AsyncCallback<FeedInfo>>();
   public readonly onMemberAdmitted: Callback<AsyncCallback<MemberInfo>>;
   public readonly onCredentialProcessed: Callback<AsyncCallback<Credential>>;
+  public readonly onDelegatedInvitation: Callback<AsyncCallback<DelegateSpaceInvitation>>;
+  public readonly onDelegatedInvitationRemoved: Callback<AsyncCallback<DelegateSpaceInvitation>>;
 
   @trace.metricsCounter()
   private _usage = new TimeUsageCounter();
@@ -92,6 +95,8 @@ export class ControlPipeline {
 
     this.onMemberAdmitted = this._spaceStateMachine.onMemberAdmitted;
     this.onCredentialProcessed = this._spaceStateMachine.onCredentialProcessed;
+    this.onDelegatedInvitation = this._spaceStateMachine.onDelegatedInvitation;
+    this.onDelegatedInvitationRemoved = this._spaceStateMachine.onDelegatedInvitationRemoved;
   }
 
   get spaceState(): SpaceState {

--- a/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
+++ b/packages/core/echo/echo-pipeline/src/space/control-pipeline.ts
@@ -5,6 +5,7 @@
 import { DeferredTask, sleepWithContext, trackLeaks } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { SpaceStateMachine, type SpaceState, type MemberInfo, type FeedInfo } from '@dxos/credentials';
+import { type DelegateInvitationCredential } from '@dxos/credentials/dist/types/src/state-machine/invitation-state-machine';
 import { type FeedWrapper } from '@dxos/feed-store';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
@@ -12,7 +13,6 @@ import { type FeedMessageBlock } from '@dxos/protocols';
 import type { FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
 import { type ControlPipelineSnapshot } from '@dxos/protocols/proto/dxos/echo/metadata';
 import { AdmittedFeed, type Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
-import { type DelegateSpaceInvitation } from '@dxos/protocols/proto/dxos/halo/invitations';
 import { Timeframe } from '@dxos/timeframe';
 import { TimeSeriesCounter, TimeUsageCounter, trace } from '@dxos/tracing';
 import { type AsyncCallback, Callback, tracer } from '@dxos/util';
@@ -51,8 +51,8 @@ export class ControlPipeline {
   public readonly onFeedAdmitted = new Callback<AsyncCallback<FeedInfo>>();
   public readonly onMemberAdmitted: Callback<AsyncCallback<MemberInfo>>;
   public readonly onCredentialProcessed: Callback<AsyncCallback<Credential>>;
-  public readonly onDelegatedInvitation: Callback<AsyncCallback<DelegateSpaceInvitation>>;
-  public readonly onDelegatedInvitationRemoved: Callback<AsyncCallback<DelegateSpaceInvitation>>;
+  public readonly onDelegatedInvitation: Callback<AsyncCallback<DelegateInvitationCredential>>;
+  public readonly onDelegatedInvitationRemoved: Callback<AsyncCallback<DelegateInvitationCredential>>;
 
   @trace.metricsCounter()
   private _usage = new TimeUsageCounter();

--- a/packages/core/echo/echo-pipeline/src/space/space-manager.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space-manager.ts
@@ -3,6 +3,7 @@
 //
 
 import { synchronized, trackLeaks } from '@dxos/async';
+import { type DelegateInvitationCredential } from '@dxos/credentials/dist/types/src/state-machine/invitation-state-machine';
 import { failUndefined } from '@dxos/debug';
 import { type FeedStore } from '@dxos/feed-store';
 import { PublicKey } from '@dxos/keys';
@@ -11,7 +12,6 @@ import { type NetworkManager } from '@dxos/network-manager';
 import { trace } from '@dxos/protocols';
 import type { FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
 import { type SpaceMetadata } from '@dxos/protocols/proto/dxos/echo/metadata';
-import { type DelegateSpaceInvitation } from '@dxos/protocols/proto/dxos/halo/invitations';
 import { type Teleport } from '@dxos/teleport';
 import { type BlobStore } from '@dxos/teleport-extension-object-sync';
 import { ComplexMap } from '@dxos/util';
@@ -43,7 +43,7 @@ export type ConstructSpaceParams = {
    */
   onAuthorizedConnection: (session: Teleport) => void;
   onAuthFailure?: (session: Teleport) => void;
-  onDelegatedInvitationStatusChange: (invitation: DelegateSpaceInvitation, isActive: boolean) => Promise<void>;
+  onDelegatedInvitationStatusChange: (invitation: DelegateInvitationCredential, isActive: boolean) => Promise<void>;
 };
 
 /**

--- a/packages/core/echo/echo-pipeline/src/space/space-manager.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space-manager.ts
@@ -11,6 +11,7 @@ import { type NetworkManager } from '@dxos/network-manager';
 import { trace } from '@dxos/protocols';
 import type { FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
 import { type SpaceMetadata } from '@dxos/protocols/proto/dxos/echo/metadata';
+import { type DelegateSpaceInvitation } from '@dxos/protocols/proto/dxos/halo/invitations';
 import { type Teleport } from '@dxos/teleport';
 import { type BlobStore } from '@dxos/teleport-extension-object-sync';
 import { ComplexMap } from '@dxos/util';
@@ -42,6 +43,7 @@ export type ConstructSpaceParams = {
    */
   onAuthorizedConnection: (session: Teleport) => void;
   onAuthFailure?: (session: Teleport) => void;
+  onDelegatedInvitationStatusChange: (invitation: DelegateSpaceInvitation, isActive: boolean) => Promise<void>;
 };
 
 /**
@@ -84,6 +86,7 @@ export class SpaceManager {
     swarmIdentity,
     onAuthorizedConnection,
     onAuthFailure,
+    onDelegatedInvitationStatusChange,
     memberKey,
   }: ConstructSpaceParams) {
     log.trace('dxos.echo.space-manager.construct-space', trace.begin({ id: this._instanceId }));
@@ -111,6 +114,7 @@ export class SpaceManager {
       metadataStore: this._metadataStore,
       snapshotManager,
       memberKey,
+      onDelegatedInvitationStatusChange,
     });
     this._spaces.set(space.key, space);
 

--- a/packages/core/echo/echo-pipeline/src/space/space-manager.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space-manager.ts
@@ -3,7 +3,7 @@
 //
 
 import { synchronized, trackLeaks } from '@dxos/async';
-import { type DelegateInvitationCredential } from '@dxos/credentials/dist/types/src/state-machine/invitation-state-machine';
+import { type DelegateInvitationCredential } from '@dxos/credentials';
 import { failUndefined } from '@dxos/debug';
 import { type FeedStore } from '@dxos/feed-store';
 import { PublicKey } from '@dxos/keys';

--- a/packages/core/echo/echo-pipeline/src/space/space.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space.ts
@@ -4,8 +4,7 @@
 
 import { Event, Mutex, synchronized, trackLeaks } from '@dxos/async';
 import { Resource, type Context, LifecycleState } from '@dxos/context';
-import { type FeedInfo } from '@dxos/credentials';
-import { type DelegateInvitationCredential } from '@dxos/credentials/dist/types/src/state-machine/invitation-state-machine';
+import { type FeedInfo, type DelegateInvitationCredential } from '@dxos/credentials';
 import { type FeedOptions, type FeedWrapper } from '@dxos/feed-store';
 import { invariant } from '@dxos/invariant';
 import { type PublicKey } from '@dxos/keys';

--- a/packages/core/echo/echo-pipeline/src/space/space.ts
+++ b/packages/core/echo/echo-pipeline/src/space/space.ts
@@ -5,13 +5,13 @@
 import { Event, Mutex, synchronized, trackLeaks } from '@dxos/async';
 import { Resource, type Context, LifecycleState } from '@dxos/context';
 import { type FeedInfo } from '@dxos/credentials';
+import { type DelegateInvitationCredential } from '@dxos/credentials/dist/types/src/state-machine/invitation-state-machine';
 import { type FeedOptions, type FeedWrapper } from '@dxos/feed-store';
 import { invariant } from '@dxos/invariant';
 import { type PublicKey } from '@dxos/keys';
 import { log, logInfo } from '@dxos/log';
 import type { FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
 import { AdmittedFeed, type Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
-import { type DelegateSpaceInvitation } from '@dxos/protocols/proto/dxos/halo/invitations';
 import { type Timeframe } from '@dxos/timeframe';
 import { trace } from '@dxos/tracing';
 import { Callback, type AsyncCallback } from '@dxos/util';
@@ -37,7 +37,7 @@ export type SpaceParams = {
   // TODO(dmaretskyi): Superseded by epochs.
   snapshotId?: string | undefined;
 
-  onDelegatedInvitationStatusChange: (invitation: DelegateSpaceInvitation, isActive: boolean) => Promise<void>;
+  onDelegatedInvitationStatusChange: (invitation: DelegateInvitationCredential, isActive: boolean) => Promise<void>;
 };
 
 export type CreatePipelineParams = {

--- a/packages/core/echo/echo-pipeline/src/testing/test-agent-builder.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/test-agent-builder.ts
@@ -190,6 +190,7 @@ export class TestAgent {
           this.createGossip().createExtension({ remotePeerId: session.remotePeerId }),
         );
       },
+      onDelegatedInvitationStatusChange: async () => {},
     });
     await space.setControlFeed(controlFeed);
     await space.setDataFeed(dataFeed);

--- a/packages/core/halo/credentials/src/credentials/credential-generator.ts
+++ b/packages/core/halo/credentials/src/credentials/credential-generator.ts
@@ -208,6 +208,7 @@ export const createAdmissionCredentials = async (
   spaceKey: PublicKey,
   genesisFeedKey: PublicKey,
   profile?: ProfileDocument,
+  invitationCredentialId?: PublicKey,
 ): Promise<FeedMessage.Payload[]> => {
   const credentials = await Promise.all([
     await signer.createCredential({
@@ -218,6 +219,7 @@ export const createAdmissionCredentials = async (
         role: SpaceMember.Role.ADMIN, // TODO(burdon): Configure.
         profile,
         genesisFeedKey,
+        invitationCredentialId,
       },
     }),
   ]);

--- a/packages/core/halo/credentials/src/credentials/credential-generator.ts
+++ b/packages/core/halo/credentials/src/credentials/credential-generator.ts
@@ -13,6 +13,7 @@ import {
   type ProfileDocument,
   SpaceMember,
 } from '@dxos/protocols/proto/dxos/halo/credentials';
+import { type DelegateSpaceInvitation } from '@dxos/protocols/proto/dxos/halo/invitations';
 import { Timeframe } from '@dxos/timeframe';
 
 import { createCredential, type CredentialSigner } from './credential-factory';
@@ -224,4 +225,25 @@ export const createAdmissionCredentials = async (
   return credentials.map((credential) => ({
     credential: { credential },
   }));
+};
+
+export const createDelegatedSpaceInvitationCredential = async (
+  signer: CredentialSigner,
+  subject: PublicKey,
+  invitation: DelegateSpaceInvitation,
+): Promise<FeedMessage.Payload> => {
+  const credential = await signer.createCredential({
+    subject,
+    assertion: {
+      '@type': 'dxos.halo.invitations.DelegateSpaceInvitation',
+      invitationId: invitation.invitationId,
+      authMethod: invitation.authMethod,
+      swarmKey: invitation.swarmKey,
+      role: invitation.role,
+      guestKey: invitation.guestKey,
+      expiresOn: invitation.expiresOn,
+      multiUse: invitation.multiUse,
+    },
+  });
+  return { credential: { credential } };
 };

--- a/packages/core/halo/credentials/src/state-machine/index.ts
+++ b/packages/core/halo/credentials/src/state-machine/index.ts
@@ -5,3 +5,4 @@
 export * from './space-state-machine';
 export * from './feed-state-machine';
 export * from './member-state-machine';
+export * from './invitation-state-machine';

--- a/packages/core/halo/credentials/src/state-machine/invitation-state-machine.test.ts
+++ b/packages/core/halo/credentials/src/state-machine/invitation-state-machine.test.ts
@@ -71,6 +71,17 @@ describe('InvitationStateMachine', () => {
     expectNoInvitation(stateMachine, baseInvitation);
   });
 
+  test('invitation stays if unrelated admission credential', async () => {
+    const stateMachine = createStateMachine();
+    const unrelatedInvitation = await delegateInvitation({
+      ...baseInvitation,
+      invitationId: PublicKey.random().toHex(),
+    });
+    await stateMachine.process(await delegateInvitation(baseInvitation));
+    await stateMachine.process(await admitMember(unrelatedInvitation));
+    expectHasInvitation(stateMachine, baseInvitation);
+  });
+
   test('multi-use invitations', async () => {
     const stateMachine = createStateMachine();
     const multiUseInvitation = { ...baseInvitation, multiUse: true };

--- a/packages/core/halo/credentials/src/state-machine/invitation-state-machine.test.ts
+++ b/packages/core/halo/credentials/src/state-machine/invitation-state-machine.test.ts
@@ -1,0 +1,155 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+import { expect } from 'chai';
+
+import { Keyring } from '@dxos/keyring';
+import { PublicKey } from '@dxos/keys';
+import { Invitation } from '@dxos/protocols/proto/dxos/client/services';
+import { SpaceMember, type Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
+import { type DelegateSpaceInvitation } from '@dxos/protocols/proto/dxos/halo/invitations';
+import { describe, test } from '@dxos/test';
+import { range } from '@dxos/util';
+
+import { InvitationStateMachine } from './invitation-state-machine';
+import {
+  createCredential,
+  createCredentialSignerWithKey,
+  createDelegatedSpaceInvitationCredential,
+} from '../credentials';
+
+describe('InvitationStateMachine', () => {
+  const keyring = new Keyring();
+  let space: PublicKey;
+  let identity: PublicKey;
+  const baseInvitation: DelegateSpaceInvitation = {
+    invitationId: PublicKey.random().toHex(),
+    swarmKey: PublicKey.random(),
+    role: SpaceMember.Role.ADMIN,
+    authMethod: Invitation.AuthMethod.KNOWN_PUBLIC_KEY,
+    multiUse: false,
+  };
+  beforeEach(async () => {
+    space = await keyring.createKey();
+    identity = await keyring.createKey();
+  });
+
+  test('invitation delegated', async () => {
+    const stateMachine = createStateMachine();
+    await stateMachine.process(await delegateInvitation(baseInvitation));
+    expectHasInvitation(stateMachine, baseInvitation);
+  });
+
+  test('multiple invitations', async () => {
+    const stateMachine = createStateMachine();
+    const invitations = range(3).map(() => ({ ...baseInvitation, invitationId: PublicKey.random().toHex() }));
+    await Promise.all(
+      invitations.map(async (invitation) => {
+        return stateMachine.process(await delegateInvitation(invitation));
+      }),
+    );
+    invitations.forEach((invitation) => expectHasInvitation(stateMachine, invitation));
+  });
+
+  test('expired invitations are ignored', async () => {
+    const stateMachine = createStateMachine();
+    await stateMachine.process(
+      await delegateInvitation({
+        ...baseInvitation,
+        expiresOn: new Date(Date.now() - 1),
+      }),
+    );
+    expectNoInvitation(stateMachine, baseInvitation);
+  });
+
+  test('single use invitation redeemed when a member joins', async () => {
+    const stateMachine = createStateMachine();
+    const delegatedInvitation = await delegateInvitation(baseInvitation);
+    await stateMachine.process(delegatedInvitation);
+    await stateMachine.process(await admitMember(delegatedInvitation));
+    expectNoInvitation(stateMachine, baseInvitation);
+  });
+
+  test('multi-use invitations', async () => {
+    const stateMachine = createStateMachine();
+    const multiUseInvitation = { ...baseInvitation, multiUse: true };
+    const delegatedInvitation = await delegateInvitation(multiUseInvitation);
+    await stateMachine.process(delegatedInvitation);
+    await stateMachine.process(await admitMember(delegatedInvitation));
+    await stateMachine.process(await admitMember(delegatedInvitation));
+    expectHasInvitation(stateMachine, multiUseInvitation);
+  });
+
+  test('explicit cancellation', async () => {
+    const stateMachine = createStateMachine();
+    const delegatedInvitation = await delegateInvitation(baseInvitation);
+    await stateMachine.process(delegatedInvitation);
+    await stateMachine.process(await cancelInvitation(delegatedInvitation));
+    expectNoInvitation(stateMachine, baseInvitation);
+  });
+
+  test('out of order joining', async () => {
+    const stateMachine = createStateMachine();
+    const delegatedInvitation = await delegateInvitation(baseInvitation);
+    await stateMachine.process(await admitMember(delegatedInvitation));
+    await stateMachine.process(delegatedInvitation);
+    expectNoInvitation(stateMachine, baseInvitation);
+  });
+
+  test('out of order cancellation', async () => {
+    const stateMachine = createStateMachine();
+    const delegatedInvitation = await delegateInvitation(baseInvitation);
+    await stateMachine.process(await cancelInvitation(delegatedInvitation));
+    await stateMachine.process(delegatedInvitation);
+    expectNoInvitation(stateMachine, baseInvitation);
+  });
+
+  const expectHasInvitation = (state: InvitationStateMachine, expected: DelegateSpaceInvitation) => {
+    const actual = [...state.invitations.values()].find((i) => i.invitationId === expected.invitationId);
+    expect(actual).to.deep.contain(expected);
+  };
+
+  const expectNoInvitation = (state: InvitationStateMachine, expected: DelegateSpaceInvitation) => {
+    const actual = [...state.invitations.values()].find((i) => i.invitationId === expected.invitationId);
+    expect(actual).to.be.undefined;
+  };
+
+  const delegateInvitation = async (invitation: DelegateSpaceInvitation): Promise<Credential> => {
+    const message = await createDelegatedSpaceInvitationCredential(
+      createCredentialSignerWithKey(keyring, identity),
+      space,
+      invitation,
+    );
+    return message.credential!.credential;
+  };
+
+  const cancelInvitation = async (invitation: Credential): Promise<Credential> => {
+    return createCredential({
+      issuer: space,
+      subject: identity,
+      assertion: {
+        '@type': 'dxos.halo.invitations.CancelDelegatedInvitation',
+        credentialId: invitation.id!,
+      },
+      signer: keyring,
+    });
+  };
+
+  const admitMember = (invitation: Credential) => {
+    return createCredential({
+      issuer: space,
+      subject: identity,
+      assertion: {
+        '@type': 'dxos.halo.credentials.SpaceMember',
+        spaceKey: space,
+        role: SpaceMember.Role.ADMIN,
+        genesisFeedKey: PublicKey.random(),
+        invitationCredentialId: invitation.id,
+      },
+      signer: keyring,
+    });
+  };
+});
+
+const createStateMachine = () => new InvitationStateMachine();

--- a/packages/core/halo/credentials/src/state-machine/invitation-state-machine.ts
+++ b/packages/core/halo/credentials/src/state-machine/invitation-state-machine.ts
@@ -45,9 +45,10 @@ export class InvitationStateMachine {
       }
       case 'dxos.halo.invitations.DelegateSpaceInvitation': {
         if (credential.id) {
+          const isExpired = credential.expirationDate && credential.expirationDate.getTime() < Date.now();
           const wasUsed = this._redeemedInvitationCredentialIds.has(credential.id) && !assertion.multiUse;
           const wasCancelled = this._cancelledInvitationCredentialIds.has(credential.id);
-          if (wasCancelled || wasUsed) {
+          if (isExpired || wasCancelled || wasUsed) {
             return;
           }
           const invitation: DelegateSpaceInvitation = { ...assertion };

--- a/packages/core/halo/credentials/src/state-machine/invitation-state-machine.ts
+++ b/packages/core/halo/credentials/src/state-machine/invitation-state-machine.ts
@@ -1,0 +1,72 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+import { PublicKey } from '@dxos/keys';
+import { type Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
+import { type DelegateSpaceInvitation } from '@dxos/protocols/proto/dxos/halo/invitations';
+import { type AsyncCallback, Callback, ComplexMap, ComplexSet } from '@dxos/util';
+
+import { getCredentialAssertion } from '../credentials';
+
+/**
+ * Tracks the feed tree for a space.
+ * Provides a list of admitted feeds.
+ */
+export class InvitationStateMachine {
+  private readonly _invitations = new ComplexMap<PublicKey, DelegateSpaceInvitation>(PublicKey.hash);
+  private readonly _redeemedInvitationCredentialIds = new ComplexSet(PublicKey.hash);
+  private readonly _cancelledInvitationCredentialIds = new ComplexSet(PublicKey.hash);
+
+  readonly onOutstandingInvitation = new Callback<AsyncCallback<DelegateSpaceInvitation>>();
+  readonly onOutstandingInvitationRemoved = new Callback<AsyncCallback<DelegateSpaceInvitation>>();
+
+  constructor(private readonly _spaceKey: PublicKey) {}
+
+  get invitations(): ReadonlyMap<PublicKey, DelegateSpaceInvitation> {
+    return this._invitations;
+  }
+
+  async process(credential: Credential): Promise<void> {
+    const credentialId = credential.id;
+    if (credentialId == null) {
+      return;
+    }
+    const assertion = getCredentialAssertion(credential);
+    switch (assertion['@type']) {
+      case 'dxos.halo.invitations.CancelDelegatedInvitation': {
+        this._cancelledInvitationCredentialIds.add(assertion.credentialId);
+        const existingInvitation = this._invitations.get(assertion.credentialId);
+        if (existingInvitation != null) {
+          this._invitations.delete(assertion.credentialId);
+          await this.onOutstandingInvitationRemoved.callIfSet(existingInvitation);
+        }
+        break;
+      }
+      case 'dxos.halo.invitations.DelegateSpaceInvitation': {
+        if (credential.id) {
+          const wasUsed = this._redeemedInvitationCredentialIds.has(credential.id) && !assertion.multiUse;
+          const wasCancelled = this._cancelledInvitationCredentialIds.has(credential.id);
+          if (wasCancelled || wasUsed) {
+            return;
+          }
+          const invitation: DelegateSpaceInvitation = { ...assertion };
+          this._invitations.set(credential.id, invitation);
+          await this.onOutstandingInvitation.callIfSet(invitation);
+        }
+        break;
+      }
+      case 'dxos.halo.credentials.SpaceMember': {
+        if (assertion.invitationCredentialId != null) {
+          this._redeemedInvitationCredentialIds.add(assertion.invitationCredentialId);
+          const existingInvitation = this._invitations.get(assertion.invitationCredentialId);
+          if (existingInvitation != null && !existingInvitation.multiUse) {
+            this._invitations.delete(assertion.invitationCredentialId);
+            await this.onOutstandingInvitationRemoved.callIfSet(existingInvitation);
+          }
+        }
+        break;
+      }
+    }
+  }
+}

--- a/packages/core/halo/credentials/src/state-machine/invitation-state-machine.ts
+++ b/packages/core/halo/credentials/src/state-machine/invitation-state-machine.ts
@@ -21,8 +21,6 @@ export class InvitationStateMachine {
   readonly onDelegatedInvitation = new Callback<AsyncCallback<DelegateSpaceInvitation>>();
   readonly onDelegatedInvitationRemoved = new Callback<AsyncCallback<DelegateSpaceInvitation>>();
 
-  constructor(private readonly _spaceKey: PublicKey) {}
-
   get invitations(): ReadonlyMap<PublicKey, DelegateSpaceInvitation> {
     return this._invitations;
   }
@@ -45,7 +43,7 @@ export class InvitationStateMachine {
       }
       case 'dxos.halo.invitations.DelegateSpaceInvitation': {
         if (credential.id) {
-          const isExpired = credential.expirationDate && credential.expirationDate.getTime() < Date.now();
+          const isExpired = assertion.expiresOn && assertion.expiresOn.getTime() < Date.now();
           const wasUsed = this._redeemedInvitationCredentialIds.has(credential.id) && !assertion.multiUse;
           const wasCancelled = this._cancelledInvitationCredentialIds.has(credential.id);
           if (isExpired || wasCancelled || wasUsed) {

--- a/packages/core/halo/credentials/src/state-machine/invitation-state-machine.ts
+++ b/packages/core/halo/credentials/src/state-machine/invitation-state-machine.ts
@@ -18,8 +18,8 @@ export class InvitationStateMachine {
   private readonly _redeemedInvitationCredentialIds = new ComplexSet(PublicKey.hash);
   private readonly _cancelledInvitationCredentialIds = new ComplexSet(PublicKey.hash);
 
-  readonly onOutstandingInvitation = new Callback<AsyncCallback<DelegateSpaceInvitation>>();
-  readonly onOutstandingInvitationRemoved = new Callback<AsyncCallback<DelegateSpaceInvitation>>();
+  readonly onDelegatedInvitation = new Callback<AsyncCallback<DelegateSpaceInvitation>>();
+  readonly onDelegatedInvitationRemoved = new Callback<AsyncCallback<DelegateSpaceInvitation>>();
 
   constructor(private readonly _spaceKey: PublicKey) {}
 
@@ -39,7 +39,7 @@ export class InvitationStateMachine {
         const existingInvitation = this._invitations.get(assertion.credentialId);
         if (existingInvitation != null) {
           this._invitations.delete(assertion.credentialId);
-          await this.onOutstandingInvitationRemoved.callIfSet(existingInvitation);
+          await this.onDelegatedInvitationRemoved.callIfSet(existingInvitation);
         }
         break;
       }
@@ -52,7 +52,7 @@ export class InvitationStateMachine {
           }
           const invitation: DelegateSpaceInvitation = { ...assertion };
           this._invitations.set(credential.id, invitation);
-          await this.onOutstandingInvitation.callIfSet(invitation);
+          await this.onDelegatedInvitation.callIfSet(invitation);
         }
         break;
       }
@@ -62,7 +62,7 @@ export class InvitationStateMachine {
           const existingInvitation = this._invitations.get(assertion.invitationCredentialId);
           if (existingInvitation != null && !existingInvitation.multiUse) {
             this._invitations.delete(assertion.invitationCredentialId);
-            await this.onOutstandingInvitationRemoved.callIfSet(existingInvitation);
+            await this.onDelegatedInvitationRemoved.callIfSet(existingInvitation);
           }
         }
         break;

--- a/packages/core/halo/credentials/src/state-machine/space-state-machine.ts
+++ b/packages/core/halo/credentials/src/state-machine/space-state-machine.ts
@@ -169,7 +169,6 @@ export class SpaceStateMachine implements SpaceState {
 
         toBeRevoked.revoked = true;
         await this._members.onRevoked(toBeRevoked.credential, credential);
-        await this._invitations.process(credential);
         break;
       }
       case 'dxos.halo.credentials.SpaceGenesis': {

--- a/packages/core/halo/credentials/src/state-machine/space-state-machine.ts
+++ b/packages/core/halo/credentials/src/state-machine/space-state-machine.ts
@@ -52,7 +52,7 @@ const REVOCABLE_CREDENTIALS = ['dxos.halo.credentials.SpaceMember'];
 export class SpaceStateMachine implements SpaceState {
   private readonly _members = new MemberStateMachine(this._spaceKey);
   private readonly _feeds = new FeedStateMachine(this._spaceKey);
-  private readonly _invitations = new InvitationStateMachine(this._spaceKey);
+  private readonly _invitations = new InvitationStateMachine();
   private readonly _credentials: CredentialEntry[] = [];
   private readonly _credentialsById = new ComplexMap<PublicKey, CredentialEntry>(PublicKey.hash);
   private readonly _processedCredentials = new ComplexSet<PublicKey>(PublicKey.hash);

--- a/packages/core/halo/credentials/src/state-machine/space-state-machine.ts
+++ b/packages/core/halo/credentials/src/state-machine/space-state-machine.ts
@@ -23,7 +23,7 @@ export interface SpaceState {
   readonly credentials: Credential[];
   readonly genesisCredential: Credential | undefined;
   readonly creator: MemberInfo | undefined;
-  readonly invitations: DelegateSpaceInvitation[];
+  readonly invitations: ReadonlyMap<PublicKey, DelegateSpaceInvitation>;
 
   addCredentialProcessor(processor: CredentialProcessor): Promise<void>;
   removeCredentialProcessor(processor: CredentialProcessor): Promise<void>;
@@ -92,8 +92,8 @@ export class SpaceStateMachine implements SpaceState {
     return this._genesisCredential;
   }
 
-  get invitations(): DelegateSpaceInvitation[] {
-    return [...this._invitations.invitations.values()];
+  get invitations(): ReadonlyMap<PublicKey, DelegateSpaceInvitation> {
+    return this._invitations.invitations;
   }
 
   async addCredentialProcessor(processor: CredentialProcessor) {

--- a/packages/core/halo/credentials/src/state-machine/space-state-machine.ts
+++ b/packages/core/halo/credentials/src/state-machine/space-state-machine.ts
@@ -8,6 +8,7 @@ import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { type TypedMessage } from '@dxos/protocols';
 import { type Credential, SpaceMember } from '@dxos/protocols/proto/dxos/halo/credentials';
+import { type DelegateSpaceInvitation } from '@dxos/protocols/proto/dxos/halo/invitations';
 import { type AsyncCallback, Callback, ComplexMap, ComplexSet } from '@dxos/util';
 
 import { type FeedInfo, FeedStateMachine } from './feed-state-machine';
@@ -22,6 +23,7 @@ export interface SpaceState {
   readonly credentials: Credential[];
   readonly genesisCredential: Credential | undefined;
   readonly creator: MemberInfo | undefined;
+  readonly invitations: DelegateSpaceInvitation[];
 
   addCredentialProcessor(processor: CredentialProcessor): Promise<void>;
   removeCredentialProcessor(processor: CredentialProcessor): Promise<void>;
@@ -61,6 +63,8 @@ export class SpaceStateMachine implements SpaceState {
   readonly onCredentialProcessed = new Callback<AsyncCallback<Credential>>();
   readonly onMemberAdmitted = this._members.onMemberAdmitted;
   readonly onFeedAdmitted = this._feeds.onFeedAdmitted;
+  readonly onDelegatedInvitation = this._invitations.onDelegatedInvitation;
+  readonly onDelegatedInvitationRemoved = this._invitations.onDelegatedInvitationRemoved;
 
   constructor(private readonly _spaceKey: PublicKey) {}
 
@@ -86,6 +90,10 @@ export class SpaceStateMachine implements SpaceState {
 
   get genesisCredential(): Credential | undefined {
     return this._genesisCredential;
+  }
+
+  get invitations(): DelegateSpaceInvitation[] {
+    return [...this._invitations.invitations.values()];
   }
 
   async addCredentialProcessor(processor: CredentialProcessor) {

--- a/packages/core/protocols/src/proto/dxos/client/services.proto
+++ b/packages/core/protocols/src/proto/dxos/client/services.proto
@@ -480,6 +480,9 @@ message Invitation {
 
   /// Guest's keypair required for AuthMethod.KNOWN_PUBLIC_KEY.
   optional AdmissionKeypair guest_keypair = 16;
+
+  /// Present on Type.DELEGATED invitations.
+  optional dxos.keys.PublicKey delegation_credential_id = 17;
 }
 
 message AdmissionKeypair {

--- a/packages/core/protocols/src/proto/dxos/halo/credentials.proto
+++ b/packages/core/protocols/src/proto/dxos/halo/credentials.proto
@@ -68,6 +68,9 @@ message SpaceMember {
   /// Genesis feed of the space.
   /// Needed so that the admitted member can start replicating the space based on this credential alone.
   dxos.keys.PublicKey genesis_feed_key = 4;
+
+  /// Present to associate SpaceMember admissions with delegated invitations.
+  optional dxos.keys.PublicKey invitation_credential_id = 5;
 }
 
 message MemberProfile {

--- a/packages/core/protocols/src/proto/dxos/halo/invitations.proto
+++ b/packages/core/protocols/src/proto/dxos/halo/invitations.proto
@@ -80,6 +80,7 @@ message DelegateSpaceInvitation {
   dxos.client.services.Invitation.AuthMethod auth_method = 2;
   dxos.keys.PublicKey swarm_key = 3;
   dxos.halo.credentials.SpaceMember.Role role = 4;
+  /// Present for AuthMethod.KNOWN_PUBLIC_KEY, where guess needs to prove possession of a corresponding private key
   optional dxos.keys.PublicKey guest_key = 5;
   optional google.protobuf.Timestamp expires_on = 6;
   bool multi_use = 7;

--- a/packages/core/protocols/src/proto/dxos/halo/invitations.proto
+++ b/packages/core/protocols/src/proto/dxos/halo/invitations.proto
@@ -5,6 +5,7 @@
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
 
 import "dxos/client/services.proto";
 import "dxos/echo/timeframe.proto";
@@ -72,6 +73,20 @@ message SpaceAdmissionRequest {
   dxos.keys.PublicKey device_key = 2;
   dxos.keys.PublicKey control_feed_key = 3;
   dxos.keys.PublicKey data_feed_key = 4;
+}
+
+message DelegateSpaceInvitation {
+  string invitation_id = 1;
+  dxos.client.services.Invitation.AuthMethod auth_method = 2;
+  dxos.keys.PublicKey swarm_key = 3;
+  dxos.halo.credentials.SpaceMember.Role role = 4;
+  optional dxos.keys.PublicKey guest_key = 5;
+  optional google.protobuf.Timestamp expires_on = 6;
+  bool multi_use = 7;
+}
+
+message CancelDelegatedInvitation {
+  dxos.keys.PublicKey credential_id = 1;
 }
 
 message AdmissionRequest {

--- a/packages/sdk/client-services/src/packlets/identity/identity-manager.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity-manager.ts
@@ -385,6 +385,7 @@ export class IdentityManager {
         log.warn('auth failure');
       },
       memberKey: identityKey,
+      onDelegatedInvitationStatusChange: async () => {}, // TODO: will be used for recovery keys
     });
   }
 }

--- a/packages/sdk/client-services/src/packlets/identity/identity.test.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity.test.ts
@@ -94,6 +94,7 @@ describe('identity/identity', () => {
       metadataStore,
       snapshotManager: new SnapshotManager(snapshotStore, blobStore, protocol.blobSync),
       snapshotId: undefined,
+      onDelegatedInvitationStatusChange: async () => {},
     });
     await space.setControlFeed(controlFeed);
     await space.setDataFeed(dataFeed);
@@ -206,6 +207,7 @@ describe('identity/identity', () => {
         memberKey: identityKey,
         metadataStore,
         snapshotManager: new SnapshotManager(snapshotStore, blobStore, protocol.blobSync),
+        onDelegatedInvitationStatusChange: async () => {},
       });
       await space.setControlFeed(controlFeed);
       await space.setDataFeed(dataFeed);
@@ -296,6 +298,7 @@ describe('identity/identity', () => {
         memberKey: identityKey,
         metadataStore,
         snapshotManager: new SnapshotManager(snapshotStore, blobStore, protocol.blobSync),
+        onDelegatedInvitationStatusChange: async () => {},
       });
       await space.setControlFeed(controlFeed);
       await space.setDataFeed(dataFeed);

--- a/packages/sdk/client-services/src/packlets/invitations/device-invitation-protocol.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/device-invitation-protocol.ts
@@ -38,7 +38,7 @@ export class DeviceInvitationProtocol implements InvitationProtocol {
     throw new Error('delegation not supported');
   }
 
-  async admit(request: AdmissionRequest): Promise<AdmissionResponse> {
+  async admit(_: Invitation, request: AdmissionRequest): Promise<AdmissionResponse> {
     invariant(request.device);
     const identity = this._getIdentity();
     await identity.admitDevice(request.device);

--- a/packages/sdk/client-services/src/packlets/invitations/device-invitation-protocol.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/device-invitation-protocol.ts
@@ -33,6 +33,10 @@ export class DeviceInvitationProtocol implements InvitationProtocol {
     };
   }
 
+  async delegate(invitation: Invitation): Promise<void> {
+    throw new Error('delegation not supported');
+  }
+
   async admit(request: AdmissionRequest): Promise<AdmissionResponse> {
     invariant(request.device);
     const identity = this._getIdentity();

--- a/packages/sdk/client-services/src/packlets/invitations/device-invitation-protocol.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/device-invitation-protocol.ts
@@ -4,6 +4,7 @@
 
 import { invariant } from '@dxos/invariant';
 import { type Keyring } from '@dxos/keyring';
+import { type PublicKey } from '@dxos/keys';
 import { AlreadyJoinedError } from '@dxos/protocols';
 import { Invitation } from '@dxos/protocols/proto/dxos/client/services';
 import type { DeviceProfileDocument } from '@dxos/protocols/proto/dxos/halo/credentials';
@@ -33,7 +34,7 @@ export class DeviceInvitationProtocol implements InvitationProtocol {
     };
   }
 
-  async delegate(invitation: Invitation): Promise<void> {
+  async delegate(invitation: Invitation): Promise<PublicKey> {
     throw new Error('delegation not supported');
   }
 

--- a/packages/sdk/client-services/src/packlets/invitations/invitation-protocol.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitation-protocol.ts
@@ -2,6 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
+import { type PublicKey } from '@dxos/keys';
 import type { ApiError } from '@dxos/protocols';
 import type { Invitation } from '@dxos/protocols/proto/dxos/client/services';
 import type { ProfileDocument, DeviceProfileDocument } from '@dxos/protocols/proto/dxos/halo/credentials';
@@ -33,7 +34,7 @@ export interface InvitationProtocol {
   /**
    * Once authentication is successful, the host can admit the guest to the requested resource.
    */
-  delegate(invitation: Invitation): Promise<void>;
+  delegate(invitation: Invitation): Promise<PublicKey>;
 
   /**
    * Once authentication is successful, the host can admit the guest to the requested resource.

--- a/packages/sdk/client-services/src/packlets/invitations/invitation-protocol.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitation-protocol.ts
@@ -33,6 +33,11 @@ export interface InvitationProtocol {
   /**
    * Once authentication is successful, the host can admit the guest to the requested resource.
    */
+  delegate(invitation: Invitation): Promise<void>;
+
+  /**
+   * Once authentication is successful, the host can admit the guest to the requested resource.
+   */
   admit(request: AdmissionRequest, guestProfile?: ProfileDocument): Promise<AdmissionResponse>;
 
   //

--- a/packages/sdk/client-services/src/packlets/invitations/invitation-protocol.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitation-protocol.ts
@@ -39,7 +39,7 @@ export interface InvitationProtocol {
   /**
    * Once authentication is successful, the host can admit the guest to the requested resource.
    */
-  admit(request: AdmissionRequest, guestProfile?: ProfileDocument): Promise<AdmissionResponse>;
+  admit(invitation: Invitation, request: AdmissionRequest, guestProfile?: ProfileDocument): Promise<AdmissionResponse>;
 
   //
   // Guest

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
@@ -85,7 +85,7 @@ export class InvitationsHandler {
           try {
             const deviceKey = admissionRequest.device?.deviceKey ?? admissionRequest.space?.deviceKey;
             invariant(deviceKey);
-            const admissionResponse = await protocol.admit(admissionRequest, extension.guestProfile);
+            const admissionResponse = await protocol.admit(invitation, admissionRequest, extension.guestProfile);
 
             // Updating credentials complete.
             extension.completedTrigger.wake(deviceKey);

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
@@ -3,14 +3,8 @@
 //
 
 import { PushStream, scheduleTask, TimeoutError, Trigger } from '@dxos/async';
-import {
-  AuthenticatingInvitation,
-  AUTHENTICATION_CODE_LENGTH,
-  CancellableInvitation,
-  INVITATION_TIMEOUT,
-} from '@dxos/client-protocol';
+import { AuthenticatingInvitation, INVITATION_TIMEOUT } from '@dxos/client-protocol';
 import { Context } from '@dxos/context';
-import { generatePasscode } from '@dxos/credentials';
 import { createKeyPair, sign } from '@dxos/crypto';
 import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
@@ -67,55 +61,12 @@ export class InvitationsHandler {
    */
   constructor(private readonly _networkManager: NetworkManager) {}
 
-  createInvitation(protocol: InvitationProtocol, options?: Partial<Invitation>): CancellableInvitation {
-    const {
-      invitationId = PublicKey.random().toHex(),
-      type = Invitation.Type.INTERACTIVE,
-      authMethod = Invitation.AuthMethod.SHARED_SECRET,
-      state = Invitation.State.INIT,
-      timeout = INVITATION_TIMEOUT,
-      swarmKey = PublicKey.random(),
-      persistent = options?.authMethod !== Invitation.AuthMethod.KNOWN_PUBLIC_KEY, // default no not storing keypairs
-      created = new Date(),
-      guestKeypair = undefined,
-      lifetime = 86400, // 1 day,
-      multiUse = false,
-    } = options ?? {};
-    const authCode =
-      options?.authCode ??
-      (authMethod === Invitation.AuthMethod.SHARED_SECRET ? generatePasscode(AUTHENTICATION_CODE_LENGTH) : undefined);
-    invariant(protocol);
-
-    const invitation: Invitation = {
-      invitationId,
-      type,
-      authMethod,
-      state,
-      swarmKey,
-      authCode,
-      timeout,
-      persistent: persistent && type !== Invitation.Type.DELEGATED, // delegated invitations are persisted in control feed
-      guestKeypair:
-        guestKeypair ?? (authMethod === Invitation.AuthMethod.KNOWN_PUBLIC_KEY ? createAdmissionKeypair() : undefined),
-      created,
-      lifetime,
-      multiUse,
-      ...protocol.getInvitationContext(),
-    };
-
-    const stream = new PushStream<Invitation>();
-    const ctx = new Context({
-      onError: (err) => {
-        stream.error(err);
-        void ctx.dispose();
-      },
-    });
-
-    ctx.onDispose(() => {
-      log('complete', { ...protocol.toJSON() });
-      stream.complete();
-    });
-
+  handleInvitationFlow(
+    ctx: Context,
+    stream: PushStream<Invitation>,
+    protocol: InvitationProtocol,
+    invitation: Invitation,
+  ): void {
     // Called for every connecting peer.
     const createExtension = (): InvitationHostExtension => {
       const extension = new InvitationHostExtension({
@@ -154,7 +105,7 @@ export class InvitationsHandler {
               log.trace('dxos.sdk.invitations-handler.host.onOpen', trace.begin({ id: traceId }));
               log('connected', { ...protocol.toJSON() });
               stream.next({ ...invitation, state: Invitation.State.CONNECTED });
-              const deviceKey = await extension.completedTrigger.wait({ timeout });
+              const deviceKey = await extension.completedTrigger.wait({ timeout: invitation.timeout });
               log('admitted guest', { guest: deviceKey, ...protocol.toJSON() });
               stream.next({ ...invitation, state: Invitation.State.SUCCESS });
               log.trace('dxos.sdk.invitations-handler.host.onOpen', trace.end({ id: traceId }));
@@ -168,7 +119,7 @@ export class InvitationsHandler {
               }
               log.trace('dxos.sdk.invitations-handler.host.onOpen', trace.error({ id: traceId, error: err }));
             } finally {
-              if (!multiUse) {
+              if (!invitation.multiUse) {
                 // Wait for graceful close before disposing.
                 await swarmConnection.close();
                 await ctx.dispose();
@@ -229,18 +180,6 @@ export class InvitationsHandler {
 
       stream.next({ ...invitation, state: Invitation.State.CONNECTING });
     });
-
-    // TODO(burdon): Stop anything pending.
-    const observable = new CancellableInvitation({
-      initialInvitation: invitation,
-      subscriber: stream.observable,
-      onCancel: async () => {
-        stream.next({ ...invitation, state: Invitation.State.CANCELLED });
-        await ctx.dispose();
-      },
-    });
-
-    return observable;
   }
 
   acceptInvitation(

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-manager.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-manager.ts
@@ -78,7 +78,7 @@ export class InvitationsManager {
       return observableInvitation;
     }
 
-    this._invitationsHandler.handleInvitationFlow(ctx, stream, handler, invitation);
+    this._invitationsHandler.handleInvitationFlow(ctx, stream, handler, observableInvitation.get());
 
     return observableInvitation;
   }
@@ -211,6 +211,7 @@ export class InvitationsManager {
       created,
       lifetime,
       multiUse,
+      delegationCredentialId: options?.delegationCredentialId,
       ...protocol.getInvitationContext(),
     } satisfies Invitation;
   }

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-manager.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-manager.ts
@@ -36,11 +36,11 @@ export class InvitationsManager {
 
   constructor(
     private readonly _invitationsHandler: InvitationsHandler,
-    private readonly _getHandler: (invitation: Invitation) => InvitationProtocol,
+    private readonly _getHandler: (invitation: Partial<Invitation> & Pick<Invitation, 'kind'>) => InvitationProtocol,
     private readonly _metadataStore: MetadataStore,
   ) {}
 
-  createInvitation(options: Invitation): CancellableInvitation {
+  createInvitation(options: Partial<Invitation> & Pick<Invitation, 'invitationId' | 'kind'>): CancellableInvitation {
     const existingInvitation = this._createInvitations.get(options.invitationId);
     if (existingInvitation) {
       return existingInvitation;

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-service.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-service.ts
@@ -27,9 +27,11 @@ export class InvitationsServiceImpl implements InvitationsService {
   }
 
   createInvitation(options: Invitation): Stream<Invitation> {
-    const invitation = this._invitationsManager.createInvitation(options);
     return new Stream<Invitation>(({ next, close }) => {
-      invitation.subscribe(next, close, close);
+      this._invitationsManager
+        .createInvitation(options)
+        .then((invitation) => invitation.subscribe(next, close, close))
+        .catch(close);
     });
   }
 

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-service.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-service.ts
@@ -28,7 +28,7 @@ export class InvitationsServiceImpl implements InvitationsService {
 
   createInvitation(options: Invitation): Stream<Invitation> {
     return new Stream<Invitation>(({ next, close }) => {
-      this._invitationsManager
+      void this._invitationsManager
         .createInvitation(options)
         .then((invitation) => invitation.subscribe(next, close, close))
         .catch(close);

--- a/packages/sdk/client-services/src/packlets/invitations/space-invitation-protocol.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/space-invitation-protocol.ts
@@ -47,7 +47,11 @@ export class SpaceInvitationProtocol implements InvitationProtocol {
     };
   }
 
-  async admit(request: AdmissionRequest, guestProfile?: ProfileDocument | undefined): Promise<AdmissionResponse> {
+  async admit(
+    invitation: Invitation,
+    request: AdmissionRequest,
+    guestProfile?: ProfileDocument | undefined,
+  ): Promise<AdmissionResponse> {
     invariant(this._spaceKey);
     const space = await this._spaceManager.spaces.get(this._spaceKey);
     invariant(space);
@@ -63,6 +67,7 @@ export class SpaceInvitationProtocol implements InvitationProtocol {
       space.key,
       space.inner.genesisFeedKey,
       guestProfile,
+      invitation.delegationCredentialId,
     );
 
     // TODO(dmaretskyi): Refactor.

--- a/packages/sdk/client-services/src/packlets/invitations/space-invitation-protocol.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/space-invitation-protocol.ts
@@ -80,7 +80,7 @@ export class SpaceInvitationProtocol implements InvitationProtocol {
     };
   }
 
-  async delegate(invitation: Invitation): Promise<void> {
+  async delegate(invitation: Invitation): Promise<PublicKey> {
     invariant(this._spaceKey);
     const space = await this._spaceManager.spaces.get(this._spaceKey);
     invariant(space);
@@ -108,7 +108,9 @@ export class SpaceInvitationProtocol implements InvitationProtocol {
       },
     );
 
+    invariant(credential.credential);
     await writeMessages(space.inner.controlPipeline.writer, [credential]);
+    return credential.credential.credential.id!;
   }
 
   checkInvitation(invitation: Partial<Invitation>) {

--- a/packages/sdk/client-services/src/packlets/services/service-context.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-context.ts
@@ -256,6 +256,7 @@ export class ServiceContext extends Resource {
       signingContext,
       this.feedStore,
       this.automergeHost,
+      this.invitationsManager,
       this._runtimeParams as DataSpaceManagerRuntimeParams,
     );
     await this.dataSpaceManager.open();

--- a/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/data-space-manager.ts
@@ -273,7 +273,7 @@ export class DataSpaceManager {
         afterReady: async () => {
           log('after space ready', { space: space.key, open: this._isOpen });
           if (this._isOpen) {
-            this._createDelegatedInvitations(space.spaceState.invitations);
+            this._createDelegatedInvitations(dataSpace, space.spaceState.invitations);
             this.updated.emit();
           }
         },
@@ -306,17 +306,18 @@ export class DataSpaceManager {
       return;
     }
     if (isActive) {
-      this._createDelegatedInvitations([invitation]);
+      this._createDelegatedInvitations(dataSpace, [invitation]);
     } else {
       await this._invitationsManager.cancelInvitation(invitation);
     }
   }
 
-  private _createDelegatedInvitations(invitations: DelegateSpaceInvitation[]) {
+  private _createDelegatedInvitations(space: DataSpace, invitations: DelegateSpaceInvitation[]) {
     invitations.forEach((invitation) => {
       this._invitationsManager.createInvitation({
         type: Invitation.Type.INTERACTIVE,
         kind: Invitation.Kind.SPACE,
+        spaceKey: space.key,
         authMethod: invitation.authMethod,
         invitationId: invitation.invitationId,
         swarmKey: invitation.swarmKey,

--- a/packages/sdk/client-services/src/packlets/testing/invitation-utils.ts
+++ b/packages/sdk/client-services/src/packlets/testing/invitation-utils.ts
@@ -60,146 +60,149 @@ export const performInvitation = ({
   const guestComplete = new Trigger<Result>();
   const authCode = new Trigger<string>();
 
-  const hostObservable = createInvitation(host, options);
-  hostObservable.subscribe(
-    async (hostInvitation: Invitation) => {
-      switch (hostInvitation.state) {
-        case Invitation.State.CONNECTING: {
-          if (hooks?.host?.onConnecting?.(hostObservable)) {
-            break;
-          }
-          const guestObservable = acceptInvitation(guest, hostInvitation, guestDeviceProfile);
-          guestObservable.subscribe(
-            async (guestInvitation: Invitation) => {
-              switch (guestInvitation.state) {
-                case Invitation.State.CONNECTING: {
-                  if (hooks?.guest?.onConnecting?.(guestObservable)) {
+  void createInvitation(host, options).then((hostObservable) => {
+    hostObservable.subscribe(
+      async (hostInvitation: Invitation) => {
+        switch (hostInvitation.state) {
+          case Invitation.State.CONNECTING: {
+            if (hooks?.host?.onConnecting?.(hostObservable)) {
+              break;
+            }
+            const guestObservable = acceptInvitation(guest, hostInvitation, guestDeviceProfile);
+            guestObservable.subscribe(
+              async (guestInvitation: Invitation) => {
+                switch (guestInvitation.state) {
+                  case Invitation.State.CONNECTING: {
+                    if (hooks?.guest?.onConnecting?.(guestObservable)) {
+                      break;
+                    }
+                    invariant(hostInvitation.swarmKey!.equals(guestInvitation.swarmKey!));
                     break;
                   }
-                  invariant(hostInvitation.swarmKey!.equals(guestInvitation.swarmKey!));
-                  break;
-                }
 
-                case Invitation.State.CONNECTED: {
-                  hooks?.guest?.onConnected?.(guestObservable);
-                  break;
-                }
-
-                case Invitation.State.READY_FOR_AUTHENTICATION: {
-                  if (hooks?.guest?.onReady?.(guestObservable)) {
+                  case Invitation.State.CONNECTED: {
+                    hooks?.guest?.onConnected?.(guestObservable);
                     break;
                   }
-                  await guestObservable.authenticate(await authCode.wait());
-                  break;
-                }
 
-                case Invitation.State.AUTHENTICATING: {
-                  hooks?.guest?.onAuthenticating?.(guestObservable);
-                  break;
-                }
-
-                case Invitation.State.SUCCESS: {
-                  if (hooks?.guest?.onSuccess?.(guestObservable)) {
+                  case Invitation.State.READY_FOR_AUTHENTICATION: {
+                    if (hooks?.guest?.onReady?.(guestObservable)) {
+                      break;
+                    }
+                    await guestObservable.authenticate(await authCode.wait());
                     break;
                   }
-                  guestComplete.wake({ invitation: guestInvitation });
-                  break;
-                }
 
-                case Invitation.State.CANCELLED: {
-                  if (hooks?.guest?.onCancelled?.(guestObservable)) {
+                  case Invitation.State.AUTHENTICATING: {
+                    hooks?.guest?.onAuthenticating?.(guestObservable);
                     break;
                   }
-                  guestComplete.wake({ invitation: guestInvitation });
-                  break;
-                }
 
-                case Invitation.State.TIMEOUT: {
-                  if (hooks?.guest?.onTimeout?.(guestObservable)) {
-                    return;
+                  case Invitation.State.SUCCESS: {
+                    if (hooks?.guest?.onSuccess?.(guestObservable)) {
+                      break;
+                    }
+                    guestComplete.wake({ invitation: guestInvitation });
+                    break;
                   }
-                  guestComplete.wake({ invitation: guestInvitation });
+
+                  case Invitation.State.CANCELLED: {
+                    if (hooks?.guest?.onCancelled?.(guestObservable)) {
+                      break;
+                    }
+                    guestComplete.wake({ invitation: guestInvitation });
+                    break;
+                  }
+
+                  case Invitation.State.TIMEOUT: {
+                    if (hooks?.guest?.onTimeout?.(guestObservable)) {
+                      return;
+                    }
+                    guestComplete.wake({ invitation: guestInvitation });
+                  }
                 }
-              }
-            },
-            (error: Error) => {
-              if (hooks?.guest?.onError?.(guestObservable)) {
-                return;
-              }
-              guestComplete.wake({ error });
-            },
-          );
-          break;
-        }
-
-        case Invitation.State.CONNECTED: {
-          hooks?.host?.onConnected?.(hostObservable);
-          break;
-        }
-
-        case Invitation.State.READY_FOR_AUTHENTICATION: {
-          if (hooks?.host?.onReady?.(hostObservable)) {
+              },
+              (error: Error) => {
+                if (hooks?.guest?.onError?.(guestObservable)) {
+                  return;
+                }
+                guestComplete.wake({ error });
+              },
+            );
             break;
           }
-          if (hostInvitation.authCode) {
-            authCode.wake(hostInvitation.authCode);
-          }
-          break;
-        }
 
-        case Invitation.State.AUTHENTICATING: {
-          hooks?.host?.onAuthenticating?.(hostObservable);
-          break;
-        }
-
-        case Invitation.State.SUCCESS: {
-          if (hooks?.host?.onSuccess?.(hostObservable)) {
+          case Invitation.State.CONNECTED: {
+            hooks?.host?.onConnected?.(hostObservable);
             break;
           }
-          hostComplete.wake({ invitation: hostInvitation });
-          break;
-        }
 
-        case Invitation.State.CANCELLED: {
-          if (hooks?.host?.onCancelled?.(hostObservable)) {
+          case Invitation.State.READY_FOR_AUTHENTICATION: {
+            if (hooks?.host?.onReady?.(hostObservable)) {
+              break;
+            }
+            if (hostInvitation.authCode) {
+              authCode.wake(hostInvitation.authCode);
+            }
             break;
           }
-          hostComplete.wake({ invitation: hostInvitation });
-          break;
-        }
 
-        case Invitation.State.TIMEOUT: {
-          if (hooks?.host?.onTimeout?.(hostObservable)) {
+          case Invitation.State.AUTHENTICATING: {
+            hooks?.host?.onAuthenticating?.(hostObservable);
             break;
           }
-          hostComplete.wake({ invitation: hostInvitation });
-          break;
+
+          case Invitation.State.SUCCESS: {
+            if (hooks?.host?.onSuccess?.(hostObservable)) {
+              break;
+            }
+            hostComplete.wake({ invitation: hostInvitation });
+            break;
+          }
+
+          case Invitation.State.CANCELLED: {
+            if (hooks?.host?.onCancelled?.(hostObservable)) {
+              break;
+            }
+            hostComplete.wake({ invitation: hostInvitation });
+            break;
+          }
+
+          case Invitation.State.TIMEOUT: {
+            if (hooks?.host?.onTimeout?.(hostObservable)) {
+              break;
+            }
+            hostComplete.wake({ invitation: hostInvitation });
+            break;
+          }
         }
-      }
-    },
-    (error: Error) => {
-      if (hooks?.host?.onError?.(hostObservable)) {
-        return;
-      }
-      hostComplete.wake({ error });
-    },
-  );
+      },
+      (error: Error) => {
+        if (hooks?.host?.onError?.(hostObservable)) {
+          return;
+        }
+        hostComplete.wake({ error });
+      },
+    );
+  });
 
   return [hostComplete.wait(), guestComplete.wait()];
 };
 
-const createInvitation = (
+const createInvitation = async (
   host: ServiceContext | InvitationHost,
   options?: Partial<Invitation>,
-): CancellableInvitation => {
+): Promise<CancellableInvitation> => {
   options ??= {
     authMethod: Invitation.AuthMethod.NONE,
     ...(options ?? {}),
   };
 
   if (host instanceof ServiceContext) {
-    const hostHandler = host.getInvitationHandler({ kind: Invitation.Kind.SPACE, ...options });
-    return host.invitations.createInvitation(hostHandler, options);
+    return host.invitationsManager.createInvitation({
+      kind: Invitation.Kind.SPACE,
+      ...options,
+    });
   }
 
   return host.share(options);

--- a/packages/sdk/client/src/tests/invitations.test.ts
+++ b/packages/sdk/client/src/tests/invitations.test.ts
@@ -6,7 +6,7 @@ import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import waitForExpect from 'wait-for-expect';
 
-import { asyncChain, asyncTimeout, Trigger } from '@dxos/async';
+import { asyncChain, asyncTimeout, Trigger, waitForCondition } from '@dxos/async';
 import { type Space } from '@dxos/client-protocol';
 import {
   createAdmissionKeypair,
@@ -438,6 +438,9 @@ describe('Invitations', () => {
           const persistentInvitation = tempHost.share({ authMethod: Invitation.AuthMethod.NONE });
           persistentInvitationId = persistentInvitation.get().invitationId;
           await savedTrigger.wait();
+          await waitForCondition({
+            condition: () => hostContext.networkManager.topics.includes(persistentInvitation.get().swarmKey),
+          });
           // TODO(nf): expose this in API as suspendInvitation()/SuspendableInvitation?
           await hostContext.networkManager.leaveSwarm(persistentInvitation.get().swarmKey);
         }

--- a/packages/sdk/client/src/tests/spaces-invitations.test.ts
+++ b/packages/sdk/client/src/tests/spaces-invitations.test.ts
@@ -4,37 +4,28 @@
 
 import { expect } from 'chai';
 
+import { sleep, Trigger } from '@dxos/async';
+import { type CancellableInvitation } from '@dxos/client-protocol';
 import { performInvitation } from '@dxos/client-services/testing';
 import { log } from '@dxos/log';
-import { Invitation } from '@dxos/protocols/proto/dxos/client/services';
+import { Invitation, QueryInvitationsResponse } from '@dxos/protocols/proto/dxos/client/services';
 import { afterTest, describe, test } from '@dxos/test';
+import { range } from '@dxos/util';
 
 import { Client } from '../client';
 import { TestBuilder, testSpaceAutomerge, waitForSpace } from '../testing';
 
 describe('Spaces/invitations', () => {
   test('creates a space and invites a peer', async () => {
-    const testBuilder = new TestBuilder();
-
-    const client1 = new Client({ services: testBuilder.createLocal() });
-    const client2 = new Client({ services: testBuilder.createLocal() });
-    await client1.initialize();
-    await client2.initialize();
-    await client1.halo.createIdentity({ displayName: 'Peer 1' });
-    await client2.halo.createIdentity({ displayName: 'Peer 2' });
+    const [client1, client2] = await createInitializedClients(2);
+    afterTest(() => destroyClients([client1, client2]));
 
     log('initialized');
-
-    afterTest(() => Promise.all([client1.destroy()]));
-    afterTest(() => Promise.all([client2.destroy()]));
 
     const space1 = await client1.spaces.create();
     log('spaces.create', { key: space1.key });
     const [{ invitation: hostInvitation }, { invitation: guestInvitation }] = await Promise.all(
-      performInvitation({
-        host: space1,
-        guest: client2.spaces,
-      }),
+      performInvitation({ host: space1, guest: client2.spaces }),
     );
     expect(guestInvitation?.spaceKey).to.deep.eq(space1.key);
     expect(hostInvitation?.spaceKey).to.deep.eq(guestInvitation?.spaceKey);
@@ -45,4 +36,106 @@ describe('Spaces/invitations', () => {
       await testSpaceAutomerge(space.db);
     }
   });
+
+  describe('delegated', () => {
+    test('single-use', async () => {
+      const clients = await createInitializedClients(3);
+      afterTest(() => destroyClients(clients));
+      const [alice, bob, fred] = clients;
+
+      // Alice invites Bob
+      const space = await alice.spaces.create();
+      const [{ invitation: hostInvitation }] = await Promise.all(performInvitation({ host: space, guest: bob.spaces }));
+      expect(hostInvitation?.state).to.eq(Invitation.State.SUCCESS);
+
+      // Alice creates a delegated invitation
+      const delegatedInvitationPosted = new Trigger();
+      const delegatedInvitationDisposed = new Trigger();
+      const invitationStream = bob.services.services.InvitationsService!.queryInvitations();
+      afterTest(() => invitationStream.close());
+      let observableInvitation: CancellableInvitation | null = null;
+      invitationStream.subscribe((msg) => {
+        const invitation = observableInvitation?.get();
+        if (invitation == null) {
+          return;
+        }
+        if (invitation.invitationId === msg.invitations?.[0]?.invitationId) {
+          if (msg.action === QueryInvitationsResponse.Action.ADDED) {
+            delegatedInvitationPosted.wake();
+          } else if (msg.action === QueryInvitationsResponse.Action.REMOVED) {
+            delegatedInvitationDisposed.wake();
+          }
+        }
+      });
+      observableInvitation = space.share({
+        type: Invitation.Type.DELEGATED,
+        authMethod: Invitation.AuthMethod.KNOWN_PUBLIC_KEY,
+        multiUse: false,
+      });
+      await delegatedInvitationPosted.wait();
+      // Alice leaves
+      await alice.destroy();
+      // Bob admits Fred
+      fred.spaces.join(observableInvitation.get());
+      await waitForSpace(fred, space.key!, { ready: true });
+      // Invitation gets disposed
+      await delegatedInvitationDisposed.wait();
+    });
+
+    test('multi-use', async () => {
+      const clients = await createInitializedClients(4);
+      afterTest(() => destroyClients(clients));
+      const [alice, bob, fred, charlie] = clients;
+
+      // Alice invites Bob
+      const space = await alice.spaces.create();
+      const [{ invitation: hostInvitation }] = await Promise.all(performInvitation({ host: space, guest: bob.spaces }));
+      expect(hostInvitation?.state).to.eq(Invitation.State.SUCCESS);
+
+      // Alice creates a delegated invitation
+      const delegatedInvitationPosted = new Trigger();
+      const invitationStream = bob.services.services.InvitationsService!.queryInvitations();
+      afterTest(() => invitationStream.close());
+      let observableInvitation: CancellableInvitation | null = null;
+      invitationStream.subscribe((msg) => {
+        const invitation = observableInvitation?.get();
+        if (invitation == null) {
+          return;
+        }
+        if (invitation.invitationId === msg.invitations?.[0]?.invitationId) {
+          delegatedInvitationPosted.wake();
+        }
+      });
+      observableInvitation = space.share({
+        type: Invitation.Type.DELEGATED,
+        authMethod: Invitation.AuthMethod.KNOWN_PUBLIC_KEY,
+        multiUse: true,
+      });
+      await delegatedInvitationPosted.wait();
+      await alice.destroy();
+      // Bob admits Fred
+      fred.spaces.join(observableInvitation.get());
+      await waitForSpace(fred, space.key!, { ready: true });
+      // Charlie gets admitted using the same invitation after some time
+      await sleep(10);
+      charlie.spaces.join(observableInvitation.get());
+      await waitForSpace(charlie, space.key!, { ready: true });
+    });
+  });
 });
+
+const createInitializedClients = (count: number): Promise<Client[]> => {
+  const testBuilder = new TestBuilder();
+  const clients = range(count).map(() => new Client({ services: testBuilder.createLocal() }));
+  return Promise.all(
+    clients.map(async (c, index) => {
+      await c.initialize();
+      await c.halo.createIdentity({ displayName: `Peer ${index}` });
+      return c;
+    }),
+  );
+};
+
+const destroyClients = async (clients: Client[]): Promise<void> => {
+  await Promise.all(clients.map((c) => c.destroy()));
+};


### PR DESCRIPTION
### Details

* Added `InvitationStateMachine` as a part of `SpaceStateMachine` to process credentials related to delegated invitations. It maintains a set of currently active delegated invitations and notifies listeners when it changes.
* When `DataSpaceManager` constructs a space it starts listening to invitation set changes, calling `InvitationManager,(create|cancel)Invitation` when the set changes.
* Added a `delegate` method `InvitationProtocol` that gets called when a delegated invitation is created to write a credential to subject control feed.
* Tests.

re #6301