### PR TITLE
feat: Plank heading menu detail section

### DIFF
--- a/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
+++ b/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
@@ -151,16 +151,15 @@ const NodePlankHeading = ({
       <ActionRoot>
         {node ? (
           <PlankHeading.ActionsMenu
+            Icon={Icon}
+            attendableId={node.id}
             triggerLabel={t('actions menu label')}
             actions={node.actions()}
             onAction={(action) =>
               typeof action.data === 'function' && action.data?.({ node: action as Node, caller: DECK_PLUGIN })
             }
           >
-            <PlankHeading.Button attendableId={node.id}>
-              <span className='sr-only'>{label}</span>
-              <Icon {...plankHeadingIconProps} />
-            </PlankHeading.Button>
+            <Surface role='menu-footer' data={{ object: node.data }} />
           </PlankHeading.ActionsMenu>
         ) : (
           <PlankHeading.Button>

--- a/packages/apps/plugins/plugin-navtree/src/components/NavBarStart.tsx
+++ b/packages/apps/plugins/plugin-navtree/src/components/NavBarStart.tsx
@@ -7,7 +7,7 @@ import React, { Fragment } from 'react';
 
 import { type Node } from '@dxos/app-graph';
 import { Popover, toLocalizedString, useTranslation } from '@dxos/react-ui';
-import { PlankHeading, plankHeadingIconProps } from '@dxos/react-ui-deck';
+import { PlankHeading } from '@dxos/react-ui-deck';
 
 import { KEY_BINDING, NAVTREE_PLUGIN } from '../meta';
 
@@ -32,17 +32,14 @@ export const NavBarStart = ({ activeNode, popoverAnchorId }: { activeNode: Node;
     <>
       <ActionRoot>
         <PlankHeading.ActionsMenu
+          Icon={Icon}
+          attendableId={activeNode.id}
           triggerLabel={menuTriggerLabel}
           actions={actions}
           onAction={(action) =>
             typeof action.data === 'function' && action.data({ node: action as Node, caller: TREE_ITEM_MAIN_HEADING })
           }
-        >
-          <PlankHeading.Button attendableId={activeNode.id}>
-            <Icon {...plankHeadingIconProps} />
-            <span className='sr-only'>{menuTriggerLabel}</span>
-          </PlankHeading.Button>
-        </PlankHeading.ActionsMenu>
+        />
       </ActionRoot>
       <PlankHeading.Label attendableId={activeNode.id}>{label}</PlankHeading.Label>
     </>

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -50,6 +50,7 @@ import {
   EmptySpace,
   EmptyTree,
   FolderMain,
+  MenuFooter,
   MissingObject,
   PopoverRemoveObject,
   PopoverRenameObject,
@@ -397,6 +398,12 @@ export const SpacePlugin = ({
             }
             case 'settings':
               return data.plugin === meta.id ? <SpaceSettings settings={settings.values} /> : null;
+            case 'menu-footer':
+              if (!isEchoObject(data.object)) {
+                return null;
+              } else {
+                return <MenuFooter object={data.object} />;
+              }
             default:
               return null;
           }

--- a/packages/apps/plugins/plugin-space/src/components/MenuFooter.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/MenuFooter.tsx
@@ -1,0 +1,31 @@
+//
+// Copyright 2024 DXOS.org
+//
+import { Planet } from '@phosphor-icons/react';
+import React from 'react';
+
+import { getSpace } from '@dxos/client/echo';
+import type { EchoReactiveObject } from '@dxos/echo-schema';
+import { DropdownMenu, toLocalizedString, useTranslation } from '@dxos/react-ui';
+
+import { SPACE_PLUGIN } from '../meta';
+import { getSpaceDisplayName } from '../util';
+
+export const MenuFooter = ({ object }: { object: EchoReactiveObject<any> }) => {
+  const { t } = useTranslation(SPACE_PLUGIN);
+  const space = getSpace(object);
+  const spaceName = space ? getSpaceDisplayName(space) : '';
+  return space ? (
+    <>
+      <DropdownMenu.Separator />
+      <DropdownMenu.GroupLabel>{t('menu footer label')}</DropdownMenu.GroupLabel>
+      <dl className='pli-2 mbe-2 text-xs grid grid-cols-[max-content_1fr] gap-2'>
+        <dt className='uppercase text-[.75em] tracking-wide font-medium self-center mbs-px'>{t('location label')}</dt>
+        <dd>
+          <Planet className='inline-block mie-1' />
+          {toLocalizedString(spaceName, t)}
+        </dd>
+      </dl>
+    </>
+  ) : null;
+};

--- a/packages/apps/plugins/plugin-space/src/components/MenuFooter.tsx
+++ b/packages/apps/plugins/plugin-space/src/components/MenuFooter.tsx
@@ -19,9 +19,9 @@ export const MenuFooter = ({ object }: { object: EchoReactiveObject<any> }) => {
     <>
       <DropdownMenu.Separator />
       <DropdownMenu.GroupLabel>{t('menu footer label')}</DropdownMenu.GroupLabel>
-      <dl className='pli-2 mbe-2 text-xs grid grid-cols-[max-content_1fr] gap-2'>
-        <dt className='uppercase text-[.75em] tracking-wide font-medium self-center mbs-px'>{t('location label')}</dt>
-        <dd>
+      <dl className='pis-2 mbe-2 text-xs grid grid-cols-[max-content_1fr] gap-2'>
+        <dt className='uppercase text-[.75em] tracking-wide font-medium mbs-px self-start'>{t('location label')}</dt>
+        <dd className='line-clamp-3'>
           <Planet className='inline-block mie-1' />
           {toLocalizedString(spaceName, t)}
         </dd>

--- a/packages/apps/plugins/plugin-space/src/components/index.ts
+++ b/packages/apps/plugins/plugin-space/src/components/index.ts
@@ -6,6 +6,7 @@ export * from './AwaitingObject';
 export * from './EmptySpace';
 export * from './EmptyTree';
 export * from './FolderMain';
+export * from './MenuFooter';
 export * from './MissingObject';
 export * from './PersistenceStatus';
 export * from './PopoverRemoveObject';

--- a/packages/apps/plugins/plugin-space/src/translations.ts
+++ b/packages/apps/plugins/plugin-space/src/translations.ts
@@ -73,6 +73,8 @@ export default [
         'more actions label': 'More actions',
         'invitations heading': 'Invitations',
         'keyshortcuts label': 'Keyboard shortcuts',
+        'menu footer label': 'Details',
+        'location label': 'Located in',
       },
     },
   },

--- a/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
+++ b/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
@@ -3,7 +3,14 @@
 //
 
 import { CaretLeft, CaretLineLeft, CaretLineRight, CaretRight, type IconProps, X } from '@phosphor-icons/react';
-import React, { type ComponentPropsWithRef, forwardRef, type PropsWithChildren, useRef, useState } from 'react';
+import React, {
+  type ComponentPropsWithRef,
+  type FC,
+  forwardRef,
+  type PropsWithChildren,
+  useRef,
+  useState,
+} from 'react';
 
 import { keySymbols } from '@dxos/keyboard';
 import {
@@ -90,13 +97,15 @@ const PlankHeadingButton = forwardRef<HTMLButtonElement, PlankHeadingButtonProps
 );
 
 type PlankHeadingActionsMenuProps = PropsWithChildren<{
+  attendableId?: string;
   triggerLabel: string;
   actions?: PlankHeadingAction[];
+  Icon: FC<IconProps>;
   onAction?: (action: PlankHeadingAction) => void;
 }>;
 
 const PlankHeadingActionsMenu = forwardRef<HTMLButtonElement, PlankHeadingActionsMenuProps>(
-  ({ actions, onAction, triggerLabel, children }, forwardedRef) => {
+  ({ actions, onAction, triggerLabel, attendableId, Icon, children }, forwardedRef) => {
     const { t } = useTranslation(translationKey);
     const suppressNextTooltip = useRef(false);
 
@@ -128,7 +137,10 @@ const PlankHeadingActionsMenu = forwardRef<HTMLButtonElement, PlankHeadingAction
         >
           <Tooltip.Trigger asChild>
             <DropdownMenu.Trigger asChild ref={forwardedRef}>
-              {children}
+              <PlankHeadingButton attendableId={attendableId}>
+                <span className='sr-only'>{triggerLabel}</span>
+                <Icon {...plankHeadingIconProps} />
+              </PlankHeadingButton>
             </DropdownMenu.Trigger>
           </Tooltip.Trigger>
           <DropdownMenu.Portal>
@@ -164,13 +176,14 @@ const PlankHeadingActionsMenu = forwardRef<HTMLButtonElement, PlankHeadingAction
                     </DropdownMenu.Item>
                   );
                 })}
+                {children}
               </DropdownMenu.Viewport>
               <DropdownMenu.Arrow />
             </DropdownMenu.Content>
           </DropdownMenu.Portal>
         </DropdownMenu.Root>
         <Tooltip.Portal>
-          <Tooltip.Content style={{ zIndex: 70 }} side='left'>
+          <Tooltip.Content style={{ zIndex: 70 }} side='bottom'>
             {triggerLabel}
             <Tooltip.Arrow />
           </Tooltip.Content>

--- a/packages/ui/react-ui-theme/src/styles/components/menu.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/menu.ts
@@ -35,7 +35,7 @@ export const menuItem: ComponentFunction<MenuStyleProps> = (_props, ...etc) =>
   );
 
 export const menuSeparator: ComponentFunction<MenuStyleProps> = (_props, ...etc) =>
-  mx('mlb-1 mli-2 bs-px surface-separator', ...etc);
+  mx('mlb-1 mli-2 bs-px bg-neutral-75 dark:bg-neutral-700', ...etc);
 
 export const menuGroupLabel: ComponentFunction<MenuStyleProps> = (_props, ...etc) =>
   mx(descriptionText, 'select-none pli-2 plb-2', ...etc);

--- a/packages/ui/react-ui-theme/src/styles/components/tooltip.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/tooltip.ts
@@ -11,7 +11,7 @@ export type TooltipStyleProps = {};
 
 export const tooltipContent: ComponentFunction<TooltipStyleProps> = (_props, ...etc) =>
   mx(
-    'inline-flex items-center rounded-md plb-2 pli-3',
+    'inline-flex items-center rounded-md plb-2 pli-3 max-is-64',
     modalSurface,
     popperMotion,
     surfaceElevation({ elevation: 'group' }),


### PR DESCRIPTION
This PR:
- adds a details section to the plank heading menu
- resolves #6773
- fixes a color token issue where separators were not visible in modal surfaces

<img width="271" alt="Screenshot 2024-06-04 at 15 41 02" src="https://github.com/dxos/dxos/assets/855039/12d27562-4598-4d41-b379-adfac00c2408">

For spaces with long names:

<img width="295" alt="Screenshot 2024-06-04 at 15 50 45" src="https://github.com/dxos/dxos/assets/855039/6865e57c-87e7-481e-b940-96e89a4232ac">
