### PR TITLE
feat(plugin-telegram-user): personal Telegram account sync via MTProto

### DIFF
--- a/packages/apps/composer-app/package.json
+++ b/packages/apps/composer-app/package.json
@@ -84,6 +84,7 @@
     "@dxos/plugin-stack": "workspace:*",
     "@dxos/plugin-status-bar": "workspace:*",
     "@dxos/plugin-table": "workspace:*",
+    "@dxos/plugin-telegram-user": "workspace:*",
     "@dxos/plugin-template": "workspace:*",
     "@dxos/plugin-theme": "workspace:*",
     "@dxos/plugin-thread": "workspace:*",

--- a/packages/apps/composer-app/src/plugin-defs.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.tsx
@@ -56,6 +56,7 @@ import { SpotlightPlugin } from '@dxos/plugin-spotlight';
 import { StackPlugin } from '@dxos/plugin-stack';
 import { StatusBarPlugin } from '@dxos/plugin-status-bar';
 import { TablePlugin } from '@dxos/plugin-table';
+import { TelegramUserPlugin } from '@dxos/plugin-telegram-user';
 import { ThemePlugin } from '@dxos/plugin-theme';
 import { ThreadPlugin } from '@dxos/plugin-thread';
 import { TicTacToePlugin } from '@dxos/plugin-tictactoe';
@@ -150,6 +151,7 @@ export const getDefaults = ({ isDev, isLabs }: PluginConfig): string[] =>
       MeetingPlugin.meta.id,
       OutlinerPlugin.meta.id,
       PipelinePlugin.meta.id,
+      TelegramUserPlugin.meta.id,
       TranscriptionPlugin.meta.id,
       ZenPlugin.meta.id,
     ],
@@ -241,6 +243,7 @@ export const getPlugins = ({
     StackPlugin(),
     StatusBarPlugin(),
     TablePlugin(),
+    TelegramUserPlugin(),
     ThemePlugin({
       appName: 'Composer',
       noCache: isDev,

--- a/packages/apps/composer-app/tsconfig.json
+++ b/packages/apps/composer-app/tsconfig.json
@@ -230,6 +230,9 @@
       "path": "../../plugins/plugin-table"
     },
     {
+      "path": "../../plugins/plugin-telegram-user"
+    },
+    {
       "path": "../../plugins/plugin-template"
     },
     {

--- a/packages/plugins/plugin-telegram-user/README.md
+++ b/packages/plugins/plugin-telegram-user/README.md
@@ -1,0 +1,47 @@
+# @dxos/plugin-telegram-user
+
+Personal Telegram **account** sync for Composer Agent.
+
+Logs into Telegram as *you* (via the MTProto user protocol, the same one official Telegram clients use) and builds a **unified inbox** of every DM, group, and channel you're in — so the agent can react to all incoming messages across your whole Telegram life, not just one bot.
+
+## ⚠️ Not what you want for agent-as-a-bot
+
+This plugin is your *personal* Telegram account. It cannot easily post as a neutral third-party identity, because any message it sends appears as coming from *you*.
+
+To let the agent send and receive messages *as a dedicated bot* (e.g. a notification bot in a team chat), use **[@dxos/plugin-telegram-bot](../plugin-telegram-bot)** instead.
+
+| | `plugin-telegram-user` (this plugin) | `plugin-telegram-bot` |
+|---|---|---|
+| Protocol | MTProto (user protocol) | Bot API (REST) |
+| Identity | Your personal account | A bot you create |
+| Can read | Every chat you're in | Messages sent *to the bot* |
+| Auth | Phone + SMS code + 2FA | Bot token from @BotFather |
+| Setup complexity | Multi-step login flow | Paste a token |
+| Use case | Unified inbox, personal sync | Agent-as-bot, notifications, team commands |
+
+The two plugins are independent and can be installed together.
+
+## Setup
+
+1. Register an app at <https://my.telegram.org/apps> — you'll need the `api_id` (integer) and `api_hash` (hex string). One-time per account.
+2. In Composer: Settings → Telegram → paste the `api_id`, `api_hash`, and your phone number (with country code). Click **Connect**.
+3. Enter the SMS / Telegram code Telegram sends to your account.
+4. If you have 2FA enabled, enter your cloud password.
+5. Done — the session is saved locally. Subsequent reloads auto-reconnect. Open the Telegram panel (deck companion) to see your unified inbox.
+
+## Security notes
+
+- The **session string** produced after login is equivalent to your Telegram login. Anyone who obtains it can act as you in Telegram. It's currently stored in localStorage under the plugin's settings key; migration to an encrypted `AccessToken` in the space is tracked in `plans/adopt-access-token-for-sync-plugins.md`.
+- The `api_hash` is *not* secret per Telegram's own guidance, but treat it like a secret anyway — if a bad actor has both your `api_hash` and a valid SMS code, they can log in as you.
+
+## Limitations (for now)
+
+- Messages live **in memory** only — refresh loses scroll state but not the session. Persistence to ECHO is future work.
+- Media (photos / files / stickers) is rendered as `[media]` for now; text only.
+- No outgoing messages from the plugin yet. (Use the Telegram app directly or plugin-telegram-bot.)
+- Bundle cost: gramjs is ~500 KB. It's lazy-loaded so you only pay if you enable the plugin.
+
+## Related
+
+- **[@dxos/plugin-telegram-bot](../plugin-telegram-bot)** — Telegram bot integration for agent-as-a-bot use cases.
+- **[@dxos/plugin-inbox](../plugin-inbox)** — similar unified-inbox pattern for Gmail.

--- a/packages/plugins/plugin-telegram-user/moon.yml
+++ b/packages/plugins/plugin-telegram-user/moon.yml
@@ -2,6 +2,7 @@ layer: library
 language: typescript
 tags:
   - ts-build
+  - ts-test
   - pack
 tasks:
   compile:

--- a/packages/plugins/plugin-telegram-user/moon.yml
+++ b/packages/plugins/plugin-telegram-user/moon.yml
@@ -1,0 +1,11 @@
+layer: library
+language: typescript
+tags:
+  - ts-build
+  - pack
+tasks:
+  compile:
+    args:
+      - '--entryPoint=src/index.ts'
+      - '--entryPoint=src/meta.ts'
+      - '--platform=browser'

--- a/packages/plugins/plugin-telegram-user/package.json
+++ b/packages/plugins/plugin-telegram-user/package.json
@@ -1,0 +1,81 @@
+{
+  "name": "@dxos/plugin-telegram-user",
+  "version": "0.8.3",
+  "private": true,
+  "description": "Personal Telegram account sync for Composer Agent via MTProto — a unified inbox of every Telegram DM, group, and channel you're in. For agent-as-a-bot functionality, see @dxos/plugin-telegram-bot.",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dxos/dxos"
+  },
+  "license": "MIT",
+  "author": "DXOS.org",
+  "sideEffects": true,
+  "type": "module",
+  "imports": {
+    "#capabilities": "./src/capabilities/index.ts",
+    "#components": "./src/components/index.ts",
+    "#hooks": "./src/hooks/index.ts",
+    "#meta": "./src/meta.ts",
+    "#types": "./src/types/index.ts"
+  },
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/types/src/index.d.ts",
+      "browser": "./dist/lib/browser/index.mjs"
+    },
+    "./meta": {
+      "source": "./src/meta.ts",
+      "types": "./dist/types/src/meta.d.ts",
+      "browser": "./dist/lib/browser/meta.mjs"
+    }
+  },
+  "types": "dist/types/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "meta": [
+        "dist/types/src/meta.d.ts"
+      ]
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@dxos/app-framework": "workspace:*",
+    "@dxos/app-graph": "workspace:*",
+    "@dxos/app-toolkit": "workspace:*",
+    "@dxos/echo": "workspace:*",
+    "@dxos/echo-atom": "workspace:*",
+    "@dxos/effect": "workspace:*",
+    "@dxos/log": "workspace:*",
+    "@dxos/plugin-graph": "workspace:*",
+    "@dxos/react-client": "workspace:*",
+    "@dxos/util": "workspace:*",
+    "@effect-atom/atom": "catalog:",
+    "telegram": "^2.26.22"
+  },
+  "devDependencies": {
+    "@dxos/react-ui": "workspace:*",
+    "@dxos/react-ui-components": "workspace:*",
+    "@dxos/ui-theme": "workspace:*",
+    "@effect-atom/atom-react": "catalog:",
+    "@types/react": "catalog:",
+    "effect": "catalog:",
+    "react": "catalog:"
+  },
+  "peerDependencies": {
+    "@dxos/react-ui": "workspace:*",
+    "@dxos/react-ui-components": "workspace:*",
+    "@dxos/ui-theme": "workspace:*",
+    "@effect-atom/atom-react": "catalog:",
+    "effect": "catalog:",
+    "react": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugins/plugin-telegram-user/package.json
+++ b/packages/plugins/plugin-telegram-user/package.json
@@ -56,7 +56,7 @@
     "@dxos/react-client": "workspace:*",
     "@dxos/util": "workspace:*",
     "@effect-atom/atom": "catalog:",
-    "telegram": "^2.26.22"
+    "telegram": "catalog:"
   },
   "devDependencies": {
     "@dxos/react-ui": "workspace:*",

--- a/packages/plugins/plugin-telegram-user/src/TelegramUserPlugin.tsx
+++ b/packages/plugins/plugin-telegram-user/src/TelegramUserPlugin.tsx
@@ -1,0 +1,22 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppActivationEvents, AppPlugin } from '@dxos/app-toolkit';
+
+import { AppGraphBuilder, ReactSurface, Settings } from '#capabilities';
+import { meta } from '#meta';
+import { translations } from './translations';
+
+export const TelegramUserPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addAppGraphModule({ activate: AppGraphBuilder }),
+  AppPlugin.addSurfaceModule({ activate: ReactSurface }),
+  AppPlugin.addTranslationsModule({ translations }),
+  Plugin.addModule({
+    id: 'settings',
+    activatesOn: AppActivationEvents.SetupSettings,
+    activate: Settings,
+  }),
+  Plugin.make,
+);

--- a/packages/plugins/plugin-telegram-user/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-telegram-user/src/capabilities/app-graph-builder.ts
@@ -1,0 +1,34 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capability } from '@dxos/app-framework';
+import { AppCapabilities, AppNode } from '@dxos/app-toolkit';
+import { GraphBuilder, NodeMatcher } from '@dxos/plugin-graph';
+
+import { meta } from '#meta';
+
+export default Capability.makeModule(
+  Effect.fnUntraced(function* () {
+    const extensions = yield* Effect.all([
+      GraphBuilder.createExtension({
+        id: `${meta.id}/deck-companion`,
+        match: NodeMatcher.whenRoot,
+        connector: () =>
+          Effect.succeed([
+            AppNode.makeDeckCompanion({
+              id: 'telegram-user',
+              label: ['plugin.name', { ns: meta.id }],
+              icon: meta.icon ?? 'ph--telegram-logo--regular',
+              data: 'telegram-user',
+              position: 'fallback',
+            }),
+          ]),
+      }),
+    ]);
+
+    return Capability.contributes(AppCapabilities.AppGraphBuilder, extensions);
+  }),
+);

--- a/packages/plugins/plugin-telegram-user/src/capabilities/index.ts
+++ b/packages/plugins/plugin-telegram-user/src/capabilities/index.ts
@@ -1,0 +1,11 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Capability } from '@dxos/app-framework';
+
+export const AppGraphBuilder = Capability.lazy('AppGraphBuilder', () => import('./app-graph-builder'));
+
+export const ReactSurface = Capability.lazy('ReactSurface', () => import('./react-surface'));
+
+export const Settings = Capability.lazy('Settings', () => import('./settings'));

--- a/packages/plugins/plugin-telegram-user/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-telegram-user/src/capabilities/react-surface.tsx
@@ -1,0 +1,54 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import React, { useMemo } from 'react';
+
+import { Capabilities, Capability } from '@dxos/app-framework';
+import { Surface, useCapabilities, useSettingsState } from '@dxos/app-framework/ui';
+import { AppSurface } from '@dxos/app-toolkit/ui';
+import { createKvsStore } from '@dxos/effect';
+
+import { TelegramUserFeed, TelegramUserSettings } from '#components';
+import { meta } from '#meta';
+import { TelegramUserCapabilities } from '#types';
+
+const TelegramUserFeedWithSettings = () => {
+  const capabilities = useCapabilities(TelegramUserCapabilities.Settings);
+  const fallbackAtom = useMemo(
+    () =>
+      createKvsStore({
+        key: `${meta.id}.fallback`,
+        schema: TelegramUserCapabilities.SettingsSchema,
+        defaultValue: () => ({}),
+      }),
+    [],
+  );
+  const settingsAtom = capabilities[0] ?? fallbackAtom;
+  const { settings } = useSettingsState<TelegramUserCapabilities.Settings>(settingsAtom);
+
+  return <TelegramUserFeed settings={settings} />;
+};
+
+export default Capability.makeModule(() =>
+  Effect.succeed(
+    Capability.contributes(Capabilities.ReactSurface, [
+      Surface.create({
+        id: 'plugin-settings',
+        role: 'article',
+        filter: AppSurface.settingsArticle(meta.id),
+        component: ({ data: { subject } }) => {
+          const { settings, updateSettings } = useSettingsState<TelegramUserCapabilities.Settings>(subject.atom);
+          return <TelegramUserSettings settings={settings} onSettingsChange={updateSettings} />;
+        },
+      }),
+      Surface.create({
+        id: 'telegram-user-feed',
+        role: 'deck-companion--telegram-user',
+        filter: AppSurface.literalSection('telegram-user'),
+        component: () => <TelegramUserFeedWithSettings />,
+      }),
+    ]),
+  ),
+);

--- a/packages/plugins/plugin-telegram-user/src/capabilities/settings.ts
+++ b/packages/plugins/plugin-telegram-user/src/capabilities/settings.ts
@@ -1,0 +1,31 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capability } from '@dxos/app-framework';
+import { AppCapabilities } from '@dxos/app-toolkit';
+import { createKvsStore } from '@dxos/effect';
+
+import { meta } from '#meta';
+import { TelegramUserCapabilities } from '#types';
+
+export default Capability.makeModule(() =>
+  Effect.sync(() => {
+    const settingsAtom = createKvsStore({
+      key: meta.id,
+      schema: TelegramUserCapabilities.SettingsSchema,
+      defaultValue: () => ({}),
+    });
+
+    return [
+      Capability.contributes(TelegramUserCapabilities.Settings, settingsAtom),
+      Capability.contributes(AppCapabilities.Settings, {
+        prefix: meta.id,
+        schema: TelegramUserCapabilities.SettingsSchema,
+        atom: settingsAtom,
+      }),
+    ];
+  }),
+);

--- a/packages/plugins/plugin-telegram-user/src/components/TelegramUserFeed.tsx
+++ b/packages/plugins/plugin-telegram-user/src/components/TelegramUserFeed.tsx
@@ -1,0 +1,108 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React, { useEffect, useMemo, useRef } from 'react';
+
+import { Icon, ScrollArea } from '@dxos/react-ui';
+import { mx } from '@dxos/ui-theme';
+
+import { type TelegramUserMessage, useTelegramUserClient, useTelegramUserMessages } from '#hooks';
+import { type TelegramUserCapabilities } from '#types';
+
+export type TelegramUserFeedProps = {
+  settings: TelegramUserCapabilities.Settings;
+};
+
+/**
+ * Unified inbox: renders every new message from the user's Telegram account,
+ * across every chat, in chronological order. Auto-connects if a session is
+ * stored; otherwise shows a "go to settings" prompt.
+ */
+export const TelegramUserFeed = ({ settings }: TelegramUserFeedProps) => {
+  const { status, client, connectWithSession } = useTelegramUserClient();
+  const { messages, error } = useTelegramUserMessages(client);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Auto-connect with saved session.
+  useEffect(() => {
+    if (settings.sessionString && settings.apiId && settings.apiHash && status === 'disconnected') {
+      void connectWithSession({
+        apiId: Number(settings.apiId),
+        apiHash: settings.apiHash,
+        sessionString: settings.sessionString,
+      });
+    }
+  }, [settings.sessionString, settings.apiId, settings.apiHash, status, connectWithSession]);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+    }
+  }, [messages.length]);
+
+  const sorted = useMemo(() => [...messages].sort((first, second) => first.date - second.date), [messages]);
+
+  if (!settings.sessionString) {
+    return (
+      <div className='flex flex-col items-center justify-center h-full p-8 text-center text-description'>
+        <Icon icon='ph--telegram-logo--regular' size={10} classNames='mb-4 opacity-50' />
+        <p className='text-sm'>Connect your personal Telegram account in Settings to see your unified inbox.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex flex-col h-full'>
+      <div className='flex items-center gap-2 p-2 border-b border-separator'>
+        <Icon icon='ph--telegram-logo--regular' size={5} />
+        <span className='text-sm font-medium grow'>Telegram</span>
+        {status === 'connected' && <div className='size-2 rounded-full bg-green-500 animate-pulse' title='Live' />}
+        {status !== 'connected' && <span className='text-xs text-description'>{status}</span>}
+      </div>
+
+      {error && (
+        <div className='px-3 py-2 text-xs text-red-500 bg-red-50 dark:bg-red-950'>{error}</div>
+      )}
+
+      <ScrollArea.Root className='flex-1'>
+        <ScrollArea.Viewport ref={scrollRef} className='max-h-full'>
+          <div className='flex flex-col gap-1 p-2'>
+            {sorted.length === 0 ? (
+              <div className='text-sm text-description text-center py-8'>
+                {status === 'connected' ? 'Listening for messages…' : 'Waiting for connection…'}
+              </div>
+            ) : (
+              sorted.map((message) => <MessageRow key={message.id} message={message} />)
+            )}
+          </div>
+        </ScrollArea.Viewport>
+      </ScrollArea.Root>
+    </div>
+  );
+};
+
+const MessageRow = ({ message }: { message: TelegramUserMessage }) => {
+  const time = new Date(message.date * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const initial = (message.fromName ?? message.chatTitle).charAt(0).toUpperCase();
+
+  return (
+    <div className={mx('flex gap-2 p-2 rounded', message.outgoing && 'opacity-70')}>
+      <div className='flex-shrink-0 size-8 rounded-full bg-neutral-200 text-neutral-700 flex items-center justify-center text-xs font-medium'>
+        {initial}
+      </div>
+      <div className='flex flex-col gap-0.5 min-w-0 grow'>
+        <div className='flex items-baseline gap-2'>
+          <span className='text-sm font-medium truncate'>
+            {message.fromName ?? (message.outgoing ? 'You' : message.chatTitle)}
+          </span>
+          {message.chatType !== 'user' && (
+            <span className='text-xs text-description truncate'>in {message.chatTitle}</span>
+          )}
+          <span className='text-xs text-description ml-auto flex-shrink-0'>{time}</span>
+        </div>
+        <p className='text-sm whitespace-pre-wrap break-words'>{message.text}</p>
+      </div>
+    </div>
+  );
+};

--- a/packages/plugins/plugin-telegram-user/src/components/TelegramUserSettings.tsx
+++ b/packages/plugins/plugin-telegram-user/src/components/TelegramUserSettings.tsx
@@ -1,0 +1,270 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { Button, Icon, Input } from '@dxos/react-ui';
+import { mx } from '@dxos/ui-theme';
+
+import { useTelegramUserClient } from '#hooks';
+import { type TelegramUserCapabilities, type TelegramUserConnectionStatus } from '#types';
+
+export type TelegramUserSettingsProps = {
+  settings: TelegramUserCapabilities.Settings;
+  onSettingsChange: (fn: (current: TelegramUserCapabilities.Settings) => TelegramUserCapabilities.Settings) => void;
+};
+
+/**
+ * Settings surface for plugin-telegram-user. Drives the multi-step MTProto
+ * login: phone → SMS code → (optional) 2FA password → save session string.
+ *
+ * If the user already has a saved session, shows a "connected, disconnect"
+ * state and auto-reconnects on mount.
+ */
+export const TelegramUserSettings = ({ settings, onSettingsChange }: TelegramUserSettingsProps) => {
+  const { status, error, startLogin, submitCode, submitPassword, connectWithSession, disconnect } =
+    useTelegramUserClient();
+
+  const [apiIdInput, setApiIdInput] = useState(settings.apiId ?? '');
+  const [apiHashInput, setApiHashInput] = useState(settings.apiHash ?? '');
+  const [phoneInput, setPhoneInput] = useState(settings.phoneNumber ?? '');
+  const [codeInput, setCodeInput] = useState('');
+  const [passwordInput, setPasswordInput] = useState('');
+
+  const updatePartial = useCallback(
+    (partial: Partial<TelegramUserCapabilities.Settings>) => {
+      onSettingsChange((current) => ({ ...current, ...partial }));
+    },
+    [onSettingsChange],
+  );
+
+  // Auto-reconnect if we have a saved session.
+  useEffect(() => {
+    if (settings.sessionString && settings.apiId && settings.apiHash && status === 'disconnected') {
+      void connectWithSession({
+        apiId: Number(settings.apiId),
+        apiHash: settings.apiHash,
+        sessionString: settings.sessionString,
+      });
+    }
+  }, [settings.sessionString, settings.apiId, settings.apiHash, status, connectWithSession]);
+
+  const handleStartLogin = useCallback(async () => {
+    const apiIdNumber = Number(apiIdInput);
+    if (!Number.isInteger(apiIdNumber) || apiIdNumber <= 0 || !apiHashInput || !phoneInput) {
+      return;
+    }
+    updatePartial({ apiId: apiIdInput, apiHash: apiHashInput, phoneNumber: phoneInput });
+    const sessionString = await startLogin({ apiId: apiIdNumber, apiHash: apiHashInput, phoneNumber: phoneInput });
+    if (sessionString) {
+      updatePartial({ sessionString });
+    }
+  }, [apiIdInput, apiHashInput, phoneInput, startLogin, updatePartial]);
+
+  const handleSubmitCode = useCallback(() => {
+    if (codeInput.trim()) {
+      submitCode(codeInput.trim());
+      setCodeInput('');
+    }
+  }, [codeInput, submitCode]);
+
+  const handleSubmitPassword = useCallback(() => {
+    if (passwordInput) {
+      submitPassword(passwordInput);
+      setPasswordInput('');
+    }
+  }, [passwordInput, submitPassword]);
+
+  const handleDisconnect = useCallback(async () => {
+    await disconnect();
+    updatePartial({ sessionString: undefined });
+  }, [disconnect, updatePartial]);
+
+  return (
+    <div className='flex flex-col gap-4 p-3'>
+      <div className='flex flex-col gap-2'>
+        <h3 className='text-sm font-medium'>Telegram (personal account)</h3>
+        <p className='text-xs text-description'>
+          Syncs every DM, group, and channel from your personal Telegram account into a unified inbox. Uses the MTProto
+          user protocol — a real Telegram login, same as the official apps.
+        </p>
+        <div className='flex items-center gap-2'>
+          <StatusIndicator status={status} />
+          <span className='text-sm text-description'>
+            {statusLabel(status)}
+            {error && ` — ${error}`}
+          </span>
+        </div>
+      </div>
+
+      {settings.sessionString && status === 'connected' ? (
+        <div className='flex gap-2'>
+          <Button variant='ghost' onClick={handleDisconnect}>
+            <Icon icon='ph--plugs--regular' size={4} />
+            Disconnect + forget session
+          </Button>
+        </div>
+      ) : (
+        <div className='flex flex-col gap-3'>
+          <p className='text-xs text-description'>
+            Get an <code className='font-mono'>api_id</code> and <code className='font-mono'>api_hash</code> from{' '}
+            <a
+              className='underline'
+              href='https://my.telegram.org/apps'
+              target='_blank'
+              rel='noreferrer'
+            >
+              my.telegram.org/apps
+            </a>
+            . One-time setup.
+          </p>
+
+          <Labelled label='API ID'>
+            <Input.Root>
+              <Input.TextInput
+                placeholder='12345678'
+                value={apiIdInput}
+                onChange={(event) => setApiIdInput(event.target.value)}
+                type='text'
+                inputMode='numeric'
+                classNames='font-mono text-xs'
+                disabled={status === 'logging-in' || status === 'need-code' || status === 'need-password'}
+              />
+            </Input.Root>
+          </Labelled>
+
+          <Labelled label='API Hash'>
+            <Input.Root>
+              <Input.TextInput
+                placeholder='0123456789abcdef…'
+                value={apiHashInput}
+                onChange={(event) => setApiHashInput(event.target.value)}
+                type='password'
+                classNames='font-mono text-xs'
+                disabled={status === 'logging-in' || status === 'need-code' || status === 'need-password'}
+              />
+            </Input.Root>
+          </Labelled>
+
+          <Labelled label='Phone number (with country code)'>
+            <Input.Root>
+              <Input.TextInput
+                placeholder='+14155551212'
+                value={phoneInput}
+                onChange={(event) => setPhoneInput(event.target.value)}
+                type='tel'
+                classNames='font-mono text-xs'
+                disabled={status === 'logging-in' || status === 'need-code' || status === 'need-password'}
+              />
+            </Input.Root>
+          </Labelled>
+
+          {status === 'need-code' && (
+            <div className='flex flex-col gap-1'>
+              <Labelled label='Enter SMS / Telegram code'>
+                <Input.Root>
+                  <Input.TextInput
+                    placeholder='12345'
+                    value={codeInput}
+                    onChange={(event) => setCodeInput(event.target.value)}
+                    type='text'
+                    inputMode='numeric'
+                    classNames='font-mono text-xs'
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') {
+                        handleSubmitCode();
+                      }
+                    }}
+                  />
+                </Input.Root>
+              </Labelled>
+              <Button variant='primary' onClick={handleSubmitCode} disabled={!codeInput.trim()}>
+                Submit code
+              </Button>
+            </div>
+          )}
+
+          {status === 'need-password' && (
+            <div className='flex flex-col gap-1'>
+              <Labelled label='Two-factor password'>
+                <Input.Root>
+                  <Input.TextInput
+                    placeholder='••••••••'
+                    value={passwordInput}
+                    onChange={(event) => setPasswordInput(event.target.value)}
+                    type='password'
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') {
+                        handleSubmitPassword();
+                      }
+                    }}
+                  />
+                </Input.Root>
+              </Labelled>
+              <Button variant='primary' onClick={handleSubmitPassword} disabled={!passwordInput}>
+                Submit password
+              </Button>
+            </div>
+          )}
+
+          <div className='flex gap-2'>
+            <Button
+              variant='primary'
+              onClick={handleStartLogin}
+              disabled={
+                !apiIdInput.trim() ||
+                !apiHashInput.trim() ||
+                !phoneInput.trim() ||
+                status === 'logging-in' ||
+                status === 'need-code' ||
+                status === 'need-password'
+              }
+            >
+              <Icon icon='ph--plug--regular' size={4} />
+              Connect
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const statusLabel = (status: TelegramUserConnectionStatus): string => {
+  switch (status) {
+    case 'disconnected':
+      return 'Not connected';
+    case 'need-credentials':
+      return 'Credentials needed';
+    case 'logging-in':
+      return 'Connecting…';
+    case 'need-code':
+      return 'Waiting for SMS code';
+    case 'need-password':
+      return 'Waiting for 2FA password';
+    case 'connected':
+      return 'Connected';
+    case 'error':
+      return 'Error';
+  }
+};
+
+const StatusIndicator = ({ status }: { status: TelegramUserConnectionStatus }) => (
+  <div
+    className={mx(
+      'size-2 rounded-full',
+      status === 'connected' && 'bg-green-500',
+      (status === 'logging-in' || status === 'need-code' || status === 'need-password') && 'bg-yellow-500 animate-pulse',
+      status === 'error' && 'bg-red-500',
+      (status === 'disconnected' || status === 'need-credentials') && 'bg-neutral-400',
+    )}
+  />
+);
+
+const Labelled = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <label className='flex flex-col gap-1'>
+    <span className='text-xs text-description'>{label}</span>
+    {children}
+  </label>
+);

--- a/packages/plugins/plugin-telegram-user/src/components/index.ts
+++ b/packages/plugins/plugin-telegram-user/src/components/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './TelegramUserFeed';
+export * from './TelegramUserSettings';

--- a/packages/plugins/plugin-telegram-user/src/hooks/index.ts
+++ b/packages/plugins/plugin-telegram-user/src/hooks/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './useTelegramUserClient';
+export * from './useTelegramUserMessages';

--- a/packages/plugins/plugin-telegram-user/src/hooks/useTelegramUserClient.ts
+++ b/packages/plugins/plugin-telegram-user/src/hooks/useTelegramUserClient.ts
@@ -1,0 +1,182 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { log } from '@dxos/log';
+
+import { type TelegramUserConnectionStatus } from '#types';
+
+/**
+ * Deferred<T> is a promise plus its resolver — lets us bridge gramjs's
+ * callback-driven login flow (phoneCode, password) into React state.
+ * The user fills a form, we call resolve(value), gramjs unblocks.
+ */
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (err: unknown) => void;
+};
+
+const makeDeferred = <T>(): Deferred<T> => {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+export type StartLoginArgs = {
+  apiId: number;
+  apiHash: string;
+  phoneNumber: string;
+};
+
+export type UseTelegramUserClientResult = {
+  status: TelegramUserConnectionStatus;
+  error?: string;
+  /** Dynamically-imported client (null until gramjs has loaded). */
+  client: any;
+  /** Kick off the login flow. Status will transition to `need-code`, then (maybe) `need-password`, then `connected`. */
+  startLogin: (args: StartLoginArgs) => Promise<string | undefined>;
+  /** Supply the SMS code from the user; unblocks the login promise. */
+  submitCode: (code: string) => void;
+  /** Supply the 2FA password from the user; unblocks the login promise. */
+  submitPassword: (password: string) => void;
+  /** Connect using a previously-saved session string (no login needed). */
+  connectWithSession: (args: { apiId: number; apiHash: string; sessionString: string }) => Promise<void>;
+  /** Fully disconnect and clear the client. */
+  disconnect: () => Promise<void>;
+};
+
+/**
+ * Wraps a single gramjs TelegramClient instance + its login lifecycle.
+ *
+ * gramjs is lazy-loaded on first use (~500 KB bundle) so unused panels don't
+ * pay the cost. The hook keeps a single client across renders and surfaces
+ * its state as a friendly `status` enum.
+ */
+export const useTelegramUserClient = (): UseTelegramUserClientResult => {
+  const [status, setStatus] = useState<TelegramUserConnectionStatus>('disconnected');
+  const [error, setError] = useState<string | undefined>();
+  const [client, setClient] = useState<any>(null);
+
+  const codeDeferredRef = useRef<Deferred<string> | undefined>(undefined);
+  const passwordDeferredRef = useRef<Deferred<string> | undefined>(undefined);
+
+  const loadGramjs = useCallback(async () => {
+    // Lazy import — kept in a Function call so Vite doesn't eager-bundle it.
+    const telegram = await import('telegram');
+    const sessions = await import('telegram/sessions');
+    return { TelegramClient: telegram.TelegramClient, StringSession: sessions.StringSession };
+  }, []);
+
+  const startLogin = useCallback(
+    async ({ apiId, apiHash, phoneNumber }: StartLoginArgs): Promise<string | undefined> => {
+      try {
+        setStatus('logging-in');
+        setError(undefined);
+        const { TelegramClient, StringSession } = await loadGramjs();
+        const session = new StringSession('');
+        const next = new TelegramClient(session, apiId, apiHash, { connectionRetries: 3 });
+        setClient(next);
+
+        codeDeferredRef.current = makeDeferred<string>();
+        passwordDeferredRef.current = makeDeferred<string>();
+
+        await next.start({
+          phoneNumber: async () => phoneNumber,
+          phoneCode: async () => {
+            setStatus('need-code');
+            return codeDeferredRef.current!.promise;
+          },
+          password: async () => {
+            setStatus('need-password');
+            return passwordDeferredRef.current!.promise;
+          },
+          onError: (err: unknown) => {
+            log.warn('telegram-user: login error', { error: String(err) });
+            setError(String(err));
+          },
+        });
+
+        const sessionString = session.save();
+        setStatus('connected');
+        return sessionString;
+      } catch (err) {
+        setStatus('error');
+        setError(err instanceof Error ? err.message : String(err));
+        return undefined;
+      }
+    },
+    [loadGramjs],
+  );
+
+  const submitCode = useCallback((code: string) => {
+    codeDeferredRef.current?.resolve(code);
+    setStatus('logging-in');
+  }, []);
+
+  const submitPassword = useCallback((password: string) => {
+    passwordDeferredRef.current?.resolve(password);
+    setStatus('logging-in');
+  }, []);
+
+  const connectWithSession = useCallback(
+    async ({ apiId, apiHash, sessionString }: { apiId: number; apiHash: string; sessionString: string }) => {
+      try {
+        setStatus('logging-in');
+        setError(undefined);
+        const { TelegramClient, StringSession } = await loadGramjs();
+        const session = new StringSession(sessionString);
+        const next = new TelegramClient(session, apiId, apiHash, { connectionRetries: 3 });
+        await next.connect();
+        setClient(next);
+        setStatus('connected');
+      } catch (err) {
+        setStatus('error');
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [loadGramjs],
+  );
+
+  const disconnect = useCallback(async () => {
+    if (client) {
+      try {
+        await client.disconnect();
+      } catch {
+        // Ignore disconnect errors.
+      }
+    }
+    setClient(null);
+    setStatus('disconnected');
+  }, [client]);
+
+  // Cleanup on unmount.
+  useEffect(
+    () => () => {
+      if (client) {
+        client.disconnect().catch(() => undefined);
+      }
+    },
+    [client],
+  );
+
+  return useMemo(
+    () => ({
+      status,
+      error,
+      client,
+      startLogin,
+      submitCode,
+      submitPassword,
+      connectWithSession,
+      disconnect,
+    }),
+    [status, error, client, startLogin, submitCode, submitPassword, connectWithSession, disconnect],
+  );
+};

--- a/packages/plugins/plugin-telegram-user/src/hooks/useTelegramUserClient.ts
+++ b/packages/plugins/plugin-telegram-user/src/hooks/useTelegramUserClient.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { log } from '@dxos/log';
 
@@ -48,135 +48,202 @@ export type UseTelegramUserClientResult = {
   submitPassword: (password: string) => void;
   /** Connect using a previously-saved session string (no login needed). */
   connectWithSession: (args: { apiId: number; apiHash: string; sessionString: string }) => Promise<void>;
-  /** Fully disconnect and clear the client. */
+  /** Fully disconnect and clear the shared client. */
   disconnect: () => Promise<void>;
 };
 
+// ---------------------------------------------------------------------------
+// Module-level shared state.
+//
+// Previously each useTelegramUserClient() call created its own TelegramClient.
+// With two surfaces (Settings + Feed) that meant two WebSocket connections per
+// user and — worse — "forget session" from Settings left Feed's client still
+// receiving messages until the tab reloaded. Hoisting to module scope gives
+// every consumer the same client + the same disconnect button.
+// ---------------------------------------------------------------------------
+
+type SharedState = {
+  status: TelegramUserConnectionStatus;
+  error?: string;
+  client: any;
+  codeDeferred?: Deferred<string>;
+  passwordDeferred?: Deferred<string>;
+};
+
+let sharedState: SharedState = { status: 'disconnected', client: null };
+
+const listeners = new Set<() => void>();
+
+const setSharedState = (patch: Partial<SharedState>) => {
+  sharedState = { ...sharedState, ...patch };
+  for (const listener of listeners) {
+    listener();
+  }
+};
+
+const loadGramjs = async () => {
+  const telegram = await import('telegram');
+  const sessions = await import('telegram/sessions');
+  return { TelegramClient: telegram.TelegramClient, StringSession: sessions.StringSession };
+};
+
+const startLoginImpl = async ({ apiId, apiHash, phoneNumber }: StartLoginArgs): Promise<string | undefined> => {
+  try {
+    setSharedState({ status: 'logging-in', error: undefined });
+    const { TelegramClient, StringSession } = await loadGramjs();
+    const session = new StringSession('');
+    const next = new TelegramClient(session, apiId, apiHash, { connectionRetries: 3 });
+    setSharedState({ client: next });
+
+    await next.start({
+      phoneNumber: async () => phoneNumber,
+      // Create a fresh deferred *inside* the callback. gramjs retries the
+      // callback on PHONE_CODE_INVALID / PASSWORD_HASH_INVALID — reusing a
+      // resolved deferred would resubmit the stale value forever.
+      phoneCode: async () => {
+        const deferred = makeDeferred<string>();
+        setSharedState({ status: 'need-code', codeDeferred: deferred });
+        return deferred.promise;
+      },
+      password: async () => {
+        const deferred = makeDeferred<string>();
+        setSharedState({ status: 'need-password', passwordDeferred: deferred });
+        return deferred.promise;
+      },
+      onError: (err: unknown) => {
+        log.warn('telegram-user: login error', { error: String(err) });
+        setSharedState({ error: String(err) });
+      },
+    });
+
+    const sessionString = session.save();
+    setSharedState({ status: 'connected', codeDeferred: undefined, passwordDeferred: undefined });
+    return sessionString;
+  } catch (err) {
+    setSharedState({
+      status: 'error',
+      error: err instanceof Error ? err.message : String(err),
+      codeDeferred: undefined,
+      passwordDeferred: undefined,
+    });
+    return undefined;
+  }
+};
+
+const connectWithSessionImpl = async ({
+  apiId,
+  apiHash,
+  sessionString,
+}: {
+  apiId: number;
+  apiHash: string;
+  sessionString: string;
+}): Promise<void> => {
+  // Already connected with a live client — no-op (we could compare session strings, but for now
+  // the first caller wins and the second is a no-op to avoid churning the WebSocket).
+  if (sharedState.client && sharedState.status === 'connected') {
+    return;
+  }
+  try {
+    setSharedState({ status: 'logging-in', error: undefined });
+    const { TelegramClient, StringSession } = await loadGramjs();
+    const session = new StringSession(sessionString);
+    const next = new TelegramClient(session, apiId, apiHash, { connectionRetries: 3 });
+    await next.connect();
+    // connect() only establishes transport. checkAuthorization() verifies the
+    // saved session is still valid; without it we'd mark 'connected' even for
+    // revoked sessions and fail downstream inside getDialogs().
+    const authorized = await next.checkAuthorization();
+    if (!authorized) {
+      await next.disconnect().catch(() => undefined);
+      setSharedState({
+        client: null,
+        status: 'error',
+        error: 'Saved Telegram session is no longer authorized. Please log in again.',
+      });
+      return;
+    }
+    setSharedState({ client: next, status: 'connected' });
+  } catch (err) {
+    setSharedState({
+      status: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+};
+
+const disconnectImpl = async (): Promise<void> => {
+  const { client, codeDeferred, passwordDeferred } = sharedState;
+  // Reject any in-flight login deferreds so start()'s promise chain unblocks.
+  codeDeferred?.reject(new Error('disconnected'));
+  passwordDeferred?.reject(new Error('disconnected'));
+  if (client) {
+    try {
+      await client.disconnect();
+    } catch {
+      // Ignore disconnect errors.
+    }
+  }
+  setSharedState({
+    client: null,
+    status: 'disconnected',
+    error: undefined,
+    codeDeferred: undefined,
+    passwordDeferred: undefined,
+  });
+};
+
+const submitCodeImpl = (code: string) => {
+  const deferred = sharedState.codeDeferred;
+  // Clear the ref first so a duplicate submit doesn't re-resolve an already-
+  // resolved promise, and a fresh prompt cycle can install its own deferred.
+  setSharedState({ codeDeferred: undefined, status: 'logging-in' });
+  deferred?.resolve(code);
+};
+
+const submitPasswordImpl = (password: string) => {
+  const deferred = sharedState.passwordDeferred;
+  setSharedState({ passwordDeferred: undefined, status: 'logging-in' });
+  deferred?.resolve(password);
+};
+
 /**
- * Wraps a single gramjs TelegramClient instance + its login lifecycle.
+ * Wraps the single module-shared TelegramClient + its login lifecycle.
  *
  * gramjs is lazy-loaded on first use (~500 KB bundle) so unused panels don't
- * pay the cost. The hook keeps a single client across renders and surfaces
- * its state as a friendly `status` enum.
+ * pay the cost. Every consumer of this hook gets the same client instance and
+ * observes the same status.
  */
 export const useTelegramUserClient = (): UseTelegramUserClientResult => {
-  const [status, setStatus] = useState<TelegramUserConnectionStatus>('disconnected');
-  const [error, setError] = useState<string | undefined>();
-  const [client, setClient] = useState<any>(null);
+  const [, forceUpdate] = useState(0);
 
-  const codeDeferredRef = useRef<Deferred<string> | undefined>(undefined);
-  const passwordDeferredRef = useRef<Deferred<string> | undefined>(undefined);
-
-  const loadGramjs = useCallback(async () => {
-    // Lazy import — kept in a Function call so Vite doesn't eager-bundle it.
-    const telegram = await import('telegram');
-    const sessions = await import('telegram/sessions');
-    return { TelegramClient: telegram.TelegramClient, StringSession: sessions.StringSession };
+  // Subscribe to shared-state changes.
+  useEffect(() => {
+    const listener = () => forceUpdate((tick) => tick + 1);
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
   }, []);
 
-  const startLogin = useCallback(
-    async ({ apiId, apiHash, phoneNumber }: StartLoginArgs): Promise<string | undefined> => {
-      try {
-        setStatus('logging-in');
-        setError(undefined);
-        const { TelegramClient, StringSession } = await loadGramjs();
-        const session = new StringSession('');
-        const next = new TelegramClient(session, apiId, apiHash, { connectionRetries: 3 });
-        setClient(next);
-
-        codeDeferredRef.current = makeDeferred<string>();
-        passwordDeferredRef.current = makeDeferred<string>();
-
-        await next.start({
-          phoneNumber: async () => phoneNumber,
-          phoneCode: async () => {
-            setStatus('need-code');
-            return codeDeferredRef.current!.promise;
-          },
-          password: async () => {
-            setStatus('need-password');
-            return passwordDeferredRef.current!.promise;
-          },
-          onError: (err: unknown) => {
-            log.warn('telegram-user: login error', { error: String(err) });
-            setError(String(err));
-          },
-        });
-
-        const sessionString = session.save();
-        setStatus('connected');
-        return sessionString;
-      } catch (err) {
-        setStatus('error');
-        setError(err instanceof Error ? err.message : String(err));
-        return undefined;
-      }
-    },
-    [loadGramjs],
-  );
-
-  const submitCode = useCallback((code: string) => {
-    codeDeferredRef.current?.resolve(code);
-    setStatus('logging-in');
-  }, []);
-
-  const submitPassword = useCallback((password: string) => {
-    passwordDeferredRef.current?.resolve(password);
-    setStatus('logging-in');
-  }, []);
-
-  const connectWithSession = useCallback(
-    async ({ apiId, apiHash, sessionString }: { apiId: number; apiHash: string; sessionString: string }) => {
-      try {
-        setStatus('logging-in');
-        setError(undefined);
-        const { TelegramClient, StringSession } = await loadGramjs();
-        const session = new StringSession(sessionString);
-        const next = new TelegramClient(session, apiId, apiHash, { connectionRetries: 3 });
-        await next.connect();
-        setClient(next);
-        setStatus('connected');
-      } catch (err) {
-        setStatus('error');
-        setError(err instanceof Error ? err.message : String(err));
-      }
-    },
-    [loadGramjs],
-  );
-
-  const disconnect = useCallback(async () => {
-    if (client) {
-      try {
-        await client.disconnect();
-      } catch {
-        // Ignore disconnect errors.
-      }
-    }
-    setClient(null);
-    setStatus('disconnected');
-  }, [client]);
-
-  // Cleanup on unmount.
-  useEffect(
-    () => () => {
-      if (client) {
-        client.disconnect().catch(() => undefined);
-      }
-    },
-    [client],
-  );
+  const startLogin = useCallback(startLoginImpl, []);
+  const submitCode = useCallback(submitCodeImpl, []);
+  const submitPassword = useCallback(submitPasswordImpl, []);
+  const connectWithSession = useCallback(connectWithSessionImpl, []);
+  const disconnect = useCallback(disconnectImpl, []);
 
   return useMemo(
     () => ({
-      status,
-      error,
-      client,
+      status: sharedState.status,
+      error: sharedState.error,
+      client: sharedState.client,
       startLogin,
       submitCode,
       submitPassword,
       connectWithSession,
       disconnect,
     }),
-    [status, error, client, startLogin, submitCode, submitPassword, connectWithSession, disconnect],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sharedState.status, sharedState.error, sharedState.client, startLogin, submitCode, submitPassword, connectWithSession, disconnect],
   );
 };

--- a/packages/plugins/plugin-telegram-user/src/hooks/useTelegramUserMessages.test.ts
+++ b/packages/plugins/plugin-telegram-user/src/hooks/useTelegramUserMessages.test.ts
@@ -52,10 +52,30 @@ describe('extractChatInfo', () => {
 describe('normalizeMessage', () => {
   const chat = { id: '42', title: 'Bob', type: 'user' as const, unread: 0 };
 
-  test('returns undefined for messages with no text (media-only, service, etc.)', ({ expect }) => {
+  test('returns undefined for service messages with no text and no media', ({ expect }) => {
     expect(normalizeMessage({ id: 1, message: '', date: 100 }, chat)).toBeUndefined();
     expect(normalizeMessage({ id: 1, message: undefined, date: 100 }, chat)).toBeUndefined();
     expect(normalizeMessage({ id: 1, date: 100 }, chat)).toBeUndefined();
+  });
+
+  test('renders [media] for photo-only messages', ({ expect }) => {
+    const out = normalizeMessage({ id: 1, message: '', date: 100, photo: { id: 'abc' } }, chat);
+    expect(out?.text).toBe('[media]');
+  });
+
+  test('renders [media] for messages with msg.media set', ({ expect }) => {
+    const out = normalizeMessage({ id: 1, date: 100, media: { className: 'MessageMediaPhoto' } }, chat);
+    expect(out?.text).toBe('[media]');
+  });
+
+  test('renders [media] for sticker messages', ({ expect }) => {
+    const out = normalizeMessage({ id: 1, message: '', date: 100, sticker: {} }, chat);
+    expect(out?.text).toBe('[media]');
+  });
+
+  test('still prefers real text over [media] placeholder when both are present', ({ expect }) => {
+    const out = normalizeMessage({ id: 1, message: 'caption', date: 100, photo: {} }, chat);
+    expect(out?.text).toBe('caption');
   });
 
   test('populates a minimal message from chat info + msg.message', ({ expect }) => {

--- a/packages/plugins/plugin-telegram-user/src/hooks/useTelegramUserMessages.test.ts
+++ b/packages/plugins/plugin-telegram-user/src/hooks/useTelegramUserMessages.test.ts
@@ -1,0 +1,135 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { extractChatInfo, normalizeMessage } from './useTelegramUserMessages';
+
+describe('extractChatInfo', () => {
+  test('handles a regular User entity', ({ expect }) => {
+    const info = extractChatInfo({
+      className: 'User',
+      id: 12345n,
+      firstName: 'Alice',
+      lastName: 'Example',
+      username: 'alice',
+    });
+    expect(info).toEqual({ id: '12345', title: 'Alice Example', type: 'user', unread: 0 });
+  });
+
+  test('falls back to username when names are missing', ({ expect }) => {
+    const info = extractChatInfo({ className: 'User', id: 7n, firstName: undefined, lastName: undefined, username: 'lone' });
+    expect(info?.title).toBe('lone');
+  });
+
+  test('falls back to "User {id}" when nothing else is available', ({ expect }) => {
+    const info = extractChatInfo({ className: 'User', id: 9n, firstName: undefined, lastName: undefined, username: undefined });
+    expect(info?.title).toBe('User 9');
+  });
+
+  test('handles a Chat (group) entity', ({ expect }) => {
+    const info = extractChatInfo({ className: 'Chat', id: 100n, title: 'Team' });
+    expect(info).toEqual({ id: '100', title: 'Team', type: 'chat', unread: 0 });
+  });
+
+  test('handles a Channel entity', ({ expect }) => {
+    const info = extractChatInfo({ className: 'Channel', id: 200n, title: 'Announce' });
+    expect(info).toEqual({ id: '200', title: 'Announce', type: 'channel', unread: 0 });
+  });
+
+  test('returns undefined for unknown entity types', ({ expect }) => {
+    expect(extractChatInfo({ className: 'ChatForbidden', id: 1n })).toBeUndefined();
+    expect(extractChatInfo(undefined)).toBeUndefined();
+    expect(extractChatInfo(null)).toBeUndefined();
+  });
+
+  test('returns undefined when the id is missing', ({ expect }) => {
+    expect(extractChatInfo({ className: 'User', id: undefined })).toBeUndefined();
+  });
+});
+
+describe('normalizeMessage', () => {
+  const chat = { id: '42', title: 'Bob', type: 'user' as const, unread: 0 };
+
+  test('returns undefined for messages with no text (media-only, service, etc.)', ({ expect }) => {
+    expect(normalizeMessage({ id: 1, message: '', date: 100 }, chat)).toBeUndefined();
+    expect(normalizeMessage({ id: 1, message: undefined, date: 100 }, chat)).toBeUndefined();
+    expect(normalizeMessage({ id: 1, date: 100 }, chat)).toBeUndefined();
+  });
+
+  test('populates a minimal message from chat info + msg.message', ({ expect }) => {
+    const out = normalizeMessage({ id: 99, message: 'hi', date: 1735_000_000, out: false }, chat);
+    expect(out).toMatchObject({
+      id: '42:99',
+      chatId: '42',
+      chatTitle: 'Bob',
+      chatType: 'user',
+      text: 'hi',
+      date: 1735_000_000,
+      outgoing: false,
+    });
+  });
+
+  test('derives chatId from a DM (PeerUser) when the chat arg is missing', ({ expect }) => {
+    const out = normalizeMessage(
+      { id: 1, message: 'hi', date: 1, peerId: { className: 'PeerUser', userId: 55n } },
+      undefined,
+    );
+    expect(out?.chatId).toBe('55');
+  });
+
+  test('derives chatId from a GROUP (PeerChat) when the chat arg is missing', ({ expect }) => {
+    // If extractChatInfo didn't resolve the entity (e.g. access hash miss),
+    // we still need to bucket the message into the right chat. Previously we
+    // only looked at peerId.userId, so group messages fell off.
+    const out = normalizeMessage(
+      { id: 1, message: 'hi', date: 1, peerId: { className: 'PeerChat', chatId: 777n } },
+      undefined,
+    );
+    expect(out?.chatId).toBe('777');
+  });
+
+  test('derives chatId from a CHANNEL (PeerChannel) when the chat arg is missing', ({ expect }) => {
+    const out = normalizeMessage(
+      { id: 1, message: 'hi', date: 1, peerId: { className: 'PeerChannel', channelId: 888n } },
+      undefined,
+    );
+    expect(out?.chatId).toBe('888');
+  });
+
+  test('populates fromName from sender.firstName + lastName', ({ expect }) => {
+    const out = normalizeMessage(
+      { id: 1, message: 'hi', date: 1, sender: { firstName: 'Jane', lastName: 'Doe' } },
+      chat,
+    );
+    expect(out?.fromName).toBe('Jane Doe');
+  });
+
+  test('skips undefined surname gracefully', ({ expect }) => {
+    const out = normalizeMessage({ id: 1, message: 'hi', date: 1, sender: { firstName: 'Jane' } }, chat);
+    expect(out?.fromName).toBe('Jane');
+  });
+
+  test('stringifies BigInt senderId without the "n" suffix', ({ expect }) => {
+    const out = normalizeMessage({ id: 1, message: 'hi', date: 1, senderId: 1234567890n }, chat);
+    expect(out?.fromId).toBe('1234567890');
+  });
+
+  test('flags outgoing messages', ({ expect }) => {
+    const out = normalizeMessage({ id: 1, message: 'hi', date: 1, out: true }, chat);
+    expect(out?.outgoing).toBe(true);
+  });
+
+  test('falls back to now() when date is missing', ({ expect }) => {
+    const before = Math.floor(Date.now() / 1000);
+    const out = normalizeMessage({ id: 1, message: 'hi' }, chat);
+    const after = Math.floor(Date.now() / 1000);
+    expect(out?.date).toBeGreaterThanOrEqual(before);
+    expect(out?.date).toBeLessThanOrEqual(after);
+  });
+
+  test('returns undefined when no chatId can be resolved at all', ({ expect }) => {
+    expect(normalizeMessage({ id: 1, message: 'hi', date: 1 }, undefined)).toBeUndefined();
+  });
+});

--- a/packages/plugins/plugin-telegram-user/src/hooks/useTelegramUserMessages.ts
+++ b/packages/plugins/plugin-telegram-user/src/hooks/useTelegramUserMessages.ts
@@ -65,7 +65,9 @@ export const useTelegramUserMessages = (client: any | null) => {
           if (chatInfo) {
             trackChat(chatInfo);
           }
-          if (dialog.message && typeof dialog.message.message === 'string' && dialog.message.message.length > 0) {
+          // normalizeMessage handles the text-vs-media decision itself; let it run
+          // on anything we got back and just use its undefined return as the filter.
+          if (dialog.message) {
             const normalized = normalizeMessage(dialog.message, chatInfo);
             if (normalized) {
               seed.push(normalized);
@@ -161,9 +163,27 @@ export const extractChatInfo = (entity: any): TelegramUserChat | undefined => {
   return undefined;
 };
 
+/** Heuristic: does this gramjs Message have attached media we should surface as [media]? */
+const hasMedia = (msg: any): boolean => {
+  if (!msg) {
+    return false;
+  }
+  if (msg.media) {
+    return true;
+  }
+  if (msg.photo || msg.document || msg.video || msg.audio || msg.sticker || msg.voice) {
+    return true;
+  }
+  return false;
+};
+
 /** Flatten a gramjs Message into the feed's shape. */
 export const normalizeMessage = (msg: any, chat: TelegramUserChat | undefined): TelegramUserMessage | undefined => {
-  const text = typeof msg?.message === 'string' ? msg.message : '';
+  const rawText = typeof msg?.message === 'string' ? msg.message : '';
+  // If text is empty but media is attached, render a [media] placeholder
+  // instead of dropping the message. Matches the behavior documented in
+  // the plugin README and keeps the unified inbox complete.
+  const text = rawText || (hasMedia(msg) ? '[media]' : '');
   if (!text) {
     return undefined;
   }

--- a/packages/plugins/plugin-telegram-user/src/hooks/useTelegramUserMessages.ts
+++ b/packages/plugins/plugin-telegram-user/src/hooks/useTelegramUserMessages.ts
@@ -1,0 +1,188 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { log } from '@dxos/log';
+
+import { type TelegramUserChat } from '#types';
+
+/** Normalized message pushed into the feed. */
+export type TelegramUserMessage = {
+  /** Client-side compound id: `${chatId}:${messageId}`. */
+  readonly id: string;
+  readonly chatId: string;
+  readonly chatTitle: string;
+  readonly chatType: 'user' | 'chat' | 'channel';
+  readonly fromId?: string;
+  readonly fromName?: string;
+  readonly text: string;
+  /** Unix seconds. */
+  readonly date: number;
+  /** True if this message was sent by the logged-in user (outgoing). */
+  readonly outgoing: boolean;
+};
+
+const MAX_MESSAGES = 500;
+
+/**
+ * Subscribes to NewMessage events on a connected gramjs client and maintains
+ * a rolling feed of recent messages across every chat the user is in.
+ *
+ * Prefetches recent dialogs on connect so the feed isn't empty before the
+ * first new message arrives.
+ */
+export const useTelegramUserMessages = (client: any | null) => {
+  const [messages, setMessages] = useState<TelegramUserMessage[]>([]);
+  const [chats, setChats] = useState<TelegramUserChat[]>([]);
+  const [error, setError] = useState<string | undefined>();
+  const chatsByIdRef = useRef(new Map<string, TelegramUserChat>());
+  const trackChat = useCallback((chat: TelegramUserChat) => {
+    const existing = chatsByIdRef.current.get(chat.id);
+    if (existing && existing.title === chat.title && existing.type === chat.type) {
+      return;
+    }
+    chatsByIdRef.current.set(chat.id, chat);
+    setChats(Array.from(chatsByIdRef.current.values()));
+  }, []);
+
+  // Prefetch recent dialogs so the feed shows history immediately.
+  useEffect(() => {
+    if (!client || !client.connected) {
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const dialogs = await client.getDialogs({ limit: 30 });
+        if (cancelled) {
+          return;
+        }
+        const seed: TelegramUserMessage[] = [];
+        for (const dialog of dialogs) {
+          const chatInfo = extractChatInfo(dialog.entity);
+          if (chatInfo) {
+            trackChat(chatInfo);
+          }
+          if (dialog.message && typeof dialog.message.message === 'string' && dialog.message.message.length > 0) {
+            const normalized = normalizeMessage(dialog.message, chatInfo);
+            if (normalized) {
+              seed.push(normalized);
+            }
+          }
+        }
+        seed.sort((first, second) => first.date - second.date);
+        setMessages(seed.slice(-MAX_MESSAGES));
+      } catch (err) {
+        log.warn('telegram-user: getDialogs failed', { error: String(err) });
+        setError(String(err));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, trackChat]);
+
+  // Subscribe to new messages.
+  useEffect(() => {
+    if (!client) {
+      return;
+    }
+    let cancelled = false;
+    let eventsMod: any;
+    const handler = async (event: any) => {
+      if (cancelled) {
+        return;
+      }
+      try {
+        const chatEntity = await event.getChat().catch(() => undefined);
+        const chatInfo = extractChatInfo(chatEntity);
+        if (chatInfo) {
+          trackChat(chatInfo);
+        }
+        const normalized = normalizeMessage(event.message, chatInfo);
+        if (!normalized) {
+          return;
+        }
+        setMessages((prev) => [...prev, normalized].slice(-MAX_MESSAGES));
+      } catch (err) {
+        log.warn('telegram-user: event handler failed', { error: String(err) });
+      }
+    };
+    (async () => {
+      try {
+        eventsMod = await import('telegram/events');
+        client.addEventHandler(handler, new eventsMod.NewMessage({}));
+      } catch (err) {
+        log.warn('telegram-user: subscribe failed', { error: String(err) });
+        setError(String(err));
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (eventsMod && client) {
+        try {
+          client.removeEventHandler(handler, new eventsMod.NewMessage({}));
+        } catch {
+          // Ignore removal errors on disconnect.
+        }
+      }
+    };
+  }, [client, trackChat]);
+
+  return { messages, chats, error };
+};
+
+/** Produce a minimal chat descriptor from a gramjs entity (User / Chat / Channel). */
+const extractChatInfo = (entity: any): TelegramUserChat | undefined => {
+  if (!entity) {
+    return undefined;
+  }
+  const id = String(entity.id ?? '');
+  if (!id) {
+    return undefined;
+  }
+  if (entity.className === 'User') {
+    const name = [entity.firstName, entity.lastName].filter(Boolean).join(' ');
+    return {
+      id,
+      title: name || entity.username || `User ${id}`,
+      type: 'user',
+      unread: 0,
+    };
+  }
+  if (entity.className === 'Chat') {
+    return { id, title: entity.title ?? `Chat ${id}`, type: 'chat', unread: 0 };
+  }
+  if (entity.className === 'Channel') {
+    return { id, title: entity.title ?? `Channel ${id}`, type: 'channel', unread: 0 };
+  }
+  return undefined;
+};
+
+/** Flatten a gramjs Message into the feed's shape. */
+const normalizeMessage = (msg: any, chat: TelegramUserChat | undefined): TelegramUserMessage | undefined => {
+  const text = typeof msg?.message === 'string' ? msg.message : '';
+  if (!text) {
+    return undefined;
+  }
+  const chatId = chat?.id ?? String(msg?.chatId ?? msg?.peerId?.userId ?? '');
+  if (!chatId) {
+    return undefined;
+  }
+  const fromId = msg.senderId ? String(msg.senderId) : undefined;
+  return {
+    id: `${chatId}:${msg.id}`,
+    chatId,
+    chatTitle: chat?.title ?? `Chat ${chatId}`,
+    chatType: chat?.type ?? 'user',
+    fromId,
+    fromName: msg.sender?.firstName
+      ? [msg.sender.firstName, msg.sender.lastName].filter(Boolean).join(' ')
+      : undefined,
+    text,
+    date: Number(msg.date ?? Math.floor(Date.now() / 1000)),
+    outgoing: Boolean(msg.out),
+  };
+};

--- a/packages/plugins/plugin-telegram-user/src/hooks/useTelegramUserMessages.ts
+++ b/packages/plugins/plugin-telegram-user/src/hooks/useTelegramUserMessages.ts
@@ -135,7 +135,7 @@ export const useTelegramUserMessages = (client: any | null) => {
 };
 
 /** Produce a minimal chat descriptor from a gramjs entity (User / Chat / Channel). */
-const extractChatInfo = (entity: any): TelegramUserChat | undefined => {
+export const extractChatInfo = (entity: any): TelegramUserChat | undefined => {
   if (!entity) {
     return undefined;
   }
@@ -162,12 +162,18 @@ const extractChatInfo = (entity: any): TelegramUserChat | undefined => {
 };
 
 /** Flatten a gramjs Message into the feed's shape. */
-const normalizeMessage = (msg: any, chat: TelegramUserChat | undefined): TelegramUserMessage | undefined => {
+export const normalizeMessage = (msg: any, chat: TelegramUserChat | undefined): TelegramUserMessage | undefined => {
   const text = typeof msg?.message === 'string' ? msg.message : '';
   if (!text) {
     return undefined;
   }
-  const chatId = chat?.id ?? String(msg?.chatId ?? msg?.peerId?.userId ?? '');
+  // Fall back to msg.chatId, then to whichever field peerId happens to carry
+  // (PeerUser→userId, PeerChat→chatId, PeerChannel→channelId). Missing any of
+  // these meant group/channel messages were silently dropped from the feed
+  // whenever the entity wasn't resolvable via access hash.
+  const peerFallback =
+    msg?.chatId ?? msg?.peerId?.userId ?? msg?.peerId?.chatId ?? msg?.peerId?.channelId;
+  const chatId = chat?.id ?? (peerFallback != null ? String(peerFallback) : '');
   if (!chatId) {
     return undefined;
   }

--- a/packages/plugins/plugin-telegram-user/src/index.ts
+++ b/packages/plugins/plugin-telegram-user/src/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export { meta } from './meta';
+export { TelegramUserPlugin } from './TelegramUserPlugin';

--- a/packages/plugins/plugin-telegram-user/src/meta.ts
+++ b/packages/plugins/plugin-telegram-user/src/meta.ts
@@ -1,0 +1,12 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Plugin } from '@dxos/app-framework';
+
+export const meta: Plugin.Meta = {
+  id: 'org.dxos.plugin.telegram.user',
+  name: 'Telegram',
+  description: 'Personal Telegram account sync — unified inbox of all your DMs, groups, and channels.',
+  icon: 'ph--telegram-logo--regular',
+};

--- a/packages/plugins/plugin-telegram-user/src/translations.ts
+++ b/packages/plugins/plugin-telegram-user/src/translations.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Resource } from '@dxos/react-ui';
+
+import { meta } from '#meta';
+
+export const translations = [
+  {
+    'en-US': {
+      [meta.id]: {
+        'plugin.name': 'Telegram',
+      },
+    },
+  },
+] as const satisfies Resource[];

--- a/packages/plugins/plugin-telegram-user/src/types/index.ts
+++ b/packages/plugins/plugin-telegram-user/src/types/index.ts
@@ -1,0 +1,49 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Schema from 'effect/Schema';
+
+import { Capability } from '@dxos/app-framework';
+
+import { meta } from '#meta';
+
+/** MTProto client connection status. */
+export type TelegramUserConnectionStatus =
+  | 'disconnected'
+  | 'need-credentials'
+  | 'logging-in'
+  | 'need-code'
+  | 'need-password'
+  | 'connected'
+  | 'error';
+
+/** A single chat discovered as messages arrive. */
+export type TelegramUserChat = {
+  id: string;
+  title: string;
+  type: 'user' | 'chat' | 'channel';
+  unread: number;
+};
+
+/** Settings persisted per-plugin. The session string is equivalent to a Telegram login — guard it. */
+export namespace TelegramUserCapabilities {
+  export const SettingsSchema = Schema.mutable(
+    Schema.Struct({
+      /** API ID from https://my.telegram.org (integer as string for KVS-safety). */
+      apiId: Schema.optional(Schema.String),
+      /** API hash from https://my.telegram.org. */
+      apiHash: Schema.optional(Schema.String),
+      /** Phone number used for the initial login. */
+      phoneNumber: Schema.optional(Schema.String),
+      /** StringSession payload saved after a successful login. Equivalent to a Telegram login cookie. */
+      sessionString: Schema.optional(Schema.String),
+    }),
+  );
+
+  export type Settings = Schema.Schema.Type<typeof SettingsSchema>;
+
+  export const Settings = Capability.make<import('@effect-atom/atom').Atom.Writable<Settings>>(
+    `${meta.id}.capability.settings`,
+  );
+}

--- a/packages/plugins/plugin-telegram-user/tsconfig.json
+++ b/packages/plugins/plugin-telegram-user/tsconfig.json
@@ -1,0 +1,59 @@
+{
+  "extends": [
+    "../../../tsconfig.base.json"
+  ],
+  "compilerOptions": {
+    "types": [
+      "node"
+    ]
+  },
+  "exclude": [
+    "*.t.ts"
+  ],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../../common/effect"
+    },
+    {
+      "path": "../../common/log"
+    },
+    {
+      "path": "../../common/util"
+    },
+    {
+      "path": "../../core/echo/echo"
+    },
+    {
+      "path": "../../core/echo/echo-atom"
+    },
+    {
+      "path": "../../sdk/app-framework"
+    },
+    {
+      "path": "../../sdk/app-graph"
+    },
+    {
+      "path": "../../sdk/app-toolkit"
+    },
+    {
+      "path": "../../sdk/react-client"
+    },
+    {
+      "path": "../../ui/react-ui"
+    },
+    {
+      "path": "../../ui/react-ui-components"
+    },
+    {
+      "path": "../../ui/ui-theme"
+    },
+    {
+      "path": "../plugin-graph"
+    }
+  ]
+}

--- a/packages/plugins/plugin-telegram-user/vitest.config.ts
+++ b/packages/plugins/plugin-telegram-user/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1656,6 +1656,9 @@ catalogs:
     tauri-plugin-web-auth-api:
       specifier: ^1.0.0
       version: 1.0.0
+    telegram:
+      specifier: ^2.26.22
+      version: 2.26.22
     three:
       specifier: ^0.178.0
       version: 0.178.0
@@ -13307,7 +13310,7 @@ importers:
         specifier: 'catalog:'
         version: 0.5.1(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
       telegram:
-        specifier: ^2.26.22
+        specifier: 'catalog:'
         version: 2.26.22
     devDependencies:
       '@dxos/react-ui':
@@ -52519,13 +52522,13 @@ snapshots:
 
   fs-extra@11.3.2:
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.0
 
   fs-extra@8.1.0:
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
 
@@ -52550,7 +52553,7 @@ snapshots:
 
   fstream@1.0.12:
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       inherits: 2.0.4
       mkdirp: 0.5.6
       rimraf: 2.7.1
@@ -54280,7 +54283,7 @@ snapshots:
 
   jsonfile@4.0.0:
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
 
   jsonfile@6.1.0:
     dependencies:
@@ -60333,7 +60336,7 @@ snapshots:
       buffer-indexof-polyfill: 1.0.2
       duplexer2: 0.1.4
       fstream: 1.0.12
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       listenercount: 1.0.1
       readable-stream: 2.3.7
       setimmediate: 1.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1916,7 +1916,7 @@ importers:
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
-        version: 0.8.61(@cloudflare/workers-types@4.20260303.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4)
+        version: 0.8.61(@cloudflare/workers-types@4.20260303.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vitest@3.2.4)
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 4.20260303.0
@@ -2051,7 +2051,7 @@ importers:
         version: 4.0.0(@swc/helpers@0.5.17)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 3.2.4(playwright@1.57.0)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)(webdriverio@8.33.1(typescript@6.0.2))
+        version: 3.2.4(bufferutil@4.1.0)(playwright@1.57.0)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)(webdriverio@8.33.1(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
@@ -2138,10 +2138,10 @@ importers:
         version: 8.0.1
       jsdom:
         specifier: 'catalog:'
-        version: 27.0.0(canvas@3.2.0)(postcss@8.5.6)
+        version: 27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10)
       jsdom-global:
         specifier: 'catalog:'
-        version: 3.0.2(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6))
+        version: 3.0.2(jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10))
       json-stringify-safe:
         specifier: 'catalog:'
         version: 5.0.1
@@ -2207,7 +2207,7 @@ importers:
         version: 14.2.5
       storybook:
         specifier: 'catalog:'
-        version: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.2.0
@@ -2258,16 +2258,16 @@ importers:
         version: 5.1.4(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       wait-on:
         specifier: 'catalog:'
         version: 8.0.3
       webdriverio:
         specifier: 'catalog:'
-        version: 8.33.1(typescript@6.0.2)
+        version: 8.33.1(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)
       wrangler:
         specifier: '>=4.59.1'
-        version: 4.68.1(@cloudflare/workers-types@4.20260303.0)
+        version: 4.68.1(@cloudflare/workers-types@4.20260303.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       yaml:
         specifier: 'catalog:'
         version: 2.8.2
@@ -2500,6 +2500,9 @@ importers:
       '@dxos/plugin-table':
         specifier: workspace:*
         version: link:../../plugins/plugin-table
+      '@dxos/plugin-telegram-user':
+        specifier: workspace:*
+        version: link:../../plugins/plugin-telegram-user
       '@dxos/plugin-template':
         specifier: workspace:*
         version: link:../../plugins/plugin-template
@@ -2665,7 +2668,7 @@ importers:
         version: 0.94.4(effect@3.20.0)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 0.104.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
+        version: 0.104.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(bufferutil@4.1.0)(effect@3.20.0)(utf-8-validate@5.0.10)
       '@tauri-apps/cli':
         specifier: 'catalog:'
         version: 2.8.4
@@ -2683,13 +2686,13 @@ importers:
         version: 2.2.0
       jsdom:
         specifier: 'catalog:'
-        version: 27.0.0(canvas@3.2.0)(postcss@8.5.6)
+        version: 27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10)
       lit:
         specifier: 'catalog:'
         version: 3.3.1
       pwa-asset-generator:
         specifier: 'catalog:'
-        version: 6.4.0
+        version: 6.4.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       rollup-plugin-visualizer:
         specifier: 'catalog:'
         version: 5.12.0(rollup@4.46.2)
@@ -2876,7 +2879,7 @@ importers:
         version: 4.20260303.0
       wrangler:
         specifier: '>=4.59.1'
-        version: 4.68.1(@cloudflare/workers-types@4.20260303.0)
+        version: 4.68.1(@cloudflare/workers-types@4.20260303.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   packages/apps/tasks:
     dependencies:
@@ -3064,7 +3067,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       partykit:
         specifier: 'catalog:'
-        version: 0.0.103
+        version: 0.0.103(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       vite:
         specifier: '>=7.1.11'
         version: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -3856,7 +3859,7 @@ importers:
         version: 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       storybook:
         specifier: 'catalog:'
-        version: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
     devDependencies:
       '@types/react':
         specifier: ~19.2.7
@@ -3890,7 +3893,7 @@ importers:
         version: 4.6.1
       storybook:
         specifier: 10.2.0
-        version: 10.2.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 10.2.0(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
     devDependencies:
       '@dxos/react-ui':
         specifier: workspace:*
@@ -4023,7 +4026,7 @@ importers:
         version: 19.2.3(react@19.2.3)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/common/web-context-solid:
     dependencies:
@@ -4114,7 +4117,7 @@ importers:
         version: 0.94.4(effect@3.20.0)
       '@effect/platform-node':
         specifier: 'catalog:'
-        version: 0.104.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
+        version: 0.104.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(bufferutil@4.1.0)(effect@3.20.0)(utf-8-validate@5.0.10)
       '@effect/workflow':
         specifier: 'catalog:'
         version: 0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
@@ -5073,7 +5076,7 @@ importers:
         version: 2.11.10(@testing-library/jest-dom@6.9.1)(solid-js@1.9.11)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/core/echo/feed:
     dependencies:
@@ -5424,7 +5427,7 @@ importers:
         version: link:../protocols
       miniflare:
         specifier: 'catalog:'
-        version: 4.20251210.0
+        version: 4.20251210.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   packages/core/functions-testing:
     dependencies:
@@ -5619,10 +5622,10 @@ importers:
         version: 1.9.0
       isomorphic-ws:
         specifier: 'catalog:'
-        version: 5.0.0(ws@8.18.3)
+        version: 5.0.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ws:
         specifier: '>=8.17.1'
-        version: 8.18.3
+        version: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     devDependencies:
       '@dxos/test-utils':
         specifier: workspace:*
@@ -5668,10 +5671,10 @@ importers:
         version: link:../../../common/util
       isomorphic-ws:
         specifier: 'catalog:'
-        version: 5.0.0(ws@8.18.3)
+        version: 5.0.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ws:
         specifier: '>=8.17.1'
-        version: 8.18.3
+        version: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     devDependencies:
       '@dxos/keyring':
         specifier: workspace:*
@@ -6031,10 +6034,10 @@ importers:
         version: link:../rpc
       isomorphic-ws:
         specifier: 'catalog:'
-        version: 5.0.0(ws@8.18.3)
+        version: 5.0.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ws:
         specifier: '>=8.17.1'
-        version: 8.18.3
+        version: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   packages/core/operation:
     dependencies:
@@ -6077,7 +6080,7 @@ importers:
         version: 3.20.0
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/core/protocols:
     dependencies:
@@ -6288,7 +6291,7 @@ importers:
         version: 0.94.4(effect@3.20.0)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 0.87.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
+        version: 0.87.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(bufferutil@4.1.0)(effect@3.20.0)(utf-8-validate@5.0.10)
       '@effect/printer':
         specifier: 'catalog:'
         version: 0.47.0(@effect/typeclass@0.38.0(effect@3.20.0))(effect@3.20.0)
@@ -6370,7 +6373,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/devtools/cli-util:
     dependencies:
@@ -6422,7 +6425,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/devtools/devtools:
     dependencies:
@@ -6596,7 +6599,7 @@ importers:
         version: 3.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(use-resize-observer@9.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       isomorphic-ws:
         specifier: 'catalog:'
-        version: 5.0.0(ws@8.18.3)
+        version: 5.0.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       localforage:
         specifier: 'catalog:'
         version: 1.10.0
@@ -6635,7 +6638,7 @@ importers:
         version: 9.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ws:
         specifier: '>=8.17.1'
-        version: 8.18.3
+        version: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     devDependencies:
       '@babel/core':
         specifier: 'catalog:'
@@ -6835,7 +6838,7 @@ importers:
         version: 2.5.1(patch_hash=be766431e3a6459feb58222ae46cd90e3ad69b2350653ea95d8707259278baa8)
       '@automerge/automerge-repo-network-websocket':
         specifier: 'catalog:'
-        version: 2.5.1
+        version: 2.5.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@automerge/automerge-repo-storage-indexeddb':
         specifier: 'catalog:'
         version: 2.5.1
@@ -6958,7 +6961,7 @@ importers:
         version: 5.3.2
       isomorphic-ws:
         specifier: 'catalog:'
-        version: 5.0.0(ws@8.18.3)
+        version: 5.0.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       js-yaml:
         specifier: 'catalog:'
         version: 4.1.1
@@ -6982,10 +6985,10 @@ importers:
         version: 9.0.1
       websocket-stream:
         specifier: 'catalog:'
-        version: 5.5.2
+        version: 5.5.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       ws:
         specifier: '>=8.17.1'
-        version: 8.18.3
+        version: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       yargs:
         specifier: 'catalog:'
         version: 16.2.0
@@ -7120,7 +7123,7 @@ importers:
         version: link:../../common/node-std
       discord.js:
         specifier: 'catalog:'
-        version: 14.14.1
+        version: 14.14.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     devDependencies:
       '@babel/core':
         specifier: 'catalog:'
@@ -8248,7 +8251,7 @@ importers:
         version: link:../../common/storybook-utils
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 10.2.12(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 10.2.12(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@types/react':
         specifier: ~19.2.7
         version: 19.2.7
@@ -9076,7 +9079,7 @@ importers:
         version: link:../../ui/ui-theme
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 10.2.12(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 10.2.12(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@types/react':
         specifier: ~19.2.7
         version: 19.2.7
@@ -13268,6 +13271,67 @@ importers:
         specifier: '>=7.1.11'
         version: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/plugins/plugin-telegram-user:
+    dependencies:
+      '@dxos/app-framework':
+        specifier: workspace:*
+        version: link:../../sdk/app-framework
+      '@dxos/app-graph':
+        specifier: workspace:*
+        version: link:../../sdk/app-graph
+      '@dxos/app-toolkit':
+        specifier: workspace:*
+        version: link:../../sdk/app-toolkit
+      '@dxos/echo':
+        specifier: workspace:*
+        version: link:../../core/echo/echo
+      '@dxos/echo-atom':
+        specifier: workspace:*
+        version: link:../../core/echo/echo-atom
+      '@dxos/effect':
+        specifier: workspace:*
+        version: link:../../common/effect
+      '@dxos/log':
+        specifier: workspace:*
+        version: link:../../common/log
+      '@dxos/plugin-graph':
+        specifier: workspace:*
+        version: link:../plugin-graph
+      '@dxos/react-client':
+        specifier: workspace:*
+        version: link:../../sdk/react-client
+      '@dxos/util':
+        specifier: workspace:*
+        version: link:../../common/util
+      '@effect-atom/atom':
+        specifier: 'catalog:'
+        version: 0.5.1(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
+      telegram:
+        specifier: ^2.26.22
+        version: 2.26.22
+    devDependencies:
+      '@dxos/react-ui':
+        specifier: workspace:*
+        version: link:../../ui/react-ui
+      '@dxos/react-ui-components':
+        specifier: workspace:*
+        version: link:../../ui/react-ui-components
+      '@dxos/ui-theme':
+        specifier: workspace:*
+        version: link:../../ui/ui-theme
+      '@effect-atom/atom-react':
+        specifier: 'catalog:'
+        version: 0.5.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)(react@19.2.3)(scheduler@0.27.0)
+      '@types/react':
+        specifier: ~19.2.7
+        version: 19.2.7
+      effect:
+        specifier: 3.20.0
+        version: 3.20.0
+      react:
+        specifier: ~19.2.3
+        version: 19.2.3
+
   packages/plugins/plugin-template:
     dependencies:
       '@dxos/app-framework':
@@ -13811,7 +13875,7 @@ importers:
         version: 0.73.2(@effect/platform@0.94.4(effect@3.20.0))(@effect/printer-ansi@0.47.0(@effect/typeclass@0.38.0(effect@3.20.0))(effect@3.20.0))(@effect/printer@0.47.0(@effect/typeclass@0.38.0(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
       '@effect/platform-bun':
         specifier: 'catalog:'
-        version: 0.87.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
+        version: 0.87.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(bufferutil@4.1.0)(effect@3.20.0)(utf-8-validate@5.0.10)
       '@tauri-apps/api':
         specifier: 'catalog:'
         version: 2.10.1
@@ -17828,10 +17892,10 @@ importers:
         version: 3.20.0
       happy-dom:
         specifier: 'catalog:'
-        version: 20.7.0
+        version: 20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       jsdom:
         specifier: 'catalog:'
-        version: 27.0.0(canvas@3.2.0)(postcss@8.5.6)
+        version: 27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10)
       mocha:
         specifier: 'catalog:'
         version: 10.6.0
@@ -19786,10 +19850,10 @@ importers:
         version: 3.20.0
       happy-dom:
         specifier: 'catalog:'
-        version: 20.7.0
+        version: 20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       jsdom:
         specifier: 'catalog:'
-        version: 27.0.0(canvas@3.2.0)(postcss@8.5.6)
+        version: 27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10)
       mocha:
         specifier: 'catalog:'
         version: 10.6.0
@@ -19977,7 +20041,7 @@ importers:
         version: 0.1.3
       ink:
         specifier: 'catalog:'
-        version: 6.3.1(@types/react@19.2.7)(react@19.2.3)
+        version: 6.3.1(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
       react:
         specifier: ~19.2.3
         version: 19.2.3
@@ -20000,28 +20064,28 @@ importers:
         version: link:../vite-plugin-icons
       '@storybook/addon-docs':
         specifier: 'catalog:'
-        version: 10.2.12(@types/react@19.2.7)(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+        version: 10.2.12(@types/react@19.2.7)(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
       '@storybook/addon-links':
         specifier: 'catalog:'
-        version: 10.2.12(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 10.2.12(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
       '@storybook/addon-themes':
         specifier: 'catalog:'
-        version: 10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
       '@storybook/addon-vitest':
         specifier: 'catalog:'
-        version: 10.2.12(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@3.2.4)
+        version: 10.2.12(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vitest@3.2.4)
       '@storybook/builder-vite':
         specifier: 'catalog:'
-        version: 10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+        version: 10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
       '@storybook/web-components-vite':
         specifier: 'catalog:'
-        version: 10.2.12(esbuild@0.27.3)(lit@3.3.1)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+        version: 10.2.12(esbuild@0.27.3)(lit@3.3.1)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
       lit:
         specifier: 'catalog:'
         version: 3.3.1
       storybook:
         specifier: 'catalog:'
-        version: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       vite:
         specifier: '>=7.1.11'
         version: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -20048,28 +20112,28 @@ importers:
         version: link:../vite-plugin-import-source
       '@storybook/addon-docs':
         specifier: 'catalog:'
-        version: 10.2.12(@types/react@19.2.7)(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+        version: 10.2.12(@types/react@19.2.7)(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
       '@storybook/addon-links':
         specifier: 'catalog:'
-        version: 10.2.12(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 10.2.12(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
       '@storybook/addon-themes':
         specifier: 'catalog:'
-        version: 10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
       '@storybook/addon-vitest':
         specifier: 'catalog:'
-        version: 10.2.12(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@3.2.4)
+        version: 10.2.12(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vitest@3.2.4)
       '@storybook/builder-vite':
         specifier: 'catalog:'
-        version: 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+        version: 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
       '@storybook/html-vite':
         specifier: 'catalog:'
-        version: 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+        version: 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
       '@storybook/mdx2-csf':
         specifier: 'catalog:'
         version: 1.1.0
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 10.2.12(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+        version: 10.2.12(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
       '@types/lodash.flatten':
         specifier: 'catalog:'
         version: 4.4.7
@@ -20099,7 +20163,7 @@ importers:
         version: 19.2.3(react@19.2.3)
       storybook:
         specifier: 'catalog:'
-        version: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       vite:
         specifier: '>=7.1.11'
         version: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -20120,28 +20184,28 @@ importers:
         version: link:../vite-plugin-icons
       '@storybook/addon-docs':
         specifier: 'catalog:'
-        version: 10.2.12(@types/react@19.2.7)(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+        version: 10.2.12(@types/react@19.2.7)(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
       '@storybook/addon-links':
         specifier: 'catalog:'
-        version: 10.2.12(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 10.2.12(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
       '@storybook/addon-themes':
         specifier: 'catalog:'
-        version: 10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
       '@storybook/addon-vitest':
         specifier: 'catalog:'
-        version: 10.2.12(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@3.2.4)
+        version: 10.2.12(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vitest@3.2.4)
       '@storybook/builder-vite':
         specifier: 'catalog:'
-        version: 10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+        version: 10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
       solid-js:
         specifier: 'catalog:'
         version: 1.9.11
       storybook:
         specifier: 'catalog:'
-        version: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       storybook-solidjs-vite:
         specifier: 'catalog:'
-        version: 10.0.9(@testing-library/jest-dom@6.9.1)(esbuild@0.27.3)(rollup@4.46.2)(solid-js@1.9.11)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+        version: 10.0.9(@testing-library/jest-dom@6.9.1)(esbuild@0.27.3)(rollup@4.46.2)(solid-js@1.9.11)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
       vite:
         specifier: '>=7.1.11'
         version: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -20260,16 +20324,16 @@ importers:
         version: 2.3.6
       ink:
         specifier: 'catalog:'
-        version: 6.3.1(@types/react@19.2.7)(react@19.2.3)
+        version: 6.3.1(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
       ink-spinner:
         specifier: 'catalog:'
-        version: 5.0.0(ink@6.3.1(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+        version: 5.0.0(ink@6.3.1(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       ink-table:
         specifier: 'catalog:'
-        version: 3.1.0(ink@6.3.1(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+        version: 3.1.0(ink@6.3.1(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       ink-text-input:
         specifier: 'catalog:'
-        version: 6.0.0(ink@6.3.1(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+        version: 6.0.0(ink@6.3.1(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)
       js-yaml:
         specifier: 'catalog:'
         version: 4.1.1
@@ -21751,6 +21815,9 @@ packages:
 
   '@crxjs/vite-plugin@2.1.0':
     resolution: {integrity: sha512-7PkVsg9ar/QyXJvi9aHekrpWpxf6xHOH6bDQPfLbwsyAGzzmDrI5naXsJeNvQw6WPyHexQRk8gSwXmjfOyMmIg==}
+
+  '@cryptography/aes@0.1.1':
+    resolution: {integrity: sha512-PcYz4FDGblO6tM2kSC+VzhhK62vml6k6/YAkiWtyPvrgJVfnDRoHGDtKn5UiaRRUrvUTTocBpvc2rRgTCqxjsg==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -28975,6 +29042,9 @@ packages:
   async-each@1.0.3:
     resolution: {integrity: sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==}
 
+  async-mutex@0.3.2:
+    resolution: {integrity: sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==}
+
   async@2.6.4:
     resolution: {integrity: sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==}
 
@@ -29363,6 +29433,10 @@ packages:
   buffers@0.1.1:
     resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
     engines: {node: '>=0.2.0'}
+
+  bufferutil@4.1.0:
+    resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
+    engines: {node: '>=6.14.2'}
 
   bun-ffi-structs@0.1.2:
     resolution: {integrity: sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w==}
@@ -30369,6 +30443,10 @@ packages:
     resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
     engines: {node: '>=12'}
 
+  d@1.0.2:
+    resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
+    engines: {node: '>=0.12'}
+
   dagre-d3-es@7.0.10:
     resolution: {integrity: sha512-qTCQmEhcynucuaZgY5/+ti3X/rnszKZhEQH/ZdWdtP1tA/y3VoHJzcVrO9pjjJCNpigfscAtoUB5ONcd2wNn0A==}
 
@@ -30984,8 +31062,15 @@ packages:
   es-toolkit@1.40.0:
     resolution: {integrity: sha512-8o6w0KFmU0CiIl0/Q/BCEOabF2IJaELM1T2PWj6e8KqzHv1gdx+7JtFnDwOx1kJH/isJ5NwlDG1nCr1HrRF94Q==}
 
+  es5-ext@0.10.64:
+    resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
+    engines: {node: '>=0.10'}
+
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
+  es6-iterator@2.0.3:
+    resolution: {integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==}
 
   es6-object-assign@1.1.0:
     resolution: {integrity: sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==}
@@ -30993,6 +31078,10 @@ packages:
   es6-promise-pool@2.5.0:
     resolution: {integrity: sha512-VHErXfzR/6r/+yyzPKeBvO0lgjfC5cbDCQWjWwMZWSb6YU39TGIl51OUmCfWCq4ylMdJSB8zkz2vIuIeIxXApA==}
     engines: {node: '>=0.10.0'}
+
+  es6-symbol@3.1.4:
+    resolution: {integrity: sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==}
+    engines: {node: '>=0.12'}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -31126,6 +31215,10 @@ packages:
       jiti:
         optional: true
 
+  esniff@2.0.1:
+    resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
+    engines: {node: '>=0.10'}
+
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -31185,6 +31278,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  event-emitter@0.3.5:
+    resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
 
   event-target-polyfill@0.0.4:
     resolution: {integrity: sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==}
@@ -31268,6 +31364,9 @@ packages:
 
   expressive-code@0.40.2:
     resolution: {integrity: sha512-1zIda2rB0qiDZACawzw2rbdBQiWHBT56uBctS+ezFe5XMAaFaHLnnSYND/Kd+dVzO9HfCXRDpzH3d+3fvOWRcw==}
+
+  ext@1.7.0:
+    resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -32191,6 +32290,9 @@ packages:
 
   htmlparser2@10.0.0:
     resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
+
+  htmlparser2@6.1.0:
+    resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
@@ -34424,6 +34526,10 @@ packages:
     resolution: {integrity: sha512-K9vk96HdTK5fEipJwxSvIIqwTqr4e3HRJeJrNxBSeVMNSC/JWARRaX7etOLOuTmrRMeOI/K5TCJu3aWIwZiNTw==}
     engines: {node: '>= 7.6.0'}
 
+  node-localstorage@2.2.1:
+    resolution: {integrity: sha512-vv8fJuOUCCvSPjDjBLlMqYMHob4aGjkmrkaE42/mZr0VT+ZAU10jRF8oTnX9+pgU9/vYJ8P7YT3Vd6ajkmzSCw==}
+    engines: {node: '>=0.12'}
+
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
 
@@ -35748,6 +35854,9 @@ packages:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
+  real-cancellable-promise@1.2.3:
+    resolution: {integrity: sha512-hBI5Gy/55VEeeMtImMgEirD7eq5UmqJf1J8dFZtbJZA/3rB0pYFZ7PayMGueb6v4UtUtpKpP+05L0VwyE1hI9Q==}
+
   recast@0.23.9:
     resolution: {integrity: sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==}
     engines: {node: '>= 4'}
@@ -36501,6 +36610,9 @@ packages:
   sliced@1.0.1:
     resolution: {integrity: sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==}
 
+  slide@1.1.6:
+    resolution: {integrity: sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==}
+
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -36706,6 +36818,9 @@ packages:
   stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
+
+  store2@2.14.4:
+    resolution: {integrity: sha512-srTItn1GOvyvOycgxjAnPA63FZNwy0PTyUBFMHRM+hVFltAeoh0LmNBz9SZqUS9mMqGk8rfyWyXn3GH5ReJ8Zw==}
 
   storybook-solidjs-vite@10.0.9:
     resolution: {integrity: sha512-n6MwWCL9mK/qIaUutE9vhGB0X1I1hVnKin2NL+iVC5oXfAiuaABVZlr/1oEeEypsgCdyDOcbEbhJmDWmaqGpPw==}
@@ -37026,6 +37141,9 @@ packages:
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
+  telegram@2.26.22:
+    resolution: {integrity: sha512-EIj7Yrjiu0Yosa3FZ/7EyPg9s6UiTi/zDQrFmR/2Mg7pIUU+XjAit1n1u9OU9h2oRnRM5M+67/fxzQluZpaJJg==}
+
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
@@ -37322,6 +37440,10 @@ packages:
     peerDependencies:
       typescript: ^6.0.2
 
+  ts-custom-error@3.3.1:
+    resolution: {integrity: sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==}
+    engines: {node: '>=14.0.0'}
+
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -37470,6 +37592,9 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  type@2.7.3:
+    resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -37913,6 +38038,10 @@ packages:
     resolution: {integrity: sha512-ayFKY3H+Pwfy4W98yPdtH1VqH4psDeyW8lYYFzfecR9d6hqLpqhecktvYR3SEEXt7vG0S1JEpciI3g94pMErig==}
     engines: {node: '>= 0.8.0'}
 
+  utf-8-validate@5.0.10:
+    resolution: {integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==}
+    engines: {node: '>=6.14.2'}
+
   utif2@4.1.0:
     resolution: {integrity: sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==}
 
@@ -38284,6 +38413,10 @@ packages:
   websocket-stream@5.5.2:
     resolution: {integrity: sha512-8z49MKIHbGk3C4HtuHWDtYX8mYej1wWabjthC/RupM9ngeukU4IWoM46dgth1UOS/T4/IqgEdCDJuMe2039OQQ==}
 
+  websocket@1.0.35:
+    resolution: {integrity: sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==}
+    engines: {node: '>=4.0.0'}
+
   webworkify@1.5.0:
     resolution: {integrity: sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==}
 
@@ -38493,6 +38626,9 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  write-file-atomic@1.3.4:
+    resolution: {integrity: sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==}
+
   write-file-atomic@3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
 
@@ -38580,6 +38716,11 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yaeti@0.0.6:
+    resolution: {integrity: sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==}
+    engines: {node: '>=0.10.32'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -39168,14 +39309,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@automerge/automerge-repo-network-websocket@2.5.1':
+  '@automerge/automerge-repo-network-websocket@2.5.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@automerge/automerge-repo': 2.5.1(patch_hash=be766431e3a6459feb58222ae46cd90e3ad69b2350653ea95d8707259278baa8)
       cbor-x: 1.5.4
       debug: 4.4.3
       eventemitter3: 5.0.1
-      isomorphic-ws: 5.0.0(ws@8.18.3)
-      ws: 8.18.3
+      isomorphic-ws: 5.0.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -40712,17 +40853,17 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260302.0
 
-  '@cloudflare/vitest-pool-workers@0.8.61(@cloudflare/workers-types@4.20260303.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4)':
+  '@cloudflare/vitest-pool-workers@0.8.61(@cloudflare/workers-types@4.20260303.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vitest@3.2.4)':
     dependencies:
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
       birpc: 0.2.14
       cjs-module-lexer: 1.3.1
       devalue: 5.6.3
-      miniflare: 4.20250803.0
+      miniflare: 4.20250803.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       semver: 7.7.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      wrangler: 4.68.1(@cloudflare/workers-types@4.20260303.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      wrangler: 4.68.1(@cloudflare/workers-types@4.20260303.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -41062,6 +41203,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@cryptography/aes@0.1.1': {}
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -41146,7 +41289,7 @@ snapshots:
 
   '@discordjs/util@1.0.2': {}
 
-  '@discordjs/ws@1.0.2':
+  '@discordjs/ws@1.0.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@discordjs/collection': 2.0.0
       '@discordjs/rest': 2.2.0
@@ -41156,7 +41299,7 @@ snapshots:
       '@vladfrangu/async_event_emitter': 2.2.4
       discord-api-types: 0.37.61
       tslib: 2.8.1
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -41286,11 +41429,11 @@ snapshots:
       effect: 3.20.0
       multipasta: 0.2.7
 
-  '@effect/platform-bun@0.87.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)':
+  '@effect/platform-bun@0.87.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(bufferutil@4.1.0)(effect@3.20.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@effect/cluster': 0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
       '@effect/platform': 0.94.4(effect@3.20.0)
-      '@effect/platform-node-shared': 0.57.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
+      '@effect/platform-node-shared': 0.57.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(bufferutil@4.1.0)(effect@3.20.0)(utf-8-validate@5.0.10)
       '@effect/rpc': 0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)
       '@effect/sql': 0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)
       effect: 3.20.0
@@ -41299,7 +41442,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node-shared@0.57.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)':
+  '@effect/platform-node-shared@0.57.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(bufferutil@4.1.0)(effect@3.20.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@effect/cluster': 0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
       '@effect/platform': 0.94.4(effect@3.20.0)
@@ -41308,22 +41451,22 @@ snapshots:
       '@parcel/watcher': 2.5.1
       effect: 3.20.0
       multipasta: 0.2.7
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@0.104.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)':
+  '@effect/platform-node@0.104.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(bufferutil@4.1.0)(effect@3.20.0)(utf-8-validate@5.0.10)':
     dependencies:
       '@effect/cluster': 0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
       '@effect/platform': 0.94.4(effect@3.20.0)
-      '@effect/platform-node-shared': 0.57.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
+      '@effect/platform-node-shared': 0.57.1(@effect/cluster@0.56.3(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(bufferutil@4.1.0)(effect@3.20.0)(utf-8-validate@5.0.10)
       '@effect/rpc': 0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)
       '@effect/sql': 0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)
       effect: 3.20.0
       mime: 3.0.0
       undici: 7.22.0
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -41391,7 +41534,7 @@ snapshots:
   '@effect/vitest@0.27.0(effect@3.20.0)(vitest@3.2.4)':
     dependencies:
       effect: 3.20.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@effect/wa-sqlite@0.1.2': {}
 
@@ -46360,15 +46503,15 @@ snapshots:
     dependencies:
       react: 19.2.3
 
-  '@storybook/addon-docs@10.2.12(@types/react@19.2.7)(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
+  '@storybook/addon-docs@10.2.12(@types/react@19.2.7)(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@19.2.7)(react@19.2.3)
-      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
       '@storybook/icons': 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@storybook/react-dom-shim': 10.2.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@storybook/react-dom-shim': 10.2.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -46377,15 +46520,15 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.2.12(@types/react@19.2.7)(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
+  '@storybook/addon-docs@10.2.12(@types/react@19.2.7)(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@19.2.7)(react@19.2.3)
-      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
       '@storybook/icons': 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@storybook/react-dom-shim': 10.2.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@storybook/react-dom-shim': 10.2.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -46394,35 +46537,35 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-links@10.2.12(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@storybook/addon-links@10.2.12(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
     optionalDependencies:
       react: 19.2.3
 
-  '@storybook/addon-themes@10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@storybook/addon-themes@10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))':
     dependencies:
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-vitest@10.2.12(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@3.2.4)':
+  '@storybook/addon-vitest@10.2.12(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vitest@3.2.4)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(playwright@1.57.0)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)(webdriverio@8.33.1(typescript@6.0.2))
+      '@vitest/browser': 3.2.4(bufferutil@4.1.0)(playwright@1.57.0)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)(webdriverio@8.33.1(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10))
       '@vitest/runner': 3.2.4
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/builder-vite@10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       ts-dedent: 2.2.0
       vite: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -46430,10 +46573,10 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/builder-vite@10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
+  '@storybook/builder-vite@10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       ts-dedent: 2.2.0
       vite: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -46441,10 +46584,10 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/builder-vite@10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
+  '@storybook/builder-vite@10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@storybook/csf-plugin': 10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       ts-dedent: 2.2.0
       vite: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -46452,18 +46595,18 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/csf-plugin@10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       unplugin: 2.3.5
     optionalDependencies:
       esbuild: 0.27.3
       rollup: 3.30.0
       vite: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@storybook/csf-plugin@10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
+  '@storybook/csf-plugin@10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
     dependencies:
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       unplugin: 2.3.5
     optionalDependencies:
       esbuild: 0.27.3
@@ -46471,9 +46614,9 @@ snapshots:
       vite: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       webpack: 5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3)
 
-  '@storybook/csf-plugin@10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
+  '@storybook/csf-plugin@10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
     dependencies:
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       unplugin: 2.3.5
     optionalDependencies:
       esbuild: 0.27.3
@@ -46483,21 +46626,21 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/html-vite@10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
+  '@storybook/html-vite@10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
     dependencies:
-      '@storybook/builder-vite': 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
-      '@storybook/html': 10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@storybook/builder-vite': 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+      '@storybook/html': 10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - vite
       - webpack
 
-  '@storybook/html@10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@storybook/html@10.2.12(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       ts-dedent: 2.2.0
 
   '@storybook/icons@2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
@@ -46507,25 +46650,25 @@ snapshots:
 
   '@storybook/mdx2-csf@1.1.0': {}
 
-  '@storybook/react-dom-shim@10.2.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@storybook/react-dom-shim@10.2.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))':
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
 
-  '@storybook/react-vite@10.2.12(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/react-vite@10.2.12(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@rollup/pluginutils': 5.3.0(rollup@3.30.0)
-      '@storybook/builder-vite': 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@storybook/react': 10.2.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.2)
+      '@storybook/builder-vite': 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/react': 10.2.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@6.0.2)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.3
       react-docgen: 8.0.2
       react-dom: 19.2.3(react@19.2.3)
       resolve: 1.22.10
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       tsconfig-paths: 4.2.0
       vite: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -46535,19 +46678,19 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react-vite@10.2.12(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
+  '@storybook/react-vite@10.2.12(esbuild@0.27.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@rollup/pluginutils': 5.3.0(rollup@3.30.0)
-      '@storybook/builder-vite': 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
-      '@storybook/react': 10.2.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.2)
+      '@storybook/builder-vite': 10.2.12(esbuild@0.27.3)(rollup@3.30.0)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+      '@storybook/react': 10.2.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@6.0.2)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.3
       react-docgen: 8.0.2
       react-dom: 19.2.3(react@19.2.3)
       resolve: 1.22.10
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       tsconfig-paths: 4.2.0
       vite: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -46557,24 +46700,24 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.2.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.2)':
+  '@storybook/react@10.2.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@6.0.2)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.2.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@storybook/react-dom-shim': 10.2.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
       react: 19.2.3
       react-docgen: 8.0.2
       react-dom: 19.2.3(react@19.2.3)
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/web-components-vite@10.2.12(esbuild@0.27.3)(lit@3.3.1)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
+  '@storybook/web-components-vite@10.2.12(esbuild@0.27.3)(lit@3.3.1)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))':
     dependencies:
-      '@storybook/builder-vite': 10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
-      '@storybook/web-components': 10.2.12(lit@3.3.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@storybook/builder-vite': 10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+      '@storybook/web-components': 10.2.12(lit@3.3.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - esbuild
       - lit
@@ -46582,11 +46725,11 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/web-components@10.2.12(lit@3.3.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@storybook/web-components@10.2.12(lit@3.3.1)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@storybook/global': 5.0.0
       lit: 3.3.1
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       tiny-invariant: 1.3.3
       ts-dedent: 2.2.0
 
@@ -47876,7 +48019,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.2.4(playwright@1.57.0)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)(webdriverio@8.33.1(typescript@6.0.2))':
+  '@vitest/browser@3.2.4(bufferutil@4.1.0)(playwright@1.57.0)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)(webdriverio@8.33.1(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10))':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
@@ -47885,11 +48028,11 @@ snapshots:
       magic-string: 0.30.21
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      ws: 8.18.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       playwright: 1.57.0
-      webdriverio: 8.33.1(typescript@6.0.2)
+      webdriverio: 8.33.1(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -47911,9 +48054,9 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(playwright@1.57.0)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)(webdriverio@8.33.1(typescript@6.0.2))
+      '@vitest/browser': 3.2.4(bufferutil@4.1.0)(playwright@1.57.0)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)(webdriverio@8.33.1(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10))
     transitivePeerDependencies:
       - supports-color
 
@@ -47962,7 +48105,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -49251,6 +49394,10 @@ snapshots:
 
   async-each@1.0.3: {}
 
+  async-mutex@0.3.2:
+    dependencies:
+      tslib: 2.8.1
+
   async@2.6.4:
     dependencies:
       lodash: 4.17.23
@@ -49699,6 +49846,10 @@ snapshots:
       ieee754: 1.2.1
 
   buffers@0.1.1: {}
+
+  bufferutil@4.1.0:
+    dependencies:
+      node-gyp-build: 4.5.0
 
   bun-ffi-structs@0.1.2(typescript@6.0.2):
     dependencies:
@@ -50805,6 +50956,11 @@ snapshots:
       d3-transition: 3.0.1(d3-selection@3.0.0)
       d3-zoom: 3.0.0
 
+  d@1.0.2:
+    dependencies:
+      es5-ext: 0.10.64
+      type: 2.7.3
+
   dagre-d3-es@7.0.10:
     dependencies:
       d3: 7.9.0
@@ -51175,14 +51331,14 @@ snapshots:
       '@types/express': 4.17.25
     optional: true
 
-  discord.js@14.14.1:
+  discord.js@14.14.1(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@discordjs/builders': 1.7.0
       '@discordjs/collection': 1.5.3
       '@discordjs/formatters': 0.3.3
       '@discordjs/rest': 2.2.0
       '@discordjs/util': 1.0.2
-      '@discordjs/ws': 1.0.2
+      '@discordjs/ws': 1.0.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@sapphire/snowflake': 3.5.1
       '@types/ws': 8.5.9
       discord-api-types: 0.37.61
@@ -51190,7 +51346,7 @@ snapshots:
       lodash.snakecase: 4.1.1
       tslib: 2.6.2
       undici: 7.22.0
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -51493,11 +51649,29 @@ snapshots:
 
   es-toolkit@1.40.0: {}
 
+  es5-ext@0.10.64:
+    dependencies:
+      es6-iterator: 2.0.3
+      es6-symbol: 3.1.4
+      esniff: 2.0.1
+      next-tick: 1.1.0
+
   es6-error@4.1.1: {}
+
+  es6-iterator@2.0.3:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      es6-symbol: 3.1.4
 
   es6-object-assign@1.1.0: {}
 
   es6-promise-pool@2.5.0: {}
+
+  es6-symbol@3.1.4:
+    dependencies:
+      d: 1.0.2
+      ext: 1.7.0
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -51674,6 +51848,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esniff@2.0.1:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      event-emitter: 0.3.5
+      type: 2.7.3
+
   espree@11.2.0:
     dependencies:
       acorn: 8.16.0
@@ -51734,6 +51915,11 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  event-emitter@0.3.5:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
 
   event-target-polyfill@0.0.4: {}
 
@@ -51892,6 +52078,10 @@ snapshots:
       '@expressive-code/plugin-frames': 0.40.2
       '@expressive-code/plugin-shiki': 0.40.2
       '@expressive-code/plugin-text-markers': 0.40.2
+
+  ext@1.7.0:
+    dependencies:
+      type: 2.7.3
 
   extend-shallow@2.0.1:
     dependencies:
@@ -52755,14 +52945,14 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
-  happy-dom@20.7.0:
+  happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@types/node': 22.10.2
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -53122,6 +53312,13 @@ snapshots:
       domutils: 3.2.2
       entities: 6.0.1
 
+  htmlparser2@6.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 4.3.1
+      domutils: 2.8.0
+      entities: 2.0.3
+
   htmlparser2@8.0.2:
     dependencies:
       domelementtype: 2.3.0
@@ -53330,26 +53527,26 @@ snapshots:
 
   ini@4.1.3: {}
 
-  ink-spinner@5.0.0(ink@6.3.1(@types/react@19.2.7)(react@19.2.3))(react@19.2.3):
+  ink-spinner@5.0.0(ink@6.3.1(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
       cli-spinners: 2.9.2
-      ink: 6.3.1(@types/react@19.2.7)(react@19.2.3)
+      ink: 6.3.1(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
       react: 19.2.3
 
-  ink-table@3.1.0(ink@6.3.1(@types/react@19.2.7)(react@19.2.3))(react@19.2.3):
+  ink-table@3.1.0(ink@6.3.1(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
-      ink: 6.3.1(@types/react@19.2.7)(react@19.2.3)
+      ink: 6.3.1(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
       object-hash: 2.2.0
       react: 19.2.3
 
-  ink-text-input@6.0.0(ink@6.3.1(@types/react@19.2.7)(react@19.2.3))(react@19.2.3):
+  ink-text-input@6.0.0(ink@6.3.1(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
       chalk: 5.6.2
-      ink: 6.3.1(@types/react@19.2.7)(react@19.2.3)
+      ink: 6.3.1(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
       react: 19.2.3
       type-fest: 4.41.0
 
-  ink@6.3.1(@types/react@19.2.7)(react@19.2.3):
+  ink@6.3.1(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.2.0
       ansi-escapes: 7.0.0
@@ -53373,7 +53570,7 @@ snapshots:
       type-fest: 4.41.0
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       yoga-layout: 3.2.1
     optionalDependencies:
       '@types/react': 19.2.7
@@ -53773,9 +53970,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  isomorphic-ws@5.0.0(ws@8.18.3):
+  isomorphic-ws@5.0.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
     dependencies:
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   isomorphic.js@0.2.5: {}
 
@@ -53993,11 +54190,11 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom-global@3.0.2(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6)):
+  jsdom-global@3.0.2(jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10)):
     dependencies:
-      jsdom: 27.0.0(canvas@3.2.0)(postcss@8.5.6)
+      jsdom: 27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10)
 
-  jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6):
+  jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10):
     dependencies:
       '@asamuzakjp/dom-selector': 6.6.2
       cssstyle: 5.3.1(postcss@8.5.6)
@@ -54017,7 +54214,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       xml-name-validator: 5.0.0
     optionalDependencies:
       canvas: 3.2.0
@@ -55471,7 +55668,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  miniflare@3.20240320.0:
+  miniflare@3.20240320.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       acorn: 8.15.0
@@ -55482,7 +55679,7 @@ snapshots:
       stoppable: 1.1.0
       undici: 7.22.0
       workerd: 1.20240320.1
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       youch: 3.3.3
       zod: 3.25.76
     transitivePeerDependencies:
@@ -55490,7 +55687,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  miniflare@4.20250803.0:
+  miniflare@4.20250803.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       acorn: 8.14.0
@@ -55501,14 +55698,14 @@ snapshots:
       stoppable: 1.1.0
       undici: 7.22.0
       workerd: 1.20250803.0
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       youch: 4.1.0-beta.10
       zod: 3.22.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  miniflare@4.20251210.0:
+  miniflare@4.20251210.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       acorn: 8.14.0
@@ -55519,20 +55716,20 @@ snapshots:
       stoppable: 1.1.0
       undici: 7.22.0
       workerd: 1.20251210.0
-      ws: 8.18.0
+      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       youch: 4.1.0-beta.10
       zod: 3.22.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  miniflare@4.20260302.0:
+  miniflare@4.20260302.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
       undici: 7.22.0
       workerd: 1.20260302.0
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -55858,6 +56055,10 @@ snapshots:
   node-interval-tree@1.3.3:
     dependencies:
       shallowequal: 1.1.0
+
+  node-localstorage@2.2.1:
+    dependencies:
+      write-file-atomic: 1.3.4
 
   node-mock-http@1.0.4: {}
 
@@ -56427,12 +56628,12 @@ snapshots:
 
   parsimmon@1.18.1: {}
 
-  partykit@0.0.103:
+  partykit@0.0.103(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@cloudflare/workers-types': 4.20240320.1
       clipboardy: 4.0.0
       esbuild: 0.27.3
-      miniflare: 3.20240320.0
+      miniflare: 3.20240320.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       yoga-wasm-web: 0.3.3
     optionalDependencies:
       fsevents: 2.3.3
@@ -56950,7 +57151,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  puppeteer-core@13.7.0:
+  puppeteer-core@13.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       cross-fetch: 3.1.5
       debug: 4.3.4
@@ -56963,7 +57164,7 @@ snapshots:
       rimraf: 3.0.2
       tar-fs: 3.1.1
       unbzip2-stream: 1.4.3
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -56972,14 +57173,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  puppeteer-core@20.9.0(typescript@6.0.2):
+  puppeteer-core@20.9.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10):
     dependencies:
       '@puppeteer/browsers': 1.4.6(typescript@6.0.2)
       chromium-bidi: 0.4.16(devtools-protocol@0.0.1147663)
       cross-fetch: 4.0.0
       debug: 4.3.4
       devtools-protocol: 0.0.1147663
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -56992,7 +57193,7 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  pwa-asset-generator@6.4.0:
+  pwa-asset-generator@6.4.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       chalk: 4.1.2
       cheerio: 1.0.0-rc.12
@@ -57004,7 +57205,7 @@ snapshots:
       mime-types: 2.1.35
       pretty: 2.0.0
       progress: 2.0.3
-      puppeteer-core: 13.7.0
+      puppeteer-core: 13.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       slash: 3.0.0
     transitivePeerDependencies:
       - bare-abort-controller
@@ -57532,6 +57733,8 @@ snapshots:
       picomatch: 2.3.1
 
   readdirp@5.0.0: {}
+
+  real-cancellable-promise@1.2.3: {}
 
   recast@0.23.9:
     dependencies:
@@ -58643,6 +58846,8 @@ snapshots:
 
   sliced@1.0.1: {}
 
+  slide@1.1.6: {}
+
   smart-buffer@4.2.0: {}
 
   smob@1.5.0: {}
@@ -58877,13 +59082,15 @@ snapshots:
 
   stoppable@1.1.0: {}
 
-  storybook-solidjs-vite@10.0.9(@testing-library/jest-dom@6.9.1)(esbuild@0.27.3)(rollup@4.46.2)(solid-js@1.9.11)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3)):
+  store2@2.14.4: {}
+
+  storybook-solidjs-vite@10.0.9(@testing-library/jest-dom@6.9.1)(esbuild@0.27.3)(rollup@4.46.2)(solid-js@1.9.11)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3)):
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.3(typescript@6.0.2)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@storybook/builder-vite': 10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
+      '@storybook/builder-vite': 10.2.12(esbuild@0.27.3)(rollup@4.46.2)(storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.27.3))
       '@storybook/global': 5.0.0
       solid-js: 1.9.11
-      storybook: 10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      storybook: 10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10)
       vite: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-plugin-solid: 2.11.10(@testing-library/jest-dom@6.9.1)(solid-js@1.9.11)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
@@ -58895,7 +59102,7 @@ snapshots:
       - supports-color
       - webpack
 
-  storybook@10.2.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  storybook@10.2.0(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -58908,7 +59115,7 @@ snapshots:
       recast: 0.23.9
       semver: 7.7.3
       use-sync-external-store: 1.6.0(react@19.2.3)
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       prettier: 3.6.2
     transitivePeerDependencies:
@@ -58918,7 +59125,7 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  storybook@10.2.12(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  storybook@10.2.12(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -58931,7 +59138,7 @@ snapshots:
       recast: 0.23.9
       semver: 7.7.3
       use-sync-external-store: 1.6.0(react@19.2.3)
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       prettier: 3.6.2
     transitivePeerDependencies:
@@ -59310,6 +59517,28 @@ snapshots:
       - bare-abort-controller
     optional: true
 
+  telegram@2.26.22:
+    dependencies:
+      '@cryptography/aes': 0.1.1
+      async-mutex: 0.3.2
+      big-integer: 1.6.51
+      buffer: 6.0.3
+      htmlparser2: 6.1.0
+      mime: 3.0.0
+      node-localstorage: 2.2.1
+      pako: 2.0.3
+      path-browserify: 1.0.1
+      real-cancellable-promise: 1.2.3
+      socks: 2.8.7
+      store2: 2.14.4
+      ts-custom-error: 3.3.1
+      websocket: 1.0.35
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
   temp-dir@2.0.0: {}
 
   tempy@0.6.0:
@@ -59615,6 +59844,8 @@ snapshots:
     dependencies:
       typescript: 6.0.2
 
+  ts-custom-error@3.3.1: {}
+
   ts-dedent@2.2.0: {}
 
   ts-easing@0.2.0: {}
@@ -59742,6 +59973,8 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  type@2.7.3: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -60185,6 +60418,10 @@ snapshots:
 
   userhome@1.0.0: {}
 
+  utf-8-validate@5.0.10:
+    dependencies:
+      node-gyp-build: 4.5.0
+
   utif2@4.1.0:
     dependencies:
       pako: 1.0.11
@@ -60430,7 +60667,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.6))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.10.2)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.6.1)(jsdom@27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -60458,10 +60695,10 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.10.2
-      '@vitest/browser': 3.2.4(playwright@1.57.0)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)(webdriverio@8.33.1(typescript@6.0.2))
+      '@vitest/browser': 3.2.4(bufferutil@4.1.0)(playwright@1.57.0)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.10.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4)(webdriverio@8.33.1(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10))
       '@vitest/ui': 3.2.4(vitest@3.2.4)
-      happy-dom: 20.7.0
-      jsdom: 27.0.0(canvas@3.2.0)(postcss@8.5.6)
+      happy-dom: 20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      jsdom: 27.0.0(bufferutil@4.1.0)(canvas@3.2.0)(postcss@8.5.6)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - jiti
       - less
@@ -60532,7 +60769,7 @@ snapshots:
 
   web-worker@1.5.0: {}
 
-  webdriver@8.33.1:
+  webdriver@8.33.1(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@types/node': 22.10.2
       '@types/ws': 8.5.12
@@ -60544,7 +60781,7 @@ snapshots:
       deepmerge-ts: 5.1.0
       got: 12.6.1
       ky: 0.33.3
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -60552,7 +60789,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webdriverio@8.33.1(typescript@6.0.2):
+  webdriverio@8.33.1(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10):
     dependencies:
       '@types/node': 22.10.2
       '@wdio/config': 8.33.1
@@ -60572,12 +60809,12 @@ snapshots:
       lodash.clonedeep: 4.5.0
       lodash.zip: 4.2.0
       minimatch: 10.2.2
-      puppeteer-core: 20.9.0(typescript@6.0.2)
+      puppeteer-core: 20.9.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)
       query-selector-shadow-dom: 1.0.1
       resq: 1.11.0
       rgb2hex: 0.2.5
       serialize-error: 11.0.3
-      webdriver: 8.33.1
+      webdriver: 8.33.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -60649,17 +60886,28 @@ snapshots:
     dependencies:
       sdp: 3.2.0
 
-  websocket-stream@5.5.2:
+  websocket-stream@5.5.2(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       duplexify: 3.7.1
       inherits: 2.0.4
       readable-stream: 2.3.7
       safe-buffer: 5.2.1
-      ws: 8.18.3
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       xtend: 4.0.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  websocket@1.0.35:
+    dependencies:
+      bufferutil: 4.1.0
+      debug: 2.6.9
+      es5-ext: 0.10.64
+      typedarray-to-buffer: 3.1.5
+      utf-8-validate: 5.0.10
+      yaeti: 0.0.6
+    transitivePeerDependencies:
+      - supports-color
 
   webworkify@1.5.0: {}
 
@@ -60945,13 +61193,13 @@ snapshots:
 
   workerpool@6.5.1: {}
 
-  wrangler@4.68.1(@cloudflare/workers-types@4.20260303.0):
+  wrangler@4.68.1(@cloudflare/workers-types@4.20260303.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@cloudflare/unenv-preset': 2.14.0(unenv@2.0.0-rc.24)(workerd@1.20260302.0)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260302.0
+      miniflare: 4.20260302.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       path-to-regexp: 8.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260302.0
@@ -60988,6 +61236,12 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  write-file-atomic@1.3.4:
+    dependencies:
+      graceful-fs: 4.2.11
+      imurmurhash: 0.1.4
+      slide: 1.1.6
+
   write-file-atomic@3.0.3:
     dependencies:
       imurmurhash: 0.1.4
@@ -60995,9 +61249,15 @@ snapshots:
       signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
 
-  ws@8.18.0: {}
+  ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 5.0.10
 
-  ws@8.18.3: {}
+  ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 5.0.10
 
   wsl-utils@0.1.0:
     dependencies:
@@ -61040,6 +61300,8 @@ snapshots:
   y18n@4.0.3: {}
 
   y18n@5.0.8: {}
+
+  yaeti@0.0.6: {}
 
   yallist@3.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -585,6 +585,7 @@ catalog:
   tailwindcss: ^4.2.0
   tailwindcss-radix: ^4.0.2
   tauri-plugin-web-auth-api: ^1.0.0
+  telegram: ^2.26.22
   three: ^0.178.0
   todomvc-app-css: ^2.4.2
   todomvc-common: ^1.0.5

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -740,6 +740,11 @@
         },
         {
           "type": "json",
+          "path": "packages/plugins/plugin-telegram-user/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "packages/plugins/plugin-template/package.json",
           "jsonpath": "$.version"
         },

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -430,6 +430,9 @@
       "path": "packages/plugins/plugin-table/tsconfig.json"
     },
     {
+      "path": "packages/plugins/plugin-telegram-user/tsconfig.json"
+    },
+    {
       "path": "packages/plugins/plugin-template/tsconfig.json"
     },
     {


### PR DESCRIPTION
## Summary

Adds `@dxos/plugin-telegram-user` — logs into Telegram as *the user* via MTProto and builds a **unified inbox** of every DM, group, and channel. Companion to `@dxos/plugin-telegram-bot` (#11066).

### Which one do I want?

| | `plugin-telegram-user` (this PR) | `plugin-telegram-bot` (#11066) |
|---|---|---|
| Protocol | MTProto (user protocol) | Bot API (REST) |
| Identity | Your personal account | A bot you create |
| Can read | Every chat you're in | Messages sent *to the bot* |
| Auth | Phone + SMS code + 2FA | Bot token from @BotFather |
| Use case | Unified inbox, personal sync | Agent-as-bot, notifications, team commands |

The two plugins are independent and can be installed together.

### Plugin contents
- **`useTelegramUserClient`** — wraps a single `gramjs` `TelegramClient`. Handles the multi-step login flow (phone → SMS code → optional 2FA password → session string) by bridging gramjs's callback-driven `client.start()` into React state via deferred promises.
- **`useTelegramUserMessages`** — subscribes to `NewMessage` events; prefetches recent dialogs on connect so the feed has history immediately; normalizes gramjs messages into a flat feed shape.
- **`TelegramUserSettings`** — the multi-step login UI. Walks the user through getting api_id/api_hash from my.telegram.org, entering phone, code, and (if enabled) 2FA password.
- **`TelegramUserFeed`** — unified inbox panel. Auto-connects from saved session. Shows DMs, groups, and channels together in chronological order.
- **Lazy imports** — gramjs (~500 KB) is dynamically imported on first use so unused panels don't pay the cost.
- **README** in `packages/plugins/plugin-telegram-user/README.md` clearly contrasts bot vs user and links to the sibling plugin.

### Security notes

- The session string produced after login is equivalent to a Telegram login — anyone with it can act as you. It's currently stored in localStorage via the plugin-settings atom. Migrating to an encrypted `AccessToken` in the space is tracked in `plans/adopt-access-token-for-sync-plugins.md` (not in scope for this PR).

### Known limitations (for this PR)

- Messages live in memory only — persistence to ECHO is future work.
- Media (photos / files / stickers) shown as `[media]`; text-only for now.
- No outgoing messages from the plugin yet.

## Test plan

- [ ] `pnpm install && moon run plugin-telegram-user:build` compiles clean
- [ ] Register an app at https://my.telegram.org/apps, get api_id + api_hash
- [ ] Open Composer → Settings → Telegram → paste api_id, api_hash, your phone number
- [ ] Click Connect → receive SMS code → submit → (if 2FA) submit password
- [ ] Reload page → auto-reconnects without re-login
- [ ] Send yourself a message on Telegram from another device → appears in the feed
- [ ] Disconnect + forget session wipes the session string

Companion PR: https://github.com/dxos/dxos/pull/11066 (plugin-telegram-bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composer app now includes a Telegram personal-account plugin to view a unified inbox of DMs, groups, and channels.
  * In-app feed and settings UI to connect, perform the multi-step login, manage session, and see live connection status with auto-scroll.

* **Documentation**
  * Added setup guide covering credentials, login steps, and current limitations.

* **Tests**
  * Unit tests for message/chat normalization and parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->