### PR TITLE
fix: bundle random-access-idb

### DIFF
--- a/packages/common/feed-store/package.json
+++ b/packages/common/feed-store/package.json
@@ -34,7 +34,6 @@
     "@dxos/util": "workspace:*",
     "lodash.defaultsdeep": "^4.6.1",
     "race-as-promised": "^0.0.2",
-    "random-access-storage": "^1.3.0",
     "streamx": "^2.12.5"
   },
   "devDependencies": {

--- a/packages/common/feed-store/package.json
+++ b/packages/common/feed-store/package.json
@@ -34,7 +34,7 @@
     "@dxos/util": "workspace:*",
     "lodash.defaultsdeep": "^4.6.1",
     "race-as-promised": "^0.0.2",
-    "random-access-storage": "^3.0.0",
+    "random-access-storage": "^1.3.0",
     "streamx": "^2.12.5"
   },
   "devDependencies": {

--- a/packages/common/random-access-storage/package.json
+++ b/packages/common/random-access-storage/package.json
@@ -25,10 +25,14 @@
     "@dxos/node-std": "workspace:*",
     "@dxos/tracing": "workspace:*",
     "@dxos/util": "workspace:*",
+    "buffer-alloc": "^1.1.0",
+    "buffer-from": "^0.1.1",
     "del": "^5.1.0",
+    "inherits": "^2.0.3",
+    "next-tick": "^1.0.0",
+    "once": "^1.4.0",
     "pify": "~5.0.0",
     "random-access-file": "^2.2.1",
-    "random-access-idb": "^1.2.2",
     "random-access-memory": "^4.1.0",
     "random-access-storage": "^3.0.0",
     "random-access-web": "^2.0.3"
@@ -36,6 +40,7 @@
   "devDependencies": {
     "@types/pify": "^3.0.2",
     "@types/randombytes": "^2.0.0",
+    "random-access-idb": "^1.2.2",
     "randombytes": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/common/random-access-storage/package.json
+++ b/packages/common/random-access-storage/package.json
@@ -34,7 +34,7 @@
     "pify": "~5.0.0",
     "random-access-file": "^2.2.1",
     "random-access-memory": "^4.1.0",
-    "random-access-storage": "^3.0.0",
+    "random-access-storage": "^1.3.0",
     "random-access-web": "^2.0.3"
   },
   "devDependencies": {

--- a/packages/common/random-access-storage/project.json
+++ b/packages/common/random-access-storage/project.json
@@ -7,6 +7,9 @@
     "build": {},
     "compile": {
       "options": {
+        "bundlePackages": [
+          "random-access-idb"
+        ],
         "entryPoints": [
           "packages/common/random-access-storage/src/index.ts"
         ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4797,8 +4797,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       random-access-storage:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^1.3.0
+        version: 1.4.3
       random-access-web:
         specifier: ^2.0.3
         version: 2.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4261,9 +4261,6 @@ importers:
       race-as-promised:
         specifier: ^0.0.2
         version: 0.0.2
-      random-access-storage:
-        specifier: ^1.3.0
-        version: 1.4.3
       streamx:
         specifier: ^2.12.5
         version: 2.12.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4262,8 +4262,8 @@ importers:
         specifier: ^0.0.2
         version: 0.0.2
       random-access-storage:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^1.3.0
+        version: 1.4.3
       streamx:
         specifier: ^2.12.5
         version: 2.12.5
@@ -42157,13 +42157,6 @@ packages:
       events: 3.3.0
       inherits: 2.0.4
       queue-tick: 1.0.1
-
-  /random-access-storage@3.0.0:
-    resolution: {integrity: sha512-f9KeHUMhrqj0hE2d4HbUXk/Cd5vElaVzdA0PuqPTlnxsG3dDvwQaMg8POT5tWK6UxJ80zAONZpHgLPMnnff1RA==}
-    dependencies:
-      events: 3.3.0
-      queue-tick: 1.0.1
-    dev: false
 
   /random-access-web@2.0.3:
     resolution: {integrity: sha512-nN3AAgl4/lTOYMk5Qm44SzFsglOmaG2d0Kh0603umh35+rk9QXYLFf0nFJ0GOv9INBsP9iT1lub24r8PjyCtvA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4769,18 +4769,30 @@ importers:
       '@dxos/util':
         specifier: workspace:*
         version: link:../util
+      buffer-alloc:
+        specifier: ^1.1.0
+        version: 1.2.0
+      buffer-from:
+        specifier: ^0.1.1
+        version: 0.1.2
       del:
         specifier: ^5.1.0
         version: 5.1.0
+      inherits:
+        specifier: ^2.0.3
+        version: 2.0.4
+      next-tick:
+        specifier: ^1.0.0
+        version: 1.1.0
+      once:
+        specifier: ^1.4.0
+        version: 1.4.0
       pify:
         specifier: ~5.0.0
         version: 5.0.0
       random-access-file:
         specifier: ^2.2.1
         version: 2.2.1
-      random-access-idb:
-        specifier: ^1.2.2
-        version: 1.2.2(patch_hash=mqfhtwnltd5kq5s4kb4gk7k2k4)
       random-access-memory:
         specifier: ^4.1.0
         version: 4.1.0
@@ -4797,6 +4809,9 @@ importers:
       '@types/randombytes':
         specifier: ^2.0.0
         version: 2.0.0
+      random-access-idb:
+        specifier: ^1.2.2
+        version: 1.2.2(patch_hash=mqfhtwnltd5kq5s4kb4gk7k2k4)
       randombytes:
         specifier: ^2.1.0
         version: 2.1.0
@@ -27651,7 +27666,6 @@ packages:
 
   /buffer-from@0.1.2:
     resolution: {integrity: sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==}
-    dev: false
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -39772,7 +39786,6 @@ packages:
 
   /next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
-    dev: false
 
   /nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -42114,7 +42127,6 @@ packages:
       next-tick: 1.1.0
       once: 1.4.0
       random-access-storage: 1.4.3
-    dev: false
     patched: true
 
   /random-access-memory@3.1.4:


### PR DESCRIPTION
Reverts #6248

The fix here is specifically aligning the version of idb that `@dxos/random-access-storage` was bundling with one compatible with `random-access-idb`.