### PR TITLE
ci: fix composer-app preview URL host

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -57,12 +57,12 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           wrangler pages deploy preview/packages/apps/composer-app/out/composer \
-            --project-name composer \
+            --project-name composer-app \
             --branch "${{ steps.meta.outputs.branch_alias }}" \
             | tee deploy.log
-          URL=$(grep -Eo 'https://[a-z0-9-]+\.composer\.pages\.dev' deploy.log | head -n1)
+          URL=$(grep -Eo 'https://[a-z0-9-]+\.composer-app\.pages\.dev' deploy.log | head -n1)
           echo "url=$URL" >> $GITHUB_OUTPUT
-          echo "alias=https://${{ steps.meta.outputs.branch_alias }}.composer.pages.dev" >> $GITHUB_OUTPUT
+          echo "alias=https://${{ steps.meta.outputs.branch_alias }}.composer-app.pages.dev" >> $GITHUB_OUTPUT
 
       - name: Comment preview URL on PR
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
## Summary

The Cloudflare Pages project is named `composer-app`, so deployments land on `composer-app.pages.dev` (see `packages/apps/composer-app/ENV.md`). The preview-deploy workflow was using `composer` (without `-app`), which caused two visible bugs in the sticky preview comment:

- **Branch alias** linked to `https://pr-NNNN.composer.pages.dev`, which doesn't exist.
- **Deployment** was blank because the regex matched `composer\.pages\.dev`, so it never captured the real `composer-app.pages.dev` URL printed by `wrangler`.

This change updates `.github/workflows/preview-deploy.yml` so the `--project-name`, the URL grep, and the alias output all use `composer-app`.

## Test plan

- [ ] Re-run the Preview Build + Preview Deploy workflows on a PR and confirm the sticky comment links to a working `https://pr-NNNN.composer-app.pages.dev` and that the Deployment URL is populated.

https://claude.ai/code/session_01QLKsgsTJF2NkrFJRnvabMv

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLKsgsTJF2NkrFJRnvabMv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated preview deployment infrastructure to standardize project branding and ensure consistent deployment URLs throughout the pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->