### PR TITLE
ci: ensure that prebuild runs before bundle

### DIFF
--- a/packages/apps/composer-app/moon.yml
+++ b/packages/apps/composer-app/moon.yml
@@ -7,6 +7,9 @@ tags:
   - vite
   - ts-test
 tasks:
+  bundle:
+    deps:
+      - prebuild
   compile:
     deps:
       - prebuild


### PR DESCRIPTION
part of DX-444