### PR TITLE
fix: Restore `iconOnly` in EditorToolbar.

### DIFF
--- a/packages/ui/react-ui-editor/src/components/EditorToolbar/EditorToolbar.tsx
+++ b/packages/ui/react-ui-editor/src/components/EditorToolbar/EditorToolbar.tsx
@@ -84,9 +84,6 @@ const createToolbar = ({
   return { nodes, edges };
 };
 
-//
-// Root
-//
 const useEditorToolbarActionGraph = ({ onAction, ...props }: EditorToolbarProps) => {
   const menuCreator = useCallback(() => createToolbar(props), [props]);
 

--- a/packages/ui/react-ui-editor/src/components/EditorToolbar/util.ts
+++ b/packages/ui/react-ui-editor/src/components/EditorToolbar/util.ts
@@ -60,6 +60,6 @@ export const createEditorActionGroup = (
   id: string,
   props: Omit<ToolbarMenuActionGroupProperties, 'icon'>,
   icon?: string,
-) => createMenuItemGroup(id, { icon, ...props });
+) => createMenuItemGroup(id, { icon, iconOnly: true, ...props });
 
 export const editorToolbarSearch = createEditorAction({ type: 'search' }, 'ph--magnifying-glass--regular');


### PR DESCRIPTION
This PR
- fixes an issue where EditorToolbar was not specifying `iconOnly` when it should

<img width="1068" alt="Screenshot 2025-01-24 at 15 45 18" src="https://github.com/user-attachments/assets/f705ca6c-a31b-4c55-b8dd-bd40fc740258" />
