### PR TITLE
fix(cli): imports and default configs

### DIFF
--- a/packages/apps/testbench-app/dx.yml
+++ b/packages/apps/testbench-app/dx.yml
@@ -14,8 +14,6 @@ runtime:
     edgeFeatures:
       signaling: true
   services:
-    # signaling:
-    #   - server: wss://kube.dxos.org/.well-known/dx/signal
     ice:
       - urls: turn:kube.dxos.org:3478
         username: dxos

--- a/packages/common/async/package.json
+++ b/packages/common/async/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/codec-protobuf/package.json
+++ b/packages/common/codec-protobuf/package.json
@@ -10,7 +10,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -18,7 +18,7 @@
       "browser": "./dist/lib/browser/stream.mjs",
       "node": {
         "require": "./dist/lib/node/stream.cjs",
-        "default": "./dist/lib/node-esm/stream.mjs"
+        "default": "./dist/lib/node/stream.cjs"
       },
       "types": "./dist/types/src/stream.d.ts"
     }

--- a/packages/common/context/package.json
+++ b/packages/common/context/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/crypto-names/package.json
+++ b/packages/common/crypto-names/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/crypto/package.json
+++ b/packages/common/crypto/package.json
@@ -17,7 +17,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/debug/package.json
+++ b/packages/common/debug/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/display-name/package.json
+++ b/packages/common/display-name/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/feed-store/package.json
+++ b/packages/common/feed-store/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/testing/index.mjs",
       "node": {
         "require": "./dist/lib/node/testing/index.cjs",
-        "default": "./dist/lib/node-esm/testing/index.mjs"
+        "default": "./dist/lib/node/testing/index.cjs"
       },
       "types": "./dist/types/src/testing/index.d.ts"
     }

--- a/packages/common/hypercore/package.json
+++ b/packages/common/hypercore/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/invariant/package.json
+++ b/packages/common/invariant/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/keyboard/package.json
+++ b/packages/common/keyboard/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/keys/package.json
+++ b/packages/common/keys/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/kv-store/package.json
+++ b/packages/common/kv-store/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/testing/index.mjs",
       "node": {
         "require": "./dist/lib/node/testing/index.cjs",
-        "default": "./dist/lib/node-esm/testing/index.mjs"
+        "default": "./dist/lib/node/testing/index.cjs"
       },
       "types": "./dist/types/src/testing/index.d.ts"
     }

--- a/packages/common/local-storage/package.json
+++ b/packages/common/local-storage/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/lock-file/package.json
+++ b/packages/common/lock-file/package.json
@@ -10,7 +10,7 @@
     ".": {
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/log/package.json
+++ b/packages/common/log/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/phoenix/package.json
+++ b/packages/common/phoenix/package.json
@@ -10,7 +10,7 @@
     ".": {
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/plate/package.json
+++ b/packages/common/plate/package.json
@@ -9,14 +9,14 @@
     ".": {
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
     "./main": {
       "node": {
         "require": "./dist/lib/node/main.cjs",
-        "default": "./dist/lib/node-esm/main.mjs"
+        "default": "./dist/lib/node/main.cjs"
       },
       "types": "./dist/types/src/main.d.ts"
     }

--- a/packages/common/random-access-storage/package.json
+++ b/packages/common/random-access-storage/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/random/package.json
+++ b/packages/common/random/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/test-utils/package.json
+++ b/packages/common/test-utils/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/playwright.mjs",
       "node": {
         "require": "./dist/lib/node/playwright.cjs",
-        "default": "./dist/lib/node-esm/playwright.mjs"
+        "default": "./dist/lib/node/playwright.cjs"
       },
       "types": "./dist/types/src/playwright.d.ts"
     }

--- a/packages/common/timeframe/package.json
+++ b/packages/common/timeframe/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/tracing/package.json
+++ b/packages/common/tracing/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/common/util/package.json
+++ b/packages/common/util/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/agent/package.json
+++ b/packages/core/agent/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/chain/package.json
+++ b/packages/core/chain/package.json
@@ -12,7 +12,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/echo/echo-db/package.json
+++ b/packages/core/echo/echo-db/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/testing/index.mjs",
       "node": {
         "require": "./dist/lib/node/testing/index.cjs",
-        "default": "./dist/lib/node-esm/testing/index.mjs"
+        "default": "./dist/lib/node/testing/index.cjs"
       },
       "types": "./dist/types/src/testing/index.d.ts"
     }

--- a/packages/core/echo/echo-generator/package.json
+++ b/packages/core/echo/echo-generator/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/echo/echo-pipeline/package.json
+++ b/packages/core/echo/echo-pipeline/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/testing/index.mjs",
       "node": {
         "require": "./dist/lib/node/testing/index.cjs",
-        "default": "./dist/lib/node-esm/testing/index.mjs"
+        "default": "./dist/lib/node/testing/index.cjs"
       },
       "types": "./dist/types/src/testing/index.d.ts"
     }

--- a/packages/core/echo/echo-protocol/package.json
+++ b/packages/core/echo/echo-protocol/package.json
@@ -12,7 +12,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/echo/echo-query/package.json
+++ b/packages/core/echo/echo-query/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/echo/echo-schema/package.json
+++ b/packages/core/echo/echo-schema/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/testing/index.mjs",
       "node": {
         "require": "./dist/lib/node/testing/index.cjs",
-        "default": "./dist/lib/node-esm/testing/index.mjs"
+        "default": "./dist/lib/node/testing/index.cjs"
       },
       "types": "./dist/types/src/testing/index.d.ts"
     }

--- a/packages/core/echo/echo-signals/package.json
+++ b/packages/core/echo/echo-signals/package.json
@@ -12,7 +12,7 @@
       "browser": "./dist/lib/browser/core.mjs",
       "node": {
         "require": "./dist/lib/node/core.cjs",
-        "default": "./dist/lib/node-esm/core.mjs"
+        "default": "./dist/lib/node/core.cjs"
       },
       "types": "./dist/types/src/core.d.ts"
     },
@@ -20,7 +20,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -28,7 +28,7 @@
       "browser": "./dist/lib/browser/react.mjs",
       "node": {
         "require": "./dist/lib/node/react.cjs",
-        "default": "./dist/lib/node-esm/react.mjs"
+        "default": "./dist/lib/node/react.cjs"
       },
       "types": "./dist/types/src/react.d.ts"
     },
@@ -36,7 +36,7 @@
       "browser": "./dist/lib/browser/runtime/index.mjs",
       "node": {
         "require": "./dist/lib/node/runtime/index.cjs",
-        "default": "./dist/lib/node-esm/runtime/index.mjs"
+        "default": "./dist/lib/node/runtime/index.cjs"
       },
       "types": "./dist/types/src/runtime/index.d.ts"
     }

--- a/packages/core/echo/indexing/package.json
+++ b/packages/core/echo/indexing/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/functions/package.json
+++ b/packages/core/functions/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/testing/index.mjs",
       "node": {
         "require": "./dist/lib/node/testing/index.cjs",
-        "default": "./dist/lib/node-esm/testing/index.mjs"
+        "default": "./dist/lib/node/testing/index.cjs"
       },
       "types": "./dist/types/src/testing/index.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/types.mjs",
       "node": {
         "require": "./dist/lib/node/types.cjs",
-        "default": "./dist/lib/node-esm/types.mjs"
+        "default": "./dist/lib/node/types.cjs"
       },
       "types": "./dist/types/src/types.d.ts"
     }

--- a/packages/core/halo/credentials/package.json
+++ b/packages/core/halo/credentials/package.json
@@ -12,7 +12,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/halo/keyring/package.json
+++ b/packages/core/halo/keyring/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/mesh/edge-client/package.json
+++ b/packages/core/mesh/edge-client/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/mesh/messaging/package.json
+++ b/packages/core/mesh/messaging/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/mesh/network-manager/package.json
+++ b/packages/core/mesh/network-manager/package.json
@@ -23,7 +23,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -31,7 +31,7 @@
       "browser": "./dist/lib/browser/testing/index.mjs",
       "node": {
         "require": "./dist/lib/node/testing/index.cjs",
-        "default": "./dist/lib/node-esm/testing/index.mjs"
+        "default": "./dist/lib/node/testing/index.cjs"
       },
       "types": "./dist/types/src/testing/index.d.ts"
     }

--- a/packages/core/mesh/rpc-tunnel/package.json
+++ b/packages/core/mesh/rpc-tunnel/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/mesh/rpc/package.json
+++ b/packages/core/mesh/rpc/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/mesh/signal/package.json
+++ b/packages/core/mesh/signal/package.json
@@ -11,7 +11,7 @@
     ".": {
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/mesh/teleport-extension-automerge-replicator/package.json
+++ b/packages/core/mesh/teleport-extension-automerge-replicator/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/mesh/teleport-extension-gossip/package.json
+++ b/packages/core/mesh/teleport-extension-gossip/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/mesh/teleport-extension-object-sync/package.json
+++ b/packages/core/mesh/teleport-extension-object-sync/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/mesh/teleport-extension-replicator/package.json
+++ b/packages/core/mesh/teleport-extension-replicator/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/core/mesh/teleport/package.json
+++ b/packages/core/mesh/teleport/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/testing/index.mjs",
       "node": {
         "require": "./dist/lib/node/testing/index.cjs",
-        "default": "./dist/lib/node-esm/testing/index.mjs"
+        "default": "./dist/lib/node/testing/index.cjs"
       },
       "types": "./dist/types/src/testing/index.d.ts"
     }

--- a/packages/core/mesh/websocket-rpc/package.json
+++ b/packages/core/mesh/websocket-rpc/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/devtools/cli-base/config/config-default.yml
+++ b/packages/devtools/cli-base/config/config-default.yml
@@ -5,18 +5,25 @@ runtime:
     storage:
       persistent: true
 
+    edgeFeatures:
+      signaling: true
+
   services:
     ipfs:
       server: https://api.ipfs.dxos.network/api/v0
       gateway: https://gateway.ipfs.dxos.network/ipfs
-    signaling:
-      - server: wss://dev.kube.dxos.org/.well-known/dx/signal
-      - server: wss://kube.dxos.org/.well-known/dx/signal
+
+    edge:
+      url: wss://edge-main.dxos.workers.dev/
+
     ice:
-      - urls: stun:kube.dxos.org:3478
       - urls: turn:kube.dxos.org:3478
         username: dxos
         credential: dxos
+
+    iceProviders:
+      - urls: https://edge-main.dxos.workers.dev/ice
+
     publisher:
       server: ws://127.0.0.1/.well-known/dx/deploy
     supervisor:

--- a/packages/devtools/cli-base/config/config-default.yml
+++ b/packages/devtools/cli-base/config/config-default.yml
@@ -4,7 +4,6 @@ runtime:
   client:
     storage:
       persistent: true
-
     edgeFeatures:
       signaling: true
 

--- a/packages/devtools/cli-base/config/config-local.yml
+++ b/packages/devtools/cli-base/config/config-local.yml
@@ -5,23 +5,16 @@ runtime:
     storage:
       persistent: true
       dataRoot: /tmp/dx/run
-
+    edgeFeatures:
+      signaling: true
 
   services:
-    signaling:
-      - server: ws://localhost/.well-known/dx/signal
-      - server: wss://kube.dxos.org/.well-known/dx/signal
     ice:
-      - urls: stun:kube.dxos.org:3478
-        username: dxos
-        credential: dxos
-      - urls: turn:kube.dxos.org:3478
-        username: dxos
-        credential: dxos
-      - urls: stun:dev.kube.dxos.org:3478
       - urls: turn:dev.kube.dxos.org:3478
         username: dxos
         credential: dxos
+    edge:
+      url: wss://edge-main.dxos.workers.dev/
     ipfs:
       server: http://127.0.0.1:5001/
       gateway: http://127.0.0.1:8888/ipfs

--- a/packages/devtools/devtools/package.json
+++ b/packages/devtools/devtools/package.json
@@ -12,7 +12,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/experimental/agent-functions/package.json
+++ b/packages/experimental/agent-functions/package.json
@@ -12,7 +12,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/experimental/chess-app/package.json
+++ b/packages/experimental/chess-app/package.json
@@ -12,7 +12,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -20,7 +20,7 @@
       "browser": "./dist/lib/browser/types.mjs",
       "node": {
         "require": "./dist/lib/node/types.cjs",
-        "default": "./dist/lib/node-esm/types.mjs"
+        "default": "./dist/lib/node/types.cjs"
       },
       "types": "./dist/types/src/types.d.ts"
     }

--- a/packages/experimental/discord-bot/package.json
+++ b/packages/experimental/discord-bot/package.json
@@ -12,7 +12,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/experimental/gem-core/package.json
+++ b/packages/experimental/gem-core/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/experimental/gem-globe/package.json
+++ b/packages/experimental/gem-globe/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },

--- a/packages/experimental/gem-spore/package.json
+++ b/packages/experimental/gem-spore/package.json
@@ -12,7 +12,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -20,7 +20,7 @@
       "browser": "./dist/lib/browser/testing/index.mjs",
       "node": {
         "require": "./dist/lib/node/testing/index.cjs",
-        "default": "./dist/lib/node-esm/testing/index.mjs"
+        "default": "./dist/lib/node/testing/index.cjs"
       },
       "types": "./dist/types/src/testing/index.d.ts"
     },

--- a/packages/experimental/plexus/package.json
+++ b/packages/experimental/plexus/package.json
@@ -12,7 +12,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/experimental/react-metagraph/package.json
+++ b/packages/experimental/react-metagraph/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/gravity/blade-runner/package.json
+++ b/packages/gravity/blade-runner/package.json
@@ -12,7 +12,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -20,7 +20,7 @@
       "browser": "./dist/lib/browser/main.mjs",
       "node": {
         "require": "./dist/lib/node/main.cjs",
-        "default": "./dist/lib/node-esm/main.mjs"
+        "default": "./dist/lib/node/main.cjs"
       },
       "types": "./dist/types/src/main.d.ts"
     }

--- a/packages/gravity/kube-publishing/package.json
+++ b/packages/gravity/kube-publishing/package.json
@@ -12,7 +12,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -20,7 +20,7 @@
       "browser": "./dist/lib/browser/main.mjs",
       "node": {
         "require": "./dist/lib/node/main.cjs",
-        "default": "./dist/lib/node-esm/main.mjs"
+        "default": "./dist/lib/node/main.cjs"
       },
       "types": "./dist/types/src/main.d.ts"
     }

--- a/packages/plugins/experimental/plugin-chain/package.json
+++ b/packages/plugins/experimental/plugin-chain/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/types/index.mjs",
       "node": {
         "require": "./dist/lib/node/types/index.cjs",
-        "default": "./dist/lib/node-esm/types/index.mjs"
+        "default": "./dist/lib/node/types/index.cjs"
       },
       "types": "./dist/types/src/types/index.d.ts"
     }

--- a/packages/plugins/experimental/plugin-explorer/package.json
+++ b/packages/plugins/experimental/plugin-explorer/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/types/index.mjs",
       "node": {
         "require": "./dist/lib/node/types/index.cjs",
-        "default": "./dist/lib/node-esm/types/index.mjs"
+        "default": "./dist/lib/node/types/index.cjs"
       },
       "types": "./dist/types/src/types/index.d.ts"
     }

--- a/packages/plugins/experimental/plugin-grid/package.json
+++ b/packages/plugins/experimental/plugin-grid/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/types/index.mjs",
       "node": {
         "require": "./dist/lib/node/types/index.cjs",
-        "default": "./dist/lib/node-esm/types/index.mjs"
+        "default": "./dist/lib/node/types/index.cjs"
       },
       "types": "./dist/types/src/types/index.d.ts"
     }

--- a/packages/plugins/experimental/plugin-inbox/package.json
+++ b/packages/plugins/experimental/plugin-inbox/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/types/index.mjs",
       "node": {
         "require": "./dist/lib/node/types/index.cjs",
-        "default": "./dist/lib/node-esm/types/index.mjs"
+        "default": "./dist/lib/node/types/index.cjs"
       },
       "types": "./dist/types/src/types/index.d.ts"
     }

--- a/packages/plugins/experimental/plugin-ipfs/package.json
+++ b/packages/plugins/experimental/plugin-ipfs/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/types/index.mjs",
       "node": {
         "require": "./dist/lib/node/types/index.cjs",
-        "default": "./dist/lib/node-esm/types/index.mjs"
+        "default": "./dist/lib/node/types/index.cjs"
       },
       "types": "./dist/types/src/types/index.d.ts"
     }

--- a/packages/plugins/experimental/plugin-kanban/package.json
+++ b/packages/plugins/experimental/plugin-kanban/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/types/index.mjs",
       "node": {
         "require": "./dist/lib/node/types/index.cjs",
-        "default": "./dist/lib/node-esm/types/index.mjs"
+        "default": "./dist/lib/node/types/index.cjs"
       },
       "types": "./dist/types/src/types/index.d.ts"
     }

--- a/packages/plugins/experimental/plugin-map/package.json
+++ b/packages/plugins/experimental/plugin-map/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/types/index.mjs",
       "node": {
         "require": "./dist/lib/node/types/index.cjs",
-        "default": "./dist/lib/node-esm/types/index.mjs"
+        "default": "./dist/lib/node/types/index.cjs"
       },
       "types": "./dist/types/src/types/index.d.ts"
     }

--- a/packages/plugins/experimental/plugin-outliner/package.json
+++ b/packages/plugins/experimental/plugin-outliner/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/types/index.mjs",
       "node": {
         "require": "./dist/lib/node/types/index.cjs",
-        "default": "./dist/lib/node-esm/types/index.mjs"
+        "default": "./dist/lib/node/types/index.cjs"
       },
       "types": "./dist/types/src/types/index.d.ts"
     }

--- a/packages/plugins/experimental/plugin-script/package.json
+++ b/packages/plugins/experimental/plugin-script/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/edge/index.mjs",
       "node": {
         "require": "./dist/lib/node/edge/index.cjs",
-        "default": "./dist/lib/node-esm/edge/index.mjs"
+        "default": "./dist/lib/node/edge/index.cjs"
       },
       "types": "./dist/types/src/edge/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -35,7 +35,7 @@
       "browser": "./dist/lib/browser/types/index.mjs",
       "node": {
         "require": "./dist/lib/node/types/index.cjs",
-        "default": "./dist/lib/node-esm/types/index.mjs"
+        "default": "./dist/lib/node/types/index.cjs"
       },
       "types": "./dist/types/src/types/index.d.ts"
     }

--- a/packages/plugins/plugin-attention/package.json
+++ b/packages/plugins/plugin-attention/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     }

--- a/packages/plugins/plugin-client/package.json
+++ b/packages/plugins/plugin-client/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     }

--- a/packages/plugins/plugin-graph/package.json
+++ b/packages/plugins/plugin-graph/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     }

--- a/packages/plugins/plugin-markdown/package.json
+++ b/packages/plugins/plugin-markdown/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/types/index.mjs",
       "node": {
         "require": "./dist/lib/node/types/index.cjs",
-        "default": "./dist/lib/node-esm/types/index.mjs"
+        "default": "./dist/lib/node/types/index.cjs"
       },
       "types": "./dist/types/src/types/index.d.ts"
     }

--- a/packages/plugins/plugin-metadata/package.json
+++ b/packages/plugins/plugin-metadata/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     }

--- a/packages/plugins/plugin-settings/package.json
+++ b/packages/plugins/plugin-settings/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     }

--- a/packages/plugins/plugin-sheet/package.json
+++ b/packages/plugins/plugin-sheet/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -34,7 +34,7 @@
       "browser": "./dist/lib/browser/types.mjs",
       "node": {
         "require": "./dist/lib/node/types.cjs",
-        "default": "./dist/lib/node-esm/types.mjs"
+        "default": "./dist/lib/node/types.cjs"
       },
       "types": "./dist/types/src/types.d.ts"
     }

--- a/packages/plugins/plugin-sketch/package.json
+++ b/packages/plugins/plugin-sketch/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/types/index.mjs",
       "node": {
         "require": "./dist/lib/node/types/index.cjs",
-        "default": "./dist/lib/node-esm/types/index.mjs"
+        "default": "./dist/lib/node/types/index.cjs"
       },
       "types": "./dist/types/src/types/index.d.ts"
     }

--- a/packages/plugins/plugin-space/package.json
+++ b/packages/plugins/plugin-space/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/types/index.mjs",
       "node": {
         "require": "./dist/lib/node/types/index.cjs",
-        "default": "./dist/lib/node-esm/types/index.mjs"
+        "default": "./dist/lib/node/types/index.cjs"
       },
       "types": "./dist/types/src/types/index.d.ts"
     }

--- a/packages/plugins/plugin-stack/package.json
+++ b/packages/plugins/plugin-stack/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/types/index.mjs",
       "node": {
         "require": "./dist/lib/node/types/index.cjs",
-        "default": "./dist/lib/node-esm/types/index.mjs"
+        "default": "./dist/lib/node/types/index.cjs"
       },
       "types": "./dist/types/src/types/index.d.ts"
     }

--- a/packages/plugins/plugin-table/package.json
+++ b/packages/plugins/plugin-table/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/types/index.mjs",
       "node": {
         "require": "./dist/lib/node/types/index.cjs",
-        "default": "./dist/lib/node-esm/types/index.mjs"
+        "default": "./dist/lib/node/types/index.cjs"
       },
       "types": "./dist/types/src/types/index.d.ts"
     }

--- a/packages/plugins/plugin-thread/package.json
+++ b/packages/plugins/plugin-thread/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/meta.mjs",
       "node": {
         "require": "./dist/lib/node/meta.cjs",
-        "default": "./dist/lib/node-esm/meta.mjs"
+        "default": "./dist/lib/node/meta.cjs"
       },
       "types": "./dist/types/src/meta.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/types.mjs",
       "node": {
         "require": "./dist/lib/node/types.cjs",
-        "default": "./dist/lib/node-esm/types.mjs"
+        "default": "./dist/lib/node/types.cjs"
       },
       "types": "./dist/types/src/types.d.ts"
     }

--- a/packages/sdk/app-framework/package.json
+++ b/packages/sdk/app-framework/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/sdk/app-graph/package.json
+++ b/packages/sdk/app-graph/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/sdk/client-protocol/package.json
+++ b/packages/sdk/client-protocol/package.json
@@ -12,7 +12,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/sdk/client-services/package.json
+++ b/packages/sdk/client-services/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/testing/index.mjs",
       "node": {
         "require": "./dist/lib/node/testing/index.cjs",
-        "default": "./dist/lib/node-esm/testing/index.mjs"
+        "default": "./dist/lib/node/testing/index.cjs"
       },
       "types": "./dist/types/src/testing/index.d.ts"
     }

--- a/packages/sdk/client/package.json
+++ b/packages/sdk/client/package.json
@@ -12,7 +12,7 @@
       "browser": "./dist/lib/browser/devtools/index.mjs",
       "node": {
         "require": "./dist/lib/node/devtools/index.cjs",
-        "default": "./dist/lib/node-esm/devtools/index.mjs"
+        "default": "./dist/lib/node/devtools/index.cjs"
       },
       "types": "./dist/types/src/devtools/index.d.ts"
     },
@@ -20,7 +20,7 @@
       "browser": "./dist/lib/browser/echo/index.mjs",
       "node": {
         "require": "./dist/lib/node/echo/index.cjs",
-        "default": "./dist/lib/node-esm/echo/index.mjs"
+        "default": "./dist/lib/node/echo/index.cjs"
       },
       "types": "./dist/types/src/echo/index.d.ts"
     },
@@ -28,7 +28,7 @@
       "browser": "./dist/lib/browser/halo/index.mjs",
       "node": {
         "require": "./dist/lib/node/halo/index.cjs",
-        "default": "./dist/lib/node-esm/halo/index.mjs"
+        "default": "./dist/lib/node/halo/index.cjs"
       },
       "types": "./dist/types/src/halo/index.d.ts"
     },
@@ -36,7 +36,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -44,7 +44,7 @@
       "browser": "./dist/lib/browser/invitations/index.mjs",
       "node": {
         "require": "./dist/lib/node/invitations/index.cjs",
-        "default": "./dist/lib/node-esm/invitations/index.mjs"
+        "default": "./dist/lib/node/invitations/index.cjs"
       },
       "types": "./dist/types/src/invitations/index.d.ts"
     },
@@ -52,7 +52,7 @@
       "browser": "./dist/lib/browser/mesh/index.mjs",
       "node": {
         "require": "./dist/lib/node/mesh/index.cjs",
-        "default": "./dist/lib/node-esm/mesh/index.mjs"
+        "default": "./dist/lib/node/mesh/index.cjs"
       },
       "types": "./dist/types/src/mesh/index.d.ts"
     },
@@ -60,7 +60,7 @@
       "browser": "./dist/lib/browser/testing/index.mjs",
       "node": {
         "require": "./dist/lib/node/testing/index.cjs",
-        "default": "./dist/lib/node-esm/testing/index.mjs"
+        "default": "./dist/lib/node/testing/index.cjs"
       },
       "types": "./dist/types/src/testing/index.d.ts"
     },
@@ -68,7 +68,7 @@
       "browser": "./dist/lib/browser/worker/index.mjs",
       "node": {
         "require": "./dist/lib/node/worker/index.cjs",
-        "default": "./dist/lib/node-esm/worker/index.mjs"
+        "default": "./dist/lib/node/worker/index.cjs"
       },
       "types": "./dist/types/src/worker/index.d.ts"
     }

--- a/packages/sdk/client/src/services/local-client-services.ts
+++ b/packages/sdk/client/src/services/local-client-services.ts
@@ -59,9 +59,9 @@ const setupNetworking = async (
 
   const signals = config.get('runtime.services.signaling');
   const edgeFeatures = config.get('runtime.client.edgeFeatures');
-  if (signals) {
+  if (signals || edgeFeatures?.signaling) {
     const {
-      signalManager = edgeFeatures?.signaling ? undefined : new WebsocketSignalManager(signals, signalMetadata),
+      signalManager = signals && new WebsocketSignalManager(signals, signalMetadata),
       // TODO(nf): configure better
       transportFactory = process.env.MOCHA_ENV === 'nodejs'
         ? createLibDataChannelTransportFactory(

--- a/packages/sdk/migrations/package.json
+++ b/packages/sdk/migrations/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/sdk/observability/package.json
+++ b/packages/sdk/observability/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/segment/index.mjs",
       "node": {
         "require": "./dist/lib/node/segment/index.cjs",
-        "default": "./dist/lib/node-esm/segment/index.mjs"
+        "default": "./dist/lib/node/segment/index.cjs"
       },
       "types": "./dist/types/src/segment/index.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/sentry/index.mjs",
       "node": {
         "require": "./dist/lib/node/sentry/index.cjs",
-        "default": "./dist/lib/node-esm/sentry/index.mjs"
+        "default": "./dist/lib/node/sentry/index.cjs"
       },
       "types": "./dist/types/src/sentry/index.d.ts"
     }

--- a/packages/sdk/observability/src/observability.ts
+++ b/packages/sdk/observability/src/observability.ts
@@ -289,7 +289,7 @@ export class Observability {
     const updateSignalMetrics = new Event<NetworkStatus>().debounce(NETWORK_METRICS_MIN_INTERVAL);
     updateSignalMetrics.on(this._ctx, async () => {
       log('send signal metrics');
-      (this._lastNetworkStatus?.signaling as NetworkStatus.Signal[]).forEach(({ server, state }) => {
+      (this._lastNetworkStatus?.signaling as NetworkStatus.Signal[])?.forEach(({ server, state }) => {
         this.gauge('dxos.client.network.signal.connectionState', state, { server });
       });
 

--- a/packages/sdk/react-client/package.json
+++ b/packages/sdk/react-client/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/devtools/index.mjs",
       "node": {
         "require": "./dist/lib/node/devtools/index.cjs",
-        "default": "./dist/lib/node-esm/devtools/index.mjs"
+        "default": "./dist/lib/node/devtools/index.cjs"
       },
       "types": "./dist/types/src/devtools/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/echo/index.mjs",
       "node": {
         "require": "./dist/lib/node/echo/index.cjs",
-        "default": "./dist/lib/node-esm/echo/index.mjs"
+        "default": "./dist/lib/node/echo/index.cjs"
       },
       "types": "./dist/types/src/echo/index.d.ts"
     },
@@ -27,7 +27,7 @@
       "browser": "./dist/lib/browser/halo/index.mjs",
       "node": {
         "require": "./dist/lib/node/halo/index.cjs",
-        "default": "./dist/lib/node-esm/halo/index.mjs"
+        "default": "./dist/lib/node/halo/index.cjs"
       },
       "types": "./dist/types/src/halo/index.d.ts"
     },
@@ -35,7 +35,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -43,7 +43,7 @@
       "browser": "./dist/lib/browser/invitations/index.mjs",
       "node": {
         "require": "./dist/lib/node/invitations/index.cjs",
-        "default": "./dist/lib/node-esm/invitations/index.mjs"
+        "default": "./dist/lib/node/invitations/index.cjs"
       },
       "types": "./dist/types/src/invitations/index.d.ts"
     },
@@ -51,7 +51,7 @@
       "browser": "./dist/lib/browser/mesh/index.mjs",
       "node": {
         "require": "./dist/lib/node/mesh/index.cjs",
-        "default": "./dist/lib/node-esm/mesh/index.mjs"
+        "default": "./dist/lib/node/mesh/index.cjs"
       },
       "types": "./dist/types/src/mesh/index.d.ts"
     },
@@ -59,7 +59,7 @@
       "browser": "./dist/lib/browser/testing/index.mjs",
       "node": {
         "require": "./dist/lib/node/testing/index.cjs",
-        "default": "./dist/lib/node-esm/testing/index.mjs"
+        "default": "./dist/lib/node/testing/index.cjs"
       },
       "types": "./dist/types/src/testing/index.d.ts"
     },
@@ -67,7 +67,7 @@
       "browser": "./dist/lib/browser/worker.mjs",
       "node": {
         "require": "./dist/lib/node/worker.cjs",
-        "default": "./dist/lib/node-esm/worker.mjs"
+        "default": "./dist/lib/node/worker.cjs"
       },
       "types": "./dist/types/src/worker.d.ts"
     }

--- a/packages/sdk/shell/dx.yml
+++ b/packages/sdk/shell/dx.yml
@@ -5,15 +5,14 @@ runtime:
     mode: local
     storage:
       persistent: true
+    edgeFeatures:
+      signaling: true
   services:
-    signaling:
-      - server: wss://kube.dxos.org/.well-known/dx/signal
+    edge:
+      url: wss://edge-main.dxos.workers.dev/
     ice:
-      - urls: stun:dev.kube.dxos.org:3478
       - urls: turn:dev.kube.dxos.org:3478
         username: dxos
         credential: dxos
-      - urls: stun:kube.dxos.org:3478
-      - urls: turn:kube.dxos.org:3478
-        username: dxos
-        credential: dxos
+    iceProviders:
+      - urls: https://edge-main.dxos.workers.dev/ice

--- a/packages/ui/primitives/react-hooks/package.json
+++ b/packages/ui/primitives/react-hooks/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/ui/primitives/react-list/package.json
+++ b/packages/ui/primitives/react-list/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/packages/ui/react-ui-stack/package.json
+++ b/packages/ui/react-ui-stack/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     },
@@ -19,7 +19,7 @@
       "browser": "./dist/lib/browser/testing/index.mjs",
       "node": {
         "require": "./dist/lib/node/testing/index.cjs",
-        "default": "./dist/lib/node-esm/testing/index.mjs"
+        "default": "./dist/lib/node/testing/index.cjs"
       },
       "types": "./dist/types/src/testing/index.d.ts"
     }

--- a/packages/ui/react-ui-types/package.json
+++ b/packages/ui/react-ui-types/package.json
@@ -11,7 +11,7 @@
       "browser": "./dist/lib/browser/index.mjs",
       "node": {
         "require": "./dist/lib/node/index.cjs",
-        "default": "./dist/lib/node-esm/index.mjs"
+        "default": "./dist/lib/node/index.cjs"
       },
       "types": "./dist/types/src/index.d.ts"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36851,7 +36851,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.2.1
-      protobufjs: 7.2.6
+      protobufjs: 7.3.2
       yargs: 17.7.2
 
   '@hapi/b64@5.0.0':
@@ -42541,7 +42541,7 @@ snapshots:
       '@swc-node/sourcemap-support': 0.5.0
       '@swc/core': 1.5.7(@swc/helpers@0.5.1)
       colorette: 2.0.20
-      debug: 4.3.4
+      debug: 4.3.7(supports-color@5.5.0)
       pirates: 4.0.6
       tslib: 2.6.2
       typescript: 5.6.2
@@ -42555,7 +42555,7 @@ snapshots:
       '@swc-node/sourcemap-support': 0.5.0
       '@swc/core': 1.5.7(@swc/helpers@0.5.1)
       colorette: 2.0.20
-      debug: 4.3.4
+      debug: 4.3.7(supports-color@5.5.0)
       pirates: 4.0.6
       tslib: 2.6.2
       typescript: 5.6.2

--- a/tools/executors/toolbox/src/toolbox.ts
+++ b/tools/executors/toolbox/src/toolbox.ts
@@ -567,7 +567,7 @@ export class Toolbox {
         if (isNode) {
           (packageJson.exports[exportName] as any).node = {
             require: `./dist/lib/node/${distSlug}.cjs`,
-            default: `./dist/lib/node-esm/${distSlug}.mjs`,
+            default: `./dist/lib/node/${distSlug}.cjs`,
           };
         }
         (packageJson.exports[exportName] as any).types = `./dist/types/src/${distSlug}.d.ts`;


### PR DESCRIPTION
### Details

cli is broken on main.
esm imports are not working:
```
Error: Cannot find module 'packages/common/hypercore/node_modules/sodium-universal/memory' imported from packages/common/hypercore/dist/lib/node-esm/index.mjs
Did you mean to import "sodium-universal/memory.js"?
    at finalizeResolution (node:internal/modules/esm/resolve:265:11)
    at moduleResolve (node:internal/modules/esm/resolve:933:10)
    at defaultResolve (node:internal/modules/esm/resolve:1157:11)
```

and different signaling prevents connecting a local agent with browser