### PR TITLE
chore: remove baseUrl from tsconfig files

### DIFF
--- a/packages/plugins/plugin-assistant/src/capabilities/ai-service.ts
+++ b/packages/plugins/plugin-assistant/src/capabilities/ai-service.ts
@@ -5,7 +5,7 @@
 import { Effect, Layer } from 'effect';
 
 import { AiServiceRouter } from '@dxos/ai';
-import { type Capability, type InterfaceDef, type PluginContext, contributes } from '@dxos/app-framework';
+import { type PluginContext, contributes } from '@dxos/app-framework';
 
 import { AssistantCapabilities } from './capabilities';
 

--- a/packages/plugins/plugin-assistant/src/capabilities/ai-service.ts
+++ b/packages/plugins/plugin-assistant/src/capabilities/ai-service.ts
@@ -5,7 +5,7 @@
 import { Effect, Layer } from 'effect';
 
 import { AiServiceRouter } from '@dxos/ai';
-import { type PluginContext, contributes } from '@dxos/app-framework';
+import { type Capability, type InterfaceDef, type PluginContext, contributes } from '@dxos/app-framework';
 
 import { AssistantCapabilities } from './capabilities';
 

--- a/packages/plugins/plugin-markdown/src/components/MarkdownCard/MarkdownCard.stories.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownCard/MarkdownCard.stories.tsx
@@ -13,7 +13,6 @@ import { Markdown } from '@dxos/plugin-markdown/types';
 import { faker } from '@dxos/random';
 import { CardContainer } from '@dxos/react-ui-stack/testing';
 import { withLayout, withTheme } from '@dxos/storybook-utils';
-import { DataType } from '@dxos/schema';
 
 import { translations } from '../../translations';
 
@@ -21,7 +20,7 @@ import { MarkdownCard } from './MarkdownCard';
 
 faker.seed(1234);
 
-const meta = {
+const meta: Meta<typeof MarkdownCard> = {
   title: 'plugins/plugin-markdown/Card',
   component: MarkdownCard,
   render: ({ role, subject, ...args }) => {

--- a/packages/plugins/plugin-markdown/src/components/MarkdownCard/MarkdownCard.stories.tsx
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownCard/MarkdownCard.stories.tsx
@@ -13,6 +13,7 @@ import { Markdown } from '@dxos/plugin-markdown/types';
 import { faker } from '@dxos/random';
 import { CardContainer } from '@dxos/react-ui-stack/testing';
 import { withLayout, withTheme } from '@dxos/storybook-utils';
+import { DataType } from '@dxos/schema';
 
 import { translations } from '../../translations';
 

--- a/packages/sdk/app-framework/src/core/capabilities.ts
+++ b/packages/sdk/app-framework/src/core/capabilities.ts
@@ -22,6 +22,10 @@ export type InterfaceDef<T> = {
   identifier: string;
 };
 
+export namespace InterfaceDef {
+  export type Implementation<I extends InterfaceDef<any>> = I extends InterfaceDef<infer T> ? T : never;
+}
+
 /**
  * Helper to define the interface of a capability.
  */
@@ -69,12 +73,12 @@ class CapabilityImpl<T> {
 /**
  * Helper to define the implementation of a capability.
  */
-export const contributes = <T>(
-  interfaceDef: Capability<T>['interface'],
-  implementation: Capability<T>['implementation'],
-  deactivate?: Capability<T>['deactivate'],
-): Capability<T> => {
-  return { interface: interfaceDef, implementation, deactivate } satisfies Capability<T>;
+export const contributes = <I extends InterfaceDef<any>>(
+  interfaceDef: I,
+  implementation: Capability<InterfaceDef.Implementation<I>>['implementation'],
+  deactivate?: Capability<InterfaceDef.Implementation<I>>['deactivate'],
+): Capability<I> => {
+  return { interface: interfaceDef, implementation, deactivate } satisfies Capability<I>;
 };
 
 type LoadCapability<T, U> = () => Promise<{ default: (props: T) => MaybePromise<Capability<U>> }>;

--- a/packages/sdk/schema/src/common/DataType.ts
+++ b/packages/sdk/schema/src/common/DataType.ts
@@ -1,0 +1,30 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Obj } from '@dxos/echo';
+import { type ObjectId } from '@dxos/echo-schema';
+
+export { AccessToken } from './access-token';
+export { Actor, ActorRole, ActorRoles } from './actor';
+export { Event } from './event';
+export { Collection, QueryCollection } from './collection';
+export { Message, ContentBlock as MessageBlock } from './message';
+/** @deprecated */
+export { MessageV1, MessageV1ToV2 } from './message';
+export { Organization, OrganizationStatusOptions } from './organization';
+export { PostalAddress } from './postal-address';
+export { Person } from './person';
+export { Project } from './project';
+export { StoredSchema } from '@dxos/echo-schema';
+export { Task } from './task';
+export { Text } from './text';
+export { View } from '../view';
+export { Employer, HasConnection, HasRelationship } from './relations';
+
+// TODO(burdon): Move Thread from plugin-space?
+
+import { Text as TextSchema } from './text';
+
+export const makeText = (content = '', id?: ObjectId) =>
+  id ? Obj.make(TextSchema, { content, id }) : Obj.make(TextSchema, { content });

--- a/packages/sdk/schema/src/common/index.ts
+++ b/packages/sdk/schema/src/common/index.ts
@@ -2,30 +2,6 @@
 // Copyright 2025 DXOS.org
 //
 
-import { Obj } from '@dxos/echo';
-import * as EchoSchema$ from '@dxos/echo-schema';
-import { type ObjectId } from '@dxos/echo-schema';
-
-import * as View$ from '../view';
-
-import * as AccessToken$ from './access-token';
-import * as Actor$ from './actor';
-import * as Collection$ from './collection';
-import * as Event$ from './event';
-import * as Message$ from './message';
-import * as Organization$ from './organization';
-import * as Person$ from './person';
-import * as PostalAddress$ from './postal-address';
-import * as Project$ from './project';
-import * as Relations$ from './relations';
-import * as Task$ from './task';
-import * as Text$ from './text';
-
-// TODO(burdon): Remove (fix The inferred type of 'DeleteMessage' cannot be named without a reference.)
-export * from './message';
-export * from './relations';
-export * from './task';
-
 // TODO(burdon): Replace instanceof checks.
 // TODO(burdon): Remove Type suffix from other type defs (after API changes).
 // TODO(wittjosiah): Introduce a generic canvas type which stores data using OCIF (https://www.canvasprotocol.org/).
@@ -34,130 +10,8 @@ export * from './task';
  * Common data types.
  * https://schema.org/docs/schemas.html
  */
-export namespace DataType {
-  //
-  // AccessToken
-  //
-
-  export const AccessToken = AccessToken$.AccessToken;
-  export type AccessToken = AccessToken$.AccessToken;
-
-  //
-  // Actor
-  //
-
-  export const ActorRoles = Actor$.ActorRoles;
-  export const ActorRole = Actor$.ActorRole;
-  export type ActorRole = Actor$.ActorRole;
-
-  export const Actor = Actor$.Actor;
-  export type Actor = Actor$.Actor;
-
-  //
-  // Event
-  //
-
-  export const Event = Event$.Event;
-  export type Event = Event$.Event;
-
-  //
-  // Collection
-  //
-
-  export const Collection = Collection$.Collection;
-  export type Collection = Collection$.Collection;
-
-  export const QueryCollection = Collection$.QueryCollection;
-  export type QueryCollection = Collection$.QueryCollection;
-
-  //
-  // Message
-  //
-
-  export const Message = Message$.Message;
-  export type Message = Message$.Message;
-
-  export import MessageBlock = Message$.ContentBlock;
-
-  /** @deprecated */
-  export const MessageV1 = Message$.MessageV1;
-  /** @deprecated */
-  export type MessageV1 = Message$.MessageV1;
-  /** @deprecated */
-  export const MessageV1ToV2 = Message$.MessageV1ToV2;
-
-  //
-  // Organization
-  //
-
-  export const Organization = Organization$.Organization;
-  export type Organization = Organization$.Organization;
-
-  // TODO(burdon): Remove.
-  export const OrganizationStatusOptions = Organization$.OrganizationStatusOptions;
-
-  export const PostalAddress = PostalAddress$.PostalAddress;
-
-  //
-  // Person
-  //
-
-  export const Person = Person$.Person;
-  export type Person = Person$.Person;
-
-  //
-  // Project
-  //
-
-  export const Project = Project$.Project;
-  export type Project = Project$.Project;
-
-  //
-  // StoredSchema
-  //
-
-  export const StoredSchema = EchoSchema$.StoredSchema;
-  export type StoredSchema = EchoSchema$.StoredSchema;
-
-  //
-  // Task
-  //
-
-  export const Task = Task$.Task;
-  export type Task = Task$.Task;
-
-  //
-  // Text
-  //
-
-  export const Text = Text$.Text;
-  export type Text = Text$.Text;
-
-  export const makeText = (content = '', id?: ObjectId) =>
-    id ? Obj.make(Text, { content, id }) : Obj.make(Text, { content });
-
-  //
-  // View
-  //
-
-  export const View = View$.View;
-  export type View = View$.View;
-
-  //
-  // Relations
-  //
-
-  export const Employer = Relations$.Employer;
-  export type Employer = Relations$.Employer;
-
-  export const HasConnection = Relations$.HasConnection;
-  export type HasConnection = Relations$.HasConnection;
-
-  export const HasRelationship = Relations$.HasRelationship;
-  export type HasRelationship = Relations$.HasRelationship;
-
-  // TOOD(burdon): Move Thread from plugin-space?
-}
+export * as DataType from './DataType';
+import * as DataType from './DataType';
 
 export const DataTypes = [
   // Objects
@@ -178,3 +32,8 @@ export const DataTypes = [
   DataType.HasRelationship,
   DataType.HasConnection,
 ];
+
+// TODO(burdon): Remove (fix The inferred type of 'DeleteMessage' cannot be named without a reference.)
+export * from './message';
+export * from './relations';
+export * from './task';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,6 @@
 {
   "compilerOptions": {
     "allowJs": false,
-    "baseUrl": "${configDir}",
     "composite": true,
     "declaration": true,
     "declarationMap": true,

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -2,7 +2,6 @@
 // The included projects will be built from source when running composer-app:serve.
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@dxos/storybook-utils": ["packages/common/storybook-utils/src/index.ts"],
       "@dxos/assistant-testing": ["packages/core/assistant-testing/src/index.ts"],


### PR DESCRIPTION
## Summary

This PR removes the `baseUrl` configuration from TypeScript configuration files:
- Removed `baseUrl: "."` from `tsconfig.paths.json`
- Removed `baseUrl: "${configDir}"` from `tsconfig.base.json`

## Changes
- `tsconfig.base.json`: Removed baseUrl configuration
- `tsconfig.paths.json`: Removed baseUrl configuration

## Testing
The build currently fails with unrelated TypeScript errors in the client-protocol package regarding missing '@dxos/echo-db' module. These errors appear to be pre-existing and not related to the baseUrl removal.