### PR TITLE
feat(sdk): Allow consumers of `create` to supply `id`

### DIFF
--- a/packages/core/echo/echo-schema/src/handler/create.ts
+++ b/packages/core/echo/echo-schema/src/handler/create.ts
@@ -44,8 +44,6 @@ export const create: {
         const fromResult = PublicKey.safeFrom(anyObj.id);
         if (fromResult) {
           anyObj.id = fromResult.toHex();
-        } else if (PublicKey.isPublicKey(anyObj.id)) {
-          anyObj.id = anyObj.id.toHex();
         } else {
           throw new Error(
             [


### PR DESCRIPTION
### Proposed change
- If `id` is an instance of `PublicKey` or a `PublicKeyLike` that can be parsed we should allow the user to supply it.

### Rationale

When mixing rendering of in-memory / db objects it's useful to have consistent id's to key into.

Being able to assign an `id` will work towards solving #6468.