### PR TITLE
chore: Surface name refactor

### DIFF
--- a/packages/core/artifact-testing/src/plugins.tsx
+++ b/packages/core/artifact-testing/src/plugins.tsx
@@ -60,7 +60,7 @@ export const capabilities: AnyCapability[] = [
     Capabilities.ReactSurface,
     createSurface({
       id: 'plugin-image',
-      role: 'canvas-node',
+      role: 'card--extrinsic',
       filter: (data: any): data is any => isImage(data.value),
       component: ({ data }) => (
         <img
@@ -79,7 +79,7 @@ export const capabilities: AnyCapability[] = [
     Capabilities.ReactSurface,
     createSurface({
       id: 'plugin-default',
-      role: 'canvas-node',
+      role: 'card--extrinsic',
       position: 'fallback',
       component: ({ role, data }) => <JsonFilter data={data} />,
     }),

--- a/packages/plugins/plugin-chess/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-chess/src/capabilities/react-surface.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { Capabilities, contributes, createSurface } from '@dxos/app-framework';
 import { Obj } from '@dxos/echo';
 
-import { ChessContainer, Chess } from '../components';
+import { ChessContainer } from '../components';
 import { meta } from '../meta';
 import { ChessType } from '../types';
 
@@ -19,18 +19,5 @@ export default () =>
       // TODO(burdon): Could this be standardized so that we don't require a subject property (like below)?
       filter: (data): data is { subject: ChessType } => Obj.instanceOf(ChessType, data.subject),
       component: ({ data, role }) => <ChessContainer game={data.subject} role={role} />,
-    }),
-    createSurface({
-      id: 'plugin-chess',
-      // TODO(burdon): Change role to card?
-      role: 'canvas-node',
-      filter: Obj.instanceOf(ChessType),
-      component: ({ data }) => (
-        <Chess.Root game={data}>
-          <Chess.Content>
-            <Chess.Board />
-          </Chess.Content>
-        </Chess.Root>
-      ),
     }),
   ]);

--- a/packages/plugins/plugin-chess/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-chess/src/capabilities/react-surface.tsx
@@ -15,7 +15,7 @@ export default () =>
   contributes(Capabilities.ReactSurface, [
     createSurface({
       id: meta.id,
-      role: ['article', 'section', 'card--intrinsic', 'card--extrinsic', 'popover', 'transclusion'],
+      role: ['article', 'section', 'card--intrinsic', 'card--extrinsic', 'popover', 'card--transclusion'],
       // TODO(burdon): Could this be standardized so that we don't require a subject property (like below)?
       filter: (data): data is { subject: ChessType } => Obj.instanceOf(ChessType, data.subject),
       component: ({ data, role }) => <ChessContainer game={data.subject} role={role} />,

--- a/packages/plugins/plugin-chess/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-chess/src/capabilities/react-surface.tsx
@@ -15,7 +15,7 @@ export default () =>
   contributes(Capabilities.ReactSurface, [
     createSurface({
       id: meta.id,
-      role: ['article', 'section', 'card--intrinsic', 'card--extrinsic', 'popover', 'card--transclusion'],
+      role: ['article', 'section', 'card--intrinsic', 'card--extrinsic', 'card--popover', 'card--transclusion'],
       // TODO(burdon): Could this be standardized so that we don't require a subject property (like below)?
       filter: (data): data is { subject: ChessType } => Obj.instanceOf(ChessType, data.subject),
       component: ({ data, role }) => <ChessContainer game={data.subject} role={role} />,

--- a/packages/plugins/plugin-chess/src/components/ChessContainer.stories.tsx
+++ b/packages/plugins/plugin-chess/src/components/ChessContainer.stories.tsx
@@ -24,7 +24,7 @@ import ChessContainer from './ChessContainer';
 import { ChessType } from '../types';
 
 type StoryProps = {
-  role: 'popover' | 'card--intrinsic' | 'card--extrinsic';
+  role: 'card--popover' | 'card--intrinsic' | 'card--extrinsic';
 };
 
 const render: Meta<StoryProps>['render'] = ({ role }) => {
@@ -93,7 +93,7 @@ export default meta;
 
 export const Popover = {
   args: {
-    role: 'popover',
+    role: 'card--popover',
   },
 };
 

--- a/packages/plugins/plugin-chess/src/components/ChessContainer.tsx
+++ b/packages/plugins/plugin-chess/src/components/ChessContainer.tsx
@@ -20,51 +20,52 @@ const ChessContainer = ({ game, role }: { game: ChessType; role?: string }) => {
     return null;
   }
 
-  if (role === 'popover') {
-    return (
-      <Chess.Root game={game}>
-        <div role='none' className='popover-square size-container'>
-          <Chess.Board classNames={containFragment} />
-        </div>
-      </Chess.Root>
-    );
+  switch (role) {
+    case 'popover': {
+      return (
+        <Chess.Root game={game}>
+          <div role='none' className='popover-square size-container'>
+            <Chess.Board classNames={containFragment} />
+          </div>
+        </Chess.Root>
+      );
+    }
+    case 'card--extrinsic': {
+      return (
+        <Chess.Root game={game}>
+          <div role='none' className='grid is-full bs-full size-container place-content-center'>
+            <Chess.Board classNames={containFragment} />
+          </div>
+        </Chess.Root>
+      );
+    }
+    case 'card--intrinsic': {
+      return (
+        <Chess.Root game={game}>
+          <Chess.Board />
+        </Chess.Root>
+      );
+    }
+    default: {
+      return (
+        <StackItem.Content>
+          <div role='none' className='grid grid-rows-[60px_1fr_60px] grow overflow-hidden'>
+            <div />
+
+            <div className='flex m-4 overflow-hidden'>
+              <Chess.Root game={game}>
+                <Chess.Content>
+                  <Chess.Board />
+                </Chess.Content>
+              </Chess.Root>
+            </div>
+
+            <PlayerSelector space={space} game={game} />
+          </div>
+        </StackItem.Content>
+      );
+    }
   }
-
-  if (role === 'card--extrinsic') {
-    return (
-      <Chess.Root game={game}>
-        <div role='none' className='grid is-full bs-full size-container place-content-center'>
-          <Chess.Board classNames={containFragment} />
-        </div>
-      </Chess.Root>
-    );
-  }
-
-  if (role === 'card--intrinsic') {
-    return (
-      <Chess.Root game={game}>
-        <Chess.Board />
-      </Chess.Root>
-    );
-  }
-
-  return (
-    <StackItem.Content>
-      <div role='none' className='grid grid-rows-[60px_1fr_60px] grow overflow-hidden'>
-        <div />
-
-        <div className='flex m-4 overflow-hidden'>
-          <Chess.Root game={game}>
-            <Chess.Content>
-              <Chess.Board />
-            </Chess.Content>
-          </Chess.Root>
-        </div>
-
-        <PlayerSelector space={space} game={game} />
-      </div>
-    </StackItem.Content>
-  );
 };
 
 export default ChessContainer;

--- a/packages/plugins/plugin-chess/src/components/ChessContainer.tsx
+++ b/packages/plugins/plugin-chess/src/components/ChessContainer.tsx
@@ -21,7 +21,7 @@ const ChessContainer = ({ game, role }: { game: ChessType; role?: string }) => {
   }
 
   switch (role) {
-    case 'popover': {
+    case 'card--popover': {
       return (
         <Chess.Root game={game}>
           <div role='none' className='popover-square size-container'>

--- a/packages/plugins/plugin-deck/src/components/DeckLayout/Popover.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/Popover.tsx
@@ -95,7 +95,7 @@ export const PopoverContent = () => {
         hideWhenDetached
       >
         <Popover.Viewport>
-          <Surface role='popover' data={layout.popoverContent} limit={1} />
+          <Surface role='card--popover' data={layout.popoverContent} limit={1} />
         </Popover.Viewport>
         <Popover.Arrow />
       </Popover.Content>

--- a/packages/plugins/plugin-map/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-map/src/capabilities/react-surface.tsx
@@ -51,7 +51,7 @@ export default () =>
     }),
     // createSurface({
     //   id: 'plugin-map',
-    //   role: 'canvas-node',
+    //   role: 'card--extrinsic',
     //   filter: (data) => Obj.instanceOf(MapType, data),
     //   component: ({ data }) => {
     //     const [lng = 0, lat = 0] = data?.coordinates ?? [];

--- a/packages/plugins/plugin-markdown/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-markdown/src/capabilities/react-surface.tsx
@@ -105,7 +105,7 @@ export default () =>
     }),
     createSurface({
       id: `${MARKDOWN_PLUGIN}/preview`,
-      role: ['popover', 'card--intrinsic', 'card--extrinsic', 'transclusion', 'card'],
+      role: ['popover', 'card--intrinsic', 'card--extrinsic', 'card--transclusion', 'card'],
       filter: (data): data is { subject: DocumentType | DataType.Text } =>
         Obj.instanceOf(DocumentType, data.subject) || Obj.instanceOf(DataType.Text, data.subject),
       component: ({ data, role }) => <MarkdownPreview {...data} role={role} />,

--- a/packages/plugins/plugin-markdown/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-markdown/src/capabilities/react-surface.tsx
@@ -105,7 +105,7 @@ export default () =>
     }),
     createSurface({
       id: `${MARKDOWN_PLUGIN}/preview`,
-      role: ['popover', 'card--intrinsic', 'card--extrinsic', 'card--transclusion', 'card'],
+      role: ['card--popover', 'card--intrinsic', 'card--extrinsic', 'card--transclusion', 'card'],
       filter: (data): data is { subject: DocumentType | DataType.Text } =>
         Obj.instanceOf(DocumentType, data.subject) || Obj.instanceOf(DataType.Text, data.subject),
       component: ({ data, role }) => <MarkdownPreview {...data} role={role} />,

--- a/packages/plugins/plugin-markdown/src/components/MarkdownContainer.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownContainer.tsx
@@ -190,7 +190,7 @@ const PreviewBlock = ({ link, el }: { link: PreviewLinkRef; el: HTMLElement }) =
   const [subject] = useQuery(space, Query.select(Filter.ids(echoDXN?.echoId ?? '')));
   const data = useMemo(() => ({ subject }), [subject]);
 
-  return createPortal(<Surface role='transclusion' data={data} limit={1} />, el);
+  return createPortal(<Surface role='card--transclusion' data={data} limit={1} />, el);
 };
 
 type DocumentEditorProps = Omit<MarkdownContainerProps, 'object' | 'extensionProviders' | 'editorStateStore'> &

--- a/packages/plugins/plugin-markdown/src/components/MarkdownPreview/MarkdownPreview.stories.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownPreview/MarkdownPreview.stories.tsx
@@ -62,7 +62,7 @@ const data = (() => {
 export const Popover = {
   args: {
     subject: Obj.make(DocumentType, data.document),
-    role: 'popover',
+    role: 'card--popover',
   },
 };
 

--- a/packages/plugins/plugin-markdown/src/components/MarkdownPreview/MarkdownPreview.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownPreview/MarkdownPreview.tsx
@@ -60,7 +60,7 @@ export const MarkdownPreview = ({ subject, role }: PreviewProps<DocumentType | D
     <Card.SurfaceRoot role={role}>
       <Card.Heading>{getTitle(subject, t('fallback title'))}</Card.Heading>
       {snippet && <Card.Text classNames='line-clamp-3 break-words col-span-2'>{snippet}</Card.Text>}
-      {role === 'popover' && (
+      {role === 'card--popover' && (
         <Card.Chrome>
           <Button onClick={handleNavigate}>
             <span className='grow'>{t('navigate to document label')}</span>

--- a/packages/plugins/plugin-preview/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-preview/src/capabilities/react-surface.tsx
@@ -24,7 +24,7 @@ export default () =>
     //
     createSurface({
       id: `${PREVIEW_PLUGIN}/schema-popover--contact`,
-      role: ['popover', 'card--intrinsic', 'transclusion', 'card--extrinsic', 'card'],
+      role: ['popover', 'card--intrinsic', 'card--transclusion', 'card--extrinsic', 'card'],
       filter: (data): data is { subject: DataType.Person } => Obj.instanceOf(DataType.Person, data.subject),
       component: ({ data, role }) => {
         // TODO(wittjosiah): Handle org click.
@@ -66,7 +66,7 @@ export default () =>
     }),
     createSurface({
       id: `${PREVIEW_PLUGIN}/schema-popover--organization`,
-      role: ['popover', 'card--intrinsic', 'transclusion', 'card--extrinsic', 'card'],
+      role: ['popover', 'card--intrinsic', 'card--transclusion', 'card--extrinsic', 'card'],
       filter: (data): data is { subject: DataType.Organization } => Obj.instanceOf(DataType.Organization, data.subject),
       component: ({ data, role }) => (
         <OrganizationCard role={role} subject={data.subject}>
@@ -76,7 +76,7 @@ export default () =>
     }),
     createSurface({
       id: `${PREVIEW_PLUGIN}/schema-popover--project`,
-      role: ['popover', 'card--intrinsic', 'transclusion', 'card--extrinsic', 'card'],
+      role: ['popover', 'card--intrinsic', 'card--transclusion', 'card--extrinsic', 'card'],
       filter: (data): data is { subject: DataType.Project } => Obj.instanceOf(DataType.Project, data.subject),
       component: ({ data, role }) => <ProjectCard subject={data.subject} role={role} />,
     }),
@@ -86,7 +86,7 @@ export default () =>
     //
     createSurface({
       id: `${PREVIEW_PLUGIN}/fallback-popover`,
-      role: ['popover', 'card--intrinsic', 'transclusion', 'card--extrinsic', 'card'],
+      role: ['popover', 'card--intrinsic', 'card--transclusion', 'card--extrinsic', 'card'],
       position: 'fallback',
       filter: (data): data is { subject: Obj.Any } => Obj.isObject(data.subject),
       component: ({ data, role }) => {

--- a/packages/plugins/plugin-preview/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-preview/src/capabilities/react-surface.tsx
@@ -24,7 +24,7 @@ export default () =>
     //
     createSurface({
       id: `${PREVIEW_PLUGIN}/schema-popover--contact`,
-      role: ['popover', 'card--intrinsic', 'card--transclusion', 'card--extrinsic', 'card'],
+      role: ['card--popover', 'card--intrinsic', 'card--transclusion', 'card--extrinsic', 'card'],
       filter: (data): data is { subject: DataType.Person } => Obj.instanceOf(DataType.Person, data.subject),
       component: ({ data, role }) => {
         // TODO(wittjosiah): Handle org click.
@@ -59,24 +59,24 @@ export default () =>
         // );
         return (
           <ContactCard role={role} subject={data.subject}>
-            {role === 'popover' && <Surface role='related' data={data} />}
+            {role === 'card--popover' && <Surface role='related' data={data} />}
           </ContactCard>
         );
       },
     }),
     createSurface({
       id: `${PREVIEW_PLUGIN}/schema-popover--organization`,
-      role: ['popover', 'card--intrinsic', 'card--transclusion', 'card--extrinsic', 'card'],
+      role: ['card--popover', 'card--intrinsic', 'card--transclusion', 'card--extrinsic', 'card'],
       filter: (data): data is { subject: DataType.Organization } => Obj.instanceOf(DataType.Organization, data.subject),
       component: ({ data, role }) => (
         <OrganizationCard role={role} subject={data.subject}>
-          {role === 'popover' && <Surface role='related' data={data} />}
+          {role === 'card--popover' && <Surface role='related' data={data} />}
         </OrganizationCard>
       ),
     }),
     createSurface({
       id: `${PREVIEW_PLUGIN}/schema-popover--project`,
-      role: ['popover', 'card--intrinsic', 'card--transclusion', 'card--extrinsic', 'card'],
+      role: ['card--popover', 'card--intrinsic', 'card--transclusion', 'card--extrinsic', 'card'],
       filter: (data): data is { subject: DataType.Project } => Obj.instanceOf(DataType.Project, data.subject),
       component: ({ data, role }) => <ProjectCard subject={data.subject} role={role} />,
     }),
@@ -86,7 +86,7 @@ export default () =>
     //
     createSurface({
       id: `${PREVIEW_PLUGIN}/fallback-popover`,
-      role: ['popover', 'card--intrinsic', 'card--transclusion', 'card--extrinsic', 'card'],
+      role: ['card--popover', 'card--intrinsic', 'card--transclusion', 'card--extrinsic', 'card'],
       position: 'fallback',
       filter: (data): data is { subject: Obj.Any } => Obj.isObject(data.subject),
       component: ({ data, role }) => {
@@ -110,7 +110,7 @@ export default () =>
             <Form
               schema={schema}
               values={data.subject}
-              readonly={role === 'popover'}
+              readonly={role === 'card--popover'}
               onSave={handleSave}
               autoSave
               {...(role === 'card--intrinsic' && { outerSpacing: 'blockStart-0' })}

--- a/packages/plugins/plugin-preview/src/testing/PopoverPreviews.stories.tsx
+++ b/packages/plugins/plugin-preview/src/testing/PopoverPreviews.stories.tsx
@@ -30,7 +30,7 @@ export const Contact = {
     icon: 'ph--user--regular',
     subject: 'contact',
     withImage: true,
-    role: 'popover',
+    role: 'card--popover',
   },
 };
 
@@ -40,7 +40,7 @@ export const Organization = {
     icon: 'ph--building-office--regular',
     subject: 'organization',
     withImage: true,
-    role: 'popover',
+    role: 'card--popover',
   },
 };
 
@@ -50,6 +50,6 @@ export const Project = {
     icon: 'ph--building--regular',
     subject: 'project',
     withImage: true,
-    role: 'popover',
+    role: 'card--popover',
   },
 };

--- a/packages/plugins/plugin-preview/src/testing/util.tsx
+++ b/packages/plugins/plugin-preview/src/testing/util.tsx
@@ -19,7 +19,7 @@ export type StoryProps = {
   icon?: string;
   withImage?: boolean;
   subject: 'project' | 'contact' | 'organization';
-  role: 'popover' | 'card--intrinsic' | 'card--extrinsic' | 'transclusion';
+  role: 'popover' | 'card--intrinsic' | 'card--extrinsic' | 'card--transclusion';
 };
 
 export const render: Meta<StoryProps>['render'] = ({

--- a/packages/plugins/plugin-preview/src/testing/util.tsx
+++ b/packages/plugins/plugin-preview/src/testing/util.tsx
@@ -19,7 +19,7 @@ export type StoryProps = {
   icon?: string;
   withImage?: boolean;
   subject: 'project' | 'contact' | 'organization';
-  role: 'popover' | 'card--intrinsic' | 'card--extrinsic' | 'card--transclusion';
+  role: 'card--popover' | 'card--intrinsic' | 'card--extrinsic' | 'card--transclusion';
 };
 
 export const render: Meta<StoryProps>['render'] = ({

--- a/packages/plugins/plugin-space/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-space/src/capabilities/react-surface.tsx
@@ -313,13 +313,13 @@ export default ({ createInvitationUrl }: ReactSurfaceOptions) =>
     }),
     createSurface({
       id: POPOVER_RENAME_SPACE,
-      role: 'popover',
+      role: 'card--popover',
       filter: (data): data is { props: Space } => data.component === POPOVER_RENAME_SPACE && isSpace(data.props),
       component: ({ data }) => <PopoverRenameSpace space={data.props} />,
     }),
     createSurface({
       id: POPOVER_RENAME_OBJECT,
-      role: 'popover',
+      role: 'card--popover',
       filter: (data): data is { props: Obj.Any } =>
         data.component === POPOVER_RENAME_OBJECT && isLiveObject(data.props),
       component: ({ data }) => <PopoverRenameObject object={data.props} />,

--- a/packages/plugins/plugin-storybook-layout/src/components/Layout.tsx
+++ b/packages/plugins/plugin-storybook-layout/src/components/Layout.tsx
@@ -109,7 +109,7 @@ export const Layout = ({ children }: PropsWithChildren<{}>) => {
           hideWhenDetached
         >
           <Popover.Viewport>
-            <Surface role='popover' data={layout.popoverContent} limit={1} />
+            <Surface role='card--popover' data={layout.popoverContent} limit={1} />
           </Popover.Viewport>
           <Popover.Arrow />
         </Popover.Content>

--- a/packages/plugins/plugin-table/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-table/src/capabilities/react-surface.tsx
@@ -23,7 +23,7 @@ export default () =>
     }),
     createSurface({
       id: `${meta.id}/table-preview`,
-      role: ['card--intrinsic', 'card--extrinsic', 'popover', 'transclusion', 'card'],
+      role: ['card--intrinsic', 'card--extrinsic', 'popover', 'card--transclusion', 'card'],
       filter: (data): data is { subject: DataType.View } =>
         Obj.instanceOf(DataType.View, data.subject) && Obj.instanceOf(TableView, data.subject.presentation.target),
       component: ({ data, role }) => <TablePreview view={data.subject} role={role} />,

--- a/packages/plugins/plugin-table/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-table/src/capabilities/react-surface.tsx
@@ -23,7 +23,7 @@ export default () =>
     }),
     createSurface({
       id: `${meta.id}/table-preview`,
-      role: ['card--intrinsic', 'card--extrinsic', 'popover', 'card--transclusion', 'card'],
+      role: ['card--intrinsic', 'card--extrinsic', 'card--popover', 'card--transclusion', 'card'],
       filter: (data): data is { subject: DataType.View } =>
         Obj.instanceOf(DataType.View, data.subject) && Obj.instanceOf(TableView, data.subject.presentation.target),
       component: ({ data, role }) => <TablePreview view={data.subject} role={role} />,

--- a/packages/plugins/plugin-table/src/components/TablePreview.stories.tsx
+++ b/packages/plugins/plugin-table/src/components/TablePreview.stories.tsx
@@ -105,7 +105,7 @@ export default meta;
 
 export const Popover = {
   args: {
-    role: 'popover',
+    role: 'card--popover',
   },
 };
 

--- a/packages/ui/react-ui-canvas-compute/src/shapes/Surface.tsx
+++ b/packages/ui/react-ui-canvas-compute/src/shapes/Surface.tsx
@@ -41,7 +41,7 @@ export const SurfaceComponent = ({ shape }: ShapeComponentProps<SurfaceShape>) =
 
   return (
     <Box shape={shape} onAction={handleAction}>
-      {value !== null && <Surface role='canvas-node' data={{ value }} limit={1} />}
+      {value !== null && <Surface role='card--extrinsic' data={{ value }} limit={1} />}
     </Box>
   );
 };

--- a/packages/ui/react-ui-editor/src/stories/Preview.stories.tsx
+++ b/packages/ui/react-ui-editor/src/stories/Preview.stories.tsx
@@ -48,7 +48,7 @@ const PreviewCard = () => {
     <Popover.Portal>
       <Popover.Content onOpenAutoFocus={(event) => event.preventDefault()}>
         <Popover.Viewport>
-          <Card.SurfaceRoot role='popover'>
+          <Card.SurfaceRoot role='card--popover'>
             <Card.Heading>{target?.label}</Card.Heading>
             {target && <Card.Text classNames='line-clamp-3'>{target.text}</Card.Text>}
           </Card.SurfaceRoot>

--- a/packages/ui/react-ui-graph/src/components/Graph/Graph.stories.tsx
+++ b/packages/ui/react-ui-graph/src/components/Graph/Graph.stories.tsx
@@ -255,7 +255,7 @@ const DefaultStory = ({
       <Popover.VirtualTrigger virtualRef={popoverAnchorRef} />
       <Popover.Content onOpenAutoFocus={(event) => event.preventDefault()}>
         <Popover.Viewport>
-          <Card.SurfaceRoot role='popover'>
+          <Card.SurfaceRoot role='card--popover'>
             <SyntaxHighlighter
               classNames='bg-transparent text-xs !mlb-cardSpacingBlock !pli-cardSpacingInline !overflow-visible'
               language='json'

--- a/packages/ui/react-ui-stack/src/exemplars/Card/Card.tsx
+++ b/packages/ui/react-ui-stack/src/exemplars/Card/Card.tsx
@@ -43,11 +43,11 @@ const CardSurfaceRoot = ({
   children,
   classNames,
 }: ThemedClassName<PropsWithChildren<{ role?: string }>>) => {
-  if (['popover', 'card--intrinsic', 'card--extrinsic'].includes(role)) {
+  if (['card--popover', 'card--intrinsic', 'card--extrinsic'].includes(role)) {
     return (
       <div
         className={mx(
-          role === 'popover'
+          role === 'card--popover'
             ? 'popover-card-width'
             : ['card--intrinsic', 'card--extrinsic'].includes(role)
               ? 'contents'

--- a/packages/ui/react-ui-stack/src/exemplars/Card/Card.tsx
+++ b/packages/ui/react-ui-stack/src/exemplars/Card/Card.tsx
@@ -61,7 +61,11 @@ const CardSurfaceRoot = ({
   } else {
     return (
       <CardStaticRoot
-        classNames={[role === 'transclusion' && 'mlb-[1em]', role === 'transclusion' && hoverableControls, classNames]}
+        classNames={[
+          role === 'card--transclusion' && 'mlb-[1em]',
+          role === 'card--transclusion' && hoverableControls,
+          classNames,
+        ]}
       >
         {children}
       </CardStaticRoot>

--- a/packages/ui/react-ui-stack/src/testing/CardContainer.tsx
+++ b/packages/ui/react-ui-stack/src/testing/CardContainer.tsx
@@ -14,7 +14,7 @@ export const CardContainer = ({
   role,
 }: PropsWithChildren<{ icon?: string; role?: string }>) => {
   switch (role) {
-    case 'popover':
+    case 'card--popover':
       return <PopoverCardContainer icon={icon}>{children}</PopoverCardContainer>;
     case 'card--intrinsic':
       return (

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -58,10 +58,10 @@ const TableRoot = ({ children, role = 'article' }: TableRootProps) => {
       role='none'
       className={mx(
         'relative !border-separator [&_.dx-grid]:max-is-[--dx-grid-content-inline-size] [&_.dx-grid]:max-bs-[--dx-grid-content-block-size]',
-        role === 'popover' && 'popover-card-height',
+        role === 'card--popover' && 'popover-card-height',
         role === 'section' && 'attention-surface',
         role === 'card--intrinsic' && '[&_.dx-grid]:bs-[--dx-grid-content-block-size]',
-        ['popover', 'section', 'card--extrinsic'].includes(role) && 'overflow-hidden',
+        ['card--popover', 'section', 'card--extrinsic'].includes(role) && 'overflow-hidden',
         ['article', 'slide'].includes(role) && 'flex flex-col [&_.dx-grid]:grow [&_.dx-grid]:bs-0',
       )}
     >


### PR DESCRIPTION
This PR:
- renames roles such that all roles considered by `Card.SurfaceRoot` begin with `card--`
  - `transclusion` -> `card--transclusion`
  - `popover` -> `card--popover`
  - `canvas-node` -> `card--extrinsic`
- Adjusts ChessContainer and ChessPlugin’s react-surface.