### PR TITLE
refactor: graph optimizations to avoid long render tasks

### DIFF
--- a/packages/apps/composer-app/src/help.ts
+++ b/packages/apps/composer-app/src/help.ts
@@ -35,17 +35,17 @@ export const steps: Step[] = [
   {
     ...base,
     before: ensureSidebar,
-    target: '[data-testid="spacePlugin.createObject"]',
-    title: 'Creating content',
-    content: 'Press (+) to add new content.',
+    target: '[data-testid="spacePlugin.createSpace"]',
+    title: 'Sharing',
+    content: 'Create shared spaces to collaborate with others.',
     placement: 'bottom',
   },
   {
     ...base,
     before: ensureSidebar,
-    target: '[data-testid="spacePlugin.createSpace"]',
-    title: 'Sharing',
-    content: 'Create shared spaces to collaborate with others.',
+    target: '[data-testid="spacePlugin.createObject"]',
+    title: 'Creating content',
+    content: 'Press (+) to add new content.',
     placement: 'bottom',
   },
   {

--- a/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
+++ b/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
@@ -143,8 +143,12 @@ const NodePlankHeading = ({
   const ActionRoot = node && popoverAnchorId === `dxos.org/ui/${DECK_PLUGIN}/${node.id}` ? Popover.Anchor : Fragment;
 
   useEffect(() => {
-    // Load actions for the node.
-    node && graph.actions(node);
+    const frame = requestAnimationFrame(() => {
+      // Load actions for the node.
+      node && graph.actions(node);
+    });
+
+    return () => cancelAnimationFrame(frame);
   }, [node]);
 
   return (
@@ -155,7 +159,7 @@ const NodePlankHeading = ({
             Icon={Icon}
             attendableId={node.id}
             triggerLabel={t('actions menu label')}
-            actions={graph.actions(node, { onlyLoaded: true })}
+            actions={graph.actions(node)}
             onAction={(action) =>
               typeof action.data === 'function' && action.data?.({ node: action as Node, caller: DECK_PLUGIN })
             }

--- a/packages/apps/plugins/plugin-deck/src/hooks/useNode.ts
+++ b/packages/apps/plugins/plugin-deck/src/hooks/useNode.ts
@@ -20,7 +20,8 @@ export const useNodes = (graph: Graph, ids: string[], timeout?: number): Node[] 
   const [nodes, setNodes] = useState<Node[]>([]);
 
   useEffect(() => {
-    const t = setTimeout(async () => {
+    // Set timeout did not seem to effectively not block the UI thread.
+    const frame = requestAnimationFrame(async () => {
       const maybeNodes = await Promise.all(
         ids.map(async (id) => {
           try {
@@ -33,7 +34,7 @@ export const useNodes = (graph: Graph, ids: string[], timeout?: number): Node[] 
       setNodes(maybeNodes.filter(nonNullable));
     });
 
-    return () => clearTimeout(t);
+    return () => cancelAnimationFrame(frame);
   }, [graph, JSON.stringify(ids)]);
 
   return nodes;
@@ -55,7 +56,9 @@ export const useNode = <T = any>(graph: Graph, id?: string, timeout?: number): N
     if (nodeState?.id === id || !id) {
       return;
     }
-    const t = setTimeout(async () => {
+
+    // Set timeout did not seem to effectively not block the UI thread.
+    const frame = requestAnimationFrame(async () => {
       try {
         const node = await graph.waitForNode(id, timeout);
         if (node) {
@@ -63,7 +66,8 @@ export const useNode = <T = any>(graph: Graph, id?: string, timeout?: number): N
         }
       } catch {}
     });
-    return () => clearTimeout(t);
+
+    return () => cancelAnimationFrame(frame);
   }, [graph, id, timeout, nodeState?.id]);
 
   return nodeState;

--- a/packages/apps/plugins/plugin-navtree/src/NavTreePlugin.tsx
+++ b/packages/apps/plugins/plugin-navtree/src/NavTreePlugin.tsx
@@ -65,7 +65,6 @@ export const NavTreePlugin = (): PluginDefinition<NavTreePluginProvides> => {
       // TODO(wittjosiah): Factor out.
       // TODO(wittjosiah): Handle removal of actions.
       graph.subscribeTraverse({
-        onlyLoaded: true,
         visitor: (node, path) => {
           // TODO(wittjosiah): Remove.
           paths.set(node.id, path);

--- a/packages/sdk/app-graph/src/graph-builder.test.ts
+++ b/packages/sdk/app-graph/src/graph-builder.test.ts
@@ -3,7 +3,8 @@
 //
 
 import { signal } from '@preact/signals-core';
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
 import { describe, test } from '@dxos/test';
 
@@ -11,13 +12,15 @@ import { ACTION_TYPE } from './graph';
 import { GraphBuilder, createExtension, memoize } from './graph-builder';
 import { type Node } from './node';
 
+chai.use(chaiAsPromised);
+
 const exampleId = (id: number) => `dx:test:${id}`;
 const EXAMPLE_ID = exampleId(1);
 const EXAMPLE_TYPE = 'dxos.org/type/example';
 
 describe('GraphBuilder', () => {
   describe('resolver', () => {
-    test('works', () => {
+    test('works', async () => {
       const builder = new GraphBuilder();
       const graph = builder.graph;
 
@@ -31,14 +34,14 @@ describe('GraphBuilder', () => {
       );
 
       {
-        const node = graph.findNode(EXAMPLE_ID);
+        const node = await graph.waitForNode(EXAMPLE_ID);
         expect(node?.id).to.equal(EXAMPLE_ID);
         expect(node?.type).to.equal(EXAMPLE_TYPE);
         expect(node?.data).to.equal(1);
       }
     });
 
-    test('updates', () => {
+    test('updates', async () => {
       const builder = new GraphBuilder();
       const name = signal('default');
       builder.addExtension(
@@ -46,14 +49,14 @@ describe('GraphBuilder', () => {
       );
       const graph = builder.graph;
 
-      const node = graph.findNode(EXAMPLE_ID);
+      const node = await graph.waitForNode(EXAMPLE_ID);
       expect(node?.data).to.equal('default');
 
       name.value = 'updated';
       expect(node?.data).to.equal('updated');
     });
 
-    test('memoize', () => {
+    test('memoize', async () => {
       const builder = new GraphBuilder();
       const name = signal('default');
       let count = 0;
@@ -73,7 +76,7 @@ describe('GraphBuilder', () => {
       );
       const graph = builder.graph;
 
-      const node = graph.findNode(EXAMPLE_ID);
+      const node = await graph.waitForNode(EXAMPLE_ID);
       expect(node?.data).to.equal('default');
       expect(count).to.equal(1);
       expect(memoizedCount).to.equal(1);
@@ -89,9 +92,8 @@ describe('GraphBuilder', () => {
   });
 
   describe('connector', () => {
-    test('works', () => {
+    test('works', async () => {
       const builder = new GraphBuilder();
-      const graph = builder.graph;
       builder.addExtension(
         createExtension({
           id: 'outbound-connector',
@@ -106,6 +108,10 @@ describe('GraphBuilder', () => {
         }),
       );
 
+      const graph = builder.graph;
+      await graph.expand(graph.root);
+      await graph.expand(graph.root, 'inbound');
+
       const outbound = graph.nodes(graph.root);
       const inbound = graph.nodes(graph.root, { relation: 'inbound' });
 
@@ -117,7 +123,7 @@ describe('GraphBuilder', () => {
       expect(inbound?.[0].data).to.equal(0);
     });
 
-    test('updates', () => {
+    test('updates', async () => {
       const name = signal('default');
       const builder = new GraphBuilder();
       builder.addExtension(
@@ -127,6 +133,7 @@ describe('GraphBuilder', () => {
         }),
       );
       const graph = builder.graph;
+      await graph.expand(graph.root);
 
       const [node] = graph.nodes(graph.root);
       expect(node.properties.label).to.equal('default');
@@ -135,7 +142,7 @@ describe('GraphBuilder', () => {
       expect(node.properties.label).to.equal('updated');
     });
 
-    test('removes', () => {
+    test('removes', async () => {
       const nodes = signal([
         { id: exampleId(1), type: EXAMPLE_TYPE, data: 1 },
         { id: exampleId(2), type: EXAMPLE_TYPE, data: 2 },
@@ -149,6 +156,7 @@ describe('GraphBuilder', () => {
         }),
       );
       const graph = builder.graph;
+      await graph.expand(graph.root);
 
       {
         const nodes = graph.nodes(graph.root);
@@ -166,7 +174,7 @@ describe('GraphBuilder', () => {
       }
     });
 
-    test('filters by type', () => {
+    test('filters by type', async () => {
       const builder = new GraphBuilder();
       builder.addExtension(
         createExtension({
@@ -177,21 +185,22 @@ describe('GraphBuilder', () => {
       );
       const graph = builder.graph;
 
+      await graph.expand(graph.root, 'outbound', ACTION_TYPE);
       const actions = graph.actions(graph.root);
       expect(actions).has.length(1);
       expect(actions?.[0].id).to.equal('action');
       expect(actions?.[0].type).to.equal(ACTION_TYPE);
 
-      const node = graph.findNode('not-action', EXAMPLE_TYPE);
-      expect(node).to.be.undefined;
+      await expect(graph.waitForNode('not-action', 10)).to.be.rejected;
 
+      await graph.expand(graph.root);
       const nodes = graph.nodes(graph.root);
       expect(nodes).has.length(1);
       expect(nodes?.[0].id).to.equal('not-action');
       expect(nodes?.[0].data).to.equal(1);
     });
 
-    test('filters by callback', () => {
+    test('filters by callback', async () => {
       const builder = new GraphBuilder();
       builder.addExtension(
         createExtension({
@@ -201,6 +210,7 @@ describe('GraphBuilder', () => {
         }),
       );
       const graph = builder.graph;
+      await graph.expand(graph.root);
 
       const [node1] = graph.nodes(graph.root);
       expect(node1?.id).to.equal(EXAMPLE_ID);
@@ -209,7 +219,7 @@ describe('GraphBuilder', () => {
       expect(nodes).has.length(0);
     });
 
-    test('memoize', () => {
+    test('memoize', async () => {
       const builder = new GraphBuilder();
       const name = signal('default');
       let count = 0;
@@ -228,6 +238,7 @@ describe('GraphBuilder', () => {
         }),
       );
       const graph = builder.graph;
+      await graph.expand(graph.root);
 
       const [node] = graph.nodes(graph.root);
       expect(node.properties.label).to.equal('default');
@@ -271,7 +282,7 @@ describe('GraphBuilder', () => {
   });
 
   describe('multiples', () => {
-    test('one of each with multiple memos', () => {
+    test('one of each with multiple memos', async () => {
       const name = signal('default');
       const builder = new GraphBuilder();
       builder.addExtension(
@@ -291,8 +302,9 @@ describe('GraphBuilder', () => {
       );
       const graph = builder.graph;
 
-      const one = graph.findNode(EXAMPLE_ID);
+      const one = await graph.waitForNode(EXAMPLE_ID);
       const initialData = one!.data;
+      await graph.expand(one!);
       const two = graph.nodes(one!)[0];
       const initialA = two?.data.a;
       const initialB = two?.data.b;

--- a/packages/sdk/app-graph/src/graph-builder.ts
+++ b/packages/sdk/app-graph/src/graph-builder.ts
@@ -338,7 +338,7 @@ export class GraphBuilder {
         );
         this.graph._sortEdges(
           node.id,
-          'outbound',
+          nodesRelation,
           nodes.map(({ id }) => id),
         );
         nodes.forEach((n) => {

--- a/packages/sdk/app-graph/src/graph.ts
+++ b/packages/sdk/app-graph/src/graph.ts
@@ -26,8 +26,6 @@ export const ROOT_TYPE = 'dxos.org/type/GraphRoot';
 export const ACTION_TYPE = 'dxos.org/type/GraphAction';
 export const ACTION_GROUP_TYPE = 'dxos.org/type/GraphActionGroup';
 
-const NODE_TIMEOUT = 5_000;
-
 export type NodesOptions<T = any, U extends Record<string, any> = Record<string, any>> = {
   relation?: Relation;
   filter?: NodeFilter<T, U>;
@@ -160,7 +158,7 @@ export class Graph {
    * @param id The id of the node to wait for.
    * @param timeout The time in milliseconds to wait for the node to be added.
    */
-  async waitForNode(id: string, timeout = NODE_TIMEOUT): Promise<Node> {
+  async waitForNode(id: string, timeout?: number): Promise<Node> {
     const trigger = this._waitingForNodes[id] ?? (this._waitingForNodes[id] = new Trigger<Node>());
     const node = this.findNode(id);
     if (node) {
@@ -168,7 +166,11 @@ export class Graph {
       return node;
     }
 
-    return asyncTimeout(trigger.wait(), timeout, `Node not found: ${id}`);
+    if (timeout === undefined) {
+      return trigger.wait();
+    } else {
+      return asyncTimeout(trigger.wait(), timeout, `Node not found: ${id}`);
+    }
   }
 
   /**

--- a/packages/sdk/app-graph/src/graph.ts
+++ b/packages/sdk/app-graph/src/graph.ts
@@ -31,7 +31,7 @@ const NODE_TIMEOUT = 5_000;
 export type NodesOptions<T = any, U extends Record<string, any> = Record<string, any>> = {
   relation?: Relation;
   filter?: NodeFilter<T, U>;
-  onlyLoaded?: boolean;
+  expansion?: boolean;
   type?: string;
 };
 
@@ -58,18 +58,18 @@ export type GraphTraversalOptions = {
   relation?: Relation;
 
   /**
-   * Only traverse nodes that are already loaded.
+   * Allow traversal to trigger expansion of the graph via `onInitialNodes`.
    */
-  onlyLoaded?: boolean;
+  expansion?: boolean;
 };
 
 /**
  * The Graph represents the structure of the application constructed via plugins.
  */
 export class Graph {
-  private readonly _onInitialNode?: (id: string, type?: string) => NodeArg<any> | undefined;
-  private readonly _onInitialNodes?: (node: Node, relation: Relation, type?: string) => NodeArg<any>[] | undefined;
-  private readonly _onRemoveNode?: (id: string) => void;
+  private readonly _onInitialNode?: (id: string) => Promise<void>;
+  private readonly _onInitialNodes?: (node: Node, relation: Relation, type?: string) => Promise<void>;
+  private readonly _onRemoveNode?: (id: string) => Promise<void>;
 
   private readonly _waitingForNodes: Record<string, Trigger<Node>> = {};
   private readonly _initialized: Record<string, boolean> = {};
@@ -110,13 +110,9 @@ export class Graph {
   /**
    * Convert the graph to a JSON object.
    */
-  toJSON({
-    id = ROOT_ID,
-    maxLength = 32,
-    onlyLoaded = true,
-  }: { id?: string; maxLength?: number; onlyLoaded?: boolean } = {}) {
+  toJSON({ id = ROOT_ID, maxLength = 32 }: { id?: string; maxLength?: number } = {}) {
     const toJSON = (node: Node, seen: string[] = []): any => {
-      const nodes = this.nodes(node, { onlyLoaded });
+      const nodes = this.nodes(node);
       const obj: Record<string, any> = {
         id: node.id.length > maxLength ? `${node.id.slice(0, maxLength - 3)}...` : node.id,
         type: node.type,
@@ -147,10 +143,13 @@ export class Graph {
    * If a node is not found within the graph and an `onInitialNode` callback is provided,
    * it is called with the id and type of the node, potentially initializing the node.
    */
-  findNode(id: string, type?: string): Node | undefined {
+  findNode(id: string): Node | undefined {
     const existingNode = this._nodes[id];
-    const nodeArg = !existingNode && this._onInitialNode?.(id, type);
-    return existingNode ?? (nodeArg ? this._addNode(nodeArg) : undefined);
+    if (!existingNode) {
+      void this._onInitialNode?.(id);
+    }
+
+    return existingNode;
   }
 
   /**
@@ -162,12 +161,13 @@ export class Graph {
    * @param timeout The time in milliseconds to wait for the node to be added.
    */
   async waitForNode(id: string, timeout = NODE_TIMEOUT): Promise<Node> {
+    const trigger = this._waitingForNodes[id] ?? (this._waitingForNodes[id] = new Trigger<Node>());
     const node = this.findNode(id);
     if (node) {
+      delete this._waitingForNodes[id];
       return node;
     }
 
-    const trigger = this._waitingForNodes[id] ?? (this._waitingForNodes[id] = new Trigger<Node>());
     return asyncTimeout(trigger.wait(), timeout, `Node not found: ${id}`);
   }
 
@@ -175,8 +175,8 @@ export class Graph {
    * Nodes that this node is connected to in default order.
    */
   nodes<T = any, U extends Record<string, any> = Record<string, any>>(node: Node, options: NodesOptions<T, U> = {}) {
-    const { onlyLoaded, relation, filter, type } = options;
-    const nodes = this._getNodes({ node, relation, type, onlyLoaded });
+    const { relation, expansion, filter, type } = options;
+    const nodes = this._getNodes({ node, relation, expansion, type });
     return nodes.filter((n) => untracked(() => !isActionLike(n))).filter((n) => filter?.(n, node) ?? true);
   }
 
@@ -190,11 +190,21 @@ export class Graph {
   /**
    * Actions or action groups that this node is connected to in default order.
    */
-  actions(node: Node, { onlyLoaded }: { onlyLoaded?: boolean } = {}) {
+  actions(node: Node, { expansion }: { expansion?: boolean } = {}) {
     return [
-      ...this._getNodes({ node, type: ACTION_GROUP_TYPE, onlyLoaded }),
-      ...this._getNodes({ node, type: ACTION_TYPE, onlyLoaded }),
+      ...this._getNodes({ node, expansion, type: ACTION_GROUP_TYPE }),
+      ...this._getNodes({ node, expansion, type: ACTION_TYPE }),
     ];
+  }
+
+  async expand(node: Node, relation: Relation = 'outbound', type?: string) {
+    // TODO(wittjosiah): Factor out helper.
+    const key = `${node.id}-${relation}-${type}`;
+    const initialized = this._initialized[key];
+    if (!initialized && this._onInitialNodes) {
+      await this._onInitialNodes(node, relation, type);
+      this._initialized[key] = true;
+    }
   }
 
   /**
@@ -205,7 +215,7 @@ export class Graph {
    * @param options.visitor A callback which is called for each node visited during traversal.
    */
   traverse(
-    { visitor, node = this.root, relation = 'outbound', onlyLoaded }: GraphTraversalOptions,
+    { visitor, node = this.root, relation = 'outbound', expansion }: GraphTraversalOptions,
     path: string[] = [],
   ): void {
     // Break cycles.
@@ -218,8 +228,8 @@ export class Graph {
       return;
     }
 
-    Object.values(this._getNodes({ node, relation, onlyLoaded })).forEach((child) =>
-      this.traverse({ node: child, relation, visitor, onlyLoaded }, [...path, node.id]),
+    Object.values(this._getNodes({ node, relation, expansion })).forEach((child) =>
+      this.traverse({ node: child, relation, visitor, expansion }, [...path, node.id]),
     );
   }
 
@@ -231,7 +241,7 @@ export class Graph {
    * @param options.visitor A callback which is called for each node visited during traversal.
    */
   subscribeTraverse(
-    { visitor, node = this.root, relation = 'outbound', onlyLoaded }: GraphTraversalOptions,
+    { visitor, node = this.root, relation = 'outbound', expansion }: GraphTraversalOptions,
     currentPath: string[] = [],
   ) {
     return effect(() => {
@@ -241,8 +251,8 @@ export class Graph {
         return;
       }
 
-      const nodes = this._getNodes({ node, relation, onlyLoaded });
-      const nodeSubscriptions = nodes.map((n) => this.subscribeTraverse({ node: n, visitor, onlyLoaded }, path));
+      const nodes = this._getNodes({ node, relation, expansion });
+      const nodeSubscriptions = nodes.map((n) => this.subscribeTraverse({ node: n, visitor, expansion }, path));
 
       return () => {
         nodeSubscriptions.forEach((unsubscribe) => unsubscribe());
@@ -261,7 +271,6 @@ export class Graph {
 
     let found: string[] | undefined;
     this.traverse({
-      onlyLoaded: true,
       node: start,
       visitor: (node, path) => {
         if (found) {
@@ -361,10 +370,10 @@ export class Graph {
 
       if (edges) {
         // Remove edges from connected nodes.
-        this._getNodes({ node, onlyLoaded: true }).forEach((node) => {
+        this._getNodes({ node }).forEach((node) => {
           this._removeEdge({ source: id, target: node.id });
         });
-        this._getNodes({ node, relation: 'inbound', onlyLoaded: true }).forEach((node) => {
+        this._getNodes({ node, relation: 'inbound' }).forEach((node) => {
           this._removeEdge({ source: node.id, target: id });
         });
 
@@ -374,7 +383,7 @@ export class Graph {
 
       // Remove node.
       delete this._nodes[id];
-      this._onRemoveNode?.(id);
+      void this._onRemoveNode?.(id);
     });
   }
 
@@ -463,27 +472,15 @@ export class Graph {
     node,
     relation = 'outbound',
     type,
-    onlyLoaded,
+    expansion,
   }: {
     node: Node;
     relation?: Relation;
     type?: string;
-    onlyLoaded?: boolean;
+    expansion?: boolean;
   }): Node[] {
-    // TODO(wittjosiah): Factor out helper.
-    const key = `${node.id}-${relation}-${type}`;
-    const initialized = this._initialized[key];
-    if (!initialized && !onlyLoaded && this._onInitialNodes) {
-      const args = this._onInitialNodes(node, relation, type)?.filter((n) => !type || n.type === type);
-      this._initialized[key] = true;
-      if (args && args.length > 0) {
-        const nodes = this._addNodes(args);
-        this._addEdges(
-          nodes.map(({ id }) =>
-            relation === 'outbound' ? { source: node.id, target: id } : { source: id, target: node.id },
-          ),
-        );
-      }
+    if (expansion) {
+      void this.expand(node, relation, type);
     }
 
     const edges = this._edges[node.id];

--- a/packages/sdk/app-graph/src/stories/EchoGraph.stories.tsx
+++ b/packages/sdk/app-graph/src/stories/EchoGraph.stories.tsx
@@ -106,6 +106,12 @@ const objectBuilderExtension = createExtension({
 
 const graph = new GraphBuilder().addExtension(spaceBuilderExtension).addExtension(objectBuilderExtension).graph;
 
+graph.subscribeTraverse({
+  visitor: (node) => {
+    void graph.expand(node);
+  },
+});
+
 enum Action {
   CREATE_SPACE = 'CREATE_SPACE',
   CLOSE_SPACE = 'CLOSE_SPACE',
@@ -243,7 +249,7 @@ const EchoGraphStory = () => {
           </Select.Root>
         </DensityProvider>
       </div>
-      <Tree data={graph.toJSON({ onlyLoaded: false })} />
+      <Tree data={graph.toJSON()} />
     </>
   );
 };

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItem.tsx
@@ -129,17 +129,26 @@ export const NavTreeItem: MosaicTileComponent<NavTreeItemData, HTMLLIElement> = 
     const [tooltipOpen, setTooltipOpen] = useState<boolean>(false);
     const [menuOpen, setMenuOpen] = useState<boolean>(false);
 
+    // TODO(wittjosiah): Don't do this in an effect, trigger more directly via user interaction.
     useEffect(() => {
-      node.loadActions();
+      const frame = requestAnimationFrame(() => {
+        node.loadActions();
 
-      // Preload children for branches to avoid flickering when opening.
-      node.loadChildren();
+        // Preload children for branches to avoid flickering when opening.
+        node.loadChildren();
+      });
+
+      return () => cancelAnimationFrame(frame);
     }, [node]);
 
     useEffect(() => {
-      if (primaryAction && 'actions' in primaryAction) {
-        primaryAction.loadActions();
-      }
+      const frame = requestAnimationFrame(() => {
+        if (primaryAction && 'actions' in primaryAction) {
+          primaryAction.loadActions();
+        }
+      });
+
+      return () => cancelAnimationFrame(frame);
     }, [primaryAction]);
 
     const disabled = !!(node.properties?.disabled ?? node.properties?.isPreview);

--- a/packages/ui/react-ui-navtree/src/helpers.ts
+++ b/packages/ui/react-ui-navtree/src/helpers.ts
@@ -2,7 +2,16 @@
 // Copyright 2024 DXOS.org
 //
 
-import { type Action, type ActionGroup, isAction, type Node, type NodeFilter, type Graph } from '@dxos/app-graph';
+import {
+  type Action,
+  type ActionGroup,
+  isAction,
+  type Node,
+  type NodeFilter,
+  type Graph,
+  ACTION_TYPE,
+  ACTION_GROUP_TYPE,
+} from '@dxos/app-graph';
 import { create } from '@dxos/echo-schema';
 import { nonNullable } from '@dxos/util';
 
@@ -64,7 +73,7 @@ export const treeNodeFromGraphNode = (
     },
     get children() {
       return graph
-        .nodes(node, { filter, onlyLoaded: true })
+        .nodes(node, { filter })
         .map((n) => {
           // Break cycles.
           const nextPath = [...path, node.id];
@@ -74,7 +83,7 @@ export const treeNodeFromGraphNode = (
     },
     get actions() {
       return graph
-        .actions(node, { onlyLoaded: true })
+        .actions(node)
         .map((action) =>
           isAction(action)
             ? treeActionFromGraphAction(graph, action)
@@ -82,10 +91,11 @@ export const treeNodeFromGraphNode = (
         );
     },
     loadChildren: () => {
-      graph.nodes(node, { filter });
+      void graph.expand(node);
     },
     loadActions: () => {
-      graph.actions(node);
+      void graph.expand(node, 'outbound', ACTION_TYPE);
+      void graph.expand(node, 'outbound', ACTION_GROUP_TYPE);
     },
   });
 
@@ -123,11 +133,11 @@ export const treeActionGroupFromGraphActionGroup = (graph: Graph, actionGroup: A
     get actions() {
       // TODO(wittjosiah): Support nested action groups.
       return graph
-        .actions(actionGroup, { onlyLoaded: true })
+        .actions(actionGroup)
         .flatMap((action) => (isAction(action) ? treeActionFromGraphAction(graph, action) : []));
     },
     loadActions: () => {
-      graph.actions(actionGroup);
+      void graph.expand(actionGroup, 'outbound', ACTION_TYPE);
     },
   });
 


### PR DESCRIPTION
- make graph expansion explicit
- don't expand the graph by default
- make graph expansion async
- swap setTimeout for requestAnimationFrame in a few couple effects
