### PR TITLE
feat(halo): delegated invitations

### DIFF
--- a/packages/common/async/src/mutex.ts
+++ b/packages/common/async/src/mutex.ts
@@ -2,11 +2,10 @@
 // Copyright 2020 DXOS.org
 //
 
-import { warnAfterTimeout } from '@dxos/debug';
-
 // Import explicit resource management polyfill.
 import '@dxos/util';
 import { cancelWithContext, type Context } from '@dxos/context';
+import { warnAfterTimeout } from '@dxos/debug';
 
 /**
  * A locking mechanism to ensure that a given section of the code is executed by only one single "thread" at a time.

--- a/packages/common/util/src/circular-buffer.ts
+++ b/packages/common/util/src/circular-buffer.ts
@@ -14,10 +14,24 @@ export class CircularBuffer<T> {
     this._buffer = new Array(size);
   }
 
+  public some(predicate: (element: T) => boolean): boolean {
+    for (let i = 0; i < this._elementCount; i++) {
+      if (predicate(this._buffer[i])) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public push(element: T) {
     this._buffer[this._nextIndex] = element;
     this._nextIndex = (this._nextIndex + 1) % this._buffer.length;
     this._elementCount = Math.min(this._buffer.length, this._elementCount + 1);
+  }
+
+  public clear() {
+    this._elementCount = 0;
+    this._nextIndex = 0;
   }
 
   public getLast(): T | undefined {

--- a/packages/common/util/src/circular-buffer.ts
+++ b/packages/common/util/src/circular-buffer.ts
@@ -14,24 +14,10 @@ export class CircularBuffer<T> {
     this._buffer = new Array(size);
   }
 
-  public some(predicate: (element: T) => boolean): boolean {
-    for (let i = 0; i < this._elementCount; i++) {
-      if (predicate(this._buffer[i])) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   public push(element: T) {
     this._buffer[this._nextIndex] = element;
     this._nextIndex = (this._nextIndex + 1) % this._buffer.length;
     this._elementCount = Math.min(this._buffer.length, this._elementCount + 1);
-  }
-
-  public clear() {
-    this._elementCount = 0;
-    this._nextIndex = 0;
   }
 
   public getLast(): T | undefined {

--- a/packages/core/halo/credentials/src/credentials/credential-generator.ts
+++ b/packages/core/halo/credentials/src/credentials/credential-generator.ts
@@ -249,3 +249,18 @@ export const createDelegatedSpaceInvitationCredential = async (
   });
   return { credential: { credential } };
 };
+
+export const createCancelDelegatedSpaceInvitationCredential = async (
+  signer: CredentialSigner,
+  subject: PublicKey,
+  invitationCredentialId: PublicKey,
+): Promise<FeedMessage.Payload> => {
+  const credential = await signer.createCredential({
+    subject,
+    assertion: {
+      '@type': 'dxos.halo.invitations.CancelDelegatedInvitation',
+      credentialId: invitationCredentialId,
+    },
+  });
+  return { credential: { credential } };
+};

--- a/packages/core/halo/credentials/src/credentials/credential-generator.ts
+++ b/packages/core/halo/credentials/src/credentials/credential-generator.ts
@@ -250,6 +250,11 @@ export const createDelegatedSpaceInvitationCredential = async (
   return { credential: { credential } };
 };
 
+/**
+ * @param signer - credential issuer.
+ * @param subject - key of the space the invitation was for.
+ * @param invitationCredentialId id of a dxos.halo.invitations.DelegateSpaceInvitation credential.
+ */
 export const createCancelDelegatedSpaceInvitationCredential = async (
   signer: CredentialSigner,
   subject: PublicKey,

--- a/packages/core/mesh/network-manager/src/swarm/connection.ts
+++ b/packages/core/mesh/network-manager/src/swarm/connection.ts
@@ -2,7 +2,7 @@
 // Copyright 2021 DXOS.org
 //
 
-import { DeferredTask, Event, sleep, scheduleTask, scheduleTaskInterval, synchronized } from '@dxos/async';
+import { DeferredTask, Event, sleep, scheduleTask, scheduleTaskInterval, synchronized, Trigger } from '@dxos/async';
 import { Context, cancelWithContext } from '@dxos/context';
 import { ErrorStream } from '@dxos/debug';
 import { invariant } from '@dxos/invariant';
@@ -100,6 +100,9 @@ export class Connection {
   private readonly _ctx = new Context();
   private connectedTimeoutContext = new Context();
 
+  private _protocolClosed = new Trigger();
+  private _transportClosed = new Trigger();
+
   private _state: ConnectionState = ConnectionState.CREATED;
   private _transport: Transport | undefined;
   closeReason?: string;
@@ -181,6 +184,7 @@ export class Connection {
     // TODO(dmaretskyi): Piped streams should do this automatically, but it break's without this code.
     this._protocol.stream.on('close', () => {
       log('protocol stream closed');
+      this._protocolClosed.wake();
       this.close(new ProtocolError('protocol stream closed')).catch((err) => this.errors.raise(err));
     });
 
@@ -215,6 +219,7 @@ export class Connection {
 
     this._transport.closed.once(() => {
       this._transport = undefined;
+      this._transportClosed.wake();
       log('abort triggered by transport close');
       this.abort().catch((err) => this.errors.raise(err));
     });
@@ -272,15 +277,14 @@ export class Connection {
 
     try {
       // Forcefully close the stream flushing any unsent data packets.
-      log('aborting protocol... ');
-      await this._protocol.abort();
+      await this._closeProtocol();
     } catch (err: any) {
       log.catch(err);
     }
 
     try {
       // After the transport is closed streams are disconnected.
-      await this._transport?.close();
+      await this._closeTransport();
     } catch (err: any) {
       log.catch(err);
     }
@@ -318,26 +322,26 @@ export class Connection {
     if (lastState === ConnectionState.CONNECTED) {
       try {
         // Gracefully close the stream flushing any unsent data packets.
-        await this._protocol.close();
+        await this._closeProtocol();
       } catch (err: any) {
         log.catch(err);
       }
 
       try {
         // After the transport is closed streams are disconnected.
-        await this._transport?.close();
+        await this._closeTransport();
       } catch (err: any) {
         log.catch(err);
       }
     } else {
       log(`graceful close requested when we were in ${lastState} state? aborting`);
       try {
-        await this._protocol.abort();
+        await this._closeProtocol();
       } catch (err: any) {
         log.catch(err);
       }
       try {
-        await this._transport?.close();
+        await this._closeTransport();
       } catch (err: any) {
         log.catch(err);
       }
@@ -346,6 +350,18 @@ export class Connection {
     log('closed', { peerId: this.ownId });
     this._changeState(ConnectionState.CLOSED);
     this._callbacks?.onClosed?.(err);
+  }
+
+  private async _closeProtocol() {
+    log('closing protocol');
+    await Promise.race([this._protocol.close(), this._protocolClosed.wait()]);
+    log('protocol closed');
+  }
+
+  private async _closeTransport() {
+    log('closing transport');
+    await Promise.race([this._transport?.close(), this._transportClosed.wait()]);
+    log('transport closed');
   }
 
   private _sendSignal(signal: Signal) {

--- a/packages/core/mesh/network-manager/src/swarm/peer.ts
+++ b/packages/core/mesh/network-manager/src/swarm/peer.ts
@@ -170,7 +170,7 @@ export class Peer {
     invariant(!this.initiating, 'Initiation in progress.');
     invariant(!this.connection, 'Already connected.');
     const sessionId = PublicKey.random();
-    log('initiating...', { id: this.id, topic: this.topic, peerId: this.id, sessionId });
+    log('initiating...', { ownPeerId: this.localPeerId, topic: this.topic, remotePeerId: this.id, sessionId });
 
     const connection = this._createConnection(true, sessionId);
     this.initiating = true;

--- a/packages/core/mesh/network-manager/src/swarm/swarm.ts
+++ b/packages/core/mesh/network-manager/src/swarm/swarm.ts
@@ -17,7 +17,7 @@ import { ComplexMap, isNotNullOrUndefined } from '@dxos/util';
 import { type Connection, ConnectionState } from './connection';
 import { type ConnectionLimiter } from './connection-limiter';
 import { Peer } from './peer';
-import { SwarmMessenger, type OfferMessage, type SignalMessage } from '../signal';
+import { type OfferMessage, type SignalMessage, SwarmMessenger } from '../signal';
 import { type SwarmController, type Topology } from '../topology';
 import { type TransportFactory } from '../transport';
 import { type Topic } from '../types';
@@ -320,6 +320,7 @@ export class Swarm {
         candidates: Array.from(this._peers.values())
           .filter((peer) => !peer.connection && peer.advertizing && peer.availableToConnect)
           .map((peer) => peer.id),
+        allPeers: Array.from(this._peers.values()).map((peer) => peer.id),
       }),
       connect: (peer) => {
         if (this._ctx.disposed) {
@@ -357,6 +358,7 @@ export class Swarm {
 
     // It is likely that the other peer will also try to connect to us at the same time.
     // If our peerId is higher, we will wait for a bit so that other peer has a chance to connect first.
+    const peer = this._getOrCreatePeer(remoteId);
     if (remoteId.toHex() < this._ownPeerId.toHex()) {
       log('initiation delay', { remoteId });
       await sleep(this._initiationDelay);
@@ -365,7 +367,9 @@ export class Swarm {
       return;
     }
 
-    const peer = this._getOrCreatePeer(remoteId);
+    if (this._peers.get(remoteId) == null) {
+      throw new Error('Peer left during initiation delay');
+    }
 
     if (peer.connection) {
       // Do nothing if peer is already connected.

--- a/packages/core/mesh/network-manager/src/topology/topology.ts
+++ b/packages/core/mesh/network-manager/src/topology/topology.ts
@@ -38,7 +38,7 @@ export interface SwarmState {
   candidates: PublicKey[];
 
   /**
-   * Candidates for connection. Does not intersect with a set of already connected peers.
+   * All peers in the swarm, including candidates, connected peers and those we have connection timeout with.
    */
   allPeers: PublicKey[];
 }

--- a/packages/core/mesh/network-manager/src/topology/topology.ts
+++ b/packages/core/mesh/network-manager/src/topology/topology.ts
@@ -36,6 +36,11 @@ export interface SwarmState {
    * Candidates for connection. Does not intersect with a set of already connected peers.
    */
   candidates: PublicKey[];
+
+  /**
+   * Candidates for connection. Does not intersect with a set of already connected peers.
+   */
+  allPeers: PublicKey[];
 }
 
 export interface Topology {

--- a/packages/core/mesh/network-manager/src/wire-protocol.ts
+++ b/packages/core/mesh/network-manager/src/wire-protocol.ts
@@ -5,7 +5,7 @@
 import { type Duplex } from 'node:stream';
 
 import { type PublicKey } from '@dxos/keys';
-import { Teleport } from '@dxos/teleport';
+import { Teleport, type TeleportParams } from '@dxos/teleport';
 
 export type WireProtocolParams = {
   initiator: boolean;
@@ -31,13 +31,15 @@ export interface WireProtocol {
 /**
  * Create a wire-protocol provider backed by a teleport instance.
  * @param onConnection Called after teleport is initialized for the session. Protocol extensions could be attached here.
+ * @param defaultParams Optionally provide default Teleport params that might be overridden by factory callers.
  * @returns
  */
 export const createTeleportProtocolFactory = (
   onConnection: (teleport: Teleport) => Promise<void>,
+  defaultParams?: Partial<TeleportParams>,
 ): WireProtocolProvider => {
   return (params) => {
-    const teleport = new Teleport(params);
+    const teleport = new Teleport({ ...defaultParams, ...params });
     return {
       stream: teleport.stream,
       open: async (sessionId?: PublicKey) => {

--- a/packages/core/mesh/teleport/src/control-extension.ts
+++ b/packages/core/mesh/teleport/src/control-extension.ts
@@ -14,6 +14,7 @@ import { Callback } from '@dxos/util';
 import { type ExtensionContext, type TeleportExtension } from './teleport';
 
 const HEARTBEAT_RTT_WARN_THRESH = 10_000;
+const DEBUG_PRINT_HEARTBEAT = false; // very noisy
 
 type ControlRpcBundle = {
   Control: ControlService;
@@ -63,11 +64,13 @@ export class ControlExtension implements TeleportExtension {
             this.onExtensionRegistered.call(request.name);
           },
           heartbeat: async (request) => {
-            log('received heartbeat request', {
-              ts: request.requestTimestamp,
-              localPeerId: this.localPeerId.truncate(),
-              remotePeerId: this.remotePeerId.truncate(),
-            });
+            if (DEBUG_PRINT_HEARTBEAT) {
+              log('received heartbeat request', {
+                ts: request.requestTimestamp,
+                localPeerId: this.localPeerId.truncate(),
+                remotePeerId: this.remotePeerId.truncate(),
+              });
+            }
             return {
               requestTimestamp: request.requestTimestamp,
             };
@@ -106,17 +109,20 @@ export class ControlExtension implements TeleportExtension {
                 remotePeerId: this.remotePeerId.truncate(),
               });
             } else {
-              log('heartbeat RTT', {
-                rtt: now - resp.requestTimestamp.getTime(),
-                localPeerId: this.localPeerId.truncate(),
-                remotePeerId: this.remotePeerId.truncate(),
-              });
+              if (DEBUG_PRINT_HEARTBEAT) {
+                log('heartbeat RTT', {
+                  rtt: now - resp.requestTimestamp.getTime(),
+                  localPeerId: this.localPeerId.truncate(),
+                  remotePeerId: this.remotePeerId.truncate(),
+                });
+              }
             }
           }
         } catch (err: any) {
           const now = Date.now();
           if (err instanceof RpcClosedError) {
             log('ignoring RpcClosedError in heartbeat');
+            this._extensionContext.close(err);
             return;
           }
           if (err instanceof AsyncTimeoutError) {

--- a/packages/core/mesh/teleport/src/control-extension.ts
+++ b/packages/core/mesh/teleport/src/control-extension.ts
@@ -121,6 +121,7 @@ export class ControlExtension implements TeleportExtension {
         } catch (err: any) {
           const now = Date.now();
           if (err instanceof RpcClosedError) {
+            // TODO: expose 'closed' event in Rpc peer to close context as soon the the peer gets closed
             log('ignoring RpcClosedError in heartbeat');
             this._extensionContext.close(err);
             return;

--- a/packages/core/mesh/teleport/src/rpc-extension.ts
+++ b/packages/core/mesh/teleport/src/rpc-extension.ts
@@ -17,15 +17,15 @@ export abstract class RpcExtension<Client, Server> implements TeleportExtension 
   constructor(private readonly _rpcParams: Omit<ProtoRpcPeerOptions<Client, Server>, 'port' | 'handlers'>) {}
 
   get initiator() {
-    return this._extensionContext.initiator;
+    return this._extensionContext?.initiator;
   }
 
   get localPeerId() {
-    return this._extensionContext.localPeerId;
+    return this._extensionContext?.localPeerId;
   }
 
   get remotePeerId() {
-    return this._extensionContext.remotePeerId;
+    return this._extensionContext?.remotePeerId;
   }
 
   get rpc(): Client {
@@ -67,6 +67,6 @@ export abstract class RpcExtension<Client, Server> implements TeleportExtension 
   }
 
   close() {
-    this._extensionContext.close();
+    this._extensionContext?.close();
   }
 }

--- a/packages/sdk/client-services/src/packlets/invitations/device-invitation-protocol.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/device-invitation-protocol.ts
@@ -34,7 +34,11 @@ export class DeviceInvitationProtocol implements InvitationProtocol {
     };
   }
 
-  async delegate(invitation: Invitation): Promise<PublicKey> {
+  async delegate(): Promise<PublicKey> {
+    throw new Error('delegation not supported');
+  }
+
+  async cancelDelegation(): Promise<void> {
     throw new Error('delegation not supported');
   }
 

--- a/packages/sdk/client-services/src/packlets/invitations/invitation-guest-extenstion.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitation-guest-extenstion.ts
@@ -1,0 +1,101 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type Mutex, type MutexGuard, Trigger } from '@dxos/async';
+import { cancelWithContext, Context } from '@dxos/context';
+import { invariant } from '@dxos/invariant';
+import { log } from '@dxos/log';
+import { InvalidInvitationExtensionRoleError, schema } from '@dxos/protocols';
+import { type InvitationHostService, Options } from '@dxos/protocols/proto/dxos/halo/invitations';
+import { type ExtensionContext, RpcExtension } from '@dxos/teleport';
+
+const OPTIONS_TIMEOUT = 10_000;
+
+type InvitationGuestExtensionCallbacks = {
+  // Deliberately not async to not block the extensions opening.
+  onOpen: (ctx: Context) => void;
+  onError: (error: Error) => void;
+};
+
+/**
+ * Guest's side for a connection to a concrete peer in p2p network during invitation.
+ */
+export class InvitationGuestExtension extends RpcExtension<
+  { InvitationHostService: InvitationHostService },
+  { InvitationHostService: InvitationHostService }
+> {
+  private _ctx = new Context();
+  private _remoteOptions?: Options;
+  private _remoteOptionsTrigger = new Trigger();
+  /**
+   * Held to allow only one invitation flow at a time to be active.
+   */
+  private _invitationFlowLock: MutexGuard | null = null;
+
+  constructor(
+    private readonly _invitationFlowMutex: Mutex,
+    private readonly _callbacks: InvitationGuestExtensionCallbacks,
+  ) {
+    super({
+      requested: {
+        InvitationHostService: schema.getService('dxos.halo.invitations.InvitationHostService'),
+      },
+      exposed: {
+        InvitationHostService: schema.getService('dxos.halo.invitations.InvitationHostService'),
+      },
+    });
+  }
+
+  protected override async getHandlers(): Promise<{ InvitationHostService: InvitationHostService }> {
+    return {
+      InvitationHostService: {
+        options: async (options) => {
+          invariant(!this._remoteOptions, 'Remote options already set.');
+          this._remoteOptions = options;
+          this._remoteOptionsTrigger.wake();
+        },
+        introduce: () => {
+          throw new Error('Method not allowed.');
+        },
+        authenticate: () => {
+          throw new Error('Method not allowed.');
+        },
+        admit: () => {
+          throw new Error('Method not allowed.');
+        },
+      },
+    };
+  }
+
+  override async onOpen(context: ExtensionContext) {
+    await super.onOpen(context);
+
+    try {
+      log('begin options');
+      this._invitationFlowLock = await cancelWithContext(this._ctx, this._invitationFlowMutex.acquire());
+      await cancelWithContext(this._ctx, this.rpc.InvitationHostService.options({ role: Options.Role.GUEST }));
+      await cancelWithContext(this._ctx, this._remoteOptionsTrigger.wait({ timeout: OPTIONS_TIMEOUT }));
+      log('end options');
+      if (this._remoteOptions?.role !== Options.Role.HOST) {
+        throw new InvalidInvitationExtensionRoleError(undefined, {
+          expected: Options.Role.HOST,
+          remoteOptions: this._remoteOptions,
+          remotePeerId: context.remotePeerId,
+        });
+      }
+
+      this._callbacks.onOpen(this._ctx);
+    } catch (err: any) {
+      log('openError', err);
+      this._callbacks.onError(err);
+    }
+  }
+
+  override async onClose() {
+    log('onClose');
+    this._invitationFlowLock?.release();
+    this._invitationFlowLock = null;
+    await this._ctx.dispose();
+  }
+}

--- a/packages/sdk/client-services/src/packlets/invitations/invitation-host-extension.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitation-host-extension.ts
@@ -209,10 +209,12 @@ export class InvitationHostExtension extends RpcExtension<
           const invitation = this._requireActiveInvitation();
 
           try {
-            this._assertInvitationState(Invitation.State.AUTHENTICATING);
             // Check authenticated.
-            if (isAuthenticationRequired(invitation) && !this.authenticationPassed) {
-              throw new Error('Not authenticated');
+            if (isAuthenticationRequired(invitation)) {
+              this._assertInvitationState(Invitation.State.AUTHENTICATING);
+              if (!this.authenticationPassed) {
+                throw new Error('Not authenticated');
+              }
             }
 
             const response = await this._callbacks.admit(request);

--- a/packages/sdk/client-services/src/packlets/invitations/invitation-protocol.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitation-protocol.ts
@@ -32,9 +32,14 @@ export interface InvitationProtocol {
   getInvitationContext(): Partial<Invitation> & Pick<Invitation, 'kind'>;
 
   /**
-   * Once authentication is successful, the host can admit the guest to the requested resource.
+   * Allow authorized peers to handle this invitation behalf of invitation creator.
    */
   delegate(invitation: Invitation): Promise<PublicKey>;
+
+  /**
+   * Notify other peers that a delegated invitation was cancelled;
+   */
+  cancelDelegation(invitation: Invitation): Promise<void>;
 
   /**
    * Once authentication is successful, the host can admit the guest to the requested resource.

--- a/packages/sdk/client-services/src/packlets/invitations/invitation-protocol.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitation-protocol.ts
@@ -33,6 +33,7 @@ export interface InvitationProtocol {
 
   /**
    * Allow authorized peers to handle this invitation behalf of invitation creator.
+   * @return id of the delegation credential written to subject control-feed.
    */
   delegate(invitation: Invitation): Promise<PublicKey>;
 

--- a/packages/sdk/client-services/src/packlets/invitations/invitation-topology.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitation-topology.ts
@@ -1,0 +1,84 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { invariant } from '@dxos/invariant';
+import { PublicKey } from '@dxos/keys';
+import { log } from '@dxos/log';
+import type { SwarmController, Topology } from '@dxos/network-manager';
+import { Options } from '@dxos/protocols/proto/dxos/halo/invitations';
+import { ComplexSet } from '@dxos/util';
+
+/**
+ * Hosts are listening on an invitation topic.
+ * They initiate a connection with any new peer if they are not currently in the invitation flow
+ * with another peer.
+ * When the invitation flow ends guest leaves the swarm and topology is updated once again,
+ * so we can connect to the next peer we haven't tried before yet.
+ * If the peer turns out to be a host their ID is remembered so that we don't try to establish
+ * a connection with them again.
+ *
+ * Guests don't initiate connections. They accept all connections because if we reject,
+ * the host won't retry their offer.
+ * Even if we started an invitation flow with one host we might want to try other hosts in case
+ * the first one failed due to a network error, so multiple connections are accepted.
+ */
+export class InvitationTopology implements Topology {
+  private _controller?: SwarmController;
+  private _wrongRolePeers = new ComplexSet<PublicKey>(PublicKey.hash);
+
+  constructor(private readonly _role: Options.Role) {}
+
+  init(controller: SwarmController): void {
+    invariant(!this._controller, 'Already initialized.');
+    this._controller = controller;
+  }
+
+  update(): void {
+    invariant(this._controller, 'Not initialized.');
+    if (this._role === Options.Role.GUEST) {
+      return;
+    }
+    const { candidates, connected } = this._controller.getState();
+    // don't start a connection while we have an active invitation flow
+    if (connected.length > 0) {
+      return;
+    }
+
+    const cleanedUpWrongRolePeerSet = new ComplexSet<PublicKey>(PublicKey.hash);
+    let firstUnknownPeer: PublicKey | null = null;
+    for (const candidate of candidates) {
+      if (this._wrongRolePeers.has(candidate)) {
+        cleanedUpWrongRolePeerSet.add(candidate);
+      } else if (firstUnknownPeer == null) {
+        firstUnknownPeer = candidate;
+      }
+    }
+
+    this._wrongRolePeers = cleanedUpWrongRolePeerSet;
+    if (firstUnknownPeer != null) {
+      this._controller.connect(firstUnknownPeer);
+    }
+  }
+
+  async onOffer(peer: PublicKey): Promise<boolean> {
+    invariant(this._controller, 'Not initialized.');
+    return !this._wrongRolePeers.has(peer);
+  }
+
+  public addWrongRolePeer(peerId: PublicKey) {
+    if (this._wrongRolePeers.size > 500) {
+      log.warn('wrongRolePeerKeys set is too big, likely a cleanup bug');
+      this._wrongRolePeers.clear();
+    }
+    this._wrongRolePeers.add(peerId);
+  }
+
+  async destroy(): Promise<void> {
+    this._wrongRolePeers.clear();
+  }
+
+  toString() {
+    return `InvitationTopology(${this._role === Options.Role.GUEST ? 'guest' : 'host'})`;
+  }
+}

--- a/packages/sdk/client-services/src/packlets/invitations/invitation-topology.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitation-topology.ts
@@ -26,6 +26,14 @@ import { ComplexSet } from '@dxos/util';
 export class InvitationTopology implements Topology {
   private _controller?: SwarmController;
 
+  /**
+   * Peers we tried to establish a connection with.
+   * In invitation flow peers are assigned random ids when they join the swarm, so we'll retry
+   * a peer if they reload an invitation.
+   *
+   * Consider keeping a separate set for peers we know are hosts and have some retry timeout
+   * for guests we failed an invitation flow with (potentially due to a network error).
+   */
   private _seenPeers = new ComplexSet<PublicKey>(PublicKey.hash);
 
   constructor(private readonly _role: Options.Role) {}

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-handler.test.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-handler.test.ts
@@ -32,7 +32,7 @@ type StateUpdateSink = PushStream<Invitation> & {
   waitFor(state: Invitation.State): Promise<void>;
 };
 
-describe.only('InvitationHandler', () => {
+describe('InvitationHandler', () => {
   let testBuilder: TestBuilder;
   beforeEach(() => {
     testBuilder = new TestBuilder();
@@ -152,7 +152,6 @@ describe.only('InvitationHandler', () => {
         hosts.push(await createNewHost(invitation));
       }
 
-      console.log('hello 23');
       const guest = await createPeer(host.spaceKey);
       const codeInput = await acceptInvitation(guest, invitation);
       while (!guest.ctx.disposed) {
@@ -307,6 +306,8 @@ describe.only('InvitationHandler', () => {
     return {
       sink,
       next: sink.push.bind(sink),
+      error: () => {},
+      complete: () => {},
       hasState,
       get lastState() {
         return sink[sink.length - 1]?.state;

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-handler.test.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-handler.test.ts
@@ -1,0 +1,340 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { expect } from 'chai';
+
+import { type PushStream, sleep, Trigger, waitForCondition } from '@dxos/async';
+import { Context } from '@dxos/context';
+import { PublicKey } from '@dxos/keys';
+import { Invitation } from '@dxos/protocols/proto/dxos/client/services';
+import { afterTest, describe, openAndClose, test } from '@dxos/test';
+import { range } from '@dxos/util';
+
+import { type InvitationProtocol } from './invitation-protocol';
+import { InvitationsHandler } from './invitations-handler';
+import { SpaceInvitationProtocol } from './space-invitation-protocol';
+import { TestBuilder, type TestPeer } from '../testing';
+
+interface PeerSetup {
+  ctx: Context;
+  peer: TestPeer;
+  sink: StateUpdateSink;
+  protocol: InvitationProtocol;
+  handler: InvitationsHandler;
+  spaceKey: PublicKey;
+}
+
+type StateUpdateSink = PushStream<Invitation> & {
+  sink: Invitation[];
+  lastState: Invitation.State | undefined;
+  hasState(startingFrom: number, state: Invitation.State): boolean;
+  waitFor(state: Invitation.State): Promise<void>;
+};
+
+describe.only('InvitationHandler', () => {
+  let testBuilder: TestBuilder;
+  beforeEach(() => {
+    testBuilder = new TestBuilder();
+  });
+
+  describe('delegated invitations', () => {
+    for (const multiUse of [false, true]) {
+      test(`base case success multiUse=${multiUse}`, async () => {
+        const host = await createPeer();
+        const invitation = await createInvitation(host, { multiUse });
+        await hostInvitation(host, invitation);
+
+        const guest = await createPeer(host.spaceKey);
+        await performAuth(guest, invitation);
+
+        await sleep(15);
+        expect(guest.ctx.disposed).to.be.true;
+        if (multiUse) {
+          expect(host.ctx.disposed).to.be.false;
+        } else {
+          expect(host.ctx.disposed).to.be.true;
+        }
+      });
+    }
+
+    test('host ctx active on single use invitation timeout', async () => {
+      const host = await createPeer();
+      const invitation = await createInvitation(host, {
+        timeout: 100,
+      });
+      await hostInvitation(host, invitation);
+
+      const guest = await createPeer(host.spaceKey);
+      await acceptInvitation(guest, invitation);
+
+      await guest.sink.waitFor(Invitation.State.READY_FOR_AUTHENTICATION);
+      await guest.ctx.dispose();
+      await host.sink.waitFor(Invitation.State.TIMEOUT);
+
+      await sleep(25);
+      expect(host.ctx.disposed).to.be.false;
+    });
+
+    test('invitation success after first guest error', async () => {
+      const host = await createPeer();
+      const invitation = await createInvitation(host);
+      await hostInvitation(host, invitation);
+
+      const badGuest = await createPeer(host.spaceKey);
+      await failAuth(badGuest, invitation);
+      await badGuest.sink.waitFor(Invitation.State.ERROR);
+
+      const goodGuest = await createPeer(host.spaceKey);
+      await performAuth(goodGuest, invitation);
+      await host.sink.waitFor(Invitation.State.SUCCESS);
+
+      await sleep(10);
+      expect(goodGuest.ctx.disposed).to.be.true;
+      expect(host.ctx.disposed).to.be.true;
+    });
+
+    test('multiUse invitation with multiple guests', async () => {
+      const host = await createPeer();
+      const invitation = await createInvitation(host, { multiUse: true });
+      await hostInvitation(host, invitation);
+
+      const guest1 = await createPeer(host.spaceKey);
+      await performAuth(guest1, invitation);
+      const guest2 = await createPeer(host.spaceKey);
+      await performAuth(guest2, invitation);
+
+      await sleep(5);
+      [guest1, guest2].forEach((g) => expect(g.ctx.disposed).to.be.true);
+      expect(host.ctx.disposed).to.be.false;
+    });
+
+    test('invitation success after host error with another host', async () => {
+      const host = await createPeer();
+      const invitation = await createInvitation(host, { multiUse: true });
+      await hostInvitation(host, invitation);
+      const anotherHost = await createNewHost(invitation);
+
+      const guest = await createPeer(host.spaceKey);
+      const codeInput = await failAuth(guest, invitation);
+      while (!guest.ctx.disposed) {
+        codeInput.wake(invitation.authCode!);
+        await sleep(10);
+      }
+      await guest.sink.waitFor(Invitation.State.SUCCESS);
+
+      const hostFailed = [host, anotherHost].map((h) => h.sink.hasState(0, Invitation.State.ERROR));
+      expect(hostFailed.sort()).to.deep.eq([false, true]);
+    });
+
+    test('single guest - many hosts', async () => {
+      const hosts: PeerSetup[] = [await createPeer()];
+      const [host] = hosts;
+      const invitation = await createInvitation(host, { multiUse: true });
+      await hostInvitation(host, invitation);
+      for (let i = 0; i < 4; i++) {
+        hosts.push(await createNewHost(invitation));
+      }
+
+      const guest = await createPeer(host.spaceKey);
+      await performAuth(guest, invitation);
+      await guest.sink.waitFor(Invitation.State.SUCCESS);
+      await sleep(10);
+      expect(guest.ctx.disposed).to.be.true;
+    });
+
+    test('guest gives up after trying with three hosts', async () => {
+      const hosts: PeerSetup[] = [await createPeer()];
+      const [host] = hosts;
+      const invitation = await createInvitation(host, { multiUse: true });
+      await hostInvitation(host, invitation);
+      for (let i = 0; i < 2; i++) {
+        hosts.push(await createNewHost(invitation));
+      }
+
+      console.log('hello 23');
+      const guest = await createPeer(host.spaceKey);
+      const codeInput = await acceptInvitation(guest, invitation);
+      while (!guest.ctx.disposed) {
+        await failCodeInput(guest, codeInput, invitation);
+        await sleep(10);
+      }
+
+      await sleep(10);
+      expect(guest.sink.lastState).to.eq(Invitation.State.ERROR);
+    });
+
+    test('single host - many guests', async () => {
+      const hosts: PeerSetup[] = [await createPeer()];
+      const [host] = hosts;
+      const invitation = await createInvitation(host, { multiUse: true });
+      await hostInvitation(host, invitation);
+      const guests = await Promise.all(
+        range(5).map(async () => {
+          const guest = await createPeer(host.spaceKey);
+          await performAuth(guest, invitation);
+          return guest;
+        }),
+      );
+
+      await sleep(10);
+      guests.forEach((g) => {
+        expect(g.ctx.disposed).to.be.true;
+        expect(g.sink.lastState).to.eq(Invitation.State.SUCCESS);
+      });
+    });
+
+    test('many guests - many hosts', async () => {
+      const hosts: PeerSetup[] = [await createPeer()];
+      const [host] = hosts;
+      const invitation = await createInvitation(host, { multiUse: true });
+      await hostInvitation(host, invitation);
+      for (let i = 0; i < 4; i++) {
+        hosts.push(await createNewHost(invitation));
+      }
+      const guests = await Promise.all(
+        range(5).map(async () => {
+          const guest = await createPeer(host.spaceKey);
+          await performAuth(guest, invitation);
+          return guest;
+        }),
+      );
+      await sleep(10);
+      guests.forEach((g) => {
+        expect(g.ctx.disposed).to.be.true;
+        expect(g.sink.lastState).to.eq(Invitation.State.SUCCESS);
+      });
+    });
+
+    test('single use invitation - many guests - only one admitted', async () => {
+      const host = await createPeer();
+      const invitation = await createInvitation(host);
+      await hostInvitation(host, invitation);
+      const guests = await Promise.all(
+        range(5).map(async () => {
+          const guest = await createPeer(invitation.spaceKey);
+          const authCodeInput2 = await acceptInvitation(guest, invitation);
+          authCodeInput2.wake(invitation.authCode!);
+          return guest;
+        }),
+      );
+
+      await waitForCondition({
+        condition: () => guests.find((g) => g.sink.lastState === Invitation.State.SUCCESS) != null,
+      });
+      await sleep(40);
+      const success = guests.filter((g) => g.sink.lastState === Invitation.State.SUCCESS);
+      expect(success.length).to.eq(1);
+    });
+  });
+
+  const createPeer = async (spaceKey: PublicKey | null = null): Promise<PeerSetup> => {
+    const peer = testBuilder.createPeer();
+    await peer.createIdentity();
+    await openAndClose(peer.echoHost, peer.dataSpaceManager);
+    if (spaceKey == null) {
+      const space = await peer.dataSpaceManager.createSpace();
+      spaceKey = space.key;
+    }
+    const invitationHandler = new InvitationsHandler(peer.networkManager, {
+      controlHeartbeatInterval: 250, // faster peer failure detection
+    });
+    const protocol = new SpaceInvitationProtocol(peer.dataSpaceManager, peer.identity, peer.keyring, spaceKey);
+    const ctx = new Context();
+    afterTest(() => ctx.dispose());
+    const sink = newStateUpdateSink();
+    return { ctx, sink, peer, protocol, handler: invitationHandler, spaceKey };
+  };
+
+  const hostInvitation = async (setup: PeerSetup, invitation: Invitation) => {
+    await setup.ctx.dispose();
+    setup.ctx = new Context();
+    afterTest(() => setup.ctx.dispose());
+    setup.handler.handleInvitationFlow(setup.ctx, setup.sink, setup.protocol, invitation);
+  };
+
+  const acceptInvitation = async (setup: PeerSetup, invitation: Invitation): Promise<Trigger<string>> => {
+    await setup.ctx.dispose();
+    setup.ctx = new Context();
+    afterTest(() => setup.ctx.dispose());
+    const authCodeInput = new Trigger<string>();
+    setup.handler.acceptInvitation(setup.ctx, setup.sink, setup.protocol, invitation, authCodeInput);
+    return authCodeInput;
+  };
+
+  const failAuth = async (setup: PeerSetup, invitation: Invitation) => {
+    const wrongAuthCodeInput = await acceptInvitation(setup, invitation);
+    await setup.sink.waitFor(Invitation.State.READY_FOR_AUTHENTICATION);
+    await failCodeInput(setup, wrongAuthCodeInput, invitation);
+    return wrongAuthCodeInput;
+  };
+
+  const failCodeInput = async (setup: PeerSetup, codeInput: Trigger<string>, invitation: Invitation): Promise<void> => {
+    const checkFrom = setup.sink.sink.length;
+    while (
+      !setup.ctx.disposed &&
+      !setup.sink.hasState(checkFrom, Invitation.State.ERROR) &&
+      !setup.sink.hasState(checkFrom, Invitation.State.CONNECTED)
+    ) {
+      codeInput.wake(invitation.authCode + '1');
+      await sleep(20);
+    }
+  };
+
+  const createNewHost = async (invitation: Invitation): Promise<PeerSetup> => {
+    const newHost = await createPeer(invitation.spaceKey!);
+    await performAuth(newHost, invitation);
+    await sleep(30);
+    await hostInvitation(newHost, invitation);
+    return newHost;
+  };
+
+  const performAuth = async (setup: PeerSetup, invitation: Invitation) => {
+    const authCodeInput2 = await acceptInvitation(setup, invitation);
+    await setup.sink.waitFor(Invitation.State.READY_FOR_AUTHENTICATION);
+    authCodeInput2.wake(invitation.authCode!);
+    await setup.sink.waitFor(Invitation.State.SUCCESS);
+  };
+
+  const newStateUpdateSink = (): StateUpdateSink => {
+    const sink: Invitation[] = [];
+    const hasState = (startingIndex: number, state: Invitation.State): boolean => {
+      return sink
+        .slice(startingIndex)
+        .map((i) => i.state)
+        .includes(state);
+    };
+    return {
+      sink,
+      next: sink.push.bind(sink),
+      hasState,
+      get lastState() {
+        return sink[sink.length - 1]?.state;
+      },
+      waitFor: async (state: Invitation.State): Promise<void> => {
+        if (sink[sink.length - 1]?.state === state) {
+          return;
+        }
+        const sliceStart = sink.length;
+        await waitForCondition({
+          condition: () => hasState(sliceStart, state),
+        });
+      },
+    } as any;
+  };
+
+  const createInvitation = async (setup: PeerSetup, options?: Partial<Invitation>): Promise<Invitation> => {
+    const observable = await setup.peer.invitationsManager.createInvitation({
+      type: Invitation.Type.DELEGATED,
+      kind: Invitation.Kind.SPACE,
+      authMethod: Invitation.AuthMethod.SHARED_SECRET,
+      spaceKey: setup.spaceKey,
+      multiUse: false,
+      ...options,
+    });
+    // cancel to avoid interfering with invitations-handler direct invocations
+    const invitation = observable.get();
+    await setup.peer.invitationsManager.cancelInvitation(invitation);
+    return { ...invitation, swarmKey: PublicKey.random() };
+  };
+});

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-manager.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-manager.ts
@@ -267,7 +267,7 @@ export class InvitationsManager {
       initialInvitation: initialState,
       subscriber: stream.observable,
       onCancel: async () => {
-        stream.complete({ ...initialState, state: Invitation.State.CANCELLED });
+        stream.next({ ...initialState, state: Invitation.State.CANCELLED });
         await ctx.dispose();
       },
       onAuthenticate: async (code: string) => {

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-manager.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-manager.ts
@@ -2,9 +2,9 @@
 // Copyright 2024 DXOS.org
 //
 
-import { Event, PushStream } from '@dxos/async';
+import { Event, PushStream, TimeoutError, Trigger } from '@dxos/async';
 import {
-  type AuthenticatingInvitation,
+  AuthenticatingInvitation,
   AUTHENTICATION_CODE_LENGTH,
   CancellableInvitation,
   INVITATION_TIMEOUT,
@@ -117,7 +117,8 @@ export class InvitationsManager {
     }
 
     const handler = this._getHandler(options);
-    const invitation = this._invitationsHandler.acceptInvitation(handler, options, request.deviceProfile);
+    const { ctx, invitation, stream, otpEnteredTrigger } = this._createObservableAcceptingInvitation(handler, options);
+    this._invitationsHandler.acceptInvitation(ctx, stream, handler, options, otpEnteredTrigger, request.deviceProfile);
     this._acceptInvitations.set(invitation.get().invitationId, invitation);
     this.invitationAccepted.emit(invitation.get());
 
@@ -237,6 +238,40 @@ export class InvitationsManager {
       },
     });
     return { ctx, stream, observableInvitation };
+  }
+
+  private _createObservableAcceptingInvitation(handler: InvitationProtocol, initialState: Invitation) {
+    const otpEnteredTrigger = new Trigger<string>();
+    const stream = new PushStream<Invitation>();
+    const ctx = new Context({
+      onError: (err) => {
+        if (err instanceof TimeoutError) {
+          log('timeout', { ...handler.toJSON() });
+          stream.next({ ...initialState, state: Invitation.State.TIMEOUT });
+        } else {
+          log.warn('auth failed', err);
+          stream.next({ ...initialState, state: Invitation.State.ERROR });
+        }
+        void ctx.dispose();
+      },
+    });
+    ctx.onDispose(() => {
+      log('complete', { ...handler.toJSON() });
+      stream.complete();
+    });
+    const invitation = new AuthenticatingInvitation({
+      initialInvitation: initialState,
+      subscriber: stream.observable,
+      onCancel: async () => {
+        stream.next({ ...initialState, state: Invitation.State.CANCELLED });
+        await ctx.dispose();
+      },
+      onAuthenticate: async (code: string) => {
+        // TODO(burdon): Reset creates a race condition? Event?
+        otpEnteredTrigger.wake(code);
+      },
+    });
+    return { ctx, invitation, stream, otpEnteredTrigger };
   }
 
   private async _persistIfRequired(

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-manager.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-manager.ts
@@ -267,7 +267,7 @@ export class InvitationsManager {
       initialInvitation: initialState,
       subscriber: stream.observable,
       onCancel: async () => {
-        stream.next({ ...initialState, state: Invitation.State.CANCELLED });
+        stream.complete({ ...initialState, state: Invitation.State.CANCELLED });
         await ctx.dispose();
       },
       onAuthenticate: async (code: string) => {

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-manager.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-manager.ts
@@ -150,6 +150,10 @@ export class InvitationsManager {
       if (created.get().persistent) {
         await this._metadataStore.removeInvitation(invitationId);
       }
+      if (created.get().type === Invitation.Type.DELEGATED) {
+        const handler = this._getHandler(created.get());
+        await handler.cancelDelegation(created.get());
+      }
       await created.cancel();
       this._createInvitations.delete(invitationId);
       this.removedCreated.emit(created.get());

--- a/packages/sdk/client-services/src/packlets/invitations/utils.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/utils.ts
@@ -2,8 +2,26 @@
 // Copyright 2024 DXOS.org
 //
 
+import { type Mutex, type MutexGuard } from '@dxos/async';
+import { cancelWithContext, type Context, ContextDisposedError } from '@dxos/context';
 import { Invitation } from '@dxos/protocols/proto/dxos/client/services';
 
 export const stateToString = (state: Invitation.State): string => {
   return Object.entries(Invitation.State).find(([key, val]) => val === state)?.[0] ?? 'unknown';
+};
+
+export const tryAcquireBeforeContextDisposed = async (ctx: Context, mutex: Mutex): Promise<MutexGuard> => {
+  let guard: MutexGuard | undefined;
+  return cancelWithContext(
+    ctx,
+    (async () => {
+      guard = await mutex.acquire();
+      if (ctx.disposed) {
+        guard.release();
+        guard = undefined;
+        throw new ContextDisposedError();
+      }
+      return guard;
+    })(),
+  );
 };

--- a/packages/sdk/client-services/src/packlets/invitations/utils.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/utils.ts
@@ -1,0 +1,9 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { Invitation } from '@dxos/protocols/proto/dxos/client/services';
+
+export const stateToString = (state: Invitation.State): string => {
+  return Object.entries(Invitation.State).find(([key, val]) => val === state)?.[0] ?? 'unknown';
+};

--- a/packages/sdk/client-services/src/packlets/services/service-context.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-context.ts
@@ -21,6 +21,7 @@ import { Invitation } from '@dxos/protocols/proto/dxos/client/services';
 import type { FeedMessage } from '@dxos/protocols/proto/dxos/echo/feed';
 import { type Credential, type ProfileDocument } from '@dxos/protocols/proto/dxos/halo/credentials';
 import { type Storage } from '@dxos/random-access-storage';
+import type { TeleportParams } from '@dxos/teleport';
 import { BlobStore } from '@dxos/teleport-extension-object-sync';
 import { trace as Trace } from '@dxos/tracing';
 import { safeInstanceof } from '@dxos/util';
@@ -40,7 +41,8 @@ import {
 import { InvitationsManager } from '../invitations/invitations-manager';
 import { DataSpaceManager, type DataSpaceManagerRuntimeParams, type SigningContext } from '../spaces';
 
-export type ServiceContextRuntimeParams = IdentityManagerRuntimeParams & DataSpaceManagerRuntimeParams;
+export type ServiceContextRuntimeParams = IdentityManagerRuntimeParams &
+  DataSpaceManagerRuntimeParams & { invitationConnectionDefaultParams?: Partial<TeleportParams> };
 /**
  * Shared backend for all client services.
  */
@@ -81,7 +83,7 @@ export class ServiceContext extends Resource {
     public readonly level: LevelDB,
     public readonly networkManager: NetworkManager,
     public readonly signalManager: SignalManager,
-    public readonly _runtimeParams?: IdentityManagerRuntimeParams & DataSpaceManagerRuntimeParams,
+    public readonly _runtimeParams?: ServiceContextRuntimeParams,
   ) {
     super();
 
@@ -123,7 +125,7 @@ export class ServiceContext extends Resource {
       storage: this.storage,
     });
 
-    this.invitations = new InvitationsHandler(this.networkManager);
+    this.invitations = new InvitationsHandler(this.networkManager, _runtimeParams?.invitationConnectionDefaultParams);
     this.invitationsManager = new InvitationsManager(
       this.invitations,
       (invitation) => this.getInvitationHandler(invitation),

--- a/packages/sdk/client-services/src/packlets/testing/invitation-utils.ts
+++ b/packages/sdk/client-services/src/packlets/testing/invitation-utils.ts
@@ -216,8 +216,10 @@ const acceptInvitation = (
   invitation = sanitizeInvitation(invitation);
 
   if (guest instanceof ServiceContext) {
-    const guestHandler = guest.getInvitationHandler({ kind: invitation.kind });
-    return guest.invitations.acceptInvitation(guestHandler, invitation, guestDeviceProfile);
+    return guest.invitationsManager.acceptInvitation({
+      invitation,
+      deviceProfile: guestDeviceProfile,
+    });
   }
 
   return guest.join(invitation, guestDeviceProfile);

--- a/packages/sdk/client-services/src/packlets/testing/test-builder.ts
+++ b/packages/sdk/client-services/src/packlets/testing/test-builder.ts
@@ -49,7 +49,9 @@ export const createServiceContext = async ({
   const level = createTestLevel();
   await level.open();
 
-  return new ServiceContext(storage, level, networkManager, signalManager);
+  return new ServiceContext(storage, level, networkManager, signalManager, {
+    invitationConnectionDefaultParams: { controlHeartbeatInterval: 200 },
+  });
 };
 
 export const createPeers = async (numPeers: number) => {

--- a/packages/sdk/client/src/testing/test-builder.ts
+++ b/packages/sdk/client/src/testing/test-builder.ts
@@ -135,6 +135,7 @@ export class TestBuilder {
       config: this.config,
       storage: this.storage,
       level: this.level,
+      runtimeParams: { invitationConnectionDefaultParams: { controlHeartbeatInterval: 200 } },
       ...this.networking,
     });
     this._ctx.onDispose(async () => {

--- a/packages/sdk/client/src/tests/client-services.test.ts
+++ b/packages/sdk/client/src/tests/client-services.test.ts
@@ -147,6 +147,10 @@ describe('Client services', () => {
       }),
     );
 
+    // Check same identity.
+    expect(hostInvitation!.identityKey).not.to.exist;
+    expect(guestInvitation?.identityKey).to.deep.eq(client1.halo.identity.get()!.identityKey);
+    expect(guestInvitation?.identityKey).to.deep.eq(client2.halo.identity.get()!.identityKey);
     expect(hostInvitation?.state).to.eq(Invitation.State.SUCCESS);
     expect(guestInvitation?.state).to.eq(Invitation.State.SUCCESS);
 

--- a/packages/sdk/client/src/tests/client-services.test.ts
+++ b/packages/sdk/client/src/tests/client-services.test.ts
@@ -147,10 +147,6 @@ describe('Client services', () => {
       }),
     );
 
-    // Check same identity.
-    expect(hostInvitation!.identityKey).not.to.exist;
-    expect(guestInvitation?.identityKey).to.deep.eq(client1.halo.identity.get()!.identityKey);
-    expect(guestInvitation?.identityKey).to.deep.eq(client2.halo.identity.get()!.identityKey);
     expect(hostInvitation?.state).to.eq(Invitation.State.SUCCESS);
     expect(guestInvitation?.state).to.eq(Invitation.State.SUCCESS);
 


### PR DESCRIPTION
### Details

* Cancel delegated invitation in HALO chain when an invitation is cancelled.
* Fixed connection initiation with a peer which left a swarm while we were sleeping.
* Expose `allPeers` to topology as part of `SwarmState` (needed for invitation topology to cleanup peer ids).
* Allow overriding control heartbeat interval on `Teleport` creation for faster failure detection in tests.
* Fixed rpc closed while opening early return.
* Close control connection as soon as `RpcClosedError` is received to speed up connection termination.
* Split InvitationExtension into separate host&guest files.
* Enforce flow state invariants in host invitation flow.
* Use mutex to serialize invitation flow for many-guests and/or many-hosts scenarios.
* Created `InvitationTopology` to try properly connecting hosts with guests.
* Reviewed error handling during invitation flow and added tests for invitations handler.

re #6301