### PR TITLE
fix(attention): Issues after attention plugin refactor

### DIFF
--- a/packages/apps/plugins/plugin-markdown/package.json
+++ b/packages/apps/plugins/plugin-markdown/package.json
@@ -23,6 +23,7 @@
     "src"
   ],
   "dependencies": {
+    "@braneframe/plugin-attention": "workspace:*",
     "@braneframe/plugin-settings": "workspace:*",
     "@braneframe/types": "workspace:*",
     "@codemirror/view": "^6.25.0",

--- a/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/EditorMain.tsx
@@ -5,6 +5,7 @@
 import { type EditorView } from '@codemirror/view';
 import React, { useMemo, useEffect } from 'react';
 
+import { parseAttentionPlugin } from '@braneframe/plugin-attention';
 import {
   LayoutAction,
   useResolvePlugin,
@@ -68,10 +69,11 @@ export const EditorMain = ({
 }: EditorMainProps) => {
   const { t } = useTranslation(MARKDOWN_PLUGIN);
   const { themeMode } = useThemeContext();
+  const attentionPlugin = useResolvePlugin(parseAttentionPlugin);
   const navigationPlugin = useResolvePlugin(parseNavigationPlugin);
   const layoutPlugin = useResolvePlugin(parseLayoutPlugin);
   const isDeckModel = navigationPlugin?.meta.id === 'dxos.org/plugin/deck';
-  const attended = Array.from(navigationPlugin?.provides.attention?.attended ?? []);
+  const attended = Array.from(attentionPlugin?.provides.attention?.attended ?? []);
   const isDirectlyAttended = attended.length === 1 && attended[0] === id;
   const idParts = id.split(':');
   const docId = idParts[idParts.length - 1];

--- a/packages/apps/plugins/plugin-markdown/tsconfig.json
+++ b/packages/apps/plugins/plugin-markdown/tsconfig.json
@@ -77,6 +77,9 @@
       "path": "../../types"
     },
     {
+      "path": "../plugin-attention"
+    },
+    {
       "path": "../plugin-client"
     },
     {

--- a/packages/apps/plugins/plugin-thread/package.json
+++ b/packages/apps/plugins/plugin-thread/package.json
@@ -23,6 +23,7 @@
     "src"
   ],
   "dependencies": {
+    "@braneframe/plugin-attention": "workspace:*",
     "@braneframe/plugin-settings": "workspace:*",
     "@braneframe/plugin-space": "workspace:*",
     "@braneframe/types": "workspace:*",

--- a/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -6,6 +6,7 @@ import { Chat, type IconProps } from '@phosphor-icons/react';
 import { batch, effect, untracked } from '@preact/signals-core';
 import React from 'react';
 
+import { type AttentionPluginProvides, parseAttentionPlugin } from '@braneframe/plugin-attention';
 import { parseClientPlugin } from '@braneframe/plugin-client';
 import { parseSpacePlugin, updateGraphWithAddObjectAction } from '@braneframe/plugin-space';
 import { ThreadType, DocumentType, MessageType, ChannelType } from '@braneframe/types';
@@ -69,6 +70,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
   const settings = new LocalStorageStore<ThreadSettingsProps>(THREAD_PLUGIN);
   const state = create<ThreadState>({ threads: {} });
 
+  let attentionPlugin: Plugin<AttentionPluginProvides> | undefined;
   let navigationPlugin: Plugin<LocationProvides> | undefined;
   let isDeckModel = false;
   let intentPlugin: Plugin<IntentPluginProvides> | undefined;
@@ -80,6 +82,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
     ready: async (plugins) => {
       settings.prop({ key: 'standalone', type: LocalStorageStore.bool({ allowUndefined: true }) });
 
+      attentionPlugin = resolvePlugin(plugins, parseAttentionPlugin);
       navigationPlugin = resolvePlugin(plugins, parseNavigationPlugin);
       isDeckModel = navigationPlugin?.meta.id === 'dxos.org/plugin/deck';
       intentPlugin = resolvePlugin(plugins, parseIntentPlugin)!;
@@ -93,16 +96,18 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
       //  This should have a better solution when deck is introduced.
       const channelsQuery = client.spaces.query(Filter.schema(ChannelType));
       queryUnsubscribe = channelsQuery.subscribe();
+
       unsubscribe = isDeckModel
         ? effect(() => {
-            const firstAttendedNodeWithComments = (
-              Array.from(navigationPlugin?.provides.attention?.attended ?? new Set<string>()) as string[]
-            )
+            const attention = attentionPlugin?.provides.attention;
+            if (!attention?.attended) {
+              return;
+            }
+
+            const firstAttendedNodeWithComments = Array.from(attention.attended)
               .map((id) => graphPlugin?.provides.graph.findNode(id))
-              .filter(
-                (maybeNode) =>
-                  maybeNode && maybeNode?.data instanceof DocumentType && (maybeNode.data.threads?.length ?? 0) > 0,
-              )[0];
+              .find((node) => node?.data instanceof DocumentType && (node.data.threads?.length ?? 0) > 0);
+
             if (firstAttendedNodeWithComments) {
               void intentPlugin?.provides.intent.dispatch({
                 action: NavigationAction.OPEN,
@@ -311,7 +316,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
                   .map((thread) => thread.id);
 
                 const attention =
-                  navigationPlugin?.provides.attention?.attended ?? new Set([fullyQualifiedId(data.subject)]);
+                  attentionPlugin?.provides.attention?.attended ?? new Set([fullyQualifiedId(data.subject)]);
                 const attendableAttrs = useAttendable(fullyQualifiedId(data.subject));
                 const space = getSpace(data.subject);
                 const context = space?.db.getObjectById(firstMainId(location?.active));

--- a/packages/apps/plugins/plugin-thread/tsconfig.json
+++ b/packages/apps/plugins/plugin-thread/tsconfig.json
@@ -83,6 +83,9 @@
       "path": "../../types"
     },
     {
+      "path": "../plugin-attention"
+    },
+    {
       "path": "../plugin-client"
     },
     {

--- a/packages/sdk/app-framework/src/plugins/common/navigation.ts
+++ b/packages/sdk/app-framework/src/plugins/common/navigation.ts
@@ -82,7 +82,6 @@ export const isIdActive = (active: string | ActiveParts | undefined, id: string)
  */
 export type LocationProvides = {
   location: Readonly<Location>;
-  attention?: Readonly<Attention>;
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2295,6 +2295,9 @@ importers:
 
   packages/apps/plugins/plugin-markdown:
     dependencies:
+      '@braneframe/plugin-attention':
+        specifier: workspace:*
+        version: link:../plugin-attention
       '@braneframe/plugin-settings':
         specifier: workspace:*
         version: link:../plugin-settings
@@ -3755,6 +3758,9 @@ importers:
 
   packages/apps/plugins/plugin-thread:
     dependencies:
+      '@braneframe/plugin-attention':
+        specifier: workspace:*
+        version: link:../plugin-attention
       '@braneframe/plugin-settings':
         specifier: workspace:*
         version: link:../plugin-settings


### PR DESCRIPTION
After the refactor to the attention plugin, attention should have been removed from the `NavigationPlugin` provides. There were still some places where we were getting attended from the navigation plugin instead of the new attention plugin. This resulted in the attended array being `undefined` in a few places.

- Replace navigation plugin references with attention plugin for attended data
- Fix undefined attended array issues in affected components
- Ensure consistency in attention data source across the application
