### PR TITLE
fix: L1 and Plank heading polish

### DIFF
--- a/packages/plugins/plugin-help/src/components/Shortcuts/ShortcutsDialog.tsx
+++ b/packages/plugins/plugin-help/src/components/Shortcuts/ShortcutsDialog.tsx
@@ -21,7 +21,7 @@ export const ShortcutsDialogContent = () => {
 
         <Dialog.Close asChild>
           <Button density='fine' variant='ghost' autoFocus>
-            <Icon icon='ph--x--regular' size={3} />
+            <Icon icon='ph--x--bold' size={3} />
           </Button>
         </Dialog.Close>
       </div>

--- a/packages/plugins/plugin-navtree/src/components/L1Panels.tsx
+++ b/packages/plugins/plugin-navtree/src/components/L1Panels.tsx
@@ -36,7 +36,7 @@ const HeadingBackButton = ({ title, onClick }: { title: string } & Pick<ButtonPr
       classNames='pli-1 flex-1 relative group text-start justify-start bs-[--rail-action] font-normal'
       onClick={onClick}
     >
-      <Icon icon='ph--caret-left--regular' size={3} />
+      <Icon icon='ph--caret-left--bold' size={3} />
       <span
         className={mx(
           headingBackButtonLabel,

--- a/packages/plugins/plugin-navtree/src/components/L1Panels.tsx
+++ b/packages/plugins/plugin-navtree/src/components/L1Panels.tsx
@@ -115,13 +115,15 @@ const L1Panel = ({ item, path, currentItemId, onBack }: L1PanelProps) => {
                 variant='ghost'
                 classNames={mx('shrink-0', hoverableControlItem, hoverableOpenControlItem, 'pli-2 pointer-fine:pli-1')}
                 iconOnly
+                size={5}
+                density='coarse'
                 icon={alternateTree.properties.icon ?? 'ph--placeholder--regular'}
                 label={toLocalizedString(alternateTree.properties.label ?? alternateTree.id, t)}
                 data-testid='treeView.alternateTreeButton'
                 onClick={handleOpen}
               />
             )}
-            <NavTreeItemColumns path={path} item={item} open />
+            <NavTreeItemColumns path={path} item={item} open density='coarse' />
           </h2>
           <div role='none' className='overflow-y-auto'>
             {isAlternate ? (

--- a/packages/plugins/plugin-navtree/src/components/L1Panels.tsx
+++ b/packages/plugins/plugin-navtree/src/components/L1Panels.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useMemo } from 'react';
 
 import { useLayout } from '@dxos/app-framework';
 import { type Node } from '@dxos/app-graph';
-import { Button, Icon, IconButton, toLocalizedString, useTranslation } from '@dxos/react-ui';
+import { Button, type ButtonProps, Icon, IconButton, toLocalizedString, useTranslation } from '@dxos/react-ui';
 import { Tree } from '@dxos/react-ui-list';
 import { Tabs } from '@dxos/react-ui-tabs';
 import { hoverableControlItem, hoverableOpenControlItem, mx } from '@dxos/react-ui-theme';
@@ -23,6 +23,38 @@ export type L1PanelProps = {
   path: string[];
   currentItemId: string;
   onBack?: () => void;
+};
+
+const headingBackButtonLabel =
+  'absolute inset-0 min-is-0 truncate flex items-center pis-6 transition-[transform,opacity] ease-in-out duration-200';
+
+const HeadingBackButton = ({ title, onClick }: { title: string } & Pick<ButtonProps, 'onClick'>) => {
+  const { t } = useTranslation(NAVTREE_PLUGIN);
+  return (
+    <Button
+      variant='ghost'
+      classNames='pli-1 flex-1 relative group text-start justify-start bs-[--rail-action] font-normal'
+      onClick={onClick}
+    >
+      <Icon icon='ph--caret-left--regular' size={3} />
+      <span
+        className={mx(
+          headingBackButtonLabel,
+          'translate-y-2 opacity-0 group-hover:translate-y-0 group-hover:opacity-100 group-focus:translate-y-0 group-focus:opacity-100',
+        )}
+      >
+        {t('back label')}
+      </span>
+      <span
+        className={mx(
+          headingBackButtonLabel,
+          'translate-y-0 opacity-100 group-hover:-translate-y-2 group-hover:opacity-0 group-focus:-translate-y-2 group-focus:opacity-0',
+        )}
+      >
+        {title}
+      </span>
+    </Button>
+  );
 };
 
 const L1Panel = ({ item, path, currentItemId, onBack }: L1PanelProps) => {
@@ -55,6 +87,9 @@ const L1Panel = ({ item, path, currentItemId, onBack }: L1PanelProps) => {
     }
   }, [isAlternate, onBack, alternatePath, setAlternateTree]);
 
+  const title = toLocalizedString(item.properties.label, t);
+  const backCapable = item.id.startsWith('!') || isAlternate;
+
   return (
     <Tabs.Tabpanel
       key={item.id}
@@ -64,25 +99,17 @@ const L1Panel = ({ item, path, currentItemId, onBack }: L1PanelProps) => {
         item.id === currentItemId && 'grid',
       ]}
       tabIndex={-1}
+      aria-label={title}
       {...(!layout.sidebarOpen && { inert: 'true' })}
     >
       {item.id === currentItemId && (
         <>
-          <h2 className='flex items-center border-be border-separator app-drag'>
-            <Button
-              variant='ghost'
-              density='fine'
-              classNames={mx(
-                'is-6 pli-0 dx-focus-ring-inset',
-                !item.id.startsWith('!') && !isAlternate && 'invisible',
-                hoverableControlItem,
-                hoverableOpenControlItem,
-              )}
-              onClick={handleBack}
-            >
-              <Icon icon='ph--caret-left--regular' size={3} />
-            </Button>
-            <span className='flex-1 truncate cursor-default'>{toLocalizedString(item.properties.label, t)}</span>
+          <h2 className='flex items-center border-be border-separator app-drag pis-1'>
+            {backCapable ? (
+              <HeadingBackButton title={title} onClick={handleBack} />
+            ) : (
+              <span className='flex-1 truncate min-is-0 pis-6'>{title}</span>
+            )}
             {alternateTree && !isAlternate && (
               <IconButton
                 variant='ghost'

--- a/packages/plugins/plugin-navtree/src/components/NavTreeItemAction.tsx
+++ b/packages/plugins/plugin-navtree/src/components/NavTreeItemAction.tsx
@@ -5,7 +5,7 @@
 import React, { type MutableRefObject, useRef } from 'react';
 
 import { type Action, type Node } from '@dxos/app-graph';
-import { useTranslation, toLocalizedString, IconButton } from '@dxos/react-ui';
+import { useTranslation, toLocalizedString, IconButton, useDensityContext } from '@dxos/react-ui';
 import { DropdownMenu, MenuProvider, type MenuItem } from '@dxos/react-ui-menu';
 import { hoverableControlItem, hoverableOpenControlItem, mx } from '@dxos/react-ui-theme';
 
@@ -23,9 +23,13 @@ export type NavTreeItemActionMenuProps = ActionProperties & {
 
 const fallbackIcon = 'ph--placeholder--regular';
 
-const actionButtonProps = {
+const fineActionButtonProps = {
   size: 4 as const,
   density: 'fine' as const,
+};
+const coarseActionButtonProps = {
+  size: 5 as const,
+  density: 'coarse' as const,
 };
 
 export const NavTreeItemActionDropdownMenu = ({
@@ -37,12 +41,13 @@ export const NavTreeItemActionDropdownMenu = ({
 }: NavTreeItemActionMenuProps) => {
   const { t } = useTranslation(NAVTREE_PLUGIN);
   const suppressNextTooltip = useRef<boolean>(false);
+  const density = useDensityContext();
   return (
     <MenuProvider onAction={onAction}>
       <DropdownMenu.Root items={menuActions as MenuItem[]} suppressNextTooltip={suppressNextTooltip}>
         <DropdownMenu.Trigger asChild>
           <IconButton
-            {...actionButtonProps}
+            {...(density === 'coarse' ? coarseActionButtonProps : fineActionButtonProps)}
             classNames={mx('shrink-0 pli-2 pointer-fine:pli-1', hoverableControlItem, hoverableOpenControlItem)}
             variant='ghost'
             icon={icon ?? fallbackIcon}
@@ -63,9 +68,10 @@ export const NavTreeItemMonolithicAction = ({
   data: invoke,
   baseLabel,
 }: Action & { parent: Node; onAction?: (action: Action) => void; baseLabel: string }) => {
+  const density = useDensityContext();
   return (
     <IconButton
-      {...actionButtonProps}
+      {...(density === 'coarse' ? coarseActionButtonProps : fineActionButtonProps)}
       variant={variant}
       classNames={mx(
         'shrink-0',

--- a/packages/plugins/plugin-navtree/src/components/NavTreeItemColumns.tsx
+++ b/packages/plugins/plugin-navtree/src/components/NavTreeItemColumns.tsx
@@ -5,7 +5,7 @@
 import React, { Fragment, memo } from 'react';
 
 import { isAction } from '@dxos/app-graph';
-import { Popover, toLocalizedString, Treegrid, useTranslation } from '@dxos/react-ui';
+import { DensityProvider, Popover, toLocalizedString, Treegrid, useTranslation } from '@dxos/react-ui';
 
 import { NAV_TREE_ITEM } from './NavTree';
 import { useNavTreeContext } from './NavTreeContext';
@@ -14,7 +14,7 @@ import type { NavTreeItemColumnsProps } from './types';
 import { useLoadDescendents } from '../hooks';
 import { NAVTREE_PLUGIN } from '../meta';
 
-export const NavTreeItemColumns = memo(({ path, item, open }: NavTreeItemColumnsProps) => {
+export const NavTreeItemColumns = memo(({ path, item, open, density = 'fine' }: NavTreeItemColumnsProps) => {
   const { t } = useTranslation(NAVTREE_PLUGIN);
   const { getActions, renderItemEnd: ItemEnd, popoverAnchorId } = useNavTreeContext();
 
@@ -35,37 +35,39 @@ export const NavTreeItemColumns = memo(({ path, item, open }: NavTreeItemColumns
   useLoadDescendents(primaryAction && !isAction(primaryAction) ? primaryAction : undefined);
 
   return (
-    <div role='none' className='contents app-no-drag'>
-      {primaryAction?.properties?.disposition === 'list-item-primary' && !primaryAction?.properties?.disabled ? (
-        <NavTreeItemAction
-          testId={primaryAction.properties?.testId}
-          label={toLocalizedString(primaryAction.properties?.label, t)}
-          icon={primaryAction.properties?.icon ?? 'ph--placeholder--regular'}
-          parent={item}
-          monolithic={isAction(primaryAction)}
-          menuActions={isAction(primaryAction) ? [primaryAction] : groupedActions[primaryAction.id]}
-          menuType={primaryAction.properties?.menuType}
-          caller={NAV_TREE_ITEM}
-        />
-      ) : (
-        <Treegrid.Cell />
-      )}
-      <ActionRoot>
-        {actions.length > 0 ? (
+    <DensityProvider density={density}>
+      <div role='none' className='contents app-no-drag'>
+        {primaryAction?.properties?.disposition === 'list-item-primary' && !primaryAction?.properties?.disabled ? (
           <NavTreeItemAction
-            testId={`navtree.treeItem.actionsLevel${level}`}
-            label={t('tree item actions label')}
-            icon='ph--dots-three-vertical--regular'
+            testId={primaryAction.properties?.testId}
+            label={toLocalizedString(primaryAction.properties?.label, t)}
+            icon={primaryAction.properties?.icon ?? 'ph--placeholder--regular'}
             parent={item}
-            menuActions={actions}
-            menuType='dropdown'
+            monolithic={isAction(primaryAction)}
+            menuActions={isAction(primaryAction) ? [primaryAction] : groupedActions[primaryAction.id]}
+            menuType={primaryAction.properties?.menuType}
             caller={NAV_TREE_ITEM}
           />
         ) : (
           <Treegrid.Cell />
         )}
-      </ActionRoot>
-      {ItemEnd && <ItemEnd node={item} open={open} />}
-    </div>
+        <ActionRoot>
+          {actions.length > 0 ? (
+            <NavTreeItemAction
+              testId={`navtree.treeItem.actionsLevel${level}`}
+              label={t('tree item actions label')}
+              icon='ph--dots-three-vertical--regular'
+              parent={item}
+              menuActions={actions}
+              menuType='dropdown'
+              caller={NAV_TREE_ITEM}
+            />
+          ) : (
+            <Treegrid.Cell />
+          )}
+        </ActionRoot>
+        {ItemEnd && <ItemEnd node={item} open={open} />}
+      </div>
+    </DensityProvider>
   );
 });

--- a/packages/plugins/plugin-navtree/src/components/types.ts
+++ b/packages/plugins/plugin-navtree/src/components/types.ts
@@ -5,6 +5,7 @@
 import type { FC } from 'react';
 
 import type { Node } from '@dxos/app-graph';
+import type { Density } from '@dxos/react-ui';
 import type { TreeProps } from '@dxos/react-ui-list';
 import type { MaybePromise } from '@dxos/util';
 
@@ -15,6 +16,7 @@ export type NavTreeItemColumnsProps = {
   path: string[];
   item: Node;
   open: boolean;
+  density?: Density;
 };
 
 export type NavTreeProps = Pick<TreeProps<NavTreeItemGraphNode>, 'id' | 'root'>;

--- a/packages/plugins/plugin-navtree/src/translations.ts
+++ b/packages/plugins/plugin-navtree/src/translations.ts
@@ -8,6 +8,7 @@ export default [
   {
     'en-US': {
       [NAVTREE_PLUGIN]: {
+        'back label': 'Back',
         'open settings label': 'Settings',
         'open commands label': 'Search commands',
         'commands dialog title': 'Commands',

--- a/packages/plugins/plugin-registry/src/components/PluginItem.tsx
+++ b/packages/plugins/plugin-registry/src/components/PluginItem.tsx
@@ -93,7 +93,7 @@ export const PluginItem = ({
           <IconButton
             aria-describedby={descriptionId}
             classNames='text-sm text-description cursor-pointer'
-            icon='ph--gear--regular'
+            icon='ph--faders--regular'
             label={t('settings label')}
             iconOnly
             size={4}

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder.ts
@@ -130,7 +130,7 @@ export default (context: PluginsContext) => {
           },
           properties: {
             label: ['open current space settings label', { ns: SPACE_PLUGIN }],
-            icon: 'ph--gear--regular',
+            icon: 'ph--faders--regular',
             keyBinding: {
               macos: 'meta+shift+,',
               windows: 'ctrl+shift+,',

--- a/packages/plugins/plugin-space/src/components/SpacePresence.tsx
+++ b/packages/plugins/plugin-space/src/components/SpacePresence.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useState } from 'react';
 
 import { useAppGraph, useCapability } from '@dxos/app-framework';
 import { generateName } from '@dxos/display-name';
@@ -20,6 +20,7 @@ import {
   List,
   ListItem,
   useDefaultValue,
+  type DxAvatar,
 } from '@dxos/react-ui';
 import { AttentionGlyph, useAttended, useAttention, type AttentionGlyphProps } from '@dxos/react-ui-attention';
 import { ComplexMap, keyToFallback } from '@dxos/util';
@@ -116,7 +117,7 @@ export const FullPresence = (props: MemberPresenceProps) => {
       {members.slice(0, 3).map((member, i) => (
         <Tooltip.Root key={member.identity.identityKey.toHex()}>
           <Tooltip.Trigger>
-            <PrensenceAvatar
+            <PresenceAvatar
               identity={member.identity}
               match={member.currentlyAttended} // TODO(Zan): Match always true now we're showing 'members viewing current object'.
               index={members.length - i}
@@ -142,6 +143,7 @@ export const FullPresence = (props: MemberPresenceProps) => {
                 status='inactive'
                 style={{ zIndex: members.length - 4 }}
                 fallback={`+${members.length - 3}`}
+                size={size}
               />
             </Avatar.Root>
           </Tooltip.Trigger>
@@ -157,7 +159,7 @@ export const FullPresence = (props: MemberPresenceProps) => {
                     data-testid='identity-list-item'
                   >
                     {/* TODO(Zan): Match always true now we're showing 'members viewing current object'. */}
-                    <PrensenceAvatar identity={member.identity} size={size} showName match={member.currentlyAttended} />
+                    <PresenceAvatar identity={member.identity} size={size} showName match={member.currentlyAttended} />
                   </ListItem.Root>
                 ))}
               </List>
@@ -177,26 +179,28 @@ type PresenceAvatarProps = Pick<AvatarContentProps, 'size'> & {
   onClick?: () => void;
 };
 
-const PrensenceAvatar = ({ identity, showName, match, index, onClick, size }: PresenceAvatarProps) => {
-  const status = match ? 'current' : 'active';
-  const fallbackValue = keyToFallback(identity.identityKey);
-  return (
-    <Avatar.Root>
-      <Avatar.Content
-        status={status}
-        hue={identity.profile?.data?.hue || fallbackValue.hue}
-        data-testid='spacePlugin.presence.member'
-        data-status={status}
-        size={size}
-        classNames='mbs-2 mie-4'
-        {...(index ? { style: { zIndex: index } } : {})}
-        onClick={() => onClick?.()}
-        fallback={identity.profile?.data?.emoji || fallbackValue.emoji}
-      />
-      <Avatar.Label classNames={showName ? 'text-sm truncate pli-2' : 'sr-only'}>{getName(identity)}</Avatar.Label>
-    </Avatar.Root>
-  );
-};
+const PresenceAvatar = forwardRef<DxAvatar, PresenceAvatarProps>(
+  ({ identity, showName, match, index, onClick, size }, forwardedRef) => {
+    const status = match ? 'current' : 'active';
+    const fallbackValue = keyToFallback(identity.identityKey);
+    return (
+      <Avatar.Root>
+        <Avatar.Content
+          status={status}
+          hue={identity.profile?.data?.hue || fallbackValue.hue}
+          data-testid='spacePlugin.presence.member'
+          data-status={status}
+          size={size}
+          {...(index ? { style: { zIndex: index } } : {})}
+          onClick={onClick}
+          fallback={identity.profile?.data?.emoji || fallbackValue.emoji}
+          ref={forwardedRef}
+        />
+        <Avatar.Label classNames={showName ? 'text-sm truncate pli-2' : 'sr-only'}>{getName(identity)}</Avatar.Label>
+      </Avatar.Root>
+    );
+  },
+);
 
 export type SmallPresenceLiveProps = {
   id?: string;

--- a/packages/plugins/plugin-space/src/components/SyncStatus/Space.tsx
+++ b/packages/plugins/plugin-space/src/components/SyncStatus/Space.tsx
@@ -84,7 +84,7 @@ export const SpaceRow = ({
     >
       <span className='is-1/2 truncate'>{spaceName}</span>
       <Icon
-        icon='ph--arrow-fat-line-left--regular'
+        icon='ph--arrow-fat-line-left--bold'
         size={3}
         classNames={mx(downActive && 'animate-[pulse_1s_infinite]')}
       />
@@ -94,7 +94,7 @@ export const SpaceRow = ({
         title={spaceId}
       />
       <Icon
-        icon='ph--arrow-fat-line-right--regular'
+        icon='ph--arrow-fat-line-right--bold'
         size={3}
         classNames={mx(upActive && 'animate-[pulse_1s_step-start_infinite]')}
       />

--- a/packages/plugins/plugin-space/src/translations.ts
+++ b/packages/plugins/plugin-space/src/translations.ts
@@ -132,7 +132,7 @@ export default [
 
         'settings panel label': 'Space Settings',
         'open current space settings label': 'Open current space settings',
-        'space settings properties label': 'General',
+        'space settings properties label': 'General settings',
         'space properties settings verbose label': 'Manage space properties',
         'space properties settings description': 'You can configure how this space is displayed in the app here.',
         'space settings schema label': 'Schema',

--- a/packages/plugins/plugin-space/src/util.tsx
+++ b/packages/plugins/plugin-space/src/util.tsx
@@ -219,7 +219,7 @@ export const constructSpaceNode = ({
         data: null,
         properties: {
           label: ['settings panel label', { ns: SPACE_PLUGIN }],
-          icon: 'ph--gear--regular',
+          icon: 'ph--faders--regular',
           disposition: 'alternate-tree',
         },
         nodes: [

--- a/packages/ui/lit-ui/src/dx-avatar/dx-avatar.pcss
+++ b/packages/ui/lit-ui/src/dx-avatar/dx-avatar.pcss
@@ -1,5 +1,5 @@
 .dx-avatar-group {
-  @apply inline-flex items-center;
+  @apply inline-flex items-center pie-2;
 }
 
 .dx-avatar-group .dx-avatar {

--- a/packages/ui/react-ui-attention/src/components/AttentionGlyph.tsx
+++ b/packages/ui/react-ui-attention/src/components/AttentionGlyph.tsx
@@ -60,7 +60,7 @@ export const Syncing = () => {
   return (
     <div role='status' className='flex items-center'>
       <Icon
-        icon='ph--circle-notch--regular'
+        icon='ph--circle-notch--bold'
         size={3}
         style={animationProps}
         classNames='text-subdued animate-[spin_2s_linear_infinite]'

--- a/packages/ui/react-ui-editor/src/extensions/folding.tsx
+++ b/packages/ui/react-ui-editor/src/extensions/folding.tsx
@@ -29,7 +29,7 @@ export const folding = (_props: FoldingOptions = {}): Extension => [
       const el = createElement('div', { className: 'flex h-full items-center' });
       return renderRoot(
         el,
-        <Icon icon='ph--caret-right--regular' size={3} classNames={['mx-3 cursor-pointer', open && 'rotate-90']} />,
+        <Icon icon='ph--caret-right--bold' size={3} classNames={['mx-3 cursor-pointer', open && 'rotate-90']} />,
       );
     },
   }),

--- a/packages/ui/react-ui-list/src/components/Tree/TreeItemToggle.tsx
+++ b/packages/ui/react-ui-list/src/components/Tree/TreeItemToggle.tsx
@@ -26,11 +26,7 @@ export const TreeItemToggle = memo(
         classNames={mx('is-6 pli-0 dx-focus-ring-inset', hidden ? 'hidden' : !isBranch && 'invisible')}
         onClick={onToggle}
       >
-        <Icon
-          icon='ph--caret-right--regular'
-          size={3}
-          classNames={mx('transition duration-200', open && 'rotate-90')}
-        />
+        <Icon icon='ph--caret-right--bold' size={3} classNames={mx('transition duration-200', open && 'rotate-90')} />
       </Button>
     );
   }),

--- a/packages/ui/react-ui/src/components/Avatars/Avatar.tsx
+++ b/packages/ui/react-ui/src/components/Avatars/Avatar.tsx
@@ -41,19 +41,22 @@ const DxAvatar = createComponent({
 
 type AvatarContentProps = ThemedClassName<Omit<ComponentProps<typeof DxAvatar>, 'children'>>;
 
-const AvatarContent = ({ icon, classNames, ...props }: AvatarContentProps) => {
-  const href = useIconHref(icon);
-  const { labelId, descriptionId } = useAvatarContext('AvatarContent');
-  return (
-    <DxAvatar
-      {...props}
-      icon={href}
-      labelId={labelId}
-      aria-describedby={descriptionId}
-      rootClassName={mx(classNames)}
-    />
-  );
-};
+const AvatarContent = forwardRef<NaturalDxAvatar, AvatarContentProps>(
+  ({ icon, classNames, ...props }, forwardedRef) => {
+    const href = useIconHref(icon);
+    const { labelId, descriptionId } = useAvatarContext('AvatarContent');
+    return (
+      <DxAvatar
+        {...props}
+        icon={href}
+        labelId={labelId}
+        aria-describedby={descriptionId}
+        rootClassName={mx(classNames)}
+        ref={forwardedRef}
+      />
+    );
+  },
+);
 
 type AvatarLabelProps = ThemedClassName<Omit<ComponentPropsWithRef<typeof Primitive.span>, 'id'>> & {
   asChild?: boolean;
@@ -113,4 +116,5 @@ export type {
   AvatarContentProps,
   AvatarLabelProps,
   AvatarDescriptionProps,
+  NaturalDxAvatar as DxAvatar,
 };


### PR DESCRIPTION
This PR:
- resolves some of #9038
- resolves #9037
- increases the size of the back button for alternate trees
- increases the size of L1 heading actions
- enforces the `bold` icon variant for all icons of size `3` or less
- uses the `faders` icon for all entity-specific settings items, leaving `gear` exclusively for app-wide settings

https://github.com/user-attachments/assets/75b4e47d-86ab-4cb1-8bfb-51f1a234eed2
