### PR TITLE
feat(tools): jump to _open/_close shortcut for jetbrains IDEs

### DIFF
--- a/tools/intellij-plugin/README.md
+++ b/tools/intellij-plugin/README.md
@@ -15,3 +15,4 @@ Run "Install Plugin from disk": `cmd+shift+A` and search the action, or go to Pl
 ## Features
 
 * `nx test` executor for all the context where `Mocha` plugin suggests a run configuration.
+* `Jump to _open / _close` of `Resource` subclasses line marker.

--- a/tools/intellij-plugin/build.gradle
+++ b/tools/intellij-plugin/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'org.dxos'
-version = '0.0.2'
+version = '0.0.3'
 
 repositories {
   mavenCentral()

--- a/tools/intellij-plugin/src/main/kotlin/org/dxos/navigation/RealImplementationLocator.kt
+++ b/tools/intellij-plugin/src/main/kotlin/org/dxos/navigation/RealImplementationLocator.kt
@@ -1,0 +1,63 @@
+package org.dxos.navigation
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.icons.AllIcons
+import com.intellij.lang.javascript.psi.JSCallExpression
+import com.intellij.lang.javascript.psi.JSFunction
+import com.intellij.lang.javascript.psi.JSReferenceExpression
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptSingleType
+import com.intellij.lang.javascript.psi.ecmal4.JSClass
+import com.intellij.lang.javascript.psi.resolve.JSResolveUtil
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.psi.PsiElement
+import com.intellij.util.PsiNavigateUtil
+
+class RealImplementationLocator(
+  private val wrapperMethodHostClass: String,
+  private val wrapperMethods: Array<String>,
+  private val methodNameTransform: (String?) -> String,
+) {
+  fun createNavigationMarker(element: PsiElement): LineMarkerInfo<*>? {
+    val file = element.containingFile.virtualFile
+    if (file == null || file.fileType.isBinary) {
+      return null
+    }
+    if (element !is JSCallExpression) {
+      return null
+    }
+    val methodRef = element.methodExpression as? JSReferenceExpression ?: return null
+    val receiver = methodRef.firstChild as? JSReferenceExpression ?: return null
+    if (methodRef.referenceName !in wrapperMethods) {
+      return null
+    }
+    val resolvedFunction = methodRef.resolve()
+    if (resolvedFunction !is JSFunction) {
+      return null
+    }
+    val containingClass = resolvedFunction.context
+    if (containingClass !is JSClass || containingClass.name != wrapperMethodHostClass) {
+      return null
+    }
+    val resolvedReceiver = receiver.resolve()
+    val receiverType = JSResolveUtil.getElementJSType(resolvedReceiver);
+    val receiverDeclaration = receiverType?.source?.sourceElement as? TypeScriptSingleType
+    val resolvedClass = (receiverDeclaration?.firstChild as? JSReferenceExpression)?.resolve()
+    val typeScriptClass = resolvedClass as? JSClass ?: return null
+    val implementationName = methodNameTransform(methodRef.referenceName)
+    val implementationFunction = typeScriptClass.functions.find { it.name == implementationName }
+    if (implementationFunction == null) {
+      return null
+    }
+
+    val name = "Jump to $implementationName"
+    return LineMarkerInfo(
+      element,
+      element.getTextRange(),
+      AllIcons.Gutter.ImplementingMethod,
+      { name },
+      { _, _ -> PsiNavigateUtil.navigate(implementationFunction) },
+      GutterIconRenderer.Alignment.CENTER,
+      { name },
+    )
+  }
+}

--- a/tools/intellij-plugin/src/main/kotlin/org/dxos/navigation/ResourceImplMarkerProvider.kt
+++ b/tools/intellij-plugin/src/main/kotlin/org/dxos/navigation/ResourceImplMarkerProvider.kt
@@ -1,0 +1,22 @@
+package org.dxos.navigation
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
+import com.intellij.psi.PsiElement
+
+
+class ResourceImplMarkerProvider : LineMarkerProviderDescriptor() {
+
+  private val implementationLocator = RealImplementationLocator(
+    wrapperMethodHostClass = "Resource",
+    wrapperMethods = arrayOf("open", "close"),
+    methodNameTransform = { methodName -> "_${methodName}" }
+  )
+
+  override fun getName() = "Resource method"
+
+  override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+    return implementationLocator.createNavigationMarker(element)
+  }
+
+}

--- a/tools/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/tools/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -11,5 +11,9 @@
   <extensions defaultExtensionNs="com.intellij">
     <configurationType implementation="org.dxos.test.DxosMochaRunConfigFactory"/>
     <runConfigurationProducer implementation="org.dxos.test.DxosMochaRunConfigProducer"/>
+
+    <codeInsight.lineMarkerProvider
+      language="JavaScript"
+      implementationClass="org.dxos.navigation.ResourceImplMarkerProvider"/>
   </extensions>
 </idea-plugin>


### PR DESCRIPTION
### Details

Adds a marker to the left of `open()` and `close()` calls of `Resource` subclasses.
On click jumps to corresponding implementations (`_open()` and `_close()`) instead of the base method.

<img width="350" alt="image" src="https://github.com/dxos/dxos/assets/9644546/0a5e6279-5f75-4781-b113-7406370f0e98">
