### PR TITLE
fix(plugin-spacetime): fix WASM memory exhaustion in extrusion tool

### DIFF
--- a/packages/plugins/plugin-spacetime/src/engine/extrusion.ts
+++ b/packages/plugins/plugin-spacetime/src/engine/extrusion.ts
@@ -464,15 +464,17 @@ export const applyExtrusion = (
   faceId: number,
   normal: Model.Vec3,
   distance: number,
+  /** Pre-computed bounding box to avoid repeated WASM calls on the hot path. */
+  cachedBBox?: { min: number[]; max: number[] },
 ): Manifold => {
   if (distance === 0) {
-    // NOTE: Must clone even for zero distance. The caller (onPointerUp) deletes baseSolid
-    // and stores the result in ctx.solids. Self-union is a no-op clone in Manifold.
-    return Manifold.union(baseSolid, baseSolid);
+    // Clone via getMesh() roundtrip — avoids heavyweight CSG union and ensures
+    // the result shares no internal WASM state with baseSolid.
+    return new Manifold(baseSolid.getMesh());
   }
 
   // Clamp negative extrusion to prevent collapse below minimum size.
-  const bbox = baseSolid.boundingBox();
+  const bbox = cachedBBox ?? baseSolid.boundingBox();
   const normalArr = [normal.x, normal.y, normal.z];
   const absNormal = normalArr.map(Math.abs);
   const dominantAxis =
@@ -484,7 +486,7 @@ export const applyExtrusion = (
     const maxInward = Math.max(0, bboxDim - MIN_SIZE);
     clampedDistance = -Math.min(Math.abs(distance), maxInward);
     if (clampedDistance === 0) {
-      return Manifold.union(baseSolid, baseSolid);
+      return new Manifold(baseSolid.getMesh());
     }
   }
 

--- a/packages/plugins/plugin-spacetime/src/tools/tools/extrude-tool.ts
+++ b/packages/plugins/plugin-spacetime/src/tools/tools/extrude-tool.ts
@@ -24,6 +24,9 @@ const snapToGrid = (value: number): number => Math.round(value / SNAP_SIZE) * SN
 /** Dot product of a Vector3 and a plain {x,y,z} vector. */
 const dotVec3 = (a: Vector3, b: Vector3): number => a.x * b.x + a.y * b.y + a.z * b.z;
 
+/** Minimum distance threshold to trigger an extrusion (avoids no-op WASM work). */
+const DISTANCE_EPSILON = 0.001;
+
 /** State tracked during an active extrude drag. */
 type ExtrudeState = {
   /** ECHO object id being extruded. */
@@ -42,6 +45,8 @@ type ExtrudeState = {
   startT: number;
   /** Manifold solid at the start of this extrusion (cloned). */
   baseSolid: Manifold;
+  /** Pre-computed bounding box — cached to avoid repeated WASM calls during drag. */
+  baseBBox: { min: number[]; max: number[] };
   /** Timestamp of last move update (for throttling). */
   lastMoveTime: number;
 };
@@ -139,9 +144,11 @@ export class ExtrudeTool implements Tool {
       ctx.selection.highlightMesh.setEnabled(false);
     }
 
-    // Clone the solid so we can rebuild from base during drag.
+    // Deep-copy the solid via getMesh() roundtrip — avoids heavyweight CSG union
+    // and ensures the clone shares no internal WASM state with the original.
     const { Manifold } = ctx.manifold;
-    const baseSolid = Manifold.union(currentSolid, currentSolid);
+    const baseSolid = new Manifold(currentSolid.getMesh());
+    const baseBBox = baseSolid.boundingBox();
 
     this._state = {
       objectId,
@@ -152,6 +159,7 @@ export class ExtrudeTool implements Tool {
       normalVec,
       startT,
       baseSolid,
+      baseBBox,
       lastMoveTime: 0,
     };
 
@@ -184,6 +192,11 @@ export class ExtrudeTool implements Tool {
       distance = snapToGrid(facePos + distance) - facePos;
     }
 
+    // Skip WASM operations when distance is negligible (e.g. initial move with no displacement).
+    if (Math.abs(distance) < DISTANCE_EPSILON) {
+      return true;
+    }
+
     const t0 = performance.now();
     const extruded = applyExtrusion(
       ctx.manifold.Manifold,
@@ -191,6 +204,7 @@ export class ExtrudeTool implements Tool {
       this._state.faceId,
       this._state.normal,
       distance,
+      this._state.baseBBox,
     );
 
     const t1 = performance.now();
@@ -227,12 +241,26 @@ export class ExtrudeTool implements Tool {
       distance = snapToGrid(facePos + distance) - facePos;
     }
 
+    // No significant drag — clean up without creating a new solid.
+    // This avoids unnecessary WASM allocations on clicks without drag.
+    if (Math.abs(distance) < DISTANCE_EPSILON) {
+      this._state.baseSolid.delete();
+      // Restore selection highlight that was hidden at drag start.
+      if (ctx.selection?.type === 'face' && ctx.selection.highlightMesh) {
+        ctx.selection.highlightMesh.setEnabled(true);
+      }
+      ctx.camera.attachControl(ctx.canvas, true);
+      this._state = null;
+      return true;
+    }
+
     const finalSolid = applyExtrusion(
       ctx.manifold.Manifold,
       this._state.baseSolid,
       this._state.faceId,
       this._state.normal,
       distance,
+      this._state.baseBBox,
     );
 
     // Replace the runtime solid for this object.


### PR DESCRIPTION
## Summary

- Replace `Manifold.union(solid, solid)` clone pattern with `new Manifold(solid.getMesh())` roundtrip to avoid heavyweight CSG operations and ensure clones share no internal WASM state with the original
- Cache `boundingBox()` result once per extrusion (in `onPointerDown`) and pass it to all `applyExtrusion` calls, eliminating ~33 WASM calls/sec during drag
- Short-circuit zero-distance extrusions in both `onPointerMove` and `onPointerUp` to skip unnecessary Manifold allocations on clicks without drag

## Test plan

- [x] All 30 plugin-spacetime tests pass (18 extrusion, 7 boolean-ops, 5 obj-import)
- [x] Build passes
- [x] Lint passes
- [ ] Manual: repeatedly extrude faces on a cube — should no longer slow down and crash with `memory access out of bounds`
- [ ] Manual: click on faces with extrude tool without dragging — should preserve face selection highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized extrusion operations to skip processing negligible distance changes during interactive dragging, improving responsiveness.
  * Reduced redundant computations through geometry caching.

* **Bug Fixes**
  * Improved resource cleanup when minimal extrusion distances are applied, preventing unnecessary state retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->