### PR TITLE
fix(composer): Anchor settings dialog to prevent content jumps

### DIFF
--- a/packages/apps/plugins/plugin-settings/src/SettingsPlugin.tsx
+++ b/packages/apps/plugins/plugin-settings/src/SettingsPlugin.tsx
@@ -77,6 +77,7 @@ export const SettingsPlugin = (): PluginDefinition<SettingsPluginProvides> => {
                       data: {
                         element: 'dialog',
                         component: `${SETTINGS_PLUGIN}/Settings`,
+                        dialogBlockAlign: 'start',
                       },
                     },
                   ],

--- a/packages/apps/plugins/plugin-settings/src/components/SettingsDialog.tsx
+++ b/packages/apps/plugins/plugin-settings/src/components/SettingsDialog.tsx
@@ -35,7 +35,7 @@ export const SettingsDialog = ({
     .sort(({ name: a }, { name: b }) => a?.localeCompare(b ?? '') ?? 0);
 
   return (
-    <Dialog.Content classNames={['h-auto h-max-full md:max-is-[40rem] overflow-hidden']}>
+    <Dialog.Content classNames={['bs-content max-bs-full md:max-is-[40rem] overflow-hidden']}>
       <Dialog.Title>{t('settings dialog title')}</Dialog.Title>
 
       <div className='grow mlb-4 overflow-hidden grid grid-cols-[minmax(min-content,1fr)_3fr] gap-1'>

--- a/packages/apps/plugins/plugin-settings/src/components/SettingsDialog.tsx
+++ b/packages/apps/plugins/plugin-settings/src/components/SettingsDialog.tsx
@@ -35,7 +35,7 @@ export const SettingsDialog = ({
     .sort(({ name: a }, { name: b }) => a?.localeCompare(b ?? '') ?? 0);
 
   return (
-    <Dialog.Content classNames={['h-full md:max-is-[40rem] overflow-hidden']}>
+    <Dialog.Content classNames={['h-auto h-max-full md:max-is-[40rem] overflow-hidden']}>
       <Dialog.Title>{t('settings dialog title')}</Dialog.Title>
 
       <div className='grow mlb-4 overflow-hidden grid grid-cols-[minmax(min-content,1fr)_3fr] gap-1'>


### PR DESCRIPTION
Pretty simple fix since we were able to leverage the work done for #6145

- Resolves #6488


https://github.com/dxos/dxos/assets/12402727/6c501fc4-60b6-4237-8383-0e9d8454aff7

