### PR TITLE
ci: tweak triggers

### DIFF
--- a/.github/workflows/check-buildjet.yml
+++ b/.github/workflows/check-buildjet.yml
@@ -1,7 +1,13 @@
 name: Check BuildJet
 
 on:
+  pull_request:
+  merge_group:
+
   push:
+    branches:
+      - main
+      - ci/*
 
   schedule:
     - cron: '0 4 * * 1-5'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,13 @@
 name: Check
 
 on:
+  pull_request:
+  merge_group:
+
   push:
+    branches:
+      - main
+      - ci/*
 
   schedule:
     - cron: '0 4 * * 1-5'

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,6 +1,7 @@
 on:
   pull_request_target:
     types: [edited, opened, synchronize, reopened]
+  merge_group:
 
 name: validate-pr-title
 
@@ -10,5 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v3.4.6
+        if: ${{ github.event_name == 'pull_request_target' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- don't run ci on all pushes to reduce the number of runs
- include merge_group trigger to allow for merge queue