### PR TITLE
chore: remove rsync from copy_assets.sh

### DIFF
--- a/packages/apps/plugins/plugin-sketch/scripts/copy_assets.sh
+++ b/packages/apps/plugins/plugin-sketch/scripts/copy_assets.sh
@@ -11,4 +11,5 @@ cp -R ${SRC}/fonts ${DEST}
 cp -R ${SRC}/icons ${DEST}
 cp -R ${SRC}/translations ${DEST}
 
-rsync -av --ignore-existing ./assets/ ${DEST}/
+cp -R ./assets/fonts/* ${DEST}/fonts
+cp -R ./assets/icons/icon/* ${DEST}/icons/icon


### PR DESCRIPTION
cloudflare pages does not have rsync available
