### PR TITLE
docs: remove apidoc's clean repo check

### DIFF
--- a/tools/apidoc/src/log.ts
+++ b/tools/apidoc/src/log.ts
@@ -1,9 +1,0 @@
-//
-// Copyright 2024 DXOS.org
-//
-
-import chalk from 'chalk';
-
-export const info = (...args: any[]) => console.warn(chalk.cyan('[info]'), ...args);
-export const warn = (...args: any[]) => console.warn(chalk.yellow('[warn]'), ...args);
-export const err = (...args: any[]) => console.warn(chalk.red('[err]'), ...args);

--- a/tools/apidoc/src/main.ts
+++ b/tools/apidoc/src/main.ts
@@ -2,33 +2,11 @@
 // Copyright 2022 DXOS.org
 //
 
-import { exec } from 'child_process';
-
 import { loadConfig } from './config.js';
 import { generateApiDocs } from './generateApiDocs.js';
-import { err } from './log.js';
 import { remarkDocumentation } from './remarkDocumentation.js';
 
-const isGitClean = async () => {
-  const cmd = 'git status --porcelain';
-  return new Promise((resolve, reject) => {
-    exec(cmd, (err, stdout, stderr) => {
-      if (err) {
-        reject(err);
-      }
-      if (stderr) {
-        reject(stderr);
-      }
-      resolve(!stdout.trim().length);
-    });
-  });
-};
-
 const main = async () => {
-  if (!(process.env.CI || process.env.DIRTY_OK) && !(await isGitClean())) {
-    err('\ngit repository not clean prior to regenerating docs, bailing.\n');
-    process.exit(1);
-  }
   const config = await loadConfig();
   const flags = process.argv.slice(2);
   const tasks = {


### PR DESCRIPTION
It was useful when typedoc and apidoc were run separately. Now that they're combined it prevents running apidoc.
