### PR TITLE
fix: Minor visual fixes to DxGrid and DxAvatar

### DIFF
--- a/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.tsx
+++ b/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.tsx
@@ -60,11 +60,11 @@ const frozen = {
 };
 
 const sheetColDefault = {
-  frozenColsStart: { size: 48, readonly: true },
+  frozenColsStart: { size: 48, readonly: true, focusUnfurl: false },
   grid: { size: defaultColSize, resizeable: true },
 };
 const sheetRowDefault = {
-  frozenRowsStart: { size: defaultRowSize, readonly: true },
+  frozenRowsStart: { size: defaultRowSize, readonly: true, focusUnfurl: false },
   grid: { size: defaultRowSize, resizeable: true },
 };
 

--- a/packages/ui/lit-grid/src/defs.ts
+++ b/packages/ui/lit-grid/src/defs.ts
@@ -4,3 +4,4 @@
 
 export const defaultColSize = 180;
 export const defaultRowSize = 30;
+export const focusUnfurlDefault = true;

--- a/packages/ui/lit-grid/src/dx-grid.pcss
+++ b/packages/ui/lit-grid/src/dx-grid.pcss
@@ -137,7 +137,7 @@
     [role='gridcell'],
     [role='columnheader'],
     [role='rowheader'] {
-      &:not(.dx-grid__cell--no-focus-unfurl){
+      &:not([data-focus-unfurl="false"]):not(.dx-grid__cell--no-focus-unfurl) {
         &:focus,
         &:focus-within {
           & > .dx-grid__cell__content {

--- a/packages/ui/lit-grid/src/dx-grid.ts
+++ b/packages/ui/lit-grid/src/dx-grid.ts
@@ -8,7 +8,7 @@ import { type Ref, createRef, ref } from 'lit/directives/ref.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { html as staticHtml, unsafeStatic } from 'lit/static-html.js';
 
-import { defaultColSize, defaultRowSize } from './defs';
+import { defaultColSize, defaultRowSize, focusUnfurlDefault } from './defs';
 import './dx-grid-axis-resize-handle';
 import {
   DxAxisResize,
@@ -83,12 +83,12 @@ export class DxGrid extends LitElement {
   gridId: string = 'default-grid-id';
 
   @property({ type: Object })
-  rowDefault: DxGridPlaneRecord<DxGridFrozenRowsPlane, Partial<DxGridAxisMetaProps>> = {
+  rowDefault: Partial<DxGridPlaneRecord<DxGridFrozenRowsPlane, Partial<DxGridAxisMetaProps>>> = {
     grid: { size: defaultRowSize },
   };
 
   @property({ type: Object })
-  columnDefault: DxGridPlaneRecord<DxGridFrozenColsPlane, Partial<DxGridAxisMetaProps>> = {
+  columnDefault: Partial<DxGridPlaneRecord<DxGridFrozenColsPlane, Partial<DxGridAxisMetaProps>>> = {
     grid: { size: defaultColSize },
   };
 
@@ -1285,6 +1285,23 @@ export class DxGrid extends LitElement {
     return isReadonly(colReadOnly) || isReadonly(rowReadOnly);
   }
 
+  private cellFocusUnfurl(col: number, row: number, plane: DxGridPlane): boolean {
+    const colPlane = resolveColPlane(plane);
+    const rowPlane = resolveRowPlane(plane);
+
+    // Check cell-specific setting first.
+    const cellUnfurl = this.cell(col, row, plane)?.focusUnfurl;
+    if (cellUnfurl !== undefined) {
+      return cellUnfurl;
+    }
+
+    // Check column/row defaults.
+    const colUnfurl = this.columns?.[colPlane]?.[col]?.focusUnfurl ?? this.columnDefault?.[colPlane]?.focusUnfurl;
+    const rowUnfurl = this.rows?.[rowPlane]?.[row]?.focusUnfurl ?? this.rowDefault?.[rowPlane]?.focusUnfurl;
+
+    return colUnfurl ?? rowUnfurl ?? focusUnfurlDefault;
+  }
+
   /**
    * Determines if the cell's text content should be selectable based on its readonly value.
    * @returns true if the cells text content is selectable, false otherwise.
@@ -1347,6 +1364,7 @@ export class DxGrid extends LitElement {
     const cell = this.cell(col, row, plane);
     const active = this.cellActive(col, row, plane);
     const readonly = this.cellReadonly(col, row, plane);
+    const focusUnfurl = this.cellFocusUnfurl(col, row, plane);
     const textSelectable = this.cellTextSelectable(col, row, plane);
     const resizeIndex = cell?.resizeHandle ? (cell.resizeHandle === 'col' ? col : row) : undefined;
     const resizePlane = cell?.resizeHandle ? resolveFrozenPlane(cell.resizeHandle, plane) : undefined;
@@ -1358,6 +1376,7 @@ export class DxGrid extends LitElement {
       aria-readonly=${readonly ? 'true' : nothing}
       class=${cell?.className ?? nothing}
       data-refs=${cell?.dataRefs ?? nothing}
+      data-focus-unfurl=${focusUnfurl ? nothing : 'false'}
       ?data-dx-active=${active}
       data-text-selectable=${textSelectable ? 'true' : 'false'}
       data-dx-grid-action="cell"

--- a/packages/ui/lit-grid/src/types.ts
+++ b/packages/ui/lit-grid/src/types.ts
@@ -90,6 +90,8 @@ export type DxGridAxisMetaProps = {
   description?: string;
   resizeable?: boolean;
   readonly?: DxGridReadonlyValue;
+  minSize?: number;
+  maxSize?: number;
 };
 
 export type DxGridAxisSizes = DxGridPlaneRecord<DxGridFrozenPlane, Record<string, number>>;

--- a/packages/ui/lit-grid/src/types.ts
+++ b/packages/ui/lit-grid/src/types.ts
@@ -83,6 +83,10 @@ export type DxGridCellValue = {
    * Controls the read-only state of the cell.
    */
   readonly?: DxGridReadonlyValue;
+  /**
+   * Controls whether the cell content should unfurl when the cell has focus.
+   */
+  focusUnfurl?: boolean;
 };
 
 export type DxGridAxisMetaProps = {
@@ -90,6 +94,7 @@ export type DxGridAxisMetaProps = {
   description?: string;
   resizeable?: boolean;
   readonly?: DxGridReadonlyValue;
+  focusUnfurl?: boolean;
   minSize?: number;
   maxSize?: number;
 };

--- a/packages/ui/lit-ui/src/dx-avatar/dx-avatar.pcss
+++ b/packages/ui/lit-ui/src/dx-avatar/dx-avatar.pcss
@@ -74,5 +74,11 @@ dx-avatar {
       @apply hidden;
     }
   }
+
+  &[data-state-loading-status="error"] {
+    .dx-avatar__image {
+      @apply hidden;
+    }
+  }
 }
 

--- a/packages/ui/lit-ui/src/dx-avatar/dx-avatar.ts
+++ b/packages/ui/lit-ui/src/dx-avatar/dx-avatar.ts
@@ -195,6 +195,7 @@ export class DxAvatar extends LitElement {
               width="100%"
               height="100%"
               preserveAspectRatio="xMidYMid slice"
+              class="dx-avatar__image"
               href=${this.imgSrc}
               mask=${`url(#${this.maskId})`}
               crossorigin=${this.imgCrossOrigin}

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -47,6 +47,8 @@ import { ColumnSettings } from './ColumnSettings';
 import { CreateRefPanel } from './CreateRefPanel';
 import { RowActionsMenu } from './RowActionsMenu';
 
+const columnDefault = { grid: { minSize: 42 } };
+
 //
 // Table.Root
 //
@@ -405,6 +407,7 @@ const TableMain = forwardRef<TableController, TableMainProps>(
           className={mx('[--dx-grid-base:var(--baseSurface)]', gridSeparatorInlineEnd, gridSeparatorBlockEnd)}
           frozen={frozen}
           columns={model.columnMeta.value}
+          columnDefault={columnDefault}
           limitRows={model.getRowCount() ?? 0}
           limitColumns={model.projection.fields.length}
           overscroll='trap'

--- a/packages/ui/react-ui-table/src/components/Table/Table.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.tsx
@@ -48,6 +48,7 @@ import { CreateRefPanel } from './CreateRefPanel';
 import { RowActionsMenu } from './RowActionsMenu';
 
 const columnDefault = { grid: { minSize: 42 } };
+const rowDefault = { frozenRowsStart: { readonly: true, focusUnfurl: false } };
 
 //
 // Table.Root
@@ -408,6 +409,7 @@ const TableMain = forwardRef<TableController, TableMainProps>(
           frozen={frozen}
           columns={model.columnMeta.value}
           columnDefault={columnDefault}
+          rowDefault={rowDefault}
           limitRows={model.getRowCount() ?? 0}
           limitColumns={model.projection.fields.length}
           overscroll='trap'

--- a/packages/ui/react-ui-table/src/model/table-presentation.ts
+++ b/packages/ui/react-ui-table/src/model/table-presentation.ts
@@ -317,7 +317,6 @@ export class TablePresentation<T extends TableRow = TableRow> {
       cells[toPlaneCellIndex({ col, row: 0 })] = {
         // TODO(burdon): Use same logic as form for fallback title.
         value: props.title ?? field.path,
-        readonly: true,
         resizeHandle: 'col',
         accessoryHtml: `
           ${direction !== undefined ? tableButtons.sort.render({ fieldId: field.id, direction }) : ''}

--- a/packages/ui/react-ui/src/components/Avatars/Avatar.stories.tsx
+++ b/packages/ui/react-ui/src/components/Avatars/Avatar.stories.tsx
@@ -67,6 +67,8 @@ export default {
 const sampleImage =
   'https://png.pngtree.com/thumb_back/fh260/background/20230614/pngtree-the-photo-of-a-woman-with-red-sunglasses-is-surrounded-by-image_2931163.jpg';
 
+const brokenImage = 'https://png.pngtree.com/potato_squirrel.png';
+
 const row = (size: Size) => (
   <>
     <DefaultStory size={size} status='inactive' description='Offline' />
@@ -95,6 +97,12 @@ export const Default = () => (
 export const Image = () => (
   <div>
     <DefaultStory variant='circle' imgSrc={sampleImage} />
+  </div>
+);
+
+export const BrokenImage = () => (
+  <div>
+    <DefaultStory variant='circle' imgSrc={brokenImage} />
   </div>
 );
 


### PR DESCRIPTION
This PR:
- resolves DX-386 and DX-387
- adds a `focusUnfurl` option to cells and axes in `dx-grid` which can disable the focus unfurl layout; maintains the utility class for this in case that is more convenient for consumers

https://github.com/user-attachments/assets/01e10986-01a3-45e7-8005-7aaff1b2d096

https://github.com/user-attachments/assets/a364ee3e-2f11-4387-9388-3c3017ee2b37
