### PR TITLE
fix(react-ui-stack): Label getter call

### DIFF
--- a/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -104,7 +104,8 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
       metadata: {
         records: {
           [DocumentType.typename]: {
-            label: (object: any) => (object instanceof DocumentType ? getFallbackTitle(object) : undefined),
+            label: (object: any) =>
+              object instanceof DocumentType ? object.title ?? getFallbackTitle(object) : undefined,
             placeholder: ['document title placeholder', { ns: MARKDOWN_PLUGIN }],
             icon: (props: IconProps) => <TextAa {...props} />,
           },

--- a/packages/apps/plugins/plugin-table/src/TablePlugin.tsx
+++ b/packages/apps/plugins/plugin-table/src/TablePlugin.tsx
@@ -30,6 +30,7 @@ export const TablePlugin = (): PluginDefinition<TablePluginProvides> => {
       metadata: {
         records: {
           [TableType.typename]: {
+            label: (object: any) => (object instanceof TableType ? object.title : undefined),
             placeholder: ['object placeholder', { ns: TABLE_PLUGIN }],
             icon: (props: IconProps) => <Table {...props} />,
           },

--- a/packages/ui/react-ui-stack/src/components/Section.tsx
+++ b/packages/ui/react-ui-stack/src/components/Section.tsx
@@ -35,6 +35,9 @@ import {
   type TFunction,
   type ThemedClassName,
   ScrollArea,
+  toLocalizedString,
+  type Label,
+  isLabel,
 } from '@dxos/react-ui';
 import { DropDownMenuDragHandleTrigger, resizeHandle, resizeHandleHorizontal } from '@dxos/react-ui-deck';
 import {
@@ -87,7 +90,7 @@ export type StackSectionItem = MosaicDataItem & {
   size?: SectionSize;
   icon?: FC<IconProps>;
   placeholder?: string | [string, Parameters<TFunction>[1]];
-  label?: (data: any) => string | undefined;
+  label?: ((data: any) => string | undefined) | Label;
   isResizable?: boolean;
 };
 
@@ -335,14 +338,13 @@ export const SectionTile: MosaicTileComponent<StackSectionItemWithContext, HTMLL
     // TODO(thure): When `item` is a preview, it is a Graph.Node and has `data` instead of `object`.
     const itemObject = transformedItem.object ?? (transformedItem as unknown as { data: StackSectionContent }).data;
 
-    const title =
+    const title: string =
       (typeof transformedItem.label === 'function' ? transformedItem.label(itemObject) : undefined) ??
-      // TODO(wittjosiah): `t` function is thinks it might not always return a string here for some reason.
-      ((typeof transformedItem.placeholder === 'string'
-        ? transformedItem.placeholder
-        : transformedItem.placeholder
-          ? t(...transformedItem.placeholder)
-          : t('untitled section title')) as string);
+      (isLabel(transformedItem.label)
+        ? toLocalizedString(transformedItem.label as Label, t)
+        : isLabel(transformedItem.placeholder)
+          ? toLocalizedString(transformedItem.placeholder, t)
+          : t('untitled section title'));
 
     const section = (
       <Section

--- a/packages/ui/react-ui-stack/src/components/Section.tsx
+++ b/packages/ui/react-ui-stack/src/components/Section.tsx
@@ -336,7 +336,7 @@ export const SectionTile: MosaicTileComponent<StackSectionItemWithContext, HTMLL
     const itemObject = transformedItem.object ?? (transformedItem as unknown as { data: StackSectionContent }).data;
 
     const title =
-      transformedItem.label?.(itemObject) ??
+      (typeof transformedItem.label === 'function' ? transformedItem.label(itemObject) : undefined) ??
       // TODO(wittjosiah): `t` function is thinks it might not always return a string here for some reason.
       ((typeof transformedItem.placeholder === 'string'
         ? transformedItem.placeholder

--- a/packages/ui/react-ui/src/components/ThemeProvider/TranslationsProvider.tsx
+++ b/packages/ui/react-ui/src/components/ThemeProvider/TranslationsProvider.tsx
@@ -14,6 +14,16 @@ const initialDtLocale = dtLocaleEnUs;
 // TODO(thure): `Parameters<TFunction>` causes typechecking issues because `TFunction` has so many signatures.
 export type Label = string | [string, { ns: string; count?: number }];
 
+export const isLabel = (o: any): o is Label =>
+  typeof o === 'string' ||
+  (Array.isArray(o) &&
+    o.length === 2 &&
+    typeof o[0] === 'string' &&
+    !!o[1] &&
+    typeof o[1] === 'object' &&
+    'ns' in o[1] &&
+    typeof o[1].ns === 'string');
+
 export const toLocalizedString = (label: Label, t: TFunction) => (Array.isArray(label) ? t(...label) : label);
 
 export const resources = {

--- a/packages/ui/react-ui/src/components/ThemeProvider/index.ts
+++ b/packages/ui/react-ui/src/components/ThemeProvider/index.ts
@@ -3,4 +3,4 @@
 //
 
 export * from './ThemeProvider';
-export { type Label, toLocalizedString, useTranslation } from './TranslationsProvider';
+export { type Label, toLocalizedString, useTranslation, isLabel } from './TranslationsProvider';


### PR DESCRIPTION
This PR fixes cases where a Stack section’s `transformedItem.label` may be defined but uncallable.