### PR TITLE
chore: re-create composer global

### DIFF
--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -78,6 +78,9 @@ const main = async () => {
 
   Migrations.define(appKey, __COMPOSER_MIGRATIONS__);
 
+  // Namespace for global Composer test & debug hooks.
+  (window as any).composer = {};
+
   let config = await setupConfig();
   if (
     !config.values.runtime?.client?.storage?.dataStore &&

--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -208,7 +208,7 @@ export class AppManager {
   async changeStorageVersionInMetadata(version: number) {
     await this.page.evaluate(
       ({ version }) => {
-        (window as any).changeStorageVersionInMetadata(version);
+        (window as any).composer.changeStorageVersionInMetadata(version);
       },
       { version },
     );

--- a/packages/apps/plugins/plugin-debug/src/DebugPlugin.tsx
+++ b/packages/apps/plugins/plugin-debug/src/DebugPlugin.tsx
@@ -44,7 +44,8 @@ export const DebugPlugin = (): PluginDefinition<DebugPluginProvides> => {
 
       // TODO(burdon): Remove hacky dependency on global variable.
       // Used to test how composer handles breaking protocol changes.
-      (window as any).changeStorageVersionInMetadata = async (version: number) => {
+      const composer = (window as any).composer;
+      composer.changeStorageVersionInMetadata = async (version: number) => {
         const { changeStorageVersionInMetadata } = await import('@dxos/echo-pipeline/testing');
         const { createStorageObjects } = await import('@dxos/client-services');
         const client: Client = (window as any).dxos.client;


### PR DESCRIPTION
e2e tests depend on the hooks exposed there
