### PR TITLE
fix(ai): set default max_tokens to 4096 for all Anthropic models

### DIFF
--- a/packages/core/ai/src/resolvers/anthropic/AnthropicResolver.ts
+++ b/packages/core/ai/src/resolvers/anthropic/AnthropicResolver.ts
@@ -26,33 +26,40 @@ export const make = () =>
               type: 'adaptive' as any,
             } as const)
           : undefined;
+        const max_tokens = 4096;
         switch (model) {
           case '@anthropic/claude-3-5-haiku-20241022':
-            return AnthropicLanguageModel.layer({ model: 'claude-3-5-haiku-20241022' }).pipe(
+            return AnthropicLanguageModel.layer({ model: 'claude-3-5-haiku-20241022', config: { max_tokens } }).pipe(
               Layer.provide(clientLayer),
             );
           case '@anthropic/claude-3-5-sonnet-20241022':
-            return AnthropicLanguageModel.layer({ model: 'claude-3-5-sonnet-20241022' }).pipe(
+            return AnthropicLanguageModel.layer({ model: 'claude-3-5-sonnet-20241022', config: { max_tokens } }).pipe(
               Layer.provide(clientLayer),
             );
           case '@anthropic/claude-haiku-4-5':
-            return AnthropicLanguageModel.layer({ model: 'claude-haiku-4-5' }).pipe(Layer.provide(clientLayer));
+            return AnthropicLanguageModel.layer({ model: 'claude-haiku-4-5', config: { max_tokens } }).pipe(
+              Layer.provide(clientLayer),
+            );
           case '@anthropic/claude-opus-4-0':
-            return AnthropicLanguageModel.layer({ model: 'claude-opus-4-0', config: { thinking } }).pipe(
+            return AnthropicLanguageModel.layer({ model: 'claude-opus-4-0', config: { thinking, max_tokens } }).pipe(
               Layer.provide(clientLayer),
             );
           case '@anthropic/claude-opus-4-5':
-            return AnthropicLanguageModel.layer({ model: 'claude-opus-4-5', config: { thinking } }).pipe(
+            return AnthropicLanguageModel.layer({ model: 'claude-opus-4-5', config: { thinking, max_tokens } }).pipe(
               Layer.provide(clientLayer),
             );
           case '@anthropic/claude-opus-4-6':
-            return AnthropicLanguageModel.layer({ model: 'claude-opus-4-6', config: { thinking } }).pipe(
+            return AnthropicLanguageModel.layer({ model: 'claude-opus-4-6', config: { thinking, max_tokens } }).pipe(
               Layer.provide(clientLayer),
             );
           case '@anthropic/claude-sonnet-4-0':
-            return AnthropicLanguageModel.layer({ model: 'claude-sonnet-4-0' }).pipe(Layer.provide(clientLayer));
+            return AnthropicLanguageModel.layer({ model: 'claude-sonnet-4-0', config: { max_tokens } }).pipe(
+              Layer.provide(clientLayer),
+            );
           case '@anthropic/claude-sonnet-4-5':
-            return AnthropicLanguageModel.layer({ model: 'claude-sonnet-4-5' }).pipe(Layer.provide(clientLayer));
+            return AnthropicLanguageModel.layer({ model: 'claude-sonnet-4-5', config: { max_tokens } }).pipe(
+              Layer.provide(clientLayer),
+            );
           default:
             return Layer.fail(new AiModelNotAvailableError(model));
         }


### PR DESCRIPTION
## Summary

Without an explicit `max_tokens`, the Anthropic SDK defaults to a small value (~1024) which truncates responses mid-word for any non-trivial output. This is especially visible in agent tool-use flows where the model needs to reference multiple data sources in a single response.

4096 is generous enough for any realistic response while staying well under model limits.

**Change:** adds `const max_tokens = 4096` and passes it into every `AnthropicLanguageModel.layer()` config.

## Test plan
- [x] `moon run ai:build` passes
- [x] Verified in live Composer agent session — responses no longer truncate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and stability of Anthropic model configurations by ensuring all model variants receive appropriate token limit settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->