### PR TITLE
fix(plugin-assistant): prevent duplicate <reasoning> tag during streaming

### DIFF
--- a/packages/plugins/plugin-assistant/src/components/ChatThread/ChatThread.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/ChatThread.tsx
@@ -2,7 +2,7 @@
 // Copyright 2025 DXOS.org
 //
 
-import React, { type CSSProperties, forwardRef, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { PublicKey } from '@dxos/keys';
 import { type Identity } from '@dxos/react-client/halo';

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/ChatThread.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/ChatThread.tsx
@@ -78,12 +78,8 @@ export const ChatThread = forwardRef<MarkdownStreamController | null, ChatThread
     return (
       <div
         role='none'
+        data-hue={userHue}
         className={mx('flex h-full w-full justify-center overflow-hidden', classNames)}
-        style={
-          {
-            '--user-fill': `var(--color-${userHue}-fill)`,
-          } as CSSProperties
-        }
       >
         <MarkdownStream
           registry={componentRegistry}

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/MarkdownStream.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/MarkdownStream.stories.tsx
@@ -22,6 +22,7 @@ import { keyToFallback } from '@dxos/util';
 
 import { translations } from '../../translations';
 import { componentRegistry } from './registry';
+import REASONING from './testing/reasoning.md?raw';
 import THINKING from './testing/thinking.md?raw';
 import THREAD_1 from './testing/thread-1.md?raw';
 import THREAD_WIDGETS from './testing/thread-widgets.md?raw';
@@ -238,6 +239,24 @@ export const Thinking: Story = {
     seedToolWidgetsFromMarkdown: true,
     options: {
       autoScroll: true,
+    },
+  },
+};
+
+/**
+ * Streams a reasoning block whose body contains a numbered list — exercises the streaming-tail XML
+ * scan as `<reasoning>` opens, accumulates list-marker lines like `"1. "`, and finally closes. Use
+ * this to visually verify that the reasoning widget renders cleanly without duplicate opening tags
+ * (regression from the per-line bullet stripper that used to collapse `"1. "` to empty mid-stream).
+ */
+export const Reasoning: Story = {
+  args: {
+    registry: componentRegistry,
+    content: REASONING,
+    options: {
+      autoScroll: true,
+      wire: true,
+      cursor: true,
     },
   },
 };

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/MarkdownStream.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/MarkdownStream.stories.tsx
@@ -3,7 +3,7 @@
 //
 
 import { type Meta, type StoryObj } from '@storybook/react-vite';
-import React, { useCallback, useEffect, useState, type CSSProperties } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import '@dxos/lit-ui';
 import { PublicKey } from '@dxos/keys';
@@ -145,7 +145,7 @@ const DefaultStory = ({
   }, [controller]);
 
   return (
-    <Panel.Root style={{ '--user-fill': `var(--color-${userHue}-fill)` } as CSSProperties}>
+    <Panel.Root data-hue={userHue}>
       <Panel.Toolbar asChild>
         <Toolbar.Root>
           <Toolbar.IconButton
@@ -244,6 +244,23 @@ export const Thinking: Story = {
 };
 
 /**
+ * Splits a fixture at the first `</prompt>` so the prompt can be pre-loaded as initialContent
+ * (matching production: user prompts are submitted whole and never streamed) while the assistant
+ * body is streamed. Keeps the streaming-tail XML scan focused on the tags it is meant for
+ * (`<reasoning>`, `<status>`) instead of accumulating widgets for an unclosed `<prompt>`.
+ */
+const splitPromptAndBody = (markdown: string): { prompt: string; body: string } => {
+  const closing = '</prompt>';
+  const idx = markdown.indexOf(closing);
+  if (idx === -1) {
+    return { prompt: '', body: markdown };
+  }
+  return { prompt: markdown.slice(0, idx + closing.length), body: markdown.slice(idx + closing.length) };
+};
+
+const REASONING_PARTS = splitPromptAndBody(REASONING);
+
+/**
  * Streams a reasoning block whose body contains a numbered list — exercises the streaming-tail XML
  * scan as `<reasoning>` opens, accumulates list-marker lines like `"1. "`, and finally closes. Use
  * this to visually verify that the reasoning widget renders cleanly without duplicate opening tags
@@ -252,7 +269,8 @@ export const Thinking: Story = {
 export const Reasoning: Story = {
   args: {
     registry: componentRegistry,
-    content: REASONING,
+    initialContent: REASONING_PARTS.prompt,
+    content: REASONING_PARTS.body,
     options: {
       autoScroll: true,
       wire: true,

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/registry.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/registry.tsx
@@ -231,18 +231,13 @@ const blockToMarkdownImpl = (context: MessageThreadContext, message: Message.Mes
 const escapeXmlTextContent = (raw: string): string =>
   raw.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
-/**
- * Strip actual list-marker prefixes without removing meaningful leading content.
- */
-const stripBulletLikeLinePrefixes = (raw: string): string =>
-  raw
-    .split(/\r?\n/)
-    .map((line) => line.replace(/^\s*(?:[-*+•]|\d+[.)]\s)/, ''))
-    .join('\n');
-
 const renderXMLBlock = (tag: string, opts: { content?: string; pending?: boolean; attributes?: string }) => {
-  // Replace paragraph breaks so that markdown parser does not split the content into multiple paragraphs.
-  const content = escapeXmlTextContent(stripBulletLikeLinePrefixes((opts.content ?? '').replace(/\n\n/g, ' ').trim()));
+  // Replace paragraph breaks so that the markdown parser does not split the content into multiple paragraphs.
+  // NOTE: do not strip leading list-marker prefixes (`-`, `*`, `1. `, ...) per line — the streaming
+  // tag's range is replaced atomically by the XML widget so the inner markdown is never user-visible,
+  // and stripping can collapse a line to empty mid-stream (e.g. when only `1. ` has arrived), breaking
+  // the prefix-extension contract that `MessageSyncer` relies on for incremental appends.
+  const content = escapeXmlTextContent((opts.content ?? '').replace(/\n\n/g, ' ').trim());
 
   if (opts.pending) {
     return `<${tag}${opts.attributes ? ` ${opts.attributes}` : ''}>${content}`;

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/sync.test.ts
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/sync.test.ts
@@ -183,7 +183,9 @@ describe('reducers', () => {
       syncer.append(messages);
 
       const openTagCount = (doc.content.match(/<reasoning>/g) ?? []).length;
+      const closeTagCount = (doc.content.match(/<\/reasoning>/g) ?? []).length;
       expect(openTagCount).toBe(1);
+      expect(closeTagCount).toBe(1);
     }),
   );
 });

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/sync.test.ts
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/sync.test.ts
@@ -10,12 +10,12 @@ import * as Effect from 'effect/Effect';
 
 import { Obj } from '@dxos/echo';
 import { type Mutable } from '@dxos/echo/internal';
-import { type ContentBlock } from '@dxos/types';
+import { type ContentBlock, type Message } from '@dxos/types';
 
 import { createMessage } from '#testing';
 
 import { blockToMarkdown } from './registry';
-import { MessageSyncer, type TextModel } from './sync';
+import { type BlockRenderer, MessageSyncer, type MessageThreadContext, type TextModel } from './sync';
 
 class TestDocument implements TextModel {
   private readonly _view = new EditorView({ extensions: [] });
@@ -94,6 +94,96 @@ describe('reducers', () => {
       expect(doc.content).toEqual(
         ['<prompt>Hello</prompt>', 'Hi there! How are you?', 'How can I help?', ''].join('\n'),
       );
+    }),
+  );
+
+  // Regression: streaming reasoning text that passes through a bare list-marker state
+  // (e.g. `"…\n1. "`) used to make `stripBulletLikeLinePrefixes` collapse the line to empty,
+  // breaking the prefix-diff invariant in `MessageSyncer` and producing a duplicate `<reasoning>`
+  // opening tag in the document.
+  it.effect(
+    'streaming reasoning with list-marker transitions does not duplicate opening tag',
+    Effect.fn(function* ({ expect }) {
+      const doc = new TestDocument();
+      const syncer = new MessageSyncer(doc, blockToMarkdown);
+
+      const setReasoning = (message: Message.Message, text: string, pending: boolean) => {
+        Obj.change(message, (message) => {
+          const block = message.blocks[0] as Mutable<ContentBlock.Reasoning>;
+          block.reasoningText = text;
+          block.pending = pending;
+        });
+      };
+
+      const messages = [createMessage('assistant', [{ _tag: 'reasoning', reasoningText: 'abc\n1', pending: true }])];
+
+      // Tick 1: `"abc\n1"` — `\d+[.)]\s` regex does not match (no dot/space yet).
+      syncer.append(messages);
+
+      // Tick 2: `"abc\n1."` — still no match (no trailing whitespace).
+      setReasoning(messages[0], 'abc\n1.', true);
+      syncer.append(messages);
+
+      // Tick 3: `"abc\n1. "` — line `"1. "` matches and is stripped to empty.
+      setReasoning(messages[0], 'abc\n1. ', true);
+      syncer.append(messages);
+
+      // Tick 4: `"abc\n1. foo"` — list item with content.
+      setReasoning(messages[0], 'abc\n1. foo', true);
+      syncer.append(messages);
+
+      // Tick 5: finalize.
+      setReasoning(messages[0], 'abc\n1. foo', false);
+      syncer.append(messages);
+
+      const openTagCount = (doc.content.match(/<reasoning>/g) ?? []).length;
+      const closeTagCount = (doc.content.match(/<\/reasoning>/g) ?? []).length;
+      expect(openTagCount).toBe(1);
+      expect(closeTagCount).toBe(1);
+    }),
+  );
+
+  // Direct test of `MessageSyncer`'s tolerance for non-monotonic renderer output —
+  // any renderer that produces a shorter string for the same streaming block (e.g. due
+  // to whitespace normalisation or future transforms) must not produce duplicate output.
+  it.effect(
+    'non-monotonic renderer output does not duplicate previously-emitted content',
+    Effect.fn(function* ({ expect }) {
+      const doc = new TestDocument();
+
+      const renderer: BlockRenderer = (_ctx: MessageThreadContext, _msg: Message.Message, block: ContentBlock.Any) => {
+        if (block._tag !== 'reasoning') {
+          return undefined;
+        }
+        const text = block.reasoningText ?? '';
+        // Simulate a non-monotonic transform: collapse a line that is a sole digit+dot+space.
+        const normalised = text
+          .split(/\r?\n/)
+          .map((line) => line.replace(/^\s*\d+[.)]\s$/, ''))
+          .join('\n')
+          .trim();
+        return block.pending ? `<reasoning>${normalised}` : `<reasoning>${normalised}</reasoning>\n`;
+      };
+
+      const syncer = new MessageSyncer(doc, renderer);
+
+      const messages = [createMessage('assistant', [{ _tag: 'reasoning', reasoningText: 'abc\n1.', pending: true }])];
+
+      syncer.append(messages);
+      Obj.change(messages[0], (obj) => {
+        const block = obj.blocks[0] as Mutable<ContentBlock.Reasoning>;
+        block.reasoningText = 'abc\n1. ';
+      });
+      syncer.append(messages);
+      Obj.change(messages[0], (obj) => {
+        const block = obj.blocks[0] as Mutable<ContentBlock.Reasoning>;
+        block.reasoningText = 'abc\n1. tail';
+        block.pending = false;
+      });
+      syncer.append(messages);
+
+      const openTagCount = (doc.content.match(/<reasoning>/g) ?? []).length;
+      expect(openTagCount).toBe(1);
     }),
   );
 });

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/sync.ts
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/sync.ts
@@ -49,6 +49,13 @@ export class MessageSyncer {
   private _currentMessageIndex = 0;
   private _currentBlockIndex = 0;
   private _currentBlockContent?: string;
+  /**
+   * Set by `processBlocks` when a streaming block's renderer output stops being a
+   * prefix-extension of the previously-emitted content (e.g. an upstream normalisation collapses
+   * a line). The incremental append path can no longer produce a correct delta, so the caller
+   * resets the syncer and rebuilds the whole document via the buffer/`setContent` path.
+   */
+  private _needsRebuild = false;
 
   private readonly _context: MessageThreadContext;
 
@@ -70,6 +77,7 @@ export class MessageSyncer {
     this._currentMessageIndex = 0;
     this._currentBlockIndex = 0;
     this._currentBlockContent = undefined;
+    this._needsRebuild = false;
     void this._document.setContent('');
   }
 
@@ -77,12 +85,6 @@ export class MessageSyncer {
    * Syncs messages with the editor.
    */
   append(messages: Message.Message[], flush = false): boolean {
-    // TODO(dmaretskyi): MarkdownStream currently does not support streaming XML tags, so we need to remove pending non-text blocks.
-    // messages = messages.map((message) => ({
-    //   ...message,
-    //   blocks: message.blocks.filter((block) => !block.pending || block._tag === 'text'),
-    // }));
-
     // Check if new set of messages.
     if (this._initialMessageId !== messages[0]?.id) {
       this.reset();
@@ -90,43 +92,54 @@ export class MessageSyncer {
     }
 
     if (this._document.length === 0 && flush) {
-      const buffer: string[] = [];
-      this.processBlocks(messages, (content) => buffer.push(content));
-      const content = buffer.join('');
-      // `setContent` dispatches `xmlTagResetEffect`, which clears widget props accumulated during
-      // `processBlocks`; re-apply tool state after the document is replaced.
-      const epoch = this.#syncEpoch;
-      void this._document
-        .setContent(content)
-        .then(() => {
-          if (epoch !== this.#syncEpoch) {
-            return;
-          }
-          rehydrateToolWidgetsFromMessages(this._context, messages);
-        })
-        .catch((error) => {
-          log.warn('failed to replace thread content before widget rehydration', { error });
-        });
+      return this.#fullRebuild(messages);
+    }
 
-      return true;
-    } else {
-      this.processBlocks(messages, (content) => {
-        void this._document.append(content);
+    this._needsRebuild = false;
+    this.processBlocks(messages, (content) => {
+      void this._document.append(content);
+    });
+
+    if (this._needsRebuild) {
+      // A streaming block's render diverged from the previously-emitted content; the incremental
+      // append path cannot recover (it would duplicate the opening of the block in the document).
+      // Reset and rebuild from scratch via the `setContent` path so the document matches `messages`.
+      log.warn('non-monotonic streaming render detected; rebuilding chat thread document');
+      this.reset();
+      this._initialMessageId = messages[0]?.id;
+      return this.#fullRebuild(messages);
+    }
+
+    return false;
+  }
+
+  /**
+   * Render every block into a fresh buffer and hand the result to `setContent`, then rehydrate
+   * tool widget state once the dispatch settles.
+   */
+  #fullRebuild(messages: Message.Message[]): boolean {
+    const buffer: string[] = [];
+    this.processBlocks(messages, (content) => buffer.push(content));
+    const content = buffer.join('');
+    // `setContent` dispatches `xmlTagResetEffect`, which clears widget props accumulated during
+    // `processBlocks`; re-apply tool state after the document is replaced.
+    const epoch = this.#syncEpoch;
+    void this._document
+      .setContent(content)
+      .then(() => {
+        if (epoch !== this.#syncEpoch) {
+          return;
+        }
+        rehydrateToolWidgetsFromMessages(this._context, messages);
+      })
+      .catch((error) => {
+        log.warn('failed to replace thread content before widget rehydration', { error });
       });
 
-      return false;
-    }
+    return true;
   }
 
   private processBlocks(messages: Message.Message[], append: (content: string) => void) {
-    // console.log('sync', {
-    //   doc: this._model.view?.state.doc.length,
-    //   messages: messages.map((message) => message.blocks.length),
-    //   currentMessageIndex: this._currentMessageIndex,
-    //   currentBlockIndex: this._currentBlockIndex,
-    //   currentBlockContent: this._currentBlockContent,
-    // });
-
     let i = this._currentMessageIndex;
     for (const message of messages.slice(this._currentMessageIndex)) {
       if (i > this._currentMessageIndex) {
@@ -139,16 +152,20 @@ export class MessageSyncer {
         this._currentBlockIndex = j;
         const currentBlockContent = this._renderer(this._context, message, block);
         if (currentBlockContent) {
-          let content: string = '';
-          if (this._currentBlockContent && currentBlockContent.startsWith(this._currentBlockContent)) {
-            content = currentBlockContent.slice(this._currentBlockContent.length);
-          } else {
-            content = currentBlockContent;
+          if (this._currentBlockContent !== undefined && !currentBlockContent.startsWith(this._currentBlockContent)) {
+            // The renderer's output for a streaming block must be a prefix-extension of the
+            // previously-emitted content; otherwise the incremental append path cannot recover.
+            // Signal the caller to fall back to a full rebuild and bail out.
+            this._needsRebuild = true;
+            return;
           }
 
-          // console.log('append', { message: i, block: j, content });
+          const delta =
+            this._currentBlockContent !== undefined
+              ? currentBlockContent.slice(this._currentBlockContent.length)
+              : currentBlockContent;
           this._currentBlockContent = currentBlockContent;
-          append(content);
+          append(delta);
         }
 
         if (block.pending) {

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/sync.ts
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/sync.ts
@@ -72,13 +72,23 @@ export class MessageSyncer {
 
   reset() {
     log('reset');
+    this.#resetState();
+    void this._document.setContent('');
+  }
+
+  /**
+   * Clears in-memory sync cursors without touching the document. Used by the internal rebuild
+   * path (which immediately re-dispatches content via `#fullRebuild`) and by `reset()` (which
+   * also clears the document). Kept private so callers cannot forget to match a state reset
+   * with a document update.
+   */
+  #resetState() {
     this.#syncEpoch++;
     this._initialMessageId = undefined;
     this._currentMessageIndex = 0;
     this._currentBlockIndex = 0;
     this._currentBlockContent = undefined;
     this._needsRebuild = false;
-    void this._document.setContent('');
   }
 
   /**
@@ -104,8 +114,10 @@ export class MessageSyncer {
       // A streaming block's render diverged from the previously-emitted content; the incremental
       // append path cannot recover (it would duplicate the opening of the block in the document).
       // Reset and rebuild from scratch via the `setContent` path so the document matches `messages`.
+      // Use `#resetState` (not `reset()`) to avoid dispatching an extra `setContent('')` that
+      // `#fullRebuild` would immediately overwrite.
       log.warn('non-monotonic streaming render detected; rebuilding chat thread document');
-      this.reset();
+      this.#resetState();
       this._initialMessageId = messages[0]?.id;
       return this.#fullRebuild(messages);
     }
@@ -133,7 +145,13 @@ export class MessageSyncer {
         rehydrateToolWidgetsFromMessages(this._context, messages);
       })
       .catch((error) => {
-        log.warn('failed to replace thread content before widget rehydration', { error });
+        // `processBlocks` advanced the sync cursors for `messages`; if the document dispatch
+        // rejected, those cursors no longer match the document state, so any subsequent
+        // incremental append would emit incorrect deltas. Clear cursor state (while leaving the
+        // document as-is for the controller to recover) and force the next `append` to start
+        // from scratch.
+        log.warn('failed to replace thread content; resetting syncer state for next append', { error });
+        this.#resetState();
       });
 
     return true;

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/testing/reasoning.md
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/testing/reasoning.md
@@ -1,0 +1,25 @@
+<prompt>How should I structure a CLI tool with subcommands?</prompt>
+
+<reasoning>
+The user is asking about CLI subcommand structure. Let me think through what they likely care about:
+
+1. Discoverability — every subcommand needs help text and a flat top-level listing.
+2. Composability — subcommands should be invokable individually for scripting.
+3. Shared concerns — auth, config, logging should not be duplicated per command.
+
+A few patterns worth considering:
+
+- A single binary that dispatches to subcommand handlers (like `git`, `kubectl`).
+- A plugin model where subcommands live in separate binaries on the PATH (like `git-foo`).
+- A library that each subcommand wraps as a thin executable.
+
+The plugin model wins for very large surfaces but adds packaging cost. For a tool with under ~30 subcommands the dispatcher pattern stays clearer.
+</reasoning>
+
+For a CLI with a moderate set of subcommands, the dispatcher pattern is usually the right default:
+
+1. One binary, one entry point.
+2. Subcommands registered as handlers off a shared root.
+3. Cross-cutting concerns (auth, config, logging) wired in at the root and inherited.
+
+If you grow past ~30 subcommands or want third-party extensions, switch to a plugin model where binaries named `<tool>-<subcommand>` are discovered on the `PATH`.

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/PromptWidget.ts
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/PromptWidget.ts
@@ -19,7 +19,8 @@ export class PromptWidget extends WidgetType {
   }
 
   /**
-   * NOTE: Container must set var based on user's identity.
+   * NOTE: An ancestor element must set `data-hue` so `.dx-panel` resolves to the user's hue tokens
+   * (see `packages/ui/ui-theme/src/css/components/panel.css`).
    */
   override toDOM() {
     return Domino.of('div')
@@ -27,5 +28,3 @@ export class PromptWidget extends WidgetType {
       .append(Domino.of('div').classNames('dx-panel px-3 py-1.5 rounded-sm').text(this.text)).root;
   }
 }
-
-// `var(--color-${userHue}-fill)`

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/PromptWidget.ts
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/PromptWidget.ts
@@ -22,7 +22,10 @@ export class PromptWidget extends WidgetType {
    * NOTE: Container must set var based on user's identity.
    */
   override toDOM() {
-    const inner = Domino.of('div').classNames('px-3 py-1.5 bg-(--user-fill) rounded-xs').text(this.text);
-    return Domino.of('div').classNames('flex justify-end my-2').append(inner).root;
+    return Domino.of('div')
+      .classNames('flex justify-end my-2')
+      .append(Domino.of('div').classNames('dx-panel px-3 py-1.5 rounded-sm').text(this.text)).root;
   }
 }
+
+// `var(--color-${userHue}-fill)`

--- a/packages/ui/react-ui-components/src/components/MarkdownStream/MarkdownStream.stories.tsx
+++ b/packages/ui/react-ui-components/src/components/MarkdownStream/MarkdownStream.stories.tsx
@@ -4,7 +4,7 @@
 
 import { WidgetType } from '@codemirror/view';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
-import React, { useCallback, useEffect, useState, type CSSProperties } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import '@dxos/lit-ui';
 import { PublicKey } from '@dxos/keys';
@@ -129,7 +129,7 @@ const DefaultStory = ({
   }, [controller]);
 
   return (
-    <Panel.Root style={{ '--user-fill': `var(--color-${userHue}-fill)` } as CSSProperties}>
+    <Panel.Root data-hue={userHue}>
       <Panel.Toolbar asChild>
         <Toolbar.Root>
           <Toolbar.IconButton

--- a/packages/ui/ui-theme/src/css/components/panel.css
+++ b/packages/ui/ui-theme/src/css/components/panel.css
@@ -110,7 +110,7 @@
     @apply bg-warning-surface text-warning-surface-text border-warning-border;
   }
 
-  [data-hue='error'],
+  [data-hue='error'] .dx-panel,
   .dx-panel--error {
     @apply bg-error-surface text-error-surface-text border-error-border;
   }

--- a/packages/ui/ui-theme/src/css/components/panel.css
+++ b/packages/ui/ui-theme/src/css/components/panel.css
@@ -5,112 +5,112 @@
  */
 
 @layer dx-components {
-  .dx-panel[data-hue='neutral'],
+  [data-hue='neutral'] .dx-panel,
   .dx-panel--neutral {
     @apply bg-neutral-surface text-neutral-surface-text border-neutral-border;
   }
 
-  .dx-panel[data-hue='red'],
+  [data-hue='red'] .dx-panel,
   .dx-panel--red {
     @apply bg-red-surface text-red-surface-text border-red-border;
   }
 
-  .dx-panel[data-hue='orange'],
+  [data-hue='orange'] .dx-panel,
   .dx-panel--orange {
     @apply bg-orange-surface text-orange-surface-text border-orange-border;
   }
 
-  .dx-panel[data-hue='amber'],
+  [data-hue='amber'] .dx-panel,
   .dx-panel--amber {
     @apply bg-amber-surface text-amber-surface-text border-amber-border;
   }
 
-  .dx-panel[data-hue='yellow'],
+  [data-hue='yellow'] .dx-panel,
   .dx-panel--yellow {
     @apply bg-yellow-surface text-yellow-surface-text border-yellow-border;
   }
 
-  .dx-panel[data-hue='lime'],
+  [data-hue='lime'] .dx-panel,
   .dx-panel--lime {
     @apply bg-lime-surface text-lime-surface-text border-lime-border;
   }
 
-  .dx-panel[data-hue='green'],
+  [data-hue='green'] .dx-panel,
   .dx-panel--green {
     @apply bg-green-surface text-green-surface-text border-green-border;
   }
 
-  .dx-panel[data-hue='emerald'],
+  [data-hue='emerald'] .dx-panel,
   .dx-panel--emerald {
     @apply bg-emerald-surface text-emerald-surface-text border-emerald-border;
   }
 
-  .dx-panel[data-hue='teal'],
+  [data-hue='teal'] .dx-panel,
   .dx-panel--teal {
     @apply bg-teal-surface text-teal-surface-text border-teal-border;
   }
 
-  .dx-panel[data-hue='cyan'],
+  [data-hue='cyan'] .dx-panel,
   .dx-panel--cyan {
     @apply bg-cyan-surface text-cyan-surface-text border-cyan-border;
   }
 
-  .dx-panel[data-hue='sky'],
+  [data-hue='sky'] .dx-panel,
   .dx-panel--sky {
     @apply bg-sky-surface text-sky-surface-text border-sky-border;
   }
 
-  .dx-panel[data-hue='blue'],
+  [data-hue='blue'] .dx-panel,
   .dx-panel--blue {
     @apply bg-blue-surface text-blue-surface-text border-blue-border;
   }
 
-  .dx-panel[data-hue='indigo'],
+  [data-hue='indigo'] .dx-panel,
   .dx-panel--indigo {
     @apply bg-indigo-surface text-indigo-surface-text border-indigo-border;
   }
 
-  .dx-panel[data-hue='violet'],
+  [data-hue='violet'] .dx-panel,
   .dx-panel--violet {
     @apply bg-violet-surface text-violet-surface-text border-violet-border;
   }
 
-  .dx-panel[data-hue='purple'],
+  [data-hue='purple'] .dx-panel,
   .dx-panel--purple {
     @apply bg-purple-surface text-purple-surface-text border-purple-border;
   }
 
-  .dx-panel[data-hue='fuchsia'],
+  [data-hue='fuchsia'] .dx-panel,
   .dx-panel--fuchsia {
     @apply bg-fuchsia-surface text-fuchsia-surface-text border-fuchsia-border;
   }
 
-  .dx-panel[data-hue='pink'],
+  [data-hue='pink'] .dx-panel,
   .dx-panel--pink {
     @apply bg-pink-surface text-pink-surface-text border-pink-border;
   }
 
-  .dx-panel[data-hue='rose'],
+  [data-hue='rose'] .dx-panel,
   .dx-panel--rose {
     @apply bg-rose-surface text-rose-surface-text border-rose-border;
   }
 
-  .dx-panel[data-hue='info'],
+  [data-hue='info'] .dx-panel,
   .dx-panel--info {
     @apply bg-info-surface text-info-surface-text border-info-border;
   }
 
-  .dx-panel[data-hue='success'],
+  [data-hue='success'] .dx-panel,
   .dx-panel--success {
     @apply bg-success-surface text-success-surface-text border-success-border;
   }
 
-  .dx-panel[data-hue='warning'],
+  [data-hue='warning'] .dx-panel,
   .dx-panel--warning {
     @apply bg-warning-surface text-warning-surface-text border-warning-border;
   }
 
-  .dx-panel[data-hue='error'],
+  [data-hue='error'],
   .dx-panel--error {
     @apply bg-error-surface text-error-surface-text border-error-border;
   }


### PR DESCRIPTION
## Summary

- The bullet/number-prefix stripper in `renderXMLBlock` collapsed list-marker-only lines (e.g. `"1. "`) to empty mid-stream, breaking the prefix-extension contract that `MessageSyncer.processBlocks` relies on. The fallback branch then re-appended the full render — including the opening `<reasoning>` — producing `<reasoning>X<reasoning>X more</reasoning>` in the chat thread.
- Removed the strip (the streaming XML range is replaced atomically by the reasoning widget, so list-marker parsing inside the content has no visual effect).
- Hardened `MessageSyncer` so any future non-monotonic renderer can no longer corrupt the document: on prefix mismatch it now logs a warning and triggers a clean rebuild via `setContent` (preserving tool-widget rehydration), instead of duplicating output.

## Why a two-part fix

Removing the strip alone fixes the user-visible bug, but the prefix-extension contract is implicit and easy to re-break with future renderer transforms. The `MessageSyncer` defense makes the contract violation observable (warning log) and self-correcting rather than silently corrupting the document.

## Test plan

- [x] New unit test drives the production `blockToMarkdown` through a streaming `"abc\n1"` → `"abc\n1."` → `"abc\n1. "` → `"abc\n1. foo"` → finalize sequence and asserts exactly one `<reasoning>` opening and one `</reasoning>` closing.
- [x] New unit test feeds a synthetic non-monotonic renderer to verify the syncer's rebuild-on-mismatch path produces a single opening tag.
- [x] `moon run plugin-assistant:test` — 29 passed.
- [x] `moon run plugin-assistant:build` — clean.
- [x] `moon run plugin-assistant:lint` — clean.
- [x] `pnpm format` — applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamed markdown now preserves list-marker prefixes so numbered/bulleted lists render correctly.
  * Sync avoids duplicating previously emitted reasoning content when streamed output changes non-monotonically; it triggers a safe full rebuild when needed.

* **New Features**
  * Storybook "Reasoning" example demonstrating streamed assistant output with lists and auto-scroll.

* **Tests**
  * Added regression tests covering streaming, non-monotonic updates, and sync behavior.

* **Style**
  * Theming switched to a data-hue attribute; panel selectors updated for consistent styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->