### PR TITLE
feat(eslint-plugin-rules): add consistent-change-param rule for Obj/Relation/Entity.change

### DIFF
--- a/.agent/workflows/types/Function.ts
+++ b/.agent/workflows/types/Function.ts
@@ -68,15 +68,15 @@ export const make = (props: Obj.MakeProps<typeof Function>) => Obj.make(Function
  * @param source - Source object to copy properties from.
  */
 export const setFrom = (target: Function, source: Function) => {
-  Obj.change(target, (obj) => {
-    obj.key = source.key ?? target.key;
-    obj.name = source.name ?? target.name;
-    obj.version = source.version;
-    obj.description = source.description;
-    obj.updated = source.updated;
+  Obj.change(target, (target) => {
+    target.key = source.key ?? target.key;
+    target.name = source.name ?? target.name;
+    target.version = source.version;
+    target.description = source.description;
+    target.updated = source.updated;
     // TODO(dmaretskyi): A workaround for an ECHO bug.
-    obj.inputSchema = source.inputSchema ? JSON.parse(JSON.stringify(source.inputSchema)) : undefined;
-    obj.outputSchema = source.outputSchema ? JSON.parse(JSON.stringify(source.outputSchema)) : undefined;
-    Obj.getMeta(obj).keys = JSON.parse(JSON.stringify(Obj.getMeta(source).keys));
+    target.inputSchema = source.inputSchema ? JSON.parse(JSON.stringify(source.inputSchema)) : undefined;
+    target.outputSchema = source.outputSchema ? JSON.parse(JSON.stringify(source.outputSchema)) : undefined;
+    Obj.getMeta(target).keys = JSON.parse(JSON.stringify(Obj.getMeta(source).keys));
   });
 };

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,6 +7,7 @@
     "denyWarnings": true
   },
   "rules": {
+    "@dxos/eslint-plugin-rules/consistent-change-param": "warn",
     "@dxos/eslint-plugin-rules/effect-subpath-imports": "warn",
     "@dxos/eslint-plugin-rules/header": "warn",
     "@dxos/eslint-plugin-rules/import-as-namespace": "warn",

--- a/packages/apps/composer-app/src/plugins/welcome/capabilities/default-content.ts
+++ b/packages/apps/composer-app/src/plugins/welcome/capabilities/default-content.ts
@@ -54,11 +54,11 @@ export default Capability.makeModule(
     space.db.add(readme);
 
     const gettingStarted = space.db.add(Obj.make(Collection.Collection, { name: 'Getting Started', objects: [] }));
-    Obj.change(gettingStarted, (collection) => {
-      collection.objects.push(Ref.make(readme));
+    Obj.change(gettingStarted, (gettingStarted) => {
+      gettingStarted.objects.push(Ref.make(readme));
     });
-    Obj.change(defaultSpaceCollection, (collection) => {
-      collection.objects.push(Ref.make(gettingStarted));
+    Obj.change(defaultSpaceCollection, (defaultSpaceCollection) => {
+      defaultSpaceCollection.objects.push(Ref.make(gettingStarted));
     });
 
     // Ensure the default content is in the graph and connected.

--- a/packages/apps/testbench-app/src/components/ItemList.tsx
+++ b/packages/apps/testbench-app/src/components/ItemList.tsx
@@ -61,7 +61,8 @@ export const Item = ({ object, onDelete }: ItemProps<Obj.Any>) => {
 
   // TODO(burdon): [API]: Type check?
   const getValue = (object: Obj.Any, prop: string) => object[prop];
-  const setValue = (object: Obj.Any, prop: string, value: any) => Obj.change(object, (obj) => (obj[prop] = value));
+  const setValue = (object: Obj.Any, prop: string, value: any) =>
+    Obj.change(object, (object) => (object[prop] = value));
 
   return (
     <div className={mx('flex m-1 p-2 border', subtleHover)}>

--- a/packages/apps/todomvc/src/components/Todos.tsx
+++ b/packages/apps/todomvc/src/components/Todos.tsx
@@ -60,8 +60,8 @@ export const Todos = () => {
       todoRefs.map(async (ref) => {
         const todo = await ref.load();
         if (todo.completed !== checked) {
-          Obj.change(todo, (obj) => {
-            obj.completed = checked;
+          Obj.change(todo, (todo) => {
+            todo.completed = checked;
           });
         }
       }),

--- a/packages/common/eslint-plugin-rules/index.js
+++ b/packages/common/eslint-plugin-rules/index.js
@@ -5,6 +5,7 @@
 import fs from 'node:fs';
 
 import comment from './rules/comment.js';
+import consistentChangeParam from './rules/consistent-change-param.js';
 import effectSubpathImports from './rules/effect-subpath-imports.js';
 import header from './rules/header.js';
 import importAsNamespace from './rules/import-as-namespace.js';
@@ -23,6 +24,7 @@ const plugin = {
   },
   rules: {
     comment,
+    'consistent-change-param': consistentChangeParam,
     'effect-subpath-imports': effectSubpathImports,
     header,
     'import-as-namespace': importAsNamespace,

--- a/packages/common/eslint-plugin-rules/rules/consistent-change-param.js
+++ b/packages/common/eslint-plugin-rules/rules/consistent-change-param.js
@@ -1,0 +1,143 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+/**
+ * ESLint rule to enforce that the callback parameter name in Obj.change(),
+ * Relation.change(), and Entity.change() matches the first argument name.
+ *
+ * @example
+ * // ❌ Bad
+ * Obj.change(trigger, (t) => { t.enabled = true; });
+ * Obj.change(trigger, (mutableTrigger) => { mutableTrigger.enabled = true; });
+ *
+ * // ✅ Good
+ * Obj.change(trigger, (trigger) => { trigger.enabled = true; });
+ */
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Enforce callback parameter name matches the first argument in Obj.change, Relation.change, and Entity.change.',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      mismatchedName:
+        'Callback parameter "{{callbackParam}}" should be "{{firstArg}}" to match the first argument of {{caller}}.change().',
+    },
+  },
+  create(context) {
+    /** Yield all Identifier reference nodes for `name` inside `node`, respecting scope shadowing. */
+    function* collectReferences(node, name) {
+      if (!node || typeof node !== 'object' || !node.type) {
+        return;
+      }
+
+      if (
+        node.type === 'ArrowFunctionExpression' ||
+        node.type === 'FunctionExpression' ||
+        node.type === 'FunctionDeclaration'
+      ) {
+        if (node.params?.some((p) => p.type === 'Identifier' && p.name === name)) {
+          return;
+        }
+        yield* collectReferences(node.body, name);
+        return;
+      }
+
+      if (node.type === 'Identifier' && node.name === name) {
+        yield node;
+        return;
+      }
+
+      for (const key of Object.keys(node)) {
+        if (key === 'parent') {
+          continue;
+        }
+        if (node.type === 'MemberExpression' && key === 'property' && !node.computed) {
+          continue;
+        }
+        if (node.type === 'Property' && key === 'key' && !node.computed && !node.shorthand) {
+          continue;
+        }
+
+        const child = node[key];
+        if (Array.isArray(child)) {
+          for (const item of child) {
+            if (item && typeof item === 'object' && item.type) {
+              yield* collectReferences(item, name);
+            }
+          }
+        } else if (child && typeof child === 'object' && child.type) {
+          yield* collectReferences(child, name);
+        }
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        const { callee } = node;
+
+        if (
+          callee.type !== 'MemberExpression' ||
+          callee.object.type !== 'Identifier' ||
+          !['Obj', 'Relation', 'Entity'].includes(callee.object.name) ||
+          callee.property.type !== 'Identifier' ||
+          callee.property.name !== 'change'
+        ) {
+          return;
+        }
+
+        const args = node.arguments;
+        if (args.length < 2) {
+          return;
+        }
+
+        const firstArg = args[0];
+        const callback = args[1];
+
+        if (firstArg.type !== 'Identifier') {
+          return;
+        }
+        if (callback.type !== 'ArrowFunctionExpression' && callback.type !== 'FunctionExpression') {
+          return;
+        }
+        if (callback.params.length !== 1) {
+          return;
+        }
+
+        const param = callback.params[0];
+        if (param.type !== 'Identifier') {
+          return;
+        }
+        if (param.name === firstArg.name) {
+          return;
+        }
+
+        context.report({
+          node: param,
+          messageId: 'mismatchedName',
+          data: {
+            callbackParam: param.name,
+            firstArg: firstArg.name,
+            caller: callee.object.name,
+          },
+          fix(fixer) {
+            const oldName = param.name;
+            const newName = firstArg.name;
+
+            const fixes = [fixer.replaceTextRange([param.range[0], param.range[0] + oldName.length], newName)];
+            for (const ref of collectReferences(callback.body, oldName)) {
+              fixes.push(fixer.replaceTextRange([ref.range[0], ref.range[0] + oldName.length], newName));
+            }
+            return fixes;
+          },
+        });
+      },
+    };
+  },
+};

--- a/packages/core/assistant-toolkit/src/blueprints/blueprint-manager/blueprint.test.ts
+++ b/packages/core/assistant-toolkit/src/blueprints/blueprint-manager/blueprint.test.ts
@@ -142,8 +142,8 @@ describe('Blueprint Manager', () => {
 
         const stored = yield* Blueprint.upsert('org.dxos.blueprint.database');
         const originalName = stored.name;
-        Obj.change(stored, (mutable) => {
-          mutable.name = '___TEST_MUTATED_BLUEPRINT_NAME___';
+        Obj.change(stored, (stored) => {
+          stored.name = '___TEST_MUTATED_BLUEPRINT_NAME___';
         });
         yield* Database.flush();
         expect(stored.name).toBe('___TEST_MUTATED_BLUEPRINT_NAME___');

--- a/packages/core/assistant-toolkit/src/blueprints/database/blueprint.test.ts
+++ b/packages/core/assistant-toolkit/src/blueprints/database/blueprint.test.ts
@@ -284,7 +284,7 @@ describe('Database Blueprint', () => {
         const org = yield* Database.add(Obj.make(Organization.Organization, { name: 'Untagged Corp' }));
         const tag = yield* Database.add(Tag.make({ label: 'obsolete' }));
         const tagDxn = Obj.getDXN(tag).toString();
-        Entity.change(org, (obj) => Entity.addTag(obj, tagDxn));
+        Entity.change(org, (org) => Entity.addTag(org, tagDxn));
         expect(Obj.getMeta(org).tags ?? []).toContain(tagDxn);
         yield* agent.submitPrompt(`Remove tag "obsolete" from the organization "Untagged Corp".`);
         yield* agent.waitForCompletion();

--- a/packages/core/assistant-toolkit/src/blueprints/database/functions/tag-add.ts
+++ b/packages/core/assistant-toolkit/src/blueprints/database/functions/tag-add.ts
@@ -14,7 +14,7 @@ export default TagAdd.pipe(
     Effect.fn(function* ({ tag, obj }) {
       const object = yield* Database.load(obj);
       const tagObj = yield* Database.load(tag);
-      Entity.change(object, (obj) => Entity.addTag(obj, Obj.getDXN(tagObj).toString()));
+      Entity.change(object, (object) => Entity.addTag(object, Obj.getDXN(tagObj).toString()));
       return Entity.toJSON(object);
     }),
   ),

--- a/packages/core/assistant-toolkit/src/blueprints/database/functions/tag-remove.ts
+++ b/packages/core/assistant-toolkit/src/blueprints/database/functions/tag-remove.ts
@@ -14,7 +14,7 @@ export default TagRemove.pipe(
     Effect.fn(function* ({ tag, obj }) {
       const object = yield* Database.load(obj);
       const tagObj = yield* Database.load(tag);
-      Entity.change(object, (obj) => Entity.removeTag(obj, Obj.getDXN(tagObj).toString()));
+      Entity.change(object, (object) => Entity.removeTag(object, Obj.getDXN(tagObj).toString()));
       return Entity.toJSON(object);
     }),
   ),

--- a/packages/core/assistant-toolkit/src/blueprints/markdown/functions/update.ts
+++ b/packages/core/assistant-toolkit/src/blueprints/markdown/functions/update.ts
@@ -14,8 +14,8 @@ export default Update.pipe(
     Effect.fn(function* ({ doc, content }) {
       const document = yield* Database.load(doc);
       const text = yield* Database.load(document.content);
-      Obj.change(text, (obj) => {
-        obj.content = content;
+      Obj.change(text, (text) => {
+        text.content = content;
       });
     }),
   ),

--- a/packages/core/assistant-toolkit/src/functions/entity-extraction/entity-extraction.ts
+++ b/packages/core/assistant-toolkit/src/functions/entity-extraction/entity-extraction.ts
@@ -55,13 +55,13 @@ export default EntityExtraction.pipe(
             throw new Error('Multiple organizations created');
           } else if (created.length === 1) {
             organization = yield* Database.resolve(created[0], Organization.Organization);
-            Obj.change(organization, (org) => {
-              const meta = Obj.getMeta(org);
+            Obj.change(organization, (organization) => {
+              const meta = Obj.getMeta(organization);
               meta.tags ??= [];
               meta.tags.push(...(tags ?? []));
             });
-            Obj.change(contact, (obj) => {
-              obj.organization = Ref.make(organization!);
+            Obj.change(contact, (contact) => {
+              contact.organization = Ref.make(organization!);
             });
           }
         }
@@ -109,8 +109,8 @@ const extractContact = Effect.fn('extractContact')(function* (actor: Actor.Actor
   yield* Database.add(newContact);
 
   if (name) {
-    Obj.change(newContact, (obj) => {
-      obj.fullName = name;
+    Obj.change(newContact, (newContact) => {
+      newContact.fullName = name;
     });
   }
 
@@ -150,8 +150,8 @@ const extractContact = Effect.fn('extractContact')(function* (actor: Actor.Actor
 
   if (matchingOrg) {
     log.info('found matching organization', { organization: matchingOrg });
-    Obj.change(newContact, (obj) => {
-      obj.organization = Ref.make(matchingOrg);
+    Obj.change(newContact, (newContact) => {
+      newContact.organization = Ref.make(matchingOrg);
     });
   }
 

--- a/packages/core/assistant-toolkit/src/sync/sync.ts
+++ b/packages/core/assistant-toolkit/src/sync/sync.ts
@@ -63,7 +63,7 @@ export const syncObjects: (
 });
 
 const copyObjectData = (existing: Obj.Unknown, newObj: Obj.Unknown) => {
-  Obj.change(existing, (obj) => {
+  Obj.change(existing, (existing) => {
     // Copy properties from newObj to existing.
     for (const key of Object.keys(newObj)) {
       if (typeof key !== 'string' || key === 'id') continue;
@@ -74,22 +74,22 @@ const copyObjectData = (existing: Obj.Unknown, newObj: Obj.Unknown) => {
         !Ref.isRef((newObj as any)[key])
       )
         continue;
-      (obj as any)[key] = (newObj as any)[key];
+      (existing as any)[key] = (newObj as any)[key];
     }
 
     // Delete properties that don't exist in newObj.
-    for (const key of Object.keys(obj)) {
+    for (const key of Object.keys(existing)) {
       if (typeof key !== 'string' || key === 'id') continue;
       if (!(key in newObj)) {
-        delete (obj as any)[key];
+        delete (existing as any)[key];
       }
     }
 
     // Update foreign keys.
     for (const foreignKey of Obj.getMeta(newObj).keys) {
-      Obj.deleteKeys(obj, foreignKey.source);
+      Obj.deleteKeys(existing, foreignKey.source);
       // TODO(dmaretskyi): Doesn't work: `Obj.getMeta(existing).keys.push(foreignKey);`
-      Obj.getMeta(obj).keys.push({ ...foreignKey });
+      Obj.getMeta(existing).keys.push({ ...foreignKey });
     }
   });
 };

--- a/packages/core/blueprints/src/blueprint/registry.ts
+++ b/packages/core/blueprints/src/blueprint/registry.ts
@@ -52,8 +52,8 @@ export class Registry {
           continue;
         }
         const source = Obj.clone(registryBlueprint, { deep: true });
-        Obj.change(blueprint, (mutable) => {
-          void Obj.updateFrom(mutable, source);
+        Obj.change(blueprint, (blueprint) => {
+          void Obj.updateFrom(blueprint, source);
         });
       }
     }).pipe(Effect.orDie);

--- a/packages/core/compute/src/compute-graph-registry.test.ts
+++ b/packages/core/compute/src/compute-graph-registry.test.ts
@@ -65,8 +65,8 @@ describe('ComputeGraphRegistry', () => {
     });
 
     const functionObj = Operation.serialize(add);
-    Obj.change(functionObj, (obj) => {
-      obj.binding = 'ADD';
+    Obj.change(functionObj, (functionObj) => {
+      functionObj.binding = 'ADD';
     });
     space.db.add(functionObj);
 
@@ -135,8 +135,8 @@ describe('ComputeGraphRegistry', () => {
     onTestFinished(unsubscribe);
 
     const functionObj = Operation.serialize(add);
-    Obj.change(functionObj, (obj) => {
-      obj.binding = 'ADD';
+    Obj.change(functionObj, (functionObj) => {
+      functionObj.binding = 'ADD';
     });
     space.db.add(functionObj);
 

--- a/packages/core/echo/echo-atom/src/ref-atom.test.ts
+++ b/packages/core/echo/echo-atom/src/ref-atom.test.ts
@@ -60,8 +60,8 @@ describe('AtomRef - Basic Functionality', () => {
     expect(updateCount).toBe(1);
 
     // Mutate target - ref atom does NOT react to this.
-    Obj.change(targetObj, (obj) => {
-      obj.name = 'Updated';
+    Obj.change(targetObj, (targetObj) => {
+      targetObj.name = 'Updated';
     });
 
     // Update count should still be 1 - ref atom doesn't subscribe to target changes.

--- a/packages/core/echo/echo-db/src/core-db/core-database.test.ts
+++ b/packages/core/echo/echo-db/src/core-db/core-database.test.ts
@@ -239,11 +239,11 @@ describe('CoreDatabase', () => {
       const partiallyLoadedLinks = range(3).map(() => createTextObject('test2'));
       const objectsToAdd = range(2).map(() => Obj.make(TestSchema.Expando, {}));
       const rootObject = Obj.make(TestSchema.Expando, {});
-      Obj.change(rootObject, (root: any) => {
+      Obj.change(rootObject, (rootObject: any) => {
         [linksToRemove, loadedLinks, partiallyLoadedLinks]
           .flatMap((v: any[]) => v)
           .forEach((obj: any) => {
-            root[obj.id] = Ref.make(obj);
+            rootObject[obj.id] = Ref.make(obj);
           });
       });
 

--- a/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
@@ -235,8 +235,8 @@ describe('Reactive Object with ECHO database', () => {
     await graph.schemaRegistry.register([TestSchema]);
     const objectHost = db.add(Obj.make(TestSchema, { field: [] }));
     const object = db.add(Obj.make(TestSchema, { field: 'foo' }));
-    Obj.change(objectHost, (obj) => {
-      obj.field?.push({ hosted: Ref.make(object) });
+    Obj.change(objectHost, (objectHost) => {
+      objectHost.field?.push({ hosted: Ref.make(object) });
     });
     Obj.make(TestSchema, {
       field: [Obj.make(TestSchema, { field: Ref.make(objectHost) })],
@@ -425,8 +425,8 @@ describe('Reactive Object with ECHO database', () => {
         array: [{ field: undefined }],
       }),
     );
-    Obj.change(object, (obj) => {
-      obj.array.push({ field: undefined });
+    Obj.change(object, (object) => {
+      object.array.push({ field: undefined });
     });
     for (const value of [object.field, object.nested.deep.field, ...object.array.map((o: any) => o.field)]) {
       expect(value).to.be.undefined;
@@ -500,8 +500,8 @@ describe('Reactive Object with ECHO database', () => {
       const { db } = await builder.createDatabase();
       const another = Obj.make(TestSchema.Expando, { title: 'another' });
       const task = Obj.make(TestSchema.Expando, { title: 'test', previous: Ref.make(another) });
-      Obj.change(another, (obj) => {
-        obj.previous = Ref.make(task);
+      Obj.change(another, (another) => {
+        another.previous = Ref.make(task);
       });
       db.add(task);
     });
@@ -586,13 +586,13 @@ describe('Reactive Object with ECHO database', () => {
       const task1 = Obj.make(TestSchema.Task, { title: 'Task1' });
       const task2 = Obj.make(TestSchema.Task, { title: 'Task2' });
 
-      Obj.change(contact, (obj) => {
-        obj.tasks!.push(Ref.make(task1));
-        obj.tasks!.push(Ref.make(task2));
+      Obj.change(contact, (contact) => {
+        contact.tasks!.push(Ref.make(task1));
+        contact.tasks!.push(Ref.make(task2));
       });
 
-      Obj.change(task2, (obj) => {
-        obj.previous = Ref.make(task1);
+      Obj.change(task2, (task2) => {
+        task2.previous = Ref.make(task1);
       });
 
       expect(contact.tasks![0].target).to.eq(task1);
@@ -660,7 +660,7 @@ describe('Reactive Object with ECHO database', () => {
     test('meta taken from reactive object when saving to echo', async () => {
       const testKey = { source: 'test', id: 'hello' };
       const reactiveObject = Obj.make(TestSchema.Expando, {});
-      Obj.change(reactiveObject, (obj) => Obj.getMeta(obj).keys.push(testKey));
+      Obj.change(reactiveObject, (reactiveObject) => Obj.getMeta(reactiveObject).keys.push(testKey));
 
       const { db } = await builder.createDatabase();
       const obj = db.add(reactiveObject);
@@ -861,20 +861,20 @@ describe('Reactive Object with ECHO database', () => {
 
       const originalValue = { foo: 'bar', nested: { value: 42 } };
       const obj1 = db.add(Obj.make(TestSchema.Expando, { title: 'Object 1' }));
-      Obj.change(obj1, (obj) => {
-        obj.field = originalValue;
+      Obj.change(obj1, (obj1) => {
+        obj1.field = originalValue;
       });
       expect(obj1.field).toEqual(originalValue);
 
       const obj2 = db.add(Obj.make(TestSchema.Expando, { title: 'Object 2' }));
-      Obj.change(obj2, (obj) => {
-        obj.field = obj1.field;
+      Obj.change(obj2, (obj2) => {
+        obj2.field = obj1.field;
       });
       expect(obj1.field).toEqual(obj2.field);
 
-      Obj.change(obj1, (obj) => {
-        obj.field.foo = obj.field.foo + '_v2';
-        obj.field.nested.value += 1;
+      Obj.change(obj1, (obj1) => {
+        obj1.field.foo = obj1.field.foo + '_v2';
+        obj1.field.nested.value += 1;
       });
       expect(obj1.field.foo).not.toEqual(obj2.field.foo);
       expect(obj1.field.nested.value).not.toEqual(obj2.field.nested.value);
@@ -885,19 +885,19 @@ describe('Reactive Object with ECHO database', () => {
 
       const obj1 = db.add(Obj.make(TestSchema.Expando, { title: 'Object 1' }));
       const obj2 = Obj.make(TestSchema.Expando, { title: 'Object 2' });
-      Obj.change(obj1, (obj) => {
-        obj.nested = { object: { ref: Ref.make(obj2) } };
+      Obj.change(obj1, (obj1) => {
+        obj1.nested = { object: { ref: Ref.make(obj2) } };
       });
       expect(obj1.nested.object.ref.target).toEqual(obj2);
 
       const obj3 = db.add(Obj.make(TestSchema.Expando, { title: 'Object 3' }));
-      Obj.change(obj3, (obj) => {
-        obj.nested = obj1.nested;
+      Obj.change(obj3, (obj3) => {
+        obj3.nested = obj1.nested;
       });
       expect(obj1.nested.object.ref.target).toEqual(obj3.nested.object.ref.target);
 
-      Obj.change(obj1, (obj) => {
-        obj.nested.object.ref = Ref.make(Obj.make(TestSchema.Expando, { title: 'Object 4' }));
+      Obj.change(obj1, (obj1) => {
+        obj1.nested.object.ref = Ref.make(Obj.make(TestSchema.Expando, { title: 'Object 4' }));
       });
       expect(obj1.nested.object.ref.target).not.toEqual(obj3.nested.object.ref.target);
     });
@@ -960,17 +960,17 @@ describe('Reactive Object with ECHO database', () => {
     const newObj = Obj.make(TestSchema.Expando, { title: 'New object' });
     const foreignKey1 = { source: 'example.com', id: 'key-1' };
     const foreignKey2 = { source: 'another.com', id: 'key-2' };
-    Obj.change(newObj, (obj) => {
-      const meta = Obj.getMeta(obj);
+    Obj.change(newObj, (newObj) => {
+      const meta = Obj.getMeta(newObj);
       meta.keys.push(foreignKey1);
       meta.keys.push(foreignKey2);
     });
 
     // Copy foreign keys from new object to existing object (existing is in database).
     for (const foreignKey of Obj.getMeta(newObj).keys) {
-      Obj.change(existing, (obj) => {
-        Obj.deleteKeys(obj, foreignKey.source);
-        Obj.getMeta(obj).keys.push({ ...foreignKey });
+      Obj.change(existing, (existing) => {
+        Obj.deleteKeys(existing, foreignKey.source);
+        Obj.getMeta(existing).keys.push({ ...foreignKey });
       });
     }
 

--- a/packages/core/echo/echo-db/src/echo-handler/reactive-proxy.blueprint-test.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/reactive-proxy.blueprint-test.ts
@@ -466,8 +466,8 @@ export const reactiveProxyTests = (testConfigFactory: TestConfigurationFactory):
           const { array, parent } = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(parent);
 
-          Obj.change(parent, (obj) => {
-            obj.stringArray![0] = '2';
+          Obj.change(parent, (parent) => {
+            parent.stringArray![0] = '2';
           });
           expect(array[0]).to.eq('2');
           expect(updates.count, 'update count').to.eq(1);
@@ -478,8 +478,8 @@ export const reactiveProxyTests = (testConfigFactory: TestConfigurationFactory):
           using updates = updateCounter(parent);
           expect(array.length).to.eq(3);
 
-          Obj.change(parent, (obj) => {
-            obj.stringArray!.push('4');
+          Obj.change(parent, (parent) => {
+            parent.stringArray!.push('4');
           });
           expect(array.length).to.eq(4);
           expect(updates.count, 'update count').to.eq(1);
@@ -489,8 +489,8 @@ export const reactiveProxyTests = (testConfigFactory: TestConfigurationFactory):
           const { array, parent } = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(parent);
 
-          Obj.change(parent, (obj) => {
-            obj.stringArray!.length = 2;
+          Obj.change(parent, (parent) => {
+            parent.stringArray!.length = 2;
           });
           expect(array.length).to.eq(2);
           expect(updates.count, 'update count').to.eq(1);
@@ -500,8 +500,8 @@ export const reactiveProxyTests = (testConfigFactory: TestConfigurationFactory):
           const { array, parent } = await createReactiveArray(['1', '2', '3']);
           using updates = updateCounter(parent);
 
-          Obj.change(parent, (obj) => {
-            obj.stringArray!.push('4');
+          Obj.change(parent, (parent) => {
+            parent.stringArray!.push('4');
           });
           expect(array).to.deep.eq(['1', '2', '3', '4']);
           expect(updates.count, 'update count').to.eq(1);
@@ -512,8 +512,8 @@ export const reactiveProxyTests = (testConfigFactory: TestConfigurationFactory):
           using updates = updateCounter(parent);
 
           let value: string | undefined;
-          Obj.change(parent, (obj) => {
-            value = obj.stringArray!.pop();
+          Obj.change(parent, (parent) => {
+            value = parent.stringArray!.pop();
           });
           expect(value).to.eq('3');
           expect(array).to.deep.eq(['1', '2']);
@@ -525,8 +525,8 @@ export const reactiveProxyTests = (testConfigFactory: TestConfigurationFactory):
           using updates = updateCounter(parent);
 
           let value: string | undefined;
-          Obj.change(parent, (obj) => {
-            value = obj.stringArray!.shift();
+          Obj.change(parent, (parent) => {
+            value = parent.stringArray!.shift();
           });
           expect(value).to.eq('1');
           expect(array).to.deep.eq(['2', '3']);
@@ -538,8 +538,8 @@ export const reactiveProxyTests = (testConfigFactory: TestConfigurationFactory):
           using updates = updateCounter(parent);
 
           let newLength: number = 0;
-          Obj.change(parent, (obj) => {
-            newLength = obj.stringArray!.unshift('0');
+          Obj.change(parent, (parent) => {
+            newLength = parent.stringArray!.unshift('0');
           });
           expect(newLength).to.eq(4);
           expect(array).to.deep.eq(['0', '1', '2', '3']);
@@ -551,8 +551,8 @@ export const reactiveProxyTests = (testConfigFactory: TestConfigurationFactory):
           using updates = updateCounter(parent);
 
           let removed: string[] = [];
-          Obj.change(parent, (obj) => {
-            removed = obj.stringArray!.splice(1, 1, '4');
+          Obj.change(parent, (parent) => {
+            removed = parent.stringArray!.splice(1, 1, '4');
           });
           expect(removed).to.deep.eq(['2']);
           expect(array).to.deep.eq(['1', '4', '3']);
@@ -564,8 +564,8 @@ export const reactiveProxyTests = (testConfigFactory: TestConfigurationFactory):
           using updates = updateCounter(parent);
 
           let returnValue: string[] = [];
-          Obj.change(parent, (obj) => {
-            returnValue = obj.stringArray!.sort();
+          Obj.change(parent, (parent) => {
+            returnValue = parent.stringArray!.sort();
           });
           expect(returnValue === array).to.be.true;
           expect(array).to.deep.eq(['1', '2', '3']);
@@ -583,8 +583,8 @@ export const reactiveProxyTests = (testConfigFactory: TestConfigurationFactory):
           using updates = updateCounter(parent);
 
           let returnValue: string[] = [];
-          Obj.change(parent, (obj) => {
-            returnValue = obj.stringArray!.reverse();
+          Obj.change(parent, (parent) => {
+            returnValue = parent.stringArray!.reverse();
           });
           expect(returnValue === array).to.be.true;
           expect(array).to.deep.eq(['3', '2', '1']);

--- a/packages/core/echo/echo-db/src/echo-handler/subscription.test.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/subscription.test.ts
@@ -29,13 +29,13 @@ describe('create subscription', () => {
 
     const counter = createUpdateCounter(task);
 
-    Obj.change(task, (obj) => {
-      obj.title = 'Test title';
+    Obj.change(task, (task) => {
+      task.title = 'Test title';
     });
     expect(counter.value).to.equal(2);
 
-    Obj.change(task, (obj) => {
-      obj.title = 'Test title revision';
+    Obj.change(task, (task) => {
+      task.title = 'Test title revision';
     });
     expect(counter.value).to.equal(3);
   });
@@ -54,8 +54,8 @@ describe('create subscription', () => {
     expect(actions).to.deep.equal(['update']);
 
     actions.push('before');
-    Obj.change(task, (obj) => {
-      obj.title = 'Test title';
+    Obj.change(task, (task) => {
+      task.title = 'Test title';
     });
     actions.push('after');
 
@@ -78,8 +78,8 @@ describe('create subscription', () => {
     });
     selection.update([task]);
 
-    Obj.change(task, (obj) => {
-      obj.title = 'Test title';
+    Obj.change(task, (task) => {
+      task.title = 'Test title';
     });
     expect(await title.wait()).to.equal('Test title');
   });
@@ -97,8 +97,8 @@ describe('create subscription', () => {
     const counter = createUpdateCounter(task);
 
     expect(counter.value).to.equal(1);
-    Obj.change(task, (obj) => {
-      obj.nested.title = 'New title';
+    Obj.change(task, (task) => {
+      task.nested.title = 'New title';
     });
     expect(counter.value).to.equal(2);
   });
@@ -113,8 +113,8 @@ describe('create subscription', () => {
     const counter = createUpdateCounter(task);
 
     expect(counter.value).to.equal(1);
-    Obj.change(task, (obj) => {
-      obj.nested.deep_nested.title = 'New title';
+    Obj.change(task, (task) => {
+      task.nested.deep_nested.title = 'New title';
     });
     expect(counter.value).to.equal(2);
   });
@@ -127,8 +127,8 @@ describe('create subscription', () => {
     const counter = createUpdateCounter(task);
 
     expect(counter.value).to.equal(1);
-    Obj.change(task, (obj) => {
-      obj.array[0] = 'New value';
+    Obj.change(task, (task) => {
+      task.array[0] = 'New value';
     });
     expect(counter.value).to.equal(2);
   });
@@ -141,8 +141,8 @@ describe('create subscription', () => {
     const counter = createUpdateCounter(task);
 
     expect(counter.value).to.equal(1);
-    Obj.change(task, (obj) => {
-      obj.array[0].title = 'New value';
+    Obj.change(task, (task) => {
+      task.array[0].title = 'New value';
     });
     expect(counter.value).to.equal(2);
   });
@@ -156,8 +156,8 @@ describe('create subscription', () => {
     const counter = createUpdateCounter(task);
 
     expect(counter.value).to.equal(1);
-    Obj.change(task, (obj) => {
-      obj.array[0].nested_array[0].title = 'New value';
+    Obj.change(task, (task) => {
+      task.array[0].nested_array[0].title = 'New value';
     });
     expect(counter.value).to.equal(2);
   });

--- a/packages/core/echo/echo-db/src/hypergraph.test.ts
+++ b/packages/core/echo/echo-db/src/hypergraph.test.ts
@@ -35,8 +35,8 @@ describe('HyperGraph', () => {
       }),
     );
 
-    Obj.change(obj1, (obj) => {
-      obj.link = Ref.make(obj2);
+    Obj.change(obj1, (obj1) => {
+      obj1.link = Ref.make(obj2);
     });
     expect(obj1.link.target?.title).to.eq('B');
 
@@ -70,8 +70,8 @@ describe('HyperGraph', () => {
         title: 'B',
       }),
     );
-    Obj.change(obj1, (obj) => {
-      obj.link = Ref.make(obj2);
+    Obj.change(obj1, (obj1) => {
+      obj1.link = Ref.make(obj2);
     });
     await Promise.all([db1.flush(), db2.flush()]);
     expect(obj1.link.target?.title).to.eq('B');

--- a/packages/core/echo/echo-db/src/proxy-db/database.test.ts
+++ b/packages/core/echo/echo-db/src/proxy-db/database.test.ts
@@ -272,9 +272,9 @@ describe('Database', () => {
       const container = db.add(Obj.make(TestSchema.Container, { objects: [] }));
       await db.flush();
 
-      Obj.change(container, (obj) => {
-        obj.objects!.push(Ref.make(Obj.make(TestSchema.Expando, { foo: 100 })));
-        obj.objects!.push(Ref.make(Obj.make(TestSchema.Expando, { bar: 200 })));
+      Obj.change(container, (container) => {
+        container.objects!.push(Ref.make(Obj.make(TestSchema.Expando, { foo: 100 })));
+        container.objects!.push(Ref.make(Obj.make(TestSchema.Expando, { bar: 200 })));
       });
     }
 
@@ -299,9 +299,9 @@ describe('Database', () => {
       const container = db.add(Obj.make(TestSchema.Container, { objects: [] }));
       await db.flush();
 
-      Obj.change(container, (obj) => {
-        obj.objects!.push(Ref.make(Obj.make(TestSchema.Task, {})));
-        obj.objects!.push(Ref.make(Obj.make(TestSchema.Person, {})));
+      Obj.change(container, (container) => {
+        container.objects!.push(Ref.make(Obj.make(TestSchema.Task, {})));
+        container.objects!.push(Ref.make(Obj.make(TestSchema.Person, {})));
       });
     }
 
@@ -317,8 +317,8 @@ describe('Database', () => {
   test('object fields', async () => {
     const task = Obj.make(TestSchema.Task, {});
 
-    Obj.change(task, (obj) => {
-      obj.title = 'test';
+    Obj.change(task, (task) => {
+      task.title = 'test';
     });
     expect(task.title).to.eq('test');
     expect(Obj.getMeta(task).keys).to.have.length(0);
@@ -399,8 +399,8 @@ describe('Database', () => {
     expect(Obj.versionValid(version2)).to.be.true;
     expect(Obj.compareVersions(version1, version2)).to.eq('equal');
 
-    Obj.change(task, (obj) => {
-      obj.title = 'Main task 2';
+    Obj.change(task, (task) => {
+      task.title = 'Main task 2';
     });
     const version3 = Obj.version(task as any);
     expect(Obj.isVersion(version3)).to.be.true;
@@ -414,9 +414,9 @@ describe('Database', () => {
       const root = newTask();
       expect(root.subTasks).to.have.length(0);
 
-      Obj.change(root, (obj) => {
-        range(3).forEach(() => obj.subTasks!.push(Ref.make(newTask())));
-        obj.subTasks!.push(Ref.make(newTask()), Ref.make(newTask()));
+      Obj.change(root, (root) => {
+        range(3).forEach(() => root.subTasks!.push(Ref.make(newTask())));
+        root.subTasks!.push(Ref.make(newTask()), Ref.make(newTask()));
       });
 
       expect(root.subTasks).to.have.length(5);
@@ -428,8 +428,8 @@ describe('Database', () => {
       root.subTasks!.forEach((task: any, i: number) => expect(task.target!.id).to.eq(ids[i]));
       expect(Array.from(root.subTasks!.values())).to.have.length(5);
 
-      Obj.change(root, (obj) => {
-        obj.subTasks = [
+      Obj.change(root, (root) => {
+        root.subTasks = [
           Ref.make(Obj.make(TestSchema.Task, {})),
           Ref.make(Obj.make(TestSchema.Task, {})),
           Ref.make(Obj.make(TestSchema.Task, {})),
@@ -442,11 +442,11 @@ describe('Database', () => {
 
     test('splice', async () => {
       const root = newTask();
-      Obj.change(root, (obj) => {
-        obj.subTasks = range(3).map((_i) => Ref.make(newTask()));
+      Obj.change(root, (root) => {
+        root.subTasks = range(3).map((_i) => Ref.make(newTask()));
       });
-      Obj.change(root, (obj) => {
-        obj.subTasks!.splice(0, 2, Ref.make(newTask()));
+      Obj.change(root, (root) => {
+        root.subTasks!.splice(0, 2, Ref.make(newTask()));
       });
       expect(root.subTasks).to.have.length(2);
       await addToDatabase(root);
@@ -454,8 +454,8 @@ describe('Database', () => {
 
     test('array of plain objects', async () => {
       const root = Obj.make(TestSchema.Container, { records: [] });
-      Obj.change(root, (obj) => {
-        obj.records!.push({
+      Obj.change(root, (root) => {
+        root.records!.push({
           title: 'test',
           contacts: [Ref.make(Obj.make(TestSchema.Person, { name: 'tester' }))],
         });
@@ -471,20 +471,20 @@ describe('Database', () => {
     test('reset array', async () => {
       const { db, obj: root } = await addToDatabase(Obj.make(TestSchema.Container, { records: [] }));
 
-      Obj.change(root, (obj) => {
-        obj.records!.push({ title: 'one' });
+      Obj.change(root, (root) => {
+        root.records!.push({ title: 'one' });
       });
       expect(root.records).to.have.length(1);
 
-      Obj.change(root, (obj) => {
-        obj.records = [];
+      Obj.change(root, (root) => {
+        root.records = [];
       });
       expect(root.records).to.have.length(0);
       await db.flush();
       expect(root.records).to.have.length(0);
 
-      Obj.change(root, (obj) => {
-        obj.records!.push({ title: 'two' });
+      Obj.change(root, (root) => {
+        root.records!.push({ title: 'two' });
       });
       expect(root.records).to.have.length(1);
       await db.flush();

--- a/packages/core/echo/echo-db/src/proxy-db/mutable-schema.test.ts
+++ b/packages/core/echo/echo-db/src/proxy-db/mutable-schema.test.ts
@@ -95,8 +95,8 @@ describe('EchoSchema', () => {
       field: Schema.String,
     }).pipe(Type.object({ typename: 'com.example.type.test', version: '0.1.0' }));
     const [schema] = await db.schemaRegistry.register([GeneratedSchema]);
-    Obj.change(instanceWithSchemaRef, (obj) => {
-      obj.schemaArray!.push(Ref.make(schema));
+    Obj.change(instanceWithSchemaRef, (instanceWithSchemaRef) => {
+      instanceWithSchemaRef.schemaArray!.push(Ref.make(schema));
     });
     expect(instanceWithSchemaRef.schemaArray![0].target!.typename).to.eq(GeneratedSchema.typename);
   });
@@ -106,15 +106,15 @@ describe('EchoSchema', () => {
     const [schema] = await db.schemaRegistry.register([TestEmpty]);
     const object = Obj.make(schema, {});
     schema.addFields({ field1: Schema.String });
-    Obj.change(object, (obj) => {
-      obj.field1 = 'works';
+    Obj.change(object, (object) => {
+      object.field1 = 'works';
     });
-    Obj.change(object, (obj) => {
-      obj.field1 = undefined;
+    Obj.change(object, (object) => {
+      object.field1 = undefined;
     });
     expect(() => {
-      Obj.change(object, (obj) => {
-        obj.field1 = 42;
+      Obj.change(object, (object) => {
+        object.field1 = 42;
       });
     }).to.throw();
 

--- a/packages/core/echo/echo-db/src/query/query.test.ts
+++ b/packages/core/echo/echo-db/src/query/query.test.ts
@@ -408,8 +408,8 @@ describe('Query', () => {
       }
       const cutoff = secondAfterFlush * 1000;
 
-      Obj.change(obj, (o: any) => {
-        o.value = 999;
+      Obj.change(obj, (obj: any) => {
+        obj.value = 999;
       });
       await db.flush();
 
@@ -2253,8 +2253,8 @@ describe('Query', () => {
       });
       onTestFinished(() => unsub());
 
-      Obj.change(contact, (obj) => {
-        obj.name = name;
+      Obj.change(contact, (contact) => {
+        contact.name = name;
       });
       db.add(Obj.make(TestSchema.Person, {}));
 

--- a/packages/core/echo/echo-db/src/testing/Obj.updateFrom.test.ts
+++ b/packages/core/echo/echo-db/src/testing/Obj.updateFrom.test.ts
@@ -31,12 +31,12 @@ describe('Obj.updateFrom (database)', () => {
     const stored = db.add(Obj.make(TestSchema.Expando, { label: 'v1', note: 'keep' }));
     const registryCopy = Obj.clone(Obj.make(TestSchema.Expando, { label: 'v1', note: 'keep' }), { deep: true });
 
-    Obj.change(stored, (mutable) => {
-      mutable.label = 'drifted';
+    Obj.change(stored, (stored) => {
+      stored.label = 'drifted';
     });
 
-    Obj.change(stored, (mutable) => {
-      expect(Obj.updateFrom(mutable, registryCopy)).toBe(true);
+    Obj.change(stored, (stored) => {
+      expect(Obj.updateFrom(stored, registryCopy)).toBe(true);
     });
 
     expect(stored.label).toBe('v1');

--- a/packages/core/echo/echo-react/src/useObject.ts
+++ b/packages/core/echo/echo-react/src/useObject.ts
@@ -123,20 +123,20 @@ export const useObject: {
       if (obj === undefined) {
         return;
       }
-      Obj.change(obj, (o: any) => {
+      Obj.change(obj, (obj: any) => {
         if (typeof updateOrValue === 'function') {
-          const returnValue = updateOrValue(property !== undefined ? o[property] : o);
+          const returnValue = updateOrValue(property !== undefined ? obj[property] : obj);
           if (returnValue !== undefined) {
             if (property === undefined) {
               throw new Error('Cannot re-assign the entire object');
             }
-            o[property] = returnValue;
+            obj[property] = returnValue;
           }
         } else {
           if (property === undefined) {
             throw new Error('Cannot re-assign the entire object');
           }
-          o[property] = updateOrValue;
+          obj[property] = updateOrValue;
         }
       });
     },

--- a/packages/core/echo/echo-solid/src/useObject.ts
+++ b/packages/core/echo/echo-solid/src/useObject.ts
@@ -160,20 +160,20 @@ export function useObject<T extends Obj.Unknown, K extends keyof T>(
       return;
     }
 
-    Obj.change(obj, (o: any) => {
+    Obj.change(obj, (obj: any) => {
       if (typeof updateOrValue === 'function') {
-        const returnValue = (updateOrValue as (obj: unknown) => unknown)(property !== undefined ? o[property] : o);
+        const returnValue = (updateOrValue as (obj: unknown) => unknown)(property !== undefined ? obj[property] : obj);
         if (returnValue !== undefined) {
           if (property === undefined) {
             throw new Error('Cannot re-assign the entire object');
           }
-          o[property] = returnValue;
+          obj[property] = returnValue;
         }
       } else {
         if (property === undefined) {
           throw new Error('Cannot re-assign the entire object');
         }
-        o[property] = updateOrValue;
+        obj[property] = updateOrValue;
       }
     });
   };

--- a/packages/core/echo/echo/src/Obj.test.ts
+++ b/packages/core/echo/echo/src/Obj.test.ts
@@ -166,8 +166,8 @@ describe('Obj', () => {
 
       const cloned = Obj.clone(original);
 
-      Obj.change(original, (obj) => {
-        obj.name = 'Bob';
+      Obj.change(original, (original) => {
+        original.name = 'Bob';
       });
 
       expect(original.name).toBe('Bob');
@@ -206,8 +206,8 @@ describe('Obj', () => {
       expect(cloned.employer?.target).toBe(person.employer?.target);
 
       // Modifying the referenced object affects both
-      Obj.change(employer, (org) => {
-        org.name = 'Updated DXOS';
+      Obj.change(employer, (employer) => {
+        employer.name = 'Updated DXOS';
       });
 
       expect(cloned.employer?.target?.name).toBe('Updated DXOS');
@@ -234,8 +234,8 @@ describe('Obj', () => {
       expect(cloned.employer?.target?.name).toBe(employer.name);
 
       // Modifying the original referenced object does not affect the clone
-      Obj.change(employer, (org) => {
-        org.name = 'Updated DXOS';
+      Obj.change(employer, (employer) => {
+        employer.name = 'Updated DXOS';
       });
 
       expect(cloned.employer?.target?.name).toBe('DXOS');
@@ -333,8 +333,8 @@ describe('Obj', () => {
       expect(cloned.address?.coordinates.lng).toBe(-122.4194);
 
       // Modifying nested properties should be independent
-      Obj.change(person, (obj) => {
-        obj.address!.city = 'New York';
+      Obj.change(person, (person) => {
+        person.address!.city = 'New York';
       });
 
       expect(cloned.address?.city).toBe('San Francisco');
@@ -366,8 +366,8 @@ describe('Obj', () => {
       expect(cloned.tasks?.[2]?.target).not.toBe(task3);
 
       // Modifying original tasks should not affect cloned ones
-      Obj.change(task1, (obj) => {
-        obj.title = 'Updated Task 1';
+      Obj.change(task1, (task1) => {
+        task1.title = 'Updated Task 1';
       });
 
       expect(cloned.tasks?.[0]?.target?.title).toBe('Task 1');
@@ -449,8 +449,8 @@ describe('Obj', () => {
     test('returns false when values already match', () => {
       const target = Obj.make(TestSchema.Organization, { name: 'Acme', properties: { region: 'EU' } });
       const source = Obj.make(TestSchema.Organization, { name: 'Acme', properties: { region: 'EU' } });
-      Obj.change(target, (mutable) => {
-        expect(Obj.updateFrom(mutable, source)).toBe(false);
+      Obj.change(target, (target) => {
+        expect(Obj.updateFrom(target, source)).toBe(false);
       });
     });
 
@@ -463,8 +463,8 @@ describe('Obj', () => {
         name: 'New',
         properties: { a: '2', b: '3' },
       });
-      Obj.change(target, (mutable) => {
-        expect(Obj.updateFrom(mutable, source)).toBe(true);
+      Obj.change(target, (target) => {
+        expect(Obj.updateFrom(target, source)).toBe(true);
       });
       expect(target.name).toBe('New');
       expect(target.properties).toEqual({ a: '2', b: '3' });
@@ -487,8 +487,8 @@ describe('Obj', () => {
         employer: Ref.make(orgB),
         address: { city: 'Portland', state: 'OR', zip: '97201', coordinates: { lat: 45.5, lng: -122.6 } },
       });
-      Obj.change(target, (mutable) => {
-        expect(Obj.updateFrom(mutable, source)).toBe(true);
+      Obj.change(target, (target) => {
+        expect(Obj.updateFrom(target, source)).toBe(true);
       });
       expect(target.employer?.dxn.toString()).toBe(Ref.make(orgB).dxn.toString());
       expect(target.address?.city).toBe('Portland');
@@ -510,8 +510,8 @@ describe('Obj', () => {
         email: 'bob@x.test',
         tasks: [Ref.make(t1), Ref.make(t3)],
       });
-      Obj.change(target, (mutable) => {
-        expect(Obj.updateFrom(mutable, source)).toBe(true);
+      Obj.change(target, (target) => {
+        expect(Obj.updateFrom(target, source)).toBe(true);
       });
       expect(target.tasks?.map((r) => r.dxn.toString())).toEqual(source.tasks?.map((r) => r.dxn.toString()));
     });
@@ -519,8 +519,8 @@ describe('Obj', () => {
     test('respects include option', () => {
       const target = Obj.make(TestSchema.Organization, { name: 'Keep', properties: { x: '1' } });
       const source = Obj.make(TestSchema.Organization, { name: 'Drop', properties: { x: '2' } });
-      Obj.change(target, (mutable) => {
-        expect(Obj.updateFrom(mutable, source, { include: ['properties'] })).toBe(true);
+      Obj.change(target, (target) => {
+        expect(Obj.updateFrom(target, source, { include: ['properties'] })).toBe(true);
       });
       expect(target.name).toBe('Keep');
       expect(target.properties).toEqual({ x: '2' });
@@ -529,8 +529,8 @@ describe('Obj', () => {
     test('respects exclude option', () => {
       const target = Obj.make(TestSchema.Organization, { name: 'Old', properties: { x: '1' } });
       const source = Obj.make(TestSchema.Organization, { name: 'New', properties: { x: '2' } });
-      Obj.change(target, (mutable) => {
-        expect(Obj.updateFrom(mutable, source, { exclude: ['name'] })).toBe(true);
+      Obj.change(target, (target) => {
+        expect(Obj.updateFrom(target, source, { exclude: ['name'] })).toBe(true);
       });
       expect(target.name).toBe('Old');
       expect(target.properties).toEqual({ x: '2' });

--- a/packages/core/echo/echo/src/internal/Obj/json-serializer.test.ts
+++ b/packages/core/echo/echo/src/internal/Obj/json-serializer.test.ts
@@ -20,8 +20,8 @@ import { objectFromJSON, objectToJSON } from './json-serializer';
 describe('Object JSON serializer', () => {
   test('should serialize and deserialize object', async () => {
     const contact = makeObject(TestSchema.Person, { name: 'Alice' });
-    Obj.change(contact, (obj) => {
-      getMetaChecked(obj).keys.push({ id: '12345', source: 'example.com' });
+    Obj.change(contact, (contact) => {
+      getMetaChecked(contact).keys.push({ id: '12345', source: 'example.com' });
     });
 
     const task = createObject(TestSchema.Task, {

--- a/packages/core/echo/echo/src/internal/Obj/set-value.test.ts
+++ b/packages/core/echo/echo/src/internal/Obj/set-value.test.ts
@@ -17,7 +17,7 @@ describe('Obj.setValue', () => {
       email: 'john@example.com',
     });
 
-    Obj.change(person, (obj) => Obj.setValue(obj, ['address', 'city'], 'NYC'));
+    Obj.change(person, (person) => Obj.setValue(person, ['address', 'city'], 'NYC'));
 
     expect(person.address).toBeDefined();
     expect(person.address?.city).toBe('NYC');
@@ -30,7 +30,7 @@ describe('Obj.setValue', () => {
       email: 'john@example.com',
     });
 
-    Obj.change(person, (obj) => Obj.setValue(obj, ['fields', 0, 'label'], 'Phone'));
+    Obj.change(person, (person) => Obj.setValue(person, ['fields', 0, 'label'], 'Phone'));
 
     expect(Array.isArray(person.fields)).toBe(true);
     expect(person.fields?.[0].label).toBe('Phone');
@@ -45,7 +45,7 @@ describe('Obj.setValue', () => {
       email: 'john@example.com',
     });
 
-    Obj.change(person, (obj) => Obj.setValue(obj, ['address', 'coordinates', 'lat'], 40.7128));
+    Obj.change(person, (person) => Obj.setValue(person, ['address', 'coordinates', 'lat'], 40.7128));
 
     expect(person.address).toBeDefined();
     expect(person.address?.coordinates).toBeDefined();
@@ -69,10 +69,10 @@ describe('Obj.setValue', () => {
 
     const container = Obj.make(Container, { name: 'box' });
 
-    Obj.change(container, (obj) => {
-      Obj.setValue(obj, ['items', 0, 'value'], 10);
-      Obj.setValue(obj, ['items', 1, 'value'], 20);
-      Obj.setValue(obj, ['items', 2, 'value'], 30);
+    Obj.change(container, (container) => {
+      Obj.setValue(container, ['items', 0, 'value'], 10);
+      Obj.setValue(container, ['items', 1, 'value'], 20);
+      Obj.setValue(container, ['items', 2, 'value'], 30);
     });
 
     expect(container.items).toHaveLength(3);
@@ -88,7 +88,7 @@ describe('Obj.setValue', () => {
       email: 'john@example.com',
     });
 
-    Obj.change(person, (obj) => Obj.setValue(obj, ['age'], 25));
+    Obj.change(person, (person) => Obj.setValue(person, ['age'], 25));
 
     expect(person.age).toBe(25);
   });
@@ -100,7 +100,7 @@ describe('Obj.setValue', () => {
       email: 'john@example.com',
     });
 
-    Obj.change(person, (obj) => Obj.setValue(obj, ['address', 'city'], 'NYC'));
+    Obj.change(person, (person) => Obj.setValue(person, ['address', 'city'], 'NYC'));
 
     expect(person.address).toBeDefined();
     expect(person.address?.city).toBe('NYC');
@@ -114,8 +114,8 @@ describe('Obj.setValue', () => {
     });
 
     let result: any;
-    Obj.change(person, (obj) => {
-      result = Obj.setValue(obj, ['age'], 30);
+    Obj.change(person, (person) => {
+      result = Obj.setValue(person, ['age'], 30);
     });
 
     expect(result).toBe(30);
@@ -129,7 +129,7 @@ describe('Obj.setValue', () => {
       age: 25,
     });
 
-    Obj.change(person, (obj) => Obj.setValue(obj, ['age'], 30));
+    Obj.change(person, (person) => Obj.setValue(person, ['age'], 30));
 
     expect(person.age).toBe(30);
   });
@@ -142,7 +142,7 @@ describe('Obj.setValue', () => {
       address: { city: 'Boston', state: 'MA', coordinates: {} },
     });
 
-    Obj.change(person, (obj) => Obj.setValue(obj, ['address', 'city'], 'NYC'));
+    Obj.change(person, (person) => Obj.setValue(person, ['address', 'city'], 'NYC'));
 
     expect(person.address?.city).toBe('NYC');
     expect(person.address?.state).toBe('MA');
@@ -160,11 +160,11 @@ describe('Obj.setValue', () => {
 
     const matrix = Obj.make(Matrix, {});
 
-    Obj.change(matrix, (obj) => {
-      Obj.setValue(obj, ['values', 0, 0], 1);
-      Obj.setValue(obj, ['values', 0, 1], 2);
-      Obj.setValue(obj, ['values', 1, 0], 3);
-      Obj.setValue(obj, ['values', 1, 1], 4);
+    Obj.change(matrix, (matrix) => {
+      Obj.setValue(matrix, ['values', 0, 0], 1);
+      Obj.setValue(matrix, ['values', 0, 1], 2);
+      Obj.setValue(matrix, ['values', 1, 0], 3);
+      Obj.setValue(matrix, ['values', 1, 1], 4);
     });
 
     expect(matrix.values?.[0][0]).toBe(1);
@@ -180,8 +180,8 @@ describe('Obj.setValue', () => {
       email: 'john@example.com',
     });
 
-    Obj.change(person, (obj) => {
-      expect(() => Obj.setValue(obj, [], 'value')).toThrow('Path must not be empty');
+    Obj.change(person, (person) => {
+      expect(() => Obj.setValue(person, [], 'value')).toThrow('Path must not be empty');
     });
   });
 
@@ -192,7 +192,7 @@ describe('Obj.setValue', () => {
       email: 'john@example.com',
     });
 
-    Obj.change(person, (obj) => Obj.setValue(obj, ['age'], 30));
+    Obj.change(person, (person) => Obj.setValue(person, ['age'], 30));
 
     expect(person.age).toBe(30);
   });
@@ -215,7 +215,7 @@ describe('Obj.setValue', () => {
     const container = Obj.make(Container, { name: 'box' });
 
     // Using string '0' for array index.
-    Obj.change(container, (obj) => Obj.setValue(obj, ['items', '0', 'value'], 42));
+    Obj.change(container, (container) => Obj.setValue(container, ['items', '0', 'value'], 42));
 
     expect(container.items?.[0].value).toBe(42);
   });
@@ -243,7 +243,7 @@ describe('Obj.setValue', () => {
 
     // This should work: setting a nested property on an array element.
     // The required 'id' field should be initialized with a default value.
-    Obj.change(todoList, (obj) => Obj.setValue(obj, ['tasks', 0, 'title'], 'Buy groceries'));
+    Obj.change(todoList, (todoList) => Obj.setValue(todoList, ['tasks', 0, 'title'], 'Buy groceries'));
 
     expect(todoList.tasks?.[0].id).toBe(''); // Default value for required String
     expect(todoList.tasks?.[0].title).toBe('Buy groceries');
@@ -270,7 +270,7 @@ describe('Obj.setValue', () => {
 
     const container = Obj.make(Container, { name: 'box' });
 
-    Obj.change(container, (obj) => Obj.setValue(obj, ['items', 0, 'label'], 'First Item'));
+    Obj.change(container, (container) => Obj.setValue(container, ['items', 0, 'label'], 'First Item'));
 
     // All required primitive fields should have default values.
     expect(container.items?.[0].id).toBe('');

--- a/packages/core/echo/echo/src/internal/common/proxy/change.test.ts
+++ b/packages/core/echo/echo/src/internal/common/proxy/change.test.ts
@@ -59,8 +59,8 @@ describe('Obj.change enforcement', () => {
     test('getMeta returns mutable ObjectMeta inside change callback', ({ expect }) => {
       const obj = Obj.make(TestSchema.Person, { name: 'Test' });
 
-      Obj.change(obj, (mutableObj) => {
-        const meta = Obj.getMeta(mutableObj);
+      Obj.change(obj, (obj) => {
+        const meta = Obj.getMeta(obj);
 
         // These should compile without errors because meta is ObjectMeta (mutable).
         meta.keys = [];
@@ -76,9 +76,9 @@ describe('Obj.change enforcement', () => {
       const obj = Obj.make(TestSchema.Person, { name: 'Test' });
 
       // These should compile without errors inside change callback.
-      Obj.change(obj, (mutableObj) => {
-        Obj.addTag(mutableObj, 'my-tag');
-        Obj.setValue(mutableObj, ['name'], 'Updated');
+      Obj.change(obj, (obj) => {
+        Obj.addTag(obj, 'my-tag');
+        Obj.setValue(obj, ['name'], 'Updated');
       });
 
       expect(obj.name).toBe('Updated');
@@ -310,8 +310,8 @@ describe('Obj.change enforcement', () => {
         obj.name = 'Jane';
 
         // Nested change should work (already in change context).
-        Obj.change(obj, (p2) => {
-          p2.age = 30;
+        Obj.change(obj, (obj) => {
+          obj.age = 30;
         });
       });
 
@@ -455,8 +455,8 @@ describe('Obj.change enforcement', () => {
         [Relation.Target]: target,
       });
 
-      Relation.change(rel, (obj) => {
-        const meta = Relation.getMeta(obj);
+      Relation.change(rel, (rel) => {
+        const meta = Relation.getMeta(rel);
         meta.tags = ['rel-tag'];
         meta.keys.push({ source: 'rel-source', id: 'rel-key' });
       });
@@ -473,14 +473,14 @@ describe('Obj.change enforcement', () => {
         [Relation.Target]: target,
       });
 
-      Relation.change(rel, (obj) => {
-        Relation.addTag(obj, 'important');
+      Relation.change(rel, (rel) => {
+        Relation.addTag(rel, 'important');
       });
 
       expect(Relation.getMeta(rel).tags).toContain('important');
 
-      Relation.change(rel, (obj) => {
-        Relation.removeTag(obj, 'important');
+      Relation.change(rel, (rel) => {
+        Relation.removeTag(rel, 'important');
       });
 
       expect(Relation.getMeta(rel).tags).not.toContain('important');

--- a/packages/core/functions-runtime/src/triggers/trigger-dispatcher.test.ts
+++ b/packages/core/functions-runtime/src/triggers/trigger-dispatcher.test.ts
@@ -567,8 +567,8 @@ describe('TriggerDispatcher', () => {
         expect(results.length).toBe(1);
 
         // Update the person object
-        Obj.change(person, (obj) => {
-          obj.fullName = 'Robert Jones';
+        Obj.change(person, (person) => {
+          person.fullName = 'Robert Jones';
         });
         yield* Database.flush({ indexes: true });
 
@@ -617,8 +617,8 @@ describe('TriggerDispatcher', () => {
         expect(results.length).toBe(0);
 
         // Update the object
-        Obj.change(person, (obj) => {
-          obj.fullName = 'Charles Brown';
+        Obj.change(person, (person) => {
+          person.fullName = 'Charles Brown';
         });
         yield* Database.flush({ indexes: true });
 

--- a/packages/core/functions-testing/src/cpu-limit.test.ts
+++ b/packages/core/functions-testing/src/cpu-limit.test.ts
@@ -88,8 +88,8 @@ describe.runIf(process.env.DX_TEST_TAGS?.includes('functions-e2e'))('CPU limit',
     }
 
     {
-      Obj.change(trigger, (obj) => {
-        obj.input!.iterations = 100;
+      Obj.change(trigger, (trigger) => {
+        trigger.input!.iterations = 100;
       });
       await sync(space);
       const result = await functionsServiceClient.forceRunCronTrigger(Context.default(), space.id, trigger.id);
@@ -136,14 +136,14 @@ describe.runIf(process.env.DX_TEST_TAGS?.includes('functions-e2e'))('CPU limit',
     await sync(space);
     await observeInvocations(space, 5);
 
-    Obj.change(trigger, (obj) => {
-      obj.input!.iterations = 1_000_000_000;
+    Obj.change(trigger, (trigger) => {
+      trigger.input!.iterations = 1_000_000_000;
     });
     await sync(space);
     await observeInvocations(space, 10);
 
-    Obj.change(trigger, (obj) => {
-      obj.input!.iterations = 100;
+    Obj.change(trigger, (trigger) => {
+      trigger.input!.iterations = 100;
     });
     await sync(space);
     await observeInvocations(space, 1_000);

--- a/packages/devtools/cli/src/commands/debug/generate.ts
+++ b/packages/devtools/cli/src/commands/debug/generate.ts
@@ -96,8 +96,8 @@ export const handler = Effect.fn(function* ({
   if (queriedObjects.length > 0) {
     for (let i = 0; i < mutations; i++) {
       const object = random.helpers.arrayElement(queriedObjects);
-      Obj.change(object, (obj) => {
-        obj.title = random.lorem.word();
+      Obj.change(object, (object) => {
+        object.title = random.lorem.word();
       });
       yield* Database.flush();
       yield* pause(interval, jitter);

--- a/packages/devtools/cli/src/commands/function/deploy/echo.ts
+++ b/packages/devtools/cli/src/commands/function/deploy/echo.ts
@@ -76,15 +76,17 @@ export const upsertFunctionObject: (opts: {
     });
     space.db.add(functionObject);
   }
-  Obj.change(functionObject, (obj) => {
-    obj.key = uploadResult.meta.key ?? obj.key;
-    obj.name = name ?? uploadResult.meta.name ?? obj.name;
-    obj.version = uploadResult.version;
-    obj.description = uploadResult.meta.description;
-    obj.inputSchema = uploadResult.meta.inputSchema;
-    obj.outputSchema = uploadResult.meta.outputSchema;
+  Obj.change(functionObject, (functionObject) => {
+    functionObject.key = uploadResult.meta.key ?? functionObject.key;
+    functionObject.name = name ?? uploadResult.meta.name ?? functionObject.name;
+    functionObject.version = uploadResult.version;
+    functionObject.description = uploadResult.meta.description;
+    functionObject.inputSchema = uploadResult.meta.inputSchema;
+    functionObject.outputSchema = uploadResult.meta.outputSchema;
   });
-  Obj.change(functionObject, (fn) => setUserFunctionIdInMetadata(Obj.getMeta(fn), uploadResult.functionId));
+  Obj.change(functionObject, (functionObject) =>
+    setUserFunctionIdInMetadata(Obj.getMeta(functionObject), uploadResult.functionId),
+  );
   if (verbose) {
     yield* Console.log('Upserted function object', functionObject.id);
   }
@@ -96,8 +98,8 @@ const makeObjectNavigableInComposer = Effect.fn(function* (space: Space, obj: Ob
   if (collectionRef) {
     const collection = yield* Database.load(collectionRef);
     if (collection) {
-      Obj.change(collection, (obj) => {
-        obj.objects.push(Ref.make(obj));
+      Obj.change(collection, (collection) => {
+        collection.objects.push(Ref.make(collection));
       });
     }
   }
@@ -124,16 +126,16 @@ export const upsertComposerScript = Effect.fn(function* ({
       () => functionObject.source!.load() as Promise<Script.Script>,
     )) as Script.Script;
     const source = (yield* Effect.tryPromise(() => script.source!.load())) as Text.Text;
-    Obj.change(source, (s: Obj.Mutable<Text.Text>) => {
-      s.content = scriptFileContent;
+    Obj.change(source, (source: Obj.Mutable<Text.Text>) => {
+      source.content = scriptFileContent;
     });
     if (verbose) {
       yield* Console.log('Updated composer script', script.id);
     }
   } else {
     const obj = yield* Database.add(Script.make({ name: scriptFileName, source: scriptFileContent }));
-    Obj.change(functionObject, (obj) => {
-      obj.source = Ref.make(obj);
+    Obj.change(functionObject, (functionObject) => {
+      functionObject.source = Ref.make(functionObject);
     });
     yield* makeObjectNavigableInComposer(space, obj);
     if (verbose) {

--- a/packages/e2e/proto-guard/src/generate-snapshot.ts
+++ b/packages/e2e/proto-guard/src/generate-snapshot.ts
@@ -54,8 +54,8 @@ const seedData = async (client: Client) => {
         name: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
       }),
     );
-    Obj.change(expando, (obj) => {
-      obj.value.push(Ref.make(todo));
+    Obj.change(expando, (expando) => {
+      expando.value.push(Ref.make(todo));
     });
     await space.db.flush();
   }
@@ -78,9 +78,9 @@ const seedData = async (client: Client) => {
     const object2 = space.db.add(Obj.make(dynamicSchema, { testField: 'Test' }));
 
     dynamicSchema.addFields({ name: Schema.String, todo: Ref.Ref(Todo) });
-    Obj.change(object2, (object) => {
-      object.name = 'Test';
-      object.todo = Ref.make(Obj.make(Todo, { name: 'Test todo' }));
+    Obj.change(object2, (object2) => {
+      object2.name = 'Test';
+      object2.todo = Ref.make(Obj.make(Todo, { name: 'Test todo' }));
     });
     await space.db.flush();
   }

--- a/packages/plugins/plugin-assistant/src/components/TemplateEditor/TemplateForm.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/components/TemplateEditor/TemplateForm.stories.tsx
@@ -42,7 +42,7 @@ const DefaultStory = () => {
 
   const handleChange: TemplateChangeCallback = useCallback(
     (mutate) => {
-      Obj.change(blueprint, (obj) => mutate(obj.instructions));
+      Obj.change(blueprint, (blueprint) => mutate(blueprint.instructions));
     },
     [blueprint],
   );

--- a/packages/plugins/plugin-automation/src/capabilities/compute-runtime.ts
+++ b/packages/plugins/plugin-automation/src/capabilities/compute-runtime.ts
@@ -234,8 +234,8 @@ const TracingServiceLive = Layer.unwrapEffect(
     // TODO(burdon): Check ref target has loaded?
     if (!properties.invocationTraceQueue || !properties.invocationTraceQueue.target) {
       const queue = yield* QueueService.createQueue({ subspaceTag: 'trace' });
-      Obj.change(properties, (obj) => {
-        obj.invocationTraceQueue = Ref.fromDXN(queue.dxn);
+      Obj.change(properties, (properties) => {
+        properties.invocationTraceQueue = Ref.fromDXN(queue.dxn);
       });
     }
 

--- a/packages/plugins/plugin-automation/src/cli/commands/trigger/update/queue.ts
+++ b/packages/plugins/plugin-automation/src/cli/commands/trigger/update/queue.ts
@@ -92,8 +92,8 @@ const updateFunction = Effect.fn(function* (trigger: Trigger.Trigger, functionId
     if (!foundFn || !Obj.instanceOf(Operation.PersistentOperation, foundFn)) {
       return yield* Effect.fail(new Error(`Function not found: ${functionId}`));
     }
-    Obj.change(trigger, (mutableTrigger) => {
-      mutableTrigger.function = Ref.make(foundFn);
+    Obj.change(trigger, (trigger) => {
+      trigger.function = Ref.make(foundFn);
     });
     currentFn = foundFn;
   }
@@ -130,9 +130,9 @@ const updateQueue = Effect.fn(function* (trigger: Trigger.Trigger, queueOption: 
       onNone: () => selectQueue(),
       onSome: (dxn) => Effect.succeed(dxn.toString()),
     });
-    Obj.change(trigger, (mutableTrigger) => {
-      if (mutableTrigger.spec?.kind === 'queue') {
-        mutableTrigger.spec.queue = queueDxn;
+    Obj.change(trigger, (trigger) => {
+      if (trigger.spec?.kind === 'queue') {
+        trigger.spec.queue = queueDxn;
       }
     });
   }
@@ -166,8 +166,8 @@ const updateInput = Effect.fn(function* (
         promptForSchemaInput(fn.inputSchema ? JsonSchema.toEffectSchema(fn.inputSchema) : undefined, currentInput),
       onSome: (value) => Effect.succeed(value as Record<string, any>),
     });
-    Obj.change(trigger, (mutableTrigger) => {
-      mutableTrigger.input = inputObj;
+    Obj.change(trigger, (trigger) => {
+      trigger.input = inputObj;
     });
   }
 });
@@ -189,7 +189,7 @@ const updateEnabled = Effect.fn(function* (
       }).pipe(Prompt.run),
     onSome: () => Effect.succeed(enabled),
   });
-  Obj.change(trigger, (mutableTrigger) => {
-    mutableTrigger.enabled = enabledValue;
+  Obj.change(trigger, (trigger) => {
+    trigger.enabled = enabledValue;
   });
 });

--- a/packages/plugins/plugin-automation/src/cli/commands/trigger/update/subscription.ts
+++ b/packages/plugins/plugin-automation/src/cli/commands/trigger/update/subscription.ts
@@ -121,8 +121,8 @@ const updateFunction = Effect.fn(function* (trigger: Trigger.Trigger, functionId
     if (!foundFn || !Obj.instanceOf(Operation.PersistentOperation, foundFn)) {
       return yield* Effect.fail(new Error(`Function not found: ${functionId}`));
     }
-    Obj.change(trigger, (mutableTrigger) => {
-      mutableTrigger.function = Ref.make(foundFn);
+    Obj.change(trigger, (trigger) => {
+      trigger.function = Ref.make(foundFn);
     });
     currentFn = foundFn;
   }
@@ -211,8 +211,8 @@ const updateSpec = Effect.fn(function* (
       subscriptionOptions.delay = delayOptionValue.value;
     }
 
-    Obj.change(trigger, (mutableTrigger) => {
-      const spec = mutableTrigger.spec;
+    Obj.change(trigger, (trigger) => {
+      const spec = trigger.spec;
       if (spec?.kind === 'subscription') {
         // Cast needed because QueryAST types are deeply readonly but spec.query expects mutable.
         spec.query = { ast: queryAst } as NonNullable<typeof spec.query>;
@@ -250,8 +250,8 @@ const updateInput = Effect.fn(function* (
         promptForSchemaInput(fn.inputSchema ? JsonSchema.toEffectSchema(fn.inputSchema) : undefined, currentInput),
       onSome: (value) => Effect.succeed(value as Record<string, any>),
     });
-    Obj.change(trigger, (mutableTrigger) => {
-      mutableTrigger.input = inputObj;
+    Obj.change(trigger, (trigger) => {
+      trigger.input = inputObj;
     });
   }
 });
@@ -273,7 +273,7 @@ const updateEnabled = Effect.fn(function* (
       }).pipe(Prompt.run),
     onSome: () => Effect.succeed(enabled),
   });
-  Obj.change(trigger, (mutableTrigger) => {
-    mutableTrigger.enabled = enabledValue;
+  Obj.change(trigger, (trigger) => {
+    trigger.enabled = enabledValue;
   });
 });

--- a/packages/plugins/plugin-automation/src/cli/commands/trigger/update/timer.ts
+++ b/packages/plugins/plugin-automation/src/cli/commands/trigger/update/timer.ts
@@ -93,8 +93,8 @@ const updateFunction = Effect.fn(function* (trigger: Trigger.Trigger, functionId
     if (!foundFn || !Obj.instanceOf(Operation.PersistentOperation, foundFn)) {
       return yield* Effect.fail(new Error(`Function not found: ${functionId}`));
     }
-    Obj.change(trigger, (mutableTrigger) => {
-      mutableTrigger.function = Ref.make(foundFn);
+    Obj.change(trigger, (trigger) => {
+      trigger.function = Ref.make(foundFn);
     });
     currentFn = foundFn;
   }
@@ -129,9 +129,9 @@ const updateCron = Effect.fn(function* (trigger: Trigger.Trigger, cronOption: Op
         }).pipe(Prompt.run),
       onSome: (value) => Effect.succeed(value),
     });
-    Obj.change(trigger, (mutableTrigger) => {
-      if (mutableTrigger.spec?.kind === 'timer') {
-        mutableTrigger.spec.cron = cron;
+    Obj.change(trigger, (trigger) => {
+      if (trigger.spec?.kind === 'timer') {
+        trigger.spec.cron = cron;
       }
     });
   }
@@ -165,8 +165,8 @@ const updateInput = Effect.fn(function* (
         promptForSchemaInput(fn.inputSchema ? JsonSchema.toEffectSchema(fn.inputSchema) : undefined, currentInput),
       onSome: (value) => Effect.succeed(value as Record<string, any>),
     });
-    Obj.change(trigger, (mutableTrigger) => {
-      mutableTrigger.input = inputObj;
+    Obj.change(trigger, (trigger) => {
+      trigger.input = inputObj;
     });
   }
 });
@@ -188,7 +188,7 @@ const updateEnabled = Effect.fn(function* (
       }).pipe(Prompt.run),
     onSome: () => Effect.succeed(enabled),
   });
-  Obj.change(trigger, (mutableTrigger) => {
-    mutableTrigger.enabled = enabledValue;
+  Obj.change(trigger, (trigger) => {
+    trigger.enabled = enabledValue;
   });
 });

--- a/packages/plugins/plugin-automation/src/components/AutomationPanel/AutomationPanel.tsx
+++ b/packages/plugins/plugin-automation/src/components/AutomationPanel/AutomationPanel.tsx
@@ -77,8 +77,8 @@ export const AutomationPanel = ({ space, object, initialTrigger, onDone }: Autom
 
   const handleSave: TriggerEditorProps['onSave'] = (trigger) => {
     if (selected) {
-      Obj.change(selected, (mutable) => {
-        Object.assign(mutable, trigger);
+      Obj.change(selected, (selected) => {
+        Object.assign(selected, trigger);
       });
     } else {
       space.db.add(Trigger.make(trigger));
@@ -99,8 +99,8 @@ export const AutomationPanel = ({ space, object, initialTrigger, onDone }: Autom
   };
 
   const handleResetCursor = async (trigger: Trigger.Trigger) => {
-    Obj.change(trigger, (obj) => {
-      Obj.deleteKeys(obj, KEY_QUEUE_CURSOR);
+    Obj.change(trigger, (trigger) => {
+      Obj.deleteKeys(trigger, KEY_QUEUE_CURSOR);
     });
     await space.db.flush({ indexes: true });
   };

--- a/packages/plugins/plugin-automation/src/components/TriggerEditor/TriggerEditor.tsx
+++ b/packages/plugins/plugin-automation/src/components/TriggerEditor/TriggerEditor.tsx
@@ -41,8 +41,8 @@ export const TriggerEditor = ({ db, types, tags, readonlySpec, trigger, ...formP
 
   const handleValuesChanged = useCallback(
     (newValues: Partial<TriggerFormSchema>) => {
-      Obj.change(trigger, (obj) => {
-        Object.assign(obj, newValues);
+      Obj.change(trigger, (trigger) => {
+        Object.assign(trigger, newValues);
       });
     },
     [trigger],

--- a/packages/plugins/plugin-automation/src/operations/create-trigger-from-template.ts
+++ b/packages/plugins/plugin-automation/src/operations/create-trigger-from-template.ts
@@ -31,8 +31,8 @@ const handler: Operation.WithHandler<typeof CreateTriggerFromTemplate> = CreateT
           );
           const [fn] = functions;
           if (fn) {
-            Obj.change(trigger, (obj) => {
-              obj.function = Ref.make(fn);
+            Obj.change(trigger, (trigger) => {
+              trigger.function = Ref.make(fn);
             });
           }
         }
@@ -40,14 +40,14 @@ const handler: Operation.WithHandler<typeof CreateTriggerFromTemplate> = CreateT
 
       switch (template.type) {
         case 'timer': {
-          Obj.change(trigger, (obj) => {
-            obj.spec = { kind: 'timer', cron: template.cron };
+          Obj.change(trigger, (trigger) => {
+            trigger.spec = { kind: 'timer', cron: template.cron };
           });
           break;
         }
         case 'queue': {
-          Obj.change(trigger, (obj) => {
-            obj.spec = {
+          Obj.change(trigger, (trigger) => {
+            trigger.spec = {
               kind: 'queue',
               queue: (template.queueDXN as DXN).toString(),
             };

--- a/packages/plugins/plugin-board/src/containers/BoardContainer/BoardContainer.stories.tsx
+++ b/packages/plugins/plugin-board/src/containers/BoardContainer/BoardContainer.stories.tsx
@@ -86,13 +86,13 @@ const meta = {
               yield* Effect.promise(() => space.waitUntilReady());
               const board = space.db.add(createBoard());
 
-              Obj.change(board, (obj) => {
+              Obj.change(board, (board) => {
                 // Add some sample items
                 Array.from({ length: 10 }).map(() => {
                   const org = createOrg();
                   space.db.add(org);
-                  obj.items.push(Ref.make(org));
-                  obj.layout.cells[org.id] = {
+                  board.items.push(Ref.make(org));
+                  board.layout.cells[org.id] = {
                     x: Math.floor(Math.random() * 5) - 2,
                     y: Math.floor(Math.random() * 5) - 2,
                     width: 1,

--- a/packages/plugins/plugin-board/src/containers/BoardContainer/BoardContainer.tsx
+++ b/packages/plugins/plugin-board/src/containers/BoardContainer/BoardContainer.tsx
@@ -73,11 +73,11 @@ export const BoardContainer = ({ role, subject: board, attendableId }: BoardCont
     (id) => {
       // TODO(burdon): Impl. DXN.equals and pass in DXN from `id`.
       const idx = board.items.findIndex((ref) => ref.dxn.asEchoDXN()?.echoId === id);
-      Obj.change(board, (obj) => {
+      Obj.change(board, (board) => {
         if (idx !== -1) {
-          obj.items.splice(idx, 1);
+          board.items.splice(idx, 1);
         }
-        delete obj.layout.cells[id];
+        delete board.layout.cells[id];
       });
     },
     [board],
@@ -86,8 +86,8 @@ export const BoardContainer = ({ role, subject: board, attendableId }: BoardCont
   const handleMove = useCallback<NonNullable<BoardRootProps['onMove']>>(
     (id, position) => {
       const layout = board.layout.cells[id];
-      Obj.change(board, (obj) => {
-        obj.layout.cells[id] = { ...layout, ...position };
+      Obj.change(board, (board) => {
+        board.layout.cells[id] = { ...layout, ...position };
       });
     },
     [board],
@@ -106,11 +106,11 @@ export const BoardContainer = ({ role, subject: board, attendableId }: BoardCont
       }
 
       // Create a reference to the selected object and add it to the board.
-      Obj.change(board, (obj) => {
-        obj.items.push(Ref.make(selectedObject));
+      Obj.change(board, (board) => {
+        board.items.push(Ref.make(selectedObject));
 
         // Set the layout position for the new item.
-        obj.layout.cells[selectedObject.id.toString()] = pickerState.position;
+        board.layout.cells[selectedObject.id.toString()] = pickerState.position;
       });
 
       // Close the picker.

--- a/packages/plugins/plugin-chess/src/capabilities/artifact-definition.ts
+++ b/packages/plugins/plugin-chess/src/capabilities/artifact-definition.ts
@@ -121,8 +121,8 @@ export default Capability.makeModule(() =>
               return ToolResult.Error(error.message);
             }
 
-            Obj.change(game, (obj) => {
-              obj.pgn = chess.pgn();
+            Obj.change(game, (game) => {
+              game.pgn = chess.pgn();
             });
             return ToolResult.Success(game.pgn);
           },

--- a/packages/plugins/plugin-chess/src/operations/move.ts
+++ b/packages/plugins/plugin-chess/src/operations/move.ts
@@ -24,8 +24,8 @@ const handler: Operation.WithHandler<typeof Move> = Move.pipe(
 
       chess.move(move, { strict: false });
       const pgn = chess.pgn();
-      Obj.change(obj, (game) => {
-        const mutableGame = game as Obj.Mutable<typeof game>;
+      Obj.change(obj, (obj) => {
+        const mutableGame = obj as Obj.Mutable<typeof obj>;
         mutableGame.pgn = pgn;
       });
       return { pgn };

--- a/packages/plugins/plugin-chess/src/operations/play.ts
+++ b/packages/plugins/plugin-chess/src/operations/play.ts
@@ -33,8 +33,8 @@ const handler: Operation.WithHandler<typeof Play> = Play.pipe(
 
       chess.move(move, { strict: false });
       const pgn = chess.pgn();
-      Obj.change(object, (game) => {
-        const mutableGame = game as Obj.Mutable<typeof game>;
+      Obj.change(object, (object) => {
+        const mutableGame = object as Obj.Mutable<typeof object>;
         mutableGame.pgn = pgn;
       });
       return { move, pgn };

--- a/packages/plugins/plugin-daily-summary/src/blueprints/functions/generate.ts
+++ b/packages/plugins/plugin-daily-summary/src/blueprints/functions/generate.ts
@@ -158,14 +158,14 @@ const updateDocContent = Effect.fn(function* (doc: MarkdownDoc, newContent: stri
   if (Ref.isRef(textRef)) {
     const text: Text.Text | undefined = yield* Effect.promise(() => textRef.load());
     if (text) {
-      Obj.change(text, (mutable) => {
-        mutable.content = newContent;
+      Obj.change(text, (text) => {
+        text.content = newContent;
       });
       return;
     }
   }
-  Obj.change(doc, (mutable) => {
-    mutable.content = Ref.make(Text.make(newContent));
+  Obj.change(doc, (doc) => {
+    doc.content = Ref.make(Text.make(newContent));
   });
 });
 

--- a/packages/plugins/plugin-debug/src/components/SpaceGenerator/presets.ts
+++ b/packages/plugins/plugin-debug/src/components/SpaceGenerator/presets.ts
@@ -74,8 +74,8 @@ export const generator = () => ({
 
           const tag = space.db.add(Tag.make({ label: 'Investor' }));
           const tagDxn = Obj.getDXN(tag).toString();
-          Obj.change(doc, (obj) => {
-            Obj.getMeta(obj).tags = [tagDxn];
+          Obj.change(doc, (doc) => {
+            Obj.getMeta(doc).tags = [tagDxn];
           });
 
           // space.db.add(
@@ -763,8 +763,8 @@ const createQueueSinkPreset = <SpecType extends Trigger.Kind>(
     functionTrigger = triggerShape.functionTrigger!.target!;
     const triggerSpec = functionTrigger.spec;
     invariant(triggerSpec && triggerSpec.kind === triggerKind, 'No trigger spec.');
-    Obj.change(functionTrigger, (ft) => {
-      initSpec(ft.spec as any);
+    Obj.change(functionTrigger, (functionTrigger) => {
+      initSpec(functionTrigger.spec as any);
     });
   });
 
@@ -815,9 +815,9 @@ const setupQueue = (
 const attachTrigger = (functionTrigger: Trigger.Trigger | undefined, computeModel: ComputeGraphModel) => {
   invariant(functionTrigger);
   const inputNode = computeModel.nodes.find((node) => node.type === NODE_INPUT)!;
-  Obj.change(functionTrigger, (obj) => {
-    obj.function = Ref.make(computeModel.root);
-    obj.inputNodeId = inputNode.id;
+  Obj.change(functionTrigger, (functionTrigger) => {
+    functionTrigger.function = Ref.make(computeModel.root);
+    functionTrigger.inputNodeId = inputNode.id;
   });
 };
 

--- a/packages/plugins/plugin-exemplar/src/containers/ExemplarArticle.tsx
+++ b/packages/plugins/plugin-exemplar/src/containers/ExemplarArticle.tsx
@@ -38,15 +38,15 @@ export const ExemplarArticle = ({ role, subject, attendableId }: ExemplarArticle
   // ECHO objects are reactive proxies — changes replicate to other peers.
   const handleValuesChanged = useCallback(
     (values: Partial<{ name: string; description: string; status: 'active' | 'archived' | 'draft' }>) => {
-      Obj.change(subject, (draft) => {
+      Obj.change(subject, (subject) => {
         if (values.name !== undefined) {
-          draft.name = values.name;
+          subject.name = values.name;
         }
         if (values.description !== undefined) {
-          draft.description = values.description;
+          subject.description = values.description;
         }
         if (values.status !== undefined) {
-          draft.status = values.status;
+          subject.status = values.status;
         }
       });
     },

--- a/packages/plugins/plugin-exemplar/src/operations/randomize.ts
+++ b/packages/plugins/plugin-exemplar/src/operations/randomize.ts
@@ -18,10 +18,10 @@ const STATUSES: string[] = ['active', 'archived', 'draft'];
 const handler: Operation.WithHandler<typeof Randomize> = Randomize.pipe(
   Operation.withHandler(({ item }) =>
     Effect.sync(() => {
-      Obj.change(item, (draft) => {
-        draft.name = random.lorem.words({ min: 2, max: 5 });
-        draft.description = random.lorem.sentence();
-        draft.status = random.helpers.arrayElement(STATUSES);
+      Obj.change(item, (item) => {
+        item.name = random.lorem.words({ min: 2, max: 5 });
+        item.description = random.lorem.sentence();
+        item.status = random.helpers.arrayElement(STATUSES);
       });
     }),
   ),

--- a/packages/plugins/plugin-exemplar/src/operations/update-status.ts
+++ b/packages/plugins/plugin-exemplar/src/operations/update-status.ts
@@ -18,8 +18,8 @@ const handler: Operation.WithHandler<typeof UpdateStatus> = UpdateStatus.pipe(
     // `Effect.sync` wraps a synchronous side-effect. For async work, use `Effect.promise`.
     // `Obj.change` provides a mutable draft for safe property assignment on ECHO objects.
     Effect.sync(() => {
-      Obj.change(item, (draft) => {
-        draft.status = status;
+      Obj.change(item, (item) => {
+        item.status = status;
       });
     }),
   ),

--- a/packages/plugins/plugin-feed/src/operations/sync-feed.ts
+++ b/packages/plugins/plugin-feed/src/operations/sync-feed.ts
@@ -68,20 +68,20 @@ const handler: Operation.WithHandler<typeof SyncFeed> = SyncFeed.pipe(
         // Advance cursor to the newest post.
         const newestGuid = posts[0]?.guid;
         if (newestGuid) {
-          Obj.change(subscriptionFeed, (obj) => {
-            obj.cursor = newestGuid;
+          Obj.change(subscriptionFeed, (subscriptionFeed) => {
+            subscriptionFeed.cursor = newestGuid;
           });
         }
 
         // Update feed metadata from channel if not already set.
         if (feedMeta.name && !subscriptionFeed.name) {
-          Obj.change(subscriptionFeed, (obj) => {
-            obj.name = feedMeta.name;
+          Obj.change(subscriptionFeed, (subscriptionFeed) => {
+            subscriptionFeed.name = feedMeta.name;
           });
         }
         if (feedMeta.description && !subscriptionFeed.description) {
-          Obj.change(subscriptionFeed, (obj) => {
-            obj.description = feedMeta.description;
+          Obj.change(subscriptionFeed, (subscriptionFeed) => {
+            subscriptionFeed.description = feedMeta.description;
           });
         }
       }).pipe(

--- a/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/app-graph-builder.ts
@@ -133,8 +133,8 @@ export default Capability.makeModule(
                           data: () =>
                             Effect.sync(() => {
                               const index = mailbox.filters.findIndex((f: any) => f.name === name);
-                              Obj.change(mailbox, (mutable: any) => {
-                                mutable.filters.splice(index, 1);
+                              Obj.change(mailbox, (mailbox: any) => {
+                                mailbox.filters.splice(index, 1);
                               });
                             }),
                           properties: {

--- a/packages/plugins/plugin-inbox/src/components/ComposeEmailPanel/ComposeEmailPanel.tsx
+++ b/packages/plugins/plugin-inbox/src/components/ComposeEmailPanel/ComposeEmailPanel.tsx
@@ -41,8 +41,8 @@ export const ComposeEmailPanel = composable<HTMLDivElement, ComposeEmailPanelPro
 
     const handleValuesChanged = useCallback(
       (newValues: Partial<ComposeEmailForm>) => {
-        Obj.change(draft, (msg) => {
-          const properties = (msg.properties ??= {});
+        Obj.change(draft, (draft) => {
+          const properties = (draft.properties ??= {});
           if (newValues.to !== undefined) {
             properties.to = newValues.to;
           }
@@ -56,11 +56,11 @@ export const ComposeEmailPanel = composable<HTMLDivElement, ComposeEmailPanelPro
             properties.subject = newValues.subject;
           }
           if (newValues.body !== undefined) {
-            const textBlock = msg.blocks.find((b) => b._tag === 'text');
+            const textBlock = draft.blocks.find((b) => b._tag === 'text');
             if (textBlock && 'text' in textBlock) {
               textBlock.text = newValues.body;
             } else {
-              msg.blocks.push({ _tag: 'text', text: newValues.body });
+              draft.blocks.push({ _tag: 'text', text: newValues.body });
             }
           }
         });

--- a/packages/plugins/plugin-inbox/src/containers/EventArticle/EventArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/EventArticle/EventArticle.tsx
@@ -30,8 +30,8 @@ export const EventArticle = ({ role, subject, companionTo: calendar }: EventArti
     const event = createShadowEvent();
     const notes = await event.notes?.load();
     if (!notes) {
-      Obj.change(event, (obj) => {
-        obj.notes = Ref.make(Text.make());
+      Obj.change(event, (event) => {
+        event.notes = Ref.make(Text.make());
       });
     }
   }, [id, subject, db, shadowedEvent]);

--- a/packages/plugins/plugin-inbox/src/hooks/useShadowObject.ts
+++ b/packages/plugins/plugin-inbox/src/hooks/useShadowObject.ts
@@ -37,8 +37,8 @@ export const useShadowObject = <T extends Obj.Unknown>(
     }
 
     const newObject = db.add(Obj.clone(subject));
-    Obj.change(newObject, (obj) => {
-      Obj.getMeta(obj).keys.push({ source: 'echo', id }); // TODO(burdon): Factor out const?
+    Obj.change(newObject, (newObject) => {
+      Obj.getMeta(newObject).keys.push({ source: 'echo', id }); // TODO(burdon): Factor out const?
     });
     setTarget(newObject);
     return newObject;

--- a/packages/plugins/plugin-inbox/src/operations/extract-contact.ts
+++ b/packages/plugins/plugin-inbox/src/operations/extract-contact.ts
@@ -44,8 +44,8 @@ const handler: Operation.WithHandler<typeof ExtractContact> = ExtractContact.pip
         emails: [{ value: email }],
       });
       if (name) {
-        Obj.change(newContact, (contact) => {
-          contact.fullName = name;
+        Obj.change(newContact, (newContact) => {
+          newContact.fullName = name;
         });
       }
 
@@ -91,8 +91,8 @@ const handler: Operation.WithHandler<typeof ExtractContact> = ExtractContact.pip
         log.info('found matching organization', {
           organization: matchingOrg,
         });
-        Obj.change(newContact, (contact) => {
-          contact.organization = Ref.make(matchingOrg);
+        Obj.change(newContact, (newContact) => {
+          newContact.organization = Ref.make(matchingOrg);
         });
       }
 

--- a/packages/plugins/plugin-map/src/containers/MapViewEditor/MapViewEditor.tsx
+++ b/packages/plugins/plugin-map/src/containers/MapViewEditor/MapViewEditor.tsx
@@ -70,8 +70,8 @@ export const MapViewEditor = ({ object }: MapViewEditorProps) => {
   const onSave = useCallback(
     (values: Partial<{ coordinateColumn: string }>) => {
       if (view && values.coordinateColumn) {
-        Obj.change(view, (obj) => {
-          obj.projection.pivotFieldId = values.coordinateColumn;
+        Obj.change(view, (view) => {
+          view.projection.pivotFieldId = values.coordinateColumn;
         });
       }
     },

--- a/packages/plugins/plugin-markdown/src/util.tsx
+++ b/packages/plugins/plugin-markdown/src/util.tsx
@@ -116,8 +116,8 @@ export const getContentSnippet = (content = '', maxLines = 3) => {
 export const setFallbackName = debounce((doc: Markdown.Document, content = '') => {
   const name = getFallbackName(content);
   if (doc.fallbackName !== name) {
-    Obj.change(doc, (obj) => {
-      obj.fallbackName = name;
+    Obj.change(doc, (doc) => {
+      doc.fallbackName = name;
     });
   }
 }, 200);

--- a/packages/plugins/plugin-native-filesystem/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-native-filesystem/src/capabilities/app-graph-builder.ts
@@ -177,8 +177,8 @@ export default Capability.makeModule(
                     }),
                   );
 
-                  Obj.change(spacesOrder, (mutableOrder: Record<string, unknown>) => {
-                    mutableOrder.order = nextOrder.map((item) => {
+                  Obj.change(spacesOrder, (spacesOrder: Record<string, unknown>) => {
+                    spacesOrder.order = nextOrder.map((item) => {
                       if (isFilesystemWorkspace(item)) {
                         return item.id;
                       }

--- a/packages/plugins/plugin-native-filesystem/src/capabilities/state/markdown-documents.ts
+++ b/packages/plugins/plugin-native-filesystem/src/capabilities/state/markdown-documents.ts
@@ -159,8 +159,8 @@ export const createMarkdownDocuments = (
       const state = registry.get(stateAtom);
       const fileResult = findFileById(state.workspaces, fileId);
       if (fileResult && doc.name !== fileResult.file.name) {
-        Obj.change(doc, (mutable) => {
-          mutable.name = fileResult.file.name;
+        Obj.change(doc, (doc) => {
+          doc.name = fileResult.file.name;
         });
       }
 
@@ -270,8 +270,8 @@ export const createMarkdownDocuments = (
     const existing = documentsByFileId.get(file.id);
     if (existing) {
       if (existing.name !== file.name) {
-        Obj.change(existing, (doc) => {
-          doc.name = file.name;
+        Obj.change(existing, (existing) => {
+          existing.name = file.name;
         });
       }
       updateMapsForDocument(file.id, file.path, existing);
@@ -365,8 +365,8 @@ export const createMarkdownDocuments = (
         ensureFileWatcher(file);
 
         if (target.name !== file.name) {
-          Obj.change(target, (mutable) => {
-            mutable.name = file.name;
+          Obj.change(target, (target) => {
+            target.name = file.name;
           });
         }
 

--- a/packages/plugins/plugin-outliner/src/components/Journal/Journal.tsx
+++ b/packages/plugins/plugin-outliner/src/components/Journal/Journal.tsx
@@ -43,8 +43,8 @@ export const Journal = composable<HTMLDivElement, JournalProps>(({ journal, onSe
     }
 
     const entry = JournalType.makeEntry();
-    Obj.change(journal, (obj) => {
-      obj.entries[getDateString(date)] = Ref.make(entry);
+    Obj.change(journal, (journal) => {
+      journal.entries[getDateString(date)] = Ref.make(entry);
     });
   }, [journal, date]);
 

--- a/packages/plugins/plugin-outliner/src/types/Journal.ts
+++ b/packages/plugins/plugin-outliner/src/types/Journal.ts
@@ -106,8 +106,8 @@ export const getOrCreateEntry = async (
   }
 
   const entry = db.add(makeEntry(date)) as JournalEntry;
-  Obj.change(journal, (draft) => {
-    draft.entries[dateKey] = Ref.make(entry);
+  Obj.change(journal, (journal) => {
+    journal.entries[dateKey] = Ref.make(entry);
   });
   return entry;
 };

--- a/packages/plugins/plugin-pipeline/src/components/PipelineComponent/PipelineComponent.stories.tsx
+++ b/packages/plugins/plugin-pipeline/src/components/PipelineComponent/PipelineComponent.stories.tsx
@@ -64,10 +64,10 @@ const DefaultStory = () => {
       fields: ['fullName'],
     });
 
-    Obj.change(pipeline, (obj) => {
-      obj.columns.push({
+    Obj.change(pipeline, (pipeline) => {
+      pipeline.columns.push({
         name: 'New Contacts',
-        view: Ref.make(view) as (typeof obj.columns)[number]['view'],
+        view: Ref.make(view) as (typeof pipeline.columns)[number]['view'],
         order: [],
       });
     });
@@ -108,10 +108,10 @@ const MutationsStory = () => {
       fields: ['fullName'],
     });
 
-    Obj.change(pipeline, (obj) => {
-      obj.columns.push({
+    Obj.change(pipeline, (pipeline) => {
+      pipeline.columns.push({
         name: 'New Contacts',
-        view: Ref.make(view) as (typeof obj.columns)[number]['view'],
+        view: Ref.make(view) as (typeof pipeline.columns)[number]['view'],
         order: [],
       });
     });
@@ -131,8 +131,8 @@ const MutationsStory = () => {
       if (p < 0.4) {
         // Append to the name
         const contactToAdjust = random.helpers.arrayElement(contacts);
-        Obj.change(contactToAdjust, (obj) => {
-          obj.fullName = (obj.fullName ?? '') + ' X';
+        Obj.change(contactToAdjust, (contactToAdjust) => {
+          contactToAdjust.fullName = (contactToAdjust.fullName ?? '') + ' X';
         });
         return;
       } else if (p < 0.7 && contacts.length > 1) {

--- a/packages/plugins/plugin-pipeline/src/components/PipelineComponent/PipelineComponent.tsx
+++ b/packages/plugins/plugin-pipeline/src/components/PipelineComponent/PipelineComponent.tsx
@@ -97,7 +97,7 @@ const PipelineColumns = composable<HTMLDivElement, PipelineColumnsProps>(({ pipe
     get: (data) => data as unknown as Obj.Unknown,
     make: (object) => object as unknown as Pipeline.Column,
     canDrop: ({ source }) => model.isColumn(source.data),
-    onChange: (mutate) => Obj.change(pipeline, (obj) => mutate(obj.columns)),
+    onChange: (mutate) => Obj.change(pipeline, (pipeline) => mutate(pipeline.columns)),
   });
 
   return <Board.Content {...props} id='pipeline' eventHandler={eventHandler} Tile={PipelineColumn} />;

--- a/packages/plugins/plugin-script/src/blueprints/functions/deploy.ts
+++ b/packages/plugins/plugin-script/src/blueprints/functions/deploy.ts
@@ -54,8 +54,8 @@ export default Deploy.pipe(
 
       Operation.setFrom(loaded, newFunction);
 
-      Obj.change(script, (draft) => {
-        draft.changed = false;
+      Obj.change(script, (script) => {
+        script.changed = false;
       });
 
       const edgeFunctionId = getUserFunctionIdInMetadata(Obj.getMeta(loaded));

--- a/packages/plugins/plugin-script/src/blueprints/functions/update.ts
+++ b/packages/plugins/plugin-script/src/blueprints/functions/update.ts
@@ -22,12 +22,12 @@ export default Update.pipe(
       const script = (yield* Database.load(loaded.source)) as Script.Script;
 
       if (name !== undefined || description !== undefined) {
-        Obj.change(script, (draft) => {
+        Obj.change(script, (script) => {
           if (name !== undefined) {
-            draft.name = name;
+            script.name = name;
           }
           if (description !== undefined) {
-            draft.description = description;
+            script.description = description;
           }
         });
       }
@@ -56,8 +56,8 @@ export default Update.pipe(
           });
         }
 
-        Obj.change(script, (draft) => {
-          draft.changed = true;
+        Obj.change(script, (script) => {
+          script.changed = true;
         });
       }
 

--- a/packages/plugins/plugin-script/src/containers/NotebookContainer/NotebookContainer.tsx
+++ b/packages/plugins/plugin-script/src/containers/NotebookContainer/NotebookContainer.tsx
@@ -78,8 +78,8 @@ export const NotebookContainer = ({ role, subject: notebook, attendableId, env }
                 }
               });
             } else {
-              Obj.change(graph, (obj) => {
-                obj.query.ast = ast as Obj.Mutable<typeof ast>;
+              Obj.change(graph, (graph) => {
+                graph.query.ast = ast as Obj.Mutable<typeof ast>;
               });
             }
           }
@@ -137,10 +137,10 @@ export const NotebookContainer = ({ role, subject: notebook, attendableId, env }
       const from = notebook.cells.findIndex((cell) => cell.id === source.id);
       const to = notebook.cells.findIndex((cell) => cell.id === target.id);
       if (from != null && to != null) {
-        Obj.change(notebook, (obj) => {
-          const cell = obj.cells.splice(from, 1)[0];
+        Obj.change(notebook, (notebook) => {
+          const cell = notebook.cells.splice(from, 1)[0];
           if (cell) {
-            obj.cells.splice(to, 0, cell);
+            notebook.cells.splice(to, 0, cell);
           }
         });
       }
@@ -173,8 +173,8 @@ export const NotebookContainer = ({ role, subject: notebook, attendableId, env }
       }
 
       const idx = after ? notebook.cells.findIndex((cell) => cell.id === after) : notebook.cells.length;
-      Obj.change(notebook, (obj) => {
-        obj.cells.splice(idx, 0, cell);
+      Obj.change(notebook, (notebook) => {
+        notebook.cells.splice(idx, 0, cell);
       });
     },
     [db, notebook],
@@ -185,8 +185,8 @@ export const NotebookContainer = ({ role, subject: notebook, attendableId, env }
       invariant(notebook);
       const idx = notebook.cells.findIndex((cell) => cell.id === id);
       if (idx !== -1) {
-        Obj.change(notebook, (obj) => {
-          obj.cells.splice(idx, 1);
+        Obj.change(notebook, (notebook) => {
+          notebook.cells.splice(idx, 1);
         });
       }
     },

--- a/packages/plugins/plugin-script/src/containers/ScriptContainer/ScriptContainer.tsx
+++ b/packages/plugins/plugin-script/src/containers/ScriptContainer/ScriptContainer.tsx
@@ -51,8 +51,8 @@ export const ScriptContainer = ({
       listener({
         onChange: ({ text }) => {
           if (script.source.target?.content !== text) {
-            Obj.change(script, (obj) => {
-              obj.changed = true;
+            Obj.change(script, (script) => {
+              script.changed = true;
             });
           }
         },

--- a/packages/plugins/plugin-script/src/containers/ScriptObjectSettings/ScriptObjectSettings.tsx
+++ b/packages/plugins/plugin-script/src/containers/ScriptObjectSettings/ScriptObjectSettings.tsx
@@ -64,14 +64,14 @@ const BlueprintEditor = ({ object }: ScriptObjectSettingsProps) => {
     try {
       if (existingBlueprint) {
         const text = await existingBlueprint.instructions.source.load();
-        Obj.change(text, (obj) => {
-          obj.content = instructions;
+        Obj.change(text, (text) => {
+          text.content = instructions;
         });
         if (fn?.key) {
           const toolId = ToolId.make(fn.key);
           if (!existingBlueprint.tools?.includes(toolId)) {
-            Obj.change(existingBlueprint, (obj) => {
-              obj.tools = [...(obj.tools ?? []), toolId];
+            Obj.change(existingBlueprint, (existingBlueprint) => {
+              existingBlueprint.tools = [...(existingBlueprint.tools ?? []), toolId];
             });
           }
         }
@@ -151,8 +151,8 @@ const Binding = ({ object }: ScriptObjectSettingsProps) => {
 
   const handleBindingBlur = useCallback(() => {
     if (fn) {
-      Obj.change(fn, (obj) => {
-        obj.binding = binding;
+      Obj.change(fn, (fn) => {
+        fn.binding = binding;
       });
     }
   }, [fn, binding]);
@@ -173,8 +173,8 @@ const Binding = ({ object }: ScriptObjectSettingsProps) => {
                 disabled
                 value={functionUrl}
                 onChange={(event) => {
-                  Obj.change(fn, (obj) => {
-                    obj.name = event.target.value;
+                  Obj.change(fn, (fn) => {
+                    fn.name = event.target.value;
                   });
                 }}
               />
@@ -260,8 +260,8 @@ const Publishing = ({ object }: ScriptObjectSettingsProps) => {
         });
         const gistId = response.data.id;
         if (gistId) {
-          Obj.change(object, (obj) => {
-            Obj.getMeta(obj).keys.push({ source: 'github.com', id: gistId });
+          Obj.change(object, (object) => {
+            Obj.getMeta(object).keys.push({ source: 'github.com', id: gistId });
           });
         }
       }

--- a/packages/plugins/plugin-script/src/containers/ScriptProperties/ScriptProperties.tsx
+++ b/packages/plugins/plugin-script/src/containers/ScriptProperties/ScriptProperties.tsx
@@ -23,8 +23,8 @@ export const ScriptProperties = ({ object }: ScriptPropertiesProps) => {
         placeholder={t('description.placeholder')}
         value={object.description ?? ''}
         onChange={(event) => {
-          Obj.change(object, (obj) => {
-            obj.description = event.target.value;
+          Obj.change(object, (object) => {
+            object.description = event.target.value;
           });
         }}
       />

--- a/packages/plugins/plugin-script/src/hooks/template.ts
+++ b/packages/plugins/plugin-script/src/hooks/template.ts
@@ -15,9 +15,9 @@ const createTemplateSelectActions = (script: Script.Script) => {
     return createMenuAction<TemplateActionProperties>(
       `template--${template.id}`,
       () => {
-        Obj.change(script, (obj) => {
-          obj.name = template.name;
-          const meta = Obj.getMeta(obj);
+        Obj.change(script, (script) => {
+          script.name = template.name;
+          const meta = Obj.getMeta(script);
           const oldPresetIndex = meta.keys.findIndex((key) => key.source === FUNCTIONS_PRESET_META_KEY);
           if (oldPresetIndex >= 0) {
             meta.keys.splice(oldPresetIndex, 1);

--- a/packages/plugins/plugin-script/src/notebook/compute-graph.test.ts
+++ b/packages/plugins/plugin-script/src/notebook/compute-graph.test.ts
@@ -43,8 +43,8 @@ describe('notebook', () => {
     // Replace one of the cells with code that tries to access window/document.
     const sourceTarget = notebook.cells[2].source?.target;
     if (sourceTarget) {
-      Obj.change(sourceTarget, (obj) => {
-        obj.content = 'b = typeof window';
+      Obj.change(sourceTarget, (sourceTarget) => {
+        sourceTarget.content = 'b = typeof window';
       });
     }
 
@@ -57,8 +57,8 @@ describe('notebook', () => {
 
     // Test document access.
     if (sourceTarget) {
-      Obj.change(sourceTarget, (obj) => {
-        obj.content = 'b = typeof document';
+      Obj.change(sourceTarget, (sourceTarget) => {
+        sourceTarget.content = 'b = typeof document';
       });
     }
     graph.parse();
@@ -69,8 +69,8 @@ describe('notebook', () => {
 
     // Test that safe globals still work.
     if (sourceTarget) {
-      Obj.change(sourceTarget, (obj) => {
-        obj.content = 'b = Math.max(100, 200)';
+      Obj.change(sourceTarget, (sourceTarget) => {
+        sourceTarget.content = 'b = Math.max(100, 200)';
       });
     }
     graph.parse();

--- a/packages/plugins/plugin-script/src/templates/chess-bot.ts
+++ b/packages/plugins/plugin-script/src/templates/chess-bot.ts
@@ -51,8 +51,8 @@ export default ChessBot.pipe(
 
       chess.move(move.san);
       const newPgn = chess.pgn();
-      Obj.change(loadedGame, (obj) => {
-        obj.pgn = newPgn;
+      Obj.change(loadedGame, (loadedGame) => {
+        loadedGame.pgn = newPgn;
       });
       yield* Database.flush();
       return { state: chess.ascii() };

--- a/packages/plugins/plugin-script/src/templates/commentary.ts
+++ b/packages/plugins/plugin-script/src/templates/commentary.ts
@@ -175,8 +175,8 @@ export default Commentary.pipe(
           );
 
           const documentRef = Ref.make(document);
-          Obj.change(rootCollection, (obj) => {
-            obj.objects.push(documentRef);
+          Obj.change(rootCollection, (rootCollection) => {
+            rootCollection.objects.push(documentRef);
           });
 
           // Create the HasSubject relation

--- a/packages/plugins/plugin-script/src/util/deploy.ts
+++ b/packages/plugins/plugin-script/src/util/deploy.ts
@@ -63,8 +63,8 @@ export const deployScript = async ({
     });
 
     const storedFunction = createOrUpdateFunctionInSpace(space, fn, script, newFunction);
-    Obj.change(script, (obj) => {
-      obj.changed = false;
+    Obj.change(script, (script) => {
+      script.changed = false;
     });
 
     return { success: true, functionId: getUserFunctionIdInMetadata(Obj.getMeta(storedFunction)) };
@@ -94,8 +94,8 @@ const createOrUpdateFunctionInSpace = (
     Operation.setFrom(fn, newFunction);
     return fn;
   } else {
-    Obj.change(newFunction, (obj) => {
-      obj.source = Ref.make(script);
+    Obj.change(newFunction, (newFunction) => {
+      newFunction.source = Ref.make(script);
     });
     return space.db.add(newFunction);
   }

--- a/packages/plugins/plugin-script/src/util/functions.ts
+++ b/packages/plugins/plugin-script/src/util/functions.ts
@@ -40,29 +40,29 @@ export const updateFunctionMetadata = (
   meta: any,
   functionId: string,
 ) => {
-  Obj.change(storedFunction, (obj) => {
+  Obj.change(storedFunction, (storedFunction) => {
     if (script.description !== undefined && script.description.trim() !== '') {
-      obj.description = script.description;
+      storedFunction.description = script.description;
     } else if (meta.description) {
-      obj.description = meta.description;
+      storedFunction.description = meta.description;
     } else {
       log.verbose('no description in function metadata', { functionId });
     }
 
     if (meta.inputSchema) {
-      obj.inputSchema = meta.inputSchema;
+      storedFunction.inputSchema = meta.inputSchema;
     } else {
       log.verbose('no input schema in function metadata', { functionId });
     }
 
     if (meta.outputSchema) {
-      obj.outputSchema = meta.outputSchema;
+      storedFunction.outputSchema = meta.outputSchema;
     } else {
       log.verbose('no output schema in function metadata', { functionId });
     }
 
     if (meta.key) {
-      obj.key = meta.key;
+      storedFunction.key = meta.key;
     } else {
       log.verbose('no key in function metadata', { functionId });
     }

--- a/packages/plugins/plugin-sheet/src/components/SheetContent/SheetCellEditor.stories.tsx
+++ b/packages/plugins/plugin-sheet/src/components/SheetContent/SheetCellEditor.stories.tsx
@@ -39,9 +39,9 @@ const AutomergeStory = ({ value, ...props }: CellEditorProps) => {
     const space = await client.spaces.create();
 
     const sheet = Sheet.make();
-    Obj.change(sheet, (obj) => {
-      obj.name = 'Test';
-      obj.cells[cell] = { value };
+    Obj.change(sheet, (sheet) => {
+      sheet.name = 'Test';
+      sheet.cells[cell] = { value };
     });
     space.db.add(sheet);
     setObject(sheet);

--- a/packages/plugins/plugin-sheet/src/containers/RangeList/RangeList.tsx
+++ b/packages/plugins/plugin-sheet/src/containers/RangeList/RangeList.tsx
@@ -25,8 +25,8 @@ export const RangeList = ({ sheet }: RangeListProps) => {
   const handleDeleteRange = useCallback(
     (range: Sheet.Range) => {
       const index = sheet.ranges.findIndex((sheetRange) => sheetRange === range);
-      Obj.change(sheet, (obj) => {
-        obj.ranges.splice(index, 1);
+      Obj.change(sheet, (sheet) => {
+        sheet.ranges.splice(index, 1);
       });
     },
     [sheet],

--- a/packages/plugins/plugin-sheet/src/types/Sheet.ts
+++ b/packages/plugins/plugin-sheet/src/types/Sheet.ts
@@ -84,17 +84,17 @@ export const make = ({ name, cells = {}, ...size }: SheetProps = {}) => {
   const sheet = Obj.make(Sheet, { name, cells: {}, rows: [], columns: [], rowMeta: {}, columnMeta: {}, ranges: [] });
 
   // Initialize and set cells within Obj.change to satisfy change context requirements.
-  Obj.change(sheet, (obj) => {
-    initialize(obj, size);
+  Obj.change(sheet, (sheet) => {
+    initialize(sheet, size);
 
     if (cells) {
       Object.entries(cells).forEach(([key, { value }]) => {
-        const idx = addressToIndex(obj, addressFromA1Notation(key));
+        const idx = addressToIndex(sheet, addressFromA1Notation(key));
         if (isFormula(value)) {
-          value = mapFormulaRefsToIndices(obj, value);
+          value = mapFormulaRefsToIndices(sheet, value);
         }
 
-        obj.cells[idx] = { value };
+        sheet.cells[idx] = { value };
       });
     }
   });

--- a/packages/plugins/plugin-sketch/src/util/serializer.ts
+++ b/packages/plugins/plugin-sketch/src/util/serializer.ts
@@ -34,10 +34,10 @@ export const serializer: TypedObjectSerializer<Sketch.Sketch> = {
 };
 
 const setCanvasContent = (object: Sketch.Canvas, content: any) => {
-  Obj.change(object, (obj) => {
-    obj.content = {};
+  Obj.change(object, (object) => {
+    object.content = {};
     Object.entries(content).forEach(([key, value]) => {
-      obj.content[key] = value;
+      object.content[key] = value;
     });
   });
 };

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/collections.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/collections.ts
@@ -277,8 +277,8 @@ const constructObjectActions = ({
                   const layout = yield* Capabilities.getAtomValue(AppCapabilities.Layout);
                   const isActive = layout.active.includes(nodeId);
 
-                  Obj.change(parentCollection, (mutable) => {
-                    mutable.objects.splice(index, 1);
+                  Obj.change(parentCollection, (parentCollection) => {
+                    parentCollection.objects.splice(index, 1);
                   });
 
                   if (isActive) {

--- a/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.ts
+++ b/packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/spaces.ts
@@ -230,8 +230,8 @@ const constructSpaceNode = ({
           nextOrder.map(({ id }) => id),
         );
 
-        Obj.change(spacesOrder, (mutableOrder: any) => {
-          mutableOrder.order = nextOrder.map(({ id }) => id);
+        Obj.change(spacesOrder, (spacesOrder: any) => {
+          spacesOrder.order = nextOrder.map(({ id }) => id);
         });
       };
       spaceRearrangeCache.set(space.id, onRearrange);

--- a/packages/plugins/plugin-space/src/capabilities/repair.ts
+++ b/packages/plugins/plugin-space/src/capabilities/repair.ts
@@ -33,8 +33,8 @@ const removeQueryCollections = async (space: Space) => {
     return;
   }
 
-  Obj.change(rootCollection, (obj) => {
-    obj.objects = objects
+  Obj.change(rootCollection, (rootCollection) => {
+    rootCollection.objects = objects
       .filter((object) => Obj.getTypename(object) !== 'org.dxos.type.queryCollection')
       .map((object) => Ref.make(object));
   });

--- a/packages/plugins/plugin-space/src/components/ObjectDetails/BaseObjectSettings.tsx
+++ b/packages/plugins/plugin-space/src/components/ObjectDetails/BaseObjectSettings.tsx
@@ -50,8 +50,8 @@ export const BaseObjectSettings = composable<HTMLDivElement, BaseObjectSettingsP
       invariant(Type.isObjectSchema(schema));
       const newObject = db.add(Obj.make(schema, values));
       if (Obj.instanceOf(Tag.Tag, newObject)) {
-        Obj.change(object, (obj) => {
-          Obj.getMeta(obj).tags = [...(Obj.getMeta(obj).tags ?? []), Obj.getDXN(newObject).toString()];
+        Obj.change(object, (object) => {
+          Obj.getMeta(object).tags = [...(Obj.getMeta(object).tags ?? []), Obj.getDXN(newObject).toString()];
         });
       }
     }, []);
@@ -71,8 +71,8 @@ export const BaseObjectSettings = composable<HTMLDivElement, BaseObjectSettingsP
         // Handle tags separately using Obj.change.
         const hasTagsChange = changedPaths.some((path) => splitJsonPath(path)[0] === 'tags');
         if (hasTagsChange) {
-          Obj.change(object, (obj) => {
-            Obj.getMeta(obj).tags = tags?.map((tag: Ref.Ref<Tag.Tag>) => tag.dxn.toString()) ?? [];
+          Obj.change(object, (object) => {
+            Obj.getMeta(object).tags = tags?.map((tag: Ref.Ref<Tag.Tag>) => tag.dxn.toString()) ?? [];
           });
         }
 

--- a/packages/plugins/plugin-space/src/components/ObjectForm/ObjectForm.tsx
+++ b/packages/plugins/plugin-space/src/components/ObjectForm/ObjectForm.tsx
@@ -54,8 +54,8 @@ export const ObjectForm = ({ object, schema }: ObjectFormProps) => {
     invariant(Type.isObjectSchema(schema));
     const newObject = db.add(Obj.make(schema, values));
     if (Obj.instanceOf(Tag.Tag, newObject)) {
-      Obj.change(object, (obj) => {
-        Obj.getMeta(obj).tags = [...(Obj.getMeta(obj).tags ?? []), Obj.getDXN(newObject).toString()];
+      Obj.change(object, (object) => {
+        Obj.getMeta(object).tags = [...(Obj.getMeta(object).tags ?? []), Obj.getDXN(newObject).toString()];
       });
     }
   }, []);
@@ -72,8 +72,8 @@ export const ObjectForm = ({ object, schema }: ObjectFormProps) => {
       // Handle tags separately using Obj.change.
       const hasTagsChange = changedPaths.some((path) => splitJsonPath(path)[0] === 'tags');
       if (hasTagsChange) {
-        Obj.change(object, (obj) => {
-          Obj.getMeta(obj).tags = tags?.map((tag: Ref.Ref<Tag.Tag>) => tag.dxn.toString()) ?? [];
+        Obj.change(object, (object) => {
+          Obj.getMeta(object).tags = tags?.map((tag: Ref.Ref<Tag.Tag>) => tag.dxn.toString()) ?? [];
         });
       }
 

--- a/packages/plugins/plugin-space/src/containers/ViewEditor/ViewEditor.tsx
+++ b/packages/plugins/plugin-space/src/containers/ViewEditor/ViewEditor.tsx
@@ -54,8 +54,8 @@ export const ViewEditor = ({ view }: ViewEditorProps) => {
 
       const queue = target && DXN.tryParse(target) ? target : undefined;
       const query = queue ? Query.fromAst(newQuery).from({ queues: [queue] }) : Query.fromAst(newQuery);
-      Obj.change(view, (obj) => {
-        obj.query.ast = query.ast as Mutable<typeof query.ast>;
+      Obj.change(view, (view) => {
+        view.query.ast = query.ast as Mutable<typeof query.ast>;
       });
       const newSchema = await resolveSchemaWithRegistry(space.db.schemaRegistry, query.ast);
       if (!newSchema) {
@@ -66,8 +66,8 @@ export const ViewEditor = ({ view }: ViewEditorProps) => {
         query,
         jsonSchema: JsonSchema.toJsonSchema(newSchema),
       });
-      Obj.change(view, (obj) => {
-        obj.projection = Obj.getSnapshot(newView).projection as Mutable<typeof obj.projection>;
+      Obj.change(view, (view) => {
+        view.projection = Obj.getSnapshot(newView).projection as Mutable<typeof view.projection>;
       });
 
       setSchema(() => newSchema);

--- a/packages/plugins/plugin-space/src/operations/remove-objects.ts
+++ b/packages/plugins/plugin-space/src/operations/remove-objects.ts
@@ -52,8 +52,8 @@ const handler: Operation.WithHandler<typeof SpaceOperation.RemoveObjects> = Spac
 
         const index = parentCollection.objects.findIndex((ref) => ref.target === obj);
         if (index !== -1) {
-          Obj.change(parentCollection, (obj) => {
-            obj.objects.splice(index, 1);
+          Obj.change(parentCollection, (parentCollection) => {
+            parentCollection.objects.splice(index, 1);
           });
         }
 

--- a/packages/plugins/plugin-space/src/operations/restore-objects.ts
+++ b/packages/plugins/plugin-space/src/operations/restore-objects.ts
@@ -32,10 +32,10 @@ const handler: Operation.WithHandler<typeof SpaceOperation.RestoreObjects> = Spa
         }
       });
 
-      Obj.change(parentCollection, (obj) => {
+      Obj.change(parentCollection, (parentCollection) => {
         indices.forEach((index: number, i: number) => {
           if (index !== -1) {
-            obj.objects.splice(index, 0, Ref.make(restoredObjects[i] as Obj.Unknown));
+            parentCollection.objects.splice(index, 0, Ref.make(restoredObjects[i] as Obj.Unknown));
           }
         });
       });

--- a/packages/plugins/plugin-spacetime/src/components/SpacetimeEditor/SpacetimeEditor.tsx
+++ b/packages/plugins/plugin-spacetime/src/components/SpacetimeEditor/SpacetimeEditor.tsx
@@ -155,8 +155,8 @@ const SpacetimeEditorRoot = forwardRef<SpacetimeController, SpacetimeEditorRootP
       for (const ref of scene.objects) {
         const obj = ref?.target;
         if (obj && (obj as any).id === selectedObjectId) {
-          Obj.change(obj, (draft) => {
-            draft.color = editorState.hue;
+          Obj.change(obj, (obj) => {
+            obj.color = editorState.hue;
           });
           break;
         }

--- a/packages/plugins/plugin-spacetime/src/components/SpacetimeEditor/import-export.ts
+++ b/packages/plugins/plugin-spacetime/src/components/SpacetimeEditor/import-export.ts
@@ -40,8 +40,8 @@ export const handleImport = ({ scene, hue, importGLBRef, setSelectedObjectId }: 
         mesh: meshData,
         color: hue,
       });
-      Obj.change(scene, (obj) => {
-        obj.objects.push(Ref.make(object));
+      Obj.change(scene, (scene) => {
+        scene.objects.push(Ref.make(object));
       });
       Obj.setParent(object, scene);
       const objId = (object as any).id as string | undefined;

--- a/packages/plugins/plugin-spacetime/src/tools/actions/add-object.ts
+++ b/packages/plugins/plugin-spacetime/src/tools/actions/add-object.ts
@@ -47,8 +47,8 @@ export class AddObjectAction implements ActionHandler {
       });
     }
 
-    Obj.change(scene, (sceneObj) => {
-      sceneObj.objects.push(Ref.make(object));
+    Obj.change(scene, (scene) => {
+      scene.objects.push(Ref.make(object));
     });
     Obj.setParent(object, scene);
 

--- a/packages/plugins/plugin-spacetime/src/tools/actions/delete-objects.ts
+++ b/packages/plugins/plugin-spacetime/src/tools/actions/delete-objects.ts
@@ -25,11 +25,11 @@ export class DeleteObjectsAction implements ActionHandler {
     ctx.setSelection(null);
 
     // Remove from ECHO scene.
-    Obj.change(scene, (sceneObj) => {
+    Obj.change(scene, (scene) => {
       for (const objId of selectedObjectIds) {
-        const index = sceneObj.objects.findIndex((ref) => (ref?.target as any)?.id === objId);
+        const index = scene.objects.findIndex((ref) => (ref?.target as any)?.id === objId);
         if (index !== -1) {
-          sceneObj.objects.splice(index, 1);
+          scene.objects.splice(index, 1);
         }
       }
     });

--- a/packages/plugins/plugin-spacetime/src/tools/actions/join-objects.ts
+++ b/packages/plugins/plugin-spacetime/src/tools/actions/join-objects.ts
@@ -57,14 +57,14 @@ export class JoinObjectsAction implements ActionHandler {
 
     ctx.setSelection(null);
 
-    Obj.change(scene, (sceneObj) => {
+    Obj.change(scene, (scene) => {
       for (const objId of objectsToDelete) {
-        const index = sceneObj.objects.findIndex((ref) => (ref?.target as any)?.id === objId);
+        const index = scene.objects.findIndex((ref) => (ref?.target as any)?.id === objId);
         if (index !== -1) {
-          sceneObj.objects.splice(index, 1);
+          scene.objects.splice(index, 1);
         }
       }
-      sceneObj.objects.push(Ref.make(newObject));
+      scene.objects.push(Ref.make(newObject));
     });
     Obj.setParent(newObject, scene);
 

--- a/packages/plugins/plugin-spacetime/src/tools/actions/subtract-objects.ts
+++ b/packages/plugins/plugin-spacetime/src/tools/actions/subtract-objects.ts
@@ -57,14 +57,14 @@ export class SubtractObjectsAction implements ActionHandler {
 
     ctx.setSelection(null);
 
-    Obj.change(scene, (sceneObj) => {
+    Obj.change(scene, (scene) => {
       for (const objId of objectsToDelete) {
-        const index = sceneObj.objects.findIndex((ref) => (ref?.target as any)?.id === objId);
+        const index = scene.objects.findIndex((ref) => (ref?.target as any)?.id === objId);
         if (index !== -1) {
-          sceneObj.objects.splice(index, 1);
+          scene.objects.splice(index, 1);
         }
       }
-      sceneObj.objects.push(Ref.make(newObject));
+      scene.objects.push(Ref.make(newObject));
     });
     Obj.setParent(newObject, scene);
 

--- a/packages/plugins/plugin-spacetime/src/tools/tools/extrude-tool.ts
+++ b/packages/plugins/plugin-spacetime/src/tools/tools/extrude-tool.ts
@@ -250,9 +250,9 @@ export class ExtrudeTool implements Tool {
     const modelObject = ctx.getObject(this._state.objectId);
     if (modelObject) {
       const meshData = serializeManifold(finalSolid);
-      Obj.change(modelObject, (obj) => {
-        obj.primitive = undefined;
-        obj.mesh = meshData;
+      Obj.change(modelObject, (modelObject) => {
+        modelObject.primitive = undefined;
+        modelObject.mesh = meshData;
       });
     }
 

--- a/packages/plugins/plugin-spacetime/src/tools/tools/move-tool.ts
+++ b/packages/plugins/plugin-spacetime/src/tools/tools/move-tool.ts
@@ -194,8 +194,8 @@ export class MoveTool implements Tool {
     const modelObject = ctx.getObject(objectId);
     if (modelObject) {
       // Commit final position to ECHO.
-      Obj.change(modelObject, (obj) => {
-        obj.position = {
+      Obj.change(modelObject, (modelObject) => {
+        modelObject.position = {
           x: mesh.position.x,
           y: mesh.position.y,
           z: mesh.position.z,
@@ -207,8 +207,8 @@ export class MoveTool implements Tool {
     for (const companion of this._drag.companions) {
       const companionObj = ctx.getObject(companion.objectId);
       if (companionObj) {
-        Obj.change(companionObj, (obj) => {
-          obj.position = {
+        Obj.change(companionObj, (companionObj) => {
+          companionObj.position = {
             x: companion.mesh.position.x,
             y: companion.mesh.position.y,
             z: companion.mesh.position.z,

--- a/packages/plugins/plugin-thread/src/containers/ChatContainer/ChatContainer.tsx
+++ b/packages/plugins/plugin-thread/src/containers/ChatContainer/ChatContainer.tsx
@@ -81,8 +81,8 @@ export const ChatContainer = composable<HTMLDivElement, ChatContainerProps>(
         return false;
       }
 
-      Obj.change(thread, (obj) => {
-        obj.messages.push(
+      Obj.change(thread, (thread) => {
+        thread.messages.push(
           Ref.make(
             Obj.make(Message.Message, {
               created: new Date().toISOString(),

--- a/packages/plugins/plugin-thread/src/extensions/threads.ts
+++ b/packages/plugins/plugin-thread/src/extensions/threads.ts
@@ -73,8 +73,8 @@ export const threads = (
             const name = getName(doc, anchor.anchor);
             const thread = Relation.getSource(anchor) as Thread.Thread;
             if (name && name !== thread.name) {
-              Obj.change(thread, (obj) => {
-                obj.name = name;
+              Obj.change(thread, (thread) => {
+                thread.name = name;
               });
             }
           }
@@ -130,8 +130,8 @@ export const threads = (
 
         const thread = query.results.find((object) => Relation.getSource(object).id === id);
         if (thread) {
-          Relation.change(thread, (obj) => {
-            obj.anchor = undefined;
+          Relation.change(thread, (thread) => {
+            thread.anchor = undefined;
           });
         }
       },
@@ -139,11 +139,11 @@ export const threads = (
         const draft = registry.get(stateAtom).drafts[objectId]?.find((d) => Relation.getDXN(d).toString() === id);
         if (draft) {
           const thread = Relation.getSource(draft) as Thread.Thread;
-          Obj.change(thread, (obj) => {
-            obj.name = getName(doc, cursor);
+          Obj.change(thread, (thread) => {
+            thread.name = getName(doc, cursor);
           });
-          Relation.change(draft, (obj) => {
-            obj.anchor = cursor;
+          Relation.change(draft, (draft) => {
+            draft.anchor = cursor;
           });
         }
 
@@ -151,11 +151,11 @@ export const threads = (
         if (relation) {
           const thread = Relation.getSource(relation);
           if (Obj.instanceOf(Thread.Thread, thread)) {
-            Obj.change(thread, (obj) => {
-              obj.name = getName(doc, cursor);
+            Obj.change(thread, (thread) => {
+              thread.name = getName(doc, cursor);
             });
-            Relation.change(relation, (obj) => {
-              obj.anchor = cursor;
+            Relation.change(relation, (relation) => {
+              relation.anchor = cursor;
             });
           }
         }

--- a/packages/plugins/plugin-thread/src/operations/add-message.ts
+++ b/packages/plugins/plugin-thread/src/operations/add-message.ts
@@ -30,15 +30,15 @@ const handler: Operation.WithHandler<typeof AddMessage> = AddMessage.pipe(
         sender,
         blocks: [{ _tag: 'text', text }],
       });
-      Obj.change(thread, (obj) => {
-        obj.messages.push(Ref.make(message));
+      Obj.change(thread, (thread) => {
+        thread.messages.push(Ref.make(message));
       });
 
       const state = registry.get(stateAtom);
       const draft = state.drafts[subjectId]?.find((a: { id: string }) => a.id === anchor.id);
       if (draft) {
-        Obj.change(thread, (obj) => {
-          obj.status = 'active';
+        Obj.change(thread, (thread) => {
+          thread.status = 'active';
         });
         registry.set(stateAtom, {
           ...state,

--- a/packages/plugins/plugin-thread/src/operations/delete-message.ts
+++ b/packages/plugins/plugin-thread/src/operations/delete-message.ts
@@ -31,8 +31,8 @@ const handler: Operation.WithHandler<typeof DeleteMessage> = DeleteMessage.pipe(
         return { messageIndex: -1 };
       }
 
-      Obj.change(thread, (obj) => {
-        obj.messages.splice(msgIndex, 1);
+      Obj.change(thread, (thread) => {
+        thread.messages.splice(msgIndex, 1);
       });
 
       yield* Operation.schedule(ObservabilityOperation.SendEvent, {

--- a/packages/plugins/plugin-thread/src/operations/restore-message.ts
+++ b/packages/plugins/plugin-thread/src/operations/restore-message.ts
@@ -19,8 +19,8 @@ const handler: Operation.WithHandler<typeof RestoreMessage> = RestoreMessage.pip
       const db = Obj.getDatabase(thread);
       invariant(db, 'Database not found');
 
-      Obj.change(thread, (obj) => {
-        obj.messages.splice(messageIndex, 0, Ref.make(message));
+      Obj.change(thread, (thread) => {
+        thread.messages.splice(messageIndex, 0, Ref.make(message));
       });
 
       yield* Operation.schedule(ObservabilityOperation.SendEvent, {

--- a/packages/plugins/plugin-thread/src/operations/toggle-resolved.ts
+++ b/packages/plugins/plugin-thread/src/operations/toggle-resolved.ts
@@ -16,11 +16,11 @@ const handler: Operation.WithHandler<typeof ToggleResolved> = ToggleResolved.pip
     Effect.fnUntraced(function* (input) {
       const thread = input.thread;
 
-      Obj.change(thread, (obj) => {
-        if (obj.status === 'active' || obj.status === undefined) {
-          obj.status = 'resolved';
-        } else if (obj.status === 'resolved') {
-          obj.status = 'active';
+      Obj.change(thread, (thread) => {
+        if (thread.status === 'active' || thread.status === undefined) {
+          thread.status = 'resolved';
+        } else if (thread.status === 'resolved') {
+          thread.status = 'active';
         }
       });
 

--- a/packages/plugins/plugin-token-manager/src/hooks/useOAuth.ts
+++ b/packages/plugins/plugin-token-manager/src/hooks/useOAuth.ts
@@ -55,7 +55,7 @@ export const enrichGoogleTokenWithEmail = (token: AccessToken.AccessToken) =>
     );
 
     if (userInfo.email) {
-      Obj.change(token, (obj) => (obj.account = userInfo.email));
+      Obj.change(token, (token) => (token.account = userInfo.email));
     }
   }).pipe(
     Effect.provide(FetchHttpClient.layer),
@@ -100,8 +100,8 @@ export const useOAuth = ({ spaceId, onAddAccessToken }: UseOAuthOptions) => {
             return;
           }
 
-          Obj.change(token, (obj) => {
-            obj.token = data.accessToken;
+          Obj.change(token, (token) => {
+            token.token = data.accessToken;
           });
           yield* enrichGoogleTokenWithEmail(token);
           onAddAccessToken(token);

--- a/packages/plugins/plugin-token-manager/src/oauth/mobile-flow.ts
+++ b/packages/plugins/plugin-token-manager/src/oauth/mobile-flow.ts
@@ -101,8 +101,8 @@ export const performMobileOAuthFlow = ({
     }
 
     // Update the access token with the received value.
-    Obj.change(accessToken, (obj) => {
-      obj.token = accessTokenValue;
+    Obj.change(accessToken, (accessToken) => {
+      accessToken.token = accessTokenValue;
     });
 
     log.info('Mobile OAuth flow completed successfully');

--- a/packages/plugins/plugin-token-manager/src/oauth/oauth-flow.ts
+++ b/packages/plugins/plugin-token-manager/src/oauth/oauth-flow.ts
@@ -195,8 +195,8 @@ export const performOAuthFlow = Effect.fn(function* (
       return yield* Effect.fail(new Error(`OAuth flow failed: ${oauthResult.reason}`));
     }
 
-    Obj.change(accessToken, (obj) => {
-      obj.token = oauthResult.accessToken;
+    Obj.change(accessToken, (accessToken) => {
+      accessToken.token = oauthResult.accessToken;
     });
   }).pipe(Effect.ensuring(server.stop().pipe(Effect.catchAll(() => Effect.void))));
 });

--- a/packages/plugins/plugin-transcription/src/model/model.test.ts
+++ b/packages/plugins/plugin-transcription/src/model/model.test.ts
@@ -51,8 +51,8 @@ describe('SerializationModel', () => {
     }
 
     // Update message.
-    Obj.change(message, (obj) => {
-      obj.blocks.push({ _tag: 'transcript', started: createDate(), text: 'Hello again!' });
+    Obj.change(message, (message) => {
+      message.blocks.push({ _tag: 'transcript', started: createDate(), text: 'Hello again!' });
     });
     model.updateChunk(message);
     {
@@ -133,16 +133,16 @@ describe('SerializationModel', () => {
       expect(view.state.doc.toString()).to.eq('###### Alice\nHello world!\n\n');
 
       // Update message (add block).
-      Obj.change(message, (obj) => {
-        obj.blocks.push({ _tag: 'transcript', started: createDate(), text: 'Hello again!' });
+      Obj.change(message, (message) => {
+        message.blocks.push({ _tag: 'transcript', started: createDate(), text: 'Hello again!' });
       });
       model.updateChunk(message);
       model.sync(adapter);
       expect(view.state.doc.toString()).to.eq('###### Alice\nHello world!\nHello again!\n\n');
 
       // Update message (remove block).
-      Obj.change(message, (obj) => {
-        obj.blocks.splice(0, 1);
+      Obj.change(message, (message) => {
+        message.blocks.splice(0, 1);
       });
       model.updateChunk(message);
       model.sync(adapter);

--- a/packages/plugins/plugin-voxel/src/operations/add-voxels.ts
+++ b/packages/plugins/plugin-voxel/src/operations/add-voxels.ts
@@ -15,11 +15,11 @@ const handler: Operation.WithHandler<typeof AddVoxels> = AddVoxels.pipe(
     Effect.fn(function* ({ world, voxels }) {
       const loaded = (yield* Database.load(world)) as Voxel.World;
       let added = 0;
-      Obj.change(loaded, (obj) => {
-        if (!obj.voxels) {
-          obj.voxels = {};
+      Obj.change(loaded, (loaded) => {
+        if (!loaded.voxels) {
+          loaded.voxels = {};
         }
-        const voxelMap = obj.voxels as Obj.Mutable<typeof obj.voxels>;
+        const voxelMap = loaded.voxels as Obj.Mutable<typeof loaded.voxels>;
         for (const voxel of voxels) {
           const key = Voxel.voxelKey(voxel.x, voxel.y, voxel.z);
           if (!(key in voxelMap)) {

--- a/packages/plugins/plugin-voxel/src/operations/generate-shape.ts
+++ b/packages/plugins/plugin-voxel/src/operations/generate-shape.ts
@@ -17,11 +17,11 @@ const handler: Operation.WithHandler<typeof GenerateShape> = GenerateShape.pipe(
       const loaded = (yield* Database.load(world)) as Voxel.World;
       const voxels = generateModel(shape, origin, hue);
       let added = 0;
-      Obj.change(loaded, (obj) => {
-        if (!obj.voxels) {
-          obj.voxels = {};
+      Obj.change(loaded, (loaded) => {
+        if (!loaded.voxels) {
+          loaded.voxels = {};
         }
-        const voxelMap = obj.voxels as Obj.Mutable<typeof obj.voxels>;
+        const voxelMap = loaded.voxels as Obj.Mutable<typeof loaded.voxels>;
         for (const voxel of voxels) {
           const key = Voxel.voxelKey(voxel.x, voxel.y, voxel.z);
           voxelMap[key] = { hue: voxel.hue };

--- a/packages/plugins/plugin-voxel/src/operations/remove-voxels.ts
+++ b/packages/plugins/plugin-voxel/src/operations/remove-voxels.ts
@@ -15,9 +15,9 @@ const handler: Operation.WithHandler<typeof RemoveVoxels> = RemoveVoxels.pipe(
     Effect.fn(function* ({ world, positions }) {
       const loaded = (yield* Database.load(world)) as Voxel.World;
       let removed = 0;
-      Obj.change(loaded, (obj) => {
-        if (obj.voxels) {
-          const voxelMap = obj.voxels as Obj.Mutable<typeof obj.voxels>;
+      Obj.change(loaded, (loaded) => {
+        if (loaded.voxels) {
+          const voxelMap = loaded.voxels as Obj.Mutable<typeof loaded.voxels>;
           for (const position of positions) {
             const key = Voxel.voxelKey(position.x, position.y, position.z);
             if (key in voxelMap) {

--- a/packages/plugins/plugin-youtube/src/operations/clear-synced-videos.ts
+++ b/packages/plugins/plugin-youtube/src/operations/clear-synced-videos.ts
@@ -25,9 +25,9 @@ const handler: Operation.WithHandler<typeof ClearSyncedVideos> = ClearSyncedVide
       yield* Database.add(newFeed);
       Obj.setParent(newFeed, channel);
 
-      Obj.change(channel, (mutable) => {
-        mutable.feed = Ref.make(newFeed);
-        delete mutable.lastSyncedAt;
+      Obj.change(channel, (channel) => {
+        channel.feed = Ref.make(newFeed);
+        delete channel.lastSyncedAt;
       });
 
       if (videos.length > 0) {

--- a/packages/plugins/plugin-zen/src/components/Mixer/Mixer.tsx
+++ b/packages/plugins/plugin-zen/src/components/Mixer/Mixer.tsx
@@ -90,8 +90,8 @@ export const Mixer = ({ classNames, dream, engine }: MixerProps) => {
 
   const handleAdd = useCallback(() => {
     const sequence = Sequence.makeSequence();
-    Obj.change(dream, (obj) => {
-      obj.sequences = [...(obj.sequences ?? []), sequence];
+    Obj.change(dream, (dream) => {
+      dream.sequences = [...(dream.sequences ?? []), sequence];
     });
     setSelected(sequence.id);
   }, [dream]);

--- a/packages/sdk/app-graph/src/stories/EchoGraph.stories.tsx
+++ b/packages/sdk/app-graph/src/stories/EchoGraph.stories.tsx
@@ -175,8 +175,8 @@ const runAction = async (client: Client, action: Action) => {
       if (space) {
         const objects = await space.db.query(Filter.type(TestSchema.Expando, { type: 'test' })).run();
         const object = objects[Math.floor(Math.random() * objects.length)];
-        Obj.change(object, (obj) => {
-          obj.name = random.commerce.productName();
+        Obj.change(object, (object) => {
+          object.name = random.commerce.productName();
         });
       }
       break;

--- a/packages/sdk/app-toolkit/src/object-node.ts
+++ b/packages/sdk/app-toolkit/src/object-node.ts
@@ -77,32 +77,32 @@ export const buildCollectionPartials = (
   acceptPersistenceKey: getAcceptPersistenceKey(db.spaceId),
   role: 'branch' as const,
   onTransferStart: (child: Node.Node<Obj.Unknown>, index?: number) => {
-    Obj.change(collection, (mutable) => {
-      if (!mutable.objects.find((object) => object.target === child.data)) {
+    Obj.change(collection, (collection) => {
+      if (!collection.objects.find((object) => object.target === child.data)) {
         if (typeof index !== 'undefined') {
-          mutable.objects.splice(index, 0, Ref.make(child.data));
+          collection.objects.splice(index, 0, Ref.make(child.data));
         } else {
-          mutable.objects.push(Ref.make(child.data));
+          collection.objects.push(Ref.make(child.data));
         }
       }
     });
   },
   onTransferEnd: (child: Node.Node<Obj.Unknown>, _destination: Node.Node) => {
-    Obj.change(collection, (mutable) => {
-      const idx = mutable.objects.findIndex((object) => object.target === child.data);
+    Obj.change(collection, (collection) => {
+      const idx = collection.objects.findIndex((object) => object.target === child.data);
       if (idx > -1) {
-        mutable.objects.splice(idx, 1);
+        collection.objects.splice(idx, 1);
       }
     });
   },
   onCopy: async (child: Node.Node<Obj.Unknown>, index?: number) => {
     const newObject = await cloneObject(child.data, resolve, db);
     db.add(newObject);
-    Obj.change(collection, (mutable) => {
+    Obj.change(collection, (collection) => {
       if (typeof index !== 'undefined') {
-        mutable.objects.splice(index, 0, Ref.make(newObject));
+        collection.objects.splice(index, 0, Ref.make(newObject));
       } else {
-        mutable.objects.push(Ref.make(newObject));
+        collection.objects.push(Ref.make(newObject));
       }
     });
   },
@@ -173,8 +173,8 @@ export const createObjectNode = ({
     onRearrange = rearrangeCache.get(collectionDxn);
     if (!onRearrange) {
       onRearrange = (nextOrder: unknown[]) => {
-        Obj.change(parentCollection, (mutable) => {
-          mutable.objects = nextOrder.filter(Obj.isObject).map(Ref.make);
+        Obj.change(parentCollection, (parentCollection) => {
+          parentCollection.objects = nextOrder.filter(Obj.isObject).map(Ref.make);
         });
       };
       rearrangeCache.set(collectionDxn, onRearrange);

--- a/packages/sdk/client/src/tests/client.test.ts
+++ b/packages/sdk/client/src/tests/client.test.ts
@@ -240,8 +240,8 @@ describe('Client', () => {
         ],
       }),
     );
-    Obj.change(thread2, (obj) => {
-      obj.messages.push(Ref.make(message));
+    Obj.change(thread2, (thread2) => {
+      thread2.messages.push(Ref.make(message));
     });
     await space2.db.flush();
 

--- a/packages/sdk/client/src/tests/contact-book.test.ts
+++ b/packages/sdk/client/src/tests/contact-book.test.ts
@@ -55,8 +55,8 @@ describe('ContactBook', () => {
       const guestSpace = await waitForSpace(client2, space2.key, { ready: true });
       await expectDocumentReplicated(guestSpace, document);
 
-      Obj.change(document, (obj) => {
-        obj.content = 'Hello, world!';
+      Obj.change(document, (document) => {
+        document.content = 'Hello, world!';
       });
       await space2.db.flush();
       await expectDocumentReplicated(guestSpace, document);

--- a/packages/sdk/client/src/tests/lazy-space-loading.test.ts
+++ b/packages/sdk/client/src/tests/lazy-space-loading.test.ts
@@ -116,8 +116,8 @@ describe('Lazy Space Loading', () => {
 
     await expect.poll(() => hostSpace.db.getObjectById(guestObject.id)).not.toEqual(undefined);
 
-    Obj.change(guestObject, (obj) => {
-      obj.content = 'foo';
+    Obj.change(guestObject, (guestObject) => {
+      guestObject.content = 'foo';
     });
 
     await expect.poll(() => hostSpace.db.getObjectById(guestObject.id)?.content).toEqual(guestObject.content);

--- a/packages/sdk/client/src/tests/spaces.test.ts
+++ b/packages/sdk/client/src/tests/spaces.test.ts
@@ -363,8 +363,8 @@ describe('Spaces', () => {
     await waitForObject(guestSpace, hostDocument);
 
     const text = Obj.make(TestSchema.TextV0Type, { content: 'Hello, world!' });
-    Obj.change(hostDocument, (obj) => {
-      obj.content = Ref.make(text);
+    Obj.change(hostDocument, (hostDocument) => {
+      hostDocument.content = Ref.make(text);
     });
 
     await expect.poll(() => getDocumentText(guestSpace, hostDocument.id)).toEqual('Hello, world!');
@@ -459,8 +459,8 @@ describe('Spaces', () => {
       const text = Obj.make(TestSchema.TextV0Type, {
         content: 'Hello, world!',
       });
-      Obj.change(hostDocument, (obj) => {
-        obj.content = Ref.make(text);
+      Obj.change(hostDocument, (hostDocument) => {
+        hostDocument.content = Ref.make(text);
       });
 
       await expect.poll(() => getDocumentText(guestSpace, hostDocument.id)).toEqual('Hello, world!');
@@ -476,8 +476,8 @@ describe('Spaces', () => {
       const text = Obj.make(TestSchema.TextV0Type, {
         content: 'Hello, world!',
       });
-      Obj.change(hostDocument, (obj) => {
-        obj.content = Ref.make(text);
+      Obj.change(hostDocument, (hostDocument) => {
+        hostDocument.content = Ref.make(text);
       });
 
       await expect.poll(() => getDocumentText(guestSpace, hostDocument.id)).toEqual('Hello, world!');
@@ -556,8 +556,8 @@ describe('Spaces', () => {
 
       onTestFinished(() => unsub());
 
-      Obj.change(hostRoot, (obj) => {
-        obj.entries.push(Ref.make(createObject({ name: 'second' })));
+      Obj.change(hostRoot, (hostRoot) => {
+        hostRoot.entries.push(Ref.make(createObject({ name: 'second' })));
       });
       await done.wait({ timeout: 1_000 });
     }

--- a/packages/sdk/examples/src/examples/TaskList.tsx
+++ b/packages/sdk/examples/src/examples/TaskList.tsx
@@ -48,8 +48,8 @@ const TaskList = ({ id, spaceId }: { id: number; spaceId?: SpaceId }) => {
               <Input.Checkbox
                 checked={!!task.completed}
                 onCheckedChange={() =>
-                  Obj.change(task, (obj) => {
-                    obj.completed = !obj.completed;
+                  Obj.change(task, (task) => {
+                    task.completed = !task.completed;
                   })
                 }
               />

--- a/packages/sdk/schema/src/experimental/biz-objects.test.ts
+++ b/packages/sdk/schema/src/experimental/biz-objects.test.ts
@@ -173,8 +173,8 @@ describe('analysis', () => {
 
     // Add a proposition using Ref.make (required for ECHO object references).
     const proposition = Proposition.make({ text: 'Unique decentralized object graph.' });
-    Obj.change(analysis, (obj) => {
-      obj.strengths.push(Ref.make(proposition));
+    Obj.change(analysis, (analysis) => {
+      analysis.strengths.push(Ref.make(proposition));
     });
 
     expect(analysis.strengths).toHaveLength(1);

--- a/packages/sdk/schema/src/projection/projection.ts
+++ b/packages/sdk/schema/src/projection/projection.ts
@@ -66,7 +66,7 @@ export const createEchoChangeCallback = (
   schema?: EchoSchema | Types.DeepMutable<JsonSchemaType>,
 ): ProjectionChangeCallback => ({
   // Inside Obj.change, v is Mutable<View.View>, so v.projection is already mutable.
-  projection: (mutate) => Obj.change(view, (obj) => mutate(obj.projection as Mutable<View.Projection>)),
+  projection: (mutate) => Obj.change(view, (view) => mutate(view.projection as Mutable<View.Projection>)),
   schema:
     schema instanceof EchoSchema
       ? (mutate) => Obj.change(schema.persistentSchema as unknown as Obj.Unknown, (s: any) => mutate(s.jsonSchema))

--- a/packages/sdk/schema/src/types/CollectionModel.ts
+++ b/packages/sdk/schema/src/types/CollectionModel.ts
@@ -20,8 +20,8 @@ type AddProps = {
 export const add = Effect.fn(function* ({ object, target, hidden }: AddProps) {
   const objectRef = Ref.make(object);
   if (Collection.isCollection(target)) {
-    Obj.change(target, (obj) => {
-      obj.objects.push(objectRef);
+    Obj.change(target, (target) => {
+      target.objects.push(objectRef);
     });
   } else if (hidden) {
     yield* Database.add(object);
@@ -33,14 +33,14 @@ export const add = Effect.fn(function* ({ object, target, hidden }: AddProps) {
     const collectionRef: Ref.Ref<Collection.Collection> | undefined = properties[Collection.Collection.typename];
     if (collectionRef) {
       const collection = yield* Effect.promise(() => collectionRef.load());
-      Obj.change(collection, (obj) => {
-        obj.objects.push(objectRef);
+      Obj.change(collection, (collection) => {
+        collection.objects.push(objectRef);
       });
     } else {
       const newCollection = Collection.make({ objects: [objectRef] });
       const collectionRef = Ref.make(newCollection);
-      Obj.change(properties, (obj) => {
-        obj[Collection.Collection.typename] = collectionRef;
+      Obj.change(properties, (properties) => {
+        properties[Collection.Collection.typename] = collectionRef;
       });
     }
   }

--- a/packages/sdk/schema/src/types/ViewModel.ts
+++ b/packages/sdk/schema/src/types/ViewModel.ts
@@ -62,7 +62,7 @@ export const make = ({ query, queryRaw, jsonSchema, overrideSchema, fields, pivo
 
   // Create change callback that wraps mutations in Obj.change.
   const changeCallback: ProjectionChangeCallback = {
-    projection: (mutate) => Obj.change(view, (obj) => mutate(obj.projection as Mutable<View.Projection>)),
+    projection: (mutate) => Obj.change(view, (view) => mutate(view.projection as Mutable<View.Projection>)),
     schema: (mutate) => mutate(jsonSchema as Types.DeepMutable<JsonSchema.JsonSchema>),
   };
 
@@ -92,8 +92,8 @@ export const make = ({ query, queryRaw, jsonSchema, overrideSchema, fields, pivo
 
   // Sort fields to match the order in the params.
   if (fields) {
-    Obj.change(view, (obj) => {
-      (obj.projection.fields as Mutable<View.Projection>['fields']).sort((a, b) => {
+    Obj.change(view, (view) => {
+      (view.projection.fields as Mutable<View.Projection>['fields']).sort((a, b) => {
         const indexA = fields.indexOf(a.path);
         const indexB = fields.indexOf(b.path);
         return indexA - indexB;
@@ -104,8 +104,8 @@ export const make = ({ query, queryRaw, jsonSchema, overrideSchema, fields, pivo
   if (pivotFieldName) {
     const fieldId = projection.getFieldId(pivotFieldName);
     if (fieldId) {
-      Obj.change(view, (obj) => {
-        obj.projection.pivotFieldId = fieldId;
+      Obj.change(view, (view) => {
+        view.projection.pivotFieldId = fieldId;
       });
     }
   }
@@ -141,7 +141,7 @@ export const makeWithReferences = async ({
 
   // Create change callback that wraps mutations in Obj.change.
   const changeCallback: ProjectionChangeCallback = {
-    projection: (mutate) => Obj.change(view, (obj) => mutate(obj.projection as Mutable<View.Projection>)),
+    projection: (mutate) => Obj.change(view, (view) => mutate(view.projection as Mutable<View.Projection>)),
     schema: (mutate) => mutate(jsonSchema as Types.DeepMutable<JsonSchema.JsonSchema>),
   };
 

--- a/packages/stories/stories-assistant/src/stories/Chat.stories.tsx
+++ b/packages/stories/stories-assistant/src/stories/Chat.stories.tsx
@@ -759,8 +759,8 @@ export const WithProject: Story = {
       const tagDxn = Obj.getDXN(tag).toString();
 
       people.slice(0, 4).forEach((person) => {
-        Obj.change(person, (obj) => {
-          Obj.getMeta(obj).tags = [tagDxn];
+        Obj.change(person, (person) => {
+          Obj.getMeta(person).tags = [tagDxn];
         });
       });
 
@@ -783,16 +783,16 @@ export const WithProject: Story = {
         }),
       );
       [dxosResearch, blueyardResearch].forEach((research) => {
-        Obj.change(research, (obj) => {
-          Obj.getMeta(obj).tags = [tagDxn];
+        Obj.change(research, (research) => {
+          Obj.getMeta(research).tags = [tagDxn];
         });
       });
 
       const dxos = organizations.find((org) => org.name === 'DXOS')!;
       const blueyard = organizations.find((org) => org.name === 'BlueYard')!;
       [dxos, blueyard].forEach((organization) => {
-        Obj.change(organization, (org) => {
-          Obj.getMeta(org).tags = [tagDxn];
+        Obj.change(organization, (organization) => {
+          Obj.getMeta(organization).tags = [tagDxn];
         });
       });
       // TODO(wittjosiah): Support relations.

--- a/packages/ui/react-ui-canvas-compute/src/hooks/useGraphMonitor.ts
+++ b/packages/ui/react-ui-canvas-compute/src/hooks/useGraphMonitor.ts
@@ -112,9 +112,9 @@ export const createComputeGraph = (graph?: CanvasGraphModel<ComputeShape>) => {
 const linkTriggerToCompute = (graph: ComputeGraphModel, computeNode: ComputeNode, triggerData: TriggerShape) => {
   const functionTrigger = triggerData.functionTrigger?.target;
   invariant(functionTrigger);
-  Obj.change(functionTrigger, (obj) => {
-    obj.function = Ref.make(graph.root);
-    obj.inputNodeId = computeNode.id;
+  Obj.change(functionTrigger, (functionTrigger) => {
+    functionTrigger.function = Ref.make(graph.root);
+    functionTrigger.inputNodeId = computeNode.id;
   });
 };
 

--- a/packages/ui/react-ui-canvas-compute/src/shapes/Trigger.tsx
+++ b/packages/ui/react-ui-canvas-compute/src/shapes/Trigger.tsx
@@ -53,8 +53,8 @@ export const TriggerComponent = ({ shape }: TriggerComponentProps) => {
 
   useEffect(() => {
     if (functionTrigger && !functionTrigger.spec) {
-      Obj.change(functionTrigger, (obj) => {
-        obj.spec = createTriggerSpec({ triggerKind: 'email', spaceId: space?.id }) as Mutable<Trigger.Spec>;
+      Obj.change(functionTrigger, (functionTrigger) => {
+        functionTrigger.spec = createTriggerSpec({ triggerKind: 'email', spaceId: space?.id }) as Mutable<Trigger.Spec>;
       });
     }
   }, [functionTrigger, functionTrigger?.spec]);

--- a/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.stories.tsx
+++ b/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.stories.tsx
@@ -90,8 +90,8 @@ const DefaultStory = (props: DefaultStoryProps) => {
       if (props.mode === 'tag') {
         const queue = target && DXN.tryParse(target) ? target : undefined;
         const query = queue ? Query.fromAst(newQuery).from({ queues: [queue] }) : Query.fromAst(newQuery);
-        Obj.change(view, (obj) => {
-          obj.query.ast = query.ast as Mutable<typeof query.ast>;
+        Obj.change(view, (view) => {
+          view.query.ast = query.ast as Mutable<typeof query.ast>;
         });
 
         const typename = getTypenameFromQuery(query.ast);
@@ -104,13 +104,13 @@ const DefaultStory = (props: DefaultStoryProps) => {
           query,
           jsonSchema: newSchema.jsonSchema,
         });
-        Obj.change(view, (obj) => {
-          obj.projection = Obj.getSnapshot(newView).projection as Mutable<typeof obj.projection>;
+        Obj.change(view, (view) => {
+          view.projection = Obj.getSnapshot(newView).projection as Mutable<typeof view.projection>;
         });
         setSchema(() => newSchema);
       } else {
-        Obj.change(view, (obj) => {
-          obj.query.ast = newQuery as Mutable<typeof newQuery>;
+        Obj.change(view, (view) => {
+          view.query.ast = newQuery as Mutable<typeof newQuery>;
         });
         schema.updateTypename(getTypenameFromQuery(newQuery));
       }

--- a/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
+++ b/packages/ui/react-ui-form/src/components/ViewEditor/ViewEditor.tsx
@@ -274,12 +274,12 @@ const FieldList = ({ schema, view, registry, readonly, showHeading = false, onDe
   const handleMove = useCallback(
     (fromIndex: number, toIndex: number) => {
       invariant(!readonly);
-      Obj.change(view, (obj) => {
+      Obj.change(view, (view) => {
         // NOTE(ZaymonFC): Using arrayMove here causes a race condition with the kanban model.
-        const fields = [...obj.projection.fields];
+        const fields = [...view.projection.fields];
         const [moved] = fields.splice(fromIndex, 1);
         fields.splice(toIndex, 0, moved);
-        obj.projection.fields = fields;
+        view.projection.fields = fields;
       });
     },
     [view, readonly],

--- a/packages/ui/react-ui-mosaic/src/components/Board/Board.stories.tsx
+++ b/packages/ui/react-ui-mosaic/src/components/Board/Board.stories.tsx
@@ -125,13 +125,13 @@ const useTestBoardModel = (): TestBoardModelResult => {
         return item;
       },
       onItemDelete: (column: TestColumn, current: TestItem) => {
-        Obj.change(column, (mutableColumn) => {
-          if (!mutableColumn.items) {
+        Obj.change(column, (column) => {
+          if (!column.items) {
             return;
           }
-          const idx = mutableColumn.items.findIndex((ref: Ref.Ref<TestItem>) => ref.target?.id === current?.id);
+          const idx = column.items.findIndex((ref: Ref.Ref<TestItem>) => ref.target?.id === current?.id);
           if (idx !== -1) {
-            mutableColumn.items.splice(idx, 1);
+            column.items.splice(idx, 1);
           }
         });
       },

--- a/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
+++ b/packages/ui/react-ui-table/src/components/Table/Table.stories.tsx
@@ -73,8 +73,8 @@ const StoryViewEditor = ({
       invariant(Type.isMutable(schema));
       schema.updateTypename(getTypenameFromQuery(newQuery));
       invariant(view);
-      Obj.change(view, (obj) => {
-        obj.query.ast = newQuery as Mutable<typeof newQuery>;
+      Obj.change(view, (view) => {
+        view.query.ast = newQuery as Mutable<typeof newQuery>;
       });
     },
     [schema, view],
@@ -173,10 +173,10 @@ const meta = {
         const [schema] = await space.db.schemaRegistry.register([Example]);
         const { view, jsonSchema } = await ViewModel.makeFromDatabase({ db: space.db, typename: schema.typename });
         const table = Table.make({ view, jsonSchema });
-        Obj.change(view, (obj) => {
-          obj.projection.fields = [
-            obj.projection.fields.find((field) => field.path === 'name')!,
-            ...obj.projection.fields.filter((field) => field.path !== 'name'),
+        Obj.change(view, (view) => {
+          view.projection.fields = [
+            view.projection.fields.find((field) => field.path === 'name')!,
+            ...view.projection.fields.filter((field) => field.path !== 'name'),
           ];
         });
 

--- a/packages/ui/react-ui-table/src/model/table-model.ts
+++ b/packages/ui/react-ui-table/src/model/table-model.ts
@@ -53,10 +53,10 @@ export type TableChangeCallback<T extends TableRow> = {
  * Use this when the table and rows are stored in the ECHO database.
  */
 export const createEchoChangeCallback = <T extends TableRow>(table: Table.Table): TableChangeCallback<T> => ({
-  table: (mutate) => Obj.change(table, (mutableTable) => mutate(mutableTable as unknown as Table.Table)),
+  table: (mutate) => Obj.change(table, (table) => mutate(table as unknown as Table.Table)),
   row: (row, mutate) => {
     if (Obj.isObject(row)) {
-      Obj.change(row, (mutableRow) => mutate(mutableRow as T));
+      Obj.change(row, (row) => mutate(row as T));
     } else {
       mutate(row);
     }
@@ -894,14 +894,14 @@ export class TableModel<T extends TableRow = TableRow> extends Resource {
       if (field) {
         // Persist sort to view.query.ast
         const newQuery = baseQuery.orderBy(Order.property<any>(field.path as string, inMemorySort.direction));
-        Obj.change(view, (obj) => {
-          obj.query.ast = newQuery.ast as Mutable<typeof newQuery.ast>;
+        Obj.change(view, (view) => {
+          view.query.ast = newQuery.ast as Mutable<typeof newQuery.ast>;
         });
       }
     } else {
       // Clear sort from view.query.ast
-      Obj.change(view, (obj) => {
-        obj.query.ast = baseQuery.ast as Mutable<typeof baseQuery.ast>;
+      Obj.change(view, (view) => {
+        view.query.ast = baseQuery.ast as Mutable<typeof baseQuery.ast>;
       });
     }
 

--- a/packages/ui/react-ui-table/src/util/dynamic-table.ts
+++ b/packages/ui/react-ui-table/src/util/dynamic-table.ts
@@ -93,8 +93,8 @@ const setProperties = (
     const field = projection.getFields().find((field) => field.path === property.name);
     if (field) {
       if (property.size !== undefined) {
-        Obj.change(table, (obj) => {
-          obj.sizes[field.path] = property.size!;
+        Obj.change(table, (table) => {
+          table.sizes[field.path] = property.size!;
         });
       }
 
@@ -111,9 +111,9 @@ const setProperties = (
         const currentQuery = Query.fromAst(Obj.getSnapshot(view).query.ast);
         // Use any type parameter since we're working with dynamic field paths
         const newQuery = currentQuery.orderBy(Order.property<any>(field.path as string, property.sort));
-        Obj.change(view, (obj) => {
+        Obj.change(view, (view) => {
           // Type assertion needed because Query AST types have some variance issues.
-          obj.query.ast = newQuery.ast as typeof obj.query.ast;
+          view.query.ast = newQuery.ast as typeof view.query.ast;
         });
       }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new ESLint rule `consistent-change-param` to the `@dxos/eslint-plugin-rules` package that enforces the callback parameter name in `Obj.change()`, `Relation.change()`, and `Entity.change()` matches the first argument name. All 364 existing violations have been auto-fixed.

### Example

```ts
// ❌ Bad
Obj.change(trigger, (t) => { t.enabled = true; });
Obj.change(trigger, (mutableTrigger) => { mutableTrigger.enabled = true; });

// ✅ Good
Obj.change(trigger, (trigger) => { trigger.enabled = true; });
```

### Features

- Detects mismatched parameter names across `Obj.change`, `Relation.change`, and `Entity.change`
- **Auto-fix** renames both the parameter and all references within the callback body
- Preserves type annotations on parameters (e.g. `(param: any)` → `(newName: any)`)
- Respects scope shadowing in nested functions
- Skips non-reference identifier positions (property keys, member access properties)

### Changes

- `packages/common/eslint-plugin-rules/rules/consistent-change-param.js` — new rule
- `packages/common/eslint-plugin-rules/index.js` — register the rule
- `.oxlintrc.json` — enable with `warn` level
- 118 files auto-fixed across the codebase (364 violations, pure renames)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b9de2b9-4ca0-4d51-b181-9a1173d6b49e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b9de2b9-4ca0-4d51-b181-9a1173d6b49e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new ESLint rule to enforce consistent callback parameter naming for change operations.

* **Refactor**
  * Updated callback parameter names throughout the codebase to match the objects being mutated, improving code clarity and readability.
  * Registered the new ESLint rule in the linter configuration for automatic enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->