### PR TITLE
fix(map): improve hasId check to not use `any`

### DIFF
--- a/packages/plugins/experimental/plugin-map/src/components/MapDetectLocations.ts
+++ b/packages/plugins/experimental/plugin-map/src/components/MapDetectLocations.ts
@@ -84,7 +84,8 @@ export const useMapDetectLocations = (map: MapType): Marker[] => {
 
 export default useMapDetectLocations;
 
-const hasId = (obj: any): obj is { id: string } => typeof obj.id === 'string';
+const hasId = (obj: unknown): obj is { id: string } =>
+  typeof obj === 'object' && obj !== null && 'id' in obj && typeof obj?.id === 'string';
 
 const schemaHasLatitudeAndLongitude = (schema: DynamicSchema): boolean => {
   const properties = schema.getProperties();

--- a/packages/plugins/experimental/plugin-map/src/components/MapDetectLocations.ts
+++ b/packages/plugins/experimental/plugin-map/src/components/MapDetectLocations.ts
@@ -85,7 +85,7 @@ export const useMapDetectLocations = (map: MapType): Marker[] => {
 export default useMapDetectLocations;
 
 const hasId = (obj: unknown): obj is { id: string } =>
-  typeof obj === 'object' && obj !== null && 'id' in obj && typeof obj?.id === 'string';
+  typeof obj === 'object' && obj !== null && 'id' in obj && typeof obj.id === 'string';
 
 const schemaHasLatitudeAndLongitude = (schema: DynamicSchema): boolean => {
   const properties = schema.getProperties();


### PR DESCRIPTION
Close #7653. There might be other problems in the module if objects without `id` fields are coming out of `useQuery`, but this will fix the immediate error that occurs within `hasId`.