### PR TITLE
feat: edge http auth & edge replicator reconnect backoff

### DIFF
--- a/packages/core/mesh/edge-client/src/auth.ts
+++ b/packages/core/mesh/edge-client/src/auth.ts
@@ -8,7 +8,7 @@ import { Keyring } from '@dxos/keyring';
 import { PublicKey } from '@dxos/keys';
 import { type Chain, type Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
 
-import type { EdgeIdentity } from './edge-client';
+import type { EdgeIdentity } from './edge-identity';
 
 /**
  * Edge identity backed by a device key without a credential chain.

--- a/packages/core/mesh/edge-client/src/edge-client.ts
+++ b/packages/core/mesh/edge-client/src/edge-client.ts
@@ -6,14 +6,12 @@ import WebSocket from 'isomorphic-ws';
 
 import { Trigger, Event, scheduleTaskInterval, scheduleTask, TriggerState } from '@dxos/async';
 import { Context, LifecycleState, Resource, type Lifecycle } from '@dxos/context';
-import { randomBytes } from '@dxos/crypto';
 import { log } from '@dxos/log';
 import { buf } from '@dxos/protocols/buf';
 import { type Message, MessageSchema } from '@dxos/protocols/buf/dxos/edge/messenger_pb';
-import { schema } from '@dxos/protocols/proto';
-import { type Presentation } from '@dxos/protocols/proto/dxos/halo/credentials';
 
 import { protocol } from './defs';
+import { type EdgeIdentity, handleAuthChallenge } from './edge-identity';
 import { EdgeConnectionClosedError, EdgeIdentityChangedError } from './errors';
 import { PersistentLifecycle } from './persistent-lifecycle';
 import { type Protocol, toUint8Array } from './protocol';
@@ -45,17 +43,6 @@ export type MessengerConfig = {
   disableAuth?: boolean;
 };
 
-export interface EdgeIdentity {
-  peerKey: string;
-  identityKey: string;
-  /**
-   * Returns credential presentation issued by the identity key.
-   * Presentation must have the provided challenge.
-   * Presentation may include ServiceAccess credentials.
-   */
-  presentCredentials({ challenge }: { challenge: Uint8Array }): Promise<Presentation>;
-}
-
 /**
  * Messenger client.
  */
@@ -74,14 +61,16 @@ export class EdgeClient extends Resource implements EdgeConnection {
   private _keepaliveCtx?: Context = undefined;
   private _heartBeatContext?: Context = undefined;
 
-  private _baseUrl: string;
+  private _baseWsUrl: string;
+  private _baseHttpUrl: string;
 
   constructor(
     private _identity: EdgeIdentity,
     private readonly _config: MessengerConfig,
   ) {
     super();
-    this._baseUrl = getEdgeUrlWithProtocol(_config.socketEndpoint, 'ws');
+    this._baseWsUrl = getEdgeUrlWithProtocol(_config.socketEndpoint, 'ws');
+    this._baseHttpUrl = getEdgeUrlWithProtocol(_config.socketEndpoint, 'http');
   }
 
   // TODO(burdon): Attach logging.
@@ -137,20 +126,13 @@ export class EdgeClient extends Resource implements EdgeConnection {
   }
 
   private async _openWebSocket() {
-    let protocolHeader: string | undefined;
-
-    if (!this._config.disableAuth) {
-      // TODO(dmaretskyi): Get challenge from the WWW-Authenticate header returned by the endpoint.
-      const challenge = randomBytes(32);
-      const credential = await this._identity.presentCredentials({ challenge });
-      protocolHeader = encodePresentationIntoAuthHeader(credential);
-    }
-
     if (this._ctx.disposed) {
       return;
     }
+    const path = `/ws/${this._identity.identityKey}/${this._identity.peerKey}`;
+    const protocolHeader = this._config.disableAuth ? undefined : await this._createAuthHeader(path);
 
-    const url = new URL(`/ws/${this._identity.identityKey}/${this._identity.peerKey}`, this._baseUrl);
+    const url = new URL(path, this._baseWsUrl);
     log('Opening websocket', { url: url.toString(), protocolHeader });
     this._ws = new WebSocket(url, protocolHeader ? [protocolHeader] : []);
 
@@ -271,12 +253,22 @@ export class EdgeClient extends Resource implements EdgeConnection {
       2 * SIGNAL_KEEPALIVE_INTERVAL,
     );
   }
+
+  private async _createAuthHeader(path: string): Promise<string | undefined> {
+    const httpUrl = new URL(path, this._baseHttpUrl);
+    httpUrl.protocol = getEdgeUrlWithProtocol(this._baseWsUrl.toString(), 'http');
+    const response = await fetch(httpUrl, { method: 'GET' });
+    if (response.status === 401) {
+      return encodePresentationWsAuthHeader(await handleAuthChallenge(response, this._identity));
+    } else {
+      log.warn('no auth challenge from edge', { status: response.status, statusText: response.statusText });
+      return undefined;
+    }
+  }
 }
 
-const encodePresentationIntoAuthHeader = (presentation: Presentation): string => {
-  const encoded = schema.getCodecForType('dxos.halo.credentials.Presentation').encode(presentation);
+const encodePresentationWsAuthHeader = (encodedPresentation: Uint8Array): string => {
   // = and / characters are not allowed in the WebSocket subprotocol header.
-  const encodedToken = Buffer.from(encoded).toString('base64').replace(/=*$/, '').replaceAll('/', '|');
-
+  const encodedToken = Buffer.from(encodedPresentation).toString('base64').replace(/=*$/, '').replaceAll('/', '|');
   return `base64url.bearer.authorization.dxos.org.${encodedToken}`;
 };

--- a/packages/core/mesh/edge-client/src/edge-http-client.ts
+++ b/packages/core/mesh/edge-client/src/edge-http-client.ts
@@ -19,6 +19,7 @@ import {
   type GetAgentStatusResponseBody,
 } from '@dxos/protocols';
 
+import { type EdgeIdentity, handleAuthChallenge } from './edge-identity';
 import { getEdgeUrlWithProtocol } from './utils';
 
 const DEFAULT_RETRY_TIMEOUT = 1500;
@@ -28,9 +29,19 @@ const DEFAULT_MAX_RETRIES_COUNT = 3;
 export class EdgeHttpClient {
   private readonly _baseUrl: string;
 
+  private _edgeIdentity: EdgeIdentity | undefined;
+  /**
+   * Auth header is cached until receiving the next 401 from EDGE, at which point it gets refreshed.
+   */
+  private _authHeader: string | undefined;
+
   constructor(baseUrl: string) {
     this._baseUrl = getEdgeUrlWithProtocol(baseUrl, 'http');
     log('created', { url: this._baseUrl });
+  }
+
+  setIdentity(identity: EdgeIdentity) {
+    this._edgeIdentity = identity;
   }
 
   public createAgent(body: CreateAgentRequestBody, args?: EdgeHttpGetArgs): Promise<CreateAgentResponseBody> {
@@ -67,15 +78,17 @@ export class EdgeHttpClient {
   private async _call<T>(path: string, args: EdgeHttpCallArgs): Promise<T> {
     const requestContext = args.context ?? new Context();
     const shouldRetry = createRetryHandler(args);
-    const request = createRequest(args);
     const url = `${this._baseUrl}${path.startsWith('/') ? path.slice(1) : path}`;
 
     log.info('call', { method: args.method, path, request: args.body });
 
+    let handledAuth = false;
+    let authHeader = this._authHeader;
     while (true) {
       let processingError: EdgeCallFailedError;
       let retryAfterHeaderValue: number = Number.NaN;
       try {
+        const request = createRequest(args, authHeader);
         const response = await fetch(url, request);
 
         retryAfterHeaderValue = Number(response.headers.get('Retry-After'));
@@ -93,6 +106,10 @@ export class EdgeHttpClient {
           } else {
             processingError = EdgeCallFailedError.fromUnsuccessfulResponse(response, body);
           }
+        } else if (response.status === 401 && !handledAuth) {
+          authHeader = await this._handleUnauthorized(response);
+          handledAuth = true;
+          continue;
         } else {
           processingError = EdgeCallFailedError.fromHttpFailure(response);
         }
@@ -107,14 +124,18 @@ export class EdgeHttpClient {
       }
     }
   }
-}
 
-const createRequest = (args: EdgeHttpCallArgs): RequestInit => {
-  return {
-    method: args.method,
-    body: args.body && JSON.stringify(args.body),
-  };
-};
+  private async _handleUnauthorized(response: Response) {
+    if (!this._edgeIdentity) {
+      log.warn('edge unauthorized response received before identity was set');
+      throw EdgeCallFailedError.fromHttpFailure(response);
+    }
+    const challenge = await handleAuthChallenge(response, this._edgeIdentity);
+    this._authHeader = `VerifiablePresentation pb;base64,${Buffer.from(challenge).toString('base64')}`;
+    log('auth header updated');
+    return this._authHeader;
+  }
+}
 
 const createRetryHandler = (args: EdgeHttpCallArgs) => {
   if (!args.retry || args.retry.count < 1) {
@@ -164,4 +185,12 @@ type EdgeHttpCallArgs = {
   body?: any;
   context?: Context;
   retry?: RetryConfig;
+};
+
+const createRequest = (args: EdgeHttpCallArgs, authHeader: string | undefined): RequestInit => {
+  return {
+    method: args.method,
+    body: args.body && JSON.stringify(args.body),
+    headers: authHeader ? { Authorization: authHeader } : undefined,
+  };
 };

--- a/packages/core/mesh/edge-client/src/edge-identity.ts
+++ b/packages/core/mesh/edge-client/src/edge-identity.ts
@@ -1,0 +1,31 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { invariant } from '@dxos/invariant';
+import { schema } from '@dxos/protocols/proto';
+import { type Presentation } from '@dxos/protocols/proto/dxos/halo/credentials';
+
+export interface EdgeIdentity {
+  peerKey: string;
+  identityKey: string;
+  /**
+   * Returns credential presentation issued by the identity key.
+   * Presentation must have the provided challenge.
+   * Presentation may include ServiceAccess credentials.
+   */
+  presentCredentials({ challenge }: { challenge: Uint8Array }): Promise<Presentation>;
+}
+
+export const handleAuthChallenge = async (failedResponse: Response, identity: EdgeIdentity): Promise<Uint8Array> => {
+  invariant(failedResponse.status === 401);
+
+  const headerValue = failedResponse.headers.get('Www-Authenticate');
+  invariant(headerValue?.startsWith('VerifiablePresentation challenge='));
+
+  const challenge = headerValue?.slice('VerifiablePresentation challenge='.length);
+  invariant(challenge);
+
+  const presentation = await identity.presentCredentials({ challenge: Buffer.from(challenge, 'base64') });
+  return schema.getCodecForType('dxos.halo.credentials.Presentation').encode(presentation);
+};

--- a/packages/core/mesh/edge-client/src/index.ts
+++ b/packages/core/mesh/edge-client/src/index.ts
@@ -10,3 +10,4 @@ export * from './protocol';
 export * from './errors';
 export * from './auth';
 export * from './edge-http-client';
+export * from './edge-identity';

--- a/packages/core/mesh/messaging/src/signal-manager/edge-signal-manager.ts
+++ b/packages/core/mesh/messaging/src/signal-manager/edge-signal-manager.ts
@@ -9,12 +9,13 @@ import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/keys';
 import { log } from '@dxos/log';
 import { EdgeService } from '@dxos/protocols';
-import { bufWkt } from '@dxos/protocols/buf';
+import { type buf, bufWkt } from '@dxos/protocols/buf';
 import {
   SwarmRequestSchema,
   SwarmRequest_Action as SwarmRequestAction,
   SwarmResponseSchema,
   type Message as EdgeMessage,
+  type PeerSchema,
 } from '@dxos/protocols/buf/dxos/edge/messenger_pb';
 import { ComplexMap, ComplexSet } from '@dxos/util';
 
@@ -62,6 +63,7 @@ export class EdgeSignalManager extends Resource implements SignalManager {
     await this._edgeConnection.send(
       protocol.createMessage(SwarmRequestSchema, {
         serviceId: EdgeService.SWARM_SERVICE_ID,
+        source: createMessageSource(topic, peer),
         payload: { action: SwarmRequestAction.JOIN, swarmKeys: [topic.toHex()] },
       }),
     );
@@ -72,6 +74,7 @@ export class EdgeSignalManager extends Resource implements SignalManager {
     await this._edgeConnection.send(
       protocol.createMessage(SwarmRequestSchema, {
         serviceId: EdgeService.SWARM_SERVICE_ID,
+        source: createMessageSource(topic, peer),
         payload: { action: SwarmRequestAction.LEAVE, swarmKeys: [topic.toHex()] },
       }),
     );
@@ -187,3 +190,11 @@ export class EdgeSignalManager extends Resource implements SignalManager {
     }
   }
 }
+
+const createMessageSource = (topic: PublicKey, peerInfo: PeerInfo): buf.MessageInitShape<typeof PeerSchema> => {
+  return {
+    swarmKey: topic.toHex(),
+    identityKey: peerInfo.identityKey,
+    peerKey: peerInfo.peerKey,
+  };
+};

--- a/packages/core/protocols/src/edge.ts
+++ b/packages/core/protocols/src/edge.ts
@@ -162,6 +162,5 @@ const isRetryableCode = (status: number) => {
     // Not Implemented
     return false;
   }
-  // TODO: handle 401 Not Authorized
   return !(status >= 400 && status < 500);
 };

--- a/packages/sdk/client-services/src/packlets/services/service-context.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-context.ts
@@ -397,9 +397,8 @@ export class ServiceContext extends Resource {
       edgeIdentity = await createEphemeralEdgeIdentity();
     }
 
-    if (this._edgeConnection) {
-      this._edgeConnection.setIdentity(edgeIdentity);
-    }
+    this._edgeConnection?.setIdentity(edgeIdentity);
+    this._edgeHttpClient?.setIdentity(edgeIdentity);
     this.networkManager.setPeerInfo({
       identityKey: edgeIdentity.identityKey,
       peerKey: edgeIdentity.peerKey,


### PR DESCRIPTION
### Details

* Extracted EdgeIdentity for reuse between edge ws and http clients. 
* Added real challenge fetch before ws connection open. Browser doesn't give access to ws error response headers.
* Added edge http client 401 handling.
* Added retry backoff to automerge replicator.