### PR TITLE
feat(views): Hidden fields

### DIFF
--- a/packages/plugins/plugin-kanban/src/components/KanbanViewEditor.tsx
+++ b/packages/plugins/plugin-kanban/src/components/KanbanViewEditor.tsx
@@ -49,16 +49,10 @@ export const KanbanViewEditor = ({ kanban }: KanbanViewEditorProps) => {
     }
   }, [kanban?.cardView?.target, schema, JSON.stringify(schema)]);
 
-  const selectFields = useMemo(() => {
-    if (!projection) {
-      return [];
-    }
-
-    return projection
-      .getFieldProjections()
-      .filter((field) => field.props.format === FormatEnum.SingleSelect)
-      .map(({ field }) => ({ value: field.id, label: field.path }));
-  }, [projection]);
+  const fieldProjections = projection?.getFieldProjections() || [];
+  const selectFields = fieldProjections
+    .filter((field) => field.props.format === FormatEnum.SingleSelect)
+    .map(({ field }) => ({ value: field.id, label: field.path }));
 
   const onSave = useCallback(
     (values: Partial<{ columnFieldId: string }>) => {

--- a/packages/plugins/plugin-kanban/src/components/KanbanViewEditor.tsx
+++ b/packages/plugins/plugin-kanban/src/components/KanbanViewEditor.tsx
@@ -67,7 +67,7 @@ export const KanbanViewEditor = ({ kanban }: KanbanViewEditorProps) => {
     [kanban],
   );
 
-  const initialValues = useMemo(() => ({ columnFieldId: kanban.columnFieldId }), [kanban]);
+  const initialValues = useMemo(() => ({ columnFieldId: kanban.columnFieldId }), [kanban.columnFieldId]);
   const custom: CustomInputMap = useMemo(
     () => ({ columnFieldId: (props) => <SelectInput {...props} options={selectFields} /> }),
     [selectFields],

--- a/packages/sdk/schema/package.json
+++ b/packages/sdk/schema/package.json
@@ -42,6 +42,8 @@
     "@dxos/live-object": "workspace:*",
     "@dxos/log": "workspace:*",
     "@dxos/util": "workspace:*",
+    "@effect/schema": "^0.75.5",
+    "@preact/signals-core": "^1.6.0",
     "date-fns": "^3.3.1",
     "jsonpath": "^1.1.1"
   },

--- a/packages/sdk/schema/src/projection.test.ts
+++ b/packages/sdk/schema/src/projection.test.ts
@@ -20,10 +20,13 @@ import {
   EntityKind,
   getPropertyMetaAnnotation,
 } from '@dxos/echo-schema';
+import { registerSignalsRuntime } from '@dxos/echo-signals';
 import { invariant } from '@dxos/invariant';
 
 import { ViewProjection } from './projection';
 import { createView, type ViewType } from './view';
+
+registerSignalsRuntime();
 
 const getFieldId = (view: ViewType, path: string): string => {
   const field = view.fields.find((field) => field.path === path);
@@ -515,17 +518,17 @@ describe('ViewProjection', () => {
     // Hide the email field.
     const emailId = getFieldId(view, 'email');
     projection.hideFieldProjection(emailId);
+    projection.hideFieldProjection(createdAtId);
 
     // Check both hidden properties are returned.
     const multipleHidden = projection.getHiddenProperties();
-    expect(multipleHidden).to.have.length(1);
+    expect(multipleHidden).to.have.length(2);
     expect(multipleHidden).to.include('email');
+    expect(multipleHidden).to.include('createdAt');
 
     // Unhide email and verify ID is preserved
     projection.showFieldProjection('email' as JsonProp);
-    expect(view.fields).to.have.length(3);
     expect(getFieldId(view, 'email')).to.equal(emailId);
-    expect(view.hiddenFields).to.have.length(0);
 
     // Ensure schema still matches.
     expect(mutable.getSchemaSnapshot()).to.deep.equal(initialSchema);

--- a/packages/sdk/schema/src/projection.test.ts
+++ b/packages/sdk/schema/src/projection.test.ts
@@ -428,7 +428,6 @@ describe('ViewProjection', () => {
   });
 
   // TODO(burdon): Test changing format.
-
   test('hidden fields are tracked in hiddenFields', async ({ expect }) => {
     const { db } = await builder.createDatabase();
     const registry = new EchoSchemaRegistry(db);
@@ -524,6 +523,12 @@ describe('ViewProjection', () => {
     const multipleHidden = projection.getHiddenProperties();
     expect(multipleHidden).to.have.length(1);
     expect(multipleHidden).to.include('email');
+
+    // Unhide email and verify ID is preserved
+    projection.unhideFieldProjection('email' as JsonProp);
+    expect(view.fields).to.have.length(3);
+    expect(getFieldId(view, 'email')).to.equal(emailId);
+    expect(view.hiddenFields).to.have.length(0);
 
     // Ensure schema still matches.
     expect(mutable.getSchemaSnapshot()).to.deep.equal(initialSchema);

--- a/packages/sdk/schema/src/projection.test.ts
+++ b/packages/sdk/schema/src/projection.test.ts
@@ -481,7 +481,7 @@ describe('ViewProjection', () => {
     expect(hiddenProps[0]).to.equal('createdAt');
 
     // Verify we can unhide the hidden field.
-    projection.unhideFieldProjection('createdAt' as JsonProp);
+    projection.showFieldProjection('createdAt' as JsonProp);
     expect(projection.getFieldProjection(getFieldId(view, 'createdAt'))).to.exist;
     expect(view.fields).to.have.length(3);
     expect(view.fields.map((f) => f.path)).to.deep.equal(['name', 'email', 'createdAt']);
@@ -503,7 +503,7 @@ describe('ViewProjection', () => {
     expect(() => getFieldId(view, 'createdAt')).to.throw();
 
     // Unhide using the same property name.
-    projection.unhideFieldProjection('createdAt' as JsonProp);
+    projection.showFieldProjection('createdAt' as JsonProp);
 
     // Field should be back in visible fields with same ID.
     expect(view.fields).to.have.length(3);
@@ -522,7 +522,7 @@ describe('ViewProjection', () => {
     expect(multipleHidden).to.include('email');
 
     // Unhide email and verify ID is preserved
-    projection.unhideFieldProjection('email' as JsonProp);
+    projection.showFieldProjection('email' as JsonProp);
     expect(view.fields).to.have.length(3);
     expect(getFieldId(view, 'email')).to.equal(emailId);
     expect(view.hiddenFields).to.have.length(0);

--- a/packages/sdk/schema/src/projection.test.ts
+++ b/packages/sdk/schema/src/projection.test.ts
@@ -21,7 +21,6 @@ import {
   getPropertyMetaAnnotation,
 } from '@dxos/echo-schema';
 import { invariant } from '@dxos/invariant';
-import { getSnapshot } from '@dxos/live-object';
 
 import { ViewProjection } from './projection';
 import { createView, type ViewType } from './view';

--- a/packages/sdk/schema/src/projection.ts
+++ b/packages/sdk/schema/src/projection.ts
@@ -140,7 +140,7 @@ export class ViewProjection {
   hideFieldProjection(fieldId: string): void {
     const index = this._view.fields.findIndex((field) => field.id === fieldId);
     if (index !== -1) {
-      const fieldToHide = this._view.fields[index];
+      const fieldToHide = getSnapshot(this._view.fields[index]);
       this._view.fields.splice(index, 1);
       if (!this._view.hiddenFields) {
         this._view.hiddenFields = [];
@@ -163,7 +163,7 @@ export class ViewProjection {
       const hiddenIndex = this._view.hiddenFields.findIndex((field) => field.path === property);
 
       if (hiddenIndex !== -1) {
-        const fieldToUnhide = this._view.hiddenFields[hiddenIndex];
+        const fieldToUnhide = getSnapshot(this._view.hiddenFields[hiddenIndex]);
         this._view.hiddenFields.splice(hiddenIndex, 1);
         this._view.fields.push(fieldToUnhide);
         return;

--- a/packages/sdk/schema/src/projection.ts
+++ b/packages/sdk/schema/src/projection.ts
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 DXOS.org
+// Copyright 2025 DXOS.org
 //
 
 import { computed, untracked } from '@preact/signals-core';

--- a/packages/sdk/schema/src/projection.ts
+++ b/packages/sdk/schema/src/projection.ts
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import { computed, ReadonlySignal } from '@preact/signals-core';
+import { computed } from '@preact/signals-core';
 
 import {
   formatToType,

--- a/packages/sdk/schema/src/projection.ts
+++ b/packages/sdk/schema/src/projection.ts
@@ -42,6 +42,9 @@ export class ViewProjection {
   private readonly _encode = S.encodeSync(PropertySchema);
   private readonly _decode = S.decodeSync(PropertySchema, {});
 
+  private _fieldProjections = computed(() => this._view.fields.map((field) => this.getFieldProjection(field.id)));
+  private _hiddenProperties = computed(() => this._view.hiddenFields?.map((field) => field.path as string) ?? []);
+
   constructor(
     // TODO(burdon): This could be StoredSchema?
     // TODO(burdon): How to use tables with static schema.
@@ -130,21 +133,13 @@ export class ViewProjection {
     return this.getFieldProjection(fieldId);
   }
 
-  private _fieldProjectionsComputed = computed(() =>
-    this._view.fields.map((field) => this.getFieldProjection(field.id)),
-  );
-
   /**
    * Get all field projections
    * @reactive
    */
   getFieldProjections(): FieldProjection[] {
-    return this._fieldProjectionsComputed.value;
+    return this._fieldProjections.value;
   }
-
-  private _hiddenPropertiesComputed = computed(
-    () => this._view.hiddenFields?.map((field) => field.path as string) ?? [],
-  );
 
   /**
    * Identifies schema properties not visible in the current view projection.
@@ -152,7 +147,7 @@ export class ViewProjection {
    * @reactive
    */
   getHiddenProperties(): string[] {
-    return this._hiddenPropertiesComputed.value;
+    return this._hiddenProperties.value;
   }
 
   /**

--- a/packages/sdk/schema/src/projection.ts
+++ b/packages/sdk/schema/src/projection.ts
@@ -169,7 +169,7 @@ export class ViewProjection {
     });
   }
 
-  unhideFieldProjection(property: JsonProp): void {
+  showFieldProjection(property: JsonProp): void {
     untracked(() => {
       invariant(this._schema.jsonSchema.properties);
       invariant(property in this._schema.jsonSchema.properties);

--- a/packages/sdk/schema/src/view.ts
+++ b/packages/sdk/schema/src/view.ts
@@ -70,6 +70,12 @@ export class ViewType extends TypedObject({
   fields: S.mutable(S.Array(FieldSchema)),
 
   /**
+   * Array of fields that are part of the view's schema but hidden from UI display.
+   * These fields follow the FieldSchema structure but are marked for exclusion from visual rendering.
+   */
+  hiddenFields: S.optional(S.mutable(S.Array(FieldSchema))),
+
+  /**
    * Additional metadata for the view.
    */
   metadata: S.optional(S.Record({ key: S.String, value: S.Any }).pipe(S.mutable)),

--- a/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
+++ b/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { type SchemaRegistry } from '@dxos/echo-db';
-import { AST, Format, type EchoSchema, S } from '@dxos/echo-schema';
+import { AST, Format, type EchoSchema, S, type JsonProp } from '@dxos/echo-schema';
 import { IconButton, type ThemedClassName, useTranslation } from '@dxos/react-ui';
 import { List } from '@dxos/react-ui-list';
 import { ghostHover, inputTextLabel, mx } from '@dxos/react-ui-theme';
@@ -101,6 +101,25 @@ export const ViewEditor = ({
 
   const handleClose = useCallback(() => setField(undefined), []);
 
+  const hiddenProperties = projection.getHiddenProperties();
+
+  const handleUnhide = useCallback(
+    (property: string) => {
+      projection.unhideFieldProjection(property as JsonProp);
+    },
+    [projection],
+  );
+
+  const handleHide = useCallback(
+    (fieldId: string) => {
+      projection.hideFieldProjection(fieldId);
+      if (field?.id === fieldId) {
+        setField(undefined);
+      }
+    },
+    [projection, field],
+  );
+
   return (
     <div role='none' className={mx('flex flex-col w-full divide-y divide-separator', classNames)}>
       <Form<ViewMetaType> autoSave schema={ViewMetaSchema} values={viewValues} onSave={handleViewUpdate} />
@@ -131,7 +150,14 @@ export const ViewEditor = ({
                   <List.Item<FieldType> key={field.id} item={field} classNames={mx(grid, ghostHover, 'cursor-pointer')}>
                     <List.ItemDragHandle />
                     <List.ItemTitle onClick={() => handleSelect(field)}>{field.path}</List.ItemTitle>
-                    <List.ItemDeleteButton disabled={view.fields.length <= 1} onClick={() => onDelete(field.id)} />
+                    <div className='flex items-center gap-2 -ml-4'>
+                      <List.ItemButton
+                        icon='ph--eye-slash--regular'
+                        disabled={view.fields.length <= 1}
+                        onClick={() => handleHide(field.id)}
+                      />
+                      <List.ItemDeleteButton disabled={view.fields.length <= 1} onClick={() => onDelete(field.id)} />
+                    </div>
                   </List.Item>
                 ))}
               </div>
@@ -139,6 +165,32 @@ export const ViewEditor = ({
           )}
         </List.Root>
       </div>
+
+      {hiddenProperties.length > 0 && (
+        <div>
+          <div role='none' className='p-2'>
+            <label className={mx(inputTextLabel)}>{t('hidden fields label')}</label>
+          </div>
+
+          <List.Root<string>
+            items={hiddenProperties}
+            isItem={(item): item is string => typeof item === 'string'}
+            getId={(property) => property}
+          >
+            {({ items: properties }) => (
+              <div role='list' className='flex flex-col w-full'>
+                {properties?.map((property) => (
+                  <List.Item<string> key={property} item={property} classNames={mx(grid, ghostHover, 'cursor-pointer')}>
+                    <div />
+                    <List.ItemTitle>{property}</List.ItemTitle>
+                    <List.ItemButton icon='ph--eye--regular' onClick={() => handleUnhide(property)} />
+                  </List.Item>
+                ))}
+              </div>
+            )}
+          </List.Root>
+        </div>
+      )}
 
       {field && (
         <FieldEditor

--- a/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
+++ b/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
@@ -111,10 +111,12 @@ export const ViewEditor = ({
 
   const handleClose = useCallback(() => setField(undefined), []);
 
+  // TODO(ZaymonFC): Make this reactive?
   const hiddenProperties = projection.getHiddenProperties();
 
   const handleUnhide = useCallback(
     (property: string) => {
+      setField(undefined);
       projection.unhideFieldProjection(property as JsonProp);
     },
     [projection],
@@ -122,12 +124,10 @@ export const ViewEditor = ({
 
   const handleHide = useCallback(
     (fieldId: string) => {
+      setField(undefined);
       projection.hideFieldProjection(fieldId);
-      if (field?.id === fieldId) {
-        setField(undefined);
-      }
     },
-    [projection, field],
+    [projection],
   );
 
   return (

--- a/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
+++ b/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
@@ -113,18 +113,18 @@ export const ViewEditor = ({
 
   const hiddenProperties = projection.getHiddenProperties();
 
-  const handleUnhide = useCallback(
-    (property: string) => {
-      setField(undefined);
-      projection.unhideFieldProjection(property as JsonProp);
-    },
-    [projection],
-  );
-
   const handleHide = useCallback(
     (fieldId: string) => {
       setField(undefined);
       projection.hideFieldProjection(fieldId);
+    },
+    [projection],
+  );
+
+  const handleShow = useCallback(
+    (property: string) => {
+      setField(undefined);
+      projection.showFieldProjection(property as JsonProp);
     },
     [projection],
   );
@@ -199,7 +199,7 @@ export const ViewEditor = ({
                     >
                       <div />
                       <List.ItemTitle>{property}</List.ItemTitle>
-                      <List.ItemButton icon='ph--eye--regular' onClick={() => handleUnhide(property)} />
+                      <List.ItemButton icon='ph--eye--regular' onClick={() => handleShow(property)} />
                     </List.Item>
                   ))}
                 </div>

--- a/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
+++ b/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
@@ -111,7 +111,6 @@ export const ViewEditor = ({
 
   const handleClose = useCallback(() => setField(undefined), []);
 
-  // TODO(ZaymonFC): Make this reactive?
   const hiddenProperties = projection.getHiddenProperties();
 
   const handleUnhide = useCallback(

--- a/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
+++ b/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
@@ -88,6 +88,16 @@ export const ViewEditor = ({
     setField(field);
   }, [view]);
 
+  const handleDelete = useCallback(
+    (fieldId: string) => {
+      if (fieldId === field?.id) {
+        setField(undefined);
+      }
+      onDelete(fieldId);
+    },
+    [onDelete, field],
+  );
+
   const handleMove = useCallback(
     (fromIndex: number, toIndex: number) => {
       // NOTE(ZaymonFC): Using arrayMove here causes a race condition with the kanban model.
@@ -156,7 +166,11 @@ export const ViewEditor = ({
                         disabled={view.fields.length <= 1}
                         onClick={() => handleHide(field.id)}
                       />
-                      <List.ItemDeleteButton disabled={view.fields.length <= 1} onClick={() => onDelete(field.id)} />
+                      <List.ItemDeleteButton
+                        icon='ph--trash--regular'
+                        disabled={view.fields.length <= 1}
+                        onClick={() => handleDelete(field.id)}
+                      />
                     </div>
                   </List.Item>
                 ))}
@@ -164,33 +178,37 @@ export const ViewEditor = ({
             </>
           )}
         </List.Root>
-      </div>
 
-      {hiddenProperties.length > 0 && (
-        <div>
-          <div role='none' className='p-2'>
-            <label className={mx(inputTextLabel)}>{t('hidden fields label')}</label>
+        {hiddenProperties.length > 0 && (
+          <div>
+            <div role='none' className='p-2'>
+              <label className={mx(inputTextLabel)}>{t('hidden fields label')}</label>
+            </div>
+
+            <List.Root<string>
+              items={hiddenProperties}
+              isItem={(item): item is string => typeof item === 'string'}
+              getId={(property) => property}
+            >
+              {({ items: properties }) => (
+                <div role='list' className='flex flex-col w-full'>
+                  {properties?.map((property) => (
+                    <List.Item<string>
+                      key={property}
+                      item={property}
+                      classNames={mx(grid, ghostHover, 'cursor-pointer')}
+                    >
+                      <div />
+                      <List.ItemTitle>{property}</List.ItemTitle>
+                      <List.ItemButton icon='ph--eye--regular' onClick={() => handleUnhide(property)} />
+                    </List.Item>
+                  ))}
+                </div>
+              )}
+            </List.Root>
           </div>
-
-          <List.Root<string>
-            items={hiddenProperties}
-            isItem={(item): item is string => typeof item === 'string'}
-            getId={(property) => property}
-          >
-            {({ items: properties }) => (
-              <div role='list' className='flex flex-col w-full'>
-                {properties?.map((property) => (
-                  <List.Item<string> key={property} item={property} classNames={mx(grid, ghostHover, 'cursor-pointer')}>
-                    <div />
-                    <List.ItemTitle>{property}</List.ItemTitle>
-                    <List.ItemButton icon='ph--eye--regular' onClick={() => handleUnhide(property)} />
-                  </List.Item>
-                ))}
-              </div>
-            )}
-          </List.Root>
-        </div>
-      )}
+        )}
+      </div>
 
       {field && (
         <FieldEditor

--- a/packages/ui/react-ui-form/src/translations.ts
+++ b/packages/ui/react-ui-form/src/translations.ts
@@ -9,6 +9,7 @@ export default [
     'en-US': {
       [translationKey]: {
         'fields label': 'Fields',
+        'hidden fields label': 'Hidden Fields',
 
         // TODO(burdon): Standardize field/property.
         'button add property': 'Add property',

--- a/packages/ui/react-ui-kanban/src/components/Kanban.tsx
+++ b/packages/ui/react-ui-kanban/src/components/Kanban.tsx
@@ -226,10 +226,17 @@ const CardForm = <T extends BaseKanbanItem>({ card, model, autoFocus }: CardForm
     if (!model.columnFieldPath) {
       return undefined;
     }
-    return {
-      [model.columnFieldPath]: () => <></>,
-    };
-  }, [model.columnFieldPath]);
+
+    const custom: ComponentProps<typeof Form>['Custom'] = {};
+    custom[model.columnFieldPath] = () => <></>;
+    for (const field of model.kanban.cardView?.target?.hiddenFields ?? []) {
+      custom[field.path] = () => <></>;
+    }
+
+    return custom;
+  }, [model.columnFieldPath, JSON.stringify(model.kanban.cardView?.target?.hiddenFields)]);
+
+  console.log('Render kanban', Custom, JSON.stringify(model.kanban.cardView?.target?.hiddenFields));
 
   return (
     <Form

--- a/packages/ui/react-ui-kanban/src/components/Kanban.tsx
+++ b/packages/ui/react-ui-kanban/src/components/Kanban.tsx
@@ -236,8 +236,6 @@ const CardForm = <T extends BaseKanbanItem>({ card, model, autoFocus }: CardForm
     return custom;
   }, [model.columnFieldPath, JSON.stringify(model.kanban.cardView?.target?.hiddenFields)]);
 
-  console.log('Render kanban', Custom, JSON.stringify(model.kanban.cardView?.target?.hiddenFields));
-
   return (
     <Form
       values={initialValue}

--- a/packages/ui/react-ui-kanban/src/defs/kanban-model.ts
+++ b/packages/ui/react-ui-kanban/src/defs/kanban-model.ts
@@ -46,6 +46,10 @@ export class KanbanModel<T extends BaseKanbanItem = { id: string }> extends Reso
     this._computeArrangement();
   }
 
+  get kanban() {
+    return this._kanban;
+  }
+
   get id() {
     return this._kanban.id;
   }

--- a/packages/ui/react-ui-kanban/src/defs/kanban-model.ts
+++ b/packages/ui/react-ui-kanban/src/defs/kanban-model.ts
@@ -54,12 +54,12 @@ export class KanbanModel<T extends BaseKanbanItem = { id: string }> extends Reso
     return this._kanban.id;
   }
 
-  get columnFieldPath() {
+  get columnFieldPath(): JsonProp | undefined {
     const columnFieldId = this._kanban.columnFieldId;
     if (columnFieldId === undefined) {
       return undefined;
     }
-    const columnFieldProjection = this._projection.getFieldProjection(columnFieldId);
+    const columnFieldProjection = this._projection.tryGetFieldProjection(columnFieldId);
     return columnFieldProjection?.props.property;
   }
 
@@ -98,13 +98,10 @@ export class KanbanModel<T extends BaseKanbanItem = { id: string }> extends Reso
   }
 
   private initializeEffects(): void {
-    // Effect to recompute arrangement when columnField changes
     const arrangementWatcher = effect(() => {
-      // Touch the field to subscribe to changes
       const _ = this._kanban.columnFieldId;
       this._cards.value = this._computeArrangement();
     });
-
     this._ctx.onDispose(arrangementWatcher);
   }
 
@@ -161,7 +158,7 @@ export class KanbanModel<T extends BaseKanbanItem = { id: string }> extends Reso
       return [];
     }
 
-    return this._projection.getFieldProjection(this._kanban.columnFieldId).props.options ?? [];
+    return this._projection.tryGetFieldProjection(this._kanban.columnFieldId)?.props.options ?? [];
   }
 
   private _computeArrangement(): ArrangedCards<T> {

--- a/packages/ui/react-ui-list/src/components/List/List.tsx
+++ b/packages/ui/react-ui-list/src/components/List/List.tsx
@@ -7,6 +7,7 @@ import {
   type IconButtonProps,
   ListItem,
   ListItemDeleteButton,
+  ListItemButton,
   ListItemDragHandle,
   ListItemDragPreview,
   type ListItemProps,
@@ -35,6 +36,7 @@ export const List = {
   ItemWrapper: ListItemWrapper,
   ItemDragHandle: ListItemDragHandle,
   ItemDeleteButton: ListItemDeleteButton,
+  ItemButton: ListItemButton,
   ItemTitle: ListItemTitle,
   IconButton,
 };

--- a/packages/ui/react-ui-list/src/components/List/ListItem.tsx
+++ b/packages/ui/react-ui-list/src/components/List/ListItem.tsx
@@ -202,13 +202,14 @@ export const ListItemDeleteButton = ({
   autoHide = true,
   classNames,
   disabled,
+  icon = 'ph--x--regular',
   ...props
-}: Omit<IconButtonProps, 'icon'> & { autoHide?: boolean }) => {
+}: Partial<Pick<IconButtonProps, 'icon'>> & Omit<IconButtonProps, 'icon'> & { autoHide?: boolean }) => {
   const { state } = useListContext('DELETE_BUTTON');
   const isDisabled = state.type !== 'idle' || disabled;
   return (
     <IconButton
-      icon='ph--x--regular'
+      icon={icon}
       disabled={isDisabled}
       classNames={[classNames, autoHide && disabled && 'hidden']}
       {...props}

--- a/packages/ui/react-ui-list/src/components/List/ListItem.tsx
+++ b/packages/ui/react-ui-list/src/components/List/ListItem.tsx
@@ -216,6 +216,17 @@ export const ListItemDeleteButton = ({
   );
 };
 
+export const ListItemButton = ({
+  autoHide = true,
+  classNames,
+  disabled,
+  ...props
+}: IconButtonProps & { autoHide?: boolean }) => {
+  const { state } = useListContext('ITEM_BUTTON');
+  const isDisabled = state.type !== 'idle' || disabled;
+  return <IconButton disabled={isDisabled} classNames={[classNames, autoHide && disabled && 'hidden']} {...props} />;
+};
+
 export const ListItemDragHandle = () => {
   const { dragHandleRef } = useListItemContext('DRAG_HANDLE');
   return <IconButton ref={dragHandleRef as any} icon='ph--dots-six-vertical--regular' />;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10442,6 +10442,12 @@ importers:
       '@dxos/util':
         specifier: workspace:*
         version: link:../../common/util
+      '@effect/schema':
+        specifier: ^0.75.5
+        version: 0.75.5(effect@3.12.7)
+      '@preact/signals-core':
+        specifier: ^1.6.0
+        version: 1.6.0
       date-fns:
         specifier: ^3.3.1
         version: 3.6.0


### PR DESCRIPTION
- Resolves #8591 
---
- [x] Update the view projection to return hidden fields (fields that exist in the schema but not in the view)
- [x] View projection should check if its view field still exists in the schema
  - [x] Normalization pass on view projection construction?
- [x] Check which fields exist in the schema but not in the view and add those to hidden fields on view projection construction
- [x] Distinguish the difference between hiding a view field and deleting it
  - Deletion removes the field from the schema and will *impact* all other views
- [x] Test that snapshotting when deleting works as expected
- [x] View editor
  - Delineate between hiding and deleting
  - Show hidden fields (no rearrange?)
- [x] Fields should have a 'hidden' category
  - This will allow us to preserve field IDs so that if the user toggles hide/unhide in a kanban, the column won't get nuked
  - [x] We will coalesce fields that are there but 'hidden' and fields that are in the underlying schema
  - [x] Get field projections / get field projection shouldn't return hidden fields
- [x] Remove the separator
- [x] Resolve panic when hiding kanban pivot column