### PR TITLE
fix: Source maps for production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "react": "~18.2.0",
     "react-dom": "~18.2.0",
     "rollup": "^3.20.4",
+    "rollup-plugin-sourcemaps": "^0.6.3",
     "semver": "^7.3.8",
     "serve": "^14.1.2",
     "syncpack": "^8.2.4",

--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -6,6 +6,7 @@ import { sentryVitePlugin } from '@sentry/vite-plugin';
 import ReactPlugin from '@vitejs/plugin-react-swc';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import sourceMaps from 'rollup-plugin-sourcemaps';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig, searchForWorkspaceRoot } from 'vite';
 import Inspect from 'vite-plugin-inspect';

--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -10,7 +10,6 @@ import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig, searchForWorkspaceRoot } from 'vite';
 import Inspect from 'vite-plugin-inspect';
 import { VitePWA } from 'vite-plugin-pwa';
-import TopLevelAwaitPlugin from 'vite-plugin-top-level-await';
 import WasmPlugin from 'vite-plugin-wasm';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
@@ -28,7 +27,7 @@ const isTrue = (str?: string) => str === 'true' || str === '1';
 const isFalse = (str?: string) => str === 'false' || str === '0';
 
 // https://vitejs.dev/config
-export default defineConfig({
+export default defineConfig((env) => ({
   test: baseConfig()['test'],
   server: {
     host: true,
@@ -49,9 +48,13 @@ export default defineConfig({
       ],
     },
   },
+  esbuild: {
+    keepNames: true,
+  },
   build: {
     sourcemap: true,
     minify: !isFalse(process.env.DX_MINIFY),
+    target: ['chrome89', 'edge89', 'firefox89', 'safari15'],
     rollupOptions: {
       // NOTE: Set cache to fix to help debug flaky builds.
       // cache: false,
@@ -81,13 +84,15 @@ export default defineConfig({
   },
   worker: {
     format: 'es',
-    plugins: () => [TopLevelAwaitPlugin(), WasmPlugin()],
+    plugins: () => [WasmPlugin()],
   },
   plugins: [
+    sourceMaps(),
     // TODO(wittjosiah): Causing issues with bundle.
-    tsconfigPaths({
-      projects: ['../../../tsconfig.paths.json'],
-    }),
+    env.command === 'serve' &&
+      tsconfigPaths({
+        projects: ['../../../tsconfig.paths.json'],
+      }),
     ConfigPlugin(),
     ThemePlugin({
       root: __dirname,
@@ -115,7 +120,6 @@ export default defineConfig({
     // https://github.com/antfu-collective/vite-plugin-inspect#readme
     // localhost:5173/__inspect
     isTrue(process.env.DX_INSPECT) && Inspect(),
-    TopLevelAwaitPlugin(),
     WasmPlugin(),
     // https://github.com/preactjs/signals/issues/269
     ReactPlugin({
@@ -241,7 +245,7 @@ export default defineConfig({
         ]
       : []),
   ], // Plugins
-});
+}));
 
 /**
  * Generate nicer chunk names.

--- a/packages/apps/testbench-app/vite.config.ts
+++ b/packages/apps/testbench-app/vite.config.ts
@@ -16,103 +16,107 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 import { UserConfig } from 'vitest/config';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  server: {
-    host: true,
-    cors: true,
-    // Set isolation to enable performance.measureUserAgentSpecificMemory
-    // https://web.dev/articles/coop-coep
-    headers: {
-      'Cross-Origin-Embedder-Policy': 'require-corp',
-      'Cross-Origin-Opener-Policy': 'same-origin',
-    },
-    https:
-      process.env.HTTPS === 'true'
-        ? {
-            key: './key.pem',
-            cert: './cert.pem',
-          }
-        : undefined,
-    fs: {
-      strict: false,
-      allow: [
-        // TODO(wittjosiah): Not detecting pnpm-workspace?
-        //  https://vitejs.dev/config/server-options.html#server-fs-allow
-        searchForWorkspaceRoot(process.cwd()),
-      ],
-    },
-  },
-  esbuild: {
-    keepNames: true,
-  },
-  build: {
-    sourcemap: true,
-    minify: false,
-    target: ['chrome89', 'edge89', 'firefox89', 'safari15'],
-    rollupOptions: {
-      input: {
-        main: resolve(__dirname, './index.html'),
-        shell: resolve(__dirname, './shell.html'),
-      },
-      output: {
-        manualChunks: {
-          react: ['react', 'react-dom', 'react-router-dom'],
-          dxos: ['@dxos/react-client'],
-          ui: ['@dxos/react-ui', '@dxos/react-ui-theme'],
-          editor: ['@dxos/react-ui-editor'],
+export default defineConfig(
+  (env) =>
+    ({
+      server: {
+        host: true,
+        cors: true,
+        // Set isolation to enable performance.measureUserAgentSpecificMemory
+        // https://web.dev/articles/coop-coep
+        headers: {
+          'Cross-Origin-Embedder-Policy': 'require-corp',
+          'Cross-Origin-Opener-Policy': 'same-origin',
+        },
+        https:
+          process.env.HTTPS === 'true'
+            ? {
+                key: './key.pem',
+                cert: './cert.pem',
+              }
+            : undefined,
+        fs: {
+          strict: false,
+          allow: [
+            // TODO(wittjosiah): Not detecting pnpm-workspace?
+            //  https://vitejs.dev/config/server-options.html#server-fs-allow
+            searchForWorkspaceRoot(process.cwd()),
+          ],
         },
       },
-    },
-  },
-  worker: {
-    format: 'es',
-    plugins: () => [WasmPlugin(), sourceMaps()],
-  },
-  plugins: [
-    sourceMaps(),
-    tsconfigPaths({
-      projects: ['../../../tsconfig.paths.json'],
-    }),
-    ConfigPlugin({
-      env: ['DX_VAULT', 'BASELIME_API_KEY'],
-    }),
-    ThemePlugin({
-      root: __dirname,
-      content: [resolve(__dirname, './index.html'), resolve(__dirname, './src/**/*.{js,ts,jsx,tsx}')],
-    }),
-    WasmPlugin(),
-    // https://github.com/preactjs/signals/issues/269
-    ReactPlugin({ jsxRuntime: 'classic' }),
-    // https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/vite
-    // https://www.npmjs.com/package/@sentry/vite-plugin
-    // sentryVitePlugin({
-    //   org: 'dxos',
-    //   project: 'testbench-app',
-    //   sourcemaps: {
-    //     assets: './packages/apps/testbench-app/out/testbench-app/**',
-    //   },
-    //   authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN,
-    //   disable: process.env.DX_ENVIRONMENT !== 'production',
-    // }),
-    // https://www.bundle-buddy.com/rollup
-    {
-      name: 'bundle-buddy',
-      buildEnd() {
-        const deps: { source: string; target: string }[] = [];
-        for (const id of this.getModuleIds()) {
-          const m = this.getModuleInfo(id);
-          if (m != null && !m.isExternal) {
-            for (const target of m.importedIds) {
-              deps.push({ source: m.id, target });
-            }
-          }
-        }
-        const outDir = join(__dirname, 'out');
-        if (!existsSync(outDir)) {
-          mkdirSync(outDir);
-        }
-        writeFileSync(join(outDir, 'graph.json'), JSON.stringify(deps, null, 2));
+      esbuild: {
+        keepNames: true,
       },
-    },
-  ],
-} as UserConfig);
+      build: {
+        sourcemap: true,
+        minify: false,
+        target: ['chrome89', 'edge89', 'firefox89', 'safari15'],
+        rollupOptions: {
+          input: {
+            main: resolve(__dirname, './index.html'),
+            shell: resolve(__dirname, './shell.html'),
+          },
+          output: {
+            manualChunks: {
+              react: ['react', 'react-dom', 'react-router-dom'],
+              dxos: ['@dxos/react-client'],
+              ui: ['@dxos/react-ui', '@dxos/react-ui-theme'],
+              editor: ['@dxos/react-ui-editor'],
+            },
+          },
+        },
+      },
+      worker: {
+        format: 'es',
+        plugins: () => [WasmPlugin(), sourceMaps()],
+      },
+      plugins: [
+        sourceMaps(),
+        env.command === 'serve' &&
+          tsconfigPaths({
+            projects: ['../../../tsconfig.paths.json'],
+          }),
+        ConfigPlugin({
+          env: ['DX_VAULT', 'BASELIME_API_KEY'],
+        }),
+        ThemePlugin({
+          root: __dirname,
+          content: [resolve(__dirname, './index.html'), resolve(__dirname, './src/**/*.{js,ts,jsx,tsx}')],
+        }),
+        WasmPlugin(),
+        // https://github.com/preactjs/signals/issues/269
+        ReactPlugin({ jsxRuntime: 'classic' }),
+        // https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/vite
+        // https://www.npmjs.com/package/@sentry/vite-plugin
+        // sentryVitePlugin({
+        //   org: 'dxos',
+        //   project: 'testbench-app',
+        //   sourcemaps: {
+        //     assets: './packages/apps/testbench-app/out/testbench-app/**',
+        //   },
+        //   authToken: process.env.SENTRY_RELEASE_AUTH_TOKEN,
+        //   disable: process.env.DX_ENVIRONMENT !== 'production',
+        // }),
+        // https://www.bundle-buddy.com/rollup
+        {
+          name: 'bundle-buddy',
+          buildEnd() {
+            const deps: { source: string; target: string }[] = [];
+            for (const id of this.getModuleIds()) {
+              const m = this.getModuleInfo(id);
+              if (m != null && !m.isExternal) {
+                for (const target of m.importedIds) {
+                  deps.push({ source: m.id, target });
+                }
+              }
+            }
+            const outDir = join(__dirname, 'out');
+            if (!existsSync(outDir)) {
+              mkdirSync(outDir);
+            }
+            writeFileSync(join(outDir, 'graph.json'), JSON.stringify(deps, null, 2));
+          },
+        },
+      ],
+    }) as UserConfig,
+);

--- a/packages/apps/testbench-app/vite.config.ts
+++ b/packages/apps/testbench-app/vite.config.ts
@@ -4,10 +4,10 @@
 
 // import { sentryVitePlugin } from '@sentry/vite-plugin';
 import ReactPlugin from '@vitejs/plugin-react';
-import { join, resolve } from 'node:path';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import sourceMaps from 'rollup-plugin-sourcemaps';
 import { defineConfig, searchForWorkspaceRoot } from 'vite';
-import TopLevelAwaitPlugin from 'vite-plugin-top-level-await';
 import WasmPlugin from 'vite-plugin-wasm';
 
 import { ConfigPlugin } from '@dxos/config/vite-plugin';
@@ -42,9 +42,13 @@ export default defineConfig({
       ],
     },
   },
+  esbuild: {
+    keepNames: true,
+  },
   build: {
     sourcemap: true,
     minify: false,
+    target: ['chrome89', 'edge89', 'firefox89', 'safari15'],
     rollupOptions: {
       input: {
         main: resolve(__dirname, './index.html'),
@@ -62,9 +66,10 @@ export default defineConfig({
   },
   worker: {
     format: 'es',
-    plugins: () => [TopLevelAwaitPlugin(), WasmPlugin()],
+    plugins: () => [WasmPlugin(), sourceMaps()],
   },
   plugins: [
+    sourceMaps(),
     tsconfigPaths({
       projects: ['../../../tsconfig.paths.json'],
     }),
@@ -75,7 +80,6 @@ export default defineConfig({
       root: __dirname,
       content: [resolve(__dirname, './index.html'), resolve(__dirname, './src/**/*.{js,ts,jsx,tsx}')],
     }),
-    TopLevelAwaitPlugin(),
     WasmPlugin(),
     // https://github.com/preactjs/signals/issues/269
     ReactPlugin({ jsxRuntime: 'classic' }),
@@ -103,7 +107,6 @@ export default defineConfig({
             }
           }
         }
-
         const outDir = join(__dirname, 'out');
         if (!existsSync(outDir)) {
           mkdirSync(outDir);

--- a/packages/common/keys/src/dxn.ts
+++ b/packages/common/keys/src/dxn.ts
@@ -58,7 +58,7 @@ export class DXN {
     switch (kind) {
       case DXN.kind.ECHO:
         if (parts.length !== 2) {
-          throw new Error(`Invalid "echo" DXN`);
+          throw new Error('Invalid "echo" DXN');
         }
         break;
       case DXN.kind.TYPE:

--- a/packages/common/keys/src/dxn.ts
+++ b/packages/common/keys/src/dxn.ts
@@ -57,10 +57,14 @@ export class DXN {
     // Per-type validation.
     switch (kind) {
       case DXN.kind.ECHO:
-        invariant(parts.length === 2);
+        if (parts.length !== 2) {
+          throw new Error(`Invalid "echo" DXN`);
+        }
         break;
       case DXN.kind.TYPE:
-        invariant(parts.length === 1);
+        if (parts.length !== 1) {
+          throw new Error('Invalid "type" DXN');
+        }
         break;
     }
 

--- a/packages/core/echo/echo-db/src/core-db/core-database.ts
+++ b/packages/core/echo/echo-db/src/core-db/core-database.ts
@@ -245,6 +245,10 @@ export class CoreDatabase {
   }
 
   getObjectCoreById(id: string, { load = true }: GetObjectCoreByIdOptions = {}): ObjectCore | undefined {
+    if (!this._automergeDocLoader.hasRootHandle) {
+      throw new Error('Database is not ready.');
+    }
+
     const objCore = this._objects.get(id);
     if (load && !objCore) {
       this._automergeDocLoader.loadObjectDocument(id);
@@ -273,6 +277,10 @@ export class CoreDatabase {
     objectIds: string[],
     { inactivityTimeout = 30000, returnDeleted = false }: { inactivityTimeout?: number; returnDeleted?: boolean } = {},
   ): Promise<(ObjectCore | undefined)[]> {
+    if (!this._automergeDocLoader.hasRootHandle) {
+      throw new Error('Database is not ready.');
+    }
+
     const result: (ObjectCore | undefined)[] = new Array(objectIds.length);
     const objectsToLoad: Array<{ id: string; resultIndex: number }> = [];
     for (let i = 0; i < objectIds.length; i++) {

--- a/packages/core/echo/echo-db/src/testing/integration.test.ts
+++ b/packages/core/echo/echo-db/src/testing/integration.test.ts
@@ -341,7 +341,7 @@ describe('load tests', () => {
 
   const NUM_OBJECTS = 100;
 
-  test('replication', async () => {
+  test('replication', { timeout: 20_000 }, async () => {
     const [spaceKey] = PublicKey.randomSequence();
     await using network = await new TestReplicationNetwork().open();
     const dataAssertion = createDataAssertion({ numObjects: NUM_OBJECTS });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,6 +319,9 @@ importers:
       rollup:
         specifier: ^3.20.4
         version: 3.23.0
+      rollup-plugin-sourcemaps:
+        specifier: ^0.6.3
+        version: 0.6.3(@types/node@22.6.1)(rollup@3.23.0)
       semver:
         specifier: ^7.3.8
         version: 7.5.4
@@ -3992,7 +3995,7 @@ importers:
         version: 18.2.0
       react-charts:
         specifier: beta
-        version: 3.0.0-beta.55(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 3.0.0-beta.57(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-dom:
         specifier: ~18.2.0
         version: 18.2.0(react@18.2.0)
@@ -18458,6 +18461,7 @@ packages:
 
   '@socketsupply/socket@0.5.4':
     resolution: {integrity: sha512-8sDIEL5cyFI4jlpZYUL4JqSgkj1XjUlbi9kA16/5DfzAYefQx38QXQaI0Hj7G1T3WwPnKN8f9xLvESMHikysrA==}
+    cpu: [arm64, x64]
     os: [linux, darwin, win32]
     hasBin: true
 
@@ -19811,6 +19815,9 @@ packages:
   '@types/node@20.14.2':
     resolution: {integrity: sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==}
 
+  '@types/node@22.5.5':
+    resolution: {integrity: sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==}
+
   '@types/node@22.6.1':
     resolution: {integrity: sha512-V48tCfcKb/e6cVUigLAaJDAILdMP0fUW6BidkPK4GpGjXcfbnoHasCZDwz3N3yVt5we2RHm4XTQCpv0KJz9zqw==}
 
@@ -20691,6 +20698,11 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -20822,6 +20834,7 @@ packages:
   are-we-there-yet@2.0.0:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
@@ -20986,6 +20999,11 @@ packages:
   at-least-node@1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
+
+  atob@2.1.2:
+    resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
+    engines: {node: '>= 4.5.0'}
+    hasBin: true
 
   atomic-batcher@1.0.2:
     resolution: {integrity: sha512-EFGCRj4kLX1dHv1cDzTk+xbjBFj1GnJDpui52YmEcxxHHEWjYyT6l51U7n6WQ28osZH4S9gSybxe56Vm7vB61Q==}
@@ -22760,6 +22778,10 @@ packages:
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
 
+  decode-uri-component@0.2.2:
+    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
+    engines: {node: '>=0.10'}
+
   decompress-response@4.2.1:
     resolution: {integrity: sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==}
     engines: {node: '>=8'}
@@ -24300,6 +24322,7 @@ packages:
   gauge@3.0.2:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   gaxios@5.1.3:
     resolution: {integrity: sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==}
@@ -27643,6 +27666,7 @@ packages:
 
   npmlog@5.0.1:
     resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
+    deprecated: This package is no longer supported.
 
   nth-check@1.0.2:
     resolution: {integrity: sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==}
@@ -28904,8 +28928,8 @@ packages:
   react-base16-styling@0.9.1:
     resolution: {integrity: sha512-1s0CY1zRBOQ5M3T61wetEpvQmsYSNtWEcdYzyZNxKa8t7oDvaOn9d21xrGezGAHFWLM7SHcktPuPTrvoqxSfKw==}
 
-  react-charts@3.0.0-beta.55:
-    resolution: {integrity: sha512-PuPGoK/3B4SgmnANqh1+biuJAN/iYAvLO/juLKJ2dtF0+Wzfa0KarGbgAij2o8P83bAn9bZnu46RCevNvYwOjQ==}
+  react-charts@3.0.0-beta.57:
+    resolution: {integrity: sha512-vqas7IQhsnDGcMxreGaWXvSIL3poEMoUBNltJrslz/+m0pI3QejBCszL1QrLNYQfOWXrbZADfedi/a+yWOQ7Hw==}
     peerDependencies:
       react: ~18.2.0
       react-dom: ~18.2.0
@@ -29554,6 +29578,7 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   ripemd160@2.0.2:
@@ -29572,6 +29597,16 @@ packages:
 
   rollup-plugin-node-polyfills@0.2.1:
     resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
+
+  rollup-plugin-sourcemaps@0.6.3:
+    resolution: {integrity: sha512-paFu+nT1xvuO1tPFYXGe+XnQvg4Hjqv/eIhG8i5EspfYYPBKL57X7iVbfv55aNVASg3dzWvES9dmWsL2KhfByw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      '@types/node': '>=10.0.0'
+      rollup: '>=0.31.2'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   rollup-plugin-terser@7.0.2:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
@@ -30091,6 +30126,10 @@ packages:
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       webpack: ^5.72.1
+
+  source-map-resolve@0.6.0:
+    resolution: {integrity: sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==}
+    deprecated: See https://github.com/lydell/source-map-resolve#deprecated
 
   source-map-support@0.5.19:
     resolution: {integrity: sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==}
@@ -30671,6 +30710,7 @@ packages:
 
   three-mesh-bvh@0.7.8:
     resolution: {integrity: sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw==}
+    deprecated: Deprecated due to three.js version incompatibility. Please use v0.8.0, instead.
     peerDependencies:
       three: '>= 0.151.0'
 
@@ -37796,21 +37836,6 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/js@19.7.2(@babel/traverse@7.24.8)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.6.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.6.1)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.6.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.4.5)':
-    dependencies:
-      '@nx/js': 19.7.2(patch_hash=mavp33mumclr54vvfyyf557nvq)(@babel/traverse@7.24.8)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.6.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.6.1)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.6.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.4.5)
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@swc-node/register'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - debug
-      - nx
-      - supports-color
-      - typescript
-      - verdaccio
-
   '@nrwl/js@19.7.2(@babel/traverse@7.24.8)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.6.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.6.1)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.6.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.6.2)':
     dependencies:
       '@nx/js': 19.7.2(patch_hash=mavp33mumclr54vvfyyf557nvq)(@babel/traverse@7.24.8)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.6.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.6.1)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.6.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.6.2)
@@ -38049,7 +38074,7 @@ snapshots:
       '@babel/preset-env': 7.24.8(@babel/core@7.24.6)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.24.6)
       '@babel/runtime': 7.24.5
-      '@nrwl/js': 19.7.2(@babel/traverse@7.24.8)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.6.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.6.1)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.6.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.4.5)
+      '@nrwl/js': 19.7.2(@babel/traverse@7.24.8)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.6.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.6.1)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.6.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.6.2)
       '@nx/devkit': 19.7.2(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.6.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))
       '@nx/workspace': 19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.6.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))
       babel-plugin-const-enum: 1.2.0(@babel/core@7.24.6)
@@ -41166,6 +41191,13 @@ snapshots:
       picomatch: 2.3.1
       rollup: 2.79.1
 
+  '@rollup/pluginutils@3.1.0(rollup@3.23.0)':
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      picomatch: 2.3.1
+      rollup: 3.23.0
+
   '@rollup/pluginutils@4.2.1':
     dependencies:
       estree-walker: 2.0.2
@@ -43381,7 +43413,7 @@ snapshots:
 
   '@types/http-proxy@1.17.15':
     dependencies:
-      '@types/node': 22.6.1
+      '@types/node': 22.5.5
 
   '@types/imap-simple@4.2.8':
     dependencies:
@@ -43626,7 +43658,7 @@ snapshots:
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 22.6.1
+      '@types/node': 22.5.5
 
   '@types/node@11.11.6': {}
 
@@ -43641,6 +43673,10 @@ snapshots:
   '@types/node@20.14.2':
     dependencies:
       undici-types: 5.26.5
+
+  '@types/node@22.5.5':
+    dependencies:
+      undici-types: 6.19.8
 
   '@types/node@22.6.1':
     dependencies:
@@ -44955,8 +44991,8 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv-formats@2.1.1:
-    dependencies:
+  ajv-formats@2.1.1(ajv@8.12.0):
+    optionalDependencies:
       ajv: 8.12.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
@@ -45277,6 +45313,8 @@ snapshots:
   asynckit@0.4.0: {}
 
   at-least-node@1.0.0: {}
+
+  atob@2.1.2: {}
 
   atomic-batcher@1.0.2: {}
 
@@ -46496,7 +46534,7 @@ snapshots:
   conf@12.0.0:
     dependencies:
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.12.0)
       atomically: 2.0.3
       debounce-fn: 5.1.2
       dot-prop: 8.0.2
@@ -47314,6 +47352,8 @@ snapshots:
   decode-named-character-reference@1.0.2:
     dependencies:
       character-entities: 2.0.2
+
+  decode-uri-component@0.2.2: {}
 
   decompress-response@4.2.1:
     dependencies:
@@ -50985,7 +51025,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.6.1
+      '@types/node': 22.5.5
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -54807,7 +54847,7 @@ snapshots:
       csstype: 3.1.3
       lodash.curry: 4.1.1
 
-  react-charts@3.0.0-beta.55(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  react-charts@3.0.0-beta.57(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.22.15
       '@types/d3-array': 3.0.3
@@ -55717,6 +55757,14 @@ snapshots:
     dependencies:
       rollup-plugin-inject: 3.0.2
 
+  rollup-plugin-sourcemaps@0.6.3(@types/node@22.6.1)(rollup@3.23.0):
+    dependencies:
+      '@rollup/pluginutils': 3.1.0(rollup@3.23.0)
+      rollup: 3.23.0
+      source-map-resolve: 0.6.0
+    optionalDependencies:
+      '@types/node': 22.6.1
+
   rollup-plugin-terser@7.0.2(rollup@2.79.1):
     dependencies:
       '@babel/code-frame': 7.24.7
@@ -55929,7 +55977,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.12.0)
       ajv-keywords: 5.1.0(ajv@8.12.0)
 
   scroll@3.0.1: {}
@@ -56388,6 +56436,11 @@ snapshots:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
       webpack: 5.88.2(@swc/core@1.5.7(@swc/helpers@0.5.1))(esbuild@0.23.1)
+
+  source-map-resolve@0.6.0:
+    dependencies:
+      atob: 2.1.2
+      decode-uri-component: 0.2.2
 
   source-map-support@0.5.19:
     dependencies:

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -7,7 +7,6 @@ import inject from '@rollup/plugin-inject';
 import { type Plugin, UserConfig as ViteConfig } from 'vite';
 import { defineConfig, type UserConfig as VitestConfig } from 'vitest/config';
 // import Inspect from 'vite-plugin-inspect';
-import TopLevelAwaitPlugin from 'vite-plugin-top-level-await';
 import WasmPlugin from 'vite-plugin-wasm';
 import Inspect from 'vite-plugin-inspect';
 
@@ -50,7 +49,6 @@ const createBrowserConfig = ({ browserName, nodeExternal = false, injectGlobals 
   defineConfig({
     plugins: [
       nodeStdPlugin(),
-      TopLevelAwaitPlugin(),
       WasmPlugin(),
       // Inspect()
     ],


### PR DESCRIPTION
- Remove `top-level-await-plugin` as it is breaking sourcemaps
- Add `rollup-plugin-sourcemaps` to make vite read sourcemaps of workspace packages
- Preserve class and function names during minification (helps preserve log and context names)
- Only enable tsconfig paths mappings in local dev mode
- Improve error messages in sdk