### PR TITLE
fix(echo): peers not disconnected when replicator is removed

### DIFF
--- a/packages/core/echo/echo-pipeline/src/automerge/echo-network-adapter.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/echo-network-adapter.test.ts
@@ -72,6 +72,17 @@ describe('EchoNetworkAdapter', () => {
     expect(errored).to.be.true;
   });
 
+  test('peer disconnected when replicator is removed', async () => {
+    const controller = createReplicatorController();
+    const adapter = await createConnectedAdapter(controller.replicator);
+    await controller.connectPeer(ANOTHER_PEER_ID);
+    const onDisconnected = new Trigger<any>();
+    adapter.on('peer-disconnected', (payload) => onDisconnected.wake(payload));
+    await adapter.removeReplicator(controller.replicator);
+    const disconnectedPeer = await onDisconnected.wait();
+    expect(disconnectedPeer.peerId).to.eq(ANOTHER_PEER_ID);
+  });
+
   test('message sending is queued', async () => {
     let sentTotal = 0;
     let sendInProgress = false;

--- a/packages/core/echo/echo-pipeline/src/automerge/mesh-echo-replicator.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/mesh-echo-replicator.ts
@@ -38,6 +38,9 @@ export class MeshEchoReplicator implements EchoReplicator {
   }
 
   async disconnect() {
+    for (const connection of this._connectionsPerPeer.values()) {
+      this._context?.onConnectionClosed(connection);
+    }
     for (const connection of this._connections) {
       await connection.close();
     }


### PR DESCRIPTION
### Details

I suppose this might be related to service-host tests becoming flaky recently. 