### PR TITLE
fix: resolve scroll intents when applied

### DIFF
--- a/packages/plugins/plugin-markdown/src/hooks/useSelectCurrentThread.tsx
+++ b/packages/plugins/plugin-markdown/src/hooks/useSelectCurrentThread.tsx
@@ -35,6 +35,8 @@ export const useSelectCurrentThread = (editorView: EditorView | undefined, docum
               effects,
               selection: selection ? { anchor: range.from } : undefined,
             });
+
+            return { data: true };
           }
         }
       }

--- a/packages/plugins/plugin-sheet/src/integrations/thread-ranges.ts
+++ b/packages/plugins/plugin-sheet/src/integrations/thread-ranges.ts
@@ -43,6 +43,8 @@ export const useUpdateFocusedCellOnThreadSelection = (grid: DxGridElement | null
           // TODO(Zan): Everywhere we refer to the cursor in a thread context should change to `anchor`.
           const range = parseThreadAnchorAsCellRange(data.cursor);
           range && grid?.setFocus({ ...range.to, plane: 'grid' }, true);
+
+          return { data: true };
         }
       }
     },

--- a/packages/plugins/plugin-thread/src/components/ThreadComplementary.tsx
+++ b/packages/plugins/plugin-thread/src/components/ThreadComplementary.tsx
@@ -69,6 +69,9 @@ export const ThreadComplementary = ({
         if (current !== threadId) {
           current = threadId;
 
+          // TODO(wittjosiah): Should this be a thread-specific intent?
+          //  The layout doesn't know about threads and this working depends on other plugins conditionally handling it.
+          //  This may be overloading this intent or highjacking its intended purpose.
           void dispatch?.([
             {
               action: LayoutAction.SCROLL_INTO_VIEW,


### PR DESCRIPTION
These intent handlers were not returning anything so the intent system
thought the intent wasn't handled, this lead to the layout handling it
and focus on the thread input being lost when it shouldn't be.
