### PR TITLE
feat: Theme increment

### DIFF
--- a/packages/plugins/plugin-deck/src/components/Plank/PlankHeading.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/PlankHeading.tsx
@@ -150,13 +150,13 @@ export const PlankHeading = memo(
     return (
       <StackItem.Heading
         classNames={[
-          'plb-1 border-be border-separator items-stretch gap-1 sticky inline-start-12 app-drag min-is-0 contain-layout',
+          'plb-1 border-be border-subduedSeparator items-stretch gap-1 sticky inline-start-12 app-drag min-is-0 contain-layout',
           part === 'solo' ? soloInlinePadding : 'pli-1',
           ...(layoutMode === 'solo--fullscreen'
             ? [
                 hoverableControls,
                 hoverableFocusedWithinControls,
-                '[&>*]:transition-opacity [&>*]:opacity-[--controls-opacity] bg-transparent border-transparent transition-[background-color,border-color] hover-hover:hover:bg-headerSurface focus-within:bg-headerSurface hover-hover:hover:border-separator focus-within:border-separator',
+                '[&>*]:transition-opacity [&>*]:opacity-[--controls-opacity] bg-transparent border-transparent transition-[background-color,border-color] hover-hover:hover:bg-headerSurface focus-within:bg-headerSurface hover-hover:hover:border-subduedSeparator focus-within:border-subduedSeparator',
               ]
             : []),
         ]}

--- a/packages/plugins/plugin-deck/src/components/Sidebar/ComplementarySidebar.tsx
+++ b/packages/plugins/plugin-deck/src/components/Sidebar/ComplementarySidebar.tsx
@@ -90,7 +90,7 @@ export const ComplementarySidebar = ({ current }: ComplementarySidebarProps) => 
       <Tabs.Root orientation='vertical' verticalVariant='stateless' value={internalValue} classNames='contents'>
         <div
           role='none'
-          className='absolute z-[1] inset-block-0 inline-end-0 !is-[--r0-size] pbs-[env(safe-area-inset-top)] pbe-[env(safe-area-inset-bottom)] border-is border-separator grid grid-cols-1 grid-rows-[1fr_min-content] bg-baseSurface contain-layout app-drag'
+          className='absolute z-[1] inset-block-0 inline-end-0 !is-[--r0-size] pbs-[env(safe-area-inset-top)] pbe-[env(safe-area-inset-bottom)] border-is border-subduedSeparator grid grid-cols-1 grid-rows-[1fr_min-content] bg-baseSurface contain-layout app-drag'
         >
           <Tabs.Tablist classNames='grid grid-cols-1 auto-rows-[--rail-action] p-1 gap-1 !overflow-y-auto'>
             {companions.map((companion) => (
@@ -169,7 +169,7 @@ const ComplementarySidebarPanel = ({ companion, activeId, data, hoistStatusbar }
 
   return (
     <>
-      <h2 className='flex items-center pli-2 border-separator border-be font-medium'>
+      <h2 className='flex items-center pli-2 border-subduedSeparator border-be font-medium'>
         {toLocalizedString(companion.properties.label, t)}
       </h2>
       <Wrapper>
@@ -183,7 +183,7 @@ const ComplementarySidebarPanel = ({ companion, activeId, data, hoistStatusbar }
       {!hoistStatusbar && (
         <div
           role='contentinfo'
-          className='flex flex-wrap justify-center items-center border-bs border-separator pbs-1 pbe-[max(env(safe-area-inset-bottom),0.25rem)]'
+          className='flex flex-wrap justify-center items-center border-bs border-subduedSeparator pbs-1 pbe-[max(env(safe-area-inset-bottom),0.25rem)]'
         >
           <Surface role='status-bar--r1-footer' limit={1} />
         </div>

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L0Menu.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L0Menu.tsx
@@ -319,7 +319,7 @@ export const L0Menu = ({ menuActions, topLevelItems, pinnedItems, userAccountIte
       classNames={[
         'group/l0 absolute z-[1] inset-block-0 inline-start-0 rounded-is-lg',
         'grid grid-cols-[var(--l0-size)] grid-rows-[var(--rail-size)_1fr_min-content_var(--l0-size)] gap-1 contain-layout',
-        '!is-[--l0-size] bg-baseSurface border-ie border-separator app-drag pbe-[env(safe-area-inset-bottom)]',
+        '!is-[--l0-size] bg-baseSurface border-ie border-subduedSeparator app-drag pbe-[env(safe-area-inset-bottom)]',
       ]}
     >
       <div role='none' className='flex justify-center p-1'>

--- a/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
+++ b/packages/plugins/plugin-navtree/src/components/Sidebar/L1Panel.tsx
@@ -83,7 +83,7 @@ const L1Panel = ({ open, item, path, currentItemId, onBack }: L1PanelProps) => {
     >
       {item.id === currentItemId && (
         <>
-          <h2 className='flex items-center border-be border-separator app-drag pli-1'>
+          <h2 className='flex items-center border-be border-subduedSeparator app-drag pli-1'>
             {backCapable ? (
               <TitleButton title={title} onClick={handleBack} />
             ) : (

--- a/packages/plugins/plugin-sheet/src/components/FunctionEditor/FunctionEditor.tsx
+++ b/packages/plugins/plugin-sheet/src/components/FunctionEditor/FunctionEditor.tsx
@@ -26,7 +26,7 @@ export const FunctionEditor = () => {
   }
 
   return (
-    <div className='flex shrink-0 justify-between items-center px-4 py-1 text-sm bg-toolbarSurface border-bs !border-separator'>
+    <div className='flex shrink-0 justify-between items-center px-4 py-1 text-sm bg-toolbarSurface border-bs !border-subduedSeparator'>
       <div className='flex gap-4 items-center'>
         <div className='flex w-16 items-center font-mono'>
           {(range && rangeToA1Notation(range)) || (cursor && addressToA1Notation(cursor))}

--- a/packages/plugins/plugin-space/src/components/PopoverRenameObject.tsx
+++ b/packages/plugins/plugin-space/src/components/PopoverRenameObject.tsx
@@ -41,7 +41,7 @@ export const PopoverRenameObject = ({ object: obj }: { object: Live<any> }) => {
   }, [object, name]);
 
   return (
-    <div role='none' className='p-1 flex gap-2'>
+    <div role='none' className='p-2 flex gap-2'>
       <div role='none' className='flex-1'>
         <Input.Root>
           <Input.Label srOnly>{t('object name label')}</Input.Label>

--- a/packages/plugins/plugin-space/src/components/PopoverRenameSpace.tsx
+++ b/packages/plugins/plugin-space/src/components/PopoverRenameSpace.tsx
@@ -30,7 +30,7 @@ export const PopoverRenameSpace = ({ space }: { space: Space }) => {
 
   // TODO(thure): Why does the input value need to be uncontrolled to work?
   return (
-    <div role='none' className='p-1 flex gap-2'>
+    <div role='none' className='p-2 flex gap-2'>
       <div role='none' className='flex-1'>
         <Input.Root>
           <Input.Label srOnly>{t('space name label')}</Input.Label>

--- a/packages/ui/react-ui-editor/src/defaults.ts
+++ b/packages/ui/react-ui-editor/src/defaults.ts
@@ -49,6 +49,6 @@ export const stackItemContentEditorClassNames = (role?: string) =>
 
 export const stackItemContentToolbarClassNames = (role?: string) =>
   mx(
-    'relative z-[1] flex is-full bg-toolbarSurface border-be border-separator',
+    'relative z-[1] flex is-full bg-toolbarSurface border-be border-subduedSeparator',
     role === 'section' && 'sticky block-start-0 -mbe-px min-is-0',
   );

--- a/packages/ui/react-ui-theme/src/config/tailwind.ts
+++ b/packages/ui/react-ui-theme/src/config/tailwind.ts
@@ -41,6 +41,13 @@ export const tailwindConfig = ({
           containerMaxWidth: 'var(--dx-containerMaxWidth)',
           popoverMaxWidth: 'var(--dx-popoverMaxWidth)',
         },
+        borderRadius: {
+          none: '0',
+          sm: '0.25rem',
+          DEFAULT: '0.5rem',
+          md: '.75rem',
+          lg: '1rem',
+        },
         screens: {
           'pointer-fine': { raw: '(pointer: fine)' },
           'hover-hover': { raw: '(hover: hover)' },

--- a/packages/ui/react-ui-theme/src/config/tokens/sememes-system.ts
+++ b/packages/ui/react-ui-theme/src/config/tokens/sememes-system.ts
@@ -194,8 +194,12 @@ export const systemSememes = {
     dark: ['primary', 350],
   },
   neutralFocusIndicator: {
-    light: ['neutral', 350],
+    light: ['neutral', 300],
     dark: ['neutral', 450],
+  },
+  accentFocusIndicator: {
+    light: ['primary', 300],
+    dark: ['primary', 450],
   },
   accentSurfaceText: {
     light: ['neutral', 0],

--- a/packages/ui/react-ui-theme/src/config/tokens/sememes-system.ts
+++ b/packages/ui/react-ui-theme/src/config/tokens/sememes-system.ts
@@ -36,26 +36,36 @@ const applyAlpha = (sememe: Sememe, alpha: number): Sememe => {
 // Both elevation cadences go from darker to lighter from “elevation” 0 to `ELEVATION_SCALE`,
 // whereas both contrast cadences go from highest contrast at 0 to lowest contrast at `CONTRAST_SCALE`.
 
-const DARK_ELEVATION = 850;
-const DARK_TRANSITION = 750;
-const DARK_CONTRAST = 500;
+const DARK_ELEVATION_MIN = 855;
+const DARK_ELEVATION_MAX = 731;
 
-const LIGHT_ELEVATION = 10;
-const LIGHT_TRANSITION = 80;
-const LIGHT_CONTRAST = 450;
+const DARK_CONTRAST_MIN = 750;
+const DARK_CONTRAST_MAX = 665;
 
-const ELEVATION_SCALE = 3;
-const CONTRAST_SCALE = 4;
+const LIGHT_ELEVATION_MIN = 0;
+const LIGHT_ELEVATION_MAX = 0;
+
+const LIGHT_CONTRAST_MIN = 82;
+const LIGHT_CONTRAST_MAX = 24;
+
+const ELEVATION_SCALE = 2;
+const CONTRAST_SCALE = 3;
 
 const darkElevationCadence = (depth: number) =>
-  Math.round(DARK_TRANSITION + (DARK_ELEVATION - DARK_TRANSITION) * ((ELEVATION_SCALE - depth) / ELEVATION_SCALE));
+  Math.round(
+    DARK_ELEVATION_MAX + (DARK_ELEVATION_MIN - DARK_ELEVATION_MAX) * ((ELEVATION_SCALE - depth) / ELEVATION_SCALE),
+  );
 const darkContrastCadence = (depth: number) =>
-  Math.round(DARK_CONTRAST + (DARK_TRANSITION - DARK_CONTRAST) * ((ELEVATION_SCALE - depth) / ELEVATION_SCALE));
+  Math.round(
+    DARK_CONTRAST_MAX + (DARK_CONTRAST_MIN - DARK_CONTRAST_MAX) * ((ELEVATION_SCALE - depth) / ELEVATION_SCALE),
+  );
 
 const lightElevationCadence = (depth: number) =>
-  Math.round(LIGHT_ELEVATION + (LIGHT_TRANSITION - LIGHT_ELEVATION) * ((CONTRAST_SCALE - depth) / CONTRAST_SCALE));
+  Math.round(
+    LIGHT_ELEVATION_MIN + (LIGHT_ELEVATION_MAX - LIGHT_ELEVATION_MIN) * ((CONTRAST_SCALE - depth) / CONTRAST_SCALE),
+  );
 const lightContrastCadence = (depth: number) =>
-  Math.round(LIGHT_TRANSITION + (LIGHT_CONTRAST - LIGHT_TRANSITION) * (depth / CONTRAST_SCALE));
+  Math.round(LIGHT_CONTRAST_MAX + (LIGHT_CONTRAST_MIN - LIGHT_CONTRAST_MAX) * (depth / CONTRAST_SCALE));
 
 const elevationCadence = (lightDepth: number, darkDepth: number = lightDepth, alpha: number = 1): Sememe =>
   applyAlpha(
@@ -79,33 +89,51 @@ export const systemSememes = {
   //
   // Elevation cadence tokens
   //
-  rootSurface: elevationCadence(0),
-  baseSurface: elevationCadence(1),
-  groupSurface: elevationCadence(2),
-  modalSurface: elevationCadence(3),
+  baseSurface: elevationCadence(0),
+  groupSurface: elevationCadence(1),
+  modalSurface: elevationCadence(2),
 
   //
   // Contrast cadence tokens
   //
 
-  hoverSurfaceBase: contrastCadence(1.1, 0.7),
-  hoverSurfaceGroup: contrastCadence(0.9, 0.9),
-  hoverSurfaceModal: contrastCadence(0.7, 1.3),
+  textInputSurfaceBase: contrastCadence(0, 0),
+  textInputSurfaceGroup: contrastCadence(0, 0.5),
+  textInputSurfaceModal: contrastCadence(0, 1),
 
-  inputSurfaceBase: contrastCadence(0.7, 0.3),
-  inputSurfaceGroup: contrastCadence(0.5, 0.5),
-  inputSurfaceModal: contrastCadence(0.3, 0.9),
+  inputSurfaceBase: contrastCadence(1, 0.5),
+  inputSurfaceGroup: contrastCadence(1, 1),
+  inputSurfaceModal: contrastCadence(1, 1.5),
 
-  unAccent: contrastCadence(3),
-  unAccentHover: contrastCadence(4),
-  hoverOverlay: contrastCadence(4, 4, 0.1),
+  hoverSurfaceBase: contrastCadence(2, 1.5),
+  hoverSurfaceGroup: contrastCadence(2, 2),
+  hoverSurfaceModal: contrastCadence(2, 2.5),
+
+  separatorBase: contrastCadence(3, 2),
+  separatorGroup: contrastCadence(3, 2.5),
+  separatorModal: contrastCadence(3, 3),
+
+  subduedSeparator: contrastCadence(1, 1),
+
+  unAccent: {
+    light: ['neutral', 400],
+    dark: ['neutral', 400],
+  },
+  unAccentHover: {
+    light: ['neutral', 450],
+    dark: ['neutral', 450],
+  },
+  hoverOverlay: {
+    light: ['neutral', '450/.1'],
+    dark: ['neutral', '450/.1'],
+  },
 
   //
   // Special surfaces.
   //
 
   // Screen overlay for modal dialogs.
-  scrimSurface: applyAlpha({ light: ['neutral', LIGHT_CONTRAST], dark: ['neutral', DARK_ELEVATION] }, 0.65),
+  scrimSurface: applyAlpha({ light: ['neutral', LIGHT_CONTRAST_MAX], dark: ['neutral', DARK_ELEVATION_MIN] }, 0.65),
 
   // High contrast for focused interactive elements. (Technically this is part of the surface cadence, but the contrast cadence is on the opposite side of the elevation cadence as this point.)
   focusSurface: {
@@ -115,8 +143,8 @@ export const systemSememes = {
 
   // For tooltips only; the highest elevation from the opposite theme
   inverseSurface: {
-    light: ['neutral', DARK_ELEVATION],
-    dark: ['neutral', LIGHT_ELEVATION],
+    light: ['neutral', DARK_ELEVATION_MIN],
+    dark: ['neutral', LIGHT_ELEVATION_MIN],
   },
 
   //
@@ -182,17 +210,16 @@ type SememeName = keyof typeof systemSememes;
  */
 const aliasDefs: Record<string, Record<string, SememeName>> = {
   // The background color appearing in overscroll and between planks when Deck is enabled.
-  deckSurface: { root: 'rootSurface' },
+  deckSurface: { root: 'groupSurface' },
 
   // Secondary aliases
+  textInputSurface: { root: 'textInputSurfaceBase', group: 'textInputSurfaceGroup', modal: 'textInputSurfaceModal' },
   inputSurface: { root: 'inputSurfaceBase', group: 'inputSurfaceGroup', modal: 'inputSurfaceModal' },
   hoverSurface: { root: 'hoverSurfaceBase', group: 'hoverSurfaceGroup', modal: 'hoverSurfaceModal' },
+  separator: { root: 'separatorBase', group: 'separatorGroup', modal: 'separatorModal' },
 
   // Selected items, current items, other surfaces needing special contrast against baseSurface.
   activeSurface: { root: 'inputSurface' as any /* TODO(thure): strongly type secondary aliases. */ },
-
-  // Hovered items
-  separator: { root: 'hoverSurface' as any /* TODO(thure): strongly type secondary aliases. */ },
 
   // Main sidebar panel.
   sidebarSurface: { root: 'groupSurface' },

--- a/packages/ui/react-ui-theme/src/styles/components/input.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/input.ts
@@ -54,9 +54,9 @@ export const warningInputValence = 'shadow-amber-500/50 dark:shadow-amber-600/50
 export const errorInputValence = 'shadow-rose-500/50 dark:shadow-rose-600/50';
 
 const textInputSurfaceFocus =
-  'transition-colors bg-transparent focus:bg-focusSurface border border-inputSurface focus:border-transparent';
+  'transition-colors bg-textInputSurface focus:bg-focusSurface border border-separator focus:border-separator';
 
-const textInputSurfaceHover = 'hover:bg-hoverSurface focus:hover:bg-focusSurface';
+const textInputSurfaceHover = 'hover:bg-textInputSurface focus:hover:bg-focusSurface';
 
 const booleanInputSurface =
   'shadow-inner transition-colors bg-unAccent aria-checked:bg-accentSurface aria-[checked=mixed]:bg-accentSurface';

--- a/packages/ui/react-ui-theme/src/styles/components/menu.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/menu.ts
@@ -21,11 +21,11 @@ export type MenuStyleProps = Partial<{
 }>;
 
 export const menuViewport: ComponentFunction<MenuStyleProps> = (_props, ...etc) =>
-  mx('rounded-md p-1 max-bs-[--radix-dropdown-menu-content-available-height] overflow-y-auto', ...etc);
+  mx('rounded p-1 max-bs-[--radix-dropdown-menu-content-available-height] overflow-y-auto', ...etc);
 
 export const menuContent: ComponentFunction<MenuStyleProps> = ({ elevation }, ...etc) =>
   mx(
-    'is-48 rounded-md md:is-56 border border-separator',
+    'is-48 rounded md:is-56 border border-separator',
     surfaceZIndex({ elevation, level: 'menu' }),
     surfaceShadow({ elevation: 'positioned' }),
     modalSurface,

--- a/packages/ui/react-ui-theme/src/styles/components/popover.ts
+++ b/packages/ui/react-ui-theme/src/styles/components/popover.ts
@@ -15,7 +15,7 @@ export type PopoverStyleProps = Partial<{
 
 export const popoverViewport: ComponentFunction<PopoverStyleProps> = ({ constrainBlock, constrainInline }, ...etc) =>
   mx(
-    'rounded-lg',
+    'rounded-md',
     constrainBlock && 'max-bs-[--radix-popover-content-available-height] overflow-y-auto',
     constrainInline && 'max-is-[--radix-popover-content-available-width] overflow-x-auto',
     ...etc,
@@ -23,7 +23,7 @@ export const popoverViewport: ComponentFunction<PopoverStyleProps> = ({ constrai
 
 export const popoverContent: ComponentFunction<PopoverStyleProps> = ({ elevation }, ...etc) =>
   mx(
-    'border border-separator rounded-lg',
+    'border border-separator rounded-md',
     modalSurface,
     surfaceShadow({ elevation: 'positioned' }),
     surfaceZIndex({ elevation, level: 'menu' }),

--- a/packages/ui/react-ui-theme/src/styles/layers/checkbox.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/checkbox.css
@@ -6,7 +6,7 @@
     &[aria-checked='true'],
     &[aria-checked='mixed'],
     &:checked {
-      @apply bg-accentSurface accent-accentSurface;
+      @apply bg-accentSurface accent-accentSurface border-accentSurface;
     }
 
     &:not([disabled]),
@@ -16,7 +16,7 @@
         &[aria-checked='true'],
         &[aria-checked='mixed'],
         &:checked {
-          @apply bg-accentSurfaceHover accent-accentSurfaceHover;
+          @apply bg-accentSurfaceHover accent-accentSurfaceHover border-accentSurfaceHover;
         }
       }
     }

--- a/packages/ui/react-ui-theme/src/styles/layers/focus-ring.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/focus-ring.css
@@ -9,6 +9,10 @@
       &:focus-visible {
         @apply ring-focusLine ring-offset-focusOffset z-[1] ring-neutralFocusIndicator;
 
+        &[data-variant="primary"] {
+          @apply ring-accentFocusIndicator
+        }
+
         &:hover {
           @apply outline-none;
 
@@ -33,6 +37,10 @@
   .dx-focus-ring-group-x:focus-visible .dx-focus-ring-group-x-indicator,
   .dx-focus-ring-group-y:focus-visible .dx-focus-ring-group-y-indicator {
     @apply ring-focusLine ring-offset-focusOffset ring-neutralFocusIndicator;
+
+    &[data-variant="primary"] {
+      @apply ring-accentFocusIndicator
+    }
 
     &:hover {
       @apply outline-none;
@@ -67,6 +75,10 @@
       &:focus-visible {
         &::after {
           @apply ring-focusLine ring-offset-focusOffset ring-inset z-[1] ring-neutralFocusIndicator;
+        }
+
+        &[data-variant="primary"]::after {
+          @apply ring-accentFocusIndicator
         }
 
         &:hover {

--- a/packages/ui/react-ui-theme/src/styles/layers/main.css
+++ b/packages/ui/react-ui-theme/src/styles/layers/main.css
@@ -75,7 +75,7 @@
   .dx-main-sidebar {
     @apply fixed overscroll-contain overflow-x-hidden overflow-y-auto;
     @apply duration-200 ease-in-out-symmetric;
-    @apply border-landmarkLine border-separator rounded-lg;
+    @apply border-landmarkLine border-subduedSeparator rounded-lg;
     @apply sidebar-surface backdrop-blur-md dark:backdrop-blur-lg;
 
     transition-property: inset-inline-start, inset-inline-end, inline-size;
@@ -93,7 +93,7 @@
     }
 
     &[data-side="is"] {
-      @apply -inline-start-[100vw] border-ie-landmarkLine border-separator;
+      @apply -inline-start-[100vw] border-ie-landmarkLine border-subduedSeparator;
       z-index: 8;
 
       &[data-state="expanded"] {

--- a/packages/ui/react-ui/src/testing/decorators/withSurfaceVariantsLayout.tsx
+++ b/packages/ui/react-ui/src/testing/decorators/withSurfaceVariantsLayout.tsx
@@ -28,7 +28,7 @@ export const withSurfaceVariantsLayout = ({
           densities.map((density) => (
             <div
               key={`${elevation}--${density}`}
-              className={mx('p-4 mlb-4 rounded', surface, surfaceShadow({ elevation }))}
+              className={mx('p-4 mlb-4 rounded-md border border-separator', surface, surfaceShadow({ elevation }))}
             >
               <Story />
             </div>
@@ -40,7 +40,7 @@ export const withSurfaceVariantsLayout = ({
           densities.map((density) => (
             <div
               key={`${elevation}--${density}`}
-              className={mx('p-4 mlb-4 rounded', surface, surfaceShadow({ elevation }))}
+              className={mx('p-4 mlb-4 rounded-md border border-separator', surface, surfaceShadow({ elevation }))}
             >
               <Story />
             </div>


### PR DESCRIPTION
This PR:
- adjusts the neutral theme cadence to align with shadcn’s
- increases border radii, adds some padding where needed
- restores `subduedSeparator` as a distinct token
- restores `accentFocusIndicator` and applies to elements with `.dx-focus-ring*[data-variant='primary']`

<img width="963" alt="Screenshot 2025-06-12 at 15 53 18" src="https://github.com/user-attachments/assets/b830bf05-3283-4970-96c4-3e56913bde96" />
<img width="963" alt="Screenshot 2025-06-12 at 15 48 10" src="https://github.com/user-attachments/assets/78019b0b-7bf3-4dd3-a7b3-7332db909ddc" />
