### PR TITLE
fix: Grid e2e and visual fixes, input color token fix

### DIFF
--- a/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.stories.tsx
+++ b/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.stories.tsx
@@ -7,6 +7,7 @@ import '@dxos-theme';
 import { type Meta } from '@storybook/react';
 import React from 'react';
 
+import { IntentPlugin } from '@dxos/app-framework';
 import { withPluginManager } from '@dxos/app-framework/testing';
 import { useSpace } from '@dxos/react-client/echo';
 import { withClientProvider } from '@dxos/react-client/testing';
@@ -42,7 +43,9 @@ const meta: Meta = {
     withComputeGraphDecorator(),
     withTheme,
     withLayout({ fullscreen: true, classNames: 'grid' }),
-    withPluginManager(),
+    withPluginManager({
+      plugins: [IntentPlugin()],
+    }),
   ],
   parameters: { translations },
 };

--- a/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.tsx
+++ b/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.tsx
@@ -306,7 +306,8 @@ export const GridSheet = () => {
   useSelectThreadOnCellFocus();
 
   return (
-    <div role='none' className='relative min-bs-0'>
+    // TODO(thure): Why are Table’s and Sheet’s editor boxes off by 1px?
+    <div role='none' className='relative min-bs-0 [&_.cm-editor]:!border-lb [&_.cm-editor]:!border-transparent '>
       <GridCellEditor getCellContent={getCellContent} extension={extension} onBlur={handleBlur} />
       <Grid.Content
         initialCells={initialCells}

--- a/packages/ui/lit-grid/src/dx-grid.ts
+++ b/packages/ui/lit-grid/src/dx-grid.ts
@@ -269,6 +269,7 @@ export class DxGrid extends LitElement {
             cellIndex,
             cellBox: this.focusedCellBox(),
             cellElement: this.focusedCellElement(),
+            initialContent,
           }),
         );
       });

--- a/packages/ui/react-ui-grid/src/CellEditor/CellEditor.tsx
+++ b/packages/ui/react-ui-grid/src/CellEditor/CellEditor.tsx
@@ -140,7 +140,7 @@ export const CellEditor = ({ value, extension, autoFocus, onBlur, box, gridId }:
           themeMode,
           slots: {
             editor: {
-              className: '!border-lb !border-transparent [&>.cm-scroller]:scrollbar-none tabular-nums',
+              className: '[&>.cm-scroller]:scrollbar-none tabular-nums',
             },
             content: {
               className:

--- a/packages/ui/react-ui-grid/src/Grid/Grid.tsx
+++ b/packages/ui/react-ui-grid/src/Grid/Grid.tsx
@@ -113,7 +113,6 @@ const GridContent = forwardRef<NaturalDxGrid, GridScopedProps<GridContentProps>>
   const { id, editing, setEditBox, setEditing } = useGridContext(GRID_CONTENT_NAME, props.__gridScope);
   const [dxGrid, setDxGridInternal] = useState<NaturalDxGrid | null>(null);
 
-  // TODO(burdon): Can we use useImperativeHandle here?
   // NOTE(thure): using `useState` instead of `useRef` works with refs provided by `@lit/react` and gives us
   // a reliable dependency for `useEffect` whereas `useLayoutEffect` does not guarantee the element will be defined.
   const setDxGrid = useCallback(

--- a/packages/ui/react-ui-theme/src/config/tokens/sememes-system.ts
+++ b/packages/ui/react-ui-theme/src/config/tokens/sememes-system.ts
@@ -57,6 +57,10 @@ const surface: Record<string, Sememe> = {
     light: ['neutral', lightCadence(2.8)],
     dark: ['neutral', darkCadence(3)],
   },
+  '35': {
+    light: ['neutral', lightCadence(3.5)],
+    dark: ['neutral', darkCadence(3.5)],
+  },
   '40': {
     light: ['neutral', lightCadence(4)],
     dark: ['neutral', darkCadence(4)],
@@ -97,6 +101,7 @@ export const systemSememes = {
   'surface-10t': applyAlpha(surface['10'], 0.65),
   'surface-20': surface['20'],
   'surface-30': surface['30'],
+  'surface-35': surface['35'],
   'surface-40': surface['40'],
   'surface-50': surface['50'],
   'surface-60': surface['60'],
@@ -232,7 +237,7 @@ const aliasDefssDefs: Record<Alias, { root?: SememeName; attention?: SememeName 
   attention: { root: 'surface-10' },
   currentRelated: { root: 'accentSurface-300t' },
   hoverOverlay: { root: 'surface-450t' },
-  input: { root: 'surface-50', attention: 'surface-40' },
+  input: { root: 'surface-35', attention: 'surface-35' },
   separator: { root: 'surface-50' },
   subduedSeparator: { root: 'surface-30' },
   unAccent: { root: 'surface-400' },


### PR DESCRIPTION
This PR does what it says on the tin.

#### e2e

<img width="941" alt="Screenshot 2025-05-20 at 17 56 14" src="https://github.com/user-attachments/assets/9d24b19a-ed14-4872-a194-56c30619805f" />

#### Other grid issues

https://github.com/user-attachments/assets/00309131-d9ee-4fc5-90fd-18e856f43dc8

#### Colors

<img width="934" alt="Screenshot 2025-05-20 at 17 54 56" src="https://github.com/user-attachments/assets/1a887899-9f7a-47cf-8b98-e21e2857a1cb" />
<img width="934" alt="Screenshot 2025-05-20 at 17 54 48" src="https://github.com/user-attachments/assets/a8da0bda-1ddf-44f3-a34e-0eb4e06011ea" />
