### PR TITLE
fix(plugin-sketch): Show controls on attention

### DIFF
--- a/packages/apps/plugins/plugin-sketch/src/SketchPlugin.tsx
+++ b/packages/apps/plugins/plugin-sketch/src/SketchPlugin.tsx
@@ -31,17 +31,11 @@ export const SketchPlugin = (): PluginDefinition<SketchPluginProvides> => {
   return {
     meta,
     ready: async () => {
-      settings
-        .prop({
-          key: 'autoHideControls',
-          storageKey: 'auto-hide-controls',
-          type: LocalStorageStore.bool({ allowUndefined: true }),
-        })
-        .prop({
-          key: 'gridType',
-          storageKey: 'grid-type',
-          type: LocalStorageStore.enum<SketchGridType>({ allowUndefined: true }),
-        });
+      settings.prop({
+        key: 'gridType',
+        storageKey: 'grid-type',
+        type: LocalStorageStore.enum<SketchGridType>({ allowUndefined: true }),
+      });
     },
     provides: {
       metadata: {
@@ -171,11 +165,7 @@ export const SketchPlugin = (): PluginDefinition<SketchPluginProvides> => {
           switch (role) {
             case 'main':
               return isDiagramType(data.active, TLDRAW_SCHEMA) ? (
-                <SketchMain
-                  sketch={data.active}
-                  autoHideControls={settings.values.autoHideControls}
-                  grid={settings.values.gridType}
-                />
+                <SketchMain sketch={data.active} grid={settings.values.gridType} />
               ) : null;
             case 'slide':
               return isDiagramType(data.slide, TLDRAW_SCHEMA) ? (
@@ -186,7 +176,6 @@ export const SketchPlugin = (): PluginDefinition<SketchPluginProvides> => {
                   autoZoom
                   maxZoom={1.5}
                   className='p-16'
-                  autoHideControls={settings.values.autoHideControls}
                   grid={settings.values.gridType}
                 />
               ) : null;
@@ -199,7 +188,6 @@ export const SketchPlugin = (): PluginDefinition<SketchPluginProvides> => {
                   sketch={data.object}
                   autoZoom={role === 'section'}
                   className={role === 'article' ? 'row-span-2' : 'aspect-square'}
-                  autoHideControls={settings.values.autoHideControls}
                   grid={settings.values.gridType}
                 />
               ) : null;

--- a/packages/apps/plugins/plugin-sketch/src/components/SketchComponent/Sketch.tsx
+++ b/packages/apps/plugins/plugin-sketch/src/components/SketchComponent/Sketch.tsx
@@ -37,7 +37,6 @@ export type SketchComponentProps = {
   className?: string;
   autoZoom?: boolean;
   maxZoom?: number;
-  autoHideControls?: boolean;
   grid?: SketchGridType;
   assetsBaseUrl?: string | null;
 };
@@ -45,19 +44,17 @@ export type SketchComponentProps = {
 /**
  *
  */
-export const SketchComponent = ({
+export const Sketch = ({
   sketch,
   autoZoom,
   maxZoom = 1,
   readonly = false,
   className,
-  autoHideControls,
   grid,
   assetsBaseUrl = '/assets/plugin-sketch',
 }: SketchComponentProps) => {
   const { themeMode } = useThemeContext();
   const adapter = useStoreAdapter(sketch);
-  const [active, setActive] = useState(!autoHideControls);
   const [editor, setEditor] = useState<Editor>();
   const attended = useHasAttention(fullyQualifiedId(sketch));
 
@@ -107,18 +104,11 @@ export const SketchComponent = ({
         isSnapMode: true,
       });
       editor.updateInstanceState({
-        isGridMode: active,
-        isReadonly: readonly || !active,
+        isGridMode: attended,
+        isReadonly: readonly || !attended,
       });
     }
-  }, [editor, active, readonly, themeMode]);
-
-  // Ensure controls are visible when not in hover mode.
-  useEffect(() => {
-    if (!autoHideControls && !active) {
-      setActive(true);
-    }
-  }, [autoHideControls]);
+  }, [editor, attended, readonly, themeMode]);
 
   // Zoom to fit.
   const { ref: containerRef, width = 0, height } = useResizeDetector();
@@ -157,16 +147,6 @@ export const SketchComponent = ({
       ref={containerRef}
       style={{ visibility: ready ? 'visible' : 'hidden' }}
       className={mx('is-full bs-full', className)}
-      onPointerEnter={() => {
-        if (autoHideControls) {
-          setActive(!readonly && !adapter.readonly);
-        }
-      }}
-      onPointerLeave={() => {
-        if (autoHideControls) {
-          setActive(false);
-        }
-      }}
     >
       {/* https://tldraw.dev/docs/user-interface */}
       {/* NOTE: Key forces unmount; otherwise throws error. */}
@@ -174,7 +154,7 @@ export const SketchComponent = ({
         // Setting the key forces re-rendering when the content changes.
         key={fullyQualifiedId(sketch)}
         store={adapter.store}
-        hideUi={!active}
+        hideUi={!attended}
         inferDarkMode
         // https://tldraw.dev/docs/assets
         maxAssetSize={1024 * 1024}

--- a/packages/apps/plugins/plugin-sketch/src/components/SketchComponent/SketchComponent.stories.tsx
+++ b/packages/apps/plugins/plugin-sketch/src/components/SketchComponent/SketchComponent.stories.tsx
@@ -15,7 +15,7 @@ import { create } from '@dxos/echo-schema';
 import { Button, Toolbar } from '@dxos/react-ui';
 import { withFullscreen, withTheme } from '@dxos/storybook-utils';
 
-import { SketchComponent } from './SketchComponent';
+import { Sketch } from './Sketch';
 import { data } from '../../testing';
 
 const createSketch = (content: SerializedStore<TLRecord> = {}) => {
@@ -48,7 +48,7 @@ const Story = () => {
       </Toolbar.Root>
       <div className='flex grow overflow-hidden'>
         {/* TODO(burdon): Configure local storybook assets? */}
-        <SketchComponent sketch={sketch} assetsBaseUrl={null} />
+        <Sketch sketch={sketch} assetsBaseUrl={null} />
       </div>
     </div>
   );
@@ -56,7 +56,7 @@ const Story = () => {
 
 export default {
   title: 'plugin-sketch/SketchComponent',
-  component: SketchComponent,
+  component: Sketch,
   render: Story,
   decorators: [withTheme, withFullscreen()],
   parameters: {

--- a/packages/apps/plugins/plugin-sketch/src/components/SketchComponent/index.ts
+++ b/packages/apps/plugins/plugin-sketch/src/components/SketchComponent/index.ts
@@ -2,8 +2,8 @@
 // Copyright 2024 DXOS.org
 //
 
-import { SketchComponent } from './SketchComponent';
+import { Sketch } from './Sketch';
 
-export * from './SketchComponent';
+export * from './Sketch';
 
-export default SketchComponent;
+export default Sketch;

--- a/packages/apps/plugins/plugin-sketch/src/components/SketchMain.tsx
+++ b/packages/apps/plugins/plugin-sketch/src/components/SketchMain.tsx
@@ -13,12 +13,12 @@ import {
   topbarBlockPaddingStart,
 } from '@dxos/react-ui-theme';
 
-import { SketchComponent, type SketchComponentProps } from './SketchComponent';
+import { Sketch, type SketchComponentProps } from './SketchComponent';
 
 const SketchMain = (props: SketchComponentProps) => {
   return (
     <Main.Content classNames={[baseSurface, fixedInsetFlexLayout, topbarBlockPaddingStart, bottombarBlockPaddingEnd]}>
-      <SketchComponent
+      <Sketch
         key={fullyQualifiedId(props.sketch)} // Force instance per sketch object. Otherwise, sketch shares the same instance.
         {...props}
       />

--- a/packages/apps/plugins/plugin-sketch/src/components/SketchSettings.tsx
+++ b/packages/apps/plugins/plugin-sketch/src/components/SketchSettings.tsx
@@ -14,20 +14,11 @@ export const SketchSettings = ({ settings }: { settings: SketchSettingsProps }) 
   const { t } = useTranslation(SKETCH_PLUGIN);
 
   return (
-    <>
-      <SettingsValue label={t('settings hover tools label')}>
-        <Input.Switch
-          checked={settings.autoHideControls}
-          onCheckedChange={(checked) => (settings.autoHideControls = !!checked)}
-        />
-      </SettingsValue>
-
-      <SettingsValue label={t('settings grid type label')}>
-        <Input.Switch
-          checked={settings.gridType === 'dotted'}
-          onCheckedChange={(checked) => (settings.gridType = checked ? 'dotted' : 'mesh')}
-        />
-      </SettingsValue>
-    </>
+    <SettingsValue label={t('settings grid type label')}>
+      <Input.Switch
+        checked={settings.gridType === 'dotted'}
+        onCheckedChange={(checked) => (settings.gridType = checked ? 'dotted' : 'mesh')}
+      />
+    </SettingsValue>
   );
 };

--- a/packages/apps/plugins/plugin-sketch/src/types.ts
+++ b/packages/apps/plugins/plugin-sketch/src/types.ts
@@ -41,6 +41,5 @@ export interface SketchModel {
 export type SketchGridType = 'mesh' | 'dotted';
 
 export type SketchSettingsProps = {
-  autoHideControls?: boolean;
   gridType?: SketchGridType;
 };


### PR DESCRIPTION
This PR:
- resolves #7459
- removes the obsolete setting which reveals/hides controls on pointer enter/leave

https://github.com/user-attachments/assets/7e0749d8-5940-4a38-bf54-0e3078c535de
