### PR TITLE
feat: Pass space ref to file.upload provider

### DIFF
--- a/packages/apps/plugins/plugin-debug/src/components/DebugSettings.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DebugSettings.tsx
@@ -53,7 +53,7 @@ export const DebugSettings = ({ settings }: { settings: DebugSettingsProps }) =>
     download(file, fileName);
 
     if (fileManagerPlugin?.provides.file.upload) {
-      const info = await fileManagerPlugin.provides.file.upload(new File([file], fileName));
+      const info = await fileManagerPlugin.provides.file.upload(new File([file], fileName), client.spaces.default);
       if (!info) {
         log.error('diagnostics failed to upload to IPFS');
         return;

--- a/packages/apps/plugins/plugin-ipfs/src/IpfsPlugin.tsx
+++ b/packages/apps/plugins/plugin-ipfs/src/IpfsPlugin.tsx
@@ -43,7 +43,7 @@ export const IpfsPlugin = (): PluginDefinition<IpfsPluginProvides> => {
       },
       // TODO(burdon): Add intent to upload file.
       file: {
-        upload: async (file) => {
+        upload: async (file, space) => {
           try {
             // TODO(burdon): Set via config or IPFS_API_SECRET in dev.
             const config = clientPlugin?.provides.client.config;

--- a/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -4,7 +4,7 @@
 
 import { type IconProps, TextAa } from '@phosphor-icons/react';
 import { batch, effect } from '@preact/signals-core';
-import React, { useCallback, useMemo, type Ref } from 'react';
+import React, { useMemo, type Ref } from 'react';
 
 import { parseClientPlugin } from '@braneframe/plugin-client';
 import { parseSpacePlugin, updateGraphWithAddObjectAction } from '@braneframe/plugin-space';

--- a/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -247,20 +247,19 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
           }, [doc, space, settings.values.editorMode]);
 
           const fileManagerPlugin = useResolvePlugin(parseFileManagerPlugin);
-          const onFileUpload = useCallback(
-            async (file: File) => {
-              if (space === undefined) {
-                return undefined;
-              }
+          const onFileUpload = useMemo(() => {
+            if (space === undefined) {
+              return undefined;
+            }
 
-              if (fileManagerPlugin?.provides.file.upload === undefined) {
-                return undefined;
-              }
+            if (fileManagerPlugin?.provides.file.upload === undefined) {
+              return undefined;
+            }
 
-              return await fileManagerPlugin.provides.file.upload(file, space);
-            },
-            [fileManagerPlugin, space],
-          );
+            return async (file: File) => {
+              return await fileManagerPlugin?.provides?.file?.upload?.(file, space);
+            };
+          }, [fileManagerPlugin, space]);
 
           switch (role) {
             // TODO(burdon): Normalize layout (reduce variants).

--- a/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
@@ -110,16 +110,17 @@ const StackMain: FC<{ stack: StackType; separation?: boolean }> = ({ stack, sepa
   );
 
   // TODO(wittjosiah): Factor out.
-  const handleFileUpload = fileManagerPlugin?.provides.file.upload
-    ? async (file: File) => {
-        const filename = file.name.split('.')[0];
-        const info = await fileManagerPlugin.provides.file.upload?.(file);
-        if (info) {
-          const obj = create(FileType, { type: file.type, title: filename, filename, cid: info.cid });
-          handleAdd(obj);
+  const handleFileUpload =
+    fileManagerPlugin?.provides.file.upload && space
+      ? async (file: File) => {
+          const filename = file.name.split('.')[0];
+          const info = await fileManagerPlugin.provides.file.upload?.(file, space);
+          if (info) {
+            const obj = create(FileType, { type: file.type, title: filename, filename, cid: info.cid });
+            handleAdd(obj);
+          }
         }
-      }
-    : undefined;
+      : undefined;
 
   const handleNavigate = async (object: MosaicDataItem) => {
     const toId = fullyQualifiedId(object);

--- a/packages/sdk/app-framework/package.json
+++ b/packages/sdk/app-framework/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@dxos/app-graph": "workspace:*",
     "@dxos/async": "workspace:*",
+    "@dxos/client-protocol": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/echo-schema": "workspace:*",
     "@dxos/invariant": "workspace:*",

--- a/packages/sdk/app-framework/src/plugins/common/file.ts
+++ b/packages/sdk/app-framework/src/plugins/common/file.ts
@@ -2,6 +2,8 @@
 // Copyright 2024 DXOS.org
 //
 
+import { type Space } from '@dxos/client-protocol';
+
 import { type Plugin } from '../PluginHost';
 
 // TODO(burdon): See Accept attribute (uses MIME types).
@@ -17,7 +19,7 @@ export type FileInfo = {
   cid?: string; // TODO(burdon): Meta key? Or other common properties with other file management system? (e.g., WNFS).
 };
 
-export type FileUploader = (file: File) => Promise<FileInfo | undefined>;
+export type FileUploader = (file: File, space: Space) => Promise<FileInfo | undefined>;
 
 /**
  * Generic interface provided by file plugins (e.g., IPFS, WNFS).

--- a/packages/sdk/app-framework/tsconfig.json
+++ b/packages/sdk/app-framework/tsconfig.json
@@ -40,6 +40,9 @@
     },
     {
       "path": "../app-graph"
+    },
+    {
+      "path": "../client-protocol"
     }
   ],
   "ts-node": {

--- a/packages/ui/react-ui-editor/src/components/Toolbar/Toolbar.tsx
+++ b/packages/ui/react-ui-editor/src/components/Toolbar/Toolbar.tsx
@@ -323,7 +323,7 @@ const MarkdownStandard = () => (
 
 // TODO(burdon): Make extensible.
 export type MarkdownCustomOptions = {
-  onUpload?: (file: File) => Promise<{ url?: string }>;
+  onUpload?: (file: File) => Promise<{ url?: string } | undefined>;
 };
 
 const MarkdownCustom = ({ onUpload }: MarkdownCustomOptions = {}) => {
@@ -348,9 +348,9 @@ const MarkdownCustom = ({ onUpload }: MarkdownCustomOptions = {}) => {
           lastModified: f.lastModified,
         });
 
-        const { url } = await onUpload(file);
-        if (url) {
-          onAction?.({ type: 'image', data: url });
+        const info = await onUpload(file);
+        if (info) {
+          onAction?.({ type: 'image', data: info.url });
         }
       });
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8219,6 +8219,9 @@ importers:
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
+      '@dxos/client-protocol':
+        specifier: workspace:*
+        version: link:../client-protocol
       '@dxos/debug':
         specifier: workspace:*
         version: link:../../common/debug


### PR DESCRIPTION
### Motivation / Background

This PR aims to complete the first two TODOs from #6717 

### Details

- [x] Passes the relevant space to `provides.file.upload`
- [x] Remove the need for `useResolvePlugin(parseFileManagerPlugin)` in the `EditorMain` component of the markdown plugin
