### PR TITLE
fix(tables): Storybook crash

### DIFF
--- a/packages/plugins/experimental/plugin-kanban/src/components/KanbanViewEditor.tsx
+++ b/packages/plugins/experimental/plugin-kanban/src/components/KanbanViewEditor.tsx
@@ -19,27 +19,10 @@ type KanbanViewEditorProps = { kanban: KanbanType };
 export const KanbanViewEditor = ({ kanban }: KanbanViewEditorProps) => {
   const { dispatchPromise: dispatch } = useIntentDispatcher();
   const space = getSpace(kanban);
-
-  const [schema, setSchema] = useState<EchoSchema | undefined>();
-
-  useEffect(() => {
-    if (space && kanban?.cardView?.target?.query?.type) {
-      const query = space.db.schemaRegistry.query({ typename: kanban.cardView.target.query.type });
-      const unsubscribe = query.subscribe(
-        () => {
-          const [schema] = query.results;
-          if (schema) {
-            setSchema(schema);
-          }
-        },
-        { fire: true },
-      );
-      return unsubscribe;
-    }
-  }, [space, kanban?.cardView?.target?.query?.type]);
-
-  const views = useQuery(space, Filter.schema(ViewType));
   const currentTypename = useMemo(() => kanban?.cardView?.target?.query?.type, [kanban?.cardView?.target?.query?.type]);
+  const schema = useSchema(space, currentTypename);
+  const views = useQuery(space, Filter.schema(ViewType));
+
   const updateViewTypename = useCallback(
     (newTypename: string) => {
       invariant(schema);

--- a/packages/plugins/experimental/plugin-kanban/src/components/KanbanViewEditor.tsx
+++ b/packages/plugins/experimental/plugin-kanban/src/components/KanbanViewEditor.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useMemo } from 'react';
 import { createIntent, useIntentDispatcher } from '@dxos/app-framework';
 import { FormatEnum } from '@dxos/echo-schema';
 import { invariant } from '@dxos/invariant';
-import { Filter, getSpace, useQuery } from '@dxos/react-client/echo';
+import { Filter, getSpace, useQuery, useSchema } from '@dxos/react-client/echo';
 import { ViewEditor, Form, SelectInput, type CustomInputMap } from '@dxos/react-ui-form';
 import { type KanbanType, KanbanSettingsSchema } from '@dxos/react-ui-kanban';
 import { ViewType, ViewProjection } from '@dxos/schema';

--- a/packages/plugins/experimental/plugin-kanban/src/components/KanbanViewEditor.tsx
+++ b/packages/plugins/experimental/plugin-kanban/src/components/KanbanViewEditor.tsx
@@ -2,10 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { createIntent, useIntentDispatcher } from '@dxos/app-framework';
-import { type EchoSchema, FormatEnum } from '@dxos/echo-schema';
+import { FormatEnum } from '@dxos/echo-schema';
 import { invariant } from '@dxos/invariant';
 import { Filter, getSpace, useQuery } from '@dxos/react-client/echo';
 import { ViewEditor, Form, SelectInput, type CustomInputMap } from '@dxos/react-ui-form';

--- a/packages/plugins/plugin-table/src/components/ObjectDetailsPanel.tsx
+++ b/packages/plugins/plugin-table/src/components/ObjectDetailsPanel.tsx
@@ -2,12 +2,11 @@
 // Copyright 2025 DXOS.org
 //
 
-import React, { useCallback, useMemo, useSyncExternalStore } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
-import { type JsonPath, type EchoSchema, setValue } from '@dxos/echo-schema';
+import { type JsonPath, setValue } from '@dxos/echo-schema';
 import { invariant } from '@dxos/invariant';
-import { getSpace, Filter, type Space } from '@dxos/react-client/echo';
-import { useQuery } from '@dxos/react-client/echo';
+import { getSpace, Filter, useQuery, useSchema } from '@dxos/react-client/echo';
 import { useTranslation } from '@dxos/react-ui';
 import { useSelectedItems } from '@dxos/react-ui-attention';
 import { Form } from '@dxos/react-ui-form';

--- a/packages/plugins/plugin-table/src/components/ObjectDetailsPanel.tsx
+++ b/packages/plugins/plugin-table/src/components/ObjectDetailsPanel.tsx
@@ -15,35 +15,6 @@ import { type ViewType } from '@dxos/schema';
 
 import { TABLE_PLUGIN } from '../meta';
 
-// TODO(ZaymonFC): Factor this out and use it where we query for schemas with typename.
-const useSchema = (space: Space | undefined, typename: string | undefined): EchoSchema | undefined => {
-  const { subscribe, getSchema } = useMemo(() => {
-    if (!typename || !space) {
-      return {
-        subscribe: () => () => {},
-        getSchema: () => undefined,
-      };
-    }
-
-    const query = space.db.schemaRegistry.query({ typename });
-    const initialResult = query.runSync()[0];
-    let currentSchema = initialResult;
-
-    return {
-      subscribe: (onStoreChange: () => void) => {
-        const unsubscribe = query.subscribe(() => {
-          currentSchema = query.results[0];
-          onStoreChange();
-        });
-        return unsubscribe;
-      },
-      getSchema: () => currentSchema,
-    };
-  }, [typename, space]);
-
-  return useSyncExternalStore(subscribe, getSchema);
-};
-
 type RowDetailsPanelProps = { objectId: string; view: ViewType };
 
 const ObjectDetailsPanel = ({ objectId, view }: RowDetailsPanelProps) => {

--- a/packages/plugins/plugin-table/src/components/TableContainer.tsx
+++ b/packages/plugins/plugin-table/src/components/TableContainer.tsx
@@ -8,7 +8,7 @@ import { createIntent, useIntentDispatcher } from '@dxos/app-framework';
 import { useGlobalFilteredObjects } from '@dxos/plugin-search';
 import { SpaceAction } from '@dxos/plugin-space/types';
 import { ThreadAction } from '@dxos/plugin-thread/types';
-import { create, fullyQualifiedId, getSpace, Filter, useQuery } from '@dxos/react-client/echo';
+import { create, fullyQualifiedId, getSpace, Filter, useQuery, useSchema } from '@dxos/react-client/echo';
 import { StackItem } from '@dxos/react-ui-stack';
 import {
   Table,
@@ -28,10 +28,7 @@ const TableContainer = ({ role, table }: { table: TableType; role?: string }) =>
   const { dispatchPromise: dispatch } = useIntentDispatcher();
   const space = getSpace(table);
 
-  const schema = useMemo(
-    () => (table.view?.target ? space?.db.schemaRegistry.getSchema(table.view.target.query.type) : undefined),
-    [space, table.view?.target],
-  );
+  const schema = useSchema(space, table.view?.target?.query.type);
   const queriedObjects = useQuery(space, schema ? Filter.schema(schema) : Filter.nothing());
   const filteredObjects = useGlobalFilteredObjects(queriedObjects);
 

--- a/packages/plugins/plugin-table/src/components/TableViewEditor.tsx
+++ b/packages/plugins/plugin-table/src/components/TableViewEditor.tsx
@@ -2,11 +2,11 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { createIntent, useIntentDispatcher } from '@dxos/app-framework';
 import { invariant } from '@dxos/invariant';
-import { Filter, getSpace, useQuery } from '@dxos/react-client/echo';
+import { Filter, getSpace, useQuery, useSchema } from '@dxos/react-client/echo';
 import { ViewEditor } from '@dxos/react-ui-form';
 import { type TableType } from '@dxos/react-ui-table';
 import { ViewType } from '@dxos/schema';
@@ -18,29 +18,7 @@ type TableViewEditorProps = { table: TableType };
 const TableViewEditor = ({ table }: TableViewEditorProps) => {
   const { dispatchPromise: dispatch } = useIntentDispatcher();
   const space = getSpace(table);
-
-  // TODO(ZaymonFC): The schema registry needs an API where we can query with initial value and
-  // endure typename changes. We shouldn't need to manage a subscription at this layer.
-  const [schema, setSchema] = useState(
-    space && table?.view?.target?.query?.type
-      ? space.db.schemaRegistry.getSchema(table.view.target!.query.type)
-      : undefined,
-  );
-  // TODO(dmaretskyi): New hook for schema query.
-  useEffect(() => {
-    if (space && table?.view?.target?.query?.type) {
-      const unsubscribe = space.db.schemaRegistry
-        .query({ typename: table.view.target.query.type })
-        .subscribe((query) => {
-          const schema = query.results[0];
-          if (schema) {
-            setSchema(schema);
-          }
-        });
-
-      return unsubscribe;
-    }
-  }, [space, table?.view?.target?.query?.type]);
+  const schema = useSchema(space, table.view?.target?.query.type);
 
   const views = useQuery(space, Filter.schema(ViewType));
   const currentTypename = useMemo(() => table?.view?.target?.query?.type, [table?.view?.target?.query?.type]);

--- a/packages/sdk/react-client/src/echo/index.ts
+++ b/packages/sdk/react-client/src/echo/index.ts
@@ -6,6 +6,7 @@ export * from '@dxos/client/echo';
 
 export * from './useMembers';
 export * from './useQuery';
+export * from './useSchema';
 export * from './useSpaces';
 export * from './useSpaceInvitations';
 export * from './useSubscription';

--- a/packages/sdk/react-client/src/echo/useSchema.ts
+++ b/packages/sdk/react-client/src/echo/useSchema.ts
@@ -9,9 +9,6 @@ import { type EchoSchema } from '@dxos/echo-schema';
 
 /**
  * Subscribe to and retrieve schema changes from a space's schema registry.
- * @param space - The containing space from which to fetch schema data.
- * @param typename - The specific type name to query from the schema registry.
- * @returns The current schema for the given type, or undefined if space/typename unavailable.
  */
 export const useSchema = (space: Space | undefined, typename: string | undefined): EchoSchema | undefined => {
   const { subscribe, getSchema } = useMemo(() => {

--- a/packages/ui/react-ui-attention/src/components/SelectionProvider.tsx
+++ b/packages/ui/react-ui-attention/src/components/SelectionProvider.tsx
@@ -58,7 +58,7 @@ export const useSelectionActions = (contextId?: string) => {
 
   const clear = useCallback(() => {
     if (!contextId) {
-      return new Set();
+      return;
     }
     selection.clearSelection(contextId);
   }, [selection, contextId]);

--- a/packages/ui/react-ui-attention/src/components/SelectionProvider.tsx
+++ b/packages/ui/react-ui-attention/src/components/SelectionProvider.tsx
@@ -36,12 +36,11 @@ export const useSelectedItems = (contextId: string): Set<string> => {
 export const useSelectionActions = (contextId?: string) => {
   const { selection } = useSelectionContext(SELECTION_NAME);
 
-  if (!contextId) {
-    return { select: () => {}, toggle: () => {}, clear: () => {} };
-  }
-
   const select = useCallback(
     (ids: string[]) => {
+      if (!contextId) {
+        return new Set();
+      }
       selection.updateSelection(contextId, ids);
     },
     [selection, contextId],
@@ -49,12 +48,18 @@ export const useSelectionActions = (contextId?: string) => {
 
   const toggle = useCallback(
     (id: string) => {
+      if (!contextId) {
+        return new Set();
+      }
       selection.toggleSelection(contextId, id);
     },
     [selection, contextId],
   );
 
   const clear = useCallback(() => {
+    if (!contextId) {
+      return new Set();
+    }
     selection.clearSelection(contextId);
   }, [selection, contextId]);
 

--- a/packages/ui/react-ui-kanban/src/components/Kanban.stories.tsx
+++ b/packages/ui/react-ui-kanban/src/components/Kanban.stories.tsx
@@ -7,10 +7,9 @@ import '@dxos-theme';
 import { type StoryObj, type Meta } from '@storybook/react';
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { type EchoSchema } from '@dxos/echo-schema';
 import { useGlobalFilteredObjects } from '@dxos/plugin-search';
 import { faker } from '@dxos/random';
-import { Filter, useSpaces, useQuery, create } from '@dxos/react-client/echo';
+import { Filter, useSpaces, useQuery, useSchema, create } from '@dxos/react-client/echo';
 import { withClientProvider } from '@dxos/react-client/testing';
 import { ViewEditor } from '@dxos/react-ui-form';
 import { SyntaxHighlighter } from '@dxos/react-ui-syntax-highlighter';
@@ -33,8 +32,8 @@ const StorybookKanban = () => {
   const space = spaces[spaces.length - 1];
   const kanbans = useQuery(space, Filter.schema(KanbanType));
   const [kanban, setKanban] = useState<KanbanType>();
-  const [cardSchema, setCardSchema] = useState<EchoSchema>();
   const [projection, setProjection] = useState<ViewProjection>();
+  const cardSchema = useSchema(space, kanban?.cardView?.target?.query.type);
 
   useEffect(() => {
     if (kanbans.length && !kanban) {
@@ -42,24 +41,6 @@ const StorybookKanban = () => {
       setKanban(kanban);
     }
   }, [kanbans]);
-
-  useEffect(() => {
-    if (!kanban) {
-      return;
-    }
-
-    const query = space.db.schemaRegistry.query({ typename: kanban.cardView?.target?.query.type });
-    const unsubscribe = query.subscribe(
-      () => {
-        const [schema] = query.results;
-        if (schema) {
-          setCardSchema(schema);
-        }
-      },
-      { fire: true },
-    );
-    return unsubscribe;
-  }, [kanban, kanban?.cardView?.target?.query.type, space]);
 
   useEffect(() => {
     if (kanban?.cardView?.target && cardSchema) {

--- a/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
@@ -7,11 +7,10 @@ import '@dxos-theme';
 import { type Meta } from '@storybook/react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { type EchoSchema } from '@dxos/echo-schema';
 import { invariant } from '@dxos/invariant';
 import { useGlobalFilteredObjects } from '@dxos/plugin-search';
 import { faker } from '@dxos/random';
-import { Filter, useQuery, create } from '@dxos/react-client/echo';
+import { Filter, useQuery, useSchema, create } from '@dxos/react-client/echo';
 import { useClientProvider, withClientProvider } from '@dxos/react-client/testing';
 import { useDefaultValue } from '@dxos/react-ui';
 import { ViewEditor } from '@dxos/react-ui-form';
@@ -41,13 +40,13 @@ const DefaultStory = () => {
 
   const tables = useQuery(space, Filter.schema(TableType));
   const [table, setTable] = useState<TableType>();
-  const [schema, setSchema] = useState<EchoSchema>();
+  const schema = useSchema(space, table?.view?.target?.query.type);
+
   useEffect(() => {
     if (space && tables.length && !table) {
       const table = tables[0];
       invariant(table.view);
       setTable(table);
-      setSchema(space.db.schemaRegistry.getSchema(table.view.target!.query.type));
     }
   }, [space, tables]);
 


### PR DESCRIPTION
- **`useSelectionActions` was breaking the rules of hooks**


@wittjosiah It turns out that the selection provider breaking the rules of hooks was the reason that the `useSchema` hook was breaking the other day. So I've restored that as well and gotten rid of the duplicated code. I tested it both in the stories and in composer, it's working great.