### PR TITLE
fix(inbox): mailbox messages as deck planks in multi layout

### DIFF
--- a/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
+++ b/packages/plugins/plugin-deck/src/capabilities/url-handler.ts
@@ -9,6 +9,7 @@ import {
   AppCapabilities,
   LayoutOperation,
   NOT_FOUND_PATH,
+  expandPath,
   fromUrlPath,
   getWorkspaceFromPath,
   toUrlPath,
@@ -66,6 +67,7 @@ export default Capability.makeModule(
     };
 
     const handleNavigation = Effect.fn(function* (url?: URL) {
+      const { graph } = yield* Capability.get(AppCapabilities.AppGraph);
       const resolvedUrl = url ?? new URL(window.location.href);
       // When native redirect is active, check-app-scheme owns the initial dispatch
       // to prevent one-time tokens from being consumed before the native app can use them.
@@ -119,6 +121,9 @@ export default Capability.makeModule(
         // Multi-mode: restore planks from query params.
         const plankIds = deserializePlanks(resolvedUrl);
         if (plankIds.length > 0) {
+          for (const plankId of plankIds) {
+            expandPath(graph, plankId);
+          }
           updateState((state) => updateActiveDeck(state, { active: plankIds, initialized: true }));
         }
       }

--- a/packages/plugins/plugin-inbox/src/capabilities/navigation-resolver.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/navigation-resolver.ts
@@ -100,7 +100,7 @@ export default Capability.makeModule(
               const feed = await mailbox.feed.load();
               const messages = await space.db.query(Query.select(Filter.id(messageId)).from(feed)).run();
               if (messages.length > 0) {
-                return Option.some(mailboxDxn);
+                return Option.some(Obj.getDXN(messages[0]));
               }
             }
 

--- a/packages/plugins/plugin-inbox/src/capabilities/navigation-resolver.ts
+++ b/packages/plugins/plugin-inbox/src/capabilities/navigation-resolver.ts
@@ -108,7 +108,7 @@ export default Capability.makeModule(
               | Message.Message
               | undefined;
             if (fromDb && DraftMessage.belongsTo(fromDb, mailboxDxnString)) {
-              return Option.some(mailboxDxn);
+              return Option.some(Obj.getDXN(fromDb));
             }
 
             return Option.none<DXN>();

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
@@ -149,6 +149,15 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
                 state: 'expanded',
               });
               break;
+            case 'multi': {
+              invariant(db);
+              void invokePromise(LayoutOperation.Open, {
+                subject: [getMailboxMessagePath(db.spaceId, mailbox.id, message.id)],
+                pivotId: id,
+                navigation: 'immediate',
+              });
+              break;
+            }
             default:
               // Show message in the companion panel.
               void invokePromise(DeckOperation.ChangeCompanion, {


### PR DESCRIPTION
## Summary

Improves mailbox behavior in **multi (deck) layout** and fixes **reload** so message planks resolve correctly.

## Changes

### Mailbox (plugin-inbox)

- **Open messages in a new plank** instead of only the companion: `MailboxArticle` uses `LayoutOperation.Open` with the mailbox plank as pivot when `layout.mode === 'multi'` for both `current` and `current-thread` actions.
- **Navigation path resolver**: resolve validated **message** paths (feed messages and drafts) to the **message** DXN, not the mailbox DXN. This matches how the deck `Open` operation dedupes subjects by DXN; returning the mailbox DXN caused the message subject to be remapped to the mailbox plank id, so no new plank appeared.

### Deck URL restore (plugin-deck)

- On **multi-mode** navigation, restored plank ids from query params now run through `expandPath` for each id **before** updating deck state. Restoring `active` alone skipped graph expansion; `LayoutOperation.Open` had been the only path that called `expandPath`, so resolver-backed nodes (e.g. mailbox message `~` segments) did not materialize after a full reload.

## Verification

- Multi deck: select messages from a mailbox; each should open as a plank to the right of the mailbox.
- Reload the app with the same URL: message planks should still resolve (no blank / missing node).
- With threading enabled, thread row actions should open a plank in multi mode as well.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL navigation handling in multi-mode layouts to properly process multiple items
  * Enhanced message navigation resolution to correctly identify specific messages
  * Added support for opening messages directly in multi-mode layouts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->