### PR TITLE
fix(graph): `useNode` latched first resolved node

### DIFF
--- a/packages/apps/plugins/plugin-deck/src/hooks/useNode.ts
+++ b/packages/apps/plugins/plugin-deck/src/hooks/useNode.ts
@@ -52,10 +52,9 @@ export const useNode = <T = any>(graph: Graph, id?: string, timeout?: number): N
   const [nodeState, setNodeState] = useState<Node<T> | undefined>(id ? graph.findNode(id) : undefined);
 
   useEffect(() => {
-    if (nodeState || !id) {
+    if (nodeState?.id === id || !id) {
       return;
     }
-
     const t = setTimeout(async () => {
       try {
         const node = await graph.waitForNode(id, timeout);
@@ -64,9 +63,8 @@ export const useNode = <T = any>(graph: Graph, id?: string, timeout?: number): N
         }
       } catch {}
     });
-
     return () => clearTimeout(t);
-  }, [graph, id, nodeState]);
+  }, [graph, id, timeout, nodeState?.id]);
 
   return nodeState;
 };


### PR DESCRIPTION
The `useNode` hook wasn't properly updating when the id changed if a node was already loaded. 

This was due to the condition `if (nodeState || !id)` which prevented the effect from running if there was an existing nodeState, regardless of whether it matched the new id.
