### PR TITLE
fix: introp with the current prod version

### DIFF
--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -37,6 +37,11 @@ const main = async () => {
   // Namespace for global Composer test & debug hooks.
   (window as any).composer = {};
 
+  const searchParams = new URLSearchParams(window.location.search);
+  if (searchParams.get('deviceInviteInterop')) {
+    (window as any).DEVICE_INVITE_INTEROP = true;
+  }
+
   let config = await setupConfig();
   if (
     !config.values.runtime?.client?.storage?.dataStore &&

--- a/packages/core/mesh/edge-client/src/auth.ts
+++ b/packages/core/mesh/edge-client/src/auth.ts
@@ -4,6 +4,7 @@
 
 import { createCredential, signPresentation } from '@dxos/credentials';
 import { type Signer } from '@dxos/crypto';
+import { invariant } from '@dxos/invariant';
 import { Keyring } from '@dxos/keyring';
 import { PublicKey } from '@dxos/keys';
 import { type Chain, type Credential } from '@dxos/protocols/proto/dxos/halo/credentials';
@@ -47,7 +48,7 @@ export const createChainEdgeIdentity = async (
   signer: Signer,
   identityKey: PublicKey,
   peerKey: PublicKey,
-  chain: Chain,
+  chain: Chain | undefined,
   credentials: Credential[],
 ): Promise<EdgeIdentity> => {
   const credentialsToSign =
@@ -70,6 +71,8 @@ export const createChainEdgeIdentity = async (
     identityKey: identityKey.toHex(),
     peerKey: peerKey.toHex(),
     presentCredentials: async ({ challenge }) => {
+      // TODO: make chain required after device invitation flow update release
+      invariant(chain);
       return signPresentation({
         presentation: {
           credentials: credentialsToSign,

--- a/packages/core/mesh/network-manager/src/transport/webrtc/rtc-peer-connection.ts
+++ b/packages/core/mesh/network-manager/src/transport/webrtc/rtc-peer-connection.ts
@@ -26,7 +26,17 @@ export type RtcPeerChannelFactoryOptions = {
   // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection#iceservers
   webrtcConfig?: RTCConfiguration;
   iceProvider?: IceProvider;
+
+  /**
+   * TODO: remove after the new rtc code rollout. Used for staging interop with older version running in prod.
+   */
+  legacyInitiator?: boolean;
 };
+
+/**
+ * TODO: remove after the new rtc code rollout. Used for staging interop with older version running in prod.
+ */
+const isLegacyInteropEnabled = () => Boolean((globalThis as any)?.DEVICE_INVITE_INTEROP);
 
 /**
  * A factory for rtc Transport implementations for a particular peer.
@@ -59,7 +69,9 @@ export class RtcPeerConnection {
     private readonly _factory: RtcConnectionFactory,
     private readonly _options: RtcPeerChannelFactoryOptions,
   ) {
-    this._initiator = chooseInitiatorPeer(_options.ownPeerKey, _options.remotePeerKey) === _options.ownPeerKey;
+    this._initiator = isLegacyInteropEnabled()
+      ? Boolean(this._options.legacyInitiator)
+      : chooseInitiatorPeer(_options.ownPeerKey, _options.remotePeerKey) === _options.ownPeerKey;
   }
 
   public get transportChannelCount() {
@@ -71,25 +83,27 @@ export class RtcPeerConnection {
   }
 
   public async createDataChannel(topic: string): Promise<RTCDataChannel> {
+    const channelKey = isLegacyInteropEnabled() ? 'dxos.mesh.transport' : topic;
+
     const connection = await this._openConnection();
-    if (!this._transportChannels.has(topic)) {
+    if (isLegacyInteropEnabled() ? this._transportChannels.size === 0 : !this._transportChannels.has(channelKey)) {
       if (!this._transportChannels.size) {
         this._lockAndCloseConnection();
       }
       throw new Error('Transport closed while connection was being open');
     }
     if (this._initiator) {
-      const channel = connection.createDataChannel(topic);
-      this._dataChannels.set(topic, channel);
+      const channel = connection.createDataChannel(channelKey);
+      this._dataChannels.set(channelKey, channel);
       return channel;
     } else {
-      const existingChannel = this._dataChannels.get(topic);
+      const existingChannel = this._dataChannels.get(channelKey);
       if (existingChannel) {
         return existingChannel;
       }
       log('waiting for initiator-peer to open a data channel');
       return new Promise((resolve, reject) => {
-        this._channelCreatedCallbacks.set(topic, { resolve, reject });
+        this._channelCreatedCallbacks.set(channelKey, { resolve, reject });
       });
     }
   }

--- a/packages/core/mesh/network-manager/src/transport/webrtc/rtc-transport-channel.ts
+++ b/packages/core/mesh/network-manager/src/transport/webrtc/rtc-transport-channel.ts
@@ -67,7 +67,13 @@ export class RtcTransportChannel extends Resource implements Transport {
       })
       .catch((err) => {
         if (this.isOpen) {
-          this.errors.raise(new ConnectivityError(`Failed to create a channel: ${err?.message ?? 'unknown reason.'}`));
+          const error =
+            err instanceof Error
+              ? err
+              : new ConnectivityError(`Failed to create a channel: ${JSON.stringify(err?.message)}`);
+          this.errors.raise(error);
+        } else {
+          log.verbose('connection establishment failed after transport was closed', { err });
         }
       })
       .finally(() => {

--- a/packages/core/mesh/network-manager/src/transport/webrtc/rtc-transport-factory.ts
+++ b/packages/core/mesh/network-manager/src/transport/webrtc/rtc-transport-factory.ts
@@ -19,6 +19,7 @@ export const createRtcTransportFactory = (
         ownPeerKey: options.ownPeerKey,
         remotePeerKey: options.remotePeerKey,
         sendSignal: options.sendSignal,
+        legacyInitiator: options.initiator,
         webrtcConfig,
         iceProvider,
       });

--- a/packages/core/mesh/network-manager/src/transport/webrtc/rtc-transport-service.ts
+++ b/packages/core/mesh/network-manager/src/transport/webrtc/rtc-transport-service.ts
@@ -88,8 +88,6 @@ export class RtcTransportService implements BridgeService {
         writeProcessedCallbacks: [],
       };
 
-      pushNewState(ConnectionState.CONNECTING);
-
       transport.connected.on(() => pushNewState(ConnectionState.CONNECTED));
 
       transport.errors.handle(async (err) => {
@@ -113,6 +111,10 @@ export class RtcTransportService implements BridgeService {
       });
 
       ready();
+
+      log('stream ready');
+
+      pushNewState(ConnectionState.CONNECTING);
     });
   }
 

--- a/packages/sdk/client-services/src/packlets/services/service-context.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-context.ts
@@ -381,12 +381,12 @@ export class ServiceContext extends Resource {
         identity: identity.identityKey.toHex(),
         swarms: this.networkManager.topics,
       });
-      if (params?.deviceCredential) {
+      if (params?.deviceCredential || Boolean((globalThis as any)?.DEVICE_INVITE_INTEROP)) {
         edgeIdentity = await createChainEdgeIdentity(
           identity.signer,
           identity.identityKey,
           identity.deviceKey,
-          { credential: params.deviceCredential },
+          params?.deviceCredential && { credential: params.deviceCredential },
           [], // TODO(dmaretskyi): Service access credentials.
         );
       } else {


### PR DESCRIPTION
### Details

Some backward-incompatible changes were made for edge signaling and rtc connection that break the release-candidate branch testing with invite from prod env.

This PR contains the temporary logic for enabling compatibility mode by setting `DEVICE_INVITE_INTEROP` on globalThis. The logic should be removed after the release.

Use `?deviceInvitationCode=code&deviceInviteInterop=true` query args with device invitations to ensure the mode is enabled before a connection is established.