### PR TITLE
feat(plugin-slack): Slack bot integration with ECHO context

### DIFF
--- a/packages/plugins/plugin-slack/moon.yml
+++ b/packages/plugins/plugin-slack/moon.yml
@@ -1,0 +1,11 @@
+layer: library
+language: typescript
+tags:
+  - ts-build
+  - pack
+tasks:
+  compile:
+    args:
+      - '--entryPoint=src/index.ts'
+      - '--entryPoint=src/meta.ts'
+      - '--platform=browser'

--- a/packages/plugins/plugin-slack/package.json
+++ b/packages/plugins/plugin-slack/package.json
@@ -1,0 +1,87 @@
+{
+  "name": "@dxos/plugin-slack",
+  "version": "0.8.3",
+  "private": true,
+  "description": "Slack channel integration for Composer Agent.",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dxos/dxos"
+  },
+  "license": "MIT",
+  "author": "DXOS.org",
+  "sideEffects": true,
+  "type": "module",
+  "imports": {
+    "#capabilities": "./src/capabilities/index.ts",
+    "#components": "./src/components/index.ts",
+    "#containers": "./src/containers/index.ts",
+    "#hooks": "./src/hooks/index.ts",
+    "#meta": "./src/meta.ts",
+    "#types": "./src/types/index.ts"
+  },
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/types/src/index.d.ts",
+      "browser": "./dist/lib/browser/index.mjs"
+    },
+    "./meta": {
+      "source": "./src/meta.ts",
+      "types": "./dist/types/src/meta.d.ts",
+      "browser": "./dist/lib/browser/meta.mjs"
+    }
+  },
+  "types": "dist/types/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "meta": [
+        "dist/types/src/meta.d.ts"
+      ]
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@dxos/app-framework": "workspace:*",
+    "@dxos/app-graph": "workspace:*",
+    "@dxos/app-toolkit": "workspace:*",
+    "@dxos/blueprints": "workspace:*",
+    "@dxos/echo": "workspace:*",
+    "@dxos/echo-atom": "workspace:*",
+    "@dxos/effect": "workspace:*",
+    "@dxos/invariant": "workspace:*",
+    "@dxos/keys": "workspace:*",
+    "@dxos/log": "workspace:*",
+    "@dxos/operation": "workspace:*",
+    "@dxos/plugin-assistant": "workspace:*",
+    "@dxos/plugin-graph": "workspace:*",
+    "@dxos/react-client": "workspace:*",
+    "@dxos/types": "workspace:*",
+    "@dxos/util": "workspace:*",
+    "@effect-atom/atom": "catalog:"
+  },
+  "devDependencies": {
+    "@dxos/react-ui": "workspace:*",
+    "@dxos/react-ui-components": "workspace:*",
+    "@dxos/ui-theme": "workspace:*",
+    "@effect-atom/atom-react": "catalog:",
+    "@types/react": "catalog:",
+    "effect": "catalog:",
+    "react": "catalog:"
+  },
+  "peerDependencies": {
+    "@dxos/react-ui": "workspace:*",
+    "@dxos/react-ui-components": "workspace:*",
+    "@dxos/ui-theme": "workspace:*",
+    "@effect-atom/atom-react": "catalog:",
+    "effect": "catalog:",
+    "react": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugins/plugin-slack/src/SlackPlugin.tsx
+++ b/packages/plugins/plugin-slack/src/SlackPlugin.tsx
@@ -1,0 +1,23 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppActivationEvents, AppPlugin } from '@dxos/app-toolkit';
+
+import { AppGraphBuilder, BlueprintDefinition, ReactSurface, Settings } from '#capabilities';
+import { meta } from '#meta';
+import { translations } from './translations';
+
+export const SlackPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addAppGraphModule({ activate: AppGraphBuilder }),
+  AppPlugin.addBlueprintDefinitionModule({ activate: BlueprintDefinition }),
+  AppPlugin.addSurfaceModule({ activate: ReactSurface }),
+  AppPlugin.addTranslationsModule({ translations }),
+  Plugin.addModule({
+    id: 'settings',
+    activatesOn: AppActivationEvents.SetupSettings,
+    activate: Settings,
+  }),
+  Plugin.make,
+);

--- a/packages/plugins/plugin-slack/src/blueprints/email-triage.ts
+++ b/packages/plugins/plugin-slack/src/blueprints/email-triage.ts
@@ -1,0 +1,73 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import { Blueprint, Template } from '@dxos/blueprints';
+import { trim } from '@dxos/util';
+
+export const EMAIL_TRIAGE_KEY = 'org.dxos.blueprint.email-triage';
+
+const INBOX_TOOLS = [
+  'org.dxos.plugin.inbox.operation.read-email',
+  'org.dxos.plugin.inbox.operation.classify-email',
+  'org.dxos.plugin.inbox.operation.draft-email',
+  'org.dxos.plugin.inbox.operation.summarize-mailbox',
+  'org.dxos.plugin.inbox.operation.google-mail-sync',
+];
+
+const make = () =>
+  Blueprint.make({
+    key: EMAIL_TRIAGE_KEY,
+    name: 'Email Triage',
+    agentCanEnable: true,
+    tools: Blueprint.toolDefinitions({
+      operations: [],
+      tools: INBOX_TOOLS,
+    }),
+    instructions: Template.make({
+      source: trim`
+        {{! Email Triage }}
+
+        You are an email triage assistant. You have tools to read and classify emails.
+
+        # Process
+
+        1. Sync the mailbox to get latest emails (use google-mail-sync).
+        2. Read the emails (use read-email).
+        3. For each email, classify it by urgency (use classify-email).
+        4. For urgent emails, draft responses (use draft-email).
+        5. Present the triaged results.
+
+        # Classification Categories
+
+        - **Urgent**: Requires response within the hour. Escalate immediately.
+        - **Action Required**: Needs a response or action today.
+        - **FYI**: Important to know but no action needed.
+        - **Low Priority**: Can wait. Newsletter, promotional, automated notifications.
+
+        # Output Format
+
+        ## Urgent
+        - **Subject** from Sender — Key issue. [Draft response ready]
+
+        ## Action Required
+        - **Subject** from Sender — What's needed by when.
+
+        ## FYI
+        - **Subject** from Sender — One-line summary.
+
+        ## Action Items
+        - [ ] Respond to X about Y (deadline: Z)
+        - [ ] Review attachment from A
+        Format as markdown checkboxes.
+      `,
+    }),
+  });
+
+const blueprint: AppCapabilities.BlueprintDefinition = {
+  key: EMAIL_TRIAGE_KEY,
+  make,
+};
+
+export default blueprint;

--- a/packages/plugins/plugin-slack/src/blueprints/index.ts
+++ b/packages/plugins/plugin-slack/src/blueprints/index.ts
@@ -1,0 +1,9 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export { default as morningBriefing } from './morning-briefing';
+export { default as emailTriage } from './email-triage';
+export { default as meetingPrep } from './meeting-prep';
+export { default as slackResponder } from './slack-responder';
+export { default as researchDigest } from './research-digest';

--- a/packages/plugins/plugin-slack/src/blueprints/meeting-prep.ts
+++ b/packages/plugins/plugin-slack/src/blueprints/meeting-prep.ts
@@ -1,0 +1,74 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import { Blueprint, Template } from '@dxos/blueprints';
+import { trim } from '@dxos/util';
+
+export const MEETING_PREP_KEY = 'org.dxos.blueprint.meeting-prep';
+
+const INBOX_TOOLS = [
+  'org.dxos.plugin.inbox.operation.read-email',
+  'org.dxos.plugin.inbox.operation.summarize-mailbox',
+  'org.dxos.plugin.inbox.operation.google-calendar-sync',
+];
+
+const make = () =>
+  Blueprint.make({
+    key: MEETING_PREP_KEY,
+    name: 'Meeting Prep',
+    agentCanEnable: true,
+    tools: Blueprint.toolDefinitions({
+      operations: [],
+      tools: INBOX_TOOLS,
+    }),
+    instructions: Template.make({
+      source: trim`
+        {{! Meeting Prep }}
+
+        You are a meeting preparation assistant. You have tools to read emails and check the calendar.
+
+        # Process
+
+        1. Sync the calendar to get the latest events (use google-calendar-sync).
+        2. Identify the next upcoming meeting.
+        3. Read recent emails to find context related to the meeting attendees and topic (use read-email).
+        4. Synthesize a preparation brief.
+
+        # Output Format
+
+        ## Meeting: [Title]
+        **Time:** [start] - [end]
+        **Attendees:** [list with roles if known]
+
+        ## Context
+        Brief summary of what this meeting is about based on gathered information.
+
+        ## Key Points to Raise
+        - Topics from recent email threads that need discussion
+        - Open questions from conversations
+        - Unresolved action items from previous interactions
+
+        ## Attendee Notes
+        For each attendee:
+        - Last interaction (email subject and date)
+        - Any pending items between you and them
+
+        ## Suggested Agenda
+        Based on gathered context, suggest a focused agenda.
+
+        # Rules
+        - If no upcoming meeting is found, say so clearly
+        - Focus on actionable preparation, not summaries of obvious information
+        - Keep it scannable — this is read 5 minutes before the meeting
+      `,
+    }),
+  });
+
+const blueprint: AppCapabilities.BlueprintDefinition = {
+  key: MEETING_PREP_KEY,
+  make,
+};
+
+export default blueprint;

--- a/packages/plugins/plugin-slack/src/blueprints/morning-briefing.ts
+++ b/packages/plugins/plugin-slack/src/blueprints/morning-briefing.ts
@@ -1,0 +1,82 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import { Blueprint, Template } from '@dxos/blueprints';
+import { trim } from '@dxos/util';
+
+export const MORNING_BRIEFING_KEY = 'org.dxos.blueprint.morning-briefing';
+
+// Tool keys from plugin-inbox operations (referenced by key to avoid Vite import resolution issues).
+const INBOX_TOOLS = [
+  'org.dxos.plugin.inbox.operation.read-email',
+  'org.dxos.plugin.inbox.operation.summarize-mailbox',
+  'org.dxos.plugin.inbox.operation.google-mail-sync',
+  'org.dxos.plugin.inbox.operation.google-calendar-sync',
+];
+
+const make = () =>
+  Blueprint.make({
+    key: MORNING_BRIEFING_KEY,
+    name: 'Morning Briefing',
+    agentCanEnable: true,
+    tools: Blueprint.toolDefinitions({
+      operations: [],
+      tools: INBOX_TOOLS,
+    }),
+    instructions: Template.make({
+      source: trim`
+        {{! Morning Briefing }}
+
+        You are a personal executive assistant generating a morning briefing.
+        You have tools to read emails and sync calendars.
+
+        # Process
+
+        1. First, sync the mailbox to get latest emails (use google-mail-sync).
+        2. Then, sync the calendar to get today's events (use google-calendar-sync).
+        3. Read the latest emails (use read-email).
+        4. Synthesize everything into a structured briefing.
+
+        # Briefing Structure
+
+        ## Today's Schedule
+        List today's calendar events chronologically with:
+        - Time and duration
+        - Event name and key attendees
+        - One-line context (why this meeting matters)
+
+        ## Email Highlights
+        Summarize the most important unread emails:
+        - **Urgent**: Requires response within the hour
+        - **Action Required**: Needs a response or action today
+        - **FYI**: Important to know but no action needed
+        Group by priority, not chronologically.
+
+        ## Action Items
+        A consolidated, prioritized list of everything that needs attention today:
+        - [ ] Action item with source (email/calendar/Slack)
+        Format as markdown checkboxes.
+
+        ## Quick Stats
+        - Unread emails: count
+        - Meetings today: count
+        - Pending action items: count
+
+        # Formatting Rules
+        - Be concise — this is a 2-minute read, not a novel
+        - Lead with what matters most
+        - Include references to source objects where possible
+        - Use markdown formatting
+        - Don't include greetings or sign-offs — get straight to the content
+      `,
+    }),
+  });
+
+const blueprint: AppCapabilities.BlueprintDefinition = {
+  key: MORNING_BRIEFING_KEY,
+  make,
+};
+
+export default blueprint;

--- a/packages/plugins/plugin-slack/src/blueprints/research-digest.ts
+++ b/packages/plugins/plugin-slack/src/blueprints/research-digest.ts
@@ -1,0 +1,66 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import { Blueprint, Template } from '@dxos/blueprints';
+import { trim } from '@dxos/util';
+
+export const RESEARCH_DIGEST_KEY = 'org.dxos.blueprint.research-digest';
+
+const make = () =>
+  Blueprint.make({
+    key: RESEARCH_DIGEST_KEY,
+    name: 'Research Digest',
+    agentCanEnable: true,
+    tools: Blueprint.toolDefinitions({
+      operations: [],
+      tools: [],
+    }),
+    instructions: Template.make({
+      source: trim`
+        {{! Research Digest }}
+
+        You are a research assistant that creates focused digests on specific topics.
+
+        # When asked to research a topic:
+
+        1. Search through available data sources (emails, documents, Slack messages)
+        2. Identify relevant information from the last 7 days
+        3. Synthesize findings into a structured digest
+
+        # Output Format
+
+        ## Research Digest: [Topic]
+        *Generated [date]*
+
+        ### Key Findings
+        Numbered list of the most important discoveries.
+
+        ### Sources
+        Where each finding came from, with references.
+
+        ### Trends
+        Patterns or changes observed over the time period.
+
+        ### Recommendations
+        Actionable suggestions based on the research.
+
+        ### Open Questions
+        Things that need further investigation.
+
+        # Rules
+        - Cite sources for every claim
+        - Distinguish between facts and inferences
+        - Flag any conflicting information
+        - Keep it scannable — busy people read this
+      `,
+    }),
+  });
+
+const blueprint: AppCapabilities.BlueprintDefinition = {
+  key: RESEARCH_DIGEST_KEY,
+  make,
+};
+
+export default blueprint;

--- a/packages/plugins/plugin-slack/src/blueprints/slack-responder.ts
+++ b/packages/plugins/plugin-slack/src/blueprints/slack-responder.ts
@@ -1,0 +1,75 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import { Blueprint, Template } from '@dxos/blueprints';
+import { trim } from '@dxos/util';
+
+export const SLACK_RESPONDER_KEY = 'org.dxos.blueprint.slack-responder';
+
+const make = () =>
+  Blueprint.make({
+    key: SLACK_RESPONDER_KEY,
+    name: 'Slack Responder',
+    agentCanEnable: true,
+    tools: Blueprint.toolDefinitions({
+      operations: [],
+      tools: [
+        // Database tools for querying the user's workspace.
+        'org.dxos.function.database.query',
+        'org.dxos.function.database.load',
+        // Email tools for checking inbox context.
+        'org.dxos.plugin.inbox.operation.read-email',
+        'org.dxos.plugin.inbox.operation.summarize-mailbox',
+      ],
+    }),
+    instructions: Template.make({
+      source: trim`
+        {{! Slack Responder }}
+
+        You are an AI assistant responding to Slack messages.
+
+        # Behavior
+
+        - Be concise and conversational — Slack is not email
+        - Do not use markdown formatting — Slack has its own markup
+        - Use *bold* and _italic_ with Slack's syntax when needed
+        - Keep responses under 3 paragraphs unless the question is complex
+        - If you don't know something, say so clearly
+        - When referencing data from emails or calendar, cite the source
+
+        # Context Awareness
+
+        You have access to the user's:
+        - Email inbox (recent messages and threads)
+        - Calendar (today's schedule and upcoming events)
+        - Documents and notes in the workspace
+
+        Use this context to give informed answers. For example:
+        - "Based on your email thread with Sarah, the deadline is Friday"
+        - "You have a meeting with that team at 2pm today"
+
+        # Escalation
+
+        If a message requires action you can't take:
+        - Clearly state what needs to be done
+        - Suggest the appropriate channel or person
+        - Offer to draft an email or create a task
+
+        # Thread Behavior
+
+        When continuing a thread conversation:
+        - Reference earlier messages naturally
+        - Don't repeat information already established
+        - Build on the conversation context
+      `,
+    }),
+  });
+
+const blueprint: AppCapabilities.BlueprintDefinition = {
+  key: SLACK_RESPONDER_KEY,
+  make,
+};
+
+export default blueprint;

--- a/packages/plugins/plugin-slack/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-slack/src/capabilities/app-graph-builder.ts
@@ -1,0 +1,34 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capability } from '@dxos/app-framework';
+import { AppCapabilities, AppNode } from '@dxos/app-toolkit';
+import { GraphBuilder, NodeMatcher } from '@dxos/plugin-graph';
+
+import { meta } from '#meta';
+
+export default Capability.makeModule(
+  Effect.fnUntraced(function* () {
+    const extensions = yield* Effect.all([
+      GraphBuilder.createExtension({
+        id: `${meta.id}/deck-companion`,
+        match: NodeMatcher.whenRoot,
+        connector: () =>
+          Effect.succeed([
+            AppNode.makeDeckCompanion({
+              id: 'slack',
+              label: ['plugin.name', { ns: meta.id }],
+              icon: meta.icon ?? 'ph--slack-logo--regular',
+              data: 'slack',
+              position: 'fallback',
+            }),
+          ]),
+      }),
+    ]);
+
+    return Capability.contributes(AppCapabilities.AppGraphBuilder, extensions);
+  }),
+);

--- a/packages/plugins/plugin-slack/src/capabilities/blueprint-definition.ts
+++ b/packages/plugins/plugin-slack/src/capabilities/blueprint-definition.ts
@@ -1,0 +1,20 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capability } from '@dxos/app-framework';
+import { AppCapabilities } from '@dxos/app-toolkit';
+
+import { morningBriefing, emailTriage, meetingPrep, slackResponder, researchDigest } from '../blueprints';
+
+export default Capability.makeModule(() =>
+  Effect.succeed([
+    Capability.contributes(AppCapabilities.BlueprintDefinition, morningBriefing),
+    Capability.contributes(AppCapabilities.BlueprintDefinition, emailTriage),
+    Capability.contributes(AppCapabilities.BlueprintDefinition, meetingPrep),
+    Capability.contributes(AppCapabilities.BlueprintDefinition, slackResponder),
+    Capability.contributes(AppCapabilities.BlueprintDefinition, researchDigest),
+  ]),
+);

--- a/packages/plugins/plugin-slack/src/capabilities/index.ts
+++ b/packages/plugins/plugin-slack/src/capabilities/index.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Capability } from '@dxos/app-framework';
+
+export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
+
+export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
+
+export const ReactSurface = Capability.lazy('ReactSurface', () => import('./react-surface'));
+
+export const Settings = Capability.lazy('Settings', () => import('./settings'));

--- a/packages/plugins/plugin-slack/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-slack/src/capabilities/react-surface.tsx
@@ -1,0 +1,54 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import React, { useMemo } from 'react';
+
+import { Capabilities, Capability } from '@dxos/app-framework';
+import { Surface, useCapabilities, useSettingsState } from '@dxos/app-framework/ui';
+import { AppSurface, useActiveSpace } from '@dxos/app-toolkit/ui';
+import { createKvsStore } from '@dxos/effect';
+
+import { SlackFeed, SlackSettings } from '#components';
+import { meta } from '#meta';
+import { SlackCapabilities } from '#types';
+
+const SlackFeedWithSettings = () => {
+  const capabilities = useCapabilities(SlackCapabilities.Settings);
+  const fallbackAtom = useMemo(
+    () => createKvsStore({ key: `${meta.id}.fallback`, schema: SlackCapabilities.SettingsSchema, defaultValue: () => ({}) }),
+    [],
+  );
+  const settingsAtom = capabilities[0] ?? fallbackAtom;
+  const { settings } = useSettingsState<SlackCapabilities.Settings>(settingsAtom);
+  const space = useActiveSpace();
+
+  if (!space) {
+    return null;
+  }
+
+  return <SlackFeed settings={settings} db={space.db} />;
+};
+
+export default Capability.makeModule(() =>
+  Effect.succeed(
+    Capability.contributes(Capabilities.ReactSurface, [
+      Surface.create({
+        id: 'plugin-settings',
+        role: 'article',
+        filter: AppSurface.settingsArticle(meta.id),
+        component: ({ data: { subject } }) => {
+          const { settings, updateSettings } = useSettingsState<SlackCapabilities.Settings>(subject.atom);
+          return <SlackSettings settings={settings} onSettingsChange={updateSettings} />;
+        },
+      }),
+      Surface.create({
+        id: 'slack-feed',
+        role: 'deck-companion--slack',
+        filter: AppSurface.literalSection('slack'),
+        component: () => <SlackFeedWithSettings />,
+      }),
+    ]),
+  ),
+);

--- a/packages/plugins/plugin-slack/src/capabilities/settings.ts
+++ b/packages/plugins/plugin-slack/src/capabilities/settings.ts
@@ -1,0 +1,34 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capability } from '@dxos/app-framework';
+import { AppCapabilities } from '@dxos/app-toolkit';
+import { createKvsStore } from '@dxos/effect';
+
+import { meta } from '#meta';
+import { SlackCapabilities } from '#types';
+
+export default Capability.makeModule(() =>
+  Effect.sync(() => {
+    const settingsAtom = createKvsStore({
+      key: meta.id,
+      schema: SlackCapabilities.SettingsSchema,
+      defaultValue: () => ({
+        respondToMentions: true,
+        respondToDMs: true,
+      }),
+    });
+
+    return [
+      Capability.contributes(SlackCapabilities.Settings, settingsAtom),
+      Capability.contributes(AppCapabilities.Settings, {
+        prefix: meta.id,
+        schema: SlackCapabilities.SettingsSchema,
+        atom: settingsAtom,
+      }),
+    ];
+  }),
+);

--- a/packages/plugins/plugin-slack/src/components/SlackFeed.tsx
+++ b/packages/plugins/plugin-slack/src/components/SlackFeed.tsx
@@ -47,12 +47,18 @@ export const SlackFeed = ({ settings, db }: SlackFeedProps) => {
     }
   }, [messages.length, responses]);
 
-  // Auto-start monitoring.
+  // Start / stop monitoring based on settings. Previously this only started
+  // polling and never stopped it when the bot token was cleared or the
+  // channel list was emptied — leaving the interval alive and the polling
+  // flag stale.
   useEffect(() => {
-    if (settings.botToken && (settings.monitoredChannels ?? []).length > 0 && !polling) {
+    const enabled = Boolean(settings.botToken) && (settings.monitoredChannels ?? []).length > 0;
+    if (enabled && !polling) {
       startPolling();
+    } else if (!enabled && polling) {
+      stopPolling();
     }
-  }, [settings.botToken, settings.monitoredChannels, polling, startPolling]);
+  }, [settings.botToken, settings.monitoredChannels, polling, startPolling, stopPolling]);
 
   /** Update a response entry. */
   const updateResponse = useCallback((key: string, update: Partial<AgentResponse>) => {
@@ -260,6 +266,15 @@ export const SlackFeed = ({ settings, db }: SlackFeedProps) => {
       }
       return;
     }
+    // Respect the settings toggle: if the user has disabled @mention auto-
+    // response, drain the queue without invoking the agent so we don't
+    // silently ignore the setting (or accumulate pending mentions forever).
+    if (settings.respondToMentions === false) {
+      if (pendingMentions.length > 0) {
+        clearPendingMentions();
+      }
+      return;
+    }
     if (pendingMentions.length === 0) {
       return;
     }
@@ -271,7 +286,7 @@ export const SlackFeed = ({ settings, db }: SlackFeedProps) => {
       }
       void handleAskAgent(mention);
     }
-  }, [pendingMentions, clearPendingMentions, handleAskAgent]);
+  }, [pendingMentions, clearPendingMentions, handleAskAgent, settings.respondToMentions]);
 
   // Auto-respond to thread replies.
   useEffect(() => {

--- a/packages/plugins/plugin-slack/src/components/SlackFeed.tsx
+++ b/packages/plugins/plugin-slack/src/components/SlackFeed.tsx
@@ -1,0 +1,522 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useOperationInvoker } from '@dxos/app-framework/ui';
+import { type Database } from '@dxos/echo';
+import { log } from '@dxos/log';
+import { AssistantOperation } from '@dxos/plugin-assistant/operations';
+import { Button, Icon, ScrollArea } from '@dxos/react-ui';
+import { mx } from '@dxos/ui-theme';
+
+import { type SlackMessage, type SlackUser, useSlackMessages, useSpaceContext } from '#hooks';
+import { type SlackCapabilities } from '#types';
+
+export type SlackFeedProps = {
+  settings: SlackCapabilities.Settings;
+  db: Database.Database;
+};
+
+type AgentResponse = {
+  messageTs: string;
+  text: string;
+  status: 'searching' | 'streaming' | 'posting' | 'done' | 'error';
+  /** Number of workspace results found during search. */
+  contextHits?: number;
+};
+
+export const SlackFeed = ({ settings, db }: SlackFeedProps) => {
+  const {
+    messages, users, polling, error: slackError, botUserId, pendingMentions,
+    startPolling, stopPolling, fetchMessages, fetchThread, trackThread,
+    checkThreadReplies, clearPendingMentions, postMessage,
+  } = useSlackMessages(settings.botToken, settings.monitoredChannels ?? []);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [responses, setResponses] = useState<Map<string, AgentResponse>>(new Map());
+  const { invokePromise } = useOperationInvoker();
+  const handledRef = useRef<Set<string>>(new Set());
+  const { searchContext } = useSpaceContext(db);
+
+  // Auto-scroll on any state change.
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+    }
+  }, [messages.length, responses]);
+
+  // Auto-start monitoring.
+  useEffect(() => {
+    if (settings.botToken && (settings.monitoredChannels ?? []).length > 0 && !polling) {
+      startPolling();
+    }
+  }, [settings.botToken, settings.monitoredChannels, polling, startPolling]);
+
+  /** Update a response entry. */
+  const updateResponse = useCallback((key: string, update: Partial<AgentResponse>) => {
+    setResponses((prev) => {
+      const existing = prev.get(key);
+      if (!existing) {
+        return prev;
+      }
+      return new Map(prev).set(key, { ...existing, ...update });
+    });
+  }, []);
+
+  /** Stream AI response and post to Slack. */
+  const respondToMessage = useCallback(
+    async (responseKey: string, channelId: string, threadTs: string, threadMessages: SlackMessage[]) => {
+      const apiKey = globalThis.localStorage?.getItem('ANTHROPIC_API_KEY');
+      if (!apiKey) {
+        throw new Error('Set ANTHROPIC_API_KEY in localStorage');
+      }
+
+      // Phase 1: Search workspace.
+      updateResponse(responseKey, { status: 'searching', text: '' });
+
+      const conversationMessages: { role: string; content: string }[] = [];
+      for (const msg of threadMessages) {
+        const isBot = msg.user === botUserId;
+        const userName = users.get(msg.user)?.realName ?? users.get(msg.user)?.name ?? msg.user;
+        if (isBot) {
+          conversationMessages.push({ role: 'assistant', content: msg.text });
+        } else {
+          const cleanText = botUserId ? msg.text.replace(new RegExp(`<@${botUserId}>`, 'g'), '').trim() : msg.text;
+          conversationMessages.push({
+            role: 'user',
+            content: threadMessages.length > 1 ? `${userName}: ${cleanText}` : cleanText,
+          });
+        }
+      }
+
+      const latestText = threadMessages[threadMessages.length - 1].text;
+      const lastMsg = threadMessages[threadMessages.length - 1];
+      const userName = users.get(lastMsg.user)?.realName ?? users.get(lastMsg.user)?.name ?? lastMsg.user;
+      const channelName = lastMsg.channelName;
+
+      // Build workspace search query from recent thread context so pronoun
+      // follow-ups ("what did we decide on it?") still resolve to the original subject.
+      // Include the last few user + assistant turns, not just the latest message.
+      const recentContextText = threadMessages
+        .slice(-6)
+        .map((msg) => (botUserId && msg.user === botUserId
+          ? msg.text
+          : (botUserId ? msg.text.replace(new RegExp(`<@${botUserId}>`, 'g'), '') : msg.text)))
+        .join(' ');
+      const searchQuery = threadMessages.length > 1 ? recentContextText : latestText;
+
+      const spaceContext = await searchContext(searchQuery);
+      const contextHits = spaceContext ? (spaceContext.match(/^\d+\./gm)?.length ?? 0) : 0;
+
+      log.info('slack: workspace search complete', { contextHits });
+
+      // Fire parallel agent trace for Inspector.
+      const tracePrompt = `[Slack #${channelName}] ${userName}: "${latestText}"`;
+      void invokePromise(AssistantOperation.RunPromptInNewChat, {
+        db,
+        prompt: tracePrompt,
+        background: true,
+      }).catch(() => {});
+
+      // Phase 2: Stream AI response.
+      updateResponse(responseKey, { status: 'streaming', text: '', contextHits });
+
+      const systemPrompt = [
+        'You are a helpful AI assistant participating in a Slack conversation.',
+        'Be concise, friendly, and conversational. Do not use markdown formatting.',
+        'Keep responses under 3 paragraphs.',
+        '',
+        'You have access to the user\'s Composer workspace data (documents, notes, tasks, emails).',
+        'When the user asks about their work, projects, or data, use the workspace context below to give informed answers.',
+        'If you reference workspace data, mention where the information came from.',
+        'If the workspace data doesn\'t contain relevant information, say so honestly.',
+        spaceContext,
+      ].join('\n');
+
+      const aiResponse = await fetch('/api/anthropic/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model: 'claude-sonnet-4-20250514',
+          max_tokens: 500,
+          stream: true,
+          system: systemPrompt,
+          messages: conversationMessages,
+        }),
+      });
+
+      if (!aiResponse.ok) {
+        const errorBody = await aiResponse.text();
+        throw new Error(`AI error ${aiResponse.status}: ${errorBody.slice(0, 200)}`);
+      }
+
+      // Parse SSE stream.
+      let fullText = '';
+      const reader = aiResponse.body?.getReader();
+      const decoder = new TextDecoder();
+
+      if (reader) {
+        let buffer = '';
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() ?? '';
+
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) {
+              continue;
+            }
+            const data = line.slice(6);
+            if (data === '[DONE]') {
+              continue;
+            }
+            try {
+              const event = JSON.parse(data);
+              if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+                fullText += event.delta.text;
+                updateResponse(responseKey, { text: fullText });
+              }
+            } catch {
+              // Skip malformed events.
+            }
+          }
+        }
+      }
+
+      if (!fullText) {
+        throw new Error('No response generated');
+      }
+
+      // Phase 3: Post to Slack.
+      updateResponse(responseKey, { status: 'posting', text: fullText });
+      await postMessage(channelId, fullText, threadTs);
+      log.info('slack: posted to Slack', { channelId, threadTs, length: fullText.length });
+
+      updateResponse(responseKey, { status: 'done', text: fullText });
+      return fullText;
+    },
+    [botUserId, users, postMessage, invokePromise, db, searchContext, updateResponse],
+  );
+
+  /** Handle clicking robot icon. */
+  const handleAskAgent = useCallback(
+    async (message: SlackMessage) => {
+      if (handledRef.current.has(message.ts)) {
+        return;
+      }
+      handledRef.current.add(message.ts);
+
+      setResponses((prev) =>
+        new Map(prev).set(message.ts, { messageTs: message.ts, text: '', status: 'searching' }),
+      );
+
+      try {
+        // If the @mention is inside an existing thread, pull in the full
+        // thread history so pronouns and follow-ups resolve correctly.
+        const rootTs = message.threadTs ?? message.ts;
+        let contextMessages: SlackMessage[] = [message];
+        if (message.threadTs) {
+          try {
+            const thread = await fetchThread(message.channelId, message.threadTs);
+            if (thread.length > 0) {
+              contextMessages = thread;
+            }
+          } catch {
+            // Fall back to single message if thread fetch fails.
+          }
+        }
+        await respondToMessage(message.ts, message.channelId, rootTs, contextMessages);
+        trackThread(rootTs, message.channelId);
+        setTimeout(() => void fetchMessages(), 2000);
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : 'Unknown error';
+        setResponses((prev) =>
+          new Map(prev).set(message.ts, { messageTs: message.ts, text: errorMsg, status: 'error' }),
+        );
+        handledRef.current.delete(message.ts);
+      }
+    },
+    [respondToMessage, trackThread, fetchMessages],
+  );
+
+  // Auto-respond to @mentions.
+  // Gated by DEMO_SHARED_AGENT_ACTIVE — when the cross-surface shared-agent
+  // observer is running, we let it handle all responses so we don't double-reply.
+  useEffect(() => {
+    if (globalThis.localStorage?.getItem('DEMO_SHARED_AGENT_ACTIVE') === 'true') {
+      if (pendingMentions.length > 0) {
+        clearPendingMentions();
+      }
+      return;
+    }
+    if (pendingMentions.length === 0) {
+      return;
+    }
+    const mentions = [...pendingMentions];
+    clearPendingMentions();
+    for (const mention of mentions) {
+      if (handledRef.current.has(mention.ts)) {
+        continue;
+      }
+      void handleAskAgent(mention);
+    }
+  }, [pendingMentions, clearPendingMentions, handleAskAgent]);
+
+  // Auto-respond to thread replies.
+  useEffect(() => {
+    if (!polling) {
+      return;
+    }
+    const interval = setInterval(async () => {
+      try {
+        const threadUpdates = await checkThreadReplies();
+        for (const { thread, newReplies } of threadUpdates) {
+          const lastReply = newReplies[newReplies.length - 1];
+          const replyKey = `thread-${lastReply.ts}`;
+          if (handledRef.current.has(replyKey)) {
+            continue;
+          }
+          handledRef.current.add(replyKey);
+
+          setResponses((prev) =>
+            new Map(prev).set(replyKey, { messageTs: lastReply.ts, text: '', status: 'searching' }),
+          );
+
+          try {
+            await respondToMessage(replyKey, thread.channelId, thread.threadTs, thread.messages);
+          } catch (err) {
+            const errorMsg = err instanceof Error ? err.message : 'Unknown error';
+            setResponses((prev) =>
+              new Map(prev).set(replyKey, { messageTs: lastReply.ts, text: errorMsg, status: 'error' }),
+            );
+            handledRef.current.delete(replyKey);
+          }
+        }
+      } catch {
+        // Non-fatal.
+      }
+    }, 12_000);
+    return () => clearInterval(interval);
+  }, [polling, checkThreadReplies, respondToMessage]);
+
+  if (!settings.botToken) {
+    return (
+      <div className='flex flex-col items-center justify-center p-8 gap-3 text-description text-sm'>
+        <Icon icon='ph--slack-logo--regular' size={8} classNames='opacity-30' />
+        <span>Connect Slack in Settings to get started.</span>
+      </div>
+    );
+  }
+
+  if ((settings.monitoredChannels ?? []).length === 0) {
+    return (
+      <div className='flex flex-col items-center justify-center p-8 gap-3 text-description text-sm'>
+        <Icon icon='ph--hash--regular' size={8} classNames='opacity-30' />
+        <span>Select channels to monitor in Settings.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex flex-col h-full'>
+      <div className='flex items-center gap-2 px-3 py-2 border-b border-separator'>
+        <Icon icon='ph--slack-logo--regular' size={4} />
+        <span className='text-sm font-medium flex-1'>Slack</span>
+        {polling && (
+          <div className='flex items-center gap-1'>
+            <div className='size-1.5 rounded-full bg-green-500 animate-pulse' />
+            <span className='text-xs text-description'>Live</span>
+          </div>
+        )}
+        <Button variant='ghost' classNames='p-1' onClick={() => void fetchMessages()} title='Refresh'>
+          <Icon icon='ph--arrow-clockwise--regular' size={3} />
+        </Button>
+        {polling ? (
+          <Button variant='ghost' classNames='p-1' onClick={stopPolling} title='Stop'>
+            <Icon icon='ph--stop--regular' size={3} />
+          </Button>
+        ) : (
+          <Button variant='ghost' classNames='p-1' onClick={startPolling} title='Start'>
+            <Icon icon='ph--play--regular' size={3} />
+          </Button>
+        )}
+      </div>
+
+      <ScrollArea.Root className='flex-1'>
+        <ScrollArea.Viewport ref={scrollRef} className='max-h-full'>
+          {slackError && (
+            <div className='px-3 py-2 text-xs text-error rounded m-2'>{slackError}</div>
+          )}
+          {messages.length === 0 ? (
+            <div className='flex flex-col items-center justify-center p-8 gap-2 text-description text-sm'>
+              {polling ? (
+                <>
+                  <Icon icon='ph--spinner-gap--regular' size={5} classNames='animate-spin opacity-30' />
+                  <span>Listening for messages...</span>
+                </>
+              ) : (
+                <span>Click play to start monitoring.</span>
+              )}
+            </div>
+          ) : (
+            <div className='flex flex-col gap-0.5 p-2'>
+              {messages.map((message) => (
+                <MessageRow
+                  key={message.ts}
+                  message={message}
+                  user={users.get(message.user)}
+                  isBotMessage={message.user === botUserId}
+                  response={responses.get(message.ts)}
+                  onAskAgent={() => void handleAskAgent(message)}
+                />
+              ))}
+            </div>
+          )}
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>
+    </div>
+  );
+};
+
+const formatTime = (ts: string): string => {
+  const date = new Date(Number(ts) * 1000);
+  return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+};
+
+const StatusLabel = ({ status, contextHits }: { status: AgentResponse['status']; contextHits?: number }) => {
+  switch (status) {
+    case 'searching':
+      return (
+        <div className='flex items-center gap-1.5'>
+          <Icon icon='ph--magnifying-glass--regular' size={3} classNames='animate-pulse text-amber-500' />
+          <span>Searching workspace...</span>
+        </div>
+      );
+    case 'streaming':
+      return (
+        <div className='flex items-center gap-1.5'>
+          <Icon icon='ph--brain--regular' size={3} classNames='text-purple-400' />
+          <span>
+            Generating response
+            {contextHits !== undefined && contextHits > 0 && ` (${contextHits} sources found)`}
+          </span>
+        </div>
+      );
+    case 'posting':
+      return (
+        <div className='flex items-center gap-1.5'>
+          <Icon icon='ph--paper-plane-right--regular' size={3} classNames='text-primary' />
+          <span>Posting to Slack...</span>
+        </div>
+      );
+    case 'done':
+      return (
+        <div className='flex items-center gap-1'>
+          <Icon icon='ph--check--regular' size={2.5} classNames='text-green-500' />
+          <span className='text-green-600 dark:text-green-400'>Posted to thread</span>
+        </div>
+      );
+    case 'error':
+      return (
+        <div className='flex items-center gap-1'>
+          <Icon icon='ph--warning--regular' size={2.5} classNames='text-error' />
+          <span>Error</span>
+        </div>
+      );
+  }
+};
+
+const MessageRow = ({
+  message,
+  user,
+  isBotMessage,
+  response,
+  onAskAgent,
+}: {
+  message: SlackMessage;
+  user?: SlackUser;
+  isBotMessage: boolean;
+  response?: AgentResponse;
+  onAskAgent: () => void;
+}) => {
+  const isActive = response?.status === 'searching' || response?.status === 'streaming' || response?.status === 'posting';
+  const isDone = response?.status === 'done';
+
+  return (
+    <div className='flex flex-col'>
+      <div className={mx('group flex gap-2 px-2 py-1 rounded-sm', !isBotMessage && 'hover:bg-hoverSurface')}>
+        <div className={mx('mt-0.5 shrink-0 size-5 rounded-full flex items-center justify-center text-[10px]', isBotMessage ? 'bg-primary/20' : 'bg-neutral-200 dark:bg-neutral-700')}>
+          {isBotMessage ? (
+            <Icon icon='ph--robot--regular' size={3} />
+          ) : (
+            <span>{(user?.realName ?? user?.name ?? '?')[0].toUpperCase()}</span>
+          )}
+        </div>
+
+        <div className='flex flex-col flex-1 min-w-0'>
+          <div className='flex items-center gap-1.5'>
+            <span className={mx('text-xs font-semibold', isBotMessage && 'text-primary')}>
+              {isBotMessage ? 'Composer Agent' : (user?.realName ?? user?.name ?? message.user)}
+            </span>
+            <span className='text-[10px] text-description'>{formatTime(message.ts)}</span>
+            {message.replyCount !== undefined && message.replyCount > 0 && (
+              <span className='text-[10px] text-primary font-medium'>
+                {message.replyCount} {message.replyCount === 1 ? 'reply' : 'replies'}
+              </span>
+            )}
+          </div>
+          <p className={mx('text-sm break-words', isBotMessage && 'text-description')}>{message.text}</p>
+        </div>
+
+        {!isBotMessage && !isDone && !isActive && (
+          <div className='flex items-start pt-1 opacity-0 group-hover:opacity-100 transition-opacity'>
+            <Button
+              variant='ghost'
+              classNames='p-0.5 rounded-full'
+              onClick={onAskAgent}
+              title='Ask Agent to respond'
+            >
+              <Icon icon='ph--robot--regular' size={3.5} />
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* Agent response area */}
+      {response && (
+        <div className={mx(
+          'ml-7 mr-2 mt-0.5 mb-1 rounded-sm text-xs',
+          response.status === 'error' ? 'text-error bg-error/10 px-2.5 py-1.5' : 'border-l-2 border-primary/40 px-2.5 py-1.5',
+        )}>
+          <div className='text-[10px] font-medium mb-0.5'>
+            <StatusLabel status={response.status} contextHits={response.contextHits} />
+          </div>
+
+          {/* Streaming text — appears word by word. */}
+          {response.text && (
+            <p className={mx(
+              'break-words whitespace-pre-wrap',
+              response.status === 'streaming' ? 'text-foreground' : 'text-description',
+            )}>
+              {response.text}
+              {response.status === 'streaming' && (
+                <span className='inline-block w-1.5 h-3 bg-primary/60 animate-pulse ml-0.5 -mb-0.5' />
+              )}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/plugins/plugin-slack/src/components/SlackSettings.tsx
+++ b/packages/plugins/plugin-slack/src/components/SlackSettings.tsx
@@ -1,0 +1,160 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React, { useCallback, useState } from 'react';
+
+import { Button, Icon, Input } from '@dxos/react-ui';
+import { mx } from '@dxos/ui-theme';
+
+import { useSlackApi } from '#hooks';
+import { type SlackCapabilities, type SlackChannel } from '#types';
+
+export type SlackSettingsProps = {
+  settings: SlackCapabilities.Settings;
+  onSettingsChange: (fn: (current: SlackCapabilities.Settings) => SlackCapabilities.Settings) => void;
+};
+
+export const SlackSettings = ({ settings, onSettingsChange }: SlackSettingsProps) => {
+  const [tokenInput, setTokenInput] = useState(settings.botToken ?? '');
+  const { status, channels, teamName, error, testConnection } = useSlackApi(settings.botToken);
+
+  const updatePartial = useCallback(
+    (partial: Partial<SlackCapabilities.Settings>) => {
+      onSettingsChange((current) => ({ ...current, ...partial }));
+    },
+    [onSettingsChange],
+  );
+
+  const handleTestConnection = useCallback(async () => {
+    const trimmed = tokenInput.trim();
+    if (trimmed) {
+      updatePartial({ botToken: trimmed });
+    }
+    await testConnection();
+  }, [tokenInput, updatePartial, testConnection]);
+
+  const handleDisconnect = useCallback(() => {
+    updatePartial({ botToken: undefined, monitoredChannels: [] });
+    setTokenInput('');
+  }, [updatePartial]);
+
+  const handleToggleChannel = useCallback(
+    (channelId: string) => {
+      const current = settings.monitoredChannels ?? [];
+      const next = current.includes(channelId)
+        ? current.filter((id) => id !== channelId)
+        : [...current, channelId];
+      updatePartial({ monitoredChannels: next });
+    },
+    [settings.monitoredChannels, updatePartial],
+  );
+
+  return (
+    <div className='flex flex-col gap-4 p-3'>
+      <div className='flex flex-col gap-2'>
+        <h3 className='text-sm font-medium'>Slack Connection</h3>
+
+        <div className='flex items-center gap-2'>
+          <StatusIndicator status={status} />
+          <span className='text-sm text-description'>
+            {status === 'connected' && teamName ? `Connected to ${teamName}` : status === 'error' ? error : status === 'connecting' ? 'Connecting...' : 'Not connected'}
+          </span>
+        </div>
+
+        <div className='flex gap-2'>
+          <Input.Root>
+            <Input.TextInput
+              placeholder='xoxb-...'
+              value={tokenInput}
+              onChange={(event) => setTokenInput(event.target.value)}
+              type='password'
+              classNames='font-mono text-xs'
+            />
+          </Input.Root>
+        </div>
+
+        <div className='flex gap-2'>
+          <Button variant='primary' onClick={handleTestConnection} disabled={!tokenInput.trim()}>
+            <Icon icon='ph--plug--regular' size={4} />
+            Test Connection
+          </Button>
+          {settings.botToken && (
+            <Button variant='ghost' onClick={handleDisconnect}>
+              <Icon icon='ph--plugs--regular' size={4} />
+              Disconnect
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {status === 'connected' && channels.length > 0 && (
+        <div className='flex flex-col gap-2'>
+          <h3 className='text-sm font-medium'>
+            Monitored Channels ({channels.length} available)
+          </h3>
+          <div className='flex flex-col gap-1 max-h-96 overflow-y-auto border border-separator rounded p-1'>
+            {channels.map((channel) => (
+              <ChannelRow
+                key={channel.id}
+                channel={channel}
+                monitored={settings.monitoredChannels?.includes(channel.id) ?? false}
+                onToggle={() => handleToggleChannel(channel.id)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {status === 'connected' && (
+        <div className='flex flex-col gap-2'>
+          <h3 className='text-sm font-medium'>Behavior</h3>
+          <label className='flex items-center gap-2 text-sm'>
+            <input
+              type='checkbox'
+              checked={settings.respondToMentions ?? true}
+              onChange={(event) => updatePartial({ respondToMentions: event.target.checked })}
+            />
+            Respond to @mentions
+          </label>
+          <label className='flex items-center gap-2 text-sm'>
+            <input
+              type='checkbox'
+              checked={settings.respondToDMs ?? true}
+              onChange={(event) => updatePartial({ respondToDMs: event.target.checked })}
+            />
+            Respond to direct messages
+          </label>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const StatusIndicator = ({ status }: { status: string }) => (
+  <div
+    className={mx(
+      'size-2 rounded-full',
+      status === 'connected' && 'bg-green-500',
+      status === 'connecting' && 'bg-yellow-500 animate-pulse',
+      status === 'error' && 'bg-red-500',
+      status === 'disconnected' && 'bg-neutral-400',
+    )}
+  />
+);
+
+const ChannelRow = ({
+  channel,
+  monitored,
+  onToggle,
+}: {
+  channel: SlackChannel;
+  monitored: boolean;
+  onToggle: () => void;
+}) => (
+  <label className='flex items-center gap-2 text-sm px-2 py-1 rounded hover:bg-hoverSurface cursor-pointer'>
+    <input type='checkbox' checked={monitored} onChange={onToggle} />
+    <Icon icon='ph--hash--regular' size={3} classNames='text-description' />
+    {channel.name}
+  </label>
+);

--- a/packages/plugins/plugin-slack/src/components/SlackSettings.tsx
+++ b/packages/plugins/plugin-slack/src/components/SlackSettings.tsx
@@ -28,10 +28,17 @@ export const SlackSettings = ({ settings, onSettingsChange }: SlackSettingsProps
 
   const handleTestConnection = useCallback(async () => {
     const trimmed = tokenInput.trim();
-    if (trimmed) {
+    if (!trimmed) {
+      return;
+    }
+    // Validate the trimmed input *first*; only persist if Slack accepts it.
+    // Previously we persisted the typed-but-unvalidated token and then called
+    // testConnection(), which used the stale bound token. Bad tokens could
+    // end up saved.
+    const ok = await testConnection(trimmed);
+    if (ok) {
       updatePartial({ botToken: trimmed });
     }
-    await testConnection();
   }, [tokenInput, updatePartial, testConnection]);
 
   const handleDisconnect = useCallback(() => {

--- a/packages/plugins/plugin-slack/src/components/index.ts
+++ b/packages/plugins/plugin-slack/src/components/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './SlackFeed';
+export * from './SlackSettings';

--- a/packages/plugins/plugin-slack/src/containers/SlackSettings/index.ts
+++ b/packages/plugins/plugin-slack/src/containers/SlackSettings/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export { SlackSettings as default } from '#components';

--- a/packages/plugins/plugin-slack/src/containers/index.ts
+++ b/packages/plugins/plugin-slack/src/containers/index.ts
@@ -1,0 +1,7 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { lazy, type ComponentType } from 'react';
+
+export const SlackSettings: ComponentType<any> = lazy(() => import('./SlackSettings'));

--- a/packages/plugins/plugin-slack/src/hooks/index.ts
+++ b/packages/plugins/plugin-slack/src/hooks/index.ts
@@ -1,0 +1,8 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './useSlackApi';
+export * from './useSlackMessages';
+export * from './useSpaceContext';
+export * from './useUrlEnricher';

--- a/packages/plugins/plugin-slack/src/hooks/useSlackApi.ts
+++ b/packages/plugins/plugin-slack/src/hooks/useSlackApi.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { type SlackChannel, type SlackConnectionStatus } from '#types';
 
@@ -10,10 +10,20 @@ const SLACK_API = 'https://slack.com/api';
 
 /** Lightweight Slack API client using fetch. No npm dependency needed. */
 export const useSlackApi = (botToken?: string) => {
-  const [status, setStatus] = useState<SlackConnectionStatus>(botToken ? 'disconnected' : 'disconnected');
+  const [status, setStatus] = useState<SlackConnectionStatus>('disconnected');
   const [channels, setChannels] = useState<SlackChannel[]>([]);
   const [teamName, setTeamName] = useState<string | undefined>();
   const [error, setError] = useState<string | undefined>();
+
+  // Reset state when the token changes (including when cleared via Disconnect).
+  // Without this, swapping or removing tokens left stale `connected` / team
+  // / channel state on the UI until the next testConnection() call.
+  useEffect(() => {
+    setStatus('disconnected');
+    setChannels([]);
+    setTeamName(undefined);
+    setError(undefined);
+  }, [botToken]);
 
   const callSlack = useCallback(
     async (method: string, params?: Record<string, string>) => {
@@ -37,16 +47,31 @@ export const useSlackApi = (botToken?: string) => {
     [botToken],
   );
 
-  const testConnection = useCallback(async () => {
-    if (!botToken) {
+  // Accept an explicit token override so callers can validate a freshly-
+  // typed token before persisting it to settings (avoids the race where
+  // `testConnection` uses the stale `botToken` prop while the component is
+  // mid-update).
+  const testConnection = useCallback(async (overrideToken?: string) => {
+    const token = overrideToken ?? botToken;
+    if (!token) {
       setStatus('disconnected');
       return false;
     }
 
     setStatus('connecting');
     setError(undefined);
+    const call = async (method: string, params?: Record<string, string>) => {
+      const body = new URLSearchParams({ token, ...params });
+      const response = await fetch(`${SLACK_API}/${method}`, { method: 'POST', body });
+      const data = await response.json();
+      if (!data.ok) {
+        const detail = data.needed ? ` (need scope: ${data.needed})` : '';
+        throw new Error(`${data.error ?? 'Slack API error'}${detail}`);
+      }
+      return data;
+    };
     try {
-      const authData = await callSlack('auth.test');
+      const authData = await call('auth.test');
       setTeamName(authData.team);
       setStatus('connected');
 
@@ -62,7 +87,7 @@ export const useSlackApi = (botToken?: string) => {
         if (cursor) {
           params.cursor = cursor;
         }
-        const channelsData = await callSlack('conversations.list', params);
+        const channelsData = await call('conversations.list', params);
         const page: SlackChannel[] = (channelsData.channels ?? []).map(
           (channel: { id: string; name: string; is_member: boolean }) => ({
             id: channel.id,
@@ -82,7 +107,7 @@ export const useSlackApi = (botToken?: string) => {
       setError(err instanceof Error ? err.message : 'Unknown error');
       return false;
     }
-  }, [botToken, callSlack]);
+  }, [botToken]);
 
   const postMessage = useCallback(
     async (channelId: string, text: string, threadTs?: string) => {

--- a/packages/plugins/plugin-slack/src/hooks/useSlackApi.ts
+++ b/packages/plugins/plugin-slack/src/hooks/useSlackApi.ts
@@ -1,0 +1,99 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { useCallback, useState } from 'react';
+
+import { type SlackChannel, type SlackConnectionStatus } from '#types';
+
+const SLACK_API = 'https://slack.com/api';
+
+/** Lightweight Slack API client using fetch. No npm dependency needed. */
+export const useSlackApi = (botToken?: string) => {
+  const [status, setStatus] = useState<SlackConnectionStatus>(botToken ? 'disconnected' : 'disconnected');
+  const [channels, setChannels] = useState<SlackChannel[]>([]);
+  const [teamName, setTeamName] = useState<string | undefined>();
+  const [error, setError] = useState<string | undefined>();
+
+  const callSlack = useCallback(
+    async (method: string, params?: Record<string, string>) => {
+      if (!botToken) {
+        throw new Error('No bot token configured');
+      }
+      // Use POST with form body to avoid CORS preflight issues.
+      // Slack Web API supports token in the form body for all methods.
+      const body = new URLSearchParams({ token: botToken, ...params });
+      const response = await fetch(`${SLACK_API}/${method}`, {
+        method: 'POST',
+        body,
+      });
+      const data = await response.json();
+      if (!data.ok) {
+        const detail = data.needed ? ` (need scope: ${data.needed})` : '';
+        throw new Error(`${data.error ?? 'Slack API error'}${detail}`);
+      }
+      return data;
+    },
+    [botToken],
+  );
+
+  const testConnection = useCallback(async () => {
+    if (!botToken) {
+      setStatus('disconnected');
+      return false;
+    }
+
+    setStatus('connecting');
+    setError(undefined);
+    try {
+      const authData = await callSlack('auth.test');
+      setTeamName(authData.team);
+      setStatus('connected');
+
+      // Paginate through all channels.
+      const allChannels: SlackChannel[] = [];
+      let cursor: string | undefined;
+      do {
+        const params: Record<string, string> = {
+          types: 'public_channel,private_channel',
+          limit: '200',
+          exclude_archived: 'true',
+        };
+        if (cursor) {
+          params.cursor = cursor;
+        }
+        const channelsData = await callSlack('conversations.list', params);
+        const page: SlackChannel[] = (channelsData.channels ?? []).map(
+          (channel: { id: string; name: string; is_member: boolean }) => ({
+            id: channel.id,
+            name: channel.name,
+            isMember: channel.is_member,
+          }),
+        );
+        allChannels.push(...page);
+        cursor = channelsData.response_metadata?.next_cursor || undefined;
+      } while (cursor);
+
+      allChannels.sort((first, second) => first.name.localeCompare(second.name));
+      setChannels(allChannels);
+      return true;
+    } catch (err) {
+      setStatus('error');
+      setError(err instanceof Error ? err.message : 'Unknown error');
+      return false;
+    }
+  }, [botToken, callSlack]);
+
+  const postMessage = useCallback(
+    async (channelId: string, text: string, threadTs?: string) => {
+      const params: Record<string, string> = { channel: channelId, text };
+      if (threadTs) {
+        params.thread_ts = threadTs;
+      }
+      return callSlack('chat.postMessage', params);
+    },
+    [callSlack],
+  );
+
+  return { status, channels, teamName, error, testConnection, postMessage };
+};

--- a/packages/plugins/plugin-slack/src/hooks/useSlackMessages.ts
+++ b/packages/plugins/plugin-slack/src/hooks/useSlackMessages.ts
@@ -276,15 +276,31 @@ export const useSlackMessages = (
     });
   }, [normalizeChannelIds, resolveChannelName, resolveUserName]);
 
+  // In-flight guard so overlapping polls don't queue up when the network is
+  // slow or channel count is high. Without this a slow Slack response could
+  // cause `fetchMessages` writes to land out of order.
+  const fetchInFlightRef = useRef(false);
+  const guardedFetch = useCallback(async () => {
+    if (fetchInFlightRef.current) {
+      return;
+    }
+    fetchInFlightRef.current = true;
+    try {
+      await fetchMessages();
+    } finally {
+      fetchInFlightRef.current = false;
+    }
+  }, [fetchMessages]);
+
   const startPolling = useCallback(() => {
     if (intervalRef.current) {
       return;
     }
     setPolling(true);
     log.info('slack: starting polling');
-    void fetchMessages();
-    intervalRef.current = setInterval(() => void fetchMessages(), pollIntervalMs);
-  }, [fetchMessages, pollIntervalMs]);
+    void guardedFetch();
+    intervalRef.current = setInterval(() => void guardedFetch(), pollIntervalMs);
+  }, [guardedFetch, pollIntervalMs]);
 
   const stopPolling = useCallback(() => {
     setPolling(false);

--- a/packages/plugins/plugin-slack/src/hooks/useSlackMessages.ts
+++ b/packages/plugins/plugin-slack/src/hooks/useSlackMessages.ts
@@ -1,0 +1,325 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { log } from '@dxos/log';
+
+const SLACK_API = 'https://slack.com/api';
+
+export type SlackMessage = {
+  ts: string;
+  text: string;
+  user: string;
+  channelId: string;
+  channelName: string;
+  threadTs?: string;
+  replyCount?: number;
+};
+
+export type SlackUser = {
+  id: string;
+  name: string;
+  realName?: string;
+};
+
+export type SlackThread = {
+  channelId: string;
+  threadTs: string;
+  messages: SlackMessage[];
+};
+
+const callSlackApi = async (botToken: string, method: string, params?: Record<string, string>) => {
+  const body = new URLSearchParams({ token: botToken, ...params });
+  const response = await fetch(`${SLACK_API}/${method}`, { method: 'POST', body });
+  const data = await response.json();
+  if (!data.ok) {
+    const detail = data.needed ? ` (need scope: ${data.needed})` : '';
+    throw new Error(`${data.error ?? 'Slack API error'}${detail}`);
+  }
+  return data;
+};
+
+/**
+ * Polls Slack channels for recent messages and tracks thread conversations.
+ */
+export const useSlackMessages = (
+  botToken: string | undefined,
+  channelIds: string[],
+  pollIntervalMs = 10_000,
+) => {
+  const [messages, setMessages] = useState<SlackMessage[]>([]);
+  const [users, setUsers] = useState<Map<string, SlackUser>>(new Map());
+  const [polling, setPolling] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  const [botUserId, setBotUserId] = useState<string | undefined>();
+  // New mentions detected this poll cycle.
+  const [pendingMentions, setPendingMentions] = useState<SlackMessage[]>([]);
+
+  const botTokenRef = useRef(botToken);
+  const channelIdsRef = useRef(channelIds);
+  const usersRef = useRef(users);
+  const botUserIdRef = useRef(botUserId);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const channelNamesRef = useRef<Record<string, string>>({});
+  // Map from human-friendly name → channel id, populated lazily when settings
+  // include names instead of IDs (common first-run state before the demo
+  // orchestrator resolved them).
+  const nameToIdRef = useRef<Record<string, string>>({});
+  const trackedThreadsRef = useRef<Map<string, string>>(new Map());
+  const lastReplyTsRef = useRef<Map<string, string>>(new Map());
+  // Track all message timestamps we've seen to detect new ones.
+  const seenMessagesRef = useRef<Set<string>>(new Set());
+  // First poll flag — don't auto-respond to existing messages on startup.
+  const firstPollDoneRef = useRef(false);
+
+  // Channel "IDs" coming from settings might actually be names. Slack rejects
+  // names on conversations.history with channel_not_found, so normalize here.
+  const normalizeChannelIds = useCallback(async (token: string, channels: string[]): Promise<string[]> => {
+    // Real Slack channel IDs begin with uppercase C / D / G and have no
+    // dashes. Everything else we try to resolve via conversations.list, once.
+    const looksLikeId = (value: string): boolean => /^[CDG][A-Z0-9]+$/.test(value);
+    const unresolved = channels.filter((channel) => !looksLikeId(channel) && !nameToIdRef.current[channel]);
+    if (unresolved.length > 0) {
+      try {
+        const data = await callSlackApi(token, 'conversations.list', {
+          exclude_archived: 'true',
+          limit: '1000',
+          types: 'public_channel,private_channel',
+        });
+        for (const entry of (data.channels ?? []) as { id: string; name: string }[]) {
+          nameToIdRef.current[entry.name] = entry.id;
+        }
+      } catch {
+        // leave map empty; we'll just pass the name through and the API will 404 again
+      }
+    }
+    return channels.map((channel) => (looksLikeId(channel) ? channel : nameToIdRef.current[channel] ?? channel));
+  }, []);
+
+  useEffect(() => { botTokenRef.current = botToken; }, [botToken]);
+  useEffect(() => { channelIdsRef.current = channelIds; }, [channelIds]);
+  useEffect(() => { usersRef.current = users; }, [users]);
+  useEffect(() => { botUserIdRef.current = botUserId; }, [botUserId]);
+
+  const resolveChannelName = useCallback(async (token: string, channelId: string): Promise<string> => {
+    if (channelNamesRef.current[channelId]) {
+      return channelNamesRef.current[channelId];
+    }
+    try {
+      const data = await callSlackApi(token, 'conversations.info', { channel: channelId });
+      const name = data.channel?.name ?? channelId;
+      channelNamesRef.current[channelId] = name;
+      return name;
+    } catch {
+      return channelId;
+    }
+  }, []);
+
+  const resolveUserName = useCallback(async (token: string, userId: string): Promise<SlackUser> => {
+    const cached = usersRef.current.get(userId);
+    if (cached) {
+      return cached;
+    }
+    try {
+      const data = await callSlackApi(token, 'users.info', { user: userId });
+      const user: SlackUser = {
+        id: data.user.id,
+        name: data.user.name,
+        realName: data.user.real_name,
+      };
+      setUsers((prev) => new Map(prev).set(userId, user));
+      return user;
+    } catch {
+      return { id: userId, name: userId };
+    }
+  }, []);
+
+  const trackThread = useCallback((threadTs: string, channelId: string) => {
+    trackedThreadsRef.current.set(threadTs, channelId);
+  }, []);
+
+  const fetchThread = useCallback(async (channelId: string, threadTs: string): Promise<SlackMessage[]> => {
+    const token = botTokenRef.current;
+    if (!token) {
+      return [];
+    }
+    const channelName = await resolveChannelName(token, channelId);
+    const data = await callSlackApi(token, 'conversations.replies', { channel: channelId, ts: threadTs });
+    const threadMessages: SlackMessage[] = (data.messages ?? []).map(
+      (msg: { ts: string; text: string; user: string; thread_ts?: string }) => ({
+        ts: msg.ts, text: msg.text, user: msg.user, channelId, channelName, threadTs: msg.thread_ts,
+      }),
+    );
+    for (const msg of threadMessages) {
+      await resolveUserName(token, msg.user);
+    }
+    return threadMessages;
+  }, [resolveChannelName, resolveUserName]);
+
+  const checkThreadReplies = useCallback(async (): Promise<{ thread: SlackThread; newReplies: SlackMessage[] }[]> => {
+    const token = botTokenRef.current;
+    const currentBotId = botUserIdRef.current;
+    if (!token) {
+      return [];
+    }
+    const results: { thread: SlackThread; newReplies: SlackMessage[] }[] = [];
+    for (const [threadTs, channelId] of trackedThreadsRef.current.entries()) {
+      try {
+        const threadMessages = await fetchThread(channelId, threadTs);
+        const lastSeen = lastReplyTsRef.current.get(threadTs) ?? threadTs;
+        const newReplies = threadMessages.filter(
+          (msg) => msg.ts > lastSeen && msg.user !== currentBotId,
+        );
+        if (newReplies.length > 0) {
+          const maxTs = newReplies.reduce((max, msg) => (msg.ts > max ? msg.ts : max), lastSeen);
+          lastReplyTsRef.current.set(threadTs, maxTs);
+          results.push({ thread: { channelId, threadTs, messages: threadMessages }, newReplies });
+          log.info('slack: new thread replies', { threadTs, count: newReplies.length });
+        }
+      } catch (err) {
+        log.warn('slack: failed to check thread', { threadTs, error: String(err) });
+      }
+    }
+    return results;
+  }, [fetchThread]);
+
+  /** Clear consumed mentions. */
+  const clearPendingMentions = useCallback(() => {
+    setPendingMentions([]);
+  }, []);
+
+  const fetchMessages = useCallback(async () => {
+    const token = botTokenRef.current;
+    const rawChannels = channelIdsRef.current;
+    const currentBotId = botUserIdRef.current;
+
+    if (!token || rawChannels.length === 0) {
+      return;
+    }
+
+    // Resolve any name-shaped entries to real channel IDs before hitting
+    // conversations.history (which 404s on names).
+    const channels = await normalizeChannelIds(token, rawChannels);
+
+    // Resolve bot user ID on first fetch.
+    if (!currentBotId) {
+      try {
+        const authData = await callSlackApi(token, 'auth.test');
+        setBotUserId(authData.user_id);
+        botUserIdRef.current = authData.user_id;
+      } catch {
+        // Non-fatal.
+      }
+    }
+
+    setError(undefined);
+    const newMessages: SlackMessage[] = [];
+
+    for (const channelId of channels) {
+      try {
+        const channelName = await resolveChannelName(token, channelId);
+        const data = await callSlackApi(token, 'conversations.history', { channel: channelId, limit: '15' });
+
+        const channelMessages = (data.messages ?? [])
+          .filter((msg: { subtype?: string }) => !msg.subtype)
+          .map((msg: { ts: string; text: string; user: string; thread_ts?: string; reply_count?: number }) => ({
+            ts: msg.ts, text: msg.text, user: msg.user, channelId, channelName,
+            threadTs: msg.thread_ts, replyCount: msg.reply_count,
+          }));
+
+        newMessages.push(...channelMessages);
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : 'Unknown error';
+        if (errorMsg.includes('not_in_channel')) {
+          continue;
+        }
+        log.warn('slack: failed to fetch channel', { channelId, error: errorMsg });
+        setError(errorMsg);
+      }
+    }
+
+    for (const msg of newMessages) {
+      await resolveUserName(token, msg.user);
+    }
+
+    // Detect new @mentions (only after first poll to avoid responding to old messages).
+    if (firstPollDoneRef.current && botUserIdRef.current) {
+      const botMention = `<@${botUserIdRef.current}>`;
+      const newMentions = newMessages.filter(
+        (msg) =>
+          !seenMessagesRef.current.has(msg.ts) &&
+          msg.user !== botUserIdRef.current &&
+          msg.text.includes(botMention),
+      );
+      if (newMentions.length > 0) {
+        log.info('slack: detected @mentions', { count: newMentions.length });
+        setPendingMentions((prev) => [...prev, ...newMentions]);
+      }
+    }
+
+    // Mark all current messages as seen.
+    for (const msg of newMessages) {
+      seenMessagesRef.current.add(msg.ts);
+    }
+    firstPollDoneRef.current = true;
+
+    setMessages((prev) => {
+      const byTs = new Map(prev.map((msg) => [msg.ts, msg]));
+      for (const msg of newMessages) {
+        byTs.set(msg.ts, msg);
+      }
+      return [...byTs.values()]
+        .sort((first, second) => Number(first.ts) - Number(second.ts))
+        .slice(-100);
+    });
+  }, [normalizeChannelIds, resolveChannelName, resolveUserName]);
+
+  const startPolling = useCallback(() => {
+    if (intervalRef.current) {
+      return;
+    }
+    setPolling(true);
+    log.info('slack: starting polling');
+    void fetchMessages();
+    intervalRef.current = setInterval(() => void fetchMessages(), pollIntervalMs);
+  }, [fetchMessages, pollIntervalMs]);
+
+  const stopPolling = useCallback(() => {
+    setPolling(false);
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, []);
+
+  const postMessage = useCallback(
+    async (channelId: string, text: string, threadTs?: string) => {
+      if (!botTokenRef.current) {
+        throw new Error('No bot token');
+      }
+      const params: Record<string, string> = { channel: channelId, text };
+      if (threadTs) {
+        params.thread_ts = threadTs;
+      }
+      return callSlackApi(botTokenRef.current, 'chat.postMessage', params);
+    },
+    [],
+  );
+
+  return {
+    messages, users, polling, error, botUserId, pendingMentions,
+    startPolling, stopPolling, fetchMessages, fetchThread, trackThread,
+    checkThreadReplies, clearPendingMentions, postMessage,
+  };
+};

--- a/packages/plugins/plugin-slack/src/hooks/useSpaceContext.ts
+++ b/packages/plugins/plugin-slack/src/hooks/useSpaceContext.ts
@@ -1,0 +1,220 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { useCallback } from 'react';
+
+import { type Database, Filter, Obj } from '@dxos/echo';
+import { log } from '@dxos/log';
+
+import { extractUrls, useUrlEnricher } from './useUrlEnricher';
+
+/** Fields to extract text from for matching and context. */
+const TEXT_FIELDS = [
+  'title', 'name', 'fullName', 'content', 'text', 'description',
+  'subject', 'link', 'author', 'published', 'url', 'notes',
+];
+
+/**
+ * Searches ECHO space objects AND feed items for relevant context.
+ * Properly queries inside Feed objects (mailbox messages, calendar events, RSS posts).
+ */
+export const useSpaceContext = (db: Database.Database | undefined) => {
+  const { fetchMany } = useUrlEnricher();
+
+  const searchContext = useCallback(
+    async (query: string, maxResults = 20): Promise<string> => {
+      if (!db) {
+        return '';
+      }
+
+      try {
+        const queryLower = query.toLowerCase();
+        // Strip <@U123> mentions before splitting.
+        const cleanQuery = query.replace(/<@[A-Z0-9]+>/g, ' ');
+        const allWords = cleanQuery.split(/\s+/).filter((word) => word.length > 2);
+        const queryWords = allWords.map((word) => word.toLowerCase());
+
+        // Identify "entity tokens" — capitalized words (proper nouns like company or
+        // person names) in the original query. These are the words a user almost
+        // always cares about. Rare-but-critical terms like "Hilbert" get drowned out
+        // if we weight them the same as common words like "tell" or "about".
+        // If any entity tokens are present, results MUST contain at least one of them,
+        // otherwise we fall back to the old behavior.
+        const entityTokens = allWords
+          .filter((word) => /^[A-Z]/.test(word) || /\d/.test(word))
+          .map((word) => word.toLowerCase())
+          // Drop the leading-caps-by-sentence-start artifacts for very common words.
+          .filter((word) => !['tell', 'what', 'which', 'why', 'how', 'who', 'when', 'where', 'the', 'and', 'but'].includes(word));
+        const stopwords = new Set(['tell', 'about', 'what', 'which', 'why', 'how', 'who', 'when', 'where', 'the', 'and', 'but', 'for', 'did', 'was', 'are', 'have', 'has', 'our', 'your', 'this', 'that', 'with', 'from', 'you', 'can']);
+        const rareTokens = queryWords.filter((word) => !stopwords.has(word));
+
+        const scored: { id: string; score: number; summary: string; hasEntityMatch: boolean }[] = [];
+        const seenIds = new Set<string>();
+
+        // Score a word match. Entity tokens (proper nouns) are weighted very highly
+        // because they're almost always what the user is actually asking about.
+        // Stopwords get zero weight. Remaining "rare" tokens get a small weight.
+        const wordWeight = (word: string, baseWeight: number): number => {
+          if (entityTokens.includes(word)) {
+            return baseWeight * 50;
+          }
+          if (stopwords.has(word)) {
+            return 0;
+          }
+          return baseWeight;
+        };
+
+        const scoreObject = (object: any, bonus = 0) => {
+          const objectId = (object as any).id;
+          if (!objectId || seenIds.has(objectId)) {
+            return;
+          }
+          seenIds.add(objectId);
+
+          let score = bonus;
+          let hasEntityMatch = false;
+          const parts: string[] = [];
+
+          const recordMatch = (haystackLower: string, baseWeight: number) => {
+            for (const word of queryWords) {
+              if (haystackLower.includes(word)) {
+                score += wordWeight(word, baseWeight);
+                if (entityTokens.includes(word)) {
+                  hasEntityMatch = true;
+                }
+              }
+            }
+          };
+
+          // Truncation limits per field. Short ID-like fields (name, title, subject)
+          // stay small; narrative fields (description, content, notes) get far more
+          // room since the entity filter already keeps result counts low.
+          const LONG_FIELDS = new Set(['description', 'content', 'notes', 'text']);
+          const fieldLimit = (field: string) => (LONG_FIELDS.has(field) ? 3000 : 300);
+
+          for (const field of TEXT_FIELDS) {
+            const value = (object as any)[field];
+            if (typeof value === 'string' && value.length > 0) {
+              recordMatch(value.toLowerCase(), 2);
+              if (value.length > 3) {
+                parts.push(`${field}: ${value.slice(0, fieldLimit(field))}`);
+              }
+            }
+          }
+
+          // Check ECHO text content (referenced documents).
+          const content = (object as any).content;
+          if (content && typeof content === 'object' && typeof content.text === 'string') {
+            const textContent = content.text;
+            recordMatch(textContent.toLowerCase(), 3);
+            parts.push(`content: ${textContent.slice(0, 3000)}`);
+          }
+
+          // Check message blocks (for emails and chat messages).
+          const blocks = (object as any).blocks;
+          if (Array.isArray(blocks)) {
+            for (const block of blocks.slice(0, 5)) {
+              if (block?.text && typeof block.text === 'string') {
+                recordMatch(block.text.toLowerCase(), 1);
+                parts.push(`message: ${block.text.slice(0, 800)}`);
+              }
+            }
+          }
+
+          // Check sender info (for emails).
+          const sender = (object as any).sender;
+          if (sender) {
+            const senderName = sender.name ?? sender.email ?? '';
+            if (senderName) {
+              parts.push(`from: ${senderName}`);
+            }
+          }
+
+          // Check properties (email subject, etc.).
+          const properties = (object as any).properties;
+          if (properties && typeof properties === 'object') {
+            const propSubject = properties.subject;
+            if (typeof propSubject === 'string' && propSubject.length > 0) {
+              recordMatch(propSubject.toLowerCase(), 3);
+              parts.push(`subject: ${propSubject}`);
+            }
+          }
+
+          if (parts.length > 0) {
+            const typename = Obj.getSchema(object)?.typename ?? 'Object';
+            scored.push({
+              id: objectId,
+              score: score + bonus,
+              hasEntityMatch,
+              summary: `[${typename}] ${parts.join(' | ')}`,
+            });
+          }
+        };
+
+        // 1. Query top-level space objects.
+        const allObjects = await db.query(Filter.everything()).run();
+
+        // Log typenames found for debugging.
+        const typenameCounts: Record<string, number> = {};
+        for (const object of allObjects) {
+          const typename = Obj.getSchema(object)?.typename ?? 'unknown';
+          typenameCounts[typename] = (typenameCounts[typename] ?? 0) + 1;
+          scoreObject(object);
+        }
+
+        // If the user mentioned specific entities (proper nouns, IDs), results must
+        // contain at least one of those entity tokens. Otherwise rare-but-critical
+        // terms like "Hilbert" get drowned out by objects matching common words.
+        const candidateSet = entityTokens.length > 0
+          ? scored.filter((result) => result.hasEntityMatch)
+          : scored;
+
+        log.info('slack: ECHO context search', {
+          query: queryLower.slice(0, 50),
+          entityTokens,
+          rareTokens,
+          topLevelObjects: allObjects.length,
+          scored: scored.length,
+          candidates: candidateSet.length,
+          types: typenameCounts,
+        });
+
+        // Sort by score, take top results.
+        candidateSet.sort((first, second) => second.score - first.score);
+        const topResults = candidateSet.slice(0, maxResults);
+
+        if (topResults.length === 0) {
+          return '';
+        }
+
+        const contextLines = topResults.map((result, index) => `${index + 1}. ${result.summary}`);
+        const baseContext = contextLines.join('\n');
+
+        // Generic URL enrichment: pull URLs out of the top snippets and fetch
+        // their public content via the dev proxy. Content-agnostic — doesn't
+        // know or care what any specific site is.
+        const urlsInContext = extractUrls(baseContext, 3);
+        let fetchedSection = '';
+        if (urlsInContext.length > 0) {
+          const fetched = await fetchMany(urlsInContext);
+          if (fetched.size > 0) {
+            const lines: string[] = [];
+            for (const [url, text] of fetched) {
+              lines.push(`[${url}]\n${text}`);
+            }
+            fetchedSection = `\n\n--- Fetched content from referenced URLs ---\n${lines.join('\n\n')}\n--- End fetched content ---`;
+          }
+        }
+
+        return `\n\n--- Relevant data from the user's workspace ---\n${baseContext}\n--- End workspace data ---${fetchedSection}`;
+      } catch (err) {
+        log.warn('slack: failed to search ECHO', { error: String(err) });
+        return '';
+      }
+    },
+    [db, fetchMany],
+  );
+
+  return { searchContext };
+};

--- a/packages/plugins/plugin-slack/src/hooks/useUrlEnricher.ts
+++ b/packages/plugins/plugin-slack/src/hooks/useUrlEnricher.ts
@@ -1,0 +1,99 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { useCallback } from 'react';
+
+import { log } from '@dxos/log';
+
+/** Fetched-content cache, shared across hook instances. */
+const urlCache = new Map<string, { text: string; timestamp: number }>();
+const CACHE_TTL_MS = 15 * 60 * 1000;
+const MAX_TEXT_LENGTH = 4000;
+
+const URL_REGEX = /https?:\/\/[^\s<>"')\]]+/g;
+
+/** Strip HTML tags and collapse whitespace. Intentionally dumb — works across most pages. */
+const htmlToText = (html: string): string => {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<noscript[\s\S]*?<\/noscript>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+/** Extract up to `limit` URLs from a blob of text, de-duplicated, in order of appearance. */
+export const extractUrls = (text: string, limit = 5): string[] => {
+  const seen = new Set<string>();
+  const urls: string[] = [];
+  const matches = text.match(URL_REGEX) ?? [];
+  for (const match of matches) {
+    // Strip trailing punctuation that often attaches to URLs in prose.
+    const cleaned = match.replace(/[.,;:!?)"']+$/, '');
+    if (!seen.has(cleaned)) {
+      seen.add(cleaned);
+      urls.push(cleaned);
+      if (urls.length >= limit) {
+        break;
+      }
+    }
+  }
+  return urls;
+};
+
+/**
+ * Fetches public web URLs via the dev proxy and returns extracted plain text.
+ * Uses an in-memory LRU-ish cache (TTL-based). Content-agnostic — doesn't know
+ * about any specific site.
+ */
+export const useUrlEnricher = () => {
+  const fetchUrl = useCallback(async (url: string): Promise<string | undefined> => {
+    const cached = urlCache.get(url);
+    if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+      return cached.text;
+    }
+    try {
+      const response = await fetch(`/api/fetch?url=${encodeURIComponent(url)}`);
+      if (!response.ok) {
+        log.info('urlEnricher: fetch failed', { url, status: response.status });
+        return undefined;
+      }
+      const contentType = response.headers.get('content-type') ?? '';
+      const raw = await response.text();
+      const text = contentType.includes('html') ? htmlToText(raw) : raw;
+      const capped = text.slice(0, MAX_TEXT_LENGTH);
+      urlCache.set(url, { text: capped, timestamp: Date.now() });
+      return capped;
+    } catch (err) {
+      log.info('urlEnricher: fetch error', { url, error: String(err) });
+      return undefined;
+    }
+  }, []);
+
+  /** Fetch many URLs in parallel; skip any that fail. Returns url → extracted text. */
+  const fetchMany = useCallback(
+    async (urls: string[]): Promise<Map<string, string>> => {
+      const results = await Promise.all(
+        urls.map(async (url) => [url, await fetchUrl(url)] as const),
+      );
+      const map = new Map<string, string>();
+      for (const [url, text] of results) {
+        if (text) {
+          map.set(url, text);
+        }
+      }
+      return map;
+    },
+    [fetchUrl],
+  );
+
+  return { fetchUrl, fetchMany };
+};

--- a/packages/plugins/plugin-slack/src/hooks/useUrlEnricher.ts
+++ b/packages/plugins/plugin-slack/src/hooks/useUrlEnricher.ts
@@ -10,6 +10,15 @@ import { log } from '@dxos/log';
 const urlCache = new Map<string, { text: string; timestamp: number }>();
 const CACHE_TTL_MS = 15 * 60 * 1000;
 const MAX_TEXT_LENGTH = 4000;
+const FETCH_TIMEOUT_MS = 10_000;
+/** Size cap on the raw body we'll read from the proxy — prevents memory DoS from huge pages. */
+const MAX_RAW_BYTES = 2_000_000;
+
+/** Redact the query string from a URL for logging — params can leak tokens/IDs. */
+const redactUrl = (url: string): string => {
+  const queryIndex = url.indexOf('?');
+  return queryIndex === -1 ? url : `${url.slice(0, queryIndex)}?…`;
+};
 
 const URL_REGEX = /https?:\/\/[^\s<>"')\]]+/g;
 
@@ -60,21 +69,48 @@ export const useUrlEnricher = () => {
     if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
       return cached.text;
     }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     try {
-      const response = await fetch(`/api/fetch?url=${encodeURIComponent(url)}`);
+      const response = await fetch(`/api/fetch?url=${encodeURIComponent(url)}`, {
+        signal: controller.signal,
+      });
       if (!response.ok) {
-        log.info('urlEnricher: fetch failed', { url, status: response.status });
+        // Redact query string — URLs from Slack messages can contain tokens.
+        log.info('urlEnricher: fetch failed', { url: redactUrl(url), status: response.status });
         return undefined;
       }
       const contentType = response.headers.get('content-type') ?? '';
-      const raw = await response.text();
+      // Read body with a size cap so a pathologically-large page can't exhaust
+      // memory (response.text() doesn't bound read size).
+      const reader = response.body?.getReader();
+      let raw = '';
+      if (reader) {
+        const decoder = new TextDecoder('utf-8');
+        let total = 0;
+        while (total < MAX_RAW_BYTES) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          total += value.byteLength;
+          raw += decoder.decode(value, { stream: true });
+          if (total >= MAX_RAW_BYTES) {
+            await reader.cancel();
+            break;
+          }
+        }
+        raw += decoder.decode();
+      } else {
+        raw = await response.text();
+      }
       const text = contentType.includes('html') ? htmlToText(raw) : raw;
       const capped = text.slice(0, MAX_TEXT_LENGTH);
       urlCache.set(url, { text: capped, timestamp: Date.now() });
       return capped;
     } catch (err) {
-      log.info('urlEnricher: fetch error', { url, error: String(err) });
+      log.info('urlEnricher: fetch error', { url: redactUrl(url), error: String(err) });
       return undefined;
+    } finally {
+      clearTimeout(timer);
     }
   }, []);
 

--- a/packages/plugins/plugin-slack/src/index.ts
+++ b/packages/plugins/plugin-slack/src/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export { meta } from './meta';
+export { SlackPlugin } from './SlackPlugin';

--- a/packages/plugins/plugin-slack/src/meta.ts
+++ b/packages/plugins/plugin-slack/src/meta.ts
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Plugin } from '@dxos/app-framework';
+import { trim } from '@dxos/util';
+
+export const meta: Plugin.Meta = {
+  id: 'org.dxos.plugin.slack',
+  name: 'Slack',
+  description: trim`
+    Slack channel integration for Composer Agent.
+    Connects your agent to Slack workspaces.
+  `,
+  icon: 'ph--slack-logo--regular',
+};

--- a/packages/plugins/plugin-slack/src/translations.ts
+++ b/packages/plugins/plugin-slack/src/translations.ts
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Resource } from '@dxos/react-ui';
+
+import { meta } from '#meta';
+
+export const translations = [
+  {
+    'en-US': {
+      [meta.id]: {
+        'plugin.name': 'Slack',
+        'settings-title.label': 'Slack Integration',
+        'bot-token.label': 'Bot Token',
+        'bot-token.placeholder': 'xoxb-...',
+        'test-connection.label': 'Test Connection',
+        'disconnect.label': 'Disconnect',
+        'channels-title.label': 'Monitored Channels',
+        'respond-mentions.label': 'Respond to @mentions',
+        'respond-dms.label': 'Respond to DMs',
+        'status-connected.label': 'Connected',
+        'status-disconnected.label': 'Not connected',
+        'status-error.label': 'Connection error',
+        'no-channels.message': 'Connect to load channels',
+      },
+    },
+  },
+] as const satisfies Resource[];

--- a/packages/plugins/plugin-slack/src/types/index.ts
+++ b/packages/plugins/plugin-slack/src/types/index.ts
@@ -1,0 +1,41 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Schema from 'effect/Schema';
+
+import { Capability } from '@dxos/app-framework';
+
+import { meta } from '#meta';
+
+/** Slack connection status. */
+export type SlackConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
+
+/** Slack channel info from the API. */
+export type SlackChannel = {
+  id: string;
+  name: string;
+  isMember: boolean;
+};
+
+/** Slack settings persisted per-plugin. */
+export namespace SlackCapabilities {
+  export const SettingsSchema = Schema.mutable(
+    Schema.Struct({
+      /** Bot token for Slack API access. */
+      botToken: Schema.optional(Schema.String),
+      /** Channels the agent monitors. */
+      monitoredChannels: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
+      /** Whether to respond to @mentions. */
+      respondToMentions: Schema.optional(Schema.Boolean),
+      /** Whether to respond to DMs. */
+      respondToDMs: Schema.optional(Schema.Boolean),
+    }),
+  );
+
+  export type Settings = Schema.Schema.Type<typeof SettingsSchema>;
+
+  export const Settings = Capability.make<import('@effect-atom/atom').Atom.Writable<Settings>>(
+    `${meta.id}.capability.settings`,
+  );
+}

--- a/packages/plugins/plugin-slack/tsconfig.json
+++ b/packages/plugins/plugin-slack/tsconfig.json
@@ -1,0 +1,77 @@
+{
+  "extends": [
+    "../../../tsconfig.base.json"
+  ],
+  "compilerOptions": {
+    "types": [
+      "node"
+    ]
+  },
+  "exclude": [
+    "*.t.ts"
+  ],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../../common/effect"
+    },
+    {
+      "path": "../../common/invariant"
+    },
+    {
+      "path": "../../common/keys"
+    },
+    {
+      "path": "../../common/log"
+    },
+    {
+      "path": "../../common/util"
+    },
+    {
+      "path": "../../core/blueprints"
+    },
+    {
+      "path": "../../core/echo/echo"
+    },
+    {
+      "path": "../../core/echo/echo-atom"
+    },
+    {
+      "path": "../../core/operation"
+    },
+    {
+      "path": "../../sdk/app-framework"
+    },
+    {
+      "path": "../../sdk/app-graph"
+    },
+    {
+      "path": "../../sdk/app-toolkit"
+    },
+    {
+      "path": "../../sdk/react-client"
+    },
+    {
+      "path": "../../sdk/types"
+    },
+    {
+      "path": "../../ui/react-ui"
+    },
+    {
+      "path": "../../ui/react-ui-components"
+    },
+    {
+      "path": "../../ui/ui-theme"
+    },
+    {
+      "path": "../plugin-assistant"
+    },
+    {
+      "path": "../plugin-graph"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Slack bot plugin — polls channels for messages, auto-responds to @mentions using workspace context search, supports blueprints for customizable agent behavior.

- **SlackFeed** — real-time channel polling with thread tracking
- **Blueprints** — morning briefing, triage, Slack responder
- **useSlackMessages** — React hook for Slack API polling with mention detection
- Channel name → ID resolution for flexible configuration

### Architecture notes

This plugin's real-time polling model differs from plugin-inbox's sync-operation pattern. Slack messages are consumed as a live feed rather than batch-synced. The blueprint system enables agent-driven responses with configurable prompts.

### Known TODOs for follow-up
- [ ] Move credential storage to AccessToken ref pattern
- [ ] Replace custom DOM in SlackFeed with Composer UI primitives
- [ ] Consider Effect-based API client (currently uses raw fetch)
- [ ] Foreign keys for message/thread identity

## Test plan
- [x] Build passes
- [x] Verified with real Slack workspace (Blue Yard / @composerclaw)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack plugin to connect workspaces, manage bot token, and select monitored channels
  * Slack feed UI showing monitored conversations with streaming AI-generated replies and manual reply controls
  * Configurable auto-response settings for mentions and direct messages with test/disconnect flows
  * Five built-in AI blueprints: Morning Briefing, Email Triage, Meeting Prep, Slack Responder, Research Digest
<!-- end of auto-generated comment: release notes by coderabbit.ai -->