### PR TITLE
fix: don't subscribe to query

### DIFF
--- a/packages/plugins/experimental/plugin-automation/src/capabilities/complementary-panel.ts
+++ b/packages/plugins/experimental/plugin-automation/src/capabilities/complementary-panel.ts
@@ -16,31 +16,31 @@ import { AUTOMATION_PLUGIN } from '../meta';
 export default (context: PluginsContext) => {
   const state = create({ functionsAvailable: false });
   const setState = (next: boolean) => {
-    untracked(() => {
-      if (next !== state.functionsAvailable) {
-        state.functionsAvailable = next;
-      }
-    });
+    if (next !== state.functionsAvailable) {
+      state.functionsAvailable = next;
+    }
   };
 
   const unsubscribe = effect(() => {
     const client = context.requestCapabilities(ClientCapabilities.Client)[0];
     const workspace = context.requestCapabilities(Capabilities.Layout)[0]?.workspace;
-    const { spaceId } = parseId(workspace);
-    if (!spaceId || !client) {
-      setState(false);
-      return;
-    }
+    return untracked(() => {
+      const { spaceId } = parseId(workspace);
+      if (!spaceId || !client) {
+        setState(false);
+        return;
+      }
 
-    const space = client.spaces.get(spaceId);
-    if (!space) {
-      setState(false);
-      return;
-    }
+      const space = client.spaces.get(spaceId);
+      if (!space) {
+        setState(false);
+        return;
+      }
 
-    return space.db
-      .query(Filter.schema(FunctionType))
-      .subscribe((query) => setState(query.objects.length > 0), { fire: true });
+      return space.db
+        .query(Filter.schema(FunctionType))
+        .subscribe((query) => setState(query.objects.length > 0), { fire: true });
+    });
   });
 
   return contributes(


### PR DESCRIPTION
When subscribe is called with `{ fire: true }` is synchronously calls
the callback which accesses `objects` and subscribes to the query
signal. Placing within `untracked` resolves this.
