### PR TITLE
refactor(protocols): replace google.protobuf.Struct with JSON strings in queue proto

### DIFF
--- a/packages/core/echo/echo-db/src/queue/queue-service.ts
+++ b/packages/core/echo/echo-db/src/queue/queue-service.ts
@@ -33,7 +33,10 @@ export class QueueServiceImpl implements QueueService {
       request.query.spaceId as SpaceId,
       request.query,
     );
-    return result as any as QueueQueryResult;
+    return {
+      ...result,
+      objects: (result.objects ?? []).map((obj) => JSON.stringify(obj)),
+    } as QueueQueryResult;
   }
 
   insertIntoQueue(request: InsertIntoQueueRequest): Promise<void> {
@@ -43,7 +46,7 @@ export class QueueServiceImpl implements QueueService {
       request.subspaceTag!,
       request.spaceId as SpaceId,
       request.queueId as ObjectId,
-      request.objects!,
+      (request.objects ?? []).map((encoded) => JSON.parse(encoded)),
     );
   }
 
@@ -67,7 +70,7 @@ export class QueueServiceImpl implements QueueService {
  * Mock implementation for testing.
  */
 export class MockQueueService implements QueueService {
-  private _queues = new ComplexMap<[subspaceTag: string, spaceId: SpaceId, queueId: ObjectId], unknown[]>(
+  private _queues = new ComplexMap<[subspaceTag: string, spaceId: SpaceId, queueId: ObjectId], ObjectJSON[]>(
     ([subspaceTag, spaceId, queueId]) => compositeKey(subspaceTag, spaceId, queueId),
   );
 
@@ -77,7 +80,7 @@ export class MockQueueService implements QueueService {
       this._queues.get([request.query.queuesNamespace!, query!.spaceId as SpaceId, query!.queueIds![0] as ObjectId]) ??
       [];
     return {
-      objects: objects as any,
+      objects: objects.map((obj) => JSON.stringify(obj)),
       nextCursor: '',
       prevCursor: '',
     };
@@ -88,8 +91,9 @@ export class MockQueueService implements QueueService {
     const key: [string, SpaceId, ObjectId] = [subspaceTag!, spaceId as SpaceId, queueId as ObjectId];
     const array = this._queues.get(key) ?? [];
     this._queues.set(key, array);
-    for (const obj of objects!) {
-      setQueuePosition(obj as ObjectJSON, array.length);
+    for (const encoded of objects ?? []) {
+      const obj = JSON.parse(encoded) as ObjectJSON;
+      setQueuePosition(obj, array.length);
       array.push(obj);
     }
   }
@@ -100,7 +104,7 @@ export class MockQueueService implements QueueService {
     const existing = this._queues.get(key) ?? [];
     this._queues.set(
       key,
-      existing.filter((obj: any) => !objectIds!.includes(obj.id)),
+      existing.filter((obj) => !objectIds!.includes((obj as any).id)),
     );
   }
 

--- a/packages/core/echo/echo-db/src/queue/queue.ts
+++ b/packages/core/echo/echo-db/src/queue/queue.ts
@@ -58,7 +58,14 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
       }
 
       const decodedObjects = await Promise.all(
-        (objects ?? []).map(async (obj) => {
+        (objects ?? []).map(async (encoded) => {
+          let obj: ObjectJSON;
+          try {
+            obj = JSON.parse(encoded) as ObjectJSON;
+          } catch (err) {
+            log.verbose('queue object JSON parse failed; object ignored', { encoded, error: err });
+            return undefined;
+          }
           try {
             return await Obj.fromJSON(obj, {
               refResolver: this._refResolver,
@@ -204,15 +211,15 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
     }
     this.updated.emit();
 
-    const json = items.map((item) => Entity.toJSON(item));
+    const encoded = items.map((item) => JSON.stringify(Entity.toJSON(item)));
 
     try {
-      for (let i = 0; i < json.length; i += QUEUE_APPEND_BATCH_SIZE) {
+      for (let i = 0; i < encoded.length; i += QUEUE_APPEND_BATCH_SIZE) {
         await this._service.insertIntoQueue({
           subspaceTag: this._subspaceTag,
           spaceId: this._spaceId,
           queueId: this._queueId,
-          objects: json.slice(i, i + QUEUE_APPEND_BATCH_SIZE) as any,
+          objects: encoded.slice(i, i + QUEUE_APPEND_BATCH_SIZE),
         });
       }
     } catch (err) {
@@ -305,7 +312,7 @@ export class QueueImpl<T extends Entity.Unknown = Entity.Unknown> implements Que
         queueIds: [this._queueId],
       },
     });
-    return objects as ObjectJSON[];
+    return (objects ?? []).map((encoded) => JSON.parse(encoded) as ObjectJSON);
   }
 
   async hydrateObject(obj: ObjectJSON): Promise<Entity.Unknown> {

--- a/packages/core/echo/echo-pipeline/src/db-host/local-queue-service.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/local-queue-service.ts
@@ -59,8 +59,8 @@ export class LocalQueueServiceImpl implements QueueService {
           limit: query.limit,
         });
 
-        const objects = result.blocks.map(
-          (block: FeedProtocol.Block) => EchoFeedCodec.decode(block.data, block.position ?? undefined) as ObjectJSON,
+        const objects = result.blocks.map((block: FeedProtocol.Block) =>
+          JSON.stringify(EchoFeedCodec.decode(block.data, block.position ?? undefined) as ObjectJSON),
         );
 
         const lastBlock = result.blocks[result.blocks.length - 1];
@@ -87,11 +87,11 @@ export class LocalQueueServiceImpl implements QueueService {
     );
     return RuntimeProvider.runPromise(this.#runtime)(
       Effect.gen(this, function* () {
-        const messages = objects!.map((obj) => ({
+        const messages = (objects ?? []).map((encoded) => ({
           spaceId: spaceId,
           feedId: queueId!,
           feedNamespace,
-          data: EchoFeedCodec.encode(obj as ObjectJSON),
+          data: EchoFeedCodec.encode(JSON.parse(encoded) as ObjectJSON),
         }));
 
         yield* this.#feedStore.appendLocal(messages);

--- a/packages/core/echo/echo-pipeline/src/db-host/queue-service.test.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/queue-service.test.ts
@@ -42,7 +42,7 @@ describe('LocalQueueServiceImpl', () => {
           subspaceTag: FeedProtocol.WellKnownNamespaces.data,
           spaceId,
           queueId,
-          objects: [object1, object2],
+          objects: [object1, object2].map((obj) => JSON.stringify(obj)),
         }),
       );
 
@@ -51,8 +51,8 @@ describe('LocalQueueServiceImpl', () => {
           query: { spaceId, queueIds: [queueId] },
         }),
       );
-      expect(result.objects?.[0]).toMatchObject(object1);
-      expect(result.objects?.[1]).toMatchObject(object2);
+      expect(JSON.parse(result.objects![0])).toMatchObject(object1);
+      expect(JSON.parse(result.objects![1])).toMatchObject(object2);
     }).pipe(Effect.provide(TestLayer)),
   );
 
@@ -73,7 +73,7 @@ describe('LocalQueueServiceImpl', () => {
           subspaceTag: FeedProtocol.WellKnownNamespaces.data,
           spaceId,
           queueId,
-          objects: [object1],
+          objects: [JSON.stringify(object1)],
         }),
       );
       yield* Effect.promise(() =>
@@ -91,7 +91,7 @@ describe('LocalQueueServiceImpl', () => {
         }),
       );
       expect(result.objects).toHaveLength(2);
-      expect(result.objects?.[1]).toMatchObject({ id: object1Id, '@deleted': true });
+      expect(JSON.parse(result.objects![1])).toMatchObject({ id: object1Id, '@deleted': true });
     }).pipe(Effect.provide(TestLayer)),
   );
 
@@ -111,7 +111,7 @@ describe('LocalQueueServiceImpl', () => {
           subspaceTag: FeedProtocol.WellKnownNamespaces.data,
           spaceId,
           queueId,
-          objects: items,
+          objects: items.map((item) => JSON.stringify(item)),
         }),
       );
 
@@ -122,8 +122,8 @@ describe('LocalQueueServiceImpl', () => {
         }),
       );
       expect(page1.objects).toHaveLength(5);
-      expect(page1.objects?.[0]).toMatchObject(items[0]);
-      expect(page1.objects?.[4]).toMatchObject(items[4]);
+      expect(JSON.parse(page1.objects![0])).toMatchObject(items[0]);
+      expect(JSON.parse(page1.objects![4])).toMatchObject(items[4]);
       expect(page1.nextCursor).toBeDefined();
 
       // Query next 5
@@ -138,8 +138,8 @@ describe('LocalQueueServiceImpl', () => {
         }),
       );
       expect(page2.objects).toHaveLength(5);
-      expect(page2.objects?.[0]).toMatchObject(items[5]);
-      expect(page2.objects?.[4]).toMatchObject(items[9]);
+      expect(JSON.parse(page2.objects![0])).toMatchObject(items[5]);
+      expect(JSON.parse(page2.objects![4])).toMatchObject(items[9]);
     }).pipe(Effect.provide(TestLayer)),
   );
 });

--- a/packages/core/functions-runtime-cloudflare/src/internal/service-container.ts
+++ b/packages/core/functions-runtime-cloudflare/src/internal/service-container.ts
@@ -83,7 +83,7 @@ export class ServiceContainer {
       subspaceTag,
       spaceId,
       queueId,
-      objects: objects as FeedProtocol.InsertIntoQueueRequest['objects'],
+      objects: objects.map((obj) => JSON.stringify(obj)),
     });
   }
 }

--- a/packages/core/functions-runtime-cloudflare/src/queues-api.ts
+++ b/packages/core/functions-runtime-cloudflare/src/queues-api.ts
@@ -4,9 +4,14 @@
 
 import { type AnyEntity } from '@dxos/echo/internal';
 import type { DXN, SpaceId } from '@dxos/keys';
-import { type FeedProtocol } from '@dxos/protocols';
 
 import type { ServiceContainer } from './internal';
+
+export interface QueryResult {
+  objects: AnyEntity[];
+  nextCursor: string | null;
+  prevCursor: string | null;
+}
 
 // TODO(dmaretskyi): Temporary API to get the queues working.
 // TODO(dmaretskyi): To be replaced with integrating queues into echo.
@@ -14,7 +19,7 @@ import type { ServiceContainer } from './internal';
  * @deprecated
  */
 export interface QueuesAPI {
-  queryQueue(queue: DXN, options?: {}): Promise<FeedProtocol.QueryResult>;
+  queryQueue(queue: DXN, options?: {}): Promise<QueryResult>;
   insertIntoQueue(queue: DXN, objects: AnyEntity[]): Promise<void>;
 }
 
@@ -27,8 +32,13 @@ export class QueuesAPIImpl implements QueuesAPI {
     private readonly _spaceId: SpaceId,
   ) {}
 
-  queryQueue(queue: DXN, options?: {}): Promise<FeedProtocol.QueryResult> {
-    return this._serviceContainer.queryQueue(queue);
+  async queryQueue(queue: DXN, options?: {}): Promise<QueryResult> {
+    const result = await this._serviceContainer.queryQueue(queue);
+    return {
+      objects: (result.objects ?? []).map((encoded) => JSON.parse(encoded) as AnyEntity),
+      nextCursor: result.nextCursor ?? null,
+      prevCursor: result.prevCursor ?? null,
+    };
   }
 
   insertIntoQueue(queue: DXN, objects: AnyEntity[]): Promise<void> {

--- a/packages/core/protocols/src/proto/dxos/client/queue.proto
+++ b/packages/core/protocols/src/proto/dxos/client/queue.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package dxos.client.services;
 
-import "google/protobuf/struct.proto";
 import "google/protobuf/empty.proto";
 
 
@@ -34,9 +33,12 @@ message QueueQuery {
 }
 
 message QueueQueryResult {
-  repeated google.protobuf.Struct objects = 1;
+  /// JSON-encoded object payloads. Each entry is a serialized ObjectJSON.
+  /// We use JSON strings instead of google.protobuf.Struct because Struct
+  /// coerces `undefined` to `null`, corrupting optional fields.
+  repeated string objects = 1;
 
-  /// Cursor to query the next items. Can be passed to `after` in query to keep querying. 
+  /// Cursor to query the next items. Can be passed to `after` in query to keep querying.
   string next_cursor = 2;
 
   string prev_cursor = 3;
@@ -50,7 +52,8 @@ message InsertIntoQueueRequest {
   string subspace_tag = 1;
   string space_id = 2;
   string queue_id = 3;
-  repeated google.protobuf.Struct objects = 4;
+  /// JSON-encoded object payloads. Each entry is a serialized ObjectJSON.
+  repeated string objects = 4;
 }
 
 message DeleteFromQueueRequest {

--- a/packages/sdk/client-services/src/packlets/space-export/serialized-space-writer.ts
+++ b/packages/sdk/client-services/src/packlets/space-export/serialized-space-writer.ts
@@ -230,7 +230,7 @@ const collectQueueMessages = async (echoHost: EchoHost, queueDxn: DXN): Promise<
         after: cursor,
       },
     });
-    const batch = (result.objects ?? []) as Obj.JSON[];
+    const batch = (result.objects ?? []).map((encoded) => JSON.parse(encoded) as Obj.JSON);
     if (batch.length === 0) {
       break;
     }

--- a/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
+++ b/packages/sdk/client-services/src/packlets/spaces/spaces-service.ts
@@ -384,7 +384,7 @@ export class SpacesServiceImpl implements SpacesService {
           spaceId: space.id,
           queueId: feed.feedObjectId,
           subspaceTag: namespace,
-          objects: feed.messages,
+          objects: feed.messages.map((message) => JSON.stringify(message)),
         });
       } catch (err) {
         log.warn('failed to import feed data', { feedObjectId: feed.feedObjectId, error: err });


### PR DESCRIPTION
## Summary

- `google.protobuf.Struct` coerces `undefined` to `null` when encoding, corrupting optional fields on objects that flow through the queue RPC.
- Switch `QueueQueryResult.objects` and `InsertIntoQueueRequest.objects` from `repeated google.protobuf.Struct` to `repeated string`, where each entry is a JSON-encoded `ObjectJSON`.
- Update all producers/consumers across echo-db, echo-pipeline, client-services, and functions-runtime-cloudflare to stringify/parse at the proto boundary.

## Changes

- `packages/core/protocols/src/proto/dxos/client/queue.proto`: drop the `Struct` import; change `objects` fields on `QueueQueryResult` and `InsertIntoQueueRequest` to `repeated string`.
- `echo-db/src/queue/queue.ts`: stringify on `append`, parse on `_refreshTask` and `fetchObjectsJSON`.
- `echo-db/src/queue/queue-service.ts`: stringify/parse at the boundary to `EdgeHttpClient`; update `MockQueueService` to store `ObjectJSON` internally and convert at the proto boundary.
- `echo-pipeline/src/db-host/local-queue-service.ts`: stringify decoded blocks on query; parse before encoding on insert.
- `echo-pipeline/src/db-host/queue-service.test.ts`: tests now stringify inputs and parse outputs.
- `functions-runtime-cloudflare/src/internal/service-container.ts`: stringify `AnyEntity[]` before forwarding to the edge queue service.
- `functions-runtime-cloudflare/src/queues-api.ts`: the deprecated `QueuesAPI` now returns a local `QueryResult` shape with parsed `AnyEntity[]` so existing template callers keep receiving objects instead of strings.
- `client-services/src/packlets/spaces/spaces-service.ts` and `serialized-space-writer.ts`: stringify/parse at the queue RPC boundary.

## Test plan

- [x] `moon run protocols:compile`
- [x] `moon run echo-db:compile` and `moon run echo-pipeline:compile`
- [x] `moon run echo-pipeline:test -- src/db-host/queue-service.test.ts` (3 tests passing)
- [x] `moon run echo-db:test -- src/testing/queue.test.ts` (15 tests passing)
- [x] `moon run echo-db:test -- src/queue/feed.test.ts` (all passing)
- [x] `moon run echo-db:test -- src/query/query.test.ts` (all 106 tests passing)
- [x] `moon run client-services:test` (110 tests passing)
- [x] `moon run client:compile functions-runtime-cloudflare:compile assistant:compile`
- [ ] Verify the Cloudflare edge worker side still interoperates (separate repo; out of scope)

https://claude.ai/code/session_01PUckQttyZ8M9WG8pjiwCfj

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUckQttyZ8M9WG8pjiwCfj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON serialization/deserialization handling across queue operations to ensure proper encoding of queue objects throughout the system.

* **Refactor**
  * Updated internal queue protocol to use JSON-encoded strings instead of raw object payloads, with corresponding changes to queue service implementations and API layers for consistent data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->