### PR TITLE
fix: More pixel pushing

### DIFF
--- a/packages/plugins/plugin-deck/src/components/DeckLayout/ComplementarySidebar.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/ComplementarySidebar.tsx
@@ -62,8 +62,8 @@ export const ComplementarySidebar = ({ panels, current }: ComplementarySidebarPr
   // TODO(burdon): Debug panel doesn't change when switching even though id has chagned.
   return (
     <Main.ComplementarySidebar>
-      <StackContext.Provider value={{ size: 'contain', orientation: 'horizontal', separators: true, rail: true }}>
-        <div role='none' className={mx(railGridHorizontal, 'grid-cols-1 bs-full divide-y divide-separator')}>
+      <StackContext.Provider value={{ size: 'contain', orientation: 'horizontal', separators: false, rail: true }}>
+        <div role='none' className={mx(railGridHorizontal, 'grid-cols-1 bs-full')}>
           <NodePlankHeading coordinate={coordinate} node={node} popoverAnchorId={popoverAnchorId} actions={actions} />
           <div className='divide-y divide-separator overflow-x-hidden overflow-y-scroll'>
             {node && (

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/DeckLayout.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/DeckLayout.tsx
@@ -216,7 +216,7 @@ export const DeckLayout = ({ layoutParts, toasts, overscroll, showHints, panels,
                 {...(!isSoloModeLoaded && { inert: '' })}
               >
                 <StackContext.Provider
-                  value={{ size: 'contain', orientation: 'horizontal', separators: true, rail: true }}
+                  value={{ size: 'contain', orientation: 'horizontal', separators: false, rail: true }}
                 >
                   <Plank entry={layoutParts.solo?.[0]} layoutParts={layoutParts} part='solo' layoutMode={layoutMode} />
                 </StackContext.Provider>

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/Plank.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/Plank.tsx
@@ -102,7 +102,7 @@ export const Plank = memo(({ entry, layoutParts, part, layoutMode, order, last }
     'attention-surface relative',
     isSolo && mainIntrinsicSize,
     isSolo && railGridHorizontal,
-    isSolo ? 'grid absolute inset-0 divide-separator divide-y' : '!border-separator border-li',
+    isSolo ? 'grid absolute inset-0' : '!border-separator border-li',
   );
 
   return (

--- a/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownEditor.tsx
@@ -175,8 +175,8 @@ export const MarkdownEditor = ({
         <div
           role='none'
           className={mx(
-            'attention-surface is-full',
-            role === 'section' && 'sticky block-start-0 z-[1] border-be !border-separator -mbe-px min-is-0',
+            'attention-surface is-full border-be !border-separator',
+            role === 'section' && 'sticky block-start-0 z-[1] -mbe-px min-is-0',
           )}
         >
           <Toolbar.Root

--- a/packages/plugins/plugin-navtree/src/components/NavTreeContainer.tsx
+++ b/packages/plugins/plugin-navtree/src/components/NavTreeContainer.tsx
@@ -12,7 +12,6 @@ import { useGraph } from '@dxos/plugin-graph';
 import { isEchoObject, isSpace } from '@dxos/react-client/echo';
 import { ElevationProvider, useMediaQuery, useSidebars } from '@dxos/react-ui';
 import { isItem } from '@dxos/react-ui-list';
-import { mx } from '@dxos/react-ui-theme';
 import { arrayMove } from '@dxos/util';
 
 import { NAV_TREE_ITEM, NavTree, type NavTreeProps } from './NavTree';
@@ -183,15 +182,14 @@ export const NavTreeContainer = ({ items, current, open, popoverAnchorId, ...pro
     <ElevationProvider elevation='chrome'>
       <div
         role='none'
-        className={mx(
-          'grid grid-cols-1 grid-rows-[var(--rail-size)_1fr_min-content]',
-          'bs-full overflow-hidden row-span-3 divide-y divide-separator',
-        )}
+        className='grid grid-cols-1 grid-rows-[var(--rail-size)_1fr_min-content] bs-full overflow-hidden'
       >
-        <Surface role='search-input' limit={1} />
+        <div role='none' className='border-be border-separator'>
+          <Surface role='search-input' limit={1} />
+        </div>
 
         {/* TODO(thure): What gives this an inline `overflow: initial`? */}
-        <div role='none' className='!overflow-y-auto'>
+        <div role='none' className='border-be border-separator !overflow-y-auto'>
           <NavTree
             items={items}
             open={open}

--- a/packages/plugins/plugin-sheet/src/components/SheetContainer/SheetContainer.tsx
+++ b/packages/plugins/plugin-sheet/src/components/SheetContainer/SheetContainer.tsx
@@ -19,7 +19,7 @@ export const SheetContainer = ({ space, sheet, role }: { space: Space; sheet: Sh
 
   return graph ? (
     <SheetProvider sheet={sheet} graph={graph}>
-      <StackItem.Content toolbar statusbar>
+      <StackItem.Content toolbar statusbar {...(role === 'section' && { classNames: 'aspect-video' })}>
         <Toolbar.Root role={role}>
           <Toolbar.Styles />
           <Toolbar.Alignment />

--- a/packages/plugins/plugin-sheet/src/components/Toolbar/Toolbar.tsx
+++ b/packages/plugins/plugin-sheet/src/components/Toolbar/Toolbar.tsx
@@ -178,7 +178,7 @@ const ToolbarRoot = ({ children, role, classNames }: ToolbarProps) => {
 
   return (
     <ToolbarContextProvider onAction={handleAction}>
-      <NaturalToolbar.Root classNames={['pli-0.5', !hasAttention && 'opacity-20', classNames]}>
+      <NaturalToolbar.Root classNames={['pli-0.5 attention-surface', !hasAttention && 'opacity-20', classNames]}>
         {children}
       </NaturalToolbar.Root>
     </ToolbarContextProvider>

--- a/packages/plugins/plugin-stack/src/StackPlugin.tsx
+++ b/packages/plugins/plugin-stack/src/StackPlugin.tsx
@@ -83,7 +83,7 @@ export const StackPlugin = (): PluginDefinition<StackPluginProvides> => {
               ) : null;
             case 'article':
               return primary instanceof CollectionType ? (
-                <div role='none' className='row-span-2 overflow-auto' style={{ contain: 'layout' }}>
+                <div role='none' className='overflow-auto' style={{ contain: 'layout' }}>
                   <StackMain id={id ?? fullyQualifiedId(primary)} collection={primary} />
                 </div>
               ) : null;

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -46,9 +46,9 @@ const TableRoot = ({ children, role }: TableRootProps) => {
     <div
       role='none'
       className={mx(
-        'relative border-bs border-separator',
+        'relative border-bs !border-separator',
         role === 'section'
-          ? 'overflow-hidden'
+          ? 'attention-surface overflow-hidden [&_.dx-grid]:max-is-max'
           : 'flex flex-col [&_.dx-grid]:grow [&_.dx-grid]:max-is-max [&_.dx-grid]:bs-0 [&_.dx-grid]:max-bs-max',
       )}
     >

--- a/packages/ui/react-ui-theme/src/theme.css
+++ b/packages/ui/react-ui-theme/src/theme.css
@@ -26,7 +26,7 @@
   --topbar-size: theme(spacing.12);
   --statusbar-size: theme(spacing.8);
   --sticky-top: 0;
-  --rail-size: 48px;
+  --rail-size: 49px;
   --rail-action: 40px;
   --nav-sidebar-size: 16.875rem;
   --complementary-sidebar-size: 22.5rem;


### PR DESCRIPTION
This PR makes additional layout & border adjustments so that Stack, Markdown, Table, and Sheet all work in planks, sections, solo, and complementary positions.

The separator border is now included in `--rail-size`.


https://github.com/user-attachments/assets/a6fc41fb-48de-4a64-bf38-f01e86976c05

