### PR TITLE
feat(tools): jump to ServiceImpl for services registered in service-host.ts file

### DIFF
--- a/packages/core/echo/echo-db/src/host/echo-host.ts
+++ b/packages/core/echo/echo-db/src/host/echo-host.ts
@@ -25,7 +25,6 @@ import { invariant } from '@dxos/invariant';
 import { type PublicKey } from '@dxos/keys';
 import { type LevelDB } from '@dxos/kv-store';
 import { type IndexConfig, IndexKind } from '@dxos/protocols/proto/dxos/echo/indexing';
-import { type QueryService } from '@dxos/protocols/proto/dxos/echo/query';
 import { type TeleportExtension } from '@dxos/teleport';
 import { trace } from '@dxos/tracing';
 
@@ -116,7 +115,7 @@ export class EchoHost extends Resource {
     });
   }
 
-  get queryService(): QueryService {
+  get queryService(): QueryServiceImpl {
     return this._queryService;
   }
 

--- a/tools/intellij-plugin/README.md
+++ b/tools/intellij-plugin/README.md
@@ -16,3 +16,4 @@ Run "Install Plugin from disk": `cmd+shift+A` and search the action, or go to Pl
 
 * `nx test` executor for all the context where `Mocha` plugin suggests a run configuration.
 * `Jump to _open / _close` of `Resource` subclasses line marker.
+* `Jump to ServiceImpl` for services registered in `service-host.ts` file.

--- a/tools/intellij-plugin/build.gradle
+++ b/tools/intellij-plugin/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'org.dxos'
-version = '0.0.3'
+version = '0.0.4'
 
 repositories {
   mavenCentral()

--- a/tools/intellij-plugin/src/main/kotlin/org/dxos/navigation/ImplementationMarker.kt
+++ b/tools/intellij-plugin/src/main/kotlin/org/dxos/navigation/ImplementationMarker.kt
@@ -1,0 +1,22 @@
+package org.dxos.navigation
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.psi.PsiElement
+import com.intellij.util.PsiNavigateUtil
+
+
+class ImplementationMarker(
+  name: String,
+  element: PsiElement,
+  target: PsiElement
+) : LineMarkerInfo<PsiElement>(
+  element,
+  element.textRange,
+  AllIcons.Gutter.ImplementingMethod,
+  { name },
+  { _, _ -> PsiNavigateUtil.navigate(target) },
+  GutterIconRenderer.Alignment.CENTER,
+  { name },
+)

--- a/tools/intellij-plugin/src/main/kotlin/org/dxos/navigation/RealImplementationLocator.kt
+++ b/tools/intellij-plugin/src/main/kotlin/org/dxos/navigation/RealImplementationLocator.kt
@@ -1,16 +1,12 @@
 package org.dxos.navigation
 
 import com.intellij.codeInsight.daemon.LineMarkerInfo
-import com.intellij.icons.AllIcons
 import com.intellij.lang.javascript.psi.JSCallExpression
 import com.intellij.lang.javascript.psi.JSFunction
 import com.intellij.lang.javascript.psi.JSReferenceExpression
-import com.intellij.lang.javascript.psi.ecma6.TypeScriptSingleType
 import com.intellij.lang.javascript.psi.ecmal4.JSClass
-import com.intellij.lang.javascript.psi.resolve.JSResolveUtil
-import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.psi.PsiElement
-import com.intellij.util.PsiNavigateUtil
+import org.dxos.psi.PsiTypeResolver
 
 class RealImplementationLocator(
   private val wrapperMethodHostClass: String,
@@ -38,26 +34,17 @@ class RealImplementationLocator(
     if (containingClass !is JSClass || containingClass.name != wrapperMethodHostClass) {
       return null
     }
-    val resolvedReceiver = receiver.resolve()
-    val receiverType = JSResolveUtil.getElementJSType(resolvedReceiver);
-    val receiverDeclaration = receiverType?.source?.sourceElement as? TypeScriptSingleType
-    val resolvedClass = (receiverDeclaration?.firstChild as? JSReferenceExpression)?.resolve()
-    val typeScriptClass = resolvedClass as? JSClass ?: return null
+    val typeScriptClass = PsiTypeResolver.resolveFromReference(receiver) ?: return null
     val implementationName = methodNameTransform(methodRef.referenceName)
-    val implementationFunction = typeScriptClass.functions.find { it.name == implementationName }
-    if (implementationFunction == null) {
+    val implementationMethod = typeScriptClass.functions.find { it.name == implementationName }
+    if (implementationMethod == null) {
       return null
     }
 
-    val name = "Jump to $implementationName"
-    return LineMarkerInfo(
-      element,
-      element.getTextRange(),
-      AllIcons.Gutter.ImplementingMethod,
-      { name },
-      { _, _ -> PsiNavigateUtil.navigate(implementationFunction) },
-      GutterIconRenderer.Alignment.CENTER,
-      { name },
+    return ImplementationMarker(
+      name = "Jump to $implementationName",
+      element = element,
+      target = implementationMethod
     )
   }
 }

--- a/tools/intellij-plugin/src/main/kotlin/org/dxos/navigation/ServiceMethodImplMarkerProvider.kt
+++ b/tools/intellij-plugin/src/main/kotlin/org/dxos/navigation/ServiceMethodImplMarkerProvider.kt
@@ -1,0 +1,45 @@
+package org.dxos.navigation
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
+import com.intellij.lang.javascript.psi.JSCallExpression
+import com.intellij.lang.javascript.psi.JSReferenceExpression
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.dxos.project.ImplementationRegistryService
+
+class ServiceMethodImplMarkerProvider : LineMarkerProviderDescriptor() {
+
+  override fun getName() = "Service method"
+
+  override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+    val file = element.containingFile.virtualFile
+    if (file == null || file.fileType.isBinary) {
+      return null
+    }
+    if (element !is JSCallExpression) {
+      return null
+    }
+    val methodRef = element.methodExpression as? JSReferenceExpression ?: return null
+    val receiverRef = PsiTreeUtil.findChildOfType(methodRef, JSReferenceExpression::class.java)
+    if (receiverRef?.referenceKind != JSReferenceExpression.Kind.PropertyAccess) {
+      return null
+    }
+    if (receiverRef.text?.matches(".*\\.services\\.\\w+$".toRegex()) != true) {
+      return null
+    }
+    val implementationRegistry = element.project.getService(ImplementationRegistryService::class.java)
+    val serviceImplementation = implementationRegistry.getByName(receiverRef.referenceName)
+    val methodImplementation = serviceImplementation?.functions?.find { it.name == methodRef.referenceName }
+    if (methodImplementation == null) {
+      return null
+    }
+
+    return ImplementationMarker(
+      name = "Jump to ${serviceImplementation.name}",
+      element = element,
+      target = methodImplementation
+    )
+  }
+
+}

--- a/tools/intellij-plugin/src/main/kotlin/org/dxos/project/ImplementationRegistryService.kt
+++ b/tools/intellij-plugin/src/main/kotlin/org/dxos/project/ImplementationRegistryService.kt
@@ -1,0 +1,50 @@
+package org.dxos.project
+
+import com.intellij.lang.javascript.TypeScriptFileType
+import com.intellij.lang.javascript.psi.JSCallExpression
+import com.intellij.lang.javascript.psi.JSObjectLiteralExpression
+import com.intellij.lang.javascript.psi.JSReferenceExpression
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptNewExpression
+import com.intellij.lang.javascript.psi.ecmal4.JSClass
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.PsiUtilCore
+import org.dxos.psi.PsiTypeResolver
+
+@Service(Service.Level.PROJECT)
+class ImplementationRegistryService(private val project: Project) {
+
+  private val serviceRegistrationFile by lazy {
+    FilenameIndex.getVirtualFilesByName(
+      SERVICE_REGISTRATION_FILE,
+      GlobalSearchScope.getScopeRestrictedByFileTypes(
+        GlobalSearchScope.projectScope(project),
+        TypeScriptFileType.INSTANCE
+      ))
+      .toList()[0]
+  }
+
+  fun getByName(serviceName: String?): JSClass? {
+    val psiFile = PsiUtilCore.getPsiFile(project, serviceRegistrationFile)
+    val serviceRegistration = PsiTreeUtil.findChildrenOfType(psiFile, JSCallExpression::class.java).find {
+      (it.methodExpression as? JSReferenceExpression)?.referenceName == "setServices"
+    }
+    val params = PsiTreeUtil.findChildOfType(serviceRegistration, JSObjectLiteralExpression::class.java)
+    return (params?.properties ?: emptyArray()).firstNotNullOfOrNull { property ->
+      val value = property.value
+      when {
+        property.name != serviceName -> null
+        value is JSReferenceExpression -> PsiTypeResolver.resolveFromReference(value)
+        value is TypeScriptNewExpression -> PsiTypeResolver.resolveFromConstructor(value)
+        else -> null
+      }
+    }
+  }
+
+  companion object {
+    private const val SERVICE_REGISTRATION_FILE = "service-host.ts"
+  }
+}

--- a/tools/intellij-plugin/src/main/kotlin/org/dxos/psi/PsiTypeResolver.kt
+++ b/tools/intellij-plugin/src/main/kotlin/org/dxos/psi/PsiTypeResolver.kt
@@ -1,0 +1,26 @@
+package org.dxos.psi
+
+import com.intellij.lang.javascript.psi.JSReferenceExpression
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptNewExpression
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptSingleType
+import com.intellij.lang.javascript.psi.ecmal4.JSClass
+import com.intellij.lang.javascript.psi.resolve.JSResolveUtil
+import com.intellij.psi.util.PsiTreeUtil
+
+object PsiTypeResolver {
+  fun resolveFromReference(reference: JSReferenceExpression?): JSClass? {
+    val resolvedReceiver = reference?.resolve()
+    val receiverType = JSResolveUtil.getElementJSType(resolvedReceiver);
+    val sourceElement = receiverType?.sourceElement
+    if (sourceElement is JSClass) {
+      return sourceElement
+    }
+    val receiverDeclaration = receiverType?.source?.sourceElement as? TypeScriptSingleType
+    val resolvedClass = (receiverDeclaration?.firstChild as? JSReferenceExpression)?.resolve()
+    return resolvedClass as? JSClass ?: return null
+  }
+
+  fun resolveFromConstructor(newExpression: TypeScriptNewExpression?) = newExpression?.let {
+    PsiTreeUtil.findChildOfType(it, JSReferenceExpression::class.java)
+  }?.resolve() as? JSClass
+}

--- a/tools/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/tools/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -15,5 +15,8 @@
     <codeInsight.lineMarkerProvider
       language="JavaScript"
       implementationClass="org.dxos.navigation.ResourceImplMarkerProvider"/>
+    <codeInsight.lineMarkerProvider
+      language="JavaScript"
+      implementationClass="org.dxos.navigation.ServiceMethodImplMarkerProvider"/>
   </extensions>
 </idea-plugin>


### PR DESCRIPTION
### Details

Adds a marker to the left of service calls, if the service was registered in `service-host.ts` file. 
On click navigates to the implementation.
Not ideal, but parsing the known file is a cheap and easy way for locating implementations.

<img width="600" alt="image" src="https://github.com/dxos/dxos/assets/9644546/3c7e8137-4809-4b7c-ae5d-c027f52433a7">

