### PR TITLE
fix: Scroll plank into view when navigating from a Stack section

### DIFF
--- a/packages/apps/plugins/plugin-deck/src/DeckPlugin.tsx
+++ b/packages/apps/plugins/plugin-deck/src/DeckPlugin.tsx
@@ -242,7 +242,7 @@ export const DeckPlugin = ({
             onChangeAttend={(nextAttended) => {
               // TODO(thure): Is this / could this be better handled by an intent?
               attention.attended = nextAttended;
-              if (nextAttended.has(layout.values.scrollIntoView)) {
+              if (layout.values.scrollIntoView && nextAttended.has(layout.values.scrollIntoView)) {
                 layout.values.scrollIntoView = undefined;
               }
             }}

--- a/packages/apps/plugins/plugin-deck/src/DeckPlugin.tsx
+++ b/packages/apps/plugins/plugin-deck/src/DeckPlugin.tsx
@@ -242,6 +242,9 @@ export const DeckPlugin = ({
             onChangeAttend={(nextAttended) => {
               // TODO(thure): Is this / could this be better handled by an intent?
               attention.attended = nextAttended;
+              if (nextAttended.has(layout.values.scrollIntoView)) {
+                layout.values.scrollIntoView = undefined;
+              }
             }}
           >
             <LayoutContext.Provider value={layout.values}>{props.children}</LayoutContext.Provider>

--- a/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
+++ b/packages/apps/plugins/plugin-stack/src/components/StackMain.tsx
@@ -122,10 +122,14 @@ const StackMain: FC<{ stack: StackType; separation?: boolean }> = ({ stack, sepa
     : undefined;
 
   const handleNavigate = async (object: MosaicDataItem) => {
-    await dispatch({
-      action: NavigationAction.OPEN,
-      data: { activeParts: { main: [fullyQualifiedId(object)] } },
-    });
+    const toId = fullyQualifiedId(object);
+    await dispatch([
+      {
+        action: NavigationAction.OPEN,
+        data: { activeParts: { main: [toId] } },
+      },
+      { action: LayoutAction.SCROLL_INTO_VIEW, data: { id: toId } },
+    ]);
   };
 
   const handleTransform = (item: MosaicDataItem, type?: string) => {

--- a/packages/ui/react-ui-stack/src/components/Section.tsx
+++ b/packages/ui/react-ui-stack/src/components/Section.tsx
@@ -182,10 +182,10 @@ export const Section: ForwardRefExoticComponent<SectionProps & RefAttributes<HTM
           <div
             role='none'
             className={mx(
-              'grid col-span-2 grid-cols-subgrid outline outline-1 outline-transparent mlb-px surface-base focus-within:s-outline-separator focus-within:surface-attention',
+              'grid col-span-2 grid-cols-subgrid border border-transparent mlb-px surface-base focus-within:separator-separator focus-within:surface-attention',
               hoverableControls,
               hoverableFocusedWithinControls,
-              active && 'surface-attention after:separator-separator s-outline-separator',
+              active && 'surface-attention separator-separator',
               (active === 'origin' || active === 'rearrange' || active === 'destination') && 'opacity-0',
             )}
           >


### PR DESCRIPTION
This PR:
- resolves #6885
- adjusts stack sections to use border instead of outline, aligning appearance with documents

https://github.com/dxos/dxos/assets/855039/2b9615f7-0f9e-4db0-a337-31a745824f44
