### PR TITLE
ci: replace CREATE_PR_TOKEN with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -21,8 +21,8 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  id-token: write # Required for npm trusted publisher OIDC
+  contents: write # Required to upload release assets.
+  id-token: write # Required for npm trusted publisher OIDC.
 
 jobs:
   publish:
@@ -127,5 +127,5 @@ jobs:
         uses: fnkr/github-action-ghr@v1
         env:
           GHR_PATH: artifacts/
-          GITHUB_TOKEN: ${{ secrets.CREATE_PR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -3,6 +3,9 @@ on:
 
 name: release-candidate
 
+permissions:
+  contents: write # Required to create RC branch and force-push to staging.
+
 jobs:
   release-candidate:
     runs-on: ubuntu-latest
@@ -28,7 +31,7 @@ jobs:
 
       - uses: peterjgrainger/action-create-branch@v2.2.0
         env:
-          GITHUB_TOKEN: ${{ secrets.CREATE_PR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           branch: ${{ steps.branch.outputs.prefix }}-${{ steps.time.outputs.today }}-${{ steps.git.outputs.sha }}
 
@@ -36,7 +39,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Checkout all branches
-          token: ${{ secrets.CREATE_PR_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push to Staging
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,10 @@ on:
 
 name: release-please
 
+permissions:
+  contents: write # Required to tag releases, push merges, and delete branches.
+  pull-requests: write # Required to create release PRs.
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -14,7 +18,7 @@ jobs:
         id: release
         uses: google-github-actions/release-please-action@v3
         with:
-          token: ${{ secrets.CREATE_PR_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           default-branch: ${{ github.ref_name }}
           release-type: node
           command: github-release
@@ -22,7 +26,7 @@ jobs:
       - name: Version Bump
         uses: google-github-actions/release-please-action@v3
         with:
-          token: ${{ secrets.CREATE_PR_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           default-branch: ${{ github.ref_name }}
           release-type: node
           command: manifest-pr
@@ -31,7 +35,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Checkout all branches
-          token: ${{ secrets.CREATE_PR_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Git
         run: |
@@ -102,5 +106,5 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: dawidd6/action-delete-branch@v3
         with:
-          github_token: ${{ secrets.CREATE_PR_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           branches: ${{ github.ref_name }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -5,6 +5,11 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write # Required to push update branches.
+  pull-requests: write # Required to open dependency PRs.
+  packages: read # Required to pull the container image from ghcr.
+
 jobs:
   update:
     strategy:
@@ -44,14 +49,14 @@ jobs:
       image: ghcr.io/dxos/gh-actions:24.11.1
       credentials:
         username: dxos-bot
-        password: ${{ secrets.CREATE_PR_TOKEN }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
           lfs: true
-          token: ${{ secrets.CREATE_PR_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract branch
         id: extract_branch
@@ -74,4 +79,4 @@ jobs:
           delete-branch: true
           title: 'chore: Update ${{ matrix.packages.name }} dependencies'
           draft: false
-          token: ${{ secrets.CREATE_PR_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Swap `secrets.CREATE_PR_TOKEN` → `secrets.GITHUB_TOKEN` in `release-candidate`, `release-please`, `update-dependencies`, and `publish-all` workflows. The `CREATE_PR_TOKEN` secret is gone, causing these workflows to fail with `HttpError: Bad credentials`.
- Add `permissions:` blocks so each workflow gets the scopes the built-in token needs (`contents: write`, `pull-requests: write`, `packages: read` where applicable). `publish-all.yml` already had a `permissions:` block — bumped `contents: read` → `write` so it can upload release assets.

## Not changed

- `edge-tests.yml` still references `CREATE_PR_TOKEN` to check out `dxos/edge`. `GITHUB_TOKEN` is scoped to the current repo and can't read a sibling repo, so that one needs a different fix (GitHub App token, new PAT, or deletion).

## Reviewer notes

Two runtime gotchas to verify in repo settings:

1. **Branch protection.** `GITHUB_TOKEN` cannot bypass branch protection. If the old PAT was an admin/bot that bypassed rules, the following may now be blocked:
   - `release-please` merging into `main`/`production`
   - `release-candidate` force-pushing to `staging`
   - `release-please` deleting the RC branch
   If that's the case, we'll need a GitHub App token (e.g. `actions/create-github-app-token`) for those steps specifically.
2. **Action-created PRs.** `peter-evans/create-pull-request` (used by `update-dependencies` and `release-please`) requires *Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"* to be enabled. Also worth noting: PRs created by `GITHUB_TOKEN` do **not** trigger downstream workflows (by design). Dependency-update PRs may open without CI running until someone closes/reopens them.

## Test plan

- [ ] Manually dispatch `release-candidate` on `main` and confirm the branch is created and `staging` is updated.
- [ ] Wait for nightly `update-dependencies` run (or dispatch) and confirm PRs open successfully.
- [ ] On next `rc-*` push, verify `release-please` runs end-to-end.
- [ ] Verify `publish-all` release-asset upload on next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated release and deployment workflow configurations with standardized permission and authentication settings across multiple processes. Changes applied to release publishing, release candidate creation, dependency management, and manifest update workflows. All automated operations now use consistent authentication methods and explicitly configured permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->