### PR TITLE
refactor: Rename Card subcomponents

### DIFF
--- a/packages/plugins/plugin-markdown/src/components/MarkdownPreview/MarkdownPreview.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownPreview/MarkdownPreview.tsx
@@ -57,7 +57,7 @@ export const MarkdownPreview = ({ subject, role }: PreviewProps<DocumentType | D
   );
 
   return (
-    <Card.Container role={role}>
+    <Card.SurfaceRoot role={role}>
       <Card.Heading>{getTitle(subject, t('fallback title'))}</Card.Heading>
       {snippet && <Card.Text classNames='line-clamp-3 break-words col-span-2'>{snippet}</Card.Text>}
       <Card.Chrome>
@@ -66,6 +66,6 @@ export const MarkdownPreview = ({ subject, role }: PreviewProps<DocumentType | D
           <Icon icon='ph--arrow-right--regular' />
         </Button>
       </Card.Chrome>
-    </Card.Container>
+    </Card.SurfaceRoot>
   );
 };

--- a/packages/plugins/plugin-preview/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-preview/src/capabilities/react-surface.tsx
@@ -114,7 +114,7 @@ export default () =>
         }, []);
 
         return (
-          <Card.Container role={role}>
+          <Card.SurfaceRoot role={role}>
             <Form
               schema={schema}
               values={data.subject}
@@ -123,7 +123,7 @@ export default () =>
               autoSave
               {...(role === 'card--kanban' && { outerSpacing: 'blockStart-0' })}
             />
-          </Card.Container>
+          </Card.SurfaceRoot>
         );
       },
     }),

--- a/packages/plugins/plugin-preview/src/components/ContactCard.tsx
+++ b/packages/plugins/plugin-preview/src/components/ContactCard.tsx
@@ -19,7 +19,7 @@ export const ContactCard = ({
 }: PreviewProps<DataType.Person> & { onOrgClick?: (org: DataType.Organization) => void }) => {
   const organizationName = organization && typeof organization === 'object' ? organization.target?.name : organization;
   return (
-    <Card.Container role={role}>
+    <Card.SurfaceRoot role={role}>
       <Avatar.Root>
         <Card.Text role='group' classNames='grid gap-3 grid-cols-[min-content_1fr]'>
           <Avatar.Content imgSrc={image} icon='ph--user--regular' size={16} hue='neutral' />
@@ -65,6 +65,6 @@ export const ContactCard = ({
           ))}
       </dl>
       {children}
-    </Card.Container>
+    </Card.SurfaceRoot>
   );
 };

--- a/packages/plugins/plugin-preview/src/components/OrganizationCard.tsx
+++ b/packages/plugins/plugin-preview/src/components/OrganizationCard.tsx
@@ -16,7 +16,7 @@ export const OrganizationCard = ({
   role,
 }: PreviewProps<DataType.Organization>) => {
   return (
-    <Card.Container role={role}>
+    <Card.SurfaceRoot role={role}>
       <Card.Poster alt={name!} {...(image ? { image } : { icon: 'ph--building-office--regular' })} />
       <Card.Heading>{name}</Card.Heading>
       {description && <Card.Text classNames='line-clamp-2'>{description}</Card.Text>}
@@ -36,6 +36,6 @@ export const OrganizationCard = ({
         </Card.Chrome>
       )}
       {children}
-    </Card.Container>
+    </Card.SurfaceRoot>
   );
 };

--- a/packages/plugins/plugin-preview/src/components/ProjectCard.tsx
+++ b/packages/plugins/plugin-preview/src/components/ProjectCard.tsx
@@ -11,10 +11,10 @@ import { type PreviewProps } from '../types';
 
 export const ProjectCard = ({ subject: { name, image, description }, role }: PreviewProps<DataType.Project>) => {
   return (
-    <Card.Container role={role}>
+    <Card.SurfaceRoot role={role}>
       {image && <Card.Poster image={image} alt={name} aspect='auto' />}
       <Card.Heading>{name}</Card.Heading>
       {description && <Card.Text classNames='line-clamp-2'>{description}</Card.Text>}
-    </Card.Container>
+    </Card.SurfaceRoot>
   );
 };

--- a/packages/plugins/plugin-search/src/components/SearchResults/SearchResults.tsx
+++ b/packages/plugins/plugin-search/src/components/SearchResults/SearchResults.tsx
@@ -43,21 +43,19 @@ export const SearchItem = forwardRef<HTMLDivElement, SearchItemProps>((item, for
   const { id, objectType, label, snippet, match, selected, onSelect } = item;
 
   return (
-    <Card.Root>
-      <Card.Content
-        ref={forwardRef}
-        classNames={['mx-2 mt-2 cursor-pointer', selected && '!bg-activeSurface', ghostHover]}
-        onClick={() => onSelect?.(id)}
-      >
-        {objectType && (
-          <>
-            <div className='text-xs text-neutral-400 ml-4'>{objectType}</div>
-          </>
-        )}
-        <Card.Heading>{label ?? 'Untitled'}</Card.Heading>
-        {snippet && <Snippet text={snippet} match={match} />}
-      </Card.Content>
-    </Card.Root>
+    <Card.Content
+      ref={forwardRef}
+      classNames={['mx-2 mt-2 cursor-pointer', selected && '!bg-activeSurface', ghostHover]}
+      onClick={() => onSelect?.(id)}
+    >
+      {objectType && (
+        <>
+          <div className='text-xs text-neutral-400 ml-4'>{objectType}</div>
+        </>
+      )}
+      <Card.Heading>{label ?? 'Untitled'}</Card.Heading>
+      {snippet && <Snippet text={snippet} match={match} />}
+    </Card.Content>
   );
 });
 

--- a/packages/plugins/plugin-search/src/components/SearchResults/SearchResults.tsx
+++ b/packages/plugins/plugin-search/src/components/SearchResults/SearchResults.tsx
@@ -43,7 +43,7 @@ export const SearchItem = forwardRef<HTMLDivElement, SearchItemProps>((item, for
   const { id, objectType, label, snippet, match, selected, onSelect } = item;
 
   return (
-    <Card.Content
+    <Card.StaticRoot
       ref={forwardRef}
       classNames={['mx-2 mt-2 cursor-pointer', selected && '!bg-activeSurface', ghostHover]}
       onClick={() => onSelect?.(id)}
@@ -55,7 +55,7 @@ export const SearchItem = forwardRef<HTMLDivElement, SearchItemProps>((item, for
       )}
       <Card.Heading>{label ?? 'Untitled'}</Card.Heading>
       {snippet && <Snippet text={snippet} match={match} />}
-    </Card.Content>
+    </Card.StaticRoot>
   );
 });
 

--- a/packages/ui/react-ui-editor/src/stories/Preview.stories.tsx
+++ b/packages/ui/react-ui-editor/src/stories/Preview.stories.tsx
@@ -48,10 +48,10 @@ const PreviewCard = () => {
     <Popover.Portal>
       <Popover.Content onOpenAutoFocus={(event) => event.preventDefault()}>
         <Popover.Viewport>
-          <Card.Container role='popover'>
+          <Card.SurfaceRoot role='popover'>
             <Card.Heading>{target?.label}</Card.Heading>
             {target && <Card.Text classNames='line-clamp-3'>{target.text}</Card.Text>}
-          </Card.Container>
+          </Card.SurfaceRoot>
         </Popover.Viewport>
         <Popover.Arrow />
       </Popover.Content>
@@ -126,7 +126,7 @@ const PreviewBlock = ({ link, el, view }: { link: PreviewLinkRef; el: HTMLElemen
   }, [handleAction, link, target]);
 
   return createPortal(
-    <Card.Content classNames={hoverableControls}>
+    <Card.StaticRoot classNames={hoverableControls}>
       <div className='flex items-start'>
         {!view?.state.readOnly && (
           <Card.Toolbar classNames='is-min p-[--dx-cardSpacingInline]'>
@@ -159,7 +159,7 @@ const PreviewBlock = ({ link, el, view }: { link: PreviewLinkRef; el: HTMLElemen
         </Card.Heading>
       </div>
       {target && <Card.Text classNames='line-clamp-3 mbs-0'>{target.text}</Card.Text>}
-    </Card.Content>,
+    </Card.StaticRoot>,
     el,
   );
 };

--- a/packages/ui/react-ui-form/src/components/testing.tsx
+++ b/packages/ui/react-ui-form/src/components/testing.tsx
@@ -17,7 +17,7 @@ export const TestLayout = ({ classNames, json, children }: ThemedClassName<Props
 );
 
 export const TestPanel = ({ classNames, children }: ThemedClassName<PropsWithChildren>) => (
-  <Card.Content classNames={[textBlockWidth, classNames]}>{children}</Card.Content>
+  <Card.StaticRoot classNames={[textBlockWidth, classNames]}>{children}</Card.StaticRoot>
 );
 
 // Symbol for accessing debug objects in tests.

--- a/packages/ui/react-ui-graph/src/components/Graph/Graph.stories.tsx
+++ b/packages/ui/react-ui-graph/src/components/Graph/Graph.stories.tsx
@@ -255,13 +255,13 @@ const DefaultStory = ({
       <Popover.VirtualTrigger virtualRef={popoverAnchorRef} />
       <Popover.Content onOpenAutoFocus={(event) => event.preventDefault()}>
         <Popover.Viewport>
-          <Card.Container role='popover'>
+          <Card.SurfaceRoot role='popover'>
             <SyntaxHighlighter
               classNames='bg-transparent text-xs !mlb-cardSpacingBlock !pli-cardSpacingInline !overflow-visible'
               language='json'
               code={JSON.stringify(popover, null, 2)}
             />
-          </Card.Container>
+          </Card.SurfaceRoot>
         </Popover.Viewport>
         <Popover.Arrow />
       </Popover.Content>

--- a/packages/ui/react-ui-kanban/src/components/Kanban.tsx
+++ b/packages/ui/react-ui-kanban/src/components/Kanban.tsx
@@ -50,7 +50,7 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
       orientation='horizontal'
       size='contain'
       rail={false}
-      classNames='pli-1'
+      classNames='pli-1 density-fine'
       onRearrange={model.handleRearrange}
       itemsCount={model.arrangedCards.length}
       {...autoScrollRootAttributes}
@@ -87,8 +87,8 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                         prevSiblingId={cardIndex > 0 ? cardsArray[cardIndex - 1].id : undefined}
                         nextSiblingId={cardIndex < cardsArray.length - 1 ? cardsArray[cardIndex + 1].id : undefined}
                       >
-                        <Card.Content>
-                          <Card.Toolbar>
+                        <Card.StaticRoot>
+                          <Card.Toolbar classNames='density-fine'>
                             <StackItem.DragHandle asChild>
                               <Card.DragHandle toolbarItem />
                             </StackItem.DragHandle>
@@ -107,7 +107,7 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                             )}
                           </Card.Toolbar>
                           <Surface role='card--kanban' limit={1} data={{ subject: card }} />
-                        </Card.Content>
+                        </Card.StaticRoot>
                         <StackItem.DragPreview>
                           {({ item }) => (
                             <CardDragPreview.Root>
@@ -177,9 +177,9 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                       {/* Cards Container */}
                       <CardStackDragPreview.Content itemsCount={cards.length}>
                         {cards.map((card) => (
-                          <Card.Content key={card.id}>
+                          <Card.StaticRoot key={card.id}>
                             <Surface role='card--kanban' limit={1} data={{ subject: card }} />
-                          </Card.Content>
+                          </Card.StaticRoot>
                         ))}
                       </CardStackDragPreview.Content>
 

--- a/packages/ui/react-ui-kanban/src/components/Kanban.tsx
+++ b/packages/ui/react-ui-kanban/src/components/Kanban.tsx
@@ -79,7 +79,7 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                   getDropElement={getColumnDropElement}
                 >
                   {cards.map((card, cardIndex, cardsArray) => (
-                    <Card.Root asChild key={card.id}>
+                    <CardStack.Item asChild key={card.id}>
                       <StackItem.Root
                         item={card}
                         focusIndicatorVariant='group'
@@ -121,7 +121,7 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                           )}
                         </StackItem.DragPreview>
                       </StackItem.Root>
-                    </Card.Root>
+                    </CardStack.Item>
                   ))}
                 </CardStack.Stack>
 

--- a/packages/ui/react-ui-kanban/src/components/Kanban.tsx
+++ b/packages/ui/react-ui-kanban/src/components/Kanban.tsx
@@ -88,7 +88,7 @@ export const Kanban = ({ model, onAddCard, onRemoveCard }: KanbanProps) => {
                         nextSiblingId={cardIndex < cardsArray.length - 1 ? cardsArray[cardIndex + 1].id : undefined}
                       >
                         <Card.StaticRoot>
-                          <Card.Toolbar classNames='density-fine'>
+                          <Card.Toolbar>
                             <StackItem.DragHandle asChild>
                               <Card.DragHandle toolbarItem />
                             </StackItem.DragHandle>

--- a/packages/ui/react-ui-stack/src/exemplars/Card/Card.stories.tsx
+++ b/packages/ui/react-ui-stack/src/exemplars/Card/Card.stories.tsx
@@ -62,7 +62,7 @@ export default meta;
 export const Default: StoryObj<CardStoryProps> = {
   render: ({ title, description, image, showImage, showIcon }: CardStoryProps) => (
     <div className='max-is-md'>
-      <Card.Content>
+      <Card.StaticRoot>
         <Card.Toolbar>
           <Card.DragHandle toolbarItem />
           <Card.ToolbarSeparator variant='gap' />
@@ -72,7 +72,7 @@ export const Default: StoryObj<CardStoryProps> = {
         {!showImage && showIcon && <Card.Poster alt={title} icon='ph--building-office--regular' />}
         <Card.Heading>{title}</Card.Heading>
         {description && <Card.Text classNames='line-clamp-2'>{description}</Card.Text>}
-      </Card.Content>
+      </Card.StaticRoot>
     </div>
   ),
 };

--- a/packages/ui/react-ui-stack/src/exemplars/Card/Card.stories.tsx
+++ b/packages/ui/react-ui-stack/src/exemplars/Card/Card.stories.tsx
@@ -62,19 +62,17 @@ export default meta;
 export const Default: StoryObj<CardStoryProps> = {
   render: ({ title, description, image, showImage, showIcon }: CardStoryProps) => (
     <div className='max-is-md'>
-      <Card.Root>
-        <Card.Content>
-          <Card.Toolbar>
-            <Card.DragHandle toolbarItem />
-            <Card.ToolbarSeparator variant='gap' />
-            <Card.ToolbarIconButton iconOnly variant='ghost' icon='ph--x--regular' label={'remove card label'} />
-          </Card.Toolbar>
-          {showImage && <Card.Poster alt={title} image={image} />}
-          {!showImage && showIcon && <Card.Poster alt={title} icon='ph--building-office--regular' />}
-          <Card.Heading>{title}</Card.Heading>
-          {description && <Card.Text classNames='line-clamp-2'>{description}</Card.Text>}
-        </Card.Content>
-      </Card.Root>
+      <Card.Content>
+        <Card.Toolbar>
+          <Card.DragHandle toolbarItem />
+          <Card.ToolbarSeparator variant='gap' />
+          <Card.ToolbarIconButton iconOnly variant='ghost' icon='ph--x--regular' label={'remove card label'} />
+        </Card.Toolbar>
+        {showImage && <Card.Poster alt={title} image={image} />}
+        {!showImage && showIcon && <Card.Poster alt={title} icon='ph--building-office--regular' />}
+        <Card.Heading>{title}</Card.Heading>
+        {description && <Card.Text classNames='line-clamp-2'>{description}</Card.Text>}
+      </Card.Content>
     </div>
   ),
 };

--- a/packages/ui/react-ui-stack/src/exemplars/Card/Card.tsx
+++ b/packages/ui/react-ui-stack/src/exemplars/Card/Card.tsx
@@ -15,18 +15,16 @@ import React, {
 import { Icon, IconButton, type ThemedClassName, Toolbar, type ToolbarRootProps, useTranslation } from '@dxos/react-ui';
 import { hoverableControls, mx } from '@dxos/react-ui-theme';
 
-import { cardChrome, cardContent, cardHeading, cardText, cardSpacing } from './fragments';
+import { cardChrome, cardRoot, cardHeading, cardText, cardSpacing } from './fragments';
 import { StackItem } from '../../components';
 import { translationKey } from '../../translations';
 
 type SharedCardProps = ThemedClassName<ComponentPropsWithoutRef<'div'>> & { asChild?: boolean };
 
-const CardContent = forwardRef<HTMLDivElement, SharedCardProps>(
+const CardStaticRoot = forwardRef<HTMLDivElement, SharedCardProps>(
   ({ children, classNames, asChild, role = 'group', ...props }, forwardedRef) => {
     const Root = asChild ? Slot : 'div';
-    const rootProps = asChild
-      ? { classNames: [cardContent, classNames] }
-      : { className: mx(cardContent, classNames), role };
+    const rootProps = asChild ? { classNames: [cardRoot, classNames] } : { className: mx(cardRoot, classNames), role };
     return (
       <Root {...props} {...rootProps} ref={forwardedRef}>
         {children}
@@ -40,8 +38,8 @@ const CardContent = forwardRef<HTMLDivElement, SharedCardProps>(
  * in a Popover) and knows this based on the `role` it receives. This will render a `Card.Content` by default, otherwise
  * it will render a `div` primitive with the appropriate styling for specific handled situations.
  */
-const CardConditionalContent = ({ role, children }: PropsWithChildren<{ role?: string }>) => {
-  if (['popover', 'card--kanban'].includes(role ?? 'never')) {
+const CardSurfaceRoot = ({ role, children }: PropsWithChildren<{ role: string }>) => {
+  if (['popover', 'card--kanban'].includes(role)) {
     return (
       <div className={role === 'popover' ? 'popover-card-width' : role === 'card--kanban' ? 'contents' : ''}>
         {children}
@@ -49,9 +47,9 @@ const CardConditionalContent = ({ role, children }: PropsWithChildren<{ role?: s
     );
   } else {
     return (
-      <CardContent {...(role === 'card--document' && { classNames: ['mlb-[1em]', hoverableControls] })}>
+      <CardStaticRoot {...(role === 'card--document' && { classNames: ['mlb-[1em]', hoverableControls] })}>
         {children}
-      </CardContent>
+      </CardStaticRoot>
     );
   }
 };
@@ -152,8 +150,8 @@ const CardText = forwardRef<HTMLParagraphElement, SharedCardProps>(
 );
 
 export const Card = {
-  Content: CardContent,
-  Container: CardConditionalContent,
+  StaticRoot: CardStaticRoot,
+  SurfaceRoot: CardSurfaceRoot,
   Heading: CardHeading,
   Toolbar: CardToolbar,
   ToolbarIconButton: CardToolbarIconButton,
@@ -166,4 +164,4 @@ export const Card = {
   Text: CardText,
 };
 
-export { cardContent, cardHeading, cardText, cardChrome, cardSpacing };
+export { cardRoot, cardHeading, cardText, cardChrome, cardSpacing };

--- a/packages/ui/react-ui-stack/src/exemplars/Card/Card.tsx
+++ b/packages/ui/react-ui-stack/src/exemplars/Card/Card.tsx
@@ -35,10 +35,10 @@ const CardStaticRoot = forwardRef<HTMLDivElement, SharedCardProps>(
 
 /**
  * This should be used by Surface fulfillments in cases where the content may or may not already be encapsulated (e.g.
- * in a Popover) and knows this based on the `role` it receives. This will render a `Card.Content` by default, otherwise
+ * in a Popover) and knows this based on the `role` it receives. This will render a `Card.StaticRoot` by default, otherwise
  * it will render a `div` primitive with the appropriate styling for specific handled situations.
  */
-const CardSurfaceRoot = ({ role, children }: PropsWithChildren<{ role: string }>) => {
+const CardSurfaceRoot = ({ role = 'never', children }: PropsWithChildren<{ role?: string }>) => {
   if (['popover', 'card--kanban'].includes(role)) {
     return (
       <div className={role === 'popover' ? 'popover-card-width' : role === 'card--kanban' ? 'contents' : ''}>
@@ -70,7 +70,7 @@ const CardHeading = forwardRef<HTMLDivElement, SharedCardProps>(
 
 const CardToolbar = forwardRef<HTMLDivElement, ToolbarRootProps>(({ children, classNames, ...props }, forwardedRef) => {
   return (
-    <Toolbar.Root {...props} classNames={['bg-transparent', classNames]} ref={forwardedRef}>
+    <Toolbar.Root {...props} classNames={['bg-transparent density-coarse', classNames]} ref={forwardedRef}>
       {children}
     </Toolbar.Root>
   );

--- a/packages/ui/react-ui-stack/src/exemplars/Card/Card.tsx
+++ b/packages/ui/react-ui-stack/src/exemplars/Card/Card.tsx
@@ -15,23 +15,11 @@ import React, {
 import { Icon, IconButton, type ThemedClassName, Toolbar, type ToolbarRootProps, useTranslation } from '@dxos/react-ui';
 import { hoverableControls, mx } from '@dxos/react-ui-theme';
 
-import { cardChrome, cardContent, cardHeading, cardRoot, cardText, cardSpacing } from './fragments';
+import { cardChrome, cardContent, cardHeading, cardText, cardSpacing } from './fragments';
 import { StackItem } from '../../components';
 import { translationKey } from '../../translations';
 
 type SharedCardProps = ThemedClassName<ComponentPropsWithoutRef<'div'>> & { asChild?: boolean };
-
-const CardRoot = forwardRef<HTMLDivElement, SharedCardProps>(
-  ({ children, classNames, asChild, role = 'none', ...props }, forwardedRef) => {
-    const Root = asChild ? Slot : 'div';
-    const rootProps = asChild ? { classNames: [cardRoot, classNames] } : { className: mx(cardRoot, classNames), role };
-    return (
-      <Root {...props} {...rootProps} ref={forwardedRef}>
-        {children}
-      </Root>
-    );
-  },
-);
 
 const CardContent = forwardRef<HTMLDivElement, SharedCardProps>(
   ({ children, classNames, asChild, role = 'group', ...props }, forwardedRef) => {
@@ -164,7 +152,6 @@ const CardText = forwardRef<HTMLParagraphElement, SharedCardProps>(
 );
 
 export const Card = {
-  Root: CardRoot,
   Content: CardContent,
   Container: CardConditionalContent,
   Heading: CardHeading,
@@ -179,4 +166,4 @@ export const Card = {
   Text: CardText,
 };
 
-export { cardRoot, cardContent, cardHeading, cardText, cardChrome, cardSpacing };
+export { cardContent, cardHeading, cardText, cardChrome, cardSpacing };

--- a/packages/ui/react-ui-stack/src/exemplars/Card/CardDragPreview.tsx
+++ b/packages/ui/react-ui-stack/src/exemplars/Card/CardDragPreview.tsx
@@ -6,14 +6,14 @@ import React, { type PropsWithChildren } from 'react';
 
 import { mx } from '@dxos/react-ui-theme';
 
-import { cardContent } from './fragments';
+import { cardRoot } from './fragments';
 
 const CardDragPreviewRoot = ({ children }: PropsWithChildren<{}>) => {
   return <div className='p-2'>{children}</div>;
 };
 
 const CardDragPreviewContent = ({ children }: PropsWithChildren<{}>) => {
-  return <div className={mx(cardContent, 'ring-focusLine ring-neutralFocusIndicator')}>{children}</div>;
+  return <div className={mx(cardRoot, 'ring-focusLine ring-neutralFocusIndicator')}>{children}</div>;
 };
 
 export const CardDragPreview = {

--- a/packages/ui/react-ui-stack/src/exemplars/Card/fragments.ts
+++ b/packages/ui/react-ui-stack/src/exemplars/Card/fragments.ts
@@ -2,8 +2,6 @@
 // Copyright 2025 DXOS.org
 //
 
-export const cardRoot = 'contain-layout pli-2 plb-1 first-of-type:pbs-0 last-of-type:pbe-0';
-
 export const cardContent =
   'rounded overflow-hidden bg-cardSurface border border-separator dark:border-subduedSeparator dx-focus-ring-group-y-indicator relative min-bs-[--rail-item] group/card';
 

--- a/packages/ui/react-ui-stack/src/exemplars/Card/fragments.ts
+++ b/packages/ui/react-ui-stack/src/exemplars/Card/fragments.ts
@@ -2,7 +2,7 @@
 // Copyright 2025 DXOS.org
 //
 
-export const cardContent =
+export const cardRoot =
   'rounded overflow-hidden bg-cardSurface border border-separator dark:border-subduedSeparator dx-focus-ring-group-y-indicator relative min-bs-[--rail-item] group/card';
 
 export const cardSpacing = 'pli-cardSpacingInline mlb-cardSpacingBlock';

--- a/packages/ui/react-ui-stack/src/exemplars/CardStack/CardStack.stories.tsx
+++ b/packages/ui/react-ui-stack/src/exemplars/CardStack/CardStack.stories.tsx
@@ -111,7 +111,7 @@ const CardStackStory = () => {
                   prevSiblingId={prevCardId}
                   nextSiblingId={nextCardId}
                 >
-                  <Card.Content>
+                  <Card.StaticRoot>
                     <Card.Toolbar>
                       <StackItem.DragHandle asChild>
                         <Card.DragHandle toolbarItem />
@@ -128,7 +128,7 @@ const CardStackStory = () => {
                     <Card.Poster alt={card.title} image={card.image} />
                     <Card.Heading>{card.title}</Card.Heading>
                     <Card.Text classNames='line-clamp-2'>{card.description}</Card.Text>
-                  </Card.Content>
+                  </Card.StaticRoot>
                   <StackItem.DragPreview>
                     {({ item }) => (
                       <CardDragPreview.Root>

--- a/packages/ui/react-ui-stack/src/exemplars/CardStack/CardStack.stories.tsx
+++ b/packages/ui/react-ui-stack/src/exemplars/CardStack/CardStack.stories.tsx
@@ -104,7 +104,7 @@ const CardStackStory = () => {
             const nextCardId = cardIndex < cardsArray.length - 1 ? cardsArray[cardIndex + 1].id : undefined;
 
             return (
-              <Card.Root asChild key={card.id}>
+              <CardStack.Item asChild key={card.id}>
                 <StackItem.Root
                   item={cardItem}
                   focusIndicatorVariant='group'
@@ -144,7 +144,7 @@ const CardStackStory = () => {
                     )}
                   </StackItem.DragPreview>
                 </StackItem.Root>
-              </Card.Root>
+              </CardStack.Item>
             );
           })}
         </CardStack.Stack>

--- a/packages/ui/react-ui-stack/src/exemplars/CardStack/CardStack.tsx
+++ b/packages/ui/react-ui-stack/src/exemplars/CardStack/CardStack.tsx
@@ -107,6 +107,22 @@ const CardStackRoot = forwardRef<HTMLDivElement, SharedCardStackProps>(
   },
 );
 
+const cardStackItem = 'contain-layout pli-2 plb-1 first-of-type:pbs-0 last-of-type:pbe-0';
+
+const CardStackItem = forwardRef<HTMLDivElement, SharedCardStackProps>(
+  ({ children, classNames, asChild, role = 'none', ...props }, forwardedRef) => {
+    const Root = asChild ? Slot : 'div';
+    const rootProps = asChild
+      ? { classNames: [cardStackItem, classNames] }
+      : { className: mx(cardStackItem, classNames), role };
+    return (
+      <Root {...props} {...rootProps} ref={forwardedRef}>
+        {children}
+      </Root>
+    );
+  },
+);
+
 export const CardStack = {
   Root: CardStackRoot,
   Content: CardStackContent,
@@ -114,6 +130,7 @@ export const CardStack = {
   Heading: CardStackHeading,
   Footer: CardStackFooter,
   DragHandle: CardStackDragHandle,
+  Item: CardStackItem,
 };
 
-export { cardStackRoot, cardStackFooter, cardStackHeading, cardStackContent };
+export { cardStackRoot, cardStackFooter, cardStackHeading, cardStackContent, cardStackItem };

--- a/packages/ui/react-ui-theme/src/util/mx.ts
+++ b/packages/ui/react-ui-theme/src/util/mx.ts
@@ -6,7 +6,7 @@ import { extendTailwindMerge, validators } from 'tailwind-merge';
 
 import { withLogical, type WithLogicalClassGroups } from './withLogical';
 
-type AdditionalClassGroups = 'foreground' | 'surface' | 'separator' | WithLogicalClassGroups;
+type AdditionalClassGroups = 'density' | WithLogicalClassGroups;
 
 export const mx = extendTailwindMerge<AdditionalClassGroups>(
   {
@@ -27,6 +27,7 @@ export const mx = extendTailwindMerge<AdditionalClassGroups>(
           // Arbitrary numbers
           validators.isArbitraryNumber,
         ],
+        density: ['density-fine', 'density-coarse'],
       },
     },
   },


### PR DESCRIPTION
This PR:
- renames `Card.Root` as `CardStack.Item`
- renames `Card.Content` as `Card.StaticRoot`
- renames `Card.Container` as `Card.SurfaceRoot`
- adjusts some other density/spacing issues