### PR TITLE
chore: Verbatim module syntax tsconfig

### DIFF
--- a/packages/common/esbuild-plugins/tsconfig.json
+++ b/packages/common/esbuild-plugins/tsconfig.json
@@ -7,7 +7,8 @@
     "outDir": "dist",
     "types": [
       "node"
-    ]
+    ],
+    "verbatimModuleSyntax": false
   },
   "include": [
     "src"

--- a/packages/sdk/migrations/tsconfig.json
+++ b/packages/sdk/migrations/tsconfig.json
@@ -13,9 +13,6 @@
       "path": "../../common/invariant"
     },
     {
-      "path": "../../common/keys"
-    },
-    {
       "path": "../../common/log"
     },
     {

--- a/packages/sdk/migrations/tsconfig.json
+++ b/packages/sdk/migrations/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../../common/invariant"
     },
     {
+      "path": "../../common/keys"
+    },
+    {
       "path": "../../common/log"
     },
     {

--- a/tools/beast/tsconfig.json
+++ b/tools/beast/tsconfig.json
@@ -8,7 +8,8 @@
     "outDir": "dist",
     "types": [
       "node"
-    ]
+    ],
+    "verbatimModuleSyntax": false
   },
   "exclude": [
     "dist",

--- a/tools/dx-compile/tsconfig.json
+++ b/tools/dx-compile/tsconfig.json
@@ -4,7 +4,8 @@
     "emitDeclarationOnly": false,
     "module": "CommonJS",
     "moduleResolution": "Node",
-    "outDir": "dist"
+    "outDir": "dist",
+    "verbatimModuleSyntax": false
   },
   "include": [
     "src"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,6 +11,7 @@
     "experimentalDecorators": true,
     "incremental": true,
     "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "jsx": "react",
     "lib": ["DOM", "ESNext"],
     "module": "Preserve",


### PR DESCRIPTION
Enable `verbatimModuleSyntax` in the base tsconfig and disable it for specific CommonJS packages.

`verbatimModuleSyntax` was enabled globally to enforce stricter module import/export syntax. However, some packages (esbuild-plugins, beast, dx-compile) are configured with `module: "CommonJS"` but are written using ES import/export syntax. To prevent compilation errors, `verbatimModuleSyntax` is explicitly set to `false` in their respective `tsconfig.json` files.

---
Linear Issue: [DX-730](https://linear.app/dxos/issue/DX-730/enable-verbatimmodulesyntax-for-base-tsconfig)

<a href="https://cursor.com/background-agent?bcId=bc-3d03081f-b253-43f7-bb31-386e9ac482e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d03081f-b253-43f7-bb31-386e9ac482e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

