### PR TITLE
chore(native): Add socket config and bundle script to `testbench-app`

### DIFF
--- a/packages/apps/composer-app/scripts/bundle.sh
+++ b/packages/apps/composer-app/scripts/bundle.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 DX_HOST=true pnpm -w nx bundle composer-app
 

--- a/packages/apps/testbench-app/README.md
+++ b/packages/apps/testbench-app/README.md
@@ -5,3 +5,10 @@ To run the app:
 ```bash
 pnpm -w nx run testbench-app:serve
 ```
+
+To run the app in a native context (SocketSupply)
+
+```bash
+# Navigate to the testbench-app directory
+./scripts/bundle.sh
+```

--- a/packages/apps/testbench-app/scripts/bundle.sh
+++ b/packages/apps/testbench-app/scripts/bundle.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+DX_HOST=true pnpm -w nx bundle testbench-app
+
+ssc build -r

--- a/packages/apps/testbench-app/socket.ini
+++ b/packages/apps/testbench-app/socket.ini
@@ -1,0 +1,406 @@
+
+;  ___  __   ___      __ ____
+; /__  /  / /   /_/  /_   /
+; __/ /__/ /__ /  \ /__  /
+;
+; Socket ⚡︎ Runtime · A modern runtime for Web Apps · v0.5.4 (f8db1eaf)
+;
+; Note that "~" alias won't expand to the home directory in any of the config
+; files. Use the full path instead.
+
+
+[build]
+
+; ssc will copy everything in this directory to the build output directory.
+; This is useful when you want to avoid bundling or want to use tools like
+; vite, webpack, rollup, etc. to build your project and then copy output to
+; the Socket bundle resources directory.
+; default value: "src"
+copy = "out/testbench-app"
+
+; An ini file that maps files from the source directory to the build directory.
+; copy_map = src/mapping.ini
+
+; An list of environment variables, separated by commas.
+env = USER, TMPDIR, PWD
+
+; Advanced Compiler Settings (ie C++ compiler -02, -03, etc).
+flags = -O3
+
+; If true, the window will never be displayed.
+; default value: false
+headless = false
+
+; The name of the program and executable to be output. Can't contain spaces or special characters. Required field.
+name = "testbench"
+
+; The binary output path. It's recommended to add this path to .gitignore.
+; default value: "build"
+output = "build"
+
+; The build script. It runs before the `[build] copy` phase.
+; script = "./scripts/bundle.sh"
+
+
+[build.script]
+; If true, it will pass build arguments to the build script. WARNING: this could be deprecated in the future.
+; default value: false
+forward_arguments = false
+
+
+[build.watch]
+; Configure your project to watch for sources that could change when running `ssc`.
+; Could be a string or an array of strings
+sources[] = "src"
+
+
+[webview]
+; Make root open index.html
+; default value: "/"
+root = "/"
+
+; Set default 'index.html' path to open for implicit routes
+; default value: ""
+; default_index  = ""
+
+; Tell the webview to watch for changes in its resources
+; default value: false
+watch = true
+
+; Custom headers injected on all webview routes
+; default value: ""
+; headers[] = "X-Custom-Header: Some-Value"
+
+[webview.watch]
+; Configure webview to reload when a file changes
+; default value: true
+reload = true
+
+; Timeout in milliseconds to wait for service worker to reload before reloading webview
+; default value: 500
+service_worker_reload_timeout = 500
+
+; Mount file system paths in webview navigator
+[webview.navigator.mounts]
+; $HOST_HOME/directory-in-home-folder/ = /mount/path/in/navigator
+; $HOST_CONTAINER/directory-app-container/ = /mount/path/in/navigator
+; $HOST_PROCESS_WORKING_DIRECTORY/directory-in-app-process-working-directory/ = /mount/path/in/navigator
+
+; Specify allowed navigator navigation policy patterns
+[webview.navigator.policies]
+; allowed[] = "https://*.example.com/*"
+
+[permissions]
+; Allow/Disallow fullscreen in application
+; default value: true
+; allow_fullscreen = true
+
+; Allow/Disallow microphone in application
+; default value: true
+; allow_microphone = true
+
+; Allow/Disallow camera in application
+; default value: true
+; allow_camera = true
+
+; Allow/Disallow user media (microphone + camera) in application
+; default value: true
+; allow_user_media = true
+
+; Allow/Disallow geolocation in application
+; default value: true
+; allow_geolocation = true
+
+; Allow/Disallow notifications in application
+; default value: true
+; allow_notifications = true
+
+; Allow/Disallow sensors in application
+; default value: true
+; allow_sensors = true
+
+; Allow/Disallow clipboard in application
+; default value: true
+; allow_clipboard = true
+
+; Allow/Disallow bluetooth in application
+; default value: true
+; allow_bluetooth = true
+
+; Allow/Disallow data access in application
+; default value: true
+; allow_data_access = true
+
+; Allow/Disallow AirPlay access in application (macOS/iOS) only
+; default value: true
+; allow_airplay = true
+
+; Allow/Disallow HotKey binding registration (desktop only)
+; default value: true
+; allow_hotkeys = true
+
+[debug]
+; Advanced Compiler Settings for debug purposes (ie C++ compiler -g, etc).
+flags = "-g"
+
+
+[meta]
+; A unique ID that identifies the bundle (used by all app stores).
+; It's required when `[meta] type` is not `"extension"`.
+; It should be in a reverse DNS notation https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleidentifier#discussion
+bundle_identifier = "space.testbench"
+; A unique application protocol scheme to support deep linking
+; If this value is not defined, then it is derived from the `[meta] bundle_identifier` value
+application_protocol = "testbench"
+
+; A string that gets used in the about dialog and package meta info.
+copyright = "(c) 2024, DXOS.org"
+; A short description of the app.
+description = "DXOS Test Bench"
+; A String used in the about dialog and meta info.
+maintainer = "DXOS.org"
+; The title of the app used in metadata files. This is NOT a window title. Can contain spaces and special characters. Defaults to name in a [build] section.
+title = "Test Bench App"
+; A string that indicates the version of the application. It should be a semver triple like 1.2.3. Defaults to 1.0.0.
+
+version = "0.0.1"
+
+; Set the limit of files that can be opened by your process.
+file_limit = 1024
+; Localization
+lang = "en-us"
+
+[android]
+; Extensions of files that will not be stored compressed in the APK.
+aapt_no_compress = ""
+
+; Enables gradle based ndk build rather than using external native build (standard ndk is the old slow way)
+enable_standard_ndk_build = false
+
+; Name of the MainActivity class. Could be overwritten by custom native code.
+main_activity = ""
+
+; Which permissions does your application need: https://developer.android.com/guide/topics/permissions/overview
+manifest_permissions = ""
+
+; To restrict the set of ABIs that your application supports, set them here.
+native_abis = ""
+
+; Used for adding custom source files and related compiler attributes.
+native_cflags = ""
+native_sources = ""
+native_makefile = ""
+sources = ""
+
+; The icon to use for identifying your app on Android.
+icon = "public/icon.png"
+
+; The various sizes and scales of the icons to create, required minimum are listed by default.
+icon_sizes = "512@1x"
+
+
+[ios]
+
+; signing guide: https://socketsupply.co/guides/#ios-1
+codesign_identity = ""
+
+; Describes how Xcode should export the archive. Available options: app-store, package, release-testing, enterprise, development, and developer-id.
+distribution_method = "release-testing"
+
+; A path to the provisioning profile used for signing iOS app.
+provisioning_profile = ""
+
+; which device to target when building for the simulator.
+simulator_device = "iPhone 14"
+
+; Indicate to Apple if you are using encryption that is not exempt.
+; default value: false
+; nonexempt_encryption = false
+
+; The icon to use for identifying your app on iOS.
+icon = "public/icon.png"
+
+; The various sizes and scales of the icons to create, required minimum are listed by default.
+icon_sizes = "29@1x 29@2x 29@3x 40@2x 40@3x 57@1x 57@2x 60@2x 60@3x"
+
+[linux]
+
+; Helps to make your app searchable in Linux desktop environments.
+categories = "Developer Tools"
+
+; The command to execute to spawn the "back-end" process.
+; cmd = "node backend/index.js"
+
+; The icon to use for identifying your app in Linux desktop environments.
+icon = "public/icon.png"
+
+; The various sizes and scales of the icons to create, required minimum are listed by default.
+icon_sizes = "512@1x"
+
+
+[mac]
+
+; A category in the App Store
+category = "productivity"
+
+; The command to execute to spawn the "back-end" process.
+; cmd = "node backend/index.js"
+
+; TODO Signing guide: https://socketsupply.co/guides/#code-signing-certificates
+codesign_identity = ""
+
+; Additional paths to codesign
+codesign_paths = ""
+
+; Minimum supported MacOS version
+; default value: "13.0.0"
+; minimum_supported_version = "13.0.0"
+
+; If titlebar_style is "hiddenInset", this will determine the x and y offsets of the window controls (traffic lights).
+; window_control_offsets = "10x24"
+
+; The icon to use for identifying your app on MacOS.
+icon = "public/icon.png"
+
+; The various sizes and scales of the icons to create, required minimum are listed by default.
+icon_sizes = "16@1x 32@1x 128@1x"
+
+
+[native]
+
+; Files that should be added to the compile step.
+files = native-module1.cc native-module2.cc
+
+; Extra Headers
+headers = native-module1.hh
+
+
+[win]
+
+; The command to execute to spawn the “back-end” process.
+; cmd = "node backend/index.js"
+
+; The icon to use for identifying your app on Windows, relative to copied path resources
+logo = "pulic/icon.ico"
+
+; A relative path to the pfx file used for signing.
+; pfx = "certs/cert.pfx"
+
+; The signing information needed by the appx api.
+; publisher = "CN=Beep Boop Corp., O=Beep Boop Corp., L=San Francisco, S=California, C=US"
+
+; The icon to use for identifying your app on Windows.
+; TODO(zan): I don't think we have this .ico asset yet
+icon = "public/icon.ico"
+
+; The various sizes and scales of the icons to create, required minimum are listed by default.
+icon_sizes = "512@1x"
+
+
+[window]
+
+; The initial height of the first window in pixels or as a percentage of the screen.
+height = 50%
+
+; The initial width of the first window in pixels or as a percentage of the screen.
+width = 50%
+
+; The initial color of the window in dark mode. If not provided, matches the current theme.
+; default value: ""
+; backgroundColorDark = "rgba(0, 0, 0, 1)"
+
+; The initial color of the window in light mode. If not provided, matches the current theme.
+; default value: ""
+; backgroundColorLight = "rgba(255, 255, 255, 1)"
+
+; Determine if the titlebar style (hidden, hiddenInset)
+; default value: ""
+; titlebar_style = "hiddenInset"
+
+; Maximum height of the window in pixels or as a percentage of the screen.
+; default value: 100%
+; max_height = 100%
+
+; Maximum width of the window in pixels or as a percentage of the screen.
+; default value: 100%
+; max_width = 100%
+
+; Minimum height of the window in pixels or as a percentage of the screen.
+; default value: 0
+; min_height = 0
+
+; Minimum width of the window in pixels or as a percentage of the screen.
+; default value: 0
+; min_width = 0
+
+; Determines if the window has a title bar and border.
+; default value: false
+; frameless = false
+
+; Determines if the window is resizable.
+; default value: true
+; resizable = true
+
+; Determines if the window is maximizable.
+; default value: true
+; maximizable = true
+
+; Determines if the window is minimizable.
+; default value: true
+; minimizable = true
+
+; Determines if the window is closable.
+; default value: true
+; closable = true
+
+; Determines the window is utility window.
+; default value: false
+; utility = false
+
+[window.alert]
+
+; The title that appears in the 'alert', 'prompt', and 'confirm' dialogs. If this value is not present, then the application title is used instead. Currently only supported on iOS/macOS.
+; defalut value = ""
+; title = ""
+
+
+[application]
+
+; If agent is set to true, the app will not display in the tab/window switcher or dock/task-bar etc. Useful if you are building a tray-only app.
+; default value: false
+; agent = true
+
+
+[tray]
+
+; The icon to be displayed in the operating system tray. On Windows, you may need to use ICO format.
+; defalut value = ""
+; icon = "public/icon.png"
+
+
+[headless]
+
+; The headless runner command. It is used when no OS specific runner is set.
+runner = ""
+; The headless runner command flags. It is used when no OS specific runner is set.
+runner_flags = ""
+; The headless runner command for Android
+runner_android = ""
+; The headless runner command flags for Android
+runner_android_flags = ""
+; The headless runner command for iOS
+runner_ios = ""
+; The headless runner command flags for iOS
+runner_ios_flags = ""
+; The headless runner command for Linux
+runner_linux = ""
+; The headless runner command flags for Linux
+runner_linux_flags = ""
+; The headless runner command for MacOS
+runner_mac = ""
+; The headless runner command flags for MacOS
+runner_mac_flags = ""
+; The headless runner command for Windows
+runner_win32 = ""
+; The headless runner command flags for Windows
+runner_win32_flags = ""


### PR DESCRIPTION
Add socket config and bundle script to the testbench application.

<img width="1224" alt="image" src="https://github.com/dxos/dxos/assets/12402727/f4bb888e-c7c0-4552-92d5-38a48252cfbe">

