### PR TITLE
fix: View editor layout

### DIFF
--- a/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
+++ b/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
@@ -255,14 +255,16 @@ export const ViewEditor = ({
       </div>
 
       {field && (
-        <FieldEditor
-          key={field.id}
-          view={view}
-          projection={projection}
-          field={field}
-          registry={registry}
-          onSave={handleClose}
-        />
+        <div role='none' className='p-2'>
+          <FieldEditor
+            key={field.id}
+            view={view}
+            projection={projection}
+            field={field}
+            registry={registry}
+            onSave={handleClose}
+          />
+        </div>
       )}
 
       {!readonly && !field && (


### PR DESCRIPTION
The field editor section wasn't getting any padding. Note, we don't apply padding at the container because we want the list items to be full bleed across the complementary sidebar.
