### PR TITLE
refactor(echo): rename Queue -> Feed across SDK and consumers

### DIFF
--- a/packages/core/functions-testing/src/testing/util.ts
+++ b/packages/core/functions-testing/src/testing/util.ts
@@ -86,9 +86,7 @@ export const observeInvocations = async (space: Space, maxCount: number | null) 
     try {
       const traceFeed = space.properties.invocationTraceFeed?.target;
       const traceQueueDxn = traceFeed ? Feed.getQueueDxn(traceFeed) : undefined;
-      const invocations = traceQueueDxn
-        ? ((await space.queues.get(traceQueueDxn).queryObjects()) ?? [])
-        : [];
+      const invocations = traceQueueDxn ? ((await space.queues.get(traceQueueDxn).queryObjects()) ?? []) : [];
 
       for (const invocation of invocations) {
         if (Obj.instanceOf(InvocationTraceStartEvent, invocation)) {

--- a/packages/core/functions-testing/src/testing/util.ts
+++ b/packages/core/functions-testing/src/testing/util.ts
@@ -8,7 +8,7 @@ import { sleep } from '@dxos/async';
 import { Client, type Config } from '@dxos/client';
 import { type Space } from '@dxos/client/echo';
 import { Context } from '@dxos/context';
-import { Filter, Obj, Query } from '@dxos/echo';
+import { Feed, Obj } from '@dxos/echo';
 import { Trigger } from '@dxos/functions';
 import { InvocationTraceEndEvent, InvocationTraceStartEvent } from '@dxos/functions-runtime';
 import { FunctionsServiceClient } from '@dxos/functions-runtime/edge';
@@ -84,8 +84,11 @@ export const observeInvocations = async (space: Space, maxCount: number | null) 
   let count = 0;
   while (true) {
     try {
-      const invocations =
-        (await space.properties.invocationTraceQueue?.target!.query(Query.select(Filter.everything())).run()) ?? [];
+      const traceFeed = space.properties.invocationTraceFeed?.target;
+      const traceQueueDxn = traceFeed ? Feed.getQueueDxn(traceFeed) : undefined;
+      const invocations = traceQueueDxn
+        ? ((await space.queues.get(traceQueueDxn).queryObjects()) ?? [])
+        : [];
 
       for (const invocation of invocations) {
         if (Obj.instanceOf(InvocationTraceStartEvent, invocation)) {

--- a/packages/devtools/cli/src/commands/function/trace/trace.tsx
+++ b/packages/devtools/cli/src/commands/function/trace/trace.tsx
@@ -15,7 +15,7 @@ import * as Option from 'effect/Option';
 import { CommandConfig, Common, spaceIdWithDefault, spaceLayer, withTypes } from '@dxos/cli-util';
 import { ClientService, ConfigService } from '@dxos/client';
 import { SpaceProperties } from '@dxos/client-protocol';
-import { Database, Filter, type Key } from '@dxos/echo';
+import { Database, Feed, Filter, type Key } from '@dxos/echo';
 import { QueueService } from '@dxos/functions';
 import { InvocationTraceEndEvent, InvocationTraceStartEvent, TriggerDispatcher } from '@dxos/functions-runtime';
 import { invariant } from '@dxos/invariant';
@@ -51,12 +51,13 @@ export const trace = Command.make(
       const objects = yield* Database.runQuery(Filter.type(SpaceProperties));
       const properties = objects.at(0);
       invariant(properties, 'SpaceProperties not found');
-      const queueDxn = properties.invocationTraceQueue?.dxn;
+      const traceFeed = properties.invocationTraceFeed?.target;
+      const queueDxn = traceFeed ? Feed.getQueueDxn(traceFeed) : undefined;
 
       if (!queueDxn) {
-        log.info('trace: no invocationTraceQueue found in space properties', { spaceId: db.spaceId });
+        log.info('trace: no invocationTraceFeed found in space properties', { spaceId: db.spaceId });
       } else {
-        log.info('trace: found invocationTraceQueue', { spaceId: db.spaceId, queueDxn });
+        log.info('trace: found invocationTraceFeed', { spaceId: db.spaceId, queueDxn });
       }
 
       // Start trigger runtime in background if enabled

--- a/packages/plugins/plugin-assistant/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-assistant/src/capabilities/react-surface.tsx
@@ -13,7 +13,7 @@ import { Blueprint, Prompt } from '@dxos/blueprints';
 import { getSpace } from '@dxos/client/echo';
 import { Sequence } from '@dxos/conductor';
 import { InvocationTraceContainer } from '@dxos/devtools';
-import { Obj } from '@dxos/echo';
+import { Feed, Obj } from '@dxos/echo';
 import { Panel } from '@dxos/react-ui';
 
 import { AssistantSettings } from '#components';
@@ -91,7 +91,8 @@ export default Capability.makeModule(() =>
           data.subject === 'invocations',
         component: ({ data, role }) => {
           const space = getSpace(data.companionTo);
-          const queueDxn = space?.properties.invocationTraceQueue?.dxn;
+          const feed = space?.properties.invocationTraceFeed?.target;
+          const queueDxn = feed ? Feed.getQueueDxn(feed) : undefined;
           // TODO(wittjosiah): Support invocation filtering for prompts.
           const target = Obj.instanceOf(Prompt.Prompt, data.companionTo) ? undefined : data.companionTo;
           return (

--- a/packages/plugins/plugin-assistant/src/queue-logger.ts
+++ b/packages/plugins/plugin-assistant/src/queue-logger.ts
@@ -32,7 +32,8 @@ export class QueueLogger implements SequenceLogger {
       invariant(queueDxn, 'invocationTraceFeed has no queue DXN');
     } else {
       const feed = space.db.add(Feed.make({ namespace: 'trace' }));
-      queueDxn = Feed.getQueueDxn(feed)!;
+      queueDxn = Feed.getQueueDxn(feed) ?? undefined;
+      invariant(queueDxn, 'New invocationTraceFeed has no queue DXN');
       Obj.change(this._space.properties, (obj) => {
         obj.invocationTraceFeed = Ref.make(feed);
       });

--- a/packages/plugins/plugin-assistant/src/queue-logger.ts
+++ b/packages/plugins/plugin-assistant/src/queue-logger.ts
@@ -24,11 +24,13 @@ export class QueueLogger implements SequenceLogger {
     const existingFeedRef = this._space.properties.invocationTraceFeed;
     let queueDxn: DXN | undefined;
 
-    if (existingFeedRef?.target) {
+    if (existingFeedRef) {
+      // A feed reference exists; resolve its queue DXN. If the target isn't loaded yet,
+      // fail loudly rather than silently creating a new feed and orphaning existing traces.
+      invariant(existingFeedRef.target, 'invocationTraceFeed reference is not yet loaded');
       queueDxn = Feed.getQueueDxn(existingFeedRef.target) ?? undefined;
-    }
-
-    if (!queueDxn) {
+      invariant(queueDxn, 'invocationTraceFeed has no queue DXN');
+    } else {
       const feed = space.db.add(Feed.make({ namespace: 'trace' }));
       queueDxn = Feed.getQueueDxn(feed)!;
       Obj.change(this._space.properties, (obj) => {

--- a/packages/plugins/plugin-assistant/src/queue-logger.ts
+++ b/packages/plugins/plugin-assistant/src/queue-logger.ts
@@ -4,7 +4,7 @@
 
 import { type Queue, Ref, type Space, getSpace } from '@dxos/client/echo';
 import { type Sequence, type SequenceEvent, type SequenceLogger } from '@dxos/conductor';
-import { DXN, Key, Obj } from '@dxos/echo';
+import { DXN, Feed, Obj } from '@dxos/echo';
 import { InvocationTraceEndEvent, InvocationTraceEventType, InvocationTraceStartEvent } from '@dxos/functions-runtime';
 import { TraceEvent } from '@dxos/functions-runtime';
 import { InvocationOutcome } from '@dxos/functions-runtime';
@@ -20,15 +20,23 @@ export class QueueLogger implements SequenceLogger {
     const space = getSpace(sequence);
     invariant(space, 'Space not found');
     this._space = space;
-    let dxn = this._space.properties.invocationTraceQueue?.dxn;
-    if (!dxn) {
-      dxn = DXN.fromQueue(QueueSubspaceTags.TRACE, this._space.id, Key.ObjectId.random());
-      const newDxn = dxn;
+
+    const existingFeedRef = this._space.properties.invocationTraceFeed;
+    let queueDxn: DXN | undefined;
+
+    if (existingFeedRef?.target) {
+      queueDxn = Feed.getQueueDxn(existingFeedRef.target) ?? undefined;
+    }
+
+    if (!queueDxn) {
+      const feed = space.db.add(Feed.make({ namespace: 'trace' }));
+      queueDxn = Feed.getQueueDxn(feed)!;
       Obj.change(this._space.properties, (obj) => {
-        obj.invocationTraceQueue = Ref.fromDXN(newDxn);
+        obj.invocationTraceFeed = Ref.make(feed);
       });
     }
-    this._invocationTraceQueue = this._space.queues.get(dxn);
+
+    this._invocationTraceQueue = this._space.queues.get(queueDxn);
   }
 
   log(event: SequenceEvent) {

--- a/packages/plugins/plugin-debug/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-debug/src/capabilities/react-surface.tsx
@@ -35,7 +35,7 @@ import {
   TestingPanel,
   WorkflowPanel,
 } from '@dxos/devtools';
-import { Obj } from '@dxos/echo';
+import { Feed, Obj } from '@dxos/echo';
 import { Collection } from '@dxos/echo';
 import { type LogBuffer } from '@dxos/log';
 import { log } from '@dxos/log';
@@ -349,7 +349,8 @@ export default Capability.makeModule(
         filter: AppSurface.literal(AppSurface.Article, Devtools.Edge.Traces),
         component: () => {
           const space = useCurrentSpace();
-          const queueDxn = space?.properties.invocationTraceQueue?.dxn;
+          const feed = space?.properties.invocationTraceFeed?.target;
+          const queueDxn = feed ? Feed.getQueueDxn(feed) : undefined;
           return <InvocationTraceContainer db={space?.db} queueDxn={queueDxn} detailAxis='block' />;
         },
       }),

--- a/packages/plugins/plugin-inbox/src/operations/classify-email.ts
+++ b/packages/plugins/plugin-inbox/src/operations/classify-email.ts
@@ -10,8 +10,7 @@ import * as Option from 'effect/Option';
 
 import { AiService, ConsolePrinter, ToolExecutionService, ToolResolverService } from '@dxos/ai';
 import { AiRequest, GenerationObserver } from '@dxos/assistant';
-import { Database, Filter, Obj, Relation, Tag, Type } from '@dxos/echo';
-import { ContextQueueService, QueueService } from '@dxos/functions';
+import { Database, Feed, Filter, Obj, Ref, Relation, Tag, Type } from '@dxos/echo';
 import * as Trace from '@dxos/functions/Trace';
 import { DXN } from '@dxos/keys';
 import { log } from '@dxos/log';
@@ -85,11 +84,11 @@ const handler: Operation.WithHandler<typeof ClassifyEmail> = ClassifyEmail.pipe(
         log.info('queueDXNInfo', queueDXNInfo);
 
         if (!queueDXNInfo) {
-          return yield* Effect.fail(new Error('Message is not in a queue'));
+          return yield* Effect.fail(new Error('Message is not in a feed'));
         }
 
-        const queueDXN = DXN.fromQueue(queueDXNInfo.subspaceTag, queueDXNInfo.spaceId, queueDXNInfo.queueId);
-        const queue = yield* QueueService.getQueue(queueDXN);
+        const feedDxn = DXN.fromSpaceAndObjectId(queueDXNInfo.spaceId, queueDXNInfo.queueId);
+        const feed = yield* Database.load(Ref.fromDXN(feedDxn));
 
         const relation = Relation.make(HasSubject.HasSubject, {
           [Relation.Source]: selectedTag,
@@ -100,7 +99,7 @@ const handler: Operation.WithHandler<typeof ClassifyEmail> = ClassifyEmail.pipe(
           completedAt: new Date().toISOString(),
         });
 
-        yield* QueueService.append(queue, [relation]).pipe(Effect.provide(ContextQueueService.layer(queue)));
+        yield* Feed.append(feed, [relation]);
         yield* Database.flush();
 
         return {
@@ -115,6 +114,7 @@ const handler: Operation.WithHandler<typeof ClassifyEmail> = ClassifyEmail.pipe(
           ToolExecutionService.layerEmpty,
           Trace.writerLayerNoop,
           Database.notAvailable,
+          Feed.notAvailable,
           Layer.succeed(Operation.Service, {
             invoke: () => Effect.die('Not available.'),
             schedule: () => Effect.die('Not available.'),

--- a/packages/plugins/plugin-inbox/src/operations/definitions.ts
+++ b/packages/plugins/plugin-inbox/src/operations/definitions.ts
@@ -8,7 +8,7 @@ import { AiService } from '@dxos/ai';
 import { Capability } from '@dxos/app-framework';
 import { SpaceSchema } from '@dxos/client/echo';
 import { Collection, Database, Feed, Obj, Ref } from '@dxos/echo';
-import { CredentialsService } from '@dxos/functions';
+import { CredentialsService, QueueService } from '@dxos/functions';
 import { Operation } from '@dxos/operation';
 import { Actor, Message } from '@dxos/types';
 
@@ -253,7 +253,7 @@ export const SummarizeMailbox = Operation.make({
       description: 'The summary of the mailbox.',
     }),
   }),
-  services: [Database.Service, Feed.FeedService, AiService.AiService],
+  services: [Database.Service, Feed.FeedService, AiService.AiService, QueueService],
 });
 
 export const ClassifyEmail = Operation.make({

--- a/packages/plugins/plugin-inbox/src/operations/definitions.ts
+++ b/packages/plugins/plugin-inbox/src/operations/definitions.ts
@@ -8,7 +8,7 @@ import { AiService } from '@dxos/ai';
 import { Capability } from '@dxos/app-framework';
 import { SpaceSchema } from '@dxos/client/echo';
 import { Collection, Database, Feed, Obj, Ref } from '@dxos/echo';
-import { CredentialsService, QueueService } from '@dxos/functions';
+import { CredentialsService } from '@dxos/functions';
 import { Operation } from '@dxos/operation';
 import { Actor, Message } from '@dxos/types';
 
@@ -253,7 +253,7 @@ export const SummarizeMailbox = Operation.make({
       description: 'The summary of the mailbox.',
     }),
   }),
-  services: [Database.Service, Feed.FeedService, AiService.AiService, QueueService],
+  services: [Database.Service, Feed.FeedService, AiService.AiService],
 });
 
 export const ClassifyEmail = Operation.make({
@@ -279,7 +279,7 @@ export const ClassifyEmail = Operation.make({
     }),
     Schema.Void,
   ),
-  services: [AiService.AiService, Database.Service, QueueService],
+  services: [AiService.AiService, Database.Service, Feed.FeedService],
 });
 
 export const ExtractContact = Operation.make({

--- a/packages/plugins/plugin-inbox/src/operations/google/gmail/sync-e2e.test.ts
+++ b/packages/plugins/plugin-inbox/src/operations/google/gmail/sync-e2e.test.ts
@@ -218,9 +218,7 @@ export const observeInvocations = async (space: Space, maxCount: number | null) 
     try {
       const traceFeed = space.properties.invocationTraceFeed?.target;
       const traceQueueDxn = traceFeed ? Feed.getQueueDxn(traceFeed) : undefined;
-      const invocations = traceQueueDxn
-        ? ((await space.queues.get(traceQueueDxn).queryObjects()) ?? [])
-        : [];
+      const invocations = traceQueueDxn ? ((await space.queues.get(traceQueueDxn).queryObjects()) ?? []) : [];
 
       for (const invocation of invocations) {
         if (Obj.instanceOf(InvocationTraceStartEvent, invocation)) {

--- a/packages/plugins/plugin-inbox/src/operations/google/gmail/sync-e2e.test.ts
+++ b/packages/plugins/plugin-inbox/src/operations/google/gmail/sync-e2e.test.ts
@@ -11,7 +11,7 @@ import { Client } from '@dxos/client';
 import { type Space } from '@dxos/client/echo';
 import { configPreset } from '@dxos/config';
 import { Context } from '@dxos/context';
-import { Feed, Filter, Obj, Query, Ref } from '@dxos/echo';
+import { Feed, Obj, Query, Ref } from '@dxos/echo';
 import { Trigger } from '@dxos/functions';
 import { InvocationTraceEndEvent, InvocationTraceStartEvent } from '@dxos/functions-runtime';
 import { FunctionsServiceClient } from '@dxos/functions-runtime/edge';
@@ -216,8 +216,11 @@ export const observeInvocations = async (space: Space, maxCount: number | null) 
   let count = 0;
   while (true) {
     try {
-      const invocations =
-        (await space.properties.invocationTraceQueue?.target!.query(Query.select(Filter.everything())).run()) ?? [];
+      const traceFeed = space.properties.invocationTraceFeed?.target;
+      const traceQueueDxn = traceFeed ? Feed.getQueueDxn(traceFeed) : undefined;
+      const invocations = traceQueueDxn
+        ? ((await space.queues.get(traceQueueDxn).queryObjects()) ?? [])
+        : [];
 
       for (const invocation of invocations) {
         if (Obj.instanceOf(InvocationTraceStartEvent, invocation)) {

--- a/packages/plugins/plugin-inbox/src/operations/summarize-mailbox.ts
+++ b/packages/plugins/plugin-inbox/src/operations/summarize-mailbox.ts
@@ -19,6 +19,7 @@ import {
   makeGraphWriterToolkit,
 } from '@dxos/assistant-toolkit';
 import { Database, Feed, Filter, Obj } from '@dxos/echo';
+import { QueueService } from '@dxos/functions';
 import * as Trace from '@dxos/functions/Trace';
 import { Operation, OperationRegistry } from '@dxos/operation';
 import { Message, Organization, Person, Pipeline } from '@dxos/types';
@@ -89,6 +90,7 @@ const handler: Operation.WithHandler<typeof SummarizeMailbox> = SummarizeMailbox
           ToolExecutionService.layerEmpty,
           Trace.writerLayerNoop,
           Database.notAvailable,
+          QueueService.notAvailable,
           Layer.succeed(Operation.Service, {
             invoke: () => Effect.die('Not available.'),
             schedule: () => Effect.die('Not available.'),

--- a/packages/plugins/plugin-meeting/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-meeting/src/capabilities/app-graph-builder.ts
@@ -7,7 +7,7 @@ import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
 import { AppCapabilities, AppNode } from '@dxos/app-toolkit';
-import { Obj, Type } from '@dxos/echo';
+import { Feed, Obj, Type } from '@dxos/echo';
 import { AtomObj } from '@dxos/echo-atom';
 import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
@@ -159,10 +159,13 @@ export default Capability.makeModule(
 
                 const callManager = yield* Capability.get(ThreadCapabilities.CallManager);
                 const transcript = yield* Effect.promise(() => meeting.transcript.load());
+                const transcriptFeed = yield* Effect.promise(() => transcript.feed.load());
+                const transcriptQueueDxn = Feed.getQueueDxn(transcriptFeed);
+                invariant(transcriptQueueDxn, 'Transcript feed has no queue DXN');
                 const transcriptionEnabled = !enabled;
                 callManager.setActivity(Type.getTypename(Meeting.Meeting)!, {
                   meetingId: Obj.getDXN(meeting).toString(),
-                  transcriptDxn: transcript.queue.dxn.toString(),
+                  transcriptDxn: transcriptQueueDxn.toString(),
                   transcriptionEnabled,
                 });
 

--- a/packages/plugins/plugin-meeting/src/containers/MeetingContainer/MeetingContainer.stories.tsx
+++ b/packages/plugins/plugin-meeting/src/containers/MeetingContainer/MeetingContainer.stories.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { Capability } from '@dxos/app-framework';
 import { withPluginManager } from '@dxos/app-framework/testing';
 import { AppCapabilities } from '@dxos/app-toolkit';
-import { Obj, Ref } from '@dxos/echo';
+import { Feed, Obj, Ref } from '@dxos/echo';
 import { ClientPlugin } from '@dxos/plugin-client';
 import { initializeIdentity } from '@dxos/plugin-client/testing';
 import { MarkdownPlugin } from '@dxos/plugin-markdown';
@@ -48,11 +48,12 @@ const meta = {
           onClientInitialized: ({ client }) =>
             Effect.gen(function* () {
               const { personalSpace } = yield* initializeIdentity(client);
+              const transcriptFeed = personalSpace.db.add(Feed.make());
               personalSpace.db.add(
                 Obj.make(Meeting.Meeting, {
                   created: new Date().toISOString(),
                   participants: [],
-                  transcript: Ref.make(Transcript.make(personalSpace.queues.create().dxn)),
+                  transcript: Ref.make(Transcript.make(Ref.make(transcriptFeed))),
                   notes: Ref.make(Text.make('Notes')),
                   summary: Ref.make(Text.make()),
                   thread: Ref.make(Thread.make()),

--- a/packages/plugins/plugin-script/src/blueprints/functions/definitions.ts
+++ b/packages/plugins/plugin-script/src/blueprints/functions/definitions.ts
@@ -5,8 +5,7 @@
 import * as Schema from 'effect/Schema';
 
 import { ClientService } from '@dxos/client';
-import { Database, Ref } from '@dxos/echo';
-import { QueueService } from '@dxos/functions';
+import { Database, Feed, Ref } from '@dxos/echo';
 import { Operation } from '@dxos/operation';
 import { trim } from '@dxos/util';
 
@@ -263,7 +262,7 @@ export const InspectInvocations = Operation.make({
       description: 'Total number of invocations found.',
     }),
   }),
-  services: [Database.Service, QueueService],
+  services: [Database.Service, Feed.FeedService],
 });
 
 const DeployedFunctionSchema = Schema.Struct({

--- a/packages/plugins/plugin-script/src/blueprints/functions/inspect-invocations.ts
+++ b/packages/plugins/plugin-script/src/blueprints/functions/inspect-invocations.ts
@@ -5,9 +5,9 @@
 import * as Effect from 'effect/Effect';
 
 import { SpaceProperties } from '@dxos/client-protocol';
-import { Database, Obj, Query } from '@dxos/echo';
-import { getUserFunctionIdInMetadata, QueueService } from '@dxos/functions';
-import { type InvocationTraceEvent, createInvocationSpans } from '@dxos/functions-runtime';
+import { Database, Feed, Filter, Obj, Query } from '@dxos/echo';
+import { getUserFunctionIdInMetadata } from '@dxos/functions';
+import { InvocationTraceEndEvent, InvocationTraceStartEvent, createInvocationSpans } from '@dxos/functions-runtime';
 import { Operation } from '@dxos/operation';
 
 import { InspectInvocations } from './definitions';
@@ -19,13 +19,14 @@ export default InspectInvocations.pipe(
       const maxResults = limit ?? 20;
 
       const [properties] = yield* Database.runQuery(Query.type(SpaceProperties));
-      if (!properties?.invocationTraceQueue?.target) {
+      if (!properties?.invocationTraceFeed) {
         return { invocations: [], total: 0 };
       }
 
-      const queue = yield* QueueService.getQueue<InvocationTraceEvent>(properties.invocationTraceQueue.target.dxn);
-      const events = yield* Effect.promise(() => queue.queryObjects());
-      const allSpans = createInvocationSpans(events);
+      const feed = yield* Database.load(properties.invocationTraceFeed);
+      const startEvents = yield* Feed.runQuery(feed, Filter.type(InvocationTraceStartEvent));
+      const endEvents = yield* Feed.runQuery(feed, Filter.type(InvocationTraceEndEvent));
+      const allSpans = createInvocationSpans([...startEvents, ...endEvents]);
 
       const functionId = getUserFunctionIdInMetadata(Obj.getMeta(loaded));
 

--- a/packages/plugins/plugin-script/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-script/src/capabilities/react-surface.tsx
@@ -9,6 +9,7 @@ import { Capabilities, Capability } from '@dxos/app-framework';
 import { Surface, useAtomCapability, useSettingsState } from '@dxos/app-framework/ui';
 import { AppSurface } from '@dxos/app-toolkit/ui';
 import { InvocationTraceContainer } from '@dxos/devtools';
+import { Feed } from '@dxos/echo';
 import { Script } from '@dxos/functions';
 import { useClient } from '@dxos/react-client';
 import { getSpace } from '@dxos/react-client/echo';
@@ -103,7 +104,8 @@ export default Capability.makeModule(() =>
         ),
         component: ({ data, role }) => {
           const space = getSpace(data.companionTo);
-          const queueDxn = space?.properties.invocationTraceQueue?.dxn;
+          const feed = space?.properties.invocationTraceFeed?.target;
+          const queueDxn = feed ? Feed.getQueueDxn(feed) : undefined;
           return (
             <Panel.Root role={role}>
               <Panel.Content>

--- a/packages/plugins/plugin-transcription/src/TranscriptionPlugin.tsx
+++ b/packages/plugins/plugin-transcription/src/TranscriptionPlugin.tsx
@@ -6,7 +6,7 @@ import * as Option from 'effect/Option';
 
 import { Plugin } from '@dxos/app-framework';
 import { AppActivationEvents, AppPlugin } from '@dxos/app-toolkit';
-import { Annotation, Obj } from '@dxos/echo';
+import { Annotation, Feed, Obj } from '@dxos/echo';
 import { getSpace } from '@dxos/react-client/echo';
 import { Message, Transcript } from '@dxos/types';
 
@@ -28,7 +28,9 @@ export const TranscriptionPlugin = Plugin.define(meta).pipe(
         getTextContent: async (transcript: Transcript.Transcript) => {
           const space = getSpace(transcript);
           const members = space?.members.get().map((member) => member.identity) ?? [];
-          const queue = space?.queues.get<Message.Message>(transcript.queue.dxn);
+          const feed = await transcript.feed.load();
+          const queueDxn = Feed.getQueueDxn(feed);
+          const queue = queueDxn ? space?.queues.get<Message.Message>(queueDxn) : undefined;
           await queue?.refresh();
           const content = queue?.objects
             .filter((message) => Obj.instanceOf(Message.Message, message))

--- a/packages/plugins/plugin-transcription/src/containers/TranscriptionContainer/TranscriptionContainer.tsx
+++ b/packages/plugins/plugin-transcription/src/containers/TranscriptionContainer/TranscriptionContainer.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 
 import { type AppSurface } from '@dxos/app-toolkit/ui';
-import { Obj } from '@dxos/echo';
+import { Feed, Obj } from '@dxos/echo';
 import { useMembers, useQueue } from '@dxos/react-client/echo';
 import { Panel } from '@dxos/react-ui';
 import { type Message, type Transcript } from '@dxos/types';
@@ -20,7 +20,9 @@ export type TranscriptionContainerProps = AppSurface.ObjectArticleProps<Transcri
 export const TranscriptionContainer = ({ role, subject: transcript, attendableId }: TranscriptionContainerProps) => {
   const db = Obj.getDatabase(transcript);
   const members = useMembers(db?.spaceId).map((member) => member.identity);
-  const queue = useQueue<Message.Message>(transcript.queue.dxn, { pollInterval: 1_000 });
+  const feed = transcript.feed.target;
+  const queueDxn = feed ? Feed.getQueueDxn(feed) : undefined;
+  const queue = useQueue<Message.Message>(queueDxn, { pollInterval: 1_000 });
   const model = useQueueModelAdapter(renderByline(members), queue);
 
   return (

--- a/packages/plugins/plugin-transcription/src/operations/create.ts
+++ b/packages/plugins/plugin-transcription/src/operations/create.ts
@@ -4,6 +4,7 @@
 
 import * as Effect from 'effect/Effect';
 
+import { Feed, Ref } from '@dxos/echo';
 import { Operation } from '@dxos/operation';
 import { Transcript } from '@dxos/types';
 
@@ -12,8 +13,9 @@ import { Create } from './definitions';
 const handler: Operation.WithHandler<typeof Create> = Create.pipe(
   Operation.withHandler(
     Effect.fn(function* ({ space }) {
+      const feed = space.db.add(Feed.make());
       return {
-        object: Transcript.make(space.queues.create().dxn),
+        object: Transcript.make(Ref.make(feed)),
       };
     }),
   ),

--- a/packages/plugins/plugin-transcription/src/operations/definitions.ts
+++ b/packages/plugins/plugin-transcription/src/operations/definitions.ts
@@ -6,8 +6,7 @@ import * as Schema from 'effect/Schema';
 
 import { AiService } from '@dxos/ai';
 import { SpaceSchema } from '@dxos/client/echo';
-import { Database, Ref } from '@dxos/echo';
-import { QueueService } from '@dxos/functions';
+import { Database, Feed, Ref } from '@dxos/echo';
 import { Operation } from '@dxos/operation';
 import { Message, Transcript } from '@dxos/types';
 
@@ -51,7 +50,7 @@ export const Open = Operation.make({
   output: Schema.Struct({
     content: Schema.String,
   }),
-  services: [Database.Service, QueueService],
+  services: [Database.Service, Feed.FeedService],
 });
 
 export const Summarize = Operation.make({

--- a/packages/plugins/plugin-transcription/src/operations/open.ts
+++ b/packages/plugins/plugin-transcription/src/operations/open.ts
@@ -4,8 +4,7 @@
 
 import * as Effect from 'effect/Effect';
 
-import { Database, Obj } from '@dxos/echo';
-import { QueueService } from '@dxos/functions';
+import { Database, Feed, Filter } from '@dxos/echo';
 import { Operation } from '@dxos/operation';
 import { Message } from '@dxos/types';
 
@@ -16,11 +15,9 @@ const handler: Operation.WithHandler<typeof Open> = Open.pipe(
   Operation.withHandler(
     Effect.fn(function* ({ transcript }) {
       const transcriptObj = yield* Database.load(transcript);
-      const { dxn } = yield* Effect.promise(() => transcriptObj.queue.load());
-      const queue = yield* QueueService.getQueue(dxn);
-      yield* Effect.promise(() => queue?.queryObjects());
-      const content = queue?.objects
-        .filter((message: unknown) => Obj.instanceOf(Message.Message, message))
+      const feed = yield* Database.load(transcriptObj.feed);
+      const messages = yield* Feed.runQuery(feed, Filter.type(Message.Message));
+      const content = messages
         .flatMap((message: Message.Message, index: number) => renderByline([])(message, index))
         .join('\n\n');
       return { content };

--- a/packages/sdk/client-protocol/src/echo.ts
+++ b/packages/sdk/client-protocol/src/echo.ts
@@ -37,7 +37,7 @@ export interface Echo extends MulticastObservable<Space[]>, Database.Queryable {
    * Creates a new space.
    */
   create(
-    props?: Pick<SpaceProperties, 'name' | 'hue' | 'icon' | 'invocationTraceQueue'>,
+    props?: Pick<SpaceProperties, 'name' | 'hue' | 'icon' | 'invocationTraceFeed'>,
     options?: { tags?: string[]; membershipPolicy?: MembershipPolicy },
   ): Promise<Space>;
 

--- a/packages/sdk/client-protocol/src/types/SpaceProperties.ts
+++ b/packages/sdk/client-protocol/src/types/SpaceProperties.ts
@@ -4,8 +4,7 @@
 
 import * as Schema from 'effect/Schema';
 
-import { Annotation, Ref, Type } from '@dxos/echo';
-import { Queue } from '@dxos/echo-db';
+import { Annotation, Feed, Ref, Type } from '@dxos/echo';
 
 export const SpacePropertiesSchema = Schema.Struct(
   {
@@ -17,7 +16,7 @@ export const SpacePropertiesSchema = Schema.Struct(
     // TODO(burdon): Change to mode (no booleans?)
     // TODO(wittjosiah): Make optional with default value.
     edgeReplication: Schema.optional(Schema.Boolean),
-    invocationTraceQueue: Schema.optional(Ref.Ref(Queue)),
+    invocationTraceFeed: Schema.optional(Ref.Ref(Feed.Feed)),
 
     //
     // User properties.

--- a/packages/sdk/types/src/types/Transcript.ts
+++ b/packages/sdk/types/src/types/Transcript.ts
@@ -6,8 +6,7 @@
 
 import * as Schema from 'effect/Schema';
 
-import { Annotation, type DXN, Obj, Ref, Type } from '@dxos/echo';
-import { Queue } from '@dxos/echo-db';
+import { Annotation, Feed, Obj, Ref, Type } from '@dxos/echo';
 import { SystemTypeAnnotation } from '@dxos/echo/internal';
 
 /**
@@ -20,9 +19,9 @@ export const Transcript = Schema.Struct({
   ended: Schema.optional(Schema.String),
 
   /**
-   * Queue containing TranscriptBlock objects.
+   * Feed containing TranscriptBlock objects.
    */
-  queue: Ref.Ref(Queue),
+  feed: Ref.Ref(Feed.Feed),
 }).pipe(
   Type.object({
     typename: 'org.dxos.type.transcript',
@@ -49,4 +48,4 @@ const TranscriptHeader = Schema.Struct({
 
 export type TranscriptHeader = Schema.Schema.Type<typeof TranscriptHeader>;
 
-export const make = (queueDxn: DXN): Transcript => Obj.make(Transcript, { queue: Ref.fromDXN(queueDxn) });
+export const make = (feed: Ref.Ref<Feed.Feed>): Transcript => Obj.make(Transcript, { feed });

--- a/packages/stories/stories-assistant/src/components/ExecutionGraphModule.tsx
+++ b/packages/stories/stories-assistant/src/components/ExecutionGraphModule.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { Obj } from '@dxos/echo';
+import { Feed, Obj } from '@dxos/echo';
 import { InvocationTraceStartEvent } from '@dxos/functions-runtime';
 import { type Queue, useQueue } from '@dxos/react-client/echo';
 import { Timeline, useExecutionGraph } from '@dxos/react-ui-components';
@@ -12,9 +12,10 @@ import { Timeline, useExecutionGraph } from '@dxos/react-ui-components';
 import { type ComponentProps } from './types';
 
 export const ExecutionGraphModule = ({ space, traceQueue }: ComponentProps & { traceQueue?: Queue }) => {
+  const traceFeed = space.properties?.invocationTraceFeed?.target;
+  const traceQueueDxn = traceFeed ? Feed.getQueueDxn(traceFeed) : undefined;
   const invocations =
-    useQueue(space.properties?.invocationTraceQueue?.dxn)?.objects.filter(Obj.instanceOf(InvocationTraceStartEvent)) ??
-    [];
+    useQueue(traceQueueDxn)?.objects.filter(Obj.instanceOf(InvocationTraceStartEvent)) ?? [];
   // Use provided traceQueue, or fall back to the per-invocation trace queue from the most recent invocation.
   const queue = traceQueue ?? invocations?.at(-1)?.invocationTraceQueue?.target;
   const { branches, commits } = useExecutionGraph(queue);

--- a/packages/stories/stories-assistant/src/components/ExecutionGraphModule.tsx
+++ b/packages/stories/stories-assistant/src/components/ExecutionGraphModule.tsx
@@ -14,8 +14,7 @@ import { type ComponentProps } from './types';
 export const ExecutionGraphModule = ({ space, traceQueue }: ComponentProps & { traceQueue?: Queue }) => {
   const traceFeed = space.properties?.invocationTraceFeed?.target;
   const traceQueueDxn = traceFeed ? Feed.getQueueDxn(traceFeed) : undefined;
-  const invocations =
-    useQueue(traceQueueDxn)?.objects.filter(Obj.instanceOf(InvocationTraceStartEvent)) ?? [];
+  const invocations = useQueue(traceQueueDxn)?.objects.filter(Obj.instanceOf(InvocationTraceStartEvent)) ?? [];
   // Use provided traceQueue, or fall back to the per-invocation trace queue from the most recent invocation.
   const queue = traceQueue ?? invocations?.at(-1)?.invocationTraceQueue?.target;
   const { branches, commits } = useExecutionGraph(queue);

--- a/packages/stories/stories-assistant/src/components/InvocationsModule.tsx
+++ b/packages/stories/stories-assistant/src/components/InvocationsModule.tsx
@@ -5,11 +5,13 @@
 import React from 'react';
 
 import { InvocationTraceContainer } from '@dxos/devtools';
+import { Feed } from '@dxos/echo';
 
 import { type ComponentProps } from './types';
 
 export const InvocationsModule = ({ space }: ComponentProps) => {
-  const queueDxn = space?.properties.invocationTraceQueue?.dxn;
+  const feed = space?.properties.invocationTraceFeed?.target;
+  const queueDxn = feed ? Feed.getQueueDxn(feed) : undefined;
   return (
     <div className='flex h-full min-h-[20rem] items-center justify-center'>
       <InvocationTraceContainer db={space?.db} queueDxn={queueDxn} detailAxis='block' />

--- a/packages/stories/stories-assistant/src/stories/Chat.stories.tsx
+++ b/packages/stories/stories-assistant/src/stories/Chat.stories.tsx
@@ -590,10 +590,12 @@ export const WithTranscription: Story = {
     config: config.remote,
     types: [Transcript.Transcript],
     onInit: async ({ space }) => {
-      const queue = space.queues.create();
+      const feed = space.db.add(Feed.make());
+      const queueDxn = Feed.getQueueDxn(feed);
+      invariant(queueDxn);
       const messages = createTestTranscription();
-      await queue.append(messages);
-      space.db.add(Transcript.make(queue.dxn));
+      await space.queues.get(queueDxn).append(messages);
+      space.db.add(Transcript.make(Ref.make(feed)));
     },
     onChatCreated: async ({ space, binder }) => {
       const objects = await space.db.query(Filter.type(Transcript.Transcript)).run();
@@ -731,7 +733,7 @@ export const WithResearchQueue: Story = {
         Trigger.make({
           function: Ref.make(Operation.serialize(AgentPrompt)),
           enabled: true,
-          spec: Trigger.specQueue(researchInputQueue.queue.dxn.toString()),
+          spec: Trigger.specQueue(Feed.getQueueDxn(feed)!.toString()),
           input: {
             prompt: Ref.make(researchPrompt),
             input: '{{event.item}}',

--- a/packages/stories/stories-assistant/src/testing/schema.ts
+++ b/packages/stories/stories-assistant/src/testing/schema.ts
@@ -4,11 +4,10 @@
 
 import * as Schema from 'effect/Schema';
 
-import { Ref, Type } from '@dxos/echo';
-import { Queue } from '@dxos/echo-db';
+import { Feed, Ref, Type } from '@dxos/echo';
 
 export const ResearchInputQueue = Schema.Struct({
-  queue: Ref.Ref(Queue),
+  feed: Ref.Ref(Feed.Feed),
 }).pipe(
   Type.object({
     typename: 'org.dxos.type.researchInputQueue',


### PR DESCRIPTION
## Summary

- Rename `SpaceProperties.invocationTraceQueue: Ref.Ref(Queue)` to `invocationTraceFeed: Ref.Ref(Feed.Feed)` (imported from `@dxos/echo` instead of `Queue` from `@dxos/echo-db`) and update `Echo.create` prop pick accordingly.
- Rename `Transcript.queue` to `Transcript.feed` and change `Transcript.make()` to take a `Ref.Ref<Feed.Feed>` directly (instead of a DXN).
- Migrate all consumers: plugins (assistant, debug, inbox, meeting, script, transcription), devtools (CLI + InvocationTracePanel), functions-testing, stories-assistant, and related surfaces/containers. At consumer sites that still need the underlying queue DXN, we now derive it at the callsite via `Feed.getQueueDxn(feed)`.

The rename aligns the SDK type surface with the ECHO `Feed` abstraction (which is the intended storage primitive) and keeps the `Queue` runtime concept as an implementation detail obtained from a feed.

## Test plan

- [ ] \`moon run :build\` (full build)
- [ ] \`MOON_CONCURRENCY=4 moon run :test -- --no-file-parallelism\`
- [ ] Manual: verify transcription containers still render and record transcripts
- [ ] Manual: verify devtools InvocationTrace panel resolves the feed and lists invocations
- [ ] Manual: verify meeting → transcript activation still propagates transcript DXN to call manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Invocation tracing, logs, transcripts and related UI now use feed-backed storage instead of direct queue handles across CLI, plugins, SDK and stories.
  * Inbox classification, script inspection and transcription workflows switched to feeds for more consistent data access.
  * Space properties, transcript references and story fixtures updated to reference feeds; end-user behavior and workflows are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->