### PR TITLE
fix(cli): don't log.catch normal cancellations

### DIFF
--- a/packages/core/echo/echo-db/src/client/index-query-source-provider.ts
+++ b/packages/core/echo/echo-db/src/client/index-query-source-provider.ts
@@ -8,6 +8,7 @@ import { Context } from '@dxos/context';
 import { type EchoReactiveObject } from '@dxos/echo-schema';
 import { type PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
+import { RpcClosedError } from '@dxos/protocols';
 import { QueryOptions } from '@dxos/protocols/proto/dxos/echo/filter';
 import {
   type QueryResponse,
@@ -102,7 +103,7 @@ export class IndexQuerySource implements QuerySource {
     filter: Filter,
     queryType: QueryType,
     onResult: (results: QueryResult[]) => void,
-    onError: (error: Error) => void = (error: any) => log.catch(error),
+    onError?: (error: Error) => void,
   ) {
     const queryId = INDEX_QUERY_ID++;
 
@@ -159,7 +160,11 @@ export class IndexQuerySource implements QuerySource {
       },
       (err) => {
         if (err != null) {
-          onError(err);
+          if (onError) {
+            onError(err);
+          } else if (!(err instanceof RpcClosedError)) {
+            log.catch(err);
+          }
         }
       },
     );

--- a/packages/core/echo/echo-db/src/client/index-query-source-provider.ts
+++ b/packages/core/echo/echo-db/src/client/index-query-source-provider.ts
@@ -155,7 +155,11 @@ export class IndexQuerySource implements QuerySource {
             log.warn('results from the previous update are ignored', { queryId });
           }
         } catch (err: any) {
-          onError(err);
+          if (onError) {
+            onError(err);
+          } else {
+            log.catch(err);
+          }
         }
       },
       (err) => {

--- a/packages/core/mesh/network-manager/src/swarm/connection.ts
+++ b/packages/core/mesh/network-manager/src/swarm/connection.ts
@@ -3,7 +3,7 @@
 //
 
 import { DeferredTask, Event, sleep, scheduleTask, scheduleTaskInterval, synchronized, Trigger } from '@dxos/async';
-import { Context, cancelWithContext } from '@dxos/context';
+import { Context, cancelWithContext, ContextDisposedError } from '@dxos/context';
 import { ErrorStream } from '@dxos/debug';
 import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
@@ -381,7 +381,11 @@ export class Connection {
       });
     } catch (err) {
       // TODO(nf): determine why instanceof doesn't work here
-      if (err instanceof CancelledError || (err instanceof Error && err.message?.includes('CANCELLED'))) {
+      if (
+        err instanceof CancelledError ||
+        err instanceof ContextDisposedError ||
+        (err instanceof Error && err.message?.includes('CANCELLED'))
+      ) {
         return;
       }
 


### PR DESCRIPTION
### Details

Don't `log.catch` normal cancellations. Was happening during invitations in running agent and on one-shot invocations like `dx space list`. 

<img width="800" alt="image" src="https://github.com/user-attachments/assets/b1137b42-34ab-4c5b-873f-081f8b07bf56">

