### PR TITLE
fix(tables): Sorting another column should clear current column sorting

### DIFF
--- a/packages/ui/react-ui-table/src/components/ColumnMenu/ColumnMenu.tsx
+++ b/packages/ui/react-ui-table/src/components/ColumnMenu/ColumnMenu.tsx
@@ -10,7 +10,7 @@ import { Button, DensityProvider, Popover, DropdownMenu } from '@dxos/react-ui';
 import { getSize, mx } from '@dxos/react-ui-theme';
 
 import { ColumnSettingsForm } from './ColumnSettingsForm';
-import { useColumnSorting } from '../../hooks';
+import { useSortColumn } from '../../hooks';
 import { type TableDef, type ColumnProps } from '../../schema';
 
 export type ColumnMenuProps<TData extends RowData, TValue> = {
@@ -26,7 +26,7 @@ export const ColumnMenu = <TData extends RowData, TValue>({ column, ...props }: 
   const title = column.label?.length ? column.label : column.id;
   const header = props.context.header;
 
-  const { canSort, sortDirection, onSelectSort, onToggleSort, onClearSort } = useColumnSorting(header.column);
+  const { canSort, sortDirection, onSelectSort, onToggleSort, onClearSort } = useSortColumn(header.column);
 
   const columnSettingsAnchorRef = useRef<any>(null);
 
@@ -83,7 +83,7 @@ export const ColumnMenu = <TData extends RowData, TValue>({ column, ...props }: 
                         <ArrowDown className={getSize(4)} />
                       </span>
                     </DropdownMenu.Item>
-                    {sortDirection !== false && (
+                    {sortDirection && (
                       <DropdownMenu.Item onClick={onClearSort}>
                         <span className='grow'>Clear sort</span>
                         <span className='opacity-50'>
@@ -124,10 +124,10 @@ export const SortIndicator = ({
   direction,
   onClick,
 }: {
-  direction: SortDirection | false;
+  direction: SortDirection | undefined;
   onClick: (e: any) => void;
 }) => {
-  if (direction === false) {
+  if (direction === undefined) {
     return null;
   }
 

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -24,7 +24,7 @@ import { TableFooter } from './TableFooter';
 import { TableHead } from './TableHead';
 import { TableRootContext, useTableRootContext } from './TableRootContext';
 import { type TableProps } from './props';
-import { useColumnResizing, usePinLastRow, useRowSelection } from '../../hooks';
+import { useColumnResizing, useColumnSorting, usePinLastRow, useRowSelection } from '../../hooks';
 import { groupTh, tableRoot } from '../../theme';
 
 type TableRootProps = { children: React.ReactNode };
@@ -87,6 +87,8 @@ export const TablePrimitive = <TData extends RowData>(props: TableProps<TData>) 
   const [grouping, handleGroupingChange] = useState<GroupingState>(props.grouping ?? []);
   useEffect(() => handleGroupingChange(props.grouping ?? []), [handleGroupingChange, props.grouping]);
 
+  const columnSorting = useColumnSorting();
+
   const table = useReactTable({
     // Data
     meta: {},
@@ -104,6 +106,7 @@ export const TablePrimitive = <TData extends RowData>(props: TableProps<TData>) 
       columnVisibility,
       columnSizing,
       columnSizingInfo,
+      sorting: columnSorting.sorting,
       rowSelection,
       grouping,
     },
@@ -146,7 +149,7 @@ export const TablePrimitive = <TData extends RowData>(props: TableProps<TData>) 
 
   return (
     <TableProvider
-      {...props}
+      {...{ ...props, ...columnSorting }}
       table={table}
       header={header}
       expand={expand}

--- a/packages/ui/react-ui-table/src/components/Table/props.ts
+++ b/packages/ui/react-ui-table/src/components/Table/props.ts
@@ -6,6 +6,7 @@ import { type RowData, type RowSelectionState, type Table, type VisibilityState 
 
 import { type ClassNameValue } from '@dxos/react-ui-types';
 
+import { type ColumnSorting } from '../../hooks';
 import { type KeyValue, type TableColumnDef } from '../../types';
 
 export type TableFlags = Partial<{
@@ -56,4 +57,4 @@ export type TableContextValue<TData> = TableFlags &
   Pick<TableProps<TData>, 'keyAccessor'> & {
     table: Table<TData>;
     isGrid: boolean;
-  };
+  } & ColumnSorting;


### PR DESCRIPTION
- Resolves #6506

I thought this would be a quick change, but I ended up having to bring sorting into controlled state, since there's no way to get a reactive handle to the current sort in `@tanstack/table`.