### PR TITLE
Remove @dxos/echo-db dependency from @dxos/echo package

### DIFF
--- a/packages/core/echo/echo/package.json
+++ b/packages/core/echo/echo/package.json
@@ -22,7 +22,6 @@
   ],
   "dependencies": {
     "@dxos/debug": "workspace:*",
-    "@dxos/echo-db": "workspace:*",
     "@dxos/echo-protocol": "workspace:*",
     "@dxos/echo-schema": "workspace:*",
     "@dxos/echo-signals": "workspace:*",

--- a/packages/core/echo/echo/src/type/Obj.ts
+++ b/packages/core/echo/echo/src/type/Obj.ts
@@ -2,9 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
-import { type AnyLiveObject as AnyLiveObject$ } from '@dxos/echo-db';
 import { type BaseEchoObject, type BaseObject, getSchema as getSchema$ } from '@dxos/echo-schema';
-import { live as live$ } from '@dxos/live-object';
+import { type Live, live as live$ } from '@dxos/live-object';
+
+type AnyLiveObject$<T extends BaseObject> = Live<T> & BaseEchoObject;
 
 // TODO(burdon): Remove from Type?
 

--- a/packages/core/echo/echo/src/type/Type.ts
+++ b/packages/core/echo/echo/src/type/Type.ts
@@ -4,7 +4,7 @@
 
 import { type Schema } from 'effect';
 
-import { type AnyLiveObject as AnyLiveObject$ } from '@dxos/echo-db';
+import { type Live } from '@dxos/live-object';
 import {
   type BaseEchoObject,
   type BaseObject,
@@ -31,6 +31,8 @@ import {
 import { invariant } from '@dxos/invariant';
 import { SpaceId as SpaceId$ } from '@dxos/keys';
 import { live as live$ } from '@dxos/live-object';
+
+type AnyLiveObject$<T extends BaseObject> = Live<T> & BaseEchoObject;
 
 /**
  * Type System API.


### PR DESCRIPTION
Removes the @dxos/echo-db dependency from the @dxos/echo package by replacing AnyLiveObject imports with local type definitions using components from @dxos/live-object and @dxos/echo-schema.

Fixes #9271

Generated with [Claude Code](https://claude.ai/code)