### PR TITLE
fix: `inert` typo and other minor fixes

### DIFF
--- a/packages/devtools/devtools/src/components/performance/StatsPanel.tsx
+++ b/packages/devtools/devtools/src/components/performance/StatsPanel.tsx
@@ -97,7 +97,7 @@ export const StatsPanel = ({ stats, onRefresh }: QueryPanelProps) => {
 
   // TODO(burdon): Add Surface debug.
   return (
-    <div className='flex flex-col w-full h-full divide-y divide-separator'>
+    <div className='flex flex-col w-full h-full max-bs-[calc(var(--radix-popover-content-available-height)-2*var(--dx-modalLine))] overflow-y-auto divide-y divide-separator rounded-lg'>
       <Panel
         id='main'
         icon='ph--chart-bar--regular'

--- a/packages/plugins/plugin-debug/src/components/DebugStatus.tsx
+++ b/packages/plugins/plugin-debug/src/components/DebugStatus.tsx
@@ -192,7 +192,7 @@ const PerformanceIndicator = () => {
         </StatusBar.Button>
       </Popover.Trigger>
       <Popover.Portal>
-        <Popover.Content classNames='max-is-80 max-bs-[--radix-popover-content-available-height] overflow-y-auto'>
+        <Popover.Content classNames='max-is-[min(var(--radix-popover-content-available-width),300px)] max-bs-[--radix-popover-content-available-height]'>
           <StatsPanel stats={stats} onRefresh={refreshStats} />
           <Popover.Arrow />
         </Popover.Content>

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/ComplementarySidebar.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/ComplementarySidebar.tsx
@@ -84,10 +84,7 @@ export const ComplementarySidebar = ({ panels, current }: ComplementarySidebarPr
           role='none'
           className='absolute z-[1] inset-block-0 inline-end-0 !is-[--r0-size] border-is border-separator grid grid-cols-1 grid-rows-[1fr_min-content] bg-baseSurface contain-layout app-drag'
         >
-          <Tabs.Tablist
-            classNames='grid grid-cols-1 auto-rows-[--rail-action] p-1 gap-1 !overflow-y-auto'
-            {...(layout.complementarySidebarState !== 'expanded' && { inert: 'true' })}
-          >
+          <Tabs.Tablist classNames='grid grid-cols-1 auto-rows-[--rail-action] p-1 gap-1 !overflow-y-auto'>
             {panels.map((panel) => (
               <Tabs.Tab key={panel.id} value={panel.id} asChild>
                 <IconButton
@@ -123,6 +120,7 @@ export const ComplementarySidebar = ({ panels, current }: ComplementarySidebarPr
             key={panel.id}
             value={panel.id}
             classNames='absolute data-[state="inactive"]:-z-[1] inset-block-0 inline-start-0 is-[calc(100%-var(--r0-size))] lg:is-[--r1-size] grid grid-cols-1 grid-rows-[var(--rail-size)_1fr_min-content]'
+            {...(layout.complementarySidebarState !== 'expanded' && { inert: 'true' })}
           >
             {panel.id === activePanelId && node && (
               <>

--- a/packages/plugins/plugin-space/src/components/SyncStatus/SyncStatus.tsx
+++ b/packages/plugins/plugin-space/src/components/SyncStatus/SyncStatus.tsx
@@ -66,8 +66,9 @@ export const SyncStatusIndicator = ({ state, saved }: { state: SpaceSyncStateMap
           <StatusBar.Button title={title}>{icon}</StatusBar.Button>
         </Popover.Trigger>
         <Popover.Portal>
-          <Popover.Content sideOffset={16}>
+          <Popover.Content>
             <SyncStatusDetail state={state} summary={summary} debug={false} />
+            <Popover.Arrow />
           </Popover.Content>
         </Popover.Portal>
       </Popover.Root>

--- a/packages/ui/react-ui-grid/src/CellEditor/CellEditor.tsx
+++ b/packages/ui/react-ui-grid/src/CellEditor/CellEditor.tsx
@@ -143,7 +143,7 @@ export const CellEditor = ({ value, extension, autoFocus, onBlur, box, gridId }:
               className: '[&>.cm-scroller]:scrollbar-none tabular-nums',
             },
             content: {
-              className: 'border border-transparent pli-[4px] plb-0.5',
+              className: '!border !border-transparent !pli-[4px] !plb-0.5',
             },
           },
         }),

--- a/packages/ui/react-ui-theme/src/config/tokens/lengths.ts
+++ b/packages/ui/react-ui-theme/src/config/tokens/lengths.ts
@@ -32,7 +32,7 @@ export const lengthsFacet = {
     statements: [':root'],
     aliases: {
       noLine: ['focusOffset'],
-      hairLine: ['modalLine', 'landmarkLine', 'positionedLine', 'gridLine'],
+      hairLine: ['modalLine', 'landmarkLine', 'positionedLine', 'gridGap'],
       thickLine: ['focusLine'],
     },
   },


### PR DESCRIPTION
This PR:
- moves a typo-misapplication of the `inert` attribute
- deconflicts the `gridLine` token to fix grid line colors
- restores `!` on cell editor content to fix spacing
- fixes Space sync status popover
- fixes debug panel popover