### PR TITLE
refactor: remove circular imports

### DIFF
--- a/packages/common/plate/src/api.ts
+++ b/packages/common/plate/src/api.ts
@@ -1,25 +1,13 @@
 //
 // Copyright 2023 DXOS.org
 //
+
 import callsite from 'callsite';
 import path from 'node:path';
 
-import {
-  BASENAME,
-  DirectoryTemplate,
-  type DirectoryTemplateLoadOptions,
-  type DirectoryTemplateOptions,
-} from './DirectoryTemplate';
-import {
-  InteractiveDirectoryTemplate,
-  type InteractiveDirectoryTemplateOptions,
-  type ExecuteInteractiveDirectoryTemplateOptions,
-} from './InteractiveDirectoryTemplate';
 import { type FileSlots, FileEffect } from './util/file';
 import { imports, type Imports } from './util/imports';
-import { safeLoadModule } from './util/loadModule';
 import { error } from './util/logger';
-import { type Optional } from './util/optional';
 import { pretty } from './util/pretty';
 import {
   type Context,
@@ -33,7 +21,6 @@ import {
   type ResultOf,
   type Slot,
 } from './util/template';
-import { type InquirableZodType } from './util/zodInquire';
 
 export type Group<I = any> = (context: Options<I, any>) => Template<I, any>[];
 
@@ -156,76 +143,3 @@ export class Plate<I = null, TSlots extends Slots<I> = {}> {
   }
 }
 export const template = <TInput = null>() => new Plate<TInput>();
-
-export type TemplateOptions<I> = Optional<DirectoryTemplateOptions<I>, 'src'>;
-
-export const directory = <I>(options: TemplateOptions<I>) => {
-  const stack = callsite();
-  const templateFile = stack[1].getFileName();
-  const dir = path.dirname(templateFile);
-  const { src, ...rest } = { src: dir, ...options };
-  return new DirectoryTemplate({
-    src: path.isAbsolute(src) ? src : path.resolve(dir, src),
-    ...rest,
-  });
-};
-
-export type InteractiveTemplateOptions<I extends InquirableZodType> = Optional<
-  InteractiveDirectoryTemplateOptions<I>,
-  'src'
->;
-
-export const interactiveDirectory = <I extends InquirableZodType>(options: InteractiveTemplateOptions<I>) => {
-  const stack = callsite();
-  const templateFile = stack[1].getFileName();
-  const dir = path.dirname(templateFile);
-  const { src, ...rest } = { src: dir, ...options };
-  return new InteractiveDirectoryTemplate({
-    src: path.isAbsolute(src) ? src : path.resolve(dir, src),
-    ...rest,
-  });
-};
-
-export const loadTemplate = async <T = InteractiveDirectoryTemplate<any>>(
-  src: string,
-  options?: DirectoryTemplateLoadOptions,
-) => {
-  const tsName = path.resolve(src, BASENAME + '.ts');
-  const jsName = path.resolve(src, BASENAME + '.js');
-  const { verbose } = { verbose: false, ...options };
-  try {
-    const module = (await safeLoadModule(tsName, options))?.module ?? (await safeLoadModule(jsName, options))?.module;
-    const config = { ...module?.default };
-    return config as T;
-  } catch (err: any) {
-    if (verbose) {
-      console.warn('exception while loading template config:\n' + err.toString());
-    }
-    throw err;
-  }
-};
-
-export const executeDirectoryTemplate = async <I extends InquirableZodType>(
-  options: ExecuteInteractiveDirectoryTemplateOptions<I>,
-) => {
-  const { src, verbose } = options;
-  if (!src) {
-    throw new Error('cannot load template without an src option');
-  }
-  const template = await loadTemplate(src, { verbose });
-  if (!template) {
-    throw new Error(`failed to load template function from ${src}`);
-  }
-  if (!(template instanceof DirectoryTemplate)) {
-    throw new Error(`template is not an executable template ${src}`);
-  }
-  if (!template.apply) {
-    throw new Error(`template does not have an apply function ${src}`);
-  }
-  try {
-    return template.apply(options);
-  } catch (err) {
-    console.error(`problem in template ${src}`);
-    throw err;
-  }
-};

--- a/packages/common/plate/src/index.ts
+++ b/packages/common/plate/src/index.ts
@@ -5,6 +5,7 @@
 export * from 'zod';
 export * from './api';
 export * from './DirectoryTemplate';
+export * from './InteractiveDirectoryTemplate';
 export * from './util/templateLiterals';
 export {
   type InputOf,

--- a/packages/common/plate/src/main.ts
+++ b/packages/common/plate/src/main.ts
@@ -8,7 +8,7 @@ import process from 'node:process';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-import { executeDirectoryTemplate } from './api';
+import { executeDirectoryTemplate } from './InteractiveDirectoryTemplate';
 import { catFiles } from './util/catFiles';
 import { logger } from './util/logger';
 


### PR DESCRIPTION
Removes circular imports in plate which were causing the docs build to
fail.
