### PR TITLE
feat(kanban): Create kanban from existing type

### DIFF
--- a/packages/plugins/experimental/plugin-kanban/package.json
+++ b/packages/plugins/experimental/plugin-kanban/package.json
@@ -35,6 +35,7 @@
     "@dxos/app-framework": "workspace:*",
     "@dxos/async": "workspace:*",
     "@dxos/echo-schema": "workspace:*",
+    "@dxos/effect": "workspace:*",
     "@dxos/invariant": "workspace:*",
     "@dxos/plugin-client": "workspace:*",
     "@dxos/plugin-graph": "workspace:*",

--- a/packages/plugins/experimental/plugin-kanban/src/KanbanPlugin.tsx
+++ b/packages/plugins/experimental/plugin-kanban/src/KanbanPlugin.tsx
@@ -10,7 +10,7 @@ import { KanbanType, translations as kanbanTranslations } from '@dxos/react-ui-k
 import { IntentResolver, ReactSurface } from './capabilities';
 import { KANBAN_PLUGIN, meta } from './meta';
 import translations from './translations';
-import { KanbanAction } from './types';
+import { CreateKanbanSchema, type CreateKanbanType, KanbanAction } from './types';
 
 export const KanbanPlugin = () =>
   definePlugin(meta, [
@@ -26,7 +26,8 @@ export const KanbanPlugin = () =>
         contributes(Capabilities.Metadata, {
           id: KanbanType.typename,
           metadata: {
-            createObject: (props: { name?: string }, options: { space: Space }) =>
+            creationSchema: CreateKanbanSchema,
+            createObject: (props: CreateKanbanType, options: { space: Space }) =>
               createIntent(KanbanAction.Create, { ...props, space: options.space }),
             placeholder: ['kanban title placeholder', { ns: KANBAN_PLUGIN }],
             icon: 'ph--kanban--regular',

--- a/packages/plugins/experimental/plugin-kanban/src/capabilities/intent-resolver.ts
+++ b/packages/plugins/experimental/plugin-kanban/src/capabilities/intent-resolver.ts
@@ -14,8 +14,8 @@ export default () =>
   contributes(Capabilities.IntentResolver, [
     createResolver({
       intent: KanbanAction.Create,
-      resolve: async ({ space }) => ({
-        data: { object: await createKanban(space) },
+      resolve: async ({ space, initialSchema, initialPivotColumn }) => ({
+        data: { object: await createKanban({ space, initialSchema, initialPivotColumn }) },
       }),
     }),
     createResolver({

--- a/packages/plugins/experimental/plugin-kanban/src/capabilities/react-surface.tsx
+++ b/packages/plugins/experimental/plugin-kanban/src/capabilities/react-surface.tsx
@@ -2,14 +2,19 @@
 // Copyright 2025 DXOS.org
 //
 
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { Capabilities, contributes, createSurface } from '@dxos/app-framework';
+import { type S } from '@dxos/echo-schema';
+import { findAnnotation } from '@dxos/effect';
+import { type CollectionType } from '@dxos/plugin-space/types';
+import { getSpace, isSpace, type Space } from '@dxos/react-client/echo';
+import { type InputProps, SelectInput, useFormValues } from '@dxos/react-ui-form';
 import { type KanbanType } from '@dxos/react-ui-kanban';
 
 import { KanbanContainer, KanbanViewEditor } from '../components';
 import { KANBAN_PLUGIN } from '../meta';
-import { isKanban } from '../types';
+import { isKanban, InitialSchemaAnnotationId, InitialPivotColumnAnnotationId } from '../types';
 
 export default () =>
   contributes(Capabilities.ReactSurface, [
@@ -24,5 +29,66 @@ export default () =>
       role: 'complementary--settings',
       filter: (data): data is { subject: KanbanType } => isKanban(data.subject),
       component: ({ data }) => <KanbanViewEditor kanban={data.subject} />,
+    }),
+    createSurface({
+      id: `${KANBAN_PLUGIN}/create-initial-schema-form-[schema]`,
+      role: 'form-input',
+      filter: (data): data is { prop: string; schema: S.Schema<any>; target: Space | CollectionType | undefined } => {
+        const annotation = findAnnotation<boolean>((data.schema as S.Schema.All).ast, InitialSchemaAnnotationId);
+        return !!annotation;
+      },
+      component: ({ data: { target }, ...inputProps }) => {
+        const props = inputProps as any as InputProps;
+        const space = isSpace(target) ? target : getSpace(target);
+        if (!space) {
+          return null;
+        }
+        const schemata = space?.db.schemaRegistry.query().runSync();
+
+        return <SelectInput {...props} options={schemata.map((schema) => ({ value: schema.typename }))} />;
+      },
+    }),
+    createSurface({
+      id: `${KANBAN_PLUGIN}/create-initial-schema-form-[pivot-column]`,
+      role: 'form-input',
+      filter: (data): data is { prop: string; schema: S.Schema<any>; target: Space | CollectionType | undefined } => {
+        const annotation = findAnnotation<boolean>((data.schema as S.Schema.All).ast, InitialPivotColumnAnnotationId);
+        return !!annotation;
+      },
+      component: ({ data: { target }, ...inputProps }) => {
+        const props = inputProps as any as InputProps;
+        const space = isSpace(target) ? target : getSpace(target);
+        if (!space) {
+          return null;
+        }
+        const schemata = space?.db.schemaRegistry.query().runSync();
+        const { initialSchema } = useFormValues();
+
+        const selectedSchema = useMemo(
+          () => schemata.find((schema) => schema.typename === initialSchema),
+          [schemata, initialSchema],
+        );
+
+        const singleSelectColumns = useMemo(() => {
+          if (!selectedSchema?.jsonSchema?.properties) {
+            return [];
+          }
+
+          const columns = Object.entries(selectedSchema.jsonSchema.properties).reduce<string[]>((acc, [key, value]) => {
+            if (typeof value === 'object' && value?.format === 'single-select') {
+              acc.push(key);
+            }
+            return acc;
+          }, []);
+
+          return columns;
+        }, [selectedSchema?.jsonSchema]);
+
+        if (!initialSchema) {
+          return null;
+        }
+
+        return <SelectInput {...props} options={singleSelectColumns.map((column) => ({ value: column }))} />;
+      },
     }),
   ]);

--- a/packages/plugins/experimental/plugin-kanban/src/capabilities/react-surface.tsx
+++ b/packages/plugins/experimental/plugin-kanban/src/capabilities/react-surface.tsx
@@ -61,13 +61,8 @@ export default () =>
         if (!space) {
           return null;
         }
-        const schemata = space?.db.schemaRegistry.query().runSync();
         const { initialSchema } = useFormValues();
-
-        const selectedSchema = useMemo(
-          () => schemata.find((schema) => schema.typename === initialSchema),
-          [schemata, initialSchema],
-        );
+        const [selectedSchema] = space?.db.schemaRegistry.query({ typename: initialSchema }).runSync();
 
         const singleSelectColumns = useMemo(() => {
           if (!selectedSchema?.jsonSchema?.properties) {

--- a/packages/plugins/experimental/plugin-kanban/src/types.ts
+++ b/packages/plugins/experimental/plugin-kanban/src/types.ts
@@ -1,6 +1,8 @@
 //
-// Copyright 2023 DXOS.org
+// Copyright 2025 DXOS.org
 //
+
+import { TitleAnnotationId } from '@effect/schema/AST';
 
 import { S } from '@dxos/echo-schema';
 import { type Space, SpaceSchema } from '@dxos/react-client/echo';
@@ -19,14 +21,33 @@ import { KANBAN_PLUGIN } from './meta';
  * by the model (e.g., a query of items based on metadata within a column object).
  */
 
+// TODO(ZaymonFC): Consider making this a common annotation.
+export const InitialSchemaAnnotationId = Symbol.for('@dxos/plugin-kanban/annotation/InitialSchema');
+export const InitialPivotColumnAnnotationId = Symbol.for('@dxos/plugin-kanban/annotation/InitialPivotColumn');
+
+export const CreateKanbanSchema = S.Struct({
+  name: S.optional(S.String),
+  initialSchema: S.optional(
+    S.String.annotations({
+      [InitialSchemaAnnotationId]: true,
+      [TitleAnnotationId]: 'Select card schema (leave empty to start fresh)',
+    }),
+  ),
+  initialPivotColumn: S.optional(
+    S.String.annotations({
+      [InitialPivotColumnAnnotationId]: true,
+      [TitleAnnotationId]: 'Pivot column',
+    }),
+  ),
+});
+
+export type CreateKanbanType = S.Schema.Type<typeof CreateKanbanSchema>;
+
 export namespace KanbanAction {
   const KANBAN_ACTION = `${KANBAN_PLUGIN}/action`;
 
   export class Create extends S.TaggedClass<Create>()(`${KANBAN_ACTION}/create`, {
-    input: S.Struct({
-      name: S.optional(S.String),
-      space: SpaceSchema,
-    }),
+    input: S.extend(S.Struct({ space: SpaceSchema }), CreateKanbanSchema),
     output: S.Struct({
       object: KanbanType,
     }),
@@ -69,7 +90,7 @@ export type Location = {
 
 export const isKanban = (object: unknown): object is KanbanType => object != null && object instanceof KanbanType;
 
-export const createKanban = async (space: Space) => {
-  const { kanban } = await initializeKanban({ space });
+export const createKanban = async (props: { space: Space; initialSchema?: string; initialPivotColumn?: string }) => {
+  const { kanban } = await initializeKanban(props);
   return kanban;
 };

--- a/packages/plugins/experimental/plugin-kanban/src/types.ts
+++ b/packages/plugins/experimental/plugin-kanban/src/types.ts
@@ -21,7 +21,6 @@ import { KANBAN_PLUGIN } from './meta';
  * by the model (e.g., a query of items based on metadata within a column object).
  */
 
-// TODO(ZaymonFC): Consider making this a common annotation.
 export const InitialSchemaAnnotationId = Symbol.for('@dxos/plugin-kanban/annotation/InitialSchema');
 export const InitialPivotColumnAnnotationId = Symbol.for('@dxos/plugin-kanban/annotation/InitialPivotColumn');
 

--- a/packages/plugins/experimental/plugin-kanban/tsconfig.json
+++ b/packages/plugins/experimental/plugin-kanban/tsconfig.json
@@ -26,6 +26,9 @@
       "path": "../../../common/async"
     },
     {
+      "path": "../../../common/effect"
+    },
+    {
       "path": "../../../common/invariant"
     },
     {

--- a/packages/ui/react-ui-form/src/components/Form/index.ts
+++ b/packages/ui/react-ui-form/src/components/Form/index.ts
@@ -2,8 +2,11 @@
 // Copyright 2024 DXOS.org
 //
 
+import { useFormValues } from './FormContext';
+
 export * from './custom';
 
 export * from './Defaults';
 export * from './Form';
 export * from './Input';
+export { useFormValues };

--- a/packages/ui/react-ui-kanban/src/components/Kanban.stories.tsx
+++ b/packages/ui/react-ui-kanban/src/components/Kanban.stories.tsx
@@ -133,11 +133,11 @@ const meta: Meta<StoryProps> = {
       createIdentity: true,
       createSpace: true,
       onSpaceCreated: async ({ space }) => {
-        const { taskSchema } = await initializeKanban({ space });
+        const { schema } = await initializeKanban({ space });
         // TODO(burdon): Replace with sdk/schema/testing.
         Array.from({ length: 8 }).map(() => {
           return space.db.add(
-            create(taskSchema, {
+            create(schema, {
               title: faker.commerce.productName(),
               description: faker.lorem.paragraph(),
             }),

--- a/packages/ui/react-ui-kanban/src/defs/kanban-model.ts
+++ b/packages/ui/react-ui-kanban/src/defs/kanban-model.ts
@@ -52,9 +52,11 @@ export class KanbanModel<T extends BaseKanbanItem = { id: string }> extends Reso
 
   get columnFieldPath() {
     const columnFieldId = this._kanban.columnFieldId;
-    invariant(columnFieldId);
+    if (columnFieldId === undefined) {
+      return undefined;
+    }
     const columnFieldProjection = this._projection.getFieldProjection(columnFieldId);
-    return columnFieldProjection?.props.property || '';
+    return columnFieldProjection?.props.property;
   }
 
   /**
@@ -147,8 +149,11 @@ export class KanbanModel<T extends BaseKanbanItem = { id: string }> extends Reso
   //
 
   private _getSelectOptions() {
-    invariant(this._kanban.columnFieldId);
-    return this._projection.getFieldProjection(this._kanban.columnFieldId).props.options;
+    if (this._kanban.columnFieldId === undefined) {
+      return [];
+    }
+
+    return this._projection.getFieldProjection(this._kanban.columnFieldId).props.options ?? [];
   }
 
   private _computeArrangement(): ArrangedCards<T> {
@@ -157,7 +162,12 @@ export class KanbanModel<T extends BaseKanbanItem = { id: string }> extends Reso
       return [];
     }
 
-    return computeArrangement<T>(this._kanban, this._items.value, this.columnFieldPath, options);
+    return computeArrangement<T>({
+      kanban: this._kanban,
+      items: this._items.value,
+      pivotPath: this.columnFieldPath,
+      selectOptions: options,
+    });
   }
 
   /**

--- a/packages/ui/react-ui-kanban/src/testing/initialize-kanban.ts
+++ b/packages/ui/react-ui-kanban/src/testing/initialize-kanban.ts
@@ -2,23 +2,29 @@
 // Copyright 2024 DXOS.org
 //
 
-import { AST, type EchoSchema, S, TypedObject, FormatEnum, TypeEnum, type JsonProp } from '@dxos/echo-schema';
+import { AST, S, TypedObject, FormatEnum, TypeEnum, type JsonProp, type EchoSchema } from '@dxos/echo-schema';
 import { invariant } from '@dxos/invariant';
 import { PublicKey } from '@dxos/react-client';
 import { type Space, create, makeRef } from '@dxos/react-client/echo';
-import { createView, ViewProjection, createFieldId } from '@dxos/schema';
+import { createView, ViewProjection, createFieldId, getSchemaProperties } from '@dxos/schema';
 import { capitalize } from '@dxos/util';
 
 import { KanbanType } from '../defs';
 
-type InitialiseKanbanProps = {
+type InitializeKanbanProps = {
   space: Space;
+  initialSchema?: string;
+  initialPivotColumn?: string;
 };
 
-export const initializeKanban = async ({
-  space,
-}: InitialiseKanbanProps): Promise<{ kanban: KanbanType; taskSchema: EchoSchema }> => {
-  const TaskSchema = TypedObject({
+const createDefaultTaskSchema = () => {
+  const stateOptions = [
+    { id: PublicKey.random().truncate(), title: 'Draft', color: 'indigo' },
+    { id: PublicKey.random().truncate(), title: 'Active', color: 'cyan' },
+    { id: PublicKey.random().truncate(), title: 'Completed', color: 'emerald' },
+  ];
+
+  const schema = TypedObject({
     typename: `example.com/type/${PublicKey.random().truncate()}`,
     version: '0.1.0',
   })({
@@ -28,52 +34,74 @@ export const initializeKanban = async ({
     description: S.optional(S.String).annotations({
       [AST.TitleAnnotationId]: 'Description',
     }),
+    state: S.optional(S.String),
   });
 
-  const [taskSchema] = await space.db.schemaRegistry.register([TaskSchema]);
+  return { schema, stateOptions };
+};
 
-  const view = createView({
-    name: "Test kanban's card view",
-    typename: taskSchema.typename,
-    jsonSchema: taskSchema.jsonSchema,
-    fields: ['title', 'description'],
-  });
+export const initializeKanban = async ({
+  space,
+  initialSchema,
+  initialPivotColumn,
+}: InitializeKanbanProps): Promise<{ kanban: KanbanType; schema: EchoSchema }> => {
+  if (initialSchema) {
+    const schema = await space.db.schemaRegistry.query({ typename: initialSchema }).firstOrUndefined();
+    invariant(schema, `Schema not found: ${initialSchema}`);
 
-  const stateOptions = [
-    { id: PublicKey.random().truncate(), title: 'Draft', color: 'indigo' },
-    { id: PublicKey.random().truncate(), title: 'Active', color: 'cyan' },
-    { id: PublicKey.random().truncate(), title: 'Completed', color: 'emerald' },
-  ];
+    const fields = getSchemaProperties(schema.ast)
+      .filter((prop) => prop.type !== 'object' || prop.format === FormatEnum.Ref)
+      .map((prop) => prop.name);
 
-  const initialPivotField = 'state';
+    const view = createView({
+      name: "Kanban's card view",
+      typename: schema.typename,
+      jsonSchema: schema.jsonSchema,
+      fields,
+    });
 
-  const viewProjection = new ViewProjection(taskSchema, view);
+    const kanban = create(KanbanType, { cardView: makeRef(view), columnFieldId: undefined });
+    if (initialPivotColumn) {
+      const viewProjection = new ViewProjection(schema, view);
+      const fieldId = viewProjection.getFieldId(initialPivotColumn);
+      if (fieldId) {
+        kanban.columnFieldId = fieldId;
+      }
+    }
+    return { kanban, schema };
+  } else {
+    const { schema: taskSchema, stateOptions } = createDefaultTaskSchema();
+    const [schema] = await space.db.schemaRegistry.register([taskSchema]);
 
-  viewProjection.setFieldProjection({
-    field: {
-      id: createFieldId(),
-      path: initialPivotField as JsonProp,
-      size: 150,
-    },
-    props: {
-      property: initialPivotField as JsonProp,
-      type: TypeEnum.String,
-      format: FormatEnum.SingleSelect,
-      title: capitalize(initialPivotField),
-      options: stateOptions,
-    },
-  });
+    const view = createView({
+      name: "Kanban's card view",
+      typename: schema.typename,
+      jsonSchema: schema.jsonSchema,
+      fields: ['title', 'description'],
+    });
 
-  const fieldId = viewProjection.getFieldId(initialPivotField);
-  invariant(fieldId);
+    const initialPivotField = 'state';
+    const viewProjection = new ViewProjection(schema, view);
 
-  const kanban = space.db.add(
-    create(KanbanType, {
-      cardView: makeRef(view),
-      columnFieldId: fieldId,
-      // NOTE(ZaymonFC): Kanban arrangement is computed automatically.
-    }),
-  );
+    viewProjection.setFieldProjection({
+      field: {
+        id: createFieldId(),
+        path: initialPivotField as JsonProp,
+        size: 150,
+      },
+      props: {
+        property: initialPivotField as JsonProp,
+        type: TypeEnum.String,
+        format: FormatEnum.SingleSelect,
+        title: capitalize(initialPivotField),
+        options: stateOptions,
+      },
+    });
 
-  return { kanban, taskSchema };
+    const fieldId = viewProjection.getFieldId(initialPivotField);
+    invariant(fieldId);
+
+    const kanban = create(KanbanType, { cardView: makeRef(view), columnFieldId: fieldId });
+    return { kanban, schema };
+  }
 };

--- a/packages/ui/react-ui-kanban/src/util.ts
+++ b/packages/ui/react-ui-kanban/src/util.ts
@@ -7,12 +7,17 @@ import { type SelectOption } from '@dxos/echo-schema';
 import { type BaseKanbanItem, type KanbanType } from './defs';
 import { UNCATEGORIZED_VALUE } from './defs';
 
-export const computeArrangement = <T extends BaseKanbanItem = { id: string }>(
-  kanban: KanbanType,
-  items: T[],
-  pivotPath: string,
-  selectOptions: SelectOption[],
-) => {
+export const computeArrangement = <T extends BaseKanbanItem = { id: string }>({
+  kanban,
+  items,
+  pivotPath,
+  selectOptions,
+}: {
+  kanban: KanbanType;
+  items: T[];
+  pivotPath?: string;
+  selectOptions: SelectOption[];
+}) => {
   // Get valid column values from select options
   const validColumnValues = new Set(selectOptions.map((opt) => opt.id));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5930,6 +5930,9 @@ importers:
       '@dxos/echo-schema':
         specifier: workspace:*
         version: link:../../../core/echo/echo-schema
+      '@dxos/effect':
+        specifier: workspace:*
+        version: link:../../../common/effect
       '@dxos/invariant':
         specifier: workspace:*
         version: link:../../../common/invariant


### PR DESCRIPTION
Adds type selection and initial pivot column options (from available `single-select` fields) during Kanban creation.



https://github.com/user-attachments/assets/50aa1f74-7ce7-421f-9861-194d3f50ade9

