### PR TITLE
chore: try bundling sourcemaps with releases

### DIFF
--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -174,6 +174,9 @@ export default defineConfig({
       },
       authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN,
       disable: process.env.DX_ENVIRONMENT !== 'production',
+      release: {
+        name: process.env.npm_package_version,
+      },
     }),
     // https://www.bundle-buddy.com/rollup
     {


### PR DESCRIPTION
### Details

Source maps are uploaded, but not associated with releases properly.
![image](https://github.com/dxos/dxos/assets/9644546/fb318138-2faa-498d-af86-49727f4fe46c)
