### PR TITLE
fix: Plank improvements & fixes

### DIFF
--- a/packages/apps/plugins/plugin-deck/src/DeckPlugin.tsx
+++ b/packages/apps/plugins/plugin-deck/src/DeckPlugin.tsx
@@ -30,7 +30,7 @@ import {
 import { create } from '@dxos/echo-schema';
 import { Keyboard } from '@dxos/keyboard';
 import { LocalStorageStore } from '@dxos/local-storage';
-import { AttentionProvider } from '@dxos/react-ui-deck';
+import { AttentionProvider, translations as deckTranslations } from '@dxos/react-ui-deck';
 import { Mosaic } from '@dxos/react-ui-mosaic';
 
 import { LayoutContext, LayoutSettings, DeckLayout, NAV_ID } from './components';
@@ -194,7 +194,7 @@ export const DeckPlugin = ({
       layout: layout.values,
       location,
       attention,
-      translations,
+      translations: [...translations, ...deckTranslations],
       graph: {
         builder: (_, graph) => {
           // TODO(burdon): Root menu isn't visible so nothing bound.

--- a/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
+++ b/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
@@ -101,13 +101,11 @@ const PlankError = ({
   useEffect(() => {
     setTimeout(() => setTimedOut(true), 5e3);
   }, []);
-  return timedOut ? (
+  return (
     <>
-      <NodePlankHeading node={node} part={part} slug={slug} />
-      <PlankContentError error={error} />
+      <NodePlankHeading node={node} part={part} slug={slug} pending={!timedOut} />
+      {timedOut ? <PlankContentError error={error} /> : <PlankLoading />}
     </>
-  ) : (
-    <PlankLoading />
   );
 };
 
@@ -119,15 +117,19 @@ const NodePlankHeading = ({
   part,
   slug,
   popoverAnchorId,
+  pending,
 }: {
   node?: Node;
   part: PartIdentifier;
   slug: string;
   popoverAnchorId?: string;
+  pending?: boolean;
 }) => {
   const { t } = useTranslation(DECK_PLUGIN);
   const Icon = node?.properties?.icon ?? Placeholder;
-  const label = toLocalizedString(node?.properties?.label ?? ['plank heading fallback label', { ns: DECK_PLUGIN }], t);
+  const label = pending
+    ? t('pending heading')
+    : toLocalizedString(node?.properties?.label ?? ['plank heading fallback label', { ns: DECK_PLUGIN }], t);
   const { dispatch } = useIntent();
   const ActionRoot = node && popoverAnchorId === `dxos.org/ui/${DECK_PLUGIN}/${node.id}` ? Popover.Anchor : Fragment;
   return (
@@ -153,7 +155,9 @@ const NodePlankHeading = ({
           </PlankHeading.Button>
         )}
       </ActionRoot>
-      <PlankHeading.Label attendableId={node?.id}>{label}</PlankHeading.Label>
+      <PlankHeading.Label attendableId={node?.id} {...(pending && { classNames: 'fg-description' })}>
+        {label}
+      </PlankHeading.Label>
       {node && part[0] !== 'complementary' && (
         <Surface role='navbar-end' direction='inline-reverse' data={{ object: node.data, part }} />
       )}

--- a/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
+++ b/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
@@ -153,7 +153,7 @@ const NodePlankHeading = ({
           </PlankHeading.Button>
         )}
       </ActionRoot>
-      <PlankHeading.Label classNames='grow'>{label}</PlankHeading.Label>
+      <PlankHeading.Label attendableId={node?.id}>{label}</PlankHeading.Label>
       {node && part[0] !== 'complementary' && (
         <Surface role='navbar-end' direction='inline-reverse' data={{ object: node.data, part }} />
       )}

--- a/packages/apps/plugins/plugin-deck/src/translations.ts
+++ b/packages/apps/plugins/plugin-deck/src/translations.ts
@@ -29,6 +29,7 @@ export default [
         'actions menu label': 'Options',
         'settings deck label': 'Enable Deck',
         'reload required message': 'Reload required.',
+        'pending heading': 'Loading…',
       },
     },
   },

--- a/packages/ui/react-ui-deck/src/components/Deck/Deck.tsx
+++ b/packages/ui/react-ui-deck/src/components/Deck/Deck.tsx
@@ -13,6 +13,8 @@ import { mx } from '@dxos/react-ui-theme';
 import { resizeHandle, resizeHandleVertical } from '../../fragments';
 import { translationKey } from '../../translations';
 
+const MIN_WIDTH = [20, 'rem'] as const;
+
 type DeckRootProps = ThemedClassName<ComponentPropsWithRef<'div'>> & { asChild?: boolean };
 
 const deckGrid =
@@ -47,6 +49,7 @@ type DeckPlankProps = ThemedClassName<ComponentPropsWithRef<'article'>> & {
 type DeckPlankResizing = Pick<MouseEvent, 'pageX'> & { size: number } & { [Unit in DeckPlankUnit]: number };
 
 const DeckPlank = forwardRef<HTMLDivElement, DeckPlankProps>(
+  // TODO(thure): implement units (currently only `rem` is actually supported)
   ({ unit = 'rem', classNames, style, children, scrollIntoViewOnMount, suppressAutofocus, ...props }, forwardedRef) => {
     const { t } = useTranslation(translationKey);
     const [isSm] = useMediaQuery('sm', { ssr: false });
@@ -62,7 +65,7 @@ const DeckPlank = forwardRef<HTMLDivElement, DeckPlankProps>(
       ({ pageX }: PointerEvent) => {
         if (resizing) {
           const delta = pageX - resizing.pageX;
-          setSize(resizing.size + delta / resizing[unit]);
+          setSize(Math.max(MIN_WIDTH[0], resizing.size + delta / resizing[unit]));
         }
       },
       [resizing],

--- a/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
+++ b/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
@@ -224,7 +224,9 @@ const PlankHeadingControl = ({ children, label, ...props }: ButtonProps & { labe
         </Button>
       </Tooltip.Trigger>
       <Tooltip.Portal>
-        <Tooltip.Content side='bottom'>{label}</Tooltip.Content>
+        <Tooltip.Content side='bottom' classNames='z-[70]'>
+          {label}
+        </Tooltip.Content>
       </Tooltip.Portal>
     </Tooltip.Root>
   );

--- a/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
+++ b/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
@@ -189,7 +189,10 @@ const PlankHeadingLabel = forwardRef<HTMLHeadingElement, PlankHeadingLabelProps>
       <h1
         {...props}
         data-attention={hasAttention.toString()}
-        className={mx('pli-1 min-is-0 shrink truncate font-medium fg-base data-[attention=true]:fg-accent', classNames)}
+        className={mx(
+          'pli-1 min-is-0 is-0 grow truncate font-medium fg-base data-[attention=true]:fg-accent',
+          classNames,
+        )}
         ref={forwardedRef}
       />
     );

--- a/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
+++ b/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
@@ -214,6 +214,22 @@ type PlankHeadingControlsProps = Omit<ButtonGroupProps, 'onClick'> & {
   pin?: 'start' | 'end' | 'both';
 };
 
+const PlankHeadingControl = ({ children, label, ...props }: ButtonProps & { label: string }) => {
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger asChild>
+        <Button variant='ghost' {...props}>
+          <span className='sr-only'>{label}</span>
+          {children}
+        </Button>
+      </Tooltip.Trigger>
+      <Tooltip.Portal>
+        <Tooltip.Content side='bottom'>{label}</Tooltip.Content>
+      </Tooltip.Portal>
+    </Tooltip.Root>
+  );
+};
+
 const PlankHeadingControls = forwardRef<HTMLDivElement, PlankHeadingControlsProps>(
   ({ part, onClick, variant = 'default', increment = true, pin, close = false, children, ...props }, forwardedRef) => {
     const { t } = useTranslation(translationKey);
@@ -222,44 +238,52 @@ const PlankHeadingControls = forwardRef<HTMLDivElement, PlankHeadingControlsProp
       <ButtonGroup {...props} ref={forwardedRef}>
         {children}
         {pin && ['both', 'start'].includes(pin) && (
-          <Button variant='ghost' classNames={buttonClassNames} onClick={() => onClick?.({ type: 'pin-start', part })}>
-            <span className='sr-only'>{t('pin start label')}</span>
+          <PlankHeadingControl
+            label={t('pin start label')}
+            variant='ghost'
+            classNames={buttonClassNames}
+            onClick={() => onClick?.({ type: 'pin-start', part })}
+          >
             <CaretLineLeft />
-          </Button>
+          </PlankHeadingControl>
         )}
         {increment && (
           <>
-            <Button
+            <PlankHeadingControl
+              label={t('increment start label')}
               disabled={part[1] < 1}
-              variant='ghost'
               classNames={buttonClassNames}
               onClick={() => onClick?.({ type: 'increment-start', part })}
             >
-              <span className='sr-only'>{t('increment start label')}</span>
               <CaretLeft />
-            </Button>
-            <Button
+            </PlankHeadingControl>
+            <PlankHeadingControl
+              label={t('increment end label')}
               disabled={part[1] > part[2] - 2}
-              variant='ghost'
               classNames={buttonClassNames}
               onClick={() => onClick?.({ type: 'increment-end', part })}
             >
-              <span className='sr-only'>{t('increment end label')}</span>
               <CaretRight />
-            </Button>
+            </PlankHeadingControl>
           </>
         )}
         {pin && ['both', 'end'].includes(pin) && (
-          <Button variant='ghost' classNames={buttonClassNames} onClick={() => onClick?.({ type: 'pin-end', part })}>
-            <span className='sr-only'>{t('pin end label')}</span>
+          <PlankHeadingControl
+            label={t('pin end label')}
+            classNames={buttonClassNames}
+            onClick={() => onClick?.({ type: 'pin-end', part })}
+          >
             <CaretLineRight />
-          </Button>
+          </PlankHeadingControl>
         )}
         {close && (
-          <Button variant='ghost' classNames={buttonClassNames} onClick={() => onClick?.({ type: 'close', part })}>
-            <span className='sr-only'>{t('close label')}</span>
+          <PlankHeadingControl
+            label={t('close label')}
+            classNames={buttonClassNames}
+            onClick={() => onClick?.({ type: 'close', part })}
+          >
             <X />
-          </Button>
+          </PlankHeadingControl>
         )}
       </ButtonGroup>
     );

--- a/packages/ui/react-ui-deck/src/fragments/resize-handle.ts
+++ b/packages/ui/react-ui-deck/src/fragments/resize-handle.ts
@@ -3,7 +3,8 @@
 //
 
 export const resizeHandle =
-  'grid p-0 touch-none before:rounded-full before:surface-input hover:before:surface-inputHover before:transition-colors hover:before:surface-accentFocusIndicator focus-visible:before:surface-accentFocusIndicator data-[resizing=true]:before:surface-accentFocusIndicator focus:outline-none';
-export const resizeHandleVertical = 'is-6 cursor-col-resize justify-items-center items-stretch plb-2 before:is-1';
+  'grid p-0 touch-none before:rounded-full before:surface-input hover:before:surface-inputHover before:transition-[block-size,inline-size,background-color] duration-300 ease-in-out hover:before:surface-accentFocusIndicator focus-visible:before:surface-accentFocusIndicator data-[resizing=true]:before:surface-accentFocusIndicator focus:outline-none';
+export const resizeHandleVertical =
+  'is-6 cursor-col-resize justify-items-center items-start plb-1 before:is-1 before:bs-[--rail-action] hover:before:bs-full focus:before:bs-full';
 export const resizeHandleHorizontal =
   'bs-6 cursor-row-resize justify-center items-center pli-2 before:bs-1 before:is-[--rail-size]';

--- a/packages/ui/react-ui-deck/src/index.ts
+++ b/packages/ui/react-ui-deck/src/index.ts
@@ -4,3 +4,4 @@
 
 export * from './components';
 export * from './fragments';
+export { default as translations } from './translations';


### PR DESCRIPTION
This PR:
- Resolves #6771
- Resolves #6772
- Resolves #6780 
- Implements a more subdued design for the resize handle which is persistently visible but does not fill the full height of the Deck unless hovered or focused
- Always renders a Plank heading, using “Loading…” for planks that have not yet timed out.

https://github.com/dxos/dxos/assets/855039/0dd67b7e-f81f-49ac-95c0-4d6b3968257a