### PR TITLE
fix: make space root doc id a part of collectionId

### DIFF
--- a/packages/core/echo/echo-db/src/client/repo-proxy.test.ts
+++ b/packages/core/echo/echo-db/src/client/repo-proxy.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, test } from 'vitest';
 import { Trigger, asyncTimeout, latch } from '@dxos/async';
 import { next as A } from '@dxos/automerge/automerge';
 import { type AutomergeUrl } from '@dxos/automerge/automerge-repo';
-import { AutomergeHost, DataServiceImpl } from '@dxos/echo-pipeline';
+import { AutomergeHost, DataServiceImpl, SpaceStateManager } from '@dxos/echo-pipeline';
 import { TestReplicationNetwork } from '@dxos/echo-pipeline/testing';
 import { IndexMetadataStore } from '@dxos/indexing';
 import { SpaceId } from '@dxos/keys';
@@ -278,7 +278,11 @@ const setup = async (kv = createTestLevel()) => {
   });
   await openAndClose(host);
 
-  const dataService = new DataServiceImpl({ automergeHost: host, updateIndexes: async () => {} });
+  const dataService = new DataServiceImpl({
+    automergeHost: host,
+    spaceStateManager: new SpaceStateManager(),
+    updateIndexes: async () => {},
+  });
   return { kv, host, dataService };
 };
 

--- a/packages/core/echo/echo-db/src/core-db/automerge-doc-loader.test.ts
+++ b/packages/core/echo/echo-db/src/core-db/automerge-doc-loader.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, test } from 'vitest';
 
 import { sleep } from '@dxos/async';
 import { Context } from '@dxos/context';
-import { AutomergeHost, DataServiceImpl, createIdFromSpaceKey } from '@dxos/echo-pipeline';
+import { AutomergeHost, DataServiceImpl, createIdFromSpaceKey, SpaceStateManager } from '@dxos/echo-pipeline';
 import { type SpaceDoc, SpaceDocVersion } from '@dxos/echo-protocol';
 import { createObjectId } from '@dxos/echo-schema';
 import { IndexMetadataStore } from '@dxos/indexing';
@@ -85,7 +85,11 @@ describe('AutomergeDocumentLoader', () => {
       indexMetadataStore: new IndexMetadataStore({ db: level.sublevel('index-metadata') }),
     });
     await openAndClose(host);
-    const dataService = new DataServiceImpl({ automergeHost: host, updateIndexes: async () => {} });
+    const dataService = new DataServiceImpl({
+      automergeHost: host,
+      spaceStateManager: new SpaceStateManager(),
+      updateIndexes: async () => {},
+    });
     const repo = new RepoProxy(dataService, SpaceId.random());
     await openAndClose(repo);
 

--- a/packages/core/echo/echo-pipeline/src/automerge/space-collection.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/space-collection.ts
@@ -2,14 +2,16 @@
 // Copyright 2024 DXOS.org
 //
 
+import { type DocumentId } from '@dxos/automerge/automerge-repo';
 import type { CollectionId } from '@dxos/echo-protocol';
 import { invariant } from '@dxos/invariant';
 import { SpaceId } from '@dxos/keys';
 
-export const deriveCollectionIdFromSpaceId = (spaceId: SpaceId): CollectionId => `space:${spaceId}` as CollectionId;
+export const deriveCollectionIdFromSpaceId = (spaceId: SpaceId, rootDocumentId: DocumentId): CollectionId =>
+  `space:${spaceId}:${rootDocumentId}` as CollectionId;
 
 export const getSpaceIdFromCollectionId = (collectionId: CollectionId): SpaceId => {
-  const spaceId = collectionId.replace(/^space:/, '');
+  const spaceId = collectionId.split(':')[1];
   invariant(SpaceId.isValid(spaceId));
   return spaceId;
 };

--- a/packages/core/echo/echo-pipeline/src/automerge/space-collection.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/space-collection.ts
@@ -7,8 +7,8 @@ import type { CollectionId } from '@dxos/echo-protocol';
 import { invariant } from '@dxos/invariant';
 import { SpaceId } from '@dxos/keys';
 
-export const deriveCollectionIdFromSpaceId = (spaceId: SpaceId, rootDocumentId: DocumentId): CollectionId =>
-  `space:${spaceId}:${rootDocumentId}` as CollectionId;
+export const deriveCollectionIdFromSpaceId = (spaceId: SpaceId, rootDocumentId?: DocumentId): CollectionId =>
+  (rootDocumentId ? `space:${spaceId}:${rootDocumentId}` : `space:${spaceId}`) as CollectionId;
 
 export const getSpaceIdFromCollectionId = (collectionId: CollectionId): SpaceId => {
   const spaceId = collectionId.split(':')[1];

--- a/packages/core/echo/echo-pipeline/src/db-host/echo-host.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/echo-host.ts
@@ -163,6 +163,8 @@ export class EchoHost extends Resource {
     await this._spaceStateManager.open(ctx);
 
     this._spaceStateManager.spaceDocumentListUpdated.on(this._ctx, (e) => {
+      // TODO(yaroslav): remove collection without spaceRootId after release (production<->staging interop)
+      void this._automergeHost.updateLocalCollectionState(deriveCollectionIdFromSpaceId(e.spaceId), e.documentIds);
       void this._automergeHost.updateLocalCollectionState(
         deriveCollectionIdFromSpaceId(e.spaceId, e.spaceRootId),
         e.documentIds,

--- a/packages/core/echo/echo-pipeline/src/db-host/echo-host.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/echo-host.ts
@@ -31,7 +31,6 @@ import {
   type LoadDocOptions,
   type CreateDocOptions,
   type EchoReplicator,
-  type CollectionSyncState,
   type EchoDataStats,
   type PeerIdProvider,
 } from '../automerge';
@@ -91,6 +90,7 @@ export class EchoHost extends Resource {
 
     this._dataService = new DataServiceImpl({
       automergeHost: this._automergeHost,
+      spaceStateManager: this._spaceStateManager,
       updateIndexes: async () => {
         await this._indexer.updateIndexes();
       },
@@ -163,7 +163,10 @@ export class EchoHost extends Resource {
     await this._spaceStateManager.open(ctx);
 
     this._spaceStateManager.spaceDocumentListUpdated.on(this._ctx, (e) => {
-      void this._automergeHost.updateLocalCollectionState(deriveCollectionIdFromSpaceId(e.spaceId), e.documentIds);
+      void this._automergeHost.updateLocalCollectionState(
+        deriveCollectionIdFromSpaceId(e.spaceId, e.spaceRootId),
+        e.documentIds,
+      );
     });
   }
 
@@ -248,11 +251,6 @@ export class EchoHost extends Resource {
    */
   async removeReplicator(replicator: EchoReplicator): Promise<void> {
     await this._automergeHost.removeReplicator(replicator);
-  }
-
-  async getSpaceSyncState(spaceId: SpaceId): Promise<CollectionSyncState> {
-    const collectionId = deriveCollectionIdFromSpaceId(spaceId);
-    return this._automergeHost.getCollectionSyncState(collectionId);
   }
 }
 

--- a/packages/core/echo/echo-pipeline/src/db-host/index.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/index.ts
@@ -8,3 +8,4 @@ export * from './echo-host';
 export * from './database-root';
 export * from './query-state';
 export * from './query-service';
+export * from './space-state-manager';

--- a/packages/core/echo/echo-pipeline/src/db-host/space-state-manager.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/space-state-manager.ts
@@ -35,6 +35,10 @@ export class SpaceStateManager extends Resource {
     return this._roots.get(documentId);
   }
 
+  getSpaceRootDocumentId(spaceId: SpaceId): DocumentId | undefined {
+    return this._rootBySpace.get(spaceId);
+  }
+
   async assignRootToSpace(spaceId: SpaceId, handle: DocHandle<SpaceDoc>): Promise<DatabaseRoot> {
     let root: DatabaseRoot;
     if (this._roots.has(handle.documentId)) {
@@ -67,7 +71,9 @@ export class SpaceStateManager extends Resource {
         const documentIds = [root.documentId, ...root.getAllLinkedDocuments().map((url) => interpretAsDocumentId(url))];
         if (!isEqual(documentIds, this._lastSpaceDocumentList.get(spaceId))) {
           this._lastSpaceDocumentList.set(spaceId, documentIds);
-          this.spaceDocumentListUpdated.emit(new SpaceDocumentListUpdatedEvent(spaceId, documentIds));
+          this.spaceDocumentListUpdated.emit(
+            new SpaceDocumentListUpdatedEvent(spaceId, root.documentId, prevRootId, documentIds),
+          );
         }
       },
       { maxFrequency: 50 },
@@ -85,6 +91,8 @@ export class SpaceStateManager extends Resource {
 export class SpaceDocumentListUpdatedEvent {
   constructor(
     public readonly spaceId: SpaceId,
+    public readonly spaceRootId: DocumentId,
+    public readonly previousRootId: DocumentId | undefined,
     public readonly documentIds: DocumentId[],
   ) {}
 }


### PR DESCRIPTION
### Details

Edge is sending heads of all the documents from space including those from previous epochs. 
Include the current space root document id so that edge can use it to send the relevant documents only.