### PR TITLE
fix: Overflow & layout

### DIFF
--- a/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
@@ -176,7 +176,7 @@ export const MarkdownEditor = ({
           role='none'
           className={mx(
             'attention-surface is-full',
-            role === 'section' && 'sticky block-start-0 z-[1] border-be !border-separator -mbe-px',
+            role === 'section' && 'sticky block-start-0 z-[1] border-be !border-separator -mbe-px min-is-0',
           )}
         >
           <Toolbar.Root

--- a/packages/plugins/plugin-table/src/components/TableContainer.tsx
+++ b/packages/plugins/plugin-table/src/components/TableContainer.tsx
@@ -107,13 +107,13 @@ const TableContainer = ({ role, table }: LayoutContainerProps<{ table: TableType
   );
 
   return (
-    <StackItem.Content toolbar>
+    <StackItem.Content toolbar role={role}>
       <Toolbar.Root onAction={handleAction} classNames={!hasAttention && 'opacity-20'}>
         <Toolbar.Editing />
         <Toolbar.Separator />
         <Toolbar.Actions />
       </Toolbar.Root>
-      <Table.Root role={role}>
+      <Table.Root>
         <Table.Main key={table.id} ref={tableRef} model={model} />
       </Table.Root>
     </StackItem.Content>

--- a/packages/ui/react-ui-stack/src/components/StackItemContent.tsx
+++ b/packages/ui/react-ui-stack/src/components/StackItemContent.tsx
@@ -30,8 +30,7 @@ export const StackItemContent = ({
       role='none'
       {...props}
       className={mx(
-        'group grid-cols-[100%]',
-        contentSize === 'intrinsic' ? 'flex flex-col' : 'grid',
+        'group grid grid-cols-[100%]',
         size === 'contain' && 'min-bs-0 overflow-hidden',
         separators && 'divide-separator divide-y',
         classNames,

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -16,7 +16,6 @@ import { invariant } from '@dxos/invariant';
 import { Filter, getSpace, fullyQualifiedId } from '@dxos/react-client/echo';
 import { useAttention } from '@dxos/react-ui-attention';
 import { type DxGridElement, Grid, type GridContentProps, closestCell } from '@dxos/react-ui-grid';
-import { StackItem } from '@dxos/react-ui-stack';
 import { mx } from '@dxos/react-ui-theme';
 import { isNotFalsy } from '@dxos/util';
 
@@ -44,9 +43,9 @@ export type TableRootProps = PropsWithChildren<{ role?: string }>;
 
 const TableRoot = ({ children }: TableRootProps) => {
   return (
-    <StackItem.Content toolbar contentSize='intrinsic' classNames='relative'>
+    <div role='none' className='relative flex flex-col'>
       {children}
-    </StackItem.Content>
+    </div>
   );
 };
 
@@ -185,7 +184,7 @@ const TableMain = forwardRef<TableController, TableMainProps>(({ model }, forwar
         <Grid.Content
           onWheelCapture={handleWheel}
           className={mx(
-            '[--dx-grid-base:var(--surface-bg)] [&_.dx-grid]:bs-min [&_.dx-grid]:shrink [&_.dx-grid]:max-is-max',
+            '[--dx-grid-base:var(--surface-bg)] [&_.dx-grid]:grow [&_.dx-grid]:max-is-max [&_.dx-grid]:bs-0 [&_.dx-grid]:max-bs-max',
             inlineEndLine,
             blockEndLine,
           )}


### PR DESCRIPTION
This PR:
- fixes an issue where toolbars caused stack sections to have an inline size of `min-content`
- fixes an issue where tables occupied a block size of `min-content` where they shouldn’t