### PR TITLE
fix: Increate default RPC timeout from 3 to 30 seconds

### DIFF
--- a/packages/core/mesh/rpc/src/rpc.ts
+++ b/packages/core/mesh/rpc/src/rpc.ts
@@ -15,7 +15,7 @@ import { exponentialBackoffInterval } from '@dxos/util';
 
 import { decodeRpcError } from './errors';
 
-const DEFAULT_TIMEOUT = 3_000;
+const DEFAULT_TIMEOUT = 30_000;
 const BYE_SEND_TIMEOUT = 2_000;
 
 const DEBUG_CALLS = true;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RPC operations now have an extended default timeout window, providing additional time for requests to complete before timing out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->