### PR TITLE
ci: remove --force from bundle-apps

### DIFF
--- a/.github/workflows/scripts/bundle-apps.sh
+++ b/.github/workflows/scripts/bundle-apps.sh
@@ -20,8 +20,7 @@ for APP_PATH in "${APPS[@]}"; do
     export LOG_FILTER="error"
   fi
 
-  # Don't use the cache when bundling the app for deployment to avoid any caching issues causing bad builds.
-  moon run "$APP:bundle" --force
+  moon run "$APP:bundle"
 
   popd
 done


### PR DESCRIPTION
## Summary

- Removes `--force` from `moon run "$APP:bundle"` in `bundle-apps.sh`
- Moon's `--force` bypasses cache for **all tasks in the pipeline**, not just the root task — so `--force` on `bundle` was causing `^:build` deps to re-run even though the Build step had already run and cached them
- The `bundle` task's inputs in `tag-vite.yml` already list all relevant env vars (`$LOG_FILTER`, `$DX_POSTHOG_*`, `$NODE_OPTIONS`, etc.), so the cache naturally invalidates when those change — `--force` was redundant

## Context

The `--force` flag was added in #10878 as a precaution during a refactor, not in response to a specific caching bug. The comment ("avoid any caching issues causing bad builds") suggests defensive intent, but the comprehensive env var inputs added to the `bundle` task make this unnecessary and wasteful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the app bundle deployment process to enable caching, improving build efficiency and reducing deployment times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->