### PR TITLE
feat(functions-runtime): add ServiceMesh for managing services with affinities

### DIFF
--- a/packages/core/functions-runtime/src/process/LayerSpec.ts
+++ b/packages/core/functions-runtime/src/process/LayerSpec.ts
@@ -8,13 +8,14 @@ import * as Types from 'effect/Types';
 
 // @import-as-namespace
 
-export const TypeId = '~@dxos/functions-runtime/Service' as const;
+export const TypeId = '~@dxos/functions-runtime/LayerSpec' as const;
 export type TypeId = typeof TypeId;
 
 /**
- * Untyped layer with introspectable tags.
+ * Untyped layer specification with introspectable tags.
+ * Used to define services with their dependencies and affinity.
  */
-export interface Service {
+export interface LayerSpec {
   readonly [TypeId]: TypeId;
 
   readonly affinity: Affinity;
@@ -40,12 +41,12 @@ interface MakeOpts {
 }
 
 /**
- * Make a service.
+ * Make a layer specification.
  */
 export const make = <const Opts extends Types.NoExcessProperties<MakeOpts, Opts>>(
   opts: Opts,
-  layer: Layer.Layer<Context.Tag.Service<Opts['provides'][number]>, never, Opts['requires'][number]>,
-): Service => {
+  layer: Layer.Layer<Context.Tag.Identifier<Opts['provides'][number]>, never, Context.Tag.Identifier<Opts['requires'][number]>>,
+): LayerSpec => {
   return {
     [TypeId]: TypeId,
     affinity: opts.affinity,

--- a/packages/core/functions-runtime/src/process/LayerSpec.ts
+++ b/packages/core/functions-runtime/src/process/LayerSpec.ts
@@ -45,7 +45,11 @@ interface MakeOpts {
  */
 export const make = <const Opts extends Types.NoExcessProperties<MakeOpts, Opts>>(
   opts: Opts,
-  layer: Layer.Layer<Context.Tag.Identifier<Opts['provides'][number]>, never, Context.Tag.Identifier<Opts['requires'][number]>>,
+  layer: Layer.Layer<
+    Context.Tag.Identifier<Opts['provides'][number]>,
+    never,
+    Context.Tag.Identifier<Opts['requires'][number]>
+  >,
 ): LayerSpec => {
   return {
     [TypeId]: TypeId,

--- a/packages/core/functions-runtime/src/process/ServiceMesh.test.ts
+++ b/packages/core/functions-runtime/src/process/ServiceMesh.test.ts
@@ -1,0 +1,568 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, it } from '@effect/vitest';
+import * as Context from 'effect/Context';
+import * as Effect from 'effect/Effect';
+import * as Exit from 'effect/Exit';
+import * as Layer from 'effect/Layer';
+import * as Scope from 'effect/Scope';
+
+import { ServiceResolver } from '@dxos/functions';
+import { type SpaceId } from '@dxos/keys';
+
+import * as Service from './Service';
+import { ServiceMesh, ServiceMeshService, layer as serviceMeshLayer } from './ServiceMesh';
+
+// Test service tags.
+class CounterService extends Context.Tag('test/CounterService')<CounterService, { count: () => number }>() {}
+
+class LoggerService extends Context.Tag('test/LoggerService')<
+  LoggerService,
+  { log: (msg: string) => void; logs: () => string[] }
+>() {}
+
+class CompositeService extends Context.Tag('test/CompositeService')<
+  CompositeService,
+  { getCountAndLog: () => { count: number; logs: string[] } }
+>() {}
+
+// Track service creation for testing.
+let counterCreations = 0;
+let loggerCreations = 0;
+let compositeCreations = 0;
+
+const resetCreationCounters = () => {
+  counterCreations = 0;
+  loggerCreations = 0;
+  compositeCreations = 0;
+};
+
+// Test services.
+const makeCounterService = (affinity: Service.Affinity): Service.Service => ({
+  [Service.TypeId]: Service.TypeId,
+  affinity,
+  requires: [],
+  provides: [CounterService],
+  layer: Layer.effect(
+    CounterService,
+    Effect.sync(() => {
+      counterCreations++;
+      let count = 0;
+      return { count: () => ++count };
+    }),
+  ),
+});
+
+const makeLoggerService = (affinity: Service.Affinity): Service.Service => ({
+  [Service.TypeId]: Service.TypeId,
+  affinity,
+  requires: [],
+  provides: [LoggerService],
+  layer: Layer.effect(
+    LoggerService,
+    Effect.sync(() => {
+      loggerCreations++;
+      const logs: string[] = [];
+      return {
+        log: (msg: string) => logs.push(msg),
+        logs: () => [...logs],
+      };
+    }),
+  ),
+});
+
+const makeCompositeService = (affinity: Service.Affinity): Service.Service => ({
+  [Service.TypeId]: Service.TypeId,
+  affinity,
+  requires: [CounterService, LoggerService],
+  provides: [CompositeService],
+  layer: Layer.effect(
+    CompositeService,
+    Effect.gen(function* () {
+      compositeCreations++;
+      const counter = yield* CounterService;
+      const logger = yield* LoggerService;
+      return {
+        getCountAndLog: () => ({ count: counter.count(), logs: logger.logs() }),
+      };
+    }),
+  ),
+});
+
+describe('ServiceMesh', () => {
+  describe('basic operations', () => {
+    it.effect(
+      'creates and resolves application-scoped services',
+      Effect.fn(function* ({ expect }) {
+        resetCreationCounters();
+        const mesh = new ServiceMesh([makeCounterService('application')]);
+
+        const result = yield* mesh.run(
+          Effect.gen(function* () {
+            const counter = yield* ServiceResolver.resolve(CounterService, {});
+            return counter.count();
+          }),
+        );
+
+        expect(result).toBe(1);
+        expect(counterCreations).toBe(1);
+
+        yield* mesh.destroy();
+      }),
+    );
+
+    it.effect(
+      'caches application-scoped services across multiple runs',
+      Effect.fn(function* ({ expect }) {
+        resetCreationCounters();
+        const mesh = new ServiceMesh([makeCounterService('application')]);
+
+        // First run.
+        const result1 = yield* mesh.run(
+          Effect.gen(function* () {
+            const counter = yield* ServiceResolver.resolve(CounterService, {});
+            return counter.count();
+          }),
+        );
+
+        // Second run should use cached instance.
+        const result2 = yield* mesh.run(
+          Effect.gen(function* () {
+            const counter = yield* ServiceResolver.resolve(CounterService, {});
+            return counter.count();
+          }),
+        );
+
+        expect(result1).toBe(1);
+        expect(result2).toBe(2);
+        expect(counterCreations).toBe(1);
+
+        yield* mesh.destroy();
+      }),
+    );
+
+    it.effect(
+      'resolves space-scoped services with space context',
+      Effect.fn(function* ({ expect }) {
+        resetCreationCounters();
+        const mesh = new ServiceMesh([makeCounterService('space')]);
+        const spaceId = 'space-1' as SpaceId;
+
+        const result = yield* mesh.run(
+          Effect.gen(function* () {
+            const counter = yield* ServiceResolver.resolve(CounterService, {});
+            return counter.count();
+          }),
+          { space: spaceId },
+        );
+
+        expect(result).toBe(1);
+        expect(counterCreations).toBe(1);
+
+        yield* mesh.destroy();
+      }),
+    );
+
+    it.effect(
+      'creates separate instances for different spaces',
+      Effect.fn(function* ({ expect }) {
+        resetCreationCounters();
+        const mesh = new ServiceMesh([makeCounterService('space')]);
+        const space1 = 'space-1' as SpaceId;
+        const space2 = 'space-2' as SpaceId;
+
+        const result1 = yield* mesh.run(
+          Effect.gen(function* () {
+            const counter = yield* ServiceResolver.resolve(CounterService, {});
+            return counter.count();
+          }),
+          { space: space1 },
+        );
+
+        const result2 = yield* mesh.run(
+          Effect.gen(function* () {
+            const counter = yield* ServiceResolver.resolve(CounterService, {});
+            return counter.count();
+          }),
+          { space: space2 },
+        );
+
+        expect(result1).toBe(1);
+        expect(result2).toBe(1);
+        expect(counterCreations).toBe(2);
+
+        yield* mesh.destroy();
+      }),
+    );
+
+    it.effect(
+      'resolves process-scoped services with process context',
+      Effect.fn(function* ({ expect }) {
+        resetCreationCounters();
+        const mesh = new ServiceMesh([makeCounterService('process')]);
+
+        const result = yield* mesh.run(
+          Effect.gen(function* () {
+            const counter = yield* ServiceResolver.resolve(CounterService, {});
+            return counter.count();
+          }),
+          { pid: 'process-1' },
+        );
+
+        expect(result).toBe(1);
+        expect(counterCreations).toBe(1);
+
+        yield* mesh.destroy();
+      }),
+    );
+
+    it.effect(
+      'creates separate instances for different processes',
+      Effect.fn(function* ({ expect }) {
+        resetCreationCounters();
+        const mesh = new ServiceMesh([makeCounterService('process')]);
+
+        const result1 = yield* mesh.run(
+          Effect.gen(function* () {
+            const counter = yield* ServiceResolver.resolve(CounterService, {});
+            return counter.count();
+          }),
+          { pid: 'process-1' },
+        );
+
+        const result2 = yield* mesh.run(
+          Effect.gen(function* () {
+            const counter = yield* ServiceResolver.resolve(CounterService, {});
+            return counter.count();
+          }),
+          { pid: 'process-2' },
+        );
+
+        expect(result1).toBe(1);
+        expect(result2).toBe(1);
+        expect(counterCreations).toBe(2);
+
+        yield* mesh.destroy();
+      }),
+    );
+  });
+
+  describe('dependency resolution', () => {
+    it.effect(
+      'resolves service dependencies',
+      Effect.fn(function* ({ expect }) {
+        resetCreationCounters();
+        const mesh = new ServiceMesh([
+          makeCounterService('application'),
+          makeLoggerService('application'),
+          makeCompositeService('application'),
+        ]);
+
+        const result = yield* mesh.run(
+          Effect.gen(function* () {
+            const composite = yield* ServiceResolver.resolve(CompositeService, {});
+            return composite.getCountAndLog();
+          }),
+        );
+
+        expect(result.count).toBe(1);
+        expect(counterCreations).toBe(1);
+        expect(loggerCreations).toBe(1);
+        expect(compositeCreations).toBe(1);
+
+        yield* mesh.destroy();
+      }),
+    );
+
+    it.effect(
+      'topologically sorts services within affinity',
+      Effect.fn(function* ({ expect }) {
+        resetCreationCounters();
+        // Add services in reverse dependency order.
+        const mesh = new ServiceMesh([
+          makeCompositeService('application'),
+          makeLoggerService('application'),
+          makeCounterService('application'),
+        ]);
+
+        const result = yield* mesh.run(
+          Effect.gen(function* () {
+            const composite = yield* ServiceResolver.resolve(CompositeService, {});
+            return composite.getCountAndLog();
+          }),
+        );
+
+        expect(result.count).toBe(1);
+        expect(counterCreations).toBe(1);
+        expect(loggerCreations).toBe(1);
+        expect(compositeCreations).toBe(1);
+
+        yield* mesh.destroy();
+      }),
+    );
+  });
+
+  describe('add and remove', () => {
+    it.effect(
+      'adds services dynamically',
+      Effect.fn(function* ({ expect }) {
+        resetCreationCounters();
+        const mesh = new ServiceMesh();
+
+        mesh.add(makeCounterService('application'));
+
+        const result = yield* mesh.run(
+          Effect.gen(function* () {
+            const counter = yield* ServiceResolver.resolve(CounterService, {});
+            return counter.count();
+          }),
+        );
+
+        expect(result).toBe(1);
+
+        yield* mesh.destroy();
+      }),
+    );
+
+    it.effect(
+      'removes services',
+      Effect.fn(function* ({ expect }) {
+        resetCreationCounters();
+        const counterService = makeCounterService('application');
+        const mesh = new ServiceMesh([counterService]);
+
+        mesh.remove(counterService);
+
+        const result = yield* mesh
+          .run(
+            Effect.gen(function* () {
+              const counter = yield* ServiceResolver.resolve(CounterService, {});
+              return counter.count();
+            }),
+          )
+          .pipe(Effect.either);
+
+        expect(result._tag).toBe('Left');
+
+        yield* mesh.destroy();
+      }),
+    );
+  });
+
+  describe('getResolver', () => {
+    it.effect(
+      'returns a resolver that can be used directly',
+      Effect.fn(function* ({ expect }) {
+        resetCreationCounters();
+        const mesh = new ServiceMesh([makeCounterService('application')]);
+
+        // Use mesh.run which handles the scope internally.
+        const count = yield* mesh.run(
+          Effect.gen(function* () {
+            const counter = yield* ServiceResolver.resolve(CounterService, {});
+            return counter.count();
+          }),
+        );
+        expect(count).toBe(1);
+
+        yield* mesh.destroy();
+      }),
+    );
+
+    it.effect(
+      'cleans up space-scoped services when resolver scope closes',
+      Effect.fn(function* ({ expect }) {
+        resetCreationCounters();
+        const mesh = new ServiceMesh([makeCounterService('space')]);
+        const spaceId = 'space-cleanup' as SpaceId;
+
+        // First run - creates the service.
+        yield* mesh.run(
+          Effect.gen(function* () {
+            const counter = yield* ServiceResolver.resolve(CounterService, {});
+            expect(counter.count()).toBe(1);
+          }),
+          { space: spaceId },
+        );
+
+        // Give time for cleanup (use real timeout, not Effect.sleep which uses test clock).
+        yield* Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, 50)));
+
+        // Second run - should create a new service since the previous was cleaned up.
+        yield* mesh.run(
+          Effect.gen(function* () {
+            const counter = yield* ServiceResolver.resolve(CounterService, {});
+            expect(counter.count()).toBe(1);
+          }),
+          { space: spaceId },
+        );
+
+        expect(counterCreations).toBe(2);
+
+        yield* mesh.destroy();
+      }),
+    );
+
+    it.effect(
+      'caches space-scoped services within same run',
+      Effect.fn(function* ({ expect }) {
+        resetCreationCounters();
+        const mesh = new ServiceMesh([makeCounterService('space')]);
+        const spaceId = 'space-cache' as SpaceId;
+
+        // Multiple resolves within the same run should use the same service instance.
+        const result = yield* mesh.run(
+          Effect.gen(function* () {
+            const counter1 = yield* ServiceResolver.resolve(CounterService, {});
+            const count1 = counter1.count();
+
+            const counter2 = yield* ServiceResolver.resolve(CounterService, {});
+            const count2 = counter2.count();
+
+            return { count1, count2 };
+          }),
+          { space: spaceId },
+        );
+
+        // Both should use the same counter instance.
+        expect(result.count1).toBe(1);
+        expect(result.count2).toBe(2);
+        expect(counterCreations).toBe(1);
+
+        yield* mesh.destroy();
+      }),
+    );
+  });
+
+  describe('destroy', () => {
+    it.effect(
+      'cleans up all services on destroy',
+      Effect.fn(function* ({ expect }) {
+        resetCreationCounters();
+        const mesh = new ServiceMesh([
+          makeCounterService('application'),
+          makeCounterService('space'),
+          makeCounterService('process'),
+        ]);
+
+        // Create instances of each affinity.
+        yield* mesh.run(
+          Effect.gen(function* () {
+            yield* ServiceResolver.resolve(CounterService, {});
+          }),
+        );
+
+        yield* mesh.run(
+          Effect.gen(function* () {
+            yield* ServiceResolver.resolve(CounterService, {});
+          }),
+          { space: 'space-1' as SpaceId },
+        );
+
+        yield* mesh.run(
+          Effect.gen(function* () {
+            yield* ServiceResolver.resolve(CounterService, {});
+          }),
+          { pid: 'process-1' },
+        );
+
+        yield* mesh.destroy();
+
+        // Mesh should be destroyed - running after destroy should fail.
+        const result = yield* mesh
+          .run(
+            Effect.gen(function* () {
+              yield* ServiceResolver.resolve(CounterService, {});
+            }),
+          )
+          .pipe(Effect.exit);
+
+        expect(Exit.isFailure(result)).toBe(true);
+      }),
+    );
+  });
+
+  describe('error handling', () => {
+    it.effect(
+      'fails when space-scoped service is requested without space context',
+      Effect.fn(function* ({ expect }) {
+        const mesh = new ServiceMesh([makeCounterService('space')]);
+
+        const result = yield* mesh
+          .run(
+            Effect.gen(function* () {
+              yield* ServiceResolver.resolve(CounterService, {});
+            }),
+          )
+          .pipe(Effect.either);
+
+        expect(result._tag).toBe('Left');
+
+        yield* mesh.destroy();
+      }),
+    );
+
+    it.effect(
+      'fails when process-scoped service is requested without process context',
+      Effect.fn(function* ({ expect }) {
+        const mesh = new ServiceMesh([makeCounterService('process')]);
+
+        const result = yield* mesh
+          .run(
+            Effect.gen(function* () {
+              yield* ServiceResolver.resolve(CounterService, {});
+            }),
+          )
+          .pipe(Effect.either);
+
+        expect(result._tag).toBe('Left');
+
+        yield* mesh.destroy();
+      }),
+    );
+
+    it.effect(
+      'fails when service is not available',
+      Effect.fn(function* ({ expect }) {
+        const mesh = new ServiceMesh();
+
+        const result = yield* mesh
+          .run(
+            Effect.gen(function* () {
+              yield* ServiceResolver.resolve(CounterService, {});
+            }),
+          )
+          .pipe(Effect.either);
+
+        expect(result._tag).toBe('Left');
+
+        yield* mesh.destroy();
+      }),
+    );
+  });
+
+  describe('layer', () => {
+    it.effect(
+      'provides ServiceMesh through layer',
+      Effect.fn(function* ({ expect }) {
+        resetCreationCounters();
+
+        const result = yield* Effect.gen(function* () {
+          const mesh = yield* ServiceMeshService;
+          mesh.add(makeCounterService('application'));
+
+          return yield* mesh.run(
+            Effect.gen(function* () {
+              const counter = yield* ServiceResolver.resolve(CounterService, {});
+              return counter.count();
+            }),
+          );
+        }).pipe(Effect.provide(serviceMeshLayer()));
+
+        expect(result).toBe(1);
+      }),
+    );
+  });
+});

--- a/packages/core/functions-runtime/src/process/ServiceMesh.test.ts
+++ b/packages/core/functions-runtime/src/process/ServiceMesh.test.ts
@@ -7,13 +7,12 @@ import * as Context from 'effect/Context';
 import * as Effect from 'effect/Effect';
 import * as Exit from 'effect/Exit';
 import * as Layer from 'effect/Layer';
-import * as Scope from 'effect/Scope';
 
 import { ServiceResolver } from '@dxos/functions';
 import { type SpaceId } from '@dxos/keys';
 
 import * as Service from './Service';
-import { ServiceMesh, ServiceMeshService, layer as serviceMeshLayer } from './ServiceMesh';
+import * as ServiceMesh from './ServiceMesh';
 
 // Test service tags.
 class CounterService extends Context.Tag('test/CounterService')<CounterService, { count: () => number }>() {}
@@ -97,7 +96,7 @@ describe('ServiceMesh', () => {
       'creates and resolves application-scoped services',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh([makeCounterService('application')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('application')]);
 
         const result = yield* mesh.run(
           Effect.gen(function* () {
@@ -117,7 +116,7 @@ describe('ServiceMesh', () => {
       'caches application-scoped services across multiple runs',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh([makeCounterService('application')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('application')]);
 
         // First run.
         const result1 = yield* mesh.run(
@@ -147,7 +146,7 @@ describe('ServiceMesh', () => {
       'resolves space-scoped services with space context',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh([makeCounterService('space')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('space')]);
         const spaceId = 'space-1' as SpaceId;
 
         const result = yield* mesh.run(
@@ -169,7 +168,7 @@ describe('ServiceMesh', () => {
       'creates separate instances for different spaces',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh([makeCounterService('space')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('space')]);
         const space1 = 'space-1' as SpaceId;
         const space2 = 'space-2' as SpaceId;
 
@@ -201,7 +200,7 @@ describe('ServiceMesh', () => {
       'resolves process-scoped services with process context',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh([makeCounterService('process')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('process')]);
 
         const result = yield* mesh.run(
           Effect.gen(function* () {
@@ -222,7 +221,7 @@ describe('ServiceMesh', () => {
       'creates separate instances for different processes',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh([makeCounterService('process')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('process')]);
 
         const result1 = yield* mesh.run(
           Effect.gen(function* () {
@@ -254,7 +253,7 @@ describe('ServiceMesh', () => {
       'resolves service dependencies',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh([
+        const mesh = new ServiceMesh.ServiceMesh([
           makeCounterService('application'),
           makeLoggerService('application'),
           makeCompositeService('application'),
@@ -281,7 +280,7 @@ describe('ServiceMesh', () => {
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
         // Add services in reverse dependency order.
-        const mesh = new ServiceMesh([
+        const mesh = new ServiceMesh.ServiceMesh([
           makeCompositeService('application'),
           makeLoggerService('application'),
           makeCounterService('application'),
@@ -309,7 +308,7 @@ describe('ServiceMesh', () => {
       'adds services dynamically',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh();
+        const mesh = new ServiceMesh.ServiceMesh();
 
         mesh.add(makeCounterService('application'));
 
@@ -331,7 +330,7 @@ describe('ServiceMesh', () => {
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
         const counterService = makeCounterService('application');
-        const mesh = new ServiceMesh([counterService]);
+        const mesh = new ServiceMesh.ServiceMesh([counterService]);
 
         mesh.remove(counterService);
 
@@ -356,7 +355,7 @@ describe('ServiceMesh', () => {
       'returns a resolver that can be used directly',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh([makeCounterService('application')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('application')]);
 
         // Use mesh.run which handles the scope internally.
         const count = yield* mesh.run(
@@ -375,7 +374,7 @@ describe('ServiceMesh', () => {
       'cleans up space-scoped services when resolver scope closes',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh([makeCounterService('space')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('space')]);
         const spaceId = 'space-cleanup' as SpaceId;
 
         // First run - creates the service.
@@ -409,7 +408,7 @@ describe('ServiceMesh', () => {
       'caches space-scoped services within same run',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh([makeCounterService('space')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('space')]);
         const spaceId = 'space-cache' as SpaceId;
 
         // Multiple resolves within the same run should use the same service instance.
@@ -441,7 +440,7 @@ describe('ServiceMesh', () => {
       'cleans up all services on destroy',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh([
+        const mesh = new ServiceMesh.ServiceMesh([
           makeCounterService('application'),
           makeCounterService('space'),
           makeCounterService('process'),
@@ -488,7 +487,7 @@ describe('ServiceMesh', () => {
     it.effect(
       'fails when space-scoped service is requested without space context',
       Effect.fn(function* ({ expect }) {
-        const mesh = new ServiceMesh([makeCounterService('space')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('space')]);
 
         const result = yield* mesh
           .run(
@@ -507,7 +506,7 @@ describe('ServiceMesh', () => {
     it.effect(
       'fails when process-scoped service is requested without process context',
       Effect.fn(function* ({ expect }) {
-        const mesh = new ServiceMesh([makeCounterService('process')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('process')]);
 
         const result = yield* mesh
           .run(
@@ -526,7 +525,7 @@ describe('ServiceMesh', () => {
     it.effect(
       'fails when service is not available',
       Effect.fn(function* ({ expect }) {
-        const mesh = new ServiceMesh();
+        const mesh = new ServiceMesh.ServiceMesh();
 
         const result = yield* mesh
           .run(
@@ -550,7 +549,7 @@ describe('ServiceMesh', () => {
         resetCreationCounters();
 
         const result = yield* Effect.gen(function* () {
-          const mesh = yield* ServiceMeshService;
+          const mesh = yield* ServiceMesh.ServiceMeshService;
           mesh.add(makeCounterService('application'));
 
           return yield* mesh.run(
@@ -559,7 +558,7 @@ describe('ServiceMesh', () => {
               return counter.count();
             }),
           );
-        }).pipe(Effect.provide(serviceMeshLayer()));
+        }).pipe(Effect.provide(ServiceMesh.layer()));
 
         expect(result).toBe(1);
       }),

--- a/packages/core/functions-runtime/src/process/ServiceMesh.test.ts
+++ b/packages/core/functions-runtime/src/process/ServiceMesh.test.ts
@@ -11,7 +11,7 @@ import * as Layer from 'effect/Layer';
 import { ServiceResolver } from '@dxos/functions';
 import { type SpaceId } from '@dxos/keys';
 
-import * as Service from './Service';
+import * as LayerSpec from './LayerSpec';
 import * as ServiceMesh from './ServiceMesh';
 
 // Test service tags.
@@ -38,57 +38,63 @@ const resetCreationCounters = () => {
   compositeCreations = 0;
 };
 
-// Test services.
-const makeCounterService = (affinity: Service.Affinity): Service.Service => ({
-  [Service.TypeId]: Service.TypeId,
-  affinity,
-  requires: [],
-  provides: [CounterService],
-  layer: Layer.effect(
-    CounterService,
-    Effect.sync(() => {
-      counterCreations++;
-      let count = 0;
-      return { count: () => ++count };
-    }),
-  ),
-});
+// Test layer specs using LayerSpec.make().
+const makeCounterLayerSpec = (affinity: LayerSpec.Affinity): LayerSpec.LayerSpec =>
+  LayerSpec.make(
+    {
+      affinity,
+      requires: [],
+      provides: [CounterService],
+    },
+    Layer.effect(
+      CounterService,
+      Effect.sync(() => {
+        counterCreations++;
+        let count = 0;
+        return { count: () => ++count };
+      }),
+    ),
+  );
 
-const makeLoggerService = (affinity: Service.Affinity): Service.Service => ({
-  [Service.TypeId]: Service.TypeId,
-  affinity,
-  requires: [],
-  provides: [LoggerService],
-  layer: Layer.effect(
-    LoggerService,
-    Effect.sync(() => {
-      loggerCreations++;
-      const logs: string[] = [];
-      return {
-        log: (msg: string) => logs.push(msg),
-        logs: () => [...logs],
-      };
-    }),
-  ),
-});
+const makeLoggerLayerSpec = (affinity: LayerSpec.Affinity): LayerSpec.LayerSpec =>
+  LayerSpec.make(
+    {
+      affinity,
+      requires: [],
+      provides: [LoggerService],
+    },
+    Layer.effect(
+      LoggerService,
+      Effect.sync(() => {
+        loggerCreations++;
+        const logs: string[] = [];
+        return {
+          log: (msg: string) => logs.push(msg),
+          logs: () => [...logs],
+        };
+      }),
+    ),
+  );
 
-const makeCompositeService = (affinity: Service.Affinity): Service.Service => ({
-  [Service.TypeId]: Service.TypeId,
-  affinity,
-  requires: [CounterService, LoggerService],
-  provides: [CompositeService],
-  layer: Layer.effect(
-    CompositeService,
-    Effect.gen(function* () {
-      compositeCreations++;
-      const counter = yield* CounterService;
-      const logger = yield* LoggerService;
-      return {
-        getCountAndLog: () => ({ count: counter.count(), logs: logger.logs() }),
-      };
-    }),
-  ),
-});
+const makeCompositeLayerSpec = (affinity: LayerSpec.Affinity): LayerSpec.LayerSpec =>
+  LayerSpec.make(
+    {
+      affinity,
+      requires: [CounterService, LoggerService],
+      provides: [CompositeService],
+    },
+    Layer.effect(
+      CompositeService,
+      Effect.gen(function* () {
+        compositeCreations++;
+        const counter = yield* CounterService;
+        const logger = yield* LoggerService;
+        return {
+          getCountAndLog: () => ({ count: counter.count(), logs: logger.logs() }),
+        };
+      }),
+    ),
+  );
 
 describe('ServiceMesh', () => {
   describe('basic operations', () => {
@@ -96,7 +102,7 @@ describe('ServiceMesh', () => {
       'creates and resolves application-scoped services',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('application')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterLayerSpec('application')]);
 
         const result = yield* mesh.run(
           Effect.gen(function* () {
@@ -116,7 +122,7 @@ describe('ServiceMesh', () => {
       'caches application-scoped services across multiple runs',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('application')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterLayerSpec('application')]);
 
         // First run.
         const result1 = yield* mesh.run(
@@ -146,7 +152,7 @@ describe('ServiceMesh', () => {
       'resolves space-scoped services with space context',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('space')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterLayerSpec('space')]);
         const spaceId = 'space-1' as SpaceId;
 
         const result = yield* mesh.run(
@@ -168,7 +174,7 @@ describe('ServiceMesh', () => {
       'creates separate instances for different spaces',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('space')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterLayerSpec('space')]);
         const space1 = 'space-1' as SpaceId;
         const space2 = 'space-2' as SpaceId;
 
@@ -200,7 +206,7 @@ describe('ServiceMesh', () => {
       'resolves process-scoped services with process context',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('process')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterLayerSpec('process')]);
 
         const result = yield* mesh.run(
           Effect.gen(function* () {
@@ -221,7 +227,7 @@ describe('ServiceMesh', () => {
       'creates separate instances for different processes',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('process')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterLayerSpec('process')]);
 
         const result1 = yield* mesh.run(
           Effect.gen(function* () {
@@ -254,9 +260,9 @@ describe('ServiceMesh', () => {
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
         const mesh = new ServiceMesh.ServiceMesh([
-          makeCounterService('application'),
-          makeLoggerService('application'),
-          makeCompositeService('application'),
+          makeCounterLayerSpec('application'),
+          makeLoggerLayerSpec('application'),
+          makeCompositeLayerSpec('application'),
         ]);
 
         const result = yield* mesh.run(
@@ -276,14 +282,14 @@ describe('ServiceMesh', () => {
     );
 
     it.effect(
-      'topologically sorts services within affinity',
+      'topologically sorts layer specs within affinity',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        // Add services in reverse dependency order.
+        // Add layer specs in reverse dependency order.
         const mesh = new ServiceMesh.ServiceMesh([
-          makeCompositeService('application'),
-          makeLoggerService('application'),
-          makeCounterService('application'),
+          makeCompositeLayerSpec('application'),
+          makeLoggerLayerSpec('application'),
+          makeCounterLayerSpec('application'),
         ]);
 
         const result = yield* mesh.run(
@@ -305,12 +311,12 @@ describe('ServiceMesh', () => {
 
   describe('add and remove', () => {
     it.effect(
-      'adds services dynamically',
+      'adds layer specs dynamically',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
         const mesh = new ServiceMesh.ServiceMesh();
 
-        mesh.add(makeCounterService('application'));
+        mesh.add(makeCounterLayerSpec('application'));
 
         const result = yield* mesh.run(
           Effect.gen(function* () {
@@ -326,13 +332,13 @@ describe('ServiceMesh', () => {
     );
 
     it.effect(
-      'removes services',
+      'removes layer specs',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const counterService = makeCounterService('application');
-        const mesh = new ServiceMesh.ServiceMesh([counterService]);
+        const counterLayerSpec = makeCounterLayerSpec('application');
+        const mesh = new ServiceMesh.ServiceMesh([counterLayerSpec]);
 
-        mesh.remove(counterService);
+        mesh.remove(counterLayerSpec);
 
         const result = yield* mesh
           .run(
@@ -355,7 +361,7 @@ describe('ServiceMesh', () => {
       'returns a resolver that can be used directly',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('application')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterLayerSpec('application')]);
 
         // Use mesh.run which handles the scope internally.
         const count = yield* mesh.run(
@@ -374,7 +380,7 @@ describe('ServiceMesh', () => {
       'cleans up space-scoped services when resolver scope closes',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('space')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterLayerSpec('space')]);
         const spaceId = 'space-cleanup' as SpaceId;
 
         // First run - creates the service.
@@ -408,7 +414,7 @@ describe('ServiceMesh', () => {
       'caches space-scoped services within same run',
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
-        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('space')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterLayerSpec('space')]);
         const spaceId = 'space-cache' as SpaceId;
 
         // Multiple resolves within the same run should use the same service instance.
@@ -441,9 +447,9 @@ describe('ServiceMesh', () => {
       Effect.fn(function* ({ expect }) {
         resetCreationCounters();
         const mesh = new ServiceMesh.ServiceMesh([
-          makeCounterService('application'),
-          makeCounterService('space'),
-          makeCounterService('process'),
+          makeCounterLayerSpec('application'),
+          makeCounterLayerSpec('space'),
+          makeCounterLayerSpec('process'),
         ]);
 
         // Create instances of each affinity.
@@ -487,7 +493,7 @@ describe('ServiceMesh', () => {
     it.effect(
       'fails when space-scoped service is requested without space context',
       Effect.fn(function* ({ expect }) {
-        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('space')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterLayerSpec('space')]);
 
         const result = yield* mesh
           .run(
@@ -506,7 +512,7 @@ describe('ServiceMesh', () => {
     it.effect(
       'fails when process-scoped service is requested without process context',
       Effect.fn(function* ({ expect }) {
-        const mesh = new ServiceMesh.ServiceMesh([makeCounterService('process')]);
+        const mesh = new ServiceMesh.ServiceMesh([makeCounterLayerSpec('process')]);
 
         const result = yield* mesh
           .run(
@@ -550,7 +556,7 @@ describe('ServiceMesh', () => {
 
         const result = yield* Effect.gen(function* () {
           const mesh = yield* ServiceMesh.ServiceMeshService;
-          mesh.add(makeCounterService('application'));
+          mesh.add(makeCounterLayerSpec('application'));
 
           return yield* mesh.run(
             Effect.gen(function* () {

--- a/packages/core/functions-runtime/src/process/ServiceMesh.ts
+++ b/packages/core/functions-runtime/src/process/ServiceMesh.ts
@@ -171,31 +171,31 @@ export class ServiceMesh {
       const resolver = ServiceResolver.make(
         <I, S>(tag: Context.Tag<I, S>, resolutionContext: ServiceResolver.ResolutionContext) =>
           Effect.gen(this, function* () {
-          const service = this.#findServiceForTag(tag);
-          if (!service) {
-            return yield* Effect.fail(new ServiceNotAvailableError(String(tag.key ?? tag)));
-          }
+            const service = this.#findServiceForTag(tag);
+            if (!service) {
+              return yield* Effect.fail(new ServiceNotAvailableError(String(tag.key ?? tag)));
+            }
 
-          // Merge resolution contexts.
-          const mergedContext: ResolutionContext = {
-            space: resolutionContext.space ?? context.space,
-            pid: resolutionContext.process ?? context.pid,
-          };
+            // Merge resolution contexts.
+            const mergedContext: ResolutionContext = {
+              space: resolutionContext.space ?? context.space,
+              pid: resolutionContext.process ?? context.pid,
+            };
 
-          // Get or create the service instance based on affinity.
-          const instance = yield* this.#getOrCreateInstance(
-            service,
-            mergedContext,
-            acquiredSpaceRefs,
-            acquiredProcessRefs,
-          );
+            // Get or create the service instance based on affinity.
+            const instance = yield* this.#getOrCreateInstance(
+              service,
+              mergedContext,
+              acquiredSpaceRefs,
+              acquiredProcessRefs,
+            );
 
-          const serviceValue = Context.getOption(instance.context, tag);
-          if (Option.isNone(serviceValue)) {
-            return yield* Effect.fail(new ServiceNotAvailableError(String(tag.key ?? tag)));
-          }
+            const serviceValue = Context.getOption(instance.context, tag);
+            if (Option.isNone(serviceValue)) {
+              return yield* Effect.fail(new ServiceNotAvailableError(String(tag.key ?? tag)));
+            }
 
-          return serviceValue.value as S;
+            return serviceValue.value as S;
           }),
       );
 
@@ -373,7 +373,9 @@ export class ServiceMesh {
         case 'space': {
           if (!context.space) {
             return yield* Effect.fail(
-              new ServiceNotAvailableError(`Space-scoped service requires space context: ${this.#getServiceName(service)}`),
+              new ServiceNotAvailableError(
+                `Space-scoped service requires space context: ${this.#getServiceName(service)}`,
+              ),
             );
           }
           const key = this.#getSpaceCacheKey(service, context.space);
@@ -394,7 +396,9 @@ export class ServiceMesh {
         case 'process': {
           if (!context.pid) {
             return yield* Effect.fail(
-              new ServiceNotAvailableError(`Process-scoped service requires process context: ${this.#getServiceName(service)}`),
+              new ServiceNotAvailableError(
+                `Process-scoped service requires process context: ${this.#getServiceName(service)}`,
+              ),
             );
           }
           const key = this.#getProcessCacheKey(service, context.pid);
@@ -432,7 +436,9 @@ export class ServiceMesh {
       const builtContext = yield* Layer.buildWithScope(service.layer, instanceScope).pipe(
         Effect.provide(dependencyContext),
         Effect.catchAll((error) =>
-          Effect.fail(new ServiceNotAvailableError(`Failed to build service ${this.#getServiceName(service)}: ${error}`)),
+          Effect.fail(
+            new ServiceNotAvailableError(`Failed to build service ${this.#getServiceName(service)}: ${error}`),
+          ),
         ),
       );
 

--- a/packages/core/functions-runtime/src/process/ServiceMesh.ts
+++ b/packages/core/functions-runtime/src/process/ServiceMesh.ts
@@ -131,11 +131,19 @@ export class ServiceMesh {
     effect: Effect.Effect<A, E, R | ServiceResolver.ServiceResolver>,
     context: ResolutionContext = {},
   ): Effect.Effect<A, E, Exclude<R, ServiceResolver.ServiceResolver | Scope.Scope>> {
-    return Effect.scoped(
-      Effect.flatMap(this.getResolver(context), (resolver) =>
-        effect.pipe(Effect.provideService(ServiceResolver.ServiceResolver, resolver)),
-      ),
-    ) as Effect.Effect<A, E, Exclude<R, ServiceResolver.ServiceResolver | Scope.Scope>>;
+    return effect.pipe(Effect.provide(this.getResolverLayer(context))) as Effect.Effect<
+      A,
+      E,
+      Exclude<R, ServiceResolver.ServiceResolver | Scope.Scope>
+    >;
+  }
+
+  /**
+   * Get a layer that provides a service resolver for the given context.
+   * The layer is scoped - when the scope closes, reference counts are decremented.
+   */
+  getResolverLayer(context: ResolutionContext = {}): Layer.Layer<ServiceResolver.ServiceResolver, never, Scope.Scope> {
+    return Layer.scoped(ServiceResolver.ServiceResolver, this.getResolver(context));
   }
 
   /**
@@ -362,7 +370,7 @@ export class ServiceMesh {
           const key = this.#getApplicationCacheKey(spec);
           let instance = this.#applicationCache.get(key);
           if (!instance) {
-            instance = yield* this.#createInstance(spec, context);
+            instance = yield* this.#createInstance(spec, context, acquiredSpaceRefs, acquiredProcessRefs);
             this.#applicationCache.set(key, instance);
             log('ServiceMesh: created application service', { key });
           }
@@ -380,7 +388,7 @@ export class ServiceMesh {
           const key = this.#getSpaceCacheKey(spec, context.space);
           let instance = this.#spaceCache.get(key);
           if (!instance) {
-            instance = yield* this.#createInstance(spec, context);
+            instance = yield* this.#createInstance(spec, context, acquiredSpaceRefs, acquiredProcessRefs);
             this.#spaceCache.set(key, instance);
             log('ServiceMesh: created space service', { key, space: context.space });
           }
@@ -403,7 +411,7 @@ export class ServiceMesh {
           const key = this.#getProcessCacheKey(spec, context.pid);
           let instance = this.#processCache.get(key);
           if (!instance) {
-            instance = yield* this.#createInstance(spec, context);
+            instance = yield* this.#createInstance(spec, context, acquiredSpaceRefs, acquiredProcessRefs);
             this.#processCache.set(key, instance);
             log('ServiceMesh: created process service', { key, pid: context.pid });
           }
@@ -424,12 +432,19 @@ export class ServiceMesh {
   #createInstance(
     spec: LayerSpec.LayerSpec,
     context: ResolutionContext,
+    acquiredSpaceRefs: Set<CacheKey>,
+    acquiredProcessRefs: Set<CacheKey>,
   ): Effect.Effect<CachedInstance, ServiceNotAvailableError, Scope.Scope> {
     return Effect.gen(this, function* () {
       const instanceScope = yield* Scope.make();
 
-      // Resolve dependencies.
-      const dependencyContext = yield* this.#resolveDependencies(spec, context);
+      // Resolve dependencies - pass through the acquired refs for proper reference counting.
+      const dependencyContext = yield* this.#resolveDependencies(
+        spec,
+        context,
+        acquiredSpaceRefs,
+        acquiredProcessRefs,
+      );
 
       // Build the service layer.
       const builtContext = yield* Layer.buildWithScope(spec.layer, instanceScope).pipe(
@@ -455,6 +470,8 @@ export class ServiceMesh {
   #resolveDependencies(
     spec: LayerSpec.LayerSpec,
     context: ResolutionContext,
+    acquiredSpaceRefs: Set<CacheKey>,
+    acquiredProcessRefs: Set<CacheKey>,
   ): Effect.Effect<Context.Context<any>, ServiceNotAvailableError, Scope.Scope> {
     return Effect.gen(this, function* () {
       let result: Context.Context<any> = Context.empty() as Context.Context<any>;
@@ -462,8 +479,8 @@ export class ServiceMesh {
       for (const tag of spec.requires) {
         const depSpec = this.#findLayerSpecForTag(tag);
         if (depSpec) {
-          // Recursively resolve dependency.
-          const instance = yield* this.#getOrCreateInstance(depSpec, context, new Set(), new Set());
+          // Recursively resolve dependency with proper reference counting.
+          const instance = yield* this.#getOrCreateInstance(depSpec, context, acquiredSpaceRefs, acquiredProcessRefs);
           result = Context.merge(result, instance.context);
         }
       }

--- a/packages/core/functions-runtime/src/process/ServiceMesh.ts
+++ b/packages/core/functions-runtime/src/process/ServiceMesh.ts
@@ -16,7 +16,7 @@ import { ServiceNotAvailableError, ServiceResolver } from '@dxos/functions';
 import type { SpaceId } from '@dxos/keys';
 import { log } from '@dxos/log';
 
-import * as Service from './Service';
+import * as LayerSpec from './LayerSpec';
 
 /**
  * Context key for a space-scoped resolution.
@@ -64,8 +64,8 @@ interface CachedInstance {
  * Services within each affinity are topologically sorted by their dependencies.
  */
 export class ServiceMesh {
-  readonly #services: Service.Service[] = [];
-  readonly #sortedByAffinity = new Map<Service.Affinity, Service.Service[]>();
+  readonly #layerSpecs: LayerSpec.LayerSpec[] = [];
+  readonly #sortedByAffinity = new Map<LayerSpec.Affinity, LayerSpec.LayerSpec[]>();
 
   /**
    * Application-level cache (lives until destroy).
@@ -84,43 +84,43 @@ export class ServiceMesh {
 
   #destroyed = false;
 
-  constructor(services: Service.Service[] = []) {
-    this.add(services);
+  constructor(layerSpecs: LayerSpec.LayerSpec[] = []) {
+    this.add(layerSpecs);
   }
 
   /**
-   * Add services to the mesh.
+   * Add layer specs to the mesh.
    */
-  add(services: Service.Service | Service.Service[]): void {
+  add(layerSpecs: LayerSpec.LayerSpec | LayerSpec.LayerSpec[]): void {
     if (this.#destroyed) {
       throw new Error('ServiceMesh has been destroyed');
     }
 
-    const toAdd = Array.isArray(services) ? services : [services];
-    for (const service of toAdd) {
-      if (!this.#services.includes(service)) {
-        this.#services.push(service);
+    const toAdd = Array.isArray(layerSpecs) ? layerSpecs : [layerSpecs];
+    for (const spec of toAdd) {
+      if (!this.#layerSpecs.includes(spec)) {
+        this.#layerSpecs.push(spec);
       }
     }
-    this.#rebuildSortedServices();
+    this.#rebuildSortedLayerSpecs();
   }
 
   /**
-   * Remove services from the mesh.
+   * Remove layer specs from the mesh.
    */
-  remove(services: Service.Service | Service.Service[]): void {
+  remove(layerSpecs: LayerSpec.LayerSpec | LayerSpec.LayerSpec[]): void {
     if (this.#destroyed) {
       throw new Error('ServiceMesh has been destroyed');
     }
 
-    const toRemove = Array.isArray(services) ? services : [services];
-    for (const service of toRemove) {
-      const index = this.#services.indexOf(service);
+    const toRemove = Array.isArray(layerSpecs) ? layerSpecs : [layerSpecs];
+    for (const spec of toRemove) {
+      const index = this.#layerSpecs.indexOf(spec);
       if (index !== -1) {
-        this.#services.splice(index, 1);
+        this.#layerSpecs.splice(index, 1);
       }
     }
-    this.#rebuildSortedServices();
+    this.#rebuildSortedLayerSpecs();
   }
 
   /**
@@ -170,8 +170,8 @@ export class ServiceMesh {
       const resolver = ServiceResolver.make(
         <I, S>(tag: Context.Tag<I, S>, resolutionContext: ServiceResolver.ResolutionContext) =>
           Effect.gen(this, function* () {
-            const service = this.#findServiceForTag(tag);
-            if (!service) {
+            const spec = this.#findLayerSpecForTag(tag);
+            if (!spec) {
               return yield* Effect.fail(new ServiceNotAvailableError(String(tag.key ?? tag)));
             }
 
@@ -183,7 +183,7 @@ export class ServiceMesh {
 
             // Get or create the service instance based on affinity.
             const instance = yield* this.#getOrCreateInstance(
-              service,
+              spec,
               mergedContext,
               acquiredSpaceRefs,
               acquiredProcessRefs,
@@ -235,7 +235,7 @@ export class ServiceMesh {
       }
       this.#processCache.clear();
 
-      this.#services.length = 0;
+      this.#layerSpecs.length = 0;
       this.#sortedByAffinity.clear();
 
       log('ServiceMesh: destroyed');
@@ -243,77 +243,77 @@ export class ServiceMesh {
   }
 
   /**
-   * Rebuild the topologically sorted service lists for each affinity.
+   * Rebuild the topologically sorted layer spec lists for each affinity.
    */
-  #rebuildSortedServices(): void {
+  #rebuildSortedLayerSpecs(): void {
     this.#sortedByAffinity.clear();
 
-    const byAffinity = new Map<Service.Affinity, Service.Service[]>();
-    for (const service of this.#services) {
-      const list = byAffinity.get(service.affinity) ?? [];
-      list.push(service);
-      byAffinity.set(service.affinity, list);
+    const byAffinity = new Map<LayerSpec.Affinity, LayerSpec.LayerSpec[]>();
+    for (const spec of this.#layerSpecs) {
+      const list = byAffinity.get(spec.affinity) ?? [];
+      list.push(spec);
+      byAffinity.set(spec.affinity, list);
     }
 
-    for (const [affinity, services] of byAffinity) {
-      this.#sortedByAffinity.set(affinity, this.#topologicalSort(services));
+    for (const [affinity, specs] of byAffinity) {
+      this.#sortedByAffinity.set(affinity, this.#topologicalSort(specs));
     }
   }
 
   /**
-   * Topologically sort services based on their dependencies.
-   * Services that provide dependencies come before services that require them.
+   * Topologically sort layer specs based on their dependencies.
+   * Specs that provide dependencies come before specs that require them.
    */
-  #topologicalSort(services: Service.Service[]): Service.Service[] {
-    // Build a map of tag keys to services that provide them.
-    const providersMap = new Map<string, Service.Service>();
-    for (const service of services) {
-      for (const tag of service.provides) {
-        providersMap.set(tag.key, service);
+  #topologicalSort(specs: LayerSpec.LayerSpec[]): LayerSpec.LayerSpec[] {
+    // Build a map of tag keys to specs that provide them.
+    const providersMap = new Map<string, LayerSpec.LayerSpec>();
+    for (const spec of specs) {
+      for (const tag of spec.provides) {
+        providersMap.set(tag.key, spec);
       }
     }
 
-    // Build adjacency list: service -> services it depends on.
-    const dependencies = new Map<Service.Service, Set<Service.Service>>();
-    for (const service of services) {
-      const deps = new Set<Service.Service>();
-      for (const tag of service.requires) {
+    // Build adjacency list: spec -> specs it depends on.
+    const dependencies = new Map<LayerSpec.LayerSpec, Set<LayerSpec.LayerSpec>>();
+    for (const spec of specs) {
+      const deps = new Set<LayerSpec.LayerSpec>();
+      for (const tag of spec.requires) {
         const provider = providersMap.get(tag.key);
-        if (provider && provider !== service && services.includes(provider)) {
+        if (provider && provider !== spec && specs.includes(provider)) {
           deps.add(provider);
         }
       }
-      dependencies.set(service, deps);
+      dependencies.set(spec, deps);
     }
 
     // Kahn's algorithm for topological sort.
-    const result: Service.Service[] = [];
-    const inDegree = new Map<Service.Service, number>();
-    const queue: Service.Service[] = [];
+    const result: LayerSpec.LayerSpec[] = [];
+    const inDegree = new Map<LayerSpec.LayerSpec, number>();
+    const queue: LayerSpec.LayerSpec[] = [];
 
     // Calculate in-degrees.
-    for (const service of services) {
-      inDegree.set(service, 0);
+    for (const spec of specs) {
+      inDegree.set(spec, 0);
     }
-    for (const [service, deps] of dependencies) {
+    for (const [spec, deps] of dependencies) {
       for (const dep of deps) {
         inDegree.set(dep, (inDegree.get(dep) ?? 0) + 1);
       }
     }
 
-    // Find services with no dependents (in-degree 0).
-    for (const [service, degree] of inDegree) {
+    // Find specs with no dependents (in-degree 0).
+    for (const [spec, degree] of inDegree) {
       if (degree === 0) {
-        queue.push(service);
+        queue.push(spec);
       }
     }
 
     // Process queue.
     while (queue.length > 0) {
-      const service = queue.shift()!;
-      result.push(service);
+      const spec = queue.shift()!;
+      result.push(spec);
 
-      const deps = dependencies.get(service) ?? new Set();
+      const deps = dependencies.get(spec) ?? new Set();
       for (const dep of deps) {
         const newDegree = (inDegree.get(dep) ?? 0) - 1;
         inDegree.set(dep, newDegree);
@@ -323,10 +323,10 @@ export class ServiceMesh {
       }
     }
 
-    // If we couldn't sort all services, there's a cycle - just return original order.
-    if (result.length !== services.length) {
-      log.warn('ServiceMesh: cycle detected in service dependencies, using original order');
-      return services;
+    // If we couldn't sort all specs, there's a cycle - just return original order.
+    if (result.length !== specs.length) {
+      log.warn('ServiceMesh: cycle detected in layer spec dependencies, using original order');
+      return specs;
     }
 
     // Reverse to get dependencies first.
@@ -334,13 +334,13 @@ export class ServiceMesh {
   }
 
   /**
-   * Find the service that provides the given tag.
+   * Find the layer spec that provides the given tag.
    */
-  #findServiceForTag(tag: Context.Tag<any, any>): Service.Service | undefined {
-    for (const service of this.#services) {
-      for (const providedTag of service.provides) {
+  #findLayerSpecForTag(tag: Context.Tag<any, any>): LayerSpec.LayerSpec | undefined {
+    for (const spec of this.#layerSpecs) {
+      for (const providedTag of spec.provides) {
         if (providedTag.key === tag.key) {
-          return service;
+          return spec;
         }
       }
     }
@@ -351,18 +351,18 @@ export class ServiceMesh {
    * Get or create a service instance based on its affinity.
    */
   #getOrCreateInstance(
-    service: Service.Service,
+    spec: LayerSpec.LayerSpec,
     context: ResolutionContext,
     acquiredSpaceRefs: Set<CacheKey>,
     acquiredProcessRefs: Set<CacheKey>,
   ): Effect.Effect<CachedInstance, ServiceNotAvailableError, Scope.Scope> {
     return Effect.gen(this, function* () {
-      switch (service.affinity) {
+      switch (spec.affinity) {
         case 'application': {
-          const key = this.#getApplicationCacheKey(service);
+          const key = this.#getApplicationCacheKey(spec);
           let instance = this.#applicationCache.get(key);
           if (!instance) {
-            instance = yield* this.#createInstance(service, context);
+            instance = yield* this.#createInstance(spec, context);
             this.#applicationCache.set(key, instance);
             log('ServiceMesh: created application service', { key });
           }
@@ -373,14 +373,14 @@ export class ServiceMesh {
           if (!context.space) {
             return yield* Effect.fail(
               new ServiceNotAvailableError(
-                `Space-scoped service requires space context: ${this.#getServiceName(service)}`,
+                `Space-scoped service requires space context: ${this.#getLayerSpecName(spec)}`,
               ),
             );
           }
-          const key = this.#getSpaceCacheKey(service, context.space);
+          const key = this.#getSpaceCacheKey(spec, context.space);
           let instance = this.#spaceCache.get(key);
           if (!instance) {
-            instance = yield* this.#createInstance(service, context);
+            instance = yield* this.#createInstance(spec, context);
             this.#spaceCache.set(key, instance);
             log('ServiceMesh: created space service', { key, space: context.space });
           }
@@ -396,14 +396,14 @@ export class ServiceMesh {
           if (!context.pid) {
             return yield* Effect.fail(
               new ServiceNotAvailableError(
-                `Process-scoped service requires process context: ${this.#getServiceName(service)}`,
+                `Process-scoped service requires process context: ${this.#getLayerSpecName(spec)}`,
               ),
             );
           }
-          const key = this.#getProcessCacheKey(service, context.pid);
+          const key = this.#getProcessCacheKey(spec, context.pid);
           let instance = this.#processCache.get(key);
           if (!instance) {
-            instance = yield* this.#createInstance(service, context);
+            instance = yield* this.#createInstance(spec, context);
             this.#processCache.set(key, instance);
             log('ServiceMesh: created process service', { key, pid: context.pid });
           }
@@ -422,21 +422,21 @@ export class ServiceMesh {
    * Create a new service instance.
    */
   #createInstance(
-    service: Service.Service,
+    spec: LayerSpec.LayerSpec,
     context: ResolutionContext,
   ): Effect.Effect<CachedInstance, ServiceNotAvailableError, Scope.Scope> {
     return Effect.gen(this, function* () {
       const instanceScope = yield* Scope.make();
 
       // Resolve dependencies.
-      const dependencyContext = yield* this.#resolveDependencies(service, context);
+      const dependencyContext = yield* this.#resolveDependencies(spec, context);
 
       // Build the service layer.
-      const builtContext = yield* Layer.buildWithScope(service.layer, instanceScope).pipe(
+      const builtContext = yield* Layer.buildWithScope(spec.layer, instanceScope).pipe(
         Effect.provide(dependencyContext),
         Effect.catchAll((error) =>
           Effect.fail(
-            new ServiceNotAvailableError(`Failed to build service ${this.#getServiceName(service)}: ${error}`),
+            new ServiceNotAvailableError(`Failed to build service ${this.#getLayerSpecName(spec)}: ${error}`),
           ),
         ),
       );
@@ -450,20 +450,20 @@ export class ServiceMesh {
   }
 
   /**
-   * Resolve dependencies for a service.
+   * Resolve dependencies for a layer spec.
    */
   #resolveDependencies(
-    service: Service.Service,
+    spec: LayerSpec.LayerSpec,
     context: ResolutionContext,
   ): Effect.Effect<Context.Context<any>, ServiceNotAvailableError, Scope.Scope> {
     return Effect.gen(this, function* () {
       let result: Context.Context<any> = Context.empty() as Context.Context<any>;
 
-      for (const tag of service.requires) {
-        const depService = this.#findServiceForTag(tag);
-        if (depService) {
+      for (const tag of spec.requires) {
+        const depSpec = this.#findLayerSpecForTag(tag);
+        if (depSpec) {
           // Recursively resolve dependency.
-          const instance = yield* this.#getOrCreateInstance(depService, context, new Set(), new Set());
+          const instance = yield* this.#getOrCreateInstance(depSpec, context, new Set(), new Set());
           result = Context.merge(result, instance.context);
         }
       }
@@ -489,20 +489,20 @@ export class ServiceMesh {
     }
   }
 
-  #getApplicationCacheKey(service: Service.Service): string {
-    return service.provides.map((tag) => tag.key).join(',');
+  #getApplicationCacheKey(spec: LayerSpec.LayerSpec): string {
+    return spec.provides.map((tag) => tag.key).join(',');
   }
 
-  #getSpaceCacheKey(service: Service.Service, space: SpaceId): string {
-    return `${space}:${service.provides.map((tag) => tag.key).join(',')}`;
+  #getSpaceCacheKey(spec: LayerSpec.LayerSpec, space: SpaceId): string {
+    return `${space}:${spec.provides.map((tag) => tag.key).join(',')}`;
   }
 
-  #getProcessCacheKey(service: Service.Service, pid: string): string {
-    return `${pid}:${service.provides.map((tag) => tag.key).join(',')}`;
+  #getProcessCacheKey(spec: LayerSpec.LayerSpec, pid: string): string {
+    return `${pid}:${spec.provides.map((tag) => tag.key).join(',')}`;
   }
 
-  #getServiceName(service: Service.Service): string {
-    return service.provides.map((tag) => String(tag.key ?? tag)).join(', ');
+  #getLayerSpecName(spec: LayerSpec.LayerSpec): string {
+    return spec.provides.map((tag) => String(tag.key ?? tag)).join(', ');
   }
 }
 
@@ -517,11 +517,11 @@ export class ServiceMeshService extends Context.Tag('@dxos/functions-runtime/Ser
 /**
  * Create a layer that provides a ServiceMesh.
  */
-export const layer = (services: Service.Service[] = []): Layer.Layer<ServiceMeshService> =>
+export const layer = (layerSpecs: LayerSpec.LayerSpec[] = []): Layer.Layer<ServiceMeshService> =>
   Layer.scoped(
     ServiceMeshService,
     Effect.gen(function* () {
-      const mesh = new ServiceMesh(services);
+      const mesh = new ServiceMesh(layerSpecs);
       yield* Effect.addFinalizer(() => mesh.destroy());
       return mesh;
     }),

--- a/packages/core/functions-runtime/src/process/ServiceMesh.ts
+++ b/packages/core/functions-runtime/src/process/ServiceMesh.ts
@@ -1,0 +1,523 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+// @import-as-namespace
+
+import * as Context from 'effect/Context';
+import * as Effect from 'effect/Effect';
+import * as Exit from 'effect/Exit';
+import * as Layer from 'effect/Layer';
+import * as MutableRef from 'effect/MutableRef';
+import * as Option from 'effect/Option';
+import * as Scope from 'effect/Scope';
+
+import { ServiceNotAvailableError, ServiceResolver } from '@dxos/functions';
+import type { SpaceId } from '@dxos/keys';
+import { log } from '@dxos/log';
+
+import * as Service from './Service';
+
+/**
+ * Context key for a space-scoped resolution.
+ */
+export interface SpaceContext {
+  readonly space: SpaceId;
+}
+
+/**
+ * Context key for a process-scoped resolution.
+ */
+export interface ProcessContext {
+  readonly pid: string;
+}
+
+/**
+ * Resolution context for service mesh.
+ */
+export type ResolutionContext = {
+  readonly space?: SpaceId;
+  readonly pid?: string;
+};
+
+/**
+ * Internal cache key for affinity-based service instances.
+ */
+type CacheKey = string;
+
+/**
+ * Cached layer instance with its scope.
+ */
+interface CachedInstance {
+  readonly context: Context.Context<any>;
+  readonly scope: Scope.CloseableScope;
+  readonly refCount: MutableRef.MutableRef<number>;
+}
+
+/**
+ * ServiceMesh manages services with three affinities:
+ * - `application` - single instance lives until destroy() is called.
+ * - `space` - instance per space, lives until scope on getResolver is closed.
+ * - `process` - instance per process, lives until scope on getResolver is closed.
+ *
+ * Services are lazily loaded and cached based on their affinity.
+ * Services within each affinity are topologically sorted by their dependencies.
+ */
+export class ServiceMesh {
+  readonly #services: Service.Service[] = [];
+  readonly #sortedByAffinity = new Map<Service.Affinity, Service.Service[]>();
+
+  /**
+   * Application-level cache (lives until destroy).
+   */
+  readonly #applicationCache = new Map<string, CachedInstance>();
+
+  /**
+   * Space-level cache (reference counted, lives until all resolvers are closed).
+   */
+  readonly #spaceCache = new Map<CacheKey, CachedInstance>();
+
+  /**
+   * Process-level cache (reference counted, lives until all resolvers are closed).
+   */
+  readonly #processCache = new Map<CacheKey, CachedInstance>();
+
+  #destroyed = false;
+
+  constructor(services: Service.Service[] = []) {
+    this.add(services);
+  }
+
+  /**
+   * Add services to the mesh.
+   */
+  add(services: Service.Service | Service.Service[]): void {
+    if (this.#destroyed) {
+      throw new Error('ServiceMesh has been destroyed');
+    }
+
+    const toAdd = Array.isArray(services) ? services : [services];
+    for (const service of toAdd) {
+      if (!this.#services.includes(service)) {
+        this.#services.push(service);
+      }
+    }
+    this.#rebuildSortedServices();
+  }
+
+  /**
+   * Remove services from the mesh.
+   */
+  remove(services: Service.Service | Service.Service[]): void {
+    if (this.#destroyed) {
+      throw new Error('ServiceMesh has been destroyed');
+    }
+
+    const toRemove = Array.isArray(services) ? services : [services];
+    for (const service of toRemove) {
+      const index = this.#services.indexOf(service);
+      if (index !== -1) {
+        this.#services.splice(index, 1);
+      }
+    }
+    this.#rebuildSortedServices();
+  }
+
+  /**
+   * Run an effect with a service resolver provided for the given context.
+   * The resolver scope is tied to the effect's scope.
+   */
+  run<A, E, R>(
+    effect: Effect.Effect<A, E, R | ServiceResolver.ServiceResolver>,
+    context: ResolutionContext = {},
+  ): Effect.Effect<A, E, Exclude<R, ServiceResolver.ServiceResolver>> {
+    return Effect.scoped(
+      Effect.gen(this, function* () {
+        const resolver = yield* this.getResolver(context);
+        return yield* effect.pipe(Effect.provideService(ServiceResolver.ServiceResolver, resolver));
+      }),
+    ) as Effect.Effect<A, E, Exclude<R, ServiceResolver.ServiceResolver>>;
+  }
+
+  /**
+   * Get a service resolver for the given context.
+   * The scope parameter controls the lifetime of space/process-scoped services.
+   * When the scope is closed, reference counts are decremented and services may be cleaned up.
+   */
+  getResolver(context: ResolutionContext = {}): Effect.Effect<ServiceResolver.ServiceResolver, never, Scope.Scope> {
+    return Effect.gen(this, function* () {
+      if (this.#destroyed) {
+        return yield* Effect.die('ServiceMesh has been destroyed');
+      }
+
+      const scope = yield* Scope.Scope;
+
+      // Track which caches we've acquired references to.
+      const acquiredSpaceRefs = new Set<CacheKey>();
+      const acquiredProcessRefs = new Set<CacheKey>();
+
+      // Add finalizer to decrement reference counts when scope closes.
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          for (const key of acquiredSpaceRefs) {
+            this.#decrementRef(this.#spaceCache, key);
+          }
+          for (const key of acquiredProcessRefs) {
+            this.#decrementRef(this.#processCache, key);
+          }
+        }),
+      );
+
+      const resolver = ServiceResolver.make(
+        <I, S>(tag: Context.Tag<I, S>, resolutionContext: ServiceResolver.ResolutionContext) =>
+          Effect.gen(this, function* () {
+          const service = this.#findServiceForTag(tag);
+          if (!service) {
+            return yield* Effect.fail(new ServiceNotAvailableError(String(tag.key ?? tag)));
+          }
+
+          // Merge resolution contexts.
+          const mergedContext: ResolutionContext = {
+            space: resolutionContext.space ?? context.space,
+            pid: resolutionContext.process ?? context.pid,
+          };
+
+          // Get or create the service instance based on affinity.
+          const instance = yield* this.#getOrCreateInstance(
+            service,
+            mergedContext,
+            acquiredSpaceRefs,
+            acquiredProcessRefs,
+          );
+
+          const serviceValue = Context.getOption(instance.context, tag);
+          if (Option.isNone(serviceValue)) {
+            return yield* Effect.fail(new ServiceNotAvailableError(String(tag.key ?? tag)));
+          }
+
+          return serviceValue.value as S;
+          }),
+      );
+
+      return resolver;
+    });
+  }
+
+  /**
+   * Destroy the service mesh and clean up all cached services.
+   */
+  destroy(): Effect.Effect<void> {
+    return Effect.gen(this, function* () {
+      if (this.#destroyed) {
+        return;
+      }
+      this.#destroyed = true;
+
+      log('ServiceMesh: destroying');
+
+      // Close all application-scoped services.
+      for (const [key, instance] of this.#applicationCache) {
+        log('ServiceMesh: closing application service', { key });
+        yield* Scope.close(instance.scope, Exit.void);
+      }
+      this.#applicationCache.clear();
+
+      // Close all space-scoped services.
+      for (const [key, instance] of this.#spaceCache) {
+        log('ServiceMesh: closing space service', { key });
+        yield* Scope.close(instance.scope, Exit.void);
+      }
+      this.#spaceCache.clear();
+
+      // Close all process-scoped services.
+      for (const [key, instance] of this.#processCache) {
+        log('ServiceMesh: closing process service', { key });
+        yield* Scope.close(instance.scope, Exit.void);
+      }
+      this.#processCache.clear();
+
+      this.#services.length = 0;
+      this.#sortedByAffinity.clear();
+
+      log('ServiceMesh: destroyed');
+    });
+  }
+
+  /**
+   * Rebuild the topologically sorted service lists for each affinity.
+   */
+  #rebuildSortedServices(): void {
+    this.#sortedByAffinity.clear();
+
+    const byAffinity = new Map<Service.Affinity, Service.Service[]>();
+    for (const service of this.#services) {
+      const list = byAffinity.get(service.affinity) ?? [];
+      list.push(service);
+      byAffinity.set(service.affinity, list);
+    }
+
+    for (const [affinity, services] of byAffinity) {
+      this.#sortedByAffinity.set(affinity, this.#topologicalSort(services));
+    }
+  }
+
+  /**
+   * Topologically sort services based on their dependencies.
+   * Services that provide dependencies come before services that require them.
+   */
+  #topologicalSort(services: Service.Service[]): Service.Service[] {
+    // Build a map of tag keys to services that provide them.
+    const providersMap = new Map<string, Service.Service>();
+    for (const service of services) {
+      for (const tag of service.provides) {
+        providersMap.set(tag.key, service);
+      }
+    }
+
+    // Build adjacency list: service -> services it depends on.
+    const dependencies = new Map<Service.Service, Set<Service.Service>>();
+    for (const service of services) {
+      const deps = new Set<Service.Service>();
+      for (const tag of service.requires) {
+        const provider = providersMap.get(tag.key);
+        if (provider && provider !== service && services.includes(provider)) {
+          deps.add(provider);
+        }
+      }
+      dependencies.set(service, deps);
+    }
+
+    // Kahn's algorithm for topological sort.
+    const result: Service.Service[] = [];
+    const inDegree = new Map<Service.Service, number>();
+    const queue: Service.Service[] = [];
+
+    // Calculate in-degrees.
+    for (const service of services) {
+      inDegree.set(service, 0);
+    }
+    for (const [service, deps] of dependencies) {
+      for (const dep of deps) {
+        inDegree.set(dep, (inDegree.get(dep) ?? 0) + 1);
+      }
+    }
+
+    // Find services with no dependents (in-degree 0).
+    for (const [service, degree] of inDegree) {
+      if (degree === 0) {
+        queue.push(service);
+      }
+    }
+
+    // Process queue.
+    while (queue.length > 0) {
+      const service = queue.shift()!;
+      result.push(service);
+
+      const deps = dependencies.get(service) ?? new Set();
+      for (const dep of deps) {
+        const newDegree = (inDegree.get(dep) ?? 0) - 1;
+        inDegree.set(dep, newDegree);
+        if (newDegree === 0) {
+          queue.push(dep);
+        }
+      }
+    }
+
+    // If we couldn't sort all services, there's a cycle - just return original order.
+    if (result.length !== services.length) {
+      log.warn('ServiceMesh: cycle detected in service dependencies, using original order');
+      return services;
+    }
+
+    // Reverse to get dependencies first.
+    return result.reverse();
+  }
+
+  /**
+   * Find the service that provides the given tag.
+   */
+  #findServiceForTag(tag: Context.Tag<any, any>): Service.Service | undefined {
+    for (const service of this.#services) {
+      for (const providedTag of service.provides) {
+        if (providedTag.key === tag.key) {
+          return service;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Get or create a service instance based on its affinity.
+   */
+  #getOrCreateInstance(
+    service: Service.Service,
+    context: ResolutionContext,
+    acquiredSpaceRefs: Set<CacheKey>,
+    acquiredProcessRefs: Set<CacheKey>,
+  ): Effect.Effect<CachedInstance, ServiceResolver.ServiceNotAvailableError, Scope.Scope> {
+    return Effect.gen(this, function* () {
+      switch (service.affinity) {
+        case 'application': {
+          const key = this.#getApplicationCacheKey(service);
+          let instance = this.#applicationCache.get(key);
+          if (!instance) {
+            instance = yield* this.#createInstance(service, context);
+            this.#applicationCache.set(key, instance);
+            log('ServiceMesh: created application service', { key });
+          }
+          return instance;
+        }
+
+        case 'space': {
+          if (!context.space) {
+            return yield* Effect.fail(
+              new ServiceNotAvailableError(`Space-scoped service requires space context: ${this.#getServiceName(service)}`),
+            );
+          }
+          const key = this.#getSpaceCacheKey(service, context.space);
+          let instance = this.#spaceCache.get(key);
+          if (!instance) {
+            instance = yield* this.#createInstance(service, context);
+            this.#spaceCache.set(key, instance);
+            log('ServiceMesh: created space service', { key, space: context.space });
+          }
+          // Increment ref count if not already acquired.
+          if (!acquiredSpaceRefs.has(key)) {
+            MutableRef.update(instance.refCount, (count) => count + 1);
+            acquiredSpaceRefs.add(key);
+          }
+          return instance;
+        }
+
+        case 'process': {
+          if (!context.pid) {
+            return yield* Effect.fail(
+              new ServiceNotAvailableError(`Process-scoped service requires process context: ${this.#getServiceName(service)}`),
+            );
+          }
+          const key = this.#getProcessCacheKey(service, context.pid);
+          let instance = this.#processCache.get(key);
+          if (!instance) {
+            instance = yield* this.#createInstance(service, context);
+            this.#processCache.set(key, instance);
+            log('ServiceMesh: created process service', { key, pid: context.pid });
+          }
+          // Increment ref count if not already acquired.
+          if (!acquiredProcessRefs.has(key)) {
+            MutableRef.update(instance.refCount, (count) => count + 1);
+            acquiredProcessRefs.add(key);
+          }
+          return instance;
+        }
+      }
+    });
+  }
+
+  /**
+   * Create a new service instance.
+   */
+  #createInstance(
+    service: Service.Service,
+    context: ResolutionContext,
+  ): Effect.Effect<CachedInstance, ServiceResolver.ServiceNotAvailableError, Scope.Scope> {
+    return Effect.gen(this, function* () {
+      const instanceScope = yield* Scope.make();
+
+      // Resolve dependencies.
+      const dependencyContext = yield* this.#resolveDependencies(service, context);
+
+      // Build the service layer.
+      const builtContext = yield* Layer.buildWithScope(service.layer, instanceScope).pipe(
+        Effect.provide(dependencyContext),
+        Effect.catchAll((error) =>
+          Effect.fail(new ServiceNotAvailableError(`Failed to build service ${this.#getServiceName(service)}: ${error}`)),
+        ),
+      );
+
+      return {
+        context: builtContext,
+        scope: instanceScope,
+        refCount: MutableRef.make(0),
+      };
+    });
+  }
+
+  /**
+   * Resolve dependencies for a service.
+   */
+  #resolveDependencies(
+    service: Service.Service,
+    context: ResolutionContext,
+  ): Effect.Effect<Context.Context<any>, ServiceResolver.ServiceNotAvailableError, Scope.Scope> {
+    return Effect.gen(this, function* () {
+      let result: Context.Context<any> = Context.empty() as Context.Context<any>;
+
+      for (const tag of service.requires) {
+        const depService = this.#findServiceForTag(tag);
+        if (depService) {
+          // Recursively resolve dependency.
+          const instance = yield* this.#getOrCreateInstance(depService, context, new Set(), new Set());
+          result = Context.merge(result, instance.context);
+        }
+      }
+
+      return result;
+    });
+  }
+
+  /**
+   * Decrement reference count and clean up if zero.
+   */
+  #decrementRef(cache: Map<CacheKey, CachedInstance>, key: CacheKey): void {
+    const instance = cache.get(key);
+    if (!instance) {
+      return;
+    }
+
+    const newCount = MutableRef.updateAndGet(instance.refCount, (count) => Math.max(0, count - 1));
+    if (newCount === 0) {
+      log('ServiceMesh: cleaning up service', { key });
+      cache.delete(key);
+      Effect.runFork(Scope.close(instance.scope, Exit.void));
+    }
+  }
+
+  #getApplicationCacheKey(service: Service.Service): string {
+    return service.provides.map((tag) => tag.key).join(',');
+  }
+
+  #getSpaceCacheKey(service: Service.Service, space: SpaceId): string {
+    return `${space}:${service.provides.map((tag) => tag.key).join(',')}`;
+  }
+
+  #getProcessCacheKey(service: Service.Service, pid: string): string {
+    return `${pid}:${service.provides.map((tag) => tag.key).join(',')}`;
+  }
+
+  #getServiceName(service: Service.Service): string {
+    return service.provides.map((tag) => String(tag.key ?? tag)).join(', ');
+  }
+}
+
+/**
+ * Tag for the ServiceMesh service.
+ */
+export class ServiceMeshService extends Context.Tag('@dxos/functions-runtime/ServiceMeshService')<
+  ServiceMeshService,
+  ServiceMesh
+>() {}
+
+/**
+ * Create a layer that provides a ServiceMesh.
+ */
+export const layer = (services: Service.Service[] = []): Layer.Layer<ServiceMeshService> =>
+  Layer.scoped(
+    ServiceMeshService,
+    Effect.gen(function* () {
+      const mesh = new ServiceMesh(services);
+      yield* Effect.addFinalizer(() => mesh.destroy());
+      return mesh;
+    }),
+  );

--- a/packages/core/functions-runtime/src/process/ServiceMesh.ts
+++ b/packages/core/functions-runtime/src/process/ServiceMesh.ts
@@ -130,13 +130,12 @@ export class ServiceMesh {
   run<A, E, R>(
     effect: Effect.Effect<A, E, R | ServiceResolver.ServiceResolver>,
     context: ResolutionContext = {},
-  ): Effect.Effect<A, E, Exclude<R, ServiceResolver.ServiceResolver>> {
+  ): Effect.Effect<A, E, Exclude<R, ServiceResolver.ServiceResolver | Scope.Scope>> {
     return Effect.scoped(
-      Effect.gen(this, function* () {
-        const resolver = yield* this.getResolver(context);
-        return yield* effect.pipe(Effect.provideService(ServiceResolver.ServiceResolver, resolver));
-      }),
-    ) as Effect.Effect<A, E, Exclude<R, ServiceResolver.ServiceResolver>>;
+      Effect.flatMap(this.getResolver(context), (resolver) =>
+        effect.pipe(Effect.provideService(ServiceResolver.ServiceResolver, resolver)),
+      ),
+    ) as Effect.Effect<A, E, Exclude<R, ServiceResolver.ServiceResolver | Scope.Scope>>;
   }
 
   /**
@@ -356,7 +355,7 @@ export class ServiceMesh {
     context: ResolutionContext,
     acquiredSpaceRefs: Set<CacheKey>,
     acquiredProcessRefs: Set<CacheKey>,
-  ): Effect.Effect<CachedInstance, ServiceResolver.ServiceNotAvailableError, Scope.Scope> {
+  ): Effect.Effect<CachedInstance, ServiceNotAvailableError, Scope.Scope> {
     return Effect.gen(this, function* () {
       switch (service.affinity) {
         case 'application': {
@@ -425,7 +424,7 @@ export class ServiceMesh {
   #createInstance(
     service: Service.Service,
     context: ResolutionContext,
-  ): Effect.Effect<CachedInstance, ServiceResolver.ServiceNotAvailableError, Scope.Scope> {
+  ): Effect.Effect<CachedInstance, ServiceNotAvailableError, Scope.Scope> {
     return Effect.gen(this, function* () {
       const instanceScope = yield* Scope.make();
 
@@ -456,7 +455,7 @@ export class ServiceMesh {
   #resolveDependencies(
     service: Service.Service,
     context: ResolutionContext,
-  ): Effect.Effect<Context.Context<any>, ServiceResolver.ServiceNotAvailableError, Scope.Scope> {
+  ): Effect.Effect<Context.Context<any>, ServiceNotAvailableError, Scope.Scope> {
     return Effect.gen(this, function* () {
       let result: Context.Context<any> = Context.empty() as Context.Context<any>;
 

--- a/packages/core/functions-runtime/src/process/ServiceMesh.ts
+++ b/packages/core/functions-runtime/src/process/ServiceMesh.ts
@@ -439,12 +439,7 @@ export class ServiceMesh {
       const instanceScope = yield* Scope.make();
 
       // Resolve dependencies - pass through the acquired refs for proper reference counting.
-      const dependencyContext = yield* this.#resolveDependencies(
-        spec,
-        context,
-        acquiredSpaceRefs,
-        acquiredProcessRefs,
-      );
+      const dependencyContext = yield* this.#resolveDependencies(spec, context, acquiredSpaceRefs, acquiredProcessRefs);
 
       // Build the service layer.
       const builtContext = yield* Layer.buildWithScope(spec.layer, instanceScope).pipe(

--- a/packages/core/functions-runtime/src/process/index.ts
+++ b/packages/core/functions-runtime/src/process/index.ts
@@ -4,4 +4,6 @@
 
 export { Process, ServiceResolver } from '@dxos/functions';
 export * as ProcessManager from './ProcessManager';
+export * as Service from './Service';
+export * as ServiceMesh from './ServiceMesh';
 export * as StorageService from './StorageService';

--- a/packages/core/functions-runtime/src/process/index.ts
+++ b/packages/core/functions-runtime/src/process/index.ts
@@ -3,7 +3,7 @@
 //
 
 export { Process, ServiceResolver } from '@dxos/functions';
+export * as LayerSpec from './LayerSpec';
 export * as ProcessManager from './ProcessManager';
-export * as Service from './Service';
 export * as ServiceMesh from './ServiceMesh';
 export * as StorageService from './StorageService';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds a `ServiceMesh` class to manage services with three different affinities (application, space, process), as specified in DX-908.

## Changes

### LayerSpec.ts (renamed from Service.ts)

The `LayerSpec` module provides:

- **`LayerSpec` interface** - Untyped layer specification with introspectable tags
- **`LayerSpec.make(opts, layer)`** - Create a layer specification with:
  - `affinity` - application, space, or process
  - `requires` - array of required service tags
  - `provides` - array of provided service tags
  - `layer` - the Effect Layer implementation

### ServiceMesh.ts

The `ServiceMesh` class provides:

- **Three affinities for service lifetime management:**
  - `application` - single instance lives until `destroy()` is called
  - `space` - instance per space, lives until resolver scope closes (reference counted)
  - `process` - instance per process, lives until resolver scope closes (reference counted)

- **Core API:**
  - `new ServiceMesh(layerSpecs: LayerSpec[])` - create a mesh with initial layer specs
  - `serviceMesh.add(layerSpecs)` / `serviceMesh.remove(layerSpecs)` - dynamically add/remove layer specs
  - `serviceMesh.run(effect, { space?, pid? })` - run an effect with service resolver provided
  - `serviceMesh.getResolver({ space?, pid? })` - get a resolver for a specific context (scoped)
  - `serviceMesh.getResolverLayer({ space?, pid? })` - get a layer that provides the resolver (for cleaner composition)
  - `serviceMesh.destroy()` - clean up all cached services

- **Features:**
  - Topological sorting of layer specs within each affinity based on dependencies
  - Lazy loading - services are only instantiated when first requested
  - Caching - service instances are reused based on their affinity and context
  - Reference counting for space/process scoped services
  - Proper transitive dependency reference counting

### ServiceMesh.test.ts

Comprehensive tests covering:
- Basic operations for all three affinities
- Service caching and instance reuse
- Dependency resolution and topological sorting
- Dynamic add/remove of layer specs
- Scope-based cleanup for space/process services
- Error handling for missing context or services
- Layer-based provisioning

## Latest Changes (addressing PR review)

1. **Added `getResolverLayer(context)` method** - Returns a `Layer<ServiceResolver>` for cleaner composition with other layers
2. **Refactored `run()` to use `getResolverLayer()`** - Cleaner internal implementation
3. **Fixed dependency reference counting** - Now properly passes `acquiredSpaceRefs` and `acquiredProcessRefs` through the entire call chain (`#createInstance` -> `#resolveDependencies` -> `#getOrCreateInstance`) to ensure transitive dependencies are tracked for scope cleanup

## MemoMap Evaluation

Evaluated Effect's `MemoMap` for layer memoization. **Conclusion: Not directly applicable** to ServiceMesh because:

1. MemoMap is designed for single-scope memoization where layers are built once and shared
2. ServiceMesh requires affinity-based caching with different lifetimes:
   - `application` - lives until destroy()
   - `space` - one instance per space, reference counted
   - `process` - one instance per process, reference counted
3. Our manual caching approach with reference counting is more appropriate for these requirements

## Remaining Work (compute-runtime integration)

The compute-runtime integration in plugin-automation requires more careful planning due to:
- Complex layer composition with many interdependent services
- Need to define proper LayerSpecs for each service with correct affinities
- Type alignment between the existing `ComputeServices` union and ServiceMesh resolver

This will be addressed in a follow-up PR after the core ServiceMesh implementation is reviewed and merged.

## Related Issue

Closes DX-908
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DX-908](https://linear.app/dxos/issue/DX-908/servicemesh)

<div><a href="https://cursor.com/agents/bc-8642131a-e3b7-4e80-b155-974474a2b100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8642131a-e3b7-4e80-b155-974474a2b100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced ServiceMesh: scoped service resolution with application/space/process lifetimes, caching, scoped run/getResolver flows, dynamic add/remove of service specs, topological ordering, and destroy cleanup.
  * Added LayerSpec API for declaring layered services with dependency resolution and affinity-aware instantiation.
  * Re-exported LayerSpec and ServiceMesh for easier consumption.

* **Tests**
  * Added comprehensive tests for resolution, caching, scoping, dependency ordering, dynamic membership, lifecycle cleanup, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->