### PR TITLE
feat(client-services): order system fields first in space archive JSON

### DIFF
--- a/packages/sdk/client-services/src/packlets/space-export/serialized-space-writer.ts
+++ b/packages/sdk/client-services/src/packlets/space-export/serialized-space-writer.ts
@@ -22,12 +22,55 @@ const SERIALIZED_SPACE_VERSION = 1;
 
 const FEED_TYPENAME = 'org.dxos.type.feed';
 
+const ATTR_ID = 'id';
 const ATTR_TYPE = '@type';
 const ATTR_META = '@meta';
 const ATTR_DELETED = '@deleted';
 const ATTR_PARENT = '@parent';
 const ATTR_RELATION_SOURCE = '@relationSource';
 const ATTR_RELATION_TARGET = '@relationTarget';
+
+/**
+ * Canonical order of well-known system fields in a serialized object.
+ * All remaining `@*` fields follow in the order they appear on the source
+ * object, and finally the data fields are appended in their existing order.
+ */
+const SYSTEM_FIELD_ORDER: readonly string[] = [
+  ATTR_ID,
+  ATTR_TYPE,
+  ATTR_META,
+  ATTR_DELETED,
+  ATTR_PARENT,
+  ATTR_RELATION_SOURCE,
+  ATTR_RELATION_TARGET,
+];
+
+/**
+ * Reorder the keys of an {@link Obj.JSON} so that system fields appear first
+ * (`id`, `@type`, `@meta`, then any other `@*` attributes), followed by data
+ * fields. The returned object has identical values to the input — only the key
+ * iteration order changes.
+ */
+export const orderObjJsonFields = (obj: Obj.JSON): Obj.JSON => {
+  const source = obj as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const key of SYSTEM_FIELD_ORDER) {
+    if (key in source) {
+      result[key] = source[key];
+    }
+  }
+  for (const key of Object.keys(source)) {
+    if (key.startsWith('@') && !(key in result)) {
+      result[key] = source[key];
+    }
+  }
+  for (const key of Object.keys(source)) {
+    if (!(key in result)) {
+      result[key] = source[key];
+    }
+  }
+  return result as Obj.JSON;
+};
 
 export type WriteSerializedSpaceArchiveOptions = {
   space: DataSpace;
@@ -106,33 +149,33 @@ const collectObjectsFromDoc = (doc: DatabaseDirectory, out: Obj.JSON[]): void =>
  * `@meta` section so archives produced by this writer can be round-tripped
  * through {@link Obj.fromJSON}.
  */
-const objectStructureToObjJson = (objectId: string, structure: ObjectStructure): Obj.JSON => {
-  const result: Obj.JSON = {
-    ...structure.data,
-    id: objectId,
+export const objectStructureToObjJson = (objectId: string, structure: ObjectStructure): Obj.JSON => {
+  const result: Record<string, unknown> = {
+    [ATTR_ID]: objectId,
     [ATTR_TYPE]: (structure.system?.type?.['/'] ?? '') as any,
   };
 
-  if (structure.system?.deleted) {
-    (result as any)[ATTR_DELETED] = true;
-  }
-  if (structure.system?.parent) {
-    (result as any)[ATTR_PARENT] = structure.system.parent['/'];
-  }
-  if (structure.system?.source) {
-    (result as any)[ATTR_RELATION_SOURCE] = structure.system.source['/'];
-  }
-  if (structure.system?.target) {
-    (result as any)[ATTR_RELATION_TARGET] = structure.system.target['/'];
-  }
   if (structure.meta) {
-    (result as any)[ATTR_META] = {
+    result[ATTR_META] = {
       keys: structure.meta.keys ?? [],
       ...(structure.meta.tags ? { tags: structure.meta.tags } : {}),
     };
   }
+  if (structure.system?.deleted) {
+    result[ATTR_DELETED] = true;
+  }
+  if (structure.system?.parent) {
+    result[ATTR_PARENT] = structure.system.parent['/'];
+  }
+  if (structure.system?.source) {
+    result[ATTR_RELATION_SOURCE] = structure.system.source['/'];
+  }
+  if (structure.system?.target) {
+    result[ATTR_RELATION_TARGET] = structure.system.target['/'];
+  }
+  Object.assign(result, structure.data);
 
-  return result;
+  return result as Obj.JSON;
 };
 
 const exportFeedData = async (space: DataSpace, echoHost: EchoHost, objects: Obj.JSON[]): Promise<SerializedFeed[]> => {
@@ -191,7 +234,9 @@ const collectQueueMessages = async (echoHost: EchoHost, queueDxn: DXN): Promise<
     if (batch.length === 0) {
       break;
     }
-    messages.push(...batch);
+    for (const message of batch) {
+      messages.push(orderObjJsonFields(message));
+    }
     if (!result.nextCursor || result.nextCursor === cursor) {
       break;
     }

--- a/packages/sdk/client-services/src/packlets/space-export/space-archive.test.ts
+++ b/packages/sdk/client-services/src/packlets/space-export/space-archive.test.ts
@@ -17,6 +17,7 @@ import { SpaceArchive } from '@dxos/protocols/proto/dxos/client/services';
 
 import { detectSpaceArchiveFormat } from './archive-format';
 import { buildDatabaseDirectoryFromObjects, readSerializedSpaceArchive } from './serialized-space-reader';
+import { objectStructureToObjJson, orderObjJsonFields } from './serialized-space-writer';
 import { extractSpaceArchive } from './space-archive-reader';
 import { SpaceArchiveWriter } from './space-archive-writer';
 
@@ -376,6 +377,65 @@ describe('SpaceArchive', () => {
       expect(structure.data).toEqual({ title: 'hello' });
       expect(structure.system?.type).toEqual({ '/': 'dxn:type:example.Thing' });
       expect(structure.system?.kind).toBe('object');
+    });
+
+    test('objectStructureToObjJson emits fields in canonical order', () => {
+      const id = ObjectId.random();
+      const sourceId = ObjectId.random();
+      const targetId = ObjectId.random();
+      const parentId = ObjectId.random();
+      const obj = objectStructureToObjJson(id, {
+        data: { title: 'hello', count: 42 },
+        meta: { keys: [] },
+        system: {
+          type: { '/': 'dxn:type:example.Link' },
+          kind: 'relation',
+          source: { '/': sourceId },
+          target: { '/': targetId },
+          parent: { '/': parentId },
+          deleted: true,
+        },
+      });
+
+      expect(Object.keys(obj)).toEqual([
+        'id',
+        '@type',
+        '@meta',
+        '@deleted',
+        '@parent',
+        '@relationSource',
+        '@relationTarget',
+        'title',
+        'count',
+      ]);
+    });
+
+    test('orderObjJsonFields reorders feed queue messages with id/@type/@meta first', () => {
+      const id = ObjectId.random();
+      const message = {
+        payload: { value: 'x' },
+        timestamp: 1000,
+        id,
+        '@meta': { keys: [] },
+        '@type': 'dxn:type:example.Message',
+      } as any;
+
+      const ordered = orderObjJsonFields(message);
+      expect(Object.keys(ordered)).toEqual(['id', '@type', '@meta', 'payload', 'timestamp']);
+      expect(ordered).toEqual(message);
+    });
+
+    test('orderObjJsonFields preserves unknown @-prefixed fields between system and data', () => {
+      const id = ObjectId.random();
+      const obj = {
+        data: 1,
+        '@custom': 'extension',
+        '@type': 'dxn:type:example.Thing',
+        id,
+      } as any;
+
+      const ordered = orderObjJsonFields(obj);
+      expect(Object.keys(ordered)).toEqual(['id', '@type', '@custom', 'data']);
     });
 
     test('buildDatabaseDirectoryFromObjects flags relations', () => {


### PR DESCRIPTION
## Summary
- Serialized space archive now emits object fields in canonical order: `id`, `@type`, `@meta`, other `@*` attributes (`@deleted`, `@parent`, `@relationSource`, `@relationTarget`), then data fields.
- Same ordering is applied to feed queue messages collected via `collectQueueMessages`, so both ECHO objects and feed-object messages share a consistent shape in the JSON output.
- Exported `objectStructureToObjJson` and added `orderObjJsonFields` helper so the ordering rule is reusable and directly testable.

## Test plan
- [x] Added unit tests in `space-archive.test.ts` asserting `Object.keys` order for:
  - `objectStructureToObjJson` with a relation structure containing all system fields + data.
  - `orderObjJsonFields` on a feed queue message with arbitrary key insertion order.
  - `orderObjJsonFields` preserving unknown `@*` keys between system and data fields.
- [x] `moon run client-services:test` — all 23 tests pass.
- [x] `moon run client-services:lint -- --fix` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Exported space objects now serialize with consistent JSON field ordering, with system fields appearing first for improved reliability.

* **Tests**
  * Added test coverage for deterministic JSON field ordering in space exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->