### PR TITLE
chore: replace dependency to fix publish

### DIFF
--- a/packages/sdk/observability/package.json
+++ b/packages/sdk/observability/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@dxos/async": "workspace:*",
+    "@dxos/client": "workspace:*",
     "@dxos/client-protocol": "workspace:*",
     "@dxos/client-services": "workspace:*",
     "@dxos/config": "workspace:*",
@@ -72,7 +73,6 @@
     "@dxos/network-manager": "workspace:*",
     "@dxos/node-std": "workspace:*",
     "@dxos/protocols": "workspace:*",
-    "@dxos/react-client": "workspace:*",
     "@dxos/tracing": "workspace:*",
     "@dxos/util": "workspace:*",
     "@segment/analytics-node": "^2.1.0",

--- a/packages/sdk/observability/tsconfig.json
+++ b/packages/sdk/observability/tsconfig.json
@@ -52,6 +52,9 @@
       "path": "../../core/protocols"
     },
     {
+      "path": "../client"
+    },
+    {
       "path": "../client-protocol"
     },
     {
@@ -59,9 +62,6 @@
     },
     {
       "path": "../config"
-    },
-    {
-      "path": "../react-client"
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9264,6 +9264,9 @@ importers:
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
+      '@dxos/client':
+        specifier: workspace:*
+        version: link:../client
       '@dxos/client-protocol':
         specifier: workspace:*
         version: link:../client-protocol
@@ -9294,9 +9297,6 @@ importers:
       '@dxos/protocols':
         specifier: workspace:*
         version: link:../../core/protocols
-      '@dxos/react-client':
-        specifier: workspace:*
-        version: link:../react-client
       '@dxos/tracing':
         specifier: workspace:*
         version: link:../../common/tracing


### PR DESCRIPTION
### Details

<img width="687" alt="image" src="https://github.com/dxos/dxos/assets/9644546/a344f5cc-3803-4d58-9bc2-df0587f7e8da">

Seems like there's no reason for observability to depend on react-client.