### PR TITLE
fix: replication for documents not present locally

### DIFF
--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
@@ -148,9 +148,13 @@ export class AutomergeHost extends Resource {
     Event.wrap(this._echoNetworkAdapter, 'peer-disconnected').on(this._ctx, ((e: PeerDisconnectedPayload) =>
       this._onPeerDisconnected(e.peerId)) as any);
 
-    this._collectionSynchronizer.remoteStateUpdated.on(this._ctx, ({ collectionId, peerId }) => {
+    this._collectionSynchronizer.remoteStateUpdated.on(this._ctx, ({ collectionId, peerId, newDocsAppeared }) => {
       this._onRemoteCollectionStateUpdated(collectionId, peerId);
       this.collectionStateUpdated.emit({ collectionId: collectionId as CollectionId });
+      // We use collection lookups during share policy check, so we might need to update share policy for the new doc
+      if (newDocsAppeared) {
+        this._echoNetworkAdapter.onConnectionAuthScopeChanged(peerId);
+      }
     });
 
     await this._echoNetworkAdapter.open();

--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
@@ -44,6 +44,8 @@ import { LevelDBStorageAdapter, type BeforeSaveParams } from './leveldb-storage-
 
 export type PeerIdProvider = () => string | undefined;
 
+export type RootDocumentSpaceKeyProvider = (documentId: string) => PublicKey | undefined;
+
 export type AutomergeHostParams = {
   db: LevelDB;
 
@@ -54,6 +56,7 @@ export type AutomergeHostParams = {
    * Used for creating stable ids. A random key is generated on open, if no value is provided.
    */
   peerIdProvider?: PeerIdProvider;
+  getSpaceKeyByRootDocumentId?: RootDocumentSpaceKeyProvider;
 };
 
 export type LoadDocOptions = {
@@ -90,10 +93,17 @@ export class AutomergeHost extends Resource {
   private _peerId!: PeerId;
 
   private readonly _peerIdProvider?: PeerIdProvider;
+  private readonly _getSpaceKeyByRootDocumentId?: RootDocumentSpaceKeyProvider;
 
   public readonly collectionStateUpdated = new Event<{ collectionId: CollectionId }>();
 
-  constructor({ db, indexMetadataStore, dataMonitor, peerIdProvider }: AutomergeHostParams) {
+  constructor({
+    db,
+    indexMetadataStore,
+    dataMonitor,
+    peerIdProvider,
+    getSpaceKeyByRootDocumentId,
+  }: AutomergeHostParams) {
     super();
     this._db = db;
     this._storage = new LevelDBStorageAdapter({
@@ -114,6 +124,7 @@ export class AutomergeHost extends Resource {
     this._headsStore = new HeadsStore({ db: db.sublevel('heads') });
     this._indexMetadataStore = indexMetadataStore;
     this._peerIdProvider = peerIdProvider;
+    this._getSpaceKeyByRootDocumentId = getSpaceKeyByRootDocumentId;
   }
 
   protected override async _open() {
@@ -351,16 +362,23 @@ export class AutomergeHost extends Resource {
 
   private async _getContainingSpaceForDocument(documentId: string): Promise<PublicKey | null> {
     const doc = this._repo.handles[documentId as any]?.docSync();
-    if (!doc) {
-      return null;
+    if (doc) {
+      const spaceKeyHex = getSpaceKeyFromDoc(doc);
+      if (spaceKeyHex) {
+        return PublicKey.from(spaceKeyHex);
+      }
+    }
+    /**
+     * Edge case on the initial space setup.
+     * A peer is maybe trying to share space root document with us after a successful invitation.
+     * We don't have a document to check access block locally, so we need to rely on external sources (space metada).
+     */
+    const rootDocSpaceKey = this._getSpaceKeyByRootDocumentId?.(documentId);
+    if (rootDocSpaceKey) {
+      return rootDocSpaceKey;
     }
 
-    const spaceKeyHex = getSpaceKeyFromDoc(doc);
-    if (!spaceKeyHex) {
-      return null;
-    }
-
-    return PublicKey.from(spaceKeyHex);
+    return null;
   }
 
   /**

--- a/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.ts
@@ -35,7 +35,7 @@ export class CollectionSynchronizer extends Resource {
 
   private readonly _connectedPeers = new Set<PeerId>();
 
-  public readonly remoteStateUpdated = new Event<{ collectionId: string; peerId: PeerId }>();
+  public readonly remoteStateUpdated = new Event<{ collectionId: string; peerId: PeerId; newDocsAppeared: boolean }>();
 
   constructor(params: CollectionSynchronizerParams) {
     super();
@@ -159,8 +159,12 @@ export class CollectionSynchronizer extends Resource {
     log('onRemoteStateReceived', { collectionId, peerId, state });
     validateCollectionState(state);
     const perCollectionState = this._getOrCreatePerCollectionState(collectionId);
-    perCollectionState.remoteStates.set(peerId, state);
-    this.remoteStateUpdated.emit({ peerId, collectionId });
+    const existingState = perCollectionState.remoteStates.get(peerId) ?? { documents: {} };
+    const diff = diffCollectionState(existingState, state);
+    if (diff.missingOnLocal.length > 0 || diff.different.length > 0) {
+      perCollectionState.remoteStates.set(peerId, state);
+      this.remoteStateUpdated.emit({ peerId, collectionId, newDocsAppeared: diff.missingOnLocal.length > 0 });
+    }
   }
 
   private _getOrCreatePerCollectionState(collectionId: string): PerCollectionState {

--- a/packages/core/echo/echo-pipeline/src/automerge/echo-network-adapter.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/echo-network-adapter.ts
@@ -246,6 +246,13 @@ export class EchoNetworkAdapter extends NetworkAdapter {
     this._params.monitor?.recordMessageReceived(message);
   }
 
+  public onConnectionAuthScopeChanged(peer: PeerId) {
+    const entry = this._connections.get(peer);
+    if (entry) {
+      this._onConnectionAuthScopeChanged(entry.connection);
+    }
+  }
+
   /**
    * Trigger doc-synchronizer shared documents set recalculation. Happens on peer-candidate.
    * TODO(y): replace with a proper API call when sharePolicy update becomes supported by automerge-repo

--- a/packages/core/echo/echo-pipeline/src/db-host/echo-host.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/echo-host.ts
@@ -33,6 +33,7 @@ import {
   type EchoReplicator,
   type EchoDataStats,
   type PeerIdProvider,
+  type RootDocumentSpaceKeyProvider,
 } from '../automerge';
 
 const INDEXER_CONFIG: IndexConfig = {
@@ -43,6 +44,7 @@ const INDEXER_CONFIG: IndexConfig = {
 export type EchoHostParams = {
   kv: LevelDB;
   peerIdProvider?: PeerIdProvider;
+  getSpaceKeyByRootDocumentId?: RootDocumentSpaceKeyProvider;
 };
 
 /**
@@ -60,7 +62,7 @@ export class EchoHost extends Resource {
   private readonly _spaceStateManager = new SpaceStateManager();
   private readonly _echoDataMonitor: EchoDataMonitor;
 
-  constructor({ kv, peerIdProvider }: EchoHostParams) {
+  constructor({ kv, peerIdProvider, getSpaceKeyByRootDocumentId }: EchoHostParams) {
     super();
 
     this._indexMetadataStore = new IndexMetadataStore({ db: kv.sublevel('index-metadata') });
@@ -72,6 +74,7 @@ export class EchoHost extends Resource {
       dataMonitor: this._echoDataMonitor,
       indexMetadataStore: this._indexMetadataStore,
       peerIdProvider,
+      getSpaceKeyByRootDocumentId,
     });
 
     this._indexer = new Indexer({

--- a/packages/experimental/react-metagraph/src/useMetagraph.tsx
+++ b/packages/experimental/react-metagraph/src/useMetagraph.tsx
@@ -62,7 +62,7 @@ export const useModules = (query: Query, { polling }: UseModulesOptions = {}): M
       return;
     }
 
-    let interval: NodeJS.Timeout;
+    let interval: any;
     let unsubscribe: () => void | undefined;
     setTimeout(async () => {
       const observable = await metagraph.modules.query(query);

--- a/packages/sdk/client-services/src/packlets/services/service-context.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-context.ts
@@ -154,6 +154,7 @@ export class ServiceContext extends Resource {
     this.echoHost = new EchoHost({
       kv: this.level,
       peerIdProvider: () => this.identityManager.identity?.deviceKey?.toHex(),
+      getSpaceKeyByRootDocumentId: (documentId) => this.spaceManager.findSpaceByRootDocumentId(documentId)?.key,
     });
 
     this._meshReplicator = new MeshEchoReplicator();


### PR DESCRIPTION
### Details

Fixes two edge cases of sharePolicy check for documents not present locally. Was caught by a consistently failing test in edge.
1. Root document replication right after a space invite. We don't have the document locally to check access.spaceKey, but we can't open the space to start collection-sync, so the space gets stuck in `initializing` state.
2. Another potential edge-case that came to mind while working on a fix. Peer A creates a document and sends a sync to B before collection-sync completes for B to learn which space the new document belongs to. When collection-sync completes B won't start replication with A because `sharePolicy: false` was cached on automerge-repo level.