### PR TITLE
fix: Dispose queries correctly

### DIFF
--- a/packages/core/echo/echo-db/src/hypergraph.ts
+++ b/packages/core/echo/echo-db/src/hypergraph.ts
@@ -179,6 +179,9 @@ export class Hypergraph {
         this._queryContexts.add(context);
       },
       onStop: () => {
+        for (const source of context.sources) {
+          source.close();
+        }
         this._queryContexts.delete(context);
       },
     });

--- a/packages/core/echo/echo-db/src/query/query-service.ts
+++ b/packages/core/echo/echo-db/src/query/query-service.ts
@@ -97,6 +97,8 @@ export class QueryServiceImpl extends Resource implements QueryService {
       this._queries.add(query);
 
       queueMicrotask(async () => {
+        await query.state.open();
+
         try {
           const { changed } = await query.state.execQuery();
           if (changed) {

--- a/packages/sdk/react-client/src/echo/useQuery.ts
+++ b/packages/sdk/react-client/src/echo/useQuery.ts
@@ -5,13 +5,13 @@
 import { useMemo, useSyncExternalStore } from 'react';
 
 import {
-  type QueryOptions,
-  type Query,
-  type FilterSource,
-  type Space,
-  type EchoReactiveObject,
-  type Echo,
   isSpace,
+  type Echo,
+  type EchoReactiveObject,
+  type FilterSource,
+  type Query,
+  type QueryOptions,
+  type Space,
 } from '@dxos/client/echo';
 
 type UseQuery = {


### PR DESCRIPTION
Some queries seem to get stuck in active state randomly - suspecting it's an artifact of how diagnostics are collected rather then a real leak