### PR TITLE
fix: do not sync old collections

### DIFF
--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
@@ -453,6 +453,10 @@ export class AutomergeHost extends Resource {
     this._collectionSynchronizer.setLocalCollectionState(collectionId, { documents });
   }
 
+  async clearLocalCollectionState(collectionId: string) {
+    this._collectionSynchronizer.clearLocalCollectionState(collectionId);
+  }
+
   private _onCollectionStateQueried(collectionId: string, peerId: PeerId) {
     this._collectionSynchronizer.onCollectionStateQueried(collectionId, peerId);
   }

--- a/packages/core/echo/echo-pipeline/src/db-host/echo-host.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/echo-host.ts
@@ -163,6 +163,9 @@ export class EchoHost extends Resource {
     await this._spaceStateManager.open(ctx);
 
     this._spaceStateManager.spaceDocumentListUpdated.on(this._ctx, (e) => {
+      if (e.previousRootId) {
+        void this._automergeHost.clearLocalCollectionState(deriveCollectionIdFromSpaceId(e.spaceId, e.previousRootId));
+      }
       // TODO(yaroslav): remove collection without spaceRootId after release (production<->staging interop)
       void this._automergeHost.updateLocalCollectionState(deriveCollectionIdFromSpaceId(e.spaceId), e.documentIds);
       void this._automergeHost.updateLocalCollectionState(


### PR DESCRIPTION
### Details

`CollectionSynchronizer` gets polluted with collections during epoch credential processing. Added cleanup logic.