### PR TITLE
fix: `lit-ui` and `react-ui-table` e2e

### DIFF
--- a/packages/ui/lit-ui/project.json
+++ b/packages/ui/lit-ui/project.json
@@ -24,14 +24,6 @@
         "tsConfig": "{projectRoot}/tsconfig.json"
       }
     },
-    "e2e": {
-      "dependsOn": [
-        "^compile"
-      ],
-      "options": {
-        "config": "{projectRoot}/src/testing/playwright/playwright.config.cts"
-      }
-    },
     "lint": {
       "options": {
         "lintFilePatterns": [

--- a/packages/ui/react-ui-table/src/playwright/smoke.spec.ts
+++ b/packages/ui/react-ui-table/src/playwright/smoke.spec.ts
@@ -4,12 +4,11 @@
 
 import { expect, test } from '@playwright/test';
 
-import { setupPage } from '@dxos/test-utils/playwright';
+import { setupPage, storybookUrl } from '@dxos/test-utils/playwright';
 
 import { TableManager } from './TableManager';
 
-const storyId = 'ui-react-ui-table-table';
-const storyUrl = `http://localhost:9009/iframe.html?id=${storyId}&viewMode=story`;
+const storyUrl = storybookUrl('ui-react-ui-table-table--default');
 
 // NOTE(ZaymonFC): This test suite relies on the faker seed being set to 0 in the story.
 test.describe('Table', () => {

--- a/tools/stories/config/e2e/main.mts
+++ b/tools/stories/config/e2e/main.mts
@@ -11,5 +11,6 @@ export default config({
     join(packages, '/sdk/react-client/src/**/*.stories.tsx'),
     join(packages, '/sdk/shell/src/stories/Invitations.e2e-stories.tsx'),
     join(packages, '/ui/react-ui-stack/src/**/*.stories.tsx'),
+    join(packages, '/ui/react-ui-table/src/**/*.stories.tsx'),
   ],
 });


### PR DESCRIPTION
This PR:
- removes an unintended e2e task in the project.json for `lit-ui`
- adds `react-ui-table` to the set of e2e stories, which was missing

<img width="880" alt="Screenshot 2025-04-23 at 16 41 34" src="https://github.com/user-attachments/assets/bd273c7c-6472-44fa-ac65-ca693213782e" />
