### PR TITLE
fix(echo): allow accessing type reference if schema wasn't registered

### DIFF
--- a/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
@@ -16,6 +16,7 @@ import {
   foreignKey,
   getMeta,
   getSchema,
+  getType,
   getTypeReference,
   isDeleted,
   ref,
@@ -460,6 +461,14 @@ describe('Reactive Object with ECHO database', () => {
       const obj = db.add(create(TestType, { field: 1 }, { keys: [foreignKey('example.com', '123')] }));
       getMeta(obj).keys.push(foreignKey('example.com', '456'));
       expect(getMeta(obj).keys.length).to.eq(2);
+    });
+
+    test('can get type reference of unregistered schema', async () => {
+      const { db } = await builder.createDatabase();
+      const obj = db.add(create({ field: 1 }));
+      const typeReference = getTypeReference(TestSchema)!;
+      getAutomergeObjectCore(obj).setType(typeReference);
+      expect(getType(obj)).to.deep.eq(typeReference);
     });
 
     test('meta persistence', async () => {

--- a/packages/core/echo/echo-db/src/echo-handler/echo-handler.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/echo-handler.ts
@@ -313,6 +313,10 @@ export class EchoReactiveHandler implements ReactiveHandler<ProxyTarget> {
     return target[symbolInternals].core.database._dbApi.schemaRegistry.getById(typeReference.itemId);
   }
 
+  getTypeReference(target: ProxyTarget): Reference | undefined {
+    return target[symbolNamespace] === DATA_NAMESPACE ? target[symbolInternals].core.getType() : undefined;
+  }
+
   isDeleted(target: any): boolean {
     return target[symbolInternals].core.isDeleted();
   }

--- a/packages/core/echo/echo-db/src/echo-handler/proxy.blueprint-test.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/proxy.blueprint-test.ts
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 import jestExpect from 'expect';
 import { describe, test } from 'mocha';
 
-import { getProxyHandlerSlot } from '@dxos/echo-schema';
+import { getProxyHandlerSlot, getSchema, getType, getTypeReference } from '@dxos/echo-schema';
 import { updateCounter, TEST_OBJECT, TestSchema, TestSchemaClass } from '@dxos/echo-schema/testing';
 import { registerSignalRuntime } from '@dxos/echo-signals';
 import { beforeAll, afterAll } from '@dxos/test';
@@ -132,6 +132,11 @@ export const reactiveProxyTests = (testConfigFactory: TestConfigurationFactory):
         obj.objectArray?.push({ field: 'bar' });
         expect(() => obj.objectArray?.splice(1, 0, { field: 1 } as any)).to.throw();
         expect(() => (obj.objectArray![1].field = 1 as any)).to.throw();
+      });
+
+      test('getTypeReference', async () => {
+        const obj = await createObject({ number: 42 });
+        expect(getType(obj)).to.deep.eq(getTypeReference(getSchema(obj)));
       });
 
       test('can assign arrays with objects', async () => {

--- a/packages/core/echo/echo-schema/src/getter.ts
+++ b/packages/core/echo/echo-schema/src/getter.ts
@@ -54,10 +54,20 @@ export const isDeleted = <T extends {}>(obj: T): boolean => {
 };
 
 // TODO(burdon): Replace most uses with getTypename (and rename itemId property).
-export const getType = <T extends {}>(obj: T | undefined): Reference | undefined => getTypeReference(getSchema(obj));
+export const getType = <T extends {}>(obj: T): Reference | undefined => {
+  if (obj == null) {
+    return undefined;
+  }
 
-export const getTypename = <T extends {}>(obj: T | undefined): string | undefined =>
-  getTypeReference(getSchema(obj))?.itemId;
+  if (isReactiveObject(obj)) {
+    const proxyHandlerSlot = getProxyHandlerSlot(obj);
+    return proxyHandlerSlot.handler?.getTypeReference(obj);
+  }
+
+  return undefined;
+};
+
+export const getTypename = <T extends {}>(obj: T): string | undefined => getType(obj)?.itemId;
 
 export const requireTypeReference = (schema: S.Schema<any>): Reference => {
   const typeReference = getTypeReference(schema);

--- a/packages/core/echo/echo-schema/src/getter.ts
+++ b/packages/core/echo/echo-schema/src/getter.ts
@@ -54,7 +54,7 @@ export const isDeleted = <T extends {}>(obj: T): boolean => {
 };
 
 // TODO(burdon): Replace most uses with getTypename (and rename itemId property).
-export const getType = <T extends {}>(obj: T): Reference | undefined => {
+export const getType = <T extends {}>(obj: T | undefined): Reference | undefined => {
   if (obj == null) {
     return undefined;
   }

--- a/packages/core/echo/echo-schema/src/handler/logging-handler.ts
+++ b/packages/core/echo/echo-schema/src/handler/logging-handler.ts
@@ -2,6 +2,8 @@
 // Copyright 2024 DXOS.org
 //
 
+import { type Reference } from '@dxos/echo-protocol';
+
 import { getTargetMeta } from './object';
 import { type ReactiveHandler } from '../proxy';
 import type { ObjectMeta } from '../types';
@@ -29,6 +31,10 @@ export class LoggingReactiveHandler implements ReactiveHandler<any> {
   }
 
   getSchema() {
+    return undefined;
+  }
+
+  getTypeReference(): Reference | undefined {
     return undefined;
   }
 

--- a/packages/core/echo/echo-schema/src/handler/typed-handler.ts
+++ b/packages/core/echo/echo-schema/src/handler/typed-handler.ts
@@ -6,11 +6,13 @@ import { isTypeLiteral } from '@effect/schema/AST';
 import * as S from '@effect/schema/Schema';
 import { inspect, type InspectOptionsStylized } from 'node:util';
 
+import { type Reference } from '@dxos/echo-protocol';
 import { compositeRuntime, type GenericSignal } from '@dxos/echo-signals/runtime';
 import { invariant } from '@dxos/invariant';
 
 import { getTargetMeta } from './object';
 import { SchemaValidator, symbolSchema } from '../ast';
+import { getTypeReference } from '../getter';
 import { createReactiveProxy, isValidProxyTarget, ReactiveArray, type ReactiveHandler, symbolIsProxy } from '../proxy';
 import { data, type ObjectMeta } from '../types';
 import { defineHiddenProperty } from '../utils';
@@ -126,6 +128,10 @@ export class TypedReactiveHandler implements ReactiveHandler<ProxyTarget> {
 
   getSchema(target: any) {
     return target[symbolSchema];
+  }
+
+  getTypeReference(target: any): Reference | undefined {
+    return getTypeReference(target[symbolSchema]);
   }
 
   getMeta(target: any): ObjectMeta {

--- a/packages/core/echo/echo-schema/src/handler/untyped-handler.ts
+++ b/packages/core/echo/echo-schema/src/handler/untyped-handler.ts
@@ -110,6 +110,10 @@ export class UntypedReactiveHandler implements ReactiveHandler<ProxyTarget> {
     return undefined;
   }
 
+  getTypeReference() {
+    return undefined;
+  }
+
   getMeta(target: any): ObjectMeta {
     return getTargetMeta(target);
   }

--- a/packages/core/echo/echo-schema/src/proxy/types.ts
+++ b/packages/core/echo/echo-schema/src/proxy/types.ts
@@ -4,6 +4,8 @@
 
 import type * as S from '@effect/schema/Schema';
 
+import { type Reference } from '@dxos/echo-protocol';
+
 import { type ObjectMeta } from '../types';
 
 /**
@@ -23,6 +25,12 @@ export interface ReactiveHandler<T extends {}> extends ProxyHandler<T> {
   isDeleted(target: T): boolean;
 
   getSchema(target: T): S.Schema<any> | undefined;
+
+  /**
+   * We always store a type reference together with an object, but schema might not have been
+   * registered or replicated yet.
+   */
+  getTypeReference(target: T): Reference | undefined;
 
   getMeta(target: T): ObjectMeta;
 }


### PR DESCRIPTION
### Details

We always store a type reference together with an object, but schema might not have been registered or replicated yet. It should be possible to get the reference in this case.