### PR TITLE
fix: `withLayout` Lit implementation

### DIFF
--- a/tools/lit-storybook/.storybook/preview.ts
+++ b/tools/lit-storybook/.storybook/preview.ts
@@ -5,9 +5,55 @@
 import '@dxos-theme';
 
 import { withThemeByClassName } from '@storybook/addon-themes';
-import { type Preview } from '@storybook/web-components-vite';
+import { type Decorator, type Preview } from '@storybook/web-components-vite';
+import { html } from 'lit';
 
-import { withLayout } from '@dxos/storybook-utils';
+import { mx } from '@dxos/react-ui-theme';
+
+const withLayout: Decorator = (Story, context) => {
+  const {
+    parameters: { layout },
+  } = context;
+  const { type, classNames, scroll } = typeof layout === 'object' ? layout : { type: layout };
+
+  switch (type) {
+    // Fullscreen.
+    case 'fullscreen':
+      return html`
+        <div role="none" class="${mx('fixed inset-0 flex flex-col overflow-hidden bg-baseSurface', classNames)}">
+          ${Story()}
+        </div>
+      `;
+
+    // Centered column.
+    case 'column':
+      return html`
+        <div role="none" class="fixed inset-0 flex justify-center overflow-hidden bg-deckSurface">
+          <div
+            role="none"
+            class="${mx(
+              'flex flex-col bs-full is-[40rem] bg-baseSurface border-is border-ie border-subduedSeparator',
+              classNames,
+              scroll ? 'overflow-y-auto' : 'overflow-hidden',
+            )}"
+          >
+            ${Story()}
+          </div>
+        </div>
+      `;
+
+    // Centered.
+    case 'centered':
+      return html`
+        <div role="none" class="fixed inset-0 grid place-items-center bg-deckSurface">
+          <div role="none" class="${mx('contents bg-baseSurface', classNames)}">${Story()}</div>
+        </div>
+      `;
+
+    default:
+      return Story();
+  }
+};
 
 /**
  * Configure Storybook rendering.


### PR DESCRIPTION
This PR fixes e2e tests which were failing for any running `lit-storybook` due to the `withLayout` change.

<img width="760" height="429" alt="Screenshot 2025-10-10 at 15 27 03" src="https://github.com/user-attachments/assets/5f5812f1-1166-4d4d-9d4a-9e872425a37c" />
