### PR TITLE
Fix link to Quick Start

### DIFF
--- a/docs/content/api/@dxos/client/README.md
+++ b/docs/content/api/@dxos/client/README.md
@@ -19,7 +19,7 @@ const client = new Client();
 
 ## Documentation
 
-- [⚡️ Quick Start](https://docs.dxos.org/guide/quick-start)
+- [⚡️ Quick Start](https://docs.dxos.org/guide/getting-started.html)
 - [📖 Developer Guide](https://docs.dxos.org/guide/echo/)
 - [📚 API Reference](https://docs.dxos.org/api/@dxos/client)
 

--- a/packages/apps/testbench-app/src/webrtc/client/peer.ts
+++ b/packages/apps/testbench-app/src/webrtc/client/peer.ts
@@ -157,7 +157,7 @@ export class Peer {
         }
       },
 
-      // When ICE candidate identified (should be send to remote peer) and when ICE gathering finalized.
+      // When ICE candidate identified (should be sent to remote peer) and when ICE gathering finalized.
       // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/icecandidate_event
       onicecandidate: (event) => {
         log.info('connection.onicecandidate', { event });


### PR DESCRIPTION
It seems https://docs.dxos.org/guide/quick-start is a 404