### PR TITLE
fix(client-services): preserve space tags during identity recovery

### DIFF
--- a/packages/sdk/client-services/src/packlets/services/service-context.ts
+++ b/packages/sdk/client-services/src/packlets/services/service-context.ts
@@ -442,6 +442,7 @@ export class ServiceContext extends Resource {
           await this.dataSpaceManager.acceptSpace(this._ctx, {
             spaceKey: assertion.spaceKey,
             genesisFeedKey: assertion.genesisFeedKey,
+            tags: assertion.tags,
           });
         } catch (err) {
           log.catch(err);


### PR DESCRIPTION
## Summary

- `_deviceSpaceSync.processCredential` now forwards `assertion.tags` from the `SpaceMember` credential into `acceptSpace`, so recovered spaces keep the tags they were created with (e.g. `org.dxos.space.personal`).

## Background

`SpaceMetadata.tags` is per-device local metadata, not part of the space data feed, so a freshly recovered device starts with an empty tag list for every space. The tags are already embedded in the `SpaceMember` credential by `createAdmissionCredentials`, so this is a one-line forward.

Without the fix, anything that gates on `getPersonalSpace()` / `isPersonalSpace()` silently breaks after identity recovery — most visibly, the graph builder waits for the personal space before rendering siblings, so the sidebar stays empty.

## Test plan

- [ ] Recover identity on a fresh browser; confirm the personal space resolves and the sidebar populates as expected.
- [ ] Confirm pre-existing spaces created with explicit tags also retain them after recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Credential assertion tags are now properly included when accepting spaces in DataSpace operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->