### PR TITLE
fix(mesh): fixed signal delivery race condition

### DIFF
--- a/packages/core/mesh/network-manager/src/signal/ice.ts
+++ b/packages/core/mesh/network-manager/src/signal/ice.ts
@@ -2,6 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
+import { asyncTimeout } from '@dxos/async';
 import { log } from '@dxos/log';
 import { type Runtime } from '@dxos/protocols/proto/dxos/config';
 import { isNotNullOrUndefined } from '@dxos/util';
@@ -21,7 +22,7 @@ export const createIceProvider = (iceProviders: Runtime.Services.IceProvider[]):
       cachedIceServers = (
         await Promise.all(
           iceProviders.map(({ urls }) =>
-            fetch(urls, { method: 'GET' })
+            asyncTimeout(fetch(urls, { method: 'GET' }), 10_000)
               .then((response) => response.json())
               .catch((err) => log.error('Failed to fetch ICE servers from provider', { urls, err })),
           ),

--- a/packages/core/mesh/network-manager/src/transport/simplepeer-transport.ts
+++ b/packages/core/mesh/network-manager/src/transport/simplepeer-transport.ts
@@ -6,7 +6,7 @@
 import SimplePeerConstructor, { type Instance as SimplePeer } from 'simple-peer';
 import invariant from 'tiny-invariant';
 
-import { Event } from '@dxos/async';
+import { Event, synchronized } from '@dxos/async';
 import { ErrorStream, raise } from '@dxos/debug';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
@@ -117,6 +117,7 @@ export class SimplePeerTransport implements Transport {
     return `${rc.ip}:${rc.port}/${rc.protocol} ${rc.candidateType}`;
   }
 
+  @synchronized
   async open() {
     log.trace('dxos.mesh.webrtc-transport.open', trace.begin({ id: this._instanceId }));
     log('created connection', { params: this._params });
@@ -216,6 +217,7 @@ export class SimplePeerTransport implements Transport {
     log.trace('dxos.mesh.webrtc-transport.open', trace.end({ id: this._instanceId }));
   }
 
+  @synchronized
   async close() {
     log('closing...');
     if (this._closed) {
@@ -228,6 +230,7 @@ export class SimplePeerTransport implements Transport {
     log('closed');
   }
 
+  @synchronized
   async onSignal(signal: Signal) {
     if (this._closed) {
       return; // Ignore signals after close.


### PR DESCRIPTION
### Details

Signal delivery attempt during ice server fetching was crashing and closing the connection.

```
TypeError: Cannot read properties of undefined (reading 'destroy')
    at SimplePeerTransport.close (packages/core/mesh/network-manager/dist/lib/browser/chunk-ZAP7RLHV.mjs:3152:16)
    at SimplePeerTransportService.close (packages/core/mesh/network-manager/dist/lib/browser/chunk-ZAP7RLHV.mjs:3334:51)
    at ServiceHandler.call (packages/common/codec-protobuf/dist/lib/browser/index.mjs:739:28)
    at async RpcPeer._callHandler (packages/core/mesh/rpc/dist/lib/browser/index.mjs:627:24)
    at async RpcPeer._receive (packages/core/mesh/rpc/dist/lib/browser/index.mjs:303:26)
    at async packages/core/mesh/rpc/dist/lib/browser/index.mjs:95:9
    at RPC dxos.mesh.bridge.BridgeService.Close 
    at RpcPeer.call (packages/core/mesh/rpc/dist/lib/browser/index.mjs:518:13)
    at async Service.close (packages/common/codec-protobuf/dist/lib/browser/index.mjs:693:28)
    at async SimplePeerTransportProxy.close (packages/core/mesh/network-manager/dist/lib/browser/chunk-ZAP7RLHV.mjs:3473:7)
    at async Connection._closeTransport (packages/core/mesh/network-manager/dist/lib/browser/chunk-ZAP7RLHV.mjs:400:5)
    at async Connection.close (packages/core/mesh/network-manager/dist/lib/browser/chunk-ZAP7RLHV.mjs:355:7)
    at async Connection.close$synchronized (packages/common/async/dist/lib/browser/index.mjs:789:14)
    at async Peer.closeConnection (packages/core/mesh/network-manager/dist/lib/browser/chunk-ZAP7RLHV.mjs:1306:5)

Error: Invariant failed: Peer must be initialized before receiving signals.
    at invariant (http://localhost:5173/node_modules/.vite/deps/tiny-invariant.js?v=64f2fb67:15:9)
    at SimplePeerTransport.onSignal (packages/core/mesh/network-manager/dist/lib/browser/chunk-T2LK7S2F.mjs:3179:5)
    at SimplePeerTransportService.sendSignal (packages/core/mesh/network-manager/dist/lib/browser/chunk-T2LK7S2F.mjs:3289:50)
    at ServiceHandler.call (packages/common/codec-protobuf/dist/lib/browser/index.mjs:739:28)
    at async RpcPeer._callHandler (packages/core/mesh/rpc/dist/lib/browser/index.mjs:627:24)
    at async RpcPeer._receive (packages/core/mesh/rpc/dist/lib/browser/index.mjs:303:26)
    at async packages/core/mesh/rpc/dist/lib/browser/index.mjs:95:9
    at RPC dxos.mesh.bridge.BridgeService.SendSignal 
    at RpcPeer.call (packages/core/mesh/rpc/dist/lib/browser/index.mjs:518:13)
    at async Service.sendSignal (packages/common/codec-protobuf/dist/lib/browser/index.mjs:693:28)
```