### PR TITLE
ci: align setup action moon-version with .prototools (2.2.3)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,7 +15,7 @@ runs:
     - uses: moonrepo/setup-toolchain@v0
       with:
         # IMPORTANT: Keep in-sync with .prototools
-        moon-version: '2.1.4'
+        moon-version: '2.2.3'
 
     - name: Log out debug info
       run: |


### PR DESCRIPTION
## Summary

- Updates `.github/actions/setup/action.yml` from `moon-version: '2.1.4'` to `'2.2.3'` so it matches the rest of the moon version pins in the repo (`.prototools`, the `@moonrepo/cli` catalog entry, and `publish-tauri.yaml`).

## Why

The composite setup action — used by `check.yml`, `pkg-pr-new.yml`, `publish-all.yml`, `preview.yml`, and others — was pinned to moon 2.1.4 while local development and tauri publishing run 2.2.3. CI therefore exercised a different moon than developers do.

## Test plan

- [ ] Verify the **Check** workflow passes after this change picks up 2.2.3 in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
