### PR TITLE
feat(plugin-inbox): add settings with thread grouping

### DIFF
--- a/packages/plugins/plugin-inbox/src/InboxPlugin.tsx
+++ b/packages/plugins/plugin-inbox/src/InboxPlugin.tsx
@@ -19,13 +19,14 @@ import { CalendarBlueprint, InboxBlueprint } from '#blueprints';
 import {
   AppGraphBuilder,
   BlueprintDefinition,
+  InboxSettings,
   NavigationResolver,
   OperationHandler,
   ReactSurface,
 } from '#capabilities';
 import { meta } from '#meta';
 import { InboxOperation } from '#operations';
-import { Calendar, Mailbox } from '#types';
+import { Calendar, InboxEvents, Mailbox } from '#types';
 
 import { translations } from './translations';
 import { CreateCalendarSchema } from './types/Calendar';
@@ -118,6 +119,11 @@ export const InboxPlugin = Plugin.define(meta).pipe(
   }),
   AppPlugin.addSurfaceModule({ activate: ReactSurface }),
   AppPlugin.addTranslationsModule({ translations }),
+  Plugin.addModule({
+    activatesOn: AppActivationEvents.SetupSettings,
+    activatesAfter: [InboxEvents.SettingsReady],
+    activate: InboxSettings,
+  }),
   Plugin.addModule({
     id: 'on-space-created',
     activatesOn: SpaceEvents.SpaceCreated,

--- a/packages/plugins/plugin-inbox/src/capabilities/index.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/index.ts
@@ -13,3 +13,4 @@ export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHan
   () => import('./operation-handler'),
 );
 export const ReactSurface = Capability.lazy('ReactSurface', () => import('./react-surface'));
+export const InboxSettings = Capability.lazy('InboxSettings', () => import('./settings'));

--- a/packages/plugins/plugin-inbox/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-inbox/src/capabilities/react-surface.tsx
@@ -6,13 +6,14 @@ import * as Effect from 'effect/Effect';
 import React from 'react';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
-import { Surface } from '@dxos/app-framework/ui';
+import { Surface, useSettingsState } from '@dxos/app-framework/ui';
 import { useActiveSpace } from '@dxos/app-toolkit/ui';
 import { AppSurface, useAppGraph } from '@dxos/app-toolkit/ui';
 import { Obj } from '@dxos/echo';
 import { getParentId, useNode } from '@dxos/plugin-graph';
 import { Event, Message, Organization, Person } from '@dxos/types';
 
+import { InboxSettings } from '#components';
 import {
   CalendarArticle,
   CalendarProperties,
@@ -28,7 +29,8 @@ import {
   RelatedToOrganization,
   SaveFilterPopover,
 } from '#containers';
-import { Calendar, DraftMessage, Mailbox } from '#types';
+import { meta } from '#meta';
+import { Calendar, DraftMessage, Mailbox, type Settings } from '#types';
 
 import { MAILBOX_DRAFTS_NODE_DATA, POPOVER_SAVE_FILTER } from '../constants';
 import { getDraftsId } from '../paths';
@@ -36,6 +38,15 @@ import { getDraftsId } from '../paths';
 export default Capability.makeModule(() =>
   Effect.succeed(
     Capability.contributes(Capabilities.ReactSurface, [
+      Surface.create({
+        id: 'plugin-settings',
+        role: 'article',
+        filter: AppSurface.settingsArticle(meta.id),
+        component: ({ data: { subject } }) => {
+          const { settings, updateSettings } = useSettingsState<Settings.Settings>(subject.atom);
+          return <InboxSettings settings={settings} onSettingsChange={updateSettings} />;
+        },
+      }),
       Surface.create({
         id: 'drafts',
         role: ['article'],

--- a/packages/plugins/plugin-inbox/src/capabilities/settings.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/settings.ts
@@ -1,0 +1,33 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capability } from '@dxos/app-framework';
+import { AppCapabilities } from '@dxos/app-toolkit';
+import { createKvsStore } from '@dxos/effect';
+
+import { meta } from '#meta';
+import { InboxCapabilities, Settings } from '#types';
+
+export default Capability.makeModule(() =>
+  Effect.sync(() => {
+    const settingsAtom = createKvsStore({
+      key: meta.id,
+      schema: Settings.Settings,
+      defaultValue: () => ({
+        threads: false,
+      }),
+    });
+
+    return [
+      Capability.contributes(InboxCapabilities.Settings, settingsAtom),
+      Capability.contributes(AppCapabilities.Settings, {
+        prefix: meta.id,
+        schema: Settings.Settings,
+        atom: settingsAtom,
+      }),
+    ];
+  }),
+);

--- a/packages/plugins/plugin-inbox/src/components/InboxSettings/InboxSettings.tsx
+++ b/packages/plugins/plugin-inbox/src/components/InboxSettings/InboxSettings.tsx
@@ -1,0 +1,32 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import React from 'react';
+
+import { type AppSurface } from '@dxos/app-toolkit/ui';
+import { Input, useTranslation } from '@dxos/react-ui';
+import { Settings as SettingsForm } from '@dxos/react-ui-form';
+
+import { meta } from '#meta';
+import { Settings } from '#types';
+
+export type InboxSettingsProps = AppSurface.SettingsArticleProps<Settings.Settings>;
+
+export const InboxSettings = ({ settings, onSettingsChange }: InboxSettingsProps) => {
+  const { t } = useTranslation(meta.id);
+
+  return (
+    <SettingsForm.Viewport>
+      <SettingsForm.Section title={t('settings.title', { ns: meta.id })}>
+        <SettingsForm.Item title={t('settings.threads.label')} description={t('settings.threads.description')}>
+          <Input.Switch
+            disabled={!onSettingsChange}
+            checked={settings.threads ?? false}
+            onCheckedChange={(checked) => onSettingsChange?.((s) => ({ ...s, threads: checked }))}
+          />
+        </SettingsForm.Item>
+      </SettingsForm.Section>
+    </SettingsForm.Viewport>
+  );
+};

--- a/packages/plugins/plugin-inbox/src/components/InboxSettings/index.ts
+++ b/packages/plugins/plugin-inbox/src/components/InboxSettings/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+export * from './InboxSettings';

--- a/packages/plugins/plugin-inbox/src/components/MessageStack/MessageStack.stories.tsx
+++ b/packages/plugins/plugin-inbox/src/components/MessageStack/MessageStack.stories.tsx
@@ -21,15 +21,22 @@ import { withMosaic } from '@dxos/react-ui-mosaic/testing';
 import { Loading, withLayout, withTheme } from '@dxos/react-ui/testing';
 import { Message, Person } from '@dxos/types';
 
-import { Builder, LABELS, initializeMailbox } from '#testing';
+import { Builder, LABELS, MessagesOptions, initializeMailbox } from '#testing';
 import { Mailbox } from '#types';
 
 import { InboxPlugin } from '../../InboxPlugin';
-import { MessageStack as MessageStackComponent } from './MessageStack';
+import { MessageStack, MessageStackProps } from './MessageStack';
 
-const DefaultStory = () => {
-  const [messages] = useState(() => new Builder().createMessages(100).build().messages);
-  return <MessageStackComponent id='story' messages={messages} ignoreAttention labels={LABELS} />;
+const DefaultStory = ({
+  count = 0,
+  options,
+  ...props
+}: MessageStackProps & { count?: number; options?: MessagesOptions }) => {
+  const [messages] = useState(() =>
+    count ? new Builder().createMessages(count, options).build().messages : undefined,
+  );
+
+  return <MessageStack {...props} messages={messages} />;
 };
 
 const CompanionStory = () => {
@@ -65,23 +72,45 @@ const CompanionStory = () => {
 
 const meta = {
   title: 'plugins/plugin-inbox/components/MessageStack',
-  component: MessageStackComponent as any,
+  component: MessageStack,
   render: DefaultStory,
-  decorators: [withLayout({ layout: 'column' }), withAttention(), withMosaic()],
+  decorators: [withTheme(), withLayout({ layout: 'column' }), withAttention(), withMosaic()],
   parameters: {
     layout: 'fullscreen',
   },
-} satisfies Meta<typeof DefaultStory>;
+} satisfies Meta<typeof MessageStack>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  decorators: [withTheme()],
+  args: {
+    id: 'story',
+  },
 };
 
-export const WithCompanion: Story = {
+export const WithMessages: Story = {
+  args: {
+    id: 'story',
+    labels: LABELS,
+    count: 100,
+  },
+};
+
+export const WithThreads: Story = {
+  args: {
+    id: 'story',
+    labels: LABELS,
+    threads: true,
+    count: 100,
+    options: {
+      threads: 10,
+    },
+  },
+};
+
+export const WithCompanion = {
   render: CompanionStory,
   decorators: [
     withLayout({ layout: 'fullscreen' }),
@@ -98,7 +127,6 @@ export const WithCompanion: Story = {
               log.info('mailbox', { id: mailbox.id });
             }),
         }),
-
         StorybookPlugin({}),
         InboxPlugin(),
         PreviewPlugin(),

--- a/packages/plugins/plugin-inbox/src/components/MessageStack/MessageStack.tsx
+++ b/packages/plugins/plugin-inbox/src/components/MessageStack/MessageStack.tsx
@@ -29,10 +29,14 @@ export type MessageStackActionHandler = (action: MessageStackAction) => void;
 
 export type MessageStackProps = {
   id: string;
-  messages: Message.Message[];
-  currentId?: string;
+  messages?: Message.Message[];
   labels?: MailboxType.Labels;
-  ignoreAttention?: boolean;
+  currentId?: string;
+  /**
+   * When true, messages are grouped by `threadId` and only the most recent message
+   * in each thread is displayed. Messages without a threadId form singleton threads.
+   */
+  threads?: boolean;
   onAction?: MessageStackActionHandler;
 };
 
@@ -40,17 +44,38 @@ export type MessageStackProps = {
  * Card-based message stack component using mosaic layout.
  */
 export const MessageStack = composable<HTMLDivElement, MessageStackProps>(
-  ({ messages, labels, currentId, onAction, ...props }, forwardedRef) => {
+  ({ messages, labels, currentId, threads, onAction, ...props }, forwardedRef) => {
     const [viewport, setViewport] = useState<HTMLElement | null>(null);
+
+    const displayedMessages = useMemo(() => {
+      if (!threads) {
+        return messages;
+      }
+
+      const groups = new Map<string, Message.Message>();
+      for (const message of messages ?? []) {
+        const key = message.threadId ?? message.id;
+        const existing = groups.get(key);
+        if (!existing || message.created > existing.created) {
+          groups.set(key, message);
+        }
+      }
+
+      return Array.from(groups.values());
+    }, [messages, threads]);
+
     const items = useMemo(
-      () => messages.map((message) => ({ message, labels, onAction })),
-      [messages, labels, onAction],
+      () => displayedMessages?.map((message) => ({ message, labels, onAction })),
+      [displayedMessages, labels, onAction],
     );
 
     const handleCurrentChange = useCallback(
       (id: string | undefined) => {
         if (id) {
-          onAction?.({ type: 'current', messageId: id });
+          onAction?.({
+            type: 'current',
+            messageId: id,
+          });
         }
       },
       [onAction],

--- a/packages/plugins/plugin-inbox/src/components/MessageStack/MessageStack.tsx
+++ b/packages/plugins/plugin-inbox/src/components/MessageStack/MessageStack.tsx
@@ -17,6 +17,7 @@ import { getMessageProps } from '../../util';
 
 export type MessageStackAction =
   | { type: 'current'; messageId: string }
+  | { type: 'current-thread'; threadId: string; messageId: string }
   | { type: 'select'; messageId: string }
   | { type: 'select-tag'; label: string }
   | { type: 'save'; filter: string };
@@ -47,27 +48,42 @@ export const MessageStack = composable<HTMLDivElement, MessageStackProps>(
   ({ messages, labels, currentId, threads, onAction, ...props }, forwardedRef) => {
     const [viewport, setViewport] = useState<HTMLElement | null>(null);
 
-    const displayedMessages = useMemo(() => {
+    const threadGroups = useMemo(() => {
       if (!threads) {
-        return messages;
+        return undefined;
       }
 
-      const groups = new Map<string, Message.Message>();
+      const groups = new Map<string, Message.Message[]>();
       for (const message of messages ?? []) {
         const key = message.threadId ?? message.id;
-        const existing = groups.get(key);
-        if (!existing || message.created > existing.created) {
-          groups.set(key, message);
+        const group = groups.get(key);
+        if (group) {
+          group.push(message);
+        } else {
+          groups.set(key, [message]);
         }
       }
 
-      return Array.from(groups.values());
+      // Sort each group by created descending (most recent first).
+      for (const group of groups.values()) {
+        group.sort((a, b) => b.created.localeCompare(a.created));
+      }
+
+      return groups;
     }, [messages, threads]);
 
-    const items = useMemo(
-      () => displayedMessages?.map((message) => ({ message, labels, onAction })),
-      [displayedMessages, labels, onAction],
-    );
+    const items = useMemo(() => {
+      if (threadGroups) {
+        return Array.from(threadGroups.entries(), ([threadId, threadMessages]) => ({
+          threadId,
+          messages: threadMessages,
+          labels,
+          onAction,
+        }));
+      }
+
+      return messages?.map((message) => ({ message, labels, onAction }));
+    }, [threadGroups, messages, labels, onAction]);
 
     const handleCurrentChange = useCallback(
       (id: string | undefined) => {
@@ -94,12 +110,12 @@ export const MessageStack = composable<HTMLDivElement, MessageStackProps>(
           <ScrollArea.Root padding centered>
             <ScrollArea.Viewport ref={setViewport}>
               <Mosaic.VirtualStack
-                Tile={MessageTile}
+                Tile={threads ? (ThreadTile as any) : MessageTile}
                 classNames='my-2'
                 gap={8}
-                items={items}
+                items={items as any}
                 draggable={false}
-                getId={(item) => item.message.id}
+                getId={(item: any) => item.threadId ?? item.message?.id}
                 getScrollElement={() => viewport}
                 estimateSize={() => 150}
               />
@@ -221,3 +237,90 @@ const MessageTile = forwardRef<HTMLDivElement, MessageTileProps>(({ data, locati
 });
 
 MessageTile.displayName = 'MessageTile';
+
+//
+// ThreadTile
+//
+
+type ThreadTileData = {
+  threadId: string;
+  messages: Message.Message[];
+  labels?: MailboxType.Labels;
+  onAction?: MessageStackActionHandler;
+};
+
+type ThreadTileProps = Pick<MosaicTileProps<ThreadTileData>, 'data' | 'location' | 'current'>;
+
+const ThreadTile = forwardRef<HTMLDivElement, ThreadTileProps>(({ data, location, current }, forwardedRef) => {
+  const { threadId, messages, onAction } = data;
+  const latest = messages[0];
+  const { hue, from, date, subject } = getMessageProps(latest, new Date(), true);
+  const { setCurrentId } = useMosaicContainer('ThreadTile');
+
+  const handleCurrentChange = useCallback(() => {
+    setCurrentId(threadId);
+  }, [threadId, setCurrentId]);
+
+  const handleHeaderClick = useCallback(() => {
+    onAction?.({ type: 'current-thread', threadId, messageId: latest.id });
+  }, [threadId, latest.id, onAction]);
+
+  const handleMessageClick = useCallback(
+    (event: MouseEvent, messageId: string) => {
+      event.stopPropagation();
+      onAction?.({ type: 'current', messageId });
+    },
+    [onAction],
+  );
+
+  return (
+    <Mosaic.Tile asChild classNames='dx-hover dx-current dx-selected' id={threadId} data={data} location={location}>
+      <Focus.Item asChild current={current} onCurrentChange={handleCurrentChange}>
+        <Card.Root ref={forwardedRef} fullWidth onClick={handleHeaderClick}>
+          <Card.Toolbar>
+            <Card.IconBlock>
+              <DxAvatar hue={hue} hueVariant='surface' variant='square' size={6} fallback={from} />
+            </Card.IconBlock>
+            <Card.Title classNames='flex items-center gap-3'>
+              <span className='grow truncate font-medium'>{subject}</span>
+              <span className='text-xs text-description whitespace-nowrap shrink-0'>{date}</span>
+            </Card.Title>
+            <Card.Menu />
+          </Card.Toolbar>
+          <Card.Content>
+            {/* TODO(burdon): Currently limits to last n messages. */}
+            {messages.slice(0, 4).map((message) => {
+              const { from, date, snippet } = getMessageProps(message, new Date(), true);
+              return (
+                <Card.Row key={message.id}>
+                  <div role='none' className='flex flex-col py-1'>
+                    <button
+                      type='button'
+                      className='flex items-center w-full gap-2 text-start text-sm dx-hover dx-focus-ring'
+                      onClick={(event) => handleMessageClick(event, message.id)}
+                    >
+                      <span className='text-xs text-info-text whitespace-nowrap shrink-0'>{date}</span>
+                      {from && <span className='truncate'>{from}</span>}
+                    </button>
+
+                    {snippet && (
+                      <button
+                        type='button'
+                        className='text-start text-description line-clamp-2'
+                        onClick={(event) => handleMessageClick(event, message.id)}
+                      >
+                        {snippet}
+                      </button>
+                    )}
+                  </div>
+                </Card.Row>
+              );
+            })}
+          </Card.Content>
+        </Card.Root>
+      </Focus.Item>
+    </Mosaic.Tile>
+  );
+});
+
+ThreadTile.displayName = 'ThreadTile';

--- a/packages/plugins/plugin-inbox/src/components/index.ts
+++ b/packages/plugins/plugin-inbox/src/components/index.ts
@@ -8,6 +8,7 @@ export * from './ComposeEmailPanel';
 export * from './DateComponent';
 export * from './Event';
 export * from './EventStack';
+export * from './InboxSettings';
 export * from './MessageStack';
 export * from './Message';
 export * from './RelatedContacts';

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
@@ -128,8 +128,28 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
   const handleAction = useCallback<MessageStackActionHandler>(
     (action) => {
       switch (action.type) {
+        case 'current-thread': {
+          const message = sortedMessages.find((message) => message.id === action.messageId);
+          void invokePromise(AttentionOperation.Select, {
+            contextId: id,
+            selection: { mode: 'single', id: message?.id },
+          });
+
+          const companion = linkedSegment('message');
+          if (layout.mode === 'simple') {
+            void invokePromise(LayoutOperation.UpdateComplementary, {
+              subject: companion,
+              state: 'expanded',
+            });
+          } else if (message) {
+            void invokePromise(DeckOperation.ChangeCompanion, {
+              companion,
+            });
+          }
+          break;
+        }
+
         case 'current': {
-          // TODO(burdon): Handle threads.
           const message = sortedMessages.find((message) => message.id === action.messageId);
           void invokePromise(AttentionOperation.Select, {
             contextId: id,

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
@@ -5,7 +5,7 @@
 import { Atom, useAtomSet, useAtomValue } from '@effect-atom/atom-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { useOperationInvoker } from '@dxos/app-framework/ui';
+import { useAtomCapability, useOperationInvoker } from '@dxos/app-framework/ui';
 import { LayoutOperation } from '@dxos/app-toolkit';
 import { useLayout, type AppSurface } from '@dxos/app-toolkit/ui';
 import { type Database, type Feed, Obj, Query, Relation, Tag } from '@dxos/echo';
@@ -24,7 +24,7 @@ import { HasSubject, Message } from '@dxos/types';
 import { type MessageStackActionHandler, MessageStack } from '#components';
 import { meta } from '#meta';
 import { InboxOperation } from '#operations';
-import { type Mailbox } from '#types';
+import { InboxCapabilities, type Mailbox } from '#types';
 
 import { POPOVER_SAVE_FILTER } from '../../constants';
 import { getMailboxMessagePath } from '../../paths';
@@ -41,6 +41,7 @@ export type MailboxArticleProps = AppSurface.ObjectArticleProps<
 export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendableId }: MailboxArticleProps) => {
   const { t } = useTranslation(meta.id);
   const { invokePromise } = useOperationInvoker();
+  const settings = useAtomCapability(InboxCapabilities.Settings);
   const id = attendableId ?? Obj.getDXN(mailbox).toString();
   const db = Obj.getDatabase(mailbox);
 
@@ -130,6 +131,7 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
     (action) => {
       switch (action.type) {
         case 'current': {
+          // TODO(burdon): Handle threads.
           const message = sortedMessages.find((message) => message.id === action.messageId);
           void invokePromise(AttentionOperation.Select, {
             contextId: id,
@@ -236,6 +238,7 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
             messages={messagesWithTags}
             currentId={currentId}
             labels={mergedLabels}
+            threads={settings.threads}
             onAction={handleAction}
           />
         )}

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
@@ -43,10 +43,8 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
   const { invokePromise } = useOperationInvoker();
   const settings = useAtomCapability(InboxCapabilities.Settings);
   const id = attendableId ?? Obj.getDXN(mailbox).toString();
-  const db = Obj.getDatabase(mailbox);
-
-  // TODO(burdon): Review.
   const currentId = useSelected(id, 'single');
+  const db = Obj.getDatabase(mailbox);
 
   // TODO(wittjosiah): Should be `const feed = useObjectValue(mailbox.feed)`.
   useObject(mailbox);
@@ -78,6 +76,10 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
   }, [tags]);
   const parser = useMemo(() => new QueryBuilder(tagMap), [tagMap]);
   useEffect(() => setFilter(parser.build(filterText).filter), [filterText, parser]);
+
+  const layout = useLayout();
+  const filterEditorRef = useRef<EditorController>(null);
+  const filterSaveButtonRef = useRef<HTMLButtonElement>(null);
 
   // Build message-to-tags map from HasSubject relations incrementally.
   const messageTagsMap = useMessageTagsMap(db, feed);
@@ -122,10 +124,6 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
     }, 1_000);
     return () => clearTimeout(t);
   }, [sortedMessages]);
-
-  const layout = useLayout();
-  const filterEditorRef = useRef<EditorController>(null);
-  const filterSaveButtonRef = useRef<HTMLButtonElement>(null);
 
   const handleAction = useCallback<MessageStackActionHandler>(
     (action) => {
@@ -203,25 +201,25 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
             <Panel.Toolbar asChild>
               <Menu.Toolbar>
                 <QueryEditor
-                  ref={filterEditorRef}
                   classNames='grow min-w-0 ps-1'
                   db={db}
                   tags={tagMap}
                   value={filterText}
                   onChange={setFilterText}
+                  ref={filterEditorRef}
                 />
                 <IconButton
-                  ref={filterSaveButtonRef}
                   disabled={!filter}
-                  label={t('mailbox-toolbar-save-button.label')}
                   icon='ph--folder-plus--regular'
                   iconOnly
+                  label={t('mailbox-toolbar-save-button.label')}
                   onClick={() => filter && handleAction({ type: 'save', filter: filterText })}
+                  ref={filterSaveButtonRef}
                 />
                 <IconButton
-                  label={t('mailbox-toolbar-clear-button.label')}
                   icon='ph--x--regular'
                   iconOnly
+                  label={t('mailbox-toolbar-clear-button.label')}
                   onClick={() => handleClear()}
                 />
               </Menu.Toolbar>

--- a/packages/plugins/plugin-inbox/src/operations/google/gmail/mapper.ts
+++ b/packages/plugins/plugin-inbox/src/operations/google/gmail/mapper.ts
@@ -43,9 +43,9 @@ export const mapMessage = Effect.fn(function* (message: GoogleMail.Message) {
 
     created,
     sender,
+    threadId: message.threadId,
 
     properties: {
-      threadId: message.threadId,
       snippet: message.snippet,
       subject: message.payload.headers.find(({ name }) => name === 'Subject')?.value,
       labels: message.labelIds,

--- a/packages/plugins/plugin-inbox/src/operations/google/gmail/mapper.ts
+++ b/packages/plugins/plugin-inbox/src/operations/google/gmail/mapper.ts
@@ -46,7 +46,7 @@ export const mapMessage = Effect.fn(function* (message: GoogleMail.Message) {
     threadId: message.threadId,
 
     properties: {
-      snippet: message.snippet,
+      snippet: message.snippet.trim(),
       subject: message.payload.headers.find(({ name }) => name === 'Subject')?.value,
       labels: message.labelIds,
       messageId: message.payload.headers.find(({ name }) => name === 'Message-ID')?.value,

--- a/packages/plugins/plugin-inbox/src/operations/google/gmail/sync.ts
+++ b/packages/plugins/plugin-inbox/src/operations/google/gmail/sync.ts
@@ -67,7 +67,6 @@ export default GoogleMailSync.pipe(
 
         const objects = yield* Feed.runQuery(feed, Filter.type(Message.Message));
         const lastMessage = objects.at(-1);
-
         const recentMessages = objects.slice(-STREAMING_CONFIG.maxResults);
         const existingGmailIds = new Set(
           recentMessages.flatMap((msg) => {

--- a/packages/plugins/plugin-inbox/src/testing/builder.ts
+++ b/packages/plugins/plugin-inbox/src/testing/builder.ts
@@ -255,7 +255,7 @@ export class Builder {
 
       const enrichedText = words.join(' ');
       // First block plain text (links stripped), second block enriched text (links intact).
-      text = enrichedText.replace(/\[(.*?)\]\[.*?\]/g, '$1');
+      text = enrichedText.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
       blocks = [
         { _tag: 'text', text },
         { _tag: 'text', text: enrichedText },

--- a/packages/plugins/plugin-inbox/src/testing/builder.ts
+++ b/packages/plugins/plugin-inbox/src/testing/builder.ts
@@ -36,11 +36,32 @@ export type BuilderOptions = {
   messages?: DateRange;
 };
 
-export type LinkedMessageOptions = {
-  /** Number of paragraphs to generate per message. Defaults to 3. */
-  paragraphs?: number;
+export type MessageLinkOptions = {
+  /** Space to which linked Person objects will be added. */
+  space: Space;
   /** Maximum number of linked Person objects to splice into the text. Defaults to 5. */
-  links?: number;
+  max?: number;
+};
+
+export type MessageOptions = {
+  /** Number of paragraphs to generate per message. Defaults to a random value between 1 and 4. */
+  paragraphs?: number;
+  /**
+   * If provided, markdown links to newly-created Person objects are injected into
+   * the message text. In this mode the message contains two text blocks: the first
+   * with link syntax stripped, the second with links intact.
+   */
+  links?: MessageLinkOptions;
+  /** Thread ID to assign to the message's `threadId`. */
+  threadId?: string;
+};
+
+export type MessagesOptions = MessageOptions & {
+  /**
+   * If set, generates a pool of N thread IDs and randomly assigns each message to one.
+   * Overrides any `threadId` supplied in the base options.
+   */
+  threads?: number;
 };
 
 export type BuildResult = {
@@ -206,66 +227,24 @@ export class Builder {
   //
 
   /**
-   * Creates a single plain-text Message at a random time within the message range.
+   * Creates a single Message at a random time within the message range.
+   * If `options.links` is provided, the message body will include markdown links
+   * to newly-created Person objects, and the message will contain two text blocks
+   * (first with link syntax stripped, second with links intact).
    */
-  createMessage(): this {
+  createMessage({ paragraphs, links, threadId }: MessageOptions = {}): this {
     const created = this._nextMessageTime();
-    const paragraphCount = random.number.int({ min: 1, max: 4 });
-    const text = random.helpers
+    const paragraphCount = paragraphs ?? random.number.int({ min: 1, max: 4 });
+
+    let text = random.helpers
       .multiple(() => random.lorem.paragraph(random.number.int({ min: 1, max: 3 })), { count: paragraphCount })
       .join('\n\n');
 
-    this._messages.push(
-      Message.make({
-        created: created.toISOString(),
-        sender: this._randomActor(),
-        blocks: [{ _tag: 'text', text }],
-        properties: {
-          subject:
-            random.helpers.arrayElement(['', 'Re: ']) + random.lorem.sentence(random.number.int({ min: 4, max: 8 })),
-          snippet: text.slice(0, 120),
-          labels: random.helpers.randomSubset(Object.keys(LABELS), {
-            min: 0,
-            max: Math.min(3, Object.keys(LABELS).length),
-          }),
-        },
-      }),
-    );
-
-    return this;
-  }
-
-  /**
-   * Creates multiple plain-text Messages, each at a random time within the message range.
-   */
-  createMessages(count: number): this {
-    for (let index = 0; index < count; index++) {
-      this.createMessage();
-    }
-    return this;
-  }
-
-  //
-  // Linked message factory
-  //
-
-  /**
-   * Creates a single Message whose body contains markdown links to Person objects
-   * added to the given Space database. The message has two content blocks:
-   * a plain-text block (links stripped) and an enriched block (links intact).
-   */
-  createLinkedMessage(space: Space, { paragraphs = 3, links = 5 }: LinkedMessageOptions = {}): this {
-    const created = this._nextMessageTime();
-
-    let text = random.helpers
-      .multiple(() => random.lorem.paragraph(random.number.int({ min: 1, max: 3 })), { count: paragraphs })
-      .join('\n\n');
-
-    let enrichedText = text;
-    const words = text.split(' ');
-
-    if (links > 0) {
-      const linkCount = Math.floor(Math.random() * links) + 1;
+    let blocks: { _tag: 'text'; text: string }[];
+    if (links) {
+      const { space, max = 5 } = links;
+      const words = text.split(' ');
+      const linkCount = Math.floor(Math.random() * max) + 1;
       for (let index = 0; index < linkCount; index++) {
         const fullName = random.person.fullName();
         const obj = space.db.add(Person.make({ fullName }));
@@ -273,21 +252,24 @@ export class Builder {
         const position = Math.floor(Math.random() * words.length);
         words.splice(position, 0, `[${fullName}](${dxn})`);
       }
-    }
 
-    // First block: plain text with link syntax stripped, keeping the label.
-    enrichedText = words.join(' ');
-    text = enrichedText.replace(/\[(.*?)\]\[.*?\]/g, '$1');
+      const enrichedText = words.join(' ');
+      // First block plain text (links stripped), second block enriched text (links intact).
+      text = enrichedText.replace(/\[(.*?)\]\[.*?\]/g, '$1');
+      blocks = [
+        { _tag: 'text', text },
+        { _tag: 'text', text: enrichedText },
+      ];
+    } else {
+      blocks = [{ _tag: 'text', text }];
+    }
 
     this._messages.push(
       Message.make({
         created: created.toISOString(),
         sender: this._randomActor(),
-        // First block plain text (links stripped), second block enriched text (links intact).
-        blocks: [
-          { _tag: 'text', text },
-          { _tag: 'text', text: enrichedText },
-        ],
+        blocks,
+        ...(threadId && { threadId }),
         properties: {
           subject:
             random.helpers.arrayElement(['', 'Re: ']) + random.lorem.sentence(random.number.int({ min: 4, max: 8 })),
@@ -304,12 +286,18 @@ export class Builder {
   }
 
   /**
-   * Creates multiple linked Messages, each at a random time within the message range.
+   * Creates multiple Messages, each at a random time within the message range.
+   * When `options.threads` is set, a pool of thread IDs is generated and each message
+   * is randomly assigned to one of them.
    */
-  createLinkedMessages(count: number, space: Space, options?: LinkedMessageOptions): this {
+  createMessages(count: number, options?: MessagesOptions): this {
+    const { threads, ...messageOptions } = options ?? {};
+    const threadIds = threads && threads > 0 ? Array.from({ length: threads }, () => random.string.uuid()) : undefined;
     for (let index = 0; index < count; index++) {
-      this.createLinkedMessage(space, options);
+      const threadId = threadIds ? random.helpers.arrayElement(threadIds) : messageOptions.threadId;
+      this.createMessage({ ...messageOptions, threadId });
     }
+
     return this;
   }
 

--- a/packages/plugins/plugin-inbox/src/testing/data.ts
+++ b/packages/plugins/plugin-inbox/src/testing/data.ts
@@ -33,7 +33,7 @@ export const initializeMailbox = async (space: Space, count = 0) => {
     throw new Error('Mailbox missing backing feed');
   }
 
-  const { messages } = new Builder().createLinkedMessages(count, space).build();
+  const { messages } = new Builder().createMessages(count, { links: { space }, threads: 10 }).build();
   await runAndForwardErrors(Feed.append(feed, messages).pipe(Effect.provide(createFeedServiceLayer(space.queues))));
   return mailbox;
 };

--- a/packages/plugins/plugin-inbox/src/translations.ts
+++ b/packages/plugins/plugin-inbox/src/translations.ts
@@ -128,6 +128,10 @@ export const translations = [
         'open-calendar.button': 'Open calendar',
         'open-profile.button': 'Open profile',
         'saved-filter-name.label': 'Filter name',
+
+        'settings.title': 'Inbox settings',
+        'settings.threads.label': 'Group by thread',
+        'settings.threads.description': 'Group messages by thread and show only the most recent message per thread.',
       },
     },
   },

--- a/packages/plugins/plugin-inbox/src/translations.ts
+++ b/packages/plugins/plugin-inbox/src/translations.ts
@@ -131,7 +131,7 @@ export const translations = [
 
         'settings.title': 'Inbox settings',
         'settings.threads.label': 'Group by thread',
-        'settings.threads.description': 'Group messages by thread and show only the most recent message per thread.',
+        'settings.threads.description': 'Group messages and responses that belong to the same conversation.',
       },
     },
   },

--- a/packages/plugins/plugin-inbox/src/types/Settings.ts
+++ b/packages/plugins/plugin-inbox/src/types/Settings.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+// @import-as-namespace
+
+import * as Schema from 'effect/Schema';
+
+export const Settings = Schema.Struct({
+  /** Group messages by thread and display only the most recent message per thread. */
+  threads: Schema.optional(Schema.Boolean),
+}).pipe(Schema.mutable);
+export type Settings = Schema.Schema.Type<typeof Settings>;

--- a/packages/plugins/plugin-inbox/src/types/capabilities.ts
+++ b/packages/plugins/plugin-inbox/src/types/capabilities.ts
@@ -1,0 +1,15 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { type Atom } from '@effect-atom/atom-react';
+
+import { Capability } from '@dxos/app-framework';
+
+import { meta } from '#meta';
+
+import * as Settings from './Settings';
+
+export namespace InboxCapabilities {
+  export const Settings = Capability.make<Atom.Writable<Settings.Settings>>(`${meta.id}.capability.settings`);
+}

--- a/packages/plugins/plugin-inbox/src/types/events.ts
+++ b/packages/plugins/plugin-inbox/src/types/events.ts
@@ -1,0 +1,15 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { type ActivationEvent } from '@dxos/app-framework';
+import { AppActivationEvents } from '@dxos/app-toolkit';
+
+import { InboxCapabilities } from './capabilities';
+
+export namespace InboxEvents {
+  /** Fired when the Inbox Settings capability is ready. */
+  export const SettingsReady: ActivationEvent.ActivationEvent = AppActivationEvents.createSettingsEvent(
+    InboxCapabilities.Settings.identifier,
+  );
+}

--- a/packages/plugins/plugin-inbox/src/types/index.ts
+++ b/packages/plugins/plugin-inbox/src/types/index.ts
@@ -5,3 +5,6 @@
 export * as Calendar from './Calendar';
 export * as DraftMessage from './DraftMessage';
 export * as Mailbox from './Mailbox';
+export * from './capabilities';
+export * from './events';
+export * as Settings from './Settings';

--- a/packages/sdk/types/src/types/Message.ts
+++ b/packages/sdk/types/src/types/Message.ts
@@ -21,9 +21,10 @@ import * as ContentBlock from './ContentBlock';
 //  - Read receipts don't need to be added to schema until they being implemented.
 export const Message = Schema.Struct({
   id: Obj.ID, // TODO(burdon): Remove (from all types in this package).
-  // TODO(dmaretskyi): Consider adding a channelId too.
   parentMessage: Schema.optional(Obj.ID),
-  // TODO(burdon): Rename sent (don't clash with metadata for created).
+  /** Optional grouping identifier for related messages. */
+  threadId: Schema.optional(Schema.String),
+  /** Message creation timestamp. NOTE: May be different from the object creation timestamp. */
   created: Schema.String.pipe(
     Schema.annotations({ description: 'ISO date string when the message was sent.' }),
     GeneratorAnnotation.set('date.iso8601'),
@@ -58,6 +59,7 @@ export const make = ({
   sender,
   blocks = [],
   properties,
+  ...rest
 }: MakeOptional<Omit<Obj.MakeProps<typeof Message>, 'sender'>, 'created' | 'blocks'> & {
   sender: Actor.Actor | Actor.Role;
 }) => {
@@ -66,5 +68,6 @@ export const make = ({
     sender: typeof sender === 'string' ? { role: sender } : sender,
     blocks,
     properties,
+    ...rest,
   });
 };


### PR DESCRIPTION
## Summary

- Add Inbox **Settings** with a `threads` flag — schema, `InboxCapabilities.Settings` capability, KVS-backed atom, and a `SettingsForm` UI surface.
- Promote `Message.threadId` to a top-level schema field; pass it through in `Message.make` and update the Gmail mapper.
- Consolidate the two `createMessage` / `createLinkedMessage` builder methods into a single `createMessage(options)` with optional `links: { space, max? }` for inline Person refs, and add a `threads` bulk option that distributes messages across a generated pool of thread IDs.
- Add a `threads` prop to `MessageStack` that groups by `threadId` and renders only the most recent message per thread; `MailboxArticle` reads the new setting and forwards it.

## Test plan

- [ ] `moon run plugin-inbox:build` succeeds.
- [ ] `moon run plugin-inbox:test` passes.
- [ ] Storybook: `MessageStack` → `Default`, `WithMessages`, `WithThreads` render correctly; `WithThreads` shows ~10 cards (one per thread) from 100 generated messages.
- [ ] Open Inbox settings panel and toggle "Group by thread" — `MailboxArticle` switches between flat and threaded views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Inbox settings UI with a "Group by thread" toggle.
  * Message list can be grouped by thread, showing the latest message per thread when enabled.

* **Other**
  * Settings persist and immediately affect message views.
  * Message snippets are trimmed for cleaner display and translations added for new settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->