### PR TITLE
fix: deprecated `getSnapshot` causing schema RTE

### DIFF
--- a/packages/ui/react-ui-table/src/components/Table/Relations.stories.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Relations.stories.tsx
@@ -103,7 +103,7 @@ const DefaultStory = () => {
 };
 
 const meta: Meta<typeof DefaultStory> = {
-  title: 'ui/react-ui-table/relations',
+  title: 'ui/react-ui-table/Relations',
   render: DefaultStory,
   parameters: { translations, controls: { disable: true } },
   decorators: [

--- a/packages/ui/react-ui-table/src/model/table-model.ts
+++ b/packages/ui/react-ui-table/src/model/table-model.ts
@@ -12,14 +12,13 @@ import {
   type JsonProp,
   type JsonSchemaType,
   getSchema,
-  getSnapshot,
   getValue,
   setValue,
   toEffectSchema,
 } from '@dxos/echo-schema';
 import { invariant } from '@dxos/invariant';
 import { ObjectId } from '@dxos/keys';
-import { isLiveObject } from '@dxos/live-object';
+import { getSnapshot, isLiveObject } from '@dxos/live-object';
 import { fullyQualifiedId } from '@dxos/react-client/echo';
 import { type Label } from '@dxos/react-ui';
 import { formatForEditing, parseValue } from '@dxos/react-ui-form';

--- a/packages/ui/react-ui-table/src/playwright/smoke.spec.ts
+++ b/packages/ui/react-ui-table/src/playwright/smoke.spec.ts
@@ -5,6 +5,7 @@
 import { expect, test } from '@playwright/test';
 
 import { type DxGrid } from '@dxos/lit-grid';
+import { faker } from '@dxos/random';
 import { setupPage, storybookUrl } from '@dxos/test-utils/playwright';
 
 import { TableManager } from './TableManager';
@@ -242,7 +243,7 @@ test.describe('Table', () => {
     await page.close();
   });
 
-  test('new relations work as expected', async ({ browser, browserName }) => {
+  test.only('new relations work as expected', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
     const { page } = await setupPage(browser, { url: relationsStoryUrl });
@@ -283,6 +284,20 @@ test.describe('Table', () => {
 
     // Assert that the cell element has the org name
     await expect(targetCell).toHaveText(orgName);
+
+    // Make a change to a non-ref cell to check that populated refs don’t cause problems with snapshots or schemas.
+    await dxGrid.evaluate(async (dxGridElement: DxGrid) => {
+      dxGridElement.scrollToColumn(6);
+    });
+
+    const nonRefContent = faker.lorem.words(3);
+    const nonRefCell = dxGrid.locator('[data-dx-grid-plane="grid"] [aria-rowindex="0"][aria-colindex="6"]');
+    await nonRefCell.click();
+    await page.keyboard.press('Enter');
+    await page.getByTestId('grid.cell-editor').waitFor({ state: 'visible' });
+    await page.keyboard.type(nonRefContent, { delay: 500 });
+    await page.keyboard.press('Enter');
+    await expect(nonRefCell).toHaveText(nonRefContent);
 
     await page.close();
   });

--- a/packages/ui/react-ui-table/src/playwright/smoke.spec.ts
+++ b/packages/ui/react-ui-table/src/playwright/smoke.spec.ts
@@ -243,7 +243,7 @@ test.describe('Table', () => {
     await page.close();
   });
 
-  test.only('new relations work as expected', async ({ browser, browserName }) => {
+  test('new relations work as expected', async ({ browser, browserName }) => {
     test.skip(browserName === 'webkit');
     test.skip(browserName === 'firefox');
     const { page } = await setupPage(browser, { url: relationsStoryUrl });


### PR DESCRIPTION
This PR:
- switches to use the recommended `getSnapshot`
- adds an e2e test case so this doesn’t regress

https://github.com/user-attachments/assets/4bda2fd3-8618-4066-8423-bcf4995772e7

