### PR TITLE
fix(react-ui-stack): Remove tooltip from StackItemSigil

### DIFF
--- a/packages/ui/react-ui-stack/src/components/StackItemSigil.tsx
+++ b/packages/ui/react-ui-stack/src/components/StackItemSigil.tsx
@@ -6,15 +6,7 @@ import React, { Fragment, type PropsWithChildren, forwardRef, useRef, useState }
 
 import { type ActionLike } from '@dxos/app-graph';
 import { keySymbols } from '@dxos/keyboard';
-import {
-  Button,
-  type ButtonProps,
-  DropdownMenu,
-  Icon,
-  toLocalizedString,
-  Tooltip,
-  useTranslation,
-} from '@dxos/react-ui';
+import { Button, type ButtonProps, DropdownMenu, Icon, toLocalizedString, useTranslation } from '@dxos/react-ui';
 import { type AttendableId, type Related, useAttention } from '@dxos/react-ui-attention';
 import { descriptionText, mx } from '@dxos/react-ui-theme';
 import { getHostPlatform } from '@dxos/util';
@@ -68,103 +60,82 @@ export const StackItemSigil = forwardRef<HTMLButtonElement, StackItemSigilProps>
     const suppressNextTooltip = useRef(false);
 
     const [optionsMenuOpen, setOptionsMenuOpen] = useState(false);
-    const [triggerTooltipOpen, setTriggerTooltipOpen] = useState(false);
 
     return (
-      <Tooltip.Root
-        open={triggerTooltipOpen}
-        onOpenChange={(nextOpen) => {
-          if (suppressNextTooltip.current) {
-            setTriggerTooltipOpen(false);
-            suppressNextTooltip.current = false;
-          } else {
-            setTriggerTooltipOpen(nextOpen);
-          }
+      <DropdownMenu.Root
+        {...{
+          open: optionsMenuOpen,
+          onOpenChange: (nextOpen: boolean) => {
+            if (!nextOpen) {
+              suppressNextTooltip.current = true;
+            }
+            return setOptionsMenuOpen(nextOpen);
+          },
         }}
       >
-        <DropdownMenu.Root
-          {...{
-            open: optionsMenuOpen,
-            onOpenChange: (nextOpen: boolean) => {
-              if (!nextOpen) {
-                suppressNextTooltip.current = true;
-              }
-              return setOptionsMenuOpen(nextOpen);
-            },
-          }}
-        >
-          <Tooltip.Trigger asChild>
-            <DropdownMenu.Trigger asChild ref={forwardedRef}>
-              <StackItemSigilButton attendableId={attendableId} related={related}>
-                <span className='sr-only'>{triggerLabel}</span>
-                <Icon icon={icon} size={5} />
-              </StackItemSigilButton>
-            </DropdownMenu.Trigger>
-          </Tooltip.Trigger>
-          <DropdownMenu.Portal>
-            <DropdownMenu.Content classNames='z-[31]'>
-              <DropdownMenu.Viewport>
-                {actionGroups?.map((actions, index) => {
-                  const separator = index > 0 ? <DropdownMenu.Separator /> : null;
-                  return (
-                    <Fragment key={index}>
-                      {separator}
-                      {actions.map((action) => {
-                        const shortcut =
-                          typeof action.properties.keyBinding === 'string'
-                            ? action.properties.keyBinding
-                            : action.properties.keyBinding?.[getHostPlatform()];
+        <DropdownMenu.Trigger asChild ref={forwardedRef}>
+          <StackItemSigilButton attendableId={attendableId} related={related}>
+            <span className='sr-only'>{triggerLabel}</span>
+            <Icon icon={icon} size={5} />
+          </StackItemSigilButton>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content classNames='z-[31]'>
+            <DropdownMenu.Viewport>
+              {actionGroups?.map((actions, index) => {
+                const separator = index > 0 ? <DropdownMenu.Separator /> : null;
+                return (
+                  <Fragment key={index}>
+                    {separator}
+                    {actions.map((action) => {
+                      const shortcut =
+                        typeof action.properties.keyBinding === 'string'
+                          ? action.properties.keyBinding
+                          : action.properties.keyBinding?.[getHostPlatform()];
 
-                        const menuItemType = action.properties.menuItemType;
-                        const Root = menuItemType === 'toggle' ? DropdownMenu.CheckboxItem : DropdownMenu.Item;
+                      const menuItemType = action.properties.menuItemType;
+                      const Root = menuItemType === 'toggle' ? DropdownMenu.CheckboxItem : DropdownMenu.Item;
 
-                        return (
-                          <Root
-                            key={action.id}
-                            onClick={(event) => {
-                              if (action.properties.disabled) {
-                                return;
-                              }
-                              event.stopPropagation();
-                              // TODO(thure): Why does Dialog’s modal-ness cause issues if we don’t explicitly close the menu here?
-                              suppressNextTooltip.current = true;
-                              setOptionsMenuOpen(false);
-                              onAction?.(action);
-                            }}
-                            classNames='gap-2'
-                            disabled={action.properties.disabled}
-                            checked={menuItemType === 'toggle' ? action.properties.isChecked : undefined}
-                            {...(action.properties?.testId && { 'data-testid': action.properties.testId })}
-                          >
-                            <Icon icon={action.properties.icon ?? 'ph--placeholder--regular'} size={4} />
-                            <span className='grow truncate'>{toLocalizedString(action.properties.label ?? '', t)}</span>
-                            {menuItemType === 'toggle' && (
-                              <DropdownMenu.ItemIndicator asChild>
-                                <Icon icon='ph--check--regular' size={4} />
-                              </DropdownMenu.ItemIndicator>
-                            )}
-                            {shortcut && (
-                              <span className={mx('shrink-0', descriptionText)}>{keySymbols(shortcut).join('')}</span>
-                            )}
-                          </Root>
-                        );
-                      })}
-                    </Fragment>
-                  );
-                })}
-                {children}
-              </DropdownMenu.Viewport>
-              <DropdownMenu.Arrow />
-            </DropdownMenu.Content>
-          </DropdownMenu.Portal>
-        </DropdownMenu.Root>
-        <Tooltip.Portal>
-          <Tooltip.Content side='bottom'>
-            {triggerLabel}
-            <Tooltip.Arrow />
-          </Tooltip.Content>
-        </Tooltip.Portal>
-      </Tooltip.Root>
+                      return (
+                        <Root
+                          key={action.id}
+                          onClick={(event) => {
+                            if (action.properties.disabled) {
+                              return;
+                            }
+                            event.stopPropagation();
+                            // TODO(thure): Why does Dialog’s modal-ness cause issues if we don’t explicitly close the menu here?
+                            suppressNextTooltip.current = true;
+                            setOptionsMenuOpen(false);
+                            onAction?.(action);
+                          }}
+                          classNames='gap-2'
+                          disabled={action.properties.disabled}
+                          checked={menuItemType === 'toggle' ? action.properties.isChecked : undefined}
+                          {...(action.properties?.testId && { 'data-testid': action.properties.testId })}
+                        >
+                          <Icon icon={action.properties.icon ?? 'ph--placeholder--regular'} size={4} />
+                          <span className='grow truncate'>{toLocalizedString(action.properties.label ?? '', t)}</span>
+                          {menuItemType === 'toggle' && (
+                            <DropdownMenu.ItemIndicator asChild>
+                              <Icon icon='ph--check--regular' size={4} />
+                            </DropdownMenu.ItemIndicator>
+                          )}
+                          {shortcut && (
+                            <span className={mx('shrink-0', descriptionText)}>{keySymbols(shortcut).join('')}</span>
+                          )}
+                        </Root>
+                      );
+                    })}
+                  </Fragment>
+                );
+              })}
+              {children}
+            </DropdownMenu.Viewport>
+            <DropdownMenu.Arrow />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
     );
   },
 );


### PR DESCRIPTION
This PR:
- removes SackItemSigil’s tooltip, since the sigil is often autofocused on mount and the tooltip is not necessary in this case