### PR TITLE
feat(react-ui-stack): Hoist navigate-to action

### DIFF
--- a/packages/apps/plugins/plugin-markdown/src/components/DocumentSection.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/DocumentSection.tsx
@@ -63,7 +63,7 @@ const DocumentSection: FC<{
   const handleAction = useActionHandler(editorView);
 
   return (
-    <div role='none' className='flex flex-col group'>
+    <div role='none' className='flex flex-col'>
       <div
         {...focusAttributes}
         ref={parentRef}
@@ -74,7 +74,7 @@ const DocumentSection: FC<{
         <Toolbar.Root
           state={formattingState}
           onAction={handleAction}
-          classNames={['z-[1] invisible group-focus-within:visible', sectionToolbarLayout]}
+          classNames={['z-[1] invisible group-focus-within/section:visible', sectionToolbarLayout]}
         >
           <Toolbar.Markdown />
           <Toolbar.Separator />

--- a/packages/ui/react-ui-stack/src/components/Section.tsx
+++ b/packages/ui/react-ui-stack/src/components/Section.tsx
@@ -200,6 +200,19 @@ export const Section: ForwardRefExoticComponent<SectionProps & RefAttributes<HTM
                   <DropdownMenu.Portal>
                     <DropdownMenu.Content>
                       <DropdownMenu.Viewport>
+                        {collapsed ? (
+                          <DropdownMenu.Item onClick={onNavigate} data-testid='section.navigate-to'>
+                            <ArrowSquareOut className={mx(getSize(5), 'mr-2')} />
+                            <span className='grow'>{t('navigate to section label')}</span>
+                          </DropdownMenu.Item>
+                        ) : (
+                          <CollapsiblePrimitive.Trigger asChild>
+                            <DropdownMenu.Item>
+                              <CaretDownUp className={mx(getSize(5), 'mr-2')} />
+                              <span className='grow'>{t('collapse label')}</span>
+                            </DropdownMenu.Item>
+                          </CollapsiblePrimitive.Trigger>
+                        )}
                         <DropdownMenu.Item onClick={onAddBefore} data-testid='section.add-before'>
                           <ArrowLineUp className={mx(getSize(5), 'mr-2')} />
                           <span className='grow'>{t('add section before label')}</span>
@@ -207,10 +220,6 @@ export const Section: ForwardRefExoticComponent<SectionProps & RefAttributes<HTM
                         <DropdownMenu.Item onClick={onAddAfter} data-testid='section.add-after'>
                           <ArrowLineDown className={mx(getSize(5), 'mr-2')} />
                           <span className='grow'>{t('add section after label')}</span>
-                        </DropdownMenu.Item>
-                        <DropdownMenu.Item onClick={onNavigate} data-testid='section.navigate-to'>
-                          <ArrowSquareOut className={mx(getSize(5), 'mr-2')} />
-                          <span className='grow'>{t('navigate to section label')}</span>
                         </DropdownMenu.Item>
                         <DropdownMenu.Item onClick={() => onDelete?.()} data-testid='section.remove'>
                           <X className={mx(getSize(5), 'mr-2')} />
@@ -221,12 +230,24 @@ export const Section: ForwardRefExoticComponent<SectionProps & RefAttributes<HTM
                     </DropdownMenu.Content>
                   </DropdownMenu.Portal>
                 </DropdownMenu.Root>
-                <CollapsiblePrimitive.Trigger asChild>
-                  <Button variant='ghost' data-state='' classNames={sectionActionDimensions}>
-                    <span className='sr-only'>{t(collapsed ? 'expand label' : 'collapse label')}</span>
-                    {collapsed ? <CaretUpDown className={getSize(4)} /> : <CaretDownUp className={getSize(4)} />}
+                {collapsed ? (
+                  <CollapsiblePrimitive.Trigger asChild>
+                    <Button variant='ghost' classNames={sectionActionDimensions}>
+                      <span className='sr-only'>{t('expand label')}</span>
+                      <CaretUpDown className={getSize(4)} />
+                    </Button>
+                  </CollapsiblePrimitive.Trigger>
+                ) : (
+                  <Button
+                    variant='ghost'
+                    classNames={sectionActionDimensions}
+                    onClick={onNavigate}
+                    data-testid='section.navigate-to'
+                  >
+                    <ArrowSquareOut className={mx(getSize(4))} />
+                    <span className='sr-only'>{t('navigate to section label')}</span>
                   </Button>
-                </CollapsiblePrimitive.Trigger>
+                )}
               </div>
             </div>
 

--- a/packages/ui/react-ui-stack/src/translations.ts
+++ b/packages/ui/react-ui-stack/src/translations.ts
@@ -14,6 +14,8 @@ export default [
         'untitled section title': 'Untitled section',
         'add section before label': 'Add before',
         'add section after label': 'Add after',
+        'expand label': 'Expand',
+        'collapse label': 'Collapse',
       },
     },
   },


### PR DESCRIPTION
Resolves #6567.

This PR hosts navitate-to for stack sections that are expanded, otherwise the expand action is hoisted.

This PR also fixes a bug related to document toolbars scoped to the wrong group.

https://github.com/dxos/dxos/assets/855039/63136b85-c557-4339-9689-696c6cfff554
