### PR TITLE
fix(config): add entry point files for plugin type exports

### DIFF
--- a/packages/sdk/config/src/esbuild-plugin/index.ts
+++ b/packages/sdk/config/src/esbuild-plugin/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2021 DXOS.org
+//
+
+export { ConfigPlugin } from '../plugin/esbuild-plugin';
+export { type ConfigPluginOpts } from '../plugin/types';

--- a/packages/sdk/config/src/rollup-plugin/index.ts
+++ b/packages/sdk/config/src/rollup-plugin/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+export { ConfigPlugin } from '../plugin/rollup-plugin';
+export { type ConfigPluginOpts } from '../plugin/types';

--- a/packages/sdk/config/src/vite-plugin/index.ts
+++ b/packages/sdk/config/src/vite-plugin/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2022 DXOS.org
+//
+
+export { ConfigPlugin } from '../plugin/vite-plugin';
+export { type ConfigPluginOpts } from '../plugin/types';


### PR DESCRIPTION
## Summary
- Create dedicated entry point files for `vite-plugin`, `esbuild-plugin`, and `rollup-plugin` that export both the `ConfigPlugin` and `ConfigPluginOpts` type
- Fixes the missing type exports that were referenced in package.json but didn't exist

## Problem
The `package.json` exports configuration referenced source files that didn't exist:
- `./src/vite-plugin/index.ts`
- `./src/esbuild-plugin/index.ts`
- `./src/rollup-plugin/index.ts`

This caused TypeScript to not find type declarations when importing from `@dxos/config/vite-plugin` (and the other plugin entry points).

## Solution
Created the missing entry point files that re-export both:
- `ConfigPlugin` - the actual plugin function
- `ConfigPluginOpts` - the options type interface

## Test plan
- [x] Build passes: `moon run config:build`
- [x] Lint passes: `moon run config:lint`
- [x] Types are correctly generated in `dist/types/src/vite-plugin/index.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)