### PR TITLE
feat(plugin-granola): Granola meeting note sync integration

### DIFF
--- a/packages/plugins/plugin-granola/moon.yml
+++ b/packages/plugins/plugin-granola/moon.yml
@@ -1,0 +1,11 @@
+layer: library
+language: typescript
+tags:
+  - ts-build
+  - ts-test
+  - pack
+tasks:
+  compile:
+    args:
+      - '--entryPoint=src/index.ts'
+      - '--entryPoint=src/types/index.ts'

--- a/packages/plugins/plugin-granola/package.json
+++ b/packages/plugins/plugin-granola/package.json
@@ -1,0 +1,87 @@
+{
+  "name": "@dxos/plugin-granola",
+  "version": "0.8.3",
+  "private": true,
+  "description": "Granola meeting notes integration plugin for syncing notes, summaries, and transcripts.",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dxos/dxos"
+  },
+  "license": "MIT",
+  "author": "DXOS.org",
+  "sideEffects": true,
+  "type": "module",
+  "imports": {
+    "#capabilities": "./src/capabilities/index.ts",
+    "#components": "./src/components/index.ts",
+    "#containers": "./src/containers/index.ts",
+    "#meta": "./src/meta.ts",
+    "#types": "./src/types/index.ts"
+  },
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/types/src/index.d.ts",
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": "./dist/lib/node-esm/index.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "browser": "./dist/lib/browser/types/index.mjs",
+      "node": "./dist/lib/node-esm/types/index.mjs"
+    }
+  },
+  "types": "dist/types/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "types": [
+        "dist/types/src/types/index.d.ts"
+      ]
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@dxos/app-framework": "workspace:*",
+    "@dxos/app-toolkit": "workspace:*",
+    "@dxos/async": "workspace:*",
+    "@dxos/echo": "workspace:*",
+    "@dxos/echo-db": "workspace:*",
+    "@dxos/invariant": "workspace:*",
+    "@dxos/log": "workspace:*",
+    "@dxos/operation": "workspace:*",
+    "@dxos/plugin-graph": "workspace:*",
+    "@dxos/plugin-markdown": "workspace:*",
+    "@dxos/plugin-space": "workspace:*",
+    "@dxos/plugin-trello": "workspace:*",
+    "@dxos/react-client": "workspace:*",
+    "@dxos/react-ui-mosaic": "workspace:*",
+    "@dxos/schema": "workspace:*",
+    "@dxos/ui-theme": "workspace:*",
+    "@dxos/util": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@dxos/plugin-theme": "workspace:*",
+    "@dxos/react-ui": "workspace:*",
+    "@dxos/storybook-utils": "workspace:*",
+    "@dxos/ui-theme": "workspace:*",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "vite": "catalog:"
+  },
+  "peerDependencies": {
+    "@dxos/react-ui": "workspace:*",
+    "@dxos/ui-theme": "workspace:*",
+    "effect": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  }
+}

--- a/packages/plugins/plugin-granola/src/GranolaPlugin.tsx
+++ b/packages/plugins/plugin-granola/src/GranolaPlugin.tsx
@@ -1,0 +1,50 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { Annotation } from '@dxos/echo';
+import { Operation } from '@dxos/operation';
+import { SpaceOperation } from '@dxos/plugin-space/operations';
+import { type CreateObject } from '@dxos/plugin-space/types';
+
+import { ReactSurface } from '#capabilities';
+import { meta } from '#meta';
+import { Granola } from '#types';
+
+import { translations } from './translations';
+
+export const GranolaPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addMetadataModule({
+    metadata: [
+      {
+        id: Granola.GranolaAccount.typename,
+        metadata: {
+          icon: Annotation.IconAnnotation.get(Granola.GranolaAccount).pipe(Option.getOrThrow).icon,
+          iconHue: Annotation.IconAnnotation.get(Granola.GranolaAccount).pipe(Option.getOrThrow).hue ?? 'white',
+          inputSchema: Granola.CreateGranolaAccountSchema,
+          createObject: ((props, options) =>
+            Effect.gen(function* () {
+              const object = Granola.makeAccount(props);
+              return yield* Operation.invoke(SpaceOperation.AddObject, {
+                object,
+                target: options.target,
+                hidden: false,
+                targetNodeId: options.targetNodeId,
+              });
+            })) satisfies CreateObject,
+        },
+      },
+    ],
+  }),
+  AppPlugin.addSchemaModule({
+    schema: [Granola.GranolaAccount, Granola.GranolaSyncRecord],
+  }),
+  AppPlugin.addSurfaceModule({ activate: ReactSurface }),
+  AppPlugin.addTranslationsModule({ translations }),
+  Plugin.make,
+);

--- a/packages/plugins/plugin-granola/src/capabilities/index.ts
+++ b/packages/plugins/plugin-granola/src/capabilities/index.ts
@@ -1,0 +1,7 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Capability } from '@dxos/app-framework';
+
+export const ReactSurface = Capability.lazy('ReactSurface', () => import('./react-surface'));

--- a/packages/plugins/plugin-granola/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-granola/src/capabilities/react-surface.tsx
@@ -1,0 +1,28 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import React from 'react';
+
+import { Capabilities, Capability } from '@dxos/app-framework';
+import { Surface } from '@dxos/app-framework/ui';
+import { AppSurface } from '@dxos/app-toolkit/ui';
+
+import { GranolaArticle } from '#containers';
+import { Granola } from '#types';
+
+export default Capability.makeModule(() =>
+  Effect.succeed(
+    Capability.contributes(Capabilities.ReactSurface, [
+      Surface.create({
+        id: 'granola-account',
+        role: ['article', 'section'],
+        filter: AppSurface.objectArticle(Granola.GranolaAccount),
+        component: ({ data, role }) => (
+          <GranolaArticle role={role} subject={data.subject} attendableId={data.attendableId} />
+        ),
+      }),
+    ]),
+  ),
+);

--- a/packages/plugins/plugin-granola/src/components/index.ts
+++ b/packages/plugins/plugin-granola/src/components/index.ts
@@ -1,0 +1,3 @@
+//
+// Copyright 2025 DXOS.org
+//

--- a/packages/plugins/plugin-granola/src/containers/GranolaArticle/GranolaArticle.tsx
+++ b/packages/plugins/plugin-granola/src/containers/GranolaArticle/GranolaArticle.tsx
@@ -100,7 +100,7 @@ const aiMatch = async (
     const doc = record.document?.target;
     const summary = doc?.content?.target?.content?.slice(0, 500) ?? '';
     return {
-      id: record.granolaId,
+      id: Granola.getGranolaId(record),
       noteTitle: doc?.name ?? '',
       meetingTitle: record.calendarEvent?.title ?? '',
       attendees: (record.attendees ?? []).map((attendee) => attendee.name ?? attendee.email ?? '').join(', '),
@@ -176,15 +176,15 @@ const NoteTile = forwardRef<HTMLDivElement, NoteTileProps>(({ data, location, cu
   const doc = record.document?.target;
 
   const handleClick = useCallback(() => {
-    setCurrentId(record.granolaId);
+    setCurrentId(Granola.getGranolaId(record));
     onOpen(record);
   }, [record, onOpen, setCurrentId]);
 
   const published = record.createdAt ? new Date(record.createdAt).toLocaleDateString() : undefined;
 
   return (
-    <Mosaic.Tile asChild classNames='dx-hover dx-current' id={record.granolaId} data={data} location={location}>
-      <Focus.Item asChild current={current} onCurrentChange={() => setCurrentId(record.granolaId)}>
+    <Mosaic.Tile asChild classNames='dx-hover dx-current' id={Granola.getGranolaId(record)} data={data} location={location}>
+      <Focus.Item asChild current={current} onCurrentChange={() => setCurrentId(Granola.getGranolaId(record))}>
         <Card.Root ref={forwardedRef} onClick={handleClick}>
           <Card.Toolbar>
             <Card.IconBlock>
@@ -293,7 +293,7 @@ export const GranolaArticle = ({ role, subject: account }: GranolaArticleProps) 
   const handleMatchToTrello = useCallback(async () => {
     setMatching(true);
     try {
-      const uniqueByGranola = [...new Map(syncRecords.map((record) => [record.granolaId, record])).values()];
+      const uniqueByGranola = [...new Map(syncRecords.map((record) => [Granola.getGranolaId(record), record])).values()];
       const activeCards = trelloCards.filter((card) => !card.closed);
       const results = await aiMatch(uniqueByGranola, activeCards);
       setMatches(results);
@@ -340,14 +340,14 @@ export const GranolaArticle = ({ role, subject: account }: GranolaArticleProps) 
   }, [db, matches, invokePromise]);
 
   const handleSync = useCallback(async () => {
-    if (!db || !account.apiKey) {
+    if (!db || !account.accessToken?.target?.token) {
       return;
     }
 
     setSyncing(true);
     try {
-      const headers = { Authorization: `Bearer ${account.apiKey}` };
-      const existingByGranolaId = new Map(syncRecords.map((record) => [record.granolaId, record]));
+      const headers = { Authorization: `Bearer ${account.accessToken?.target?.token ?? ''}` };
+      const existingByGranolaId = new Map(syncRecords.map((record) => [Granola.getGranolaId(record), record]));
 
       let cursor: string | undefined;
       let hasMore = true;
@@ -365,6 +365,10 @@ export const GranolaArticle = ({ role, subject: account }: GranolaArticleProps) 
         const data = await response.json();
         remoteNotes.push(...data.notes);
         hasMore = data.hasMore;
+        if (hasMore && !data.cursor) {
+          log.warn("granola: pagination stuck — hasMore=true but no cursor");
+          break;
+        }
         cursor = data.cursor ?? undefined;
       }
 
@@ -440,13 +444,13 @@ export const GranolaArticle = ({ role, subject: account }: GranolaArticleProps) 
 
   const didAutoSync = useRef(false);
   useEffect(() => {
-    if (!didAutoSync.current && account.apiKey && !account.lastSyncedAt) {
+    if (!didAutoSync.current && account.accessToken?.target?.token && !account.lastSyncedAt) {
       didAutoSync.current = true;
       void handleSync();
     }
-  }, [account.apiKey, account.lastSyncedAt, handleSync]);
+  }, [account.accessToken?.target?.token, account.lastSyncedAt, handleSync]);
 
-  const uniqueRecords = [...new Map(syncRecords.map((record) => [record.granolaId, record])).values()];
+  const uniqueRecords = [...new Map(syncRecords.map((record) => [Granola.getGranolaId(record), record])).values()];
   const sortedRecords = [...uniqueRecords].sort((recordA, recordB) => {
     const dateA = recordA.createdAt ? new Date(recordA.createdAt).getTime() : 0;
     const dateB = recordB.createdAt ? new Date(recordB.createdAt).getTime() : 0;
@@ -473,7 +477,7 @@ export const GranolaArticle = ({ role, subject: account }: GranolaArticleProps) 
             label={syncing ? 'Syncing...' : 'Sync notes'}
             icon='ph--arrows-clockwise--regular'
             iconOnly
-            disabled={syncing || !account.apiKey}
+            disabled={syncing || !account.accessToken?.target?.token}
             onClick={handleSync}
           />
           {trelloCards.length > 0 && (
@@ -532,7 +536,7 @@ export const GranolaArticle = ({ role, subject: account }: GranolaArticleProps) 
                   gap={8}
                   items={noteItems}
                   draggable={false}
-                  getId={(item) => item.record.granolaId}
+                  getId={(item) => Granola.getGranolaId(item.record) ?? item.record.id}
                   getScrollElement={() => noteViewport}
                   estimateSize={() => 120}
                 />
@@ -541,7 +545,7 @@ export const GranolaArticle = ({ role, subject: account }: GranolaArticleProps) 
           </Mosaic.Container>
         </Focus.Group>
       </Panel.Content>
-      {!account.apiKey && (
+      {!account.accessToken && (
         <Panel.Statusbar>
           <p className='flex p-1 items-center text-warning-text'>Configure API key in account properties to enable sync.</p>
         </Panel.Statusbar>

--- a/packages/plugins/plugin-granola/src/containers/GranolaArticle/GranolaArticle.tsx
+++ b/packages/plugins/plugin-granola/src/containers/GranolaArticle/GranolaArticle.tsx
@@ -1,0 +1,551 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import React, { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useOperationInvoker } from '@dxos/app-framework/ui';
+import { getObjectPathFromObject, LayoutOperation } from '@dxos/app-toolkit';
+import { Filter, Obj, Ref } from '@dxos/echo';
+import { log } from '@dxos/log';
+import { Markdown } from '@dxos/plugin-markdown/types';
+import { Trello } from '@dxos/plugin-trello/types';
+import { useQuery } from '@dxos/react-client/echo';
+import { Card, Icon, Panel, ScrollArea, Toolbar } from '@dxos/react-ui';
+import { Focus, Mosaic, type MosaicTileProps, useMosaicContainer } from '@dxos/react-ui-mosaic';
+
+import { Granola } from '#types';
+
+export type GranolaArticleProps = {
+  role: string;
+  subject: Granola.GranolaAccount;
+  attendableId?: string;
+};
+
+// Use local proxy in dev to avoid CORS, direct API in production.
+const GRANOLA_API_BASE = '/api/granola';
+
+/** Build rich markdown content from Granola note details. */
+const buildDocumentContent = (detail: any): string => {
+  const sections: string[] = [];
+
+  if (detail.calendar_event?.title) {
+    sections.push(`> **Meeting:** ${detail.calendar_event.title}`);
+    const parts: string[] = [];
+    if (detail.calendar_event.start_time) {
+      const start = new Date(detail.calendar_event.start_time);
+      const end = detail.calendar_event.end_time ? new Date(detail.calendar_event.end_time) : undefined;
+      parts.push(`**Date:** ${start.toLocaleDateString()} ${start.toLocaleTimeString()}${end ? ` - ${end.toLocaleTimeString()}` : ''}`);
+    }
+    if (detail.calendar_event.organizer_email) {
+      parts.push(`**Organizer:** ${detail.calendar_event.organizer_email}`);
+    }
+    if (parts.length > 0) {
+      sections.push(`> ${parts.join(' | ')}`);
+    }
+  }
+
+  if (detail.attendees?.length > 0) {
+    const names = detail.attendees.map((attendee: any) => attendee.name ?? attendee.email).join(', ');
+    sections.push(`> **Attendees:** ${names}`);
+  }
+
+  if (sections.length > 0) {
+    sections.push('');
+  }
+
+  const summary = detail.summary_markdown ?? detail.summary_text;
+  if (summary) {
+    sections.push(summary);
+  }
+
+  if (detail.transcript?.length > 0) {
+    sections.push('', '---', '', '## Transcript', '');
+    for (const entry of detail.transcript) {
+      const speaker = entry.speaker_source ? `**${entry.speaker_source}:** ` : '';
+      sections.push(`${speaker}${entry.text}`, '');
+    }
+  }
+
+  return sections.join('\n');
+};
+
+//
+// AI matching.
+//
+
+type MatchResult = {
+  noteTitle: string;
+  meetingTitle: string;
+  cardName: string;
+  cardListName: string;
+  confidence: string;
+  reasoning: string;
+};
+
+/** Use Claude to find matches between Granola notes and Trello cards. */
+const aiMatch = async (
+  records: Granola.GranolaSyncRecord[],
+  cards: Trello.TrelloCard[],
+): Promise<MatchResult[]> => {
+  const apiKey = typeof globalThis.localStorage !== 'undefined'
+    ? globalThis.localStorage.getItem('ANTHROPIC_API_KEY')
+    : null;
+
+  if (!apiKey) {
+    throw new Error('Set ANTHROPIC_API_KEY in localStorage to use AI matching.');
+  }
+
+  const noteSummaries = records.map((record) => {
+    const doc = record.document?.target;
+    const summary = doc?.content?.target?.content?.slice(0, 500) ?? '';
+    return {
+      id: record.granolaId,
+      noteTitle: doc?.name ?? '',
+      meetingTitle: record.calendarEvent?.title ?? '',
+      attendees: (record.attendees ?? []).map((attendee) => attendee.name ?? attendee.email ?? '').join(', '),
+      summarySnippet: summary,
+    };
+  });
+
+  const cardSummaries = cards.map((card) => ({
+    name: card.name,
+    list: card.listName ?? '',
+    description: (card.description ?? '').slice(0, 200),
+    labels: (card.labels ?? []).map((label) => label.name).join(', '),
+  }));
+
+  const response = await fetch('/api/anthropic/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 4096,
+      messages: [{
+        role: 'user',
+        content: `You are matching meeting notes to Trello cards. For each meeting note, determine if it relates to any of the Trello cards. A match means the meeting was likely about that card's topic, involved the same people/project, or discussed the subject the card tracks.
+
+MEETING NOTES:
+${JSON.stringify(noteSummaries, null, 2)}
+
+TRELLO CARDS:
+${JSON.stringify(cardSummaries, null, 2)}
+
+Return a JSON array of matches. Each match should have:
+- noteTitle: the meeting note title
+- meetingTitle: the calendar event title
+- cardName: the matched Trello card name (exact match from the list above)
+- cardListName: the list the card is in
+- confidence: "high", "medium", or "low"
+- reasoning: one sentence explaining why this is a match
+
+Only include matches where there is a real connection. If a note has no matching card, skip it. Return ONLY the JSON array, no other text.`,
+      }],
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Anthropic API ${response.status}: ${errorText}`);
+  }
+
+  const result = await response.json();
+  const text = result.content?.[0]?.text ?? '[]';
+  const jsonText = text.replace(/^```json?\n?/, '').replace(/\n?```$/, '').trim();
+  return JSON.parse(jsonText) as MatchResult[];
+};
+
+//
+// Tile components for Mosaic.VirtualStack.
+//
+
+type NoteTileData = {
+  record: Granola.GranolaSyncRecord;
+  onOpen: (record: Granola.GranolaSyncRecord) => void;
+};
+
+type NoteTileProps = Pick<MosaicTileProps<NoteTileData>, 'data' | 'location' | 'current'>;
+
+const NoteTile = forwardRef<HTMLDivElement, NoteTileProps>(({ data, location, current }, forwardedRef) => {
+  const { record, onOpen } = data;
+  const { setCurrentId } = useMosaicContainer('NoteTile');
+  const doc = record.document?.target;
+
+  const handleClick = useCallback(() => {
+    setCurrentId(record.granolaId);
+    onOpen(record);
+  }, [record, onOpen, setCurrentId]);
+
+  const published = record.createdAt ? new Date(record.createdAt).toLocaleDateString() : undefined;
+
+  return (
+    <Mosaic.Tile asChild classNames='dx-hover dx-current' id={record.granolaId} data={data} location={location}>
+      <Focus.Item asChild current={current} onCurrentChange={() => setCurrentId(record.granolaId)}>
+        <Card.Root ref={forwardedRef} onClick={handleClick}>
+          <Card.Toolbar>
+            <Card.IconBlock>
+              <Card.Icon icon='ph--notebook--regular' />
+            </Card.IconBlock>
+            <Card.Text classNames='truncate'>{doc?.name ?? 'Untitled Note'}</Card.Text>
+          </Card.Toolbar>
+          <Card.Content>
+            {record.calendarEvent?.title && (
+              <Card.Row icon='ph--calendar--regular'>
+                <Card.Text variant='description'>{record.calendarEvent.title}</Card.Text>
+              </Card.Row>
+            )}
+            {record.attendees && record.attendees.length > 0 && (
+              <Card.Row icon='ph--users--regular'>
+                <Card.Text variant='description'>
+                  {record.attendees.map((attendee) => attendee.name ?? attendee.email).join(', ')}
+                </Card.Text>
+              </Card.Row>
+            )}
+            {published && (
+              <Card.Row icon='ph--clock--regular'>
+                <Card.Text variant='description'>{published}</Card.Text>
+              </Card.Row>
+            )}
+          </Card.Content>
+        </Card.Root>
+      </Focus.Item>
+    </Mosaic.Tile>
+  );
+});
+
+NoteTile.displayName = 'NoteTile';
+
+type MatchTileData = {
+  match: MatchResult;
+  index: number;
+};
+
+type MatchTileProps = Pick<MosaicTileProps<MatchTileData>, 'data' | 'location' | 'current'>;
+
+const MatchTile = forwardRef<HTMLDivElement, MatchTileProps>(({ data, location, current }, forwardedRef) => {
+  const { match, index } = data;
+  const { setCurrentId } = useMosaicContainer('MatchTile');
+  const matchId = `match-${index}`;
+
+  const confidenceIcon = match.confidence === 'high'
+    ? 'ph--check-circle--regular'
+    : match.confidence === 'medium'
+      ? 'ph--warning-circle--regular'
+      : 'ph--question--regular';
+
+  return (
+    <Mosaic.Tile asChild classNames='dx-hover dx-current' id={matchId} data={data} location={location}>
+      <Focus.Item asChild current={current} onCurrentChange={() => setCurrentId(matchId)}>
+        <Card.Root ref={forwardedRef}>
+          <Card.Toolbar>
+            <Card.IconBlock>
+              <Card.Icon icon={confidenceIcon} />
+            </Card.IconBlock>
+            <Card.Text classNames='truncate'>{match.noteTitle || match.meetingTitle}</Card.Text>
+            <Card.IconBlock>
+              <Icon icon='ph--arrow-right--regular' size={4} />
+            </Card.IconBlock>
+            <Card.Text classNames='truncate'>{match.cardName}</Card.Text>
+          </Card.Toolbar>
+          <Card.Content>
+            <Card.Row icon='ph--list-bullets--regular'>
+              <Card.Text variant='description'>{match.cardListName}</Card.Text>
+            </Card.Row>
+            <Card.Row icon='ph--lightbulb--regular'>
+              <Card.Text variant='description'>{match.reasoning}</Card.Text>
+            </Card.Row>
+          </Card.Content>
+        </Card.Root>
+      </Focus.Item>
+    </Mosaic.Tile>
+  );
+});
+
+MatchTile.displayName = 'MatchTile';
+
+//
+// Main article component.
+//
+
+export const GranolaArticle = ({ role, subject: account }: GranolaArticleProps) => {
+  const db = Obj.getDatabase(account);
+  const syncRecords: Granola.GranolaSyncRecord[] = useQuery(db, Filter.type(Granola.GranolaSyncRecord));
+  const trelloCards: Trello.TrelloCard[] = useQuery(db, Filter.type(Trello.TrelloCard));
+  const [syncing, setSyncing] = useState(false);
+  const [matching, setMatching] = useState(false);
+  const [matches, setMatches] = useState<MatchResult[]>([]);
+  const [noteViewport, setNoteViewport] = useState<HTMLElement | null>(null);
+  const { invokePromise } = useOperationInvoker();
+
+  const handleOpenDocument = useCallback((record: Granola.GranolaSyncRecord) => {
+    const doc = record.document?.target;
+    if (!doc) {
+      return;
+    }
+    const docPath = getObjectPathFromObject(doc);
+    void invokePromise(LayoutOperation.Open, { subject: [docPath] });
+  }, [invokePromise]);
+
+  const handleMatchToTrello = useCallback(async () => {
+    setMatching(true);
+    try {
+      const uniqueByGranola = [...new Map(syncRecords.map((record) => [record.granolaId, record])).values()];
+      const activeCards = trelloCards.filter((card) => !card.closed);
+      const results = await aiMatch(uniqueByGranola, activeCards);
+      setMatches(results);
+    } catch (error) {
+      log.catch(error);
+    } finally {
+      setMatching(false);
+    }
+  }, [syncRecords, trelloCards]);
+
+  const handleSaveMatchReport = useCallback(() => {
+    if (!db || matches.length === 0) {
+      return;
+    }
+
+    const lines = [
+      '# Granola → Trello Match Report',
+      '',
+      `Generated: ${new Date().toLocaleString()}`,
+      `Matches found: ${matches.length}`,
+      '',
+    ];
+
+    for (const match of matches) {
+      lines.push(`## "${match.noteTitle}" → "${match.cardName}"`);
+      lines.push(`- **Confidence:** ${match.confidence}`);
+      lines.push(`- **Meeting:** ${match.meetingTitle || 'N/A'}`);
+      lines.push(`- **Card list:** ${match.cardListName}`);
+      lines.push(`- **Reasoning:** ${match.reasoning}`);
+      lines.push('');
+    }
+
+    const doc = Markdown.make({ name: `Match Report ${new Date().toLocaleString()}`, content: lines.join('\n') });
+    db.add(doc);
+
+    setTimeout(() => {
+      try {
+        const docPath = getObjectPathFromObject(doc);
+        void invokePromise(LayoutOperation.Open, { subject: [docPath] });
+      } catch (error) {
+        log.catch(error);
+      }
+    }, 500);
+  }, [db, matches, invokePromise]);
+
+  const handleSync = useCallback(async () => {
+    if (!db || !account.apiKey) {
+      return;
+    }
+
+    setSyncing(true);
+    try {
+      const headers = { Authorization: `Bearer ${account.apiKey}` };
+      const existingByGranolaId = new Map(syncRecords.map((record) => [record.granolaId, record]));
+
+      let cursor: string | undefined;
+      let hasMore = true;
+      const remoteNotes: any[] = [];
+
+      while (hasMore) {
+        const params = new URLSearchParams({ page_size: '30' });
+        if (cursor) {
+          params.set('cursor', cursor);
+        }
+        const response = await fetch(`${GRANOLA_API_BASE}/notes?${params}`, { headers });
+        if (!response.ok) {
+          throw new Error(`Granola API: ${response.status}`);
+        }
+        const data = await response.json();
+        remoteNotes.push(...data.notes);
+        hasMore = data.hasMore;
+        cursor = data.cursor ?? undefined;
+      }
+
+      for (const summary of remoteNotes) {
+        const detailRes = await fetch(`${GRANOLA_API_BASE}/notes/${summary.id}?include=transcript`, { headers });
+        if (!detailRes.ok) {
+          log.warn('Failed to fetch note detail', { noteId: summary.id, status: detailRes.status });
+          continue;
+        }
+
+        const detail = await detailRes.json();
+        const content = buildDocumentContent(detail);
+        const title = detail.title ?? 'Untitled Meeting';
+
+        const attendees = detail.attendees?.map((attendee: any) => ({
+          name: attendee.name,
+          email: attendee.email,
+        }));
+
+        const calendarEvent = detail.calendar_event
+          ? {
+              title: detail.calendar_event.title,
+              eventId: detail.calendar_event.event_id,
+              organizerEmail: detail.calendar_event.organizer_email,
+              startTime: detail.calendar_event.start_time,
+              endTime: detail.calendar_event.end_time,
+            }
+          : undefined;
+
+        const existing = existingByGranolaId.get(summary.id);
+        if (existing) {
+          const doc = existing.document?.target;
+          if (doc) {
+            Obj.change(doc, (mutable) => { mutable.name = title; });
+            const textObj = doc.content?.target;
+            if (textObj) {
+              Obj.change(textObj, (mutable) => { mutable.content = content; });
+            }
+          }
+          Obj.change(existing, (mutable) => {
+            mutable.attendees = attendees;
+            mutable.calendarEvent = calendarEvent;
+            mutable.ownerName = detail.owner?.name;
+            mutable.ownerEmail = detail.owner?.email;
+            mutable.updatedAt = detail.updated_at;
+          });
+        } else {
+          const doc = Markdown.make({ name: title, content });
+          db.add(doc);
+          const syncRecord = Obj.make(Granola.GranolaSyncRecord, {
+            granolaId: summary.id,
+            document: Ref.make(doc),
+            attendees,
+            calendarEvent,
+            ownerName: detail.owner?.name,
+            ownerEmail: detail.owner?.email,
+            createdAt: detail.created_at,
+            updatedAt: detail.updated_at,
+          });
+          db.add(syncRecord);
+        }
+      }
+
+      Obj.change(account, (mutable) => {
+        mutable.lastSyncedAt = new Date().toISOString();
+      });
+    } catch (error) {
+      log.catch(error);
+    } finally {
+      setSyncing(false);
+    }
+  }, [db, account, syncRecords]);
+
+  const didAutoSync = useRef(false);
+  useEffect(() => {
+    if (!didAutoSync.current && account.apiKey && !account.lastSyncedAt) {
+      didAutoSync.current = true;
+      void handleSync();
+    }
+  }, [account.apiKey, account.lastSyncedAt, handleSync]);
+
+  const uniqueRecords = [...new Map(syncRecords.map((record) => [record.granolaId, record])).values()];
+  const sortedRecords = [...uniqueRecords].sort((recordA, recordB) => {
+    const dateA = recordA.createdAt ? new Date(recordA.createdAt).getTime() : 0;
+    const dateB = recordB.createdAt ? new Date(recordB.createdAt).getTime() : 0;
+    return dateB - dateA;
+  });
+
+  const noteItems = useMemo(
+    () => sortedRecords.map((record) => ({ record, onOpen: handleOpenDocument })),
+    [sortedRecords, handleOpenDocument],
+  );
+
+  const matchItems = useMemo(
+    () => matches.map((match, index) => ({ match, index })),
+    [matches],
+  );
+
+  return (
+    <Panel.Root role={role}>
+      <Panel.Toolbar asChild>
+        <Toolbar.Root>
+          <Toolbar.Text>{account.name ?? 'Granola Notes'}</Toolbar.Text>
+          <Toolbar.Separator />
+          <Toolbar.IconButton
+            label={syncing ? 'Syncing...' : 'Sync notes'}
+            icon='ph--arrows-clockwise--regular'
+            iconOnly
+            disabled={syncing || !account.apiKey}
+            onClick={handleSync}
+          />
+          {trelloCards.length > 0 && (
+            <Toolbar.IconButton
+              label={matching ? 'Matching...' : 'Match to Trello'}
+              icon='ph--magnifying-glass--regular'
+              iconOnly
+              disabled={matching || syncRecords.length === 0}
+              onClick={handleMatchToTrello}
+            />
+          )}
+          {matches.length > 0 && (
+            <Toolbar.IconButton
+              label='Save match report'
+              icon='ph--file-text--regular'
+              iconOnly
+              onClick={handleSaveMatchReport}
+            />
+          )}
+          {account.lastSyncedAt && (
+            <>
+              <Toolbar.Separator />
+              <Toolbar.Text>
+                {new Date(account.lastSyncedAt).toLocaleTimeString()}
+              </Toolbar.Text>
+            </>
+          )}
+        </Toolbar.Root>
+      </Panel.Toolbar>
+      <Panel.Content>
+        {matches.length > 0 && (
+          <div className='p-2'>
+            <Focus.Group asChild>
+              <Mosaic.Container withFocus>
+                <Mosaic.VirtualStack
+                  Tile={MatchTile}
+                  classNames='my-2'
+                  gap={8}
+                  items={matchItems}
+                  draggable={false}
+                  getId={(item) => `match-${item.index}`}
+                  getScrollElement={() => noteViewport}
+                  estimateSize={() => 100}
+                />
+              </Mosaic.Container>
+            </Focus.Group>
+          </div>
+        )}
+        <Focus.Group asChild>
+          <Mosaic.Container asChild withFocus autoScroll={noteViewport}>
+            <ScrollArea.Root orientation='vertical' padding centered>
+              <ScrollArea.Viewport ref={setNoteViewport}>
+                <Mosaic.VirtualStack
+                  Tile={NoteTile}
+                  classNames='my-2'
+                  gap={8}
+                  items={noteItems}
+                  draggable={false}
+                  getId={(item) => item.record.granolaId}
+                  getScrollElement={() => noteViewport}
+                  estimateSize={() => 120}
+                />
+              </ScrollArea.Viewport>
+            </ScrollArea.Root>
+          </Mosaic.Container>
+        </Focus.Group>
+      </Panel.Content>
+      {!account.apiKey && (
+        <Panel.Statusbar>
+          <p className='flex p-1 items-center text-warning-text'>Configure API key in account properties to enable sync.</p>
+        </Panel.Statusbar>
+      )}
+    </Panel.Root>
+  );
+};

--- a/packages/plugins/plugin-granola/src/containers/GranolaArticle/GranolaArticle.tsx
+++ b/packages/plugins/plugin-granola/src/containers/GranolaArticle/GranolaArticle.tsx
@@ -2,6 +2,7 @@
 // Copyright 2025 DXOS.org
 //
 
+import * as Schema from 'effect/Schema';
 import React, { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
@@ -15,6 +16,18 @@ import { Card, Icon, Panel, ScrollArea, Toolbar } from '@dxos/react-ui';
 import { Focus, Mosaic, type MosaicTileProps, useMosaicContainer } from '@dxos/react-ui-mosaic';
 
 import { Granola } from '#types';
+
+/** Shape the model is asked to return. Used to validate AI output at the boundary. */
+const MatchResultSchema = Schema.Struct({
+  noteTitle: Schema.String,
+  meetingTitle: Schema.String,
+  cardName: Schema.String,
+  cardListName: Schema.String,
+  confidence: Schema.String,
+  reasoning: Schema.String,
+});
+const MatchResultArraySchema = Schema.Array(MatchResultSchema);
+const decodeMatches = Schema.decodeUnknownSync(MatchResultArraySchema);
 
 export type GranolaArticleProps = {
   role: string;
@@ -74,14 +87,7 @@ const buildDocumentContent = (detail: any): string => {
 // AI matching.
 //
 
-type MatchResult = {
-  noteTitle: string;
-  meetingTitle: string;
-  cardName: string;
-  cardListName: string;
-  confidence: string;
-  reasoning: string;
-};
+type MatchResult = Schema.Schema.Type<typeof MatchResultSchema>;
 
 /** Use Claude to find matches between Granola notes and Trello cards. */
 const aiMatch = async (
@@ -156,7 +162,15 @@ Only include matches where there is a real connection. If a note has no matching
   const result = await response.json();
   const text = result.content?.[0]?.text ?? '[]';
   const jsonText = text.replace(/^```json?\n?/, '').replace(/\n?```$/, '').trim();
-  return JSON.parse(jsonText) as MatchResult[];
+  // Decode through a schema so malformed or partial model output fails
+  // predictably (with a useful error) instead of sneaking past as `any`.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (err) {
+    throw new Error(`AI match: model returned non-JSON output (${err instanceof Error ? err.message : 'parse error'})`);
+  }
+  return [...decodeMatches(parsed)];
 };
 
 //
@@ -273,8 +287,18 @@ MatchTile.displayName = 'MatchTile';
 
 export const GranolaArticle = ({ role, subject: account }: GranolaArticleProps) => {
   const db = Obj.getDatabase(account);
-  const syncRecords: Granola.GranolaSyncRecord[] = useQuery(db, Filter.type(Granola.GranolaSyncRecord));
+  const allSyncRecords: Granola.GranolaSyncRecord[] = useQuery(db, Filter.type(Granola.GranolaSyncRecord));
   const trelloCards: Trello.TrelloCard[] = useQuery(db, Filter.type(Trello.TrelloCard));
+  // Scope sync records to this account so multi-account spaces don't surface,
+  // match, or mutate records belonging to a different account. Records
+  // without an `account` ref are legacy (pre-ref) and always included.
+  const syncRecords = useMemo(
+    () =>
+      allSyncRecords.filter(
+        (record) => !record.account?.target || record.account.target.id === account.id,
+      ),
+    [allSyncRecords, account.id],
+  );
   const [syncing, setSyncing] = useState(false);
   const [matching, setMatching] = useState(false);
   const [matches, setMatches] = useState<MatchResult[]>([]);
@@ -366,8 +390,8 @@ export const GranolaArticle = ({ role, subject: account }: GranolaArticleProps) 
         remoteNotes.push(...data.notes);
         hasMore = data.hasMore;
         if (hasMore && !data.cursor) {
-          log.warn("granola: pagination stuck — hasMore=true but no cursor");
-          break;
+          // Fail fast rather than loop forever on the same cursor.
+          throw new Error('Granola API: hasMore=true but no cursor was returned; aborting sync');
         }
         cursor = data.cursor ?? undefined;
       }
@@ -409,6 +433,11 @@ export const GranolaArticle = ({ role, subject: account }: GranolaArticleProps) 
             }
           }
           Obj.change(existing, (mutable) => {
+            // Back-fill the account ref on legacy records so they're scoped
+            // correctly from now on.
+            if (!mutable.account) {
+              mutable.account = Ref.make(account);
+            }
             mutable.attendees = attendees;
             mutable.calendarEvent = calendarEvent;
             mutable.ownerName = detail.owner?.name;
@@ -418,9 +447,12 @@ export const GranolaArticle = ({ role, subject: account }: GranolaArticleProps) 
         } else {
           const doc = Markdown.make({ name: title, content });
           db.add(doc);
-          const syncRecord = Obj.make(Granola.GranolaSyncRecord, {
+          // Use the factory so the Granola ID lands in Obj.Meta.keys, not as
+          // a schema field (the older inline Obj.make form dropped the id).
+          const syncRecord = Granola.makeSyncRecord({
             granolaId: summary.id,
             document: Ref.make(doc),
+            account: Ref.make(account),
             attendees,
             calendarEvent,
             ownerName: detail.owner?.name,

--- a/packages/plugins/plugin-granola/src/containers/GranolaArticle/index.ts
+++ b/packages/plugins/plugin-granola/src/containers/GranolaArticle/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+export { GranolaArticle as default } from './GranolaArticle';

--- a/packages/plugins/plugin-granola/src/containers/index.ts
+++ b/packages/plugins/plugin-granola/src/containers/index.ts
@@ -1,0 +1,7 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { type ComponentType, lazy } from 'react';
+
+export const GranolaArticle: ComponentType<any> = lazy(() => import('./GranolaArticle'));

--- a/packages/plugins/plugin-granola/src/index.ts
+++ b/packages/plugins/plugin-granola/src/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+export { meta } from './meta';
+export { GranolaPlugin } from './GranolaPlugin';

--- a/packages/plugins/plugin-granola/src/meta.ts
+++ b/packages/plugins/plugin-granola/src/meta.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+
+export const meta: Plugin.Meta = {
+  id: 'org.dxos.plugin.granola',
+  name: 'Granola',
+  description: 'Syncs meeting notes from Granola into Composer.',
+  icon: 'ph--notebook--regular',
+  iconHue: 'purple',
+};

--- a/packages/plugins/plugin-granola/src/translations.ts
+++ b/packages/plugins/plugin-granola/src/translations.ts
@@ -1,0 +1,22 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Granola } from '#types';
+
+export const translations = [
+  {
+    'en-US': {
+      [Granola.GranolaAccount.typename]: {
+        'typename.label_one': 'Granola Account',
+        'typename.label_other': 'Granola Accounts',
+        'object-name.placeholder': 'Granola Account',
+      },
+      [Granola.GranolaSyncRecord.typename]: {
+        'typename.label_one': 'Granola Sync Record',
+        'typename.label_other': 'Granola Sync Records',
+        'object-name.placeholder': 'Granola Sync Record',
+      },
+    },
+  },
+];

--- a/packages/plugins/plugin-granola/src/types/Granola.ts
+++ b/packages/plugins/plugin-granola/src/types/Granola.ts
@@ -37,6 +37,8 @@ export type CalendarEvent = Schema.Schema.Type<typeof CalendarEvent>;
  * (`{ source: 'granola.ai', id: <granolaId> }`).
  */
 export const GranolaSyncRecord = Schema.Struct({
+  /** The Granola account that owns this record. Populated by sync; scopes the record to one account in multi-account spaces. */
+  account: Schema.optional(Ref.Ref(Schema.suspend(() => GranolaAccount)).pipe(FormInputAnnotation.set(false))),
   /** Reference to the synced Composer Document. */
   document: Ref.Ref(Markdown.Document).pipe(FormInputAnnotation.set(false)),
   /** Meeting attendees. */
@@ -121,6 +123,7 @@ export const makeAccount = (props?: { name?: string }): GranolaAccount => {
 export const makeSyncRecord = (props: {
   granolaId: string;
   document: Ref.Ref<Markdown.Document>;
+  account?: Ref.Ref<GranolaAccount>;
   attendees?: Attendee[];
   calendarEvent?: CalendarEvent;
   ownerName?: string;
@@ -143,6 +146,5 @@ const GRANOLA_SOURCE = 'granola.ai';
 
 /** Extract the Granola ID from an object's foreignKeys. */
 export const getGranolaId = (obj: Obj.Any): string | undefined => {
-  const meta = Obj.getMeta(obj);
-  return meta.keys?.find((key: { source: string; id: string }) => key.source === GRANOLA_SOURCE)?.id;
+  return Obj.getKeys(obj, GRANOLA_SOURCE)[0]?.id;
 };

--- a/packages/plugins/plugin-granola/src/types/Granola.ts
+++ b/packages/plugins/plugin-granola/src/types/Granola.ts
@@ -126,6 +126,7 @@ export const makeSyncRecord = (props: {
   ownerName?: string;
   ownerEmail?: string;
   createdAt?: string;
+  updatedAt?: string;
 }): GranolaSyncRecord => {
   const { granolaId, ...rest } = props;
   return Obj.make(GranolaSyncRecord, {

--- a/packages/plugins/plugin-granola/src/types/Granola.ts
+++ b/packages/plugins/plugin-granola/src/types/Granola.ts
@@ -1,0 +1,110 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import * as Schema from 'effect/Schema';
+
+import { Annotation, Obj, Ref, Type } from '@dxos/echo';
+import { FormInputAnnotation, LabelAnnotation } from '@dxos/echo/internal';
+import { Markdown } from '@dxos/plugin-markdown/types';
+
+// @import-as-namespace
+
+/** Attendee of a Granola meeting. */
+export const Attendee = Schema.Struct({
+  name: Schema.optional(Schema.String),
+  email: Schema.optional(Schema.String),
+});
+
+export type Attendee = Schema.Schema.Type<typeof Attendee>;
+
+/** Calendar event metadata. */
+export const CalendarEvent = Schema.Struct({
+  title: Schema.optional(Schema.String),
+  eventId: Schema.optional(Schema.String),
+  organizerEmail: Schema.optional(Schema.String),
+  startTime: Schema.optional(Schema.String),
+  endTime: Schema.optional(Schema.String),
+});
+
+export type CalendarEvent = Schema.Schema.Type<typeof CalendarEvent>;
+
+/**
+ * Lightweight sync record that links a Granola note ID to a Composer Document.
+ * Stores meeting metadata that doesn't map to the Document type.
+ */
+export const GranolaSyncRecord = Schema.Struct({
+  /** Granola note ID for sync. */
+  granolaId: Schema.String.pipe(FormInputAnnotation.set(false)),
+  /** Reference to the synced Composer Document. */
+  document: Ref.Ref(Markdown.Document).pipe(FormInputAnnotation.set(false)),
+  /** Meeting attendees. */
+  attendees: Schema.optional(Schema.Array(Attendee).pipe(FormInputAnnotation.set(false))),
+  /** Calendar event metadata. */
+  calendarEvent: Schema.optional(CalendarEvent.pipe(FormInputAnnotation.set(false))),
+  /** Owner name from Granola. */
+  ownerName: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+  /** Owner email from Granola. */
+  ownerEmail: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+  /** Note creation timestamp from Granola. */
+  createdAt: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+  /** Note last updated timestamp from Granola. */
+  updatedAt: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+}).pipe(
+  Type.object({
+    typename: 'org.dxos.type.granolaSyncRecord',
+    version: '0.1.0',
+  }),
+  LabelAnnotation.set(['granolaId']),
+  Annotation.IconAnnotation.set({
+    icon: 'ph--notebook--regular',
+    hue: 'purple',
+  }),
+);
+
+export interface GranolaSyncRecord extends Schema.Schema.Type<typeof GranolaSyncRecord> {}
+
+/**
+ * GranolaAccount schema for API credentials and sync state.
+ */
+export const GranolaAccount = Schema.Struct({
+  /** Display name. */
+  name: Schema.optional(Schema.String),
+  /** Granola API key. */
+  apiKey: Schema.String.pipe(FormInputAnnotation.set(false)),
+  /** Last sync timestamp. */
+  lastSyncedAt: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+  /** Polling interval in milliseconds. */
+  pollIntervalMs: Schema.optional(Schema.Number),
+}).pipe(
+  Type.object({
+    typename: 'org.dxos.type.granolaAccount',
+    version: '0.1.0',
+  }),
+  LabelAnnotation.set(['name']),
+  Annotation.IconAnnotation.set({
+    icon: 'ph--notebook--regular',
+    hue: 'purple',
+  }),
+);
+
+export interface GranolaAccount extends Schema.Schema.Type<typeof GranolaAccount> {}
+
+/** Input schema for creating a GranolaAccount. */
+export const CreateGranolaAccountSchema = Schema.Struct({
+  apiKey: Schema.String.annotations({
+    title: 'API Key',
+    description: 'Granola API key (from Settings > API in the Granola app).',
+  }),
+});
+
+export interface CreateGranolaAccountSchema extends Schema.Schema.Type<typeof CreateGranolaAccountSchema> {}
+
+/** Creates a GranolaAccount object. */
+export const makeAccount = (props: CreateGranolaAccountSchema): GranolaAccount => {
+  return Obj.make(GranolaAccount, {
+    name: 'Granola Notes',
+    apiKey: props.apiKey,
+    pollIntervalMs: 60_000,
+  });
+};

--- a/packages/plugins/plugin-granola/src/types/Granola.ts
+++ b/packages/plugins/plugin-granola/src/types/Granola.ts
@@ -7,6 +7,7 @@ import * as Schema from 'effect/Schema';
 import { Annotation, Obj, Ref, Type } from '@dxos/echo';
 import { FormInputAnnotation, LabelAnnotation } from '@dxos/echo/internal';
 import { Markdown } from '@dxos/plugin-markdown/types';
+import { AccessToken } from '@dxos/types';
 
 // @import-as-namespace
 
@@ -30,12 +31,12 @@ export const CalendarEvent = Schema.Struct({
 export type CalendarEvent = Schema.Schema.Type<typeof CalendarEvent>;
 
 /**
- * Lightweight sync record that links a Granola note ID to a Composer Document.
- * Stores meeting metadata that doesn't map to the Document type.
+ * Lightweight sync record that links a Granola note to a Composer Document.
+ *
+ * External identity tracked via `Obj.Meta` foreignKeys
+ * (`{ source: 'granola.ai', id: <granolaId> }`).
  */
 export const GranolaSyncRecord = Schema.Struct({
-  /** Granola note ID for sync. */
-  granolaId: Schema.String.pipe(FormInputAnnotation.set(false)),
   /** Reference to the synced Composer Document. */
   document: Ref.Ref(Markdown.Document).pipe(FormInputAnnotation.set(false)),
   /** Meeting attendees. */
@@ -53,9 +54,9 @@ export const GranolaSyncRecord = Schema.Struct({
 }).pipe(
   Type.object({
     typename: 'org.dxos.type.granolaSyncRecord',
-    version: '0.1.0',
+    version: '0.2.0',
   }),
-  LabelAnnotation.set(['granolaId']),
+  LabelAnnotation.set(['ownerName']),
   Annotation.IconAnnotation.set({
     icon: 'ph--notebook--regular',
     hue: 'purple',
@@ -65,13 +66,19 @@ export const GranolaSyncRecord = Schema.Struct({
 export interface GranolaSyncRecord extends Schema.Schema.Type<typeof GranolaSyncRecord> {}
 
 /**
- * GranolaAccount schema for API credentials and sync state.
+ * GranolaAccount for sync configuration.
+ * Credentials stored as an `AccessToken` reference, not inline.
  */
 export const GranolaAccount = Schema.Struct({
   /** Display name. */
   name: Schema.optional(Schema.String),
-  /** Granola API key. */
-  apiKey: Schema.String.pipe(FormInputAnnotation.set(false)),
+  /** Granola API credentials. */
+  accessToken: Schema.optional(
+    Ref.Ref(AccessToken.AccessToken).annotations({
+      title: 'Granola credentials',
+      description: 'API key for syncing meeting notes.',
+    }),
+  ),
   /** Last sync timestamp. */
   lastSyncedAt: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
   /** Polling interval in milliseconds. */
@@ -79,7 +86,7 @@ export const GranolaAccount = Schema.Struct({
 }).pipe(
   Type.object({
     typename: 'org.dxos.type.granolaAccount',
-    version: '0.1.0',
+    version: '0.2.0',
   }),
   LabelAnnotation.set(['name']),
   Annotation.IconAnnotation.set({
@@ -90,21 +97,51 @@ export const GranolaAccount = Schema.Struct({
 
 export interface GranolaAccount extends Schema.Schema.Type<typeof GranolaAccount> {}
 
-/** Input schema for creating a GranolaAccount. */
+/** Input schema for creating a GranolaAccount via the Create menu. */
 export const CreateGranolaAccountSchema = Schema.Struct({
-  apiKey: Schema.String.annotations({
-    title: 'API Key',
-    description: 'Granola API key (from Settings > API in the Granola app).',
-  }),
+  name: Schema.optional(
+    Schema.String.annotations({
+      title: 'Name',
+      description: 'Display name for this Granola account.',
+    }),
+  ),
 });
 
 export interface CreateGranolaAccountSchema extends Schema.Schema.Type<typeof CreateGranolaAccountSchema> {}
 
 /** Creates a GranolaAccount object. */
-export const makeAccount = (props: CreateGranolaAccountSchema): GranolaAccount => {
+export const makeAccount = (props?: { name?: string }): GranolaAccount => {
   return Obj.make(GranolaAccount, {
-    name: 'Granola Notes',
-    apiKey: props.apiKey,
+    name: props?.name ?? 'Granola Notes',
     pollIntervalMs: 60_000,
   });
+};
+
+/** Creates a GranolaSyncRecord with foreignKey for the Granola note ID. */
+export const makeSyncRecord = (props: {
+  granolaId: string;
+  document: Ref.Ref<Markdown.Document>;
+  attendees?: Attendee[];
+  calendarEvent?: CalendarEvent;
+  ownerName?: string;
+  ownerEmail?: string;
+  createdAt?: string;
+}): GranolaSyncRecord => {
+  const { granolaId, ...rest } = props;
+  return Obj.make(GranolaSyncRecord, {
+    [Obj.Meta]: {
+      keys: [{ id: granolaId, source: 'granola.ai' }],
+    },
+    ...rest,
+  });
+};
+
+// ── Foreign key helpers ─────────────────────────────────────────────────────
+
+const GRANOLA_SOURCE = 'granola.ai';
+
+/** Extract the Granola ID from an object's foreignKeys. */
+export const getGranolaId = (obj: Obj.Any): string | undefined => {
+  const meta = Obj.getMeta(obj);
+  return meta.keys?.find((key: { source: string; id: string }) => key.source === GRANOLA_SOURCE)?.id;
 };

--- a/packages/plugins/plugin-granola/src/types/Granola.ts
+++ b/packages/plugins/plugin-granola/src/types/Granola.ts
@@ -83,8 +83,8 @@ export const GranolaAccount = Schema.Struct({
   ),
   /** Last sync timestamp. */
   lastSyncedAt: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
-  /** Polling interval in milliseconds. */
-  pollIntervalMs: Schema.optional(Schema.Number),
+  /** Polling interval in milliseconds. Positive integer. */
+  pollIntervalMs: Schema.optional(Schema.Number.pipe(Schema.greaterThan(0))),
 }).pipe(
   Type.object({
     typename: 'org.dxos.type.granolaAccount',

--- a/packages/plugins/plugin-granola/src/types/index.ts
+++ b/packages/plugins/plugin-granola/src/types/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+export * as Granola from './Granola';

--- a/packages/plugins/plugin-granola/tsconfig.json
+++ b/packages/plugins/plugin-granola/tsconfig.json
@@ -1,0 +1,81 @@
+{
+  "extends": [
+    "../../../tsconfig.base.json"
+  ],
+  "compilerOptions": {
+    "types": [
+      "node"
+    ]
+  },
+  "exclude": [
+    "*.t.ts",
+    "vite.config.ts"
+  ],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../../common/async"
+    },
+    {
+      "path": "../../common/invariant"
+    },
+    {
+      "path": "../../common/log"
+    },
+    {
+      "path": "../../common/storybook-utils"
+    },
+    {
+      "path": "../../common/util"
+    },
+    {
+      "path": "../../core/echo/echo"
+    },
+    {
+      "path": "../../core/echo/echo-db"
+    },
+    {
+      "path": "../../core/operation"
+    },
+    {
+      "path": "../../sdk/app-framework"
+    },
+    {
+      "path": "../../sdk/app-toolkit"
+    },
+    {
+      "path": "../../sdk/react-client"
+    },
+    {
+      "path": "../../sdk/schema"
+    },
+    {
+      "path": "../../ui/react-ui"
+    },
+    {
+      "path": "../../ui/react-ui-mosaic"
+    },
+    {
+      "path": "../../ui/ui-theme"
+    },
+    {
+      "path": "../plugin-graph"
+    },
+    {
+      "path": "../plugin-markdown"
+    },
+    {
+      "path": "../plugin-space"
+    },
+    {
+      "path": "../plugin-theme"
+    },
+    {
+      "path": "../plugin-trello"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New plugin for syncing Granola meeting notes into Composer.

- **GranolaSyncRecord** — links a Granola note to a Composer Document via foreignKey (`source: 'granola.ai'`)
- **GranolaAccount** — credentials via `AccessToken` ref (not inline API key)
- Meeting metadata: attendees, calendar event, owner
- Container with sync UI and note browser
- TODO: move sync logic to operation handler, replace custom DOM with Composer UI

## Test plan
- [x] Build passes
- [x] Verified in live Composer session with real Granola API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces the Granola plugin to sync meeting notes into Composer with automatic initial sync and configurable polling.
  * Adds a dedicated Granola article view with a virtualized list, toolbar controls, and document-opening flows.
  * AI-powered matching between Granola notes and Trello cards, plus generation/saving of match reports.
* **Localization**
  * Adds English locale labels and placeholders for Granola entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->