### PR TITLE
fix: Field editor `property` should validate correctly

### DIFF
--- a/packages/common/effect/src/jsonPath.ts
+++ b/packages/common/effect/src/jsonPath.ts
@@ -22,8 +22,8 @@ export const JsonPath = Schema.String.pipe(Schema.pattern(PATH_REGEX)).annotatio
 }) as any as Schema.Schema<JsonPath>;
 export const JsonProp = Schema.NonEmptyString.pipe(
   Schema.pattern(PROP_REGEX, {
-    message: () => 'Property name must contain only letters, numbers, and underscores'
-  })
+    message: () => 'Property name must contain only letters, numbers, and underscores',
+  }),
 ) as any as Schema.Schema<JsonProp>;
 
 export const isJsonPath = (value: unknown): value is JsonPath => {

--- a/packages/common/effect/src/jsonPath.ts
+++ b/packages/common/effect/src/jsonPath.ts
@@ -11,7 +11,7 @@ export type JsonProp = string & { __JsonPath: true; __JsonProp: true };
 export type JsonPath = string & { __JsonPath: true };
 
 const PATH_REGEX = /^($|[a-zA-Z_$][\w$]*(?:\.[a-zA-Z_$][\w$]*|\[\d+\](?:\.)?)*$)/;
-const PROP_REGEX = /\w+/;
+const PROP_REGEX = /^\w+$/;
 
 /**
  * https://www.ietf.org/archive/id/draft-goessner-dispatch-jsonpath-00.html
@@ -20,7 +20,11 @@ export const JsonPath = Schema.String.pipe(Schema.pattern(PATH_REGEX)).annotatio
   title: 'JSON path',
   description: 'JSON path to a property',
 }) as any as Schema.Schema<JsonPath>;
-export const JsonProp = Schema.NonEmptyString.pipe(Schema.pattern(PROP_REGEX)) as any as Schema.Schema<JsonProp>;
+export const JsonProp = Schema.NonEmptyString.pipe(
+  Schema.pattern(PROP_REGEX, {
+    message: () => 'Property name must contain only letters, numbers, and underscores'
+  })
+) as any as Schema.Schema<JsonProp>;
 
 export const isJsonPath = (value: unknown): value is JsonPath => {
   return Option.isSome(Schema.validateOption(JsonPath)(value));

--- a/packages/ui/react-ui-form/src/components/FieldEditor/FieldEditor.stories.tsx
+++ b/packages/ui/react-ui-form/src/components/FieldEditor/FieldEditor.stories.tsx
@@ -15,10 +15,8 @@ import { withLayout, withTheme } from '@dxos/storybook-utils';
 
 import { FieldEditor, type FieldEditorProps } from './FieldEditor';
 import translations from '../../translations';
-import { TestLayout, TestPanel } from '../testing';
+import { TestLayout, TestPanel, FIELD_EDITOR_DEBUG_SYMBOL } from '../testing';
 
-// Symbol for accessing debug objects in tests.
-export const FIELD_EDITOR_DEBUG_SYMBOL = Symbol('fieldEditorDebug');
 
 // Type definition for debug objects exposed to tests.
 export type FieldEditorDebugObjects = {

--- a/packages/ui/react-ui-form/src/components/FieldEditor/FieldEditor.stories.tsx
+++ b/packages/ui/react-ui-form/src/components/FieldEditor/FieldEditor.stories.tsx
@@ -17,7 +17,6 @@ import { FieldEditor, type FieldEditorProps } from './FieldEditor';
 import translations from '../../translations';
 import { TestLayout, TestPanel, FIELD_EDITOR_DEBUG_SYMBOL } from '../testing';
 
-
 // Type definition for debug objects exposed to tests.
 export type FieldEditorDebugObjects = {
   props: FieldEditorProps;

--- a/packages/ui/react-ui-form/src/components/FieldEditor/FieldEditor.test.tsx
+++ b/packages/ui/react-ui-form/src/components/FieldEditor/FieldEditor.test.tsx
@@ -9,7 +9,8 @@ import { afterEach, describe, expect, test } from 'vitest';
 import { ViewProjection } from '@dxos/schema';
 
 import * as stories from './FieldEditor.stories';
-import { FIELD_EDITOR_DEBUG_SYMBOL, type FieldEditorDebugObjects } from './FieldEditor.stories';
+import { FIELD_EDITOR_DEBUG_SYMBOL } from '../testing';
+import { type FieldEditorDebugObjects } from './FieldEditor.stories';
 
 const { Default } = composeStories(stories);
 

--- a/packages/ui/react-ui-form/src/components/FieldEditor/FieldEditor.test.tsx
+++ b/packages/ui/react-ui-form/src/components/FieldEditor/FieldEditor.test.tsx
@@ -9,8 +9,8 @@ import { afterEach, describe, expect, test } from 'vitest';
 import { ViewProjection } from '@dxos/schema';
 
 import * as stories from './FieldEditor.stories';
-import { FIELD_EDITOR_DEBUG_SYMBOL } from '../testing';
 import { type FieldEditorDebugObjects } from './FieldEditor.stories';
+import { FIELD_EDITOR_DEBUG_SYMBOL } from '../testing';
 
 const { Default } = composeStories(stories);
 

--- a/packages/ui/react-ui-form/src/components/testing.tsx
+++ b/packages/ui/react-ui-form/src/components/testing.tsx
@@ -22,3 +22,4 @@ export const TestPanel = ({ classNames, children }: ThemedClassName<PropsWithChi
 
 // Symbol for accessing debug objects in tests.
 export const VIEW_EDITOR_DEBUG_SYMBOL = Symbol('viewEditorDebug');
+export const FIELD_EDITOR_DEBUG_SYMBOL = Symbol('fieldEditorDebug');


### PR DESCRIPTION
- Resolves #9355
- Fixes `FieldEditor` stories