### PR TITLE
feat(edge-client): add clientTag support for WebSocket connections and update EdgeClient initialization

### DIFF
--- a/packages/core/mesh/edge-client/src/edge-client.ts
+++ b/packages/core/mesh/edge-client/src/edge-client.ts
@@ -39,6 +39,8 @@ export type MessengerConfig = {
   timeout?: number;
   protocol?: Protocol;
   disableAuth?: boolean;
+  /** Sent as `X-DXOS-Client-Tag` on the WebSocket upgrade (Node/`ws` only; ignored in browsers). */
+  clientTag?: string;
 };
 
 export interface EdgeConnection extends Required<Lifecycle> {
@@ -242,7 +244,11 @@ export class EdgeClient extends Resource implements EdgeConnection {
     log('Opening websocket', { url: url.toString(), protocolHeader });
     const connection = new EdgeWsConnection(
       identity,
-      { url, protocolHeader },
+      {
+        url,
+        protocolHeader,
+        headers: this._config.clientTag ? { 'X-DXOS-Client-Tag': this._config.clientTag } : undefined,
+      },
       {
         onConnected: () => {
           if (this._isActive(connection)) {

--- a/packages/core/mesh/edge-client/src/edge-ws-connection.ts
+++ b/packages/core/mesh/edge-client/src/edge-ws-connection.ts
@@ -50,7 +50,7 @@ export class EdgeWsConnection extends Resource {
 
   constructor(
     private readonly _identity: EdgeIdentity,
-    private readonly _connectionInfo: { url: URL; protocolHeader?: string },
+    private readonly _connectionInfo: { url: URL; protocolHeader?: string; headers?: Record<string, string> },
     private readonly _callbacks: EdgeWsConnectionCallbacks,
   ) {
     super();
@@ -121,6 +121,7 @@ export class EdgeWsConnection extends Resource {
       this._connectionInfo.protocolHeader
         ? [...baseProtocols, this._connectionInfo.protocolHeader]
         : [...baseProtocols],
+      this._connectionInfo.headers ? { headers: this._connectionInfo.headers } : undefined,
     );
     const muxer = new WebSocketMuxer(this._ws);
     this._wsMuxer = muxer;

--- a/packages/sdk/client-services/src/packlets/services/service-host.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-host.ts
@@ -259,7 +259,7 @@ export class ClientServicesHost {
     const endpoint = config?.get('runtime.services.edge.url');
     if (endpoint) {
       const clientTag = config?.get('runtime.app.env.DX_EDGE_CLIENT_TAG');
-      this._edgeConnection = new EdgeClient(createStubEdgeIdentity(), { socketEndpoint: endpoint });
+      this._edgeConnection = new EdgeClient(createStubEdgeIdentity(), { socketEndpoint: endpoint, clientTag });
       this._edgeHttpClient = new EdgeHttpClient(endpoint, { clientTag });
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure**
  * Enhanced Edge connection configuration to support custom client identification headers and improved WebSocket connection initialization with optional parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->