### PR TITLE
fix(map): show markers again

### DIFF
--- a/packages/plugins/experimental/plugin-map/src/components/MapDetectLocations.ts
+++ b/packages/plugins/experimental/plugin-map/src/components/MapDetectLocations.ts
@@ -85,7 +85,7 @@ export const useMapDetectLocations = (map: MapType): Marker[] => {
 export default useMapDetectLocations;
 
 const hasId = (obj: unknown): obj is { id: string } =>
-  typeof obj === 'object' && obj !== null && 'id' in obj && typeof obj.id === 'string';
+  typeof obj === 'object' && obj !== null && obj.hasOwnProperty('id') && typeof (obj as any).id === 'string';
 
 const schemaHasLatitudeAndLongitude = (schema: DynamicSchema): boolean => {
   const properties = schema.getProperties();

--- a/packages/plugins/experimental/plugin-map/src/components/MapDetectLocations.ts
+++ b/packages/plugins/experimental/plugin-map/src/components/MapDetectLocations.ts
@@ -85,7 +85,10 @@ export const useMapDetectLocations = (map: MapType): Marker[] => {
 export default useMapDetectLocations;
 
 const hasId = (obj: unknown): obj is { id: string } =>
-  typeof obj === 'object' && obj !== null && obj.hasOwnProperty('id') && typeof (obj as any).id === 'string';
+  typeof obj === 'object' &&
+  obj !== null &&
+  Object.prototype.hasOwnProperty.call(obj, 'id') &&
+  typeof (obj as any).id === 'string';
 
 const schemaHasLatitudeAndLongitude = (schema: DynamicSchema): boolean => {
   const properties = schema.getProperties();


### PR DESCRIPTION
Turns out my previous PR https://github.com/dxos/dxos/pull/7658 stopped that crash by disabling markers entirely. `'id' in obj` will always return false for the ECHO objects we're interested in.

This still uses an `any`, but I think safely. It displays markers and the crash is still gone.