### PR TITLE
chore: Clean-up react-ui-editor state management

### DIFF
--- a/packages/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -31,6 +31,7 @@ import {
   type EditorViewMode,
   EditorViewModes,
   translations as editorTranslations,
+  createEditorStateStore,
 } from '@dxos/react-ui-editor';
 
 import { MarkdownContainer, MarkdownSettings } from './components';
@@ -56,6 +57,8 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
     folding: true,
     experimental: false,
   });
+
+  const editorStateStore = createEditorStateStore(`${MARKDOWN_PLUGIN}/editor`);
 
   const state = new LocalStorageStore<MarkdownPluginState>(MARKDOWN_PLUGIN, { extensionProviders: [], viewMode: {} });
 
@@ -263,6 +266,7 @@ export const MarkdownPlugin = (): PluginDefinition<MarkdownPluginProvides> => {
                   settings={settings.values}
                   extensionProviders={state.values.extensionProviders}
                   viewMode={getViewMode(id)}
+                  editorStateStore={editorStateStore}
                   onViewModeChange={setViewMode}
                 />
               );

--- a/packages/plugins/plugin-markdown/src/components/MarkdownContainer.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownContainer.tsx
@@ -6,7 +6,6 @@ import React, { useEffect, useMemo } from 'react';
 
 import { useResolvePlugin, parseFileManagerPlugin } from '@dxos/app-framework';
 import { fullyQualifiedId, getSpace } from '@dxos/react-client/echo';
-import { localStorageStateStoreAdapter, type EditorSelectionState } from '@dxos/react-ui-editor';
 
 import { MarkdownEditor, type MarkdownEditorProps } from './MarkdownEditor';
 import { useExtensions } from '../extensions';
@@ -15,7 +14,7 @@ import { getFallbackName } from '../util';
 
 export type MarkdownContainerProps = Pick<
   MarkdownEditorProps,
-  'role' | 'coordinate' | 'extensionProviders' | 'viewMode' | 'onViewModeChange'
+  'role' | 'coordinate' | 'extensionProviders' | 'viewMode' | 'editorStateStore' | 'onViewModeChange'
 > & {
   id: string;
   object: DocumentType | any;
@@ -62,11 +61,12 @@ export const DocumentEditor = ({
   extensionProviders,
   settings,
   viewMode,
+  editorStateStore,
   ...props
 }: DocumentEditorProps) => {
   const space = getSpace(doc);
   const initialValue = useMemo(() => doc.content?.content, [doc.content]);
-  const extensions = useExtensions({ extensionProviders, document: doc, settings, viewMode });
+  const extensions = useExtensions({ extensionProviders, document: doc, settings, viewMode, editorStateStore });
 
   // Migrate gradually to `fallbackName`.
   useEffect(() => {
@@ -74,12 +74,6 @@ export const DocumentEditor = ({
       doc.fallbackName = getFallbackName(doc.content.content);
     }
   }, [doc, doc.content]);
-
-  // Restore last selection and scroll point.
-  const { scrollTo, selection } = useMemo<EditorSelectionState>(
-    () => localStorageStateStoreAdapter.getState(id) ?? {},
-    [id, doc],
-  );
 
   // File dragging.
   const fileManagerPlugin = useResolvePlugin(parseFileManagerPlugin);
@@ -97,8 +91,6 @@ export const DocumentEditor = ({
       id={id}
       initialValue={initialValue}
       extensions={extensions}
-      scrollTo={scrollTo}
-      selection={selection}
       toolbar={settings.toolbar}
       inputMode={settings.editorInputMode}
       viewMode={viewMode}

--- a/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
@@ -14,6 +14,8 @@ import {
   type DNDOptions,
   type EditorViewMode,
   type EditorInputMode,
+  type EditorSelectionState,
+  type EditorStateStore,
   Toolbar,
   type UseTextEditorProps,
   createBasicExtensions,
@@ -47,9 +49,10 @@ export type MarkdownEditorProps = {
   scrollPastEnd?: boolean;
   toolbar?: boolean;
   viewMode?: EditorViewMode;
+  editorStateStore?: EditorStateStore;
   onViewModeChange?: (id: string, mode: EditorViewMode) => void;
   onFileUpload?: (file: File) => Promise<FileInfo | undefined>;
-} & Pick<UseTextEditorProps, 'initialValue' | 'scrollTo' | 'selection' | 'extensions'> &
+} & Pick<UseTextEditorProps, 'initialValue' | 'extensions'> &
   Partial<Pick<MarkdownPluginState, 'extensionProviders'>>;
 
 /**
@@ -65,10 +68,9 @@ export const MarkdownEditor = ({
   extensions,
   extensionProviders,
   scrollPastEnd,
-  scrollTo,
-  selection,
   toolbar,
   viewMode,
+  editorStateStore,
   onFileUpload,
   onViewModeChange,
 }: MarkdownEditorProps) => {
@@ -78,6 +80,9 @@ export const MarkdownEditor = ({
   const [formattingState, formattingObserver] = useFormattingState();
   const attendableAttributes = useAttendableAttributes(id);
   const { hasAttention } = useAttention(id);
+
+  // Restore last selection and scroll point.
+  const { scrollTo, selection } = useMemo<EditorSelectionState>(() => editorStateStore?.getState(id) ?? {}, [id]);
 
   // Extensions from other plugins.
   // TODO(burdon): Reconcile with DocumentEditor.useExtensions.

--- a/packages/plugins/plugin-markdown/src/extensions.tsx
+++ b/packages/plugins/plugin-markdown/src/extensions.tsx
@@ -10,17 +10,20 @@ import { invariant } from '@dxos/invariant';
 import { createDocAccessor, fullyQualifiedId, getSpace, type Query } from '@dxos/react-client/echo';
 import { useIdentity } from '@dxos/react-client/halo';
 import { Icon, ThemeProvider } from '@dxos/react-ui';
-import { createDataExtensions, listener, localStorageStateStoreAdapter, state } from '@dxos/react-ui-editor';
 import {
   type AutocompleteResult,
+  type EditorStateStore,
   type EditorViewMode,
   type Extension,
   InputModeExtensions,
+  createDataExtensions,
   autocomplete,
   decorateMarkdown,
   folding,
   formattingKeymap,
   linkTooltip,
+  listener,
+  selectionState,
   typewriter,
 } from '@dxos/react-ui-editor';
 import { defaultTx } from '@dxos/react-ui-theme';
@@ -35,16 +38,17 @@ type ExtensionsOptions = {
   query?: Query<DocumentType>;
   settings: MarkdownSettingsProps;
   viewMode?: EditorViewMode;
+  editorStateStore?: EditorStateStore;
 };
 
-// TODO(burdon): Merge with createBaseExtensions above.
+// TODO(burdon): Merge with createBaseExtensions below.
 export const useExtensions = ({
-  extensionProviders,
   document,
   settings,
   viewMode,
-}: Pick<ExtensionsOptions, 'document' | 'settings' | 'viewMode'> &
-  Pick<MarkdownPluginState, 'extensionProviders'>): Extension[] => {
+  editorStateStore,
+  extensionProviders,
+}: ExtensionsOptions & Pick<MarkdownPluginState, 'extensionProviders'>): Extension[] => {
   const dispatch = useIntentDispatcher();
   const identity = useIdentity();
   const space = getSpace(document);
@@ -94,7 +98,7 @@ export const useExtensions = ({
           space,
           identity,
         }),
-        state(localStorageStateStoreAdapter),
+        selectionState(editorStateStore),
         listener({
           onChange: (text) => setFallbackName(document, text),
         }),

--- a/packages/plugins/plugin-sheet/src/extensions/compute.ts
+++ b/packages/plugins/plugin-sheet/src/extensions/compute.ts
@@ -16,7 +16,7 @@ import { Decoration, EditorView, ViewPlugin, WidgetType } from '@codemirror/view
 
 import { type UnsubscribeCallback, debounce } from '@dxos/async';
 import { invariant } from '@dxos/invariant';
-import { documentId, singleValueFacet } from '@dxos/react-ui-editor/state';
+import { documentId, singleValueFacet } from '@dxos/react-ui-editor';
 
 import { type CellAddress } from '../defs';
 import { type ComputeGraph, type ComputeNode, createSheetName } from '../graph';

--- a/packages/plugins/plugin-sheet/src/extensions/editor/extension.ts
+++ b/packages/plugins/plugin-sheet/src/extensions/editor/extension.ts
@@ -18,7 +18,7 @@ import { type SyntaxNode } from '@lezer/common';
 import { tags } from '@lezer/highlight';
 import { spreadsheet } from 'codemirror-lang-spreadsheet';
 
-import { singleValueFacet } from '@dxos/react-ui-editor/state';
+import { singleValueFacet } from '@dxos/react-ui-editor';
 import { mx } from '@dxos/react-ui-theme';
 
 import { type FunctionDefinition } from '../../graph';

--- a/packages/ui/react-ui-editor/project.json
+++ b/packages/ui/react-ui-editor/project.json
@@ -11,8 +11,7 @@
     "compile": {
       "options": {
         "entryPoints": [
-          "{projectRoot}/src/index.ts",
-          "{projectRoot}/src/state/index.ts"
+          "{projectRoot}/src/index.ts"
         ],
         "platforms": [
           "browser",

--- a/packages/ui/react-ui-editor/src/TextEditor.stories.tsx
+++ b/packages/ui/react-ui-editor/src/TextEditor.stories.tsx
@@ -48,16 +48,18 @@ import {
   linkTooltip,
   listener,
   mention,
+  selectionState,
   table,
   typewriter,
   type CommandAction,
   type CommentsOptions,
   type DebugNode,
+  type EditorSelectionState,
 } from './extensions';
-import { renderRoot } from './extensions/util';
 import { useTextEditor, type UseTextEditorProps } from './hooks';
-import { type Comment, type EditorSelectionState, state } from './state';
 import translations from './translations';
+import { type Comment } from './types';
+import { renderRoot } from './util';
 
 faker.seed(101);
 
@@ -416,7 +418,7 @@ export const Scrolling = {
   render: () => (
     <DefaultStory
       text={str('# Large Document', '', longText)}
-      extensions={state({
+      extensions={selectionState({
         setState: (id, state) => global.set(id, state),
         getState: (id) => global.get(id),
       })}

--- a/packages/ui/react-ui-editor/src/extensions/annotations.ts
+++ b/packages/ui/react-ui-editor/src/extensions/annotations.ts
@@ -7,7 +7,7 @@ import { Decoration, EditorView } from '@codemirror/view';
 
 import { isNotFalsy } from '@dxos/util';
 
-import { Cursor } from '../state';
+import { Cursor } from '../util';
 
 type Annotation = {
   cursor: string;

--- a/packages/ui/react-ui-editor/src/extensions/automerge/automerge.ts
+++ b/packages/ui/react-ui-editor/src/extensions/automerge/automerge.ts
@@ -13,7 +13,7 @@ import { type DocAccessor } from '@dxos/react-client/echo';
 import { cursorConverter } from './cursor';
 import { updateHeadsEffect, isReconcile, type State } from './defs';
 import { Syncer } from './sync';
-import { Cursor } from '../../state';
+import { Cursor } from '../../util';
 
 export const automerge = (accessor: DocAccessor): Extension => {
   const syncState = StateField.define<State>({

--- a/packages/ui/react-ui-editor/src/extensions/automerge/cursor.ts
+++ b/packages/ui/react-ui-editor/src/extensions/automerge/cursor.ts
@@ -5,7 +5,7 @@
 import { log } from '@dxos/log';
 import { type DocAccessor, fromCursor, toCursor } from '@dxos/react-client/echo';
 
-import { type CursorConverter } from '../../state';
+import { type CursorConverter } from '../../util';
 
 export const cursorConverter = (accessor: DocAccessor): CursorConverter => ({
   toCursor: (pos, assoc) => {

--- a/packages/ui/react-ui-editor/src/extensions/awareness/awareness.ts
+++ b/packages/ui/react-ui-editor/src/extensions/awareness/awareness.ts
@@ -16,7 +16,7 @@ import {
 import { Event } from '@dxos/async';
 import { Context } from '@dxos/context';
 
-import { singleValueFacet, Cursor, type CursorConverter } from '../../state';
+import { singleValueFacet, Cursor, type CursorConverter } from '../../util';
 
 export interface AwarenessProvider {
   remoteStateChange: Event<void>;

--- a/packages/ui/react-ui-editor/src/extensions/command/hint.ts
+++ b/packages/ui/react-ui-editor/src/extensions/command/hint.ts
@@ -7,7 +7,7 @@ import { Decoration, EditorView, ViewPlugin, type ViewUpdate, WidgetType } from 
 
 import { type CommandOptions } from './command';
 import { commandState } from './state';
-import { clientRectsFor, flattenRect } from '../util';
+import { clientRectsFor, flattenRect } from '../../util';
 
 class CommandHint extends WidgetType {
   constructor(readonly content: string | HTMLElement) {

--- a/packages/ui/react-ui-editor/src/extensions/command/state.ts
+++ b/packages/ui/react-ui-editor/src/extensions/command/state.ts
@@ -13,7 +13,7 @@ import {
 } from '@codemirror/view';
 
 import { type CommandOptions } from './command';
-import { singleValueFacet } from '../../state';
+import { singleValueFacet } from '../../util';
 
 type CommandState = {
   tooltip?: Tooltip | null;

--- a/packages/ui/react-ui-editor/src/extensions/comments.ts
+++ b/packages/ui/react-ui-editor/src/extensions/comments.ts
@@ -28,10 +28,9 @@ import { debounce, type UnsubscribeCallback } from '@dxos/async';
 import { log } from '@dxos/log';
 import { nonNullable } from '@dxos/util';
 
-import { overlap } from './util';
-import { Cursor, documentId, singleValueFacet } from '../state';
-import { type Comment, type Range } from '../state';
-import { callbackWrapper } from '../util';
+import { documentId } from './selection';
+import { type Comment, type Range } from '../types';
+import { Cursor, overlap, singleValueFacet, callbackWrapper } from '../util';
 
 //
 // State management.

--- a/packages/ui/react-ui-editor/src/extensions/folding.tsx
+++ b/packages/ui/react-ui-editor/src/extensions/folding.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 import { Icon } from '@dxos/react-ui';
 
-import { createElement, renderRoot } from './util';
+import { createElement, renderRoot } from '../util';
 
 export type FoldingOptions = {};
 

--- a/packages/ui/react-ui-editor/src/extensions/index.ts
+++ b/packages/ui/react-ui-editor/src/extensions/index.ts
@@ -17,4 +17,5 @@ export * from './listener';
 export * from './markdown';
 export * from './mention';
 export * from './modes';
+export * from './selection';
 export * from './typewriter';

--- a/packages/ui/react-ui-editor/src/extensions/markdown/decorate.ts
+++ b/packages/ui/react-ui-editor/src/extensions/markdown/decorate.ts
@@ -15,7 +15,7 @@ import { image } from './image';
 import { formattingStyles, bulletListIndentationWidth, orderedListIndentationWidth } from './styles';
 import { table } from './table';
 import { theme, type HeadingLevel } from '../../styles';
-import { wrapWithCatch } from '../util';
+import { wrapWithCatch } from '../../util';
 
 /**
  * Unicode characters.

--- a/packages/ui/react-ui-editor/src/extensions/modes.ts
+++ b/packages/ui/react-ui-editor/src/extensions/modes.ts
@@ -7,7 +7,7 @@ import { keymap } from '@codemirror/view';
 import { vim } from '@replit/codemirror-vim';
 import { vscodeKeymap } from '@replit/codemirror-vscode-keymap';
 
-import { singleValueFacet } from '../state';
+import { singleValueFacet } from '../util';
 
 export const focusEvent = 'focus.container';
 

--- a/packages/ui/react-ui-editor/src/extensions/selection.ts
+++ b/packages/ui/react-ui-editor/src/extensions/selection.ts
@@ -1,0 +1,100 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type Extension, Transaction, type TransactionSpec } from '@codemirror/state';
+import { EditorView, keymap } from '@codemirror/view';
+
+import { debounce } from '@dxos/async';
+import { invariant } from '@dxos/invariant';
+import { isNotFalsy } from '@dxos/util';
+
+import { singleValueFacet } from '../util';
+
+/**
+ * Currently edited document id as FQ string.
+ */
+export const documentId = singleValueFacet<string>();
+
+export type EditorSelection = {
+  anchor: number;
+  head?: number;
+};
+
+export type EditorSelectionState = {
+  scrollTo?: number;
+  selection?: EditorSelection;
+};
+
+export type EditorStateStore = {
+  setState: (id: string, state: EditorSelectionState) => void;
+  getState: (id: string) => EditorSelectionState | undefined;
+};
+
+const stateRestoreAnnotation = 'dxos.org/cm/state-restore';
+
+export const createEditorStateTransaction = ({ scrollTo, selection }: EditorSelectionState): TransactionSpec => {
+  return {
+    selection,
+    scrollIntoView: !scrollTo,
+    effects: scrollTo ? EditorView.scrollIntoView(scrollTo, { yMargin: 96 }) : undefined,
+    annotations: Transaction.userEvent.of(stateRestoreAnnotation),
+  };
+};
+
+export const createEditorStateStore = (keyPrefix: string): EditorStateStore => ({
+  getState: (id) => {
+    invariant(id);
+    const state = localStorage.getItem(`${keyPrefix}/${id}`);
+    return state ? JSON.parse(state) : undefined;
+  },
+
+  setState: (id, state) => {
+    invariant(id);
+    localStorage.setItem(`${keyPrefix}/${id}`, JSON.stringify(state));
+  },
+});
+
+/**
+ * Track scrolling and selection state to be restored when switching to document.
+ */
+export const selectionState = ({ getState, setState }: Partial<EditorStateStore> = {}): Extension => {
+  const setStateDebounced = debounce(setState!, 1_000);
+
+  return [
+    // TODO(burdon): Track scrolling (currently only updates when cursor moves).
+    // EditorView.domEventHandlers({
+    //   scroll: (event) => {
+    //     setStateDebounced(id, {});
+    //   },
+    // }),
+    EditorView.updateListener.of(({ view, transactions }) => {
+      const id = view.state.facet(documentId);
+      if (!id || transactions.some((tr) => tr.isUserEvent(stateRestoreAnnotation))) {
+        return;
+      }
+
+      if (setState) {
+        const { scrollTop } = view.scrollDOM;
+        const pos = view.posAtCoords({ x: 0, y: scrollTop });
+        if (pos !== null) {
+          const { anchor, head } = view.state.selection.main;
+          setStateDebounced(id, { scrollTo: pos, selection: { anchor, head } });
+        }
+      }
+    }),
+    getState &&
+      keymap.of([
+        {
+          key: 'ctrl-r', // TODO(burdon): Setting to jump back to selection.
+          run: (view) => {
+            const state = getState(view.state.facet(documentId));
+            if (state) {
+              view.dispatch(createEditorStateTransaction(state));
+            }
+            return true;
+          },
+        },
+      ]),
+  ].filter(isNotFalsy);
+};

--- a/packages/ui/react-ui-editor/src/hooks/useTextEditor.ts
+++ b/packages/ui/react-ui-editor/src/hooks/useTextEditor.ts
@@ -19,8 +19,7 @@ import {
 import { log } from '@dxos/log';
 import { getProviderValue, isNotFalsy, type MaybeProvider } from '@dxos/util';
 
-import { editorInputMode } from '../extensions';
-import { type EditorSelection, documentId, createEditorStateTransaction } from '../state';
+import { editorInputMode, type EditorSelection, documentId, createEditorStateTransaction } from '../extensions';
 import { debugDispatcher } from '../util';
 
 export type UseTextEditor = {
@@ -150,7 +149,7 @@ export const useTextEditor = (
           return;
         }
 
-        view.dispatch(createEditorStateTransaction(view.state, { scrollTo, selection }));
+        view.dispatch(createEditorStateTransaction({ scrollTo, selection }));
       }
     }
   }, [view, scrollTo, selection]);

--- a/packages/ui/react-ui-editor/src/index.ts
+++ b/packages/ui/react-ui-editor/src/index.ts
@@ -14,7 +14,7 @@ export * from './components';
 export * from './defaults';
 export * from './extensions';
 export * from './hooks';
-export * from './state';
+export * from './types';
 export * from './util';
 
 export { translations };

--- a/packages/ui/react-ui-editor/src/types.ts
+++ b/packages/ui/react-ui-editor/src/types.ts
@@ -1,0 +1,16 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+// Runtime data structure.
+export type Range = {
+  from: number;
+  to: number;
+};
+
+// Persistent data structure.
+// TODO(burdon): Rename annotation?
+export type Comment = {
+  id: string;
+  cursor?: string;
+};

--- a/packages/ui/react-ui-editor/src/util/cursor.ts
+++ b/packages/ui/react-ui-editor/src/util/cursor.ts
@@ -1,0 +1,56 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { type EditorState } from '@codemirror/state';
+
+import { singleValueFacet } from './facet';
+import { type Range } from '../types';
+
+/**
+ * Determines if two ranges overlap.
+ * A range is considered to overlap if there is any intersection
+ * between the two ranges, inclusive of their boundaries.
+ */
+export const overlap = (a: Range, b: Range): boolean => a.from <= b.to && a.to >= b.from;
+
+/**
+ * Converts indexes into the text document into stable peer-independent cursors.
+ *
+ * See:
+ *  - https://automerge.org/automerge/api-docs/js/functions/next.getCursor.html
+ *  - https://github.com/yjs/yjs?tab=readme-ov-file#relative-positions
+ *
+ * @param {assoc} number Negative values will associate the cursor with the previous character
+ *  while positive - with the next one.
+ */
+export interface CursorConverter {
+  toCursor(position: number, assoc?: -1 | 1 | undefined): string;
+  fromCursor(cursor: string): number;
+}
+
+const defaultCursorConverter: CursorConverter = {
+  toCursor: (position) => position.toString(),
+  fromCursor: (cursor) => parseInt(cursor),
+};
+
+export class Cursor {
+  static readonly converter = singleValueFacet(defaultCursorConverter);
+
+  static readonly getCursorFromRange = (state: EditorState, range: Range) => {
+    const cursorConverter = state.facet(Cursor.converter);
+
+    const from = cursorConverter.toCursor(range.from);
+    const to = cursorConverter.toCursor(range.to, -1);
+    return [from, to].join(':');
+  };
+
+  static readonly getRangeFromCursor = (state: EditorState, cursor: string) => {
+    const cursorConverter = state.facet(Cursor.converter);
+
+    const parts = cursor.split(':');
+    const from = cursorConverter.fromCursor(parts[0]);
+    const to = cursorConverter.fromCursor(parts[1]);
+    return from !== undefined && to !== undefined ? { from, to } : undefined;
+  };
+}

--- a/packages/ui/react-ui-editor/src/util/debug.ts
+++ b/packages/ui/react-ui-editor/src/util/debug.ts
@@ -2,15 +2,25 @@
 // Copyright 2024 DXOS.org
 //
 
-import type { Transaction } from '@codemirror/state';
+import { type Transaction } from '@codemirror/state';
 import { type EditorView } from '@codemirror/view';
 
 import { log } from '@dxos/log';
 
+export const wrapWithCatch = (fn: (...args: any[]) => any) => {
+  return (...args: any[]) => {
+    try {
+      return fn(...args);
+    } catch (err) {
+      log.catch(err);
+    }
+  };
+};
+
 /**
  * CodeMirror callbacks swallow errors so wrap handlers.
  */
-// TODO(burdon): EditorView.exceptionSink should catch errors.
+// TODO(burdon): Reconcile with wrapWithCatch.
 export const callbackWrapper = <T extends Function>(fn: T): T =>
   ((...args: any[]) => {
     try {
@@ -29,6 +39,9 @@ export const debugDispatcher = (trs: readonly Transaction[], view: EditorView) =
   view.update(trs);
 };
 
+/**
+ * Util to log transactions in update listener.
+ */
 export const logChanges = (trs: readonly Transaction[]) => {
   const changes = trs
     .flatMap((tr) => {

--- a/packages/ui/react-ui-editor/src/util/dom.ts
+++ b/packages/ui/react-ui-editor/src/util/dom.ts
@@ -1,0 +1,36 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+// Copied from @codemirror/view
+
+export interface Rect {
+  readonly left: number;
+  readonly right: number;
+  readonly top: number;
+  readonly bottom: number;
+}
+
+export const flattenRect = (rect: Rect, left: boolean) => {
+  const x = left ? rect.left : rect.right;
+  return { left: x, right: x, top: rect.top, bottom: rect.bottom };
+};
+
+let scratchRange: Range | null;
+
+export const textRange = (node: Text, from: number, to = from) => {
+  const range = scratchRange || (scratchRange = document.createRange());
+  range.setEnd(node, to);
+  range.setStart(node, from);
+  return range;
+};
+
+export const clientRectsFor = (dom: Node) => {
+  if (dom.nodeType === 3) {
+    return textRange(dom as Text, 0, dom.nodeValue!.length).getClientRects();
+  } else if (dom.nodeType === 1) {
+    return (dom as HTMLElement).getClientRects();
+  } else {
+    return [] as any as DOMRectList;
+  }
+};

--- a/packages/ui/react-ui-editor/src/util/facet.ts
+++ b/packages/ui/react-ui-editor/src/util/facet.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import { Facet } from '@codemirror/state';
+
+export const singleValueFacet = <I, O = I>(defaultValue?: O) =>
+  Facet.define<I, O>({
+    // Called immediately.
+    combine: (providers) => {
+      return (providers[0] ?? defaultValue) as O;
+    },
+  });

--- a/packages/ui/react-ui-editor/src/util/index.ts
+++ b/packages/ui/react-ui-editor/src/util/index.ts
@@ -1,0 +1,9 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+export * from './cursor';
+export * from './debug';
+export * from './dom';
+export * from './facet';
+export * from './react';

--- a/packages/ui/react-ui-editor/src/util/react.tsx
+++ b/packages/ui/react-ui-editor/src/util/react.tsx
@@ -1,0 +1,34 @@
+//
+// Copyright 2024 DXOS.org
+//
+
+import React, { type ReactNode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { ThemeProvider } from '@dxos/react-ui';
+import { defaultTx } from '@dxos/react-ui-theme';
+
+// TODO(burdon): Factor out.
+
+export type ElementOptions = {
+  className?: string;
+};
+
+export const createElement = (tag: string, options?: ElementOptions, children?: ReactNode): HTMLElement => {
+  const el = document.createElement(tag);
+  if (options?.className) {
+    el.className = options.className;
+  }
+  if (children) {
+    el.append(...(Array.isArray(children) ? children : [children]));
+  }
+
+  return el;
+};
+
+// TODO(burdon): Remove react rendering; use DOM directly.
+// NOTE: CM seems to remove/detach/overwrite portals that are attached to the DOM it control.s
+export const renderRoot = <T extends Element>(root: T, node: ReactNode): T => {
+  createRoot(root).render(<ThemeProvider tx={defaultTx}>{node}</ThemeProvider>);
+  return root;
+};

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -344,9 +344,6 @@
       "@dxos/react-ui-editor": [
         "packages/ui/react-ui-editor/src/index.ts"
       ],
-      "@dxos/react-ui-editor/state": [
-        "packages/ui/react-ui-editor/src/state/index.ts"
-      ],
       "@dxos/react-ui-grid": [
         "packages/ui/react-ui-grid/src/index.ts"
       ],


### PR DESCRIPTION
- createEditorStateStore created by markdown plugin and passed to extensions
- reorganize utils