### PR TITLE
feat(plugin-sketch): Sketch planks

### DIFF
--- a/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
+++ b/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
@@ -61,7 +61,7 @@ export const firstComplementaryId = (active: Location['active']): string | undef
 
 const PlankLoading = () => {
   return (
-    <div role='none' className='grid bs-[100dvh] place-items-center'>
+    <div role='none' className='grid bs-[100dvh] place-items-center row-span-2'>
       <Status indeterminate aria-label='Initializing' />
     </div>
   );
@@ -311,7 +311,7 @@ export const DeckLayout = ({
                             popoverAnchorId,
                           }}
                           limit={1}
-                          fallback={<PlankLoading />}
+                          fallback={PlankLoading}
                         />
                       </>
                     ) : (

--- a/packages/apps/plugins/plugin-sketch/src/SketchPlugin.tsx
+++ b/packages/apps/plugins/plugin-sketch/src/SketchPlugin.tsx
@@ -126,11 +126,17 @@ export const SketchPlugin = (): PluginDefinition<SketchPluginProvides> => {
               return data.active instanceof SketchType ? <SketchMain sketch={data.active} /> : null;
             case 'slide':
               return data.slide instanceof SketchType ? (
-                <SketchComponent sketch={data.slide} readonly={true} autoZoom={true} maxZoom={1.5} className={'p-16'} />
+                <SketchComponent sketch={data.slide} readonly autoZoom maxZoom={1.5} className='p-16' />
               ) : null;
+            case 'article':
             case 'section':
               return data.object instanceof SketchType ? (
-                <SketchComponent sketch={data.object} readonly={true} autoZoom={true} className={'h-[400px]'} />
+                <SketchComponent
+                  sketch={data.object}
+                  readonly={role === 'section'}
+                  className={role === 'article' ? 'row-span-2' : 'bs-96'}
+                  autoZoom
+                />
               ) : null;
             default:
               return null;

--- a/packages/apps/plugins/plugin-sketch/src/components/Sketch.tsx
+++ b/packages/apps/plugins/plugin-sketch/src/components/Sketch.tsx
@@ -49,30 +49,29 @@ const SketchComponent: FC<SketchComponentProps> = ({ sketch, autoZoom, maxZoom =
   // Zoom to fit.
   const { ref: containerRef, width = 0, height } = useResizeDetector();
   const [ready, setReady] = useState(!autoZoom);
+
+  const zoomToContent = (animate = true) => {
+    const commonBounds = editor?.allShapesCommonBounds;
+    if (editor && width && height && commonBounds?.width && commonBounds?.height) {
+      const padding = 40;
+      // NOTE: Objects culled (unstyled) if outside of bounds.
+      const zoom = Math.min(maxZoom, (width - padding) / commonBounds.width, (height - padding) / commonBounds.height);
+      if (zoom <= 0) {
+        throw new Error('Sketch has non-positive size.');
+      }
+      const center = {
+        x: (width - commonBounds.width * zoom) / 2 / zoom - commonBounds.minX,
+        y: (height - commonBounds.height * zoom) / 2 / zoom - commonBounds.minY,
+      };
+      editor.animateCamera(center.x, center.y, zoom, animate ? { duration: 250 } : undefined);
+      setReady(true);
+    }
+  };
+
   useEffect(() => {
-    if (!autoZoom) {
+    if (!autoZoom || width < 1 || (height ?? 0) < 1) {
       return;
     }
-
-    const zoomToContent = (animate = true) => {
-      const commonBounds = editor?.allShapesCommonBounds;
-      if (editor && width && height && commonBounds?.width && commonBounds?.height) {
-        const padding = 40;
-        // NOTE: Objects culled (unstyled) if outside of bounds.
-        const zoom = Math.min(
-          maxZoom,
-          (width - padding) / commonBounds.width,
-          (height - padding) / commonBounds.height,
-        );
-        const center = {
-          x: (width - commonBounds.width * zoom) / 2 / zoom - commonBounds.minX,
-          y: (height - commonBounds.height * zoom) / 2 / zoom - commonBounds.minY,
-        };
-
-        editor.animateCamera(center.x, center.y, zoom, animate ? { duration: 250 } : undefined);
-        setReady(true);
-      }
-    };
 
     editor?.updateViewportScreenBounds();
     zoomToContent(false);
@@ -89,7 +88,7 @@ const SketchComponent: FC<SketchComponentProps> = ({ sketch, autoZoom, maxZoom =
       ref={containerRef}
       style={{ visibility: ready ? 'visible' : 'hidden' }}
       className={mx(
-        'w-full h-full',
+        'is-full bs-full',
         // 14Override z-index.
         '[&>div>span>div]:z-0',
         // 14Hide .tlui-menu-zone

--- a/packages/apps/plugins/plugin-sketch/src/components/SketchMain.tsx
+++ b/packages/apps/plugins/plugin-sketch/src/components/SketchMain.tsx
@@ -12,7 +12,7 @@ import SketchComponent, { type SketchComponentProps } from './Sketch';
 const SketchMain: FC<SketchComponentProps> = (props) => {
   return (
     <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart]}>
-      <SketchComponent {...props} />{' '}
+      <SketchComponent {...props} />
     </Main.Content>
   );
 };


### PR DESCRIPTION
Resolves #6691.

This PR adds Deck support to SketchPlugin.

https://github.com/dxos/dxos/assets/855039/64b1a44f-25b9-47b7-bffc-9c95544d9526

This PR fixes a couple bugs:
- `PlankLoading` was provided rendered instead of as an FC
- `SketchComponent` crashes if `zoom` is evaluated as `0`, now throws an error instead of crashing