### PR TITLE
feat: Kanban increment, theme tooling

### DIFF
--- a/packages/plugins/plugin-preview/src/components/ContactCard.tsx
+++ b/packages/plugins/plugin-preview/src/components/ContactCard.tsx
@@ -33,17 +33,13 @@ export const ContactCard = ({
       {organizationName && (
         <div role='none' className={previewChrome}>
           {typeof organization === 'object' && onOrgClick ? (
-            <Button
-              variant='ghost'
-              classNames='gap-2 text-start bg-groupSurface'
-              onClick={() => onOrgClick(organization.target!)}
-            >
+            <Button variant='ghost' classNames='gap-2 text-start' onClick={() => onOrgClick(organization.target!)}>
               <Icon icon='ph--buildings--regular' size={5} classNames='text-subdued' />
               <span className='min-is-0 flex-1 truncate'>{organizationName}</span>
               <Icon icon='ph--arrow-right--regular' />
             </Button>
           ) : (
-            <p className='dx-button gap-2 bg-groupSurface' data-variant='ghost'>
+            <p className='dx-button gap-2' data-variant='ghost'>
               <Icon icon='ph--buildings--regular' size={5} classNames='text-subdued' />
               <span className='min-is-0 flex-1 truncate'>{organizationName}</span>
             </p>

--- a/packages/plugins/plugin-preview/src/components/ContactCard.tsx
+++ b/packages/plugins/plugin-preview/src/components/ContactCard.tsx
@@ -33,13 +33,17 @@ export const ContactCard = ({
       {organizationName && (
         <div role='none' className={previewChrome}>
           {typeof organization === 'object' && onOrgClick ? (
-            <Button variant='ghost' classNames='gap-2 text-start' onClick={() => onOrgClick(organization.target!)}>
+            <Button
+              variant='ghost'
+              classNames='gap-2 text-start bg-groupSurface'
+              onClick={() => onOrgClick(organization.target!)}
+            >
               <Icon icon='ph--buildings--regular' size={5} classNames='text-subdued' />
               <span className='min-is-0 flex-1 truncate'>{organizationName}</span>
               <Icon icon='ph--arrow-right--regular' />
             </Button>
           ) : (
-            <p className='dx-button gap-2' data-variant='ghost'>
+            <p className='dx-button gap-2 bg-groupSurface' data-variant='ghost'>
               <Icon icon='ph--buildings--regular' size={5} classNames='text-subdued' />
               <span className='min-is-0 flex-1 truncate'>{organizationName}</span>
             </p>

--- a/packages/plugins/plugin-preview/src/components/OrganizationCard.tsx
+++ b/packages/plugins/plugin-preview/src/components/OrganizationCard.tsx
@@ -29,7 +29,7 @@ export const OrganizationCard = ({
       {description && <p className={mx(previewProse, 'line-clamp-2')}>{description}</p>}
       {website && (
         <div role='none' className={previewChrome}>
-          <a className='dx-button dx-focus-ring gap-2' href={website} target='_blank' rel='noreferrer'>
+          <a className='dx-button bg-groupSurface dx-focus-ring gap-2' href={website} target='_blank' rel='noreferrer'>
             <Icon icon='ph--link--regular' size={5} classNames='text-subdued' />
             <span className='grow'>{website}</span>
             <Icon icon='ph--arrow-square-out--regular' />

--- a/packages/plugins/plugin-preview/src/components/OrganizationCard.tsx
+++ b/packages/plugins/plugin-preview/src/components/OrganizationCard.tsx
@@ -29,7 +29,13 @@ export const OrganizationCard = ({
       {description && <p className={mx(previewProse, 'line-clamp-2')}>{description}</p>}
       {website && (
         <div role='none' className={previewChrome}>
-          <a className='dx-button bg-groupSurface dx-focus-ring gap-2' href={website} target='_blank' rel='noreferrer'>
+          <a
+            className='dx-button dx-focus-ring gap-2'
+            data-variant='ghost'
+            href={website}
+            target='_blank'
+            rel='noreferrer'
+          >
             <Icon icon='ph--link--regular' size={5} classNames='text-subdued' />
             <span className='grow'>{website}</span>
             <Icon icon='ph--arrow-square-out--regular' />

--- a/packages/ui/lit-theme-editor/.eslintrc.cjs
+++ b/packages/ui/lit-theme-editor/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['../../../.eslintrc.js'],
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir: __dirname,
+  },
+};

--- a/packages/ui/lit-theme-editor/LICENSE
+++ b/packages/ui/lit-theme-editor/LICENSE
@@ -1,0 +1,8 @@
+MIT License 
+Copyright (c) 2025 DXOS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/ui/lit-theme-editor/README.md
+++ b/packages/ui/lit-theme-editor/README.md
@@ -1,0 +1,3 @@
+# @dxos/lit-theme-editor
+
+A component for editing the user tokens layer of dxos-theme.

--- a/packages/ui/lit-theme-editor/package.json
+++ b/packages/ui/lit-theme-editor/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@dxos/lit-theme-editor",
+  "version": "0.8.1",
+  "description": "A component for editing the user tokens layer of dxos-theme.",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "license": "MIT",
+  "author": "DXOS.org",
+  "sideEffects": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/types/src/index.d.ts",
+      "browser": "./dist/src/index.js",
+      "node": "./dist/src/index.js"
+    },
+    "./dx-theme-editor.pcss": "./src/dx-theme-editor/dx-theme-editor.pcss"
+  },
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "dependencies": {
+    "lit": "^3.2.0",
+    "@dxos/lit-ui": "workspace:*"
+  },
+  "devDependencies": {
+    "@dxos/test-utils": "workspace:*"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/ui/lit-theme-editor/package.json
+++ b/packages/ui/lit-theme-editor/package.json
@@ -23,8 +23,8 @@
     "dist"
   ],
   "dependencies": {
-    "lit": "^3.2.0",
-    "@dxos/lit-ui": "workspace:*"
+    "@dxos/lit-ui": "workspace:*",
+    "lit": "^3.2.0"
   },
   "devDependencies": {
     "@dxos/test-utils": "workspace:*"

--- a/packages/ui/lit-theme-editor/package.json
+++ b/packages/ui/lit-theme-editor/package.json
@@ -27,6 +27,7 @@
     "@ch-ui/tokens": "2.4.0",
     "@dxos/lit-ui": "workspace:*",
     "@dxos/log": "workspace:*",
+    "@dxos/react-hooks": "workspace:*",
     "@dxos/react-ui-theme": "workspace:*",
     "lit": "^3.2.0"
   },

--- a/packages/ui/lit-theme-editor/package.json
+++ b/packages/ui/lit-theme-editor/package.json
@@ -23,6 +23,7 @@
     "dist"
   ],
   "dependencies": {
+    "@ch-ui/colors": "1.2.0",
     "@ch-ui/tokens": "2.4.0",
     "@dxos/lit-ui": "workspace:*",
     "@dxos/log": "workspace:*",

--- a/packages/ui/lit-theme-editor/package.json
+++ b/packages/ui/lit-theme-editor/package.json
@@ -23,7 +23,10 @@
     "dist"
   ],
   "dependencies": {
+    "@ch-ui/tokens": "2.4.0",
     "@dxos/lit-ui": "workspace:*",
+    "@dxos/log": "workspace:*",
+    "@dxos/react-ui-theme": "workspace:*",
     "lit": "^3.2.0"
   },
   "devDependencies": {

--- a/packages/ui/lit-theme-editor/project.json
+++ b/packages/ui/lit-theme-editor/project.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
-  "name": "lit-ui",
+  "name": "lit-theme-editor",
   "tags": [
     "scope:ui"
   ],

--- a/packages/ui/lit-theme-editor/project.json
+++ b/packages/ui/lit-theme-editor/project.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "name": "lit-ui",
+  "tags": [
+    "scope:ui"
+  ],
+  "sourceRoot": "{projectRoot}/src",
+  "projectType": "library",
+  "targets": {
+    "build": {},
+    "compile": {
+      "cache": true,
+      "dependsOn": [
+        "^build"
+      ],
+      "executor": "@nx/js:tsc",
+      "options": {
+        "entryPoints": [
+          "{projectRoot}/src/index.ts",
+          "{projectRoot}/src/testing/index.ts"
+        ],
+        "main": "{projectRoot}/src/index.ts",
+        "outputPath": "{projectRoot}/dist",
+        "tsConfig": "{projectRoot}/tsconfig.json"
+      }
+    },
+    "lint": {
+      "options": {
+        "lintFilePatterns": [
+          "{projectRoot}/src/**/*.{ts,tsx,js,jsx}"
+        ]
+      }
+    },
+    "pack": {}
+  },
+  "implicitDependencies": [
+    "esbuild",
+    "node-std"
+  ]
+}

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-range-spinbutton.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-range-spinbutton.ts
@@ -1,0 +1,128 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { styleMap } from 'lit/directives/style-map.js';
+
+import './dx-theme-editor.pcss';
+
+export type DxRangeSpinbuttonVariant = 'reverse-range' | 'reverse-order' | 'torsion';
+
+@customElement('dx-range-spinbutton')
+export class DxRangeSpinbutton extends LitElement {
+  @property({ type: String })
+  label: string = '';
+
+  @property({ type: String })
+  min: string | number = 0;
+
+  @property({ type: String })
+  max: string | number = 100;
+
+  @property({ type: String })
+  step: string | number = 1;
+
+  @property({ type: String })
+  value: string | number = 0;
+
+  @property({ type: String })
+  headingId: string = '';
+
+  @property({ type: String })
+  variant?: DxRangeSpinbuttonVariant;
+
+  private handleInput(e: Event) {
+    const value = (e.target as HTMLInputElement).value;
+    this.value = value;
+
+    // For torsion variant, calculate and apply styles
+    if (this.variant === 'torsion') {
+      const controlInputsDiv = (e.target as HTMLElement).closest('.control-inputs');
+      if (controlInputsDiv) {
+        const styles = this.calculateTorsionStyles(Number(value), Number(this.min), Number(this.max));
+        Object.entries(styles).forEach(([key, value]) => {
+          (controlInputsDiv as HTMLElement).style.setProperty(key, value);
+        });
+      }
+    }
+
+    // Dispatch custom event
+    this.dispatchEvent(
+      new CustomEvent('value-changed', {
+        detail: { value: parseFloat(value) },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private calculateTorsionStyles(value: number, min: number, max: number): Record<string, string> {
+    // Calculate the width per step
+    const totalSteps = Math.abs(min) + Math.abs(max);
+    const widthPerStep = 100 / totalSteps; // Using percentage for width
+
+    // Calculate the width of the before element
+    const beforeWidth = `${Math.abs(value) * widthPerStep}%`;
+
+    // Calculate the position of the before element
+    let beforeLeft = '50%';
+    if (value < 0) {
+      beforeLeft = `calc(50% - ${beforeWidth})`;
+    }
+
+    return {
+      '--before-width': beforeWidth,
+      '--before-left': beforeLeft,
+    };
+  }
+
+  override render() {
+    const controlId = `${this.headingId}-${this.label.toLowerCase().replace(/[^a-z0-9]/g, '-')}`;
+
+    // For torsion variant, calculate initial styles
+    const isTorsion = this.variant === 'torsion';
+    const initialStyles = isTorsion
+      ? this.calculateTorsionStyles(Number(this.value), Number(this.min), Number(this.max))
+      : {};
+
+    return html`
+      <div class="control-row">
+        <label class="control-label" id="${controlId}-label" for="${controlId}-range">${this.label}:</label>
+        <div
+          class="${classMap({ 'control-inputs': true, ...(this.variant && { [this.variant]: true }) })}"
+          style=${isTorsion ? styleMap(initialStyles) : undefined}
+        >
+          <input
+            id="${controlId}-range"
+            type="range"
+            min="${this.min}"
+            max="${this.max}"
+            step="${this.step}"
+            class="range-input dx-focus-ring"
+            .value=${this.value.toString()}
+            @input=${this.handleInput}
+            aria-labelledby="${this.headingId} ${controlId}-label"
+          />
+          <input
+            id="${controlId}-number"
+            type="number"
+            min="${this.min}"
+            max="${this.max}"
+            step="${this.step}"
+            class="number-input dx-focus-ring"
+            .value=${this.value.toString()}
+            @input=${this.handleInput}
+            aria-labelledby="${this.headingId} ${controlId}-label"
+          />
+        </div>
+      </div>
+    `;
+  }
+
+  override createRenderRoot() {
+    return this;
+  }
+}

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-range-spinbutton.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-range-spinbutton.ts
@@ -89,35 +89,33 @@ export class DxRangeSpinbutton extends LitElement {
       : {};
 
     return html`
-      <div class="control-row">
-        <label class="control-label" id="${controlId}-label" for="${controlId}-range">${this.label}:</label>
-        <div
-          class="${classMap({ 'control-inputs': true, ...(this.variant && { [this.variant]: true }) })}"
-          style=${isTorsion ? styleMap(initialStyles) : undefined}
-        >
-          <input
-            id="${controlId}-range"
-            type="range"
-            min="${this.min}"
-            max="${this.max}"
-            step="${this.step}"
-            class="range-input dx-focus-ring"
-            .value=${this.value.toString()}
-            @input=${this.handleInput}
-            aria-labelledby="${this.headingId} ${controlId}-label"
-          />
-          <input
-            id="${controlId}-number"
-            type="number"
-            min="${this.min}"
-            max="${this.max}"
-            step="${this.step}"
-            class="number-input dx-focus-ring"
-            .value=${this.value.toString()}
-            @input=${this.handleInput}
-            aria-labelledby="${this.headingId} ${controlId}-label"
-          />
-        </div>
+      <label class="control-label" id="${controlId}-label" for="${controlId}-range">${this.label}:</label>
+      <div
+        class="${classMap({ 'control-inputs': true, ...(this.variant && { [this.variant]: true }) })}"
+        style=${isTorsion ? styleMap(initialStyles) : undefined}
+      >
+        <input
+          id="${controlId}-range"
+          type="range"
+          min="${this.min}"
+          max="${this.max}"
+          step="${this.step}"
+          class="range-input dx-focus-ring"
+          .value=${this.value.toString()}
+          @input=${this.handleInput}
+          aria-labelledby="${this.headingId} ${controlId}-label"
+        />
+        <input
+          id="${controlId}-number"
+          type="number"
+          min="${this.min}"
+          max="${this.max}"
+          step="${this.step}"
+          class="number-input dx-focus-ring"
+          .value=${this.value.toString()}
+          @input=${this.handleInput}
+          aria-labelledby="${this.headingId} ${controlId}-label"
+        />
       </div>
     `;
   }

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-physical-colors.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-physical-colors.ts
@@ -69,7 +69,6 @@ export class DxThemeEditorPhysicalColors extends LitElement {
     this.updateSeriesProperty(series, 'torsion', value);
   }
 
-
   private renderSeriesControls(series: string) {
     const seriesData = this.tokenSet.colors?.physical?.definitions?.series?.[series];
     if (!isHelicalArcSeries(seriesData)) {
@@ -158,12 +157,9 @@ export class DxThemeEditorPhysicalColors extends LitElement {
 
   override render() {
     return html`
-      <div class="theme-editor-container">
-        <h2>Physical series</h2>
-        ${bindSeriesDefinitions.map(
-          (series) => html` <div class="series-container">${this.renderSeriesControls(series)}</div> `,
-        )}
-      </div>
+      ${bindSeriesDefinitions.map(
+        (series) => html` <div class="series-container">${this.renderSeriesControls(series)}</div> `,
+      )}
     `;
   }
 

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-physical-colors.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-physical-colors.ts
@@ -6,13 +6,13 @@ import { cssGradientFromCurve, helicalArcFromConfig } from '@ch-ui/colors';
 import { type ResolvedHelicalArcSeries, type TokenSet } from '@ch-ui/tokens';
 import { LitElement, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { debounce } from '@dxos/async';
 
 import { restore, saveAndRender } from './util';
 
+import './dx-range-spinbutton';
 import './dx-theme-editor.pcss';
 
 export type DxThemeEditorPhysicalColorsProps = {};
@@ -69,48 +69,6 @@ export class DxThemeEditorPhysicalColors extends LitElement {
     this.updateSeriesProperty(series, 'torsion', value);
   }
 
-  private renderControlRow(
-    label: string,
-    min: string | number,
-    max: string | number,
-    step: string | number,
-    value: string | number,
-    onInput: (e: Event) => void,
-    headingId: string,
-    variant?: 'reverse-range' | 'reverse-order',
-  ) {
-    const controlId = `${headingId}-${label.toLowerCase().replace(/[^a-z0-9]/g, '-')}`;
-
-    return html`
-      <div class="control-row">
-        <label class="control-label" id="${controlId}-label" for="${controlId}-range">${label}:</label>
-        <div class="${classMap({ 'control-inputs': true, ...(variant && { [variant]: true }) })}">
-          <input
-            id="${controlId}-range"
-            type="range"
-            min="${min}"
-            max="${max}"
-            step="${step}"
-            class="range-input dx-focus-ring"
-            .value=${value.toString()}
-            @input=${onInput}
-            aria-labelledby="${headingId} ${controlId}-label"
-          />
-          <input
-            id="${controlId}-number"
-            type="number"
-            min="${min}"
-            max="${max}"
-            step="${step}"
-            class="number-input dx-focus-ring"
-            .value=${value.toString()}
-            @input=${onInput}
-            aria-labelledby="${headingId} ${controlId}-label"
-          />
-        </div>
-      </div>
-    `;
-  }
 
   private renderSeriesControls(series: string) {
     const seriesData = this.tokenSet.colors?.physical?.definitions?.series?.[series];
@@ -138,57 +96,56 @@ export class DxThemeEditorPhysicalColors extends LitElement {
         ></div>
         <h3 class="series-title">${series} Series</h3>
 
-        ${this.renderControlRow(
-          'Hue (0-360)',
-          0,
-          360,
-          0.5,
-          keyPoint[2],
-          (e: Event) => this.handleKeyPointChange(series, 2, parseFloat((e.target as HTMLInputElement).value)),
-          keyColorHeadingId,
-        )}
-        ${this.renderControlRow(
-          'Torsion (-180 to 180)',
-          -180,
-          180,
-          0.5,
-          torsion,
-          (e: Event) => this.handleTorsionChange(series, parseFloat((e.target as HTMLInputElement).value)),
-          torsionHeadingId,
-        )}
-        ${this.renderControlRow(
-          'Chroma (0-0.4)',
-          0,
-          0.4,
-          0.0025,
-          keyPoint[1],
-          (e: Event) => this.handleKeyPointChange(series, 1, parseFloat((e.target as HTMLInputElement).value)),
-          keyColorHeadingId,
-        )}
+        <dx-range-spinbutton
+          label="Hue (0-360)"
+          min="0"
+          max="360"
+          step="0.5"
+          .value=${keyPoint[2]}
+          headingId=${keyColorHeadingId}
+          @value-changed=${(e: CustomEvent) => this.handleKeyPointChange(series, 2, e.detail.value)}
+        ></dx-range-spinbutton>
+        <dx-range-spinbutton
+          label="Torsion (-180 to 180)"
+          min="-180"
+          max="180"
+          step="0.5"
+          .value=${torsion}
+          headingId=${torsionHeadingId}
+          variant="torsion"
+          @value-changed=${(e: CustomEvent) => this.handleTorsionChange(series, e.detail.value)}
+        ></dx-range-spinbutton>
+        <dx-range-spinbutton
+          label="Chroma (0-0.4)"
+          min="0"
+          max="0.4"
+          step="0.0025"
+          .value=${keyPoint[1]}
+          headingId=${keyColorHeadingId}
+          @value-changed=${(e: CustomEvent) => this.handleKeyPointChange(series, 1, e.detail.value)}
+        ></dx-range-spinbutton>
 
         <div class="control-group">
-          ${this.renderControlRow(
-            'Dark Control Point (0-1)',
-            0,
-            1,
-            0.01,
-            upperCp,
-            (e: Event) =>
-              this.handleControlPointChange(series, 'upperCp', parseFloat((e.target as HTMLInputElement).value)),
-            controlPointsHeadingId,
-            'reverse-range',
-          )}
-          ${this.renderControlRow(
-            'Light Control Point (0-1)',
-            0,
-            1,
-            0.01,
-            lowerCp,
-            (e: Event) =>
-              this.handleControlPointChange(series, 'lowerCp', parseFloat((e.target as HTMLInputElement).value)),
-            controlPointsHeadingId,
-            'reverse-order',
-          )}
+          <dx-range-spinbutton
+            label="Dark Control Point (0-1)"
+            min="0"
+            max="1"
+            step="0.01"
+            .value=${upperCp}
+            headingId=${controlPointsHeadingId}
+            variant="reverse-range"
+            @value-changed=${(e: CustomEvent) => this.handleControlPointChange(series, 'upperCp', e.detail.value)}
+          ></dx-range-spinbutton>
+          <dx-range-spinbutton
+            label="Light Control Point (0-1)"
+            min="0"
+            max="1"
+            step="0.01"
+            .value=${lowerCp}
+            headingId=${controlPointsHeadingId}
+            variant="reverse-order"
+            @value-changed=${(e: CustomEvent) => this.handleControlPointChange(series, 'lowerCp', e.detail.value)}
+          ></dx-range-spinbutton>
         </div>
       </div>
     `;

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-physical-colors.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-physical-colors.ts
@@ -23,8 +23,8 @@ const isHelicalArcSeries = (o: any): o is ResolvedHelicalArcSeries => {
   return 'keyPoint' in (o ?? {});
 };
 
-@customElement('dx-theme-editor')
-export class DxThemeEditor extends LitElement {
+@customElement('dx-theme-editor-physical-colors')
+export class DxThemeEditorPhysicalColors extends LitElement {
   @state()
   tokenSet: TokenSet = restore();
 

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-physical-colors.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-physical-colors.ts
@@ -15,7 +15,7 @@ import { restore, saveAndRender } from './util';
 
 import './dx-theme-editor.pcss';
 
-export type DxThemeEditorProps = {};
+export type DxThemeEditorPhysicalColorsProps = {};
 
 const bindSeriesDefinitions = ['neutral', 'primary'];
 

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-semantic-colors.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-semantic-colors.ts
@@ -226,14 +226,11 @@ export class DxThemeEditorSemanticColors extends LitElement {
     const semanticTokens = this.getSemanticTokens();
 
     return html`
-      <div class="theme-editor-container">
-        <h2>Semantic Colors</h2>
-        ${semanticTokens.map(
-          ([tokenName, tokenValue]) => html`
-            <div class="token-container">${this.renderTokenControls(tokenName, tokenValue)}</div>
-          `,
-        )}
-      </div>
+      ${semanticTokens.map(
+        ([tokenName, tokenValue]) => html`
+          <div class="token-container">${this.renderTokenControls(tokenName, tokenValue)}</div>
+        `,
+      )}
     `;
   }
 

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-semantic-colors.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-semantic-colors.ts
@@ -200,81 +200,104 @@ export class DxThemeEditorSemanticColors extends LitElement {
     const lightHeadingId = `${tokenName}-light-heading`;
     const darkHeadingId = `${tokenName}-dark-heading`;
     const seriesSelectId = `${tokenName}-series`;
+    const contentId = `${tokenName}-content`;
+
+    // Toggle expanded/collapsed state
+    const toggleExpanded = (e: Event) => {
+      const button = e.currentTarget as HTMLButtonElement;
+      const container = button.closest('.token-container') as HTMLElement;
+      const isExpanded = container.getAttribute('data-state') === 'expanded';
+      container.setAttribute('data-state', isExpanded ? 'collapsed' : 'expanded');
+      button.setAttribute('aria-expanded', isExpanded ? 'false' : 'true');
+    };
 
     return html`
-      <h3 id="${tokenHeadingId}" class="token-title">
-        <input
-          type="text"
-          class="token-name-input dx-focus-ring"
-          .value=${tokenName}
-          @change=${(e: Event) => this.handleTokenNameChange(tokenName, (e.target as HTMLInputElement).value)}
-          aria-label="Token name"
-        />
-        <button
-          class="remove-token-button dx-focus-ring dx-button"
-          @click=${() => this.removeSemanticToken(tokenName)}
-          aria-label="Remove token"
-        >
-          <span class="sr-only">Remove token</span>
-          <dx-icon icon="ph--minus--regular" />
-        </button>
-      </h3>
-      <div class="token-header">
-        <div class="token-series-select">
-          <label class="control-label" for="${seriesSelectId}">Palette:</label>
-          <select
-            id="${seriesSelectId}"
-            class="series-select dx-focus-ring"
-            .value=${currentSeries}
-            @change=${(e: Event) => this.handleBothSeriesChange(tokenName, (e.target as HTMLSelectElement).value)}
-            aria-labelledby="${tokenHeadingId}"
+      <div role="group" class="token-container" data-state="collapsed">
+        <h3 id="${tokenHeadingId}" class="token-title">
+          <button
+            class="toggle-button dx-focus-ring dx-button"
+            @click=${toggleExpanded}
+            aria-expanded="false"
+            aria-controls="${contentId}"
           >
-            ${physicalColorSeries.map(
-              (series) => html`<option value="${series}" ?selected=${series === currentSeries}>${series}</option>`,
-            )}
-          </select>
-        </div>
-        <dx-range-spinbutton
-          label="Alpha"
-          min="0"
-          max="1"
-          step="0.01"
-          .value=${currentAlpha}
-          headingId=${tokenHeadingId}
-          @value-changed=${(e: CustomEvent) => this.handleAlphaChange(tokenName, e.detail.value)}
-        ></dx-range-spinbutton>
-      </div>
-
-      <div role="group" class="control-group">
-        <div role="none" class="control-group-item">
-          <div class="shade-preview dark">
-            <div class="shade" style="${styleMap({ backgroundColor: `var(--dx-${tokenName})` })}"></div>
+            <dx-icon icon="ph--caret-down--regular" />
+            <span class="sr-only">Toggle token controls</span>
+          </button>
+          <span class="static-token-name">${tokenName}</span>
+          <input
+            type="text"
+            class="token-name-input dx-focus-ring"
+            .value=${tokenName}
+            @change=${(e: Event) => this.handleTokenNameChange(tokenName, (e.target as HTMLInputElement).value)}
+            aria-label="Token name"
+          />
+          <button
+            class="remove-token-button dx-focus-ring dx-button"
+            @click=${() => this.removeSemanticToken(tokenName)}
+            aria-label="Remove token"
+          >
+            <span class="sr-only">Remove token</span>
+            <dx-icon icon="ph--minus--regular" />
+          </button>
+        </h3>
+        <div id="${contentId}" class="token-content">
+          <div class="token-header">
+            <div class="token-series-select">
+              <label class="control-label" for="${seriesSelectId}">Palette:</label>
+              <select
+                id="${seriesSelectId}"
+                class="series-select dx-focus-ring"
+                .value=${currentSeries}
+                @change=${(e: Event) => this.handleBothSeriesChange(tokenName, (e.target as HTMLSelectElement).value)}
+                aria-labelledby="${tokenHeadingId}"
+              >
+                ${physicalColorSeries.map(
+                  (series) => html`<option value="${series}" ?selected=${series === currentSeries}>${series}</option>`,
+                )}
+              </select>
+            </div>
+            <dx-range-spinbutton
+              label="Alpha"
+              min="0"
+              max="1"
+              step="0.01"
+              .value=${currentAlpha}
+              headingId=${tokenHeadingId}
+              @value-changed=${(e: CustomEvent) => this.handleAlphaChange(tokenName, e.detail.value)}
+            ></dx-range-spinbutton>
           </div>
-          <dx-range-spinbutton
-            label="Dark"
-            min="0"
-            max="1000"
-            step="1"
-            .value=${darkLuminosity}
-            headingId=${darkHeadingId}
-            @value-changed=${(e: CustomEvent) => this.handleLuminosityChange(tokenName, 'dark', e.detail.value)}
-            variant="reverse-range"
-          ></dx-range-spinbutton>
-        </div>
-        <div role="none" class="control-group-item">
-          <div class="shade-preview">
-            <div class="shade" style="${styleMap({ backgroundColor: `var(--dx-${tokenName})` })}"></div>
+          <div role="group" class="control-group">
+            <div role="none" class="control-group-item">
+              <div class="shade-preview dark">
+                <div class="shade" style="${styleMap({ backgroundColor: `var(--dx-${tokenName})` })}"></div>
+              </div>
+              <dx-range-spinbutton
+                label="Dark"
+                min="0"
+                max="1000"
+                step="1"
+                .value=${darkLuminosity}
+                headingId=${darkHeadingId}
+                @value-changed=${(e: CustomEvent) => this.handleLuminosityChange(tokenName, 'dark', e.detail.value)}
+                variant="reverse-range"
+              ></dx-range-spinbutton>
+            </div>
+            <div role="none" class="control-group-item">
+              <div class="shade-preview">
+                <div class="shade" style="${styleMap({ backgroundColor: `var(--dx-${tokenName})` })}"></div>
+              </div>
+              <dx-range-spinbutton
+                label="Light"
+                min="0"
+                max="1000"
+                step="1"
+                .value=${lightLuminosity}
+                headingId=${lightHeadingId}
+                @value-changed=${(e: CustomEvent) => this.handleLuminosityChange(tokenName, 'light', e.detail.value)}
+                variant="reverse-order"
+              ></dx-range-spinbutton>
+            </div>
           </div>
-          <dx-range-spinbutton
-            label="Light"
-            min="0"
-            max="1000"
-            step="1"
-            .value=${lightLuminosity}
-            headingId=${lightHeadingId}
-            @value-changed=${(e: CustomEvent) => this.handleLuminosityChange(tokenName, 'light', e.detail.value)}
-            variant="reverse-order"
-          ></dx-range-spinbutton>
         </div>
       </div>
     `;
@@ -289,11 +312,7 @@ export class DxThemeEditorSemanticColors extends LitElement {
     const semanticTokens = this.getSemanticTokens();
 
     return html`
-      ${semanticTokens.map(
-        ([tokenName, tokenValue]) => html`
-          <div class="token-container">${this.renderTokenControls(tokenName, tokenValue)}</div>
-        `,
-      )}
+      ${semanticTokens.map(([tokenName, tokenValue]) => this.renderTokenControls(tokenName, tokenValue))}
       <button class="add-token-button dx-focus-ring dx-button" @click=${() => this.addSemanticToken()}>
         Add token
       </button>

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-semantic-colors.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-semantic-colors.ts
@@ -10,6 +10,7 @@ import { debounce } from '@dxos/async';
 
 import { restore, saveAndRender } from './util';
 
+import './dx-range-spinbutton';
 import './dx-theme-editor.pcss';
 
 export type DxThemeEditorSemanticColorsProps = {};
@@ -89,47 +90,6 @@ export class DxThemeEditorSemanticColors extends LitElement {
     this.updateSemanticToken(tokenName, condition, 1, value);
   }
 
-  private renderControlRow(
-    label: string,
-    min: string | number,
-    max: string | number,
-    step: string | number,
-    value: string | number,
-    onInput: (e: Event) => void,
-    headingId: string,
-  ) {
-    const controlId = `${headingId}-${label.toLowerCase().replace(/[^a-z0-9]/g, '-')}`;
-
-    return html`
-      <div class="control-row">
-        <label class="control-label" id="${controlId}-label" for="${controlId}-range">${label}:</label>
-        <div class="control-inputs">
-          <input
-            id="${controlId}-range"
-            type="range"
-            min="${min}"
-            max="${max}"
-            step="${step}"
-            class="range-input dx-focus-ring"
-            .value=${value.toString()}
-            @input=${onInput}
-            aria-labelledby="${headingId} ${controlId}-label"
-          />
-          <input
-            id="${controlId}-number"
-            type="number"
-            min="${min}"
-            max="${max}"
-            step="${step}"
-            class="number-input dx-focus-ring"
-            .value=${value.toString()}
-            @input=${onInput}
-            aria-labelledby="${headingId} ${controlId}-label"
-          />
-        </div>
-      </div>
-    `;
-  }
 
   private renderTokenControls(tokenName: string, tokenValue: any) {
     const physicalColorSeries = this.getPhysicalColorSeries();
@@ -172,16 +132,15 @@ export class DxThemeEditorSemanticColors extends LitElement {
               )}
             </select>
           </div>
-          ${this.renderControlRow(
-            'Luminosity',
-            0,
-            1000,
-            1,
-            lightLuminosity,
-            (e: Event) =>
-              this.handleLuminosityChange(tokenName, 'light', parseFloat((e.target as HTMLInputElement).value)),
-            lightHeadingId,
-          )}
+          <dx-range-spinbutton
+            label="Luminosity"
+            min="0"
+            max="1000"
+            step="1"
+            .value=${lightLuminosity}
+            headingId=${lightHeadingId}
+            @value-changed=${(e: CustomEvent) => this.handleLuminosityChange(tokenName, 'light', e.detail.value)}
+          ></dx-range-spinbutton>
         </div>
 
         <div class="control-group">
@@ -200,16 +159,15 @@ export class DxThemeEditorSemanticColors extends LitElement {
               )}
             </select>
           </div>
-          ${this.renderControlRow(
-            'Luminosity',
-            0,
-            1000,
-            1,
-            darkLuminosity,
-            (e: Event) =>
-              this.handleLuminosityChange(tokenName, 'dark', parseFloat((e.target as HTMLInputElement).value)),
-            darkHeadingId,
-          )}
+          <dx-range-spinbutton
+            label="Luminosity"
+            min="0"
+            max="1000"
+            step="1"
+            .value=${darkLuminosity}
+            headingId=${darkHeadingId}
+            @value-changed=${(e: CustomEvent) => this.handleLuminosityChange(tokenName, 'dark', e.detail.value)}
+          ></dx-range-spinbutton>
         </div>
       </div>
     `;

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-semantic-colors.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-semantic-colors.ts
@@ -6,6 +6,7 @@ import { type AlphaLuminosity } from '@ch-ui/colors';
 import { type TokenSet, parseAlphaLuminosity } from '@ch-ui/tokens';
 import { LitElement, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+import { styleMap } from 'lit/directives/style-map.js';
 
 import { debounce } from '@dxos/async';
 
@@ -168,7 +169,7 @@ export class DxThemeEditorSemanticColors extends LitElement {
       </h3>
       <div class="token-header">
         <div class="token-series-select">
-          <label class="control-label" for="${seriesSelectId}">Series:</label>
+          <label class="control-label" for="${seriesSelectId}">Palette:</label>
           <select
             id="${seriesSelectId}"
             class="series-select dx-focus-ring"
@@ -192,27 +193,37 @@ export class DxThemeEditorSemanticColors extends LitElement {
         ></dx-range-spinbutton>
       </div>
 
-      <div class="control-group">
-        <dx-range-spinbutton
-          label="Dark shade number"
-          min="0"
-          max="1000"
-          step="1"
-          .value=${darkLuminosity}
-          headingId=${darkHeadingId}
-          @value-changed=${(e: CustomEvent) => this.handleLuminosityChange(tokenName, 'dark', e.detail.value)}
-          variant="reverse-range"
-        ></dx-range-spinbutton>
-        <dx-range-spinbutton
-          label="Light shade number"
-          min="0"
-          max="1000"
-          step="1"
-          .value=${lightLuminosity}
-          headingId=${lightHeadingId}
-          @value-changed=${(e: CustomEvent) => this.handleLuminosityChange(tokenName, 'light', e.detail.value)}
-          variant="reverse-order"
-        ></dx-range-spinbutton>
+      <div role="group" class="control-group">
+        <div role="none" class="control-group-item">
+          <div class="shade-preview dark">
+            <div class="shade" style="${styleMap({ backgroundColor: `var(--dx-${tokenName})` })}"></div>
+          </div>
+          <dx-range-spinbutton
+            label="Dark"
+            min="0"
+            max="1000"
+            step="1"
+            .value=${darkLuminosity}
+            headingId=${darkHeadingId}
+            @value-changed=${(e: CustomEvent) => this.handleLuminosityChange(tokenName, 'dark', e.detail.value)}
+            variant="reverse-range"
+          ></dx-range-spinbutton>
+        </div>
+        <div role="none" class="control-group-item">
+          <div class="shade-preview">
+            <div class="shade" style="${styleMap({ backgroundColor: `var(--dx-${tokenName})` })}"></div>
+          </div>
+          <dx-range-spinbutton
+            label="Light"
+            min="0"
+            max="1000"
+            step="1"
+            .value=${lightLuminosity}
+            headingId=${lightHeadingId}
+            @value-changed=${(e: CustomEvent) => this.handleLuminosityChange(tokenName, 'light', e.detail.value)}
+            variant="reverse-order"
+          ></dx-range-spinbutton>
+        </div>
       </div>
     `;
   }

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-semantic-colors.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-semantic-colors.ts
@@ -1,0 +1,241 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { type TokenSet } from '@ch-ui/tokens';
+import { LitElement, html } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+
+import { debounce } from '@dxos/async';
+
+import { restore, saveAndRender } from './util';
+
+import './dx-theme-editor.pcss';
+
+export type DxThemeEditorSemanticColorsProps = {};
+
+@customElement('dx-theme-editor-semantic-colors')
+export class DxThemeEditorSemanticColors extends LitElement {
+  @state()
+  tokenSet: TokenSet = restore();
+
+  private debouncedSaveAndRender = debounce(() => {
+    saveAndRender(this.tokenSet);
+  }, 200);
+
+  private getPhysicalColorSeries(): string[] {
+    if (!this.tokenSet.colors?.physical?.series) {
+      return [];
+    }
+
+    return Object.keys(this.tokenSet.colors.physical.series);
+  }
+
+  private getSemanticTokens(): [string, any][] {
+    if (!this.tokenSet.colors?.semantic?.sememes) {
+      return [];
+    }
+
+    return Object.entries(this.tokenSet.colors.semantic.sememes);
+  }
+
+  private updateSemanticToken(tokenName: string, condition: 'light' | 'dark', property: 0 | 1, value: any) {
+    if (!this.tokenSet.colors?.semantic?.sememes?.[tokenName]?.[condition]) {
+      return;
+    }
+
+    // Create a deep copy of the tokenSet to avoid direct mutation
+    const updatedTokenSet = JSON.parse(JSON.stringify(this.tokenSet));
+
+    // Update the specific property
+    updatedTokenSet.colors.semantic.sememes[tokenName][condition][property] = value;
+
+    // Update the state
+    this.tokenSet = updatedTokenSet;
+
+    // Save and render changes
+    this.debouncedSaveAndRender();
+  }
+
+  private handleTokenNameChange(tokenName: string, newName: string) {
+    if (!this.tokenSet.colors?.semantic?.sememes?.[tokenName]) {
+      return;
+    }
+
+    // Create a deep copy of the tokenSet to avoid direct mutation
+    const updatedTokenSet = JSON.parse(JSON.stringify(this.tokenSet));
+
+    // Get the token value
+    const tokenValue = updatedTokenSet.colors.semantic.sememes[tokenName];
+
+    // Delete the old token
+    delete updatedTokenSet.colors.semantic.sememes[tokenName];
+
+    // Add the token with the new name
+    updatedTokenSet.colors.semantic.sememes[newName] = tokenValue;
+
+    // Update the state
+    this.tokenSet = updatedTokenSet;
+
+    // Save and render changes
+    this.debouncedSaveAndRender();
+  }
+
+  private handleSeriesChange(tokenName: string, condition: 'light' | 'dark', value: string) {
+    this.updateSemanticToken(tokenName, condition, 0, value);
+  }
+
+  private handleLuminosityChange(tokenName: string, condition: 'light' | 'dark', value: number) {
+    this.updateSemanticToken(tokenName, condition, 1, value);
+  }
+
+  private renderControlRow(
+    label: string,
+    min: string | number,
+    max: string | number,
+    step: string | number,
+    value: string | number,
+    onInput: (e: Event) => void,
+    headingId: string,
+  ) {
+    const controlId = `${headingId}-${label.toLowerCase().replace(/[^a-z0-9]/g, '-')}`;
+
+    return html`
+      <div class="control-row">
+        <label class="control-label" id="${controlId}-label" for="${controlId}-range">${label}:</label>
+        <div class="control-inputs">
+          <input
+            id="${controlId}-range"
+            type="range"
+            min="${min}"
+            max="${max}"
+            step="${step}"
+            class="range-input dx-focus-ring"
+            .value=${value.toString()}
+            @input=${onInput}
+            aria-labelledby="${headingId} ${controlId}-label"
+          />
+          <input
+            id="${controlId}-number"
+            type="number"
+            min="${min}"
+            max="${max}"
+            step="${step}"
+            class="number-input dx-focus-ring"
+            .value=${value.toString()}
+            @input=${onInput}
+            aria-labelledby="${headingId} ${controlId}-label"
+          />
+        </div>
+      </div>
+    `;
+  }
+
+  private renderTokenControls(tokenName: string, tokenValue: any) {
+    const physicalColorSeries = this.getPhysicalColorSeries();
+    const lightSeries = tokenValue.light?.[0] || '';
+    const lightLuminosity = tokenValue.light?.[1] || 0;
+    const darkSeries = tokenValue.dark?.[0] || '';
+    const darkLuminosity = tokenValue.dark?.[1] || 0;
+
+    // Create unique IDs for headings to reference in aria-labelledby
+    const tokenHeadingId = `${tokenName}-heading`;
+    const lightHeadingId = `${tokenName}-light-heading`;
+    const darkHeadingId = `${tokenName}-dark-heading`;
+
+    return html`
+      <div class="token-controls">
+        <h3 id="${tokenHeadingId}" class="token-title">
+          <input
+            type="text"
+            class="token-name-input dx-focus-ring"
+            .value=${tokenName}
+            @change=${(e: Event) => this.handleTokenNameChange(tokenName, (e.target as HTMLInputElement).value)}
+            aria-label="Token name"
+          />
+        </h3>
+
+        <div class="control-group">
+          <h4 id="${lightHeadingId}" class="control-group-title">Light Condition</h4>
+          <div class="control-row">
+            <label class="control-label" for="${tokenName}-light-series">Series:</label>
+            <select
+              id="${tokenName}-light-series"
+              class="series-select dx-focus-ring"
+              .value=${lightSeries}
+              @change=${(e: Event) =>
+                this.handleSeriesChange(tokenName, 'light', (e.target as HTMLSelectElement).value)}
+              aria-labelledby="${lightHeadingId} ${tokenName}-light-series-label"
+            >
+              ${physicalColorSeries.map(
+                (series) => html`<option value="${series}" ?selected=${series === lightSeries}>${series}</option>`,
+              )}
+            </select>
+          </div>
+          ${this.renderControlRow(
+            'Luminosity',
+            0,
+            1000,
+            1,
+            lightLuminosity,
+            (e: Event) =>
+              this.handleLuminosityChange(tokenName, 'light', parseFloat((e.target as HTMLInputElement).value)),
+            lightHeadingId,
+          )}
+        </div>
+
+        <div class="control-group">
+          <h4 id="${darkHeadingId}" class="control-group-title">Dark Condition</h4>
+          <div class="control-row">
+            <label class="control-label" for="${tokenName}-dark-series">Series:</label>
+            <select
+              id="${tokenName}-dark-series"
+              class="series-select dx-focus-ring"
+              .value=${darkSeries}
+              @change=${(e: Event) => this.handleSeriesChange(tokenName, 'dark', (e.target as HTMLSelectElement).value)}
+              aria-labelledby="${darkHeadingId} ${tokenName}-dark-series-label"
+            >
+              ${physicalColorSeries.map(
+                (series) => html`<option value="${series}" ?selected=${series === darkSeries}>${series}</option>`,
+              )}
+            </select>
+          </div>
+          ${this.renderControlRow(
+            'Luminosity',
+            0,
+            1000,
+            1,
+            darkLuminosity,
+            (e: Event) =>
+              this.handleLuminosityChange(tokenName, 'dark', parseFloat((e.target as HTMLInputElement).value)),
+            darkHeadingId,
+          )}
+        </div>
+      </div>
+    `;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    saveAndRender(this.tokenSet);
+  }
+
+  override render() {
+    const semanticTokens = this.getSemanticTokens();
+
+    return html`
+      <div class="theme-editor-container">
+        <h2>Semantic Colors</h2>
+        ${semanticTokens.map(
+          ([tokenName, tokenValue]) => html`
+            <div class="token-container">${this.renderTokenControls(tokenName, tokenValue)}</div>
+          `,
+        )}
+      </div>
+    `;
+  }
+
+  override createRenderRoot() {
+    return this;
+  }
+}

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-semantic-colors.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor-semantic-colors.ts
@@ -9,6 +9,8 @@ import { customElement, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { debounce } from '@dxos/async';
+import '@dxos/lit-ui';
+import { makeId } from '@dxos/react-hooks';
 
 import { restore, saveAndRender } from './util';
 
@@ -134,6 +136,48 @@ export class DxThemeEditorSemanticColors extends LitElement {
     });
   }
 
+  private addSemanticToken() {
+    if (!this.tokenSet.colors?.semantic?.sememes) {
+      return;
+    }
+
+    // Create a deep copy of the tokenSet to avoid direct mutation
+    const updatedTokenSet = JSON.parse(JSON.stringify(this.tokenSet));
+
+    // Generate a random ID for the token name
+    const tokenName = makeId('sememe--');
+
+    // Create a new token with default values
+    updatedTokenSet.colors.semantic.sememes[tokenName] = {
+      light: ['neutral', 500],
+      dark: ['neutral', 500],
+    };
+
+    // Update the state
+    this.tokenSet = updatedTokenSet;
+
+    // Save and render changes
+    this.debouncedSaveAndRender();
+  }
+
+  private removeSemanticToken(tokenName: string) {
+    if (!this.tokenSet.colors?.semantic?.sememes?.[tokenName]) {
+      return;
+    }
+
+    // Create a deep copy of the tokenSet to avoid direct mutation
+    const updatedTokenSet = JSON.parse(JSON.stringify(this.tokenSet));
+
+    // Delete the token
+    delete updatedTokenSet.colors.semantic.sememes[tokenName];
+
+    // Update the state
+    this.tokenSet = updatedTokenSet;
+
+    // Save and render changes
+    this.debouncedSaveAndRender();
+  }
+
   private renderTokenControls(tokenName: string, tokenValue: any) {
     const physicalColorSeries = this.getPhysicalColorSeries();
     const lightSeries = tokenValue.light?.[0] || '';
@@ -166,6 +210,14 @@ export class DxThemeEditorSemanticColors extends LitElement {
           @change=${(e: Event) => this.handleTokenNameChange(tokenName, (e.target as HTMLInputElement).value)}
           aria-label="Token name"
         />
+        <button
+          class="remove-token-button dx-focus-ring dx-button"
+          @click=${() => this.removeSemanticToken(tokenName)}
+          aria-label="Remove token"
+        >
+          <span class="sr-only">Remove token</span>
+          <dx-icon icon="ph--minus--regular" />
+        </button>
       </h3>
       <div class="token-header">
         <div class="token-series-select">
@@ -242,6 +294,9 @@ export class DxThemeEditorSemanticColors extends LitElement {
           <div class="token-container">${this.renderTokenControls(tokenName, tokenValue)}</div>
         `,
       )}
+      <button class="add-token-button dx-focus-ring dx-button" @click=${() => this.addSemanticToken()}>
+        Add token
+      </button>
     `;
   }
 

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.lit-stories.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.lit-stories.ts
@@ -2,17 +2,29 @@
 // Copyright 2025 DXOS.org
 //
 
+import './dx-theme-editor.ts';
 import './dx-theme-editor-physical-colors.ts';
+import './dx-theme-editor-semantic-colors.ts';
 import './dx-theme-editor.pcss';
 import { html } from 'lit';
 
-import { type DxThemeEditorProps } from './dx-theme-editor-physical-colors';
+import { type DxThemeEditorProps } from './dx-theme-editor';
+import { type DxThemeEditorPhysicalColorsProps } from './dx-theme-editor-physical-colors';
+import { type DxThemeEditorSemanticColorsProps } from './dx-theme-editor-semantic-colors';
 
 export default {
   title: 'dx-theme-editor',
   parameters: { layout: 'fullscreen' },
 };
 
-export const Basic = (props: DxThemeEditorProps) => {
+export const CombinedThemeEditor = (props: DxThemeEditorProps) => {
+  return html`<dx-theme-editor></dx-theme-editor>`;
+};
+
+export const PhysicalColors = (props: DxThemeEditorPhysicalColorsProps) => {
   return html`<dx-theme-editor-physical-colors></dx-theme-editor-physical-colors>`;
+};
+
+export const SemanticColors = (props: DxThemeEditorSemanticColorsProps) => {
+  return html`<dx-theme-editor-semantic-colors></dx-theme-editor-semantic-colors>`;
 };

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.lit-stories.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.lit-stories.ts
@@ -2,11 +2,11 @@
 // Copyright 2025 DXOS.org
 //
 
-import './dx-theme-editor.ts';
+import './dx-theme-editor-physical-colors.ts';
 import './dx-theme-editor.pcss';
 import { html } from 'lit';
 
-import { type DxThemeEditorProps } from './dx-theme-editor';
+import { type DxThemeEditorProps } from './dx-theme-editor-physical-colors';
 
 export default {
   title: 'dx-theme-editor',
@@ -14,5 +14,5 @@ export default {
 };
 
 export const Basic = (props: DxThemeEditorProps) => {
-  return html`<dx-theme-editor></dx-theme-editor>`;
+  return html`<dx-theme-editor-physical-colors></dx-theme-editor-physical-colors>`;
 };

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.lit-stories.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.lit-stories.ts
@@ -1,0 +1,18 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import './dx-theme-editor.ts';
+import './dx-theme-editor.pcss';
+import { html } from 'lit';
+
+import { type DxThemeEditorProps } from './dx-theme-editor';
+
+export default {
+  title: 'dx-theme-editor',
+  parameters: { layout: 'fullscreen' },
+};
+
+export const Basic = (props: DxThemeEditorProps) => {
+  return html`<dx-theme-editor></dx-theme-editor>`;
+};

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -2,17 +2,9 @@ dx-theme-editor {
   display: contents;
 
   .theme-editor-container {
-    font-family: system-ui, sans-serif;
-    padding: 1rem;
-    max-width: 800px;
-    margin: 0 auto;
   }
 
   .series-container {
-    margin-bottom: 2rem;
-    padding: 1rem;
-    border: 1px solid #ccc;
-    border-radius: 4px;
   }
 
   .series-header {
@@ -26,11 +18,13 @@ dx-theme-editor {
     margin: 0;
   }
 
-  .color-preview {
-    width: 40px;
-    height: 40px;
-    border-radius: 4px;
-    border: 1px solid #ccc;
+  .series-controls {
+    padding: 1rem;
+  }
+
+  .series-preview {
+    block-size: 4rem;
+    border-radius: .25rem;
   }
 
   .control-group {

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -1,4 +1,4 @@
-dx-theme-editor {
+dx-theme-editor-physical-colors {
   display: contents;
 
   input {

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -1,0 +1,3 @@
+dx-theme-editor {
+  display: contents;
+}

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -1,3 +1,68 @@
 dx-theme-editor {
   display: contents;
+
+  .theme-editor-container {
+    font-family: system-ui, sans-serif;
+    padding: 1rem;
+    max-width: 800px;
+    margin: 0 auto;
+  }
+
+  .series-container {
+    margin-bottom: 2rem;
+    padding: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+
+  .series-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+  }
+
+  .series-title {
+    margin: 0;
+  }
+
+  .color-preview {
+    width: 40px;
+    height: 40px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+  }
+
+  .control-group {
+    margin-bottom: 1.5rem;
+  }
+
+  .control-group:last-child {
+    margin-bottom: 1rem;
+  }
+
+  .control-group-title {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+  }
+
+  .control-row {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.5rem;
+    gap: 0.5rem;
+  }
+
+  .control-label {
+    min-width: 180px;
+  }
+
+  .range-input {
+    flex: 1;
+  }
+
+  .number-input {
+    width: 80px;
+  }
+
 }

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -1,11 +1,9 @@
 dx-theme-editor {
   display: contents;
 
-  .theme-editor-container {
-  }
+  .theme-editor-container {}
 
-  .series-container {
-  }
+  .series-container {}
 
   .series-header {
     display: flex;
@@ -35,6 +33,7 @@ dx-theme-editor {
         direction: rtl;
       }
     }
+
     &.reverse-order {
       flex-direction: row-reverse;
     }
@@ -43,9 +42,11 @@ dx-theme-editor {
   .control-group {
     display: flex;
     gap: 1rem;
+
     .control-row {
       display: block;
       flex: 1 1 0;
+
       .control-inputs {
         display: flex;
         gap: .5rem;

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -7,13 +7,6 @@ dx-theme-editor-semantic-colors {
     accent-color: var(--dx-accentSurface);
   }
 
-  .theme-editor-container {
-    font-family: system-ui, sans-serif;
-    padding: 1rem;
-    max-width: 800px;
-    margin: 0 auto;
-  }
-
   .tabs-container {
     display: flex;
     border-bottom: 1px solid #ccc;

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -1,6 +1,10 @@
 dx-theme-editor {
   display: contents;
 
+  input {
+    accent-color: var(--dx-accentSurface);
+  }
+
   .theme-editor-container {}
 
   .series-container {}

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -1,11 +1,53 @@
-dx-theme-editor-physical-colors {
+dx-theme-editor,
+dx-theme-editor-physical-colors,
+dx-theme-editor-semantic-colors {
   display: contents;
 
   input {
     accent-color: var(--dx-accentSurface);
   }
 
-  .theme-editor-container {}
+  .theme-editor-container {
+    font-family: system-ui, sans-serif;
+    padding: 1rem;
+    max-width: 800px;
+    margin: 0 auto;
+  }
+
+  .tabs-container {
+    display: flex;
+    border-bottom: 1px solid #ccc;
+    margin-bottom: 1rem;
+  }
+
+  .tab {
+    padding: 0.5rem 1rem;
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 1rem;
+    border-bottom: 2px solid transparent;
+
+    &.active {
+      border-bottom-color: var(--dx-accentSurface, #0066cc);
+      font-weight: bold;
+    }
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.05);
+    }
+
+    &:focus {
+      outline: 2px solid var(--dx-accentFocusIndicator, #0066cc);
+      outline-offset: 2px;
+    }
+  }
+
+  .tab-panel {
+    &[hidden] {
+      display: none;
+    }
+  }
 
   .series-container {}
 
@@ -86,4 +128,37 @@ dx-theme-editor-physical-colors {
     width: 80px;
   }
 
+  /* Semantic Colors Editor Styles */
+  .token-container {
+    margin-bottom: 1rem;
+    padding: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 0.25rem;
+  }
+
+  .token-controls {
+    padding: 0.5rem;
+  }
+
+  .token-title {
+    margin: 0 0 1rem 0;
+    display: flex;
+    align-items: center;
+  }
+
+  .token-name-input {
+    font-size: 1rem;
+    font-weight: bold;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 0.25rem;
+    width: 100%;
+  }
+
+  .series-select {
+    padding: 0.25rem 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 0.25rem;
+    flex: 1;
+  }
 }

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -152,11 +152,16 @@ dx-theme-editor-semantic-colors {
     display: flex;
     align-items: center;
     flex: 1 0 10rem;
+    gap: 0.5rem;
   }
 
   .token-name-input {
     width: 100%;
     min-width: min-content;
+  }
+
+  .add-token-button {
+    inline-size: 100%;
   }
 
   .token-series-select {

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -1,6 +1,7 @@
 dx-theme-editor,
 dx-theme-editor-physical-colors,
-dx-theme-editor-semantic-colors {
+dx-theme-editor-semantic-colors,
+dx-range-spinbutton {
   display: contents;
 
   input {

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -29,6 +29,15 @@ dx-theme-editor {
 
   .control-inputs {
     display: contents;
+
+    &.reverse-range {
+      .range-input {
+        direction: rtl;
+      }
+    }
+    &.reverse-order {
+      flex-direction: row-reverse;
+    }
   }
 
   .control-group {

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -42,7 +42,8 @@ dx-theme-editor-semantic-colors {
     }
   }
 
-  .series-container {}
+  .series-container {
+  }
 
   .series-header {
     display: flex;
@@ -74,6 +75,7 @@ dx-theme-editor-semantic-colors {
     background-position: 0 0, 16px 16px;
     position: relative;
     overflow: hidden;
+
     & > .shade {
       position: absolute;
       inset: 0;
@@ -123,7 +125,8 @@ dx-theme-editor-semantic-colors {
     gap: 0.5rem;
   }
 
-  .control-label {}
+  .control-label {
+  }
 
   .range-input {
     flex: 1;
@@ -134,7 +137,29 @@ dx-theme-editor-semantic-colors {
   }
 
   .token-container {
-    padding: 1rem;
+    display: contents;
+
+    .static-token-name {
+      display: none;
+    }
+
+    &:not([data-state="expanded"]) {
+      .token-content {
+        display: none;
+      }
+
+      .remove-token-button, .token-name-input {
+        display: none;
+      }
+
+      .static-token-name {
+        display: block;
+      }
+
+      .toggle-button dx-icon svg {
+        transform: rotate(-90deg);
+      }
+    }
   }
 
   .token-controls {

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -64,6 +64,22 @@ dx-theme-editor-semantic-colors {
     border-radius: .25rem;
   }
 
+  .shade-preview {
+    block-size: 2rem;
+    border-radius: .25rem;
+    background-color: #888;
+    background-image: linear-gradient(45deg, #777 25%, transparent 25%, transparent 75%, #777 75%, #777),
+    linear-gradient(45deg, #777 25%, transparent 25%, transparent 75%, #777 75%, #777);
+    background-size: 32px 32px;
+    background-position: 0 0, 16px 16px;
+    position: relative;
+    overflow: hidden;
+    & > .shade {
+      position: absolute;
+      inset: 0;
+    }
+  }
+
   .control-inputs {
     display: contents;
 
@@ -82,7 +98,7 @@ dx-theme-editor-semantic-colors {
     display: flex;
     gap: 1rem;
 
-    .control-row, dx-range-spinbutton {
+    .control-row, dx-range-spinbutton, .control-group-item {
       display: block;
       flex: 1 1 0;
       margin-block: 0;

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -92,6 +92,7 @@ dx-theme-editor-semantic-colors {
     .control-row, dx-range-spinbutton {
       display: block;
       flex: 1 1 0;
+      margin-block: 0;
 
       .control-inputs {
         display: flex;
@@ -100,22 +101,16 @@ dx-theme-editor-semantic-colors {
     }
   }
 
-  .control-group:last-child {
-    margin-bottom: 1rem;
-  }
-
   .control-group-title {
     margin-top: 0;
     margin-bottom: 0.5rem;
   }
 
   .control-row, dx-range-spinbutton {
+    flex: 1 0 auto;
     display: flex;
     align-items: center;
-  }
-
-  .control-row {
-    margin-bottom: 0.5rem;
+    margin-block: 0.5rem;
     gap: 0.5rem;
   }
 
@@ -130,10 +125,7 @@ dx-theme-editor-semantic-colors {
   }
 
   .token-container {
-    margin-bottom: 1rem;
     padding: 1rem;
-    border: 1px solid #ccc;
-    border-radius: 0.25rem;
   }
 
   .token-controls {
@@ -143,7 +135,6 @@ dx-theme-editor-semantic-colors {
   .token-header {
     display: flex;
     align-items: center;
-    margin-bottom: 1rem;
     gap: 1rem;
   }
 

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -27,8 +27,21 @@ dx-theme-editor {
     border-radius: .25rem;
   }
 
+  .control-inputs {
+    display: contents;
+  }
+
   .control-group {
-    margin-bottom: 1.5rem;
+    display: flex;
+    gap: 1rem;
+    .control-row {
+      display: block;
+      flex: 1 1 0;
+      .control-inputs {
+        display: flex;
+        gap: .5rem;
+      }
+    }
   }
 
   .control-group:last-child {

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.pcss
@@ -1,7 +1,6 @@
 dx-theme-editor,
 dx-theme-editor-physical-colors,
-dx-theme-editor-semantic-colors,
-dx-range-spinbutton {
+dx-theme-editor-semantic-colors {
   display: contents;
 
   input {
@@ -30,7 +29,7 @@ dx-range-spinbutton {
     border-bottom: 2px solid transparent;
 
     &.active {
-      border-bottom-color: var(--dx-accentSurface, #0066cc);
+      border-bottom-color: var(--dx-accentSurface);
       font-weight: bold;
     }
 
@@ -39,7 +38,7 @@ dx-range-spinbutton {
     }
 
     &:focus {
-      outline: 2px solid var(--dx-accentFocusIndicator, #0066cc);
+      outline: 2px solid var(--dx-accentFocusIndicator);
       outline-offset: 2px;
     }
   }
@@ -90,7 +89,7 @@ dx-range-spinbutton {
     display: flex;
     gap: 1rem;
 
-    .control-row {
+    .control-row, dx-range-spinbutton {
       display: block;
       flex: 1 1 0;
 
@@ -110,26 +109,26 @@ dx-range-spinbutton {
     margin-bottom: 0.5rem;
   }
 
-  .control-row {
+  .control-row, dx-range-spinbutton {
     display: flex;
     align-items: center;
+  }
+
+  .control-row {
     margin-bottom: 0.5rem;
     gap: 0.5rem;
   }
 
-  .control-label {
-    min-width: 180px;
-  }
+  .control-label {}
 
   .range-input {
     flex: 1;
   }
 
   .number-input {
-    width: 80px;
+    width: 6rem;
   }
 
-  /* Semantic Colors Editor Styles */
   .token-container {
     margin-bottom: 1rem;
     padding: 1rem;
@@ -141,25 +140,32 @@ dx-range-spinbutton {
     padding: 0.5rem;
   }
 
-  .token-title {
-    margin: 0 0 1rem 0;
+  .token-header {
     display: flex;
     align-items: center;
+    margin-bottom: 1rem;
+    gap: 1rem;
+  }
+
+  .token-title {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    flex: 1 0 10rem;
   }
 
   .token-name-input {
-    font-size: 1rem;
-    font-weight: bold;
-    padding: 0.25rem 0.5rem;
-    border: 1px solid #ccc;
-    border-radius: 0.25rem;
     width: 100%;
+    min-width: min-content;
+  }
+
+  .token-series-select {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
   }
 
   .series-select {
-    padding: 0.25rem 0.5rem;
-    border: 1px solid #ccc;
-    border-radius: 0.25rem;
     flex: 1;
   }
 }

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
@@ -1,0 +1,19 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+export type DxThemeEditorProps = {};
+
+@customElement('dx-theme-editor')
+export class DxThemeEditor extends LitElement {
+  override render() {
+    return html`<span>Theme editor</span>`;
+  }
+
+  override createRenderRoot() {
+    return this;
+  }
+}

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
@@ -2,23 +2,262 @@
 // Copyright 2025 DXOS.org
 //
 
-import { type TokenSet } from '@ch-ui/tokens';
+import { type ResolvedHelicalArcSeries, type TokenSet } from '@ch-ui/tokens';
 import { LitElement, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
-import { restore } from './util';
+import { debounce } from '@dxos/async';
+
+import { restore, saveAndRender } from './util';
 
 export type DxThemeEditorProps = {};
 
 const bindSeriesDefinitions = ['neutral', 'primary'];
+
+const isHelicalArcSeries = (o: any): o is ResolvedHelicalArcSeries => {
+  return 'keyPoint' in (o ?? {});
+};
 
 @customElement('dx-theme-editor')
 export class DxThemeEditor extends LitElement {
   @state()
   tokenSet: TokenSet = restore();
 
+  private debouncedSaveAndRender = debounce(() => {
+    saveAndRender(JSON.stringify(this.tokenSet));
+  }, 200);
+
+  private updateSeriesProperty(series: string, property: string, value: any) {
+    if (!this.tokenSet.colors?.physical?.definitions?.series?.[series]) {
+      return;
+    }
+
+    // Create a deep copy of the tokenSet to avoid direct mutation
+    const updatedTokenSet = JSON.parse(JSON.stringify(this.tokenSet));
+
+    // Update the specific property
+    updatedTokenSet.colors.physical.definitions.series[series][property] = value;
+
+    // Update the state
+    this.tokenSet = updatedTokenSet;
+
+    // Save and render changes
+    this.debouncedSaveAndRender();
+  }
+
+  private handleKeyPointChange(series: string, index: number, value: number) {
+    if (!isHelicalArcSeries(this.tokenSet.colors?.physical?.definitions?.series?.[series])) {
+      return;
+    }
+
+    const keyPoint = [...this.tokenSet.colors.physical.definitions.series[series].keyPoint];
+    keyPoint[index] = value;
+
+    this.updateSeriesProperty(series, 'keyPoint', keyPoint);
+  }
+
+  private handleControlPointChange(series: string, property: 'lowerCp' | 'upperCp', value: number) {
+    this.updateSeriesProperty(series, property, value);
+  }
+
+  private handleTorsionChange(series: string, value: number) {
+    this.updateSeriesProperty(series, 'torsion', value);
+  }
+
+  private renderSeriesControls(series: string) {
+    const seriesData = this.tokenSet.colors?.physical?.definitions?.series?.[series];
+    if (!isHelicalArcSeries(seriesData)) {
+      return html`<div>Series ${series} not found</div>`;
+    }
+
+    const keyPoint = seriesData.keyPoint || [0, 0, 0];
+    const lowerCp = seriesData.lowerCp || 0;
+    const upperCp = seriesData.upperCp || 0;
+    const torsion = seriesData.torsion || 0;
+
+    // Create a color preview based on the keyPoint
+    const previewColor = `oklch(${keyPoint[0]} ${keyPoint[1]} ${keyPoint[2]})`;
+
+    return html`
+      <div class="series-controls">
+        <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem;">
+          <h3 style="margin: 0;">${series} Series</h3>
+          <div
+            style="width: 40px; height: 40px; border-radius: 4px; background-color: ${previewColor}; border: 1px solid #ccc;"
+          ></div>
+        </div>
+
+        <div class="control-group" style="margin-bottom: 1.5rem;">
+          <h4 style="margin-top: 0; margin-bottom: 0.5rem;">Key Color</h4>
+
+          <div class="control-row" style="display: flex; align-items: center; margin-bottom: 0.5rem; gap: 0.5rem;">
+            <label style="min-width: 180px;">Lightness (0-1):</label>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              style="flex: 1;"
+              .value=${keyPoint[0].toString()}
+              @input=${(e: Event) =>
+                this.handleKeyPointChange(series, 0, parseFloat((e.target as HTMLInputElement).value))}
+            />
+            <input
+              type="number"
+              min="0"
+              max="1"
+              step="0.01"
+              style="width: 80px;"
+              .value=${keyPoint[0].toString()}
+              @input=${(e: Event) =>
+                this.handleKeyPointChange(series, 0, parseFloat((e.target as HTMLInputElement).value))}
+            />
+          </div>
+
+          <div class="control-row" style="display: flex; align-items: center; margin-bottom: 0.5rem; gap: 0.5rem;">
+            <label style="min-width: 180px;">Chroma (0-0.3):</label>
+            <input
+              type="range"
+              min="0"
+              max="0.3"
+              step="0.01"
+              style="flex: 1;"
+              .value=${keyPoint[1].toString()}
+              @input=${(e: Event) =>
+                this.handleKeyPointChange(series, 1, parseFloat((e.target as HTMLInputElement).value))}
+            />
+            <input
+              type="number"
+              min="0"
+              max="0.3"
+              step="0.01"
+              style="width: 80px;"
+              .value=${keyPoint[1].toString()}
+              @input=${(e: Event) =>
+                this.handleKeyPointChange(series, 1, parseFloat((e.target as HTMLInputElement).value))}
+            />
+          </div>
+
+          <div class="control-row" style="display: flex; align-items: center; margin-bottom: 0.5rem; gap: 0.5rem;">
+            <label style="min-width: 180px;">Hue (0-360):</label>
+            <input
+              type="range"
+              min="0"
+              max="360"
+              step="1"
+              style="flex: 1;"
+              .value=${keyPoint[2].toString()}
+              @input=${(e: Event) =>
+                this.handleKeyPointChange(series, 2, parseFloat((e.target as HTMLInputElement).value))}
+            />
+            <input
+              type="number"
+              min="0"
+              max="360"
+              step="1"
+              style="width: 80px;"
+              .value=${keyPoint[2].toString()}
+              @input=${(e: Event) =>
+                this.handleKeyPointChange(series, 2, parseFloat((e.target as HTMLInputElement).value))}
+            />
+          </div>
+        </div>
+
+        <div class="control-group" style="margin-bottom: 1.5rem;">
+          <h4 style="margin-top: 0; margin-bottom: 0.5rem;">Control Points</h4>
+
+          <div class="control-row" style="display: flex; align-items: center; margin-bottom: 0.5rem; gap: 0.5rem;">
+            <label style="min-width: 180px;">Light Control Point (0-1):</label>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              style="flex: 1;"
+              .value=${lowerCp.toString()}
+              @input=${(e: Event) =>
+                this.handleControlPointChange(series, 'lowerCp', parseFloat((e.target as HTMLInputElement).value))}
+            />
+            <input
+              type="number"
+              min="0"
+              max="1"
+              step="0.01"
+              style="width: 80px;"
+              .value=${lowerCp.toString()}
+              @input=${(e: Event) =>
+                this.handleControlPointChange(series, 'lowerCp', parseFloat((e.target as HTMLInputElement).value))}
+            />
+          </div>
+
+          <div class="control-row" style="display: flex; align-items: center; margin-bottom: 0.5rem; gap: 0.5rem;">
+            <label style="min-width: 180px;">Dark Control Point (0-1):</label>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              style="flex: 1;"
+              .value=${upperCp.toString()}
+              @input=${(e: Event) =>
+                this.handleControlPointChange(series, 'upperCp', parseFloat((e.target as HTMLInputElement).value))}
+            />
+            <input
+              type="number"
+              min="0"
+              max="1"
+              step="0.01"
+              style="width: 80px;"
+              .value=${upperCp.toString()}
+              @input=${(e: Event) =>
+                this.handleControlPointChange(series, 'upperCp', parseFloat((e.target as HTMLInputElement).value))}
+            />
+          </div>
+        </div>
+
+        <div class="control-group" style="margin-bottom: 1rem;">
+          <h4 style="margin-top: 0; margin-bottom: 0.5rem;">Torsion</h4>
+
+          <div class="control-row" style="display: flex; align-items: center; margin-bottom: 0.5rem; gap: 0.5rem;">
+            <label style="min-width: 180px;">Torsion (-180 to 180):</label>
+            <input
+              type="range"
+              min="-180"
+              max="180"
+              step="1"
+              style="flex: 1;"
+              .value=${torsion.toString()}
+              @input=${(e: Event) => this.handleTorsionChange(series, parseFloat((e.target as HTMLInputElement).value))}
+            />
+            <input
+              type="number"
+              min="-180"
+              max="180"
+              step="1"
+              style="width: 80px;"
+              .value=${torsion.toString()}
+              @input=${(e: Event) => this.handleTorsionChange(series, parseFloat((e.target as HTMLInputElement).value))}
+            />
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
   override render() {
-    return html`<span>Theme editor</span>`;
+    return html`
+      <div style="font-family: system-ui, sans-serif; padding: 1rem; max-width: 800px; margin: 0 auto;">
+        <h2>Theme Editor</h2>
+
+        ${bindSeriesDefinitions.map(
+          (series) => html`
+            <div style="margin-bottom: 2rem; padding: 1rem; border: 1px solid #ccc; border-radius: 4px;">
+              ${this.renderSeriesControls(series)}
+            </div>
+          `,
+        )}
+      </div>
+    `;
   }
 
   override createRenderRoot() {

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
@@ -66,6 +66,46 @@ export class DxThemeEditor extends LitElement {
     this.updateSeriesProperty(series, 'torsion', value);
   }
 
+  private renderControlRow(
+    label: string,
+    min: string | number,
+    max: string | number,
+    step: string | number,
+    value: string | number,
+    onInput: (e: Event) => void,
+    headingId: string,
+  ) {
+    const controlId = `${headingId}-${label.toLowerCase().replace(/[^a-z0-9]/g, '-')}`;
+
+    return html`
+      <div class="control-row">
+        <label class="control-label" id="${controlId}-label" for="${controlId}-range">${label}:</label>
+        <input
+          id="${controlId}-range"
+          type="range"
+          min="${min}"
+          max="${max}"
+          step="${step}"
+          class="range-input"
+          .value=${value.toString()}
+          @input=${onInput}
+          aria-labelledby="${headingId} ${controlId}-label"
+        />
+        <input
+          id="${controlId}-number"
+          type="number"
+          min="${min}"
+          max="${max}"
+          step="${step}"
+          class="number-input"
+          .value=${value.toString()}
+          @input=${onInput}
+          aria-labelledby="${headingId} ${controlId}-label"
+        />
+      </div>
+    `;
+  }
+
   private renderSeriesControls(series: string) {
     const seriesData = this.tokenSet.colors?.physical?.definitions?.series?.[series];
     if (!isHelicalArcSeries(seriesData)) {
@@ -80,168 +120,87 @@ export class DxThemeEditor extends LitElement {
     // Create a color preview based on the keyPoint
     const previewColor = `oklch(${keyPoint[0]} ${keyPoint[1]} ${keyPoint[2]})`;
 
+    // Create unique IDs for headings to reference in aria-labelledby
+    const keyColorHeadingId = `${series}-key-color-heading`;
+    const controlPointsHeadingId = `${series}-control-points-heading`;
+    const torsionHeadingId = `${series}-torsion-heading`;
+
     return html`
       <div class="series-controls">
         <div class="series-header">
           <h3 class="series-title">${series} Series</h3>
-          <div
-            class="color-preview"
-            style=${styleMap({ backgroundColor: previewColor })}
-          ></div>
+          <div class="color-preview" style=${styleMap({ backgroundColor: previewColor })}></div>
         </div>
 
         <div class="control-group">
-          <h4 class="control-group-title">Key Color</h4>
+          <h4 id="${keyColorHeadingId}" class="control-group-title">Key Color</h4>
 
-          <div class="control-row">
-            <label class="control-label">Lightness (0-1):</label>
-            <input
-              type="range"
-              min="0"
-              max="1"
-              step="0.01"
-              class="range-input"
-              .value=${keyPoint[0].toString()}
-              @input=${(e: Event) =>
-                this.handleKeyPointChange(series, 0, parseFloat((e.target as HTMLInputElement).value))}
-            />
-            <input
-              type="number"
-              min="0"
-              max="1"
-              step="0.01"
-              class="number-input"
-              .value=${keyPoint[0].toString()}
-              @input=${(e: Event) =>
-                this.handleKeyPointChange(series, 0, parseFloat((e.target as HTMLInputElement).value))}
-            />
-          </div>
-
-          <div class="control-row">
-            <label class="control-label">Chroma (0-0.3):</label>
-            <input
-              type="range"
-              min="0"
-              max="0.3"
-              step="0.01"
-              class="range-input"
-              .value=${keyPoint[1].toString()}
-              @input=${(e: Event) =>
-                this.handleKeyPointChange(series, 1, parseFloat((e.target as HTMLInputElement).value))}
-            />
-            <input
-              type="number"
-              min="0"
-              max="0.3"
-              step="0.01"
-              class="number-input"
-              .value=${keyPoint[1].toString()}
-              @input=${(e: Event) =>
-                this.handleKeyPointChange(series, 1, parseFloat((e.target as HTMLInputElement).value))}
-            />
-          </div>
-
-          <div class="control-row">
-            <label class="control-label">Hue (0-360):</label>
-            <input
-              type="range"
-              min="0"
-              max="360"
-              step="1"
-              class="range-input"
-              .value=${keyPoint[2].toString()}
-              @input=${(e: Event) =>
-                this.handleKeyPointChange(series, 2, parseFloat((e.target as HTMLInputElement).value))}
-            />
-            <input
-              type="number"
-              min="0"
-              max="360"
-              step="1"
-              class="number-input"
-              .value=${keyPoint[2].toString()}
-              @input=${(e: Event) =>
-                this.handleKeyPointChange(series, 2, parseFloat((e.target as HTMLInputElement).value))}
-            />
-          </div>
+          ${this.renderControlRow(
+            'Lightness (0-1)',
+            0,
+            1,
+            0.01,
+            keyPoint[0],
+            (e: Event) => this.handleKeyPointChange(series, 0, parseFloat((e.target as HTMLInputElement).value)),
+            keyColorHeadingId,
+          )}
+          ${this.renderControlRow(
+            'Chroma (0-0.3)',
+            0,
+            0.3,
+            0.01,
+            keyPoint[1],
+            (e: Event) => this.handleKeyPointChange(series, 1, parseFloat((e.target as HTMLInputElement).value)),
+            keyColorHeadingId,
+          )}
+          ${this.renderControlRow(
+            'Hue (0-360)',
+            0,
+            360,
+            1,
+            keyPoint[2],
+            (e: Event) => this.handleKeyPointChange(series, 2, parseFloat((e.target as HTMLInputElement).value)),
+            keyColorHeadingId,
+          )}
         </div>
 
         <div class="control-group">
-          <h4 class="control-group-title">Control Points</h4>
+          <h4 id="${controlPointsHeadingId}" class="control-group-title">Control Points</h4>
 
-          <div class="control-row">
-            <label class="control-label">Light Control Point (0-1):</label>
-            <input
-              type="range"
-              min="0"
-              max="1"
-              step="0.01"
-              class="range-input"
-              .value=${lowerCp.toString()}
-              @input=${(e: Event) =>
-                this.handleControlPointChange(series, 'lowerCp', parseFloat((e.target as HTMLInputElement).value))}
-            />
-            <input
-              type="number"
-              min="0"
-              max="1"
-              step="0.01"
-              class="number-input"
-              .value=${lowerCp.toString()}
-              @input=${(e: Event) =>
-                this.handleControlPointChange(series, 'lowerCp', parseFloat((e.target as HTMLInputElement).value))}
-            />
-          </div>
-
-          <div class="control-row">
-            <label class="control-label">Dark Control Point (0-1):</label>
-            <input
-              type="range"
-              min="0"
-              max="1"
-              step="0.01"
-              class="range-input"
-              .value=${upperCp.toString()}
-              @input=${(e: Event) =>
-                this.handleControlPointChange(series, 'upperCp', parseFloat((e.target as HTMLInputElement).value))}
-            />
-            <input
-              type="number"
-              min="0"
-              max="1"
-              step="0.01"
-              class="number-input"
-              .value=${upperCp.toString()}
-              @input=${(e: Event) =>
-                this.handleControlPointChange(series, 'upperCp', parseFloat((e.target as HTMLInputElement).value))}
-            />
-          </div>
+          ${this.renderControlRow(
+            'Light Control Point (0-1)',
+            0,
+            1,
+            0.01,
+            lowerCp,
+            (e: Event) =>
+              this.handleControlPointChange(series, 'lowerCp', parseFloat((e.target as HTMLInputElement).value)),
+            controlPointsHeadingId,
+          )}
+          ${this.renderControlRow(
+            'Dark Control Point (0-1)',
+            0,
+            1,
+            0.01,
+            upperCp,
+            (e: Event) =>
+              this.handleControlPointChange(series, 'upperCp', parseFloat((e.target as HTMLInputElement).value)),
+            controlPointsHeadingId,
+          )}
         </div>
 
         <div class="control-group">
-          <h4 class="control-group-title">Torsion</h4>
+          <h4 id="${torsionHeadingId}" class="control-group-title">Torsion</h4>
 
-          <div class="control-row">
-            <label class="control-label">Torsion (-180 to 180):</label>
-            <input
-              type="range"
-              min="-180"
-              max="180"
-              step="1"
-              class="range-input"
-              .value=${torsion.toString()}
-              @input=${(e: Event) => this.handleTorsionChange(series, parseFloat((e.target as HTMLInputElement).value))}
-            />
-            <input
-              type="number"
-              min="-180"
-              max="180"
-              step="1"
-              class="number-input"
-              .value=${torsion.toString()}
-              @input=${(e: Event) => this.handleTorsionChange(series, parseFloat((e.target as HTMLInputElement).value))}
-            />
-          </div>
+          ${this.renderControlRow(
+            'Torsion (-180 to 180)',
+            -180,
+            180,
+            1,
+            torsion,
+            (e: Event) => this.handleTorsionChange(series, parseFloat((e.target as HTMLInputElement).value)),
+            torsionHeadingId,
+          )}
         </div>
       </div>
     `;
@@ -253,11 +212,7 @@ export class DxThemeEditor extends LitElement {
         <h2>Theme Editor</h2>
 
         ${bindSeriesDefinitions.map(
-          (series) => html`
-            <div class="series-container">
-              ${this.renderSeriesControls(series)}
-            </div>
-          `,
+          (series) => html` <div class="series-container">${this.renderSeriesControls(series)}</div> `,
         )}
       </div>
     `;

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
@@ -2,13 +2,21 @@
 // Copyright 2025 DXOS.org
 //
 
+import { type TokenSet } from '@ch-ui/tokens';
 import { LitElement, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
+
+import { restore } from './util';
 
 export type DxThemeEditorProps = {};
 
+const bindSeriesDefinitions = ['neutral', 'primary'];
+
 @customElement('dx-theme-editor')
 export class DxThemeEditor extends LitElement {
+  @state()
+  tokenSet: TokenSet = restore();
+
   override render() {
     return html`<span>Theme editor</span>`;
   }

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
@@ -29,7 +29,7 @@ export class DxThemeEditor extends LitElement {
   tokenSet: TokenSet = restore();
 
   private debouncedSaveAndRender = debounce(() => {
-    saveAndRender(JSON.stringify(this.tokenSet));
+    saveAndRender(this.tokenSet);
   }, 200);
 
   private updateSeriesProperty(series: string, property: string, value: any) {
@@ -157,9 +157,9 @@ export class DxThemeEditor extends LitElement {
           torsionHeadingId,
         )}
         ${this.renderControlRow(
-          'Chroma (0-0.5)',
+          'Chroma (0-0.4)',
           0,
-          0.5,
+          0.4,
           0.0025,
           keyPoint[1],
           (e: Event) => this.handleKeyPointChange(series, 1, parseFloat((e.target as HTMLInputElement).value)),
@@ -192,6 +192,11 @@ export class DxThemeEditor extends LitElement {
         </div>
       </div>
     `;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    saveAndRender(this.tokenSet);
   }
 
   override render() {

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
@@ -1,0 +1,76 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { LitElement, html } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+import './dx-theme-editor-physical-colors';
+import './dx-theme-editor-semantic-colors';
+import './dx-theme-editor.pcss';
+
+export type DxThemeEditorProps = {};
+
+@customElement('dx-theme-editor')
+export class DxThemeEditor extends LitElement {
+  @state()
+  private activeTab: 'physical' | 'semantic' = 'physical';
+
+  private handleTabClick(tab: 'physical' | 'semantic') {
+    this.activeTab = tab;
+  }
+
+  override render() {
+    return html`
+      <div class="theme-editor-container">
+        <div class="tabs-container" role="tablist">
+          <button
+            id="tab-physical"
+            class=${classMap({ 'tab': true, 'active': this.activeTab === 'physical' })}
+            role="tab"
+            aria-selected=${this.activeTab === 'physical'}
+            aria-controls="panel-physical"
+            @click=${() => this.handleTabClick('physical')}
+          >
+            Physical
+          </button>
+          <button
+            id="tab-semantic"
+            class=${classMap({ 'tab': true, 'active': this.activeTab === 'semantic' })}
+            role="tab"
+            aria-selected=${this.activeTab === 'semantic'}
+            aria-controls="panel-semantic"
+            @click=${() => this.handleTabClick('semantic')}
+          >
+            Semantic
+          </button>
+        </div>
+        
+        <div 
+          id="panel-physical"
+          class=${classMap({ 'tab-panel': true, 'active': this.activeTab === 'physical' })}
+          role="tabpanel"
+          aria-labelledby="tab-physical"
+          ?hidden=${this.activeTab !== 'physical'}
+        >
+          <dx-theme-editor-physical-colors></dx-theme-editor-physical-colors>
+        </div>
+        
+        <div 
+          id="panel-semantic"
+          class=${classMap({ 'tab-panel': true, 'active': this.activeTab === 'semantic' })}
+          role="tabpanel"
+          aria-labelledby="tab-semantic"
+          ?hidden=${this.activeTab !== 'semantic'}
+        >
+          <dx-theme-editor-semantic-colors></dx-theme-editor-semantic-colors>
+        </div>
+      </div>
+    `;
+  }
+
+  override createRenderRoot() {
+    return this;
+  }
+}

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
@@ -5,10 +5,12 @@
 import { type ResolvedHelicalArcSeries, type TokenSet } from '@ch-ui/tokens';
 import { LitElement, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+import { styleMap } from 'lit/directives/style-map.js';
 
 import { debounce } from '@dxos/async';
 
 import { restore, saveAndRender } from './util';
+import './dx-theme-editor.pcss';
 
 export type DxThemeEditorProps = {};
 
@@ -80,24 +82,25 @@ export class DxThemeEditor extends LitElement {
 
     return html`
       <div class="series-controls">
-        <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem;">
-          <h3 style="margin: 0;">${series} Series</h3>
+        <div class="series-header">
+          <h3 class="series-title">${series} Series</h3>
           <div
-            style="width: 40px; height: 40px; border-radius: 4px; background-color: ${previewColor}; border: 1px solid #ccc;"
+            class="color-preview"
+            style=${styleMap({ backgroundColor: previewColor })}
           ></div>
         </div>
 
-        <div class="control-group" style="margin-bottom: 1.5rem;">
-          <h4 style="margin-top: 0; margin-bottom: 0.5rem;">Key Color</h4>
+        <div class="control-group">
+          <h4 class="control-group-title">Key Color</h4>
 
-          <div class="control-row" style="display: flex; align-items: center; margin-bottom: 0.5rem; gap: 0.5rem;">
-            <label style="min-width: 180px;">Lightness (0-1):</label>
+          <div class="control-row">
+            <label class="control-label">Lightness (0-1):</label>
             <input
               type="range"
               min="0"
               max="1"
               step="0.01"
-              style="flex: 1;"
+              class="range-input"
               .value=${keyPoint[0].toString()}
               @input=${(e: Event) =>
                 this.handleKeyPointChange(series, 0, parseFloat((e.target as HTMLInputElement).value))}
@@ -107,21 +110,21 @@ export class DxThemeEditor extends LitElement {
               min="0"
               max="1"
               step="0.01"
-              style="width: 80px;"
+              class="number-input"
               .value=${keyPoint[0].toString()}
               @input=${(e: Event) =>
                 this.handleKeyPointChange(series, 0, parseFloat((e.target as HTMLInputElement).value))}
             />
           </div>
 
-          <div class="control-row" style="display: flex; align-items: center; margin-bottom: 0.5rem; gap: 0.5rem;">
-            <label style="min-width: 180px;">Chroma (0-0.3):</label>
+          <div class="control-row">
+            <label class="control-label">Chroma (0-0.3):</label>
             <input
               type="range"
               min="0"
               max="0.3"
               step="0.01"
-              style="flex: 1;"
+              class="range-input"
               .value=${keyPoint[1].toString()}
               @input=${(e: Event) =>
                 this.handleKeyPointChange(series, 1, parseFloat((e.target as HTMLInputElement).value))}
@@ -131,21 +134,21 @@ export class DxThemeEditor extends LitElement {
               min="0"
               max="0.3"
               step="0.01"
-              style="width: 80px;"
+              class="number-input"
               .value=${keyPoint[1].toString()}
               @input=${(e: Event) =>
                 this.handleKeyPointChange(series, 1, parseFloat((e.target as HTMLInputElement).value))}
             />
           </div>
 
-          <div class="control-row" style="display: flex; align-items: center; margin-bottom: 0.5rem; gap: 0.5rem;">
-            <label style="min-width: 180px;">Hue (0-360):</label>
+          <div class="control-row">
+            <label class="control-label">Hue (0-360):</label>
             <input
               type="range"
               min="0"
               max="360"
               step="1"
-              style="flex: 1;"
+              class="range-input"
               .value=${keyPoint[2].toString()}
               @input=${(e: Event) =>
                 this.handleKeyPointChange(series, 2, parseFloat((e.target as HTMLInputElement).value))}
@@ -155,7 +158,7 @@ export class DxThemeEditor extends LitElement {
               min="0"
               max="360"
               step="1"
-              style="width: 80px;"
+              class="number-input"
               .value=${keyPoint[2].toString()}
               @input=${(e: Event) =>
                 this.handleKeyPointChange(series, 2, parseFloat((e.target as HTMLInputElement).value))}
@@ -163,17 +166,17 @@ export class DxThemeEditor extends LitElement {
           </div>
         </div>
 
-        <div class="control-group" style="margin-bottom: 1.5rem;">
-          <h4 style="margin-top: 0; margin-bottom: 0.5rem;">Control Points</h4>
+        <div class="control-group">
+          <h4 class="control-group-title">Control Points</h4>
 
-          <div class="control-row" style="display: flex; align-items: center; margin-bottom: 0.5rem; gap: 0.5rem;">
-            <label style="min-width: 180px;">Light Control Point (0-1):</label>
+          <div class="control-row">
+            <label class="control-label">Light Control Point (0-1):</label>
             <input
               type="range"
               min="0"
               max="1"
               step="0.01"
-              style="flex: 1;"
+              class="range-input"
               .value=${lowerCp.toString()}
               @input=${(e: Event) =>
                 this.handleControlPointChange(series, 'lowerCp', parseFloat((e.target as HTMLInputElement).value))}
@@ -183,21 +186,21 @@ export class DxThemeEditor extends LitElement {
               min="0"
               max="1"
               step="0.01"
-              style="width: 80px;"
+              class="number-input"
               .value=${lowerCp.toString()}
               @input=${(e: Event) =>
                 this.handleControlPointChange(series, 'lowerCp', parseFloat((e.target as HTMLInputElement).value))}
             />
           </div>
 
-          <div class="control-row" style="display: flex; align-items: center; margin-bottom: 0.5rem; gap: 0.5rem;">
-            <label style="min-width: 180px;">Dark Control Point (0-1):</label>
+          <div class="control-row">
+            <label class="control-label">Dark Control Point (0-1):</label>
             <input
               type="range"
               min="0"
               max="1"
               step="0.01"
-              style="flex: 1;"
+              class="range-input"
               .value=${upperCp.toString()}
               @input=${(e: Event) =>
                 this.handleControlPointChange(series, 'upperCp', parseFloat((e.target as HTMLInputElement).value))}
@@ -207,7 +210,7 @@ export class DxThemeEditor extends LitElement {
               min="0"
               max="1"
               step="0.01"
-              style="width: 80px;"
+              class="number-input"
               .value=${upperCp.toString()}
               @input=${(e: Event) =>
                 this.handleControlPointChange(series, 'upperCp', parseFloat((e.target as HTMLInputElement).value))}
@@ -215,17 +218,17 @@ export class DxThemeEditor extends LitElement {
           </div>
         </div>
 
-        <div class="control-group" style="margin-bottom: 1rem;">
-          <h4 style="margin-top: 0; margin-bottom: 0.5rem;">Torsion</h4>
+        <div class="control-group">
+          <h4 class="control-group-title">Torsion</h4>
 
-          <div class="control-row" style="display: flex; align-items: center; margin-bottom: 0.5rem; gap: 0.5rem;">
-            <label style="min-width: 180px;">Torsion (-180 to 180):</label>
+          <div class="control-row">
+            <label class="control-label">Torsion (-180 to 180):</label>
             <input
               type="range"
               min="-180"
               max="180"
               step="1"
-              style="flex: 1;"
+              class="range-input"
               .value=${torsion.toString()}
               @input=${(e: Event) => this.handleTorsionChange(series, parseFloat((e.target as HTMLInputElement).value))}
             />
@@ -234,7 +237,7 @@ export class DxThemeEditor extends LitElement {
               min="-180"
               max="180"
               step="1"
-              style="width: 80px;"
+              class="number-input"
               .value=${torsion.toString()}
               @input=${(e: Event) => this.handleTorsionChange(series, parseFloat((e.target as HTMLInputElement).value))}
             />
@@ -246,12 +249,12 @@ export class DxThemeEditor extends LitElement {
 
   override render() {
     return html`
-      <div style="font-family: system-ui, sans-serif; padding: 1rem; max-width: 800px; margin: 0 auto;">
+      <div class="theme-editor-container">
         <h2>Theme Editor</h2>
 
         ${bindSeriesDefinitions.map(
           (series) => html`
-            <div style="margin-bottom: 2rem; padding: 1rem; border: 1px solid #ccc; border-radius: 4px;">
+            <div class="series-container">
               ${this.renderSeriesControls(series)}
             </div>
           `,

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
@@ -27,7 +27,7 @@ export class DxThemeEditor extends LitElement {
         <div class="tabs-container" role="tablist">
           <button
             id="tab-physical"
-            class=${classMap({ 'tab': true, 'active': this.activeTab === 'physical' })}
+            class=${classMap({ tab: true, active: this.activeTab === 'physical' })}
             role="tab"
             aria-selected=${this.activeTab === 'physical'}
             aria-controls="panel-physical"
@@ -37,7 +37,7 @@ export class DxThemeEditor extends LitElement {
           </button>
           <button
             id="tab-semantic"
-            class=${classMap({ 'tab': true, 'active': this.activeTab === 'semantic' })}
+            class=${classMap({ tab: true, active: this.activeTab === 'semantic' })}
             role="tab"
             aria-selected=${this.activeTab === 'semantic'}
             aria-controls="panel-semantic"
@@ -46,20 +46,20 @@ export class DxThemeEditor extends LitElement {
             Semantic
           </button>
         </div>
-        
-        <div 
+
+        <div
           id="panel-physical"
-          class=${classMap({ 'tab-panel': true, 'active': this.activeTab === 'physical' })}
+          class=${classMap({ 'tab-panel': true, active: this.activeTab === 'physical' })}
           role="tabpanel"
           aria-labelledby="tab-physical"
           ?hidden=${this.activeTab !== 'physical'}
         >
           <dx-theme-editor-physical-colors></dx-theme-editor-physical-colors>
         </div>
-        
-        <div 
+
+        <div
           id="panel-semantic"
-          class=${classMap({ 'tab-panel': true, 'active': this.activeTab === 'semantic' })}
+          class=${classMap({ 'tab-panel': true, active: this.activeTab === 'semantic' })}
           role="tabpanel"
           aria-labelledby="tab-semantic"
           ?hidden=${this.activeTab !== 'semantic'}

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
@@ -2,6 +2,7 @@
 // Copyright 2025 DXOS.org
 //
 
+import { cssGradientFromCurve, helicalArcFromConfig } from '@ch-ui/colors';
 import { type ResolvedHelicalArcSeries, type TokenSet } from '@ch-ui/tokens';
 import { LitElement, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
@@ -10,6 +11,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { debounce } from '@dxos/async';
 
 import { restore, saveAndRender } from './util';
+
 import './dx-theme-editor.pcss';
 
 export type DxThemeEditorProps = {};
@@ -117,9 +119,6 @@ export class DxThemeEditor extends LitElement {
     const upperCp = seriesData.upperCp || 0;
     const torsion = seriesData.torsion || 0;
 
-    // Create a color preview based on the keyPoint
-    const previewColor = `oklch(${keyPoint[0]} ${keyPoint[1]} ${keyPoint[2]})`;
-
     // Create unique IDs for headings to reference in aria-labelledby
     const keyColorHeadingId = `${series}-key-color-heading`;
     const controlPointsHeadingId = `${series}-control-points-heading`;
@@ -127,28 +126,23 @@ export class DxThemeEditor extends LitElement {
 
     return html`
       <div class="series-controls">
+        <div
+          class="series-preview"
+          style=${styleMap({
+            backgroundImage: cssGradientFromCurve(helicalArcFromConfig(seriesData), 21, [0, 1], 'p3'),
+          })}
+        ></div>
         <div class="series-header">
           <h3 class="series-title">${series} Series</h3>
-          <div class="color-preview" style=${styleMap({ backgroundColor: previewColor })}></div>
         </div>
 
         <div class="control-group">
           <h4 id="${keyColorHeadingId}" class="control-group-title">Key Color</h4>
-
           ${this.renderControlRow(
-            'Lightness (0-1)',
+            'Chroma (0-0.5)',
             0,
-            1,
-            0.01,
-            keyPoint[0],
-            (e: Event) => this.handleKeyPointChange(series, 0, parseFloat((e.target as HTMLInputElement).value)),
-            keyColorHeadingId,
-          )}
-          ${this.renderControlRow(
-            'Chroma (0-0.3)',
-            0,
-            0.3,
-            0.01,
+            0.5,
+            0.0025,
             keyPoint[1],
             (e: Event) => this.handleKeyPointChange(series, 1, parseFloat((e.target as HTMLInputElement).value)),
             keyColorHeadingId,
@@ -157,7 +151,7 @@ export class DxThemeEditor extends LitElement {
             'Hue (0-360)',
             0,
             360,
-            1,
+            0.5,
             keyPoint[2],
             (e: Event) => this.handleKeyPointChange(series, 2, parseFloat((e.target as HTMLInputElement).value)),
             keyColorHeadingId,
@@ -168,16 +162,6 @@ export class DxThemeEditor extends LitElement {
           <h4 id="${controlPointsHeadingId}" class="control-group-title">Control Points</h4>
 
           ${this.renderControlRow(
-            'Light Control Point (0-1)',
-            0,
-            1,
-            0.01,
-            lowerCp,
-            (e: Event) =>
-              this.handleControlPointChange(series, 'lowerCp', parseFloat((e.target as HTMLInputElement).value)),
-            controlPointsHeadingId,
-          )}
-          ${this.renderControlRow(
             'Dark Control Point (0-1)',
             0,
             1,
@@ -185,6 +169,16 @@ export class DxThemeEditor extends LitElement {
             upperCp,
             (e: Event) =>
               this.handleControlPointChange(series, 'upperCp', parseFloat((e.target as HTMLInputElement).value)),
+            controlPointsHeadingId,
+          )}
+          ${this.renderControlRow(
+            'Light Control Point (0-1)',
+            0,
+            1,
+            0.01,
+            lowerCp,
+            (e: Event) =>
+              this.handleControlPointChange(series, 'lowerCp', parseFloat((e.target as HTMLInputElement).value)),
             controlPointsHeadingId,
           )}
         </div>
@@ -196,7 +190,7 @@ export class DxThemeEditor extends LitElement {
             'Torsion (-180 to 180)',
             -180,
             180,
-            1,
+            0.5,
             torsion,
             (e: Event) => this.handleTorsionChange(series, parseFloat((e.target as HTMLInputElement).value)),
             torsionHeadingId,
@@ -209,8 +203,7 @@ export class DxThemeEditor extends LitElement {
   override render() {
     return html`
       <div class="theme-editor-container">
-        <h2>Theme Editor</h2>
-
+        <h2>Physical series</h2>
         ${bindSeriesDefinitions.map(
           (series) => html` <div class="series-container">${this.renderSeriesControls(series)}</div> `,
         )}

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
@@ -6,6 +6,7 @@ import { cssGradientFromCurve, helicalArcFromConfig } from '@ch-ui/colors';
 import { type ResolvedHelicalArcSeries, type TokenSet } from '@ch-ui/tokens';
 import { LitElement, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { debounce } from '@dxos/async';
@@ -76,34 +77,37 @@ export class DxThemeEditor extends LitElement {
     value: string | number,
     onInput: (e: Event) => void,
     headingId: string,
+    variant?: 'reverse',
   ) {
     const controlId = `${headingId}-${label.toLowerCase().replace(/[^a-z0-9]/g, '-')}`;
 
     return html`
       <div class="control-row">
         <label class="control-label" id="${controlId}-label" for="${controlId}-range">${label}:</label>
-        <input
-          id="${controlId}-range"
-          type="range"
-          min="${min}"
-          max="${max}"
-          step="${step}"
-          class="range-input"
-          .value=${value.toString()}
-          @input=${onInput}
-          aria-labelledby="${headingId} ${controlId}-label"
-        />
-        <input
-          id="${controlId}-number"
-          type="number"
-          min="${min}"
-          max="${max}"
-          step="${step}"
-          class="number-input"
-          .value=${value.toString()}
-          @input=${onInput}
-          aria-labelledby="${headingId} ${controlId}-label"
-        />
+        <div class="${classMap({ 'control-inputs': true, reverse: variant === 'reverse' })}">
+          <input
+            id="${controlId}-range"
+            type="range"
+            min="${min}"
+            max="${max}"
+            step="${step}"
+            class="range-input"
+            .value=${value.toString()}
+            @input=${onInput}
+            aria-labelledby="${headingId} ${controlId}-label"
+          />
+          <input
+            id="${controlId}-number"
+            type="number"
+            min="${min}"
+            max="${max}"
+            step="${step}"
+            class="number-input"
+            .value=${value.toString()}
+            @input=${onInput}
+            aria-labelledby="${headingId} ${controlId}-label"
+          />
+        </div>
       </div>
     `;
   }
@@ -132,35 +136,29 @@ export class DxThemeEditor extends LitElement {
             backgroundImage: cssGradientFromCurve(helicalArcFromConfig(seriesData), 21, [0, 1], 'p3'),
           })}
         ></div>
-        <div class="series-header">
-          <h3 class="series-title">${series} Series</h3>
-        </div>
+        <h3 class="series-title">${series} Series</h3>
+
+        ${this.renderControlRow(
+          'Chroma (0-0.5)',
+          0,
+          0.5,
+          0.0025,
+          keyPoint[1],
+          (e: Event) => this.handleKeyPointChange(series, 1, parseFloat((e.target as HTMLInputElement).value)),
+          keyColorHeadingId,
+          'reverse',
+        )}
+        ${this.renderControlRow(
+          'Hue (0-360)',
+          0,
+          360,
+          0.5,
+          keyPoint[2],
+          (e: Event) => this.handleKeyPointChange(series, 2, parseFloat((e.target as HTMLInputElement).value)),
+          keyColorHeadingId,
+        )}
 
         <div class="control-group">
-          <h4 id="${keyColorHeadingId}" class="control-group-title">Key Color</h4>
-          ${this.renderControlRow(
-            'Chroma (0-0.5)',
-            0,
-            0.5,
-            0.0025,
-            keyPoint[1],
-            (e: Event) => this.handleKeyPointChange(series, 1, parseFloat((e.target as HTMLInputElement).value)),
-            keyColorHeadingId,
-          )}
-          ${this.renderControlRow(
-            'Hue (0-360)',
-            0,
-            360,
-            0.5,
-            keyPoint[2],
-            (e: Event) => this.handleKeyPointChange(series, 2, parseFloat((e.target as HTMLInputElement).value)),
-            keyColorHeadingId,
-          )}
-        </div>
-
-        <div class="control-group">
-          <h4 id="${controlPointsHeadingId}" class="control-group-title">Control Points</h4>
-
           ${this.renderControlRow(
             'Dark Control Point (0-1)',
             0,
@@ -183,19 +181,15 @@ export class DxThemeEditor extends LitElement {
           )}
         </div>
 
-        <div class="control-group">
-          <h4 id="${torsionHeadingId}" class="control-group-title">Torsion</h4>
-
-          ${this.renderControlRow(
-            'Torsion (-180 to 180)',
-            -180,
-            180,
-            0.5,
-            torsion,
-            (e: Event) => this.handleTorsionChange(series, parseFloat((e.target as HTMLInputElement).value)),
-            torsionHeadingId,
-          )}
-        </div>
+        ${this.renderControlRow(
+          'Torsion (-180 to 180)',
+          -180,
+          180,
+          0.5,
+          torsion,
+          (e: Event) => this.handleTorsionChange(series, parseFloat((e.target as HTMLInputElement).value)),
+          torsionHeadingId,
+        )}
       </div>
     `;
   }

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
@@ -91,7 +91,7 @@ export class DxThemeEditor extends LitElement {
             min="${min}"
             max="${max}"
             step="${step}"
-            class="range-input"
+            class="range-input dx-focus-ring"
             .value=${value.toString()}
             @input=${onInput}
             aria-labelledby="${headingId} ${controlId}-label"
@@ -102,7 +102,7 @@ export class DxThemeEditor extends LitElement {
             min="${min}"
             max="${max}"
             step="${step}"
-            class="number-input"
+            class="number-input dx-focus-ring"
             .value=${value.toString()}
             @input=${onInput}
             aria-labelledby="${headingId} ${controlId}-label"

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/dx-theme-editor.ts
@@ -77,14 +77,14 @@ export class DxThemeEditor extends LitElement {
     value: string | number,
     onInput: (e: Event) => void,
     headingId: string,
-    variant?: 'reverse',
+    variant?: 'reverse-range' | 'reverse-order',
   ) {
     const controlId = `${headingId}-${label.toLowerCase().replace(/[^a-z0-9]/g, '-')}`;
 
     return html`
       <div class="control-row">
         <label class="control-label" id="${controlId}-label" for="${controlId}-range">${label}:</label>
-        <div class="${classMap({ 'control-inputs': true, reverse: variant === 'reverse' })}">
+        <div class="${classMap({ 'control-inputs': true, ...(variant && { [variant]: true }) })}">
           <input
             id="${controlId}-range"
             type="range"
@@ -139,22 +139,30 @@ export class DxThemeEditor extends LitElement {
         <h3 class="series-title">${series} Series</h3>
 
         ${this.renderControlRow(
-          'Chroma (0-0.5)',
-          0,
-          0.5,
-          0.0025,
-          keyPoint[1],
-          (e: Event) => this.handleKeyPointChange(series, 1, parseFloat((e.target as HTMLInputElement).value)),
-          keyColorHeadingId,
-          'reverse',
-        )}
-        ${this.renderControlRow(
           'Hue (0-360)',
           0,
           360,
           0.5,
           keyPoint[2],
           (e: Event) => this.handleKeyPointChange(series, 2, parseFloat((e.target as HTMLInputElement).value)),
+          keyColorHeadingId,
+        )}
+        ${this.renderControlRow(
+          'Torsion (-180 to 180)',
+          -180,
+          180,
+          0.5,
+          torsion,
+          (e: Event) => this.handleTorsionChange(series, parseFloat((e.target as HTMLInputElement).value)),
+          torsionHeadingId,
+        )}
+        ${this.renderControlRow(
+          'Chroma (0-0.5)',
+          0,
+          0.5,
+          0.0025,
+          keyPoint[1],
+          (e: Event) => this.handleKeyPointChange(series, 1, parseFloat((e.target as HTMLInputElement).value)),
           keyColorHeadingId,
         )}
 
@@ -168,6 +176,7 @@ export class DxThemeEditor extends LitElement {
             (e: Event) =>
               this.handleControlPointChange(series, 'upperCp', parseFloat((e.target as HTMLInputElement).value)),
             controlPointsHeadingId,
+            'reverse-range',
           )}
           ${this.renderControlRow(
             'Light Control Point (0-1)',
@@ -178,18 +187,9 @@ export class DxThemeEditor extends LitElement {
             (e: Event) =>
               this.handleControlPointChange(series, 'lowerCp', parseFloat((e.target as HTMLInputElement).value)),
             controlPointsHeadingId,
+            'reverse-order',
           )}
         </div>
-
-        ${this.renderControlRow(
-          'Torsion (-180 to 180)',
-          -180,
-          180,
-          0.5,
-          torsion,
-          (e: Event) => this.handleTorsionChange(series, parseFloat((e.target as HTMLInputElement).value)),
-          torsionHeadingId,
-        )}
       </div>
     `;
   }

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/index.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+export * from './dx-theme-editor';

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/index.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/index.ts
@@ -2,4 +2,6 @@
 // Copyright 2025 DXOS.org
 //
 
+export * from './dx-theme-editor';
 export * from './dx-theme-editor-physical-colors';
+export * from './dx-theme-editor-semantic-colors';

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/index.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/index.ts
@@ -2,4 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-export * from './dx-theme-editor';
+export * from './dx-theme-editor-physical-colors';

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/util.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/util.ts
@@ -30,10 +30,10 @@ export const restore = () => {
 
 const styleNodeId = `${storageKey}/style`;
 
-export const saveAndRender = (value?: string) => {
+export const saveAndRender = (tokenSet?: TokenSet) => {
   let tokens = '';
   try {
-    const nextTokens = value ? JSON.parse(value) : restore();
+    const nextTokens = tokenSet ?? restore();
     localStorage.setItem(storageKey, JSON.stringify(nextTokens));
     tokens = `@layer user-tokens { ${renderTokenSet(nextTokens)} }`;
   } catch (err) {

--- a/packages/ui/lit-theme-editor/src/dx-theme-editor/util.ts
+++ b/packages/ui/lit-theme-editor/src/dx-theme-editor/util.ts
@@ -1,0 +1,57 @@
+//
+// Copyright 2025 DXOS.org
+//
+import { renderTokenSet, type TokenSet } from '@ch-ui/tokens';
+
+import { log } from '@dxos/log';
+import { userDefaultTokenSet } from '@dxos/react-ui-theme';
+
+const storageKey = 'dxos.org/dx-theme-editor/user-tokens';
+
+export const save = (value: string) => {
+  let nextValue = null;
+  try {
+    nextValue = JSON.stringify(JSON.parse(value));
+  } catch (err) {
+    log.warn('Invalid JSON', err);
+    return err;
+  }
+  if (nextValue) {
+    localStorage.setItem(storageKey, nextValue);
+    log.debug('Saved');
+    return null;
+  }
+};
+
+export const restore = () => {
+  const storedTokenSet = localStorage.getItem(storageKey);
+  return (storedTokenSet ? JSON.parse(storedTokenSet) : userDefaultTokenSet) as TokenSet;
+};
+
+const styleNodeId = `${storageKey}/style`;
+
+export const saveAndRender = (value?: string) => {
+  let tokens = '';
+  try {
+    const nextTokens = value ? JSON.parse(value) : restore();
+    localStorage.setItem(storageKey, JSON.stringify(nextTokens));
+    tokens = `@layer user-tokens { ${renderTokenSet(nextTokens)} }`;
+  } catch (err) {
+    return log.warn('Failed to render', err);
+  }
+  if (tokens) {
+    const styleNode = document.getElementById(styleNodeId);
+    if (styleNode) {
+      styleNode.textContent = tokens;
+    } else {
+      const newStyleNode = document.createElement('style');
+      newStyleNode.id = styleNodeId;
+      newStyleNode.textContent = tokens;
+      document.head.appendChild(newStyleNode);
+    }
+  }
+};
+
+export const reset = () => {
+  save(JSON.stringify(userDefaultTokenSet));
+};

--- a/packages/ui/lit-theme-editor/src/index.ts
+++ b/packages/ui/lit-theme-editor/src/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+export * from './dx-theme-editor';

--- a/packages/ui/lit-theme-editor/tsconfig.json
+++ b/packages/ui/lit-theme-editor/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "experimentalDecorators": true,
+    "types": [
+      "node"
+    ],
+    "useDefineForClassFields": false
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../../common/test-utils"
+    },
+    {
+      "path": "../primitives/react-hooks"
+    }
+  ]
+}

--- a/packages/ui/lit-theme-editor/tsconfig.json
+++ b/packages/ui/lit-theme-editor/tsconfig.json
@@ -18,7 +18,7 @@
       "path": "../../common/test-utils"
     },
     {
-      "path": "../primitives/react-hooks"
+      "path": "../lit-ui"
     }
   ]
 }

--- a/packages/ui/lit-theme-editor/tsconfig.json
+++ b/packages/ui/lit-theme-editor/tsconfig.json
@@ -24,6 +24,9 @@
       "path": "../lit-ui"
     },
     {
+      "path": "../primitives/react-hooks"
+    },
+    {
       "path": "../react-ui-theme"
     }
   ]

--- a/packages/ui/lit-theme-editor/tsconfig.json
+++ b/packages/ui/lit-theme-editor/tsconfig.json
@@ -15,10 +15,16 @@
   ],
   "references": [
     {
+      "path": "../../common/log"
+    },
+    {
       "path": "../../common/test-utils"
     },
     {
       "path": "../lit-ui"
+    },
+    {
+      "path": "../react-ui-theme"
     }
   ]
 }

--- a/packages/ui/react-ui-kanban/src/components/Kanban.tsx
+++ b/packages/ui/react-ui-kanban/src/components/Kanban.tsx
@@ -76,7 +76,7 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                 rail={false}
                 classNames={
                   /* NOTE(thure): Do not eliminate spacing here without ensuring this element will have a significant size, otherwise dropping items into an empty stack will be made difficult or impossible. See #9035. */
-                  'pbe-1 drag-preview-p-0'
+                  ['plb-1', cards.length > 0 && '-mlb-1']
                 }
                 onRearrange={model.handleRearrange}
                 itemsCount={cards.length}
@@ -85,7 +85,7 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                   <StackItem.Root
                     key={card.id}
                     item={card}
-                    classNames='contain-layout pli-2 drag-preview-p-0'
+                    classNames='contain-layout pli-2 plb-1 first:pbs-0 last:pbe-0'
                     focusIndicatorVariant='group'
                     onClick={() => select([card.id])}
                   >

--- a/packages/ui/react-ui-kanban/src/components/Kanban.tsx
+++ b/packages/ui/react-ui-kanban/src/components/Kanban.tsx
@@ -65,7 +65,7 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
             <div
               role='none'
               className={mx(
-                'shrink min-bs-0 bg-groupSurface rounded-lg grid dx-focus-ring-group-x-indicator',
+                'shrink min-bs-0 border border-separator bg-baseSurface rounded-lg grid dx-focus-ring-group-x-indicator',
                 railGridHorizontalContainFitContent,
               )}
             >
@@ -85,13 +85,13 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                   <StackItem.Root
                     key={card.id}
                     item={card}
-                    classNames={'contain-layout pli-2 drag-preview-p-0'}
+                    classNames='contain-layout pli-2 drag-preview-p-0'
                     focusIndicatorVariant='group'
                     onClick={() => select([card.id])}
                   >
                     <div
                       role='none'
-                      className='rounded overflow-hidden bg-baseSurface dx-focus-ring-group-y-indicator relative min-bs-[--rail-item]'
+                      className='rounded overflow-hidden bg-cardSurface dx-focus-ring-group-y-indicator relative min-bs-[--rail-item]'
                     >
                       <div role='none' className='flex items-center absolute block-start-0 inset-inline-0'>
                         <StackItem.DragHandle asChild>
@@ -128,12 +128,12 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                     icon='ph--plus--regular'
                     label={t('add card label')}
                     onClick={() => handleAddCard(columnValue)}
-                    classNames='is-full bg-baseSurface'
+                    classNames='is-full'
                   />
                 </div>
               )}
 
-              <StackItem.Heading classNames='pli-2 order-first bg-groupSurface rounded-t-md'>
+              <StackItem.Heading classNames='pli-2 order-first rounded-t-md bg-transparent'>
                 {!uncategorized && (
                   <StackItem.DragHandle asChild>
                     <IconButton

--- a/packages/ui/react-ui-kanban/src/components/Kanban.tsx
+++ b/packages/ui/react-ui-kanban/src/components/Kanban.tsx
@@ -75,8 +75,9 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                 size='contain'
                 rail={false}
                 classNames={
-                  /* NOTE(thure): Do not eliminate spacing here without ensuring this element will have a significant size, otherwise dropping items into an empty stack will be made difficult or impossible. See #9035. */
-                  ['plb-1', cards.length > 0 && '-mlb-1']
+                  /* NOTE(thure): Do not let this element have zero intrinsic size, otherwise dropping items into an
+                    empty stack will be made difficult or impossible. See #9035. */
+                  'plb-0 min-bs-2'
                 }
                 onRearrange={model.handleRearrange}
                 itemsCount={cards.length}
@@ -85,7 +86,7 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                   <StackItem.Root
                     key={card.id}
                     item={card}
-                    classNames='contain-layout pli-2 plb-1 first:pbs-0 last:pbe-0'
+                    classNames='contain-layout pli-2 plb-1 first-of-type:pbs-0 last-of-type:pbe-0'
                     focusIndicatorVariant='group'
                     onClick={() => select([card.id])}
                   >
@@ -100,6 +101,7 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                             icon='ph--dots-six-vertical--regular'
                             variant='ghost'
                             label={t('card drag handle label')}
+                            classNames='pli-2'
                           />
                         </StackItem.DragHandle>
                         <AttentionGlyph attended={selectedItems.has(card.id)} />

--- a/packages/ui/react-ui-theme/src/config/tokens/index.ts
+++ b/packages/ui/react-ui-theme/src/config/tokens/index.ts
@@ -55,7 +55,13 @@ const adapterConfig: TailwindAdapterConfig = {
 export const userDefaultTokenSet = {
   colors: {
     physical: {
-      definitions: physicalColors.definitions,
+      definitions: {
+        series: {
+          neutral: physicalColors.definitions!.series!.neutral,
+          primary: physicalColors.definitions!.series!.primary,
+        },
+        accompanyingSeries: physicalColors.definitions!.accompanyingSeries,
+      },
       conditions: physicalColors.conditions,
       series: {
         neutral: physicalColors.series.neutral,

--- a/packages/ui/react-ui-theme/src/config/tokens/physical-colors.ts
+++ b/packages/ui/react-ui-theme/src/config/tokens/physical-colors.ts
@@ -58,7 +58,10 @@ export const huePalettes = {
 };
 
 /**
- * The keyPoint represents the LCH value (Lightness: 0-1; Chroma: min 0, max 0.08–0.3 depending on hue; Hue: 0-360 [~26=Red, ~141=Green, ~262=Blue]).
+ * The keyPoint represents the LCH value:
+ * - Lightness: 0-1, should usually set the keyPoint at or near 0.5
+ * - Chroma: min 0, max 0.08–0.5 depending on hue and gamut, theme will clamp final value to within gamut’s range
+ * - Hue: 0-360 (~26 “red”, ~141 “green”, ~262 “blue”)
  *
  * NOTE: Rebuild the theme and restart the dev server to see changes.
  *
@@ -71,7 +74,7 @@ export const huePalettes = {
  */
 const systemPalettes = {
   neutral: {
-    keyPoint: [0, 0.01, 260],
+    keyPoint: [0.5, 0.01, 260],
     lowerCp: 0,
     upperCp: 0,
     torsion: 0,

--- a/packages/ui/react-ui-theme/src/config/tokens/sememes-system.ts
+++ b/packages/ui/react-ui-theme/src/config/tokens/sememes-system.ts
@@ -198,7 +198,7 @@ const aliasDefs: Record<string, { root?: SememeName; attention?: SememeName }> =
   // Base surface for text (e.g., Document, Table, Sheet.)
   baseSurface: { root: 'surface-20', attention: 'surface-0' },
 
-  // Forms, cards, etc.
+  // Currented / selected items, other surfaces needing special contrast against baseSurface. TODO(thure): Rename.
   groupSurface: { root: 'surface-50', attention: 'surface-40' },
 
   // Main sidebar panel.
@@ -209,6 +209,9 @@ const aliasDefs: Record<string, { root?: SememeName; attention?: SememeName }> =
 
   // Plank header.
   headerSurface: { root: 'surface-30', attention: 'surface-20' },
+
+  // Forms, cards, etc.
+  cardSurface: { root: 'surface-30', attention: 'surface-20' },
 
   // Toolbars, table/sheet headers, etc.
   toolbarSurface: { root: 'surface-30', attention: 'surface-20' },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11299,6 +11299,9 @@ importers:
       '@dxos/log':
         specifier: workspace:*
         version: link:../../common/log
+      '@dxos/react-hooks':
+        specifier: workspace:*
+        version: link:../primitives/react-hooks
       '@dxos/react-ui-theme':
         specifier: workspace:*
         version: link:../react-ui-theme

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11287,6 +11287,9 @@ importers:
 
   packages/ui/lit-theme-editor:
     dependencies:
+      '@ch-ui/colors':
+        specifier: 1.2.0
+        version: 1.2.0
       '@ch-ui/tokens':
         specifier: 2.4.0
         version: 2.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.5.17
-        version: 0.5.17(@cloudflare/workers-types@4.20241022.0)(@vitest/runner@3.1.3)(@vitest/snapshot@3.1.3)(vitest@3.1.3)
+        version: 0.5.17(@cloudflare/workers-types@4.20241022.0)(@vitest/runner@3.1.3)(@vitest/snapshot@3.1.3)(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
       '@cloudflare/workers-types':
         specifier: ^4.20241018.0
         version: 4.20241022.0
@@ -105,7 +105,7 @@ importers:
         version: link:packages/common/typings
       '@effect/vitest':
         specifier: ~0.17.3
-        version: 0.17.8(effect@3.14.21)(vitest@3.1.3)
+        version: 0.17.8(effect@3.14.21)(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
       '@mdx-js/react':
         specifier: ^2.1.3
         version: 2.1.5(react@18.2.0)
@@ -123,13 +123,13 @@ importers:
         version: 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))
       '@nx/playwright':
         specifier: 19.7.2
-        version: 19.7.2(@babel/traverse@7.25.9)(@playwright/test@1.46.1)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(@zkochan/js-yaml@0.0.7)(esbuild@0.23.1)(eslint@8.57.0)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3)
+        version: 19.7.2(@babel/traverse@7.25.9)(@playwright/test@1.46.1)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(@zkochan/js-yaml@0.0.7)(esbuild@0.23.1)(eslint@8.57.0)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
       '@nx/storybook':
         specifier: 19.7.2
         version: 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)
       '@nx/vite':
         specifier: 19.7.2
-        version: 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3)
+        version: 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
       '@nx/web':
         specifier: 19.7.2
         version: 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)
@@ -225,7 +225,7 @@ importers:
         version: 3.1.3(playwright@1.46.1)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3)(webdriverio@8.33.1(encoding@0.1.13)(typescript@5.8.3))
       '@vitest/coverage-v8':
         specifier: ^3.1.1
-        version: 3.1.3(@vitest/browser@3.1.3)(vitest@3.1.3)
+        version: 3.1.3(@vitest/browser@3.1.3(playwright@1.46.1)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3)(webdriverio@8.33.1(encoding@0.1.13)(typescript@5.8.3)))(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
       '@vitest/expect':
         specifier: ^3.1.1
         version: 3.1.3
@@ -4712,7 +4712,7 @@ importers:
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.5.17
-        version: 0.5.17(@cloudflare/workers-types@4.20241022.0)(@vitest/runner@3.1.3)(@vitest/snapshot@3.1.3)(vitest@3.1.3)
+        version: 0.5.17(@cloudflare/workers-types@4.20241022.0)(@vitest/runner@3.1.3)(@vitest/snapshot@3.1.3)(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
       '@cloudflare/workers-types':
         specifier: ^4.20241018.0
         version: 4.20241022.0
@@ -11277,6 +11277,19 @@ importers:
       '@atlaskit/pragmatic-drag-and-drop':
         specifier: ^1.4.0
         version: 1.4.0
+      lit:
+        specifier: ^3.2.0
+        version: 3.2.0
+    devDependencies:
+      '@dxos/test-utils':
+        specifier: workspace:*
+        version: link:../../common/test-utils
+
+  packages/ui/lit-theme-editor:
+    dependencies:
+      '@dxos/lit-ui':
+        specifier: workspace:*
+        version: link:../lit-ui
       lit:
         specifier: ^3.2.0
         version: 3.2.0
@@ -38100,7 +38113,7 @@ snapshots:
     dependencies:
       mime: 3.0.0
 
-  '@cloudflare/vitest-pool-workers@0.5.17(@cloudflare/workers-types@4.20241022.0)(@vitest/runner@3.1.3)(@vitest/snapshot@3.1.3)(vitest@3.1.3)':
+  '@cloudflare/vitest-pool-workers@0.5.17(@cloudflare/workers-types@4.20241022.0)(@vitest/runner@3.1.3)(@vitest/snapshot@3.1.3)(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))':
     dependencies:
       '@vitest/runner': 3.1.3
       '@vitest/snapshot': 3.1.3
@@ -38602,7 +38615,7 @@ snapshots:
       effect: 3.14.21
       fast-check: 3.23.1
 
-  '@effect/vitest@0.17.8(effect@3.14.21)(vitest@3.1.3)':
+  '@effect/vitest@0.17.8(effect@3.14.21)(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))':
     dependencies:
       effect: 3.14.21
       vitest: 3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2)
@@ -40261,9 +40274,9 @@ snapshots:
       - '@swc/core'
       - debug
 
-  '@nrwl/vite@19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3)':
+  '@nrwl/vite@19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))':
     dependencies:
-      '@nx/vite': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3)
+      '@nx/vite': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -40564,12 +40577,12 @@ snapshots:
   '@nx/nx-win32-x64-msvc@19.7.2':
     optional: true
 
-  '@nx/playwright@19.7.2(@babel/traverse@7.25.9)(@playwright/test@1.46.1)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(@zkochan/js-yaml@0.0.7)(esbuild@0.23.1)(eslint@8.57.0)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3)':
+  '@nx/playwright@19.7.2(@babel/traverse@7.25.9)(@playwright/test@1.46.1)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(@zkochan/js-yaml@0.0.7)(esbuild@0.23.1)(eslint@8.57.0)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))':
     dependencies:
       '@nx/devkit': 19.7.2(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))
       '@nx/eslint': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))
       '@nx/js': 19.7.2(patch_hash=mavp33mumclr54vvfyyf557nvq)(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)
-      '@nx/vite': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3)
+      '@nx/vite': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
       '@nx/webpack': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(esbuild@0.23.1)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
       minimatch: 9.0.3
@@ -40636,9 +40649,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3)':
+  '@nx/vite@19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))':
     dependencies:
-      '@nrwl/vite': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3)
+      '@nrwl/vite': 19.7.2(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))
       '@nx/devkit': 19.7.2(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))
       '@nx/js': 19.7.2(patch_hash=mavp33mumclr54vvfyyf557nvq)(@babel/traverse@7.25.9)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@22.10.2)(nx@19.7.2(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@swc/types@0.1.5)(typescript@5.8.3))(@swc/core@1.5.7(@swc/helpers@0.5.17)))(typescript@5.8.3)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
@@ -46147,7 +46160,7 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/coverage-v8@3.1.3(@vitest/browser@3.1.3)(vitest@3.1.3)':
+  '@vitest/coverage-v8@3.1.3(@vitest/browser@3.1.3(playwright@1.46.1)(vite@5.4.7(patch_hash=i2cyw7vpoo7fbe7qgy5pwsznyq)(@types/node@22.10.2)(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))(vitest@3.1.3)(webdriverio@8.33.1(encoding@0.1.13)(typescript@5.8.3)))(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.1.3)(@vitest/ui@3.1.3)(happy-dom@13.3.4)(jsdom@24.0.0(canvas@2.11.2(encoding@0.1.13)))(less@4.1.3)(sass@1.70.0)(stylus@0.59.0)(terser@5.19.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11287,9 +11287,18 @@ importers:
 
   packages/ui/lit-theme-editor:
     dependencies:
+      '@ch-ui/tokens':
+        specifier: 2.4.0
+        version: 2.4.0
       '@dxos/lit-ui':
         specifier: workspace:*
         version: link:../lit-ui
+      '@dxos/log':
+        specifier: workspace:*
+        version: link:../../common/log
+      '@dxos/react-ui-theme':
+        specifier: workspace:*
+        version: link:../react-ui-theme
       lit:
         specifier: ^3.2.0
         version: 3.2.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -754,6 +754,11 @@
         },
         {
           "type": "json",
+          "path": "packages/ui/lit-theme-editor/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "packages/ui/lit-ui/package.json",
           "jsonpath": "$.version"
         },

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -433,6 +433,9 @@
       "path": "packages/ui/lit-grid/tsconfig.json"
     },
     {
+      "path": "packages/ui/lit-theme-editor/tsconfig.json"
+    },
+    {
       "path": "packages/ui/lit-ui/tsconfig.json"
     },
     {


### PR DESCRIPTION
This PR:
- increments `Kanban`’s color token application
- adds a semantic token `cardSurface`, initially equivalent to `headerSurface`, for patterns which should be raised subtly against `baseSurface`
- begins fleshing-out low-level componentry for adjusting token values in Storybooks and possibly Composer as well

https://github.com/user-attachments/assets/4e534b2d-857c-48a0-b156-c907c3fe4e0f
