### PR TITLE
fix: Sheet & Mailbox stories

### DIFF
--- a/packages/plugins/plugin-inbox/src/components/Mailbox/Mailbox.stories.tsx
+++ b/packages/plugins/plugin-inbox/src/components/Mailbox/Mailbox.stories.tsx
@@ -32,7 +32,7 @@ import { Mailbox as MailboxComponent } from './Mailbox';
 
 const DefaultStory = () => {
   const [messages] = useState(() => createMessages(100));
-  return <MailboxComponent id='story' messages={messages} ignoreAttention />;
+  return <MailboxComponent id='story' messages={messages} ignoreAttention role='story' />;
 };
 
 const WithCompanionStory = () => {
@@ -53,7 +53,7 @@ const WithCompanionStory = () => {
   }
 
   return (
-    <div {...attentionAttrs} className='is-full grid grid-cols-2 grid-rows-2 overflow-hidden'>
+    <div {...attentionAttrs} className='bs-full is-full grid grid-cols-2 grid-rows-2 overflow-hidden'>
       <Surface role='article' data={mailboxData} />
       <Surface role='article' data={companionData} />
     </div>

--- a/packages/plugins/plugin-inbox/src/components/Mailbox/Mailbox.tsx
+++ b/packages/plugins/plugin-inbox/src/components/Mailbox/Mailbox.tsx
@@ -204,7 +204,14 @@ export const Mailbox = ({ id, role, messages, currentMessageId, ignoreAttention,
   }, [messages]);
 
   return (
-    <div role='none' className={mx('flex flex-col [&_.dx-grid]:grow', role !== 'section' && '[&_.dx-grid]:bs-0')}>
+    <div
+      role='none'
+      className={mx(
+        'flex flex-col [&_.dx-grid]:grow',
+        role !== 'section' && '[&_.dx-grid]:bs-0',
+        role === 'story' && 'bs-full',
+      )}
+    >
       <Grid.Root id={`${id}__grid`}>
         <Grid.Content
           className={mx(

--- a/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.stories.tsx
+++ b/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.stories.tsx
@@ -29,7 +29,9 @@ export const Basic = () => {
 
   return (
     <SheetProvider graph={graph} sheet={sheet} ignoreAttention>
-      <GridSheet />
+      <div role='none' className='grid bs-full is-full'>
+        <GridSheet />
+      </div>
     </SheetProvider>
   );
 };

--- a/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.tsx
+++ b/packages/plugins/plugin-sheet/src/components/GridSheet/GridSheet.tsx
@@ -308,7 +308,7 @@ export const GridSheet = () => {
 
   return (
     // TODO(thure): Why are Table’s and Sheet’s editor boxes off by 1px?
-    <div role='none' className='relative min-bs-0 [&_.cm-editor]:!border-lb [&_.cm-editor]:!border-transparent '>
+    <div role='none' className='relative min-bs-0 [&_.cm-editor]:!border-lb [&_.cm-editor]:!border-transparent'>
       <GridCellEditor getCellContent={getCellContent} extensions={extensions} onBlur={handleBlur} />
       <Grid.Content
         initialCells={initialCells}

--- a/packages/plugins/plugin-sheet/src/components/SheetContainer/SheetContainer.stories.tsx
+++ b/packages/plugins/plugin-sheet/src/components/SheetContainer/SheetContainer.stories.tsx
@@ -64,7 +64,7 @@ export const Default = () => {
 
   return (
     <AttendableContainer id={fullyQualifiedId(sheet)} classNames='contents'>
-      <SheetContainer space={space} sheet={sheet} role='article' ignoreAttention />
+      <SheetContainer space={space} sheet={sheet} role='story' ignoreAttention />
     </AttendableContainer>
   );
 };
@@ -79,8 +79,8 @@ export const Spec = () => {
 
   return (
     <AttendableContainer id={fullyQualifiedId(sheet)} classNames='contents'>
-      <div role='none' className='grid grid-rows-[66%_33%] grid-cols-1'>
-        <SheetContainer space={space} sheet={sheet} role='article' ignoreAttention />
+      <div role='none' className='grid grid-rows-[66%_33%] bs-full grid-cols-1'>
+        <SheetContainer space={space} sheet={sheet} role='story' ignoreAttention />
         <div role='none' data-testid='grid.range-list'>
           <RangeList sheet={sheet} />
         </div>

--- a/packages/plugins/plugin-sheet/src/components/SheetContainer/SheetContainer.tsx
+++ b/packages/plugins/plugin-sheet/src/components/SheetContainer/SheetContainer.tsx
@@ -26,7 +26,11 @@ export const SheetContainer = ({ space, sheet, role, ignoreAttention }: SheetCon
 
   return graph ? (
     <SheetProvider sheet={sheet} graph={graph} ignoreAttention={ignoreAttention}>
-      <StackItem.Content toolbar statusbar {...(role === 'section' && { classNames: 'aspect-video' })}>
+      <StackItem.Content
+        toolbar
+        statusbar
+        classNames={[role === 'section' && 'aspect-video', role === 'story' && 'bs-full']}
+      >
         <SheetToolbar id={fullyQualifiedId(sheet)} />
         <GridSheet />
         <FunctionEditor />


### PR DESCRIPTION
This PR fixes a caveat of #9940, where grids with an unbounded size needed an extrinsic full size to occupy the full height of the viewport.