### PR TITLE
feat: Popper Radix fork automatic collision boundary detection

### DIFF
--- a/packages/plugins/plugin-deck/src/components/DeckLayout/Popover.tsx
+++ b/packages/plugins/plugin-deck/src/components/DeckLayout/Popover.tsx
@@ -3,7 +3,7 @@
 //
 
 import { createContext } from '@radix-ui/react-context';
-import React, { type PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { type PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
 
 import { Surface, useCapability } from '@dxos/app-framework';
 import { Popover, type PopoverContentInteractOutsideEvent } from '@dxos/react-ui';
@@ -76,21 +76,12 @@ export const PopoverContent = () => {
     [setOpen],
   );
 
-  const collisionBoundaries: HTMLElement[] = useMemo(() => {
-    const closest = layout.popoverAnchor?.closest('[data-popover-collision-boundary]') as
-      | HTMLElement
-      | null
-      | undefined;
-    return closest ? [closest] : [];
-  }, [layout.popoverAnchor]);
-
   return (
     <Popover.Portal>
       <Popover.Content
         side={layout.popoverSide}
         onInteractOutside={handleClose}
         onEscapeKeyDown={handleClose}
-        collisionBoundary={collisionBoundaries}
         sticky='always'
         hideWhenDetached
       >

--- a/packages/plugins/plugin-deck/src/components/Plank/Plank.tsx
+++ b/packages/plugins/plugin-deck/src/components/Plank/Plank.tsx
@@ -2,6 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
+import { useFocusFinders } from '@fluentui/react-tabster';
 import React, {
   type KeyboardEvent,
   type PropsWithChildren,
@@ -111,6 +112,7 @@ const PlankContainer = ({
   return (
     <div
       role='none'
+      data-popover-collision-boundary={true}
       className={mx(
         'absolute inset-[--main-spacing] grid',
         encapsulate && 'border border-separator rounded overflow-hidden',
@@ -156,6 +158,7 @@ const PlankComponent = memo(
   }: PlankComponentProps) => {
     const { dispatchPromise: dispatch } = useIntentDispatcher();
     const { deck, popoverAnchorId, scrollIntoView } = useCapability(DeckCapabilities.DeckState);
+    const { findFirstFocusable } = useFocusFinders();
     const canResize = layoutMode === 'deck';
 
     const attentionAttrs = useAttentionAttributes(primary?.id ?? id);
@@ -179,8 +182,15 @@ const PlankComponent = memo(
 
     // TODO(thure): Tabster’s focus group should handle moving focus to Main, but something is blocking it.
     const handleKeyDown = useCallback((event: KeyboardEvent) => {
-      if (event.target === event.currentTarget && event.key === 'Escape') {
-        rootElement.current?.closest('main')?.focus();
+      if (event.target === event.currentTarget) {
+        switch (event.key) {
+          case 'Escape':
+            rootElement.current?.closest('main')?.focus();
+            break;
+          case 'Enter':
+            rootElement.current && findFirstFocusable(rootElement.current)?.focus();
+            break;
+        }
       }
     }, []);
 
@@ -234,6 +244,7 @@ const PlankComponent = memo(
       <Root
         ref={rootElement}
         data-testid='deck.plank'
+        data-popover-collision-boundary={true}
         tabIndex={0}
         {...(part.startsWith('solo')
           ? ({ ...sizeAttrs, className } as any)

--- a/packages/plugins/plugin-storybook-layout/src/components/Layout.tsx
+++ b/packages/plugins/plugin-storybook-layout/src/components/Layout.tsx
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import React, { type PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { type PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
 
 import { Surface, useCapability } from '@dxos/app-framework';
 import {
@@ -57,14 +57,6 @@ export const Layout = ({ children }: PropsWithChildren<{}>) => {
     }
   }, []);
 
-  const collisionBoundaries: HTMLElement[] = useMemo(() => {
-    const closest = layout.popoverAnchor?.closest('[data-popover-collision-boundary]') as
-      | HTMLElement
-      | null
-      | undefined;
-    return closest ? [closest] : [];
-  }, [layout.popoverAnchor]);
-
   const DialogRoot = layout.dialogType === 'alert' ? AlertDialog.Root : Dialog.Root;
   const DialogOverlay = layout.dialogType === 'alert' ? AlertDialog.Overlay : Dialog.Overlay;
 
@@ -103,7 +95,6 @@ export const Layout = ({ children }: PropsWithChildren<{}>) => {
           side={layout.popoverSide}
           onInteractOutside={handleInteractOutside}
           onEscapeKeyDown={handleInteractOutside}
-          collisionBoundary={collisionBoundaries}
           sticky='always'
           hideWhenDetached
         >

--- a/packages/ui/react-ui/src/components/Popover/Popover.tsx
+++ b/packages/ui/react-ui/src/components/Popover/Popover.tsx
@@ -31,6 +31,7 @@ import React, {
   forwardRef,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -432,6 +433,7 @@ const PopoverContentImpl = forwardRef<PopoverContentImplElement, PopoverContentI
       onFocusOutside,
       onInteractOutside,
       collisionPadding = 8,
+      collisionBoundary,
       classNames,
       ...contentProps
     } = props;
@@ -443,6 +445,20 @@ const PopoverContentImpl = forwardRef<PopoverContentImplElement, PopoverContentI
 
     // Make sure the whole tree has focus guards as our `Popover` may be the last element in the DOM (because of the `Portal`)
     useFocusGuards();
+
+    // Check for the closest annotated collision boundary in the DOM tree.
+    const computedCollisionBoundary = useMemo(() => {
+      const closestBoundary = context.triggerRef.current?.closest(
+        '[data-popover-collision-boundary]',
+      ) as HTMLElement | null;
+      return closestBoundary
+        ? Array.isArray(collisionBoundary)
+          ? [closestBoundary, ...collisionBoundary]
+          : collisionBoundary
+            ? [closestBoundary, collisionBoundary]
+            : [closestBoundary]
+        : collisionBoundary;
+    }, [context.open, collisionBoundary, context.triggerRef.current]);
 
     return (
       <FocusScope
@@ -468,6 +484,7 @@ const PopoverContentImpl = forwardRef<PopoverContentImplElement, PopoverContentI
             {...popperScope}
             {...contentProps}
             collisionPadding={safeCollisionPadding}
+            collisionBoundary={computedCollisionBoundary}
             className={tx('popover.content', 'popover', { elevation }, classNames)}
             ref={forwardedRef}
             style={{


### PR DESCRIPTION
This PR:
- moves `DeckLayout`’s method of detecting collision boundary elements upstream into our forks of Popover and DropdownMenu.
- fixes an issue where Planks don’t pass focus inward on Enter.

<img width="294" height="153" alt="Screenshot 2025-10-31 at 16 20 26" src="https://github.com/user-attachments/assets/226b1c16-c8dd-41fd-a530-79a6f514792d" />
