### PR TITLE
chore(plugin-wnfs): standardize Discord link to use dxos.org/discord redirect

### DIFF
--- a/packages/plugins/plugin-wnfs/README.md
+++ b/packages/plugins/plugin-wnfs/README.md
@@ -6,7 +6,7 @@ Plugin that allows for data to be stored on WNFS.
 
 - [Website](https://dxos.org)
 - [Developer Documentation](https://docs.dxos.org)
-- Talk to us on [Discord](https://discord.gg/eXVfryv3sW)
+- Talk to us on [Discord](https://dxos.org/discord)
 
 ## Contributions
 


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `discord.gg/eXVfryv3sW` invite link in `plugin-wnfs/README.md` with the canonical `https://dxos.org/discord` redirect, consistent with every other Discord link in the repo.

## Test Plan
- [ ] No code changes — docs-only update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Discord community link to the new URL for easier access to community resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->