### PR TITLE
chore: filter core plugins in settings SettingsDialog

### DIFF
--- a/packages/apps/plugins/plugin-registry/src/components/PluginSettings.tsx
+++ b/packages/apps/plugins/plugin-registry/src/components/PluginSettings.tsx
@@ -15,7 +15,7 @@ import { REGISTRY_PLUGIN } from '../meta';
 
 export const PluginSettings = ({ settings }: { settings: RegistrySettingsProps }) => {
   const { t } = useTranslation(REGISTRY_PLUGIN);
-  const { enabled, plugins, setPlugin, ...pluginContext } = usePlugins();
+  const { enabled, core, plugins, setPlugin, ...pluginContext } = usePlugins();
   const dispatch = useIntentDispatcher();
 
   const sort = (a: Plugin['meta'], b: Plugin['meta']) => a.name?.localeCompare(b.name ?? '') ?? 0;
@@ -24,6 +24,7 @@ export const PluginSettings = ({ settings }: { settings: RegistrySettingsProps }
   const installed = useMemo(
     () =>
       plugins
+        .filter(({ meta }) => !core.includes(meta.id))
         .filter(({ meta }) => enabled.includes(meta.id))
         .map(({ meta }) => meta)
         .sort(sort),

--- a/packages/apps/plugins/plugin-settings/src/components/SettingsDialog.tsx
+++ b/packages/apps/plugins/plugin-settings/src/components/SettingsDialog.tsx
@@ -32,6 +32,7 @@ export const SettingsDialog = ({
   ];
 
   const filteredPlugins = enabled
+    .filter((id) => !core.includes(id))
     .map((id) => plugins.find((plugin) => plugin.meta.id === id))
     .filter((plugin) => (plugin?.provides as any)?.settings)
     .map((plugin) => plugin!.meta)

--- a/packages/sdk/app-framework/src/plugins/PluginHost/PluginContext.tsx
+++ b/packages/sdk/app-framework/src/plugins/PluginHost/PluginContext.tsx
@@ -14,6 +14,11 @@ export type PluginContext = {
   ready: boolean;
 
   /**
+   * Core plugins.
+   */
+  core: string[];
+
+  /**
    * Ids of plugins which are enabled on this device.
    */
   enabled: string[];
@@ -38,6 +43,7 @@ export type PluginContext = {
 
 const PluginContext: Context<PluginContext> = createContext<PluginContext>({
   ready: false,
+  core: [],
   enabled: [],
   plugins: [],
   available: [],

--- a/packages/sdk/app-framework/src/plugins/PluginHost/PluginHost.tsx
+++ b/packages/sdk/app-framework/src/plugins/PluginHost/PluginHost.tsx
@@ -42,6 +42,7 @@ export const PluginHost = ({
 }: BootstrapPluginsParams): PluginDefinition<PluginHostProvides> => {
   const state = new LocalStorageStore<PluginContext>(PLUGIN_HOST, {
     ready: false,
+    core,
     enabled: [...defaults],
     plugins: [],
     available: order.filter(({ id }) => !core.includes(id)),


### PR DESCRIPTION
this prevents plugins which migrate into core from showing up in unexpected places
