### PR TITLE
fix(echo): async queries don't wait missing object load

### DIFF
--- a/packages/core/echo/echo-db/src/client/echo-client.ts
+++ b/packages/core/echo/echo-db/src/client/echo-client.ts
@@ -118,7 +118,7 @@ export class EchoClient extends Resource {
     return db;
   }
 
-  private async _loadObjectFromDocument({ spaceKey, objectId, documentId, localDataOnly }: LoadObjectParams) {
+  private async _loadObjectFromDocument({ spaceKey, objectId, documentId }: LoadObjectParams) {
     const db = this._databases.get(await createIdFromSpaceKey(spaceKey));
     if (!db) {
       return undefined;
@@ -135,12 +135,10 @@ export class EchoClient extends Resource {
       throw err;
     }
 
-    if (localDataOnly) {
-      const objectDocId = db._coreDatabase._automergeDocLoader.getObjectDocumentId(objectId);
-      if (objectDocId !== documentId) {
-        log.warn("documentIds don't match", { objectId, expected: documentId, actual: objectDocId ?? null });
-        return undefined;
-      }
+    const objectDocId = db._coreDatabase._automergeDocLoader.getObjectDocumentId(objectId);
+    if (objectDocId !== documentId) {
+      log("documentIds don't match", { objectId, expected: documentId, actual: objectDocId ?? null });
+      return undefined;
     }
 
     return db.loadObjectById(objectId);

--- a/packages/core/echo/echo-db/src/client/index-query-source-provider.ts
+++ b/packages/core/echo/echo-db/src/client/index-query-source-provider.ts
@@ -138,7 +138,7 @@ export class IndexQuerySource implements QuerySource {
 
         try {
           const processedResults = await Promise.all(
-            (response.results ?? []).map((result) => this._filterMapResult(ctx, queryType, start, result)),
+            (response.results ?? []).map((result) => this._filterMapResult(ctx, start, result)),
           );
           const results = processedResults.filter(nonNullable);
 
@@ -167,7 +167,6 @@ export class IndexQuerySource implements QuerySource {
 
   private async _filterMapResult(
     ctx: Context,
-    queryType: QueryType,
     queryStartTimestamp: number,
     result: RemoteQueryResult,
   ): Promise<QueryResult | null> {

--- a/packages/core/echo/echo-db/src/client/index-query-source-provider.ts
+++ b/packages/core/echo/echo-db/src/client/index-query-source-provider.ts
@@ -24,7 +24,6 @@ export type LoadObjectParams = {
   spaceKey: PublicKey;
   objectId: string;
   documentId: string;
-  localDataOnly: boolean;
 };
 
 export interface ObjectLoader {
@@ -185,7 +184,6 @@ export class IndexQuerySource implements QuerySource {
       spaceKey: result.spaceKey,
       objectId: result.id,
       documentId: result.documentId,
-      localDataOnly: queryType === QueryType.ONE_SHOT,
     });
     if (!object) {
       return null;


### PR DESCRIPTION
After space root migrations index might still contain references to removed objects. Don't wait for their load in async queries - only load objects where `(id, documentUrl)` is present in the current `spaceRoot.links` map.