### PR TITLE
chore: align moon version to 2.2.3 across all config files

### DIFF
--- a/.github/workflows/publish-tauri.yaml
+++ b/.github/workflows/publish-tauri.yaml
@@ -177,7 +177,7 @@ jobs:
       - uses: moonrepo/setup-toolchain@v0
         with:
           # IMPORTANT: Keep in-sync with .prototools
-          moon-version: '2.1.4'
+          moon-version: '2.2.3'
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -318,7 +318,7 @@ jobs:
       - uses: moonrepo/setup-toolchain@v0
         with:
           # IMPORTANT: Keep in-sync with .prototools
-          moon-version: '2.1.4'
+          moon-version: '2.2.3'
 
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,8 +274,8 @@ catalogs:
       specifier: ^1.0.8
       version: 1.0.8
     '@moonrepo/cli':
-      specifier: 2.1.4
-      version: 2.1.4
+      specifier: 2.2.3
+      version: 2.2.3
     '@ngneat/falso':
       specifier: ^7.1.1
       version: 7.1.1
@@ -1976,7 +1976,7 @@ importers:
         version: 0.27.0(effect@3.20.0)(vitest@3.2.4)
       '@moonrepo/cli':
         specifier: 'catalog:'
-        version: 2.1.4
+        version: 2.2.3
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
@@ -23545,41 +23545,46 @@ packages:
     peerDependencies:
       three: '>= 0.159.0'
 
-  '@moonrepo/cli@2.1.4':
-    resolution: {integrity: sha512-u8PZQIT/k9h/EIQEjEcmtd4vQBr7KqnLaG+uFqhiZTIe++RTtgMlH8GYMoqLwg2VHGIxV0OURMGt9x8Qjm9/EQ==}
+  '@moonrepo/cli@2.2.3':
+    resolution: {integrity: sha512-Y2yX2yw2ieRQ8/LHmlLgJT0RGPcPbKlrmpTw/trsrMuW5UElzqgObztf1bB3jbOfTVjcbWmNqKP7aDDST0u3/w==}
     hasBin: true
 
-  '@moonrepo/core-linux-arm64-gnu@2.1.4':
-    resolution: {integrity: sha512-pEp0GMHOT5hJrfL4q3zecvbUJ0xYWVqNzWFPFJWTZxbhTWYCbuOTGTPCpT21XY9URIJHUGKc+m8PXMc7DrRYow==}
+  '@moonrepo/core-linux-arm64-gnu@2.2.3':
+    resolution: {integrity: sha512-O2mLzDvgJd7Bgxkvq37RJsm9XAG5avA+7cD49ZIgeBKlGD8+3KZ+DmOz5SD1CELaxXrgOSh2c2vorlBzaXNmZA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@moonrepo/core-linux-arm64-musl@2.1.4':
-    resolution: {integrity: sha512-U42RJD2io986lQQ+uUmWElAIMSWfuoyXpao2aHuMn/ACxOi5xPTozPWkoLb1v53w+irCbsD8WVovJ4wY+vB/VQ==}
+  '@moonrepo/core-linux-arm64-musl@2.2.3':
+    resolution: {integrity: sha512-QD5mStzFfkhDb5Fha8Jw/rX3SlnOkSKsyBJWsMWn5WahCqV0NMOOOf4PrAAywO3NTKDorGEipqGJdqec7lIizg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@moonrepo/core-linux-x64-gnu@2.1.4':
-    resolution: {integrity: sha512-NvcevuDLzMeGFAYqNVNHZJ5C2hx5GJerUW5Snwi+28/KcPpNq2z31W5c8EivUzsc1iopV6Oy85FEohNzci9sPw==}
+  '@moonrepo/core-linux-x64-gnu@2.2.3':
+    resolution: {integrity: sha512-Ip68pMsXbVVfCOb3csWFv3jQtatbbHuLgQ50MUVRx8VYi2L8sPwVTGuyU57tNcMLXqeOCJxgBrTvFq/U9ElQ5g==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@moonrepo/core-linux-x64-musl@2.1.4':
-    resolution: {integrity: sha512-f00vupGU1pUie/ycuj9v6iRL2cP318pS2dxBH4iI6M83xVw3BL2FxIoXklk5Ji3P7EJhIG48j7dKVID6VdrNVA==}
+  '@moonrepo/core-linux-x64-musl@2.2.3':
+    resolution: {integrity: sha512-10bUudg3eTrs0N/4tbH2CFWoOEuf3K7WhTypop4zArPCrq5sl5rG2Ik/wZNn40h4JdF09I7A2ZCGWlubsudd5g==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@moonrepo/core-macos-arm64@2.1.4':
-    resolution: {integrity: sha512-4bdSgstioFiBKx26uu6U1G0n5Sk8JpkpxfVj3zsNITFfT3fdS5oBMU8Z18uYIf4v1l3poIQ7r0T2R1MdMOkJyw==}
+  '@moonrepo/core-macos-arm64@2.2.3':
+    resolution: {integrity: sha512-5/2cVkMVwsS/3aKPe5xzL8eegZz3V74xE7Wruf847UavfN0YuoIew14PfaTz5Pt69hAapdnXDiF8kmbSaKkWKA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@moonrepo/core-windows-x64-msvc@2.1.4':
-    resolution: {integrity: sha512-KhkxZ1aJVeRsrOOrDlE6oB5gDny0ETOQdIoDFBFR6hDEGZ4OFHrRBScLjwK7RteQGCV1YKo47uIiIbmIN1wMvg==}
+  '@moonrepo/core-macos-x64@2.2.3':
+    resolution: {integrity: sha512-T23dHlXqZWUkxLu45Piy8jxlzEImAurWQN1TVr06oTxZMSSTqzfyY+2Vk6GuyYnsZg0ELNnPW2ljnkEkczzy0g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@moonrepo/core-windows-x64-msvc@2.2.3':
+    resolution: {integrity: sha512-ez8/0AnMdzfUtbDitynJtR10PhG7CME3UCavLamE5BvV7dHUvtzLHipxVZIHWGx0gTEtQx6XpyDukYOozXGVlA==}
     cpu: [x64]
     os: [win32]
 
@@ -42727,33 +42732,37 @@ snapshots:
       promise-worker-transferable: 1.0.4
       three: 0.178.0
 
-  '@moonrepo/cli@2.1.4':
+  '@moonrepo/cli@2.2.3':
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      '@moonrepo/core-linux-arm64-gnu': 2.1.4
-      '@moonrepo/core-linux-arm64-musl': 2.1.4
-      '@moonrepo/core-linux-x64-gnu': 2.1.4
-      '@moonrepo/core-linux-x64-musl': 2.1.4
-      '@moonrepo/core-macos-arm64': 2.1.4
-      '@moonrepo/core-windows-x64-msvc': 2.1.4
+      '@moonrepo/core-linux-arm64-gnu': 2.2.3
+      '@moonrepo/core-linux-arm64-musl': 2.2.3
+      '@moonrepo/core-linux-x64-gnu': 2.2.3
+      '@moonrepo/core-linux-x64-musl': 2.2.3
+      '@moonrepo/core-macos-arm64': 2.2.3
+      '@moonrepo/core-macos-x64': 2.2.3
+      '@moonrepo/core-windows-x64-msvc': 2.2.3
 
-  '@moonrepo/core-linux-arm64-gnu@2.1.4':
+  '@moonrepo/core-linux-arm64-gnu@2.2.3':
     optional: true
 
-  '@moonrepo/core-linux-arm64-musl@2.1.4':
+  '@moonrepo/core-linux-arm64-musl@2.2.3':
     optional: true
 
-  '@moonrepo/core-linux-x64-gnu@2.1.4':
+  '@moonrepo/core-linux-x64-gnu@2.2.3':
     optional: true
 
-  '@moonrepo/core-linux-x64-musl@2.1.4':
+  '@moonrepo/core-linux-x64-musl@2.2.3':
     optional: true
 
-  '@moonrepo/core-macos-arm64@2.1.4':
+  '@moonrepo/core-macos-arm64@2.2.3':
     optional: true
 
-  '@moonrepo/core-windows-x64-msvc@2.1.4':
+  '@moonrepo/core-macos-x64@2.2.3':
+    optional: true
+
+  '@moonrepo/core-windows-x64-msvc@2.2.3':
     optional: true
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -109,7 +109,7 @@ catalog:
   '@lezer/xml': ^1.0.6
   '@lit/react': ^1.0.8
   '@modelcontextprotocol/sdk': ^1.27.1
-  '@moonrepo/cli': 2.1.4
+  '@moonrepo/cli': 2.2.3
   '@ngneat/falso': ^7.1.1
   '@observablehq/plot': ^0.6.11
   '@obsidize/tar-browserify': ^5.2.0


### PR DESCRIPTION
## Summary

- Updates `@moonrepo/cli` in the pnpm catalog (`pnpm-workspace.yaml`) from `2.1.4` to `2.2.3`
- Updates `moon-version` in `.github/workflows/publish-tauri.yaml` (both occurrences) from `2.1.4` to `2.2.3`
- Regenerates `pnpm-lock.yaml` to reflect the updated catalog entry
- `.prototools` already had `moon = "2.2.3"` — this brings the other locations in sync

## Test plan

- [ ] CI build passes with the updated moon version
- [ ] Tauri publish workflow uses consistent moon version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Moon toolchain and build dependencies to version 2.2.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->