### PR TITLE
fix(shell): Fix typo which broke reset flow

### DIFF
--- a/packages/sdk/shell/src/panels/JoinPanel/JoinPanel.tsx
+++ b/packages/sdk/shell/src/panels/JoinPanel/JoinPanel.tsx
@@ -60,7 +60,7 @@ export const JoinPanelImpl = (props: JoinPanelImplProps) => {
           <Viewport.View classNames={stepStyles} id='reset storage confirmation'>
             <ConfirmResetComponent
               send={send}
-              active={activeView === 'reset identity confirmation'}
+              active={activeView === 'reset storage confirmation'}
               onCancel={onCancelResetStorage}
               onConfirm={onConfirmResetStorage}
             />
@@ -222,7 +222,7 @@ export const JoinPanel = ({
       case joinState.matches({ choosingIdentity: 'choosingAuthMethod' }):
         return 'addition method chooser';
       case joinState.matches('resettingIdentity'):
-        return 'reset identity confirmation';
+        return 'reset storage confirmation';
       case joinState.matches({ choosingIdentity: 'creatingIdentity' }):
         return 'create identity input';
       case joinState.matches({ choosingIdentity: 'recoveringIdentity' }):


### PR DESCRIPTION
Resolves #6582.

This PR fixes the reset flow, caused by a typo.

https://github.com/dxos/dxos/assets/855039/8be6af2a-852c-446c-a84a-4eb0c2dfb9d9

<img width="1119" alt="Screenshot 2024-05-08 at 12 45 27" src="https://github.com/dxos/dxos/assets/855039/492462c0-01de-496f-8fc2-5ef227e3c641">
