### PR TITLE
fix(edge): immediately start feed replication if edge-client is connected

### DIFF
--- a/packages/core/mesh/edge-client/src/edge-client.test.ts
+++ b/packages/core/mesh/edge-client/src/edge-client.test.ts
@@ -4,6 +4,7 @@
 
 import { test, expect, describe, onTestFinished } from 'vitest';
 
+import { Trigger } from '@dxos/async';
 import { PublicKey } from '@dxos/keys';
 import { TextMessageSchema } from '@dxos/protocols/buf/dxos/edge/messenger_pb';
 import { openAndClose } from '@dxos/test-utils';
@@ -29,6 +30,28 @@ describe('EdgeClient', () => {
     await closeConnection();
     await reconnected;
     await expect(client.send(textMessage('Hello world 2'))).resolves.not.toThrow();
+  });
+
+  test('isConnected', async () => {
+    const admitConnection = new Trigger();
+    const { closeConnection, endpoint, cleanup } = await createTestEdgeWsServer(8001, { admitConnection });
+    onTestFinished(cleanup);
+
+    const id = PublicKey.random().toHex();
+    const client = new EdgeClient(id, id, { socketEndpoint: endpoint });
+    await openAndClose(client);
+
+    expect(client.isConnected).toBeFalsy();
+    admitConnection.wake();
+    await expect.poll(() => client.isConnected).toBeTruthy();
+
+    admitConnection.reset();
+    await closeConnection();
+    expect(client.isOpen).is.true;
+    await expect.poll(() => client.isConnected).toBeFalsy();
+
+    admitConnection.wake();
+    await expect.poll(() => client.isConnected).toBeTruthy();
   });
 
   test('set identity reconnects', async () => {

--- a/packages/core/mesh/edge-client/src/edge-client.ts
+++ b/packages/core/mesh/edge-client/src/edge-client.ts
@@ -28,6 +28,7 @@ export interface EdgeConnection extends Required<Lifecycle> {
   get identityKey(): string;
   get peerKey(): string;
   get isOpen(): boolean;
+  get isConnected(): boolean;
   setIdentity(params: { peerKey: string; identityKey: string }): void;
   addListener(listener: MessageListener): () => void;
   send(message: Message): Promise<void>;
@@ -72,6 +73,10 @@ export class EdgeClient extends Resource implements EdgeConnection {
       identity: this._identityKey,
       device: this._peerKey,
     };
+  }
+
+  get isConnected() {
+    return Boolean(this._ws) && this._ready.state === TriggerState.RESOLVED;
   }
 
   get identityKey() {

--- a/packages/sdk/client-services/src/packlets/spaces/edge-feed-replicator.test.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/edge-feed-replicator.test.ts
@@ -41,6 +41,16 @@ describe('EdgeFeedReplicator', () => {
     expect(messageSink[0].type).toEqual('get-metadata');
   });
 
+  test('replicates if added to a connected client', async () => {
+    const { endpoint, admitConnection, messageSink } = await createEdge();
+    const { messenger } = await createClient(endpoint);
+    admitConnection.wake();
+    await expect.poll(() => messenger.isConnected).toBeTruthy();
+
+    await attachReplicator(messenger);
+    await expect.poll(() => messageSink.length).toEqual(1);
+  });
+
   test('sends a block', async () => {
     const { endpoint, admitConnection, messageSink } = await createEdge();
     const { messenger } = await createClient(endpoint);

--- a/packages/sdk/client-services/src/packlets/spaces/edge-feed-replicator.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/edge-feed-replicator.ts
@@ -75,33 +75,28 @@ export class EdgeFeedReplicator extends Resource {
 
     this._messenger.connected.on(this._ctx, async () => {
       await this._resetConnection();
-
-      this._connected = true;
-      const connectionCtx = new Context({
-        onError: async (err: any) => {
-          if (connectionCtx !== this._connectionCtx) {
-            return;
-          }
-          if (err instanceof EdgeIdentityChangedError || err instanceof EdgeConnectionClosedError) {
-            log('resetting on reconnect');
-            await this._resetConnection();
-          } else {
-            this._ctx.raise(err);
-          }
-        },
-      });
-      this._connectionCtx = connectionCtx;
-      log('connection context created');
-      scheduleMicroTask(connectionCtx, async () => {
-        for (const feed of this._feeds.values()) {
-          await this._replicateFeed(connectionCtx, feed);
-        }
-      });
+      this._startReplication();
     });
+
+    if (this._messenger.isConnected) {
+      this._startReplication();
+    }
   }
 
   protected override async _close(): Promise<void> {
     await this._resetConnection();
+  }
+
+  private _startReplication() {
+    this._connected = true;
+    const connectionCtx = this._createConnectionContext();
+    this._connectionCtx = connectionCtx;
+    log('connection context created');
+    scheduleMicroTask(connectionCtx, async () => {
+      for (const feed of this._feeds.values()) {
+        await this._replicateFeed(connectionCtx, feed);
+      }
+    });
   }
 
   private async _resetConnection() {
@@ -271,6 +266,23 @@ export class EdgeFeedReplicator extends Resource {
     if (remoteLength < feed.length) {
       await this._pushBlocks(feed, remoteLength, feed.length);
     }
+  }
+
+  private _createConnectionContext() {
+    const connectionCtx = new Context({
+      onError: async (err: any) => {
+        if (connectionCtx !== this._connectionCtx) {
+          return;
+        }
+        if (err instanceof EdgeIdentityChangedError || err instanceof EdgeConnectionClosedError) {
+          log('resetting on reconnect');
+          await this._resetConnection();
+        } else {
+          this._ctx.raise(err);
+        }
+      },
+    });
+    return connectionCtx;
   }
 }
 


### PR DESCRIPTION
### Details

Fixes the race where edge replicator needs to be opened before edge client is connected for things to work.