### PR TITLE
fix: `ScrollContainer` native scrolling

### DIFF
--- a/packages/plugins/experimental/plugin-automation/src/components/Thread/Thread.tsx
+++ b/packages/plugins/experimental/plugin-automation/src/components/Thread/Thread.tsx
@@ -66,7 +66,7 @@ export const Thread = ({
 
   return (
     <>
-      <ScrollContainer ref={scroller} fadeClassNames='from-[--surface-bg] h-[6rem]'>
+      <ScrollContainer ref={scroller} fade>
         <div role='none' className={mx(filteredMessages.length > 0 && 'pbs-6 pbe-6', classNames)}>
           {filteredMessages.map((message) => (
             <ThreadMessage

--- a/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.stories.tsx
+++ b/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.stories.tsx
@@ -43,7 +43,7 @@ const meta: Meta<typeof ScrollContainer> = {
           <div className='flex-1' />
           <div>{lines.length}</div>
         </Toolbar.Root>
-        <ScrollContainer {...args} ref={scroller} fadeClassNames={'from-baseSurface h-[6rem]'}>
+        <ScrollContainer fade {...args} ref={scroller}>
           {lines.map((line, index) => (
             <div key={index} className='p-2'>
               {line}

--- a/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.tsx
+++ b/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.tsx
@@ -83,7 +83,7 @@ export const ScrollContainer = forwardRef<ScrollController, ScrollContainerProps
     }, [Children.count(children), viewport]);
 
     return (
-      <div className='relative flex-1 min-bs-0 grid'>
+      <div className='relative flex-1 min-bs-0 grid overflow-hidden'>
         {fade && (
           <div
             role='none'

--- a/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.tsx
+++ b/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.tsx
@@ -33,7 +33,7 @@ export const ScrollContainer = forwardRef<ScrollController, ScrollContainerProps
   ({ children, classNames, fade }, forwardedRef) => {
     const [viewport, setViewport] = useState<HTMLDivElement | null>(null);
     const [isOverflowing, setIsOverflowing] = useState(false);
-    const [scrolledFromTop, setScrolledFromTop] = useState(false);
+    const [scrolledAtTop, setScrolledAtTop] = useState(false);
 
     // Scroll controller imperative ref
     useImperativeHandle(
@@ -53,7 +53,7 @@ export const ScrollContainer = forwardRef<ScrollController, ScrollContainerProps
         // Check if content is overflowing
         setIsOverflowing(viewport.scrollHeight > viewport.clientHeight);
         // In flex-col-reverse, scrollTop > 0 means we're not at the visual top, also the value will be negative.
-        setScrolledFromTop(-viewport.scrollTop + 16 >= viewport.scrollHeight - viewport.clientHeight);
+        setScrolledAtTop(-viewport.scrollTop + 16 >= viewport.scrollHeight - viewport.clientHeight);
       }
     }, [viewport]);
 
@@ -87,7 +87,7 @@ export const ScrollContainer = forwardRef<ScrollController, ScrollContainerProps
         {fade && (
           <div
             role='none'
-            data-visible={isOverflowing && !scrolledFromTop}
+            data-visible={isOverflowing && !scrolledAtTop}
             className='opacity-0 duration-200 transition-opacity data-[visible="true"]:opacity-100 z-10 absolute block-start-0 inset-inline-0 bs-24 pointer-events-none bg-gradient-to-b from-[--surface-bg] to-transparent pointer-events-none'
           />
         )}

--- a/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.tsx
+++ b/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.tsx
@@ -2,7 +2,15 @@
 // Copyright 2025 DXOS.org
 //
 
-import React, { type PropsWithChildren, forwardRef, useImperativeHandle, useState, Children } from 'react';
+import React, {
+  type PropsWithChildren,
+  forwardRef,
+  useImperativeHandle,
+  useState,
+  Children,
+  useEffect,
+  useCallback,
+} from 'react';
 
 import { invariant } from '@dxos/invariant';
 import { type ThemedClassName } from '@dxos/react-ui';
@@ -24,6 +32,8 @@ export type ScrollContainerProps = ThemedClassName<
 export const ScrollContainer = forwardRef<ScrollController, ScrollContainerProps>(
   ({ children, classNames, fade }, forwardedRef) => {
     const [viewport, setViewport] = useState<HTMLDivElement | null>(null);
+    const [isOverflowing, setIsOverflowing] = useState(false);
+    const [scrolledFromTop, setScrolledFromTop] = useState(false);
 
     // Scroll controller imperative ref
     useImperativeHandle(
@@ -38,12 +48,47 @@ export const ScrollContainer = forwardRef<ScrollController, ScrollContainerProps
       [viewport],
     );
 
+    const updateScrollState = useCallback(() => {
+      if (viewport) {
+        // Check if content is overflowing
+        setIsOverflowing(viewport.scrollHeight > viewport.clientHeight);
+        // In flex-col-reverse, scrollTop > 0 means we're not at the visual top, also the value will be negative.
+        setScrolledFromTop(-viewport.scrollTop + 16 >= viewport.scrollHeight - viewport.clientHeight);
+      }
+    }, [viewport]);
+
+    useEffect(() => {
+      if (!viewport || !fade) {
+        return;
+      }
+
+      // Initial check
+      updateScrollState();
+
+      // Listen for scroll events
+      viewport.addEventListener('scroll', updateScrollState);
+
+      // Setup resize observer to detect content changes
+      const resizeObserver = new ResizeObserver(updateScrollState);
+      resizeObserver.observe(viewport);
+
+      return () => {
+        viewport.removeEventListener('scroll', updateScrollState);
+        resizeObserver.disconnect();
+      };
+    }, [viewport, fade]);
+
+    useEffect(() => {
+      updateScrollState();
+    }, [Children.count(children), viewport]);
+
     return (
       <div className='relative flex-1 min-bs-0 grid'>
         {fade && (
           <div
             role='none'
-            className='z-10 absolute block-start-0 inset-inline-0 bs-24 pointer-events-none bg-gradient-to-b from-[--surface-bg] to-transparent pointer-events-none'
+            data-visible={isOverflowing && !scrolledFromTop}
+            className='opacity-0 duration-200 transition-opacity data-[visible="true"]:opacity-100 z-10 absolute block-start-0 inset-inline-0 bs-24 pointer-events-none bg-gradient-to-b from-[--surface-bg] to-transparent pointer-events-none'
           />
         )}
         <div

--- a/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.tsx
+++ b/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.tsx
@@ -2,10 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
-import React, { type PropsWithChildren, forwardRef, useImperativeHandle, useState, useEffect, Children } from 'react';
+import React, { type PropsWithChildren, forwardRef, useImperativeHandle, useState, Children } from 'react';
 
 import { invariant } from '@dxos/invariant';
-import { ScrollArea, AnchoredOverflow, type ThemedClassName } from '@dxos/react-ui';
+import { type ThemedClassName } from '@dxos/react-ui';
 import { mx } from '@dxos/react-ui-theme';
 
 export interface ScrollController {
@@ -15,7 +15,6 @@ export interface ScrollController {
 export type ScrollContainerProps = ThemedClassName<
   PropsWithChildren<{
     fade?: boolean;
-    // TODO(thure): Restore autoScroll prop.
   }>
 >;
 
@@ -26,45 +25,29 @@ export const ScrollContainer = forwardRef<ScrollController, ScrollContainerProps
   ({ children, classNames, fade }, forwardedRef) => {
     const [viewport, setViewport] = useState<HTMLDivElement | null>(null);
 
-    // Controller.
+    // Scroll controller imperative ref
     useImperativeHandle(
       forwardedRef,
       () => ({
         scrollToBottom: () => {
           invariant(viewport);
           // NOTE: Should be instant otherwise scrollHeight might be out of date.
-          viewport.scrollTo({ top: viewport.scrollHeight, behavior: 'instant' });
+          viewport.scrollTo({ top: 0, behavior: 'instant' });
         },
       }),
       [viewport],
     );
 
-    useEffect(() => {
-      if (viewport) {
-        // debugger;
-      }
-    }, [viewport]);
-
-    useEffect(() => {
-      console.log('[child added]');
-    }, [Children.count(children)]);
-
     return (
-      <ScrollArea.Root classNames={mx('relative flex flex-col grow overflow-hidden', classNames)}>
-        {fade && viewport && (
+      <div className={mx('relative flex flex-col-reverse grow overflow-y-auto', classNames)} ref={setViewport}>
+        {fade && (
           <div
             role='none'
             className='z-10 absolute block-start-0 inset-inline-0 bs-24 pointer-events-none bg-gradient-to-b from-[--surface-bg] to-transparent pointer-events-none'
           />
         )}
-        <ScrollArea.Viewport ref={setViewport} classNames='overflow-anchored'>
-          {children}
-          <AnchoredOverflow.Anchor />
-        </ScrollArea.Viewport>
-        <ScrollArea.Scrollbar orientation='vertical'>
-          <ScrollArea.Thumb />
-        </ScrollArea.Scrollbar>
-      </ScrollArea.Root>
+        {[...Children.toArray(children)].reverse()}
+      </div>
     );
   },
 );

--- a/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.tsx
+++ b/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.tsx
@@ -39,14 +39,19 @@ export const ScrollContainer = forwardRef<ScrollController, ScrollContainerProps
     );
 
     return (
-      <div className={mx('relative flex flex-col-reverse grow overflow-y-auto', classNames)} ref={setViewport}>
+      <div className='relative flex-1 min-bs-0 grid'>
         {fade && (
           <div
             role='none'
             className='z-10 absolute block-start-0 inset-inline-0 bs-24 pointer-events-none bg-gradient-to-b from-[--surface-bg] to-transparent pointer-events-none'
           />
         )}
-        {[...Children.toArray(children)].reverse()}
+        <div
+          className={mx('flex flex-col-reverse min-bs-0 overflow-y-auto scrollbar-thin', classNames)}
+          ref={setViewport}
+        >
+          {[...Children.toArray(children)].reverse()}
+        </div>
       </div>
     );
   },


### PR DESCRIPTION
This PR:
- refactors to use `flex-col-reverse` to achieve native scroll anchoring of thread content
- applies the fade only when overflowing _and_ when not within 16 px of the top of the thread

https://github.com/user-attachments/assets/94b6184c-61a1-4ab1-8e61-e98804541ec9

