### PR TITLE
fix: `MessageCard` style bug

### DIFF
--- a/packages/plugins/plugin-inbox/src/components/Mailbox/mailbox.css
+++ b/packages/plugins/plugin-inbox/src/components/Mailbox/mailbox.css
@@ -4,12 +4,12 @@
     @apply pli-cardSpacingChrome plb-cardSpacingChrome;
   }
 
+  body[data-is-keyboard='true'] article:focus-within & > .dx-grid__cell__content {
+    @apply border;
+  }
+
   & > .dx-grid__cell__content, &.message__card {
     @apply grid grid-cols-[var(--rail-action)_1fr] gap-1 border-0;
-
-    body[data-is-keyboard='true'] article:focus-within & {
-      @apply border;
-    }
 
     &::before,
     &::after {


### PR DESCRIPTION
This PR fixes an issue which caused styles intended for dx-grid cells to apply to `MessageCard`.