### PR TITLE
fix(assistant-toolkit): address review comments on query `in` parameter

### DIFF
--- a/packages/core/assistant-toolkit/src/blueprints/database/blueprint.test.ts
+++ b/packages/core/assistant-toolkit/src/blueprints/database/blueprint.test.ts
@@ -454,37 +454,6 @@ describe('Database Blueprint', () => {
   );
 
   it.effect(
-    'query operation: in param scopes to children via invokeFunction',
-    Effect.fnUntraced(
-      function* ({ expect }) {
-        const parent = yield* Database.add(Obj.make(Organization.Organization, { name: 'Parent Org' }));
-        yield* Database.add(
-          Obj.make(Organization.Organization, {
-            [Obj.Parent]: parent,
-            name: 'Child Org',
-          }),
-        );
-        yield* Database.add(Obj.make(Organization.Organization, { name: 'Unrelated Org' }));
-        yield* Database.flush();
-
-        const { db } = yield* Database.Service;
-        const parentRef = db.makeRef(Obj.getDXN(parent)) as Ref.Ref<any>;
-
-        const results = yield* FunctionInvocationService.invokeFunction(DatabaseQueryOperation, {
-          in: [parentRef],
-          limit: 20,
-        });
-        type QueryRow = { typename?: string; label?: string };
-        expect(results).toHaveLength(1);
-        expect((results as QueryRow[]).some((row) => String(row.label ?? '').includes('Child Org'))).toBe(true);
-        expect((results as QueryRow[]).some((row) => String(row.label ?? '').includes('Unrelated'))).toBe(false);
-      },
-      Effect.provide(TestLayer),
-      TestHelpers.provideTestContext,
-    ),
-  );
-
-  it.effect(
     'query: in param scopes to feed children (agent uses Query tool)',
     Effect.fnUntraced(
       function* (_) {
@@ -507,20 +476,10 @@ describe('Database Blueprint', () => {
         ]);
         yield* Database.flush();
 
-        const feed1Dxn = Obj.getDXN(feed1).toString();
-
         const agent = yield* AgentService.createSession({
           blueprints: [DatabaseBlueprint.make()],
         });
-        yield* agent.submitPrompt(trim`
-          Query for organizations scoped to a specific feed. Use the Query tool with:
-          - in: [{"/" : "${feed1Dxn}"}]
-          - includeQueues: true
-          - includeContent: false
-          - limit: 20
-
-          Confirm which organizations you found.
-        `);
+        yield* agent.submitPrompt('Query for organizations in "inbox-1" feed.');
         yield* agent.waitForCompletion();
       },
       Effect.provide(TestLayer),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #10983 addressing review comments from @dmaretskyi.

## Changes

- **Removed `invokeFunction` test** for `in` param — per review, keep only the agent test
- **Simplified agent prompt** from explicit tool parameter instructions to natural language: `'Query for organizations in "inbox-1" feed.'` — tests that the agent understands the `in` parameter instructions without hand-holding
- **Regenerated memoized LLM conversations**

## Test results
- All 17 database blueprint tests pass
- The agent correctly uses the `in` parameter with the natural prompt, finding only "Email Corp Alpha" from inbox-1 (not Beta from inbox-2)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DX-911](https://linear.app/dxos/issue/DX-911/add-in-parameter-to-database-blueprint-query-tool)

<div><a href="https://cursor.com/agents/bc-1c33fbee-9765-42ee-9825-953883b5d8eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c33fbee-9765-42ee-9825-953883b5d8eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an integration test for database query operation parameter scoping.
  * Simplified an integration test prompt for query functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->