### PR TITLE
fix(composer-app): allow opener plugin in desktop Tauri capability

### DIFF
--- a/packages/apps/composer-app/src-tauri/capabilities/desktop.json
+++ b/packages/apps/composer-app/src-tauri/capabilities/desktop.json
@@ -36,6 +36,8 @@
         }
       ]
     },
+    "opener:allow-open-url",
+    "opener:default",
     "updater:default"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `opener:allow-open-url` and `opener:default` permissions to the desktop Tauri capability
- Fixes OAuth flow failing with `Command plugin:opener|open_url not allowed by ACL` error

## Test plan
- [ ] Launch the desktop Tauri app
- [ ] Trigger the OAuth flow
- [ ] Verify the browser opens successfully without ACL errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening URLs from within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->