### PR TITLE
experiment: Capabilities as tags

### DIFF
--- a/packages/sdk/app-framework/package.json
+++ b/packages/sdk/app-framework/package.json
@@ -47,6 +47,7 @@
     "@dxos/client-protocol": "workspace:*",
     "@dxos/debug": "workspace:*",
     "@dxos/echo-schema": "workspace:*",
+    "@dxos/effect": "workspace:*",
     "@dxos/invariant": "workspace:*",
     "@dxos/keys": "workspace:*",
     "@dxos/live-object": "workspace:*",

--- a/packages/sdk/app-framework/src/core/capabilities.test.ts
+++ b/packages/sdk/app-framework/src/core/capabilities.test.ts
@@ -3,10 +3,11 @@
 //
 
 import { Registry } from '@effect-rx/rx-react';
-import { Effect } from 'effect';
+import { Context, Effect, flow } from 'effect';
 import { describe, expect, it, onTestFinished } from 'vitest';
 
-import { defineCapability, PluginContext } from './capabilities';
+import { defineCapability, PluginContext, type InterfaceDef } from './capabilities';
+import { runAndForwardErrors } from '@dxos/effect';
 
 const defaultOptions = {
   activate: () => Effect.succeed(false),
@@ -132,5 +133,45 @@ describe('PluginsContext', () => {
     const implementation = { example: 'identifier' };
     context.contributeCapability({ interface: interfaceDef, implementation, module: 'test' });
     expect(capability).toEqual(implementation);
+  });
+});
+
+describe('Capabilities within effect', () => {
+  class CapabilityProvider extends Context.Tag('@dxos/app-framework/CapabilityProvider')<
+    CapabilityProvider,
+    PluginContext
+  >() {
+    static provide<I extends InterfaceDef<any>[]>(
+      ...interfaceDefs: I
+    ): <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, Exclude<R, I[number]> | CapabilityProvider> {
+      const provides = interfaceDefs.map((interfaceDef) =>
+        Effect.provideServiceEffect(
+          interfaceDef,
+          CapabilityProvider.pipe(Effect.map((context) => context.getCapabilities(interfaceDef))),
+        ),
+      );
+      return (flow as any)(...provides);
+    }
+  }
+
+  it('are yieldable and provideable', async () => {
+    const Example1 = defineCapability<{ example1: string }>('@dxos/app-framework/test/Example1');
+    const Example2 = defineCapability<{ example2: string }>('@dxos/app-framework/test/Example2');
+
+    const registry = Registry.make();
+    const context = new PluginContext({ registry, ...defaultOptions });
+    context.contributeCapability({ interface: Example1, implementation: { example1: 'identifier1' }, module: 'test' });
+    context.contributeCapability({ interface: Example2, implementation: { example2: 'identifier2' }, module: 'test' });
+
+    const a = Effect.gen(function* () {
+      const capability1 = yield* Example1;
+      const capability2 = yield* Example2;
+
+      console.log({ capability1, capability2 });
+      expect(capability1).toEqual([{ example1: 'identifier1' }]);
+      expect(capability2).toEqual([{ example2: 'identifier2' }]);
+    });
+
+    const b = a.pipe(CapabilityProvider.provide(Example1, Example2));
   });
 });

--- a/packages/sdk/app-framework/src/core/capabilities.ts
+++ b/packages/sdk/app-framework/src/core/capabilities.ts
@@ -3,7 +3,7 @@
 //
 
 import { type Registry, Rx } from '@effect-rx/rx-react';
-import { Effect } from 'effect';
+import { Context, Effect } from 'effect';
 
 import { Trigger } from '@dxos/async';
 import { invariant } from '@dxos/invariant';
@@ -17,16 +17,20 @@ const InterfaceDefTypeId: unique symbol = Symbol.for('InterfaceDefTypeId');
 /**
  * The interface definition of a capability.
  */
-export type InterfaceDef<T> = {
+// TODO(dmaretskyi): Not passing in the Id generic likely cause type issues with unrelated tags with the same value type being merged.
+export interface InterfaceDef<T> extends Context.Tag<T, T[]> {
   [InterfaceDefTypeId]: T;
   identifier: string;
-};
+}
 
 /**
  * Helper to define the interface of a capability.
  */
 export const defineCapability = <T>(identifier: string) => {
-  return { identifier } as InterfaceDef<T>;
+  return class extends Context.Tag(identifier)<any, T[]>() {
+    static [InterfaceDefTypeId]: T = null as any;
+    static identifier: string = identifier;
+  } as unknown as InterfaceDef<T>;
 };
 
 /**

--- a/packages/sdk/app-framework/tsconfig.json
+++ b/packages/sdk/app-framework/tsconfig.json
@@ -15,6 +15,9 @@
       "path": "../../common/debug"
     },
     {
+      "path": "../../common/effect"
+    },
+    {
       "path": "../../common/invariant"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10656,6 +10656,9 @@ importers:
       '@dxos/echo-schema':
         specifier: workspace:*
         version: link:../../core/echo/echo-schema
+      '@dxos/effect':
+        specifier: workspace:*
+        version: link:../../common/effect
       '@dxos/invariant':
         specifier: workspace:*
         version: link:../../common/invariant


### PR DESCRIPTION
Types don't work here. To move forward we would need to make the capability definition follow the Contex.Tag syntax:

```ts
export class MyCapability extends Capability.Define('@dxos/example/MyCapability')<MyCapability, { field: string }>() {}
```