### PR TITLE
fix: relax dynamic schema validation

### DIFF
--- a/packages/core/echo/echo-db/src/proxy-db/mutable-schema.test.ts
+++ b/packages/core/echo/echo-db/src/proxy-db/mutable-schema.test.ts
@@ -14,6 +14,7 @@ import {
   ref,
   TypedObject,
   S,
+  getTypename,
 } from '@dxos/echo-schema';
 import { EmptySchemaType } from '@dxos/echo-schema/testing';
 
@@ -84,6 +85,7 @@ describe('MutableSchema', () => {
 
     expect(getSchema(object)?.ast).to.deep.eq(schema.ast);
     expect(getType(object)?.objectId).to.be.eq(schema.id);
+    expect(getTypename(object)).to.be.eq(EmptySchemaType.typename);
 
     db.add(object);
     const queried = (await db.query(Filter.schema(schema)).run()).objects;

--- a/packages/core/echo/echo-schema/src/ast/annotations.ts
+++ b/packages/core/echo/echo-schema/src/ast/annotations.ts
@@ -93,6 +93,8 @@ export const getReferenceAnnotation = (schema: S.Schema<any>) =>
     Option.getOrElse(() => undefined),
   );
 
+export const SchemaMetaSymbol = Symbol.for('@dxos/schema/SchemaMeta');
+
 // TODO(burdon): Factor out.
 // TODO(burdon): Reconcile with ObjectAnnotation above.
 export type SchemaMeta = {

--- a/packages/core/echo/echo-schema/src/handler/ref.ts
+++ b/packages/core/echo/echo-schema/src/handler/ref.ts
@@ -42,9 +42,7 @@ export type JsonSchemaReferenceInfo = {
 // TODO(burdon): Move to json schema and make private?
 export const createEchoReferenceSchema = (annotation: ObjectAnnotation): S.Schema<any> => {
   const typePredicate =
-    annotation.typename === EXPANDO_TYPENAME
-      ? () => true
-      : (obj: object) => getTypename(obj) === (annotation.schemaId ?? annotation.typename);
+    annotation.typename === EXPANDO_TYPENAME ? () => true : (obj: object) => getTypename(obj) === annotation.typename;
 
   const referenceInfo: JsonSchemaReferenceInfo = {
     schema: {

--- a/packages/core/echo/echo-schema/src/mutable/mutable-schema.ts
+++ b/packages/core/echo/echo-schema/src/mutable/mutable-schema.ts
@@ -12,7 +12,7 @@ import {
   updateFieldsInSchema,
 } from './manipulation';
 import { StoredSchema } from './types';
-import { type HasId, type JsonSchemaType, schemaVariance } from '../ast';
+import { type HasId, type JsonSchemaType, schemaVariance, type SchemaMeta, SchemaMetaSymbol } from '../ast';
 import { toEffectSchema, toJsonSchema } from '../json';
 
 interface MutableSchemaConstructor extends S.Schema<MutableSchema> {
@@ -58,6 +58,10 @@ export class MutableSchema extends MutableSchemaBase() implements S.Schema<any> 
 
   public get [S.TypeId]() {
     return schemaVariance;
+  }
+
+  public get [SchemaMetaSymbol](): SchemaMeta {
+    return { id: this.id, typename: this.typename, version: this._storedSchema.version };
   }
 
   public override get id() {

--- a/packages/core/echo/echo-schema/src/proxy/getter.ts
+++ b/packages/core/echo/echo-schema/src/proxy/getter.ts
@@ -6,7 +6,7 @@ import { Reference } from '@dxos/echo-protocol';
 import { type S } from '@dxos/effect';
 
 import { getProxyHandler, isReactiveObject } from './proxy';
-import { getObjectAnnotation } from '../ast';
+import { getObjectAnnotation, SchemaMetaSymbol } from '../ast';
 
 /**
  * Returns the schema for the given object if one is defined.
@@ -52,7 +52,14 @@ export const getType = <T extends {}>(obj: T | undefined): Reference | undefined
 };
 
 // TODO(burdon): Reconcile functions.
-export const getTypename = <T extends {}>(obj: T): string | undefined => getType(obj)?.objectId;
+export const getTypename = <T extends {}>(obj: T): string | undefined => {
+  const schema = getSchema(obj);
+  // Special handling for MutableSchema. objectId is StoredSchema objectId, not a typename.
+  if (typeof schema === 'object' && SchemaMetaSymbol in schema) {
+    return (schema as any)[SchemaMetaSymbol].typename;
+  }
+  return getType(obj)?.objectId;
+};
 export const getTypenameOrThrow = (schema: S.Schema<any>): string => requireTypeReference(schema).objectId;
 
 export const requireTypeReference = (schema: S.Schema<any>): Reference => {


### PR DESCRIPTION
### Details

Relaxes `ref` validation for mutable schema.
Allow matches by typename in addition to strict stored schema id match requirement. 