### PR TITLE
chore: try to fix ERR_MODULE_NOT_FOUND

### DIFF
--- a/packages/devtools/cli/bin/dx.js
+++ b/packages/devtools/cli/bin/dx.js
@@ -1,12 +1,17 @@
-#!/usr/bin/env -S node --import=extensionless/register --no-warnings
+#!/usr/bin/env -S node --no-warnings
 
 // Note: `npm publish` or `pnpm deploy` will change the default depending on the DX_ENVIRONMENT at time of invocation.
 //
 // Copyright 2024 DXOS.org
 //
 
-import { execute } from '@oclif/core';
+import { register } from 'module';
+import { argv } from 'process';
+
+register('extensionless', import.meta.url, { parentURL: import.meta.url, data: { argv1: argv[1] } });
+
+const oclif = await import('@oclif/core');
 
 process.env.DX_ENVIRONMENT ??= 'development';
 
-await execute({ dir: import.meta.url });
+await oclif.execute({ dir: import.meta.url });


### PR DESCRIPTION
Seems like `node --import` flag doesn't use `NODE_PATH` env variable for resolution and just does the node_modules traversal from current to parent. Try registering hooks in process. 