### PR TITLE
Fix sheet index handling.

### DIFF
--- a/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.tsx
+++ b/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.tsx
@@ -27,9 +27,11 @@ import {
   type EditorBlurHandler,
   type GridContentProps,
   type DxGridPosition,
+  type DxGridCellIndex,
+  parseCellIndex,
 } from '@dxos/react-ui-grid';
 
-import { colLabelCell, dxGridCellIndexToSheetCellAddress, rowLabelCell, useSheetModelDxGridProps } from './util';
+import { colLabelCell, rowLabelCell, useSheetModelDxGridProps } from './util';
 import { DEFAULT_COLUMNS, DEFAULT_ROWS, rangeToA1Notation, type CellRange } from '../../defs';
 import { rangeExtension, sheetExtension, type RangeController } from '../../extensions';
 import { useSelectThreadOnCellFocus, useUpdateFocusedCellOnThreadSelection } from '../../integrations';
@@ -113,7 +115,7 @@ export const GridSheet = () => {
   const handleBlur = useCallback<EditorBlurHandler>(
     (value) => {
       if (value !== undefined) {
-        model.setValue(dxGridCellIndexToSheetCellAddress(editing!.index), value);
+        model.setValue(parseCellIndex(editing!.index), value);
       }
     },
     [model, editing],
@@ -293,9 +295,8 @@ export const GridSheet = () => {
   );
 
   const getCellContent = useCallback(
-    (index: string) => {
-      const cell = dxGridCellIndexToSheetCellAddress(index);
-      return model.getCellText(cell);
+    (index: DxGridCellIndex) => {
+      return model.getCellText(parseCellIndex(index));
     },
     [model],
   );

--- a/packages/plugins/plugin-sheet/src/components/GridSheet/util.ts
+++ b/packages/plugins/plugin-sheet/src/components/GridSheet/util.ts
@@ -20,17 +20,9 @@ import {
 } from '@dxos/react-ui-grid';
 import { mx } from '@dxos/react-ui-theme';
 
-import { type CellAddress, inRange, cellClassNameForRange, rangeFromIndex } from '../../defs';
+import { inRange, cellClassNameForRange, rangeFromIndex } from '../../defs';
 import { parseThreadAnchorAsCellRange } from '../../integrations';
 import { type SheetModel } from '../../model';
-
-export const dxGridCellIndexToSheetCellAddress = (index: string): CellAddress => {
-  const [colStr, rowStr] = index.split(',');
-  return {
-    col: parseInt(colStr),
-    row: parseInt(rowStr),
-  };
-};
 
 const createDxGridColumns = (model: SheetModel): DxGridAxisMeta => {
   return model.sheet.columns.reduce(

--- a/packages/plugins/plugin-sheet/src/defs/types.ts
+++ b/packages/plugins/plugin-sheet/src/defs/types.ts
@@ -3,6 +3,7 @@
 //
 
 import { invariant } from '@dxos/invariant';
+import { type DxGridPlanePosition } from '@dxos/react-ui-grid';
 
 export const DEFAULT_ROWS = 50;
 export const DEFAULT_COLUMNS = 26;
@@ -10,7 +11,7 @@ export const DEFAULT_COLUMNS = 26;
 export const MAX_ROWS = 500;
 export const MAX_COLUMNS = 26 * 2;
 
-export type CellAddress = { col: number; row: number };
+export type CellAddress = DxGridPlanePosition;
 
 export type CellRange = { from: CellAddress; to?: CellAddress };
 export type CompleteCellRange = { from: CellAddress; to: CellAddress };

--- a/packages/ui/react-ui-grid/src/CellEditor/GridCellEditor.tsx
+++ b/packages/ui/react-ui-grid/src/CellEditor/GridCellEditor.tsx
@@ -5,10 +5,10 @@
 import React, { useCallback } from 'react';
 
 import { CellEditor, type CellEditorProps } from './CellEditor';
-import { type GridScopedProps, useGridContext } from '../Grid';
+import { type GridScopedProps, useGridContext, type DxGridCellIndex } from '../Grid';
 
 export type GridCellEditorProps = GridScopedProps<
-  Pick<CellEditorProps, 'extension' | 'onBlur'> & { getCellContent: (index: string) => string | undefined }
+  Pick<CellEditorProps, 'extension' | 'onBlur'> & { getCellContent: (index: DxGridCellIndex) => string | undefined }
 >;
 
 export const GridCellEditor = ({ extension, getCellContent, onBlur, __gridScope }: GridCellEditorProps) => {


### PR DESCRIPTION
This PR:
- resolves #8380.

<img width="996" alt="Screenshot 2024-12-08 at 12 37 28" src="https://github.com/user-attachments/assets/01dcbf10-35bf-491c-aefc-446e3316be07">

#### Postmortem

`dx-grid` extended `DxEditRequest` with the requested cell’s `plane`, which was technical debt that needed clearing at the time. It provides a narrower type for cell indexes already and additionally added `parseCellIndex` so consumers did not need to split by `','`, but sheet was still doing so.