### PR TITLE
chore(composer-app): hook up shared worker to sentry

### DIFF
--- a/packages/apps/composer-app/src/config.ts
+++ b/packages/apps/composer-app/src/config.ts
@@ -6,7 +6,13 @@ import { Config, Defaults, Envs, Local, Storage } from '@dxos/config';
 import { Remote } from '@dxos/react-client';
 
 export const setupConfig = async () => {
-  const searchParams = new URLSearchParams(window.location.search);
-  // TODO(burdon): Add monolithic flag. Currently, can set `target=file://local`.
-  return new Config(Remote(searchParams.get('target') ?? undefined), await Storage(), Envs(), Local(), Defaults());
+  const sources = [await Storage(), Envs(), Local(), Defaults()];
+  // Not available in the worker.
+  if (typeof window !== 'undefined') {
+    const searchParams = new URLSearchParams(window.location.search);
+    // TODO(burdon): Add monolithic flag. Currently, can set `target=file://local`.
+    sources.splice(0, 0, Remote(searchParams.get('target') ?? undefined));
+  }
+
+  return new Config(...sources);
 };

--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -97,7 +97,7 @@ const main = async () => {
     config.values.runtime?.app?.env?.DX_HOST
       ? undefined
       : () =>
-          new SharedWorker(new URL('@dxos/client/shared-worker', import.meta.url), {
+          new SharedWorker(new URL('./shared-worker', import.meta.url), {
             type: 'module',
             name: 'dxos-client-worker',
           }),

--- a/packages/apps/composer-app/src/shared-worker.ts
+++ b/packages/apps/composer-app/src/shared-worker.ts
@@ -1,0 +1,22 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+import { initializeAppObservability } from '@dxos/observability';
+
+import { setupConfig } from './config';
+import { appKey } from './constants';
+
+onconnect = async (event) => {
+  // All worker code & imports have been moved behind an async import due to WASM + top-level await breaking the connect even somehow.
+  // See: https://github.com/Menci/vite-plugin-wasm/issues/37
+  const { onconnect } = await import('@dxos/client/worker');
+  await onconnect(event);
+};
+
+const init = async () => {
+  const config = await setupConfig();
+  await initializeAppObservability({ namespace: appKey, config });
+};
+
+void init();

--- a/packages/apps/composer-app/tsconfig.json
+++ b/packages/apps/composer-app/tsconfig.json
@@ -11,7 +11,8 @@
     "module": "ESNext",
     "outDir": "dist",
     "types": [
-      "node"
+      "node",
+      "sharedworker"
     ]
   },
   "exclude": [

--- a/packages/apps/testbench-app/src/main.tsx
+++ b/packages/apps/testbench-app/src/main.tsx
@@ -79,7 +79,7 @@ const main = async () => {
   const createWorker = config.values.runtime?.app?.env?.DX_HOST
     ? undefined
     : () =>
-        new SharedWorker(new URL('@dxos/client/shared-worker', import.meta.url), {
+        new SharedWorker(new URL('./shared-worker', import.meta.url), {
           type: 'module',
           name: 'dxos-client-worker',
         });

--- a/packages/apps/testbench-app/src/shared-worker.ts
+++ b/packages/apps/testbench-app/src/shared-worker.ts
@@ -2,11 +2,9 @@
 // Copyright 2022 DXOS.org
 //
 
-// TODO(wittjosiah): This worker doesn't work with the Vite dev server outside of the monorepo.
-
 onconnect = async (event) => {
   // All worker code & imports have been moved behind an async import due to WASM + top-level await breaking the connect even somehow.
   // See: https://github.com/Menci/vite-plugin-wasm/issues/37
-  const { onconnect } = await import('./onconnect');
+  const { onconnect } = await import('@dxos/client/worker');
   await onconnect(event);
 };

--- a/packages/common/tracing/src/api.ts
+++ b/packages/common/tracing/src/api.ts
@@ -64,10 +64,12 @@ const mark = (name: string) => {
 
 export type SpanOptions = {
   showInBrowserTimeline?: boolean;
+  op?: string;
+  attributes?: Record<string, any>;
 };
 
 const span =
-  ({ showInBrowserTimeline = false }: SpanOptions = {}) =>
+  ({ showInBrowserTimeline = false, op, attributes }: SpanOptions = {}) =>
   (target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<(...args: any) => any>) => {
     const method = descriptor.value!;
 
@@ -78,6 +80,8 @@ const span =
         methodName: propertyKey,
         instance: this,
         showInBrowserTimeline,
+        op,
+        attributes,
       });
 
       const callArgs = span.ctx ? [span.ctx, ...args.slice(1)] : args;

--- a/packages/common/tracing/src/remote/tracing.ts
+++ b/packages/common/tracing/src/remote/tracing.ts
@@ -38,7 +38,7 @@ export class RemoteTracing {
     if (!span.endTs) {
       const remoteSpan = this._tracing.startSpan({
         name: span.methodName,
-        op: span.op,
+        op: span.op ?? 'function',
         attributes: span.attributes,
       });
       this._spanMap.set(span, remoteSpan);

--- a/packages/core/echo/echo-db/src/query/query-state.ts
+++ b/packages/core/echo/echo-db/src/query/query-state.ts
@@ -75,7 +75,8 @@ export class QueryState extends Resource {
     return this._results;
   }
 
-  @trace.span({ showInBrowserTimeline: true })
+  // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/db.md#generic-database-attributes
+  @trace.span({ showInBrowserTimeline: true, op: 'db.query', attributes: { 'db.system': 'echo' } })
   async execQuery(): Promise<QueryRunResult> {
     const filter = Filter.fromProto(this._params.request.filter);
     const beginQuery = performance.now();

--- a/packages/sdk/client/package.json
+++ b/packages/sdk/client/package.json
@@ -57,13 +57,6 @@
       "node": "./dist/lib/node/services/index.cjs",
       "types": "./dist/types/src/services/index.d.ts"
     },
-    "./shared-worker": {
-      "browser": "./dist/lib/browser/worker/shared-worker.mjs",
-      "import": "./dist/lib/browser/worker/shared-worker.mjs",
-      "require": "./dist/lib/node/worker/shared-worker.cjs",
-      "node": "./dist/lib/node/worker/shared-worker.cjs",
-      "types": "./dist/types/src/worker/shared-worker.d.ts"
-    },
     "./testing": {
       "browser": "./dist/lib/browser/testing/index.mjs",
       "import": "./dist/lib/browser/testing/index.mjs",

--- a/packages/sdk/client/project.json
+++ b/packages/sdk/client/project.json
@@ -20,7 +20,6 @@
           "packages/sdk/client/src/services/index.ts",
           "packages/sdk/client/src/testing/index.ts",
           "packages/sdk/client/src/worker/index.ts",
-          "packages/sdk/client/src/worker/shared-worker.ts"
         ]
       }
     },

--- a/packages/sdk/client/src/services/worker-client-services.ts
+++ b/packages/sdk/client/src/services/worker-client-services.ts
@@ -166,7 +166,11 @@ const mapLogMeta = (meta: LogEntry.Meta | undefined): CallMetadata | undefined =
     meta && {
       F: meta.file,
       L: meta.line,
-      S: meta.scope,
+      S: {
+        ...meta.scope,
+        remoteSessionId: meta.scope?.hostSessionId,
+        hostSessionId: undefined,
+      },
     }
   );
 };

--- a/packages/sdk/observability/src/sentry/sentry-log-processor.ts
+++ b/packages/sdk/observability/src/sentry/sentry-log-processor.ts
@@ -16,7 +16,8 @@ export class SentryLogProcessor {
 
   public readonly logProcessor: LogProcessor = (config: LogConfig, entry: LogEntry) => {
     const { level, meta, error } = entry;
-    if (!shouldLog(entry, config.captureFilters)) {
+    // Don't forward logs from remote sessions.
+    if (!shouldLog(entry, config.captureFilters) || meta?.S?.remoteSessionId) {
       return;
     }
     if (entry.level !== LogLevel.WARN && entry.level !== LogLevel.ERROR) {


### PR DESCRIPTION
- hooks up sentry in shared worker
- stops re-emitted logs in app from being forwarded to sentry
