### PR TITLE
feat(plugin-attention): add ephemeral attention context for chat

### DIFF
--- a/packages/core/ai/src/AiParser.test.ts
+++ b/packages/core/ai/src/AiParser.test.ts
@@ -250,6 +250,51 @@ describe('parser', () => {
         ] satisfies ContentBlock.Any[]);
       }),
     );
+
+    it.effect(
+      'ephemeral_context tag is silently dropped (unknown tag)',
+      Effect.fn(function* ({ expect }) {
+        const result = yield* makeInputStream([
+          ...text([
+            '<ephemeral_context>Currently viewing: [dxn:echo:space1:obj1 Document "My Doc" path:root/space1/obj1].</ephemeral_context>',
+            'Hello, world!',
+          ]),
+        ])
+          .pipe(AiParser.parseResponse())
+          .pipe(Stream.runCollect)
+          .pipe(Effect.map(Chunk.toArray));
+
+        expect(result).toEqual([
+          {
+            _tag: 'text',
+            text: 'Hello, world!',
+          },
+        ] satisfies ContentBlock.Any[]);
+      }),
+    );
+
+    it.effect(
+      'ephemeral_context tag with recently viewed is silently dropped',
+      Effect.fn(function* ({ expect }) {
+        const result = yield* makeInputStream([
+          ...text(
+            splitByCharacter(
+              '<ephemeral_context>Currently viewing: [dxn:echo:space1:obj1 Document "Doc1"]. Recently viewed: [dxn:echo:space1:obj2 Note "Note1"].</ephemeral_context>What is this document about?',
+            ),
+          ),
+        ])
+          .pipe(AiParser.parseResponse())
+          .pipe(Stream.runCollect)
+          .pipe(Effect.map(Chunk.toArray));
+
+        expect(result).toEqual([
+          {
+            _tag: 'text',
+            text: 'What is this document about?',
+          },
+        ] satisfies ContentBlock.Any[]);
+      }),
+    );
   });
 
   describe('streaming', () => {

--- a/packages/plugins/plugin-assistant/package.json
+++ b/packages/plugins/plugin-assistant/package.json
@@ -69,6 +69,7 @@
     "@codemirror/view": "catalog:",
     "@dxos/ai": "workspace:*",
     "@dxos/app-framework": "workspace:*",
+    "@dxos/app-graph": "workspace:*",
     "@dxos/app-toolkit": "workspace:*",
     "@dxos/assistant": "workspace:*",
     "@dxos/assistant-toolkit": "workspace:*",

--- a/packages/plugins/plugin-assistant/src/hooks/useChatProcessor.ts
+++ b/packages/plugins/plugin-assistant/src/hooks/useChatProcessor.ts
@@ -4,13 +4,15 @@
 
 import { type Registry, RegistryContext } from '@effect-atom/atom-react';
 import type * as Runtime from 'effect/Runtime';
-import { useContext, useMemo, useState } from 'react';
+import { useCallback, useContext, useMemo, useState } from 'react';
 
+import { type Graph } from '@dxos/app-graph';
 import { Ref } from '@dxos/echo';
 import { AiConversation } from '@dxos/assistant';
 import { type Chat } from '@dxos/assistant-toolkit';
 import { type Blueprint } from '@dxos/blueprints';
 import { log } from '@dxos/log';
+import { type AttentionManager, createAmbientFocusContext } from '@dxos/plugin-attention';
 import { type Queue, type Space } from '@dxos/react-client/echo';
 import { useAsyncEffect } from '@dxos/react-ui';
 
@@ -24,6 +26,10 @@ export type UseChatProcessorProps = {
   services?: () => Promise<Runtime.Runtime<AiChatServices>>;
   blueprintRegistry?: Blueprint.Registry;
   settings?: Assistant.Settings;
+  /** Attention manager for ambient focus context injection. */
+  attention?: AttentionManager;
+  /** App graph for resolving attention IDs to ECHO nodes. */
+  graph?: Graph.ReadableGraph;
 };
 
 /**
@@ -36,6 +42,8 @@ export const useChatProcessor = ({
   services,
   blueprintRegistry,
   settings,
+  attention,
+  graph,
 }: UseChatProcessorProps): AiChatProcessor | undefined => {
   const observableRegistry = useContext(RegistryContext);
 
@@ -61,6 +69,14 @@ export const useChatProcessor = ({
     };
   }, [space, chat?.queue.dxn.toString()]);
 
+  // Create ambient focus getter.
+  const getAmbientFocus = useCallback(() => {
+    if (!attention || !graph) {
+      return undefined;
+    }
+    return createAmbientFocusContext({ attention, graph });
+  }, [attention, graph]);
+
   // Create processor.
   const processor = useMemo(() => {
     if (!services || !conversation) {
@@ -73,8 +89,9 @@ export const useChatProcessor = ({
       observableRegistry,
       blueprintRegistry,
       model: preset?.model,
+      getAmbientFocus,
     });
-  }, [services, conversation, blueprintRegistry, preset]);
+  }, [services, conversation, blueprintRegistry, preset, getAmbientFocus]);
 
   return processor;
 };

--- a/packages/plugins/plugin-assistant/src/processor/processor.ts
+++ b/packages/plugins/plugin-assistant/src/processor/processor.ts
@@ -64,6 +64,11 @@ export type AiChatProcessorOptions = {
    * For tracing.
    */
   chat?: Ref.Ref<Chat.Chat>;
+  /**
+   * Returns ambient focus context to inject into prompts.
+   * "Ambient focus" (not "context") to avoid collision with AiContextBinder / AiContextService.
+   */
+  getAmbientFocus?: () => string | undefined;
 } & Pick<AiConversationRunProps, 'system'>;
 
 const defaultOptions: Partial<AiChatProcessorOptions> = {
@@ -181,6 +186,10 @@ export class AiChatProcessor {
 
       const services = await this._services();
 
+      // Prepend ambient focus context if available.
+      const ambientFocus = this._options.getAmbientFocus?.();
+      const prompt = ambientFocus ? `${ambientFocus}\n${requestProp.message}` : requestProp.message;
+
       // Create request.
       const request = Effect.gen(this, function* () {
         const tracer = yield* TracingService;
@@ -189,7 +198,7 @@ export class AiChatProcessor {
           payload: {
             chat: this._options.chat,
             data: {
-              prompt: requestProp.message,
+              prompt,
             },
           },
         });
@@ -197,7 +206,7 @@ export class AiChatProcessor {
         const result = yield* this._conversation
           .createRequest({
             system: this._options.system,
-            prompt: requestProp.message,
+            prompt,
             observer: this._observer,
           })
           .pipe(

--- a/packages/plugins/plugin-assistant/tsconfig.json
+++ b/packages/plugins/plugin-assistant/tsconfig.json
@@ -104,6 +104,9 @@
       "path": "../../sdk/app-framework"
     },
     {
+      "path": "../../sdk/app-graph"
+    },
+    {
       "path": "../../sdk/app-toolkit"
     },
     {

--- a/packages/plugins/plugin-attention/package.json
+++ b/packages/plugins/plugin-attention/package.json
@@ -49,6 +49,7 @@
   ],
   "dependencies": {
     "@dxos/app-framework": "workspace:*",
+    "@dxos/app-graph": "workspace:*",
     "@dxos/app-toolkit": "workspace:*",
     "@dxos/echo": "workspace:*",
     "@dxos/keyboard": "workspace:*",

--- a/packages/plugins/plugin-attention/src/ambient-focus.ts
+++ b/packages/plugins/plugin-attention/src/ambient-focus.ts
@@ -1,0 +1,164 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import * as Option from 'effect/Option';
+
+import { Graph } from '@dxos/app-graph';
+import { Obj } from '@dxos/echo';
+import { type AttentionHistoryEntry, type AttentionManager } from '@dxos/react-ui-attention';
+
+/**
+ * Resolved ECHO object info from a graph node.
+ */
+export type ResolvedEchoNode = {
+  /** The DXN of the ECHO object. */
+  dxn: string;
+  /** The typename of the ECHO object. */
+  typename: string;
+  /** The label of the graph node. */
+  label: string;
+  /** The graph node ID. */
+  nodeId: string;
+  /** The path from root to this node in the graph. */
+  path: string[];
+};
+
+/**
+ * Options for resolving attention IDs to ECHO nodes.
+ */
+export type ResolveAttentionOptions = {
+  /** The attention manager to get current and history from. */
+  attention: AttentionManager;
+  /** The app graph to resolve nodes from. */
+  graph: Graph.ReadableGraph;
+};
+
+/**
+ * Resolves a list of attention IDs to ECHO-backed graph nodes.
+ * Filters out non-ECHO nodes and deduplicates by DXN.
+ */
+export const resolveAttentionToEchoNodes = (
+  attentionIds: readonly string[],
+  graph: Graph.ReadableGraph,
+): ResolvedEchoNode[] => {
+  const seen = new Set<string>();
+  const resolved: ResolvedEchoNode[] = [];
+
+  for (const nodeId of attentionIds) {
+    const nodeOpt = Graph.getNode(graph, nodeId);
+    if (Option.isNone(nodeOpt)) {
+      continue;
+    }
+
+    const node = nodeOpt.value;
+    const persistenceClass = node.properties.persistenceClass;
+
+    if (persistenceClass !== 'echo') {
+      continue;
+    }
+
+    const data = node.data;
+    if (!Obj.isObject(data)) {
+      continue;
+    }
+
+    const dxn = Obj.getDXN(data)?.toString();
+    if (!dxn || seen.has(dxn)) {
+      continue;
+    }
+
+    seen.add(dxn);
+
+    const pathOpt = Graph.getPath(graph, { target: nodeId });
+    const path: string[] = Option.isSome(pathOpt) ? [...pathOpt.value] : [nodeId];
+
+    resolved.push({
+      dxn,
+      typename: node.type,
+      label: String(node.properties.label ?? ''),
+      nodeId,
+      path,
+    });
+  }
+
+  return resolved;
+};
+
+/**
+ * Maximum token budget for ambient focus context (approximate).
+ */
+const MAX_TOKEN_BUDGET = 500;
+
+/**
+ * Estimates token count for a string (rough approximation: ~4 chars per token).
+ */
+const estimateTokens = (text: string): number => Math.ceil(text.length / 4);
+
+/**
+ * Formats a resolved ECHO node for display in the ephemeral context.
+ */
+const formatNode = (node: ResolvedEchoNode): string => {
+  return `[${node.dxn} ${node.typename} "${node.label}" path:${node.path.join('/')}]`;
+};
+
+/**
+ * Creates the ambient focus context string from attention state.
+ * Returns undefined if there's nothing to inject.
+ *
+ * Format: `<ephemeral_context>Currently viewing: [...]. Recently viewed: [...].</ephemeral_context>`
+ */
+export const createAmbientFocusContext = ({ attention, graph }: ResolveAttentionOptions): string | undefined => {
+  const currentIds = attention.getCurrent();
+  const history = attention.getHistory();
+
+  if (currentIds.length === 0 && history.length === 0) {
+    return undefined;
+  }
+
+  const currentNodes = resolveAttentionToEchoNodes(currentIds, graph);
+  const historyNodes = resolveAttentionToEchoNodes(
+    history.map((entry: AttentionHistoryEntry) => entry.id),
+    graph,
+  );
+
+  if (currentNodes.length === 0 && historyNodes.length === 0) {
+    return undefined;
+  }
+
+  const currentDxns = new Set(currentNodes.map((node) => node.dxn));
+  const recentNodes = historyNodes.filter((node) => !currentDxns.has(node.dxn));
+
+  const parts: string[] = [];
+  let tokenCount = 0;
+
+  if (currentNodes.length > 0) {
+    const currentFormatted = currentNodes.map(formatNode);
+    const currentText = `Currently viewing: ${currentFormatted.join(', ')}.`;
+    tokenCount += estimateTokens(currentText);
+    parts.push(currentText);
+  }
+
+  if (recentNodes.length > 0 && tokenCount < MAX_TOKEN_BUDGET) {
+    const recentFormatted: string[] = [];
+    for (const node of recentNodes) {
+      const formatted = formatNode(node);
+      const additionalTokens = estimateTokens(formatted + ', ');
+      if (tokenCount + additionalTokens > MAX_TOKEN_BUDGET) {
+        break;
+      }
+      recentFormatted.push(formatted);
+      tokenCount += additionalTokens;
+    }
+
+    if (recentFormatted.length > 0) {
+      parts.push(`Recently viewed: ${recentFormatted.join(', ')}.`);
+    }
+  }
+
+  if (parts.length === 0) {
+    return undefined;
+  }
+
+  return `<ephemeral_context>${parts.join(' ')}</ephemeral_context>`;
+};

--- a/packages/plugins/plugin-attention/src/index.ts
+++ b/packages/plugins/plugin-attention/src/index.ts
@@ -4,6 +4,7 @@
 
 export * from '@dxos/react-ui-attention';
 
+export * from './ambient-focus';
 export * from './AttentionPlugin';
 export * from './meta';
 export * from './types';

--- a/packages/plugins/plugin-attention/tsconfig.json
+++ b/packages/plugins/plugin-attention/tsconfig.json
@@ -33,6 +33,9 @@
       "path": "../../sdk/app-framework"
     },
     {
+      "path": "../../sdk/app-graph"
+    },
+    {
       "path": "../../sdk/app-toolkit"
     },
     {

--- a/packages/ui/react-ui-attention/src/attention.ts
+++ b/packages/ui/react-ui-attention/src/attention.ts
@@ -4,7 +4,12 @@
 
 import { Atom, type Registry } from '@effect-atom/atom-react';
 
-import { type Attention } from './types';
+import { type Attention, type AttentionHistoryEntry } from './types';
+
+/**
+ * Default maximum number of entries in the attention history ring buffer.
+ */
+const DEFAULT_HISTORY_SIZE = 20;
 
 /**
  * Manages attention state for an application.
@@ -14,11 +19,17 @@ export class AttentionManager {
   private readonly _map = new Map<string, Atom.Writable<Attention>>();
   private readonly _currentAtom: Atom.Writable<string[]>;
 
+  /** Bounded ring buffer for attention history (newest first). */
+  private readonly _history: AttentionHistoryEntry[] = [];
+  private readonly _historySize: number;
+
   constructor(
     private readonly _registry: Registry.Registry,
     initial: string[] = [],
+    historySize: number = DEFAULT_HISTORY_SIZE,
   ) {
     this._currentAtom = Atom.make<string[]>([]).pipe(Atom.keepAlive);
+    this._historySize = historySize;
     if (initial.length > 0) {
       this.update(initial);
     }
@@ -88,6 +99,22 @@ export class AttentionManager {
   }
 
   /**
+   * Returns deduplicated recent attention history entries, newest first.
+   * Entries are deduplicated by ID, keeping only the most recent occurrence.
+   */
+  getHistory(): AttentionHistoryEntry[] {
+    const seen = new Set<string>();
+    const deduplicated: AttentionHistoryEntry[] = [];
+    for (const entry of this._history) {
+      if (!seen.has(entry.id)) {
+        seen.add(entry.id);
+        deduplicated.push(entry);
+      }
+    }
+    return deduplicated;
+  }
+
+  /**
    * Update the currently attended element.
    * Takes the array of qualified IDs collected from the DOM; the first element is the primary attended item.
    * Ancestry is derived from the progressive prefixes of the primary ID.
@@ -102,6 +129,8 @@ export class AttentionManager {
     if (!primaryId) {
       return;
     }
+
+    this._pushHistory(primaryId);
 
     const currentIds = this.getCurrent();
     const prevPrimaryId = currentIds[0];
@@ -152,6 +181,21 @@ export class AttentionManager {
       isAncestor: attention.isAncestor ?? false,
       isRelated: attention.isRelated ?? false,
     });
+  }
+
+  /**
+   * Push a new entry to the history ring buffer.
+   * Maintains bounded size by removing oldest entries when full.
+   */
+  private _pushHistory(id: string): void {
+    const entry: AttentionHistoryEntry = {
+      id,
+      timestamp: Date.now(),
+    };
+    this._history.unshift(entry);
+    while (this._history.length > this._historySize) {
+      this._history.pop();
+    }
   }
 }
 

--- a/packages/ui/react-ui-attention/src/types.ts
+++ b/packages/ui/react-ui-attention/src/types.ts
@@ -11,3 +11,13 @@ export type Attention = {
 export type CurrentState = {
   current: string[];
 };
+
+/**
+ * Entry in the attention history ring buffer.
+ */
+export type AttentionHistoryEntry = {
+  /** The attention ID (graph node ID). */
+  id: string;
+  /** Timestamp when this ID received attention. */
+  timestamp: number;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7071,6 +7071,9 @@ importers:
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
+      '@dxos/app-graph':
+        specifier: workspace:*
+        version: link:../../sdk/app-graph
       '@dxos/app-toolkit':
         specifier: workspace:*
         version: link:../../sdk/app-toolkit
@@ -7357,6 +7360,9 @@ importers:
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
+      '@dxos/app-graph':
+        specifier: workspace:*
+        version: link:../../sdk/app-graph
       '@dxos/app-toolkit':
         specifier: workspace:*
         version: link:../../sdk/app-toolkit


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR implements ephemeral attention context injection for chat prompts as specified in DX-877. The AI is now automatically aware of the user's current and recent attention (what they're looking at) without explicit mention.

## Changes

### `@dxos/react-ui-attention` — `AttentionManager`
- Added a bounded history ring buffer (20 entries by default) to track recent attention
- On each `update()`, the new primary ID + timestamp is pushed into the history
- Added `getHistory()` method that returns deduplicated recent entries, newest first
- History is ephemeral (in-memory only, not persisted)

### `@dxos/plugin-attention` — `ambient-focus.ts`
- Created utility function `resolveAttentionToEchoNodes()` to resolve attention IDs to ECHO-backed graph nodes
- For each node: extracts `{ dxn, typename, label, nodeId, path }` (includes graph node IDs/paths as suggested in comments)
- Filters out non-ECHO nodes (no `persistenceClass: 'echo'`)
- Deduplicates by DXN
- Created `createAmbientFocusContext()` to format the ephemeral context string

### `AiChatProcessor`
- Added optional `getAmbientFocus?: () => string | undefined` to `AiChatProcessorOptions`
- "Ambient focus" naming avoids collision with `AiContextBinder` / `AiContextService`
- Returns a single-line string (or `undefined` if nothing to inject)

### `useChatProcessor`
- Wired `getAmbientFocus` from optional `attention` and `graph` props
- Implementation reads `attention.getCurrent()` + `attention.getHistory()`, resolves through graph, formats

### Prompt injection
- Before passing `requestProp.message` to `this._conversation.createRequest`, prepends:
  ```
  <ephemeral_context>Currently viewing: [DXN typename "label" path:...]. Recently viewed: [DXN typename "label" path:...].</ephemeral_context>
  ```
- Tag contents are single-line (parser has issues with multi-line tags)
- Trims to ~500 token budget

### Parser handling
- `<ephemeral_context>` is an unknown tag → `makeContentBlock` returns `undefined` for unknown tags → silently dropped
- Added test cases to verify this behavior

## Testing

- All parser tests pass (15 tests including 2 new ephemeral_context tests)
- Build succeeds for all affected packages
- Lint passes

Closes DX-877
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DX-877](https://linear.app/dxos/issue/DX-877/spec-ephemeral-attention-context-for-chat)

<div><a href="https://cursor.com/agents/bc-9ccf2e75-2130-4119-b437-2461fa91360a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ccf2e75-2130-4119-b437-2461fa91360a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

