### PR TITLE
docs: fix command to run tailwind config viewer

### DIFF
--- a/packages/ui/react-ui-theme/README.md
+++ b/packages/ui/react-ui-theme/README.md
@@ -11,7 +11,7 @@ pnpm i @dxos/react-ui-theme
 To view the interactive Tailwind CSS configuration viewer, run the following command:
 
 ```bash
-pnpm nx run tailwind-config-viewer
+pnpm nx run react-ui-theme:tailwind-config-viewer
 ```
 
 ## Documentation


### PR DESCRIPTION
The command provided 

```shell
pnpm nx run tailwind-config-viewer
```

gives the error

```shell
 NX   Both project and target have to be specified
 ```
 
 This command works:
 
 ```shell
 pnpm nx run react-ui-theme:tailwind-config-viewer
 ```