### PR TITLE
fix(echo): throttle query updates on document change

### DIFF
--- a/packages/core/echo/echo-db/src/core-db/core-database.ts
+++ b/packages/core/echo/echo-db/src/core-db/core-database.ts
@@ -455,7 +455,7 @@ export class CoreDatabase {
     this._rebindObjects(event.handle, documentChanges.objectsToRebind);
     this._automergeDocLoader.onObjectLinksUpdated(documentChanges.linkedDocuments);
     this._createInlineObjects(event.handle, documentChanges.createdObjectIds);
-    this._emitUpdateEvent(documentChanges.updatedObjectIds);
+    this._scheduleThrottledUpdate(documentChanges.updatedObjectIds);
   };
 
   private _processDocumentUpdate(event: ChangeEvent<SpaceDoc>): DocumentChanges {

--- a/packages/core/echo/echo-db/src/hypergraph.test.ts
+++ b/packages/core/echo/echo-db/src/hypergraph.test.ts
@@ -4,6 +4,7 @@
 
 import { expect } from 'chai';
 
+import { sleep } from '@dxos/async';
 import { create, Expando } from '@dxos/echo-schema';
 import { PublicKey } from '@dxos/keys';
 import { describe, openAndClose, test } from '@dxos/test';
@@ -54,17 +55,20 @@ describe('HyperGraph', () => {
     await db1.flush();
     expect(updated).to.eq(true);
 
+    await sleep(220);
     updated = false;
     obj2.completed = true;
     await db2.flush();
     expect(updated).to.eq(true);
 
+    await sleep(220);
     updated = false;
     db2.remove(obj2);
     await db2.flush();
     expect(updated).to.eq(true);
     expect(query.objects.map((obj) => obj.id)).to.deep.eq([obj1.id]);
 
+    await sleep(220);
     updated = false;
     obj3.type = 'task';
     await db2.flush();

--- a/packages/core/functions/src/trigger/trigger-registry.test.ts
+++ b/packages/core/functions/src/trigger/trigger-registry.test.ts
@@ -159,10 +159,11 @@ describe('trigger registry', () => {
       });
 
       space.db.add(create(TestType, { title: '1' }));
-      await sleep(20);
+      await sleep(110);
       expect(count).to.eq(1);
 
       space.db.remove(echoTrigger);
+      await sleep(110);
       space.db.add(create(TestType, { title: '2' }));
       await sleep(20);
       expect(count).to.eq(1);


### PR DESCRIPTION
### Details

Based on [this thread](https://discord.com/channels/837138313172353095/1270491117779026034).
Profiled big (10k) document bathes in testbench, most of the cpu-time is spent in query filter matching. 

<img width="400" alt="image" src="https://github.com/user-attachments/assets/098869cd-35c4-4c79-9796-7c0291c46110">

Without the change I gave up on waiting with profiler disabled. With the change it still froze the UI but after ~15s items were there. The majority of time is spent in automerge code now.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/dce94fc4-188c-40aa-a058-07f1b0e82681">
