### PR TITLE
refactor(react-ui): Column CSS custom property cascade with withColumn utilities

### DIFF
--- a/docs/superpowers/plans/2026-04-20-column-refactor.md
+++ b/docs/superpowers/plans/2026-04-20-column-refactor.md
@@ -15,6 +15,7 @@
 ### Task 1: Add `withColumn` theme utilities
 
 **Files:**
+
 - Modify: `packages/ui/ui-theme/src/theme/primitives/column.ts`
 
 - [ ] **Step 1: Add withColumn utility object**
@@ -90,6 +91,7 @@ git commit -m "feat(ui-theme): add withColumn utilities and simplify Column them
 ### Task 2: Update Column React components
 
 **Files:**
+
 - Modify: `packages/ui/react-ui/src/primitives/Column/Column.tsx`
 
 - [ ] **Step 1: Update ColumnRoot — set --dx-col**
@@ -235,6 +237,7 @@ git commit -m "refactor(react-ui): update Column components for --dx-col cascade
 ### Task 3: Update ScrollArea theme — reset --dx-col
 
 **Files:**
+
 - Modify: `packages/ui/ui-theme/src/theme/components/scroll-area.ts`
 
 - [ ] **Step 1: Import withColumn**
@@ -301,6 +304,7 @@ git commit -m "refactor(ui-theme): reset --dx-col in ScrollArea.Viewport"
 ### Task 4: Update Dialog — use withColumn in theme and components
 
 **Files:**
+
 - Modify: `packages/ui/ui-theme/src/theme/components/dialog.ts`
 - Modify: `packages/ui/react-ui/src/components/Dialog/Dialog.tsx`
 - Modify: `packages/ui/react-ui/src/components/Dialog/Dialog.stories.tsx`
@@ -382,10 +386,13 @@ Check if `Column` is still imported for Dialog.Content (it is — `Column.Root`)
 - [ ] **Step 6: Fix Dialog.stories.tsx comment**
 
 Change line 27 from:
+
 ```ts
  * Dialog.Body delegates to Column.Center, placing content in the center column between gutters.
 ```
+
 To:
+
 ```ts
  * Dialog.Body propagates the Column grid via subgrid. Children auto-center via --dx-col.
 ```
@@ -411,6 +418,7 @@ git commit -m "refactor(react-ui): Dialog uses withColumn theme utilities"
 ### Task 5: Update Form — add column awareness
 
 **Files:**
+
 - Modify: `packages/ui/react-ui-form/src/components/Form/Form.tsx`
 
 - [ ] **Step 1: Import withColumn**
@@ -470,6 +478,7 @@ git commit -m "feat(react-ui-form): make Form.Content and Form.Actions column-aw
 ### Task 6: Update SearchList — add column awareness
 
 **Files:**
+
 - Modify: `packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx`
 
 - [ ] **Step 1: Import withColumn**
@@ -549,6 +558,7 @@ git commit -m "feat(react-ui-search): make SearchList column-aware"
 ### Task 7: Update Card — use own subgrid CSS
 
 **Files:**
+
 - Modify: `packages/ui/react-ui/src/components/Card/Card.tsx`
 
 - [ ] **Step 1: Change CardRow — replace Column.Row with own subgrid**
@@ -605,6 +615,7 @@ git commit -m "refactor(react-ui): Card.Row uses own subgrid instead of Column.R
 ### Task 8: Update Column stories
 
 **Files:**
+
 - Modify: `packages/ui/react-ui/src/primitives/Column/Column.stories.tsx`
 
 - [ ] **Step 1: Update DefaultStory**
@@ -760,11 +771,13 @@ git commit -m "refactor(react-ui): update Column stories for simplified API"
 ### Task 9: Update AUDIT.md
 
 **Files:**
+
 - Modify: `packages/ui/react-ui/src/primitives/Column/AUDIT.md`
 
 - [ ] **Step 1: Update the document**
 
 Update the AUDIT.md to reflect the new design:
+
 - Document the `withColumn` utilities (center, propagate, consumed)
 - Document the `--dx-col` CSS custom property cascade
 - Update the Column primitives table
@@ -783,6 +796,7 @@ git commit -m "docs(react-ui): update Column AUDIT.md for withColumn refactor"
 ### Task 10: Full build and search for remaining Column.Row center usages
 
 **Files:**
+
 - Potentially modify: any consumer still using `Column.Row center` or `Column.Row fullWidth`
 
 - [ ] **Step 1: Search for remaining Column.Row center/fullWidth usages**

--- a/docs/superpowers/plans/2026-04-20-column-refactor.md
+++ b/docs/superpowers/plans/2026-04-20-column-refactor.md
@@ -1,0 +1,820 @@
+# Column Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make all core UI components (Dialog, Form, Card, SearchList) automatically column-aware via CSS custom properties and theme utilities, eliminating manual Column wrapper wiring.
+
+**Architecture:** Column.Root sets `--dx-col: 2 / span 1` alongside `--gutter`. Non-viewport components consume `--dx-col` for grid placement. ScrollArea.Viewport resets `--dx-col` after consuming `--gutter`. Theme provides `withColumn` utilities so components are column-aware without importing Column. Intermediate containers propagate the grid via CSS subgrid.
+
+**Tech Stack:** CSS custom properties, CSS subgrid, Tailwind arbitrary values, DXOS ui-theme system.
+
+**Spec:** `docs/superpowers/specs/2026-04-20-column-refactor-design.md`
+
+---
+
+### Task 1: Add `withColumn` theme utilities
+
+**Files:**
+- Modify: `packages/ui/ui-theme/src/theme/primitives/column.ts`
+
+- [ ] **Step 1: Add withColumn utility object**
+
+Add the `withColumn` export before the `columnTheme` export:
+
+```ts
+/**
+ * Column-aware theme utilities.
+ * Components apply these in their theme functions to participate in the Column grid
+ * without importing Column React components.
+ *
+ * CSS custom property cascade:
+ * - Column.Root sets `--dx-col: 2 / span 1` (center column placement).
+ * - ScrollArea.Viewport resets `--dx-col: auto` after consuming `--gutter`.
+ * - Components apply `grid-column: var(--dx-col, auto)` to auto-center in Column
+ *   or do nothing outside Column / inside ScrollArea.
+ */
+export const withColumn = {
+  /** Centers element in the Column grid via --dx-col. No-op outside Column or inside ScrollArea. */
+  center: () => '[grid-column:var(--dx-col,auto)]',
+
+  /** Propagates the Column grid to children via subgrid. No-op outside Column. */
+  propagate: () => '[.dx-column_&]:col-span-full [.dx-column_&]:grid [.dx-column_&]:grid-cols-subgrid',
+
+  /** Resets --dx-col after consuming --gutter. Applied by ScrollArea.Viewport. */
+  consumed: () => '[--dx-col:auto]',
+};
+```
+
+- [ ] **Step 2: Update columnRow — remove center/fullWidth**
+
+Change the `ColumnStyleProps` type and `columnRow` function:
+
+```ts
+export type ColumnStyleProps = {};
+
+const columnRow: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
+  return mx('col-span-3 grid grid-cols-subgrid', ...etc);
+};
+```
+
+- [ ] **Step 3: Update columnBleed — add subgrid propagation**
+
+```ts
+const columnBleed: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
+  return mx('col-span-full grid grid-cols-subgrid min-h-0', ...etc);
+};
+```
+
+- [ ] **Step 4: Update columnCenter — use withColumn.center()**
+
+```ts
+const columnCenter: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
+  return mx(withColumn.center(), 'min-h-0', ...etc);
+};
+```
+
+- [ ] **Step 5: Build to verify**
+
+Run: `moon run ui-theme:build`
+Expected: PASS (no consumers changed yet)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/ui-theme/src/theme/primitives/column.ts
+git commit -m "feat(ui-theme): add withColumn utilities and simplify Column theme"
+```
+
+---
+
+### Task 2: Update Column React components
+
+**Files:**
+- Modify: `packages/ui/react-ui/src/primitives/Column/Column.tsx`
+
+- [ ] **Step 1: Update ColumnRoot — set --dx-col**
+
+Add `'--dx-col': '2 / span 1'` to the inline style object in ColumnRoot (line 54):
+
+```ts
+const ColumnRoot = slottable<HTMLDivElement, ColumnRootProps>(
+  ({ children, asChild, role, gutter = 'md', ...props }, forwardedRef) => {
+    const { className, ...rest } = composableProps(props);
+    const Comp = asChild ? Slot : Primitive.div;
+    const { tx } = useThemeContext();
+    const gutterSize = gutterSizes[gutter];
+    return (
+      <Comp
+        {...rest}
+        role={role ?? 'none'}
+        style={
+          {
+            '--gutter': gutterSize,
+            '--dx-col': '2 / span 1',
+            gridTemplateColumns: [gutterSize, 'minmax(0,1fr)', gutterSize].join(' '),
+          } as CSSProperties
+        }
+        className={tx('column.root', { gutter }, className)}
+        ref={forwardedRef}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+```
+
+- [ ] **Step 2: Update ColumnRow — remove center/fullWidth props**
+
+Remove `fullWidth` and `center` from the destructure and the `tx` call:
+
+```ts
+type ColumnRowProps = {};
+
+/**
+ * Spans all 3 columns of the parent Column.Root and uses CSS subgrid to inherit their sizing.
+ * Children map to: [col-1: icon/slot] [col-2: content] [col-3: icon/action].
+ * Must be a direct child of Column.Root or a subgrid propagator.
+ */
+const ColumnRow = slottable<HTMLDivElement, ColumnRowProps>(
+  ({ children, asChild, role, ...props }, forwardedRef) => {
+    const { className, ...rest } = composableProps(props);
+    const Comp = asChild ? Slot : Primitive.div;
+    const { tx } = useThemeContext();
+    return (
+      <Comp
+        {...rest}
+        role={role ?? 'none'}
+        className={tx('column.row', {}, className)}
+        ref={forwardedRef}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+```
+
+- [ ] **Step 3: Update ColumnRoot JSDoc**
+
+```ts
+/**
+ * Creates a 3-column CSS grid with left/right gutter columns and a center content column.
+ * Sets the `--gutter` and `--dx-col` CSS variables for nested components.
+ *
+ * Direct children participate in the grid in one of several ways:
+ * - **Column.Center** — places element in the center column (col 2) via `--dx-col`.
+ * - **Column.Bleed** — spans all 3 columns with subgrid propagation for nested grid children.
+ * - **Column.Row** — 3-col subgrid row (icons in gutters, content in center).
+ *
+ * Components can also be column-aware via `withColumn` theme utilities without using
+ * these wrapper components.
+ *
+ * Gutter sizes: `'sm'` for compact layouts (Dialog); `'md'` (default); `'lg'` for wider spacing.
+ */
+```
+
+- [ ] **Step 4: Update ColumnBleed JSDoc**
+
+```ts
+/**
+ * Spans all 3 columns of the parent Column.Root and propagates the grid via CSS subgrid.
+ * Children become grid items and can use `--dx-col` for placement.
+ * Use for intermediate containers (Dialog.Body) that need to pass the Column grid through.
+ */
+```
+
+- [ ] **Step 5: Remove ColumnStyleProps import from Column.tsx**
+
+Update the `ColumnRowProps` type. Since `ColumnStyleProps` is now empty, `ColumnRowProps` should use `SlottableProps` or an empty object:
+
+```ts
+import { type SlottableProps } from '@dxos/ui-types';
+
+// ...
+
+type ColumnRowProps = SlottableProps;
+```
+
+Wait — `SlottableProps` is already the base from `slottable`. The second type param is the additional props. Since there are none, use `{}` or omit it. Check the `slottable` signature. The current code has:
+
+```ts
+type ColumnRowProps = ColumnStyleProps;
+```
+
+Change to:
+
+```ts
+type ColumnRowProps = {};
+```
+
+- [ ] **Step 6: Update exports — remove ColumnStyleProps from public types**
+
+The current export line:
+
+```ts
+export type { ColumnRootProps, ColumnRowProps, ColumnBleedProps, ColumnCenterProps };
+```
+
+This stays the same — the types are still exported, they're just simpler now.
+
+- [ ] **Step 7: Build to verify**
+
+Run: `moon run react-ui:build`
+Expected: FAIL — Dialog.tsx and Card.tsx still pass `center` to Column.Row. That's expected; we'll fix those in later tasks.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/ui/react-ui/src/primitives/Column/Column.tsx
+git commit -m "refactor(react-ui): update Column components for --dx-col cascade"
+```
+
+---
+
+### Task 3: Update ScrollArea theme — reset --dx-col
+
+**Files:**
+- Modify: `packages/ui/ui-theme/src/theme/components/scroll-area.ts`
+
+- [ ] **Step 1: Import withColumn**
+
+Add import at top of file:
+
+```ts
+import { withColumn } from '../primitives/column';
+```
+
+- [ ] **Step 2: Add withColumn.consumed() to scrollAreaViewport**
+
+In the `scrollAreaViewport` function, add `withColumn.consumed()` to the `mx()` call. Place it after the existing gutter comment block (after line 78):
+
+```ts
+export const scrollAreaViewport: ComponentFunction<ScrollAreaStyleProps> = (
+  { orientation, centered, padding, snap, thin, autoHide },
+  ...etc
+) => {
+  return mx(
+    'h-full w-full',
+
+    orientation === 'vertical' && 'flex flex-col overflow-y-scroll',
+    orientation === 'horizontal' && 'flex overflow-x-scroll overscroll-x-contain',
+    orientation === 'all' && 'overflow-scroll',
+
+    '[&::-webkit-scrollbar-corner]:bg-transparent',
+    '[&::-webkit-scrollbar-track]:bg-transparent',
+    '[&::-webkit-scrollbar-thumb]:rounded-none',
+
+    '[&::-webkit-scrollbar]:w-[var(--scroll-width)] [&::-webkit-scrollbar]:h-[var(--scroll-width)]',
+
+    // If contained within Column.Root grid the gutter is set by that component (--gutter CSS variable).
+    // If centered, left padding compensates for scrollbar width so content is visually centered.
+    (orientation === 'vertical' || orientation === 'all') &&
+      (padding
+        ? [
+            centered ? 'pl-[var(--gutter,calc(var(--scroll-width)+var(--scroll-padding)))]' : 'pl-[var(--gutter,0)]',
+            'pr-[calc(var(--gutter,calc(var(--scroll-width)+var(--scroll-padding)))-var(--scroll-width))]',
+          ]
+        : centered && 'pl-[var(--scroll-width)]'),
+
+    // Reset --dx-col so nested components don't try to grid-position themselves.
+    // ScrollArea has already consumed --gutter for padding.
+    withColumn.consumed(),
+
+    // ... rest unchanged (horizontal padding, snap, autoHide) ...
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `moon run ui-theme:build`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/ui-theme/src/theme/components/scroll-area.ts
+git commit -m "refactor(ui-theme): reset --dx-col in ScrollArea.Viewport"
+```
+
+---
+
+### Task 4: Update Dialog — use withColumn in theme and components
+
+**Files:**
+- Modify: `packages/ui/ui-theme/src/theme/components/dialog.ts`
+- Modify: `packages/ui/react-ui/src/components/Dialog/Dialog.tsx`
+- Modify: `packages/ui/react-ui/src/components/Dialog/Dialog.stories.tsx`
+
+- [ ] **Step 1: Update dialog theme — add withColumn to header, body, actionbar**
+
+In `dialog.ts`, import `withColumn` and update the three theme functions:
+
+```ts
+import { withColumn } from '../primitives/column';
+
+// ...
+
+export const dialogHeader: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
+  mx('dx-dialog__header flex pb-4 items-center justify-between', withColumn.center(), ...etc);
+
+export const dialogBody: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
+  mx('dx-dialog__body', withColumn.propagate(), ...etc);
+
+export const dialogActionBar: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
+  mx('dx-dialog__actionbar flex items-center pt-4 gap-2 dx-density-coarse', withColumn.center(), ...etc);
+```
+
+- [ ] **Step 2: Update DialogHeader — remove Column.Row, use plain div**
+
+In `Dialog.tsx`, change DialogHeader from wrapping in `Column.Row` to a plain div with theme:
+
+```ts
+const DialogHeader = slottable<HTMLDivElement>(({ children, asChild, ...props }, forwardedRef) => {
+  const { className, ...rest } = composableProps(props);
+  const Comp = asChild ? Slot : Primitive.div;
+  const { tx } = useThemeContext();
+  return (
+    <Comp {...rest} className={tx('dialog.header', {}, className)} ref={forwardedRef}>
+      {children}
+    </Comp>
+  );
+});
+```
+
+- [ ] **Step 3: Update DialogBody — remove Column.Center, use plain div**
+
+Change DialogBody from wrapping in `Column.Center` to a plain div with theme:
+
+```ts
+const DialogBody = slottable<HTMLDivElement>(({ children, asChild, ...props }, forwardedRef) => {
+  const { className, ...rest } = composableProps(props);
+  const Comp = asChild ? Slot : Primitive.div;
+  const { tx } = useThemeContext();
+  return (
+    <Comp {...rest} className={tx('dialog.body', {}, className)} ref={forwardedRef}>
+      {children}
+    </Comp>
+  );
+});
+```
+
+- [ ] **Step 4: Update DialogActionBar — remove Column.Row, use plain div**
+
+Change DialogActionBar. Currently it nests a `<div>` inside `<Column.Row center>`. Flatten to just the div with theme:
+
+```ts
+const DialogActionBar = slottable<HTMLDivElement>(({ children, asChild, ...props }, forwardedRef) => {
+  const { className: classNames, ...rest } = composableProps(props);
+  const Comp = asChild ? Slot : Primitive.div;
+  const { tx } = useThemeContext();
+  return (
+    <Comp {...rest} className={tx('dialog.actionbar', {}, classNames)} ref={forwardedRef}>
+      {children}
+    </Comp>
+  );
+});
+```
+
+- [ ] **Step 5: Remove Column import from Dialog.tsx if no longer used**
+
+Check if `Column` is still imported for Dialog.Content (it is — `Column.Root`). Keep the import but verify only `Column.Root` is used.
+
+- [ ] **Step 6: Fix Dialog.stories.tsx comment**
+
+Change line 27 from:
+```ts
+ * Dialog.Body delegates to Column.Center, placing content in the center column between gutters.
+```
+To:
+```ts
+ * Dialog.Body propagates the Column grid via subgrid. Children auto-center via --dx-col.
+```
+
+Also fix line 65 if `--gutter-offset` reference exists — change to reference `--gutter`.
+
+- [ ] **Step 7: Build to verify**
+
+Run: `moon run react-ui:build`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/ui/ui-theme/src/theme/components/dialog.ts \
+       packages/ui/react-ui/src/components/Dialog/Dialog.tsx \
+       packages/ui/react-ui/src/components/Dialog/Dialog.stories.tsx
+git commit -m "refactor(react-ui): Dialog uses withColumn theme utilities"
+```
+
+---
+
+### Task 5: Update Form — add column awareness
+
+**Files:**
+- Modify: `packages/ui/react-ui-form/src/components/Form/Form.tsx`
+
+- [ ] **Step 1: Import withColumn**
+
+Add to the existing `@dxos/ui-theme` import line:
+
+```ts
+import { composable, composableProps, mx, withColumn } from '@dxos/ui-theme';
+```
+
+- [ ] **Step 2: Update FormContent — add withColumn.center()**
+
+Change the classNames in FormContent (line 197):
+
+```ts
+const FormContent = composable<HTMLDivElement, FormContentProps>(({ children, ...props }, forwardedRef) => {
+  const { form, testId } = useFormContext(FORM_CONTENT_NAME);
+  const localRef = useRef<HTMLDivElement>(null);
+  const mergedRef = useMergeRefs([forwardedRef, localRef]);
+  useKeyHandler(localRef, form);
+
+  return (
+    <div
+      {...composableProps(props, { role: 'form', classNames: mx(withColumn.center(), 'flex flex-col w-full pb-form-gap') })}
+      data-testid={testId}
+      ref={mergedRef}
+    >
+      {children}
+    </div>
+  );
+});
+```
+
+- [ ] **Step 3: Update FormActions — add withColumn.center()**
+
+Change the classNames in FormActions (line 248):
+
+```ts
+return (
+  <div role='none' className={mx(withColumn.center(), 'grid grid-flow-col gap-form-gap auto-cols-fr py-form-padding', classNames)}>
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run: `moon run react-ui-form:build`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/react-ui-form/src/components/Form/Form.tsx
+git commit -m "feat(react-ui-form): make Form.Content and Form.Actions column-aware"
+```
+
+---
+
+### Task 6: Update SearchList — add column awareness
+
+**Files:**
+- Modify: `packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx`
+
+- [ ] **Step 1: Import withColumn**
+
+Add to the existing `@dxos/ui-theme` import line:
+
+```ts
+import { composable, composableProps, mx, withColumn } from '@dxos/ui-theme';
+```
+
+- [ ] **Step 2: Update SearchListContent — add withColumn.propagate()**
+
+Change classNames and update JSDoc (lines 236-249):
+
+```ts
+/**
+ * Optional wrapper that groups `SearchList.Input` and `SearchList.Viewport`.
+ * When inside a Column context, propagates the grid via subgrid so children
+ * can auto-center (Input) or auto-bleed (Viewport).
+ */
+const SearchListContent = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
+  return (
+    <div {...composableProps(props, { role: 'none', classNames: mx('dx-expander', withColumn.propagate()) })} ref={forwardedRef}>
+      {children}
+    </div>
+  );
+});
+```
+
+- [ ] **Step 3: Update SearchListInput — add withColumn.center()**
+
+SearchListInput renders `<Input.Root>` which is a div. Add a classNames prop to Input.Root to apply withColumn.center(). Change the return statement (lines 353-366):
+
+```ts
+return (
+  <Input.Root classNames={withColumn.center()}>
+    <Input.TextInput
+      {...props}
+      variant='subdued'
+      autoFocus={props.autoFocus && !hasIosKeyboard}
+      placeholder={placeholder ?? defaultPlaceholder}
+      value={query}
+      onChange={handleChange}
+      onKeyDown={handleKeyDown}
+      ref={forwardedRef}
+    />
+  </Input.Root>
+);
+```
+
+Verify that `Input.Root` accepts a `classNames` prop. If it uses `composableProps` or `slottable`, it should accept `classNames` via the spread. If not, wrap in a div instead:
+
+```ts
+return (
+  <div className={withColumn.center()}>
+    <Input.Root>
+      <Input.TextInput ... />
+    </Input.Root>
+  </div>
+);
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run: `moon run react-ui-search:build`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
+git commit -m "feat(react-ui-search): make SearchList column-aware"
+```
+
+---
+
+### Task 7: Update Card — use own subgrid CSS
+
+**Files:**
+- Modify: `packages/ui/react-ui/src/components/Card/Card.tsx`
+
+- [ ] **Step 1: Change CardRow — replace Column.Row with own subgrid**
+
+CardRow currently renders `<Column.Row {...rest} className={tx('card.row', {}, className)}>`. Change it to use a plain div with the subgrid CSS:
+
+```ts
+const CardRow = slottable<HTMLDivElement, CardRowProps>(
+  ({ children, asChild, icon, ...props }, forwardedRef) => {
+    const { className, ...rest } = composableProps(props);
+    const Comp = asChild ? Slot : Primitive.div;
+    const { tx } = useThemeContext();
+
+    return (
+      <Comp {...rest} className={tx('card.row', {}, className)} ref={forwardedRef}>
+        {(icon && <CardIcon classNames='text-subdued' icon={icon} size={4} />) || <div />}
+        {children}
+      </Comp>
+    );
+  },
+);
+```
+
+Check `card.row` theme function to ensure it already includes `col-span-3 grid grid-cols-subgrid` or equivalent. If not, update the card theme:
+
+```ts
+// In card.ts theme (find cardRow function)
+// Ensure it includes: 'col-span-3 grid grid-cols-subgrid'
+```
+
+- [ ] **Step 2: Remove Column import from Card.tsx if no longer needed**
+
+Check if `Column` is still used elsewhere in Card.tsx (it is — `Card.Root` uses `Column.Root`). Keep the import.
+
+Actually, CardRow currently uses `<Column.Row>` which gets `col-span-3 grid grid-cols-subgrid` from the theme. If we switch to `<Comp>` (a plain div), the card.row theme function must include those classes. Check the card theme file to see if `card.row` already has the subgrid classes or if they come from `column.row`.
+
+If `card.row` theme does NOT include the subgrid classes (they come from column.row), add them to the card.row theme function.
+
+- [ ] **Step 3: Build to verify**
+
+Run: `moon run react-ui:build`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/react-ui/src/components/Card/Card.tsx
+# Also add card theme file if modified
+git commit -m "refactor(react-ui): Card.Row uses own subgrid instead of Column.Row"
+```
+
+---
+
+### Task 8: Update Column stories
+
+**Files:**
+- Modify: `packages/ui/react-ui/src/primitives/Column/Column.stories.tsx`
+
+- [ ] **Step 1: Update DefaultStory**
+
+Replace all `Column.Row center` with `Column.Center`. Replace the raw 3-slot `Column.Row` usage (A|B|C) to keep it as Column.Row:
+
+```tsx
+const DefaultStory = () => {
+  return (
+    <Column.Root classNames='overflow-hidden' gutter='md'>
+      <Column.Center>
+        <h1 className='p-1 bg-blue-500 text-black'>Header</h1>
+      </Column.Center>
+
+      <Column.Row>
+        <div className='p-1 bg-blue-500'>A</div>
+        <div className='p-1 bg-red-500'>B</div>
+        <div className='p-1 bg-blue-500'>C</div>
+      </Column.Row>
+
+      <Column.Center classNames='py-2'>
+        <Input.Root>
+          <Input.TextInput placeholder='Search' />
+        </Input.Root>
+      </Column.Center>
+
+      <Column.Bleed asChild>
+        <ScrollArea.Root orientation='vertical' padding>
+          <ScrollArea.Viewport>
+            <div className='flex flex-col gap-2'>
+              {Array.from({ length: 100 }).map((_, i) => (
+                <Input.Root key={i}>
+                  <Input.TextInput value={`Item ${i}`} readOnly />
+                </Input.Root>
+              ))}
+            </div>
+          </ScrollArea.Viewport>
+        </ScrollArea.Root>
+      </Column.Bleed>
+
+      <Column.Center>
+        <Flex column>
+          <h1 className='p-1 bg-red-500 text-black'>Section with overflow</h1>
+          <pre className='p-1 text-xs text-subdued overflow-auto'>{new Error().stack}</pre>
+        </Flex>
+      </Column.Center>
+
+      <Column.Center>
+        <div className='p-1 bg-green-500 text-black'>Footer</div>
+      </Column.Center>
+    </Column.Root>
+  );
+};
+```
+
+- [ ] **Step 2: Update WithScrollArea story**
+
+Replace `Column.Row center` with `Column.Center`:
+
+```tsx
+export const WithScrollArea = {
+  decorators: [withLayout({ layout: 'column' })],
+  render: () => (
+    <Column.Root classNames='overflow-hidden' gutter='md'>
+      <Column.Center>
+        <h2 className='py-3'>Header</h2>
+      </Column.Center>
+      <ScrollArea.Root padding centered orientation='vertical' classNames='col-span-full'>
+        <ScrollArea.Viewport>
+          <InputList items={30} />
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>
+      <Column.Center>
+        <h2 className='py-3'>Footer</h2>
+      </Column.Center>
+    </Column.Root>
+  ),
+};
+```
+
+- [ ] **Step 3: Update WithCenter story**
+
+Replace `Column.Row center` headers/footers with `Column.Center`:
+
+```tsx
+export const WithCenter: Story = {
+  decorators: [withLayout({ layout: 'column', classNames: 'w-[25rem]' })],
+  render: () => (
+    <Column.Root classNames='overflow-hidden' gutter='md'>
+      <Column.Center>
+        <h2 className='py-3'>Header (Column.Center)</h2>
+      </Column.Center>
+      <Column.Center classNames='flex flex-col'>
+        <p className='py-2'>This text is inside Column.Center. It sits in the central column between the gutters.</p>
+        <Input.Root>
+          <Input.Label>Name</Input.Label>
+          <Input.TextInput placeholder='Enter name' />
+        </Input.Root>
+      </Column.Center>
+      <Column.Center>
+        <h2 className='py-3'>Footer (Column.Center)</h2>
+      </Column.Center>
+    </Column.Root>
+  ),
+};
+```
+
+- [ ] **Step 4: Update WithBleed story**
+
+Replace `Column.Row center` with `Column.Center`:
+
+```tsx
+export const WithBleed: Story = {
+  decorators: [withLayout({ layout: 'column', classNames: 'w-[25rem]' })],
+  render: () => (
+    <Column.Root classNames='overflow-hidden' gutter='md'>
+      <Column.Center>
+        <h2 className='py-3'>Header (Column.Center)</h2>
+      </Column.Center>
+      <Column.Bleed asChild>
+        <ScrollArea.Root orientation='vertical' padding thin>
+          <ScrollArea.Viewport>
+            <InputList items={30} />
+          </ScrollArea.Viewport>
+        </ScrollArea.Root>
+      </Column.Bleed>
+      <Column.Center>
+        <h2 className='py-3'>Footer (Column.Center)</h2>
+      </Column.Center>
+    </Column.Root>
+  ),
+};
+```
+
+- [ ] **Step 5: Remove the TODO on line 13**
+
+The `List` component at the top of the file renders `ScrollArea.Root centered` directly inside Column.Root. ScrollArea auto-bleeds via `[.dx-column_&]:col-span-full`, so the clipping issue should be resolved. Remove or update the TODO comment.
+
+- [ ] **Step 6: Build to verify**
+
+Run: `moon run react-ui:build`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/ui/react-ui/src/primitives/Column/Column.stories.tsx
+git commit -m "refactor(react-ui): update Column stories for simplified API"
+```
+
+---
+
+### Task 9: Update AUDIT.md
+
+**Files:**
+- Modify: `packages/ui/react-ui/src/primitives/Column/AUDIT.md`
+
+- [ ] **Step 1: Update the document**
+
+Update the AUDIT.md to reflect the new design:
+- Document the `withColumn` utilities (center, propagate, consumed)
+- Document the `--dx-col` CSS custom property cascade
+- Update the Column primitives table
+- Update the component integration sections (Dialog, Form, SearchList, Card)
+- Remove references to old patterns (Column.Row center, Dialog.Body = Column.Center)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/ui/react-ui/src/primitives/Column/AUDIT.md
+git commit -m "docs(react-ui): update Column AUDIT.md for withColumn refactor"
+```
+
+---
+
+### Task 10: Full build and search for remaining Column.Row center usages
+
+**Files:**
+- Potentially modify: any consumer still using `Column.Row center` or `Column.Row fullWidth`
+
+- [ ] **Step 1: Search for remaining Column.Row center/fullWidth usages**
+
+Run: `grep -r 'Column\.Row.*center\|Column\.Row.*fullWidth\|center.*Column\.Row\|fullWidth.*Column\.Row' packages/ --include='*.tsx' --include='*.ts'`
+
+Fix any remaining usages by replacing with `Column.Center`.
+
+- [ ] **Step 2: Search for any direct ColumnStyleProps usage**
+
+Run: `grep -r 'ColumnStyleProps' packages/ --include='*.tsx' --include='*.ts'`
+
+Update any external references to the now-empty type.
+
+- [ ] **Step 3: Full build**
+
+Run: `moon run :build`
+Expected: PASS with no TypeScript errors
+
+- [ ] **Step 4: Run tests**
+
+Run: `moon run react-ui:test && moon run react-ui-form:test && moon run react-ui-search:test`
+Expected: PASS
+
+- [ ] **Step 5: Run lint**
+
+Run: `moon run :lint -- --fix`
+Expected: PASS or only pre-existing warnings
+
+- [ ] **Step 6: Final commit if any fixes were needed**
+
+```bash
+git add -A
+git commit -m "fix: address remaining Column.Row center usages"
+```

--- a/docs/superpowers/specs/2026-04-20-column-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-20-column-refactor-design.md
@@ -94,7 +94,7 @@ withColumn = {
 
   /** Resets --dx-col after consuming --gutter. Applied by ScrollArea.Viewport. */
   consumed: () => '[--dx-col:auto]',
-}
+};
 ```
 
 Usage in component theme functions:
@@ -115,14 +115,15 @@ const dialogBody = (_, ...etc) => mx(withColumn.propagate(), ...etc);
 
 ### Column primitives (simplified)
 
-| Primitive          | CSS                                              | Purpose                                  |
-| :----------------- | :----------------------------------------------- | :--------------------------------------- |
-| **Column.Root**    | `grid`, sets `--gutter` + `--dx-col`             | 3-column grid container                  |
-| **Column.Row**     | `col-span-full grid grid-cols-subgrid`           | 3-slot subgrid row (icon/content/action) |
-| **Column.Center**  | `withColumn.center()` convenience wrapper        | Center column placement                  |
-| **Column.Bleed**   | `withColumn.propagate()` convenience wrapper     | Full-width subgrid pass-through          |
+| Primitive         | CSS                                          | Purpose                                  |
+| :---------------- | :------------------------------------------- | :--------------------------------------- |
+| **Column.Root**   | `grid`, sets `--gutter` + `--dx-col`         | 3-column grid container                  |
+| **Column.Row**    | `col-span-full grid grid-cols-subgrid`       | 3-slot subgrid row (icon/content/action) |
+| **Column.Center** | `withColumn.center()` convenience wrapper    | Center column placement                  |
+| **Column.Bleed**  | `withColumn.propagate()` convenience wrapper | Full-width subgrid pass-through          |
 
 Changes from current:
+
 - **Column.Row** loses `center` and `fullWidth` props — always a 3-slot subgrid row.
 - **Column.Center** becomes a thin wrapper over `withColumn.center()` (same behavior, cleaner internals).
 - **Column.Bleed** changes from plain `col-span-full` to `col-span-full grid grid-cols-subgrid` (subgrid propagation).
@@ -132,41 +133,41 @@ Changes from current:
 
 #### Dialog
 
-| Sub-component    | Current                | After                            |
-| :--------------- | :--------------------- | :------------------------------- |
-| Dialog.Content   | Column.Root            | Column.Root (unchanged)          |
-| Dialog.Header    | Column.Row (center)    | withColumn.center() in theme     |
-| Dialog.Body      | Column.Center          | withColumn.propagate() in theme  |
-| Dialog.ActionBar | Column.Row (center)    | withColumn.center() in theme     |
+| Sub-component    | Current             | After                           |
+| :--------------- | :------------------ | :------------------------------ |
+| Dialog.Content   | Column.Root         | Column.Root (unchanged)         |
+| Dialog.Header    | Column.Row (center) | withColumn.center() in theme    |
+| Dialog.Body      | Column.Center       | withColumn.propagate() in theme |
+| Dialog.ActionBar | Column.Row (center) | withColumn.center() in theme    |
 
 #### Form
 
-| Sub-component  | Current               | After                           |
-| :------------- | :-------------------- | :------------------------------ |
-| Form.Viewport  | ScrollArea (unchanged)| ScrollArea (unchanged)          |
-| Form.Content   | No Column awareness   | withColumn.center() in theme    |
-| Form.Actions   | No Column awareness   | withColumn.center() in theme    |
+| Sub-component | Current                | After                        |
+| :------------ | :--------------------- | :--------------------------- |
+| Form.Viewport | ScrollArea (unchanged) | ScrollArea (unchanged)       |
+| Form.Content  | No Column awareness    | withColumn.center() in theme |
+| Form.Actions  | No Column awareness    | withColumn.center() in theme |
 
 #### SearchList
 
-| Sub-component      | Current               | After                        |
-| :----------------- | :-------------------- | :--------------------------- |
-| SearchList.Viewport| ScrollArea (unchanged)| ScrollArea (unchanged)       |
-| SearchList.Input   | No Column awareness   | withColumn.center() in theme |
+| Sub-component       | Current                | After                        |
+| :------------------ | :--------------------- | :--------------------------- |
+| SearchList.Viewport | ScrollArea (unchanged) | ScrollArea (unchanged)       |
+| SearchList.Input    | No Column awareness    | withColumn.center() in theme |
 
 #### Card
 
-| Sub-component | Current     | After                             |
-| :------------ | :---------- | :-------------------------------- |
-| Card.Root     | Column.Root | Column.Root (unchanged)           |
-| Card.Row      | Column.Row  | Own subgrid CSS (no Column.Row)   |
+| Sub-component | Current     | After                           |
+| :------------ | :---------- | :------------------------------ |
+| Card.Root     | Column.Root | Column.Root (unchanged)         |
+| Card.Row      | Column.Row  | Own subgrid CSS (no Column.Row) |
 
 #### ScrollArea
 
-| Sub-component      | Current                           | After                                      |
-| :----------------- | :-------------------------------- | :----------------------------------------- |
-| ScrollArea.Root    | `[.dx-column_&]:col-span-full`   | Unchanged                                  |
-| ScrollArea.Viewport| Consumes `--gutter` for padding  | Also applies `withColumn.consumed()` to reset `--dx-col` |
+| Sub-component       | Current                         | After                                                    |
+| :------------------ | :------------------------------ | :------------------------------------------------------- |
+| ScrollArea.Root     | `[.dx-column_&]:col-span-full`  | Unchanged                                                |
+| ScrollArea.Viewport | Consumes `--gutter` for padding | Also applies `withColumn.consumed()` to reset `--dx-col` |
 
 ### Example: Form inside Dialog (no scroll)
 
@@ -236,6 +237,7 @@ All usages of `Column.Row center` must be migrated to `Column.Center` (or to ele
 apply `withColumn.center()` via their theme).
 
 Known usages:
+
 - Dialog.Header → theme uses `withColumn.center()`
 - Dialog.ActionBar → theme uses `withColumn.center()`
 - Column stories → update to use Column.Center
@@ -244,6 +246,7 @@ Known usages:
 ### Storybook verification
 
 Visually verify after migration:
+
 - Dialog with Form (scrolling and non-scrolling variants)
 - Dialog with SearchList
 - Card layout with icon rows

--- a/docs/superpowers/specs/2026-04-20-column-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-20-column-refactor-design.md
@@ -1,0 +1,259 @@
+# Column Refactor: CSS Custom Property Cascade
+
+## Summary
+
+Refactor the Column primitive system so that all core UI components (Dialog, Form, Card, SearchList)
+are automatically column-aware via CSS custom properties and theme utilities. Remove redundant props
+and ensure consistent gutter alignment without manual wiring.
+
+## Background
+
+`Column` is the core layout primitive for vertically-aligned component layouts (Dialog, Form, Card).
+It establishes a 3-column CSS grid — left gutter, center content, right gutter — via the `--gutter`
+CSS variable.
+
+### Current problems
+
+1. **Dialog.Body uses Column.Center**, which constrains children to the center column. When a Form or
+   SearchList is placed inside Dialog.Body, their ScrollArea (Viewport) can't bleed to full width for
+   proper scrollbar placement.
+
+2. **Column.Row `center` duplicates Column.Center**. When `center` is true, Column.Row drops its
+   subgrid and produces identical CSS to Column.Center (`col-start-2 col-span-1`).
+
+3. **Non-viewport components are not column-aware**. Form.Content, SearchList.Input, and Form.Actions
+   have no Column detection. Consumers must manually wrap them in Column.Center when used inside a
+   Column grid.
+
+4. **ScrollArea auto-bleeds but nothing auto-centers**. ScrollArea.Root detects Column context
+   (via `.dx-column` marker) and applies `col-span-full`. But there is no equivalent mechanism for
+   components that should center themselves.
+
+### How gutter alignment works today
+
+- `Column.Root` sets `--gutter` as an inline CSS variable and adds the `dx-column` marker class.
+- `ScrollArea.Root` detects `dx-column` and applies `[.dx-column_&]:col-span-full` (auto-bleed).
+- `ScrollArea.Viewport` consumes `--gutter` via `pl-[var(--gutter,...)]` / `pr-[calc(var(--gutter,...)-var(--scroll-width))]`.
+- `Form.Viewport` and `SearchList.Viewport` wrap ScrollArea, so they inherit this behavior.
+- Non-viewport components (Form.Content, SearchList.Input) have no Column awareness.
+
+## Design
+
+### CSS custom property cascade
+
+Column.Root sets a new CSS custom property `--dx-col` alongside the existing `--gutter`.
+Components consume `--dx-col` for grid placement. ScrollArea.Viewport resets it after consuming `--gutter`.
+
+```
+Column.Root
+│  sets --gutter: <size>
+│  sets --dx-col: 2 / span 1
+│
+├── Non-viewport component (Form.Content, SearchList.Input)
+│   applies: grid-column: var(--dx-col, auto)
+│   result: centers in column 2
+│
+├── ScrollArea.Root
+│   applies: col-span-full (via dx-column detection, existing)
+│   └── ScrollArea.Viewport
+│       consumes: --gutter for padding (existing)
+│       resets: --dx-col: auto
+│       │
+│       └── Nested component (Form.Content inside Form.Viewport)
+│           applies: grid-column: var(--dx-col, auto)
+│           result: auto — no grid placement, gutter already handled by ScrollArea
+```
+
+### Subgrid propagation
+
+For `--dx-col` grid placement to work, a component must be a CSS grid item (direct child of a grid
+container). Intermediate containers (Dialog.Body, etc.) must propagate the Column grid via CSS subgrid
+so their children remain grid items:
+
+```css
+col-span-full grid grid-cols-subgrid
+```
+
+This was previously rejected when it was combined with padding-based gutters (overflow-hidden clipped
+negative margins). With the current approach (grid columns for gutters, no padding breakout), subgrid
+propagation has no overflow issues.
+
+### Theme utilities (`withColumn`)
+
+The theme provides reusable utilities that components apply in their theme functions.
+Individual components never import Column or think about Column mechanics.
+
+```ts
+// In ui-theme column.ts
+withColumn = {
+  /** Centers element in the Column grid via --dx-col. No-op outside Column or inside ScrollArea. */
+  center: () => '[grid-column:var(--dx-col,auto)]',
+
+  /** Propagates the Column grid to children via subgrid. No-op outside Column. */
+  propagate: () => '[.dx-column_&]:col-span-full [.dx-column_&]:grid [.dx-column_&]:grid-cols-subgrid',
+
+  /** Resets --dx-col after consuming --gutter. Applied by ScrollArea.Viewport. */
+  consumed: () => '[--dx-col:auto]',
+}
+```
+
+Usage in component theme functions:
+
+```ts
+// form.ts
+const formContent = (_, ...etc) => mx(withColumn.center(), 'flex flex-col w-full pb-form-gap', ...etc);
+
+// search-list.ts
+const searchListInput = (_, ...etc) => mx(withColumn.center(), ...etc);
+
+// scroll-area.ts (viewport)
+const scrollAreaViewport = (...) => mx(withColumn.consumed(), ...existing...);
+
+// dialog.ts (body)
+const dialogBody = (_, ...etc) => mx(withColumn.propagate(), ...etc);
+```
+
+### Column primitives (simplified)
+
+| Primitive          | CSS                                              | Purpose                                  |
+| :----------------- | :----------------------------------------------- | :--------------------------------------- |
+| **Column.Root**    | `grid`, sets `--gutter` + `--dx-col`             | 3-column grid container                  |
+| **Column.Row**     | `col-span-full grid grid-cols-subgrid`           | 3-slot subgrid row (icon/content/action) |
+| **Column.Center**  | `withColumn.center()` convenience wrapper        | Center column placement                  |
+| **Column.Bleed**   | `withColumn.propagate()` convenience wrapper     | Full-width subgrid pass-through          |
+
+Changes from current:
+- **Column.Row** loses `center` and `fullWidth` props — always a 3-slot subgrid row.
+- **Column.Center** becomes a thin wrapper over `withColumn.center()` (same behavior, cleaner internals).
+- **Column.Bleed** changes from plain `col-span-full` to `col-span-full grid grid-cols-subgrid` (subgrid propagation).
+- **Column.Root** sets `--dx-col: 2 / span 1` alongside `--gutter`.
+
+### Consumer integration
+
+#### Dialog
+
+| Sub-component    | Current                | After                            |
+| :--------------- | :--------------------- | :------------------------------- |
+| Dialog.Content   | Column.Root            | Column.Root (unchanged)          |
+| Dialog.Header    | Column.Row (center)    | withColumn.center() in theme     |
+| Dialog.Body      | Column.Center          | withColumn.propagate() in theme  |
+| Dialog.ActionBar | Column.Row (center)    | withColumn.center() in theme     |
+
+#### Form
+
+| Sub-component  | Current               | After                           |
+| :------------- | :-------------------- | :------------------------------ |
+| Form.Viewport  | ScrollArea (unchanged)| ScrollArea (unchanged)          |
+| Form.Content   | No Column awareness   | withColumn.center() in theme    |
+| Form.Actions   | No Column awareness   | withColumn.center() in theme    |
+
+#### SearchList
+
+| Sub-component      | Current               | After                        |
+| :----------------- | :-------------------- | :--------------------------- |
+| SearchList.Viewport| ScrollArea (unchanged)| ScrollArea (unchanged)       |
+| SearchList.Input   | No Column awareness   | withColumn.center() in theme |
+
+#### Card
+
+| Sub-component | Current     | After                             |
+| :------------ | :---------- | :-------------------------------- |
+| Card.Root     | Column.Root | Column.Root (unchanged)           |
+| Card.Row      | Column.Row  | Own subgrid CSS (no Column.Row)   |
+
+#### ScrollArea
+
+| Sub-component      | Current                           | After                                      |
+| :----------------- | :-------------------------------- | :----------------------------------------- |
+| ScrollArea.Root    | `[.dx-column_&]:col-span-full`   | Unchanged                                  |
+| ScrollArea.Viewport| Consumes `--gutter` for padding  | Also applies `withColumn.consumed()` to reset `--dx-col` |
+
+### Example: Form inside Dialog (no scroll)
+
+```
+Dialog.Content = Column.Root (--gutter: sm, --dx-col: 2/span 1, grid: 16px|1fr|16px)
+  Dialog.Header (grid-column: var(--dx-col) → col 2 ✓)
+  Dialog.Body (col-span-full, subgrid → passes 3-col grid to children)
+    Form.Content (grid-column: var(--dx-col) → col 2 ✓)
+    Form.Actions (grid-column: var(--dx-col) → col 2 ✓)
+  Dialog.ActionBar (grid-column: var(--dx-col) → col 2 ✓)
+```
+
+### Example: Form inside Dialog (with scroll)
+
+```
+Dialog.Content = Column.Root (--gutter: sm, --dx-col: 2/span 1)
+  Dialog.Header (grid-column: var(--dx-col) → col 2 ✓)
+  Dialog.Body (col-span-full, subgrid)
+    Form.Viewport = ScrollArea.Root (col-span-full ✓)
+      ScrollArea.Viewport (padding via --gutter, resets --dx-col: auto)
+        Form.Content (grid-column: auto → no grid placement ✓)
+    Form.Actions (grid-column: var(--dx-col) → col 2 ✓)
+  Dialog.ActionBar (grid-column: var(--dx-col) → col 2 ✓)
+```
+
+### Example: SearchList inside Dialog
+
+```
+Dialog.Content = Column.Root (--gutter: sm, --dx-col: 2/span 1)
+  Dialog.Header (grid-column: var(--dx-col) → col 2 ✓)
+  Dialog.Body (col-span-full, subgrid)
+    SearchList.Input (grid-column: var(--dx-col) → col 2 ✓)
+    SearchList.Viewport = ScrollArea.Root (col-span-full ✓)
+      ScrollArea.Viewport (padding via --gutter, resets --dx-col: auto)
+        SearchList.Item... (inside scroll, no grid placement ✓)
+  Dialog.ActionBar (grid-column: var(--dx-col) → col 2 ✓)
+```
+
+### Subgrid chain integrity
+
+For subgrid propagation to work, every intermediate DOM element between Column.Root and the
+target component must either:
+
+1. Apply `withColumn.propagate()` (col-span-full + subgrid), or
+2. Use `display: contents` to become grid-transparent.
+
+Components that are pure React context providers with a wrapping `<div>` (e.g., Form.Root)
+must apply `withColumn.propagate()` in their theme so the subgrid chain is not broken.
+Similarly, optional wrapper components like SearchList.Content (`dx-expander`) must propagate
+when inside a Column context.
+
+The `[.dx-column_&]` prefix ensures these styles only apply inside a Column — outside Column,
+these components remain normal block/flex containers.
+
+## Migration
+
+### Dialog consumers
+
+All Dialog consumers using `Dialog.Body` continue to work — Body's internal change from
+Column.Center to subgrid propagation is transparent. Consumers that manually use Column.Center
+or Column.Bleed inside Dialog.Content should be reviewed but will likely still work since
+Column.Center and Column.Bleed remain as convenience components.
+
+### Column.Row center → Column.Center
+
+All usages of `Column.Row center` must be migrated to `Column.Center` (or to elements that
+apply `withColumn.center()` via their theme).
+
+Known usages:
+- Dialog.Header → theme uses `withColumn.center()`
+- Dialog.ActionBar → theme uses `withColumn.center()`
+- Column stories → update to use Column.Center
+- Card.Row → remains as Column.Row (uses the 3-slot subgrid, never used `center`)
+
+### Storybook verification
+
+Visually verify after migration:
+- Dialog with Form (scrolling and non-scrolling variants)
+- Dialog with SearchList
+- Card layout with icon rows
+- Column stories (Default, WithCenter, WithBleed, WithScrollArea)
+
+## Known issues to fix
+
+1. **Dialog story comment is wrong**: `Dialog.stories.tsx` line 27 says "Dialog.Body delegates to
+   Column.Center" — needs updating to reflect the new propagation behavior.
+
+2. **Column story TODO**: `Column.stories.tsx` line 13 has `TODO(burdon): Content is clipped!` —
+   the `List` component renders ScrollArea.Root without Column.Bleed wrapper. After this refactor,
+   ScrollArea auto-bleeds so this should resolve itself.

--- a/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
+++ b/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
@@ -172,6 +172,31 @@ const ChatRoot = ({ children, chat, queue, processor, onEvent, ...props }: ChatR
 ChatRoot.displayName = 'Chat.Root';
 
 //
+// Toolbar
+//
+
+const CHAT_TOOLBAR_NAME = 'Chat.Toolbar';
+
+type ChatToolbarProps = Pick<MenuRootProps, 'attendableId'> & {
+  companionTo?: Obj.Unknown;
+};
+
+const ChatToolbar = composable<HTMLDivElement, ChatToolbarProps>(
+  ({ attendableId, companionTo, ...props }, forwardedRef) => {
+    const { chat } = useChatContext(CHAT_TOOLBAR_NAME);
+    const menuActions = useChatToolbarActions({ chat, companionTo });
+
+    return (
+      <Menu.Root {...menuActions} attendableId={attendableId}>
+        <Menu.Toolbar {...composableProps(props)} ref={forwardedRef} />
+      </Menu.Root>
+    );
+  },
+);
+
+ChatToolbar.displayName = CHAT_TOOLBAR_NAME;
+
+//
 // Viewport
 //
 
@@ -435,40 +460,15 @@ const ChatPrompt = ({
 ChatPrompt.displayName = CHAT_PROMPT_NAME;
 
 //
-// Toolbar
-//
-
-const CHAT_TOOLBAR_NAME = 'Chat.Toolbar';
-
-type ChatToolbarProps = Pick<MenuRootProps, 'attendableId'> & {
-  companionTo?: Obj.Unknown;
-};
-
-const ChatToolbar = composable<HTMLDivElement, ChatToolbarProps>(
-  ({ attendableId, companionTo, ...props }, forwardedRef) => {
-    const { chat } = useChatContext(CHAT_TOOLBAR_NAME);
-    const menuActions = useChatToolbarActions({ chat, companionTo });
-
-    return (
-      <Menu.Root {...menuActions} attendableId={attendableId}>
-        <Menu.Toolbar {...composableProps(props)} ref={forwardedRef} />
-      </Menu.Root>
-    );
-  },
-);
-
-ChatToolbar.displayName = CHAT_TOOLBAR_NAME;
-
-//
 // Chat
 //
 
 export const Chat = {
   Root: ChatRoot,
+  Toolbar: ChatToolbar,
   Viewport: ChatViewport,
   Thread: ChatThread,
   Prompt: ChatPrompt,
-  Toolbar: ChatToolbar,
 };
 
-export type { ChatRootProps, ChatViewportProps, ChatThreadProps, ChatPromptProps, ChatToolbarProps, ChatEvent };
+export type { ChatRootProps, ChatToolbarProps, ChatViewportProps, ChatThreadProps, ChatPromptProps, ChatEvent };

--- a/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatOptions.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatOptions.stories.tsx
@@ -1,0 +1,129 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { type Meta, type StoryObj } from '@storybook/react-vite';
+import * as Effect from 'effect/Effect';
+import React, { useState } from 'react';
+
+import { withPluginManager } from '@dxos/app-framework/testing';
+import { capabilities } from '@dxos/assistant-toolkit/testing';
+import { Feed, Filter } from '@dxos/echo';
+import { ChessPlugin } from '@dxos/plugin-chess';
+import { ClientPlugin } from '@dxos/plugin-client';
+import { initializeIdentity } from '@dxos/plugin-client/testing';
+import { MapPlugin } from '@dxos/plugin-map';
+import { TablePlugin } from '@dxos/plugin-table';
+import { corePlugins } from '@dxos/plugin-testing';
+import { random } from '@dxos/random';
+import { useQuery, useSpaces } from '@dxos/react-client/echo';
+import { Loading, withTheme } from '@dxos/react-ui/testing';
+import { createObjectFactory } from '@dxos/schema/testing';
+import { Organization, Person } from '@dxos/types';
+
+import { useBlueprintRegistry, useContextBinder } from '#hooks';
+
+import { translations } from '../../translations';
+import { ChatOptions, ObjectsPanel, type ChatOptionsProps } from './ChatOptions';
+
+random.seed(1);
+
+const presets = [
+  { id: 'edge-claude-sonnet', label: 'Edge · Claude Sonnet' },
+  { id: 'edge-gpt-4o', label: 'Edge · GPT-4o' },
+  { id: 'ollama-llama3', label: 'Ollama · Llama 3' },
+];
+
+type DefaultStoryProps = Pick<ChatOptionsProps, 'presets'>;
+
+const DefaultStory = ({ presets }: DefaultStoryProps) => {
+  const [space] = useSpaces();
+  const [feed] = useQuery(space?.db, Filter.type(Feed.Feed));
+  const blueprintRegistry = useBlueprintRegistry();
+  const binder = useContextBinder(space, feed);
+  const [preset, setPreset] = useState(presets?.[0]?.id);
+  if (!space || !binder) {
+    return <Loading />;
+  }
+  return (
+    <ChatOptions
+      db={space.db}
+      context={binder}
+      blueprintRegistry={blueprintRegistry}
+      presets={presets}
+      preset={preset}
+      onPresetChange={setPreset}
+    />
+  );
+};
+
+const meta = {
+  title: 'plugins/plugin-assistant/components/ChatOptions',
+  component: ChatOptions as any,
+  render: DefaultStory,
+  decorators: [
+    withTheme(),
+    withPluginManager({
+      plugins: [
+        ...corePlugins(),
+        ClientPlugin({
+          types: [Feed.Feed, Organization.Organization, Person.Person],
+          onClientInitialized: ({ client }) =>
+            Effect.gen(function* () {
+              yield* initializeIdentity(client);
+              const [space] = client.spaces.get();
+              yield* Effect.promise(() => space.waitUntilReady());
+
+              // Populate space with sample objects.
+              const factory = createObjectFactory(space.db, random as any);
+              yield* Effect.promise(() =>
+                factory([
+                  { type: Organization.Organization, count: 8 },
+                  { type: Person.Person, count: 8 },
+                ]),
+              );
+
+              // Create the chat feed used by the context binder.
+              space.db.add(Feed.make());
+              yield* Effect.promise(() => space.db.flush({ indexes: true }));
+            }),
+        }),
+        ChessPlugin(),
+        MapPlugin(),
+        TablePlugin(),
+      ],
+      capabilities,
+    }),
+  ],
+  parameters: {
+    layout: 'centered',
+    translations,
+  },
+} satisfies Meta<typeof DefaultStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    presets,
+  },
+};
+
+export const ObjectsPanelStory: Story = {
+  render: () => {
+    const [space] = useSpaces();
+    const [feed] = useQuery(space?.db, Filter.type(Feed.Feed));
+    const binder = useContextBinder(space, feed);
+    if (!space || !binder) {
+      return <Loading />;
+    }
+
+    return (
+      <div className='flex flex-col w-[300px] h-[300px] border border-separator'>
+        <ObjectsPanel db={space.db} context={binder} />
+      </div>
+    );
+  },
+};

--- a/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatOptions.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatOptions.tsx
@@ -7,8 +7,7 @@ import React, { type JSX, useMemo, useState } from 'react';
 
 import { type AiContextBinder } from '@dxos/assistant';
 import { type Blueprint } from '@dxos/blueprints';
-import { type Database, Filter, Obj, Type } from '@dxos/echo';
-import { Annotation } from '@dxos/echo';
+import { Annotation, type Database, Filter, Obj, Type } from '@dxos/echo';
 import { useQuery } from '@dxos/react-client/echo';
 import { IconButton, Popover, Select, useTranslation } from '@dxos/react-ui';
 import { Listbox, SearchList, useSearchListResults } from '@dxos/react-ui-search';
@@ -65,6 +64,7 @@ export const ChatOptions = ({ db, context, blueprintRegistry, presets, preset, o
             <Popover.Viewport>
               <Tabs.Root orientation='horizontal' defaultValue='blueprints' defaultActivePart='list' tabIndex={-1}>
                 <Tabs.Viewport
+                  // TODO(burdon): Simplify styles.
                   classNames={mx(
                     'max-h-(--radix-popover-content-available-height) grid grid-rows-[1fr_min-content]',
                     '[&_[cmdk-root]]:contents [&_[role="tabpanel"]]:grid [&_[role="tabpanel"]]:grid-rows-[1fr_min-content]',
@@ -107,7 +107,6 @@ const BlueprintsPanel = ({
   const blueprints = useBlueprints({ blueprintRegistry, db });
   const activeBlueprints = useActiveBlueprints({ context });
   const { onUpdateBlueprint } = useBlueprintHandlers({ db, context, blueprintRegistry });
-
   const { results, handleSearch } = useSearchListResults({
     items: blueprints,
     extract: (blueprint) => blueprint.name,
@@ -158,7 +157,8 @@ const ModelsPanel = ({
 
 const ANY = '__any__';
 
-const ObjectsPanel = ({ db, context }: Pick<ChatOptionsProps, 'db' | 'context'>): JSX.Element => {
+/** @private */
+export const ObjectsPanel = ({ db, context }: Pick<ChatOptionsProps, 'db' | 'context'>): JSX.Element => {
   const { t } = useTranslation(meta.id);
 
   // Item types sorted by label.
@@ -186,7 +186,6 @@ const ObjectsPanel = ({ db, context }: Pick<ChatOptionsProps, 'db' | 'context'>)
   // Context objects.
   const objects = useQuery(db, typename === ANY ? anyFilter : Filter.typename(typename));
   const { objects: contextObjects, onUpdateObject } = useContextObjects({ db, context });
-
   const { results, handleSearch } = useSearchListResults({
     items: objects,
     extract: (object) => Obj.getLabel(object) ?? Obj.getTypename(object) ?? object.id,
@@ -201,7 +200,10 @@ const ObjectsPanel = ({ db, context }: Pick<ChatOptionsProps, 'db' | 'context'>)
               const isActive = contextObjects.findIndex((obj) => obj.id === object.id) !== -1;
               const { icon, hue } = Option.fromNullable(Obj.getSchema(object)).pipe(
                 Option.flatMap(Annotation.IconAnnotation.get),
-                Option.getOrElse(() => ({ icon: DEFAULT_OBJECT_ICON, hue: undefined as string | undefined })),
+                Option.getOrElse(() => ({
+                  icon: 'ph--cube--regular',
+                  hue: undefined as string | undefined,
+                })),
               );
               const styles = hue ? getStyles(hue) : undefined;
               return (
@@ -223,7 +225,7 @@ const ObjectsPanel = ({ db, context }: Pick<ChatOptionsProps, 'db' | 'context'>)
         </SearchList.Viewport>
       </SearchList.Content>
 
-      <div role='none' className='grid grid-cols-[min-content_1fr] gap-2 px-form-chrome mb-form-chrome'>
+      <div role='none' className='grid grid-cols-[min-content_1fr] px-form-chrome mb-form-chrome'>
         <Select.Root value={typename === ANY ? undefined : typename} onValueChange={setTypename}>
           <Select.TriggerButton placeholder={t('type-filter.placeholder')} />
           <Select.Portal>
@@ -247,6 +249,3 @@ const ObjectsPanel = ({ db, context }: Pick<ChatOptionsProps, 'db' | 'context'>)
     </SearchList.Root>
   );
 };
-
-// TODO(dmaretskyi): Extract those somewhere else.
-const DEFAULT_OBJECT_ICON = 'ph--cube--regular';

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/ReasoningWidget.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/ReasoningWidget.stories.tsx
@@ -37,7 +37,7 @@ const DefaultStory = ({ text }: DefaultStoryProps) => {
 };
 
 const meta = {
-  title: 'plugins/plugin-assistant/components/ChatThread/widgets/ReasoningWidget',
+  title: 'plugins/plugin-assistant/components/ChatWidgets/ReasoningWidget',
   component: DefaultStory,
   decorators: [withTheme(), withLayout({ layout: 'column' })],
   parameters: {

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/ToolWidget.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/ToolWidget.stories.tsx
@@ -33,7 +33,7 @@ const toolCallAndResult: ContentBlock.Any[] = [
 ];
 
 const meta = {
-  title: 'plugins/plugin-assistant/components/ChatThread/widgets/ToolWidget',
+  title: 'plugins/plugin-assistant/components/ChatWidgets/ToolWidget',
   component: ToolWidget,
   decorators: [withTheme(), withLayout({ layout: 'column' })],
   parameters: {

--- a/packages/plugins/plugin-discord/src/containers/BotArticle/BotArticle.tsx
+++ b/packages/plugins/plugin-discord/src/containers/BotArticle/BotArticle.tsx
@@ -44,9 +44,8 @@ export const BotArticle = ({ role, subject: bot }: BotArticleProps) => {
       </Panel.Toolbar>
       <Panel.Content asChild>
         <Column.Root>
-          <Column.Bleed asChild>
-            <ScrollArea.Root orientation='vertical' padding>
-              <ScrollArea.Viewport>
+          <ScrollArea.Root orientation='vertical' padding>
+            <ScrollArea.Viewport>
                 <Input.Root>
                   <Input.Label>{t('bot-token.label')}</Input.Label>
                   <div role='none' className='flex items-center gap-2'>
@@ -92,9 +91,8 @@ export const BotArticle = ({ role, subject: bot }: BotArticleProps) => {
                     {t('disconnect.button')}
                   </Button>
                 )}
-              </ScrollArea.Viewport>
-            </ScrollArea.Root>
-          </Column.Bleed>
+            </ScrollArea.Viewport>
+          </ScrollArea.Root>
         </Column.Root>
       </Panel.Content>
     </Panel.Root>

--- a/packages/plugins/plugin-discord/src/containers/BotArticle/BotArticle.tsx
+++ b/packages/plugins/plugin-discord/src/containers/BotArticle/BotArticle.tsx
@@ -46,51 +46,51 @@ export const BotArticle = ({ role, subject: bot }: BotArticleProps) => {
         <Column.Root>
           <ScrollArea.Root orientation='vertical' padding>
             <ScrollArea.Viewport>
+              <Input.Root>
+                <Input.Label>{t('bot-token.label')}</Input.Label>
+                <div role='none' className='flex items-center gap-2'>
+                  <Input.TextInput
+                    type={tokenVisible ? 'text' : 'password'}
+                    value={bot.token ?? ''}
+                    onChange={(event) => handleSetToken(event.target.value)}
+                  />
+                  <Button variant='ghost' onClick={() => setTokenVisible((visible) => !visible)}>
+                    {tokenVisible ? t('token-hide.label') : t('token-show.label')}
+                  </Button>
+                </div>
+              </Input.Root>
+
+              {bot.inviteUrl && (
                 <Input.Root>
-                  <Input.Label>{t('bot-token.label')}</Input.Label>
+                  <Input.Label>{t('invite-url.label')}</Input.Label>
                   <div role='none' className='flex items-center gap-2'>
-                    <Input.TextInput
-                      type={tokenVisible ? 'text' : 'password'}
-                      value={bot.token ?? ''}
-                      onChange={(event) => handleSetToken(event.target.value)}
-                    />
-                    <Button variant='ghost' onClick={() => setTokenVisible((visible) => !visible)}>
-                      {tokenVisible ? t('token-hide.label') : t('token-show.label')}
-                    </Button>
+                    <Input.TextInput disabled value={bot.inviteUrl} />
+                    <Clipboard.IconButton value={bot.inviteUrl} />
                   </div>
                 </Input.Root>
+              )}
 
-                {bot.inviteUrl && (
-                  <Input.Root>
-                    <Input.Label>{t('invite-url.label')}</Input.Label>
-                    <div role='none' className='flex items-center gap-2'>
-                      <Input.TextInput disabled value={bot.inviteUrl} />
-                      <Clipboard.IconButton value={bot.inviteUrl} />
-                    </div>
-                  </Input.Root>
-                )}
+              {bot.guildName && (
+                <Input.Root>
+                  <Input.Label>{t('guild.label')}</Input.Label>
+                  <Input.TextInput disabled value={bot.guildName} />
+                </Input.Root>
+              )}
 
-                {bot.guildName && (
-                  <Input.Root>
-                    <Input.Label>{t('guild.label')}</Input.Label>
-                    <Input.TextInput disabled value={bot.guildName} />
-                  </Input.Root>
-                )}
+              {bot.channels && bot.channels.length > 0 && (
+                <Input.Root>
+                  <Input.Label>{t('channels.label')}</Input.Label>
+                  {bot.channels.map((channel) => (
+                    <Input.TextInput key={channel.channelId} disabled value={`#${channel.channelName}`} />
+                  ))}
+                </Input.Root>
+              )}
 
-                {bot.channels && bot.channels.length > 0 && (
-                  <Input.Root>
-                    <Input.Label>{t('channels.label')}</Input.Label>
-                    {bot.channels.map((channel) => (
-                      <Input.TextInput key={channel.channelId} disabled value={`#${channel.channelName}`} />
-                    ))}
-                  </Input.Root>
-                )}
-
-                {bot.guildId && (
-                  <Button variant='outline' onClick={handleDisconnect}>
-                    {t('disconnect.button')}
-                  </Button>
-                )}
+              {bot.guildId && (
+                <Button variant='outline' onClick={handleDisconnect}>
+                  {t('disconnect.button')}
+                </Button>
+              )}
             </ScrollArea.Viewport>
           </ScrollArea.Root>
         </Column.Root>

--- a/packages/plugins/plugin-navtree/src/containers/CommandsDialogContent/CommandsDialogContent.tsx
+++ b/packages/plugins/plugin-navtree/src/containers/CommandsDialogContent/CommandsDialogContent.tsx
@@ -10,7 +10,7 @@ import { useAppGraph } from '@dxos/app-toolkit/ui';
 import { Keyboard, keySymbols } from '@dxos/keyboard';
 import { Graph, Node, useActionRunner } from '@dxos/plugin-graph';
 import { useActions } from '@dxos/plugin-graph';
-import { Button, Column, Dialog, toLocalizedString, useTranslation } from '@dxos/react-ui';
+import { Button, Dialog, toLocalizedString, useTranslation } from '@dxos/react-ui';
 import { SearchList, useSearchListResults } from '@dxos/react-ui-search';
 import { osTranslations } from '@dxos/ui-theme';
 import { getHostPlatform } from '@dxos/util';
@@ -72,11 +72,8 @@ export const CommandsDialogContent = forwardRef<HTMLDivElement, CommandsDialogCo
       <Dialog.Content ref={forwardedRef}>
         <Dialog.Title srOnly>{t('commands-dialog.title', { ns: meta.id })}</Dialog.Title>
         <SearchList.Root onSearch={handleSearch}>
-          <Column.Center>
-            <SearchList.Input placeholder={t('command-list-input.placeholder')} />
-          </Column.Center>
-          <Column.Bleed>
-            <SearchList.Viewport>
+          <SearchList.Input placeholder={t('command-list-input.placeholder')} />
+          <SearchList.Viewport>
               {results.map((action) => {
                 const shortcut =
                   typeof action.properties.keyBinding === 'string'
@@ -117,8 +114,7 @@ export const CommandsDialogContent = forwardRef<HTMLDivElement, CommandsDialogCo
                   />
                 );
               })}
-            </SearchList.Viewport>
-          </Column.Bleed>
+          </SearchList.Viewport>
         </SearchList.Root>
         <Dialog.ActionBar>
           <Dialog.Close asChild>

--- a/packages/plugins/plugin-navtree/src/containers/CommandsDialogContent/CommandsDialogContent.tsx
+++ b/packages/plugins/plugin-navtree/src/containers/CommandsDialogContent/CommandsDialogContent.tsx
@@ -74,46 +74,46 @@ export const CommandsDialogContent = forwardRef<HTMLDivElement, CommandsDialogCo
         <SearchList.Root onSearch={handleSearch}>
           <SearchList.Input placeholder={t('command-list-input.placeholder')} />
           <SearchList.Viewport>
-              {results.map((action) => {
-                const shortcut =
-                  typeof action.properties.keyBinding === 'string'
-                    ? action.properties.keyBinding
-                    : action.properties.keyBinding?.[getHostPlatform()];
+            {results.map((action) => {
+              const shortcut =
+                typeof action.properties.keyBinding === 'string'
+                  ? action.properties.keyBinding
+                  : action.properties.keyBinding?.[getHostPlatform()];
 
-                return (
-                  <SearchList.Item
-                    value={action.id}
-                    key={action.id}
-                    label={toLocalizedString(action.properties.label, t)}
-                    icon={action.properties.icon}
-                    suffix={shortcut ? keySymbols(shortcut).join('') : undefined}
-                    onSelect={() => {
-                      if (action.properties.disabled) {
-                        return;
+              return (
+                <SearchList.Item
+                  value={action.id}
+                  key={action.id}
+                  label={toLocalizedString(action.properties.label, t)}
+                  icon={action.properties.icon}
+                  suffix={shortcut ? keySymbols(shortcut).join('') : undefined}
+                  onSelect={() => {
+                    if (action.properties.disabled) {
+                      return;
+                    }
+
+                    if (Node.isActionGroup(action)) {
+                      setSelected(action.id);
+                      return;
+                    }
+
+                    void invokePromise(LayoutOperation.UpdateDialog, { state: false });
+                    setTimeout(() => {
+                      const lookupId = group?.id ?? action.id;
+                      const node = Graph.getConnections(graph, lookupId, Node.actionRelation('inbound'))[0];
+                      if (node && Node.isAction(action)) {
+                        void runAction(action, { parent: node, caller: KEY_BINDING });
                       }
-
-                      if (Node.isActionGroup(action)) {
-                        setSelected(action.id);
-                        return;
-                      }
-
-                      void invokePromise(LayoutOperation.UpdateDialog, { state: false });
-                      setTimeout(() => {
-                        const lookupId = group?.id ?? action.id;
-                        const node = Graph.getConnections(graph, lookupId, Node.actionRelation('inbound'))[0];
-                        if (node && Node.isAction(action)) {
-                          void runAction(action, { parent: node, caller: KEY_BINDING });
-                        }
-                      });
-                    }}
-                    classNames='flex items-center gap-2'
-                    disabled={action.properties.disabled}
-                    {...(action.properties?.testId && {
-                      'data-testid': action.properties.testId,
-                    })}
-                  />
-                );
-              })}
+                    });
+                  }}
+                  classNames='flex items-center gap-2'
+                  disabled={action.properties.disabled}
+                  {...(action.properties?.testId && {
+                    'data-testid': action.properties.testId,
+                  })}
+                />
+              );
+            })}
           </SearchList.Viewport>
         </SearchList.Root>
         <Dialog.ActionBar>

--- a/packages/plugins/plugin-search/src/containers/SearchDialog/SearchDialog.tsx
+++ b/packages/plugins/plugin-search/src/containers/SearchDialog/SearchDialog.tsx
@@ -10,7 +10,7 @@ import { useLayout } from '@dxos/app-toolkit/ui';
 import { useActiveSpace } from '@dxos/app-toolkit/ui';
 import { Entity, Obj, Query } from '@dxos/echo';
 import { Filter, type Space, useQuery } from '@dxos/react-client/echo';
-import { Column, Dialog, useTranslation } from '@dxos/react-ui';
+import { Dialog, useTranslation } from '@dxos/react-ui';
 import { SearchList } from '@dxos/react-ui-search';
 import { Text } from '@dxos/schema';
 
@@ -76,24 +76,20 @@ export const SearchDialog = ({ pivotId: pivotIdProp, space: spaceProp }: SearchD
         </Dialog.Close>
       </Dialog.Header>
       <SearchList.Root onSearch={handleSearch}>
-        <Column.Center>
-          <SearchList.Input classNames='px-0' autoFocus placeholder={t('search.placeholder')} />
-        </Column.Center>
-        <Column.Bleed>
-          <SearchList.Viewport classNames='max-h-[24rem]'>
-            {allResults.map((result) => (
-              <SearchList.Item
-                key={result.id}
-                classNames='flex gap-2 items-center'
-                value={result.id}
-                label={result.label ?? (result.object ? Entity.getLabel(result.object) : undefined) ?? result.id}
-                icon={result.icon}
-                onSelect={() => void handleSelect(result)}
-              />
-            ))}
-            {query && allResults.length === 0 && <SearchList.Empty />}
-          </SearchList.Viewport>
-        </Column.Bleed>
+        <SearchList.Input classNames='px-0' autoFocus placeholder={t('search.placeholder')} />
+        <SearchList.Viewport classNames='max-h-[24rem]'>
+          {allResults.map((result) => (
+            <SearchList.Item
+              key={result.id}
+              classNames='flex gap-2 items-center'
+              value={result.id}
+              label={result.label ?? (result.object ? Entity.getLabel(result.object) : undefined) ?? result.id}
+              icon={result.icon}
+              onSelect={() => void handleSelect(result)}
+            />
+          ))}
+          {query && allResults.length === 0 && <SearchList.Empty />}
+        </SearchList.Viewport>
       </SearchList.Root>
     </Dialog.Content>
   );

--- a/packages/plugins/plugin-space/src/components/CreateDialog/CreateObjectPanel.tsx
+++ b/packages/plugins/plugin-space/src/components/CreateDialog/CreateObjectPanel.tsx
@@ -9,7 +9,7 @@ import { type Database, Obj } from '@dxos/echo';
 import { type Collection } from '@dxos/echo';
 import { type AnyProperties } from '@dxos/echo/internal';
 import { type Space, type SpaceId } from '@dxos/react-client/echo';
-import { Column, toLocalizedString, useDefaultValue, useTranslation } from '@dxos/react-ui';
+import { toLocalizedString, useDefaultValue, useTranslation } from '@dxos/react-ui';
 import { Form, omitId } from '@dxos/react-ui-form';
 import { SearchList, useSearchListResults } from '@dxos/react-ui-search';
 import { type MaybePromise } from '@dxos/util';
@@ -141,26 +141,23 @@ const SelectType = ({ options, onChange }: SelectTypeProps) => {
 
   return (
     <SearchList.Root onSearch={handleSearch}>
-      <Column.Center classNames='mb-form-gap'>
-        <SearchList.Input
-          autoFocus
-          data-testid='create-object-form.schema-input'
-          placeholder={t('schema-input.placeholder')}
-        />
-      </Column.Center>
-      <Column.Bleed>
-        <SearchList.Viewport>
-          {results.map((option) => (
-            <SearchList.Item
-              key={option.id}
-              value={option.id}
-              label={option.label}
-              icon={option.icon ?? 'ph--placeholder--regular'}
-              onSelect={() => onChange(option.id)}
-            />
-          ))}
-        </SearchList.Viewport>
-      </Column.Bleed>
+      <SearchList.Input
+        classNames='mb-form-gap'
+        autoFocus
+        data-testid='create-object-form.schema-input'
+        placeholder={t('schema-input.placeholder')}
+      />
+      <SearchList.Viewport>
+        {results.map((option) => (
+          <SearchList.Item
+            key={option.id}
+            value={option.id}
+            label={option.label}
+            icon={option.icon ?? 'ph--placeholder--regular'}
+            onSelect={() => onChange(option.id)}
+          />
+        ))}
+      </SearchList.Viewport>
     </SearchList.Root>
   );
 };
@@ -205,27 +202,23 @@ const SelectSpace = ({ spaces, defaultSpaceId, onChange }: SelectSpaceProps) => 
 
   return (
     <SearchList.Root onSearch={handleSearch}>
-      <Column.Center>
-        <SearchList.Input
-          autoFocus
-          data-testid='create-object-form.space-input'
-          placeholder={t('space-input.placeholder')}
-        />
-      </Column.Center>
-      <Column.Bleed>
-        <SearchList.Viewport>
-          {results.map((space) => {
-            return (
-              <SearchList.Item
-                key={space.id}
-                value={space.id}
-                label={toLocalizedString(getSpaceDisplayName(space, { personal: space.id === defaultSpaceId }), t)}
-                onSelect={() => onChange?.(space.db)}
-              />
-            );
-          })}
-        </SearchList.Viewport>
-      </Column.Bleed>
+      <SearchList.Input
+        autoFocus
+        data-testid='create-object-form.space-input'
+        placeholder={t('space-input.placeholder')}
+      />
+      <SearchList.Viewport>
+        {results.map((space) => {
+          return (
+            <SearchList.Item
+              key={space.id}
+              value={space.id}
+              label={toLocalizedString(getSpaceDisplayName(space, { personal: space.id === defaultSpaceId }), t)}
+              onSelect={() => onChange?.(space.db)}
+            />
+          );
+        })}
+      </SearchList.Viewport>
     </SearchList.Root>
   );
 };

--- a/packages/plugins/plugin-space/src/components/CreateDialog/CreateObjectPanel.tsx
+++ b/packages/plugins/plugin-space/src/components/CreateDialog/CreateObjectPanel.tsx
@@ -203,6 +203,7 @@ const SelectSpace = ({ spaces, defaultSpaceId, onChange }: SelectSpaceProps) => 
   return (
     <SearchList.Root onSearch={handleSearch}>
       <SearchList.Input
+        classNames='mb-form-gap'
         autoFocus
         data-testid='create-object-form.space-input'
         placeholder={t('space-input.placeholder')}

--- a/packages/ui/react-ui-form/src/components/Form/Form.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/Form.tsx
@@ -17,7 +17,7 @@ import {
   useMergeRefs,
   useTranslation,
 } from '@dxos/react-ui';
-import { composable, composableProps, mx } from '@dxos/ui-theme';
+import { composable, composableProps, mx, withColumn } from '@dxos/ui-theme';
 
 import {
   type FormHandler,
@@ -194,7 +194,7 @@ const FormContent = composable<HTMLDivElement, FormContentProps>(({ children, ..
 
   return (
     <div
-      {...composableProps(props, { role: 'form', classNames: 'flex flex-col w-full pb-form-gap' })}
+      {...composableProps(props, { role: 'form', classNames: mx(withColumn.center(), 'flex flex-col w-full pb-form-gap') })}
       data-testid={testId}
       ref={mergedRef}
     >
@@ -245,7 +245,7 @@ const FormActions = ({ classNames }: FormActionsProps) => {
   //   Deprecate FormSubmit ans use FormActions without Cancel button if no callback is supplied.
 
   return (
-    <div role='none' className={mx('grid grid-flow-col gap-form-gap auto-cols-fr py-form-padding', classNames)}>
+    <div role='none' className={mx(withColumn.center(), 'grid grid-flow-col gap-form-gap auto-cols-fr py-form-padding', classNames)}>
       {onCancel && (
         <IconButton
           icon='ph--x--regular'

--- a/packages/ui/react-ui-form/src/components/Form/Form.tsx
+++ b/packages/ui/react-ui-form/src/components/Form/Form.tsx
@@ -194,7 +194,10 @@ const FormContent = composable<HTMLDivElement, FormContentProps>(({ children, ..
 
   return (
     <div
-      {...composableProps(props, { role: 'form', classNames: mx(withColumn.center(), 'flex flex-col w-full pb-form-gap') })}
+      {...composableProps(props, {
+        role: 'form',
+        classNames: mx(withColumn.center(), 'flex flex-col w-full pb-form-gap'),
+      })}
       data-testid={testId}
       ref={mergedRef}
     >
@@ -245,7 +248,10 @@ const FormActions = ({ classNames }: FormActionsProps) => {
   //   Deprecate FormSubmit ans use FormActions without Cancel button if no callback is supplied.
 
   return (
-    <div role='none' className={mx(withColumn.center(), 'grid grid-flow-col gap-form-gap auto-cols-fr py-form-padding', classNames)}>
+    <div
+      role='none'
+      className={mx(withColumn.center(), 'grid grid-flow-col gap-form-gap auto-cols-fr py-form-padding', classNames)}
+    >
       {onCancel && (
         <IconButton
           icon='ph--x--regular'

--- a/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
+++ b/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
@@ -240,7 +240,10 @@ type SearchListContentProps = {};
  */
 const SearchListContent = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
   return (
-    <div {...composableProps(props, { role: 'none', classNames: mx('dx-expander', withColumn.propagate()) })} ref={forwardedRef}>
+    <div
+      {...composableProps(props, { role: 'none', classNames: mx('dx-expander', withColumn.propagate()) })}
+      ref={forwardedRef}
+    >
       {children}
     </div>
   );
@@ -349,20 +352,18 @@ const SearchListInput = forwardRef<HTMLInputElement, SearchListInputProps>(
     );
 
     return (
-      <div className={withColumn.center()}>
-        <Input.Root>
-          <Input.TextInput
-            {...props}
-            variant='subdued'
-            autoFocus={props.autoFocus && !hasIosKeyboard}
-            placeholder={placeholder ?? defaultPlaceholder}
-            value={query}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-            ref={forwardedRef}
-          />
-        </Input.Root>
-      </div>
+      <Input.Root>
+        <Input.TextInput
+          {...props}
+          variant='subdued'
+          autoFocus={props.autoFocus && !hasIosKeyboard}
+          placeholder={placeholder ?? defaultPlaceholder}
+          value={query}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          ref={forwardedRef}
+        />
+      </Input.Root>
     );
   },
 );
@@ -377,8 +378,17 @@ type SearchListViewportProps = {};
 
 const SearchListViewport = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
   return (
-    <ScrollArea.Root {...composableProps(props)} role='listbox' thin padding ref={forwardedRef}>
-      <ScrollArea.Viewport>{children}</ScrollArea.Viewport>
+    <ScrollArea.Root
+      {...composableProps(props, { classNames: 'border border-red-500' })}
+      role='listbox'
+      thin
+      padding
+      ref={forwardedRef}
+    >
+      <ScrollArea.Viewport>
+        <div className='h-[100px]'>PLACEHOLDER</div>
+        {children}
+      </ScrollArea.Viewport>
     </ScrollArea.Root>
   );
 });

--- a/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
+++ b/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
@@ -29,7 +29,7 @@ import {
   useThemeContext,
   useTranslation,
 } from '@dxos/react-ui';
-import { composable, composableProps, mx, withColumn } from '@dxos/ui-theme';
+import { composable, composableProps, mx } from '@dxos/ui-theme';
 
 import { translationKey } from '../../translations';
 import {
@@ -234,16 +234,15 @@ SearchListRoot.displayName = 'SearchList.Root';
 type SearchListContentProps = {};
 
 /**
- * Optional wrapper that groups `SearchList.Input` and `SearchList.Viewport`.
- * When inside a Column context, propagates the grid via subgrid so children
- * can auto-center (Input) or auto-bleed (Viewport).
+ * Optional styling wrapper that groups `SearchList.Input` and `SearchList.Viewport` into a single
+ * `dx-expander` container. Layout-neutral: it does NOT participate in any column/grid placement.
+ *
+ * When hosting `SearchList` inside a `Column.Root` (e.g. `Dialog.Body`), the parent propagator
+ * handles column placement for SearchList's children automatically.
  */
 const SearchListContent = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
   return (
-    <div
-      {...composableProps(props, { role: 'none', classNames: mx('dx-expander', withColumn.propagate()) })}
-      ref={forwardedRef}
-    >
+    <div {...composableProps(props, { role: 'none', classNames: 'dx-expander' })} ref={forwardedRef}>
       {children}
     </div>
   );

--- a/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
+++ b/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
@@ -242,7 +242,7 @@ type SearchListContentProps = {};
  */
 const SearchListContent = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
   return (
-    <div {...composableProps(props, { role: 'none', classNames: 'flex-1 min-h-0 overflow-hidden flex flex-col' })} ref={forwardedRef}>
+    <div {...composableProps(props, { role: 'none', classNames: 'dx-expander' })} ref={forwardedRef}>
       {children}
     </div>
   );

--- a/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
+++ b/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
@@ -242,7 +242,7 @@ type SearchListContentProps = {};
  */
 const SearchListContent = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
   return (
-    <div {...composableProps(props, { role: 'none', classNames: 'dx-expander flex flex-col' })} ref={forwardedRef}>
+    <div {...composableProps(props, { role: 'none', classNames: 'dx-container flex flex-col' })} ref={forwardedRef}>
       {children}
     </div>
   );

--- a/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
+++ b/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
@@ -242,7 +242,7 @@ type SearchListContentProps = {};
  */
 const SearchListContent = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
   return (
-    <div {...composableProps(props, { role: 'none', classNames: 'flex-1 min-h-0 min-w-0 overflow-hidden' })} ref={forwardedRef}>
+    <div {...composableProps(props, { role: 'none', classNames: 'dx-expander' })} ref={forwardedRef}>
       {children}
     </div>
   );

--- a/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
+++ b/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
@@ -242,7 +242,7 @@ type SearchListContentProps = {};
  */
 const SearchListContent = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
   return (
-    <div {...composableProps(props, { role: 'none', classNames: 'dx-container flex flex-col' })} ref={forwardedRef}>
+    <div {...composableProps(props, { role: 'none', classNames: 'flex-1 min-h-0 overflow-hidden flex flex-col' })} ref={forwardedRef}>
       {children}
     </div>
   );

--- a/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
+++ b/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
@@ -377,17 +377,8 @@ type SearchListViewportProps = {};
 
 const SearchListViewport = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
   return (
-    <ScrollArea.Root
-      {...composableProps(props, { classNames: 'border border-red-500' })}
-      role='listbox'
-      thin
-      padding
-      ref={forwardedRef}
-    >
-      <ScrollArea.Viewport>
-        <div className='h-[100px]'>PLACEHOLDER</div>
-        {children}
-      </ScrollArea.Viewport>
+    <ScrollArea.Root {...composableProps(props)} role='listbox' thin padding ref={forwardedRef}>
+      <ScrollArea.Viewport>{children}</ScrollArea.Viewport>
     </ScrollArea.Root>
   );
 });

--- a/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
+++ b/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
@@ -242,7 +242,7 @@ type SearchListContentProps = {};
  */
 const SearchListContent = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
   return (
-    <div {...composableProps(props, { role: 'none', classNames: 'dx-expander' })} ref={forwardedRef}>
+    <div {...composableProps(props, { role: 'none', classNames: 'flex-1 min-h-0 min-w-0 overflow-hidden' })} ref={forwardedRef}>
       {children}
     </div>
   );

--- a/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
+++ b/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
@@ -29,7 +29,7 @@ import {
   useThemeContext,
   useTranslation,
 } from '@dxos/react-ui';
-import { composable, composableProps, mx } from '@dxos/ui-theme';
+import { composable, composableProps, mx, withColumn } from '@dxos/ui-theme';
 
 import { translationKey } from '../../translations';
 import {
@@ -234,15 +234,13 @@ SearchListRoot.displayName = 'SearchList.Root';
 type SearchListContentProps = {};
 
 /**
- * Optional styling wrapper that groups `SearchList.Input` and `SearchList.Viewport` into a single
- * `dx-expander` container. Layout-neutral: it does NOT participate in any column/grid placement.
- *
- * When hosting `SearchList` inside a `Column.Root` (e.g. `Dialog.Body`), skip this wrapper and
- * place the `Input` and `Viewport` directly with `<Column.Center>` / `<Column.Bleed>`.
+ * Optional wrapper that groups `SearchList.Input` and `SearchList.Viewport`.
+ * When inside a Column context, propagates the grid via subgrid so children
+ * can auto-center (Input) or auto-bleed (Viewport).
  */
 const SearchListContent = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
   return (
-    <div {...composableProps(props, { role: 'none', classNames: 'dx-expander' })} ref={forwardedRef}>
+    <div {...composableProps(props, { role: 'none', classNames: mx('dx-expander', withColumn.propagate()) })} ref={forwardedRef}>
       {children}
     </div>
   );
@@ -351,18 +349,20 @@ const SearchListInput = forwardRef<HTMLInputElement, SearchListInputProps>(
     );
 
     return (
-      <Input.Root>
-        <Input.TextInput
-          {...props}
-          variant='subdued'
-          autoFocus={props.autoFocus && !hasIosKeyboard}
-          placeholder={placeholder ?? defaultPlaceholder}
-          value={query}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          ref={forwardedRef}
-        />
-      </Input.Root>
+      <div className={withColumn.center()}>
+        <Input.Root>
+          <Input.TextInput
+            {...props}
+            variant='subdued'
+            autoFocus={props.autoFocus && !hasIosKeyboard}
+            placeholder={placeholder ?? defaultPlaceholder}
+            value={query}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            ref={forwardedRef}
+          />
+        </Input.Root>
+      </div>
     );
   },
 );

--- a/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
+++ b/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
@@ -242,7 +242,7 @@ type SearchListContentProps = {};
  */
 const SearchListContent = composable<HTMLDivElement>(({ children, ...props }, forwardedRef) => {
   return (
-    <div {...composableProps(props, { role: 'none', classNames: 'dx-expander' })} ref={forwardedRef}>
+    <div {...composableProps(props, { role: 'none', classNames: 'dx-expander flex flex-col' })} ref={forwardedRef}>
       {children}
     </div>
   );

--- a/packages/ui/react-ui/src/components/Card/Card.tsx
+++ b/packages/ui/react-ui/src/components/Card/Card.tsx
@@ -251,17 +251,20 @@ const CARD_ROW_NAME = 'Card.Row';
 
 type CardRowProps = { icon?: string; fullWidth?: boolean };
 
-const CardRow = composable<HTMLDivElement, CardRowProps>(({ children, icon, ...props }, forwardedRef) => {
-  const { className, ...rest } = composableProps(props);
-  const { tx } = useThemeContext();
+const CardRow = slottable<HTMLDivElement, CardRowProps>(
+  ({ children, asChild, icon, ...props }, forwardedRef) => {
+    const { className, ...rest } = composableProps(props);
+    const Comp = asChild ? Slot : Primitive.div;
+    const { tx } = useThemeContext();
 
-  return (
-    <Column.Row {...rest} className={tx('card.row', {}, className)} ref={forwardedRef}>
-      {(icon && <CardIcon classNames='text-subdued' icon={icon} size={4} />) || <div />}
-      {children}
-    </Column.Row>
-  );
-});
+    return (
+      <Comp {...rest} className={tx('card.row', {}, className)} ref={forwardedRef}>
+        {(icon && <CardIcon classNames='text-subdued' icon={icon} size={4} />) || <div />}
+        {children}
+      </Comp>
+    );
+  },
+);
 
 CardRow.displayName = CARD_ROW_NAME;
 

--- a/packages/ui/react-ui/src/components/Card/Card.tsx
+++ b/packages/ui/react-ui/src/components/Card/Card.tsx
@@ -251,20 +251,18 @@ const CARD_ROW_NAME = 'Card.Row';
 
 type CardRowProps = { icon?: string; fullWidth?: boolean };
 
-const CardRow = slottable<HTMLDivElement, CardRowProps>(
-  ({ children, asChild, icon, ...props }, forwardedRef) => {
-    const { className, ...rest } = composableProps(props);
-    const Comp = asChild ? Slot : Primitive.div;
-    const { tx } = useThemeContext();
+const CardRow = slottable<HTMLDivElement, CardRowProps>(({ children, asChild, icon, ...props }, forwardedRef) => {
+  const { className, ...rest } = composableProps(props);
+  const Comp = asChild ? Slot : Primitive.div;
+  const { tx } = useThemeContext();
 
-    return (
-      <Comp {...rest} className={tx('card.row', {}, className)} ref={forwardedRef}>
-        {(icon && <CardIcon classNames='text-subdued' icon={icon} size={4} />) || <div />}
-        {children}
-      </Comp>
-    );
-  },
-);
+  return (
+    <Comp {...rest} className={tx('card.row', {}, className)} ref={forwardedRef}>
+      {(icon && <CardIcon classNames='text-subdued' icon={icon} size={4} />) || <div />}
+      {children}
+    </Comp>
+  );
+});
 
 CardRow.displayName = CARD_ROW_NAME;
 

--- a/packages/ui/react-ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/ui/react-ui/src/components/Dialog/Dialog.stories.tsx
@@ -24,7 +24,7 @@ type DefaultStoryProps = Pick<DialogContentProps, 'size'> &
 
 /**
  * Standard Dialog with non-scrolling content in Dialog.Body.
- * Dialog.Body delegates to Column.Center, placing content in the center column between gutters.
+ * Dialog.Body propagates the Column grid via subgrid. Children auto-center via --dx-col.
  */
 const DefaultStory = ({ size, title, description, openTrigger, closeTrigger, blockAlign }: DefaultStoryProps) => {
   return (
@@ -62,7 +62,7 @@ const DefaultStory = ({ size, title, description, openTrigger, closeTrigger, blo
 
 /**
  * Dialog with a ScrollArea child inside Dialog.Body.
- * The ScrollArea breaks out of Body's gutter padding via `--gutter-offset`
+ * The ScrollArea breaks out of Body's gutter padding via `--gutter`
  * and applies its own asymmetric padding (accounting for scrollbar width).
  */
 const ScrollingStory = ({ size, title, description, openTrigger, closeTrigger, blockAlign }: DefaultStoryProps) => {

--- a/packages/ui/react-ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/react-ui/src/components/Dialog/Dialog.tsx
@@ -4,17 +4,17 @@
 
 import { createContext } from '@radix-ui/react-context';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { Primitive } from '@radix-ui/react-primitive';
+import { Slot } from '@radix-ui/react-slot';
 import React, {
   type ComponentPropsWithRef,
   type ForwardRefExoticComponent,
   type FunctionComponent,
-  type PropsWithChildren,
   forwardRef,
 } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { type DialogSize, osTranslations } from '@dxos/ui-theme';
-import { slottable } from '@dxos/ui-theme';
+import { composableProps, type DialogSize, osTranslations, slottable } from '@dxos/ui-theme';
 import { type SlottableProps } from '@dxos/ui-types';
 
 import { useThemeContext } from '../../hooks';
@@ -138,18 +138,18 @@ DialogContent.displayName = DIALOG_CONTENT_NAME;
 // Header
 //
 
-type DialogHeaderProps = PropsWithChildren;
+type DialogHeaderProps = SlottableProps;
 
-const DialogHeader: ForwardRefExoticComponent<DialogHeaderProps> = forwardRef<HTMLHeadingElement, DialogHeaderProps>(
-  ({ children }, forwardedRef) => {
-    const { tx } = useThemeContext();
-    return (
-      <Column.Row className={tx('dialog.header')} center ref={forwardedRef}>
-        {children}
-      </Column.Row>
-    );
-  },
-);
+const DialogHeader = slottable<HTMLDivElement>(({ children, asChild, ...props }, forwardedRef) => {
+  const { className, ...rest } = composableProps(props);
+  const Comp = asChild ? Slot : Primitive.div;
+  const { tx } = useThemeContext();
+  return (
+    <Comp {...rest} className={tx('dialog.header', {}, className)} ref={forwardedRef}>
+      {children}
+    </Comp>
+  );
+});
 
 //
 // CloseIconButton
@@ -181,11 +181,13 @@ const DialogCloseIconButton = forwardRef<HTMLButtonElement, DialogCloseIconButto
 type DialogBodyProps = SlottableProps;
 
 const DialogBody = slottable<HTMLDivElement>(({ children, asChild, ...props }, forwardedRef) => {
+  const { className, ...rest } = composableProps(props);
+  const Comp = asChild ? Slot : Primitive.div;
   const { tx } = useThemeContext();
   return (
-    <Column.Center {...props} asChild={asChild} className={tx('dialog.body', {})} ref={forwardedRef}>
+    <Comp {...rest} className={tx('dialog.body', {}, className)} ref={forwardedRef}>
       {children}
-    </Column.Center>
+    </Comp>
   );
 });
 
@@ -227,20 +229,18 @@ const DialogDescription = forwardRef<HTMLParagraphElement, DialogDescriptionProp
 // ActionBar
 //
 
-type DialogActionBarProps = ThemedClassName<PropsWithChildren>;
+type DialogActionBarProps = SlottableProps;
 
-const DialogActionBar = forwardRef<HTMLDivElement, DialogActionBarProps>(
-  ({ children, classNames, ...props }, forwardedRef) => {
-    const { tx } = useThemeContext();
-    return (
-      <Column.Row center>
-        <div {...props} className={tx('dialog.actionbar', {}, classNames)} ref={forwardedRef}>
-          {children}
-        </div>
-      </Column.Row>
-    );
-  },
-);
+const DialogActionBar = slottable<HTMLDivElement>(({ children, asChild, ...props }, forwardedRef) => {
+  const { className: classNames, ...rest } = composableProps(props);
+  const Comp = asChild ? Slot : Primitive.div;
+  const { tx } = useThemeContext();
+  return (
+    <Comp {...rest} className={tx('dialog.actionbar', {}, classNames)} ref={forwardedRef}>
+      {children}
+    </Comp>
+  );
+});
 
 //
 // Close

--- a/packages/ui/react-ui/src/primitives/Column/AUDIT.md
+++ b/packages/ui/react-ui/src/primitives/Column/AUDIT.md
@@ -60,21 +60,21 @@ Exported from `@dxos/ui-theme`. Components import and call these in their theme 
 participate in the Column grid without importing Column React components.
 
 ```ts
-withColumn.center()
+withColumn.center();
 // → '[grid-column:var(--dx-col,auto)]'
 
-withColumn.propagate()
+withColumn.propagate();
 // → '[.dx-column_&]:col-span-full [.dx-column_&]:grid [.dx-column_&]:grid-cols-subgrid'
 
-withColumn.consumed()
+withColumn.consumed();
 // → '[--dx-col:auto]'
 ```
 
-| Utility | Purpose | Where used |
-| :--- | :--- | :--- |
-| `center()` | Place element in col 2 via `--dx-col`. No-op outside Column or inside ScrollArea. | Dialog.Header, Dialog.ActionBar, Form.Content, Form.Actions, SearchList.Input |
-| `propagate()` | Extend Column subgrid to children. No-op outside Column. | Dialog.Body, SearchList.Content |
-| `consumed()` | Reset `--dx-col` after `--gutter` is consumed. | ScrollArea.Viewport |
+| Utility       | Purpose                                                                           | Where used                                                                    |
+| :------------ | :-------------------------------------------------------------------------------- | :---------------------------------------------------------------------------- |
+| `center()`    | Place element in col 2 via `--dx-col`. No-op outside Column or inside ScrollArea. | Dialog.Header, Dialog.ActionBar, Form.Content, Form.Actions, SearchList.Input |
+| `propagate()` | Extend Column subgrid to children. No-op outside Column.                          | Dialog.Body, SearchList.Content                                               |
+| `consumed()`  | Reset `--dx-col` after `--gutter` is consumed.                                    | ScrollArea.Viewport                                                           |
 
 ## CSS custom property cascade
 
@@ -102,26 +102,26 @@ Column.Root
 
 ### Dialog
 
-| Sub-component | withColumn applied | Effect |
-| :--- | :--- | :--- |
-| `Dialog.Content` | `Column.Root` (gutter `'sm'`) | Establishes the 3-col grid. |
-| `Dialog.Header` | `withColumn.center()` | Placed in col 2. |
-| `Dialog.Body` | `withColumn.propagate()` | Children inherit the subgrid. |
-| `Dialog.ActionBar` | `withColumn.center()` | Placed in col 2. |
+| Sub-component      | withColumn applied            | Effect                        |
+| :----------------- | :---------------------------- | :---------------------------- |
+| `Dialog.Content`   | `Column.Root` (gutter `'sm'`) | Establishes the 3-col grid.   |
+| `Dialog.Header`    | `withColumn.center()`         | Placed in col 2.              |
+| `Dialog.Body`      | `withColumn.propagate()`      | Children inherit the subgrid. |
+| `Dialog.ActionBar` | `withColumn.center()`         | Placed in col 2.              |
 
 ### Form
 
-| Sub-component | withColumn applied | Effect |
-| :--- | :--- | :--- |
+| Sub-component  | withColumn applied    | Effect                              |
+| :------------- | :-------------------- | :---------------------------------- |
 | `Form.Content` | `withColumn.center()` | Placed in col 2 when inside Column. |
 | `Form.Actions` | `withColumn.center()` | Placed in col 2 when inside Column. |
 
 ### SearchList
 
-| Sub-component | withColumn applied | Effect |
-| :--- | :--- | :--- |
-| `SearchList.Content` | `withColumn.propagate()` | Extends subgrid to children when inside Column. |
-| `SearchList.Input` wrapper | `withColumn.center()` | Input row placed in col 2. |
+| Sub-component              | withColumn applied       | Effect                                          |
+| :------------------------- | :----------------------- | :---------------------------------------------- |
+| `SearchList.Content`       | `withColumn.propagate()` | Extends subgrid to children when inside Column. |
+| `SearchList.Input` wrapper | `withColumn.center()`    | Input row placed in col 2.                      |
 
 ### Card
 

--- a/packages/ui/react-ui/src/primitives/Column/AUDIT.md
+++ b/packages/ui/react-ui/src/primitives/Column/AUDIT.md
@@ -78,7 +78,7 @@ withColumn.consumed()
 
 ## CSS custom property cascade
 
-```
+```text
 Column.Root
   sets --gutter = var(--dx-gutter-<size>)
   sets --dx-col = 2 / span 1

--- a/packages/ui/react-ui/src/primitives/Column/AUDIT.md
+++ b/packages/ui/react-ui/src/primitives/Column/AUDIT.md
@@ -1,354 +1,148 @@
-# Column composition
+# Column architecture reference
 
 ## Background
 
-We have a complex design issue that requires research and deep thinking.
+`Column` establishes a 3-column CSS grid with left/right gutter columns and a center content
+channel. Two CSS custom properties drive the system:
 
-`Column` is a primitive that establishes a 3 column grid (side gutters and main content channel) by creating a CSS `grid` and setting the `--gutter` CSS variable.
-Both `Dialog` and `Card` use `Column` to establish their grid and both have separate sub-components.
-Also `ScrollArea` uses the `Column` grid to establish the side margins (padding via `--gutter`) for the main content.
-Various components (e.g., `Form`) define a `Viewport` that implements a `ScrollArea` to establish their grid.
+- `--gutter` — the gutter track width (e.g. `var(--dx-gutter-md)`); consumed by `ScrollArea.Viewport` for padding.
+- `--dx-col` — the grid-column placement token; set by `Column.Root` and consumed by `withColumn` utilities.
 
-## Initial Tasks
+## Column primitives
 
-1. Create a column-aligned Markdown table listing the sub-components for `Card` and `Dialog`.
-2. Add to this table all Radix-style components that have a `Viewport` sub-component that uses `ScrollArea`.
-3. For each of these component comment on whether they use appropraite standard for `Content` and `Viewport`, and call out any major design issues.
-
-## Design Challenge
-
-The use of `Column` is intended to standardize how components establish a grid.
-It is intended that this supports nesting; e.g., a `Dialog` that has a `Form` in its `Viewport`.
-However there is a problem when child components contain other components that contain `Viewport`.
-For example:
-
-```
-- CreateObjectDialog (plugin-space)
-  - Dialog.Root
-    - Dialog.Body
-      - Dialog.Viewport => ScrollArea
-        - CreateObjectPanel
-          - Form.Root
-            - Form.Viewport => ScrollArea
-              - Form.Content
-                - Form.FieldSet
-                - Form.Actions
-```
-
-The nested Viewports create a double set of scrollbars,
-whereas the entire contents of the `Dialog.Body` should be considered to be a single scroll-area.
-In this case we could omit the `Dialog.Viewport`, but inside `CreateObjectPanel` there are other components that do not define `Viewports`.
-
-Determine if this is really a problem. And consider different approachs.
-
-## Audit
-
-### Sub-components for Dialog and Card
-
-| Component  | Sub-component   | Uses Column                     | Uses ScrollArea                    | Has Viewport | Notes                            |
-| :--------- | :-------------- | :------------------------------ | :--------------------------------- | :----------- | :------------------------------- |
-| **Dialog** | Root            | —                               | —                                  | —            | ElevationProvider wrapper        |
-|            | Trigger         | —                               | —                                  | —            | Radix primitive                  |
-|            | Portal          | —                               | —                                  | —            | Radix primitive                  |
-|            | Overlay         | —                               | —                                  | —            | OverlayLayoutProvider            |
-|            | Content         | **Column.Root** (gutter='sm')   | —                                  | —            | Establishes the 3-col grid       |
-|            | Header          | **Column.Row** (center)         | —                                  | —            | Title + Close row                |
-|            | Body            | col-span-full                   | —                                  | —            | Plain div, no gutters applied    |
-|            | **Viewport**    | **Column.Viewport**             | **ScrollArea** (vertical, padding) | **Yes**      | Alias for Column.Viewport        |
-|            | Title           | —                               | —                                  | —            | Radix primitive                  |
-|            | Description     | —                               | —                                  | —            | Radix primitive                  |
-|            | ActionBar       | **Column.Row** (center)         | —                                  | —            | Action buttons row               |
-|            | Close           | —                               | —                                  | —            | Radix primitive                  |
-|            | CloseIconButton | —                               | —                                  | —            | Icon button                      |
-| **Card**   | Root            | **Column.Root** (gutter varies) | —                                  | —            | gutter='lg' coarse, 'md' default |
-|            | Toolbar         | col-span-3, subgrid             | —                                  | —            | Toolbar.Root wrapper             |
-|            | DragHandle      | —                               | —                                  | —            | In CardIconBlock                 |
-|            | CloseIconButton | —                               | —                                  | —            | In CardIconBlock                 |
-|            | Menu            | —                               | —                                  | —            | In CardIconBlock                 |
-|            | Icon            | —                               | —                                  | —            | In CardIconBlock                 |
-|            | IconBlock       | —                               | —                                  | —            | Grid cell for icons              |
-|            | Title           | —                               | —                                  | —            | Heading div                      |
-|            | Content         | —                               | —                                  | —            | `display: contents`              |
-|            | Row             | **Column.Row**                  | —                                  | —            | With optional icon slot          |
-|            | Section         | col-span-full                   | —                                  | —            | **Deprecated**                   |
-|            | Heading         | —                               | —                                  | —            | **Deprecated**                   |
-|            | Text            | —                               | —                                  | —            | Text display                     |
-|            | Poster          | col-span-full                   | —                                  | —            | Image/icon                       |
-|            | Action          | Column.Row via subgrid          | —                                  | —            | Button row                       |
-|            | Link            | Column.Row via subgrid          | —                                  | —            | External link row                |
-
-### Components with Viewport sub-components using ScrollArea
-
-| Component      | Viewport impl          | ScrollArea config                         | Notes                                    |
-| :------------- | :--------------------- | :---------------------------------------- | :--------------------------------------- |
-| **Column**     | Column.Viewport        | vertical, padding                         | Base primitive; adds `py-2`              |
-| **Dialog**     | Dialog.Viewport        | (alias for Column.Viewport)               | No Dialog-specific behavior              |
-| **Form**       | Form.Viewport          | vertical, margin, padding, thin           | Sets `role='listbox'`                    |
-| **SearchList** | SearchList.Viewport    | thin only                                 | Sets `role='listbox'`; no margin/padding |
-| **Settings**   | Settings.Root (itself) | vertical, margin                          | Root IS the ScrollArea; adds `p-trim-md` |
-| **Popover**    | Popover.Viewport       | **None** (constraint div, not ScrollArea) | Just constrains inline/block size        |
-| **Combobox**   | Combobox.List          | (delegates to SearchList.Viewport)        | Nested inside Popover.Viewport           |
-
-### Design issues per component
-
-| Component      | Content/Viewport standard                           | Issues                                                                                                                                                                              |
-| :------------- | :-------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Dialog**     | Content → Column.Root; Viewport → Column.Viewport   | `Dialog.Viewport` is a raw alias with no Dialog-specific awareness. `Dialog.Body` has `col-span-full` but no gutter padding — non-scrolling content inside it has no side margins.  |
-| **Card**       | Content → `display:contents`; No Viewport           | Card has no scroll support. Card.Content using `display:contents` collapses the element from layout, which can cause containment/styling issues. No Body equivalent exists.         |
-| **Form**       | Root → context provider; Viewport → ScrollArea      | Form.Viewport applies its own gutter padding via `--gutter`. When nested inside Dialog.Content (which sets `--gutter`), the padding aligns — but creates a second scroll container. |
-| **SearchList** | Content → flex column; Viewport → ScrollArea (thin) | SearchList.Viewport uses `thin` but NOT `margin` or `padding` — it doesn't apply `--gutter` padding at all. Content alignment inside a Column grid depends entirely on the parent.  |
-| **Settings**   | Root IS the ScrollArea                              | Standalone design; would double-scroll if placed inside another Viewport.                                                                                                           |
-| **Combobox**   | Delegates to SearchList.Viewport inside Popover     | No conflict — Popover.Viewport is not ScrollArea-based.                                                                                                                             |
-
-## Analysis
-
-### The problem
-
-The core tension is between two responsibilities that `Viewport` (ScrollArea) currently conflates:
-
-1. **Scrolling** — overflow handling and scrollbar styling.
-2. **Gutter padding** — applying `px-[var(--gutter)]` (with scrollbar-width offset) to align content within the Column grid.
-
-When a container like `Dialog` provides its own Viewport and a child like `Form` also provides one,
-you get double scrollbars. Removing the container's Viewport fixes scrolling but breaks gutter alignment
-for child paths that don't bring their own Viewport (e.g., plain text content).
-
-### The real nesting in CreateObjectDialog today
-
-```
-Dialog.Content (Column.Root, sets --gutter)
-  Dialog.Header (Column.Row)
-  Dialog.Body (col-span-full, NO gutter padding)
-    CreateObjectPanel (switches between paths):
-      Path A: SelectType → SearchList → SearchList.Viewport (ScrollArea, thin)
-      Path B: SelectSpace → SearchList → SearchList.Viewport (ScrollArea, thin)
-      Path C: Form.Root → Form.Viewport (ScrollArea, margin, padding, thin) → Form.Content
-      Path D: (future) plain content — no Viewport, no gutters, broken alignment
-```
-
-Dialog.Viewport was removed to avoid double scrollbars in paths A–C.
-But path D would have no gutter padding because Dialog.Body doesn't provide it.
-
-### Design principles
-
-1. **Column.Content provides gutters via subgrid.** `Column.Root` sets `--gutter` and establishes the 3-column grid. `Column.Content` inherits this grid via CSS subgrid, placing non-scrolling children in the center column and allowing ScrollArea children to span full width.
-2. **Leaves own scrolling.** Components that need to scroll (Form, SearchList) provide their own Viewport. Components that don't need to scroll do nothing.
-3. **ScrollArea is always full width.** ScrollArea.Root must span all 3 grid columns and apply its own gutter padding via `--gutter` on its Viewport. No parent should constrain its width.
-4. **Subgrid propagation.** Components with both Content and Viewport sub-components (e.g., SearchList) propagate the subgrid in their Content element when inside a Column context.
-
-## Implemented Solution: Column.Content as subgrid
-
-### Mechanism
-
-`Column.Content` uses `grid-cols-subgrid` to inherit `Column.Root`'s 3-column grid. Non-scrolling children default to the center column; ScrollArea children span all 3 columns.
-
-Direct children of `Column.Root` participate in the grid in one of three ways:
-
-- **Column.Row** — 3-col subgrid row (icons in gutters, content in center).
-- **Column.Content** — multi-row subgrid; children default to center column, ScrollArea spans full width.
-- **Column.Viewport** — full-width scrollable area (delegates gutters to ScrollArea).
+### Column.Root
 
 ```css
-/* Column.Content — subgrid that inherits Column.Root's 3-column grid */
-.column-content {
-  col-span-full;
-  display: grid;
-  grid-template-columns: subgrid;
-  min-height: 0;                          /* allow shrinking in flex/grid parents */
-  > *:not(.dx-container) { col-start: 2 } /* non-ScrollArea children → center column */
-  /* ScrollArea children span full width via [.dx-column_&]:col-span-full (existing) */
-}
+/* column.ts — columnRoot */
+dx-column grid
+/* inline style */
+--gutter: <gutterSize>
+--dx-col: 2 / span 1
+grid-template-columns: <gutter> minmax(0,1fr) <gutter>
 ```
 
-### Why subgrid instead of padding
+Sets the 3-column grid and both CSS variables. All `withColumn` utilities are no-ops outside this context.
 
-An earlier approach used `px-[var(--gutter)]` padding on Column.Content with a `--gutter-offset`
-CSS variable for ScrollArea to break out via negative margins. This failed because:
-
-1. **Height constraint required `overflow-hidden`** — needed for ScrollArea to get a bounded height.
-2. **`overflow-hidden` clips negative margins** — ScrollArea couldn't break out horizontally.
-3. **CSS doesn't allow mixed overflow** — `overflow-y: hidden` with `overflow-x: visible` isn't possible (browser converts visible to auto).
-
-Subgrid avoids all three issues: gutters come from grid columns (not padding), so there's nothing to break out of and no overflow conflict.
-
-### Subgrid propagation pattern
-
-Components that have both a Content element and a ScrollArea-based Viewport must propagate
-the subgrid in their Content element when inside a Column context. This ensures the grid chain
-is maintained from Column.Root through intermediate components down to ScrollArea.Root.
+### Column.Center
 
 ```css
-/* Applied to SearchList.Content (and similar) when inside a Column context */
-[.dx-column_&]:col-span-full
-[.dx-column_&]:grid
-[.dx-column_&]:grid-cols-subgrid
-[.dx-column_&]:[&>:not(.dx-container)]:col-start-2
+/* column.ts — columnCenter */
+[grid-column:var(--dx-col,auto)] min-h-0
 ```
 
-Components using this pattern:
+Places a single element in col 2 (the center track). Does not use subgrid — placement is explicit
+on this element only, so arbitrary compound components (including `display: contents` wrappers) can
+be nested safely.
 
-- **SearchList.Content** — propagates subgrid; SearchList.Viewport (ScrollArea) spans full width
+### Column.Bleed
 
-Outside a Column context, these remain normal flex containers.
-
-### Example: CreateObjectDialog
-
-```
-Dialog.Content (Column.Root, --gutter: var(--dx-gutter-sm), grid: 16px|1fr|16px)
-  Dialog.Header (Column.Row, center)
-  Dialog.Body → Column.Content (subgrid, children default to col-start-2)
-    CreateObjectPanel:
-      Path A: SearchList.Content (subgrid in column context)
-                → SearchList.Input (col-start-2, in center — guttered ✓)
-                → SearchList.Viewport (ScrollArea, col-span-full — full width ✓)
-                    → ScrollArea.Viewport (pl/pr with --gutter and scrollbar offset ✓)
-      Path B: (same as A) ✓
-      Path C: Form.Viewport (ScrollArea, col-span-full — full width ✓)
-                → ScrollArea.Viewport (pl/pr with --gutter and scrollbar offset ✓)
-      Path D: <plain text> — col-start-2 (center column, guttered ✓)
+```css
+/* column.ts — columnBleed */
+col-span-full grid grid-cols-subgrid min-h-0
 ```
 
-### Dialog sub-component mapping
+Spans all 3 columns and propagates the subgrid. Use for `ScrollArea`, full-width dividers, and
+any content that should ignore the gutters.
 
-| Dialog sub-component | Column primitive | Gutter mechanism                               |
-| :------------------- | :--------------- | :--------------------------------------------- |
-| Dialog.Content       | Column.Root      | Establishes the 3-col grid and sets `--gutter` |
-| Dialog.Header        | Column.Row       | Gutters via grid columns (subgrid)             |
-| Dialog.Body          | Column.Content   | Subgrid; children in center column             |
-| Dialog.ActionBar     | Column.Row       | Gutters via grid columns (subgrid)             |
+### Column.Row
 
-### AlertDialog unified with Dialog ✅
+```css
+/* column.ts — columnRow */
+col-span-3 grid grid-cols-subgrid
+```
 
-AlertDialog now shares sub-components with Dialog:
+Three-slot icon row. Children map to: `[col-1: icon/slot] [col-2: content] [col-3: icon/action]`.
+Must be a direct child of `Column.Root`.
 
-| Sub-component     | Source                     | Notes                                                          |
-| :---------------- | :------------------------- | :------------------------------------------------------------- |
-| Header            | **Dialog.Header**          | Shared — was missing from AlertDialog                          |
-| Body              | **Dialog.Body**            | Shared — was Column.Viewport, now Column.Content               |
-| ActionBar         | **Dialog.ActionBar**       | Shared — was duplicated, now shared                            |
-| CloseIconButton   | **Dialog.CloseIconButton** | Shared — AlertDialog gains this                                |
-| Content           | AlertDialog-specific       | Uses AlertDialogPrimitive.Content; gutter normalized to `'sm'` |
-| Overlay           | AlertDialog-specific       | Uses AlertDialogPrimitive.Overlay                              |
-| Title/Description | AlertDialog-specific       | Uses AlertDialogPrimitive.Title/Description                    |
-| Cancel/Action     | AlertDialog-specific       | Radix dismissal primitives                                     |
+## withColumn theme utilities
 
-## Dialog Usage Audit
+Exported from `@dxos/ui-theme`. Components import and call these in their theme functions to
+participate in the Column grid without importing Column React components.
 
-Full audit of all Dialog/AlertDialog consumers, checking whether they use the standard
-`Dialog.Content > Dialog.Header > Dialog.Body > Dialog.ActionBar` structure.
+```ts
+withColumn.center()
+// → '[grid-column:var(--dx-col,auto)]'
 
-### Correctly structured (uses Dialog.Body)
+withColumn.propagate()
+// → '[.dx-column_&]:col-span-full [.dx-column_&]:grid [.dx-column_&]:grid-cols-subgrid'
 
-| File                                           | Type   | Sub-components used              | Body content                        |
-| :--------------------------------------------- | :----- | :------------------------------- | :---------------------------------- |
-| `devtools/.../DialogRestoreSpace.tsx`          | Dialog | Content, Header, Body, ActionBar | Paragraph text + FileUploader       |
-| `plugin-navtree/.../CommandsDialogContent.tsx` | Dialog | Content, Header, Body, ActionBar | SearchList with Viewport            |
-| `plugin-space/.../CreateObjectDialog.tsx`      | Dialog | Content, Header, Body            | CreateObjectPanel (Form/SearchList) |
-| `shell/.../ConfirmReset.tsx`                   | Dialog | Body, ActionBar (step component) | Message, TextInput, checkboxes      |
-| `react-ui/.../Dialog.stories.tsx`              | Dialog | Content, Header, Body, ActionBar | ScrollArea with Input               |
+withColumn.consumed()
+// → '[--dx-col:auto]'
+```
 
-### Correctly structured (AlertDialog with Body)
+| Utility | Purpose | Where used |
+| :--- | :--- | :--- |
+| `center()` | Place element in col 2 via `--dx-col`. No-op outside Column or inside ScrollArea. | Dialog.Header, Dialog.ActionBar, Form.Content, Form.Actions, SearchList.Input |
+| `propagate()` | Extend Column subgrid to children. No-op outside Column. | Dialog.Body, SearchList.Content |
+| `consumed()` | Reset `--dx-col` after `--gutter` is consumed. | ScrollArea.Viewport |
 
-| File                                       | Type        | Sub-components used             | Body content                  |
-| :----------------------------------------- | :---------- | :------------------------------ | :---------------------------- |
-| `plugin-client/.../RecoveryCodeDialog.tsx` | AlertDialog | Content, Body, Title, ActionBar | Checkboxes, code grid, inputs |
-| `composer-app/.../ResetDialog.tsx`         | AlertDialog | Content, Body, Title, ActionBar | Error display, IconButtons    |
-| `shell/.../JoinDialog.tsx`                 | AlertDialog | Content, Body, Cancel, Action   | JoinPanel                     |
-| `shell/.../StatusDialog.tsx`               | AlertDialog | Content, Body                   | StatusPanel                   |
-| `react-ui/.../AlertDialog.stories.tsx`     | AlertDialog | Content, Body, Title, ActionBar | Title, Description            |
+## CSS custom property cascade
 
-### Missing Dialog.Body (should be added)
+```
+Column.Root
+  sets --gutter = var(--dx-gutter-<size>)
+  sets --dx-col = 2 / span 1
+    │
+    ├─ Column.Center        → grid-column: var(--dx-col)   ← consumes --dx-col
+    ├─ Column.Bleed         → col-span-full, subgrid
+    ├─ Column.Row           → col-span-3, subgrid
+    │
+    └─ withColumn.center()  → grid-column: var(--dx-col)   ← consumes --dx-col
+       withColumn.propagate() → col-span-full, grid, subgrid (inside .dx-column only)
+         │
+         └─ ScrollArea.Root → col-span-full (inside .dx-column only)
+              ScrollArea.Viewport
+                applies pl/pr using --gutter
+                withColumn.consumed() → sets --dx-col: auto
+                  │
+                  └─ (nested components no longer auto-position)
+```
 
-| File                                         | Type   | What's used instead      | Body content                   | Issue                                                 |
-| :------------------------------------------- | :----- | :----------------------- | :----------------------------- | :---------------------------------------------------- |
-| `plugin-script/.../DeploymentDialog.tsx`     | Dialog | Custom flex divs         | Text, list items, buttons      | No Header, no Body, no gutter padding                 |
-| `plugin-search/.../SearchDialog.tsx`         | Dialog | Content directly         | SearchList with max-h overflow | No Header, no Body; SearchList has own scroll         |
-| `plugin-help/.../ShortcutsDialogContent.tsx` | Dialog | Custom flex divs         | ShortcutsList                  | No Header, no Body                                    |
-| `plugin-space/.../CreateSpaceDialog.tsx`     | Dialog | Form.Viewport in Content | Form fields                    | Has Header but no Body; Form.Viewport provides scroll |
-| `plugin-space/.../JoinDialog.tsx`            | Dialog | Content directly         | JoinPanel                      | No Header, no Body; panel manages layout              |
-| `plugin-client/.../JoinDialog.tsx`           | Dialog | Content directly         | JoinPanel                      | No Body; panel manages layout                         |
-| `plugin-client/.../ResetDialog.tsx`          | Dialog | Content directly         | ConfirmReset step              | No Body; step component has its own Body              |
-| `shell/.../SpaceDialog.tsx`                  | Dialog | Content directly         | SpacePanel                     | No Header, no Body; panel manages layout              |
-| `shell/.../IdentityDialog.tsx`               | Dialog | Content directly         | IdentityPanel                  | No Header, no Body; panel manages layout              |
-| `shell/.../run-shell.tsx`                    | Dialog | Content directly         | Button (fallback)              | No Header, no Body; minimal fallback UI               |
+## Component integration
 
-### Custom layout (not standard Dialog)
+### Dialog
 
-| File                                  | Type   | Notes                                                     |
-| :------------------------------------ | :----- | :-------------------------------------------------------- |
-| `react-ui-chat/.../ChatDialog.tsx`    | Custom | Own Column-based grid layout with Header, Content, Footer |
-| `plugin-assistant/.../ChatDialog.tsx` | Custom | Uses ChatDialog from react-ui-chat                        |
+| Sub-component | withColumn applied | Effect |
+| :--- | :--- | :--- |
+| `Dialog.Content` | `Column.Root` (gutter `'sm'`) | Establishes the 3-col grid. |
+| `Dialog.Header` | `withColumn.center()` | Placed in col 2. |
+| `Dialog.Body` | `withColumn.propagate()` | Children inherit the subgrid. |
+| `Dialog.ActionBar` | `withColumn.center()` | Placed in col 2. |
 
-### Observations
+### Form
 
-1. **Shell panel dialogs** (SpaceDialog, IdentityDialog, JoinDialog) all delegate layout to internal Panel components. These panels manage their own structure inside Dialog.Content, bypassing Dialog.Body/Header. This may be intentional (panels are reusable outside dialogs) but means they lack standard gutter alignment.
+| Sub-component | withColumn applied | Effect |
+| :--- | :--- | :--- |
+| `Form.Content` | `withColumn.center()` | Placed in col 2 when inside Column. |
+| `Form.Actions` | `withColumn.center()` | Placed in col 2 when inside Column. |
 
-2. **Search-style dialogs** (SearchDialog, CommandsDialogContent) have full-bleed SearchList content. CommandsDialogContent correctly uses Dialog.Body; SearchDialog does not and handles its own max-height overflow.
+### SearchList
 
-3. **Form dialogs** (CreateSpaceDialog) use Form.Viewport directly in Dialog.Content, skipping Dialog.Body. This is safe because `--gutter-offset` is set by Column.Content (not Column.Root), so Form.Viewport's ScrollArea.Root sees `--gutter-offset` defaulting to `0px` and applies no negative margin. These dialogs should still be updated to use Dialog.Body for consistency, but they won't break.
+| Sub-component | withColumn applied | Effect |
+| :--- | :--- | :--- |
+| `SearchList.Content` | `withColumn.propagate()` | Extends subgrid to children when inside Column. |
+| `SearchList.Input` wrapper | `withColumn.center()` | Input row placed in col 2. |
 
-4. **AlertDialog.Body uses Column.Viewport** (ScrollArea), while **Dialog.Body uses Column.Content** (non-scrolling). This inconsistency should be resolved — AlertDialog.Body should likely also use Column.Content so that child components can bring their own scroll.
+### Card
 
-## Completed Work
+`Card.Row` uses its own inline subgrid CSS (`col-span-3 grid grid-cols-subgrid`) and does not
+participate in an outer Column grid. `Card.Root` establishes a separate 3-column grid for its
+own icon-slot layout.
 
-### Column.Content primitive ✅
+## Subgrid chain integrity
 
-- New `Column.Content` component using CSS subgrid
-- `Column.Root` JSDoc updated to document three child types (Row, Content, Viewport)
-- `ColumnContentProps` exported from `@dxos/react-ui`
-- Column stories added (WithContent, ContentWithScrollArea)
+Every intermediate container between `Column.Root` and a `ScrollArea.Root` must propagate the
+subgrid, otherwise `ScrollArea.Root`'s `[.dx-column_&]:col-span-full` selector will not match
+and the scrollbar will not extend to the gutter.
 
-### Dialog standardization ✅
+Required chain:
 
-- `Dialog.Viewport` removed (no consumers)
-- `Dialog.Body` delegates to `Column.Content`
-- Dialog stories updated (DefaultStory, ScrollingStory)
-- All dialog stories use consistent `Root > Overlay > Content` wrapping (no Portal)
+```
+Column.Root (.dx-column)
+  → withColumn.propagate() container   (col-span-full, grid, grid-cols-subgrid)
+    → ScrollArea.Root                  (.dx-container, [.dx-column_&]:col-span-full)
+      → ScrollArea.Viewport            (applies --gutter padding, resets --dx-col)
+```
 
-### AlertDialog unified with Dialog ✅
-
-- AlertDialog shares Header, Body, ActionBar, CloseIconButton with Dialog
-- AlertDialog.Content normalized to `gutter='sm'`
-- AlertDialog.Body changed from Column.Viewport (scroll) to Column.Content (subgrid)
-
-### Consumer migrations ✅
-
-All dialogs updated to standard `Dialog.Content > Dialog.Header > Dialog.Body` structure:
-
-1. CreateSpaceDialog — wrapped Form.Root in Dialog.Body ✅
-2. SearchDialog — added Header and Body ✅
-3. ShortcutsDialogContent — replaced custom flex layout with Header and Body ✅
-4. DeploymentDialog — restructured to use Header, Body, ActionBar ✅
-5. SpaceDialog — wrapped SpacePanel in Dialog.Body ✅
-6. IdentityDialog — wrapped IdentityPanel in Dialog.Body ✅
-7. JoinDialog (plugin-space) — wrapped JoinPanel in Dialog.Body ✅
-8. JoinDialog (plugin-client) — wrapped JoinPanel in Dialog.Body ✅
-9. plugin-client ResetDialog — already correct (ConfirmReset uses Dialog.Body internally) ✅
-
-### SearchList subgrid propagation ✅
-
-- SearchList.Content propagates subgrid when inside a Column context
-- SearchList.Viewport now passes `padding` for gutter alignment
-
-## Remaining Work
-
-### Storybook verification
-
-Visually verify all migrated dialogs in storybook:
-
-- Gutter alignment for non-scrolling content in Dialog.Body
-- ScrollArea full width with correct gutter padding on Viewport
-- Height constraint and scrolling behavior
-- AlertDialog stories with the aligned Body implementation
-
-### Form subgrid propagation
-
-Form currently doesn't propagate the subgrid in Column context.
-If Form is used inside Dialog.Body, Form.Viewport (ScrollArea) needs to
-span full width. This may require the same subgrid propagation pattern
-applied to SearchList.Content.
-
-### Card alignment
-
-Card has no Body equivalent. Consider adding Card.Body using Column.Content
-for cards that need scrollable or guttered content areas.
+If any intermediate element wraps the ScrollArea without propagating, use `Column.Bleed` or
+apply `withColumn.propagate()` to that wrapper.

--- a/packages/ui/react-ui/src/primitives/Column/Column.stories.tsx
+++ b/packages/ui/react-ui/src/primitives/Column/Column.stories.tsx
@@ -7,7 +7,6 @@ import React from 'react';
 
 import { Input, ScrollArea } from '../../components';
 import { withLayout, withTheme } from '../../testing';
-import { Flex } from '../Flex';
 import { Column } from './Column';
 
 const List = () => {
@@ -45,25 +44,23 @@ const DefaultStory = () => {
         </div>
       </Column.Center>
 
-      <Column.Bleed asChild>
-        <ScrollArea.Root orientation='vertical' padding>
-          <ScrollArea.Viewport>
-            <div className='flex flex-col gap-2'>
-              {Array.from({ length: 100 }).map((_, i) => (
-                <Input.Root key={i}>
-                  <Input.TextInput value={`Item ${i}`} readOnly />
-                </Input.Root>
-              ))}
-            </div>
-          </ScrollArea.Viewport>
-        </ScrollArea.Root>
-      </Column.Bleed>
+      <ScrollArea.Root orientation='vertical' padding>
+        <ScrollArea.Viewport>
+          <div className='flex flex-col gap-2'>
+            {Array.from({ length: 100 }).map((_, i) => (
+              <Input.Root key={i}>
+                <Input.TextInput value={`Item ${i}`} readOnly />
+              </Input.Root>
+            ))}
+          </div>
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>
 
       <Column.Center asChild>
-        <Flex column>
+        <div className='flex flex-col'>
           <h1 className='p-1 bg-red-500 text-black'>Section with overflow</h1>
           <pre className='p-1 text-xs text-subdued overflow-auto'>{new Error().stack}</pre>
-        </Flex>
+        </div>
       </Column.Center>
 
       <Column.Center>
@@ -105,7 +102,7 @@ export const WithScrollArea = {
       <Column.Center>
         <h2 className='py-3'>Header</h2>
       </Column.Center>
-      <ScrollArea.Root padding centered orientation='vertical' classNames='col-span-full'>
+      <ScrollArea.Root padding centered orientation='vertical'>
         <ScrollArea.Viewport>
           <InputList items={30} />
         </ScrollArea.Viewport>
@@ -125,42 +122,40 @@ export const WithScrollArea = {
 export const WithCenter: Story = {
   decorators: [withLayout({ layout: 'column', classNames: 'w-[25rem]' })],
   render: () => (
-    <Column.Root classNames='overflow-hidden' gutter='md'>
+    <Column.Root gutter='md'>
       <Column.Center>
-        <h2 className='py-3'>Header (Column.Center)</h2>
+        <h2>Header (Column.Center)</h2>
       </Column.Center>
       <Column.Center classNames='flex flex-col'>
-        <p className='py-2'>This text is inside Column.Center. It sits in the central column between the gutters.</p>
+        <p>This text is inside Column.Center. It sits in the central column between the gutters.</p>
         <Input.Root>
           <Input.Label>Name</Input.Label>
           <Input.TextInput placeholder='Enter name' />
         </Input.Root>
       </Column.Center>
       <Column.Center>
-        <h2 className='py-3'>Footer (Column.Center)</h2>
+        <h2>Footer (Column.Center)</h2>
       </Column.Center>
     </Column.Root>
   ),
 };
 
 /**
- * Column.Bleed spans all 3 columns gutter-to-gutter.
- * Use for ScrollArea so that its scrollbar sits in the right-gutter track.
+ * ScrollArea auto-bleeds inside Column.Root (via [.dx-column_&]:col-span-full).
+ * No Column.Bleed wrapper needed.
  */
-export const WithBleed: Story = {
+export const WithScrollAreaAutoBleed: Story = {
   decorators: [withLayout({ layout: 'column', classNames: 'w-[25rem]' })],
   render: () => (
     <Column.Root classNames='overflow-hidden' gutter='md'>
       <Column.Center>
         <h2 className='py-3'>Header (Column.Center)</h2>
       </Column.Center>
-      <Column.Bleed asChild>
-        <ScrollArea.Root orientation='vertical' padding thin>
-          <ScrollArea.Viewport>
-            <InputList items={30} />
-          </ScrollArea.Viewport>
-        </ScrollArea.Root>
-      </Column.Bleed>
+      <ScrollArea.Root orientation='vertical' padding thin>
+        <ScrollArea.Viewport>
+          <InputList items={30} />
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>
       <Column.Center>
         <h2 className='py-3'>Footer (Column.Center)</h2>
       </Column.Center>

--- a/packages/ui/react-ui/src/primitives/Column/Column.stories.tsx
+++ b/packages/ui/react-ui/src/primitives/Column/Column.stories.tsx
@@ -10,7 +10,6 @@ import { withLayout, withTheme } from '../../testing';
 import { Flex } from '../Flex';
 import { Column } from './Column';
 
-// TODO(burdon): Content is clipped!
 const List = () => {
   return (
     <ScrollArea.Root centered>
@@ -28,9 +27,9 @@ const List = () => {
 const DefaultStory = () => {
   return (
     <Column.Root classNames='overflow-hidden' gutter='md'>
-      <Column.Row center>
+      <Column.Center>
         <h1 className='p-1 bg-blue-500 text-black'>Header</h1>
-      </Column.Row>
+      </Column.Center>
 
       <Column.Row>
         <div className='p-1 bg-blue-500'>A</div>
@@ -38,13 +37,13 @@ const DefaultStory = () => {
         <div className='p-1 bg-blue-500'>C</div>
       </Column.Row>
 
-      <Column.Row asChild center>
+      <Column.Center asChild>
         <div className='py-2'>
           <Input.Root>
             <Input.TextInput placeholder='Search' />
           </Input.Root>
         </div>
-      </Column.Row>
+      </Column.Center>
 
       <Column.Bleed asChild>
         <ScrollArea.Root orientation='vertical' padding>
@@ -60,16 +59,16 @@ const DefaultStory = () => {
         </ScrollArea.Root>
       </Column.Bleed>
 
-      <Column.Row asChild center>
+      <Column.Center asChild>
         <Flex column>
           <h1 className='p-1 bg-red-500 text-black'>Section with overflow</h1>
           <pre className='p-1 text-xs text-subdued overflow-auto'>{new Error().stack}</pre>
         </Flex>
-      </Column.Row>
+      </Column.Center>
 
-      <Column.Row center>
+      <Column.Center>
         <div className='p-1 bg-green-500 text-black'>Footer</div>
-      </Column.Row>
+      </Column.Center>
     </Column.Root>
   );
 };
@@ -103,17 +102,17 @@ export const WithScrollArea = {
   decorators: [withLayout({ layout: 'column' })],
   render: () => (
     <Column.Root classNames='overflow-hidden' gutter='md'>
-      <Column.Row center>
+      <Column.Center>
         <h2 className='py-3'>Header</h2>
-      </Column.Row>
+      </Column.Center>
       <ScrollArea.Root padding centered orientation='vertical' classNames='col-span-full'>
         <ScrollArea.Viewport>
           <InputList items={30} />
         </ScrollArea.Viewport>
       </ScrollArea.Root>
-      <Column.Row center>
+      <Column.Center>
         <h2 className='py-3'>Footer</h2>
-      </Column.Row>
+      </Column.Center>
     </Column.Root>
   ),
 };
@@ -127,9 +126,9 @@ export const WithCenter: Story = {
   decorators: [withLayout({ layout: 'column', classNames: 'w-[25rem]' })],
   render: () => (
     <Column.Root classNames='overflow-hidden' gutter='md'>
-      <Column.Row center>
-        <h2 className='py-3'>Header (Column.Row)</h2>
-      </Column.Row>
+      <Column.Center>
+        <h2 className='py-3'>Header (Column.Center)</h2>
+      </Column.Center>
       <Column.Center classNames='flex flex-col'>
         <p className='py-2'>This text is inside Column.Center. It sits in the central column between the gutters.</p>
         <Input.Root>
@@ -137,9 +136,9 @@ export const WithCenter: Story = {
           <Input.TextInput placeholder='Enter name' />
         </Input.Root>
       </Column.Center>
-      <Column.Row center>
-        <h2 className='py-3'>Footer (Column.Row)</h2>
-      </Column.Row>
+      <Column.Center>
+        <h2 className='py-3'>Footer (Column.Center)</h2>
+      </Column.Center>
     </Column.Root>
   ),
 };
@@ -152,9 +151,9 @@ export const WithBleed: Story = {
   decorators: [withLayout({ layout: 'column', classNames: 'w-[25rem]' })],
   render: () => (
     <Column.Root classNames='overflow-hidden' gutter='md'>
-      <Column.Row center>
-        <h2 className='py-3'>Header (Column.Row)</h2>
-      </Column.Row>
+      <Column.Center>
+        <h2 className='py-3'>Header (Column.Center)</h2>
+      </Column.Center>
       <Column.Bleed asChild>
         <ScrollArea.Root orientation='vertical' padding thin>
           <ScrollArea.Viewport>
@@ -162,9 +161,9 @@ export const WithBleed: Story = {
           </ScrollArea.Viewport>
         </ScrollArea.Root>
       </Column.Bleed>
-      <Column.Row center>
-        <h2 className='py-3'>Footer (Column.Row)</h2>
-      </Column.Row>
+      <Column.Center>
+        <h2 className='py-3'>Footer (Column.Center)</h2>
+      </Column.Center>
     </Column.Root>
   ),
 };

--- a/packages/ui/react-ui/src/primitives/Column/Column.stories.tsx
+++ b/packages/ui/react-ui/src/primitives/Column/Column.stories.tsx
@@ -37,7 +37,7 @@ const DefaultStory = () => {
       </Column.Row>
 
       <Column.Center asChild>
-        <div className='py-2'>
+        <div>
           <Input.Root>
             <Input.TextInput placeholder='Search' />
           </Input.Root>
@@ -100,7 +100,7 @@ export const WithScrollArea = {
   render: () => (
     <Column.Root classNames='overflow-hidden' gutter='md'>
       <Column.Center>
-        <h2 className='py-3'>Header</h2>
+        <h2>Header</h2>
       </Column.Center>
       <ScrollArea.Root padding centered orientation='vertical'>
         <ScrollArea.Viewport>
@@ -108,7 +108,7 @@ export const WithScrollArea = {
         </ScrollArea.Viewport>
       </ScrollArea.Root>
       <Column.Center>
-        <h2 className='py-3'>Footer</h2>
+        <h2>Footer</h2>
       </Column.Center>
     </Column.Root>
   ),
@@ -120,7 +120,7 @@ export const WithScrollArea = {
  * compound components (Form.Root, Editor.Root, etc.) that render `display: contents`.
  */
 export const WithCenter: Story = {
-  decorators: [withLayout({ layout: 'column', classNames: 'w-[25rem]' })],
+  decorators: [withLayout({ classNames: 'w-[25rem]' })],
   render: () => (
     <Column.Root gutter='md'>
       <Column.Center>
@@ -149,7 +149,7 @@ export const WithScrollAreaAutoBleed: Story = {
   render: () => (
     <Column.Root classNames='overflow-hidden' gutter='md'>
       <Column.Center>
-        <h2 className='py-3'>Header (Column.Center)</h2>
+        <h2>Header (Column.Center)</h2>
       </Column.Center>
       <ScrollArea.Root orientation='vertical' padding thin>
         <ScrollArea.Viewport>
@@ -157,7 +157,7 @@ export const WithScrollAreaAutoBleed: Story = {
         </ScrollArea.Viewport>
       </ScrollArea.Root>
       <Column.Center>
-        <h2 className='py-3'>Footer (Column.Center)</h2>
+        <h2>Footer (Column.Center)</h2>
       </Column.Center>
     </Column.Root>
   ),

--- a/packages/ui/react-ui/src/primitives/Column/Column.tsx
+++ b/packages/ui/react-ui/src/primitives/Column/Column.tsx
@@ -6,7 +6,7 @@ import { Primitive } from '@radix-ui/react-primitive';
 import { Slot } from '@radix-ui/react-slot';
 import React, { type CSSProperties } from 'react';
 
-import { type ColumnStyleProps, composableProps, slottable } from '@dxos/ui-theme';
+import { composableProps, slottable } from '@dxos/ui-theme';
 import { type SlottableProps } from '@dxos/ui-types';
 
 import { useThemeContext } from '../../hooks';
@@ -30,13 +30,17 @@ type ColumnRootProps = { gutter?: GutterSize };
 
 /**
  * Creates a 3-column CSS grid with left/right gutter columns and a center content column.
- * Sets the `--gutter` CSS variable for nested components.
+ * Sets `--gutter` and `--dx-col` CSS variables for nested components.
+ * `--dx-col` defaults to `2 / span 1` (center column), enabling `withColumn` utilities
+ * to cascade the correct grid placement to slotted children.
  *
  * Direct children participate in the grid in one of several ways:
  * - **Column.Center** — places element in the center column (col 2). Preferred for plain content.
  * - **Column.Bleed** — spans all 3 columns gutter-to-gutter. Preferred for `ScrollArea` and
  *   other content that should ignore the gutters.
  * - **Column.Row** — 3-col subgrid row (icons in gutters, content in center).
+ *
+ * Use `withColumn.center()` / `withColumn.bleed()` helpers to apply placement on slotted elements.
  *
  * Gutter sizes: `'sm'` for compact layouts (Dialog); `'md'` (default); `'lg'` for wider spacing.
  */
@@ -53,6 +57,7 @@ const ColumnRoot = slottable<HTMLDivElement, ColumnRootProps>(
         style={
           {
             '--gutter': gutterSize,
+            '--dx-col': '2 / span 1',
             gridTemplateColumns: [gutterSize, 'minmax(0,1fr)', gutterSize].join(' '),
           } as CSSProperties
         }
@@ -73,7 +78,7 @@ ColumnRoot.displayName = COLUMN_ROOT_NAME;
 
 const COLUMN_ROW_NAME = 'Column.Row';
 
-type ColumnRowProps = ColumnStyleProps;
+type ColumnRowProps = {};
 
 /**
  * Spans all 3 columns of the parent Column.Root and uses CSS subgrid to inherit their sizing.
@@ -81,7 +86,7 @@ type ColumnRowProps = ColumnStyleProps;
  * Must be a direct child of Column.Root.
  */
 const ColumnRow = slottable<HTMLDivElement, ColumnRowProps>(
-  ({ children, asChild, role, fullWidth, center, ...props }, forwardedRef) => {
+  ({ children, asChild, role, ...props }, forwardedRef) => {
     const { className, ...rest } = composableProps(props);
     const Comp = asChild ? Slot : Primitive.div;
     const { tx } = useThemeContext();
@@ -89,7 +94,7 @@ const ColumnRow = slottable<HTMLDivElement, ColumnRowProps>(
       <Comp
         {...rest}
         role={role ?? 'none'}
-        className={tx('column.row', { fullWidth, center }, className)}
+        className={tx('column.row', {}, className)}
         ref={forwardedRef}
       >
         {children}
@@ -110,6 +115,7 @@ type ColumnBleedProps = SlottableProps;
 
 /**
  * Spans all 3 columns of the parent Column.Root (gutter-to-gutter).
+ * Establishes a CSS subgrid so that grandchildren can participate in the parent column tracks.
  * Use for `ScrollArea`, full-width dividers, tables, or any content that should ignore the gutters.
  */
 const ColumnBleed = slottable<HTMLDivElement>(({ children, asChild, ...props }, forwardedRef) => {

--- a/packages/ui/react-ui/src/primitives/Column/Column.tsx
+++ b/packages/ui/react-ui/src/primitives/Column/Column.tsx
@@ -85,23 +85,16 @@ type ColumnRowProps = {};
  * Children map to: [col-1: icon/slot] [col-2: content] [col-3: icon/action].
  * Must be a direct child of Column.Root.
  */
-const ColumnRow = slottable<HTMLDivElement, ColumnRowProps>(
-  ({ children, asChild, role, ...props }, forwardedRef) => {
-    const { className, ...rest } = composableProps(props);
-    const Comp = asChild ? Slot : Primitive.div;
-    const { tx } = useThemeContext();
-    return (
-      <Comp
-        {...rest}
-        role={role ?? 'none'}
-        className={tx('column.row', {}, className)}
-        ref={forwardedRef}
-      >
-        {children}
-      </Comp>
-    );
-  },
-);
+const ColumnRow = slottable<HTMLDivElement, ColumnRowProps>(({ children, asChild, role, ...props }, forwardedRef) => {
+  const { className, ...rest } = composableProps(props);
+  const Comp = asChild ? Slot : Primitive.div;
+  const { tx } = useThemeContext();
+  return (
+    <Comp {...rest} role={role ?? 'none'} className={tx('column.row', {}, className)} ref={forwardedRef}>
+      {children}
+    </Comp>
+  );
+});
 
 ColumnRow.displayName = COLUMN_ROW_NAME;
 

--- a/packages/ui/ui-theme/src/css/utilities.css
+++ b/packages/ui/ui-theme/src/css/utilities.css
@@ -31,17 +31,17 @@
 }
 
 /**
- * Column that fills the available space (extends dx-expander with overflow clipping).
- */
-@utility dx-column {
-  @apply flex-1 min-w-0 w-full;
-}
-
-/**
  * Container that fills the available space (extends dx-expander with overflow clipping).
  */
 @utility dx-container {
   @apply dx-expander overflow-hidden;
+}
+
+/**
+ * Column that fills the available space (extends dx-expander with overflow clipping).
+ */
+@utility dx-column {
+  @apply flex-1 min-w-0 w-full;
 }
 
 /**

--- a/packages/ui/ui-theme/src/theme/components/card.ts
+++ b/packages/ui/ui-theme/src/theme/components/card.ts
@@ -73,6 +73,9 @@ const cardLink: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
 const cardLinkLabel: ComponentFunction<CardStyleProps> = (_props, ...etc) =>
   mx('dx-card__link-label min-w-0 flex-1 truncate', ...etc);
 
+const cardRow: ComponentFunction<CardStyleProps> = (_, ...etc) =>
+  mx('dx-card__row col-span-3 grid grid-cols-subgrid', ...etc);
+
 const cardIconBlock: ComponentFunction<CardStyleProps> = ({ padding }, ...etc) =>
   mx(
     'dx-card__icon-block grid h-[var(--dx-rail-item)] w-[var(--dx-rail-item)] place-items-center',
@@ -85,6 +88,7 @@ export const cardTheme: Theme<CardStyleProps> = {
   toolbar: cardToolbar,
   title: cardTitle,
   content: cardContent,
+  row: cardRow,
   heading: cardHeading,
   text: cardText,
   'text-span': cardTextSpan,

--- a/packages/ui/ui-theme/src/theme/components/dialog.ts
+++ b/packages/ui/ui-theme/src/theme/components/dialog.ts
@@ -5,6 +5,7 @@
 import { type ComponentFunction, type Elevation, type Theme } from '@dxos/ui-types';
 
 import { mx } from '../../util';
+import { withColumn } from '../primitives/column';
 
 export type DialogSize = 'sm' | 'md' | 'lg' | 'xl';
 
@@ -35,12 +36,13 @@ export const dialogContent: ComponentFunction<DialogStyleProps> = ({ inOverlayLa
 };
 
 export const dialogHeader: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
-  mx('dx-dialog__header flex pb-4 items-center justify-between', ...etc);
+  mx('dx-dialog__header flex pb-4 items-center justify-between', withColumn.center(), ...etc);
 
-export const dialogBody: ComponentFunction<DialogStyleProps> = (_props, ...etc) => mx('dx-dialog__body', ...etc);
+export const dialogBody: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
+  mx('dx-dialog__body', withColumn.propagate(), ...etc);
 
 export const dialogActionBar: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
-  mx('dx-dialog__actionbar flex items-center pt-4 gap-2 dx-density-coarse', ...etc);
+  mx('dx-dialog__actionbar flex items-center pt-4 gap-2 dx-density-coarse', withColumn.center(), ...etc);
 
 export const dialogTitle: ComponentFunction<DialogStyleProps> = ({ srOnly }, ...etc) =>
   mx('dx-dialog__title', srOnly && 'sr-only', ...etc);

--- a/packages/ui/ui-theme/src/theme/components/dialog.ts
+++ b/packages/ui/ui-theme/src/theme/components/dialog.ts
@@ -39,7 +39,7 @@ export const dialogHeader: ComponentFunction<DialogStyleProps> = (_props, ...etc
   mx('dx-dialog__header flex pb-4 items-center justify-between', withColumn.center(), ...etc);
 
 export const dialogBody: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
-  mx('dx-dialog__body', withColumn.propagate(), ...etc);
+  mx('dx-dialog__body dx-expander', withColumn.propagate(), ...etc);
 
 export const dialogActionBar: ComponentFunction<DialogStyleProps> = (_props, ...etc) =>
   mx('dx-dialog__actionbar flex items-center pt-4 gap-2 dx-density-coarse', withColumn.center(), ...etc);

--- a/packages/ui/ui-theme/src/theme/components/popover.ts
+++ b/packages/ui/ui-theme/src/theme/components/popover.ts
@@ -23,7 +23,7 @@ export const popoverContent: ComponentFunction<PopoverStyleProps> = ({ elevation
 
 export const popoverViewport: ComponentFunction<PopoverStyleProps> = ({ constrainBlock, constrainInline }, ...etc) =>
   mx(
-    'flex flex-col min-h-0 min-w-popover-min-width',
+    'grid grid-rows-[1fr] min-h-0 min-w-popover-min-width',
     (constrainBlock || constrainInline) && 'overflow-hidden',
     constrainBlock && 'max-h-(--radix-popover-content-available-height)',
     constrainBlock &&

--- a/packages/ui/ui-theme/src/theme/components/scroll-area.ts
+++ b/packages/ui/ui-theme/src/theme/components/scroll-area.ts
@@ -58,7 +58,11 @@ export const scrollAreaViewport: ComponentFunction<ScrollAreaStyleProps> = (
   return mx(
     'flex-1 min-h-0 w-full',
 
-    orientation === 'vertical' && 'flex flex-col overflow-y-scroll',
+    // Reset --dx-col so nested components don't try to grid-position themselves.
+    // ScrollArea has already consumed --gutter for padding.
+    withColumn.consumed(),
+
+    orientation === 'vertical' && 'overflow-y-scroll',
     orientation === 'horizontal' && 'flex overflow-x-scroll overscroll-x-contain',
     orientation === 'all' && 'overflow-scroll',
 
@@ -77,10 +81,6 @@ export const scrollAreaViewport: ComponentFunction<ScrollAreaStyleProps> = (
             'pr-[calc(var(--gutter,calc(var(--scroll-width)+var(--scroll-padding)))-var(--scroll-width))]',
           ]
         : centered && 'pl-[var(--scroll-width)]'),
-
-    // Reset --dx-col so nested components don't try to grid-position themselves.
-    // ScrollArea has already consumed --gutter for padding.
-    withColumn.consumed(),
 
     (orientation === 'horizontal' || orientation === 'all') &&
       (padding

--- a/packages/ui/ui-theme/src/theme/components/scroll-area.ts
+++ b/packages/ui/ui-theme/src/theme/components/scroll-area.ts
@@ -42,8 +42,8 @@ export const scrollAreaRoot: ComponentFunction<ScrollAreaStyleProps> = ({ orient
     orientation === 'horizontal' && 'group/scroll-h flex',
     orientation === 'all' && 'group/scroll-all',
 
-    // Apply col-span-full only when inside a Column.Root grid (detected via dx-column marker).
-    '[.dx-column_&]:col-span-full',
+    // Apply col-span-full only when inside a Column.Root grid (detected via dx-column-root marker).
+    '[.dx-column-root_&]:col-span-full',
 
     ...etc,
   );

--- a/packages/ui/ui-theme/src/theme/components/scroll-area.ts
+++ b/packages/ui/ui-theme/src/theme/components/scroll-area.ts
@@ -52,11 +52,11 @@ export const scrollAreaRoot: ComponentFunction<ScrollAreaStyleProps> = ({ orient
  * NOTE: The browser reserves space for scrollbars.
  */
 export const scrollAreaViewport: ComponentFunction<ScrollAreaStyleProps> = (
-  { orientation, centered, padding, snap, thin, autoHide },
+  { orientation, centered, padding, snap, autoHide },
   ...etc
 ) => {
   return mx(
-    'h-full w-full',
+    'flex-1 min-h-0 w-full',
 
     orientation === 'vertical' && 'flex flex-col overflow-y-scroll',
     orientation === 'horizontal' && 'flex overflow-x-scroll overscroll-x-contain',

--- a/packages/ui/ui-theme/src/theme/components/scroll-area.ts
+++ b/packages/ui/ui-theme/src/theme/components/scroll-area.ts
@@ -5,6 +5,7 @@
 import { type AllowedAxis, type ComponentFunction, type Theme } from '@dxos/ui-types';
 
 import { mx } from '../../util';
+import { withColumn } from '../primitives/column';
 
 export const scrollbar = {
   thin: {
@@ -76,6 +77,10 @@ export const scrollAreaViewport: ComponentFunction<ScrollAreaStyleProps> = (
             'pr-[calc(var(--gutter,calc(var(--scroll-width)+var(--scroll-padding)))-var(--scroll-width))]',
           ]
         : centered && 'pl-[var(--scroll-width)]'),
+
+    // Reset --dx-col so nested components don't try to grid-position themselves.
+    // ScrollArea has already consumed --gutter for padding.
+    withColumn.consumed(),
 
     (orientation === 'horizontal' || orientation === 'all') &&
       (padding

--- a/packages/ui/ui-theme/src/theme/primitives/column.ts
+++ b/packages/ui/ui-theme/src/theme/primitives/column.ts
@@ -31,7 +31,7 @@ export const withColumn = {
 export type ColumnStyleProps = {};
 
 const columnRoot: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
-  return mx('dx-column grid', ...etc);
+  return mx('dx-column grid content-start', ...etc);
 };
 
 /**

--- a/packages/ui/ui-theme/src/theme/primitives/column.ts
+++ b/packages/ui/ui-theme/src/theme/primitives/column.ts
@@ -6,10 +6,29 @@ import { type ComponentFunction } from '@dxos/ui-types';
 
 import { mx } from '../../util';
 
-export type ColumnStyleProps = {
-  fullWidth?: boolean;
-  center?: boolean;
+/**
+ * Column-aware theme utilities.
+ * Components apply these in their theme functions to participate in the Column grid
+ * without importing Column React components.
+ *
+ * CSS custom property cascade:
+ * - Column.Root sets `--dx-col: 2 / span 1` (center column placement).
+ * - ScrollArea.Viewport resets `--dx-col: auto` after consuming `--gutter`.
+ * - Components apply `grid-column: var(--dx-col, auto)` to auto-center in Column
+ *   or do nothing outside Column / inside ScrollArea.
+ */
+export const withColumn = {
+  /** Centers element in the Column grid via --dx-col. No-op outside Column or inside ScrollArea. */
+  center: () => '[grid-column:var(--dx-col,auto)]',
+
+  /** Propagates the Column grid to children via subgrid. No-op outside Column. */
+  propagate: () => '[.dx-column_&]:col-span-full [.dx-column_&]:grid [.dx-column_&]:grid-cols-subgrid',
+
+  /** Resets --dx-col after consuming --gutter. Applied by ScrollArea.Viewport. */
+  consumed: () => '[--dx-col:auto]',
 };
+
+export type ColumnStyleProps = {};
 
 const columnRoot: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
   return mx('dx-column grid', ...etc);
@@ -21,7 +40,7 @@ const columnRoot: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
  * Safe to nest arbitrary compound components (including those that render `display: contents`).
  */
 const columnCenter: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
-  return mx('col-start-2 col-span-1 min-h-0', ...etc);
+  return mx(withColumn.center(), 'min-h-0', ...etc);
 };
 
 /**
@@ -29,7 +48,7 @@ const columnCenter: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
  * Use for `ScrollArea`, full-width dividers, tables, or any content that should ignore gutters.
  */
 const columnBleed: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
-  return mx('col-span-full min-h-0', ...etc);
+  return mx('col-span-full grid grid-cols-subgrid min-h-0', ...etc);
 };
 
 /**
@@ -38,8 +57,8 @@ const columnBleed: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
  * Children map to: [col-1: icon/slot] [col-2: content] [col-3: icon/action].
  * NOTE: Must not use overflow-hidden here since it will clip input focus rings.
  */
-const columnRow: ComponentFunction<ColumnStyleProps> = ({ fullWidth, center }, ...etc) => {
-  return mx('col-span-3 grid grid-cols-subgrid', fullWidth ? 'col-span-3' : center && 'col-start-2 col-span-1', ...etc);
+const columnRow: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
+  return mx('col-span-3 grid grid-cols-subgrid', ...etc);
 };
 
 export const columnTheme = {

--- a/packages/ui/ui-theme/src/theme/primitives/column.ts
+++ b/packages/ui/ui-theme/src/theme/primitives/column.ts
@@ -21,8 +21,10 @@ export const withColumn = {
   /** Centers element in the Column grid via --dx-col. No-op outside Column or inside ScrollArea. */
   center: () => '[grid-column:var(--dx-col,auto)]',
 
-  /** Propagates the Column grid to children via subgrid. No-op outside Column. */
-  propagate: () => '[.dx-column-root_&]:col-span-full [.dx-column-root_&]:grid [.dx-column-root_&]:grid-cols-subgrid',
+  /** Propagates the Column grid to children via subgrid. No-op outside Column.
+   *  Direct children default to center column unless they are a dx-container (ScrollArea). */
+  propagate: () =>
+    '[.dx-column-root_&]:col-span-full [.dx-column-root_&]:grid [.dx-column-root_&]:grid-cols-subgrid [.dx-column-root_&]:[&>*:not(.dx-container)]:[grid-column:var(--dx-col,auto)]',
 
   /** Resets --dx-col after consuming --gutter. Applied by ScrollArea.Viewport. */
   consumed: () => '[--dx-col:auto]',

--- a/packages/ui/ui-theme/src/theme/primitives/column.ts
+++ b/packages/ui/ui-theme/src/theme/primitives/column.ts
@@ -31,7 +31,7 @@ export const withColumn = {
 export type ColumnStyleProps = {};
 
 const columnRoot: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
-  return mx('dx-column grid content-start', ...etc);
+  return mx('dx-column grid', ...etc);
 };
 
 /**

--- a/packages/ui/ui-theme/src/theme/primitives/column.ts
+++ b/packages/ui/ui-theme/src/theme/primitives/column.ts
@@ -22,7 +22,7 @@ export const withColumn = {
   center: () => '[grid-column:var(--dx-col,auto)]',
 
   /** Propagates the Column grid to children via subgrid. No-op outside Column. */
-  propagate: () => '[.dx-column_&]:col-span-full [.dx-column_&]:grid [.dx-column_&]:grid-cols-subgrid',
+  propagate: () => '[.dx-column-root_&]:col-span-full [.dx-column-root_&]:grid [.dx-column-root_&]:grid-cols-subgrid',
 
   /** Resets --dx-col after consuming --gutter. Applied by ScrollArea.Viewport. */
   consumed: () => '[--dx-col:auto]',
@@ -31,7 +31,7 @@ export const withColumn = {
 export type ColumnStyleProps = {};
 
 const columnRoot: ComponentFunction<ColumnStyleProps> = (_, ...etc) => {
-  return mx('dx-column grid', ...etc);
+  return mx('dx-column-root grid', ...etc);
 };
 
 /**


### PR DESCRIPTION
## Summary

- Add `withColumn` theme utilities (`center`, `propagate`, `consumed`) so components are automatically column-aware via CSS custom properties
- `Column.Root` sets `--dx-col: 2 / span 1`; components consume it for grid placement; `ScrollArea.Viewport` resets it
- Dialog, Form, SearchList, and Card now use `withColumn` utilities instead of manual Column wrapper wiring
- Remove redundant `Column.Bleed` wrappers around ScrollArea (auto-bleeds via `[.dx-column-root_&]:col-span-full`)
- `Column.Row` simplified (removed `center`/`fullWidth` props)
- `Column.Bleed` now propagates grid via CSS subgrid
- Fix pre-existing ScrollArea scroll issues:
  - `ScrollArea.Viewport`: use `flex-1 min-h-0` instead of `h-full` for reliable flex chain sizing
  - `ScrollArea.Viewport`: remove `flex flex-col` for vertical orientation so children use block flow (prevents item compression)
  - `Popover.Viewport`: use `grid` instead of `flex flex-col` so `max-h` gives definite row sizing
  - `withColumn.propagate()` defaults children to center column via `[&>*:not(.dx-container)]`
  - Rename `dx-column` marker to `dx-column-root` to avoid false matches with `dx-column` CSS utility
- Chat.Toolbar extraction, ChatOptions.stories, story title fixes

## Test plan

- [ ] Storybook: verify Column stories (Default, WithCenter, WithScrollArea, WithScrollAreaAutoBleed)
- [ ] Storybook: verify Dialog stories (Default, Scrolling)
- [ ] Storybook: verify ChatOptions stories (Default with Popover scroll, ObjectsPanelStory)
- [ ] App: verify CreateObjectDialog scrolls correctly with type list
- [ ] App: verify CommandsDialog search input is centered, results scroll
- [ ] App: verify SearchDialog layout
- [ ] App: verify Card layout in deck view
- [ ] App: verify Combobox/filter popovers scroll correctly
- [ ] App: verify ResetDialog text layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)