### PR TITLE
chore: graph fixes

### DIFF
--- a/packages/apps/plugins/plugin-deck/src/hooks/useNodeFromSlug.ts
+++ b/packages/apps/plugins/plugin-deck/src/hooks/useNodeFromSlug.ts
@@ -17,8 +17,8 @@ export const useNodesFromSlugs = (graph: Graph, slugs: string[]): { id: string; 
     splitSlugs.map(({ id }) => id),
   );
 
-  return splitSlugs.map(({ id, path }, index) => {
-    const node = nodes[index];
+  return splitSlugs.map(({ id, path }) => {
+    const node = nodes.find((node) => node.id === id);
     if (!node) {
       return { id };
     } else if (path.length > 0) {


### PR DESCRIPTION
- match nodes with slug by id to avoid slug/node mismatches when updating the deck
- trigger resolve node via waitForNode to ensure nodes are loaded when reloading the page
