### PR TITLE
docs: exclude node_modules from lychee

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -136,7 +136,7 @@ glob_ignore_case = false
 exclude = [".proto"]
 
 # Exclude these filesystem paths from getting checked.
-exclude_path = []
+exclude_path = ["node_modules"]
 
 # URLs to check (supports regex). Has preference over all excludes.
 include = []


### PR DESCRIPTION
I would have rather excluded everything in .gitignore, but didn't see a convenient way to do this.
