### PR TITLE
feat(plugin-deck): Persistent fullscreen chrome

### DIFF
--- a/packages/plugins/plugin-deck/src/components/DeckLayout/DeckLayout.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/DeckLayout.tsx
@@ -91,14 +91,15 @@ export const DeckLayout = ({ onDismissToast }: DeckLayoutProps) => {
     }
   }, [isNotMobile, deck, dispatch]);
 
-  // If deck is disabled in settings, ensure that the layout is in solo mode.
+  // When deck is disabled in settings, set to solo mode if the current layout mode is deck.
+  // TODO(thure): Applying this as an effect should be avoided over emitting the intent only when the setting changes.
   useEffect(() => {
-    if (!settings.enableDeck) {
+    if (!settings.enableDeck && layoutMode === 'deck') {
       void dispatch(
         createIntent(LayoutAction.SetLayoutMode, { part: 'mode', subject: active[0], options: { mode: 'solo' } }),
       );
     }
-  }, [settings.enableDeck, dispatch, active]);
+  }, [settings.enableDeck, dispatch, active, layoutMode]);
 
   /**
    * Clear scroll restoration state if the window is resized

--- a/packages/plugins/plugin-deck/src/components/Plank/Plank.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/Plank.tsx
@@ -143,8 +143,6 @@ const PlankComponent = memo(
       part === 'deck' && (companioned === 'companion' ? '!border-separator border-ie' : '!border-separator border-li'),
       part.startsWith('solo-') && 'row-span-2 grid-rows-subgrid min-is-0',
       part === 'solo-companion' && '!border-separator border-is',
-      layoutMode === 'solo--fullscreen' &&
-        '!transition-[margin-block-start,inline-size] -mbs-[--rail-action] has-[[data-plank-heading]:hover]:mbs-0',
     );
 
     return (

--- a/packages/plugins/plugin-deck/src/components/Plank/Plank.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/Plank.tsx
@@ -131,7 +131,10 @@ const PlankComponent = memo(
     const placeholder = useMemo(() => <PlankLoading />, []);
 
     const Root = part.startsWith('solo') ? 'article' : StackItem.Root;
-    const classNames = mx(
+
+    // NOTE(thure): The result of any `mx` call is always `className` without the ‘s’ to signal its compatibility with
+    //   HTML primitives.
+    const className = mx(
       'attention-surface relative',
       isSolo && mainIntrinsicSize,
       isSolo && railGridHorizontal,
@@ -150,12 +153,12 @@ const PlankComponent = memo(
         data-testid='deck.plank'
         tabIndex={0}
         {...(part.startsWith('solo')
-          ? ({ ...sizeAttrs, className: classNames } as any)
+          ? ({ ...sizeAttrs, className } as any)
           : {
               item: { id },
               size,
               onSizeChange: handleSizeChange,
-              classNames,
+              classNames: className,
               order,
               role: 'article',
             })}
@@ -204,6 +207,16 @@ export type PlankProps = Pick<PlankComponentProps, 'layoutMode' | 'part' | 'path
 // TODO(burdon): Factor out conditional rendering.
 //   Remove this wrapper component and render the entire set of planks in the deck with conditional visibility
 //   to obviate mounting and unmounting when switching between solo and companion mode?
+// NOTE(thure, in reply): Whether any surface should be rendered and hidden is a performance matter — remember that
+//  article surfaces contain full experiences, so being able to unmount them will yield relatively large performance
+//  benefits. I think where we anticipate users will definitely want to quickly switch between showing and hiding entire
+//  articles, over the (again probably large) performance benefit that unmounting them would confer, we can mount and
+//  hide them, but I think that scenario in its most unambiguous form is probably rare. You could extrapolate
+//  the scenario to include all “potential” planks such as companions, which we could keep mounted and hidden, but I
+//  don’t think the resulting performance would be acceptable. I think the real issue is “perceived performance” which
+//  has mitigations that are in between mounting and un-mounting since both of those have tradeoffs; we may need one or more
+//  “partially-mounted” experiences, like loading skeletons at the simple end, or screenshots of “sleeping” planks at
+//  the advanced end.
 export const Plank = memo(({ id = UNKNOWN_ID, companionId, ...props }: PlankProps) => {
   const { graph } = useAppGraph();
   const node = useNode(graph, id);
@@ -238,7 +251,7 @@ export const Plank = memo(({ id = UNKNOWN_ID, companionId, ...props }: PlankProp
 const Container = ({ children, solo, companion }: PropsWithChildren<{ solo: boolean; companion: boolean }>) => {
   const sizeAttrs = useMainSize();
   if (!solo) {
-    return <Fragment>{children}</Fragment>;
+    return children;
   }
 
   // TODO(burdon): Make resizable.

--- a/packages/plugins/plugin-deck/src/components/Plank/PlankControls.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/PlankControls.tsx
@@ -78,7 +78,7 @@ export const PlankControls = forwardRef<HTMLDivElement, PlankControlsProps>(
     const layoutIsAnySolo = !!layoutMode?.startsWith('solo');
 
     return (
-      <ButtonGroup {...props} classNames={['app-no-drag', classNames]} ref={forwardedRef}>
+      <ButtonGroup {...props} classNames={['app-no-drag !opacity-100', classNames]} ref={forwardedRef}>
         {capabilities.deck ? (
           <>
             {capabilities.solo && (

--- a/packages/plugins/plugin-deck/src/components/Plank/PlankControls.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/PlankControls.tsx
@@ -18,6 +18,7 @@ export type PlankCapabilities = {
   incrementEnd?: boolean;
   deck?: boolean;
   solo?: boolean;
+  fullscreen?: boolean;
   companion?: boolean;
 };
 
@@ -78,7 +79,7 @@ export const PlankControls = forwardRef<HTMLDivElement, PlankControlsProps>(
 
     return (
       <ButtonGroup {...props} classNames={['app-no-drag', classNames]} ref={forwardedRef}>
-        {capabilities.deck && (
+        {capabilities.deck ? (
           <>
             {capabilities.solo && (
               <>
@@ -130,6 +131,15 @@ export const PlankControls = forwardRef<HTMLDivElement, PlankControlsProps>(
               </>
             )}
           </>
+        ) : (
+          capabilities.fullscreen && (
+            <PlankControl
+              label={t(layoutMode === 'solo--fullscreen' ? 'exit fullscreen label' : 'show fullscreen plank label')}
+              classNames={buttonClassNames}
+              icon={layoutMode === 'solo--fullscreen' ? 'ph--corners-in--regular' : 'ph--corners-out--regular'}
+              onClick={() => onClick?.('solo--fullscreen')}
+            />
+          )
         )}
 
         {close && !layoutIsAnySolo && (

--- a/packages/plugins/plugin-deck/src/components/Plank/PlankHeading.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/PlankHeading.tsx
@@ -9,6 +9,7 @@ import { type Node } from '@dxos/plugin-graph';
 import { Icon, IconButton, Popover, toLocalizedString, useTranslation } from '@dxos/react-ui';
 import { StackItem, type StackItemSigilAction } from '@dxos/react-ui-stack';
 import { TextTooltip } from '@dxos/react-ui-text-tooltip';
+import { hoverableControls, hoverableFocusedWithinControls } from '@dxos/react-ui-theme';
 
 import { PlankCompanionControls, PlankControls } from './PlankControls';
 import { parseEntryId } from '../../layout';
@@ -78,8 +79,8 @@ export const PlankHeading = memo(
         solo: breakpoint !== 'mobile' && (part === 'solo' || part === 'deck'),
         incrementStart: canIncrementStart,
         incrementEnd: canIncrementEnd,
-        fullscreen: !isCompanionNode,
-        companion: !isCompanionNode && companions && companions.length > 0,
+        fullscreen: !isCompanionNode && !companioned,
+        companion: !isCompanionNode && companions && companions.length > 0 && layoutMode !== 'solo--fullscreen',
       }),
       [breakpoint, part, companions, canIncrementStart, canIncrementEnd, isCompanionNode, deckEnabled],
     );
@@ -149,12 +150,17 @@ export const PlankHeading = memo(
         classNames={[
           'plb-1 border-be border-separator items-stretch gap-1 sticky inline-start-12 app-drag min-is-0 contain-layout',
           part === 'solo' ? soloInlinePadding : 'pli-1',
-          layoutMode === 'solo--fullscreen' &&
-            'opacity-0 border-transparent hover:border-separator hover:opacity-100 transition-[border-color,opacity]',
+          ...(layoutMode === 'solo--fullscreen'
+            ? [
+                hoverableControls,
+                hoverableFocusedWithinControls,
+                '[&>*]:transition-opacity [&>*]:opacity-[--controls-opacity] bg-transparent border-transparent transition-[background-color,border-color] hover-hover:hover:bg-headerSurface focus-within:bg-headerSurface hover-hover:hover:border-separator focus-within:border-separator',
+              ]
+            : []),
         ]}
         data-plank-heading
       >
-        {companions && isCompanionNode ? (
+        {companions && isCompanionNode /* TODO(thure): This is a tablist, it should be implemented as such. */ ? (
           <div role='none' className='flex-1 min-is-0 overflow-x-auto scrollbar-thin flex gap-1'>
             {companions.map(({ id, properties: { icon, label } }) => (
               <IconButton

--- a/packages/plugins/plugin-deck/src/components/Plank/PlankHeading.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/PlankHeading.tsx
@@ -79,8 +79,8 @@ export const PlankHeading = memo(
         solo: breakpoint !== 'mobile' && (part === 'solo' || part === 'deck'),
         incrementStart: canIncrementStart,
         incrementEnd: canIncrementEnd,
-        fullscreen: !isCompanionNode && !companioned,
-        companion: !isCompanionNode && companions && companions.length > 0 && layoutMode !== 'solo--fullscreen',
+        fullscreen: !isCompanionNode,
+        companion: !isCompanionNode && companions && companions.length > 0,
       }),
       [breakpoint, part, companions, canIncrementStart, canIncrementEnd, isCompanionNode, deckEnabled],
     );

--- a/packages/plugins/plugin-deck/src/components/Plank/PlankHeading.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/PlankHeading.tsx
@@ -78,6 +78,7 @@ export const PlankHeading = memo(
         solo: breakpoint !== 'mobile' && (part === 'solo' || part === 'deck'),
         incrementStart: canIncrementStart,
         incrementEnd: canIncrementEnd,
+        fullscreen: !isCompanionNode,
         companion: !isCompanionNode && companions && companions.length > 0,
       }),
       [breakpoint, part, companions, canIncrementStart, canIncrementEnd, isCompanionNode, deckEnabled],


### PR DESCRIPTION
This PR:
- fixes plank heading controls when multiplank deck is disabled
- applies the `hoverableControls` pattern to all plank heading content except the controls when in fullcreen

https://github.com/user-attachments/assets/d608b149-dbb3-43e2-9788-2bc59ceb9f25

