### PR TITLE
fix: Neutral message color tokens

### DIFF
--- a/packages/ui/react-ui-theme/src/styles/fragments/valence.ts
+++ b/packages/ui/react-ui-theme/src/styles/fragments/valence.ts
@@ -24,7 +24,7 @@ export const valenceColorText = (valence?: MessageValence) => {
   }
 };
 
-export const neutralMessageColors = 'bg-neutral-25 dark:bg-neutral-850';
+export const neutralMessageColors = 'bg-activeSurface';
 export const successMessageColors = 'text-successSurfaceText bg-successSurface';
 export const infoMessageColors = 'text-infoSurfaceText bg-infoSurface';
 export const warningMessageColors = 'text-warningSurfaceText bg-warningSurface';

--- a/packages/ui/react-ui/src/components/Message/Message.stories.tsx
+++ b/packages/ui/react-ui/src/components/Message/Message.stories.tsx
@@ -37,7 +37,7 @@ export default {
 
 export const Default = {
   args: {
-    valence: 'error',
+    valence: 'neutral',
     title: 'Alert title',
     body: 'Alert content',
   },


### PR DESCRIPTION
This PR clears some design debt on neutral messages.

<img width="858" alt="Screenshot 2025-06-16 at 14 09 22" src="https://github.com/user-attachments/assets/cb088193-8e3e-4d52-8c00-9bc4aeddc299" />
<img width="858" alt="Screenshot 2025-06-16 at 14 09 17" src="https://github.com/user-attachments/assets/94685051-457c-40ee-8855-211924619b95" />
