### PR TITLE
fix: ensure identity is restorable

### DIFF
--- a/packages/sdk/client-services/src/packlets/identity/identity-manager.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity-manager.ts
@@ -265,9 +265,11 @@ export class IdentityManager {
    */
   public async acceptIdentity(identity: Identity, identityRecord: IdentityRecord, profile?: DeviceProfileDocument) {
     this._identity = identity;
+
+    // Identity becomes ready after device chain is replicated. Wait for it before storing the record.
+    await this._identity.ready();
     await this._metadataStore.setIdentityRecord(identityRecord);
 
-    await this._identity.ready();
     log.trace('dxos.halo.identity', {
       identityKey: this._identity!.identityKey,
       displayName: this._identity.profileDocument?.displayName,


### PR DESCRIPTION
### Details

Identity becomes ready after device chain is replicated. Wait for it before storing the record.
This ensures we can reconstruct identity on the next app launch.