### PR TITLE
fix: deck crash

### DIFF
--- a/packages/plugins/plugin-deck/src/capabilities/intent-resolver.ts
+++ b/packages/plugins/plugin-deck/src/capabilities/intent-resolver.ts
@@ -327,7 +327,7 @@ export default (context: PluginsContext) =>
         const state = context.requestCapability(DeckCapabilities.MutableDeckState);
         // TODO(thure): Reactivity only works when creating a lexically new `activeCompanions`… Are these not proxy objects?
         if (data.companion === null) {
-          const { [data.primary]: _, ...nextActiveCompanions } = state.deck.activeCompanions;
+          const { [data.primary]: _, ...nextActiveCompanions } = state.deck.activeCompanions ?? {};
           state.deck.activeCompanions = nextActiveCompanions;
         } else {
           state.deck.activeCompanions = {

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/DeckLayout.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/DeckLayout.tsx
@@ -191,7 +191,7 @@ export const DeckLayout = ({ overscroll, showHints, onDismissToast }: DeckLayout
     return active.reduce(
       (acc: { result: Record<string, number>; cursor: number }, entryId) => {
         acc.result[entryId] = acc.cursor + 1;
-        acc.cursor += activeCompanions[entryId] ? 3 : 2;
+        acc.cursor += activeCompanions?.[entryId] ? 3 : 2;
         return acc;
       },
       { result: {}, cursor: 0 },
@@ -273,7 +273,7 @@ export const DeckLayout = ({ overscroll, showHints, onDismissToast }: DeckLayout
                       <PlankSeparator order={order[entryId] - 1} />
                       <Plank
                         id={entryId}
-                        companionId={activeCompanions[entryId]}
+                        companionId={activeCompanions?.[entryId]}
                         part='deck'
                         order={order[entryId]}
                         active={active}
@@ -293,7 +293,7 @@ export const DeckLayout = ({ overscroll, showHints, onDismissToast }: DeckLayout
                 <StackContext.Provider value={{ size: 'contain', orientation: 'horizontal', rail: true }}>
                   <Plank
                     id={solo}
-                    companionId={solo ? activeCompanions[solo] : undefined}
+                    companionId={solo ? activeCompanions?.[solo] : undefined}
                     part='solo'
                     layoutMode={layoutMode}
                   />

--- a/packages/plugins/plugin-deck/src/types.ts
+++ b/packages/plugins/plugin-deck/src/types.ts
@@ -56,7 +56,8 @@ export const Deck = S.Struct({
     description: "If false, the deck has not yet left solo mode and new planks should be solo'd.",
   }),
   active: S.mutable(S.Array(S.String)),
-  activeCompanions: S.Record({ key: S.String, value: S.String }).pipe(S.mutable),
+  // TODO(wittjosiah): Piping into both mutable and optional caused invalid typescript output.
+  activeCompanions: S.optional(S.mutable(S.Record({ key: S.String, value: S.String }))),
   inactive: S.mutable(S.Array(S.String)),
   solo: S.optional(S.String),
   fullscreen: S.Boolean,

--- a/toolbox.json
+++ b/toolbox.json
@@ -52,7 +52,7 @@
       "include": [
         "packages/plugins/*",
         "packages/plugins/experimental/*",
-        "packages/ui/*",
+        "packages/ui/react-ui*",
         "packages/devtools/devtools",
         "packages/sdk/app-graph",
         "packages/sdk/app-framework",

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -256,9 +256,6 @@
       "@dxos/shell/testing": [
         "packages/sdk/shell/src/testing/index.ts"
       ],
-      "@dxos/brand": [
-        "packages/ui/brand/src/index.ts"
-      ],
       "@dxos/react-ui": [
         "packages/ui/react-ui/src/index.ts"
       ],


### PR DESCRIPTION
deck state is persisted to localstorage so new fields need to be optional else they can cause crashes when accessing missing state