### PR TITLE
chore: Storybook/vite setup

### DIFF
--- a/packages/common/node-std/package.json
+++ b/packages/common/node-std/package.json
@@ -10,8 +10,8 @@
   "type": "module",
   "exports": {
     "./_/config": {
-      "import": "./dist/lib/browser/_/config.mjs",
-      "require": "./dist/lib/node-esm/_/config.mjs"
+      "import": "./dist/lib/node-esm/_/config.mjs",
+      "require": "./dist/lib/node-cjs/_/config.cjs"
     },
     "./assert": "./dist/lib/browser/assert.mjs",
     "./buffer": "./dist/lib/browser/buffer.mjs",

--- a/packages/common/node-std/project.json
+++ b/packages/common/node-std/project.json
@@ -1,9 +1,7 @@
 {
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "name": "node-std",
-  "tags": [
-    "scope:common"
-  ],
+  "tags": ["scope:common"],
   "sourceRoot": "{projectRoot}/src",
   "projectType": "library",
   "targets": {
@@ -63,16 +61,11 @@
           "{projectRoot}/src/stream.js",
           "{projectRoot}/src/util.js"
         ],
-        "platforms": [
-          "browser",
-          "node"
-        ]
+        "platforms": ["browser", "node"],
+        "moduleFormat": ["cjs", "esm"]
       }
     },
     "lint": {}
   },
-  "implicitDependencies": [
-    "esbuild",
-    "node-std"
-  ]
+  "implicitDependencies": ["esbuild", "node-std"]
 }

--- a/packages/devtools/storybook-utils/src/stories/test/Test.stories.tsx
+++ b/packages/devtools/storybook-utils/src/stories/test/Test.stories.tsx
@@ -12,7 +12,7 @@ import { log } from '@dxos/log';
 import { withTheme } from '@dxos/storybook-utils';
 
 import { Test, type TestProps } from './Test';
-import { TEST_ID } from './Test.test';
+import { TEST_ID } from './defs';
 
 /**
  * Storybook sanity test.

--- a/packages/devtools/storybook-utils/src/stories/test/Test.test.tsx
+++ b/packages/devtools/storybook-utils/src/stories/test/Test.test.tsx
@@ -11,8 +11,7 @@ import { ThemeProvider } from '@dxos/react-ui';
 
 import { Test } from './Test';
 import * as stories from './Test.stories';
-
-export const TEST_ID = 'test';
+import { TEST_ID } from './defs';
 
 const { Default } = composeStories(stories);
 

--- a/packages/devtools/storybook-utils/src/stories/test/defs.ts
+++ b/packages/devtools/storybook-utils/src/stories/test/defs.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+export const TEST_ID = 'test';

--- a/tools/stories/project.json
+++ b/tools/stories/project.json
@@ -97,6 +97,7 @@
         "outputDir": "{projectRoot}/out/examples"
       }
     },
+    "test": {},
     "vitest": {
       "configurations": {
         "browser": {

--- a/tools/stories/vitest.config.ts
+++ b/tools/stories/vitest.config.ts
@@ -2,33 +2,59 @@
 // Copyright 2025 DXOS.org
 //
 
+import { ThemePlugin } from '@dxos/react-ui-theme/plugin';
+import { searchForWorkspaceRoot } from 'vite';
 import { defineConfig, mergeConfig } from 'vitest/config';
 
-import { baseConfig } from '../../vitest.base.config';
+import { join } from 'node:path';
 
-export default mergeConfig(
-  baseConfig({ cwd: __dirname }),
-  defineConfig({
-    test: {
-      setupFiles: ['./.storybook/vitest.setup.ts'],
-      projects: [
-        {
-          // pnpm -w nx test stories --project=unit
-          test: {
-            name: 'unit',
-            environment: 'node',
-          },
+const rootDir = searchForWorkspaceRoot(process.cwd());
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        // pnpm -w nx test stories --project=unit
+        test: {
+          name: 'unit',
+          environment: 'node',
         },
-        {
+      },
+      mergeConfig(
+        defineConfig({}),
+        // baseConfig({ cwd: __dirname }),
+        defineConfig({
+          root: join(__dirname, '../../'),
+          // pnpm vitest run --project browser
           test: {
+            include: [
+              //
+              // '../../packages/*/*/src/**/*.test.tsx',
+              'packages/devtools/*/src/**/*.test.tsx',
+            ],
+            // setupFiles: ['./.storybook/vitest.setup.ts'],
             // https://vitest.dev/guide/browser
             name: 'browser',
             browser: {
               enabled: true,
+              instances: [{ browser: 'chromium' }],
             },
           },
-        },
-      ],
-    },
-  }),
-);
+          plugins: [
+            ThemePlugin({
+              root: __dirname,
+              content: [
+                join(__dirname, './index.html'),
+                join(__dirname, './src/**/*.{js,ts,jsx,tsx}'),
+                join(rootDir, '/packages/devtools/*/src/**/*.{js,ts,jsx,tsx}'),
+                join(rootDir, '/packages/experimental/*/src/**/*.{js,ts,jsx,tsx}'),
+                join(rootDir, '/packages/plugins/*/src/**/*.{js,ts,jsx,tsx}'),
+                join(rootDir, '/packages/sdk/*/src/**/*.{js,ts,jsx,tsx}'),
+                join(rootDir, '/packages/ui/*/src/**/*.{js,ts,jsx,tsx}'),
+              ],
+            }),
+          ],
+        }),
+      ),
+    ],
+  },
+});


### PR DESCRIPTION
Goal: run storybooks in vitest

Issue: from `tools/stories`, run `pnpm vitest run --project browser`


```
Consider adding an error boundary to your tree to customize error handling behavior.
Visit https://reactjs.org/link/error-boundaries to learn more about error boundaries.
 ❯  browser (chromium)  packages/devtools/storybook-utils/src/stories/test/Test.test.tsx (2 tests | 2 failed) 15ms
   × Test > should render 14ms
     → Cannot set property focus of #<HTMLElement> which has only a getter
   × Test > calls onClick when clicked 1ms
     → Cannot set property focus of #<HTMLElement> which has only a getter

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL   browser (chromium)  packages/devtools/storybook-utils/src/stories/test/Test.test.tsx > Test > should render
 FAIL   browser (chromium)  packages/devtools/storybook-utils/src/stories/test/Test.test.tsx > Test > calls onClick when clicked
TypeError: Cannot set property focus of #<HTMLElement> which has only a getter
 ❯ canOverrideNativeFocus node_modules/.pnpm/keyborg@2.5.0/node_modules/keyborg/src/FocusEvent.ts:38:24
 ❯ setupFocusEvent node_modules/.pnpm/keyborg@2.5.0/node_modules/keyborg/src/FocusEvent.ts:93:30
 ❯ new KeyborgCore node_modules/.pnpm/keyborg@2.5.0/node_modules/keyborg/src/Keyborg.ts:72:4
 ❯ new _Keyborg node_modules/.pnpm/keyborg@2.5.0/node_modules/keyborg/src/Keyborg.ts:291:19
 ❯ _Keyborg.create node_modules/.pnpm/keyborg@2.5.0/node_modules/keyborg/src/Keyborg.ts:267:11
 ❯ createKeyborg node_modules/.pnpm/keyborg@2.5.0/node_modules/keyborg/src/Keyborg.ts:357:17
 ❯ createKeyborg packages/ui/react-ui/src/components/ThemeProvider/ThemeProvider.tsx:50:17
     48|   useEffect(() => {
     49|     if (document.defaultView) {
     50|       const kb = createKeyborg(document.defaultView);
       |                 ^
     51|       kb.subscribe(handleInputModalityChange);
     52|       return () => kb.unsubscribe(handleInputModalityChange);
 ❯ commitHookEffectListMount node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:23150:25
 ❯ commitPassiveMountOnFiber node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:24931:10
 ❯ commitPassiveMountEffects_complete node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:24891:8
 ```