### PR TITLE
fix: use deviceKey for automerge peer id is identity is set

### DIFF
--- a/packages/core/echo/echo-pipeline/src/db-host/echo-host.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/echo-host.ts
@@ -33,6 +33,7 @@ import {
   type EchoReplicator,
   type CollectionSyncState,
   type EchoDataStats,
+  type PeerIdProvider,
 } from '../automerge';
 
 const INDEXER_CONFIG: IndexConfig = {
@@ -42,6 +43,7 @@ const INDEXER_CONFIG: IndexConfig = {
 
 export type EchoHostParams = {
   kv: LevelDB;
+  peerIdProvider?: PeerIdProvider;
 };
 
 /**
@@ -59,7 +61,7 @@ export class EchoHost extends Resource {
   private readonly _spaceStateManager = new SpaceStateManager();
   private readonly _echoDataMonitor: EchoDataMonitor;
 
-  constructor({ kv }: EchoHostParams) {
+  constructor({ kv, peerIdProvider }: EchoHostParams) {
     super();
 
     this._indexMetadataStore = new IndexMetadataStore({ db: kv.sublevel('index-metadata') });
@@ -70,6 +72,7 @@ export class EchoHost extends Resource {
       db: kv,
       dataMonitor: this._echoDataMonitor,
       indexMetadataStore: this._indexMetadataStore,
+      peerIdProvider,
     });
 
     this._indexer = new Indexer({

--- a/packages/sdk/client-services/src/packlets/services/service-context.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-context.ts
@@ -151,7 +151,10 @@ export class ServiceContext extends Resource {
       this._acceptIdentity.bind(this),
     );
 
-    this.echoHost = new EchoHost({ kv: this.level });
+    this.echoHost = new EchoHost({
+      kv: this.level,
+      peerIdProvider: () => this.identityManager.identity?.deviceKey?.toHex(),
+    });
 
     this._meshReplicator = new MeshEchoReplicator();
 


### PR DESCRIPTION
### Details

Random IDs were just easier to implement.
Doesn't work well with edge automerge-replicator, because it maintains multiple mappings to the same peer. 