### PR TITLE
chore: remove ui packages from paths

### DIFF
--- a/packages/plugins/plugin-observability/package.json
+++ b/packages/plugins/plugin-observability/package.json
@@ -10,11 +10,13 @@
   "exports": {
     ".": {
       "types": "./dist/types/src/index.d.ts",
-      "browser": "./dist/lib/browser/index.mjs"
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": "./dist/lib/node-esm/index.mjs"
     },
     "./meta": {
       "types": "./dist/types/src/meta.d.ts",
-      "browser": "./dist/lib/browser/meta.mjs"
+      "browser": "./dist/lib/browser/meta.mjs",
+      "node": "./dist/lib/node-esm/meta.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/plugins/plugin-observability/project.json
+++ b/packages/plugins/plugin-observability/project.json
@@ -13,9 +13,6 @@
         "entryPoints": [
           "{projectRoot}/src/index.ts",
           "{projectRoot}/src/meta.ts"
-        ],
-        "platforms": [
-          "browser"
         ]
       }
     },

--- a/packages/plugins/plugin-status-bar/package.json
+++ b/packages/plugins/plugin-status-bar/package.json
@@ -10,11 +10,13 @@
   "exports": {
     ".": {
       "types": "./dist/types/src/index.d.ts",
-      "browser": "./dist/lib/browser/index.mjs"
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": "./dist/lib/node-esm/index.mjs"
     },
     "./meta": {
       "types": "./dist/types/src/meta.d.ts",
-      "browser": "./dist/lib/browser/meta.mjs"
+      "browser": "./dist/lib/browser/meta.mjs",
+      "node": "./dist/lib/node-esm/meta.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/plugins/plugin-status-bar/project.json
+++ b/packages/plugins/plugin-status-bar/project.json
@@ -13,9 +13,6 @@
         "entryPoints": [
           "{projectRoot}/src/index.ts",
           "{projectRoot}/src/meta.ts"
-        ],
-        "platforms": [
-          "browser"
         ]
       }
     },

--- a/packages/plugins/plugin-table/package.json
+++ b/packages/plugins/plugin-table/package.json
@@ -31,7 +31,7 @@
         "dist/types/src/meta.d.ts"
       ],
       "types": [
-        "dist/types/src/types/types.d.ts"
+        "dist/types/src/types/index.d.ts"
       ]
     }
   },

--- a/packages/ui/react-ui-attention/package.json
+++ b/packages/ui/react-ui-attention/package.json
@@ -10,11 +10,13 @@
   "exports": {
     ".": {
       "types": "./dist/types/src/index.d.ts",
-      "browser": "./dist/lib/browser/index.mjs"
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": "./dist/lib/node-esm/index.mjs"
     },
     "./testing": {
       "types": "./dist/types/src/testing/index.d.ts",
-      "browser": "./dist/lib/browser/testing/index.mjs"
+      "browser": "./dist/lib/browser/testing/index.mjs",
+      "node": "./dist/lib/node-esm/testing/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/ui/react-ui-attention/project.json
+++ b/packages/ui/react-ui-attention/project.json
@@ -13,9 +13,6 @@
         "entryPoints": [
           "{projectRoot}/src/index.ts",
           "{projectRoot}/src/testing/index.ts"
-        ],
-        "platforms": [
-          "browser"
         ]
       }
     },

--- a/packages/ui/react-ui-form/package.json
+++ b/packages/ui/react-ui-form/package.json
@@ -23,9 +23,7 @@
   ],
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
-    "@atlaskit/pragmatic-drag-and-drop-flourish": "^1.1.2",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
-    "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator": "^1.1.3",
     "@dxos/async": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/echo-db": "workspace:*",

--- a/packages/ui/react-ui-list/package.json
+++ b/packages/ui/react-ui-list/package.json
@@ -23,9 +23,7 @@
   ],
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
-    "@atlaskit/pragmatic-drag-and-drop-flourish": "^1.1.2",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
-    "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator": "^1.1.3",
     "@dxos/debug": "workspace:*",
     "@dxos/echo-schema": "workspace:*",
     "@dxos/invariant": "workspace:*",

--- a/packages/ui/react-ui-mosaic/package.json
+++ b/packages/ui/react-ui-mosaic/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "types": "./dist/types/src/index.d.ts",
-      "browser": "./dist/lib/browser/index.mjs"
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": "./dist/lib/node-esm/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/ui/react-ui-mosaic/project.json
+++ b/packages/ui/react-ui-mosaic/project.json
@@ -12,9 +12,6 @@
       "options": {
         "entryPoints": [
           "{projectRoot}/src/index.ts"
-        ],
-        "platforms": [
-          "browser"
         ]
       }
     },

--- a/packages/ui/react-ui-stack/package.json
+++ b/packages/ui/react-ui-stack/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.4.0",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
-    "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator": "^1.1.3",
     "@dxos/echo-schema": "workspace:*",
     "@dxos/keyboard": "workspace:*",
     "@dxos/react-ui-attention": "workspace:*",

--- a/packages/ui/react-ui-stack/src/components/StackItem.tsx
+++ b/packages/ui/react-ui-stack/src/components/StackItem.tsx
@@ -9,7 +9,8 @@ import {
   type Edge,
   extractClosestEdge,
 } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
-import { DropIndicator } from '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/box';
+// TODO(wittjosiah): Drop indicator that doesn't depend on emotion. See react-ui-list DropIndicator.
+// import { DropIndicator } from '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/box';
 import { useFocusableGroup } from '@fluentui/react-tabster';
 import { composeRefs } from '@radix-ui/react-compose-refs';
 import React, { forwardRef, useLayoutEffect, useState, type ComponentPropsWithRef, useCallback } from 'react';
@@ -146,7 +147,7 @@ const StackItemRoot = forwardRef<HTMLDivElement, StackItemRootProps>(
           ref={composedItemRef}
         >
           {children}
-          {closestEdge && <DropIndicator edge={closestEdge} />}
+          {/* {closestEdge && <DropIndicator edge={closestEdge} />} */}
         </Root>
       </StackItemContext.Provider>
     );

--- a/packages/ui/react-ui-stack/src/components/StackItem.tsx
+++ b/packages/ui/react-ui-stack/src/components/StackItem.tsx
@@ -58,7 +58,7 @@ const StackItemRoot = forwardRef<HTMLDivElement, StackItemRootProps>(
   ) => {
     const [itemElement, itemRef] = useState<HTMLDivElement | null>(null);
     const [selfDragHandleElement, selfDragHandleRef] = useState<HTMLDivElement | null>(null);
-    const [closestEdge, setEdge] = useState<Edge | null>(null);
+    const [_closestEdge, setEdge] = useState<Edge | null>(null);
     const { orientation, rail, separators } = useStack();
     const [size = orientation === 'horizontal' ? DEFAULT_HORIZONTAL_SIZE : DEFAULT_VERTICAL_SIZE, setInternalSize] =
       useState(propsSize);

--- a/packages/ui/react-ui-syntax-highlighter/package.json
+++ b/packages/ui/react-ui-syntax-highlighter/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "types": "./dist/types/src/index.d.ts",
-      "browser": "./dist/lib/browser/index.mjs"
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": "./dist/lib/node-esm/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/ui/react-ui-syntax-highlighter/project.json
+++ b/packages/ui/react-ui-syntax-highlighter/project.json
@@ -12,9 +12,6 @@
       "options": {
         "entryPoints": [
           "{projectRoot}/src/index.ts"
-        ],
-        "platforms": [
-          "browser"
         ]
       }
     },

--- a/packages/ui/react-ui-table/package.json
+++ b/packages/ui/react-ui-table/package.json
@@ -8,32 +8,30 @@
   "author": "DXOS.org",
   "sideEffects": true,
   "exports": {
+    "./deprecated": {
+      "types": "./dist/types/src/_deprecated/index.d.ts",
+      "browser": "./dist/lib/browser/_deprecated/index.mjs",
+      "node": "./dist/lib/node-esm/_deprecated/index.mjs"
+    },
     ".": {
       "types": "./dist/types/src/index.d.ts",
       "browser": "./dist/lib/browser/index.mjs",
-      "require": "./dist/lib/node/index.cjs",
-      "import": "./dist/lib/node-esm/index.mjs"
+      "node": "./dist/lib/node-esm/index.mjs"
     },
     "./types": {
       "types": "./dist/types/src/types/index.d.ts",
       "browser": "./dist/lib/browser/types/index.mjs",
-      "require": "./dist/lib/node/types/index.cjs",
-      "import": "./dist/lib/node-esm/types/index.mjs"
-    },
-    "./deprecated": {
-      "types": "./dist/types/src/_deprecated/index.d.ts",
-      "browser": "./dist/lib/browser/_deprecated/index.mjs",
-      "require": "./dist/lib/node/_deprecated/index.cjs",
-      "import": "./dist/lib/node-esm/_deprecated/index.mjs"
+      "node": "./dist/lib/node-esm/types/index.mjs"
     }
   },
+  "types": "dist/types/src/index.d.ts",
   "typesVersions": {
     "*": {
       "deprecated": [
-        "./dist/types/src/_deprecated/index.d.ts"
+        "dist/types/src/_deprecated/index.d.ts"
       ],
       "types": [
-        "./dist/types/src/types/index.d.ts"
+        "dist/types/src/types/index.d.ts"
       ]
     }
   },

--- a/packages/ui/react-ui-table/project.json
+++ b/packages/ui/react-ui-table/project.json
@@ -14,10 +14,6 @@
           "{projectRoot}/src/_deprecated/index.ts",
           "{projectRoot}/src/index.ts",
           "{projectRoot}/src/types/index.ts"
-        ],
-        "platforms": [
-          "browser",
-          "node"
         ]
       }
     },

--- a/packages/ui/react-ui-tabs/package.json
+++ b/packages/ui/react-ui-tabs/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "types": "./dist/types/src/index.d.ts",
-      "browser": "./dist/lib/browser/index.mjs"
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": "./dist/lib/node-esm/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/ui/react-ui-tabs/project.json
+++ b/packages/ui/react-ui-tabs/project.json
@@ -12,9 +12,6 @@
       "options": {
         "entryPoints": [
           "{projectRoot}/src/index.ts"
-        ],
-        "platforms": [
-          "browser"
         ]
       }
     },

--- a/packages/ui/react-ui-text-tooltip/package.json
+++ b/packages/ui/react-ui-text-tooltip/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "types": "./dist/types/src/index.d.ts",
-      "browser": "./dist/lib/browser/index.mjs"
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": "./dist/lib/node-esm/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/ui/react-ui-text-tooltip/project.json
+++ b/packages/ui/react-ui-text-tooltip/project.json
@@ -12,9 +12,6 @@
       "options": {
         "entryPoints": [
           "{projectRoot}/src/index.ts"
-        ],
-        "platforms": [
-          "browser"
         ]
       }
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10404,15 +10404,9 @@ importers:
       '@atlaskit/pragmatic-drag-and-drop':
         specifier: ^1.4.0
         version: 1.4.0
-      '@atlaskit/pragmatic-drag-and-drop-flourish':
-        specifier: ^1.1.2
-        version: 1.1.2(@babel/core@7.25.9)(@types/react@18.2.79)(react@18.2.0)
       '@atlaskit/pragmatic-drag-and-drop-hitbox':
         specifier: ^1.0.3
         version: 1.0.3
-      '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator':
-        specifier: ^1.1.3
-        version: 1.1.3(@babel/core@7.25.9)(@types/react@18.2.79)(react@18.2.0)
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -10580,15 +10574,9 @@ importers:
       '@atlaskit/pragmatic-drag-and-drop':
         specifier: ^1.4.0
         version: 1.4.0
-      '@atlaskit/pragmatic-drag-and-drop-flourish':
-        specifier: ^1.1.2
-        version: 1.1.2(@babel/core@7.25.9)(@types/react@18.2.79)(react@18.2.0)
       '@atlaskit/pragmatic-drag-and-drop-hitbox':
         specifier: ^1.0.3
         version: 1.0.3
-      '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator':
-        specifier: ^1.1.3
-        version: 1.1.3(@babel/core@7.25.9)(@types/react@18.2.79)(react@18.2.0)
       '@dxos/debug':
         specifier: workspace:*
         version: link:../../common/debug
@@ -10808,9 +10796,6 @@ importers:
       '@atlaskit/pragmatic-drag-and-drop-hitbox':
         specifier: ^1.0.3
         version: 1.0.3
-      '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator':
-        specifier: ^1.1.3
-        version: 1.1.3(@babel/core@7.25.9)(@types/react@18.2.79)(react@18.2.0)
       '@dxos/echo-schema':
         specifier: workspace:*
         version: link:../../core/echo/echo-schema
@@ -11605,9 +11590,6 @@ importers:
       '@dxos/esbuild-plugins':
         specifier: workspace:*
         version: link:../../packages/common/esbuild-plugins
-      '@dxos/esbuild-server':
-        specifier: ~2.29.0
-        version: 2.29.0(@types/react@18.2.79)
       '@dxos/protobuf-compiler':
         specifier: workspace:*
         version: link:../../packages/common/protobuf-compiler
@@ -11866,44 +11848,11 @@ packages:
     peerDependencies:
       ajv: '>=8'
 
-  '@atlaskit/ds-lib@2.7.0':
-    resolution: {integrity: sha512-+U4aPE2dBRFUBYWCM9vkrwJGrLAYVcK30ZpEiQDNpM2D7K41223TfEijC8azaN4VM3tsCgwSKBWwniloNxqYbA==}
-    peerDependencies:
-      react: ~18.2.0
-
-  '@atlaskit/ds-lib@3.1.0':
-    resolution: {integrity: sha512-1os/bwBxDkR1bqrnuW2fZR1uAm/tncI8W55fR31GKfpzI/WgmWABzzY9MdWim2kXjR4rsE0GvfjoNMJhJvfUVQ==}
-    peerDependencies:
-      react: ~18.2.0
-
-  '@atlaskit/motion@1.9.2':
-    resolution: {integrity: sha512-JvO+gpETBXU7eIAtIiJhaV8CV7g12ELkbdDFYcAnrSMvC6zZkEqijbgcdU1gdKMqln2R+fT7cLwjJ1MDObdDMg==}
-    peerDependencies:
-      react: ~18.2.0
-
-  '@atlaskit/platform-feature-flags@0.3.0':
-    resolution: {integrity: sha512-/0u5fFJ0Rw2j4M5wzsXgaHO6Ey12oekPCDTRvmmAIp4GO9T2Swbl80bavLAPSOmSHMhHTSuvRxiJveZXfQ21IQ==}
-
-  '@atlaskit/pragmatic-drag-and-drop-flourish@1.1.2':
-    resolution: {integrity: sha512-8x8YjW1oZNDbdDYYRVZfOY1fOcX4sF6pmYsflTJ4j0QtEGMl2Ae2DmXGqw13m0mJoMPIZvToWfKncTCZejKyDw==}
-    peerDependencies:
-      react: ~18.2.0
-
   '@atlaskit/pragmatic-drag-and-drop-hitbox@1.0.3':
     resolution: {integrity: sha512-/Sbu/HqN2VGLYBhnsG7SbRNg98XKkbF6L7XDdBi+izRybfaK1FeMfodPpm/xnBHPJzwYMdkE0qtLyv6afhgMUA==}
 
-  '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator@1.1.3':
-    resolution: {integrity: sha512-/4bKoIuaA1itAUhImYh8Z+25c2y9+07dCsumQ4aIwF3OPktWAoSEXILt43TvA4cSddHISs/Pq+eAdgMy0k7Rvg==}
-    peerDependencies:
-      react: ~18.2.0
-
   '@atlaskit/pragmatic-drag-and-drop@1.4.0':
     resolution: {integrity: sha512-qRY3PTJIcxfl/QB8Gwswz+BRvlmgAC5pB+J2hL6dkIxgqAgVwOhAamMUKsrOcFU/axG2Q7RbNs1xfoLKDuhoPg==}
-
-  '@atlaskit/tokens@2.0.1':
-    resolution: {integrity: sha512-/BqDg8snjLCwzI6vunJo7FDKT2LXdxj0entWe3ag/hyTMzT+d1wsVnByjeizkuvwTqbt++vFffi/ZLM7/KDMQw==}
-    peerDependencies:
-      react: ~18.2.0
 
   '@automerge/automerge-repo-network-broadcastchannel@1.1.12':
     resolution: {integrity: sha512-XEyNWa43ixZtMOTUMAzeB0KY31EseLG3/AEJMnFQGIVwDyb95ihtuBSPWfdjshSZd46dJmCPxzNa4Niev80Siw==}
@@ -13865,11 +13814,6 @@ packages:
   '@dxos/debug@0.4.9':
     resolution: {integrity: sha512-nnnmDqII7/9LnbnVdwEzmcq9FqFTe5vaM5Qc0JvZo3/BMhPc3pFZkMqtQpGn7DQJq4/xes09c/6Vw19MjW4SIA==}
 
-  '@dxos/esbuild-server@2.29.0':
-    resolution: {integrity: sha512-5jsQ800UgsX80Mbp5tGct/r3U1/4nzQDkyCWN2gbKnLBs/Nd3WTkLOTgbRd/GIBN6DSTkCdycPEVDXI0+P13uw==}
-    deprecated: Versions published prior to open sourcing are no longer supported
-    hasBin: true
-
   '@dxos/invariant@0.4.9':
     resolution: {integrity: sha512-BXpmvZmX6uweggeTQW+d30/S9A1fcl8V+IfotV0TADAbgOE4LLXiNXlbDuFhlL7XQQg1AYv6efJ4OMnyur9/EA==}
 
@@ -13911,69 +13855,20 @@ packages:
       emoji-mart: ^5.2
       react: ~18.2.0
 
-  '@emotion/babel-plugin@11.10.2':
-    resolution: {integrity: sha512-xNQ57njWTFVfPAc3cjfuaPdsgLp5QOSuRsj9MA6ndEhH/AzuZM86qIQzt6rq+aGBwj3n5/TkLmU5lhAfdRmogA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@emotion/cache@11.10.3':
-    resolution: {integrity: sha512-Psmp/7ovAa8appWh3g51goxu/z3iVms7JXOreq136D8Bbn6dYraPnmL6mdM8GThEx9vwSn92Fz+mGSjBzN8UPQ==}
-
   '@emotion/hash@0.9.0':
     resolution: {integrity: sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==}
-
-  '@emotion/is-prop-valid@0.8.8':
-    resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
 
   '@emotion/is-prop-valid@1.2.0':
     resolution: {integrity: sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==}
 
-  '@emotion/memoize@0.7.4':
-    resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
-
-  '@emotion/memoize@0.7.5':
-    resolution: {integrity: sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==}
-
   '@emotion/memoize@0.8.0':
     resolution: {integrity: sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==}
-
-  '@emotion/react@11.10.4':
-    resolution: {integrity: sha512-j0AkMpr6BL8gldJZ6XQsQ8DnS9TxEQu1R+OGmDZiWjBAJtCcbt0tS3I/YffoqHXxH6MjgI7KdMbYKw3MEiU9eA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      '@types/react': '*'
-      react: ~18.2.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/react':
-        optional: true
-
-  '@emotion/serialize@1.1.0':
-    resolution: {integrity: sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==}
-
-  '@emotion/sheet@1.2.0':
-    resolution: {integrity: sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w==}
 
   '@emotion/stylis@0.8.5':
     resolution: {integrity: sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==}
 
   '@emotion/unitless@0.7.5':
     resolution: {integrity: sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==}
-
-  '@emotion/unitless@0.8.0':
-    resolution: {integrity: sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==}
-
-  '@emotion/use-insertion-effect-with-fallbacks@1.0.1':
-    resolution: {integrity: sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==}
-    peerDependencies:
-      react: ~18.2.0
-
-  '@emotion/utils@1.2.0':
-    resolution: {integrity: sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==}
-
-  '@emotion/weak-memoize@0.3.0':
-    resolution: {integrity: sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==}
 
   '@esbuild-plugins/node-globals-polyfill@0.2.3':
     resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
@@ -14361,12 +14256,6 @@ packages:
     resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.14.54':
-    resolution: {integrity: sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.17.19':
@@ -15797,14 +15686,6 @@ packages:
     peerDependenciesMeta:
       markdown-it:
         optional: true
-
-  '@mdx-js/esbuild@2.1.5':
-    resolution: {integrity: sha512-9bfsKaD5ii4zcmy5WmERzQyDVXiQPHJk9FBQ3DLKzzmD56UIV1GFg16xVeg+vhWlO36U2VNiz5fYJIITZxUAJw==}
-    peerDependencies:
-      esbuild: '>=0.11.0'
-
-  '@mdx-js/mdx@2.1.5':
-    resolution: {integrity: sha512-zEG0lt+Bl/r5U6e0TOS7qDbsXICtemfAPquxWFsMbdzrvlWaqMGemLl+sjVpqlyaaiCiGVQBSGdCk0t1qXjkQg==}
 
   '@mdx-js/react@2.1.5':
     resolution: {integrity: sha512-3Az1I6SAWA9R38rYjz5rXBrGKeZhq96CSSyQtqY+maPj8stBsoUH5pNcmIixuGkufYsh8F5+ka2CVPo2fycWZw==}
@@ -18448,9 +18329,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rushstack/debug-certificate-manager@1.1.83':
-    resolution: {integrity: sha512-0628D2l0n9E3cDFw/y2JC0pklDCCB5oOgjtReVe3S4DuCHpy5Jar9Y3NZj2i98dl+kNBHIacGlCo20/Mmk//kw==}
-
   '@rushstack/eslint-patch@1.4.0':
     resolution: {integrity: sha512-cEjvTPU32OM9lUFegJagO0mRnIn+rbqrG89vV8/xLnLFX0DoR0r1oy5IlTga71Q7uT3Qus7qm7wgeiMT/+Irlg==}
 
@@ -18458,12 +18336,6 @@ packages:
     resolution: {integrity: sha512-ftvrRvN7a5dfpDidDtrqJHH25JvL4huqk3a0S4zv5Rlh1kz6sfPvaKosDQowzEHBIWLvAtTN+P8ygWoyL0/XYw==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  '@rushstack/node-core-library@3.50.2':
-    resolution: {integrity: sha512-+zpZBcaX5s+wA0avF0Lk3sd5jbGRo5SmsEJpElJbqQd3KGFvc/hcyeNSMqV5+esJ1JuTfnE1QyRt8nvxFNTaQg==}
-
-  '@rushstack/node-core-library@3.53.2':
-    resolution: {integrity: sha512-FggLe5DQs0X9MNFeJN3/EXwb+8hyZUTEp2i+V1e8r4Va4JgkjBNY0BuEaQI+3DW6S4apV3UtXU3im17MSY00DA==}
 
   '@rushstack/tree-pattern@0.2.4':
     resolution: {integrity: sha512-H8i0OinWsdKM1TKEKPeRRTw85e+/7AIFpxm7q1blceZJhuxRBjCGAUZvQXZK4CMLx75xPqh/h1t5WHwFmElAPA==}
@@ -19157,48 +19029,6 @@ packages:
       lit: ^2.0.0 || ^3.0.0
       storybook: ^8.3.6
 
-  '@styled-system/background@5.1.2':
-    resolution: {integrity: sha512-jtwH2C/U6ssuGSvwTN3ri/IyjdHb8W9X/g8Y0JLcrH02G+BW3OS8kZdHphF1/YyRklnrKrBT2ngwGUK6aqqV3A==}
-
-  '@styled-system/border@5.1.5':
-    resolution: {integrity: sha512-JvddhNrnhGigtzWRCVuAHepniyVi6hBlimxWDVAdcTuk7aRn9BYJUwfHslURtwYFsF5FoEs8Zmr1oZq2M1AP0A==}
-
-  '@styled-system/color@5.1.2':
-    resolution: {integrity: sha512-1kCkeKDZkt4GYkuFNKc7vJQMcOmTl3bJY3YBUs7fCNM6mMYJeT1pViQ2LwBSBJytj3AB0o4IdLBoepgSgGl5MA==}
-
-  '@styled-system/core@5.1.2':
-    resolution: {integrity: sha512-XclBDdNIy7OPOsN4HBsawG2eiWfCcuFt6gxKn1x4QfMIgeO6TOlA2pZZ5GWZtIhCUqEPTgIBta6JXsGyCkLBYw==}
-
-  '@styled-system/css@5.1.5':
-    resolution: {integrity: sha512-XkORZdS5kypzcBotAMPBoeckDs9aSZVkvrAlq5K3xP8IMAUek+x2O4NtwoSgkYkWWzVBu6DGdFZLR790QWGG+A==}
-
-  '@styled-system/flexbox@5.1.2':
-    resolution: {integrity: sha512-6hHV52+eUk654Y1J2v77B8iLeBNtc+SA3R4necsu2VVinSD7+XY5PCCEzBFaWs42dtOEDIa2lMrgL0YBC01mDQ==}
-
-  '@styled-system/grid@5.1.2':
-    resolution: {integrity: sha512-K3YiV1KyHHzgdNuNlaw8oW2ktMuGga99o1e/NAfTEi5Zsa7JXxzwEnVSDSBdJC+z6R8WYTCYRQC6bkVFcvdTeg==}
-
-  '@styled-system/layout@5.1.2':
-    resolution: {integrity: sha512-wUhkMBqSeacPFhoE9S6UF3fsMEKFv91gF4AdDWp0Aym1yeMPpqz9l9qS/6vjSsDPF7zOb5cOKC3tcKKOMuDCPw==}
-
-  '@styled-system/position@5.1.2':
-    resolution: {integrity: sha512-60IZfMXEOOZe3l1mCu6sj/2NAyUmES2kR9Kzp7s2D3P4qKsZWxD1Se1+wJvevb+1TP+ZMkGPEYYXRyU8M1aF5A==}
-
-  '@styled-system/shadow@5.1.2':
-    resolution: {integrity: sha512-wqniqYb7XuZM7K7C0d1Euxc4eGtqEe/lvM0WjuAFsQVImiq6KGT7s7is+0bNI8O4Dwg27jyu4Lfqo/oIQXNzAg==}
-
-  '@styled-system/should-forward-prop@5.1.5':
-    resolution: {integrity: sha512-+rPRomgCGYnUIaFabDoOgpSDc4UUJ1KsmlnzcEp0tu5lFrBQKgZclSo18Z1URhaZm7a6agGtS5Xif7tuC2s52Q==}
-
-  '@styled-system/space@5.1.2':
-    resolution: {integrity: sha512-+zzYpR8uvfhcAbaPXhH8QgDAV//flxqxSjHiS9cDFQQUSznXMQmxJegbhcdEF7/eNnJgHeIXv1jmny78kipgBA==}
-
-  '@styled-system/typography@5.1.2':
-    resolution: {integrity: sha512-BxbVUnN8N7hJ4aaPOd7wEsudeT7CxarR+2hns8XCX1zp0DFfbWw4xYa/olA0oQaqx7F1hzDg+eRaGzAJbF+jOg==}
-
-  '@styled-system/variant@5.1.5':
-    resolution: {integrity: sha512-Yn8hXAFoWIro8+Q5J8YJd/mP85Teiut3fsGVR9CAxwgNfIAiqlYxsk5iHU7VHJks/0KjL4ATSjmbtCDC/4l1qw==}
-
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
 
@@ -19550,48 +19380,6 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@theme-ui/color-modes@0.14.7':
-    resolution: {integrity: sha512-nEVS9o37Ga+ARLIivibWJzp6T2Q7cz6N0FRuSQYUSBimuMw329SRBXZ9LTmltatQO9+iYb5miiJOe/t/vQeOxg==}
-    peerDependencies:
-      '@emotion/react': ^11
-      react: ~18.2.0
-
-  '@theme-ui/components@0.14.7':
-    resolution: {integrity: sha512-iIzqBvRL8GNVkzuZinxInYNFW/38pvqqthuCgLsnOC0/A4Q4v13mn/fxlZa6pJjwouswsRLOrkd63bS7Svzkfw==}
-    peerDependencies:
-      '@emotion/react': ^11
-      react: ~18.2.0
-
-  '@theme-ui/core@0.14.7':
-    resolution: {integrity: sha512-u60cKOZYsGDG9sSoM4jYj743OpNXXU27f7vXGwrO/B1t/1sv1MAQA0R8HtVwoi9DyOIcOmWfMWYTiMg+4vV1MA==}
-    peerDependencies:
-      '@emotion/react': ^11
-      react: ~18.2.0
-
-  '@theme-ui/css@0.14.7':
-    resolution: {integrity: sha512-DbGw0T4MrTjiRs6lnyYgSD2TV/LvFErzDDpm0ICPL2KqDwqgHX4mFpDafj8/DkyCO9wx2KEiUuE+0NtOlR3i4w==}
-    peerDependencies:
-      '@emotion/react': ^11
-
-  '@theme-ui/mdx@0.14.7':
-    resolution: {integrity: sha512-Hqlrzj5tI/fRuD5sJMblTcaChA5xajeSC7qpMRACjWgdNNiw/g/bi0V5uNejBRpILgmZua5EDQ2XV0IqhSGcPQ==}
-    peerDependencies:
-      '@emotion/react': ^11
-      '@mdx-js/react': ^1 || ^2
-      react: ~18.2.0
-
-  '@theme-ui/parse-props@0.14.7':
-    resolution: {integrity: sha512-qF10mAYs3wcIkSU5ZSbmHUngwTkPS87D23qg1ArbeO+m+/e4uqOy0+6W0Lt/4JTP7lnWWsCYuScK3F3hOp2q0w==}
-    peerDependencies:
-      '@emotion/react': ^11
-      react: ~18.2.0
-
-  '@theme-ui/theme-provider@0.14.7':
-    resolution: {integrity: sha512-RmuDkdotzMcNSx/nI2nwBtQAwH/B9mae/nsR0o6AXyd+zOAfF9YY3vbtjYZicaYfcE/mnjmXqKTTwd4KaHu4UQ==}
-    peerDependencies:
-      '@emotion/react': ^11
-      react: ~18.2.0
-
   '@tldraw/assets@3.0.0':
     resolution: {integrity: sha512-TRoU/UVEgfkmuswbnLei8x9ozTyk2aeIp7jW8fCmfbm65z0zpIQgMmVkHHfhmssLAh6hpHEJNYE8XZ1QFXP+tw==}
 
@@ -19671,9 +19459,6 @@ packages:
 
   '@types/accepts@1.3.7':
     resolution: {integrity: sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==}
-
-  '@types/acorn@4.0.6':
-    resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
 
   '@types/argparse@2.0.10':
     resolution: {integrity: sha512-C4wahC3gz3vQtvPazrJ5ONwmK1zSDllQboiWvpMM/iOswCYfBREFnjFbq/iWKIVOCl8+m5Pk6eva6/ZSsDuIGA==}
@@ -20373,9 +20158,6 @@ packages:
 
   '@types/string-hash@1.1.1':
     resolution: {integrity: sha512-ijt3zdHi2DmZxQpQTmozXszzDo78V4R3EdvX0jFMfnMH2ZzQSmCbaWOMPGXFUYSzSIdStv78HDjg32m5dxc+tA==}
-
-  '@types/styled-system@5.1.15':
-    resolution: {integrity: sha512-1uls4wipZn8FtYFZ7upRVFDoEeOXTQTs2zuyOZPn02T6rjIxtvj2P2lG5qsxXHhKuKsu3thveCZrtaeLE/ibLg==}
 
   '@types/stylus@0.48.38':
     resolution: {integrity: sha512-B5otJekvD6XM8iTrnO6e2twoTY2tKL9VkL/57/2Lo4tv3EatbCaufdi68VVtn/h4yjO+HVvYEyrNQd0Lzj6riw==}
@@ -21339,10 +21121,6 @@ packages:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
 
-  astring@1.8.3:
-    resolution: {integrity: sha512-sRpyiNrx2dEYIMmUXprS8nlpRg2Drs8m9ElX9vVEXaCB4XEAJhKfs7IcX0IwShjuOAjLR6wzIrgoptz1n19i1A==}
-    hasBin: true
-
   async-array-reduce@0.2.1:
     resolution: {integrity: sha512-/ywTADOcaEnwiAnOEi0UB/rAcIq5bTFfCV9euv3jLYFUMmy6KvKccTQUnLlp8Ensmfj43wHSmbGiPqjsZ6RhNA==}
     engines: {node: '>=0.10.0'}
@@ -21453,10 +21231,6 @@ packages:
 
   babel-plugin-macros@2.8.0:
     resolution: {integrity: sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==}
-
-  babel-plugin-macros@3.1.0:
-    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
-    engines: {node: '>=10', npm: '>=6'}
 
   babel-plugin-polyfill-corejs2@0.3.3:
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
@@ -22357,10 +22131,6 @@ packages:
 
   colors@0.6.2:
     resolution: {integrity: sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==}
-    engines: {node: '>=0.1.90'}
-
-  colors@1.2.5:
-    resolution: {integrity: sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==}
     engines: {node: '>=0.1.90'}
 
   colorspace@1.1.4:
@@ -23737,102 +23507,6 @@ packages:
   es6-promisify@5.0.0:
     resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
 
-  esbuild-android-64@0.14.54:
-    resolution: {integrity: sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
-  esbuild-android-arm64@0.14.54:
-    resolution: {integrity: sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
-  esbuild-darwin-64@0.14.54:
-    resolution: {integrity: sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-
-  esbuild-darwin-arm64@0.14.54:
-    resolution: {integrity: sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
-  esbuild-freebsd-64@0.14.54:
-    resolution: {integrity: sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-
-  esbuild-freebsd-arm64@0.14.54:
-    resolution: {integrity: sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  esbuild-linux-32@0.14.54:
-    resolution: {integrity: sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
-  esbuild-linux-64@0.14.54:
-    resolution: {integrity: sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-
-  esbuild-linux-arm64@0.14.54:
-    resolution: {integrity: sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
-  esbuild-linux-arm@0.14.54:
-    resolution: {integrity: sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-
-  esbuild-linux-mips64le@0.14.54:
-    resolution: {integrity: sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
-  esbuild-linux-ppc64le@0.14.54:
-    resolution: {integrity: sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-
-  esbuild-linux-riscv64@0.14.54:
-    resolution: {integrity: sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
-  esbuild-linux-s390x@0.14.54:
-    resolution: {integrity: sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
-  esbuild-netbsd-64@0.14.54:
-    resolution: {integrity: sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
-  esbuild-openbsd-64@0.14.54:
-    resolution: {integrity: sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-
   esbuild-plugin-inline-image@0.0.9:
     resolution: {integrity: sha512-pw3ZgN2phh32Z7BpKrhRDtmI+iVCl+Gc0BLOT9croXg1MnMjRuN7aXhIQirhLeK39erkIwfFlhy6xieroBGc1Q==}
 
@@ -23856,37 +23530,8 @@ packages:
   esbuild-style-plugin@1.6.1:
     resolution: {integrity: sha512-t5ZtQyGKNiM8DLedz+iwFH0LPWLnMmaEQ2RnnP1ppFHq35najxqJHAhUVVSbTFm5cR2ZumGdBMqnmuKBRBMvDw==}
 
-  esbuild-sunos-64@0.14.54:
-    resolution: {integrity: sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
   esbuild-wasm@0.16.17:
     resolution: {integrity: sha512-Tn7NuMqRcM+T/qCOxbQRq0qrwWl1sUWp6ARfJRakE8Bepew6zata4qrKgH2YqovNC5e/2fcTa7o+VL/FAOZC1Q==}
-    engines: {node: '>=12'}
-    hasBin: true
-
-  esbuild-windows-32@0.14.54:
-    resolution: {integrity: sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
-  esbuild-windows-64@0.14.54:
-    resolution: {integrity: sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-
-  esbuild-windows-arm64@0.14.54:
-    resolution: {integrity: sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-
-  esbuild@0.14.54:
-    resolution: {integrity: sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==}
     engines: {node: '>=12'}
     hasBin: true
 
@@ -24156,21 +23801,6 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
-
-  estree-util-attach-comments@2.1.0:
-    resolution: {integrity: sha512-rJz6I4L0GaXYtHpoMScgDIwM0/Vwbu5shbMeER596rB2D1EWF6+Gj0e0UKzJPZrpoOc87+Q2kgVFHfjAymIqmw==}
-
-  estree-util-build-jsx@2.2.0:
-    resolution: {integrity: sha512-apsfRxF9uLrqosApvHVtYZjISPvTJ+lBiIydpC+9wE6cF6ssbhnjyQLqaIjgzGxvC2Hbmec1M7g91PoBayYoQQ==}
-
-  estree-util-is-identifier-name@2.0.1:
-    resolution: {integrity: sha512-rxZj1GkQhY4x1j/CSnybK9cGuMFQYFPLq0iNyopqf14aOVLFtMv7Esika+ObJWPWiOHuMOAHz3YkWoLYYRnzWQ==}
-
-  estree-util-to-js@1.1.0:
-    resolution: {integrity: sha512-490lbfCcpLk+ofK6HCgqDfYs4KAfq6QVvDw3+Bm1YoKRgiOjKiKYGAVQE1uwh7zVxBgWhqp4FDtp5SqunpUk1A==}
-
-  estree-util-visit@1.2.0:
-    resolution: {integrity: sha512-wdsoqhWueuJKsh5hqLw3j8lwFqNStm92VcwtAOAny8g/KS/l5Y8RISjR4k5W6skCj3Nirag/WUCMS0Nfy3sgsg==}
 
   estree-walker@0.6.1:
     resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
@@ -24495,9 +24125,6 @@ packages:
     resolution: {integrity: sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==}
     hasBin: true
 
-  find-root@1.1.0:
-    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
-
   find-up@1.1.2:
     resolution: {integrity: sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==}
     engines: {node: '>=0.10.0'}
@@ -24678,10 +24305,6 @@ packages:
   fs-extra@11.2.0:
     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
     engines: {node: '>=14.14'}
-
-  fs-extra@7.0.1:
-    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
-    engines: {node: '>=6 <7 || >=8'}
 
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
@@ -25194,9 +24817,6 @@ packages:
   hast-util-select@1.0.1:
     resolution: {integrity: sha512-wNFpEC9Or4YTcSzDERXu5n7L+dNTy9tLbqW+LMIkCH69g9NkLEKcGBoXUnJwOVG5KmecLmHxVbrRh3RJmUxtmA==}
 
-  hast-util-to-estree@2.1.0:
-    resolution: {integrity: sha512-Vwch1etMRmm89xGgz+voWXvVHba2iiMdGMKmaMfYt35rbVtFDq8JNwwAIvi8zHMkO6Gvqo9oTMwJTmzVRfXh4g==}
-
   hast-util-to-html@8.0.3:
     resolution: {integrity: sha512-/D/E5ymdPYhHpPkuTHOUkSatxr4w1ZKrZsG0Zv/3C2SRVT0JFJG53VS45AMrBtYk0wp5A7ksEhiC8QaOZM95+A==}
 
@@ -25539,10 +25159,6 @@ packages:
   import-in-the-middle@1.9.1:
     resolution: {integrity: sha512-E+3tEOutU1MV0mxhuCwfSPNNWRkbTJ3/YyL5be+blNIbHwZc53uYHQfuIhAU77xWR0BoF2eT7cqDJ6VlU5APPg==}
 
-  import-lazy@4.0.0:
-    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
-    engines: {node: '>=8'}
-
   import-meta-resolve@4.0.0:
     resolution: {integrity: sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==}
 
@@ -25620,9 +25236,6 @@ packages:
 
   inline-style-parser@0.1.1:
     resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
-
-  inpath@1.0.2:
-    resolution: {integrity: sha512-DTt55ovuYFC62a8oJxRjV2MmTPUdxN43Gd8I2ZgawxbAha6PvJkDQy/RbZGFCJF5IXrpp4PAYtW1w3aV7jXkew==}
 
   inquirer@12.0.0:
     resolution: {integrity: sha512-W3mwgzLtWIqHndtAb82zCHbRfdPit3jcqEyYkAjM/4p15g/1tOoduYydx6IJ3sh31FHT82YoqYZB8RoTwoMy7w==}
@@ -25952,9 +25565,6 @@ packages:
     resolution: {integrity: sha512-cr/SlUEe5zOGmzvj9bUyC4LVvkNVAXu4GytXLNMr1pny+a65MpQ9IJzFHD5vi7FyJgb4qt27+eS3TuQnqB+RQw==}
     engines: {node: '>=0.10.0'}
 
-  is-reference@3.0.0:
-    resolution: {integrity: sha512-Eo1W3wUoHWoCoVM4GVl/a+K0IgiqE5aIo4kJABFyMum1ZORlPkC+UC357sSQUL5w5QCE5kCC9upl75b7+7CY/Q==}
-
   is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
@@ -26275,9 +25885,6 @@ packages:
   jiti@1.21.0:
     resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
     hasBin: true
-
-  jju@1.4.0:
-    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
   joi@17.12.3:
     resolution: {integrity: sha512-2RRziagf555owrm9IRVtdKynOBeITiDpuZqIpgwqXShPncPKNiRQoiGsl/T8SQdq+8ugRzH2LqY67irr2y/d+g==}
@@ -27153,10 +26760,6 @@ packages:
   map-or-similar@1.5.0:
     resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
 
-  markdown-extensions@1.1.1:
-    resolution: {integrity: sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==}
-    engines: {node: '>=0.10.0'}
-
   markdown-it-anchor@8.6.7:
     resolution: {integrity: sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==}
     peerDependencies:
@@ -27271,15 +26874,6 @@ packages:
 
   mdast-util-mdx-expression@1.3.1:
     resolution: {integrity: sha512-TTb6cKyTA1RD+1su1iStZ5PAv3rFfOUKcoU5EstUpv/IZo63uDX03R8+jXjMEhcobXnNOiG6/ccekvVl4eV1zQ==}
-
-  mdast-util-mdx-jsx@2.1.0:
-    resolution: {integrity: sha512-KzgzfWMhdteDkrY4mQtyvTU5bc/W4ppxhe9SzelO6QUUiwLAM+Et2Dnjjprik74a336kHdo0zKm7Tp+n6FFeRg==}
-
-  mdast-util-mdx@2.0.0:
-    resolution: {integrity: sha512-M09lW0CcBT1VrJUaF/PYxemxxHa7SLDHdSn94Q9FhxjCQfuW7nMAWKWimTmA3OyDMSTH981NN1csW1X+HPSluw==}
-
-  mdast-util-mdxjs-esm@1.3.0:
-    resolution: {integrity: sha512-7N5ihsOkAEGjFotIX9p/YPdl4TqUoMxL4ajNz7PbT89BqsdWJuBC9rvgt6wpbwTZqWWR0jKWqQbwsOWDBUZv4g==}
 
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
@@ -27408,21 +27002,6 @@ packages:
   micromark-extension-gfm@2.0.1:
     resolution: {integrity: sha512-p2sGjajLa0iYiGQdT0oelahRYtMWvLjy8J9LOCxzIQsllMCGLbsLW+Nc+N4vi02jcRJvedVJ68cjelKIO6bpDA==}
 
-  micromark-extension-mdx-expression@1.0.3:
-    resolution: {integrity: sha512-TjYtjEMszWze51NJCZmhv7MEBcgYRgb3tJeMAJ+HQCAaZHHRBaDCccqQzGizR/H4ODefP44wRTgOn2vE5I6nZA==}
-
-  micromark-extension-mdx-jsx@1.0.3:
-    resolution: {integrity: sha512-VfA369RdqUISF0qGgv2FfV7gGjHDfn9+Qfiv5hEwpyr1xscRj/CiVRkU7rywGFCO7JwJ5L0e7CJz60lY52+qOA==}
-
-  micromark-extension-mdx-md@1.0.0:
-    resolution: {integrity: sha512-xaRAMoSkKdqZXDAoSgp20Azm0aRQKGOl0RrS81yGu8Hr/JhMsBmfs4wR7m9kgVUIO36cMUQjNyiyDKPrsv8gOw==}
-
-  micromark-extension-mdxjs-esm@1.0.3:
-    resolution: {integrity: sha512-2N13ol4KMoxb85rdDwTAC6uzs8lMX0zeqpcyx7FhS7PxXomOnLactu8WI8iBNXW8AVyea3KIJd/1CKnUmwrK9A==}
-
-  micromark-extension-mdxjs@1.0.0:
-    resolution: {integrity: sha512-TZZRZgeHvtgm+IhtgC2+uDMR7h8eTKF0QUX9YsgoL9+bADBpBY6SiLvWqnBlLbCEevITmTqmEuY3FoxMKVs1rQ==}
-
   micromark-factory-destination@1.0.0:
     resolution: {integrity: sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==}
 
@@ -27434,9 +27013,6 @@ packages:
 
   micromark-factory-label@2.0.0:
     resolution: {integrity: sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==}
-
-  micromark-factory-mdx-expression@1.0.6:
-    resolution: {integrity: sha512-WRQIc78FV7KrCfjsEf/sETopbYjElh3xAmNpLkd1ODPqxEngP42eVRGbiPEQWpRV27LzqW+XVTvQAMIIRLPnNA==}
 
   micromark-factory-space@1.0.0:
     resolution: {integrity: sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==}
@@ -27497,9 +27073,6 @@ packages:
 
   micromark-util-encode@2.0.0:
     resolution: {integrity: sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==}
-
-  micromark-util-events-to-acorn@1.2.0:
-    resolution: {integrity: sha512-WWp3bf7xT9MppNuw3yPjpnOxa8cj5ACivEzXJKu0WwnjBYfzaBvIAT9KfeyI0Qkll+bfQtfftSwdgTH6QhTOKw==}
 
   micromark-util-html-tag-name@1.1.0:
     resolution: {integrity: sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA==}
@@ -27808,9 +27381,6 @@ packages:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
 
-  mute-stream@0.0.8:
-    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
-
   mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -27887,10 +27457,6 @@ packages:
   natural-orderby@3.0.2:
     resolution: {integrity: sha512-x7ZdOwBxZCEm9MM7+eQCjkrNLrW3rkBKNHVr78zbtqnMGVNlnDi6C/eUEYgxHNrcbu0ymvjzcwIL/6H1iHri9g==}
     engines: {node: '>=18'}
-
-  ncp@2.0.0:
-    resolution: {integrity: sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==}
-    hasBin: true
 
   needle@3.3.1:
     resolution: {integrity: sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==}
@@ -28656,9 +28222,6 @@ packages:
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
-  periscopic@3.0.4:
-    resolution: {integrity: sha512-SFx68DxCv0Iyo6APZuw/AKewkkThGwssmU0QWtTlvov3VAtPX+QJ4CadwSaz8nrT5jPIuxdvJWB4PnD2KNDxQg==}
-
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
@@ -28693,9 +28256,6 @@ packages:
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
-
-  pidof@1.0.2:
-    resolution: {integrity: sha512-LLJhTVEUCZnotdAM5rd7KiTdLGgk6i763/hsd5pO+8yuF7mdgg0ob8w/98KrTAcPsj6YzGrkFLPVtBOr1uW2ag==}
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -29716,16 +29276,6 @@ packages:
     peerDependencies:
       react: ~18.2.0
 
-  react-uid@2.3.3:
-    resolution: {integrity: sha512-iNpDovcb9qBpBTo8iUgqRSQOS8GV3bWoNaTaUptHkXtAooXSo0OWe7vN6TqqB8x3x0bNBbQx96kkmSltQ5h9kQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': ~18.2.0
-      react: ~18.2.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   react-vis@1.11.12:
     resolution: {integrity: sha512-WuYZrwrH/cXgxKcynciuwZ6+6V9a5N43qa4Wwfgll/tyLq+ACcJ5m8fHFXQk7fQBK80RAp61Oc+a+T64woorvw==}
     engines: {node: '>=0.10.0', npm: '>=3.0'}
@@ -29759,10 +29309,6 @@ packages:
   read-yaml-file@2.1.0:
     resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
     engines: {node: '>=10.13'}
-
-  read@1.0.7:
-    resolution: {integrity: sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==}
-    engines: {node: '>=0.8'}
 
   readable-stream@1.1.14:
     resolution: {integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==}
@@ -29896,9 +29442,6 @@ packages:
   rehype-external-links@3.0.0:
     resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}
 
-  rehype-highlight@5.0.2:
-    resolution: {integrity: sha512-ZNm8V8BQUDn05cJPzAu/PjiloaFFrh+Pt3bY+NCcdCggI7Uyl5mW0FGR7RATeIz5/ECUd1D8Kvjt4HaLPmnOMw==}
-
   rehype-highlight@6.0.0:
     resolution: {integrity: sha512-q7UtlFicLhetp7K48ZgZiJgchYscMma7XjzX7t23bqEJF8m6/s+viXQEe4oHjrATTIZpX7RG8CKD7BlNZoh9gw==}
 
@@ -29927,9 +29470,6 @@ packages:
 
   remark-lint@9.1.1:
     resolution: {integrity: sha512-zhe6twuqgkx/9KgZyNyaO0cceA4jQuJcyzMOBC+JZiAzMN6mFUmcssWZyY30ko8ut9vQDMX/pyQnolGn+Fg/Tw==}
-
-  remark-mdx@2.1.5:
-    resolution: {integrity: sha512-A8vw5s+BgOa968Irt8BO7DfWJTE0Fe7Ge3hX8zzDB1DnwMZTNdK6qF2IcFao+/7nzk1vSysKcFp+3ku4vhMpaQ==}
 
   remark-message-control@7.1.1:
     resolution: {integrity: sha512-xKRWl1NTBOKed0oEtCd8BUfH5m4s8WXxFFSoo7uUwx6GW/qdCy4zov5LfPyw7emantDmhfWn5PdIZgcbVcWMDQ==}
@@ -30032,9 +29572,6 @@ packages:
   resolve.exports@2.0.2:
     resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
     engines: {node: '>=10'}
-
-  resolve@1.17.0:
-    resolution: {integrity: sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==}
 
   resolve@1.22.2:
     resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
@@ -30364,11 +29901,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.3.8:
-    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
@@ -30683,10 +30215,6 @@ packages:
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
-  source-map@0.5.7:
-    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
-    engines: {node: '>=0.10.0'}
-
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -30996,9 +30524,6 @@ packages:
   style-mod@4.1.0:
     resolution: {integrity: sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==}
 
-  style-to-object@0.3.0:
-    resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
-
   style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
 
@@ -31010,17 +30535,11 @@ packages:
       react-dom: ~18.2.0
       react-is: '>= 16.8.0'
 
-  styled-system@5.1.5:
-    resolution: {integrity: sha512-7VoD0o2R3RKzOzPK0jYrVnS8iJdfkKsQJNiLRDjikOpQVqQHns/DXWaPZOH4tIKkhAT7I6wIsy9FWTWh2X3q+A==}
-
   stylehacks@6.1.1:
     resolution: {integrity: sha512-gSTTEQ670cJNoaeIp9KX6lZmm8LJ3jPB5yJmX8Zq/wQxOsAFXV3qjWzHas3YYk1qesuVIyYWWUpZ0vSE/dTSGg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-
-  stylis@4.0.13:
-    resolution: {integrity: sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==}
 
   stylis@4.3.0:
     resolution: {integrity: sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==}
@@ -31044,10 +30563,6 @@ packages:
     resolution: {integrity: sha512-ydQOU34rpSyj2TGyz4D2p8rbktIOZ8QY9s+DGLvFU1i5pWJE8vkpruCjGCMHsdXwnD7JDcS+noSwM/a7zyNFDQ==}
     engines: {node: '>=8'}
     hasBin: true
-
-  sudo@1.0.3:
-    resolution: {integrity: sha512-3xMsaPg+8Xm+4LQm0b2V+G3lz3YxtDBzlqiU8CXw2AOIIDSvC1kBxIxBjnoCTq8dTTXAy23m58g6mdClUocpmQ==}
-    engines: {node: '>=0.8'}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -31228,12 +30743,6 @@ packages:
     engines: {node: '>=0.8'}
     hasBin: true
 
-  theme-ui@0.14.7:
-    resolution: {integrity: sha512-3CMyupASBnf3/b3We8VS3kSPUnk/jhXGzRCQCcHsNkA8nrxZ6pR2QABa768YRlc7EYBUlXCvyWnSmGQlX0Omog==}
-    peerDependencies:
-      react: ~18.2.0
-      react-dom: ~18.2.0
-
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -31279,9 +30788,6 @@ packages:
 
   timeout-refresh@1.0.3:
     resolution: {integrity: sha512-Mz0CX4vBGM5lj8ttbIFt7o4ZMxk/9rgudJRh76EvB7xXZMur7T/cjRiH2w4Fmkq0zxf2QpM8IFvOSRn8FEu3gA==}
-
-  timsort@0.3.0:
-    resolution: {integrity: sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==}
 
   tiny-each-async@2.0.3:
     resolution: {integrity: sha512-5ROII7nElnAirvFn8g7H7MtpfV1daMcyfTGQwsn/x2VtyV+VPiO5CjReCJtWLvoKTDEDmZocf3cNPraiMnBXLA==}
@@ -31827,14 +31333,8 @@ packages:
   unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
 
-  unist-util-position-from-estree@1.1.1:
-    resolution: {integrity: sha512-xtoY50b5+7IH8tFbkw64gisG9tMSpxDjhX9TmaJJae/XuxQ9R/Kc8Nv1eOsf43Gt4KV/LkriMy9mptDr7XLcaw==}
-
   unist-util-position@4.0.3:
     resolution: {integrity: sha512-p/5EMGIa1qwbXjA+QgcBXaPWjSnZfQ2Sc3yBEEfgPwsEmJd8Qh+DSk3LGnmOM4S1bY2C0AjmMnB8RuEYxpPwXQ==}
-
-  unist-util-remove-position@4.0.1:
-    resolution: {integrity: sha512-0yDkppiIhDlPrfHELgB+NLQD5mfjup3a8UYclHruTJWmY74je8g+CIFr79x5f6AkmzSwlvKLbs63hC0meOMowQ==}
 
   unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
@@ -32084,10 +31584,6 @@ packages:
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  validator@13.7.0:
-    resolution: {integrity: sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==}
-    engines: {node: '>= 0.10'}
 
   varint@4.0.1:
     resolution: {integrity: sha512-vu4cpCqZHA4u77jWdOZlXtXHJofIIyq51DtzstbrvI9e1I1ELseAJLxYr47N/DdLPFGfYMLY1HqAURSTKKJ6ww==}
@@ -33346,11 +32842,6 @@ packages:
   youch@3.3.3:
     resolution: {integrity: sha512-qSFXUk3UZBLfggAW3dJKg0BMblG5biqSF8M34E06o5CSsZtH92u9Hqmj2RzGiHDi64fhe83+4tENFP2DB6t6ZA==}
 
-  z-schema@5.0.4:
-    resolution: {integrity: sha512-gm/lx3hDzJNcLwseIeQVm1UcwhWIKpSB4NqH89pTBtFns4k/HDHudsICtvG05Bvw/Mv3jMyk700y5dadueLHdA==}
-    engines: {node: '>=8.0.0'}
-    hasBin: true
-
   zen-observable@0.10.0:
     resolution: {integrity: sha512-iI3lT0iojZhKwT5DaFy2Ce42n3yFcLdFyOh01G7H0flMY60P8MJuVFEoJoNwXlmAyQ45GrjL6AcZmmlv8A5rbw==}
 
@@ -33460,89 +32951,16 @@ snapshots:
       jsonpointer: 5.0.1
       leven: 3.1.0
 
-  '@atlaskit/ds-lib@2.7.0(@types/react@18.2.79)(react@18.2.0)':
-    dependencies:
-      '@atlaskit/platform-feature-flags': 0.3.0
-      '@babel/runtime': 7.25.9
-      bind-event-listener: 3.0.0
-      react: 18.2.0
-      react-uid: 2.3.3(@types/react@18.2.79)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@atlaskit/ds-lib@3.1.0(@types/react@18.2.79)(react@18.2.0)':
-    dependencies:
-      '@atlaskit/platform-feature-flags': 0.3.0
-      '@babel/runtime': 7.25.9
-      bind-event-listener: 3.0.0
-      react: 18.2.0
-      react-uid: 2.3.3(@types/react@18.2.79)(react@18.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@atlaskit/motion@1.9.2(@babel/core@7.25.9)(@types/react@18.2.79)(react@18.2.0)':
-    dependencies:
-      '@atlaskit/ds-lib': 3.1.0(@types/react@18.2.79)(react@18.2.0)
-      '@babel/runtime': 7.25.9
-      '@emotion/react': 11.10.4(@babel/core@7.25.9)(@types/react@18.2.79)(react@18.2.0)
-      bind-event-listener: 3.0.0
-      react: 18.2.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/react'
-      - supports-color
-
-  '@atlaskit/platform-feature-flags@0.3.0':
-    dependencies:
-      '@babel/runtime': 7.25.9
-
-  '@atlaskit/pragmatic-drag-and-drop-flourish@1.1.2(@babel/core@7.25.9)(@types/react@18.2.79)(react@18.2.0)':
-    dependencies:
-      '@atlaskit/motion': 1.9.2(@babel/core@7.25.9)(@types/react@18.2.79)(react@18.2.0)
-      '@atlaskit/tokens': 2.0.1(@types/react@18.2.79)(react@18.2.0)
-      '@babel/runtime': 7.25.9
-      react: 18.2.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/react'
-      - supports-color
-
   '@atlaskit/pragmatic-drag-and-drop-hitbox@1.0.3':
     dependencies:
       '@atlaskit/pragmatic-drag-and-drop': 1.4.0
       '@babel/runtime': 7.25.9
-
-  '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator@1.1.3(@babel/core@7.25.9)(@types/react@18.2.79)(react@18.2.0)':
-    dependencies:
-      '@atlaskit/pragmatic-drag-and-drop': 1.4.0
-      '@atlaskit/pragmatic-drag-and-drop-hitbox': 1.0.3
-      '@atlaskit/tokens': 2.0.1(@types/react@18.2.79)(react@18.2.0)
-      '@babel/runtime': 7.24.5
-      '@emotion/react': 11.10.4(@babel/core@7.25.9)(@types/react@18.2.79)(react@18.2.0)
-      react: 18.2.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/react'
-      - supports-color
 
   '@atlaskit/pragmatic-drag-and-drop@1.4.0':
     dependencies:
       '@babel/runtime': 7.25.9
       bind-event-listener: 3.0.0
       raf-schd: 4.0.3
-
-  '@atlaskit/tokens@2.0.1(@types/react@18.2.79)(react@18.2.0)':
-    dependencies:
-      '@atlaskit/ds-lib': 2.7.0(@types/react@18.2.79)(react@18.2.0)
-      '@atlaskit/platform-feature-flags': 0.3.0
-      '@babel/runtime': 7.25.9
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.25.9
-      bind-event-listener: 3.0.0
-      react: 18.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
 
   '@automerge/automerge-repo-network-broadcastchannel@1.1.12(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.5.5)(typescript@5.6.2)':
     dependencies:
@@ -35250,19 +34668,9 @@ snapshots:
       '@babel/core': 7.25.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.21.3)':
-    dependencies:
-      '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.25.7)':
     dependencies:
       '@babel/core': 7.25.7
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.25.9)':
-    dependencies:
-      '@babel/core': 7.25.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.21.3)':
@@ -37422,34 +36830,6 @@ snapshots:
     dependencies:
       '@dxos/node-std': 0.4.9
 
-  '@dxos/esbuild-server@2.29.0(@types/react@18.2.79)':
-    dependencies:
-      '@babel/core': 7.21.3
-      '@emotion/react': 11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0)
-      '@mdx-js/esbuild': 2.1.5(esbuild@0.14.54)
-      '@mdx-js/mdx': 2.1.5
-      '@mdx-js/react': 2.1.5(react@18.2.0)
-      '@rushstack/debug-certificate-manager': 1.1.83
-      '@rushstack/node-core-library': 3.50.2
-      chalk: 4.1.2
-      esbuild: 0.14.54
-      glob: 7.2.3
-      lodash.defaultsdeep: 4.6.1
-      ncp: 2.0.0
-      pkg-up: 3.1.0
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-is: 18.2.0
-      react-router-dom: 6.4.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      react-syntax-highlighter: 15.5.0(react@18.2.0)
-      rehype-highlight: 5.0.2
-      styled-components: 5.3.6(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)
-      theme-ui: 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(@mdx-js/react@2.1.5(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      yargs: 17.7.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-
   '@dxos/invariant@0.4.9':
     dependencies:
       '@dxos/node-std': 0.4.9
@@ -37526,123 +36906,17 @@ snapshots:
       emoji-mart: 5.5.2
       react: 18.2.0
 
-  '@emotion/babel-plugin@11.10.2(@babel/core@7.21.3)':
-    dependencies:
-      '@babel/core': 7.21.3
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
-      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.21.3)
-      '@babel/runtime': 7.25.9
-      '@emotion/hash': 0.9.0
-      '@emotion/memoize': 0.8.0
-      '@emotion/serialize': 1.1.0
-      babel-plugin-macros: 3.1.0
-      convert-source-map: 1.9.0
-      escape-string-regexp: 4.0.0
-      find-root: 1.1.0
-      source-map: 0.5.7
-      stylis: 4.0.13
-    transitivePeerDependencies:
-      - supports-color
-
-  '@emotion/babel-plugin@11.10.2(@babel/core@7.25.9)':
-    dependencies:
-      '@babel/core': 7.25.9
-      '@babel/helper-module-imports': 7.25.7(supports-color@5.5.0)
-      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.25.9)
-      '@babel/runtime': 7.25.9
-      '@emotion/hash': 0.9.0
-      '@emotion/memoize': 0.8.0
-      '@emotion/serialize': 1.1.0
-      babel-plugin-macros: 3.1.0
-      convert-source-map: 1.9.0
-      escape-string-regexp: 4.0.0
-      find-root: 1.1.0
-      source-map: 0.5.7
-      stylis: 4.0.13
-    transitivePeerDependencies:
-      - supports-color
-
-  '@emotion/cache@11.10.3':
-    dependencies:
-      '@emotion/memoize': 0.8.0
-      '@emotion/sheet': 1.2.0
-      '@emotion/utils': 1.2.0
-      '@emotion/weak-memoize': 0.3.0
-      stylis: 4.0.13
-
   '@emotion/hash@0.9.0': {}
-
-  '@emotion/is-prop-valid@0.8.8':
-    dependencies:
-      '@emotion/memoize': 0.7.4
 
   '@emotion/is-prop-valid@1.2.0':
     dependencies:
       '@emotion/memoize': 0.8.0
 
-  '@emotion/memoize@0.7.4': {}
-
-  '@emotion/memoize@0.7.5': {}
-
   '@emotion/memoize@0.8.0': {}
-
-  '@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0)':
-    dependencies:
-      '@babel/runtime': 7.25.9
-      '@emotion/babel-plugin': 11.10.2(@babel/core@7.21.3)
-      '@emotion/cache': 11.10.3
-      '@emotion/serialize': 1.1.0
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
-      '@emotion/utils': 1.2.0
-      '@emotion/weak-memoize': 0.3.0
-      hoist-non-react-statics: 3.3.2
-      react: 18.2.0
-    optionalDependencies:
-      '@babel/core': 7.21.3
-      '@types/react': 18.2.79
-    transitivePeerDependencies:
-      - supports-color
-
-  '@emotion/react@11.10.4(@babel/core@7.25.9)(@types/react@18.2.79)(react@18.2.0)':
-    dependencies:
-      '@babel/runtime': 7.25.9
-      '@emotion/babel-plugin': 11.10.2(@babel/core@7.25.9)
-      '@emotion/cache': 11.10.3
-      '@emotion/serialize': 1.1.0
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
-      '@emotion/utils': 1.2.0
-      '@emotion/weak-memoize': 0.3.0
-      hoist-non-react-statics: 3.3.2
-      react: 18.2.0
-    optionalDependencies:
-      '@babel/core': 7.25.9
-      '@types/react': 18.2.79
-    transitivePeerDependencies:
-      - supports-color
-
-  '@emotion/serialize@1.1.0':
-    dependencies:
-      '@emotion/hash': 0.9.0
-      '@emotion/memoize': 0.8.0
-      '@emotion/unitless': 0.8.0
-      '@emotion/utils': 1.2.0
-      csstype: 3.1.3
-
-  '@emotion/sheet@1.2.0': {}
 
   '@emotion/stylis@0.8.5': {}
 
   '@emotion/unitless@0.7.5': {}
-
-  '@emotion/unitless@0.8.0': {}
-
-  '@emotion/use-insertion-effect-with-fallbacks@1.0.1(react@18.2.0)':
-    dependencies:
-      react: 18.2.0
-
-  '@emotion/utils@1.2.0': {}
-
-  '@emotion/weak-memoize@0.3.0': {}
 
   '@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.17.19)':
     dependencies:
@@ -37841,9 +37115,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ia32@0.23.1':
-    optional: true
-
-  '@esbuild/linux-loong64@0.14.54':
     optional: true
 
   '@esbuild/linux-loong64@0.17.19':
@@ -39022,37 +38293,6 @@ snapshots:
       '@types/markdown-it': 13.0.7
     optionalDependencies:
       markdown-it: 13.0.2
-
-  '@mdx-js/esbuild@2.1.5(esbuild@0.14.54)':
-    dependencies:
-      '@mdx-js/mdx': 2.1.5
-      esbuild: 0.14.54
-      node-fetch: 3.3.2
-      vfile: 5.3.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@mdx-js/mdx@2.1.5':
-    dependencies:
-      '@types/estree-jsx': 1.0.0
-      '@types/mdx': 2.0.2
-      estree-util-build-jsx: 2.2.0
-      estree-util-is-identifier-name: 2.0.1
-      estree-util-to-js: 1.1.0
-      estree-walker: 3.0.3
-      hast-util-to-estree: 2.1.0
-      markdown-extensions: 1.1.1
-      periscopic: 3.0.4
-      remark-mdx: 2.1.5
-      remark-parse: 10.0.1
-      remark-rehype: 10.1.0
-      unified: 10.1.2
-      unist-util-position-from-estree: 1.1.1
-      unist-util-stringify-position: 3.0.2
-      unist-util-visit: 4.1.1
-      vfile: 5.3.6
-    transitivePeerDependencies:
-      - supports-color
 
   '@mdx-js/react@2.1.5(react@18.2.0)':
     dependencies:
@@ -42769,12 +42009,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.9.6':
     optional: true
 
-  '@rushstack/debug-certificate-manager@1.1.83':
-    dependencies:
-      '@rushstack/node-core-library': 3.53.2
-      node-forge: 1.3.1
-      sudo: 1.0.3
-
   '@rushstack/eslint-patch@1.4.0': {}
 
   '@rushstack/eslint-plugin-packlets@0.7.0(eslint@8.57.0)(typescript@5.6.2)':
@@ -42785,29 +42019,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  '@rushstack/node-core-library@3.50.2':
-    dependencies:
-      '@types/node': 22.5.5
-      colors: 1.2.5
-      fs-extra: 7.0.1
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.17.0
-      semver: 7.3.8
-      timsort: 0.3.0
-      z-schema: 5.0.4
-
-  '@rushstack/node-core-library@3.53.2':
-    dependencies:
-      '@types/node': 22.5.5
-      colors: 1.2.5
-      fs-extra: 7.0.1
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.17.0
-      semver: 7.3.8
-      z-schema: 5.0.4
 
   '@rushstack/tree-pattern@0.2.4': {}
 
@@ -43828,63 +43039,6 @@ snapshots:
       tiny-invariant: 1.3.3
       ts-dedent: 2.2.0
 
-  '@styled-system/background@5.1.2':
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  '@styled-system/border@5.1.5':
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  '@styled-system/color@5.1.2':
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  '@styled-system/core@5.1.2':
-    dependencies:
-      object-assign: 4.1.1
-
-  '@styled-system/css@5.1.5': {}
-
-  '@styled-system/flexbox@5.1.2':
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  '@styled-system/grid@5.1.2':
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  '@styled-system/layout@5.1.2':
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  '@styled-system/position@5.1.2':
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  '@styled-system/shadow@5.1.2':
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  '@styled-system/should-forward-prop@5.1.5':
-    dependencies:
-      '@emotion/is-prop-valid': 0.8.8
-      '@emotion/memoize': 0.7.5
-      styled-system: 5.1.5
-
-  '@styled-system/space@5.1.2':
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  '@styled-system/typography@5.1.2':
-    dependencies:
-      '@styled-system/core': 5.1.2
-
-  '@styled-system/variant@5.1.5':
-    dependencies:
-      '@styled-system/core': 5.1.2
-      '@styled-system/css': 5.1.5
-
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
       ejs: 3.1.10
@@ -44242,62 +43396,6 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.0
 
-  '@theme-ui/color-modes@0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@emotion/react': 11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0)
-      '@theme-ui/core': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
-      '@theme-ui/css': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))
-      deepmerge: 4.3.1
-      react: 18.2.0
-
-  '@theme-ui/components@0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@emotion/react': 11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0)
-      '@styled-system/color': 5.1.2
-      '@styled-system/should-forward-prop': 5.1.5
-      '@styled-system/space': 5.1.2
-      '@theme-ui/css': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))
-      '@types/styled-system': 5.1.15
-      react: 18.2.0
-
-  '@theme-ui/core@0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@emotion/react': 11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0)
-      '@theme-ui/css': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))
-      '@theme-ui/parse-props': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
-      deepmerge: 4.3.1
-      react: 18.2.0
-
-  '@theme-ui/css@0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))':
-    dependencies:
-      '@emotion/react': 11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0)
-      csstype: 3.1.3
-
-  '@theme-ui/mdx@0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(@mdx-js/react@2.1.5(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@emotion/react': 11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0)
-      '@mdx-js/react': 2.1.5(react@18.2.0)
-      '@theme-ui/core': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
-      '@theme-ui/css': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))
-      react: 18.2.0
-
-  '@theme-ui/parse-props@0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@emotion/react': 11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0)
-      '@theme-ui/css': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))
-      react: 18.2.0
-
-  '@theme-ui/theme-provider@0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(@mdx-js/react@2.1.5(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@emotion/react': 11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0)
-      '@theme-ui/color-modes': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
-      '@theme-ui/core': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
-      '@theme-ui/css': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))
-      '@theme-ui/mdx': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(@mdx-js/react@2.1.5(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-    transitivePeerDependencies:
-      - '@mdx-js/react'
-
   '@tldraw/assets@3.0.0':
     dependencies:
       '@tldraw/utils': 3.0.0
@@ -44398,10 +43496,6 @@ snapshots:
   '@types/accepts@1.3.7':
     dependencies:
       '@types/node': 22.5.5
-
-  '@types/acorn@4.0.6':
-    dependencies:
-      '@types/estree': 1.0.6
 
   '@types/argparse@2.0.10': {}
 
@@ -45199,10 +44293,6 @@ snapshots:
   '@types/statuses@2.0.5': {}
 
   '@types/string-hash@1.1.1': {}
-
-  '@types/styled-system@5.1.15':
-    dependencies:
-      csstype: 3.1.3
 
   '@types/stylus@0.48.38':
     dependencies:
@@ -46596,8 +45686,6 @@ snapshots:
 
   astral-regex@2.0.0: {}
 
-  astring@1.8.3: {}
-
   async-array-reduce@0.2.1: {}
 
   async-each@1.0.3: {}
@@ -46721,12 +45809,6 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.25.9
       cosmiconfig: 6.0.0
-      resolve: 1.22.8
-
-  babel-plugin-macros@3.1.0:
-    dependencies:
-      '@babel/runtime': 7.25.9
-      cosmiconfig: 7.1.0
       resolve: 1.22.8
 
   babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.21.3):
@@ -47803,8 +46885,6 @@ snapshots:
   colorjs.io@0.5.2: {}
 
   colors@0.6.2: {}
-
-  colors@1.2.5: {}
 
   colorspace@1.1.4:
     dependencies:
@@ -49378,54 +48458,6 @@ snapshots:
     dependencies:
       es6-promise: 4.2.8
 
-  esbuild-android-64@0.14.54:
-    optional: true
-
-  esbuild-android-arm64@0.14.54:
-    optional: true
-
-  esbuild-darwin-64@0.14.54:
-    optional: true
-
-  esbuild-darwin-arm64@0.14.54:
-    optional: true
-
-  esbuild-freebsd-64@0.14.54:
-    optional: true
-
-  esbuild-freebsd-arm64@0.14.54:
-    optional: true
-
-  esbuild-linux-32@0.14.54:
-    optional: true
-
-  esbuild-linux-64@0.14.54:
-    optional: true
-
-  esbuild-linux-arm64@0.14.54:
-    optional: true
-
-  esbuild-linux-arm@0.14.54:
-    optional: true
-
-  esbuild-linux-mips64le@0.14.54:
-    optional: true
-
-  esbuild-linux-ppc64le@0.14.54:
-    optional: true
-
-  esbuild-linux-riscv64@0.14.54:
-    optional: true
-
-  esbuild-linux-s390x@0.14.54:
-    optional: true
-
-  esbuild-netbsd-64@0.14.54:
-    optional: true
-
-  esbuild-openbsd-64@0.14.54:
-    optional: true
-
   esbuild-plugin-inline-image@0.0.9: {}
 
   esbuild-plugin-raw@0.1.8(esbuild@0.23.1):
@@ -49455,43 +48487,7 @@ snapshots:
       postcss: 8.4.47
       postcss-modules: 4.3.1(postcss@8.4.47)
 
-  esbuild-sunos-64@0.14.54:
-    optional: true
-
   esbuild-wasm@0.16.17: {}
-
-  esbuild-windows-32@0.14.54:
-    optional: true
-
-  esbuild-windows-64@0.14.54:
-    optional: true
-
-  esbuild-windows-arm64@0.14.54:
-    optional: true
-
-  esbuild@0.14.54:
-    optionalDependencies:
-      '@esbuild/linux-loong64': 0.14.54
-      esbuild-android-64: 0.14.54
-      esbuild-android-arm64: 0.14.54
-      esbuild-darwin-64: 0.14.54
-      esbuild-darwin-arm64: 0.14.54
-      esbuild-freebsd-64: 0.14.54
-      esbuild-freebsd-arm64: 0.14.54
-      esbuild-linux-32: 0.14.54
-      esbuild-linux-64: 0.14.54
-      esbuild-linux-arm: 0.14.54
-      esbuild-linux-arm64: 0.14.54
-      esbuild-linux-mips64le: 0.14.54
-      esbuild-linux-ppc64le: 0.14.54
-      esbuild-linux-riscv64: 0.14.54
-      esbuild-linux-s390x: 0.14.54
-      esbuild-netbsd-64: 0.14.54
-      esbuild-openbsd-64: 0.14.54
-      esbuild-sunos-64: 0.14.54
-      esbuild-windows-32: 0.14.54
-      esbuild-windows-64: 0.14.54
-      esbuild-windows-arm64: 0.14.54
 
   esbuild@0.17.19:
     optionalDependencies:
@@ -49918,29 +48914,6 @@ snapshots:
   estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
-
-  estree-util-attach-comments@2.1.0:
-    dependencies:
-      '@types/estree': 1.0.6
-
-  estree-util-build-jsx@2.2.0:
-    dependencies:
-      '@types/estree-jsx': 1.0.0
-      estree-util-is-identifier-name: 2.0.1
-      estree-walker: 3.0.3
-
-  estree-util-is-identifier-name@2.0.1: {}
-
-  estree-util-to-js@1.1.0:
-    dependencies:
-      '@types/estree-jsx': 1.0.0
-      astring: 1.8.3
-      source-map: 0.7.4
-
-  estree-util-visit@1.2.0:
-    dependencies:
-      '@types/estree-jsx': 1.0.0
-      '@types/unist': 2.0.6
 
   estree-walker@0.6.1: {}
 
@@ -50374,8 +49347,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-root@1.1.0: {}
-
   find-up@1.1.2:
     dependencies:
       path-exists: 2.1.0
@@ -50548,12 +49519,6 @@ snapshots:
       graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
-
-  fs-extra@7.0.1:
-    dependencies:
-      graceful-fs: 4.2.10
-      jsonfile: 4.0.0
-      universalify: 0.1.2
 
   fs-extra@8.1.0:
     dependencies:
@@ -51244,26 +50209,6 @@ snapshots:
       space-separated-tokens: 1.1.5
       zwitch: 1.0.5
 
-  hast-util-to-estree@2.1.0:
-    dependencies:
-      '@types/estree': 1.0.6
-      '@types/estree-jsx': 1.0.0
-      '@types/hast': 2.3.4
-      '@types/unist': 2.0.6
-      comma-separated-tokens: 2.0.2
-      estree-util-attach-comments: 2.1.0
-      estree-util-is-identifier-name: 2.0.1
-      hast-util-whitespace: 2.0.0
-      mdast-util-mdx-expression: 1.3.1
-      mdast-util-mdxjs-esm: 1.3.0
-      property-information: 6.1.1
-      space-separated-tokens: 2.0.1
-      style-to-object: 0.3.0
-      unist-util-position: 4.0.3
-      zwitch: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   hast-util-to-html@8.0.3:
     dependencies:
       '@types/hast': 2.3.4
@@ -51742,8 +50687,6 @@ snapshots:
       cjs-module-lexer: 1.3.1
       module-details-from-path: 1.0.3
 
-  import-lazy@4.0.0: {}
-
   import-meta-resolve@4.0.0: {}
 
   imurmurhash@0.1.4: {}
@@ -51853,8 +50796,6 @@ snapshots:
       - utf-8-validate
 
   inline-style-parser@0.1.1: {}
-
-  inpath@1.0.2: {}
 
   inquirer@12.0.0(@types/node@22.5.5):
     dependencies:
@@ -52140,10 +51081,6 @@ snapshots:
   is-promise@2.2.2: {}
 
   is-redirect@1.0.0: {}
-
-  is-reference@3.0.0:
-    dependencies:
-      '@types/estree': 1.0.6
 
   is-regex@1.1.4:
     dependencies:
@@ -52521,8 +51458,6 @@ snapshots:
       supports-color: 8.1.1
 
   jiti@1.21.0: {}
-
-  jju@1.4.0: {}
 
   joi@17.12.3:
     dependencies:
@@ -53472,8 +52407,6 @@ snapshots:
 
   map-or-similar@1.5.0: {}
 
-  markdown-extensions@1.1.1: {}
-
   markdown-it-anchor@8.6.7(@types/markdown-it@13.0.7)(markdown-it@13.0.2):
     dependencies:
       '@types/markdown-it': 13.0.7
@@ -53691,37 +52624,6 @@ snapshots:
       - supports-color
 
   mdast-util-mdx-expression@1.3.1:
-    dependencies:
-      '@types/estree-jsx': 1.0.0
-      '@types/hast': 2.3.4
-      '@types/mdast': 3.0.10
-      mdast-util-from-markdown: 1.3.1
-      mdast-util-to-markdown: 1.3.0
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-mdx-jsx@2.1.0:
-    dependencies:
-      '@types/estree-jsx': 1.0.0
-      '@types/hast': 2.3.4
-      '@types/mdast': 3.0.10
-      ccount: 2.0.1
-      mdast-util-to-markdown: 1.3.0
-      parse-entities: 4.0.0
-      stringify-entities: 4.0.3
-      unist-util-remove-position: 4.0.1
-      unist-util-stringify-position: 3.0.2
-      vfile-message: 3.1.2
-
-  mdast-util-mdx@2.0.0:
-    dependencies:
-      mdast-util-mdx-expression: 1.3.1
-      mdast-util-mdx-jsx: 2.1.0
-      mdast-util-mdxjs-esm: 1.3.0
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-mdxjs-esm@1.3.0:
     dependencies:
       '@types/estree-jsx': 1.0.0
       '@types/hast': 2.3.4
@@ -53988,54 +52890,6 @@ snapshots:
       micromark-util-combine-extensions: 1.0.0
       micromark-util-types: 1.0.2
 
-  micromark-extension-mdx-expression@1.0.3:
-    dependencies:
-      micromark-factory-mdx-expression: 1.0.6
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-events-to-acorn: 1.2.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      uvu: 0.5.6
-
-  micromark-extension-mdx-jsx@1.0.3:
-    dependencies:
-      '@types/acorn': 4.0.6
-      estree-util-is-identifier-name: 2.0.1
-      micromark-factory-mdx-expression: 1.0.6
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      uvu: 0.5.6
-      vfile-message: 3.1.2
-
-  micromark-extension-mdx-md@1.0.0:
-    dependencies:
-      micromark-util-types: 1.0.2
-
-  micromark-extension-mdxjs-esm@1.0.3:
-    dependencies:
-      micromark-core-commonmark: 1.0.6
-      micromark-util-character: 1.1.0
-      micromark-util-events-to-acorn: 1.2.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      unist-util-position-from-estree: 1.1.1
-      uvu: 0.5.6
-      vfile-message: 3.1.2
-
-  micromark-extension-mdxjs@1.0.0:
-    dependencies:
-      acorn: 8.11.3
-      acorn-jsx: 5.3.2(acorn@8.11.3)
-      micromark-extension-mdx-expression: 1.0.3
-      micromark-extension-mdx-jsx: 1.0.3
-      micromark-extension-mdx-md: 1.0.0
-      micromark-extension-mdxjs-esm: 1.0.3
-      micromark-util-combine-extensions: 1.0.0
-      micromark-util-types: 1.0.2
-
   micromark-factory-destination@1.0.0:
     dependencies:
       micromark-util-character: 1.1.0
@@ -54061,17 +52915,6 @@ snapshots:
       micromark-util-character: 2.1.0
       micromark-util-symbol: 2.0.0
       micromark-util-types: 2.0.0
-
-  micromark-factory-mdx-expression@1.0.6:
-    dependencies:
-      micromark-factory-space: 1.0.0
-      micromark-util-character: 1.1.0
-      micromark-util-events-to-acorn: 1.2.0
-      micromark-util-symbol: 1.0.1
-      micromark-util-types: 1.0.2
-      unist-util-position-from-estree: 1.1.1
-      uvu: 0.5.6
-      vfile-message: 3.1.2
 
   micromark-factory-space@1.0.0:
     dependencies:
@@ -54177,16 +53020,6 @@ snapshots:
   micromark-util-encode@1.0.1: {}
 
   micromark-util-encode@2.0.0: {}
-
-  micromark-util-events-to-acorn@1.2.0:
-    dependencies:
-      '@types/acorn': 4.0.6
-      '@types/estree': 1.0.6
-      estree-util-visit: 1.2.0
-      micromark-util-types: 1.0.2
-      uvu: 0.5.6
-      vfile-location: 4.0.1
-      vfile-message: 3.1.2
 
   micromark-util-html-tag-name@1.1.0: {}
 
@@ -54586,8 +53419,6 @@ snapshots:
 
   mustache@4.2.0: {}
 
-  mute-stream@0.0.8: {}
-
   mute-stream@1.0.0: {}
 
   mute-stream@2.0.0: {}
@@ -54655,8 +53486,6 @@ snapshots:
   natural-compare@1.4.0: {}
 
   natural-orderby@3.0.2: {}
-
-  ncp@2.0.0: {}
 
   needle@3.3.1:
     dependencies:
@@ -55555,11 +54384,6 @@ snapshots:
 
   performance-now@2.1.0: {}
 
-  periscopic@3.0.4:
-    dependencies:
-      estree-walker: 3.0.3
-      is-reference: 3.0.0
-
   pg-int8@1.0.1: {}
 
   pg-protocol@1.6.1: {}
@@ -55585,8 +54409,6 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
-
-  pidof@1.0.2: {}
 
   pify@2.3.0: {}
 
@@ -56709,13 +55531,6 @@ snapshots:
       react-shallow-renderer: 16.15.0(react@18.2.0)
       scheduler: 0.23.0
 
-  react-uid@2.3.3(@types/react@18.2.79)(react@18.2.0):
-    dependencies:
-      react: 18.2.0
-      tslib: 2.8.0
-    optionalDependencies:
-      '@types/react': 18.2.79
-
   react-vis@1.11.12(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       d3-array: 1.2.4
@@ -56774,10 +55589,6 @@ snapshots:
     dependencies:
       js-yaml: 4.1.0
       strip-bom: 4.0.0
-
-  read@1.0.7:
-    dependencies:
-      mute-stream: 0.0.8
 
   readable-stream@1.1.14:
     dependencies:
@@ -56960,14 +55771,6 @@ snapshots:
       space-separated-tokens: 2.0.2
       unist-util-visit: 5.0.0
 
-  rehype-highlight@5.0.2:
-    dependencies:
-      '@types/hast': 2.3.4
-      hast-util-to-text: 3.1.1
-      lowlight: 2.7.0
-      unified: 10.1.2
-      unist-util-visit: 4.1.1
-
   rehype-highlight@6.0.0:
     dependencies:
       '@types/hast': 2.3.4
@@ -57032,13 +55835,6 @@ snapshots:
       '@types/mdast': 3.0.10
       remark-message-control: 7.1.1
       unified: 10.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  remark-mdx@2.1.5:
-    dependencies:
-      mdast-util-mdx: 2.0.0
-      micromark-extension-mdxjs: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -57185,10 +55981,6 @@ snapshots:
       protocol-buffers-schema: 3.6.0
 
   resolve.exports@2.0.2: {}
-
-  resolve@1.17.0:
-    dependencies:
-      path-parse: 1.0.7
 
   resolve@1.22.2:
     dependencies:
@@ -57547,10 +56339,6 @@ snapshots:
   semver@7.0.0: {}
 
   semver@7.3.7:
-    dependencies:
-      lru-cache: 6.0.0
-
-  semver@7.3.8:
     dependencies:
       lru-cache: 6.0.0
 
@@ -58010,8 +56798,6 @@ snapshots:
       buffer-from: 1.1.2
       source-map: 0.6.1
 
-  source-map@0.5.7: {}
-
   source-map@0.6.1: {}
 
   source-map@0.7.4: {}
@@ -58366,10 +57152,6 @@ snapshots:
 
   style-mod@4.1.0: {}
 
-  style-to-object@0.3.0:
-    dependencies:
-      inline-style-parser: 0.1.1
-
   style-to-object@0.4.4:
     dependencies:
       inline-style-parser: 0.1.1
@@ -58390,29 +57172,11 @@ snapshots:
       shallowequal: 1.1.0
       supports-color: 5.5.0
 
-  styled-system@5.1.5:
-    dependencies:
-      '@styled-system/background': 5.1.2
-      '@styled-system/border': 5.1.5
-      '@styled-system/color': 5.1.2
-      '@styled-system/core': 5.1.2
-      '@styled-system/flexbox': 5.1.2
-      '@styled-system/grid': 5.1.2
-      '@styled-system/layout': 5.1.2
-      '@styled-system/position': 5.1.2
-      '@styled-system/shadow': 5.1.2
-      '@styled-system/space': 5.1.2
-      '@styled-system/typography': 5.1.2
-      '@styled-system/variant': 5.1.5
-      object-assign: 4.1.1
-
   stylehacks@6.1.1(postcss@8.4.47):
     dependencies:
       browserslist: 4.24.0
       postcss: 8.4.47
       postcss-selector-parser: 6.1.2
-
-  stylis@4.0.13: {}
 
   stylis@4.3.0: {}
 
@@ -58444,12 +57208,6 @@ snapshots:
       mz: 2.7.0
       pirates: 4.0.5
       ts-interface-checker: 0.1.13
-
-  sudo@1.0.3:
-    dependencies:
-      inpath: 1.0.2
-      pidof: 1.0.2
-      read: 1.0.7
 
   supports-color@5.5.0:
     dependencies:
@@ -58748,20 +57506,6 @@ snapshots:
       xpath: 0.0.23
       yauzl: 2.7.0
 
-  theme-ui@0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(@mdx-js/react@2.1.5(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
-    dependencies:
-      '@theme-ui/color-modes': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
-      '@theme-ui/components': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
-      '@theme-ui/core': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
-      '@theme-ui/css': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))
-      '@theme-ui/mdx': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(@mdx-js/react@2.1.5(react@18.2.0))(react@18.2.0)
-      '@theme-ui/theme-provider': 0.14.7(@emotion/react@11.10.4(@babel/core@7.21.3)(@types/react@18.2.79)(react@18.2.0))(@mdx-js/react@2.1.5(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - '@emotion/react'
-      - '@mdx-js/react'
-
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -58804,8 +57548,6 @@ snapshots:
   timed-out@3.1.3: {}
 
   timeout-refresh@1.0.3: {}
-
-  timsort@0.3.0: {}
 
   tiny-each-async@2.0.3: {}
 
@@ -59376,18 +58118,9 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.0
 
-  unist-util-position-from-estree@1.1.1:
-    dependencies:
-      '@types/unist': 2.0.6
-
   unist-util-position@4.0.3:
     dependencies:
       '@types/unist': 2.0.6
-
-  unist-util-remove-position@4.0.1:
-    dependencies:
-      '@types/unist': 2.0.6
-      unist-util-visit: 4.1.1
 
   unist-util-stringify-position@2.0.3:
     dependencies:
@@ -59666,8 +58399,6 @@ snapshots:
       spdx-expression-parse: 3.0.1
 
   validate-npm-package-name@5.0.1: {}
-
-  validator@13.7.0: {}
 
   varint@4.0.1: {}
 
@@ -61181,14 +59912,6 @@ snapshots:
       cookie: 0.5.0
       mustache: 4.2.0
       stacktracey: 2.1.8
-
-  z-schema@5.0.4:
-    dependencies:
-      lodash.get: 4.4.2
-      lodash.isequal: 4.5.0
-      validator: 13.7.0
-    optionalDependencies:
-      commander: 2.20.3
 
   zen-observable@0.10.0: {}
 

--- a/toolbox.json
+++ b/toolbox.json
@@ -36,8 +36,7 @@
         "packages/sdk/app-graph",
         "packages/sdk/app-framework",
         "packages/sdk/migrations",
-        "packages/sdk/shell",
-        "packages/ui/*"
+        "packages/sdk/shell"
       ]
     },
     "noProjectReferences": true

--- a/tools/ridoculous/package.json
+++ b/tools/ridoculous/package.json
@@ -42,7 +42,6 @@
   "devDependencies": {
     "@babel/core": "^7.18.13",
     "@dxos/esbuild-plugins": "workspace:*",
-    "@dxos/esbuild-server": "~2.29.0",
     "@dxos/protobuf-compiler": "workspace:*",
     "@types/diff": "^5.0.2",
     "@types/glob": "~7.1.3",

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -328,69 +328,6 @@
       ],
       "@dxos/shell/testing": [
         "packages/sdk/shell/src/testing/index.ts"
-      ],
-      "@dxos/brand": [
-        "packages/ui/brand/src/index.ts"
-      ],
-      "@dxos/react-ui": [
-        "packages/ui/react-ui/src/index.ts"
-      ],
-      "@dxos/react-ui-attention": [
-        "packages/ui/react-ui-attention/src/index.ts"
-      ],
-      "@dxos/react-ui-attention/testing": [
-        "packages/ui/react-ui-attention/src/testing/index.ts"
-      ],
-      "@dxos/react-ui-card": [
-        "packages/ui/react-ui-card/src/index.ts"
-      ],
-      "@dxos/react-ui-editor": [
-        "packages/ui/react-ui-editor/src/index.ts"
-      ],
-      "@dxos/react-ui-form": [
-        "packages/ui/react-ui-form/src/index.ts"
-      ],
-      "@dxos/react-ui-grid": [
-        "packages/ui/react-ui-grid/src/index.ts"
-      ],
-      "@dxos/react-ui-list": [
-        "packages/ui/react-ui-list/src/index.ts"
-      ],
-      "@dxos/react-ui-mosaic": [
-        "packages/ui/react-ui-mosaic/src/index.ts"
-      ],
-      "@dxos/react-ui-searchlist": [
-        "packages/ui/react-ui-searchlist/src/index.ts"
-      ],
-      "@dxos/react-ui-stack": [
-        "packages/ui/react-ui-stack/src/index.ts"
-      ],
-      "@dxos/react-ui-stack/testing": [
-        "packages/ui/react-ui-stack/src/testing/index.ts"
-      ],
-      "@dxos/react-ui-syntax-highlighter": [
-        "packages/ui/react-ui-syntax-highlighter/src/index.ts"
-      ],
-      "@dxos/react-ui-table/_deprecated": [
-        "packages/ui/react-ui-table/src/_deprecated/index.ts"
-      ],
-      "@dxos/react-ui-table": [
-        "packages/ui/react-ui-table/src/index.ts"
-      ],
-      "@dxos/react-ui-table/types": [
-        "packages/ui/react-ui-table/src/types/index.ts"
-      ],
-      "@dxos/react-ui-tabs": [
-        "packages/ui/react-ui-tabs/src/index.ts"
-      ],
-      "@dxos/react-ui-text-tooltip": [
-        "packages/ui/react-ui-text-tooltip/src/index.ts"
-      ],
-      "@dxos/react-ui-thread": [
-        "packages/ui/react-ui-thread/src/index.ts"
-      ],
-      "@dxos/react-ui-types": [
-        "packages/ui/react-ui-types/src/index.ts"
       ]
     }
   },


### PR DESCRIPTION
When ui packages were included in paths vite was optimizing react-ui in
some cases which lead to there being multiple theme contexts. This
likely points to some other issues with the dependency graph, but this
workaround makes everything work (with the caveat that ui packages need
to be rebuilt by watch to update in composer).

Also removes unused dependencies which were causing emotion to be pulled
into the app bundle.
