### PR TITLE
fix: delegated invitation expiration

### DIFF
--- a/packages/sdk/client-protocol/src/invitations/encoder.test.ts
+++ b/packages/sdk/client-protocol/src/invitations/encoder.test.ts
@@ -9,6 +9,8 @@ import { Invitation } from '@dxos/protocols/proto/dxos/client/services';
 
 import { InvitationEncoder } from './encoder';
 
+const CREATED = new Date(1739956589 * 1000);
+
 const baseInvitation: Invitation = {
   invitationId: PublicKey.random().toHex(),
   type: Invitation.Type.INTERACTIVE,
@@ -18,6 +20,8 @@ const baseInvitation: Invitation = {
   swarmKey: PublicKey.random(),
   spaceKey: PublicKey.random(),
   spaceId: SpaceId.random(),
+  created: CREATED,
+  lifetime: 86400,
 };
 
 describe('Invitation utils', () => {

--- a/packages/sdk/client-protocol/src/invitations/encoder.ts
+++ b/packages/sdk/client-protocol/src/invitations/encoder.ts
@@ -37,6 +37,8 @@ export class InvitationEncoder {
         timeout: invitation.timeout,
         guestKeypair: invitation.guestKeypair,
         spaceId: invitation.spaceId,
+        lifetime: invitation.lifetime,
+        created: invitation.created,
         // TODO(wittjosiah): Make these optional to encode for greater privacy.
         ...(invitation.spaceKey ? { spaceKey: invitation.spaceKey } : {}),
         ...(invitation.target ? { target: invitation.target } : {}),

--- a/packages/sdk/client-protocol/src/invitations/invitations.ts
+++ b/packages/sdk/client-protocol/src/invitations/invitations.ts
@@ -41,20 +41,12 @@ export class CancellableInvitation extends MulticastObservable<Invitation> {
   }
 
   get expired() {
-    const invitation = this.get();
-    return (
-      invitation.created &&
-      invitation.lifetime &&
-      invitation.lifetime !== 0 &&
-      invitation.created.getTime() + invitation.lifetime * 1000 < Date.now()
-    );
+    const expiration = getExpirationTime(this.get());
+    return expiration && expiration.getTime() < Date.now();
   }
 
   get expiry() {
-    const invitation = this.get();
-    return invitation.created && invitation.lifetime && invitation.lifetime !== 0
-      ? new Date(invitation.created.getTime() + invitation.lifetime * 1000)
-      : undefined;
+    return getExpirationTime(this.get());
   }
 }
 
@@ -105,4 +97,11 @@ export const wrapObservable = async (observable: CancellableInvitation): Promise
       },
     );
   });
+};
+
+export const getExpirationTime = (invitation: Partial<Invitation>): Date | undefined => {
+  if (!(invitation.created && invitation.lifetime)) {
+    return;
+  }
+  return new Date(invitation.created.getTime() + invitation.lifetime * 1000);
 };

--- a/packages/sdk/client-services/src/packlets/invitations/space-invitation-protocol.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/space-invitation-protocol.ts
@@ -28,6 +28,7 @@ import {
 } from '@dxos/protocols/proto/dxos/halo/invitations';
 
 import { type InvitationProtocol } from './invitation-protocol';
+import { computeExpirationTime } from './utils';
 import { type DataSpaceManager, type SigningContext } from '../spaces';
 
 export class SpaceInvitationProtocol implements InvitationProtocol {
@@ -113,9 +114,7 @@ export class SpaceInvitationProtocol implements InvitationProtocol {
         authMethod: invitation.authMethod,
         swarmKey: invitation.swarmKey,
         role: invitation.role ?? SpaceMember.Role.ADMIN,
-        expiresOn: invitation.lifetime
-          ? new Date((invitation.created?.getTime() ?? Date.now()) + invitation.lifetime)
-          : undefined,
+        expiresOn: computeExpirationTime(invitation),
         multiUse: invitation.multiUse ?? false,
         guestKey:
           invitation.authMethod === Invitation.AuthMethod.KNOWN_PUBLIC_KEY

--- a/packages/sdk/client-services/src/packlets/invitations/utils.ts
+++ b/packages/sdk/client-services/src/packlets/invitations/utils.ts
@@ -10,6 +10,13 @@ export const stateToString = (state: Invitation.State): string => {
   return Object.entries(Invitation.State).find(([key, val]) => val === state)?.[0] ?? 'unknown';
 };
 
+export const computeExpirationTime = (invitation: Partial<Invitation>): Date | undefined => {
+  if (!invitation.lifetime) {
+    return;
+  }
+  return new Date((invitation.created?.getTime() ?? Date.now()) + invitation.lifetime * 1000);
+};
+
 export const tryAcquireBeforeContextDisposed = async (ctx: Context, mutex: Mutex): Promise<MutexGuard> => {
   let guard: MutexGuard | undefined;
   return cancelWithContext(


### PR DESCRIPTION
### Details

1. Encode invitation lifetime and create timestamp into invitation code so that guests can detect expired invitations.
2. Fix `DelegateInvitation` expiration time calculation (lifetime was treated as millis, event though it's in seconds).