### PR TITLE
fix: Restore missing `role` to preview card stories

### DIFF
--- a/packages/plugins/plugin-preview/src/Preview.stories.tsx
+++ b/packages/plugins/plugin-preview/src/Preview.stories.tsx
@@ -95,6 +95,7 @@ export const ContactWithImage = {
     Component: ContactCard,
     icon: 'ph--user--regular',
     subject: data.contact,
+    role: 'popover',
   },
 };
 
@@ -103,6 +104,7 @@ export const ContactNoImage = {
     Component: ContactCard,
     icon: 'ph--user--regular',
     subject: omitImage(data.contact),
+    role: 'popover',
   },
 };
 
@@ -111,6 +113,7 @@ export const OrganizationWithImage = {
     Component: OrganizationCard,
     icon: 'ph--building-office--regular',
     subject: data.organization,
+    role: 'popover',
   },
 };
 
@@ -119,6 +122,7 @@ export const OrganizationNoImage = {
     Component: OrganizationCard,
     icon: 'ph--building-office--regular',
     subject: omitImage(data.organization),
+    role: 'popover',
   },
 };
 
@@ -127,6 +131,7 @@ export const ProjectWithImage = {
     Component: ProjectCard,
     icon: 'ph--building--regular',
     subject: data.project,
+    role: 'popover',
   },
 };
 
@@ -135,5 +140,6 @@ export const ProjectNoImage = {
     Component: ProjectCard,
     icon: 'ph--building--regular',
     subject: omitImage(data.project),
+    role: 'popover',
   },
 };


### PR DESCRIPTION
This PR:
- does what it says on the tin

https://github.com/user-attachments/assets/4f8e02cb-2d66-480d-b70b-c7c03e8a69ca
