### PR TITLE
fix: DocumentSection focus

### DIFF
--- a/packages/apps/plugins/plugin-deck/src/DeckPlugin.tsx
+++ b/packages/apps/plugins/plugin-deck/src/DeckPlugin.tsx
@@ -183,10 +183,7 @@ export const DeckPlugin = ({
       context: (props: PropsWithChildren) => {
         return (
           <AttentionProvider attended={attention.attended}>
-            <Mosaic.Root>
-              <LayoutContext.Provider value={layout.values}>{props.children}</LayoutContext.Provider>
-              <Mosaic.DragOverlay />
-            </Mosaic.Root>
+            <LayoutContext.Provider value={layout.values}>{props.children}</LayoutContext.Provider>
           </AttentionProvider>
         );
       },
@@ -223,25 +220,28 @@ export const DeckPlugin = ({
         }, [location.active]);
 
         return (
-          <DeckLayout
-            attention={attention}
-            location={location}
-            fullscreen={layout.values.fullscreen}
-            showHintsFooter={settings.values.showFooter}
-            toasts={layout.values.toasts}
-            onDismissToast={(id) => {
-              const index = layout.values.toasts.findIndex((toast) => toast.id === id);
-              if (index !== -1) {
-                // Allow time for the toast to animate out.
-                setTimeout(() => {
-                  if (layout.values.toasts[index].id === currentUndoId) {
-                    currentUndoId = undefined;
-                  }
-                  layout.values.toasts.splice(index, 1);
-                }, 1000);
-              }
-            }}
-          />
+          <Mosaic.Root>
+            <DeckLayout
+              attention={attention}
+              location={location}
+              fullscreen={layout.values.fullscreen}
+              showHintsFooter={settings.values.showFooter}
+              toasts={layout.values.toasts}
+              onDismissToast={(id) => {
+                const index = layout.values.toasts.findIndex((toast) => toast.id === id);
+                if (index !== -1) {
+                  // Allow time for the toast to animate out.
+                  setTimeout(() => {
+                    if (layout.values.toasts[index].id === currentUndoId) {
+                      currentUndoId = undefined;
+                    }
+                    layout.values.toasts.splice(index, 1);
+                  }, 1000);
+                }
+              }}
+            />
+            <Mosaic.DragOverlay />
+          </Mosaic.Root>
         );
       },
       surface: {

--- a/packages/apps/plugins/plugin-kanban/src/components/KanbanCard.tsx
+++ b/packages/apps/plugins/plugin-kanban/src/components/KanbanCard.tsx
@@ -44,7 +44,7 @@ export const KanbanCardComponent: FC<{
   });
   const tx = transform ? Object.assign(transform, { scaleY: 1 }) : null;
 
-  const { parentRef } = useTextEditor(
+  const { parentRef, focusAttributes } = useTextEditor(
     () => ({
       doc: item.title?.content,
       extensions: [
@@ -68,7 +68,7 @@ export const KanbanCardComponent: FC<{
           <DotsSixVertical className={getSize(5)} />
         </button>
         <div className='flex flex-col grow pt-1'>
-          <div className={mx(focusRing, 'p-1')} ref={parentRef} />
+          <div {...focusAttributes} className={mx(focusRing, 'rounded-sm p-1')} ref={parentRef} />
           {debug && <div className='text-xs text-red-800'>{item.id.slice(0, 9)}</div>}
         </div>
         {onDelete && (

--- a/packages/apps/plugins/plugin-markdown/src/components/DocumentCard.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/DocumentCard.tsx
@@ -48,7 +48,7 @@ export const DocumentCard: MosaicTileComponent<DocumentItemProps, HTMLDivElement
   ) => {
     const { t } = useTranslation(MARKDOWN_PLUGIN);
     const { themeMode } = useThemeContext();
-    const { parentRef } = useTextEditor(
+    const { parentRef, focusAttributes } = useTextEditor(
       () => ({
         doc: object.content?.content,
         extensions: [
@@ -93,7 +93,7 @@ export const DocumentCard: MosaicTileComponent<DocumentItemProps, HTMLDivElement
             </Card.Menu>
           </Card.Header>
           <Card.Body>
-            <div ref={parentRef} className={mx(focusRing, 'h-full p-1 text-sm')} />
+            <div {...focusAttributes} ref={parentRef} className={mx(focusRing, 'rounded-sm h-full p-1 text-sm')} />
           </Card.Body>
         </Card.Root>
       </div>

--- a/packages/apps/plugins/plugin-markdown/src/components/DocumentSection.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/DocumentSection.tsx
@@ -20,6 +20,7 @@ import {
   useFormattingState,
 } from '@dxos/react-ui-editor';
 import { sectionToolbarLayout } from '@dxos/react-ui-stack';
+import { focusRing, mx } from '@dxos/react-ui-theme';
 
 import { MARKDOWN_PLUGIN } from '../meta';
 
@@ -34,7 +35,11 @@ const DocumentSection: FC<{
 
   const { themeMode } = useThemeContext();
   const [formattingState, formattingObserver] = useFormattingState();
-  const { parentRef, view: editorView } = useTextEditor(
+  const {
+    parentRef,
+    view: editorView,
+    focusAttributes,
+  } = useTextEditor(
     () => ({
       doc: document.content?.content,
       extensions: [
@@ -58,7 +63,13 @@ const DocumentSection: FC<{
   const handleAction = useActionHandler(editorView);
 
   return (
-    <div role='none' className='contents group'>
+    <div role='none' className='flex flex-col group'>
+      <div
+        {...focusAttributes}
+        ref={parentRef}
+        className={mx('min-bs-[8rem] order-last rounded-sm', focusRing)}
+        data-testid='composer.markdownRoot'
+      />
       {toolbar && (
         <Toolbar.Root
           state={formattingState}
@@ -69,7 +80,6 @@ const DocumentSection: FC<{
           <Toolbar.Separator />
         </Toolbar.Root>
       )}
-      <div ref={parentRef} className='min-bs-[8rem]' data-testid='composer.markdownRoot' />
     </div>
   );
 };

--- a/packages/apps/plugins/plugin-script/src/components/ScriptEditor/ScriptEditor.tsx
+++ b/packages/apps/plugins/plugin-script/src/components/ScriptEditor/ScriptEditor.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { DocAccessor } from '@dxos/react-client/echo';
 import { type ThemeMode } from '@dxos/react-ui';
 import { automerge, defaultTheme, useTextEditor } from '@dxos/react-ui-editor';
-import { mx } from '@dxos/react-ui-theme';
+import { focusRing, mx } from '@dxos/react-ui-theme';
 
 export type ScriptEditorProps = {
   source: DocAccessor;
@@ -22,7 +22,7 @@ export type ScriptEditorProps = {
 // TODO(burdon): https://davidmyers.dev/blog/how-to-build-a-code-editor-with-codemirror-6-and-typescript/introduction
 
 export const ScriptEditor = ({ source, themeMode, className }: ScriptEditorProps) => {
-  const { parentRef } = useTextEditor(
+  const { parentRef, focusAttributes } = useTextEditor(
     () => ({
       doc: DocAccessor.getValue(source),
       extensions: [
@@ -48,5 +48,5 @@ export const ScriptEditor = ({ source, themeMode, className }: ScriptEditorProps
     [source, themeMode],
   );
 
-  return <div ref={parentRef} className={mx('flex grow', className)} />;
+  return <div {...focusAttributes} ref={parentRef} className={mx('flex grow rounded-sm', focusRing, className)} />;
 };

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -255,15 +255,17 @@ export const SpacePlugin = ({ onFirstRun }: SpacePluginOptions = {}): PluginDefi
       },
       surface: {
         component: ({ data, role }) => {
+          const primary = data.active ?? data.object;
           switch (role) {
+            case 'article':
             case 'main':
               // TODO(wittjosiah): ItemID length constant.
-              return isSpace(data.active) ? (
-                <SpaceMain space={data.active} />
-              ) : data.active instanceof FolderType ? (
-                <FolderMain folder={data.active} />
-              ) : typeof data.active === 'string' && data.active.length === 64 ? (
-                <MissingObject id={data.active} />
+              return isSpace(primary) ? (
+                <SpaceMain space={primary} role={role} />
+              ) : primary instanceof FolderType ? (
+                <FolderMain folder={primary} />
+              ) : typeof primary === 'string' && primary.length === 64 ? (
+                <MissingObject id={primary} />
               ) : null;
             // TODO(burdon): Add role name syntax to minimal plugin docs.
             case 'tree--empty':

--- a/packages/apps/plugins/plugin-space/src/components/SpaceMain/SpaceMain.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/SpaceMain/SpaceMain.tsx
@@ -50,27 +50,28 @@ const KeyShortcuts = () => {
   );
 };
 
-export const SpaceMain = ({ space }: { space: Space }) => {
+const spaceMainLayout =
+  'grid gap-y-2 auto-rows-min before:bs-2 before:col-span-5 grid-cols-[var(--rail-size)_var(--rail-size)_1fr_var(--rail-size)] md:grid-cols-[var(--rail-size)_var(--rail-size)_minmax(max-content,1fr)_var(--rail-size)_var(--rail-size)_minmax(max-content,2fr)_var(--rail-size)]';
+
+export const SpaceMain = ({ space, role }: { space: Space; role: 'main' | 'article' }) => {
   // const { graph } = useGraph();
   // const _actionsMap = graph.findNode(space.key.toHex())?.actionsMap;
   const state = space.state.get();
   const ready = state === SpaceState.READY;
+  const Root = role === 'main' ? Main.Content : 'div';
   return (
     <ClipboardProvider>
-      <Main.Content
-        classNames={[
-          topbarBlockPaddingStart,
-          'min-bs-dvh grid gap-y-2 auto-rows-min before:bs-2 before:col-span-5',
-          'grid-cols-[var(--rail-size)_var(--rail-size)_1fr_var(--rail-size)]',
-          'md:grid-cols-[var(--rail-size)_var(--rail-size)_minmax(max-content,1fr)_var(--rail-size)_var(--rail-size)_minmax(max-content,2fr)_var(--rail-size)]',
-        ]}
-        data-testid='spacePlugin.main'
+      <Root
+        {...(role === 'main'
+          ? { classNames: [topbarBlockPaddingStart, 'min-bs-dvh', spaceMainLayout] }
+          : { role: 'none', className: mx(topbarBlockPaddingStart, 'row-span-2', spaceMainLayout) })}
+        data-testid={`spacePlugin.${role}`}
         data-isready={ready ? 'true' : 'false'}
       >
         {/* {actionsMap && <InFlowSpaceActions actionsMap={actionsMap} />} */}
         {ready && <SpaceMembersSection space={space} />}
         <KeyShortcuts />
-      </Main.Content>
+      </Root>
     </ClipboardProvider>
   );
 };

--- a/packages/ui/react-ui-editor/src/hooks/useTextEditor.ts
+++ b/packages/ui/react-ui-editor/src/hooks/useTextEditor.ts
@@ -4,7 +4,17 @@
 
 import { EditorSelection, EditorState } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
-import { type DependencyList, type RefObject, useEffect, useMemo, useRef, useState } from 'react';
+import { useFocusableGroup } from '@fluentui/react-tabster';
+import {
+  type DependencyList,
+  type KeyboardEventHandler,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { log } from '@dxos/log';
 import { isNotFalsy } from '@dxos/util';
@@ -16,6 +26,10 @@ import { logChanges } from '../util';
 export type UseTextEditor = {
   parentRef: RefObject<HTMLDivElement>;
   view?: EditorView;
+  focusAttributes: ReturnType<typeof useFocusableGroup> & {
+    tabIndex: 0;
+    onKeyUp: KeyboardEventHandler<HTMLDivElement>;
+  };
 };
 
 export type UseTextEditorProps = Omit<TextEditorProps, 'moveToEndOfLine' | 'dataTestId'>;
@@ -98,5 +112,24 @@ export const useTextEditor = (cb: () => UseTextEditorProps = () => ({}), deps: D
     }
   }, [view, autoFocus, selection, scrollTo]);
 
-  return { parentRef, view };
+  const focusableGroup = useFocusableGroup({ tabBehavior: 'limited' });
+  // Focus editor on Enter (e.g., when tabbing to this component).
+  const handleKeyUp = useCallback<KeyboardEventHandler<HTMLDivElement>>(
+    (event) => {
+      const { key, target, currentTarget } = event;
+      if (target === currentTarget) {
+        switch (key) {
+          case 'Enter': {
+            view?.focus();
+            break;
+          }
+        }
+      }
+    },
+    [view],
+  );
+
+  const focusAttributes = { tabIndex: 0 as const, ...focusableGroup, onKeyUp: handleKeyUp };
+
+  return { parentRef, view, focusAttributes };
 };

--- a/packages/ui/react-ui-stack/src/testing/EditorContent.tsx
+++ b/packages/ui/react-ui-stack/src/testing/EditorContent.tsx
@@ -2,8 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import { useFocusableGroup } from '@fluentui/react-tabster';
-import React, { type KeyboardEventHandler, useCallback, useState } from 'react';
+import React, { useState } from 'react';
 
 import { TextV0Type } from '@braneframe/types';
 import { create } from '@dxos/echo-schema';
@@ -31,7 +30,7 @@ export const EditorContent = ({ data: { content = '' } }: { data: StackSectionCo
   const id = text.id;
   const doc = text.content;
   const [formattingState, formattingObserver] = useFormattingState();
-  const { parentRef, view } = useTextEditor(() => {
+  const { parentRef, view, focusAttributes } = useTextEditor(() => {
     return {
       id,
       doc,
@@ -50,24 +49,9 @@ export const EditorContent = ({ data: { content = '' } }: { data: StackSectionCo
 
   const handleAction = useActionHandler(view);
 
-  // TODO(thure): Should these be factored out?
-  const focusableGroup = useFocusableGroup({ tabBehavior: 'limited' });
-  // Focus editor on Enter (e.g., when tabbing to this component).
-  const handleKeyUp = useCallback<KeyboardEventHandler<HTMLDivElement>>(
-    (event) => {
-      const { key } = event;
-      switch (key) {
-        case 'Enter': {
-          view?.focus();
-          break;
-        }
-      }
-    },
-    [view],
-  );
-
   return (
-    <>
+    <div role='none' className='flex flex-col'>
+      <div {...focusAttributes} className={mx(textBlockWidth, focusRing, 'rounded-sm order-last')} ref={parentRef} />
       <Toolbar.Root
         onAction={handleAction}
         state={formattingState}
@@ -76,13 +60,6 @@ export const EditorContent = ({ data: { content = '' } }: { data: StackSectionCo
         <Toolbar.Markdown />
         <Toolbar.Separator />
       </Toolbar.Root>
-      <div
-        ref={parentRef}
-        className={mx(textBlockWidth, focusRing, 'mbs-1 rounded-sm')}
-        tabIndex={0}
-        {...focusableGroup}
-        onKeyUp={handleKeyUp}
-      />
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
Resolves #6563.

This PR fixes `DocumentSection` focus.

https://github.com/dxos/dxos/assets/855039/da2f44d8-2f87-4a60-9a76-5a2b0d87f2d0

This PR also:
- refactors `useTextEditor` to also return oft copypasted affordances for focus as `focusAttributes`
- uses `focusAttributes` for several stories and features
  - some were skipped (e.g. OutlinerPlugin’s) since focus appears to be managed or irrelevant
- reverses the toolbar and the editor so that the editor is the first focusable item in a DocumentSection