### PR TITLE
fix: reactive objects not being linked on assignment

### DIFF
--- a/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
@@ -623,11 +623,11 @@ describe('Reactive Object with ECHO database', () => {
       expect(isEchoObject(obj.field)).to.be.false;
     });
 
-    test('nested reactive object is not an echo object', async () => {
+    test('nested reactive object is an echo object', async () => {
       const { db } = await builder.createDatabase();
       const obj = db.add(create(Expando, { title: 'Object 1' }));
       obj.field = { ref: create(Expando, { title: 'Object 2' }) };
-      expect(isEchoObject(obj.field.ref)).to.be.false;
+      expect(isEchoObject(obj.field.ref)).to.be.true;
     });
 
     test('nested ref is an echo object', async () => {
@@ -640,19 +640,23 @@ describe('Reactive Object with ECHO database', () => {
     test('reassign an object field', async () => {
       const { db } = await builder.createDatabase();
 
+      const originalValue = { foo: 'bar', nested: { value: 42 } };
       const obj1 = db.add(create(Expando, { title: 'Object 1' }));
-      obj1.field = { foo: 'bar' };
+      obj1.field = originalValue;
+      expect(obj1.field).toEqual(originalValue);
+
       const obj2 = db.add(create(Expando, { title: 'Object 2' }));
       obj2.field = obj1.field;
       expect(obj1.field).toEqual(obj2.field);
 
       obj1.field.foo = obj1.field.foo + '_v2';
-      expect(obj1.field).not.toEqual(obj2.field);
+      obj1.field.nested.value += 1;
+      expect(obj1.field.foo).not.toEqual(obj2.field.foo);
+      expect(obj1.field.nested.value).not.toEqual(obj2.field.nested.value);
     });
   });
 
-  // TODO(burdon): Failing 11/30/24
-  test.skip('typed object is linked with the database on assignment to another db-linked object', async () => {
+  test('typed object is linked with the database on assignment to another db-linked object', async () => {
     const { db, graph } = await builder.createDatabase();
     graph.schemaRegistry.addSchema([TestSchemaType]);
 

--- a/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
@@ -654,6 +654,22 @@ describe('Reactive Object with ECHO database', () => {
       expect(obj1.field.foo).not.toEqual(obj2.field.foo);
       expect(obj1.field.nested.value).not.toEqual(obj2.field.nested.value);
     });
+
+    test('reassign a field with nested echo object', async () => {
+      const { db } = await builder.createDatabase();
+
+      const obj1 = db.add(create(Expando, { title: 'Object 1' }));
+      const obj2 = create(Expando, { title: 'Object 2' });
+      obj1.nested = { object: { ref: obj2 } };
+      expect(obj1.nested.object.ref).toEqual(obj2);
+
+      const obj3 = db.add(create(Expando, { title: 'Object 3' }));
+      obj3.nested = obj1.nested;
+      expect(obj1.nested.object.ref).toEqual(obj3.nested.object.ref);
+
+      obj1.nested.object.ref = create(Expando, { title: 'Object 4' });
+      expect(obj1.nested.object.ref).not.toEqual(obj3.nested.object.ref);
+    });
   });
 
   test('typed object is linked with the database on assignment to another db-linked object', async () => {

--- a/packages/core/echo/echo-db/src/echo-handler/echo-handler.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/echo-handler.ts
@@ -363,9 +363,9 @@ export class EchoReactiveHandler implements ReactiveHandler<ProxyTarget> {
   }
 
   arrayPush(target: ProxyTarget, path: KeyPath, ...items: any[]): number {
-    this._validateForArray(target, path, items, target.length);
+    const validatedItems = this._validateForArray(target, path, items, target.length);
 
-    const encodedItems = this._encodeForArray(target, items);
+    const encodedItems = this._encodeForArray(target, validatedItems);
     return target[symbolInternals].core.arrayPush([getNamespace(target), ...path], encodedItems);
   }
 
@@ -396,10 +396,10 @@ export class EchoReactiveHandler implements ReactiveHandler<ProxyTarget> {
   }
 
   arrayUnshift(target: ProxyTarget, path: KeyPath, ...items: any[]): number {
-    this._validateForArray(target, path, items, 0);
+    const validatedItems = this._validateForArray(target, path, items, 0);
 
     const fullPath = this._getPropertyMountPath(target, path);
-    const encodedItems = this._encodeForArray(target, items);
+    const encodedItems = this._encodeForArray(target, validatedItems);
 
     let newLength: number = -1;
     target[symbolInternals].core.change((doc) => {
@@ -413,10 +413,10 @@ export class EchoReactiveHandler implements ReactiveHandler<ProxyTarget> {
   }
 
   arraySplice(target: ProxyTarget, path: KeyPath, start: number, deleteCount?: number, ...items: any[]): any[] {
-    this._validateForArray(target, path, items, start);
+    const validatedItems = this._validateForArray(target, path, items, start);
 
     const fullPath = this._getPropertyMountPath(target, path);
-    const encodedItems = this._encodeForArray(target, items);
+    const encodedItems = this._encodeForArray(target, validatedItems);
 
     let deletedElements: any[] | undefined;
     target[symbolInternals].core.change((doc) => {
@@ -559,10 +559,9 @@ export class EchoReactiveHandler implements ReactiveHandler<ProxyTarget> {
   }
 
   private _validateForArray(target: ProxyTarget, path: KeyPath, items: any[], start: number) {
-    let index = start;
-    for (const item of items) {
-      this.validateValue(target, [...path, String(index++)], item);
-    }
+    return items.map((item, index) => {
+      return this.validateValue(target, [...path, String(start + index)], item);
+    });
   }
 
   // TODO(dmaretskyi): Change to not rely on object-core doing linking.

--- a/packages/core/echo/echo-db/src/echo-handler/echo-handler.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/echo-handler.ts
@@ -257,7 +257,7 @@ export class EchoReactiveHandler implements ReactiveHandler<ProxyTarget> {
     if (validatedValue === undefined) {
       target[symbolInternals].core.delete(fullPath);
     } else {
-      const withLinks = this._handleLinksAssignment(target, value);
+      const withLinks = this._handleLinksAssignment(target, validatedValue);
       target[symbolInternals].core.setDecoded(fullPath, withLinks);
     }
 

--- a/packages/core/echo/echo-db/src/proxy-db/mutable-schema.test.ts
+++ b/packages/core/echo/echo-db/src/proxy-db/mutable-schema.test.ts
@@ -23,6 +23,7 @@ import { EchoTestBuilder } from '../testing';
 
 class TestSchema extends TypedObject({ typename: 'example.com/type/Test', version: '0.1.0' })({
   schema: S.optional(ref(MutableSchema)),
+  schemaArray: S.optional(S.mutable(S.Array(ref(MutableSchema)))),
 }) {}
 
 describe('MutableSchema', () => {
@@ -66,7 +67,17 @@ describe('MutableSchema', () => {
 
     const schema = db.schemaRegistry.addSchema(GeneratedSchema);
     const instanceWithSchemaRef = db.add(create(TestSchema, { schema }));
-    expect(instanceWithSchemaRef.schema!.typename).to.eq('example.com/type/Test');
+    expect(instanceWithSchemaRef.schema!.typename).to.eq(GeneratedSchema.typename);
+  });
+
+  test('push MutableSchema to echo object schema array', async () => {
+    const { db } = await setupTest();
+    const instanceWithSchemaRef = db.add(create(TestSchema, { schemaArray: [] }));
+    class GeneratedSchema extends TypedObject({ typename: 'example.com/type/Test', version: '0.1.0' })({
+      field: S.String,
+    }) {}
+    instanceWithSchemaRef.schemaArray!.push(db.schemaRegistry.addSchema(GeneratedSchema));
+    expect(instanceWithSchemaRef.schemaArray![0].typename).to.eq(GeneratedSchema.typename);
   });
 
   test('can be used to create objects', async () => {


### PR DESCRIPTION
### Details

The previous fix for echo object field assignment broke automatic object linking when a reactive objects is assigned to echo object.
This PR fixes this and unskips the broken test.
Also fixes unused validation result on array value updates. 