### PR TITLE
fix(tables): Enforce virtualisation

### DIFF
--- a/packages/apps/plugins/plugin-debug/src/components/SchemaList.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/SchemaList.tsx
@@ -71,7 +71,7 @@ export const SchemaList: FC<{ space: Space; onCreate?: (schema: any /* Schema */
 
   return (
     <DensityProvider density={'fine'}>
-      <Table<SchemaRecord> columns={columns} data={data} />
+      <Table.Table<SchemaRecord> columns={columns} data={data} />
     </DensityProvider>
   );
 };

--- a/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.stories.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.stories.tsx
@@ -57,7 +57,7 @@ const Story = ({ table }: { table?: TableType }) => {
 
   return (
     <div ref={containerRef} className='inset-0 overflow-auto'>
-      <ObjectTable table={table} stickyHeader getScrollElement={() => containerRef.current} />
+      <ObjectTable table={table} stickyHeader />
     </div>
   );
 };

--- a/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
@@ -16,11 +16,11 @@ import { createColumns, updateTableProp } from './utils';
 import { getSchema } from '../../schema';
 import { TableSettings } from '../TableSettings';
 
-export type ObjectTableProps = Pick<TableProps<any>, 'stickyHeader' | 'role' | 'getScrollElement'> & {
+export type ObjectTableProps = Pick<TableProps<any>, 'stickyHeader' | 'role'> & {
   table: TableType;
 };
 
-export const ObjectTable: FC<ObjectTableProps> = ({ table, role, stickyHeader, getScrollElement }) => {
+export const ObjectTable: FC<ObjectTableProps> = ({ table, role, stickyHeader }) => {
   const space = getSpace(table);
   const [showSettings, setShowSettings] = useState(false);
 
@@ -61,13 +61,11 @@ export const ObjectTable: FC<ObjectTableProps> = ({ table, role, stickyHeader, g
   if (showSettings) {
     return <TableSettings open={showSettings} table={table} schemas={schemas} onClose={handleClose} />;
   } else {
-    return (
-      <ObjectTableImpl table={table} role={role} stickyHeader={stickyHeader} getScrollElement={getScrollElement} />
-    );
+    return <ObjectTableImpl table={table} role={role} stickyHeader={stickyHeader} />;
   }
 };
 
-const ObjectTableImpl: FC<ObjectTableProps> = ({ table, role, stickyHeader, getScrollElement }) => {
+const ObjectTableImpl: FC<ObjectTableProps> = ({ table, role, stickyHeader }) => {
   const space = getSpace(table);
 
   const objects = useTableObjects(space, table.schema);
@@ -131,14 +129,13 @@ const ObjectTableImpl: FC<ObjectTableProps> = ({ table, role, stickyHeader, getS
 
   return (
     <DensityProvider density='fine'>
-      <Table<any>
+      <Table.Table<any>
         keyAccessor={keyAccessor}
         columns={columns}
         data={rows}
         border
         role={role ?? 'grid'}
         stickyHeader={stickyHeader}
-        getScrollElement={getScrollElement}
         onColumnResize={handleColumnResize}
         pinLastRow
       />

--- a/packages/apps/plugins/plugin-table/src/components/TableMain.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/TableMain.tsx
@@ -9,7 +9,7 @@ import { baseSurface } from '@dxos/react-ui-theme';
 
 import { ObjectTable, type ObjectTableProps } from './ObjectTable';
 
-const TableMain: FC<ObjectTableProps> = ({ table }) => {
+const TableMain: FC<Omit<ObjectTableProps, 'getScrollElement'>> = ({ table }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   return (

--- a/packages/apps/plugins/plugin-table/src/components/TableMain.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/TableMain.tsx
@@ -2,30 +2,30 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { type FC, useRef } from 'react';
+import React, { type FC } from 'react';
 
 import { Main } from '@dxos/react-ui';
+import { Table } from '@dxos/react-ui-table';
 import { baseSurface } from '@dxos/react-ui-theme';
 
 import { ObjectTable, type ObjectTableProps } from './ObjectTable';
 
-const TableMain: FC<Omit<ObjectTableProps, 'getScrollElement'>> = ({ table }) => {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  return (
-    <Main.Content
-      classNames={[baseSurface, 'fixed inset-inline-0 block-start-[--topbar-size] block-end-0 overflow-auto']}
-      ref={containerRef}
-    >
-      <ObjectTable
-        table={table}
-        key={table.id} // New component instance per table.
-        stickyHeader
-        role='grid'
-        getScrollElement={() => containerRef.current}
-      />
-    </Main.Content>
-  );
-};
+const TableMain: FC<Omit<ObjectTableProps, 'getScrollElement'>> = ({ table }) => (
+  <Main.Content>
+    <Table.Root>
+      {/* TODO(Zan): Is moving the classes from Main.Content to the viewport ok? */}
+      <Table.Viewport
+        classNames={[baseSurface, 'fixed inset-inline-0 block-start-[--topbar-size] block-end-0 overflow-auto']}
+      >
+        <ObjectTable
+          table={table}
+          key={table.id} // New component instance per table.
+          stickyHeader
+          role='grid'
+        />
+      </Table.Viewport>
+    </Table.Root>
+  </Main.Content>
+);
 
 export default TableMain;

--- a/packages/apps/plugins/plugin-table/src/components/TableMain.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/TableMain.tsx
@@ -11,10 +11,9 @@ import { baseSurface } from '@dxos/react-ui-theme';
 import { ObjectTable, type ObjectTableProps } from './ObjectTable';
 
 const TableMain: FC<Omit<ObjectTableProps, 'getScrollElement'>> = ({ table }) => (
-  <Main.Content>
-    <Table.Root>
-      {/* TODO(Zan): Is moving the classes from Main.Content to the viewport ok? */}
-      <Table.Viewport
+  <Table.Root>
+    <Table.Viewport asChild>
+      <Main.Content
         classNames={[baseSurface, 'fixed inset-inline-0 block-start-[--topbar-size] block-end-0 overflow-auto']}
       >
         <ObjectTable
@@ -23,9 +22,9 @@ const TableMain: FC<Omit<ObjectTableProps, 'getScrollElement'>> = ({ table }) =>
           stickyHeader
           role='grid'
         />
-      </Table.Viewport>
-    </Table.Root>
-  </Main.Content>
+      </Main.Content>
+    </Table.Viewport>
+  </Table.Root>
 );
 
 export default TableMain;

--- a/packages/apps/plugins/plugin-table/src/components/TableSection.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/TableSection.tsx
@@ -6,8 +6,9 @@ import React, { type FC, useRef } from 'react';
 
 import { ObjectTable, type ObjectTableProps } from './ObjectTable';
 
-const TableSection: FC<ObjectTableProps> = ({ table }) => {
+const TableSection: FC<Omit<ObjectTableProps, 'getScrollElement'>> = ({ table }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
+
   return (
     <div className='bs-96 mlb-2 overflow-auto' ref={containerRef}>
       <ObjectTable

--- a/packages/apps/plugins/plugin-table/src/components/TableSection.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/TableSection.tsx
@@ -2,23 +2,22 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { type FC, useRef } from 'react';
+import React, { type FC } from 'react';
+
+import { Table } from '@dxos/react-ui-table';
 
 import { ObjectTable, type ObjectTableProps } from './ObjectTable';
 
-const TableSection: FC<Omit<ObjectTableProps, 'getScrollElement'>> = ({ table }) => {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  return (
-    <div className='bs-96 mlb-2 overflow-auto' ref={containerRef}>
+const TableSection: FC<Omit<ObjectTableProps, 'getScrollElement'>> = ({ table }) => (
+  <Table.Root>
+    <Table.Viewport classNames='bs-96 mlb-2 overflow-auto'>
       <ObjectTable
         key={table.id} // New component instance per table.
         table={table}
         role='table'
-        getScrollElement={() => containerRef.current}
       />
-    </div>
-  );
-};
+    </Table.Viewport>
+  </Table.Root>
+);
 
 export default TableSection;

--- a/packages/apps/plugins/plugin-table/src/components/TableSection.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/TableSection.tsx
@@ -10,12 +10,14 @@ import { ObjectTable, type ObjectTableProps } from './ObjectTable';
 
 const TableSection: FC<Omit<ObjectTableProps, 'getScrollElement'>> = ({ table }) => (
   <Table.Root>
-    <Table.Viewport classNames='bs-96 mlb-2 overflow-auto'>
-      <ObjectTable
-        key={table.id} // New component instance per table.
-        table={table}
-        role='table'
-      />
+    <Table.Viewport asChild>
+      <div className='bs-96 mlb-2 overflow-auto'>
+        <ObjectTable
+          key={table.id} // New component instance per table.
+          table={table}
+          role='table'
+        />
+      </div>
     </Table.Viewport>
   </Table.Root>
 );

--- a/packages/apps/plugins/plugin-table/src/components/TableSlide.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/TableSlide.tsx
@@ -12,13 +12,15 @@ const TableSlide: FC<Omit<ObjectTableProps, 'getScrollElement'>> = ({ table }) =
   return (
     <div role='none' className='flex-1 min-bs-0 pli-16 plb-24'>
       <Table.Root>
-        <Table.Viewport classNames='bs-full overflow-auto grid place-items-center'>
-          <ObjectTable
-            key={table.id} // New component instance per table.
-            table={table}
-            stickyHeader
-            role='table'
-          />
+        <Table.Viewport asChild>
+          <div role='none' className='bs-full overflow-auto grid place-items-center'>
+            <ObjectTable
+              key={table.id} // New component instance per table.
+              table={table}
+              stickyHeader
+              role='table'
+            />
+          </div>
         </Table.Viewport>
       </Table.Root>
     </div>

--- a/packages/apps/plugins/plugin-table/src/components/TableSlide.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/TableSlide.tsx
@@ -2,24 +2,25 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { type FC, useRef } from 'react';
+import React, { type FC } from 'react';
+
+import { Table } from '@dxos/react-ui-table';
 
 import { ObjectTable, type ObjectTableProps } from './ObjectTable';
 
 const TableSlide: FC<Omit<ObjectTableProps, 'getScrollElement'>> = ({ table }) => {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
   return (
     <div role='none' className='flex-1 min-bs-0 pli-16 plb-24'>
-      <div role='none' className='bs-full overflow-auto grid place-items-center' ref={containerRef}>
-        <ObjectTable
-          key={table.id} // New component instance per table.
-          table={table}
-          stickyHeader
-          role='table'
-          getScrollElement={() => containerRef.current}
-        />
-      </div>
+      <Table.Root>
+        <Table.Viewport classNames='bs-full overflow-auto grid place-items-center'>
+          <ObjectTable
+            key={table.id} // New component instance per table.
+            table={table}
+            stickyHeader
+            role='table'
+          />
+        </Table.Viewport>
+      </Table.Root>
     </div>
   );
 };

--- a/packages/apps/plugins/plugin-table/src/components/TableSlide.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/TableSlide.tsx
@@ -6,8 +6,9 @@ import React, { type FC, useRef } from 'react';
 
 import { ObjectTable, type ObjectTableProps } from './ObjectTable';
 
-const TableSlide: FC<ObjectTableProps> = ({ table }) => {
+const TableSlide: FC<Omit<ObjectTableProps, 'getScrollElement'>> = ({ table }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
+
   return (
     <div role='none' className='flex-1 min-bs-0 pli-16 plb-24'>
       <div role='none' className='bs-full overflow-auto grid place-items-center' ref={containerRef}>

--- a/packages/apps/testbench-app/src/components/ItemTable.tsx
+++ b/packages/apps/testbench-app/src/components/ItemTable.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 
 import type { S, EchoReactiveObject } from '@dxos/echo-schema';
 import { Table, schemaToColumnDefs } from '@dxos/react-ui-table';
@@ -13,7 +13,6 @@ export type ItemTableProps<T> = {
 };
 
 export const ItemTable = <T extends EchoReactiveObject<any>>({ schema, objects = [] }: ItemTableProps<T>) => {
-  const containerRef = useRef<HTMLDivElement | null>(null);
   const columns = useMemo(() => {
     // TODO(burdon): [API]: id is added to schema?
     const [id, ...rest] = schemaToColumnDefs(schema);
@@ -31,18 +30,19 @@ export const ItemTable = <T extends EchoReactiveObject<any>>({ schema, objects =
   }, [schema]);
 
   return (
-    <div ref={containerRef} className='overflow-auto'>
-      <Table<T>
-        role='grid'
-        rowsSelectable='multi'
-        keyAccessor={(row) => row.id}
-        columns={columns}
-        data={objects}
-        fullWidth
-        stickyHeader
-        border
-        getScrollElement={() => containerRef.current}
-      />
-    </div>
+    <Table.Root>
+      <Table.Viewport classNames='overflow-auto'>
+        <Table.Table<T>
+          role='grid'
+          rowsSelectable='multi'
+          keyAccessor={(row) => row.id}
+          columns={columns}
+          data={objects}
+          fullWidth
+          stickyHeader
+          border
+        />
+      </Table.Viewport>
+    </Table.Root>
   );
 };

--- a/packages/devtools/devtools/src/components/MasterDetailTable.tsx
+++ b/packages/devtools/devtools/src/components/MasterDetailTable.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 
 import { AnchoredOverflow } from '@dxos/react-ui';
 import { Table, type TableColumnDef } from '@dxos/react-ui-table';
@@ -28,23 +28,22 @@ export const MasterDetailTable = <T extends {}>({
   const TableContainer = pinToBottom ? AnchoredOverflow.Root : 'div';
   const tableContainerStyles = pinToBottom ? { classNames: widths[0] } : { className: mx('overflow-auto', widths[0]) };
 
-  const containerRef = useRef<HTMLDivElement>(null);
-
   return (
-    <div className='flex grow overflow-hidden divide-x'>
-      <TableContainer {...tableContainerStyles} ref={containerRef}>
-        <Table<T>
-          columns={columns}
-          data={data}
-          rowsSelectable
-          currentDatum={selected}
-          onDatumClick={setSelected}
-          fullWidth
-          getScrollElement={() => containerRef.current}
-        />
-        {pinToBottom && <AnchoredOverflow.Anchor />}
-      </TableContainer>
+    <Table.Root>
+      <Table.Viewport classNames='flex grow overflow-hidden divide-x'>
+        <TableContainer {...tableContainerStyles}>
+          <Table.Table<T>
+            columns={columns}
+            data={data}
+            rowsSelectable
+            currentDatum={selected}
+            onDatumClick={setSelected}
+            fullWidth
+          />
+          {pinToBottom && <AnchoredOverflow.Anchor />}
+        </TableContainer>
+      </Table.Viewport>
       <div className={mx('flex overflow-auto', widths[1])}>{selected && <JsonView data={selected} />}</div>
-    </div>
+    </Table.Root>
   );
 };

--- a/packages/devtools/devtools/src/components/MasterDetailTable.tsx
+++ b/packages/devtools/devtools/src/components/MasterDetailTable.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { AnchoredOverflow } from '@dxos/react-ui';
 import { Table, type TableColumnDef } from '@dxos/react-ui-table';
@@ -28,9 +28,11 @@ export const MasterDetailTable = <T extends {}>({
   const TableContainer = pinToBottom ? AnchoredOverflow.Root : 'div';
   const tableContainerStyles = pinToBottom ? { classNames: widths[0] } : { className: mx('overflow-auto', widths[0]) };
 
+  const containerRef = useRef<HTMLDivElement>(null);
+
   return (
     <div className='flex grow overflow-hidden divide-x'>
-      <TableContainer {...tableContainerStyles}>
+      <TableContainer {...tableContainerStyles} ref={containerRef}>
         <Table<T>
           columns={columns}
           data={data}
@@ -38,6 +40,7 @@ export const MasterDetailTable = <T extends {}>({
           currentDatum={selected}
           onDatumClick={setSelected}
           fullWidth
+          getScrollElement={() => containerRef.current}
         />
         {pinToBottom && <AnchoredOverflow.Anchor />}
       </TableContainer>

--- a/packages/devtools/devtools/src/components/MasterDetailTable.tsx
+++ b/packages/devtools/devtools/src/components/MasterDetailTable.tsx
@@ -29,21 +29,23 @@ export const MasterDetailTable = <T extends {}>({
   const tableContainerStyles = pinToBottom ? { classNames: widths[0] } : { className: mx('overflow-auto', widths[0]) };
 
   return (
-    <Table.Root>
-      <Table.Viewport classNames='flex grow overflow-hidden divide-x'>
-        <TableContainer {...tableContainerStyles}>
-          <Table.Table<T>
-            columns={columns}
-            data={data}
-            rowsSelectable
-            currentDatum={selected}
-            onDatumClick={setSelected}
-            fullWidth
-          />
-          {pinToBottom && <AnchoredOverflow.Anchor />}
-        </TableContainer>
-      </Table.Viewport>
+    <div className='flex grow overflow-hidden divide-x'>
+      <Table.Root>
+        <Table.Viewport asChild>
+          <TableContainer {...tableContainerStyles}>
+            <Table.Table<T>
+              columns={columns}
+              data={data}
+              rowsSelectable
+              currentDatum={selected}
+              onDatumClick={setSelected}
+              fullWidth
+            />
+            {pinToBottom && <AnchoredOverflow.Anchor />}
+          </TableContainer>
+        </Table.Viewport>
+      </Table.Root>
       <div className={mx('flex overflow-auto', widths[1])}>{selected && <JsonView data={selected} />}</div>
-    </Table.Root>
+    </div>
   );
 };

--- a/packages/devtools/devtools/src/panels/client/TracingPanel/LogTable.tsx
+++ b/packages/devtools/devtools/src/panels/client/TracingPanel/LogTable.tsx
@@ -47,13 +47,6 @@ const logColumns = (() => {
   return columns;
 })();
 
-export const LogView: FC<{ logs: LogEntry[]; scrollContextRef: React.RefObject<HTMLDivElement> }> = ({
-  logs = [],
-  scrollContextRef,
-}) => {
-  return (
-    <Table.Root scrollContextRef={scrollContextRef}>
-      <Table.Table<LogEntry> columns={logColumns} data={logs} fullWidth />
-    </Table.Root>
-  );
+export const LogTable: FC<{ logs: LogEntry[] }> = ({ logs = [] }) => {
+  return <Table.Table<LogEntry> columns={logColumns} data={logs} fullWidth />;
 };

--- a/packages/devtools/devtools/src/panels/client/TracingPanel/LogView.tsx
+++ b/packages/devtools/devtools/src/panels/client/TracingPanel/LogView.tsx
@@ -47,9 +47,13 @@ const logColumns = (() => {
   return columns;
 })();
 
-export const LogView: FC<{ logs: LogEntry[]; getContainerRef: () => Element | null }> = ({
+export const LogView: FC<{ logs: LogEntry[]; scrollContextRef: React.RefObject<HTMLDivElement> }> = ({
   logs = [],
-  getContainerRef,
+  scrollContextRef,
 }) => {
-  return <Table<LogEntry> columns={logColumns} data={logs} fullWidth getScrollElement={getContainerRef} />;
+  return (
+    <Table.Root scrollContextRef={scrollContextRef}>
+      <Table.Table<LogEntry> columns={logColumns} data={logs} fullWidth />
+    </Table.Root>
+  );
 };

--- a/packages/devtools/devtools/src/panels/client/TracingPanel/LogView.tsx
+++ b/packages/devtools/devtools/src/panels/client/TracingPanel/LogView.tsx
@@ -47,6 +47,9 @@ const logColumns = (() => {
   return columns;
 })();
 
-export const LogView: FC<{ logs: LogEntry[] }> = ({ logs = [] }) => {
-  return <Table<LogEntry> columns={logColumns} data={logs} fullWidth />;
+export const LogView: FC<{ logs: LogEntry[]; getContainerRef: () => Element | null }> = ({
+  logs = [],
+  getContainerRef,
+}) => {
+  return <Table<LogEntry> columns={logColumns} data={logs} fullWidth getScrollElement={getContainerRef} />;
 };

--- a/packages/devtools/devtools/src/panels/client/TracingPanel/TracingPanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/TracingPanel/TracingPanel.tsx
@@ -12,7 +12,7 @@ import { AnchoredOverflow } from '@dxos/react-ui'; // Deliberately not using the
 import { createColumnBuilder, Table, type TableColumnDef, textPadding } from '@dxos/react-ui-table';
 import { mx } from '@dxos/react-ui-theme';
 
-import { LogView } from './LogView';
+import { LogTable } from './LogTable';
 import { MetricsView } from './MetricsView';
 import { ResourceName } from './Resource';
 import { TraceView } from './TraceView';
@@ -112,23 +112,25 @@ export const TracingPanel = () => {
     'border-b first:border-r last:border-l',
   );
 
-  const anchoredOverflowRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
   return (
     <PanelContainer>
-      <AnchoredOverflow.Root ref={anchoredOverflowRef} classNames='flex flex-col h-1/3 overflow-auto'>
-        <Table.Root scrollContextRef={anchoredOverflowRef}>
-          <Table.Table<ResourceState>
-            columns={columns}
-            data={Array.from(state.current.resources.values())}
-            currentDatum={selectedResource}
-            onDatumClick={(resourceState) => setSelectedResourceId(resourceState.resource.id)}
-            fullWidth
-          />
-        </Table.Root>
-        <AnchoredOverflow.Anchor />
-      </AnchoredOverflow.Root>
+      <Table.Root>
+        <Table.Viewport asChild>
+          <AnchoredOverflow.Root classNames='flex flex-col h-1/3 overflow-auto'>
+            <Table.Table<ResourceState>
+              columns={columns}
+              data={Array.from(state.current.resources.values())}
+              currentDatum={selectedResource}
+              onDatumClick={(resourceState) => setSelectedResourceId(resourceState.resource.id)}
+              fullWidth
+            />
+            <AnchoredOverflow.Anchor />
+          </AnchoredOverflow.Root>
+        </Table.Viewport>
+      </Table.Root>
+
       <div className='flex flex-col h-2/3 overflow-hidden border-t'>
         <Tabs.Root defaultValue='details' className='flex flex-col grow overflow-hidden'>
           <Tabs.List className='flex'>
@@ -147,9 +149,13 @@ export const TracingPanel = () => {
             <MetricsView resource={selectedResource?.resource} />
           </Tabs.Content>
 
-          <Tabs.Content ref={containerRef} value='logs' className='grow overflow-auto'>
-            <LogView logs={selectedResource?.logs ?? []} scrollContextRef={containerRef} />
-          </Tabs.Content>
+          <Table.Root>
+            <Table.Viewport asChild>
+              <Tabs.Content ref={containerRef} value='logs' className='grow overflow-auto'>
+                <LogTable logs={selectedResource?.logs ?? []} />
+              </Tabs.Content>
+            </Table.Viewport>
+          </Table.Root>
 
           <Tabs.Content value='spans' className='grow overflow-hidden'>
             <TraceView state={state.current} resourceId={selectedResourceId} />

--- a/packages/devtools/devtools/src/panels/client/TracingPanel/TracingPanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/TracingPanel/TracingPanel.tsx
@@ -117,17 +117,15 @@ export const TracingPanel = () => {
   return (
     <PanelContainer>
       <Table.Root>
-        <Table.Viewport asChild>
-          <AnchoredOverflow.Root classNames='flex flex-col h-1/3 overflow-auto'>
-            <Table.Table<ResourceState>
-              columns={columns}
-              data={Array.from(state.current.resources.values())}
-              currentDatum={selectedResource}
-              onDatumClick={(resourceState) => setSelectedResourceId(resourceState.resource.id)}
-              fullWidth
-            />
-            <AnchoredOverflow.Anchor />
-          </AnchoredOverflow.Root>
+        <Table.Viewport classNames={'overflow-anchored flex flex-col h-1/3 overflow-auto'}>
+          <Table.Table<ResourceState>
+            columns={columns}
+            data={Array.from(state.current.resources.values())}
+            currentDatum={selectedResource}
+            onDatumClick={(resourceState) => setSelectedResourceId(resourceState.resource.id)}
+            fullWidth
+          />
+          <AnchoredOverflow.Anchor />
         </Table.Viewport>
       </Table.Root>
 

--- a/packages/devtools/devtools/src/panels/client/TracingPanel/TracingPanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/TracingPanel/TracingPanel.tsx
@@ -112,15 +112,19 @@ export const TracingPanel = () => {
     'border-b first:border-r last:border-l',
   );
 
+  const anchoredOverflowRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
   return (
     <PanelContainer>
-      <AnchoredOverflow.Root classNames='flex flex-col h-1/3 overflow-auto'>
+      <AnchoredOverflow.Root ref={anchoredOverflowRef} classNames='flex flex-col h-1/3 overflow-auto'>
         <Table<ResourceState>
           columns={columns}
           data={Array.from(state.current.resources.values())}
           currentDatum={selectedResource}
           onDatumClick={(resourceState) => setSelectedResourceId(resourceState.resource.id)}
           fullWidth
+          getScrollElement={() => anchoredOverflowRef.current}
         />
         <AnchoredOverflow.Anchor />
       </AnchoredOverflow.Root>
@@ -142,8 +146,8 @@ export const TracingPanel = () => {
             <MetricsView resource={selectedResource?.resource} />
           </Tabs.Content>
 
-          <Tabs.Content value='logs' className='grow overflow-auto'>
-            <LogView logs={selectedResource?.logs ?? []} />
+          <Tabs.Content ref={containerRef} value='logs' className='grow overflow-auto'>
+            <LogView logs={selectedResource?.logs ?? []} getContainerRef={() => containerRef.current} />
           </Tabs.Content>
 
           <Tabs.Content value='spans' className='grow overflow-hidden'>

--- a/packages/devtools/devtools/src/panels/client/TracingPanel/TracingPanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/TracingPanel/TracingPanel.tsx
@@ -118,14 +118,15 @@ export const TracingPanel = () => {
   return (
     <PanelContainer>
       <AnchoredOverflow.Root ref={anchoredOverflowRef} classNames='flex flex-col h-1/3 overflow-auto'>
-        <Table<ResourceState>
-          columns={columns}
-          data={Array.from(state.current.resources.values())}
-          currentDatum={selectedResource}
-          onDatumClick={(resourceState) => setSelectedResourceId(resourceState.resource.id)}
-          fullWidth
-          getScrollElement={() => anchoredOverflowRef.current}
-        />
+        <Table.Root scrollContextRef={anchoredOverflowRef}>
+          <Table.Table<ResourceState>
+            columns={columns}
+            data={Array.from(state.current.resources.values())}
+            currentDatum={selectedResource}
+            onDatumClick={(resourceState) => setSelectedResourceId(resourceState.resource.id)}
+            fullWidth
+          />
+        </Table.Root>
         <AnchoredOverflow.Anchor />
       </AnchoredOverflow.Root>
       <div className='flex flex-col h-2/3 overflow-hidden border-t'>
@@ -147,7 +148,7 @@ export const TracingPanel = () => {
           </Tabs.Content>
 
           <Tabs.Content ref={containerRef} value='logs' className='grow overflow-auto'>
-            <LogView logs={selectedResource?.logs ?? []} getContainerRef={() => containerRef.current} />
+            <LogView logs={selectedResource?.logs ?? []} scrollContextRef={containerRef} />
           </Tabs.Content>
 
           <Tabs.Content value='spans' className='grow overflow-hidden'>

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/FeedTable.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/FeedTable.tsx
@@ -55,13 +55,9 @@ export const FeedTable: FC = () => {
   return (
     // TODO(Zan): Is this the right container to use?
     <AnchoredOverflow.Root ref={containerRef}>
-      <Table<FeedInfo>
-        columns={columns}
-        data={updatedFeeds}
-        onDatumClick={handleSelect}
-        fullWidth
-        getScrollElement={() => containerRef.current}
-      />
+      <Table.Root scrollContextRef={containerRef}>
+        <Table.Table<FeedInfo> columns={columns} data={updatedFeeds} onDatumClick={handleSelect} fullWidth />
+      </Table.Root>
       <AnchoredOverflow.Anchor />
     </AnchoredOverflow.Root>
   );

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/FeedTable.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/FeedTable.tsx
@@ -1,0 +1,68 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import React, { type FC } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { type PublicKey } from '@dxos/keys';
+import { useDevtools, useStream } from '@dxos/react-client/devtools';
+import { AnchoredOverflow } from '@dxos/react-ui';
+import { createColumnBuilder, Table, type TableColumnDef } from '@dxos/react-ui-table';
+
+import { Bitbar } from '../../../components';
+import { useDevtoolsDispatch, useDevtoolsState } from '../../../hooks';
+
+type FeedInfo = {
+  feedKey: PublicKey;
+  downloaded: Uint8Array;
+  maxLength: number;
+};
+
+const { helper, builder } = createColumnBuilder<FeedInfo>();
+const columns: TableColumnDef<FeedInfo, any>[] = [
+  helper.accessor('feedKey', builder.key({ tooltip: true })),
+  helper.accessor('downloaded', {
+    cell: (cell) => (
+      <Bitbar value={cell.getValue()} length={cell.row.original.maxLength} size={6} margin={1} height={8} />
+    ),
+  }),
+];
+
+export const FeedTable: FC = () => {
+  const { space } = useDevtoolsState();
+  const navigate = useNavigate();
+  const setContext = useDevtoolsDispatch();
+
+  // TODO(burdon): Constant updates.
+  // TODO(burdon): Out of order with main table.
+  const feedKeys = [
+    ...(space?.internal.data.pipeline?.controlFeeds ?? []),
+    ...(space?.internal.data.pipeline?.dataFeeds ?? []),
+  ];
+  const devtoolsHost = useDevtools();
+  const { feeds = [] } = useStream(() => devtoolsHost.subscribeToFeeds({ feedKeys }), {}, [feedKeys]);
+  const maxLength = feeds.reduce((max, feed) => (feed?.length > max ? feed.length : max), 0);
+  const updatedFeeds = feeds.map((feed) => ({ ...feed, maxLength }));
+
+  const handleSelect = (selected: FeedInfo | undefined) => {
+    setContext((ctx) => ({ ...ctx, feedKey: selected?.feedKey }));
+    navigate('/echo/feeds');
+  };
+
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  return (
+    // TODO(Zan): Is this the right container to use?
+    <AnchoredOverflow.Root ref={containerRef}>
+      <Table<FeedInfo>
+        columns={columns}
+        data={updatedFeeds}
+        onDatumClick={handleSelect}
+        fullWidth
+        getScrollElement={() => containerRef.current}
+      />
+      <AnchoredOverflow.Anchor />
+    </AnchoredOverflow.Root>
+  );
+};

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/FeedTable.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/FeedTable.tsx
@@ -50,15 +50,15 @@ export const FeedTable: FC = () => {
     navigate('/echo/feeds');
   };
 
-  const containerRef = React.useRef<HTMLDivElement>(null);
-
   return (
-    // TODO(Zan): Is this the right container to use?
-    <AnchoredOverflow.Root ref={containerRef}>
-      <Table.Root scrollContextRef={containerRef}>
-        <Table.Table<FeedInfo> columns={columns} data={updatedFeeds} onDatumClick={handleSelect} fullWidth />
-      </Table.Root>
-      <AnchoredOverflow.Anchor />
-    </AnchoredOverflow.Root>
+    <Table.Root>
+      <Table.Viewport asChild>
+        {/* // TODO(Zan): Is this the right container to use? */}
+        <AnchoredOverflow.Root>
+          <Table.Table<FeedInfo> columns={columns} data={updatedFeeds} onDatumClick={handleSelect} fullWidth />
+          <AnchoredOverflow.Anchor />
+        </AnchoredOverflow.Root>
+      </Table.Viewport>
+    </Table.Root>
   );
 };

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/FeedTable.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/FeedTable.tsx
@@ -52,12 +52,9 @@ export const FeedTable: FC = () => {
 
   return (
     <Table.Root>
-      <Table.Viewport asChild>
-        {/* // TODO(Zan): Is this the right container to use? */}
-        <AnchoredOverflow.Root>
-          <Table.Table<FeedInfo> columns={columns} data={updatedFeeds} onDatumClick={handleSelect} fullWidth />
-          <AnchoredOverflow.Anchor />
-        </AnchoredOverflow.Root>
+      <Table.Viewport classNames='overflow-anchored'>
+        <Table.Table<FeedInfo> columns={columns} data={updatedFeeds} onDatumClick={handleSelect} fullWidth />
+        <AnchoredOverflow.Anchor />
       </Table.Viewport>
     </Table.Root>
   );

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/PipelineTable.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/PipelineTable.tsx
@@ -126,15 +126,14 @@ export const PipelineTable: FC<{
     navigate('/echo/feeds');
   };
 
-  const containerRef = React.useRef<HTMLDivElement>(null);
-
   return (
-    <AnchoredOverflow.Root ref={containerRef}>
-      <Table.Root scrollContextRef={containerRef}>
-        <Table.Table<PipelineTableRow> columns={columns} data={data} onDatumClick={handleSelect} fullWidth />
-      </Table.Root>
-      ;
-      <AnchoredOverflow.Anchor />
-    </AnchoredOverflow.Root>
+    <Table.Root>
+      <Table.Viewport asChild>
+        <AnchoredOverflow.Root>
+          <Table.Table<PipelineTableRow> columns={columns} data={data} onDatumClick={handleSelect} fullWidth />
+          <AnchoredOverflow.Anchor />
+        </AnchoredOverflow.Root>
+      </Table.Viewport>
+    </Table.Root>
   );
 };

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/PipelineTable.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/PipelineTable.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { PublicKey } from '@dxos/keys';
 import { type Space as SpaceProto } from '@dxos/protocols/proto/dxos/client/services';
 import { type SubscribeToSpacesResponse } from '@dxos/protocols/proto/dxos/devtools/host';
+import { AnchoredOverflow } from '@dxos/react-ui';
 import { createColumnBuilder, Table, type TableColumnDef, textPadding } from '@dxos/react-ui-table';
 import { Timeframe } from '@dxos/timeframe';
 import { ComplexSet } from '@dxos/util';
@@ -125,5 +126,19 @@ export const PipelineTable: FC<{
     navigate('/echo/feeds');
   };
 
-  return <Table<PipelineTableRow> columns={columns} data={data} onDatumClick={handleSelect} fullWidth />;
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  return (
+    <AnchoredOverflow.Root ref={containerRef}>
+      <Table<PipelineTableRow>
+        columns={columns}
+        data={data}
+        onDatumClick={handleSelect}
+        fullWidth
+        getScrollElement={() => containerRef.current}
+      />
+      ;
+      <AnchoredOverflow.Anchor />
+    </AnchoredOverflow.Root>
+  );
 };

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/PipelineTable.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/PipelineTable.tsx
@@ -130,13 +130,9 @@ export const PipelineTable: FC<{
 
   return (
     <AnchoredOverflow.Root ref={containerRef}>
-      <Table<PipelineTableRow>
-        columns={columns}
-        data={data}
-        onDatumClick={handleSelect}
-        fullWidth
-        getScrollElement={() => containerRef.current}
-      />
+      <Table.Root scrollContextRef={containerRef}>
+        <Table.Table<PipelineTableRow> columns={columns} data={data} onDatumClick={handleSelect} fullWidth />
+      </Table.Root>
       ;
       <AnchoredOverflow.Anchor />
     </AnchoredOverflow.Root>

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/PipelineTable.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/PipelineTable.tsx
@@ -9,7 +9,7 @@ import { PublicKey } from '@dxos/keys';
 import { type Space as SpaceProto } from '@dxos/protocols/proto/dxos/client/services';
 import { type SubscribeToSpacesResponse } from '@dxos/protocols/proto/dxos/devtools/host';
 import { AnchoredOverflow } from '@dxos/react-ui';
-import { createColumnBuilder, Table, type TableColumnDef, textPadding } from '@dxos/react-ui-table';
+import { Table, createColumnBuilder, textPadding, type TableColumnDef } from '@dxos/react-ui-table';
 import { Timeframe } from '@dxos/timeframe';
 import { ComplexSet } from '@dxos/util';
 
@@ -128,11 +128,9 @@ export const PipelineTable: FC<{
 
   return (
     <Table.Root>
-      <Table.Viewport asChild>
-        <AnchoredOverflow.Root>
-          <Table.Table<PipelineTableRow> columns={columns} data={data} onDatumClick={handleSelect} fullWidth />
-          <AnchoredOverflow.Anchor />
-        </AnchoredOverflow.Root>
+      <Table.Viewport classNames='overflow-anchored'>
+        <Table.Table<PipelineTableRow> columns={columns} data={data} onDatumClick={handleSelect} fullWidth />
+        <AnchoredOverflow.Anchor />
       </Table.Viewport>
     </Table.Root>
   );

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/SpaceInfoPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/SpaceInfoPanel.tsx
@@ -4,65 +4,28 @@
 
 import { ArrowClockwise } from '@phosphor-icons/react';
 import React, { type FC } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import { MulticastObservable } from '@dxos/async';
-import { type PublicKey } from '@dxos/keys';
 import { SpaceState } from '@dxos/protocols/proto/dxos/client/services';
 import { useMulticastObservable } from '@dxos/react-async';
-import { useDevtools, useStream } from '@dxos/react-client/devtools';
 import { Toolbar } from '@dxos/react-ui';
-import { createColumnBuilder, Table, type TableColumnDef } from '@dxos/react-ui-table';
 import { getSize } from '@dxos/react-ui-theme';
 
+import { FeedTable } from './FeedTable';
 import { PipelineTable } from './PipelineTable';
 import { SpaceProperties } from './SpaceProperties';
-import { Bitbar, PanelContainer } from '../../../components';
+import { PanelContainer } from '../../../components';
 import { DataSpaceSelector } from '../../../containers';
-import { useDevtoolsDispatch, useDevtoolsState, useSpacesInfo } from '../../../hooks';
-
-type FeedInfo = {
-  feedKey: PublicKey;
-  downloaded: Uint8Array;
-  maxLength: number;
-};
-
-const { helper, builder } = createColumnBuilder<FeedInfo>();
-const columns: TableColumnDef<FeedInfo, any>[] = [
-  helper.accessor('feedKey', builder.key({ tooltip: true })),
-  helper.accessor('downloaded', {
-    cell: (cell) => (
-      <Bitbar value={cell.getValue()} length={cell.row.original.maxLength} size={6} margin={1} height={8} />
-    ),
-  }),
-];
+import { useDevtoolsState, useSpacesInfo } from '../../../hooks';
 
 export const SpaceInfoPanel: FC = () => {
   const [, forceUpdate] = React.useState({});
   const { space } = useDevtoolsState();
 
-  // TODO(burdon): Constant updates.
-  // TODO(burdon): Out of order with main table.
-  const feedKeys = [
-    ...(space?.internal.data.pipeline?.controlFeeds ?? []),
-    ...(space?.internal.data.pipeline?.dataFeeds ?? []),
-  ];
-  const devtoolsHost = useDevtools();
-  const { feeds = [] } = useStream(() => devtoolsHost.subscribeToFeeds({ feedKeys }), {}, [feedKeys]);
-  const maxLength = feeds.reduce((max, feed) => (feed?.length > max ? feed.length : max), 0);
-  const updatedFeeds = feeds.map((feed) => ({ ...feed, maxLength }));
-
   // TODO(dmaretskyi): We don't need SpaceInfo anymore?
   const spacesInfo = useSpacesInfo();
   const metadata = space?.key && spacesInfo.find((info) => info.key.equals(space?.key));
   const pipelineState = useMulticastObservable(space?.pipeline ?? MulticastObservable.empty());
-
-  const navigate = useNavigate();
-  const setContext = useDevtoolsDispatch();
-  const handleSelect = (selected: FeedInfo | undefined) => {
-    setContext((ctx) => ({ ...ctx, feedKey: selected?.feedKey }));
-    navigate('/echo/feeds');
-  };
 
   const toggleActive = async () => {
     const state = space!.state.get();
@@ -92,7 +55,7 @@ export const SpaceInfoPanel: FC = () => {
         <div className='flex flex-col gap-4'>
           <SpaceProperties space={space} metadata={metadata} />
           <PipelineTable state={pipelineState ?? {}} metadata={metadata} />
-          <Table<FeedInfo> columns={columns} data={updatedFeeds} onDatumClick={handleSelect} fullWidth />
+          <FeedTable />
         </div>
       )}
     </PanelContainer>

--- a/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
@@ -130,13 +130,9 @@ export const SpaceListPanel: FC = () => {
 
       {/* TODO(Zan): Is this the right container? */}
       <AnchoredOverflow.Root ref={containerRef}>
-        <Table<Space>
-          columns={columns}
-          data={spaces}
-          onDatumClick={handleSelect}
-          fullWidth
-          getScrollElement={() => containerRef.current}
-        />
+        <Table.Root scrollContextRef={containerRef}>
+          <Table.Table<Space> columns={columns} data={spaces} onDatumClick={handleSelect} fullWidth />
+        </Table.Root>
         <AnchoredOverflow.Anchor />
       </AnchoredOverflow.Root>
     </PanelContainer>

--- a/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
@@ -122,19 +122,19 @@ export const SpaceListPanel: FC = () => {
     }),
   ];
 
-  const containerRef = React.useRef<HTMLDivElement>(null);
-
   return (
     <PanelContainer classNames='overflow-auto flex-1'>
       <DialogRestoreSpace handleFile={handleImport} />
 
-      {/* TODO(Zan): Is this the right container? */}
-      <AnchoredOverflow.Root ref={containerRef}>
-        <Table.Root scrollContextRef={containerRef}>
-          <Table.Table<Space> columns={columns} data={spaces} onDatumClick={handleSelect} fullWidth />
-        </Table.Root>
-        <AnchoredOverflow.Anchor />
-      </AnchoredOverflow.Root>
+      <Table.Root>
+        <Table.Viewport asChild>
+          {/* TODO(Zan): Is this the right container? */}
+          <AnchoredOverflow.Root>
+            <Table.Table<Space> columns={columns} data={spaces} onDatumClick={handleSelect} fullWidth />
+            <AnchoredOverflow.Anchor />
+          </AnchoredOverflow.Root>
+        </Table.Viewport>
+      </Table.Root>
     </PanelContainer>
   );
 };

--- a/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
@@ -9,7 +9,7 @@ import { type PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { useClient } from '@dxos/react-client';
 import { type Space, useSpaces } from '@dxos/react-client/echo';
-import { Button, useFileDownload } from '@dxos/react-ui';
+import { AnchoredOverflow, Button, useFileDownload } from '@dxos/react-ui';
 import { Table, type TableColumnDef, createColumnBuilder, textPadding } from '@dxos/react-ui-table';
 
 import { DialogRestoreSpace } from './DialogRestoreSpace';
@@ -122,10 +122,23 @@ export const SpaceListPanel: FC = () => {
     }),
   ];
 
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
   return (
     <PanelContainer classNames='overflow-auto flex-1'>
       <DialogRestoreSpace handleFile={handleImport} />
-      <Table<Space> columns={columns} data={spaces} onDatumClick={handleSelect} fullWidth />
+
+      {/* TODO(Zan): Is this the right container? */}
+      <AnchoredOverflow.Root ref={containerRef}>
+        <Table<Space>
+          columns={columns}
+          data={spaces}
+          onDatumClick={handleSelect}
+          fullWidth
+          getScrollElement={() => containerRef.current}
+        />
+        <AnchoredOverflow.Anchor />
+      </AnchoredOverflow.Root>
     </PanelContainer>
   );
 };

--- a/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
@@ -127,12 +127,9 @@ export const SpaceListPanel: FC = () => {
       <DialogRestoreSpace handleFile={handleImport} />
 
       <Table.Root>
-        <Table.Viewport asChild>
-          {/* TODO(Zan): Is this the right container? */}
-          <AnchoredOverflow.Root>
-            <Table.Table<Space> columns={columns} data={spaces} onDatumClick={handleSelect} fullWidth />
-            <AnchoredOverflow.Anchor />
-          </AnchoredOverflow.Root>
+        <Table.Viewport classNames='overflow-anchored'>
+          <Table.Table<Space> columns={columns} data={spaces} onDatumClick={handleSelect} fullWidth />
+          <AnchoredOverflow.Anchor />
         </Table.Viewport>
       </Table.Root>
     </PanelContainer>

--- a/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalStatusTable.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalStatusTable.tsx
@@ -114,11 +114,9 @@ export const SignalStatusTable = () => {
 
   return (
     <Table.Root>
-      <Table.Viewport asChild>
-        <AnchoredOverflow.Root>
-          <Table.Table<SignalStatus> columns={columns} data={status} />
-          <AnchoredOverflow.Anchor />
-        </AnchoredOverflow.Root>
+      <Table.Viewport classNames='overflow-anchored'>
+        <Table.Table<SignalStatus> columns={columns} data={status} />
+        <AnchoredOverflow.Anchor />
       </Table.Viewport>
     </Table.Root>
   );

--- a/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalStatusTable.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalStatusTable.tsx
@@ -11,6 +11,7 @@ import { type SignalStatus } from '@dxos/messaging';
 import { type SubscribeToSignalStatusResponse } from '@dxos/protocols/proto/dxos/devtools/host';
 import { SignalState } from '@dxos/protocols/proto/dxos/mesh/signal';
 import { useDevtools, useStream } from '@dxos/react-client/devtools';
+import { AnchoredOverflow } from '@dxos/react-ui';
 import { createColumnBuilder, Table, type TableColumnDef, textPadding } from '@dxos/react-ui-table';
 
 const states = {
@@ -111,5 +112,12 @@ export const SignalStatusTable = () => {
     helper.accessor('error', {}),
   ];
 
-  return <Table<SignalStatus> columns={columns} data={status} />;
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  return (
+    <AnchoredOverflow.Root ref={containerRef}>
+      <Table<SignalStatus> columns={columns} data={status} getScrollElement={() => containerRef.current} />
+      <AnchoredOverflow.Anchor />
+    </AnchoredOverflow.Root>
+  );
 };

--- a/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalStatusTable.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalStatusTable.tsx
@@ -116,7 +116,9 @@ export const SignalStatusTable = () => {
 
   return (
     <AnchoredOverflow.Root ref={containerRef}>
-      <Table<SignalStatus> columns={columns} data={status} getScrollElement={() => containerRef.current} />
+      <Table.Root scrollContextRef={containerRef}>
+        <Table.Table<SignalStatus> columns={columns} data={status} />
+      </Table.Root>
       <AnchoredOverflow.Anchor />
     </AnchoredOverflow.Root>
   );

--- a/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalStatusTable.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalStatusTable.tsx
@@ -112,14 +112,14 @@ export const SignalStatusTable = () => {
     helper.accessor('error', {}),
   ];
 
-  const containerRef = React.useRef<HTMLDivElement>(null);
-
   return (
-    <AnchoredOverflow.Root ref={containerRef}>
-      <Table.Root scrollContextRef={containerRef}>
-        <Table.Table<SignalStatus> columns={columns} data={status} />
-      </Table.Root>
-      <AnchoredOverflow.Anchor />
-    </AnchoredOverflow.Root>
+    <Table.Root>
+      <Table.Viewport asChild>
+        <AnchoredOverflow.Root>
+          <Table.Table<SignalStatus> columns={columns} data={status} />
+          <AnchoredOverflow.Anchor />
+        </AnchoredOverflow.Root>
+      </Table.Viewport>
+    </Table.Root>
   );
 };

--- a/packages/devtools/devtools/src/panels/mesh/SwarmPanel/ConnectionInfoView.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SwarmPanel/ConnectionInfoView.tsx
@@ -49,13 +49,14 @@ export const ConnectionInfoView: FC<{ connection?: ConnectionInfo }> = ({ connec
       />
 
       <AnchoredOverflow.Root ref={containerRef} classNames='flex grow'>
-        <Table<ConnectionInfo.StreamStats>
-          columns={columns}
-          data={connection.streams ?? []}
-          keyAccessor={(row) => row.id.toString()}
-          fullWidth
-          getScrollElement={() => containerRef.current}
-        />
+        <Table.Root scrollContextRef={containerRef}>
+          <Table.Table<ConnectionInfo.StreamStats>
+            columns={columns}
+            data={connection.streams ?? []}
+            keyAccessor={(row) => row.id.toString()}
+            fullWidth
+          />
+        </Table.Root>
         <AnchoredOverflow.Anchor />
       </AnchoredOverflow.Root>
     </>

--- a/packages/devtools/devtools/src/panels/mesh/SwarmPanel/ConnectionInfoView.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SwarmPanel/ConnectionInfoView.tsx
@@ -48,16 +48,14 @@ export const ConnectionInfoView: FC<{ connection?: ConnectionInfo }> = ({ connec
       />
 
       <Table.Root>
-        <Table.Viewport asChild>
-          <AnchoredOverflow.Root classNames='flex grow'>
-            <Table.Table<ConnectionInfo.StreamStats>
-              columns={columns}
-              data={connection.streams ?? []}
-              keyAccessor={(row) => row.id.toString()}
-              fullWidth
-            />
-            <AnchoredOverflow.Anchor />
-          </AnchoredOverflow.Root>
+        <Table.Viewport classNames='flex grow overflow-anchored'>
+          <Table.Table<ConnectionInfo.StreamStats>
+            columns={columns}
+            data={connection.streams ?? []}
+            keyAccessor={(row) => row.id.toString()}
+            fullWidth
+          />
+          <AnchoredOverflow.Anchor />
         </Table.Viewport>
       </Table.Root>
     </>

--- a/packages/devtools/devtools/src/panels/mesh/SwarmPanel/ConnectionInfoView.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SwarmPanel/ConnectionInfoView.tsx
@@ -27,6 +27,7 @@ const schema = {
 
 // TODO(burdon): Stream results.
 export const ConnectionInfoView: FC<{ connection?: ConnectionInfo }> = ({ connection }) => {
+  const containerRef = React.useRef<HTMLDivElement>(null);
   if (!connection) {
     return null;
   }
@@ -47,12 +48,13 @@ export const ConnectionInfoView: FC<{ connection?: ConnectionInfo }> = ({ connec
         }}
       />
 
-      <AnchoredOverflow.Root classNames='flex grow'>
+      <AnchoredOverflow.Root ref={containerRef} classNames='flex grow'>
         <Table<ConnectionInfo.StreamStats>
           columns={columns}
           data={connection.streams ?? []}
           keyAccessor={(row) => row.id.toString()}
           fullWidth
+          getScrollElement={() => containerRef.current}
         />
         <AnchoredOverflow.Anchor />
       </AnchoredOverflow.Root>

--- a/packages/devtools/devtools/src/panels/mesh/SwarmPanel/ConnectionInfoView.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SwarmPanel/ConnectionInfoView.tsx
@@ -27,7 +27,6 @@ const schema = {
 
 // TODO(burdon): Stream results.
 export const ConnectionInfoView: FC<{ connection?: ConnectionInfo }> = ({ connection }) => {
-  const containerRef = React.useRef<HTMLDivElement>(null);
   if (!connection) {
     return null;
   }
@@ -48,17 +47,19 @@ export const ConnectionInfoView: FC<{ connection?: ConnectionInfo }> = ({ connec
         }}
       />
 
-      <AnchoredOverflow.Root ref={containerRef} classNames='flex grow'>
-        <Table.Root scrollContextRef={containerRef}>
-          <Table.Table<ConnectionInfo.StreamStats>
-            columns={columns}
-            data={connection.streams ?? []}
-            keyAccessor={(row) => row.id.toString()}
-            fullWidth
-          />
-        </Table.Root>
-        <AnchoredOverflow.Anchor />
-      </AnchoredOverflow.Root>
+      <Table.Root>
+        <Table.Viewport asChild>
+          <AnchoredOverflow.Root classNames='flex grow'>
+            <Table.Table<ConnectionInfo.StreamStats>
+              columns={columns}
+              data={connection.streams ?? []}
+              keyAccessor={(row) => row.id.toString()}
+              fullWidth
+            />
+            <AnchoredOverflow.Anchor />
+          </AnchoredOverflow.Root>
+        </Table.Viewport>
+      </Table.Root>
     </>
   );
 };

--- a/packages/devtools/devtools/src/panels/mesh/SwarmPanel/SwarmPanel.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SwarmPanel/SwarmPanel.tsx
@@ -131,15 +131,18 @@ export const SwarmPanel = () => {
   // TODO(dmaretskyi): Grid already has some sort features.
   items.sort(comparer((row) => (row.connection ? Object.keys(stateFormat).indexOf(row.connection.state) : Infinity)));
 
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
   return (
     <PanelContainer classNames='divide-y'>
-      <div className='h-1/2 overflow-auto'>
+      <div ref={containerRef} className='h-1/2 overflow-auto'>
         <Table<SwarmConnection>
           columns={columns}
           data={items}
           keyAccessor={(row) => row.id.toHex()}
           grouping={['topic']}
           onDatumClick={(datum) => handleSelect([datum])}
+          getScrollElement={() => containerRef.current}
         />
       </div>
       <div className='h-1/2 overflow-auto'>

--- a/packages/devtools/devtools/src/panels/mesh/SwarmPanel/SwarmPanel.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SwarmPanel/SwarmPanel.tsx
@@ -131,19 +131,20 @@ export const SwarmPanel = () => {
   // TODO(dmaretskyi): Grid already has some sort features.
   items.sort(comparer((row) => (row.connection ? Object.keys(stateFormat).indexOf(row.connection.state) : Infinity)));
 
-  const containerRef = React.useRef<HTMLDivElement>(null);
-
   return (
     <PanelContainer classNames='divide-y'>
-      <div ref={containerRef} className='h-1/2 overflow-auto'>
-        <Table.Table<SwarmConnection>
-          columns={columns}
-          data={items}
-          keyAccessor={(row) => row.id.toHex()}
-          grouping={['topic']}
-          onDatumClick={(datum) => handleSelect([datum])}
-        />
-      </div>
+      <Table.Root>
+        <Table.Viewport classNames='h-1/2 overflow-auto'>
+          <Table.Table<SwarmConnection>
+            columns={columns}
+            data={items}
+            keyAccessor={(row) => row.id.toHex()}
+            grouping={['topic']}
+            onDatumClick={(datum) => handleSelect([datum])}
+          />
+        </Table.Viewport>
+      </Table.Root>
+
       <div className='h-1/2 overflow-auto'>
         {sessionId ? (
           connection ? (

--- a/packages/devtools/devtools/src/panels/mesh/SwarmPanel/SwarmPanel.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SwarmPanel/SwarmPanel.tsx
@@ -136,13 +136,12 @@ export const SwarmPanel = () => {
   return (
     <PanelContainer classNames='divide-y'>
       <div ref={containerRef} className='h-1/2 overflow-auto'>
-        <Table<SwarmConnection>
+        <Table.Table<SwarmConnection>
           columns={columns}
           data={items}
           keyAccessor={(row) => row.id.toHex()}
           grouping={['topic']}
           onDatumClick={(datum) => handleSelect([datum])}
-          getScrollElement={() => containerRef.current}
         />
       </div>
       <div className='h-1/2 overflow-auto'>

--- a/packages/ui/react-ui-stack/src/testing/TableContent.tsx
+++ b/packages/ui/react-ui-stack/src/testing/TableContent.tsx
@@ -111,7 +111,8 @@ export type TableContentProps = StackSectionContent & Pick<TableProps<Item>, 'co
 
 export const TableContent = ({ data: { columns, data } }: { data: TableContentProps }) => (
   <Table.Root>
-    {/* TODO(Zan): Does this work without viewport? */}
-    <Table.Table columns={columns} data={data} />;
+    <Table.Viewport>
+      <Table.Table columns={columns} data={data} />;
+    </Table.Viewport>
   </Table.Root>
 );

--- a/packages/ui/react-ui-stack/src/testing/TableContent.tsx
+++ b/packages/ui/react-ui-stack/src/testing/TableContent.tsx
@@ -109,6 +109,9 @@ export const createItems = (count: number) =>
 
 export type TableContentProps = StackSectionContent & Pick<TableProps<Item>, 'columns' | 'data'>;
 
-export const TableContent = ({ data: { columns, data } }: { data: TableContentProps }) => {
-  return <Table columns={columns} data={data} />;
-};
+export const TableContent = ({ data: { columns, data } }: { data: TableContentProps }) => (
+  <Table.Root>
+    {/* TODO(Zan): Does this work without viewport? */}
+    <Table.Table columns={columns} data={data} />;
+  </Table.Root>
+);

--- a/packages/ui/react-ui-table/package.json
+++ b/packages/ui/react-ui-table/package.json
@@ -29,6 +29,7 @@
     "@fluentui/react-tabster": "^9.19.0",
     "@radix-ui/react-context": "^1.0.0",
     "@radix-ui/react-primitive": "^1.0.2",
+    "@radix-ui/react-slot": "^1.0.1",
     "@radix-ui/react-use-controllable-state": "^1.0.0",
     "@tanstack/react-table": "^8.13.2",
     "@tanstack/react-virtual": "^3.0.1",

--- a/packages/ui/react-ui-table/package.json
+++ b/packages/ui/react-ui-table/package.json
@@ -28,6 +28,7 @@
     "@effect/schema": "0.64.7",
     "@fluentui/react-tabster": "^9.19.0",
     "@radix-ui/react-context": "^1.0.0",
+    "@radix-ui/react-primitive": "^1.0.2",
     "@radix-ui/react-use-controllable-state": "^1.0.0",
     "@tanstack/react-table": "^8.13.2",
     "@tanstack/react-virtual": "^3.0.1",

--- a/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
@@ -116,9 +116,19 @@ const makeColumns = (onUpdate?: ValueUpdater<Item, any>): TableColumnDef<Item, a
 // Tests
 //
 
+const MinimalTable = (props: any) => {
+  return (
+    <Table.Root>
+      <Table.Viewport classNames='fixed inset-0 overflow-auto'>
+        <Table.Table<any> {...props} />
+      </Table.Viewport>
+    </Table.Root>
+  );
+};
+
 export default {
   title: 'react-ui-table/Table',
-  component: Table,
+  component: MinimalTable,
   args: {
     header: true,
     keyAccessor: (item: Item) => item.publicKey.toHex(),
@@ -205,7 +215,7 @@ export const Dynamic = {
 
     return (
       <Table.Root>
-        <Table.Viewport classNames='fixed inset-0'>
+        <Table.Viewport classNames='fixed inset-0 overflow-auto'>
           <Table.Table<Item>
             role='grid'
             rowsSelectable='multi'
@@ -236,7 +246,7 @@ export const Editable = {
 
     return (
       <Table.Root>
-        <Table.Viewport classNames='fixed inset-0'>
+        <Table.Viewport classNames='fixed inset-0 overflow-auto'>
           <Table.Table<Item>
             role='grid'
             rowsSelectable='multi'
@@ -267,7 +277,7 @@ export const PinnedLastRow = {
 
     return (
       <Table.Root>
-        <Table.Viewport classNames='fixed inset-0'>
+        <Table.Viewport classNames='fixed inset-0 overflow-auto'>
           <Table.Table<Item>
             role='grid'
             rowsSelectable='multi'
@@ -321,7 +331,7 @@ export const InsertDelete = {
           <Button onClick={onDeleteLast}>Delete last</Button>
         </div>
         <Table.Root>
-          <Table.Viewport classNames='fixed inset-0'>
+          <Table.Viewport classNames='fixed inset-0 overflow-auto'>
             <Table.Table<Item>
               role='grid'
               rowsSelectable='multi'
@@ -351,7 +361,7 @@ export const Resizable = {
 
     return (
       <Table.Root>
-        <Table.Viewport classNames='fixed inset-0'>
+        <Table.Viewport classNames='fixed inset-0 overflow-auto'>
           <Table.Table<Item>
             rowsSelectable='multi'
             keyAccessor={(row) => row.publicKey.toHex()}
@@ -379,7 +389,7 @@ export const TenThousandRows = {
 
     return (
       <Table.Root>
-        <Table.Viewport classNames='fixed inset-0'>
+        <Table.Viewport classNames='fixed inset-0 overflow-auto'>
           <Table.Table<Item>
             role='grid'
             rowsSelectable='multi'
@@ -481,7 +491,7 @@ export const RealTimeUpdates = {
 
     return (
       <Table.Root>
-        <Table.Viewport classNames='fixed inset-0'>
+        <Table.Viewport classNames='fixed inset-0 overflow-auto'>
           <Table.Table<Item>
             role='grid'
             rowsSelectable='multi'

--- a/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
@@ -5,13 +5,13 @@
 import '@dxosTheme';
 
 import { Plugs, PlugsConnected } from '@phosphor-icons/react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { create } from '@dxos/echo-schema';
 import { registerSignalRuntime } from '@dxos/echo-signals/react';
 import { PublicKey } from '@dxos/keys';
 import { faker } from '@dxos/random';
-import { AnchoredOverflow, Button, DensityProvider } from '@dxos/react-ui';
+import { Button, DensityProvider } from '@dxos/react-ui';
 import { withTheme } from '@dxos/storybook-utils';
 import { range } from '@dxos/util';
 
@@ -187,7 +187,6 @@ export const Empty = {
 
 export const Dynamic = {
   render: () => {
-    const containerRef = useRef<HTMLDivElement | null>(null);
     const [items, setItems] = useState<Item[]>(createItems(50));
 
     useEffect(() => {
@@ -205,26 +204,27 @@ export const Dynamic = {
     const columns = useMemo(() => makeColumns(), []);
 
     return (
-      <AnchoredOverflow.Root classNames='max-bs-[80dvh]' ref={containerRef}>
-        <Table<Item>
-          rowsSelectable='multi'
-          keyAccessor={(row) => row.publicKey.toHex()}
-          columns={columns}
-          data={items}
-          fullWidth
-          footer
-          stickyHeader
-          getScrollElement={() => containerRef.current}
-        />
-        <AnchoredOverflow.Anchor />
-      </AnchoredOverflow.Root>
+      <Table.Root>
+        <Table.Viewport classNames='fixed inset-0'>
+          <Table.Table<Item>
+            role='grid'
+            rowsSelectable='multi'
+            keyAccessor={(row) => row.publicKey.toHex()}
+            columns={columns}
+            data={items}
+            fullWidth
+            stickyHeader
+            border
+            pinLastRow
+          />
+        </Table.Viewport>
+      </Table.Root>
     );
   },
 };
 
 export const Editable = {
   render: () => {
-    const containerRef = useRef<HTMLDivElement | null>(null);
     const [items, setItems] = useState<Item[]>(createItems(200));
 
     const onUpdate: ValueUpdater<Item, any> = useCallback(
@@ -235,26 +235,27 @@ export const Editable = {
     const columns = useMemo(() => makeColumns(onUpdate), [onUpdate]);
 
     return (
-      <div ref={containerRef} className='fixed inset-0 overflow-auto'>
-        <Table<Item>
-          role='grid'
-          rowsSelectable='multi'
-          keyAccessor={(row) => row.publicKey.toHex()}
-          columns={columns}
-          data={items}
-          fullWidth
-          stickyHeader
-          border
-          getScrollElement={() => containerRef.current}
-        />
-      </div>
+      <Table.Root>
+        <Table.Viewport classNames='fixed inset-0'>
+          <Table.Table<Item>
+            role='grid'
+            rowsSelectable='multi'
+            keyAccessor={(row) => row.publicKey.toHex()}
+            columns={columns}
+            data={items}
+            fullWidth
+            stickyHeader
+            border
+            pinLastRow
+          />
+        </Table.Viewport>
+      </Table.Root>
     );
   },
 };
 
 export const PinnedLastRow = {
   render: () => {
-    const containerRef = useRef<HTMLDivElement | null>(null);
     const [items, setItems] = useState<Item[]>(createItems(200));
 
     const onUpdate: ValueUpdater<Item, any> = useCallback(
@@ -265,27 +266,27 @@ export const PinnedLastRow = {
     const columns = useMemo(() => makeColumns(onUpdate), [onUpdate]);
 
     return (
-      <div ref={containerRef} className='fixed inset-0 overflow-auto'>
-        <Table<Item>
-          role='grid'
-          rowsSelectable='multi'
-          keyAccessor={(row) => row.publicKey.toHex()}
-          columns={columns}
-          data={items}
-          fullWidth
-          stickyHeader
-          border
-          getScrollElement={() => containerRef.current}
-          pinLastRow
-        />
-      </div>
+      <Table.Root>
+        <Table.Viewport classNames='fixed inset-0'>
+          <Table.Table<Item>
+            role='grid'
+            rowsSelectable='multi'
+            keyAccessor={(row) => row.publicKey.toHex()}
+            columns={columns}
+            data={items}
+            fullWidth
+            stickyHeader
+            border
+            pinLastRow
+          />
+        </Table.Viewport>
+      </Table.Root>
     );
   },
 };
 
 export const InsertDelete = {
   render: () => {
-    const containerRef = useRef<HTMLDivElement | null>(null);
     const [items, setItems] = useState<Item[]>(createItems(10));
 
     const onUpdate: ValueUpdater<Item, any> = useCallback(
@@ -319,20 +320,21 @@ export const InsertDelete = {
           <Button onClick={onDeleteFirst}>Delete first</Button>
           <Button onClick={onDeleteLast}>Delete last</Button>
         </div>
-        <div ref={containerRef} className='fixed inset-0 top-[72px] overflow-auto'>
-          <Table<Item>
-            role='grid'
-            rowsSelectable='multi'
-            keyAccessor={(row) => row.publicKey.toHex()}
-            columns={columns}
-            data={items}
-            fullWidth
-            stickyHeader
-            border
-            getScrollElement={() => containerRef.current}
-            pinLastRow
-          />
-        </div>
+        <Table.Root>
+          <Table.Viewport classNames='fixed inset-0'>
+            <Table.Table<Item>
+              role='grid'
+              rowsSelectable='multi'
+              keyAccessor={(row) => row.publicKey.toHex()}
+              columns={columns}
+              data={items}
+              fullWidth
+              stickyHeader
+              border
+              pinLastRow
+            />
+          </Table.Viewport>
+        </Table.Root>
       </div>
     );
   },
@@ -340,7 +342,6 @@ export const InsertDelete = {
 
 export const Resizable = {
   render: () => {
-    const containerRef = useRef<HTMLDivElement | null>(null);
     const [items, setItems] = useState<Item[]>(createItems(10));
 
     const onUpdate: ValueUpdater<Item, any> = useCallback(
@@ -349,25 +350,24 @@ export const Resizable = {
     );
 
     return (
-      <div ref={containerRef} className='fixed inset-0 overflow-auto'>
-        <Table<Item>
-          rowsSelectable='multi'
-          keyAccessor={(row) => row.publicKey.toHex()}
-          columns={makeColumns(onUpdate)}
-          data={items}
-          fullWidth
-          stickyHeader
-          getScrollElement={() => containerRef.current}
-          // onColumnResize={handleColumnResize}
-        />
-      </div>
+      <Table.Root>
+        <Table.Viewport classNames='fixed inset-0'>
+          <Table.Table<Item>
+            rowsSelectable='multi'
+            keyAccessor={(row) => row.publicKey.toHex()}
+            columns={makeColumns(onUpdate)}
+            data={items}
+            fullWidth
+            stickyHeader
+          />
+        </Table.Viewport>
+      </Table.Root>
     );
   },
 };
 
 export const TenThousandRows = {
   render: () => {
-    const containerRef = useRef<HTMLDivElement | null>(null);
     const [items, setItems] = useState<Item[]>(createItems(10000));
 
     const onUpdate: ValueUpdater<Item, any> = useCallback(
@@ -378,19 +378,20 @@ export const TenThousandRows = {
     const columns = useMemo(() => makeColumns(onUpdate), [onUpdate]);
 
     return (
-      <div ref={containerRef} className='fixed inset-0 overflow-auto'>
-        <Table<Item>
-          role='grid'
-          rowsSelectable='multi'
-          keyAccessor={(row) => row.publicKey.toHex()}
-          columns={columns}
-          data={items}
-          fullWidth
-          stickyHeader
-          border
-          getScrollElement={() => containerRef.current}
-        />
-      </div>
+      <Table.Root>
+        <Table.Viewport classNames='fixed inset-0'>
+          <Table.Table<Item>
+            role='grid'
+            rowsSelectable='multi'
+            keyAccessor={(row) => row.publicKey.toHex()}
+            columns={columns}
+            data={items}
+            fullWidth
+            stickyHeader
+            border
+          />{' '}
+        </Table.Viewport>
+      </Table.Root>
     );
   },
 };
@@ -475,25 +476,25 @@ export const RealTimeUpdates = {
       return () => clearInterval(interval);
     }, [periodicDeletions, deletionInterval, state.items]);
 
-    const containerRef = useRef<HTMLDivElement | null>(null);
-
     const onUpdate = useCallback((...args: any[]) => {}, []);
     const columns = useMemo(() => makeColumns(onUpdate), []);
 
     return (
-      <div ref={containerRef} className='fixed inset-0 overflow-auto'>
-        <Table<Item>
-          role='grid'
-          rowsSelectable='multi'
-          keyAccessor={(row) => row.publicKey.toHex()}
-          columns={columns}
-          data={state.items}
-          fullWidth
-          stickyHeader
-          border
-          getScrollElement={() => containerRef.current}
-        />
-      </div>
+      <Table.Root>
+        <Table.Viewport classNames='fixed inset-0'>
+          <Table.Table<Item>
+            role='grid'
+            rowsSelectable='multi'
+            keyAccessor={(row) => row.publicKey.toHex()}
+            columns={columns}
+            data={state.items}
+            fullWidth
+            stickyHeader
+            border
+            pinLastRow
+          />
+        </Table.Viewport>
+      </Table.Root>
     );
   },
 };

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -45,8 +45,7 @@ type TableViewportProps = ThemedClassName<ComponentPropsWithoutRef<typeof Primit
 const TableViewport = ({ children, classNames, ...props }: TableViewportProps) => {
   const { scrollContextRef } = useTableRootContext();
 
-  // TODO(Zan): This isn't sufficient yet.
-  const classes = mx('overflow-auto', classNames);
+  const classes = mx(classNames);
 
   return (
     <div role='none' className={classes} ref={scrollContextRef} {...props}>

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -2,6 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 import { type Primitive } from '@radix-ui/react-primitive';
+import { Slot } from '@radix-ui/react-slot';
 import {
   getCoreRowModel,
   getSortedRowModel,
@@ -26,29 +27,27 @@ import { type TableProps } from './props';
 import { useColumnResizing, usePinLastRow, useRowSelection } from '../../hooks';
 import { groupTh, tableRoot } from '../../theme';
 
-type TableRootProps = {
-  children: React.ReactNode;
-  scrollContextRef?: React.RefObject<HTMLDivElement>;
-};
+type TableRootProps = { children: React.ReactNode };
 
-const TableRoot = ({ children, scrollContextRef }: TableRootProps) => {
-  const contextValue = useTableRootContext(scrollContextRef);
+const TableRoot = ({ children }: TableRootProps) => {
+  const contextValue = useTableRootContext();
   return <TableRootContext.Provider value={contextValue}>{children}</TableRootContext.Provider>;
 };
 
-type TableViewportProps = ThemedClassName<ComponentPropsWithoutRef<typeof Primitive.div>>;
+type TableViewportProps = ThemedClassName<ComponentPropsWithoutRef<typeof Primitive.div>> & {
+  asChild?: boolean;
+};
 
-const TableViewport = ({ children, classNames, ...props }: TableViewportProps) => {
-  const { dispatch } = useContext(TableRootContext);
-  const scrollContextRef = React.useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    dispatch({ type: 'updateScrollContextRef', ref: scrollContextRef });
-  }, []);
+const TableViewport = ({ children, classNames, asChild, ...props }: TableViewportProps) => {
+  const { scrollContextRef } = useContext(TableRootContext);
 
   const classes = mx(classNames);
 
-  return (
+  return asChild ? (
+    <Slot ref={scrollContextRef} {...props}>
+      {children}
+    </Slot>
+  ) : (
     <div role='none' className={classes} ref={scrollContextRef} {...props}>
       {children}
     </div>

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -197,9 +197,14 @@ const TableImpl = <TData extends RowData>(props: TableProps<TData>) => {
 
 const VirtualizedTableContent = () => {
   const { table } = useTableContext();
-  const { scrollContextRef } = useContext(TableRootContext);
+  const { virtualizer, dispatch } = useContext(TableRootContext);
 
   const centerRows = table.getCenterRows();
+
+  useEffect(() => {
+    dispatch({ type: 'updateTableCount', count: centerRows.length });
+  }, [centerRows.length]);
+
   let pinnedRows = [] as Row<unknown>[];
 
   try {
@@ -211,24 +216,19 @@ const VirtualizedTableContent = () => {
   } catch (_) {} // Ignore error
 
   // TODO(Zan): This needs to move to the TableRoot context.
-  const { getTotalSize, getVirtualItems } = useVirtualizer({
-    getScrollElement: () => scrollContextRef?.current ?? null,
-    count: centerRows.length,
-    overscan: 8,
-    estimateSize: () => 40,
-  });
+  const { getTotalSize, getVirtualItems } = virtualizer;
 
-  // TODO: (Zan), this always fires on mount before the scroll context ref is set.
-  // We can resolve this when we support unvirtualised tables again.
-  if (scrollContextRef === undefined) {
-    log.warn(
-      [
-        'No scroll context ref found.',
-        'Either wrap `Table` in a `Table.Viewport` or provide a `scrollContextRef` to the `Table.Root`',
-      ].join('\n'),
-    );
-    return null;
-  }
+  // // TODO: (Zan), this always fires on mount before the scroll context ref is set.
+  // // We can resolve this when we support unvirtualised tables again.
+  // if (scrollContextRef === undefined) {
+  //   log.warn(
+  //     [
+  //       'No scroll context ref found.',
+  //       'Either wrap `Table` in a `Table.Viewport` or provide a `scrollContextRef` to the `Table.Root`',
+  //     ].join('\n'),
+  //   );
+  //   return null;
+  // }
 
   const virtualRows = getVirtualItems();
   const totalSize = getTotalSize();

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -12,10 +12,8 @@ import {
   getExpandedRowModel,
   type Row,
 } from '@tanstack/react-table';
-import { useVirtualizer } from '@tanstack/react-virtual';
 import React, { type ComponentPropsWithoutRef, Fragment, useCallback, useEffect, useState, useContext } from 'react';
 
-import { log } from '@dxos/log';
 import { type ThemedClassName, useDefaultValue } from '@dxos/react-ui';
 import { mx } from '@dxos/react-ui-theme';
 

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -212,20 +212,7 @@ const VirtualizedTableContent = () => {
     pinnedRows = table.getBottomRows();
   } catch (_) {} // Ignore error
 
-  // TODO(Zan): This needs to move to the TableRoot context.
   const { getTotalSize, getVirtualItems } = virtualizer;
-
-  // // TODO: (Zan), this always fires on mount before the scroll context ref is set.
-  // // We can resolve this when we support unvirtualised tables again.
-  // if (scrollContextRef === undefined) {
-  //   log.warn(
-  //     [
-  //       'No scroll context ref found.',
-  //       'Either wrap `Table` in a `Table.Viewport` or provide a `scrollContextRef` to the `Table.Root`',
-  //     ].join('\n'),
-  //   );
-  //   return null;
-  // }
 
   const virtualRows = getVirtualItems();
   const totalSize = getTotalSize();

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -1,6 +1,7 @@
 //
 // Copyright 2023 DXOS.org
 //
+import { type Primitive } from '@radix-ui/react-primitive';
 import {
   getCoreRowModel,
   getSortedRowModel,
@@ -12,19 +13,49 @@ import {
   type Row,
 } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import React, { Fragment, useCallback, useEffect, useState } from 'react';
+import React, { type ComponentPropsWithoutRef, Fragment, useCallback, useEffect, useState } from 'react';
 
-import { useDefaultValue } from '@dxos/react-ui';
+import { type ThemedClassName, useDefaultValue } from '@dxos/react-ui';
+import { mx } from '@dxos/react-ui-theme';
 
 import { TableBody } from './TableBody';
 import { type TypedTableProvider, TableProvider as UntypedTableProvider, useTableContext } from './TableContext';
 import { TableFooter } from './TableFooter';
 import { TableHead } from './TableHead';
+import { TableRootProvider, useTableRootContext } from './TableRootContext';
 import { type TableProps } from './props';
 import { useColumnResizing, usePinLastRow, useRowSelection } from '../../hooks';
 import { groupTh, tableRoot } from '../../theme';
 
-export const Table = <TData extends RowData>(props: TableProps<TData>) => {
+type TableRootProps = {
+  children: React.ReactNode;
+  scrollContextRef?: React.RefObject<HTMLDivElement>;
+};
+
+const TableRoot = ({ children, scrollContextRef }: TableRootProps) => {
+  // Use provided scrollContextRef or a new internal ref as a fallback
+  const internalRef = React.useRef<HTMLDivElement>(null);
+  const effectiveRef = scrollContextRef || internalRef;
+
+  return <TableRootProvider scrollContextRef={effectiveRef}>{children}</TableRootProvider>;
+};
+
+type TableViewportProps = ThemedClassName<ComponentPropsWithoutRef<typeof Primitive.div>>;
+
+const TableViewport = ({ children, classNames, ...props }: TableViewportProps) => {
+  const { scrollContextRef } = useTableRootContext();
+
+  // TODO(Zan): This isn't sufficient yet.
+  const classes = mx('overflow-auto', classNames);
+
+  return (
+    <div role='none' className={classes} ref={scrollContextRef} {...props}>
+      {children}
+    </div>
+  );
+};
+
+export const TablePrimitive = <TData extends RowData>(props: TableProps<TData>) => {
   const {
     role,
     onColumnResize,
@@ -33,7 +64,6 @@ export const Table = <TData extends RowData>(props: TableProps<TData>) => {
     rowsSelectable,
     debug,
     onDataSelectionChange,
-    getScrollElement,
     pinLastRow,
   } = props;
 
@@ -110,7 +140,7 @@ export const Table = <TData extends RowData>(props: TableProps<TData>) => {
     onDataSelectionChange?.(Object.keys(rowSelection).map((id) => table.getRowModel().rowsById[id].original));
   }, [onDataSelectionChange, rowSelection, table]);
 
-  usePinLastRow(pinLastRow, table, data, getScrollElement);
+  usePinLastRow(pinLastRow, table, data);
 
   // Create additional expansion column if all columns have fixed width.
   const expand = false; // columns.map((column) => column.size).filter(Boolean).length === columns?.length;
@@ -128,11 +158,12 @@ export const Table = <TData extends RowData>(props: TableProps<TData>) => {
   );
 };
 
+// TODO(Zan): Smush this into the Table component.
 /**
  * Pure implementation of table outside of context set-up.
  */
 const TableImpl = <TData extends RowData>(props: TableProps<TData>) => {
-  const { debug, classNames, getScrollElement, role, footer, grouping, fullWidth } = props;
+  const { debug, classNames, role, footer, grouping, fullWidth } = props;
   const { table } = useTableContext<TData>();
 
   if (debug) {
@@ -155,15 +186,16 @@ const TableImpl = <TData extends RowData>(props: TableProps<TData>) => {
     >
       <TableHead />
 
-      {grouping?.length !== 0 ? <TableComponent getScrollElement={getScrollElement} /> : <GroupedTableContent />}
+      {grouping?.length !== 0 ? <TableComponent /> : <GroupedTableContent />}
 
       {footer && <TableFooter />}
     </table>
   );
 };
 
-const VirtualizedTableContent = ({ getScrollElement }: Pick<TableProps<any>, 'getScrollElement'>) => {
+const VirtualizedTableContent = () => {
   const { table } = useTableContext();
+  const { scrollContextRef } = useTableRootContext();
 
   const centerRows = table.getCenterRows();
   let pinnedRows = [] as Row<unknown>[];
@@ -176,8 +208,9 @@ const VirtualizedTableContent = ({ getScrollElement }: Pick<TableProps<any>, 'ge
     pinnedRows = table.getBottomRows();
   } catch (_) {} // Ignore error
 
+  // TODO(Zan): This needs to move to the TableRoot context.
   const { getTotalSize, getVirtualItems } = useVirtualizer({
-    getScrollElement,
+    getScrollElement: () => scrollContextRef.current,
     count: centerRows.length,
     overscan: 8,
     estimateSize: () => 40,
@@ -232,4 +265,10 @@ const GroupedTableContent = () => {
       })}
     </>
   );
+};
+
+export const Table = {
+  Root: TableRoot,
+  Table: TablePrimitive,
+  Viewport: TableViewport,
 };

--- a/packages/ui/react-ui-table/src/components/Table/TableBody.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/TableBody.tsx
@@ -4,9 +4,10 @@
 
 import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import { flexRender, type Row, type RowData } from '@tanstack/react-table';
-import React from 'react';
+import React, { useContext } from 'react';
 
 import { useTableContext } from './TableContext';
+import { TableRootContext } from './TableRootContext';
 import { tbodyTr } from '../../theme';
 import { Cell } from '../Cell/Cell';
 
@@ -23,6 +24,8 @@ const TableBody = ({ rows }: TableBodyProps) => {
   const domAttributes = useArrowNavigationGroup({ axis: 'grid' });
   const canBeCurrent = !isGrid && !!onDatumClick;
 
+  const { virtualizer } = useContext(TableRootContext);
+
   return (
     <tbody {...(isGrid && domAttributes)}>
       {rows.map((row) => {
@@ -37,6 +40,8 @@ const TableBody = ({ rows }: TableBodyProps) => {
           <tr
             key={keyAccessor ? keyAccessor(row.original) : row.id}
             className={classNames}
+            data-index={row.index}
+            ref={virtualizer.measureElement}
             {...(isCurrent && { 'aria-current': 'location' })}
             {...(isSelected && { 'aria-selected': 'true' })}
             {...(canBeCurrent && {

--- a/packages/ui/react-ui-table/src/components/Table/TableRootContext.ts
+++ b/packages/ui/react-ui-table/src/components/Table/TableRootContext.ts
@@ -3,15 +3,12 @@
 //
 
 import { useVirtualizer } from '@tanstack/react-virtual';
-import type React from 'react';
-import { createContext, useState } from 'react';
+import { createContext, useRef, useState } from 'react';
 
-type TableRootContextActions =
-  | { type: 'updateScrollContextRef'; ref: React.RefObject<HTMLDivElement> }
-  | { type: 'updateTableCount'; count: number };
+type TableRootContextActions = { type: 'updateTableCount'; count: number };
 
-export const useTableRootContext = (initialRef?: React.RefObject<HTMLDivElement>) => {
-  const [scrollContextRef, setScrollContextRef] = useState(initialRef);
+export const useTableRootContext = () => {
+  const scrollContextRef = useRef<HTMLDivElement>(null);
   const [tableCount, setTableCount] = useState(0);
 
   const virtualizer = useVirtualizer({
@@ -23,10 +20,6 @@ export const useTableRootContext = (initialRef?: React.RefObject<HTMLDivElement>
 
   const dispatch = (action: TableRootContextActions) => {
     switch (action.type) {
-      case 'updateScrollContextRef':
-        setScrollContextRef(action.ref);
-        break;
-
       case 'updateTableCount':
         setTableCount(action.count);
         break;

--- a/packages/ui/react-ui-table/src/components/Table/TableRootContext.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/TableRootContext.tsx
@@ -2,25 +2,30 @@
 // Copyright 2024 DXOS.org
 //
 
-import React, { useContext, createContext, type ReactNode } from 'react';
+import type React from 'react';
+import { createContext, useState } from 'react';
 
-type TableRootContextValue = {
-  scrollContextRef: React.RefObject<HTMLDivElement>;
+type TableRootContextActions = { type: 'updateScrollContextRef'; ref: React.RefObject<HTMLDivElement> };
+
+export const useTableRootContext = (initialRef?: React.RefObject<HTMLDivElement>) => {
+  const [scrollContextRef, setScrollContextRef] = useState(initialRef);
+
+  const dispatch = (action: TableRootContextActions) => {
+    switch (action.type) {
+      case 'updateScrollContextRef':
+        setScrollContextRef(action.ref);
+        break;
+
+      default:
+        break;
+    }
+  };
+
+  return { scrollContextRef, dispatch };
 };
+
+export type TableRootContextValue = ReturnType<typeof useTableRootContext>;
 
 // Create the context without a default value.
 // The expectation is that the provider will always supply a value, so no need to define a default here.
-const TableContext = createContext<TableRootContextValue>({} as TableRootContextValue);
-
-export const TableRootProvider: React.FC<TableRootContextValue & { children: ReactNode }> = ({
-  children,
-  ...value
-}) => {
-  return <TableContext.Provider value={value}>{children}</TableContext.Provider>;
-};
-
-// Create a custom hook to consume the context
-export const useTableRootContext = (): TableRootContextValue => {
-  const context = useContext(TableContext as React.Context<TableRootContextValue>);
-  return context;
-};
+export const TableRootContext = createContext<TableRootContextValue>({} as TableRootContextValue);

--- a/packages/ui/react-ui-table/src/components/Table/TableRootContext.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/TableRootContext.tsx
@@ -1,0 +1,26 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import React, { useContext, createContext, type ReactNode } from 'react';
+
+type TableRootContextValue = {
+  scrollContextRef: React.RefObject<HTMLDivElement>;
+};
+
+// Create the context without a default value.
+// The expectation is that the provider will always supply a value, so no need to define a default here.
+const TableContext = createContext<TableRootContextValue>({} as TableRootContextValue);
+
+export const TableRootProvider: React.FC<TableRootContextValue & { children: ReactNode }> = ({
+  children,
+  ...value
+}) => {
+  return <TableContext.Provider value={value}>{children}</TableContext.Provider>;
+};
+
+// Create a custom hook to consume the context
+export const useTableRootContext = (): TableRootContextValue => {
+  const context = useContext(TableContext as React.Context<TableRootContextValue>);
+  return context;
+};

--- a/packages/ui/react-ui-table/src/components/Table/TableRootContext.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/TableRootContext.tsx
@@ -2,13 +2,24 @@
 // Copyright 2024 DXOS.org
 //
 
+import { useVirtualizer } from '@tanstack/react-virtual';
 import type React from 'react';
 import { createContext, useState } from 'react';
 
-type TableRootContextActions = { type: 'updateScrollContextRef'; ref: React.RefObject<HTMLDivElement> };
+type TableRootContextActions =
+  | { type: 'updateScrollContextRef'; ref: React.RefObject<HTMLDivElement> }
+  | { type: 'updateTableCount'; count: number };
 
 export const useTableRootContext = (initialRef?: React.RefObject<HTMLDivElement>) => {
   const [scrollContextRef, setScrollContextRef] = useState(initialRef);
+  const [tableCount, setTableCount] = useState(0);
+
+  const virtualizer = useVirtualizer({
+    getScrollElement: () => scrollContextRef?.current ?? null,
+    count: tableCount,
+    overscan: 8,
+    estimateSize: () => 40,
+  });
 
   const dispatch = (action: TableRootContextActions) => {
     switch (action.type) {
@@ -16,12 +27,16 @@ export const useTableRootContext = (initialRef?: React.RefObject<HTMLDivElement>
         setScrollContextRef(action.ref);
         break;
 
+      case 'updateTableCount':
+        setTableCount(action.count);
+        break;
+
       default:
         break;
     }
   };
 
-  return { scrollContextRef, dispatch };
+  return { scrollContextRef, virtualizer, dispatch };
 };
 
 export type TableRootContextValue = ReturnType<typeof useTableRootContext>;

--- a/packages/ui/react-ui-table/src/components/Table/index.ts
+++ b/packages/ui/react-ui-table/src/components/Table/index.ts
@@ -4,3 +4,4 @@
 
 export * from './Table';
 export * from './props';
+export * from './TableRootContext';

--- a/packages/ui/react-ui-table/src/components/Table/props.ts
+++ b/packages/ui/react-ui-table/src/components/Table/props.ts
@@ -3,7 +3,6 @@
 //
 
 import { type RowData, type RowSelectionState, type Table, type VisibilityState } from '@tanstack/react-table';
-import { type VirtualizerOptions } from '@tanstack/react-virtual';
 
 import { type ClassNameValue } from '@dxos/react-ui-types';
 
@@ -48,7 +47,7 @@ export type TableProps<TData extends RowData> = TableFlags &
     // `table` element props
     classNames: ClassNameValue;
     pinLastRow: boolean;
-  }> & { getScrollElement: VirtualizerOptions<Element, any>['getScrollElement'] };
+  }>;
 
 export type { RowSelectionState, VisibilityState, TableColumnDef, KeyValue };
 

--- a/packages/ui/react-ui-table/src/components/Table/props.ts
+++ b/packages/ui/react-ui-table/src/components/Table/props.ts
@@ -31,30 +31,24 @@ export type TableCurrent<TData extends RowData> = Partial<{
   onDatumClick: (datum: TData) => void;
 }>;
 
-export type TableProps<
-  TData extends RowData,
-  ScrollElement extends Element | Window = Element,
-  ItemElement extends Element = HTMLTableRowElement,
-> = TableFlags &
+export type TableProps<TData extends RowData> = TableFlags &
   TableCurrent<TData> &
-  Partial<
-    {
-      keyAccessor: KeyValue<TData>;
-      data: TData[];
-      columns: TableColumnDef<TData>[];
-      onColumnResize: (state: Record<string, number>) => void;
-      columnVisibility: VisibilityState;
-      // Controllable row selection
-      rowSelection: RowSelectionState;
-      defaultRowSelection: RowSelectionState;
-      onRowSelectionChange: (rowSelection: RowSelectionState) => void;
-      // Derived from row selection
-      onDataSelectionChange: (dataSelection: TData[]) => void;
-      // `table` element props
-      classNames: ClassNameValue;
-      pinLastRow: boolean;
-    } & Pick<VirtualizerOptions<ScrollElement, ItemElement>, 'getScrollElement'>
-  >;
+  Partial<{
+    keyAccessor: KeyValue<TData>;
+    data: TData[];
+    columns: TableColumnDef<TData>[];
+    onColumnResize: (state: Record<string, number>) => void;
+    columnVisibility: VisibilityState;
+    // Controllable row selection
+    rowSelection: RowSelectionState;
+    defaultRowSelection: RowSelectionState;
+    onRowSelectionChange: (rowSelection: RowSelectionState) => void;
+    // Derived from row selection
+    onDataSelectionChange: (dataSelection: TData[]) => void;
+    // `table` element props
+    classNames: ClassNameValue;
+    pinLastRow: boolean;
+  }> & { getScrollElement: VirtualizerOptions<Element, any>['getScrollElement'] };
 
 export type { RowSelectionState, VisibilityState, TableColumnDef, KeyValue };
 

--- a/packages/ui/react-ui-table/src/hooks/usePinLastRow.ts
+++ b/packages/ui/react-ui-table/src/hooks/usePinLastRow.ts
@@ -5,21 +5,21 @@
 import { type Row, type Table } from '@tanstack/react-table';
 import { useCallback, useEffect, useState } from 'react';
 
-export const usePinLastRow = (
-  pinLastRow: boolean | undefined,
-  table: Table<any>,
-  data: any[],
-  getScrollElement?: () => Element | null,
-) => {
+import { useTableRootContext } from '../components';
+
+export const usePinLastRow = (pinLastRow: boolean | undefined, table: Table<any>, data: any[]) => {
+  const { scrollContextRef } = useTableRootContext();
   const [pinnedRowKey, setPinnedRowKey] = useState<string>();
 
   // Scrolls to the bottom of a scrollable element.
   const scrollToBottom = useCallback(() => {
-    const scrollElement = getScrollElement?.();
-    if (scrollElement) {
-      requestAnimationFrame(() => scrollElement.scrollTo({ top: scrollElement.scrollHeight }));
+    const element = scrollContextRef.current;
+    const scrollHeight = element?.scrollHeight;
+
+    if (element && scrollHeight) {
+      requestAnimationFrame(() => element.scrollTo({ top: scrollHeight }));
     }
-  }, [getScrollElement]);
+  }, []);
 
   const pinRow = useCallback(
     (rowToPin: Row<any>) => {

--- a/packages/ui/react-ui-table/src/schema/SchemaToTable.stories.tsx
+++ b/packages/ui/react-ui-table/src/schema/SchemaToTable.stories.tsx
@@ -6,7 +6,7 @@ import '@dxosTheme';
 
 import * as Arbitrary from '@effect/schema/Arbitrary';
 import * as fc from 'fast-check';
-import React, { useRef } from 'react';
+import React from 'react';
 
 import { S } from '@dxos/echo-schema';
 import { DensityProvider } from '@dxos/react-ui';
@@ -51,22 +51,21 @@ const items = fc.sample(exampleSchemaArbitrary, 10);
 
 export const SchemaTable = {
   render: () => {
-    const containerRef = useRef<HTMLDivElement | null>(null);
-
     return (
-      <div ref={containerRef} className='fixed inset-0 overflow-auto'>
-        <Table<ExampleSchema>
-          role='grid'
-          rowsSelectable='multi'
-          keyAccessor={(row) => JSON.stringify(row)}
-          columns={columns}
-          data={items}
-          fullWidth
-          stickyHeader
-          border
-          getScrollElement={() => containerRef.current}
-        />
-      </div>
+      <Table.Root>
+        <Table.Viewport classNames='inset-0 fixed'>
+          <Table.Table<ExampleSchema>
+            role='grid'
+            rowsSelectable='multi'
+            keyAccessor={(row) => JSON.stringify(row)}
+            columns={columns}
+            data={items}
+            fullWidth
+            stickyHeader
+            border
+          />
+        </Table.Viewport>
+      </Table.Root>
     );
   },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9593,6 +9593,12 @@ importers:
       '@radix-ui/react-context':
         specifier: ^1.0.0
         version: 1.0.1(@types/react@18.0.21)(react@18.2.0)
+      '@radix-ui/react-primitive':
+        specifier: ^1.0.2
+        version: 1.0.3(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot':
+        specifier: ^1.0.1
+        version: 1.0.2(@types/react@18.0.21)(react@18.2.0)
       '@radix-ui/react-use-controllable-state':
         specifier: ^1.0.0
         version: 1.0.1(@types/react@18.0.21)(react@18.2.0)


### PR DESCRIPTION
This PR introduces `Table.Root` as well as `Table.Viewport` for managing a ref to the scrolling context.

This PR also enforces virtualised usage of tables and implements dynamic measurement to resolve an issue we've been seeing in Testbench app.

This PR updates all usages of Table, and should resolve a slew of warnings we've been getting from the devtools tables.