### PR TITLE
feat: Add WNFS plugin

### DIFF
--- a/packages/apps/composer-app/package.json
+++ b/packages/apps/composer-app/package.json
@@ -66,6 +66,7 @@
     "@dxos/plugin-theme": "workspace:*",
     "@dxos/plugin-thread": "workspace:*",
     "@dxos/plugin-wildcard": "workspace:*",
+    "@dxos/plugin-wnfs": "workspace:*",
     "@dxos/react-client": "workspace:*",
     "@dxos/react-ui": "workspace:*",
     "@dxos/react-ui-editor": "workspace:*",

--- a/packages/apps/composer-app/src/plugins.tsx
+++ b/packages/apps/composer-app/src/plugins.tsx
@@ -47,6 +47,7 @@ import TableMeta from '@dxos/plugin-table/meta';
 import ThemeMeta from '@dxos/plugin-theme/meta';
 import ThreadMeta from '@dxos/plugin-thread/meta';
 import WildcardMeta from '@dxos/plugin-wildcard/meta';
+import WnfsMeta from '@dxos/plugin-wnfs/meta';
 import { isNotFalsy } from '@dxos/util';
 
 import { INITIAL_COLLECTION_TITLE, INITIAL_CONTENT, INITIAL_DOC_TITLE } from './constants';
@@ -131,6 +132,7 @@ export const recommended = ({ isLabs }: PluginConfig): PluginMeta[] => [
   PresenterMeta,
   ScriptMeta,
   SearchMeta,
+  WnfsMeta,
 
   ...(isLabs
     ? [
@@ -260,4 +262,5 @@ export const plugins = ({
   [ThreadMeta.id]: Plugin.lazy(() => import('@dxos/plugin-thread')),
   [WelcomeMeta.id]: Plugin.lazy(() => import('./plugins/welcome'), { firstRun }),
   [WildcardMeta.id]: Plugin.lazy(() => import('@dxos/plugin-wildcard')),
+  [WnfsMeta.id]: Plugin.lazy(() => import('@dxos/plugin-wnfs')),
 });

--- a/packages/plugins/experimental/plugin-wnfs/.eslintrc.js
+++ b/packages/plugins/experimental/plugin-wnfs/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  "extends": [
+    "../../../../.eslintrc.js"
+  ],
+  "parserOptions": {
+    "project": "tsconfig.json",
+    "tsconfigRootDir": __dirname,
+  }
+}

--- a/packages/plugins/experimental/plugin-wnfs/LICENSE
+++ b/packages/plugins/experimental/plugin-wnfs/LICENSE
@@ -1,0 +1,8 @@
+MIT License
+Copyright (c) 2024 DXOS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/plugins/experimental/plugin-wnfs/README.md
+++ b/packages/plugins/experimental/plugin-wnfs/README.md
@@ -1,0 +1,15 @@
+# @dxos/plugin-wnfs
+
+Plugin that allows for data to be stored on WNFS.
+
+## DXOS Resources
+
+- [Website](https://dxos.org)
+- [Developer Documentation](https://docs.dxos.org)
+- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+
+## Contributions
+
+Your ideas, issues, and code are most welcome. Please take a look at our [community code of conduct](https://github.com/dxos/dxos/blob/main/CODE_OF_CONDUCT.md), the [issue guide](https://github.com/dxos/dxos/blob/main/CONTRIBUTING.md#submitting-issues), and the [PR contribution guide](https://github.com/dxos/dxos/blob/main/CONTRIBUTING.md#submitting-prs).
+
+License: [MIT](./LICENSE) Copyright 2024 © DXOS

--- a/packages/plugins/experimental/plugin-wnfs/package.json
+++ b/packages/plugins/experimental/plugin-wnfs/package.json
@@ -1,0 +1,91 @@
+{
+  "name": "@dxos/plugin-wnfs",
+  "version": "0.6.11",
+  "description": "WNFS file management plugin",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "license": "MIT",
+  "author": "DXOS.org",
+  "exports": {
+    ".": {
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": {
+        "default": "./dist/lib/node/index.cjs"
+      },
+      "types": "./dist/types/src/index.d.ts"
+    },
+    "./meta": {
+      "browser": "./dist/lib/browser/meta.mjs",
+      "node": {
+        "default": "./dist/lib/node/meta.cjs"
+      },
+      "types": "./dist/types/src/meta.d.ts"
+    },
+    "./types": {
+      "browser": "./dist/lib/browser/types/index.mjs",
+      "node": {
+        "default": "./dist/lib/node/types/index.cjs"
+      },
+      "types": "./dist/types/src/types/index.d.ts"
+    }
+  },
+  "types": "dist/types/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "meta": [
+        "dist/types/src/meta.d.ts"
+      ],
+      "types": [
+        "dist/types/src/types/index.d.ts"
+      ]
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@codemirror/language": "^6.10.3",
+    "@codemirror/state": "^6.4.1",
+    "@codemirror/view": "^6.34.1",
+    "@dxos/app-framework": "workspace:*",
+    "@dxos/crypto": "workspace:*",
+    "@dxos/echo-schema": "workspace:*",
+    "@dxos/invariant": "workspace:*",
+    "@dxos/local-storage": "workspace:*",
+    "@dxos/log": "workspace:*",
+    "@dxos/plugin-client": "workspace:*",
+    "@dxos/plugin-markdown": "workspace:*",
+    "@dxos/react-client": "workspace:*",
+    "@dxos/react-ui-card": "workspace:*",
+    "@dxos/react-ui-mosaic": "workspace:*",
+    "blockstore-core": "^5.0.1",
+    "blockstore-idb": "^2.0.0",
+    "interface-blockstore": "^5.2.10",
+    "multiformats": "^13.2.2",
+    "uint8arrays": "^5.1.0",
+    "wnfs": "0.2.2"
+  },
+  "devDependencies": {
+    "@dxos/react-ui": "workspace:*",
+    "@dxos/react-ui-editor": "workspace:*",
+    "@dxos/react-ui-theme": "workspace:*",
+    "@dxos/storybook-utils": "workspace:*",
+    "@phosphor-icons/react": "^2.1.5",
+    "@types/react": "~18.2.0",
+    "@types/react-dom": "~18.2.0",
+    "react": "~18.2.0",
+    "react-dom": "~18.2.0",
+    "vite": "5.4.7"
+  },
+  "peerDependencies": {
+    "@dxos/react-ui": "workspace:*",
+    "@dxos/react-ui-theme": "workspace:*",
+    "@phosphor-icons/react": "^2.0.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugins/experimental/plugin-wnfs/project.json
+++ b/packages/plugins/experimental/plugin-wnfs/project.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "name": "plugin-wnfs",
+  "tags": [
+    "scope:experimental",
+    "scope:plugins"
+  ],
+  "sourceRoot": "packages/plugins/experimental/plugin-wnfs/src",
+  "projectType": "library",
+  "targets": {
+    "build": {},
+    "compile": {
+      "options": {
+        "entryPoints": [
+          "{projectRoot}/src/index.ts",
+          "{projectRoot}/src/meta.tsx",
+          "{projectRoot}/src/types/index.ts"
+        ],
+        "platforms": [
+          "browser"
+        ]
+      }
+    },
+    "lint": {}
+  },
+  "implicitDependencies": [
+    "esbuild"
+  ]
+}

--- a/packages/plugins/experimental/plugin-wnfs/src/WnfsPlugin.tsx
+++ b/packages/plugins/experimental/plugin-wnfs/src/WnfsPlugin.tsx
@@ -1,0 +1,102 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { FileCloud, type IconProps } from '@phosphor-icons/react';
+import React, { type Ref } from 'react';
+
+import { type PluginDefinition, isObject, resolvePlugin } from '@dxos/app-framework';
+import { invariant } from '@dxos/invariant';
+import { parseClientPlugin } from '@dxos/plugin-client';
+import { type DocumentType } from '@dxos/plugin-markdown/types';
+import { type Space, getSpace } from '@dxos/react-client/echo';
+import { isTileComponentProps } from '@dxos/react-ui-mosaic';
+
+import * as Blockstore from './blockstore';
+import { FileCard, FileMain, FileSection, FileSlide } from './components';
+import { image as imageExtension } from './extensions';
+import meta, { WNFS_PLUGIN } from './meta';
+import translations from './translations';
+import { FileType } from './types';
+import { type WnfsPluginProvides } from './types';
+import { upload } from './upload';
+
+export const WnfsPlugin = (): PluginDefinition<WnfsPluginProvides> => {
+  let blockstore: Blockstore.MixedBlockstore | undefined;
+
+  return {
+    meta,
+    ready: async (plugins) => {
+      const client = resolvePlugin(plugins, parseClientPlugin)?.provides.client;
+      invariant(client);
+      const apiHost = client.config.values.runtime?.services?.edge?.url || 'http://localhost:8787';
+      blockstore = Blockstore.create(apiHost);
+      await blockstore.open();
+    },
+    provides: {
+      translations,
+      metadata: {
+        records: {
+          [FileType.typename]: {
+            placeholder: ['file title placeholder', { ns: WNFS_PLUGIN }],
+            icon: (props: IconProps) => <FileCloud {...props} />,
+          },
+        },
+      },
+      echo: {
+        schema: [FileType],
+      },
+      // TODO(burdon): Add intent to upload file.
+      file: {
+        upload: async (file: File, space: Space) => {
+          if (!blockstore) {
+            throw new Error('Blockstore is not ready yet');
+          }
+
+          return await upload({ blockstore, file, space });
+        },
+      },
+      markdown: {
+        extensions: ({ document }: { document?: DocumentType }) => {
+          if (!blockstore) {
+            throw new Error('Blockstore is not ready yet');
+          }
+
+          if (document) {
+            const space = getSpace(document);
+            return space ? [imageExtension({ blockstore, space })] : [];
+          }
+
+          return [];
+        },
+      },
+      surface: {
+        component: ({ data, role, ...props }, forwardedRef) => {
+          switch (role) {
+            case 'main':
+              return data.active instanceof FileType ? <FileMain file={data.active} /> : null;
+            case 'slide':
+              return data.slide instanceof FileType ? <FileSlide file={data.slide} cover={false} /> : null;
+            case 'section':
+              return data.object instanceof FileType ? <FileSection file={data.object} /> : null;
+            case 'card': {
+              if (
+                isObject(data.content) &&
+                typeof data.content.id === 'string' &&
+                data.content.object instanceof FileType
+              ) {
+                const cardProps = { ...props, item: { id: data.content.id, object: data.content.object } };
+                return isTileComponentProps(cardProps) ? (
+                  <FileCard {...cardProps} ref={forwardedRef as Ref<HTMLDivElement>} />
+                ) : null;
+              }
+              break;
+            }
+          }
+
+          return null;
+        },
+      },
+    },
+  };
+};

--- a/packages/plugins/experimental/plugin-wnfs/src/blockstore.ts
+++ b/packages/plugins/experimental/plugin-wnfs/src/blockstore.ts
@@ -1,0 +1,96 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { BaseBlockstore } from 'blockstore-core';
+import { IDBBlockstore } from 'blockstore-idb';
+import type { CID } from 'multiformats';
+
+import { storeName } from './common';
+
+export const create = (apiHost?: string) => {
+  return new MixedBlockstore(apiHost);
+};
+
+/**
+ * A blockstore that communicates with the DXOS blob service,
+ * and which uses an indexedDB blockstore as a client cache.
+ */
+export class MixedBlockstore extends BaseBlockstore {
+  readonly #apiHost: string | undefined;
+  readonly #idbStore: IDBBlockstore;
+
+  constructor(apiHost?: string) {
+    super();
+
+    this.#apiHost = apiHost;
+    this.#idbStore = new IDBBlockstore(storeName());
+  }
+
+  async open() {
+    await this.#idbStore.open();
+  }
+
+  url(apiHost: string, cid?: CID) {
+    const path = cid ? cid.toString() : '';
+    return `${apiHost}/api/file/${path}`;
+  }
+
+  // Blockstore implementation
+  override async delete(key: CID): Promise<void> {
+    await this.#idbStore.delete(key);
+
+    if (this.#apiHost) {
+      await fetch(this.url(this.#apiHost, key), {
+        method: 'DELETE',
+      });
+    }
+  }
+
+  override async get(key: CID): Promise<Uint8Array> {
+    if (await this.#idbStore.has(key)) {
+      return await this.#idbStore.get(key);
+    }
+
+    if (this.#apiHost) {
+      return await fetch(this.url(this.#apiHost, key), {
+        method: 'GET',
+      })
+        .then((r) => r.arrayBuffer())
+        .then((r) => new Uint8Array(r));
+    }
+
+    return await this.#idbStore.get(key);
+  }
+
+  override async has(key: CID): Promise<boolean> {
+    if (await this.#idbStore.has(key)) {
+      return true;
+    }
+
+    if (this.#apiHost) {
+      return await fetch(this.url(this.#apiHost, key), {
+        method: 'HEAD',
+      }).then((r) => r.ok);
+    }
+
+    return false;
+  }
+
+  override async put(key: CID, val: Uint8Array): Promise<CID> {
+    await this.#idbStore.put(key, val);
+
+    if (this.#apiHost) {
+      await fetch(this.url(this.#apiHost, key), {
+        method: 'POST',
+        body: val,
+      });
+    }
+
+    return key;
+  }
+
+  async destroy(): Promise<void> {
+    await this.#idbStore.destroy();
+  }
+}

--- a/packages/plugins/experimental/plugin-wnfs/src/common.ts
+++ b/packages/plugins/experimental/plugin-wnfs/src/common.ts
@@ -1,0 +1,84 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import type { Blockstore } from 'interface-blockstore';
+import { CID } from 'multiformats/cid';
+import { sha256 } from 'multiformats/hashes/sha2';
+import { type BlockStore as WnfsBlockStore } from 'wnfs';
+
+import * as crypto from '@dxos/crypto';
+import { type Space } from '@dxos/react-client/echo';
+
+//
+// PATH
+//
+
+export const filePath = (fileName: string, space: Space) => {
+  return ['spaces', space.properties.id, 'files', fileName];
+};
+
+//
+// RNG
+//
+
+export class Rng {
+  randomBytes(count: number): Uint8Array {
+    return new Uint8Array(crypto.randomBytes(count));
+  }
+}
+
+//
+// STORE
+//
+
+export const store = (blockstore: Blockstore): WnfsBlockStore => {
+  const getBlock = async (cid: Uint8Array): Promise<Uint8Array | undefined> => {
+    const decodedCid = CID.decode(cid);
+    return await blockstore.get(decodedCid);
+  };
+
+  const hasBlock = async (cid: Uint8Array): Promise<boolean> => {
+    const decodedCid = CID.decode(cid);
+    return await blockstore.has(decodedCid);
+  };
+
+  const putBlockKeyed = async (cid: Uint8Array, bytes: Uint8Array): Promise<void> => {
+    const decodedCid = CID.decode(cid);
+    await blockstore.put(decodedCid, bytes);
+  };
+
+  // Don't hash blocks with the rs-wnfs default Blake 3, sha256 has better support.
+  const putBlock = async (bytes: Uint8Array, codec: number): Promise<Uint8Array> => {
+    const hash = await sha256.digest(bytes);
+    const cid = CID.create(1, codec, hash);
+    await blockstore.put(cid, bytes);
+    return cid.bytes;
+  };
+
+  return { getBlock, hasBlock, putBlockKeyed, putBlock };
+};
+
+export const storeName = () => 'dxos/wnfs';
+
+//
+// OTHER
+//
+
+export const readFile = (file: File): Promise<Uint8Array> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const result = event.target?.result;
+      if (result === null || result === undefined || typeof result === 'string') {
+        reject(new Error('Expected an ArrayBuffer'));
+        return;
+      }
+      resolve(new Uint8Array(result));
+    };
+    reader.onerror = (err) => {
+      reject(err);
+    };
+    reader.readAsArrayBuffer(file);
+  });
+};

--- a/packages/plugins/experimental/plugin-wnfs/src/components/FileCard.tsx
+++ b/packages/plugins/experimental/plugin-wnfs/src/components/FileCard.tsx
@@ -1,0 +1,45 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React, { forwardRef } from 'react';
+
+import { DropdownMenu } from '@dxos/react-ui';
+import { Card } from '@dxos/react-ui-card';
+import type { MosaicTileComponent } from '@dxos/react-ui-mosaic';
+import { mx } from '@dxos/react-ui-theme';
+
+import { type FileType } from '../types';
+
+export type FileCardProps = {
+  id: string;
+  object: FileType;
+};
+
+const FileCard: MosaicTileComponent<FileCardProps> = forwardRef(
+  (
+    { classNames, isDragging, draggableStyle, draggableProps, item: { id, object: file }, grow, onSelect, onAction },
+    forwardRef,
+  ) => {
+    const url = 'TODO';
+
+    return (
+      <div role='none' ref={forwardRef} className='flex w-full' style={draggableStyle}>
+        <Card.Root classNames={mx('w-full snap-center', isDragging && 'opacity-20', classNames)} grow={grow}>
+          <Card.Header onDoubleClick={() => onSelect?.()} floating={!!url}>
+            <Card.DragHandle {...draggableProps} position='left' />
+            <Card.Menu position='right'>
+              {/* TODO(burdon): Handle events/intents? */}
+              <DropdownMenu.Item onClick={() => onAction?.({ id, action: 'delete' })}>
+                <span className='grow'>Delete</span>
+              </DropdownMenu.Item>
+            </Card.Menu>
+          </Card.Header>
+          <Card.Media src={url} />
+        </Card.Root>
+      </div>
+    );
+  },
+);
+
+export default FileCard;

--- a/packages/plugins/experimental/plugin-wnfs/src/components/FileMain.tsx
+++ b/packages/plugins/experimental/plugin-wnfs/src/components/FileMain.tsx
@@ -1,0 +1,28 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React, { type FC } from 'react';
+
+import { Main } from '@dxos/react-ui';
+import {
+  baseSurface,
+  topbarBlockPaddingStart,
+  fixedInsetFlexLayout,
+  bottombarBlockPaddingEnd,
+} from '@dxos/react-ui-theme';
+
+import { FilePreview } from './FilePreview';
+import { type FileType } from '../types';
+
+const FileMain: FC<{ file: FileType }> = ({ file }) => {
+  const url = 'TODO';
+
+  return (
+    <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart, bottombarBlockPaddingEnd]}>
+      <FilePreview type={file.type} url={url} />
+    </Main.Content>
+  );
+};
+
+export default FileMain;

--- a/packages/plugins/experimental/plugin-wnfs/src/components/FilePreview.tsx
+++ b/packages/plugins/experimental/plugin-wnfs/src/components/FilePreview.tsx
@@ -1,0 +1,23 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React from 'react';
+
+import { type ThemedClassName } from '@dxos/react-ui';
+import { mx } from '@dxos/react-ui-theme';
+
+export type FilePreviewProps = ThemedClassName<{ type: string; url: string }>;
+
+/**
+ * File/content preview iframe.
+ */
+export const FilePreview = ({ type, url, classNames }: FilePreviewProps) => {
+  if (type.startsWith('image/')) {
+    return <img className={mx('w-full h-full object-contain', classNames)} src={url} />;
+  } else if (type.startsWith('video/')) {
+    return <video className={mx('w-full h-full object-contain', classNames)} src={url} controls />;
+  } else {
+    return <iframe className={mx('w-full h-full overflow-auto', classNames)} src={url} />;
+  }
+};

--- a/packages/plugins/experimental/plugin-wnfs/src/components/FileSection.tsx
+++ b/packages/plugins/experimental/plugin-wnfs/src/components/FileSection.tsx
@@ -1,0 +1,20 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React, { type FC } from 'react';
+
+import { FilePreview } from './FilePreview';
+import { type FileType } from '../types';
+
+const FileSection: FC<{ file: FileType; height?: number }> = ({ file, height = 400 }) => {
+  const url = 'TODO';
+
+  return (
+    <div style={{ height }} className='flex w-full p-2 justify-center align-center'>
+      <FilePreview type={file.type} url={url} className='object-contain' />
+    </div>
+  );
+};
+
+export default FileSection;

--- a/packages/plugins/experimental/plugin-wnfs/src/components/FileSection.tsx
+++ b/packages/plugins/experimental/plugin-wnfs/src/components/FileSection.tsx
@@ -12,7 +12,7 @@ const FileSection: FC<{ file: FileType; height?: number }> = ({ file, height = 4
 
   return (
     <div style={{ height }} className='flex w-full p-2 justify-center align-center'>
-      <FilePreview type={file.type} url={url} className='object-contain' />
+      <FilePreview type={file.type} url={url} classNames='object-contain' />
     </div>
   );
 };

--- a/packages/plugins/experimental/plugin-wnfs/src/components/FileSlide.tsx
+++ b/packages/plugins/experimental/plugin-wnfs/src/components/FileSlide.tsx
@@ -1,0 +1,20 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React, { type FC } from 'react';
+
+import { FilePreview } from './FilePreview';
+import { type FileType } from '../types';
+
+const FileSlide: FC<{ file: FileType; cover?: boolean }> = ({ file, cover }) => {
+  const url = 'TODO';
+
+  return (
+    <div className='h-full flex justify-center align-center'>
+      <FilePreview type={file.type} url={url} className={cover ? 'object-cover' : 'object-contain'} />
+    </div>
+  );
+};
+
+export default FileSlide;

--- a/packages/plugins/experimental/plugin-wnfs/src/components/FileSlide.tsx
+++ b/packages/plugins/experimental/plugin-wnfs/src/components/FileSlide.tsx
@@ -12,7 +12,7 @@ const FileSlide: FC<{ file: FileType; cover?: boolean }> = ({ file, cover }) => 
 
   return (
     <div className='h-full flex justify-center align-center'>
-      <FilePreview type={file.type} url={url} className={cover ? 'object-cover' : 'object-contain'} />
+      <FilePreview type={file.type} url={url} classNames={cover ? 'object-cover' : 'object-contain'} />
     </div>
   );
 };

--- a/packages/plugins/experimental/plugin-wnfs/src/components/index.ts
+++ b/packages/plugins/experimental/plugin-wnfs/src/components/index.ts
@@ -1,0 +1,11 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import React from 'react';
+
+// Lazily load components for content surfaces.
+export const FileCard = React.lazy(() => import('./FileCard'));
+export const FileMain = React.lazy(() => import('./FileMain'));
+export const FileSection = React.lazy(() => import('./FileSection'));
+export const FileSlide = React.lazy(() => import('./FileSlide'));

--- a/packages/plugins/experimental/plugin-wnfs/src/extensions/image.stories.tsx
+++ b/packages/plugins/experimental/plugin-wnfs/src/extensions/image.stories.tsx
@@ -1,0 +1,142 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import '@dxos-theme';
+
+import type { Blockstore } from 'interface-blockstore';
+import React, { useEffect, useState } from 'react';
+
+import { useSpace } from '@dxos/react-client/echo';
+import { withClientProvider } from '@dxos/react-client/testing';
+import { useThemeContext } from '@dxos/react-ui';
+import {
+  createBasicExtensions,
+  createMarkdownExtensions,
+  createThemeExtensions,
+  decorateMarkdown,
+  useTextEditor,
+} from '@dxos/react-ui-editor';
+import { withTheme, withLayout } from '@dxos/storybook-utils';
+
+import { image } from './image';
+import { create as createBlockstore } from '../blockstore';
+import { filePath, store } from '../common';
+import { loadWnfs } from '../load';
+import { upload } from '../upload';
+
+const Story = () => {
+  const space = useSpace();
+
+  const [blockstore, setBlockstore] = useState<Blockstore>();
+  const [amountOfUploads, setAmountOfUploads] = useState<number>(0);
+  const [images, setImages] = useState<{ url: string }[]>([]);
+
+  useEffect(() => {
+    if (space) {
+      console.log('SPACE ID', space.properties.id);
+    }
+
+    const create = async () => {
+      // NOTE: We don't pass in the URL of the Blob service, so we don't use it.
+      const bs = createBlockstore();
+      await bs.open();
+      setBlockstore(bs);
+    };
+
+    create().catch(console.error);
+  }, [space]);
+
+  useEffect(() => {
+    if (!space || !blockstore) {
+      return;
+    }
+
+    (async () => {
+      const { directory, forest } = await loadWnfs(space, blockstore);
+      const parentPath = ['spaces', space.properties.id, 'files'];
+      const parentNode = await directory.getNode(parentPath, true, forest, store(blockstore));
+      if (!parentNode) {
+        return;
+      }
+
+      const { result } = await directory.ls(parentPath, true, forest, store(blockstore));
+
+      const images = await Promise.all(
+        result.map(async (r: any) => {
+          const path = filePath(r.name, space);
+          const reading = await directory.read(path, true, forest, store(blockstore));
+          const bytes = reading.result;
+          const blob = new Blob([bytes]);
+          const url = URL.createObjectURL(blob);
+          return { url };
+        }),
+      );
+
+      setImages(images);
+    })().catch(console.error);
+  }, [space, blockstore, amountOfUploads]);
+
+  const onFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      if (blockstore) {
+        if (space) {
+          await upload({ blockstore, file, space });
+          setAmountOfUploads(amountOfUploads + 1);
+        } else {
+          console.warn('Space is undefined.');
+        }
+      } else {
+        console.warn("Blockstore hasn't been initialised yet.");
+      }
+    }
+  };
+
+  const { themeMode } = useThemeContext();
+  const { parentRef, focusAttributes } = useTextEditor(
+    () => ({
+      initialValue: '',
+      extensions: [
+        createBasicExtensions(),
+        createMarkdownExtensions({ themeMode }),
+        createThemeExtensions({ themeMode, syntaxHighlighting: true }),
+        blockstore && space ? [image({ blockstore, space })] : [],
+        decorateMarkdown(),
+      ],
+    }),
+    [themeMode],
+  );
+
+  const renderedImages = images.map((image, index) => (
+    <div key={index} className='mt-1'>
+      <img src={image.url} width='300' />
+    </div>
+  ));
+
+  return (
+    <>
+      <div className='mb-2'>
+        <input type='file' accept='image/*' onChange={onFileChange} />
+      </div>
+      <div className='w-[50rem]' ref={parentRef} {...focusAttributes} />
+      <div>
+        {images.length ? (
+          renderedImages
+        ) : (
+          <p>
+            <strong className='text-green-600'>Select an image file to add to WNFS and render it.</strong>
+          </p>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default {
+  title: 'plugins/plugin-wnfs/image',
+  render: Story,
+  decorators: [withClientProvider({ createIdentity: true, createSpace: true }), withTheme, withLayout()],
+};
+
+export const Default = {};

--- a/packages/plugins/experimental/plugin-wnfs/src/extensions/image.ts
+++ b/packages/plugins/experimental/plugin-wnfs/src/extensions/image.ts
@@ -1,0 +1,244 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { syntaxTree } from '@codemirror/language';
+import { type EditorState, type Extension, StateField, type Range, StateEffect } from '@codemirror/state';
+import { Decoration, EditorView, WidgetType, ViewPlugin, type ViewUpdate } from '@codemirror/view';
+import type { Blockstore } from 'interface-blockstore';
+import type { PrivateDirectory, PrivateForest } from 'wnfs';
+
+import { log } from '@dxos/log';
+import { type Space } from '@dxos/react-client/echo';
+
+import { store } from '../common';
+import { loadWnfs } from '../load';
+
+export type ImageOptions = {
+  blockstore: Blockstore;
+  space: Space;
+};
+
+export const image = (options: ImageOptions): Extension[] => {
+  return [stateField(options), viewPlugin(options)];
+};
+
+// GLOBAL STATE
+
+/** Indexed by space id */
+const loadedWnfsInstances: Record<string, { directory: PrivateDirectory; forest: PrivateForest }> = {};
+
+// EFFECT + EXTENSIONS
+
+const stateEffect = StateEffect.define<{
+  decorations: Range<Decoration>[];
+  from: number;
+  to: number;
+}>({});
+
+const stateField = (options: ImageOptions) =>
+  StateField.define({
+    create: () => {
+      return Decoration.none;
+    },
+    update: (value, tr) => {
+      for (const effect of tr.effects) {
+        if (effect.is(stateEffect)) {
+          return value.map(tr.changes).update({
+            filterFrom: effect.value.from,
+            filterTo: effect.value.to,
+            filter: () => false,
+            add: effect.value.decorations,
+          });
+        }
+      }
+
+      return value;
+    },
+    provide: (f) => {
+      return EditorView.decorations.from(f);
+    },
+  });
+
+const viewPlugin = (options: ImageOptions) =>
+  ViewPlugin.define((view: EditorView) => {
+    // Initial decoration set on document load
+    buildDecorations({
+      from: 0,
+      to: view.state.doc.length,
+      state: view.state,
+      options,
+    })
+      .then((decorations) => {
+        view.dispatch({
+          effects: stateEffect.of({
+            decorations,
+            from: 0,
+            to: view.state.doc.length,
+          }),
+        });
+      })
+      .catch((err) => {
+        throw new Error(err);
+      });
+
+    const update = (update: ViewUpdate) => {
+      if (!update.docChanged) {
+        return;
+      }
+
+      const { from, to } = changedRange(update);
+      buildDecorations({
+        from,
+        to,
+        state: view.state,
+        options,
+      })
+        .then((decorations) => {
+          view.dispatch({
+            effects: stateEffect.of({
+              decorations,
+              from,
+              to,
+            }),
+          });
+        })
+        .catch((err) => {
+          log.catch(err);
+        });
+    };
+
+    return { update };
+  });
+
+// 🛠️
+
+const changedRange = (update: ViewUpdate) => {
+  // Find range of changes and cursor changes.
+  const cursor = update.state.selection.main.head;
+  const oldCursor = update.changes.mapPos(update.startState.selection.main.head);
+
+  let from = Math.min(cursor, oldCursor);
+  let to = Math.max(cursor, oldCursor);
+
+  update.changes.iterChangedRanges((fromA, toA, fromB, toB) => {
+    from = Math.min(from, fromB);
+    to = Math.max(to, toB);
+  });
+
+  // Expand to cover lines.
+  from = update.state.doc.lineAt(from).from;
+  to = update.state.doc.lineAt(to).to;
+
+  // Fin
+  return { from, to };
+};
+
+const buildDecorations = async ({
+  from,
+  to,
+  state,
+  options,
+}: {
+  from: number;
+  to: number;
+  state: EditorState;
+  options: ImageOptions;
+}) => {
+  const cursor = state.selection.main.head;
+  let nodes: { from: number; hide: boolean; to: number; url: string }[] = [];
+
+  syntaxTree(state).iterate({
+    enter: (node) => {
+      if (node.name === 'Image') {
+        const urlNode = node.node.getChild('URL');
+        if (urlNode) {
+          const hide = state.readOnly || cursor < node.from || cursor > node.to;
+          const url = state.sliceDoc(urlNode.from, urlNode.to);
+
+          if (url.startsWith('wnfs://')) {
+            nodes.push({
+              from: node.from,
+              to: node.to,
+              hide,
+              url,
+            });
+          }
+        }
+      }
+    },
+    from,
+    to,
+  });
+
+  // Nodes must be sorted by `from`
+  nodes = nodes.sort((a, b) => {
+    return a.from - b.from;
+  });
+
+  const decorations = await nodes.reduce(
+    async (acc, node) => {
+      const array = await acc;
+      const path = node.url
+        .replace(/^wnfs:\/\//, '')
+        .split('/')
+        .map((p) => decodeURIComponent(p));
+
+      // Cannot load images from other spaces
+      const spaceIdFromUrl = path[1];
+      if (spaceIdFromUrl !== options.space.properties.id) {
+        return array;
+      }
+
+      const cacheKey = options.space.properties.wnfs_private_forest_cid;
+
+      const { directory, forest } = loadedWnfsInstances[cacheKey]
+        ? loadedWnfsInstances[cacheKey]
+        : await loadWnfs(options.space, options.blockstore);
+
+      loadedWnfsInstances[cacheKey] = {
+        directory,
+        forest,
+      };
+
+      const wnfsStore = store(options.blockstore);
+
+      // Load image contents into memory blob
+      const { result } = await directory.read(path, true, forest, wnfsStore);
+      const blob = new Blob([result]);
+      const blobUrl = URL.createObjectURL(blob);
+
+      // Create decoration
+      return [
+        ...array,
+        Decoration.replace({
+          block: true, // Prevent cursor from entering.
+          widget: new WnfsImageWidget(blobUrl),
+        }).range(node.hide ? node.from : node.to, node.to),
+      ];
+    },
+    Promise.resolve([] as Range<Decoration>[]),
+  );
+
+  return decorations;
+};
+
+class WnfsImageWidget extends WidgetType {
+  constructor(readonly _url: string) {
+    super();
+  }
+
+  override eq(other: this) {
+    return this._url === (other as any as WnfsImageWidget)._url;
+  }
+
+  override toDOM(view: EditorView) {
+    const img = document.createElement('img');
+    img.setAttribute('loading', 'lazy');
+    img.setAttribute('src', this._url);
+    img.setAttribute('class', 'cm-image');
+    // Images are hidden until successfully loaded to avoid flickering effects.
+    img.onload = () => img.classList.add('cm-loaded-image');
+    return img;
+  }
+}

--- a/packages/plugins/experimental/plugin-wnfs/src/extensions/index.ts
+++ b/packages/plugins/experimental/plugin-wnfs/src/extensions/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+export * from './image';

--- a/packages/plugins/experimental/plugin-wnfs/src/index.ts
+++ b/packages/plugins/experimental/plugin-wnfs/src/index.ts
@@ -1,0 +1,9 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { WnfsPlugin } from './WnfsPlugin';
+
+export default WnfsPlugin;
+
+export * from './WnfsPlugin';

--- a/packages/plugins/experimental/plugin-wnfs/src/load.ts
+++ b/packages/plugins/experimental/plugin-wnfs/src/load.ts
@@ -1,0 +1,63 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import type { Blockstore } from 'interface-blockstore';
+import { CID } from 'multiformats';
+import * as Uint8Arrays from 'uint8arrays';
+import { AccessKey, PrivateForest, PrivateDirectory, PrivateNode } from 'wnfs';
+
+import { type Space } from '@dxos/react-client/echo';
+
+import { Rng, store } from './common';
+
+//
+// LOAD
+//
+
+export const loadWnfs = async (space: Space, blockstore: Blockstore) => {
+  const exists =
+    space.properties.wnfs_access_key !== undefined && space.properties.wnfs_private_forest_cid !== undefined;
+
+  return exists ? await loadWnfsDir(blockstore, space) : await createWnfsDir(blockstore, space);
+};
+
+//
+// PRIVATE
+//
+
+const createWnfsDir = async (blockstore: Blockstore, space: Space) => {
+  const wnfsStore = store(blockstore);
+  const rng = new Rng();
+  const forest = new PrivateForest(rng);
+
+  const dirResult = await PrivateDirectory.newAndStore(forest.emptyName(), new Date(), forest, wnfsStore, rng);
+  const dir = dirResult.rootDir as PrivateDirectory;
+
+  const [accessKeyRaw, newForest]: [AccessKey, PrivateForest] = await dir
+    .asNode()
+    .store(dirResult.forest as PrivateForest, wnfsStore, rng);
+
+  const cidBytes = await newForest.store(wnfsStore);
+
+  space.properties.wnfs_access_key = Uint8Arrays.toString(accessKeyRaw.toBytes(), 'base64');
+  space.properties.wnfs_private_forest_cid = CID.decode(cidBytes).toString();
+
+  return {
+    directory: dir,
+    forest: newForest,
+  };
+};
+
+const loadWnfsDir = async (blockstore: Blockstore, space: Space) => {
+  const wnfsStore = store(blockstore);
+
+  const accessKey = AccessKey.fromBytes(Uint8Arrays.fromString(space.properties.wnfs_access_key, 'base64'));
+  const forest = await PrivateForest.load(CID.parse(space.properties.wnfs_private_forest_cid).bytes, wnfsStore);
+  const node: PrivateNode = await PrivateNode.load(accessKey, forest, wnfsStore);
+
+  return {
+    directory: node.asDir(),
+    forest,
+  };
+};

--- a/packages/plugins/experimental/plugin-wnfs/src/meta.tsx
+++ b/packages/plugins/experimental/plugin-wnfs/src/meta.tsx
@@ -1,0 +1,15 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { type PluginMeta } from '@dxos/app-framework';
+
+export const WNFS_PLUGIN = 'dxos.org/plugin/WNFS';
+
+export default {
+  id: WNFS_PLUGIN,
+  name: 'WNFS',
+  description: 'Upload & view files with WNFS.',
+  tags: ['experimental'],
+  icon: 'ph--file-cloud--regular',
+} satisfies PluginMeta;

--- a/packages/plugins/experimental/plugin-wnfs/src/translations.ts
+++ b/packages/plugins/experimental/plugin-wnfs/src/translations.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import { WNFS_PLUGIN } from './meta';
+
+export default [
+  {
+    'en-US': {
+      [WNFS_PLUGIN]: {
+        'plugin name': 'Files',
+        'file title placeholder': 'New file',
+        'delete object label': 'Delete',
+      },
+    },
+  },
+];

--- a/packages/plugins/experimental/plugin-wnfs/src/types/file.ts
+++ b/packages/plugins/experimental/plugin-wnfs/src/types/file.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { S, TypedObject } from '@dxos/echo-schema';
+
+export class FileType extends TypedObject({ typename: 'dxos.org/type/File', version: '0.1.0' })({
+  filename: S.String,
+  type: S.String,
+  timestamp: S.optional(S.String),
+  name: S.optional(S.String),
+  cid: S.optional(S.String),
+}) {}

--- a/packages/plugins/experimental/plugin-wnfs/src/types/index.ts
+++ b/packages/plugins/experimental/plugin-wnfs/src/types/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+export * from './file';
+export * from './types';

--- a/packages/plugins/experimental/plugin-wnfs/src/types/types.ts
+++ b/packages/plugins/experimental/plugin-wnfs/src/types/types.ts
@@ -1,0 +1,27 @@
+//
+// Copyright 2023 DXOS.org
+//
+
+import {
+  type FileManagerProvides,
+  type MetadataRecordsProvides,
+  type SurfaceProvides,
+  type TranslationsProvides,
+} from '@dxos/app-framework';
+import { type SchemaProvides } from '@dxos/plugin-client';
+import { type MarkdownExtensionProvides } from '@dxos/plugin-markdown/types';
+
+import { WNFS_PLUGIN } from '../meta';
+
+const WNFS_ACTION = `${WNFS_PLUGIN}/action`;
+
+export enum WnfsAction {
+  CREATE = `${WNFS_ACTION}/create`,
+}
+
+export type WnfsPluginProvides = FileManagerProvides &
+  SurfaceProvides &
+  MetadataRecordsProvides &
+  TranslationsProvides &
+  SchemaProvides &
+  MarkdownExtensionProvides;

--- a/packages/plugins/experimental/plugin-wnfs/src/upload.ts
+++ b/packages/plugins/experimental/plugin-wnfs/src/upload.ts
@@ -3,11 +3,11 @@
 //
 
 import type { Blockstore } from 'interface-blockstore';
-import type { Space } from '@dxos/client/echo';
 import { CID } from 'multiformats';
 import * as Raw from 'multiformats/codecs/raw';
 import { sha256 } from 'multiformats/hashes/sha2';
 
+import type { Space } from '@dxos/client/echo';
 import { log } from '@dxos/log';
 
 import { Rng, filePath, store } from './common';

--- a/packages/plugins/experimental/plugin-wnfs/src/upload.ts
+++ b/packages/plugins/experimental/plugin-wnfs/src/upload.ts
@@ -1,0 +1,46 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import type { Blockstore } from 'interface-blockstore';
+import type { Space } from '@dxos/client/echo';
+import { CID } from 'multiformats';
+import * as Raw from 'multiformats/codecs/raw';
+import { sha256 } from 'multiformats/hashes/sha2';
+
+import { log } from '@dxos/log';
+
+import { Rng, filePath, store } from './common';
+import { loadWnfs } from './load';
+import { wnfsUrl } from './wnfs-url';
+
+export const upload = async ({ blockstore, file, space }: { blockstore: Blockstore; file: File; space: Space }) => {
+  const { directory, forest } = await loadWnfs(space, blockstore);
+  const wnfsStore = store(blockstore);
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const hash = await sha256.digest(bytes);
+  const cid = CID.create(1, Raw.code, hash);
+
+  const path = filePath(cid.toString(), space);
+
+  // Given the root directory of the private file system,
+  // write the file contents to `path` in said directory.
+  const result = await directory.write(path, true, bytes, new Date(), forest, wnfsStore, new Rng());
+
+  // Given the new immutable instance of the root directory after writing to it,
+  // **store** the changes in the "dark forest" and the associated (block) store.
+  const [_, updatedForest] = await result.rootDir.store(result.forest, wnfsStore, new Rng());
+  const cidBytes = await updatedForest.store(wnfsStore);
+
+  // Update the forest pointer on the associated space.
+  space.properties.wnfs_private_forest_cid = CID.decode(cidBytes).toString();
+
+  // Generate `wnfs://` URL & return the info.
+  const info = {
+    url: wnfsUrl(path),
+  };
+
+  log('upload', { file, info });
+  return info;
+};

--- a/packages/plugins/experimental/plugin-wnfs/src/wnfs-url.ts
+++ b/packages/plugins/experimental/plugin-wnfs/src/wnfs-url.ts
@@ -1,0 +1,7 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+export const wnfsUrl = (filePath: string[]) => {
+  return 'wnfs://' + filePath.map((f) => encodeURIComponent(f)).join('/');
+};

--- a/packages/plugins/experimental/plugin-wnfs/tsconfig.json
+++ b/packages/plugins/experimental/plugin-wnfs/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": [
+    "../../../../tsconfig.json"
+  ],
+  "compilerOptions": {
+    "lib": [
+      "DOM",
+      "ESNext"
+    ],
+    "outDir": "dist/types",
+    "types": [
+      "node"
+    ]
+  },
+  "exclude": [
+    "*.t.ts",
+    "vite.config.ts"
+  ],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/*.ts"
+  ],
+  "references": []
+}

--- a/packages/sdk/config/src/plugin/definitions.ts
+++ b/packages/sdk/config/src/plugin/definitions.ts
@@ -25,8 +25,8 @@ export const definitions = ({
   env,
 }: ConfigPluginOpts) => {
   const KEYS_TO_FILE = {
-    __CONFIG_DEFAULTS__: configPath ?? resolve(CWD, 'dx.yml'),
-    __CONFIG_ENVS__: envPath ?? resolve(CWD, 'dx-env.yml'),
+    __CONFIG_DEFAULTS__: configPath?.length ? configPath : resolve(CWD, 'dx.yml'),
+    __CONFIG_ENVS__: envPath?.length ? envPath : resolve(CWD, 'dx-env.yml'),
   } as { [key: string]: string };
 
   if (mode !== 'production') {

--- a/packages/ui/react-ui-editor/src/extensions/markdown/image.ts
+++ b/packages/ui/react-ui-editor/src/extensions/markdown/image.ts
@@ -63,6 +63,10 @@ const buildDecorations = (from: number, to: number, state: EditorState) => {
         if (urlNode) {
           const hide = state.readOnly || cursor < node.from || cursor > node.to;
           const url = state.sliceDoc(urlNode.from, urlNode.to);
+          // Some plugins might be using custom URLs, avoid attempts to render those URLs
+          if (url.match(/^https?:\/\//) === null && url.match(/^file?:\/\//) === null) {
+            return;
+          }
           // TODO(burdon): Doesn't load if scrolling with mouse.
           preloadImage(url);
           decorations.push(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -701,6 +701,9 @@ importers:
       '@dxos/plugin-wildcard':
         specifier: workspace:*
         version: link:../../plugins/plugin-wildcard
+      '@dxos/plugin-wnfs':
+        specifier: workspace:*
+        version: link:../../plugins/experimental/plugin-wnfs
       '@dxos/react-client':
         specifier: workspace:*
         version: link:../../sdk/react-client
@@ -4568,7 +4571,7 @@ importers:
         version: link:../../common/util
       '@langchain/community':
         specifier: ^0.0.43
-        version: 0.0.43(@smithy/util-utf8@2.3.0)(@tensorflow/tfjs-converter@3.21.0(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13)))(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13))(discord.js@14.14.1)(encoding@0.1.13)(faiss-node@0.5.1)(google-auth-library@8.9.0(encoding@0.1.13))(googleapis@126.0.1(encoding@0.1.13))(hnswlib-node@1.4.2)(html-to-text@9.0.5)(interface-datastore@8.2.11)(ioredis@5.3.2)(it-all@3.0.6)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(lodash@4.17.21)(openai@4.26.1(encoding@0.1.13))(redis@4.6.6)(ws@8.18.0)
+        version: 0.0.43(@smithy/util-utf8@2.3.0)(@tensorflow/tfjs-converter@3.21.0(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13)))(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13))(discord.js@14.14.1)(encoding@0.1.13)(faiss-node@0.5.1)(google-auth-library@8.9.0(encoding@0.1.13))(googleapis@126.0.1(encoding@0.1.13))(hnswlib-node@1.4.2)(html-to-text@9.0.5)(interface-datastore@8.3.1)(ioredis@5.3.2)(it-all@3.0.6)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(lodash@4.17.21)(openai@4.26.1(encoding@0.1.13))(redis@4.6.6)(ws@8.18.0)
       '@langchain/core':
         specifier: ^0.1.51
         version: 0.1.62(openai@4.26.1(encoding@0.1.13))
@@ -4637,7 +4640,7 @@ importers:
         version: 4.1.0
       langchain:
         specifier: ^0.1.12
-        version: 0.1.13(@smithy/util-utf8@2.3.0)(@tensorflow/tfjs-converter@3.21.0(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13)))(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13))(axios@1.7.7)(cheerio@1.0.0-rc.12)(discord.js@14.14.1)(encoding@0.1.13)(faiss-node@0.5.1)(fast-xml-parser@4.3.2)(google-auth-library@8.9.0(encoding@0.1.13))(googleapis@126.0.1(encoding@0.1.13))(hnswlib-node@1.4.2)(html-to-text@9.0.5)(ignore@5.2.4)(interface-datastore@8.2.11)(ioredis@5.3.2)(it-all@3.0.6)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(lodash@4.17.21)(openai@4.26.1(encoding@0.1.13))(playwright@1.46.1)(redis@4.6.6)(ws@8.18.0)
+        version: 0.1.13(@smithy/util-utf8@2.3.0)(@tensorflow/tfjs-converter@3.21.0(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13)))(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13))(axios@1.7.7)(cheerio@1.0.0-rc.12)(discord.js@14.14.1)(encoding@0.1.13)(faiss-node@0.5.1)(fast-xml-parser@4.3.2)(google-auth-library@8.9.0(encoding@0.1.13))(googleapis@126.0.1(encoding@0.1.13))(hnswlib-node@1.4.2)(html-to-text@9.0.5)(ignore@5.2.4)(interface-datastore@8.3.1)(ioredis@5.3.2)(it-all@3.0.6)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(lodash@4.17.21)(openai@4.26.1(encoding@0.1.13))(playwright@1.46.1)(redis@4.6.6)(ws@8.18.0)
       lodash.defaultsdeep:
         specifier: ^4.6.1
         version: 4.6.1
@@ -6824,6 +6827,100 @@ importers:
       '@dxos/react-ui':
         specifier: workspace:*
         version: link:../../../ui/react-ui
+      '@dxos/react-ui-theme':
+        specifier: workspace:*
+        version: link:../../../ui/react-ui-theme
+      '@dxos/storybook-utils':
+        specifier: workspace:*
+        version: link:../../../common/storybook-utils
+      '@phosphor-icons/react':
+        specifier: ^2.1.5
+        version: 2.1.7(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@types/react':
+        specifier: ~18.2.0
+        version: 18.2.79
+      '@types/react-dom':
+        specifier: ~18.2.0
+        version: 18.2.25
+      react:
+        specifier: ~18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ~18.2.0
+        version: 18.2.0(react@18.2.0)
+      vite:
+        specifier: 5.4.7
+        version: 5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.5.5)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2)
+
+  packages/plugins/experimental/plugin-wnfs:
+    dependencies:
+      '@codemirror/language':
+        specifier: ^6.10.3
+        version: 6.10.3
+      '@codemirror/state':
+        specifier: ^6.4.1
+        version: 6.4.1
+      '@codemirror/view':
+        specifier: ^6.34.1
+        version: 6.34.1
+      '@dxos/app-framework':
+        specifier: workspace:*
+        version: link:../../../sdk/app-framework
+      '@dxos/crypto':
+        specifier: workspace:*
+        version: link:../../../common/crypto
+      '@dxos/echo-schema':
+        specifier: workspace:*
+        version: link:../../../core/echo/echo-schema
+      '@dxos/invariant':
+        specifier: workspace:*
+        version: link:../../../common/invariant
+      '@dxos/local-storage':
+        specifier: workspace:*
+        version: link:../../../common/local-storage
+      '@dxos/log':
+        specifier: workspace:*
+        version: link:../../../common/log
+      '@dxos/plugin-client':
+        specifier: workspace:*
+        version: link:../../plugin-client
+      '@dxos/plugin-markdown':
+        specifier: workspace:*
+        version: link:../../plugin-markdown
+      '@dxos/react-client':
+        specifier: workspace:*
+        version: link:../../../sdk/react-client
+      '@dxos/react-ui-card':
+        specifier: workspace:*
+        version: link:../../../ui/react-ui-card
+      '@dxos/react-ui-mosaic':
+        specifier: workspace:*
+        version: link:../../../ui/react-ui-mosaic
+      blockstore-core:
+        specifier: ^5.0.1
+        version: 5.0.2
+      blockstore-idb:
+        specifier: ^2.0.0
+        version: 2.0.1
+      interface-blockstore:
+        specifier: ^5.2.10
+        version: 5.3.1
+      multiformats:
+        specifier: ^13.2.2
+        version: 13.3.0
+      uint8arrays:
+        specifier: ^5.1.0
+        version: 5.1.0
+      wnfs:
+        specifier: 0.2.2
+        version: 0.2.2
+    devDependencies:
+      '@dxos/react-ui':
+        specifier: workspace:*
+        version: link:../../../ui/react-ui
+      '@dxos/react-ui-editor':
+        specifier: workspace:*
+        version: link:../../../ui/react-ui-editor
       '@dxos/react-ui-theme':
         specifier: workspace:*
         version: link:../../../ui/react-ui-theme
@@ -15673,8 +15770,14 @@ packages:
   '@libp2p/interface@1.3.1':
     resolution: {integrity: sha512-KJoYP6biAgIHUU3pxaixaaYCvIHZshzXetxfoNigadAZ3hCGuwpdFhk7IABEaI3RgadOOYUwW3MXPbL+cxnXVQ==}
 
+  '@libp2p/interface@2.2.0':
+    resolution: {integrity: sha512-Pn3P5ixDggBjDyuULT0GvwdgD3JA426OqZ0e521mI7ysS+/M9Z9fp4Qcy8JrkJ45bLmIi9cgrNrefuU/Zu+bAQ==}
+
   '@libp2p/logger@4.0.12':
     resolution: {integrity: sha512-eSiHY06Zijq6b1rMBob/ZuGBEavFm8IPNPEzeOU3JrBU7v/OV8Da0FesbemtkudZVPRi8mqRoOiIwmWn0mObng==}
+
+  '@libp2p/logger@5.1.3':
+    resolution: {integrity: sha512-NUVWEWGbXlBDgDE5ntdm51+ZICmaKYI8mor6KrlPeB1WXDyIFxRWIBw6uzt+HgprQJWzLTojeUEGv6OPsj95Dg==}
 
   '@libp2p/peer-id@4.1.1':
     resolution: {integrity: sha512-Fu25drhhdc5JDWb3x33u+5p9I3F2tmYrlx2aiwD5Kv70RLKC9k7B1m4iywBkFE82QKUPtT21IrVYlwsm46znqQ==}
@@ -16040,6 +16143,9 @@ packages:
 
   '@multiformats/multiaddr@12.2.1':
     resolution: {integrity: sha512-UwjoArBbv64FlaetV4DDwh+PUMfzXUBltxQwdh+uTYnGFzVa8ZfJsn1vt1RJlJ6+Xtrm3RMekF/B+K338i2L5Q==}
+
+  '@multiformats/multiaddr@12.3.1':
+    resolution: {integrity: sha512-yoGODQY4nIj41ENJClucS8FtBoe8w682bzbKldEQr9lSlfdHqAsRC+vpJAOBpiMwPps1tHua4kxrDmvprdhoDQ==}
 
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
@@ -21764,6 +21870,12 @@ packages:
   blob-to-it@2.0.5:
     resolution: {integrity: sha512-3VIFla8L4JuB+0WCdf+0POI7E1tTl8mhdGiwwwmnZEu6QjRJciS9fIvz8NgWY9URb0iagXYModGEYTcYeq9BMg==}
 
+  blockstore-core@5.0.2:
+    resolution: {integrity: sha512-y7/BHdYLO3YCpJMg6Ue7b4Oz4FT1HWSZoHHdlsaJTsvoE8XieXb6kUCB9UkkUBDw2x4neRDwlgYBpyK77+Ro2Q==}
+
+  blockstore-idb@2.0.1:
+    resolution: {integrity: sha512-dDoiEILLn0BaL5YMHTJW25XeEtSA8HV7yiUb/UMVFqdBHvvdSCuQnSbi0S5CMG/cc78ZkNaWG4Te4SfOL66UvQ==}
+
   bluebird@3.4.7:
     resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
 
@@ -25537,6 +25649,9 @@ packages:
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
 
+  idb@8.0.0:
+    resolution: {integrity: sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -25674,11 +25789,20 @@ packages:
   inspect-custom-symbol@1.1.1:
     resolution: {integrity: sha512-GOucsp9EcdlLdhPUyOTvQDnbFJtp2WBWZV1Jqe+mVnkJQBL3w96+fB84C+JL+EKXOspMdB0eMDQPDp5w9fkfZA==}
 
+  interface-blockstore@5.3.1:
+    resolution: {integrity: sha512-nhgrQnz6yUQEqxTFLhlOBurQOy5lWlwCpgFmZ3GTObTVTQS9RZjK/JTozY6ty9uz2lZs7VFJSqwjWAltorJ4Vw==}
+
   interface-datastore@8.2.11:
     resolution: {integrity: sha512-9E0iXehfp/j0UbZ2mvlYB4K9pP7uQBCppfuy8WHs1EHF6wLQrM9+zwyX+8Qt6HnH4GKZRyXX/CNXm6oD4+QYgA==}
 
+  interface-datastore@8.3.1:
+    resolution: {integrity: sha512-3r0ETmHIi6HmvM5sc09QQiCD3gUfwtEM/AAChOyAd/UAKT69uk8LXfTSUBufbUIO/dU65Vj8nb9O6QjwW8vDSQ==}
+
   interface-store@5.1.7:
     resolution: {integrity: sha512-DVMTgZ43NAdDtXL3QsEq8N0vuUYVBxiGbxN0uI0lrNasuX/CGSrU7bjOO2DaGTMNut4Pt3ae+VQYFvNtH4Oyeg==}
+
+  interface-store@6.0.2:
+    resolution: {integrity: sha512-KSFCXtBlNoG0hzwNa0RmhHtrdhzexp+S+UY2s0rWTBJyfdEIgn6i6Zl9otVqrcFYbYrneBT7hbmHQ8gE0C3umA==}
 
   internal-slot@1.0.5:
     resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
@@ -26207,6 +26331,12 @@ packages:
   it-all@3.0.6:
     resolution: {integrity: sha512-HXZWbxCgQZJfrv5rXvaVeaayXED8nTKx9tj9fpBhmcUJcedVZshMMMqTj0RG2+scGypb9Ut1zd1ifbf3lA8L+Q==}
 
+  it-drain@3.0.7:
+    resolution: {integrity: sha512-vy6S1JKjjHSIFHgBpLpD1zhkCRl3z1zYWUxE14+kAYf+BL9ssWSFImJfhl361IIcwr0ofw8etzg11VqqB+ntUA==}
+
+  it-filter@3.1.1:
+    resolution: {integrity: sha512-TOXmVuaSkxlLp2hXKoMTra0WMZMKVFxE3vSsbIA+PbADNCBAHhjJ/lM31vBOUTddHMO34Ku++vU8T9PLlBxQtg==}
+
   it-first@3.0.6:
     resolution: {integrity: sha512-ExIewyK9kXKNAplg2GMeWfgjUcfC1FnUXz/RPfAvIXby+w7U4b3//5Lic0NV03gXT8O/isj5Nmp6KiY0d45pIQ==}
 
@@ -26218,6 +26348,9 @@ packages:
 
   it-map@3.1.0:
     resolution: {integrity: sha512-B7zNmHYRE0qes8oTiNYU7jXEF5WvKZNAUosskCks1JT9Z4DNwRClrQyd+C/hgITG8ewDbVZMGx9VXAx3KMY2kA==}
+
+  it-merge@3.0.5:
+    resolution: {integrity: sha512-2l7+mPf85pyRF5pqi0dKcA54E5Jm/2FyY5GsOaN51Ta0ipC7YZ3szuAsH8wOoB6eKY4XsU4k2X+mzPmFBMayEA==}
 
   it-peekable@3.0.4:
     resolution: {integrity: sha512-Bb4xyMX5xAveFyh9ySbCrHMCpIF0+fIbl+0ZkcxP94JVofLe5j/mSBK0gjrrISsSVURVyey8X4L/IqrekOxjiA==}
@@ -27793,6 +27926,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  ms@3.0.0-canary.1:
+    resolution: {integrity: sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==}
+    engines: {node: '>=12.13'}
+
   msw@2.4.6:
     resolution: {integrity: sha512-flx3DIP3+a81vvEY1lCmZVFKVYVcDiizNHg6mHYc2+F2xU+4LmZ6P2eYZUGEFoJWqA3yRWS70pJa0riFVTb5FQ==}
     engines: {node: '>=18'}
@@ -27809,6 +27946,9 @@ packages:
 
   multiformats@13.1.0:
     resolution: {integrity: sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==}
+
+  multiformats@13.3.0:
+    resolution: {integrity: sha512-CBiqvsufgmpo01VT5ze94O+uc+Pbf6f/sThlvWss0sBZmAOu6GQn5usrYV2sf2mr17FWYc0rO8c/CNe2T90QAA==}
 
   multimatch@5.0.0:
     resolution: {integrity: sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==}
@@ -31026,6 +31166,10 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  supports-color@9.4.0:
+    resolution: {integrity: sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==}
+    engines: {node: '>=12'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -31683,6 +31827,9 @@ packages:
 
   uint8arrays@5.0.3:
     resolution: {integrity: sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==}
+
+  uint8arrays@5.1.0:
+    resolution: {integrity: sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==}
 
   ulidx@2.3.0:
     resolution: {integrity: sha512-36piWNqcdp9hKlQewyeehCaALy4lyx3FodsCxHuV6i0YdexSkjDOubwxEVr2yi4kh62L/0MgyrxqG4K+qtovnw==}
@@ -32672,6 +32819,9 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  weald@1.0.4:
+    resolution: {integrity: sha512-+kYTuHonJBwmFhP1Z4YQK/dGi3jAnJGCYhyODFpHK73rbxnp9lnZQj7a2m+WVgn8fXr5bJaxUpF6l8qZpPeNWQ==}
+
   web-streams-polyfill@3.2.1:
     resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
     engines: {node: '>= 8'}
@@ -32909,6 +33059,9 @@ packages:
   wmf@1.0.2:
     resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
     engines: {node: '>=0.8'}
+
+  wnfs@0.2.2:
+    resolution: {integrity: sha512-smqSbccaLyShSdCA46zIkmbZa8cmdXYpmwqBJQ8q+mGieyFPRrjaEPwcvYNY1KcTw89tUGhg8KragXyWixALMA==}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -38287,16 +38440,16 @@ snapshots:
   '@ipld/dag-cbor@9.1.0':
     dependencies:
       cborg: 4.0.9
-      multiformats: 13.1.0
+      multiformats: 13.3.0
 
   '@ipld/dag-json@10.1.7':
     dependencies:
       cborg: 4.0.9
-      multiformats: 13.1.0
+      multiformats: 13.3.0
 
   '@ipld/dag-pb@4.0.8':
     dependencies:
-      multiformats: 13.1.0
+      multiformats: 13.3.0
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -38415,7 +38568,7 @@ snapshots:
 
   '@juggle/resize-observer@3.4.0': {}
 
-  '@langchain/community@0.0.43(@smithy/util-utf8@2.3.0)(@tensorflow/tfjs-converter@3.21.0(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13)))(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13))(discord.js@14.14.1)(encoding@0.1.13)(faiss-node@0.5.1)(google-auth-library@8.9.0(encoding@0.1.13))(googleapis@126.0.1(encoding@0.1.13))(hnswlib-node@1.4.2)(html-to-text@9.0.5)(interface-datastore@8.2.11)(ioredis@5.3.2)(it-all@3.0.6)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(lodash@4.17.21)(openai@4.26.1(encoding@0.1.13))(redis@4.6.6)(ws@8.18.0)':
+  '@langchain/community@0.0.43(@smithy/util-utf8@2.3.0)(@tensorflow/tfjs-converter@3.21.0(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13)))(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13))(discord.js@14.14.1)(encoding@0.1.13)(faiss-node@0.5.1)(google-auth-library@8.9.0(encoding@0.1.13))(googleapis@126.0.1(encoding@0.1.13))(hnswlib-node@1.4.2)(html-to-text@9.0.5)(interface-datastore@8.3.1)(ioredis@5.3.2)(it-all@3.0.6)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(lodash@4.17.21)(openai@4.26.1(encoding@0.1.13))(redis@4.6.6)(ws@8.18.0)':
     dependencies:
       '@langchain/core': 0.1.62(openai@4.26.1(encoding@0.1.13))
       '@langchain/openai': 0.0.23(encoding@0.1.13)
@@ -38434,7 +38587,7 @@ snapshots:
       googleapis: 126.0.1(encoding@0.1.13)
       hnswlib-node: 1.4.2
       html-to-text: 9.0.5
-      interface-datastore: 8.2.11
+      interface-datastore: 8.3.1
       ioredis: 5.3.2
       it-all: 3.0.6
       jsdom: 24.0.0(canvas@2.11.2(encoding@0.1.13))
@@ -38588,7 +38741,16 @@ snapshots:
       '@multiformats/multiaddr': 12.2.1
       it-pushable: 3.2.3
       it-stream-types: 2.0.1
-      multiformats: 13.1.0
+      multiformats: 13.3.0
+      progress-events: 1.0.0
+      uint8arraylist: 2.4.8
+
+  '@libp2p/interface@2.2.0':
+    dependencies:
+      '@multiformats/multiaddr': 12.3.1
+      it-pushable: 3.2.3
+      it-stream-types: 2.0.1
+      multiformats: 13.3.0
       progress-events: 1.0.0
       uint8arraylist: 2.4.8
 
@@ -38598,15 +38760,23 @@ snapshots:
       '@multiformats/multiaddr': 12.2.1
       debug: 4.3.7(supports-color@5.5.0)
       interface-datastore: 8.2.11
-      multiformats: 13.1.0
+      multiformats: 13.3.0
     transitivePeerDependencies:
       - supports-color
+
+  '@libp2p/logger@5.1.3':
+    dependencies:
+      '@libp2p/interface': 2.2.0
+      '@multiformats/multiaddr': 12.3.1
+      interface-datastore: 8.3.1
+      multiformats: 13.3.0
+      weald: 1.0.4
 
   '@libp2p/peer-id@4.1.1':
     dependencies:
       '@libp2p/interface': 1.3.1
-      multiformats: 13.1.0
-      uint8arrays: 5.0.3
+      multiformats: 13.3.0
+      uint8arrays: 5.1.0
 
   '@linkedmd/markdown-it-directive@1.0.1':
     dependencies:
@@ -39039,7 +39209,7 @@ snapshots:
       hashlru: 2.3.0
       p-queue: 8.0.1
       progress-events: 1.0.0
-      uint8arrays: 5.0.3
+      uint8arrays: 5.1.0
 
   '@multiformats/multiaddr-to-uri@10.0.1':
     dependencies:
@@ -39051,9 +39221,18 @@ snapshots:
       '@chainsafe/netmask': 2.0.0
       '@libp2p/interface': 1.3.1
       '@multiformats/dns': 1.0.6
-      multiformats: 13.1.0
+      multiformats: 13.3.0
       uint8-varint: 2.0.4
-      uint8arrays: 5.0.3
+      uint8arrays: 5.1.0
+
+  '@multiformats/multiaddr@12.3.1':
+    dependencies:
+      '@chainsafe/is-ip': 2.0.2
+      '@chainsafe/netmask': 2.0.0
+      '@multiformats/dns': 1.0.6
+      multiformats: 13.3.0
+      uint8-varint: 2.0.4
+      uint8arrays: 5.1.0
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
@@ -46804,6 +46983,25 @@ snapshots:
     dependencies:
       browser-readablestream-to-it: 2.0.5
 
+  blockstore-core@5.0.2:
+    dependencies:
+      '@libp2p/logger': 5.1.3
+      interface-blockstore: 5.3.1
+      interface-store: 6.0.2
+      it-drain: 3.0.7
+      it-filter: 3.1.1
+      it-merge: 3.0.5
+      it-pushable: 3.2.3
+      multiformats: 13.3.0
+
+  blockstore-idb@2.0.1:
+    dependencies:
+      blockstore-core: 5.0.2
+      idb: 8.0.0
+      interface-blockstore: 5.3.1
+      interface-store: 6.0.2
+      multiformats: 13.3.0
+
   bluebird@3.4.7: {}
 
   bluebird@3.7.2: {}
@@ -48390,7 +48588,7 @@ snapshots:
   dag-jose@5.0.0:
     dependencies:
       '@ipld/dag-cbor': 9.1.0
-      multiformats: 13.1.0
+      multiformats: 13.3.0
 
   dagre-d3-es@7.0.10:
     dependencies:
@@ -51398,6 +51596,8 @@ snapshots:
 
   idb@7.1.1: {}
 
+  idb@8.0.0: {}
+
   ieee754@1.2.1: {}
 
   ignore-by-default@1.0.1: {}
@@ -51576,12 +51776,24 @@ snapshots:
 
   inspect-custom-symbol@1.1.1: {}
 
+  interface-blockstore@5.3.1:
+    dependencies:
+      interface-store: 6.0.2
+      multiformats: 13.3.0
+
   interface-datastore@8.2.11:
     dependencies:
       interface-store: 5.1.7
-      uint8arrays: 5.0.3
+      uint8arrays: 5.1.0
+
+  interface-datastore@8.3.1:
+    dependencies:
+      interface-store: 6.0.2
+      uint8arrays: 5.1.0
 
   interface-store@5.1.7: {}
+
+  interface-store@6.0.2: {}
 
   internal-slot@1.0.5:
     dependencies:
@@ -52074,6 +52286,12 @@ snapshots:
 
   it-all@3.0.6: {}
 
+  it-drain@3.0.7: {}
+
+  it-filter@3.1.1:
+    dependencies:
+      it-peekable: 3.0.4
+
   it-first@3.0.6: {}
 
   it-glob@2.0.7:
@@ -52085,6 +52303,10 @@ snapshots:
   it-map@3.1.0:
     dependencies:
       it-peekable: 3.0.4
+
+  it-merge@3.0.5:
+    dependencies:
+      it-pushable: 3.2.3
 
   it-peekable@3.0.4: {}
 
@@ -52568,10 +52790,10 @@ snapshots:
 
   kysely@0.27.4: {}
 
-  langchain@0.1.13(@smithy/util-utf8@2.3.0)(@tensorflow/tfjs-converter@3.21.0(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13)))(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13))(axios@1.7.7)(cheerio@1.0.0-rc.12)(discord.js@14.14.1)(encoding@0.1.13)(faiss-node@0.5.1)(fast-xml-parser@4.3.2)(google-auth-library@8.9.0(encoding@0.1.13))(googleapis@126.0.1(encoding@0.1.13))(hnswlib-node@1.4.2)(html-to-text@9.0.5)(ignore@5.2.4)(interface-datastore@8.2.11)(ioredis@5.3.2)(it-all@3.0.6)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(lodash@4.17.21)(openai@4.26.1(encoding@0.1.13))(playwright@1.46.1)(redis@4.6.6)(ws@8.18.0):
+  langchain@0.1.13(@smithy/util-utf8@2.3.0)(@tensorflow/tfjs-converter@3.21.0(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13)))(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13))(axios@1.7.7)(cheerio@1.0.0-rc.12)(discord.js@14.14.1)(encoding@0.1.13)(faiss-node@0.5.1)(fast-xml-parser@4.3.2)(google-auth-library@8.9.0(encoding@0.1.13))(googleapis@126.0.1(encoding@0.1.13))(hnswlib-node@1.4.2)(html-to-text@9.0.5)(ignore@5.2.4)(interface-datastore@8.3.1)(ioredis@5.3.2)(it-all@3.0.6)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(lodash@4.17.21)(openai@4.26.1(encoding@0.1.13))(playwright@1.46.1)(redis@4.6.6)(ws@8.18.0):
     dependencies:
       '@anthropic-ai/sdk': 0.9.1(encoding@0.1.13)
-      '@langchain/community': 0.0.43(@smithy/util-utf8@2.3.0)(@tensorflow/tfjs-converter@3.21.0(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13)))(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13))(discord.js@14.14.1)(encoding@0.1.13)(faiss-node@0.5.1)(google-auth-library@8.9.0(encoding@0.1.13))(googleapis@126.0.1(encoding@0.1.13))(hnswlib-node@1.4.2)(html-to-text@9.0.5)(interface-datastore@8.2.11)(ioredis@5.3.2)(it-all@3.0.6)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(lodash@4.17.21)(openai@4.26.1(encoding@0.1.13))(redis@4.6.6)(ws@8.18.0)
+      '@langchain/community': 0.0.43(@smithy/util-utf8@2.3.0)(@tensorflow/tfjs-converter@3.21.0(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13)))(@tensorflow/tfjs-core@3.21.0(encoding@0.1.13))(discord.js@14.14.1)(encoding@0.1.13)(faiss-node@0.5.1)(google-auth-library@8.9.0(encoding@0.1.13))(googleapis@126.0.1(encoding@0.1.13))(hnswlib-node@1.4.2)(html-to-text@9.0.5)(interface-datastore@8.3.1)(ioredis@5.3.2)(it-all@3.0.6)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(lodash@4.17.21)(openai@4.26.1(encoding@0.1.13))(redis@4.6.6)(ws@8.18.0)
       '@langchain/core': 0.1.62(openai@4.26.1(encoding@0.1.13))
       '@langchain/openai': 0.0.23(encoding@0.1.13)
       binary-extensions: 2.2.0
@@ -54221,6 +54443,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  ms@3.0.0-canary.1: {}
+
   msw@2.4.6(typescript@5.6.2):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.0
@@ -54249,6 +54473,8 @@ snapshots:
       thunky: 1.1.0
 
   multiformats@13.1.0: {}
+
+  multiformats@13.3.0: {}
 
   multimatch@5.0.0:
     dependencies:
@@ -55781,7 +56007,7 @@ snapshots:
     dependencies:
       uint8-varint: 2.0.4
       uint8arraylist: 2.4.8
-      uint8arrays: 5.0.3
+      uint8arrays: 5.1.0
 
   proxy-addr@2.0.7:
     dependencies:
@@ -58069,6 +58295,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-color@9.4.0: {}
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   suspend-react@0.1.3(react@18.2.0):
@@ -58848,17 +59076,21 @@ snapshots:
   uint8-varint@2.0.4:
     dependencies:
       uint8arraylist: 2.4.8
-      uint8arrays: 5.0.3
+      uint8arrays: 5.1.0
 
   uint8array-extras@0.3.0: {}
 
   uint8arraylist@2.4.8:
     dependencies:
-      uint8arrays: 5.0.3
+      uint8arrays: 5.1.0
 
   uint8arrays@5.0.3:
     dependencies:
-      multiformats: 13.1.0
+      multiformats: 13.3.0
+
+  uint8arrays@5.1.0:
+    dependencies:
+      multiformats: 13.3.0
 
   ulidx@2.3.0:
     dependencies:
@@ -59976,6 +60208,11 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
+  weald@1.0.4:
+    dependencies:
+      ms: 3.0.0-canary.1
+      supports-color: 9.4.0
+
   web-streams-polyfill@3.2.1: {}
 
   web-streams-polyfill@4.0.0-beta.3: {}
@@ -60319,6 +60556,8 @@ snapshots:
       winston-transport: 4.7.1
 
   wmf@1.0.2: {}
+
+  wnfs@0.2.2: {}
 
   word-wrap@1.2.5: {}
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -554,6 +554,11 @@
         },
         {
           "type": "json",
+          "path": "packages/plugins/experimental/plugin-wnfs/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "packages/plugins/plugin-attention/package.json",
           "jsonpath": "$.version"
         },

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -125,6 +125,15 @@
       "@dxos/plugin-template/meta": [
         "packages/plugins/experimental/plugin-template/src/meta.ts"
       ],
+      "@dxos/plugin-wnfs": [
+        "packages/plugins/experimental/plugin-wnfs/src/index.ts"
+      ],
+      "@dxos/plugin-wnfs/meta": [
+        "packages/plugins/experimental/plugin-wnfs/src/meta.tsx"
+      ],
+      "@dxos/plugin-wnfs/types": [
+        "packages/plugins/experimental/plugin-wnfs/src/types/index.ts"
+      ],
       "@dxos/plugin-attention": [
         "packages/plugins/plugin-attention/src/index.ts"
       ],


### PR DESCRIPTION
### Motivation / Background

Adds a WNFS plugin that allows for private image uploads in Composer which are synced to other devices using the Blob (edge) service.

### Details

Initial working version of the idea.
Connects to the `http://localhost:8787` blob service, is there a way to configure the URL for this?
Depends on https://github.com/dxos/edge/pull/91

Demo:
https://discord.com/channels/837138313172353095/1142114470479536368/1284153524103549009

Needs some fine tuning, notes/todos:
- Codemirror plugin needs improving (I don't have any experience with this, just threw something together)
- A WNFS is built up out of several merkle DAGs, it makes an HTTP request for each one of them (only 1st time, after = cache). Both for retrieval and storage. So this might turn out slow for big files, could write a batching mechanism.
- Related to the above. What if the person closes the browser during the remote blob storage call? The blob service won't have the data. I guess we need some guard rails here. Like tracking if the blob upload was successful, if not, retry on next app launch. Or maybe, prevent the browser from closing during upload.
- Still needs to check if the browser is online or not. If not, don't try to push to the remote blob store and track which ones need to uploaded later on when the connection comes back.
- Loading animations for images.