### PR TITLE
chore: track sdk migrating state

### DIFF
--- a/packages/apps/plugins/plugin-space/src/types.ts
+++ b/packages/apps/plugins/plugin-space/src/types.ts
@@ -79,6 +79,12 @@ export type PluginState = {
    */
   // TODO(wittjosiah): Move state into space?
   enabled: string[];
+
+  /**
+   * Which spaces have an SDK migration running currently.
+   */
+  // TODO(wittjosiah): Factor out to sdk. Migration running should probably be a space state.
+  sdkMigrationRunning: Record<string, boolean>;
 };
 
 export type SpaceSettingsProps = { showHidden?: boolean };

--- a/packages/apps/plugins/plugin-space/src/util.tsx
+++ b/packages/apps/plugins/plugin-space/src/util.tsx
@@ -116,6 +116,7 @@ export const updateGraphWithSpace = ({
   graph,
   space,
   namesCache,
+  migrating,
   enabled,
   hidden,
   isPersonalSpace,
@@ -124,6 +125,7 @@ export const updateGraphWithSpace = ({
   graph: Graph;
   space: Space;
   namesCache?: Record<string, string>;
+  migrating?: boolean;
   enabled?: boolean;
   hidden?: boolean;
   isPersonalSpace?: boolean;
@@ -249,7 +251,7 @@ export const updateGraphWithSpace = ({
               icon: (props: IconProps) => <Database {...props} />,
               disposition: 'toolbar',
               mainAreaDisposition: 'in-flow',
-              disabled: Migrations.running(space),
+              disabled: migrating || Migrations.running(space),
             },
             edges: [[space.id, 'inbound']],
           },


### PR DESCRIPTION
Adds state to prevent sdk migrations from being run again while they are in progress.
