### PR TITLE
Check for dead links w/ lychee, starting with a subset of the repo

### DIFF
--- a/docs/content/composer/plugins/core.md
+++ b/docs/content/composer/plugins/core.md
@@ -4,15 +4,15 @@ order: 4
 
 # Core Plugins
 
-## [Intent](intents)
+## [Intent](intent.md)
 
 Intents are a way for plugins to communicate with each other. They represent user actions and enable plugins to respond to changes in state initiated by the user or any other plugin. Similar to redux actions.
 
-## [Surface](surface)
+## [Surface](surface.md)
 
 Defines a component `<Surface />` that allows developers to delegate presentation of arbitrary content to plugins. The entire user interface of Composer is constructed of Surfaces, and the core plugins `provide` components that fulfill them.
 
-## [Graph](graph)
+## [Graph](graph.md)
 
 Responsible for maintaining the organizational structure of the user's data and representing the user's possible actions on that data.
 

--- a/docs/content/composer/plugins/definition.md
+++ b/docs/content/composer/plugins/definition.md
@@ -27,7 +27,7 @@ Plugins can exchange functionality by exposing a `provides` object.
 
 The contents of the provides object are of interest only to other plugins, which implement specific keys and values to define functionality with.
 
-For example, the [Surface](surface) plugin defines a `provides.surface.component` object that `<Surface />` elements use to determine what components to use when rendering:
+For example, the [Surface](surface.md) plugin defines a `provides.surface.component` object that `<Surface />` elements use to determine what components to use when rendering:
 
 ```tsx
 import { definePlugin, SurfaceProvides } from '@dxos/app-framework';
@@ -53,7 +53,7 @@ Plugins may provide a `context` component which will be used to wrap the entire 
 
 This enables plugins to share state and functionality with all the components of the app, most of which may be coming from other plugins.
 
-The order in which contexts are nested depends on the order in which the plugins were provided to the `<App />` component in the [entry point](entry).
+The order in which contexts are nested depends on the order in which the plugins were provided to the `<App />` component in the [entry point](entry.md).
 
 ```tsx
 import { PropsWithChildren } from 'react';

--- a/docs/content/composer/quick-start.md
+++ b/docs/content/composer/quick-start.md
@@ -39,7 +39,7 @@ The contents of your personal space will be visible only to you.
 
 ## Sharing
 
-Composer is organized into [spaces](spaces) for grouping and sharing content.
+Composer is organized into [spaces](spaces.md) for grouping and sharing content.
 
 Click the <HopeIcon icon="plus" /> next to <span class="composer-pink">`Shared Spaces`</span> in the sidebar to create a new space.
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,121 @@
+#############################  Display  #############################
+
+# Verbose program output
+# Accepts log level: "error", "warn", "info", "debug", "trace"
+verbose = "info"
+
+# Don't show interactive progress bar while checking links.
+no_progress = false
+
+# Path to summary output file.
+output = ".config.dummy.report.md"
+
+#############################  Cache  ###############################
+
+# Enable link caching. This can be helpful to avoid checking the same links on
+# multiple runs.
+cache = true
+
+# Discard all cached requests older than this duration.
+max_cache_age = "2d"
+
+#############################  Runtime  #############################
+
+# Number of threads to utilize.
+# Defaults to number of cores available to the system if omitted.
+threads = 2
+
+# Maximum number of allowed redirects.
+max_redirects = 10
+
+# Maximum number of allowed retries before a link is declared dead.
+max_retries = 2
+
+# Maximum number of concurrent link checks.
+max_concurrency = 14
+
+#############################  Requests  ############################
+
+# User agent to send with each request.
+user_agent = "curl/7.83. 1"
+
+# Website timeout from connect to response finished.
+timeout = 20
+
+# Minimum wait time in seconds between retries of failed requests.
+retry_wait_time = 2
+
+# Comma-separated list of accepted status codes for valid links.
+# Supported values are:
+#
+# accept = ["200..=204", "429"]
+# accept = "200..=204, 429"
+# accept = ["200", "429"]
+# accept = "200, 429"
+accept = ["200", "429"]
+
+# Proceed for server connections considered insecure (invalid TLS).
+insecure = false
+
+# Only test links with the given schemes (e.g. https).
+# Omit to check links with any other scheme.
+# At the moment, we support http, https, file, and mailto.
+scheme = ["https"]
+
+# When links are available using HTTPS, treat HTTP links as errors.
+require_https = false
+
+# Request method
+method = "get"
+
+# Custom request headers
+headers = []
+
+# Remap URI matching pattern to different URI.
+remap = ["https://example.com http://example.invalid"]
+
+# Base URL or website root directory to check relative URLs.
+base = "https://example.com"
+
+# HTTP basic auth support. This will be the username and password passed to the
+# authorization HTTP header. See
+# <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization>
+basic_auth = ["example.com user:pwd"]
+
+#############################  Exclusions  ##########################
+
+# Skip missing input files (default is to error if they don't exist).
+skip_missing = false
+
+# Check links inside `<code>` and `<pre>` blocks as well as Markdown code
+# blocks.
+include_verbatim = false
+
+# Ignore case of paths when matching glob patterns.
+glob_ignore_case = false
+
+# Exclude URLs and mail addresses from checking (supports regex).
+exclude = ['^https://www\.linkedin\.com', '^https://web\.archive\.org/web/']
+
+# Exclude these filesystem paths from getting checked.
+exclude_path = ["file/path/to/Ignore", "./other/file/path/to/Ignore"]
+
+# URLs to check (supports regex). Has preference over all excludes.
+include = ['gist\.github\.com.*']
+
+# Exclude all private IPs from checking.
+# Equivalent to setting `exclude_private`, `exclude_link_local`, and
+# `exclude_loopback` to true.
+exclude_all_private = false
+
+# Exclude private IP address ranges from checking.
+exclude_private = false
+
+# Exclude link-local IP address range from checking.
+exclude_link_local = false
+
+# Exclude loopback IP address range and localhost from checking.
+exclude_loopback = false
+
+# Check mail addresses
+include_mail = true

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,3 +1,14 @@
+#
+# Config file docs: https://lychee.cli.rs/usage/config/
+#
+# Run with `lychee --offline .` to only check local links.
+#
+
+# Based on this lychee.example.toml:
+# https://github.com/lycheeverse/lychee/blob/0a54079d01ba9a4ff9850d8e46d3ba64743d2c8d/lychee.example.toml
+#
+# From lychee-0.15.1
+
 #############################  Display  #############################
 
 # Verbose program output
@@ -8,7 +19,7 @@ verbose = "info"
 no_progress = false
 
 # Path to summary output file.
-output = ".config.dummy.report.md"
+output = ".lychee.report.md"
 
 #############################  Cache  ###############################
 
@@ -72,7 +83,7 @@ method = "get"
 headers = []
 
 # Remap URI matching pattern to different URI.
-remap = ["https://example.com http://example.invalid"]
+remap = []
 
 # Base URL or website root directory to check relative URLs.
 base = "https://example.com"
@@ -80,7 +91,7 @@ base = "https://example.com"
 # HTTP basic auth support. This will be the username and password passed to the
 # authorization HTTP header. See
 # <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization>
-basic_auth = ["example.com user:pwd"]
+basic_auth = []
 
 #############################  Exclusions  ##########################
 
@@ -95,13 +106,17 @@ include_verbatim = false
 glob_ignore_case = false
 
 # Exclude URLs and mail addresses from checking (supports regex).
-exclude = ['^https://www\.linkedin\.com', '^https://web\.archive\.org/web/']
+#
+# NOTE: For more information on the ".proto" exclude see: https://github.com/dxos/dxos/issues/6375
+exclude = [".proto"]
 
 # Exclude these filesystem paths from getting checked.
-exclude_path = ["file/path/to/Ignore", "./other/file/path/to/Ignore"]
+exclude_path = []
 
 # URLs to check (supports regex). Has preference over all excludes.
-include = ['gist\.github\.com.*']
+#
+# NOTE: This can also be an array, the default example was ['gist\.github\.com.*']
+include = true
 
 # Exclude all private IPs from checking.
 # Equivalent to setting `exclude_private`, `exclude_link_local`, and


### PR DESCRIPTION
Related PR: https://github.com/dxos/dxos/issues/6369

This PR just checks that dead links aren't present in `./docs/content/composer` for now. We can expand that to the rest of the docs and repo (converting links to end in `.md` along the way) once we're sure that lychee works well for us in CI.