### PR TITLE
fix(plugin-script): fix TypeScript 6.0 moduleResolution deprecation error in VirtualTypeScriptParser

### DIFF
--- a/.moon/tasks/tag-ts-test-browser.yml
+++ b/.moon/tasks/tag-ts-test-browser.yml
@@ -11,6 +11,7 @@ tasks:
     inputs:
       - '@group(sources)'
       - /vitest.base.config.ts
+      - /pnpm-lock.yaml # Ensure cache is invalidated when dependencies change.
       - vitest.config.ts
       - $VITEST_COVERAGE
       - $VITEST_DEBUG

--- a/.moon/tasks/tag-ts-test-storybook.yml
+++ b/.moon/tasks/tag-ts-test-storybook.yml
@@ -14,6 +14,7 @@ tasks:
       - /tools/storybook-react/.storybook/main.ts
       - /tools/storybook-react/.storybook/vitest.setup.ts
       - /vitest.base.config.ts
+      - /pnpm-lock.yaml # Ensure cache is invalidated when dependencies change.
       - .storybook/*
       - vitest.config.ts
       - $VITEST_COVERAGE

--- a/.moon/tasks/tag-ts-test.yml
+++ b/.moon/tasks/tag-ts-test.yml
@@ -9,6 +9,7 @@ tasks:
     inputs:
       - '@group(sources)'
       - /vitest.base.config.ts
+      - /pnpm-lock.yaml # Ensure cache is invalidated when dependencies change.
       - vitest.config.ts
       - $NODE_VERSION # Ensure cache isn't shared between node versions in CI.
       - $VITEST_COVERAGE

--- a/packages/plugins/plugin-script/src/notebook/vfs-parser.ts
+++ b/packages/plugins/plugin-script/src/notebook/vfs-parser.ts
@@ -42,6 +42,7 @@ export class VirtualTypeScriptParser {
   protected compilerOptions: ts.CompilerOptions = {
     target: ts.ScriptTarget.ES2020,
     module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
     strict: true,
     esModuleInterop: true,
     skipLibCheck: true,


### PR DESCRIPTION
## Summary

- Adds explicit `moduleResolution: ts.ModuleResolutionKind.Bundler` to `VirtualTypeScriptParser.compilerOptions` in `vfs-parser.ts` — TypeScript 6.0 raises TS5107 when `module: ESNext` is used without an explicit `moduleResolution`, as the implicit default (`node10`) is now deprecated
- Adds `/pnpm-lock.yaml` to the inputs of all three moon test tasks (`tag-ts-test`, `tag-ts-test-browser`, `tag-ts-test-storybook`) so that dependency upgrades (e.g. TypeScript version bumps) correctly invalidate cached test results — this was the reason the breakage went undetected: the TS 6.0 upgrade didn't change any test task inputs, so moon served stale passing results from before the upgrade

## Root cause

The TS 6.0 upgrade (#10856 / #11016) broke `plugin-script` notebook tests but the regression was invisible because moon's test cache wasn't invalidated — `pnpm-lock.yaml` was not listed as a test input. On a fresh machine with no cache, all 8 tests in `compute-graph.test.ts` and `vfs-parser.test.ts` fail with:

```
error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0.
```

## Test plan

- [x] `moon run plugin-script:test` — 8/8 tests pass after the fix
- [x] Verified failure on a clean machine before the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build task configuration to properly track dependency changes and invalidate caches when dependencies are updated.
  * Improved TypeScript compiler module resolution settings for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->