### PR TITLE
chore(plugin-presenter): remove erroneous peer dependency

### DIFF
--- a/packages/apps/plugins/plugin-presenter/package.json
+++ b/packages/apps/plugins/plugin-presenter/package.json
@@ -61,7 +61,6 @@
   },
   "peerDependencies": {
     "@braneframe/plugin-client": "workspace:*",
-    "@braneframe/plugin-layout": "workspace:*",
     "@braneframe/plugin-markdown": "workspace:*",
     "@braneframe/plugin-space": "workspace:*",
     "@braneframe/plugin-stack": "workspace:*",

--- a/packages/apps/plugins/plugin-presenter/tsconfig.json
+++ b/packages/apps/plugins/plugin-presenter/tsconfig.json
@@ -56,9 +56,6 @@
       "path": "../plugin-client"
     },
     {
-      "path": "../plugin-layout"
-    },
-    {
       "path": "../plugin-markdown"
     },
     {


### PR DESCRIPTION
Causing

> ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL  Cannot resolve workspace protocol of dependency "@braneframe/plugin-layout" because this dependency is not installed. Try running "pnpm install".

on publish
