### PR TITLE
fix(threads): React hooks rule violation

### DIFF
--- a/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
+++ b/packages/apps/plugins/plugin-deck/src/components/DeckLayout.tsx
@@ -23,7 +23,7 @@ import {
   useIntentDispatcher,
 } from '@dxos/app-framework';
 import { Button, Dialog, Main, Popover, Status, Tooltip, toLocalizedString, useTranslation } from '@dxos/react-ui';
-import { useAttendable } from '@dxos/react-ui-attention';
+import { createAttendableAttributes } from '@dxos/react-ui-attention';
 import { Deck, deckGrid, PlankHeading, Plank, plankHeadingIconProps } from '@dxos/react-ui-deck';
 import { TextTooltip } from '@dxos/react-ui-text-tooltip';
 import { descriptionText, fixedInsetFlexLayout, getSize, mx } from '@dxos/react-ui-theme';
@@ -63,12 +63,14 @@ export const firstSidebarId = (active: Location['active']): string | undefined =
 export const firstFullscreenId = (active: Location['active']): string | undefined =>
   isActiveParts(active) ? (Array.isArray(active.fullScreen) ? active.fullScreen[0] : active.fullScreen) : undefined;
 
-export const firstComplementaryId = (active: Location['active']): string | undefined =>
-  isActiveParts(active)
-    ? Array.isArray(active.complementary)
-      ? active.complementary[0]
-      : active.complementary
-    : undefined;
+export const useFirstComplementaryId = (active: Location['active']): string | undefined => {
+  return useMemo(() => {
+    if (isActiveParts(active)) {
+      return Array.isArray(active.complementary) ? active.complementary[0] : active.complementary;
+    }
+    return undefined;
+  }, [active]);
+};
 
 const PlankLoading = () => {
   return (
@@ -255,10 +257,11 @@ export const DeckLayout = ({
   const fullScreenNode = useNode(graph, fullScreenSlug);
   const fullScreenAvailable =
     fullScreenSlug?.startsWith(SURFACE_PREFIX) || fullScreenSlug === NAV_ID || !!fullScreenNode;
-  const complementarySlug = firstComplementaryId(activeParts);
+  const complementarySlug = useFirstComplementaryId(activeParts);
   const complementaryNode = useNode(graph, complementarySlug);
   const complementaryAvailable = complementarySlug === NAV_ID || !!complementaryNode;
-  const complementaryAttrs = useAttendable(complementarySlug?.split(SLUG_PATH_SEPARATOR)[0] ?? 'never');
+  const complementaryAttrs = createAttendableAttributes(complementarySlug?.split(SLUG_PATH_SEPARATOR)[0] ?? 'never');
+
   const activeIds = getActiveIds(location.active);
   const mainNodes = useNodesFromSlugs(
     graph,
@@ -428,7 +431,7 @@ export const DeckLayout = ({
               <Deck.Root classNames={mx('absolute inset-0', slots?.deck?.classNames)}>
                 {mainNodes.map(({ id, node, path }, index, main) => {
                   const layoutCoordinate = { part: 'main', index, partSize: main.length } satisfies LayoutCoordinate;
-                  const attendableAttrs = useAttendable(id);
+                  const attendableAttrs = createAttendableAttributes(id);
                   return (
                     <Plank.Root key={id}>
                       <Plank.Content

--- a/packages/apps/plugins/plugin-layout/src/components/MainLayout.tsx
+++ b/packages/apps/plugins/plugin-layout/src/components/MainLayout.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import { Surface, type Toast as ToastSchema } from '@dxos/app-framework';
 import { Button, Main, Dialog, useTranslation, DensityProvider, Popover, Status } from '@dxos/react-ui';
-import { useAttendable } from '@dxos/react-ui-attention';
+import { createAttendableAttributes } from '@dxos/react-ui-attention';
 import { baseSurface, fixedInsetFlexLayout, getSize } from '@dxos/react-ui-theme';
 
 import { Fallback } from './Fallback';
@@ -47,7 +47,7 @@ export const MainLayout = ({
   } = context;
   const { t } = useTranslation(LAYOUT_PLUGIN);
 
-  const attendableAttrs = useAttendable(attendableId);
+  const attendableAttrs = createAttendableAttributes(attendableId);
 
   if (fullscreen) {
     return (

--- a/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/apps/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -44,7 +44,7 @@ import {
   getRangeFromCursor,
 } from '@dxos/react-client/echo';
 import { ScrollArea } from '@dxos/react-ui';
-import { useAttendable } from '@dxos/react-ui-attention';
+import { createAttendableAttributes } from '@dxos/react-ui-attention';
 import { comments, createExternalCommentSync, listener } from '@dxos/react-ui-editor';
 import { translations as threadTranslations } from '@dxos/react-ui-thread';
 import { nonNullable } from '@dxos/util';
@@ -396,7 +396,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
 
                 const qualifiedSubjectId = fullyQualifiedId(doc);
                 const attention = attentionPlugin?.provides.attention?.attended ?? new Set([qualifiedSubjectId]);
-                const attendableAttrs = useAttendable(qualifiedSubjectId);
+                const attendableAttrs = createAttendableAttributes(qualifiedSubjectId);
                 const space = getSpace(doc);
                 const context = space?.db.getObjectById(firstMainId(location?.active));
                 const { showResolvedThreads } = getViewState(qualifiedSubjectId);

--- a/packages/ui/react-ui-attention/src/components/AttentionProvider.tsx
+++ b/packages/ui/react-ui-attention/src/components/AttentionProvider.tsx
@@ -29,7 +29,7 @@ const useHasAttention = (attendableId?: string) => {
  * Computes HTML element attributes to apply so the attention system can detect changes
  * @param attendableId
  */
-const useAttendable = (attendableId?: string) => {
+const createAttendableAttributes = (attendableId?: string) => {
   return { 'data-attendable-id': attendableId };
 };
 
@@ -97,6 +97,6 @@ const AttentionProvider = ({
   );
 };
 
-export { AttentionProvider, useAttentionContext, useHasAttention, useAttendable, ATTENTION_NAME };
+export { AttentionProvider, useAttentionContext, useHasAttention, createAttendableAttributes, ATTENTION_NAME };
 
 export type { AttentionContextValue };

--- a/packages/ui/react-ui-stack/src/components/Section.tsx
+++ b/packages/ui/react-ui-stack/src/components/Section.tsx
@@ -35,7 +35,7 @@ import {
   toLocalizedString,
   type Label,
 } from '@dxos/react-ui';
-import { useAttendable } from '@dxos/react-ui-attention';
+import { createAttendableAttributes } from '@dxos/react-ui-attention';
 import { DropDownMenuDragHandleTrigger, resizeHandle, resizeHandleHorizontal } from '@dxos/react-ui-deck';
 import {
   type MosaicActiveType,
@@ -157,7 +157,7 @@ export const Section: ForwardRefExoticComponent<SectionProps & RefAttributes<HTM
       mover: { cyclic: true, direction: 1, memorizeCurrent: false },
     });
     const sectionContentGroup = useFocusableGroup({});
-    const attendableProps = useAttendable(id);
+    const attendableProps = createAttendableAttributes(id);
 
     return (
       <CollapsiblePrimitive.Root


### PR DESCRIPTION
### Issue
Documents with comments were crashing the app, particularly when refreshing with the 'complementary' part present in the URL. This was caused by a violation of React's Rules of Hooks in the Thread Plugin.

### Root Cause
Analytics hooks were being called within a case statement in the Thread Plugin, violating React's rule that hooks must be called at the top level of a component.

### Notes
- The error manifested far downstream, making initial debugging challenging.
- This highlights the importance of adhering strictly to React's Rules of Hooks.

### Future Improvements
Consider adding the ESLint Rules of Hooks plugin to catch similar issues earlier in the development process.