### PR TITLE
chore: remove typesVersions from all package.json files

### DIFF
--- a/packages/common/async/package.json
+++ b/packages/common/async/package.json
@@ -23,9 +23,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/codec-protobuf/package.json
+++ b/packages/common/codec-protobuf/package.json
@@ -30,13 +30,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "stream": [
-        "dist/types/src/stream.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/context/package.json
+++ b/packages/common/context/package.json
@@ -23,9 +23,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/crypto/package.json
+++ b/packages/common/crypto/package.json
@@ -28,9 +28,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src",

--- a/packages/common/debug/package.json
+++ b/packages/common/debug/package.json
@@ -23,9 +23,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/display-name/package.json
+++ b/packages/common/display-name/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/effect-atom-solid/package.json
+++ b/packages/common/effect-atom-solid/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/effect/package.json
+++ b/packages/common/effect/package.json
@@ -26,13 +26,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "./dist/types/src/testing.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/errors/package.json
+++ b/packages/common/errors/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/feed-store/package.json
+++ b/packages/common/feed-store/package.json
@@ -27,13 +27,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "testing.d.ts",
     "testing.js",

--- a/packages/common/graph/package.json
+++ b/packages/common/graph/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/hypercore/package.json
+++ b/packages/common/hypercore/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/invariant/package.json
+++ b/packages/common/invariant/package.json
@@ -23,9 +23,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/keyboard/package.json
+++ b/packages/common/keyboard/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/keys/package.json
+++ b/packages/common/keys/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/kv-store/package.json
+++ b/packages/common/kv-store/package.json
@@ -27,13 +27,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/lock-file/package.json
+++ b/packages/common/lock-file/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/log/package.json
+++ b/packages/common/log/package.json
@@ -43,9 +43,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/merkle-search-tree/package.json
+++ b/packages/common/merkle-search-tree/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/node-std/package.json
+++ b/packages/common/node-std/package.json
@@ -66,13 +66,6 @@
       "node": "./src/node/util.js"
     }
   },
-  "typesVersions": {
-    "*": {
-      "_/config": [
-        "types/_/config.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src/node",

--- a/packages/common/phoenix/package.json
+++ b/packages/common/phoenix/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "bin",
     "dist",

--- a/packages/common/random-access-storage/package.json
+++ b/packages/common/random-access-storage/package.json
@@ -32,9 +32,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/random/package.json
+++ b/packages/common/random/package.json
@@ -23,9 +23,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/storybook-utils/package.json
+++ b/packages/common/storybook-utils/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/test-utils/package.json
+++ b/packages/common/test-utils/package.json
@@ -24,13 +24,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "playwright": [
-        "dist/types/src/playwright.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/timeframe/package.json
+++ b/packages/common/timeframe/package.json
@@ -23,9 +23,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/tracing/package.json
+++ b/packages/common/tracing/package.json
@@ -23,9 +23,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/util/package.json
+++ b/packages/common/util/package.json
@@ -23,9 +23,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/web-context-react/package.json
+++ b/packages/common/web-context-react/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/web-context-solid/package.json
+++ b/packages/common/web-context-solid/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/common/web-context/package.json
+++ b/packages/common/web-context/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/ai/package.json
+++ b/packages/core/ai/package.json
@@ -33,13 +33,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "vendor",

--- a/packages/core/assistant/package.json
+++ b/packages/core/assistant/package.json
@@ -30,16 +30,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ],
-      "extraction": [
-        "dist/types/src/extraction/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/compute/package.json
+++ b/packages/core/compute/package.json
@@ -25,13 +25,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/conductor/package.json
+++ b/packages/core/conductor/package.json
@@ -27,13 +27,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/echo/echo-atom/package.json
+++ b/packages/core/echo/echo-atom/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/echo/echo-db/package.json
+++ b/packages/core/echo/echo-db/package.json
@@ -25,13 +25,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/echo/echo-generator/package.json
+++ b/packages/core/echo/echo-generator/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/echo/echo-pipeline/package.json
+++ b/packages/core/echo/echo-pipeline/package.json
@@ -30,13 +30,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "testing.d.ts",
     "testing.js",

--- a/packages/core/echo/echo-protocol/package.json
+++ b/packages/core/echo/echo-protocol/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/echo/echo-query/package.json
+++ b/packages/core/echo/echo-query/package.json
@@ -24,9 +24,6 @@
     "./api.d.ts": "./dist/query-lite/index.d.ts"
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/echo/echo-react/package.json
+++ b/packages/core/echo/echo-react/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/echo/echo-solid/package.json
+++ b/packages/core/echo/echo-solid/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/echo/feed/package.json
+++ b/packages/core/echo/feed/package.json
@@ -25,13 +25,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/functions-runtime/package.json
+++ b/packages/core/functions-runtime/package.json
@@ -40,16 +40,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "bundler": [
-        "dist/types/src/bundler/index.d.ts"
-      ],
-      "edge": [
-        "dist/types/src/edge/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist/lib",
     "dist/types",

--- a/packages/core/functions-simulator-cloudflare/package.json
+++ b/packages/core/functions-simulator-cloudflare/package.json
@@ -25,13 +25,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/functions-testing/package.json
+++ b/packages/core/functions-testing/package.json
@@ -25,13 +25,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/halo/credentials/package.json
+++ b/packages/core/halo/credentials/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "dependencies": {
     "@dxos/async": "workspace:*",
     "@dxos/context": "workspace:*",

--- a/packages/core/halo/keyring/package.json
+++ b/packages/core/halo/keyring/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/mesh/edge-client/package.json
+++ b/packages/core/mesh/edge-client/package.json
@@ -30,13 +30,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src",

--- a/packages/core/mesh/messaging/package.json
+++ b/packages/core/mesh/messaging/package.json
@@ -25,13 +25,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src",

--- a/packages/core/mesh/network-manager/package.json
+++ b/packages/core/mesh/network-manager/package.json
@@ -62,16 +62,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ],
-      "transport/tcp": [
-        "dist/types/src/transport/tcp/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "testing.d.ts",
     "testing.js",

--- a/packages/core/mesh/rpc-tunnel/package.json
+++ b/packages/core/mesh/rpc-tunnel/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/mesh/rpc/package.json
+++ b/packages/core/mesh/rpc/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/mesh/signal/package.json
+++ b/packages/core/mesh/signal/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "dependencies": {
     "@dxos/async": "workspace:*",
     "@dxos/log": "workspace:*",

--- a/packages/core/mesh/teleport-extension-automerge-replicator/package.json
+++ b/packages/core/mesh/teleport-extension-automerge-replicator/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/mesh/teleport-extension-gossip/package.json
+++ b/packages/core/mesh/teleport-extension-gossip/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/mesh/teleport-extension-object-sync/package.json
+++ b/packages/core/mesh/teleport-extension-object-sync/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/mesh/teleport-extension-replicator/package.json
+++ b/packages/core/mesh/teleport-extension-replicator/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/core/mesh/teleport/package.json
+++ b/packages/core/mesh/teleport/package.json
@@ -25,13 +25,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "testing.d.ts",
     "testing.js",

--- a/packages/core/mesh/websocket-rpc/package.json
+++ b/packages/core/mesh/websocket-rpc/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src",

--- a/packages/core/protocols/package.json
+++ b/packages/core/protocols/package.json
@@ -39,25 +39,6 @@
     }
   },
   "types": "dist/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "proto/*": [
-        "dist/src/proto/gen/*"
-      ],
-      "buf/*": [
-        "dist/src/buf/proto/gen/*"
-      ],
-      "feed-replication": [
-        "dist/src/feed-replication.d.ts"
-      ],
-      "buf": [
-        "dist/src/buf/index.d.ts"
-      ],
-      "proto": [
-        "dist/src/proto/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/devtools/devtools/package.json
+++ b/packages/devtools/devtools/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "scripts": {
     "proxy": "vite-node scripts/proxy.ts"
   },

--- a/packages/e2e/blade-runner/package.json
+++ b/packages/e2e/blade-runner/package.json
@@ -28,13 +28,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "main": [
-        "dist/types/src/main.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "run-tests": "moon run blade-runner:build && node ./dist/lib/node-esm/main.mjs"
   },

--- a/packages/experimental/discord-bot/package.json
+++ b/packages/experimental/discord-bot/package.json
@@ -22,9 +22,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/experimental/env-tests/package.json
+++ b/packages/experimental/env-tests/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/experimental/script-toolbox/package.json
+++ b/packages/experimental/script-toolbox/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-assistant/package.json
+++ b/packages/plugins/plugin-assistant/package.json
@@ -51,19 +51,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "blueprints": [
-        "dist/types/src/blueprints/index.d.ts"
-      ],
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "assets",
     "dist",

--- a/packages/plugins/plugin-attention/package.json
+++ b/packages/plugins/plugin-attention/package.json
@@ -39,16 +39,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ],
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-automation/package.json
+++ b/packages/plugins/plugin-automation/package.json
@@ -59,16 +59,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "hooks": [
-        "dist/types/src/hooks/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "assets",
     "dist",

--- a/packages/plugins/plugin-board/package.json
+++ b/packages/plugins/plugin-board/package.json
@@ -34,13 +34,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-chess/package.json
+++ b/packages/plugins/plugin-chess/package.json
@@ -54,13 +54,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-client/package.json
+++ b/packages/plugins/plugin-client/package.json
@@ -58,19 +58,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ],
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-crm/package.json
+++ b/packages/plugins/plugin-crm/package.json
@@ -62,25 +62,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "blueprints": [
-        "dist/types/src/blueprints/index.d.ts"
-      ],
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ],
-      "sources": [
-        "dist/types/src/sources/index.d.ts"
-      ],
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-crx/package.json
+++ b/packages/plugins/plugin-crx/package.json
@@ -34,13 +34,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-debug/package.json
+++ b/packages/plugins/plugin-debug/package.json
@@ -27,9 +27,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-deck/package.json
+++ b/packages/plugins/plugin-deck/package.json
@@ -41,16 +41,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-discord/package.json
+++ b/packages/plugins/plugin-discord/package.json
@@ -36,13 +36,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-explorer/package.json
+++ b/packages/plugins/plugin-explorer/package.json
@@ -41,16 +41,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "meta": [
-        "dist/types/src/meta.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-feed/package.json
+++ b/packages/plugins/plugin-feed/package.json
@@ -46,19 +46,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "meta": [
-        "dist/types/src/meta.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ],
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-files/package.json
+++ b/packages/plugins/plugin-files/package.json
@@ -28,9 +28,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-graph/package.json
+++ b/packages/plugins/plugin-graph/package.json
@@ -25,9 +25,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-help/package.json
+++ b/packages/plugins/plugin-help/package.json
@@ -44,19 +44,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "meta": [
-        "dist/types/src/meta.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ],
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-inbox/package.json
+++ b/packages/plugins/plugin-inbox/package.json
@@ -61,16 +61,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "blueprints": [
-        "dist/types/src/blueprints/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-kanban/package.json
+++ b/packages/plugins/plugin-kanban/package.json
@@ -50,16 +50,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "blueprints": [
-        "dist/types/src/blueprints/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-map-solid/package.json
+++ b/packages/plugins/plugin-map-solid/package.json
@@ -25,9 +25,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-map/package.json
+++ b/packages/plugins/plugin-map/package.json
@@ -55,22 +55,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "blueprints": [
-        "dist/types/src/blueprints/index.d.ts"
-      ],
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ],
-      "testing": [
-        "dist/types/src/testing.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-markdown/package.json
+++ b/packages/plugins/plugin-markdown/package.json
@@ -67,22 +67,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "blueprints": [
-        "dist/types/src/blueprints/index.d.ts"
-      ],
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ],
-      "toolkit": [
-        "dist/types/src/toolkit.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-masonry/package.json
+++ b/packages/plugins/plugin-masonry/package.json
@@ -34,13 +34,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-meeting/package.json
+++ b/packages/plugins/plugin-meeting/package.json
@@ -34,13 +34,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-mermaid/package.json
+++ b/packages/plugins/plugin-mermaid/package.json
@@ -23,9 +23,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-native-filesystem/package.json
+++ b/packages/plugins/plugin-native-filesystem/package.json
@@ -29,9 +29,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-native/package.json
+++ b/packages/plugins/plugin-native/package.json
@@ -24,9 +24,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-navtree/package.json
+++ b/packages/plugins/plugin-navtree/package.json
@@ -30,9 +30,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-observability/package.json
+++ b/packages/plugins/plugin-observability/package.json
@@ -47,16 +47,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ],
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-outliner/package.json
+++ b/packages/plugins/plugin-outliner/package.json
@@ -41,16 +41,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-pipeline/package.json
+++ b/packages/plugins/plugin-pipeline/package.json
@@ -33,13 +33,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-presenter/package.json
+++ b/packages/plugins/plugin-presenter/package.json
@@ -34,9 +34,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-preview/package.json
+++ b/packages/plugins/plugin-preview/package.json
@@ -24,9 +24,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-pwa/package.json
+++ b/packages/plugins/plugin-pwa/package.json
@@ -23,9 +23,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-registry/package.json
+++ b/packages/plugins/plugin-registry/package.json
@@ -35,9 +35,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-sample/package.json
+++ b/packages/plugins/plugin-sample/package.json
@@ -53,13 +53,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-script/package.json
+++ b/packages/plugins/plugin-script/package.json
@@ -56,22 +56,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "blueprints": [
-        "dist/types/src/blueprints/index.d.ts"
-      ],
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ],
-      "templates": [
-        "dist/types/src/templates/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-settings/package.json
+++ b/packages/plugins/plugin-settings/package.json
@@ -33,13 +33,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-sheet/package.json
+++ b/packages/plugins/plugin-sheet/package.json
@@ -42,16 +42,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-sidekick/package.json
+++ b/packages/plugins/plugin-sidekick/package.json
@@ -34,13 +34,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-sketch/package.json
+++ b/packages/plugins/plugin-sketch/package.json
@@ -49,19 +49,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ],
-      "sdk": [
-        "dist/types/src/sdk.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-space/package.json
+++ b/packages/plugins/plugin-space/package.json
@@ -58,19 +58,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "meta": [
-        "dist/types/src/meta.d.ts"
-      ],
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-spacetime/package.json
+++ b/packages/plugins/plugin-spacetime/package.json
@@ -33,13 +33,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-spec/package.json
+++ b/packages/plugins/plugin-spec/package.json
@@ -32,13 +32,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-stack/package.json
+++ b/packages/plugins/plugin-stack/package.json
@@ -34,13 +34,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-status-bar/package.json
+++ b/packages/plugins/plugin-status-bar/package.json
@@ -27,9 +27,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-table/package.json
+++ b/packages/plugins/plugin-table/package.json
@@ -47,16 +47,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "blueprints": [
-        "dist/types/src/blueprints/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-template/package.json
+++ b/packages/plugins/plugin-template/package.json
@@ -31,13 +31,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-theme/package.json
+++ b/packages/plugins/plugin-theme/package.json
@@ -28,13 +28,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "meta": [
-        "dist/types/src/meta.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-thread/package.json
+++ b/packages/plugins/plugin-thread/package.json
@@ -50,19 +50,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "blueprints": [
-        "dist/types/src/blueprints/index.d.ts"
-      ],
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-tictactoe/package.json
+++ b/packages/plugins/plugin-tictactoe/package.json
@@ -49,13 +49,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-token-manager/package.json
+++ b/packages/plugins/plugin-token-manager/package.json
@@ -48,9 +48,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-transcription/package.json
+++ b/packages/plugins/plugin-transcription/package.json
@@ -49,19 +49,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "blueprints": [
-        "dist/types/src/blueprints/index.d.ts"
-      ],
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-transformer/package.json
+++ b/packages/plugins/plugin-transformer/package.json
@@ -33,13 +33,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-voxel/package.json
+++ b/packages/plugins/plugin-voxel/package.json
@@ -36,13 +36,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-wnfs/package.json
+++ b/packages/plugins/plugin-wnfs/package.json
@@ -37,16 +37,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ],
-      "operations": [
-        "dist/types/src/operations/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-youtube/package.json
+++ b/packages/plugins/plugin-youtube/package.json
@@ -41,16 +41,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "blueprints": [
-        "dist/types/src/blueprints/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/plugins/plugin-zen/package.json
+++ b/packages/plugins/plugin-zen/package.json
@@ -36,13 +36,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/sdk/app-framework/package.json
+++ b/packages/sdk/app-framework/package.json
@@ -91,46 +91,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "ActivationEvent": [
-        "dist/types/src/activation-event/index.d.ts"
-      ],
-      "ActivationEvents": [
-        "dist/types/src/common/activation-events.d.ts"
-      ],
-      "Capabilities": [
-        "dist/types/src/common/capabilities.d.ts"
-      ],
-      "Capability": [
-        "dist/types/src/capability/index.d.ts"
-      ],
-      "Plugin": [
-        "dist/types/src/plugin/index.d.ts"
-      ],
-      "PluginManager": [
-        "dist/types/src/plugin-manager/index.d.ts"
-      ],
-      "UrlLoader": [
-        "dist/types/src/url-loader/index.d.ts"
-      ],
-      "vite-plugin": [
-        "dist/types/src/vite-plugin/index.d.ts"
-      ],
-      "cli": [
-        "dist/types/src/cli/index.d.ts"
-      ],
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ],
-      "testing-react": [
-        "dist/types/src/testing/react.d.ts"
-      ],
-      "ui": [
-        "dist/types/src/ui/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "typedoc": "typedoc --out typedoc"
   },

--- a/packages/sdk/app-graph/package.json
+++ b/packages/sdk/app-graph/package.json
@@ -27,13 +27,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "./dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/sdk/app-solid/package.json
+++ b/packages/sdk/app-solid/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/sdk/app-toolkit/package.json
+++ b/packages/sdk/app-toolkit/package.json
@@ -33,16 +33,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "query": [
-        "dist/types/src/query.d.ts"
-      ],
-      "ui": [
-        "dist/types/src/ui/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/sdk/client-protocol/package.json
+++ b/packages/sdk/client-protocol/package.json
@@ -27,13 +27,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "./types": [
-        "./dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/sdk/client-services/package.json
+++ b/packages/sdk/client-services/package.json
@@ -47,13 +47,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/sdk/client/package.json
+++ b/packages/sdk/client/package.json
@@ -102,37 +102,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "devtools": [
-        "dist/types/src/devtools/index.d.ts"
-      ],
-      "echo": [
-        "dist/types/src/echo/index.d.ts"
-      ],
-      "halo": [
-        "dist/types/src/halo/index.d.ts"
-      ],
-      "edge": [
-        "dist/types/src/edge/index.d.ts"
-      ],
-      "invitations": [
-        "dist/types/src/invitations/index.d.ts"
-      ],
-      "mesh": [
-        "dist/types/src/mesh/index.d.ts"
-      ],
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ],
-      "worker": [
-        "dist/types/src/worker/index.d.ts"
-      ],
-      "opfs-worker": [
-        "dist/types/src/worker/opfs-worker.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/sdk/config/package.json
+++ b/packages/sdk/config/package.json
@@ -72,19 +72,6 @@
   },
   "main": "dist/lib/node/index.cjs",
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "esbuild-plugin": [
-        "dist/types/src/esbuild-plugin/index.d.ts"
-      ],
-      "rollup-plugin": [
-        "dist/types/src/rollup-plugin/index.d.ts"
-      ],
-      "vite-plugin": [
-        "dist/types/src/vite-plugin/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/sdk/migrations/package.json
+++ b/packages/sdk/migrations/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/sdk/react-client/package.json
+++ b/packages/sdk/react-client/package.json
@@ -63,31 +63,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "devtools": [
-        "dist/types/src/devtools/index.d.ts"
-      ],
-      "echo": [
-        "dist/types/src/echo/index.d.ts"
-      ],
-      "halo": [
-        "dist/types/src/halo/index.d.ts"
-      ],
-      "invitations": [
-        "dist/types/src/invitations/index.d.ts"
-      ],
-      "mesh": [
-        "dist/types/src/mesh/index.d.ts"
-      ],
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ],
-      "worker": [
-        "dist/types/src/worker.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "typedoc": "typedoc --out typedoc"
   },

--- a/packages/sdk/react-edge-client/package.json
+++ b/packages/sdk/react-edge-client/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/sdk/schema/package.json
+++ b/packages/sdk/schema/package.json
@@ -26,13 +26,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/sdk/shell/package.json
+++ b/packages/sdk/shell/package.json
@@ -35,16 +35,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "react": [
-        "dist/types/src/react.d.ts"
-      ],
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/sdk/types/package.json
+++ b/packages/sdk/types/package.json
@@ -26,13 +26,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/stories/stories-ui/package.json
+++ b/packages/stories/stories-ui/package.json
@@ -14,9 +14,6 @@
   "sideEffects": true,
   "type": "module",
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/brand/package.json
+++ b/packages/ui/brand/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "assets",
     "dist",

--- a/packages/ui/lit-grid/package.json
+++ b/packages/ui/lit-grid/package.json
@@ -30,13 +30,6 @@
   },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "src",
     "dist"

--- a/packages/ui/lit-ui/package.json
+++ b/packages/ui/lit-ui/package.json
@@ -29,13 +29,6 @@
   },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "react": [
-        "./dist/src/react.d.ts"
-      ]
-    }
-  },
   "files": [
     "src",
     "dist"

--- a/packages/ui/react-primitives/react-error-boundary/package.json
+++ b/packages/ui/react-primitives/react-error-boundary/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-primitives/react-hooks/package.json
+++ b/packages/ui/react-primitives/react-hooks/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-primitives/react-list/package.json
+++ b/packages/ui/react-primitives/react-list/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-attention/package.json
+++ b/packages/ui/react-ui-attention/package.json
@@ -33,16 +33,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "types": [
-        "dist/types/src/types.d.ts"
-      ],
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-board/package.json
+++ b/packages/ui/react-ui-board/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-calendar/package.json
+++ b/packages/ui/react-ui-calendar/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-canvas-compute/package.json
+++ b/packages/ui/react-ui-canvas-compute/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-canvas-editor/package.json
+++ b/packages/ui/react-ui-canvas-editor/package.json
@@ -26,13 +26,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-canvas/package.json
+++ b/packages/ui/react-ui-canvas/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-chat/package.json
+++ b/packages/ui/react-ui-chat/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-components/package.json
+++ b/packages/ui/react-ui-components/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-dnd/package.json
+++ b/packages/ui/react-ui-dnd/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-editor/package.json
+++ b/packages/ui/react-ui-editor/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-form/package.json
+++ b/packages/ui/react-ui-form/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-gameboard/package.json
+++ b/packages/ui/react-ui-gameboard/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-geo/package.json
+++ b/packages/ui/react-ui-geo/package.json
@@ -27,13 +27,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "data": [
-        "dist/types/src/data.d.ts"
-      ]
-    }
-  },
   "files": [
     "data",
     "dist",

--- a/packages/ui/react-ui-graph/package.json
+++ b/packages/ui/react-ui-graph/package.json
@@ -28,13 +28,6 @@
     "./styles/graph.css": "./styles/graph.css"
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "testing.d.ts",
     "testing.js",

--- a/packages/ui/react-ui-grid/package.json
+++ b/packages/ui/react-ui-grid/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-list/package.json
+++ b/packages/ui/react-ui-list/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-markdown/package.json
+++ b/packages/ui/react-ui-markdown/package.json
@@ -19,9 +19,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-menu/package.json
+++ b/packages/ui/react-ui-menu/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-mosaic/package.json
+++ b/packages/ui/react-ui-mosaic/package.json
@@ -33,16 +33,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "playwright": [
-        "dist/types/src/playwright/index.d.ts"
-      ],
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-pickers/package.json
+++ b/packages/ui/react-ui-pickers/package.json
@@ -26,13 +26,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "icons": [
-        "./dist/types/src/components/IconPicker/icons.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-search/package.json
+++ b/packages/ui/react-ui-search/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-sfx/package.json
+++ b/packages/ui/react-ui-sfx/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-stack/package.json
+++ b/packages/ui/react-ui-stack/package.json
@@ -25,16 +25,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "playwright": [
-        "dist/types/src/playwright/index.d.ts"
-      ],
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-syntax-highlighter/package.json
+++ b/packages/ui/react-ui-syntax-highlighter/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-table/package.json
+++ b/packages/ui/react-ui-table/package.json
@@ -39,19 +39,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "deprecated": [
-        "dist/types/src/deprecated/index.d.ts"
-      ],
-      "testing": [
-        "dist/types/src/testing/index.d.ts"
-      ],
-      "types": [
-        "dist/types/src/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-tabs/package.json
+++ b/packages/ui/react-ui-tabs/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-text-tooltip/package.json
+++ b/packages/ui/react-ui-text-tooltip/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui-thread/package.json
+++ b/packages/ui/react-ui-thread/package.json
@@ -20,9 +20,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/react-ui/package.json
+++ b/packages/ui/react-ui/package.json
@@ -27,13 +27,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "testing": [
-        "./dist/types/src/testing/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/solid-ui-geo/package.json
+++ b/packages/ui/solid-ui-geo/package.json
@@ -25,13 +25,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "data": [
-        "dist/types/src/data.d.ts"
-      ]
-    }
-  },
   "files": [
     "data",
     "dist",

--- a/packages/ui/solid-ui/package.json
+++ b/packages/ui/solid-ui/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/ui-editor/package.json
+++ b/packages/ui/ui-editor/package.json
@@ -27,9 +27,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/ui-theme/package.json
+++ b/packages/ui/ui-theme/package.json
@@ -27,13 +27,6 @@
       "require": "./dist/plugin/node-cjs/plugins/ThemePlugin.cjs"
     }
   },
-  "typesVersions": {
-    "*": {
-      "plugin": [
-        "dist/types/src/plugins/ThemePlugin.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/ui-types/package.json
+++ b/packages/ui/ui-types/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"

--- a/packages/ui/ui/package.json
+++ b/packages/ui/ui/package.json
@@ -21,9 +21,6 @@
     }
   },
   "types": "dist/types/src/index.d.ts",
-  "typesVersions": {
-    "*": {}
-  },
   "files": [
     "dist",
     "src"


### PR DESCRIPTION
## Summary

- Removes the `typesVersions` field from 180 `package.json` files across the workspace.
- Modern TypeScript module resolution (`bundler` / `node16` / `nodenext`) resolves subpath types via the `exports.<subpath>.types` field, which every affected package already declares. The `typesVersions` field is therefore redundant.
- This also aligns the codebase with the existing `scripts/pkg-lint.mjs` policy, which already flags `typesVersions` as a warning ("use exports instead").

## Test plan

- [ ] CI Check workflow passes (build + tests).
- [ ] `moon run :build` succeeds for all packages.
- [ ] `moon run :test` succeeds.
- [ ] Spot-check that subpath imports (e.g. `@dxos/react-ui/testing`, `@dxos/client/echo`, `@dxos/client/halo`, `@dxos/client/devtools`) still resolve their types via the `exports` field.

https://claude.ai/code/session_01YZkV5KXEMQNgeNShUiW2gy

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZkV5KXEMQNgeNShUiW2gy)_