### PR TITLE
fix(react-ui-navtree): Only apply `hoverableControls` for navtree items not at root.

### DIFF
--- a/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
@@ -177,7 +177,7 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
                   className={mx(
                     'flex items-start rounded',
                     levelPadding(level),
-                    hoverableControls,
+                    level > 0 && hoverableControls,
                     hoverableFocusedWithinControls,
                     hoverableDescriptionIcons,
                     level < 1 && topLevelCollapsibleSpacing,


### PR DESCRIPTION
Resolves #4634.

This PR conditionally applies `hoverableControls` only to NavTree items which are deeper than at the root.

https://github.com/dxos/dxos/assets/855039/f3627a2d-1d4d-4486-9f03-ea11310671b1

