### PR TITLE
test(plugin-chess): rewrite activation tests to exercise realistic startup

### DIFF
--- a/packages/plugins/plugin-chess/src/ChessPlugin.test.ts
+++ b/packages/plugins/plugin-chess/src/ChessPlugin.test.ts
@@ -4,50 +4,36 @@
 
 import { describe, test } from 'vitest';
 
-import { ActivationEvents, Capabilities } from '@dxos/app-framework';
-import { createTestApp } from '@dxos/app-framework/testing';
-import { AppActivationEvents, AppCapabilities } from '@dxos/app-toolkit';
+import { ActivationEvents } from '@dxos/app-framework';
+import { AppActivationEvents } from '@dxos/app-toolkit';
+// Use the CLI variant — the main ClientPlugin references capabilities that resolve to undefined under Node.
+import { ClientPlugin } from '@dxos/plugin-client/cli';
 import { createComposerTestApp } from '@dxos/plugin-testing/harness';
 
 import { ChessPlugin } from './ChessPlugin';
+import { meta } from './meta';
 import { Print } from './operations';
 
+const moduleId = (name: string) => `${meta.id}.module.${name}`;
+
 describe('ChessPlugin', () => {
-  test('activates and contributes expected capabilities', async ({ expect }) => {
-    await using harness = await createTestApp({ plugins: [ChessPlugin()] });
-    const surfaces = harness.getAll(Capabilities.ReactSurface).flat();
-    expect(surfaces.length).toBeGreaterThan(0);
-  });
+  test('modules activate on the expected events', async ({ expect }) => {
+    await using harness = await createComposerTestApp({
+      plugins: [ClientPlugin({}), ChessPlugin()],
+    });
 
-  test('fires activation events explicitly with autoStart: false', async ({ expect }) => {
-    await using harness = await createTestApp({ plugins: [ChessPlugin()], autoStart: false });
+    // Modules expected to be active after a normal startup.
+    expect(harness.manager.getActive()).toEqual(
+      expect.arrayContaining([moduleId('metadata'), moduleId('schema'), moduleId('ReactSurface')]),
+    );
 
-    // No modules have activated yet; schema/surface capabilities are absent.
-    expect(harness.getAll(AppCapabilities.Schema)).toHaveLength(0);
-    expect(harness.getAll(Capabilities.ReactSurface)).toHaveLength(0);
+    // SetupArtifactDefinition is fired by AssistantPlugin, which can't be included here due to a workspace cycle.
+    await harness.fire(AppActivationEvents.SetupArtifactDefinition);
+    expect(harness.manager.getActive()).toContain(moduleId('BlueprintDefinition'));
 
-    // Fire SetupSchema — the schema module activates and contributes the Chess.Game type.
-    await harness.fire(AppActivationEvents.SetupSchema);
-    const schemas = harness.getAll(AppCapabilities.Schema).flat();
-    expect(schemas.length).toBeGreaterThan(0);
-
-    // ReactSurface is gated on a different event; still absent.
-    expect(harness.getAll(Capabilities.ReactSurface)).toHaveLength(0);
-
-    // Fire SetupReactSurface; the surface module contributes.
-    await harness.fire(ActivationEvents.SetupReactSurface);
-    expect(harness.getAll(Capabilities.ReactSurface).flat().length).toBeGreaterThan(0);
-  });
-
-  test('waitForEvent resolves once the event has been fired', async ({ expect }) => {
-    await using harness = await createTestApp({ plugins: [ChessPlugin()], autoStart: false });
-
-    // Fire and wait concurrently — waitForEvent resolves regardless of ordering.
-    await Promise.all([
-      harness.fire(AppActivationEvents.SetupTranslations),
-      harness.waitForEvent(AppActivationEvents.SetupTranslations),
-    ]);
-    expect(harness.getAll(AppCapabilities.Translations).flat().length).toBeGreaterThan(0);
+    // Operation handlers are not loaded on startup — SetupOperationHandler fires lazily when an operation is invoked.
+    await harness.fire(ActivationEvents.SetupOperationHandler);
+    expect(harness.manager.getActive()).toContain(moduleId('OperationHandler'));
   });
 
   test('invokes the Print operation via the invoker capability', async ({ expect }) => {


### PR DESCRIPTION
## Summary

Rewrites the `ChessPlugin` activation tests so they exercise a realistic Composer startup instead of declaring the module's `activatesOn` mapping in both directions (which was tautological).

## What changed

- Dropped the \"fire each setup event explicitly and assert the matching capability appears\" tests — these restated the module definitions and caught no real regressions.
- Added a single test with two stages:
  1. **Normal startup** (`createComposerTestApp` + `ClientPlugin`): assert `manager.getActive()` contains `metadata`, `schema`, and `ReactSurface` modules. These come up only because `GraphPlugin` fires `SetupMetadata`, `ClientPlugin.SchemaDefs` fires `SetupSchema`, and the harness fires `SetupReactSurface` — so this catches regressions in those event chains.
  2. **Manually fired** for events no headless plugin triggers: `SetupArtifactDefinition` → `BlueprintDefinition`, `SetupOperationHandler` → `OperationHandler`. Comments call out why each is not reached by startup.
- Kept the two `Print` invocation tests — they exercise real operation-handler behavior.
- Uses `@dxos/plugin-client/cli` because the main `ClientPlugin` references capabilities (`AppGraphBuilder`, `Migrations`, `NavigationHandler`, `ReactContext`, `ReactSurface`) that are not exported from `#capabilities/node.ts` and resolve to `undefined` under Node.

## Not covered (intentional)

- **Translations module** — too trivial to warrant a test.
- **AssistantPlugin cannot be included** to trigger `SetupArtifactDefinition` from startup because `plugin-assistant` stories import `plugin-chess`, creating a workspace cycle. That's why `SetupArtifactDefinition` is fired manually. Worth a follow-up to move those chess stories into `stories-assistant` so this could be covered via a real event chain.

## Test plan

- [x] `pnpm exec vitest run src/ChessPlugin.test.ts` — all 3 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored Chess Plugin test suite to use module-activation assertions, improving test clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->