### PR TITLE
fix(plugin-help): fix Joyride tour final step visibility and tooltip spacing

### DIFF
--- a/packages/plugins/plugin-deck/src/containers/Sidebar/ComplementarySidebar.tsx
+++ b/packages/plugins/plugin-deck/src/containers/Sidebar/ComplementarySidebar.tsx
@@ -105,6 +105,7 @@ export const ComplementarySidebar = ({ current }: ComplementarySidebarProps) => 
                   iconOnly
                   tooltipSide='left'
                   data-value={getLinkedVariant(companion.id)}
+                  {...(companion.properties.joyride && { 'data-joyride': companion.properties.joyride })}
                   variant={
                     activeId === getLinkedVariant(companion.id)
                       ? state.complementarySidebarState === 'expanded'

--- a/packages/plugins/plugin-deck/src/hooks/useDeckCompanions.ts
+++ b/packages/plugins/plugin-deck/src/hooks/useDeckCompanions.ts
@@ -19,6 +19,7 @@ export type DeckCompanion = NodeType.Node<
     /** If true, the panel will not be wrapped in a scroll area. */
     fixed?: boolean;
     position?: Position;
+    joyride?: string;
   }
 >;
 

--- a/packages/plugins/plugin-help/src/components/WelcomeTour/WelcomeTour.tsx
+++ b/packages/plugins/plugin-help/src/components/WelcomeTour/WelcomeTour.tsx
@@ -163,6 +163,7 @@ export const WelcomeTour = ({ steps: initialSteps, running: runningProp, onRunni
         callback={callback}
         floaterProps={floaterProps}
         tooltipComponent={Tooltip}
+        spotlightPadding={0}
       />
     </HelpContext.Provider>
   );

--- a/packages/plugins/plugin-observability/src/capabilities/app-graph-builder.ts
+++ b/packages/plugins/plugin-observability/src/capabilities/app-graph-builder.ts
@@ -25,6 +25,7 @@ export default Capability.makeModule(
               icon: 'ph--question--regular',
               data: null,
               position: 'hoist',
+              joyride: 'welcome/feedback',
             }),
           ]),
       }),

--- a/packages/sdk/app-toolkit/src/app-node.ts
+++ b/packages/sdk/app-toolkit/src/app-node.ts
@@ -56,12 +56,14 @@ export const makeDeckCompanion = <TData = any>({
   icon,
   data,
   position,
+  joyride,
 }: {
   id: string;
   label: Label;
   icon: string;
   data: TData;
   position?: Position;
+  joyride?: string;
 }): Node.NodeArg<TData> => ({
   id,
   type: DECK_COMPANION_TYPE,
@@ -71,6 +73,7 @@ export const makeDeckCompanion = <TData = any>({
     icon,
     disposition: 'hidden',
     ...(position !== undefined && { position }),
+    ...(joyride !== undefined && { joyride }),
   },
 });
 


### PR DESCRIPTION
## Summary

- **Missing tour target**: The final "Feedback" step of the onboarding Joyride tour targeted `[data-joyride="welcome/feedback"]`, but no element in the DOM had this attribute — causing Joyride to silently end the tour before reaching the done step. Fixed by wiring a `joyride` property through `makeDeckCompanion` → companion node → `ComplementarySidebar` tab button.
- **Excess tooltip spacing**: Joyride's component-level `spotlightPadding` defaults to `10` and is always added to the floater offset, so even with `offset: 0` on each step the tooltip sat ~18px from anchors. Fixed by passing `spotlightPadding={0}` directly to the `<Joyride>` component.

## Changes

- `app-toolkit/src/app-node.ts` — add optional `joyride` param to `makeDeckCompanion`
- `plugin-deck/src/hooks/useDeckCompanions.ts` — add `joyride?: string` to `DeckCompanion` properties type
- `plugin-observability/src/capabilities/app-graph-builder.ts` — pass `joyride: 'welcome/feedback'` to the help companion
- `plugin-deck/src/containers/Sidebar/ComplementarySidebar.tsx` — render `data-joyride` on the companion tab button when set
- `plugin-help/src/components/WelcomeTour/WelcomeTour.tsx` — set `spotlightPadding={0}` on `<Joyride>`

## Test Plan

- [ ] Trigger the onboarding Joyride tour (new identity / reset storage) and verify all 6 steps are reachable including the final "Feedback" step with a visible Done button
- [ ] Verify tooltip appears closer to its anchor element on each step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for associating guided tour identifiers with companion elements across the platform.
  * Enhanced tour rendering with improved visual spotlight padding for better visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->