### PR TITLE
fix: Codemirror task list indentation

### DIFF
--- a/packages/ui/react-ui-editor/src/TextEditor.stories.tsx
+++ b/packages/ui/react-ui-editor/src/TextEditor.stories.tsx
@@ -261,9 +261,11 @@ const renderLinkButton = (el: Element, url: string) => {
 // Story
 //
 
+type DebugMode = 'syntax' | 'raw';
+
 type StoryProps = {
   id?: string;
-  debug?: boolean;
+  debug?: DebugMode;
   text?: string;
   readonly?: boolean;
   placeholder?: string;
@@ -318,7 +320,12 @@ const Story = ({
   return (
     <div className='flex w-full'>
       <div role='none' className='flex w-full overflow-hidden' ref={parentRef} {...focusAttributes} />
-      {debug && (
+      {debug === 'raw' && (
+        <div className='w-[800px] border-l border-separator overflow-auto'>
+          <pre className='p-1 font-mono text-xs text-green-800 dark:text-green-200'>{view?.state.doc.toString()}</pre>
+        </div>
+      )}
+      {debug === 'syntax' && (
         <div className='w-[800px] border-l border-separator overflow-auto'>
           <pre className='p-1 font-mono text-xs text-green-800 dark:text-green-200'>
             {JSON.stringify(tree, null, 2)}
@@ -466,7 +473,7 @@ export const OrderedList = {
 };
 
 export const TaskList = {
-  render: () => <Story text={str(content.tasks, content.footer)} extensions={[decorateMarkdown()]} debug />,
+  render: () => <Story text={str(content.tasks, content.footer)} extensions={[decorateMarkdown()]} debug='raw' />,
 };
 
 export const Table = {


### PR DESCRIPTION
- [x] Fixes task list indentation.
- [x] Make key nav through hidden decorations smoother (cannot step into tasks, and now one cursor step from start of bullet back to previous one)

New debug modes:

<img width="1265" alt="Screenshot 2024-09-20 at 8 56 08 PM" src="https://github.com/user-attachments/assets/c8f62d7c-dc84-41da-a742-77461aba450f">

<img width="1265" alt="Screenshot 2024-09-20 at 8 55 50 PM" src="https://github.com/user-attachments/assets/1d2420e9-7910-47c7-8e13-9ef42d3ddd26">
