### PR TITLE
fix(plugin-welcome): Apply forced dark mode correctly in `WelcomePlugin`

### DIFF
--- a/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.tsx
@@ -54,7 +54,7 @@ export const Welcome = ({
 
   return (
     <Dialog.Root defaultOpen>
-      <Dialog.Overlay classNames='!bg-neutral-950'>
+      <Dialog.Overlay classNames='dark !bg-neutral-950'>
         <div
           className={mx(
             'relative grid grid-cols-1 md:grid-cols-2 md:w-[900px] max-w-[900px] h-full md:h-[620px] overflow-hidden',

--- a/packages/ui/react-ui-theme/src/theme.css
+++ b/packages/ui/react-ui-theme/src/theme.css
@@ -38,10 +38,11 @@
 
 .dark {
   --surface-bg: theme(colors.neutral.850);
+  --surface-text: white;
   --input-bg: theme(colors.neutral.825);
   --input-bg-hover: theme(colors.neutral.800);
-  --surface-text: white;
   --description-text: theme(colors.neutral.500);
+  color: var(--surface-text);
 }
 
 html {


### PR DESCRIPTION
This PR fixes an issue observed in UR where users in a light theme were unable to see text in `WelcomePlugin` since all text was a near-black color on near-black backgrounds.

This now forces dark mode within the `Welcome` component.

<img width="1598" alt="Screenshot 2024-08-20 at 17 34 05" src="https://github.com/user-attachments/assets/88a6031d-d389-4d03-b04c-677de1628c97">
