### PR TITLE
fix(echo): collection-sync for documents not present locally

### DIFF
--- a/packages/core/echo/echo-pipeline/src/automerge/echo-network-adapter.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/echo-network-adapter.test.ts
@@ -105,6 +105,7 @@ describe('EchoNetworkAdapter', () => {
   const createConnectedAdapter = async (replicator: MeshEchoReplicator) => {
     const adapter = new EchoNetworkAdapter({
       getContainingSpaceForDocument: async () => null,
+      isDocumentInRemoteCollection: async () => true,
       onCollectionStateQueried: () => {},
       onCollectionStateReceived: () => {},
     });

--- a/packages/core/echo/echo-pipeline/src/automerge/echo-network-adapter.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/echo-network-adapter.ts
@@ -12,6 +12,7 @@ import { nonNullable } from '@dxos/util';
 
 import {
   type EchoReplicator,
+  type RemoteDocumentExistenceCheckParams,
   type ReplicatorConnection,
   type ShouldAdvertiseParams,
   type ShouldSyncCollectionParams,
@@ -34,6 +35,7 @@ export interface NetworkDataMonitor {
 
 export type EchoNetworkAdapterParams = {
   getContainingSpaceForDocument: (documentId: string) => Promise<PublicKey | null>;
+  isDocumentInRemoteCollection: (params: RemoteDocumentExistenceCheckParams) => Promise<boolean>;
   onCollectionStateQueried: (collectionId: string, peerId: PeerId) => void;
   onCollectionStateReceived: (collectionId: string, peerId: PeerId, state: unknown) => void;
   monitor?: NetworkDataMonitor;
@@ -112,6 +114,7 @@ export class EchoNetworkAdapter extends NetworkAdapter {
       onConnectionOpen: this._onConnectionOpen.bind(this),
       onConnectionClosed: this._onConnectionClosed.bind(this),
       onConnectionAuthScopeChanged: this._onConnectionAuthScopeChanged.bind(this),
+      isDocumentInRemoteCollection: this._params.isDocumentInRemoteCollection,
       getContainingSpaceForDocument: this._params.getContainingSpaceForDocument,
       getContainingSpaceIdForDocument: async (documentId) => {
         const key = await this._params.getContainingSpaceForDocument(documentId);

--- a/packages/core/echo/echo-pipeline/src/automerge/echo-replicator.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/echo-replicator.ts
@@ -28,6 +28,7 @@ export interface EchoReplicatorContext {
    */
   getContainingSpaceForDocument(documentId: string): Promise<PublicKey | null>;
   getContainingSpaceIdForDocument(documentId: string): Promise<SpaceId | null>;
+  isDocumentInRemoteCollection(params: RemoteDocumentExistenceCheckParams): Promise<boolean>;
 
   onConnectionOpen(connection: ReplicatorConnection): void;
   onConnectionClosed(connection: ReplicatorConnection): void;
@@ -68,4 +69,9 @@ export type ShouldAdvertiseParams = {
 
 export type ShouldSyncCollectionParams = {
   collectionId: string;
+};
+
+export type RemoteDocumentExistenceCheckParams = {
+  peerId: string;
+  documentId: string;
 };

--- a/packages/core/echo/echo-pipeline/src/automerge/mesh-echo-replicator.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/mesh-echo-replicator.ts
@@ -83,11 +83,19 @@ export class MeshEchoReplicator implements EchoReplicator {
         try {
           const spaceKey = await this._context.getContainingSpaceForDocument(params.documentId);
           if (!spaceKey) {
+            const remoteDocumentExists = await this._context.isDocumentInRemoteCollection({
+              documentId: params.documentId,
+              peerId: connection.peerId,
+            });
             log('document not found locally for share policy check, accepting the remote document', {
               peerId: connection.peerId,
               documentId: params.documentId,
+              remoteDocumentExists,
             });
-            return true;
+            // If a document is not present locally return true if another peer claims to have it.
+            // Simply returning true will add the peer to "generous peers list" for this document which will
+            // start replication of the document after we receive, even if the peer is not in the corresponding space.
+            return remoteDocumentExists;
           }
 
           const spaceId = await createIdFromSpaceKey(spaceKey);

--- a/packages/core/echo/echo-pipeline/src/automerge/mesh-echo-replicator.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/mesh-echo-replicator.ts
@@ -83,11 +83,11 @@ export class MeshEchoReplicator implements EchoReplicator {
         try {
           const spaceKey = await this._context.getContainingSpaceForDocument(params.documentId);
           if (!spaceKey) {
-            log('space key not found for share policy check', {
+            log('document not found locally for share policy check, accepting the remote document', {
               peerId: connection.peerId,
               documentId: params.documentId,
             });
-            return false;
+            return true;
           }
 
           const spaceId = await createIdFromSpaceKey(spaceKey);

--- a/packages/core/echo/echo-pipeline/src/testing/test-network-adapter.ts
+++ b/packages/core/echo/echo-pipeline/src/testing/test-network-adapter.ts
@@ -7,13 +7,15 @@ import { type Message, NetworkAdapter, type PeerId } from '@dxos/automerge/autom
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
 
+export type TestConnectionStateProvider = () => 'on' | 'off';
+
 export class TestAdapter extends NetworkAdapter {
-  static createPair() {
+  static createPair(connectionStateProvider: TestConnectionStateProvider = () => 'on') {
     const adapter1: TestAdapter = new TestAdapter({
-      send: (message: Message) => sleep(10).then(() => adapter2.receive(message)),
+      send: (message: Message) => connectionStateProvider() === 'on' && sleep(10).then(() => adapter2.receive(message)),
     });
     const adapter2: TestAdapter = new TestAdapter({
-      send: (message: Message) => sleep(10).then(() => adapter1.receive(message)),
+      send: (message: Message) => connectionStateProvider() === 'on' && sleep(10).then(() => adapter1.receive(message)),
     });
 
     return [adapter1, adapter2];

--- a/packages/core/mesh/teleport-extension-automerge-replicator/src/automerge-replicator.ts
+++ b/packages/core/mesh/teleport-extension-automerge-replicator/src/automerge-replicator.ts
@@ -89,7 +89,6 @@ export class AutomergeReplicator implements TeleportExtension {
             await this._callbacks.onStartReplication?.(info, context.remotePeerId);
           },
           sendSyncMessage: async (message: SyncMessage): Promise<void> => {
-            log('sendSyncMessage', { localPeerId: context.localPeerId, remotePeerId: context.remotePeerId, message });
             await this._callbacks.onSyncMessage?.(message);
           },
         },

--- a/packages/sdk/client/src/testing/test-builder.ts
+++ b/packages/sdk/client/src/testing/test-builder.ts
@@ -53,8 +53,8 @@ export class TestBuilder {
   private readonly _ctx = new Context({ name: 'TestBuilder' });
 
   public config: Config;
-  public storage?: Storage;
-  public level?: LevelDB;
+  public storage?: () => Storage;
+  public level?: () => LevelDB;
 
   _transport: TransportKind;
 
@@ -128,8 +128,8 @@ export class TestBuilder {
   createClientServicesHost(runtimeParams?: ServiceContextRuntimeParams) {
     const services = new ClientServicesHost({
       config: this.config,
-      storage: this.storage,
-      level: this.level,
+      storage: this?.storage?.(),
+      level: this?.level?.(),
       runtimeParams,
       ...this.networking,
     });
@@ -145,8 +145,8 @@ export class TestBuilder {
   createLocalClientServices(options?: { fastPeerPresenceUpdate?: boolean }): LocalClientServices {
     const services = new LocalClientServices({
       config: this.config,
-      storage: this.storage,
-      level: this.level,
+      storage: this?.storage?.(),
+      level: this?.level?.(),
       runtimeParams: {
         ...(options?.fastPeerPresenceUpdate
           ? { spaceMemberPresenceAnnounceInterval: 200, spaceMemberPresenceOfflineTimeout: 400 }
@@ -179,7 +179,6 @@ export class TestBuilder {
 
   async destroy() {
     await this._ctx.dispose(false); // TODO(burdon): Set to true to check clean shutdown.
-    await this.level?.close();
   }
 }
 

--- a/packages/sdk/client/src/testing/utils.ts
+++ b/packages/sdk/client/src/testing/utils.ts
@@ -57,8 +57,10 @@ export const createInitializedClientsWithContext = async (
   options?: CreateInitializedClientsOptions,
 ): Promise<Client[]> => {
   const testBuilder = new TestBuilder(options?.config);
-  testBuilder.storage = options?.storage ? createStorage({ type: StorageType.RAM }) : undefined;
-  testBuilder.level = options?.storage ? createTestLevel() : undefined;
+  testBuilder.storage = options?.storage
+    ? () => createStorage({ type: StorageType.RAM, root: String(Math.random()) })
+    : undefined;
+  testBuilder.level = options?.storage ? () => createTestLevel() : undefined;
 
   const clients = range(
     count,

--- a/packages/sdk/client/src/tests/client-services.test.ts
+++ b/packages/sdk/client/src/tests/client-services.test.ts
@@ -55,7 +55,7 @@ describe('Client services', () => {
 
   test('creates clients with multiple peers connected via memory transport', async () => {
     const testBuilder = new TestBuilder();
-    testBuilder.level = createTestLevel();
+    testBuilder.level = () => createTestLevel();
     afterTest(() => testBuilder.destroy());
 
     {

--- a/packages/sdk/client/src/tests/halo-persistent.test.ts
+++ b/packages/sdk/client/src/tests/halo-persistent.test.ts
@@ -30,7 +30,7 @@ describe('Halo', () => {
     });
 
     const testBuilder = new TestBuilder(config);
-    testBuilder.level = createTestLevel();
+    testBuilder.level = () => createTestLevel();
 
     {
       const client = new Client({ config, services: testBuilder.createLocalClientServices() });


### PR DESCRIPTION
### Details

`collection-sync` wasn't working for documents not present locally if they were not loaded in other peer's memory (a document is loaded when it was requested at least once during a session using `query` or `getById`).
The problem was in sharePolicy, since it's spaceKey-based, it wasn't passing on failure to resolve space key from a document.
So `sharePolicy` was never returning true for documents we didn't have making [`.find(documentId)`](https://github.com/dxos/dxos/blob/main/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts#L468) after collection-sync a no-op.
Other peers still could push documents to us, so replication was working.
Tests were passing because peers were sharing storage. 

Fixed by making a document lookup in peers remote collection state. 
The majority of changes are new tests and existing test refactoring.
