### PR TITLE
feat(plugin-sheet): Grid axis resize support

### DIFF
--- a/packages/plugins/plugin-sheet/src/components/GridSheet/util.ts
+++ b/packages/plugins/plugin-sheet/src/components/GridSheet/util.ts
@@ -32,7 +32,7 @@ const createDxGridCells = (model: SheetModel, formatting: FormattingModel) => {
   }, {});
 };
 
-const createDxGridColumnns = (model: SheetModel): GridContentProps['columns'] => {
+const createDxGridColumns = (model: SheetModel): GridContentProps['columns'] => {
   return model.sheet.columns.reduce((acc: NonNullable<GridContentProps['columns']>, columnId, numericIndex) => {
     if (model.sheet.columnMeta[columnId] && model.sheet.columnMeta[columnId].size) {
       acc[numericIndex] = { size: model.sheet.columnMeta[columnId].size, resizeable: true };
@@ -55,8 +55,8 @@ export const useSheetModelDxGridProps = (
   formatting: FormattingModel,
 ): Pick<GridContentProps, 'cells' | 'columns' | 'rows'> => {
   const [dxGridCells, setDxGridCells] = useState<GridContentProps['cells']>(createDxGridCells(model, formatting));
-  const [dxGridColumns, setDxGridColumns] = useState<GridContentProps['columns']>(createDxGridColumnns(model));
-  const [dxGridRows, setDxGridRows] = useState<GridContentProps['rows']>(createDxGridColumnns(model));
+  const [dxGridColumns, setDxGridColumns] = useState<GridContentProps['columns']>(createDxGridColumns(model));
+  const [dxGridRows, setDxGridRows] = useState<GridContentProps['rows']>(createDxGridColumns(model));
 
   useEffect(() => {
     const cellsAccessor = createDocAccessor(model.sheet, ['cells']);
@@ -71,7 +71,7 @@ export const useSheetModelDxGridProps = (
     const columnMetaAccessor = createDocAccessor(model.sheet, ['columnMeta']);
     const rowMetaAccessor = createDocAccessor(model.sheet, ['rowMeta']);
     const handleColumnMetaUpdate = () => {
-      setDxGridColumns(createDxGridColumnns(model));
+      setDxGridColumns(createDxGridColumns(model));
     };
     const handleRowMetaUpdate = () => {
       setDxGridRows(createDxGridRows(model));

--- a/packages/plugins/plugin-sheet/src/components/GridSheet/util.ts
+++ b/packages/plugins/plugin-sheet/src/components/GridSheet/util.ts
@@ -59,15 +59,30 @@ export const useSheetModelDxGridProps = (
   const [dxGridRows, setDxGridRows] = useState<GridContentProps['rows']>(createDxGridColumnns(model));
 
   useEffect(() => {
-    const accessor = createDocAccessor(model.sheet, ['cells']);
+    const cellAccessor = createDocAccessor(model.sheet, ['cells']);
     const handleUpdate = () => {
       setDxGridCells(createDxGridCells(model, formatting));
+    };
+    cellAccessor.handle.addListener('change', handleUpdate);
+    return () => cellAccessor.handle.removeListener('change', handleUpdate);
+  }, [model, formatting]);
+
+  useEffect(() => {
+    const columnMetaAccessor = createDocAccessor(model.sheet, ['columnMeta']);
+    const rowMetaAccessor = createDocAccessor(model.sheet, ['rowMeta']);
+    const handleColumnMetaUpdate = () => {
       setDxGridColumns(createDxGridColumnns(model));
+    };
+    const handleRowMetaUpdate = () => {
       setDxGridRows(createDxGridRows(model));
     };
-    accessor.handle.addListener('change', handleUpdate);
-    return () => accessor.handle.removeListener('change', handleUpdate);
-  }, [model, formatting]);
+    columnMetaAccessor.handle.addListener('change', handleColumnMetaUpdate);
+    rowMetaAccessor.handle.addListener('change', handleRowMetaUpdate);
+    return () => {
+      columnMetaAccessor.handle.removeListener('change', handleColumnMetaUpdate);
+      rowMetaAccessor.handle.removeListener('change', handleRowMetaUpdate);
+    };
+  }, [model]);
 
   return { cells: dxGridCells, columns: dxGridColumns, rows: dxGridRows };
 };

--- a/packages/plugins/plugin-sheet/src/components/GridSheet/util.ts
+++ b/packages/plugins/plugin-sheet/src/components/GridSheet/util.ts
@@ -59,12 +59,12 @@ export const useSheetModelDxGridProps = (
   const [dxGridRows, setDxGridRows] = useState<GridContentProps['rows']>(createDxGridColumnns(model));
 
   useEffect(() => {
-    const cellAccessor = createDocAccessor(model.sheet, ['cells']);
-    const handleUpdate = () => {
+    const cellsAccessor = createDocAccessor(model.sheet, ['cells']);
+    const handleCellsUpdate = () => {
       setDxGridCells(createDxGridCells(model, formatting));
     };
-    cellAccessor.handle.addListener('change', handleUpdate);
-    return () => cellAccessor.handle.removeListener('change', handleUpdate);
+    cellsAccessor.handle.addListener('change', handleCellsUpdate);
+    return () => cellsAccessor.handle.removeListener('change', handleCellsUpdate);
   }, [model, formatting]);
 
   useEffect(() => {

--- a/packages/plugins/plugin-sheet/src/components/GridSheet/util.ts
+++ b/packages/plugins/plugin-sheet/src/components/GridSheet/util.ts
@@ -32,17 +32,42 @@ const createDxGridCells = (model: SheetModel, formatting: FormattingModel) => {
   }, {});
 };
 
-export const useSheetModelDxGridCells = (model: SheetModel, formatting: FormattingModel): GridContentProps['cells'] => {
+const createDxGridColumnns = (model: SheetModel): GridContentProps['columns'] => {
+  return model.sheet.columns.reduce((acc: NonNullable<GridContentProps['columns']>, columnId, numericIndex) => {
+    if (model.sheet.columnMeta[columnId] && model.sheet.columnMeta[columnId].size) {
+      acc[numericIndex] = { size: model.sheet.columnMeta[columnId].size, resizeable: true };
+    }
+    return acc;
+  }, {});
+};
+
+const createDxGridRows = (model: SheetModel): GridContentProps['rows'] => {
+  return model.sheet.rows.reduce((acc: NonNullable<GridContentProps['rows']>, rowId, numericIndex) => {
+    if (model.sheet.rowMeta[rowId] && model.sheet.rowMeta[rowId].size) {
+      acc[numericIndex] = { size: model.sheet.rowMeta[rowId].size, resizeable: true };
+    }
+    return acc;
+  }, {});
+};
+
+export const useSheetModelDxGridProps = (
+  model: SheetModel,
+  formatting: FormattingModel,
+): Pick<GridContentProps, 'cells' | 'columns' | 'rows'> => {
   const [dxGridCells, setDxGridCells] = useState<GridContentProps['cells']>(createDxGridCells(model, formatting));
+  const [dxGridColumns, setDxGridColumns] = useState<GridContentProps['columns']>(createDxGridColumnns(model));
+  const [dxGridRows, setDxGridRows] = useState<GridContentProps['rows']>(createDxGridColumnns(model));
 
   useEffect(() => {
     const accessor = createDocAccessor(model.sheet, ['cells']);
     const handleUpdate = () => {
       setDxGridCells(createDxGridCells(model, formatting));
+      setDxGridColumns(createDxGridColumnns(model));
+      setDxGridRows(createDxGridRows(model));
     };
     accessor.handle.addListener('change', handleUpdate);
     return () => accessor.handle.removeListener('change', handleUpdate);
   }, [model, formatting]);
 
-  return dxGridCells;
+  return { cells: dxGridCells, columns: dxGridColumns, rows: dxGridRows };
 };


### PR DESCRIPTION
This PR:
- succeeds #7817
- continues resolution of #7615
  - binds `DxGrid`’s `AxisResize` events to `SheetModel`’s `columnMeta` and `rowMeta` properties.

Will auto—merge this since the scope is limited and low-risk, but I’d be glad to incorporate any feedback into a follow-up.

https://github.com/user-attachments/assets/e63eeb7a-ccfc-42ce-b2e4-ad7977337bcd
