### PR TITLE
fix(plugin-inbox): remove redundant message guards in DraftsArticle

### DIFF
--- a/packages/plugins/plugin-inbox/src/containers/DraftsArticle/DraftsArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/DraftsArticle/DraftsArticle.tsx
@@ -75,13 +75,13 @@ export const DraftsArticle = ({ role, space, attendableId, mailbox }: DraftsArti
               subject: companion,
               state: 'expanded',
             });
-          } else if (layout.mode === 'multi' && message && db) {
+          } else if (layout.mode === 'multi' && db) {
             void invokePromise(LayoutOperation.Open, {
               subject: [getMailboxMessagePath(db.spaceId, mailbox.id, message.id)],
               pivotId: id,
               navigation: 'immediate',
             });
-          } else if (message) {
+          } else {
             void invokePromise(LayoutOperation.UpdateCompanion, {
               subject: companion,
             });


### PR DESCRIPTION
## Summary

Follow-up to #11130: after the early `if (!message) return` guard was added, the subsequent `&& message` and `else if (message)` checks in the same branch became redundant. Simplifies them to `&& db` and a plain `else` respectively.

https://claude.ai/code/session_0115kqrfFTBhcrr2s4879SSV

---
_Generated by [Claude Code](https://claude.ai/code/session_0115kqrfFTBhcrr2s4879SSV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined draft article selection logic by simplifying the internal control flow and removing redundant validation checks, improving code efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->