### PR TITLE
fix(plugin-kanban): Restore space in empty Stack

### DIFF
--- a/packages/ui/react-ui-kanban/src/components/Kanban.tsx
+++ b/packages/ui/react-ui-kanban/src/components/Kanban.tsx
@@ -73,8 +73,9 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                 orientation='vertical'
                 size='contain'
                 rail={false}
-                { /* NOTE(thure): Do not eliminate spacing here without ensuring this element will have a significant size, otherwise dropping items into an empty stack will be made difficult or impossible. See #9035. */ }
-                classNames='pbe-1 drag-preview-p-0'
+                classNames={
+                  /* NOTE(thure): Do not eliminate spacing here without ensuring this element will have a significant size, otherwise dropping items into an empty stack will be made difficult or impossible. See #9035. */ 'pbe-1 drag-preview-p-0'
+                }
                 onRearrange={model.handleRearrange}
                 itemsCount={cards.length}
               >

--- a/packages/ui/react-ui-kanban/src/components/Kanban.tsx
+++ b/packages/ui/react-ui-kanban/src/components/Kanban.tsx
@@ -73,7 +73,8 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                 orientation='vertical'
                 size='contain'
                 rail={false}
-                classNames='!plb-0 !pbe-0 drag-preview-p-0'
+                { /* NOTE(thure): Do not eliminate spacing here without ensuring this element will have a significant size, otherwise dropping items into an empty stack will be made difficult or impossible. See #9035. */ }
+                classNames='pbe-1 drag-preview-p-0'
                 onRearrange={model.handleRearrange}
                 itemsCount={cards.length}
               >


### PR DESCRIPTION
This PR:
- fixes #9035.

https://github.com/user-attachments/assets/9289c8ea-2d3e-427b-9797-bd5f4343acbd
