### PR TITLE
chore: edge testing fixes

### DIFF
--- a/packages/apps/composer-app/dx-local.yml
+++ b/packages/apps/composer-app/dx-local.yml
@@ -9,7 +9,7 @@ runtime:
 
   services:
     edge:
-       url: wss://edge.dxos.workers.dev/
-#      url: wss://edge-main.dxos.workers.dev/
+       url: https://edge.dxos.workers.dev/
+#      url: https://edge-main.dxos.workers.dev/
     agentHosting:
       type: LOCAL_TESTING

--- a/packages/apps/composer-app/dx.yml
+++ b/packages/apps/composer-app/dx.yml
@@ -21,7 +21,7 @@ runtime:
   services:
     edge:
       # TODO(wittjosiah): Default should be edge-production.
-      url: wss://edge-main.dxos.workers.dev/
+      url: https://edge-main.dxos.workers.dev/
     ice:
       - urls: turn:kube.dxos.org:3478
         username: dxos

--- a/packages/apps/testbench-app/dx.yml
+++ b/packages/apps/testbench-app/dx.yml
@@ -22,6 +22,6 @@ runtime:
         username: dxos
         credential: dxos
     edge:
-      url: wss://edge-main.dxos.workers.dev/
+      url: https://edge-main.dxos.workers.dev/
     iceProviders:
       - urls: https://edge-production.dxos.workers.dev/ice

--- a/packages/common/effect/package.json
+++ b/packages/common/effect/package.json
@@ -25,8 +25,7 @@
     "src"
   ],
   "dependencies": {
-    "@dxos/node-std": "workspace:*",
-    "xcase": "^2.0.1"
+    "@dxos/node-std": "workspace:*"
   },
   "devDependencies": {
     "@effect/schema": "^0.75.1",

--- a/packages/common/effect/src/decamelize.ts
+++ b/packages/common/effect/src/decamelize.ts
@@ -1,0 +1,36 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+const LOW_DASH = '_'.codePointAt(0)!;
+const SMALL_A = 'a'.codePointAt(0)!;
+const CAPITAL_A = 'A'.codePointAt(0)!;
+const SMALL_Z = 'z'.codePointAt(0)!;
+const CAPITAL_Z = 'Z'.codePointAt(0)!;
+
+const isLower = (char: number) => char >= SMALL_A && char <= SMALL_Z;
+
+const isUpper = (char: number) => char >= CAPITAL_A && char <= CAPITAL_Z;
+
+const toLower = (char: number) => char + 0x20;
+
+export const decamelize = (str: string) => {
+  const firstChar = str.charCodeAt(0);
+  if (!isLower(firstChar)) {
+    return str;
+  }
+  const length = str.length;
+  let changed = false;
+  const out: number[] = [];
+  for (let i = 0; i < length; ++i) {
+    const c = str.charCodeAt(i);
+    if (isUpper(c)) {
+      out.push(LOW_DASH);
+      out.push(toLower(c));
+      changed = true;
+    } else {
+      out.push(c);
+    }
+  }
+  return changed ? String.fromCharCode.apply(undefined, out) : str;
+};

--- a/packages/common/effect/src/url.ts
+++ b/packages/common/effect/src/url.ts
@@ -4,7 +4,8 @@
 
 import { AST, type Schema as S } from '@effect/schema';
 import { Option, pipe } from 'effect';
-import { decamelize } from 'xcase';
+
+import { decamelize } from './decamelize';
 
 const ParamKeyAnnotationId = Symbol.for('@dxos/schema/annotation/ParamKey');
 

--- a/packages/common/typings/src/index.d.ts
+++ b/packages/common/typings/src/index.d.ts
@@ -16,5 +16,4 @@ import './nanoresource-promise';
 import './race-as-promised';
 import './random-access-storage';
 import './streamx';
-import './xcase';
 import './zen-push';

--- a/packages/common/typings/src/xcase.d.ts
+++ b/packages/common/typings/src/xcase.d.ts
@@ -1,7 +1,0 @@
-//
-// Copyright 2024 DXOS.org
-//
-
-declare module 'xcase' {
-  const decamelize: (str: string) => string;
-}

--- a/packages/core/mesh/edge-client/src/edge-client.ts
+++ b/packages/core/mesh/edge-client/src/edge-client.ts
@@ -17,6 +17,7 @@ import { protocol } from './defs';
 import { EdgeConnectionClosedError, EdgeIdentityChangedError } from './errors';
 import { PersistentLifecycle } from './persistent-lifecycle';
 import { type Protocol, toUint8Array } from './protocol';
+import { getEdgeUrlWithProtocol } from './utils';
 
 const DEFAULT_TIMEOUT = 10_000;
 const SIGNAL_KEEPALIVE_INTERVAL = 5_000;
@@ -74,11 +75,14 @@ export class EdgeClient extends Resource implements EdgeConnection {
   private _keepaliveCtx?: Context = undefined;
   private _heartBeatContext?: Context = undefined;
 
+  private _baseUrl: string;
+
   constructor(
     private _identity: EdgeIdentity,
     private readonly _config: MessengerConfig,
   ) {
     super();
+    this._baseUrl = getEdgeUrlWithProtocol(_config.socketEndpoint, 'ws');
   }
 
   // TODO(burdon): Attach logging.
@@ -140,7 +144,7 @@ export class EdgeClient extends Resource implements EdgeConnection {
       protocolHeader = encodePresentationIntoAuthHeader(credential);
     }
 
-    const url = new URL(`/ws/${this._identity.identityKey}/${this._identity.peerKey}`, this._config.socketEndpoint);
+    const url = new URL(`/ws/${this._identity.identityKey}/${this._identity.peerKey}`, this._baseUrl);
     log('Opening websocket', { url: url.toString(), protocolHeader });
     this._ws = new WebSocket(url, protocolHeader ? [protocolHeader] : []);
 

--- a/packages/core/mesh/edge-client/src/edge-http-client.ts
+++ b/packages/core/mesh/edge-client/src/edge-http-client.ts
@@ -13,6 +13,8 @@ import {
   type PostNotarizationRequestBody,
 } from '@dxos/protocols';
 
+import { getEdgeUrlWithProtocol } from './utils';
+
 const DEFAULT_RETRY_TIMEOUT = 1500;
 const DEFAULT_RETRY_JITTER = 500;
 const DEFAULT_MAX_RETRIES_COUNT = 3;
@@ -21,9 +23,7 @@ export class EdgeHttpClient {
   private readonly _baseUrl: string;
 
   constructor(baseUrl: string) {
-    const url = new URL(baseUrl);
-    url.protocol = 'https';
-    this._baseUrl = url.toString();
+    this._baseUrl = getEdgeUrlWithProtocol(baseUrl, 'http');
     log('created', { url: this._baseUrl });
   }
 

--- a/packages/core/mesh/edge-client/src/utils.ts
+++ b/packages/core/mesh/edge-client/src/utils.ts
@@ -1,0 +1,10 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+export const getEdgeUrlWithProtocol = (baseUrl: string, protocol: 'http' | 'ws') => {
+  const isSecure = baseUrl.startsWith('https') || baseUrl.startsWith('wss');
+  const url = new URL(baseUrl);
+  url.protocol = protocol + (isSecure ? 's' : '');
+  return url.toString();
+};

--- a/packages/plugins/experimental/plugin-script/README.md
+++ b/packages/plugins/experimental/plugin-script/README.md
@@ -13,7 +13,7 @@ runtime:
       echoReplicator: true
   services:
     edge:
-      url: wss://edge.dxos.workers.dev/
+      url: https://edge.dxos.workers.dev/
     agentHosting:
       type: LOCAL_TESTING
 ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1462,9 +1462,6 @@ importers:
       '@dxos/node-std':
         specifier: workspace:*
         version: link:../node-std
-      xcase:
-        specifier: ^2.0.1
-        version: 2.0.1
     devDependencies:
       '@effect/schema':
         specifier: ^0.75.1
@@ -32976,9 +32973,6 @@ packages:
     resolution: {integrity: sha512-Ip6C2KeQPl/F3aP1EfOnPoQk14Udd9lffpoqWDNH3Xt78svxPbv53ngtmtfI0q2Te3oTq79XKTnRNXVIn/GsPA==}
     hasBin: true
 
-  xcase@2.0.1:
-    resolution: {integrity: sha512-UmFXIPU+9Eg3E9m/728Bii0lAIuoc+6nbrNUKaRPJOFp91ih44qqGlWtxMB6kXFrRD6po+86ksHM5XHCfk6iPw==}
-
   xlsjs@0.7.6:
     resolution: {integrity: sha512-IQtL2z+BVYaIVzEhknZ1YBr8ItUbqiS7kaQZ3O35/k1q+kSgjVxmzwno6r3EbBgEWhrVCad2mKbnFeMmEE5zdw==}
     engines: {node: '>=0.8'}
@@ -60472,8 +60466,6 @@ snapshots:
   ws@8.18.0: {}
 
   wtfnode@0.9.1: {}
-
-  xcase@2.0.1: {}
 
   xlsjs@0.7.6:
     dependencies:


### PR DESCRIPTION
### Details

* Simplify edge testing by allowing non-secure urls provided via config.
* Remove xcase to fix workerd env tests. Hard to inline a dependency imported from util which is the easiest way to enable cjs interop.