### PR TITLE
chore: run assets copy in prebuild

### DIFF
--- a/packages/apps/composer-app/project.json
+++ b/packages/apps/composer-app/project.json
@@ -30,8 +30,7 @@
     "bundle-app": {
       "cache": true,
       "dependsOn": [
-        "^build",
-        "copy"
+        "^build"
       ],
       "executor": "@nx/vite:build",
       "inputs": [
@@ -82,10 +81,7 @@
         "{options.outputPath}"
       ]
     },
-    "copy": {
-      "dependsOn": [
-        "^build"
-      ],
+    "prebuild": {
       "executor": "nx:run-script",
       "options": {
         "script": "copy:assets"
@@ -112,9 +108,6 @@
       }
     },
     "serve": {
-      "dependsOn": [
-        "copy"
-      ],
       "executor": "@nx/vite:dev-server",
       "options": {
         "buildTarget": "composer-app:bundle"

--- a/packages/apps/plugins/plugin-sketch/project.json
+++ b/packages/apps/plugins/plugin-sketch/project.json
@@ -7,13 +7,7 @@
   "sourceRoot": "packages/apps/plugins/plugin-sketch/src",
   "projectType": "library",
   "targets": {
-    "build": {
-      "dependsOn": [
-        "^build",
-        "compile",
-        "copy"
-      ]
-    },
+    "build": {},
     "compile": {
       "options": {
         "entryPoints": [
@@ -25,7 +19,7 @@
         ]
       }
     },
-    "copy": {
+    "prebuild": {
       "executor": "nx:run-script",
       "options": {
         "script": "copy:assets"


### PR DESCRIPTION
copy had caused composer's serve target to depend on dependencies build, slowing down rebuilds
