### PR TITLE
fix(sdk): Focus within iframe when shell opens

### DIFF
--- a/packages/sdk/client/src/services/shell-manager.ts
+++ b/packages/sdk/client/src/services/shell-manager.ts
@@ -59,6 +59,7 @@ export class ShellManager {
     this._display = ShellDisplay.FULLSCREEN;
     this.contextUpdate.emit({ display: this._display });
     await this._shellRpc.rpc.ShellService.setLayout(request, { timeout: RPC_TIMEOUT });
+    // Focus the first focusable element when the iframe has something to display so that keybindings global to the iframe (e.g. Escape) work as expected.
     (
       this._iframeManager.iframe?.contentDocument?.querySelector(
         'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',

--- a/packages/sdk/client/src/services/shell-manager.ts
+++ b/packages/sdk/client/src/services/shell-manager.ts
@@ -59,6 +59,11 @@ export class ShellManager {
     this._display = ShellDisplay.FULLSCREEN;
     this.contextUpdate.emit({ display: this._display });
     await this._shellRpc.rpc.ShellService.setLayout(request, { timeout: RPC_TIMEOUT });
+    (
+      this._iframeManager.iframe?.contentDocument?.querySelector(
+        'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ) as HTMLElement | null | undefined
+    )?.focus();
   }
 
   async setInvitationUrl(request: InvitationUrlRequest) {


### PR DESCRIPTION
This PR:
- resolves #7143
- fixes keyboard access to shell more broadly, by focusing the first focusable element in the shell when it opens

https://github.com/dxos/dxos/assets/855039/46eade83-d449-403b-af9a-1128daa1e5dd
