### PR TITLE
test(composer-app): add error boundary reset test

### DIFF
--- a/packages/apps/composer-app/src/components/ResetDialog.tsx
+++ b/packages/apps/composer-app/src/components/ResetDialog.tsx
@@ -120,12 +120,16 @@ export const ResetDialog = ({
             <div role='none' className='flex-grow' />
             <DropdownMenu.Root>
               <DropdownMenu.Trigger asChild>
-                <Button variant='ghost'>{t('reset client label')}</Button>
+                <Button data-testid='resetDialog.reset' variant='ghost'>
+                  {t('reset client label')}
+                </Button>
               </DropdownMenu.Trigger>
               <DropdownMenu.Portal>
                 <DropdownMenu.Content side='top' classNames='z-[51]'>
                   <DropdownMenu.Viewport>
-                    <DropdownMenu.Item onClick={handleReset}>{t('reset client confirm label')}</DropdownMenu.Item>
+                    <DropdownMenu.Item data-testid='resetDialog.confirmReset' onClick={handleReset}>
+                      {t('reset client confirm label')}
+                    </DropdownMenu.Item>
                   </DropdownMenu.Viewport>
                   <DropdownMenu.Arrow />
                 </DropdownMenu.Content>

--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -240,6 +240,15 @@ export class AppManager {
 
     await this.page.getByTestId('resetDialog').waitFor();
   }
+
+  //
+  // Error Boundary
+  //
+
+  async reset() {
+    await this.page.getByTestId('resetDialog.reset').click();
+    await this.page.getByTestId('resetDialog.confirmReset').click();
+  }
 }
 
 // TODO(wittjosiah): Factor out.

--- a/packages/apps/composer-app/src/playwright/basic.spec.ts
+++ b/packages/apps/composer-app/src/playwright/basic.spec.ts
@@ -40,18 +40,25 @@ test.describe('Basic tests', () => {
     });
   });
 
-  test('error boundary is rendered on invalid storage version', async ({ browserName }) => {
+  test('error boundary is rendered on invalid storage version, reset wipes old data', async ({ browserName }) => {
     // TODO(wittjosiah): This test seems to crash firefox in CI.
     if (browserName === 'firefox') {
       test.skip();
     }
 
-    await host.openSettings();
-    await host.toggleExperimenalPlugins();
-    await host.enablePlugin('dxos.org/plugin/debug');
+    await host.createSpace();
+    await waitForExpect(async () => {
+      expect(await host.getSpaceItemsCount()).to.equal(2);
+    });
+
     await host.changeStorageVersionInMetadata(9999);
     expect(await host.page.getByTestId('resetDialog').locator('p').innerText()).to.contain('9999');
     expect(await host.page.getByTestId('resetDialog').locator('h2').innerText()).to.equal('Invalid storage version');
+
+    await host.reset();
+    await waitForExpect(async () => {
+      expect(await host.getSpaceItemsCount()).to.equal(1);
+    });
   });
 
   test('reset device', async ({ browserName }) => {


### PR DESCRIPTION
- Resolves #5726
- also fixes test where debug is enabled by default outside of production
