### PR TITLE
fix(react-ui-deck): Support minification of sidebars as a variation of close

### DIFF
--- a/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
+++ b/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
@@ -146,7 +146,7 @@ const NodePlankHeading = ({
   const { dispatch } = useIntent();
   const ActionRoot = node && popoverAnchorId === `dxos.org/ui/${DECK_PLUGIN}/${node.id}` ? Popover.Anchor : Fragment;
   return (
-    <PlankHeading.Root {...(part[0] !== 'main' && { classNames: 'pie-2' })}>
+    <PlankHeading.Root {...(part[0] !== 'main' && { classNames: 'pie-1' })}>
       <ActionRoot>
         {node ? (
           <PlankHeading.ActionsMenu

--- a/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
+++ b/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
@@ -146,7 +146,7 @@ const NodePlankHeading = ({
   const { dispatch } = useIntent();
   const ActionRoot = node && popoverAnchorId === `dxos.org/ui/${DECK_PLUGIN}/${node.id}` ? Popover.Anchor : Fragment;
   return (
-    <PlankHeading.Root>
+    <PlankHeading.Root {...(part[0] !== 'main' && { classNames: 'pie-2' })}>
       <ActionRoot>
         {node ? (
           <PlankHeading.ActionsMenu
@@ -182,19 +182,27 @@ const NodePlankHeading = ({
         onClick={({ type, part }) =>
           dispatch(
             type === 'close'
-              ? {
-                  action: NavigationAction.CLOSE,
-                  data: {
-                    activeParts: {
-                      complementary: `${slug}${SLUG_PATH_SEPARATOR}comments${SLUG_COLLECTION_INDICATOR}`,
-                      [part[0]]: slug,
+              ? part[0] === 'complementary'
+                ? {
+                    action: LayoutAction.SET_LAYOUT,
+                    data: {
+                      element: 'complementary',
+                      state: false,
                     },
-                  },
-                }
+                  }
+                : {
+                    action: NavigationAction.CLOSE,
+                    data: {
+                      activeParts: {
+                        complementary: `${slug}${SLUG_PATH_SEPARATOR}comments${SLUG_COLLECTION_INDICATOR}`,
+                        [part[0]]: slug,
+                      },
+                    },
+                  }
               : { action: NavigationAction.ADJUST, data: { type, part } },
           )
         }
-        close
+        close={part[0] === 'complementary' ? 'minify-end' : true}
       >
         {/* TODO(thure): This, and all other hardcoded `comments` references, needs to be refactored. */}
         {node && !!node.data?.comments && !slug?.endsWith('comments') && (

--- a/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
+++ b/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
@@ -209,7 +209,7 @@ type PlankHeadingControlsProps = Omit<ButtonGroupProps, 'onClick'> & {
   part: [string, number, number];
   onClick?: PlankControlHandler;
   variant?: 'hide-disabled' | 'default';
-  close?: boolean;
+  close?: boolean | 'minify-start' | 'minify-end';
   increment?: boolean;
   pin?: 'start' | 'end' | 'both';
 };
@@ -280,11 +280,11 @@ const PlankHeadingControls = forwardRef<HTMLDivElement, PlankHeadingControlsProp
         )}
         {close && (
           <PlankHeadingControl
-            label={t('close label')}
+            label={t(`${typeof close === 'string' ? 'minify' : 'close'} label`)}
             classNames={buttonClassNames}
             onClick={() => onClick?.({ type: 'close', part })}
           >
-            <X />
+            {close === 'minify-start' ? <CaretLineLeft /> : close === 'minify-end' ? <CaretLineRight /> : <X />}
           </PlankHeadingControl>
         )}
       </ButtonGroup>

--- a/packages/ui/react-ui-deck/src/translations.ts
+++ b/packages/ui/react-ui-deck/src/translations.ts
@@ -15,6 +15,7 @@ export default [
         'increment start label': 'Move to the left',
         'increment end label': 'Move to the right',
         'close label': 'Close',
+        'minify label': 'Minify',
       },
     },
   },


### PR DESCRIPTION
This PR adjusts Deck to support minifying planks rather than closing them, as a variation on the close button.

https://github.com/dxos/dxos/assets/855039/83bdcb3c-216a-4c29-9ba2-b47a4f943fa6
