### PR TITLE
fix: fixed stream memory leak

### DIFF
--- a/packages/apps/composer-app/project.json
+++ b/packages/apps/composer-app/project.json
@@ -31,7 +31,7 @@
       "cache": true,
       "dependsOn": [
         "^build",
-        "prebuild",
+        "prebuild"
       ],
       "executor": "@nx/vite:build",
       "inputs": [

--- a/packages/core/mesh/rpc/src/rpc.ts
+++ b/packages/core/mesh/rpc/src/rpc.ts
@@ -474,6 +474,7 @@ export class RpcPeer {
         }).catch((err) => {
           log.catch(err);
         });
+        this._outgoingRequests.delete(id);
       };
     });
   }


### PR DESCRIPTION
### Details

`_outgoingRequests` of `RpcPeer` wasn't cleared on the closing side when a stream was closed. 
It was cleared only when a connection was closed or another another party initiated the close.

fixes #7153
