### PR TITLE
ci: use GH_DXOS_BOT_PAT to allow downstream workflow triggers

### DIFF
--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -127,5 +127,5 @@ jobs:
         uses: fnkr/github-action-ghr@v1
         env:
           GHR_PATH: artifacts/
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_DXOS_BOT_PAT }}
         if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: peterjgrainger/action-create-branch@v2.2.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_DXOS_BOT_PAT }}
         with:
           branch: ${{ steps.branch.outputs.prefix }}-${{ steps.time.outputs.today }}-${{ steps.git.outputs.sha }}
 
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Checkout all branches
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_DXOS_BOT_PAT }}
 
       - name: Push to Staging
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
         id: release
         uses: google-github-actions/release-please-action@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_DXOS_BOT_PAT }}
           default-branch: ${{ github.ref_name }}
           release-type: node
           command: github-release
@@ -26,7 +26,7 @@ jobs:
       - name: Version Bump
         uses: google-github-actions/release-please-action@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_DXOS_BOT_PAT }}
           default-branch: ${{ github.ref_name }}
           release-type: node
           command: manifest-pr
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Checkout all branches
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_DXOS_BOT_PAT }}
 
       - name: Setup Git
         run: |
@@ -106,5 +106,5 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: dawidd6/action-delete-branch@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_DXOS_BOT_PAT }}
           branches: ${{ github.ref_name }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -49,14 +49,14 @@ jobs:
       image: ghcr.io/dxos/gh-actions:24.11.1
       credentials:
         username: dxos-bot
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GH_DXOS_BOT_PAT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
           lfs: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_DXOS_BOT_PAT }}
 
       - name: Extract branch
         id: extract_branch
@@ -79,4 +79,4 @@ jobs:
           delete-branch: true
           title: 'chore: Update ${{ matrix.packages.name }} dependencies'
           draft: false
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_DXOS_BOT_PAT }}


### PR DESCRIPTION
## Summary
- Replaces `GITHUB_TOKEN` with `GH_DXOS_BOT_PAT` in `release-candidate`, `release-please`, `publish-all`, and `update-dependencies` workflows
- `GITHUB_TOKEN` pushes do not trigger downstream GitHub Actions runs; a PAT is required for the `release-candidate` branch push to trigger `release-please`
- Follows up on #11101 which replaced `CREATE_PR_TOKEN` with `GITHUB_TOKEN`

## Test Plan
- [ ] Run `release-candidate` workflow from `main` and verify the RC branch push triggers `release-please`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow authentication credentials across multiple automated deployment and dependency management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->