### PR TITLE
fix: halo space feeds not getting into the edge replicator

### DIFF
--- a/packages/sdk/client-services/src/packlets/agents/edge-agent-manager.ts
+++ b/packages/sdk/client-services/src/packlets/agents/edge-agent-manager.ts
@@ -142,9 +142,9 @@ export class EdgeAgentManager extends Resource {
       if ([SpaceState.SPACE_INACTIVE, SpaceState.SPACE_CLOSED].includes(space.state)) {
         continue;
       }
-      const agentFeedNeedsNotarization = !space.inner.spaceState.feeds
-        .values()
-        .some((feed) => feed.assertion.deviceKey.equals(agentDeviceKey));
+      const agentFeedNeedsNotarization = ![...space.inner.spaceState.feeds.values()].some((feed) =>
+        feed.assertion.deviceKey.equals(agentDeviceKey),
+      );
       space.notarizationPlugin.setActiveEdgePollingEnabled(agentFeedNeedsNotarization);
 
       log.info('set active edge polling', { enabled: agentFeedNeedsNotarization, spaceId: space.id });

--- a/packages/sdk/client-services/src/packlets/identity/identity.ts
+++ b/packages/sdk/client-services/src/packlets/identity/identity.ts
@@ -118,13 +118,13 @@ export class Identity {
     await this.space.spaceState.addCredentialProcessor(this._deviceStateMachine);
     await this.space.spaceState.addCredentialProcessor(this._profileStateMachine);
     await this.space.spaceState.addCredentialProcessor(this._defaultSpaceStateMachine);
+    if (this._edgeFeedReplicator) {
+      this.space.protocol.feedAdded.append(this._onFeedAdded);
+    }
     await this.space.open(ctx);
   }
 
   public async joinNetwork() {
-    if (this._edgeFeedReplicator) {
-      this.space.protocol.feedAdded.append(this._onFeedAdded);
-    }
     await this.space.startProtocol();
     await this._edgeFeedReplicator?.open();
   }


### PR DESCRIPTION
### Details

Credential processing starts in `space.open`. All listeners must be registered before that.