### PR TITLE
fix(composer-app): remove environment condition from welcome gate

### DIFF
--- a/packages/apps/composer-app/src/plugins/welcome/onboarding-manager.ts
+++ b/packages/apps/composer-app/src/plugins/welcome/onboarding-manager.ts
@@ -65,8 +65,7 @@ export class OnboardingManager {
     this._invokePromise = invokePromise;
     this._client = client;
     this._hubUrl = hubUrl;
-    // TODO(wittjosiah): Remove the environment condition. The gate should show whenever a hub URL is configured.
-    this._skipAuth = ['main', 'labs'].includes(client.config.values.runtime?.app?.env?.DX_ENVIRONMENT) || !this._hubUrl;
+    this._skipAuth = !this._hubUrl;
     this._token = token;
     this._tokenType = tokenType;
     this._recoverIdentity = recoverIdentity || false;


### PR DESCRIPTION
## Summary

- Removes the `DX_ENVIRONMENT` check from `OnboardingManager` that was preventing the welcome gate from showing in `main`/`labs` environments
- The gate now shows whenever `DX_HUB_URL` is configured, as intended by the existing TODO comment

## Test Plan

- [ ] Verify welcome gate appears when `DX_HUB_URL` is set, regardless of `DX_ENVIRONMENT`
- [ ] Verify welcome gate is skipped when `DX_HUB_URL` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authentication handling in the onboarding flow to depend solely on hub URL configuration, removing additional environment-based conditions from the authentication bypass logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->