### PR TITLE
chore: Re-enable CAR block uploads for wnfs-plugin

### DIFF
--- a/packages/plugins/plugin-wnfs/src/blockstore.ts
+++ b/packages/plugins/plugin-wnfs/src/blockstore.ts
@@ -170,17 +170,9 @@ export class MixedBlockstore extends BaseBlockstore {
       }),
     );
 
-    // TODO: Create & submit CAR
-    //       DEPENDS ON EDGE BLOB-SERVICE CHANGES
-    // const car = await this.#createCar(blocks);
-    // await this.putCarRemote(car);
-    //
-    // Temporary solution:
-    await Promise.all(
-      blocks.map((block: Block) => {
-        return this.putRemote(block.cid, block.bytes);
-      }),
-    );
+    // Create & submit CAR
+    const car = await this.#createCar(blocks);
+    await this.putCarRemote(car);
 
     // Adjust queue
     const queue = [...this.#queue].filter((k) => {


### PR DESCRIPTION
This was missing a piece on the edge service which has now been [added](https://github.com/dxos/edge/pull/220).

## How it works

The debouncing mechanism groups up the IPLD blocks and then uploads them all at once to the edge blob service using a [CAR](https://ipld.io/specs/transport/car/carv1/) file. Each block is then independently retrievable using its [CID](https://github.com/multiformats/cid?tab=readme-ov-file#cid-content-identifier-specification).