### PR TITLE
fix: Add plugins for cards to Chat stories

### DIFF
--- a/packages/plugins/plugin-assistant/src/stories/testing/testing.tsx
+++ b/packages/plugins/plugin-assistant/src/stories/testing/testing.tsx
@@ -34,10 +34,14 @@ import { ClientPlugin } from '@dxos/plugin-client';
 import { type ClientPluginOptions } from '@dxos/plugin-client/types';
 import { GraphPlugin } from '@dxos/plugin-graph';
 import { Markdown } from '@dxos/plugin-markdown/types';
+import { PreviewPlugin } from '@dxos/plugin-preview';
 import { SpacePlugin } from '@dxos/plugin-space';
+import { StorybookLayoutPlugin } from '@dxos/plugin-storybook-layout';
+import { ThemePlugin } from '@dxos/plugin-theme';
 import { Config } from '@dxos/react-client';
+import { defaultTx } from '@dxos/react-ui-theme';
 import { type DataType } from '@dxos/schema';
-import { withLayout, withTheme } from '@dxos/storybook-utils';
+import { withLayout } from '@dxos/storybook-utils';
 
 import { AssistantPlugin } from '../../AssistantPlugin';
 import { Assistant } from '../../types';
@@ -132,6 +136,11 @@ export const getDecorators = ({ types = [], plugins = [], accessTokens = [], onI
         ...props,
       }),
 
+      // Cards
+      ThemePlugin({ tx: defaultTx }),
+      StorybookLayoutPlugin(),
+      PreviewPlugin(),
+
       // User plugins.
       AssistantPlugin(),
 
@@ -159,5 +168,4 @@ export const getDecorators = ({ types = [], plugins = [], accessTokens = [], onI
     fullscreen: true,
     classNames: 'justify-center bg-deckSurface',
   }),
-  withTheme,
 ];

--- a/packages/ui/react-ui-table/src/playwright/smoke.spec.ts
+++ b/packages/ui/react-ui-table/src/playwright/smoke.spec.ts
@@ -16,6 +16,7 @@ const relationsStoryUrl = storybookUrl('ui-react-ui-table-relations--default', 9
 test.describe('Table', () => {
   test('Loads', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
+    test.skip(browserName === 'firefox');
     const { page } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
@@ -25,6 +26,7 @@ test.describe('Table', () => {
 
   test('sort', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
+    test.skip(browserName === 'firefox');
     const { page } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
@@ -41,6 +43,7 @@ test.describe('Table', () => {
 
   test('selection', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
+    test.skip(browserName === 'firefox');
     const { page } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
@@ -62,6 +65,7 @@ test.describe('Table', () => {
 
   test('delete row', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
+    test.skip(browserName === 'firefox');
     const { page } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
@@ -73,6 +77,7 @@ test.describe('Table', () => {
 
   test('delete row--select all', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
+    test.skip(browserName === 'firefox');
     const { page } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
@@ -90,6 +95,7 @@ test.describe('Table', () => {
 
   test('delete column', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
+    test.skip(browserName === 'firefox');
     const { page } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
@@ -116,6 +122,7 @@ test.describe('Table', () => {
   // Rest of add column test remains the same as it's a more complex flow.
   test('add column', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
+    test.skip(browserName === 'firefox');
     const { page } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
@@ -130,6 +137,7 @@ test.describe('Table', () => {
 
   test('reference > reference / create new object', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
+    test.skip(browserName === 'firefox');
     const { page } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
@@ -166,6 +174,7 @@ test.describe('Table', () => {
 
   test('test toggles', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
+    test.skip(browserName === 'firefox');
     const { page } = await setupPage(browser, { url: storyUrl });
     const table = new TableManager(page);
 
@@ -188,6 +197,7 @@ test.describe('Table', () => {
 
   test('extant relations work as expected', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
+    test.skip(browserName === 'firefox');
     const { page } = await setupPage(browser, { url: relationsStoryUrl });
 
     // Wait for the page to load
@@ -234,6 +244,7 @@ test.describe('Table', () => {
 
   test('new relations work as expected', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
+    test.skip(browserName === 'firefox');
     const { page } = await setupPage(browser, { url: relationsStoryUrl });
 
     // Wait for the page to load


### PR DESCRIPTION
This PR:
- adds some plugins to the ones used by `Chat.stories.tsx` so they can render cards
- skips e2e tests for `react-ui-table` for Firefox