### PR TITLE
refactor: simplify default re-exports in plugin index files

### DIFF
--- a/packages/plugins/plugin-assistant/src/components/AssistantSettings/index.ts
+++ b/packages/plugins/plugin-assistant/src/components/AssistantSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { AssistantSettings } from './AssistantSettings';
-
-export default AssistantSettings;
+export { AssistantSettings as default } from './AssistantSettings';

--- a/packages/plugins/plugin-assistant/src/containers/BlueprintArticle/index.ts
+++ b/packages/plugins/plugin-assistant/src/containers/BlueprintArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { BlueprintArticle } from './BlueprintArticle';
-
-export default BlueprintArticle;
+export { BlueprintArticle as default } from './BlueprintArticle';

--- a/packages/plugins/plugin-assistant/src/containers/ChatCompanion/index.ts
+++ b/packages/plugins/plugin-assistant/src/containers/ChatCompanion/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { ChatCompanion } from './ChatCompanion';
-
-export default ChatCompanion;
+export { ChatCompanion as default } from './ChatCompanion';

--- a/packages/plugins/plugin-assistant/src/containers/ChatContainer/index.ts
+++ b/packages/plugins/plugin-assistant/src/containers/ChatContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { ChatContainer } from './ChatContainer';
-
-export default ChatContainer;
+export { ChatContainer as default } from './ChatContainer';

--- a/packages/plugins/plugin-assistant/src/containers/ChatDialog/index.ts
+++ b/packages/plugins/plugin-assistant/src/containers/ChatDialog/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { ChatDialog } from './ChatDialog';
-
-export default ChatDialog;
+export { ChatDialog as default } from './ChatDialog';

--- a/packages/plugins/plugin-assistant/src/containers/ProjectArticle/index.ts
+++ b/packages/plugins/plugin-assistant/src/containers/ProjectArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2026 DXOS.org
 //
 
-import { ProjectArticle } from './ProjectArticle';
-
-export default ProjectArticle;
+export { ProjectArticle as default } from './ProjectArticle';

--- a/packages/plugins/plugin-assistant/src/containers/ProjectSettings/index.ts
+++ b/packages/plugins/plugin-assistant/src/containers/ProjectSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2026 DXOS.org
 //
 
-import { ProjectSettings } from './ProjectSettings';
-
-export default ProjectSettings;
+export { ProjectSettings as default } from './ProjectSettings';

--- a/packages/plugins/plugin-assistant/src/containers/PromptArticle/index.ts
+++ b/packages/plugins/plugin-assistant/src/containers/PromptArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { PromptArticle } from './PromptArticle';
-
-export default PromptArticle;
+export { PromptArticle as default } from './PromptArticle';

--- a/packages/plugins/plugin-assistant/src/containers/PromptList/index.ts
+++ b/packages/plugins/plugin-assistant/src/containers/PromptList/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { PromptList } from './PromptList';
-
-export default PromptList;
+export { PromptList as default } from './PromptList';

--- a/packages/plugins/plugin-assistant/src/containers/TriggerStatus/index.ts
+++ b/packages/plugins/plugin-assistant/src/containers/TriggerStatus/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { TriggerStatus } from './TriggerStatus';
-
-export default TriggerStatus;
+export { TriggerStatus as default } from './TriggerStatus';

--- a/packages/plugins/plugin-automation/src/containers/AutomationSettings/index.ts
+++ b/packages/plugins/plugin-automation/src/containers/AutomationSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { AutomationSettings } from './AutomationSettings';
-
-export default AutomationSettings;
+export { AutomationSettings as default } from './AutomationSettings';

--- a/packages/plugins/plugin-automation/src/containers/FunctionsContainer/index.ts
+++ b/packages/plugins/plugin-automation/src/containers/FunctionsContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { FunctionsContainer } from './FunctionsContainer';
-
-export default FunctionsContainer;
+export { FunctionsContainer as default } from './FunctionsContainer';

--- a/packages/plugins/plugin-board/src/containers/BoardContainer/index.ts
+++ b/packages/plugins/plugin-board/src/containers/BoardContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { BoardContainer } from './BoardContainer';
-
-export default BoardContainer;
+export { BoardContainer as default } from './BoardContainer';

--- a/packages/plugins/plugin-chess/src/containers/ChessArticle/index.ts
+++ b/packages/plugins/plugin-chess/src/containers/ChessArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2026 DXOS.org
 //
 
-import { ChessArticle } from './ChessArticle';
-
-export default ChessArticle;
+export { ChessArticle as default } from './ChessArticle';

--- a/packages/plugins/plugin-chess/src/containers/ChessCard/index.ts
+++ b/packages/plugins/plugin-chess/src/containers/ChessCard/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2026 DXOS.org
 //
 
-import { ChessCard } from './ChessCard';
-
-export default ChessCard;
+export { ChessCard as default } from './ChessCard';

--- a/packages/plugins/plugin-client/src/containers/DevicesContainer/index.ts
+++ b/packages/plugins/plugin-client/src/containers/DevicesContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { DevicesContainer } from './DevicesContainer';
-
-export default DevicesContainer;
+export { DevicesContainer as default } from './DevicesContainer';

--- a/packages/plugins/plugin-client/src/containers/JoinDialog/index.ts
+++ b/packages/plugins/plugin-client/src/containers/JoinDialog/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { JoinDialog } from './JoinDialog';
-
-export default JoinDialog;
+export { JoinDialog as default } from './JoinDialog';

--- a/packages/plugins/plugin-client/src/containers/ProfileContainer/index.ts
+++ b/packages/plugins/plugin-client/src/containers/ProfileContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { ProfileContainer } from './ProfileContainer';
-
-export default ProfileContainer;
+export { ProfileContainer as default } from './ProfileContainer';

--- a/packages/plugins/plugin-client/src/containers/RecoveryCredentialsContainer/index.ts
+++ b/packages/plugins/plugin-client/src/containers/RecoveryCredentialsContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { RecoveryCredentialsContainer } from './RecoveryCredentialsContainer';
-
-export default RecoveryCredentialsContainer;
+export { RecoveryCredentialsContainer as default } from './RecoveryCredentialsContainer';

--- a/packages/plugins/plugin-conductor/src/containers/CanvasContainer/index.ts
+++ b/packages/plugins/plugin-conductor/src/containers/CanvasContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { CanvasContainer } from './CanvasContainer';
-
-export default CanvasContainer;
+export { CanvasContainer as default } from './CanvasContainer';

--- a/packages/plugins/plugin-daily-summary/src/containers/DailySummarySettings/index.ts
+++ b/packages/plugins/plugin-daily-summary/src/containers/DailySummarySettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2026 DXOS.org
 //
 
-import { DailySummarySettings } from './DailySummarySettings';
-
-export default DailySummarySettings;
+export { DailySummarySettings as default } from './DailySummarySettings';

--- a/packages/plugins/plugin-debug/src/components/DebugSettings/index.ts
+++ b/packages/plugins/plugin-debug/src/components/DebugSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { DebugSettings } from './DebugSettings';
-
-export default DebugSettings;
+export { DebugSettings as default } from './DebugSettings';

--- a/packages/plugins/plugin-debug/src/containers/DebugGraph/index.ts
+++ b/packages/plugins/plugin-debug/src/containers/DebugGraph/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { DebugGraph } from './DebugGraph';
-
-export default DebugGraph;
+export { DebugGraph as default } from './DebugGraph';

--- a/packages/plugins/plugin-debug/src/containers/DebugObjectPanel/index.ts
+++ b/packages/plugins/plugin-debug/src/containers/DebugObjectPanel/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { DebugObjectPanel } from './DebugObjectPanel';
-
-export default DebugObjectPanel;
+export { DebugObjectPanel as default } from './DebugObjectPanel';

--- a/packages/plugins/plugin-debug/src/containers/DebugSpaceObjectsPanel/index.ts
+++ b/packages/plugins/plugin-debug/src/containers/DebugSpaceObjectsPanel/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { DebugSpaceObjectsPanel } from './DebugSpaceObjectsPanel';
-
-export default DebugSpaceObjectsPanel;
+export { DebugSpaceObjectsPanel as default } from './DebugSpaceObjectsPanel';

--- a/packages/plugins/plugin-debug/src/containers/DebugStatus/index.ts
+++ b/packages/plugins/plugin-debug/src/containers/DebugStatus/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { DebugStatus } from './DebugStatus';
-
-export default DebugStatus;
+export { DebugStatus as default } from './DebugStatus';

--- a/packages/plugins/plugin-debug/src/containers/DevtoolsOverviewContainer/index.ts
+++ b/packages/plugins/plugin-debug/src/containers/DevtoolsOverviewContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { DevtoolsOverviewContainer } from './DevtoolsOverviewContainer';
-
-export default DevtoolsOverviewContainer;
+export { DevtoolsOverviewContainer as default } from './DevtoolsOverviewContainer';

--- a/packages/plugins/plugin-debug/src/containers/SpaceGenerator/index.ts
+++ b/packages/plugins/plugin-debug/src/containers/SpaceGenerator/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { SpaceGenerator } from './SpaceGenerator';
-
-export default SpaceGenerator;
+export { SpaceGenerator as default } from './SpaceGenerator';

--- a/packages/plugins/plugin-debug/src/containers/Wireframe/index.ts
+++ b/packages/plugins/plugin-debug/src/containers/Wireframe/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { Wireframe } from './Wireframe';
-
-export default Wireframe;
+export { Wireframe as default } from './Wireframe';

--- a/packages/plugins/plugin-deck/src/components/DeckSettings/index.ts
+++ b/packages/plugins/plugin-deck/src/components/DeckSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { DeckSettings } from './DeckSettings';
-
-export default DeckSettings;
+export { DeckSettings as default } from './DeckSettings';

--- a/packages/plugins/plugin-excalidraw/src/components/SketchSettings/index.ts
+++ b/packages/plugins/plugin-excalidraw/src/components/SketchSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { SketchSettings } from './SketchSettings';
-
-export default SketchSettings;
+export { SketchSettings as default } from './SketchSettings';

--- a/packages/plugins/plugin-excalidraw/src/containers/SketchContainer/index.ts
+++ b/packages/plugins/plugin-excalidraw/src/containers/SketchContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { SketchContainer } from './SketchContainer';
-
-export default SketchContainer;
+export { SketchContainer as default } from './SketchContainer';

--- a/packages/plugins/plugin-explorer/src/containers/ExplorerContainer/index.ts
+++ b/packages/plugins/plugin-explorer/src/containers/ExplorerContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ExplorerContainer } from './ExplorerContainer';
-
-export default ExplorerContainer;
+export { ExplorerContainer as default } from './ExplorerContainer';

--- a/packages/plugins/plugin-feed/src/containers/FeedArticle/index.ts
+++ b/packages/plugins/plugin-feed/src/containers/FeedArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { FeedArticle } from './FeedArticle';
-
-export default FeedArticle;
+export { FeedArticle as default } from './FeedArticle';

--- a/packages/plugins/plugin-feed/src/containers/SubscriptionsArticle/index.ts
+++ b/packages/plugins/plugin-feed/src/containers/SubscriptionsArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { SubscriptionsArticle } from './SubscriptionsArticle';
-
-export default SubscriptionsArticle;
+export { SubscriptionsArticle as default } from './SubscriptionsArticle';

--- a/packages/plugins/plugin-files/src/components/FilesSettings/index.ts
+++ b/packages/plugins/plugin-files/src/components/FilesSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { FilesSettings } from './FilesSettings';
-
-export default FilesSettings;
+export { FilesSettings as default } from './FilesSettings';

--- a/packages/plugins/plugin-files/src/containers/ExportStatus/index.ts
+++ b/packages/plugins/plugin-files/src/containers/ExportStatus/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { ExportStatus } from './ExportStatus';
-
-export default ExportStatus;
+export { ExportStatus as default } from './ExportStatus';

--- a/packages/plugins/plugin-files/src/containers/LocalFileContainer/index.ts
+++ b/packages/plugins/plugin-files/src/containers/LocalFileContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { LocalFileContainer } from './LocalFileContainer';
-
-export default LocalFileContainer;
+export { LocalFileContainer as default } from './LocalFileContainer';

--- a/packages/plugins/plugin-help/src/containers/ShortcutsDialogContent/index.ts
+++ b/packages/plugins/plugin-help/src/containers/ShortcutsDialogContent/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ShortcutsDialogContent } from './ShortcutsDialogContent';
-
-export default ShortcutsDialogContent;
+export { ShortcutsDialogContent as default } from './ShortcutsDialogContent';

--- a/packages/plugins/plugin-help/src/containers/ShortcutsHints/index.ts
+++ b/packages/plugins/plugin-help/src/containers/ShortcutsHints/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ShortcutsHints } from './ShortcutsHints';
-
-export default ShortcutsHints;
+export { ShortcutsHints as default } from './ShortcutsHints';

--- a/packages/plugins/plugin-help/src/containers/ShortcutsList/index.ts
+++ b/packages/plugins/plugin-help/src/containers/ShortcutsList/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { ShortcutsList } from './ShortcutsList';
-
-export default ShortcutsList;
+export { ShortcutsList as default } from './ShortcutsList';

--- a/packages/plugins/plugin-inbox/src/containers/CalendarArticle/index.ts
+++ b/packages/plugins/plugin-inbox/src/containers/CalendarArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { CalendarArticle } from './CalendarArticle';
-
-export default CalendarArticle;
+export { CalendarArticle as default } from './CalendarArticle';

--- a/packages/plugins/plugin-inbox/src/containers/CalendarSettings/index.ts
+++ b/packages/plugins/plugin-inbox/src/containers/CalendarSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { CalendarSettings } from './CalendarSettings';
-
-export default CalendarSettings;
+export { CalendarSettings as default } from './CalendarSettings';

--- a/packages/plugins/plugin-inbox/src/containers/DraftMessageArticle/index.ts
+++ b/packages/plugins/plugin-inbox/src/containers/DraftMessageArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { DraftMessageArticle } from './DraftMessageArticle';
-
-export default DraftMessageArticle;
+export { DraftMessageArticle as default } from './DraftMessageArticle';

--- a/packages/plugins/plugin-inbox/src/containers/DraftsArticle/index.ts
+++ b/packages/plugins/plugin-inbox/src/containers/DraftsArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2026 DXOS.org
 //
 
-import { DraftsArticle } from './DraftsArticle';
-
-export default DraftsArticle;
+export { DraftsArticle as default } from './DraftsArticle';

--- a/packages/plugins/plugin-inbox/src/containers/EventArticle/index.ts
+++ b/packages/plugins/plugin-inbox/src/containers/EventArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { EventArticle } from './EventArticle';
-
-export default EventArticle;
+export { EventArticle as default } from './EventArticle';

--- a/packages/plugins/plugin-inbox/src/containers/EventCard/index.ts
+++ b/packages/plugins/plugin-inbox/src/containers/EventCard/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { EventCard } from './EventCard';
-
-export default EventCard;
+export { EventCard as default } from './EventCard';

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/index.ts
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { MailboxArticle } from './MailboxArticle';
-
-export default MailboxArticle;
+export { MailboxArticle as default } from './MailboxArticle';

--- a/packages/plugins/plugin-inbox/src/containers/MailboxSettings/index.ts
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { MailboxSettings } from './MailboxSettings';
-
-export default MailboxSettings;
+export { MailboxSettings as default } from './MailboxSettings';

--- a/packages/plugins/plugin-inbox/src/containers/MessageArticle/index.ts
+++ b/packages/plugins/plugin-inbox/src/containers/MessageArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { MessageArticle } from './MessageArticle';
-
-export default MessageArticle;
+export { MessageArticle as default } from './MessageArticle';

--- a/packages/plugins/plugin-inbox/src/containers/MessageCard/index.ts
+++ b/packages/plugins/plugin-inbox/src/containers/MessageCard/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { MessageCard } from './MessageCard';
-
-export default MessageCard;
+export { MessageCard as default } from './MessageCard';

--- a/packages/plugins/plugin-inbox/src/containers/RelatedToContact/index.ts
+++ b/packages/plugins/plugin-inbox/src/containers/RelatedToContact/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { RelatedToContact } from './RelatedToContact';
-
-export default RelatedToContact;
+export { RelatedToContact as default } from './RelatedToContact';

--- a/packages/plugins/plugin-inbox/src/containers/RelatedToOrganization/index.ts
+++ b/packages/plugins/plugin-inbox/src/containers/RelatedToOrganization/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { RelatedToOrganization } from './RelatedToOrganization';
-
-export default RelatedToOrganization;
+export { RelatedToOrganization as default } from './RelatedToOrganization';

--- a/packages/plugins/plugin-inbox/src/containers/SaveFilterPopover/index.ts
+++ b/packages/plugins/plugin-inbox/src/containers/SaveFilterPopover/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { SaveFilterPopover } from './SaveFilterPopover';
-
-export default SaveFilterPopover;
+export { SaveFilterPopover as default } from './SaveFilterPopover';

--- a/packages/plugins/plugin-kanban/src/containers/KanbanContainer/index.ts
+++ b/packages/plugins/plugin-kanban/src/containers/KanbanContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { KanbanContainer } from './KanbanContainer';
-
-export default KanbanContainer;
+export { KanbanContainer as default } from './KanbanContainer';

--- a/packages/plugins/plugin-kanban/src/containers/KanbanViewEditor/index.ts
+++ b/packages/plugins/plugin-kanban/src/containers/KanbanViewEditor/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2026 DXOS.org
 //
 
-import { KanbanViewEditor } from './KanbanViewEditor';
-
-export default KanbanViewEditor;
+export { KanbanViewEditor as default } from './KanbanViewEditor';

--- a/packages/plugins/plugin-map/src/containers/MapViewEditor/index.ts
+++ b/packages/plugins/plugin-map/src/containers/MapViewEditor/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { MapViewEditor } from './MapViewEditor';
-
-export default MapViewEditor;
+export { MapViewEditor as default } from './MapViewEditor';

--- a/packages/plugins/plugin-markdown/src/components/MarkdownSettings/index.ts
+++ b/packages/plugins/plugin-markdown/src/components/MarkdownSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { MarkdownSettings } from './MarkdownSettings';
-
-export default MarkdownSettings;
+export { MarkdownSettings as default } from './MarkdownSettings';

--- a/packages/plugins/plugin-markdown/src/containers/MarkdownCard/index.ts
+++ b/packages/plugins/plugin-markdown/src/containers/MarkdownCard/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { MarkdownCard } from './MarkdownCard';
-
-export default MarkdownCard;
+export { MarkdownCard as default } from './MarkdownCard';

--- a/packages/plugins/plugin-masonry/src/containers/MasonryContainer/index.ts
+++ b/packages/plugins/plugin-masonry/src/containers/MasonryContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { MasonryContainer } from './MasonryContainer';
-
-export default MasonryContainer;
+export { MasonryContainer as default } from './MasonryContainer';

--- a/packages/plugins/plugin-meeting/src/components/MeetingSettings/index.ts
+++ b/packages/plugins/plugin-meeting/src/components/MeetingSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { MeetingSettings } from './MeetingSettings';
-
-export default MeetingSettings;
+export { MeetingSettings as default } from './MeetingSettings';

--- a/packages/plugins/plugin-meeting/src/containers/MeetingContainer/index.ts
+++ b/packages/plugins/plugin-meeting/src/containers/MeetingContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { MeetingContainer } from './MeetingContainer';
-
-export default MeetingContainer;
+export { MeetingContainer as default } from './MeetingContainer';

--- a/packages/plugins/plugin-meeting/src/containers/MeetingsList/index.ts
+++ b/packages/plugins/plugin-meeting/src/containers/MeetingsList/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { MeetingsList } from './MeetingsList';
-
-export default MeetingsList;
+export { MeetingsList as default } from './MeetingsList';

--- a/packages/plugins/plugin-navtree/src/containers/CommandsDialogContent/index.ts
+++ b/packages/plugins/plugin-navtree/src/containers/CommandsDialogContent/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { CommandsDialogContent } from './CommandsDialogContent';
-
-export default CommandsDialogContent;
+export { CommandsDialogContent as default } from './CommandsDialogContent';

--- a/packages/plugins/plugin-navtree/src/containers/CommandsTrigger/index.ts
+++ b/packages/plugins/plugin-navtree/src/containers/CommandsTrigger/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { CommandsTrigger } from './CommandsTrigger';
-
-export default CommandsTrigger;
+export { CommandsTrigger as default } from './CommandsTrigger';

--- a/packages/plugins/plugin-navtree/src/containers/NavTreeDocumentTitle/index.ts
+++ b/packages/plugins/plugin-navtree/src/containers/NavTreeDocumentTitle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { NavTreeDocumentTitle } from './NavTreeDocumentTitle';
-
-export default NavTreeDocumentTitle;
+export { NavTreeDocumentTitle as default } from './NavTreeDocumentTitle';

--- a/packages/plugins/plugin-observability/src/components/ObservabilitySettings/index.ts
+++ b/packages/plugins/plugin-observability/src/components/ObservabilitySettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ObservabilitySettings } from './ObservabilitySettings';
-
-export default ObservabilitySettings;
+export { ObservabilitySettings as default } from './ObservabilitySettings';

--- a/packages/plugins/plugin-observability/src/containers/HelpContainer/index.ts
+++ b/packages/plugins/plugin-observability/src/containers/HelpContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { HelpContainer } from './HelpContainer';
-
-export default HelpContainer;
+export { HelpContainer as default } from './HelpContainer';

--- a/packages/plugins/plugin-outliner/src/containers/JournalContainer/index.ts
+++ b/packages/plugins/plugin-outliner/src/containers/JournalContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { JournalContainer } from './JournalContainer';
-
-export default JournalContainer;
+export { JournalContainer as default } from './JournalContainer';

--- a/packages/plugins/plugin-outliner/src/containers/OutlineCard/index.ts
+++ b/packages/plugins/plugin-outliner/src/containers/OutlineCard/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { OutlineCard } from './OutlineCard';
-
-export default OutlineCard;
+export { OutlineCard as default } from './OutlineCard';

--- a/packages/plugins/plugin-outliner/src/containers/OutlineContainer/index.ts
+++ b/packages/plugins/plugin-outliner/src/containers/OutlineContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { OutlineContainer } from './OutlineContainer';
-
-export default OutlineContainer;
+export { OutlineContainer as default } from './OutlineContainer';

--- a/packages/plugins/plugin-outliner/src/containers/QuickEntryDialog/index.ts
+++ b/packages/plugins/plugin-outliner/src/containers/QuickEntryDialog/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { QuickEntryDialog } from './QuickEntryDialog';
-
-export default QuickEntryDialog;
+export { QuickEntryDialog as default } from './QuickEntryDialog';

--- a/packages/plugins/plugin-pipeline/src/containers/PipelineContainer/index.ts
+++ b/packages/plugins/plugin-pipeline/src/containers/PipelineContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { PipelineContainer } from './PipelineContainer';
-
-export default PipelineContainer;
+export { PipelineContainer as default } from './PipelineContainer';

--- a/packages/plugins/plugin-pipeline/src/containers/PipelineObjectSettings/index.ts
+++ b/packages/plugins/plugin-pipeline/src/containers/PipelineObjectSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { PipelineObjectSettings } from './PipelineObjectSettings';
-
-export default PipelineObjectSettings;
+export { PipelineObjectSettings as default } from './PipelineObjectSettings';

--- a/packages/plugins/plugin-presenter/src/components/PresenterSettings/index.ts
+++ b/packages/plugins/plugin-presenter/src/components/PresenterSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { PresenterSettings } from './PresenterSettings';
-
-export default PresenterSettings;
+export { PresenterSettings as default } from './PresenterSettings';

--- a/packages/plugins/plugin-presenter/src/containers/CollectionPresenterContainer/index.ts
+++ b/packages/plugins/plugin-presenter/src/containers/CollectionPresenterContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { CollectionPresenterContainer } from './CollectionPresenterContainer';
-
-export default CollectionPresenterContainer;
+export { CollectionPresenterContainer as default } from './CollectionPresenterContainer';

--- a/packages/plugins/plugin-presenter/src/containers/DocumentPresenterContainer/index.ts
+++ b/packages/plugins/plugin-presenter/src/containers/DocumentPresenterContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { DocumentPresenterContainer } from './DocumentPresenterContainer';
-
-export default DocumentPresenterContainer;
+export { DocumentPresenterContainer as default } from './DocumentPresenterContainer';

--- a/packages/plugins/plugin-presenter/src/containers/MarkdownSlide/index.ts
+++ b/packages/plugins/plugin-presenter/src/containers/MarkdownSlide/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { MarkdownSlide } from './MarkdownSlide';
-
-export default MarkdownSlide;
+export { MarkdownSlide as default } from './MarkdownSlide';

--- a/packages/plugins/plugin-registry/src/containers/LoadPluginDialog/index.ts
+++ b/packages/plugins/plugin-registry/src/containers/LoadPluginDialog/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { LoadPluginDialog } from './LoadPluginDialog';
-
-export default LoadPluginDialog;
+export { LoadPluginDialog as default } from './LoadPluginDialog';

--- a/packages/plugins/plugin-registry/src/containers/PluginArticle/index.ts
+++ b/packages/plugins/plugin-registry/src/containers/PluginArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { PluginArticle } from './PluginArticle';
-
-export default PluginArticle;
+export { PluginArticle as default } from './PluginArticle';

--- a/packages/plugins/plugin-registry/src/containers/PluginRegistry/index.ts
+++ b/packages/plugins/plugin-registry/src/containers/PluginRegistry/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { PluginRegistry } from './PluginRegistry';
-
-export default PluginRegistry;
+export { PluginRegistry as default } from './PluginRegistry';

--- a/packages/plugins/plugin-script/src/components/ScriptPluginSettings/index.ts
+++ b/packages/plugins/plugin-script/src/components/ScriptPluginSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ScriptPluginSettings } from './ScriptPluginSettings';
-
-export default ScriptPluginSettings;
+export { ScriptPluginSettings as default } from './ScriptPluginSettings';

--- a/packages/plugins/plugin-script/src/containers/DeploymentDialog/index.ts
+++ b/packages/plugins/plugin-script/src/containers/DeploymentDialog/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { DeploymentDialog } from './DeploymentDialog';
-
-export default DeploymentDialog;
+export { DeploymentDialog as default } from './DeploymentDialog';

--- a/packages/plugins/plugin-script/src/containers/NotebookContainer/index.ts
+++ b/packages/plugins/plugin-script/src/containers/NotebookContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { NotebookContainer } from './NotebookContainer';
-
-export default NotebookContainer;
+export { NotebookContainer as default } from './NotebookContainer';

--- a/packages/plugins/plugin-script/src/containers/ScriptContainer/index.ts
+++ b/packages/plugins/plugin-script/src/containers/ScriptContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ScriptContainer } from './ScriptContainer';
-
-export default ScriptContainer;
+export { ScriptContainer as default } from './ScriptContainer';

--- a/packages/plugins/plugin-script/src/containers/ScriptObjectSettings/index.ts
+++ b/packages/plugins/plugin-script/src/containers/ScriptObjectSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { ScriptObjectSettings } from './ScriptObjectSettings';
-
-export default ScriptObjectSettings;
+export { ScriptObjectSettings as default } from './ScriptObjectSettings';

--- a/packages/plugins/plugin-script/src/containers/ScriptProperties/index.ts
+++ b/packages/plugins/plugin-script/src/containers/ScriptProperties/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { ScriptProperties } from './ScriptProperties';
-
-export default ScriptProperties;
+export { ScriptProperties as default } from './ScriptProperties';

--- a/packages/plugins/plugin-script/src/containers/TestContainer/index.ts
+++ b/packages/plugins/plugin-script/src/containers/TestContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { TestContainer } from './TestContainer';
-
-export default TestContainer;
+export { TestContainer as default } from './TestContainer';

--- a/packages/plugins/plugin-search/src/containers/SearchArticle/index.ts
+++ b/packages/plugins/plugin-search/src/containers/SearchArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { SearchArticle } from './SearchArticle';
-
-export default SearchArticle;
+export { SearchArticle as default } from './SearchArticle';

--- a/packages/plugins/plugin-sheet/src/containers/RangeList/index.ts
+++ b/packages/plugins/plugin-sheet/src/containers/RangeList/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { RangeList } from './RangeList';
-
-export default RangeList;
+export { RangeList as default } from './RangeList';

--- a/packages/plugins/plugin-sheet/src/containers/SheetContainer/index.ts
+++ b/packages/plugins/plugin-sheet/src/containers/SheetContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { SheetContainer } from './SheetContainer';
-
-export default SheetContainer;
+export { SheetContainer as default } from './SheetContainer';

--- a/packages/plugins/plugin-sketch/src/components/SketchSettings/index.ts
+++ b/packages/plugins/plugin-sketch/src/components/SketchSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { SketchSettings } from './SketchSettings';
-
-export default SketchSettings;
+export { SketchSettings as default } from './SketchSettings';

--- a/packages/plugins/plugin-sketch/src/containers/SketchContainer/index.ts
+++ b/packages/plugins/plugin-sketch/src/containers/SketchContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { SketchContainer } from './SketchContainer';
-
-export default SketchContainer;
+export { SketchContainer as default } from './SketchContainer';

--- a/packages/plugins/plugin-space/src/components/SpacePluginSettings/index.ts
+++ b/packages/plugins/plugin-space/src/components/SpacePluginSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { SpacePluginSettings } from './SpacePluginSettings';
-
-export default SpacePluginSettings;
+export { SpacePluginSettings as default } from './SpacePluginSettings';

--- a/packages/plugins/plugin-space/src/containers/CollectionArticle/index.ts
+++ b/packages/plugins/plugin-space/src/containers/CollectionArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { CollectionArticle } from './CollectionArticle';
-
-export default CollectionArticle;
+export { CollectionArticle as default } from './CollectionArticle';

--- a/packages/plugins/plugin-space/src/containers/CollectionSection/index.ts
+++ b/packages/plugins/plugin-space/src/containers/CollectionSection/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { CollectionSection } from './CollectionSection';
-
-export default CollectionSection;
+export { CollectionSection as default } from './CollectionSection';

--- a/packages/plugins/plugin-space/src/containers/CreateSpaceDialog/index.ts
+++ b/packages/plugins/plugin-space/src/containers/CreateSpaceDialog/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { CreateSpaceDialog } from './CreateSpaceDialog';
-
-export default CreateSpaceDialog;
+export { CreateSpaceDialog as default } from './CreateSpaceDialog';

--- a/packages/plugins/plugin-space/src/containers/InlineSyncStatus/index.ts
+++ b/packages/plugins/plugin-space/src/containers/InlineSyncStatus/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { InlineSyncStatus } from './InlineSyncStatus';
-
-export default InlineSyncStatus;
+export { InlineSyncStatus as default } from './InlineSyncStatus';

--- a/packages/plugins/plugin-space/src/containers/MembersContainer/index.ts
+++ b/packages/plugins/plugin-space/src/containers/MembersContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { MembersContainer } from './MembersContainer';
-
-export default MembersContainer;
+export { MembersContainer as default } from './MembersContainer';

--- a/packages/plugins/plugin-space/src/containers/MenuFooter/index.ts
+++ b/packages/plugins/plugin-space/src/containers/MenuFooter/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { MenuFooter } from './MenuFooter';
-
-export default MenuFooter;
+export { MenuFooter as default } from './MenuFooter';

--- a/packages/plugins/plugin-space/src/containers/ObjectCardStack/index.ts
+++ b/packages/plugins/plugin-space/src/containers/ObjectCardStack/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { ObjectCardStack } from './ObjectCardStack';
-
-export default ObjectCardStack;
+export { ObjectCardStack as default } from './ObjectCardStack';

--- a/packages/plugins/plugin-space/src/containers/ObjectDetails/index.ts
+++ b/packages/plugins/plugin-space/src/containers/ObjectDetails/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { ObjectDetails } from './ObjectDetails';
-
-export default ObjectDetails;
+export { ObjectDetails as default } from './ObjectDetails';

--- a/packages/plugins/plugin-space/src/containers/ObjectRenamePopover/index.ts
+++ b/packages/plugins/plugin-space/src/containers/ObjectRenamePopover/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ObjectRenamePopover } from './ObjectRenamePopover';
-
-export default ObjectRenamePopover;
+export { ObjectRenamePopover as default } from './ObjectRenamePopover';

--- a/packages/plugins/plugin-space/src/containers/RecordArticle/index.ts
+++ b/packages/plugins/plugin-space/src/containers/RecordArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { RecordArticle } from './RecordArticle';
-
-export default RecordArticle;
+export { RecordArticle as default } from './RecordArticle';

--- a/packages/plugins/plugin-space/src/containers/SchemaContainer/index.ts
+++ b/packages/plugins/plugin-space/src/containers/SchemaContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { SchemaContainer } from './SchemaContainer';
-
-export default SchemaContainer;
+export { SchemaContainer as default } from './SchemaContainer';

--- a/packages/plugins/plugin-space/src/containers/SpaceRenamePopover/index.ts
+++ b/packages/plugins/plugin-space/src/containers/SpaceRenamePopover/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { SpaceRenamePopover } from './SpaceRenamePopover';
-
-export default SpaceRenamePopover;
+export { SpaceRenamePopover as default } from './SpaceRenamePopover';

--- a/packages/plugins/plugin-space/src/containers/SpaceSettingsContainer/index.ts
+++ b/packages/plugins/plugin-space/src/containers/SpaceSettingsContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { SpaceSettingsContainer } from './SpaceSettingsContainer';
-
-export default SpaceSettingsContainer;
+export { SpaceSettingsContainer as default } from './SpaceSettingsContainer';

--- a/packages/plugins/plugin-space/src/containers/SyncStatus/index.ts
+++ b/packages/plugins/plugin-space/src/containers/SyncStatus/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { SyncStatus } from './SyncStatus';
-
-export default SyncStatus;
+export { SyncStatus as default } from './SyncStatus';

--- a/packages/plugins/plugin-space/src/containers/ViewEditor/index.ts
+++ b/packages/plugins/plugin-space/src/containers/ViewEditor/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ViewEditor } from './ViewEditor';
-
-export default ViewEditor;
+export { ViewEditor as default } from './ViewEditor';

--- a/packages/plugins/plugin-spacetime/src/containers/SpacetimeArticle/index.ts
+++ b/packages/plugins/plugin-spacetime/src/containers/SpacetimeArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2026 DXOS.org
 //
 
-import { SpacetimeArticle } from './SpacetimeArticle';
-
-export default SpacetimeArticle;
+export { SpacetimeArticle as default } from './SpacetimeArticle';

--- a/packages/plugins/plugin-stack/src/containers/StackContainer/index.ts
+++ b/packages/plugins/plugin-stack/src/containers/StackContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { StackContainer } from './StackContainer';
-
-export default StackContainer;
+export { StackContainer as default } from './StackContainer';

--- a/packages/plugins/plugin-status-bar/src/containers/StatusBarActions/index.ts
+++ b/packages/plugins/plugin-status-bar/src/containers/StatusBarActions/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { StatusBarActions } from './StatusBarActions';
-
-export default StatusBarActions;
+export { StatusBarActions as default } from './StatusBarActions';

--- a/packages/plugins/plugin-status-bar/src/containers/StatusBarPanel/index.ts
+++ b/packages/plugins/plugin-status-bar/src/containers/StatusBarPanel/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { StatusBarPanel } from './StatusBarPanel';
-
-export default StatusBarPanel;
+export { StatusBarPanel as default } from './StatusBarPanel';

--- a/packages/plugins/plugin-status-bar/src/containers/VersionNumber/index.ts
+++ b/packages/plugins/plugin-status-bar/src/containers/VersionNumber/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { VersionNumber } from './VersionNumber';
-
-export default VersionNumber;
+export { VersionNumber as default } from './VersionNumber';

--- a/packages/plugins/plugin-thread/src/components/ThreadSettings/index.ts
+++ b/packages/plugins/plugin-thread/src/components/ThreadSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2023 DXOS.org
 //
 
-import { ThreadSettings } from './ThreadSettings';
-
-export default ThreadSettings;
+export { ThreadSettings as default } from './ThreadSettings';

--- a/packages/plugins/plugin-thread/src/containers/CallDebugPanel/index.ts
+++ b/packages/plugins/plugin-thread/src/containers/CallDebugPanel/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { CallDebugPanel } from './CallDebugPanel';
-
-export default CallDebugPanel;
+export { CallDebugPanel as default } from './CallDebugPanel';

--- a/packages/plugins/plugin-thread/src/containers/CallSidebar/index.ts
+++ b/packages/plugins/plugin-thread/src/containers/CallSidebar/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { CallSidebar } from './CallSidebar';
-
-export default CallSidebar;
+export { CallSidebar as default } from './CallSidebar';

--- a/packages/plugins/plugin-thread/src/containers/ChannelContainer/index.ts
+++ b/packages/plugins/plugin-thread/src/containers/ChannelContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { ChannelContainer } from './ChannelContainer';
-
-export default ChannelContainer;
+export { ChannelContainer as default } from './ChannelContainer';

--- a/packages/plugins/plugin-thread/src/containers/ThreadCompanion/index.ts
+++ b/packages/plugins/plugin-thread/src/containers/ThreadCompanion/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { ThreadCompanion } from './ThreadCompanion';
-
-export default ThreadCompanion;
+export { ThreadCompanion as default } from './ThreadCompanion';

--- a/packages/plugins/plugin-token-manager/src/components/IntegrationAuthButton/index.ts
+++ b/packages/plugins/plugin-token-manager/src/components/IntegrationAuthButton/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { IntegrationAuthButton } from './IntegrationAuthButton';
-
-export default IntegrationAuthButton;
+export { IntegrationAuthButton as default } from './IntegrationAuthButton';

--- a/packages/plugins/plugin-token-manager/src/containers/TokensContainer/index.ts
+++ b/packages/plugins/plugin-token-manager/src/containers/TokensContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { TokensContainer } from './TokensContainer';
-
-export default TokensContainer;
+export { TokensContainer as default } from './TokensContainer';

--- a/packages/plugins/plugin-transcription/src/containers/TranscriptionContainer/index.ts
+++ b/packages/plugins/plugin-transcription/src/containers/TranscriptionContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { TranscriptionContainer } from './TranscriptionContainer';
-
-export default TranscriptionContainer;
+export { TranscriptionContainer as default } from './TranscriptionContainer';

--- a/packages/plugins/plugin-voxel/src/containers/VoxelArticle/index.ts
+++ b/packages/plugins/plugin-voxel/src/containers/VoxelArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2026 DXOS.org
 //
 
-import { VoxelArticle } from './VoxelArticle';
-
-export default VoxelArticle;
+export { VoxelArticle as default } from './VoxelArticle';

--- a/packages/plugins/plugin-voxel/src/containers/VoxelCard/index.ts
+++ b/packages/plugins/plugin-voxel/src/containers/VoxelCard/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2026 DXOS.org
 //
 
-import { VoxelCard } from './VoxelCard';
-
-export default VoxelCard;
+export { VoxelCard as default } from './VoxelCard';

--- a/packages/plugins/plugin-wnfs/src/containers/FileContainer/index.ts
+++ b/packages/plugins/plugin-wnfs/src/containers/FileContainer/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { FileContainer } from './FileContainer';
-
-export default FileContainer;
+export { FileContainer as default } from './FileContainer';

--- a/packages/plugins/plugin-youtube/src/containers/ChannelArticle/index.ts
+++ b/packages/plugins/plugin-youtube/src/containers/ChannelArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { ChannelArticle } from './ChannelArticle';
-
-export default ChannelArticle;
+export { ChannelArticle as default } from './ChannelArticle';

--- a/packages/plugins/plugin-youtube/src/containers/ChannelSettings/index.ts
+++ b/packages/plugins/plugin-youtube/src/containers/ChannelSettings/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { ChannelSettings } from './ChannelSettings';
-
-export default ChannelSettings;
+export { ChannelSettings as default } from './ChannelSettings';

--- a/packages/plugins/plugin-youtube/src/containers/VideoArticle/index.ts
+++ b/packages/plugins/plugin-youtube/src/containers/VideoArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { VideoArticle } from './VideoArticle';
-
-export default VideoArticle;
+export { VideoArticle as default } from './VideoArticle';

--- a/packages/plugins/plugin-youtube/src/containers/VideoCard/index.ts
+++ b/packages/plugins/plugin-youtube/src/containers/VideoCard/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2024 DXOS.org
 //
 
-import { VideoCard } from './VideoCard';
-
-export default VideoCard;
+export { VideoCard as default } from './VideoCard';

--- a/packages/plugins/plugin-zen/src/containers/ZenArticle/index.ts
+++ b/packages/plugins/plugin-zen/src/containers/ZenArticle/index.ts
@@ -2,6 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-import { ZenArticle } from './ZenArticle';
-
-export default ZenArticle;
+export { ZenArticle as default } from './ZenArticle';


### PR DESCRIPTION
## Summary
- Replace `import { X } from './X'; export default X;` with `export { X as default } from './X';` across 130 plugin index files
- Pure mechanical refactor, no behavior change

## Test plan
- [ ] Build passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated module export declarations across plugin packages to use re-export syntax, consolidating import and export statements into single export clauses across approximately 110+ index files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->