### PR TITLE
[docs] Import create function from @dxos/client/echo

### DIFF
--- a/docs/content/guide/echo/typescript/mutations.md
+++ b/docs/content/guide/echo/typescript/mutations.md
@@ -38,7 +38,7 @@ Without strong types, the generic `Expando` class can be used:
 
 ```tsx file=./snippets/create-objects.ts#L5-
 import { Client } from '@dxos/client';
-import { Expando } from '@dxos/client/echo';
+import { create, Expando } from '@dxos/client/echo';
 
 const client = new Client();
 

--- a/packages/apps/testbench-app/src/webrtc/client/peer.ts
+++ b/packages/apps/testbench-app/src/webrtc/client/peer.ts
@@ -157,7 +157,7 @@ export class Peer {
         }
       },
 
-      // When ICE candidate identified (should be send to remote peer) and when ICE gathering finalized.
+      // When ICE candidate identified (should be sent to remote peer) and when ICE gathering finalized.
       // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/icecandidate_event
       onicecandidate: (event) => {
         log.info('connection.onicecandidate', { event });


### PR DESCRIPTION
It seems the `create` function was undefined in this snippet and @dxos/client/echo does have an export by that name, so that's probably the one to use?