### PR TITLE
fix(plugin-space): restore legacy personal space fallbacks for older profiles

### DIFF
--- a/packages/plugins/plugin-space/src/capabilities/spaces-ready.ts
+++ b/packages/plugins/plugin-space/src/capabilities/spaces-ready.ts
@@ -36,7 +36,6 @@ const WAIT_FOR_OBJECT_TIMEOUT = 5_000;
 // E.g., dxn:echo:BA25QRC2FEWCSAMRP4RZL65LWJ7352CKE:01J00J9B45YHYSGZQTQMSKMGJ6
 const ECHO_DXN_LENGTH = 3 + 1 + 4 + 1 + 33 + 1 + 26;
 
-
 export default Capability.makeModule(
   Effect.fnUntraced(function* () {
     const subscriptions = new SubscriptionList();

--- a/packages/plugins/plugin-space/src/capabilities/spaces-ready.ts
+++ b/packages/plugins/plugin-space/src/capabilities/spaces-ready.ts
@@ -6,7 +6,13 @@ import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
-import { AppCapabilities, LayoutOperation, getPersonalSpace, getSpacePath } from '@dxos/app-toolkit';
+import {
+  AppCapabilities,
+  LayoutOperation,
+  getSpacePath,
+  resolvePersonalSpace,
+  setPersonalSpace,
+} from '@dxos/app-toolkit';
 import { SubscriptionList } from '@dxos/async';
 import { Filter, Obj } from '@dxos/echo';
 import { log } from '@dxos/log';
@@ -30,6 +36,7 @@ const WAIT_FOR_OBJECT_TIMEOUT = 5_000;
 // E.g., dxn:echo:BA25QRC2FEWCSAMRP4RZL65LWJ7352CKE:01J00J9B45YHYSGZQTQMSKMGJ6
 const ECHO_DXN_LENGTH = 3 + 1 + 4 + 1 + 33 + 1 + 26;
 
+
 export default Capability.makeModule(
   Effect.fnUntraced(function* () {
     const subscriptions = new SubscriptionList();
@@ -49,13 +56,17 @@ export default Capability.makeModule(
     //
 
     let personalSpaceInitialized = false;
-    const initializePersonalSpace = async (personalSpace: Space) => {
+    const initializePersonalSpace = async (personalSpace: Space, { fromCredential }: { fromCredential: boolean }) => {
       if (personalSpaceInitialized) {
         return;
       }
 
       await personalSpace.waitUntilReady();
       personalSpaceInitialized = true;
+
+      if (fromCredential) {
+        setPersonalSpace(personalSpace);
+      }
 
       // Check if deck state indicates we should switch to default space.
       const layout = registry.get(layoutAtom);
@@ -76,15 +87,15 @@ export default Capability.makeModule(
 
     // Try to find the personal space now, or subscribe to find it later.
     // Initialization is async (non-blocking) so subscriptions wire immediately.
-    const personalSpace = getPersonalSpace(client);
-    if (personalSpace) {
-      void initializePersonalSpace(personalSpace);
+    const resolved = resolvePersonalSpace(client);
+    if (resolved) {
+      void initializePersonalSpace(resolved.space, resolved);
     } else {
       subscriptions.add(
         client.spaces.subscribe(() => {
-          const personalSpace = getPersonalSpace(client);
-          if (personalSpace) {
-            void initializePersonalSpace(personalSpace);
+          const resolved = resolvePersonalSpace(client);
+          if (resolved) {
+            void initializePersonalSpace(resolved.space, resolved);
           }
         }).unsubscribe,
       );
@@ -134,12 +145,12 @@ export default Capability.makeModule(
     subscriptions.add(
       client.spaces.subscribe(async (spaces) => {
         // TODO(wittjosiah): Remove. This is a hack to be able to migrate the personal space properties.
-        const personalSpaceForMigration = getPersonalSpace(client);
+        const personalSpaceForMigration = resolvePersonalSpace(client);
         if (
-          personalSpaceForMigration &&
-          personalSpaceForMigration.state.get() === SpaceState.SPACE_REQUIRES_MIGRATION
+          personalSpaceForMigration?.space &&
+          personalSpaceForMigration.space.state.get() === SpaceState.SPACE_REQUIRES_MIGRATION
         ) {
-          await personalSpaceForMigration.internal.migrate();
+          await personalSpaceForMigration.space.internal.migrate();
         }
 
         spaces

--- a/packages/plugins/plugin-space/src/capabilities/spaces-ready.ts
+++ b/packages/plugins/plugin-space/src/capabilities/spaces-ready.ts
@@ -60,9 +60,10 @@ export default Capability.makeModule(
       if (personalSpaceInitialized) {
         return;
       }
+      // Set before any await so concurrent subscribe callbacks don't start a second initialization.
+      personalSpaceInitialized = true;
 
       await personalSpace.waitUntilReady();
-      personalSpaceInitialized = true;
 
       if (fromCredential) {
         setPersonalSpace(personalSpace);

--- a/packages/sdk/app-toolkit/src/personal-space.ts
+++ b/packages/sdk/app-toolkit/src/personal-space.ts
@@ -3,16 +3,73 @@
 //
 
 import { type Space } from '@dxos/client/echo';
+import { Obj } from '@dxos/echo';
 
 /** Space tag for the personal space. */
 export const PERSONAL_SPACE_TAG = 'org.dxos.space.personal';
+
+// TODO(wittjosiah): Remove once all profiles have tagged personal spaces (tags cannot be added retroactively).
+const DEFAULT_SPACE_KEY = '__DEFAULT__';
 
 /** Check if a space has a specific tag. */
 export const hasTag = (space: Pick<Space, 'tags'>, tag: string): boolean => space.tags.includes(tag);
 
 /** Check if a space is the personal space. */
-export const isPersonalSpace = (space: Pick<Space, 'tags'>): boolean => hasTag(space, PERSONAL_SPACE_TAG);
+export const isPersonalSpace = (space: Pick<Space, 'tags' | 'properties'>): boolean => {
+  if (hasTag(space, PERSONAL_SPACE_TAG)) {
+    return true;
+  }
+
+  // TODO(wittjosiah): Remove once all profiles have tagged personal spaces (tags cannot be added retroactively).
+  try {
+    return space.properties[DEFAULT_SPACE_KEY] === true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Mark a space as the personal space via legacy property.
+ * @deprecated Use `tags: [PERSONAL_SPACE_TAG]` when creating the space instead.
+ * TODO(wittjosiah): Remove once all profiles have tagged personal spaces (tags cannot be added retroactively).
+ */
+export const setPersonalSpace = (space: Space): void => {
+  Obj.change(space.properties, (properties) => {
+    (properties as any)[DEFAULT_SPACE_KEY] = true;
+  });
+};
 
 /** Find the personal space. */
 export const getPersonalSpace = (client: { spaces: { get(): Space[] } }): Space | undefined =>
   client.spaces.get().find((space) => isPersonalSpace(space));
+
+/**
+ * Find the personal space, falling back to the legacy `DefaultSpace` HALO credential for profiles
+ * that predate immutable space tags.
+ *
+ * Returns `{ space, fromCredential }` where `fromCredential: true` means the space was found via
+ * the old credential and `setPersonalSpace` should be called once the space is ready to persist
+ * the `__DEFAULT__` marker for future loads.
+ *
+ * TODO(wittjosiah): Remove once all profiles have tagged personal spaces (tags cannot be added retroactively).
+ */
+export const resolvePersonalSpace = (client: {
+  spaces: { get(): Space[]; get(id: any): Space | undefined };
+  halo: { queryCredentials(options: { type: string }): any[] };
+}): { space: Space; fromCredential: boolean } | undefined => {
+  const found = getPersonalSpace(client);
+  if (found) {
+    return { space: found, fromCredential: false };
+  }
+
+  const defaultSpaceCredential = client.halo.queryCredentials({
+    type: 'dxos.halo.credentials.DefaultSpace',
+  })[0];
+  if (!defaultSpaceCredential) {
+    return undefined;
+  }
+
+  const defaultSpaceId = defaultSpaceCredential.subject.assertion.spaceId;
+  const space = client.spaces.get(defaultSpaceId);
+  return space ? { space, fromCredential: true } : undefined;
+};

--- a/packages/sdk/app-toolkit/src/personal-space.ts
+++ b/packages/sdk/app-toolkit/src/personal-space.ts
@@ -69,7 +69,10 @@ export const resolvePersonalSpace = (client: {
     return undefined;
   }
 
-  const defaultSpaceId = defaultSpaceCredential.subject.assertion.spaceId;
+  const defaultSpaceId = defaultSpaceCredential?.subject?.assertion?.spaceId;
+  if (typeof defaultSpaceId !== 'string') {
+    return undefined;
+  }
   const space = client.spaces.get(defaultSpaceId);
   return space ? { space, fromCredential: true } : undefined;
 };


### PR DESCRIPTION
## Summary

- Restores the `__DEFAULT__` property fallback in `isPersonalSpace` for profiles whose personal space predates immutable space tags
- Restores the `DefaultSpace` HALO credential lookup (`resolvePersonalSpace`) for the oldest profiles
- Consolidates all legacy migration logic into `personal-space.ts` with consistent TODOs; `spaces-ready.ts` has no legacy logic of its own

## Background

`c4d6a73994` (`#10899`) removed the legacy fallbacks for identifying a personal space on older profiles. Profiles created before immutable space tags were introduced (`#10887`) have no `PERSONAL_SPACE_TAG` on their personal space. After `#10899`, `getPersonalSpace()` returns `undefined` for these profiles, and the spaces connector at `spaces.ts:122` silently returns an empty graph — causing all spaces to disappear for older labs profiles. New (incognito) profiles are unaffected since `identity-created.ts` passes `tags: [PERSONAL_SPACE_TAG]` at creation time.

## What changed

**`packages/sdk/app-toolkit/src/personal-space.ts`**
- `isPersonalSpace` checks both `PERSONAL_SPACE_TAG` tag and legacy `space.properties.__DEFAULT__ === true`
- `setPersonalSpace` restored (writes `__DEFAULT__: true` after `waitUntilReady()` when space was found via credential)
- `resolvePersonalSpace` moved here (previously local to `spaces-ready.ts`) — two-tier lookup: tag/property first, then `DefaultSpace` HALO credential

**`packages/plugins/plugin-space/src/capabilities/spaces-ready.ts`**
- Imports `resolvePersonalSpace` + `setPersonalSpace` from `@dxos/app-toolkit`; no legacy logic inline

All TODOs read: *"Remove once all profiles have tagged personal spaces (tags cannot be added retroactively)."*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent personal-space initialization races for more reliable startup.
  * Improved persistence to avoid unintended overwrites during initialization.

* **Refactor**
  * Enhanced personal-space resolution to support both modern tags and legacy credential-based markers.
  * Updated migration handling to work with the resolved personal-space shape for smoother upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->