### PR TITLE
fix: SpacePresence layout

### DIFF
--- a/packages/plugins/plugin-deck/src/components/Plank/PlankHeading.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/PlankHeading.tsx
@@ -141,7 +141,7 @@ export const PlankHeading = memo(
     return (
       <StackItem.Heading
         classNames={[
-          'plb-1 border-be border-separator items-stretch gap-1 sticky inline-start-12 app-drag min-is-0 layout-contain',
+          'plb-1 border-be border-separator items-stretch gap-1 sticky inline-start-12 app-drag min-is-0 contain-layout',
           part === 'solo' ? soloInlinePadding : 'pli-1',
         ]}
       >

--- a/packages/plugins/plugin-space/src/components/SpacePresence.tsx
+++ b/packages/plugins/plugin-space/src/components/SpacePresence.tsx
@@ -116,7 +116,7 @@ export const FullPresence = (props: MemberPresenceProps) => {
     <div className='dx-avatar-group' data-testid='spacePlugin.presence'>
       {members.slice(0, 3).map((member, i) => (
         <Tooltip.Root key={member.identity.identityKey.toHex()}>
-          <Tooltip.Trigger>
+          <Tooltip.Trigger className='grid focus:outline-none'>
             <PresenceAvatar
               identity={member.identity}
               match={member.currentlyAttended} // TODO(Zan): Match always true now we're showing 'members viewing current object'.
@@ -136,7 +136,7 @@ export const FullPresence = (props: MemberPresenceProps) => {
 
       {members.length > 3 && (
         <Tooltip.Root>
-          <Tooltip.Trigger>
+          <Tooltip.Trigger className='grid focus:outline-none'>
             <Avatar.Root>
               {/* TODO(wittjosiah): Make text fit. */}
               <Avatar.Content

--- a/packages/ui/lit-ui/src/dx-avatar/dx-avatar.pcss
+++ b/packages/ui/lit-ui/src/dx-avatar/dx-avatar.pcss
@@ -17,10 +17,10 @@ dx-avatar {
 }
 
 .dx-avatar {
-  @apply relative inline-flex shrink-0;
+  @apply relative inline-flex shrink-0 contain-layout;
 
   .dx-avatar__frame {
-    @apply is-full bs-full bg-[--surface-bg]
+    @apply is-full bs-full bg-[--surface-bg];
   }
 
   .dx-avatar__frame, .dx-avatar__ring {


### PR DESCRIPTION
This PR:
- fixes a small issue with SpacePresence in the Plank heading

<img width="597" alt="Screenshot 2025-04-30 at 17 20 31" src="https://github.com/user-attachments/assets/c05f25a4-928b-48c2-a4e6-9658c435413c" />
