### PR TITLE
fix: sketch serializer

### DIFF
--- a/packages/apps/types/src/serializer/clone.ts
+++ b/packages/apps/types/src/serializer/clone.ts
@@ -18,5 +18,5 @@ export const cloneObject = async (object: Expando): Promise<Expando> => {
   const serializer = serializers[typename] ?? serializers.default;
   invariant(serializer, `No serializer for type: ${typename}`);
   const content = await serializer.serialize({ object, serializers });
-  return serializer.deserialize({ content, serializers, preserveId: false });
+  return serializer.deserialize({ content, serializers, newId: true });
 };

--- a/packages/apps/types/src/serializer/clone.ts
+++ b/packages/apps/types/src/serializer/clone.ts
@@ -11,12 +11,12 @@ import { TypeOfExpando } from './types';
 /**
  * @deprecated Workaround for ECHO not supporting clone.
  */
-// TODO(burdon): Remove?
+// TODO(burdon): Remove.
 export const cloneObject = async (object: Expando): Promise<Expando> => {
   const schema = getSchema(object);
   const typename = schema ? getEchoObjectAnnotation(schema)?.typename ?? TypeOfExpando : TypeOfExpando;
   const serializer = serializers[typename] ?? serializers.default;
   invariant(serializer, `No serializer for type: ${typename}`);
   const content = await serializer.serialize({ object, serializers });
-  return serializer.deserialize({ content, serializers });
+  return serializer.deserialize({ content, serializers, preserveId: false });
 };

--- a/packages/apps/types/src/serializer/serializers/document.ts
+++ b/packages/apps/types/src/serializer/serializers/document.ts
@@ -45,14 +45,14 @@ export const serializer: TypedObjectSerializer<DocumentType> = {
     return `${text}\n\n${footnote}`;
   },
 
-  deserialize: async ({ content, file, object: existingDoc, preserveId }) => {
+  deserialize: async ({ content, file, object: existingDoc, newId }) => {
     if (existingDoc instanceof DocumentType) {
       existingDoc.content!.content = content;
       return existingDoc;
     } else {
       const doc = createEchoObject(create(DocumentType, { content: create(TextV0Type, { content }), comments: [] }));
 
-      if (file && preserveId) {
+      if (file && !newId) {
         const core = getObjectCore(doc);
         core.id = file.id;
       }

--- a/packages/apps/types/src/serializer/serializers/document.ts
+++ b/packages/apps/types/src/serializer/serializers/document.ts
@@ -45,14 +45,14 @@ export const serializer: TypedObjectSerializer<DocumentType> = {
     return `${text}\n\n${footnote}`;
   },
 
-  deserialize: async ({ content, file, object: existingDoc }) => {
+  deserialize: async ({ content, file, object: existingDoc, preserveId }) => {
     if (existingDoc instanceof DocumentType) {
       existingDoc.content!.content = content;
       return existingDoc;
     } else {
       const doc = createEchoObject(create(DocumentType, { content: create(TextV0Type, { content }), comments: [] }));
 
-      if (file) {
+      if (file && preserveId) {
         const core = getObjectCore(doc);
         core.id = file.id;
       }

--- a/packages/apps/types/src/serializer/serializers/index.ts
+++ b/packages/apps/types/src/serializer/serializers/index.ts
@@ -2,14 +2,13 @@
 // Copyright 2024 DXOS.org
 //
 
-// TODO(burdon): Fix import ordering.
 import { type TypedObjectSerializer, jsonSerializer } from './default';
 import { serializer as document } from './document';
-import { serializer as thread } from './thread';
-import { DocumentType, ThreadType } from '../../schema';
+import { serializer as sketch } from './sketch';
+import { DocumentType, SketchType } from '../../schema';
 
 export const serializers: Record<string, TypedObjectSerializer> = {
   [DocumentType.typename]: document,
-  [ThreadType.typename]: thread,
+  [SketchType.typename]: sketch,
   default: jsonSerializer,
 };

--- a/packages/apps/types/src/serializer/serializers/sketch.ts
+++ b/packages/apps/types/src/serializer/serializers/sketch.ts
@@ -15,11 +15,12 @@ export const serializer: TypedObjectSerializer<SketchType> = {
 
   serialize: async ({ object }): Promise<string> => {
     // TODO(wittjosiah): Implement `toJSON` method?
-    const sketch = { ...object, data: { ...object.data } };
+    const data = await loadObjectReferences(object, (s) => s.data);
+    const sketch = { ...object, data: { ...data } };
     return JSON.stringify(sketch, null, 2);
   },
 
-  deserialize: async ({ content, object: existingSketch, preserveId }) => {
+  deserialize: async ({ content, object: existingSketch, newId }) => {
     const parsed = JSON.parse(content);
 
     if (existingSketch instanceof SketchType) {
@@ -31,7 +32,7 @@ export const serializer: TypedObjectSerializer<SketchType> = {
       const data = create(Expando, {});
       const sketch = createEchoObject(create(SketchType, { title: parsed.title, data }));
 
-      if (preserveId) {
+      if (!newId) {
         const core = getObjectCore(sketch);
         core.id = parsed.id;
 

--- a/packages/apps/types/src/serializer/serializers/sketch.ts
+++ b/packages/apps/types/src/serializer/serializers/sketch.ts
@@ -2,8 +2,10 @@
 // Copyright 2024 DXOS.org
 //
 
+import { Expando, loadObjectReferences, createEchoObject, create, getObjectCore } from '@dxos/client/echo';
+
 import { type TypedObjectSerializer, validFilename } from './default';
-import { type SketchType } from '../../schema';
+import { SketchType } from '../../schema';
 
 export const serializer: TypedObjectSerializer<SketchType> = {
   filename: (object) => ({
@@ -12,10 +14,41 @@ export const serializer: TypedObjectSerializer<SketchType> = {
   }),
 
   serialize: async ({ object }): Promise<string> => {
-    throw new Error('Not implemented.');
+    // TODO(wittjosiah): Implement `toJSON` method?
+    const sketch = { ...object, data: { ...object.data } };
+    return JSON.stringify(sketch, null, 2);
   },
 
-  deserialize: async ({ content }) => {
-    throw new Error('Not implemented.');
+  deserialize: async ({ content, object: existingSketch, preserveId }) => {
+    const parsed = JSON.parse(content);
+
+    if (existingSketch instanceof SketchType) {
+      existingSketch.title = parsed.title;
+      const data = await loadObjectReferences(existingSketch, (s) => s.data);
+      setSketchData(data, parsed.data.content);
+      return existingSketch;
+    } else {
+      const data = create(Expando, {});
+      const sketch = createEchoObject(create(SketchType, { title: parsed.title, data }));
+
+      if (preserveId) {
+        const core = getObjectCore(sketch);
+        core.id = parsed.id;
+
+        const dataCore = getObjectCore(data);
+        dataCore.id = parsed.data.id;
+      }
+
+      setSketchData(data, parsed.data.content);
+
+      return sketch;
+    }
   },
+};
+
+const setSketchData = (object: Expando, content: any) => {
+  object.content = {};
+  Object.entries(content).forEach(([key, value]) => {
+    object.content[key] = value;
+  });
 };


### PR DESCRIPTION
During the clone operation only the sketch is serialized and the data isn't included.
Clone needs to not preserve ids right now so that you can copy things back and forth
between spaces and not have it fail because of id collision. Not preserving ids
makes references complicated because you need to update all the references.

The document serializer works because it collapses the references into a flat thing
(markdown) and then rebuilds the object structure afterwards. This does the same thing
but using json for sketch objects.

Resolves #6749 