### PR TITLE
fix(echo): handle peer automerge auth scope changes

### DIFF
--- a/packages/core/echo/echo-pipeline/src/automerge/echo-network-adapter.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/echo-network-adapter.ts
@@ -93,6 +93,7 @@ export class EchoNetworkAdapter extends NetworkAdapter {
       peerId: this.peerId,
       onConnectionOpen: this._onConnectionOpen.bind(this),
       onConnectionClosed: this._onConnectionClosed.bind(this),
+      onConnectionAuthScopeChanged: this._onConnectionAuthScopeChanged.bind(this),
       getContainingSpaceForDocument: this._params.getContainingSpaceForDocument,
     });
   }
@@ -101,7 +102,6 @@ export class EchoNetworkAdapter extends NetworkAdapter {
   async removeReplicator(replicator: EchoReplicator) {
     invariant(this._lifecycleState === LifecycleState.OPEN);
     invariant(this._replicators.has(replicator));
-    ('');
     await replicator.disconnect();
     this._replicators.delete(replicator);
   }
@@ -142,13 +142,18 @@ export class EchoNetworkAdapter extends NetworkAdapter {
     });
 
     log('emit peer-candidate', { peerId: connection.peerId });
-    this.emit('peer-candidate', {
-      peerId: connection.peerId as PeerId,
-      peerMetadata: {
-        // TODO(dmaretskyi): Refactor this.
-        dxos_peerSource: 'EchoNetworkAdapter',
-      } as any,
-    });
+    this._emitPeerCandidate(connection);
+  }
+
+  /**
+   * Trigger doc-synchronizer shared documents set recalculation. Happens on peer-candidate.
+   */
+  private _onConnectionAuthScopeChanged(connection: ReplicatorConnection) {
+    log('Connection auth scope changed', { peerId: connection.peerId });
+    const entry = this._connections.get(connection.peerId as PeerId);
+    invariant(entry);
+    this.emit('peer-disconnected', { peerId: connection.peerId as PeerId });
+    this._emitPeerCandidate(connection);
   }
 
   private _onConnectionClosed(connection: ReplicatorConnection) {
@@ -163,6 +168,16 @@ export class EchoNetworkAdapter extends NetworkAdapter {
     void entry.writer.abort().catch((err) => log.catch(err));
 
     this._connections.delete(connection.peerId as PeerId);
+  }
+
+  private _emitPeerCandidate(connection: ReplicatorConnection) {
+    this.emit('peer-candidate', {
+      peerId: connection.peerId as PeerId,
+      peerMetadata: {
+        // TODO(dmaretskyi): Refactor this.
+        dxos_peerSource: 'EchoNetworkAdapter',
+      } as any,
+    });
   }
 }
 

--- a/packages/core/echo/echo-pipeline/src/automerge/echo-network-adapter.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/echo-network-adapter.ts
@@ -147,6 +147,7 @@ export class EchoNetworkAdapter extends NetworkAdapter {
 
   /**
    * Trigger doc-synchronizer shared documents set recalculation. Happens on peer-candidate.
+   * TODO(y): replace with a proper API call when sharePolicy update becomes supported by automerge-repo
    */
   private _onConnectionAuthScopeChanged(connection: ReplicatorConnection) {
     log('Connection auth scope changed', { peerId: connection.peerId });

--- a/packages/core/echo/echo-pipeline/src/automerge/echo-replicator.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/echo-replicator.ts
@@ -27,6 +27,8 @@ export interface EchoReplicatorContext {
 
   onConnectionClosed(connection: ReplicatorConnection): void;
 
+  onConnectionAuthScopeChanged(connection: ReplicatorConnection): void;
+
   getContainingSpaceForDocument(documentId: string): Promise<PublicKey | null>;
 }
 

--- a/packages/core/echo/echo-pipeline/src/automerge/mesh-echo-replicator.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/mesh-echo-replicator.ts
@@ -59,7 +59,9 @@ export class MeshEchoReplicator implements EchoReplicator {
         log('onRemoteConnected', { peerId: connection.peerId });
         invariant(this._context);
 
-        if (!this._connectionsPerPeer.has(connection.peerId)) {
+        if (this._connectionsPerPeer.has(connection.peerId)) {
+          this._context.onConnectionAuthScopeChanged(connection);
+        } else {
           this._connectionsPerPeer.set(connection.peerId, connection);
           await connection.enable();
           this._context.onConnectionOpen(connection);

--- a/packages/sdk/client/src/testing/utils.ts
+++ b/packages/sdk/client/src/testing/utils.ts
@@ -45,14 +45,16 @@ export const waitForSpace = async (
   return space;
 };
 
+export type CreateInitializedClientsOptions = {
+  config?: Config;
+  storage?: boolean;
+  serviceConfig?: { fastPeerPresenceUpdate?: boolean };
+};
+
 export const createInitializedClientsWithContext = async (
   ctx: Context,
   count: number,
-  options?: {
-    config?: Config;
-    storage?: boolean;
-    serviceConfig?: { fastPeerPresenceUpdate?: boolean };
-  },
+  options?: CreateInitializedClientsOptions,
 ): Promise<Client[]> => {
   const testBuilder = new TestBuilder(options?.config);
   testBuilder.storage = options?.storage ? createStorage({ type: StorageType.RAM }) : undefined;


### PR DESCRIPTION
### Details

Fixes the following scenario:
1. Peers A and B share space 1.
2. A creates a document in space 2. Automerge sharePolicy check forbids to replicate the document.
3. A invites B to space 2, we want the document to be replicated now.

Fixed with a hack where I emit peer-disconnected immediately followed by peer-candidate to refresh doc synchronizer share policies.