### PR TITLE
fix(plugin-deck): Deduplicate sidebar toggle in empty state

### DIFF
--- a/packages/plugins/plugin-deck/src/components/DeckLayout/ContentEmpty.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/ContentEmpty.tsx
@@ -14,10 +14,10 @@ export const ContentEmpty = () => {
   return (
     <div
       role='none'
-      className='min-bs-screen is-dvw sm:is-full p-8 grid grid-rows-[var(--rail-size)_1fr]'
+      className='min-bs-screen is-dvw sm:is-full p-8 grid grid-rows-[var(--rail-size)_1fr] lg:grid-rows-1'
       data-testid='layoutPlugin.firstRunMessage'
     >
-      <div role='toolbar' className={mx(soloInlinePadding, 'flex items-stretch')}>
+      <div role='toolbar' className={mx(soloInlinePadding, 'flex items-stretch lg:hidden')}>
         <ToggleSidebarButton />
         <span role='none' className='grow' />
       </div>

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/ContentEmpty.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/ContentEmpty.tsx
@@ -17,7 +17,7 @@ export const ContentEmpty = () => {
       className='min-bs-screen is-dvw sm:is-full p-8 grid grid-rows-[var(--rail-size)_1fr] lg:grid-rows-1'
       data-testid='layoutPlugin.firstRunMessage'
     >
-      <div role='toolbar' className={mx(soloInlinePadding, 'flex items-stretch lg:hidden')}>
+      <div role='toolbar' className={mx(soloInlinePadding, 'bs-[--rail-action] flex items-stretch lg:hidden')}>
         <ToggleSidebarButton />
         <span role='none' className='grow' />
       </div>


### PR DESCRIPTION
This PR addresses one concern from #8550.

<img width="1556" alt="Screenshot 2025-02-04 at 14 30 14" src="https://github.com/user-attachments/assets/8ee437f0-4fe6-4bcc-b836-0064ccff1125" />
<img width="976" alt="Screenshot 2025-02-04 at 14 30 08" src="https://github.com/user-attachments/assets/d1821abc-cfd6-487f-b2fa-a16641a1f52d" />
