### PR TITLE
chore: fix hello template

### DIFF
--- a/packages/apps/templates/bare-template/src/src/App.tsx.t.ts
+++ b/packages/apps/templates/bare-template/src/src/App.tsx.t.ts
@@ -5,6 +5,8 @@ export default template.define
   .slots({
     content: '<p>Your code goes here</p>',
     extraImports: '',
+    onClientInitialized: '',
+    onCreateIdentity: '',
   })
   .script({
     content: ({ input, slots, imports }) => {
@@ -34,9 +36,11 @@ export default template.define
           ${dxosUi ? plate`fallback={Loader}` : ''}
           onInitialized={async (client) => {
             ${schema && plate`// client.addSchema(Task);`}
+            ${slots.onClientInitialized}
             const searchParams = new URLSearchParams(location.search);
             if (!client.halo.identity.get() && !searchParams.has('deviceInvitationCode')) {
               await client.halo.createIdentity();
+              ${slots.onCreateIdentity}
             }
           }}
         >

--- a/packages/apps/templates/hello-template/src/src/App.tsx.t.ts
+++ b/packages/apps/templates/hello-template/src/src/App.tsx.t.ts
@@ -9,8 +9,16 @@ export default template.define.script({
       ...rest,
       slots: {
         content: ({ imports }) => plate`<${imports.use('Welcome', './Welcome')} name="${context.input.name}" />`,
-        extraImports: 'import "./index.css";'
-      }
+        extraImports: `
+          import "./index.css";
+          import { create, Expando } from '@dxos/react-client/echo';
+        `,
+        onClientInitialized: '',
+        onCreateIdentity: `
+          await client.spaces.isReady.wait();
+          client.spaces.default.db.add(create(Expando, { type: 'counter', count: 0 }));
+        `,
+      },
     });
     return inherited.files?.[0]?.content;
   },

--- a/packages/apps/templates/hello-template/src/src/Counter.tsx.t.ts
+++ b/packages/apps/templates/hello-template/src/src/Counter.tsx.t.ts
@@ -8,18 +8,11 @@ export default template.define.script({
       : plate/* javascript */ `
     import React, { useEffect } from 'react';
 
-    import { create, Expando, useQuery, useSpace } from '@dxos/react-client/echo';
+    import { useQuery, useSpace } from '@dxos/react-client/echo';
 
     export const Counter = () => {
       const space = useSpace();
       const [counter] = useQuery(space, { type: 'counter' });
-
-      useEffect(() => {
-        if (!counter && space) {
-          const c = create(Expando, { type: 'counter', count: 0 });
-          void space.db.add(c);
-        }
-      }, [counter, space]);
 
       if (!space) {
         return null;


### PR DESCRIPTION
Fixes an issue with the hello template where it's creating a new object every time because it takes too long for the query to load the objects that are there.

The fix here is to not run the create code in an effect but only immediately after the identity is created. This way it is run once and only once and the same object is always returned by the counter query.
