### PR TITLE
fix(react-ui-list): Fix rearranging when `getId` isn't specified

### DIFF
--- a/packages/sdk/schema/src/types/types.ts
+++ b/packages/sdk/schema/src/types/types.ts
@@ -60,7 +60,7 @@ export const FieldSchema = S.mutable(
     // TODO(ZaymonFC): Should validations be common? Think about translations?
     path: S.String.pipe(
       S.nonEmptyString({ message: () => 'Property is required.' }),
-      S.pattern(/^\w+$/, { message: () => 'Invalid property name.' }),
+      S.pattern(/^[a-zA-Z_$][\w$]*(?:\.[a-zA-Z_$][\w$]*)*$/, { message: () => 'Invalid property path.' }),
     ),
 
     // TODO(burdon): Replace with annotations?

--- a/packages/ui/react-ui-data/src/components/ViewEditor/ViewEditor.tsx
+++ b/packages/ui/react-ui-data/src/components/ViewEditor/ViewEditor.tsx
@@ -52,7 +52,12 @@ export const ViewEditor = ({ classNames, view, readonly }: ViewEditorProps) => {
 
   return (
     <div role='none' className={mx('flex flex-col w-full divide-y divide-separator', classNames)}>
-      <List.Root<FieldType> isItem={S.is(FieldSchema)} items={view.fields} onMove={handleMove}>
+      <List.Root<FieldType>
+        isItem={S.is(FieldSchema)}
+        items={view.fields}
+        onMove={handleMove}
+        getId={(field) => field.path}
+      >
         {({ items }) => (
           <div className='w-full'>
             <div role='heading' className={grid}>

--- a/packages/ui/react-ui-data/src/components/ViewEditor/ViewEditor.tsx
+++ b/packages/ui/react-ui-data/src/components/ViewEditor/ViewEditor.tsx
@@ -74,7 +74,13 @@ export const ViewEditor = ({ classNames, view, readonly }: ViewEditorProps) => {
       </List.Root>
 
       {field && view.schema && (
-        <Field classNames='p-2' autoFocus field={field} schema={space?.db.schema.getSchemaByTypename(view.schema)} />
+        <Field
+          key={field.path}
+          classNames='p-2'
+          autoFocus
+          field={field}
+          schema={space?.db.schema.getSchemaByTypename(view.schema)}
+        />
       )}
 
       {!readonly && (

--- a/packages/ui/react-ui-list/src/components/List/List.stories.tsx
+++ b/packages/ui/react-ui-list/src/components/List/List.stories.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { create, S } from '@dxos/echo-schema';
 import { ghostHover, mx } from '@dxos/react-ui-theme';
 import { withTheme, withLayout } from '@dxos/storybook-utils';
+import { arrayMove } from '@dxos/util';
 
 import { List, type ListRootProps } from './List';
 import { createList, TestItemSchema, type TestItemType } from './testing';
@@ -25,9 +26,12 @@ const DefaultStory = ({ items = [], ...props }: ListRootProps<TestItemType>) => 
     const idx = items.findIndex((i) => i.id === item.id);
     items.splice(idx, 1);
   };
+  const handleMove = (from: number, to: number) => {
+    arrayMove(items, from, to);
+  };
 
   return (
-    <List.Root<TestItemType> dragPreview items={items} {...props}>
+    <List.Root<TestItemType> dragPreview items={items} getId={(item) => item.id} onMove={handleMove} {...props}>
       {({ items }) => (
         <>
           <div className='flex flex-col w-full'>

--- a/packages/ui/react-ui-list/src/components/List/ListRoot.tsx
+++ b/packages/ui/react-ui-list/src/components/List/ListRoot.tsx
@@ -45,7 +45,22 @@ export const ListRoot = <T extends ListItemRecord>({
   onMove,
   ...props
 }: ListRootProps<T>) => {
-  const isEqual = useCallback((a: T, b: T) => (getId ? getId(a) === getId(b) : a === b), [getId]);
+  const isEqual = useCallback(
+    (a: T, b: T) => {
+      if (getId) {
+        return getId(a) === getId(b);
+      } else {
+        // Fallback for primitive values or when getId isn't provided.
+        // NOTE(ZaymonFC): Pragmatic seems to be serializing the drop target data so reference equality doesn't work.
+        try {
+          return JSON.stringify(a) === JSON.stringify(b);
+        } catch {
+          return a === b;
+        }
+      }
+    },
+    [getId],
+  );
 
   const [state, setState] = useState<ListContext<T>['state']>(idle);
   useEffect(() => {


### PR DESCRIPTION
- Resolves https://github.com/dxos/dxos/issues/8104

Fixes rearranging of list items when no `getId` function is provided by implementing a more robust equality check. The issue occurred when comparing drag target data where object references differed despite having the same content.

Previously, the comparison relied on direct reference equality. Now falls back to JSON string comparison when `getId` isn't specified.
