### PR TITLE
chore: correctly form sentry release name during sourcemap upload

### DIFF
--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -89,6 +89,7 @@ const main = async () => {
   }
 
   // Intentionally do not await, don't block app startup for telemetry.
+  // namespace has to match the value passed to sentryVitePlugin in vite.config.ts for sourcemaps to work.
   const observability = initializeAppObservability({ namespace: appKey, config });
 
   // TODO(nf): refactor.

--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -14,6 +14,7 @@ import { VitePWA } from 'vite-plugin-pwa';
 import TopLevelAwaitPlugin from 'vite-plugin-top-level-await';
 import WasmPlugin from 'vite-plugin-wasm';
 import tsconfigPaths from 'vite-tsconfig-paths';
+import { appKey } from './src/constants';
 // import Inspect from 'vite-plugin-inspect';
 
 // https://vitejs.dev/config
@@ -175,7 +176,7 @@ export default defineConfig({
       authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN,
       disable: process.env.DX_ENVIRONMENT !== 'production',
       release: {
-        name: `composer.dxos.org@${process.env.npm_package_version}`,
+        name: `${appKey}@${process.env.npm_package_version}`,
       },
     }),
     // https://www.bundle-buddy.com/rollup

--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -175,7 +175,7 @@ export default defineConfig({
       authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN,
       disable: process.env.DX_ENVIRONMENT !== 'production',
       release: {
-        name: process.env.npm_package_version,
+        name: `composer.dxos.org@${process.env.npm_package_version}`,
       },
     }),
     // https://www.bundle-buddy.com/rollup


### PR DESCRIPTION
Sourcemaps actually were successfully uploaded yesterday, they just weren't associated with the actual release.

![image](https://github.com/user-attachments/assets/951c4afb-6e4c-4a53-8875-6218d8bc4b67)

[That's how release name is formed for SDK init.](https://github.com/dxos/dxos/blob/main/packages/sdk/observability/src/helpers/browser-observability.ts#L83)
