### PR TITLE
fix(composer-app): proxy /api/rss in production worker

### DIFF
--- a/packages/apps/composer-app/src/functions/_worker.ts
+++ b/packages/apps/composer-app/src/functions/_worker.ts
@@ -69,6 +69,82 @@ const handleFeedbackLogs = async (request: Request, env: Env): Promise<Response>
   });
 };
 
+const RSS_MAX_BODY_SIZE = 8 * 1024 * 1024; // 8MB.
+const RSS_FETCH_TIMEOUT_MS = 15_000;
+
+/** Handle /api/rss?url=<feed-url> — server-side fetch to bypass CORS for RSS/Atom feeds. */
+const handleRssProxy = async (request: Request): Promise<Response> => {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return new Response('Method not allowed', { status: 405 });
+  }
+
+  // Restrict to same-origin / known origins to avoid being abused as an open proxy.
+  // Same-origin GETs typically omit Origin; allow when absent or when a known origin is set.
+  const origin = request.headers.get('Origin');
+  if (origin && !ALLOWED_ORIGINS.has(origin)) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  const url = new URL(request.url);
+  const feedUrl = url.searchParams.get('url');
+  if (!feedUrl) {
+    return new Response('Missing url parameter', { status: 400 });
+  }
+
+  let parsedFeedUrl: URL;
+  try {
+    parsedFeedUrl = new URL(feedUrl);
+  } catch {
+    return new Response('Invalid url parameter', { status: 400 });
+  }
+  if (parsedFeedUrl.protocol !== 'http:' && parsedFeedUrl.protocol !== 'https:') {
+    return new Response('Invalid url protocol', { status: 400 });
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), RSS_FETCH_TIMEOUT_MS);
+  try {
+    const upstream = await fetch(parsedFeedUrl.toString(), {
+      headers: { Accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml, */*' },
+      signal: controller.signal,
+    });
+
+    const contentLength = Number(upstream.headers.get('content-length') ?? 0);
+    if (contentLength > RSS_MAX_BODY_SIZE) {
+      return new Response('Payload too large', { status: 413 });
+    }
+
+    // Cap response size during streaming as well, in case Content-Length is missing or false.
+    let byteCount = 0;
+    let sizeExceeded = false;
+    const sizeCap = new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, sink) {
+        byteCount += chunk.byteLength;
+        if (byteCount > RSS_MAX_BODY_SIZE) {
+          sizeExceeded = true;
+          sink.error(new Error('Payload too large'));
+        } else {
+          sink.enqueue(chunk);
+        }
+      },
+    });
+
+    const contentType = upstream.headers.get('content-type') ?? 'application/xml';
+    const headers: Record<string, string> = { 'content-type': contentType };
+    if (upstream.body) {
+      upstream.body.pipeTo(sizeCap.writable).catch(() => {});
+    }
+    return new Response(upstream.body ? sizeCap.readable : null, {
+      status: sizeExceeded ? 413 : upstream.status,
+      headers,
+    });
+  } catch (error) {
+    return new Response(`Bad gateway: ${String(error)}`, { status: 502 });
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
 const OTEL_PREFIX = '/api/otel';
 const OTEL_SIGNALS = new Set(['/v1/traces', '/v1/logs', '/v1/metrics']);
 
@@ -171,6 +247,10 @@ const handler: ExportedHandler<Env> = {
     // API routes.
     if (url.pathname === '/api/feedback-logs') {
       return handleFeedbackLogs(request, env);
+    }
+
+    if (url.pathname === '/api/rss') {
+      return handleRssProxy(request);
     }
 
     // OTel ingestion proxy.

--- a/packages/apps/composer-app/src/functions/_worker.ts
+++ b/packages/apps/composer-app/src/functions/_worker.ts
@@ -72,7 +72,20 @@ const handleFeedbackLogs = async (request: Request, env: Env): Promise<Response>
 const RSS_MAX_BODY_SIZE = 8 * 1024 * 1024; // 8MB.
 const RSS_FETCH_TIMEOUT_MS = 15_000;
 
-/** Handle /api/rss?url=<feed-url> — server-side fetch to bypass CORS for RSS/Atom feeds. */
+/**
+ * Handle /api/rss?url=<feed-url> — server-side fetch to bypass CORS for RSS/Atom feeds.
+ *
+ * A proxy is required for the general case: the browser's same-origin policy blocks
+ * cross-origin `fetch()` of any response that doesn't send `Access-Control-Allow-Origin`,
+ * and RSS/Atom feeds are overwhelmingly served by CMSes (WordPress, Substack, news sites,
+ * etc.) that don't set CORS headers, so a direct browser fetch fails before the body is
+ * even read. Alternatives considered: (1) try direct, fall back to proxy — saves a hop
+ * for CORS-friendly feeds but every "no-CORS" feed pays a wasted round-trip and a console
+ * error before the fallback runs; (2) `mode: 'no-cors'` — the response becomes opaque, the
+ * body is unreadable; (3) move the fetcher out of the browser entirely (scheduled
+ * worker/edge function) — cleanest long-term but a much bigger change. We always proxy
+ * for simplicity; the cost is a hop and some Worker CPU.
+ */
 const handleRssProxy = async (request: Request): Promise<Response> => {
   if (request.method !== 'GET' && request.method !== 'HEAD') {
     return new Response('Method not allowed', { status: 405 });
@@ -104,7 +117,9 @@ const handleRssProxy = async (request: Request): Promise<Response> => {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), RSS_FETCH_TIMEOUT_MS);
   try {
+    // Forward the original method so HEAD probes don't download the full body upstream.
     const upstream = await fetch(parsedFeedUrl.toString(), {
+      method: request.method,
       headers: { Accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml, */*' },
       signal: controller.signal,
     });
@@ -114,28 +129,35 @@ const handleRssProxy = async (request: Request): Promise<Response> => {
       return new Response('Payload too large', { status: 413 });
     }
 
-    // Cap response size during streaming as well, in case Content-Length is missing or false.
-    let byteCount = 0;
-    let sizeExceeded = false;
-    const sizeCap = new TransformStream<Uint8Array, Uint8Array>({
-      transform(chunk, sink) {
-        byteCount += chunk.byteLength;
-        if (byteCount > RSS_MAX_BODY_SIZE) {
-          sizeExceeded = true;
-          sink.error(new Error('Payload too large'));
-        } else {
-          sink.enqueue(chunk);
-        }
-      },
-    });
-
     const contentType = upstream.headers.get('content-type') ?? 'application/xml';
     const headers: Record<string, string> = { 'content-type': contentType };
-    if (upstream.body) {
-      upstream.body.pipeTo(sizeCap.writable).catch(() => {});
+
+    // For HEAD or empty bodies, return immediately with the upstream status — no body to cap.
+    if (request.method === 'HEAD' || !upstream.body) {
+      return new Response(null, { status: upstream.status, headers });
     }
-    return new Response(upstream.body ? sizeCap.readable : null, {
-      status: sizeExceeded ? 413 : upstream.status,
+
+    // Buffer the body up to the cap so the response status can be decided deterministically
+    // (a TransformStream-based cap can't influence Response.status, since Response is
+    // constructed synchronously before any chunks have flowed through).
+    const reader = upstream.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let byteCount = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      byteCount += value.byteLength;
+      if (byteCount > RSS_MAX_BODY_SIZE) {
+        await reader.cancel();
+        return new Response('Payload too large', { status: 413 });
+      }
+      chunks.push(value);
+    }
+
+    return new Response(new Blob(chunks as BlobPart[]), {
+      status: upstream.status,
       headers,
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- The `/api/rss` proxy used by `plugin-feed` to bypass RSS CORS was only wired up as Vite dev middleware (`packages/apps/composer-app/vite.config.ts`). In deployed environments (labs / staging / prod) the request fell through to `env.ASSETS.fetch()` and returned the SPA's `index.html`, causing `fetchRss()` to throw `Unrecognized feed format` when clicking *Curate*.
- Add an `/api/rss` route to the Cloudflare Pages Functions worker (`_worker.ts`) that mirrors the dev middleware: `GET ?url=<feed>` proxies the upstream feed server-side.
- Hardened against open-proxy abuse: origin allowlist (when an `Origin` header is present), `http(s)` protocol check, 8MB streaming body cap, 15s upstream timeout.

## Test plan
- [ ] Deploy to labs and verify *Curate* on an RSS/Atom feed (e.g. `https://www.theregister.com/software/ai_ml/headlines.atom`) succeeds end-to-end.
- [ ] `curl -I https://labs.composer.space/api/rss?url=https%3A%2F%2Fwww.theregister.com%2Fsoftware%2Fai_ml%2Fheadlines.atom` returns the upstream feed `Content-Type` (not `text/html`).
- [ ] Local dev (`moon run composer-app:serve`) still works (Vite middleware path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a server-side RSS/Atom feed proxy endpoint (/api/rss) to bypass browser CORS for external feeds. Includes URL validation, optional origin allowlisting, request timeout protection, response size limits, HEAD support, and robust upstream error handling for reliable feed retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->