### PR TITLE
fix: unable to load object in plank

### DIFF
--- a/packages/apps/plugins/plugin-deck/src/hooks/useNode.ts
+++ b/packages/apps/plugins/plugin-deck/src/hooks/useNode.ts
@@ -23,9 +23,9 @@ export const useNodes = (graph: Graph, ids: string[], timeout?: number): Node[] 
     // Set timeout did not seem to effectively not block the UI thread.
     const frame = requestAnimationFrame(async () => {
       const maybeNodes = await Promise.all(
-        ids.map(async (id) => {
+        ids.map((id) => {
           try {
-            return await graph.waitForNode(id, timeout);
+            return graph.waitForNode(id, timeout);
           } catch {
             return undefined;
           }

--- a/packages/sdk/app-graph/src/graph-builder.ts
+++ b/packages/sdk/app-graph/src/graph-builder.ts
@@ -265,35 +265,28 @@ export class GraphBuilder {
 
   private async _onInitialNode(nodeId: string) {
     this._nodeChanged[nodeId] = this._nodeChanged[nodeId] ?? signal({});
-    let resolved = false;
-    for (const { id, resolver } of Object.values(this._extensions)) {
-      if (resolved || !resolver) {
-        continue;
-      }
-
-      const unsubscribe = effect(() => {
-        this._dispatcher.currentExtension = id;
-        this._dispatcher.stateIndex = 0;
-        BuilderInternal.currentDispatcher = this._dispatcher;
-        const node = resolver({ id: nodeId });
-        BuilderInternal.currentDispatcher = undefined;
-        if (node) {
-          resolved = true;
-          this.graph._addNodes([node]);
-          if (this._nodeChanged[node.id]) {
-            this._nodeChanged[node.id].value = {};
+    this._resolverSubscriptions.set(
+      nodeId,
+      effect(() => {
+        for (const { id, resolver } of Object.values(this._extensions)) {
+          if (!resolver) {
+            continue;
+          }
+          this._dispatcher.currentExtension = id;
+          this._dispatcher.stateIndex = 0;
+          BuilderInternal.currentDispatcher = this._dispatcher;
+          const node = resolver({ id: nodeId });
+          BuilderInternal.currentDispatcher = undefined;
+          if (node) {
+            this.graph._addNodes([node]);
+            if (this._nodeChanged[node.id]) {
+              this._nodeChanged[node.id].value = {};
+            }
+            break;
           }
         }
-      });
-
-      if (resolved) {
-        this._resolverSubscriptions.get(nodeId)?.();
-        this._resolverSubscriptions.set(nodeId, unsubscribe);
-        break;
-      } else {
-        unsubscribe();
-      }
-    }
+      }),
+    );
   }
 
   private async _onInitialNodes(node: Node, nodesRelation: Relation, nodesType?: string) {


### PR DESCRIPTION
Resolvers which didn't return right away were being unsubscribed from so if the object wasn't already loaded it would fail to be added to the graph.
This updates resolvers to be treated more the way connectors are where there is only one subscription per id.
It prevents them from clobbering each other by breaking out of the loop after the first resolver returns a value.
This PR also updates the SpacePlugin object resolver to subscribe to more signals and ensure that it emits later even if the object isn't ready right away.
