### PR TITLE
feat(app-toolkit): add SpaceArticle role and migrate space-scoped containers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@
 ## Workflow
 
 - Never work on `main`
-  - Before working on code, suggest to the user a worktree name then create the worktree using this or the name provided by the user (adding the `claude/` prefix).
+  - Before working on code, suggest to the user a worktree name then create the worktree using this or the name provided by the user (adding the agent-name prefix, e.g., `claude/`).
   - When creating worktrees/branches, use a short (2-4 word) descriptive title (kebab-case) prefixed with the agent name (e.g., `claude/add-auth-to-client`).
   - Worktrees must be created inside the main repo (e.g., `.claude/worktrees/<branch-short-name>`).
   - If there are unstaged changes, stash these and move them into the worktree.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,10 +61,12 @@
 
 ## Workflow
 
-- Never work on main; if not already in a worktree, create a new git worktree for the branch you are working on.
-- IMPORTANT: Do not change the branch or worktree after you have started unless you are instructed to directly by the user.
-- When creating worktrees/branches, use a short (2-4 word) descriptive title (kebab-case) prefixed with the agent name (e.g., `claude/add-auth-to-client`).
-- Worktrees must be created inside the main repo (e.g., `.claude/worktrees/<branch-short-name>`).
+- Never work on `main`
+  - Before working on code, suggest to the user a worktree name then create the worktree using this or the name provided by the user (adding the `claude/` prefix).
+  - When creating worktrees/branches, use a short (2-4 word) descriptive title (kebab-case) prefixed with the agent name (e.g., `claude/add-auth-to-client`).
+  - Worktrees must be created inside the main repo (e.g., `.claude/worktrees/<branch-short-name>`).
+  - If there are unstaged changes, stash these and move them into the worktree.
+  - IMPORTANT: Do not change the branch or worktree name after you have started unless you are instructed to directly by the user.
 - Check `moon.yml` for available package tasks
 - Run linter at natural stopping points
 - Confirm work complete before final build/lint check

--- a/packages/plugins/plugin-assistant/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-assistant/src/capabilities/react-surface.tsx
@@ -139,7 +139,14 @@ export default Capability.makeModule(() =>
       Surface.create({
         id: 'status',
         role: 'status-indicator',
-        component: () => <TriggerStatus />,
+        component: () => {
+          const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
+
+          return <TriggerStatus role='status-indicator' space={space} />;
+        },
       }),
       Surface.create({
         id: 'prompts',

--- a/packages/plugins/plugin-assistant/src/containers/PromptList/PromptList.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/PromptList/PromptList.stories.tsx
@@ -63,7 +63,7 @@ const DefaultStory = () => {
         <PromptList subject={subject} role='toolbar-input' attendableId='story' />
       </Panel.Toolbar>
       <Panel.Content>
-        <TracePanel space={space} />
+        <TracePanel role='article' space={space} attendableId={space.id} />
       </Panel.Content>
     </Panel.Root>
   );

--- a/packages/plugins/plugin-assistant/src/containers/TracePanel/TracePanel.stories.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/TracePanel/TracePanel.stories.tsx
@@ -195,7 +195,7 @@ const DefaultStory = () => {
         </Toolbar.Root>
       </Panel.Toolbar>
       <Panel.Content asChild>
-        <TracePanel space={space} />
+        <TracePanel role='article' space={space} attendableId={space.id} />
       </Panel.Content>
     </Panel.Root>
   );

--- a/packages/plugins/plugin-assistant/src/containers/TracePanel/TracePanel.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/TracePanel/TracePanel.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useMemo } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
 import { LayoutOperation } from '@dxos/app-toolkit';
+import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { Filter, Query } from '@dxos/echo';
 import { AtomQuery } from '@dxos/echo-atom';
 import { Trace } from '@dxos/functions';
@@ -23,9 +24,7 @@ import { composable, mx } from '@dxos/ui-theme';
 import { ProcessTree } from '../../components';
 import { buildExecutionGraph } from './execution-graph';
 
-export type TracePanelProps = {
-  space: Space;
-};
+export type TracePanelProps = AppSurface.SpaceArticleProps;
 
 export const TracePanel = composable<HTMLDivElement, TracePanelProps>(({ space, ...props }, forwardedRef) => {
   const { invokePromise } = useOperationInvoker();

--- a/packages/plugins/plugin-assistant/src/containers/TriggerStatus/TriggerStatus.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/TriggerStatus/TriggerStatus.tsx
@@ -4,11 +4,11 @@
 
 import React, { useMemo } from 'react';
 
-import { useActiveSpace } from '@dxos/app-toolkit/ui';
+import { AppSurface } from '@dxos/app-toolkit/ui';
 import { type InvocationsState } from '@dxos/functions-runtime';
 import { useTriggerRuntimeControls } from '@dxos/plugin-automation/hooks';
 import { StatusBar } from '@dxos/plugin-status-bar';
-import { useObject, type Space } from '@dxos/react-client/echo';
+import { useObject } from '@dxos/react-client/echo';
 import { IconButton, Popover, useTranslation } from '@dxos/react-ui';
 
 import { meta } from '#meta';
@@ -41,16 +41,9 @@ const getIconClassNames = (state: TriggerStatusState): string | undefined => {
   }
 };
 
-export const TriggerStatus = () => {
-  const space = useActiveSpace();
-  if (!space) {
-    return null;
-  }
+export type SpaceStatusProps = AppSurface.SpaceArticleProps;
 
-  return <SpaceStatusMain space={space} />;
-};
-
-const SpaceStatusMain = ({ space }: { space: Space }) => {
+export const SpaceStatus = ({ space }: SpaceStatusProps) => {
   const { t } = useTranslation(meta.id);
   const { state } = useTriggerRuntimeControls(space.db);
   const isEnabled = state?.enabled ?? false;
@@ -134,5 +127,3 @@ const TriggerStatusPopover = ({
     </div>
   );
 };
-
-export default TriggerStatus;

--- a/packages/plugins/plugin-assistant/src/containers/TriggerStatus/index.ts
+++ b/packages/plugins/plugin-assistant/src/containers/TriggerStatus/index.ts
@@ -2,4 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-export { TriggerStatus as default } from './TriggerStatus';
+export { SpaceStatus, SpaceStatus as default } from './TriggerStatus';

--- a/packages/plugins/plugin-automation/src/containers/AutomationSettings/AutomationSettings.tsx
+++ b/packages/plugins/plugin-automation/src/containers/AutomationSettings/AutomationSettings.tsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 
+import { AppSurface } from '@dxos/app-toolkit/ui';
 import { useTranslation } from '@dxos/react-ui';
 import { Settings } from '@dxos/react-ui-form';
 
@@ -12,7 +13,9 @@ import { meta } from '#meta';
 import { AutomationPanel, type AutomationPanelProps } from '../../components/AutomationPanel';
 import { TriggersSettings } from '../TriggerSettings';
 
-export const AutomationSettings = (props: AutomationPanelProps) => {
+export type AutomationSettingsProps = AppSurface.SpaceArticleProps<Omit<AutomationPanelProps, 'space'>>;
+
+export const AutomationSettings = (props: AutomationSettingsProps) => {
   const { t } = useTranslation(meta.id);
   return (
     <Settings.Viewport>

--- a/packages/plugins/plugin-automation/src/containers/FunctionsContainer/FunctionsContainer.tsx
+++ b/packages/plugins/plugin-automation/src/containers/FunctionsContainer/FunctionsContainer.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { type Space } from '@dxos/react-client/echo';
+import { AppSurface } from '@dxos/app-toolkit/ui';
 import { useTranslation } from '@dxos/react-ui';
 import { Settings } from '@dxos/react-ui-form';
 
@@ -13,7 +13,7 @@ import { meta } from '#meta';
 import { FunctionsPanel } from '../../components/FunctionsPanel';
 import { FunctionsRegistry } from '../../components/FunctionsRegistry';
 
-export const FunctionsContainer = ({ space }: { space: Space }) => {
+export const FunctionsContainer = ({ space }: AppSurface.SpaceArticleProps) => {
   const { t } = useTranslation(meta.id);
   return (
     <Settings.Viewport>

--- a/packages/plugins/plugin-daily-summary/src/containers/DailySummarySettings/DailySummarySettings.tsx
+++ b/packages/plugins/plugin-daily-summary/src/containers/DailySummarySettings/DailySummarySettings.tsx
@@ -4,7 +4,7 @@
 
 import React, { useCallback, useMemo } from 'react';
 
-import type { Space } from '@dxos/client/echo';
+import { AppSurface } from '@dxos/app-toolkit/ui';
 import { Filter, Ref } from '@dxos/echo';
 import { Trigger } from '@dxos/functions';
 import { Operation } from '@dxos/operation';
@@ -15,11 +15,7 @@ import { Settings } from '@dxos/react-ui-form';
 import { GenerateSummary } from '#blueprints';
 import { meta } from '#meta';
 
-export type DailySummarySettingsProps = {
-  space: Space;
-};
-
-export const DailySummarySettings = ({ space }: DailySummarySettingsProps) => {
+export const DailySummarySettings = ({ space }: AppSurface.SpaceArticleProps) => {
   const { t } = useTranslation(meta.id);
 
   const triggers = useQuery(space.db, Filter.type(Trigger.Trigger));

--- a/packages/plugins/plugin-debug/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-debug/src/capabilities/react-surface.tsx
@@ -75,8 +75,6 @@ const isGraphDebug = (data: any): data is GraphDebug => {
   );
 };
 
-const useCurrentSpace = useActiveSpace;
-
 type ReactSurfaceOptions = {
   logBuffer: LogBuffer;
 };
@@ -175,7 +173,14 @@ export default Capability.makeModule(
           Surface.makeType<{ subject: string }>('deck-companion--space-objects'),
           'space-objects',
         ),
-        component: () => <DebugSpaceObjectsPanel />,
+        component: () => {
+          const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
+
+          return <DebugSpaceObjectsPanel space={space} />;
+        },
       }),
 
       Surface.create({
@@ -184,6 +189,7 @@ export default Capability.makeModule(
         position: 'hoist',
         component: () => <DebugStatus />,
       }),
+
       //
       // Devtools
       //
@@ -227,7 +233,11 @@ export default Capability.makeModule(
         id: 'halo.credentials',
         filter: AppSurface.literal(AppSurface.Article, Devtools.Halo.Credentials),
         component: () => {
-          const space = useCurrentSpace();
+          const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
+
           return <CredentialsPanel space={space} />;
         },
       }),
@@ -247,12 +257,16 @@ export default Capability.makeModule(
         id: 'echo.space',
         filter: AppSurface.literal(AppSurface.Article, Devtools.Echo.Space),
         component: () => {
-          const space = useCurrentSpace();
+          const space = useActiveSpace();
           const { invokePromise } = useOperationInvoker();
           const handleSelect = useCallback(
             () => invokePromise(LayoutOperation.Open, { subject: [Devtools.Echo.Feeds] }),
             [invokePromise],
           );
+          if (!space) {
+            return null;
+          }
+
           return <SpaceInfoPanel space={space} onSelectFeed={handleSelect} onSelectPipeline={handleSelect} />;
         },
       }),
@@ -260,7 +274,11 @@ export default Capability.makeModule(
         id: 'echo.feeds',
         filter: AppSurface.literal(AppSurface.Article, Devtools.Echo.Feeds),
         component: () => {
-          const space = useCurrentSpace();
+          const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
+
           return <FeedsPanel space={space} />;
         },
       }),
@@ -268,7 +286,11 @@ export default Capability.makeModule(
         id: 'echo.objects',
         filter: AppSurface.literal(AppSurface.Article, Devtools.Echo.Objects),
         component: () => {
-          const space = useCurrentSpace();
+          const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
+
           return <ObjectsPanel space={space} />;
         },
       }),
@@ -276,7 +298,11 @@ export default Capability.makeModule(
         id: 'echo.schema',
         filter: AppSurface.literal(AppSurface.Article, Devtools.Echo.Schema),
         component: () => {
-          const space = useCurrentSpace();
+          const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
+
           return <SchemaPanel space={space} />;
         },
       }),
@@ -284,7 +310,11 @@ export default Capability.makeModule(
         id: 'echo.automerge',
         filter: AppSurface.literal(AppSurface.Article, Devtools.Echo.Automerge),
         component: () => {
-          const space = useCurrentSpace();
+          const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
+
           return <AutomergePanel space={space} />;
         },
       }),
@@ -297,7 +327,11 @@ export default Capability.makeModule(
         id: 'echo.members',
         filter: AppSurface.literal(AppSurface.Article, Devtools.Echo.Members),
         component: () => {
-          const space = useCurrentSpace();
+          const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
+
           return <MembersPanel space={space} />;
         },
       }),
@@ -320,7 +354,11 @@ export default Capability.makeModule(
         id: 'mesh.network',
         filter: AppSurface.literal(AppSurface.Article, Devtools.Mesh.Network),
         component: () => {
-          const space = useCurrentSpace();
+          const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
+
           return <NetworkPanel space={space} />;
         },
       }),
@@ -333,7 +371,11 @@ export default Capability.makeModule(
         id: 'edge.workflows',
         filter: AppSurface.literal(AppSurface.Article, Devtools.Edge.Workflows),
         component: () => {
-          const space = useCurrentSpace();
+          const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
+
           return <WorkflowPanel space={space} />;
         },
       }),
@@ -341,10 +383,14 @@ export default Capability.makeModule(
         id: 'edge.traces',
         filter: AppSurface.literal(AppSurface.Article, Devtools.Edge.Traces),
         component: () => {
-          const space = useCurrentSpace();
-          const feed = space?.properties.invocationTraceFeed?.target;
+          const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
+
+          const feed = space.properties.invocationTraceFeed?.target;
           const queueDxn = feed ? Feed.getQueueDxn(feed) : undefined;
-          return <InvocationTraceContainer db={space?.db} queueDxn={queueDxn} detailAxis='block' />;
+          return <InvocationTraceContainer db={space.db} queueDxn={queueDxn} detailAxis='block' />;
         },
       }),
       Surface.create({

--- a/packages/plugins/plugin-debug/src/containers/DebugSpaceObjectsPanel/DebugSpaceObjectsPanel.tsx
+++ b/packages/plugins/plugin-debug/src/containers/DebugSpaceObjectsPanel/DebugSpaceObjectsPanel.tsx
@@ -4,28 +4,20 @@
 
 import React, { useState } from 'react';
 
-import { useActiveSpace } from '@dxos/app-toolkit/ui';
+import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { ObjectsTree } from '@dxos/devtools';
-import { type Database, Filter, Query } from '@dxos/echo';
-import type { ObjectId } from '@dxos/keys';
+import { Filter, Query } from '@dxos/echo';
+import { type ObjectId } from '@dxos/keys';
 import { useQuery } from '@dxos/react-client/echo';
 import { Clipboard, Grid, Input, Panel, ScrollArea, Toolbar } from '@dxos/react-ui';
 import { JsonHighlighter } from '@dxos/react-ui-syntax-highlighter';
 
-export const DebugSpaceObjectsPanel = () => {
-  const space = useActiveSpace();
-  if (!space) {
-    return null;
-  }
+export type DebugSpaceObjectsPanelProps = AppSurface.SpaceArticleProps;
 
-  return <DebugSpaceObjectsPanelMain database={space.db} />;
-};
-
-const DebugSpaceObjectsPanelMain = ({ database }: { database: Database.Database }) => {
+export const DebugSpaceObjectsPanel = ({ space }: DebugSpaceObjectsPanelProps) => {
   const [selectedId, setSelectedId] = useState<ObjectId | null>(null);
-
   const [selectedObject] = useQuery(
-    database,
+    space.db,
     selectedId ? Query.select(Filter.id(selectedId)) : Query.select(Filter.nothing()),
   );
 
@@ -43,7 +35,7 @@ const DebugSpaceObjectsPanelMain = ({ database }: { database: Database.Database 
           <Grid rows={2} classNames='divide-y divide-separator'>
             <ScrollArea.Root>
               <ScrollArea.Viewport>
-                <ObjectsTree db={database} onSelect={(entity) => setSelectedId(entity.id)} />
+                <ObjectsTree db={space.db} onSelect={(entity) => setSelectedId(entity.id)} />
               </ScrollArea.Viewport>
             </ScrollArea.Root>
             {selectedObject && <JsonHighlighter classNames='p-1' data={selectedObject} />}

--- a/packages/plugins/plugin-debug/src/containers/DebugStatus/DebugStatus.tsx
+++ b/packages/plugins/plugin-debug/src/containers/DebugStatus/DebugStatus.tsx
@@ -4,7 +4,6 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 
-import { useActiveSpace } from '@dxos/app-toolkit/ui';
 import { TimeoutError } from '@dxos/async';
 import { StatusBar } from '@dxos/plugin-status-bar';
 import { ConnectionState } from '@dxos/protocols/proto/dxos/client/services';
@@ -145,7 +144,6 @@ const SwarmIndicator = () => {
 // TODO(burdon): Merge with SaveStatus.
 const SavingIndicator = () => {
   const [state, _setState] = useState(0);
-  const _space = useActiveSpace();
   // TODO(dmaretskyi): Fix this when we have save status for automerge.
   // useEffect(() => {
   //   if (!space) {

--- a/packages/plugins/plugin-feed/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-feed/src/capabilities/react-surface.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
 import { Surface } from '@dxos/app-framework/ui';
-import { AppSurface } from '@dxos/app-toolkit/ui';
+import { AppSurface, useActiveSpace } from '@dxos/app-toolkit/ui';
 
 import { FeedArticle, MagazineArticle, PostArticle, PostCard, SubscriptionsArticle } from '#containers';
 import { Magazine, Subscription } from '#types';
@@ -18,9 +18,14 @@ export default Capability.makeModule(() =>
       Surface.create({
         id: 'subscription-feed',
         filter: AppSurface.literal(AppSurface.Article, 'feeds-root'),
-        component: ({ data, role }) => (
-          <SubscriptionsArticle role={role} attendableId={data.attendableId} subject={data.subject} />
-        ),
+        component: ({ data, role }) => {
+          const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
+
+          return <SubscriptionsArticle role={role} space={space} attendableId={data.attendableId} />;
+        },
       }),
       Surface.create({
         id: 'magazine-article',

--- a/packages/plugins/plugin-feed/src/containers/SubscriptionsArticle/SubscriptionsArticle.stories.tsx
+++ b/packages/plugins/plugin-feed/src/containers/SubscriptionsArticle/SubscriptionsArticle.stories.tsx
@@ -27,11 +27,11 @@ const DefaultStory = () => {
   const spaces = useSpaces();
   const space = spaces[spaces.length - 1];
   const feeds = useQuery(space?.db, Filter.type(Subscription.Feed));
-  if (feeds.length === 0) {
+  if (!space || feeds.length === 0) {
     return <Loading />;
   }
 
-  return <SubscriptionsArticle role='article' subject='feeds-root' attendableId='story' />;
+  return <SubscriptionsArticle role='article' space={space} attendableId='story' />;
 };
 
 const meta: Meta<typeof DefaultStory> = {

--- a/packages/plugins/plugin-feed/src/containers/SubscriptionsArticle/SubscriptionsArticle.tsx
+++ b/packages/plugins/plugin-feed/src/containers/SubscriptionsArticle/SubscriptionsArticle.tsx
@@ -6,7 +6,7 @@ import React, { useCallback } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
 import { LayoutOperation } from '@dxos/app-toolkit';
-import { type AppSurface, useActiveSpace, useLayout } from '@dxos/app-toolkit/ui';
+import { type AppSurface, useLayout } from '@dxos/app-toolkit/ui';
 import { Filter, Obj } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
 import { SpaceOperation } from '@dxos/plugin-space/operations';
@@ -20,15 +20,14 @@ import { meta } from '#meta';
 import { FeedOperation } from '#operations';
 import { Subscription } from '#types';
 
-export type SubscriptionsArticleProps = AppSurface.ArticleProps<'feeds-root'>;
+export type SubscriptionsArticleProps = AppSurface.SpaceArticleProps;
 
-export const SubscriptionsArticle = ({ role, attendableId }: SubscriptionsArticleProps) => {
+export const SubscriptionsArticle = ({ role, space, attendableId }: SubscriptionsArticleProps) => {
   const { t } = useTranslation(meta.id);
   const { invokePromise } = useOperationInvoker();
   const layout = useLayout();
-  const space = useActiveSpace();
 
-  const feeds = useQuery(space?.db, Filter.type(Subscription.Feed));
+  const feeds = useQuery(space.db, Filter.type(Subscription.Feed));
   const currentId = useSelected(attendableId, 'single');
 
   const handleAction = useCallback(
@@ -76,12 +75,10 @@ export const SubscriptionsArticle = ({ role, attendableId }: SubscriptionsArticl
   );
 
   const handleCreate = useCallback(() => {
-    if (space) {
-      void invokePromise(SpaceOperation.OpenCreateObject, {
-        target: space.db,
-        typename: Subscription.Feed.typename,
-      });
-    }
+    void invokePromise(SpaceOperation.OpenCreateObject, {
+      target: space.db,
+      typename: Subscription.Feed.typename,
+    });
   }, [space, invokePromise]);
 
   return (

--- a/packages/plugins/plugin-inbox/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-inbox/src/capabilities/react-surface.tsx
@@ -64,8 +64,12 @@ export default Capability.makeModule(() =>
           );
         },
         component: ({ data, role }) => {
-          const mailbox = (data.properties as { mailbox: Mailbox.Mailbox }).mailbox;
           const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
+
+          const mailbox = (data.properties as { mailbox: Mailbox.Mailbox }).mailbox;
           return <DraftsArticle role={role} space={space} attendableId={data.attendableId} mailbox={mailbox} />;
         },
       }),
@@ -174,7 +178,6 @@ export default Capability.makeModule(() =>
         component: ({ data }) => <CalendarProperties subject={data.subject} />,
       }),
 
-      // TODO(card-cleanup): Remove.
       // TODO(wittjosiah): Generalize the mess below.
       Surface.create({
         id: 'contact-related',

--- a/packages/plugins/plugin-inbox/src/containers/DraftsArticle/DraftsArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/DraftsArticle/DraftsArticle.tsx
@@ -8,7 +8,6 @@ import { useOperationInvoker } from '@dxos/app-framework/ui';
 import { LayoutOperation } from '@dxos/app-toolkit';
 import { type AppSurface, useLayout } from '@dxos/app-toolkit/ui';
 import { Obj } from '@dxos/echo';
-import { type Space } from '@dxos/react-client/echo';
 import { Filter, useQuery } from '@dxos/react-client/echo';
 import { Panel, useTranslation } from '@dxos/react-ui';
 import { linkedSegment, useSelected } from '@dxos/react-ui-attention';
@@ -21,7 +20,10 @@ import { DraftMessage, type Mailbox } from '#types';
 import { getMailboxMessagePath } from '../../paths';
 import { sortByCreated } from '../../util';
 
-export type DraftsArticleProps = AppSurface.ArticleProps<unknown, { space?: Space; mailbox: Mailbox.Mailbox }>;
+export type DraftsArticleProps = AppSurface.SpaceArticleProps<{
+  attendableId?: string;
+  mailbox: Mailbox.Mailbox;
+}>;
 
 /**
  * Drafts list for a mailbox. Query matches the same mailbox-scoped draft messages as the former per-draft nav nodes.
@@ -34,7 +36,7 @@ export const DraftsArticle = ({ role, space, attendableId, mailbox }: DraftsArti
   const id = attendableId ?? Obj.getDXN(mailbox).toString();
   const currentId = useSelected(id, 'single');
 
-  const db = space?.db ?? Obj.getDatabase(mailbox);
+  const db = space.db;
   const mailboxDxn = Obj.getDXN(mailbox).toString();
 
   const draftsFilter = useMemo(

--- a/packages/plugins/plugin-inbox/src/containers/RelatedToContact/RelatedToContact.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/RelatedToContact/RelatedToContact.tsx
@@ -8,19 +8,22 @@ import React, { useCallback } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
 import { LayoutOperation, getObjectPathFromObject, getSpacePath } from '@dxos/app-toolkit';
-import { useActiveSpace, type AppSurface } from '@dxos/app-toolkit/ui';
-import { type Feed, Filter, Query } from '@dxos/echo';
+import { type AppSurface } from '@dxos/app-toolkit/ui';
+import { type Feed, Filter, Obj, Query } from '@dxos/echo';
 import { useObject, useQuery } from '@dxos/react-client/echo';
 import { Event, Message, type Person } from '@dxos/types';
 
 import { RelatedEvents, RelatedMessages } from '#components';
 import { Calendar, Mailbox } from '#types';
 
-export const RelatedToContact = ({ subject: contact }: AppSurface.ObjectArticleProps<Person.Person>) => {
+export type RelatedToContactProps = AppSurface.ObjectArticleProps<Person.Person>;
+
+export const RelatedToContact = ({ subject: contact }: RelatedToContactProps) => {
   const { invokePromise } = useOperationInvoker();
-  const space = useActiveSpace();
-  const mailboxes = useQuery(space?.db, Filter.type(Mailbox.Mailbox));
-  const calendars = useQuery(space?.db, Filter.type(Calendar.Calendar));
+  const db = Obj.getDatabase(contact);
+  const workspace = db ? getSpacePath(db.spaceId) : undefined;
+  const mailboxes = useQuery(db, Filter.type(Mailbox.Mailbox));
+  const calendars = useQuery(db, Filter.type(Calendar.Calendar));
   const mailbox = mailboxes[0];
   const calendar = calendars[0];
   // TODO(wittjosiah): Should be `const feed = useObjectValue(mailbox.feed)`.
@@ -30,11 +33,11 @@ export const RelatedToContact = ({ subject: contact }: AppSurface.ObjectArticleP
   const calendarFeed = calendar?.feed?.target as Feed.Feed | undefined;
   // TODO(wittjosiah): Way to structure this query that does not require type assertions?
   const messages: Message.Message[] = useQuery(
-    space?.db,
+    db,
     mailboxFeed ? Query.select(Filter.type(Message.Message)).from(mailboxFeed) : Query.select(Filter.nothing()),
   ) as Message.Message[];
   const events: Event.Event[] = useQuery(
-    space?.db,
+    db,
     calendarFeed ? Query.select(Filter.type(Event.Event)).from(calendarFeed) : Query.select(Filter.nothing()),
   ) as Event.Event[];
   const relatedMessages = messages
@@ -68,18 +71,16 @@ export const RelatedToContact = ({ subject: contact }: AppSurface.ObjectArticleP
       if (!mailbox) {
         return;
       }
+
       const mailboxPath = getObjectPathFromObject(mailbox);
       await invokePromise(LayoutOperation.UpdatePopover, { state: false, anchorId: '' });
-      await invokePromise(LayoutOperation.Open, {
-        subject: [mailboxPath],
-        workspace: space ? getSpacePath(space.id) : undefined,
-      });
+      await invokePromise(LayoutOperation.Open, { subject: [mailboxPath], workspace });
       await invokePromise(LayoutOperation.Select, {
         contextId: mailboxPath,
         subject: { mode: 'single', id: message.id },
       });
     },
-    [invokePromise, space, mailbox],
+    [invokePromise, db, mailbox],
   );
 
   const handleEventClick = useCallback(
@@ -87,18 +88,16 @@ export const RelatedToContact = ({ subject: contact }: AppSurface.ObjectArticleP
       if (!calendar) {
         return;
       }
+
       const calendarPath = getObjectPathFromObject(calendar);
       await invokePromise(LayoutOperation.UpdatePopover, { state: false, anchorId: '' });
-      await invokePromise(LayoutOperation.Open, {
-        subject: [calendarPath],
-        workspace: space ? getSpacePath(space.id) : undefined,
-      });
+      await invokePromise(LayoutOperation.Open, { subject: [calendarPath], workspace });
       await invokePromise(LayoutOperation.Select, {
         contextId: calendarPath,
         subject: { mode: 'single', id: event.id },
       });
     },
-    [invokePromise, space, calendar],
+    [invokePromise, db, calendar],
   );
 
   return (

--- a/packages/plugins/plugin-sample/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-sample/src/capabilities/react-surface.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
 import { Surface, useAtomCapability, useSettingsState } from '@dxos/app-framework/ui';
-import { AppSurface } from '@dxos/app-toolkit/ui';
+import { AppSurface, useActiveSpace } from '@dxos/app-toolkit/ui';
 
 import { SampleStatusIndicator } from '#components';
 import {
@@ -107,7 +107,13 @@ export default Capability.makeModule(() =>
           Surface.makeType<{ subject: string }>('deck-companion--sample-panel'),
           'sample-panel',
         ),
-        component: () => <SampleDeckCompanion />,
+        component: () => {
+          const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
+          return <SampleDeckCompanion role='deck-companion--sample-panel' space={space} />;
+        },
       }),
     ]),
   ),

--- a/packages/plugins/plugin-sample/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-sample/src/capabilities/react-surface.tsx
@@ -112,7 +112,7 @@ export default Capability.makeModule(() =>
           if (!space) {
             return null;
           }
-          return <SampleDeckCompanion role='deck-companion--sample-panel' space={space} />;
+          return <SampleDeckCompanion role='deck-companion--sample-panel' space={space} attendableId={space.id} />;
         },
       }),
     ]),

--- a/packages/plugins/plugin-sample/src/containers/SampleDeckCompanion.tsx
+++ b/packages/plugins/plugin-sample/src/containers/SampleDeckCompanion.tsx
@@ -9,22 +9,21 @@
 
 import React from 'react';
 
-import { useActiveSpace } from '@dxos/app-toolkit/ui';
+import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { Panel, Toolbar } from '@dxos/react-ui';
 
 import { ActiveSpacePanel } from '#components';
 
-export const SampleDeckCompanion = () => {
-  // `useActiveSpace` returns the currently focused space in the deck layout.
-  const space = useActiveSpace();
+export type SampleDeckCompanionProps = AppSurface.SpaceArticleProps;
 
+export const SampleDeckCompanion = ({ space }: SampleDeckCompanionProps) => {
   return (
     <Panel.Root>
       <Panel.Toolbar asChild>
         <Toolbar.Root />
       </Panel.Toolbar>
       <Panel.Content>
-        <ActiveSpacePanel spaceName={space?.properties.name ?? space?.id} />
+        <ActiveSpacePanel spaceName={space.properties.name ?? space.id} />
       </Panel.Content>
     </Panel.Root>
   );

--- a/packages/plugins/plugin-search/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-search/src/capabilities/react-surface.tsx
@@ -29,7 +29,7 @@ export default Capability.makeModule(() =>
 
           return (
             <SearchContextProvider>
-              <SearchDialog space={space} {...data.props} />
+              <SearchDialog {...data.props} space={space} />
             </SearchContextProvider>
           );
         },

--- a/packages/plugins/plugin-search/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-search/src/capabilities/react-surface.tsx
@@ -21,17 +21,27 @@ export default Capability.makeModule(() =>
       Surface.create({
         id: SEARCH_DIALOG,
         filter: AppSurface.component<ComponentProps<typeof SearchDialog>>(AppSurface.Dialog, SEARCH_DIALOG),
-        component: ({ data }) => (
-          <SearchContextProvider>
-            <SearchDialog {...data.props} />
-          </SearchContextProvider>
-        ),
+        component: ({ data }) => {
+          const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
+
+          return (
+            <SearchContextProvider>
+              <SearchDialog space={space} {...data.props} />
+            </SearchContextProvider>
+          );
+        },
       }),
       Surface.create({
         id: `${SEARCH_DIALOG}.search-input`,
         role: 'search-input',
         component: () => {
           const space = useActiveSpace();
+          if (!space) {
+            return null;
+          }
 
           return (
             <SearchContextProvider>

--- a/packages/plugins/plugin-search/src/containers/SearchArticle/SearchArticle.stories.tsx
+++ b/packages/plugins/plugin-search/src/containers/SearchArticle/SearchArticle.stories.tsx
@@ -34,14 +34,13 @@ const DefaultStory = () => {
 
   return (
     <SearchContextProvider>
-      <SearchArticle space={space} />
+      <SearchArticle role='article' space={space} attendableId={space.id} />
     </SearchContextProvider>
   );
 };
 
 const meta = {
   title: 'plugins/plugin-search/containers/SearchArticle',
-  component: SearchArticle,
   render: DefaultStory,
   decorators: [
     withLayout({ layout: 'column' }),
@@ -71,7 +70,7 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
   },
-} satisfies Meta<typeof SearchArticle>;
+} satisfies Meta<typeof DefaultStory>;
 
 export default meta;
 

--- a/packages/plugins/plugin-search/src/containers/SearchArticle/SearchArticle.tsx
+++ b/packages/plugins/plugin-search/src/containers/SearchArticle/SearchArticle.tsx
@@ -4,8 +4,9 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 
+import { AppSurface } from '@dxos/app-toolkit/ui';
 import { Entity, Query } from '@dxos/echo';
-import { Filter, type Space, useQuery } from '@dxos/react-client/echo';
+import { Filter, useQuery } from '@dxos/react-client/echo';
 import { Panel, Toolbar } from '@dxos/react-ui';
 import { SearchList } from '@dxos/react-ui-search';
 import { Text } from '@dxos/schema';
@@ -14,16 +15,12 @@ import { isTauri, getHostPlatform } from '@dxos/util';
 import { SearchResultStack } from '#components';
 import { useGlobalSearch, useGlobalSearchResults, useWebSearch } from '#hooks';
 
-export type SearchArticleProps = {
-  space?: Space;
-};
-
-export const SearchArticle = ({ space }: SearchArticleProps) => {
+export const SearchArticle = ({ space }: AppSurface.SpaceArticleProps) => {
   // TODO(burdon): Option to query across spaces.
   const [query, setQuery] = useState<string>();
   // TODO(burdon): Re-enable full-text search when indexer is available in all environments.
   const objects = useQuery(
-    space?.db,
+    space.db,
     query === undefined ? Query.select(Filter.nothing()) : Query.select(Filter.not(Filter.type(Text.Text))),
   );
 

--- a/packages/plugins/plugin-search/src/containers/SearchDialog/SearchDialog.stories.tsx
+++ b/packages/plugins/plugin-search/src/containers/SearchDialog/SearchDialog.stories.tsx
@@ -38,7 +38,7 @@ const DefaultStory = () => {
     <SearchContextProvider>
       <Dialog.Root defaultOpen>
         <Dialog.Overlay>
-          <SearchDialog pivotId='storybook' space={space} />
+          <SearchDialog role='article' space={space} attendableId={space.id} pivotId='storybook' />
         </Dialog.Overlay>
       </Dialog.Root>
     </SearchContextProvider>
@@ -47,7 +47,6 @@ const DefaultStory = () => {
 
 const meta = {
   title: 'plugins/plugin-search/containers/SearchDialog',
-  component: SearchDialog,
   render: DefaultStory,
   decorators: [
     withLayout({ layout: 'fullscreen' }),
@@ -78,7 +77,7 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
   },
-} satisfies Meta<typeof SearchDialog>;
+} satisfies Meta<typeof DefaultStory>;
 
 export default meta;
 

--- a/packages/plugins/plugin-search/src/containers/SearchDialog/SearchDialog.tsx
+++ b/packages/plugins/plugin-search/src/containers/SearchDialog/SearchDialog.tsx
@@ -6,10 +6,10 @@ import React, { useCallback, useMemo, useState } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
 import { getObjectPathFromObject, LayoutOperation } from '@dxos/app-toolkit';
+import { type AppSurface } from '@dxos/app-toolkit/ui';
 import { useLayout } from '@dxos/app-toolkit/ui';
-import { useActiveSpace } from '@dxos/app-toolkit/ui';
 import { Entity, Obj, Query } from '@dxos/echo';
-import { Filter, type Space, useQuery } from '@dxos/react-client/echo';
+import { Filter, useQuery } from '@dxos/react-client/echo';
 import { Dialog, useTranslation } from '@dxos/react-ui';
 import { SearchList } from '@dxos/react-ui-search';
 import { Text } from '@dxos/schema';
@@ -18,21 +18,18 @@ import { useGlobalSearch, useGlobalSearchResults } from '#hooks';
 import { meta } from '#meta';
 import { type SearchResult } from '#types';
 
-export type SearchDialogProps = {
+export type SearchDialogProps = AppSurface.SpaceArticleProps<{
   pivotId?: string;
-  space?: Space;
-};
+}>;
 
-export const SearchDialog = ({ pivotId: pivotIdProp, space: spaceProp }: SearchDialogProps) => {
+export const SearchDialog = ({ space, pivotId: pivotIdProp }: SearchDialogProps) => {
   const { t } = useTranslation(meta.id);
-  const layout = useLayout();
-  const pivotId = pivotIdProp ?? layout.active[layout.active.length - 1];
   const { invokePromise } = useOperationInvoker();
   const { setMatch } = useGlobalSearch();
+  const layout = useLayout();
+  const pivotId = pivotIdProp ?? layout.active[layout.active.length - 1];
   const [query, setQuery] = useState<string>();
 
-  const activeSpace = useActiveSpace();
-  const space = spaceProp ?? activeSpace;
   // TODO(burdon): Re-enable full-text search when indexer is available in all environments.
   const objects = useQuery(
     space?.db,

--- a/packages/plugins/plugin-search/src/containers/SearchDialog/index.ts
+++ b/packages/plugins/plugin-search/src/containers/SearchDialog/index.ts
@@ -2,5 +2,4 @@
 // Copyright 2025 DXOS.org
 //
 
-export { SearchDialog, type SearchDialogProps } from './SearchDialog';
 export { SearchDialog as default } from './SearchDialog';

--- a/packages/plugins/plugin-search/src/containers/index.ts
+++ b/packages/plugins/plugin-search/src/containers/index.ts
@@ -4,7 +4,5 @@
 
 import { type ComponentType, lazy } from 'react';
 
-export type { SearchDialogProps } from './SearchDialog';
-
 export const SearchDialog: ComponentType<any> = lazy(() => import('./SearchDialog'));
 export const SearchArticle: ComponentType<any> = lazy(() => import('./SearchArticle'));

--- a/packages/plugins/plugin-space/src/containers/MembersContainer/MembersContainer.tsx
+++ b/packages/plugins/plugin-space/src/containers/MembersContainer/MembersContainer.tsx
@@ -6,10 +6,11 @@ import React, { type Dispatch, type SetStateAction, useMemo, useState } from 're
 import { QR } from 'react-qr-rounded';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
+import { AppSurface } from '@dxos/app-toolkit/ui';
 import { Collection, Obj } from '@dxos/echo';
 import { log } from '@dxos/log';
 import { useConfig } from '@dxos/react-client';
-import { type Space, useSpaceInvitations } from '@dxos/react-client/echo';
+import { useSpaceInvitations } from '@dxos/react-client/echo';
 import { type CancellableInvitationObservable, Invitation, InvitationEncoder } from '@dxos/react-client/invitations';
 import { Button, Clipboard, Icon, useId, useTranslation } from '@dxos/react-ui';
 import { Settings } from '@dxos/react-ui-form';
@@ -40,10 +41,9 @@ const handleInvitationEvent = (invitation: Invitation, subscription: ZenObservab
   }
 };
 
-export type MembersContainerProps = {
-  space: Space;
+export type MembersContainerProps = AppSurface.SpaceArticleProps<{
   createInvitationUrl: (invitationCode: string) => string;
-};
+}>;
 
 export const MembersContainer = ({ space, createInvitationUrl }: MembersContainerProps) => {
   const { t } = useTranslation(meta.id);

--- a/packages/plugins/plugin-space/src/containers/SchemaContainer/SchemaContainer.tsx
+++ b/packages/plugins/plugin-space/src/containers/SchemaContainer/SchemaContainer.tsx
@@ -4,6 +4,7 @@
 
 import React, { useEffect, useState } from 'react';
 
+import { AppSurface } from '@dxos/app-toolkit/ui';
 import { type Type } from '@dxos/echo';
 import { type Space } from '@dxos/react-client/echo';
 import { useTranslation } from '@dxos/react-ui';
@@ -12,9 +13,7 @@ import { mx } from '@dxos/ui-theme';
 
 import { meta } from '#meta';
 
-type SchemaPanelProps = { space: Space };
-
-export const SchemaContainer = ({ space }: SchemaPanelProps) => {
+export const SchemaContainer = ({ space }: AppSurface.SpaceArticleProps) => {
   const { t } = useTranslation(meta.id);
   const schemas = useQuerySpaceSchemas(space);
 

--- a/packages/plugins/plugin-space/src/containers/SpaceSettingsContainer/SpaceSettingsContainer.stories.tsx
+++ b/packages/plugins/plugin-space/src/containers/SpaceSettingsContainer/SpaceSettingsContainer.stories.tsx
@@ -7,19 +7,20 @@ import React from 'react';
 
 import { OperationPlugin, RuntimePlugin } from '@dxos/app-framework';
 import { withPluginManager } from '@dxos/app-framework/testing';
+import { AppSurface } from '@dxos/app-toolkit/ui';
 import { useClientStory, withClientProvider } from '@dxos/react-client/testing';
 import { Loading, withLayout, withTheme } from '@dxos/react-ui/testing';
 
 import { translations } from '../../translations';
-import { SpaceSettingsContainer, type SpaceSettingsContainerProps } from './SpaceSettingsContainer';
+import { SpaceSettingsContainer } from './SpaceSettingsContainer';
 
-const Story = (props: Partial<SpaceSettingsContainerProps>) => {
+const Story = (props: Partial<AppSurface.SpaceArticleProps>) => {
   const { space } = useClientStory();
   if (!space) {
     return <Loading />;
   }
 
-  return <SpaceSettingsContainer {...props} space={space} />;
+  return <SpaceSettingsContainer role='article' attendableId={space.id} {...props} space={space} />;
 };
 
 const meta = {

--- a/packages/plugins/plugin-space/src/containers/SpaceSettingsContainer/SpaceSettingsContainer.tsx
+++ b/packages/plugins/plugin-space/src/containers/SpaceSettingsContainer/SpaceSettingsContainer.tsx
@@ -7,12 +7,13 @@ import React, { type ChangeEvent, useCallback, useMemo, useState } from 'react';
 
 import { useCapabilities, useOperationInvoker } from '@dxos/app-framework/ui';
 import { getPersonalSpace, getSpacePath, isPersonalSpace, LayoutOperation } from '@dxos/app-toolkit';
+import { AppSurface } from '@dxos/app-toolkit/ui';
 import { Obj } from '@dxos/echo';
 import { log } from '@dxos/log';
 import { SpaceArchive } from '@dxos/protocols/proto/dxos/client/services';
 import { EdgeReplicationSetting } from '@dxos/protocols/proto/dxos/echo/metadata';
 import { useClient } from '@dxos/react-client';
-import { type Space, SpaceState } from '@dxos/react-client/echo';
+import { SpaceState } from '@dxos/react-client/echo';
 import {
   Button,
   DropdownMenu,
@@ -38,12 +39,8 @@ const SpaceFormSchema = SpaceForm.pipe(
   ),
 );
 
-export type SpaceSettingsContainerProps = {
-  space: Space;
-};
-
 // TODO(wittjosiah): Handle space migrations here?
-export const SpaceSettingsContainer = ({ space }: SpaceSettingsContainerProps) => {
+export const SpaceSettingsContainer = ({ space }: AppSurface.SpaceArticleProps) => {
   const { t } = useTranslation(meta.id);
   const { invokePromise } = useOperationInvoker();
   const client = useClient();

--- a/packages/plugins/plugin-token-manager/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-token-manager/src/capabilities/react-surface.tsx
@@ -29,7 +29,7 @@ export default Capability.makeModule(() =>
             return null;
           }
 
-          return <TokensContainer db={space.db} />;
+          return <TokensContainer space={space} />;
         },
       }),
       Surface.create({

--- a/packages/plugins/plugin-token-manager/src/containers/TokensContainer/TokensContainer.tsx
+++ b/packages/plugins/plugin-token-manager/src/containers/TokensContainer/TokensContainer.tsx
@@ -5,7 +5,8 @@
 import React, { useCallback, useState } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
-import { type Database, Filter, Obj } from '@dxos/echo';
+import { AppSurface } from '@dxos/app-toolkit/ui';
+import { Filter, Obj } from '@dxos/echo';
 import { SpaceOperation } from '@dxos/plugin-space/operations';
 import { useQuery } from '@dxos/react-client/echo';
 import { AccessToken } from '@dxos/types';
@@ -13,12 +14,9 @@ import { AccessToken } from '@dxos/types';
 import { TokensPanel } from '#components';
 import { TokenManagerOperation } from '#operations';
 
-export type TokensContainerProps = {
-  db: Database.Database;
-};
-
-export const TokensContainer = ({ db }: TokensContainerProps) => {
+export const TokensContainer = ({ space }: AppSurface.SpaceArticleProps) => {
   const { invokePromise } = useOperationInvoker();
+  const db = space.db;
   const tokens = useQuery(db, Filter.type(AccessToken.AccessToken));
   const [adding, setAdding] = useState(false);
 

--- a/packages/sdk/app-toolkit/src/ui/components/app-surface.ts
+++ b/packages/sdk/app-toolkit/src/ui/components/app-surface.ts
@@ -6,6 +6,7 @@ import type * as Schema from 'effect/Schema';
 
 import { Surface } from '@dxos/app-framework/ui';
 import { Obj, Type } from '@dxos/echo';
+import { type Space } from '@dxos/react-client/echo';
 import { type ProjectionModel } from '@dxos/schema';
 
 import { AppCapabilities } from '../../capabilities';
@@ -242,7 +243,7 @@ export const Article: Surface.RoleToken<ArticleData<any>> = Surface.makeType('ar
 export type ArticleData<Subject = unknown, Props extends {} = {}, CompanionTo = unknown> = {
   attendableId: string;
   subject: Subject;
-  properties?: Record<string, any>;
+  properties?: Record<string, any>; // TODO(burdon): What is this for?
   variant?: string;
   path?: string[];
   popoverAnchorId?: string;
@@ -291,6 +292,32 @@ export const settings = (
     return AppCapabilities.isSettings(subject) && subject.prefix === prefix;
   };
   return { bindings: [{ role: token.role, guard }] };
+};
+
+//
+// SpaceArticle
+//
+
+/**
+ * Role token for the `space-article` role. Article-shaped surface whose subject
+ * is a Space (not an ECHO object). Renders inside a plank; `attendableId` is
+ * the Space id.
+ */
+export const SpaceArticle: Surface.RoleToken<SpaceArticleData> = Surface.makeType('space-article');
+
+/** Surface data for space-article role. */
+export type SpaceArticleData<Props extends {} = {}> = {
+  attendableId: string;
+  space: Space;
+  properties?: Record<string, any>;
+  variant?: string;
+  path?: string[];
+  popoverAnchorId?: string;
+} & Props;
+
+/** Component props for space-article role. */
+export type SpaceArticleProps<Props extends {} = {}> = SpaceArticleData<Props> & {
+  role: 'article' | (string & {});
 };
 
 //

--- a/packages/sdk/app-toolkit/src/ui/components/app-surface.ts
+++ b/packages/sdk/app-toolkit/src/ui/components/app-surface.ts
@@ -297,25 +297,23 @@ export const settings = (
 //
 // SpaceArticle
 //
+// Article-shaped surface whose container resolves a Space (typically via
+// `useActiveSpace()` in the surface callback). Reuses the `Article` role token
+// — the deck plugin keeps passing standard `ArticleData` — and only specializes
+// the props the consumer expects by adding a non-null `space` field synthesized
+// at the surface boundary.
+//
 
-/**
- * Role token for the `space-article` role. Article-shaped surface whose subject
- * is a Space (not an ECHO object). Renders inside a plank; `attendableId` is
- * the Space id.
- */
-export const SpaceArticle: Surface.RoleToken<SpaceArticleData> = Surface.makeType('space-article');
-
-/** Surface data for space-article role. */
-export type SpaceArticleData<Props extends {} = {}> = {
-  attendableId: string;
+/** Surface data for an article whose container receives a resolved Space.
+ *  `subject` from `ArticleData` is widened to optional — Space-scoped articles
+ *  often render at routes whose subject is a literal id rather than an object,
+ *  and the container reads `space` (synthesized at the surface boundary) instead. */
+export type SpaceArticleData<Props extends {} = {}> = Omit<ArticleData<unknown>, 'subject'> & {
+  subject?: unknown;
   space: Space;
-  properties?: Record<string, any>;
-  variant?: string;
-  path?: string[];
-  popoverAnchorId?: string;
 } & Props;
 
-/** Component props for space-article role. */
+/** Component props for an article whose container receives a resolved Space. */
 export type SpaceArticleProps<Props extends {} = {}> = SpaceArticleData<Props> & {
   role: 'article' | (string & {});
 };

--- a/worktrees
+++ b/worktrees
@@ -1,0 +1,1 @@
+.claude/worktrees


### PR DESCRIPTION
## Summary

- Add a new `SpaceArticle` app-surface role (`SpaceArticleData` + `SpaceArticleProps`) in `@dxos/app-toolkit/ui` for plank surfaces whose subject is a Space rather than an ECHO object. Shape mirrors `Article` but carries `space: Space` and `attendableId: string`.
- Migrate space-scoped containers across 8 plugins to consume `AppSurface.SpaceArticleProps` and to receive a guaranteed non-null `Space` via props — `useActiveSpace + null-guard` lives in the surface callback now, not inside the container.
- Plugins touched: `plugin-assistant`, `plugin-automation`, `plugin-daily-summary`, `plugin-debug`, `plugin-feed`, `plugin-inbox`, `plugin-sample`, `plugin-search`, `plugin-space`, `plugin-token-manager`.
- `plugin-debug` devtools panels (`CredentialsPanel`, `SpaceInfoPanel`, etc.) intentionally left as `{ space: Space }` — `@dxos/devtools` doesn't depend on `@dxos/app-toolkit`, so adopting `SpaceArticleProps` there would invert the layer. Only the plugin-debug surface callbacks gain null guards.
- Minor unrelated workflow tweak in `AGENTS.md`.

## Test plan

- [x] `moon run :build` passes (443 tasks, 0 failures)
- [x] `moon run :lint -- --fix` passes
- [x] `pnpm format`
- [ ] Storybook spot-check for migrated containers (SpaceSettingsContainer, MembersContainer, SchemaContainer, SubscriptionsArticle, SearchArticle, SearchDialog, TracePanel)
- [ ] Composer-app dev run — verify space-settings panels render and devtools panels still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Many UI components were made props-driven and now explicitly require an active space, preventing rendering when no space is selected and improving stability.

* **New Features**
  * Added a standardized "space-article" surface/type to support space-aware UI components and consistent prop shapes.

* **Documentation**
  * Workflow guidance rewritten as a checklist with explicit worktree/branch naming and stash/move instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->