### PR TITLE
chore: Small refactor of dynamic table props

### DIFF
--- a/packages/apps/testbench-app/src/components/ItemTable.tsx
+++ b/packages/apps/testbench-app/src/components/ItemTable.tsx
@@ -17,7 +17,7 @@ export const ItemTable = <T extends ReactiveObject<any>>({ schema, objects = [] 
   const jsonSchema = useMemo(() => toJsonSchema(schema), [schema]);
   return (
     <div role='none' className='is-full bs-full'>
-      <DynamicTable data={objects} jsonSchema={jsonSchema} />
+      <DynamicTable jsonSchema={jsonSchema} objects={objects} />
     </div>
   );
 };

--- a/packages/devtools/devtools/src/components/MasterDetailTable.tsx
+++ b/packages/devtools/devtools/src/components/MasterDetailTable.tsx
@@ -13,6 +13,7 @@ import { Placeholder } from './Placeholder';
 
 export type MasterDetailTableProps = {
   properties: TablePropertyDefinition[];
+  // TODO(burdon): Rename to objects.
   data: Array<{ id: string; [key: string]: any }>;
   detailsTransform?: (data: any) => MaybePromise<any>;
   detailsPosition?: 'bottom' | 'right';
@@ -81,7 +82,7 @@ export const MasterDetailTable = ({
 
   return (
     <div className={mx('bs-full divide-y divide-separator', gridLayout)}>
-      <DynamicTable data={data} properties={properties} onRowClicked={handleRowClicked} features={features} />
+      <DynamicTable properties={properties} objects={data} onRowClicked={handleRowClicked} features={features} />
       <div className={mx('overflow-auto text-sm', detailsPosition === 'right' && 'border-separator border-is')}>
         {selected ? (
           isLoading ? (

--- a/packages/devtools/devtools/src/panels/client/TracingPanel/LogTable.tsx
+++ b/packages/devtools/devtools/src/panels/client/TracingPanel/LogTable.tsx
@@ -32,7 +32,7 @@ export const LogTable = ({ logs = [] }: { logs: LogEntry[] }) => {
     [],
   );
 
-  const tableData = useMemo(
+  const objects = useMemo(
     () =>
       logs.map((entry) => ({
         id: `${entry.timestamp}-${Math.random()}`, // Unique ID
@@ -47,5 +47,5 @@ export const LogTable = ({ logs = [] }: { logs: LogEntry[] }) => {
     [logs],
   );
 
-  return <DynamicTable data={tableData} properties={properties} />;
+  return <DynamicTable properties={properties} objects={objects} />;
 };

--- a/packages/devtools/devtools/src/panels/client/TracingPanel/TracingPanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/TracingPanel/TracingPanel.tsx
@@ -132,8 +132,8 @@ export const TracingPanel = () => {
       <DynamicTable
         data={resourceData}
         properties={resourceProperties}
-        onRowClicked={handleRowClicked}
         features={features}
+        onRowClicked={handleRowClicked}
       />
       <Tabs.Root defaultValue='details' className='flex flex-col grow overflow-hidden'>
         <Tabs.List className='flex divide-x divide-separator border-b border-separator'>

--- a/packages/devtools/devtools/src/panels/client/TracingPanel/TracingPanel.tsx
+++ b/packages/devtools/devtools/src/panels/client/TracingPanel/TracingPanel.tsx
@@ -103,7 +103,7 @@ export const TracingPanel = () => {
     [],
   );
 
-  const resourceData = useMemo(() => {
+  const objects = useMemo(() => {
     return Array.from(state.resources.values()).map((resourceState) => ({
       id: String(resourceState.resource.id),
       name: resourceState.resource.className,
@@ -130,7 +130,7 @@ export const TracingPanel = () => {
   return (
     <PanelContainer classNames={mx('grid grid-rows-[1fr_1fr] divide-y divide-separator')}>
       <DynamicTable
-        data={resourceData}
+        objects={objects}
         properties={resourceProperties}
         features={features}
         onRowClicked={handleRowClicked}

--- a/packages/devtools/devtools/src/panels/echo/ObjectsPanel/ObjectsPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/ObjectsPanel/ObjectsPanel.tsx
@@ -192,8 +192,8 @@ export const ObjectsPanel = (props: { space?: Space }) => {
           <DynamicTable
             data={tableData}
             properties={objectProperties}
-            onRowClicked={handleObjectRowClicked}
             features={features}
+            onRowClicked={handleObjectRowClicked}
           />
           <div
             className={mx(
@@ -216,7 +216,7 @@ export const ObjectsPanel = (props: { space?: Space }) => {
           </div>
           <div className={mx(!selected && 'p-1 border-bs !border-separator')}>
             {selected ? (
-              <DynamicTable data={historyData} properties={historyProperties} onRowClicked={handleHistoryRowClicked} />
+              <DynamicTable properties={historyProperties} data={historyData} onRowClicked={handleHistoryRowClicked} />
             ) : (
               <Placeholder label='History' />
             )}

--- a/packages/devtools/devtools/src/panels/echo/ObjectsPanel/ObjectsPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/ObjectsPanel/ObjectsPanel.tsx
@@ -82,14 +82,6 @@ export const ObjectsPanel = (props: { space?: Space }) => {
     return selected ? getEditHistory(selected).map(mapHistoryRow) : [];
   }, [selected]);
 
-  const onVersionClick = useCallback(
-    (version: HistoryRow) => {
-      setSelectedVersion(version);
-      setSelectedVersionObject(checkoutVersion(selected!, [version.hash]));
-    },
-    [selected],
-  );
-
   const objectProperties = useMemo(
     () => [
       { name: 'id', format: FormatEnum.DID },
@@ -118,7 +110,7 @@ export const ObjectsPanel = (props: { space?: Space }) => {
     [],
   );
 
-  const tableData = useMemo(() => {
+  const objects = useMemo(() => {
     return items.filter(textFilter(filter)).map((item) => ({
       id: item.id,
       type: getTypename(item),
@@ -151,13 +143,21 @@ export const ObjectsPanel = (props: { space?: Space }) => {
     [],
   );
 
-  const historyData = useMemo(() => {
+  const historyObjects = useMemo(() => {
     return history.map((item) => ({
       id: item.hash,
       hash: item.hash.slice(0, 8),
       actor: item.actor,
     }));
   }, [history, selectedVersion]);
+
+  const handleVersionClick = useCallback(
+    (version: HistoryRow) => {
+      setSelectedVersion(version);
+      setSelectedVersionObject(checkoutVersion(selected!, [version.hash]));
+    },
+    [selected],
+  );
 
   const handleHistoryRowClicked = useCallback(
     (row: any) => {
@@ -170,10 +170,10 @@ export const ObjectsPanel = (props: { space?: Space }) => {
       const versionItem = history.find((item) => item.hash === row.id);
 
       if (versionItem) {
-        onVersionClick(versionItem);
+        handleVersionClick(versionItem);
       }
     },
-    [history, onVersionClick, selected],
+    [history, handleVersionClick, selected],
   );
 
   const features: Partial<TableFeatures> = useMemo(() => ({ selection: { enabled: true, mode: 'single' } }), []);
@@ -190,8 +190,8 @@ export const ObjectsPanel = (props: { space?: Space }) => {
       <div className={mx('bs-full grid grid-cols-[4fr_3fr]', 'overflow-hidden', styles.border)}>
         <div className='flex flex-col w-full overflow-hidden'>
           <DynamicTable
-            data={tableData}
             properties={objectProperties}
+            objects={objects}
             features={features}
             onRowClicked={handleObjectRowClicked}
           />
@@ -216,7 +216,11 @@ export const ObjectsPanel = (props: { space?: Space }) => {
           </div>
           <div className={mx(!selected && 'p-1 border-bs !border-separator')}>
             {selected ? (
-              <DynamicTable properties={historyProperties} data={historyData} onRowClicked={handleHistoryRowClicked} />
+              <DynamicTable
+                properties={historyProperties}
+                objects={historyObjects}
+                onRowClicked={handleHistoryRowClicked}
+              />
             ) : (
               <Placeholder label='History' />
             )}

--- a/packages/devtools/devtools/src/panels/echo/QueuesPanel/QueuesPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/QueuesPanel/QueuesPanel.tsx
@@ -33,7 +33,7 @@ export const QueuesPanel = () => {
     [],
   );
 
-  const tableData = useMemo(() => {
+  const objects = useMemo(() => {
     return (queue?.items ?? []).map((item: any) => ({
       id: item.id,
       type: item['@type'],
@@ -68,7 +68,7 @@ export const QueuesPanel = () => {
     >
       {/* TODO(burdon): Convert to MasterDetailTable. */}
       <div className={mx('flex grow flex-col divide-y divide-separator overflow-hidden', styles.border)}>
-        <DynamicTable properties={properties} data={tableData} onRowClicked={handleRowClicked} features={features} />
+        <DynamicTable objects={objects} properties={properties} onRowClicked={handleRowClicked} features={features} />
         <div className={mx('flex overflow-auto', 'h-1/2')}>
           {selected && <ObjectDataViewer object={selectedVersionObject ?? selected} />}
         </div>

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/FeedTable.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/FeedTable.tsx
@@ -44,7 +44,7 @@ export const FeedTable: FC<FeedTableProps> = ({ onSelect }) => {
     [],
   );
 
-  const tableData = useMemo(() => {
+  const objects = useMemo(() => {
     return feeds.map((feed) => ({
       id: feed.feedKey.toString(),
       feedKey: feed.feedKey.toString(),
@@ -62,5 +62,5 @@ export const FeedTable: FC<FeedTableProps> = ({ onSelect }) => {
 
   const features: Partial<TableFeatures> = useMemo(() => ({ selection: { enabled: true, mode: 'single' } }), []);
 
-  return <DynamicTable properties={properties} data={tableData} onRowClicked={handleRowClick} features={features} />;
+  return <DynamicTable properties={properties} objects={objects} onRowClicked={handleRowClick} features={features} />;
 };

--- a/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/PipelineTable.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceInfoPanel/PipelineTable.tsx
@@ -75,7 +75,7 @@ export const PipelineTable: FC<PipelineTableProps> = ({ state, metadata, onSelec
     };
   };
 
-  const data = useMemo(() => {
+  const objects = useMemo(() => {
     const controlKeys = Array.from(
       new ComplexSet(PublicKey.hash, [
         ...(state.controlFeeds ?? []),
@@ -166,5 +166,5 @@ export const PipelineTable: FC<PipelineTableProps> = ({ state, metadata, onSelec
 
   const features: Partial<TableFeatures> = useMemo(() => ({ selection: { enabled: true, mode: 'single' } }), []);
 
-  return <DynamicTable properties={properties} data={data} onRowClicked={handleRowClicked} features={features} />;
+  return <DynamicTable properties={properties} objects={objects} onRowClicked={handleRowClicked} features={features} />;
 };

--- a/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
@@ -173,14 +173,14 @@ export const SpaceListPanel = ({ onSelect }: { onSelect?: (space: SpaceData | un
       <DynamicTable
         properties={properties}
         data={tableData}
-        onRowClicked={handleRowClicked}
+        features={features}
         rowActions={[
           { id: 'toggleOpen', translationKey: 'toggle space open closed label' },
           { id: 'backup', translationKey: 'download space backup label' },
           { id: 'archive', translationKey: 'download space archive label' },
         ]}
+        onRowClicked={handleRowClicked}
         onRowAction={handleRowAction}
-        features={features}
       />
     </PanelContainer>
   );

--- a/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
+++ b/packages/devtools/devtools/src/panels/echo/SpaceListPanel/SpaceListPanel.tsx
@@ -33,7 +33,7 @@ export const SpaceListPanel = ({ onSelect }: { onSelect?: (space: SpaceData | un
   const setState = useDevtoolsDispatch();
   const download = useFileDownload();
 
-  const tableData = useMemo(() => {
+  const objects = useMemo(() => {
     return spaces.map((space) => {
       const { open, ready } = space.internal.data.metrics ?? {};
       return {
@@ -172,7 +172,7 @@ export const SpaceListPanel = ({ onSelect }: { onSelect?: (space: SpaceData | un
       <DialogRestoreSpace handleFile={handleImport} />
       <DynamicTable
         properties={properties}
-        data={tableData}
+        objects={objects}
         features={features}
         rowActions={[
           { id: 'toggleOpen', translationKey: 'toggle space open closed label' },

--- a/packages/devtools/devtools/src/panels/edge/InvocationTracePanel/InvocationTracePanel.tsx
+++ b/packages/devtools/devtools/src/panels/edge/InvocationTracePanel/InvocationTracePanel.tsx
@@ -92,7 +92,7 @@ export const InvocationTracePanel = ({ detailAxis = 'inline', ...props }: Invoca
     return [...generateProperties()];
   }, [props.script]);
 
-  const invocationData = useMemo(() => {
+  const invocationObjects = useMemo(() => {
     return invocationSpans.map((invocation) => {
       const status = invocation.outcome;
       const targetDxn = decodeReference(invocation.invocationTarget).dxn;
@@ -145,7 +145,7 @@ export const InvocationTracePanel = ({ detailAxis = 'inline', ...props }: Invoca
       <div className={mx('bs-full', gridLayout)}>
         <DynamicTable
           properties={invocationProperties}
-          data={invocationData}
+          objects={invocationObjects}
           features={features}
           onRowClicked={handleInvocationRowClicked}
         />

--- a/packages/devtools/devtools/src/panels/edge/InvocationTracePanel/InvocationTracePanel.tsx
+++ b/packages/devtools/devtools/src/panels/edge/InvocationTracePanel/InvocationTracePanel.tsx
@@ -146,8 +146,8 @@ export const InvocationTracePanel = ({ detailAxis = 'inline', ...props }: Invoca
         <DynamicTable
           properties={invocationProperties}
           data={invocationData}
-          onRowClicked={handleInvocationRowClicked}
           features={features}
+          onRowClicked={handleInvocationRowClicked}
         />
         {selectedInvocation && <Selected span={selectedInvocation} />}
       </div>

--- a/packages/devtools/devtools/src/panels/edge/InvocationTracePanel/LogPanel.tsx
+++ b/packages/devtools/devtools/src/panels/edge/InvocationTracePanel/LogPanel.tsx
@@ -49,7 +49,7 @@ export const LogPanel: React.FC<LogPanelProps> = ({ span }) => {
     [],
   );
 
-  const logData = useMemo(() => {
+  const objects = useMemo(() => {
     if (!eventQueue?.items?.length) {
       return [];
     }
@@ -70,5 +70,5 @@ export const LogPanel: React.FC<LogPanelProps> = ({ span }) => {
     return <div className={mx('flex items-center justify-center')}>Loading trace data...</div>;
   }
 
-  return <DynamicTable properties={logProperties} data={logData} />;
+  return <DynamicTable objects={objects} properties={logProperties} />;
 };

--- a/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalStatusTable.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SignalPanel/SignalStatusTable.tsx
@@ -102,8 +102,7 @@ export const SignalStatusTable = () => {
   }
 
   const properties = useMemo(() => tableProperties, []);
-
-  const tableData = useMemo(() => {
+  const objects = useMemo(() => {
     return status.map((s, index) => ({
       id: `${index}-${s.host}`,
       host: new URL(s.host).origin,
@@ -118,5 +117,5 @@ export const SignalStatusTable = () => {
     }));
   }, [status, time]);
 
-  return <DynamicTable properties={properties} data={tableData} />;
+  return <DynamicTable properties={properties} objects={objects} />;
 };

--- a/packages/devtools/devtools/src/panels/mesh/SwarmPanel/SwarmPanel.tsx
+++ b/packages/devtools/devtools/src/panels/mesh/SwarmPanel/SwarmPanel.tsx
@@ -95,9 +95,8 @@ export const SwarmPanel = () => {
 
   const connectionMap = useMemo(() => new ComplexMap<PublicKey, ConnectionInfo>(PublicKey.hash), []);
 
-  // The state options order determines the sorting priority
-
-  const data = useMemo(() => {
+  // The state options order determines the sorting priority.
+  const objects = useMemo(() => {
     const connections: TableSwarmConnection[] = [];
 
     for (const swarm of swarms) {
@@ -150,7 +149,7 @@ export const SwarmPanel = () => {
 
   return (
     <PanelContainer>
-      <DynamicTable properties={properties} data={data} />
+      <DynamicTable properties={properties} objects={objects} />
     </PanelContainer>
   );
 };

--- a/packages/plugins/plugin-space/src/capabilities/schema-tools.ts
+++ b/packages/plugins/plugin-space/src/capabilities/schema-tools.ts
@@ -10,7 +10,7 @@ import { type Space } from '@dxos/client/echo';
 import { FormatEnum, FormatEnums, S, SelectOptionSchema, GeoPoint, toJsonSchema } from '@dxos/echo-schema';
 import { invariant } from '@dxos/invariant';
 import { hues } from '@dxos/react-ui-theme';
-import { echoSchemaFromPropertyDefinitions } from '@dxos/schema';
+import { getSchemaFromPropertyDefinitions } from '@dxos/schema';
 
 // TODO(burdon): Factor out.
 declare global {
@@ -115,7 +115,7 @@ export default () =>
         invariant(extensions?.space, 'No space.');
         const space = extensions.space;
 
-        const schema = echoSchemaFromPropertyDefinitions(typename, properties);
+        const schema = getSchemaFromPropertyDefinitions(typename, properties);
         const [registeredSchema] = await space.db.schemaRegistry.register([schema]);
 
         return ToolResult.Success(registeredSchema);

--- a/packages/sdk/schema/src/construction.ts
+++ b/packages/sdk/schema/src/construction.ts
@@ -2,7 +2,15 @@
 // Copyright 2025 DXOS.org
 //
 
-import { FormatEnum, formatToType, S, TypedObject, TypeEnum, type SelectOptionSchema } from '@dxos/echo-schema';
+import {
+  type EchoSchema,
+  FormatEnum,
+  formatToType,
+  S,
+  TypedObject,
+  TypeEnum,
+  type SelectOptionSchema,
+} from '@dxos/echo-schema';
 import { createEchoSchema } from '@dxos/live-object/testing';
 
 import { makeMultiSelectAnnotations, makeSingleSelectAnnotations } from './util';
@@ -17,7 +25,10 @@ export type SchemaPropertyDefinition = {
   config?: { options?: SelectOptionType[] };
 };
 
-export const echoSchemaFromPropertyDefinitions = (typename: string, properties: SchemaPropertyDefinition[]) => {
+export const getSchemaFromPropertyDefinitions = (
+  typename: string,
+  properties: SchemaPropertyDefinition[],
+): EchoSchema => {
   const typeToSchema: Record<TypeEnum, S.Any> = {
     [TypeEnum.String]: S.String.pipe(S.optional),
     [TypeEnum.Number]: S.Number.pipe(S.optional),

--- a/packages/ui/react-ui-table/src/components/Table/DynamicTable.stories.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/DynamicTable.stories.tsx
@@ -119,7 +119,7 @@ export const WithJsonSchema: StoryObj = {
       })),
     );
 
-    return <DynamicTable jsonSchema={schema} data={objects} tableName='com.example/json_schema_table' />;
+    return <DynamicTable jsonSchema={schema} data={objects} name='json-schema-table' />;
   },
 };
 
@@ -129,12 +129,11 @@ export const WithEchoSchema: StoryObj = {
     const { space } = useClientProvider();
     const schema = useSchema(client, space, Testing.ContactType.typename);
     const objects = useQuery(space, schema ? Filter.schema(schema) : Filter.nothing());
-
     if (!schema) {
       return <div>Loading schema...</div>;
     }
 
-    return <DynamicTable echoSchema={schema} data={objects} tableName='contact-table' />;
+    return <DynamicTable schema={schema} data={objects} name='contact-table' />;
   },
   decorators: [
     withClientProvider({

--- a/packages/ui/react-ui-table/src/components/Table/DynamicTable.stories.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/DynamicTable.stories.tsx
@@ -31,7 +31,7 @@ const useTestPropertiesAndObjects = () => {
     [],
   );
 
-  const [objects, _setObjects] = useState<any[]>(
+  const [objects] = useState<any[]>(
     Array.from({ length: 10 }, () => ({
       id: faker.string.uuid(),
       name: faker.person.fullName(),
@@ -48,7 +48,7 @@ const useTestPropertiesAndObjects = () => {
 
 const DynamicTableStory = () => {
   const { properties, objects } = useTestPropertiesAndObjects();
-  return <DynamicTable properties={properties} data={objects} />;
+  return <DynamicTable properties={properties} objects={objects} />;
 };
 
 //
@@ -77,7 +77,7 @@ export const WithRowClicks: StoryObj = {
       alert(`Row clicked: ${row.name}, age: ${row.age}`);
     };
 
-    return <DynamicTable properties={properties} data={objects} onRowClicked={handleRowClicked} />;
+    return <DynamicTable properties={properties} objects={objects} onRowClicked={handleRowClicked} />;
   },
 };
 
@@ -90,7 +90,7 @@ export const WithClickToSelect: StoryObj = {
       [],
     );
 
-    return <DynamicTable properties={properties} data={objects} features={features} />;
+    return <DynamicTable properties={properties} objects={objects} features={features} />;
   },
 };
 
@@ -119,7 +119,7 @@ export const WithJsonSchema: StoryObj = {
       })),
     );
 
-    return <DynamicTable jsonSchema={schema} data={objects} name='json-schema-table' />;
+    return <DynamicTable jsonSchema={schema} objects={objects} name='json-schema-table' />;
   },
 };
 
@@ -133,7 +133,7 @@ export const WithEchoSchema: StoryObj = {
       return <div>Loading schema...</div>;
     }
 
-    return <DynamicTable schema={schema} data={objects} name='contact-table' />;
+    return <DynamicTable schema={schema} objects={objects} name='contact-table' />;
   },
   decorators: [
     withClientProvider({

--- a/packages/ui/react-ui-table/src/components/Table/DynamicTable.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/DynamicTable.tsx
@@ -29,6 +29,7 @@ type DynamicTableProps = ThemedClassName<{
  * A dynamic table component that renders data using the specified properties.
  * Properties define both the schema and display characteristics of the table columns.
  */
+// TODO(burdon): Instead of creating table variants, create different hooks that normalize the props.
 // TODO(burdon): Warning: Cannot update a component (`DynamicTable`) while rendering a different component (`DynamicTable`).
 export const DynamicTable = ({
   classNames,

--- a/packages/ui/react-ui-table/src/components/Table/DynamicTable.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/DynamicTable.tsx
@@ -15,7 +15,7 @@ import { getBaseSchems, makeDynamicTable, type TablePropertyDefinition } from '.
 
 type DynamicTableProps = ThemedClassName<{
   name?: string;
-  data: any[];
+  objects: any[];
   properties?: TablePropertyDefinition[];
   jsonSchema?: JsonSchemaType;
   schema?: BaseSchema;
@@ -29,12 +29,11 @@ type DynamicTableProps = ThemedClassName<{
  * A dynamic table component that renders data using the specified properties.
  * Properties define both the schema and display characteristics of the table columns.
  */
-// TODO(burdon): Remove variance from the props (should be normalized externally).
 // TODO(burdon): Warning: Cannot update a component (`DynamicTable`) while rendering a different component (`DynamicTable`).
 export const DynamicTable = ({
   classNames,
   name = 'example.com/dynamic-table',
-  data, // TOOD(burdon): Rename objects.
+  objects,
   properties,
   jsonSchema,
   schema,
@@ -44,6 +43,7 @@ export const DynamicTable = ({
   ...props
 }: DynamicTableProps) => {
   const { table, projection } = useMemo(() => {
+    // TODO(burdon): Remove variance from the props (should be normalized externally).
     return makeDynamicTable({ ...getBaseSchems({ typename: name, properties, jsonSchema, schema }), properties });
   }, [name, properties, schema, jsonSchema]);
 
@@ -67,7 +67,7 @@ export const DynamicTable = ({
 
   const model = useTableModel({
     table,
-    objects: data,
+    objects,
     projection,
     features,
     rowActions,

--- a/packages/ui/react-ui-table/src/components/Table/DynamicTable.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/DynamicTable.tsx
@@ -11,14 +11,14 @@ import { mx } from '@dxos/react-ui-theme';
 import { Table, type TableController } from './Table';
 import { useTableModel } from '../../hooks';
 import { type TableFeatures, TablePresentation, type TableRowAction } from '../../model';
-import { makeDynamicTable, type TablePropertyDefinition } from '../../util';
+import { getBaseSchems, makeDynamicTable, type TablePropertyDefinition } from '../../util';
 
 type DynamicTableProps = ThemedClassName<{
-  tableName?: string;
+  name?: string;
   data: any[];
   properties?: TablePropertyDefinition[];
   jsonSchema?: JsonSchemaType;
-  echoSchema?: BaseSchema;
+  schema?: BaseSchema;
   features?: Partial<TableFeatures>;
   rowActions?: TableRowAction[];
   onRowClicked?: (row: any) => void;
@@ -29,22 +29,23 @@ type DynamicTableProps = ThemedClassName<{
  * A dynamic table component that renders data using the specified properties.
  * Properties define both the schema and display characteristics of the table columns.
  */
+// TODO(burdon): Remove variance from the props (should be normalized externally).
 // TODO(burdon): Warning: Cannot update a component (`DynamicTable`) while rendering a different component (`DynamicTable`).
 export const DynamicTable = ({
   classNames,
-  tableName = 'com.example/dynamic_table',
-  data,
+  name = 'example.com/dynamic-table',
+  data, // TOOD(burdon): Rename objects.
   properties,
   jsonSchema,
-  echoSchema,
+  schema,
   rowActions,
   onRowClicked,
   onRowAction,
   ...props
 }: DynamicTableProps) => {
-  const { table, viewProjection } = useMemo(() => {
-    return makeDynamicTable({ typename: tableName, properties, jsonSchema, echoSchema });
-  }, [tableName, properties, jsonSchema]);
+  const { table, projection } = useMemo(() => {
+    return makeDynamicTable({ ...getBaseSchems({ typename: name, properties, jsonSchema, schema }), properties });
+  }, [name, properties, schema, jsonSchema]);
 
   const tableRef = useRef<TableController>(null);
   const handleCellUpdate = useCallback((cell: any) => {
@@ -67,7 +68,7 @@ export const DynamicTable = ({
   const model = useTableModel({
     table,
     objects: data,
-    projection: viewProjection,
+    projection,
     features,
     rowActions,
     onCellUpdate: handleCellUpdate,
@@ -90,8 +91,8 @@ export const DynamicTable = ({
             ref={tableRef}
             model={model}
             presentation={presentation}
-            onRowClicked={onRowClicked}
             ignoreAttention
+            onRowClicked={onRowClicked}
           />
         </Table.Root>
       </div>

--- a/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
@@ -16,7 +16,7 @@ import { Filter, useQuery, useSchema, create } from '@dxos/react-client/echo';
 import { useClientProvider, withClientProvider } from '@dxos/react-client/testing';
 import { ViewEditor } from '@dxos/react-ui-form';
 import { SyntaxHighlighter } from '@dxos/react-ui-syntax-highlighter';
-import { echoSchemaFromPropertyDefinitions, ViewProjection, ViewType } from '@dxos/schema';
+import { getSchemaFromPropertyDefinitions, ViewProjection, ViewType } from '@dxos/schema';
 import { Testing, createObjectFactory } from '@dxos/schema/testing';
 import { withLayout, withTheme } from '@dxos/storybook-utils';
 
@@ -288,7 +288,7 @@ export const Tags: Meta<StoryProps> = {
 
         const selectOptionIds = selectOptions.map((o) => o.id);
 
-        const schema = echoSchemaFromPropertyDefinitions(typename, [
+        const schema = getSchemaFromPropertyDefinitions(typename, [
           {
             name: 'single',
             format: FormatEnum.SingleSelect,

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -41,7 +41,7 @@ const blockEndLine =
   '[&>.dx-grid]:before:absolute [&>.dx-grid]:before:inset-inline-0 [&>.dx-grid]:before:-block-end-px [&>.dx-grid]:before:bs-px [&>.dx-grid]:before:bg-separator';
 
 //
-// Root
+// Table.Root
 //
 
 export type TableRootProps = PropsWithChildren<{ role?: string }>;
@@ -63,7 +63,7 @@ const TableRoot = ({ children, role }: TableRootProps) => {
 };
 
 //
-// Main
+// Table.Main
 //
 
 export type TableController = {
@@ -356,32 +356,28 @@ const TableMain = forwardRef<TableController, TableMainProps>(
           onQuery={handleQuery}
         />
         <Grid.Content
-          onWheelCapture={handleWheel}
           className={mx('[--dx-grid-base:var(--surface-bg)]', inlineEndLine, blockEndLine)}
           frozen={frozen}
           // getCells={getCells}
           columns={model.columnMeta.value}
           limitRows={model.getRowCount() ?? 0}
           limitColumns={model.view?.fields?.length ?? 0}
+          overscroll='trap'
           onAxisResize={handleAxisResize}
           onClick={handleGridClick}
           onKeyDown={handleKeyDown}
-          overscroll='trap'
+          onWheelCapture={handleWheel}
           ref={setDxGrid}
         />
         <RowActionsMenu model={model} modals={modals} />
         <ColumnActionsMenu model={model} modals={modals} />
         <ColumnSettings model={model} modals={modals} onNewColumn={handleNewColumn} />
-        <RefPanel model={model} modals={modals} />
         <CreateRefPanel model={model} modals={modals} />
+        <RefPanel model={model} modals={modals} />
       </Grid.Root>
     );
   },
 );
-
-//
-// CellEditor
-//
 
 export const Table = {
   Root: TableRoot,


### PR DESCRIPTION
Small refactor directionally to normalize props.
- avoid passing mutually exclusive options to components.
- avoid mixing of types (e.g., "name" used for "typename") might break assumptions.
- consistent ordering of properties (e.g., onX handlers at end).


TODO(zaymonfc)
- normalize props with hooks.
- remove divs
