### PR TITLE
chore: cleanup settings dialog for template usage

### DIFF
--- a/packages/apps/plugins/plugin-settings/package.json
+++ b/packages/apps/plugins/plugin-settings/package.json
@@ -23,7 +23,8 @@
     "src"
   ],
   "dependencies": {
-    "@dxos/local-storage": "workspace:*"
+    "@dxos/local-storage": "workspace:*",
+    "@dxos/util": "workspace:*"
   },
   "devDependencies": {
     "@dxos/app-framework": "workspace:*",

--- a/packages/apps/plugins/plugin-settings/src/components/SettingsDialog.tsx
+++ b/packages/apps/plugins/plugin-settings/src/components/SettingsDialog.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { type Plugin, Surface, usePlugins } from '@dxos/app-framework';
 import { Button, Dialog, List, ListItem, useTranslation } from '@dxos/react-ui';
 import { ghostHover, ghostSelected } from '@dxos/react-ui-theme';
+import { nonNullable } from '@dxos/util';
 
 import { SETTINGS_PLUGIN } from '../meta';
 
@@ -41,17 +42,19 @@ export const SettingsDialog = ({
         <div className='flex flex-col p-1 gap-4 surface-input rounded place-self-start max-bs-[100%] is-full overflow-y-auto'>
           <PluginList
             title='Options'
-            plugins={core.map((id) => plugins.find((plugin) => plugin.meta.id === id)!.meta)}
+            plugins={core.map((id) => plugins.find((plugin) => plugin.meta.id === id)?.meta).filter(nonNullable)}
             selected={selected}
             onSelect={(plugin) => onSelected(plugin)}
           />
 
-          <PluginList
-            title='Plugins'
-            plugins={filteredPlugins}
-            selected={selected}
-            onSelect={(plugin) => onSelected(plugin)}
-          />
+          {filteredPlugins.length > 0 && (
+            <PluginList
+              title='Plugins'
+              plugins={filteredPlugins}
+              selected={selected}
+              onSelect={(plugin) => onSelected(plugin)}
+            />
+          )}
         </div>
 
         <div className='pli-1 md:pli-2 max-bs-[100%] overflow-y-auto'>

--- a/packages/apps/plugins/plugin-settings/tsconfig.json
+++ b/packages/apps/plugins/plugin-settings/tsconfig.json
@@ -26,6 +26,9 @@
       "path": "../../../common/local-storage"
     },
     {
+      "path": "../../../common/util"
+    },
+    {
       "path": "../../../sdk/app-framework"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2937,6 +2937,9 @@ importers:
       '@dxos/local-storage':
         specifier: workspace:*
         version: link:../../../common/local-storage
+      '@dxos/util':
+        specifier: workspace:*
+        version: link:../../../common/util
     devDependencies:
       '@dxos/app-framework':
         specifier: workspace:*


### PR DESCRIPTION
The composer plugin template does not have all plugins available so the settings dialog crashes.
This PR attempts to mitigate those issues.

Relates to #6398
