### PR TITLE
feat: add text replacer extension and update comment styling

### DIFF
--- a/packages/plugins/plugin-markdown/src/hooks/useExtensions.tsx
+++ b/packages/plugins/plugin-markdown/src/hooks/useExtensions.tsx
@@ -32,6 +32,7 @@ import {
   linkTooltip,
   listener,
   preview,
+  replacer,
   selectionState,
   typewriter,
 } from '@dxos/react-ui-editor';
@@ -177,6 +178,7 @@ const createBaseExtensions = ({
         }),
         linkTooltip(renderLinkTooltip),
         preview(previewOptions),
+        replacer(),
       ],
     );
   }

--- a/packages/ui/react-ui-editor/src/extensions/comments.ts
+++ b/packages/ui/react-ui-editor/src/extensions/comments.ts
@@ -104,13 +104,14 @@ export const commentsState = StateField.define<CommentsState>({
 const styles = EditorView.theme({
   '.cm-comment, .cm-comment-current': {
     padding: '3px 0',
+    color: 'var(--dx-cmCommentText)',
     backgroundColor: 'var(--dx-cmCommentSurface)',
   },
   '.cm-comment > span, .cm-comment-current > span': {
     boxDecorationBreak: 'clone',
     boxShadow: '0 0 1px 3px var(--dx-cmCommentSurface)',
     backgroundColor: 'var(--dx-cmCommentSurface)',
-    color: 'var(--dx-cmComment)',
+    color: 'var(--dx-cmCommentText)',
     cursor: 'pointer',
   },
 });

--- a/packages/ui/react-ui-editor/src/extensions/index.ts
+++ b/packages/ui/react-ui-editor/src/extensions/index.ts
@@ -24,6 +24,7 @@ export * from './modes';
 export * from './outliner';
 export * from './popover';
 export * from './preview';
+export * from './replacer';
 export * from './selection';
 export * from './scrolling';
 export * from './state';

--- a/packages/ui/react-ui-editor/src/extensions/replacer.test.ts
+++ b/packages/ui/react-ui-editor/src/extensions/replacer.test.ts
@@ -1,0 +1,75 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { describe, expect, test } from 'vitest';
+
+import { replacer } from './replacer';
+
+describe('replacer extension', () => {
+  test('creates extension with custom replacements and simulates typing', () => {
+    const state = EditorState.create({
+      extensions: [
+        replacer({
+          replacements: [
+            { input: ':)', output: '😊' },
+            { input: ':(', output: '😢' },
+          ],
+        }),
+      ],
+      doc: '',
+    });
+
+    // Create a minimal mock EditorView to test input handler
+    let currentState = state;
+    const mockView = {
+      get state() {
+        return currentState;
+      },
+      dispatch: (transaction: any) => {
+        currentState = transaction.state || currentState.update(transaction).state;
+      },
+    } as any;
+
+    // Get the input handler from the extension
+    const extensions = currentState.facet(EditorView.inputHandler);
+    const inputHandler = extensions[0];
+
+    // Test typing ':' first - should not trigger replacement.
+    let handled = inputHandler(mockView, 0, 0, ':', () =>
+      mockView.state.update({ changes: { from: 0, to: 0, insert: ':' } }),
+    );
+    expect(handled).toBe(false); // Should not handle single ':'
+
+    // Manually insert ':' to simulate first character.
+    mockView.dispatch({
+      changes: { from: 0, to: 0, insert: ':' },
+      selection: { anchor: 1 },
+    });
+    expect(mockView.state.doc.toString()).toBe(':');
+
+    // Test typing ')' which should trigger replacement.
+    // The input handler is called with the position where the character will be inserted.
+    // and it should handle the replacement before the character is actually inserted.
+    handled = inputHandler(mockView, 1, 1, ')', () =>
+      mockView.state.update({ changes: { from: 1, to: 1, insert: ')' } }),
+    );
+    expect(handled).toBe(true); // Should handle and replace ':)'
+    expect(mockView.state.doc.toString()).toBe('😊');
+  });
+
+  test('creates extension with default replacements', () => {
+    const state = EditorState.create({
+      extensions: [replacer()],
+      doc: 'test',
+    });
+
+    expect(state.doc.toString()).toBe('test');
+
+    // Verify the extension is installed.
+    const inputHandlers = state.facet(EditorView.inputHandler);
+    expect(inputHandlers.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui/react-ui-editor/src/extensions/replacer.ts
+++ b/packages/ui/react-ui-editor/src/extensions/replacer.ts
@@ -1,0 +1,93 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { type Extension } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+
+type Replacement = {
+  input: string;
+  output: string;
+};
+
+/**
+ * Default character replacements for common typography.
+ */
+export const defaultReplacements: Replacement[] = [
+  { input: '--', output: '—' },
+  { input: '...', output: '…' },
+  { input: '->', output: '→' },
+  { input: '<-', output: '←' },
+  { input: '=>', output: '⇒' },
+  { input: '<=>', output: '⇔' },
+  { input: '+-', output: '±' },
+  { input: '!=', output: '≠' },
+  { input: '<=', output: '≤' },
+  { input: '>=', output: '≥' },
+  { input: '(c)', output: '©' },
+  { input: 'EUR', output: '€' },
+  { input: 'GBP', output: '£' },
+  { input: 'BTC', output: '₿' },
+];
+
+/**
+ * Options for the replacer extension.
+ */
+export interface ReplacerOptions {
+  replacements?: Replacement[];
+}
+
+/**
+ * Creates a CodeMirror extension that automatically replaces typed character sequences.
+ */
+export const replacer = ({ replacements = defaultReplacements }: ReplacerOptions = {}): Extension => {
+  // Sort replacements by input length (longest first) to handle overlapping patterns correctly.
+  const sortedReplacements = [...replacements].sort((a, b) => b.input.length - a.input.length);
+
+  return EditorView.inputHandler.of((view, from, to, insert) => {
+    // Only process single character insertions for performance.
+    if (insert.length !== 1) {
+      return false;
+    }
+
+    const state = view.state;
+    const doc = state.doc;
+
+    // Get the text before the insertion point to check for patterns.
+    const lineStart = doc.lineAt(from).from;
+    const textBefore = doc.sliceString(lineStart, from);
+    const textWithInsert = textBefore + insert;
+
+    // Check each replacement pattern.
+    for (const replacement of sortedReplacements) {
+      if (textWithInsert.endsWith(replacement.input)) {
+        const range = {
+          from: from - replacement.input.length + 1,
+          to: from,
+        };
+
+        // Ensure we don't go before the line start.
+        if (range.from < lineStart) {
+          continue;
+        }
+
+        // Create the replacement transaction.
+        view.dispatch(
+          state.update({
+            changes: {
+              ...range,
+              insert: replacement.output,
+            },
+            selection: {
+              anchor: range.from + replacement.output.length,
+            },
+          }),
+        );
+
+        return true;
+      }
+    }
+
+    return false;
+  });
+};

--- a/packages/ui/react-ui-theme/src/config/tokens/sememes-codemirror.ts
+++ b/packages/ui/react-ui-theme/src/config/tokens/sememes-codemirror.ts
@@ -39,12 +39,12 @@ export const codemirrorSememes = {
     dark: ['cyan', 600],
   },
   // TODO(burdon): Factor out defs in common with sheet.
-  cmComment: {
-    light: ['neutral', 950],
-    dark: ['neutral', 50],
+  cmCommentText: {
+    light: ['neutral', 50],
+    dark: ['neutral', 950],
   },
   cmCommentSurface: {
-    light: ['green', 200],
-    dark: ['green', 700],
+    light: ['amber', 700],
+    dark: ['amber', 200],
   },
 } satisfies ColorSememes;


### PR DESCRIPTION
- Added replacer extension to markdown editor for text replacement functionality
- Updated comment highlighting colors to amber with inverted text colors for better visibility
- Fixed CSS variable references to use cmCommentText instead of cmComment