### PR TITLE
fix: Keep focus in NavTree on navigate

### DIFF
--- a/packages/plugins/plugin-deck/src/components/Plank/Plank.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/Plank.tsx
@@ -171,11 +171,7 @@ const PlankComponent = memo(
 
     useLayoutEffect(() => {
       if (scrollIntoView === id) {
-        // TODO(wittjosiah): When focused on page load, the focus is always visible.
-        //   Forcing focus to something smaller than the plank prevents large focus ring in the interim.
-        const focusable = rootElement.current?.querySelector('button') || rootElement.current;
-        focusable?.focus({ preventScroll: true });
-        layoutMode === 'deck' && focusable?.scrollIntoView({ behavior: 'smooth', inline: 'center' });
+        layoutMode === 'deck' && rootElement.current?.scrollIntoView({ behavior: 'smooth', inline: 'center' });
         // Clear the scroll into view state once it has been actioned.
         void dispatch(createIntent(LayoutAction.ScrollIntoView, { part: 'current', subject: undefined }));
       }


### PR DESCRIPTION
This PR
- begins a resolution of DX-574
- removes Plank’s autofocus behavior

https://github.com/user-attachments/assets/22a8684a-75d6-414a-994f-0ae54dd5a7cd
