### PR TITLE
feat: edge websocket arbitrary message size support

### DIFF
--- a/packages/core/echo/echo-pipeline/src/edge/echo-edge-replicator.test.ts
+++ b/packages/core/echo/echo-pipeline/src/edge/echo-edge-replicator.test.ts
@@ -33,12 +33,12 @@ describe('EchoEdgeReplicator', () => {
     await connectionOpen.waitForCount(1);
 
     const forbidden = createForbiddenMessage({ identityKey: client.identityKey, peerKey: client.peerKey }, spaceId);
-    server.sendMessage(forbidden);
+    await server.sendMessage(forbidden);
     await connectionOpen.waitForCount(1);
 
     // Double restart to check for race conditions.
     client.setIdentity(await createEphemeralEdgeIdentity());
-    server.sendMessage(forbidden);
+    await server.sendMessage(forbidden);
     await connectionOpen.waitForCount(1);
 
     await replicator.disconnect();

--- a/packages/core/mesh/edge-client/src/edge-ws-connection.ts
+++ b/packages/core/mesh/edge-client/src/edge-ws-connection.ts
@@ -13,15 +13,17 @@ import { MessageSchema, type Message } from '@dxos/protocols/buf/dxos/edge/messe
 
 import { protocol } from './defs';
 import { type EdgeIdentity } from './edge-identity';
+import { WebSocketMuxer } from './edge-ws-muxer';
 import { toUint8Array } from './protocol';
 
 const SIGNAL_KEEPALIVE_INTERVAL = 4_000;
 const SIGNAL_KEEPALIVE_TIMEOUT = 12_000;
 
+const EDGE_WEBSOCKET_PROTOCOL_V0 = 'edge-ws-v0';
 /**
- * 1MB websocket message limit: https://developers.cloudflare.com/durable-objects/platform/limits/
+ * Supports message segmentation and muxing.
  */
-const CLOUDFLARE_MESSAGE_LENGTH_LIMIT = 1024 * 1024;
+export const EDGE_WEBSOCKET_PROTOCOL_V1 = 'edge-ws-v1';
 
 export type EdgeWsConnectionCallbacks = {
   onConnected: () => void;
@@ -32,6 +34,7 @@ export type EdgeWsConnectionCallbacks = {
 export class EdgeWsConnection extends Resource {
   private _inactivityTimeoutCtx: Context | undefined;
   private _ws: WebSocket | undefined;
+  private _wsMuxer: WebSocketMuxer | undefined;
 
   constructor(
     private readonly _identity: EdgeIdentity,
@@ -52,24 +55,25 @@ export class EdgeWsConnection extends Resource {
 
   public send(message: Message) {
     invariant(this._ws);
+    invariant(this._wsMuxer);
     log('sending...', { peerKey: this._identity.peerKey, payload: protocol.getPayloadType(message) });
-    const encoded = buf.toBinary(MessageSchema, message);
-    if (encoded.byteLength >= CLOUDFLARE_MESSAGE_LENGTH_LIMIT) {
-      log.error('edge message dropped due to websocket message limit', {
-        byteLength: encoded.byteLength,
-        serviceId: message.serviceId,
-        payload: protocol.getPayloadType(message),
-      });
-      return;
+    if (this._ws?.protocol.includes(EDGE_WEBSOCKET_PROTOCOL_V0)) {
+      this._ws.send(buf.toBinary(MessageSchema, message));
+    } else {
+      this._wsMuxer.send(message).catch((e) => log.catch(e));
     }
-    this._ws.send(encoded);
   }
 
   protected override async _open() {
+    const baseProtocols = [EDGE_WEBSOCKET_PROTOCOL_V0, EDGE_WEBSOCKET_PROTOCOL_V1];
     this._ws = new WebSocket(
       this._connectionInfo.url.toString(),
-      this._connectionInfo.protocolHeader ? [this._connectionInfo.protocolHeader] : [],
+      this._connectionInfo.protocolHeader
+        ? [...baseProtocols, this._connectionInfo.protocolHeader]
+        : [...baseProtocols],
     );
+    const muxer = new WebSocketMuxer(this._ws);
+    this._wsMuxer = muxer;
 
     this._ws.onopen = () => {
       if (this.isOpen) {
@@ -84,6 +88,7 @@ export class EdgeWsConnection extends Resource {
       if (this.isOpen) {
         log.warn('disconnected while being open', { code: event.code, reason: event.reason });
         this._callbacks.onRestartRequired();
+        muxer.destroy();
       }
     };
     this._ws.onerror = (event) => {
@@ -106,9 +111,16 @@ export class EdgeWsConnection extends Resource {
         this._rescheduleHeartbeatTimeout();
         return;
       }
-      const data = await toUint8Array(event.data);
-      if (this.isOpen) {
-        const message = buf.fromBinary(MessageSchema, data);
+      const bytes = await toUint8Array(event.data);
+      if (!this.isOpen) {
+        return;
+      }
+
+      const message = this._ws?.protocol?.includes(EDGE_WEBSOCKET_PROTOCOL_V0)
+        ? buf.fromBinary(MessageSchema, bytes)
+        : muxer.receiveData(bytes);
+
+      if (message) {
         log('received', { from: message.source, payload: protocol.getPayloadType(message) });
         this._callbacks.onMessage(message);
       }
@@ -121,6 +133,8 @@ export class EdgeWsConnection extends Resource {
     try {
       this._ws?.close();
       this._ws = undefined;
+      this._wsMuxer?.destroy();
+      this._wsMuxer = undefined;
     } catch (err) {
       if (err instanceof Error && err.message.includes('WebSocket is closed before the connection is established.')) {
         return;

--- a/packages/core/mesh/edge-client/src/edge-ws-muxer.ts
+++ b/packages/core/mesh/edge-client/src/edge-ws-muxer.ts
@@ -1,0 +1,187 @@
+//
+// Copyright 2025 DXOS.org
+//
+import WebSocket from 'isomorphic-ws';
+
+import { Trigger } from '@dxos/async';
+import { log } from '@dxos/log';
+import { buf } from '@dxos/protocols/buf';
+import { MessageSchema, type Message } from '@dxos/protocols/buf/dxos/edge/messenger_pb';
+
+import { protocol } from './defs';
+
+/**
+ * 0000 0001 - message contains a part of segmented message chunk sequence.
+ * The next byte defines a channel id and the rest of the message contains a part of Message proto binary.
+ * Messages from different channels might interleave.
+ * When the flag is NOT set the rest of the message should be interpreted as the valid Message proto binary.
+ */
+const FLAG_SEGMENT_SEQ = 1;
+/**
+ * 0000 0010 - message terminates a segmented message chunk sequence.
+ * All the chunks accumulated for the channel specified by the second byte can be concatenated
+ * and interpreted as a valid Message proto binary.
+ */
+const FLAG_SEGMENT_SEQ_TERMINATED = 1 << 1;
+
+/**
+ * 1MB websocket message limit: https://developers.cloudflare.com/durable-objects/platform/limits/
+ */
+const CLOUDFLARE_MESSAGE_LENGTH_LIMIT = 1024 * 1024;
+
+const MAX_CHUNK_LENGTH = 16384;
+const MAX_BUFFERED_AMOUNT = CLOUDFLARE_MESSAGE_LENGTH_LIMIT;
+const BUFFER_FULL_BACKOFF_TIMEOUT = 100;
+
+export class WebSocketMuxer {
+  private readonly _incomingMessageAccumulator = new Map<number, Buffer[]>();
+  private readonly _outgoingMessageChunks = new Map<number, MessageChunk[]>();
+  private readonly _serviceToChannel = new Map<string, number>();
+
+  private _sendTimeout: any | undefined;
+
+  constructor(private readonly _ws: WebSocket) {}
+
+  /**
+   * Resolves when all the message chunks get enqueued for sending.
+   */
+  public async send(message: Message): Promise<void> {
+    const binary = buf.toBinary(MessageSchema, message);
+    const channelId = this._resolveChannel(message);
+    if (channelId == null && binary.length > CLOUDFLARE_MESSAGE_LENGTH_LIMIT) {
+      log.error('Large message dropped because channel resolution failed.', {
+        byteLength: binary.byteLength,
+        serviceId: message.serviceId,
+        payload: protocol.getPayloadType(message),
+      });
+      return;
+    }
+
+    if (channelId == null || binary.length < MAX_CHUNK_LENGTH) {
+      const flags = Buffer.from([0]);
+      this._ws.send(Buffer.concat([flags, binary]));
+      return;
+    }
+
+    const terminatorSentTrigger = new Trigger();
+    const messageChunks: MessageChunk[] = [];
+    for (let i = 0; i < binary.length; i += MAX_CHUNK_LENGTH) {
+      const chunk = binary.slice(i, i + MAX_CHUNK_LENGTH);
+      const isLastChunk = i + MAX_CHUNK_LENGTH < binary.length;
+      if (isLastChunk) {
+        const flags = Buffer.from([FLAG_SEGMENT_SEQ | FLAG_SEGMENT_SEQ_TERMINATED, channelId]);
+        messageChunks.push({ payload: Buffer.concat([flags, chunk]), trigger: terminatorSentTrigger });
+      } else {
+        const flags = Buffer.from([FLAG_SEGMENT_SEQ]);
+        messageChunks.push({ payload: Buffer.concat([flags, chunk]) });
+      }
+    }
+
+    const queuedMessages = this._outgoingMessageChunks.get(channelId);
+    if (queuedMessages) {
+      queuedMessages.push(...messageChunks);
+    } else {
+      this._outgoingMessageChunks.set(channelId, messageChunks);
+    }
+
+    this._sendChunkedMessages();
+
+    return terminatorSentTrigger.wait();
+  }
+
+  public receiveData(data: Uint8Array): Message | undefined {
+    if ((data[0] & FLAG_SEGMENT_SEQ) === 0) {
+      return buf.fromBinary(MessageSchema, data.slice(1));
+    }
+
+    const [flags, channelId, ...payload] = data;
+    let chunkAccumulator = this._incomingMessageAccumulator.get(channelId);
+    if (chunkAccumulator) {
+      chunkAccumulator.push(Buffer.from(payload));
+    } else {
+      chunkAccumulator = [Buffer.from(payload)];
+      this._incomingMessageAccumulator.set(channelId, chunkAccumulator);
+    }
+
+    if ((flags & FLAG_SEGMENT_SEQ_TERMINATED) === 0) {
+      return undefined;
+    }
+
+    const message = buf.fromBinary(MessageSchema, Buffer.concat(chunkAccumulator));
+    this._incomingMessageAccumulator.delete(channelId);
+    return message;
+  }
+
+  public destroy() {
+    if (this._sendTimeout) {
+      clearTimeout(this._sendTimeout);
+      this._sendTimeout = undefined;
+    }
+    for (const channelChunks of this._outgoingMessageChunks.values()) {
+      channelChunks.forEach((chunk) => chunk.trigger?.wake());
+    }
+    this._outgoingMessageChunks.clear();
+    this._incomingMessageAccumulator.clear();
+    this._serviceToChannel.clear();
+  }
+
+  private _sendChunkedMessages() {
+    if (this._sendTimeout) {
+      return;
+    }
+
+    const send = () => {
+      if (this._ws.readyState === WebSocket.CLOSING || this._ws.readyState === WebSocket.CLOSED) {
+        log.warn('send called for closed websocket');
+        this._sendTimeout = undefined;
+        return;
+      }
+
+      let timeout = 0;
+      const emptyChannels: number[] = [];
+      for (const [channelId, messages] of this._outgoingMessageChunks.entries()) {
+        if (this._ws.bufferedAmount + MAX_CHUNK_LENGTH > MAX_BUFFERED_AMOUNT) {
+          timeout = BUFFER_FULL_BACKOFF_TIMEOUT;
+          break;
+        }
+
+        const nextMessage = messages.shift();
+        if (nextMessage) {
+          this._ws.send(nextMessage.payload);
+          nextMessage.trigger?.wake();
+        } else {
+          emptyChannels.push(channelId);
+        }
+      }
+
+      emptyChannels.forEach((channelId) => this._outgoingMessageChunks.delete(channelId));
+
+      if (this._outgoingMessageChunks.size > 0) {
+        this._sendTimeout = setTimeout(send, timeout);
+      } else {
+        this._sendTimeout = undefined;
+      }
+    };
+    this._sendTimeout = setTimeout(send);
+  }
+
+  private _resolveChannel(message: Message): number | undefined {
+    if (!message.serviceId) {
+      return undefined;
+    }
+    let id = this._serviceToChannel.get(message.serviceId);
+    if (!id) {
+      id = this._serviceToChannel.size + 1;
+      this._serviceToChannel.set(message.serviceId, id);
+    }
+    return id;
+  }
+}
+
+type MessageChunk = {
+  payload: Buffer;
+  /**
+   * Wakes when the payload is enqueued by WebSocket.
+   */
+  trigger?: Trigger;
+};

--- a/packages/core/mesh/edge-client/src/testing/test-utils.ts
+++ b/packages/core/mesh/edge-client/src/testing/test-utils.ts
@@ -10,6 +10,8 @@ import { buf } from '@dxos/protocols/buf';
 import { MessageSchema, TextMessageSchema, type Message } from '@dxos/protocols/buf/dxos/edge/messenger_pb';
 
 import { protocol } from '../defs';
+import { EDGE_WEBSOCKET_PROTOCOL_V1 } from '../edge-ws-connection';
+import { WebSocketMuxer } from '../edge-ws-muxer';
 import { toUint8Array } from '../protocol';
 
 export const DEFAULT_PORT = 8080;
@@ -21,24 +23,33 @@ type TestEdgeWsServerParams = {
 };
 
 export const createTestEdgeWsServer = async (port = DEFAULT_PORT, params?: TestEdgeWsServerParams) => {
-  const server = new WebSocket.Server({ port, verifyClient: createConnectionDelayHandler(params) });
+  const wsServer = new WebSocket.Server({
+    port,
+    verifyClient: createConnectionDelayHandler(params),
+    handleProtocols: () => [EDGE_WEBSOCKET_PROTOCOL_V1],
+  });
 
-  let connection: WebSocket | undefined;
+  let connection: { ws: WebSocket; muxer: WebSocketMuxer } | undefined;
 
   const messageSink: any[] = [];
   const messageSourceLog: any[] = [];
   const closeTrigger = new Trigger();
-  const sendResponseMessage = createResponseSender(() => connection!);
+  const sendResponseMessage = createResponseSender(() => connection!.muxer);
 
-  server.on('connection', (ws) => {
-    connection = ws;
+  wsServer.on('connection', (ws) => {
+    const muxer = new WebSocketMuxer(ws);
+    connection = { ws, muxer };
     ws.on('error', (err) => log.catch(err));
     ws.on('message', async (data) => {
       if (String(data) === '__ping__') {
         ws.send('__pong__');
         return;
       }
-      const { request, requestPayload } = await decodeRequest(params, data);
+      const message = muxer.receiveData(await toUint8Array(data));
+      if (!message) {
+        return;
+      }
+      const { request, requestPayload } = await decodePayload(message, params);
       messageSourceLog.push(request.source);
       if (params?.messageHandler) {
         const responsePayload = await params.messageHandler(requestPayload);
@@ -57,19 +68,19 @@ export const createTestEdgeWsServer = async (port = DEFAULT_PORT, params?: TestE
   });
 
   return {
-    server,
+    server: wsServer,
     messageSink,
     messageSourceLog,
-    endpoint: `ws://localhost:${port}`,
-    cleanup: () => server.close(),
+    endpoint: `ws://127.0.0.1:${port}`,
+    cleanup: () => wsServer.close(),
     currentConnection: () => connection,
     sendResponseMessage,
     sendMessage: (msg: Message) => {
-      connection!.send(buf.toBinary(MessageSchema, msg));
+      return connection!.muxer.send(msg);
     },
     closeConnection: () => {
       closeTrigger.reset();
-      connection!.close(1011);
+      connection!.ws.close(1011);
       return closeTrigger.wait();
     },
   };
@@ -89,27 +100,23 @@ const createConnectionDelayHandler = (params: TestEdgeWsServerParams | undefined
   };
 };
 
-const createResponseSender = (connection: () => WebSocket) => {
+const createResponseSender = (connection: () => WebSocketMuxer) => {
   return (request: Message, responsePayload: Uint8Array) => {
     const recipient = request.source!;
-    connection().send(
-      buf.toBinary(
-        MessageSchema,
-        buf.create(MessageSchema, {
-          source: {
-            identityKey: recipient.identityKey,
-            peerKey: recipient.peerKey,
-          },
-          serviceId: request.serviceId!,
-          payload: { value: responsePayload },
-        }),
-      ),
+    void connection().send(
+      buf.create(MessageSchema, {
+        source: {
+          identityKey: recipient.identityKey,
+          peerKey: recipient.peerKey,
+        },
+        serviceId: request.serviceId!,
+        payload: { value: responsePayload },
+      }),
     );
   };
 };
 
-const decodeRequest = async (params: TestEdgeWsServerParams | undefined, data: any) => {
-  const request = buf.fromBinary(MessageSchema, await toUint8Array(data));
+const decodePayload = async (request: Message, params: TestEdgeWsServerParams | undefined) => {
   const requestPayload = params?.payloadDecoder
     ? params.payloadDecoder(request.payload!.value!)
     : protocol.getPayload(request, TextMessageSchema);


### PR DESCRIPTION
### Details

* Simple protocol for passing large (>1MB) messages over edge websocket connection:
Reserve the first byte for flags.
`0000 0001` means the message contains a part of a larger message and the next byte is a channel id. Messages from different channels might interleave.
`0000 0010` means the message terminates a sequence of larger message chunks. All the accumulated chunks can be concatenated and interpreted as a single Message proto binary. 

* Client only enables segmentation if response protocols don't contain `edge-ws-v0`.
* `WebSocketMuxer` API allows simple integration with edge router.
* `WebSocketMuxer` send ensures that websocket buffered amount doesn't exceed 1MB when sending larger messages. Smaller messages are enqueued immediately.
*  `WebSocketMuxer` send resolves immediately for small messages (< 16KB) and when the last segment gets enqueued for larger messages.