### PR TITLE
chore: ensure first run is only triggered once

### DIFF
--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -50,6 +50,7 @@ import WildcardMeta from '@braneframe/plugin-wildcard/meta';
 import { DocumentType, TextType, CollectionType } from '@braneframe/types';
 import { LegacyTypes } from '@braneframe/types/migrations';
 import { createApp, NavigationAction, parseIntentPlugin, Plugin, resolvePlugin } from '@dxos/app-framework';
+import { Trigger } from '@dxos/async';
 import { createStorageObjects } from '@dxos/client-services';
 import { defs, SaveConfig } from '@dxos/config';
 import { registerSignalRuntime } from '@dxos/echo-signals';
@@ -108,6 +109,8 @@ const main = async () => {
     observabilityGroup,
     !observabilityDisabled,
   );
+
+  const firstRun = new Trigger();
   const isSocket = !!(globalThis as any).__args;
   const isPwa = config.values.runtime?.app?.env?.DX_PWA !== 'false';
   const isDeck = localStorage.getItem('dxos.org/settings/layout/disable-deck') !== 'true';
@@ -283,6 +286,7 @@ const main = async () => {
       [SettingsMeta.id]: Plugin.lazy(() => import('@braneframe/plugin-settings')),
       [SketchMeta.id]: Plugin.lazy(() => import('@braneframe/plugin-sketch')),
       [SpaceMeta.id]: Plugin.lazy(() => import('@braneframe/plugin-space'), {
+        firstRun,
         onFirstRun: async ({ client, dispatch }) => {
           const { create } = await import('@dxos/echo-schema');
           const personalSpaceCollection = client.spaces.default.properties[CollectionType.typename] as CollectionType;
@@ -302,7 +306,7 @@ const main = async () => {
         appName: 'Composer',
       }),
       [ThreadMeta.id]: Plugin.lazy(() => import('@braneframe/plugin-thread')),
-      [WelcomeMeta.id]: Plugin.lazy(() => import('./plugins/welcome')),
+      [WelcomeMeta.id]: Plugin.lazy(() => import('./plugins/welcome'), { firstRun }),
       [WildcardMeta.id]: Plugin.lazy(() => import('@braneframe/plugin-wildcard')),
     },
     core: [

--- a/packages/apps/composer-app/src/plugins/welcome/WelcomePlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/WelcomePlugin.tsx
@@ -16,6 +16,7 @@ import {
   NavigationAction,
   LayoutAction,
 } from '@dxos/app-framework';
+import { type Trigger } from '@dxos/async';
 import { log } from '@dxos/log';
 
 import { BetaDialog, WelcomeScreen } from './components';
@@ -29,7 +30,11 @@ const TEST_DEPRECATION = /beta_notice/.test(url.href);
 const DEPRECATED_DEPLOYMENT =
   url.hostname === 'composer.dxos.org' || url.hostname === 'composer.staging.dxos.org' || TEST_DEPRECATION;
 
-export const WelcomePlugin = (): PluginDefinition<SurfaceProvides & TranslationsProvides> => {
+export const WelcomePlugin = ({
+  firstRun,
+}: {
+  firstRun?: Trigger;
+}): PluginDefinition<SurfaceProvides & TranslationsProvides> => {
   let hubUrl: string | undefined;
 
   return {
@@ -77,6 +82,7 @@ export const WelcomePlugin = (): PluginDefinition<SurfaceProvides & Translations
           plugin: CLIENT_PLUGIN,
           action: ClientAction.CREATE_IDENTITY,
         });
+        firstRun?.wake();
         identity = result?.data;
       }
 


### PR DESCRIPTION
When redeeming a magic link sometimes the original tab is still open.
The first run code should only run in the tab where the identity is created and not in every tab once the identity is created.
