### PR TITLE
fix(plugin-outliner): fix journal entry data loss and add multi-entry quick entry

### DIFF
--- a/packages/plugins/plugin-outliner/src/containers/QuickEntryDialog/QuickEntryDialog.tsx
+++ b/packages/plugins/plugin-outliner/src/containers/QuickEntryDialog/QuickEntryDialog.tsx
@@ -3,13 +3,13 @@
 //
 
 import * as Schema from 'effect/Schema';
-import React, { useCallback } from 'react';
+import React, { type KeyboardEvent, useCallback, useEffect, useRef, useState } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
 import { LayoutOperation } from '@dxos/app-toolkit';
 import { Format } from '@dxos/echo';
-import { Dialog, useTranslation } from '@dxos/react-ui';
-import { Form } from '@dxos/react-ui-form';
+import { Dialog, IconButton, useTranslation } from '@dxos/react-ui';
+import { Form, useFormContext } from '@dxos/react-ui-form';
 
 import { meta } from '#meta';
 import { OutlineOperation } from '#operations';
@@ -24,14 +24,92 @@ const QuickEntryForm = Schema.Struct({
 
 type QuickEntryForm = Schema.Schema.Type<typeof QuickEntryForm>;
 
+const QUICK_ENTRY_ACTIONS_NAME = 'QuickEntryActions';
+
+type QuickEntryActionsProps = {
+  continueRef: { current: boolean };
+  formSaveRef: { current: (() => void) | null };
+};
+
+/**
+ * Custom form actions with Cancel, Save & Add Another, and Save buttons.
+ */
+const QuickEntryActions = ({ continueRef, formSaveRef }: QuickEntryActionsProps) => {
+  const { t } = useTranslation(meta.id);
+  const {
+    form: { canSave, onSave, onCancel },
+  } = useFormContext(QUICK_ENTRY_ACTIONS_NAME);
+
+  // Expose save function for keyboard shortcut handler.
+  useEffect(() => {
+    formSaveRef.current = canSave ? onSave : null;
+  }, [canSave, onSave, formSaveRef]);
+
+  const handleSaveAndContinue = useCallback(() => {
+    continueRef.current = true;
+    onSave();
+  }, [onSave, continueRef]);
+
+  return (
+    <div role='none' className='grid grid-flow-col gap-form-gap auto-cols-fr py-form-padding'>
+      {onCancel && (
+        <IconButton
+          icon='ph--x--regular'
+          iconEnd
+          label={t('quick-entry-cancel.label')}
+          onClick={onCancel}
+          data-testid='cancel-button'
+        />
+      )}
+      <IconButton
+        disabled={!canSave}
+        icon='ph--plus--regular'
+        iconEnd
+        label={t('quick-entry-save-and-continue.label')}
+        onClick={handleSaveAndContinue}
+        data-testid='save-and-continue-button'
+      />
+      <IconButton
+        type='submit'
+        variant='primary'
+        disabled={!canSave}
+        icon='ph--check--regular'
+        iconEnd
+        label={t('quick-entry-save.label')}
+        onClick={onSave}
+        data-testid='save-button'
+      />
+    </div>
+  );
+};
+
 export const QuickEntryDialog = () => {
   const { t } = useTranslation(meta.id);
   const { invokePromise } = useOperationInvoker();
+  const [formKey, setFormKey] = useState(0);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const continueRef = useRef(false);
+  const formSaveRef = useRef<(() => void) | null>(null);
+
+  // Auto-focus the text input when the dialog opens or the form resets.
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      const input = contentRef.current?.querySelector('textarea, input[type="text"]');
+      if (input instanceof HTMLElement) {
+        input.focus();
+      }
+    });
+  }, [formKey]);
 
   const handleSave = useCallback(
     async (values: QuickEntryForm) => {
       await invokePromise(OutlineOperation.QuickJournalEntry, { text: values.text.trim() });
-      await invokePromise(LayoutOperation.UpdateDialog, { state: false });
+      if (continueRef.current) {
+        continueRef.current = false;
+        setFormKey((key) => key + 1);
+      } else {
+        await invokePromise(LayoutOperation.UpdateDialog, { state: false });
+      }
     },
     [invokePromise],
   );
@@ -40,8 +118,18 @@ export const QuickEntryDialog = () => {
     await invokePromise(LayoutOperation.UpdateDialog, { state: false });
   }, [invokePromise]);
 
+  // Handle Cmd+Shift+Enter for "Save & Add Another".
+  const handleKeyDownCapture = useCallback((event: KeyboardEvent) => {
+    if (event.key === 'Enter' && event.metaKey && event.shiftKey) {
+      event.stopPropagation();
+      event.preventDefault();
+      continueRef.current = true;
+      formSaveRef.current?.();
+    }
+  }, []);
+
   return (
-    <Dialog.Content>
+    <Dialog.Content ref={contentRef} onKeyDownCapture={handleKeyDownCapture}>
       <Dialog.Header>
         <Dialog.Title>{t('quick-entry-dialog.title')}</Dialog.Title>
         <Dialog.Close asChild>
@@ -50,6 +138,7 @@ export const QuickEntryDialog = () => {
       </Dialog.Header>
       <Dialog.Body>
         <Form.Root
+          key={formKey}
           autoFocus
           schema={QuickEntryForm}
           defaultValues={{ text: '' }}
@@ -59,7 +148,7 @@ export const QuickEntryDialog = () => {
           <Form.Viewport>
             <Form.Content>
               <Form.FieldSet />
-              <Form.Actions />
+              <QuickEntryActions continueRef={continueRef} formSaveRef={formSaveRef} />
             </Form.Content>
           </Form.Viewport>
         </Form.Root>

--- a/packages/plugins/plugin-outliner/src/operations/quick-entry.ts
+++ b/packages/plugins/plugin-outliner/src/operations/quick-entry.ts
@@ -32,7 +32,7 @@ const handler: Operation.WithHandler<typeof QuickJournalEntry> = QuickJournalEnt
         const journals = await space.db.query(Filter.type(Journal.Journal)).run();
         const journal = journals.length > 0 ? (journals[0] as Journal.Journal) : space.db.add(Journal.make());
 
-        const entry = Journal.getOrCreateEntry(journal, space.db);
+        const entry = await Journal.getOrCreateEntry(journal, space.db);
         await Journal.addBullet(entry, cleaned);
       });
     }),

--- a/packages/plugins/plugin-outliner/src/translations.ts
+++ b/packages/plugins/plugin-outliner/src/translations.ts
@@ -46,6 +46,9 @@ export const translations = [
         'quick-entry.label': 'Add journal entry',
         'quick-entry-dialog.title': 'Quick Journal Entry',
         'quick-entry.placeholder': 'Write something...',
+        'quick-entry-cancel.label': 'Cancel',
+        'quick-entry-save.label': 'Save',
+        'quick-entry-save-and-continue.label': 'Save & Add Another',
 
         'delete-row.menu': 'Delete row',
       },

--- a/packages/plugins/plugin-outliner/src/types/Journal.test.ts
+++ b/packages/plugins/plugin-outliner/src/types/Journal.test.ts
@@ -1,0 +1,128 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { afterEach, beforeEach, describe, test } from 'vitest';
+
+import { Obj } from '@dxos/echo';
+import { type EchoDatabase } from '@dxos/echo-db';
+import { EchoTestBuilder } from '@dxos/echo-db/testing';
+import { Text } from '@dxos/schema';
+
+import { addBullet, getOrCreateEntry, Journal, JournalEntry, make, makeEntry } from './Journal';
+import { getDateString } from './util';
+
+describe('Journal', () => {
+  let builder: EchoTestBuilder;
+  let db: EchoDatabase;
+
+  beforeEach(async () => {
+    builder = await new EchoTestBuilder().open();
+    const result = await builder.createDatabase({ types: [Journal, JournalEntry, Text.Text] });
+    db = result.db;
+  });
+
+  afterEach(async () => {
+    await builder.close();
+  });
+
+  describe('addBullet', () => {
+    test('appends bullet to empty entry', async ({ expect }) => {
+      const entry = db.add(makeEntry());
+      await db.flush();
+
+      await addBullet(entry, 'Buy groceries');
+
+      const textObj = await entry.content.load();
+      expect(textObj.content).toBe('- [ ] Buy groceries');
+    });
+
+    test('appends bullet to entry with existing content', async ({ expect }) => {
+      const entry = db.add(makeEntry());
+      await db.flush();
+
+      await addBullet(entry, 'First item');
+      await addBullet(entry, 'Second item');
+
+      const textObj = await entry.content.load();
+      expect(textObj.content).toBe('- [ ] First item\n- [ ] Second item');
+    });
+
+    test('trims whitespace from text', async ({ expect }) => {
+      const entry = db.add(makeEntry());
+      await db.flush();
+
+      await addBullet(entry, '  padded text  ');
+
+      const textObj = await entry.content.load();
+      expect(textObj.content).toBe('- [ ] padded text');
+    });
+
+    test('collapses newlines in text', async ({ expect }) => {
+      const entry = db.add(makeEntry());
+      await db.flush();
+
+      await addBullet(entry, 'line one\n\nline two');
+
+      const textObj = await entry.content.load();
+      expect(textObj.content).toBe('- [ ] line one line two');
+    });
+  });
+
+  describe('getOrCreateEntry', () => {
+    test('creates entry when journal has no entry for date', async ({ expect }) => {
+      const journal = db.add(Obj.make(Journal, { entries: {} }));
+      await db.flush();
+
+      const entry = await getOrCreateEntry(journal, db);
+
+      expect(entry).toBeDefined();
+      expect(entry.date).toBe(getDateString(new Date()));
+    });
+
+    test('returns existing entry for today', async ({ expect }) => {
+      const journal = db.add(make());
+      await db.flush();
+
+      const entry = await getOrCreateEntry(journal, db);
+      await addBullet(entry, 'test bullet');
+
+      const sameEntry = await getOrCreateEntry(journal, db);
+      expect(sameEntry.id).toBe(entry.id);
+
+      const textObj = await sameEntry.content.load();
+      expect(textObj.content).toContain('test bullet');
+    });
+
+    test('does not overwrite existing entry content', async ({ expect }) => {
+      const journal = db.add(make());
+      await db.flush();
+
+      const entry = await getOrCreateEntry(journal, db);
+      await addBullet(entry, 'existing content');
+
+      // Simulate a second quick entry — should append, not overwrite.
+      const sameEntry = await getOrCreateEntry(journal, db);
+      await addBullet(sameEntry, 'new content');
+
+      const textObj = await sameEntry.content.load();
+      expect(textObj.content).toBe('- [ ] existing content\n- [ ] new content');
+    });
+
+    test('creates separate entries for different dates', async ({ expect }) => {
+      const journal = db.add(Obj.make(Journal, { entries: {} }));
+      await db.flush();
+
+      const today = new Date();
+      const yesterday = new Date(today);
+      yesterday.setDate(today.getDate() - 1);
+
+      const todayEntry = await getOrCreateEntry(journal, db, today);
+      const yesterdayEntry = await getOrCreateEntry(journal, db, yesterday);
+
+      expect(todayEntry.id).not.toBe(yesterdayEntry.id);
+      expect(todayEntry.date).toBe(getDateString(today));
+      expect(yesterdayEntry.date).toBe(getDateString(yesterday));
+    });
+  });
+});

--- a/packages/plugins/plugin-outliner/src/types/Journal.ts
+++ b/packages/plugins/plugin-outliner/src/types/Journal.ts
@@ -91,11 +91,18 @@ export const addBullet = async (entry: JournalEntry, text: string) => {
  * If the entry doesn't exist, creates one and adds it to the journal.
  * Requires `db` to persist the new entry.
  */
-export const getOrCreateEntry = (journal: Journal, db: { add: (obj: any) => any }, date = new Date()): JournalEntry => {
+export const getOrCreateEntry = async (
+  journal: Journal,
+  db: { add: (obj: any) => any },
+  date = new Date(),
+): Promise<JournalEntry> => {
   const dateKey = getDateString(date);
-  const existing = journal.entries[dateKey]?.target;
-  if (existing) {
-    return existing;
+  const existingRef = journal.entries[dateKey];
+  if (existingRef) {
+    const target = await existingRef.load();
+    if (target) {
+      return target;
+    }
   }
 
   const entry = db.add(makeEntry(date)) as JournalEntry;


### PR DESCRIPTION
## Summary
- **Bug fix**: `getOrCreateEntry` used synchronous `.target` to look up existing journal entries, which returns `undefined` for unloaded refs. This caused it to create a new empty entry and overwrite the existing reference, wiping out today's journal content. Fixed by making the function async and using `.load()`.
- **Auto-focus**: The quick entry dialog input now auto-focuses when opened so you don't have to tab into it.
- **Save & Add Another**: New button and keyboard shortcut (⌘⇧Enter) to submit an entry and immediately reset the form for another, enabling rapid multi-entry flow.
- **Tests**: Added tests for `addBullet` and `getOrCreateEntry` Journal utility functions.

## Test plan
- [ ] Open quick entry dialog — input should be focused automatically
- [ ] Submit an entry with ⌘Enter — dialog closes, entry appears in today's journal
- [ ] Submit with "Save & Add Another" button or ⌘⇧Enter — entry is saved, form clears and refocuses
- [ ] Submit multiple entries in a row — all appear in today's journal, no content lost
- [ ] Verify existing journal content is preserved when adding via quick entry
- [ ] Run `moon run plugin-outliner:test -- src/types/Journal.test.ts` — 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Save & Add Another" button to Quick Entry dialog for seamless continuous entry creation
  * Added keyboard shortcut (Cmd+Shift+Enter) to trigger "Save & Add Another"
  * Added Cancel button to Quick Entry dialog
  * Improved form input auto-focus on dialog open and after saving entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->