### PR TITLE
fix(app-framework): exclude playwright/testing subpaths from import map

### DIFF
--- a/packages/sdk/app-framework/src/vite-plugin/import-map-plugin.ts
+++ b/packages/sdk/app-framework/src/vite-plugin/import-map-plugin.ts
@@ -94,6 +94,15 @@ const importMapExcludedSubpaths: Readonly<Record<string, ReadonlySet<string>>> =
 };
 
 /**
+ * Subpaths common to many packages that should always be excluded from the import map.
+ * `./playwright` and `./testing` subpaths are e2e / unit test helpers — by convention they
+ * are not part of the runtime plugin surface and may transitively pull node-only packages
+ * (e.g. `@dxos/lit-grid/testing` imports `@playwright/test`) into the browser bundle via
+ * vite-plugin-pwa's module scan, which breaks the Composer production bundle.
+ */
+const GLOBALLY_EXCLUDED_SUBPATHS: ReadonlySet<string> = new Set(['playwright', 'testing']);
+
+/**
  * Reads a package's `exports` field and returns all JS subpath entrypoints as bare specifiers
  * (e.g. `@dxos/client`, `@dxos/client/echo`). Skips wildcard patterns, non-JS assets,
  * and excluded subpaths. Falls back to just the package name if exports is absent or simple.
@@ -124,7 +133,7 @@ const getPackageEntrypoints = (packageName: string, packageJsonPath: string): st
     }
 
     const subpath = key.slice(2);
-    if (excluded?.has(subpath)) {
+    if (excluded?.has(subpath) || GLOBALLY_EXCLUDED_SUBPATHS.has(subpath)) {
       return [];
     }
 


### PR DESCRIPTION
## Summary

- The Labs **Publish** workflow has been failing on every run for ~2 days (first failure after #11042 landed). `composer-app:bundle` dies with `[vite-plugin-pwa:build] playwright/lib/matchers/toEqual.js: Missing "./util/" specifier in "@dxos/node-std" package`.
- Adding `@dxos/lit-grid` to `DEFAULT_PACKAGES` caused `importMapPlugin` to enumerate all of lit-grid's subpath exports, including `./testing`, which imports `@playwright/test`. Playwright's node-only modules then leaked into the Composer browser bundle via vite-plugin-pwa's module scan, and the composer-app vite alias `util -> @dxos/node-std/util` rewrote playwright's `util/*` imports to a subpath `@dxos/node-std` does not export — breaking the bundle.
- Fix: globally exclude `./playwright` and `./testing` subpaths from import map enumeration. Both are test-only by convention (e2e harness and unit helpers) and are not part of the runtime plugin surface — same shape as the fix Josiah authored on `jdw/community-registry`.

## Test plan

- [x] `moon run app-framework:test` — 86/86 pass.
- [x] `moon run composer-app:bundle` — succeeds locally (failed on `main`).
- [x] `moon run app-framework:lint -- --fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Changes

* **Chores**
  * Improved module discovery and filtering in the build process to exclude testing-related subpaths from import mappings across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->