### PR TITLE
feat(database): add registerSchema function to persist schemas and improve InvocationTraceContainer with storybook support

### DIFF
--- a/packages/core/echo/echo/src/Database.ts
+++ b/packages/core/echo/echo/src/Database.ts
@@ -308,6 +308,18 @@ export const runQueryFirst: {
   );
 
 /**
+ * Persists schemas in the database so they replicate to other clients.
+ * @see {@link SchemaRegistry.SchemaRegistry.register}
+ */
+export const registerSchema = (
+  input: SchemaRegistry.RegisterSchemaInput[],
+): Effect.Effect<Type.RuntimeType[], never, Service> =>
+  Service.pipe(
+    Effect.flatMap(({ db }) => promiseWithCauseCapture(() => db.schemaRegistry.register(input))),
+    Effect.withSpan('Database.registerSchema'),
+  );
+
+/**
  * Creates a schema query result that can be subscribed to.
  */
 // TODO(dmaretskyi): Change API to `yield* Database.querySchema(...).first` and `yield* Database.querySchema(...).schema`.

--- a/packages/devtools/devtools/src/panels/edge/InvocationTracePanel/InvocationTraceContainer.stories.tsx
+++ b/packages/devtools/devtools/src/panels/edge/InvocationTracePanel/InvocationTraceContainer.stories.tsx
@@ -1,0 +1,82 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+
+import { type InvocationSpan, InvocationOutcome } from '@dxos/functions-runtime';
+import { ObjectId } from '@dxos/keys';
+import { withClientProvider } from '@dxos/react-client/testing';
+import { withLayout, withTheme } from '@dxos/react-ui/testing';
+import { withRegistry } from '@dxos/storybook-utils';
+
+import { InvocationTraceContainer } from './InvocationTraceContainer';
+
+const TARGETS = ['Airtable Webhook', 'Discord Bot', 'Email Processor', 'Slack Notifier', 'Data Sync'];
+
+const createMockSpans = (count: number): InvocationSpan[] => {
+  const base = Date.now() - count * 60_000;
+
+  return Array.from({ length: count }, (_, index) => {
+    const timestamp = base + index * 60_000 + Math.random() * 30_000;
+    const duration = 200 + Math.random() * 15_000;
+    const isFailed = index % 7 === 0;
+    const isPending = index % 13 === 0;
+
+    return {
+      id: ObjectId.random(),
+      timestamp,
+      duration,
+      outcome: isPending ? InvocationOutcome.PENDING : isFailed ? InvocationOutcome.FAILURE : InvocationOutcome.SUCCESS,
+      input: {
+        event: `trigger_${index}`,
+        target: TARGETS[index % TARGETS.length],
+        payload: { timestamp: new Date(timestamp).toISOString(), attempt: 1 },
+      },
+      error: isFailed
+        ? {
+            name: 'InvocationError',
+            message: `Function "${TARGETS[index % TARGETS.length]}" timed out after 30s`,
+            stack: [
+              `Error: Function "${TARGETS[index % TARGETS.length]}" timed out after 30s`,
+              '    at runFunction (worker.ts:42:5)',
+              '    at processInvocation (scheduler.ts:118:12)',
+              '    at async EdgeRuntime.execute (runtime.ts:67:3)',
+            ].join('\n'),
+          }
+        : undefined,
+    } satisfies InvocationSpan;
+  });
+};
+
+const MOCK_SPANS = createMockSpans(50);
+
+const meta = {
+  title: 'devtools/devtools/InvocationTrace/InvocationTraceContainer',
+  component: InvocationTraceContainer,
+  decorators: [
+    withTheme(),
+    withLayout({ layout: 'fullscreen' }),
+    withRegistry,
+    withClientProvider({ createIdentity: true }),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    invocationSpans: MOCK_SPANS,
+    detailAxis: 'block',
+  },
+} satisfies Meta<typeof InvocationTraceContainer>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const InlineAxis: Story = {
+  args: {
+    detailAxis: 'inline',
+  },
+};

--- a/packages/devtools/devtools/src/panels/edge/InvocationTracePanel/InvocationTraceContainer.tsx
+++ b/packages/devtools/devtools/src/panels/edge/InvocationTracePanel/InvocationTraceContainer.tsx
@@ -6,7 +6,7 @@ import * as Array from 'effect/Array';
 import * as Match from 'effect/Match';
 import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
-import React, { KeyboardEvent, type FC, useCallback, useMemo, useState } from 'react';
+import React, { type FC, useCallback, useMemo, useState } from 'react';
 
 import { type Database, Filter, type Obj } from '@dxos/echo';
 import { Format } from '@dxos/echo/internal';
@@ -17,7 +17,7 @@ import { type SerializedError } from '@dxos/protocols';
 import { useQuery } from '@dxos/react-client/echo';
 import { Toolbar } from '@dxos/react-ui';
 import { SyntaxHighlighter } from '@dxos/react-ui-syntax-highlighter';
-import { type TableFeatures, type TablePropertyDefinition } from '@dxos/react-ui-table';
+import { DynamicTable, type TableFeatures, type TablePropertyDefinition } from '@dxos/react-ui-table';
 import { Tabs } from '@dxos/react-ui-tabs';
 import { composable, composableProps, mx } from '@dxos/ui-theme';
 
@@ -173,7 +173,6 @@ export const InvocationTraceContainer = composable<HTMLDivElement, InvocationTra
     return (
       <div {...composableProps(props, { classNames: ['h-full', classNames] })} ref={forwardedRef}>
         <PanelContainer
-          classNames='overflow-hidden'
           toolbar={
             showSpaceSelector ? (
               <Toolbar.Root classNames='border-b border-subdued-separator'>
@@ -182,53 +181,11 @@ export const InvocationTraceContainer = composable<HTMLDivElement, InvocationTra
             ) : undefined
           }
         >
-          <div className={mx('h-full min-h-0 overflow-hidden', gridLayout)}>
-            {/* <DynamicTable properties={properties} rows={rows} features={features} onRowClick={handleRowClick} /> */}
-            <div className='min-h-0 min-w-0 overflow-auto'>
-              <table className='table-fixed min-w-full text-xs border-collapse'>
-                <thead className='sticky top-0 z-10 bg-background'>
-                  <tr>
-                    <th>ID</th>
-                    <th>Target</th>
-                    <th>Started</th>
-                    <th>Duration</th>
-                    <th>Status</th>
-                    <th>Queue</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rows
-                    .toSorted((a, b) => b.time.getTime() - a.time.getTime())
-                    .slice(0, 50)
-                    .map((row) => (
-                      <tr
-                        key={row.id}
-                        role='button'
-                        tabIndex={0}
-                        aria-selected={selectedId === row.id}
-                        onClick={() => handleRowClick(row)}
-                        onKeyDown={(e: KeyboardEvent<HTMLTableRowElement>) => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault();
-                            handleRowClick(row);
-                          }
-                        }}
-                        className='cursor-pointer focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent'
-                      >
-                        <td className='px-2 py-1 whitespace-nowrap border border-separator'>{row.id}</td>
-                        <td className='px-2 py-1 whitespace-nowrap border border-separator'>{row.target}</td>
-                        <td className='px-2 py-1 whitespace-nowrap border border-separator'>
-                          {row.time.toLocaleString()}
-                        </td>
-                        <td className='px-2 py-1 whitespace-nowrap border border-separator'>{row.duration}</td>
-                        <td className='px-2 py-1 whitespace-nowrap border border-separator'>{row.status}</td>
-                        <td className='px-2 py-1 whitespace-nowrap border border-separator'>{row.queue}</td>
-                      </tr>
-                    ))}
-                </tbody>
-              </table>
+          <div className='relative flex-1 min-h-0'>
+            <div className={mx('absolute inset-0 overflow-hidden', gridLayout)}>
+              <DynamicTable properties={properties} rows={rows} features={features} onRowClick={handleRowClick} />
+              {selectedInvocation && <Selected span={selectedInvocation} />}
             </div>
-            {selectedInvocation && <Selected span={selectedInvocation} />}
           </div>
         </PanelContainer>
       </div>
@@ -253,7 +210,7 @@ const Selected: FC<{ span: InvocationSpan }> = ({ span }) => {
   const isLogQueue = 'logs' === contents || objects.length === 0;
 
   return (
-    <div className='grid grid-cols-1 grid-rows-[min-content_1fr] h-full min-h-0 overflow-hidden border-separator'>
+    <div className='grid grid-cols-1 grid-rows-[min-content_1fr] min-h-0 overflow-hidden border-separator'>
       <Tabs.Root
         classNames='grid grid-rows-[min-content_1fr] min-h-0 [&>[role="tabpanel"]]:min-h-0 [&>[role="tabpanel"][data-state="active"]]:grid border-t border-separator'
         orientation='horizontal'

--- a/packages/devtools/devtools/src/panels/edge/InvocationTracePanel/InvocationTraceContainer.tsx
+++ b/packages/devtools/devtools/src/panels/edge/InvocationTracePanel/InvocationTraceContainer.tsx
@@ -36,12 +36,27 @@ export type InvocationTraceContainerProps = {
   showSpaceSelector?: boolean;
   target?: Obj.Unknown;
   detailAxis?: 'block' | 'inline';
+  /** Overrides hook-provided spans (for testing/storybook). */
+  invocationSpans?: InvocationSpan[];
 };
 
 export const InvocationTraceContainer = composable<HTMLDivElement, InvocationTraceContainerProps>(
-  ({ classNames, db, queueDxn, detailAxis = 'inline', showSpaceSelector = false, target, ...props }, forwardedRef) => {
+  (
+    {
+      classNames,
+      db,
+      queueDxn,
+      detailAxis = 'inline',
+      showSpaceSelector = false,
+      target,
+      invocationSpans: invocationSpansProp,
+      ...props
+    },
+    forwardedRef,
+  ) => {
     const resolver = useFunctionNameResolver({ db });
-    const invocationSpans = useInvocationSpans({ queueDxn, target });
+    const hookSpans = useInvocationSpans({ queueDxn, target });
+    const invocationSpans = invocationSpansProp ?? hookSpans;
 
     const [selectedId, setSelectedId] = useState<string>();
     const selectedInvocation = useMemo(() => {
@@ -139,13 +154,13 @@ export const InvocationTraceContainer = composable<HTMLDivElement, InvocationTra
       if (selectedInvocation) {
         switch (detailAxis) {
           case 'inline':
-            return 'grid grid-cols-[1fr_30rem]';
+            return 'grid grid-cols-[minmax(0,1fr)_30rem] grid-rows-[minmax(0,1fr)]';
           case 'block':
-            return 'grid grid-rows-[1fr_2fr]';
+            return 'grid grid-rows-[minmax(0,1fr)_minmax(0,2fr)]';
         }
       }
 
-      return 'grid grid-cols-1';
+      return 'grid grid-cols-1 grid-rows-[minmax(0,1fr)]';
     }, [selectedInvocation, detailAxis]);
 
     const features: Partial<TableFeatures> = useMemo(
@@ -158,6 +173,7 @@ export const InvocationTraceContainer = composable<HTMLDivElement, InvocationTra
     return (
       <div {...composableProps(props, { classNames: ['h-full', classNames] })} ref={forwardedRef}>
         <PanelContainer
+          classNames='overflow-hidden'
           toolbar={
             showSpaceSelector ? (
               <Toolbar.Root classNames='border-b border-subdued-separator'>
@@ -166,9 +182,9 @@ export const InvocationTraceContainer = composable<HTMLDivElement, InvocationTra
             ) : undefined
           }
         >
-          <div className={mx('h-full', gridLayout)}>
+          <div className={mx('h-full min-h-0 overflow-hidden', gridLayout)}>
             {/* <DynamicTable properties={properties} rows={rows} features={features} onRowClick={handleRowClick} /> */}
-            <div className='overflow-auto'>
+            <div className='min-h-0 min-w-0 overflow-auto'>
               <table className='table-fixed min-w-full text-xs border-collapse'>
                 <thead className='sticky top-0 z-10 bg-background'>
                   <tr>
@@ -237,7 +253,7 @@ const Selected: FC<{ span: InvocationSpan }> = ({ span }) => {
   const isLogQueue = 'logs' === contents || objects.length === 0;
 
   return (
-    <div className='grid grid-cols-1 grid-rows-[min-content_1fr] h-full min-h-0 border-separator'>
+    <div className='grid grid-cols-1 grid-rows-[min-content_1fr] h-full min-h-0 overflow-hidden border-separator'>
       <Tabs.Root
         classNames='grid grid-rows-[min-content_1fr] min-h-0 [&>[role="tabpanel"]]:min-h-0 [&>[role="tabpanel"][data-state="active"]]:grid border-t border-separator'
         orientation='horizontal'

--- a/packages/plugins/plugin-script/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-script/src/capabilities/react-surface.tsx
@@ -55,11 +55,6 @@ export default Capability.makeModule(() =>
         component: ({ data, role }) => {
           const compiler = useCompiler();
           const settings = useAtomCapability(ScriptCapabilities.Settings);
-          // TODO(wittjosiah): Why? The editor should be allow to render even if the environment is not ready.
-          if (!compiler?.environment) {
-            return null;
-          }
-
           return (
             <ScriptContainer
               role={role}

--- a/packages/plugins/plugin-script/src/compiler/compiler.ts
+++ b/packages/plugins/plugin-script/src/compiler/compiler.ts
@@ -14,8 +14,12 @@ import { invariant } from '@dxos/invariant';
 
 const GLOBALS = 'globals.d.ts';
 
-/** TS version hosted on playgroundcdn.typescriptlang.org used to fetch lib .d.ts files. */
-const CDN_TS_VERSION = '5.7.2';
+/** TS version hosted on playgroundcdn.typescriptlang.org used to fetch lib .d.ts files.
+ * Pinned to 5.6.3 because 5.7+ removed lib.es2022.sharedmemory.d.ts from the CDN.
+ * The remaining 404s (lib.core.d.ts, lib.core.es6/7.d.ts, lib.es7.d.ts) are phantom
+ * entries in @typescript/vfs's hardcoded file list and are harmlessly caught.
+ */
+const CDN_TS_VERSION = '5.6.3';
 
 const defaultOptions: ts.CompilerOptions = {
   lib: ['DOM', 'es2022'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a schema registration API to persist and register schemas.

* **Bug Fixes**
  * Fixed script rendering to reliably display regardless of compiler environment status.

* **Improvements**
  * Enhanced invocation trace panel layout with improved overflow containment and flexible grid sizing.

* **Documentation**
  * Added a Storybook story demonstrating the invocation trace container with mock spans.

* **Chores**
  * Updated TypeScript CDN version handling for compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->