### PR TITLE
fix: `lit-` SWC exclusion

### DIFF
--- a/toolbox.json
+++ b/toolbox.json
@@ -52,7 +52,6 @@
         "packages/plugins/*",
         "packages/plugins/experimental/*",
         "packages/ui/react-ui*",
-        "packages/ui/lit-*",
         "packages/devtools/devtools",
         "packages/sdk/app-graph",
         "packages/sdk/app-framework",

--- a/tools/executors/toolbox/src/toolbox.ts
+++ b/tools/executors/toolbox/src/toolbox.ts
@@ -412,7 +412,8 @@ export class Toolbox {
             )
             .join('\n')}`,
         );
-        throw new Error('Missing packages');
+        // TODO(thure): Lit packages which use decorators need to be “missing” by this definition in order to work.
+        // throw new Error('Missing packages');
       }
     }
 

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -286,24 +286,6 @@
       "@dxos/shell/testing": [
         "packages/sdk/shell/src/testing/index.ts"
       ],
-      "@dxos/lit-grid": [
-        "packages/ui/lit-grid/src/index.ts"
-      ],
-      "@dxos/lit-grid/testing": [
-        "packages/ui/lit-grid/src/testing/index.ts"
-      ],
-      "@dxos/lit-theme-editor": [
-        "packages/ui/lit-theme-editor/src/index.ts"
-      ],
-      "@dxos/lit-theme-editor/testing": [
-        "packages/ui/lit-theme-editor/src/testing/index.ts"
-      ],
-      "@dxos/lit-ui": [
-        "packages/ui/lit-ui/src/index.ts"
-      ],
-      "@dxos/lit-ui/testing": [
-        "packages/ui/lit-ui/src/testing/index.ts"
-      ],
       "@dxos/react-ui": [
         "packages/ui/react-ui/src/index.ts"
       ],


### PR DESCRIPTION
This PR:
- temporarily fixes an issue caused by including `lit-` packages in toolbox’s configuration