### PR TITLE
fix(plugin-navtree): Overflow

### DIFF
--- a/packages/apps/plugins/plugin-navtree/src/components/NavTreeContainer.tsx
+++ b/packages/apps/plugins/plugin-navtree/src/components/NavTreeContainer.tsx
@@ -357,7 +357,8 @@ export const NavTreeContainer = ({
         className='bs-full overflow-hidden row-span-3 grid grid-cols-1 grid-rows-[min-content_1fr_min-content]'
       >
         <Surface role='search-input' limit={1} />
-        <div role='none' className='overflow-y-auto'>
+        {/* TODO(thure): what gives this an inline `overflow: initial`? */}
+        <div role='none' className='!overflow-y-auto'>
           <NavTree
             id={root.id}
             items={items}


### PR DESCRIPTION
This PR restores a rule that implements correct overflow.

<img width="297" alt="Screenshot 2024-08-15 at 08 11 56" src="https://github.com/user-attachments/assets/b9a27d6c-e8f9-4aa7-b2e7-f2241ba5dee4">
