### PR TITLE
fix: CSS layers

### DIFF
--- a/packages/apps/testbench-app/src/components/AppToolbar.tsx
+++ b/packages/apps/testbench-app/src/components/AppToolbar.tsx
@@ -23,16 +23,16 @@ export const AppToolbar = ({ onHome, onProfile, onDevtools }: AppToolbarProps) =
 
   return (
     <div className='flex shrink-0 items-center p-1'>
-      <Button variant='ghost' classNames='!px-[5px] text-primary-500' onClick={onHome}>
+      <Button variant='ghost' classNames='pli-[5px] text-primary-500' onClick={onHome}>
         <Bug className={getSize(6)} />
       </Button>
-      <Button variant='ghost' classNames='!px-[5px] text-primary-500' onClick={onDevtools}>
+      <Button variant='ghost' classNames='pli-[5px] text-primary-500' onClick={onDevtools}>
         <Hammer className={getSize(6)} />
       </Button>
       <div className='grow' />
       <div className='flex gap-2 items-center'>
         <div className='font-mono'>{identity?.identityKey.truncate()}</div>
-        <Button classNames='!px-[7px]' onClick={onProfile}>
+        <Button classNames='pli-[7px]' onClick={onProfile}>
           <User className={getSize(5)} />
         </Button>
       </div>

--- a/packages/apps/testbench-app/src/components/ItemList.tsx
+++ b/packages/apps/testbench-app/src/components/ItemList.tsx
@@ -114,7 +114,7 @@ const Editor = ({ object, prop }: { object: ReactiveEchoObject<any>; prop: strin
       extensions: [
         createBasicExtensions(),
         createMarkdownExtensions({ themeMode }),
-        createThemeExtensions({ themeMode, slots: { content: { className: '!p-0' } } }),
+        createThemeExtensions({ themeMode, slots: { content: { className: 'p-0' } } }),
         automerge(createDocAccessor(object, [prop])),
       ],
     };

--- a/packages/devtools/devtools/src/components/performance/StatsPanel.tsx
+++ b/packages/devtools/devtools/src/components/performance/StatsPanel.tsx
@@ -105,7 +105,7 @@ export const StatsPanel = ({ stats, onRefresh }: QueryPanelProps) => {
         info={
           <Toggle
             pressed={live}
-            classNames='!bg-transparent !p-0'
+            classNames='bg-transparent p-0'
             density='fine'
             value='ghost'
             onClick={handleToggleLive}

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/PlankControls.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/PlankControls.tsx
@@ -59,7 +59,7 @@ export const PlankControls = forwardRef<HTMLDivElement, PlankControlsProps>(
     forwardedRef,
   ) => {
     const { t } = useTranslation(DECK_PLUGIN);
-    const buttonClassNames = variant === 'hide-disabled' ? 'disabled:hidden !pli-2 !plb-3' : '!pli-2 !plb-3';
+    const buttonClassNames = variant === 'hide-disabled' ? 'disabled:hidden pli-2 plb-3' : 'pli-2 plb-3';
 
     return (
       <ButtonGroup {...props} classNames={['app-no-drag', classNames]} ref={forwardedRef}>

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/SidebarButton.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/SidebarButton.tsx
@@ -72,7 +72,7 @@ export const CloseComplementarySidebarButton = () => {
       size={4}
       icon='ph--caret-line-right--regular'
       label={t('close complementary sidebar label')}
-      classNames='!rounded-none border-is border-separator dx-focus-ring-inset pie-2 lg:pie-[max(.5rem,env(safe-area-inset-right))]'
+      classNames='rounded-none border-is border-separator dx-focus-ring-inset pie-2 lg:pie-[max(.5rem,env(safe-area-inset-right))]'
       onClick={() => (layoutContext.complementarySidebarOpen = false)}
     />
   );

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/SidebarButton.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/SidebarButton.tsx
@@ -25,7 +25,7 @@ export const ToggleSidebarButton = ({
       onClick={() =>
         (layoutContext.sidebarState = layoutContext.sidebarState === 'expanded' ? 'collapsed' : 'expanded')
       }
-      classNames={['!pli-2 order-first', classNames]}
+      classNames={['pli-2 order-first', classNames]}
     />
   );
 };
@@ -41,7 +41,7 @@ export const CloseSidebarButton = () => {
       size={4}
       label={t('close navigation sidebar label')}
       onClick={() => (layoutContext.sidebarState = 'collapsed')}
-      classNames='!rounded-none !pli-1 dx-focus-ring-inset pie-[max(.5rem,env(safe-area-inset-left))]'
+      classNames='rounded-none pli-1 dx-focus-ring-inset pie-[max(.5rem,env(safe-area-inset-left))]'
     />
   );
 };
@@ -55,7 +55,7 @@ export const ToggleComplementarySidebarButton = () => {
       onClick={() => (layoutContext.complementarySidebarOpen = !layoutContext.complementarySidebarOpen)}
       variant='ghost'
       label={t('open complementary sidebar label')}
-      classNames='!pli-2 !plb-3 [&>svg]:-scale-x-100'
+      classNames='pli-2 plb-3 [&>svg]:-scale-x-100'
       icon='ph--sidebar-simple--regular'
       size={4}
     />

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/SidebarButton.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/SidebarButton.tsx
@@ -41,7 +41,7 @@ export const CloseSidebarButton = () => {
       size={4}
       label={t('close navigation sidebar label')}
       onClick={() => (layoutContext.sidebarState = 'collapsed')}
-      classNames='!rounded-none !pli-1 ch-focus-ring-inset pie-[max(.5rem,env(safe-area-inset-left))]'
+      classNames='!rounded-none !pli-1 dx-focus-ring-inset pie-[max(.5rem,env(safe-area-inset-left))]'
     />
   );
 };
@@ -72,7 +72,7 @@ export const CloseComplementarySidebarButton = () => {
       size={4}
       icon='ph--caret-line-right--regular'
       label={t('close complementary sidebar label')}
-      classNames='!rounded-none border-is border-separator ch-focus-ring-inset pie-2 lg:pie-[max(.5rem,env(safe-area-inset-right))]'
+      classNames='!rounded-none border-is border-separator dx-focus-ring-inset pie-2 lg:pie-[max(.5rem,env(safe-area-inset-right))]'
       onClick={() => (layoutContext.complementarySidebarOpen = false)}
     />
   );

--- a/packages/plugins/plugin-navtree/src/components/CommandsTrigger.tsx
+++ b/packages/plugins/plugin-navtree/src/components/CommandsTrigger.tsx
@@ -17,7 +17,7 @@ export const CommandsTrigger = () => {
   const { t } = useTranslation(NAVTREE_PLUGIN);
   return (
     <Button
-      classNames='m-1 !pli-1 lg:!pli-2'
+      classNames='m-1 pli-1 lg:pli-2'
       onClick={() =>
         dispatch(
           createIntent(LayoutAction.UpdateDialog, {

--- a/packages/plugins/plugin-navtree/src/components/L0Menu.tsx
+++ b/packages/plugins/plugin-navtree/src/components/L0Menu.tsx
@@ -74,7 +74,7 @@ const L0Item = ({ item, parent, path, pinned }: L0ItemProps) => {
           {...(rootProps as any)}
           data-type={type}
           className={mx(
-            'group/l0i ch-focus-ring-group grid overflow-hidden relative data[type!="collection"]:cursor-pointer app-no-drag',
+            'group/l0i dx-focus-ring-group grid overflow-hidden relative data[type!="collection"]:cursor-pointer app-no-drag',
             l0Breakpoints[item.properties.l0Breakpoint],
           )}
         >
@@ -82,7 +82,7 @@ const L0Item = ({ item, parent, path, pinned }: L0ItemProps) => {
             <div
               role='none'
               className={mx(
-                'absolute -z-[1] group-hover/l0i:bg-input ch-focus-ring-group-indicator transition-colors',
+                'absolute -z-[1] group-hover/l0i:bg-input dx-focus-ring-group-indicator transition-colors',
                 type === 'tab' || pinned ? 'rounded' : 'rounded-full',
                 pinned ? 'bg-transparent inset-inline-3 inset-block-1' : 'bg-input inset-inline-3 inset-block-2',
               )}

--- a/packages/plugins/plugin-navtree/src/components/NavTreeItemAction.tsx
+++ b/packages/plugins/plugin-navtree/src/components/NavTreeItemAction.tsx
@@ -28,7 +28,7 @@ const actionButtonProps = {
   size: 4 as const,
   variant: 'ghost' as const,
   density: 'fine' as const,
-  classNames: mx('shrink-0 !pli-2 pointer-fine:!pli-1', hoverableControlItem, hoverableOpenControlItem),
+  classNames: mx('shrink-0 pli-2 pointer-fine:pli-1', hoverableControlItem, hoverableOpenControlItem),
 };
 
 export const NavTreeItemActionDropdownMenu = ({

--- a/packages/plugins/plugin-presenter/testing/deck.md
+++ b/packages/plugins/plugin-presenter/testing/deck.md
@@ -21,7 +21,7 @@ Join us on 𝕏 and Discord <!-- .element: class="!text-center" -->
 -->
 
 ## Mission Statement
-<!-- .element: class="!text-center p-0" -->
+<!-- .element: class="!text-center !p-0" -->
 
 > To enable open source developers to build «&nbsp;commercially-competitive&nbsp;» privacy-preserving applications.
 
@@ -132,7 +132,7 @@ KUBE
 -->
 
 # Composer 
-<!-- .element: class="!text-center p-0" -->
+<!-- .element: class="!text-center !p-0" -->
 
 > *Super App*: n. A mobile or web application that integrates a wide variety of services and functions into a single platform.
 

--- a/packages/plugins/plugin-presenter/testing/deck.md
+++ b/packages/plugins/plugin-presenter/testing/deck.md
@@ -21,7 +21,7 @@ Join us on 𝕏 and Discord <!-- .element: class="!text-center" -->
 -->
 
 ## Mission Statement
-<!-- .element: class="!text-center !p-0" -->
+<!-- .element: class="!text-center p-0" -->
 
 > To enable open source developers to build «&nbsp;commercially-competitive&nbsp;» privacy-preserving applications.
 
@@ -132,7 +132,7 @@ KUBE
 -->
 
 # Composer 
-<!-- .element: class="!text-center !p-0" -->
+<!-- .element: class="!text-center p-0" -->
 
 > *Super App*: n. A mobile or web application that integrates a wide variety of services and functions into a single platform.
 

--- a/packages/plugins/plugin-sheet/src/components/GridSheet/util.ts
+++ b/packages/plugins/plugin-sheet/src/components/GridSheet/util.ts
@@ -89,7 +89,7 @@ const gridCellGetter = (model: SheetModel) => {
 
 export const rowLabelCell = (row: number) => ({
   value: rowToA1Notation(row),
-  className: 'text-end !pie-1 text-subdued',
+  className: 'text-end pie-1 text-subdued',
   resizeHandle: 'row',
 });
 

--- a/packages/plugins/plugin-status-bar/src/components/StatusBar.tsx
+++ b/packages/plugins/plugin-status-bar/src/components/StatusBar.tsx
@@ -23,7 +23,7 @@ const StatusBarButton = forwardRef<HTMLButtonElement, StatusBarButtonProps>(
   ({ classNames, children, asChild, ...props }, forwardedRef) => {
     const classes = mx(
       'flex items-center gap-2 p-1 px-2 rounded-sm',
-      'select-none cursor-pointer ch-focus-ring',
+      'select-none cursor-pointer dx-focus-ring',
       'hover:bg-neutral-75 active:bg-neutral-150 dark:hover:bg-neutral-750 dark:active:bg-neutral-700',
       classNames,
     );
@@ -69,7 +69,7 @@ const StatusBarContainer = forwardRef<HTMLDivElement, StatusBarContainerProps>(
         tabIndex={0}
         {...groupAttrs}
         className={mx(
-          'bs-[--statusbar-size] flex justify-end items-center gap-2 bg-base text-description text-lg pointer-fine:text-xs ch-focus-ring-inset',
+          'bs-[--statusbar-size] flex justify-end items-center gap-2 bg-base text-description text-lg pointer-fine:text-xs dx-focus-ring-inset',
           classNames,
         )}
         ref={forwardedRef}

--- a/packages/sdk/shell/src/components/AgentConfig.tsx
+++ b/packages/sdk/shell/src/components/AgentConfig.tsx
@@ -88,7 +88,7 @@ export const AgentConfig = ({
         <>
           <Button
             variant='ghost'
-            classNames='mlb-2 is-full justify-start gap-2 !pis-0 !pie-3'
+            classNames='mlb-2 is-full justify-start gap-2 pis-0 pie-3'
             data-testid={agentStatus === 'creatable' ? 'devices-panel.create-agent' : 'devices-panel.agent-error'}
             onClick={agentStatus === 'creatable' ? onAgentCreate : onAgentRefresh}
             aria-describedby='devices-panel.create-agent.description'

--- a/packages/sdk/shell/src/components/DeviceList/DeviceList.tsx
+++ b/packages/sdk/shell/src/components/DeviceList/DeviceList.tsx
@@ -42,7 +42,7 @@ export const DeviceList = ({
       )}
       <Button
         variant='ghost'
-        classNames='justify-start gap-2 !pis-0 !pie-3 is-full'
+        classNames='justify-start gap-2 pis-0 pie-3 is-full'
         data-testid='devices-panel.create-invitation'
         onClick={onClickAdd}
       >

--- a/packages/ui/lit-grid/src/dx-grid.lit-stories.ts
+++ b/packages/ui/lit-grid/src/dx-grid.lit-stories.ts
@@ -35,7 +35,7 @@ const initialLabels = {
     '0,0': { value: '', resizeHandle: 'col' },
   },
   frozenColsStart: [...Array(64)].reduce((acc, _, i) => {
-    acc[`0,${i}`] = { value: rowToA1Notation(i), className: 'text-end !pie-1', resizeHandle: 'row' };
+    acc[`0,${i}`] = { value: rowToA1Notation(i), className: 'text-end pie-1', resizeHandle: 'row' };
     return acc;
   }, {}),
   frozenRowsStart: [...Array(12)].reduce((acc, _, i) => {

--- a/packages/ui/react-ui-attention/src/components/AttentionProvider.tsx
+++ b/packages/ui/react-ui-attention/src/components/AttentionProvider.tsx
@@ -174,7 +174,7 @@ const AttendableContainer = forwardRef<HTMLDivElement, AttendableContainerProps>
         role='none'
         {...attendableAttrs}
         {...props}
-        className={mx('attention-surface', props.tabIndex === 0 && 'ch-focus-ring-inset-over-all', classNames)}
+        className={mx('attention-surface', props.tabIndex === 0 && 'dx-focus-ring-inset-over-all', classNames)}
         ref={forwardedRef}
       >
         {children}

--- a/packages/ui/react-ui-editor/src/extensions/markdown/decorate.ts
+++ b/packages/ui/react-ui-editor/src/extensions/markdown/decorate.ts
@@ -73,7 +73,7 @@ class CheckboxWidget extends WidgetType {
 
   override toDOM(view: EditorView) {
     const input = document.createElement('input');
-    input.className = 'cm-task-checkbox ch-checkbox';
+    input.className = 'cm-task-checkbox dx-checkbox';
     input.type = 'checkbox';
     input.tabIndex = -1;
     input.checked = this._checked;

--- a/packages/ui/react-ui-editor/src/styles/stack-item-content-class-names.ts
+++ b/packages/ui/react-ui-editor/src/styles/stack-item-content-class-names.ts
@@ -6,7 +6,7 @@ import { mx } from '@dxos/react-ui-theme';
 
 export const stackItemContentEditorClassNames = (role?: string) =>
   mx(
-    'ch-focus-ring-inset data-[toolbar=disabled]:pbs-2 attention-surface',
+    'dx-focus-ring-inset data-[toolbar=disabled]:pbs-2 attention-surface',
     role === 'article' ? 'min-bs-0' : '[&_.cm-scroller]:overflow-hidden [&_.cm-scroller]:min-bs-24',
   );
 

--- a/packages/ui/react-ui-grid/src/CellEditor/CellEditor.tsx
+++ b/packages/ui/react-ui-grid/src/CellEditor/CellEditor.tsx
@@ -143,7 +143,7 @@ export const CellEditor = ({ value, extension, autoFocus, onBlur, box, gridId }:
               className: '[&>.cm-scroller]:scrollbar-none tabular-nums',
             },
             content: {
-              className: '!border !border-transparent !pli-[4px] !plb-0.5',
+              className: 'border border-transparent pli-[4px] plb-0.5',
             },
           },
         }),

--- a/packages/ui/react-ui-grid/src/Grid/Grid.stories.tsx
+++ b/packages/ui/react-ui-grid/src/Grid/Grid.stories.tsx
@@ -25,7 +25,7 @@ const storybookInitialCells = (value?: string) => ({
   grid: {
     '1,1': {
       accessoryHtml:
-        '<button class="ch-button is-6 pli-0.5 min-bs-0 absolute inset-block-1 inline-end-1" data-story-action="menu"><svg><use href="/icons.svg#ph--arrow-right--regular"/></svg></button>',
+        '<button class="dx-button is-6 pli-0.5 min-bs-0 absolute inset-block-1 inline-end-1" data-story-action="menu"><svg><use href="/icons.svg#ph--arrow-right--regular"/></svg></button>',
       value: 'Weekly sales report',
     },
     '2,2': {

--- a/packages/ui/react-ui-list/src/components/Tree/TreeItemHeading.tsx
+++ b/packages/ui/react-ui-list/src/components/Tree/TreeItemHeading.tsx
@@ -51,14 +51,13 @@ export const TreeItemHeading = memo(
           asChild
           ref={forwardedRef}
         >
-          {/* TODO(wittjosiah): Class precedence. See #8149. */}
           <Button
             data-testid='treeItem.heading'
             variant='ghost'
             density='fine'
             classNames={mx(
-              'grow gap-2 !pis-0.5 hover:!bg-transparent dark:hover:!bg-transparent',
-              'disabled:!cursor-default disabled:!opacity-100',
+              'grow gap-2 pis-0.5 hover:bg-transparent dark:hover:bg-transparent',
+              'disabled:cursor-default disabled:opacity-100',
               className,
             )}
             disabled={disabled}

--- a/packages/ui/react-ui-list/src/components/Tree/TreeItemToggle.tsx
+++ b/packages/ui/react-ui-list/src/components/Tree/TreeItemToggle.tsx
@@ -23,7 +23,7 @@ export const TreeItemToggle = memo(
         aria-expanded={open}
         variant='ghost'
         density='fine'
-        classNames={mx('is-4 dx-focus-ring-inset !pli-0', hidden ? 'hidden' : !isBranch && 'invisible')}
+        classNames={mx('is-4 dx-focus-ring-inset pli-0', hidden ? 'hidden' : !isBranch && 'invisible')}
         onClick={onToggle}
       >
         <Icon

--- a/packages/ui/react-ui-list/src/components/Tree/TreeItemToggle.tsx
+++ b/packages/ui/react-ui-list/src/components/Tree/TreeItemToggle.tsx
@@ -23,7 +23,7 @@ export const TreeItemToggle = memo(
         aria-expanded={open}
         variant='ghost'
         density='fine'
-        classNames={mx('is-4 ch-focus-ring-inset !pli-0', hidden ? 'hidden' : !isBranch && 'invisible')}
+        classNames={mx('is-4 dx-focus-ring-inset !pli-0', hidden ? 'hidden' : !isBranch && 'invisible')}
         onClick={onToggle}
       >
         <Icon

--- a/packages/ui/react-ui-stack/src/components/StackItem.tsx
+++ b/packages/ui/react-ui-stack/src/components/StackItem.tsx
@@ -126,7 +126,7 @@ const StackItemRoot = forwardRef<HTMLDivElement, StackItemRootProps>(
           tabIndex={0}
           {...focusGroupAttrs}
           className={mx(
-            'group/stack-item grid relative ch-focus-ring-inset-over-all',
+            'group/stack-item grid relative dx-focus-ring-inset-over-all',
             size === 'min-content' && (orientation === 'horizontal' ? 'is-min' : 'bs-min'),
             orientation === 'horizontal' ? 'grid-rows-subgrid' : 'grid-cols-subgrid',
             rail && (orientation === 'horizontal' ? 'row-span-2' : 'col-span-2'),

--- a/packages/ui/react-ui-stack/src/components/StackItemHeading.tsx
+++ b/packages/ui/react-ui-stack/src/components/StackItemHeading.tsx
@@ -23,7 +23,7 @@ export const StackItemHeading = ({ children, classNames, ...props }: StackItemHe
       tabIndex={0}
       {...focusableGroupAttrs}
       className={mx(
-        'flex items-center ch-focus-ring-inset-over-all relative !border-is-0',
+        'flex items-center dx-focus-ring-inset-over-all relative !border-is-0',
         orientation === 'horizontal' ? 'bs-[--rail-size]' : 'is-[--rail-size] flex-col',
         classNames,
       )}

--- a/packages/ui/react-ui-table/src/util/table-buttons.ts
+++ b/packages/ui/react-ui-table/src/util/table-buttons.ts
@@ -39,7 +39,7 @@ const createButton = ({
     .join(' ');
 
   const positionClass = type === 'primary' ? 'inline-end-2' : 'inline-end-9';
-  return `<button ${attr} data-testid="${testId}" class="ch-button is-6 pli-0.5 min-bs-0 absolute inset-block-1 ${positionClass}" ${dataAttrs} ${disabled ? 'disabled' : ''}><svg><use href="/icons.svg#${icon}"/></svg></button>`;
+  return `<button ${attr} data-testid="${testId}" class="dx-button is-6 pli-0.5 min-bs-0 absolute inset-block-1 ${positionClass}" ${dataAttrs} ${disabled ? 'disabled' : ''}><svg><use href="/icons.svg#${icon}"/></svg></button>`;
 };
 
 const addColumnButton = {

--- a/packages/ui/react-ui-table/src/util/table-controls.ts
+++ b/packages/ui/react-ui-table/src/util/table-controls.ts
@@ -23,8 +23,8 @@ export const CONTROL_IDENTIFIERS = {
 } as const;
 
 const BASE_CLASSES = {
-  checkbox: 'absolute inset-block-[.375rem] inline-end-[.375rem] ch-checkbox',
-  switch: 'absolute inset-block-[.25rem] inline-end-[.25rem] ch-checkbox--switch',
+  checkbox: 'absolute inset-block-[.375rem] inline-end-[.375rem] dx-checkbox',
+  switch: 'absolute inset-block-[.25rem] inline-end-[.25rem] dx-checkbox--switch',
 } as const;
 
 const renderAttributes = (data: Record<string, string>) => {

--- a/packages/ui/react-ui-tabs/src/Tabs.tsx
+++ b/packages/ui/react-ui-tabs/src/Tabs.tsx
@@ -216,7 +216,7 @@ type TabsTabpanelProps = ThemedClassName<TabsPrimitive.TabsContentProps>;
 
 const TabsTabpanel = ({ classNames, children, ...props }: TabsTabpanelProps) => {
   return (
-    <TabsPrimitive.Content {...props} className={mx('ch-focus-ring-inset', classNames)}>
+    <TabsPrimitive.Content {...props} className={mx('dx-focus-ring-inset', classNames)}>
       {children}
     </TabsPrimitive.Content>
   );

--- a/packages/ui/react-ui-theme/package.json
+++ b/packages/ui/react-ui-theme/package.json
@@ -19,8 +19,8 @@
     "tailwind-config-viewer": "tailwind-config-viewer -o -c ./dist/plugin/node/config/tailwind.cjs"
   },
   "dependencies": {
-    "@ch-ui/tailwind-tokens": "^1.0.0",
-    "@ch-ui/tokens": "^1.0.0",
+    "@ch-ui/tailwind-tokens": "1.1.0",
+    "@ch-ui/tokens": "1.1.0",
     "@dxos/node-std": "workspace:*",
     "@fontsource-variable/inter": "5.0.16",
     "@fontsource-variable/jetbrains-mono": "5.0.21",

--- a/packages/ui/react-ui-theme/src/styles/components/button.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/button.ts
@@ -30,7 +30,7 @@ export type ButtonStyleProps = Partial<{
 }>;
 
 export const buttonRoot: ComponentFunction<ButtonStyleProps> = (_props, ...etc) => {
-  return mx('ch-button ch-focus-ring group', ...etc);
+  return mx('dx-button dx-focus-ring group', ...etc);
 };
 
 export const buttonGroup: ComponentFunction<{ elevation?: Elevation }> = (props, ...etc) => {

--- a/packages/ui/react-ui-theme/src/styles/components/icon-button.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/icon-button.ts
@@ -8,7 +8,7 @@ import { type ButtonStyleProps } from './button';
 import { mx } from '../../util';
 
 export const iconButtonRoot: ComponentFunction<ButtonStyleProps> = (_props, ...etc) => {
-  return mx('ch-icon-button ch-focus-ring gap-2 text-sm', ...etc);
+  return mx('ch-icon-button dx-focus-ring gap-2 text-sm', ...etc);
 };
 
 export const iconButtonTheme: Theme<ButtonStyleProps> = {

--- a/packages/ui/react-ui-theme/src/styles/components/input.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/input.ts
@@ -123,7 +123,7 @@ export const inputInput: ComponentFunction<InputStyleProps> = (props, ...etc) =>
         );
 
 export const inputCheckbox: ComponentFunction<InputStyleProps> = ({ size = 5 }, ...etc) =>
-  mx('ch-checkbox ch-focus-ring', getSize(size), ...etc);
+  mx('dx-checkbox dx-focus-ring', getSize(size), ...etc);
 
 export const inputCheckboxIndicator: ComponentFunction<InputStyleProps> = ({ size = 5, checked }, ...etc) =>
   mx(getSize(computeSize(sizeValue(size) * 0.65, 4)), !checked && 'invisible', ...etc);

--- a/packages/ui/react-ui-theme/src/styles/components/main.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/main.ts
@@ -16,24 +16,24 @@ export type MainStyleProps = Partial<{
 }>;
 
 export const mainSidebar: ComponentFunction<MainStyleProps> = (_, ...etc) =>
-  mx('ch-main-sidebar', 'ch-focus-ring-inset-over-all', ...etc);
+  mx('dx-main-sidebar', 'dx-focus-ring-inset-over-all', ...etc);
 
-export const mainPadding = 'ch-main-content-padding';
+export const mainPadding = 'dx-main-content-padding';
 
-export const mainPaddingTransitions = 'ch-main-content-padding-transitions';
+export const mainPaddingTransitions = 'dx-main-content-padding-transitions';
 
 export const mainContent: ComponentFunction<MainStyleProps> = ({ bounce, handlesFocus }, ...etc) =>
   mx(
     mainPadding,
     mainPaddingTransitions,
-    bounce && 'ch-main-bounce-layout',
-    handlesFocus && 'ch-focus-ring-inset-over-all',
+    bounce && 'dx-main-bounce-layout',
+    handlesFocus && 'dx-focus-ring-inset-over-all',
     ...etc,
   );
 
-export const mainIntrinsicSize = 'ch-main-intrinsic-size';
+export const mainIntrinsicSize = 'dx-main-intrinsic-size';
 
-export const mainOverlay: ComponentFunction<MainStyleProps> = (_, ...etc) => mx('ch-main-overlay', ...etc);
+export const mainOverlay: ComponentFunction<MainStyleProps> = (_, ...etc) => mx('dx-main-overlay', ...etc);
 
 export const mainTheme = {
   content: mainContent,

--- a/packages/ui/react-ui-theme/src/styles/components/treegrid.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/treegrid.ts
@@ -25,7 +25,7 @@ const levelStyles = new Map<number, string>([
 export const treegridRoot: ComponentFunction<TreegridStyleProps> = (_, ...etc) => mx('grid', ...etc);
 
 export const treegridRow: ComponentFunction<TreegridStyleProps> = ({ level = 1 }, ...etc) =>
-  mx('contents ch-focus-ring-inset', levelStyles.get(Math.min(Math.max(Math.round(level), 1), 8)), ...etc);
+  mx('contents dx-focus-ring-inset', levelStyles.get(Math.min(Math.max(Math.round(level), 1), 8)), ...etc);
 
 export const treegridCell: ComponentFunction<TreegridStyleProps> = ({ indent }, ...etc) =>
   mx(indent && 'indent', ...etc);

--- a/packages/ui/react-ui-theme/src/styles/fragments/focus.ts
+++ b/packages/ui/react-ui-theme/src/styles/fragments/focus.ts
@@ -2,7 +2,7 @@
 // Copyright 2022 DXOS.org
 //
 
-export const focusRing = 'ch-focus-ring';
+export const focusRing = 'dx-focus-ring';
 
 export const dropRing =
   'ring-1 ring-offset-0 ring-primary-350 ring-offset-white dark:ring-primary-450 dark:ring-offset-black';

--- a/packages/ui/react-ui-theme/src/styles/layers/anchored-overflow.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/anchored-overflow.css
@@ -1,4 +1,4 @@
-@layer components {
+@layer utilities {
   .overflow-anchored * {
     overflow-anchor: none;
   }

--- a/packages/ui/react-ui-theme/src/styles/layers/attention.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/attention.css
@@ -8,7 +8,7 @@
 }
 
 /* Utilities below control _how_ an element becomes attended. */
-@layer components {
+@layer dx-base {
   /* If an element is attended this attribute will be set. */
   [data-is-attention-source] {
     --surface-bg: var(--dx-attention);

--- a/packages/ui/react-ui-theme/src/styles/layers/base.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/base.css
@@ -1,0 +1,24 @@
+@layer dx-base {
+  :root {
+    touch-action: pan-x pan-y;
+    font-synthesis: none;
+    font-variation-settings: 'wght' 400,
+    'slnt' 0;
+    scroll-padding-block-start: theme(spacing.14);
+    scroll-padding-block-end: theme(spacing.2);
+  }
+
+  button {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .dark {
+    color: var(--surface-text);
+  }
+
+  html {
+    background-color: var(--surface-bg);
+    color: var(--surface-text);
+    @apply font-body;
+  }
+}

--- a/packages/ui/react-ui-theme/src/styles/layers/button.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/button.css
@@ -1,8 +1,8 @@
-/* TODO(thure): Focus is handled by .ch-focus-ring, but should ideally be applied as part of this component. */
+/* TODO(thure): Focus is handled by .dx-focus-ring, but should ideally be applied as part of this component. */
 @layer dx-components {
   /* Base styles */
-  .ch-button {
-    /* QUESTION(burdon): Why ch- prefix? How do we keep these consistent with TW styles (e.g., min-bs-, padding, font size.) */
+  .dx-button {
+    /* QUESTION(burdon): Why dx- prefix? How do we keep these consistent with TW styles (e.g., min-bs-, padding, font size.) */
     /* ANSWER(thure): These are not utility classes, these are component classes on a different layer, which themselves apply utility classes using `@apply`, as such they have a different naming scheme. The prefix can change, but I recommend following a webcomponent naming scheme rather than a CSS property naming scheme, since that is the corresponding scope of concern. */
     @apply font-medium shrink-0 inline-flex select-none items-center justify-center overflow-hidden transition-colors duration-100 ease-linear bg-input min-bs-[2.5rem] pli-3;
     &[aria-pressed='true'],
@@ -60,14 +60,14 @@
     }
   }
   /* Props */
-  .ch-button:not([data-props~='grouped']) {
+  .dx-button:not([data-props~='grouped']) {
     @apply rounded-sm;
   }
-  .ch-button:not([data-props~='wrap']) {
+  .dx-button:not([data-props~='wrap']) {
     @apply truncate;
   }
   @media (pointer: fine) {
-    .ch-button[data-density='fine'] {
+    .dx-button[data-density='fine'] {
       @apply min-bs-[2rem] pli-2.5;
     }
   }

--- a/packages/ui/react-ui-theme/src/styles/layers/button.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/button.css
@@ -1,10 +1,9 @@
 /* TODO(thure): Focus is handled by .ch-focus-ring, but should ideally be applied as part of this component. */
-/* TODO(thure): This should be on the `components` layer, but utility classes like `pli-0` weren’t getting precedence like they should. */
-@layer base {
+@layer dx-components {
   /* Base styles */
   .ch-button {
-    /* TODO(burdon): Why ch- prefix? How do we keep these consistent with TW styles (e.g., min-bs-, padding, font size.) */
-    /* TODO(burdon): font-medium? size changes when selected. */
+    /* QUESTION(burdon): Why ch- prefix? How do we keep these consistent with TW styles (e.g., min-bs-, padding, font size.) */
+    /* ANSWER(thure): These are not utility classes, these are component classes on a different layer, which themselves apply utility classes using `@apply`, as such they have a different naming scheme. The prefix can change, but I recommend following a webcomponent naming scheme rather than a CSS property naming scheme, since that is the corresponding scope of concern. */
     @apply font-medium shrink-0 inline-flex select-none items-center justify-center overflow-hidden transition-colors duration-100 ease-linear bg-input min-bs-[2.5rem] pli-3;
     &[aria-pressed='true'],
     &[aria-checked='true'] {

--- a/packages/ui/react-ui-theme/src/styles/layers/can-scroll.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/can-scroll.css
@@ -1,4 +1,4 @@
-@layer components {
+@layer dx-components {
   :root {
     --can-scroll-inline: initial;
   }

--- a/packages/ui/react-ui-theme/src/styles/layers/checkbox.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/checkbox.css
@@ -1,7 +1,7 @@
-/* TODO(thure): Focus is handled by .ch-focus-ring, but should ideally be applied as part of this component.*/
+/* TODO(thure): Focus is handled by .dx-focus-ring, but should ideally be applied as part of this component.*/
 @layer dx-components {
-  .ch-checkbox--switch,
-  .ch-checkbox {
+  .dx-checkbox--switch,
+  .dx-checkbox {
     &[aria-checked='true'],
     &[aria-checked='mixed'],
     &:checked {
@@ -21,13 +21,13 @@
     }
   }
 
-  .ch-checkbox {
+  .dx-checkbox {
     @apply is-4 bs-4 border-0 overflow-hidden shadow-inner transition-colors bg-unAccent accent-unAccent text-inverse shrink-0 inline-grid place-items-center rounded-sm;
   }
 
-  /* TODO(ZaymonFC): Focus is handled by .ch-focus-ring, but should ideally be applied as part of this component.*/
+  /* TODO(ZaymonFC): Focus is handled by .dx-focus-ring, but should ideally be applied as part of this component.*/
   /* NOTE: This isn't compatible with the Radix switch. */
-  .ch-checkbox--switch {
+  .dx-checkbox--switch {
     @apply inline-block appearance-none relative shrink-0 bs-5 is-8;
     @apply shadow-inner transition-colors bg-unAccent;
     @apply cursor-pointer rounded-full;

--- a/packages/ui/react-ui-theme/src/styles/layers/checkbox.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/checkbox.css
@@ -1,6 +1,5 @@
 /* TODO(thure): Focus is handled by .ch-focus-ring, but should ideally be applied as part of this component.*/
-/* TODO(thure): This should be on the `components` layer, but utility classes like `pli-0` weren’t getting precedence like they should. */
-@layer base {
+@layer dx-components {
   .ch-checkbox--switch,
   .ch-checkbox {
     &[aria-checked='true'],
@@ -29,7 +28,7 @@
   /* TODO(ZaymonFC): Focus is handled by .ch-focus-ring, but should ideally be applied as part of this component.*/
   /* NOTE: This isn't compatible with the Radix switch. */
   .ch-checkbox--switch {
-    @apply inline-block appearance-none relative shrink-0 bs-5 is-8  !bg-none;
+    @apply inline-block appearance-none relative shrink-0 bs-5 is-8;
     @apply shadow-inner transition-colors bg-unAccent;
     @apply cursor-pointer rounded-full;
 
@@ -41,6 +40,7 @@
     &[aria-checked='true'],
     &[aria-checked='mixed'],
     &:checked {
+      background-image: none;
       &::before {
         @apply translate-x-[100%];
       }

--- a/packages/ui/react-ui-theme/src/styles/layers/focus-ring.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/focus-ring.css
@@ -1,5 +1,5 @@
 @layer utilities {
-  .ch-focus-ring, .ch-focus-ring-inset {
+  .dx-focus-ring, .dx-focus-ring-inset {
     &:not([disabled]),
     &[disabled='false'] {
       &:focus {
@@ -24,17 +24,17 @@
     }
   }
 
-  .ch-focus-ring-group {
+  .dx-focus-ring-group {
     &:not([disabled]),
     &[disabled='false'] {
       &:focus {
         @apply outline-none;
       }
 
-      &:focus-visible .ch-focus-ring-group-indicator {
+      &:focus-visible .dx-focus-ring-group-indicator {
         @apply ring-2 ring-offset-0 ring-primary-350 ring-offset-white;
 
-        .dark & .ch-focus-ring-group-indicator {
+        .dark & .dx-focus-ring-group-indicator {
           @apply ring-primary-450 ring-offset-black;
         }
 
@@ -49,7 +49,7 @@
     }
   }
 
-  .ch-focus-ring-inset {
+  .dx-focus-ring-inset {
     &:not([disabled]),
     &[disabled='false'] {
       &:focus-visible {
@@ -58,7 +58,7 @@
     }
   }
 
-  .ch-focus-ring-inset-over-all, .ch-focus-ring-main[data-handles-focus="true"] {
+  .dx-focus-ring-inset-over-all, .dx-focus-ring-main[data-handles-focus="true"] {
     &:not([disabled]),
     &[disabled='false'] {
       &::after {
@@ -89,7 +89,7 @@
       }
     }
   }
-  .ch-focus-ring-inset-over-all {
+  .dx-focus-ring-inset-over-all {
     &:not([disabled]),
     &[disabled='false'] {
       &::after {
@@ -97,7 +97,7 @@
       }
     }
   }
-  .ch-focus-ring-main[data-handles-focus="true"] {
+  .dx-focus-ring-main[data-handles-focus="true"] {
     &:not([disabled]),
     &[disabled='false'] {
       &::after {

--- a/packages/ui/react-ui-theme/src/styles/layers/focus-ring.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/focus-ring.css
@@ -1,4 +1,4 @@
-@layer base {
+@layer utilities {
   .ch-focus-ring, .ch-focus-ring-inset {
     &:not([disabled]),
     &[disabled='false'] {

--- a/packages/ui/react-ui-theme/src/styles/layers/index.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/index.css
@@ -1,6 +1,6 @@
-@import './tokens.css';
 @import './anchored-overflow.css';
 @import './attention.css';
+@import './base.css';
 @import './button.css';
 @import './can-scroll.css';
 @import './checkbox.css';
@@ -10,6 +10,7 @@
 @import './native.css';
 @import './surfaces.css';
 @import './tldraw.css';
+@import './tokens.css';
 @import './typography.css';
 
-@layer tokens, user-tokens, base, components, utilities;
+@layer dx-tokens, user-tokens, tw-base, dx-base, tw-components, dx-components, utilities;

--- a/packages/ui/react-ui-theme/src/styles/layers/main.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/main.css
@@ -2,7 +2,7 @@
 
 @layer utilities {
 
-  .ch-main-content-padding {
+  .dx-main-content-padding {
     @apply pis-0 scroll-ps-0 pie-0 scroll-pe-0;
 
     @media (min-width: theme('screens.lg')) {
@@ -19,12 +19,12 @@
     }
   }
 
-  .ch-main-content-padding-transitions {
+  .dx-main-content-padding-transitions {
     transition-property: padding-inline-start, padding-inline-end, scroll-padding-start, scroll-padding-end;
     @apply duration-200 ease-in-out-symmetric;
   }
 
-  .ch-main-intrinsic-size {
+  .dx-main-intrinsic-size {
     @apply is-dvw transition-[inline-size] ease-in-out-symmetric duration-200;
 
     @media (min-width: theme('screens.lg')) {
@@ -49,7 +49,7 @@
     }
   }
 
-  .ch-main-bounce-layout {
+  .dx-main-bounce-layout {
     @apply fixed inset-0 z-0 overflow-auto overscroll-auto
   }
 
@@ -57,7 +57,7 @@
 
 @layer dx-components {
 
-  .ch-main-sidebar {
+  .dx-main-sidebar {
     @apply fixed overscroll-contain overflow-x-hidden overflow-y-auto;
     @apply duration-200 ease-in-out-symmetric;
     @apply border border-separator rounded-lg;
@@ -124,7 +124,7 @@
     }
   }
 
-  .ch-main-overlay {
+  .dx-main-overlay {
     @apply fixed inset-0 bg-scrim;
     @apply transition-opacity duration-200 ease-in-out-symmetric;
     @apply opacity-0 hidden;

--- a/packages/ui/react-ui-theme/src/styles/layers/main.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/main.css
@@ -55,7 +55,7 @@
 
 }
 
-@layer components {
+@layer dx-components {
 
   .ch-main-sidebar {
     @apply fixed overscroll-contain overflow-x-hidden overflow-y-auto;

--- a/packages/ui/react-ui-theme/src/styles/layers/positioning.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/positioning.css
@@ -13,7 +13,7 @@
   }
 }
 
-@layer components {
+@layer dx-components {
   .sticky-top-from-topbar-bottom {
     --sticky-top: var(--topbar-size);
   }

--- a/packages/ui/react-ui-theme/src/styles/layers/tldraw.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/tldraw.css
@@ -1,4 +1,4 @@
-@layer components {
+@layer dx-components {
 
   .tl-container.tl-theme__light {
     /* Converted */

--- a/packages/ui/react-ui-theme/src/styles/layers/tokens.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/tokens.css
@@ -1,4 +1,4 @@
-@layer tokens {
+@layer dx-tokens {
   @tokens dx;
 
   :root {
@@ -25,5 +25,13 @@
     --safe-area-right: env(safe-area-inset-right);
     --safe-area-top: env(safe-area-inset-top);
     --safe-area-bottom: env(safe-area-inset-bottom);
+  }
+
+  .dark {
+    --surface-bg: var(--dx-base);
+    --surface-text: var(--dx-baseText);
+    --input-bg: var(--dx-input);
+    --input-bg-hover: var(--dx-hoverSurface);
+    --description-text: var(--dx-description);
   }
 }

--- a/packages/ui/react-ui-theme/src/theme.css
+++ b/packages/ui/react-ui-theme/src/theme.css
@@ -1,40 +1,5 @@
-/**
- * Variable fonts:
- * https://fontsource.org/?category=sans-serif&variable=true
- */
-
-@import 'tailwindcss/base';
+@import 'tailwindcss/base' layer(tw-base);
 @import 'tailwindcss/utilities';
-@import 'tailwindcss/components';
+@import 'tailwindcss/components' layer(tw-components);
 
 @import './styles/layers/index.css';
-
-/* Base variables */
-
-:root {
-  touch-action: pan-x pan-y;
-  font-synthesis: none;
-  font-variation-settings: 'wght' 400,
-  'slnt' 0;
-  scroll-padding-block-start: theme(spacing.14);
-  scroll-padding-block-end: theme(spacing.2);
-}
-
-button {
-  -webkit-tap-highlight-color: transparent;
-}
-
-.dark {
-  --surface-bg: var(--dx-base);
-  --surface-text: var(--dx-baseText);
-  --input-bg: var(--dx-input);
-  --input-bg-hover: var(--dx-hoverSurface);
-  --description-text: var(--dx-description);
-  color: var(--surface-text);
-}
-
-html {
-  background-color: var(--surface-bg);
-  color: var(--surface-text);
-  @apply font-body;
-}

--- a/packages/ui/react-ui/src/components/Input/Input.tsx
+++ b/packages/ui/react-ui/src/components/Input/Input.tsx
@@ -307,7 +307,7 @@ const Switch = forwardRef<HTMLInputElement, InputScopedProps<SwitchProps>>(
     return (
       <input
         type='checkbox'
-        className='ch-checkbox--switch ch-focus-ring'
+        className='dx-checkbox--switch dx-focus-ring'
         checked={checked}
         onChange={(event) => {
           onCheckedChange(event.target.checked);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,13 +124,13 @@ importers:
         version: 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))
       '@nx/playwright':
         specifier: 19.7.2
-        version: 19.7.2(@babel/traverse@7.25.9)(@playwright/test@1.46.1)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(@zkochan/js-yaml@0.0.7)(esbuild@0.23.1)(eslint@8.57.0)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3)
+        version: 19.7.2(@babel/traverse@7.25.9)(@playwright/test@1.46.1)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(@zkochan/js-yaml@0.0.7)(esbuild@0.23.1)(eslint@8.57.0)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3(@types/node@22.10.2)(@vitest/browser@2.1.3)(@vitest/ui@2.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(msw@2.4.6(typescript@5.7.2))(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
       '@nx/storybook':
         specifier: 19.7.2
         version: 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)
       '@nx/vite':
         specifier: 19.7.2
-        version: 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3)
+        version: 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3(@types/node@22.10.2)(@vitest/browser@2.1.3)(@vitest/ui@2.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(msw@2.4.6(typescript@5.7.2))(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
       '@nx/web':
         specifier: 19.7.2
         version: 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)
@@ -220,7 +220,7 @@ importers:
         version: 2.1.3(playwright@1.46.1)(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3)(webdriverio@8.33.1(encoding@0.1.13)(typescript@5.7.2))
       '@vitest/coverage-v8':
         specifier: ^2.1.3
-        version: 2.1.3(@vitest/browser@2.1.3)(vitest@2.1.3)
+        version: 2.1.3(@vitest/browser@2.1.3(playwright@1.46.1)(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3)(webdriverio@8.33.1(encoding@0.1.13)(typescript@5.7.2)))(vitest@2.1.3(@types/node@22.10.2)(@vitest/browser@2.1.3)(@vitest/ui@2.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(msw@2.4.6(typescript@5.7.2))(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
       '@vitest/expect':
         specifier: ^2.1.3
         version: 2.1.3
@@ -4853,7 +4853,7 @@ importers:
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.5.17
-        version: 0.5.17(@cloudflare/workers-types@4.20241022.0)(@vitest/runner@2.1.3)(@vitest/snapshot@2.1.3)(vitest@2.1.3)
+        version: 0.5.17(@cloudflare/workers-types@4.20241022.0)(@vitest/runner@2.1.3)(@vitest/snapshot@2.1.3)(vitest@2.1.3(@types/node@22.10.2)(@vitest/browser@2.1.3)(@vitest/ui@2.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(msw@2.4.6(typescript@5.7.2))(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
       '@cloudflare/workers-types':
         specifier: ^4.20241018.0
         version: 4.20241022.0
@@ -12002,11 +12002,11 @@ importers:
   packages/ui/react-ui-theme:
     dependencies:
       '@ch-ui/tailwind-tokens':
-        specifier: ^1.0.0
-        version: 1.0.0(tailwindcss@3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2)))
+        specifier: 1.1.0
+        version: 1.1.0(tailwindcss@3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2)))
       '@ch-ui/tokens':
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: 1.1.0
+        version: 1.1.0
       '@dxos/node-std':
         specifier: workspace:*
         version: link:../../common/node-std
@@ -14384,14 +14384,14 @@ packages:
     resolution: {integrity: sha512-vevNSzPHnVDgyw6ZotbnE0y4FZFtIQQVKKjwVHGcfST7C5bqRyt69K1Nooo0r6s7laeJhS7YwXYmgLyPouc12w==}
     engines: {node: '>=20.0.0'}
 
-  '@ch-ui/tailwind-tokens@1.0.0':
-    resolution: {integrity: sha512-oP2iYbTLlHVAzb6mwM18NLBjOnYi26IkA/kpDJ7wpSYkapnvAfKx+YItz5HDev6FkZMuHJa98muz+vZQj4Qrsw==}
+  '@ch-ui/tailwind-tokens@1.1.0':
+    resolution: {integrity: sha512-WeI9mBz8Y+F5q25hHRZEUzAtRENq+2Ok1476+v1bgjor16EHHz+Uf2XO3gYr1JvJMZ2C4mQYPavGRTNZfJ0mjg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       tailwindcss: 3.x.x
 
-  '@ch-ui/tokens@1.0.0':
-    resolution: {integrity: sha512-lw3daEY9XI+UrxixU4LUqGtE+3xBPJ3usfvo64/zwJkhQDbh/pCJi4dZu0RbG2cToiTpZFA0ZPB+d0AZsdA2Ew==}
+  '@ch-ui/tokens@1.1.0':
+    resolution: {integrity: sha512-zCy8tWbtplHQBXszcwR43xtMPHQdQERP0G9aKa65dE0wETk7VDDPJW7EvL+DaUKDZTOc6VDa3QmEVRbof0p0Hg==}
     engines: {node: '>=20.0.0'}
 
   '@chainsafe/is-ip@2.0.2':
@@ -21731,11 +21731,6 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
 
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -37575,12 +37570,12 @@ snapshots:
     dependencies:
       svg-sprite: 2.0.4
 
-  '@ch-ui/tailwind-tokens@1.0.0(tailwindcss@3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2)))':
+  '@ch-ui/tailwind-tokens@1.1.0(tailwindcss@3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2)))':
     dependencies:
-      '@ch-ui/tokens': 1.0.0
+      '@ch-ui/tokens': 1.1.0
       tailwindcss: 3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(typescript@5.7.2))
 
-  '@ch-ui/tokens@1.0.0':
+  '@ch-ui/tokens@1.1.0':
     dependencies:
       '@ch-ui/colors': 1.0.0
       postcss: 8.4.47
@@ -37599,7 +37594,7 @@ snapshots:
     dependencies:
       mime: 3.0.0
 
-  '@cloudflare/vitest-pool-workers@0.5.17(@cloudflare/workers-types@4.20241022.0)(@vitest/runner@2.1.3)(@vitest/snapshot@2.1.3)(vitest@2.1.3)':
+  '@cloudflare/vitest-pool-workers@0.5.17(@cloudflare/workers-types@4.20241022.0)(@vitest/runner@2.1.3)(@vitest/snapshot@2.1.3)(vitest@2.1.3(@types/node@22.10.2)(@vitest/browser@2.1.3)(@vitest/ui@2.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(msw@2.4.6(typescript@5.7.2))(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))':
     dependencies:
       '@vitest/runner': 2.1.3
       '@vitest/snapshot': 2.1.3
@@ -39903,9 +39898,9 @@ snapshots:
       - '@swc/core'
       - debug
 
-  '@nrwl/vite@19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3)':
+  '@nrwl/vite@19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3(@types/node@22.10.2)(@vitest/browser@2.1.3)(@vitest/ui@2.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(msw@2.4.6(typescript@5.7.2))(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))':
     dependencies:
-      '@nx/vite': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3)
+      '@nx/vite': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3(@types/node@22.10.2)(@vitest/browser@2.1.3)(@vitest/ui@2.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(msw@2.4.6(typescript@5.7.2))(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -40213,12 +40208,12 @@ snapshots:
   '@nx/nx-win32-x64-msvc@19.7.2':
     optional: true
 
-  '@nx/playwright@19.7.2(@babel/traverse@7.25.9)(@playwright/test@1.46.1)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(@zkochan/js-yaml@0.0.7)(esbuild@0.23.1)(eslint@8.57.0)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3)':
+  '@nx/playwright@19.7.2(@babel/traverse@7.25.9)(@playwright/test@1.46.1)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(@zkochan/js-yaml@0.0.7)(esbuild@0.23.1)(eslint@8.57.0)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3(@types/node@22.10.2)(@vitest/browser@2.1.3)(@vitest/ui@2.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(msw@2.4.6(typescript@5.7.2))(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))':
     dependencies:
       '@nx/devkit': 19.7.2(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))
       '@nx/eslint': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))
       '@nx/js': 19.7.2(patch_hash=mavp33mumclr54vvfyyf557nvq)(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)
-      '@nx/vite': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3)
+      '@nx/vite': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3(@types/node@22.10.2)(@vitest/browser@2.1.3)(@vitest/ui@2.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(msw@2.4.6(typescript@5.7.2))(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
       '@nx/webpack': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(esbuild@0.23.1)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.7.2)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.7.2)
       minimatch: 9.0.3
@@ -40285,9 +40280,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3)':
+  '@nx/vite@19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3(@types/node@22.10.2)(@vitest/browser@2.1.3)(@vitest/ui@2.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(msw@2.4.6(typescript@5.7.2))(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))':
     dependencies:
-      '@nrwl/vite': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3)
+      '@nrwl/vite': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3(@types/node@22.10.2)(@vitest/browser@2.1.3)(@vitest/ui@2.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(msw@2.4.6(typescript@5.7.2))(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
       '@nx/devkit': 19.7.2(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))
       '@nx/js': 19.7.2(patch_hash=mavp33mumclr54vvfyyf557nvq)(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.1))(@swc/types@0.1.5)(typescript@5.7.2))(@swc/core@1.5.7(@swc/helpers@0.5.1)))(typescript@5.7.2)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.7.2)
@@ -45761,7 +45756,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@2.1.3(@vitest/browser@2.1.3)(vitest@2.1.3)':
+  '@vitest/coverage-v8@2.1.3(@vitest/browser@2.1.3(playwright@1.46.1)(typescript@5.7.2)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@2.1.3)(webdriverio@8.33.1(encoding@0.1.13)(typescript@5.7.2)))(vitest@2.1.3(@types/node@22.10.2)(@vitest/browser@2.1.3)(@vitest/ui@2.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(msw@2.4.6(typescript@5.7.2))(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -46486,8 +46481,8 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv-formats@2.1.1(ajv@8.12.0):
-    optionalDependencies:
+  ajv-formats@2.1.1:
+    dependencies:
       ajv: 8.12.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
@@ -48111,7 +48106,7 @@ snapshots:
   conf@12.0.0:
     dependencies:
       ajv: 8.12.0
-      ajv-formats: 2.1.1(ajv@8.12.0)
+      ajv-formats: 2.1.1
       atomically: 2.0.3
       debounce-fn: 5.1.2
       dot-prop: 8.0.2
@@ -57716,7 +57711,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       ajv: 8.12.0
-      ajv-formats: 2.1.1(ajv@8.12.0)
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0(ajv@8.12.0)
 
   screenfull@5.2.0: {}


### PR DESCRIPTION
This PR:
- resolves #8149
- prepares Composer for user color schemes
- removes `!` where they are no longer needed
- upgrades @ch-ui/tokens so we no longer see the PostCSS error about using `from` with `parse`
- refactors the `ch-` prefix to `dx-`

There should be no noticeable change in Composer, please let me know if you find any.