### PR TITLE
refactor(echo-db): use Entity.getSchema and simplify migration invariant

### DIFF
--- a/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/echo-handler.test.ts
@@ -145,7 +145,9 @@ describe('without database', () => {
   test.skip('get schema on nested object', () => {
     const obj = createObject(Obj.make(TestSchema, { nested: { name: 'foo', arr: [] } }));
     const NestedSchema = TestSchema.pipe(Schema.pluck('nested'), Schema.typeSchema);
-    expect(prepareAstForCompare(Obj.getSchema(obj.nested)!.ast)).to.deep.eq(prepareAstForCompare(NestedSchema.ast));
+    expect(prepareAstForCompare(Obj.getSchema(obj.nested as Obj.Unknown)!.ast)).to.deep.eq(
+      prepareAstForCompare(NestedSchema.ast),
+    );
   });
 
   test('create', () => {

--- a/packages/core/echo/echo-db/src/echo-handler/echo-handler.ts
+++ b/packages/core/echo/echo-db/src/echo-handler/echo-handler.ts
@@ -1079,7 +1079,7 @@ type CreateObjectReturn<T> = T extends Obj.Unknown ? T : Entity.Entity<T>;
 // TODO(burdon): Document lifecycle.
 export const createObject = <T extends AnyProperties>(obj: T): CreateObjectReturn<T> => {
   assertArgument(!isEchoObject(obj), 'obj', 'Object is already an ECHO object');
-  const schema = Obj.getSchema(obj);
+  const schema = Obj.getSchema(obj as unknown as Obj.Unknown);
   if (schema != null) {
     validateSchema(schema);
   }

--- a/packages/core/echo/echo-db/src/proxy-db/database.ts
+++ b/packages/core/echo/echo-db/src/proxy-db/database.ts
@@ -7,7 +7,7 @@ import { inspect } from 'node:util';
 import { type CleanupFn, Event, type ReadOnlyEvent, synchronized } from '@dxos/async';
 import { type Context, LifecycleState, Resource } from '@dxos/context';
 import { inspectObject } from '@dxos/debug';
-import { Database, type Entity, Obj, QueryAST, Ref } from '@dxos/echo';
+import { Database, Entity, Obj, QueryAST, Ref } from '@dxos/echo';
 import { Filter, Query } from '@dxos/echo';
 import { type AnyProperties, assertObjectModel, setRefResolver } from '@dxos/echo/internal';
 import { getProxyTarget, isProxy } from '@dxos/echo/internal';
@@ -256,7 +256,7 @@ export class EchoDatabaseImpl extends Resource implements EchoDatabase {
    */
   add<T extends Entity.Unknown = Entity.Unknown>(obj: T, opts?: Database.AddOptions): T {
     if (!isEchoObject(obj)) {
-      const schema = Obj.getSchema(obj as unknown as Obj.Unknown);
+      const schema = Entity.getSchema(obj);
       if (schema != null) {
         if (!this.schemaRegistry.hasSchema(schema) && !this.graph.schemaRegistry.hasSchema(schema)) {
           throw createSchemaNotRegisteredError(schema);
@@ -310,8 +310,7 @@ export class EchoDatabaseImpl extends Resource implements EchoDatabase {
           data: output,
           type: migration.toType,
         });
-        const postMigrationType = Obj.getTypeDXN(object);
-        invariant(postMigrationType != null && DXN.equals(postMigrationType, migration.toType));
+        invariant(DXN.equals(Obj.getTypeDXN(object), migration.toType));
 
         await migration.onMigration({ before: object, object, db: this });
       }

--- a/packages/core/echo/echo-db/src/proxy-db/database.ts
+++ b/packages/core/echo/echo-db/src/proxy-db/database.ts
@@ -256,7 +256,7 @@ export class EchoDatabaseImpl extends Resource implements EchoDatabase {
    */
   add<T extends Entity.Unknown = Entity.Unknown>(obj: T, opts?: Database.AddOptions): T {
     if (!isEchoObject(obj)) {
-      const schema = Obj.getSchema(obj);
+      const schema = Obj.getSchema(obj as unknown as Obj.Unknown);
       if (schema != null) {
         if (!this.schemaRegistry.hasSchema(schema) && !this.graph.schemaRegistry.hasSchema(schema)) {
           throw createSchemaNotRegisteredError(schema);

--- a/packages/core/echo/echo-db/src/testing/queue.test.ts
+++ b/packages/core/echo/echo-db/src/testing/queue.test.ts
@@ -64,7 +64,7 @@ describe('queues', () => {
         .resolve(DXN.fromQueue('data', spaceId, queue.dxn.asQueueDXN()!.queueId, obj.id));
       expect(resolved?.id).toEqual(obj.id);
       expect(resolved?.name).toEqual('john');
-      expect(Obj.getSchema(resolved)).toEqual(TestSchema.Person);
+      expect(Obj.getSchema(resolved as Obj.Unknown)).toEqual(TestSchema.Person);
     }
 
     {
@@ -73,7 +73,7 @@ describe('queues', () => {
         .resolve(DXN.fromLocalObjectId(obj.id));
       expect(resolved?.id).toEqual(obj.id);
       expect(resolved?.name).toEqual('john');
-      expect(Obj.getSchema(resolved)).toEqual(TestSchema.Person);
+      expect(Obj.getSchema(resolved as Obj.Unknown)).toEqual(TestSchema.Person);
     }
   });
 

--- a/packages/core/echo/echo/src/Entity.ts
+++ b/packages/core/echo/echo/src/Entity.ts
@@ -9,6 +9,7 @@ import type { DXN, ObjectId } from '@dxos/keys';
 
 import * as internal from './internal';
 import type * as Relation from './Relation';
+import type * as Type from './Type';
 
 // Re-export KindId and SnapshotKindId from internal.
 export const KindId = internal.KindId;
@@ -130,6 +131,12 @@ export const getDXN = (entity: Unknown | Snapshot): DXN => internal.getDXN(entit
  * Get the DXN of an entity's type.
  */
 export const getTypeDXN = internal.getTypeDXN;
+
+/**
+ * Get the schema of an entity.
+ * Returns the branded ECHO schema used to create the entity.
+ */
+export const getSchema: (entity: Unknown | Snapshot) => Type.AnyEntity | undefined = internal.getSchema as any;
 
 /**
  * Get the typename of an entity's type.

--- a/packages/core/echo/echo/src/Obj.ts
+++ b/packages/core/echo/echo/src/Obj.ts
@@ -13,7 +13,7 @@ import * as Utils from 'effect/Utils';
 
 import type { ForeignKey } from '@dxos/echo-protocol';
 import { createJsonPath } from '@dxos/effect';
-import { assertArgument } from '@dxos/invariant';
+import { assertArgument, invariant } from '@dxos/invariant';
 import { type DXN, ObjectId } from '@dxos/keys';
 import { assumeType, deepMapValues } from '@dxos/util';
 
@@ -470,16 +470,19 @@ export const getDXN = (entity: Unknown | Snapshot): DXN => {
 /**
  * @returns The DXN of the object's type.
  * @example dxn:com.example.type.person:1.0.0
+ * @throws If the object is missing its type (corrupted object).
  */
-// TODO(wittjosiah): Narrow types.
-export const getTypeDXN: (obj: unknown | undefined) => DXN | undefined = internal.getTypeDXN as any;
+export const getTypeDXN = (obj: Unknown | Snapshot): DXN => {
+  const type = internal.getTypeDXN(obj);
+  invariant(type != null, 'Corrupted object: missing type.');
+  return type;
+};
 
 /**
  * Get the schema of the object.
  * Returns the branded ECHO schema used to create the object.
  */
-// TODO(wittjosiah): Narrow types.
-export const getSchema: (obj: unknown | undefined) => Type.AnyEntity | undefined = internal.getSchema as any;
+export const getSchema: (obj: Unknown | Snapshot) => Type.AnyEntity | undefined = internal.getSchema as any;
 
 /**
  * @returns The typename of the object's type.

--- a/packages/devtools/devtools/src/components/ObjectsTree.tsx
+++ b/packages/devtools/devtools/src/components/ObjectsTree.tsx
@@ -287,7 +287,7 @@ class ObjectsTreeModel {
   }
 
   #mapEntityToTreeItems(entity: Entity.Snapshot, anchor: string | null): ObjectsTreeItem {
-    const { icon, hue } = Option.fromNullable(Obj.getSchema(entity)).pipe(
+    const { icon, hue } = Option.fromNullable(Entity.getSchema(entity)).pipe(
       Option.flatMap(Annotation.IconAnnotation.get),
       Option.getOrElse(() => ({
         icon: Obj.isSnapshot(entity) ? DEFAULT_OBJECT_ICON : DEFAULT_RELATION_ICON,

--- a/packages/devtools/devtools/src/panels/echo/ObjectsPanel/ObjectsTree.tsx
+++ b/packages/devtools/devtools/src/panels/echo/ObjectsPanel/ObjectsTree.tsx
@@ -188,7 +188,7 @@ class ObjectsTreeModel {
   }
 
   #mapEntityToTreeItems(entity: Entity.Snapshot, anchor: string | null): ObjectsTreeItem {
-    const { icon, hue } = Option.fromNullable(Obj.getSchema(entity)).pipe(
+    const { icon, hue } = Option.fromNullable(Entity.getSchema(entity)).pipe(
       Option.flatMap(Annotation.IconAnnotation.get),
       Option.getOrElse(() => ({
         icon: Obj.isSnapshot(entity) ? DEFAULT_OBJECT_ICON : DEFAULT_RELATION_ICON,

--- a/packages/plugins/plugin-search/src/hooks/sync.ts
+++ b/packages/plugins/plugin-search/src/hooks/sync.ts
@@ -5,7 +5,7 @@
 import type * as Schema from 'effect/Schema';
 import * as SchemaAST from 'effect/SchemaAST';
 
-import { type Entity, Obj } from '@dxos/echo';
+import { Entity, Obj } from '@dxos/echo';
 import { Text } from '@dxos/schema';
 
 import { type SearchResult } from '#types';
@@ -57,7 +57,7 @@ export const filterObjectsSync = <T extends Entity.Unknown>(objects: T[], match?
 
       results.push({
         id: object.id,
-        type: getIcon(Obj.getSchema(object)),
+        type: getIcon(Entity.getSchema(object)),
         label,
         match,
         // TODO(burdon): Truncate.

--- a/packages/plugins/plugin-search/src/hooks/useWebSearch.ts
+++ b/packages/plugins/plugin-search/src/hooks/useWebSearch.ts
@@ -5,7 +5,7 @@
 import { useCallback, useState } from 'react';
 
 import { EXA_API_KEY } from '@dxos/ai/testing';
-import { Obj } from '@dxos/echo';
+import { Entity } from '@dxos/echo';
 import { log } from '@dxos/log';
 import { getIconAnnotation } from '@dxos/schema';
 import { TestSchema } from '@dxos/schema/testing';
@@ -44,7 +44,7 @@ export const useWebSearch = ({ query, context }: UseWebSearchProps): UseWebSearc
       });
 
       const mappedResults = results.data.map((result): SearchResult => {
-        const schema = Obj.getSchema(result);
+        const schema = Entity.getSchema(result);
         return {
           id: result.id,
           label: getStringProperty(result, ['name', 'title', 'label']),

--- a/packages/plugins/plugin-space/src/containers/RelatedArticle/RelatedArticle.tsx
+++ b/packages/plugins/plugin-space/src/containers/RelatedArticle/RelatedArticle.tsx
@@ -45,7 +45,7 @@ const ObjectCard = ({ data: subject, classNames }: { data: Entity.Unknown; class
   const { t } = useTranslation(meta.id);
   const data = useMemo(() => ({ subject }), [subject]);
   const icon = Function.pipe(
-    Obj.getSchema(subject),
+    Entity.getSchema(subject),
     Option.fromNullable,
     Option.flatMap(Annotation.IconAnnotation.get),
     Option.map(({ icon }) => icon),

--- a/packages/sdk/schema/src/graph/graph.ts
+++ b/packages/sdk/schema/src/graph/graph.ts
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import { Entity, Obj, Ref } from '@dxos/echo';
+import { Entity, Ref } from '@dxos/echo';
 import { getProperties } from '@dxos/effect';
 import { Graph, GraphModel } from '@dxos/graph';
 import { log } from '@dxos/log';
@@ -21,7 +21,7 @@ export const createGraph = <T extends Entity.Unknown>(objects: T[]): GraphModel.
 
   // Find references.
   objects.forEach((object) => {
-    const schema = Obj.getSchema(object);
+    const schema = Entity.getSchema(object);
     if (!schema) {
       log('no schema for object', { id: object.id.slice(0, 8) });
       return;

--- a/packages/sdk/schema/src/graph/space-graph.ts
+++ b/packages/sdk/schema/src/graph/space-graph.ts
@@ -3,7 +3,7 @@
 //
 
 import { type CleanupFn } from '@dxos/async';
-import { type Database, type Entity, Filter, Obj, Query, Ref, Relation, Type } from '@dxos/echo';
+import { type Database, Entity, Filter, Obj, Query, Ref, Relation, Type } from '@dxos/echo';
 import { type Queue, type QueueImpl } from '@dxos/echo-db';
 import { type Graph, GraphModel } from '@dxos/graph';
 import { invariant } from '@dxos/invariant';
@@ -228,7 +228,7 @@ export class SpaceGraphModel extends GraphModel.ReactiveGraphModel<SpaceGraphNod
     ];
 
     objects.forEach((object) => {
-      const schema = Obj.getSchema(object);
+      const schema = Entity.getSchema(object);
 
       // Relations.
       if (Relation.isRelation(object)) {

--- a/packages/ui/react-ui-table/src/model/table-model.ts
+++ b/packages/ui/react-ui-table/src/model/table-model.ts
@@ -695,7 +695,7 @@ export class TableModel<T extends TableRow = TableRow> extends Resource {
       const snapshot = { ...getSnapshot(currentRow) };
       setValue(snapshot, field.path, transformedValue);
 
-      const schema = Obj.getSchema(currentRow);
+      const schema = Obj.getSchema(currentRow as unknown as Obj.Unknown);
       invariant(schema);
 
       const validationResult = validateSchema(schema, snapshot);


### PR DESCRIPTION
## Summary

Follow-up to #11085 applying CodeRabbit review nitpicks that couldn't be pushed before the original PR entered the merge queue:

- `EchoDatabase.add`: replace `Obj.getSchema(obj as unknown as Obj.Unknown)` with `Entity.getSchema(obj)` since `obj: T extends Entity.Unknown` matches the new `Entity.getSchema` signature exactly.
- `EchoDatabase.runMigrations`: drop the now-dead `postMigrationType != null` check. `Obj.getTypeDXN` throws on corrupted objects, so the check was unreachable.

## Test plan

- [x] `moon run echo-db:build`


---
_Generated by [Claude Code](https://claude.ai/code/session_01UMN4zspAkHwpgbu4TKTLcg)_