### PR TITLE
fix(plugin-markdown): Document fills plank when toolbar is disabled

### DIFF
--- a/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
@@ -148,7 +148,7 @@ export const EditorMain = ({
       <div
         role='none'
         data-toolbar={toolbar ? 'enabled' : 'disabled'}
-        className='is-full bs-full overflow-hidden data-[toolbar=disabled]:pbs-2'
+        className='is-full bs-full overflow-hidden data-[toolbar=disabled]:pbs-2 data-[toolbar=disabled]:row-span-2'
       >
         <TextEditor
           {...props}


### PR DESCRIPTION
This PR
- resolves #6798.