### PR TITLE
fix: improve edge environment handling and database flushing

### DIFF
--- a/packages/core/functions-runtime-cloudflare/src/internal/data-service-impl.ts
+++ b/packages/core/functions-runtime-cloudflare/src/internal/data-service-impl.ts
@@ -112,9 +112,8 @@ export class DataServiceImpl implements DataServiceProto {
   }
 
   async updateIndexes(): Promise<void> {
-    throw new NotImplementedError({
-      message: 'updateIndexes is not implemented.',
-    });
+    log.error('updateIndexes is not available in EDGE env.');
+    // No-op.
   }
 
   async waitUntilHeadsReplicated({ heads }: { heads: any }): Promise<void> {

--- a/packages/devtools/cli-next/src/commands/profile/list.ts
+++ b/packages/devtools/cli-next/src/commands/profile/list.ts
@@ -37,7 +37,7 @@ export const list = Command.make(
           name,
           isCurrent: name === currentProfile,
           fullPath,
-          storagePath: getProfilePath(configValues.runtime.client.storage.dataRoot ?? DX_DATA, name),
+          storagePath: getProfilePath(configValues?.runtime?.client?.storage.dataRoot ?? DX_DATA, name),
           edge: config.values.runtime?.services?.edge?.url,
         };
       }),

--- a/packages/plugins/plugin-chess/src/blueprints/functions/commentary.ts
+++ b/packages/plugins/plugin-chess/src/blueprints/functions/commentary.ts
@@ -192,8 +192,7 @@ export default defineFunction({
 
       log.info('result', { documentId: Obj.getDXN(document).toString(), commentary });
 
-      // TODO(wittjosiah): Hold function open so that mutations are persisted since flush is not supported in functions.
-      yield* Effect.sleep(5_000);
+      yield* Database.Service.flush();
 
       return {
         documentId: Obj.getDXN(document).toString(),


### PR DESCRIPTION
- Replace NotImplementedError with no-op and error log for updateIndexes in edge env
- Add optional chaining for profile config values to prevent errors
- Replace sleep workaround with proper database flush in chess commentary
