### PR TITLE
fix(devtools): handle spaces being closed

### DIFF
--- a/packages/devtools/devtools/src/containers/DataSpaceSelector.tsx
+++ b/packages/devtools/devtools/src/containers/DataSpaceSelector.tsx
@@ -40,7 +40,7 @@ export const DataSpaceSelector = () => {
 
   const getLabel = (key: PublicKey) => {
     const space = spaces.find((space) => space.key.equals(key));
-    return space?.properties.name ?? humanize(key);
+    return space?.isOpen ? space?.properties.name ?? humanize(key) : `${humanize(key)} (closed)`;
   };
 
   return (

--- a/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
@@ -126,7 +126,7 @@ export const SpaceListPanel: FC = () => {
     const { open, ready } = space.internal.data.metrics ?? {};
     return {
       key: space.key,
-      name: space.properties.name,
+      name: space.isOpen ? space.properties.name : undefined,
       objects: space.db.objects.length,
       members: space.members.get().length,
       startup: open && ready ? ready.getTime() - open.getTime() : -1,


### PR DESCRIPTION
Don't attempt to access the space's name if it is closed to prevent the panels from crashing.
