### PR TITLE
feat: Add Linear project sync support

### DIFF
--- a/.env.1password
+++ b/.env.1password
@@ -1,3 +1,4 @@
 export ANTHROPIC_API_KEY="op://CI Vault/hub.dxos.network/shared/ANTHROPIC_API_KEY"
 export DISCORD_TOKEN="op://Shared/Composer Discord Bot/credential"
 export LINEAR_API_KEY="op://Employee/Linear Key/credential"
+export VITE_LINEAR_API_KEY="op://Employee/Linear Key/credential"

--- a/packages/core/ai/src/tools/call.ts
+++ b/packages/core/ai/src/tools/call.ts
@@ -50,10 +50,18 @@ export const callTool: <Tools extends AiTool.Any>(
               _tag: 'toolResult',
               toolCallId: toolCall.toolCallId,
               name: toolCall.name,
-              error: String(error),
+              error: formatError(error),
             }) satisfies ContentBlock.ToolResult,
         ),
       ),
     );
   },
 );
+
+const formatError = (error: Error): string => {
+  if (error.cause) {
+    return `${String(error)}\ncaused by:\n${formatError(error.cause as Error)}`;
+  } else {
+    return String(error);
+  }
+};

--- a/packages/core/assistant-testing/src/blueprints/index.ts
+++ b/packages/core/assistant-testing/src/blueprints/index.ts
@@ -5,3 +5,4 @@
 export { default as DESIGN_BLUEPRINT } from './design';
 export { default as PLANNING_BLUEPRINT } from './planning';
 export { default as RESEARCH_BLUEPRINT } from './research';
+export { default as LINEAR_BLUEPRINT } from './linear';

--- a/packages/core/assistant-testing/src/blueprints/linear/index.ts
+++ b/packages/core/assistant-testing/src/blueprints/linear/index.ts
@@ -1,0 +1,3 @@
+import blueprint from './linear';
+
+export default blueprint;

--- a/packages/core/assistant-testing/src/blueprints/linear/index.ts
+++ b/packages/core/assistant-testing/src/blueprints/linear/index.ts
@@ -1,3 +1,7 @@
+//
+// Copyright 2025 DXOS.org
+//
+
 import blueprint from './linear';
 
 export default blueprint;

--- a/packages/core/assistant-testing/src/blueprints/linear/linear.ts
+++ b/packages/core/assistant-testing/src/blueprints/linear/linear.ts
@@ -15,6 +15,7 @@ import { syncLinearIssues } from '../../functions';
  */
 const instructions = trim`
   You are able to sync Linear workspaces.
+  Sometimes sync does not complete in one go and you need to call the function again.
 
   Known workspaces:
 

--- a/packages/core/assistant-testing/src/blueprints/linear/linear.ts
+++ b/packages/core/assistant-testing/src/blueprints/linear/linear.ts
@@ -1,0 +1,34 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { ToolId } from '@dxos/ai';
+import { Blueprint } from '@dxos/blueprints';
+import { Obj, Ref } from '@dxos/echo';
+import { DataType } from '@dxos/schema';
+import { trim } from '@dxos/util';
+
+import { syncLinearIssues } from '../../functions';
+
+/**
+ * Agent prompt instructions for managing hierarchical task lists.
+ */
+const instructions = trim`
+  You are able to sync Linear workspaces.
+
+  Known workspaces:
+
+  DXOS teamId: 1127c63a-6f77-4725-9229-50f6cd47321c
+`;
+
+export const blueprint = Obj.make(Blueprint.Blueprint, {
+  key: 'dxos.org/blueprint/linear',
+  name: 'Linear',
+  description: 'Syncs Linear workspaces.',
+  instructions: {
+    source: Ref.make(DataType.makeText(instructions)),
+  },
+  tools: [ToolId.make(syncLinearIssues.name)],
+});
+
+export default blueprint;

--- a/packages/core/assistant-testing/src/functions/linear/linear.test.ts
+++ b/packages/core/assistant-testing/src/functions/linear/linear.test.ts
@@ -36,7 +36,7 @@ const TestLayer = Layer.mergeAll(
       AiServiceTestingPreset('direct'),
       TestDatabaseLayer({
         // indexing: { vector: true },
-        types: [DataType.Task, DataType.Person],
+        types: [DataType.Task, DataType.Person, DataType.Project],
         storagePath: testStoragePath({ name: 'feed-test-13' }),
       }),
       CredentialsService.layerConfig([{ service: 'linear.app', apiKey: Config.redacted('LINEAR_API_KEY') }]),
@@ -63,6 +63,11 @@ describe('Linear', { timeout: 600_000 }, () => {
         console.log('people', {
           count: persons.length,
           people: persons.map((_) => `(${_.id}) ${Obj.getLabel(_)} [${Obj.getKeys(_, LINEAR_ID_KEY)[0]?.id}]`),
+        });
+        const { objects: projects } = yield* DatabaseService.runQuery(Query.type(DataType.Project));
+        console.log('projects', {
+          count: projects.length,
+          projects: projects.map((_) => `(${_.id}) ${Obj.getLabel(_)} [${Obj.getKeys(_, LINEAR_ID_KEY)[0]?.id}]`),
         });
         const { objects: tasks } = yield* DatabaseService.runQuery(Query.type(DataType.Task));
         console.log('tasks', {

--- a/packages/core/assistant-testing/src/functions/linear/sync-issues.ts
+++ b/packages/core/assistant-testing/src/functions/linear/sync-issues.ts
@@ -98,7 +98,10 @@ export default defineFunction({
     log.info('Fetched tasks', { count: tasks.length });
 
     // Synchronize new objects with ECHO.
-    return yield* syncObjects(tasks, { foreignKeyId: LINEAR_ID_KEY });
+    return {
+      objects: yield* syncObjects(tasks, { foreignKeyId: LINEAR_ID_KEY }),
+      syncComplete: tasks.length < 150,
+    };
   }, Effect.provide(FetchHttpClient.layer)),
 });
 

--- a/packages/core/assistant-testing/src/functions/linear/sync-issues.ts
+++ b/packages/core/assistant-testing/src/functions/linear/sync-issues.ts
@@ -5,7 +5,7 @@
 import { FetchHttpClient, HttpClient } from '@effect/platform';
 import { Array, Effect, Schema, pipe } from 'effect';
 
-import { Obj, Query, Ref, Type, Filter } from '@dxos/echo';
+import { Filter, Obj, Query, Ref, type Type } from '@dxos/echo';
 import { DatabaseService, defineFunction } from '@dxos/functions';
 import { log } from '@dxos/log';
 import { DataType } from '@dxos/schema';

--- a/packages/core/assistant-testing/src/functions/linear/sync-issues.ts
+++ b/packages/core/assistant-testing/src/functions/linear/sync-issues.ts
@@ -5,7 +5,7 @@
 import { FetchHttpClient, HttpClient } from '@effect/platform';
 import { Array, Effect, Schema, pipe } from 'effect';
 
-import { Obj, Query, Ref } from '@dxos/echo';
+import { Obj, Query, Ref, Type, Filter } from '@dxos/echo';
 import { DatabaseService, defineFunction } from '@dxos/functions';
 import { log } from '@dxos/log';
 import { DataType } from '@dxos/schema';
@@ -13,8 +13,8 @@ import { DataType } from '@dxos/schema';
 import { syncObjects } from '../../sync';
 import { apiKeyAuth, graphqlRequestBody } from '../../util';
 
-const query = `
-query Team($teamId: String!, $after: DateTimeOrDuration!) {
+const queryIssues = `
+query Issues($teamId: String!, $after: DateTimeOrDuration!) {
   team(id: $teamId) {
     id
     name
@@ -35,6 +35,7 @@ query Team($teamId: String!, $after: DateTimeOrDuration!) {
                 name
             }
             project {
+                id
                 name
             }
         }
@@ -57,7 +58,7 @@ type LinearIssue = {
   description: string;
   assignee: LinearPerson;
   state: { name: string };
-  project: { name: string };
+  project: { id: string; name: string };
 };
 
 type LinearPerson = {
@@ -81,12 +82,12 @@ export default defineFunction({
     const client = yield* HttpClient.HttpClient.pipe(Effect.map(apiKeyAuth({ service: 'linear.app' })));
 
     // Get the timestamp that was previosly synced.
-    const after = yield* getLatestUpdateTimestamp(data.team);
+    const after = yield* getLatestUpdateTimestamp(data.team, DataType.Task);
     log.info('will fetch', { after });
 
     // Fetch the issues that have changed since the last sync.
     const response = yield* client.post('https://api.linear.app/graphql', {
-      body: yield* graphqlRequestBody(query, {
+      body: yield* graphqlRequestBody(queryIssues, {
         teamId: data.team,
         after,
       }),
@@ -105,18 +106,20 @@ export default defineFunction({
   }, Effect.provide(FetchHttpClient.layer)),
 });
 
-const getLatestUpdateTimestamp: (teamId: string) => Effect.Effect<string, never, DatabaseService> = Effect.fnUntraced(
-  function* (teamId) {
-    const { objects: existingTasks } = yield* DatabaseService.runQuery(Query.type(DataType.Task));
-    return pipe(
-      existingTasks,
-      Array.filter((task) => Obj.getKeys(task, LINEAR_TEAM_ID_KEY).at(0)?.id === teamId),
-      Array.map((task) => Obj.getKeys(task, LINEAR_UPDATED_AT_KEY).at(0)?.id),
-      Array.filter((x) => x !== undefined),
-      Array.reduce('2025-01-01T00:00:00.000Z', (acc: string, x: string) => (x > acc ? x : acc)),
-    );
-  },
-);
+const getLatestUpdateTimestamp: (
+  teamId: string,
+  dataType: Type.Obj.Any,
+) => Effect.Effect<string, never, DatabaseService> = Effect.fnUntraced(function* (teamId, dataType) {
+  const { objects: existingTasks } = yield* DatabaseService.runQuery(
+    Query.type(dataType).select(Filter.foreignKeys(dataType, [{ source: LINEAR_TEAM_ID_KEY, id: teamId }])),
+  );
+  return pipe(
+    existingTasks,
+    Array.map((task) => Obj.getKeys(task, LINEAR_UPDATED_AT_KEY).at(0)?.id),
+    Array.filter((x) => x !== undefined),
+    Array.reduce('2025-01-01T00:00:00.000Z', (acc: string, x: string) => (x > acc ? x : acc)),
+  );
+});
 
 const mapLinearPerson = (person: LinearPerson, { teamId }: { teamId: string }): DataType.Person =>
   Obj.make(DataType.Person, {
@@ -158,5 +161,24 @@ const mapLinearIssue = (issue: LinearIssue, { teamId }: { teamId: string }): Dat
     assigned: !issue.assignee ? undefined : Ref.make(mapLinearPerson(issue.assignee, { teamId })),
     // TODO(dmaretskyi): Sync those (+ linear team as org?).
     // state: issue.state.name,
-    // project: issue.project.name,
+
+    project: !issue.project
+      ? undefined
+      : Ref.make(
+          Obj.make(DataType.Project, {
+            [Obj.Meta]: {
+              keys: [
+                {
+                  id: issue.project.id,
+                  source: LINEAR_ID_KEY,
+                },
+                {
+                  id: teamId,
+                  source: LINEAR_TEAM_ID_KEY,
+                },
+              ],
+            },
+            name: issue.project.name,
+          }),
+        ),
   });

--- a/packages/plugins/plugin-assistant/src/shims.d.ts
+++ b/packages/plugins/plugin-assistant/src/shims.d.ts
@@ -1,8 +1,0 @@
-//
-// Copyright 2025 DXOS.org
-//
-
-declare module '*?raw' {
-  const content: string;
-  export default content;
-}

--- a/packages/plugins/plugin-assistant/src/stories/Chat.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/stories/Chat.stories.tsx
@@ -438,7 +438,7 @@ export const WithLinearSync: Story = {
   decorators: getDecorators({
     plugins: [],
     config: config.remote,
-    types: [DataType.Task, DataType.Person],
+    types: [DataType.Task, DataType.Person, DataType.Project],
     accessTokens: accessTokensFromEnv({
       'linear.app': import.meta.env.VITE_LINEAR_API_KEY,
     }),

--- a/packages/plugins/plugin-assistant/src/stories/Chat.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/stories/Chat.stories.tsx
@@ -10,7 +10,7 @@ import React, { type FC, useCallback } from 'react';
 import { EXA_API_KEY } from '@dxos/ai/testing';
 import { Capabilities, useCapabilities } from '@dxos/app-framework';
 import { AiContextBinder } from '@dxos/assistant';
-import { RESEARCH_BLUEPRINT, ResearchDataTypes, ResearchGraph } from '@dxos/assistant-testing';
+import { LINEAR_BLUEPRINT, RESEARCH_BLUEPRINT, ResearchDataTypes, ResearchGraph } from '@dxos/assistant-testing';
 import { Blueprint } from '@dxos/blueprints';
 import { Filter, Obj, Ref } from '@dxos/echo';
 import { log } from '@dxos/log';
@@ -20,8 +20,7 @@ import { InboxPlugin } from '@dxos/plugin-inbox';
 import { Mailbox } from '@dxos/plugin-inbox/types';
 import { Map, MapPlugin } from '@dxos/plugin-map';
 import { createLocationSchema } from '@dxos/plugin-map/testing';
-import { MarkdownPlugin } from '@dxos/plugin-markdown';
-import { Markdown } from '@dxos/plugin-markdown';
+import { Markdown, MarkdownPlugin } from '@dxos/plugin-markdown';
 import { TablePlugin } from '@dxos/plugin-table';
 import { ThreadPlugin } from '@dxos/plugin-thread';
 import { TranscriptionPlugin } from '@dxos/plugin-transcription';
@@ -50,7 +49,7 @@ import {
   SurfaceContainer,
   TasksContainer,
 } from './components';
-import { addTestData, config, getDecorators, testTypes } from './testing';
+import { accessTokensFromEnv, addTestData, config, getDecorators, testTypes } from './testing';
 
 const panelClassNames = 'flex flex-col overflow-hidden bg-baseSurface rounded border border-separator';
 
@@ -394,7 +393,7 @@ export const WithResearch: Story = {
   decorators: getDecorators({
     plugins: [MarkdownPlugin(), TablePlugin()],
     config: config.persistent,
-    types: [...ResearchDataTypes, ResearchGraph, DataType.AccessToken],
+    types: [...ResearchDataTypes, ResearchGraph],
     accessTokens: [Obj.make(DataType.AccessToken, { source: 'exa.ai', token: EXA_API_KEY })],
   }),
   args: {
@@ -432,5 +431,20 @@ export const WithTranscription: Story = {
   args: {
     components: [ChatContainer, [SurfaceContainer, LoggingContainer]],
     blueprints: [BLUEPRINT_KEY, 'dxos.org/blueprint/transcription'],
+  },
+};
+
+export const WithLinearSync: Story = {
+  decorators: getDecorators({
+    plugins: [],
+    config: config.remote,
+    types: [DataType.Task, DataType.Person],
+    accessTokens: accessTokensFromEnv({
+      'linear.app': import.meta.env.VITE_LINEAR_API_KEY,
+    }),
+  }),
+  args: {
+    components: [ChatContainer, [GraphContainer]],
+    blueprints: [LINEAR_BLUEPRINT.key],
   },
 };

--- a/packages/plugins/plugin-assistant/src/stories/testing/testing.tsx
+++ b/packages/plugins/plugin-assistant/src/stories/testing/testing.tsx
@@ -26,12 +26,14 @@ import {
   DESIGN_BLUEPRINT,
   PLANNING_BLUEPRINT,
   RESEARCH_BLUEPRINT,
+  LINEAR_BLUEPRINT,
   readDocument,
   readTasks,
   remoteServiceEndpoints,
   research,
   updateDocument,
   updateTasks,
+  syncLinearIssues,
 } from '@dxos/assistant-testing';
 import { Blueprint } from '@dxos/blueprints';
 import { type Space } from '@dxos/client/echo';
@@ -49,7 +51,7 @@ import { StorybookLayoutPlugin } from '@dxos/plugin-storybook-layout';
 import { ThemePlugin } from '@dxos/plugin-theme';
 import { Config } from '@dxos/react-client';
 import { defaultTx } from '@dxos/react-ui-theme';
-import { type DataType } from '@dxos/schema';
+import { DataType } from '@dxos/schema';
 import { withLayout } from '@dxos/storybook-utils';
 import { trim } from '@dxos/util';
 
@@ -127,7 +129,7 @@ export const getDecorators = ({ types = [], plugins = [], accessTokens = [], onI
       SettingsPlugin(),
       SpacePlugin(),
       ClientPlugin({
-        types: [Markdown.Document, Assistant.Chat, Blueprint.Blueprint, ...types],
+        types: [Markdown.Document, Assistant.Chat, Blueprint.Blueprint, DataType.AccessToken, ...types],
         onClientInitialized: async ({ client }) => {
           log('onClientInitialized', { identity: client.halo.identity.get()?.did });
           // Abort if already initialized.
@@ -181,9 +183,11 @@ export const getDecorators = ({ types = [], plugins = [], accessTokens = [], onI
             contributes(Capabilities.BlueprintDefinition, DESIGN_BLUEPRINT),
             contributes(Capabilities.BlueprintDefinition, PLANNING_BLUEPRINT),
             contributes(Capabilities.BlueprintDefinition, RESEARCH_BLUEPRINT),
+            contributes(Capabilities.BlueprintDefinition, LINEAR_BLUEPRINT),
             contributes(Capabilities.Functions, [readDocument, updateDocument]),
             contributes(Capabilities.Functions, [readTasks, updateTasks]),
             contributes(Capabilities.Functions, [research]),
+            contributes(Capabilities.Functions, [syncLinearIssues]),
           ],
         }),
         defineModule({
@@ -228,3 +232,23 @@ export const getDecorators = ({ types = [], plugins = [], accessTokens = [], onI
     classNames: 'justify-center bg-deckSurface',
   }),
 ];
+
+/**
+ * Creates access tokens from environment variables.
+ * @param tokens - Record of token sources mapped to their VITE_ prefixed environment variable values
+ * @returns Array of AccessToken objects for non-empty token values
+ * @example
+ * ```tsx
+ * const tokens = accessTokensFromEnv({
+ *   'exa.ai': process.env.VITE_EXA_API_KEY,
+ *   'linear.app': process.env.VITE_LINEAR_API_KEY
+ * });
+ * ```
+ * @note All environment variables should use the VITE_ prefix for proper Vite bundling
+ */
+
+export const accessTokensFromEnv = (tokens: Record<string, string | undefined>) => {
+  return Object.entries(tokens)
+    .filter(([, token]) => !!token)
+    .map(([source, token]) => Obj.make(DataType.AccessToken, { source, token: token! }));
+};

--- a/packages/plugins/plugin-assistant/src/stories/testing/testing.tsx
+++ b/packages/plugins/plugin-assistant/src/stories/testing/testing.tsx
@@ -24,16 +24,16 @@ import { withPluginManager } from '@dxos/app-framework/testing';
 import { AiContextBinder, ArtifactId } from '@dxos/assistant';
 import {
   DESIGN_BLUEPRINT,
+  LINEAR_BLUEPRINT,
   PLANNING_BLUEPRINT,
   RESEARCH_BLUEPRINT,
-  LINEAR_BLUEPRINT,
   readDocument,
   readTasks,
   remoteServiceEndpoints,
   research,
+  syncLinearIssues,
   updateDocument,
   updateTasks,
-  syncLinearIssues,
 } from '@dxos/assistant-testing';
 import { Blueprint } from '@dxos/blueprints';
 import { type Space } from '@dxos/client/echo';

--- a/packages/plugins/plugin-assistant/src/typings.d.ts
+++ b/packages/plugins/plugin-assistant/src/typings.d.ts
@@ -1,9 +1,0 @@
-// src/types.d.ts
-//
-// Copyright 2025 DXOS.org
-//
-
-declare module '*.wav' {
-  const src: string;
-  export default src;
-}

--- a/packages/plugins/plugin-assistant/src/vite-env.d.ts
+++ b/packages/plugins/plugin-assistant/src/vite-env.d.ts
@@ -1,0 +1,30 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+/// <reference types="vite/client" />
+
+interface ViteTypeOptions {
+  // By adding this line, you can make the type of ImportMetaEnv strict
+  // to disallow unknown keys.
+  // strictImportMetaEnv: unknown
+}
+
+interface ImportMetaEnv {
+  readonly VITE_LINEAR_API_KEY: string | undefined;
+  // more env variables...
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
+declare module '*.wav' {
+  const src: string;
+  export default src;
+}
+
+declare module '*?raw' {
+  const content: string;
+  export default content;
+}

--- a/packages/sdk/schema/src/common/task.ts
+++ b/packages/sdk/schema/src/common/task.ts
@@ -16,6 +16,7 @@ import {
 import { ItemAnnotation } from '../annotations';
 
 import { Person } from './person';
+import { DataType } from '..';
 
 /**
  * Task schema.
@@ -82,6 +83,7 @@ const TaskSchema = Schema.Struct({
       }),
     ),
   ),
+  project: Schema.optional(Type.Ref(DataType.Project).annotations({ title: 'Project' })),
   // TODO(burdon): Created date metadata.
   // due: Date,
   // TODO(burdon): Generic tags.

--- a/packages/sdk/schema/src/common/task.ts
+++ b/packages/sdk/schema/src/common/task.ts
@@ -16,7 +16,7 @@ import {
 import { ItemAnnotation } from '../annotations';
 
 import { Person } from './person';
-import { DataType } from '..';
+import { Project } from './project';
 
 /**
  * Task schema.
@@ -83,7 +83,7 @@ const TaskSchema = Schema.Struct({
       }),
     ),
   ),
-  project: Schema.optional(Type.Ref(DataType.Project).annotations({ title: 'Project' })),
+  project: Schema.optional(Type.Ref(Project).annotations({ title: 'Project' })),
   // TODO(burdon): Created date metadata.
   // due: Date,
   // TODO(burdon): Generic tags.


### PR DESCRIPTION
## Summary

This PR adds support for syncing Linear projects along with issues and improves the Linear sync functionality.

### Changes

- **Linear sync improvements**:
  - Added project syncing when syncing Linear issues
  - Projects are now created as references on tasks
  - Added project ID and name to GraphQL query
  - Optimized queries using Filter.foreignKeys instead of post-filtering

- **Schema updates**:
  - Added optional `project` field to Task schema as a reference to Project type
  - Added Project type to various test configurations

- **Plugin assistant improvements**:
  - Added new story `WithLinearSync` for testing Linear sync functionality
  - Created `accessTokensFromEnv` helper to safely handle environment variables for API tokens
  - Added proper Vite environment type definitions

- **Code cleanup**:
  - Removed unused queryProjects GraphQL query
  - Fixed type definitions and imports
  
### Testing

- Updated tests to include Project type in database configurations
- Added logging for synced projects in test output