### PR TITLE
feat: added email trigger type

### DIFF
--- a/packages/core/functions/src/types/types.ts
+++ b/packages/core/functions/src/types/types.ts
@@ -13,6 +13,7 @@ export enum TriggerKind {
   Timer = 'timer',
   Webhook = 'webhook',
   Subscription = 'subscription',
+  Email = 'email',
 }
 
 // TODO(burdon): Rename prop kind.
@@ -30,6 +31,12 @@ const TimerTriggerSchema = S.Struct({
 }).pipe(S.mutable);
 
 export type TimerTrigger = S.Schema.Type<typeof TimerTriggerSchema>;
+
+const EmailTriggerSchema = S.Struct({
+  type: S.Literal(TriggerKind.Email).annotations(typeLiteralAnnotations),
+}).pipe(S.mutable);
+
+export type EmailTrigger = S.Schema.Type<typeof EmailTriggerSchema>;
 
 /**
  * Webhook.
@@ -84,6 +91,7 @@ export const TriggerSchema = S.Union(
   TimerTriggerSchema,
   WebhookTriggerSchema,
   SubscriptionTriggerSchema,
+  EmailTriggerSchema,
 ).annotations({
   [AST.TitleAnnotationId]: 'Trigger',
 });

--- a/packages/plugins/experimental/plugin-automation/src/translations.ts
+++ b/packages/plugins/experimental/plugin-automation/src/translations.ts
@@ -29,6 +29,7 @@ export default [
         'trigger type webhook': 'Webhook',
         'trigger type websocket': 'Websocket',
         'trigger type subscription': 'Subscription',
+        'trigger type email': 'Email',
 
         'trigger filter': 'Filter',
         'trigger cron': 'Cron',


### PR DESCRIPTION
### Details

* Added `Email` trigger type to allowed schema literals list.
* Updated plugin automation to provide a "copy" action.
* Set `automationTargetId` in trigger meta.