### PR TITLE
fix(table): Improve table in stacks

### DIFF
--- a/packages/apps/plugins/plugin-table/package.json
+++ b/packages/apps/plugins/plugin-table/package.json
@@ -24,6 +24,7 @@
   ],
   "dependencies": {
     "@braneframe/plugin-space": "workspace:*",
+    "@braneframe/plugin-stack": "workspace:*",
     "@braneframe/types": "workspace:*",
     "@dxos/async": "workspace:*",
     "@dxos/echo-schema": "workspace:*",

--- a/packages/apps/plugins/plugin-table/src/TablePlugin.tsx
+++ b/packages/apps/plugins/plugin-table/src/TablePlugin.tsx
@@ -115,6 +115,17 @@ export const TablePlugin = (): PluginDefinition<TablePluginProvides> => {
           }
         },
       },
+      stack: {
+        creators: [
+          {
+            id: 'create-stack-section-table',
+            testId: 'tablePlugin.createSectionSpaceSketch',
+            label: ['create stack section label', { ns: TABLE_PLUGIN }],
+            icon: (props: any) => <Table {...props} />,
+            intent: [{ plugin: TABLE_PLUGIN, action: TableAction.CREATE }],
+          },
+        ],
+      },
       intent: {
         resolver: (intent) => {
           switch (intent.action) {

--- a/packages/apps/plugins/plugin-table/src/components/SettingsDialog/SettingsDialog.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/SettingsDialog/SettingsDialog.tsx
@@ -13,10 +13,18 @@ export type SettingsDialogProps = {
   title: string;
   className?: string;
   onClose?: (success: boolean) => void;
+  cancellable?: boolean;
 } & Pick<DialogRootProps, 'open' | 'children'>;
 
 // TODO(burdon): Factor out styles instead of wrapping?
-export const SettingsDialog: FC<SettingsDialogProps> = ({ title, className, open, children, onClose }) => {
+export const SettingsDialog: FC<SettingsDialogProps> = ({
+  title,
+  className,
+  open,
+  children,
+  onClose,
+  cancellable = true,
+}) => {
   const { t } = useTranslation(TABLE_PLUGIN);
   const success = useRef(false);
   useEffect(() => {
@@ -39,7 +47,8 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({ title, className, open
             >
               <Button variant='primary'>{t('close dialog')}</Button>
             </Dialog.Close>
-            <Button onClick={() => onClose?.(false)}>{t('cancel dialog')}</Button>
+
+            {cancellable && <Button onClick={() => onClose?.(false)}>{t('cancel dialog')}</Button>}
           </ButtonBar>
         </Dialog.Content>
       </Dialog.Overlay>

--- a/packages/apps/plugins/plugin-table/src/components/TableSection.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/TableSection.tsx
@@ -10,14 +10,13 @@ import { ObjectTable, type ObjectTableProps } from './ObjectTable';
 
 const TableSection: FC<Omit<ObjectTableProps, 'getScrollElement'>> = ({ table }) => (
   <Table.Root>
-    <Table.Viewport asChild>
-      <div className='bs-96 mlb-2 overflow-auto'>
-        <ObjectTable
-          key={table.id} // New component instance per table.
-          table={table}
-          role='table'
-        />
-      </div>
+    <Table.Viewport classNames='max-bs-96 w-full mlb-2 overflow-auto sticky-top-0'>
+      <ObjectTable
+        key={table.id} // New component instance per table.
+        table={table}
+        role='grid'
+        stickyHeader
+      />
     </Table.Viewport>
   </Table.Root>
 );

--- a/packages/apps/plugins/plugin-table/src/components/TableSettings/TableSettings.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/TableSettings/TableSettings.tsx
@@ -30,7 +30,7 @@ export const TableSettings = ({ open, onClose, table, schemas = [] }: TableSetti
   );
 
   return (
-    <SettingsDialog title={t('settings title')} open={open} onClose={onClose}>
+    <SettingsDialog title={t('settings title')} open={open} onClose={onClose} cancellable={false}>
       <Input.Root>
         <Input.TextInput
           placeholder={t('table name placeholder')}

--- a/packages/apps/plugins/plugin-table/src/translations.ts
+++ b/packages/apps/plugins/plugin-table/src/translations.ts
@@ -19,6 +19,7 @@ export default [
         'new schema': 'New schema',
         'close dialog': 'Close',
         'cancel dialog': 'Cancel',
+        'create stack section label': 'Create table',
       },
     },
   },

--- a/packages/apps/plugins/plugin-table/src/types.ts
+++ b/packages/apps/plugins/plugin-table/src/types.ts
@@ -2,6 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
+import { type StackProvides } from '@braneframe/plugin-stack';
 import { TableType } from '@braneframe/types';
 import type {
   GraphBuilderProvides,
@@ -25,6 +26,7 @@ export type TablePluginProvides = SurfaceProvides &
   IntentResolverProvides &
   GraphBuilderProvides &
   MetadataRecordsProvides &
+  StackProvides &
   TranslationsProvides;
 
 export const isTable = (object: unknown): object is TableType => {

--- a/packages/apps/plugins/plugin-table/tsconfig.json
+++ b/packages/apps/plugins/plugin-table/tsconfig.json
@@ -69,6 +69,9 @@
     },
     {
       "path": "../plugin-space"
+    },
+    {
+      "path": "../plugin-stack"
     }
   ]
 }

--- a/packages/ui/react-ui-stack/src/components/style-fragments.ts
+++ b/packages/ui/react-ui-stack/src/components/style-fragments.ts
@@ -2,4 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-export const stackColumns = 'grid-cols-[var(--rail-size)_1fr]';
+export const stackColumns = 'grid-cols-[var(--rail-size)_calc(100%-var(--rail-size))]';

--- a/packages/ui/react-ui-theme/src/styles/layers/positioning.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/positioning.css
@@ -5,6 +5,9 @@
   .snap-block {
     scroll-snap-type: block var(--tw-scroll-snap-strictness);
   }
+  .sticky-top-0 {
+    --sticky-top: 0;
+  }
 }
 
 @layer components {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3368,6 +3368,9 @@ importers:
       '@braneframe/plugin-space':
         specifier: workspace:*
         version: link:../plugin-space
+      '@braneframe/plugin-stack':
+        specifier: workspace:*
+        version: link:../plugin-stack
       '@braneframe/types':
         specifier: workspace:*
         version: link:../../types


### PR DESCRIPTION
- Resolves #6653
- Resolves #6321
- Resolves #6654
- Resolves #6604

Changes:
- Restore focus.
- Fix stack max-width (stack section template column calculation).
- Switch to sticky-header in stack sections.
- Implement a max height for table stack sections (open to suggestions for what this value should be).
- Support adding new table to bottom of stack.
- Don't show 'Cancel' on create table form.

https://github.com/dxos/dxos/assets/12402727/cd97fea0-647b-46d4-9484-50bd360ef1ef

<img width="482" alt="image" 
src="https://github.com/dxos/dxos/assets/12402727/9adc0219-1379-4aad-bd17-2ad12eabb657">

