### PR TITLE
fix: Popover size, hide when occluded, more constrained boundaries

### DIFF
--- a/packages/plugins/plugin-deck/src/components/DeckLayout/Popover.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/Popover.tsx
@@ -45,7 +45,7 @@ export const PopoverRoot = ({ children }: DeckPopoverRootProps) => {
 
   return (
     <DeckPopoverProvider setOpen={setOpen}>
-      <Popover.Root modal open={open}>
+      <Popover.Root modal={false} open={open}>
         {layout.popoverAnchor && <Popover.VirtualTrigger key={virtualIter} virtualRef={virtualRef} />}
         {children}
       </Popover.Root>

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/Popover.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/Popover.tsx
@@ -3,7 +3,7 @@
 //
 
 import { createContext } from '@radix-ui/react-context';
-import React, { type PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
+import React, { type PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Surface, useCapability } from '@dxos/app-framework';
 import { Popover, type PopoverContentInteractOutsideEvent } from '@dxos/react-ui';
@@ -76,9 +76,24 @@ export const PopoverContent = () => {
     [setOpen],
   );
 
+  const collisionBoundaries: HTMLElement[] = useMemo(() => {
+    const closest = layout.popoverAnchor?.closest('[data-popover-collision-boundary]') as
+      | HTMLElement
+      | null
+      | undefined;
+    return closest ? [closest] : [];
+  }, [layout.popoverAnchor]);
+
   return (
     <Popover.Portal>
-      <Popover.Content side={layout.popoverSide} onInteractOutside={handleClose} onEscapeKeyDown={handleClose}>
+      <Popover.Content
+        side={layout.popoverSide}
+        onInteractOutside={handleClose}
+        onEscapeKeyDown={handleClose}
+        collisionBoundary={collisionBoundaries}
+        sticky='always'
+        hideWhenDetached
+      >
         <Popover.Viewport>
           <Surface role='popover' data={layout.popoverContent} limit={1} />
         </Popover.Viewport>

--- a/packages/plugins/plugin-inbox/src/components/Message/Message.tsx
+++ b/packages/plugins/plugin-inbox/src/components/Message/Message.tsx
@@ -64,7 +64,12 @@ export const Message = ({ space, message, viewMode, contactDxn, classNames }: Me
     <div role='none' className='grid grid-rows-[min-content_1fr]'>
       <MessageHeader message={message} viewMode={viewMode} contactDxn={contactDxn} />
       <div role='none' className='relative'>
-        <div role='none' ref={parentRef} className={mx('absolute inset-0', classNames)} />
+        <div
+          role='none'
+          ref={parentRef}
+          className={mx('absolute inset-0', classNames)}
+          data-popover-collision-boundary={true}
+        />
       </div>
     </div>
   );

--- a/packages/plugins/plugin-markdown/src/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownEditor/MarkdownEditor.tsx
@@ -231,6 +231,7 @@ export const MarkdownEditor = ({
         data-testid='composer.markdownRoot'
         data-toolbar={toolbar ? 'enabled' : 'disabled'}
         className={stackItemContentEditorClassNames(role)}
+        data-popover-collision-boundary={true}
         {...focusAttributes}
       />
     </StackItem.Content>

--- a/packages/plugins/plugin-markdown/src/components/MarkdownPreview/MarkdownPreview.stories.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownPreview/MarkdownPreview.stories.tsx
@@ -28,7 +28,7 @@ const meta: Meta<typeof MarkdownPreview> = {
   render: ({ subject }) => {
     return (
       <Popover.Root open>
-        <Popover.Content classNames='popover-max-width overflow-hidden'>
+        <Popover.Content>
           <MarkdownPreview subject={subject} />
           <Popover.Arrow />
         </Popover.Content>

--- a/packages/plugins/plugin-preview/src/types.ts
+++ b/packages/plugins/plugin-preview/src/types.ts
@@ -31,7 +31,7 @@ export type PreviewProps<T extends object> = PropsWithChildren<
  *   </Card.Body>
  * </Card.Root>
  */
-export const previewCard = 'popover-max-width rounded-lg overflow-hidden';
+export const previewCard = 'popover-consistent-width rounded-lg overflow-hidden';
 export const previewTitle = 'text-lg font-medium line-clamp-2';
 export const previewProse = 'pli-3 mlb-3';
 export const previewChrome = 'pli-1.5 mlb-1.5 [&_.dx-button]:pli-1.5 [&_.dx-button]:text-start [&_.dx-button]:is-full';

--- a/packages/plugins/plugin-space/src/components/PopoverRenameSpace.tsx
+++ b/packages/plugins/plugin-space/src/components/PopoverRenameSpace.tsx
@@ -4,6 +4,7 @@
 
 import React, { useCallback, useRef, useState } from 'react';
 
+import { createIntent, LayoutAction, useIntentDispatcher } from '@dxos/app-framework';
 import { type Space } from '@dxos/react-client/echo';
 import { Button, Input, Popover, useTranslation } from '@dxos/react-ui';
 
@@ -15,9 +16,16 @@ export const PopoverRenameSpace = ({ space }: { space: Space }) => {
   const { t } = useTranslation(SPACE_PLUGIN);
   const doneButton = useRef<HTMLButtonElement>(null);
   const [name, setName] = useState(space.properties.name ?? '');
+  const { dispatchPromise: dispatch } = useIntentDispatcher();
 
   const handleDone = useCallback(() => {
     space.properties.name = name;
+    void dispatch(
+      createIntent(LayoutAction.UpdatePopover, {
+        part: 'popover',
+        options: { variant: 'react', anchorId: '', state: false },
+      }),
+    );
   }, [space, name]);
 
   // TODO(thure): Why does the input value need to be uncontrolled to work?

--- a/packages/plugins/plugin-storybook-layout/src/components/Layout.tsx
+++ b/packages/plugins/plugin-storybook-layout/src/components/Layout.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { type PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
+import React, { type PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Surface, useCapability } from '@dxos/app-framework';
 import { Popover, type PopoverContentInteractOutsideEvent } from '@dxos/react-ui';
@@ -49,6 +49,14 @@ export const Layout = ({ children }: PropsWithChildren<{}>) => {
     }
   }, []);
 
+  const collisionBoundaries: HTMLElement[] = useMemo(() => {
+    const closest = layout.popoverAnchor?.closest('[data-popover-collision-boundary]') as
+      | HTMLElement
+      | null
+      | undefined;
+    return closest ? [closest] : [];
+  }, [layout.popoverAnchor]);
+
   return (
     <Popover.Root open={open}>
       <Popover.VirtualTrigger key={iter} virtualRef={trigger} />
@@ -57,6 +65,9 @@ export const Layout = ({ children }: PropsWithChildren<{}>) => {
           side={layout.popoverSide}
           onInteractOutside={handleInteractOutside}
           onEscapeKeyDown={handleInteractOutside}
+          collisionBoundary={collisionBoundaries}
+          sticky='always'
+          hideWhenDetached
         >
           <Popover.Viewport>
             <Surface role='popover' data={layout.popoverContent} limit={1} />

--- a/packages/plugins/plugin-transcription/src/components/Transcript/Transcript.tsx
+++ b/packages/plugins/plugin-transcription/src/components/Transcript/Transcript.tsx
@@ -90,5 +90,11 @@ export const Transcript = ({
     };
   }, [space, model]);
 
-  return <div ref={parentRef} className={mx('flex grow overflow-hidden', editorWidth, classNames)} />;
+  return (
+    <div
+      ref={parentRef}
+      className={mx('flex grow overflow-hidden', editorWidth, classNames)}
+      data-popover-collision-boundary={true}
+    />
+  );
 };

--- a/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.tsx
+++ b/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.tsx
@@ -86,7 +86,7 @@ export const ScrollContainer = forwardRef<ScrollController, ScrollContainerProps
     }, [viewport, fade]);
 
     return (
-      <div className='relative flex-1 min-bs-0 grid overflow-hidden' data-popover-collision-boundary={true}>
+      <div className='relative flex-1 min-bs-0 grid overflow-hidden'>
         {fade && (
           <div
             role='none'

--- a/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.tsx
+++ b/packages/ui/react-ui-components/src/ScrollContainer/ScrollContainer.tsx
@@ -86,7 +86,7 @@ export const ScrollContainer = forwardRef<ScrollController, ScrollContainerProps
     }, [viewport, fade]);
 
     return (
-      <div className='relative flex-1 min-bs-0 grid overflow-hidden'>
+      <div className='relative flex-1 min-bs-0 grid overflow-hidden' data-popover-collision-boundary={true}>
         {fade && (
           <div
             role='none'

--- a/packages/ui/react-ui-stack/src/components/StackItemContent.tsx
+++ b/packages/ui/react-ui-stack/src/components/StackItemContent.tsx
@@ -53,6 +53,7 @@ export const StackItemContent = forwardRef<HTMLDivElement, StackItemContentProps
             ...(statusbar ? ['var(--statusbar-size)'] : []),
           ].join(' '),
         }}
+        data-popover-collision-boundary={true}
         ref={forwardedRef}
       >
         {children}

--- a/packages/ui/react-ui-theme/src/styles/layers/size.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/size.css
@@ -6,6 +6,10 @@
   @apply is-max max-is-popoverMaxWidth;
 }
 
+.popover-consistent-width {
+  inline-size: min(var(--radix-popper-available-width), var(--dx-popoverMaxWidth));
+}
+
 @layer dx-components {
 
   /* Block size */


### PR DESCRIPTION
This PR:
- sets preview popovers to use `popover-consistent-width`, which aims for 20rem but doesn’t exceed the available space.
- removes the `modal` flag on deck popovers
- sets the `hideWhenDetached` flag on deck and storybook popovers so they hide when the anchor becomes occluded
- sets `collisionBoundary` based on the closest `[data-popover-collision-boundary]` element

<img width="592" alt="Screenshot 2025-05-07 at 13 55 41" src="https://github.com/user-attachments/assets/c1319c6d-70a3-4409-b069-ce4f501630da" />
<img width="584" alt="Screenshot 2025-05-07 at 13 55 16" src="https://github.com/user-attachments/assets/88ce147d-2154-4775-87e1-fc9d14674c30" />

https://github.com/user-attachments/assets/41aacf3f-cc83-4f51-8833-66b63f5dcad1
