### PR TITLE
fix(composer-app): include wasm files in service worker cache

### DIFF
--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -124,7 +124,7 @@ export default defineConfig({
         process.env.DX_PWA === 'false',
       workbox: {
         maximumFileSizeToCacheInBytes: 30000000,
-        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,wasm,woff2}'],
       },
       includeAssets: ['favicon.ico'],
       manifest: {


### PR DESCRIPTION
This should fix two things:

1) Wasm compile errors (e.g.: `CompileError: WebAssembly.instantiate(): expected magic word...`)
2) Composer not loading when offline if pwa is installed

I think this resolves #6019 