### PR TITLE
fix: Remove not_meta exports and standardize all stories

### DIFF
--- a/.idea/fileTemplates/Typescript storybook༏ext༏.stories.tsx
+++ b/.idea/fileTemplates/Typescript storybook༏ext༏.stories.tsx
@@ -6,16 +6,22 @@ import '@dxos-theme';
 
 import React from 'react';
 
+import { Meta, StoryObj } from '@storybook/react-vite';
+
 import { withTheme } from '@dxos/storybook-utils';
 
-const Story = () => <div>Test</div>;
+const Component = () => <div>Test</div>;
 
-export default {
+const meta: Meta<typeof Component> = {
   title: 'example/Story',
-  component: Story,
+  component: Component,
   decorators: [withTheme],
 };
 
-export const Default = {
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
   args: {},
 };

--- a/packages/plugins/plugin-markdown/src/meta.ts
+++ b/packages/plugins/plugin-markdown/src/meta.ts
@@ -17,6 +17,3 @@ export const meta: PluginMeta = {
   source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-markdown',
   screenshots: ['https://dxos.network/plugin-details-markdown-dark.png'],
 };
-
-// TODO(burdon): Workaround for suspected vitest bug? Update vitest?
-export const not_meta = meta;

--- a/packages/plugins/plugin-markdown/src/types/MarkdownAction.ts
+++ b/packages/plugins/plugin-markdown/src/types/MarkdownAction.ts
@@ -6,11 +6,11 @@ import { Schema } from 'effect';
 
 import { EditorViewMode } from '@dxos/react-ui-editor/types';
 
-import { not_meta } from '../meta';
+import { meta } from '../meta';
 
 import { Document } from './Markdown';
 
-export class Create extends Schema.TaggedClass<Create>()(`${not_meta.id}/action/create`, {
+export class Create extends Schema.TaggedClass<Create>()(`${meta.id}/action/create`, {
   input: Schema.Struct({
     name: Schema.optional(Schema.String),
     content: Schema.optional(Schema.String),
@@ -20,7 +20,7 @@ export class Create extends Schema.TaggedClass<Create>()(`${not_meta.id}/action/
   }),
 }) {}
 
-export class SetViewMode extends Schema.TaggedClass<SetViewMode>()(`${not_meta.id}/action/set-view-mode`, {
+export class SetViewMode extends Schema.TaggedClass<SetViewMode>()(`${meta.id}/action/set-view-mode`, {
   input: Schema.Struct({
     id: Schema.String,
     viewMode: EditorViewMode,

--- a/packages/plugins/plugin-meeting/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-meeting/src/capabilities/app-graph-builder.ts
@@ -17,7 +17,7 @@ import { ThreadCapabilities } from '@dxos/plugin-thread';
 import { ChannelType } from '@dxos/plugin-thread/types';
 import { SpaceState, fullyQualifiedId, getSpace } from '@dxos/react-client/echo';
 
-import { not_meta } from '../meta';
+import { meta } from '../meta';
 import { Meeting, MeetingAction } from '../types';
 
 import { MeetingCapabilities } from './capabilities';
@@ -26,7 +26,7 @@ export default (context: PluginContext) =>
   contributes(Capabilities.AppGraphBuilder, [
     // TODO(wittjosiah): This currently won't _start_ the call but will navigate to the correct channel.
     createExtension({
-      id: `${not_meta.id}/share-call-link`,
+      id: `${meta.id}/share-call-link`,
       actions: (node) =>
         Rx.make((get) =>
           pipe(
@@ -55,7 +55,7 @@ export default (context: PluginContext) =>
                   );
                 },
                 properties: {
-                  label: ['share call link label', { ns: not_meta.id }],
+                  label: ['share call link label', { ns: meta.id }],
                   icon: 'ph--share-network--regular',
                 },
               },
@@ -66,7 +66,7 @@ export default (context: PluginContext) =>
     }),
 
     createExtension({
-      id: `${not_meta.id}/call-thread`,
+      id: `${meta.id}/call-thread`,
       connector: (node) => {
         return Rx.make((get) =>
           pipe(
@@ -93,7 +93,7 @@ export default (context: PluginContext) =>
                   type: PLANK_COMPANION_TYPE,
                   data: get(rxFromSignal(() => meeting.thread.target)),
                   properties: {
-                    label: ['meeting thread label', { ns: not_meta.id }],
+                    label: ['meeting thread label', { ns: meta.id }],
                     icon: 'ph--chat-text--regular',
                     position: 'hoist',
                     disposition: 'hidden',
@@ -108,7 +108,7 @@ export default (context: PluginContext) =>
     }),
 
     createExtension({
-      id: `${not_meta.id}/call-companion`,
+      id: `${meta.id}/call-companion`,
       connector: (node) =>
         Rx.make((get) =>
           pipe(
@@ -131,7 +131,7 @@ export default (context: PluginContext) =>
                   type: PLANK_COMPANION_TYPE,
                   data,
                   properties: {
-                    label: [data === 'meeting' ? 'meeting list label' : 'meeting companion label', { ns: not_meta.id }],
+                    label: [data === 'meeting' ? 'meeting list label' : 'meeting companion label', { ns: meta.id }],
                     icon: 'ph--note--regular',
                     position: 'hoist',
                     disposition: 'hidden',
@@ -145,7 +145,7 @@ export default (context: PluginContext) =>
     }),
 
     createExtension({
-      id: `${not_meta.id}/call-transcript`,
+      id: `${meta.id}/call-transcript`,
       actions: (node) =>
         Rx.make((get) =>
           pipe(
@@ -195,8 +195,8 @@ export default (context: PluginContext) =>
                   },
                   properties: {
                     label: enabled
-                      ? ['stop transcription label', { ns: not_meta.id }]
-                      : ['start transcription label', { ns: not_meta.id }],
+                      ? ['stop transcription label', { ns: meta.id }]
+                      : ['start transcription label', { ns: meta.id }],
                     icon: 'ph--subtitles--regular',
                     disposition: 'toolbar',
                     classNames: enabled ? 'bg-callAlert' : '',
@@ -224,7 +224,7 @@ export default (context: PluginContext) =>
                   type: PLANK_COMPANION_TYPE,
                   data: get(rxFromSignal(() => meeting.transcript.target)),
                   properties: {
-                    label: ['transcript companion label', { ns: not_meta.id }],
+                    label: ['transcript companion label', { ns: meta.id }],
                     icon: 'ph--subtitles--regular',
                     position: 'hoist',
                     disposition: 'hidden',
@@ -238,7 +238,7 @@ export default (context: PluginContext) =>
     }),
 
     createExtension({
-      id: `${not_meta.id}/meeting-transcript-companion`,
+      id: `${meta.id}/meeting-transcript-companion`,
       connector: (node) =>
         Rx.make((get) =>
           pipe(
@@ -253,7 +253,7 @@ export default (context: PluginContext) =>
                   type: PLANK_COMPANION_TYPE,
                   data: get(rxFromSignal(() => meeting.transcript.target)),
                   properties: {
-                    label: ['transcript companion label', { ns: not_meta.id }],
+                    label: ['transcript companion label', { ns: meta.id }],
                     icon: 'ph--subtitles--regular',
                     position: 'hoist',
                     disposition: 'hidden',

--- a/packages/plugins/plugin-meeting/src/capabilities/call-extension.ts
+++ b/packages/plugins/plugin-meeting/src/capabilities/call-extension.ts
@@ -19,7 +19,7 @@ import { type MeetingPayloadSchema } from '@dxos/protocols/buf/dxos/edge/calls_p
 import { type Space, getSpace } from '@dxos/react-client/echo';
 import { type DataType } from '@dxos/schema';
 
-import { not_meta } from '../meta';
+import { meta } from '../meta';
 import { Meeting, MeetingAction } from '../types';
 
 import { MeetingCapabilities } from './capabilities';
@@ -32,7 +32,7 @@ export default (context: PluginContext) => {
   const { dispatchPromise: dispatch } = context.getCapability(Capabilities.IntentDispatcher);
   const client = context.getCapability(ClientCapabilities.Client);
   const state = context.getCapability(MeetingCapabilities.State);
-  const _settings = context.getCapability(Capabilities.SettingsStore).getStore<Meeting.Settings>(not_meta.id)!.value;
+  const _settings = context.getCapability(Capabilities.SettingsStore).getStore<Meeting.Settings>(meta.id)!.value;
 
   return contributes(ThreadCapabilities.CallExtension, {
     onJoin: async ({ channel }: { channel?: ChannelType }) => {

--- a/packages/plugins/plugin-meeting/src/capabilities/capabilities.ts
+++ b/packages/plugins/plugin-meeting/src/capabilities/capabilities.ts
@@ -6,7 +6,7 @@ import { defineCapability } from '@dxos/app-framework';
 import { type Live } from '@dxos/live-object';
 import { type TranscriptionManager } from '@dxos/plugin-transcription';
 
-import { not_meta } from '../meta';
+import { meta } from '../meta';
 import { type Meeting } from '../types';
 
 export namespace MeetingCapabilities {
@@ -14,5 +14,6 @@ export namespace MeetingCapabilities {
     activeMeeting?: Meeting.Meeting;
     transcriptionManager?: TranscriptionManager;
   }>;
-  export const State = defineCapability<State>(`${not_meta.id}/capability/state`);
+
+  export const State = defineCapability<State>(`${meta.id}/capability/state`);
 }

--- a/packages/plugins/plugin-meeting/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-meeting/src/capabilities/react-surface.tsx
@@ -10,26 +10,26 @@ import { SettingsStore } from '@dxos/local-storage';
 import { ChannelType } from '@dxos/plugin-thread/types';
 
 import { MeetingContainer, MeetingSettings, MeetingsList } from '../components';
-import { not_meta } from '../meta';
+import { meta } from '../meta';
 import { Meeting } from '../types';
 
 export default () =>
   contributes(Capabilities.ReactSurface, [
     createSurface({
-      id: `${not_meta.id}/plugin-settings`,
+      id: `${meta.id}/plugin-settings`,
       role: 'article',
       filter: (data): data is { subject: SettingsStore<Meeting.Settings> } =>
-        data.subject instanceof SettingsStore && data.subject.prefix === not_meta.id,
+        data.subject instanceof SettingsStore && data.subject.prefix === meta.id,
       component: ({ data: { subject } }) => <MeetingSettings settings={subject.value} />,
     }),
     createSurface({
-      id: `${not_meta.id}/meeting`,
+      id: `${meta.id}/meeting`,
       role: 'article',
       filter: (data): data is { subject: Meeting.Meeting } => Obj.instanceOf(Meeting.Meeting, data.subject),
       component: ({ data }) => <MeetingContainer meeting={data.subject} />,
     }),
     createSurface({
-      id: `${not_meta.id}/meeting-companion`,
+      id: `${meta.id}/meeting-companion`,
       role: 'article',
       filter: (data): data is { subject: Meeting.Meeting | 'meeting'; companionTo: ChannelType } =>
         (Obj.instanceOf(Meeting.Meeting, data.subject) || data.subject === 'meeting') &&

--- a/packages/plugins/plugin-meeting/src/components/MeetingContainer.tsx
+++ b/packages/plugins/plugin-meeting/src/components/MeetingContainer.tsx
@@ -9,7 +9,7 @@ import { fullyQualifiedId } from '@dxos/client/echo';
 import { IconButton, useTranslation } from '@dxos/react-ui';
 import { Stack, StackItem } from '@dxos/react-ui-stack';
 
-import { not_meta } from '../meta';
+import { meta } from '../meta';
 import { type Meeting, MeetingAction } from '../types';
 
 export type MeetingContainerProps = {
@@ -17,7 +17,7 @@ export type MeetingContainerProps = {
 };
 
 export const MeetingContainer = ({ meeting }: MeetingContainerProps) => {
-  const { t } = useTranslation(not_meta.id);
+  const { t } = useTranslation(meta.id);
   const { dispatchPromise: dispatch } = useIntentDispatcher();
   const notes = meeting.notes?.target;
   const summary = meeting.summary?.target;

--- a/packages/plugins/plugin-meeting/src/components/MeetingSettings/MeetingSettings.tsx
+++ b/packages/plugins/plugin-meeting/src/components/MeetingSettings/MeetingSettings.tsx
@@ -7,11 +7,11 @@ import React from 'react';
 import { Input, useTranslation } from '@dxos/react-ui';
 import { DeprecatedFormContainer, DeprecatedFormInput } from '@dxos/react-ui-form';
 
-import { not_meta } from '../../meta';
+import { meta } from '../../meta';
 import { type Meeting } from '../../types';
 
 export const MeetingSettings = ({ settings }: { settings: Meeting.Settings }) => {
-  const { t } = useTranslation(not_meta.id);
+  const { t } = useTranslation(meta.id);
 
   return (
     <DeprecatedFormContainer>

--- a/packages/plugins/plugin-meeting/src/components/MeetingsList.tsx
+++ b/packages/plugins/plugin-meeting/src/components/MeetingsList.tsx
@@ -14,7 +14,7 @@ import { Button, useTranslation } from '@dxos/react-ui';
 import { List } from '@dxos/react-ui-list';
 import { ghostHover, mx } from '@dxos/react-ui-theme';
 
-import { not_meta } from '../meta';
+import { meta } from '../meta';
 import { Meeting, MeetingAction } from '../types';
 
 // TODO(wittjosiah): Add a story which renders meetings alongside call?
@@ -28,7 +28,7 @@ const MeetingItem = ({
   meeting: Meeting.Meeting;
   getLabel: (meeting: Meeting.Meeting) => string;
 }) => {
-  const { t } = useTranslation(not_meta.id);
+  const { t } = useTranslation(meta.id);
   const { dispatchPromise: dispatch } = useIntentDispatcher();
 
   const handleSelectMeeting = useCallback(
@@ -51,7 +51,7 @@ const MeetingItem = ({
 };
 
 export const MeetingsList = ({ channel }: { channel: ChannelType }) => {
-  const { t } = useTranslation(not_meta.id);
+  const { t } = useTranslation(meta.id);
   const { dispatchPromise: dispatch } = useIntentDispatcher();
   const space = getSpace(channel);
   const meetings = useQuery(space, Query.type(Meeting.Meeting));

--- a/packages/plugins/plugin-meeting/src/meta.ts
+++ b/packages/plugins/plugin-meeting/src/meta.ts
@@ -15,6 +15,3 @@ export const meta: PluginMeta = {
   // TODO(wittjosiah): Needs new screenshots.
   screenshots: ['https://dxos.network/plugin-details-calls-dark.png'],
 };
-
-// TODO(burdon): Workaround for suspected vitest bug? Update vitest?
-export const not_meta = meta;

--- a/packages/plugins/plugin-meeting/src/types/MeetingAction.ts
+++ b/packages/plugins/plugin-meeting/src/types/MeetingAction.ts
@@ -8,11 +8,11 @@ import { SpaceSchema } from '@dxos/client/echo';
 import { ChannelType } from '@dxos/plugin-thread/types';
 import { DataType } from '@dxos/schema';
 
-import { not_meta } from '../meta';
+import { meta } from '../meta';
 
 import { Meeting } from './Meeting';
 
-export class OnSpaceCreated extends Schema.TaggedClass<OnSpaceCreated>()(`${not_meta.id}/on-space-created`, {
+export class OnSpaceCreated extends Schema.TaggedClass<OnSpaceCreated>()(`${meta.id}/on-space-created`, {
   input: Schema.Struct({
     space: SpaceSchema,
     rootCollection: DataType.Collection,
@@ -20,7 +20,7 @@ export class OnSpaceCreated extends Schema.TaggedClass<OnSpaceCreated>()(`${not_
   output: Schema.Void,
 }) {}
 
-export class Create extends Schema.TaggedClass<Create>()(`${not_meta.id}/action/create`, {
+export class Create extends Schema.TaggedClass<Create>()(`${meta.id}/action/create`, {
   input: Schema.Struct({
     name: Schema.optional(Schema.String),
     channel: ChannelType,
@@ -30,7 +30,7 @@ export class Create extends Schema.TaggedClass<Create>()(`${not_meta.id}/action/
   }),
 }) {}
 
-export class SetActive extends Schema.TaggedClass<SetActive>()(`${not_meta.id}/action/set-active`, {
+export class SetActive extends Schema.TaggedClass<SetActive>()(`${meta.id}/action/set-active`, {
   input: Schema.Struct({
     object: Schema.optional(Meeting),
   }),
@@ -39,7 +39,7 @@ export class SetActive extends Schema.TaggedClass<SetActive>()(`${not_meta.id}/a
   }),
 }) {}
 
-export class HandlePayload extends Schema.TaggedClass<HandlePayload>()(`${not_meta.id}/action/handle-payload`, {
+export class HandlePayload extends Schema.TaggedClass<HandlePayload>()(`${meta.id}/action/handle-payload`, {
   input: Schema.Struct({
     meetingId: Schema.optional(Schema.String),
     transcriptDxn: Schema.optional(Schema.String),
@@ -48,7 +48,7 @@ export class HandlePayload extends Schema.TaggedClass<HandlePayload>()(`${not_me
   output: Schema.Void,
 }) {}
 
-export class Summarize extends Schema.TaggedClass<Summarize>()(`${not_meta.id}/action/summarize`, {
+export class Summarize extends Schema.TaggedClass<Summarize>()(`${meta.id}/action/summarize`, {
   input: Schema.Struct({
     meeting: Meeting,
   }),

--- a/packages/plugins/plugin-transcription/src/meta.ts
+++ b/packages/plugins/plugin-transcription/src/meta.ts
@@ -15,6 +15,3 @@ export const meta: PluginMeta = {
   tags: ['labs'],
   screenshots: [],
 };
-
-// TODO(burdon): Workaround for suspected vitest bug? Update vitest?
-export const not_meta = meta;

--- a/packages/plugins/plugin-transcription/src/transcriber/transcriber.ts
+++ b/packages/plugins/plugin-transcription/src/transcriber/transcriber.ts
@@ -10,7 +10,7 @@ import { log } from '@dxos/log';
 import { type DataType } from '@dxos/schema';
 import { trace } from '@dxos/tracing';
 
-import { not_meta } from '../meta';
+import { meta } from '../meta';
 import { mergeFloat64Arrays } from '../util';
 
 import { type AudioChunk, type AudioRecorder } from './audio-recorder';
@@ -196,7 +196,7 @@ export class Transcriber extends Resource {
       throw new Error('No audio to send for transcribing');
     }
 
-    const response = await fetch(`${not_meta.id}/transcribe`, {
+    const response = await fetch(`${meta.id}/transcribe`, {
       method: 'POST',
       body: JSON.stringify({ audio }),
       headers: {

--- a/packages/plugins/plugin-transcription/src/types/TranscriptAction.ts
+++ b/packages/plugins/plugin-transcription/src/types/TranscriptAction.ts
@@ -6,14 +6,14 @@ import { Schema } from 'effect';
 
 import { SpaceSchema } from '@dxos/client/echo';
 
-import { not_meta } from '../meta';
+import { meta } from '../meta';
 
 import { Transcript } from './Transcript';
 
 /**
  * Endpoint to the calls service.
  */
-export class Create extends Schema.TaggedClass<Create>()(`${not_meta.id}/action/create`, {
+export class Create extends Schema.TaggedClass<Create>()(`${meta.id}/action/create`, {
   input: Schema.Struct({
     name: Schema.optional(Schema.String),
     space: SpaceSchema,


### PR DESCRIPTION
Semi-automated via Claude code

<img width="1728" height="1117" alt="Screenshot 2025-08-30 at 4 18 51 PM" src="https://github.com/user-attachments/assets/77d70c1b-a943-4317-bd9e-dadbfdc531af" />

<img width="1728" height="1117" alt="Screenshot 2025-08-30 at 5 04 41 PM" src="https://github.com/user-attachments/assets/b7de0c32-6355-4a77-95d8-fdc3667ebdb9" />
