### PR TITLE
fix(tables): Durable cell focus when adding row

### DIFF
--- a/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
@@ -69,7 +69,7 @@ export const ObjectTable: FC<ObjectTableProps> = ({ table, role, stickyHeader })
   }
 };
 
-const makeNewObject = () => ({ id: PublicKey.random() });
+const makeNewObject = (table: TableType) => (table.schema ? create(table.schema, {}) : create({}));
 
 const ObjectTableImpl: FC<ObjectTableProps> = ({ table, role, stickyHeader }) => {
   const space = getSpace(table);
@@ -77,7 +77,7 @@ const ObjectTableImpl: FC<ObjectTableProps> = ({ table, role, stickyHeader }) =>
   const objects = useTableObjects(space, table.schema);
   const tables = useQuery<TableType>(space, Filter.schema(TableType));
 
-  const newObject = useRef(makeNewObject());
+  const newObject = useRef(makeNewObject(table));
   const rows = useMemo(() => [...objects, newObject.current], [objects]);
 
   const onColumnUpdate = useCallback(
@@ -107,7 +107,7 @@ const ObjectTableImpl: FC<ObjectTableProps> = ({ table, role, stickyHeader }) =>
       object[prop] = value;
       if (object === newObject.current) {
         space!.db.add(create(table.schema!, { ...newObject.current }));
-        newObject.current = makeNewObject();
+        newObject.current = makeNewObject(table);
       }
     },
     [space, table.schema, newObject],

--- a/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
@@ -106,7 +106,7 @@ const ObjectTableImpl: FC<ObjectTableProps> = ({ table, role, stickyHeader }) =>
     (object: any, prop: string, value: any) => {
       object[prop] = value;
       if (object === newObject.current) {
-        space!.db.add(create(table.schema!, { ...newObject.current }));
+        space!.db.add(newObject.current);
         newObject.current = makeNewObject(table);
       }
     },

--- a/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
@@ -69,19 +69,15 @@ export const ObjectTable: FC<ObjectTableProps> = ({ table, role, stickyHeader })
   }
 };
 
+const makeNewObject = () => ({ id: PublicKey.random() });
+
 const ObjectTableImpl: FC<ObjectTableProps> = ({ table, role, stickyHeader }) => {
   const space = getSpace(table);
 
   const objects = useTableObjects(space, table.schema);
   const tables = useQuery<TableType>(space, Filter.schema(TableType));
 
-  const newObject = useRef({});
-  const newObjectKey = '__new';
-  const keyAccessor = useCallback(
-    (row: any) => (row === newObject.current ? newObjectKey : row?.id ?? 'KEY'),
-    [newObjectKey],
-  );
-
+  const newObject = useRef(makeNewObject());
   const rows = useMemo(() => [...objects, newObject.current], [objects]);
 
   const onColumnUpdate = useCallback(
@@ -111,7 +107,7 @@ const ObjectTableImpl: FC<ObjectTableProps> = ({ table, role, stickyHeader }) =>
       object[prop] = value;
       if (object === newObject.current) {
         space!.db.add(create(table.schema!, { ...newObject.current }));
-        newObject.current = {};
+        newObject.current = makeNewObject();
       }
     },
     [space, table.schema, newObject],
@@ -160,7 +156,7 @@ const ObjectTableImpl: FC<ObjectTableProps> = ({ table, role, stickyHeader }) =>
   return (
     <DensityProvider density='fine'>
       <Table.Table<any>
-        keyAccessor={keyAccessor}
+        keyAccessor={(row: any) => row.id}
         columns={columns}
         data={rows}
         border


### PR DESCRIPTION
Use an empty object with an ID that will be stable across renders to restore focus.

- Fixes: #6468 