### PR TITLE
fix(publish-tauri): fix iOS upload timeout and make it non-blocking for release

### DIFF
--- a/.github/workflows/publish-tauri.yaml
+++ b/.github/workflows/publish-tauri.yaml
@@ -418,7 +418,7 @@ jobs:
           APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Notify Discord on iOS build failure
-        if: failure()
+        if: failure() || cancelled()
         env:
           DX_DISCORD_WEBHOOK_URL: ${{ secrets.DX_DISCORD_WEBHOOK_URL }}
           REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/publish-tauri.yaml
+++ b/.github/workflows/publish-tauri.yaml
@@ -293,6 +293,10 @@ jobs:
 
     runs-on: depot-macos-latest
 
+    timeout-minutes: 90
+
+    continue-on-error: true
+
     steps:
       - uses: actions/checkout@v5
         with:
@@ -389,12 +393,13 @@ jobs:
           NODE_OPTIONS: '--max_old_space_size=12288'
 
       - name: Upload assets to CN
+        timeout-minutes: 30
         uses: ./.github/actions/cn-release
         with:
           api-key: ${{ secrets.CN_API_KEY }}
           application: ${{ env.CN_APPLICATION }}
           command: upload
-          working-directory: ./packages/apps/composer-app/
+          working-directory: ./packages/apps/composer-app/src-tauri/
 
       # https://tauri.app/distribute/app-store/#ios
       - name: Upload assets to App Store Connect

--- a/.github/workflows/publish-tauri.yaml
+++ b/.github/workflows/publish-tauri.yaml
@@ -401,15 +401,6 @@ jobs:
           command: upload
           working-directory: ./packages/apps/composer-app/src-tauri/
 
-      - name: Notify Discord on iOS build failure
-        if: failure()
-        run: |
-          curl -s -X POST "$DX_DISCORD_WEBHOOK_URL" \
-            -H "Content-Type: application/json" \
-            -d "{\"content\": \":warning: **build_tauri_ios** failed on \`${{ github.ref_name }}\`\\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"
-        env:
-          DX_DISCORD_WEBHOOK_URL: ${{ secrets.DX_DISCORD_WEBHOOK_URL }}
-
       # https://tauri.app/distribute/app-store/#ios
       - name: Upload assets to App Store Connect
         # TODO(wittjosiah): Switch to staging? Need to figure out TestFlight -> App Store release process.
@@ -425,6 +416,19 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Notify Discord on iOS build failure
+        if: failure()
+        env:
+          DX_DISCORD_WEBHOOK_URL: ${{ secrets.DX_DISCORD_WEBHOOK_URL }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          payload=$(jq -nc --arg ref "$REF_NAME" --arg url "$RUN_URL" \
+            '{content: (":warning: **build_tauri_ios** failed on `" + $ref + "`\nRun: " + $url)}')
+          curl -sS -X POST "$DX_DISCORD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$payload"
 
   publish_tauri:
     needs:

--- a/.github/workflows/publish-tauri.yaml
+++ b/.github/workflows/publish-tauri.yaml
@@ -401,6 +401,15 @@ jobs:
           command: upload
           working-directory: ./packages/apps/composer-app/src-tauri/
 
+      - name: Notify Discord on iOS build failure
+        if: failure()
+        run: |
+          curl -s -X POST "$DX_DISCORD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "{\"content\": \":warning: **build_tauri_ios** failed on \`${{ github.ref_name }}\`\\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"
+        env:
+          DX_DISCORD_WEBHOOK_URL: ${{ secrets.DX_DISCORD_WEBHOOK_URL }}
+
       # https://tauri.app/distribute/app-store/#ios
       - name: Upload assets to App Store Connect
         # TODO(wittjosiah): Switch to staging? Need to figure out TestFlight -> App Store release process.


### PR DESCRIPTION
## Summary

- **Fix root cause of timeout**: The `Upload assets to CN` step in `build_tauri_ios` was using `working-directory: ./packages/apps/composer-app/` — a much broader path than the desktop build (which uses `src-tauri/`). This caused the CrabNebula CLI to scan and upload the entire app directory tree, leading to the observed 5h 42m timeout.
- **Add timeouts**: `timeout-minutes: 90` on the job and `timeout-minutes: 30` on the upload step so runaway uploads are caught early rather than consuming 6 hours.
- **Non-blocking**: Added `continue-on-error: true` to `build_tauri_ios` so `publish_tauri` still runs and the desktop release is published even if the iOS job fails.

## Test plan

- [ ] Trigger the workflow on a `labs`/`tauri` branch and confirm the iOS upload completes in a reasonable time
- [ ] Confirm `publish_tauri` runs even if `build_tauri_ios` fails

https://claude.ai/code/session_0129FMdDdxN3u37zs8TRQcVn

---
_Generated by [Claude Code](https://claude.ai/code/session_0129FMdDdxN3u37zs8TRQcVn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased timeout for the iOS build job to reduce premature failures.
  * Added a stricter timeout for the iOS asset upload step and corrected its upload location.
  * iOS build is now allowed to continue on error so the overall workflow can proceed.
  * Conditional notification added to alert when the iOS job fails or is cancelled, including branch and run info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->