### PR TITLE
fix: fixed pushing document to wrong edge replicator

### DIFF
--- a/packages/core/echo/echo-pipeline/package.json
+++ b/packages/core/echo/echo-pipeline/package.json
@@ -73,7 +73,8 @@
   "devDependencies": {
     "@dxos/test-utils": "workspace:*",
     "@types/lodash.isequal": "^4.5.0",
-    "fast-check": "^3.19.0"
+    "fast-check": "^3.19.0",
+    "get-port-please": "^3.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/echo/echo-pipeline/src/edge/echo-edge-replicator.test.ts
+++ b/packages/core/echo/echo-pipeline/src/edge/echo-edge-replicator.test.ts
@@ -2,7 +2,8 @@
 // Copyright 2024 DXOS.org
 //
 
-import { describe, test } from 'vitest';
+import { getRandomPort } from 'get-port-please';
+import { describe, expect, onTestFinished, test } from 'vitest';
 
 import { Event } from '@dxos/async';
 import { cbor } from '@dxos/automerge/automerge-repo';
@@ -16,69 +17,111 @@ import type { Peer } from '@dxos/protocols/proto/dxos/edge/messenger';
 import { openAndClose } from '@dxos/test-utils';
 
 import { EchoEdgeReplicator } from './echo-edge-replicator';
-import type { EchoReplicatorContext } from '../automerge';
+import type { EchoReplicatorContext, ReplicatorConnection } from '../automerge';
 
 describe('EchoEdgeReplicator', () => {
-  test('reconnects', async ({ onTestFinished }) => {
-    const { endpoint, cleanup, sendMessage } = await createTestEdgeWsServer(8001);
-    onTestFinished(cleanup);
-    const client = new EdgeClient(await createEphemeralEdgeIdentity(), { socketEndpoint: endpoint });
-    await openAndClose(client);
+  test('reconnects', async () => {
+    const { client, server } = await createClientServer();
 
     const spaceId = SpaceId.random();
 
-    const replicator = new EchoEdgeReplicator({ edgeConnection: client });
     const { context, connectionOpen } = createMockContext();
-    await replicator.connect(context);
+    const replicator = await connectReplicator(client, context);
     await replicator.connectToSpace(spaceId);
 
     client.setIdentity(await createEphemeralEdgeIdentity());
     await connectionOpen.waitForCount(1);
 
-    sendMessage(
-      createForbiddenMessage(
-        {
-          identityKey: client.identityKey,
-          peerKey: client.peerKey,
-        },
-        spaceId,
-      ),
-    );
+    const forbidden = createForbiddenMessage({ identityKey: client.identityKey, peerKey: client.peerKey }, spaceId);
+    server.sendMessage(forbidden);
     await connectionOpen.waitForCount(1);
 
     // Double restart to check for race conditions.
     client.setIdentity(await createEphemeralEdgeIdentity());
-    sendMessage(
-      createForbiddenMessage(
-        {
-          identityKey: client.identityKey,
-          peerKey: client.peerKey,
-        },
-        spaceId,
-      ),
-    );
+    server.sendMessage(forbidden);
     await connectionOpen.waitForCount(1);
 
     await replicator.disconnect();
   });
+
+  describe('shouldAdvertise', () => {
+    test('true if space document belongs to connection space', async () => {
+      const { client } = await createClientServer();
+
+      const spaceId = SpaceId.random();
+      const documentId = PublicKey.random().toHex();
+      const { context, openConnections } = createMockContext({
+        documentSpaceId: { [documentId]: spaceId },
+      });
+      const replicator = await connectReplicator(client, context);
+      await replicator.connectToSpace(spaceId);
+
+      await expect.poll(() => openConnections.length === 1).toBeTruthy();
+      expect(openConnections[0].shouldAdvertise({ documentId })).toBeTruthy();
+    });
+
+    test('checks remote collection if space id can not be resolved', async () => {
+      const { client } = await createClientServer();
+
+      const spaceId = SpaceId.random();
+      const documentId = PublicKey.random().toHex();
+      const remoteCollections: { [peerId: string]: { [documentId: string]: boolean } } = {};
+      const { context, openConnections } = createMockContext({ remoteCollections });
+      const replicator = await connectReplicator(client, context);
+      await replicator.connectToSpace(spaceId);
+
+      await expect.poll(() => openConnections.length === 1).toBeTruthy();
+      const connection = openConnections[0];
+      expect(await connection.shouldAdvertise({ documentId })).toBeFalsy();
+      remoteCollections[connection.peerId] = { [documentId]: true };
+      expect(await connection.shouldAdvertise({ documentId })).toBeTruthy();
+    });
+  });
+
+  const connectReplicator = async (client: EdgeClient, context: EchoReplicatorContext) => {
+    const replicator = new EchoEdgeReplicator({ edgeConnection: client });
+    await replicator.connect(context);
+    onTestFinished(() => replicator.disconnect());
+    return replicator;
+  };
+
+  const createClientServer = async () => {
+    const server = await createTestEdgeWsServer(await getRandomPort());
+    onTestFinished(server.cleanup);
+    const client = new EdgeClient(await createEphemeralEdgeIdentity(), { socketEndpoint: server.endpoint });
+    await openAndClose(client);
+    return { client, server };
+  };
 });
 
-const createMockContext = () => {
+const createMockContext = (args?: {
+  remoteCollections?: { [peerId: string]: { [documentId: string]: boolean } };
+  documentSpaceId?: { [documentId: string]: SpaceId };
+}) => {
   const connectionOpen = new Event();
+  const openConnections: ReplicatorConnection[] = [];
   return {
     context: {
-      getContainingSpaceIdForDocument: async (documentId) => null,
+      getContainingSpaceIdForDocument: async (documentId) => args?.documentSpaceId?.[documentId] ?? null,
       getContainingSpaceForDocument: async (documentId) => null,
       onConnectionAuthScopeChanged: (connection) => {},
-      isDocumentInRemoteCollection: async (params) => false,
-      onConnectionClosed: (connection) => {},
+      isDocumentInRemoteCollection: async (params) =>
+        args?.remoteCollections?.[params.peerId]?.[params.documentId] ?? false,
+      onConnectionClosed: (connection) => {
+        const idx = openConnections.indexOf(connection);
+        if (idx >= 0) {
+          openConnections.splice(idx, 1);
+        }
+      },
       onConnectionOpen: (connection) => {
+        openConnections.push(connection);
         connectionOpen.emit();
       },
 
       peerId: PublicKey.random().toHex(),
     } satisfies EchoReplicatorContext,
 
+    openConnections,
     connectionOpen,
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2600,6 +2600,9 @@ importers:
       fast-check:
         specifier: ^3.19.0
         version: 3.19.0
+      get-port-please:
+        specifier: ^3.1.1
+        version: 3.1.1
 
   packages/core/echo/echo-protocol:
     dependencies:
@@ -21213,11 +21216,6 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
 
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -45928,8 +45926,8 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv-formats@2.1.1(ajv@8.12.0):
-    optionalDependencies:
+  ajv-formats@2.1.1:
+    dependencies:
       ajv: 8.12.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
@@ -47543,7 +47541,7 @@ snapshots:
   conf@12.0.0:
     dependencies:
       ajv: 8.12.0
-      ajv-formats: 2.1.1(ajv@8.12.0)
+      ajv-formats: 2.1.1
       atomically: 2.0.3
       debounce-fn: 5.1.2
       dot-prop: 8.0.2
@@ -56980,7 +56978,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       ajv: 8.12.0
-      ajv-formats: 2.1.1(ajv@8.12.0)
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0(ajv@8.12.0)
 
   screenfull@5.2.0: {}


### PR DESCRIPTION
### Details

The "accept a document if access control can't be checked, but it's in the remote peer's collection" logic was present in mesh, but not edge replicator. 
This was causing a bug where documents were pushed to wrong space replicator and an infinite sync-spinner would appear in composer.
Copied the logic and added more tests for share policy.