### PR TITLE
fix(comments): Remove non-null assertion from thread.anchor filter

### DIFF
--- a/packages/apps/plugins/plugin-markdown/src/components/DocumentMain.tsx
+++ b/packages/apps/plugins/plugin-markdown/src/components/DocumentMain.tsx
@@ -42,7 +42,7 @@ const DocumentMain = ({ document: doc, extensions: _extensions = [], ...props }:
   }, [doc]);
 
   const comments =
-    doc.threads?.filter((thread) => thread.anchor).map((thread) => ({ id: thread.id, cursor: thread.anchor! })) ?? [];
+    doc.threads?.filter((thread) => thread.anchor).map((thread) => ({ id: thread.id, cursor: thread.anchor })) ?? [];
 
   if (!doc.content) {
     return null;


### PR DESCRIPTION
Throwing a lot of runtime errors (including in prod). Works just fine without this assertion, the type accepts `string | undefined`.