### PR TITLE
feat(log): add lazy computed getters to LogEntry

### DIFF
--- a/packages/common/log/src/context.ts
+++ b/packages/common/log/src/context.ts
@@ -245,24 +245,32 @@ const stringifyOneLevel = (value: unknown): unknown => {
 const computeContext = (entry: LogEntry): Record<string, unknown> => {
   const result: Record<string, unknown> = {};
 
-  if (entry.meta?.S !== undefined && entry.meta.S !== null) {
-    const scopeInfo = gatherLogInfoFromScope(entry.meta.S);
-    for (const [key, value] of Object.entries(scopeInfo)) {
+  const mergeInto = (source: unknown): void => {
+    if (!source || typeof source !== 'object') {
+      return;
+    }
+    for (const [key, value] of Object.entries(source)) {
       if (RESERVED_ERROR_KEYS.has(key)) {
         continue;
       }
       result[key] = stringifyOneLevel(value);
     }
+  };
+
+  if (entry.meta?.S !== undefined && entry.meta.S !== null) {
+    mergeInto(gatherLogInfoFromScope(entry.meta.S));
   }
 
   const rawContext = typeof entry.context === 'function' ? entry.context() : entry.context;
-  if (rawContext && typeof rawContext === 'object' && !(rawContext instanceof Error)) {
-    for (const [key, value] of Object.entries(rawContext)) {
-      if (RESERVED_ERROR_KEYS.has(key)) {
-        continue;
-      }
-      result[key] = stringifyOneLevel(value);
-    }
+  if (rawContext instanceof Error) {
+    // Structured debug info attached to thrown errors lives on `.context`.
+    mergeInto((rawContext as any).context);
+  } else {
+    mergeInto(rawContext);
+  }
+
+  if (entry.error) {
+    mergeInto((entry.error as any).context);
   }
 
   return result;

--- a/packages/common/log/src/context.ts
+++ b/packages/common/log/src/context.ts
@@ -77,6 +77,8 @@ export class LogEntry {
   #computedError: string | undefined;
   #computedErrorComputed = false;
   #computedMeta: ComputedLogMeta | undefined;
+  #resolvedContext: unknown;
+  #resolvedContextComputed = false;
 
   constructor(init: LogEntryInit) {
     this.level = init.level;
@@ -85,6 +87,18 @@ export class LogEntry {
     this.meta = init.meta;
     this.error = init.error;
     this.timestamp = init.timestamp ?? Date.now();
+  }
+
+  /**
+   * Resolve a function-valued {@link context} once and cache, so getters that
+   * independently consult the raw context don't trigger duplicate evaluation.
+   */
+  #resolveContext(): unknown {
+    if (!this.#resolvedContextComputed) {
+      this.#resolvedContext = typeof this.context === 'function' ? this.context() : this.context;
+      this.#resolvedContextComputed = true;
+    }
+    return this.#resolvedContext;
   }
 
   /**
@@ -100,7 +114,7 @@ export class LogEntry {
    */
   get computedContext(): Record<string, unknown> {
     if (!this.#computedContextComputed) {
-      this.#computedContext = computeContext(this);
+      this.#computedContext = computeContext(this, this.#resolveContext());
       this.#computedContextComputed = true;
     }
     return this.#computedContext ?? {};
@@ -118,7 +132,7 @@ export class LogEntry {
    */
   get computedError(): string | undefined {
     if (!this.#computedErrorComputed) {
-      this.#computedError = computeError(this);
+      this.#computedError = computeError(this, this.#resolveContext());
       this.#computedErrorComputed = true;
     }
     return this.#computedError;
@@ -242,7 +256,7 @@ const stringifyOneLevel = (value: unknown): unknown => {
   }
 };
 
-const computeContext = (entry: LogEntry): Record<string, unknown> => {
+const computeContext = (entry: LogEntry, rawContext: unknown): Record<string, unknown> => {
   const result: Record<string, unknown> = {};
 
   const mergeInto = (source: unknown): void => {
@@ -261,7 +275,6 @@ const computeContext = (entry: LogEntry): Record<string, unknown> => {
     mergeInto(gatherLogInfoFromScope(entry.meta.S));
   }
 
-  const rawContext = typeof entry.context === 'function' ? entry.context() : entry.context;
   if (rawContext instanceof Error) {
     // Structured debug info attached to thrown errors lives on `.context`.
     mergeInto((rawContext as any).context);
@@ -286,12 +299,11 @@ const stringifyError = (err: unknown): string | undefined => {
   return String(err);
 };
 
-const computeError = (entry: LogEntry): string | undefined => {
+const computeError = (entry: LogEntry, rawContext: unknown): string | undefined => {
   if (entry.error !== undefined) {
     return stringifyError(entry.error);
   }
 
-  const rawContext = typeof entry.context === 'function' ? entry.context() : entry.context;
   if (rawContext instanceof Error) {
     return stringifyError(rawContext);
   }
@@ -313,7 +325,12 @@ const computeMeta = (entry: LogEntry): ComputedLogMeta => {
   const scope = entry.meta.S;
   // Skip globalThis and plain object scopes (module-level logs); only report class instances.
   let scopeContext: string | undefined;
-  if (typeof scope === 'object' && scope !== null && Object.getPrototypeOf(scope) !== Object.prototype) {
+  if (
+    typeof scope === 'object' &&
+    scope !== null &&
+    scope !== globalThis &&
+    Object.getPrototypeOf(scope) !== Object.prototype
+  ) {
     scopeContext = getDebugName(scope);
   }
 

--- a/packages/common/log/src/context.ts
+++ b/packages/common/log/src/context.ts
@@ -2,8 +2,11 @@
 // Copyright 2022 DXOS.org
 //
 
+import { getDebugName } from '@dxos/util';
+
 import { type LogConfig, type LogFilter, type LogLevel } from './config';
 import { type CallMetadata } from './meta';
+import { getRelativeFilename } from './processors/common';
 import { gatherLogInfoFromScope } from './scope';
 
 /**
@@ -12,14 +15,126 @@ import { gatherLogInfoFromScope } from './scope';
 export type LogContext = Record<string, any> | Error | any;
 
 /**
- * Record for current log line.
+ * Normalized call-site metadata suitable for display and serialization.
  */
-export interface LogEntry {
+export interface ComputedLogMeta {
+  /** Relative filename (normalized via {@link getRelativeFilename}). */
+  filename?: string;
+
+  /** Line number within the file. */
+  line?: number;
+
+  /** Debug name of the enclosing scope (class instance), e.g. `MyClass#3`. */
+  context?: string;
+}
+
+/**
+ * Fields required to construct a {@link LogEntry}.
+ */
+export interface LogEntryInit {
   level: LogLevel;
   message?: string;
   context?: LogContext;
   meta?: CallMetadata;
   error?: Error;
+  /** Overrides the default timestamp ({@link Date.now}). */
+  timestamp?: number;
+}
+
+/**
+ * Record for a single log line processed by the logging pipeline.
+ *
+ * Raw fields (`level`, `message`, `context`, `meta`, `error`) are preserved so processors
+ * can access unmodified inputs. Derived, lazily computed getters
+ * ({@link computedContext}, {@link computedError}, {@link computedMeta}) centralize
+ * the formatting logic shared across processors that write to serialized stores.
+ */
+export class LogEntry {
+  /** Severity of this entry. */
+  readonly level: LogLevel;
+
+  /** Human-readable log message, if any. */
+  readonly message?: string;
+
+  /**
+   * Raw context value passed at the call site. May be a record, an Error, a function
+   * returning either, or any other value. Processors that need the flattened /
+   * JSON-safe view should prefer {@link computedContext}.
+   */
+  readonly context?: LogContext;
+
+  /** Raw call-site metadata injected by the log transform plugin. */
+  readonly meta?: CallMetadata;
+
+  /** Error passed to `log.catch()` / `log.error(err)`, if any. */
+  readonly error?: Error;
+
+  /** Unix timestamp in milliseconds of when the entry was created. */
+  readonly timestamp: number;
+
+  #computedContext: Record<string, unknown> | undefined;
+  #computedContextComputed = false;
+  #computedError: string | undefined;
+  #computedErrorComputed = false;
+  #computedMeta: ComputedLogMeta | undefined;
+
+  constructor(init: LogEntryInit) {
+    this.level = init.level;
+    this.message = init.message;
+    this.context = init.context;
+    this.meta = init.meta;
+    this.error = init.error;
+    this.timestamp = init.timestamp ?? Date.now();
+  }
+
+  /**
+   * Flattened, JSON-safe context intended for serialized stores.
+   *
+   * - Single-level key-value map.
+   * - Primitives (`boolean`, `number`, `string`, `null`, `undefined`) pass through.
+   * - Non-primitive values are stringified one level deep via `JSON.stringify` (no recursion).
+   * - The reserved `error` / `err` keys are stripped — use {@link computedError} instead.
+   * - Properties from `@logInfo`-decorated members of the scope (`meta.S`) are inlined.
+   *
+   * Lazily computed and memoized on first access.
+   */
+  get computedContext(): Record<string, unknown> {
+    if (!this.#computedContextComputed) {
+      this.#computedContext = computeContext(this);
+      this.#computedContextComputed = true;
+    }
+    return this.#computedContext ?? {};
+  }
+
+  /**
+   * Stringified error for this entry, sourced (in priority order) from:
+   *   1. {@link error} (e.g. `log.catch(err)`),
+   *   2. {@link context} when the context itself is an {@link Error},
+   *   3. `context.error` or `context.err`.
+   *
+   * Formatted as `.stack` when available, falling back to `.message` or `String(err)`.
+   *
+   * Lazily computed and memoized on first access.
+   */
+  get computedError(): string | undefined {
+    if (!this.#computedErrorComputed) {
+      this.#computedError = computeError(this);
+      this.#computedErrorComputed = true;
+    }
+    return this.#computedError;
+  }
+
+  /**
+   * Normalized call-site metadata suitable for display / serialization.
+   *
+   * Lazily computed and memoized on first access.
+   */
+  get computedMeta(): ComputedLogMeta {
+    if (this.#computedMeta === undefined) {
+      this.#computedMeta = computeMeta(this);
+    }
+    return this.#computedMeta;
+  }
 }
 
 /**
@@ -73,6 +188,12 @@ export const shouldLog = (entry: LogEntry, filters?: LogFilter[]): boolean => {
   return results.length > 0 && !results.some((results) => results === false);
 };
 
+/**
+ * Merges scope info, entry context, and error into a single record — preserving nested
+ * objects and Error instances so rich consumers (console inspect, devtools) can format them.
+ *
+ * Prefer {@link LogEntry.computedContext} for serialized / JSON outputs.
+ */
 export const getContextFromEntry = (entry: LogEntry): Record<string, any> | undefined => {
   let context;
   if (entry.meta) {
@@ -99,4 +220,98 @@ export const getContextFromEntry = (entry: LogEntry): Record<string, any> | unde
   }
 
   return context && Object.keys(context).length > 0 ? context : undefined;
+};
+
+const RESERVED_ERROR_KEYS = new Set(['error', 'err']);
+
+const stringifyOneLevel = (value: unknown): unknown => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  const type = typeof value;
+  if (type === 'boolean' || type === 'number' || type === 'string') {
+    return value;
+  }
+  if (type === 'bigint') {
+    return (value as bigint).toString();
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+const computeContext = (entry: LogEntry): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+
+  if (entry.meta?.S !== undefined && entry.meta.S !== null) {
+    const scopeInfo = gatherLogInfoFromScope(entry.meta.S);
+    for (const [key, value] of Object.entries(scopeInfo)) {
+      if (RESERVED_ERROR_KEYS.has(key)) {
+        continue;
+      }
+      result[key] = stringifyOneLevel(value);
+    }
+  }
+
+  const rawContext = typeof entry.context === 'function' ? entry.context() : entry.context;
+  if (rawContext && typeof rawContext === 'object' && !(rawContext instanceof Error)) {
+    for (const [key, value] of Object.entries(rawContext)) {
+      if (RESERVED_ERROR_KEYS.has(key)) {
+        continue;
+      }
+      result[key] = stringifyOneLevel(value);
+    }
+  }
+
+  return result;
+};
+
+const stringifyError = (err: unknown): string | undefined => {
+  if (err === null || err === undefined) {
+    return undefined;
+  }
+  if (err instanceof Error) {
+    return err.stack ?? err.message;
+  }
+  return String(err);
+};
+
+const computeError = (entry: LogEntry): string | undefined => {
+  if (entry.error !== undefined) {
+    return stringifyError(entry.error);
+  }
+
+  const rawContext = typeof entry.context === 'function' ? entry.context() : entry.context;
+  if (rawContext instanceof Error) {
+    return stringifyError(rawContext);
+  }
+  if (rawContext && typeof rawContext === 'object') {
+    const ctxErr = (rawContext as any).error ?? (rawContext as any).err;
+    if (ctxErr !== undefined && ctxErr !== null) {
+      return stringifyError(ctxErr);
+    }
+  }
+
+  return undefined;
+};
+
+const computeMeta = (entry: LogEntry): ComputedLogMeta => {
+  if (!entry.meta) {
+    return {};
+  }
+
+  const scope = entry.meta.S;
+  // Skip globalThis and plain object scopes (module-level logs); only report class instances.
+  let scopeContext: string | undefined;
+  if (typeof scope === 'object' && scope !== null && Object.getPrototypeOf(scope) !== Object.prototype) {
+    scopeContext = getDebugName(scope);
+  }
+
+  return {
+    filename: getRelativeFilename(entry.meta.F),
+    line: entry.meta.L,
+    context: scopeContext,
+  };
 };

--- a/packages/common/log/src/log-buffer.test.ts
+++ b/packages/common/log/src/log-buffer.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, test } from 'vitest';
 
-import { type LogConfig, type LogEntry, LogLevel } from './index';
+import { type LogConfig, LogEntry, type LogEntryInit, LogLevel } from './index';
 import { LogBuffer } from './log-buffer';
 
 const baseConfig: LogConfig = {
@@ -13,11 +13,12 @@ const baseConfig: LogConfig = {
   processors: [],
 };
 
-const createEntry = (overrides: Partial<LogEntry> = {}): LogEntry => ({
-  level: LogLevel.INFO,
-  message: 'test message',
-  ...overrides,
-});
+const createEntry = (overrides: Partial<LogEntryInit> = {}): LogEntry =>
+  new LogEntry({
+    level: LogLevel.INFO,
+    message: 'test message',
+    ...overrides,
+  });
 
 describe('LogBuffer', () => {
   test('pushes and serializes log entries', ({ expect }) => {
@@ -123,7 +124,9 @@ describe('LogBuffer', () => {
 
     const lines = buffer.serialize().split('\n');
     const record = JSON.parse(lines[0]);
-    expect(record.c).toBeUndefined();
+    // Circular values fall back to String(value) rather than dropping the entry.
+    expect(record.c).toBeDefined();
+    expect(JSON.parse(record.c!).self).toBe('[object Object]');
   });
 
   test('serialize returns empty string for empty buffer', ({ expect }) => {

--- a/packages/common/log/src/log-buffer.ts
+++ b/packages/common/log/src/log-buffer.ts
@@ -2,7 +2,7 @@
 // Copyright 2025 DXOS.org
 //
 
-import { CircularBuffer, getDebugName } from '@dxos/util';
+import { CircularBuffer } from '@dxos/util';
 
 import { type LogConfig, LogLevel, shortLevelName } from './config';
 import { type LogEntry, type LogProcessor } from './context';
@@ -51,38 +51,39 @@ export class LogBuffer {
       return;
     }
 
+    const { filename, line, context: scopeName } = entry.computedMeta;
+
     const record: LogRecord = {
-      t: new Date().toISOString(),
+      t: new Date(entry.timestamp).toISOString(),
       l: shortLevelName[entry.level] ?? '?',
       m: entry.message ?? '',
     };
 
-    if (entry.meta) {
-      record.f = getRelativeFilename(entry.meta.F);
-      record.n = entry.meta.L;
+    if (filename !== undefined) {
+      record.f = filename;
+    }
+    if (line !== undefined) {
+      record.n = line;
+    }
+    if (scopeName !== undefined) {
+      record.o = scopeName;
     }
 
-    if (entry.error) {
-      record.e = entry.error.stack ?? entry.error.message;
+    if (entry.computedError !== undefined) {
+      record.e = entry.computedError;
     }
 
-    if (entry.context != null) {
+    const computedContext = entry.computedContext;
+    if (Object.keys(computedContext).length > 0) {
       try {
-        const ctx = typeof entry.context === 'function' ? entry.context() : entry.context;
-        if (ctx != null && !(ctx instanceof Error)) {
-          let json = JSON.stringify(ctx);
-          if (json.length > MAX_CONTEXT_LENGTH) {
-            json = json.slice(0, MAX_CONTEXT_LENGTH);
-          }
-          record.c = json;
+        let json = JSON.stringify(computedContext);
+        if (json.length > MAX_CONTEXT_LENGTH) {
+          json = json.slice(0, MAX_CONTEXT_LENGTH);
         }
+        record.c = json;
       } catch {
         // Skip context that throws or is non-serializable.
       }
-    }
-    const scope = entry.meta?.S;
-    if (typeof scope === 'object' && scope !== null && Object.getPrototypeOf(scope) !== Object.prototype) {
-      record.o = getDebugName(scope);
     }
 
     this._buffer.push(record);
@@ -107,11 +108,3 @@ export class LogBuffer {
     return lines.join('\n');
   }
 }
-
-const getRelativeFilename = (filename: string): string => {
-  const match = filename.match(/.+\/(packages\/.+\/.+)/);
-  if (match) {
-    return match[1];
-  }
-  return filename;
-};

--- a/packages/common/log/src/log.ts
+++ b/packages/common/log/src/log.ts
@@ -3,7 +3,7 @@
 //
 
 import { type LogConfig, LogLevel, type LogOptions } from './config';
-import { type LogContext, type LogProcessor } from './context';
+import { type LogContext, LogEntry, type LogProcessor } from './context';
 import { createFunctionLogDecorator, createMethodLogDecorator } from './decorators';
 import { type CallMetadata } from './meta';
 import { createConfig } from './options';
@@ -98,15 +98,8 @@ export const createLog = (): LogImp => {
     error?: Error,
   ) => {
     // TODO(burdon): Do the filter matching upstream (here) rather than in each processor?
-    log._config.processors.forEach((processor) =>
-      processor(log._config, {
-        level,
-        message,
-        context,
-        meta,
-        error,
-      }),
-    );
+    const entry = new LogEntry({ level, message, context, meta, error });
+    log._config.processors.forEach((processor) => processor(log._config, entry));
   };
 
   /**

--- a/packages/common/log/src/processors/browser-processor.ts
+++ b/packages/common/log/src/processors/browser-processor.ts
@@ -2,22 +2,10 @@
 // Copyright 2022 DXOS.org
 //
 
-import { getDebugName, safariCheck } from '@dxos/util';
+import { safariCheck } from '@dxos/util';
 
 import { LogLevel } from '../config';
 import { type LogProcessor, getContextFromEntry, shouldLog } from '../context';
-
-const getRelativeFilename = (filename: string) => {
-  // TODO(burdon): Hack uses "packages" as an anchor (pre-parse NX?)
-  // Including `packages/` part of the path so that excluded paths (e.g. from dist) are clickable in vscode.
-  const match = filename.match(/.+\/(packages\/.+\/.+)/);
-  if (match) {
-    const [, filePath] = match;
-    return filePath;
-  }
-
-  return filename;
-};
 
 type Config = {
   useTestProcessor: boolean;
@@ -47,23 +35,26 @@ const APP_BROWSER_PROCESSOR: LogProcessor = (config, entry) => {
   // const LOG_BROWSER_CSS = ['color:gray; font-size:10px; padding-bottom: 4px', 'color:#B97852; font-size:14px;'];
   const LOG_BROWSER_CSS: string[] = [];
 
+  const { filename, line: lineNumber, context: scopeDebugName } = entry.computedMeta;
+
   let link = '';
-  if (entry.meta) {
-    const filename = getRelativeFilename(entry.meta.F);
+  if (filename !== undefined && lineNumber !== undefined) {
     const filepath = `${LOG_BROWSER_PREFIX.replace(/\/$/, '')}/${filename}`;
     // TODO(burdon): Line numbers not working for app link, even with colons.
     //  https://stackoverflow.com/a/54459820/2804332
-    link = `${filepath}#L${entry.meta.L}`;
+    link = `${filepath}#L${lineNumber}`;
   }
 
   let args = [];
 
-  if (entry.meta?.S) {
-    const scope = entry.meta?.S;
-    const scopeName = scope.name || getDebugName(scope);
-    const processPrefix = entry.meta.S?.hostSessionId ? '[worker] ' : '';
-    // TODO(dmaretskyi): Those can be made clickable with a custom formatter.
-    args.push(`%c${processPrefix}${scopeName}`, 'color:#C026D3;font-weight:bold');
+  const scope = entry.meta?.S;
+  if (scope) {
+    const scopeName = scope.name || scopeDebugName;
+    if (scopeName) {
+      const processPrefix = scope.hostSessionId ? '[worker] ' : '';
+      // TODO(dmaretskyi): Those can be made clickable with a custom formatter.
+      args.push(`%c${processPrefix}${scopeName}`, 'color:#C026D3;font-weight:bold');
+    }
   }
 
   if (entry.message) {
@@ -114,10 +105,8 @@ const TEST_BROWSER_PROCESSOR: LogProcessor = (config, entry) => {
     return;
   }
 
-  let path = '';
-  if (entry.meta) {
-    path = `${getRelativeFilename(entry.meta.F)}:${entry.meta.L}`;
-  }
+  const { filename, line: lineNumber } = entry.computedMeta;
+  const path = filename !== undefined && lineNumber !== undefined ? `${filename}:${lineNumber}` : '';
 
   let args = [];
 

--- a/packages/common/log/src/processors/console-processor.ts
+++ b/packages/common/log/src/processors/console-processor.ts
@@ -9,7 +9,6 @@ import { getPrototypeSpecificInstanceId, pickBy } from '@dxos/util';
 
 import { type LogConfig, LogLevel, shortLevelName } from '../config';
 import { type LogProcessor, getContextFromEntry, shouldLog } from '../context';
-import { getRelativeFilename } from './common';
 
 const LEVEL_COLORS: Record<LogLevel, typeof chalk.ForegroundColor> = {
   [LogLevel.TRACE]: 'gray',
@@ -93,21 +92,16 @@ export const CONSOLE_PROCESSOR: LogProcessor = (config, entry) => {
     return;
   }
 
+  const { filename, line: lineNumber } = entry.computedMeta;
   const parts: FormatParts = {
     level,
     message,
     error,
-    path: undefined,
-    line: undefined,
-    scope: undefined,
+    path: filename,
+    line: lineNumber,
+    scope: meta?.S,
     context: undefined,
   };
-
-  if (meta) {
-    parts.path = getRelativeFilename(meta.F);
-    parts.line = meta.L;
-    parts.scope = meta.S;
-  }
 
   const context = getContextFromEntry(entry);
   if (context) {

--- a/packages/common/log/src/processors/file-processor.ts
+++ b/packages/common/log/src/processors/file-processor.ts
@@ -5,11 +5,8 @@
 import { appendFileSync, mkdirSync, openSync } from 'node:fs';
 import { dirname } from 'node:path';
 
-import { jsonlogify } from '@dxos/util';
-
 import { type LogFilter, LogLevel } from '../config';
-import { type LogProcessor, getContextFromEntry, shouldLog } from '../context';
-import { getRelativeFilename } from './common';
+import { type LogProcessor, shouldLog } from '../context';
 
 // Amount of time to retry writing after encountering EAGAIN before giving up.
 const EAGAIN_MAX_DURATION = 1000;
@@ -49,10 +46,12 @@ export const createFileProcessor = ({
     }
 
     const record = {
-      ...entry,
-      timestamp: Date.now(),
-      ...(entry.meta ? { meta: { file: getRelativeFilename(entry.meta.F), line: entry.meta.L } } : {}),
-      context: jsonlogify(getContextFromEntry(entry)),
+      level: entry.level,
+      message: entry.message,
+      timestamp: entry.timestamp,
+      meta: entry.computedMeta,
+      context: entry.computedContext,
+      error: entry.computedError,
     };
     let retryTS: number = 0;
 

--- a/packages/common/tracing/src/trace-processor.ts
+++ b/packages/common/tracing/src/trace-processor.ts
@@ -2,7 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { LogLevel, type LogProcessor, getContextFromEntry, log } from '@dxos/log';
+import { LogLevel, type LogProcessor, log } from '@dxos/log';
 import { type LogEntry } from '@dxos/protocols/proto/dxos/client/services';
 import { type Metric, type Resource } from '@dxos/protocols/proto/dxos/tracing';
 import { getPrototypeSpecificInstanceId } from '@dxos/util';
@@ -257,19 +257,20 @@ export class TraceProcessor {
           return;
         }
 
-        const context = getContextFromEntry(entry) ?? {};
-        for (const key of Object.keys(context)) {
-          context[key] = sanitizeValue(context[key], 0, this);
+        const context: Record<string, any> = { ...entry.computedContext };
+        if (entry.computedError !== undefined) {
+          context.error = entry.computedError;
         }
 
+        const { filename, line } = entry.computedMeta;
         const entryToPush: LogEntry = {
           level: entry.level,
-          message: entry.message ?? (entry.error ? (entry.error.message ?? String(entry.error)) : ''),
+          message: entry.message ?? entry.computedError ?? '',
           context,
-          timestamp: new Date(),
+          timestamp: new Date(entry.timestamp),
           meta: {
-            file: entry.meta?.F ?? '',
-            line: entry.meta?.L ?? 0,
+            file: filename ?? '',
+            line: line ?? 0,
             resourceId: resource.data.id,
           },
         };

--- a/packages/core/functions-runtime-cloudflare/src/logger.ts
+++ b/packages/core/functions-runtime-cloudflare/src/logger.ts
@@ -16,27 +16,29 @@ const functionLogProcessor: LogProcessor = (config, entry) => {
     return;
   }
 
+  const context = entry.computedContext;
+  const error = entry.computedError;
+  const extras = [Object.keys(context).length > 0 ? context : undefined, error].filter((value) => value !== undefined);
+
   switch (entry.level) {
     case LogLevel.DEBUG:
-      console.debug(entry.message, entry.context);
-      break;
     case LogLevel.TRACE:
-      console.debug(entry.message, entry.context);
+      console.debug(entry.message, ...extras);
       break;
     case LogLevel.VERBOSE:
-      console.log(entry.message, entry.context);
+      console.log(entry.message, ...extras);
       break;
     case LogLevel.INFO:
-      console.info(entry.message, entry.context);
+      console.info(entry.message, ...extras);
       break;
     case LogLevel.WARN:
-      console.warn(entry.message, entry.context);
+      console.warn(entry.message, ...extras);
       break;
     case LogLevel.ERROR:
-      console.error(entry.message, entry.context);
+      console.error(entry.message, ...extras);
       break;
     default:
-      console.log(entry.message, entry.context);
+      console.log(entry.message, ...extras);
       break;
   }
 };

--- a/packages/devtools/cli/src/util/log-buffer.ts
+++ b/packages/devtools/cli/src/util/log-buffer.ts
@@ -2,7 +2,7 @@
 // Copyright 2025 DXOS.org
 //
 
-import { type CallMetadata, type LogConfig, type LogEntry, LogLevel, type LogProcessor, shouldLog } from '@dxos/log';
+import { type LogConfig, type LogEntry, LogLevel, type LogProcessor, shouldLog } from '@dxos/log';
 
 export type LogPrinter = Pick<Console, 'debug' | 'log' | 'info' | 'warn' | 'error'>;
 
@@ -69,25 +69,13 @@ const getMethod = (level: LogLevel): keyof LogPrinter => {
 /**
  * Creates a log processor that buffers logs until replayed.
  */
-const formatter = (_config: LogConfig, { message, context, error, meta }: LogEntry) => {
-  return [
-    meta && line(meta),
-    message,
-    Object.keys(context).length > 0 &&
-      JSON.stringify(context, (key, value) => {
-        if (typeof value === 'bigint') {
-          return value.toString();
-        }
-        return value;
-      }),
-    error && String(error),
-  ]
+const formatter = (_config: LogConfig, entry: LogEntry) => {
+  const { filename, line: lineNumber } = entry.computedMeta;
+  const file = filename?.split('/').pop()?.split('.').shift();
+  const location = file !== undefined && lineNumber !== undefined ? `[${file}:${lineNumber}]` : undefined;
+  const context = entry.computedContext;
+
+  return [location, entry.message, Object.keys(context).length > 0 && JSON.stringify(context), entry.computedError]
     .filter(Boolean)
     .join(' ');
-};
-
-const line = (meta: CallMetadata) => {
-  const file = meta.F.split('/').pop()?.split('.').shift();
-  const line = meta.L;
-  return `[${file}:${line}]`;
 };

--- a/packages/sdk/client-services/src/packlets/logging/logging-service.ts
+++ b/packages/sdk/client-services/src/packlets/logging/logging-service.ts
@@ -121,12 +121,12 @@ export class LoggingServiceImpl implements LoggingService {
           timestamp: new Date(entry.timestamp),
           meta: {
             // TODO(dmaretskyi): Fix proto.
-            file: filename ?? entry.meta?.F ?? '',
-            line: line ?? entry.meta?.L ?? 0,
+            file: filename ?? '',
+            line: line ?? 0,
             scope: {
               hostSessionId: this._sessionId,
               uptimeSeconds: (Date.now() - this._started) / 1000,
-              name: scopeName ?? 'null',
+              name: scopeName ?? '',
             },
           },
         };

--- a/packages/sdk/client-services/src/packlets/logging/logging-service.ts
+++ b/packages/sdk/client-services/src/packlets/logging/logging-service.ts
@@ -5,13 +5,7 @@
 import { Event } from '@dxos/async';
 import { Stream } from '@dxos/codec-protobuf/stream';
 import { PublicKey } from '@dxos/keys';
-import {
-  type LogLevel,
-  type LogProcessor,
-  type LogEntry as NaturalLogEntry,
-  getContextFromEntry,
-  log,
-} from '@dxos/log';
+import { type LogLevel, type LogProcessor, type LogEntry as NaturalLogEntry, log } from '@dxos/log';
 import {
   type ControlMetricsRequest,
   type ControlMetricsResponse,
@@ -22,7 +16,7 @@ import {
   type QueryMetricsRequest,
   type QueryMetricsResponse,
 } from '@dxos/protocols/proto/dxos/client/services';
-import { getDebugName, jsonify, numericalValues, tracer } from '@dxos/util';
+import { numericalValues, tracer } from '@dxos/util';
 
 /**
  * Logging service used to spy on logs of the host.
@@ -114,19 +108,25 @@ export class LoggingServiceImpl implements LoggingService {
           return;
         }
 
+        const { filename, line, context: scopeName } = entry.computedMeta;
+        const recordContext: Record<string, any> = { ...entry.computedContext };
+        if (entry.computedError !== undefined) {
+          recordContext.error = entry.computedError;
+        }
+
         const record: LogEntry = {
-          ...entry,
-          message: entry.message ?? (entry.error ? (entry.error.message ?? String(entry.error)) : ''),
-          context: jsonify(getContextFromEntry(entry)),
-          timestamp: new Date(),
+          level: entry.level,
+          message: entry.message ?? entry.computedError ?? '',
+          context: recordContext,
+          timestamp: new Date(entry.timestamp),
           meta: {
             // TODO(dmaretskyi): Fix proto.
-            file: entry.meta?.F ?? '',
-            line: entry.meta?.L ?? 0,
+            file: filename ?? entry.meta?.F ?? '',
+            line: line ?? entry.meta?.L ?? 0,
             scope: {
               hostSessionId: this._sessionId,
               uptimeSeconds: (Date.now() - this._started) / 1000,
-              name: getDebugName(entry.meta?.S),
+              name: scopeName ?? 'null',
             },
           },
         };

--- a/packages/sdk/observability/src/extensions/posthog/log-processor.test.ts
+++ b/packages/sdk/observability/src/extensions/posthog/log-processor.test.ts
@@ -5,7 +5,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { InvariantViolation } from '@dxos/invariant';
-import { type LogConfig, type LogEntry, LogLevel } from '@dxos/log';
+import { type LogConfig, LogEntry, type LogEntryInit, LogLevel } from '@dxos/log';
 
 // Replace the posthog-js module with a stub so log-processor's top-level import resolves to our mock.
 // Dynamic imports are used so that both the mock and log-processor are loaded after vi.mock is hoisted.
@@ -23,11 +23,12 @@ const baseConfig: LogConfig = {
   processors: [],
 };
 
-const createEntry = (overrides: Partial<LogEntry> = {}): LogEntry => ({
-  level: LogLevel.ERROR,
-  message: 'test error',
-  ...overrides,
-});
+const createEntry = (overrides: Partial<LogEntryInit> = {}): LogEntry =>
+  new LogEntry({
+    level: LogLevel.ERROR,
+    message: 'test error',
+    ...overrides,
+  });
 
 describe('logProcessor', () => {
   beforeEach(() => {

--- a/packages/sdk/observability/src/extensions/posthog/log-processor.ts
+++ b/packages/sdk/observability/src/extensions/posthog/log-processor.ts
@@ -23,15 +23,16 @@ export const logProcessor: LogProcessor = (config: LogConfig, entry: LogEntry) =
   }
 
   const additionalProperties: Record<string, string | boolean | number> = {};
-  if (entry.meta) {
-    additionalProperties.transaction = `${getRelativeFilename(entry.meta.F)}:${entry.meta.L}`;
-    if (entry.meta.S?.hostSessionId) {
-      additionalProperties.service_host_issue = true;
-      additionalProperties.service_host_session = entry.meta.S?.hostSessionId;
-    }
-    if (entry.meta.S?.uptimeSeconds != null) {
-      additionalProperties.uptime_seconds = entry.meta.S.uptimeSeconds;
-    }
+  const { filename, line } = entry.computedMeta;
+  if (filename !== undefined && line !== undefined) {
+    additionalProperties.transaction = `${filename}:${line}`;
+  }
+  if (entry.meta?.S?.hostSessionId) {
+    additionalProperties.service_host_issue = true;
+    additionalProperties.service_host_session = entry.meta.S.hostSessionId;
+  }
+  if (entry.meta?.S?.uptimeSeconds != null) {
+    additionalProperties.uptime_seconds = entry.meta.S.uptimeSeconds;
   }
 
   if (capturedError instanceof InvariantViolation) {
@@ -39,16 +40,4 @@ export const logProcessor: LogProcessor = (config: LogConfig, entry: LogEntry) =
   }
 
   posthog.captureException(capturedError, additionalProperties);
-};
-
-const getRelativeFilename = (filename: string) => {
-  // TODO(burdon): Hack uses "packages" as an anchor (pre-parse NX?)
-  // Including `packages/` part of the path so that excluded paths (e.g. from dist) are clickable in vscode.
-  const match = filename.match(/.+\/(packages\/.+\/.+)/);
-  if (match) {
-    const [, filePath] = match;
-    return filePath;
-  }
-
-  return filename;
 };

--- a/tools/vite-plugin-log/src/runtime.ts
+++ b/tools/vite-plugin-log/src/runtime.ts
@@ -5,70 +5,50 @@
 /// <reference types="vite/client" />
 
 import { LogLevel, shortLevelName, log, type LogConfig, type LogEntry, type LogProcessor } from '@dxos/log';
-import { getDebugName } from '@dxos/util';
 
 const MAX_CONTEXT_LENGTH = 500;
 
 /** Coalesce sends to one macrotask; adjust if needed. */
 const FLUSH_DEBOUNCE_MS = 16;
 
-const getRelativeFilename = (filename: string): string => {
-  const match = filename.match(/.+\/(packages\/.+\/.+)/);
-  if (match) {
-    return match[1];
-  }
-  return filename;
-};
-
 const entryToNdjsonLine = (_config: LogConfig, entry: LogEntry): string | null => {
   if (entry.level <= LogLevel.TRACE) {
     return null;
   }
 
+  const { filename, line, context: scopeName } = entry.computedMeta;
+
   const record: Record<string, unknown> = {
-    t: new Date().toISOString(),
+    t: new Date(entry.timestamp).toISOString(),
     l: shortLevelName[entry.level] ?? '?',
     m: entry.message ?? '',
   };
 
-  if (entry.meta) {
-    record.f = getRelativeFilename(entry.meta.F);
-    record.n = entry.meta.L;
+  if (filename !== undefined) {
+    record.f = filename;
+  }
+  if (line !== undefined) {
+    record.n = line;
+  }
+  if (scopeName !== undefined) {
+    record.o = scopeName;
   }
 
-  const ctx = entry.context;
-
-  let error = entry.error;
-  if (!error && ctx?.error) {
-    error = ctx.error;
-    delete ctx.error;
-  } else if (!error && ctx.err) {
-    error = ctx.err;
-    delete ctx.err;
+  if (entry.computedError !== undefined) {
+    record.e = entry.computedError;
   }
 
-  if (error) {
-    record.e = error.stack ?? error.message;
-  }
-
-  if (ctx != null) {
+  const computedContext = entry.computedContext;
+  if (Object.keys(computedContext).length > 0) {
     try {
-      const ctx1 = typeof ctx === 'function' ? ctx() : ctx;
-      if (ctx1 != null && !(ctx1 instanceof Error)) {
-        let json = JSON.stringify(ctx1);
-        if (json.length > MAX_CONTEXT_LENGTH) {
-          json = json.slice(0, MAX_CONTEXT_LENGTH);
-        }
-        record.c = json;
+      let json = JSON.stringify(computedContext);
+      if (json.length > MAX_CONTEXT_LENGTH) {
+        json = json.slice(0, MAX_CONTEXT_LENGTH);
       }
+      record.c = json;
     } catch {
       // Skip context that throws or is non-serializable.
     }
-  }
-
-  const scope = entry.meta?.S;
-  if (typeof scope === 'object' && scope !== null && Object.getPrototypeOf(scope) !== Object.prototype) {
-    record.o = getDebugName(scope);
   }
 
   return `${JSON.stringify(record)}\n`;


### PR DESCRIPTION
## Summary

Centralizes log processing logic across processors by moving context flattening, error stringification, and call-site normalization into lazy-computed getters on a new `LogEntry` class. Raw fields (`level`, `message`, `context`, `meta`, `error`) are preserved so existing consumers continue to work; processors that write to serialized stores now consume the shared computed views instead of duplicating merge logic.

Key changes:

- `LogEntry` becomes a class with raw readonly fields plus lazy getters:
  - `computedContext`: single-level, JSON-safe record. Primitives pass through; non-primitives are stringified one level deep via `JSON.stringify`. Reserved `error`/`err` keys are stripped; scope info gathered from `@logInfo`-decorated members is inlined.
  - `computedError`: stringified error, sourced from `entry.error`, `context` (when `Error`), or `context.error`/`context.err`. Formatted as `.stack` with `.message`/`String(err)` fallback.
  - `computedMeta`: `{ filename, line, context }` — filename normalized via `getRelativeFilename`, `context` is the scope's debug name.
  - `timestamp`: non-lazy unix ms, defaults to `Date.now()`.
- JSDoc added for every field and getter.
- Processors updated to consume the new getters where it makes sense:
  - **Serialized stores**: `FILE_PROCESSOR`, `LogBuffer` (composer logs), `functionLogProcessor` (Cloudflare), `TraceProcessor._logProcessor`, `LoggingServiceImpl.queryLogs`, `devtools/cli log-buffer` formatter.
  - **Display**: `CONSOLE_PROCESSOR`, `BROWSER_PROCESSOR`, `posthog logProcessor` use `computedMeta` for file/line and `computedError` where relevant — `getContextFromEntry` retained for rich Error-preserving context rendering.

closes DX-933

## Test plan

- [x] `moon run log:test log:lint`
- [x] `moon run tracing:test tracing:lint`
- [x] `moon run client-services:test client-services:lint`
- [x] `moon run observability:test observability:lint`
- [x] `moon run functions-runtime-cloudflare:lint`
- [x] `moon run cli:test cli:lint`
- [x] `moon run app-framework:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified log entries to include a precomputed timestamp, normalized context, error string, and metadata so all processors and outputs render consistent file/line/scope, serialized context (including circular refs), and error info.
* **Tests**
  * Updated test helpers and expectations to construct and validate entries using the new precomputed logging model and serialized-context behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->