### PR TITLE
tests(functions): random ports to fix address already in use

### DIFF
--- a/packages/core/functions/src/runtime/dev-server.test.ts
+++ b/packages/core/functions/src/runtime/dev-server.test.ts
@@ -3,6 +3,7 @@
 //
 
 import { expect } from 'chai';
+import { getRandomPort } from 'get-port-please';
 import path from 'path';
 
 import { sleep, waitForCondition } from '@dxos/async';
@@ -16,7 +17,6 @@ import { createFunctionRuntime, testFunctionManifest } from '../testing';
 import { initFunctionsPlugin } from '../testing/plugin-init';
 
 describe('dev server', () => {
-  let port = 7201;
   let client: Client;
   let testBuilder: TestBuilder;
   before(async () => {
@@ -67,7 +67,7 @@ describe('dev server', () => {
     const registry = new FunctionRegistry(client);
     const server = new DevServer(client, registry, {
       baseDir: path.join(__dirname, '../testing'),
-      port: port++,
+      port: await getRandomPort('127.0.0.1'),
     });
     const space = await client.spaces.create();
     // TODO(burdon): Doesn't shut down cleanly.

--- a/packages/core/functions/src/runtime/scheduler.test.ts
+++ b/packages/core/functions/src/runtime/scheduler.test.ts
@@ -3,6 +3,7 @@
 //
 
 import { expect } from 'chai';
+import { getRandomPort } from 'get-port-please';
 import WebSocket from 'ws';
 
 import { Trigger } from '@dxos/async';
@@ -108,6 +109,7 @@ describe('scheduler', () => {
   });
 
   test('websocket', async () => {
+    const port = await getRandomPort('127.0.0.1');
     const manifest: FunctionManifest = {
       functions: [
         {
@@ -123,7 +125,7 @@ describe('scheduler', () => {
           spec: {
             type: 'websocket',
             // url: 'https://hub.dxos.network/api/mailbox/test',
-            url: 'http://localhost:8081',
+            url: `http://localhost:${port}`,
             init: {
               type: 'sync',
             },
@@ -141,7 +143,7 @@ describe('scheduler', () => {
 
     // Test server.
     setTimeout(() => {
-      const wss = new WebSocket.Server({ port: 8081 });
+      const wss = new WebSocket.Server({ port });
       wss.on('connection', (ws: WebSocket) => {
         ws.on('message', (data) => {
           const info = JSON.parse(new TextDecoder().decode(data as ArrayBuffer));

--- a/packages/core/functions/src/testing/setup.ts
+++ b/packages/core/functions/src/testing/setup.ts
@@ -2,6 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
+import { getRandomPort } from 'get-port-please';
 import path from 'node:path';
 
 import { waitForCondition } from '@dxos/async';
@@ -15,8 +16,6 @@ import { FunctionRegistry } from '../function';
 import { DevServer, type DevServerOptions, Scheduler } from '../runtime';
 import { TriggerRegistry } from '../trigger';
 import { FunctionDef, FunctionTrigger } from '../types';
-
-let functionsPort = 8081;
 
 export type FunctionsPluginInitializer = (client: Client) => Promise<{ close: () => Promise<void> }>;
 
@@ -39,10 +38,11 @@ export const createFunctionRuntime = async (
   testBuilder: TestBuilder,
   pluginInitializer: FunctionsPluginInitializer,
 ): Promise<Client> => {
+  const functionsPort = await getRandomPort('127.0.0.1');
   const config = new Config({
     runtime: {
       agent: {
-        plugins: [{ id: 'dxos.org/agent/plugin/functions', config: { port: functionsPort++ } }],
+        plugins: [{ id: 'dxos.org/agent/plugin/functions', config: { port: functionsPort } }],
       },
     },
   });
@@ -92,6 +92,7 @@ const startDevServer = async (
 ) => {
   const server = new DevServer(client, functionRegistry, {
     baseDir: path.join(__dirname, '../testing'),
+    port: await getRandomPort('127.0.0.1'),
     ...options,
   });
   await server.start();

--- a/packages/experimental/agent-functions/src/tests/functions/gpt.test.ts
+++ b/packages/experimental/agent-functions/src/tests/functions/gpt.test.ts
@@ -22,8 +22,6 @@ import { initFunctionsPlugin } from '../setup';
 import { StubModelInvoker } from '../stub-invoker';
 import { createTestChain, type CreateTestChainInput } from '../test-chain-builder';
 
-let port = 7270;
-
 describe.only('Gpt', () => {
   let modelStub: StubModelInvoker;
   let testBuilder: TestBuilder;
@@ -241,7 +239,6 @@ const waitForGptResponse = async (message: MessageType, thread?: ThreadType) => 
 const setupTest = async (testBuilder: TestBuilder) => {
   const functions = await startFunctionsHost(testBuilder, initFunctionsPlugin, {
     baseDir: join(__dirname, '../../functions'),
-    port: port++,
   });
   const app = (await createInitializedClients(testBuilder))[0];
   const space = await app.spaces.create();


### PR DESCRIPTION
### Details

Use random ports to fix tests failing cause of address already in use.