### PR TITLE
fix(ai): set default max_tokens to 16k for all Anthropic models

### DIFF
--- a/packages/core/ai/src/resolvers/anthropic/AnthropicResolver.ts
+++ b/packages/core/ai/src/resolvers/anthropic/AnthropicResolver.ts
@@ -26,33 +26,40 @@ export const make = () =>
               type: 'adaptive' as any,
             } as const)
           : undefined;
+        const max_tokens = 4096;
         switch (model) {
           case '@anthropic/claude-3-5-haiku-20241022':
-            return AnthropicLanguageModel.layer({ model: 'claude-3-5-haiku-20241022' }).pipe(
+            return AnthropicLanguageModel.layer({ model: 'claude-3-5-haiku-20241022', config: { max_tokens } }).pipe(
               Layer.provide(clientLayer),
             );
           case '@anthropic/claude-3-5-sonnet-20241022':
-            return AnthropicLanguageModel.layer({ model: 'claude-3-5-sonnet-20241022' }).pipe(
+            return AnthropicLanguageModel.layer({ model: 'claude-3-5-sonnet-20241022', config: { max_tokens } }).pipe(
               Layer.provide(clientLayer),
             );
           case '@anthropic/claude-haiku-4-5':
-            return AnthropicLanguageModel.layer({ model: 'claude-haiku-4-5' }).pipe(Layer.provide(clientLayer));
+            return AnthropicLanguageModel.layer({ model: 'claude-haiku-4-5', config: { max_tokens } }).pipe(
+              Layer.provide(clientLayer),
+            );
           case '@anthropic/claude-opus-4-0':
-            return AnthropicLanguageModel.layer({ model: 'claude-opus-4-0', config: { thinking } }).pipe(
+            return AnthropicLanguageModel.layer({ model: 'claude-opus-4-0', config: { thinking, max_tokens } }).pipe(
               Layer.provide(clientLayer),
             );
           case '@anthropic/claude-opus-4-5':
-            return AnthropicLanguageModel.layer({ model: 'claude-opus-4-5', config: { thinking } }).pipe(
+            return AnthropicLanguageModel.layer({ model: 'claude-opus-4-5', config: { thinking, max_tokens } }).pipe(
               Layer.provide(clientLayer),
             );
           case '@anthropic/claude-opus-4-6':
-            return AnthropicLanguageModel.layer({ model: 'claude-opus-4-6', config: { thinking } }).pipe(
+            return AnthropicLanguageModel.layer({ model: 'claude-opus-4-6', config: { thinking, max_tokens } }).pipe(
               Layer.provide(clientLayer),
             );
           case '@anthropic/claude-sonnet-4-0':
-            return AnthropicLanguageModel.layer({ model: 'claude-sonnet-4-0' }).pipe(Layer.provide(clientLayer));
+            return AnthropicLanguageModel.layer({ model: 'claude-sonnet-4-0', config: { max_tokens } }).pipe(
+              Layer.provide(clientLayer),
+            );
           case '@anthropic/claude-sonnet-4-5':
-            return AnthropicLanguageModel.layer({ model: 'claude-sonnet-4-5' }).pipe(Layer.provide(clientLayer));
+            return AnthropicLanguageModel.layer({ model: 'claude-sonnet-4-5', config: { max_tokens } }).pipe(
+              Layer.provide(clientLayer),
+            );
           default:
             return Layer.fail(new AiModelNotAvailableError(model));
         }

--- a/packages/core/ai/src/resolvers/anthropic/AnthropicResolver.ts
+++ b/packages/core/ai/src/resolvers/anthropic/AnthropicResolver.ts
@@ -26,7 +26,7 @@ export const make = () =>
               type: 'adaptive' as any,
             } as const)
           : undefined;
-        const max_tokens = 4096;
+        const max_tokens = 16_384;
         switch (model) {
           case '@anthropic/claude-3-5-haiku-20241022':
             return AnthropicLanguageModel.layer({ model: 'claude-3-5-haiku-20241022', config: { max_tokens } }).pipe(


### PR DESCRIPTION
## Summary

Supersedes #11022 (from chad's fork — fork-CI was blocking merge).

Without an explicit `max_tokens`, the Anthropic SDK defaults to ~1024, truncating non-trivial responses mid-word. The opus variants also use `type: 'adaptive'` thinking, which shares the `max_tokens` budget — so at 4096 the final response has little room once adaptive thinking warms up.

Bumps the shared default to **16384**, giving realistic responses (and adaptive thinking headroom) without approaching model output limits.

**Change:** single constant `const max_tokens = 16_384` applied to every `AnthropicLanguageModel.layer()` config.

## Test plan
- [x] `moon run ai:build` passes
- [ ] Verify in live Composer agent session — responses no longer truncate

Co-authored with chad — original commit on his PR kept as the first commit on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Anthropic model configurations to enforce a consistent maximum token limit of 16,384 across all supported models, ensuring predictable response generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->