### PR TITLE
fix(composer): fix tldraw crash when bindings are not found

### DIFF
--- a/packages/apps/plugins/plugin-sketch/src/util/base-adapter.ts
+++ b/packages/apps/plugins/plugin-sketch/src/util/base-adapter.ts
@@ -7,6 +7,7 @@ import { Context } from '@dxos/context';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
 import { type DocAccessor } from '@dxos/react-client/echo';
+import { nonNullable } from '@dxos/util';
 
 import { decode, encode, getDeep, rebasePath } from './util';
 
@@ -160,7 +161,9 @@ export abstract class AbstractAutomergeStoreAdapter<Element extends BaseElement>
 
         if (updated.size || deleted.size) {
           this.onUpdate({
-            updated: Array.from(updated).map((id) => decode(map[id])),
+            updated: Array.from(updated)
+              .map((id) => decode(map[id]))
+              .filter(nonNullable),
             deleted: Array.from(deleted),
           });
         }


### PR DESCRIPTION
### Details

Was happening consistently when I was trying to connect block centers with an arrow.
You can see in database update log there's a batch with the same elements in added and deleted lists.
`decode(map[id])` in `updateModel` was returning undefined resulting into a crash inside `TLStore`. 


<img width="442" alt="image" src="https://github.com/user-attachments/assets/811e6ffc-3bc4-4191-b78e-9916ce14c8a6">