### PR TITLE
fix(react-ui-stack,react-ui-editor): Remove max-width from stack, apply max-widths to MarkdownEditor toolbar

### DIFF
--- a/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
@@ -203,7 +203,7 @@ export const MarkdownEditor = ({
                 ? [
                     textBlockWidth,
                     'z-[2] group-focus-within/section:visible',
-                    !attended && 'invisible',
+                    !isDirectlyAttended && 'invisible',
                     sectionToolbarLayout,
                   ]
                 : [

--- a/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
@@ -200,7 +200,12 @@ export const MarkdownEditor = ({
           <Toolbar.Root
             classNames={
               role === 'section'
-                ? ['z-[2] group-focus-within/section:visible', !attended && 'invisible', sectionToolbarLayout]
+                ? [
+                    textBlockWidth,
+                    'z-[2] group-focus-within/section:visible',
+                    !attended && 'invisible',
+                    sectionToolbarLayout,
+                  ]
                 : [
                     textBlockWidth,
                     'group-focus-within/editor:separator-separator group-[[aria-current]]/editor:separator-separator',

--- a/packages/ui/react-ui-stack/src/components/Stack.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack.tsx
@@ -16,7 +16,7 @@ import {
   useItemsWithPreview,
   useMosaic,
 } from '@dxos/react-ui-mosaic';
-import { dropRingInner, mx, textBlockWidth } from '@dxos/react-ui-theme';
+import { dropRingInner } from '@dxos/react-ui-theme';
 
 import {
   type CollapsedSections,
@@ -139,7 +139,7 @@ const StackTile: MosaicTileComponent<StackItem, HTMLOListElement, Pick<StackProp
     return (
       <List
         ref={forwardedRef}
-        classNames={mx('grid relative', textBlockWidth, stackColumns, isOver && dropRingInner, classNames)}
+        classNames={['grid relative', stackColumns, isOver && dropRingInner, classNames]}
         {...(!activeItem && domAttributes)}
         {...props}
       >


### PR DESCRIPTION
<img width="912" alt="Screenshot 2024-09-05 at 09 00 12" src="https://github.com/user-attachments/assets/9f47451f-b155-4671-aac6-8751c54384be">
