### PR TITLE
test: add plugin smoke tests across packages/plugins

### DIFF
--- a/packages/plugins/plugin-attention/moon.yml
+++ b/packages/plugins/plugin-attention/moon.yml
@@ -2,6 +2,7 @@ layer: library
 language: typescript
 tags:
   - ts-build
+  - ts-test
   - pack
 tasks:
   compile:

--- a/packages/plugins/plugin-attention/src/AttentionPlugin.test.ts
+++ b/packages/plugins/plugin-attention/src/AttentionPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { AttentionPlugin } from './AttentionPlugin';
+
+describe('AttentionPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(AttentionPlugin.meta).toBeDefined();
+    expect(AttentionPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-attention/vitest.config.ts
+++ b/packages/plugins/plugin-attention/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/packages/plugins/plugin-automation/src/AutomationPlugin.test.ts
+++ b/packages/plugins/plugin-automation/src/AutomationPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { AutomationPlugin } from './AutomationPlugin';
+
+describe('AutomationPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(AutomationPlugin.meta).toBeDefined();
+    expect(AutomationPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-board/src/BoardPlugin.test.ts
+++ b/packages/plugins/plugin-board/src/BoardPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { BoardPlugin } from './BoardPlugin';
+
+describe('BoardPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(BoardPlugin.meta).toBeDefined();
+    expect(BoardPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-client/src/ClientPlugin.test.ts
+++ b/packages/plugins/plugin-client/src/ClientPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { ClientPlugin } from './ClientPlugin';
+
+describe('ClientPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(ClientPlugin.meta).toBeDefined();
+    expect(ClientPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-conductor/src/ConductorPlugin.test.ts
+++ b/packages/plugins/plugin-conductor/src/ConductorPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { ConductorPlugin } from './ConductorPlugin';
+
+describe('ConductorPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(ConductorPlugin.meta).toBeDefined();
+    expect(ConductorPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-debug/src/DebugPlugin.test.ts
+++ b/packages/plugins/plugin-debug/src/DebugPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { DebugPlugin } from './DebugPlugin';
+
+describe('DebugPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(DebugPlugin.meta).toBeDefined();
+    expect(DebugPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-discord/src/DiscordPlugin.test.ts
+++ b/packages/plugins/plugin-discord/src/DiscordPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { DiscordPlugin } from './DiscordPlugin';
+
+describe('DiscordPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(DiscordPlugin.meta).toBeDefined();
+    expect(DiscordPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-excalidraw/src/SketchPlugin.test.ts
+++ b/packages/plugins/plugin-excalidraw/src/SketchPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { ExcalidrawPlugin } from './SketchPlugin';
+
+describe('ExcalidrawPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(ExcalidrawPlugin.meta).toBeDefined();
+    expect(ExcalidrawPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-explorer/src/ExplorerPlugin.test.ts
+++ b/packages/plugins/plugin-explorer/src/ExplorerPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { ExplorerPlugin } from './ExplorerPlugin';
+
+describe('ExplorerPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(ExplorerPlugin.meta).toBeDefined();
+    expect(ExplorerPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-feed/src/FeedPlugin.test.ts
+++ b/packages/plugins/plugin-feed/src/FeedPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { FeedPlugin } from './FeedPlugin';
+
+describe('FeedPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(FeedPlugin.meta).toBeDefined();
+    expect(FeedPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-files/moon.yml
+++ b/packages/plugins/plugin-files/moon.yml
@@ -2,6 +2,7 @@ layer: library
 language: typescript
 tags:
   - ts-build
+  - ts-test
   - pack
 tasks:
   compile:

--- a/packages/plugins/plugin-files/src/FilesPlugin.test.ts
+++ b/packages/plugins/plugin-files/src/FilesPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { FilesPlugin } from './FilesPlugin';
+
+describe('FilesPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(FilesPlugin.meta).toBeDefined();
+    expect(FilesPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-files/vitest.config.ts
+++ b/packages/plugins/plugin-files/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/packages/plugins/plugin-graph/moon.yml
+++ b/packages/plugins/plugin-graph/moon.yml
@@ -2,6 +2,7 @@ layer: library
 language: typescript
 tags:
   - ts-build
+  - ts-test
   - pack
 tasks:
   compile:

--- a/packages/plugins/plugin-graph/src/GraphPlugin.test.ts
+++ b/packages/plugins/plugin-graph/src/GraphPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { GraphPlugin } from './GraphPlugin';
+
+describe('GraphPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(GraphPlugin.meta).toBeDefined();
+    expect(GraphPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-graph/vitest.config.ts
+++ b/packages/plugins/plugin-graph/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/packages/plugins/plugin-help/src/HelpPlugin.test.ts
+++ b/packages/plugins/plugin-help/src/HelpPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { HelpPlugin } from './HelpPlugin';
+
+describe('HelpPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(HelpPlugin.meta).toBeDefined();
+    expect(HelpPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-inbox/src/InboxPlugin.test.ts
+++ b/packages/plugins/plugin-inbox/src/InboxPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { InboxPlugin } from './InboxPlugin';
+
+describe('InboxPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(InboxPlugin.meta).toBeDefined();
+    expect(InboxPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-iroh-beacon/moon.yml
+++ b/packages/plugins/plugin-iroh-beacon/moon.yml
@@ -2,6 +2,7 @@ layer: library
 language: typescript
 tags:
   - ts-build
+  - ts-test
 tasks:
   compile:
     args:

--- a/packages/plugins/plugin-iroh-beacon/src/IrohBeaconPlugin.test.ts
+++ b/packages/plugins/plugin-iroh-beacon/src/IrohBeaconPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { IrohBeaconPlugin } from './IrohBeaconPlugin';
+
+describe('IrohBeaconPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(IrohBeaconPlugin.meta).toBeDefined();
+    expect(IrohBeaconPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-iroh-beacon/vitest.config.ts
+++ b/packages/plugins/plugin-iroh-beacon/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/packages/plugins/plugin-map-solid/moon.yml
+++ b/packages/plugins/plugin-map-solid/moon.yml
@@ -2,6 +2,7 @@ layer: library
 language: typescript
 tags:
   - ts-build
+  - ts-test
   - pack
 tasks:
   compile:

--- a/packages/plugins/plugin-map-solid/src/MapPlugin.test.ts
+++ b/packages/plugins/plugin-map-solid/src/MapPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { MapPlugin } from './MapPlugin';
+
+describe('MapPlugin (solid)', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(MapPlugin.meta).toBeDefined();
+    expect(MapPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-map-solid/vitest.config.ts
+++ b/packages/plugins/plugin-map-solid/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/packages/plugins/plugin-markdown/src/MarkdownPlugin.test.ts
+++ b/packages/plugins/plugin-markdown/src/MarkdownPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { MarkdownPlugin } from './MarkdownPlugin';
+
+describe('MarkdownPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(MarkdownPlugin.meta).toBeDefined();
+    expect(MarkdownPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-masonry/src/MasonryPlugin.test.ts
+++ b/packages/plugins/plugin-masonry/src/MasonryPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { MasonryPlugin } from './MasonryPlugin';
+
+describe('MasonryPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(MasonryPlugin.meta).toBeDefined();
+    expect(MasonryPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-meeting/src/MeetingPlugin.test.ts
+++ b/packages/plugins/plugin-meeting/src/MeetingPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { MeetingPlugin } from './MeetingPlugin';
+
+describe('MeetingPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(MeetingPlugin.meta).toBeDefined();
+    expect(MeetingPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-mermaid/moon.yml
+++ b/packages/plugins/plugin-mermaid/moon.yml
@@ -2,6 +2,7 @@ layer: library
 language: typescript
 tags:
   - ts-build
+  - ts-test
   - pack
   - storybook
   - ts-test-storybook

--- a/packages/plugins/plugin-mermaid/src/MermaidPlugin.test.ts
+++ b/packages/plugins/plugin-mermaid/src/MermaidPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { MermaidPlugin } from './MermaidPlugin';
+
+describe('MermaidPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(MermaidPlugin.meta).toBeDefined();
+    expect(MermaidPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-native-filesystem/src/NativeFilesystemPlugin.test.ts
+++ b/packages/plugins/plugin-native-filesystem/src/NativeFilesystemPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { NativeFilesystemPlugin } from './NativeFilesystemPlugin';
+
+describe('NativeFilesystemPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(NativeFilesystemPlugin.meta).toBeDefined();
+    expect(NativeFilesystemPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-navtree/src/NavTreePlugin.test.ts
+++ b/packages/plugins/plugin-navtree/src/NavTreePlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { NavTreePlugin } from './NavTreePlugin';
+
+describe('NavTreePlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(NavTreePlugin.meta).toBeDefined();
+    expect(NavTreePlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-observability/src/ObservabilityPlugin.test.ts
+++ b/packages/plugins/plugin-observability/src/ObservabilityPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { ObservabilityPlugin } from './ObservabilityPlugin';
+
+describe('ObservabilityPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(ObservabilityPlugin.meta).toBeDefined();
+    expect(ObservabilityPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-outliner/src/OutlinerPlugin.test.ts
+++ b/packages/plugins/plugin-outliner/src/OutlinerPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { OutlinerPlugin } from './OutlinerPlugin';
+
+describe('OutlinerPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(OutlinerPlugin.meta).toBeDefined();
+    expect(OutlinerPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-pipeline/src/PipelinePlugin.test.ts
+++ b/packages/plugins/plugin-pipeline/src/PipelinePlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { PipelinePlugin } from './PipelinePlugin';
+
+describe('PipelinePlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(PipelinePlugin.meta).toBeDefined();
+    expect(PipelinePlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-presenter/src/PresenterPlugin.test.ts
+++ b/packages/plugins/plugin-presenter/src/PresenterPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { PresenterPlugin } from './PresenterPlugin';
+
+describe('PresenterPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(PresenterPlugin.meta).toBeDefined();
+    expect(PresenterPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-preview/src/PreviewPlugin.test.ts
+++ b/packages/plugins/plugin-preview/src/PreviewPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { PreviewPlugin } from './PreviewPlugin';
+
+describe('PreviewPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(PreviewPlugin.meta).toBeDefined();
+    expect(PreviewPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-registry/src/RegistryPlugin.test.ts
+++ b/packages/plugins/plugin-registry/src/RegistryPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { RegistryPlugin } from './RegistryPlugin';
+
+describe('RegistryPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(RegistryPlugin.meta).toBeDefined();
+    expect(RegistryPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-script/src/ScriptPlugin.test.ts
+++ b/packages/plugins/plugin-script/src/ScriptPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { ScriptPlugin } from './ScriptPlugin';
+
+describe('ScriptPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(ScriptPlugin.meta).toBeDefined();
+    expect(ScriptPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-settings/moon.yml
+++ b/packages/plugins/plugin-settings/moon.yml
@@ -2,6 +2,7 @@ layer: library
 language: typescript
 tags:
   - ts-build
+  - ts-test
   - pack
 tasks:
   compile:

--- a/packages/plugins/plugin-settings/src/SettingsPlugin.test.ts
+++ b/packages/plugins/plugin-settings/src/SettingsPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { SettingsPlugin } from './SettingsPlugin';
+
+describe('SettingsPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(SettingsPlugin.meta).toBeDefined();
+    expect(SettingsPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-settings/vitest.config.ts
+++ b/packages/plugins/plugin-settings/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/packages/plugins/plugin-sheet/src/SheetPlugin.test.ts
+++ b/packages/plugins/plugin-sheet/src/SheetPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { SheetPlugin } from './SheetPlugin';
+
+describe('SheetPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(SheetPlugin.meta).toBeDefined();
+    expect(SheetPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-sidekick/moon.yml
+++ b/packages/plugins/plugin-sidekick/moon.yml
@@ -2,6 +2,7 @@ layer: library
 language: typescript
 tags:
   - ts-build
+  - ts-test
   - pack
 tasks:
   compile:

--- a/packages/plugins/plugin-sidekick/src/SidekickPlugin.test.ts
+++ b/packages/plugins/plugin-sidekick/src/SidekickPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { SidekickPlugin } from './SidekickPlugin';
+
+describe('SidekickPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(SidekickPlugin.meta).toBeDefined();
+    expect(SidekickPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-sidekick/vitest.config.ts
+++ b/packages/plugins/plugin-sidekick/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/packages/plugins/plugin-sketch/src/SketchPlugin.test.ts
+++ b/packages/plugins/plugin-sketch/src/SketchPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { SketchPlugin } from './SketchPlugin';
+
+describe('SketchPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(SketchPlugin.meta).toBeDefined();
+    expect(SketchPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-spacetime/src/SpacetimePlugin.test.ts
+++ b/packages/plugins/plugin-spacetime/src/SpacetimePlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { SpacetimePlugin } from './SpacetimePlugin';
+
+describe('SpacetimePlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(SpacetimePlugin.meta).toBeDefined();
+    expect(SpacetimePlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-spec/src/SpecPlugin.test.ts
+++ b/packages/plugins/plugin-spec/src/SpecPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { SpecPlugin } from './SpecPlugin';
+
+describe('SpecPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(SpecPlugin.meta).toBeDefined();
+    expect(SpecPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-spotlight/moon.yml
+++ b/packages/plugins/plugin-spotlight/moon.yml
@@ -2,6 +2,7 @@ layer: library
 language: typescript
 tags:
   - ts-build
+  - ts-test
   - pack
 tasks:
   compile:

--- a/packages/plugins/plugin-spotlight/src/SpotlightPlugin.test.ts
+++ b/packages/plugins/plugin-spotlight/src/SpotlightPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { SpotlightPlugin } from './SpotlightPlugin';
+
+describe('SpotlightPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(SpotlightPlugin.meta).toBeDefined();
+    expect(SpotlightPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-spotlight/vitest.config.ts
+++ b/packages/plugins/plugin-spotlight/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/packages/plugins/plugin-status-bar/src/StatusBarPlugin.test.ts
+++ b/packages/plugins/plugin-status-bar/src/StatusBarPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { StatusBarPlugin } from './StatusBarPlugin';
+
+describe('StatusBarPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(StatusBarPlugin.meta).toBeDefined();
+    expect(StatusBarPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-template/moon.yml
+++ b/packages/plugins/plugin-template/moon.yml
@@ -2,6 +2,7 @@ layer: library
 language: typescript
 tags:
   - ts-build
+  - ts-test
   - pack
 tasks:
   compile:

--- a/packages/plugins/plugin-template/src/TemplatePlugin.test.ts
+++ b/packages/plugins/plugin-template/src/TemplatePlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { TemplatePlugin } from './TemplatePlugin';
+
+describe('TemplatePlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(TemplatePlugin.meta).toBeDefined();
+    expect(TemplatePlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-template/vitest.config.ts
+++ b/packages/plugins/plugin-template/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/packages/plugins/plugin-theme/moon.yml
+++ b/packages/plugins/plugin-theme/moon.yml
@@ -2,6 +2,7 @@ layer: library
 language: typescript
 tags:
   - ts-build
+  - ts-test
   - pack
 tasks:
   compile:

--- a/packages/plugins/plugin-theme/src/ThemePlugin.test.ts
+++ b/packages/plugins/plugin-theme/src/ThemePlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { ThemePlugin } from './ThemePlugin';
+
+describe('ThemePlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(ThemePlugin.meta).toBeDefined();
+    expect(ThemePlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-theme/vitest.config.ts
+++ b/packages/plugins/plugin-theme/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/packages/plugins/plugin-thread/src/ThreadPlugin.test.ts
+++ b/packages/plugins/plugin-thread/src/ThreadPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { ThreadPlugin } from './ThreadPlugin';
+
+describe('ThreadPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(ThreadPlugin.meta).toBeDefined();
+    expect(ThreadPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-tictactoe/src/TicTacToePlugin.test.ts
+++ b/packages/plugins/plugin-tictactoe/src/TicTacToePlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { TicTacToePlugin } from './TicTacToePlugin';
+
+describe('TicTacToePlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(TicTacToePlugin.meta).toBeDefined();
+    expect(TicTacToePlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-token-manager/src/TokenManagerPlugin.test.ts
+++ b/packages/plugins/plugin-token-manager/src/TokenManagerPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { TokenManagerPlugin } from './TokenManagerPlugin';
+
+describe('TokenManagerPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(TokenManagerPlugin.meta).toBeDefined();
+    expect(TokenManagerPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-transcription/src/TranscriptionPlugin.test.ts
+++ b/packages/plugins/plugin-transcription/src/TranscriptionPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { TranscriptionPlugin } from './TranscriptionPlugin';
+
+describe('TranscriptionPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(TranscriptionPlugin.meta).toBeDefined();
+    expect(TranscriptionPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-transformer/src/TransformerPlugin.test.ts
+++ b/packages/plugins/plugin-transformer/src/TransformerPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { TransformerPlugin } from './TransformerPlugin';
+
+describe('TransformerPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(TransformerPlugin.meta).toBeDefined();
+    expect(TransformerPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-voxel/src/VoxelPlugin.test.ts
+++ b/packages/plugins/plugin-voxel/src/VoxelPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { VoxelPlugin } from './VoxelPlugin';
+
+describe('VoxelPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(VoxelPlugin.meta).toBeDefined();
+    expect(VoxelPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-wnfs/src/WnfsPlugin.test.ts
+++ b/packages/plugins/plugin-wnfs/src/WnfsPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { WnfsPlugin } from './WnfsPlugin';
+
+describe('WnfsPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(WnfsPlugin.meta).toBeDefined();
+    expect(WnfsPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-youtube/src/YouTubePlugin.test.ts
+++ b/packages/plugins/plugin-youtube/src/YouTubePlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { YouTubePlugin } from './YouTubePlugin';
+
+describe('YouTubePlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(YouTubePlugin.meta).toBeDefined();
+    expect(YouTubePlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-zen/moon.yml
+++ b/packages/plugins/plugin-zen/moon.yml
@@ -2,6 +2,7 @@ layer: library
 language: typescript
 tags:
   - ts-build
+  - ts-test
   - pack
 tasks:
   compile:

--- a/packages/plugins/plugin-zen/src/ZenPlugin.test.ts
+++ b/packages/plugins/plugin-zen/src/ZenPlugin.test.ts
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { ZenPlugin } from './ZenPlugin';
+
+describe('ZenPlugin', () => {
+  test('factory exposes meta', ({ expect }) => {
+    expect(ZenPlugin.meta).toBeDefined();
+    expect(ZenPlugin.meta.id).toBeTypeOf('string');
+  });
+});

--- a/packages/plugins/plugin-zen/vitest.config.ts
+++ b/packages/plugins/plugin-zen/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});


### PR DESCRIPTION
## Summary

Adds a minimal smoke test per plugin that asserts the factory exposes `.meta` with a string `id`. This follows the pattern in [ChessPlugin.test.ts](packages/plugins/plugin-chess/src/ChessPlugin.test.ts) — the Chess plugin test has more sophisticated checks because the Chess plugin's operations are safe to execute in Node; for the broader set, the meta-only check catches module-load regressions without depending on activation paths or browser APIs.

For packages that lacked test infrastructure, adds a node-mode `vitest.config.ts` and a `ts-test` tag in `moon.yml`.

## What's covered

48 plugin packages now have a `*Plugin.test.ts` smoke test.

## What's intentionally skipped

Plugins whose module graph pulls in browser-only code at import time (so a pure Node smoke test can't load them without significant extra setup):

- **`getComputedStyle` via `@dxos/react-ui-dnd`**: `plugin-deck`, `plugin-stack`
- **`window` via `leaflet`**: `plugin-map`
- **`Worker` via `media-encoder-host`**: `plugin-native`
- **`virtual:pwa-register` (Vite virtual module)**: `plugin-pwa`
- **Atlaskit CJS `?.` parse issue via `@dxos/react-ui-mosaic`**: `plugin-assistant`, `plugin-search`, `plugin-space`, `plugin-table`

Plugins with pre-existing broken test files that aren't currently wired into moon:

- `plugin-daily-summary` — `meta.test.ts` and `blueprints/functions/generate.test.ts` assert stale values

Plugins whose existing `vitest.config.ts` has no `node` project (they run via browser or storybook only):

- `plugin-kanban`, `plugin-simple-layout`

These gaps are worth a follow-up — either migrate to happy-dom, or move the offending import off the module-load critical path.

## Test plan

- [x] `moon run plugin-chess:test` passes (existing)
- [x] `moon run plugin-attention:test` passes (representative new-infra plugin)
- [x] `moon run plugin-excalidraw:test` passes (factory export was `ExcalidrawPlugin`, not the filename `SketchPlugin`)
- [x] Ran a broad batch via `moon exec --on-failure continue` — all kept tests green
- [ ] Verify CI **Check** workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage across all plugin packages to ensure proper plugin initialization and metadata validation.

* **Chores**
  * Updated build configurations to include test support tags for improved task categorization and workflow management.
  * Introduced Vitest configuration files for standardized test execution and Node environment support across plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->