### PR TITLE
test: Fix Phoenix test

### DIFF
--- a/packages/common/phoenix/src/phoenix.test.ts
+++ b/packages/common/phoenix/src/phoenix.test.ts
@@ -9,6 +9,7 @@ import { join } from 'node:path';
 import waitForExpect from 'wait-for-expect';
 
 import { Trigger } from '@dxos/async';
+import { log } from '@dxos/log';
 import { afterTest, describe, test } from '@dxos/test';
 
 import { Phoenix } from './phoenix';

--- a/packages/common/phoenix/src/phoenix.test.ts
+++ b/packages/common/phoenix/src/phoenix.test.ts
@@ -9,7 +9,6 @@ import { join } from 'node:path';
 import waitForExpect from 'wait-for-expect';
 
 import { Trigger } from '@dxos/async';
-import { log } from '@dxos/log';
 import { afterTest, describe, test } from '@dxos/test';
 
 import { Phoenix } from './phoenix';

--- a/packages/common/phoenix/src/phoenix.ts
+++ b/packages/common/phoenix/src/phoenix.ts
@@ -53,6 +53,10 @@ export class Phoenix {
       }
     });
 
+    watchDog.on('error', (err) => {
+      log.error('Monitor error', { err });
+    });
+
     await waitForPidFileBeingFilledWithInfo(params.pidFile);
 
     watchDog.disconnect();

--- a/packages/common/phoenix/src/testing-utils.ts
+++ b/packages/common/phoenix/src/testing-utils.ts
@@ -4,8 +4,6 @@
 
 import { existsSync, mkdirSync, unlinkSync } from 'node:fs';
 
-import { log } from '@dxos/log';
-
 export const TEST_DIR = '/tmp/dxos/testing/phoenix';
 
 if (!existsSync(TEST_DIR)) {
@@ -13,7 +11,8 @@ if (!existsSync(TEST_DIR)) {
 }
 
 export const neverEndingProcess = () => {
-  log.info('neverEndingProcess started');
+  // eslint-disable-next-line no-console
+  console.log(`neverEndingProcess started ${1}`);
   setTimeout(() => {}, 1_000_000);
 };
 


### PR DESCRIPTION
The test was spawning a process that used `log` framework, which was not bundled correctly, but checks were passing because log file contained the command itself. If the test took a little bit longer, process had enough time to reach a failing point.

Changed check to match only executed `console.log`, dropped `log` framework, and used `console.log` directly inside tests