### PR TITLE
fix(echo): fix folder removal

### DIFF
--- a/packages/core/echo/echo-db/src/query/filter.test.ts
+++ b/packages/core/echo/echo-db/src/query/filter.test.ts
@@ -8,6 +8,7 @@ import { expect } from 'chai';
 import { Reference } from '@dxos/echo-protocol';
 import { TypedObject, create } from '@dxos/echo-schema';
 import { PublicKey } from '@dxos/keys';
+import { QueryOptions } from '@dxos/protocols/proto/dxos/echo/filter';
 import { describe, test } from '@dxos/test';
 
 import { Filter, compareType, filterMatch } from './filter';
@@ -62,6 +63,16 @@ describe('Filter', () => {
     const filter2 = Filter.not(filter1);
 
     expect(filterMatch(filter1, core)).to.be.true;
+    expect(filterMatch(filter2, core)).to.be.false;
+  });
+
+  test('not preserves deleted handling', () => {
+    const core = createAutomergeObjectCore({ title: 'test' });
+    core.setDeleted(true);
+    const filter1 = Filter.from({ title: 'test' }, { deleted: QueryOptions.ShowDeletedOption.HIDE_DELETED });
+    const filter2 = Filter.not(filter1);
+
+    expect(filterMatch(filter1, core)).to.be.false;
     expect(filterMatch(filter2, core)).to.be.false;
   });
 

--- a/packages/core/echo/echo-db/src/query/filter.ts
+++ b/packages/core/echo/echo-db/src/query/filter.ts
@@ -193,7 +193,8 @@ export const filterMatch = (filter: Filter, core: AutomergeObjectCore | undefine
     return false;
   }
   const result = filterMatchInner(filter, core);
-  return filter.not ? !result : result;
+  // don't apply filter negation to deleted object handling, as it's part of filter options
+  return filter.not && !core.isDeleted() ? !result : result;
 };
 
 const filterMatchInner = (filter: Filter, core: AutomergeObjectCore): boolean => {

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-handler.test.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-handler.test.ts
@@ -181,7 +181,7 @@ describe('InvitationHandler', () => {
 
       await sleep(10);
       expect(guest.sink.lastState).to.eq(Invitation.State.ERROR);
-    });
+    }).timeout(20_000);
 
     test('single host - many guests', async () => {
       const hosts: PeerSetup[] = [await createPeer()];


### PR DESCRIPTION
A hack was added for optimization of app-graph where `Filter.not(Filter.schema())` is used to avoid loading all text objects.
This broke the behavior of filtering out deleted folders.
`Fitler.not` should respect filter options where deleted handling is specified.