### PR TITLE
fix: query objects with static and persisted schemas

### DIFF
--- a/packages/core/echo/echo-db/src/query/filter.test.ts
+++ b/packages/core/echo/echo-db/src/query/filter.test.ts
@@ -2,11 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
-import * as S from '@effect/schema/Schema';
 import { expect } from 'chai';
 
 import { Reference } from '@dxos/echo-protocol';
-import { TypedObject, create } from '@dxos/echo-schema';
+import { S, TypedObject, create } from '@dxos/echo-schema';
 import { PublicKey } from '@dxos/keys';
 import { QueryOptions } from '@dxos/protocols/proto/dxos/echo/filter';
 import { describe, test } from '@dxos/test';

--- a/packages/sdk/client/src/tests/query.test.ts
+++ b/packages/sdk/client/src/tests/query.test.ts
@@ -1,0 +1,64 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { Trigger } from '@dxos/async';
+import { S, TypedObject, create, type ReactiveObject } from '@dxos/echo-schema';
+import { afterTest, describe, test } from '@dxos/test';
+
+import { Client } from '../client';
+import { Filter, type Query } from '../echo';
+import { TestBuilder } from '../testing';
+
+describe('Query', () => {
+  test('query returns objects with both dynamic and static types', async () => {
+    // create an object with a static type
+    // persist the static type to the schemaRegistry
+    // create a second object with the type returned from the schemaRegistry
+    // query for the typename
+    // check that we got both objects
+
+    const builder = new TestBuilder();
+    afterTest(() => builder.destroy());
+
+    class GeneratedSchema extends TypedObject({ typename: 'dxos.tests.staticAndDynamic', version: '0.1.0' })({
+      title: S.string,
+    }) {}
+
+    const client = new Client({ services: builder.createLocal() });
+    await client.initialize();
+    afterTest(() => client.destroy());
+
+    if (!client.experimental.graph.runtimeSchemaRegistry.isSchemaRegistered(GeneratedSchema)) {
+      client.experimental.graph.runtimeSchemaRegistry.registerSchema(GeneratedSchema);
+    }
+
+    await client.halo.createIdentity();
+
+    const space = await client.spaces.create();
+    const obj1 = space.db.add(create(GeneratedSchema, { title: 'test' }));
+
+    await checkQueryResult(space.db.query(Filter.schema(GeneratedSchema)), [obj1]);
+
+    const schema = space.db.schemaRegistry.add(GeneratedSchema);
+    const obj2 = space.db.add(create(schema, { title: 'test' }));
+
+    await checkQueryResult(space.db.query(Filter.schema(schema)), [obj1, obj2]);
+    await checkQueryResult(space.db.query(Filter.schema(GeneratedSchema)), [obj1, obj2]);
+  });
+});
+
+const checkQueryResult = async (query: Query, expected: ReactiveObject<any>[]) => {
+  const queriedTrigger = new Trigger();
+  const unsub = query.subscribe(
+    ({ objects }) => {
+      if (objects.length === expected.length && objects.every((object) => expected.includes(object as any))) {
+        queriedTrigger.wake();
+      }
+    },
+    { fire: true },
+  );
+
+  await queriedTrigger.wait({ timeout: 1_000 });
+  unsub();
+};


### PR DESCRIPTION
### Background

I ran into an issue querying for objects with a statically-defined schema and a persisted schema in [Contacts App](https://github.com/dxos/contacts-app/pull/3). 

### Expected Behavior

I believe that all objects that match a `typename` should be returned by the query, regardless of whether the object was created with a statically-defined schema or a persisted schema.

The failing test demonstrates the expected behavior.

As an aside, it seems that we have entangled the ideas of "persisted" and "dynamic" schemas. A statically-defined schema should be able to be persisted without becoming dynamic. Persistence just implies I want to share objects and schemas with other peers without depending on them to have a statically-defined type definition in their codebase. It does not imply that I want to modify that schema at runtime (make it dynamic).