### PR TITLE
fix(operation): last registration wins for duplicate operation handlers

### DIFF
--- a/packages/core/operation/src/OperationInvoker.ts
+++ b/packages/core/operation/src/OperationInvoker.ts
@@ -199,7 +199,8 @@ class OperationInvokerImpl implements OperationInvokerInternal {
   ): Effect.Effect<Operation.Handler<any, any, NoHandlerError, Operation.Service> | undefined> {
     return Effect.gen(this, function* () {
       const match = yield* this._getHandlers().pipe(
-        Effect.map((handlers) => handlers.find((reg) => reg.meta.key === operation.meta.key)),
+        // Last registration wins so plugins can override earlier handlers (e.g. story testing hooks).
+        Effect.map((handlers) => handlers.findLast((reg) => reg.meta.key === operation.meta.key)),
       );
 
       return match?.handler;


### PR DESCRIPTION
## Summary

`OperationInvoker` resolved duplicate operation handlers with `Array.prototype.find`, so the **first** registered handler always won. Plugins that register later (e.g. story testing overriding `AssistantOperation.CreateChat`) never ran.

Use `findLast` so **later** registrations override earlier defaults.

## Context

This fixes stories-assistant chat stories where `onChatCreated` was never invoked because the assistant plugin registered `CreateChat` first.

cc @richburdon

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated handler selection to use the most recently registered handler when multiple handlers match the same operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->