### PR TITLE
fix: Add direct `outDir` to improve JetBrains IDE support

### DIFF
--- a/packages/apps/composer-crx/tsconfig.json
+++ b/packages/apps/composer-crx/tsconfig.json
@@ -10,6 +10,7 @@
       "DOM",
       "ES6"
     ],
+    "outDir": "./dist/types",
     "rootDir": "src"
   },
   "include": [

--- a/packages/common/async/tsconfig.json
+++ b/packages/common/async/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings",
       "node"

--- a/packages/common/codec-protobuf/tsconfig.json
+++ b/packages/common/codec-protobuf/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/common/context/tsconfig.json
+++ b/packages/common/context/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/common/crypto-names/tsconfig.json
+++ b/packages/common/crypto-names/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "resolveJsonModule": true,
     "types": [
       "@dxos/typings"

--- a/packages/common/crypto/tsconfig.json
+++ b/packages/common/crypto/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "declarationDir": "dist/types",
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings",
       "node"

--- a/packages/common/debug/tsconfig.json
+++ b/packages/common/debug/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": [
       "DOM"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/common/display-name/tsconfig.json
+++ b/packages/common/display-name/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "resolveJsonModule": true,
     "types": [
       "@dxos/typings"

--- a/packages/common/effect/tsconfig.json
+++ b/packages/common/effect/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings"
     ]

--- a/packages/common/feed-store/tsconfig.json
+++ b/packages/common/feed-store/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings",
       "node"

--- a/packages/common/graph/tsconfig.json
+++ b/packages/common/graph/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": [
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/common/hypercore/tsconfig.json
+++ b/packages/common/hypercore/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings",
       "node"

--- a/packages/common/invariant/tsconfig.json
+++ b/packages/common/invariant/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "lib": [
       "DOM"
-    ]
+    ],
+    "outDir": "./dist/types"
   },
   "include": [
     "src",

--- a/packages/common/keyboard/tsconfig.json
+++ b/packages/common/keyboard/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": [
       "DOM",
       "ESNext"
-    ]
+    ],
+    "outDir": "./dist/types"
   },
   "include": [
     "src",

--- a/packages/common/keys/tsconfig.json
+++ b/packages/common/keys/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "include": [
     "src"
   ],

--- a/packages/common/kv-store/tsconfig.json
+++ b/packages/common/kv-store/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "include": [
     "src",
     "test"

--- a/packages/common/local-storage/tsconfig.json
+++ b/packages/common/local-storage/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "include": [
     "src"
   ],

--- a/packages/common/lock-file/tsconfig.json
+++ b/packages/common/lock-file/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "es2019"
     ],
+    "outDir": "./dist/types",
     "skipLibCheck": true,
     "types": [
       "@dxos/typings",

--- a/packages/common/log/tsconfig.json
+++ b/packages/common/log/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "lib": [
       "DOM"
-    ]
+    ],
+    "outDir": "./dist/types"
   },
   "include": [
     "src",

--- a/packages/common/merkle-search-tree/tsconfig.json
+++ b/packages/common/merkle-search-tree/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "include": [
     "src"
   ],

--- a/packages/common/node-std/tsconfig.json
+++ b/packages/common/node-std/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "include": [
     "src",
     "types"

--- a/packages/common/phoenix/tsconfig.json
+++ b/packages/common/phoenix/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "declarationDir": "dist/types",
     "module": "ESNext",
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings",
       "node"

--- a/packages/common/plate/tsconfig.json
+++ b/packages/common/plate/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "exclude": [
     "dist",
     "node_modules"

--- a/packages/common/random-access-storage/tsconfig.json
+++ b/packages/common/random-access-storage/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "es2019"
     ],
+    "outDir": "./dist/types",
     "skipLibCheck": true,
     "types": [
       "@dxos/typings",

--- a/packages/common/random/tsconfig.json
+++ b/packages/common/random/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "include": [
     "src",
     "test"

--- a/packages/common/storybook-utils/tsconfig.json
+++ b/packages/common/storybook-utils/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/common/test-utils/tsconfig.json
+++ b/packages/common/test-utils/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": [
       "DOM"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/common/timeframe/tsconfig.json
+++ b/packages/common/timeframe/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "include": [
     "src"
   ],

--- a/packages/common/tracing/tsconfig.json
+++ b/packages/common/tracing/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings",
       "node"

--- a/packages/common/typings/tsconfig.json
+++ b/packages/common/typings/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "include": [
     "src"
   ],

--- a/packages/common/util/tsconfig.json
+++ b/packages/common/util/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings",
       "node"

--- a/packages/core/agent/tsconfig.json
+++ b/packages/core/agent/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings"
     ]

--- a/packages/core/compute/tsconfig.json
+++ b/packages/core/compute/tsconfig.json
@@ -6,6 +6,7 @@
     ],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/core/echo/automerge/tsconfig.json
+++ b/packages/core/echo/automerge/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings"
     ]

--- a/packages/core/echo/echo-db/tsconfig.json
+++ b/packages/core/echo/echo-db/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings"
     ]

--- a/packages/core/echo/echo-generator/tsconfig.json
+++ b/packages/core/echo/echo-generator/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings"
     ]

--- a/packages/core/echo/echo-pipeline/tsconfig.json
+++ b/packages/core/echo/echo-pipeline/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings"
     ]

--- a/packages/core/echo/echo-protocol/tsconfig.json
+++ b/packages/core/echo/echo-protocol/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "include": [
     "src"
   ],

--- a/packages/core/echo/echo-query/tsconfig.json
+++ b/packages/core/echo/echo-query/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings"
     ]

--- a/packages/core/echo/echo-schema/tsconfig.json
+++ b/packages/core/echo/echo-schema/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings"
     ]

--- a/packages/core/echo/echo-signals/tsconfig.json
+++ b/packages/core/echo/echo-signals/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings"
     ]

--- a/packages/core/echo/indexing/tsconfig.json
+++ b/packages/core/echo/indexing/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings",
       "@types/node"

--- a/packages/core/echo/live-object/tsconfig.json
+++ b/packages/core/echo/live-object/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings"
     ]

--- a/packages/core/functions/tsconfig.json
+++ b/packages/core/functions/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings"
     ]

--- a/packages/core/halo/credentials/tsconfig.json
+++ b/packages/core/halo/credentials/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/core/halo/keyring/tsconfig.json
+++ b/packages/core/halo/keyring/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "include": [
     "src"
   ],

--- a/packages/core/mesh/edge-client/tsconfig.json
+++ b/packages/core/mesh/edge-client/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "include": [
     "src"
   ],

--- a/packages/core/mesh/messaging/tsconfig.json
+++ b/packages/core/mesh/messaging/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "include": [
     "src"
   ],

--- a/packages/core/mesh/network-manager/tsconfig.json
+++ b/packages/core/mesh/network-manager/tsconfig.json
@@ -4,7 +4,8 @@
     "lib": [
       "DOM",
       "ESNext"
-    ]
+    ],
+    "outDir": "./dist/types"
   },
   "include": [
     "network-manager.d.ts",

--- a/packages/core/mesh/rpc-tunnel/tsconfig.json
+++ b/packages/core/mesh/rpc-tunnel/tsconfig.json
@@ -4,7 +4,8 @@
     "lib": [
       "DOM",
       "ESNext"
-    ]
+    ],
+    "outDir": "./dist/types"
   },
   "include": [
     "src"

--- a/packages/core/mesh/rpc/tsconfig.json
+++ b/packages/core/mesh/rpc/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "exclude": [
     "node_modules"
   ],

--- a/packages/core/mesh/signal/tsconfig.json
+++ b/packages/core/mesh/signal/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "include": [
     "src/**/*"
   ],

--- a/packages/core/mesh/teleport-extension-automerge-replicator/tsconfig.json
+++ b/packages/core/mesh/teleport-extension-automerge-replicator/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings",
       "node"

--- a/packages/core/mesh/teleport-extension-gossip/tsconfig.json
+++ b/packages/core/mesh/teleport-extension-gossip/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings",
       "node"

--- a/packages/core/mesh/teleport-extension-object-sync/tsconfig.json
+++ b/packages/core/mesh/teleport-extension-object-sync/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings",
       "node"

--- a/packages/core/mesh/teleport-extension-replicator/tsconfig.json
+++ b/packages/core/mesh/teleport-extension-replicator/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings",
       "node"

--- a/packages/core/mesh/teleport/tsconfig.json
+++ b/packages/core/mesh/teleport/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "exclude": [
     "node_modules"
   ],

--- a/packages/core/mesh/websocket-rpc/tsconfig.json
+++ b/packages/core/mesh/websocket-rpc/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "include": [
     "src"
   ],

--- a/packages/devtools/devtools-extension/tsconfig.json
+++ b/packages/devtools/devtools-extension/tsconfig.json
@@ -10,6 +10,7 @@
       "DOM",
       "ES6"
     ],
+    "outDir": "./dist/types",
     "rootDir": "src"
   },
   "include": [

--- a/packages/devtools/devtools/tsconfig.json
+++ b/packages/devtools/devtools/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": [
       "DOM"
     ],
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings",
       "node"

--- a/packages/experimental/agent-functions/tsconfig.json
+++ b/packages/experimental/agent-functions/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": [
       "DOM",
       "ESNext"
-    ]
+    ],
+    "outDir": "./dist/types"
   },
   "exclude": [
     "functions"

--- a/packages/experimental/assistant/tsconfig.json
+++ b/packages/experimental/assistant/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "module": "ESNext",
+    "outDir": "./dist/types",
     "types": [
       "vite/types/import-meta"
     ]

--- a/packages/experimental/cf-labs/tsconfig.json
+++ b/packages/experimental/cf-labs/tsconfig.json
@@ -6,6 +6,7 @@
     ],
     "module": "Preserve",
     "moduleResolution": "Bundler",
+    "outDir": "./dist/types",
     "types": [
       "@cloudflare/workers-types"
     ]

--- a/packages/experimental/discord-bot/tsconfig.json
+++ b/packages/experimental/discord-bot/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": [
       "DOM",
       "ESNext"
-    ]
+    ],
+    "outDir": "./dist/types"
   },
   "include": [
     "src",

--- a/packages/experimental/gem-core/tsconfig.json
+++ b/packages/experimental/gem-core/tsconfig.json
@@ -4,7 +4,8 @@
     "lib": [
       "DOM",
       "ESNext"
-    ]
+    ],
+    "outDir": "./dist/types"
   },
   "include": [
     "src",

--- a/packages/experimental/gem-globe/tsconfig.json
+++ b/packages/experimental/gem-globe/tsconfig.json
@@ -6,6 +6,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "strict": false
   },
   "include": [

--- a/packages/experimental/gem-spore/tsconfig.json
+++ b/packages/experimental/gem-spore/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "strict": false
   },
   "include": [

--- a/packages/experimental/metagraph/tsconfig.json
+++ b/packages/experimental/metagraph/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": [
       "DOM",
       "ESNext"
-    ]
+    ],
+    "outDir": "./dist/types"
   },
   "include": [
     "src"

--- a/packages/experimental/react-metagraph/tsconfig.json
+++ b/packages/experimental/react-metagraph/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": [
       "DOM",
       "ESNext"
-    ]
+    ],
+    "outDir": "./dist/types"
   },
   "include": [
     "playwright",

--- a/packages/plugins/experimental/plugin-automation/tsconfig.json
+++ b/packages/plugins/experimental/plugin-automation/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/experimental/plugin-calls/tsconfig.json
+++ b/packages/plugins/experimental/plugin-calls/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/experimental/plugin-canvas/tsconfig.json
+++ b/packages/plugins/experimental/plugin-canvas/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/experimental/plugin-excalidraw/tsconfig.json
+++ b/packages/plugins/experimental/plugin-excalidraw/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/experimental/plugin-explorer/tsconfig.json
+++ b/packages/plugins/experimental/plugin-explorer/tsconfig.json
@@ -8,6 +8,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/experimental/plugin-inbox/tsconfig.json
+++ b/packages/plugins/experimental/plugin-inbox/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/experimental/plugin-ipfs/tsconfig.json
+++ b/packages/plugins/experimental/plugin-ipfs/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/experimental/plugin-kanban/tsconfig.json
+++ b/packages/plugins/experimental/plugin-kanban/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/experimental/plugin-map/tsconfig.json
+++ b/packages/plugins/experimental/plugin-map/tsconfig.json
@@ -8,6 +8,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/experimental/plugin-native/tsconfig.json
+++ b/packages/plugins/experimental/plugin-native/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/experimental/plugin-outliner/tsconfig.json
+++ b/packages/plugins/experimental/plugin-outliner/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/experimental/plugin-script/tsconfig.json
+++ b/packages/plugins/experimental/plugin-script/tsconfig.json
@@ -8,6 +8,7 @@
       "ESNext"
     ],
     "module": "ESNext",
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/experimental/plugin-search/tsconfig.json
+++ b/packages/plugins/experimental/plugin-search/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/experimental/plugin-template/tsconfig.json
+++ b/packages/plugins/experimental/plugin-template/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-attention/tsconfig.json
+++ b/packages/plugins/plugin-attention/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-chess/tsconfig.json
+++ b/packages/plugins/plugin-chess/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-client/tsconfig.json
+++ b/packages/plugins/plugin-client/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-debug/tsconfig.json
+++ b/packages/plugins/plugin-debug/tsconfig.json
@@ -9,6 +9,7 @@
     ],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-deck/tsconfig.json
+++ b/packages/plugins/plugin-deck/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-files/tsconfig.json
+++ b/packages/plugins/plugin-files/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-graph/tsconfig.json
+++ b/packages/plugins/plugin-graph/tsconfig.json
@@ -8,6 +8,7 @@
       "ESNext"
     ],
     "module": "ESNext",
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-help/tsconfig.json
+++ b/packages/plugins/plugin-help/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-markdown/tsconfig.json
+++ b/packages/plugins/plugin-markdown/tsconfig.json
@@ -9,6 +9,7 @@
     ],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings",
       "node"

--- a/packages/plugins/plugin-mermaid/tsconfig.json
+++ b/packages/plugins/plugin-mermaid/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-navtree/tsconfig.json
+++ b/packages/plugins/plugin-navtree/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-observability/tsconfig.json
+++ b/packages/plugins/plugin-observability/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-presenter/tsconfig.json
+++ b/packages/plugins/plugin-presenter/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-pwa/tsconfig.json
+++ b/packages/plugins/plugin-pwa/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-registry/tsconfig.json
+++ b/packages/plugins/plugin-registry/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-settings-interface/tsconfig.json
+++ b/packages/plugins/plugin-settings-interface/tsconfig.json
@@ -8,6 +8,7 @@
       "ESNext"
     ],
     "module": "ESNext",
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-sheet/tsconfig.json
+++ b/packages/plugins/plugin-sheet/tsconfig.json
@@ -9,6 +9,7 @@
     ],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-sketch/tsconfig.json
+++ b/packages/plugins/plugin-sketch/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-space/tsconfig.json
+++ b/packages/plugins/plugin-space/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-stack/tsconfig.json
+++ b/packages/plugins/plugin-stack/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-status-bar/tsconfig.json
+++ b/packages/plugins/plugin-status-bar/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-table/tsconfig.json
+++ b/packages/plugins/plugin-table/tsconfig.json
@@ -9,6 +9,7 @@
     ],
     "module": "ES2022",
     "moduleResolution": "bundler",
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-theme/tsconfig.json
+++ b/packages/plugins/plugin-theme/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-thread/tsconfig.json
+++ b/packages/plugins/plugin-thread/tsconfig.json
@@ -9,6 +9,7 @@
     ],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-token-manager/tsconfig.json
+++ b/packages/plugins/plugin-token-manager/tsconfig.json
@@ -8,6 +8,7 @@
       "ESNext"
     ],
     "module": "ESNext",
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/plugins/plugin-wildcard/tsconfig.json
+++ b/packages/plugins/plugin-wildcard/tsconfig.json
@@ -7,6 +7,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/sdk/app-graph/tsconfig.json
+++ b/packages/sdk/app-graph/tsconfig.json
@@ -6,6 +6,7 @@
       "ESNext"
     ],
     "module": "ESNext",
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/sdk/client-protocol/tsconfig.json
+++ b/packages/sdk/client-protocol/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/sdk/client-services/tsconfig.json
+++ b/packages/sdk/client-services/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings",
       "node"

--- a/packages/sdk/client/tsconfig.json
+++ b/packages/sdk/client/tsconfig.json
@@ -6,6 +6,7 @@
       "ESNext"
     ],
     "module": "ESNext",
+    "outDir": "./dist/types",
     "types": [
       "node",
       "sharedworker"

--- a/packages/sdk/config/tsconfig.json
+++ b/packages/sdk/config/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": [
       "DOM",
       "ESNext"
-    ]
+    ],
+    "outDir": "./dist/types"
   },
   "exclude": [
     "src/testing"

--- a/packages/sdk/migrations/tsconfig.json
+++ b/packages/sdk/migrations/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "./dist/types",
     "types": [
       "@dxos/typings"
     ]

--- a/packages/sdk/react-client/tsconfig.json
+++ b/packages/sdk/react-client/tsconfig.json
@@ -6,7 +6,8 @@
       "DOM",
       "ESNext"
     ],
-    "module": "ESNext"
+    "module": "ESNext",
+    "outDir": "./dist/types"
   },
   "include": [
     "playwright",

--- a/packages/sdk/schema/tsconfig.json
+++ b/packages/sdk/schema/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/sdk/shell/tsconfig.json
+++ b/packages/sdk/shell/tsconfig.json
@@ -6,6 +6,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/lit-grid/tsconfig.json
+++ b/packages/ui/lit-grid/tsconfig.json
@@ -7,6 +7,7 @@
       "ESNext"
     ],
     "module": "esnext",
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/primitives/react-hooks/tsconfig.json
+++ b/packages/ui/primitives/react-hooks/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/primitives/react-input/tsconfig.json
+++ b/packages/ui/primitives/react-input/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/primitives/react-list/tsconfig.json
+++ b/packages/ui/primitives/react-list/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-attention/tsconfig.json
+++ b/packages/ui/react-ui-attention/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-canvas/tsconfig.json
+++ b/packages/ui/react-ui-canvas/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-card/tsconfig.json
+++ b/packages/ui/react-ui-card/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-editor/tsconfig.json
+++ b/packages/ui/react-ui-editor/tsconfig.json
@@ -6,6 +6,7 @@
       "ESNext"
     ],
     "module": "ESNext",
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-form/tsconfig.json
+++ b/packages/ui/react-ui-form/tsconfig.json
@@ -7,6 +7,7 @@
     ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-grid/tsconfig.json
+++ b/packages/ui/react-ui-grid/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-kanban/tsconfig.json
+++ b/packages/ui/react-ui-kanban/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-list/tsconfig.json
+++ b/packages/ui/react-ui-list/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-menu/tsconfig.json
+++ b/packages/ui/react-ui-menu/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-mosaic/tsconfig.json
+++ b/packages/ui/react-ui-mosaic/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-searchlist/tsconfig.json
+++ b/packages/ui/react-ui-searchlist/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-stack/tsconfig.json
+++ b/packages/ui/react-ui-stack/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-syntax-highlighter/tsconfig.json
+++ b/packages/ui/react-ui-syntax-highlighter/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-table/tsconfig.json
+++ b/packages/ui/react-ui-table/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-tabs/tsconfig.json
+++ b/packages/ui/react-ui-tabs/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-text-tooltip/tsconfig.json
+++ b/packages/ui/react-ui-text-tooltip/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-theme/tsconfig.json
+++ b/packages/ui/react-ui-theme/tsconfig.json
@@ -7,6 +7,7 @@
     ],
     "module": "Preserve",
     "moduleResolution": "bundler",
+    "outDir": "./dist/types",
     "skipLibCheck": true,
     "types": [
       "node"

--- a/packages/ui/react-ui-thread/tsconfig.json
+++ b/packages/ui/react-ui-thread/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui-types/tsconfig.json
+++ b/packages/ui/react-ui-types/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/packages/ui/react-ui/tsconfig.json
+++ b/packages/ui/react-ui/tsconfig.json
@@ -5,6 +5,7 @@
       "DOM",
       "ESNext"
     ],
+    "outDir": "./dist/types",
     "types": [
       "node"
     ]

--- a/tools/executors/toolbox/src/toolbox.ts
+++ b/tools/executors/toolbox/src/toolbox.ts
@@ -41,6 +41,7 @@ export type ToolboxConfig = {
       include: string[];
     };
     noProjectReferences?: boolean;
+    noDirectOutDir?: boolean;
   };
 };
 
@@ -353,6 +354,10 @@ export class Toolbox {
           });
         } else {
           tsConfigJson.references = [];
+        }
+
+        if (!this.config.tsconfig?.noDirectOutDir) {
+          tsConfigJson.compilerOptions.outDir ??= `${project.path}/dist/types`;
         }
 
         const updated = sortJson(tsConfigJson, {

--- a/tools/executors/toolbox/src/toolbox.ts
+++ b/tools/executors/toolbox/src/toolbox.ts
@@ -356,7 +356,7 @@ export class Toolbox {
           tsConfigJson.references = [];
         }
 
-        if (!this.config.tsconfig?.noDirectOutDir && tsConfigJson.extends?.endsWith('tsconfig.base.json')) {
+        if (!this.config.tsconfig?.noDirectOutDir && `${tsConfigJson?.extends}`.endsWith('tsconfig.base.json')) {
           tsConfigJson.compilerOptions ??= {};
           tsConfigJson.compilerOptions.outDir ??= `${project.path}/dist/types`;
         }

--- a/tools/executors/toolbox/src/toolbox.ts
+++ b/tools/executors/toolbox/src/toolbox.ts
@@ -358,7 +358,7 @@ export class Toolbox {
 
         if (!this.config.tsconfig?.noDirectOutDir && `${tsConfigJson?.extends}`.endsWith('tsconfig.base.json')) {
           tsConfigJson.compilerOptions ??= {};
-          tsConfigJson.compilerOptions.outDir ??= `${project.path}/dist/types`;
+          tsConfigJson.compilerOptions.outDir ??= './dist/types';
         }
 
         const updated = sortJson(tsConfigJson, {

--- a/tools/executors/toolbox/src/toolbox.ts
+++ b/tools/executors/toolbox/src/toolbox.ts
@@ -356,7 +356,8 @@ export class Toolbox {
           tsConfigJson.references = [];
         }
 
-        if (!this.config.tsconfig?.noDirectOutDir) {
+        if (!this.config.tsconfig?.noDirectOutDir && tsConfigJson.extends?.endsWith('tsconfig.base.json')) {
+          tsConfigJson.compilerOptions ??= {};
           tsConfigJson.compilerOptions.outDir ??= `${project.path}/dist/types`;
         }
 

--- a/tools/lit-stories/tsconfig.json
+++ b/tools/lit-stories/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "exclude": [
     "dist",
     "node_modules",

--- a/tools/stories/tsconfig.json
+++ b/tools/stories/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
   "exclude": [
     "dist",
     "node_modules",


### PR DESCRIPTION
This PR augments `toolbox` to add an explicit `"outdir": "./dist/types"` for `tsconfig.json`s that inherit from `tsconfig.base.json`.

`tsconfig.base.json` has `"outDir": "${configDir}/dist/types" [which JB IDEs don’t yet understand](https://youtrack.jetbrains.com/issue/WEB-71210/Auto-import-not-following-exports-field-in-monorepo-siblings-package.json#focus=Comments-27-11402859.0-0).

This appears to resolve syntax highlighting and auto-import issues (for me) in WebStorm. Before this fix, the following imported names were all white (meaning unknown):

<img width="671" alt="Screenshot 2025-01-20 at 22 34 43" src="https://github.com/user-attachments/assets/89dcde62-0bbf-4823-b0f2-4fe233f2a716" />
