### PR TITLE
chore: audit storybooks; rename import '@dxosTheme' => '@dxos-theme`

### DIFF
--- a/.vscode/react.code-snippets
+++ b/.vscode/react.code-snippets
@@ -1,9 +1,9 @@
 {
-  // Place your dxos workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and 
-  // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
-  // is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
-  // used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
-  // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
+  // Place your dxos workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
+  // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope
+  // is left empty or omitted, the snippet gets applied to all languages. The prefix is what is
+  // used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
+  // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders.
   // Placeholders with the same ids are connected.
   // Example:
   // "Print to console": {
@@ -34,7 +34,7 @@
     "body": [
       "import React from 'react';",
       "",
-      "import '@dxosTheme';",
+      "import '@dxos-theme';",
       "import { ${1:${TM_FILENAME_BASE/(.*)\\..+$/$1/}} } from './$1';",
       "",
       "export default {",

--- a/docs/content/guide/dxos-ui/README.md
+++ b/docs/content/guide/dxos-ui/README.md
@@ -53,10 +53,10 @@ export default defineConfig({
 
 The content array should contain globs that match any other code which will contain `tailwind` css classes.
 
-Import the special DXOS theme stylesheet `@dxosTheme` anywhere in code such as `main.tsx`:
+Import the special DXOS theme stylesheet `@dxos-theme` anywhere in code such as `main.tsx`:
 
 ```tsx{1} file=./snippets/vite-main.tsx#L5-
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 import { createRoot } from 'react-dom/client';
@@ -65,14 +65,14 @@ createRoot(document.getElementById('root')!).render(<main></main>);
 ```
 
 ::: tip Tip
-For best results, load `@dxosTheme` ahead of any other stylesheets.
+For best results, load `@dxos-theme` ahead of any other stylesheets.
 :::
 
 ### With other bundlers
 
 ::: details Install with other bundlers
 
-The special `@dxosTheme` import will not be a available. Include the following stylesheet in your `index.html`:
+The special `@dxos-theme` import will not be a available. Include the following stylesheet in your `index.html`:
 
 ```
 node_modules/@dxos/react-ui/dist/plugin/node/theme.css

--- a/docs/content/guide/dxos-ui/snippets/vite-main.tsx
+++ b/docs/content/guide/dxos-ui/snippets/vite-main.tsx
@@ -2,7 +2,7 @@
 // Copyright 2020 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 import { createRoot } from 'react-dom/client';

--- a/packages/apps/composer-app/script-frame/main.tsx
+++ b/packages/apps/composer-app/script-frame/main.tsx
@@ -20,6 +20,7 @@ const main = async () => {
   const { ClientServicesProxy } = await import('@dxos/react-client');
   const { createIFramePort } = await import('@dxos/rpc-tunnel');
 
+  // Modules required by the script at runtime.
   // @ts-ignore
   window.__DXOS_SANDBOX_MODULES__ = await init(async () => ({
     // prettier-ignore

--- a/packages/apps/composer-app/src/devtools.tsx
+++ b/packages/apps/composer-app/src/devtools.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { StrictMode, useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';

--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -2,7 +2,7 @@
 // Copyright 2020 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';

--- a/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.stories.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/components/Welcome/Welcome.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 import '@fontsource/poiret-one';
 
 import React, { useState } from 'react';

--- a/packages/apps/composer-app/src/shell.ts
+++ b/packages/apps/composer-app/src/shell.ts
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { runShell } from '@dxos/shell/react';
 import { TRACE_PROCESSOR } from '@dxos/tracing';

--- a/packages/apps/composer-app/src/stories/NavtreePresence.stories.tsx
+++ b/packages/apps/composer-app/src/stories/NavtreePresence.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 // import { Minus, Plus } from '@phosphor-icons/react';
 //

--- a/packages/apps/templates/bare-template/src/src/main.ts.t.ts
+++ b/packages/apps/templates/bare-template/src/src/main.ts.t.ts
@@ -17,7 +17,7 @@ export default template.define.text({
       plate`
     // This includes css styles from @dxos/react-ui-theme.
     // This must precede all other style imports in the app.
-    import '@dxosTheme';`
+    import '@dxos-theme';`
     }
 
     ${

--- a/packages/apps/templates/bare-template/src/src/main.tsx.t.ts
+++ b/packages/apps/templates/bare-template/src/src/main.tsx.t.ts
@@ -17,7 +17,7 @@ export default template.define.text({
       plate`
     // This includes css styles from @dxos/react-ui-theme.
     // This must precede all other style imports in the app.
-    import '@dxosTheme';`
+    import '@dxos-theme';`
     }
 
     ${

--- a/packages/apps/testbench-app/src/components/Main.stories.tsx
+++ b/packages/apps/testbench-app/src/components/Main.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/apps/testbench-app/src/main.tsx
+++ b/packages/apps/testbench-app/src/main.tsx
@@ -2,7 +2,7 @@
 // Copyright 2020 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { BaselimeRum } from '@baselime/react-rum';
 import { withProfiler } from '@sentry/react';

--- a/packages/apps/testbench-app/src/shell.ts
+++ b/packages/apps/testbench-app/src/shell.ts
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { runShell } from '@dxos/shell/react';
 import { TRACE_PROCESSOR } from '@dxos/tracing';

--- a/packages/common/keyboard/src/keyboard.stories.tsx
+++ b/packages/common/keyboard/src/keyboard.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useEffect, useState } from 'react';
 

--- a/packages/devtools/devtools-extension/src/sandbox.tsx
+++ b/packages/devtools/devtools-extension/src/sandbox.tsx
@@ -2,7 +2,7 @@
 // Copyright 2020 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';

--- a/packages/devtools/devtools/src/components/Bitbar.stories.tsx
+++ b/packages/devtools/devtools/src/components/Bitbar.stories.tsx
@@ -3,6 +3,7 @@
 //
 
 import '@dxos-theme';
+
 import React, { useEffect, useState } from 'react';
 
 import { mx } from '@dxos/react-ui-theme';

--- a/packages/devtools/devtools/src/components/Bitbar.stories.tsx
+++ b/packages/devtools/devtools/src/components/Bitbar.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 import React, { useEffect, useState } from 'react';
 
 import { mx } from '@dxos/react-ui-theme';

--- a/packages/devtools/devtools/src/components/FeedGraph.stories.tsx
+++ b/packages/devtools/devtools/src/components/FeedGraph.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/devtools/devtools/src/components/PropertiesTable.stories.tsx
+++ b/packages/devtools/devtools/src/components/PropertiesTable.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useMemo, useState } from 'react';
 

--- a/packages/devtools/devtools/src/components/PublicKeySelector.stories.tsx
+++ b/packages/devtools/devtools/src/components/PublicKeySelector.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/devtools/devtools/src/components/Tree.stories.tsx
+++ b/packages/devtools/devtools/src/components/Tree.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/devtools/devtools/src/main.tsx
+++ b/packages/devtools/devtools/src/main.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 import { createRoot } from 'react-dom/client';

--- a/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalMessages.stories.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalMessages.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/experimental/chess-app/src/Chessboard.stories.tsx
+++ b/packages/experimental/chess-app/src/Chessboard.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { Chess } from 'chess.js';
 import React, { useState } from 'react';

--- a/packages/experimental/gem-core/src/components/SvgContextProvider.stories.tsx
+++ b/packages/experimental/gem-core/src/components/SvgContextProvider.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 // TODO(burdon): Move to tailwind.
 import { css } from '@emotion/css';

--- a/packages/experimental/gem-core/src/components/d3.stories.tsx
+++ b/packages/experimental/gem-core/src/components/d3.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { css } from '@emotion/css';
 import * as d3 from 'd3';

--- a/packages/experimental/gem-globe/package.json
+++ b/packages/experimental/gem-globe/package.json
@@ -7,6 +7,9 @@
   "bugs": "https://github.com/dxos/issues",
   "license": "MIT",
   "author": "DXOS.org",
+  "imports": {
+    "#data_countries-110m.json": "./data/countries-110m.json"
+  },
   "exports": {
     ".": {
       "browser": "./dist/lib/browser/index.mjs",
@@ -15,9 +18,6 @@
       },
       "types": "./dist/types/src/index.d.ts"
     }
-  },
-  "imports": {
-    "#data_countries-110m.json": "./data/countries-110m.json"
   },
   "types": "dist/types/src/index.d.ts",
   "typesVersions": {

--- a/packages/experimental/gem-globe/src/components/Globe.stories.tsx
+++ b/packages/experimental/gem-globe/src/components/Globe.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2018 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import * as d3 from 'd3';
 import React, { useEffect, useMemo, useRef, useState } from 'react';

--- a/packages/experimental/gem-spore/src/components/Graph.stories.tsx
+++ b/packages/experimental/gem-spore/src/components/Graph.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useMemo } from 'react';
 

--- a/packages/experimental/gem-spore/src/components/GraphWithHooks.stories.tsx
+++ b/packages/experimental/gem-spore/src/components/GraphWithHooks.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2020 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import clsx from 'clsx';
 import * as d3 from 'd3';

--- a/packages/experimental/plexus/src/components/Plexus.stories.tsx
+++ b/packages/experimental/plexus/src/components/Plexus.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import {
   AirplaneTakeoff,

--- a/packages/gravity/gravity-dashboard/stories/experimental.stories.tsx
+++ b/packages/gravity/gravity-dashboard/stories/experimental.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { css } from '@emotion/css';
 import * as d3 from 'd3';

--- a/packages/plugins/experimental/plugin-chain/src/components/PromptTemplate/PromptTemplate.stories.tsx
+++ b/packages/plugins/experimental/plugin-chain/src/components/PromptTemplate/PromptTemplate.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useState } from 'react';
 

--- a/packages/plugins/experimental/plugin-debug/src/components/DebugSpace.stories.tsx
+++ b/packages/plugins/experimental/plugin-debug/src/components/DebugSpace.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type FC, useEffect } from 'react';
 

--- a/packages/plugins/experimental/plugin-debug/src/components/ObjectCreator.stories.tsx
+++ b/packages/plugins/experimental/plugin-debug/src/components/ObjectCreator.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type FC, useEffect } from 'react';
 

--- a/packages/plugins/experimental/plugin-excalidraw/src/components/SketchComponent/SketchComponent.stories.tsx
+++ b/packages/plugins/experimental/plugin-excalidraw/src/components/SketchComponent/SketchComponent.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useState } from 'react';
 

--- a/packages/plugins/experimental/plugin-explorer/package.json
+++ b/packages/plugins/experimental/plugin-explorer/package.json
@@ -6,6 +6,10 @@
   "bugs": "https://github.com/dxos/dxos/issues",
   "license": "MIT",
   "author": "DXOS.org",
+  "imports": {
+    "#data_cities.json": "./data/cities.json",
+    "#data_countries-110m.json": "./data/countries-110m.json"
+  },
   "exports": {
     ".": {
       "browser": "./dist/lib/browser/index.mjs",
@@ -28,10 +32,6 @@
       },
       "types": "./dist/types/src/types/index.d.ts"
     }
-  },
-  "imports": {
-    "#data_cities.json": "./data/cities.json",
-    "#data_countries-110m.json": "./data/countries-110m.json"
   },
   "types": "dist/types/src/index.d.ts",
   "typesVersions": {

--- a/packages/plugins/experimental/plugin-explorer/src/components/Chart/Chart.stories.tsx
+++ b/packages/plugins/experimental/plugin-explorer/src/components/Chart/Chart.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import * as Plot from '@observablehq/plot';
 import React from 'react';

--- a/packages/plugins/experimental/plugin-explorer/src/components/Globe/Globe.stories.tsx
+++ b/packages/plugins/experimental/plugin-explorer/src/components/Globe/Globe.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import * as Plot from '@observablehq/plot';
 import * as d3 from 'd3';

--- a/packages/plugins/experimental/plugin-explorer/src/components/Graph/Graph.stories.tsx
+++ b/packages/plugins/experimental/plugin-explorer/src/components/Graph/Graph.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useEffect, useState } from 'react';
 

--- a/packages/plugins/experimental/plugin-explorer/src/components/Tree/Tree.stories.tsx
+++ b/packages/plugins/experimental/plugin-explorer/src/components/Tree/Tree.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type FC, useEffect, useState } from 'react';
 

--- a/packages/plugins/experimental/plugin-github/src/components/Loading/Loading.stories.tsx
+++ b/packages/plugins/experimental/plugin-github/src/components/Loading/Loading.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { Loading } from './Loading';
 

--- a/packages/plugins/experimental/plugin-grid/src/components/Grid.stories.tsx
+++ b/packages/plugins/experimental/plugin-grid/src/components/Grid.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { type StoryFn } from '@storybook/react';
 import React, { type Ref, forwardRef, useState } from 'react';

--- a/packages/plugins/experimental/plugin-inbox/src/components/Email/MessageList.stories.tsx
+++ b/packages/plugins/experimental/plugin-inbox/src/components/Email/MessageList.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useState } from 'react';
 

--- a/packages/plugins/experimental/plugin-outliner/src/components/Outliner/Outliner.stories.tsx
+++ b/packages/plugins/experimental/plugin-outliner/src/components/Outliner/Outliner.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useState } from 'react';
 

--- a/packages/plugins/experimental/plugin-script/src/components/ScriptBlock/ScriptBlock.stories.tsx
+++ b/packages/plugins/experimental/plugin-script/src/components/ScriptBlock/ScriptBlock.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useEffect, useMemo } from 'react';
 

--- a/packages/plugins/experimental/plugin-script/src/components/ScriptBlock/Splitter/Splitter.stories.tsx
+++ b/packages/plugins/experimental/plugin-script/src/components/ScriptBlock/Splitter/Splitter.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useState } from 'react';
 

--- a/packages/plugins/experimental/plugin-script/src/components/Toolbar.stories.tsx
+++ b/packages/plugins/experimental/plugin-script/src/components/Toolbar.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 // import React from 'react';
 

--- a/packages/plugins/experimental/plugin-script/src/components/TypescriptEditor.stories.tsx
+++ b/packages/plugins/experimental/plugin-script/src/components/TypescriptEditor.stories.tsx
@@ -13,7 +13,7 @@
 // - virtual document image rendering
 // - mobile rendering error
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useMemo } from 'react';
 

--- a/packages/plugins/experimental/plugin-search/src/components/Search.stories.tsx
+++ b/packages/plugins/experimental/plugin-search/src/components/Search.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { type Decorator, type StoryFn } from '@storybook/react';
 import React, { type FC, useState } from 'react';

--- a/packages/plugins/experimental/plugin-search/src/components/SearchResults/SearchResults.stories.tsx
+++ b/packages/plugins/experimental/plugin-search/src/components/SearchResults/SearchResults.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type FC, useState } from 'react';
 

--- a/packages/plugins/experimental/plugin-search/src/components/Searchbar/Searchbar.stories.tsx
+++ b/packages/plugins/experimental/plugin-search/src/components/Searchbar/Searchbar.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type FC } from 'react';
 

--- a/packages/plugins/plugin-help/src/components/HelpContextProvider/HelpContextProvider.stories.tsx
+++ b/packages/plugins/plugin-help/src/components/HelpContextProvider/HelpContextProvider.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { Circle } from '@phosphor-icons/react';
 import React, { type FC, useState } from 'react';

--- a/packages/plugins/plugin-markdown/src/components/MarkdownEditor.stories.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownEditor.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 import React, { useMemo, type FC } from 'react';
 
 import { createDocAccessor, createEchoObject } from '@dxos/react-client/echo';

--- a/packages/plugins/plugin-markdown/src/components/Toolbar.stories.tsx
+++ b/packages/plugins/plugin-markdown/src/components/Toolbar.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type FC, useState } from 'react';
 

--- a/packages/plugins/plugin-mermaid/src/extensions/mermaid.stories.tsx
+++ b/packages/plugins/plugin-mermaid/src/extensions/mermaid.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 import React, { useMemo } from 'react';
 
 import { useThemeContext } from '@dxos/react-ui';

--- a/packages/plugins/plugin-navtree/src/components/HaloButton.stories.tsx
+++ b/packages/plugins/plugin-navtree/src/components/HaloButton.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/plugins/plugin-navtree/src/experimental/Tree.stories.tsx
+++ b/packages/plugins/plugin-navtree/src/experimental/Tree.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { House, List, Planet, PlusCircle, Sailboat } from '@phosphor-icons/react';
 import React, { type JSX, type PropsWithChildren, useEffect, useState } from 'react';

--- a/packages/plugins/plugin-navtree/src/stories/Graph.stories.tsx
+++ b/packages/plugins/plugin-navtree/src/stories/Graph.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { batch } from '@preact/signals-core';
 import React, { useMemo, useState } from 'react';

--- a/packages/plugins/plugin-presenter/src/components/Markdown/Container.stories.tsx
+++ b/packages/plugins/plugin-presenter/src/components/Markdown/Container.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type FC } from 'react';
 

--- a/packages/plugins/plugin-presenter/src/components/Markdown/Slide.stories.tsx
+++ b/packages/plugins/plugin-presenter/src/components/Markdown/Slide.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { Slide } from './Slide';
 import { createSlide } from '../../testing';

--- a/packages/plugins/plugin-presenter/src/components/Presenter/Pager.stories.tsx
+++ b/packages/plugins/plugin-presenter/src/components/Presenter/Pager.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type FC, useState } from 'react';
 

--- a/packages/plugins/plugin-presenter/src/components/Reveal.stories.tsx
+++ b/packages/plugins/plugin-presenter/src/components/Reveal.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/plugins/plugin-registry/src/components/Icon.stories.tsx
+++ b/packages/plugins/plugin-registry/src/components/Icon.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { IconBase, type IconWeight, GithubLogo, type IconProps } from '@phosphor-icons/react';
 import React, { forwardRef, type SVGProps, type ReactElement } from 'react';

--- a/packages/plugins/plugin-registry/src/components/PluginList.stories.tsx
+++ b/packages/plugins/plugin-registry/src/components/PluginList.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { Bug, Compass, GithubLogo, Kanban, Gear, Table } from '@phosphor-icons/react';
 import React, { useState } from 'react';

--- a/packages/plugins/plugin-sheet/src/components/CellEditor/CellEditor.stories.tsx
+++ b/packages/plugins/plugin-sheet/src/components/CellEditor/CellEditor.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { HyperFormula } from 'hyperformula';
 import React, { useEffect, useMemo, useState } from 'react';

--- a/packages/plugins/plugin-sheet/src/components/Sheet/Sheet.stories.tsx
+++ b/packages/plugins/plugin-sheet/src/components/Sheet/Sheet.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { type Decorator } from '@storybook/react';
 import React, { useContext, useEffect, useState } from 'react';

--- a/packages/plugins/plugin-sheet/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/plugins/plugin-sheet/src/components/Toolbar/Toolbar.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/plugins/plugin-sketch/src/components/Sketch/Sketch.stories.tsx
+++ b/packages/plugins/plugin-sketch/src/components/Sketch/Sketch.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { type SerializedStore } from '@tldraw/store';
 import { type TLRecord } from '@tldraw/tldraw';

--- a/packages/plugins/plugin-space/src/components/ShareSpaceButton.stories.tsx
+++ b/packages/plugins/plugin-space/src/components/ShareSpaceButton.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { withTheme } from '@dxos/storybook-utils';
 

--- a/packages/plugins/plugin-space/src/components/SpacePresence.stories.tsx
+++ b/packages/plugins/plugin-space/src/components/SpacePresence.stories.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { PublicKey } from '@dxos/keys';
 import { HaloSpaceMember, SpaceMember } from '@dxos/react-client/echo';

--- a/packages/plugins/plugin-status-bar/src/components/StatusBar.stories.tsx
+++ b/packages/plugins/plugin-status-bar/src/components/StatusBar.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { Mailbox, DiscordLogo, Lightning } from '@phosphor-icons/react';
 import React from 'react';

--- a/packages/plugins/plugin-table/src/components/ObjectTable/ObjectTable.stories.tsx
+++ b/packages/plugins/plugin-table/src/components/ObjectTable/ObjectTable.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useEffect, useState } from 'react';
 

--- a/packages/plugins/plugin-table/src/components/TableSettings/TableSettings.stories.tsx
+++ b/packages/plugins/plugin-table/src/components/TableSettings/TableSettings.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useEffect, useState } from 'react';
 

--- a/packages/plugins/plugin-thread/src/components/Chat.stories.tsx
+++ b/packages/plugins/plugin-thread/src/components/Chat.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useEffect, useState } from 'react';
 

--- a/packages/plugins/plugin-thread/src/components/Comments.stories.tsx
+++ b/packages/plugins/plugin-thread/src/components/Comments.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useEffect, useState } from 'react';
 

--- a/packages/plugins/plugin-wildcard/src/components/Wildcard.stories.tsx
+++ b/packages/plugins/plugin-wildcard/src/components/Wildcard.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { create } from '@dxos/react-client/echo';
 

--- a/packages/sdk/app-graph/src/stories/EchoGraph.stories.tsx
+++ b/packages/sdk/app-graph/src/stories/EchoGraph.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { Pause, Play, Plus, Timer } from '@phosphor-icons/react';
 import React, { useEffect, useState } from 'react';

--- a/packages/sdk/examples/src/main.tsx
+++ b/packages/sdk/examples/src/main.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { Airplane, Stack } from '@phosphor-icons/react';
 import React, { useState } from 'react';

--- a/packages/sdk/examples/src/stories/examples.stories.tsx
+++ b/packages/sdk/examples/src/stories/examples.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/sdk/examples/src/template/src/main.tsx
+++ b/packages/sdk/examples/src/template/src/main.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';

--- a/packages/sdk/react-client/src/client/ClientContext.stories.tsx
+++ b/packages/sdk/react-client/src/client/ClientContext.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2021 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { Component, type PropsWithChildren } from 'react';
 

--- a/packages/sdk/react-client/src/testing/decorators.stories.tsx
+++ b/packages/sdk/react-client/src/testing/decorators.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/sdk/shell/src/components/CompoundButton/CompoundButton.stories.tsx
+++ b/packages/sdk/shell/src/components/CompoundButton/CompoundButton.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { ArrowRight, ClockCounterClockwise } from '@phosphor-icons/react';
 import React, { type PropsWithChildren } from 'react';

--- a/packages/sdk/shell/src/components/IdentityList/SpaceMemberList.stories.tsx
+++ b/packages/sdk/shell/src/components/IdentityList/SpaceMemberList.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/sdk/shell/src/components/InvitationList/InvitationList.stories.tsx
+++ b/packages/sdk/shell/src/components/InvitationList/InvitationList.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/sdk/shell/src/components/Panel/Panel.stories.tsx
+++ b/packages/sdk/shell/src/components/Panel/Panel.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/sdk/shell/src/components/Viewport/Viewport.stories.tsx
+++ b/packages/sdk/shell/src/components/Viewport/Viewport.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/sdk/shell/src/index.ts
+++ b/packages/sdk/shell/src/index.ts
@@ -2,6 +2,6 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 export { runShell } from './composites';

--- a/packages/sdk/shell/src/panels/IdentityPanel/IdentityPanel.stories.tsx
+++ b/packages/sdk/shell/src/panels/IdentityPanel/IdentityPanel.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/sdk/shell/src/panels/JoinPanel/JoinPanel.stories.tsx
+++ b/packages/sdk/shell/src/panels/JoinPanel/JoinPanel.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/sdk/shell/src/panels/Panels.stories.tsx
+++ b/packages/sdk/shell/src/panels/Panels.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type FC } from 'react';
 

--- a/packages/sdk/shell/src/panels/SpacePanel/SpacePanel.stories.tsx
+++ b/packages/sdk/shell/src/panels/SpacePanel/SpacePanel.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/sdk/shell/src/stories/Invitations.e2e-stories.tsx
+++ b/packages/sdk/shell/src/stories/Invitations.e2e-stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { Laptop, Planet, Plus, PlusCircle, SignIn, QrCode, WifiHigh, WifiSlash } from '@phosphor-icons/react';
 import React, { useMemo, useState } from 'react';

--- a/packages/ui/brand/src/Icons.stories.tsx
+++ b/packages/ui/brand/src/Icons.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/brand/src/Logotypes.stories.tsx
+++ b/packages/ui/brand/src/Logotypes.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type FC, type ReactNode } from 'react';
 

--- a/packages/ui/brand/src/components/ComposerLogo/ComposerLogo.stories.tsx
+++ b/packages/ui/brand/src/components/ComposerLogo/ComposerLogo.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import '@fontsource/k2d/100-italic.css';
 

--- a/packages/ui/react-ui-attention/src/components/AttentionGlyph.stories.tsx
+++ b/packages/ui/react-ui-attention/src/components/AttentionGlyph.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui-card/src/components/Card.stories.tsx
+++ b/packages/ui/react-ui-card/src/components/Card.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { DndContext, type DragEndEvent } from '@dnd-kit/core';
 import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';

--- a/packages/ui/react-ui-deck/src/components/Deck/Deck.stories.tsx
+++ b/packages/ui/react-ui-deck/src/components/Deck/Deck.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.stories.tsx
+++ b/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { Chat, ImageSquare, StackSimple, TextAa } from '@phosphor-icons/react';
 import React from 'react';

--- a/packages/ui/react-ui-editor/src/InputMode.stories.tsx
+++ b/packages/ui/react-ui-editor/src/InputMode.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useState } from 'react';
 

--- a/packages/ui/react-ui-editor/src/TextEditor.stories.tsx
+++ b/packages/ui/react-ui-editor/src/TextEditor.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { markdown } from '@codemirror/lang-markdown';
 import { ArrowSquareOut, X } from '@phosphor-icons/react';

--- a/packages/ui/react-ui-editor/src/extensions/automerge/automerge.stories.tsx
+++ b/packages/ui/react-ui-editor/src/extensions/automerge/automerge.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import '@preact/signals-react';
 import React, { useEffect, useState } from 'react';

--- a/packages/ui/react-ui-mosaic/src/views/Demo/Demo.stories.tsx
+++ b/packages/ui/react-ui-mosaic/src/views/Demo/Demo.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui-mosaic/src/views/Grid/Grid.stories.tsx
+++ b/packages/ui/react-ui-mosaic/src/views/Grid/Grid.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui-mosaic/src/views/Kanban/Kanban.stories.tsx
+++ b/packages/ui/react-ui-mosaic/src/views/Kanban/Kanban.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui-mosaic/src/views/Stack/Columns.stories.tsx
+++ b/packages/ui/react-ui-mosaic/src/views/Stack/Columns.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui-mosaic/src/views/Stack/Stack.stories.tsx
+++ b/packages/ui/react-ui-mosaic/src/views/Stack/Stack.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui-mosaic/src/views/Tree/Graph.stories.tsx
+++ b/packages/ui/react-ui-mosaic/src/views/Tree/Graph.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 // import React from 'react';
 

--- a/packages/ui/react-ui-mosaic/src/views/Tree/Tree.stories.tsx
+++ b/packages/ui/react-ui-mosaic/src/views/Tree/Tree.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui-navtree/src/components/NavTree.stories.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTree.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useCallback, useState } from 'react';
 

--- a/packages/ui/react-ui-navtree/src/components/NavTreeItemAction.stories.tsx
+++ b/packages/ui/react-ui-navtree/src/components/NavTreeItemAction.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { type Meta } from '@storybook/react';
 import React from 'react';

--- a/packages/ui/react-ui-searchlist/src/components/SearchList.stories.tsx
+++ b/packages/ui/react-ui-searchlist/src/components/SearchList.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type FC } from 'react';
 

--- a/packages/ui/react-ui-searchlist/src/composites/PopoverCombobox.stories.tsx
+++ b/packages/ui/react-ui-searchlist/src/composites/PopoverCombobox.stories.tsx
@@ -3,6 +3,7 @@
 //
 
 import '@dxos-theme';
+
 import React from 'react';
 
 import { faker } from '@dxos/random';

--- a/packages/ui/react-ui-searchlist/src/composites/PopoverCombobox.stories.tsx
+++ b/packages/ui/react-ui-searchlist/src/composites/PopoverCombobox.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 import React from 'react';
 
 import { faker } from '@dxos/random';

--- a/packages/ui/react-ui-stack/src/components/ContentTypes.stories.tsx
+++ b/packages/ui/react-ui-stack/src/components/ContentTypes.stories.tsx
@@ -1,7 +1,9 @@
 //
 // Copyright 2024 DXOS.org
 //
+
 import '@dxos-theme';
+
 import React from 'react';
 
 import { faker } from '@dxos/random';

--- a/packages/ui/react-ui-stack/src/components/ContentTypes.stories.tsx
+++ b/packages/ui/react-ui-stack/src/components/ContentTypes.stories.tsx
@@ -1,7 +1,7 @@
 //
 // Copyright 2024 DXOS.org
 //
-import '@dxosTheme';
+import '@dxos-theme';
 import React from 'react';
 
 import { faker } from '@dxos/random';

--- a/packages/ui/react-ui-stack/src/components/Deck.stories.tsx
+++ b/packages/ui/react-ui-stack/src/components/Deck.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import {
   Books,

--- a/packages/ui/react-ui-stack/src/components/Section.stories.tsx
+++ b/packages/ui/react-ui-stack/src/components/Section.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui-stack/src/components/Stack.stories.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 // NOTE(thure): This unused import resolves the “likely not portable” TS error.
 // eslint-disable-next-line unused-imports/no-unused-imports

--- a/packages/ui/react-ui-table/src/components/ColumnMenu/ColumnMenu.stories.tsx
+++ b/packages/ui/react-ui-table/src/components/ColumnMenu/ColumnMenu.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { type SortDirection } from '@tanstack/react-table';
 import React, { useState } from 'react';

--- a/packages/ui/react-ui-table/src/components/ColumnMenu/ColumnSettingsForm.stories.tsx
+++ b/packages/ui/react-ui-table/src/components/ColumnMenu/ColumnSettingsForm.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 import React from 'react';
 
 import { withTheme } from '@dxos/storybook-utils';

--- a/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { Plugs, PlugsConnected } from '@phosphor-icons/react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';

--- a/packages/ui/react-ui-table/src/schema/SchemaToTable.stories.tsx
+++ b/packages/ui/react-ui-table/src/schema/SchemaToTable.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import * as Arbitrary from '@effect/schema/Arbitrary';
 import * as fc from 'fast-check';

--- a/packages/ui/react-ui-theme/src/plugin.ts
+++ b/packages/ui/react-ui-theme/src/plugin.ts
@@ -28,7 +28,7 @@ export const ThemePlugin = (
   const config: VitePluginTailwindOptions & Pick<typeof options, 'extensions'> = {
     jit: true,
     cssPath: resolve(__dirname, './theme.css'),
-    virtualFileId: '@dxos-theme', // TODO(burdon): Rename '@dxos-theme'?
+    virtualFileId: '@dxos-theme',
     ...options,
   };
 

--- a/packages/ui/react-ui-theme/src/plugin.ts
+++ b/packages/ui/react-ui-theme/src/plugin.ts
@@ -28,7 +28,7 @@ export const ThemePlugin = (
   const config: VitePluginTailwindOptions & Pick<typeof options, 'extensions'> = {
     jit: true,
     cssPath: resolve(__dirname, './theme.css'),
-    virtualFileId: '@dxosTheme', // TODO(burdon): Rename '@dxos-theme'?
+    virtualFileId: '@dxos-theme', // TODO(burdon): Rename '@dxos-theme'?
     ...options,
   };
 

--- a/packages/ui/react-ui-thread/src/Message/Message.stories.tsx
+++ b/packages/ui/react-ui-thread/src/Message/Message.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useState } from 'react';
 

--- a/packages/ui/react-ui-thread/src/Thread/Comments.stories.tsx
+++ b/packages/ui/react-ui-thread/src/Thread/Comments.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { Check, Trash } from '@phosphor-icons/react';
 import React, { type FC, useEffect, useMemo, useRef, useState } from 'react';

--- a/packages/ui/react-ui-thread/src/Thread/Thread.stories.tsx
+++ b/packages/ui/react-ui-thread/src/Thread/Thread.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { useMemo, useRef, useState } from 'react';
 

--- a/packages/ui/react-ui/src/components/Avatars/Avatar.stories.tsx
+++ b/packages/ui/react-ui/src/components/Avatars/Avatar.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type PropsWithChildren } from 'react';
 

--- a/packages/ui/react-ui/src/components/Avatars/AvatarGroup.stories.tsx
+++ b/packages/ui/react-ui/src/components/Avatars/AvatarGroup.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/ui/react-ui/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui/src/components/Buttons/Button.stories.tsx
+++ b/packages/ui/react-ui/src/components/Buttons/Button.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { CaretLeft, CaretRight } from '@phosphor-icons/react';
 import React, { type PropsWithChildren } from 'react';

--- a/packages/ui/react-ui/src/components/Buttons/Toggle.stories.tsx
+++ b/packages/ui/react-ui/src/components/Buttons/Toggle.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { TextB } from '@phosphor-icons/react';
 import React from 'react';

--- a/packages/ui/react-ui/src/components/Buttons/ToggleGroup.stories.tsx
+++ b/packages/ui/react-ui/src/components/Buttons/ToggleGroup.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { TextB, TextItalic } from '@phosphor-icons/react';
 import React from 'react';

--- a/packages/ui/react-ui/src/components/Dialogs/AlertDialog.stories.tsx
+++ b/packages/ui/react-ui/src/components/Dialogs/AlertDialog.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui/src/components/Dialogs/Dialog.stories.tsx
+++ b/packages/ui/react-ui/src/components/Dialogs/Dialog.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui/src/components/Input/Input.stories.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui/src/components/Link/Link.stories.tsx
+++ b/packages/ui/react-ui/src/components/Link/Link.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { Link } from './Link';
 import { withTheme } from '../../testing';

--- a/packages/ui/react-ui/src/components/Lists/List.stories.tsx
+++ b/packages/ui/react-ui/src/components/Lists/List.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { DndContext, type DragEndEvent, type DragStartEvent } from '@dnd-kit/core';
 import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';

--- a/packages/ui/react-ui/src/components/Lists/Tree.stories.tsx
+++ b/packages/ui/react-ui/src/components/Lists/Tree.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui/src/components/Main/Main.stories.tsx
+++ b/packages/ui/react-ui/src/components/Main/Main.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui/src/components/Menus/ContextMenu.stories.tsx
+++ b/packages/ui/react-ui/src/components/Menus/ContextMenu.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui/src/components/Menus/DropdownMenu.stories.tsx
+++ b/packages/ui/react-ui/src/components/Menus/DropdownMenu.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui/src/components/Message/Message.stories.tsx
+++ b/packages/ui/react-ui/src/components/Message/Message.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { Info } from '@phosphor-icons/react';
 import React from 'react';

--- a/packages/ui/react-ui/src/components/Popover/Popover.stories.tsx
+++ b/packages/ui/react-ui/src/components/Popover/Popover.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type PropsWithChildren, type ReactNode } from 'react';
 

--- a/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.stories.tsx
+++ b/packages/ui/react-ui/src/components/ScrollArea/ScrollArea.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type PropsWithChildren } from 'react';
 

--- a/packages/ui/react-ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/react-ui/src/components/Select/Select.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type FC, type PropsWithChildren, useState } from 'react';
 

--- a/packages/ui/react-ui/src/components/Status/Status.stories.tsx
+++ b/packages/ui/react-ui/src/components/Status/Status.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui/src/components/Tag/Tag.stories.tsx
+++ b/packages/ui/react-ui/src/components/Tag/Tag.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { Tag } from './Tag';
 import { withTheme } from '../../testing';

--- a/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
+++ b/packages/ui/react-ui/src/components/Toast/Toast.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type ReactNode, useState } from 'react';
 

--- a/packages/ui/react-ui/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/ui/react-ui/src/components/Toolbar/Toolbar.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { ArrowClockwise, Bug, FileJs, FileTs, TextB, TextItalic, TextUnderline } from '@phosphor-icons/react';
 import React from 'react';

--- a/packages/ui/react-ui/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/ui/react-ui/src/components/Tooltip/Tooltip.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui/src/playground/Controls.stories.tsx
+++ b/packages/ui/react-ui/src/playground/Controls.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import { FileTs, FileJs, ArrowClockwise, Bug, TextUnderline, TextB, TextItalic } from '@phosphor-icons/react';
 import React, { useState } from 'react';

--- a/packages/ui/react-ui/src/playground/Surfaces.stories.tsx
+++ b/packages/ui/react-ui/src/playground/Surfaces.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type PropsWithChildren } from 'react';
 

--- a/packages/ui/react-ui/src/playground/Typography.stories.tsx
+++ b/packages/ui/react-ui/src/playground/Typography.stories.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React from 'react';
 

--- a/packages/ui/react-ui/src/playground/helpers.tsx
+++ b/packages/ui/react-ui/src/playground/helpers.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import '@dxosTheme';
+import '@dxos-theme';
 
 import React, { type FunctionComponent } from 'react';
 


### PR DESCRIPTION
- follows on from fixing JSON imports for a bunch of stories and adding some "experiemntal" ux stories (i.e., gem).
