### PR TITLE
feat(react-ui-kanban): Better column drop element

### DIFF
--- a/packages/ui/react-ui-kanban/src/components/Kanban.tsx
+++ b/packages/ui/react-ui-kanban/src/components/Kanban.tsx
@@ -23,6 +23,10 @@ export type KanbanProps<T extends BaseKanbanItem = { id: string }> = {
   onRemoveCard?: (card: T) => void;
 };
 
+const getColumnDropElement = (stackElement: HTMLDivElement) => {
+  return stackElement.closest('.kanban-drop') as HTMLDivElement;
+};
+
 export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
   const { t } = useTranslation(translationKey);
   const { select, clear } = useSelectionActions([model.id, getTypename(model.schema)!]);
@@ -69,7 +73,7 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
             <div
               role='none'
               className={mx(
-                'shrink min-bs-0 border border-separator bg-baseSurface rounded-lg grid dx-focus-ring-group-x-indicator',
+                'shrink min-bs-0 border border-separator bg-baseSurface rounded-lg grid dx-focus-ring-group-x-indicator kanban-drop',
                 railGridHorizontalContainFitContent,
               )}
             >
@@ -79,12 +83,12 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                 size='contain'
                 rail={false}
                 classNames={
-                  /* NOTE(thure): Do not let this element have zero intrinsic size, otherwise dropping items into an
-                    empty stack will be made difficult or impossible. See #9035. */
+                  /* NOTE(thure): Do not let this element have zero intrinsic size, otherwise the drop indicator will not display. See #9035. */
                   ['plb-1', cards.length > 0 && 'plb-2 relative -block-start-1 z-[1] -mbe-1']
                 }
                 onRearrange={model.handleRearrange}
                 itemsCount={cards.length}
+                getDropElement={getColumnDropElement}
               >
                 {cards.map((card, cardIndex, cardsArray) => (
                   <StackItem.Root

--- a/packages/ui/react-ui-stack/src/components/Stack/Stack.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack/Stack.tsx
@@ -17,7 +17,10 @@ export type Orientation = 'horizontal' | 'vertical';
 export type Size = 'intrinsic' | 'contain' | 'contain-fit-content';
 
 export type StackProps = Omit<ThemedClassName<ComponentPropsWithRef<'div'>>, 'aria-orientation'> &
-  Partial<StackContextValue> & { itemsCount?: number };
+  Partial<StackContextValue> & {
+    itemsCount?: number;
+    getDropElement?: (stackElement: HTMLDivElement) => HTMLDivElement;
+  };
 
 export const railGridHorizontal = 'grid-rows-[[rail-start]_var(--rail-size)_[content-start]_1fr_[content-end]]';
 export const railGridVertical = 'grid-cols-[[rail-start]_var(--rail-size)_[content-start]_1fr_[content-end]]';
@@ -41,6 +44,7 @@ export const Stack = forwardRef<HTMLDivElement, StackProps>(
       size = 'intrinsic',
       onRearrange,
       itemsCount = Children.count(children),
+      getDropElement,
       ...props
     },
     forwardedRef,
@@ -59,7 +63,7 @@ export const Stack = forwardRef<HTMLDivElement, StackProps>(
 
     const { dropping } = useStackDropForElements({
       id: props.id,
-      element: stackElement,
+      element: getDropElement && stackElement ? getDropElement(stackElement) : stackElement,
       selfDroppable,
       orientation,
       onRearrange,


### PR DESCRIPTION
This PR:
- makes the entire Kanban column the drop element

https://github.com/user-attachments/assets/7e4d579c-5ddf-4b53-b602-acd8e46c1de0
