### PR TITLE
ci: add PR preview deploys for composer-app

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,78 @@
+name: Preview Deploy
+
+# Deploys the composer-app preview bundle built by preview.yml to Cloudflare
+# Pages. Uses workflow_run so this workflow executes from the BASE branch
+# (trusted), which means secrets are safe to use here. The untrusted PR code
+# never runs in this workflow — we only download the pre-built artifact.
+
+on:
+  workflow_run:
+    workflows: ['Preview Build']
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  deploy:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Download preview bundle
+        uses: actions/download-artifact@v5
+        with:
+          name: composer-preview-bundle
+          path: preview
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read deploy metadata
+        id: meta
+        run: |
+          PR_NUMBER=$(cat preview/preview-meta/pr-number)
+          HEAD_SHA=$(cat preview/preview-meta/head-sha)
+          # Validate — guard against a malicious artifact injecting arbitrary values.
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number: $PR_NUMBER" >&2
+            exit 1
+          fi
+          if ! [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid head SHA: $HEAD_SHA" >&2
+            exit 1
+          fi
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+          echo "branch_alias=pr-$PR_NUMBER" >> $GITHUB_OUTPUT
+
+      - name: Install wrangler
+        run: npm install --global wrangler@3
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          wrangler pages deploy preview/packages/apps/composer-app/out/composer \
+            --project-name composer \
+            --branch "${{ steps.meta.outputs.branch_alias }}" \
+            | tee deploy.log
+          URL=$(grep -Eo 'https://[a-z0-9-]+\.composer\.pages\.dev' deploy.log | head -n1)
+          echo "url=$URL" >> $GITHUB_OUTPUT
+          echo "alias=https://${{ steps.meta.outputs.branch_alias }}.composer.pages.dev" >> $GITHUB_OUTPUT
+
+      - name: Comment preview URL on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.meta.outputs.pr_number }}
+          header: composer-preview
+          message: |
+            ### Composer preview
+
+            - Branch alias: ${{ steps.deploy.outputs.alias }}
+            - Deployment: ${{ steps.deploy.outputs.url }}
+
+            Built from ${{ steps.meta.outputs.head_sha }}.

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,20 +1,25 @@
-name: Preview
+name: Preview Build
+
+# Builds the composer-app bundle for PR previews and uploads it as an artifact.
+# NO secrets are exposed here — this workflow runs untrusted PR code safely.
+# The artifact is picked up by preview-deploy.yml (workflow_run) which runs
+# from the base branch with secrets and performs the Cloudflare Pages deploy.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: preview-${{ github.event.pull_request.number }}
+  group: preview-build-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
-  deploy:
-    # Skip forks: they cannot access secrets.
+  build:
+    # Skip forks (per project policy) — not required for safety (no secrets are
+    # used here), but fork previews are intentionally unsupported.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: depot-ubuntu-24.04-8
     container:
@@ -23,71 +28,38 @@ jobs:
         username: dxos-bot
         password: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 45
-    env:
-      BRANCH_ALIAS: pr-${{ github.event.pull_request.number }}
     steps:
-      - name: Checkout PR head
+      - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           lfs: true
-
-      - name: Set environment variables from secrets, env files
-        run: .github/workflows/scripts/populate-env.sh "$BRANCH_ALIAS" >> $GITHUB_ENV
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
-          COMPOSER_APP_TEST_POSTHOG_API_KEY: ${{ secrets.COMPOSER_APP_TEST_POSTHOG_API_KEY }}
-          COMPOSER_APP_TEST_POSTHOG_PROJECT_ID: ${{ secrets.COMPOSER_APP_TEST_POSTHOG_PROJECT_ID }}
-          COMPOSER_APP_TEST_POSTHOG_FEEDBACK_SURVEY_ID: ${{ secrets.COMPOSER_APP_TEST_POSTHOG_FEEDBACK_SURVEY_ID }}
-          DX_OTEL_ENDPOINT: ${{ secrets.DX_OTEL_ENDPOINT }}
-          DX_OTEL_HEADERS: ${{ secrets.DX_OTEL_HEADERS }}
-          DX_POSTHOG_API_HOST: ${{ secrets.DX_POSTHOG_API_HOST }}
-          IPDATA_API_KEY: ${{ secrets.IPDATA_API_KEY }}
-          IPFS_API_SECRET: ${{ secrets.IPFS_API_SECRET }}
-          JWT_SECRET: ${{ secrets.JWT_SECRET }}
 
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Build
-        run: moon run composer-app:build
-        env:
-          NODE_ENV: production
-
       - name: Bundle composer-app
-        run: |
-          export DX_POSTHOG_API_KEY="$COMPOSER_APP_POSTHOG_API_KEY"
-          export DX_POSTHOG_PROJECT_ID="$COMPOSER_APP_POSTHOG_PROJECT_ID"
-          export DX_POSTHOG_FEEDBACK_SURVEY_ID="$COMPOSER_APP_POSTHOG_FEEDBACK_SURVEY_ID"
-          export LOG_FILTER="error"
-          moon run composer-app:bundle
+        run: moon run composer-app:bundle
         env:
           NODE_ENV: production
           NODE_OPTIONS: '--max_old_space_size=12288'
+          LOG_FILTER: error
 
       - name: Delete source maps
         run: find packages/apps/composer-app/out/composer -name '*.map' -delete
 
-      - name: Deploy to Cloudflare Pages
-        id: deploy
-        working-directory: packages/apps/composer-app
+      - name: Write deploy metadata
         run: |
-          pnpm exec wrangler pages deploy out/composer --branch "$BRANCH_ALIAS" | tee deploy.log
-          URL=$(grep -Eo 'https://[a-z0-9-]+\.composer\.pages\.dev' deploy.log | head -n1)
-          echo "url=$URL" >> $GITHUB_OUTPUT
-          echo "alias=https://${BRANCH_ALIAS}.composer.pages.dev" >> $GITHUB_OUTPUT
+          mkdir -p preview-meta
+          echo "${{ github.event.pull_request.number }}" > preview-meta/pr-number
+          echo "${{ github.event.pull_request.head.sha }}" > preview-meta/head-sha
 
-      - name: Comment preview URL on PR
-        uses: marocchino/sticky-pull-request-comment@v2
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v7
         with:
-          header: composer-preview
-          message: |
-            ### Composer preview
-
-            - Branch alias: ${{ steps.deploy.outputs.alias }}
-            - Deployment: ${{ steps.deploy.outputs.url }}
-
-            Built from ${{ github.event.pull_request.head.sha }}.
+          name: composer-preview-bundle
+          path: |
+            packages/apps/composer-app/out/composer
+            preview-meta
+          retention-days: 3
+          if-no-files-found: error

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,93 @@
+name: Preview
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy:
+    # Skip forks: they cannot access secrets.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: depot-ubuntu-24.04-8
+    container:
+      image: ghcr.io/dxos/gh-actions:24.11.1
+      credentials:
+        username: dxos-bot
+        password: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 45
+    env:
+      BRANCH_ALIAS: pr-${{ github.event.pull_request.number }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          lfs: true
+
+      - name: Set environment variables from secrets, env files
+        run: .github/workflows/scripts/populate-env.sh "$BRANCH_ALIAS" >> $GITHUB_ENV
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
+          COMPOSER_APP_TEST_POSTHOG_API_KEY: ${{ secrets.COMPOSER_APP_TEST_POSTHOG_API_KEY }}
+          COMPOSER_APP_TEST_POSTHOG_PROJECT_ID: ${{ secrets.COMPOSER_APP_TEST_POSTHOG_PROJECT_ID }}
+          COMPOSER_APP_TEST_POSTHOG_FEEDBACK_SURVEY_ID: ${{ secrets.COMPOSER_APP_TEST_POSTHOG_FEEDBACK_SURVEY_ID }}
+          DX_OTEL_ENDPOINT: ${{ secrets.DX_OTEL_ENDPOINT }}
+          DX_OTEL_HEADERS: ${{ secrets.DX_OTEL_HEADERS }}
+          DX_POSTHOG_API_HOST: ${{ secrets.DX_POSTHOG_API_HOST }}
+          IPDATA_API_KEY: ${{ secrets.IPDATA_API_KEY }}
+          IPFS_API_SECRET: ${{ secrets.IPFS_API_SECRET }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Build
+        run: moon run composer-app:build
+        env:
+          NODE_ENV: production
+
+      - name: Bundle composer-app
+        run: |
+          export DX_POSTHOG_API_KEY="$COMPOSER_APP_POSTHOG_API_KEY"
+          export DX_POSTHOG_PROJECT_ID="$COMPOSER_APP_POSTHOG_PROJECT_ID"
+          export DX_POSTHOG_FEEDBACK_SURVEY_ID="$COMPOSER_APP_POSTHOG_FEEDBACK_SURVEY_ID"
+          export LOG_FILTER="error"
+          moon run composer-app:bundle
+        env:
+          NODE_ENV: production
+          NODE_OPTIONS: '--max_old_space_size=12288'
+
+      - name: Delete source maps
+        run: find packages/apps/composer-app/out/composer -name '*.map' -delete
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        working-directory: packages/apps/composer-app
+        run: |
+          pnpm exec wrangler pages deploy out/composer --branch "$BRANCH_ALIAS" | tee deploy.log
+          URL=$(grep -Eo 'https://[a-z0-9-]+\.composer\.pages\.dev' deploy.log | head -n1)
+          echo "url=$URL" >> $GITHUB_OUTPUT
+          echo "alias=https://${BRANCH_ALIAS}.composer.pages.dev" >> $GITHUB_OUTPUT
+
+      - name: Comment preview URL on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: composer-preview
+          message: |
+            ### Composer preview
+
+            - Branch alias: ${{ steps.deploy.outputs.alias }}
+            - Deployment: ${{ steps.deploy.outputs.url }}
+
+            Built from ${{ github.event.pull_request.head.sha }}.


### PR DESCRIPTION
## Summary

Adds a new **Preview** GitHub Actions workflow that deploys composer-app to Cloudflare Pages for every same-repo PR, giving reviewers a live URL on each push.

## What changed

- New workflow at `.github/workflows/preview.yml` triggered on `pull_request_target` (opened/synchronize/reopened).
- Uses a sanitized branch alias `pr-<number>`, producing a stable URL `https://pr-<n>.composer.pages.dev`.
- Reuses the existing `populate-env.sh` pipeline; `pr-<n>` falls back to `.github/workflows/env/default`, so previews get the test PostHog project (no prod keys).
- Runs `moon run composer-app:build` → `composer-app:bundle` (no `--force`, so moon caching applies), strips source maps, then `wrangler pages deploy out/composer --branch pr-<n>`.
- Posts a sticky comment on the PR with the preview URL via `marocchino/sticky-pull-request-comment`.

## Design decisions

- **Forks skipped:** `pull_request_target` + `head.repo.full_name == github.repository` gate — fork PRs can't access CF/PostHog secrets.
- **Composer only:** storybook preview can be added later; this keeps runs fast.
- **Caching:** no `--force`, so moon reuses remote cache. Publish pipeline uses `--force` intentionally for main deploys; previews don't need that guarantee.
- **Concurrency:** grouped per PR with cancel-in-progress.

## Reviewer notes

- `pull_request_target` runs the workflow from the **base** branch, so changes to `preview.yml` on a PR don't execute until merged — this is intentional (prevents malicious PRs from exfiltrating secrets by editing the workflow).
- All referenced secrets (`CLOUDFLARE_*`, `COMPOSER_APP_TEST_POSTHOG_*`, etc.) are already used by `publish-all.yml`, so no new secrets need to be added.
- Cleanup of old preview deployments relies on Cloudflare Pages' built-in pruning; a `pull_request: closed` cleanup job can be added later if desired.

## Test plan

- [ ] Merge to main, then open a test PR and confirm the Preview workflow runs.
- [ ] Verify the sticky comment appears with a working `pr-<n>.composer.pages.dev` URL.
- [ ] Push a follow-up commit and confirm the concurrency group cancels the prior run and redeploys.
- [ ] Open a PR from a fork (or simulate) and confirm the workflow is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic preview deployments for pull requests — a preview site is built and deployed, and the preview URL plus branch alias are posted/updated in the PR comment for easy review.

* **Chores**
  * Added CI automation to build, bundle, validate deploy metadata, upload a short-lived build artifact, and trigger a follow-up deploy that captures and exposes the deployment URL and SHA.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->