### PR TITLE
feat(plugin-feed): magazine tile polish, markdown snippets + ref-resolving debug panel

### DIFF
--- a/packages/plugins/plugin-debug/src/containers/DebugObjectPanel/DebugObjectPanel.tsx
+++ b/packages/plugins/plugin-debug/src/containers/DebugObjectPanel/DebugObjectPanel.tsx
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { AppSurface } from '@dxos/app-toolkit/ui';
 import { ObjectsTree } from '@dxos/devtools';
@@ -11,6 +11,8 @@ import type { ObjectId } from '@dxos/keys';
 import { useQuery } from '@dxos/react-client/echo';
 import { Clipboard, Grid, Panel, ScrollArea, Toolbar } from '@dxos/react-ui';
 import { Syntax } from '@dxos/react-ui-syntax-highlighter';
+
+import { createRefReplacer } from './createRefReplacer';
 
 export type DebugObjectPanelProps = Pick<
   AppSurface.ObjectArticleProps<Obj.Unknown, {}, Obj.Unknown>,
@@ -24,6 +26,7 @@ export const DebugObjectPanel = ({ role, companionTo }: DebugObjectPanelProps) =
     db,
     Query.select(Filter.id(selectedId ?? companionTo.id)).options({ deleted: 'include' }),
   );
+  const refReplacer = useMemo(() => (db ? createRefReplacer({ db, depth: 1 }) : undefined), [db]);
 
   return (
     <Clipboard.Provider>
@@ -40,7 +43,7 @@ export const DebugObjectPanel = ({ role, companionTo }: DebugObjectPanelProps) =
                 </ScrollArea.Viewport>
               </ScrollArea.Root>
             )}
-            <Syntax.Root data={selectedObject}>
+            <Syntax.Root data={selectedObject} replacer={refReplacer}>
               <Syntax.Content>
                 <Syntax.Filter />
                 <Syntax.Viewport>

--- a/packages/plugins/plugin-debug/src/containers/DebugObjectPanel/createRefReplacer.ts
+++ b/packages/plugins/plugin-debug/src/containers/DebugObjectPanel/createRefReplacer.ts
@@ -41,7 +41,19 @@ export const createRefReplacer = ({ db, depth = 1 }: CreateRefReplacerOptions): 
       if (remaining <= 0) {
         return value;
       }
-      const echoId = DXN.parse(value['/']).asEchoDXN()?.echoId;
+      // The `{ '/': string }` shape is shared with non-DXN IPLD-style refs, and an unexpected
+      // string would otherwise crash the whole `JSON.stringify`. Treat any parse miss as
+      // "leave as-is" rather than propagating.
+      const dxnString = value['/'];
+      if (!dxnString.startsWith('dxn:')) {
+        return value;
+      }
+      let echoId: string | undefined;
+      try {
+        echoId = DXN.parse(dxnString).asEchoDXN()?.echoId;
+      } catch {
+        return value;
+      }
       if (!echoId) {
         return value;
       }

--- a/packages/plugins/plugin-debug/src/containers/DebugObjectPanel/createRefReplacer.ts
+++ b/packages/plugins/plugin-debug/src/containers/DebugObjectPanel/createRefReplacer.ts
@@ -1,0 +1,74 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { type Database, type Obj } from '@dxos/echo';
+import { DXN } from '@dxos/keys';
+import { type JsonReplacer } from '@dxos/react-ui-syntax-highlighter';
+
+export type CreateRefReplacerOptions = {
+  db: Database.Database;
+  /** How many levels of refs to follow. `0` leaves all refs as-is. Default: `1`. */
+  depth?: number;
+};
+
+const isEncodedRef = (value: unknown): value is { '/': string } =>
+  typeof value === 'object' &&
+  value !== null &&
+  Object.keys(value as object).length === 1 &&
+  typeof (value as { '/': unknown })['/'] === 'string';
+
+const toJson = (obj: Obj.Any): unknown => (typeof (obj as any).toJSON === 'function' ? (obj as any).toJSON() : obj);
+
+/**
+ * Returns a {@link JsonReplacer} that walks the encoded form of an ECHO object and inlines
+ * referenced objects up to `depth` levels.
+ *
+ * Beyond that depth refs are left in their standard `{ "/": "dxn:..." }` shape.
+ *
+ * Implemented as a `JSON.stringify` replacer (not a separate hook) because ECHO objects' `toJSON` runs
+ * before the replacer is invoked — by the time we see a value, refs have already been encoded.
+ *
+ * The walk happens once at the root call (`key === ''`).
+ */
+export const createRefReplacer = ({ db, depth = 1 }: CreateRefReplacerOptions): JsonReplacer => {
+  const visit = (value: any, remaining: number, seen: Set<object>): any => {
+    if (value == null || typeof value !== 'object') {
+      return value;
+    }
+
+    if (isEncodedRef(value)) {
+      if (remaining <= 0) {
+        return value;
+      }
+      const echoId = DXN.parse(value['/']).asEchoDXN()?.echoId;
+      if (!echoId) {
+        return value;
+      }
+      const target = db.getObjectById(echoId);
+      if (!target) {
+        return value;
+      }
+
+      return visit(toJson(target), remaining - 1, seen);
+    }
+
+    if (seen.has(value)) {
+      return value;
+    }
+
+    seen.add(value);
+    if (Array.isArray(value)) {
+      return value.map((item) => visit(item, remaining, seen));
+    }
+
+    const out: Record<string, any> = {};
+    for (const [key, child] of Object.entries(value)) {
+      out[key] = visit(child, remaining, seen);
+    }
+
+    return out;
+  };
+
+  return (key, value) => (key === '' ? visit(value, depth, new Set()) : value);
+};

--- a/packages/plugins/plugin-feed/package.json
+++ b/packages/plugins/plugin-feed/package.json
@@ -75,8 +75,7 @@
     "@effect-atom/atom-react": "catalog:",
     "date-fns": "catalog:",
     "defuddle": "catalog:",
-    "fast-xml-parser": "catalog:",
-    "turndown": "catalog:"
+    "fast-xml-parser": "catalog:"
   },
   "devDependencies": {
     "@dxos/echo-db": "workspace:*",
@@ -90,7 +89,6 @@
     "@storybook/react-vite": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "@types/turndown": "catalog:",
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/packages/plugins/plugin-feed/package.json
+++ b/packages/plugins/plugin-feed/package.json
@@ -75,7 +75,8 @@
     "@effect-atom/atom-react": "catalog:",
     "date-fns": "catalog:",
     "defuddle": "catalog:",
-    "fast-xml-parser": "catalog:"
+    "fast-xml-parser": "catalog:",
+    "turndown": "catalog:"
   },
   "devDependencies": {
     "@dxos/echo-db": "workspace:*",
@@ -89,6 +90,7 @@
     "@storybook/react-vite": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@types/turndown": "catalog:",
     "effect": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/packages/plugins/plugin-feed/src/components/PostContent/PostContent.tsx
+++ b/packages/plugins/plugin-feed/src/components/PostContent/PostContent.tsx
@@ -56,6 +56,10 @@ export const dedupeImagesInMarkdown = (markdown: string, excluded: ReadonlyArray
   return dedupe(dedupe(markdown, markdownImg), htmlImg);
 };
 
+/** Returns true if the markdown contains at least one Markdown or inline HTML image. */
+export const contentHasImage = (markdown: string): boolean =>
+  /!\[[^\]]*\]\(\s*[^)\s]+/.test(markdown) || /<img\b[^>]*\bsrc=["'][^"']+["']/i.test(markdown);
+
 /**
  * Shared presentational layout for an article-style post.
  * Render order: title → hero image → Markdown body (`post.content` /
@@ -78,11 +82,19 @@ export const PostContent = composable<HTMLDivElement, PostContentProps>(
       return dedupeImagesInMarkdown(source, [post.imageUrl]);
     }, [post.content, post.snippet, post.imageUrl]);
 
+    // Suppress the hero when the article body already carries imagery — RSS feeds often
+    // duplicate the lead image inside `<content>` under a different URL than `imageUrl`,
+    // and rendering both stacks the same picture twice (see e.g. Guardian galleries).
+    const showHero = useMemo(
+      () => Boolean(post.imageUrl?.startsWith('http')) && !contentHasImage(content),
+      [post.imageUrl, content],
+    );
+
     return (
       <ScrollArea.Root {...props} orientation='vertical' thin ref={forwardedRef}>
         <ScrollArea.Viewport classNames='flex flex-col gap-3 p-4'>
           {title && <h1 className='text-xl font-semibold'>{title}</h1>}
-          {post.imageUrl?.startsWith('http') && (
+          {showHero && (
             <img src={post.imageUrl} alt='' className='rounded w-full object-cover max-h-72' loading='lazy' />
           )}
           {content && <MarkdownViewer content={content} />}

--- a/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
+++ b/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
@@ -52,8 +52,9 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
     const map = new Map<string, string>();
     for (const feed of allFeeds) {
       // Fall back to URL when sync hasn't populated `name` yet (or the source RSS has no
-      // `<title>`) so each tile still shows provenance.
-      const label = feed.name ?? feed.url;
+      // `<title>`) so each tile still shows provenance. Use `||` so empty-string names
+      // (parser-supplied empty `<title>`) also fall through to the URL.
+      const label = feed.name || feed.url;
       if (label) {
         map.set((feed as { id: string }).id, label);
       }

--- a/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
+++ b/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
@@ -20,7 +20,7 @@ import { type Magazine, Subscription } from '#types';
 
 import { fetchArticle, findStarTag, hasMetaTag, useStarTag } from '../../util';
 import { MagazineTile, formatPublished } from './MagazineTile';
-import { MagazineToolbar } from './MagazineToolbar';
+import { MagazineToolbar, type MagazineView } from './MagazineToolbar';
 
 export type MagazineArticleProps = AppSurface.ObjectArticleProps<Magazine.Magazine>;
 
@@ -31,16 +31,18 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
   const id = attendableId ?? Obj.getDXN(subject).toString();
   const currentId = useSelected(id, 'single');
   const [sort, setSort] = useState<'date' | 'rank'>('date');
-  const [showArchived, setShowArchived] = useState(false);
-  const [onlyStarred, setOnlyStarred] = useState(false);
+  const [view, setView] = useState<MagazineView>('default');
   const db = Obj.getDatabase(subject);
   const starTag = useStarTag(db);
+
   // Sync feeds → curate magazine → apply per-feed keep, plus state/error
   // tracking. See `useCurate` at the bottom of the file.
   const { state, error, curate: handleCurate } = useCurate(subject, db);
+
   // Reactive query of every Subscription.Feed in the space — used to render the source
   // feed name on each tile without each tile having to subscribe to its own ref.
   const allFeeds = useQuery(db, Filter.type(Subscription.Feed));
+
   // Index feeds by bare object id (last DXN segment) — `Obj.getDXN(feed)`
   // returns the space-scoped form (`dxn:echo:<spaceId>:<id>`), but
   // `post.feed.dxn` from a `Ref.make` carries the local-id form
@@ -131,10 +133,17 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
       resolved.push(target);
     }
 
-    // Filter archived unless explicitly shown, then optionally filter to starred only.
-    let visible = showArchived ? resolved : resolved.filter((post) => !post.archived);
-    if (onlyStarred) {
-      visible = visible.filter((post) => hasMetaTag(post, starTag));
+    // View mode determines which posts the tile grid shows.
+    // - 'archived'  → only archived posts.
+    // - 'starred'   → only starred (non-archived) posts.
+    // - 'default'   → everything except archived.
+    let visible: Subscription.Post[];
+    if (view === 'archived') {
+      visible = resolved.filter((post) => post.archived);
+    } else if (view === 'starred') {
+      visible = resolved.filter((post) => !post.archived && hasMetaTag(post, starTag));
+    } else {
+      visible = resolved.filter((post) => !post.archived);
     }
 
     if (sort === 'rank') {
@@ -167,8 +176,7 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
     subject.posts.length,
     subject.posts.map((ref) => ref.dxn.toString()).join(),
     sort,
-    showArchived,
-    onlyStarred,
+    view,
     starTag,
   ]);
 
@@ -273,10 +281,8 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
         <MagazineToolbar
           sort={sort}
           onSortChange={setSort}
-          onlyStarred={onlyStarred}
-          onOnlyStarredChange={setOnlyStarred}
-          showArchived={showArchived}
-          onShowArchivedChange={setShowArchived}
+          view={view}
+          onViewChange={setView}
           state={state}
           curateDisabled={curateDisabled}
           curateTooltip={curateTooltip}

--- a/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
+++ b/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
@@ -10,7 +10,7 @@ import { type AppSurface, useShowItem } from '@dxos/app-toolkit/ui';
 import { type Database, Filter, Obj, Ref, type Tag } from '@dxos/echo';
 import { log } from '@dxos/log';
 import { useObject, useQuery } from '@dxos/react-client/echo';
-import { Icon, Panel, Toolbar, useTranslation } from '@dxos/react-ui';
+import { Panel, useTranslation } from '@dxos/react-ui';
 import { linkedSegment, useSelected } from '@dxos/react-ui-attention';
 import { Masonry } from '@dxos/react-ui-masonry';
 
@@ -20,6 +20,7 @@ import { type Magazine, Subscription } from '#types';
 
 import { fetchArticle, findStarTag, hasMetaTag, useStarTag } from '../../util';
 import { MagazineTile, formatPublished } from './MagazineTile';
+import { MagazineToolbar } from './MagazineToolbar';
 
 export type MagazineArticleProps = AppSurface.ObjectArticleProps<Magazine.Magazine>;
 
@@ -97,7 +98,7 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
     });
   }, [subject, subject.feeds, subject.posts]);
 
-  const posts = useMemo<TileData[]>(() => {
+  const posts = useMemo<Subscription.Post[]>(() => {
     const resolved: Subscription.Post[] = [];
     const seenDxn = new Set<string>();
     const seenLink = new Set<string>();
@@ -269,62 +270,19 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
   return (
     <Panel.Root role={role}>
       <Panel.Toolbar asChild>
-        <Toolbar.Root>
-          <Toolbar.ToggleGroup
-            type='single'
-            value={sort}
-            onValueChange={(value) => {
-              if (value === 'date' || value === 'rank') {
-                setSort(value);
-              }
-            }}
-          >
-            <Toolbar.ToggleGroupItem value='date' aria-label={t('sort-by-date.label')} title={t('sort-by-date.label')}>
-              <Icon icon='ph--calendar--regular' size={4} />
-            </Toolbar.ToggleGroupItem>
-            <Toolbar.ToggleGroupItem value='rank' aria-label={t('sort-by-rank.label')} title={t('sort-by-rank.label')}>
-              <Icon icon='ph--list-numbers--regular' size={4} />
-            </Toolbar.ToggleGroupItem>
-          </Toolbar.ToggleGroup>
-          <Toolbar.ToggleGroup
-            type='single'
-            value={onlyStarred ? 'on' : ''}
-            onValueChange={(value) => setOnlyStarred(value === 'on')}
-          >
-            <Toolbar.ToggleGroupItem value='on' aria-label={t('only-starred.label')} title={t('only-starred.label')}>
-              <Icon icon={onlyStarred ? 'ph--star--fill' : 'ph--star--regular'} size={4} />
-            </Toolbar.ToggleGroupItem>
-          </Toolbar.ToggleGroup>
-          <Toolbar.ToggleGroup
-            type='single'
-            value={showArchived ? 'show' : ''}
-            onValueChange={(value) => setShowArchived(value === 'show')}
-          >
-            <Toolbar.ToggleGroupItem
-              value='show'
-              aria-label={t('show-archived.label')}
-              title={t('show-archived.label')}
-            >
-              <Icon icon='ph--archive--regular' size={4} />
-            </Toolbar.ToggleGroupItem>
-          </Toolbar.ToggleGroup>
-          <Toolbar.Separator />
-          <Toolbar.IconButton
-            label={t('clear-magazine.label')}
-            icon='ph--eraser--regular'
-            iconOnly
-            disabled={state !== 'idle'}
-            onClick={handleClear}
-          />
-          <Toolbar.IconButton
-            label={curateTooltip ?? t('curate.label')}
-            icon={state === 'idle' ? 'ph--sparkle--regular' : 'ph--circle-notch--regular'}
-            iconClassNames={state !== 'idle' ? 'animate-spin' : undefined}
-            iconOnly
-            disabled={curateDisabled}
-            onClick={handleCurate}
-          />
-        </Toolbar.Root>
+        <MagazineToolbar
+          sort={sort}
+          onSortChange={setSort}
+          onlyStarred={onlyStarred}
+          onOnlyStarredChange={setOnlyStarred}
+          showArchived={showArchived}
+          onShowArchivedChange={setShowArchived}
+          state={state}
+          curateDisabled={curateDisabled}
+          curateTooltip={curateTooltip}
+          onClear={handleClear}
+          onCurate={handleCurate}
+        />
       </Panel.Toolbar>
       <Panel.Content>
         {posts.length === 0 ? (

--- a/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
+++ b/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
@@ -171,14 +171,7 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
     // contents change (ECHO's reactive proxy is stable per-object).
     // Including `.length` and a content fingerprint as deps forces re-computation on
     // any add/remove, so the masonry tiles re-render after Curate / Clear.
-  }, [
-    subject.posts,
-    subject.posts.length,
-    subject.posts.map((ref) => ref.dxn.toString()).join(),
-    sort,
-    view,
-    starTag,
-  ]);
+  }, [subject.posts, subject.posts.length, subject.posts.map((ref) => ref.dxn.toString()).join(), sort, view, starTag]);
 
   // Reset the magazine's curated post list. Starred posts are preserved so
   // the user doesn't lose manually-saved items; a follow-up Curate will

--- a/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
+++ b/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
@@ -48,9 +48,11 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
   const feedNamesById = useMemo(() => {
     const map = new Map<string, string>();
     for (const feed of allFeeds) {
-      const name = feed.name;
-      if (name) {
-        map.set((feed as { id: string }).id, name);
+      // Fall back to URL when sync hasn't populated `name` yet (or the source RSS has no
+      // `<title>`) so each tile still shows provenance.
+      const label = feed.name ?? feed.url;
+      if (label) {
+        map.set((feed as { id: string }).id, label);
       }
     }
     return map;
@@ -73,8 +75,7 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
   }, [subject.posts]);
 
   // When the user removes a feed from the magazine via ObjectProperties, prune any
-  // curated posts whose source feed is no longer present. Posts without a known
-  // source feed (e.g. synced before `Post.feed` was added) are left alone.
+  // curated posts whose source feed is no longer present.
   useEffect(() => {
     const feedDxns = new Set(subject.feeds.map((ref) => ref.dxn.toString()));
     const orphanIds = new Set<string>();
@@ -96,7 +97,7 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
     });
   }, [subject, subject.feeds, subject.posts]);
 
-  const posts = useMemo(() => {
+  const posts = useMemo<TileData[]>(() => {
     const resolved: Subscription.Post[] = [];
     const seenDxn = new Set<string>();
     const seenLink = new Set<string>();
@@ -237,10 +238,11 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
     [id, showItem],
   );
 
-  const tileItems = useMemo(
+  const tileItems = useMemo<TileData[]>(
     () =>
       posts.map((post) => {
-        // Match the post's source feed by bare object id; `post.feed.dxn` is  local-id form, while `feedNamesById` is keyed by id directly.
+        // Match the post's source feed by bare object id; `post.feed.dxn` is local-id form,
+        // while `feedNamesById` is keyed by id directly.
         const feedId = post.feed ? (post.feed.dxn.toString().split(':').pop() ?? '') : '';
         return {
           post,
@@ -436,9 +438,7 @@ const applyPerFeedKeep = (magazine: Magazine.Magazine, db: Database.Database | u
     }
   }
 
-  // Group resolved posts by their source feed id. Posts without a known
-  // source feed (e.g. older posts from before `Post.feed` was added) end up
-  // in the `undefined` bucket and are kept unconditionally.
+  // Group resolved posts by their source feed id.
   const byFeedId = new Map<string | undefined, Array<{ ref: Ref.Ref<Subscription.Post>; post: Subscription.Post }>>();
   for (const pair of resolvedPairs) {
     const feedRefDxn = pair.post.feed?.dxn.toString();

--- a/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineTile.tsx
+++ b/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineTile.tsx
@@ -61,7 +61,11 @@ export const MagazineTile = ({ post, current, feedName, published, starTag, onOp
           <Card.Poster alt={post.title ?? 'Article'} image={post.imageUrl} fit='cover' classNames='rounded-t-xs' />
         )}
         <Card.Toolbar>
-          {post.title ? <Card.Title classNames='line-clamp-2'>{post.title}</Card.Title> : <div className='grow' />}
+          {post.title ? (
+            <Card.Title classNames='line-clamp-2 col-span-3 px-2'>{post.title}</Card.Title>
+          ) : (
+            <div className='col-span-3' />
+          )}
         </Card.Toolbar>
         <Card.Content>
           {post.snippet && (

--- a/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineTile.tsx
+++ b/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineTile.tsx
@@ -61,11 +61,9 @@ export const MagazineTile = ({ post, current, feedName, published, starTag, onOp
           <Card.Poster alt={post.title ?? 'Article'} image={post.imageUrl} fit='cover' classNames='rounded-t-xs' />
         )}
         <Card.Toolbar>
-          {post.title ? (
-            <Card.Title classNames='line-clamp-2 col-span-3 px-2'>{post.title}</Card.Title>
-          ) : (
-            <div className='col-span-3' />
-          )}
+          <Card.IconBlock />
+          {post.title ? <Card.Title classNames='line-clamp-2'>{post.title}</Card.Title> : <div />}
+          <Card.IconBlock />
         </Card.Toolbar>
         <Card.Content>
           {post.snippet && (
@@ -86,10 +84,10 @@ export const MagazineTile = ({ post, current, feedName, published, starTag, onOp
                 onClick={handleToggleStar}
               />
             </Card.IconBlock>
-            <Card.Text variant='description' classNames='grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2'>
+            <div className='grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 py-1.5 text-sm text-description overflow-hidden'>
               <span className='truncate'>{feedName ?? ''}</span>
               <span className='text-end shrink-0'>{published ?? ''}</span>
-            </Card.Text>
+            </div>
           </div>
         </Card.Content>
       </Card.Root>

--- a/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineToolbar.tsx
+++ b/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineToolbar.tsx
@@ -1,0 +1,103 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React, { type ComponentPropsWithoutRef, forwardRef } from 'react';
+
+import { Icon, Toolbar, useTranslation } from '@dxos/react-ui';
+
+import { meta } from '#meta';
+
+export type MagazineSort = 'date' | 'rank';
+
+export type CurateState = 'idle' | 'syncing' | 'curating';
+
+export type MagazineToolbarProps = ComponentPropsWithoutRef<typeof Toolbar.Root> & {
+  sort: MagazineSort;
+  onSortChange: (sort: MagazineSort) => void;
+  onlyStarred: boolean;
+  onOnlyStarredChange: (value: boolean) => void;
+  showArchived: boolean;
+  onShowArchivedChange: (value: boolean) => void;
+  state: CurateState;
+  curateDisabled: boolean;
+  curateTooltip?: string;
+  onClear: () => void;
+  onCurate: () => void;
+};
+
+// Forwards ref + spreads passthrough props so this component composes under `Panel.Toolbar asChild`.
+export const MagazineToolbar = forwardRef<HTMLDivElement, MagazineToolbarProps>((props, forwardedRef) => {
+  const {
+    sort,
+    onSortChange,
+    onlyStarred,
+    onOnlyStarredChange,
+    showArchived,
+    onShowArchivedChange,
+    state,
+    curateDisabled,
+    curateTooltip,
+    onClear,
+    onCurate,
+    ...rest
+  } = props;
+  const { t } = useTranslation(meta.id);
+
+  return (
+    <Toolbar.Root {...rest} ref={forwardedRef}>
+      <Toolbar.ToggleGroup
+        type='single'
+        value={sort}
+        onValueChange={(value) => {
+          if (value === 'date' || value === 'rank') {
+            onSortChange(value);
+          }
+        }}
+      >
+        <Toolbar.ToggleGroupItem value='date' aria-label={t('sort-by-date.label')} title={t('sort-by-date.label')}>
+          <Icon icon='ph--calendar--regular' size={4} />
+        </Toolbar.ToggleGroupItem>
+        <Toolbar.ToggleGroupItem value='rank' aria-label={t('sort-by-rank.label')} title={t('sort-by-rank.label')}>
+          <Icon icon='ph--list-numbers--regular' size={4} />
+        </Toolbar.ToggleGroupItem>
+      </Toolbar.ToggleGroup>
+      <Toolbar.ToggleGroup
+        type='single'
+        value={onlyStarred ? 'on' : ''}
+        onValueChange={(value) => onOnlyStarredChange(value === 'on')}
+      >
+        <Toolbar.ToggleGroupItem value='on' aria-label={t('only-starred.label')} title={t('only-starred.label')}>
+          <Icon icon={onlyStarred ? 'ph--star--fill' : 'ph--star--regular'} size={4} />
+        </Toolbar.ToggleGroupItem>
+      </Toolbar.ToggleGroup>
+      <Toolbar.ToggleGroup
+        type='single'
+        value={showArchived ? 'show' : ''}
+        onValueChange={(value) => onShowArchivedChange(value === 'show')}
+      >
+        <Toolbar.ToggleGroupItem value='show' aria-label={t('show-archived.label')} title={t('show-archived.label')}>
+          <Icon icon='ph--archive--regular' size={4} />
+        </Toolbar.ToggleGroupItem>
+      </Toolbar.ToggleGroup>
+      <Toolbar.Separator />
+      <Toolbar.IconButton
+        label={t('clear-magazine.label')}
+        icon='ph--eraser--regular'
+        iconOnly
+        disabled={state !== 'idle'}
+        onClick={onClear}
+      />
+      <Toolbar.IconButton
+        label={curateTooltip ?? t('curate.label')}
+        icon={state === 'idle' ? 'ph--sparkle--regular' : 'ph--circle-notch--regular'}
+        iconClassNames={state !== 'idle' ? 'animate-spin' : undefined}
+        iconOnly
+        disabled={curateDisabled}
+        onClick={onCurate}
+      />
+    </Toolbar.Root>
+  );
+});
+
+MagazineToolbar.displayName = 'MagazineToolbar';

--- a/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineToolbar.tsx
+++ b/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineToolbar.tsx
@@ -2,23 +2,28 @@
 // Copyright 2026 DXOS.org
 //
 
-import React, { type ComponentPropsWithoutRef, forwardRef } from 'react';
+import React from 'react';
 
 import { Icon, Toolbar, useTranslation } from '@dxos/react-ui';
+import { composable, composableProps } from '@dxos/ui-theme';
 
 import { meta } from '#meta';
 
 export type MagazineSort = 'date' | 'rank';
 
+/**
+ * Tile filter mode. Mutually exclusive — `default` shows everything except archived,
+ * `starred` filters to starred posts, `archived` shows only archived posts.
+ */
+export type MagazineView = 'default' | 'starred' | 'archived';
+
 export type CurateState = 'idle' | 'syncing' | 'curating';
 
-export type MagazineToolbarProps = ComponentPropsWithoutRef<typeof Toolbar.Root> & {
+export type MagazineToolbarProps = {
   sort: MagazineSort;
   onSortChange: (sort: MagazineSort) => void;
-  onlyStarred: boolean;
-  onOnlyStarredChange: (value: boolean) => void;
-  showArchived: boolean;
-  onShowArchivedChange: (value: boolean) => void;
+  view: MagazineView;
+  onViewChange: (view: MagazineView) => void;
   state: CurateState;
   curateDisabled: boolean;
   curateTooltip?: string;
@@ -26,26 +31,13 @@ export type MagazineToolbarProps = ComponentPropsWithoutRef<typeof Toolbar.Root>
   onCurate: () => void;
 };
 
-// Forwards ref + spreads passthrough props so this component composes under `Panel.Toolbar asChild`.
-export const MagazineToolbar = forwardRef<HTMLDivElement, MagazineToolbarProps>((props, forwardedRef) => {
-  const {
-    sort,
-    onSortChange,
-    onlyStarred,
-    onOnlyStarredChange,
-    showArchived,
-    onShowArchivedChange,
-    state,
-    curateDisabled,
-    curateTooltip,
-    onClear,
-    onCurate,
-    ...rest
-  } = props;
+export const MagazineToolbar = composable<HTMLDivElement, MagazineToolbarProps>((props, forwardedRef) => {
+  const { sort, onSortChange, view, onViewChange, state, curateDisabled, curateTooltip, onClear, onCurate, ...rest } =
+    props;
   const { t } = useTranslation(meta.id);
 
   return (
-    <Toolbar.Root {...rest} ref={forwardedRef}>
+    <Toolbar.Root {...composableProps(rest)} ref={forwardedRef}>
       <Toolbar.ToggleGroup
         type='single'
         value={sort}
@@ -64,19 +56,28 @@ export const MagazineToolbar = forwardRef<HTMLDivElement, MagazineToolbarProps>(
       </Toolbar.ToggleGroup>
       <Toolbar.ToggleGroup
         type='single'
-        value={onlyStarred ? 'on' : ''}
-        onValueChange={(value) => onOnlyStarredChange(value === 'on')}
+        value={view}
+        // Radix returns '' when the user toggles the active item off; treat that as 'default'.
+        onValueChange={(value) => {
+          if (value === 'starred' || value === 'archived') {
+            onViewChange(value);
+          } else {
+            onViewChange('default');
+          }
+        }}
       >
-        <Toolbar.ToggleGroupItem value='on' aria-label={t('only-starred.label')} title={t('only-starred.label')}>
-          <Icon icon={onlyStarred ? 'ph--star--fill' : 'ph--star--regular'} size={4} />
+        <Toolbar.ToggleGroupItem
+          value='starred'
+          aria-label={t('only-starred.label')}
+          title={t('only-starred.label')}
+        >
+          <Icon icon={view === 'starred' ? 'ph--star--fill' : 'ph--star--regular'} size={4} />
         </Toolbar.ToggleGroupItem>
-      </Toolbar.ToggleGroup>
-      <Toolbar.ToggleGroup
-        type='single'
-        value={showArchived ? 'show' : ''}
-        onValueChange={(value) => onShowArchivedChange(value === 'show')}
-      >
-        <Toolbar.ToggleGroupItem value='show' aria-label={t('show-archived.label')} title={t('show-archived.label')}>
+        <Toolbar.ToggleGroupItem
+          value='archived'
+          aria-label={t('show-archived.label')}
+          title={t('show-archived.label')}
+        >
           <Icon icon='ph--archive--regular' size={4} />
         </Toolbar.ToggleGroupItem>
       </Toolbar.ToggleGroup>

--- a/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineToolbar.tsx
+++ b/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineToolbar.tsx
@@ -66,11 +66,7 @@ export const MagazineToolbar = composable<HTMLDivElement, MagazineToolbarProps>(
           }
         }}
       >
-        <Toolbar.ToggleGroupItem
-          value='starred'
-          aria-label={t('only-starred.label')}
-          title={t('only-starred.label')}
-        >
+        <Toolbar.ToggleGroupItem value='starred' aria-label={t('only-starred.label')} title={t('only-starred.label')}>
           <Icon icon={view === 'starred' ? 'ph--star--fill' : 'ph--star--regular'} size={4} />
         </Toolbar.ToggleGroupItem>
         <Toolbar.ToggleGroupItem

--- a/packages/plugins/plugin-feed/src/operations/curate-magazine.ts
+++ b/packages/plugins/plugin-feed/src/operations/curate-magazine.ts
@@ -10,7 +10,7 @@ import { invariant } from '@dxos/invariant';
 import { Operation } from '@dxos/operation';
 
 import { type Magazine, Subscription } from '../types';
-import { extractImageUrls, makeSnippet, stripHtml } from '../util';
+import { extractImageUrls, htmlToMarkdown, makeSnippet } from '../util';
 import { CurateMagazine } from './definitions';
 
 /** Minimal queue surface needed by {@link curateMagazine}; exposed for testability. */
@@ -101,11 +101,11 @@ export const curateMagazine = async (
         continue;
       }
       const source = queuePost.description ?? '';
-      const text = stripHtml(source);
-      if (!text) {
+      const markdown = htmlToMarkdown(source);
+      if (!markdown) {
         continue;
       }
-      const snippet = makeSnippet(text);
+      const snippet = makeSnippet(markdown);
       const imageUrl = extractImageUrls(source)[0];
 
       // Resolve to the canonical space.db proxy (or register if new) so

--- a/packages/plugins/plugin-feed/src/operations/curate-magazine.ts
+++ b/packages/plugins/plugin-feed/src/operations/curate-magazine.ts
@@ -10,7 +10,7 @@ import { invariant } from '@dxos/invariant';
 import { Operation } from '@dxos/operation';
 
 import { type Magazine, Subscription } from '../types';
-import { extractImageUrls, htmlToMarkdown, makeSnippet } from '../util';
+import { extractImageUrls, makeSnippet, stripHtml } from '../util';
 import { CurateMagazine } from './definitions';
 
 /** Minimal queue surface needed by {@link curateMagazine}; exposed for testability. */
@@ -101,11 +101,13 @@ export const curateMagazine = async (
         continue;
       }
       const source = queuePost.description ?? '';
-      const markdown = htmlToMarkdown(source);
-      if (!markdown) {
+      // Snippet is rendered as plain text on the magazine tile, so strip HTML rather than
+      // converting to markdown — otherwise `**bold**` / `[link](url)` syntax leaks through.
+      const text = stripHtml(source);
+      if (!text) {
         continue;
       }
-      const snippet = makeSnippet(markdown);
+      const snippet = makeSnippet(text);
       const imageUrl = extractImageUrls(source)[0];
 
       // Resolve to the canonical space.db proxy (or register if new) so

--- a/packages/plugins/plugin-feed/src/util/extract.ts
+++ b/packages/plugins/plugin-feed/src/util/extract.ts
@@ -2,6 +2,8 @@
 // Copyright 2026 DXOS.org
 //
 
+import TurndownService from 'turndown';
+
 /**
  * Lightweight HTML helpers used by the Magazine curation flow.
  * Regex-based; deliberately avoids a parser dependency. Good enough for
@@ -51,6 +53,30 @@ export const stripHtml = (html: string): string => {
     .replace(/ *\n */g, '\n') // Trim spaces around newlines.
     .replace(/\n{3,}/g, '\n\n') // Collapse 3+ blank lines to a single blank line.
     .trim();
+};
+
+// Reused across calls — turndown's constructor isn't free.
+const turndownService = new TurndownService({
+  headingStyle: 'atx',
+  codeBlockStyle: 'fenced',
+  emDelimiter: '_',
+  bulletListMarker: '-',
+});
+
+/**
+ * Convert an HTML fragment to Markdown.
+ *
+ * RSS `<description>` payloads are usually entity-encoded HTML (`&lt;p&gt;...`); under
+ * fast-xml-parser stopNodes the entities aren't decoded at parse time, so they reach us
+ * as literal `&lt;p&gt;` and the like. Decode first, then run turndown — that way we
+ * preserve paragraph structure and links rather than spilling raw `<p>...</p>` into
+ * snippets and content. Returns an empty string on falsy input.
+ */
+export const htmlToMarkdown = (html: string): string => {
+  if (!html) {
+    return '';
+  }
+  return turndownService.turndown(decodeEntities(html)).trim();
 };
 
 /** Produce a snippet of approximately `length` characters, cut on a word boundary. */

--- a/packages/plugins/plugin-feed/src/util/extract.ts
+++ b/packages/plugins/plugin-feed/src/util/extract.ts
@@ -2,8 +2,6 @@
 // Copyright 2026 DXOS.org
 //
 
-import TurndownService from 'turndown';
-
 /**
  * Lightweight HTML helpers used by the Magazine curation flow.
  * Regex-based; deliberately avoids a parser dependency. Good enough for
@@ -34,13 +32,19 @@ const decodeEntities = (input: string): string =>
  * Strip HTML tags and decode common entities to produce plain text.
  * Block-level tag boundaries (paragraphs, divs, headings, list items, line breaks)
  * are converted to newlines so paragraph structure survives the stripping.
+ *
+ * Decodes entities up front so entity-encoded HTML (`&lt;p&gt;...&lt;/p&gt;` — common in
+ * RSS `<description>` payloads, especially under fast-xml-parser stopNodes) gets stripped
+ * the same as raw HTML. Without that, the encoded tags would survive stripping and only
+ * decode at the end, leaking literal `<p>` into the output.
  */
 export const stripHtml = (html: string): string => {
   if (!html) {
     return '';
   }
+  const decoded = decodeEntities(html);
   // Remove script/style blocks entirely.
-  const withoutScripts = html
+  const withoutScripts = decoded
     .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, ' ')
     .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, ' ');
   // Insert paragraph breaks at common block-level boundaries before stripping tags.
@@ -48,35 +52,11 @@ export const stripHtml = (html: string): string => {
     .replace(/<\s*br\s*\/?\s*>/gi, '\n')
     .replace(/<\/\s*(?:p|div|section|article|header|footer|aside|h[1-6]|li|ul|ol|blockquote|pre|tr)\s*>/gi, '\n\n');
   const withoutTags = withParagraphBreaks.replace(/<[^>]+>/g, '');
-  return decodeEntities(withoutTags)
+  return withoutTags
     .replace(/[\t\f\v ]+/g, ' ') // Collapse horizontal whitespace, preserve newlines.
     .replace(/ *\n */g, '\n') // Trim spaces around newlines.
     .replace(/\n{3,}/g, '\n\n') // Collapse 3+ blank lines to a single blank line.
     .trim();
-};
-
-// Reused across calls — turndown's constructor isn't free.
-const turndownService = new TurndownService({
-  headingStyle: 'atx',
-  codeBlockStyle: 'fenced',
-  emDelimiter: '_',
-  bulletListMarker: '-',
-});
-
-/**
- * Convert an HTML fragment to Markdown.
- *
- * RSS `<description>` payloads are usually entity-encoded HTML (`&lt;p&gt;...`); under
- * fast-xml-parser stopNodes the entities aren't decoded at parse time, so they reach us
- * as literal `&lt;p&gt;` and the like. Decode first, then run turndown — that way we
- * preserve paragraph structure and links rather than spilling raw `<p>...</p>` into
- * snippets and content. Returns an empty string on falsy input.
- */
-export const htmlToMarkdown = (html: string): string => {
-  if (!html) {
-    return '';
-  }
-  return turndownService.turndown(decodeEntities(html)).trim();
 };
 
 /** Produce a snippet of approximately `length` characters, cut on a word boundary. */

--- a/packages/plugins/plugin-feed/src/util/extract.ts
+++ b/packages/plugins/plugin-feed/src/util/extract.ts
@@ -11,7 +11,7 @@
 const DEFAULT_SNIPPET_LENGTH = 280;
 
 /** Decode numeric (decimal + hex) and a handful of common named HTML entities. */
-const decodeEntities = (input: string): string =>
+export const decodeEntities = (input: string): string =>
   input
     .replace(/&#x([0-9a-fA-F]+);/g, (_, hex: string) => {
       const cp = Number.parseInt(hex, 16);

--- a/packages/plugins/plugin-feed/src/util/feed-fetcher.test.ts
+++ b/packages/plugins/plugin-feed/src/util/feed-fetcher.test.ts
@@ -172,6 +172,37 @@ describe('FeedFetcher', () => {
       expect(result.posts[0].link).toBe('https://example.com/post-3');
     });
 
+    test('handles deeply nested HTML in description without exceeding parser limits', async ({ expect }) => {
+      // Build nested HTML 200 levels deep — well past fast-xml-parser's default 100-tag cap.
+      let nested = 'leaf';
+      for (let index = 0; index < 200; index++) {
+        nested = `<div>${nested}</div>`;
+      }
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Nested HTML Feed</title>
+    <description>Feed.</description>
+    <item>
+      <title>Nested Post</title>
+      <link>https://example.com/nested</link>
+      <description>${nested}</description>
+      <guid>nested-1</guid>
+    </item>
+  </channel>
+</rss>`;
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(xml),
+      });
+
+      const result = await fetchRss('https://example.com/rss');
+
+      expect(result.posts).toHaveLength(1);
+      expect(result.posts[0].title).toBe('Nested Post');
+      expect(result.posts[0].guid).toBe('nested-1');
+    });
+
     test('uses CORS proxy when provided', async ({ expect }) => {
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,

--- a/packages/plugins/plugin-feed/src/util/fetch-rss.ts
+++ b/packages/plugins/plugin-feed/src/util/fetch-rss.ts
@@ -41,7 +41,21 @@ export const fetchRss: FeedFetcher = async (url: string, { corsProxy }: FetchOpt
   const fetchUrl = corsProxy ? `${corsProxy}${encodeURIComponent(url)}` : url;
   const response = await fetch(fetchUrl);
   const xml = await response.text();
-  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_' });
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: '@_',
+    // RSS/Atom feeds frequently embed HTML (sometimes un-escaped, without CDATA) in content fields,
+    // which can blow past fast-xml-parser's default 100-tag nesting cap.
+    maxNestedTags: 10_000,
+    // Treat known HTML-bearing fields as opaque text so embedded markup isn't parsed as XML.
+    stopNodes: [
+      '*.description',
+      '*.summary',
+      '*.content',
+      '*.content:encoded',
+      '*.encoded',
+    ],
+  });
   const parsed = parser.parse(xml);
 
   const channel = parsed.rss?.channel ?? parsed.feed;

--- a/packages/plugins/plugin-feed/src/util/fetch-rss.ts
+++ b/packages/plugins/plugin-feed/src/util/fetch-rss.ts
@@ -48,7 +48,7 @@ export const fetchRss: FeedFetcher = async (url: string, { corsProxy }: FetchOpt
     // which can blow past fast-xml-parser's default 100-tag nesting cap.
     maxNestedTags: 10_000,
     // Treat known HTML-bearing fields as opaque text so embedded markup isn't parsed as XML.
-    stopNodes: ['*.description', '*.summary', '*.content', '*.content:encoded', '*.encoded'],
+    stopNodes: ['*.description', '*.summary', '*.content', '*.content:encoded'],
   });
   const parsed = parser.parse(xml);
 

--- a/packages/plugins/plugin-feed/src/util/fetch-rss.ts
+++ b/packages/plugins/plugin-feed/src/util/fetch-rss.ts
@@ -6,6 +6,7 @@ import { XMLParser } from 'fast-xml-parser';
 
 import { Subscription } from '#types';
 
+import { decodeEntities } from './extract';
 import { type FeedFetcher, type FetchOptions, type FetchResult } from './feed-fetcher';
 
 /**
@@ -13,13 +14,19 @@ import { type FeedFetcher, type FetchOptions, type FetchResult } from './feed-fe
  * fast-xml-parser yields objects like `{'#text': 'foo', '@_type': 'html'}` for
  * elements with attributes, and plain strings/numbers for text-only elements.
  * Returns undefined for nullish values.
+ *
+ * Entities are decoded explicitly: stopNode'd nodes (description / content /
+ * summary / content:encoded) are returned as raw text by fast-xml-parser,
+ * skipping its built-in entity decoding. Decoding here keeps callers from
+ * having to special-case those fields. For non-stopped nodes the decode is a
+ * no-op (the parser has already decoded entities).
  */
 const text = (value: unknown): string | undefined => {
   if (value == null) {
     return undefined;
   }
   if (typeof value === 'string') {
-    return value;
+    return decodeEntities(value);
   }
   if (typeof value === 'number' || typeof value === 'boolean') {
     return String(value);
@@ -27,7 +34,7 @@ const text = (value: unknown): string | undefined => {
   if (typeof value === 'object') {
     const t = (value as { '#text'?: unknown })['#text'];
     if (typeof t === 'string') {
-      return t;
+      return decodeEntities(t);
     }
     if (typeof t === 'number' || typeof t === 'boolean') {
       return String(t);

--- a/packages/plugins/plugin-feed/src/util/fetch-rss.ts
+++ b/packages/plugins/plugin-feed/src/util/fetch-rss.ts
@@ -48,13 +48,7 @@ export const fetchRss: FeedFetcher = async (url: string, { corsProxy }: FetchOpt
     // which can blow past fast-xml-parser's default 100-tag nesting cap.
     maxNestedTags: 10_000,
     // Treat known HTML-bearing fields as opaque text so embedded markup isn't parsed as XML.
-    stopNodes: [
-      '*.description',
-      '*.summary',
-      '*.content',
-      '*.content:encoded',
-      '*.encoded',
-    ],
+    stopNodes: ['*.description', '*.summary', '*.content', '*.content:encoded', '*.encoded'],
   });
   const parsed = parser.parse(xml);
 

--- a/packages/plugins/plugin-space/src/translations.ts
+++ b/packages/plugins/plugin-space/src/translations.ts
@@ -13,17 +13,6 @@ import { meta } from '#meta';
 export const translations = [
   {
     'en-US': {
-      [Collection.Collection.typename]: {
-        'typename.label': 'Collection',
-        'typename.label_zero': 'Collections',
-        'typename.label_one': 'Collection',
-        'typename.label_other': 'Collections',
-        'object-name.placeholder': 'New collection',
-        'add-object.label': 'Add collection',
-        'rename-object.label': 'Rename collection',
-        'delete-object.label': 'Delete collection',
-        'object-deleted.label': 'Collection deleted',
-      },
       [Type.getTypename(Type.PersistentType)]: {
         'typename.label': 'Type',
         'typename.label_zero': 'Types',
@@ -34,6 +23,17 @@ export const translations = [
         'rename-object.label': 'Rename type',
         'delete-object.label': 'Delete type',
         'object-deleted.label': 'Type deleted',
+      },
+      [Collection.Collection.typename]: {
+        'typename.label': 'Collection',
+        'typename.label_zero': 'Collections',
+        'typename.label_one': 'Collection',
+        'typename.label_other': 'Collections',
+        'object-name.placeholder': 'New collection',
+        'add-object.label': 'Add collection',
+        'rename-object.label': 'Rename collection',
+        'delete-object.label': 'Delete collection',
+        'object-deleted.label': 'Collection deleted',
       },
       [Event.Event.typename]: {
         'typename.label': 'Event',
@@ -276,7 +276,7 @@ export const translations = [
         'sync-upload.label': 'Upload',
         'sync-download.label': 'Download',
 
-        'types-section.label': 'Types',
+        'types-section.label': 'Database',
         'collections-section.label': 'Collections',
         'type-collection-all.label': 'All',
 

--- a/packages/ui/react-ui-syntax-highlighter/package.json
+++ b/packages/ui/react-ui-syntax-highlighter/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@dxos/ui-types": "workspace:*",
     "@dxos/util": "workspace:*",
+    "@radix-ui/react-context": "catalog:",
     "jsonpath-plus": "catalog:",
     "react-syntax-highlighter": "catalog:"
   },

--- a/packages/ui/react-ui-syntax-highlighter/src/Syntax/Syntax.tsx
+++ b/packages/ui/react-ui-syntax-highlighter/src/Syntax/Syntax.tsx
@@ -2,16 +2,9 @@
 // Copyright 2025 DXOS.org
 //
 
+import { createContextScope, type Scope } from '@radix-ui/react-context';
 import { JSONPath } from 'jsonpath-plus';
-import React, {
-  type FC,
-  type PropsWithChildren,
-  createContext,
-  forwardRef,
-  useContext,
-  useMemo,
-  useState,
-} from 'react';
+import React, { type FC, type PropsWithChildren, forwardRef, useMemo, useState } from 'react';
 
 import { Input, ScrollArea } from '@dxos/react-ui';
 import { composable, composableProps } from '@dxos/ui-theme';
@@ -24,7 +17,9 @@ import { SyntaxHighlighter } from '../SyntaxHighlighter';
 // Context
 //
 
-type SyntaxContextType = {
+const SYNTAX_NAME = 'Syntax';
+
+type SyntaxContextValue = {
   mode: 'text' | 'json';
   // Text mode.
   source?: string;
@@ -38,15 +33,10 @@ type SyntaxContextType = {
   replacer?: JsonReplacer;
 };
 
-const SyntaxContext = createContext<SyntaxContextType | null>(null);
+type ScopedProps<P> = P & { __scopeSyntax?: Scope };
 
-const useSyntaxContext = (consumerName: string): SyntaxContextType => {
-  const context = useContext(SyntaxContext);
-  if (!context) {
-    throw new Error(`\`${consumerName}\` must be used within \`Syntax.Root\`.`);
-  }
-  return context;
-};
+const [createSyntaxContext, createSyntaxScope] = createContextScope(SYNTAX_NAME);
+const [SyntaxProvider, useSyntaxContext] = createSyntaxContext<SyntaxContextValue>(SYNTAX_NAME);
 
 //
 // Root
@@ -60,6 +50,11 @@ type SyntaxRootProps = PropsWithChildren<{
   source?: string;
   // JSON mode (presence of the `data` prop selects JSON mode; `undefined` is still JSON).
   data?: any;
+  /**
+   * `JSON.stringify` replacer applied to `data`. Use the function form to follow domain
+   * references (e.g. ECHO refs) by returning a transformed value at the root call. Keeps
+   * this package free of any domain-specific knowledge.
+   */
   replacer?: JsonReplacer;
 }>;
 
@@ -69,8 +64,8 @@ type SyntaxRootProps = PropsWithChildren<{
  * text mode (which would trip `Syntax.Filter`'s JSON-only guard). Mode is chosen by prop
  * presence, not value.
  */
-const SyntaxRoot: FC<SyntaxRootProps> = (props) => {
-  const { children, language, source, replacer } = props;
+const SyntaxRoot: FC<ScopedProps<SyntaxRootProps>> = (props) => {
+  const { __scopeSyntax, children, language, source, replacer } = props;
   const isJson = 'data' in props;
   const data = props.data;
   const [filterText, setFilterText] = useState('');
@@ -86,22 +81,22 @@ const SyntaxRoot: FC<SyntaxRootProps> = (props) => {
     }
   }, [isJson, data, filterText]);
 
-  const context = useMemo<SyntaxContextType>(
-    () => ({
-      mode: isJson ? 'json' : 'text',
-      source,
-      language,
-      data,
-      filteredData,
-      filterText,
-      setFilterText,
-      filterError,
-      replacer,
-    }),
-    [isJson, source, language, data, filteredData, filterText, filterError, replacer],
+  return (
+    <SyntaxProvider
+      scope={__scopeSyntax}
+      mode={isJson ? 'json' : 'text'}
+      source={source}
+      language={language}
+      data={data}
+      filteredData={filteredData}
+      filterText={filterText}
+      setFilterText={setFilterText}
+      filterError={filterError}
+      replacer={replacer}
+    >
+      {children}
+    </SyntaxProvider>
   );
-
-  return <SyntaxContext.Provider value={context}>{children}</SyntaxContext.Provider>;
 };
 
 SyntaxRoot.displayName = SYNTAX_ROOT_NAME;
@@ -136,9 +131,9 @@ type SyntaxFilterProps = ComposableProps<{
 }>;
 
 /** JSONPath filter input. Only meaningful when `Syntax.Root` is in JSON mode. */
-const SyntaxFilter = forwardRef<HTMLInputElement, SyntaxFilterProps>(
-  ({ classNames, placeholder = 'JSONPath (e.g., $.graph.nodes)' }, forwardedRef) => {
-    const { mode, filterText, setFilterText, filterError } = useSyntaxContext(SYNTAX_FILTER_NAME);
+const SyntaxFilter = forwardRef<HTMLInputElement, ScopedProps<SyntaxFilterProps>>(
+  ({ __scopeSyntax, classNames, placeholder = 'JSONPath (e.g., $.graph.nodes)' }, forwardedRef) => {
+    const { mode, filterText, setFilterText, filterError } = useSyntaxContext(SYNTAX_FILTER_NAME, __scopeSyntax);
     if (mode !== 'json') {
       throw new Error(`\`${SYNTAX_FILTER_NAME}\` requires \`Syntax.Root\` to be in JSON mode (pass \`data\`).`);
     }
@@ -190,28 +185,30 @@ type SyntaxCodeProps = ComposableProps<{
 }>;
 
 /** Highlighted code leaf. Reads source/data from `Syntax.Root` context. */
-const SyntaxCode = composable<HTMLDivElement, SyntaxCodeProps>(({ testId, ...props }, forwardedRef) => {
-  const context = useSyntaxContext(SYNTAX_CODE_NAME);
-  const merged = composableProps(props, { classNames: 'py-1 px-2 text-sm' });
+const SyntaxCode = composable<HTMLDivElement, ScopedProps<SyntaxCodeProps>>(
+  ({ __scopeSyntax, testId, ...props }, forwardedRef) => {
+    const context = useSyntaxContext(SYNTAX_CODE_NAME, __scopeSyntax);
+    const merged = composableProps(props, { classNames: 'py-1 px-2 text-sm' });
 
-  if (context.mode === 'json') {
+    if (context.mode === 'json') {
+      return (
+        <JsonHighlighter
+          {...merged}
+          data={context.filteredData}
+          replacer={context.replacer}
+          testId={testId}
+          ref={forwardedRef}
+        />
+      );
+    }
+
     return (
-      <JsonHighlighter
-        {...merged}
-        data={context.filteredData}
-        replacer={context.replacer}
-        testId={testId}
-        ref={forwardedRef}
-      />
+      <SyntaxHighlighter {...merged} language={context.language} data-testid={testId} ref={forwardedRef}>
+        {context.source ?? ''}
+      </SyntaxHighlighter>
     );
-  }
-
-  return (
-    <SyntaxHighlighter {...merged} language={context.language} data-testid={testId} ref={forwardedRef}>
-      {context.source ?? ''}
-    </SyntaxHighlighter>
-  );
-});
+  },
+);
 
 SyntaxCode.displayName = SYNTAX_CODE_NAME;
 
@@ -226,5 +223,7 @@ export const Syntax = {
   Viewport: SyntaxViewport,
   Code: SyntaxCode,
 };
+
+export { createSyntaxScope };
 
 export type { SyntaxRootProps, SyntaxContentProps, SyntaxFilterProps, SyntaxViewportProps, SyntaxCodeProps };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19688,6 +19688,9 @@ importers:
       '@dxos/util':
         specifier: workspace:*
         version: link:../../common/util
+      '@radix-ui/react-context':
+        specifier: 'catalog:'
+        version: 1.1.1(@types/react@19.2.7)(react@19.2.3)
       jsonpath-plus:
         specifier: 'catalog:'
         version: 10.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9424,9 +9424,6 @@ importers:
       fast-xml-parser:
         specifier: '>=5.3.6'
         version: 5.7.1
-      turndown:
-        specifier: 'catalog:'
-        version: 7.2.1
     devDependencies:
       '@dxos/echo-db':
         specifier: workspace:*
@@ -9461,9 +9458,6 @@ importers:
       '@types/react-dom':
         specifier: ~19.2.3
         version: 19.2.3(@types/react@19.2.7)
-      '@types/turndown':
-        specifier: 'catalog:'
-        version: 5.0.5
       effect:
         specifier: 3.20.0
         version: 3.20.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9424,6 +9424,9 @@ importers:
       fast-xml-parser:
         specifier: '>=5.3.6'
         version: 5.7.1
+      turndown:
+        specifier: 'catalog:'
+        version: 7.2.1
     devDependencies:
       '@dxos/echo-db':
         specifier: workspace:*
@@ -9458,6 +9461,9 @@ importers:
       '@types/react-dom':
         specifier: ~19.2.3
         version: 19.2.3(@types/react@19.2.7)
+      '@types/turndown':
+        specifier: 'catalog:'
+        version: 5.0.5
       effect:
         specifier: 3.20.0
         version: 3.20.0


### PR DESCRIPTION
## Summary

- **plugin-feed** Magazine tiles: title spans the wide middle column instead of being squeezed into the icon column; footer uses a 2-col grid so the published date is right-aligned and the feed name truncates on the left.
- **plugin-feed** Snippets: new \`htmlToMarkdown\` helper (turndown + entity decode) replaces \`stripHtml\` in the curate path. With fast-xml-parser \`stopNodes\` keeping \`<description>\` payloads entity-encoded, the prior strip-then-decode order was leaking literal \`<p>\` tags into snippets.
- **plugin-feed** PostArticle: suppress the hero image when the article body already carries inline images, so the same picture doesn't render twice (e.g. Guardian gallery posts).
- **plugin-feed** Feed-name lookup falls back to \`feed.url\` while sync hasn't populated \`feed.name\` yet, so each tile always shows provenance.
- **plugin-feed** \`fetch-rss\` (earlier in this branch): bumped fast-xml-parser \`maxNestedTags\` and added \`stopNodes\` for HTML-bearing fields, fixing \"Maximum nested tags exceeded\" on real-world feeds.
- **react-ui-syntax-highlighter** (earlier): \`Syntax.Root\` migrated to the Radix \`createContextScope\` pattern; ref-resolution stays out of this package and is handled via the existing \`replacer\` prop.
- **plugin-debug** DebugObjectPanel: new \`createRefReplacer({ db, depth })\` factory — a \`JsonReplacer\` that walks the encoded form, inlines ECHO refs up to a configurable depth via \`db.getObjectById\`, and leaves deeper refs as \`{ \"/\": \"dxn:...\" }\`.

## Notes for reviewers

- Existing magazine posts curated before this branch retain their old stripped-text snippets; only re-curated posts get markdown.
- \`htmlToMarkdown\` runs \`decodeEntities\` first because fast-xml-parser \`stopNodes\` preserves the inner XML as raw text without entity decoding.
- \`createRefReplacer\` operates on the toJSON'd encoded form (not live \`Ref\` instances) because ECHO objects' \`toJSON\` runs before the \`JSON.stringify\` replacer is invoked.

## Test plan

- [ ] Create a magazine, add a feed, curate — verify tile title is full-width, footer shows feed name (or URL fallback) on the left and date on the right.
- [ ] Curate a feed whose \`<description>\` is entity-encoded HTML; confirm snippets render as clean prose, no literal \`<p>\` tags.
- [ ] Open a PostArticle for an article that has inline images in its content — hero should not appear above the body.
- [ ] In DebugObjectPanel, view a Magazine: \`feeds[]\` and \`instructions\` are inlined one level deep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline referenced objects for richer debug views.
  * Magazine toolbar with sort and view controls.

* **Bug Fixes**
  * HTML entity handling fixed so encoded markup in feeds strips correctly.

* **Improvements**
  * More robust RSS parsing for deeply nested/embedded HTML.
  * Smarter hero image logic hides hero if body contains images.
  * Better feed attribution fallback when names are missing.
  * Scoped syntax context for improved rendering.
  * Tile metadata and toolbar rendering refinements.

* **Tests**
  * Added RSS parsing test for deeply nested HTML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->