### PR TITLE
fix(ci): fix iOS CN upload working directory for updated CN CLI

### DIFF
--- a/.github/workflows/publish-tauri.yaml
+++ b/.github/workflows/publish-tauri.yaml
@@ -394,7 +394,7 @@ jobs:
           api-key: ${{ secrets.CN_API_KEY }}
           application: ${{ env.CN_APPLICATION }}
           command: upload
-          working-directory: ./packages/apps/composer-app/src-tauri/
+          working-directory: ./packages/apps/composer-app/
 
       # https://tauri.app/distribute/app-store/#ios
       - name: Upload assets to App Store Connect


### PR DESCRIPTION
## Summary

- Changes `working-directory` for the `Upload assets to CN` step in `build_tauri_ios` from `./packages/apps/composer-app/src-tauri/` to `./packages/apps/composer-app/`

## Why

The CN CLI was updated on 2026-04-23 and changed how it discovers the Tauri project directory for iOS builds. The updated CLI now requires the working directory to be the **project root** (the directory containing `src-tauri/`) rather than `src-tauri/` itself.

For macOS builds this isn't an issue — the CLI finds `target/release/bundle/` directly and uses that as the artifact source. For iOS builds, without a `target/` directory, the CLI now falls back to looking for `src-tauri/` as a subdirectory of the working directory. Running from within `src-tauri/` means it looks for `src-tauri/src-tauri/`, which doesn't exist, producing "Could not find Tauri directory".

This was confirmed by checking CI history: the last successful run (`24818968686`, Apr 23 05:42) passed with the old CLI, and every run after (`24832725921`, Apr 23 11:29 onward) failed at the same step with no code changes in between.

The macOS upload step is unchanged — it continues to use `src-tauri/` and works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for the release workflow to correctly locate artifacts during the asset upload process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->