### PR TITLE
feat(app-framework): add test harness + plugin-chess/sample POC tests

### DIFF
--- a/packages/plugins/plugin-chess/package.json
+++ b/packages/plugins/plugin-chess/package.json
@@ -98,6 +98,7 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@dxos/plugin-testing": "workspace:*",
     "@dxos/plugin-theme": "workspace:*",
     "@dxos/react-ui": "workspace:*",
     "@dxos/storybook-utils": "workspace:*",

--- a/packages/plugins/plugin-chess/src/ChessPlugin.test.ts
+++ b/packages/plugins/plugin-chess/src/ChessPlugin.test.ts
@@ -1,0 +1,33 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { Capabilities } from '@dxos/app-framework';
+import { createTestApp } from '@dxos/app-framework/testing';
+import { createComposerTestApp } from '@dxos/plugin-testing/harness';
+
+import { ChessPlugin } from './ChessPlugin';
+import { Print } from './operations';
+
+describe('ChessPlugin', () => {
+  test('activates and contributes expected capabilities', async ({ expect }) => {
+    await using harness = await createTestApp({ plugins: [ChessPlugin()] });
+    const surfaces = harness.getAll(Capabilities.ReactSurface).flat();
+    expect(surfaces.length).toBeGreaterThan(0);
+  });
+
+  test('invokes the Print operation via the invoker capability', async ({ expect }) => {
+    await using harness = await createComposerTestApp({ plugins: [ChessPlugin()] });
+    const result = await harness.invoke(Print, {});
+    // Empty input returns empty ASCII (handler swallows errors for malformed FEN).
+    expect(typeof result.ascii).toBe('string');
+  });
+
+  test('Print renders a PGN to ASCII board', async ({ expect }) => {
+    await using harness = await createComposerTestApp({ plugins: [ChessPlugin()] });
+    const { ascii } = await harness.invoke(Print, { pgn: '1. e4 e5' });
+    expect(ascii).toContain('a  b  c  d  e  f  g  h');
+  });
+});

--- a/packages/plugins/plugin-chess/src/ChessPlugin.test.ts
+++ b/packages/plugins/plugin-chess/src/ChessPlugin.test.ts
@@ -4,8 +4,9 @@
 
 import { describe, test } from 'vitest';
 
-import { Capabilities } from '@dxos/app-framework';
+import { ActivationEvents, Capabilities } from '@dxos/app-framework';
 import { createTestApp } from '@dxos/app-framework/testing';
+import { AppActivationEvents, AppCapabilities } from '@dxos/app-toolkit';
 import { createComposerTestApp } from '@dxos/plugin-testing/harness';
 
 import { ChessPlugin } from './ChessPlugin';
@@ -16,6 +17,37 @@ describe('ChessPlugin', () => {
     await using harness = await createTestApp({ plugins: [ChessPlugin()] });
     const surfaces = harness.getAll(Capabilities.ReactSurface).flat();
     expect(surfaces.length).toBeGreaterThan(0);
+  });
+
+  test('fires activation events explicitly with autoStart: false', async ({ expect }) => {
+    await using harness = await createTestApp({ plugins: [ChessPlugin()], autoStart: false });
+
+    // No modules have activated yet; schema/surface capabilities are absent.
+    expect(harness.getAll(AppCapabilities.Schema)).toHaveLength(0);
+    expect(harness.getAll(Capabilities.ReactSurface)).toHaveLength(0);
+
+    // Fire SetupSchema — the schema module activates and contributes the Chess.Game type.
+    await harness.fire(AppActivationEvents.SetupSchema);
+    const schemas = harness.getAll(AppCapabilities.Schema).flat();
+    expect(schemas.length).toBeGreaterThan(0);
+
+    // ReactSurface is gated on a different event; still absent.
+    expect(harness.getAll(Capabilities.ReactSurface)).toHaveLength(0);
+
+    // Fire SetupReactSurface; the surface module contributes.
+    await harness.fire(ActivationEvents.SetupReactSurface);
+    expect(harness.getAll(Capabilities.ReactSurface).flat().length).toBeGreaterThan(0);
+  });
+
+  test('waitForEvent resolves once the event has been fired', async ({ expect }) => {
+    await using harness = await createTestApp({ plugins: [ChessPlugin()], autoStart: false });
+
+    // Fire and wait concurrently — waitForEvent resolves regardless of ordering.
+    await Promise.all([
+      harness.fire(AppActivationEvents.SetupTranslations),
+      harness.waitForEvent(AppActivationEvents.SetupTranslations),
+    ]);
+    expect(harness.getAll(AppCapabilities.Translations).flat().length).toBeGreaterThan(0);
   });
 
   test('invokes the Print operation via the invoker capability', async ({ expect }) => {

--- a/packages/plugins/plugin-chess/tsconfig.json
+++ b/packages/plugins/plugin-chess/tsconfig.json
@@ -105,6 +105,9 @@
       "path": "../plugin-space"
     },
     {
+      "path": "../plugin-testing"
+    },
+    {
       "path": "../plugin-theme"
     }
   ]

--- a/packages/plugins/plugin-sample/moon.yml
+++ b/packages/plugins/plugin-sample/moon.yml
@@ -2,6 +2,7 @@ layer: library
 language: typescript
 tags:
   - ts-build
+  - ts-test
 tasks:
   compile:
     args:

--- a/packages/plugins/plugin-sample/package.json
+++ b/packages/plugins/plugin-sample/package.json
@@ -87,6 +87,7 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@dxos/plugin-testing": "workspace:*",
     "@dxos/plugin-theme": "workspace:*",
     "@dxos/ui-theme": "workspace:*",
     "@types/react": "catalog:",

--- a/packages/plugins/plugin-sample/src/SamplePlugin.test.ts
+++ b/packages/plugins/plugin-sample/src/SamplePlugin.test.ts
@@ -1,0 +1,36 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { createComposerTestApp } from '@dxos/plugin-testing/harness';
+
+import { SamplePlugin } from './cli/plugin';
+import { SampleOperation } from './operations';
+import { SampleItem } from './types';
+
+describe('SamplePlugin', () => {
+  test('CreateSampleItem returns a SampleItem object', async ({ expect }) => {
+    await using harness = await createComposerTestApp({ plugins: [SamplePlugin()] });
+    const { object } = await harness.invoke(SampleOperation.CreateSampleItem, { name: 'hello' });
+    expect(object.name).toBe('hello');
+    expect(object.status).toBe('active');
+  });
+
+  test('Randomize mutates the SampleItem fields in place', async ({ expect }) => {
+    await using harness = await createComposerTestApp({ plugins: [SamplePlugin()] });
+    const item = SampleItem.make({ name: 'before' });
+    await harness.invoke(SampleOperation.Randomize, { item });
+    expect(item.name).not.toBe('before');
+    expect(item.description).toEqual(expect.any(String));
+    expect(['active', 'archived', 'draft']).toContain(item.status);
+  });
+
+  test('UpdateStatus sets the status field', async ({ expect }) => {
+    await using harness = await createComposerTestApp({ plugins: [SamplePlugin()] });
+    const item = SampleItem.make({ name: 'task', status: 'active' });
+    await harness.invoke(SampleOperation.UpdateStatus, { item, status: 'archived' });
+    expect(item.status).toBe('archived');
+  });
+});

--- a/packages/plugins/plugin-sample/tsconfig.json
+++ b/packages/plugins/plugin-sample/tsconfig.json
@@ -75,6 +75,9 @@
       "path": "../plugin-status-bar"
     },
     {
+      "path": "../plugin-testing"
+    },
+    {
       "path": "../plugin-theme"
     }
   ]

--- a/packages/plugins/plugin-testing/moon.yml
+++ b/packages/plugins/plugin-testing/moon.yml
@@ -7,3 +7,4 @@ tasks:
   compile:
     args:
       - '--entryPoint=src/index.ts'
+      - '--entryPoint=src/harness.ts'

--- a/packages/plugins/plugin-testing/package.json
+++ b/packages/plugins/plugin-testing/package.json
@@ -24,6 +24,12 @@
       "source": "./src/index.ts",
       "types": "./dist/types/src/index.d.ts",
       "browser": "./dist/lib/browser/index.mjs"
+    },
+    "./harness": {
+      "source": "./src/harness.ts",
+      "types": "./dist/types/src/harness.d.ts",
+      "browser": "./dist/lib/browser/harness.mjs",
+      "node": "./dist/lib/node-esm/harness.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/plugins/plugin-testing/src/harness.ts
+++ b/packages/plugins/plugin-testing/src/harness.ts
@@ -1,0 +1,52 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { OperationPlugin, type Plugin, RuntimePlugin } from '@dxos/app-framework';
+import { createTestApp, type TestAppOptions, type TestHarness } from '@dxos/app-framework/testing';
+import { AttentionPlugin } from '@dxos/plugin-attention';
+import { GraphPlugin } from '@dxos/plugin-graph';
+import { SettingsPlugin } from '@dxos/plugin-settings';
+
+export type ComposerTestAppOptions = Omit<TestAppOptions, 'plugins'> & {
+  /** Plugins to register in addition to the Composer core plugins. */
+  plugins?: Plugin.Plugin[];
+  /**
+   * Whether to include `ThemePlugin` in the core plugin set.
+   * Defaults to `false` — `ThemePlugin` requires a browser DOM and breaks Node-only tests.
+   * Set to `true` (with jsdom/happy-dom) when rendering React surfaces.
+   */
+  theme?: boolean;
+};
+
+/**
+ * Headless core plugins for the test harness — the subset of `corePlugins()`
+ * that can be activated without a browser DOM.
+ */
+const headlessCorePlugins = (): Plugin.Plugin[] => [
+  AttentionPlugin(),
+  GraphPlugin(),
+  OperationPlugin(),
+  RuntimePlugin(),
+  SettingsPlugin(),
+];
+
+/**
+ * Creates a TestHarness pre-loaded with the Composer core plugins
+ * (Attention, Graph, Operation, Runtime, Settings, optionally Theme).
+ *
+ * For a ClientPlugin-backed harness, pass `ClientPlugin({ ... })` via `plugins`.
+ */
+export const createComposerTestApp = async (opts: ComposerTestAppOptions = {}): Promise<TestHarness> => {
+  const { plugins = [], theme = false, ...rest } = opts;
+  const core = headlessCorePlugins();
+  if (theme) {
+    const { ThemePlugin } = await import('@dxos/plugin-theme');
+    const { defaultTx } = await import('@dxos/ui-theme');
+    core.push(ThemePlugin({ tx: defaultTx }));
+  }
+  return createTestApp({
+    ...rest,
+    plugins: [...core, ...plugins],
+  });
+};

--- a/packages/plugins/plugin-testing/src/index.ts
+++ b/packages/plugins/plugin-testing/src/index.ts
@@ -3,6 +3,7 @@
 //
 
 export * from './core';
+export * from './harness';
 export * from './meta';
 
 export * from './StorybookPlugin';

--- a/packages/sdk/app-framework/moon.yml
+++ b/packages/sdk/app-framework/moon.yml
@@ -20,6 +20,7 @@ tasks:
       - '--entryPoint=src/common/activation-events.ts'
       - '--entryPoint=src/ui/index.ts'
       - '--entryPoint=src/testing/index.ts'
+      - '--entryPoint=src/testing/react.tsx'
       - '--entryPoint=src/core/url-loader.ts'
     deps:
       - compile-plugin

--- a/packages/sdk/app-framework/package.json
+++ b/packages/sdk/app-framework/package.json
@@ -77,6 +77,12 @@
       "node": "./dist/lib/node-esm/testing/index.mjs",
       "types": "./dist/types/src/testing/index.d.ts"
     },
+    "./testing/react": {
+      "source": "./src/testing/react.tsx",
+      "browser": "./dist/lib/browser/testing/react.mjs",
+      "node": "./dist/lib/node-esm/testing/react.mjs",
+      "types": "./dist/types/src/testing/react.d.ts"
+    },
     "./ui": {
       "source": "./src/ui/index.ts",
       "browser": "./dist/lib/browser/ui/index.mjs",
@@ -117,6 +123,9 @@
       "testing": [
         "dist/types/src/testing/index.d.ts"
       ],
+      "testing/react": [
+        "dist/types/src/testing/react.d.ts"
+      ],
       "ui": [
         "dist/types/src/ui/index.d.ts"
       ]
@@ -152,6 +161,7 @@
     "@effect-atom/atom-react": "catalog:",
     "@effect/platform": "catalog:",
     "@effect/vitest": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/react": "catalog:",
     "effect": "catalog:",
     "react": "catalog:",
@@ -162,9 +172,15 @@
   "peerDependencies": {
     "@effect-atom/atom-react": "catalog:",
     "@effect/platform": "catalog:",
+    "@testing-library/react": "catalog:",
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "@testing-library/react": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sdk/app-framework/package.json
+++ b/packages/sdk/app-framework/package.json
@@ -77,7 +77,7 @@
       "node": "./dist/lib/node-esm/testing/index.mjs",
       "types": "./dist/types/src/testing/index.d.ts"
     },
-    "./testing/react": {
+    "./testing-react": {
       "source": "./src/testing/react.tsx",
       "browser": "./dist/lib/browser/testing/react.mjs",
       "node": "./dist/lib/node-esm/testing/react.mjs",
@@ -123,7 +123,7 @@
       "testing": [
         "dist/types/src/testing/index.d.ts"
       ],
-      "testing/react": [
+      "testing-react": [
         "dist/types/src/testing/react.d.ts"
       ],
       "ui": [
@@ -176,11 +176,6 @@
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
-  },
-  "peerDependenciesMeta": {
-    "@testing-library/react": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sdk/app-framework/src/testing/harness.ts
+++ b/packages/sdk/app-framework/src/testing/harness.ts
@@ -1,0 +1,229 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Registry } from '@effect-atom/atom-react';
+import * as Duration from 'effect/Duration';
+import * as Effect from 'effect/Effect';
+import * as PubSub from 'effect/PubSub';
+import * as Queue from 'effect/Queue';
+
+import { runAndForwardErrors } from '@dxos/effect';
+import { invariant } from '@dxos/invariant';
+import { type Operation } from '@dxos/operation';
+
+import { ActivationEvents, Capabilities } from '../common';
+import {
+  ActivationEvent,
+  type Capability,
+  type CapabilityManager,
+  type Plugin,
+  PluginManager,
+} from '../core';
+
+export type TestAppOptions = {
+  /** Plugins to register. */
+  plugins: Plugin.Plugin[];
+  /** Plugin ids that are always enabled. Defaults to all provided plugin ids. */
+  core?: string[];
+  /** Plugin ids that are enabled by default in addition to core. */
+  enabled?: string[];
+  /** Additional activation events fired alongside SetupReactSurface. */
+  setupEvents?: ActivationEvent.ActivationEvent[];
+  /**
+   * Whether to automatically fire SetupReactSurface + Startup during setup.
+   * Defaults to true.
+   */
+  autoStart?: boolean;
+  /**
+   * Whether to register the PluginManager + AtomRegistry framework capabilities.
+   * Defaults to true.
+   */
+  registerFrameworkCapabilities?: boolean;
+};
+
+/**
+ * A running plugin manager plus helpers for driving it in tests.
+ */
+export interface TestHarness {
+  readonly manager: PluginManager.PluginManager;
+  readonly capabilities: CapabilityManager.CapabilityManager;
+  readonly registry: Registry.Registry;
+
+  /** Activate the given event. Equivalent to `manager.activate(event)`. */
+  fire(event: ActivationEvent.ActivationEvent | string): Promise<boolean>;
+  /** Re-activate all modules that were activated by the given event. */
+  reset(event: ActivationEvent.ActivationEvent | string): Promise<boolean>;
+
+  /** Returns the first contributed capability for the given interface. Throws if none are present. */
+  get<T>(iface: Capability.InterfaceDef<T>): T;
+  /** Returns all contributed capabilities for the given interface. */
+  getAll<T>(iface: Capability.InterfaceDef<T>): T[];
+  /** Waits until at least one capability is contributed for the given interface. */
+  waitForCapability<T>(iface: Capability.InterfaceDef<T>, opts?: { timeout?: number }): Promise<T>;
+  /** Waits until the given activation event has completed. */
+  waitForEvent(event: ActivationEvent.ActivationEvent | string, opts?: { timeout?: number }): Promise<void>;
+
+  /** Invokes an operation through the `Capabilities.OperationInvoker` capability. */
+  invoke<I, O>(op: Operation.Definition<I, O>, ...args: void extends I ? [input?: I] : [input: I]): Promise<O>;
+
+  enable(id: string): Promise<boolean>;
+  disable(id: string): Promise<boolean>;
+
+  /** Shuts down the underlying plugin manager. */
+  dispose(): Promise<void>;
+
+  /** Async-disposable support so tests can use `await using harness = ...`. */
+  [Symbol.asyncDispose](): Promise<void>;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+/**
+ * Creates a TestHarness with the same bootstrap sequence that `useApp` performs,
+ * minus the React provider tree.
+ *
+ * For Node-only tests, this is enough to fire activation events, read
+ * capabilities, and invoke operations.
+ *
+ * For React tests, pass the returned harness to `render` or `renderSurface`
+ * from `@dxos/app-framework/testing/react`.
+ */
+export const createTestApp = async (opts: TestAppOptions): Promise<TestHarness> => {
+  const {
+    plugins,
+    core = plugins.map((plugin) => plugin.meta.id),
+    enabled,
+    setupEvents = [],
+    autoStart = true,
+    registerFrameworkCapabilities = true,
+  } = opts;
+
+  const pluginLoader = (id: string) =>
+    Effect.sync(() => {
+      const plugin = plugins.find((plugin) => plugin.meta.id === id);
+      invariant(plugin, `Plugin not found: ${id}`);
+      return plugin;
+    });
+
+  const manager = PluginManager.make({ pluginLoader, plugins, core, enabled });
+
+  if (registerFrameworkCapabilities) {
+    manager.capabilities.contribute({
+      interface: Capabilities.PluginManager,
+      implementation: manager,
+      module: 'org.dxos.app-framework.plugin-manager',
+    });
+    manager.capabilities.contribute({
+      interface: Capabilities.AtomRegistry,
+      implementation: manager.registry,
+      module: 'org.dxos.app-framework.atom-registry',
+    });
+  }
+
+  if (autoStart) {
+    await runAndForwardErrors(
+      Effect.all([
+        ...setupEvents.map((event) => manager.activate(event)),
+        manager.activate(ActivationEvents.SetupReactSurface),
+        manager.activate(ActivationEvents.Startup),
+      ]),
+    );
+  }
+
+  return new TestHarnessImpl(manager);
+};
+
+class TestHarnessImpl implements TestHarness {
+  constructor(readonly manager: PluginManager.PluginManager) {}
+
+  get capabilities(): CapabilityManager.CapabilityManager {
+    return this.manager.capabilities;
+  }
+
+  get registry(): Registry.Registry {
+    return this.manager.registry;
+  }
+
+  fire(event: ActivationEvent.ActivationEvent | string): Promise<boolean> {
+    return runAndForwardErrors(this.manager.activate(event));
+  }
+
+  reset(event: ActivationEvent.ActivationEvent | string): Promise<boolean> {
+    return runAndForwardErrors(this.manager.reset(event));
+  }
+
+  get<T>(iface: Capability.InterfaceDef<T>): T {
+    return this.manager.capabilities.get(iface);
+  }
+
+  getAll<T>(iface: Capability.InterfaceDef<T>): T[] {
+    return this.manager.capabilities.getAll(iface);
+  }
+
+  waitForCapability<T>(iface: Capability.InterfaceDef<T>, opts?: { timeout?: number }): Promise<T> {
+    const timeout = opts?.timeout ?? DEFAULT_TIMEOUT_MS;
+    return runAndForwardErrors(
+      this.manager.capabilities.waitFor(iface).pipe(
+        Effect.timeoutFail({
+          duration: Duration.millis(timeout),
+          onTimeout: () => timeoutError(iface.identifier),
+        }),
+      ),
+    );
+  }
+
+  waitForEvent(event: ActivationEvent.ActivationEvent | string, opts?: { timeout?: number }): Promise<void> {
+    const key = typeof event === 'string' ? event : ActivationEvent.eventKey(event);
+    const timeout = opts?.timeout ?? DEFAULT_TIMEOUT_MS;
+
+    if (this.manager.getEventsFired().includes(key)) {
+      return Promise.resolve();
+    }
+
+    const program = Effect.gen(this, function* () {
+      const queue = yield* PubSub.subscribe(this.manager.activation);
+      while (true) {
+        const message = yield* Queue.take(queue);
+        if (message.event === key && message.state === 'activated') {
+          return;
+        }
+      }
+    }).pipe(
+      Effect.scoped,
+      Effect.timeoutFail({
+        duration: Duration.millis(timeout),
+        onTimeout: () => timeoutError(key),
+      }),
+    );
+
+    return runAndForwardErrors(program);
+  }
+
+  async invoke<I, O>(op: Operation.Definition<I, O>, ...args: [input?: I]): Promise<O> {
+    const invoker = await this.waitForCapability(Capabilities.OperationInvoker);
+    const result = await invoker.invokePromise(op as any, ...(args as [any]));
+    if (result.error) {
+      throw result.error;
+    }
+    return result.data as O;
+  }
+
+  enable(id: string): Promise<boolean> {
+    return runAndForwardErrors(this.manager.enable(id));
+  }
+
+  disable(id: string): Promise<boolean> {
+    return runAndForwardErrors(this.manager.disable(id));
+  }
+
+  async dispose(): Promise<void> {
+    await runAndForwardErrors(this.manager.shutdown());
+  }
+
+  [Symbol.asyncDispose](): Promise<void> {
+    return this.dispose();
+  }
+}
+
+const timeoutError = (id: string) => new Error(`Timed out waiting for ${id}`);

--- a/packages/sdk/app-framework/src/testing/harness.ts
+++ b/packages/sdk/app-framework/src/testing/harness.ts
@@ -81,7 +81,7 @@ const DEFAULT_TIMEOUT_MS = 5_000;
  * capabilities, and invoke operations.
  *
  * For React tests, pass the returned harness to `render` or `renderSurface`
- * from `@dxos/app-framework/testing/react`.
+ * from `@dxos/app-framework/testing-react`.
  */
 export const createTestApp = async (opts: TestAppOptions): Promise<TestHarness> => {
   const {

--- a/packages/sdk/app-framework/src/testing/harness.ts
+++ b/packages/sdk/app-framework/src/testing/harness.ts
@@ -13,13 +13,7 @@ import { invariant } from '@dxos/invariant';
 import { type Operation } from '@dxos/operation';
 
 import { ActivationEvents, Capabilities } from '../common';
-import {
-  ActivationEvent,
-  type Capability,
-  type CapabilityManager,
-  type Plugin,
-  PluginManager,
-} from '../core';
+import { ActivationEvent, type Capability, type CapabilityManager, type Plugin, PluginManager } from '../core';
 
 export type TestAppOptions = {
   /** Plugins to register. */
@@ -122,13 +116,18 @@ export const createTestApp = async (opts: TestAppOptions): Promise<TestHarness> 
   }
 
   if (autoStart) {
-    await runAndForwardErrors(
-      Effect.all([
-        ...setupEvents.map((event) => manager.activate(event)),
-        manager.activate(ActivationEvents.SetupReactSurface),
-        manager.activate(ActivationEvents.Startup),
-      ]),
-    );
+    try {
+      await runAndForwardErrors(
+        Effect.all([
+          ...setupEvents.map((event) => manager.activate(event)),
+          manager.activate(ActivationEvents.SetupReactSurface),
+          manager.activate(ActivationEvents.Startup),
+        ]),
+      );
+    } catch (err) {
+      await runAndForwardErrors(manager.shutdown()).catch(() => undefined);
+      throw err;
+    }
   }
 
   return new TestHarnessImpl(manager);
@@ -177,12 +176,13 @@ class TestHarnessImpl implements TestHarness {
     const key = typeof event === 'string' ? event : ActivationEvent.eventKey(event);
     const timeout = opts?.timeout ?? DEFAULT_TIMEOUT_MS;
 
-    if (this.manager.getEventsFired().includes(key)) {
-      return Promise.resolve();
-    }
-
     const program = Effect.gen(this, function* () {
       const queue = yield* PubSub.subscribe(this.manager.activation);
+      // Re-check after subscribing to avoid a race where the event fires
+      // between the caller invoking this and the subscription being installed.
+      if (this.manager.getEventsFired().includes(key)) {
+        return;
+      }
       while (true) {
         const message = yield* Queue.take(queue);
         if (message.event === key && message.state === 'activated') {

--- a/packages/sdk/app-framework/src/testing/index.ts
+++ b/packages/sdk/app-framework/src/testing/index.ts
@@ -2,5 +2,6 @@
 // Copyright 2025 DXOS.org
 //
 
+export * from './harness';
 export * from './service';
 export * from './withPluginManager';

--- a/packages/sdk/app-framework/src/testing/react.test.tsx
+++ b/packages/sdk/app-framework/src/testing/react.test.tsx
@@ -1,0 +1,48 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import React from 'react';
+import { describe, test } from 'vitest';
+
+import { ActivationEvents, Capabilities } from '../common';
+import { Capability, Plugin } from '../core';
+import { Surface } from '../ui';
+import { createTestApp } from './harness';
+import { render, renderSurface } from './react';
+
+const testMeta = { id: 'org.dxos.plugin.test.react-harness', name: 'ReactHarnessTest' };
+
+const TestPlugin = Plugin.define(testMeta).pipe(
+  Plugin.addModule({
+    id: 'surfaces',
+    activatesOn: ActivationEvents.SetupReactSurface,
+    activate: () =>
+      Effect.succeed(
+        Capability.contributes(Capabilities.ReactSurface, [
+          Surface.create<{ message: string }>({
+            id: 'greeting',
+            role: 'greeting',
+            component: ({ data }) => <span data-testid='greeting'>hello {data.message}</span>,
+          }),
+        ]),
+      ),
+  }),
+  Plugin.make,
+);
+
+describe('testing/react', () => {
+  test('render wraps ui in the harness provider tree', async ({ expect }) => {
+    await using harness = await createTestApp({ plugins: [TestPlugin()] });
+    const view = render(harness, <span data-testid='hello'>world</span>);
+    expect(view.getByTestId('hello').textContent).toBe('world');
+  });
+
+  test('renderSurface mounts a surface registered by a plugin', async ({ expect }) => {
+    await using harness = await createTestApp({ plugins: [TestPlugin()] });
+    const view = renderSurface(harness, { role: 'greeting', data: { message: 'plugins' } });
+    const node = await view.findByTestId('greeting');
+    expect(node.textContent).toBe('hello plugins');
+  });
+});

--- a/packages/sdk/app-framework/src/testing/react.tsx
+++ b/packages/sdk/app-framework/src/testing/react.tsx
@@ -1,0 +1,107 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { RegistryContext } from '@effect-atom/atom-react';
+import { render as rtlRender, type RenderOptions, type RenderResult } from '@testing-library/react';
+import React, { type FC, Fragment, type PropsWithChildren, type ReactNode } from 'react';
+
+import { ContextProtocolProvider } from '@dxos/web-context-react';
+
+import { Capabilities } from '../common';
+import { PluginManagerContext } from '../context';
+import { topologicalSort } from '../helpers';
+import { PluginManagerProvider } from '../ui/components/PluginManager/PluginManagerProvider';
+import { SurfaceComponent } from '../ui/components/Surface/SurfaceComponent';
+import { type TestHarness } from './harness';
+
+export type HarnessRenderOptions = RenderOptions & {
+  /** Additional providers to wrap around the harness tree (applied innermost first). */
+  reactContexts?: FC<PropsWithChildren>[];
+};
+
+/**
+ * Renders `ui` wrapped in the same provider tree as `useApp` plus every contributed
+ * `Capabilities.ReactContext`.
+ */
+export const render = (harness: TestHarness, ui: ReactNode, options?: HarnessRenderOptions): RenderResult => {
+  const { reactContexts = [], ...rest } = options ?? {};
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <HarnessProviders harness={harness} extra={reactContexts}>
+      {children}
+    </HarnessProviders>
+  );
+  return rtlRender(<>{ui}</>, { wrapper: Wrapper, ...rest });
+};
+
+export type RenderSurfaceProps = {
+  role: string;
+  data?: unknown;
+  limit?: number;
+  fallback?: FC<{ error: Error; data?: any }>;
+  placeholder?: ReactNode;
+};
+
+/**
+ * Renders a `Surface` with the given role/data inside the harness provider tree.
+ */
+export const renderSurface = (
+  harness: TestHarness,
+  props: RenderSurfaceProps,
+  options?: HarnessRenderOptions,
+): RenderResult => {
+  const { role, data, limit, fallback, placeholder } = props;
+  return render(
+    harness,
+    <SurfaceComponent role={role} data={data as any} limit={limit} fallback={fallback} placeholder={placeholder} />,
+    options,
+  );
+};
+
+type HarnessProvidersProps = PropsWithChildren<{
+  harness: TestHarness;
+  extra: FC<PropsWithChildren>[];
+}>;
+
+const HarnessProviders = ({ harness, extra, children }: HarnessProvidersProps) => {
+  const contributed = harness.getAll(Capabilities.ReactContext);
+  const ContributedContext = composeContexts(contributed);
+  const ExtraContext = composeExtra(extra);
+  return (
+    <PluginManagerProvider value={harness.manager}>
+      <ContextProtocolProvider value={harness.manager} context={PluginManagerContext}>
+        <RegistryContext.Provider value={harness.registry}>
+          <ContributedContext>
+            <ExtraContext>{children}</ExtraContext>
+          </ContributedContext>
+        </RegistryContext.Provider>
+      </ContextProtocolProvider>
+    </PluginManagerProvider>
+  );
+};
+
+const composeContexts = (contexts: Capabilities.ReactContext[]): FC<PropsWithChildren> => {
+  if (contexts.length === 0) {
+    return Passthrough;
+  }
+  return topologicalSort(contexts)
+    .map(({ context }) => context)
+    .reduce((Acc, Next) => ({ children }: PropsWithChildren) => (
+      <Acc>
+        <Next>{children}</Next>
+      </Acc>
+    ));
+};
+
+const composeExtra = (contexts: FC<PropsWithChildren>[]): FC<PropsWithChildren> => {
+  if (contexts.length === 0) {
+    return Passthrough;
+  }
+  return contexts.reduce((Acc, Next) => ({ children }: PropsWithChildren) => (
+    <Acc>
+      <Next>{children}</Next>
+    </Acc>
+  ));
+};
+
+const Passthrough: FC<PropsWithChildren> = ({ children }) => <Fragment>{children}</Fragment>;

--- a/packages/sdk/app-framework/src/testing/react.tsx
+++ b/packages/sdk/app-framework/src/testing/react.tsx
@@ -15,7 +15,7 @@ import { PluginManagerProvider } from '../ui/components/PluginManager/PluginMana
 import { SurfaceComponent } from '../ui/components/Surface/SurfaceComponent';
 import { type TestHarness } from './harness';
 
-export type HarnessRenderOptions = RenderOptions & {
+export type HarnessRenderOptions = Omit<RenderOptions, 'wrapper'> & {
   /** Additional providers to wrap around the harness tree (applied innermost first). */
   reactContexts?: FC<PropsWithChildren>[];
 };
@@ -31,7 +31,7 @@ export const render = (harness: TestHarness, ui: ReactNode, options?: HarnessRen
       {children}
     </HarnessProviders>
   );
-  return rtlRender(<>{ui}</>, { wrapper: Wrapper, ...rest });
+  return rtlRender(<>{ui}</>, { ...rest, wrapper: Wrapper });
 };
 
 export type RenderSurfaceProps = {
@@ -93,15 +93,21 @@ const composeContexts = (contexts: Capabilities.ReactContext[]): FC<PropsWithChi
     ));
 };
 
+// Composes in innermost-first order: the first context in the array wraps
+// `children` directly; subsequent contexts wrap the accumulator.
 const composeExtra = (contexts: FC<PropsWithChildren>[]): FC<PropsWithChildren> => {
   if (contexts.length === 0) {
     return Passthrough;
   }
-  return contexts.reduce((Acc, Next) => ({ children }: PropsWithChildren) => (
-    <Acc>
-      <Next>{children}</Next>
-    </Acc>
-  ));
+  return contexts.reduce<FC<PropsWithChildren>>(
+    (Acc, Next) =>
+      ({ children }: PropsWithChildren) => (
+        <Next>
+          <Acc>{children}</Acc>
+        </Next>
+      ),
+    Passthrough,
+  );
 };
 
 const Passthrough: FC<PropsWithChildren> = ({ children }) => <Fragment>{children}</Fragment>;

--- a/plans/composer-plugin-test-harness/PLAN.md
+++ b/plans/composer-plugin-test-harness/PLAN.md
@@ -13,7 +13,7 @@
 Two-layer split mirrors the existing boundary between `@dxos/app-framework` (low-level) and `@dxos/plugin-testing` (Composer-flavored presets):
 
 - `@dxos/app-framework/testing` — primitive `TestHarness` + `createTestApp()`. No plugin dependencies. Reuses the existing subpath (already exported by `packages/sdk/app-framework/package.json`). Lives alongside `fromPlugins`/`withPluginManager` in `packages/sdk/app-framework/src/testing/`.
-- `@dxos/app-framework/testing/react` — optional subpath for the RTL-dependent helpers (`render`, `renderSurface`), so Node-only tests don't pull in `react-dom`/RTL.
+- `@dxos/app-framework/testing-react` — optional subpath for the RTL-dependent helpers (`render`, `renderSurface`), so Node-only tests don't pull in `react-dom`/RTL.
 - `@dxos/plugin-testing` — already exports `corePlugins()`. Adds a `createComposerTestApp()` preset that layers `corePlugins()` + optional `ClientPlugin` on top of `createTestApp()`.
 
 ## API Surface
@@ -66,7 +66,7 @@ Internals (small file, no new deps):
 - `waitForCapability` = subscribe to `manager.capabilities` via the existing `Atom`/`Registry` mechanism or `manager.activation` PubSub with a promise race against a timeout.
 - `dispose` = `runAndForwardErrors(manager.shutdown())` — already exercised by `packages/sdk/app-framework/src/ui/hooks/useApp.test.tsx`.
 
-### React helpers: `@dxos/app-framework/testing/react`
+### React helpers: `@dxos/app-framework/testing-react`
 
 ```ts
 import type { RenderOptions, RenderResult } from '@testing-library/react';
@@ -146,7 +146,7 @@ await harness.dispose();
 ### Surface render (jsdom)
 
 ```ts
-import { render, renderSurface } from '@dxos/app-framework/testing/react';
+import { render, renderSurface } from '@dxos/app-framework/testing-react';
 const harness = await createComposerTestApp({ client: true, plugins: [ChessPlugin()] });
 const view = renderSurface(harness, { role: 'article', data: { subject: chessGame } });
 expect(await view.findByRole('grid')).toBeInTheDocument();

--- a/plans/composer-plugin-test-harness/PLAN.md
+++ b/plans/composer-plugin-test-harness/PLAN.md
@@ -30,7 +30,7 @@ export type TestAppOptions = {
   registerFrameworkCapabilities?: boolean;          // default true (PluginManager + AtomRegistry)
 };
 
-export interface TestHarness {
+export interface TestHarness extends AsyncDisposable {
   readonly manager: PluginManager.PluginManager;
   readonly capabilities: CapabilityManager.CapabilityManager;
   readonly registry: Registry.Registry;
@@ -49,6 +49,7 @@ export interface TestHarness {
   disable(id: string): Promise<boolean>;
 
   dispose(): Promise<void>;                            // manager.shutdown()
+  [Symbol.asyncDispose](): Promise<void>;              // alias for dispose(); enables `await using`
 }
 
 export const createTestApp = (opts: TestAppOptions): Promise<TestHarness>;
@@ -75,11 +76,7 @@ export type HarnessRenderOptions = RenderOptions & {
   reactContexts?: Array<FC<PropsWithChildren>>;
 };
 
-export const render: (
-  harness: TestHarness,
-  ui: React.ReactNode,
-  options?: HarnessRenderOptions,
-) => RenderResult;
+export const render: (harness: TestHarness, ui: React.ReactNode, options?: HarnessRenderOptions) => RenderResult;
 
 /** Shorthand for <SurfaceComponent role=... data=... /> inside the harness. */
 export const renderSurface: (
@@ -95,14 +92,18 @@ Wraps UI in the same provider tree as `useApp`: `PluginManagerProvider`, `Contex
 
 ```ts
 export type ComposerTestAppOptions = Omit<TestAppOptions, 'plugins'> & {
-  plugins?: Plugin.Plugin[];        // added on top of core
-  client?: boolean | ClientPluginOptions;   // adds ClientPlugin, with optional config
+  plugins?: Plugin.Plugin[]; // added on top of core
+  client?: boolean | ClientPluginOptions; // adds ClientPlugin, with optional config
 };
 
 export const createComposerTestApp = (opts?: ComposerTestAppOptions) =>
   createTestApp({
     ...opts,
-    plugins: [...corePlugins(), ...(opts?.client ? [ClientPlugin(opts.client === true ? {} : opts.client)] : []), ...(opts?.plugins ?? [])],
+    plugins: [
+      ...corePlugins(),
+      ...(opts?.client ? [ClientPlugin(opts.client === true ? {} : opts.client)] : []),
+      ...(opts?.plugins ?? []),
+    ],
   });
 ```
 

--- a/plans/composer-plugin-test-harness/PLAN.md
+++ b/plans/composer-plugin-test-harness/PLAN.md
@@ -1,0 +1,165 @@
+# Composer Plugin Test Harness
+
+## Goals
+
+- Spin up a realistic `PluginManager` in tests with the same bootstrapping that `useApp` performs.
+- Fire activation events, assert on capabilities, invoke operations, and render surfaces.
+- Work equally well in pure Node (no DOM) for logic/operation tests and in jsdom / happy-dom / vitest-browser for React tests.
+- Plain `async/await` API so it composes cleanly with `@testing-library/react` and regular `it`/`describe`.
+- Zero new heavy deps; reuse everything already in `@dxos/app-framework`.
+
+## Package Placement
+
+Two-layer split mirrors the existing boundary between `@dxos/app-framework` (low-level) and `@dxos/plugin-testing` (Composer-flavored presets):
+
+- `@dxos/app-framework/testing` — primitive `TestHarness` + `createTestApp()`. No plugin dependencies. Reuses the existing subpath (already exported by `packages/sdk/app-framework/package.json`). Lives alongside `fromPlugins`/`withPluginManager` in `packages/sdk/app-framework/src/testing/`.
+- `@dxos/app-framework/testing/react` — optional subpath for the RTL-dependent helpers (`render`, `renderSurface`), so Node-only tests don't pull in `react-dom`/RTL.
+- `@dxos/plugin-testing` — already exports `corePlugins()`. Adds a `createComposerTestApp()` preset that layers `corePlugins()` + optional `ClientPlugin` on top of `createTestApp()`.
+
+## API Surface
+
+### Low-level: `@dxos/app-framework/testing`
+
+```ts
+export type TestAppOptions = {
+  plugins: Plugin.Plugin[];
+  core?: string[];                                  // defaults to all plugin ids
+  enabled?: string[];
+  setupEvents?: ActivationEvent.ActivationEvent[];  // fired alongside SetupReactSurface
+  autoStart?: boolean;                              // default true; fires SetupReactSurface + Startup
+  registerFrameworkCapabilities?: boolean;          // default true (PluginManager + AtomRegistry)
+};
+
+export interface TestHarness {
+  readonly manager: PluginManager.PluginManager;
+  readonly capabilities: CapabilityManager.CapabilityManager;
+  readonly registry: Registry.Registry;
+
+  fire(event: ActivationEvent.ActivationEvent | string): Promise<boolean>;
+  reset(event: ActivationEvent.ActivationEvent | string): Promise<boolean>;
+
+  get<T>(iface: Capability.InterfaceDef<T>): T;        // single, throws if missing
+  getAll<T>(iface: Capability.InterfaceDef<T>): T[];
+  waitForCapability<T>(iface: Capability.InterfaceDef<T>, opts?: { timeout?: number }): Promise<T>;
+  waitForEvent(key: string, opts?: { timeout?: number }): Promise<void>;
+
+  invoke<I, O>(op: Operation.Operation<I, O>, input: I): Promise<O>;   // via Capabilities.OperationInvoker
+
+  enable(id: string): Promise<boolean>;
+  disable(id: string): Promise<boolean>;
+
+  dispose(): Promise<void>;                            // manager.shutdown()
+}
+
+export const createTestApp = (opts: TestAppOptions): Promise<TestHarness>;
+
+/** Vitest lifecycle helper: auto-dispose after each test. */
+export const useTestApp = (opts: TestAppOptions | (() => TestAppOptions)): () => TestHarness;
+```
+
+Internals (small file, no new deps):
+
+- Build the manager the same way as `useApp` does — see `packages/sdk/app-framework/src/ui/hooks/useApp.tsx` lines around `manager.capabilities.contribute({ interface: Capabilities.PluginManager, ... })` and the `SetupReactSurface` + `Startup` activation block.
+- `fire` = `runPromise(manager.activate(event))`.
+- `invoke` = `runPromise(invoker.invoke(op, input))` after `waitForCapability(Capabilities.OperationInvoker)`.
+- `waitForCapability` = subscribe to `manager.capabilities` via the existing `Atom`/`Registry` mechanism or `manager.activation` PubSub with a promise race against a timeout.
+- `dispose` = `runAndForwardErrors(manager.shutdown())` — already exercised by `packages/sdk/app-framework/src/ui/hooks/useApp.test.tsx`.
+
+### React helpers: `@dxos/app-framework/testing/react`
+
+```ts
+import type { RenderOptions, RenderResult } from '@testing-library/react';
+
+export type HarnessRenderOptions = RenderOptions & {
+  /** Inject additional ReactContext capabilities under test. */
+  reactContexts?: Array<FC<PropsWithChildren>>;
+};
+
+export const render: (
+  harness: TestHarness,
+  ui: React.ReactNode,
+  options?: HarnessRenderOptions,
+) => RenderResult;
+
+/** Shorthand for <SurfaceComponent role=... data=... /> inside the harness. */
+export const renderSurface: (
+  harness: TestHarness,
+  props: { role: string; data?: unknown; limit?: number; fallback?: ReactNode },
+  options?: HarnessRenderOptions,
+) => RenderResult;
+```
+
+Wraps UI in the same provider tree as `useApp`: `PluginManagerProvider`, `ContextProtocolProvider`, `RegistryContext.Provider`, and every contributed `Capabilities.ReactContext` (so a translation-dependent component works without bespoke setup).
+
+### Composer preset: `@dxos/plugin-testing`
+
+```ts
+export type ComposerTestAppOptions = Omit<TestAppOptions, 'plugins'> & {
+  plugins?: Plugin.Plugin[];        // added on top of core
+  client?: boolean | ClientPluginOptions;   // adds ClientPlugin, with optional config
+};
+
+export const createComposerTestApp = (opts?: ComposerTestAppOptions) =>
+  createTestApp({
+    ...opts,
+    plugins: [...corePlugins(), ...(opts?.client ? [ClientPlugin(opts.client === true ? {} : opts.client)] : []), ...(opts?.plugins ?? [])],
+  });
+```
+
+Builds on the existing `packages/plugins/plugin-testing/src/core.ts` `corePlugins()` list (Attention, Graph, Operation, Runtime, Settings, Theme). `StorybookPlugin` stays where it is; tests that want its layout can opt into it explicitly.
+
+## Test Environments
+
+- **Node-only tests** (operation firehose, capability wiring, activation ordering): no vitest environment needed; the harness works in bare Node.
+- **React tests**: the test file's `vitest.config.ts` keeps setting `environment: 'jsdom'` or `'happy-dom'` (existing convention — see `packages/plugins/plugin-sheet/vitest.config.ts`, `packages/plugins/plugin-transcription/vitest.config.ts`). The React subpath is a peer dep on `@testing-library/react`.
+- **Browser-vitest**: works unchanged — same `render` helper from RTL; nothing in the harness depends on Node APIs.
+
+## Example Tests
+
+### Activation firehose (Node-only)
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createTestApp } from '@dxos/app-framework/testing';
+import { ActivationEvents } from '@dxos/app-framework';
+import { MyPlugin } from '../MyPlugin';
+
+describe('MyPlugin activation', () => {
+  it('contributes its surface on SetupReactSurface', async () => {
+    await using harness = await createTestApp({ plugins: [MyPlugin()] });
+    const surfaces = harness.getAll(Capabilities.ReactSurface);
+    expect(surfaces.some((s) => s.id === 'my.article')).toBe(true);
+  });
+});
+```
+
+### Operation invocation
+
+```ts
+const harness = await createComposerTestApp({ plugins: [ChessPlugin()] });
+const result = await harness.invoke(MakeMove, { game, move: 'e4' });
+expect(result.pgn).toContain('e4');
+await harness.dispose();
+```
+
+### Surface render (jsdom)
+
+```ts
+import { render, renderSurface } from '@dxos/app-framework/testing/react';
+const harness = await createComposerTestApp({ client: true, plugins: [ChessPlugin()] });
+const view = renderSurface(harness, { role: 'article', data: { subject: chessGame } });
+expect(await view.findByRole('grid')).toBeInTheDocument();
+```
+
+## Relationship to Existing Helpers
+
+- `fromPlugins()` (Effect Layer) in `packages/sdk/app-framework/src/testing/service.ts` stays as-is for Effect/CLI tests. The async `TestHarness` is implemented in the same file family and can be trivially wrapped in a `Layer` later if needed.
+- `withPluginManager` decorator in `packages/sdk/app-framework/src/testing/withPluginManager.tsx` is Storybook-specific and remains untouched. The new harness shares the same `setupPluginManager` shape so stories and tests activate plugins identically.
+
+## What We Can Build With It
+
+- **Plugin smoke tests**: every plugin has a `MyPlugin.test.ts` that boots it, activates known events, and asserts each advertised capability is contributed.
+- **Operation integration tests**: invoke operations end-to-end through the real invoker + `OperationHandler` capabilities (no hand-rolled handler mocks).
+- **Surface regression tests**: mount a plugin's article/card surfaces against an in-memory ECHO space (via `ClientPlugin`) and assert DOM output.
+- **Activation-ordering tests**: fire multi-event sequences and assert `manager.getActive()` / `manager.getEventsFired()` match expectations (cheap, Node-only).
+- **Multi-plugin scenarios**: boot two plugins together and verify cross-plugin graph/operation interactions, e.g. `plugin-space` + `plugin-chess`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7940,6 +7940,9 @@ importers:
         specifier: 3.20.0
         version: 3.20.0
     devDependencies:
+      '@dxos/plugin-testing':
+        specifier: workspace:*
+        version: link:../plugin-testing
       '@dxos/plugin-theme':
         specifier: workspace:*
         version: link:../plugin-theme
@@ -11638,6 +11641,9 @@ importers:
         specifier: 3.20.0
         version: 3.20.0
     devDependencies:
+      '@dxos/plugin-testing':
+        specifier: workspace:*
+        version: link:../plugin-testing
       '@dxos/plugin-theme':
         specifier: workspace:*
         version: link:../plugin-theme
@@ -14857,6 +14863,9 @@ importers:
       '@effect/vitest':
         specifier: 'catalog:'
         version: 0.27.0(effect@3.20.0)(vitest@3.2.4)
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react':
         specifier: ~19.2.7
         version: 19.2.7

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -101,6 +101,7 @@
       "@dxos/plugin-wnfs/types": ["packages/plugins/plugin-wnfs/src/types/index.ts"],
       "@dxos/app-framework": ["packages/sdk/app-framework/src/index.ts"],
       "@dxos/app-framework/testing": ["packages/sdk/app-framework/src/testing/index.ts"],
+      "@dxos/app-framework/testing-react": ["packages/sdk/app-framework/src/testing/react.tsx"],
       "@dxos/app-framework/worker": ["packages/sdk/app-framework/src/worker.ts"],
       "@dxos/app-graph": ["packages/sdk/app-graph/src/index.ts"],
       "@dxos/migrations": ["packages/sdk/migrations/src/index.ts"],


### PR DESCRIPTION
## Summary

- Adds a spec for a Composer plugin test harness under [plans/composer-plugin-test-harness/PLAN.md](plans/composer-plugin-test-harness/PLAN.md).
- Proposes a two-layer split: primitive `createTestApp()` / `TestHarness` in `@dxos/app-framework/testing` and a Composer preset `createComposerTestApp()` in `@dxos/plugin-testing`.
- Separate `@dxos/app-framework/testing/react` subpath for RTL-dependent helpers so Node-only tests stay DOM-free.

Posting this for team iteration before implementation — please leave comments on the spec.

## Test plan

- [ ] N/A — docs only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a plan describing a proposed Composer Plugin Test Harness and testing workflows.
* **New Features**
  * Introduced a test harness, a Composer test app constructor, and React test helpers to simplify plugin and UI testing.
  * Added public testing entrypoints/exports for browser and Node consumers.
* **Tests**
  * Added Vitest suites validating chess and sample plugins using the new harness and operation invoker.
* **Chores**
  * Updated project configs and build tasks to include and publish the new testing artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->