### PR TITLE
chore(deck): Disable fullscreen action node

### DIFF
--- a/packages/plugins/plugin-deck/src/DeckPlugin.tsx
+++ b/packages/plugins/plugin-deck/src/DeckPlugin.tsx
@@ -295,7 +295,9 @@ export const DeckPlugin = ({
           // TODO(burdon): Root menu isn't visible so nothing bound.
           return createExtension({
             id: DECK_PLUGIN,
-            filter: (node): node is Node<null> => node.id === 'root',
+            // NOTE(Zan): This is currently disabled.
+            // TODO(Zan): Fullscreen needs to know the active node and provide that to the layout part.
+            filter: (node): node is Node<null> => false,
             actions: () => [
               {
                 id: `${LayoutAction.SET_LAYOUT_MODE}/fullscreen`,


### PR DESCRIPTION
- Resolves https://github.com/dxos/dxos/issues/7617

Fullscreen isn't plumbed into the layout system at all currently. Presenter continues to work as expected with this change.

We should implement fullscreen as an enhancement if we desire the functionality. But for now, this will stop people from getting the app stuck in a broken state.