### PR TITLE
chore(tracing): check for endTs falsy

### DIFF
--- a/packages/common/tracing/src/remote/tracing.ts
+++ b/packages/common/tracing/src/remote/tracing.ts
@@ -35,7 +35,7 @@ export class RemoteTracing {
       return;
     }
 
-    if (span.endTs === undefined) {
+    if (!span.endTs) {
       const remoteSpan = this._tracing.startSpan({
         name: span.methodName,
         op: span.op,


### PR DESCRIPTION
endTs is null rather than undefined, just check for falsy instead
