### PR TITLE
fix: Duplicate CM slot, `scroll` styling API

### DIFF
--- a/packages/ui/react-ui-editor/src/extensions/factories.ts
+++ b/packages/ui/react-ui-editor/src/extensions/factories.ts
@@ -158,9 +158,6 @@ export type ThemeExtensionsOptions = {
     scroll?: {
       className?: string;
     };
-    scroller?: {
-      className?: string;
-    };
     content?: {
       className?: string;
     };
@@ -203,15 +200,7 @@ export const createThemeExtensions = ({
       ViewPlugin.fromClass(
         class {
           constructor(view: EditorView) {
-            view.scrollDOM.classList.add(slots.scroll.className);
-          }
-        },
-      ),
-    slots.scroller?.className &&
-      ViewPlugin.fromClass(
-        class {
-          constructor(view: EditorView) {
-            view.dom.querySelector('.cm-scroller')?.classList.add(...slots.scroller.className.split(' '));
+            view.scrollDOM.classList.add(...slots.scroll.className.split(/\s+/));
           }
         },
       ),

--- a/packages/ui/react-ui-grid/src/CellEditor/CellEditor.tsx
+++ b/packages/ui/react-ui-grid/src/CellEditor/CellEditor.tsx
@@ -149,10 +149,10 @@ export const CellEditor = ({ value, extension, autoFocus, onBlur, box, gridId, s
                 slots?.editor?.className,
               ),
             },
-            scroller: {
+            scroll: {
               className: mx(
                 '!overflow-x-hidden !plb-[max(0,calc(var(--dx-grid-cell-editor-padding-block)-1px))] !pie-0 !pis-[--dx-grid-cell-editor-padding-inline]',
-                slots?.scroller?.className,
+                slots?.scroll?.className,
               ),
             },
             content: { className: mx('!break-normal', slots?.content?.className) },

--- a/packages/ui/react-ui-table/src/components/TableCellEditor/TableCellEditor.tsx
+++ b/packages/ui/react-ui-table/src/components/TableCellEditor/TableCellEditor.tsx
@@ -96,7 +96,7 @@ export const TableValueEditor = ({
   return <TableCellEditor model={model} modals={modals} onFocus={onFocus} onSave={onSave} __gridScope={__gridScope} />;
 };
 
-const editorSlots = { scroller: { className: '!plb-[--dx-grid-cell-editor-padding-block]' } };
+const editorSlots = { scroll: { className: '!plb-[--dx-grid-cell-editor-padding-block]' } };
 
 export const TableCellEditor = ({
   model,
@@ -105,7 +105,7 @@ export const TableCellEditor = ({
   onSave,
   __gridScope,
 }: GridScopedProps<TableCellEditorProps>) => {
-  const { id: gridId, editing, setEditing } = useGridContext('TableCellEditor', __gridScope);
+  const { editing, setEditing } = useGridContext('TableCellEditor', __gridScope);
   const suppressNextBlur = useRef(false);
   const { themeMode } = useThemeContext();
   const [validationError, setValidationError] = useState<string | null>(null);


### PR DESCRIPTION
This PR removes the duplicate `scroller` slot and replaces `scroll`’s API implementation with the one that motivated the creation of `scroller`.

https://github.com/user-attachments/assets/4188bf25-8fc7-4683-9e68-d88616bd0079
