### PR TITLE
feat(plugin-github): GitHub PR tracking and repo sync integration

### DIFF
--- a/packages/plugins/plugin-github/moon.yml
+++ b/packages/plugins/plugin-github/moon.yml
@@ -1,0 +1,11 @@
+layer: library
+language: typescript
+tags:
+  - ts-build
+  - ts-test
+  - pack
+tasks:
+  compile:
+    args:
+      - '--entryPoint=src/index.ts'
+      - '--entryPoint=src/types/index.ts'

--- a/packages/plugins/plugin-github/package.json
+++ b/packages/plugins/plugin-github/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "@dxos/plugin-github",
+  "version": "0.8.3",
+  "private": true,
+  "description": "GitHub integration plugin for monitoring repos in your workspace.",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dxos/dxos"
+  },
+  "license": "MIT",
+  "author": "DXOS.org",
+  "sideEffects": true,
+  "type": "module",
+  "imports": {
+    "#capabilities": "./src/capabilities/index.ts",
+    "#containers": "./src/containers/index.ts",
+    "#meta": "./src/meta.ts",
+    "#types": "./src/types/index.ts"
+  },
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/types/src/index.d.ts",
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": "./dist/lib/node-esm/index.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "browser": "./dist/lib/browser/types/index.mjs",
+      "node": "./dist/lib/node-esm/types/index.mjs"
+    }
+  },
+  "types": "dist/types/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "types": [
+        "dist/types/src/types/index.d.ts"
+      ]
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@dxos/app-framework": "workspace:*",
+    "@dxos/app-toolkit": "workspace:*",
+    "@dxos/echo": "workspace:*",
+    "@dxos/echo-db": "workspace:*",
+    "@dxos/log": "workspace:*",
+    "@dxos/operation": "workspace:*",
+    "@dxos/plugin-graph": "workspace:*",
+    "@dxos/plugin-space": "workspace:*",
+    "@dxos/react-client": "workspace:*",
+    "@dxos/react-ui-mosaic": "workspace:*",
+    "@dxos/types": "workspace:*",
+    "@dxos/ui-theme": "workspace:*",
+    "@dxos/util": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@dxos/plugin-theme": "workspace:*",
+    "@dxos/react-ui": "workspace:*",
+    "@dxos/storybook-utils": "workspace:*",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "peerDependencies": {
+    "@dxos/react-ui": "workspace:*",
+    "effect": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  }
+}

--- a/packages/plugins/plugin-github/src/GitHubPlugin.tsx
+++ b/packages/plugins/plugin-github/src/GitHubPlugin.tsx
@@ -1,0 +1,58 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { Annotation } from '@dxos/echo';
+import { Operation } from '@dxos/operation';
+import { SpaceOperation } from '@dxos/plugin-space/operations';
+import { type CreateObject } from '@dxos/plugin-space/types';
+
+import { ReactSurface } from '#capabilities';
+import { meta } from '#meta';
+import { GitHub } from '#types';
+
+import { translations } from './translations';
+
+export const GitHubPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addMetadataModule({
+    metadata: [
+      {
+        id: GitHub.GitHubAccount.typename,
+        metadata: {
+          icon: Annotation.IconAnnotation.get(GitHub.GitHubAccount).pipe(Option.getOrThrow).icon,
+          iconHue: Annotation.IconAnnotation.get(GitHub.GitHubAccount).pipe(Option.getOrThrow).hue ?? 'white',
+          inputSchema: GitHub.CreateGitHubAccountSchema,
+          createObject: ((props, options) =>
+            Effect.gen(function* () {
+              const object = GitHub.makeAccount(props);
+              return yield* Operation.invoke(SpaceOperation.AddObject, {
+                object,
+                target: options.target,
+                hidden: false,
+                targetNodeId: options.targetNodeId,
+              });
+            })) satisfies CreateObject,
+        },
+      },
+      {
+        id: GitHub.GitHubRepo.typename,
+        metadata: {
+          label: (object: GitHub.GitHubRepo) => object.name,
+          icon: Annotation.IconAnnotation.get(GitHub.GitHubRepo).pipe(Option.getOrThrow).icon,
+          iconHue: Annotation.IconAnnotation.get(GitHub.GitHubRepo).pipe(Option.getOrThrow).hue ?? 'white',
+        },
+      },
+    ],
+  }),
+  AppPlugin.addSchemaModule({
+    schema: [GitHub.GitHubAccount, GitHub.GitHubRepo, GitHub.GitHubPullRequest],
+  }),
+  AppPlugin.addSurfaceModule({ activate: ReactSurface }),
+  AppPlugin.addTranslationsModule({ translations }),
+  Plugin.make,
+);

--- a/packages/plugins/plugin-github/src/capabilities/index.ts
+++ b/packages/plugins/plugin-github/src/capabilities/index.ts
@@ -1,0 +1,7 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Capability } from '@dxos/app-framework';
+
+export const ReactSurface = Capability.lazy('ReactSurface', () => import('./react-surface'));

--- a/packages/plugins/plugin-github/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-github/src/capabilities/react-surface.tsx
@@ -1,0 +1,28 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import React from 'react';
+
+import { Capabilities, Capability } from '@dxos/app-framework';
+import { Surface } from '@dxos/app-framework/ui';
+import { AppSurface } from '@dxos/app-toolkit/ui';
+
+import { GitHubArticle } from '#containers';
+import { GitHub } from '#types';
+
+export default Capability.makeModule(() =>
+  Effect.succeed(
+    Capability.contributes(Capabilities.ReactSurface, [
+      Surface.create({
+        id: 'github-account',
+        role: ['article', 'section'],
+        filter: AppSurface.objectArticle(GitHub.GitHubAccount),
+        component: ({ data, role }) => (
+          <GitHubArticle role={role} subject={data.subject} attendableId={data.attendableId} />
+        ),
+      }),
+    ]),
+  ),
+);

--- a/packages/plugins/plugin-github/src/containers/GitHubArticle/GitHubArticle.tsx
+++ b/packages/plugins/plugin-github/src/containers/GitHubArticle/GitHubArticle.tsx
@@ -1,0 +1,274 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import React, { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { Filter, Obj, Ref } from '@dxos/echo';
+import { log } from '@dxos/log';
+import { useQuery } from '@dxos/react-client/echo';
+import { Card, Panel, ScrollArea, Toolbar } from '@dxos/react-ui';
+import { Focus, Mosaic, type MosaicTileProps, useMosaicContainer } from '@dxos/react-ui-mosaic';
+import { Organization } from '@dxos/types';
+
+import { GitHub } from '#types';
+
+const GITHUB_API_BASE = '/api/github';
+
+export type GitHubArticleProps = {
+  role: string;
+  subject: GitHub.GitHubAccount;
+  attendableId?: string;
+};
+
+//
+// GitHub API types.
+//
+
+type GitHubApiRepo = {
+  full_name: string;
+  name: string;
+  description: string | null;
+  language: string | null;
+  stargazers_count: number;
+  forks_count: number;
+  open_issues_count: number;
+  html_url: string;
+  owner: { login: string };
+  pushed_at: string;
+  created_at: string;
+};
+
+const githubFetch = async (path: string, token: string): Promise<any> => {
+  const response = await fetch(`${GITHUB_API_BASE}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github.v3+json',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API ${response.status}: ${await response.text()}`);
+  }
+  return response.json();
+};
+
+//
+// Tile component.
+//
+
+type RepoTileData = {
+  repo: GitHub.GitHubRepo;
+};
+
+type RepoTileProps = Pick<MosaicTileProps<RepoTileData>, 'data' | 'location' | 'current'>;
+
+const RepoTile = forwardRef<HTMLDivElement, RepoTileProps>(({ data, location, current }, forwardedRef) => {
+  const { repo } = data;
+  const { setCurrentId } = useMosaicContainer('RepoTile');
+
+  return (
+    <Mosaic.Tile asChild classNames='dx-hover dx-current' id={repo.fullName} data={data} location={location}>
+      <Focus.Item asChild current={current} onCurrentChange={() => setCurrentId(repo.fullName)}>
+        <Card.Root ref={forwardedRef}>
+          <Card.Toolbar>
+            <Card.IconBlock>
+              <Card.Icon icon='ph--git-branch--regular' />
+            </Card.IconBlock>
+            <Card.Text classNames='truncate'>{repo.name ?? repo.fullName}</Card.Text>
+          </Card.Toolbar>
+          <Card.Content>
+            {repo.description && (
+              <Card.Row icon='ph--text-align-left--regular'>
+                <Card.Text variant='description'>{repo.description}</Card.Text>
+              </Card.Row>
+            )}
+            <Card.Row icon='ph--star--regular'>
+              <Card.Text variant='description'>
+                {repo.stars ?? 0} stars · {repo.forks ?? 0} forks · {repo.openIssues ?? 0} issues
+              </Card.Text>
+            </Card.Row>
+            {repo.language && (
+              <Card.Row icon='ph--code--regular'>
+                <Card.Text variant='description'>{repo.language}</Card.Text>
+              </Card.Row>
+            )}
+            {repo.lastSyncedAt && (
+              <Card.Row icon='ph--clock--regular'>
+                <Card.Text variant='description'>Synced {new Date(repo.lastSyncedAt).toLocaleString()}</Card.Text>
+              </Card.Row>
+            )}
+          </Card.Content>
+        </Card.Root>
+      </Focus.Item>
+    </Mosaic.Tile>
+  );
+});
+
+RepoTile.displayName = 'RepoTile';
+
+//
+// Main article component.
+//
+
+export const GitHubArticle = ({ role, subject: account }: GitHubArticleProps) => {
+  const db = Obj.getDatabase(account);
+  const repos: GitHub.GitHubRepo[] = useQuery(db, Filter.type(GitHub.GitHubRepo));
+  const orgs: Organization.Organization[] = useQuery(db, Filter.type(Organization.Organization));
+  const [syncing, setSyncing] = useState(false);
+  const [repoViewport, setRepoViewport] = useState<HTMLElement | null>(null);
+
+  /** Sync repos for organizations in the workspace. */
+  const handleSync = useCallback(async () => {
+    if (!db || !account.accessToken) {
+      return;
+    }
+
+    setSyncing(true);
+    try {
+      const existingByFullName = new Map(repos.map((repo) => [repo.fullName, repo]));
+
+      // Collect org names from organizations to search for repos.
+      const orgNames = new Set<string>();
+      for (const org of orgs) {
+        if (org.name) {
+          orgNames.add(org.name.toLowerCase());
+        }
+        if (org.website) {
+          // Extract org name from website domain.
+          try {
+            const domain = new URL(org.website.startsWith('http') ? org.website : `https://${org.website}`).hostname;
+            const parts = domain.replace('www.', '').split('.');
+            if (parts.length > 0) {
+              orgNames.add(parts[0]);
+            }
+          } catch {
+            // Skip invalid URLs.
+          }
+        }
+      }
+
+      // Search GitHub for repos by each org name.
+      for (const orgName of orgNames) {
+        try {
+          const searchData = await githubFetch(
+            `/search/repositories?q=org:${encodeURIComponent(orgName)}&sort=stars&per_page=10`,
+            account.accessToken,
+          );
+          const remoteRepos = (searchData.items ?? []) as GitHubApiRepo[];
+
+          for (const remote of remoteRepos) {
+            const existing = existingByFullName.get(remote.full_name);
+
+            // Find linked org.
+            const matchedOrg = orgs.find(
+              (org) => org.name?.toLowerCase() === orgName || org.website?.toLowerCase().includes(orgName),
+            );
+
+            if (existing) {
+              Obj.change(existing, (mutable) => {
+                mutable.name = remote.full_name;
+                mutable.description = remote.description ?? undefined;
+                mutable.language = remote.language ?? undefined;
+                mutable.stars = remote.stargazers_count;
+                mutable.forks = remote.forks_count;
+                mutable.openIssues = remote.open_issues_count;
+                mutable.lastSyncedAt = new Date().toISOString();
+                if (matchedOrg && !mutable.organization?.target) {
+                  mutable.organization = Ref.make(matchedOrg);
+                }
+              });
+            } else {
+              const repo = GitHub.makeRepo({
+                fullName: remote.full_name,
+                name: remote.full_name,
+                description: remote.description ?? undefined,
+                language: remote.language ?? undefined,
+                stars: remote.stargazers_count,
+                forks: remote.forks_count,
+                openIssues: remote.open_issues_count,
+                organization: matchedOrg ? Ref.make(matchedOrg) : undefined,
+                lastSyncedAt: new Date().toISOString(),
+              });
+              db.add(repo);
+            }
+          }
+        } catch (error) {
+          log.warn('Failed to search repos for org', { orgName, error });
+        }
+      }
+
+      Obj.change(account, (mutable) => {
+        mutable.lastSyncedAt = new Date().toISOString();
+      });
+    } catch (error) {
+      log.catch(error);
+    } finally {
+      setSyncing(false);
+    }
+  }, [db, account, repos, orgs]);
+
+  // Auto-sync on first load.
+  const didAutoSync = useRef(false);
+  useEffect(() => {
+    if (!didAutoSync.current && account.accessToken && !account.lastSyncedAt) {
+      didAutoSync.current = true;
+      void handleSync();
+    }
+  }, [account.accessToken, account.lastSyncedAt, handleSync]);
+
+  const sortedRepos = useMemo(
+    () => [...repos].sort((repoA, repoB) => (repoB.stars ?? 0) - (repoA.stars ?? 0)),
+    [repos],
+  );
+
+  const repoItems = useMemo(() => sortedRepos.map((repo) => ({ repo })), [sortedRepos]);
+
+  return (
+    <Panel.Root role={role}>
+      <Panel.Toolbar asChild>
+        <Toolbar.Root>
+          <Toolbar.Text>{account.name ?? 'GitHub'}</Toolbar.Text>
+          <Toolbar.Separator />
+          <Toolbar.IconButton
+            label={syncing ? 'Syncing...' : 'Sync repos'}
+            icon='ph--arrows-clockwise--regular'
+            iconOnly
+            disabled={syncing || !account.accessToken}
+            onClick={handleSync}
+          />
+          {account.lastSyncedAt && (
+            <>
+              <Toolbar.Separator />
+              <Toolbar.Text>{new Date(account.lastSyncedAt).toLocaleTimeString()}</Toolbar.Text>
+            </>
+          )}
+        </Toolbar.Root>
+      </Panel.Toolbar>
+      <Panel.Content>
+        <Focus.Group asChild>
+          <Mosaic.Container asChild withFocus autoScroll={repoViewport}>
+            <ScrollArea.Root orientation='vertical' padding centered>
+              <ScrollArea.Viewport ref={setRepoViewport}>
+                <Mosaic.VirtualStack
+                  Tile={RepoTile}
+                  classNames='my-2'
+                  gap={8}
+                  items={repoItems}
+                  draggable={false}
+                  getId={(item) => item.repo.fullName}
+                  getScrollElement={() => repoViewport}
+                  estimateSize={() => 140}
+                />
+              </ScrollArea.Viewport>
+            </ScrollArea.Root>
+          </Mosaic.Container>
+        </Focus.Group>
+      </Panel.Content>
+      {!account.accessToken && (
+        <Panel.Statusbar>
+          <p className='flex p-1 items-center text-warning-text'>Configure personal access token to enable sync.</p>
+        </Panel.Statusbar>
+      )}
+    </Panel.Root>
+  );
+};

--- a/packages/plugins/plugin-github/src/containers/GitHubArticle/GitHubArticle.tsx
+++ b/packages/plugins/plugin-github/src/containers/GitHubArticle/GitHubArticle.tsx
@@ -117,9 +117,11 @@ export const GitHubArticle = ({ role, subject: account }: GitHubArticleProps) =>
   const [syncing, setSyncing] = useState(false);
   const [repoViewport, setRepoViewport] = useState<HTMLElement | null>(null);
 
+  // TODO(richburdon): Move sync logic to an operation handler (like plugin-trello sync-board.ts).
   /** Sync repos for organizations in the workspace. */
   const handleSync = useCallback(async () => {
-    if (!db || !account.accessToken) {
+    const token = account.accessToken?.target?.token;
+    if (!db || !token) {
       return;
     }
 
@@ -152,7 +154,7 @@ export const GitHubArticle = ({ role, subject: account }: GitHubArticleProps) =>
         try {
           const searchData = await githubFetch(
             `/search/repositories?q=org:${encodeURIComponent(orgName)}&sort=stars&per_page=10`,
-            account.accessToken,
+            token,
           );
           const remoteRepos = (searchData.items ?? []) as GitHubApiRepo[];
 
@@ -266,7 +268,7 @@ export const GitHubArticle = ({ role, subject: account }: GitHubArticleProps) =>
       </Panel.Content>
       {!account.accessToken && (
         <Panel.Statusbar>
-          <p className='flex p-1 items-center text-warning-text'>Configure personal access token to enable sync.</p>
+          <Toolbar.Text>Configure an AccessToken in account properties to enable sync.</Toolbar.Text>
         </Panel.Statusbar>
       )}
     </Panel.Root>

--- a/packages/plugins/plugin-github/src/containers/GitHubArticle/index.ts
+++ b/packages/plugins/plugin-github/src/containers/GitHubArticle/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+export { GitHubArticle as default } from './GitHubArticle';

--- a/packages/plugins/plugin-github/src/containers/index.ts
+++ b/packages/plugins/plugin-github/src/containers/index.ts
@@ -1,0 +1,7 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { type ComponentType, lazy } from 'react';
+
+export const GitHubArticle: ComponentType<any> = lazy(() => import('./GitHubArticle'));

--- a/packages/plugins/plugin-github/src/index.ts
+++ b/packages/plugins/plugin-github/src/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+export { meta } from './meta';
+export { GitHubPlugin } from './GitHubPlugin';

--- a/packages/plugins/plugin-github/src/meta.ts
+++ b/packages/plugins/plugin-github/src/meta.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { type Plugin } from '@dxos/app-framework';
+
+export const meta: Plugin.Meta = {
+  id: 'org.dxos.plugin.github',
+  name: 'GitHub',
+  description: 'Monitors GitHub repos for deal-relevant activity and creates signals.',
+  icon: 'ph--github-logo--regular',
+  iconHue: 'neutral',
+};

--- a/packages/plugins/plugin-github/src/translations.ts
+++ b/packages/plugins/plugin-github/src/translations.ts
@@ -1,0 +1,22 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { GitHub } from '#types';
+
+export const translations = [
+  {
+    'en-US': {
+      [GitHub.GitHubAccount.typename]: {
+        'typename.label_one': 'GitHub Account',
+        'typename.label_other': 'GitHub Accounts',
+        'object-name.placeholder': 'GitHub Account',
+      },
+      [GitHub.GitHubRepo.typename]: {
+        'typename.label_one': 'GitHub Repo',
+        'typename.label_other': 'GitHub Repos',
+        'object-name.placeholder': 'GitHub Repo',
+      },
+    },
+  },
+];

--- a/packages/plugins/plugin-github/src/types/GitHub.ts
+++ b/packages/plugins/plugin-github/src/types/GitHub.ts
@@ -8,7 +8,7 @@ import * as Schema from 'effect/Schema';
 
 import { Annotation, Obj, Ref, Type } from '@dxos/echo';
 import { FormInputAnnotation, LabelAnnotation } from '@dxos/echo/internal';
-import { Organization } from '@dxos/types';
+import { AccessToken, Organization } from '@dxos/types';
 
 /**
  * A GitHub repository being tracked in the workspace.
@@ -52,8 +52,13 @@ export interface GitHubRepo extends Schema.Schema.Type<typeof GitHubRepo> {}
 export const GitHubAccount = Schema.Struct({
   /** Display name. */
   name: Schema.optional(Schema.String),
-  /** GitHub personal access token. */
-  accessToken: Schema.String.pipe(FormInputAnnotation.set(false)),
+  /** GitHub credentials (PAT stored as AccessToken). */
+  accessToken: Schema.optional(
+    Ref.Ref(AccessToken.AccessToken).annotations({
+      title: 'GitHub credentials',
+      description: 'Personal access token for syncing repos and PRs.',
+    }),
+  ),
   /** Last sync timestamp. */
   lastSyncedAt: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
 }).pipe(
@@ -109,25 +114,53 @@ export const GitHubPullRequest = Schema.Struct({
 
 export interface GitHubPullRequest extends Schema.Schema.Type<typeof GitHubPullRequest> {}
 
-/** Input schema for creating a GitHubAccount. */
+/** Input schema for creating a GitHubAccount via the Create menu. */
 export const CreateGitHubAccountSchema = Schema.Struct({
-  accessToken: Schema.String.annotations({
-    title: 'Personal Access Token',
-    description: 'GitHub personal access token (fine-grained or classic).',
-  }),
+  name: Schema.optional(
+    Schema.String.annotations({
+      title: 'Name',
+      description: 'Display name for this GitHub account.',
+    }),
+  ),
 });
 
 export interface CreateGitHubAccountSchema extends Schema.Schema.Type<typeof CreateGitHubAccountSchema> {}
 
 /** Creates a GitHubAccount object. */
-export const makeAccount = (props: CreateGitHubAccountSchema): GitHubAccount => {
+export const makeAccount = (props?: { name?: string }): GitHubAccount => {
   return Obj.make(GitHubAccount, {
-    name: 'GitHub',
-    accessToken: props.accessToken,
+    name: props?.name ?? 'GitHub',
   });
 };
 
-/** Creates a GitHubRepo object. */
+/** Creates a GitHubRepo object with foreignKey for the GitHub full name. */
 export const makeRepo = (props: Partial<Obj.MakeProps<typeof GitHubRepo>> & { fullName: string }): GitHubRepo => {
-  return Obj.make(GitHubRepo, props);
+  return Obj.make(GitHubRepo, {
+    [Obj.Meta]: {
+      keys: [{ id: props.fullName, source: 'github.com' }],
+    },
+    ...props,
+  });
+};
+
+/** Creates a GitHubPullRequest with foreignKey. */
+export const makePullRequest = (
+  props: Obj.MakeProps<typeof GitHubPullRequest> & { fullName: string; number: number },
+): GitHubPullRequest => {
+  return Obj.make(GitHubPullRequest, {
+    [Obj.Meta]: {
+      keys: [{ id: `${props.fullName}#${props.number}`, source: 'github.com' }],
+    },
+    ...props,
+  });
+};
+
+// ── Foreign key helpers ─────────────────────────────────────────────────────
+
+const GITHUB_SOURCE = 'github.com';
+
+/** Extract the GitHub ID from an object's foreignKeys. */
+export const getGitHubId = (obj: Obj.Any): string | undefined => {
+  const meta = Obj.getMeta(obj);
+  return meta.keys?.find((key: { source: string; id: string }) => key.source === GITHUB_SOURCE)?.id;
 };

--- a/packages/plugins/plugin-github/src/types/GitHub.ts
+++ b/packages/plugins/plugin-github/src/types/GitHub.ts
@@ -1,0 +1,133 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+// @import-as-namespace
+
+import * as Schema from 'effect/Schema';
+
+import { Annotation, Obj, Ref, Type } from '@dxos/echo';
+import { FormInputAnnotation, LabelAnnotation } from '@dxos/echo/internal';
+import { Organization } from '@dxos/types';
+
+/**
+ * A GitHub repository being tracked in the workspace.
+ */
+export const GitHubRepo = Schema.Struct({
+  /** Repository display name (owner/repo). */
+  name: Schema.optional(Schema.String),
+  /** GitHub repository full name (owner/repo). */
+  fullName: Schema.String.pipe(FormInputAnnotation.set(false)),
+  /** Repository description. */
+  description: Schema.optional(Schema.String),
+  /** Primary language. */
+  language: Schema.optional(Schema.String),
+  /** Star count at last sync. */
+  stars: Schema.optional(Schema.Number.pipe(FormInputAnnotation.set(false))),
+  /** Fork count at last sync. */
+  forks: Schema.optional(Schema.Number.pipe(FormInputAnnotation.set(false))),
+  /** Open issue count at last sync. */
+  openIssues: Schema.optional(Schema.Number.pipe(FormInputAnnotation.set(false))),
+  /** Linked organization. */
+  organization: Schema.optional(Ref.Ref(Organization.Organization).pipe(FormInputAnnotation.set(false))),
+  /** Last sync timestamp. */
+  lastSyncedAt: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+}).pipe(
+  Type.object({
+    typename: 'org.dxos.type.githubRepo',
+    version: '0.1.0',
+  }),
+  LabelAnnotation.set(['name']),
+  Annotation.IconAnnotation.set({
+    icon: 'ph--git-branch--regular',
+    hue: 'neutral',
+  }),
+);
+
+export interface GitHubRepo extends Schema.Schema.Type<typeof GitHubRepo> {}
+
+/**
+ * GitHubAccount schema for personal access token and sync configuration.
+ */
+export const GitHubAccount = Schema.Struct({
+  /** Display name. */
+  name: Schema.optional(Schema.String),
+  /** GitHub personal access token. */
+  accessToken: Schema.String.pipe(FormInputAnnotation.set(false)),
+  /** Last sync timestamp. */
+  lastSyncedAt: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+}).pipe(
+  Type.object({
+    typename: 'org.dxos.type.githubAccount',
+    version: '0.1.0',
+  }),
+  LabelAnnotation.set(['name']),
+  Annotation.IconAnnotation.set({
+    icon: 'ph--github-logo--regular',
+    hue: 'neutral',
+  }),
+);
+
+export interface GitHubAccount extends Schema.Schema.Type<typeof GitHubAccount> {}
+
+/**
+ * A GitHub pull request — open, closed, or merged. One object per PR;
+ * dedup key is `${fullName}#${number}`.
+ */
+export const GitHubPullRequest = Schema.Struct({
+  /** Repository full name (owner/repo). */
+  fullName: Schema.String.pipe(FormInputAnnotation.set(false)),
+  /** PR number. */
+  number: Schema.Number.pipe(FormInputAnnotation.set(false)),
+  /** PR title. */
+  title: Schema.String.pipe(FormInputAnnotation.set(false)),
+  /** PR body (truncated to ~4 kB at ingest). */
+  body: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+  /** GitHub login of the PR author. */
+  author: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+  /** 'open' | 'closed'. When `mergedAt` is set, the PR was merged rather than just closed. */
+  state: Schema.String.pipe(FormInputAnnotation.set(false)),
+  /** ISO timestamp. Present only for merged PRs. */
+  mergedAt: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+  /** ISO timestamp the PR was opened. */
+  createdAt: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+  /** ISO timestamp the PR was last updated on GitHub. */
+  updatedAt: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+  /** PR URL. */
+  url: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+}).pipe(
+  Type.object({
+    typename: 'org.dxos.type.githubPullRequest',
+    version: '0.1.0',
+  }),
+  LabelAnnotation.set(['title']),
+  Annotation.IconAnnotation.set({
+    icon: 'ph--git-pull-request--regular',
+    hue: 'neutral',
+  }),
+);
+
+export interface GitHubPullRequest extends Schema.Schema.Type<typeof GitHubPullRequest> {}
+
+/** Input schema for creating a GitHubAccount. */
+export const CreateGitHubAccountSchema = Schema.Struct({
+  accessToken: Schema.String.annotations({
+    title: 'Personal Access Token',
+    description: 'GitHub personal access token (fine-grained or classic).',
+  }),
+});
+
+export interface CreateGitHubAccountSchema extends Schema.Schema.Type<typeof CreateGitHubAccountSchema> {}
+
+/** Creates a GitHubAccount object. */
+export const makeAccount = (props: CreateGitHubAccountSchema): GitHubAccount => {
+  return Obj.make(GitHubAccount, {
+    name: 'GitHub',
+    accessToken: props.accessToken,
+  });
+};
+
+/** Creates a GitHubRepo object. */
+export const makeRepo = (props: Partial<Obj.MakeProps<typeof GitHubRepo>> & { fullName: string }): GitHubRepo => {
+  return Obj.make(GitHubRepo, props);
+};

--- a/packages/plugins/plugin-github/src/types/index.ts
+++ b/packages/plugins/plugin-github/src/types/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+export * as GitHub from './GitHub';

--- a/packages/plugins/plugin-github/tsconfig.json
+++ b/packages/plugins/plugin-github/tsconfig.json
@@ -1,0 +1,69 @@
+{
+  "extends": [
+    "../../../tsconfig.base.json"
+  ],
+  "compilerOptions": {
+    "types": [
+      "node"
+    ]
+  },
+  "exclude": [
+    "*.t.ts",
+    "vite.config.ts"
+  ],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../../common/log"
+    },
+    {
+      "path": "../../common/storybook-utils"
+    },
+    {
+      "path": "../../common/util"
+    },
+    {
+      "path": "../../core/echo/echo"
+    },
+    {
+      "path": "../../core/echo/echo-db"
+    },
+    {
+      "path": "../../core/operation"
+    },
+    {
+      "path": "../../sdk/app-framework"
+    },
+    {
+      "path": "../../sdk/app-toolkit"
+    },
+    {
+      "path": "../../sdk/react-client"
+    },
+    {
+      "path": "../../sdk/types"
+    },
+    {
+      "path": "../../ui/react-ui"
+    },
+    {
+      "path": "../../ui/react-ui-mosaic"
+    },
+    {
+      "path": "../../ui/ui-theme"
+    },
+    {
+      "path": "../plugin-graph"
+    },
+    {
+      "path": "../plugin-space"
+    },
+    {
+      "path": "../plugin-theme"
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9199,6 +9199,73 @@ importers:
         specifier: '>=7.1.11'
         version: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/plugins/plugin-github:
+    dependencies:
+      '@dxos/app-framework':
+        specifier: workspace:*
+        version: link:../../sdk/app-framework
+      '@dxos/app-toolkit':
+        specifier: workspace:*
+        version: link:../../sdk/app-toolkit
+      '@dxos/echo':
+        specifier: workspace:*
+        version: link:../../core/echo/echo
+      '@dxos/echo-db':
+        specifier: workspace:*
+        version: link:../../core/echo/echo-db
+      '@dxos/log':
+        specifier: workspace:*
+        version: link:../../common/log
+      '@dxos/operation':
+        specifier: workspace:*
+        version: link:../../core/operation
+      '@dxos/plugin-graph':
+        specifier: workspace:*
+        version: link:../plugin-graph
+      '@dxos/plugin-space':
+        specifier: workspace:*
+        version: link:../plugin-space
+      '@dxos/react-client':
+        specifier: workspace:*
+        version: link:../../sdk/react-client
+      '@dxos/react-ui-mosaic':
+        specifier: workspace:*
+        version: link:../../ui/react-ui-mosaic
+      '@dxos/types':
+        specifier: workspace:*
+        version: link:../../sdk/types
+      '@dxos/ui-theme':
+        specifier: workspace:*
+        version: link:../../ui/ui-theme
+      '@dxos/util':
+        specifier: workspace:*
+        version: link:../../common/util
+      effect:
+        specifier: 3.20.0
+        version: 3.20.0
+    devDependencies:
+      '@dxos/plugin-theme':
+        specifier: workspace:*
+        version: link:../plugin-theme
+      '@dxos/react-ui':
+        specifier: workspace:*
+        version: link:../../ui/react-ui
+      '@dxos/storybook-utils':
+        specifier: workspace:*
+        version: link:../../common/storybook-utils
+      '@types/react':
+        specifier: ~19.2.7
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ~19.2.3
+        version: 19.2.3(@types/react@19.2.7)
+      react:
+        specifier: ~19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: ~19.2.3
+        version: 19.2.3(react@19.2.3)
+
   packages/plugins/plugin-graph:
     dependencies:
       '@dxos/app-framework':

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -570,6 +570,11 @@
         },
         {
           "type": "json",
+          "path": "packages/plugins/plugin-github/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "packages/plugins/plugin-graph/package.json",
           "jsonpath": "$.version"
         },

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -328,6 +328,9 @@
       "path": "packages/plugins/plugin-files/tsconfig.json"
     },
     {
+      "path": "packages/plugins/plugin-github/tsconfig.json"
+    },
+    {
       "path": "packages/plugins/plugin-graph/tsconfig.json"
     },
     {


### PR DESCRIPTION
## Summary

New plugin for GitHub integration — syncs repos from organizations in the workspace and tracks PR metadata.

- **GitHubRepo** — repo metadata (stars, forks, language, linked Organization)
- **GitHubPullRequest** — PR number, title, author, state, mergedAt
- **GitHubAccount** — credentials via `AccessToken` ref (not inline tokens)
- Foreign keys via `Obj.Meta` for repos and PRs (`source: 'github.com'`)
- Composer UI: Panel/Toolbar/Card/Mosaic — no custom DOM in containers
- TODO: move sync logic from container to operation handler

## Test plan
- [x] Build passes
- [x] Verified in live Composer session

🤖 Generated with [Claude Code](https://claude.com/claude-code)