### PR TITLE
chore: fix open & close in tests

### DIFF
--- a/packages/sdk/client-services/src/packlets/services/service-context.test.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-context.test.ts
@@ -6,18 +6,15 @@ import { MemorySignalManagerContext } from '@dxos/messaging';
 import { Invitation } from '@dxos/protocols/proto/dxos/client/services';
 import { describe, openAndClose, test } from '@dxos/test';
 
-import { createServiceContext } from '../testing';
-import { performInvitation } from '../testing/invitation-utils';
+import { createServiceContext, performInvitation } from '../testing';
 
 describe('services/ServiceContext', () => {
   test('new space is synchronized on device invitations', async () => {
     const networkContext = new MemorySignalManagerContext();
-    const device1 = await createServiceContext({ signalContext: networkContext });
-    await openAndClose(device1.echoHost);
+    const device1 = await createOpenServiceContext(networkContext);
     await device1.createIdentity();
 
-    const device2 = await createServiceContext({ signalContext: networkContext });
-    await openAndClose(device2.echoHost);
+    const device2 = await createOpenServiceContext(networkContext);
     await Promise.all(performInvitation({ host: device1, guest: device2, options: { kind: Invitation.Kind.DEVICE } }));
 
     const space1 = await device1.dataSpaceManager!.createSpace();
@@ -28,16 +25,13 @@ describe('services/ServiceContext', () => {
 
   test('joined space is synchronized on device invitations', async () => {
     const networkContext = new MemorySignalManagerContext();
-    const device1 = await createServiceContext({ signalContext: networkContext });
-    await openAndClose(device1.echoHost);
+    const device1 = await createOpenServiceContext(networkContext);
     await device1.createIdentity();
 
-    const device2 = await createServiceContext({ signalContext: networkContext });
-    await openAndClose(device2.echoHost);
+    const device2 = await createOpenServiceContext(networkContext);
     await Promise.all(performInvitation({ host: device1, guest: device2, options: { kind: Invitation.Kind.DEVICE } }));
 
-    const identity2 = await createServiceContext({ signalContext: networkContext });
-    await openAndClose(identity2.echoHost);
+    const identity2 = await createOpenServiceContext(networkContext);
     await identity2.createIdentity();
     const space1 = await identity2.dataSpaceManager!.createSpace();
     await Promise.all(
@@ -52,4 +46,10 @@ describe('services/ServiceContext', () => {
     const space2 = await device2.dataSpaceManager!.spaces.get(space1.key);
     await space2!.inner.controlPipeline.state.waitUntilTimeframe(space1.inner.controlPipeline.state.timeframe);
   });
+
+  const createOpenServiceContext = async (networkContext: MemorySignalManagerContext) => {
+    const serviceContext = await createServiceContext({ signalContext: networkContext });
+    await openAndClose(serviceContext);
+    return serviceContext;
+  };
 });


### PR DESCRIPTION
### Details

I verified that `joined space is synchronized on device invitations` was influencing `queryCredentials` test result. `await openAndClose(services);` instead of `await openAndClose(services.echoHost);` seems to be fixing shutdown.