### PR TITLE
fix(mesh): fixed race condition

### DIFF
--- a/packages/core/echo/echo-pipeline/src/automerge/mesh-echo-replicator.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/mesh-echo-replicator.ts
@@ -70,8 +70,8 @@ export class MeshEchoReplicator implements EchoReplicator {
       onRemoteDisconnected: async () => {
         log('onRemoteDisconnected', { peerId: connection.peerId });
         this._context?.onConnectionClosed(connection);
-        await connection.disable();
         this._connectionsPerPeer.delete(connection.peerId);
+        await connection.disable();
         this._connections.delete(connection);
       },
       shouldAdvertize: async (params: ShouldAdvertizeParams) => {


### PR DESCRIPTION
### Details

Fixes the following race condition.

1. `this._context?.onConnectionClosed(connection);` removes connection from network adapter.
2. `await connection.disable();` creates a microtask.
3. Above this block gets executed because we haven't yet updated `_connectionsPerPeer`.
```ts
        if (this._connectionsPerPeer.has(connection.peerId)) {
          this._context.onConnectionAuthScopeChanged(connection);
        }
```
4. `onConnectionAuthScopeChanged` crashes because there's no entry for this connection.

<img width="975" alt="image" src="https://github.com/dxos/dxos/assets/9644546/b7c2def1-a3b7-4e7e-9803-571dea9de24e">
