### PR TITLE
feat(plugin-linear): Linear issue tracker integration with native Task mapping

### DIFF
--- a/packages/plugins/plugin-linear/moon.yml
+++ b/packages/plugins/plugin-linear/moon.yml
@@ -1,0 +1,10 @@
+layer: library
+language: typescript
+tags:
+  - ts-build
+  - pack
+tasks:
+  compile:
+    args:
+      - '--entryPoint=src/index.ts'
+      - '--entryPoint=src/types/index.ts'

--- a/packages/plugins/plugin-linear/package.json
+++ b/packages/plugins/plugin-linear/package.json
@@ -57,7 +57,6 @@
     "@dxos/log": "workspace:*",
     "@dxos/plugin-client": "workspace:*",
     "@dxos/plugin-kanban": "workspace:*",
-    "@dxos/plugin-space": "workspace:*",
     "@dxos/schema": "workspace:*",
     "@dxos/types": "workspace:*",
     "@dxos/util": "workspace:*",

--- a/packages/plugins/plugin-linear/package.json
+++ b/packages/plugins/plugin-linear/package.json
@@ -55,6 +55,7 @@
     "@dxos/app-toolkit": "workspace:*",
     "@dxos/echo": "workspace:*",
     "@dxos/log": "workspace:*",
+    "@dxos/types": "workspace:*",
     "@dxos/util": "workspace:*",
     "effect": "catalog:"
   },

--- a/packages/plugins/plugin-linear/package.json
+++ b/packages/plugins/plugin-linear/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@dxos/plugin-linear",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Linear integration plugin — surface issues, teams, and project state inside Composer.",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dxos/dxos"
+  },
+  "license": "MIT",
+  "author": "DXOS.org",
+  "sideEffects": true,
+  "type": "module",
+  "imports": {
+    "#capabilities": "./src/capabilities/index.ts",
+    "#meta": "./src/meta.ts",
+    "#types": "./src/types/index.ts"
+  },
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/types/src/index.d.ts",
+      "browser": "./dist/lib/browser/index.mjs"
+    },
+    "./meta": {
+      "source": "./src/meta.ts",
+      "types": "./dist/types/src/meta.d.ts",
+      "browser": "./dist/lib/browser/meta.mjs"
+    },
+    "./types": {
+      "source": "./src/types/index.ts",
+      "types": "./dist/types/src/types/index.d.ts",
+      "browser": "./dist/lib/browser/types/index.mjs"
+    }
+  },
+  "types": "dist/types/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "meta": [
+        "dist/types/src/meta.d.ts"
+      ],
+      "types": [
+        "dist/types/src/types/index.d.ts"
+      ]
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@dxos/app-framework": "workspace:*",
+    "@dxos/app-toolkit": "workspace:*",
+    "@dxos/echo": "workspace:*",
+    "@dxos/log": "workspace:*",
+    "@dxos/util": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "react": "catalog:"
+  },
+  "peerDependencies": {
+    "react": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugins/plugin-linear/package.json
+++ b/packages/plugins/plugin-linear/package.json
@@ -55,6 +55,10 @@
     "@dxos/app-toolkit": "workspace:*",
     "@dxos/echo": "workspace:*",
     "@dxos/log": "workspace:*",
+    "@dxos/plugin-client": "workspace:*",
+    "@dxos/plugin-kanban": "workspace:*",
+    "@dxos/plugin-space": "workspace:*",
+    "@dxos/schema": "workspace:*",
     "@dxos/types": "workspace:*",
     "@dxos/util": "workspace:*",
     "effect": "catalog:"

--- a/packages/plugins/plugin-linear/src/LinearPlugin.tsx
+++ b/packages/plugins/plugin-linear/src/LinearPlugin.tsx
@@ -1,0 +1,57 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+/**
+ * Linear plugin — minimal scaffold.
+ *
+ * Today: registers schemas (LinearWorkspace, LinearTeam, LinearIssue) so
+ * Linear data can live in a DXOS space alongside Granola, Trello, GitHub,
+ * and Slack. Exports a browser-side GraphQL client (`fetchRecentIssues`,
+ * `whoAmI`) that any other plugin or demo script can drive.
+ *
+ * Intentionally left small — the purpose of this scaffold is to show that
+ * adding a new work-tool integration to Composer is a weekend project,
+ * not a months-long rewrite. Bigger features (real-time sync, blueprint
+ * tools, triage UI) will land as follow-ups.
+ */
+
+import * as Option from 'effect/Option';
+
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+import { Annotation } from '@dxos/echo';
+
+import { meta } from './meta';
+import { translations } from './translations';
+import { Linear } from './types';
+
+export const LinearPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addMetadataModule({
+    metadata: [
+      {
+        id: Linear.LinearIssue.typename,
+        metadata: {
+          icon: Annotation.IconAnnotation.get(Linear.LinearIssue).pipe(Option.getOrThrow).icon,
+          iconHue: Annotation.IconAnnotation.get(Linear.LinearIssue).pipe(Option.getOrThrow).hue ?? 'violet',
+        },
+      },
+      {
+        id: Linear.LinearTeam.typename,
+        metadata: {
+          icon: Annotation.IconAnnotation.get(Linear.LinearTeam).pipe(Option.getOrThrow).icon,
+          iconHue: Annotation.IconAnnotation.get(Linear.LinearTeam).pipe(Option.getOrThrow).hue ?? 'violet',
+        },
+      },
+      {
+        id: Linear.LinearWorkspace.typename,
+        metadata: {
+          icon: Annotation.IconAnnotation.get(Linear.LinearWorkspace).pipe(Option.getOrThrow).icon,
+          iconHue: Annotation.IconAnnotation.get(Linear.LinearWorkspace).pipe(Option.getOrThrow).hue ?? 'violet',
+        },
+      },
+    ],
+  }),
+  AppPlugin.addTranslationsModule({ translations }),
+  Plugin.make,
+);

--- a/packages/plugins/plugin-linear/src/LinearPlugin.tsx
+++ b/packages/plugins/plugin-linear/src/LinearPlugin.tsx
@@ -7,10 +7,13 @@ import * as Option from 'effect/Option';
 import { Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
 import { Annotation } from '@dxos/echo';
+import { SpaceEvents } from '@dxos/plugin-space/types';
 
-import { meta } from './meta';
+import { AutoSync } from '#capabilities';
+import { meta } from '#meta';
+import { Linear } from '#types';
+
 import { translations } from './translations';
-import { Linear } from './types';
 
 export const LinearPlugin = Plugin.define(meta).pipe(
   AppPlugin.addMetadataModule({
@@ -32,5 +35,10 @@ export const LinearPlugin = Plugin.define(meta).pipe(
     ],
   }),
   AppPlugin.addTranslationsModule({ translations }),
+  Plugin.addModule({
+    id: 'auto-sync',
+    activatesOn: SpaceEvents.PersonalSpaceReady,
+    activate: AutoSync,
+  }),
   Plugin.make,
 );

--- a/packages/plugins/plugin-linear/src/LinearPlugin.tsx
+++ b/packages/plugins/plugin-linear/src/LinearPlugin.tsx
@@ -2,20 +2,6 @@
 // Copyright 2026 DXOS.org
 //
 
-/**
- * Linear plugin — minimal scaffold.
- *
- * Today: registers schemas (LinearWorkspace, LinearTeam, LinearIssue) so
- * Linear data can live in a DXOS space alongside Granola, Trello, GitHub,
- * and Slack. Exports a browser-side GraphQL client (`fetchRecentIssues`,
- * `whoAmI`) that any other plugin or demo script can drive.
- *
- * Intentionally left small — the purpose of this scaffold is to show that
- * adding a new work-tool integration to Composer is a weekend project,
- * not a months-long rewrite. Bigger features (real-time sync, blueprint
- * tools, triage UI) will land as follow-ups.
- */
-
 import * as Option from 'effect/Option';
 
 import { Plugin } from '@dxos/app-framework';
@@ -29,13 +15,6 @@ import { Linear } from './types';
 export const LinearPlugin = Plugin.define(meta).pipe(
   AppPlugin.addMetadataModule({
     metadata: [
-      {
-        id: Linear.LinearIssue.typename,
-        metadata: {
-          icon: Annotation.IconAnnotation.get(Linear.LinearIssue).pipe(Option.getOrThrow).icon,
-          iconHue: Annotation.IconAnnotation.get(Linear.LinearIssue).pipe(Option.getOrThrow).hue ?? 'violet',
-        },
-      },
       {
         id: Linear.LinearTeam.typename,
         metadata: {

--- a/packages/plugins/plugin-linear/src/LinearPlugin.tsx
+++ b/packages/plugins/plugin-linear/src/LinearPlugin.tsx
@@ -4,10 +4,9 @@
 
 import * as Option from 'effect/Option';
 
-import { Plugin } from '@dxos/app-framework';
+import { ActivationEvents, Plugin } from '@dxos/app-framework';
 import { AppPlugin } from '@dxos/app-toolkit';
 import { Annotation } from '@dxos/echo';
-import { SpaceEvents } from '@dxos/plugin-space/types';
 
 import { AutoSync } from '#capabilities';
 import { meta } from '#meta';
@@ -37,7 +36,7 @@ export const LinearPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.addModule({
     id: 'auto-sync',
-    activatesOn: SpaceEvents.PersonalSpaceReady,
+    activatesOn: ActivationEvents.Startup,
     activate: AutoSync,
   }),
   Plugin.make,

--- a/packages/plugins/plugin-linear/src/capabilities/auto-sync.ts
+++ b/packages/plugins/plugin-linear/src/capabilities/auto-sync.ts
@@ -1,0 +1,107 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capability } from '@dxos/app-framework';
+import { Filter, Obj } from '@dxos/echo';
+import { log } from '@dxos/log';
+import { ClientCapabilities } from '@dxos/plugin-client/types';
+import { Kanban } from '@dxos/plugin-kanban/types';
+import { ViewModel } from '@dxos/schema';
+import { Task } from '@dxos/types';
+
+import { fetchRecentIssues, readLinearAuth } from './linear-client';
+
+const LINEAR_SOURCE = 'linear.app';
+const SYNC_INTERVAL_MS = 5 * 60 * 1000;
+const KANBAN_NAME = 'Linear Issues';
+
+const getLinearId = (obj: Task.Task): string | undefined => {
+  const keys = Obj.getMeta(obj).keys;
+  return keys?.find((key) => key.source === LINEAR_SOURCE)?.id;
+};
+
+const syncOnce = async (client: { spaces: { get: () => any[] } }): Promise<void> => {
+  const auth = readLinearAuth();
+  if (!auth) {
+    return;
+  }
+
+  const space = client.spaces.get()[0];
+  if (!space) {
+    return;
+  }
+
+  const remoteTasks = await fetchRecentIssues(auth);
+  const existingTasks: Task.Task[] = await space.db.query(Filter.type(Task.Task)).run();
+  const existingLinearIds = new Set<string>();
+  for (const task of existingTasks) {
+    const linearId = getLinearId(task);
+    if (linearId) {
+      existingLinearIds.add(linearId);
+    }
+  }
+
+  let added = 0;
+  for (const task of remoteTasks) {
+    const linearId = getLinearId(task);
+    if (linearId && existingLinearIds.has(linearId)) {
+      continue;
+    }
+    space.db.add(task);
+    added++;
+  }
+
+  if (added > 0) {
+    log.info('linear: synced issues', { added, total: remoteTasks.length });
+  }
+
+  const existingKanbans: Kanban.Kanban[] = await space.db.query(Filter.type(Kanban.Kanban)).run();
+  const hasLinearKanban = existingKanbans.some((kanban) => kanban.name === KANBAN_NAME);
+  if (!hasLinearKanban) {
+    try {
+      const { view } = await ViewModel.makeFromDatabase({
+        db: space.db,
+        typename: 'org.dxos.type.task',
+        pivotFieldName: 'status',
+        fields: ['title', 'status', 'priority', 'description'],
+        createInitial: 0,
+      });
+      const kanban = Kanban.make({
+        name: KANBAN_NAME,
+        view,
+        arrangement: { order: ['todo', 'in-progress', 'done'], columns: {} },
+      });
+      space.db.add(kanban);
+      log.info('linear: created kanban board');
+    } catch (error) {
+      log.warn('linear: failed to create kanban', { error: error instanceof Error ? error.message : String(error) });
+    }
+  }
+};
+
+export default Capability.makeModule(
+  Effect.fnUntraced(function* () {
+    const client = yield* Capability.get(ClientCapabilities.Client);
+
+    yield* Effect.tryPromise({
+      try: async () => {
+        await syncOnce(client);
+
+        setInterval(async () => {
+          try {
+            await syncOnce(client);
+          } catch (error) {
+            log.warn('linear: periodic sync failed', { error: error instanceof Error ? error.message : String(error) });
+          }
+        }, SYNC_INTERVAL_MS);
+      },
+      catch: (error: unknown) => {
+        log.warn('linear: initial sync failed', { error: error instanceof Error ? error.message : String(error) });
+        return new Error(error instanceof Error ? error.message : String(error));
+      },
+    });
+  }),
+);

--- a/packages/plugins/plugin-linear/src/capabilities/auto-sync.ts
+++ b/packages/plugins/plugin-linear/src/capabilities/auto-sync.ts
@@ -5,17 +5,18 @@
 import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
-import { Collection, Database, Filter, Obj, Ref } from '@dxos/echo';
+import { Collection, Filter, Obj, Ref } from '@dxos/echo';
 import { log } from '@dxos/log';
 import { ClientCapabilities } from '@dxos/plugin-client/types';
 import { Kanban } from '@dxos/plugin-kanban/types';
-import { CollectionModel, ViewModel } from '@dxos/schema';
+import { ViewModel } from '@dxos/schema';
 import { Task } from '@dxos/types';
 
-import { fetchRecentIssues, readLinearAuth } from './linear-client';
+import { fetchRecentIssues, readLinearAuth, updateIssue } from './linear-client';
 
 const LINEAR_SOURCE = 'linear.app';
 const SYNC_INTERVAL_MS = 5 * 60 * 1000;
+const WRITE_BACK_INTERVAL_MS = 10_000;
 const KANBAN_NAME = 'Linear Issues';
 
 const getLinearId = (obj: Task.Task): string | undefined => {
@@ -23,17 +24,14 @@ const getLinearId = (obj: Task.Task): string | undefined => {
   return keys?.find((key) => key.source === LINEAR_SOURCE)?.id;
 };
 
-const syncOnce = async (client: { spaces: { get: () => any[] } }): Promise<void> => {
-  const auth = readLinearAuth();
-  if (!auth) {
-    return;
+const addToRootCollection = (space: any, obj: any): void => {
+  const rootCollection = space.properties[Collection.Collection.typename]?.target;
+  if (rootCollection) {
+    Obj.change(rootCollection, (c: any) => { c.objects.push(Ref.make(obj)); });
   }
+};
 
-  const space = client.spaces.get()[0];
-  if (!space) {
-    return;
-  }
-
+const syncOnce = async (space: any, auth: { apiKey: string }): Promise<void> => {
   const remoteTasks = await fetchRecentIssues(auth);
   const existingTasks: Task.Task[] = await space.db.query(Filter.type(Task.Task)).run();
   const existingLinearIds = new Set<string>();
@@ -50,19 +48,17 @@ const syncOnce = async (client: { spaces: { get: () => any[] } }): Promise<void>
     if (linearId && existingLinearIds.has(linearId)) {
       continue;
     }
-    await Effect.runPromise(
-      CollectionModel.add({ object: task }).pipe(Effect.provide(Database.layer(space.db))),
-    );
+    space.db.add(task);
+    addToRootCollection(space, task);
     added++;
   }
 
   if (added > 0) {
-    console.log('linear: synced issues', { added, total: remoteTasks.length });
+    log.info('linear: synced issues', { added, total: remoteTasks.length });
   }
 
   const existingKanbans: Kanban.Kanban[] = await space.db.query(Filter.type(Kanban.Kanban)).run();
-  const hasLinearKanban = existingKanbans.some((kanban) => kanban.name === KANBAN_NAME);
-  if (!hasLinearKanban) {
+  if (!existingKanbans.some((kanban: any) => kanban.name === KANBAN_NAME)) {
     try {
       const { view } = await ViewModel.makeFromDatabase({
         db: space.db,
@@ -76,14 +72,59 @@ const syncOnce = async (client: { spaces: { get: () => any[] } }): Promise<void>
         view,
         arrangement: { order: ['todo', 'in-progress', 'done'], columns: {} },
       });
-      await Effect.runPromise(
-        CollectionModel.add({ object: kanban }).pipe(Effect.provide(Database.layer(space.db))),
-      );
-      console.log('linear: created kanban board');
+      space.db.add(kanban);
+      addToRootCollection(space, kanban);
+      log.info('linear: created kanban board');
     } catch (error) {
       log.warn('linear: failed to create kanban', { error: error instanceof Error ? error.message : String(error) });
     }
   }
+};
+
+const startWriteBack = (space: any, auth: { apiKey: string }): void => {
+  const snapshots = new Map<string, { status?: string; priority?: string; title?: string }>();
+
+  void (async () => {
+    const tasks: Task.Task[] = await space.db.query(Filter.type(Task.Task)).run();
+    for (const task of tasks) {
+      if (getLinearId(task)) {
+        snapshots.set(task.id, { status: task.status, priority: task.priority, title: task.title });
+      }
+    }
+  })();
+
+  setInterval(async () => {
+    try {
+      const tasks: Task.Task[] = await space.db.query(Filter.type(Task.Task)).run();
+      for (const task of tasks) {
+        const linearId = getLinearId(task);
+        if (!linearId) {
+          continue;
+        }
+        const prev = snapshots.get(task.id);
+        if (!prev) {
+          snapshots.set(task.id, { status: task.status, priority: task.priority, title: task.title });
+          continue;
+        }
+        const changes: Record<string, string | undefined> = {};
+        if (task.status !== prev.status) {
+          changes.status = task.status;
+        }
+        if (task.priority !== prev.priority) {
+          changes.priority = task.priority;
+        }
+        if (task.title !== prev.title) {
+          changes.title = task.title;
+        }
+        if (Object.keys(changes).length > 0) {
+          await updateIssue(auth, linearId, changes);
+          snapshots.set(task.id, { status: task.status, priority: task.priority, title: task.title });
+        }
+      }
+    } catch (error) {
+      log.warn('linear: write-back failed', { error: error instanceof Error ? error.message : String(error) });
+    }
+  }, WRITE_BACK_INTERVAL_MS);
 };
 
 const waitForSpace = async (client: any, maxWait = 30_000): Promise<any> => {
@@ -100,32 +141,33 @@ const waitForSpace = async (client: any, maxWait = 30_000): Promise<any> => {
 
 export default Capability.makeModule(
   Effect.fnUntraced(function* () {
-    console.log('linear: auto-sync module loaded');
+    const auth = readLinearAuth();
+    if (!auth) {
+      return;
+    }
 
     const client = yield* Capability.get(ClientCapabilities.Client);
-    console.log('linear: got client');
 
     yield* Effect.tryPromise({
       try: async () => {
         const space = await waitForSpace(client);
         if (!space) {
-          console.warn('linear: no space found after waiting');
           return;
         }
-        console.log('linear: space ready, starting sync');
 
-        await syncOnce(client);
+        await syncOnce(space, auth);
+        startWriteBack(space, auth);
 
         setInterval(async () => {
           try {
-            await syncOnce(client);
+            await syncOnce(space, auth);
           } catch (error) {
             log.warn('linear: periodic sync failed', { error: error instanceof Error ? error.message : String(error) });
           }
         }, SYNC_INTERVAL_MS);
       },
       catch: (error: unknown) => {
-        console.error('linear: initial sync failed', error instanceof Error ? error.message : String(error));
+        log.warn('linear: sync failed', { error: error instanceof Error ? error.message : String(error) });
         return new Error(error instanceof Error ? error.message : String(error));
       },
     });

--- a/packages/plugins/plugin-linear/src/capabilities/auto-sync.ts
+++ b/packages/plugins/plugin-linear/src/capabilities/auto-sync.ts
@@ -31,30 +31,61 @@ const addToRootCollection = (space: any, obj: any): void => {
   }
 };
 
-const syncOnce = async (space: any, auth: { apiKey: string }): Promise<void> => {
+const syncOnce = async (
+  space: any,
+  auth: { apiKey: string },
+  snapshots: Map<string, { status?: string; priority?: string; title?: string }>,
+): Promise<void> => {
   const remoteTasks = await fetchRecentIssues(auth);
   const existingTasks: Task.Task[] = await space.db.query(Filter.type(Task.Task)).run();
-  const existingLinearIds = new Set<string>();
+  const existingByLinearId = new Map<string, Task.Task>();
   for (const task of existingTasks) {
     const linearId = getLinearId(task);
     if (linearId) {
-      existingLinearIds.add(linearId);
+      existingByLinearId.set(linearId, task);
     }
   }
 
   let added = 0;
-  for (const task of remoteTasks) {
-    const linearId = getLinearId(task);
-    if (linearId && existingLinearIds.has(linearId)) {
+  let updated = 0;
+  for (const remote of remoteTasks) {
+    const linearId = getLinearId(remote);
+    if (!linearId) {
       continue;
     }
-    space.db.add(task);
-    addToRootCollection(space, task);
-    added++;
+    const existing = existingByLinearId.get(linearId);
+    if (!existing) {
+      space.db.add(remote);
+      addToRootCollection(space, remote);
+      added++;
+      continue;
+    }
+    // Pull remote-side edits into the existing Composer Task. Apply change
+    // only when the field differs so we avoid firing spurious mutations.
+    let changed = false;
+    Obj.change(existing, (mutable: Task.Task) => {
+      if (mutable.title !== remote.title) { mutable.title = remote.title; changed = true; }
+      if (mutable.description !== remote.description) {
+        mutable.description = remote.description;
+        changed = true;
+      }
+      if (mutable.status !== remote.status) { mutable.status = remote.status; changed = true; }
+      if (mutable.priority !== remote.priority) { mutable.priority = remote.priority; changed = true; }
+    });
+    if (changed) {
+      updated++;
+      // Refresh the write-back baseline so the remote update we just applied
+      // isn't echoed back as a local edit on the next write-back tick.
+      snapshots.set(existing.id, {
+        status: existing.status,
+        priority: existing.priority,
+        title: existing.title,
+      });
+    }
   }
 
-  if (added > 0) {
-    log.info('linear: synced issues', { added, total: remoteTasks.length });
+  if (added > 0 || updated > 0) {
+    log.info('linear: synced issues', { added, updated, total: remoteTasks.length });
   }
 
   const existingKanbans: Kanban.Kanban[] = await space.db.query(Filter.type(Kanban.Kanban)).run();
@@ -81,9 +112,11 @@ const syncOnce = async (space: any, auth: { apiKey: string }): Promise<void> => 
   }
 };
 
-const startWriteBack = (space: any, auth: { apiKey: string }): void => {
-  const snapshots = new Map<string, { status?: string; priority?: string; title?: string }>();
-
+const startWriteBack = (
+  space: any,
+  auth: { apiKey: string },
+  snapshots: Map<string, { status?: string; priority?: string; title?: string }>,
+): ReturnType<typeof setInterval> => {
   void (async () => {
     const tasks: Task.Task[] = await space.db.query(Filter.type(Task.Task)).run();
     for (const task of tasks) {
@@ -93,7 +126,7 @@ const startWriteBack = (space: any, auth: { apiKey: string }): void => {
     }
   })();
 
-  setInterval(async () => {
+  return setInterval(async () => {
     try {
       const tasks: Task.Task[] = await space.db.query(Filter.type(Task.Task)).run();
       for (const task of tasks) {
@@ -148,6 +181,12 @@ export default Capability.makeModule(
 
     const client = yield* Capability.get(ClientCapabilities.Client);
 
+    // Track every timer we start so the addFinalizer below can cancel them on
+    // capability teardown (HMR, sign-out, plugin disable). Without this the
+    // intervals keep firing against a disposed space.
+    const snapshots = new Map<string, { status?: string; priority?: string; title?: string }>();
+    const timers: ReturnType<typeof setInterval>[] = [];
+
     yield* Effect.tryPromise({
       try: async () => {
         const space = await waitForSpace(client);
@@ -155,21 +194,32 @@ export default Capability.makeModule(
           return;
         }
 
-        await syncOnce(space, auth);
-        startWriteBack(space, auth);
+        await syncOnce(space, auth, snapshots);
+        timers.push(startWriteBack(space, auth, snapshots));
 
-        setInterval(async () => {
-          try {
-            await syncOnce(space, auth);
-          } catch (error) {
-            log.warn('linear: periodic sync failed', { error: error instanceof Error ? error.message : String(error) });
-          }
-        }, SYNC_INTERVAL_MS);
+        timers.push(
+          setInterval(async () => {
+            try {
+              await syncOnce(space, auth, snapshots);
+            } catch (error) {
+              log.warn('linear: periodic sync failed', { error: error instanceof Error ? error.message : String(error) });
+            }
+          }, SYNC_INTERVAL_MS),
+        );
       },
       catch: (error: unknown) => {
         log.warn('linear: sync failed', { error: error instanceof Error ? error.message : String(error) });
         return new Error(error instanceof Error ? error.message : String(error));
       },
     });
+
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        for (const timer of timers) {
+          clearInterval(timer);
+        }
+        log.info('linear: sync capability torn down', { timers: timers.length });
+      }),
+    );
   }),
 );

--- a/packages/plugins/plugin-linear/src/capabilities/auto-sync.ts
+++ b/packages/plugins/plugin-linear/src/capabilities/auto-sync.ts
@@ -5,11 +5,11 @@
 import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
-import { Filter, Obj } from '@dxos/echo';
+import { Collection, Database, Filter, Obj, Ref } from '@dxos/echo';
 import { log } from '@dxos/log';
 import { ClientCapabilities } from '@dxos/plugin-client/types';
 import { Kanban } from '@dxos/plugin-kanban/types';
-import { ViewModel } from '@dxos/schema';
+import { CollectionModel, ViewModel } from '@dxos/schema';
 import { Task } from '@dxos/types';
 
 import { fetchRecentIssues, readLinearAuth } from './linear-client';
@@ -50,12 +50,14 @@ const syncOnce = async (client: { spaces: { get: () => any[] } }): Promise<void>
     if (linearId && existingLinearIds.has(linearId)) {
       continue;
     }
-    space.db.add(task);
+    await Effect.runPromise(
+      CollectionModel.add({ object: task }).pipe(Effect.provide(Database.layer(space.db))),
+    );
     added++;
   }
 
   if (added > 0) {
-    log.info('linear: synced issues', { added, total: remoteTasks.length });
+    console.log('linear: synced issues', { added, total: remoteTasks.length });
   }
 
   const existingKanbans: Kanban.Kanban[] = await space.db.query(Filter.type(Kanban.Kanban)).run();
@@ -74,20 +76,44 @@ const syncOnce = async (client: { spaces: { get: () => any[] } }): Promise<void>
         view,
         arrangement: { order: ['todo', 'in-progress', 'done'], columns: {} },
       });
-      space.db.add(kanban);
-      log.info('linear: created kanban board');
+      await Effect.runPromise(
+        CollectionModel.add({ object: kanban }).pipe(Effect.provide(Database.layer(space.db))),
+      );
+      console.log('linear: created kanban board');
     } catch (error) {
       log.warn('linear: failed to create kanban', { error: error instanceof Error ? error.message : String(error) });
     }
   }
 };
 
+const waitForSpace = async (client: any, maxWait = 30_000): Promise<any> => {
+  const start = Date.now();
+  while (Date.now() - start < maxWait) {
+    const spaces = client.spaces.get();
+    if (spaces.length > 0) {
+      return spaces[0];
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  return undefined;
+};
+
 export default Capability.makeModule(
   Effect.fnUntraced(function* () {
+    console.log('linear: auto-sync module loaded');
+
     const client = yield* Capability.get(ClientCapabilities.Client);
+    console.log('linear: got client');
 
     yield* Effect.tryPromise({
       try: async () => {
+        const space = await waitForSpace(client);
+        if (!space) {
+          console.warn('linear: no space found after waiting');
+          return;
+        }
+        console.log('linear: space ready, starting sync');
+
         await syncOnce(client);
 
         setInterval(async () => {
@@ -99,7 +125,7 @@ export default Capability.makeModule(
         }, SYNC_INTERVAL_MS);
       },
       catch: (error: unknown) => {
-        log.warn('linear: initial sync failed', { error: error instanceof Error ? error.message : String(error) });
+        console.error('linear: initial sync failed', error instanceof Error ? error.message : String(error));
         return new Error(error instanceof Error ? error.message : String(error));
       },
     });

--- a/packages/plugins/plugin-linear/src/capabilities/index.ts
+++ b/packages/plugins/plugin-linear/src/capabilities/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './linear-client';

--- a/packages/plugins/plugin-linear/src/capabilities/index.ts
+++ b/packages/plugins/plugin-linear/src/capabilities/index.ts
@@ -2,4 +2,5 @@
 // Copyright 2026 DXOS.org
 //
 
+export { default as AutoSync } from './auto-sync';
 export * from './linear-client';

--- a/packages/plugins/plugin-linear/src/capabilities/index.ts
+++ b/packages/plugins/plugin-linear/src/capabilities/index.ts
@@ -2,5 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
-export { default as AutoSync } from './auto-sync';
+import { Capability } from '@dxos/app-framework';
+
+export const AutoSync = Capability.lazy('AutoSync', () => import('./auto-sync'));
 export * from './linear-client';

--- a/packages/plugins/plugin-linear/src/capabilities/linear-client.ts
+++ b/packages/plugins/plugin-linear/src/capabilities/linear-client.ts
@@ -1,0 +1,114 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+/**
+ * Minimal Linear GraphQL client — enough to fetch recent issues for the
+ * demo. Designed to be called from browser code; authentication is a
+ * personal API key pulled from localStorage (`LINEAR_API_KEY`).
+ *
+ * Linear's GraphQL endpoint supports CORS for direct browser calls with
+ * the Authorization header, so no dev-proxy is needed.
+ */
+
+import { Obj } from '@dxos/echo';
+import { log } from '@dxos/log';
+
+import { Linear } from '../types';
+
+const LINEAR_GRAPHQL = 'https://api.linear.app/graphql';
+
+export type LinearAuth = { readonly apiKey: string };
+
+export const readLinearAuth = (): LinearAuth | undefined => {
+  const apiKey = globalThis.localStorage?.getItem('LINEAR_API_KEY');
+  if (!apiKey) {
+    return undefined;
+  }
+  return { apiKey };
+};
+
+const graphql = async <T>(auth: LinearAuth, query: string, variables?: Record<string, unknown>): Promise<T> => {
+  const response = await fetch(LINEAR_GRAPHQL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: auth.apiKey,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const body = (await response.json()) as { data?: T; errors?: { message: string }[] };
+  if (!response.ok || body.errors) {
+    const message = body.errors?.map((entry) => entry.message).join('; ') ?? `linear ${response.status}`;
+    throw new Error(message);
+  }
+  if (!body.data) {
+    throw new Error('linear: empty response');
+  }
+  return body.data;
+};
+
+type RecentIssuesResponse = {
+  issues: {
+    nodes: {
+      id: string;
+      identifier: string;
+      title: string;
+      description: string | null;
+      updatedAt: string;
+      state: { name: string } | null;
+      team: { key: string } | null;
+      assignee: { displayName: string } | null;
+      labels: { nodes: { name: string }[] } | null;
+    }[];
+  };
+};
+
+/**
+ * Fetch the most recently updated issues across the workspace, limited to
+ * `first`. Shaped for the demo's "activity feed" angle — no pagination.
+ */
+export const fetchRecentIssues = async (
+  auth: LinearAuth,
+  first = 25,
+): Promise<Linear.LinearIssue[]> => {
+  const query = `
+    query RecentIssues($first: Int!) {
+      issues(first: $first, orderBy: updatedAt) {
+        nodes {
+          id
+          identifier
+          title
+          description
+          updatedAt
+          state { name }
+          team { key }
+          assignee { displayName }
+          labels { nodes { name } }
+        }
+      }
+    }
+  `;
+  const data = await graphql<RecentIssuesResponse>(auth, query, { first });
+  return data.issues.nodes.map((issue) =>
+    Obj.make(Linear.LinearIssue, {
+      linearIssueId: issue.id,
+      identifier: issue.identifier,
+      title: issue.title,
+      description: issue.description ?? undefined,
+      state: issue.state?.name?.toLowerCase(),
+      teamKey: issue.team?.key,
+      assignee: issue.assignee?.displayName,
+      updatedAt: issue.updatedAt,
+      labels: (issue.labels?.nodes ?? []).map((entry) => entry.name),
+    }),
+  );
+};
+
+/** One-shot auth check — returns the viewer's display name on success. */
+export const whoAmI = async (auth: LinearAuth): Promise<string> => {
+  type Response = { viewer: { displayName: string } };
+  const data = await graphql<Response>(auth, 'query { viewer { displayName } }');
+  log.info('linear: authenticated', { viewer: data.viewer.displayName });
+  return data.viewer.displayName;
+};

--- a/packages/plugins/plugin-linear/src/capabilities/linear-client.ts
+++ b/packages/plugins/plugin-linear/src/capabilities/linear-client.ts
@@ -131,6 +131,84 @@ export const fetchRecentIssues = async (
   );
 };
 
+/** Reverse-map Composer Task status back to Linear workflow state name. */
+const reverseMapStatus = (status: string | undefined): string | undefined => {
+  switch (status) {
+    case 'done': return 'Done';
+    case 'in-progress': return 'In Progress';
+    case 'todo': return 'Todo';
+    default: return undefined;
+  }
+};
+
+/** Reverse-map Composer Task priority back to Linear priority number. */
+const reverseMapPriority = (priority: string | undefined): number | undefined => {
+  switch (priority) {
+    case 'urgent': return 1;
+    case 'high': return 2;
+    case 'medium': return 3;
+    case 'low': return 4;
+    case 'none': return 0;
+    default: return undefined;
+  }
+};
+
+/** Update a Linear issue's status and/or priority. */
+export const updateIssue = async (
+  auth: LinearAuth,
+  issueId: string,
+  updates: { status?: string; priority?: string; title?: string },
+): Promise<void> => {
+  const input: Record<string, unknown> = {};
+
+  if (updates.priority !== undefined) {
+    const mapped = reverseMapPriority(updates.priority);
+    if (mapped !== undefined) {
+      input.priority = mapped;
+    }
+  }
+
+  if (updates.title !== undefined) {
+    const raw = updates.title.replace(/^\[[\w-]+\]\s*/, '');
+    input.title = raw;
+  }
+
+  if (updates.status !== undefined) {
+    const stateName = reverseMapStatus(updates.status);
+    if (stateName) {
+      const statesQuery = `
+        query IssueStates($issueId: String!) {
+          issue(id: $issueId) {
+            team { states { nodes { id name } } }
+          }
+        }
+      `;
+      type StatesResponse = { issue: { team: { states: { nodes: { id: string; name: string }[] } } } };
+      const statesData = await graphql<StatesResponse>(auth, statesQuery, { issueId });
+      const stateNode = statesData.issue.team.states.nodes.find(
+        (s) => s.name.toLowerCase() === stateName.toLowerCase(),
+      );
+      if (stateNode) {
+        input.stateId = stateNode.id;
+      }
+    }
+  }
+
+  if (Object.keys(input).length === 0) {
+    return;
+  }
+
+  const mutation = `
+    mutation UpdateIssue($issueId: String!, $input: IssueUpdateInput!) {
+      issueUpdate(id: $issueId, input: $input) {
+        success
+      }
+    }
+  `;
+  await graphql<{ issueUpdate: { success: boolean } }>(auth, mutation, { issueId, input });
+  log.info('linear: updated issue', { issueId, input });
+};
+
 /** One-shot auth check — returns the viewer's display name on success. */
 export const whoAmI = async (auth: LinearAuth): Promise<string> => {
   type Response = { viewer: { displayName: string } };

--- a/packages/plugins/plugin-linear/src/capabilities/linear-client.ts
+++ b/packages/plugins/plugin-linear/src/capabilities/linear-client.ts
@@ -20,6 +20,9 @@ const LINEAR_GRAPHQL = 'https://api.linear.app/graphql';
 export type LinearAuth = { readonly apiKey: string };
 
 export const readLinearAuth = (): LinearAuth | undefined => {
+  // TODO(linear): migrate to the AccessToken/credential-store pattern used by
+  // plugin-inbox so the API key isn't exposed to XSS via localStorage. Tracked
+  // in plans/adopt-access-token-for-sync-plugins.md.
   const apiKey = globalThis.localStorage?.getItem('LINEAR_API_KEY');
   if (!apiKey) {
     return undefined;
@@ -36,7 +39,18 @@ const graphql = async <T>(auth: LinearAuth, query: string, variables?: Record<st
     },
     body: JSON.stringify({ query, variables }),
   });
-  const body = (await response.json()) as { data?: T; errors?: { message: string }[] };
+  // Read body as text first so a non-JSON error page (rate-limit HTML, proxy,
+  // auth gateway) surfaces the real HTTP status instead of a SyntaxError from
+  // response.json().
+  const text = await response.text();
+  let body: { data?: T; errors?: { message: string }[] } = {};
+  if (text.length > 0) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      throw new Error(`linear ${response.status}: ${text.slice(0, 200)}`);
+    }
+  }
   if (!response.ok || body.errors) {
     const message = body.errors?.map((entry) => entry.message).join('; ') ?? `linear ${response.status}`;
     throw new Error(message);
@@ -56,7 +70,10 @@ type RecentIssuesResponse = {
       description: string | null;
       updatedAt: string;
       priority: number;
-      state: { name: string } | null;
+      // Fetch stable `type` enum (backlog/unstarted/started/completed/
+      // canceled/triage) rather than user-editable `name`. Teams routinely
+      // rename states ("Done" → "Shipped") which silently broke status mapping.
+      state: { type: string } | null;
       team: { key: string } | null;
       assignee: { displayName: string } | null;
       labels: { nodes: { name: string }[] } | null;
@@ -64,19 +81,21 @@ type RecentIssuesResponse = {
   };
 };
 
-/** Map Linear state names to Composer Task status. */
-const mapStatus = (linearState: string | undefined): 'todo' | 'in-progress' | 'done' | undefined => {
-  if (!linearState) {
-    return undefined;
+/** Map Linear WorkflowState.type enum to Composer Task status. */
+const mapStatus = (linearStateType: string | undefined): 'todo' | 'in-progress' | 'done' | undefined => {
+  switch (linearStateType) {
+    case 'completed':
+    case 'canceled':
+      return 'done';
+    case 'started':
+      return 'in-progress';
+    case 'backlog':
+    case 'unstarted':
+    case 'triage':
+      return 'todo';
+    default:
+      return undefined;
   }
-  const lower = linearState.toLowerCase();
-  if (lower === 'done' || lower === 'completed' || lower === 'closed' || lower === 'merged') {
-    return 'done';
-  }
-  if (lower === 'in progress' || lower === 'started' || lower === 'in review') {
-    return 'in-progress';
-  }
-  return 'todo';
 };
 
 /** Map Linear priority (1=urgent..4=low, 0=none) to Task priority. */
@@ -109,7 +128,7 @@ export const fetchRecentIssues = async (
           description
           updatedAt
           priority
-          state { name }
+          state { type }
           team { key }
           assignee { displayName }
           labels { nodes { name } }
@@ -125,7 +144,7 @@ export const fetchRecentIssues = async (
       },
       title: `[${issue.identifier}] ${issue.title}`,
       description: issue.description ?? undefined,
-      status: mapStatus(issue.state?.name),
+      status: mapStatus(issue.state?.type),
       priority: mapPriority(issue.priority),
     }),
   );
@@ -205,14 +224,19 @@ export const updateIssue = async (
       }
     }
   `;
-  await graphql<{ issueUpdate: { success: boolean } }>(auth, mutation, { issueId, input });
-  log.info('linear: updated issue', { issueId, input });
+  const result = await graphql<{ issueUpdate: { success: boolean } }>(auth, mutation, { issueId, input });
+  if (!result.issueUpdate.success) {
+    throw new Error(`linear: issueUpdate returned success=false for ${issueId}`);
+  }
+  // Log only the field names that changed, not their values — titles and
+  // priority-change patterns can be sensitive in some workspaces.
+  log.info('linear: updated issue', { issueId, fields: Object.keys(input) });
 };
 
 /** One-shot auth check — returns the viewer's display name on success. */
 export const whoAmI = async (auth: LinearAuth): Promise<string> => {
   type Response = { viewer: { displayName: string } };
   const data = await graphql<Response>(auth, 'query { viewer { displayName } }');
-  log.info('linear: authenticated', { viewer: data.viewer.displayName });
+  log.info('linear: authenticated');
   return data.viewer.displayName;
 };

--- a/packages/plugins/plugin-linear/src/capabilities/linear-client.ts
+++ b/packages/plugins/plugin-linear/src/capabilities/linear-client.ts
@@ -13,8 +13,7 @@
 
 import { Obj } from '@dxos/echo';
 import { log } from '@dxos/log';
-
-import { Linear } from '../types';
+import { Task } from '@dxos/types';
 
 const LINEAR_GRAPHQL = 'https://api.linear.app/graphql';
 
@@ -56,6 +55,7 @@ type RecentIssuesResponse = {
       title: string;
       description: string | null;
       updatedAt: string;
+      priority: number;
       state: { name: string } | null;
       team: { key: string } | null;
       assignee: { displayName: string } | null;
@@ -64,14 +64,41 @@ type RecentIssuesResponse = {
   };
 };
 
+/** Map Linear state names to Composer Task status. */
+const mapStatus = (linearState: string | undefined): 'todo' | 'in-progress' | 'done' | undefined => {
+  if (!linearState) {
+    return undefined;
+  }
+  const lower = linearState.toLowerCase();
+  if (lower === 'done' || lower === 'completed' || lower === 'closed' || lower === 'merged') {
+    return 'done';
+  }
+  if (lower === 'in progress' || lower === 'started' || lower === 'in review') {
+    return 'in-progress';
+  }
+  return 'todo';
+};
+
+/** Map Linear priority (1=urgent..4=low, 0=none) to Task priority. */
+const mapPriority = (linearPriority: number | undefined): 'urgent' | 'high' | 'medium' | 'low' | 'none' => {
+  switch (linearPriority) {
+    case 1: return 'urgent';
+    case 2: return 'high';
+    case 3: return 'medium';
+    case 4: return 'low';
+    default: return 'none';
+  }
+};
+
 /**
- * Fetch the most recently updated issues across the workspace, limited to
- * `first`. Shaped for the demo's "activity feed" angle — no pagination.
+ * Fetch recent Linear issues and return them as Composer Task objects.
+ * Each Task has a foreignKey (`source: 'linear.app'`) for 2-way sync.
+ * The `identifier` (e.g. "BLU-1") is prepended to the title for context.
  */
 export const fetchRecentIssues = async (
   auth: LinearAuth,
   first = 25,
-): Promise<Linear.LinearIssue[]> => {
+): Promise<Task.Task[]> => {
   const query = `
     query RecentIssues($first: Int!) {
       issues(first: $first, orderBy: updatedAt) {
@@ -81,6 +108,7 @@ export const fetchRecentIssues = async (
           title
           description
           updatedAt
+          priority
           state { name }
           team { key }
           assignee { displayName }
@@ -91,16 +119,14 @@ export const fetchRecentIssues = async (
   `;
   const data = await graphql<RecentIssuesResponse>(auth, query, { first });
   return data.issues.nodes.map((issue) =>
-    Obj.make(Linear.LinearIssue, {
-      linearIssueId: issue.id,
-      identifier: issue.identifier,
-      title: issue.title,
+    Task.make({
+      [Obj.Meta]: {
+        keys: [{ id: issue.id, source: 'linear.app' }],
+      },
+      title: `[${issue.identifier}] ${issue.title}`,
       description: issue.description ?? undefined,
-      state: issue.state?.name?.toLowerCase(),
-      teamKey: issue.team?.key,
-      assignee: issue.assignee?.displayName,
-      updatedAt: issue.updatedAt,
-      labels: (issue.labels?.nodes ?? []).map((entry) => entry.name),
+      status: mapStatus(issue.state?.name),
+      priority: mapPriority(issue.priority),
     }),
   );
 };

--- a/packages/plugins/plugin-linear/src/index.ts
+++ b/packages/plugins/plugin-linear/src/index.ts
@@ -1,0 +1,8 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './meta';
+export * from './LinearPlugin';
+export * from './types';
+export * from './capabilities';

--- a/packages/plugins/plugin-linear/src/meta.ts
+++ b/packages/plugins/plugin-linear/src/meta.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Plugin } from '@dxos/app-framework';
+import { trim } from '@dxos/util';
+
+export const meta: Plugin.Meta = {
+  id: 'org.dxos.plugin.linear',
+  name: 'Linear',
+  description: trim`
+    Linear integration — surface issues, teams, and project state inside
+    Composer's data graph, queryable alongside other tools.
+  `,
+  icon: 'ph--rows--regular',
+  iconHue: 'violet',
+};

--- a/packages/plugins/plugin-linear/src/translations.ts
+++ b/packages/plugins/plugin-linear/src/translations.ts
@@ -2,17 +2,18 @@
 // Copyright 2026 DXOS.org
 //
 
+import { type Resource } from '@dxos/react-ui';
+
 import { meta } from './meta';
 
+// plugin-linear doesn't define its own ECHO types (it materializes Task
+// objects from @dxos/types). Only the plugin-level name needs translation.
 export const translations = [
   {
     'en-US': {
       [meta.id]: {
-        'plugin name': 'Linear',
-        'linear issue typename label': 'Linear issue',
-        'linear team typename label': 'Linear team',
-        'linear workspace typename label': 'Linear workspace',
+        'plugin.name': 'Linear',
       },
     },
   },
-];
+] as const satisfies Resource[];

--- a/packages/plugins/plugin-linear/src/translations.ts
+++ b/packages/plugins/plugin-linear/src/translations.ts
@@ -1,0 +1,18 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { meta } from './meta';
+
+export const translations = [
+  {
+    'en-US': {
+      [meta.id]: {
+        'plugin name': 'Linear',
+        'linear issue typename label': 'Linear issue',
+        'linear team typename label': 'Linear team',
+        'linear workspace typename label': 'Linear workspace',
+      },
+    },
+  },
+];

--- a/packages/plugins/plugin-linear/src/types/Linear.ts
+++ b/packages/plugins/plugin-linear/src/types/Linear.ts
@@ -50,34 +50,3 @@ export const LinearTeam = Schema.Struct({
 );
 export interface LinearTeam extends Schema.Schema.Type<typeof LinearTeam> {}
 
-/**
- * A Linear issue. Minimal shape — the interesting fields for the demo.
- */
-export const LinearIssue = Schema.Struct({
-  linearIssueId: Schema.String.pipe(FormInputAnnotation.set(false)),
-  /** Issue identifier in the form "ENG-123". */
-  identifier: Schema.String.pipe(FormInputAnnotation.set(false)),
-  title: Schema.String.pipe(FormInputAnnotation.set(false)),
-  description: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
-  /** Workflow state: 'backlog' | 'started' | 'completed' | 'canceled' | etc. */
-  state: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
-  /** Team key (e.g. "ENG"). */
-  teamKey: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
-  /** Linear login of the assignee, if any. */
-  assignee: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
-  /** ISO timestamp of last update in Linear. */
-  updatedAt: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
-  /** Labels attached to the issue. */
-  labels: Schema.optional(Schema.Array(Schema.String).pipe(FormInputAnnotation.set(false))),
-}).pipe(
-  Type.object({
-    typename: 'org.dxos.type.linearIssue',
-    version: '0.1.0',
-  }),
-  LabelAnnotation.set(['title']),
-  Annotation.IconAnnotation.set({
-    icon: 'ph--list-checks--regular',
-    hue: 'violet',
-  }),
-);
-export interface LinearIssue extends Schema.Schema.Type<typeof LinearIssue> {}

--- a/packages/plugins/plugin-linear/src/types/Linear.ts
+++ b/packages/plugins/plugin-linear/src/types/Linear.ts
@@ -1,0 +1,83 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Schema from 'effect/Schema';
+
+import { Annotation, Type } from '@dxos/echo';
+import { FormInputAnnotation, LabelAnnotation } from '@dxos/echo/internal';
+
+// @import-as-namespace
+
+/**
+ * A Linear workspace. One per Linear org the user has connected.
+ */
+export const LinearWorkspace = Schema.Struct({
+  /** Linear workspace URL key (e.g. "dxos" for linear.app/dxos). */
+  urlKey: Schema.String.pipe(FormInputAnnotation.set(false)),
+  /** Display name. */
+  name: Schema.String.pipe(FormInputAnnotation.set(false)),
+}).pipe(
+  Type.object({
+    typename: 'org.dxos.type.linearWorkspace',
+    version: '0.1.0',
+  }),
+  LabelAnnotation.set(['name']),
+  Annotation.IconAnnotation.set({
+    icon: 'ph--buildings--regular',
+    hue: 'violet',
+  }),
+);
+export interface LinearWorkspace extends Schema.Schema.Type<typeof LinearWorkspace> {}
+
+/**
+ * A Linear team (a project scope inside a workspace).
+ */
+export const LinearTeam = Schema.Struct({
+  linearTeamId: Schema.String.pipe(FormInputAnnotation.set(false)),
+  key: Schema.String.pipe(FormInputAnnotation.set(false)),
+  name: Schema.String.pipe(FormInputAnnotation.set(false)),
+}).pipe(
+  Type.object({
+    typename: 'org.dxos.type.linearTeam',
+    version: '0.1.0',
+  }),
+  LabelAnnotation.set(['name']),
+  Annotation.IconAnnotation.set({
+    icon: 'ph--users-three--regular',
+    hue: 'violet',
+  }),
+);
+export interface LinearTeam extends Schema.Schema.Type<typeof LinearTeam> {}
+
+/**
+ * A Linear issue. Minimal shape — the interesting fields for the demo.
+ */
+export const LinearIssue = Schema.Struct({
+  linearIssueId: Schema.String.pipe(FormInputAnnotation.set(false)),
+  /** Issue identifier in the form "ENG-123". */
+  identifier: Schema.String.pipe(FormInputAnnotation.set(false)),
+  title: Schema.String.pipe(FormInputAnnotation.set(false)),
+  description: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+  /** Workflow state: 'backlog' | 'started' | 'completed' | 'canceled' | etc. */
+  state: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+  /** Team key (e.g. "ENG"). */
+  teamKey: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+  /** Linear login of the assignee, if any. */
+  assignee: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+  /** ISO timestamp of last update in Linear. */
+  updatedAt: Schema.optional(Schema.String.pipe(FormInputAnnotation.set(false))),
+  /** Labels attached to the issue. */
+  labels: Schema.optional(Schema.Array(Schema.String).pipe(FormInputAnnotation.set(false))),
+}).pipe(
+  Type.object({
+    typename: 'org.dxos.type.linearIssue',
+    version: '0.1.0',
+  }),
+  LabelAnnotation.set(['title']),
+  Annotation.IconAnnotation.set({
+    icon: 'ph--list-checks--regular',
+    hue: 'violet',
+  }),
+);
+export interface LinearIssue extends Schema.Schema.Type<typeof LinearIssue> {}

--- a/packages/plugins/plugin-linear/src/types/index.ts
+++ b/packages/plugins/plugin-linear/src/types/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * as Linear from './Linear';

--- a/packages/plugins/plugin-linear/tsconfig.json
+++ b/packages/plugins/plugin-linear/tsconfig.json
@@ -33,7 +33,19 @@
       "path": "../../sdk/app-toolkit"
     },
     {
+      "path": "../../sdk/schema"
+    },
+    {
       "path": "../../sdk/types"
+    },
+    {
+      "path": "../plugin-client"
+    },
+    {
+      "path": "../plugin-kanban"
+    },
+    {
+      "path": "../plugin-space"
     }
   ]
 }

--- a/packages/plugins/plugin-linear/tsconfig.json
+++ b/packages/plugins/plugin-linear/tsconfig.json
@@ -31,6 +31,9 @@
     },
     {
       "path": "../../sdk/app-toolkit"
+    },
+    {
+      "path": "../../sdk/types"
     }
   ]
 }

--- a/packages/plugins/plugin-linear/tsconfig.json
+++ b/packages/plugins/plugin-linear/tsconfig.json
@@ -43,9 +43,6 @@
     },
     {
       "path": "../plugin-kanban"
-    },
-    {
-      "path": "../plugin-space"
     }
   ]
 }

--- a/packages/plugins/plugin-linear/tsconfig.json
+++ b/packages/plugins/plugin-linear/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "extends": [
+    "../../../tsconfig.base.json"
+  ],
+  "compilerOptions": {
+    "types": [
+      "node"
+    ]
+  },
+  "exclude": [
+    "*.t.ts",
+    "vite.config.ts"
+  ],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../../common/log"
+    },
+    {
+      "path": "../../common/util"
+    },
+    {
+      "path": "../../core/echo/echo"
+    },
+    {
+      "path": "../../sdk/app-framework"
+    },
+    {
+      "path": "../../sdk/app-toolkit"
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9806,9 +9806,6 @@ importers:
       '@dxos/plugin-kanban':
         specifier: workspace:*
         version: link:../plugin-kanban
-      '@dxos/plugin-space':
-        specifier: workspace:*
-        version: link:../plugin-space
       '@dxos/schema':
         specifier: workspace:*
         version: link:../../sdk/schema

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9786,6 +9786,34 @@ importers:
         specifier: '>=7.1.11'
         version: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/plugins/plugin-linear:
+    dependencies:
+      '@dxos/app-framework':
+        specifier: workspace:*
+        version: link:../../sdk/app-framework
+      '@dxos/app-toolkit':
+        specifier: workspace:*
+        version: link:../../sdk/app-toolkit
+      '@dxos/echo':
+        specifier: workspace:*
+        version: link:../../core/echo/echo
+      '@dxos/log':
+        specifier: workspace:*
+        version: link:../../common/log
+      '@dxos/util':
+        specifier: workspace:*
+        version: link:../../common/util
+      effect:
+        specifier: 3.20.0
+        version: 3.20.0
+    devDependencies:
+      '@types/react':
+        specifier: ~19.2.7
+        version: 19.2.7
+      react:
+        specifier: ~19.2.3
+        version: 19.2.3
+
   packages/plugins/plugin-map:
     dependencies:
       '@dxos/ai':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9800,6 +9800,18 @@ importers:
       '@dxos/log':
         specifier: workspace:*
         version: link:../../common/log
+      '@dxos/plugin-client':
+        specifier: workspace:*
+        version: link:../plugin-client
+      '@dxos/plugin-kanban':
+        specifier: workspace:*
+        version: link:../plugin-kanban
+      '@dxos/plugin-space':
+        specifier: workspace:*
+        version: link:../plugin-space
+      '@dxos/schema':
+        specifier: workspace:*
+        version: link:../../sdk/schema
       '@dxos/types':
         specifier: workspace:*
         version: link:../../sdk/types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9800,6 +9800,9 @@ importers:
       '@dxos/log':
         specifier: workspace:*
         version: link:../../common/log
+      '@dxos/types':
+        specifier: workspace:*
+        version: link:../../sdk/types
       '@dxos/util':
         specifier: workspace:*
         version: link:../../common/util

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -595,6 +595,11 @@
         },
         {
           "type": "json",
+          "path": "packages/plugins/plugin-linear/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "packages/plugins/plugin-map/package.json",
           "jsonpath": "$.version"
         },

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -343,6 +343,9 @@
       "path": "packages/plugins/plugin-kanban/tsconfig.json"
     },
     {
+      "path": "packages/plugins/plugin-linear/tsconfig.json"
+    },
+    {
       "path": "packages/plugins/plugin-map/tsconfig.json"
     },
     {


### PR DESCRIPTION
## Summary

- Adds `@dxos/plugin-linear` — a new Composer plugin that integrates Linear issue tracking
- Linear issues are synced as Composer's **native Task type** (not a custom schema), so they appear in the sidebar under Tasks and can be viewed as a Kanban board grouped by status
- Includes a browser-side GraphQL client (`fetchRecentIssues`, `whoAmI`) with CORS-compatible direct API calls
- Maps Linear workflow states → Task status (`todo`/`in-progress`/`done`) and priorities (`urgent`/`high`/`medium`/`low`/`none`)
- Uses ECHO `foreignKeys` (`source: 'linear.app'`) for identity tracking

## Design decisions

- **Native Task type over custom LinearIssue schema**: Linear issues map cleanly to the existing Task type, so no custom schema registration is needed. Issues immediately work with all existing Task views (Kanban, list, etc.)
- **LinearWorkspace and LinearTeam types retained**: These describe the Linear connection metadata (which workspace/team is connected), separate from the issues themselves
- **Browser-side GraphQL**: Linear's API supports CORS with `Authorization` header, so no dev-proxy needed. API key stored in localStorage for the scaffold.

## Test plan

- [ ] Set `LINEAR_API_KEY` in localStorage with a valid Linear personal API key
- [ ] Call `fetchRecentIssues()` and verify it returns Task objects with status, priority, and foreignKeys
- [ ] Verify synced tasks appear in sidebar under Tasks
- [ ] Verify tasks can be viewed as a Kanban board grouped by status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linear plugin integration: workspace/team metadata with icons and localized plugin name.
  * Import recent Linear issues mapped to app tasks (status, priority, titles, descriptions).
  * Automatic initial and periodic sync to pull new/updated issues into a selected space.
  * Automatic creation of a "Linear Issues" Kanban view when none exists.
  * Auth handling with visible authenticated user logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->