### PR TITLE
fix: Plugins can provide a getter for object labels

### DIFF
--- a/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -104,6 +104,7 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
       metadata: {
         records: {
           [DocumentType.typename]: {
+            label: (object: any) => (object instanceof DocumentType ? getFallbackTitle(object) : undefined),
             placeholder: ['document title placeholder', { ns: MARKDOWN_PLUGIN }],
             icon: (props: IconProps) => <TextAa {...props} />,
           },

--- a/packages/ui/react-ui-stack/src/components/Deck.stories.tsx
+++ b/packages/ui/react-ui-stack/src/components/Deck.stories.tsx
@@ -20,7 +20,7 @@ import React, { type PropsWithChildren, useState } from 'react';
 import { faker } from '@dxos/random';
 import { Button, Main } from '@dxos/react-ui';
 import { AttentionProvider, PlankHeading, plankHeadingIconProps, Deck as NaturalDeck } from '@dxos/react-ui-deck';
-import { Mosaic } from '@dxos/react-ui-mosaic';
+import { Mosaic, type MosaicDataItem } from '@dxos/react-ui-mosaic';
 import { withTheme } from '@dxos/storybook-utils';
 import { arrayMove } from '@dxos/util';
 
@@ -39,7 +39,7 @@ const Toolbar = () => {
   );
 };
 
-const SimpleContent = ({ data }: { data: { title?: string; body?: string } }) => (
+const SimpleContent = ({ data }: { data: MosaicDataItem & { title?: string; body?: string } }) => (
   <>
     <Toolbar />
     <div className='text-xl mlb-2'>{data.title}</div>

--- a/packages/ui/react-ui-stack/src/components/Section.tsx
+++ b/packages/ui/react-ui-stack/src/components/Section.tsx
@@ -59,7 +59,7 @@ import { translationKey } from '../translations';
 
 const sectionActionDimensions = 'p-1 shrink-0 min-bs-0 is-[--rail-action] bs-min';
 
-export type StackSectionContent = MosaicDataItem & { title?: string };
+export type StackSectionContent = MosaicDataItem;
 
 export type CollapsedSections = Record<string, boolean>;
 
@@ -87,6 +87,7 @@ export type StackSectionItem = MosaicDataItem & {
   size?: SectionSize;
   icon?: FC<IconProps>;
   placeholder?: string | [string, Parameters<TFunction>[1]];
+  label?: (data: any) => string | undefined;
   isResizable?: boolean;
 };
 
@@ -335,7 +336,7 @@ export const SectionTile: MosaicTileComponent<StackSectionItemWithContext, HTMLL
     const itemObject = transformedItem.object ?? (transformedItem as unknown as { data: StackSectionContent }).data;
 
     const title =
-      itemObject?.title ??
+      transformedItem.label?.(itemObject) ??
       // TODO(wittjosiah): `t` function is thinks it might not always return a string here for some reason.
       ((typeof transformedItem.placeholder === 'string'
         ? transformedItem.placeholder

--- a/packages/ui/react-ui-stack/src/components/Stack.stories.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack.stories.tsx
@@ -4,6 +4,9 @@
 
 import '@dxosTheme';
 
+// NOTE(thure): This unused import resolves the “likely not portable” TS error.
+// eslint-disable-next-line unused-imports/no-unused-imports
+import { type IconProps } from '@phosphor-icons/react';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { faker } from '@dxos/random';
@@ -17,9 +20,13 @@ import { TestObjectGenerator } from '../testing/generator';
 
 faker.seed(3);
 
-const SimpleContent = ({ data }: { data: StackSectionContent }) => <div className='p-4 text-center'>{data.title}</div>;
+const SimpleContent = ({ data }: { data: StackSectionContent & { title?: string } }) => (
+  <div className='p-4 text-center'>{data.title ?? data.id}</div>
+);
 
-const ComplexContent = ({ data }: { data: StackSectionContent & { body?: string; image?: string } }) => {
+const ComplexContent = ({
+  data,
+}: StackSectionItem & { data: StackSectionContent & { title?: string; body?: string; image?: string } }) => {
   useEffect(() => () => console.log('[ComplexContent]', 'unmount'), []);
   return (
     <div className='flex'>
@@ -120,6 +127,8 @@ export type DemoStackProps = StackProps & {
   operation?: MosaicOperation;
 };
 
+const labelGetter = (object: { title?: string }) => object.title;
+
 const DemoStack = ({
   id = 'stack',
   SectionContent,
@@ -130,7 +139,10 @@ const DemoStack = ({
 }: DemoStackProps) => {
   const [items, setItems] = useState<StackSectionItem[]>(() => {
     const generator = new TestObjectGenerator({ types });
-    return generator.createObjects({ length: count }).map((object) => ({ id: faker.string.uuid(), object }));
+    return generator.createObjects({ length: count }).map((object) => ({
+      id: faker.string.uuid(),
+      object,
+    }));
   });
 
   const itemsRef = useRef(items);
@@ -186,6 +198,7 @@ const DemoStack = ({
       data-testid={id}
       SectionContent={SectionContent}
       items={items}
+      transform={(item, _) => ({ ...item, label: labelGetter }) as StackSectionItem}
       onOver={handleOver}
       onDrop={handleDrop}
       onDeleteSection={handleRemove}


### PR DESCRIPTION
Resolves #6561.

Implements an interface necessary to achieve #6592.

https://github.com/dxos/dxos/assets/855039/31ea88a3-b600-4ece-804c-02cc805442c3