### PR TITLE
feat(halo): verifyPresentation handles ServiceAccess exercise by a device

### DIFF
--- a/packages/core/halo/credentials/src/presentations/verifier.ts
+++ b/packages/core/halo/credentials/src/presentations/verifier.ts
@@ -74,7 +74,7 @@ export const verifyPresentationChain = async (
       let chainVerification: VerificationResult;
       const assertion = getCredentialAssertion(credential);
       if (assertion['@type'] === 'dxos.halo.credentials.ServiceAccess') {
-        chainVerification = await verifyChain(proof.chain, credential.subject.id, proof.signer);
+        chainVerification = await verifyChain(proof.chain, assertion.identityKey, proof.signer);
       } else {
         chainVerification = await verifyChain(proof.chain, credential.issuer, proof.signer);
       }


### PR DESCRIPTION
### Details

1. ServiceAccess for an identity is issued and saved in halo.
2. When a device is added AuthorizedDevice is saved in halo.
3. When a device wants to use the service it takes the ServiceAccess credential and signs a presentation providing AuthorizedDevice as a proof that it can sign ServiceAccess presentations.

Service provider can also check proof creationDate and ask to renew a presentation.
