### PR TITLE
fix: Correct base foreground token is `baseText`

### DIFF
--- a/packages/experimental/plexus/style.css
+++ b/packages/experimental/plexus/style.css
@@ -9,5 +9,5 @@ html, body, #root {
 body {
   overscroll-behavior: none;
   overflow: hidden;
-  @apply font-body font-normal text-base;
+  @apply font-body font-normal text-baseText;
 }

--- a/packages/plugins/experimental/plugin-github/src/components/GithubEchoResolverProviders/SpacePickerTreeItem.tsx
+++ b/packages/plugins/experimental/plugin-github/src/components/GithubEchoResolverProviders/SpacePickerTreeItem.tsx
@@ -67,7 +67,7 @@ export const SpacePickerTreeItem = ({
           </TreeItem.OpenTrigger>
         )}
         <TreeItem.Heading
-          classNames='grow break-words pbs-1 text-base font-medium'
+          classNames='grow break-words pbs-1 text-baseText font-medium'
           data-testid='composer.spaceTreeItemHeading'
         >
           {Array.isArray(spaceDisplayName) ? t(...spaceDisplayName) : spaceDisplayName}

--- a/packages/plugins/plugin-navtree/src/components/CommandsTrigger.tsx
+++ b/packages/plugins/plugin-navtree/src/components/CommandsTrigger.tsx
@@ -25,9 +25,7 @@ export const CommandsTrigger = () => {
         })
       }
     >
-      <span className='text-description text-base font-normal grow text-start'>
-        {t('command list input placeholder')}
-      </span>
+      <span className='text-description font-normal grow text-start'>{t('command list input placeholder')}</span>
       <MagnifyingGlass className={getSize(5)} />
     </Button>
   );

--- a/packages/plugins/plugin-navtree/src/components/NavTreeFooter.tsx
+++ b/packages/plugins/plugin-navtree/src/components/NavTreeFooter.tsx
@@ -84,7 +84,7 @@ export const NavTreeFooter = (props: { layoutPart?: LayoutPart }) => {
                 </Link>
               </Message.Body>
             </Message.Root>
-            <div role='none' className='plb-4 pli-5 space-b-2 text-base'>
+            <div role='none' className='plb-4 pli-5 space-b-2 text-baseText'>
               {timestamp && (
                 <p>
                   {t('released message', {

--- a/packages/plugins/plugin-thread/src/components/CommentsContainer.tsx
+++ b/packages/plugins/plugin-thread/src/components/CommentsContainer.tsx
@@ -95,7 +95,7 @@ export const CommentsContainer = ({
             'place-self-center border border-dashed border-neutral-400/50 rounded-lg text-center p-4 m-4',
           )}
         >
-          <h2 className='mbe-2 font-medium text-base'>{t('no comments title')}</h2>
+          <h2 className='mbe-2 font-medium text-baseText'>{t('no comments title')}</h2>
           <p>
             <Trans
               {...{

--- a/packages/plugins/plugin-thread/src/components/command-extension.ts
+++ b/packages/plugins/plugin-thread/src/components/command-extension.ts
@@ -29,7 +29,7 @@ const parser = StreamLanguage.define<{ count: number }>({
 const styles = HighlightStyle.define([
   {
     tag: tags.tagName,
-    class: mx(tagRoot({ palette: 'cyan' }), 'text-base font-medium'),
+    class: mx(tagRoot({ palette: 'cyan' }), 'text-baseText font-medium'),
   },
 ]);
 

--- a/packages/ui/react-ui-editor/src/TextEditor.stories.tsx
+++ b/packages/ui/react-ui-editor/src/TextEditor.stories.tsx
@@ -212,7 +212,7 @@ const links = [
 const names = ['adam', 'alice', 'alison', 'bob', 'carol', 'charlie', 'sayuri', 'shoko'];
 
 const hover =
-  'rounded-sm text-base text-primary-600 hover:text-primary-500 dark:text-primary-300 hover:dark:text-primary-200';
+  'rounded-sm text-baseText text-primary-600 hover:text-primary-500 dark:text-primary-300 hover:dark:text-primary-200';
 
 const renderLinkTooltip = (el: Element, url: string) => {
   const web = new URL(url);

--- a/packages/ui/react-ui-table/src/components/Cell/CellCombobox.tsx
+++ b/packages/ui/react-ui-table/src/components/Cell/CellCombobox.tsx
@@ -68,7 +68,7 @@ export const CellCombobox = <TData extends RowData>({
           <>
             <span
               className={mx(
-                'font-normal text-start text-base flex-1 min-is-0 truncate mie-2',
+                'font-normal text-start text-baseText flex-1 min-is-0 truncate mie-2',
                 !value && staticPlaceholderText,
               )}
             >

--- a/packages/ui/react-ui-theme/src/styles/components/input.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/input.ts
@@ -88,7 +88,7 @@ const sharedSubduedInputStyles: ComponentFragment<InputStyleProps> = (props) => 
 ];
 
 const sharedDefaultInputStyles: ComponentFragment<InputStyleProps> = (props) => [
-  'is-full text-base rounded text-[color:var(--surface-text)]',
+  'is-full text-baseText rounded text-[color:var(--surface-text)]',
   textInputSurfaceFocus,
   placeholderText,
   props.density === 'fine' ? fineDimensions : coarseDimensions,
@@ -96,7 +96,7 @@ const sharedDefaultInputStyles: ComponentFragment<InputStyleProps> = (props) => 
 ];
 
 const sharedStaticInputStyles: ComponentFragment<InputStyleProps> = (props) => [
-  'is-full text-base rounded text-[color:var(--surface-text)]',
+  'is-full text-baseText rounded text-[color:var(--surface-text)]',
   textInputSurfaceFocus,
   textInputSurfaceHover,
   props.focused && 'bg-attention',

--- a/packages/ui/react-ui-theme/src/styles/components/message.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/message.ts
@@ -16,7 +16,7 @@ export const messageRoot: ComponentFunction<MessageStyleProps> = ({ valence, ele
   mx('p-3 rounded-md max-is-full overflow-auto', contentElevation({ elevation }), messageValence(valence), ...etc);
 
 export const messageTitle: ComponentFunction<MessageStyleProps> = (_props, ...etc) =>
-  mx('text-base font-medium mb-2', ...etc);
+  mx('text-baseText font-medium mb-2', ...etc);
 
 export const messageBody: ComponentFunction<MessageStyleProps> = (_props, ...etc) => mx(...etc);
 

--- a/packages/ui/react-ui-theme/src/styles/components/select.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/select.ts
@@ -26,7 +26,7 @@ export const selectContent: ComponentFunction<SelectStyleProps> = ({ elevation =
 export const selectItem: ComponentFunction<SelectStyleProps> = (_props, ...etc) =>
   mx(
     'relative flex items-center pis-6 pie-3 plb-1',
-    'text-base leading-none rounded-sm select-none outline-none',
+    'text-baseText leading-none rounded-sm select-none outline-none',
     ghostHighlighted,
     ...etc,
   );

--- a/packages/ui/react-ui/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/ui/react-ui/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -16,7 +16,7 @@ const StorybookBreadcrumb = () => {
       <Breadcrumb.List>
         <Breadcrumb.ListItem>
           <Breadcrumb.Link asChild>
-            <Button variant='ghost' density='fine' classNames='pli-0 text-base font-normal'>
+            <Button variant='ghost' density='fine' classNames='pli-0 text-baseText font-normal'>
               Grocery
             </Button>
           </Breadcrumb.Link>


### PR DESCRIPTION
This PR:
- resolves #7691.

<img width="755" alt="Screenshot 2024-09-10 at 11 06 03" src="https://github.com/user-attachments/assets/f4ea1895-56d5-4c5f-b207-d214a94a1e3c">
