### PR TITLE
refactor: combine index and services exports of client

### DIFF
--- a/packages/apps/composer-app/script-frame/main.tsx
+++ b/packages/apps/composer-app/script-frame/main.tsx
@@ -17,7 +17,7 @@ const init = async (f: () => Promise<Record<string, any>>) =>
   }, {});
 
 const main = async () => {
-  const { ClientServicesProxy } = await import('@dxos/react-client/services');
+  const { ClientServicesProxy } = await import('@dxos/react-client');
   const { createIFramePort } = await import('@dxos/rpc-tunnel');
 
   // @ts-ignore

--- a/packages/apps/composer-app/src/devtools.tsx
+++ b/packages/apps/composer-app/src/devtools.tsx
@@ -9,8 +9,7 @@ import { createRoot } from 'react-dom/client';
 
 import { Devtools } from '@dxos/devtools';
 import { initializeAppObservability } from '@dxos/observability';
-import { type Client } from '@dxos/react-client';
-import { type ClientServices } from '@dxos/react-client/services';
+import { type Client, type ClientServices } from '@dxos/react-client';
 import { type Provider } from '@dxos/util';
 
 const namespace = 'devtools';
@@ -43,8 +42,7 @@ const main = async () => {
     return;
   }
 
-  const { Client, Remote, Config, Defaults } = await import('@dxos/react-client');
-  const { createClientServices } = await import('@dxos/react-client/services');
+  const { createClientServices, Client, Remote, Config, Defaults } = await import('@dxos/react-client');
 
   void initializeAppObservability({ namespace, config: new Config(Defaults()) });
 

--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -72,7 +72,7 @@ const main = async () => {
 
   const { Trigger } = await import('@dxos/async');
   const { defs, SaveConfig } = await import('@dxos/config');
-  const { createClientServices } = await import('@dxos/react-client/services');
+  const { createClientServices } = await import('@dxos/react-client');
   const { __COMPOSER_MIGRATIONS__ } = await import('@braneframe/types/migrations');
   const { Migrations } = await import('@dxos/migrations');
 

--- a/packages/apps/plugins/plugin-debug/src/components/DevtoolsArticle.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DevtoolsArticle.tsx
@@ -5,8 +5,7 @@
 import React from 'react';
 
 import { Devtools } from '@dxos/devtools';
-import { useClient } from '@dxos/react-client';
-import { type ClientServices } from '@dxos/react-client/services';
+import { useClient, type ClientServices } from '@dxos/react-client';
 
 const DevtoolsArticle = () => {
   const client = useClient();

--- a/packages/apps/plugins/plugin-debug/src/components/DevtoolsMain.tsx
+++ b/packages/apps/plugins/plugin-debug/src/components/DevtoolsMain.tsx
@@ -5,8 +5,7 @@
 import React from 'react';
 
 import { Devtools } from '@dxos/devtools';
-import { useClient } from '@dxos/react-client';
-import { type ClientServices } from '@dxos/react-client/services';
+import { useClient, type ClientServices } from '@dxos/react-client';
 import { Main } from '@dxos/react-ui';
 import {
   baseSurface,

--- a/packages/apps/plugins/plugin-help/src/components/HelpContextProvider/HelpContextProvider.tsx
+++ b/packages/apps/plugins/plugin-help/src/components/HelpContextProvider/HelpContextProvider.tsx
@@ -6,8 +6,7 @@ import React, { type PropsWithChildren, useState, useEffect } from 'react';
 import Joyride, { ACTIONS, EVENTS } from 'react-joyride';
 
 import { usePlugins, resolvePlugin, parseLayoutPlugin } from '@dxos/app-framework';
-import { useShellDisplay } from '@dxos/react-client';
-import { ShellDisplay } from '@dxos/react-client/services';
+import { useShellDisplay, ShellDisplay } from '@dxos/react-client';
 // import { useThemeContext } from '@dxos/react-ui';
 import { tailwindConfig, type TailwindConfig } from '@dxos/react-ui-theme';
 

--- a/packages/apps/plugins/plugin-script/src/components/FrameContainer/frame.tsx
+++ b/packages/apps/plugins/plugin-script/src/components/FrameContainer/frame.tsx
@@ -14,7 +14,7 @@ const init = async (f: () => Promise<Record<string, any>>) =>
   }, {});
 
 const main = async () => {
-  const { ClientServicesProxy } = await import('@dxos/react-client/services');
+  const { ClientServicesProxy } = await import('@dxos/react-client');
   const { createIFramePort } = await import('@dxos/rpc-tunnel');
 
   // @ts-ignore

--- a/packages/core/agent/src/agent.ts
+++ b/packages/core/agent/src/agent.ts
@@ -9,8 +9,14 @@ import { type Socket } from 'node:net';
 import { dirname } from 'node:path';
 
 import { Trigger } from '@dxos/async';
-import { type Config, Client, PublicKey } from '@dxos/client';
-import { type ClientServices, type ClientServicesProvider, fromHost } from '@dxos/client/services';
+import {
+  type Config,
+  Client,
+  PublicKey,
+  type ClientServices,
+  type ClientServicesProvider,
+  fromHost,
+} from '@dxos/client';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
 import {

--- a/packages/core/agent/src/plugins/epoch-monitor/plugin.test.ts
+++ b/packages/core/agent/src/plugins/epoch-monitor/plugin.test.ts
@@ -5,8 +5,7 @@
 import { expect } from 'chai';
 
 import { sleep } from '@dxos/async';
-import { Client, Config } from '@dxos/client';
-import { fromHost } from '@dxos/client/services';
+import { Client, Config, fromHost } from '@dxos/client';
 import { Context } from '@dxos/context';
 import { describe, test } from '@dxos/test';
 

--- a/packages/core/agent/src/plugins/plugin.ts
+++ b/packages/core/agent/src/plugins/plugin.ts
@@ -3,8 +3,7 @@
 //
 
 import { Event } from '@dxos/async';
-import { type Client, type Config } from '@dxos/client';
-import { type ClientServicesProvider, type LocalClientServices } from '@dxos/client/services';
+import { type Client, type Config, type ClientServicesProvider, type LocalClientServices } from '@dxos/client';
 import { type ClientServicesHost } from '@dxos/client-services';
 import { Context } from '@dxos/context';
 import { failUndefined } from '@dxos/debug';

--- a/packages/core/agent/src/util.ts
+++ b/packages/core/agent/src/util.ts
@@ -6,8 +6,7 @@ import fs, { existsSync } from 'node:fs';
 import path from 'node:path';
 
 import { Trigger, asyncTimeout, waitForCondition } from '@dxos/async';
-import { SystemStatus } from '@dxos/client';
-import { fromAgent, getUnixSocket } from '@dxos/client/services';
+import { SystemStatus, fromAgent, getUnixSocket } from '@dxos/client';
 import { DX_RUNTIME, getProfilePath } from '@dxos/client-protocol';
 import { invariant } from '@dxos/invariant';
 

--- a/packages/devtools/cli-base/src/base.ts
+++ b/packages/devtools/cli-base/src/base.ts
@@ -13,9 +13,8 @@ import readline from 'node:readline';
 import pkgUp from 'pkg-up';
 
 import { type Daemon, LaunchctlRunner, PhoenixDaemon, SystemctlRunner, SystemDaemon } from '@dxos/agent';
-import { Client, Config } from '@dxos/client';
+import { Client, Config, fromAgent } from '@dxos/client';
 import { type Space } from '@dxos/client/echo';
-import { fromAgent } from '@dxos/client/services';
 import {
   DX_CONFIG,
   DX_DATA,

--- a/packages/devtools/devtools/src/app/App.tsx
+++ b/packages/devtools/devtools/src/app/App.tsx
@@ -4,12 +4,10 @@
 
 import React, { useState } from 'react';
 
-import { createClientServices } from '@dxos/client/services';
 import { log } from '@dxos/log';
 import { type Observability, initializeAppObservability } from '@dxos/observability';
 import { useAsyncEffect } from '@dxos/react-async';
-import { Client, Config, Defaults, Remote } from '@dxos/react-client';
-import { type ClientServices } from '@dxos/react-client/services';
+import { createClientServices, Client, Config, Defaults, Remote, type ClientServices } from '@dxos/react-client';
 
 import { Devtools } from './Devtools';
 import { namespace } from '../hooks';

--- a/packages/devtools/devtools/src/app/Devtools.tsx
+++ b/packages/devtools/devtools/src/app/Devtools.tsx
@@ -6,8 +6,7 @@ import React, { useEffect, type FC, useState } from 'react';
 import { HashRouter } from 'react-router-dom';
 
 import { type Observability } from '@dxos/observability';
-import { type Client, ClientContext } from '@dxos/react-client';
-import { type ClientServices } from '@dxos/react-client/services';
+import { type Client, ClientContext, type ClientServices } from '@dxos/react-client';
 import { DensityProvider, type ThemeMode, ThemeProvider } from '@dxos/react-ui';
 import { defaultTx } from '@dxos/react-ui-theme';
 

--- a/packages/devtools/devtools/src/hooks/useProxiedClient.tsx
+++ b/packages/devtools/devtools/src/hooks/useProxiedClient.tsx
@@ -5,8 +5,7 @@
 import { useState } from 'react';
 
 import { useAsyncEffect } from '@dxos/react-async';
-import { Client, type ClientContextProps } from '@dxos/react-client';
-import { ClientServicesProxy } from '@dxos/react-client/services';
+import { Client, ClientServicesProxy, type ClientContextProps } from '@dxos/react-client';
 import { type RpcPort } from '@dxos/rpc';
 
 /**

--- a/packages/sdk/client/package.json
+++ b/packages/sdk/client/package.json
@@ -50,13 +50,6 @@
       "node": "./dist/lib/node/mesh/index.cjs",
       "types": "./dist/types/src/mesh/index.d.ts"
     },
-    "./services": {
-      "browser": "./dist/lib/browser/services/index.mjs",
-      "import": "./dist/lib/browser/services/index.mjs",
-      "require": "./dist/lib/node/services/index.cjs",
-      "node": "./dist/lib/node/services/index.cjs",
-      "types": "./dist/types/src/services/index.d.ts"
-    },
     "./testing": {
       "browser": "./dist/lib/browser/testing/index.mjs",
       "import": "./dist/lib/browser/testing/index.mjs",
@@ -89,9 +82,6 @@
       ],
       "mesh": [
         "dist/types/src/mesh/index.d.ts"
-      ],
-      "services": [
-        "dist/types/src/services/index.d.ts"
       ],
       "shared-worker": [
         "dist/types/src/worker/shared-worker.d.ts"

--- a/packages/sdk/client/project.json
+++ b/packages/sdk/client/project.json
@@ -17,7 +17,6 @@
           "packages/sdk/client/src/index.ts",
           "packages/sdk/client/src/invitations/index.ts",
           "packages/sdk/client/src/mesh/index.ts",
-          "packages/sdk/client/src/services/index.ts",
           "packages/sdk/client/src/testing/index.ts",
           "packages/sdk/client/src/worker/index.ts"
         ]

--- a/packages/sdk/client/src/client/index.ts
+++ b/packages/sdk/client/src/client/index.ts
@@ -2,4 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './client';
+export { Client, type ClientOptions } from './client';

--- a/packages/sdk/client/src/index.ts
+++ b/packages/sdk/client/src/index.ts
@@ -2,6 +2,7 @@
 // Copyright 2020 DXOS.org
 //
 
+export { type ClientServices, type ClientServicesProvider, type ShellRuntime } from '@dxos/client-protocol';
 export { Config, Defaults, Dynamics, Envs, Local, Remote, Storage } from '@dxos/config';
 export { PublicKey, type PublicKeyLike } from '@dxos/keys';
 // TODO(wittjosiah): Should all api errors be exported here?
@@ -25,6 +26,14 @@ export {
   UnknownModelError,
 } from '@dxos/protocols';
 export { SystemStatus } from '@dxos/protocols/proto/dxos/client/services';
+export {
+  type AppContextRequest,
+  type LayoutRequest,
+  type InvitationUrlRequest,
+  ShellDisplay,
+  ShellLayout,
+} from '@dxos/protocols/proto/dxos/iframe';
 
 export { Client, type ClientOptions } from './client';
+export * from './services';
 export { DXOS_VERSION } from './version';

--- a/packages/sdk/client/src/services/index.ts
+++ b/packages/sdk/client/src/services/index.ts
@@ -2,15 +2,6 @@
 // Copyright 2021 DXOS.org
 //
 
-export { type ClientServices, type ClientServicesProvider, type ShellRuntime } from '@dxos/client-protocol';
-export {
-  type AppContextRequest,
-  type LayoutRequest,
-  type InvitationUrlRequest,
-  ShellDisplay,
-  ShellLayout,
-} from '@dxos/protocols/proto/dxos/iframe';
-
 export { getUnixSocket, fromAgent, type FromAgentOptions, AgentClientServiceProvider } from './agent';
 export { createClientServices } from './client-services-factory';
 // TODO(wittjosiah): Remove this once this is internal to shell manager.

--- a/packages/sdk/react-client/package.json
+++ b/packages/sdk/react-client/package.json
@@ -49,13 +49,6 @@
       "node": "./dist/lib/node/mesh/index.cjs",
       "types": "./dist/types/src/mesh/index.d.ts"
     },
-    "./services": {
-      "browser": "./dist/lib/browser/services/index.mjs",
-      "import": "./dist/lib/browser/services/index.mjs",
-      "require": "./dist/lib/node/services/index.cjs",
-      "node": "./dist/lib/node/services/index.cjs",
-      "types": "./dist/types/src/services/index.d.ts"
-    },
     "./testing": {
       "browser": "./dist/lib/browser/testing/index.mjs",
       "import": "./dist/lib/browser/testing/index.mjs",
@@ -88,9 +81,6 @@
       ],
       "mesh": [
         "dist/types/src/mesh/index.d.ts"
-      ],
-      "services": [
-        "dist/types/src/services/index.d.ts"
       ],
       "testing": [
         "dist/types/src/testing/index.d.ts"

--- a/packages/sdk/react-client/project.json
+++ b/packages/sdk/react-client/project.json
@@ -17,7 +17,6 @@
           "packages/sdk/react-client/src/index.ts",
           "packages/sdk/react-client/src/invitations/index.ts",
           "packages/sdk/react-client/src/mesh/index.ts",
-          "packages/sdk/react-client/src/services/index.ts",
           "packages/sdk/react-client/src/testing/index.ts",
           "packages/sdk/react-client/src/worker.ts"
         ]

--- a/packages/sdk/react-client/src/client/AgentHostingProvider.tsx
+++ b/packages/sdk/react-client/src/client/AgentHostingProvider.tsx
@@ -4,8 +4,8 @@
 
 import React, { createContext, type PropsWithChildren, useContext, useState } from 'react';
 
+import { type AgentHostingProviderClient, AgentManagerClient, FakeAgentHostingProvider } from '@dxos/client';
 import { type Halo } from '@dxos/client/halo';
-import { type AgentHostingProviderClient, AgentManagerClient, FakeAgentHostingProvider } from '@dxos/client/services';
 import { type Config } from '@dxos/config';
 import { log } from '@dxos/log';
 

--- a/packages/sdk/react-client/src/client/ClientContext.stories.tsx
+++ b/packages/sdk/react-client/src/client/ClientContext.stories.tsx
@@ -6,7 +6,7 @@ import '@dxosTheme';
 
 import React, { Component, type PropsWithChildren } from 'react';
 
-import { fromHost } from '@dxos/client/services';
+import { fromHost } from '@dxos/client';
 import { Config } from '@dxos/config';
 import { withTheme } from '@dxos/storybook-utils';
 

--- a/packages/sdk/react-client/src/client/ClientContext.test.tsx
+++ b/packages/sdk/react-client/src/client/ClientContext.test.tsx
@@ -7,8 +7,7 @@ import expect from 'expect';
 import React, { Component, type PropsWithChildren } from 'react';
 
 import { waitForCondition } from '@dxos/async';
-import { Client, Config, SystemStatus } from '@dxos/client';
-import { fromHost } from '@dxos/client/services';
+import { Client, Config, SystemStatus, fromHost } from '@dxos/client';
 import { log } from '@dxos/log';
 import { describe, test } from '@dxos/test';
 

--- a/packages/sdk/react-client/src/client/ClientContext.tsx
+++ b/packages/sdk/react-client/src/client/ClientContext.tsx
@@ -13,8 +13,13 @@ import React, {
   useMemo,
 } from 'react';
 
-import { Client, SystemStatus, type ClientOptions } from '@dxos/client';
-import { type ClientServices, type ClientServicesProvider } from '@dxos/client/services';
+import {
+  Client,
+  SystemStatus,
+  type ClientOptions,
+  type ClientServices,
+  type ClientServicesProvider,
+} from '@dxos/client';
 import { type Config } from '@dxos/config';
 import { raise } from '@dxos/debug';
 import { registerSignalFactory } from '@dxos/echo-signals/react';

--- a/packages/sdk/react-client/src/client/index.ts
+++ b/packages/sdk/react-client/src/client/index.ts
@@ -2,6 +2,7 @@
 // Copyright 2020 DXOS.org
 //
 
+export * from './AgentHostingProvider';
 export * from './ClientContext';
 export * from './useClientServices';
 export * from './useConfig';

--- a/packages/sdk/react-client/src/client/useClientServices.ts
+++ b/packages/sdk/react-client/src/client/useClientServices.ts
@@ -4,7 +4,7 @@
 
 import { useContext } from 'react';
 
-import type { ClientServices } from '@dxos/client/services';
+import type { ClientServices } from '@dxos/client';
 import { raise } from '@dxos/debug';
 
 import { ClientContext } from './ClientContext';

--- a/packages/sdk/react-client/src/client/useConfig.test.tsx
+++ b/packages/sdk/react-client/src/client/useConfig.test.tsx
@@ -7,8 +7,7 @@ import expect from 'expect';
 import React from 'react';
 
 import { waitForCondition } from '@dxos/async';
-import { Client, Config, SystemStatus } from '@dxos/client';
-import { fromHost } from '@dxos/client/services';
+import { Client, Config, SystemStatus, fromHost } from '@dxos/client';
 import { describe, test } from '@dxos/test';
 
 import { ClientProvider } from './ClientContext';

--- a/packages/sdk/react-client/src/client/useShell.ts
+++ b/packages/sdk/react-client/src/client/useShell.ts
@@ -4,7 +4,7 @@
 
 import { useEffect, useState } from 'react';
 
-import { type Shell, type ShellDisplay } from '@dxos/client/services';
+import { type Shell, type ShellDisplay } from '@dxos/client';
 
 import { useClient } from './ClientContext';
 

--- a/packages/sdk/react-client/src/echo/useSpaces.test.tsx
+++ b/packages/sdk/react-client/src/echo/useSpaces.test.tsx
@@ -6,8 +6,7 @@ import { act, renderHook } from '@testing-library/react';
 import { expect } from 'chai';
 import React from 'react';
 
-import { Client } from '@dxos/client';
-import { fromHost } from '@dxos/client/services';
+import { Client, fromHost } from '@dxos/client';
 import { describe, test } from '@dxos/test';
 
 import { useSpace, useSpaces } from './useSpaces';

--- a/packages/sdk/react-client/src/halo/useDevices.test.tsx
+++ b/packages/sdk/react-client/src/halo/useDevices.test.tsx
@@ -6,8 +6,7 @@ import { renderHook } from '@testing-library/react';
 import { expect } from 'chai';
 import React from 'react';
 
-import { Client } from '@dxos/client';
-import { fromHost } from '@dxos/client/services';
+import { Client, fromHost } from '@dxos/client';
 import { describe, test } from '@dxos/test';
 
 import { useDevices } from './useDevices';

--- a/packages/sdk/react-client/src/services/index.ts
+++ b/packages/sdk/react-client/src/services/index.ts
@@ -1,7 +1,0 @@
-//
-// Copyright 2024 DXOS.org
-//
-
-export * from '@dxos/client/services';
-
-export * from './AgentHostingProvider';

--- a/packages/sdk/shell/src/composites/Shell/Shell.tsx
+++ b/packages/sdk/shell/src/composites/Shell/Shell.tsx
@@ -6,14 +6,14 @@ import React, { useEffect, useState } from 'react';
 
 import { log } from '@dxos/log';
 import { useClient } from '@dxos/react-client';
-import { useSpace } from '@dxos/react-client/echo';
 import {
-  type InvitationUrlRequest,
-  type LayoutRequest,
   ShellDisplay,
   ShellLayout,
+  type InvitationUrlRequest,
+  type LayoutRequest,
   type ShellRuntime,
-} from '@dxos/react-client/services';
+} from '@dxos/react-client';
+import { useSpace } from '@dxos/react-client/echo';
 
 import { IdentityDialog } from '../IdentityDialog';
 import { JoinDialog } from '../JoinDialog';

--- a/packages/sdk/shell/src/composites/Shell/ShellContext.tsx
+++ b/packages/sdk/shell/src/composites/Shell/ShellContext.tsx
@@ -13,10 +13,9 @@ import React, {
   useState,
 } from 'react';
 
-import { type PublicKey, useClient } from '@dxos/react-client';
+import { type PublicKey, useClient, ShellDisplay, ShellLayout, type LayoutRequest } from '@dxos/react-client';
 import type { Space } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
-import { ShellDisplay, ShellLayout, type LayoutRequest } from '@dxos/react-client/services';
 import { mx } from '@dxos/react-ui-theme';
 
 import { Shell } from './Shell';

--- a/packages/sdk/shell/src/composites/Shell/memory-shell-runtime.ts
+++ b/packages/sdk/shell/src/composites/Shell/memory-shell-runtime.ts
@@ -3,14 +3,14 @@
 //
 
 import { Event } from '@dxos/async';
-import { type PublicKey } from '@dxos/react-client';
 import {
   ShellLayout,
   type AppContextRequest,
   type InvitationUrlRequest,
   type LayoutRequest,
+  type PublicKey,
   type ShellRuntime,
-} from '@dxos/react-client/services';
+} from '@dxos/react-client';
 
 // TODO(wittjosiah): Remove?
 export class MemoryShellRuntime implements ShellRuntime {

--- a/packages/sdk/shell/src/composites/Shell/run-shell.tsx
+++ b/packages/sdk/shell/src/composites/Shell/run-shell.tsx
@@ -6,8 +6,15 @@ import React, { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { DEFAULT_CLIENT_CHANNEL, DEFAULT_SHELL_CHANNEL } from '@dxos/client-protocol';
-import { Client, ClientContext, Config, SystemStatus } from '@dxos/react-client';
-import { AgentHostingProvider, ClientServicesProxy, ShellDisplay } from '@dxos/react-client/services';
+import {
+  AgentHostingProvider,
+  Client,
+  ClientContext,
+  ClientServicesProxy,
+  Config,
+  ShellDisplay,
+  SystemStatus,
+} from '@dxos/react-client';
 import { Button, Dialog, ThemeProvider, Tooltip, useTranslation } from '@dxos/react-ui';
 import { defaultTx } from '@dxos/react-ui-theme';
 import { createIFramePort } from '@dxos/rpc-tunnel';

--- a/packages/sdk/shell/src/panels/IdentityPanel/useAgentHandlers.ts
+++ b/packages/sdk/shell/src/panels/IdentityPanel/useAgentHandlers.ts
@@ -7,10 +7,9 @@ import { useCallback, useEffect, useState } from 'react';
 import { type CancellableInvitation } from '@dxos/client-protocol';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
-import { useClient } from '@dxos/react-client';
+import { useClient, useAgentHostingClient } from '@dxos/react-client';
 import { type Identity } from '@dxos/react-client/halo';
 import { Invitation, InvitationEncoder } from '@dxos/react-client/invitations';
-import { useAgentHostingClient } from '@dxos/react-client/services';
 
 import { type AgentFormProps } from '../../components';
 


### PR DESCRIPTION
Otherwise when shell bundled the AgentHostingProvider could not find the ClientContext
