### PR TITLE
fix: CSS `@layer` order race condition

### DIFF
--- a/packages/apps/composer-app/index.html
+++ b/packages/apps/composer-app/index.html
@@ -33,9 +33,11 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png">
     -->
 
-    <!-- TODO(wittjosiah): Add hash/nonce and remove unsafe-inline from content security policy. -->
     <style>@layer dx-tokens, user-tokens, tw-base, dx-base, tw-components, dx-components, utilities;</style>
+
+    <!-- TODO(wittjosiah): Add hash/nonce and remove unsafe-inline from content security policy. -->
     <!-- TODO(nf): Blob in worker-src needed for Sentry replay. -->
+
     <script>
       function setTheme(darkMode) {
         document.documentElement.classList[darkMode ? 'add' : 'remove']('dark');

--- a/packages/apps/composer-app/index.html
+++ b/packages/apps/composer-app/index.html
@@ -34,7 +34,7 @@
     -->
 
     <!-- TODO(wittjosiah): Add hash/nonce and remove unsafe-inline from content security policy. -->
-
+    <style>@layer dx-tokens, user-tokens, tw-base, dx-base, tw-components, dx-components, utilities;</style>
     <!-- TODO(nf): Blob in worker-src needed for Sentry replay. -->
     <script>
       function setTheme(darkMode) {


### PR DESCRIPTION
This PR:
- fixes a CSS layer order issues in bundled versions of Composer

<img width="517" alt="Screenshot 2025-05-14 at 17 09 14" src="https://github.com/user-attachments/assets/f512ef1e-5e32-4d84-8866-676ec5b89c97" />
