### PR TITLE
fix(plugin-outliner): journal usability improvements

### DIFF
--- a/packages/core/echo/echo-db/src/serializer.ts
+++ b/packages/core/echo/echo-db/src/serializer.ts
@@ -58,13 +58,26 @@ export class Serializer {
     invariant(data.version === Serializer.version, `Invalid version: ${data.version}`);
 
     const { objects } = data;
+    const deferred: Obj.JSON[] = [];
     for (const object of objects) {
       const shouldImport = opts?.onObject ? await opts.onObject(object) : true;
+      if (!shouldImport) {
+        continue;
+      }
 
-      if (shouldImport) {
+      if (object['@relationSource'] || object['@relationTarget']) {
+        deferred.push(object);
+      } else {
         await this._importObject(database, object);
       }
     }
+
+    // Flush so source/target objects are queryable before importing relations.
+    await database.flush();
+    for (const object of deferred) {
+      await this._importObject(database, object);
+    }
+
     await database.flush();
   }
 

--- a/packages/plugins/plugin-outliner/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-outliner/src/capabilities/react-surface.tsx
@@ -22,7 +22,7 @@ export default Capability.makeModule(() =>
         role: ['article', 'section'],
         filter: AppSurface.objectArticle(Journal.Journal),
         component: ({ role, data }) => (
-          <JournalContainer role={role} subject={data.subject} attendableId={data.attendableId} showCalendar />
+          <JournalContainer role={role} subject={data.subject} attendableId={data.attendableId} />
         ),
       }),
       Surface.create({

--- a/packages/plugins/plugin-outliner/src/components/Journal/Journal.tsx
+++ b/packages/plugins/plugin-outliner/src/components/Journal/Journal.tsx
@@ -32,7 +32,7 @@ export const Journal = composable<HTMLDivElement, JournalProps>(({ journal, onSe
   const entryRefs = useMemo(
     () =>
       Object.entries(journalSnapshot?.entries ?? {})
-        .toSorted(([a], [b]) => (a < b ? 1 : a > b ? -1 : 0))
+        .toSorted(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
         .map(([dateKey, ref]) => ({ dateKey, ref })),
     [journalSnapshot],
   );
@@ -57,7 +57,13 @@ export const Journal = composable<HTMLDivElement, JournalProps>(({ journal, onSe
           </div>
         )}
         {entryRefs.map(({ dateKey, ref }, i) => (
-          <JournalEntry key={dateKey} entryRef={ref} classNames='p-2' onSelect={onSelect} autoFocus={i === 0} />
+          <JournalEntry
+            key={dateKey}
+            entryRef={ref}
+            classNames='p-2'
+            onSelect={onSelect}
+            autoFocus={i === entryRefs.length - 1}
+          />
         ))}
       </ScrollArea.Viewport>
     </ScrollArea.Root>

--- a/packages/plugins/plugin-outliner/src/containers/JournalContainer/JournalContainer.stories.tsx
+++ b/packages/plugins/plugin-outliner/src/containers/JournalContainer/JournalContainer.stories.tsx
@@ -54,4 +54,3 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
-

--- a/packages/plugins/plugin-outliner/src/containers/JournalContainer/JournalContainer.stories.tsx
+++ b/packages/plugins/plugin-outliner/src/containers/JournalContainer/JournalContainer.stories.tsx
@@ -15,11 +15,7 @@ import { Journal, Outline } from '#types';
 import { translations } from '../../translations';
 import { JournalContainer } from './JournalContainer';
 
-type DefaultStoryProps = {
-  showCalendar?: boolean;
-};
-
-const DefaultStory = ({ showCalendar }: DefaultStoryProps) => {
+const DefaultStory = () => {
   const space = useSpace();
   const journal = useMemo(() => {
     if (space) {
@@ -32,7 +28,7 @@ const DefaultStory = ({ showCalendar }: DefaultStoryProps) => {
     return null;
   }
 
-  return <JournalContainer role='article' subject={journal} attendableId='story' showCalendar={showCalendar} />;
+  return <JournalContainer role='article' subject={journal} attendableId='story' />;
 };
 
 const meta = {
@@ -59,8 +55,3 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const WithCalendar: Story = {
-  args: {
-    showCalendar: true,
-  },
-};

--- a/packages/plugins/plugin-outliner/src/containers/JournalContainer/JournalContainer.tsx
+++ b/packages/plugins/plugin-outliner/src/containers/JournalContainer/JournalContainer.tsx
@@ -15,11 +15,7 @@ import { type Journal } from '#types';
 
 export type JournalContainerProps = AppSurface.ObjectArticleProps<Journal.Journal>;
 
-export const JournalContainer = ({
-  role,
-  attendableId: _attendableId,
-  subject: journal,
-}: JournalContainerProps) => {
+export const JournalContainer = ({ role, attendableId: _attendableId, subject: journal }: JournalContainerProps) => {
   const { t } = useTranslation(meta.id);
   const [showCalendar, setShowCalendar] = useState(false);
   const controllerRef = useRef<CalendarController>(null);

--- a/packages/plugins/plugin-outliner/src/containers/JournalContainer/JournalContainer.tsx
+++ b/packages/plugins/plugin-outliner/src/containers/JournalContainer/JournalContainer.tsx
@@ -2,24 +2,26 @@
 // Copyright 2025 DXOS.org
 //
 
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 
 import { type AppSurface } from '@dxos/app-toolkit/ui';
-import { Panel, useMediaQuery } from '@dxos/react-ui';
+import { Panel, Toolbar, useMediaQuery, useTranslation } from '@dxos/react-ui';
 import { Calendar, type CalendarController } from '@dxos/react-ui-calendar';
 import { mx } from '@dxos/ui-theme';
 
 import { Journal as JournalComponent, type JournalProps } from '#components';
+import { meta } from '#meta';
 import { type Journal } from '#types';
 
-export type JournalContainerProps = AppSurface.ObjectArticleProps<Journal.Journal> & { showCalendar?: boolean };
+export type JournalContainerProps = AppSurface.ObjectArticleProps<Journal.Journal>;
 
 export const JournalContainer = ({
   role,
   attendableId: _attendableId,
   subject: journal,
-  showCalendar,
 }: JournalContainerProps) => {
+  const { t } = useTranslation(meta.id);
+  const [showCalendar, setShowCalendar] = useState(false);
   const controllerRef = useRef<CalendarController>(null);
 
   // TODO(burdon): Instead of media query should check physical geometry of plank.
@@ -31,6 +33,22 @@ export const JournalContainer = ({
 
   return (
     <Panel.Root role={role}>
+      <Panel.Toolbar asChild>
+        <Toolbar.Root>
+          <Toolbar.ToggleGroup
+            type='single'
+            value={showCalendar ? 'calendar' : ''}
+            onValueChange={(value) => setShowCalendar(value === 'calendar')}
+          >
+            <Toolbar.ToggleGroupIconItem
+              value='calendar'
+              label={t('toggle-calendar.label')}
+              icon='ph--calendar--regular'
+              iconOnly
+            />
+          </Toolbar.ToggleGroup>
+        </Toolbar.Root>
+      </Panel.Toolbar>
       <Panel.Content asChild>
         {/* TODO(burdon): Splitter. */}
         <div

--- a/packages/plugins/plugin-outliner/src/translations.ts
+++ b/packages/plugins/plugin-outliner/src/translations.ts
@@ -42,6 +42,7 @@ export const translations = [
 
         'meeting-notes.label': 'Notes',
         'today.label': 'Today',
+        'toggle-calendar.label': 'Toggle calendar',
 
         'quick-entry.label': 'Add journal entry',
         'quick-entry-dialog.title': 'Quick Journal Entry',

--- a/packages/sdk/client/src/echo/import.ts
+++ b/packages/sdk/client/src/echo/import.ts
@@ -3,7 +3,7 @@
 //
 
 import { LegacySpaceProperties, SpaceProperties } from '@dxos/client-protocol';
-import { Obj, Type } from '@dxos/echo';
+import { Type } from '@dxos/echo';
 import { Filter, type SerializedSpace, Serializer, decodeDXNFromJSON } from '@dxos/echo-db';
 import { type EchoDatabase } from '@dxos/echo-db';
 
@@ -19,26 +19,18 @@ export const importSpace = async (db: EchoDatabase, data: SerializedSpace, optio
 
   await new Serializer().import(db, data, {
     onObject: async (object) => {
-      const { '@type': typeEncoded, ...data } = object;
-      const typeDXN = decodeDXNFromJSON(typeEncoded);
+      const typeDXN = decodeDXNFromJSON(object['@type']);
       const typename = typeDXN?.asTypeDXN()?.type;
 
       if (typename && options?.ignoreTypes?.includes(typename)) {
         return false;
       }
 
-      // Handle Space Properties.
+      // Skip SpaceProperties when the target space already has them.
       if (
         properties &&
         (typename === Type.getTypename(SpaceProperties) || typename === Type.getTypename(LegacySpaceProperties))
       ) {
-        Obj.change(properties, (props: any) => {
-          Object.entries(data).forEach(([name, value]) => {
-            if (!name.startsWith('@')) {
-              props[name] = value;
-            }
-          });
-        });
         return false;
       }
       return true;


### PR DESCRIPTION
## Summary
- Fix "Object Id is readonly" error when importing snapshots into existing spaces by skipping SpaceProperties instead of merging them
- Defer relation object imports to a second pass so source/target objects are available for reference resolution
- Journal usability improvements: oldest-first entry ordering, toolbar toggle for calendar, auto-focus on latest entry

## Test plan
- [ ] Export a space snapshot via devtools
- [ ] Import the snapshot into a different existing space via devtools "Import data into space"
- [ ] Verify SpaceProperties are skipped without error
- [ ] Verify relation objects are imported after their source/target objects
- [ ] Verify journal entries display in chronological order with latest focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar toggle accessible via toolbar in the journal interface
  * Toggle labeled "Toggle calendar" (en-US)
  * Calendar panel mounts only when the toggle is enabled
  * Journal entries now display newest first (reverse chronological)
  * Improved auto-focus behavior to focus the most recent entry when navigating
<!-- end of auto-generated comment: release notes by coderabbit.ai -->