### PR TITLE
test(composer-app): increase default timeout for playwright tests

### DIFF
--- a/packages/apps/composer-app/src/playwright/basic.spec.ts
+++ b/packages/apps/composer-app/src/playwright/basic.spec.ts
@@ -53,8 +53,6 @@ test.describe('Basic tests', () => {
       test.skip();
     }
 
-    test.setTimeout(60_000);
-
     await host.createSpace();
     await waitForExpect(async () => {
       expect(await host.getSpaceItemsCount()).to.equal(2);
@@ -71,8 +69,6 @@ test.describe('Basic tests', () => {
   });
 
   test('reset device', async ({ browserName }) => {
-    test.setTimeout(60_000);
-
     await host.createSpace();
     await waitForExpect(async () => {
       expect(await host.getSpaceItemsCount()).to.equal(2);

--- a/packages/apps/composer-app/src/playwright/collaboration.spec.ts
+++ b/packages/apps/composer-app/src/playwright/collaboration.spec.ts
@@ -23,8 +23,6 @@ const perfomInvitation = async (host: AppManager, guest: AppManager) => {
 // TODO(wittjosiah): WebRTC only available in chromium browser for testing currently.
 //   https://github.com/microsoft/playwright/issues/2973
 test.describe('Collaboration tests', () => {
-  test.setTimeout(60_000);
-
   let host: AppManager;
   let guest: AppManager;
 

--- a/packages/apps/composer-app/src/playwright/halo.spec.ts
+++ b/packages/apps/composer-app/src/playwright/halo.spec.ts
@@ -12,8 +12,6 @@ import { AppManager } from './app-manager';
 // TODO(wittjosiah): WebRTC only available in chromium browser for testing currently.
 //   https://github.com/microsoft/playwright/issues/2973
 test.describe('HALO tests', () => {
-  test.setTimeout(60_000);
-
   let host: AppManager;
   let guest: AppManager;
 

--- a/packages/apps/composer-app/src/playwright/playwright.config.ts
+++ b/packages/apps/composer-app/src/playwright/playwright.config.ts
@@ -6,7 +6,7 @@ import { type PlaywrightTestConfig } from '@playwright/test';
 
 import { defaultPlaywrightConfig } from '@dxos/test/playwright';
 
-// TODO(wittjosiah): Sometimes seems to take a long time to hit this in CI. Can we disable PWA in CI?
-const config: PlaywrightTestConfig = { ...defaultPlaywrightConfig, timeout: 30_000 };
+// TODO(wittjosiah): Sometimes seems to take a long time to hit this in CI.
+const config: PlaywrightTestConfig = { ...defaultPlaywrightConfig, timeout: 60_000 };
 
 export default config;


### PR DESCRIPTION
Playwright tests still seem to be failing due to timeouts a bunch of the time in CI. Looking at the traces they seem to be caused primarily by the app taking 10-15s to even load before the test starts in earnest. This seems problematic, but for now just try increasing the timeout to reduce the failures.
