### PR TITLE
refactor(app-framework): rename module activation timing fields for clarity

### DIFF
--- a/packages/plugins/plugin-assistant/src/AssistantPlugin.tsx
+++ b/packages/plugins/plugin-assistant/src/AssistantPlugin.tsx
@@ -160,7 +160,7 @@ export const AssistantPlugin = Plugin.define(meta).pipe(
   AppPlugin.addSettingsModule({ activate: Settings }),
   AppPlugin.addSurfaceModule({
     activate: ReactSurface,
-    activatesBefore: [AppActivationEvents.SetupArtifactDefinition],
+    firesBeforeActivation: [AppActivationEvents.SetupArtifactDefinition],
   }),
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.addModule({
@@ -194,7 +194,7 @@ export const AssistantPlugin = Plugin.define(meta).pipe(
     activate: LocalModelResolver,
   }),
   Plugin.addModule({
-    activatesBefore: [AssistantEvents.SetupAiServiceProviders],
+    firesBeforeActivation: [AssistantEvents.SetupAiServiceProviders],
     // TODO(dmaretskyi): This should activate lazily when the AI chat is used.
     activatesOn: ActivationEvents.Startup,
     activate: AiService,

--- a/packages/plugins/plugin-attention/src/AttentionPlugin.ts
+++ b/packages/plugins/plugin-attention/src/AttentionPlugin.ts
@@ -18,7 +18,7 @@ export const AttentionPlugin = Plugin.define(meta).pipe(
   Plugin.addModule({
     id: 'attention',
     activatesOn: ActivationEvents.Startup,
-    activatesAfter: [AttentionEvents.AttentionReady],
+    firesAfterActivation: [AttentionEvents.AttentionReady],
     activate: () =>
       Effect.gen(function* () {
         const registry = yield* Capability.get(Capabilities.AtomRegistry);

--- a/packages/plugins/plugin-automation/src/AutomationPlugin.tsx
+++ b/packages/plugins/plugin-automation/src/AutomationPlugin.tsx
@@ -22,7 +22,7 @@ export const AutomationPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.addModule({
     activatesOn: ClientEvents.ClientReady,
-    activatesAfter: [AutomationEvents.ComputeRuntimeReady],
+    firesAfterActivation: [AutomationEvents.ComputeRuntimeReady],
     activate: ComputeRuntime,
   }),
   Plugin.make,

--- a/packages/plugins/plugin-automation/src/cli/plugin.ts
+++ b/packages/plugins/plugin-automation/src/cli/plugin.ts
@@ -16,7 +16,7 @@ export const AutomationPlugin = Plugin.define(meta).pipe(
   AppPlugin.addCommandModule({ commands: [trigger] }),
   Plugin.addModule({
     activatesOn: ClientEvents.ClientReady,
-    activatesAfter: [AutomationEvents.ComputeRuntimeReady],
+    firesAfterActivation: [AutomationEvents.ComputeRuntimeReady],
     activate: ComputeRuntime,
   }),
   Plugin.make,

--- a/packages/plugins/plugin-client/src/ClientPlugin.ts
+++ b/packages/plugins/plugin-client/src/ClientPlugin.ts
@@ -33,18 +33,18 @@ export const ClientPlugin = Plugin.define<ClientPluginOptions>(meta).pipe(
     return {
       id: Capability.getModuleTag(Client),
       activatesOn: ActivationEvent.oneOf(ActivationEvents.Startup, AppActivationEvents.SetupAppGraph),
-      activatesAfter: [ClientEvents.ClientReady],
+      firesAfterActivation: [ClientEvents.ClientReady],
       activate: () => Client(options),
     };
   }),
   Plugin.addModule({
     activatesOn: ClientEvents.ClientReady,
-    activatesBefore: [AppActivationEvents.SetupSchema],
+    firesBeforeActivation: [AppActivationEvents.SetupSchema],
     activate: SchemaDefs,
   }),
   Plugin.addModule({
     activatesOn: ClientEvents.ClientReady,
-    activatesBefore: [ClientEvents.SetupMigration],
+    firesBeforeActivation: [ClientEvents.SetupMigration],
     activate: Migrations,
   }),
   Plugin.addModule(

--- a/packages/plugins/plugin-client/src/cli/plugin.ts
+++ b/packages/plugins/plugin-client/src/cli/plugin.ts
@@ -19,12 +19,12 @@ export const ClientPlugin = Plugin.define<ClientPluginOptions>(meta).pipe(
   Plugin.addModule((options) => ({
     id: Capability.getModuleTag(Client),
     activatesOn: ActivationEvents.Startup,
-    activatesAfter: [ClientEvents.ClientReady],
+    firesAfterActivation: [ClientEvents.ClientReady],
     activate: () => Client(options),
   })),
   Plugin.addModule({
     activatesOn: ClientEvents.ClientReady,
-    activatesBefore: [AppActivationEvents.SetupSchema],
+    firesBeforeActivation: [AppActivationEvents.SetupSchema],
     activate: SchemaDefs,
   }),
   Plugin.make,

--- a/packages/plugins/plugin-deck/src/DeckPlugin.ts
+++ b/packages/plugins/plugin-deck/src/DeckPlugin.ts
@@ -35,7 +35,7 @@ export const DeckPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations: [...translations, ...stackTranslations] }),
   Plugin.addModule({
     activatesOn: AppActivationEvents.SetupSettings,
-    activatesAfter: [DeckEvents.SettingsReady],
+    firesAfterActivation: [DeckEvents.SettingsReady],
     activate: DeckSettings,
   }),
   Plugin.addModule({
@@ -47,7 +47,7 @@ export const DeckPlugin = Plugin.define(meta).pipe(
     //   Should this be a different event?
     //   Should settings store be renamed to be more generic?
     activatesOn: ActivationEvent.oneOf(AppActivationEvents.SetupSettings, AppActivationEvents.SetupAppGraph),
-    activatesAfter: [AppActivationEvents.LayoutReady, DeckEvents.StateReady],
+    firesAfterActivation: [AppActivationEvents.LayoutReady, DeckEvents.StateReady],
     activate: DeckState,
   }),
   Plugin.addModule({

--- a/packages/plugins/plugin-discord/src/DiscordPlugin.tsx
+++ b/packages/plugins/plugin-discord/src/DiscordPlugin.tsx
@@ -46,7 +46,7 @@ export const DiscordPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.addModule({
     activatesOn: AppActivationEvents.SetupSettings,
-    activatesAfter: [DiscordEvents.SettingsReady],
+    firesAfterActivation: [DiscordEvents.SettingsReady],
     activate: DiscordSettings,
   }),
   Plugin.make,

--- a/packages/plugins/plugin-files/src/FilesPlugin.tsx
+++ b/packages/plugins/plugin-files/src/FilesPlugin.tsx
@@ -22,7 +22,7 @@ const SettingsReady = AppActivationEvents.createSettingsEvent(FileCapabilities.S
 export const FilesPlugin = Plugin.define(meta).pipe(
   AppPlugin.addAppGraphModule({ activate: AppGraphBuilder }),
   AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
-  AppPlugin.addSettingsModule({ activate: FileSettings, activatesAfter: [SettingsReady] }),
+  AppPlugin.addSettingsModule({ activate: FileSettings, firesAfterActivation: [SettingsReady] }),
   AppPlugin.addSurfaceModule({ activate: ReactSurface }),
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.addModule({

--- a/packages/plugins/plugin-graph/src/GraphPlugin.ts
+++ b/packages/plugins/plugin-graph/src/GraphPlugin.ts
@@ -17,8 +17,8 @@ const Graph = Capability.lazy('Graph', () => import('./graph'));
 export const GraphPlugin = Plugin.define(meta).pipe(
   Plugin.addModule({
     activatesOn: ActivationEvents.Startup,
-    activatesBefore: [AppActivationEvents.SetupAppGraph, AppActivationEvents.SetupMetadata],
-    activatesAfter: [AppActivationEvents.AppGraphReady],
+    firesBeforeActivation: [AppActivationEvents.SetupAppGraph, AppActivationEvents.SetupMetadata],
+    firesAfterActivation: [AppActivationEvents.AppGraphReady],
     activate: Graph,
   }),
   Plugin.make,

--- a/packages/plugins/plugin-inbox/src/InboxPlugin.tsx
+++ b/packages/plugins/plugin-inbox/src/InboxPlugin.tsx
@@ -121,7 +121,7 @@ export const InboxPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.addModule({
     activatesOn: AppActivationEvents.SetupSettings,
-    activatesAfter: [InboxEvents.SettingsReady],
+    firesAfterActivation: [InboxEvents.SettingsReady],
     activate: InboxSettings,
   }),
   Plugin.addModule({

--- a/packages/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -76,7 +76,7 @@ export const MarkdownPlugin = Plugin.define(meta).pipe(
   AppPlugin.addSchemaModule({ schema: [Markdown.Document, Text.Text] }),
   AppPlugin.addSurfaceModule({
     activate: ReactSurface,
-    activatesBefore: [MarkdownEvents.SetupExtensions],
+    firesBeforeActivation: [MarkdownEvents.SetupExtensions],
   }),
   AppPlugin.addTranslationsModule({ translations: [...translations, ...editorTranslations] }),
   Plugin.addModule({

--- a/packages/plugins/plugin-meeting/src/MeetingPlugin.ts
+++ b/packages/plugins/plugin-meeting/src/MeetingPlugin.ts
@@ -42,7 +42,7 @@ export const MeetingPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.addModule({
     activatesOn: AppActivationEvents.SetupSettings,
-    activatesAfter: [SettingsReady],
+    firesAfterActivation: [SettingsReady],
     activate: MeetingSettings,
   }),
   Plugin.addModule({
@@ -50,7 +50,7 @@ export const MeetingPlugin = Plugin.define(meta).pipe(
     //   Should this be a different event?
     //   Should settings store be renamed to be more generic?
     activatesOn: ActivationEvent.oneOf(AppActivationEvents.SetupSettings, AppActivationEvents.SetupAppGraph),
-    activatesAfter: [StateReady],
+    firesAfterActivation: [StateReady],
     activate: MeetingState,
   }),
   Plugin.addModule({

--- a/packages/plugins/plugin-native-filesystem/src/NativeFilesystemPlugin.tsx
+++ b/packages/plugins/plugin-native-filesystem/src/NativeFilesystemPlugin.tsx
@@ -29,7 +29,7 @@ export const NativeFilesystemPlugin = Plugin.define(meta).pipe(
   Plugin.addModule({
     id: 'state',
     activatesOn: ClientEvents.ClientReady,
-    activatesAfter: [StateReady],
+    firesAfterActivation: [StateReady],
     activate: State,
   }),
   Plugin.addModule({

--- a/packages/plugins/plugin-navtree/src/NavTreePlugin.tsx
+++ b/packages/plugins/plugin-navtree/src/NavTreePlugin.tsx
@@ -41,7 +41,7 @@ export const NavTreePlugin = Plugin.define(meta).pipe(
   Plugin.addModule({
     id: 'state',
     activatesOn: AppActivationEvents.LayoutReady,
-    activatesAfter: [NavTreeEvents.StateReady],
+    firesAfterActivation: [NavTreeEvents.StateReady],
     activate: State,
   }),
   Plugin.addModule({

--- a/packages/plugins/plugin-observability/src/ObservabilityPlugin.ts
+++ b/packages/plugins/plugin-observability/src/ObservabilityPlugin.ts
@@ -47,7 +47,7 @@ export const ObservabilityPlugin = Plugin.define<ObservabilityPluginOptions>(met
   Plugin.addModule(({ namespace }) => ({
     id: Capability.getModuleTag(ObservabilityState),
     activatesOn: ActivationEvents.Startup,
-    activatesAfter: [ObservabilityEvents.StateReady],
+    firesAfterActivation: [ObservabilityEvents.StateReady],
     activate: () => ObservabilityState({ namespace }),
   })),
   Plugin.addModule(({ namespace }) => ({

--- a/packages/plugins/plugin-simple-layout/src/SimpleLayoutPlugin.ts
+++ b/packages/plugins/plugin-simple-layout/src/SimpleLayoutPlugin.ts
@@ -31,7 +31,7 @@ export const SimpleLayoutPlugin = Plugin.define<SimpleLayoutPluginOptions>(meta)
   Plugin.addModule(({ isPopover = false }) => ({
     id: Capability.getModuleTag(State),
     activatesOn: ActivationEvents.Startup,
-    activatesAfter: [SimpleLayoutEvents.StateReady, AppActivationEvents.LayoutReady],
+    firesAfterActivation: [SimpleLayoutEvents.StateReady, AppActivationEvents.LayoutReady],
     activate: () => State({ initialState: { isPopover } }),
   })),
   Plugin.addModule(({ isPopover = false }) => ({

--- a/packages/plugins/plugin-simple-layout/src/components/SimpleLayout/SimpleLayout.stories.tsx
+++ b/packages/plugins/plugin-simple-layout/src/components/SimpleLayout/SimpleLayout.stories.tsx
@@ -45,7 +45,7 @@ const createPluginManager = ({ isPopover }: { isPopover?: boolean }) => {
         Plugin.addModule(({ isPopover = false }) => ({
           id: Capability.getModuleTag(State),
           activatesOn: ActivationEvents.Startup,
-          activatesAfter: [SimpleLayoutEvents.StateReady, AppActivationEvents.LayoutReady],
+          firesAfterActivation: [SimpleLayoutEvents.StateReady, AppActivationEvents.LayoutReady],
           activate: () => State({ initialState: { isPopover } }),
         })),
         Plugin.addModule({

--- a/packages/plugins/plugin-space/src/SpacePlugin.ts
+++ b/packages/plugins/plugin-space/src/SpacePlugin.ts
@@ -182,7 +182,7 @@ export const SpacePlugin = Plugin.define<SpacePluginOptions>(meta).pipe(
     //   Should this be a different event?
     //   Should settings store be renamed to be more generic?
     activatesOn: ActivationEvent.oneOf(AppActivationEvents.SetupSettings, AppActivationEvents.SetupAppGraph),
-    activatesAfter: [SpaceEvents.StateReady],
+    firesAfterActivation: [SpaceEvents.StateReady],
     activate: SpaceState,
   }),
   Plugin.addModule(
@@ -201,7 +201,7 @@ export const SpacePlugin = Plugin.define<SpacePluginOptions>(meta).pipe(
         id: Capability.getModuleTag(ReactSurface),
         activatesOn: ActivationEvents.SetupReactSurface,
         // TODO(wittjosiah): Should occur before the settings dialog is loaded when surfaces activation is more granular.
-        activatesBefore: [SpaceEvents.SetupSettingsPanel],
+        firesBeforeActivation: [SpaceEvents.SetupSettingsPanel],
         activate: () => ReactSurface({ createInvitationUrl }),
       };
     },
@@ -240,7 +240,7 @@ export const SpacePlugin = Plugin.define<SpacePluginOptions>(meta).pipe(
   }),
   Plugin.addModule({
     activatesOn: ClientEvents.IdentityCreated,
-    activatesAfter: [SpaceEvents.PersonalSpaceReady],
+    firesAfterActivation: [SpaceEvents.PersonalSpaceReady],
     activate: IdentityCreated,
   }),
   Plugin.addModule({

--- a/packages/plugins/plugin-space/src/cli/plugin.ts
+++ b/packages/plugins/plugin-space/src/cli/plugin.ts
@@ -92,7 +92,7 @@ export const SpacePlugin = Plugin.define<SpacePluginOptions>(meta).pipe(
   ),
   Plugin.addModule({
     activatesOn: ClientEvents.IdentityCreated,
-    activatesAfter: [SpaceEvents.PersonalSpaceReady],
+    firesAfterActivation: [SpaceEvents.PersonalSpaceReady],
     activate: IdentityCreated,
   }),
   Plugin.make,

--- a/packages/plugins/plugin-spotlight/src/SpotlightPlugin.ts
+++ b/packages/plugins/plugin-spotlight/src/SpotlightPlugin.ts
@@ -17,7 +17,7 @@ export const SpotlightPlugin = Plugin.define(meta).pipe(
   Plugin.addModule({
     id: Capability.getModuleTag(State),
     activatesOn: ActivationEvents.Startup,
-    activatesAfter: [SpotlightEvents.StateReady, AppActivationEvents.LayoutReady],
+    firesAfterActivation: [SpotlightEvents.StateReady, AppActivationEvents.LayoutReady],
     activate: State,
   }),
   Plugin.addModule({

--- a/packages/plugins/plugin-testing/src/StorybookPlugin.ts
+++ b/packages/plugins/plugin-testing/src/StorybookPlugin.ts
@@ -32,7 +32,7 @@ export const StorybookPlugin = Plugin.define<StorybookPluginOptions>(meta).pipe(
   Plugin.addModule(({ initialState }) => ({
     id: Capability.getModuleTag(State),
     activatesOn: ActivationEvents.Startup,
-    activatesAfter: [AppActivationEvents.LayoutReady],
+    firesAfterActivation: [AppActivationEvents.LayoutReady],
     activate: () => State({ initialState }),
   })),
   Plugin.make,

--- a/packages/plugins/plugin-theme/src/ThemePlugin.ts
+++ b/packages/plugins/plugin-theme/src/ThemePlugin.ts
@@ -15,7 +15,7 @@ export const ThemePlugin = Plugin.define<ThemePluginOptions>(meta).pipe(
   Plugin.addModule((options: ThemePluginOptions) => ({
     id: Capability.getModuleTag(ReactContext),
     activatesOn: ActivationEvents.Startup,
-    activatesBefore: [AppActivationEvents.SetupTranslations],
+    firesBeforeActivation: [AppActivationEvents.SetupTranslations],
     activate: () => ReactContext(options),
   })),
   Plugin.make,

--- a/packages/sdk/app-framework/src/core/plugin-manager.test.ts
+++ b/packages/sdk/app-framework/src/core/plugin-manager.test.ts
@@ -572,7 +572,7 @@ describe('PluginManager', () => {
         Plugin.addModule({
           id: 'Count',
           activatesOn: ActivationEvents.Startup,
-          activatesBefore: [CountEvent],
+          firesBeforeActivation: [CountEvent],
           activate: Effect.fnUntraced(function* () {
             const capabilityManager = yield* Capability.Service;
             computeTotal(capabilityManager);

--- a/packages/sdk/app-framework/src/core/plugin-manager.ts
+++ b/packages/sdk/app-framework/src/core/plugin-manager.ts
@@ -645,7 +645,7 @@ class ManagerImpl implements PluginManager {
   ): ActivationEvent.ActivationEvent[] {
     return Function.pipe(
       modules,
-      Array.flatMap((module) => module.activatesBefore ?? []),
+      Array.flatMap((module) => module.firesBeforeActivation ?? []),
       HashSet.fromIterable,
       HashSet.toValues,
       Array.filter((event) => !activatingEvents.includes(ActivationEvent.eventKey(event))),
@@ -658,7 +658,7 @@ class ManagerImpl implements PluginManager {
   ): ActivationEvent.ActivationEvent[] {
     return Function.pipe(
       modules,
-      Array.flatMap((module) => module.activatesAfter ?? []),
+      Array.flatMap((module) => module.firesAfterActivation ?? []),
       HashSet.fromIterable,
       HashSet.toValues,
       Array.filter((event) => !activatingEvents.includes(ActivationEvent.eventKey(event))),
@@ -670,7 +670,7 @@ class ManagerImpl implements PluginManager {
     events: ActivationEvent.ActivationEvent[],
     phase: 'before' | 'after',
   ): Effect.Effect<void, Error> {
-    const logLabel = phase === 'before' ? 'activatesBefore' : 'activatesAfter';
+    const logLabel = phase === 'before' ? 'firesBeforeActivation' : 'firesAfterActivation';
     const eventKey = phase === 'before' ? 'beforeEvents' : 'afterEvents';
     return Function.pipe(
       events,

--- a/packages/sdk/app-framework/src/core/plugin.ts
+++ b/packages/sdk/app-framework/src/core/plugin.ts
@@ -89,16 +89,33 @@ export interface PluginModule {
   activatesOn: ActivationEvent.Events;
 
   /**
-   * Events which the plugin depends on being activated.
-   * Plugin is marked as needing reset a plugin activated by a dependent event is removed.
-   * Events are automatically activated before activation of the plugin.
+   * Events that this module fires *before* its own activation runs.
+   *
+   * When this module is asked to activate (via {@link activatesOn}), the
+   * plugin manager first activates every event listed here, ensuring any
+   * other modules that contribute to those events have completed before
+   * this module's {@link activate} body executes. These events are fired
+   * by the framework on this module's behalf — the module does not need
+   * to wait for some other code to fire them.
+   *
+   * The module is marked as needing reset if a module activated by one
+   * of these events is later removed.
+   *
+   * Read as: "this module fires these events before [its] activation".
    */
-  activatesBefore?: ActivationEvent.ActivationEvent[];
+  firesBeforeActivation?: ActivationEvent.ActivationEvent[];
 
   /**
-   * Events which this plugin triggers upon activation.
+   * Events that this module fires *after* its own activation completes.
+   *
+   * Once this module's {@link activate} body has finished executing, the
+   * plugin manager activates every event listed here, causing any modules
+   * listening on those events to run. These events are fired by the
+   * framework on this module's behalf as part of this module's lifecycle.
+   *
+   * Read as: "this module fires these events after [its] activation".
    */
-  activatesAfter?: ActivationEvent.ActivationEvent[];
+  firesAfterActivation?: ActivationEvent.ActivationEvent[];
 
   /**
    * Called when the module is activated.
@@ -116,15 +133,15 @@ class PluginModuleImpl implements PluginModule {
   readonly [PluginModuleTypeId]: PluginModuleTypeId = PluginModuleTypeId;
   readonly id: PluginModule['id'];
   readonly activatesOn: PluginModule['activatesOn'];
-  readonly activatesBefore?: PluginModule['activatesBefore'];
-  readonly activatesAfter?: PluginModule['activatesAfter'];
+  readonly firesBeforeActivation?: PluginModule['firesBeforeActivation'];
+  readonly firesAfterActivation?: PluginModule['firesAfterActivation'];
   readonly activate: PluginModule['activate'];
 
   constructor(options: Omit<PluginModule, typeof PluginModuleTypeId>) {
     this.id = options.id;
     this.activatesOn = options.activatesOn;
-    this.activatesBefore = options.activatesBefore;
-    this.activatesAfter = options.activatesAfter;
+    this.firesBeforeActivation = options.firesBeforeActivation;
+    this.firesAfterActivation = options.firesAfterActivation;
     this.activate = options.activate;
   }
 }

--- a/packages/sdk/app-framework/src/plugin-operation/OperationPlugin.ts
+++ b/packages/sdk/app-framework/src/plugin-operation/OperationPlugin.ts
@@ -12,8 +12,8 @@ const HistoryCapabilities = Capability.lazy('HistoryCapabilities', () => import(
 export const OperationPlugin = Plugin.define(meta).pipe(
   Plugin.addModule({
     activatesOn: ActivationEvents.ManagedRuntimeReady,
-    activatesBefore: [ActivationEvents.SetupOperationHandler],
-    activatesAfter: [ActivationEvents.OperationInvokerReady],
+    firesBeforeActivation: [ActivationEvents.SetupOperationHandler],
+    firesAfterActivation: [ActivationEvents.OperationInvokerReady],
     activate: OperationInvoker,
   }),
   Plugin.addModule({

--- a/packages/sdk/app-framework/src/plugin-runtime/RuntimePlugin.ts
+++ b/packages/sdk/app-framework/src/plugin-runtime/RuntimePlugin.ts
@@ -11,8 +11,8 @@ const ManagedRuntimeCapability = Capability.lazy('ManagedRuntime', () => import(
 export const RuntimePlugin = Plugin.define(meta).pipe(
   Plugin.addModule({
     activatesOn: ActivationEvents.Startup,
-    activatesBefore: [ActivationEvents.SetupLayer],
-    activatesAfter: [ActivationEvents.ManagedRuntimeReady],
+    firesBeforeActivation: [ActivationEvents.SetupLayer],
+    firesAfterActivation: [ActivationEvents.ManagedRuntimeReady],
     activate: ManagedRuntimeCapability,
   }),
   Plugin.make,

--- a/packages/sdk/app-toolkit/src/plugin.ts
+++ b/packages/sdk/app-toolkit/src/plugin.ts
@@ -13,7 +13,7 @@ import { AppCapabilities } from './capabilities';
 import { type Resource } from './translations';
 
 type PluginModuleOptions = Partial<
-  Pick<Plugin$.PluginModuleOptions, 'id' | 'activatesOn' | 'activatesBefore' | 'activatesAfter'>
+  Pick<Plugin$.PluginModuleOptions, 'id' | 'activatesOn' | 'firesBeforeActivation' | 'firesAfterActivation'>
 > &
   Pick<Plugin$.PluginModuleOptions, 'activate'>;
 
@@ -32,8 +32,8 @@ export namespace AppPlugin {
     return Plugin$.addModule({
       id: Capability$.getModuleTag(options.activate) ?? options.id ?? 'app-graph-builder',
       activatesOn: options.activatesOn ?? AppActivationEvents.SetupAppGraph,
-      activatesBefore: options.activatesBefore,
-      activatesAfter: options.activatesAfter,
+      firesBeforeActivation: options.firesBeforeActivation,
+      firesAfterActivation: options.firesAfterActivation,
       activate: options.activate,
     });
   }
@@ -51,8 +51,8 @@ export namespace AppPlugin {
     return Plugin$.addModule({
       id: options?.id ?? 'translations',
       activatesOn: options?.activatesOn ?? AppActivationEvents.SetupTranslations,
-      activatesBefore: options?.activatesBefore,
-      activatesAfter: options?.activatesAfter,
+      firesBeforeActivation: options?.firesBeforeActivation,
+      firesAfterActivation: options?.firesAfterActivation,
       activate: Effect.fnUntraced(function* () {
         return Capability$.contributes(
           AppCapabilities.Translations,
@@ -75,8 +75,8 @@ export namespace AppPlugin {
     return Plugin$.addModule({
       id: options.id ?? 'metadata',
       activatesOn: options.activatesOn ?? AppActivationEvents.SetupMetadata,
-      activatesBefore: options.activatesBefore,
-      activatesAfter: options.activatesAfter,
+      firesBeforeActivation: options.firesBeforeActivation,
+      firesAfterActivation: options.firesAfterActivation,
       activate: Effect.fnUntraced(function* () {
         return (Array.isArray(options.metadata) ? options.metadata : [options.metadata]).map((m) =>
           Capability$.contributes(AppCapabilities.Metadata, m),
@@ -96,8 +96,8 @@ export namespace AppPlugin {
     return Plugin$.addModule({
       id: Capability$.getModuleTag(options.activate) ?? options.id ?? 'settings',
       activatesOn: options.activatesOn ?? AppActivationEvents.SetupSettings,
-      activatesBefore: options.activatesBefore,
-      activatesAfter: options.activatesAfter,
+      firesBeforeActivation: options.firesBeforeActivation,
+      firesAfterActivation: options.firesAfterActivation,
       activate: options.activate,
     });
   }
@@ -113,8 +113,8 @@ export namespace AppPlugin {
     return Plugin$.addModule({
       id: Capability$.getModuleTag(options.activate) ?? options.id ?? 'blueprint-definition',
       activatesOn: options.activatesOn ?? AppActivationEvents.SetupArtifactDefinition,
-      activatesBefore: options.activatesBefore,
-      activatesAfter: options.activatesAfter,
+      firesBeforeActivation: options.firesBeforeActivation,
+      firesAfterActivation: options.firesAfterActivation,
       activate: options.activate,
     });
   }
@@ -132,8 +132,8 @@ export namespace AppPlugin {
     return Plugin$.addModule({
       id: options.id ?? 'schema',
       activatesOn: options.activatesOn ?? AppActivationEvents.SetupSchema,
-      activatesBefore: options.activatesBefore,
-      activatesAfter: options.activatesAfter,
+      firesBeforeActivation: options.firesBeforeActivation,
+      firesAfterActivation: options.firesAfterActivation,
       activate: Effect.fnUntraced(function* () {
         return Capability$.contributes(AppCapabilities.Schema, options.schema);
       }),
@@ -153,8 +153,8 @@ export namespace AppPlugin {
     return Plugin$.addModule({
       id: options.id ?? 'cli-commands',
       activatesOn: options.activatesOn ?? ActivationEvents.Startup,
-      activatesBefore: options.activatesBefore,
-      activatesAfter: options.activatesAfter,
+      firesBeforeActivation: options.firesBeforeActivation,
+      firesAfterActivation: options.firesAfterActivation,
       activate: Effect.fnUntraced(function* () {
         return options.commands.map((cmd) => Capability$.contributes(Capabilities.Command, cmd));
       }),
@@ -172,8 +172,8 @@ export namespace AppPlugin {
     return Plugin$.addModule({
       id: Capability$.getModuleTag(options.activate) ?? options.id ?? 'operation-handler',
       activatesOn: options.activatesOn ?? ActivationEvents.SetupOperationHandler,
-      activatesBefore: options.activatesBefore,
-      activatesAfter: options.activatesAfter,
+      firesBeforeActivation: options.firesBeforeActivation,
+      firesAfterActivation: options.firesAfterActivation,
       activate: options.activate,
     });
   }
@@ -189,8 +189,8 @@ export namespace AppPlugin {
     return Plugin$.addModule({
       id: Capability$.getModuleTag(options.activate) ?? options.id ?? 'react-context',
       activatesOn: options.activatesOn ?? ActivationEvents.Startup,
-      activatesBefore: options.activatesBefore,
-      activatesAfter: options.activatesAfter,
+      firesBeforeActivation: options.firesBeforeActivation,
+      firesAfterActivation: options.firesAfterActivation,
       activate: options.activate,
     });
   }
@@ -206,8 +206,8 @@ export namespace AppPlugin {
     return Plugin$.addModule({
       id: Capability$.getModuleTag(options.activate) ?? options.id ?? 'react-root',
       activatesOn: options.activatesOn ?? ActivationEvents.Startup,
-      activatesBefore: options.activatesBefore,
-      activatesAfter: options.activatesAfter,
+      firesBeforeActivation: options.firesBeforeActivation,
+      firesAfterActivation: options.firesAfterActivation,
       activate: options.activate,
     });
   }
@@ -223,8 +223,8 @@ export namespace AppPlugin {
     return Plugin$.addModule({
       id: Capability$.getModuleTag(options.activate) ?? options.id ?? 'navigation-resolver',
       activatesOn: options.activatesOn ?? ActivationEvents.OperationInvokerReady,
-      activatesBefore: options.activatesBefore,
-      activatesAfter: options.activatesAfter,
+      firesBeforeActivation: options.firesBeforeActivation,
+      firesAfterActivation: options.firesAfterActivation,
       activate: options.activate,
     });
   }
@@ -245,8 +245,8 @@ export namespace AppPlugin {
         return {
           id: Capability$.getModuleTag(resolved.activate) ?? resolved.id ?? 'navigation-handler',
           activatesOn: resolved.activatesOn ?? ActivationEvents.OperationInvokerReady,
-          activatesBefore: resolved.activatesBefore,
-          activatesAfter: resolved.activatesAfter,
+          firesBeforeActivation: resolved.firesBeforeActivation,
+          firesAfterActivation: resolved.firesAfterActivation,
           activate: resolved.activate,
         };
       });
@@ -254,8 +254,8 @@ export namespace AppPlugin {
     return Plugin$.addModule({
       id: Capability$.getModuleTag(options.activate) ?? options.id ?? 'navigation-handler',
       activatesOn: options.activatesOn ?? ActivationEvents.OperationInvokerReady,
-      activatesBefore: options.activatesBefore,
-      activatesAfter: options.activatesAfter,
+      firesBeforeActivation: options.firesBeforeActivation,
+      firesAfterActivation: options.firesAfterActivation,
       activate: options.activate,
     });
   }
@@ -271,8 +271,8 @@ export namespace AppPlugin {
     return Plugin$.addModule({
       id: Capability$.getModuleTag(options.activate) ?? options.id ?? 'surfaces',
       activatesOn: options.activatesOn ?? ActivationEvents.SetupReactSurface,
-      activatesBefore: options.activatesBefore,
-      activatesAfter: options.activatesAfter,
+      firesBeforeActivation: options.firesBeforeActivation,
+      firesAfterActivation: options.firesAfterActivation,
       activate: options.activate,
     });
   }


### PR DESCRIPTION
## Summary

Renames the two confusingly-named lifecycle fields on `PluginModule`:

- `activatesBefore` → `firesBeforeActivation`
- `activatesAfter` → `firesAfterActivation`

## Why

Both human and agent readers consistently misinterpret `activatesBefore`/`activatesAfter`. The names leave the subject ambiguous — "activates before [what]?" — and don't communicate the most important property of the API: that the framework *actively* fires those events on the module's behalf as part of its activation, rather than the module passively waiting on them.

The new names force the module as the subject ("the module *fires* these events *before/after* [its own] *activation*") and put the framework's firing behavior right in the field name. JSDoc on the interface is rewritten to spell out the lifecycle contract — what the framework guarantees, when it acts, and how the field interacts with `activatesOn` and `activate`.

## Scope

Mechanical rename across 29 files: the interface in `@dxos/app-framework`, the `PluginManager` implementation, the `@dxos/app-toolkit` helper functions that pass these fields through, and every plugin module call site.

## Test plan

- [ ] CI Check workflow passes (build + tests)
- [ ] No remaining `activatesBefore`/`activatesAfter` references in the repo
- [ ] App still boots and plugin activation lifecycle behaves identically (no semantic change, only renames)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Plugin module activation ordering configuration fields renamed from `activatesBefore`/`activatesAfter` to `firesBeforeActivation`/`firesAfterActivation` across all plugins and core framework. This is a breaking API change affecting custom plugin implementations.

* **Tests**
  * Updated test fixtures for new plugin module configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->