### PR TITLE
refactor: remove indirection of placeholder translations

### DIFF
--- a/packages/plugins/experimental/plugin-assistant/src/AssistantPlugin.tsx
+++ b/packages/plugins/experimental/plugin-assistant/src/AssistantPlugin.tsx
@@ -40,14 +40,12 @@ export const AssistantPlugin = () =>
         contributes(Capabilities.Metadata, {
           id: TemplateType.typename,
           metadata: {
-            placeholder: ['template title placeholder', { ns: ASSISTANT_PLUGIN }],
             icon: 'ph--code-block--regular',
           },
         }),
         contributes(Capabilities.Metadata, {
           id: AIChatType.typename,
           metadata: {
-            placeholder: ['chat title placeholder', { ns: ASSISTANT_PLUGIN }],
             icon: 'ph--atom--regular',
           },
         }),

--- a/packages/plugins/experimental/plugin-assistant/src/translations.ts
+++ b/packages/plugins/experimental/plugin-assistant/src/translations.ts
@@ -10,14 +10,14 @@ export default [
     'en-US': {
       [AIChatType.typename]: {
         'typename label': 'AI Chat',
+        'object name placeholder': 'AI Chat',
       },
       [TemplateType.typename]: {
         'typename label': 'Template',
+        'object name placeholder': 'New template',
       },
       [ASSISTANT_PLUGIN]: {
-        'chat title placeholder': 'AI Chat',
         'templates label': 'Templates',
-        'template title placeholder': 'Template',
 
         'open ambient chat label': 'Open AI chat',
         'plugin name': 'Assistant',

--- a/packages/plugins/experimental/plugin-conductor/src/ConductorPlugin.tsx
+++ b/packages/plugins/experimental/plugin-conductor/src/ConductorPlugin.tsx
@@ -11,7 +11,7 @@ import { defineObjectForm } from '@dxos/plugin-space/types';
 import { CanvasBoardType } from '@dxos/react-ui-canvas-editor';
 
 import { IntentResolver, ReactSurface } from './capabilities';
-import { CONDUCTOR_PLUGIN, meta } from './meta';
+import { meta } from './meta';
 import translations from './translations';
 import { ConductorAction } from './types';
 
@@ -29,7 +29,6 @@ export const ConductorPlugin = () =>
         contributes(Capabilities.Metadata, {
           id: CanvasBoardType.typename,
           metadata: {
-            placeholder: ['canvas title placeholder', { ns: CONDUCTOR_PLUGIN }],
             icon: 'ph--infinity--regular',
           },
         }),

--- a/packages/plugins/experimental/plugin-conductor/src/translations.ts
+++ b/packages/plugins/experimental/plugin-conductor/src/translations.ts
@@ -11,11 +11,10 @@ export default [
     'en-US': {
       [CanvasBoardType.typename]: {
         'typename label': 'Circuit',
+        'object name placeholder': 'New circuit',
       },
       [CONDUCTOR_PLUGIN]: {
         'plugin name': 'Conductor',
-        'canvas title placeholder': 'New circuit',
-        'create canvas label': 'Create circuit',
         'content placeholder': 'Enter text...',
       },
     },

--- a/packages/plugins/experimental/plugin-excalidraw/src/SketchPlugin.tsx
+++ b/packages/plugins/experimental/plugin-excalidraw/src/SketchPlugin.tsx
@@ -9,7 +9,7 @@ import { SpaceCapabilities } from '@dxos/plugin-space';
 import { defineObjectForm } from '@dxos/plugin-space/types';
 
 import { ExcalidrawSettings, IntentResolvers, ReactSurface } from './capabilities';
-import { meta, EXCALIDRAW_PLUGIN } from './meta';
+import { meta } from './meta';
 import translations from './translations';
 import { SketchAction } from './types';
 
@@ -32,7 +32,6 @@ export const ExcalidrawPlugin = () =>
         contributes(Capabilities.Metadata, {
           id: DiagramType.typename,
           metadata: {
-            placeholder: ['object placeholder', { ns: EXCALIDRAW_PLUGIN }],
             icon: 'ph--compass-tool--regular',
           },
         }),

--- a/packages/plugins/experimental/plugin-excalidraw/src/translations.ts
+++ b/packages/plugins/experimental/plugin-excalidraw/src/translations.ts
@@ -2,16 +2,19 @@
 // Copyright 2023 DXOS.org
 //
 
+import { DiagramType } from '@dxos/plugin-sketch/types';
+
 import { EXCALIDRAW_PLUGIN } from './meta';
 
 export default [
   {
     'en-US': {
+      [DiagramType.typename]: {
+        'typename label': 'Excalidraw',
+        'object name placeholder': 'New excalidraw',
+      },
       [EXCALIDRAW_PLUGIN]: {
         'plugin name': 'Sketch',
-        'object placeholder': 'New sketch',
-        'create object label': 'Create sketch (Excalidraw)',
-        'create stack section label': 'Create sketch',
         'settings hover tools label': 'Auto hide controls',
         'settings grid type label': 'Dotted grid',
       },

--- a/packages/plugins/experimental/plugin-explorer/src/ExplorerPlugin.tsx
+++ b/packages/plugins/experimental/plugin-explorer/src/ExplorerPlugin.tsx
@@ -8,7 +8,7 @@ import { SpaceCapabilities } from '@dxos/plugin-space';
 import { defineObjectForm } from '@dxos/plugin-space/types';
 
 import { IntentResolver, ReactSurface } from './capabilities';
-import { EXPLORER_PLUGIN, meta } from './meta';
+import { meta } from './meta';
 import translations from './translations';
 import { ViewType, ExplorerAction } from './types';
 
@@ -26,7 +26,6 @@ export const ExplorerPlugin = () =>
         contributes(Capabilities.Metadata, {
           id: ViewType.typename,
           metadata: {
-            placeholder: ['object placeholder', { ns: EXPLORER_PLUGIN }],
             icon: 'ph--graph--regular',
           },
         }),

--- a/packages/plugins/experimental/plugin-explorer/src/translations.ts
+++ b/packages/plugins/experimental/plugin-explorer/src/translations.ts
@@ -10,12 +10,11 @@ export default [
     'en-US': {
       [ViewType.typename]: {
         'typename label': 'Explorer',
+        'object name placeholder': 'New explorer',
       },
       [EXPLORER_PLUGIN]: {
         'plugin name': 'Explorer',
         'object title label': 'Title',
-        'object placeholder': 'New explorer',
-        'create object label': 'Create explorer',
       },
     },
   },

--- a/packages/plugins/experimental/plugin-inbox/src/InboxPlugin.tsx
+++ b/packages/plugins/experimental/plugin-inbox/src/InboxPlugin.tsx
@@ -9,7 +9,7 @@ import { SpaceCapabilities } from '@dxos/plugin-space';
 import { defineObjectForm } from '@dxos/plugin-space/types';
 
 import { ArtifactDefinition, IntentResolver, ReactSurface } from './capabilities';
-import { INBOX_PLUGIN, meta } from './meta';
+import { meta } from './meta';
 import translations from './translations';
 import { CalendarType, ContactsType, EventType, InboxAction, MailboxType } from './types';
 
@@ -27,21 +27,18 @@ export const InboxPlugin = () =>
         contributes(Capabilities.Metadata, {
           id: MailboxType.typename,
           metadata: {
-            placeholder: ['mailbox title placeholder', { ns: INBOX_PLUGIN }],
             icon: 'ph--envelope--regular',
           },
         }),
         contributes(Capabilities.Metadata, {
           id: ContactsType.typename,
           metadata: {
-            placeholder: ['contacts title placeholder', { ns: INBOX_PLUGIN }],
             icon: 'ph--address-book--regular',
           },
         }),
         contributes(Capabilities.Metadata, {
           id: CalendarType.typename,
           metadata: {
-            placeholder: ['calendar title placeholder', { ns: INBOX_PLUGIN }],
             icon: 'ph--calendar--regular',
           },
         }),

--- a/packages/plugins/experimental/plugin-inbox/src/translations.ts
+++ b/packages/plugins/experimental/plugin-inbox/src/translations.ts
@@ -3,22 +3,29 @@
 //
 
 import { INBOX_PLUGIN } from './meta';
+import { CalendarType, ContactsType, MailboxType } from './types';
 
 export default [
   {
     'en-US': {
+      [MailboxType.typename]: {
+        'typename label': 'Mailbox',
+        'object name placeholder': 'New mailbox',
+      },
+      [ContactsType.typename]: {
+        'typename label': 'Contacts',
+        'object name placeholder': 'New contacts',
+      },
+      [CalendarType.typename]: {
+        'typename label': 'Calendar',
+        'object name placeholder': 'New calendar',
+      },
       [INBOX_PLUGIN]: {
         'plugin name': 'Inbox',
-        'create mailbox label': 'Create mailbox',
-        'mailbox title placeholder': 'New mailbox',
         'no messages': 'Mailbox empty',
         'action archive': 'Archive',
         'action delete': 'Delete',
         'action mark read': 'Mark as read',
-        'create calendar label': 'Create calendar',
-        'calendar title placeholder': 'New calendar',
-        'create contacts label': 'Create contacts',
-        'contacts title placeholder': 'New contacts',
       },
     },
   },

--- a/packages/plugins/experimental/plugin-outliner/src/OutlinerPlugin.tsx
+++ b/packages/plugins/experimental/plugin-outliner/src/OutlinerPlugin.tsx
@@ -8,7 +8,7 @@ import { SpaceCapabilities } from '@dxos/plugin-space';
 import { defineObjectForm } from '@dxos/plugin-space/types';
 
 import { IntentResolver, ReactSurface } from './capabilities';
-import { meta, OUTLINER_PLUGIN } from './meta';
+import { meta } from './meta';
 import translations from './translations';
 import { JournalEntryType, JournalType, OutlinerAction, OutlineType, TaskType, TreeType } from './types';
 
@@ -26,22 +26,13 @@ export const OutlinerPlugin = () =>
         contributes(Capabilities.Metadata, {
           id: JournalType.typename,
           metadata: {
-            placeholder: ['journal object placeholder', { ns: OUTLINER_PLUGIN }],
             icon: 'ph--calendar-check--regular',
           },
         }),
         contributes(Capabilities.Metadata, {
           id: OutlineType.typename,
           metadata: {
-            placeholder: ['outline object placeholder', { ns: OUTLINER_PLUGIN }],
             icon: 'ph--tree-structure--regular',
-          },
-        }),
-        contributes(Capabilities.Metadata, {
-          id: TaskType.typename,
-          metadata: {
-            placeholder: ['task object placeholder', { ns: OUTLINER_PLUGIN }],
-            icon: 'ph--check-square-offset--regular',
           },
         }),
       ],

--- a/packages/plugins/experimental/plugin-outliner/src/translations.ts
+++ b/packages/plugins/experimental/plugin-outliner/src/translations.ts
@@ -10,14 +10,14 @@ export default [
     'en-US': {
       [JournalType.typename]: {
         'typename label': 'Journal',
+        'object name placeholder': 'New journal',
       },
       [OutlineType.typename]: {
         'typename label': 'Outline',
+        'object name placeholder': 'New outline',
       },
       [OUTLINER_PLUGIN]: {
         'plugin name': 'Outliner',
-        'journal object placeholder': 'New journal',
-        'outline object placeholder': 'New outline',
         'delete object label': 'Delete item',
         'create entry label': 'Create entry',
         'text placeholder': 'Enter text...',

--- a/packages/plugins/experimental/plugin-outliner/src/translations.ts
+++ b/packages/plugins/experimental/plugin-outliner/src/translations.ts
@@ -3,7 +3,7 @@
 //
 
 import { OUTLINER_PLUGIN } from './meta';
-import { JournalType, TreeType } from './types';
+import { JournalType, OutlineType } from './types';
 
 export default [
   {
@@ -11,7 +11,7 @@ export default [
       [JournalType.typename]: {
         'typename label': 'Journal',
       },
-      [TreeType.typename]: {
+      [OutlineType.typename]: {
         'typename label': 'Outline',
       },
       [OUTLINER_PLUGIN]: {

--- a/packages/plugins/experimental/plugin-script/src/ScriptPlugin.tsx
+++ b/packages/plugins/experimental/plugin-script/src/ScriptPlugin.tsx
@@ -44,7 +44,6 @@ export const ScriptPlugin = () =>
         contributes(Capabilities.Metadata, {
           id: ScriptType.typename,
           metadata: {
-            placeholder: ['object placeholder', { ns: SCRIPT_PLUGIN }],
             icon: 'ph--code--regular',
             // TODO(wittjosiah): Move out of metadata.
             loadReferences: async (script: ScriptType) => await RefArray.loadAll([script.source]),

--- a/packages/plugins/experimental/plugin-script/src/translations.ts
+++ b/packages/plugins/experimental/plugin-script/src/translations.ts
@@ -11,12 +11,10 @@ export default [
     'en-US': {
       [ScriptType.typename]: {
         'typename label': 'Script',
+        'object name placeholder': 'New script',
       },
       [SCRIPT_PLUGIN]: {
         'plugin name': 'Scripts',
-        'object placeholder': 'New script',
-        'create object label': 'Create script',
-        'create stack section label': 'Create script',
         'description label': 'Description',
         'description placeholder': 'Describe what the script does.',
         'binding placeholder': 'Function name',

--- a/packages/plugins/experimental/plugin-template/src/TemplatePlugin.tsx
+++ b/packages/plugins/experimental/plugin-template/src/TemplatePlugin.tsx
@@ -8,7 +8,7 @@ import { SpaceCapabilities } from '@dxos/plugin-space';
 import { defineObjectForm } from '@dxos/plugin-space/types';
 
 import { ReactSurface, IntentResolver } from './capabilities';
-import { meta, TEMPLATE_PLUGIN } from './meta';
+import { meta } from './meta';
 import translations from './translations';
 import { TemplateAction, TemplateType } from './types';
 
@@ -26,7 +26,6 @@ export const TemplatePlugin = () =>
         contributes(Capabilities.Metadata, {
           id: TemplateType.typename,
           metadata: {
-            placeholder: ['object placeholder', { ns: TEMPLATE_PLUGIN }],
             icon: 'ph--asterisk--regular',
           },
         }),

--- a/packages/plugins/experimental/plugin-template/src/translations.ts
+++ b/packages/plugins/experimental/plugin-template/src/translations.ts
@@ -3,14 +3,17 @@
 //
 
 import { TEMPLATE_PLUGIN } from './meta';
+import { TemplateType } from './types';
 
 export default [
   {
     'en-US': {
+      [TemplateType.typename]: {
+        'typename label': 'Template',
+        'object name placeholder': 'New template',
+      },
       [TEMPLATE_PLUGIN]: {
         'plugin name': 'Template',
-        'object placeholder': 'New object',
-        'create object label': 'Create object',
         'delete object label': 'Delete', // TODO(burdon): Standard for actions menu.
       },
     },

--- a/packages/plugins/experimental/plugin-transcription/src/TranscriptionPlugin.tsx
+++ b/packages/plugins/experimental/plugin-transcription/src/TranscriptionPlugin.tsx
@@ -6,7 +6,7 @@ import { Capabilities, Events, contributes, defineModule, definePlugin } from '@
 import { ClientCapabilities, ClientEvents } from '@dxos/plugin-client';
 
 import { AppGraphBuilder, IntentResolver, ReactSurface, TranscriptionCapabilities } from './capabilities';
-import { meta, TRANSCRIPTION_PLUGIN } from './meta';
+import { meta } from './meta';
 import translations from './translations';
 import { TranscriptType } from './types';
 
@@ -29,7 +29,6 @@ export const TranscriptionPlugin = () =>
         contributes(Capabilities.Metadata, {
           id: TranscriptType.typename,
           metadata: {
-            placeholder: ['transcript title placeholder', { ns: TRANSCRIPTION_PLUGIN }],
             icon: 'ph--subtitles--regular',
           },
         }),

--- a/packages/plugins/experimental/plugin-transcription/src/translations.ts
+++ b/packages/plugins/experimental/plugin-transcription/src/translations.ts
@@ -10,6 +10,7 @@ export default [
     'en-US': {
       [TranscriptType.typename]: {
         'typename label': 'Transcript',
+        'object name placeholder': 'New transcript',
       },
       [TRANSCRIPTION_PLUGIN]: {
         'plugin name': 'Transcription',

--- a/packages/plugins/plugin-chess/src/ChessPlugin.tsx
+++ b/packages/plugins/plugin-chess/src/ChessPlugin.tsx
@@ -8,7 +8,7 @@ import { SpaceCapabilities } from '@dxos/plugin-space';
 import { defineObjectForm } from '@dxos/plugin-space/types';
 
 import { ArtifactDefinition, IntentResolver, ReactSurface } from './capabilities';
-import { CHESS_PLUGIN, meta } from './meta';
+import { meta } from './meta';
 import translations from './translations';
 import { ChessAction, ChessType } from './types';
 
@@ -26,7 +26,6 @@ export const ChessPlugin = () =>
         contributes(Capabilities.Metadata, {
           id: ChessType.typename,
           metadata: {
-            placeholder: ['game title placeholder', { ns: CHESS_PLUGIN }],
             icon: 'ph--shield-chevron--regular',
           },
         }),

--- a/packages/plugins/plugin-chess/src/translations.ts
+++ b/packages/plugins/plugin-chess/src/translations.ts
@@ -10,11 +10,10 @@ export default [
     'en-US': {
       [ChessType.typename]: {
         'typename label': 'Game',
+        'object name placeholder': 'New game',
       },
       [CHESS_PLUGIN]: {
         'plugin name': 'Chess',
-        'game title placeholder': 'New game',
-        'create game label': 'Create game',
         'delete game label': 'Delete',
       },
     },

--- a/packages/plugins/plugin-kanban/src/KanbanPlugin.tsx
+++ b/packages/plugins/plugin-kanban/src/KanbanPlugin.tsx
@@ -9,7 +9,7 @@ import { defineObjectForm } from '@dxos/plugin-space/types';
 import { KanbanType, translations as kanbanTranslations } from '@dxos/react-ui-kanban';
 
 import { ArtifactDefinition, IntentResolver, ReactSurface } from './capabilities';
-import { KANBAN_PLUGIN, meta } from './meta';
+import { meta } from './meta';
 import translations from './translations';
 import { CreateKanbanSchema, KanbanAction } from './types';
 
@@ -27,7 +27,6 @@ export const KanbanPlugin = () =>
         contributes(Capabilities.Metadata, {
           id: KanbanType.typename,
           metadata: {
-            placeholder: ['kanban title placeholder', { ns: KANBAN_PLUGIN }],
             icon: 'ph--kanban--regular',
           },
         }),

--- a/packages/plugins/plugin-kanban/src/translations.ts
+++ b/packages/plugins/plugin-kanban/src/translations.ts
@@ -11,11 +11,11 @@ export default [
     'en-US': {
       [KanbanType.typename]: {
         'typename label': 'Kanban',
+        'object name placeholder': 'New kanban',
       },
       [KANBAN_PLUGIN]: {
         'plugin name': 'Kanban',
         'kanban title label': 'Title',
-        'kanban title placeholder': 'New kanban',
         'column title label': 'Column title',
         'column title placeholder': 'New column',
         'item title label': 'Item title',
@@ -24,7 +24,6 @@ export default [
         'add item label': 'Add card',
         'delete column label': 'Delete column',
         'delete item label': 'Delete card',
-        'create kanban label': 'Create kanban',
         'card field deleted label': 'Card field deleted',
         'card deleted label': 'Card deleted',
       },

--- a/packages/plugins/plugin-map/src/MapPlugin.tsx
+++ b/packages/plugins/plugin-map/src/MapPlugin.tsx
@@ -8,7 +8,7 @@ import { SpaceCapabilities } from '@dxos/plugin-space';
 import { defineObjectForm } from '@dxos/plugin-space/types';
 
 import { AppGraphBuilder, ArtifactDefinition, IntentResolver, ReactSurface, MapState } from './capabilities';
-import { MAP_PLUGIN, meta } from './meta';
+import { meta } from './meta';
 import translations from './translations';
 import { MapType, MapAction, CreateMapSchema } from './types';
 
@@ -34,7 +34,6 @@ export const MapPlugin = () =>
         contributes(Capabilities.Metadata, {
           id: MapType.typename,
           metadata: {
-            placeholder: ['object placeholder', { ns: MAP_PLUGIN }],
             icon: 'ph--compass--regular',
           },
         }),

--- a/packages/plugins/plugin-map/src/translations.ts
+++ b/packages/plugins/plugin-map/src/translations.ts
@@ -10,13 +10,11 @@ export default [
     'en-US': {
       [MapType.typename]: {
         'typename label': 'Map',
+        'object name placeholder': 'New map',
       },
       [MAP_PLUGIN]: {
         'plugin name': 'Maps',
-        'object placeholder': 'New map',
-        'create object label': 'Create map',
         'delete object label': 'Delete',
-        'create stack section label': 'Create map',
         'toggle type label': 'Toggle view',
       },
     },

--- a/packages/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -21,7 +21,7 @@ import {
   ArtifactDefinition,
 } from './capabilities';
 import { MarkdownEvents } from './events';
-import { MARKDOWN_PLUGIN, meta } from './meta';
+import { meta } from './meta';
 import translations from './translations';
 import { DocumentType, MarkdownAction } from './types';
 import { serializer } from './util';
@@ -55,7 +55,6 @@ export const MarkdownPlugin = () =>
           metadata: {
             label: (object: any) =>
               isInstanceOf(DocumentType, object) ? object.name || object.fallbackName : undefined,
-            placeholder: ['document title placeholder', { ns: MARKDOWN_PLUGIN }],
             icon: 'ph--text-aa--regular',
             graphProps: {
               managesAutofocus: true,

--- a/packages/plugins/plugin-markdown/src/capabilities/app-graph-serializer.ts
+++ b/packages/plugins/plugin-markdown/src/capabilities/app-graph-serializer.ts
@@ -23,7 +23,7 @@ export default (context: PluginsContext) =>
         const doc = node.data;
         const content = await doc.content.load();
         return {
-          name: doc.name || doc.fallbackName || translations[0]['en-US'][MARKDOWN_PLUGIN]['document title placeholder'],
+          name: doc.name || doc.fallbackName || translations[0]['en-US'][DocumentType.typename]['object name placeholder'],
           data: content.content,
           type: 'text/markdown',
         };

--- a/packages/plugins/plugin-markdown/src/capabilities/app-graph-serializer.ts
+++ b/packages/plugins/plugin-markdown/src/capabilities/app-graph-serializer.ts
@@ -9,7 +9,6 @@ import { getSchemaTypename } from '@dxos/echo-schema';
 import { SpaceAction, CollectionType } from '@dxos/plugin-space/types';
 import { isSpace } from '@dxos/react-client/echo';
 
-import { MARKDOWN_PLUGIN } from '../meta';
 import translations from '../translations';
 import { MarkdownAction, DocumentType } from '../types';
 
@@ -23,7 +22,8 @@ export default (context: PluginsContext) =>
         const doc = node.data;
         const content = await doc.content.load();
         return {
-          name: doc.name || doc.fallbackName || translations[0]['en-US'][DocumentType.typename]['object name placeholder'],
+          name:
+            doc.name || doc.fallbackName || translations[0]['en-US'][DocumentType.typename]['object name placeholder'],
           data: content.content,
           type: 'text/markdown',
         };

--- a/packages/plugins/plugin-markdown/src/translations.ts
+++ b/packages/plugins/plugin-markdown/src/translations.ts
@@ -12,16 +12,14 @@ export default [
     'en-US': {
       [getSchemaTypename(DocumentType)!]: {
         'typename label': 'Document',
+        'object name placeholder': 'New document',
       },
       [MARKDOWN_PLUGIN]: {
         'plugin name': 'Editor',
-        'create stack section label': 'Create document',
-        'document title placeholder': 'New document',
         'choose markdown from space dialog title': 'Choose one or more documents to add',
         // TODO(burdon): Style-guide for user-facing text (e.g., hints, questions, capitalization, etc.)
         'empty choose markdown from space message': 'None available; try creating a new one instead?',
         'chooser done label': 'Add selected',
-        'create document label': 'Create document',
         'editor placeholder': '',
         'editor input mode label': 'Editor input mode',
         'select editor input mode placeholder': 'Select editor input mode…',

--- a/packages/plugins/plugin-sheet/src/SheetPlugin.tsx
+++ b/packages/plugins/plugin-sheet/src/SheetPlugin.tsx
@@ -9,7 +9,7 @@ import { SpaceCapabilities, ThreadEvents } from '@dxos/plugin-space';
 import { defineObjectForm } from '@dxos/plugin-space/types';
 
 import { Markdown, Thread, ReactSurface, IntentResolver, ComputeGraphRegistry } from './capabilities';
-import { meta, SHEET_PLUGIN } from './meta';
+import { meta } from './meta';
 import { serializer } from './serializer';
 import translations from './translations';
 import { SheetAction, SheetType } from './types';
@@ -34,7 +34,6 @@ export const SheetPlugin = () =>
           id: SheetType.typename,
           metadata: {
             label: (object: any) => (object instanceof SheetType ? object.name : undefined),
-            placeholder: ['sheet title placeholder', { ns: SHEET_PLUGIN }],
             icon: 'ph--grid-nine--regular',
             serializer,
           },

--- a/packages/plugins/plugin-sheet/src/translations.ts
+++ b/packages/plugins/plugin-sheet/src/translations.ts
@@ -10,12 +10,10 @@ export default [
     'en-US': {
       [SheetType.typename]: {
         'typename label': 'Sheet',
+        'object name placeholder': 'New sheet',
       },
       [SHEET_PLUGIN]: {
         'plugin name': 'Sheets',
-        'sheet title placeholder': 'New sheet',
-        'create sheet label': 'Create sheet',
-        'create sheet section label': 'Create sheet',
         'cell placeholder': 'Cell value...',
         'range key alignment label': 'Align',
         'range key style label': 'Style',

--- a/packages/plugins/plugin-sketch/src/SketchPlugin.tsx
+++ b/packages/plugins/plugin-sketch/src/SketchPlugin.tsx
@@ -9,7 +9,7 @@ import { defineObjectForm } from '@dxos/plugin-space/types';
 import { RefArray } from '@dxos/react-client/echo';
 
 import { AppGraphSerializer, IntentResolver, ReactSurface, SketchSettings } from './capabilities';
-import { meta, SKETCH_PLUGIN } from './meta';
+import { meta } from './meta';
 import translations from './translations';
 import { CanvasType, DiagramType, SketchAction } from './types';
 import { serializer } from './util';
@@ -33,7 +33,6 @@ export const SketchPlugin = () =>
         contributes(Capabilities.Metadata, {
           id: DiagramType.typename,
           metadata: {
-            placeholder: ['object placeholder', { ns: SKETCH_PLUGIN }],
             icon: 'ph--compass-tool--regular',
             // TODO(wittjosiah): Move out of metadata.
             loadReferences: async (diagram: DiagramType) => await RefArray.loadAll([diagram.canvas]),

--- a/packages/plugins/plugin-sketch/src/capabilities/app-graph-serializer.ts
+++ b/packages/plugins/plugin-sketch/src/capabilities/app-graph-serializer.ts
@@ -8,7 +8,6 @@ import { Capabilities, chain, contributes, createIntent, type PluginsContext } f
 import { CollectionType, SpaceAction } from '@dxos/plugin-space/types';
 import { isSpace } from '@dxos/react-client/echo';
 
-import { SKETCH_PLUGIN } from '../meta';
 import translations from '../translations';
 import { SketchAction, DiagramType } from '../types';
 

--- a/packages/plugins/plugin-sketch/src/capabilities/app-graph-serializer.ts
+++ b/packages/plugins/plugin-sketch/src/capabilities/app-graph-serializer.ts
@@ -22,7 +22,7 @@ export default (context: PluginsContext) =>
         const diagram = node.data;
         const canvas = await diagram.canvas.load();
         return {
-          name: diagram.name || translations[0]['en-US'][SKETCH_PLUGIN]['object placeholder'],
+          name: diagram.name || translations[0]['en-US'][DiagramType.typename]['object name placeholder'],
           data: JSON.stringify({ schema: canvas.schema, content: canvas.content }),
           type: 'application/tldraw',
         };

--- a/packages/plugins/plugin-sketch/src/translations.ts
+++ b/packages/plugins/plugin-sketch/src/translations.ts
@@ -10,12 +10,10 @@ export default [
     'en-US': {
       [DiagramType.typename]: {
         'typename label': 'Sketch',
+        'object name placeholder': 'New sketch',
       },
       [SKETCH_PLUGIN]: {
         'plugin name': 'Sketch',
-        'object placeholder': 'New sketch',
-        'create object label': 'Create sketch',
-        'create stack section label': 'Create sketch',
         'settings hover tools label': 'Auto hide controls',
         'settings grid type label': 'Dotted grid',
       },

--- a/packages/plugins/plugin-space/src/SpacePlugin.tsx
+++ b/packages/plugins/plugin-space/src/SpacePlugin.tsx
@@ -94,7 +94,6 @@ export const SpacePlugin = ({
         contributes(Capabilities.Metadata, {
           id: CollectionType.typename,
           metadata: {
-            placeholder: ['unnamed collection label', { ns: SPACE_PLUGIN }],
             icon: 'ph--cards-three--regular',
             // TODO(wittjosiah): Move out of metadata.
             loadReferences: async (collection: CollectionType) =>

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-serializer.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-serializer.ts
@@ -46,8 +46,8 @@ export default (context: PluginsContext) =>
       inputType: CollectionType.typename,
       outputType: DIRECTORY_TYPE,
       serialize: (node) => ({
-        name: node.data.name ?? translations[0]['en-US'][SPACE_PLUGIN]['unnamed collection label'],
-        data: node.data.name ?? translations[0]['en-US'][SPACE_PLUGIN]['unnamed collection label'],
+        name: node.data.name ?? translations[0]['en-US'][CollectionType.typename]['object name placeholder'],
+        data: node.data.name ?? translations[0]['en-US'][CollectionType.typename]['object name placeholder'],
         type: DIRECTORY_TYPE,
       }),
       deserialize: async (data, ancestors) => {

--- a/packages/plugins/plugin-space/src/translations.ts
+++ b/packages/plugins/plugin-space/src/translations.ts
@@ -10,6 +10,7 @@ export default [
     'en-US': {
       [CollectionType.typename]: {
         'typename label': 'Collection',
+        'object name placeholder': 'New collection',
       },
       [SPACE_PLUGIN]: {
         'plugin name': 'Spaces',
@@ -64,9 +65,6 @@ export default [
         'missing object message': 'Object not available.',
         'missing object description':
           'The requested object has not been found yet. Ensure there are enough peers online in the space with an updated copy.',
-        'create collection label': 'Create collection',
-        'unnamed object label': 'New object',
-        'unnamed collection label': 'New collection',
         'create object in space label': 'Add to space',
         'create object in collection label': 'Add to collection',
         'share space label': 'Share',

--- a/packages/plugins/plugin-space/src/util.tsx
+++ b/packages/plugins/plugin-space/src/util.tsx
@@ -399,8 +399,7 @@ export const createObjectNode = ({
     properties: {
       ...partials,
       label: metadata.label?.(object) ||
-        object.name ||
-        metadata.placeholder || ['unnamed object label', { ns: SPACE_PLUGIN }],
+        object.name || ['object name placeholder', { ns: type, default: 'New object' }],
       icon: metadata.icon ?? 'ph--placeholder--regular',
       testId: 'spacePlugin.object',
       persistenceClass: 'echo',

--- a/packages/plugins/plugin-stack/src/StackPlugin.tsx
+++ b/packages/plugins/plugin-stack/src/StackPlugin.tsx
@@ -27,13 +27,6 @@ export const StackPlugin = () =>
       activatesOn: Events.SetupMetadata,
       activate: () => [
         contributes(Capabilities.Metadata, {
-          id: StackViewType.typename,
-          metadata: {
-            placeholder: ['stack title placeholder', { ns: STACK_PLUGIN }],
-            icon: 'ph--stack-simple--regular',
-          },
-        }),
-        contributes(Capabilities.Metadata, {
           id: SECTION_IDENTIFIER,
           metadata: {
             parse: (section: { object: ReactiveEchoObject<any> }, type: string) => {

--- a/packages/plugins/plugin-table/src/TablePlugin.tsx
+++ b/packages/plugins/plugin-table/src/TablePlugin.tsx
@@ -36,7 +36,6 @@ export const TablePlugin = () =>
           metadata: {
             // TODO(dmaretskyi): Use `getLabel` from `echo-schema`.
             label: (object: any) => (isInstanceOf(TableType, object) ? object.name : undefined),
-            placeholder: ['object placeholder', { ns: TABLE_PLUGIN }],
             icon: 'ph--table--regular',
             // TODO(wittjosiah): Move out of metadata.
             loadReferences: (table: TableType) => [], // loadObjectReferences(table, (table) => [table.schema]),

--- a/packages/plugins/plugin-table/src/translations.ts
+++ b/packages/plugins/plugin-table/src/translations.ts
@@ -11,17 +11,15 @@ export default [
     'en-US': {
       [TableType.typename]: {
         'typename label': 'Table',
+        'object name placeholder': 'New table',
       },
       [TABLE_PLUGIN]: {
         'plugin name': 'Tables',
-        'object placeholder': 'New table',
-        'create object label': 'Create table',
         'table name placeholder': 'Table name',
         'settings title': 'Table settings',
         'table schema label': 'Schema',
         'new schema': 'New schema',
         'continue label': 'Continue',
-        'create stack section label': 'Create table',
         'add row label': 'Add row',
         'save view label': 'Save view',
         'create comment': 'Create thread',

--- a/packages/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -47,7 +47,6 @@ export const ThreadPlugin = () =>
         contributes(Capabilities.Metadata, {
           id: ChannelType.typename,
           metadata: {
-            placeholder: ['channel name placeholder', { ns: THREAD_PLUGIN }],
             icon: 'ph--chat--regular',
             // TODO(wittjosiah): Move out of metadata.
             loadReferences: async (channel: ChannelType) => await RefArray.loadAll(channel.threads ?? []),

--- a/packages/plugins/plugin-thread/src/translations.ts
+++ b/packages/plugins/plugin-thread/src/translations.ts
@@ -11,13 +11,11 @@ export default [
     'en-US': {
       [ChannelType.typename]: {
         'typename label': 'Channel',
+        'object name placeholder': 'New channel',
       },
       [THREAD_PLUGIN]: {
         'plugin name': 'Threads',
-        'channel name placeholder': 'New channel',
         'channel title label': 'Title',
-        'delete channel label': 'Delete channel',
-        'create channel label': 'Create channel',
         'message placeholder': 'Reply…',
         'activity message': 'Processing…',
         'anonymous label': 'Anonymous',

--- a/packages/plugins/plugin-wnfs/src/WnfsPlugin.tsx
+++ b/packages/plugins/plugin-wnfs/src/WnfsPlugin.tsx
@@ -19,7 +19,7 @@ import { SpaceCapabilities } from '@dxos/plugin-space';
 import { defineObjectForm } from '@dxos/plugin-space/types';
 
 import { Blockstore, FileUploader, IntentResolver, Markdown, ReactSurface, WnfsCapabilities } from './capabilities';
-import { meta, WNFS_PLUGIN } from './meta';
+import { meta } from './meta';
 import translations from './translations';
 import { FileType, WnfsAction } from './types';
 

--- a/packages/plugins/plugin-wnfs/src/WnfsPlugin.tsx
+++ b/packages/plugins/plugin-wnfs/src/WnfsPlugin.tsx
@@ -51,7 +51,6 @@ export const WnfsPlugin = () =>
           id: FileType.typename,
           metadata: {
             label: (object: any) => (object instanceof FileType ? object.name : undefined),
-            placeholder: ['file title placeholder', { ns: WNFS_PLUGIN }],
             // TODO(wittjosiah): Would be nice if icon could change based on the type of the file.
             icon: 'ph--file--regular',
           },

--- a/packages/plugins/plugin-wnfs/src/translations.ts
+++ b/packages/plugins/plugin-wnfs/src/translations.ts
@@ -10,10 +10,10 @@ export default [
     'en-US': {
       [FileType.typename]: {
         'typename label': 'File',
+        'object name placeholder': 'New file',
       },
       [WNFS_PLUGIN]: {
         'plugin name': 'Files',
-        'file title placeholder': 'New file',
         'delete object label': 'Delete',
         'file input placeholder': 'Drop a file here, or click to select a file',
       },


### PR DESCRIPTION
This uses the same strategy as the CreateObjectDialog schema type labels but for the object graph node labels, foregoing the indirection through metadata