### PR TITLE
refactor: pass undefined as empty query options param

### DIFF
--- a/packages/plugins/plugin-table/src/components/ObjectTable/hooks/useTableObjects.ts
+++ b/packages/plugins/plugin-table/src/components/ObjectTable/hooks/useTableObjects.ts
@@ -6,14 +6,6 @@ import { type EchoReactiveObject, type S } from '@dxos/echo-schema';
 import { useGlobalFilteredObjects } from '@dxos/plugin-search';
 import { type Space, useQuery, Filter } from '@dxos/react-client/echo';
 
-// TODO(Zan): Consolidate.
-const Stable = {
-  empty: {
-    object: Object.freeze({}),
-    array: Object.freeze([] as any[]),
-  },
-};
-
 /**
  * Retrieves objects for a given schema and filters them using a global filter.
  *
@@ -26,7 +18,7 @@ export const useTableObjects = (space?: Space, schema?: S.Schema<any>) => {
   const objects = useQuery<EchoReactiveObject<any>>(
     space,
     schema ? Filter.schema(schema) : () => false,
-    Stable.empty.object,
+    undefined,
     // TODO(burdon): Toggle deleted.
     [schema],
   );


### PR DESCRIPTION
Trivial change, but making this code idiomatic is helpful since it will appear in a blog post.