### PR TITLE
chore: ensure autoexport can only run if roothandle exists

### DIFF
--- a/packages/apps/plugins/plugin-files/src/FilesPlugin.tsx
+++ b/packages/apps/plugins/plugin-files/src/FilesPlugin.tsx
@@ -204,7 +204,7 @@ export const FilesPlugin = (): PluginDefinition<LocalFilesPluginProvides, Markdo
       const dispatch = resolvePlugin(plugins, parseIntentPlugin)?.provides.intent.dispatch;
       subscriptions.add(
         effect(() => {
-          if (!settings.values.autoExport || !dispatch) {
+          if (!settings.values.autoExport || !settings.values.rootHandle || !dispatch) {
             return;
           }
 

--- a/packages/apps/plugins/plugin-files/src/components/FilesSettings.tsx
+++ b/packages/apps/plugins/plugin-files/src/components/FilesSettings.tsx
@@ -43,7 +43,11 @@ export const FilesSettings = ({ settings }: { settings: FilesSettingsProps }) =>
         </Button>
       </SettingsValue>
       <SettingsValue label={t('auto export label')}>
-        <Input.Switch checked={settings.autoExport} onCheckedChange={(checked) => (settings.autoExport = !!checked)} />
+        <Input.Switch
+          disabled={!settings.rootHandle}
+          checked={settings.rootHandle ? settings.autoExport : false}
+          onCheckedChange={(checked) => (settings.autoExport = !!checked)}
+        />
       </SettingsValue>
       <SettingsValue label={t('auto export interval label')}>
         <Input.TextInput


### PR DESCRIPTION
if autoexport is able to be enabled without a root it will open the settings every time it runs
