### PR TITLE
fix(random-access-storage)!: change default storage to always be idb

### DIFF
--- a/packages/common/random-access-storage/src/browser/storage.ts
+++ b/packages/common/random-access-storage/src/browser/storage.ts
@@ -8,17 +8,7 @@ import { MemoryStorage, StorageType, type Storage, type StorageConstructor } fro
 
 export const createStorage: StorageConstructor = ({ type, root = '' } = {}): Storage => {
   if (type === undefined) {
-    if (
-      navigator &&
-      navigator.storage &&
-      typeof navigator.storage.getDirectory === 'function' &&
-      FileSystemFileHandle &&
-      typeof (FileSystemFileHandle.prototype as any).createWritable === 'function'
-    ) {
-      return new WebFS(root);
-    } else {
-      return new IDbStorage(root);
-    }
+    return new IDbStorage(root);
   }
 
   switch (type) {
@@ -27,12 +17,9 @@ export const createStorage: StorageConstructor = ({ type, root = '' } = {}): Sto
     }
 
     case StorageType.IDB:
-    case StorageType.CHROME: {
-      return new IDbStorage(root);
-    }
-
+    case StorageType.CHROME:
     case StorageType.FIREFOX: {
-      throw new Error('Firefox storage is no longer supported.');
+      return new IDbStorage(root);
     }
 
     case StorageType.WEBFS: {

--- a/packages/common/random-access-storage/src/common/storage.ts
+++ b/packages/common/random-access-storage/src/common/storage.ts
@@ -8,12 +8,18 @@ import { type Directory } from './directory';
 export enum StorageType {
   RAM = 'ram',
   IDB = 'idb',
+  /**
+   * @deprecated
+   */
   CHROME = 'chrome',
   /**
    * @deprecated
    */
   FIREFOX = 'firefox',
   NODE = 'node',
+  /**
+   * @deprecated
+   */
   WEBFS = 'webfs',
 }
 


### PR DESCRIPTION
This Pull Request updates the default storage to IDB. OPFS storage will be removed in a future release. IDB was found to be more performant and maintaining both was holding back other optimizations.
