### PR TITLE
docs: standardize on `https://dxos.org/discord` for discord links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 contact_links:
   - name: Talk to us on Discord
-    url: https://discord.gg/eXVfryv3sW
+    url: https://dxos.org/discord
     about: General questions, feedback, and discussion
   - name: Report a security vulnerability
     url: mailto:security@dxos.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ We love your input. Please submit an issue for any of these reasons:
 - Proposing new features, ideas, or process
 
 Some of these other needs are not best handled by github issues:
-- Asking a question about something not working -> [Discord](https://discord.gg/eXVfryv3sW)
+
+- Asking a question about something not working -> [Discord](https://dxos.org/discord)
 - A security vulnerability or incident -> email `security@braneframe.com` directly. Do NOT post anywhere else please.
 
 ## Setting up a developer environment

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The DXOS SDK takes care of peer-to-peer collaboration for local-first apps witho
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 

--- a/docs/content/composer/README.md
+++ b/docs/content/composer/README.md
@@ -30,7 +30,7 @@ Here [device](../guide/glossary.md#device) means a running DXOS instance. One de
 ::: warning Technology Preview
 Composer is not yet ready for production. There are bugs, and breaking changes may occur. Migration guides will be provided for version updates in the [release notes](https://github.com/dxos/dxos/releases).
 
-All your feedback is most welcome on [Discord](https://discord.gg/eXVfryv3sW).
+All your feedback is most welcome on [Discord](https://dxos.org/discord).
 :::
 
 * To try composer see [Quick Start](./quick-start.md)

--- a/docs/content/composer/quick-start.md
+++ b/docs/content/composer/quick-start.md
@@ -8,7 +8,7 @@ headerDepth: 0
 ::: warning Technology Preview
 Composer is not yet ready for production. There are bugs, and breaking changes may occur. Migration guides will be provided for version updates in the [release notes](https://github.com/dxos/dxos/releases).
 
-All your feedback is most welcome on [Discord](https://discord.gg/eXVfryv3sW).
+All your feedback is most welcome on [Discord](https://dxos.org/discord).
 :::
 
 <a href="https://composer.space" class="button" target="_blank">Open Composer</a>

--- a/docs/content/composer/roadmap.md
+++ b/docs/content/composer/roadmap.md
@@ -58,6 +58,6 @@ Discovery and installation of plugins from a registry.
 
 ::: note Under Development
 
-Share your feature requests and feedback anytime on [Discord](https://discord.gg/eXVfryv3sW)!
+Share your feature requests and feedback anytime on [Discord](https://dxos.org/discord)!
 
 :::

--- a/docs/content/composer/user-guide/README.md
+++ b/docs/content/composer/user-guide/README.md
@@ -10,7 +10,7 @@ headerDepth: 0
 ::: warning Technology Preview
 Composer is not yet ready for production. There are bugs, and breaking changes may occur. Migration guides will be provided for version updates in the [release notes](https://github.com/dxos/dxos/releases).
 
-All your feedback is most welcome on [Discord](https://discord.gg/eXVfryv3sW).
+All your feedback is most welcome on [Discord](https://dxos.org/discord).
 :::
 
 ### What it is

--- a/docs/content/guide/README.md
+++ b/docs/content/guide/README.md
@@ -11,7 +11,7 @@ DXOS applications work offline, share state instantly when online, and leave end
 Composer is a collaborative productivity app where developers can build and organize knowledge, extend with custom data and UI, and run private AI against their knowledge locally.
 
 :::note
-DXOS is under development and will continue to change frequently.<br/>Your feedback is most welcome on [GitHub](https://github.com/dxos/dxos/issues) and [Discord](https://discord.gg/eXVfryv3sW). <br/>See our [Contribution Guide](https://github.com/dxos/dxos/blob/main/CONTRIBUTING.md) about contributing code.
+DXOS is under development and will continue to change frequently.<br/>Your feedback is most welcome on [GitHub](https://github.com/dxos/dxos/issues) and [Discord](https://dxos.org/discord). <br/>See our [Contribution Guide](https://github.com/dxos/dxos/blob/main/CONTRIBUTING.md) about contributing code.
 :::
 
 The DXOS SDK includes a key pair of technologies that work together:

--- a/docs/content/guide/composer-plugins/README.md
+++ b/docs/content/guide/composer-plugins/README.md
@@ -27,6 +27,6 @@ This will start your development server with a core set of plugins and the plugi
 
 The Composer Extensibility APIs are under active development. The API may change often, and these docs may not be accurate.
 
-Talk to us on [Discord](https://discord.gg/eXVfryv3sW) with feedback anytime.
+Talk to us on [Discord](https://dxos.org/discord) with feedback anytime.
 
 :::

--- a/docs/content/guide/composer-plugins/concepts.md
+++ b/docs/content/guide/composer-plugins/concepts.md
@@ -24,6 +24,6 @@ The Graph plugin provides a way to store and manipulate data in a graph structur
 
 The Composer Extensibility APIs are under active development. The API may change often, and these docs may not be accurate.
 
-Talk to us on [Discord](https://discord.gg/eXVfryv3sW) with feedback anytime.
+Talk to us on [Discord](https://dxos.org/discord) with feedback anytime.
 
 :::

--- a/docs/content/guide/composer-plugins/core.md
+++ b/docs/content/guide/composer-plugins/core.md
@@ -48,6 +48,6 @@ This plugin provides access to [DXOS](https://dxos.org) spaces.
 
 The Composer Extensibility APIs are under active development. The API may change often, and these docs may not be accurate.
 
-Talk to us on [Discord](https://discord.gg/eXVfryv3sW) with feedback anytime.
+Talk to us on [Discord](https://dxos.org/discord) with feedback anytime.
 
 :::

--- a/docs/content/guide/composer-plugins/definition.md
+++ b/docs/content/guide/composer-plugins/definition.md
@@ -116,6 +116,6 @@ const App = () => (
 
 The Composer Extensibility APIs are under active development. The API may change often, and these docs may not be accurate.
 
-Talk to us on [Discord](https://discord.gg/eXVfryv3sW) with feedback anytime.
+Talk to us on [Discord](https://dxos.org/discord) with feedback anytime.
 
 :::

--- a/docs/content/guide/composer-plugins/entry.md
+++ b/docs/content/guide/composer-plugins/entry.md
@@ -29,6 +29,6 @@ For example, the `Layout` plugin splits the screen into more Surfaces: a header,
 
 The Composer Extensibility APIs are under active development. The API may change often, and these docs may not be accurate.
 
-Talk to us on [Discord](https://discord.gg/eXVfryv3sW) with feedback anytime.
+Talk to us on [Discord](https://dxos.org/discord) with feedback anytime.
 
 :::

--- a/docs/content/guide/composer-plugins/graph.md
+++ b/docs/content/guide/composer-plugins/graph.md
@@ -10,6 +10,6 @@ The Graph is used to organize the user's content, provide a navigation structure
 
 The Composer Extensibility APIs are under active development. The API may change often, and these docs may not be accurate.
 
-Talk to us on [Discord](https://discord.gg/eXVfryv3sW) with feedback anytime.
+Talk to us on [Discord](https://dxos.org/discord) with feedback anytime.
 
 :::

--- a/docs/content/guide/composer-plugins/intent.md
+++ b/docs/content/guide/composer-plugins/intent.md
@@ -89,6 +89,6 @@ dispatch([
 
 The Composer Extensibility APIs are under active development. The API may change often, and these docs may not be accurate.
 
-Talk to us on [Discord](https://discord.gg/eXVfryv3sW) with feedback anytime.
+Talk to us on [Discord](https://dxos.org/discord) with feedback anytime.
 
 :::

--- a/docs/content/guide/composer-plugins/surface.md
+++ b/docs/content/guide/composer-plugins/surface.md
@@ -99,6 +99,6 @@ SurfaceProps are the props that are passed to the Surface component.
 
 The Composer Extensibility APIs are under active development. The API may change often, and these docs may not be accurate.
 
-Talk to us on [Discord](https://discord.gg/eXVfryv3sW) with feedback anytime.
+Talk to us on [Discord](https://dxos.org/discord) with feedback anytime.
 
 :::

--- a/docs/content/guide/contributing/README.md
+++ b/docs/content/guide/contributing/README.md
@@ -24,7 +24,7 @@ We love your input. Please submit an issue for any of these reasons:
 
 Some of these other needs are not best handled by github issues:
 
-* Asking a question about something not working -> [Discord](https://discord.gg/eXVfryv3sW)
+* Asking a question about something not working -> [Discord](https://dxos.org/discord)
 * A security vulnerability or incident -> email security@braneframe.com directly. do NOT post anywhere else please.
 
 ## Setting up a developer environment

--- a/docs/content/guide/echo/README.md
+++ b/docs/content/guide/echo/README.md
@@ -17,7 +17,7 @@ ECHO (The **E**ventually **C**onsistent **H**ierarchical **O**bject store) is a 
 * Support for offline writes and conflict resolution when peers rejoin the network.
 
 ::: note Tell us what you think
-Join our [Discord](https://discord.gg/eXVfryv3sW) and talk to us about the kind of database you are looking for.
+Join our [Discord](https://dxos.org/discord) and talk to us about the kind of database you are looking for.
 :::
 
 ## Spaces

--- a/docs/content/guide/echo/tutorial.md
+++ b/docs/content/guide/echo/tutorial.md
@@ -320,7 +320,7 @@ For more info on using DXOS, see:
 
 We hope you'll find the technology useful, and we welcome your ideas and contributions:
 
-* Join the DXOS [Discord](https://discord.gg/eXVfryv3sW)
+* Join the DXOS [Discord](https://dxos.org/discord)
 * DXOS [repository on GitHub](https://github.com/dxos/dxos)
 * File a bug or idea in [Issues](https://github.com/dxos/dxos/issues)
 

--- a/docs/content/guide/getting-started.md
+++ b/docs/content/guide/getting-started.md
@@ -206,7 +206,7 @@ For example, with [Netlify](https://netlify.com):
 
 We hope you'll find the technology useful, and we welcome your ideas and contributions:
 
-* Join the DXOS [Discord](https://discord.gg/eXVfryv3sW)
+* Join the DXOS [Discord](https://dxos.org/discord)
 * DXOS [repository on GitHub](https://github.com/dxos/dxos)
 * File a bug or idea in [Issues](https://github.com/dxos/dxos/issues)
 

--- a/packages/common/eslint-plugin-rules/README.md
+++ b/packages/common/eslint-plugin-rules/README.md
@@ -10,7 +10,7 @@ pnpm i @dxos/eslint-plugin-rules
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 

--- a/packages/common/eslint-plugin/README.md
+++ b/packages/common/eslint-plugin/README.md
@@ -10,7 +10,7 @@ pnpm i @dxos/eslint-plugin
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 

--- a/packages/plugins/plugin-status-bar/src/components/StatusBar.stories.tsx
+++ b/packages/plugins/plugin-status-bar/src/components/StatusBar.stories.tsx
@@ -27,7 +27,7 @@ export const Normal = (_props: any) => (
           <Mailbox />
           <StatusBar.Text>Quick feedback</StatusBar.Text>
         </StatusBar.Button>
-        <a href='https://discord.gg/' target='_blank' rel='noopener noreferrer'>
+        <a href='https://dxos.org/discord' target='_blank' rel='noopener noreferrer'>
           <StatusBar.Button>
             <DiscordLogo />
             <StatusBar.Text>Join us on Discord</StatusBar.Text>

--- a/packages/plugins/plugin-status-bar/src/components/StatusBarImpl.tsx
+++ b/packages/plugins/plugin-status-bar/src/components/StatusBarImpl.tsx
@@ -28,7 +28,7 @@ export const StatusBarImpl = () => {
           </Popover.Trigger>
           {/* TODO(zan): Configure this label? */}
           <StatusBar.Button aria-label='Open DXOS Discord' asChild>
-            <a href='https://discord.gg/zsxWrKjteV' target='_blank' rel='noopener noreferrer'>
+            <a href='https://dxos.org/discord' target='_blank' rel='noopener noreferrer'>
               <DiscordLogo />
               <StatusBar.Text classNames='hidden sm:block'>Discord</StatusBar.Text>
             </a>

--- a/tools/apidoc/README.md
+++ b/tools/apidoc/README.md
@@ -12,7 +12,7 @@ pnpm i @dxos/apidoc
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 

--- a/tools/conform/README.md
+++ b/tools/conform/README.md
@@ -22,7 +22,7 @@ pnpm nx dev conform
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 

--- a/tools/executors/esbuild/README.md
+++ b/tools/executors/esbuild/README.md
@@ -10,7 +10,7 @@ pnpm i @dxos/esbuild
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 

--- a/tools/executors/nx-protobuf-compiler/README.md
+++ b/tools/executors/nx-protobuf-compiler/README.md
@@ -10,7 +10,7 @@ pnpm i @dxos/protobuf-compiler
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 

--- a/tools/executors/serve-with-vault/README.md
+++ b/tools/executors/serve-with-vault/README.md
@@ -10,7 +10,7 @@ pnpm i @dxos/serve-with-vault
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 

--- a/tools/executors/test/README.md
+++ b/tools/executors/test/README.md
@@ -27,7 +27,7 @@ describe("Class", () => {
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 

--- a/tools/monitors/bare-template-monitor/README.md
+++ b/tools/monitors/bare-template-monitor/README.md
@@ -6,7 +6,7 @@ Used for testing releases by installing `@dxos/cli` from npm and verifying the b
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 

--- a/tools/monitors/cli-monitor/README.md
+++ b/tools/monitors/cli-monitor/README.md
@@ -6,7 +6,7 @@ Used for testing releases by installing `@dxos/cli` from npm and verifying it wo
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 

--- a/tools/monitors/hello-template-monitor/README.md
+++ b/tools/monitors/hello-template-monitor/README.md
@@ -6,7 +6,7 @@ Used for testing releases by installing `@dxos/cli` from npm and verifying the h
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 

--- a/tools/monitors/messaging-monitor/README.md
+++ b/tools/monitors/messaging-monitor/README.md
@@ -6,7 +6,7 @@ Used for testing releases by installing `@dxos/messaging` from npm and verifying
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 

--- a/tools/protobuf-test/README.md
+++ b/tools/protobuf-test/README.md
@@ -10,7 +10,7 @@ pnpm i @dxos/protobuf-test
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 

--- a/tools/x/README.md
+++ b/tools/x/README.md
@@ -12,7 +12,7 @@ pnpm i @dxos/x
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 


### PR DESCRIPTION
Previously we were using a mix of the `https://dxos.org/discord` redirect as well as specific links like `https://discord.gg/eXVfryv3sW`.