### PR TITLE
fix(plugin-sheet): Polish Grid integration with Composer

### DIFF
--- a/packages/plugins/plugin-sheet/src/components/FunctionEditor/FunctionEditor.tsx
+++ b/packages/plugins/plugin-sheet/src/components/FunctionEditor/FunctionEditor.tsx
@@ -26,7 +26,11 @@ export const FunctionEditor = () => {
   }
 
   return (
-    <div className={mx('flex shrink-0 justify-between items-center px-4 py-1 text-sm border-x border-gridLine')}>
+    <div
+      className={mx(
+        'flex shrink-0 justify-between items-center px-4 py-1 text-sm border-bs !border-separator attention-surface',
+      )}
+    >
       <div className='flex gap-4 items-center'>
         <div className='flex w-16 items-center font-mono'>
           {(range && rangeToA1Notation(range)) || (cursor && addressToA1Notation(cursor))}

--- a/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.tsx
+++ b/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.tsx
@@ -141,6 +141,7 @@ export const GridSheet = () => {
         columnDefault={sheetColDefault}
         frozen={frozen}
         onFocus={handleFocus}
+        className='[--dx-grid-base:var(--surface-bg)]'
         ref={dxGrid}
       />
     </>

--- a/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.tsx
+++ b/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.tsx
@@ -2,8 +2,9 @@
 // Copyright 2024 DXOS.org
 //
 
-import React, { useCallback, useMemo, useRef, type FocusEvent } from 'react';
+import React, { useCallback, useMemo, useRef, type FocusEvent, type WheelEvent } from 'react';
 
+import { useAttention } from '@dxos/react-ui-attention';
 import {
   type DxGridElement,
   Grid,
@@ -41,9 +42,10 @@ const sheetRowDefault = { grid: { size: 32, resizeable: true } };
 const sheetColDefault = { frozenColsStart: { size: 48 }, grid: { size: 180, resizeable: true } };
 
 export const GridSheet = () => {
-  const { model, formatting, editing, setEditing, setCursor, setRange } = useSheetContext();
+  const { id, model, formatting, editing, setEditing, setCursor, setRange } = useSheetContext();
   const dxGrid = useRef<DxGridElement | null>(null);
   const rangeNotifier = useRef<CellRangeNotifier>();
+  const { hasAttention } = useAttention(id);
 
   const handleFocus = useCallback(
     (event: FocusEvent) => {
@@ -105,6 +107,15 @@ export const GridSheet = () => {
     [editing],
   );
 
+  const handleWheel = useCallback(
+    (event: WheelEvent) => {
+      if (!hasAttention) {
+        event.stopPropagation();
+      }
+    },
+    [hasAttention],
+  );
+
   const { columns, rows } = useSheetModelDxGridProps(dxGrid, model, formatting);
 
   const extension = useMemo(
@@ -141,6 +152,7 @@ export const GridSheet = () => {
         columnDefault={sheetColDefault}
         frozen={frozen}
         onFocus={handleFocus}
+        onWheelCapture={handleWheel}
         className='[--dx-grid-base:var(--surface-bg)]'
         ref={dxGrid}
       />

--- a/packages/plugins/plugin-sheet/src/components/SheetContainer/SheetContainer.tsx
+++ b/packages/plugins/plugin-sheet/src/components/SheetContainer/SheetContainer.tsx
@@ -43,8 +43,10 @@ export const SheetContainer = ({ graph, sheet, role }: SheetProviderProps & { ro
         <Toolbar.Separator />
         <Toolbar.Actions />
       </Toolbar.Root>
-      <GridSheet />
-      <FunctionEditor />
+      <div role='none' className='border-bs border-separator grid cols-1 rows-[1fr_min-content] min-bs-0'>
+        <GridSheet />
+        <FunctionEditor />
+      </div>
     </SheetProvider>
   );
 };

--- a/packages/plugins/plugin-sheet/src/model/formatting-model.ts
+++ b/packages/plugins/plugin-sheet/src/model/formatting-model.ts
@@ -34,7 +34,7 @@ export class FormattingModel {
 
     // Cell-specific formatting.
     const idx = addressToIndex(this._model.sheet, cell);
-    let formatting = this._model.sheet.formatting.find(({ range }) => range === idx);
+    let formatting = this._model.sheet.formatting.find?.(({ range }) => range === idx);
     const classNames = [...(formatting?.classNames ?? [])];
 
     // Range formatting.

--- a/packages/ui/lit-grid/src/dx-grid.pcss
+++ b/packages/ui/lit-grid/src/dx-grid.pcss
@@ -60,6 +60,7 @@ dx-grid, dx-grid-axis-resize-handle {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    align-content: center;
     &[inert] {
       visibility: hidden;
     }


### PR DESCRIPTION
This PR:
- adjusts where borders are applied
- fixes the layout of GridSheet alongside FunctionEditor
- applies the surface token to the grid so it responds correctly to attention
- centers cell content by default
- prevents panning within the grid when it doesn’t have attention
  - ⚠️ I didn’t yet find a way to prevent deck scrolling _when grid does have attention_


https://github.com/user-attachments/assets/e4a8635f-f2c7-4cff-b92d-9e185a762cd0

