### PR TITLE
fix(plugin-theme-editor): Fix dependencies

### DIFF
--- a/packages/plugins/plugin-theme-editor/package.json
+++ b/packages/plugins/plugin-theme-editor/package.json
@@ -23,7 +23,7 @@
     "src"
   ],
   "dependencies": {
-    "@ch-ui/tokens": "2.0.0",
+    "@ch-ui/tokens": "2.4.0",
     "@codemirror/lang-json": "6.0.1",
     "@dxos/app-framework": "workspace:*",
     "@dxos/log": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9425,8 +9425,8 @@ importers:
   packages/plugins/plugin-theme-editor:
     dependencies:
       '@ch-ui/tokens':
-        specifier: 2.0.0
-        version: 2.0.0
+        specifier: 2.4.0
+        version: 2.4.0
       '@codemirror/lang-json':
         specifier: 6.0.1
         version: 6.0.1
@@ -16023,10 +16023,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@ch-ui/colors@1.0.0':
-    resolution: {integrity: sha512-qjk6z5ydz9fiXHBBl0S4xA0cZPFycsyYJqxSZAuiTmEvlVgYzBeJxWp188awcHZwJtpoew2LCtOkOdpMIEJGog==}
-    engines: {node: '>=20.0.0'}
-
   '@ch-ui/colors@1.2.0':
     resolution: {integrity: sha512-+kXVvIDVWq/X65sO+daSpz8nFiVwqPrOv944fpcHCx/6gzuptV4oKkthsElyGGd0NQrwW8noFUB86x6C1HBR6g==}
     engines: {node: '>=20.0.0'}
@@ -16040,10 +16036,6 @@ packages:
     engines: {node: '>=20.0.0'}
     peerDependencies:
       tailwindcss: 3.x.x
-
-  '@ch-ui/tokens@2.0.0':
-    resolution: {integrity: sha512-6rjJKi72sJtUh8B3cBvTqirVFJJtE7ojyuIu8+tGH5Q+QPgfkWKYmvt3b7m5AR+pahXWszqF6BEEkj1Du11HbQ==}
-    engines: {node: '>=20.0.0'}
 
   '@ch-ui/tokens@2.4.0':
     resolution: {integrity: sha512-YS9LgFfDYK9RGoMvyrM1ApgbeLqE8zZv12Ym/lWEDCOZFDQZIfQfrUg9VTytRIuPAdd9vniNUPKkzjs1qFwhrw==}
@@ -38068,10 +38060,6 @@ snapshots:
   '@cbor-extract/cbor-extract-win32-x64@2.2.0':
     optional: true
 
-  '@ch-ui/colors@1.0.0':
-    dependencies:
-      colorjs: colorjs.io@0.5.2
-
   '@ch-ui/colors@1.2.0':
     dependencies:
       colorjs: colorjs.io@0.5.2
@@ -38084,11 +38072,6 @@ snapshots:
     dependencies:
       '@ch-ui/tokens': 2.4.0
       tailwindcss: 3.4.1(ts-node@10.9.1(patch_hash=rke3py7up3u364r7wwqfla7cdm)(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(typescript@5.8.3))
-
-  '@ch-ui/tokens@2.0.0':
-    dependencies:
-      '@ch-ui/colors': 1.0.0
-      postcss: 8.4.47
 
   '@ch-ui/tokens@2.4.0':
     dependencies:


### PR DESCRIPTION
This PR:
- fixes `ThemeEditorPlugin`’s dependencies to work with the new `definitions` model

https://github.com/user-attachments/assets/e2beb872-d65f-4faf-91a4-529dedb630ac
