### PR TITLE
fix(testbench-app): add stub file

### DIFF
--- a/packages/apps/testbench-app/stub.mjs
+++ b/packages/apps/testbench-app/stub.mjs
@@ -1,0 +1,2 @@
+export {};
+export default {};


### PR DESCRIPTION
Fixes https://github.com/dxos/dxos/actions/runs/20291323549/job/58276218157
The bundle started failing after PR #10295 because it introduced/activated an AI/tokenizer dependency path (e.g. via anthropic-ai/tokenizer) that caused Vite to resolve the existing tiktoken/lite alias in testbench-app. That alias pointed to packages/apps/testbench-app/stub.mjs, but the file didn’t exist, so the production bundle began failing with ENOENT.