### PR TITLE
feat(cli): list schema

### DIFF
--- a/packages/apps/plugins/plugin-debug/src/components/SchemaList.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/SchemaList.tsx
@@ -22,8 +22,8 @@ export const SchemaList: FC<{ space: Space; onCreate?: (schema: any /* Schema */
 }) => {
   const [schemaCount, setSchemaCount] = useState<Record<string, number>>({});
   const [data, setData] = useState<SchemaRecord[]>([]);
-  void space.db.schemaRegistry
-    .getAll()
+  void space.db.schema
+    .listDynamic()
     .then((objects) => {
       setData(
         objects

--- a/packages/apps/plugins/plugin-explorer/src/components/Graph/graph-model.ts
+++ b/packages/apps/plugins/plugin-explorer/src/components/Graph/graph-model.ts
@@ -61,7 +61,7 @@ export class SpaceGraphModel extends GraphModel<EchoGraphNode> {
           this._objects = objects;
           this._graph.nodes = objects.map((object) => {
             if (object instanceof StoredEchoSchema) {
-              const effectSchema = space.db.schemaRegistry.getById(object.id)!;
+              const effectSchema = space.db.schema.getById(object.id)!;
               return { type: 'schema', id: object.id, schema: effectSchema.schema };
             }
             return { type: 'echo-object', id: object.id, object };

--- a/packages/apps/plugins/plugin-function/src/components/TriggerEditor.tsx
+++ b/packages/apps/plugins/plugin-function/src/components/TriggerEditor.tsx
@@ -46,8 +46,8 @@ export const TriggerEditor = ({ space, trigger }: { space: Space; trigger: Funct
   const fn = useMemo(() => query.find((fn) => fn.uri === trigger.function), [trigger.function, query]);
 
   useEffect(() => {
-    void space.db.schemaRegistry
-      .getAll()
+    void space.db.schema
+      .listDynamic()
       .then((schemas) => {
         // TODO(Zan): We should solve double adding of stored schemas in the schema registry.
         state.schemas = distinctBy([...state.schemas, ...schemas], (schema) => schema.typename).sort((a, b) =>

--- a/packages/apps/plugins/plugin-gpt/src/analyzer.ts
+++ b/packages/apps/plugins/plugin-gpt/src/analyzer.ts
@@ -27,7 +27,7 @@ export class GptAnalyzer {
   }
 
   async exec(space: Space, document: DocumentType) {
-    const schemas = await space.db.schemaRegistry.getAll();
+    const schemas = await space.db.schema.listDynamic();
     const text = document.content?.content;
     log.info('analyzing...', { length: text?.length, schema: schemas.length });
     if (!text?.length || !schemas.length) {

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -190,17 +190,9 @@ export const SpacePlugin = ({
             return;
           }
 
-          // TODO(y): Remove after the demo.
-          const migrateSpaceParam = 'migrateSpace';
-          if (searchParams.get(migrateSpaceParam) === 'true') {
-            await space.waitUntilReady();
-            await Migrations.migrate(space);
-          }
-
           const url = new URL(window.location.href);
           const params = Array.from(url.searchParams.entries());
           const [name] = params.find(([_, value]) => value === spaceInvitationCode) ?? [null, null];
-          url.searchParams.delete(migrateSpaceParam);
           if (name) {
             url.searchParams.delete(name);
             history.replaceState({}, document.title, url.href);

--- a/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
@@ -52,7 +52,7 @@ export const ObjectTable = ({ table, role, stickyHeader }: ObjectTableProps) => 
   const [schemas, setSchemas] = useState<DynamicEchoSchema[]>([]);
   useEffect(() => {
     if (space) {
-      void space.db.schemaRegistry.getAll().then(setSchemas).catch();
+      void space.db.schema.listDynamic().then(setSchemas).catch();
     }
   }, [showSettings, space]);
 

--- a/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/ObjectTable/ObjectTable.tsx
@@ -40,7 +40,7 @@ export const ObjectTable = ({ table, role, stickyHeader }: ObjectTableProps) => 
       }
 
       if (!table.schema) {
-        table.schema = space.db.schemaRegistry.add(makeStarterTableSchema());
+        table.schema = space.db.schema.add(makeStarterTableSchema());
         updateTableProp(table.props, 'title', { id: 'title', label: 'Title' });
       }
 

--- a/packages/apps/plugins/plugin-table/src/components/TableSettings/TableSettings.stories.tsx
+++ b/packages/apps/plugins/plugin-table/src/components/TableSettings/TableSettings.stories.tsx
@@ -36,7 +36,7 @@ const Story = () => {
     }
 
     setTable(space.db.add(create(TableType, { title: 'Table', props: [] })));
-    void space.db.schemaRegistry.getAll().then(setSchemas).catch();
+    void space.db.schema.listDynamic().then(setSchemas).catch();
   }, []);
 
   const handleClose = (success: boolean) => {

--- a/packages/core/echo/echo-db/src/database.ts
+++ b/packages/core/echo/echo-db/src/database.ts
@@ -31,8 +31,7 @@ export type GetObjectByIdOptions = {
 export interface EchoDatabase {
   get spaceKey(): PublicKey;
 
-  // TODO(burdon): Should this be public?
-  get schemaRegistry(): DynamicSchemaRegistry;
+  get schema(): DynamicSchemaRegistry;
 
   /**
    * All loaded objects.
@@ -109,7 +108,7 @@ export class EchoDatabaseImpl extends Resource implements EchoDatabase {
    */
   _automerge: AutomergeDb;
 
-  public readonly schemaRegistry: DynamicSchemaRegistry;
+  public readonly schema: DynamicSchemaRegistry;
 
   private _rootUrl: string | undefined = undefined;
 
@@ -123,7 +122,7 @@ export class EchoDatabaseImpl extends Resource implements EchoDatabase {
     super();
 
     this._automerge = new AutomergeDb(params.graph, params.automergeContext, params.spaceKey);
-    this.schemaRegistry = new DynamicSchemaRegistry(this);
+    this.schema = new DynamicSchemaRegistry(this);
   }
 
   get graph(): Hypergraph {
@@ -217,7 +216,7 @@ export class EchoDatabaseImpl extends Resource implements EchoDatabase {
       const schema = getSchema(obj);
 
       if (schema != null) {
-        if (!this.schemaRegistry.isRegistered(schema) && !this.graph.schemaRegistry.hasSchema(schema)) {
+        if (!this.schema.isRegistered(schema) && !this.graph.schemaRegistry.hasSchema(schema)) {
           throw createSchemaNotRegisteredError(schema);
         }
       }

--- a/packages/core/echo/echo-db/src/dynamic-schema-registry.test.ts
+++ b/packages/core/echo/echo-db/src/dynamic-schema-registry.test.ts
@@ -128,7 +128,11 @@ describe('schema registry', () => {
     const listed = await db.schema.list();
     expect(listed.length).to.eq(3);
     expect(listed.slice(0, 2)).to.deep.eq([makeStaticSchema(StoredEchoSchema), makeStaticSchema(TestSchemaClass)]);
-    expect(listed[2]).to.deep.contain({ typename: storedSchema.typename, version: storedSchema.version });
+    expect(listed[2]).to.deep.contain({
+      storedSchemaId: storedSchema.id,
+      typename: storedSchema.typename,
+      version: storedSchema.version,
+    });
     const dynamicSchema = registry.getById(storedSchema.id)!;
     expect(listed[2].schema.ast).to.deep.eq(dynamicSchema.schema.ast);
   });

--- a/packages/core/echo/echo-db/src/dynamic-schema-registry.test.ts
+++ b/packages/core/echo/echo-db/src/dynamic-schema-registry.test.ts
@@ -129,7 +129,7 @@ describe('schema registry', () => {
     expect(listed.length).to.eq(3);
     expect(listed.slice(0, 2)).to.deep.eq([makeStaticSchema(StoredEchoSchema), makeStaticSchema(TestSchemaClass)]);
     expect(listed[2]).to.deep.contain({
-      storedSchemaId: storedSchema.id,
+      id: storedSchema.id,
       typename: storedSchema.typename,
       version: storedSchema.version,
     });

--- a/packages/core/echo/echo-db/src/dynamic-schema-registry.ts
+++ b/packages/core/echo/echo-db/src/dynamic-schema-registry.ts
@@ -72,7 +72,7 @@ export class DynamicSchemaRegistry {
     const storedSnapshots = storedSchemas.map((storedSchema) => {
       const schema = new DynamicEchoSchema(storedSchema);
       return {
-        storedSchemaId: storedSchema.id,
+        id: storedSchema.id,
         typename: schema.typename,
         version: storedSchema.version,
         schema: schema.schema,

--- a/packages/core/echo/echo-db/src/dynamic-schema-registry.ts
+++ b/packages/core/echo/echo-db/src/dynamic-schema-registry.ts
@@ -72,6 +72,7 @@ export class DynamicSchemaRegistry {
     const storedSnapshots = storedSchemas.map((storedSchema) => {
       const schema = new DynamicEchoSchema(storedSchema);
       return {
+        storedSchemaId: storedSchema.id,
         typename: schema.typename,
         version: storedSchema.version,
         schema: schema.schema,

--- a/packages/core/echo/echo-db/src/dynamic-schema-registry.ts
+++ b/packages/core/echo/echo-db/src/dynamic-schema-registry.ts
@@ -5,7 +5,13 @@
 import type * as S from '@effect/schema/Schema';
 
 import { type UnsubscribeCallback } from '@dxos/async';
-import { type EchoObjectAnnotation, EchoObjectAnnotationId, getEchoObjectAnnotation } from '@dxos/echo-schema';
+import {
+  type EchoObjectAnnotation,
+  EchoObjectAnnotationId,
+  getEchoObjectAnnotation,
+  makeStaticSchema,
+  type StaticSchema,
+} from '@dxos/echo-schema';
 import { DynamicEchoSchema, StoredEchoSchema, create, effectToJsonSchema } from '@dxos/echo-schema';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
@@ -61,7 +67,21 @@ export class DynamicSchemaRegistry {
     return this._schemaByType.get(typename);
   }
 
-  public async getAll(): Promise<DynamicEchoSchema[]> {
+  public async list(): Promise<StaticSchema[]> {
+    const { objects: storedSchemas } = await this.db.query(Filter.schema(StoredEchoSchema)).run();
+    const storedSnapshots = storedSchemas.map((storedSchema) => {
+      const schema = new DynamicEchoSchema(storedSchema);
+      return {
+        typename: schema.typename,
+        version: storedSchema.version,
+        schema: schema.schema,
+      } satisfies StaticSchema;
+    });
+    const runtimeSnapshots = this.db.graph.schemaRegistry.schemas.map(makeStaticSchema);
+    return runtimeSnapshots.concat(storedSnapshots);
+  }
+
+  public async listDynamic(): Promise<DynamicEchoSchema[]> {
     return (await this.db.query(Filter.schema(StoredEchoSchema)).run()).objects.map((stored) => {
       return this._register(stored);
     });

--- a/packages/core/echo/echo-db/src/dynamic-schema.test.ts
+++ b/packages/core/echo/echo-db/src/dynamic-schema.test.ts
@@ -43,7 +43,7 @@ describe('DynamicSchema', () => {
       field: S.String,
     }) {}
 
-    instanceWithSchemaRef.schema = db.schemaRegistry.add(GeneratedSchema);
+    instanceWithSchemaRef.schema = db.schema.add(GeneratedSchema);
     const schemaWithId = GeneratedSchema.annotations({
       [EchoObjectAnnotationId]: { ...TEST_SCHEMA_TYPE, storedSchemaId: instanceWithSchemaRef.schema?.id },
     });
@@ -57,7 +57,7 @@ describe('DynamicSchema', () => {
   test('create echo object with DynamicSchema', async () => {
     const { db } = await setupTest();
     class GeneratedSchema extends TypedObject(TEST_SCHEMA_TYPE)({ field: S.String }) {}
-    const schema = db.schemaRegistry.add(GeneratedSchema);
+    const schema = db.schema.add(GeneratedSchema);
     const instanceWithSchemaRef = db.add(create(ClassWithSchemaField, { schema }));
 
     const schemaWithId = GeneratedSchema.annotations({
@@ -68,7 +68,7 @@ describe('DynamicSchema', () => {
 
   test('can be used to create objects', async () => {
     const { db } = await setupTest();
-    const schema = db.schemaRegistry.add(GeneratedEmptySchema);
+    const schema = db.schema.add(GeneratedEmptySchema);
     const object = create(schema, {});
     schema.addColumns({ field1: S.String });
     object.field1 = 'works';
@@ -91,7 +91,7 @@ describe('DynamicSchema', () => {
 
   test('getTypeReference', async () => {
     const { db } = await setupTest();
-    const schema = db.schemaRegistry.add(GeneratedEmptySchema);
+    const schema = db.schema.add(GeneratedEmptySchema);
     expect(getTypeReference(schema)?.itemId).to.eq(schema.id);
   });
 

--- a/packages/core/echo/echo-db/src/echo-handler/echo-handler.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/echo-handler.ts
@@ -177,7 +177,7 @@ export class EchoReactiveHandler implements ReactiveHandler<ProxyTarget> {
     // object instanceof StoredEchoSchema requires database to lookup schema
     const database = target[symbolInternals].database;
     if (object != null && database && object instanceof StoredEchoSchema) {
-      return database.schemaRegistry.register(object);
+      return database.schema.register(object);
     }
     return object;
   }
@@ -341,7 +341,7 @@ export class EchoReactiveHandler implements ReactiveHandler<ProxyTarget> {
       return undefined;
     }
 
-    return target[symbolInternals].database.schemaRegistry.getById(typeReference.itemId);
+    return target[symbolInternals].database.schema.getById(typeReference.itemId);
   }
 
   getTypeReference(target: ProxyTarget): Reference | undefined {

--- a/packages/core/echo/echo-db/src/query/filter.test.ts
+++ b/packages/core/echo/echo-db/src/query/filter.test.ts
@@ -123,7 +123,7 @@ describe('Filter', () => {
     class GeneratedSchema extends TypedObject({ typename: 'dynamic', version: '0.1.0' })({ title: S.String }) {}
 
     const { db } = await builder.createDatabase();
-    const schema = db.schemaRegistry.add(GeneratedSchema);
+    const schema = db.schema.add(GeneratedSchema);
 
     const obj = db.add(create(schema, { title: 'test' }));
 

--- a/packages/core/echo/echo-generator/src/generator.ts
+++ b/packages/core/echo/echo-generator/src/generator.ts
@@ -72,9 +72,9 @@ export class SpaceObjectGenerator<T extends string> extends TestObjectGenerator<
     // TODO(burdon): Map initially are objects that have not been added to the space.
     // Merge existing schema in space with defaults.
     Object.entries<DynamicEchoSchema>(schemaMap).forEach(([type, dynamicSchema]) => {
-      let schema = this._space.db.schemaRegistry.getRegisteredByTypename(type);
+      let schema = this._space.db.schema.getRegisteredByTypename(type);
       if (schema == null) {
-        schema = this._space.db.schemaRegistry.add(dynamicSchema.schema);
+        schema = this._space.db.schema.add(dynamicSchema.schema);
       }
       this.setSchema(type as T, schema);
     });
@@ -83,9 +83,9 @@ export class SpaceObjectGenerator<T extends string> extends TestObjectGenerator<
   addSchemas() {
     const result: DynamicEchoSchema[] = [];
     this.schemas.forEach((schema) => {
-      const existing = this._space.db.schemaRegistry.getRegisteredByTypename(schema.typename);
+      const existing = this._space.db.schema.getRegisteredByTypename(schema.typename);
       if (existing == null) {
-        result.push(this._space.db.schemaRegistry.add(schema.schema));
+        result.push(this._space.db.schema.add(schema.schema));
       } else {
         result.push(existing);
       }

--- a/packages/core/echo/echo-schema/src/dynamic/index.ts
+++ b/packages/core/echo/echo-schema/src/dynamic/index.ts
@@ -4,3 +4,4 @@
 
 export * from './dynamic-schema';
 export * from './stored-schema';
+export * from './static-schema';

--- a/packages/core/echo/echo-schema/src/dynamic/static-schema.ts
+++ b/packages/core/echo/echo-schema/src/dynamic/static-schema.ts
@@ -1,0 +1,24 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import type * as S from '@effect/schema/Schema';
+
+import { getEchoObjectAnnotation } from '../annotations';
+import { requireTypeReference } from '../getter';
+
+export type StaticSchema = {
+  typename: string;
+  version: string;
+  schema: S.Schema<any>;
+};
+
+export const makeStaticSchema = (schema: S.Schema<any>): StaticSchema => {
+  requireTypeReference(schema);
+  const schemaAnnotation = getEchoObjectAnnotation(schema)!;
+  return {
+    typename: schemaAnnotation.typename,
+    version: schemaAnnotation.version,
+    schema,
+  } satisfies StaticSchema;
+};

--- a/packages/core/echo/echo-schema/src/dynamic/static-schema.ts
+++ b/packages/core/echo/echo-schema/src/dynamic/static-schema.ts
@@ -8,6 +8,7 @@ import { getEchoObjectAnnotation } from '../annotations';
 import { requireTypeReference } from '../getter';
 
 export type StaticSchema = {
+  storedSchemaId?: string;
   typename: string;
   version: string;
   schema: S.Schema<any>;

--- a/packages/core/echo/echo-schema/src/dynamic/static-schema.ts
+++ b/packages/core/echo/echo-schema/src/dynamic/static-schema.ts
@@ -8,7 +8,7 @@ import { getEchoObjectAnnotation } from '../annotations';
 import { requireTypeReference } from '../getter';
 
 export type StaticSchema = {
-  storedSchemaId?: string;
+  id?: string;
   typename: string;
   version: string;
   schema: S.Schema<any>;

--- a/packages/core/echo/echo-schema/src/getter.ts
+++ b/packages/core/echo/echo-schema/src/getter.ts
@@ -73,7 +73,7 @@ export const requireTypeReference = (schema: S.Schema<any>): Reference => {
   const typeReference = getTypeReference(schema);
   if (typeReference == null) {
     // TODO(burdon): Catalog user-facing errors (this is too verbose).
-    throw new Error('Schema must have a valid annotation: MyTypeSchema.pipe(R.echoObject("MyType", "1.0.0"))');
+    throw new Error('Schema must have a valid annotation: MyTypeSchema.pipe(echoObject("MyType", "1.0.0"))');
   }
 
   return typeReference;

--- a/packages/devtools/cli/src/commands/space/schema/list.ts
+++ b/packages/devtools/cli/src/commands/space/schema/list.ts
@@ -46,7 +46,7 @@ const createTypenameFilter = (typenameFilter?: string) => {
 
 const printSchema = (schemas: StaticSchema[], flags: TableFlags = {}) => {
   const format = {
-    storedSchemaId: {
+    id: {
       header: 'echoId',
       truncate: true,
     },

--- a/packages/devtools/cli/src/commands/space/schema/list.ts
+++ b/packages/devtools/cli/src/commands/space/schema/list.ts
@@ -6,7 +6,7 @@ import { ux } from '@oclif/core';
 
 import { FLAG_SPACE_KEYS } from '@dxos/cli-base';
 import { table, type TableFlags, TABLE_FLAGS } from '@dxos/cli-base';
-import { FunctionDef, FunctionTrigger } from '@dxos/functions';
+import { type StaticSchema } from '@dxos/echo-schema';
 
 import { BaseCommand } from '../../../base';
 
@@ -24,28 +24,21 @@ export default class List extends BaseCommand<typeof List> {
   };
 
   async run(): Promise<any> {
-    const { space: spaceKeys } = this.flags;
-    await this.execWithClient(async ({ client }) => {
-      // TODO(burdon): Registered by plugin?
-      client.addSchema(FunctionDef, FunctionTrigger);
+    const { key } = this.args;
+    return await this.execWithClient(async ({ client }) => {
+      const space = await this.getSpace(client, key);
+      const schemas = await space.db.schema.list();
+      printSchema(schemas, this.flags);
     });
-
-    return await this.execWithSpace(
-      async ({ space }) => {
-        const schemas = await space.db.schema.list();
-        printSchema(schemas, this.flags);
-      },
-      { spaceKeys },
-    );
   }
 }
 
-const printSchema = (schema: any[], flags: TableFlags = {}) => {
+const printSchema = (schemas: StaticSchema[], flags: TableFlags = {}) => {
   return ux.stdout(
     table(
-      schema,
+      schemas,
       {
-        id: {}, // TODO(burdon): undefined.
+        storedSchemaId: { truncate: true }, // TODO(burdon): undefined.
         typename: {}, // TODO(burdon): Sometimes undefined.
         version: {}, // TODO(burdon): undefined.
       },

--- a/packages/devtools/cli/src/commands/space/schema/list.ts
+++ b/packages/devtools/cli/src/commands/space/schema/list.ts
@@ -28,19 +28,11 @@ export default class List extends BaseCommand<typeof List> {
     await this.execWithClient(async ({ client }) => {
       // TODO(burdon): Registered by plugin?
       client.addSchema(FunctionDef, FunctionTrigger);
-
-      // TODO(burdon): Doesn't stringify (just returns "null").
-      // TODO(burdon): Reconcile addType with schema.
-      //  space.db.schema.get/list()
-      //  rename runtimeSchemaRegistry
-      const schemas = client.experimental.graph.schemaRegistry.schemas;
-      console.log(schemas.map((s2) => s2));
-      printSchema(schemas, this.flags);
     });
 
     return await this.execWithSpace(
       async ({ space }) => {
-        const schemas = await space.db.schemaRegistry.getAll();
+        const schemas = await space.db.schema.list();
         printSchema(schemas, this.flags);
       },
       { spaceKeys },

--- a/packages/devtools/cli/src/commands/space/schema/list.ts
+++ b/packages/devtools/cli/src/commands/space/schema/list.ts
@@ -2,17 +2,19 @@
 // Copyright 2022 DXOS.org
 //
 
-import { ux } from '@oclif/core';
+import { Flags, ux } from '@oclif/core';
 
 import { FLAG_SPACE_KEYS } from '@dxos/cli-base';
 import { table, type TableFlags, TABLE_FLAGS } from '@dxos/cli-base';
-import { type StaticSchema } from '@dxos/echo-schema';
+import { effectToJsonSchema, type StaticSchema } from '@dxos/echo-schema';
 
 import { BaseCommand } from '../../../base';
 
 // TODO(burdon): Option to output JSON schema.
 
 export default class List extends BaseCommand<typeof List> {
+  static override enableJsonFlag = true;
+
   static {
     this.description = 'List schema.';
   }
@@ -21,28 +23,42 @@ export default class List extends BaseCommand<typeof List> {
     ...BaseCommand.flags,
     ...TABLE_FLAGS,
     ...FLAG_SPACE_KEYS,
+    typename: Flags.string({ default: undefined, description: 'Filter objects by typename.' }),
   };
 
   async run(): Promise<any> {
     const { key } = this.args;
     return await this.execWithClient(async ({ client }) => {
       const space = await this.getSpace(client, key);
-      const schemas = await space.db.schema.list();
+      const typenameFilter = createTypenameFilter(this.flags.typename);
+      const schemas = (await space.db.schema.list()).filter(typenameFilter);
       printSchema(schemas, this.flags);
     });
   }
 }
 
+const createTypenameFilter = (typenameFilter?: string) => {
+  if (!typenameFilter) {
+    return () => true;
+  }
+  return (schema: StaticSchema) => schema.typename.toLowerCase().includes(typenameFilter.toLowerCase());
+};
+
 const printSchema = (schemas: StaticSchema[], flags: TableFlags = {}) => {
-  return ux.stdout(
-    table(
-      schemas,
-      {
-        storedSchemaId: { truncate: true }, // TODO(burdon): undefined.
-        typename: {}, // TODO(burdon): Sometimes undefined.
-        version: {}, // TODO(burdon): undefined.
-      },
-      flags,
-    ),
-  );
+  const format = {
+    storedSchemaId: {
+      header: 'echoId',
+      truncate: true,
+    },
+    typename: {},
+    version: {},
+  };
+  if (flags.extended) {
+    for (const schema of schemas) {
+      ux.stdout(table([schema], format, flags));
+      console.log(effectToJsonSchema(schema.schema));
+    }
+  } else {
+    ux.stdout(table(schemas, format, flags));
+  }
 };

--- a/packages/devtools/cli/src/commands/space/share.ts
+++ b/packages/devtools/cli/src/commands/space/share.ts
@@ -72,7 +72,6 @@ export default class Share extends BaseCommand<typeof Share> {
             if (this.flags.open) {
               const url = new URL(this.flags.host);
               url.searchParams.append('spaceInvitationCode', InvitationEncoder.encode(invitation));
-              url.searchParams.append('migrateSpace', 'true'); // TODO(burdon): Remove.
               spawn('open', [url.toString()]);
             } else {
               this.log(chalk`\n{blue Invitation}: ${invitationCode}`);

--- a/packages/experimental/agent-functions/src/functions/github/handler.ts
+++ b/packages/experimental/agent-functions/src/functions/github/handler.ts
@@ -42,14 +42,14 @@ export const handler = subscriptionHandler(async ({ event }) => {
 
       // Create organization if failed to query.
       if (!project.org && repoData.organization) {
-        const orgSchema = space.db.schemaRegistry.getRegisteredByTypename(TestSchemaType.organization);
+        const orgSchema = space.db.schema.getRegisteredByTypename(TestSchemaType.organization);
         invariant(orgSchema, 'Missing organization schema.');
         project.org = create(orgSchema, { name: repoData.organization?.login });
         getMeta(project.org).keys.push({ source: 'github.com', id: String(repoData.organization?.id) });
       }
     }
 
-    const contactSchema = space.db.schemaRegistry.getRegisteredByTypename(TestSchemaType.contact);
+    const contactSchema = space.db.schema.getRegisteredByTypename(TestSchemaType.contact);
     invariant(contactSchema);
 
     //

--- a/packages/experimental/agent-functions/src/functions/gpt/context.ts
+++ b/packages/experimental/agent-functions/src/functions/gpt/context.ts
@@ -43,7 +43,7 @@ export const createContext = async (
 
   // Create schema registry.
   // TODO(burdon): Filter?
-  const schemaList = await space.db.schemaRegistry.getAll();
+  const schemaList = await space.db.schema.listDynamic();
   const schema = schemaList.reduce<Map<string, DynamicEchoSchema>>((map, schema) => {
     const jsonSchema = effectToJsonSchema(schema);
     if (jsonSchema.title) {

--- a/packages/experimental/agent-functions/src/functions/gpt/processor.ts
+++ b/packages/experimental/agent-functions/src/functions/gpt/processor.ts
@@ -244,7 +244,7 @@ export class RequestProcessor {
         }
 
         // TODO(dmaretskyi): Convert to the new dynamic schema API.
-        const schemas = await space.db.schemaRegistry.getAll();
+        const schemas = await space.db.schema.listDynamic();
         const schema = schemas.find((schema) => schema.typename === type);
         if (schema) {
           // TODO(burdon): Use effect schema to generate JSON schema.


### PR DESCRIPTION
### Details

Schema-related API changes:
* `db.schemaRegistry` -> `db.schema`
* `schemaRegistry.getAll()` -> `schemaRegistry.listDynamic()`
* Introduced `StaticSchema` type for immutable schema (both runtime and stored)
* Introduced `db.schema.list()` method for retrieving all static schemas

CLI-related changes:
* `dx space schema list` shows space picker if no space provided and lists all schemas.
* `dx space schema list --typename prop` lists schemas with "prop" in typename (case-insensitive).
* `dx space schema list --extended` prints schema json representation.

<img width="534" alt="image" src="https://github.com/dxos/dxos/assets/9644546/781719a8-1006-4c2b-b9de-6b5d1f4e952d">
