### PR TITLE
chore: null-pointer precaution

### DIFF
--- a/packages/core/echo/echo-schema/src/proxy/getter.ts
+++ b/packages/core/echo/echo-schema/src/proxy/getter.ts
@@ -55,7 +55,7 @@ export const getType = <T extends {}>(obj: T | undefined): Reference | undefined
 export const getTypename = <T extends {}>(obj: T): string | undefined => {
   const schema = getSchema(obj);
   // Special handling for MutableSchema. objectId is StoredSchema objectId, not a typename.
-  if (typeof schema === 'object' && SchemaMetaSymbol in schema) {
+  if (schema && typeof schema === 'object' && SchemaMetaSymbol in schema) {
     return (schema as any)[SchemaMetaSymbol].typename;
   }
   return getType(obj)?.objectId;


### PR DESCRIPTION
### Details

Shouldn't happen, but a precaution in case `getSchema` returns null.