### PR TITLE
feat: `dx-grid` handling of backspace/delete

### DIFF
--- a/packages/ui/lit-grid/src/dx-grid.ts
+++ b/packages/ui/lit-grid/src/dx-grid.ts
@@ -9,7 +9,6 @@ import { styleMap } from 'lit/directives/style-map.js';
 import { unsafeStatic, html as staticHtml } from 'lit/static-html.js';
 
 import { defaultColSize, defaultRowSize } from './defs';
-// eslint-disable-next-line unused-imports/no-unused-imports
 import './dx-grid-axis-resize-handle';
 import {
   type DxGridAxisMetaProps,
@@ -480,6 +479,13 @@ export class DxGrid extends LitElement {
           case 'Enter':
             event.preventDefault();
             this.dispatchEditRequest();
+            break;
+          case 'Backspace':
+          case 'Delete':
+            if (!event.defaultPrevented) {
+              event.preventDefault();
+              this.dispatchEditRequest('');
+            }
             break;
           default:
             if (event.key.length === 1 && event.key.match(/\P{Cc}/u) && !(event.metaKey || event.ctrlKey)) {

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -282,7 +282,12 @@ const TableMain = forwardRef<TableController, TableMainProps>(
         switch (event.key) {
           case 'Backspace':
           case 'Delete': {
-            model.setCellData(cell, undefined);
+            try {
+              model.setCellData(cell, undefined);
+              event.preventDefault();
+            } catch {
+              // Delete results in a validation error; don’t prevent default so dx-grid can emit an edit request.
+            }
             break;
           }
         }
@@ -391,7 +396,7 @@ const TableMain = forwardRef<TableController, TableMainProps>(
           overscroll='trap'
           onAxisResize={handleAxisResize}
           onClick={handleGridClick}
-          onKeyDown={handleKeyDown}
+          onKeyDownCapture={handleKeyDown}
           onWheelCapture={handleWheel}
           ref={setDxGrid}
         />


### PR DESCRIPTION
This PR:
- causes `dx-grid` to dispatch an empty edit request if default is not prevented on a backspace/delete keydown
- adjusts Table’s keydown handler, now on the capture phase, to `preventDefault` if the model is able to clear the value without editing, otherwise it lets dx-grid emit the empty edit request

https://github.com/user-attachments/assets/e9ee59b6-cea6-4dbc-9b86-7be1809b0bef

