### PR TITLE
chore: ensure type icons use latest attention changes

### DIFF
--- a/packages/plugins/experimental/plugin-script/src/components/ScriptContainer.tsx
+++ b/packages/plugins/experimental/plugin-script/src/components/ScriptContainer.tsx
@@ -5,15 +5,15 @@
 import React from 'react';
 
 import { fullyQualifiedId } from '@dxos/react-client/echo';
-import { useHasAttention } from '@dxos/react-ui-attention';
+import { useAttendableAttributes } from '@dxos/react-ui-attention';
 import { mx } from '@dxos/react-ui-theme';
 
 import { ScriptEditor, type ScriptEditorProps } from './ScriptEditor';
 
 const ScriptContainer = ({ script, ...props }: ScriptEditorProps) => {
-  const hasAttention = useHasAttention(fullyQualifiedId(script));
+  const attendableAttrs = useAttendableAttributes(fullyQualifiedId(script));
   return (
-    <div role='none' className={mx('flex row-span-2 w-full overflow-hidden', hasAttention && 'attention-surface')}>
+    <div role='none' className={mx('flex row-span-2 w-full overflow-hidden attention-surface')} {...attendableAttrs}>
       <ScriptEditor {...props} script={script} />
     </div>
   );

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/NodePlankHeading.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/NodePlankHeading.tsx
@@ -28,8 +28,6 @@ export const NodePlankHeading = ({
   id,
   layoutParts,
   layoutPart,
-  // TODO(wittjosiah): Unused?
-  layoutEntry,
   popoverAnchorId,
   pending,
   flatDeck,
@@ -38,7 +36,6 @@ export const NodePlankHeading = ({
   id?: string;
   layoutParts?: LayoutParts;
   layoutPart?: LayoutPart;
-  layoutEntry?: LayoutEntry;
   popoverAnchorId?: string;
   pending?: boolean;
   flatDeck?: boolean;
@@ -79,6 +76,7 @@ export const NodePlankHeading = ({
         {node ? (
           <PlankHeading.ActionsMenu
             icon={icon}
+            related={layoutPart === 'complementary'}
             attendableId={attendableId}
             triggerLabel={t('actions menu label')}
             actions={graph.actions(node)}
@@ -96,7 +94,11 @@ export const NodePlankHeading = ({
         )}
       </ActionRoot>
       <TextTooltip text={label} onlyWhenTruncating>
-        <PlankHeading.Label attendableId={node?.id} {...(pending && { classNames: 'text-description' })}>
+        <PlankHeading.Label
+          attendableId={attendableId}
+          related={layoutPart === 'complementary'}
+          {...(pending && { classNames: 'text-description' })}
+        >
           {label}
         </PlankHeading.Label>
       </TextTooltip>

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/NodePlankHeading.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/NodePlankHeading.tsx
@@ -14,7 +14,6 @@ import {
   partLength,
   type LayoutParts,
   type LayoutPart,
-  type LayoutEntry,
 } from '@dxos/app-framework';
 import { type Node, useGraph } from '@dxos/plugin-graph';
 import { Icon, Popover, toLocalizedString, useMediaQuery, useTranslation } from '@dxos/react-ui';

--- a/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
@@ -8,7 +8,7 @@ import React, { useMemo, useEffect, useCallback } from 'react';
 
 import { type FileInfo, LayoutAction, type LayoutCoordinate, useIntentDispatcher } from '@dxos/app-framework';
 import { useThemeContext, useTranslation } from '@dxos/react-ui';
-import { useAttendableAttributes, useHasAttention } from '@dxos/react-ui-attention';
+import { useAttendableAttributes, useAttention } from '@dxos/react-ui-attention';
 import {
   type Action,
   type DNDOptions,
@@ -77,7 +77,7 @@ export const MarkdownEditor = ({
   const dispatch = useIntentDispatcher();
   const [formattingState, formattingObserver] = useFormattingState();
   const attendableAttributes = useAttendableAttributes(id);
-  const hasAttention = useHasAttention(id);
+  const { hasAttention } = useAttention(id);
 
   // Extensions from other plugins.
   const providerExtensions = useMemo(

--- a/packages/plugins/plugin-sheet/src/components/Sheet/Sheet.tsx
+++ b/packages/plugins/plugin-sheet/src/components/Sheet/Sheet.tsx
@@ -40,7 +40,7 @@ import { debounce } from '@dxos/async';
 import { fullyQualifiedId, createDocAccessor } from '@dxos/client/echo';
 import { log } from '@dxos/log';
 import { type ThemedClassName } from '@dxos/react-ui';
-import { useAttendableAttributes, useHasAttention } from '@dxos/react-ui-attention';
+import { useAttendableAttributes, useAttention } from '@dxos/react-ui-attention';
 import { mx } from '@dxos/react-ui-theme';
 
 import {
@@ -864,7 +864,7 @@ const SheetGrid = forwardRef<HTMLDivElement, SheetGridProps>(
     // TODO(burdon): Prevent scroll if not attended.
     const id = fullyQualifiedId(model.sheet);
     const attendableAttrs = useAttendableAttributes(id);
-    const hasAttention = useHasAttention(id);
+    const { hasAttention } = useAttention(id);
 
     return (
       <div ref={containerRef} role='grid' className='relative flex grow overflow-hidden'>

--- a/packages/plugins/plugin-sheet/src/components/SheetContainer.tsx
+++ b/packages/plugins/plugin-sheet/src/components/SheetContainer.tsx
@@ -6,7 +6,7 @@ import React, { useCallback } from 'react';
 
 import { useIntentDispatcher } from '@dxos/app-framework';
 import { fullyQualifiedId } from '@dxos/react-client/echo';
-import { useHasAttention } from '@dxos/react-ui-attention';
+import { useAttention } from '@dxos/react-ui-attention';
 import { focusRing, mx } from '@dxos/react-ui-theme';
 
 import { Sheet, type SheetRootProps } from './Sheet';
@@ -26,7 +26,7 @@ const SheetContainer = ({ graph, sheet, role }: SheetRootProps & { role?: string
   const dispatch = useIntentDispatcher();
 
   const id = fullyQualifiedId(sheet);
-  const hasAttention = useHasAttention(id);
+  const { hasAttention } = useAttention(id);
 
   // TODO(Zan): Centralise the toolbar action handler. Current implementation in stories.
   const handleAction = useCallback(

--- a/packages/plugins/plugin-sketch/src/components/SketchContainer.tsx
+++ b/packages/plugins/plugin-sketch/src/components/SketchContainer.tsx
@@ -6,7 +6,7 @@ import React, { useCallback } from 'react';
 
 import { useIntentDispatcher } from '@dxos/app-framework';
 import { fullyQualifiedId } from '@dxos/react-client/echo';
-import { useAttendableAttributes, useHasAttention } from '@dxos/react-ui-attention';
+import { useAttendableAttributes, useAttention } from '@dxos/react-ui-attention';
 
 import { Sketch, type SketchProps } from './Sketch';
 
@@ -14,7 +14,7 @@ import { Sketch, type SketchProps } from './Sketch';
 const SketchContainer = ({ classNames, sketch, ...props }: SketchProps) => {
   const id = fullyQualifiedId(sketch);
   const attentionAttrs = useAttendableAttributes(id);
-  const hasAttention = useHasAttention(id);
+  const { hasAttention } = useAttention(id);
   const dispatch = useIntentDispatcher();
 
   const onThreadCreate = useCallback(() => {

--- a/packages/plugins/plugin-table/src/components/TableContainer.tsx
+++ b/packages/plugins/plugin-table/src/components/TableContainer.tsx
@@ -6,7 +6,7 @@ import React, { useCallback } from 'react';
 
 import { useIntentDispatcher, type LayoutContainerProps } from '@dxos/app-framework';
 import { fullyQualifiedId } from '@dxos/react-client/echo';
-import { useHasAttention } from '@dxos/react-ui-attention';
+import { useAttention } from '@dxos/react-ui-attention';
 import { Table } from '@dxos/react-ui-table';
 import { mx } from '@dxos/react-ui-theme';
 
@@ -17,7 +17,7 @@ import { Toolbar, type ToolbarAction } from './Toolbar';
 export const sectionToolbarLayout = 'bs-[--rail-action] bg-[--sticky-bg] sticky block-start-0 transition-opacity';
 
 const TableContainer = ({ role, table }: LayoutContainerProps<Omit<ObjectTableProps, 'role' | 'getScrollElement'>>) => {
-  const hasAttention = useHasAttention(fullyQualifiedId(table));
+  const { hasAttention } = useAttention(fullyQualifiedId(table));
   const dispatch = useIntentDispatcher();
 
   const onThreadCreate = useCallback(() => {

--- a/packages/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -170,7 +170,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
                   type: 'orphan-comments-for-subject',
                   data: null,
                   properties: {
-                    icon: 'ph--quotes--regular',
+                    icon: 'ph--chat-text--regular',
                     label,
                     showResolvedThreads: viewState.showResolvedThreads,
                     object,

--- a/packages/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -616,7 +616,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
               },
             }),
             createExternalCommentSync(
-              doc.id,
+              fullyQualifiedId(doc),
               (sink) => effect(() => sink()),
               () =>
                 threads.value
@@ -624,7 +624,7 @@ export const ThreadPlugin = (): PluginDefinition<ThreadPluginProvides> => {
                   .map((thread) => ({ id: fullyQualifiedId(thread), cursor: thread.anchor! })),
             ),
             comments({
-              id: doc.id,
+              id: fullyQualifiedId(doc),
               onCreate: ({ cursor }) => {
                 const [start, end] = cursor.split(':');
                 const name = doc.content && getTextInRange(createDocAccessor(doc.content, ['content']), start, end);

--- a/packages/plugins/plugin-thread/src/components/CommentsContainer.tsx
+++ b/packages/plugins/plugin-thread/src/components/CommentsContainer.tsx
@@ -7,8 +7,7 @@ import React, { useEffect } from 'react';
 
 import { type ThreadType } from '@dxos/plugin-space/types';
 import { fullyQualifiedId } from '@dxos/react-client/echo';
-import { useTranslation, Icon, Trans } from '@dxos/react-ui';
-import { PlankHeading } from '@dxos/react-ui-deck';
+import { useTranslation, Trans } from '@dxos/react-ui';
 import { descriptionText, mx } from '@dxos/react-ui-theme';
 
 import { CommentContainer } from './CommentContainer';

--- a/packages/plugins/plugin-thread/src/components/CommentsContainer.tsx
+++ b/packages/plugins/plugin-thread/src/components/CommentsContainer.tsx
@@ -33,19 +33,6 @@ export type ThreadsContainerProps = Omit<
   onComment?: (thread: ThreadType) => void;
 };
 
-export const CommentsHeading = ({ attendableId }: { attendableId?: string }) => {
-  const { t } = useTranslation(THREAD_PLUGIN);
-
-  return (
-    <div role='none' className='flex items-center'>
-      <PlankHeading.Button attendableId={attendableId}>
-        <Icon icon='ph--quotes--regular' size={5} />
-      </PlankHeading.Button>
-      <PlankHeading.Label attendableId={attendableId}>{t('comments heading')}</PlankHeading.Label>
-    </div>
-  );
-};
-
 /**
  * Comment threads.
  */

--- a/packages/plugins/plugin-thread/src/components/ThreadComplementary.tsx
+++ b/packages/plugins/plugin-thread/src/components/ThreadComplementary.tsx
@@ -11,7 +11,7 @@ import { ScrollArea } from '@dxos/react-ui';
 import { useAttended } from '@dxos/react-ui-attention';
 import { nonNullable } from '@dxos/util';
 
-import { CommentsContainer, CommentsHeading } from '../components';
+import { CommentsContainer } from '../components';
 import { THREAD_PLUGIN } from '../meta';
 import { ThreadAction, type ThreadProvides } from '../types';
 
@@ -61,7 +61,6 @@ export const ThreadComplementary = ({
 
   return (
     <div role='none' className='contents'>
-      {role === 'complementary' && <CommentsHeading attendableId={qualifiedSubjectId} />}
       <ScrollArea.Root classNames='row-span-2'>
         <ScrollArea.Viewport>
           <CommentsContainer

--- a/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
+++ b/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
@@ -37,7 +37,9 @@ import { type PlankHeadingAction } from '../../types';
 
 type AttendableId = { attendableId?: string };
 
-type PlankHeadingButtonProps = Omit<ButtonProps, 'variant'> & AttendableId;
+type Related = { related?: boolean };
+
+type PlankHeadingButtonProps = Omit<ButtonProps, 'variant'> & AttendableId & Related;
 
 type PlankRootProps = ThemedClassName<ComponentPropsWithRef<'div'>>;
 
@@ -78,12 +80,13 @@ const _MenuSignifierVertical = () => (
 );
 
 const PlankHeadingButton = forwardRef<HTMLButtonElement, PlankHeadingButtonProps>(
-  ({ attendableId, classNames, children, ...props }, forwardedRef) => {
-    const { hasAttention, isAncestor } = useAttention(attendableId);
+  ({ attendableId, classNames, related, children, ...props }, forwardedRef) => {
+    const { hasAttention, isAncestor, isRelated } = useAttention(attendableId);
+    const variant = (related && isRelated) || hasAttention || isAncestor ? 'primary' : 'ghost';
     return (
       <Button
         {...props}
-        variant={hasAttention || isAncestor ? 'primary' : 'ghost'}
+        variant={variant}
         classNames={['m-1 shrink-0 pli-0 min-bs-0 is-[--rail-action] bs-[--rail-action] relative', classNames]}
         ref={forwardedRef}
       >
@@ -94,16 +97,18 @@ const PlankHeadingButton = forwardRef<HTMLButtonElement, PlankHeadingButtonProps
   },
 );
 
-type PlankHeadingActionsMenuProps = PropsWithChildren<{
-  attendableId?: string;
-  triggerLabel: string;
-  actions?: PlankHeadingAction[];
-  icon: string;
-  onAction?: (action: PlankHeadingAction) => void;
-}>;
+type PlankHeadingActionsMenuProps = PropsWithChildren<
+  {
+    attendableId?: string;
+    triggerLabel: string;
+    actions?: PlankHeadingAction[];
+    icon: string;
+    onAction?: (action: PlankHeadingAction) => void;
+  } & Related
+>;
 
 const PlankHeadingActionsMenu = forwardRef<HTMLButtonElement, PlankHeadingActionsMenuProps>(
-  ({ actions, onAction, triggerLabel, attendableId, icon, children }, forwardedRef) => {
+  ({ actions, onAction, triggerLabel, attendableId, icon, related, children }, forwardedRef) => {
     const { t } = useTranslation(translationKey);
     const suppressNextTooltip = useRef(false);
 
@@ -135,7 +140,7 @@ const PlankHeadingActionsMenu = forwardRef<HTMLButtonElement, PlankHeadingAction
         >
           <Tooltip.Trigger asChild>
             <DropdownMenu.Trigger asChild ref={forwardedRef}>
-              <PlankHeadingButton attendableId={attendableId}>
+              <PlankHeadingButton attendableId={attendableId} related={related}>
                 <span className='sr-only'>{triggerLabel}</span>
                 <Icon icon={icon} size={5} />
               </PlankHeadingButton>
@@ -201,15 +206,15 @@ const PlankHeadingActionsMenu = forwardRef<HTMLButtonElement, PlankHeadingAction
   },
 );
 
-type PlankHeadingLabelProps = ThemedClassName<ComponentPropsWithRef<'h1'>> & AttendableId;
+type PlankHeadingLabelProps = ThemedClassName<ComponentPropsWithRef<'h1'>> & AttendableId & Related;
 
 const PlankHeadingLabel = forwardRef<HTMLHeadingElement, PlankHeadingLabelProps>(
-  ({ attendableId, classNames, ...props }, forwardedRef) => {
-    const { hasAttention, isAncestor } = useAttention(attendableId);
+  ({ attendableId, related, classNames, ...props }, forwardedRef) => {
+    const { hasAttention, isAncestor, isRelated } = useAttention(attendableId);
     return (
       <h1
         {...props}
-        data-attention={(hasAttention || isAncestor).toString()}
+        data-attention={((related && isRelated) || hasAttention || isAncestor).toString()}
         className={mx(
           'pli-1 min-is-0 is-0 grow truncate font-medium text-baseText data-[attention=true]:text-accentText',
           classNames,

--- a/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
+++ b/packages/ui/react-ui-deck/src/components/PlankHeading/PlankHeading.tsx
@@ -27,7 +27,7 @@ import {
   Tooltip,
   useTranslation,
 } from '@dxos/react-ui';
-import { useHasAttention } from '@dxos/react-ui-attention';
+import { useAttention } from '@dxos/react-ui-attention';
 import { descriptionText, getSize, mx } from '@dxos/react-ui-theme';
 import { getHostPlatform } from '@dxos/util';
 
@@ -79,11 +79,11 @@ const _MenuSignifierVertical = () => (
 
 const PlankHeadingButton = forwardRef<HTMLButtonElement, PlankHeadingButtonProps>(
   ({ attendableId, classNames, children, ...props }, forwardedRef) => {
-    const hasAttention = useHasAttention(attendableId);
+    const { hasAttention, isAncestor } = useAttention(attendableId);
     return (
       <Button
         {...props}
-        variant={hasAttention ? 'primary' : 'ghost'}
+        variant={hasAttention || isAncestor ? 'primary' : 'ghost'}
         classNames={['m-1 shrink-0 pli-0 min-bs-0 is-[--rail-action] bs-[--rail-action] relative', classNames]}
         ref={forwardedRef}
       >
@@ -205,11 +205,11 @@ type PlankHeadingLabelProps = ThemedClassName<ComponentPropsWithRef<'h1'>> & Att
 
 const PlankHeadingLabel = forwardRef<HTMLHeadingElement, PlankHeadingLabelProps>(
   ({ attendableId, classNames, ...props }, forwardedRef) => {
-    const hasAttention = useHasAttention(attendableId);
+    const { hasAttention, isAncestor } = useAttention(attendableId);
     return (
       <h1
         {...props}
-        data-attention={hasAttention.toString()}
+        data-attention={(hasAttention || isAncestor).toString()}
         className={mx(
           'pli-1 min-is-0 is-0 grow truncate font-medium text-baseText data-[attention=true]:text-accentText',
           classNames,

--- a/packages/ui/react-ui-editor/src/extensions/index.ts
+++ b/packages/ui/react-ui-editor/src/extensions/index.ts
@@ -18,4 +18,3 @@ export * from './markdown';
 export * from './mention';
 export * from './modes';
 export * from './typewriter';
-export * from './typewriter';


### PR DESCRIPTION
- plank type icons weren't being highlighted properly because they
should be highlighted even if they are an ancestor of the currently
attended item
- consolidate this logic into a single attention hook
- remove unused complementary sidebar heading for comments
