### PR TITLE
feat(echo-db): make Obj.getParent return Feed object for feed items

### DIFF
--- a/packages/core/echo/echo-db/src/queue/feed-service.ts
+++ b/packages/core/echo/echo-db/src/queue/feed-service.ts
@@ -4,9 +4,11 @@
 
 import * as Layer from 'effect/Layer';
 
-import { type Entity, Feed, type Filter, type Query } from '@dxos/echo';
+import { type Entity, Feed, type Filter, Obj, type Query } from '@dxos/echo';
 
 import type { QueueAPI } from './queue-factory';
+import type { QueueImpl } from './queue';
+
 /**
  * Creates a Feed.FeedService Effect layer backed by a QueueFactory.
  * This bridges the Feed public API (in echo) to the queue implementation (in echo-db).
@@ -19,7 +21,8 @@ export const createFeedServiceLayer = (queues: QueueAPI) =>
       if (!feedDxn) {
         throw new Error('Unable to append to feed: make sure feed is stored in the database');
       }
-      const queue = queues.get(feedDxn);
+      const queue = queues.get(feedDxn) as QueueImpl;
+      queue.setParentEntity(feed as Obj.Unknown);
       await queue.append(items);
     },
 
@@ -37,7 +40,8 @@ export const createFeedServiceLayer = (queues: QueueAPI) =>
       if (!feedDxn) {
         throw new Error('Unable to query feed: make sure feed is stored in the database');
       }
-      const queue = queues.get(feedDxn);
+      const queue = queues.get(feedDxn) as QueueImpl;
+      queue.setParentEntity(feed as Obj.Unknown);
       return queue.query(queryOrFilter as any);
     },
   });

--- a/packages/core/echo/echo-db/src/queue/feed-service.ts
+++ b/packages/core/echo/echo-db/src/queue/feed-service.ts
@@ -6,8 +6,8 @@ import * as Layer from 'effect/Layer';
 
 import { type Entity, Feed, type Filter, Obj, type Query } from '@dxos/echo';
 
-import type { QueueAPI } from './queue-factory';
 import type { QueueImpl } from './queue';
+import type { QueueAPI } from './queue-factory';
 
 /**
  * Creates a Feed.FeedService Effect layer backed by a QueueFactory.

--- a/packages/core/echo/echo-db/src/queue/feed.test.ts
+++ b/packages/core/echo/echo-db/src/queue/feed.test.ts
@@ -102,6 +102,47 @@ describe('Feed', () => {
     }).pipe(Effect.provide(testLayer), runAndForwardErrors);
   });
 
+  test('getParent returns Feed object for appended items', async ({ expect }) => {
+    await using peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Person] });
+    const db = await peer.createDatabase();
+    const queues = peer.client.constructQueueFactory(db.spaceId);
+    const testLayer = Layer.merge(Database.layer(db), createFeedServiceLayer(queues));
+
+    await Effect.gen(function* () {
+      const feed = yield* Database.add(Feed.make({ name: 'parent-test' }));
+
+      const alice = Obj.make(TestSchema.Person, { name: 'alice' });
+      yield* Feed.append(feed, [alice]);
+
+      const parent = Obj.getParent(alice);
+      expect(parent).toBeDefined();
+      expect(parent).toBe(feed);
+    }).pipe(Effect.provide(testLayer), runAndForwardErrors);
+  });
+
+  test('getParent returns Feed object for queried items', async ({ expect }) => {
+    await using peer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Person] });
+    const db = await peer.createDatabase();
+    const queues = peer.client.constructQueueFactory(db.spaceId);
+    const testLayer = Layer.merge(Database.layer(db), createFeedServiceLayer(queues));
+
+    await Effect.gen(function* () {
+      const feed = yield* Database.add(Feed.make({ name: 'parent-query-test' }));
+
+      const alice = Obj.make(TestSchema.Person, { name: 'alice' });
+      const bob = Obj.make(TestSchema.Person, { name: 'bob' });
+      yield* Feed.append(feed, [alice, bob]);
+
+      const results = yield* Feed.runQuery(feed, Filter.type(TestSchema.Person));
+      expect(results).toHaveLength(2);
+      for (const item of results) {
+        const parent = Obj.getParent(item);
+        expect(parent).toBeDefined();
+        expect(parent).toBe(feed);
+      }
+    }).pipe(Effect.provide(testLayer), runAndForwardErrors);
+  });
+
   // TODO(wittjosiah): Implement when queue retention is supported.
   test.todo('setRetention configures feed retention policy');
 });

--- a/packages/core/echo/echo-db/src/queue/queue.ts
+++ b/packages/core/echo/echo-db/src/queue/queue.ts
@@ -9,7 +9,7 @@ import { Event } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { type Database, Entity, Obj, type Ref } from '@dxos/echo';
 import { Filter, Query } from '@dxos/echo';
-import { type ObjectJSON, SelfDXNId, assertObjectModel, setRefResolverOnData } from '@dxos/echo/internal';
+import { type ObjectJSON, ParentId, SelfDXNId, assertObjectModel, setRefResolverOnData } from '@dxos/echo/internal';
 import { defineHiddenProperty } from '@dxos/echo/internal';
 import { failedInvariant } from '@dxos/invariant';
 import { type DXN, type ObjectId, type SpaceId } from '@dxos/keys';
@@ -76,6 +76,8 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
         return;
       }
 
+      this.#setParentOnItems(decodedObjects);
+
       for (const obj of decodedObjects) {
         this._objectCache.set(obj.id, obj as T);
       }
@@ -109,6 +111,8 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
    */
   private _pollingHandlers: number = 0;
 
+  private _parentEntity: Obj.Unknown | undefined = undefined;
+
   private _objectCache = new Map<ObjectId, T>();
   private _objects: T[] = [];
   private _isLoading = true;
@@ -126,6 +130,14 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
     this._subspaceTag = subspaceTag ?? failedInvariant();
     this._spaceId = spaceId ?? failedInvariant();
     this._queueId = queueId ?? failedInvariant();
+  }
+
+  /**
+   * Set the parent entity for items in this queue.
+   * When set, all deserialized items will have their parent set to this entity.
+   */
+  setParentEntity(parent: Obj.Unknown): void {
+    this._parentEntity = parent;
   }
 
   toJSON() {
@@ -182,6 +194,8 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
       setRefResolverOnData(item, this._refResolver);
       defineHiddenProperty(item, SelfDXNId, this._dxn.extend([item.id]));
     }
+
+    this.#setParentOnItems(items);
 
     // Optimistic update.
     this._objects = [...this._objects, ...items];
@@ -279,6 +293,7 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
         .filter(Predicate.isNotUndefined),
     );
 
+    this.#setParentOnItems(decodedObjects as Entity.Unknown[]);
     return decodedObjects as T[];
   }
 
@@ -299,6 +314,7 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
       dxn: this._dxn.extend([(obj as any).id]),
       database: this._database,
     });
+    this.#setParentOnItems([decoded]);
     return decoded;
   }
 
@@ -358,6 +374,14 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
         this._pollingInterval = null;
       }
     };
+  }
+
+  #setParentOnItems(items: Entity.Unknown[]): void {
+    if (this._parentEntity) {
+      for (const item of items) {
+        defineHiddenProperty(item, ParentId, this._parentEntity);
+      }
+    }
   }
 
   async dispose() {

--- a/packages/core/echo/echo-db/src/queue/queue.ts
+++ b/packages/core/echo/echo-db/src/queue/queue.ts
@@ -64,6 +64,7 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
               refResolver: this._refResolver,
               dxn: this._dxn.extend([(obj as any).id]),
               database: this._database,
+              parent: this._parentEntity,
             });
           } catch (err) {
             log.verbose('schema validation error; object ignored', { obj, error: err });
@@ -75,8 +76,6 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
       if (thisRefreshId !== this._refreshId) {
         return;
       }
-
-      this.#setParentOnItems(decodedObjects);
 
       for (const obj of decodedObjects) {
         this._objectCache.set(obj.id, obj as T);
@@ -193,9 +192,10 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
     for (const item of items) {
       setRefResolverOnData(item, this._refResolver);
       defineHiddenProperty(item, SelfDXNId, this._dxn.extend([item.id]));
+      if (this._parentEntity) {
+        defineHiddenProperty(item, ParentId, this._parentEntity);
+      }
     }
-
-    this.#setParentOnItems(items);
 
     // Optimistic update.
     this._objects = [...this._objects, ...items];
@@ -282,6 +282,7 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
               refResolver: this._refResolver,
               dxn: this._dxn.extend([(obj as any).id]),
               database: this._database,
+              parent: this._parentEntity,
             });
             this._objectCache.set(decoded.id, decoded as T);
             return decoded;
@@ -293,7 +294,6 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
         .filter(Predicate.isNotUndefined),
     );
 
-    this.#setParentOnItems(decodedObjects as Entity.Unknown[]);
     return decodedObjects as T[];
   }
 
@@ -313,8 +313,8 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
       refResolver: this._refResolver,
       dxn: this._dxn.extend([(obj as any).id]),
       database: this._database,
+      parent: this._parentEntity,
     });
-    this.#setParentOnItems([decoded]);
     return decoded;
   }
 
@@ -374,14 +374,6 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
         this._pollingInterval = null;
       }
     };
-  }
-
-  #setParentOnItems(items: Entity.Unknown[]): void {
-    if (this._parentEntity) {
-      for (const item of items) {
-        defineHiddenProperty(item, ParentId, this._parentEntity);
-      }
-    }
   }
 
   async dispose() {

--- a/packages/core/echo/echo/src/Obj.ts
+++ b/packages/core/echo/echo/src/Obj.ts
@@ -808,7 +808,7 @@ export const toJSON = (entity: Unknown | Snapshot): JSON => objInternal.objectTo
  */
 export const fromJSON: (
   json: unknown,
-  options?: { refResolver?: Ref.Resolver; dxn?: DXN; database?: Database.Database },
+  options?: { refResolver?: Ref.Resolver; dxn?: DXN; database?: Database.Database; parent?: Unknown },
 ) => Promise<Unknown> = objInternal.objectFromJSON as any;
 
 /**

--- a/packages/core/echo/echo/src/internal/Obj/json-serializer.ts
+++ b/packages/core/echo/echo/src/internal/Obj/json-serializer.ts
@@ -80,7 +80,12 @@ export const objectToJSON = <T extends AnyEntity>(obj: T): SerializedObject<T> =
  */
 export const objectFromJSON = async (
   jsonData: unknown,
-  { refResolver, dxn, database }: { refResolver?: RefResolver; dxn?: DXN; database?: Database.Database } = {},
+  {
+    refResolver,
+    dxn,
+    database,
+    parent,
+  }: { refResolver?: RefResolver; dxn?: DXN; database?: Database.Database; parent?: Obj.Unknown } = {},
 ): Promise<AnyEntity> => {
   assumeType<ObjectJSON>(jsonData);
   assertArgument(typeof jsonData === 'object' && jsonData !== null, 'jsonData', 'expect object');
@@ -138,7 +143,9 @@ export const objectFromJSON = async (
 
   if (jsonData[ATTR_PARENT]) {
     const parentDxn = DXN.parse(jsonData[ATTR_PARENT]);
-    const parent = (await refResolver?.resolve(parentDxn)) as Obj.Unknown | undefined;
+    const resolvedParent = (await refResolver?.resolve(parentDxn)) as Obj.Unknown | undefined;
+    defineHiddenProperty(obj, ParentId, resolvedParent);
+  } else if (parent) {
     defineHiddenProperty(obj, ParentId, parent);
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When items are stored in a Feed, `Obj.getParent()` now returns the Feed object that contains them. Previously, feed items had no parent set.

## Changes

### `packages/core/echo/echo/src/internal/Obj/json-serializer.ts`
- Added `parent` option to `objectFromJSON`. When provided and no `@parent` attribute exists in the JSON data, the parent is set on the deserialized object during construction.

### `packages/core/echo/echo/src/Obj.ts`
- Updated `Obj.fromJSON` public type signature to include the new `parent?: Unknown` option.

### `packages/core/echo/echo-db/src/queue/queue.ts`
- All `Obj.fromJSON` calls now pass `parent: this._parentEntity` through the options, setting parent during deserialization rather than post-hoc.
- The `append` path sets parent via `defineHiddenProperty` directly (items don't go through `fromJSON`).
- Retained `_parentEntity` field and `setParentEntity()` method for the queue to know which entity is the parent.

### `packages/core/echo/echo-db/src/queue/feed-service.ts`
- In both `append` and `query` operations, the feed object is set as the parent entity on the underlying queue before performing the operation.

### `packages/core/echo/echo-db/src/queue/feed.test.ts`
- Added test: `getParent returns Feed object for appended items` - verifies parent is set immediately after `Feed.append`
- Added test: `getParent returns Feed object for queried items` - verifies parent is set on items returned from `Feed.runQuery`

## Review feedback addressed
- Moved parent setting into `Obj.fromJSON` options (`parent`) per reviewer request, instead of applying it post-hoc with a separate helper.

## Verification
- All echo-db tests pass (553 tests, 26 test files)
- All echo tests pass
- Build passes
- Lint passes

Closes DX-913
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DX-913](https://linear.app/dxos/issue/DX-913/make-objgetparent-return-the-feed-object-when-called-on-items-in-feed)

<div><a href="https://cursor.com/agents/bc-c1e5965e-029c-4a39-8f06-7564a227a8bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1e5965e-029c-4a39-8f06-7564a227a8bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Objects appended to or queried from feeds now properly maintain parent-child relationships, ensuring consistent entity hierarchy tracking across append and query operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->