### PR TITLE
fix: SearchList colors

### DIFF
--- a/packages/ui/react-ui-searchlist/src/components/SearchList.tsx
+++ b/packages/ui/react-ui-searchlist/src/components/SearchList.tsx
@@ -138,11 +138,7 @@ const SearchListItem = forwardRef<HTMLDivElement, SearchListItemProps>(
       <CommandItem
         {...props}
         onSelect={handleSelect}
-        className={mx(
-          'p-1 rounded select-none cursor-pointer',
-          'data-[selected]:bg-neutral-450/10 data-[selected]:hover:bg-25/10',
-          classNames,
-        )}
+        className={mx('p-1 rounded select-none cursor-pointer data-[selected]:bg-hoverOverlay', classNames)}
         ref={forwardedRef}
       >
         {children}

--- a/packages/ui/react-ui-theme/src/config/tokens/sememes-system.ts
+++ b/packages/ui/react-ui-theme/src/config/tokens/sememes-system.ts
@@ -58,7 +58,10 @@ export const systemSememes = {
     light: ['primary', 600],
     dark: ['primary', 475],
   },
-
+  hoverOverlay: {
+    light: ['neutral', '450/.1'],
+    dark: ['neutral', '450/.1'],
+  },
   //
   // Borders (border-, divide-)
   //


### PR DESCRIPTION
This PR:
- fixes SearchList colors
  - adds a new token `hoverOverlay`
  - replaces nonfunctioning classnames with one that uses `hoverOverlay`

<img width="763" alt="Screenshot 2024-09-23 at 10 50 25" src="https://github.com/user-attachments/assets/2dc96d1a-f7d2-4470-8342-3a06edae3f99">
