### PR TITLE
fix(echo): try loading objects in chunks when exporting data

### DIFF
--- a/packages/core/echo/echo-db/src/serializer.ts
+++ b/packages/core/echo/echo-db/src/serializer.ts
@@ -12,7 +12,8 @@ import { AutomergeObjectCore, getAutomergeObjectCore } from './automerge';
 import { type EchoDatabase } from './database';
 import { Filter } from './query';
 
-const EXPORT_TIMEOUT = 60_000;
+const EXPORT_TIMEOUT = 30_000;
+const MAX_LOAD_OBJECT_CHUNK_SIZE = 30;
 
 /**
  * Archive of echo objects.
@@ -93,12 +94,18 @@ export class Serializer {
   async export(database: EchoDatabase): Promise<SerializedSpace> {
     const ids = database.automerge.getAllObjectIds();
     // TODO(wittjosiah): Ideally batch to reduce load on services, but for now just provide a large timeout.
-    const objects = await Promise.all(
-      ids.map(async (id) => database.automerge.loadObjectById(id, { timeout: EXPORT_TIMEOUT })),
-    );
+
+    const loadedObjects: Array<EchoReactiveObject<any> | undefined> = [];
+    for (const chunk of chunkArray(ids, MAX_LOAD_OBJECT_CHUNK_SIZE)) {
+      loadedObjects.push(
+        ...(await Promise.all(
+          chunk.map(async (id) => database.automerge.loadObjectById(id, { timeout: EXPORT_TIMEOUT })),
+        )),
+      );
+    }
 
     const data = {
-      objects: objects.filter(nonNullable).map((object) => {
+      objects: loadedObjects.filter(nonNullable).map((object) => {
         return this.exportObject(object as any);
       }),
 
@@ -184,4 +191,17 @@ export const getTypeRef = (type?: EncodedReferenceObject | string): Reference | 
     // TODO(mykola): Never reached?
     return Reference.fromLegacyTypename(type);
   }
+};
+
+const chunkArray = <T>(arr: T[], chunkSize: number): T[][] => {
+  if (arr.length === 0 || chunkSize < 1) {
+    return [];
+  }
+  let index = 0;
+  let resIndex = 0;
+  const result = new Array(Math.ceil(arr.length / chunkSize));
+  while (index < arr.length) {
+    result[resIndex++] = arr.slice(index, (index += chunkSize));
+  }
+  return result;
 };


### PR DESCRIPTION
Increasing timeout wasn't enough for space with too many objects. Try triggering loading on different objects incrementally.