### PR TITLE
chore: fix react-ui-stack exports

### DIFF
--- a/packages/ui/react-ui-stack/package.json
+++ b/packages/ui/react-ui-stack/package.json
@@ -9,10 +9,16 @@
   "exports": {
     ".": {
       "browser": "./dist/lib/browser/index.mjs",
+      "node": {
+        "default": "./dist/lib/node/index.cjs"
+      },
       "types": "./dist/types/src/index.d.ts"
     },
     "./testing": {
       "browser": "./dist/lib/browser/testing/index.mjs",
+      "node": {
+        "default": "./dist/lib/node/testing/index.cjs"
+      },
       "types": "./dist/types/src/testing/index.d.ts"
     }
   },

--- a/packages/ui/react-ui-stack/project.json
+++ b/packages/ui/react-ui-stack/project.json
@@ -15,7 +15,8 @@
           "packages/ui/react-ui-stack/src/testing/index.ts"
         ],
         "platforms": [
-          "browser"
+          "browser",
+          "node"
         ]
       }
     },


### PR DESCRIPTION
Previously the exports were general so even though the build was an esm build "for browser" it was being used everywhere 
