### PR TITLE
chore: restore functionality for stack next

### DIFF
--- a/packages/apps/composer-app/src/plugins/welcome/WelcomePlugin.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/WelcomePlugin.tsx
@@ -71,16 +71,10 @@ export const WelcomePlugin = ({
         const credential = credentials.find(matchServiceCredential(['composer:beta']));
         if (credential) {
           log('beta credential found', { credential });
-          await dispatch([
-            {
-              action: LayoutAction.SET_LAYOUT_MODE,
-              data: { layoutMode: 'solo' },
-            },
-            {
-              action: NavigationAction.CLOSE,
-              data: { activeParts: { fullScreen: 'surface:WelcomeScreen' } },
-            },
-          ]);
+          await dispatch({
+            action: NavigationAction.CLOSE,
+            data: { activeParts: { fullScreen: 'surface:WelcomeScreen' } },
+          });
           subscription.unsubscribe();
         }
       });

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/DeckLayout.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/DeckLayout.tsx
@@ -59,7 +59,7 @@ export const DeckLayout = ({ layoutParts, toasts, overscroll, showHints, panels,
   const scrollLeftRef = useRef<number | null>();
   const deckRef = useRef<HTMLDivElement>(null);
 
-  const isSoloModeLoaded = layoutMode === 'solo' && layoutParts.solo;
+  const isSoloModeLoaded = layoutMode === 'solo' && Boolean(layoutParts.solo?.[0]);
 
   // Ensure the first plank is attended when the deck is first rendered.
   useEffect(() => {

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/Plank.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/Plank.tsx
@@ -110,6 +110,7 @@ export const Plank = memo(({ entry, layoutParts, part, layoutMode, order, last }
     <Root
       ref={rootElement}
       data-testid='deck.plank'
+      tabIndex={0}
       {...(part === 'solo'
         ? ({ ...sizeAttrs, className } as any)
         : {


### PR DESCRIPTION
- was missing tab index for planks to allow them to be attended
- welcome was setting solo mode on load and breaking closing of planks
