### PR TITLE
fix(composer-app): emit _worker.js after vite build so it survives emptyOutDir

### DIFF
--- a/.moon/tasks/tag-vite.yml
+++ b/.moon/tasks/tag-vite.yml
@@ -7,6 +7,7 @@ tasks:
       - ^:compile
     inputs:
       - vite.config.ts
+      - '*.html'
       - '@group(production)'
       - $CONFIG_DYNAMIC
       - $DX_EDGE_BASE_URL

--- a/packages/apps/composer-app/moon.yml
+++ b/packages/apps/composer-app/moon.yml
@@ -13,6 +13,9 @@ tasks:
     script: pnpm exec vite build && pnpm run --silent build:functions
     deps:
       - prebuild
+    inputs:
+      - '*.html'
+      - script-frame/index.html
   compile:
     deps:
       - prebuild

--- a/packages/apps/composer-app/moon.yml
+++ b/packages/apps/composer-app/moon.yml
@@ -14,7 +14,6 @@ tasks:
     deps:
       - prebuild
     inputs:
-      - '*.html'
       - script-frame/index.html
   compile:
     deps:

--- a/packages/apps/composer-app/moon.yml
+++ b/packages/apps/composer-app/moon.yml
@@ -13,10 +13,6 @@ tasks:
     script: pnpm exec vite build && pnpm run --silent build:functions
     deps:
       - prebuild
-    inputs:
-      - src/functions/_worker.ts
-    outputs:
-      - out/composer/_worker.js
   compile:
     deps:
       - prebuild

--- a/packages/apps/composer-app/moon.yml
+++ b/packages/apps/composer-app/moon.yml
@@ -9,22 +9,26 @@ tags:
   - storybook
 tasks:
   bundle:
+    # Emit `_worker.js` after `vite build` so it survives Vite's `emptyOutDir`.
+    script: pnpm exec vite build && pnpm run --silent build:functions
     deps:
       - prebuild
+    inputs:
+      - src/functions/_worker.ts
+    outputs:
+      - out/composer/_worker.js
   compile:
     deps:
       - prebuild
   prebuild:
-    script: pnpm run --silent copy:assets && pnpm run --silent build:functions
+    script: pnpm run --silent copy:assets
     deps:
       - ^:prebuild
     inputs:
       - package.json
       - moon.yml
-      - src/functions/_worker.ts
     outputs:
       - public/assets/plugin-sketch
-      - out/composer/_worker.js
   serve:
     deps:
       - prebuild


### PR DESCRIPTION
## Summary

- Build `_worker.js` **after** `vite build` instead of in `prebuild`, so Vite's default `emptyOutDir: true` (which wipes `out/composer/` before writing) doesn't delete it.
- Split `prebuild` to only copy static assets; move `build:functions` into the `bundle` task as a post-step.

## Why

The Cloudflare Pages `_worker.js` for the composer app has been silently missing from deployments. When a user submitted the feedback form on labs.composer.space, `POST /api/feedback-logs` hit CF's static-asset handler (returning a header-less 405 with `Content-Length: 0`) instead of our worker. The PostHog \`survey sent\` event was captured with \`debug_log_dump_key: 'failed'\` because [extension.ts:158-160](https://github.com/dxos/dxos/blob/main/packages/sdk/observability/src/extensions/posthog/extension.ts#L158-L160) falls back to \`'failed'\` when \`/api/feedback-logs\` returns a non-OK response.

Root cause: moon task order is \`prebuild\` → \`bundle\` (vite build). \`prebuild\` wrote \`out/composer/_worker.js\`, then \`vite build\` emptied \`out/composer/\` and replaced it with only SPA assets. No worker shipped.

## Related

Also required (done separately, via the Cloudflare API) to fully fix feedback-log uploads on labs/production:
- Added the \`FEEDBACK_LOGS\` R2 binding on the \`composer\` Pages project for both \`production\` (→ \`composer-feedback-logs\`) and \`preview\` (→ \`composer-feedback-logs-preview\`) environments. The binding was declared in [wrangler.toml](https://github.com/dxos/dxos/blob/main/packages/apps/composer-app/wrangler.toml) but \`wrangler pages deploy\` does not sync project-level bindings, so the R2 binding never existed at runtime.

After this PR ships and \`labs\` is redeployed, \`POST /api/feedback-logs\` should return 200 with a key, and PostHog survey events will record the R2 object key instead of \`'failed'\`.

## Test plan

- [x] Locally: \`moon run composer-app:bundle --force\` → \`out/composer/\` contains both SPA assets and \`_worker.js\` (same timestamp).
- [ ] CI green on this PR.
- [ ] After redeploying \`labs\`: \`curl -X POST https://labs.composer.space/api/feedback-logs\` returns a JSON body with \`{ "key": ... }\` (or 503/413 from our worker, not 405 from CF static-asset handler).
- [ ] Submit feedback form on labs.composer.space, verify PostHog survey event shows \`debug_log_dump_key: logs/<date>/<uuid>.ndjson\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build pipeline adjusted so the runtime worker artifact is produced during the bundle step rather than prebuild, reducing redundant prebuild outputs.
  * Bundle step now considers HTML inputs when deciding to rebuild, and prebuild is narrowed to asset copying only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->