### PR TITLE
feat: Spreadsheet cell editor (prototype)

### DIFF
--- a/packages/apps/plugins/plugin-sheet/package.json
+++ b/packages/apps/plugins/plugin-sheet/package.json
@@ -43,12 +43,22 @@
     "@dxos/react-client": "workspace:*",
     "@dxos/react-ui-editor": "workspace:*",
     "@dxos/util": "workspace:*",
+    "@lexical/react": "^0.6.5",
+    "@lexical/selection": "^0.6.5",
+    "@lexical/text": "^0.6.5",
+    "@lexical/utils": "^0.6.5",
+    "@lezer/common": "^1.2.1",
+    "@lezer/highlight": "^1.2.0",
     "@preact/signals-core": "^1.6.0",
+    "codemirror": "^6.0.1",
+    "codemirror-lang-spreadsheet": "^1.3.0",
     "hyperformula": "^2.7.1",
+    "lexical": "^0.6.5",
     "lodash.defaultsdeep": "^4.6.1",
     "react-markdown": "^8.0.5",
     "react-resize-detector": "^11.0.1",
-    "react-window": "^1.8.10"
+    "react-window": "^1.8.10",
+    "yjs": "^13.5.22"
   },
   "devDependencies": {
     "@braneframe/plugin-client": "workspace:*",

--- a/packages/apps/plugins/plugin-sheet/src/components/Sheet/Sheet.tsx
+++ b/packages/apps/plugins/plugin-sheet/src/components/Sheet/Sheet.tsx
@@ -216,6 +216,9 @@ export const Grid: FC<{ columns: number; rows: number } & Omit<SheetProps, 'shee
     if (!readonly) {
       switch (ev.key) {
         case 'Enter': {
+          // Prevent this keydown event from being processed if the cell editor sync renders/mounts
+          ev.preventDefault();
+
           setSelected({ editing: selected?.from });
           break;
         }

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/CodeEditor.tsx
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/CodeEditor.tsx
@@ -1,0 +1,285 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { AutoFocusPlugin } from '@lexical/react/LexicalAutoFocusPlugin';
+import { LexicalComposer } from '@lexical/react/LexicalComposer';
+import { ContentEditable } from '@lexical/react/LexicalContentEditable';
+import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary';
+import { createEmptyHistoryState, HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
+import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
+import { $selectAll } from '@lexical/selection';
+import { $rootTextContent } from '@lexical/text';
+import { mergeRegister } from '@lexical/utils';
+import {
+  $getRoot,
+  $getSelection,
+  COMMAND_PRIORITY_CRITICAL,
+  KEY_ENTER_COMMAND,
+  LineBreakNode,
+  SELECTION_CHANGE_COMMAND,
+  TextNode,
+  type EditorState,
+  type Klass,
+  type LexicalEditor,
+  type LexicalNode,
+  type SerializedEditorState,
+} from 'lexical';
+import React, {
+  createElement,
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  type ForwardedRef,
+} from 'react';
+
+import { groupSurface, mx } from '@dxos/react-ui-theme';
+
+import LexicalEditorRefSetter from './LexicalEditorRefSetter';
+import CodeNode from './plugins/code/CodeNode';
+import CodePlugin from './plugins/code/CodePlugin';
+import parseTokens from './plugins/code/utils/parseTokens';
+import parsedTokensToCodeTextNode from './plugins/code/utils/parsedTokensToCodeTextNode';
+import FormPlugin from './plugins/form/FormPlugin';
+import CodeCompletionPlugin from './plugins/spreadsheet-completion/CodeCompletionPlugin';
+
+// Diffing is simplest when the Code plug-in has a flat structure.
+const NODES: Array<Klass<LexicalNode>> = [LineBreakNode, CodeNode, TextNode];
+
+export type ImperativeHandle = {
+  focus: () => void;
+};
+
+type Props = {
+  allowWrapping?: boolean;
+  autoFocus?: boolean;
+  autoSelect?: boolean;
+  dataTestId?: string;
+  dataTestName?: string;
+  editable: boolean;
+  forwardedRef?: ForwardedRef<ImperativeHandle>;
+  initialValue?: string;
+  onBlur?: () => void;
+  onCancel?: (value: string) => void;
+  onChange?: (value: string, editorState: SerializedEditorState) => void;
+  onSave?: (value: string, editorState: SerializedEditorState) => void;
+  placeholder?: string;
+  preventTabFocusChange?: boolean;
+};
+
+const CodeEditor = ({
+  allowWrapping = true,
+  autoFocus = false,
+  autoSelect = false,
+  dataTestId,
+  dataTestName,
+  editable,
+  forwardedRef,
+  initialValue = '',
+  onBlur,
+  onCancel,
+  onChange,
+  onSave,
+  placeholder = '',
+  preventTabFocusChange = false,
+}: Props): JSX.Element => {
+  const historyState = useMemo(() => createEmptyHistoryState(), []);
+
+  const editorRef = useRef<LexicalEditor>(null);
+  const backupEditorStateRef = useRef<EditorState | null>(null);
+
+  useImperativeHandle(
+    forwardedRef,
+    () => ({
+      focus: () => {
+        editorRef.current?.focus();
+      },
+    }),
+    [],
+  );
+
+  const didMountRef = useRef(false);
+  useLayoutEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+
+      if (autoSelect) {
+        const editor = editorRef.current;
+        if (editor) {
+          editor.update(() => {
+            const root = $getRoot();
+            const firstChild = root.getFirstChild();
+            if (firstChild) {
+              const selection = firstChild.select(0, 0);
+              $selectAll(selection);
+            }
+          });
+        }
+      }
+    }
+  }, [autoSelect]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (editor) {
+      const element = editor.getRootElement();
+      if (element) {
+        if (dataTestId) {
+          element.setAttribute('data-test-id', dataTestId);
+        } else {
+          element.removeAttribute('data-test-id');
+        }
+
+        if (dataTestName) {
+          element.setAttribute('data-test-name', dataTestName);
+        } else {
+          element.removeAttribute('data-test-name');
+        }
+      }
+    }
+  }, [editorRef, dataTestId, dataTestName]);
+
+  const onFormCancel = (_: EditorState) => {
+    if (onCancel !== undefined) {
+      onCancel(initialValue);
+    }
+
+    const editor = editorRef.current;
+    if (editor) {
+      editor.update(() => {
+        const editorState = backupEditorStateRef.current;
+        if (editorState) {
+          editor.setEditorState(editorState);
+        }
+      });
+    }
+  };
+
+  const onFormChange = (editorState: EditorState) => {
+    if (typeof onChange === 'function') {
+      const editor = editorRef.current;
+      if (editor !== null) {
+        editorState.read(() => {
+          const textContent = $rootTextContent();
+          onChange(textContent, editorState.toJSON());
+        });
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (!allowWrapping) {
+      const editor = editorRef.current;
+      if (editor) {
+        const onEnter = (event: KeyboardEvent) => {
+          if (event.shiftKey) {
+            event.preventDefault();
+            return true;
+          }
+
+          return false;
+        };
+
+        // Make sure the cursor is visible (if there is overflow)
+        const onSelectionChange = () => {
+          const selection = $getSelection();
+          if (selection) {
+            const nodes = selection.getNodes();
+            if (nodes?.length > 0) {
+              const node = nodes[0];
+              const element = editor.getElementByKey(node.__key);
+              if (element) {
+                element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+              }
+            }
+          }
+
+          return false;
+        };
+
+        return mergeRegister(
+          editor.registerCommand(SELECTION_CHANGE_COMMAND, onSelectionChange, COMMAND_PRIORITY_CRITICAL),
+          editor.registerCommand(KEY_ENTER_COMMAND, onEnter, COMMAND_PRIORITY_CRITICAL),
+        );
+      }
+    }
+  }, [allowWrapping, editorRef]);
+
+  const onFormSubmit = (editorState: EditorState) => {
+    const editor = editorRef.current;
+    if (editor !== null) {
+      const textContent = $rootTextContent();
+      if (onSave) {
+        onSave(textContent, editorState.toJSON());
+      }
+
+      backupEditorStateRef.current = editorState;
+    }
+  };
+
+  const rootElementRef = useRef<HTMLDivElement>(null);
+
+  // useContentEditableNoUserSelect(rootElementRef, {
+  //   autoFocus: autoFocus === true,
+  //   disableSelectionWhenNotFocused: disableSelectionWhenNotFocused === true,
+  // });
+
+  return (
+    <LexicalComposer initialConfig={createInitialConfig(initialValue, editable)}>
+      <div
+        className={mx(groupSurface, 'z-[10] w-full p-[4px] border-blue-500 border')}
+        onBlur={onBlur}
+        ref={rootElementRef}
+      >
+        <LexicalEditorRefSetter editorRef={editorRef} />
+        {autoFocus && <AutoFocusPlugin />}
+        <HistoryPlugin externalHistoryState={historyState} />
+        <RichTextPlugin
+          contentEditable={<ContentEditable className='border-none outline-none' />}
+          placeholder={<div className='absolute top-0 left-0 text-slate-100'>{placeholder}</div>}
+          ErrorBoundary={LexicalErrorBoundary}
+        />
+        <FormPlugin onCancel={onFormCancel} onChange={onFormChange} onSubmit={onFormSubmit} />
+        <CodePlugin preventTabFocusChange={preventTabFocusChange} />
+        <CodeCompletionPlugin
+          dataTestId={dataTestId ? `${dataTestId}-CodeTypeAhead` : undefined}
+          dataTestName={dataTestName ? `${dataTestName}-CodeTypeAhead` : undefined}
+        />
+      </div>
+    </LexicalComposer>
+  );
+};
+
+const CodeEditorForwardRef = forwardRef<ImperativeHandle, Props>((props: Props, ref: ForwardedRef<ImperativeHandle>) =>
+  createElement(CodeEditor, { ...props, forwardedRef: ref }),
+);
+CodeEditorForwardRef.displayName = 'ForwardRef<CodeEditor>';
+
+export default CodeEditorForwardRef;
+
+const createInitialConfig = (code: string, editable: boolean) => ({
+  editable,
+  editorState: () => {
+    const root = $getRoot();
+    if (root.getFirstChild() === null) {
+      const tokens = parseTokens(code);
+      if (tokens !== null) {
+        const node = parsedTokensToCodeTextNode(tokens);
+        root.append(node);
+      }
+    }
+  },
+  namespace: 'CodeEditor',
+  nodes: NODES,
+  onError: (error: Error) => {
+    throw error;
+  },
+  theme: LexicalTheme,
+});
+
+// The Code editor has its own built-in styling.
+// It does not rely on Lexical's rich text theme.
+const LexicalTheme = {};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/LexicalEditorRefSetter.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/LexicalEditorRefSetter.ts
@@ -1,0 +1,18 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { type LexicalEditor } from 'lexical';
+import { type RefObject, useLayoutEffect } from 'react';
+
+export default ({ editorRef }: { editorRef: RefObject<LexicalEditor | null> }) => {
+  const [editor] = useLexicalComposerContext();
+
+  useLayoutEffect(() => {
+    // @ts-ignore
+    editorRef.current = editor;
+  });
+
+  return null;
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/hooks/useContentEditableNoUserSelect.tsx
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/hooks/useContentEditableNoUserSelect.tsx
@@ -1,0 +1,89 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import assert from 'assert';
+import { type RefObject, useEffect } from 'react';
+
+export const useContentEditableNoUserSelect = (
+  rootElementRef: RefObject<HTMLElement>,
+  options: {
+    autoFocus: boolean;
+    disableSelectionWhenNotFocused: boolean;
+  },
+) => {
+  const { autoFocus, disableSelectionWhenNotFocused } = options;
+
+  useEffect(() => {
+    if (!disableSelectionWhenNotFocused) {
+      return;
+    }
+
+    const rootElement = rootElementRef.current;
+    assert(rootElement !== null, 'Root element not found');
+
+    const contentEditableElement = rootElement.querySelector('[contenteditable]') as HTMLElement;
+    if (contentEditableElement == null) {
+      return;
+    }
+
+    const disable = () => {
+      rootElement.setAttribute('tabindex', '0');
+
+      contentEditableElement.setAttribute('contenteditable', 'false');
+      contentEditableElement.style.userSelect = 'none';
+    };
+
+    const enable = () => {
+      // On tab-out (e.g. SHIFT+TAB) the parent should not steal focus and return it to the contenteditable
+      rootElement.removeAttribute('tabindex');
+
+      contentEditableElement.setAttribute('contenteditable', 'true');
+      contentEditableElement.style.userSelect = '';
+    };
+
+    const onRootElementFocus = () => {
+      enable();
+
+      contentEditableElement.focus();
+    };
+
+    const onContentEditableFocus = () => {
+      if (contentEditableElement.getAttribute('contenteditable') !== 'true') {
+        rootElement.focus();
+      }
+    };
+
+    const onContentEditableMouseDown = () => {
+      rootElement.removeAttribute('tabindex');
+
+      enable();
+    };
+
+    const onContentEditableBlur = () => {
+      disable();
+    };
+
+    rootElement.addEventListener('focus', onRootElementFocus);
+
+    contentEditableElement.addEventListener('blur', onContentEditableBlur);
+    contentEditableElement.addEventListener('focus', onContentEditableFocus);
+    contentEditableElement.addEventListener('mousedown', onContentEditableMouseDown);
+
+    // HACK Give Lexical plug-in time to run before we check if the element has been (programmatically) focused
+    // else we may disable the "contenteditable" attribute only to have Lexical re-enable it
+    setTimeout(() => {
+      if (!autoFocus && document.activeElement !== contentEditableElement) {
+        disable();
+      }
+    });
+
+    return () => {
+      rootElement.removeEventListener('focus', onRootElementFocus);
+
+      contentEditableElement.removeEventListener('blur', onContentEditableBlur);
+      contentEditableElement.removeEventListener('focus', onContentEditableFocus);
+      contentEditableElement.removeEventListener('mousedown', onContentEditableMouseDown);
+    };
+  }, [autoFocus, disableSelectionWhenNotFocused, rootElementRef]);
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/CodeNode.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/CodeNode.ts
@@ -1,0 +1,41 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type EditorConfig, ElementNode } from 'lexical';
+
+import { type SerializedCodeNode } from './types';
+import $createCodeNode from './utils/$createCodeNode';
+
+export default class CodeNode extends ElementNode {
+  static getType(): string {
+    return 'code';
+  }
+
+  static clone(node: CodeNode): CodeNode {
+    return new CodeNode(node.__key);
+  }
+
+  createDOM(_: EditorConfig): HTMLElement {
+    const dom = document.createElement('div');
+    dom.setAttribute('spellcheck', 'false');
+    return dom;
+  }
+
+  updateDOM(_: CodeNode, __: HTMLElement): boolean {
+    return false;
+  }
+
+  exportJSON(): SerializedCodeNode {
+    return {
+      ...super.exportJSON(),
+      type: 'code',
+      version: 1,
+    };
+  }
+
+  static importJSON(_: SerializedCodeNode): CodeNode {
+    const node = $createCodeNode();
+    return node;
+  }
+}

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/CodePlugin.tsx
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/CodePlugin.tsx
@@ -1,0 +1,520 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { mergeRegister } from '@lexical/utils';
+import {
+  $getNodeByKey,
+  $getSelection,
+  $isLineBreakNode,
+  $isParagraphNode,
+  $isRangeSelection,
+  $isTextNode,
+  COMMAND_PRIORITY_LOW,
+  COMMAND_PRIORITY_NORMAL,
+  KEY_ARROW_DOWN_COMMAND,
+  KEY_ARROW_UP_COMMAND,
+  KEY_TAB_COMMAND,
+  type LexicalCommand,
+  type LexicalEditor,
+  type LexicalNode,
+  MOVE_TO_END,
+  MOVE_TO_START,
+  type NodeKey,
+  TextNode,
+} from 'lexical';
+import { useEffect } from 'react';
+
+import type CodeNode from './CodeNode';
+import $createCodeNode from './utils/$createCodeNode';
+import $isCodeNode from './utils/$isCodeNode';
+import parseTokens from './utils/parseTokens';
+import parsedTokensToCodeTextNode from './utils/parsedTokensToCodeTextNode';
+
+export default ({ preventTabFocusChange }: { preventTabFocusChange: boolean }): null => {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    const onTextNodeTransform = (node: TextNode) => {
+      // Since CodeNode has flat children structure we only need to check if node's parent is a code node and run highlighting.
+      const parentNode = node.getParent();
+      if ($isCodeNode(parentNode)) {
+        codeNodeTransform(parentNode, editor);
+      } else if ($isParagraphNode(parentNode)) {
+        // Copy-paste sometimes inserts ParagraphNodes, which interfere with this plugin.
+        const terminalNode = $createCodeNode();
+        terminalNode.append(...parentNode.getChildren());
+        parentNode.replace(terminalNode);
+      }
+    };
+
+    const onTabCommand = (event: KeyboardEvent) => {
+      if (preventTabFocusChange) {
+        event.preventDefault();
+      }
+
+      // Tab key should not indent code blocks.
+      return true;
+    };
+
+    return mergeRegister(
+      editor.registerNodeTransform(TextNode, onTextNodeTransform),
+      editor.registerCommand(KEY_TAB_COMMAND, onTabCommand, COMMAND_PRIORITY_NORMAL),
+      editor.registerCommand(
+        KEY_ARROW_UP_COMMAND,
+        (payload): boolean => handleShiftLines(KEY_ARROW_UP_COMMAND, payload),
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerCommand(
+        KEY_ARROW_DOWN_COMMAND,
+        (payload): boolean => handleShiftLines(KEY_ARROW_DOWN_COMMAND, payload),
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerCommand(
+        MOVE_TO_END,
+        (payload): boolean => handleMoveTo(MOVE_TO_END, payload),
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerCommand(
+        MOVE_TO_START,
+        (payload): boolean => handleMoveTo(MOVE_TO_START, payload),
+        COMMAND_PRIORITY_LOW,
+      ),
+    );
+  }, [editor, preventTabFocusChange]);
+
+  return null;
+};
+
+const codeNodeTransform = (node: CodeNode, editor: LexicalEditor) => {
+  const nodeKey = node.getKey();
+
+  editor.update(() => {
+    updateAndRetainSelection(nodeKey, () => {
+      const currentNode = $getNodeByKey(nodeKey);
+      if (!$isCodeNode(currentNode) || !currentNode.isAttached()) {
+        return false;
+      }
+
+      const textContent = currentNode.getTextContent();
+      const tokens = parseTokens(textContent);
+      if (tokens === null) {
+        return false;
+      }
+
+      const newCodeTextNode = parsedTokensToCodeTextNode(tokens);
+
+      const diffRange = getDiffRange(currentNode.getChildren(), newCodeTextNode.getChildren());
+      const { from, to, nodesForReplacement } = diffRange;
+
+      if (from !== to || nodesForReplacement.length) {
+        node.splice(from, to - from, nodesForReplacement);
+        return true;
+      }
+
+      return false;
+    });
+  });
+};
+
+const getDiffRange = (
+  prevNodes: Array<LexicalNode>,
+  nextNodes: Array<LexicalNode>,
+): {
+  from: number;
+  nodesForReplacement: Array<LexicalNode>;
+  to: number;
+} => {
+  let leadingMatch = 0;
+  while (leadingMatch < prevNodes.length) {
+    if (!isEqual(prevNodes[leadingMatch], nextNodes[leadingMatch])) {
+      break;
+    }
+    leadingMatch++;
+  }
+
+  const prevNodesLength = prevNodes.length;
+  const nextNodesLength = nextNodes.length;
+  const maxTrailingMatch = Math.min(prevNodesLength, nextNodesLength) - leadingMatch;
+
+  let trailingMatch = 0;
+  while (trailingMatch < maxTrailingMatch) {
+    trailingMatch++;
+    if (!isEqual(prevNodes[prevNodesLength - trailingMatch], nextNodes[nextNodesLength - trailingMatch])) {
+      trailingMatch--;
+      break;
+    }
+  }
+
+  const from = leadingMatch;
+  const to = prevNodesLength - trailingMatch;
+  const nodesForReplacement = nextNodes.slice(leadingMatch, nextNodesLength - trailingMatch);
+  return {
+    from,
+    nodesForReplacement,
+    to,
+  };
+};
+
+const findFirstNotSpaceOrTabCharAtText = (text: string, isForward: boolean): number => {
+  const length = text.length;
+  let offset = -1;
+
+  if (isForward) {
+    for (let i = 0; i < length; i++) {
+      const char = text[i];
+      if (!isSpaceOrTabChar(char)) {
+        offset = i;
+        break;
+      }
+    }
+  } else {
+    for (let i = length - 1; i > -1; i--) {
+      const char = text[i];
+      if (!isSpaceOrTabChar(char)) {
+        offset = i;
+        break;
+      }
+    }
+  }
+
+  return offset;
+};
+
+export const getEndOfCodeInLine = (
+  anchor: LexicalNode,
+): {
+  node: TextNode | null;
+  offset: number;
+} => {
+  let currentNode = null;
+  let currentNodeOffset = -1;
+  const nextSiblings = anchor.getNextSiblings();
+  nextSiblings.unshift(anchor);
+  while (nextSiblings.length > 0) {
+    const node = nextSiblings.shift();
+    if ($isTextNode(node)) {
+      const text = node.getTextContent();
+      const offset = findFirstNotSpaceOrTabCharAtText(text, false);
+      if (offset !== -1) {
+        currentNode = node;
+        currentNodeOffset = offset + 1;
+      }
+    }
+    if ($isLineBreakNode(node)) {
+      break;
+    }
+  }
+
+  if (currentNode === null) {
+    const previousSiblings = anchor.getPreviousSiblings();
+    while (previousSiblings.length > 0) {
+      const node = previousSiblings.pop();
+      if ($isTextNode(node)) {
+        const text = node.getTextContent();
+        const offset = findFirstNotSpaceOrTabCharAtText(text, false);
+        if (offset !== -1) {
+          currentNode = node;
+          currentNodeOffset = offset + 1;
+          break;
+        }
+      }
+      if ($isLineBreakNode(node)) {
+        break;
+      }
+    }
+  }
+
+  return {
+    node: currentNode,
+    offset: currentNodeOffset,
+  };
+};
+
+export const getFirstTextNodeOfLine = (anchor: LexicalNode): TextNode | null | undefined => {
+  let currentNode = null;
+  const previousSiblings = anchor.getPreviousSiblings();
+  previousSiblings.push(anchor);
+  while (previousSiblings.length > 0) {
+    const node = previousSiblings.pop();
+    if ($isTextNode(node)) {
+      currentNode = node;
+    }
+    if ($isLineBreakNode(node)) {
+      break;
+    }
+  }
+
+  return currentNode;
+};
+
+export const getLastTextNodeOfLine = (anchor: LexicalNode): TextNode | null | undefined => {
+  let currentNode = null;
+  const nextSiblings = anchor.getNextSiblings();
+  nextSiblings.unshift(anchor);
+  while (nextSiblings.length > 0) {
+    const node = nextSiblings.shift();
+    if ($isTextNode(node)) {
+      currentNode = node;
+    }
+    if ($isLineBreakNode(node)) {
+      break;
+    }
+  }
+
+  return currentNode;
+};
+
+export const getStartOfCodeInLine = (
+  anchor: LexicalNode,
+): {
+  node: TextNode | null;
+  offset: number;
+} => {
+  let currentNode = null;
+  let currentNodeOffset = -1;
+  const previousSiblings = anchor.getPreviousSiblings();
+  previousSiblings.push(anchor);
+  while (previousSiblings.length > 0) {
+    const node = previousSiblings.pop();
+    if ($isTextNode(node)) {
+      const text = node.getTextContent();
+      const offset = findFirstNotSpaceOrTabCharAtText(text, true);
+      if (offset !== -1) {
+        currentNode = node;
+        currentNodeOffset = offset;
+      }
+    }
+    if ($isLineBreakNode(node)) {
+      break;
+    }
+  }
+
+  if (currentNode === null) {
+    const nextSiblings = anchor.getNextSiblings();
+    while (nextSiblings.length > 0) {
+      const node = nextSiblings.shift();
+      if ($isTextNode(node)) {
+        const text = node.getTextContent();
+        const offset = findFirstNotSpaceOrTabCharAtText(text, true);
+        if (offset !== -1) {
+          currentNode = node;
+          currentNodeOffset = offset;
+          break;
+        }
+      }
+      if ($isLineBreakNode(node)) {
+        break;
+      }
+    }
+  }
+
+  return {
+    node: currentNode,
+    offset: currentNodeOffset,
+  };
+};
+
+const handleShiftLines = (type: LexicalCommand<KeyboardEvent>, event: KeyboardEvent): boolean => {
+  // We only care about the alt+arrow keys
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection)) {
+    return false;
+  }
+
+  // I'm not quite sure why, but it seems like calling anchor.getNode() collapses the selection here
+  // So first, get the anchor and the focus, then get their nodes
+  const { anchor, focus } = selection;
+  const anchorOffset = anchor.offset;
+  const focusOffset = focus.offset;
+  const anchorNode = anchor.getNode();
+  const focusNode = focus.getNode();
+  const arrowIsUp = type === KEY_ARROW_UP_COMMAND;
+
+  // Ensure the selection is within the codeblock
+  // if (!$isCodeNode(anchorNode) || !$isCodeNode(focusNode)) {
+  //   return false;
+  // }
+  if (!$isTextNode(anchorNode) || !$isTextNode(focusNode)) {
+    return false;
+  }
+
+  if (!event.altKey) {
+    // Handle moving selection out of the code block, given there are no
+    // sibling thats can natively take the selection.
+    if (selection.isCollapsed()) {
+      const codeNode = anchorNode.getParentOrThrow();
+      if (arrowIsUp && anchorOffset === 0 && anchorNode.getPreviousSibling() === null) {
+        const codeNodeSibling = codeNode.getPreviousSibling();
+        if (codeNodeSibling === null) {
+          codeNode.selectPrevious();
+          event.preventDefault();
+          return true;
+        }
+      } else if (
+        !arrowIsUp &&
+        anchorOffset === anchorNode.getTextContentSize() &&
+        anchorNode.getNextSibling() === null
+      ) {
+        const codeNodeSibling = codeNode.getNextSibling();
+        if (codeNodeSibling === null) {
+          codeNode.selectNext();
+          event.preventDefault();
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  const start = getFirstTextNodeOfLine(anchorNode);
+  const end = getLastTextNodeOfLine(focusNode);
+  if (start == null || end == null) {
+    return false;
+  }
+
+  const range = start.getNodesBetween(end);
+  for (let i = 0; i < range.length; i++) {
+    const node = range[i];
+    if (!$isCodeNode(node) && !$isLineBreakNode(node)) {
+      return false;
+    }
+  }
+
+  // After this point, we know the selection is within the codeblock. We may not be able to
+  // actually move the lines around, but we want to return true either way to prevent
+  // the event's default behavior
+  event.preventDefault();
+  event.stopPropagation(); // required to stop cursor movement under Firefox
+
+  const linebreak = arrowIsUp ? start.getPreviousSibling() : end.getNextSibling();
+  if (!$isLineBreakNode(linebreak)) {
+    return true;
+  }
+  const sibling = arrowIsUp ? linebreak.getPreviousSibling() : linebreak.getNextSibling();
+  if (sibling == null) {
+    return true;
+  }
+
+  const maybeInsertionPoint = arrowIsUp ? getFirstTextNodeOfLine(sibling) : getLastTextNodeOfLine(sibling);
+  let insertionPoint = maybeInsertionPoint != null ? maybeInsertionPoint : sibling;
+  linebreak.remove();
+  range.forEach((node) => node.remove());
+  if (type === KEY_ARROW_UP_COMMAND) {
+    range.forEach((node) => insertionPoint.insertBefore(node));
+    insertionPoint.insertBefore(linebreak);
+  } else {
+    insertionPoint.insertAfter(linebreak);
+    insertionPoint = linebreak;
+    range.forEach((node) => {
+      insertionPoint.insertAfter(node);
+      insertionPoint = node;
+    });
+  }
+
+  selection.setTextNodeRange(anchorNode, anchorOffset, focusNode, focusOffset);
+
+  return true;
+};
+
+const handleMoveTo = (type: LexicalCommand<KeyboardEvent>, event: KeyboardEvent): boolean => {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection)) {
+    return false;
+  }
+
+  const { anchor, focus } = selection;
+  const anchorNode = anchor.getNode();
+  const focusNode = focus.getNode();
+  const isMoveToStart = type === MOVE_TO_START;
+
+  if (!$isTextNode(anchorNode) || !$isTextNode(focusNode)) {
+    return false;
+  }
+
+  let node;
+  let offset;
+
+  if (isMoveToStart) {
+    ({ node, offset } = getStartOfCodeInLine(focusNode));
+  } else {
+    ({ node, offset } = getEndOfCodeInLine(focusNode));
+  }
+
+  if (node !== null && offset !== -1) {
+    selection.setTextNodeRange(node, offset, node, offset);
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+
+  return true;
+};
+
+const isEqual = (nodeA: LexicalNode, nodeB: LexicalNode): boolean => {
+  if ($isTextNode(nodeA) && $isTextNode(nodeB)) {
+    return nodeA.__format === nodeB.__format && nodeA.__text === nodeB.__text && nodeA.__style === nodeB.__style;
+  } else if ($isLineBreakNode(nodeA) && $isLineBreakNode(nodeB)) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
+const isSpaceOrTabChar = (char: string): boolean => char === ' ' || char === '\t';
+
+const updateAndRetainSelection = (nodeKey: NodeKey, updateFn: () => boolean): void => {
+  const node = $getNodeByKey(nodeKey);
+  if (!$isCodeNode(node) || !node.isAttached()) {
+    return;
+  }
+  const selection = $getSelection();
+  // If it's not range selection (or null selection) there's no need to change it,
+  // but we can still run highlighting logic
+  if (!$isRangeSelection(selection)) {
+    updateFn();
+    return;
+  }
+
+  const anchor = selection.anchor;
+  const anchorOffset = anchor.offset;
+  const isNewLineAnchor = anchor.type === 'element' && $isLineBreakNode(node.getChildAtIndex(anchor.offset - 1));
+  let textOffset = 0;
+
+  // Calculating previous text offset (all text node prior to anchor + anchor own text offset)
+  if (!isNewLineAnchor) {
+    const anchorNode = anchor.getNode();
+    textOffset =
+      anchorOffset +
+      anchorNode.getPreviousSiblings().reduce((offset, _node) => {
+        return offset + ($isLineBreakNode(_node) ? 0 : _node.getTextContentSize());
+      }, 0);
+  }
+
+  const hasChanges = updateFn();
+  if (!hasChanges) {
+    return;
+  }
+
+  // Non-text anchors only happen for line breaks, otherwise
+  // selection will be within text node (code highlight node)
+  if (isNewLineAnchor) {
+    anchor.getNode().select(anchorOffset, anchorOffset);
+    return;
+  }
+
+  // If it was non-element anchor then we walk through child nodes
+  // and looking for a position of original text offset
+  node.getChildren().some((_node) => {
+    if ($isTextNode(_node)) {
+      const textContentSize = _node.getTextContentSize();
+      if (textContentSize >= textOffset) {
+        _node.select(textOffset, textOffset);
+        return true;
+      }
+      textOffset -= textContentSize;
+    }
+    return false;
+  });
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/types.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/types.ts
@@ -1,0 +1,20 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import type { SerializedElementNode, Spread } from 'lexical';
+
+export type SerializedCodeNode = Spread<
+  {
+    type: 'code';
+    version: 1;
+  },
+  SerializedElementNode
+>;
+
+export type TokenType = 'boolean' | 'error' | 'function' | 'reference';
+
+export type Token = {
+  text: string;
+  types: TokenType[] | null;
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/utils/$convertCodeElement.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/utils/$convertCodeElement.ts
@@ -1,0 +1,19 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type DOMConversionOutput } from 'lexical';
+
+import $createCodeNode from './$createCodeNode';
+
+export default (domNode: HTMLElement): DOMConversionOutput | null => {
+  const textContent = domNode.textContent;
+  if (textContent !== null) {
+    const node = $createCodeNode();
+    return {
+      node,
+    };
+  }
+
+  return null;
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/utils/$createCodeNode.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/utils/$createCodeNode.ts
@@ -1,0 +1,9 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { $applyNodeReplacement } from 'lexical';
+
+import CodeNode from '../CodeNode';
+
+export default (): CodeNode => $applyNodeReplacement(new CodeNode());

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/utils/$isCodeNode.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/utils/$isCodeNode.ts
@@ -1,0 +1,9 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type LexicalNode } from 'lexical';
+
+import CodeTextNode from '../CodeNode';
+
+export default (node: LexicalNode | null | undefined): node is CodeTextNode => node instanceof CodeTextNode;

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/utils/getTokenStyle.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/utils/getTokenStyle.ts
@@ -1,0 +1,27 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type TokenType } from '../types';
+
+export default (tokenTypes: TokenType[]): string | null => {
+  if (tokenTypes.length === 0) {
+    return null;
+  }
+
+  const type = tokenTypes[0];
+  if (!type) {
+    return null;
+  }
+
+  switch (type) {
+    case 'boolean':
+      return 'color: #029cfd';
+    case 'error':
+      return 'color: red';
+    case 'function':
+      return 'color: darkseagreen';
+    case 'reference':
+      return 'color: mediumpurple';
+  }
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/utils/parseTokens.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/utils/parseTokens.ts
@@ -1,0 +1,44 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { HighlightStyle } from '@codemirror/language';
+import { highlightCode, tags } from '@lezer/highlight';
+import { spreadsheet } from 'codemirror-lang-spreadsheet';
+
+import { type Token, type TokenType } from '../types';
+
+const { parser } = spreadsheet({}).language;
+
+const style = HighlightStyle.define([
+  { tag: tags.name, class: 'function' },
+  { tag: tags.bool, class: 'boolean' },
+  { tag: tags.color, class: 'reference' },
+  { tag: tags.invalid, class: 'error' },
+]);
+
+export default (textToParse: string): Token[] | null => {
+  const tree = parser.parse(textToParse);
+
+  const tokens: Token[] = [];
+
+  highlightCode(
+    textToParse,
+    tree,
+    style,
+    (code, classes) => {
+      tokens.push({
+        text: code,
+        types: classes.split(' ') as TokenType[],
+      });
+    },
+    () => {
+      tokens.push({
+        text: '\n',
+        types: [],
+      });
+    },
+  );
+
+  return tokens;
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/utils/parsedTokensToCodeTextNode.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/code/utils/parsedTokensToCodeTextNode.ts
@@ -1,0 +1,29 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { $createLineBreakNode, $createTextNode, type LexicalNode } from 'lexical';
+
+import $createCodeNode from './$createCodeNode';
+import getTokenStyle from './getTokenStyle';
+import type CodeNode from '../CodeNode';
+import { type Token } from '../types';
+
+export default (tokens: Token[]): CodeNode => {
+  const nodes: LexicalNode[] = [];
+
+  tokens.forEach((token) => {
+    const type = token.types ? getTokenStyle(token.types) || '' : '';
+    const lines = token.text.split(/[\r\n]/);
+    return lines.forEach((line, lineIndex) => {
+      if (lineIndex > 0) {
+        nodes.push($createLineBreakNode());
+      }
+      if (line !== '') {
+        nodes.push($createTextNode(line).setStyle(type));
+      }
+    });
+  });
+
+  return $createCodeNode().append(...nodes);
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/form/FormPlugin.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/form/FormPlugin.ts
@@ -1,0 +1,90 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { mergeRegister } from '@lexical/utils';
+import { COMMAND_PRIORITY_NORMAL, type EditorState, KEY_ENTER_COMMAND, KEY_ESCAPE_COMMAND } from 'lexical';
+import { useEffect, useRef } from 'react';
+
+export default ({
+  onCancel,
+  onChange,
+  onSubmit,
+}: {
+  onCancel?: (editorState: EditorState) => void;
+  onChange?: (editorState: EditorState) => void;
+  onSubmit: (editorState: EditorState) => void;
+}) => {
+  const [editor] = useLexicalComposerContext();
+
+  // Shares most recently committed component state with imperative Lexical API (which only runs on mount)
+  const committedStateRef = useRef({
+    onCancel,
+    onChange,
+    onSubmit,
+  });
+  useEffect(() => {
+    committedStateRef.current.onCancel = onCancel;
+    committedStateRef.current.onChange = onChange;
+    committedStateRef.current.onSubmit = onSubmit;
+  });
+
+  useEffect(() => {
+    const onEnterCommand = (event: KeyboardEvent) => {
+      const { onSubmit } = committedStateRef.current;
+
+      if (!editor.isEditable()) {
+        return false;
+      } else if (event.defaultPrevented) {
+        return false;
+      }
+
+      if (event.shiftKey) {
+        return false;
+      } else {
+        event.preventDefault();
+        onSubmit(editor.getEditorState());
+        return true;
+      }
+    };
+
+    const onEscapeCommand = (event: KeyboardEvent) => {
+      const { onCancel } = committedStateRef.current;
+
+      if (!editor.isEditable()) {
+        return false;
+      } else if (event.defaultPrevented) {
+        return false;
+      }
+
+      if (typeof onCancel === 'function') {
+        event.preventDefault();
+        onCancel(editor.getEditorState());
+        return true;
+      }
+
+      return false;
+    };
+
+    const onUpdate = () => {
+      const { onChange } = committedStateRef.current;
+
+      if (!editor.isEditable()) {
+        return false;
+      }
+
+      if (typeof onChange === 'function') {
+        onChange(editor.getEditorState());
+      }
+    };
+
+    return mergeRegister(
+      editor.registerUpdateListener(onUpdate),
+      editor.registerCommand(KEY_ENTER_COMMAND, onEnterCommand, COMMAND_PRIORITY_NORMAL),
+      editor.registerCommand(KEY_ESCAPE_COMMAND, onEscapeCommand, COMMAND_PRIORITY_NORMAL),
+    );
+  }, [editor]);
+
+  return null;
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/spreadsheet-completion/CodeCompletionPlugin.tsx
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/spreadsheet-completion/CodeCompletionPlugin.tsx
@@ -1,0 +1,86 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { mergeRegister } from '@lexical/utils';
+import { $createTextNode, TextNode } from 'lexical';
+import React, { type ReactNode, useEffect } from 'react';
+
+import findMatches from './findMatches';
+import getQueryData from './getQueryData';
+import { insertItemModifier } from './insertItemModifier';
+import { TypeAheadPlugin } from '../typeahead/TypeAheadPlugin';
+
+export default ({
+  dataTestId,
+  dataTestName = 'CodeTypeAhead',
+}: {
+  dataTestId?: string;
+  dataTestName?: string;
+}): JSX.Element => {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    const onCodeCompletionTextNodeTransform = (node: TextNode) => {
+      // Prevent RichTextEditor from formatting mentions text in any way.
+      if (node.getFormat() !== 0) {
+        node.setFormat(0);
+      }
+    };
+
+    return mergeRegister(editor.registerNodeTransform(TextNode, onCodeCompletionTextNodeTransform));
+  }, [editor]);
+
+  return (
+    <TypeAheadPlugin
+      arrowKeysShouldDismiss={true}
+      createItemNode={createItemNode}
+      dataTestId={dataTestId}
+      dataTestName={dataTestName}
+      getQueryData={getQueryData}
+      findMatches={findMatches}
+      insertItemModifier={insertItemModifier}
+      itemRenderer={itemRenderer}
+    />
+  );
+};
+
+const createItemNode = (match: string) => $createTextNode(match);
+
+const itemRenderer = (code: string, query: string) => {
+  const children: ReactNode[] = [];
+  let inProgress = '';
+  let codeIndex = 0;
+  let queryIndex = 0;
+
+  while (codeIndex < code.length) {
+    const queryChar = query.charAt(queryIndex) || '';
+    const codeChar = code.charAt(codeIndex);
+
+    if (codeChar.toLowerCase() === queryChar.toLowerCase()) {
+      if (inProgress !== '') {
+        children.push(<span key={children.length}>{inProgress}</span>);
+      }
+
+      children.push(
+        <span className='text-blue-500' key={children.length}>
+          {codeChar}
+        </span>,
+      );
+
+      inProgress = '';
+      queryIndex++;
+    } else {
+      inProgress += codeChar;
+    }
+
+    codeIndex++;
+  }
+
+  if (inProgress !== '') {
+    children.push(<span key={children.length}>{inProgress}</span>);
+  }
+
+  return children;
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/spreadsheet-completion/findMatches.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/spreadsheet-completion/findMatches.ts
@@ -1,0 +1,21 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { HyperFormula } from 'hyperformula';
+
+const FUNCTIONS = Object.values(HyperFormula.languages.enGB.functions);
+
+export const MAX_DISTANCE = Number.MAX_SAFE_INTEGER;
+
+const EMPTY: string[] = [];
+
+export default (query: string): string[] => {
+  if (query === '') {
+    return EMPTY;
+  }
+
+  query = query.toUpperCase();
+
+  return FUNCTIONS.filter((name) => name.startsWith(query));
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/spreadsheet-completion/getQueryData.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/spreadsheet-completion/getQueryData.ts
@@ -1,0 +1,150 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { $isRangeSelection, type LexicalNode, type TextNode } from 'lexical';
+
+import { type QueryData, type TypeAheadSelection } from '../typeahead/types';
+import $isSimpleText from '../typeahead/utils/$isSimpleText';
+
+export default (selection: TypeAheadSelection | null): QueryData | null => {
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+    return null;
+  }
+
+  const node = selection.getNodes()[0];
+  if (!$isSimpleText(node)) {
+    return null;
+  }
+
+  const anchor = selection.anchor;
+  const offset = anchor.offset;
+
+  let insertionBeginOffset = -1;
+  let insertionBeginTextNode: LexicalNode | null = null;
+  let positionBeginOffset = -1;
+  let positionBeginTextNode: LexicalNode | null = null;
+
+  {
+    let currentOffset = offset - 1;
+    let currentTextNode: LexicalNode | null = node;
+    let currentText = node.getTextContent();
+
+    if (currentTextNode !== null) {
+      while (true) {
+        for (currentOffset; currentOffset >= 0; currentOffset--) {
+          const char = currentText.charAt(currentOffset);
+
+          if (isBoundaryChar(char)) {
+            // We've found the beginning of this expression.
+            break;
+          }
+
+          positionBeginOffset = currentOffset;
+          positionBeginTextNode = currentTextNode;
+        }
+
+        const previousTextNode: TextNode | null = currentTextNode.getPreviousSibling();
+        if (previousTextNode === null || !$isSimpleText(previousTextNode)) {
+          break;
+        }
+
+        currentTextNode = previousTextNode;
+        currentText = previousTextNode.getTextContent();
+        currentOffset = currentText.length - 1;
+      }
+    }
+
+    if (insertionBeginTextNode === null) {
+      // Edge case; replace the whole text (e.g. "SU|" -> "SUM")
+      insertionBeginOffset = positionBeginOffset;
+      insertionBeginTextNode = positionBeginTextNode;
+    }
+  }
+
+  let expression = '';
+
+  let insertionEndOffset = -1;
+  let insertionEndTextNode: LexicalNode | null = null;
+  let positionEndTextNode: LexicalNode | null = null;
+
+  {
+    let currentOffset = positionBeginOffset;
+    let currentTextNode: LexicalNode | null = positionBeginTextNode;
+    let currentText = positionBeginTextNode?.getTextContent() ?? '';
+
+    if (currentTextNode !== null) {
+      while (true) {
+        for (currentOffset; currentOffset < currentText.length; currentOffset++) {
+          const char = currentText.charAt(currentOffset);
+          if (isBoundaryChar(char)) {
+            if (insertionEndTextNode === null) {
+              insertionEndTextNode = currentTextNode;
+              insertionEndOffset = currentOffset;
+            }
+
+            if (positionEndTextNode === null) {
+              positionEndTextNode = currentTextNode;
+            }
+
+            break;
+          }
+
+          if (positionEndTextNode === null) {
+            expression += char;
+          }
+        }
+
+        const nextTextNode: TextNode | null = currentTextNode.getNextSibling();
+        if (nextTextNode === null) {
+          // We've reached the end of the text.
+          break;
+        } else if (!$isSimpleText(nextTextNode)) {
+          // Don't try to parse complex nodes.
+          break;
+        } else {
+          const nextTextContent = nextTextNode.getTextContent() || '';
+          const nextChar = nextTextContent.charAt(0);
+          if (isBoundaryChar(nextChar)) {
+            // If the next node is a boundary, end on the current node.
+            break;
+          }
+        }
+
+        currentTextNode = nextTextNode;
+        currentText = nextTextNode.getTextContent();
+        currentOffset = 0;
+      }
+    }
+
+    if (insertionEndTextNode === null) {
+      insertionEndOffset = currentOffset;
+      insertionEndTextNode = currentTextNode;
+    }
+
+    if (positionEndTextNode === null) {
+      positionEndTextNode = currentTextNode;
+    }
+  }
+
+  if (insertionBeginTextNode === null) {
+    insertionBeginTextNode = node;
+    insertionBeginOffset = offset;
+  }
+  if (insertionEndTextNode === null) {
+    insertionEndTextNode = node;
+    insertionEndOffset = offset;
+  }
+
+  return {
+    query: expression,
+    textRange: {
+      beginOffset: insertionBeginOffset,
+      beginTextNode: insertionBeginTextNode,
+      endOffset: insertionEndOffset,
+      endTextNode: insertionEndTextNode,
+    },
+  };
+};
+
+const isBoundaryChar = (char: string): boolean => char.match(/[\s().,'"=]/) !== null;

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/spreadsheet-completion/insertItemModifier.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/spreadsheet-completion/insertItemModifier.ts
@@ -1,0 +1,23 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type TextRange } from '../typeahead/types';
+
+export const insertItemModifier = ({
+  item,
+  text,
+  textRange,
+}: {
+  item: string;
+  text: string | null;
+  textRange: TextRange | null;
+}): string => {
+  if (text !== null && textRange !== null) {
+    if (text.charAt(textRange.endOffset + 1) === '(') {
+      return item;
+    }
+  }
+
+  return `${item}(`;
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/spreadsheet-completion/types.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/spreadsheet-completion/types.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type Spread, type SerializedTextNode } from 'lexical';
+
+export type SerializedCodeCompletionTextNode = Spread<
+  {
+    text: string;
+    type: 'code-completion-item';
+    version: 1;
+  },
+  SerializedTextNode
+>;

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/TypeAheadItemRenderer.tsx
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/TypeAheadItemRenderer.tsx
@@ -1,0 +1,56 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type LexicalEditor } from 'lexical';
+import React, { useLayoutEffect, useRef, type ReactNode } from 'react';
+
+import { INSERT_ITEM_COMMAND } from './commands';
+
+export const TypeAheadItemRenderer = ({
+  className,
+  dataTestId,
+  dataTestName = 'TypeAheadPopup-List-Item',
+  editor,
+  isSelected,
+  item,
+  itemRenderer,
+  query,
+}: {
+  className: string;
+  dataTestId?: string;
+  dataTestName?: string;
+  editor: LexicalEditor;
+  isSelected: boolean;
+  item: string;
+  itemRenderer: (item: string, query: string) => ReactNode;
+  query: string;
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Scroll selected items into view
+  useLayoutEffect(() => {
+    if (isSelected) {
+      const element = ref.current;
+      if (element) {
+        element.scrollIntoView({ block: 'nearest' });
+      }
+    }
+  }, [isSelected]);
+
+  const onClick = () => {
+    editor.dispatchCommand(INSERT_ITEM_COMMAND, { item });
+  };
+
+  return (
+    <div
+      className={`${className} text-slate-50 pointer leading-5 px-1 hover:bg-slate-900 ${isSelected ? 'bg-slate-900' : ''}`}
+      data-test-id={dataTestId}
+      data-test-name={dataTestName}
+      onClick={onClick}
+      ref={ref}
+    >
+      {itemRenderer(item, query)}
+    </div>
+  );
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/TypeAheadListRenderer.tsx
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/TypeAheadListRenderer.tsx
@@ -1,0 +1,55 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type LexicalEditor } from 'lexical';
+import React, { type ReactNode, type RefObject } from 'react';
+
+import { TypeAheadItemRenderer } from './TypeAheadItemRenderer';
+
+// TODO(bvaughn) Use react-window to render list?
+
+export const TypeAheadListRenderer = ({
+  dataTestId,
+  dataTestName = 'TypeAheadPopup-List',
+  editor,
+  itemClassName,
+  items,
+  itemRenderer,
+  listClassName,
+  popupRef,
+  query,
+  selectedItem,
+}: {
+  dataTestId?: string;
+  dataTestName?: string;
+  editor: LexicalEditor;
+  itemClassName: string;
+  itemRenderer: (item: string, query: string) => ReactNode;
+  items: string[];
+  listClassName: string;
+  popupRef: RefObject<HTMLDivElement>;
+  query: string;
+  selectedItem: string | null;
+}) => (
+  <div
+    className={`${listClassName} absolute top-0 left-0 max-h-36 w-56 overflow-y-auto overflow-x-hidden select-none rounded z-10 bg-slate-950`}
+    data-test-id={dataTestId}
+    data-test-name={dataTestName}
+    ref={popupRef}
+  >
+    {items.map((item, index) => (
+      <TypeAheadItemRenderer
+        dataTestId={dataTestId ? `${dataTestId}-Item-${index}` : undefined}
+        dataTestName={dataTestName ? `${dataTestName}-Item` : undefined}
+        className={itemClassName}
+        editor={editor}
+        key={index}
+        isSelected={selectedItem === items[index]}
+        item={item}
+        itemRenderer={itemRenderer}
+        query={query}
+      />
+    ))}
+  </div>
+);

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/TypeAheadPlugin.tsx
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/TypeAheadPlugin.tsx
@@ -1,0 +1,225 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { mergeRegister } from '@lexical/utils';
+import {
+  $createTextNode,
+  $getSelection,
+  COMMAND_PRIORITY_NORMAL,
+  KEY_ARROW_DOWN_COMMAND,
+  KEY_ARROW_LEFT_COMMAND,
+  KEY_ARROW_RIGHT_COMMAND,
+  KEY_ARROW_UP_COMMAND,
+  type LexicalNode,
+  type TextNode,
+} from 'lexical';
+import React, { Suspense, useEffect, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+import { TypeAheadPopup } from './TypeAheadPopup';
+import { INSERT_ITEM_COMMAND } from './commands';
+import { type QueryData, type TextRange, type TypeAheadSelection } from './types';
+
+export const TypeAheadPlugin = ({
+  anchorElem = document.body,
+  arrowKeysShouldDismiss = false,
+  createItemNode = $createTextNode as any,
+  dataTestId,
+  dataTestName,
+  getQueryData,
+  findMatches,
+  insertItemModifier,
+  itemClassName = '',
+  itemRenderer = (item) => item,
+  listClassName = '',
+}: {
+  anchorElem?: HTMLElement;
+  arrowKeysShouldDismiss?: boolean;
+  createItemNode?: (item: string) => LexicalNode;
+  dataTestId?: string;
+  dataTestName?: string;
+  getQueryData: (selection: TypeAheadSelection | null) => QueryData | null;
+  findMatches: (query: string) => string[];
+  insertItemModifier?: (data: { item: string; text: string | null; textRange: TextRange | null }) => string;
+  itemClassName?: string;
+  itemRenderer?: (item: string, query: string) => ReactNode;
+  listClassName?: string;
+}): JSX.Element | null => {
+  const [editor] = useLexicalComposerContext();
+
+  const [queryData, setQueryData] = useState<QueryData | null>(null);
+
+  // Ignore the first update.
+  // We shouldn't show a type-ahead completion for an editor editor that just mounted and happens to contain content.
+  const ignoreNextUpdateRef = useRef(true);
+
+  // Shares most recently committed component state with imperative Lexical API (which only runs on mount)
+  const committedStateRef = useRef({ queryData });
+  useEffect(() => {
+    committedStateRef.current.queryData = queryData;
+  });
+
+  useEffect(() => {
+    const onUpdate = () => {
+      if (!editor.isEditable()) {
+        return;
+      }
+
+      if (ignoreNextUpdateRef.current) {
+        // Don't re-show the popup if the user just selected an item.
+        ignoreNextUpdateRef.current = false;
+        return;
+      }
+
+      editor.update(async () => {
+        const selection = $getSelection();
+        const newQueryData = getQueryData(selection);
+
+        setQueryData(newQueryData);
+      });
+    };
+
+    const onInsertItem = ({ item }: { item: string }) => {
+      editor.update(() => {
+        if (insertItemModifier) {
+          const selection = $getSelection();
+          const queryData = getQueryData(selection);
+          const text = editor.getRootElement()?.textContent;
+
+          item = insertItemModifier({
+            item,
+            text: text ?? null,
+            textRange: queryData?.textRange ?? null,
+          });
+        }
+
+        const { queryData } = committedStateRef.current;
+        if (queryData === null) {
+          return;
+        }
+
+        const itemNode = createItemNode(item);
+
+        const { beginTextNode, beginOffset, endTextNode, endOffset } = queryData.textRange;
+
+        let currentTextNode: LexicalNode | null = beginTextNode;
+        while (currentTextNode !== null) {
+          if (currentTextNode === beginTextNode) {
+            if (currentTextNode === endTextNode) {
+              if (beginOffset === endOffset) {
+                const [firstTextNode] = currentTextNode.splitText(beginOffset);
+                firstTextNode.insertAfter(itemNode);
+                itemNode.select();
+              } else {
+                const [firstTextNode, secondTextNode] = currentTextNode.splitText(beginOffset, endOffset);
+
+                if (beginOffset === 0 || secondTextNode == null) {
+                  firstTextNode.replace(itemNode);
+                } else {
+                  secondTextNode.replace(itemNode);
+                }
+
+                itemNode.select();
+              }
+
+              break;
+            } else {
+              const nextTextNode: TextNode | null = currentTextNode.getNextSibling();
+
+              const [firstTextNode, secondTextNode] = currentTextNode.splitText(beginOffset);
+
+              if (beginOffset === 0 || secondTextNode == null) {
+                firstTextNode.replace(itemNode);
+              } else {
+                secondTextNode.replace(itemNode);
+              }
+
+              itemNode.select();
+
+              currentTextNode = nextTextNode;
+            }
+          } else if (currentTextNode === endTextNode) {
+            const [firstTextNode] = currentTextNode.splitText(endOffset);
+            firstTextNode.remove();
+            break;
+          } else {
+            const nextTextNode: TextNode | null = currentTextNode.getNextSibling();
+            currentTextNode.remove();
+            currentTextNode = nextTextNode;
+          }
+        }
+
+        // Don't re-show the popup if the user just selected an item.
+        ignoreNextUpdateRef.current = true;
+
+        setQueryData(null);
+      });
+
+      return true;
+    };
+
+    const onEditable = () => {
+      if (!editor.isEditable()) {
+        setQueryData(null);
+      }
+    };
+
+    // Up/down arrow keys should not show a type-ahead suggestion,
+    // and should dismiss a type-ahead suggestion if one is active.
+    const onUpDownArrowKeyCommand = () => {
+      if (arrowKeysShouldDismiss) {
+        ignoreNextUpdateRef.current = true;
+      }
+
+      return arrowKeysShouldDismiss;
+    };
+
+    // Left/right arrow keys should dismiss a type-ahead suggestion.
+    const onLeftRightArrowKeyCommand = () => {
+      if (!editor.isEditable()) {
+        return false;
+      }
+
+      editor.update(async () => {
+        const selection = $getSelection();
+        const newQueryData = getQueryData(selection);
+
+        setQueryData(newQueryData);
+      });
+
+      return true;
+    };
+
+    return mergeRegister(
+      editor.registerEditableListener(onEditable),
+      editor.registerUpdateListener(onUpdate),
+      editor.registerCommand(INSERT_ITEM_COMMAND, onInsertItem, COMMAND_PRIORITY_NORMAL),
+      editor.registerCommand(KEY_ARROW_DOWN_COMMAND, onUpDownArrowKeyCommand, COMMAND_PRIORITY_NORMAL),
+      editor.registerCommand(KEY_ARROW_LEFT_COMMAND, onLeftRightArrowKeyCommand, COMMAND_PRIORITY_NORMAL),
+      editor.registerCommand(KEY_ARROW_RIGHT_COMMAND, onLeftRightArrowKeyCommand, COMMAND_PRIORITY_NORMAL),
+      editor.registerCommand(KEY_ARROW_UP_COMMAND, onUpDownArrowKeyCommand, COMMAND_PRIORITY_NORMAL),
+    );
+  }, [arrowKeysShouldDismiss, createItemNode, editor, findMatches, getQueryData]);
+
+  return queryData === null
+    ? null
+    : createPortal(
+        <Suspense>
+          <TypeAheadPopup
+            anchorElem={anchorElem}
+            dataTestId={dataTestId}
+            dataTestName={dataTestName}
+            editor={editor}
+            findMatches={findMatches}
+            itemClassName={itemClassName}
+            itemRenderer={itemRenderer}
+            listClassName={listClassName}
+            queryData={queryData}
+            updateQueryData={setQueryData}
+          />
+        </Suspense>,
+        anchorElem,
+      );
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/TypeAheadPopup.tsx
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/TypeAheadPopup.tsx
@@ -1,0 +1,372 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { mergeRegister } from '@lexical/utils';
+import {
+  BLUR_COMMAND,
+  COMMAND_PRIORITY_HIGH,
+  KEY_ARROW_DOWN_COMMAND,
+  KEY_ARROW_UP_COMMAND,
+  KEY_ENTER_COMMAND,
+  KEY_ESCAPE_COMMAND,
+  KEY_TAB_COMMAND,
+  type LexicalEditor,
+} from 'lexical';
+import React, { type ReactNode, useLayoutEffect, useRef, useState } from 'react';
+
+import { TypeAheadListRenderer } from './TypeAheadListRenderer';
+import { INSERT_ITEM_COMMAND } from './commands';
+import { type QueryData } from './types';
+import getDOMRangeRect from './utils/getDOMRangeRect';
+import getLexicalEditorForDomNode from './utils/getLexicalEditorForDomNode';
+import { isPromiseLike } from './utils/isPromiseLike';
+import setFloatingElemPosition from './utils/setFloatingElemPosition';
+
+const EMPTY_ARRAY: any[] = [];
+
+export const TypeAheadPopup = ({
+  anchorElem,
+  dataTestId,
+  dataTestName,
+  editor,
+  findMatches,
+  itemClassName,
+  itemRenderer,
+  listClassName,
+  queryData,
+  updateQueryData,
+}: {
+  anchorElem: HTMLElement;
+  dataTestId?: string;
+  dataTestName?: string;
+  editor: LexicalEditor;
+  findMatches: (query: string) => string[];
+  itemClassName: string;
+  itemRenderer: (item: string, query: string) => ReactNode;
+  listClassName: string;
+  queryData: QueryData;
+  updateQueryData: (queryData: QueryData | null) => void;
+}) => {
+  let items: string[] = [];
+  try {
+    items = findMatches(queryData.query);
+  } catch (errorOrPromise) {
+    if (isPromiseLike(errorOrPromise)) {
+      throw errorOrPromise;
+    }
+  }
+
+  return (
+    <TypeAheadPopUpWithItems
+      anchorElem={anchorElem}
+      dataTestId={dataTestId}
+      dataTestName={dataTestName}
+      editor={editor}
+      itemClassName={itemClassName}
+      itemRenderer={itemRenderer}
+      items={items}
+      listClassName={listClassName}
+      queryData={queryData}
+      updateQueryData={updateQueryData}
+    />
+  );
+};
+
+const TypeAheadPopUpWithItems = ({
+  anchorElem,
+  dataTestId,
+  dataTestName,
+  editor,
+  itemClassName,
+  itemRenderer,
+  items,
+  listClassName,
+  queryData,
+  updateQueryData,
+}: {
+  anchorElem: HTMLElement;
+  dataTestId?: string;
+  dataTestName?: string;
+  editor: LexicalEditor;
+  itemClassName: string;
+  itemRenderer: (item: string, query: string) => ReactNode;
+  items: string[];
+  listClassName: string;
+  queryData: QueryData;
+  updateQueryData: (queryData: QueryData | null) => void;
+}) => {
+  const popupRef = useRef<HTMLDivElement>(null);
+  const selectedItemRef = useRef<HTMLDivElement>(null);
+
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  // Refines selected item when items change.
+  const [prevState, setPrevState] = useState({
+    items: EMPTY_ARRAY,
+    selectedIndex: 0,
+  });
+  if (prevState.items !== items) {
+    const { items: prevItems, selectedIndex: prevSelectedIndex } = prevState;
+
+    const previousItem = prevSelectedIndex < prevItems.length ? prevItems[prevSelectedIndex] : null;
+
+    // Only maintain selection if the selected index is greater than 0.
+    // This avoids awkward scroll jumps while the user is typing.
+    let newSelectionIndex = 0;
+    if (previousItem !== null && prevSelectedIndex > 0) {
+      newSelectionIndex = items.indexOf(previousItem);
+      newSelectionIndex = newSelectionIndex >= 0 ? newSelectionIndex : 0;
+    }
+
+    setSelectedIndex(newSelectionIndex);
+
+    setPrevState({
+      items,
+      selectedIndex: newSelectionIndex,
+    });
+  } else if (prevState.selectedIndex !== selectedIndex) {
+    setPrevState({
+      items,
+      selectedIndex,
+    });
+  }
+
+  // Notify the parent plug-in that it should deactivate the type-ahead when there are no suggestions.
+  // This includes the case where there's only one suggestion and it's an exact match.
+  //
+  // It's best to do this with a layout effect because of the exact-match check;
+  // Otherwise the popup will appear to flicker before being hidden.
+  useLayoutEffect(() => {
+    if (queryData !== null) {
+      if (items.length === 0) {
+        updateQueryData(null);
+      }
+    }
+  }, [items, queryData, updateQueryData]);
+
+  // Shares most recently committed component state with imperative Lexical API (which only runs on mount)
+  const committedStateRef = useRef({
+    items,
+    queryData,
+    selectedIndex,
+    updateQueryData,
+  });
+  useLayoutEffect(() => {
+    committedStateRef.current.items = items;
+    committedStateRef.current.queryData = queryData;
+    committedStateRef.current.selectedIndex = selectedIndex;
+    committedStateRef.current.updateQueryData = updateQueryData;
+  });
+
+  const selectedItem = items[selectedIndex] || null;
+
+  // Position popup
+  useLayoutEffect(() => {
+    const popup = popupRef.current;
+    if (popup === null) {
+      return;
+    }
+
+    const rootElement = editor.getRootElement();
+    const nativeSelection = window.getSelection();
+    if (nativeSelection === null || rootElement === null) {
+      return;
+    }
+
+    const { anchorNode, anchorOffset, focusNode, focusOffset } = nativeSelection;
+    if (anchorNode === null || focusNode === null) {
+      return;
+    } else if (getLexicalEditorForDomNode(anchorNode) !== editor) {
+      return;
+    }
+
+    const { beginOffset, beginTextNode, endOffset, endTextNode } = queryData.textRange;
+
+    try {
+      const beginHTMLElement = editor.getElementByKey(beginTextNode.getKey());
+      const endHTMLElement = editor.getElementByKey(endTextNode.getKey());
+
+      if (beginHTMLElement && endHTMLElement) {
+        const beginTextNode =
+          beginHTMLElement.nodeType === Node.TEXT_NODE ? beginHTMLElement : beginHTMLElement.firstChild!;
+        const endTextNode = endHTMLElement.nodeType === Node.TEXT_NODE ? endHTMLElement : endHTMLElement.firstChild!;
+
+        const endTextNodeOffset = Math.min(endOffset, endTextNode.textContent ? endTextNode.textContent.length : 0);
+
+        // Position the popup at the start of the query.
+        // Temporarily change selection so we can measure the text we care about
+        nativeSelection.setBaseAndExtent(beginTextNode, beginOffset, endTextNode, endTextNodeOffset);
+
+        const positionRect = getDOMRangeRect(nativeSelection, rootElement);
+
+        // const positionRect = positionRange?.getBoundingClientRect() ?? null;
+        if (positionRect !== null) {
+          popup.style.position = 'absolute';
+          popup.style.left = '0px';
+          popup.style.top = '0px';
+
+          setFloatingElemPosition(positionRect, popup, anchorElem, 0, 0);
+        }
+      }
+    } catch (error) {
+      // console.error(error);
+    }
+
+    // Restore selection
+    nativeSelection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
+  });
+
+  // Scroll selected item into view
+  useLayoutEffect(() => {
+    const selectedItem = selectedItemRef.current;
+    if (selectedItem) {
+      selectedItem.scrollIntoView({ block: 'nearest' });
+    }
+  });
+
+  // Clicks inside of the popup shouldn't dismiss the plugin
+  // until after they have been handled.
+  useLayoutEffect(() => {
+    const popup = popupRef.current;
+    if (popup) {
+      const onMouseDown = (event: MouseEvent) => {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+      };
+
+      popup.addEventListener('mousedown', onMouseDown);
+      return () => {
+        popup.removeEventListener('mousedown', onMouseDown);
+      };
+    }
+  }, []);
+
+  // Register Lexical command listeners for mouse and keyboard interactions
+  useLayoutEffect(() => {
+    const onKeyPress = (event: KeyboardEvent) => {
+      if (event.shiftKey) {
+        // Edge case but SHIFT+TAB should not accept a suggestion
+        return true;
+      }
+
+      if (!editor.isEditable()) {
+        return false;
+      }
+
+      const { queryData } = committedStateRef.current;
+      if (queryData === null) {
+        return false;
+      }
+
+      switch (event.key) {
+        case 'ArrowDown': {
+          const { items, selectedIndex } = committedStateRef.current;
+          if (items.length === 0) {
+            return false;
+          }
+
+          event.preventDefault();
+
+          let newIndex = selectedIndex + 1;
+          if (newIndex >= items.length) {
+            newIndex = 0;
+          }
+
+          setSelectedIndex(newIndex);
+
+          return true;
+        }
+        case 'ArrowUp': {
+          const { items, selectedIndex } = committedStateRef.current;
+          if (items.length === 0) {
+            return false;
+          }
+
+          event.preventDefault();
+
+          let newIndex = selectedIndex - 1;
+          if (newIndex < 0) {
+            newIndex = items.length - 1;
+          }
+
+          setSelectedIndex(newIndex);
+
+          return true;
+        }
+        case 'Enter':
+        case 'NumpadEnter':
+        case 'Tab': {
+          const { selectedIndex, items } = committedStateRef.current;
+          const selectedItem = items[selectedIndex];
+          if (selectedItem == null) {
+            return false;
+          }
+
+          event.preventDefault();
+
+          editor.dispatchCommand(INSERT_ITEM_COMMAND, {
+            item: selectedItem,
+          });
+
+          return true;
+        }
+        case 'Escape': {
+          event.preventDefault();
+
+          const { updateQueryData } = committedStateRef.current;
+          updateQueryData(null);
+
+          return true;
+        }
+      }
+
+      return false;
+    };
+
+    // Dismiss the type-ahead popup on blur.
+    const onBlur = (event: FocusEvent) => {
+      // The only exception to this should be if the "blur" was caused by a click in the type-ahead menu.
+      const popup = popupRef.current;
+      if (popup) {
+        const relatedTarget = event.relatedTarget as Node;
+        if (popup !== relatedTarget && !popup.contains(relatedTarget)) {
+          const { updateQueryData } = committedStateRef.current;
+          updateQueryData(null);
+          return false;
+        }
+      }
+
+      return true;
+    };
+
+    return mergeRegister(
+      editor.registerCommand(BLUR_COMMAND, onBlur, COMMAND_PRIORITY_HIGH),
+      editor.registerCommand(KEY_ARROW_DOWN_COMMAND, onKeyPress, COMMAND_PRIORITY_HIGH),
+      editor.registerCommand(KEY_ARROW_UP_COMMAND, onKeyPress, COMMAND_PRIORITY_HIGH),
+      editor.registerCommand(KEY_ENTER_COMMAND, onKeyPress, COMMAND_PRIORITY_HIGH),
+      editor.registerCommand(KEY_ESCAPE_COMMAND, onKeyPress, COMMAND_PRIORITY_HIGH),
+      editor.registerCommand(KEY_TAB_COMMAND, onKeyPress, COMMAND_PRIORITY_HIGH),
+    );
+  }, [editor]);
+
+  if (items.length === 0) {
+    // Don't render an empty popup.
+    return null;
+  }
+
+  return (
+    <TypeAheadListRenderer
+      dataTestId={dataTestId}
+      dataTestName={dataTestName}
+      editor={editor}
+      itemClassName={itemClassName}
+      itemRenderer={itemRenderer}
+      listClassName={listClassName}
+      items={items}
+      popupRef={popupRef}
+      query={queryData.query}
+      selectedItem={selectedItem}
+    />
+  );
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/commands.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/commands.ts
@@ -1,0 +1,11 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type LexicalCommand } from 'lexical';
+
+export const INSERT_ITEM_COMMAND: LexicalCommand<{
+  item: any;
+}> = {
+  type: 'INSERT_ITEM',
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/types.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/types.ts
@@ -1,0 +1,50 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type GridSelection, type LexicalNode, type NodeSelection, type RangeSelection } from 'lexical';
+
+export type Callback<Item> = (query: string, items: Item[], selectedIndex: number) => void;
+
+export type ContextShape<Item> = {
+  dismiss: () => void;
+  selectItem: (item: Item) => void;
+  selectNext: () => void;
+  selectPrevious: () => void;
+  subscribe: (callback: Callback<Item>) => () => void;
+  update: (_: string, __: Item[]) => void;
+};
+
+export type HookShape<Item> = {
+  dismiss: () => void;
+  query: string;
+  selectedIndex: number;
+  selectedItem: Item | null;
+  items: Item[];
+  selectItem: (item: Item) => void;
+  selectNext: () => void;
+  selectPrevious: () => void;
+  stateRef: {
+    current: HookState<Item>;
+  };
+  update: (_: string, __: Item[]) => void;
+};
+
+export type HookState<Item> = {
+  query: string;
+  selectedIndex: number;
+  items: Item[];
+};
+export type TextRange = {
+  beginOffset: number;
+  beginTextNode: LexicalNode;
+  endOffset: number;
+  endTextNode: LexicalNode;
+};
+
+export type QueryData = {
+  query: string;
+  textRange: TextRange;
+};
+
+export type TypeAheadSelection = RangeSelection | NodeSelection | GridSelection;

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/utils/$isSimpleText.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/utils/$isSimpleText.ts
@@ -1,0 +1,8 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { $isTextNode, type LexicalNode } from 'lexical';
+
+export default (node: LexicalNode): boolean =>
+  $isTextNode(node) && typeof node.isSimpleText === 'function' && node.isSimpleText();

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/utils/getDOMRangeRect.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/utils/getDOMRangeRect.ts
@@ -1,0 +1,21 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+export default (nativeSelection: Selection, rootElement: HTMLElement): DOMRect => {
+  const domRange = nativeSelection.getRangeAt(0);
+
+  let rect;
+
+  if (nativeSelection.anchorNode === rootElement) {
+    let inner = rootElement;
+    while (inner.firstElementChild != null) {
+      inner = inner.firstElementChild as HTMLElement;
+    }
+    rect = inner.getBoundingClientRect();
+  } else {
+    rect = domRange.getBoundingClientRect();
+  }
+
+  return rect;
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/utils/getLexicalEditorForDomNode.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/utils/getLexicalEditorForDomNode.ts
@@ -1,0 +1,20 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type LexicalEditor } from 'lexical';
+
+export default (domNode: Node): LexicalEditor | null => {
+  let currentDomNode: Node | null = domNode;
+  while (currentDomNode != null) {
+    // @ts-expect-error: internal field
+    const maybeLexicalEditor = currentDomNode.__lexicalEditor;
+    if (maybeLexicalEditor != null) {
+      return maybeLexicalEditor;
+    }
+
+    currentDomNode = currentDomNode.parentElement;
+  }
+
+  return null;
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/utils/getLineTextAndCursorPosition.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/utils/getLineTextAndCursorPosition.ts
@@ -1,0 +1,46 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { $isLineBreakNode, type LexicalNode } from 'lexical';
+
+export default (initialNode: LexicalNode, initialOffset: number): [text: string | null, cursorIndex: number] => {
+  let startNode: LexicalNode | null = null;
+  let cursorIndex = -1;
+
+  let currentNode: LexicalNode | null = initialNode;
+  while (currentNode !== null) {
+    if ($isLineBreakNode(currentNode)) {
+      break;
+    } else {
+      startNode = currentNode;
+
+      if (currentNode === initialNode) {
+        cursorIndex = initialOffset;
+      } else {
+        cursorIndex += currentNode.getTextContent().length;
+      }
+    }
+
+    currentNode = currentNode.getPreviousSibling();
+  }
+
+  if (startNode === null) {
+    return [null, -1];
+  }
+
+  let text = '';
+
+  currentNode = startNode;
+  while (currentNode !== null) {
+    if ($isLineBreakNode(currentNode)) {
+      break;
+    } else {
+      text += currentNode.getTextContent();
+    }
+
+    currentNode = currentNode.getNextSibling();
+  }
+
+  return [text, cursorIndex];
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/utils/getTokenTypesForCursorPosition.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/utils/getTokenTypesForCursorPosition.ts
@@ -1,0 +1,33 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type LexicalNode } from 'lexical';
+
+import getLineTextAndCursorPosition from './getLineTextAndCursorPosition';
+import parseTokens from '../../code/utils/parseTokens';
+
+export default (initialNode: LexicalNode, initialOffset: number): string[] | null => {
+  const [text, cursorIndex] = getLineTextAndCursorPosition(initialNode, initialOffset);
+  if (text === null) {
+    return null;
+  }
+
+  const tokens = parseTokens(text);
+  if (tokens === null) {
+    return null;
+  }
+
+  let currentIndex = 0;
+  for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
+    const token = tokens[tokenIndex];
+
+    currentIndex += token.text.length;
+
+    if (currentIndex >= cursorIndex) {
+      return token.types;
+    }
+  }
+
+  return null;
+};

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/utils/isPromiseLike.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/utils/isPromiseLike.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+export const isPromiseLike = (value: any): boolean => value != null && typeof value.then === 'function';

--- a/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/utils/setFloatingElemPosition.ts
+++ b/packages/apps/plugins/plugin-sheet/src/components/lexical/plugins/typeahead/utils/setFloatingElemPosition.ts
@@ -1,0 +1,43 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+const VERTICAL_GAP = 10;
+const HORIZONTAL_OFFSET = 5;
+
+export default (
+  targetRect: { height: number; left: number; top: number } | null,
+  floatingElem: HTMLElement,
+  anchorElem: HTMLElement,
+  verticalGap: number = VERTICAL_GAP,
+  horizontalOffset: number = HORIZONTAL_OFFSET,
+): void => {
+  const scrollerElem = anchorElem.parentElement;
+
+  if (targetRect === null || !scrollerElem) {
+    floatingElem.style.opacity = '0';
+    floatingElem.style.transform = 'translate(-10000px, -10000px)';
+    return;
+  }
+
+  const floatingElemRect = floatingElem.getBoundingClientRect();
+  const anchorElementRect = anchorElem.getBoundingClientRect();
+  const editorScrollerRect = scrollerElem.getBoundingClientRect();
+
+  let top = targetRect.top - floatingElemRect.height - verticalGap;
+  let left = targetRect.left - horizontalOffset;
+
+  if (top < editorScrollerRect.top) {
+    top += floatingElemRect.height + targetRect.height + verticalGap * 2;
+  }
+
+  if (left + floatingElemRect.width > editorScrollerRect.right) {
+    left = editorScrollerRect.right - floatingElemRect.width - horizontalOffset;
+  }
+
+  top -= anchorElementRect.top;
+  left -= anchorElementRect.left;
+
+  floatingElem.style.opacity = '1';
+  floatingElem.style.transform = `translate(${left}px, ${top}px)`;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3325,12 +3325,39 @@ importers:
       '@dxos/util':
         specifier: workspace:*
         version: link:../../../common/util
+      '@lexical/react':
+        specifier: ^0.6.5
+        version: 0.6.5(lexical@0.6.5)(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.18)
+      '@lexical/selection':
+        specifier: ^0.6.5
+        version: 0.6.5(lexical@0.6.5)
+      '@lexical/text':
+        specifier: ^0.6.5
+        version: 0.6.5(lexical@0.6.5)
+      '@lexical/utils':
+        specifier: ^0.6.5
+        version: 0.6.5(lexical@0.6.5)
+      '@lezer/common':
+        specifier: ^1.2.1
+        version: 1.2.1
+      '@lezer/highlight':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@preact/signals-core':
         specifier: ^1.6.0
         version: 1.6.0
+      codemirror:
+        specifier: ^6.0.1
+        version: 6.0.1(@lezer/common@1.2.1)
+      codemirror-lang-spreadsheet:
+        specifier: ^1.3.0
+        version: 1.3.0
       hyperformula:
         specifier: ^2.7.1
         version: 2.7.1
+      lexical:
+        specifier: ^0.6.5
+        version: 0.6.5
       lodash.defaultsdeep:
         specifier: ^4.6.1
         version: 4.6.1
@@ -3343,6 +3370,9 @@ importers:
       react-window:
         specifier: ^1.8.10
         version: 1.8.10(react-dom@18.2.0)(react@18.2.0)
+      yjs:
+        specifier: ^13.5.22
+        version: 13.6.18
     devDependencies:
       '@braneframe/plugin-client':
         specifier: workspace:*
@@ -11573,7 +11603,7 @@ importers:
         version: link:../../packages/ui/react-ui-theme
       '@storybook/addon-essentials':
         specifier: ~8.1.11
-        version: 8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0)
       '@storybook/addon-interactions':
         specifier: ~8.1.11
         version: 8.1.11(jest@28.1.3)(vitest@1.5.0)
@@ -11582,25 +11612,25 @@ importers:
         version: 8.1.11(react@18.2.0)
       '@storybook/builder-vite':
         specifier: ~8.1.11
-        version: 8.1.11(prettier@3.3.3)(typescript@5.4.5)(vite@5.3.4)
+        version: 8.1.11(prettier@3.2.4)(typescript@5.4.5)(vite@5.3.4)
       '@storybook/core-server':
         specifier: ~8.1.11
-        version: 8.1.11(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 8.1.11(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0)
       '@storybook/html':
         specifier: ~8.1.11
-        version: 8.1.11(prettier@3.3.3)
+        version: 8.1.11(prettier@3.2.4)
       '@storybook/html-vite':
         specifier: ~8.1.11
-        version: 8.1.11(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)(vite@5.3.4)
+        version: 8.1.11(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)(vite@5.3.4)
       '@storybook/mdx2-csf':
         specifier: ^1.1.0
         version: 1.1.0
       '@storybook/react':
         specifier: ~8.1.11
-        version: 8.1.11(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
+        version: 8.1.11(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
       '@storybook/react-vite':
         specifier: ~8.1.11
-        version: 8.1.11(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0)(rollup@3.23.0)(typescript@5.4.5)(vite@5.3.4)
+        version: 8.1.11(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0)(rollup@3.23.0)(typescript@5.4.5)(vite@5.3.4)
       '@types/lodash.flatten':
         specifier: ^4.4.6
         version: 4.4.7
@@ -17816,8 +17846,36 @@ packages:
       minimist: 1.2.8
     dev: true
 
-  /@codemirror/autocomplete@6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.29.1)(@lezer/common@1.2.1):
-    resolution: {integrity: sha512-fdfj6e6ZxZf8yrkMHUSJJir7OJkHkZKaOZGzLWIYp2PZ3jd+d+UjG8zVPqJF6d3bKxkhvXTPan/UZ1t7Bqm0gA==}
+  /@codemirror/autocomplete@6.12.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.0)(@codemirror/view@6.29.0)(@lezer/common@1.2.1):
+    resolution: {integrity: sha512-r4IjdYFthwbCQyvqnSlx0WBHRHi8nBvU+WjJxFUij81qsBfhNudf/XKKmmC2j3m0LaOYUQTf3qiEK1J8lO1sdg==}
+    peerDependencies:
+      '@codemirror/language': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+      '@lezer/common': ^1.0.0
+    dependencies:
+      '@codemirror/language': 6.10.2
+      '@codemirror/state': 6.4.0
+      '@codemirror/view': 6.29.0
+      '@lezer/common': 1.2.1
+    dev: false
+
+  /@codemirror/autocomplete@6.12.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.0)(@codemirror/view@6.29.1)(@lezer/common@1.2.1):
+    resolution: {integrity: sha512-r4IjdYFthwbCQyvqnSlx0WBHRHi8nBvU+WjJxFUij81qsBfhNudf/XKKmmC2j3m0LaOYUQTf3qiEK1J8lO1sdg==}
+    peerDependencies:
+      '@codemirror/language': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+      '@lezer/common': ^1.0.0
+    dependencies:
+      '@codemirror/language': 6.10.2
+      '@codemirror/state': 6.4.0
+      '@codemirror/view': 6.29.1
+      '@lezer/common': 1.2.1
+    dev: false
+
+  /@codemirror/autocomplete@6.12.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.29.1)(@lezer/common@1.2.1):
+    resolution: {integrity: sha512-r4IjdYFthwbCQyvqnSlx0WBHRHi8nBvU+WjJxFUij81qsBfhNudf/XKKmmC2j3m0LaOYUQTf3qiEK1J8lO1sdg==}
     peerDependencies:
       '@codemirror/language': ^6.0.0
       '@codemirror/state': ^6.0.0
@@ -17830,8 +17888,13 @@ packages:
       '@lezer/common': 1.2.1
     dev: false
 
-  /@codemirror/commands@6.3.3:
-    resolution: {integrity: sha512-dO4hcF0fGT9tu1Pj1D2PvGvxjeGkbC6RGcZw6Qs74TH+Ed1gw98jmUgd2axWvIZEqTeTuFrg1lEB1KV6cK9h1A==}
+  /@codemirror/autocomplete@6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.29.1)(@lezer/common@1.2.1):
+    resolution: {integrity: sha512-fdfj6e6ZxZf8yrkMHUSJJir7OJkHkZKaOZGzLWIYp2PZ3jd+d+UjG8zVPqJF6d3bKxkhvXTPan/UZ1t7Bqm0gA==}
+    peerDependencies:
+      '@codemirror/language': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+      '@lezer/common': ^1.0.0
     dependencies:
       '@codemirror/language': 6.10.2
       '@codemirror/state': 6.4.1
@@ -17856,7 +17919,7 @@ packages:
       '@codemirror/language': 6.10.2
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@codemirror/lang-cpp@6.0.2:
@@ -17866,12 +17929,24 @@ packages:
       '@lezer/cpp': 1.1.0
     dev: false
 
+  /@codemirror/lang-css@6.2.1(@codemirror/view@6.29.0):
+    resolution: {integrity: sha512-/UNWDNV5Viwi/1lpr/dIXJNWiwDxpw13I4pTUAsNxZdg6E0mI2kTQb0P2iHczg1Tu+H4EBgJR+hYhKiHKko7qg==}
+    dependencies:
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.0)(@codemirror/view@6.29.0)(@lezer/common@1.2.1)
+      '@codemirror/language': 6.10.2
+      '@codemirror/state': 6.4.0
+      '@lezer/common': 1.2.1
+      '@lezer/css': 1.1.1
+    transitivePeerDependencies:
+      - '@codemirror/view'
+    dev: false
+
   /@codemirror/lang-css@6.2.1(@codemirror/view@6.29.1):
     resolution: {integrity: sha512-/UNWDNV5Viwi/1lpr/dIXJNWiwDxpw13I4pTUAsNxZdg6E0mI2kTQb0P2iHczg1Tu+H4EBgJR+hYhKiHKko7qg==}
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.29.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.0)(@codemirror/view@6.29.1)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.2
-      '@codemirror/state': 6.4.1
+      '@codemirror/state': 6.4.0
       '@lezer/common': 1.2.1
       '@lezer/css': 1.1.1
     transitivePeerDependencies:
@@ -17881,9 +17956,9 @@ packages:
   /@codemirror/lang-go@6.0.1(@codemirror/view@6.29.1):
     resolution: {integrity: sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==}
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.29.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.0)(@codemirror/view@6.29.1)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.2
-      '@codemirror/state': 6.4.1
+      '@codemirror/state': 6.4.0
       '@lezer/common': 1.2.1
       '@lezer/go': 1.0.0
     transitivePeerDependencies:
@@ -17893,12 +17968,12 @@ packages:
   /@codemirror/lang-html@6.4.2:
     resolution: {integrity: sha512-bqCBASkteKySwtIbiV/WCtGnn/khLRbbiV5TE+d9S9eQJD7BA4c5dTRm2b3bVmSpilff5EYxvB4PQaZzM/7cNw==}
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.29.1)(@lezer/common@1.2.1)
-      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.29.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.0)(@codemirror/view@6.29.0)(@lezer/common@1.2.1)
+      '@codemirror/lang-css': 6.2.1(@codemirror/view@6.29.0)
       '@codemirror/lang-javascript': 6.2.2
       '@codemirror/language': 6.10.2
-      '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.29.1
+      '@codemirror/state': 6.4.0
+      '@codemirror/view': 6.29.0
       '@lezer/common': 1.2.1
       '@lezer/css': 1.1.1
       '@lezer/html': 1.3.3
@@ -17936,7 +18011,7 @@ packages:
       '@codemirror/lang-css': 6.2.1(@codemirror/view@6.29.1)
       '@codemirror/language': 6.10.2
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     transitivePeerDependencies:
       - '@codemirror/view'
     dev: false
@@ -17944,14 +18019,14 @@ packages:
   /@codemirror/lang-liquid@6.2.1:
     resolution: {integrity: sha512-J1Mratcm6JLNEiX+U2OlCDTysGuwbHD76XwuL5o5bo9soJtSbz2g6RU3vGHFyS5DC8rgVmFSzi7i6oBftm7tnA==}
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.29.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.0)(@codemirror/view@6.29.0)(@lezer/common@1.2.1)
       '@codemirror/lang-html': 6.4.2
       '@codemirror/language': 6.10.2
-      '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.29.1
+      '@codemirror/state': 6.4.0
+      '@codemirror/view': 6.29.0
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@codemirror/lang-markdown@6.2.5:
@@ -17971,7 +18046,7 @@ packages:
     dependencies:
       '@codemirror/lang-html': 6.4.2
       '@codemirror/language': 6.10.2
-      '@codemirror/state': 6.4.1
+      '@codemirror/state': 6.4.0
       '@lezer/common': 1.2.1
       '@lezer/php': 1.0.1
     dev: false
@@ -17979,7 +18054,7 @@ packages:
   /@codemirror/lang-python@6.1.2(@codemirror/state@6.4.1)(@codemirror/view@6.29.1)(@lezer/common@1.2.1):
     resolution: {integrity: sha512-nbQfifLBZstpt6Oo4XxA2LOzlSp4b/7Bc5cmodG1R+Cs5PLLCTUvsMNWDnziiCfTOG/SW1rVzXq/GbIr6WXlcw==}
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.29.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.29.1)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.2
       '@lezer/python': 1.1.2
     transitivePeerDependencies:
@@ -18000,7 +18075,7 @@ packages:
     dependencies:
       '@codemirror/lang-css': 6.2.1(@codemirror/view@6.29.1)
       '@codemirror/language': 6.10.2
-      '@codemirror/state': 6.4.1
+      '@codemirror/state': 6.4.0
       '@lezer/common': 1.2.1
       '@lezer/sass': 1.0.3
     transitivePeerDependencies:
@@ -18010,11 +18085,11 @@ packages:
   /@codemirror/lang-sql@6.4.0(@codemirror/view@6.29.1)(@lezer/common@1.2.1):
     resolution: {integrity: sha512-UWGK1+zc9+JtkiT+XxHByp4N6VLgLvC2x0tIudrJG26gyNtn0hWOVoB0A8kh/NABPWkKl3tLWDYf2qOBJS9Zdw==}
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.29.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.0)(@codemirror/view@6.29.1)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.2
-      '@codemirror/state': 6.4.1
+      '@codemirror/state': 6.4.0
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     transitivePeerDependencies:
       - '@codemirror/view'
       - '@lezer/common'
@@ -18028,7 +18103,7 @@ packages:
       '@codemirror/language': 6.10.2
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@codemirror/lang-wast@6.0.1:
@@ -18036,15 +18111,15 @@ packages:
     dependencies:
       '@codemirror/language': 6.10.2
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@codemirror/lang-xml@6.0.2(@codemirror/view@6.29.1):
     resolution: {integrity: sha512-JQYZjHL2LAfpiZI2/qZ/qzDuSqmGKMwyApYmEUUCTxLM4MWS7sATUEfIguZQr9Zjx/7gcdnewb039smF6nC2zw==}
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.29.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.0)(@codemirror/view@6.29.1)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.2
-      '@codemirror/state': 6.4.1
+      '@codemirror/state': 6.4.0
       '@lezer/common': 1.2.1
       '@lezer/xml': 1.0.1
     transitivePeerDependencies:
@@ -18054,9 +18129,9 @@ packages:
   /@codemirror/lang-yaml@6.1.1(@codemirror/view@6.29.1):
     resolution: {integrity: sha512-HV2NzbK9bbVnjWxwObuZh5FuPCowx51mEfoFT9y3y+M37fA3+pbxx4I7uePuygFzDsAmCTwQSc/kXh/flab4uw==}
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.29.1)(@lezer/common@1.2.1)
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.0)(@codemirror/view@6.29.1)(@lezer/common@1.2.1)
       '@codemirror/language': 6.10.2
-      '@codemirror/state': 6.4.1
+      '@codemirror/state': 6.4.0
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
       '@lezer/yaml': 1.0.3
@@ -18115,8 +18190,8 @@ packages:
   /@codemirror/lint@6.4.2:
     resolution: {integrity: sha512-wzRkluWb1ptPKdzlsrbwwjYCPLgzU6N88YBAmlZi8WFyuiEduSd05MnJYNogzyc8rPK7pj6m95ptUApc8sHKVA==}
     dependencies:
-      '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.29.1
+      '@codemirror/state': 6.4.0
+      '@codemirror/view': 6.29.0
       crelt: 1.0.5
     dev: false
 
@@ -18136,6 +18211,10 @@ packages:
       crelt: 1.0.5
     dev: false
 
+  /@codemirror/state@6.4.0:
+    resolution: {integrity: sha512-hm8XshYj5Fo30Bb922QX9hXB/bxOAVH+qaqHBzw5TKa72vOeslyGwd4X8M0c1dJ9JqxlaMceOQ8RsL9tC7gU0A==}
+    dev: false
+
   /@codemirror/state@6.4.1:
     resolution: {integrity: sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==}
     dev: false
@@ -18147,6 +18226,14 @@ packages:
       '@codemirror/state': 6.4.1
       '@codemirror/view': 6.29.1
       '@lezer/highlight': 1.2.0
+    dev: false
+
+  /@codemirror/view@6.29.0:
+    resolution: {integrity: sha512-ED4ims4fkf7eOA+HYLVP8VVg3NMllt1FPm9PEJBfYFnidKlRITBaua38u68L1F60eNtw2YNcDN5jsIzhKZwWQA==}
+    dependencies:
+      '@codemirror/state': 6.4.0
+      style-mod: 4.1.0
+      w3c-keyname: 2.2.6
     dev: false
 
   /@codemirror/view@6.29.1:
@@ -20023,7 +20110,7 @@ packages:
       '@inquirer/figures': 1.0.2
       '@inquirer/type': 1.3.2
       '@types/mute-stream': 0.0.4
-      '@types/node': 20.14.14
+      '@types/node': 20.14.12
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -20042,7 +20129,7 @@ packages:
       '@inquirer/figures': 1.0.3
       '@inquirer/type': 1.3.3
       '@types/mute-stream': 0.0.4
-      '@types/node': 20.14.14
+      '@types/node': 20.14.12
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -20987,6 +21074,229 @@ packages:
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
     dev: false
 
+  /@lexical/clipboard@0.6.5(lexical@0.6.5):
+    resolution: {integrity: sha512-yQtiKJUsvS5oftJIj5VlNA0dKsDvzpeIQTRQCVFfcwboAnwTF9VmLVW54UlDsaiW7ZeIOTXj4BgEaFdfpPkFLA==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      '@lexical/html': 0.6.5(lexical@0.6.5)
+      '@lexical/list': 0.6.5(lexical@0.6.5)
+      '@lexical/selection': 0.6.5(lexical@0.6.5)
+      '@lexical/utils': 0.6.5(lexical@0.6.5)
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/code@0.6.5(lexical@0.6.5):
+    resolution: {integrity: sha512-T+JPHrYfrBb6elpvmcfHTUpNfTUfPfur8BSZ+6lHObYtoC6KE5QyDMwfx7WRtDZxZ4w4sxZKTlTGb8BoGC+7WA==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      '@lexical/utils': 0.6.5(lexical@0.6.5)
+      lexical: 0.6.5
+      prismjs: 1.29.0
+    dev: false
+
+  /@lexical/dragon@0.6.5(lexical@0.6.5):
+    resolution: {integrity: sha512-cCztCfSO7WAsQMZGqF2NnZUkvi9YlfaKW679UtpR+vZ4+ORa8mvv9k6dJ2F91oE0CB7fuodDzjUnUjS1RFmZgA==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/hashtag@0.6.5(lexical@0.6.5):
+    resolution: {integrity: sha512-7qyv3LMxqm90NiuI0KPXTf5FuCMNln0IapCTQpVOuEq/hDpQe1FNjJJWXSfmFnLfkLuLeW7HpsOcmQHLf9/yPg==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      '@lexical/utils': 0.6.5(lexical@0.6.5)
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/history@0.6.5(lexical@0.6.5):
+    resolution: {integrity: sha512-EzfVo0iWvonsdNEEEynkLpT1PovCpixT1Vx0VAnj4D4ObTtUHcN4ZgeahIRvxAQzYpqd+O8LIt0o40YfMETWmQ==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      '@lexical/utils': 0.6.5(lexical@0.6.5)
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/html@0.6.5(lexical@0.6.5):
+    resolution: {integrity: sha512-uR8dyIR9XyPBwgcWyv/g1GgMQtQvVVRY6telPDr7WQ1O9534IcgLj3Tp+FwdhMsontid/juIyzpBF+0BVOd9zA==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      '@lexical/selection': 0.6.5(lexical@0.6.5)
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/link@0.6.5(lexical@0.6.5):
+    resolution: {integrity: sha512-6TmkwqLYn5ACI87rZzl8ImtADyOimXWoWqWwUquYeGXiQyTiRhLyFVjDjTxmxi2BtXBMscoW/Lj9N4Iu7PiDtw==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      '@lexical/utils': 0.6.5(lexical@0.6.5)
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/list@0.6.5(lexical@0.6.5):
+    resolution: {integrity: sha512-fCeXjZ0QuhKNuKeZv/onJf54xGHlFvfByM5KXl6ygWBP94D6y7AuspFroZRtV+2Md188cB6rhGnohyxBy8XVJg==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      '@lexical/utils': 0.6.5(lexical@0.6.5)
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/mark@0.6.5(lexical@0.6.5):
+    resolution: {integrity: sha512-xALEEBfiBoHx2aO2ifFdwFb5piZbCwlo716bhA2NL7BGD2ZKBldYiEz2o4dvJNzGDWVbQj04T2sfBOmycDcN4g==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      '@lexical/utils': 0.6.5(lexical@0.6.5)
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/markdown@0.6.5(@lexical/clipboard@0.6.5)(@lexical/selection@0.6.5)(lexical@0.6.5):
+    resolution: {integrity: sha512-wxmawggrgg3AsoZLOZxP55oIj/N97xCXmINVVQUVWmRYnnPvIOHdrf67v+VecHzjP3GZkLhnEfjwFTD5smoHCw==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      '@lexical/code': 0.6.5(lexical@0.6.5)
+      '@lexical/link': 0.6.5(lexical@0.6.5)
+      '@lexical/list': 0.6.5(lexical@0.6.5)
+      '@lexical/rich-text': 0.6.5(@lexical/clipboard@0.6.5)(@lexical/selection@0.6.5)(@lexical/utils@0.6.5)(lexical@0.6.5)
+      '@lexical/text': 0.6.5(lexical@0.6.5)
+      '@lexical/utils': 0.6.5(lexical@0.6.5)
+      lexical: 0.6.5
+    transitivePeerDependencies:
+      - '@lexical/clipboard'
+      - '@lexical/selection'
+    dev: false
+
+  /@lexical/offset@0.6.5(lexical@0.6.5):
+    resolution: {integrity: sha512-ua1hcp7vn3IhqdtblpVS+m9hj0fM6LJBzdWVxqLuH1ETOIl3mPfrwR0c6c+eThYubf61mQn0IcK3Pz8eEhRXkA==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/overflow@0.6.5(lexical@0.6.5):
+    resolution: {integrity: sha512-xgH6SRJKkdT2KWxgiKzzXTLkZldGk8oqGAP+AD2q5hcllAscHQqaJS+mm7i5PUSVV5L/3+4V7+JDy1VPTdDzVQ==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/plain-text@0.6.5(@lexical/clipboard@0.6.5)(@lexical/selection@0.6.5)(@lexical/utils@0.6.5)(lexical@0.6.5):
+    resolution: {integrity: sha512-uQxZ4rJmpgfjBZSbhAYgpegHyapFsXBrMRVd/sNqy5jkP3W3bU3D7u9n8QraW1fADpRLEpCMo9dcidIwBkGjUA==}
+    peerDependencies:
+      '@lexical/clipboard': 0.6.5
+      '@lexical/selection': 0.6.5
+      '@lexical/utils': 0.6.5
+      lexical: 0.6.5
+    dependencies:
+      '@lexical/clipboard': 0.6.5(lexical@0.6.5)
+      '@lexical/selection': 0.6.5(lexical@0.6.5)
+      '@lexical/utils': 0.6.5(lexical@0.6.5)
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/react@0.6.5(lexical@0.6.5)(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.18):
+    resolution: {integrity: sha512-f5UBFs8FRL8Ib/vUZ7YYjvkc+KvUubV4PnvmBl/bvfXOU+fufrxrqkxt05iArE4AbB+l2xU8YdZi/+jdJjQJVA==}
+    peerDependencies:
+      lexical: 0.6.5
+      react: ~18.2.0
+      react-dom: ~18.2.0
+    dependencies:
+      '@lexical/clipboard': 0.6.5(lexical@0.6.5)
+      '@lexical/code': 0.6.5(lexical@0.6.5)
+      '@lexical/dragon': 0.6.5(lexical@0.6.5)
+      '@lexical/hashtag': 0.6.5(lexical@0.6.5)
+      '@lexical/history': 0.6.5(lexical@0.6.5)
+      '@lexical/link': 0.6.5(lexical@0.6.5)
+      '@lexical/list': 0.6.5(lexical@0.6.5)
+      '@lexical/mark': 0.6.5(lexical@0.6.5)
+      '@lexical/markdown': 0.6.5(@lexical/clipboard@0.6.5)(@lexical/selection@0.6.5)(lexical@0.6.5)
+      '@lexical/overflow': 0.6.5(lexical@0.6.5)
+      '@lexical/plain-text': 0.6.5(@lexical/clipboard@0.6.5)(@lexical/selection@0.6.5)(@lexical/utils@0.6.5)(lexical@0.6.5)
+      '@lexical/rich-text': 0.6.5(@lexical/clipboard@0.6.5)(@lexical/selection@0.6.5)(@lexical/utils@0.6.5)(lexical@0.6.5)
+      '@lexical/selection': 0.6.5(lexical@0.6.5)
+      '@lexical/table': 0.6.5(lexical@0.6.5)
+      '@lexical/text': 0.6.5(lexical@0.6.5)
+      '@lexical/utils': 0.6.5(lexical@0.6.5)
+      '@lexical/yjs': 0.6.5(lexical@0.6.5)(yjs@13.6.18)
+      lexical: 0.6.5
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-error-boundary: 3.1.4(react@18.2.0)
+    transitivePeerDependencies:
+      - yjs
+    dev: false
+
+  /@lexical/rich-text@0.6.5(@lexical/clipboard@0.6.5)(@lexical/selection@0.6.5)(@lexical/utils@0.6.5)(lexical@0.6.5):
+    resolution: {integrity: sha512-UFV+dZmEW05AaF3lH96nXzigzH5zEDZCzFy/BMt0QNLb3q1eIy+EahvA8dOMn9IL/CsBOh2XYl8l7k6lwe3W5Q==}
+    peerDependencies:
+      '@lexical/clipboard': 0.6.5
+      '@lexical/selection': 0.6.5
+      '@lexical/utils': 0.6.5
+      lexical: 0.6.5
+    dependencies:
+      '@lexical/clipboard': 0.6.5(lexical@0.6.5)
+      '@lexical/selection': 0.6.5(lexical@0.6.5)
+      '@lexical/utils': 0.6.5(lexical@0.6.5)
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/selection@0.6.5(lexical@0.6.5):
+    resolution: {integrity: sha512-PvDLxbnHCDET/9UQp1Od4R5wakc6GgTeIKPxkfMyw9eF+vr8xFELvWvOadfhcCb+ydp5IMqqsSZ7eSCl8wFODg==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/table@0.6.5(lexical@0.6.5):
+    resolution: {integrity: sha512-dAsI/ut50li/8xvgIDUo8uzLChvhB3WoyK3zxJ+ywFDzjdDSIshyhvVgQFvkJP3wJLIOSfwhqggnwxDnxLqBQQ==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      '@lexical/utils': 0.6.5(lexical@0.6.5)
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/text@0.6.5(lexical@0.6.5):
+    resolution: {integrity: sha512-cBADZKXk09hoDXPZarcp65byWKZjBQFHgtWz4aIJScfdD25/LqoQ815tHBAqouAWDMiTOUjq07MFfNS3OHc3vw==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/utils@0.6.5(lexical@0.6.5):
+    resolution: {integrity: sha512-G/PBON7SeGoKs7yYbyLNtJE7CltxuXHWfw7F9vUk0avCzoSTrBeMNkmIOhnyp8XPuT1/5hgNWP8IG7kMsgozEg==}
+    peerDependencies:
+      lexical: 0.6.5
+    dependencies:
+      '@lexical/list': 0.6.5(lexical@0.6.5)
+      '@lexical/table': 0.6.5(lexical@0.6.5)
+      lexical: 0.6.5
+    dev: false
+
+  /@lexical/yjs@0.6.5(lexical@0.6.5)(yjs@13.6.18):
+    resolution: {integrity: sha512-PFm2XWK0MqVQahHbTIBAveyVrjWVm7HegiLRBGPUzA/D6PQ+RRIdevmsPfhwmIBUkpekO26ERiQH97lmZQjYzw==}
+    peerDependencies:
+      lexical: 0.6.5
+      yjs: '>=13.5.22'
+    dependencies:
+      '@lexical/offset': 0.6.5(lexical@0.6.5)
+      lexical: 0.6.5
+      yjs: 13.6.18
+    dev: false
+
   /@lezer/common@1.2.1:
     resolution: {integrity: sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==}
     dev: false
@@ -20995,14 +21305,14 @@ packages:
     resolution: {integrity: sha512-zUHrjNFuY/DOZCkOBJ6qItQIkcopHM/Zv/QOE0a4XNG3HDNahxTNu5fQYl8dIuKCpxCqRdMl5cEwl5zekFc7BA==}
     dependencies:
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@lezer/css@1.1.1:
     resolution: {integrity: sha512-mSjx+unLLapEqdOYDejnGBokB5+AiJKZVclmud0MKQOKx3DLJ5b5VTCstgDDknR6iIV4gVrN6euzsCnj0A2gQA==}
     dependencies:
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@lezer/go@1.0.0:
@@ -21010,7 +21320,7 @@ packages:
     dependencies:
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@lezer/highlight@1.2.0:
@@ -21024,28 +21334,28 @@ packages:
     dependencies:
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@lezer/java@1.0.3:
     resolution: {integrity: sha512-kKN17wmgP1cgHb8juR4pwVSPMKkDMzY/lAPbBsZ1fpXwbk2sg3N1kIrf0q+LefxgrANaQb/eNO7+m2QPruTFng==}
     dependencies:
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@lezer/javascript@1.4.1:
     resolution: {integrity: sha512-Hqx36DJeYhKtdpc7wBYPR0XF56ZzIp0IkMO/zNNj80xcaFOV4Oj/P7TQc/8k2TxNhzl7tV5tXS8ZOCPbT4L3nA==}
     dependencies:
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@lezer/json@1.0.0:
     resolution: {integrity: sha512-zbAuUY09RBzCoCA3lJ1+ypKw5WSNvLqGMtasdW6HvVOqZoCpPr8eWrsGnOVWGKGn8Rh21FnrKRVlJXrGAVUqRw==}
     dependencies:
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@lezer/lr@1.3.3:
@@ -21054,8 +21364,8 @@ packages:
       '@lezer/common': 1.2.1
     dev: false
 
-  /@lezer/lr@1.4.2:
-    resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
+  /@lezer/lr@1.4.0:
+    resolution: {integrity: sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==}
     dependencies:
       '@lezer/common': 1.2.1
     dev: false
@@ -21071,35 +21381,35 @@ packages:
     resolution: {integrity: sha512-aqdCQJOXJ66De22vzdwnuC502hIaG9EnPK2rSi+ebXyUd+j7GAX1mRjWZOVOmf3GST1YUfUCu6WXDiEgDGOVwA==}
     dependencies:
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@lezer/python@1.1.2:
     resolution: {integrity: sha512-ukm4VhDasFX7/9BUYHTyUNXH0xQ5B7/QBlZD8P51+dh6GtXRSCQqNxloez5d+MxVb2Sg+31S8E/33qoFREfkpA==}
     dependencies:
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@lezer/rust@1.0.0:
     resolution: {integrity: sha512-IpGAxIjNxYmX9ra6GfQTSPegdCAWNeq23WNmrsMMQI7YNSvKtYxO4TX5rgZUmbhEucWn0KTBMeDEPXg99YKtTA==}
     dependencies:
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@lezer/sass@1.0.3:
     resolution: {integrity: sha512-n4l2nVOB7gWiGU/Cg2IVxpt2Ic9Hgfgy/7gk+p/XJibAsPXs0lSbsfGwQgwsAw9B/euYo3oS6lEFr9WytoqcZg==}
     dependencies:
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@lezer/xml@1.0.1:
     resolution: {integrity: sha512-jMDXrV953sDAUEMI25VNrI9dz94Ai96FfeglytFINhhwQ867HKlCE2jt3AwZTCT7M528WxdDWv/Ty8e9wizwmQ==}
     dependencies:
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.3.3
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@lezer/yaml@1.0.3:
@@ -21107,7 +21417,7 @@ packages:
     dependencies:
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
-      '@lezer/lr': 1.4.2
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@libp2p/interface@1.3.1:
@@ -27884,10 +28194,10 @@ packages:
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/addon-controls@8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0):
+  /@storybook/addon-controls@8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-q/Vt4meNVlFlBWIMCJhx6r+bqiiYocCta2RoUK5nyIZUiLzHncKHX6JnCU36EmJzRyah9zkwjfCb2G1r9cjnoQ==}
     dependencies:
-      '@storybook/blocks': 8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/blocks': 8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0)
       dequal: 2.0.3
       lodash: 4.17.21
       ts-dedent: 2.2.0
@@ -27901,12 +28211,12 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/addon-docs@8.1.11(@types/react-dom@18.0.6)(prettier@3.3.3):
+  /@storybook/addon-docs@8.1.11(@types/react-dom@18.0.6)(prettier@3.2.4):
     resolution: {integrity: sha512-69dv+CE4R5wFU7xnJmhuyEbLN2PEVDV3N/BbgJqeucIYPmm6zDV83Q66teCHKYtRln3BFUqPH5mxsjiHobxfJQ==}
     dependencies:
       '@babel/core': 7.24.6
       '@mdx-js/react': 3.0.0(@types/react@18.0.21)(react@18.2.0)
-      '@storybook/blocks': 8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/blocks': 8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0)
       '@storybook/client-logger': 8.1.11
       '@storybook/components': 8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@storybook/csf-plugin': 8.1.11
@@ -27931,19 +28241,19 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/addon-essentials@8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0):
+  /@storybook/addon-essentials@8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-uRTpcIZQnflML8H+2onicUNIIssKfuviW8Lyrs/KFwSZ1rMcYzhwzCNbGlIbAv04tgHe5NqEyNhb+DVQcZQBzg==}
     dependencies:
       '@storybook/addon-actions': 8.1.11
       '@storybook/addon-backgrounds': 8.1.11
-      '@storybook/addon-controls': 8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/addon-docs': 8.1.11(@types/react-dom@18.0.6)(prettier@3.3.3)
+      '@storybook/addon-controls': 8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/addon-docs': 8.1.11(@types/react-dom@18.0.6)(prettier@3.2.4)
       '@storybook/addon-highlight': 8.1.11
       '@storybook/addon-measure': 8.1.11
       '@storybook/addon-outline': 8.1.11
       '@storybook/addon-toolbars': 8.1.11
       '@storybook/addon-viewport': 8.1.11
-      '@storybook/core-common': 8.1.11(prettier@3.3.3)
+      '@storybook/core-common': 8.1.11(prettier@3.2.4)
       '@storybook/manager-api': 8.1.11(react-dom@18.2.0)(react@18.2.0)
       '@storybook/node-logger': 8.1.11
       '@storybook/preview-api': 8.1.11
@@ -28049,7 +28359,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@storybook/blocks@8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0):
+  /@storybook/blocks@8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-eMed7PpL/hAVM6tBS7h70bEAyzbiSU9I/kye4jZ7DkCbAsrX6OKmC7pcHSDn712WTcf3vVqxy5jOKUmOXpc0eg==}
     peerDependencies:
       react: ~18.2.0
@@ -28065,7 +28375,7 @@ packages:
       '@storybook/components': 8.1.11(@types/react-dom@18.0.6)(@types/react@18.0.21)(react-dom@18.2.0)(react@18.2.0)
       '@storybook/core-events': 8.1.11
       '@storybook/csf': 0.1.7
-      '@storybook/docs-tools': 8.1.11(prettier@3.3.3)
+      '@storybook/docs-tools': 8.1.11(prettier@3.2.4)
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.2.9(react-dom@18.2.0)(react@18.2.0)
       '@storybook/manager-api': 8.1.11(react-dom@18.2.0)(react@18.2.0)
@@ -28094,11 +28404,11 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-manager@8.1.11(prettier@3.3.3):
+  /@storybook/builder-manager@8.1.11(prettier@3.2.4):
     resolution: {integrity: sha512-U7bmed4Ayg+OlJ8HPmLeGxLTHzDY7rxmxM4aAs4YL01fufYfBcjkIP9kFhJm+GJOvGm+YJEUAPe5mbM1P/bn0Q==}
     dependencies:
       '@fal-works/esbuild-plugin-global-externals': 2.1.2
-      '@storybook/core-common': 8.1.11(prettier@3.3.3)
+      '@storybook/core-common': 8.1.11(prettier@3.2.4)
       '@storybook/manager': 8.1.11
       '@storybook/node-logger': 8.1.11
       '@types/ejs': 3.1.1
@@ -28117,7 +28427,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-vite@8.1.11(prettier@3.3.3)(typescript@5.4.5)(vite@5.3.4):
+  /@storybook/builder-vite@8.1.11(prettier@3.2.4)(typescript@5.4.5)(vite@5.3.4):
     resolution: {integrity: sha512-hG4eoNMCPgjZ2Ai+zSmk69zjsyEihe75XbJXtYfGRqjMWtz2+SAUFO54fLc2BD5svcUiTeN+ukWcTrwApyPsKg==}
     peerDependencies:
       '@preact/preset-vite': '*'
@@ -28134,7 +28444,7 @@ packages:
     dependencies:
       '@storybook/channels': 8.1.11
       '@storybook/client-logger': 8.1.11
-      '@storybook/core-common': 8.1.11(prettier@3.3.3)
+      '@storybook/core-common': 8.1.11(prettier@3.2.4)
       '@storybook/core-events': 8.1.11
       '@storybook/csf-plugin': 8.1.11
       '@storybook/node-logger': 8.1.11
@@ -28189,12 +28499,12 @@ packages:
       '@babel/types': 7.24.6
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 8.1.11
-      '@storybook/core-common': 8.1.11(prettier@3.3.3)
+      '@storybook/core-common': 8.1.11(prettier@3.2.4)
       '@storybook/core-events': 8.1.11
-      '@storybook/core-server': 8.1.11(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/core-server': 8.1.11(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0)
       '@storybook/csf-tools': 8.1.11
       '@storybook/node-logger': 8.1.11
-      '@storybook/telemetry': 8.1.11(prettier@3.3.3)
+      '@storybook/telemetry': 8.1.11(prettier@3.2.4)
       '@storybook/types': 8.1.11
       '@types/semver': 7.5.1
       '@yarnpkg/fslib': 2.10.3
@@ -28304,7 +28614,7 @@ packages:
       - '@types/react'
       - '@types/react-dom'
 
-  /@storybook/core-common@8.1.11(prettier@3.3.3):
+  /@storybook/core-common@8.1.11(prettier@3.2.4):
     resolution: {integrity: sha512-Ix0nplD4I4DrV2t9B+62jaw1baKES9UbR/Jz9LVKFF9nsua3ON0aVe73dOjMxFWBngpzBYWe+zYBTZ7aQtDH4Q==}
     peerDependencies:
       prettier: ^2 || ^3
@@ -28333,8 +28643,8 @@ packages:
       node-fetch: 2.7.0
       picomatch: 2.3.1
       pkg-dir: 5.0.0
-      prettier: 3.3.3
-      prettier-fallback: /prettier@3.3.3
+      prettier: 3.2.4
+      prettier-fallback: /prettier@3.2.4
       pretty-hrtime: 1.0.3
       resolve-from: 5.0.0
       semver: 7.6.2
@@ -28357,16 +28667,16 @@ packages:
       '@storybook/csf': 0.1.7
       ts-dedent: 2.2.0
 
-  /@storybook/core-server@8.1.11(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0):
+  /@storybook/core-server@8.1.11(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-L6dzQTmR0np/kagNONvvlm6lSvF1FNc9js3vxsEEPnEypLbhx8bDZaHmuhmBpYUzKyUMpRVQTE/WgjHLuBBuxA==}
     dependencies:
       '@aw-web-design/x-default-browser': 1.4.126
       '@babel/core': 7.24.6
       '@babel/parser': 7.24.6
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-manager': 8.1.11(prettier@3.3.3)
+      '@storybook/builder-manager': 8.1.11(prettier@3.2.4)
       '@storybook/channels': 8.1.11
-      '@storybook/core-common': 8.1.11(prettier@3.3.3)
+      '@storybook/core-common': 8.1.11(prettier@3.2.4)
       '@storybook/core-events': 8.1.11
       '@storybook/csf': 0.1.7
       '@storybook/csf-tools': 8.1.11
@@ -28376,7 +28686,7 @@ packages:
       '@storybook/manager-api': 8.1.11(react-dom@18.2.0)(react@18.2.0)
       '@storybook/node-logger': 8.1.11
       '@storybook/preview-api': 8.1.11
-      '@storybook/telemetry': 8.1.11(prettier@3.3.3)
+      '@storybook/telemetry': 8.1.11(prettier@3.2.4)
       '@storybook/types': 8.1.11
       '@types/detect-port': 1.3.2
       '@types/diff': 5.2.1
@@ -28455,10 +28765,10 @@ packages:
     resolution: {integrity: sha512-t4syFIeSyufieNovZbLruPt2DmRKpbwL4fERCZ1MifWDRIORCKLc4NCEHy+IqvIqd71/SJV2k4B51nF7vlJfmQ==}
     dev: true
 
-  /@storybook/docs-tools@8.1.11(prettier@3.3.3):
+  /@storybook/docs-tools@8.1.11(prettier@3.2.4):
     resolution: {integrity: sha512-mEXtR9rS7Y+OdKtT/QG6JBGYR1L41mcDhIqhnk7RmYl9qJstVAegrCKWR53sPKFdTVOHU7dmu6k+BD+TqHpyyw==}
     dependencies:
-      '@storybook/core-common': 8.1.11(prettier@3.3.3)
+      '@storybook/core-common': 8.1.11(prettier@3.2.4)
       '@storybook/core-events': 8.1.11
       '@storybook/preview-api': 8.1.11
       '@storybook/types': 8.1.11
@@ -28475,13 +28785,13 @@ packages:
   /@storybook/global@5.0.0:
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
 
-  /@storybook/html-vite@8.1.11(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)(vite@5.3.4):
+  /@storybook/html-vite@8.1.11(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)(vite@5.3.4):
     resolution: {integrity: sha512-U+Er6MKGeGRbgS+q10x8LZL5mj83jk3zU6ZY3CIw9woKAeUhblHb9TYaYDUgCQ1au+WlnfD41FmLj/1PEKq1CQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@storybook/builder-vite': 8.1.11(prettier@3.3.3)(typescript@5.4.5)(vite@5.3.4)
-      '@storybook/core-server': 8.1.11(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/html': 8.1.11(prettier@3.3.3)
+      '@storybook/builder-vite': 8.1.11(prettier@3.2.4)(typescript@5.4.5)(vite@5.3.4)
+      '@storybook/core-server': 8.1.11(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/html': 8.1.11(prettier@3.2.4)
       '@storybook/node-logger': 8.1.11
       '@storybook/types': 8.1.11
       magic-string: 0.30.5
@@ -28499,11 +28809,11 @@ packages:
       - vite-plugin-glimmerx
     dev: true
 
-  /@storybook/html@8.1.11(prettier@3.3.3):
+  /@storybook/html@8.1.11(prettier@3.2.4):
     resolution: {integrity: sha512-UrYZZGqz7UXUDXijt5Gh8y93ws4RkwYykl5AHDP22bzoOFfAER0PFE2v+Al9o7KGKdrlIJtuhWrXYREkQJ2VBA==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@storybook/docs-tools': 8.1.11(prettier@3.3.3)
+      '@storybook/docs-tools': 8.1.11(prettier@3.2.4)
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 8.1.11
       '@storybook/types': 8.1.11
@@ -28648,7 +28958,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@storybook/react-vite@8.1.11(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0)(rollup@3.23.0)(typescript@5.4.5)(vite@5.3.4):
+  /@storybook/react-vite@8.1.11(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0)(rollup@3.23.0)(typescript@5.4.5)(vite@5.3.4):
     resolution: {integrity: sha512-QqkE6QKsIDthXtps9+YSBQ39O4VvU7Uu3y6WSA3IPgKTtGnmIvhwXtapjf7WQ2cNb5KY1JksFxHXbDe0i5IL4g==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -28658,9 +28968,9 @@ packages:
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.1(typescript@5.4.5)(vite@5.3.4)
       '@rollup/pluginutils': 5.1.0(rollup@3.23.0)
-      '@storybook/builder-vite': 8.1.11(prettier@3.3.3)(typescript@5.4.5)(vite@5.3.4)
+      '@storybook/builder-vite': 8.1.11(prettier@3.2.4)(typescript@5.4.5)(vite@5.3.4)
       '@storybook/node-logger': 8.1.11
-      '@storybook/react': 8.1.11(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
+      '@storybook/react': 8.1.11(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
       '@storybook/types': 8.1.11
       find-up: 5.0.0
       magic-string: 0.30.5
@@ -28680,7 +28990,7 @@ packages:
       - vite-plugin-glimmerx
     dev: true
 
-  /@storybook/react@8.1.11(prettier@3.3.3)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5):
+  /@storybook/react@8.1.11(prettier@3.2.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5):
     resolution: {integrity: sha512-t+EYXOkgwg3ropLGS9y8gGvX5/Okffu/6JYL3YWksrBGAZSqVV4NkxCnVJZepS717SyhR0tN741gv/SxxFPJMg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -28692,7 +29002,7 @@ packages:
         optional: true
     dependencies:
       '@storybook/client-logger': 8.1.11
-      '@storybook/docs-tools': 8.1.11(prettier@3.3.3)
+      '@storybook/docs-tools': 8.1.11(prettier@3.2.4)
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 8.1.11
       '@storybook/react-dom-shim': 8.1.11(react-dom@18.2.0)(react@18.2.0)
@@ -28741,11 +29051,11 @@ packages:
       memoizerific: 1.11.3
       qs: 6.11.2
 
-  /@storybook/telemetry@8.1.11(prettier@3.3.3):
+  /@storybook/telemetry@8.1.11(prettier@3.2.4):
     resolution: {integrity: sha512-Jqvm7HcZismKzPuebhyLECO6KjGiSk4ycbca1WUM/TUvifxCXqgoUPlHHQEEfaRdHS63/MSqtMNjLsQRLC/vNQ==}
     dependencies:
       '@storybook/client-logger': 8.1.11
-      '@storybook/core-common': 8.1.11(prettier@3.3.3)
+      '@storybook/core-common': 8.1.11(prettier@3.2.4)
       '@storybook/csf-tools': 8.1.11
       chalk: 4.1.2
       detect-package-manager: 2.0.1
@@ -30798,8 +31108,8 @@ packages:
       undici-types: 5.26.5
     dev: true
 
-  /@types/node@20.14.14:
-    resolution: {integrity: sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==}
+  /@types/node@20.14.12:
+    resolution: {integrity: sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==}
     dependencies:
       undici-types: 5.26.5
 
@@ -34808,16 +35118,24 @@ packages:
     resolution: {integrity: sha512-+xi2ENsvchtUNa8oBUU58gHgmyN6BEEeZ8NIEgeQ0XnC+AoyihivgZYe+OOiNi+fLy/NUowugwV5gP8XWYDm0Q==}
     dev: true
 
+  /codemirror-lang-spreadsheet@1.3.0:
+    resolution: {integrity: sha512-Gudwf+QYesPP2202iGcFV5NiS8fzlBM3xDRv0M4NgBDyTbzkN9mHLggMziKxfB9o2jz6yL53w7D11Kt12cQlhQ==}
+    dependencies:
+      '@codemirror/language': 6.10.2
+      '@lezer/highlight': 1.2.0
+      '@lezer/lr': 1.4.0
+    dev: false
+
   /codemirror@6.0.1(@lezer/common@1.2.1):
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.29.1)(@lezer/common@1.2.1)
-      '@codemirror/commands': 6.3.3
+      '@codemirror/autocomplete': 6.12.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.0)(@codemirror/view@6.29.0)(@lezer/common@1.2.1)
+      '@codemirror/commands': 6.6.0
       '@codemirror/language': 6.10.2
-      '@codemirror/lint': 6.4.2
+      '@codemirror/lint': 6.8.1
       '@codemirror/search': 6.5.6
-      '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.29.1
+      '@codemirror/state': 6.4.0
+      '@codemirror/view': 6.29.0
     transitivePeerDependencies:
       - '@lezer/common'
     dev: false
@@ -35304,7 +35622,7 @@ packages:
     engines: {node: '>= 6.9.0'}
     dependencies:
       crc: 3.8.0
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: true
 
   /crc32-stream@6.0.0:
@@ -36741,7 +37059,7 @@ packages:
   /duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
     dependencies:
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
 
   /duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
@@ -39715,7 +40033,7 @@ packages:
       source-map: 0.6.1
       wordwrap: 1.0.0
     optionalDependencies:
-      uglify-js: 3.19.1
+      uglify-js: 3.19.0
     dev: true
 
   /happy-dom@13.3.4:
@@ -39840,7 +40158,7 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       inherits: 2.0.4
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
       safe-buffer: 5.2.1
     dev: false
 
@@ -42532,8 +42850,8 @@ packages:
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  /js-tokens@8.0.3:
-    resolution: {integrity: sha512-UfJMcSJc+SEXEl9lH/VLHSZbThQyLpw1vLO1Lb+j4RWDvG3N2f7yj3PVQA3cmkTBNldJ9eFnM+xEXxHIXrYiJw==}
+  /js-tokens@8.0.2:
+    resolution: {integrity: sha512-Olnt+V7xYdvGze9YTbGFZIfQXuGV4R3nQwwl8BrtgaPE/wq8UFpUHWuTNc05saowhSr1ZO6tx+V6RjE9D5YQog==}
     dev: true
 
   /js-yaml@3.14.1:
@@ -43402,8 +43720,20 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  /lexical@0.6.5:
+    resolution: {integrity: sha512-DV4/lw/CX5XLJ2qdHurkn/KjjvMw83EJidvH7Os/ub61yoaffMQxovPvsfzyOHSZ3/V+GBFCGF2hLAaaB1s37g==}
+    dev: false
+
   /lib0@0.2.78:
     resolution: {integrity: sha512-SV2nU43/6eaYnGH3l0lg2wg1ziB/TH3sAd2E8quXPGwrqo+aX98SNT2ZKucpUr5B8A52jD7ZMjAl+r87Fa/bLQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      isomorphic.js: 0.2.5
+    dev: false
+
+  /lib0@0.2.94:
+    resolution: {integrity: sha512-hZ3p54jL4Wpu7IOg26uC7dnEWiMyNlUrb9KoG7+xYs45WkQwpVvKFndVq2+pqLYKe1u8Fp3+zAfZHVvTK34PvQ==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
@@ -47400,12 +47730,6 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  /prettier@3.3.3:
-    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dev: true
-
   /pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
@@ -48143,6 +48467,16 @@ packages:
       react-is: 18.1.0
     dev: true
 
+  /react-error-boundary@3.1.4(react@18.2.0):
+    resolution: {integrity: sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==}
+    engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: ~18.2.0
+    dependencies:
+      '@babel/runtime': 7.24.5
+      react: 18.2.0
+    dev: false
+
   /react-error-boundary@4.0.13(react@18.2.0):
     resolution: {integrity: sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==}
     peerDependencies:
@@ -48545,7 +48879,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       pinkie-promise: 2.0.1
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
     dev: false
 
   /read-cache@1.0.0:
@@ -50838,7 +51172,7 @@ packages:
   /strip-literal@2.0.0:
     resolution: {integrity: sha512-f9vHgsCWBq2ugHAkGMiiYY+AYG0D/cbloKKg0nhaaaSNsujdGIpVXCNsrJpCKr5M0f4aI31mr13UjY6GAuXCKA==}
     dependencies:
-      js-tokens: 8.0.3
+      js-tokens: 8.0.2
     dev: true
 
   /striptags@3.2.0:
@@ -52118,8 +52452,8 @@ packages:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
     dev: true
 
-  /uglify-js@3.19.1:
-    resolution: {integrity: sha512-y/2wiW+ceTYR2TSSptAhfnEtpLaQ4Ups5zrjB2d3kuVxHj16j/QJwPl5PvuGy9uARb39J0+iKxcRPvtpsx4A4A==}
+  /uglify-js@3.19.0:
+    resolution: {integrity: sha512-wNKHUY2hYYkf6oSFfhwwiHo4WCHzHmzcXsqXYTN9ja3iApYIFbb2U6ics9hBcYLHcYGQoAlwnZlTrf3oF+BL/Q==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true
@@ -55107,6 +55441,13 @@ packages:
       fd-slicer: 1.0.1
     dev: false
 
+  /yjs@13.6.18:
+    resolution: {integrity: sha512-GBTjO4QCmv2HFKFkYIJl7U77hIB1o22vSCSQD1Ge8ZxWbIbn8AltI4gyXbtL+g5/GJep67HCMq3Y5AmNwDSyEg==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    dependencies:
+      lib0: 0.2.94
+    dev: false
+
   /yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -55167,7 +55508,7 @@ packages:
     dependencies:
       archiver-utils: 2.1.0
       compress-commons: 2.1.1
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: true
 
   /zip-stream@6.0.1:


### PR DESCRIPTION
Sharing a prototype I put together over the weekend. Not sure how CI will react to these changes because I'm new to this repo.

- Lezer to parse spreadsheet syntax
- Lexical to render cell editor (with syntax highlighting and code-completion)

Both Lezer and Lexical integrations _could_ be used in other places as well. (Lexical has a lot of pre-built plugins, and I've written several other open source ones [here](https://github.com/replayio/devtools/tree/main/packages/replay-next/components/lexical/plugins).) The type-ahead plugin I've written here is generic enough to be used with other languages/syntaxes. The "code plugin" is currently hard-coded to handle spreadsheet syntax (though `parseTokens` could be updated to support more languages/syntaxes if we wanted).

cc @richburdon