### PR TITLE
chore(composer-app): address worker startup issue

### DIFF
--- a/packages/apps/composer-app/src/shared-worker.ts
+++ b/packages/apps/composer-app/src/shared-worker.ts
@@ -2,21 +2,17 @@
 // Copyright 2022 DXOS.org
 //
 
-import { initializeAppObservability } from '@dxos/observability';
-
-import { setupConfig } from './config';
-import { appKey } from './constants';
+// NOTE: Shared worker doesn't support top-level imports currently.
+// All worker code & imports have been moved behind an async import due to WASM
+// + top-level await breaking the connect even somehow.
+// See: https://github.com/Menci/vite-plugin-wasm/issues/37
 
 onconnect = async (event) => {
-  // All worker code & imports have been moved behind an async import due to WASM + top-level await breaking the connect even somehow.
-  // See: https://github.com/Menci/vite-plugin-wasm/issues/37
   const { onconnect } = await import('@dxos/client/worker');
+  const { initializeAppObservability } = await import('@dxos/observability');
+  const { setupConfig } = await import('./config');
+  const { appKey } = await import('./constants');
+  // Don't block on observability setup.
+  void setupConfig().then((config) => initializeAppObservability({ namespace: appKey, config }));
   await onconnect(event);
 };
-
-const init = async () => {
-  const config = await setupConfig();
-  await initializeAppObservability({ namespace: appKey, config });
-};
-
-void init();


### PR DESCRIPTION
top level imports in shared worker cause onconnect not to fire once app is bundled
