### PR TITLE
feat(echo): add Filter.childOf(...) for parent-child hierarchy filtering

### DIFF
--- a/packages/core/echo/echo-db/src/query/query.test.ts
+++ b/packages/core/echo/echo-db/src/query/query.test.ts
@@ -2356,9 +2356,7 @@ describe('Query', () => {
       );
       await db.flush();
 
-      const objects = await db
-        .query(Query.select(Filter.childOf(grandparent, { transitive: false })))
-        .run();
+      const objects = await db.query(Query.select(Filter.childOf(grandparent, { transitive: false }))).run();
       expect(objects).toHaveLength(1);
       expect(objects[0]).toMatchObject({ name: 'Parent' });
     });
@@ -2374,9 +2372,7 @@ describe('Query', () => {
       );
       await db.flush();
 
-      const objects = await db
-        .query(Query.select(Filter.childOf(parent, { transitive: false })))
-        .run();
+      const objects = await db.query(Query.select(Filter.childOf(parent, { transitive: false }))).run();
       expect(objects).toHaveLength(1);
       expect(objects[0]).toMatchObject({ name: 'Child' });
     });
@@ -2393,9 +2389,7 @@ describe('Query', () => {
       const unrelated = db.add(Obj.make(TestSchema.Expando, { name: 'Unrelated' }));
       await db.flush();
 
-      const objects = await db
-        .query(Query.select(Filter.childOf(grandparent, { transitive: false })))
-        .run();
+      const objects = await db.query(Query.select(Filter.childOf(grandparent, { transitive: false }))).run();
       expect(objects).toHaveLength(1);
       expect(objects[0]).toMatchObject({ name: 'Parent' });
     });
@@ -2412,11 +2406,7 @@ describe('Query', () => {
       await queue.append([Obj.make(TestSchema.Task, { title: 'Task in feed' })]);
       await db.flush();
 
-      const objects = await db
-        .query(
-          Query.select(Filter.childOf(feed)).from(db, { includeFeeds: true }),
-        )
-        .run();
+      const objects = await db.query(Query.select(Filter.childOf(feed)).from(db, { includeFeeds: true })).run();
       expect(objects).toHaveLength(1);
       expect((objects[0] as TestSchema.Task).title).toEqual('Task in feed');
     });
@@ -2439,11 +2429,7 @@ describe('Query', () => {
       await queue.append([Obj.make(TestSchema.Task, { title: 'Grandchild task' })]);
       await db.flush();
 
-      const objects = await db
-        .query(
-          Query.select(Filter.childOf(parentObj)).from(db, { includeFeeds: true }),
-        )
-        .run();
+      const objects = await db.query(Query.select(Filter.childOf(parentObj)).from(db, { includeFeeds: true })).run();
       const taskResults = objects.filter((obj: any) => obj.title === 'Grandchild task');
       expect(taskResults.length).toBeGreaterThanOrEqual(1);
     });
@@ -2495,19 +2481,11 @@ describe('Query', () => {
       await queue2.append([Obj.make(TestSchema.Task, { title: 'Task in feed 2' })]);
       await db.flush();
 
-      const objects1 = await db
-        .query(
-          Query.select(Filter.childOf(feed1)).from(db, { includeFeeds: true }),
-        )
-        .run();
+      const objects1 = await db.query(Query.select(Filter.childOf(feed1)).from(db, { includeFeeds: true })).run();
       expect(objects1).toHaveLength(1);
       expect((objects1[0] as TestSchema.Task).title).toEqual('Task in feed 1');
 
-      const objects2 = await db
-        .query(
-          Query.select(Filter.childOf(feed2)).from(db, { includeFeeds: true }),
-        )
-        .run();
+      const objects2 = await db.query(Query.select(Filter.childOf(feed2)).from(db, { includeFeeds: true })).run();
       expect(objects2).toHaveLength(1);
       expect((objects2[0] as TestSchema.Task).title).toEqual('Task in feed 2');
     });

--- a/packages/core/echo/echo-db/src/query/query.test.ts
+++ b/packages/core/echo/echo-db/src/query/query.test.ts
@@ -2288,6 +2288,272 @@ describe('Query', () => {
       }
     });
   });
+
+  describe('Filter.childOf', () => {
+    test('two echo objects - positive test', async () => {
+      const { db } = await builder.createDatabase();
+      const parent = db.add(Obj.make(TestSchema.Expando, { name: 'Parent' }));
+      const child = db.add(
+        Obj.make(TestSchema.Expando, {
+          [Obj.Parent]: parent,
+          name: 'Child',
+        }),
+      );
+      await db.flush();
+
+      const objects = await db.query(Query.select(Filter.childOf(parent))).run();
+      expect(objects).toHaveLength(1);
+      expect(objects[0]).toMatchObject({ name: 'Child' });
+    });
+
+    test('two echo objects - negative test', async () => {
+      const { db } = await builder.createDatabase();
+      const parent = db.add(Obj.make(TestSchema.Expando, { name: 'Parent' }));
+      const unrelated = db.add(Obj.make(TestSchema.Expando, { name: 'Unrelated' }));
+      await db.flush();
+
+      const objects = await db.query(Query.select(Filter.childOf(parent))).run();
+      expect(objects).toHaveLength(0);
+    });
+
+    test('chain of three echo objects - transitive positive', async () => {
+      const { db } = await builder.createDatabase();
+      const grandparent = db.add(Obj.make(TestSchema.Expando, { name: 'Grandparent' }));
+      const parent = db.add(
+        Obj.make(TestSchema.Expando, {
+          [Obj.Parent]: grandparent,
+          name: 'Parent',
+        }),
+      );
+      const child = db.add(
+        Obj.make(TestSchema.Expando, {
+          [Obj.Parent]: parent,
+          name: 'Child',
+        }),
+      );
+      await db.flush();
+
+      const objects = await db.query(Query.select(Filter.childOf(grandparent))).run();
+      expect(objects).toHaveLength(2);
+      const names = objects.map((o: any) => o.name).sort();
+      expect(names).toEqual(['Child', 'Parent']);
+    });
+
+    test('chain of three echo objects - transitive negative', async () => {
+      const { db } = await builder.createDatabase();
+      const grandparent = db.add(Obj.make(TestSchema.Expando, { name: 'Grandparent' }));
+      const parent = db.add(
+        Obj.make(TestSchema.Expando, {
+          [Obj.Parent]: grandparent,
+          name: 'Parent',
+        }),
+      );
+      const child = db.add(
+        Obj.make(TestSchema.Expando, {
+          [Obj.Parent]: parent,
+          name: 'Child',
+        }),
+      );
+      await db.flush();
+
+      const objects = await db
+        .query(Query.select(Filter.childOf(grandparent, { transitive: false })))
+        .run();
+      expect(objects).toHaveLength(1);
+      expect(objects[0]).toMatchObject({ name: 'Parent' });
+    });
+
+    test('chain of three echo objects - non-transitive positive', async () => {
+      const { db } = await builder.createDatabase();
+      const parent = db.add(Obj.make(TestSchema.Expando, { name: 'Parent' }));
+      const child = db.add(
+        Obj.make(TestSchema.Expando, {
+          [Obj.Parent]: parent,
+          name: 'Child',
+        }),
+      );
+      await db.flush();
+
+      const objects = await db
+        .query(Query.select(Filter.childOf(parent, { transitive: false })))
+        .run();
+      expect(objects).toHaveLength(1);
+      expect(objects[0]).toMatchObject({ name: 'Child' });
+    });
+
+    test('chain of three echo objects - non-transitive negative', async () => {
+      const { db } = await builder.createDatabase();
+      const grandparent = db.add(Obj.make(TestSchema.Expando, { name: 'Grandparent' }));
+      const parent = db.add(
+        Obj.make(TestSchema.Expando, {
+          [Obj.Parent]: grandparent,
+          name: 'Parent',
+        }),
+      );
+      const unrelated = db.add(Obj.make(TestSchema.Expando, { name: 'Unrelated' }));
+      await db.flush();
+
+      const objects = await db
+        .query(Query.select(Filter.childOf(grandparent, { transitive: false })))
+        .run();
+      expect(objects).toHaveLength(1);
+      expect(objects[0]).toMatchObject({ name: 'Parent' });
+    });
+
+    test('object in feed', async () => {
+      const peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Task] });
+      const db = await peer.createDatabase();
+      const queues = peer.client.constructQueueFactory(db.spaceId);
+      const feed = db.add(Feed.make({ name: 'test-feed' }));
+      await db.flush();
+
+      const feedDxn = Feed.getQueueDxn(feed)!;
+      const queue = queues.get(feedDxn);
+      await queue.append([Obj.make(TestSchema.Task, { title: 'Task in feed' })]);
+      await db.flush();
+
+      const objects = await db
+        .query(
+          Query.select(Filter.childOf(feed)).from(db, { includeFeeds: true }),
+        )
+        .run();
+      expect(objects).toHaveLength(1);
+      expect((objects[0] as TestSchema.Task).title).toEqual('Task in feed');
+    });
+
+    test('A -> Feed -> B: childOf([A]) matches B', async () => {
+      const peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Task] });
+      const db = await peer.createDatabase();
+      const queues = peer.client.constructQueueFactory(db.spaceId);
+      const parentObj = db.add(Obj.make(TestSchema.Expando, { name: 'ParentA' }));
+      const feed = db.add(
+        Obj.make(Feed.Feed, {
+          [Obj.Parent]: parentObj,
+          name: 'child-feed',
+        }),
+      );
+      await db.flush();
+
+      const feedDxn = Feed.getQueueDxn(feed)!;
+      const queue = queues.get(feedDxn);
+      await queue.append([Obj.make(TestSchema.Task, { title: 'Grandchild task' })]);
+      await db.flush();
+
+      const objects = await db
+        .query(
+          Query.select(Filter.childOf(parentObj)).from(db, { includeFeeds: true }),
+        )
+        .run();
+      const taskResults = objects.filter((obj: any) => obj.title === 'Grandchild task');
+      expect(taskResults.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('childOf with type filter prevents Feed from being returned', async () => {
+      const peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Task] });
+      const db = await peer.createDatabase();
+      const queues = peer.client.constructQueueFactory(db.spaceId);
+      const parentObj = db.add(Obj.make(TestSchema.Expando, { name: 'ParentA' }));
+      const feed = db.add(
+        Obj.make(Feed.Feed, {
+          [Obj.Parent]: parentObj,
+          name: 'child-feed',
+        }),
+      );
+      await db.flush();
+
+      const feedDxn = Feed.getQueueDxn(feed)!;
+      const queue = queues.get(feedDxn);
+      await queue.append([Obj.make(TestSchema.Task, { title: 'Task from feed' })]);
+      await db.flush();
+
+      const objects = await db
+        .query(
+          Query.select(Filter.and(Filter.childOf(parentObj), Filter.type(TestSchema.Task))).from(db, {
+            includeFeeds: true,
+          }),
+        )
+        .run();
+      expect(objects).toHaveLength(1);
+      expect((objects[0] as TestSchema.Task).title).toEqual('Task from feed');
+      expect(objects.every((obj: any) => Obj.getTypename(obj) !== 'org.dxos.type.feed')).toBe(true);
+    });
+
+    test('negative test with 2 feeds - items from only one matching filter', async () => {
+      const peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Task, TestSchema.Person] });
+      const db = await peer.createDatabase();
+      const queues = peer.client.constructQueueFactory(db.spaceId);
+      const feed1 = db.add(Feed.make({ name: 'feed-1' }));
+      const feed2 = db.add(Feed.make({ name: 'feed-2' }));
+      await db.flush();
+
+      const feedDxn1 = Feed.getQueueDxn(feed1)!;
+      const feedDxn2 = Feed.getQueueDxn(feed2)!;
+      const queue1 = queues.get(feedDxn1);
+      const queue2 = queues.get(feedDxn2);
+
+      await queue1.append([Obj.make(TestSchema.Task, { title: 'Task in feed 1' })]);
+      await queue2.append([Obj.make(TestSchema.Task, { title: 'Task in feed 2' })]);
+      await db.flush();
+
+      const objects1 = await db
+        .query(
+          Query.select(Filter.childOf(feed1)).from(db, { includeFeeds: true }),
+        )
+        .run();
+      expect(objects1).toHaveLength(1);
+      expect((objects1[0] as TestSchema.Task).title).toEqual('Task in feed 1');
+
+      const objects2 = await db
+        .query(
+          Query.select(Filter.childOf(feed2)).from(db, { includeFeeds: true }),
+        )
+        .run();
+      expect(objects2).toHaveLength(1);
+      expect((objects2[0] as TestSchema.Task).title).toEqual('Task in feed 2');
+    });
+
+    test('childOf with DXN argument', async () => {
+      const { db } = await builder.createDatabase();
+      const parent = db.add(Obj.make(TestSchema.Expando, { name: 'Parent' }));
+      const child = db.add(
+        Obj.make(TestSchema.Expando, {
+          [Obj.Parent]: parent,
+          name: 'Child',
+        }),
+      );
+      await db.flush();
+
+      const parentDxn = Obj.getDXN(parent);
+      const objects = await db.query(Query.select(Filter.childOf(parentDxn))).run();
+      expect(objects).toHaveLength(1);
+      expect(objects[0]).toMatchObject({ name: 'Child' });
+    });
+
+    test('childOf with array of parents', async () => {
+      const { db } = await builder.createDatabase();
+      const parent1 = db.add(Obj.make(TestSchema.Expando, { name: 'Parent1' }));
+      const parent2 = db.add(Obj.make(TestSchema.Expando, { name: 'Parent2' }));
+      const child1 = db.add(
+        Obj.make(TestSchema.Expando, {
+          [Obj.Parent]: parent1,
+          name: 'Child1',
+        }),
+      );
+      const child2 = db.add(
+        Obj.make(TestSchema.Expando, {
+          [Obj.Parent]: parent2,
+          name: 'Child2',
+        }),
+      );
+      const unrelated = db.add(Obj.make(TestSchema.Expando, { name: 'Unrelated' }));
+      await db.flush();
+
+      const objects = await db.query(Query.select(Filter.childOf([parent1, parent2]))).run();
+      expect(objects).toHaveLength(2);
+      const names = objects.map((o: any) => o.name).sort();
+      expect(names).toEqual(['Child1', 'Child2']);
+    });
+  });
 });
 
 const createObjects = async (peer: EchoTestPeer, db: EchoDatabase, options: { count: number }) => {

--- a/packages/core/echo/echo-db/src/query/util.ts
+++ b/packages/core/echo/echo-db/src/query/util.ts
@@ -37,6 +37,19 @@ const filterContainsTimestamp = (filter: QueryAST.Filter) => {
   return false;
 };
 
+const filterContainsChildOf = (filter: QueryAST.Filter): boolean => {
+  if (filter.type === 'child-of') {
+    return true;
+  }
+  if (filter.type === 'and' || filter.type === 'or') {
+    return filter.filters.some(filterContainsChildOf);
+  }
+  if (filter.type === 'not') {
+    return filterContainsChildOf(filter.filter);
+  }
+  return false;
+};
+
 /**
  * Extracts the filter and options from a query.
  * Supports Select(...), Options(Select(...)), and From(Select(...)) queries.
@@ -69,7 +82,7 @@ export const isSimpleSelectionQuery = (
       };
     }
     case 'select': {
-      if (filterContainsTimestamp(query.filter)) {
+      if (filterContainsTimestamp(query.filter) || filterContainsChildOf(query.filter)) {
         return null;
       }
       return { filter: query.filter, options: undefined };

--- a/packages/core/echo/echo-pipeline/src/filter/filter-match.ts
+++ b/packages/core/echo/echo-pipeline/src/filter/filter-match.ts
@@ -76,6 +76,10 @@ export const filterMatchObject = (filter: QueryAST.Filter, obj: MatchedObject): 
       throw new Error('Timestamp filters must be handled at the index level, not in-memory matching.');
     }
 
+    case 'child-of': {
+      throw new Error('child-of filters must be handled at the executor level, not in-memory matching.');
+    }
+
     case 'not': {
       return !filterMatchObject(filter.filter, obj);
     }
@@ -156,6 +160,10 @@ export const filterMatchObjectJSON = (filter: QueryAST.Filter, obj: ObjectJSON):
 
     case 'timestamp': {
       throw new Error('Timestamp filters must be handled at the index level, not in-memory matching.');
+    }
+
+    case 'child-of': {
+      throw new Error('child-of filters must be handled at the executor level, not in-memory matching.');
     }
 
     case 'not': {

--- a/packages/core/echo/echo-pipeline/src/query/query-executor.ts
+++ b/packages/core/echo/echo-pipeline/src/query/query-executor.ts
@@ -229,6 +229,7 @@ declare global {
 const TRACE_QUERY_EXECUTION = !!import.meta.env.DX_TRACE_QUERY_EXECUTION;
 
 const MAX_DEPTH_FOR_DELETION_TRACING = 10;
+const MAX_DEPTH_FOR_CHILD_OF_TRACING = 10;
 
 /**
  * Executes query plans against the IndexEngine and AutomergeHost.
@@ -627,6 +628,10 @@ export class QueryExecutor extends Resource {
   }
 
   private async _execFilterStep(step: QueryPlan.FilterStep, workingSet: QueryItem[]): Promise<StepExecutionResult> {
+    if (step.filter.type === 'child-of') {
+      return this._execChildOfFilterStep(step.filter, workingSet);
+    }
+
     const timestampParams = extractTimestampParams(step.filter);
     if (timestampParams !== null) {
       return this._execTimestampFilterStep(step, workingSet, timestampParams);
@@ -720,6 +725,82 @@ export class QueryExecutor extends Resource {
         objectCount: result.length,
       },
     };
+  }
+
+  private async _execChildOfFilterStep(
+    filter: QueryAST.FilterChildOf,
+    workingSet: QueryItem[],
+  ): Promise<StepExecutionResult> {
+    const parentObjectIds = new Set<string>();
+    for (const parentDxnStr of filter.parents) {
+      const dxn = DXN.parse(parentDxnStr);
+      const echoDxn = dxn.asEchoDXN();
+      if (echoDxn) {
+        parentObjectIds.add(echoDxn.echoId);
+      }
+    }
+    const maxDepth = filter.transitive ? MAX_DEPTH_FOR_CHILD_OF_TRACING : 1;
+
+    const matches = await Promise.all(
+      workingSet.map(async (item) => this._isChildOfAny(item, parentObjectIds, maxDepth)),
+    );
+    const result = workingSet.filter((_item, index) => matches[index]);
+
+    return {
+      workingSet: result,
+      trace: {
+        ...ExecutionTrace.makeEmpty(),
+        name: 'Filter(child-of)',
+        details: JSON.stringify({ parents: filter.parents, transitive: filter.transitive }),
+        objectCount: result.length,
+      },
+    };
+  }
+
+  /**
+   * Checks if an item is a child of any of the given parent object IDs.
+   * Walks up the parent chain (and feed ownership for queue items) until a match is found or depth is exhausted.
+   */
+  private async _isChildOfAny(
+    item: QueryItem,
+    parentObjectIds: Set<string>,
+    remainingDepth: number,
+  ): Promise<boolean> {
+    if (remainingDepth <= 0) {
+      return false;
+    }
+
+    const parentRefs: { dxnStr: string; objectId: string }[] = [];
+
+    const directParent = QueryItem.getParent(item);
+    if (directParent) {
+      const echoDxn = DXN.parse(directParent).asEchoDXN();
+      if (echoDxn) {
+        parentRefs.push({ dxnStr: directParent, objectId: echoDxn.echoId });
+      }
+    }
+
+    if (item.queueId && !directParent) {
+      parentRefs.push({
+        dxnStr: DXN.fromSpaceAndObjectId(item.spaceId, item.queueId).toString(),
+        objectId: item.queueId,
+      });
+    }
+
+    for (const ref of parentRefs) {
+      if (parentObjectIds.has(ref.objectId)) {
+        return true;
+      }
+    }
+
+    for (const ref of parentRefs) {
+      const parentItem = await this._loadFromDXN(DXN.parse(ref.dxnStr), { sourceSpaceId: item.spaceId });
+      if (parentItem && (await this._isChildOfAny(parentItem, parentObjectIds, remainingDepth - 1))) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   // TODO(dmaretskyi): This needs to be completed.

--- a/packages/core/echo/echo-pipeline/src/query/query-executor.ts
+++ b/packages/core/echo/echo-pipeline/src/query/query-executor.ts
@@ -761,11 +761,7 @@ export class QueryExecutor extends Resource {
    * Checks if an item is a child of any of the given parent object IDs.
    * Walks up the parent chain (and feed ownership for queue items) until a match is found or depth is exhausted.
    */
-  private async _isChildOfAny(
-    item: QueryItem,
-    parentObjectIds: Set<string>,
-    remainingDepth: number,
-  ): Promise<boolean> {
+  private async _isChildOfAny(item: QueryItem, parentObjectIds: Set<string>, remainingDepth: number): Promise<boolean> {
     if (remainingDepth <= 0) {
       return false;
     }

--- a/packages/core/echo/echo-pipeline/src/query/query-planner.ts
+++ b/packages/core/echo/echo-pipeline/src/query/query-planner.ts
@@ -254,6 +254,24 @@ export class QueryPlanner {
         ]);
       }
 
+      // ChildOf
+      case 'child-of': {
+        return QueryPlan.Plan.make([
+          {
+            _tag: 'SelectStep',
+            scope: context.scope,
+            selector: {
+              _tag: 'WildcardSelector',
+            },
+          },
+          ...this._generateDeletedHandlingSteps(context),
+          {
+            _tag: 'FilterStep',
+            filter: { ...filter },
+          },
+        ]);
+      }
+
       // Compare
       case 'compare':
         throw queryTooComplexError(context.originalQuery);
@@ -271,7 +289,8 @@ export class QueryPlanner {
       case 'and': {
         const flatFilters = _flattenAnd(filter.filters);
         const timestampFilters = flatFilters.filter((f): f is QueryAST.FilterTimestamp => f.type === 'timestamp');
-        const nonTimestampFilters = flatFilters.filter((f) => f.type !== 'timestamp');
+        const childOfFilters = flatFilters.filter((f): f is QueryAST.FilterChildOf => f.type === 'child-of');
+        const otherFilters = flatFilters.filter((f) => f.type !== 'timestamp' && f.type !== 'child-of');
 
         if (timestampFilters.length > 0 && context.selectionInverted) {
           throw new QueryError({
@@ -281,8 +300,8 @@ export class QueryPlanner {
           });
         }
 
-        if (timestampFilters.length > 0 && nonTimestampFilters.length <= 1) {
-          const innerFilter = nonTimestampFilters[0];
+        if (timestampFilters.length > 0 && otherFilters.length <= 1 && childOfFilters.length === 0) {
+          const innerFilter = otherFilters[0];
           const innerPlan = innerFilter
             ? this._generateSelectionFromFilter(innerFilter, context)
             : QueryPlan.Plan.make([
@@ -315,12 +334,36 @@ export class QueryPlanner {
           ]);
         }
 
-        if (timestampFilters.length > 0) {
+        if (timestampFilters.length > 0 && childOfFilters.length === 0) {
           throw new QueryError({
             message:
               'Timestamp filters can only be combined with a single type or property filter via AND. Split complex filters into a subquery.',
             context: { query: context.originalQuery },
           });
+        }
+
+        if (childOfFilters.length > 0) {
+          const remainingFilters = flatFilters.filter((f) => f.type !== 'child-of');
+          const innerPlan =
+            remainingFilters.length === 1
+              ? this._generateSelectionFromFilter(remainingFilters[0], context)
+              : remainingFilters.length > 1
+                ? this._generateSelectionFromFilter({ type: 'and', filters: remainingFilters }, context)
+                : QueryPlan.Plan.make([
+                    {
+                      _tag: 'SelectStep',
+                      scope: context.scope,
+                      selector: { _tag: 'WildcardSelector' },
+                    },
+                    ...this._generateDeletedHandlingSteps(context),
+                  ]);
+
+          const childOfSteps: QueryPlan.Step[] = childOfFilters.map((f) => ({
+            _tag: 'FilterStep' as const,
+            filter: f,
+          }));
+
+          return QueryPlan.Plan.make([...innerPlan.steps, ...childOfSteps]);
         }
 
         throw queryTooComplexError(context.originalQuery);

--- a/packages/core/echo/echo-protocol/src/query/ast.ts
+++ b/packages/core/echo/echo-protocol/src/query/ast.ts
@@ -167,6 +167,21 @@ export interface FilterOr extends Schema.Schema.Type<typeof FilterOr_> {}
 export const FilterOr: Schema.Schema<FilterOr> = FilterOr_;
 
 /**
+ * Filter objects that are children of the specified parents.
+ * With transitive=true (default), matches grandchildren and beyond.
+ */
+const FilterChildOf_ = Schema.Struct({
+  type: Schema.Literal('child-of'),
+  /** Parent DXNs to match children of. */
+  parents: Schema.Array(DXN.Schema),
+  /** Whether to match transitively (grandchildren, etc.). Defaults to true. */
+  transitive: Schema.Boolean,
+});
+
+export interface FilterChildOf extends Schema.Schema.Type<typeof FilterChildOf_> {}
+export const FilterChildOf: Schema.Schema<FilterChildOf> = FilterChildOf_;
+
+/**
  * Union of filters.
  */
 export const Filter = Schema.Union(
@@ -178,6 +193,7 @@ export const Filter = Schema.Union(
   FilterRange,
   FilterTimestamp,
   FilterTextSearch,
+  FilterChildOf,
   FilterNot,
   FilterAnd,
   FilterOr,

--- a/packages/core/echo/echo/src/Filter.ts
+++ b/packages/core/echo/echo/src/Filter.ts
@@ -349,10 +349,7 @@ export type ChildOfOptions = {
  * Accepts ECHO objects, DXN values, or arrays of either.
  * With transitive=true (default), also matches grandchildren and beyond.
  */
-export const childOf = (
-  parents: Entity.Unknown | DXN | (Entity.Unknown | DXN)[],
-  options?: ChildOfOptions,
-): Any => {
+export const childOf = (parents: Entity.Unknown | DXN | (Entity.Unknown | DXN)[], options?: ChildOfOptions): Any => {
   const items = Array.isArray(parents) ? parents : [parents];
   const dxns = items.map((item) => {
     if (item instanceof DXN) {

--- a/packages/core/echo/echo/src/Filter.ts
+++ b/packages/core/echo/echo/src/Filter.ts
@@ -13,6 +13,7 @@ import { type ForeignKey, type QueryAST } from '@dxos/echo-protocol';
 import { assertArgument } from '@dxos/invariant';
 import { DXN, ObjectId } from '@dxos/keys';
 
+import type * as Entity from './Entity';
 import * as internal from './internal';
 import * as Ref from './Ref';
 
@@ -337,6 +338,34 @@ export const updated = (range: TimeRange): Any => _timeRangeFilter('updatedAt', 
  * Filter objects by createdAt timestamp.
  */
 export const created = (range: TimeRange): Any => _timeRangeFilter('createdAt', range);
+
+export type ChildOfOptions = {
+  /** Whether to match transitively (grandchildren, etc.). Defaults to true. */
+  transitive?: boolean;
+};
+
+/**
+ * Filter objects that are children of the specified parent(s).
+ * Accepts ECHO objects, DXN values, or arrays of either.
+ * With transitive=true (default), also matches grandchildren and beyond.
+ */
+export const childOf = (
+  parents: Entity.Unknown | DXN | (Entity.Unknown | DXN)[],
+  options?: ChildOfOptions,
+): Any => {
+  const items = Array.isArray(parents) ? parents : [parents];
+  const dxns = items.map((item) => {
+    if (item instanceof DXN) {
+      return item.toString();
+    }
+    return internal.getDXN(item).toString();
+  });
+  return new FilterClass({
+    type: 'child-of',
+    parents: dxns,
+    transitive: options?.transitive ?? true,
+  });
+};
 
 /**
  * Negate the filter.

--- a/packages/core/echo/echo/src/Query.test.ts
+++ b/packages/core/echo/echo/src/Query.test.ts
@@ -668,6 +668,97 @@ describe('query api', () => {
     });
   });
 
+  describe('Filter.childOf', () => {
+    test('childOf with DXN', () => {
+      const parentDxn = DXN.fromSpaceAndObjectId(SpaceId.random(), ObjectId.random());
+      const filter = Filter.childOf(parentDxn);
+
+      expect(filter.ast).toMatchObject({
+        type: 'child-of',
+        parents: [parentDxn.toString()],
+        transitive: true,
+      });
+      Schema.validateSync(QueryAST.Filter)(filter.ast);
+    });
+
+    test('childOf with object', () => {
+      const parent = Obj.make(TestSchema.Person, { name: 'Parent' });
+      const filter = Filter.childOf(parent);
+
+      expect(filter.ast).toMatchObject({
+        type: 'child-of',
+        transitive: true,
+      });
+      expect(filter.ast.type === 'child-of' && filter.ast.parents.length).toBe(1);
+      Schema.validateSync(QueryAST.Filter)(filter.ast);
+    });
+
+    test('childOf with array of DXNs', () => {
+      const dxn1 = DXN.fromSpaceAndObjectId(SpaceId.random(), ObjectId.random());
+      const dxn2 = DXN.fromSpaceAndObjectId(SpaceId.random(), ObjectId.random());
+      const filter = Filter.childOf([dxn1, dxn2]);
+
+      expect(filter.ast).toMatchObject({
+        type: 'child-of',
+        parents: [dxn1.toString(), dxn2.toString()],
+        transitive: true,
+      });
+      Schema.validateSync(QueryAST.Filter)(filter.ast);
+    });
+
+    test('childOf with transitive=false', () => {
+      const parentDxn = DXN.fromSpaceAndObjectId(SpaceId.random(), ObjectId.random());
+      const filter = Filter.childOf(parentDxn, { transitive: false });
+
+      expect(filter.ast).toMatchObject({
+        type: 'child-of',
+        parents: [parentDxn.toString()],
+        transitive: false,
+      });
+      Schema.validateSync(QueryAST.Filter)(filter.ast);
+    });
+
+    test('childOf in select query', () => {
+      const parentDxn = DXN.fromSpaceAndObjectId(SpaceId.random(), ObjectId.random());
+      const query = Query.select(Filter.childOf(parentDxn));
+
+      expect(query.ast).toMatchObject({
+        type: 'select',
+        filter: {
+          type: 'child-of',
+          parents: [parentDxn.toString()],
+          transitive: true,
+        },
+      });
+      Schema.validateSync(QueryAST.Query)(query.ast);
+    });
+
+    test('childOf combined with type filter', () => {
+      const parentDxn = DXN.fromSpaceAndObjectId(SpaceId.random(), ObjectId.random());
+      const query = Query.select(Filter.and(Filter.type(TestSchema.Person), Filter.childOf(parentDxn)));
+
+      Schema.validateSync(QueryAST.Query)(query.ast);
+      expect(query.ast).toMatchObject({
+        type: 'select',
+        filter: {
+          type: 'and',
+          filters: [
+            { type: 'object', typename: 'dxn:type:com.example.type.person:0.1.0' },
+            { type: 'child-of', parents: [parentDxn.toString()], transitive: true },
+          ],
+        },
+      });
+    });
+
+    test('childOf pretty-prints correctly', () => {
+      const parentDxn = DXN.fromSpaceAndObjectId(SpaceId.random(), ObjectId.random());
+      const filter = Filter.childOf(parentDxn);
+      const pretty = Filter.pretty(filter);
+      expect(pretty).toContain('Filter.childOf');
+      expect(pretty).toContain('transitive: true');
+    });
+  });
+
   describe('Filter', () => {
     test('Filter.or(Filter.typename(...))', () => {
       const filter = Filter.or(Filter.typename('com.example.type.person'));

--- a/packages/core/echo/echo/src/internal/Query.ts
+++ b/packages/core/echo/echo/src/internal/Query.ts
@@ -43,6 +43,8 @@ export const prettyFilter = (filter: QueryAST.Filter): string => {
         : `Filter.textSearch(${JSON.stringify(filter.text)})`;
     case 'timestamp':
       return `Filter.${filter.field}.${filter.operator}(${filter.value})`;
+    case 'child-of':
+      return `Filter.childOf([${filter.parents.map((p) => JSON.stringify(p)).join(', ')}], { transitive: ${filter.transitive} })`;
     case 'not':
       return `Filter.not(${prettyFilter(filter.filter)})`;
     case 'and':


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `Filter.childOf()` to the ECHO query system, enabling filtering objects by their parent-child hierarchy. This supports both direct children and transitive descendants, and treats feed queue items as children of their Feed objects.

closes DX-910

## Changes

### AST (`echo-protocol`)
- Added `FilterChildOf` schema with `parents: DXN[]` and `transitive: boolean` fields to the Filter union type

### Query DSL (`echo`)
- Added `Filter.childOf(parents, options?)` factory function that accepts:
  - Single ECHO object, DXN, or array of either
  - Optional `{ transitive?: boolean }` (defaults to `true`)
- Added pretty-printing support for `child-of` filters

### Query Planner (`echo-pipeline`)
- Handle `child-of` as a standalone selection filter (wildcard select + filter step)
- Handle `child-of` in `AND` combinations with other filters (e.g., `Filter.and(Filter.childOf(parent), Filter.type(Task))`)

### Query Executor (`echo-pipeline`)
- Added `_execChildOfFilterStep` that delegates to `_isChildOfAny`
- `_isChildOfAny` walks up the parent chain comparing object IDs (handles DXN format differences between local and space-qualified references)
- For queue items without an explicit parent, treats the Feed object (identified by `queueId`) as the parent
- Supports transitive traversal up to `MAX_DEPTH_FOR_CHILD_OF_TRACING` (10 levels)

### Simple Query Path (`echo-db`)
- `child-of` filters bypass the simple in-memory query path and go through the full executor pipeline
- `filterMatchObject`/`filterMatchObjectJSON` throw on `child-of` (must be handled at executor level)

## Tests

### API Tests (`echo/src/Query.test.ts`)
- `childOf` with DXN, object, array of DXNs
- `childOf` with `transitive: false`
- `childOf` in select queries and combined with type filters
- Pretty-printing verification

### Integration Tests (`echo-db/src/query/query.test.ts`)
- Two echo objects: positive and negative tests
- Chain of three objects: transitive positive/negative, non-transitive positive/negative
- Object in feed: feed items matched as children of Feed object
- `A -> Feed -> B`: `childOf([A])` matches B through transitive Feed chain
- Type filter to prevent Feed from being returned
- Negative test with 2 feeds: items from only one matching
- `childOf` with DXN argument
- `childOf` with array of parents
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DX-910](https://linear.app/dxos/issue/DX-910/add-filterchildoft-or-dxn-or-t-or-dxn-options-transitive-true)

<div><a href="https://cursor.com/agents/bc-a859c2bb-ae02-45dd-95d3-578950b0b1b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a859c2bb-ae02-45dd-95d3-578950b0b1b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Filter.childOf()` to filter objects by parent relationships with optional transitive hierarchy matching, enabling queries across both direct and multi-level parent-child relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->