### PR TITLE
chore: invitation metrics

### DIFF
--- a/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
+++ b/packages/apps/plugins/plugin-client/src/ClientPlugin.tsx
@@ -223,7 +223,12 @@ export const ClientPlugin = ({
                       action: 'dxos.org/plugin/observability/send-event',
                       data: {
                         name: 'identity.shared',
-                        properties: { deviceKey: data.device?.deviceKey.truncate() },
+                        properties: {
+                          deviceKey: data.device?.deviceKey.truncate(),
+                          deviceKind: data.device?.kind,
+                          error: data.error?.message,
+                          canceled: data.cancelled,
+                        },
                       },
                     },
                   ],

--- a/packages/apps/plugins/plugin-registry/package.json
+++ b/packages/apps/plugins/plugin-registry/package.json
@@ -23,6 +23,7 @@
     "src"
   ],
   "dependencies": {
+    "@braneframe/plugin-observability": "workspace:*",
     "@braneframe/plugin-settings": "workspace:*",
     "@dxos/local-storage": "workspace:*",
     "@dxos/util": "workspace:*"

--- a/packages/apps/plugins/plugin-registry/tsconfig.json
+++ b/packages/apps/plugins/plugin-registry/tsconfig.json
@@ -47,6 +47,9 @@
       "path": "../../../ui/storybook-utils"
     },
     {
+      "path": "../plugin-observability"
+    },
+    {
       "path": "../plugin-settings"
     }
   ]

--- a/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/apps/plugins/plugin-space/src/SpacePlugin.tsx
@@ -695,6 +695,9 @@ export const SpacePlugin = ({
                           name: 'space.share',
                           properties: {
                             spaceId,
+                            members: result.members?.length,
+                            error: result.error?.message,
+                            cancelled: result.cancelled,
                           },
                         },
                       },

--- a/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/invitations-handler.ts
@@ -16,6 +16,7 @@ import { type DeviceProfileDocument } from '@dxos/protocols/proto/dxos/halo/cred
 import { AuthenticationResponse, type IntroductionResponse } from '@dxos/protocols/proto/dxos/halo/invitations';
 import { Options } from '@dxos/protocols/proto/dxos/halo/invitations';
 import { type ExtensionContext, type TeleportExtension, type TeleportParams } from '@dxos/teleport';
+import { trace as _trace } from '@dxos/tracing';
 import { ComplexSet } from '@dxos/util';
 
 import { InvitationGuestExtension } from './invitation-guest-extenstion';
@@ -24,6 +25,7 @@ import { type InvitationProtocol } from './invitation-protocol';
 import { InvitationTopology } from './invitation-topology';
 import { stateToString } from './utils';
 
+const metrics = _trace.metrics;
 const MAX_DELEGATED_INVITATION_HOST_TRIES = 3;
 
 type InvitationExtension = InvitationHostExtension | InvitationGuestExtension;
@@ -71,6 +73,7 @@ export class InvitationsHandler {
     protocol: InvitationProtocol,
     invitation: Invitation,
   ): void {
+    metrics.increment('invitation.created');
     const guardedState = this._createGuardedState(ctx, invitation, stream);
     // Called for every connecting peer.
     const createExtension = (): InvitationHostExtension => {
@@ -117,6 +120,7 @@ export class InvitationsHandler {
               const deviceKey = await extension.completedTrigger.wait({ timeout: invitation.timeout });
               log('admitted guest', { guest: deviceKey, ...protocol.toJSON() });
               guardedState.set(extension, Invitation.State.SUCCESS);
+              metrics.increment('invitation.success');
               log.trace('dxos.sdk.invitations-handler.host.onOpen', trace.end({ id: traceId }));
               admitted = true;
 
@@ -126,10 +130,12 @@ export class InvitationsHandler {
             } catch (err: any) {
               if (err instanceof TimeoutError) {
                 if (guardedState.set(extension, Invitation.State.TIMEOUT)) {
+                  metrics.increment('invitation.timeout');
                   log('timeout', { ...protocol.toJSON() });
                 }
               } else {
                 if (guardedState.error(extension, err)) {
+                  metrics.increment('invitation.failed');
                   log.error('failed', err);
                 }
               }
@@ -146,10 +152,12 @@ export class InvitationsHandler {
           }
           if (err instanceof TimeoutError) {
             if (guardedState.set(extension, Invitation.State.TIMEOUT)) {
+              metrics.increment('invitation.timeout');
               log('timeout', { err });
             }
           } else {
             if (guardedState.error(extension, err)) {
+              metrics.increment('invitation.failed');
               log.error('failed', err);
             }
           }
@@ -169,6 +177,7 @@ export class InvitationsHandler {
             // ensure the swarm is closed before changing state and closing the stream.
             await swarmConnection.close();
             guardedState.set(null, Invitation.State.EXPIRED);
+            metrics.increment('invitation.expired');
             await ctx.dispose();
           },
           invitation.created.getTime() + invitation.lifetime * 1000 - Date.now(),

--- a/packages/sdk/client/src/services/shell.ts
+++ b/packages/sdk/client/src/services/shell.ts
@@ -141,7 +141,7 @@ export class Shell {
    * Invite new members to join the current space.
    * Opens the shell to the specified space, showing current members and allowing new members to be invited.
    *
-   * @param options.spaceKey The space to share. @deprecated Use spaceId instead.
+   * @param options.spaceKey The space to share. (Deprecated, use spaceId instead.)
    * @param options.spaceId The space to share.
    * @param options.target The target location to share with new members.
    *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2886,6 +2886,9 @@ importers:
 
   packages/apps/plugins/plugin-registry:
     dependencies:
+      '@braneframe/plugin-observability':
+        specifier: workspace:*
+        version: link:../plugin-observability
       '@braneframe/plugin-settings':
         specifier: workspace:*
         version: link:../plugin-settings


### PR DESCRIPTION
- add metrics to the invitation handler
- add more data from shell results to share events to be able to differentiate between success and failure
- add events for plugin toggling
