### PR TITLE
feat: include ClientService in ComputeRuntimeProviderImpl

### DIFF
--- a/packages/devtools/cli/src/commands/admin/util.ts
+++ b/packages/devtools/cli/src/commands/admin/util.ts
@@ -6,6 +6,7 @@ import * as FetchHttpClient from '@effect/platform/FetchHttpClient';
 import * as HttpClient from '@effect/platform/HttpClient';
 import * as HttpClientRequest from '@effect/platform/HttpClientRequest';
 import * as Config from 'effect/Config';
+import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
 
 import { withRetry } from '@dxos/edge-client';
@@ -39,7 +40,9 @@ export const adminRequest = <T>(
       HttpClientRequest.setHeader('X-Admin-Key', adminKey),
     );
 
-    const result = yield* withRetry(HttpClient.execute(request)).pipe(Effect.provide(FetchHttpClient.layer));
+    const result = yield* withRetry(HttpClient.execute(request), { timeout: Duration.seconds(30) }).pipe(
+      Effect.provide(FetchHttpClient.layer),
+    );
 
     const envelope = result as EdgeEnvelope<T>;
     if (!envelope.success) {

--- a/packages/plugins/plugin-automation/src/capabilities/compute-runtime.ts
+++ b/packages/plugins/plugin-automation/src/capabilities/compute-runtime.ts
@@ -115,6 +115,7 @@ class ComputeRuntimeProviderImpl extends Resource implements AutomationCapabilit
               AiService.AiService,
               CredentialsService,
               Blueprint.RegistryService,
+              ClientService,
             ),
           ),
           Layer.provideMerge(Layer.succeed(Blueprint.RegistryService, new Blueprint.Registry(blueprints))),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin CLI commands now enforce a 30-second timeout to prevent indefinite request hanging.

* **Improvements**
  * Plugin automation compute runtime has enhanced service initialization to ensure all required dependencies are properly loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->