### PR TITLE
fix: navtree actions cleanup

### DIFF
--- a/packages/plugins/plugin-deck/src/components/Plank/PlankHeading.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/PlankHeading.tsx
@@ -94,7 +94,12 @@ export const PlankHeading = memo(
       } else if (variant) {
         return [];
       } else {
-        return [actions, graph.getActions(node.id)].filter((a) => a.length > 0);
+        return [
+          actions,
+          graph
+            .getActions(node.id)
+            .filter((a) => ['list-item', 'list-item-primary', 'heading-list-item'].includes(a.properties.disposition)),
+        ].filter((a) => a.length > 0);
       }
     }, [actions, node, variant, graph]);
 

--- a/packages/plugins/plugin-navtree/src/NavTreePlugin.tsx
+++ b/packages/plugins/plugin-navtree/src/NavTreePlugin.tsx
@@ -55,12 +55,17 @@ export const NavTreePlugin = () =>
     }),
     defineModule({
       id: `${meta.id}/module/expose`,
-      activatesOn: allOf(Events.DispatcherReady, Events.LayoutReady, NavTreeEvents.StateReady),
+      activatesOn: allOf(Events.DispatcherReady, Events.AppGraphReady, Events.LayoutReady, NavTreeEvents.StateReady),
       activate: async (context) => {
         const layout = context.getCapability(Capabilities.Layout);
         const { dispatchPromise: dispatch } = context.getCapability(Capabilities.IntentDispatcher);
+        const { graph } = context.getCapability(Capabilities.AppGraph);
         if (dispatch && layout.active.length === 1) {
-          await dispatch(createIntent(LayoutAction.Expose, { part: 'navigation', subject: layout.active[0] }));
+          // TODO(wittjosiah): This should really be fired once the navtree renders for the first time.
+          //   That is the point at which the graph is expanded and the path should be available.
+          void graph
+            .waitForPath({ target: layout.active[0] }, { timeout: 30_000 })
+            .then(() => dispatch(createIntent(LayoutAction.Expose, { part: 'navigation', subject: layout.active[0] })));
         }
 
         return [];

--- a/packages/plugins/plugin-navtree/src/components/NavTreeItem/NavTreeItemColumns.tsx
+++ b/packages/plugins/plugin-navtree/src/components/NavTreeItem/NavTreeItemColumns.tsx
@@ -27,7 +27,7 @@ export const NavTreeItemColumns = memo(({ path, item, open, density = 'fine' }: 
 
   const actions = (primaryAction?.properties?.disposition === 'list-item-primary' ? secondaryActions : _actions)
     .flatMap((action) => (isAction(action) ? [action] : []))
-    .filter((action) => !action.properties?.hidden);
+    .filter((a) => ['list-item', 'list-item-primary'].includes(a.properties?.disposition));
 
   const ActionRoot = popoverAnchorId === `dxos.org/ui/${NAV_TREE_ITEM}/${item.id}` ? Popover.Anchor : Fragment;
 

--- a/packages/plugins/plugin-space/src/util.tsx
+++ b/packages/plugins/plugin-space/src/util.tsx
@@ -382,10 +382,11 @@ export const constructObjectActions = ({
           { ns: SPACE_PLUGIN },
         ],
         icon: 'ph--pencil-simple-line--regular',
-        // TODO(wittjosiah): Need's focus.
-        keyBinding: {
-          macos: 'shift+F6',
-        },
+        disposition: 'list-item',
+        // TODO(wittjosiah): Not working.
+        // keyBinding: {
+        //   macos: 'shift+F6',
+        // },
         testId: 'spacePlugin.renameObject',
       },
     },
@@ -404,7 +405,9 @@ export const constructObjectActions = ({
           { ns: SPACE_PLUGIN },
         ],
         icon: 'ph--trash--regular',
-        keyBinding: object instanceof CollectionType ? undefined : 'shift+meta+Backspace',
+        disposition: 'list-item',
+        // TODO(wittjosiah): This is a browser shortcut.
+        // keyBinding: object instanceof CollectionType ? undefined : 'shift+meta+Backspace',
         testId: 'spacePlugin.deleteObject',
       },
     },
@@ -420,6 +423,7 @@ export const constructObjectActions = ({
             properties: {
               label: ['copy link label', { ns: SPACE_PLUGIN }],
               icon: 'ph--link--regular',
+              disposition: 'list-item',
               testId: 'spacePlugin.copyLink',
             },
           },
@@ -435,6 +439,7 @@ export const constructObjectActions = ({
       properties: {
         label: ['expose object label', { ns: SPACE_PLUGIN }],
         icon: 'ph--eye--regular',
+        disposition: 'heading-list-item',
         testId: 'spacePlugin.exposeObject',
       },
     },


### PR DESCRIPTION
- control which actions are shown where by disposition
- comment out non-functioning shortcuts
- fix expose of solo item on load