### PR TITLE
fix(echo): prevent bind to unavailable handle

### DIFF
--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-doc-loader.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-doc-loader.ts
@@ -225,7 +225,7 @@ export class AutomergeDocumentLoaderImpl implements AutomergeDocumentLoader {
 
   private async _createObjectOnDocumentLoad(handle: DocHandle<SpaceDoc>, objectId: string) {
     try {
-      await handle.doc(['ready']);
+      await handle.whenReady();
       const logMeta = { objectId, docUrl: handle.url };
       if (this.onObjectDocumentLoaded.listenerCount() === 0) {
         log.info('document loaded after all listeners were removed', logMeta);


### PR DESCRIPTION
### Details

Fixes [invariant violation error](https://dxos.sentry.io/issues/5575660781/events/fd143d408c0340108d52a701e6b8bb4a/?project=4504340179779584&referrer=issue_details.related_trace_issue).

<img width="800" alt="image" src="https://github.com/dxos/dxos/assets/9644546/d90ec37c-6300-4466-936b-b1fa803df0e5">

`await handle.doc(['ready']);` on timeout simply returns undefined, so we were emitting "loaded" with unavailable handle.