### PR TITLE
fix(threads): bidirectional linking

### DIFF
--- a/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
@@ -107,7 +107,7 @@ export const MarkdownEditor = ({
         if (editorView && data?.id === id && data?.cursor) {
           // TODO(burdon): We need typed intents.
           const range = Cursor.getRangeFromCursor(editorView.state, data.cursor);
-          if (range?.from !== undefined) {
+          if (range) {
             const selection = editorView.state.selection.main.from !== range.from ? { anchor: range.from } : undefined;
             const effects = [
               // NOTE: This does not use the DOM scrollIntoView function.

--- a/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
@@ -107,7 +107,7 @@ export const MarkdownEditor = ({
         if (editorView && data?.id === id && data?.cursor) {
           // TODO(burdon): We need typed intents.
           const range = Cursor.getRangeFromCursor(editorView.state, data.cursor);
-          if (range?.from) {
+          if (range?.from !== undefined) {
             const selection = editorView.state.selection.main.from !== range.from ? { anchor: range.from } : undefined;
             const effects = [
               // NOTE: This does not use the DOM scrollIntoView function.


### PR DESCRIPTION
Bidirectional selection was broken when clicking threads in the side-bar when the start range of the comment was 0. 0 is falsy 🙄.
