### PR TITLE
feat(echo-db): Query.children() traverses feed -> queue items

### DIFF
--- a/packages/core/echo/echo-db/src/query/query.test.ts
+++ b/packages/core/echo/echo-db/src/query/query.test.ts
@@ -1505,6 +1505,29 @@ describe('Query', () => {
       expect(parentChildren).toHaveLength(1);
       expect(parentChildren[0]).toMatchObject({ name: 'Child' });
     });
+
+    test('traverse to children of a feed returns feed queue items', async () => {
+      const feedPeer = await builder.createPeer({ types: [Feed.Feed, TestSchema.Task] });
+      const feedDb = await feedPeer.createDatabase();
+      const queues = feedPeer.client.constructQueueFactory(feedDb.spaceId);
+
+      const feed = feedDb.add(Feed.make({ name: 'test-feed' }));
+      const feedDxn = Feed.getQueueDxn(feed)!;
+      const queue = queues.get(feedDxn);
+
+      // Space-only task (should NOT appear as a child of the feed).
+      feedDb.add(Obj.make(TestSchema.Task, { title: 'Space Task' }));
+      await queue.append([
+        Obj.make(TestSchema.Task, { title: 'Feed Task 1' }),
+        Obj.make(TestSchema.Task, { title: 'Feed Task 2' }),
+      ]);
+      await feedDb.flush();
+
+      const objects = await feedDb.query(Query.select(Filter.id(feed.id)).children()).run();
+      expect(objects).toHaveLength(2);
+      const titles = objects.map((obj: any) => obj.title).sort();
+      expect(titles).toEqual(['Feed Task 1', 'Feed Task 2']);
+    });
   });
 
   describe.skip('text search (old indexer)', () => {

--- a/packages/core/echo/echo-pipeline/src/query/query-executor.ts
+++ b/packages/core/echo/echo-pipeline/src/query/query-executor.ts
@@ -964,6 +964,8 @@ export class QueryExecutor extends Resource {
 
           case 'to-children': {
             // Traverse from parent to children using the SQL index.
+            // Covers both standard parent/child hierarchy (via the `parent` field) and
+            // feed -> queue items (via the `queueId` field — a feed's queue id matches the feed's object id).
             // Group working set by spaceId.
             const bySpace = new Map<SpaceId, ObjectId[]>();
             for (const item of workingSet) {
@@ -975,26 +977,19 @@ export class QueryExecutor extends Resource {
               }
             }
 
-            // Query children for each space.
-            const allChildren: { spaceId: SpaceId; objectId: ObjectId }[] = [];
+            const beginIndexQuery = performance.now();
+            const allMetas: ObjectMeta[] = [];
             for (const [spaceId, parentIds] of bySpace) {
               const children = await this._runInRuntime(
                 this._indexEngine.queryChildren({ spaceId: [spaceId], parentIds }),
               );
-
-              for (const child of children) {
-                allChildren.push({ spaceId, objectId: child.objectId as ObjectId });
-              }
+              allMetas.push(...children);
             }
-
-            trace.indexHits += allChildren.length;
+            trace.indexHits += allMetas.length;
+            trace.indexQueryTime += performance.now() - beginIndexQuery;
 
             const documentLoadStart = performance.now();
-            const results = await Promise.all(
-              allChildren.map(({ spaceId, objectId }) =>
-                this._loadFromDXN(DXN.fromLocalObjectId(objectId), { sourceSpaceId: spaceId }),
-              ),
-            );
+            const results = await this._loadDocumentsAfterSqlQuery(allMetas);
             trace.documentsLoaded += results.filter(isNonNullable).length;
             trace.documentLoadTime += performance.now() - documentLoadStart;
 

--- a/packages/core/echo/index-core/src/indexes/object-meta-index.ts
+++ b/packages/core/echo/index-core/src/indexes/object-meta-index.ts
@@ -453,6 +453,10 @@ export class ObjectMetaIndex implements Index {
 
   /**
    * Query children by parent object ids.
+   * Matches both:
+   * - Objects whose `parent` field references one of the given parent ids (standard parent/child hierarchy).
+   * - Queue items whose `queueId` equals one of the parent ids (e.g. items inside a Feed, since a feed's queue
+   *   DXN uses the feed's object id as its queue id — see `Feed.getQueueDxn`).
    */
   queryChildren = Effect.fn('ObjectMetaIndex.queryChildren')(
     (query: {
@@ -465,8 +469,9 @@ export class ObjectMetaIndex implements Index {
         }
 
         const sql = yield* SqlClient.SqlClient;
+        const parentDxns = query.parentIds.map((id) => DXN.fromLocalObjectId(id).toString());
         const rows =
-          yield* sql<ObjectMeta>`SELECT * FROM objectMeta WHERE spaceId IN ${sql.in(query.spaceId)} AND parent IN ${sql.in(query.parentIds.map((id) => DXN.fromLocalObjectId(id).toString()))}`;
+          yield* sql<ObjectMeta>`SELECT * FROM objectMeta WHERE ${sql.in('spaceId', query.spaceId)} AND (${sql.in('parent', parentDxns)} OR ${sql.in('queueId', query.parentIds)})`;
 
         return rows.map((row) => ({
           ...row,


### PR DESCRIPTION
## Summary

- `Query.children()` now returns items inside a `Feed`'s queue when the anchor is a feed object — in addition to the existing `parent` field-based traversal.
- `ObjectMetaIndex.queryChildren` matches both `parent IN (parentDxns)` and `queueId IN (parentIds)`. This works because a feed's queue DXN uses the feed's own object id as its queue id (see `Feed.getQueueDxn`), so queue items are already indexed with `queueId = feed.id`.
- The query executor now loads resolved metas via `_loadDocumentsAfterSqlQuery` so queue-backed objects are hydrated from indexed snapshots (the same path used by relation traversal).

## Test plan

- [x] New test: `Query > Traversal > traverse to children of a feed returns feed queue items` in `packages/core/echo/echo-db/src/query/query.test.ts`.
- [x] Existing `traverse to children` and multi-level parent/child hierarchy tests still pass.
- [x] `moon run echo-db:test` — 554 passed.
- [x] `moon run index-core:test` — 26 passed.
- [x] `moon run echo-pipeline:test` — passed.
- [x] `pnpm format` + `moon run echo-db:lint index-core:lint echo-pipeline:lint -- --fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hierarchy traversal queries to correctly identify and return queue-based child items in addition to standard parent-child relationships, ensuring complete and accurate query results.
  * Enhanced performance tracking for index queries with detailed timing metrics.

* **Tests**
  * Added test coverage to validate feed traversal semantics and proper handling of queue-based children in queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->