### PR TITLE
chore: device invitation cleanup

### DIFF
--- a/packages/apps/composer-app/src/plugins/welcome/WelcomePlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/WelcomePlugin.tsx
@@ -94,7 +94,8 @@ export const WelcomePlugin = ({
       // If identity already exists, continue with existing identity.
       // If not, only create identity if token is present.
       let identity = client.halo.identity.get();
-      if (!identity && (token || skipAuth)) {
+      const deviceInvitationCode = searchParams.get('deviceInvitationCode');
+      if (!identity && !deviceInvitationCode && (token || skipAuth)) {
         const result = await dispatch({
           plugin: CLIENT_PLUGIN,
           action: ClientAction.CREATE_IDENTITY,

--- a/packages/common/react-async/src/useAsyncEffect.ts
+++ b/packages/common/react-async/src/useAsyncEffect.ts
@@ -29,8 +29,9 @@ import { useEffect } from 'react';
  * @param callback Receives a getter function that determines if the component is still mounted.
  * @param destructor Receives the value returned from the callback.
  * @param deps
+ *
+ * @deprecated Use `setTimeout` instead.
  */
-// TODO(burdon): Move to @dxos/react-ui.
 export const useAsyncEffect = <T>(
   callback: (isMounted: () => boolean) => Promise<T> | undefined,
   destructor?: ((value?: T) => void) | any[],

--- a/packages/sdk/shell/src/composites/Shell/Shell.tsx
+++ b/packages/sdk/shell/src/composites/Shell/Shell.tsx
@@ -38,7 +38,7 @@ export const Shell = ({ runtime }: { runtime: ShellRuntime }) => {
     });
 
   const client = useClient();
-  const space = useSpace(spaceKey ?? spaceId);
+  const space = useSpace(spaceId ?? spaceKey);
 
   const createDeviceInvitationUrl = (invitationCode: string) => {
     const baseUrl = new URL(invitationUrl);

--- a/packages/ui/primitives/react-input/src/PinInput.tsx
+++ b/packages/ui/primitives/react-input/src/PinInput.tsx
@@ -25,7 +25,7 @@ const PinInput = forwardRef<HTMLInputElement, PinInputProps>(
       __inputScope,
       segmentClassName,
       inputClassName,
-      segmentPadding = '13px',
+      segmentPadding = '8px',
       segmentHeight = '100%',
       ...props
     }: InputScopedProps<PinInputProps>,


### PR DESCRIPTION
- don't create identity during dev if device invitation exists
- [x] fix pin input rendering

<img width="646" alt="Screenshot 2024-09-20 at 13 37 05" src="https://github.com/user-attachments/assets/da8655a8-fe65-4add-a316-792e00d4d444">
