### PR TITLE
fix(lit-grid): Build Lit package(s) with tsc

### DIFF
--- a/packages/ui/lit-grid/package.json
+++ b/packages/ui/lit-grid/package.json
@@ -7,16 +7,13 @@
   "license": "MIT",
   "author": "DXOS.org",
   "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "exports": {
     ".": {
-      "browser": "./dist/src/index.js",
+      "import": "./dist/src/index.js",
       "types": "./dist/types/src/index.d.ts"
     },
     "./dx-grid.pcss": "./src/dx-grid.pcss"
-  },
-  "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
   },
   "files": [
     "src",

--- a/packages/ui/lit-grid/package.json
+++ b/packages/ui/lit-grid/package.json
@@ -6,9 +6,10 @@
   "bugs": "https://github.com/dxos/dxos/issues",
   "license": "MIT",
   "author": "DXOS.org",
+  "main": "dist/src/index.js",
   "exports": {
     ".": {
-      "browser": "./dist/lib/browser/index.mjs",
+      "browser": "./dist/src/index.js",
       "types": "./dist/types/src/index.d.ts"
     },
     "./dx-grid.pcss": "./src/dx-grid.pcss"

--- a/packages/ui/lit-grid/package.json
+++ b/packages/ui/lit-grid/package.json
@@ -6,8 +6,6 @@
   "bugs": "https://github.com/dxos/dxos/issues",
   "license": "MIT",
   "author": "DXOS.org",
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/src/index.js",
@@ -15,6 +13,8 @@
     },
     "./dx-grid.pcss": "./src/dx-grid.pcss"
   },
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "files": [
     "src",
     "dist"

--- a/packages/ui/lit-grid/project.json
+++ b/packages/ui/lit-grid/project.json
@@ -9,13 +9,15 @@
   "targets": {
     "build": {},
     "compile": {
+      "cache": true,
+      "dependsOn": [
+        "^build"
+      ],
+      "executor": "@nx/js:tsc",
       "options": {
-        "entryPoints": [
-          "{projectRoot}/src/index.ts"
-        ],
-        "platforms": [
-          "browser"
-        ]
+        "main": "{projectRoot}/src/index.ts",
+        "outputPath": "{projectRoot}/dist",
+        "tsConfig": "{projectRoot}/tsconfig.json"
       }
     },
     "lint": {

--- a/packages/ui/lit-grid/tsconfig.json
+++ b/packages/ui/lit-grid/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "module": "esnext",
     "emitDeclarationOnly": false,
     "lib": [
       "DOM",
       "ESNext"
     ],
+    "module": "esnext",
     "types": [
       "node"
     ]

--- a/packages/ui/lit-grid/tsconfig.json
+++ b/packages/ui/lit-grid/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "module": "esnext",
+    "emitDeclarationOnly": false,
     "lib": [
       "DOM",
       "ESNext"

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -320,9 +320,6 @@
       "@dxos/brand": [
         "packages/ui/brand/src/index.ts"
       ],
-      "@dxos/lit-grid": [
-        "packages/ui/lit-grid/src/index.ts"
-      ],
       "@dxos/react-ui": [
         "packages/ui/react-ui/src/index.ts"
       ],


### PR DESCRIPTION
Because `dx-grid` would be substantially more unreadable than it currently is if refactored not to use decorators, it is built with `tsc` like `cli-base` is in order to interoperate with SWC and esbuild.

<img width="1235" alt="Screenshot 2024-10-14 at 23 08 09" src="https://github.com/user-attachments/assets/d5f9f447-d063-4fa8-b4ac-1a7e0271fc43">
