### PR TITLE
feat: Hide focus

### DIFF
--- a/packages/plugins/plugin-deck/src/capabilities/settings.ts
+++ b/packages/plugins/plugin-deck/src/capabilities/settings.ts
@@ -11,6 +11,7 @@ import { DeckSettingsSchema, type DeckSettingsProps } from '../types';
 export default () => {
   const settings = live<DeckSettingsProps>({
     showHints: false,
+    hideFocus: true,
     enableDeck: false,
     enableStatusbar: false,
     enableNativeRedirect: false,

--- a/packages/plugins/plugin-deck/src/capabilities/settings.ts
+++ b/packages/plugins/plugin-deck/src/capabilities/settings.ts
@@ -11,7 +11,7 @@ import { DeckSettingsSchema, type DeckSettingsProps } from '../types';
 export default () => {
   const settings = live<DeckSettingsProps>({
     showHints: false,
-    hideFocus: true,
+    hideFocus: false,
     enableDeck: false,
     enableStatusbar: false,
     enableNativeRedirect: false,

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/DeckLayout.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/DeckLayout.tsx
@@ -102,6 +102,10 @@ export const DeckLayout = ({ onDismissToast }: DeckLayoutProps) => {
     }
   }, [settings.enableDeck, dispatch, active, layoutMode]);
 
+  useEffect(() => {
+    document.body.setAttribute('data-focus', settings.hideFocus ? 'hidden' : 'normal');
+  }, [settings.hideFocus]);
+
   /**
    * Clear scroll restoration state if the window is resized
    */

--- a/packages/plugins/plugin-deck/src/components/DeckSettings/DeckSettings.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckSettings/DeckSettings.tsx
@@ -26,6 +26,9 @@ export const DeckSettings = ({ settings }: { settings: DeckSettingsProps }) => {
       <DeprecatedFormInput label={t('settings enable deck label')}>
         <Input.Switch checked={settings.enableDeck} onCheckedChange={(checked) => (settings.enableDeck = checked)} />
       </DeprecatedFormInput>
+      <DeprecatedFormInput label={t('settings hidden focus label')}>
+        <Input.Switch checked={settings.hideFocus} onCheckedChange={(checked) => (settings.hideFocus = checked)} />
+      </DeprecatedFormInput>
       <DeprecatedFormInput label={t('select new plank positioning label')}>
         <Select.Root
           disabled={!settings.enableDeck}

--- a/packages/plugins/plugin-deck/src/translations.ts
+++ b/packages/plugins/plugin-deck/src/translations.ts
@@ -57,6 +57,7 @@ export default [
         'settings overscroll none label': 'None',
         'settings enable statusbar label': 'Show status bar',
         'settings enable deck label': 'Enable Deck',
+        'settings hidden focus label': 'Hide focus indicators and suppress tooltips on focused elements',
         'close current label': 'Close current plank',
         'close others label': 'Close other planks',
         'close all label': 'Close all planks',

--- a/packages/plugins/plugin-deck/src/types.ts
+++ b/packages/plugins/plugin-deck/src/types.ts
@@ -27,6 +27,7 @@ export type ResolvedPart = Part | 'solo-primary' | 'solo-companion';
 export const DeckSettingsSchema = Schema.Struct({
   showHints: Schema.optional(Schema.Boolean),
   enableDeck: Schema.optional(Schema.Boolean),
+  hideFocus: Schema.optional(Schema.Boolean),
   enableStatusbar: Schema.optional(Schema.Boolean),
   enableNativeRedirect: Schema.optional(Schema.Boolean),
   newPlankPositioning: Schema.optional(Schema.Literal(...NewPlankPositions)),

--- a/packages/ui/react-ui-theme/src/styles/layers/focus-ring.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/focus-ring.css
@@ -8,7 +8,9 @@
 
       &:focus-visible {
         @apply ring-focusLine ring-offset-focusOffset z-[1] ring-accentFocusIndicator;
-
+        body[data-focus="hidden"] & {
+          @apply ring-transparent;
+        }
         &:hover {
           @apply outline-none;
 
@@ -33,6 +35,9 @@
   .dx-focus-ring-group-x:focus-visible .dx-focus-ring-group-x-indicator,
   .dx-focus-ring-group-y:focus-visible .dx-focus-ring-group-y-indicator {
     @apply ring-focusLine ring-offset-focusOffset ring-accentFocusIndicator;
+    body[data-focus="hidden"] & {
+      @apply ring-transparent;
+    }
 
     &:hover {
       @apply outline-none;
@@ -67,6 +72,9 @@
       &:focus-visible {
         &::after {
           @apply ring-focusLine ring-offset-focusOffset ring-inset z-[1] ring-accentFocusIndicator;
+          body[data-focus="hidden"] & {
+            @apply ring-transparent;
+          }
         }
 
         &:hover {

--- a/packages/ui/react-ui-theme/src/styles/layers/focus-ring.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/focus-ring.css
@@ -72,9 +72,9 @@
       &:focus-visible {
         &::after {
           @apply ring-focusLine ring-offset-focusOffset ring-inset z-[1] ring-accentFocusIndicator;
-          body[data-focus="hidden"] & {
-            @apply ring-transparent;
-          }
+        }
+        body[data-focus="hidden"] &::after {
+          @apply ring-transparent;
         }
 
         &:hover {

--- a/packages/ui/react-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/react-ui/src/components/Tooltip/Tooltip.tsx
@@ -321,7 +321,7 @@ const TooltipTrigger = forwardRef<TooltipTriggerElement, TooltipTriggerProps>(
             }
             if (suppressNextTooltip?.current) {
               suppressNextTooltip.current = false;
-            } else {
+            } else if (document.body.getAttribute('data-focus') !== 'hidden') {
               context.onTriggerChange(ref.current);
               context.onOpen();
             }


### PR DESCRIPTION
This PR:
- adds a setting in DeckPlugin for “hiding focus”
- when focus is “hidden”, focus rings are transparent and tooltip triggers do not react to focus events
- this is meant to address broader concerns about focus mentioned in #9153

https://github.com/user-attachments/assets/646c8b4e-95a8-4e4f-86d1-cd3a9de83eb7
