### PR TITLE
fix(authoring): Internal links work with deck

### DIFF
--- a/packages/apps/plugins/plugin-deck/src/DeckPlugin.tsx
+++ b/packages/apps/plugins/plugin-deck/src/DeckPlugin.tsx
@@ -452,7 +452,7 @@ export const DeckPlugin = ({
 
               return {
                 data: true,
-                intents: scrollIntoView ? [{ action: LayoutAction.SCROLL_INTO_VIEW, data: { id } }] : undefined,
+                intents: scrollIntoView ? [[{ action: LayoutAction.SCROLL_INTO_VIEW, data: { id } }]] : undefined,
               };
             }
 

--- a/packages/apps/plugins/plugin-layout/src/LayoutPlugin.tsx
+++ b/packages/apps/plugins/plugin-layout/src/LayoutPlugin.tsx
@@ -368,6 +368,18 @@ export const LayoutPlugin = ({
               return { data: true };
             }
 
+            case NavigationAction.ADD_TO_ACTIVE: {
+              const { id } = intent.data || {};
+              if (!id) {
+                return { data: false };
+              }
+
+              return {
+                data: true,
+                intents: [[{ action: NavigationAction.OPEN, data: { activeParts: { main: id } } }]],
+              };
+            }
+
             // TODO(wittjosiah): Factor out.
             case NavigationAction.OPEN: {
               const id = firstMainId(intent.data?.activeParts);

--- a/packages/apps/plugins/plugin-markdown/src/extensions.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/extensions.tsx
@@ -48,7 +48,6 @@ export const getExtensions = ({ dispatch, settings, document, query }: Extension
       renderLinkButton:
         dispatch && document
           ? onRenderLink((id: string) => {
-              console.log('On select object', id);
               // TODO: Support deck here
               void dispatch({
                 action: NavigationAction.ADD_TO_ACTIVE,

--- a/packages/apps/plugins/plugin-search/src/components/SearchDialog.tsx
+++ b/packages/apps/plugins/plugin-search/src/components/SearchDialog.tsx
@@ -70,6 +70,8 @@ export const SearchDialog = ({
   const [pending, results] = useSearchResults(queryString, dangerouslyLoadAllObjects);
   const resultObjects = Array.from(results.keys());
   const dispatch = useIntentDispatcher();
+
+  // TODO(Zan): Reimplement with `ADD_TO_ACTIVE`` once I understand how to retrieve the subject ID from subject.
   const handleSelect = useCallback(
     (nodeId: string) => {
       // If node is already present in the active parts, scroll to it and close the dialog.

--- a/packages/sdk/app-framework/src/plugins/common/navigation.ts
+++ b/packages/sdk/app-framework/src/plugins/common/navigation.ts
@@ -101,6 +101,7 @@ export const parseNavigationPlugin = (plugin: Plugin) => {
 const NAVIGATION_ACTION = 'dxos.org/plugin/navigation';
 export enum NavigationAction {
   OPEN = `${NAVIGATION_ACTION}/open`,
+  ADD_TO_ACTIVE = `${NAVIGATION_ACTION}/add-to-active`,
   SET = `${NAVIGATION_ACTION}/set`,
   ADJUST = `${NAVIGATION_ACTION}/adjust`,
   CLOSE = `${NAVIGATION_ACTION}/close`,
@@ -114,6 +115,14 @@ export namespace NavigationAction {
    * An additive overlay to apply to `location.active` (i.e. the result is a union of previous active and the argument)
    */
   export type Open = IntentData<{ activeParts: ActiveParts }>;
+  /**
+   * Payload for adding an item to the active items.
+   */
+  export type AddToActive = IntentData<{
+    id: string;
+    scrollIntoView?: boolean;
+    pivot?: { id: string; position: 'add-before' | 'add-after' };
+  }>;
   /**
    * A subtractive overlay to apply to `location.active` (i.e. the result is a subtraction from the previous active of the argument)
    */


### PR DESCRIPTION
- Resolves #7011

As a follow up I'd like to simplify the active id manipulation that `SearchDialog` and `NavTreeContainer` by leveraging the new NavigationAction `ADD_TO_ACTIVE`.

Open to better names for the action, however, I'm not too fussed since they're ephemeral.

Clicking on an internal link multiple times in deck will only scroll and focus the linked object the first time. 
- More discussion here: #7197 