### PR TITLE
fix: Mailbox layout

### DIFF
--- a/packages/plugins/plugin-inbox/src/components/Mailbox/MailboxContainer.tsx
+++ b/packages/plugins/plugin-inbox/src/components/Mailbox/MailboxContainer.tsx
@@ -105,49 +105,41 @@ export const MailboxContainer = ({ mailbox }: MailboxContainerProps) => {
   );
 
   return (
-    <StackItem.Content classNames='relative' toolbar>
-      <div role='none' className={gridLayout}>
-        <ElevationProvider elevation='positioned'>
-          <MenuProvider {...menu} attendableId={id}>
-            <ToolbarMenu />
-          </MenuProvider>
-        </ElevationProvider>
+    <StackItem.Content classNames={['relative', gridLayout]} layoutManaged toolbar>
+      <ElevationProvider elevation='positioned'>
+        <MenuProvider {...menu} attendableId={id}>
+          <ToolbarMenu />
+        </MenuProvider>
+      </ElevationProvider>
 
-        {tagFilterVisible.value && (
-          <div role='none' className='pli-1 pbs-[1px] border-be bs-8 flex items-center border-separator'>
-            <Icon
-              role='presentation'
-              icon='ph--tag--bold'
-              classNames='mr-1 opacity-30'
-              aria-label='tags icon'
-              size={4}
-            />
-            <TagPicker
-              ref={tagPickerFocusRef}
-              items={tagPickerCurrentItems}
-              onUpdate={onTagPickerUpdate}
-              onSearch={(text, ids) =>
-                model.availableTags
-                  .filter((tag) => tag.label.toLowerCase().includes(text.toLowerCase()))
-                  .filter((tag) => !ids.includes(tag.label))
-                  .map((tag) => ({ id: tag.label, label: tag.label, hue: tag.hue as any }))
-              }
-            />
-          </div>
-        )}
-
-        {model.messages && model.messages.length > 0 ? (
-          <Mailbox
-            messages={model.messages}
-            id={id}
-            name={mailbox.name}
-            onAction={handleAction}
-            currentMessageId={currentMessageId}
+      {tagFilterVisible.value && (
+        <div role='none' className='pli-1 pbs-[1px] border-be bs-8 flex items-center border-separator'>
+          <Icon role='presentation' icon='ph--tag--bold' classNames='mr-1 opacity-30' aria-label='tags icon' size={4} />
+          <TagPicker
+            ref={tagPickerFocusRef}
+            items={tagPickerCurrentItems}
+            onUpdate={onTagPickerUpdate}
+            onSearch={(text, ids) =>
+              model.availableTags
+                .filter((tag) => tag.label.toLowerCase().includes(text.toLowerCase()))
+                .filter((tag) => !ids.includes(tag.label))
+                .map((tag) => ({ id: tag.label, label: tag.label, hue: tag.hue as any }))
+            }
           />
-        ) : (
-          <EmptyMailboxContent mailbox={mailbox} />
-        )}
-      </div>
+        </div>
+      )}
+
+      {model.messages && model.messages.length > 0 ? (
+        <Mailbox
+          messages={model.messages}
+          id={id}
+          name={mailbox.name}
+          onAction={handleAction}
+          currentMessageId={currentMessageId}
+        />
+      ) : (
+        <EmptyMailboxContent mailbox={mailbox} />
+      )}
     </StackItem.Content>
   );
 };

--- a/packages/ui/react-ui-stack/src/components/StackItem/StackItemContent.tsx
+++ b/packages/ui/react-ui-stack/src/components/StackItem/StackItemContent.tsx
@@ -22,6 +22,11 @@ export type StackItemContentProps = ThemedClassName<ComponentPropsWithoutRef<'di
   statusbar?: boolean;
 
   /**
+   * Whether the consumer intends to do something custom and typical affordances should not apply
+   */
+  layoutManaged?: boolean;
+
+  /**
    * Whether to set a certain aspect ratio on the content, including the toolbar and statusbar. This is provided for
    * convenience and consistency; it can instead be specified by the `classNames` or `style` props as needed.
    */
@@ -33,18 +38,21 @@ export type StackItemContentProps = ThemedClassName<ComponentPropsWithoutRef<'di
  * The `toolbar` flag must be provided since this component provides for the layout of content with the toolbar.
  */
 export const StackItemContent = forwardRef<HTMLDivElement, StackItemContentProps>(
-  ({ children, toolbar, statusbar, classNames, size = 'intrinsic', ...props }, forwardedRef) => {
+  ({ children, toolbar, statusbar, layoutManaged, classNames, size = 'intrinsic', ...props }, forwardedRef) => {
     const { size: stackItemSize } = useStack();
     const { role } = useStackItem();
     const style = useMemo(
-      () => ({
-        gridTemplateRows: [
-          ...(toolbar ? [role === 'section' ? 'calc(var(--rail-action) - 1px)' : 'var(--rail-action)'] : []),
-          '1fr',
-          ...(statusbar ? ['var(--statusbar-size)'] : []),
-        ].join(' '),
-      }),
-      [toolbar, statusbar],
+      () =>
+        layoutManaged
+          ? {}
+          : {
+              gridTemplateRows: [
+                ...(toolbar ? [role === 'section' ? 'calc(var(--rail-action) - 1px)' : 'var(--rail-action)'] : []),
+                '1fr',
+                ...(statusbar ? ['var(--statusbar-size)'] : []),
+              ].join(' '),
+            },
+      [toolbar, statusbar, layoutManaged],
     );
     return (
       <div


### PR DESCRIPTION
This PR:
- fixes Mailbox’s layout
- adds a `layoutManaged` flag to `StackItem.Content` in case the consumer will provide its own grid layout (as in this case)

<img width="539" alt="Screenshot 2025-06-30 at 18 20 25" src="https://github.com/user-attachments/assets/4cb5ffbf-d46a-46af-abc5-633b59315ec6" />
<img width="550" alt="Screenshot 2025-06-30 at 18 20 21" src="https://github.com/user-attachments/assets/0b174e62-64d9-4837-8d08-cf9357643463" />
