### PR TITLE
chore: make pnpm engine less strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
   },
   "engines": {
     "node": ">=18.0.0",
-    "pnpm": "^8.15.4"
+    "pnpm": "^8.0.0"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
Was causing cloudflare pages builds to fail
