### PR TITLE
feat(react-ui-theme): Physical color token audit story

### DIFF
--- a/packages/ui/react-ui-theme/package.json
+++ b/packages/ui/react-ui-theme/package.json
@@ -19,8 +19,8 @@
     "tailwind-config-viewer": "tailwind-config-viewer -o -c ./dist/plugin/node/config/tailwind.cjs"
   },
   "dependencies": {
-    "@ch-ui/tailwind-tokens": "^0.5.5",
-    "@ch-ui/tokens": "^0.5.6",
+    "@ch-ui/tailwind-tokens": "1.0.0",
+    "@ch-ui/tokens": "1.0.0",
     "@dxos/node-std": "workspace:*",
     "@fontsource-variable/inter": "5.0.16",
     "@fontsource-variable/jetbrains-mono": "5.0.21",

--- a/packages/ui/react-ui-theme/package.json
+++ b/packages/ui/react-ui-theme/package.json
@@ -19,8 +19,8 @@
     "tailwind-config-viewer": "tailwind-config-viewer -o -c ./dist/plugin/node/config/tailwind.cjs"
   },
   "dependencies": {
-    "@ch-ui/tailwind-tokens": "1.0.0",
-    "@ch-ui/tokens": "1.0.0",
+    "@ch-ui/tailwind-tokens": "^1.0.0",
+    "@ch-ui/tokens": "^1.0.0",
     "@dxos/node-std": "workspace:*",
     "@fontsource-variable/inter": "5.0.16",
     "@fontsource-variable/jetbrains-mono": "5.0.21",

--- a/packages/ui/react-ui-theme/src/config/tokens/Tokens.stories.tsx
+++ b/packages/ui/react-ui-theme/src/config/tokens/Tokens.stories.tsx
@@ -1,0 +1,64 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import '@dxos-theme';
+import { facetSemanticValues, type Facet, resolveNaming, seriesValues, renderHelicalArcTokens } from '@ch-ui/tokens';
+import { type Meta } from '@storybook/react';
+import React from 'react';
+
+import { withTheme } from '@dxos/storybook-utils';
+
+import { tokenSet } from './index';
+
+const semanticValues = facetSemanticValues((tokenSet.colors as Facet).semantic);
+const mainCondition = 'p3';
+
+const structure = Object.entries(tokenSet.colors.physical.series)
+  .map(([seriesId, { [mainCondition]: series }]) => {
+    const resolvedNaming = resolveNaming(series?.naming as any);
+    const values = seriesValues(series!, Array.from(semanticValues?.[seriesId] ?? []));
+    return [
+      seriesId,
+      renderHelicalArcTokens({
+        seriesId,
+        conditionId: mainCondition,
+        series: series as any,
+        namespace: tokenSet.colors.physical.namespace,
+        resolvedNaming,
+        values,
+      }).map((declaration) => declaration.split(':')[0]),
+    ];
+  })
+  .reverse();
+
+const Swatch = ({ variable }: { variable: string }) => {
+  return (
+    <div className='inline-block is-16'>
+      <dd className='aspect-square' style={{ background: `var(${variable})` }}></dd>
+      <dt>{variable.substring(tokenSet.colors.physical.namespace!.length + 2)}</dt>
+    </div>
+  );
+};
+
+export const Tokens = () => {
+  return structure.map(([seriesId, variables]) => {
+    return (
+      <>
+        <h2>{seriesId}</h2>
+        <dl>
+          {(variables as string[]).map((variable) => (
+            <Swatch key={variable} variable={variable} />
+          ))}
+        </dl>
+      </>
+    );
+  });
+};
+
+const meta: Meta = {
+  title: 'ui/react-ui-theme/Tokens',
+  decorators: [withTheme],
+};
+
+export default meta;

--- a/packages/ui/react-ui-theme/src/config/tokens/Tokens.stories.tsx
+++ b/packages/ui/react-ui-theme/src/config/tokens/Tokens.stories.tsx
@@ -39,9 +39,8 @@ const Swatch = ({ variable, seriesId, shadeValue, opacity, name }: SwatchProps) 
     <div className='shrink-0 is-16'>
       <dd className='aspect-square' style={{ background: `var(${variable})` }}></dd>
       <dt className='text-xs'>
-        <p>{seriesId}</p>
         <p>{shadeValue}</p>
-        {opacity < 1 && <p>{opacity}</p>}
+        {opacity < 1 && <p>/ {opacity}</p>}
       </dt>
     </div>
   );

--- a/packages/ui/react-ui-theme/src/config/tokens/Tokens.stories.tsx
+++ b/packages/ui/react-ui-theme/src/config/tokens/Tokens.stories.tsx
@@ -3,76 +3,55 @@
 //
 
 import '@dxos-theme';
-import { facetSemanticValues, type Facet, resolveNaming, seriesValues, renderHelicalArcTokens } from '@ch-ui/tokens';
+import { auditFacet, type HelicalArcSeries, type TokenAudit, parseAlphaLuminosity } from '@ch-ui/tokens';
 import { type Meta } from '@storybook/react';
 import React from 'react';
 
 import { tokenSet } from './index';
 
-const semanticValues = facetSemanticValues((tokenSet.colors as Facet).semantic);
-const mainCondition = 'p3';
+const colorAudit = auditFacet(tokenSet.colors, { condition: 'p3' });
 
-const physicalSwatches = Object.entries(tokenSet.colors.physical.series)
-  .map(([seriesId, { [mainCondition]: series }]) => {
-    const resolvedNaming = resolveNaming(series?.naming as any);
-    const values = seriesValues(series!, Array.from(semanticValues?.[seriesId] ?? []));
-    return [
-      seriesId,
-      renderHelicalArcTokens({
-        seriesId,
-        conditionId: mainCondition,
-        series: series as any,
-        namespace: tokenSet.colors.physical.namespace,
-        resolvedNaming,
-        values,
-      })
-        .map((declaration) => declaration.split(':')[0])
-        .map((variable) => {
-          const name = variable.substring(tokenSet.colors.physical.namespace!.length + 2);
-          const results = name.split(/-|\\\/\\?/);
-          const [seriesId, shadeValue, opacity] = results;
-          return {
-            seriesId,
-            shadeValue: parseFloat(shadeValue),
-            opacity: typeof opacity !== 'undefined' ? parseFloat(opacity) : 1,
-            name,
-            variable,
-          } satisfies SwatchProps;
-        })
-        .sort((a, b) => {
-          return a.shadeValue - b.shadeValue - (a.opacity - b.opacity);
-        }),
-    ];
-  })
-  .reverse() as [string, SwatchProps[]][];
-
-type SwatchProps = { variable: string; seriesId: string; shadeValue: number; opacity: number; name: string };
-
-const Swatch = ({ variable, seriesId, shadeValue, opacity, name }: SwatchProps) => {
+const Swatch = ({ variableName, value, semantic, physical }: TokenAudit<HelicalArcSeries>) => {
+  const [luminosity, alpha] = parseAlphaLuminosity(value);
   return (
-    <div className='shrink-0 is-16'>
-      <dd className='aspect-square' style={{ background: `var(${variable})` }}></dd>
+    <div className='shrink-0 is-32'>
+      <dd className='aspect-video' style={{ background: `var(${variableName})` }}></dd>
       <dt className='text-xs'>
-        <p>{shadeValue}</p>
-        {opacity < 1 && <p>/ {opacity}</p>}
+        <p>
+          {luminosity}
+          {typeof alpha !== 'undefined' && ` / ${alpha}`}
+        </p>
+        {physical.includes('values') && <p>values</p>}
+        {physical.includes('naming') && <p>naming</p>}
+        {semantic.length > 0 && (
+          <ul>
+            {semantic.map(({ sememeName, conditionId }) => {
+              const sememeCondition = `${sememeName} / ${conditionId}`;
+              return <li key={sememeCondition}>{sememeCondition}</li>;
+            })}
+          </ul>
+        )}
       </dt>
     </div>
   );
 };
 
 export const Audit = () => {
+  if (typeof colorAudit === 'string') {
+    return null;
+  }
   return (
     <>
       <h1>Semantic tokens</h1>
       {}
       <h1>Physical tokens</h1>
-      {physicalSwatches.map(([seriesId, swatches]) => {
+      {Object.entries(colorAudit).map(([seriesId, audits]) => {
         return (
           <>
             <h2 className='mbs-4 mbe-2'>{seriesId}</h2>
             <dl className='flex flex-wrap'>
-              {swatches.map((swatch) => (
-                <Swatch key={swatch.variable} {...swatch} />
+              {audits.map((audit) => (
+                <Swatch key={audit.variableName} {...audit} />
               ))}
             </dl>
           </>

--- a/packages/ui/react-ui-theme/src/config/tokens/Tokens.stories.tsx
+++ b/packages/ui/react-ui-theme/src/config/tokens/Tokens.stories.tsx
@@ -14,10 +14,10 @@ const colorAudit = auditFacet(tokenSet.colors, { condition: 'p3' });
 const Swatch = ({ variableName, value, semantic, physical }: TokenAudit<HelicalArcSeries>) => {
   const [luminosity, alpha] = parseAlphaLuminosity(value);
   return (
-    <div className='shrink-0 is-32'>
+    <div className='shrink-0 is-40 flex flex-col rounded overflow-hidden'>
       <dd className='aspect-video' style={{ background: `var(${variableName})` }}></dd>
-      <dt className='text-xs'>
-        <p>
+      <dt className='text-xs bg-base grow pli-2 plb-1'>
+        <p className='text-sm'>
           {luminosity}
           {typeof alpha !== 'undefined' && ` / ${alpha}`}
         </p>
@@ -36,23 +36,49 @@ const Swatch = ({ variableName, value, semantic, physical }: TokenAudit<HelicalA
   );
 };
 
-export const Audit = () => {
+export const Tokens = () => {
   if (typeof colorAudit === 'string') {
     return null;
   }
   return (
     <>
-      <h1>Semantic tokens</h1>
-      {}
-      <h1>Physical tokens</h1>
+      <style>{`html{
+        background-color: #888;
+        background-image: linear-gradient(45deg, #777 25%, transparent 25%, transparent 75%, #777 75%, #777),
+        linear-gradient(45deg, #777 25%, transparent 25%, transparent 75%, #777 75%, #777);
+        background-size: 32px 32px;
+        background-position: 0 0, 16px 16px;
+      }`}</style>
+      <div className='flex'>
+        <div className='p-2 bg-base rounded'>
+          <h1 className='text-lg mbe-2'>Physical color token audit</h1>
+          <pre className='text-xs'>
+            Luminosity (/ alpha)?
+            <br />
+            value // (whether added directly as a physical value)
+            <br />
+            naming // (whether added as a named physical value)
+            <br />
+            ...`semantic token name / theme`[]
+          </pre>
+        </div>
+      </div>
       {Object.entries(colorAudit).map(([seriesId, audits]) => {
         return (
           <>
-            <h2 className='mbs-4 mbe-2'>{seriesId}</h2>
-            <dl className='flex flex-wrap'>
-              {audits.map((audit) => (
-                <Swatch key={audit.variableName} {...audit} />
-              ))}
+            <h2 className='mbs-12 mbe-4'>
+              <span className='pli-2 plb-1 bg-base rounded'>{seriesId}</span>
+            </h2>
+            <dl className='flex flex-wrap gap-2'>
+              {audits
+                .sort((a, b) => {
+                  const [aL, aA] = parseAlphaLuminosity(a.value);
+                  const [bL, bA] = parseAlphaLuminosity(b.value);
+                  return aL - bL - (Number.isFinite(aA) && Number.isFinite(bA) ? aA! - bA! : 0);
+                })
+                .map((audit) => (
+                  <Swatch key={audit.variableName} {...audit} />
+                ))}
             </dl>
           </>
         );

--- a/packages/ui/react-ui-theme/src/config/tokens/Tokens.stories.tsx
+++ b/packages/ui/react-ui-theme/src/config/tokens/Tokens.stories.tsx
@@ -50,17 +50,19 @@ const Swatch = ({ variable, seriesId, shadeValue, opacity, name }: SwatchProps) 
 export const Audit = () => {
   return (
     <>
+      <h1>Semantic tokens</h1>
+      {}
       <h1>Physical tokens</h1>
       {structure.map(([seriesId, variables]) => {
         const swatches = (variables as string[])
           .map((variable) => {
             const name = variable.substring(tokenSet.colors.physical.namespace!.length + 2);
-            const results = name.split(/-|\\\/\\/);
+            const results = name.split(/-|\\\/\\?/);
             const [seriesId, shadeValue, opacity] = results;
             return {
               seriesId,
               shadeValue: parseFloat(shadeValue),
-              opacity: opacity ? parseFloat(opacity) : 1,
+              opacity: typeof opacity !== 'undefined' ? parseFloat(opacity) : 1,
               name,
               variable,
             };

--- a/packages/ui/react-ui-theme/src/config/tokens/Tokens.stories.tsx
+++ b/packages/ui/react-ui-theme/src/config/tokens/Tokens.stories.tsx
@@ -7,8 +7,6 @@ import { facetSemanticValues, type Facet, resolveNaming, seriesValues, renderHel
 import { type Meta } from '@storybook/react';
 import React from 'react';
 
-import { withTheme } from '@dxos/storybook-utils';
-
 import { tokenSet } from './index';
 
 const semanticValues = facetSemanticValues((tokenSet.colors as Facet).semantic);
@@ -86,7 +84,6 @@ export const Audit = () => {
 
 const meta: Meta = {
   title: 'ui/react-ui-theme/Tokens',
-  decorators: [withTheme],
 };
 
 export default meta;

--- a/packages/ui/react-ui-theme/src/config/tokens/Tokens.stories.tsx
+++ b/packages/ui/react-ui-theme/src/config/tokens/Tokens.stories.tsx
@@ -32,28 +32,55 @@ const structure = Object.entries(tokenSet.colors.physical.series)
   })
   .reverse();
 
-const Swatch = ({ variable }: { variable: string }) => {
+type SwatchProps = { variable: string; seriesId: string; shadeValue: number; opacity: number; name: string };
+
+const Swatch = ({ variable, seriesId, shadeValue, opacity, name }: SwatchProps) => {
   return (
-    <div className='inline-block is-16'>
+    <div className='shrink-0 is-16'>
       <dd className='aspect-square' style={{ background: `var(${variable})` }}></dd>
-      <dt>{variable.substring(tokenSet.colors.physical.namespace!.length + 2)}</dt>
+      <dt className='text-xs'>
+        <p>{seriesId}</p>
+        <p>{shadeValue}</p>
+        {opacity < 1 && <p>{opacity}</p>}
+      </dt>
     </div>
   );
 };
 
-export const Tokens = () => {
-  return structure.map(([seriesId, variables]) => {
-    return (
-      <>
-        <h2>{seriesId}</h2>
-        <dl>
-          {(variables as string[]).map((variable) => (
-            <Swatch key={variable} variable={variable} />
-          ))}
-        </dl>
-      </>
-    );
-  });
+export const Audit = () => {
+  return (
+    <>
+      <h1>Physical tokens</h1>
+      {structure.map(([seriesId, variables]) => {
+        const swatches = (variables as string[])
+          .map((variable) => {
+            const name = variable.substring(tokenSet.colors.physical.namespace!.length + 2);
+            const results = name.split(/-|\\\/\\/);
+            const [seriesId, shadeValue, opacity] = results;
+            return {
+              seriesId,
+              shadeValue: parseFloat(shadeValue),
+              opacity: opacity ? parseFloat(opacity) : 1,
+              name,
+              variable,
+            };
+          })
+          .sort((a, b) => {
+            return a.shadeValue - b.shadeValue - (a.opacity - b.opacity);
+          });
+        return (
+          <>
+            <h2 className='mbs-4 mbe-2'>{seriesId}</h2>
+            <dl className='flex flex-wrap'>
+              {swatches.map((swatch) => (
+                <Swatch key={swatch.variable} {...swatch} />
+              ))}
+            </dl>
+          </>
+        );
+      })}
+    </>
+  );
 };
 
 const meta: Meta = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11794,11 +11794,11 @@ importers:
   packages/ui/react-ui-theme:
     dependencies:
       '@ch-ui/tailwind-tokens':
-        specifier: ^0.5.5
-        version: 0.5.5(tailwindcss@3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2)))
+        specifier: 1.0.0
+        version: 1.0.0(tailwindcss@3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2)))
       '@ch-ui/tokens':
-        specifier: ^0.5.6
-        version: 0.5.6
+        specifier: 1.0.0
+        version: 1.0.0
       '@dxos/node-std':
         specifier: workspace:*
         version: link:../../common/node-std
@@ -14168,22 +14168,22 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@ch-ui/colors@0.5.1':
-    resolution: {integrity: sha512-/WceiMV3BaLYOaRuZ74BriXphSN8UtFTsrPMeydsmoiYnpUMwJezjKk3VM8YuLfyWhuH3PQGeau/VP+oHgKyEA==}
+  '@ch-ui/colors@1.0.0':
+    resolution: {integrity: sha512-qjk6z5ydz9fiXHBBl0S4xA0cZPFycsyYJqxSZAuiTmEvlVgYzBeJxWp188awcHZwJtpoew2LCtOkOdpMIEJGog==}
     engines: {node: '>=20.0.0'}
 
   '@ch-ui/icons@0.5.0':
     resolution: {integrity: sha512-vevNSzPHnVDgyw6ZotbnE0y4FZFtIQQVKKjwVHGcfST7C5bqRyt69K1Nooo0r6s7laeJhS7YwXYmgLyPouc12w==}
     engines: {node: '>=20.0.0'}
 
-  '@ch-ui/tailwind-tokens@0.5.5':
-    resolution: {integrity: sha512-Fbr/PzdhAjB2UAm/07QMJaWKZZ8ItccZL7uh3qVCKMmXibQ41LI8GIaI/1sqgpWYvj2FleA2Kj9m7HNvhWIBnQ==}
+  '@ch-ui/tailwind-tokens@1.0.0':
+    resolution: {integrity: sha512-oP2iYbTLlHVAzb6mwM18NLBjOnYi26IkA/kpDJ7wpSYkapnvAfKx+YItz5HDev6FkZMuHJa98muz+vZQj4Qrsw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       tailwindcss: 3.x.x
 
-  '@ch-ui/tokens@0.5.6':
-    resolution: {integrity: sha512-L+DIoRYLAv1bhIC5e/S991VpQTeoarlaERJmvw46ZHQPWR+DGE4ZSTTsvgBjJ9WdyG0NmEjowZi3jMkYvA1TKg==}
+  '@ch-ui/tokens@1.0.0':
+    resolution: {integrity: sha512-lw3daEY9XI+UrxixU4LUqGtE+3xBPJ3usfvo64/zwJkhQDbh/pCJi4dZu0RbG2cToiTpZFA0ZPB+d0AZsdA2Ew==}
     engines: {node: '>=20.0.0'}
 
   '@chainsafe/is-ip@2.0.2':
@@ -37147,7 +37147,7 @@ snapshots:
   '@cbor-extract/cbor-extract-win32-x64@2.2.0':
     optional: true
 
-  '@ch-ui/colors@0.5.1':
+  '@ch-ui/colors@1.0.0':
     dependencies:
       colorjs: colorjs.io@0.5.2
 
@@ -37155,14 +37155,14 @@ snapshots:
     dependencies:
       svg-sprite: 2.0.4
 
-  '@ch-ui/tailwind-tokens@0.5.5(tailwindcss@3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2)))':
+  '@ch-ui/tailwind-tokens@1.0.0(tailwindcss@3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2)))':
     dependencies:
-      '@ch-ui/tokens': 0.5.6
+      '@ch-ui/tokens': 1.0.0
       tailwindcss: 3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2))
 
-  '@ch-ui/tokens@0.5.6':
+  '@ch-ui/tokens@1.0.0':
     dependencies:
-      '@ch-ui/colors': 0.5.1
+      '@ch-ui/colors': 1.0.0
       postcss: 8.4.47
 
   '@chainsafe/is-ip@2.0.2': {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11788,11 +11788,11 @@ importers:
   packages/ui/react-ui-theme:
     dependencies:
       '@ch-ui/tailwind-tokens':
-        specifier: ^0.5.5
-        version: 0.5.5(tailwindcss@3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2)))
+        specifier: ^1.0.0
+        version: 1.0.0(tailwindcss@3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2)))
       '@ch-ui/tokens':
-        specifier: ^0.5.6
-        version: 0.5.6
+        specifier: ^1.0.0
+        version: 1.0.0
       '@dxos/node-std':
         specifier: workspace:*
         version: link:../../common/node-std
@@ -14162,22 +14162,22 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@ch-ui/colors@0.5.1':
-    resolution: {integrity: sha512-/WceiMV3BaLYOaRuZ74BriXphSN8UtFTsrPMeydsmoiYnpUMwJezjKk3VM8YuLfyWhuH3PQGeau/VP+oHgKyEA==}
+  '@ch-ui/colors@1.0.0':
+    resolution: {integrity: sha512-qjk6z5ydz9fiXHBBl0S4xA0cZPFycsyYJqxSZAuiTmEvlVgYzBeJxWp188awcHZwJtpoew2LCtOkOdpMIEJGog==}
     engines: {node: '>=20.0.0'}
 
   '@ch-ui/icons@0.5.0':
     resolution: {integrity: sha512-vevNSzPHnVDgyw6ZotbnE0y4FZFtIQQVKKjwVHGcfST7C5bqRyt69K1Nooo0r6s7laeJhS7YwXYmgLyPouc12w==}
     engines: {node: '>=20.0.0'}
 
-  '@ch-ui/tailwind-tokens@0.5.5':
-    resolution: {integrity: sha512-Fbr/PzdhAjB2UAm/07QMJaWKZZ8ItccZL7uh3qVCKMmXibQ41LI8GIaI/1sqgpWYvj2FleA2Kj9m7HNvhWIBnQ==}
+  '@ch-ui/tailwind-tokens@1.0.0':
+    resolution: {integrity: sha512-oP2iYbTLlHVAzb6mwM18NLBjOnYi26IkA/kpDJ7wpSYkapnvAfKx+YItz5HDev6FkZMuHJa98muz+vZQj4Qrsw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       tailwindcss: 3.x.x
 
-  '@ch-ui/tokens@0.5.6':
-    resolution: {integrity: sha512-L+DIoRYLAv1bhIC5e/S991VpQTeoarlaERJmvw46ZHQPWR+DGE4ZSTTsvgBjJ9WdyG0NmEjowZi3jMkYvA1TKg==}
+  '@ch-ui/tokens@1.0.0':
+    resolution: {integrity: sha512-lw3daEY9XI+UrxixU4LUqGtE+3xBPJ3usfvo64/zwJkhQDbh/pCJi4dZu0RbG2cToiTpZFA0ZPB+d0AZsdA2Ew==}
     engines: {node: '>=20.0.0'}
 
   '@chainsafe/is-ip@2.0.2':
@@ -37141,7 +37141,7 @@ snapshots:
   '@cbor-extract/cbor-extract-win32-x64@2.2.0':
     optional: true
 
-  '@ch-ui/colors@0.5.1':
+  '@ch-ui/colors@1.0.0':
     dependencies:
       colorjs: colorjs.io@0.5.2
 
@@ -37149,14 +37149,14 @@ snapshots:
     dependencies:
       svg-sprite: 2.0.4
 
-  '@ch-ui/tailwind-tokens@0.5.5(tailwindcss@3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2)))':
+  '@ch-ui/tailwind-tokens@1.0.0(tailwindcss@3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2)))':
     dependencies:
-      '@ch-ui/tokens': 0.5.6
+      '@ch-ui/tokens': 1.0.0
       tailwindcss: 3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2))
 
-  '@ch-ui/tokens@0.5.6':
+  '@ch-ui/tokens@1.0.0':
     dependencies:
-      '@ch-ui/colors': 0.5.1
+      '@ch-ui/colors': 1.0.0
       postcss: 8.4.47
 
   '@chainsafe/is-ip@2.0.2': {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11794,10 +11794,10 @@ importers:
   packages/ui/react-ui-theme:
     dependencies:
       '@ch-ui/tailwind-tokens':
-        specifier: 1.0.0
+        specifier: ^1.0.0
         version: 1.0.0(tailwindcss@3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2)))
       '@ch-ui/tokens':
-        specifier: 1.0.0
+        specifier: ^1.0.0
         version: 1.0.0
       '@dxos/node-std':
         specifier: workspace:*


### PR DESCRIPTION
This PR
- begins a resolution of #8262
  - by using the new @ch-ui/tokens which has audit features
  - this makes it much easier to identify token sources and determine how to adjust colors going forward

<img width="1272" alt="Screenshot 2025-01-08 at 00 26 39" src="https://github.com/user-attachments/assets/7303f29f-56cb-4611-b628-c81f561b3599" />