### PR TITLE
feat(plugin-threads): Open comments in c11y sidebar when attention changes

### DIFF
--- a/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -86,10 +86,10 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
       queryUnsubscribe = threadsQuery.subscribe();
       unsubscribe = isDeckModel
         ? effect(() => {
-            const firstAttendedNodeWithComments = Array.from(
-              navigationPlugin?.provides.attention?.attended ?? new Set(),
+            const firstAttendedNodeWithComments = (
+              Array.from(navigationPlugin?.provides.attention?.attended ?? new Set<string>()) as string[]
             )
-              .map((id: string) => graphPlugin?.provides.graph.findNode(id))
+              .map((id) => graphPlugin?.provides.graph.findNode(id))
               .filter(
                 (maybeNode) =>
                   maybeNode && maybeNode?.data instanceof DocumentType && (maybeNode.data.comments?.length ?? 0) > 0,


### PR DESCRIPTION
Resolves #6571.

https://github.com/dxos/dxos/assets/855039/a4311949-cad9-43bb-9f22-17c625c88e8f

This PR adds a subscription to ThreadsPlugin’s `ready` which opens threads in the complementary sidebar if any are found related to the attended items.