### PR TITLE
feat: Stack perpendicular arrow focus movement

### DIFF
--- a/packages/ui/lit-grid/src/dx-grid.ts
+++ b/packages/ui/lit-grid/src/dx-grid.ts
@@ -1480,7 +1480,7 @@ export class DxGrid extends LitElement {
       <div
         role="none"
         class="dx-grid"
-        data-arrow-keys="handles-all"
+        data-arrow-keys="all"
         style=${styleMap({
           'grid-template-columns': [
             this.templatefrozenColsStart ? 'min-content' : false,

--- a/packages/ui/lit-grid/src/dx-grid.ts
+++ b/packages/ui/lit-grid/src/dx-grid.ts
@@ -1480,6 +1480,7 @@ export class DxGrid extends LitElement {
       <div
         role="none"
         class="dx-grid"
+        data-arrow-keys="handles-all"
         style=${styleMap({
           'grid-template-columns': [
             this.templatefrozenColsStart ? 'min-content' : false,

--- a/packages/ui/react-ui-stack/src/components/Stack/Stack.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack/Stack.tsx
@@ -109,7 +109,7 @@ export const Stack = forwardRef<HTMLDivElement, StackProps>(
      * orientation, focus cycles between items, otherwise focus is passed to an adjacent stack item; or, if there is no
      * such stack item, focus is passed to the adjacent empty stack if one can be found.
      */
-    const handleKeydown = useCallback(
+    const handleKeyDown = useCallback(
       (event: KeyboardEvent<HTMLDivElement>) => {
         const target = event.target as HTMLElement;
         if (event.key.startsWith('Arrow') && !target.closest('input, textarea')) {
@@ -189,7 +189,7 @@ export const Stack = forwardRef<HTMLDivElement, StackProps>(
                 : 'overflow-y-auto min-is-0 max-is-full is-full'),
             classNames,
           )}
-          onKeyDown={handleKeydown}
+          onKeyDown={handleKeyDown}
           data-dx-stack={stackId}
           data-rail={rail}
           aria-orientation={orientation}

--- a/packages/ui/react-ui-stack/src/components/Stack/Stack.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack/Stack.tsx
@@ -125,7 +125,7 @@ export const Stack = forwardRef<HTMLDivElement, StackProps>(
         if (
           event.key.startsWith('Arrow') &&
           !target.closest(
-            `input, textarea, [role="textbox"], [data-tabster*="mover"], [data-arrow-keys="handles-all"], [data-arrow-keys="handles-${['ArrowLeft', 'ArrowRight'].includes(event.key) ? 'horizontal' : 'vertical'}"]`,
+            `input, textarea, [role="textbox"], [data-tabster*="mover"], [data-arrow-keys="all"], [data-arrow-keys~="${event.key.toLowerCase().slice(5)}"]`,
           )
         ) {
           const closestOwnedItem = target.closest(`[data-dx-stack-item="${stackId}"]`);

--- a/packages/ui/react-ui-stack/src/components/Stack/Stack.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack/Stack.tsx
@@ -50,6 +50,8 @@ export const railGridVerticalContainFitContent =
 
 export const autoScrollRootAttributes = { 'data-drag-autoscroll': 'idle' };
 
+const PERPENDICULAR_FOCUS_THRESHHOLD = 128;
+
 export const Stack = forwardRef<HTMLDivElement, StackProps>(
   (
     {
@@ -115,7 +117,7 @@ export const Stack = forwardRef<HTMLDivElement, StackProps>(
         if (event.key.startsWith('Arrow') && !target.closest('input, textarea')) {
           const closestOwnedItem = target.closest(`[data-dx-stack-item="${stackId}"]`);
           const closestStack = target.closest('[data-dx-stack]') as HTMLElement | null;
-          const ancestorStack = closestStack?.closest('[data-dx-stack]') as HTMLElement | null;
+          const ancestorStack = closestStack?.parentElement?.closest('[data-dx-stack]') as HTMLElement | null;
           if (closestOwnedItem && closestStack) {
             const orientation = closestStack.getAttribute('aria-orientation');
             const ancestorOrientation = ancestorStack?.getAttribute('aria-orientation');
@@ -140,8 +142,8 @@ export const Stack = forwardRef<HTMLDivElement, StackProps>(
               ] as HTMLElement | undefined;
               if (nextItem) {
                 event.preventDefault();
-                nextItem.focus();
                 nextItem.scrollIntoView({ behavior: 'instant' });
+                nextItem.focus();
               }
             }
             if (perpendicularDelta !== 0 && ancestorStack && ancestorOrientation !== orientation) {
@@ -176,11 +178,14 @@ export const Stack = forwardRef<HTMLDivElement, StackProps>(
                     closestDistance = distance;
                     closestItem = item;
                   }
+                  if (closestDistance <= PERPENDICULAR_FOCUS_THRESHHOLD) {
+                    break;
+                  }
                 }
 
                 event.preventDefault();
-                closestItem.focus();
                 closestItem.scrollIntoView({ behavior: 'instant' });
+                closestItem.focus();
               }
             }
           }

--- a/packages/ui/react-ui-stack/src/components/Stack/Stack.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack/Stack.tsx
@@ -125,7 +125,7 @@ export const Stack = forwardRef<HTMLDivElement, StackProps>(
         if (
           event.key.startsWith('Arrow') &&
           !target.closest(
-            `input, textarea, [data-tabster*="mover"], [data-arrow-keys="handles-${['ArrowLeft', 'ArrowRight'].includes(event.key) ? 'horizontal' : 'vertical'}"]`,
+            `input, textarea, [role="textbox"], [data-tabster*="mover"], [data-arrow-keys="handles-all"], [data-arrow-keys="handles-${['ArrowLeft', 'ArrowRight'].includes(event.key) ? 'horizontal' : 'vertical'}"]`,
           )
         ) {
           const closestOwnedItem = target.closest(`[data-dx-stack-item="${stackId}"]`);

--- a/packages/ui/react-ui-stack/src/components/Stack/Stack.tsx
+++ b/packages/ui/react-ui-stack/src/components/Stack/Stack.tsx
@@ -2,7 +2,6 @@
 // Copyright 2025 DXOS.org
 //
 
-import { useArrowNavigationGroup } from '@fluentui/react-tabster';
 import { composeRefs } from '@radix-ui/react-compose-refs';
 import React, {
   type CSSProperties,
@@ -71,7 +70,6 @@ export const Stack = forwardRef<HTMLDivElement, StackProps>(
     const stackId = useId('stack', props.id);
     const [stackElement, stackRef] = useState<HTMLDivElement | null>(null);
     const composedItemRef = composeRefs<HTMLDivElement>(stackRef, forwardedRef);
-    const arrowNavigationAttrs = useArrowNavigationGroup({ axis: orientation });
 
     const styles: CSSProperties = {
       [orientation === 'horizontal' ? 'gridTemplateColumns' : 'gridTemplateRows']:

--- a/packages/ui/react-ui-stack/src/components/StackContext.tsx
+++ b/packages/ui/react-ui-stack/src/components/StackContext.tsx
@@ -12,6 +12,7 @@ export type StackContextValue = {
   rail: boolean;
   size: Size;
   onRearrange?: StackItemRearrangeHandler;
+  stackId?: string;
 };
 
 export const StackContext = createContext<StackContextValue>({

--- a/packages/ui/react-ui-stack/src/components/StackItem/StackItem.tsx
+++ b/packages/ui/react-ui-stack/src/components/StackItem/StackItem.tsx
@@ -90,7 +90,7 @@ const StackItemRoot = forwardRef<HTMLDivElement, StackItemRootProps>(
     const [closestEdge, setEdge] = useState<Edge | null>(null);
     const [sourceId, setSourceId] = useState<string | null>(null);
     const [dragState, setDragState] = useState<ItemDragState>(idle);
-    const { orientation, rail, onRearrange, size: stackSize } = useStack();
+    const { orientation, rail, onRearrange, size: stackSize, stackId } = useStack();
     const [size = orientation === 'horizontal' ? DEFAULT_HORIZONTAL_SIZE : DEFAULT_VERTICAL_SIZE, setInternalSize] =
       useState(propsSize);
 
@@ -240,7 +240,7 @@ const StackItemRoot = forwardRef<HTMLDivElement, StackItemRootProps>(
             role === 'section' && orientation !== 'horizontal' && 'border-be border-subduedSeparator',
             classNames,
           )}
-          data-dx-stack-item
+          data-dx-stack-item={stackId}
           {...resizeAttributes}
           style={{
             ...(stackSize !== 'split' && sizeStyle(size, orientation)),

--- a/packages/ui/react-ui-tabs/src/Tabs.tsx
+++ b/packages/ui/react-ui-tabs/src/Tabs.tsx
@@ -144,6 +144,7 @@ const TabsTablist = ({ children, classNames, ...props }: TabsTablistProps) => {
   return (
     <TabsPrimitive.List
       {...props}
+      data-arrow-keys='handled'
       className={mx(
         'max-bs-full is-full',
         // NOTE: Padding should be common to Toolbar.

--- a/packages/ui/react-ui-tabs/src/Tabs.tsx
+++ b/packages/ui/react-ui-tabs/src/Tabs.tsx
@@ -144,7 +144,7 @@ const TabsTablist = ({ children, classNames, ...props }: TabsTablistProps) => {
   return (
     <TabsPrimitive.List
       {...props}
-      data-arrow-keys='handled'
+      data-arrow-keys={`handles-${orientation}`}
       className={mx(
         'max-bs-full is-full',
         // NOTE: Padding should be common to Toolbar.

--- a/packages/ui/react-ui-tabs/src/Tabs.tsx
+++ b/packages/ui/react-ui-tabs/src/Tabs.tsx
@@ -144,7 +144,7 @@ const TabsTablist = ({ children, classNames, ...props }: TabsTablistProps) => {
   return (
     <TabsPrimitive.List
       {...props}
-      data-arrow-keys={`handles-${orientation}`}
+      data-arrow-keys={orientation === 'vertical' ? 'up down' : 'left right'}
       className={mx(
         'max-bs-full is-full',
         // NOTE: Padding should be common to Toolbar.

--- a/packages/ui/react-ui/src/components/Menus/ContextMenu.tsx
+++ b/packages/ui/react-ui/src/components/Menus/ContextMenu.tsx
@@ -34,7 +34,7 @@ const ContextMenuContent = forwardRef<HTMLDivElement, ContextMenuContentProps>(
     return (
       <ContextMenuPrimitive.Content
         {...props}
-        data-arrow-keys='handled'
+        data-arrow-keys='handles-vertical'
         collisionPadding={safeCollisionPadding}
         className={tx('menu.content', 'menu', { elevation }, classNames)}
         ref={forwardedRef}

--- a/packages/ui/react-ui/src/components/Menus/ContextMenu.tsx
+++ b/packages/ui/react-ui/src/components/Menus/ContextMenu.tsx
@@ -34,7 +34,7 @@ const ContextMenuContent = forwardRef<HTMLDivElement, ContextMenuContentProps>(
     return (
       <ContextMenuPrimitive.Content
         {...props}
-        data-arrow-keys='handles-vertical'
+        data-arrow-keys='up down'
         collisionPadding={safeCollisionPadding}
         className={tx('menu.content', 'menu', { elevation }, classNames)}
         ref={forwardedRef}

--- a/packages/ui/react-ui/src/components/Menus/ContextMenu.tsx
+++ b/packages/ui/react-ui/src/components/Menus/ContextMenu.tsx
@@ -34,6 +34,7 @@ const ContextMenuContent = forwardRef<HTMLDivElement, ContextMenuContentProps>(
     return (
       <ContextMenuPrimitive.Content
         {...props}
+        data-arrow-keys='handled'
         collisionPadding={safeCollisionPadding}
         className={tx('menu.content', 'menu', { elevation }, classNames)}
         ref={forwardedRef}

--- a/packages/ui/react-ui/src/components/Menus/DropdownMenu.tsx
+++ b/packages/ui/react-ui/src/components/Menus/DropdownMenu.tsx
@@ -264,6 +264,7 @@ const DropdownMenuContent = forwardRef<DropdownMenuContentElement, DropdownMenuC
             hasInteractedOutsideRef.current = true;
           }
         })}
+        data-arrow-keys='handled'
         className={tx('menu.content', 'menu', { elevation }, classNames)}
         style={{
           ...props.style,

--- a/packages/ui/react-ui/src/components/Menus/DropdownMenu.tsx
+++ b/packages/ui/react-ui/src/components/Menus/DropdownMenu.tsx
@@ -124,7 +124,7 @@ const DropdownMenuTrigger = forwardRef<DropdownMenuTriggerElement, DropdownMenuT
           disabled={disabled}
           {...triggerProps}
           ref={composeRefs(forwardedRef, context.triggerRef)}
-          data-arrow-keys='handles-vertical'
+          data-arrow-keys='down'
           onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
             // but not when the control key is pressed (avoiding MacOS right click)
@@ -265,7 +265,7 @@ const DropdownMenuContent = forwardRef<DropdownMenuContentElement, DropdownMenuC
             hasInteractedOutsideRef.current = true;
           }
         })}
-        data-arrow-keys='handles-vertical'
+        data-arrow-keys='up down'
         className={tx('menu.content', 'menu', { elevation }, classNames)}
         style={{
           ...props.style,

--- a/packages/ui/react-ui/src/components/Menus/DropdownMenu.tsx
+++ b/packages/ui/react-ui/src/components/Menus/DropdownMenu.tsx
@@ -124,6 +124,7 @@ const DropdownMenuTrigger = forwardRef<DropdownMenuTriggerElement, DropdownMenuT
           disabled={disabled}
           {...triggerProps}
           ref={composeRefs(forwardedRef, context.triggerRef)}
+          data-arrow-keys='handles-vertical'
           onPointerDown={composeEventHandlers(props.onPointerDown, (event) => {
             // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
             // but not when the control key is pressed (avoiding MacOS right click)
@@ -264,7 +265,7 @@ const DropdownMenuContent = forwardRef<DropdownMenuContentElement, DropdownMenuC
             hasInteractedOutsideRef.current = true;
           }
         })}
-        data-arrow-keys='handled'
+        data-arrow-keys='handles-vertical'
         className={tx('menu.content', 'menu', { elevation }, classNames)}
         style={{
           ...props.style,

--- a/packages/ui/react-ui/src/components/Select/Select.tsx
+++ b/packages/ui/react-ui/src/components/Select/Select.tsx
@@ -59,7 +59,7 @@ const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>(
     return (
       <SelectPrimitive.Content
         {...props}
-        data-arrow-keys='handled'
+        data-arrow-keys='handles-vertical'
         collisionPadding={safeCollisionPadding}
         className={tx('select.content', 'select__content', { elevation }, classNames)}
         position='popper'

--- a/packages/ui/react-ui/src/components/Select/Select.tsx
+++ b/packages/ui/react-ui/src/components/Select/Select.tsx
@@ -59,7 +59,7 @@ const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>(
     return (
       <SelectPrimitive.Content
         {...props}
-        data-arrow-keys='handles-vertical'
+        data-arrow-keys='up down'
         collisionPadding={safeCollisionPadding}
         className={tx('select.content', 'select__content', { elevation }, classNames)}
         position='popper'

--- a/packages/ui/react-ui/src/components/Select/Select.tsx
+++ b/packages/ui/react-ui/src/components/Select/Select.tsx
@@ -59,6 +59,7 @@ const SelectContent = forwardRef<HTMLDivElement, SelectContentProps>(
     return (
       <SelectPrimitive.Content
         {...props}
+        data-arrow-keys='handled'
         collisionPadding={safeCollisionPadding}
         className={tx('select.content', 'select__content', { elevation }, classNames)}
         position='popper'

--- a/packages/ui/react-ui/src/components/Toolbar/Toolbar.tsx
+++ b/packages/ui/react-ui/src/components/Toolbar/Toolbar.tsx
@@ -30,7 +30,7 @@ const ToolbarRoot = forwardRef<HTMLDivElement, ToolbarRootProps>(
     return (
       <ToolbarPrimitive.Root
         {...props}
-        data-arrow-keys='handled'
+        data-arrow-keys={`handles-${props.orientation ?? 'horizontal'}`}
         className={tx('toolbar.root', 'toolbar', { layoutManaged }, classNames)}
         ref={forwardedRef}
       >

--- a/packages/ui/react-ui/src/components/Toolbar/Toolbar.tsx
+++ b/packages/ui/react-ui/src/components/Toolbar/Toolbar.tsx
@@ -30,6 +30,7 @@ const ToolbarRoot = forwardRef<HTMLDivElement, ToolbarRootProps>(
     return (
       <ToolbarPrimitive.Root
         {...props}
+        data-arrow-keys='handled'
         className={tx('toolbar.root', 'toolbar', { layoutManaged }, classNames)}
         ref={forwardedRef}
       >

--- a/packages/ui/react-ui/src/components/Toolbar/Toolbar.tsx
+++ b/packages/ui/react-ui/src/components/Toolbar/Toolbar.tsx
@@ -30,7 +30,7 @@ const ToolbarRoot = forwardRef<HTMLDivElement, ToolbarRootProps>(
     return (
       <ToolbarPrimitive.Root
         {...props}
-        data-arrow-keys={`handles-${props.orientation ?? 'horizontal'}`}
+        data-arrow-keys={props.orientation === 'vertical' ? 'up down' : 'left right'}
         className={tx('toolbar.root', 'toolbar', { layoutManaged }, classNames)}
         ref={forwardedRef}
       >


### PR DESCRIPTION
To do:
- [x] When a nonempty stack is focused, arrows along its orientation should focus the first or last item
- [x] Handle empty sibling stack case
- [x] See if there’s a reasonable way to `scrollIntoView` that doesn’t clip the focus ring
- [x] Protect elements that may be children of stack items that handle arrow keys from losing focus

https://github.com/user-attachments/assets/b7ad2c05-9bd7-47b9-9db6-b3ba62fdaed5

https://github.com/user-attachments/assets/1043953d-de4d-4afe-a226-ed8c997bc359