### PR TITLE
feat(app-framework): add author field to plugin metadata

### DIFF
--- a/packages/core/protocols/src/edge/registry.ts
+++ b/packages/core/protocols/src/edge/registry.ts
@@ -15,6 +15,7 @@ export const PluginMetaSchema = Schema.Struct({
   id: Schema.String.pipe(Schema.nonEmptyString()),
   name: Schema.String.pipe(Schema.nonEmptyString()),
   description: Schema.optional(Schema.String),
+  author: Schema.optional(Schema.String),
   homePage: Schema.optional(Schema.String),
   source: Schema.optional(Schema.String),
   screenshots: Schema.optional(Schema.Array(Schema.String)),

--- a/packages/sdk/app-framework/src/core/plugin.ts
+++ b/packages/sdk/app-framework/src/core/plugin.ts
@@ -167,6 +167,11 @@ export type Meta = {
   description?: string;
 
   /**
+   * Name of the author or organization that created the plugin.
+   */
+  author?: string;
+
+  /**
    * URL of home page.
    */
   homePage?: string;


### PR DESCRIPTION
## Summary

- Adds optional `author?: string` field to `Plugin.Meta` type in `@dxos/app-framework`
- Adds corresponding `author: Schema.optional(Schema.String)` to `PluginMetaSchema` in `@dxos/protocols`

The field identifies the name of the author or organization that created the plugin. It is optional and consistent with the existing metadata field conventions.

## Test plan

- [ ] TypeScript types compile correctly in dependent packages
- [ ] Existing plugin definitions continue to work unchanged (field is optional)
- [ ] New plugins can set `author` in their `meta.ts`

https://claude.ai/code/session_013jmH5YNhwmj4dit6qfdFhV

---
_Generated by [Claude Code](https://claude.ai/code/session_013jmH5YNhwmj4dit6qfdFhV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin developers can now include an author field in their plugin metadata. This optional field allows developers and organizations to be clearly identified as creators of each plugin. Author information will be displayed alongside other plugin metadata including name, description, and version details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->