### PR TITLE
ci: keep --project-name composer, fix only comment URL host

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -57,12 +57,12 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           wrangler pages deploy preview/packages/apps/composer-app/out/composer \
-            --project-name composer-app \
+            --project-name composer \
             --branch "${{ steps.meta.outputs.branch_alias }}" \
             | tee deploy.log
-          URL=$(grep -Eo 'https://[a-z0-9-]+\.composer-app\.pages\.dev' deploy.log | head -n1)
+          URL=$(grep -Eo 'https://[a-z0-9-]+\.composer\.pages\.dev' deploy.log | head -n1)
           echo "url=$URL" >> $GITHUB_OUTPUT
-          echo "alias=https://${{ steps.meta.outputs.branch_alias }}.composer-app.pages.dev" >> $GITHUB_OUTPUT
+          echo "alias=https://${{ steps.meta.outputs.branch_alias }}.composer.pages.dev" >> $GITHUB_OUTPUT
 
       - name: Comment preview URL on PR
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -60,9 +60,9 @@ jobs:
             --project-name composer \
             --branch "${{ steps.meta.outputs.branch_alias }}" \
             | tee deploy.log
-          URL=$(grep -Eo 'https://[a-z0-9-]+\.composer\.pages\.dev' deploy.log | head -n1)
+          URL=$(grep -Eo 'https://[a-z0-9-]+\.composer-app\.pages\.dev' deploy.log | head -n1)
           echo "url=$URL" >> $GITHUB_OUTPUT
-          echo "alias=https://${{ steps.meta.outputs.branch_alias }}.composer.pages.dev" >> $GITHUB_OUTPUT
+          echo "alias=https://${{ steps.meta.outputs.branch_alias }}.composer-app.pages.dev" >> $GITHUB_OUTPUT
 
       - name: Comment preview URL on PR
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
## Summary

Surgical fix for the broken preview-deploy workflow on `main`. After #11115, wrangler fails with `Project not found` because the Cloudflare project's technical name is `composer` (per `packages/apps/composer-app/wrangler.toml:9`), not `composer-app`.

The Cloudflare project is **technically named `composer`** but its `*.pages.dev` host is **`composer-app.pages.dev`**. So:

- `--project-name composer` ← required for `wrangler pages deploy` to find the project (this PR reverts to `composer`).
- URL grep + comment alias on `composer-app.pages.dev` ← required so the sticky comment links to the actual deployed URL (this PR keeps these on `composer-app`).

Net effect vs `main`: only `--project-name` flips back to `composer`. The URL pattern stays at `composer-app.pages.dev`, which matches what wrangler actually prints (the original symptom that motivated #11115 — the `Deployment:` field being empty because the grep didn't match).

## Test plan

- [ ] Confirm Preview Deploy succeeds on the next PR (no `Project not found`).
- [ ] Confirm sticky preview comment shows a non-empty `Deployment:` URL on `composer-app.pages.dev` and a matching `Branch alias`.

https://claude.ai/code/session_01QLKsgsTJF2NkrFJRnvabMv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated preview deployment configuration to use the correct project name and ensure preview URLs are generated and displayed consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->