### PR TITLE
perf(composer-app): native DOM boot loader, structured profiler, startup harness

### DIFF
--- a/packages/apps/composer-app/AUDIT.md
+++ b/packages/apps/composer-app/AUDIT.md
@@ -1,0 +1,310 @@
+# Composer-app Startup Performance Audit
+
+This document is a static analysis of how composer-app starts, what we already
+measure, what we can measure better, and how to make the loading experience
+feel faster (and actually be faster). It is intentionally specific — every claim
+points at code so the reader can verify or push back.
+
+## 1. The pipeline today
+
+End-to-end, a cold load runs in this order. The first column is when the user
+*could* see something on screen.
+
+| Pixel state              | Phase                          | Code                                                                                                                 |
+| ------------------------ | ------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| Blank                    | HTML download + parse          | `index.html`                                                                                                         |
+| Blank                    | Module-graph fetch + evaluate  | bundle imports from `src/main.tsx`                                                                                   |
+| Blank                    | `dynamic-imports` phase        | `main.tsx:97-104` — `await import('@dxos/config' / react-client / migrations / ./migrations)`                        |
+| Blank                    | `config` phase                 | `main.tsx:111-138` — `setupConfig()`, IDB storage check                                                              |
+| Blank                    | `services` phase               | `main.tsx:187-249` — `createClientServices` (worker spin-up, OPFS SQLite)                                            |
+| Blank                    | `plugins-init` phase           | `main.tsx:251-283` — `getPlugins(conf)` constructs ~60 plugin instances (`plugin-defs.tsx`)                          |
+| Blank → Placeholder      | `createRoot.render(<Main />)`  | `main.tsx:330-339` — first React commit                                                                              |
+| Placeholder              | Plugin activation events       | `useApp` runs `manager.activate(SetupReactSurface)` then `Startup` (`useApp.tsx:210-214`)                            |
+| Placeholder              | Module activation              | `_loadModule` per plugin (`plugin-manager.ts:746-829`)                                                               |
+| Placeholder → App        | Done event fires               | `Startup` activated → `setReady(true)` (`useApp.tsx:192-199`)                                                        |
+| App                      | First useful paint             | `App.tsx:36-43` — composes contexts, mounts `Capabilities.ReactRoot` components                                      |
+
+Two very different concurrency stories live inside this:
+
+1. **Pre-React** (everything before `createRoot.render`) is a classic top-level
+   `await` chain. Nothing paints, nothing animates. The only signal the user has
+   that the app is alive is the favicon.
+2. **Post-React** is driven by the plugin manager via Effect fibers. A
+   `setInterval(..., 100)` polls `manager.getActive()` and pushes
+   `StartupProgress` into React state ([useApp.tsx:168-184](packages/sdk/app-framework/src/ui/hooks/useApp.tsx)). React *should* re-render on each tick, but:
+   - `Placeholder` was never wired to display the progress (the JSX block was commented out — fixed in this branch).
+   - Even if wired up, long-synchronous module activations starve the interval
+     callback. That is the "React render loop is not called while the app is
+     busy loading" symptom.
+
+## 2. Existing measurement
+
+### 2.1 What we have
+
+- `startupProfiler()` in `packages/apps/composer-app/src/profiler.ts`. Activated by
+  the `?profiler=1` query param ([config.ts:15](packages/apps/composer-app/src/config.ts), [main.tsx:65](packages/apps/composer-app/src/main.tsx)).
+- Top-level phase marks: `dynamic-imports`, `config`, `services`, `plugins-init`,
+  and `total` (`main:start` → `ready`) — all written to `User Timing` via
+  `performance.mark` / `performance.measure`.
+- Plugin manager emits per-event and per-module marks
+  ([plugin-manager.ts:592-608](packages/sdk/app-framework/src/core/plugin-manager.ts), [:763-775](packages/sdk/app-framework/src/core/plugin-manager.ts)) — `event:<id>` and `module:<id>`.
+- `dump()` is fired on the `Startup` activation event from `useApp` ([useApp.tsx:198](packages/sdk/app-framework/src/ui/hooks/useApp.tsx))
+  and writes a console table.
+
+### 2.2 What was missing
+
+- The output was console-only. No way to scrape it from a Playwright run, no
+  diff-friendly format, no persistence across reloads.
+- No mark for the *very first* moment the user sees anything — there was no
+  boot loader.
+- No e2e test that asserts "first paint happened, ready in N ms" — we had no
+  regression detector for the slowest part of the app.
+
+### 2.3 What this branch adds
+
+- `Profiler.snapshot()` returns a structured `ProfilerSnapshot` JSON object
+  (`profiler.ts`). `dump()` also persists the snapshot to
+  `localStorage['org.dxos.composer.startup-profile']` so a second tab or a
+  Playwright run can read it without scraping `console`.
+- `performance.mark('boot:html-parsed')` is written from an inline script in
+  `index.html` *before* the JS bundle is even fetched. This is the new "lower
+  bound" of how fast the app could possibly feel.
+- `src/playwright/startup.spec.ts` provides three tests:
+  - `cold start (cleared storage)` — fresh context, navigate, wait for the user-
+    account testid, pull `composer.profiler.snapshot()`, network bytes, paint
+    timings; write `test-results/composer-app/startup-cold-<browser>.json`.
+  - `warm start (reuse storage)` — prime then reload; same outputs, suffix
+    `-warm`.
+  - `boot loader paints before bundle is parsed` — asserts the inline DOM
+    loader is visible immediately after navigation commit.
+- `Placeholder.tsx` now actually reads `progress.activated`/`progress.total`
+  and binds the `Status` bar to the determinate progress fraction.
+
+## 3. The "loading bar doesn't update" problem
+
+The previous attempt (commented JSX in `Placeholder.tsx`) failed because the
+React reconciler genuinely doesn't get to paint during long synchronous
+activations. Confirmed mechanically:
+
+- `setStartupProgress` is in a `setInterval(100)` ([useApp.tsx:168](packages/sdk/app-framework/src/ui/hooks/useApp.tsx)).
+- Plugin module load runs through `Effect.forkDaemon` ([plugin-manager.ts:803](packages/sdk/app-framework/src/core/plugin-manager.ts)),
+  which *should* yield on every fiber suspension. But many module `activate()`
+  bodies do significant **synchronous** work: schema registration, surface
+  capability contributions, JS evaluation of dynamically imported plugin chunks.
+- A single sync block ≥100 ms swallows any number of interval ticks.
+- React 18 in concurrent mode defers commits even further when the main thread
+  is busy.
+
+So the recommendation is twofold:
+
+### 3.1 Native-DOM boot loader (this branch)
+
+`index.html` now contains an inline `<style>` and a small skeleton `<div
+id="boot-loader">` *inside* `#root`. Crucially:
+
+- The bar's animation is a CSS keyframe (`transform: translateX`). This animates
+  on the **compositor thread**, not the main thread, so it keeps moving even
+  while JS is parsing modules.
+- A 7-line inline `<script>` exposes `window.__composerBoot.status(text)`. The
+  three async-import phases in `main.tsx` push status text via this driver
+  (`Loading framework…`, `Reading configuration…`, `Starting services…`,
+  `Loading plugins…`).
+- When `createRoot(document.getElementById('root')).render(<Main />)` runs,
+  React replaces the boot-loader DOM with the Placeholder. The transition
+  is unbroken: CSS-animated bar → React-rendered Placeholder.
+
+This addresses the symptom for the **pre-React** window, which is the longest
+blank screen on a cold load (every other phase happens *after* React is
+mounted).
+
+### 3.2 React-rendered progress for post-mount work
+
+Already in `useApp.tsx`, the `setInterval(100)` polls `manager.getActive()` and
+sets state. We just need to display it, which this branch does. Where this is
+still flaky (long sync activations), the right fixes are:
+
+- **Yield more aggressively** during module activation — insert
+  `yield* Effect.yieldNow()` or `Effect.sleep(Duration.zero)` at fiber
+  boundaries inside `_loadModule` to give the browser a paint slot.
+- **Limit concurrency** at the activation event level — `Effect.allWith({
+  concurrency: 4 })` rather than `concurrency: 'unbounded'` ([plugin-manager.ts:712](packages/sdk/app-framework/src/core/plugin-manager.ts), [:683-684](packages/sdk/app-framework/src/core/plugin-manager.ts)). Counterintuitively, four-at-a-time finishes faster on real hardware than 60-at-a-time because the JS thread is less swamped.
+- **Use `scheduler.yield()`** if available (Chromium 129+). It's strictly better
+  than `setTimeout(0)` for cooperative scheduling.
+
+## 4. Where startup time is spent
+
+Without measurements from the harness yet (this PR only lands the harness), the
+hot spots from static reading are:
+
+### 4.1 ~60 plugins are imported eagerly
+
+[`plugin-defs.tsx`](packages/apps/composer-app/src/plugin-defs.tsx) does
+`import { AssistantPlugin } from '@dxos/plugin-assistant'` for every plugin.
+Even the ones that aren't in `core` and aren't in the user's `defaults` cause:
+
+- An HTTP request (or cache hit) per plugin entrypoint *and* its transitive deps
+  (~thousands of files in dev).
+- Synchronous evaluation of every imported module.
+- A non-trivial cost in the production bundle's `manual chunks` even with
+  Vite's tree shaking.
+
+The plugin manager already supports a `pluginLoader` that returns plugins by id
+([useApp.tsx:107-115](packages/sdk/app-framework/src/ui/hooks/useApp.tsx)).
+Recommendation: replace the eager `import` block in `plugin-defs.tsx` with a
+function that *constructs* a Plugin record where `module.activate` does
+`Effect.promise(() => import('@dxos/plugin-x'))`. Then a plugin's code is only
+ever fetched if its id is in `core` or `enabled`. For Composer specifically:
+
+- Core (always loaded): `Attention`, `Automation`, `Client`, `Crx`, `CrxBridge`,
+  `Graph`, `Help`, `Deck`/`SimpleLayout`/`Spotlight`, `Native?`, `Operation`,
+  `NavTree`, `Observability`, `Preview`, `Pwa?`, `Registry`, `Runtime`, `Search`,
+  `Settings`, `Space`, `StatusBar`, `Theme`, `TokenManager`, `Welcome`.
+- Defaults (loaded on demand the first time): `Inbox`, `Kanban`, `Markdown`,
+  `Masonry`, `Sheet`, `Sketch`, `Table`, `Thread`, `Wnfs`, `Spec`, plus the
+  whole `isLabs` set: `Assistant`, `DailySummary`, `Discord`, `Feed`,
+  `IrohBeacon`, `Meeting`, `Outliner`, `Pipeline`, `Sidekick`, `Transcription`,
+  `Zen`.
+- Everything else (`Board`, `Chess`, `Explorer`, `Map`, `MapSolid`, `Mermaid`,
+  `Presenter`, `Sample`, `Script`, `Spacetime`, `Stack`, `Voxel`, `YouTube`,
+  `TicTacToe`) is only relevant when the user actually opens that surface — the
+  registry already understands lazy loading.
+
+Estimate: ≥30 plugins do not need to be in the eager bundle. The numbers will
+be sharpened by running the harness against `before`/`after`, but every plugin
+removed shaves both transferred bytes and parse time linearly.
+
+### 4.2 Dynamic imports are serialised, not pipelined
+
+`main.tsx:98-101` has four sequential `await import(...)` calls. They have no
+dependency between them, but they run one after another:
+
+```ts
+const { Config, defs, SaveConfig } = await import('@dxos/config');
+const { createClientServices } = await import('@dxos/react-client');
+const { Migrations } = await import('@dxos/migrations');
+const { __COMPOSER_MIGRATIONS__ } = await import('./migrations');
+```
+
+`Promise.all` would let the network/parser work on all four concurrently:
+
+```ts
+const [{ Config, defs, SaveConfig }, { createClientServices }, { Migrations }, { __COMPOSER_MIGRATIONS__ }] =
+  await Promise.all([
+    import('@dxos/config'),
+    import('@dxos/react-client'),
+    import('@dxos/migrations'),
+    import('./migrations'),
+  ]);
+```
+
+In dev mode this matters less (HTTP/2 multiplexing already pipelines), but on
+the production bundle each `await import` introduces a ~1 round-trip latency
+for the chunk file plus eats a tick of synchronous parse before the next one is
+requested.
+
+### 4.3 Service worker / PWA manifest is registered before the user sees anything
+
+`virtual:pwa-register/react` is imported synchronously at the top of `main.tsx`
+([line 15](packages/apps/composer-app/src/main.tsx)). The hook itself is only
+called inside `Fallback`, but the import side-effect contributes to bundle
+weight. Move `useRegisterSW` behind a dynamic import inside `Fallback`.
+
+### 4.4 `@dxos-theme` import at module top
+
+`import '@dxos-theme'` ([main.tsx:9](packages/apps/composer-app/src/main.tsx))
+loads the entire theme package as a side-effect. It has to land before any
+React renders, but the inline `<style>` for the boot loader means we don't
+*need* the theme to be loaded before painting *something*.
+
+### 4.5 SharedWorker creation
+
+`createClientServices` instantiates `SharedWorker(./shared-worker, ...)`
+([main.tsx:230-243](packages/apps/composer-app/src/main.tsx)). Spawning a
+SharedWorker incurs a one-time cost (open second JS context, parse worker
+bundle). This is unavoidable but worth measuring — the harness's
+`profile.phases` will show it as the `services` phase.
+
+### 4.6 Activation graph
+
+`SetupReactSurface` and `Startup` are activated in `Effect.all([...])` at
+[useApp.tsx:210-214](packages/sdk/app-framework/src/ui/hooks/useApp.tsx). The
+plugin manager fans out *all* matching modules per event via
+`Effect.allWith({ concurrency: 'unbounded' })` ([plugin-manager.ts:712](packages/sdk/app-framework/src/core/plugin-manager.ts)). With `Atom` writes on each
+contribution, this can pile up React renders.
+
+A bounded concurrency (e.g. 4–8) plus a single batched render via
+`flushSync` after a whole event activates would smooth out paint cadence.
+
+## 5. Recommendations (ranked)
+
+The order reflects the impact-to-risk ratio I'd assign for a single follow-up
+PR each. The boot loader and harness are already implemented in this PR.
+
+1. **Lazy-load non-core plugins.** Convert `plugin-defs.tsx` from `import {
+   FooPlugin } from '@dxos/plugin-foo'` to a record like
+   `{ id: '@dxos/plugin-foo', activate: () => import('@dxos/plugin-foo').then(...)
+   }` so the chunk is only requested when needed. Biggest single win,
+   architectural; needs to land alongside removing eager exports of the same
+   plugins from `index.ts`/translations.
+2. **Pipeline the four `await import`s in `main.tsx`** with `Promise.all`. Tiny
+   diff; measurable on first-paint-to-services.
+3. **Bound module activation concurrency** to 4 in `plugin-manager.ts` (search
+   for `concurrency: 'unbounded'`). Risk: re-orders activations. Need to verify
+   no plugin relies on concurrent contribution timing.
+4. **Yield to the event loop inside `_loadModule`** between
+   `_contributeCapabilities` and the next module — `yield* Effect.yieldNow()`.
+   This is what unblocks React rendering the determinate progress indicator
+   reliably.
+5. **`scheduler.yield()` instead of `setInterval(100)`** in `useApp` for
+   progress updates. Shorter latency to first observed update.
+6. **Move `virtual:pwa-register/react` and PWA registration** into `Fallback`'s
+   render path (it's only needed on error or update notifications), and make
+   the PWA manifest fetch defer until `'idle'`.
+7. **Track-only the slowest 5 modules in production observability** via
+   PostHog so we have a real-world distribution, not just dev-laptop numbers.
+   Build on top of `profiler.snapshot()`.
+8. **Swap `cssText` of `#boot-loader` to use the brand Composer logo SVG** so
+   the boot loader visually matches `Placeholder.tsx` — eliminates the slight
+   flash when React replaces the DOM. Cheap, polish-grade.
+
+## 6. Files changed in this PR
+
+| File | Why |
+| --- | --- |
+| `index.html` | Native-DOM boot loader (CSS-animated, paints on first frame, status driver on `window.__composerBoot`). |
+| `src/main.tsx` | Calls `bootStatus(...)` at each profiler phase; wires the boot driver. |
+| `src/profiler.ts` | Adds `Profiler.snapshot()` returning `ProfilerSnapshot` JSON; persists to `localStorage` on `dump()`. |
+| `src/components/Placeholder/Placeholder.tsx` | Renders the determinate progress indicator (un-comments the disabled block, threads `progress.activated`/`progress.total`). |
+| `src/playwright/startup.spec.ts` | Cold + warm timing harness, plus a "boot loader paints before bundle parses" smoke test. Writes JSON to `test-results/composer-app/`. |
+| `AUDIT.md` | This document. |
+
+## 7. How to run the harness locally
+
+```sh
+# Bundle (production build, what Playwright preview serves):
+moon run composer-app:bundle
+
+# Run the harness only:
+DX_PWA=false moon run composer-app:e2e -- src/playwright/startup.spec.ts
+
+# Output:
+ls test-results/composer-app/startup-*.json
+```
+
+Each JSON file is one scenario × one browser, fields documented at the top of
+[`startup.spec.ts`](src/playwright/startup.spec.ts). Diff two runs with `jq`:
+
+```sh
+jq '.profilerTotal, .profile.slowestModules[:5]' \
+   test-results/composer-app/startup-cold-chromium.json
+```
+
+## 8. Open questions
+
+- Are we OK breaking the cache-keyed `org.dxos.app-framework.enabled`
+  localStorage value if we ship lazy plugins? (Existing keys still work; new
+  ids would simply not be in the cache.)
+- Should `?profiler=1` be the default in dev builds? Always-on would let us
+  collect numbers from every devloop without remembering the flag.
+- Can `profiler.snapshot()` be exposed via `BroadcastChannel` so devtools can
+  read it without polling localStorage?

--- a/packages/apps/composer-app/index.html
+++ b/packages/apps/composer-app/index.html
@@ -23,9 +23,94 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
 
     <link rel="manifest" href="/site.webmanifest" />
+
+    <!--
+      Boot loader: paints on first frame, before any JS bundle is parsed.
+      The CSS animation runs on the compositor thread so it keeps moving
+      even while the JS main thread is busy parsing/evaluating modules.
+      `createRoot(...).render(...)` will replace this DOM when React mounts.
+    -->
+    <style>
+      #boot-loader {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 16px;
+        background: #f7f8f9;
+        color: #252529;
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
+        font-size: 13px;
+      }
+      @media (prefers-color-scheme: dark) {
+        #boot-loader {
+          background: #252529;
+          color: #d6d6d8;
+        }
+      }
+      #boot-loader-bar {
+        position: relative;
+        width: min(240px, 50vw);
+        height: 2px;
+        overflow: hidden;
+        background: rgba(127, 127, 127, 0.18);
+        border-radius: 1px;
+      }
+      #boot-loader-bar::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        width: 40%;
+        background: currentColor;
+        opacity: 0.7;
+        border-radius: 1px;
+        animation: boot-loader-bar 1.4s ease-in-out infinite;
+      }
+      @keyframes boot-loader-bar {
+        0% {
+          transform: translateX(-100%);
+        }
+        100% {
+          transform: translateX(250%);
+        }
+      }
+      #boot-loader-status {
+        opacity: 0.7;
+        min-height: 1em;
+        letter-spacing: 0.01em;
+      }
+    </style>
   </head>
   <body>
-    <div id="root" class="contents"></div>
+    <div id="root" class="contents">
+      <div id="boot-loader" role="status" aria-live="polite" aria-label="Initializing">
+        <div id="boot-loader-bar"></div>
+        <div id="boot-loader-status">Loading…</div>
+      </div>
+    </div>
+    <script>
+      // Earliest possible mark, before the module graph is fetched.
+      performance.mark('boot:html-parsed');
+      // Tiny driver so `main.tsx` (and dynamically-imported plugins) can update
+      // the visible status without going through React. Calls are no-ops once
+      // React has replaced #root.
+      window.__composerBoot = {
+        status: function (text) {
+          var element = document.getElementById('boot-loader-status');
+          if (element) {
+            element.textContent = text;
+          }
+        },
+      };
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/apps/composer-app/src/components/Placeholder/Placeholder.tsx
+++ b/packages/apps/composer-app/src/components/Placeholder/Placeholder.tsx
@@ -15,7 +15,7 @@ export const Placeholder = ({ stage = 1, progress }: PlaceholderProps) => {
     throw new Error('Test error');
   }
 
-  const hasProgress = progress && progress.total > 0;
+  const hasProgress = !!progress && progress.total > 0;
 
   return (
     <ThemeProvider tx={defaultTx}>
@@ -28,18 +28,19 @@ export const Placeholder = ({ stage = 1, progress }: PlaceholderProps) => {
               stage >= 2 && 'scale-50 opacity-0',
             )}
           />
-          {/* TODO(burdon): Option to show progress. */}
-          {/* {hasProgress && (
-            <p className='flex justify-center absolute bottom-8 text-sm text-subdued mt-4 transition-opacity duration-300'>
-              {progress.status} ({Math.round(progress.progress * 100)}%)
+          {hasProgress && (
+            <p
+              className='flex justify-center absolute bottom-8 text-sm text-subdued mt-4 transition-opacity duration-300'
+              data-testid='composer.placeholder.progress'
+            >
+              {progress!.status} ({progress!.activated}/{progress!.total})
             </p>
-          )} */}
+          )}
         </div>
         <Status
           variant='main-bottom'
           aria-label='Initializing'
-          indeterminate
-          // {...(hasProgress ? { progress: progress.progress } : { indeterminate: true })}
+          {...(hasProgress ? { progress: progress!.progress } : { indeterminate: true })}
         />
       </div>
     </ThemeProvider>

--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -52,7 +52,19 @@ declare global {
 
   // Debug hook: run `downloadLogs()` from devtools to save buffered logs (same as Reset dialog).
   var downloadLogs: () => void;
+
+  interface Window {
+    /** Native-DOM boot loader status driver, defined inline in `index.html`. */
+    __composerBoot?: { status: (text: string) => void };
+  }
 }
+
+/**
+ * Updates the native-DOM boot loader text. No-op once React has replaced #root.
+ * The CSS animation in `index.html` keeps painting on the compositor thread
+ * regardless of main-thread work, so this is purely textual feedback.
+ */
+const bootStatus = (text: string) => window.__composerBoot?.status(text);
 
 const main = async () => {
   const url = new URL(window.location.href);
@@ -94,6 +106,7 @@ const main = async () => {
   };
 
   profiler?.mark('dynamic-imports:start');
+  bootStatus('Loading framework…');
 
   const { Config, defs, SaveConfig } = await import('@dxos/config');
   const { createClientServices } = await import('@dxos/react-client');
@@ -109,6 +122,7 @@ const main = async () => {
   Migrations.define(APP_KEY, __COMPOSER_MIGRATIONS__);
 
   profiler?.mark('config:start');
+  bootStatus('Reading configuration…');
 
   let config = await setupConfig();
 
@@ -185,6 +199,7 @@ const main = async () => {
   const useSingleClientMode = isTauri && isMobile;
 
   profiler?.mark('services:start');
+  bootStatus('Starting services…');
 
   // Decide the deployment mode for client services. The factory is a dumb switch on
   // `runtime.client.services_mode` — the app is responsible for picking the right mode from its
@@ -249,6 +264,7 @@ const main = async () => {
   profiler?.measure('services', 'services:start', 'services:end');
 
   profiler?.mark('plugins:start');
+  bootStatus('Loading plugins…');
 
   const conf: PluginConfig = {
     appKey: APP_KEY,

--- a/packages/apps/composer-app/src/playwright/startup.spec.ts
+++ b/packages/apps/composer-app/src/playwright/startup.spec.ts
@@ -1,0 +1,214 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { type Page, expect, test } from '@playwright/test';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { log } from '@dxos/log';
+
+import { INITIAL_URL } from './app-manager';
+
+if (process.env.DX_PWA !== 'false') {
+  log.error('PWA must be disabled to run e2e tests. Set DX_PWA=false before running again.');
+  process.exit(1);
+}
+
+type StartupReport = {
+  scenario: 'cold' | 'warm';
+  url: string;
+  /** ms from `navigationStart` to first paint. */
+  firstPaint: number;
+  /** ms from `navigationStart` to first contentful paint. */
+  firstContentfulPaint: number;
+  /** ms from `navigationStart` to `domContentLoaded`. */
+  domContentLoaded: number;
+  /** Time the boot loader (native HTML/CSS) became visible. */
+  bootLoaderVisible: number | null;
+  /** Total ms reported by `composer.profiler` (main:start → ready). */
+  profilerTotal: number;
+  /** Wall-clock ms from `page.goto` until the user-account testid was visible. */
+  navigationToReady: number;
+  /** Phase, event, and module timings sourced from `composer.profiler.snapshot()`. */
+  profile: {
+    phases: Array<{ name: string; duration: number; startTime: number }>;
+    eventCount: number;
+    moduleCount: number;
+    /** Top 10 slowest modules. */
+    slowestModules: Array<{ name: string; duration: number }>;
+  };
+  /** Approximate transferred bytes from network responses (`response_received` events). */
+  transferredBytes: number;
+  /** Number of network responses received. */
+  responseCount: number;
+};
+
+const REPORT_DIR = path.join(__dirname, '..', '..', '..', '..', '..', 'test-results', 'composer-app');
+
+const writeReport = (name: string, payload: unknown) => {
+  mkdirSync(REPORT_DIR, { recursive: true });
+  writeFileSync(path.join(REPORT_DIR, name), `${JSON.stringify(payload, null, 2)}\n`);
+};
+
+const waitForReady = async (page: Page, timeout = 30_000): Promise<void> => {
+  await page.getByTestId('treeView.userAccount').waitFor({ timeout });
+};
+
+const collectStartupReport = async (page: Page, scenario: StartupReport['scenario']): Promise<StartupReport> => {
+  const data = await page.evaluate(() => {
+    const profiler = (window as any).composer?.profiler;
+    const snapshot = profiler?.snapshot?.() ?? null;
+    const paints = performance.getEntriesByType('paint');
+    const fp = paints.find((entry) => entry.name === 'first-paint');
+    const fcp = paints.find((entry) => entry.name === 'first-contentful-paint');
+    const nav = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
+    const bootMark = performance.getEntriesByName('boot:html-parsed')[0];
+    return {
+      snapshot,
+      firstPaint: fp ? Math.round(fp.startTime) : 0,
+      firstContentfulPaint: fcp ? Math.round(fcp.startTime) : 0,
+      domContentLoaded: nav ? Math.round(nav.domContentLoadedEventEnd) : 0,
+      bootLoaderVisible: bootMark ? Math.round(bootMark.startTime) : null,
+    };
+  });
+
+  return {
+    scenario,
+    url: page.url(),
+    firstPaint: data.firstPaint,
+    firstContentfulPaint: data.firstContentfulPaint,
+    domContentLoaded: data.domContentLoaded,
+    bootLoaderVisible: data.bootLoaderVisible,
+    profilerTotal: data.snapshot?.total ?? 0,
+    navigationToReady: 0, // overwritten by caller
+    profile: {
+      phases: data.snapshot?.phases ?? [],
+      eventCount: data.snapshot?.events.length ?? 0,
+      moduleCount: data.snapshot?.modules.length ?? 0,
+      slowestModules: (data.snapshot?.modules ?? []).slice(0, 10).map((entry: any) => ({
+        name: entry.name,
+        duration: entry.duration,
+      })),
+    },
+    transferredBytes: 0, // populated by caller
+    responseCount: 0,
+  };
+};
+
+test.describe('Startup timing harness', () => {
+  // First-paint and module-graph evaluation each take real wall clock; webkit can be much slower.
+  test.setTimeout(120_000);
+
+  test('cold start (cleared storage)', async ({ browser, browserName }, testInfo) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    let bytes = 0;
+    let responses = 0;
+    page.on('response', async (response) => {
+      responses += 1;
+      try {
+        const lengthHeader = response.headers()['content-length'];
+        if (lengthHeader) {
+          bytes += parseInt(lengthHeader, 10) || 0;
+        } else {
+          const body = await response.body().catch(() => null);
+          if (body) {
+            bytes += body.byteLength;
+          }
+        }
+      } catch {
+        // Ignore — some redirect / preflight responses can't be read.
+      }
+    });
+
+    const start = Date.now();
+    await page.goto(`${INITIAL_URL}/?profiler=1`);
+    await waitForReady(page);
+    const navigationToReady = Date.now() - start;
+
+    const report = await collectStartupReport(page, 'cold');
+    report.navigationToReady = navigationToReady;
+    report.transferredBytes = bytes;
+    report.responseCount = responses;
+
+    writeReport(`startup-cold-${browserName}.json`, report);
+    log.info('cold start report', { browser: browserName, navigationToReady, profilerTotal: report.profilerTotal });
+
+    // Sanity assertions: keep regression-detection cheap. Tighten later as we collect baselines.
+    expect(report.firstContentfulPaint).toBeGreaterThan(0);
+    expect(report.profilerTotal).toBeGreaterThan(0);
+    expect(report.profile.phases.length).toBeGreaterThan(0);
+
+    await testInfo.attach('startup-cold.json', { body: JSON.stringify(report, null, 2), contentType: 'application/json' });
+
+    await context.close();
+  });
+
+  test('warm start (reuse storage)', async ({ browser, browserName }, testInfo) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    // Prime: first navigation populates IDB, OPFS and the SW cache.
+    await page.goto(`${INITIAL_URL}/?profiler=1`);
+    await waitForReady(page);
+
+    // Warm reload: navigate again, measure.
+    let bytes = 0;
+    let responses = 0;
+    page.on('response', async (response) => {
+      responses += 1;
+      try {
+        const lengthHeader = response.headers()['content-length'];
+        if (lengthHeader) {
+          bytes += parseInt(lengthHeader, 10) || 0;
+        } else {
+          const body = await response.body().catch(() => null);
+          if (body) {
+            bytes += body.byteLength;
+          }
+        }
+      } catch {
+        // Ignore.
+      }
+    });
+
+    const start = Date.now();
+    await page.reload();
+    await waitForReady(page);
+    const navigationToReady = Date.now() - start;
+
+    const report = await collectStartupReport(page, 'warm');
+    report.navigationToReady = navigationToReady;
+    report.transferredBytes = bytes;
+    report.responseCount = responses;
+
+    writeReport(`startup-warm-${browserName}.json`, report);
+    log.info('warm start report', { browser: browserName, navigationToReady, profilerTotal: report.profilerTotal });
+
+    expect(report.profilerTotal).toBeGreaterThan(0);
+
+    await testInfo.attach('startup-warm.json', { body: JSON.stringify(report, null, 2), contentType: 'application/json' });
+
+    await context.close();
+  });
+
+  test('boot loader paints before bundle is parsed', async ({ browser }) => {
+    // Verifies the native-DOM loader (inline in `index.html`) is on screen before
+    // `main.tsx` finishes executing. The aria-label is what assistive tech reads.
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto(`${INITIAL_URL}/?profiler=1`, { waitUntil: 'commit' });
+    const loader = page.locator('#boot-loader');
+    await expect(loader).toBeVisible({ timeout: 5_000 });
+    await expect(loader).toHaveAttribute('aria-label', 'Initializing');
+
+    // The status driver is installed by an inline script before any module loads.
+    const hasDriver = await page.evaluate(() => typeof (window as any).__composerBoot?.status === 'function');
+    expect(hasDriver).toBe(true);
+
+    await context.close();
+  });
+});

--- a/packages/apps/composer-app/src/profiler.ts
+++ b/packages/apps/composer-app/src/profiler.ts
@@ -4,9 +4,29 @@
 
 /* eslint-disable no-console */
 
+const STORAGE_KEY = 'org.dxos.composer.startup-profile';
+
+export type ProfilerSnapshot = {
+  /** Wall-clock ms from main:start to ready (or "now" if not yet ready). */
+  total: number;
+  /** True once `dump()` has finalized the profile. */
+  complete: boolean;
+  /** ISO timestamp of when `dump()` was called. */
+  finishedAt?: string;
+  /** Top-level startup phases (`startup:dynamic-imports`, `startup:services`, …). */
+  phases: Array<{ name: string; duration: number; startTime: number }>;
+  /** Activation-event timings (`event:foo:bar`). */
+  events: Array<{ name: string; duration: number; startTime: number }>;
+  /** Module activation timings (`module:org.dxos.plugin.x.module.y`). */
+  modules: Array<{ name: string; duration: number; startTime: number }>;
+};
+
 export type Profiler = {
   mark: (name: string) => void;
   measure: (name: string, startMark: string, endMark: string) => void;
+  /** Returns a JSON snapshot of timings (works before or after `dump`). */
+  snapshot: () => ProfilerSnapshot;
+  /** Finalizes the profile, logs to console, persists to localStorage. */
   dump: () => void;
 };
 
@@ -17,65 +37,89 @@ export type Profiler = {
 export const startupProfiler = (): Profiler => {
   performance.mark('startup:main:start');
 
+  let complete = false;
+  let finishedAt: string | undefined;
+
+  const collect = (): ProfilerSnapshot => {
+    const measures = performance.getEntriesByType('measure');
+    const totalEntry = measures
+      .slice()
+      .reverse()
+      .find((entry) => entry.name === 'startup:total');
+    const total = totalEntry
+      ? Math.round(totalEntry.duration)
+      : Math.round(performance.now() - (performance.getEntriesByName('startup:main:start')[0]?.startTime ?? 0));
+
+    const toRow = (entry: PerformanceEntry, prefix: string) => ({
+      name: entry.name.replace(prefix, ''),
+      duration: Math.round(entry.duration),
+      startTime: Math.round(entry.startTime),
+    });
+
+    return {
+      total,
+      complete,
+      finishedAt,
+      phases: measures
+        .filter((entry) => entry.name.startsWith('startup:'))
+        .sort((first, second) => first.startTime - second.startTime)
+        .map((entry) => toRow(entry, 'startup:')),
+      events: measures
+        .filter((entry) => entry.name.startsWith('event:'))
+        .sort((first, second) => first.startTime - second.startTime)
+        .map((entry) => toRow(entry, 'event:')),
+      modules: measures
+        .filter((entry) => entry.name.startsWith('module:'))
+        .sort((first, second) => second.duration - first.duration)
+        .map((entry) => toRow(entry, 'module:')),
+    };
+  };
+
   return {
     mark: (name: string) => performance.mark(`startup:${name}`),
     measure: (name: string, startMark: string, endMark: string) =>
       performance.measure(`startup:${name}`, `startup:${startMark}`, `startup:${endMark}`),
+    snapshot: collect,
     dump: () => {
       performance.mark('startup:ready');
       performance.measure('startup:total', 'startup:main:start', 'startup:ready');
+      complete = true;
+      finishedAt = new Date().toISOString();
 
-      const entries = performance.getEntriesByType('measure');
-      const eventEntries = entries
-        .filter((entry) => entry.name.startsWith('event:'))
-        .sort((first, second) => first.startTime - second.startTime);
-      const moduleEntries = entries
-        .filter((entry) => entry.name.startsWith('module:'))
-        .sort((first, second) => second.duration - first.duration);
-      const startupEntries = entries
-        .filter((entry) => entry.name.startsWith('startup:'))
-        .sort((first, second) => first.startTime - second.startTime);
+      const snap = collect();
 
       console.group('Startup Profile');
-
-      console.log(
-        'Total startup time:',
-        Math.round(
-          entries
-            .slice()
-            .reverse()
-            .find((entry) => entry.name === 'startup:total')?.duration ?? 0,
-        ),
-        'ms',
-      );
-
+      console.log('Total startup time:', snap.total, 'ms');
       console.table(
-        startupEntries.map((entry) => ({
-          Phase: entry.name.replace('startup:', ''),
-          'Duration (ms)': Math.round(entry.duration),
-          'Start (ms)': Math.round(entry.startTime),
+        snap.phases.map((entry) => ({
+          Phase: entry.name,
+          'Duration (ms)': entry.duration,
+          'Start (ms)': entry.startTime,
         })),
       );
-
-      console.log(`\nActivation Events (${eventEntries.length}):`);
+      console.log(`\nActivation Events (${snap.events.length}):`);
       console.table(
-        eventEntries.map((entry) => ({
-          Event: entry.name.replace('event:', ''),
-          'Duration (ms)': Math.round(entry.duration),
-          'Start (ms)': Math.round(entry.startTime),
+        snap.events.map((entry) => ({
+          Event: entry.name,
+          'Duration (ms)': entry.duration,
+          'Start (ms)': entry.startTime,
         })),
       );
-
-      console.log(`\nSlowest Modules (top 20 of ${moduleEntries.length}):`);
+      console.log(`\nSlowest Modules (top 20 of ${snap.modules.length}):`);
       console.table(
-        moduleEntries.slice(0, 20).map((entry) => ({
-          Module: entry.name.replace('module:', ''),
-          'Duration (ms)': Math.round(entry.duration),
-          'Start (ms)': Math.round(entry.startTime),
+        snap.modules.slice(0, 20).map((entry) => ({
+          Module: entry.name,
+          'Duration (ms)': entry.duration,
+          'Start (ms)': entry.startTime,
         })),
       );
-
       console.groupEnd();
+
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(snap));
+      } catch {
+        // Quota or disabled storage — non-fatal.
+      }
     },
   };
 };


### PR DESCRIPTION
## Summary

- Adds a native-DOM **boot loader** inline in `index.html` so something paints on the first frame, with a CSS-keyframe progress bar that animates on the compositor thread (does not stall while the main thread is busy parsing modules). A 7-line inline script exposes `window.__composerBoot.status(text)` that `main.tsx` calls between phases (`Loading framework` → `Reading configuration` → `Starting services` → `Loading plugins`). React replaces the loader DOM when `createRoot.render` mounts `<Placeholder>`.
- Extends the **startup profiler** (`?profiler=1`) with `Profiler.snapshot()` returning a structured `ProfilerSnapshot` JSON; `dump()` persists the same snapshot to `localStorage` so other tabs and Playwright can read it deterministically. Console output is preserved.
- Lands a **Playwright timing harness** (`src/playwright/startup.spec.ts`) with three tests: cold start (cleared storage), warm start (reused storage + reload), and a smoke test that the boot loader paints before the bundle parses. Each scenario writes JSON (`profilerTotal`, FCP, FP, DOMContentLoaded, navigation→ready, transferred bytes, top-10 slowest modules) to `test-results/composer-app/startup-{cold,warm}-<browser>.json`.
- Re-enables the **determinate progress text** in `Placeholder.tsx` (was commented out). The previous attempt didn't appear to render because (a) the JSX was disabled, and (b) long synchronous module activations starve React's render loop — that's now mitigated by the boot loader + a textual progress that updates whenever React does get a paint slot.
- [AUDIT.md](packages/apps/composer-app/AUDIT.md) documents the full pipeline, why the previous progress attempt didn't work, where startup time is spent (eager imports of ~60 plugins, sequentially-awaited dynamic imports, unbounded module-activation concurrency), and ranked recommendations.

## Test plan

- [ ] `moon run composer-app:build` — typecheck (passed locally)
- [ ] `moon run composer-app:lint` — passed locally
- [ ] `moon run composer-app:bundle` — production build incl. boot-loader HTML
- [ ] `DX_PWA=false moon run composer-app:e2e -- src/playwright/startup.spec.ts` — runs harness, writes JSON
- [ ] Manually verify: load app with `?profiler=1`, confirm boot bar is visible immediately and status text updates through the four phases
- [ ] Manually verify: in DevTools console, `composer.profiler.snapshot()` returns structured JSON, and `localStorage['org.dxos.composer.startup-profile']` is populated after `Startup` activation
- [ ] Cold + warm Playwright runs across chromium/firefox/webkit produce non-zero `profilerTotal` and at least one `profile.phases` entry per scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)