### PR TITLE
feat(app-framework): Plugin.lazy + migrate all plugins + revert composer-app workaround

### DIFF
--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -378,29 +378,35 @@ const main = async () => {
     isStrict: !isFalse(config.values.runtime?.app?.env?.DX_STRICT),
   };
 
-  // `getPlugins` dynamic-imports every plugin chunk in parallel.
-  // Run it concurrently with `UrlLoader.preload` (network-bound) so the two waits overlap.
+  // `getPlugins` is synchronous: each plugin's main entry exposes only
+  // `meta` + a `Plugin.lazy(...)` stub, so building the plugin array doesn't
+  // pull any plugin's body. The plugin manager loads the real plugin
+  // (separate Rollup chunk) on first `enable`. Remote plugin preload is
+  // network-bound — the boot loader's counter follows that until the
+  // plugin manager (post-React mount) takes over with module-activation
+  // progress.
   bootStatus('Loading plugins…');
+  const builtinPlugins = getPlugins(conf);
   const assetCache = await createAssetCache(isTauri);
-  const [builtinPlugins, remotePluginsResult] = await Promise.all([
-    getPlugins(conf, {
+  const remotePluginsResult = await runAndForwardErrors(
+    UrlLoader.preload({
+      cache: assetCache,
       onPluginLoaded: (loaded, total) => {
         // Pass `range` so the loader updates the existing line in place
-        // ("Loading plugins (12/80)") instead of appending a fresh entry per
-        // plugin tick — keeps the visible log compact and the boot trace
-        // collapses the (i/n) sequence into one transition.
+        // ("Loading plugins (3/12)") instead of appending a fresh entry per
+        // tick — keeps the visible log compact.
         window.__bootLoader?.status({ humanized: 'Loading plugins', range: { index: loaded, total } });
-        // The ring spans two phases — plugin chunks (0 → 50%) and module
-        // activation (50 → 100%, driven from `Placeholder` once React mounts).
-        // Splitting the range keeps it monotonic across the boundary.
+        // The ring spans two phases — remote-plugin preload (0 → 50%) and
+        // module activation (50 → 100%, driven from `Placeholder` once
+        // React mounts). Splitting the range keeps it monotonic across
+        // the boundary.
         window.__bootLoader?.progress((loaded / total) * 0.5);
       },
     }),
-    runAndForwardErrors(UrlLoader.preload({ cache: assetCache })),
-  ]);
+  );
 
   bootStatus('Starting Composer…');
-  // Park the ring at 50% — chunks done, activation about to take over.
+  // Park the ring at 50% — preload done, activation about to take over.
   window.__bootLoader?.progress(0.5);
   const remotePlugins: Plugin.Plugin[] = remotePluginsResult;
   const plugins = [...builtinPlugins, ...remotePlugins];

--- a/packages/apps/composer-app/src/plugin-defs.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.tsx
@@ -9,6 +9,68 @@ import { APP_DOMAIN } from '@dxos/app-toolkit';
 import { type ClientServicesProvider, type Config } from '@dxos/client';
 import { type IdbLogStore } from '@dxos/log-store-idb';
 import { type Observability } from '@dxos/observability';
+import { AssistantPlugin } from '@dxos/plugin-assistant';
+import { AttentionPlugin } from '@dxos/plugin-attention';
+import { AutomationPlugin } from '@dxos/plugin-automation';
+import { BoardPlugin } from '@dxos/plugin-board';
+import { ChessPlugin } from '@dxos/plugin-chess';
+import { ClientPlugin } from '@dxos/plugin-client';
+import { CodePlugin } from '@dxos/plugin-code';
+import { ConductorPlugin } from '@dxos/plugin-conductor';
+import { CrxPlugin } from '@dxos/plugin-crx';
+import { CrxBridgePlugin } from '@dxos/plugin-crx-bridge';
+import { DailySummaryPlugin } from '@dxos/plugin-daily-summary';
+import { DebugPlugin } from '@dxos/plugin-debug';
+import { DeckPlugin } from '@dxos/plugin-deck';
+import { DiscordPlugin } from '@dxos/plugin-discord';
+import { DoctorPlugin } from '@dxos/plugin-doctor';
+import { ExplorerPlugin } from '@dxos/plugin-explorer';
+import { FeedPlugin } from '@dxos/plugin-feed';
+import { GalleryPlugin } from '@dxos/plugin-gallery';
+import { GraphPlugin } from '@dxos/plugin-graph';
+import { HelpPlugin } from '@dxos/plugin-help';
+import { InboxPlugin } from '@dxos/plugin-inbox';
+import { IntegrationPlugin } from '@dxos/plugin-integration';
+import { IrohBeaconPlugin } from '@dxos/plugin-iroh-beacon';
+import { KanbanPlugin } from '@dxos/plugin-kanban';
+import { MapPlugin } from '@dxos/plugin-map';
+import { MapPlugin as MapPluginSolid } from '@dxos/plugin-map-solid';
+import { MarkdownPlugin } from '@dxos/plugin-markdown';
+import { MasonryPlugin } from '@dxos/plugin-masonry';
+import { MeetingPlugin } from '@dxos/plugin-meeting';
+import { MermaidPlugin } from '@dxos/plugin-mermaid';
+import { NativePlugin } from '@dxos/plugin-native';
+import { NativeFilesystemPlugin } from '@dxos/plugin-native-filesystem';
+import { NavTreePlugin } from '@dxos/plugin-navtree';
+import { ObservabilityPlugin } from '@dxos/plugin-observability';
+import { OutlinerPlugin } from '@dxos/plugin-outliner';
+import { PipelinePlugin } from '@dxos/plugin-pipeline';
+import { PresenterPlugin } from '@dxos/plugin-presenter';
+import { PreviewPlugin } from '@dxos/plugin-preview';
+import { PwaPlugin } from '@dxos/plugin-pwa';
+import { RegistryPlugin } from '@dxos/plugin-registry';
+import { SamplePlugin } from '@dxos/plugin-sample';
+import { ScriptPlugin } from '@dxos/plugin-script';
+import { SearchPlugin } from '@dxos/plugin-search';
+import { SettingsPlugin } from '@dxos/plugin-settings';
+import { SheetPlugin } from '@dxos/plugin-sheet';
+import { SidekickPlugin } from '@dxos/plugin-sidekick';
+import { SimpleLayoutPlugin } from '@dxos/plugin-simple-layout';
+import { SketchPlugin } from '@dxos/plugin-sketch';
+import { SpacePlugin } from '@dxos/plugin-space';
+import { SpacetimePlugin } from '@dxos/plugin-spacetime';
+import { SpotlightPlugin } from '@dxos/plugin-spotlight';
+import { StackPlugin } from '@dxos/plugin-stack';
+import { StatusBarPlugin } from '@dxos/plugin-status-bar';
+import { TablePlugin } from '@dxos/plugin-table';
+import { ThemePlugin } from '@dxos/plugin-theme';
+import { ThreadPlugin } from '@dxos/plugin-thread';
+import { TicTacToePlugin } from '@dxos/plugin-tictactoe';
+import { TranscriptionPlugin } from '@dxos/plugin-transcription';
+import { TrelloPlugin } from '@dxos/plugin-trello';
+import { VoxelPlugin } from '@dxos/plugin-voxel';
+import { WnfsPlugin } from '@dxos/plugin-wnfs';
+import { ZenPlugin } from '@dxos/plugin-zen';
 import { isTruthy } from '@dxos/util';
 
 import { steps } from './help';
@@ -36,109 +98,35 @@ export type PluginConfig = State & {
   isMobile?: boolean;
 };
 
-/**
- * Plugin IDs (kept in sync with each plugin's `meta.id`).
- *
- * The plugin factories themselves are dynamically imported in {@link getPlugins}
- * so the main bundle does not pull every plugin's transitive graph at
- * module-evaluation time. Hardcoding the ids here lets `getCore` and
- * `getDefaults` enumerate enabled plugins without loading the full chunks.
- *
- * If a plugin renames its `meta.id`, this constant must be updated by hand —
- * there is no compile-time guard for drift. A future improvement is to expose
- * `meta` from each plugin via a `./meta` subpath export so we can import it
- * without dragging the whole plugin chunk along.
- */
-const ID = {
-  ASSISTANT: 'org.dxos.plugin.assistant',
-  ATTENTION: 'org.dxos.plugin.attention',
-  AUTOMATION: 'org.dxos.plugin.automation',
-  BOARD: 'org.dxos.plugin.board',
-  CHESS: 'org.dxos.plugin.chess',
-  CLIENT: 'org.dxos.plugin.client',
-  CONDUCTOR: 'org.dxos.plugin.conductor',
-  CRX: 'org.dxos.plugin.crx',
-  CRX_BRIDGE: 'org.dxos.plugin.crxBridge',
-  DAILY_SUMMARY: 'org.dxos.plugin.dailySummary',
-  DEBUG: 'org.dxos.plugin.debug',
-  DECK: 'org.dxos.plugin.deck',
-  DISCORD: 'org.dxos.plugin.discord',
-  DOCTOR: 'org.dxos.plugin.doctor',
-  EXPLORER: 'org.dxos.plugin.explorer',
-  FEED: 'org.dxos.plugin.feed',
-  GALLERY: 'org.dxos.plugin.gallery',
-  GRAPH: 'org.dxos.plugin.graph',
-  HELP: 'org.dxos.plugin.help',
-  INBOX: 'org.dxos.plugin.inbox',
-  INTEGRATION: 'org.dxos.plugin.integration',
-  IROH_BEACON: 'org.dxos.plugin.irohBeacon',
-  KANBAN: 'org.dxos.plugin.kanban',
-  MAP: 'org.dxos.plugin.map',
-  MAP_SOLID: 'org.dxos.plugin.mapSolid',
-  MARKDOWN: 'org.dxos.plugin.markdown',
-  MASONRY: 'org.dxos.plugin.masonry',
-  MEETING: 'org.dxos.plugin.meeting',
-  MERMAID: 'org.dxos.plugin.mermaid',
-  NATIVE: 'org.dxos.plugin.native',
-  NATIVE_FILESYSTEM: 'org.dxos.plugin.nativeFilesystem',
-  NAVTREE: 'org.dxos.plugin.navtree',
-  OBSERVABILITY: 'org.dxos.plugin.observability',
-  OUTLINER: 'org.dxos.plugin.outliner',
-  PIPELINE: 'org.dxos.plugin.pipeline',
-  PRESENTER: 'org.dxos.plugin.presenter',
-  PREVIEW: 'org.dxos.plugin.preview',
-  PWA: 'org.dxos.plugin.pwa',
-  REGISTRY: 'org.dxos.plugin.registry',
-  SAMPLE: 'org.dxos.plugin.sample',
-  SCRIPT: 'org.dxos.plugin.script',
-  SEARCH: 'org.dxos.plugin.search',
-  SETTINGS: 'org.dxos.plugin.settings',
-  SHEET: 'org.dxos.plugin.sheet',
-  SIDEKICK: 'org.dxos.plugin.sidekick',
-  SIMPLE_LAYOUT: 'org.dxos.plugin.simpleLayout',
-  SKETCH: 'org.dxos.plugin.sketch',
-  SPACE: 'org.dxos.plugin.space',
-  CODE: 'org.dxos.plugin.code',
-  SPACETIME: 'org.dxos.plugin.spacetime',
-  SPOTLIGHT: 'org.dxos.plugin.spotlight',
-  STACK: 'org.dxos.plugin.stack',
-  STATUS_BAR: 'org.dxos.plugin.statusBar',
-  TABLE: 'org.dxos.plugin.table',
-  THEME: 'org.dxos.plugin.theme',
-  THREAD: 'org.dxos.plugin.thread',
-  TICTACTOE: 'org.dxos.plugin.tictactoe',
-  TRANSCRIPTION: 'org.dxos.plugin.transcription',
-  TRELLO: 'org.dxos.plugin.trello',
-  VOXEL: 'org.dxos.plugin.voxel',
-  WNFS: 'org.dxos.plugin.wnfs',
-  ZEN: 'org.dxos.plugin.zen',
-} as const;
-
 export const getCore = ({ isPwa, isTauri, isPopover, isMobile }: PluginConfig): string[] => {
-  const layoutPluginId = isPopover ? ID.SPOTLIGHT : isMobile ? ID.SIMPLE_LAYOUT : ID.DECK;
+  const layoutPluginId = isPopover
+    ? SpotlightPlugin.meta.id
+    : isMobile
+      ? SimpleLayoutPlugin.meta.id
+      : DeckPlugin.meta.id;
   return [
-    ID.ATTENTION,
-    ID.AUTOMATION,
-    ID.CLIENT,
-    ID.CRX,
-    ID.CRX_BRIDGE,
-    ID.GRAPH,
-    ID.HELP,
-    ID.INTEGRATION,
+    AttentionPlugin.meta.id,
+    AutomationPlugin.meta.id,
+    ClientPlugin.meta.id,
+    CrxPlugin.meta.id,
+    CrxBridgePlugin.meta.id,
+    GraphPlugin.meta.id,
+    HelpPlugin.meta.id,
+    IntegrationPlugin.meta.id,
     layoutPluginId,
-    isTauri && !isMobile && !isPopover && ID.NATIVE,
+    isTauri && !isMobile && !isPopover && NativePlugin.meta.id,
     OperationPlugin.meta.id,
-    ID.NAVTREE,
-    ID.OBSERVABILITY,
-    ID.PREVIEW,
-    !isTauri && isPwa && ID.PWA,
-    ID.REGISTRY,
+    NavTreePlugin.meta.id,
+    ObservabilityPlugin.meta.id,
+    PreviewPlugin.meta.id,
+    !isTauri && isPwa && PwaPlugin.meta.id,
+    RegistryPlugin.meta.id,
     RuntimePlugin.meta.id,
-    ID.SEARCH,
-    ID.SETTINGS,
-    ID.SPACE,
-    ID.STATUS_BAR,
-    ID.THEME,
+    SearchPlugin.meta.id,
+    SettingsPlugin.meta.id,
+    SpacePlugin.meta.id,
+    StatusBarPlugin.meta.id,
+    ThemePlugin.meta.id,
     WelcomePlugin.meta.id,
   ]
     .filter(isTruthy)
@@ -148,232 +136,56 @@ export const getCore = ({ isPwa, isTauri, isPopover, isMobile }: PluginConfig): 
 export const getDefaults = ({ isDev, isLocal, isLabs }: PluginConfig): string[] =>
   [
     // Default
-    ID.GALLERY,
-    ID.INBOX,
-    ID.KANBAN,
-    ID.MARKDOWN,
-    ID.MASONRY,
-    ID.SHEET,
-    ID.SKETCH,
-    ID.TABLE,
-    ID.THREAD,
-    ID.WNFS,
+    GalleryPlugin.meta.id,
+    InboxPlugin.meta.id,
+    KanbanPlugin.meta.id,
+    MarkdownPlugin.meta.id,
+    MasonryPlugin.meta.id,
+    SheetPlugin.meta.id,
+    SketchPlugin.meta.id,
+    TablePlugin.meta.id,
+    ThreadPlugin.meta.id,
+    WnfsPlugin.meta.id,
 
-    ID.CODE,
+    CodePlugin.meta.id,
 
     // Dev
-    isDev && ID.DEBUG,
+    isDev && DebugPlugin.meta.id,
 
     // Local
-    isLocal && ID.SAMPLE,
+    isLocal && SamplePlugin.meta.id,
 
     // Labs
     (isDev || isLabs) && [
-      ID.ASSISTANT,
-      ID.DISCORD,
-      ID.FEED,
-      ID.IROH_BEACON,
-      ID.MEETING,
-      ID.OUTLINER,
-      ID.PIPELINE,
-      ID.SIDEKICK,
-      ID.TRANSCRIPTION,
-      ID.ZEN,
+      AssistantPlugin.meta.id,
+      DiscordPlugin.meta.id,
+      FeedPlugin.meta.id,
+      IrohBeaconPlugin.meta.id,
+      MeetingPlugin.meta.id,
+      OutlinerPlugin.meta.id,
+      PipelinePlugin.meta.id,
+      SidekickPlugin.meta.id,
+      TranscriptionPlugin.meta.id,
+      ZenPlugin.meta.id,
     ],
   ]
     .filter(isTruthy)
     .flat();
 
-/**
- * Optional progress callback fired as each plugin chunk's dynamic import
- * resolves. Hosts can use this to drive a visible counter on the boot
- * loader (`Loading plugins (3/55)…`) while the lazy chunks are pipelining.
- * Resolution order is *not* the array order — these are dynamic imports
- * resolving in parallel — so callers should treat `loaded` as a count, not
- * an index.
- */
-export type GetPluginsOptions = {
-  onPluginLoaded?: (loaded: number, total: number) => void;
-};
-
-/**
- * Constructs every plugin instance the host can offer (whether enabled or not).
- *
- * Each plugin is requested via a dynamic `import()` so the main bundle doesn't
- * pull every plugin's transitive module graph at parse time. Rollup emits a
- * separate chunk per import; network and parser pipeline them in parallel via
- * {@link Promise.all}. The boot loader is already on screen during this phase.
- *
- * @returns A flat list of `Plugin.Plugin` instances, suitable for passing to
- *   `useApp({ plugins })`.
- */
-export const getPlugins = async (
-  {
-    appKey,
-    config,
-    services,
-    observability,
-    logStore,
-    isDev,
-    isLocal,
-    isLabs,
-    isPwa,
-    isTauri,
-    isPopover,
-    isMobile,
-  }: PluginConfig,
-  { onPluginLoaded }: GetPluginsOptions = {},
-): Promise<Plugin.Plugin[]> => {
-  // Track per-plugin completion. The boot loader's status bar shows a counter
-  // ("Loading plugins (12/59)…") so the user has a visible signal that the
-  // lazy chunks are landing in parallel rather than the long Promise.all
-  // looking like a single frozen step. `track()` is generic so the tuple
-  // typing of `Promise.all([...])` survives — `.map()` would collapse the
-  // tuple into a homogeneous union and break the destructure below.
-  let total = 0;
-  let loaded = 0;
-  const track = <T,>(promise: Promise<T>): Promise<T> => {
-    // Bump synchronously during array construction so the final count is
-    // available before any resolution callback fires.
-    total += 1;
-    return promise.then((module) => {
-      loaded += 1;
-      onPluginLoaded?.(loaded, total);
-      return module;
-    });
-  };
-
-  const [
-    { AssistantPlugin },
-    { AttentionPlugin },
-    { AutomationPlugin },
-    { BoardPlugin },
-    { ChessPlugin },
-    { ClientPlugin },
-    { ConductorPlugin },
-    { CrxPlugin },
-    { CrxBridgePlugin },
-    { DailySummaryPlugin },
-    { DebugPlugin },
-    { DeckPlugin },
-    { DiscordPlugin },
-    { DoctorPlugin },
-    { ExplorerPlugin },
-    { FeedPlugin },
-    { GalleryPlugin },
-    { GraphPlugin },
-    { HelpPlugin },
-    { InboxPlugin },
-    { IrohBeaconPlugin },
-    { KanbanPlugin },
-    { MapPlugin },
-    mapSolidModule,
-    { MarkdownPlugin },
-    { MasonryPlugin },
-    { MeetingPlugin },
-    { MermaidPlugin },
-    { NativePlugin },
-    { NativeFilesystemPlugin },
-    { NavTreePlugin },
-    { ObservabilityPlugin },
-    { OutlinerPlugin },
-    { PipelinePlugin },
-    { PresenterPlugin },
-    { PreviewPlugin },
-    { PwaPlugin },
-    { RegistryPlugin },
-    { SamplePlugin },
-    { ScriptPlugin },
-    { SearchPlugin },
-    { SettingsPlugin },
-    { SheetPlugin },
-    { SidekickPlugin },
-    { SimpleLayoutPlugin },
-    { SketchPlugin },
-    { SpacePlugin },
-    { CodePlugin },
-    { SpacetimePlugin },
-    { SpotlightPlugin },
-    { StackPlugin },
-    { StatusBarPlugin },
-    { TablePlugin },
-    { ThemePlugin },
-    { ThreadPlugin },
-    { TicTacToePlugin },
-    { IntegrationPlugin },
-    { TranscriptionPlugin },
-    { TrelloPlugin },
-    { VoxelPlugin },
-    { WnfsPlugin },
-    { ZenPlugin },
-  ] = await Promise.all([
-    track(import('@dxos/plugin-assistant')),
-    track(import('@dxos/plugin-attention')),
-    track(import('@dxos/plugin-automation')),
-    track(import('@dxos/plugin-board')),
-    track(import('@dxos/plugin-chess')),
-    track(import('@dxos/plugin-client')),
-    track(import('@dxos/plugin-conductor')),
-    track(import('@dxos/plugin-crx')),
-    track(import('@dxos/plugin-crx-bridge')),
-    track(import('@dxos/plugin-daily-summary')),
-    track(import('@dxos/plugin-debug')),
-    track(import('@dxos/plugin-deck')),
-    track(import('@dxos/plugin-discord')),
-    track(import('@dxos/plugin-doctor')),
-    track(import('@dxos/plugin-explorer')),
-    track(import('@dxos/plugin-feed')),
-    track(import('@dxos/plugin-gallery')),
-    track(import('@dxos/plugin-graph')),
-    track(import('@dxos/plugin-help')),
-    track(import('@dxos/plugin-inbox')),
-    track(import('@dxos/plugin-iroh-beacon')),
-    track(import('@dxos/plugin-kanban')),
-    track(import('@dxos/plugin-map')),
-    track(import('@dxos/plugin-map-solid')),
-    track(import('@dxos/plugin-markdown')),
-    track(import('@dxos/plugin-masonry')),
-    track(import('@dxos/plugin-meeting')),
-    track(import('@dxos/plugin-mermaid')),
-    track(import('@dxos/plugin-native')),
-    track(import('@dxos/plugin-native-filesystem')),
-    track(import('@dxos/plugin-navtree')),
-    track(import('@dxos/plugin-observability')),
-    track(import('@dxos/plugin-outliner')),
-    track(import('@dxos/plugin-pipeline')),
-    track(import('@dxos/plugin-presenter')),
-    track(import('@dxos/plugin-preview')),
-    track(import('@dxos/plugin-pwa')),
-    track(import('@dxos/plugin-registry')),
-    track(import('@dxos/plugin-sample')),
-    track(import('@dxos/plugin-script')),
-    track(import('@dxos/plugin-search')),
-    track(import('@dxos/plugin-settings')),
-    track(import('@dxos/plugin-sheet')),
-    track(import('@dxos/plugin-sidekick')),
-    track(import('@dxos/plugin-simple-layout')),
-    track(import('@dxos/plugin-sketch')),
-    track(import('@dxos/plugin-space')),
-    track(import('@dxos/plugin-code')),
-    track(import('@dxos/plugin-spacetime')),
-    track(import('@dxos/plugin-spotlight')),
-    track(import('@dxos/plugin-stack')),
-    track(import('@dxos/plugin-status-bar')),
-    track(import('@dxos/plugin-table')),
-    track(import('@dxos/plugin-theme')),
-    track(import('@dxos/plugin-thread')),
-    track(import('@dxos/plugin-tictactoe')),
-    track(import('@dxos/plugin-integration')),
-    track(import('@dxos/plugin-transcription')),
-    track(import('@dxos/plugin-trello')),
-    track(import('@dxos/plugin-voxel')),
-    track(import('@dxos/plugin-wnfs')),
-    track(import('@dxos/plugin-zen')),
-  ]);
-
-  // `@dxos/plugin-map-solid` re-exports `MapPlugin` (alias-imported below).
-  const MapPluginSolid = mapSolidModule.MapPlugin;
-
+export const getPlugins = ({
+  appKey,
+  config,
+  services,
+  observability,
+  logStore,
+  isDev,
+  isLocal,
+  isLabs,
+  isPwa,
+  isTauri,
+  isPopover,
+  isMobile,
+}: PluginConfig): Plugin.Plugin[] => {
   const layoutPlugin = isPopover ? SpotlightPlugin() : isMobile ? SimpleLayoutPlugin({}) : DeckPlugin();
   const origin = isTauri ? APP_LINK_ORIGIN : window.location.origin;
   return [
@@ -439,7 +251,7 @@ export const getPlugins = async (
     isLocal && SamplePlugin(),
     ScriptPlugin(),
     SearchPlugin(),
-    isLabs && SidekickPlugin(),
+    (isDev || isLabs) && SidekickPlugin(),
     SettingsPlugin(),
     SheetPlugin(),
     SketchPlugin(),

--- a/packages/plugins/plugin-assistant/src/AssistantPlugin.tsx
+++ b/packages/plugins/plugin-assistant/src/AssistantPlugin.tsx
@@ -234,3 +234,5 @@ const withComputeRuntime =
       const runtime = yield* provider.getRuntime(spaceId).runtimeEffect;
       return yield* effect.pipe(Effect.provide(runtime));
     });
+
+export default AssistantPlugin;

--- a/packages/plugins/plugin-assistant/src/index.ts
+++ b/packages/plugins/plugin-assistant/src/index.ts
@@ -2,8 +2,13 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './components';
-export * from './hooks';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const AssistantPlugin = Plugin.lazy(meta, () => import('./AssistantPlugin'));
+
 export * from './meta';
 
-export * from './AssistantPlugin';
+export * from './components';
+export * from './hooks';

--- a/packages/plugins/plugin-attention/src/AttentionPlugin.ts
+++ b/packages/plugins/plugin-attention/src/AttentionPlugin.ts
@@ -62,3 +62,5 @@ const setupDevtools = (attention: AttentionManager) => {
     },
   };
 };
+
+export default AttentionPlugin;

--- a/packages/plugins/plugin-attention/src/index.ts
+++ b/packages/plugins/plugin-attention/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2024 DXOS.org
 //
 
-export { AttentionPlugin } from './AttentionPlugin';
-export { meta } from './meta';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const AttentionPlugin = Plugin.lazy(meta, () => import('./AttentionPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-automation/src/AutomationPlugin.tsx
+++ b/packages/plugins/plugin-automation/src/AutomationPlugin.tsx
@@ -25,3 +25,5 @@ export const AutomationPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default AutomationPlugin;

--- a/packages/plugins/plugin-automation/src/index.ts
+++ b/packages/plugins/plugin-automation/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
-export { AutomationPlugin } from './AutomationPlugin';
-export { meta } from './meta';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const AutomationPlugin = Plugin.lazy(meta, () => import('./AutomationPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-board/src/BoardPlugin.tsx
+++ b/packages/plugins/plugin-board/src/BoardPlugin.tsx
@@ -43,3 +43,5 @@ export const BoardPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations: [...translations, ...boardTranslations] }),
   Plugin.make,
 );
+
+export default BoardPlugin;

--- a/packages/plugins/plugin-board/src/index.ts
+++ b/packages/plugins/plugin-board/src/index.ts
@@ -2,6 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
-export * from './meta';
+import { Plugin } from '@dxos/app-framework';
 
-export * from './BoardPlugin';
+import { meta } from './meta';
+
+export const BoardPlugin = Plugin.lazy(meta, () => import('./BoardPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-chess/src/ChessPlugin.tsx
+++ b/packages/plugins/plugin-chess/src/ChessPlugin.tsx
@@ -46,3 +46,5 @@ export const ChessPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default ChessPlugin;

--- a/packages/plugins/plugin-chess/src/index.ts
+++ b/packages/plugins/plugin-chess/src/index.ts
@@ -2,7 +2,12 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './components/Chessboard';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const ChessPlugin = Plugin.lazy(meta, () => import('./ChessPlugin'));
+
 export * from './meta';
 
-export * from './ChessPlugin';
+export * from './components/Chessboard';

--- a/packages/plugins/plugin-client/src/ClientPlugin.ts
+++ b/packages/plugins/plugin-client/src/ClientPlugin.ts
@@ -68,3 +68,5 @@ export const ClientPlugin = Plugin.define<ClientPluginOptions>(meta).pipe(
   ),
   Plugin.make,
 );
+
+export default ClientPlugin;

--- a/packages/plugins/plugin-client/src/index.ts
+++ b/packages/plugins/plugin-client/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
-export { ClientPlugin } from './ClientPlugin';
-export { meta } from './meta';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const ClientPlugin = Plugin.lazy(meta, () => import('./ClientPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-code/src/CodePlugin.tsx
+++ b/packages/plugins/plugin-code/src/CodePlugin.tsx
@@ -82,3 +82,5 @@ export const CodePlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default CodePlugin;

--- a/packages/plugins/plugin-code/src/index.ts
+++ b/packages/plugins/plugin-code/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const CodePlugin = Plugin.lazy(meta, () => import('./CodePlugin'));
+
 export * from './meta';
-export * from './CodePlugin';

--- a/packages/plugins/plugin-conductor/src/ConductorPlugin.tsx
+++ b/packages/plugins/plugin-conductor/src/ConductorPlugin.tsx
@@ -43,3 +43,5 @@ export const ConductorPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default ConductorPlugin;

--- a/packages/plugins/plugin-conductor/src/index.ts
+++ b/packages/plugins/plugin-conductor/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './ConductorPlugin';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const ConductorPlugin = Plugin.lazy(meta, () => import('./ConductorPlugin'));
+
 export * from './meta';

--- a/packages/plugins/plugin-crm/src/CrmPlugin.ts
+++ b/packages/plugins/plugin-crm/src/CrmPlugin.ts
@@ -15,3 +15,5 @@ export const CrmPlugin = Plugin.define(meta).pipe(
   AppPlugin.addSchemaModule({ schema: [ProfileOf.ProfileOf] }),
   Plugin.make,
 );
+
+export default CrmPlugin;

--- a/packages/plugins/plugin-crm/src/index.ts
+++ b/packages/plugins/plugin-crm/src/index.ts
@@ -2,6 +2,10 @@
 // Copyright 2026 DXOS.org
 //
 
-export * from './meta';
+import { Plugin } from '@dxos/app-framework';
 
-export * from './CrmPlugin';
+import { meta } from './meta';
+
+export const CrmPlugin = Plugin.lazy(meta, () => import('./CrmPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-crx-bridge/src/CrxBridgePlugin.ts
+++ b/packages/plugins/plugin-crx-bridge/src/CrxBridgePlugin.ts
@@ -50,3 +50,5 @@ export const CrxBridgePlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default CrxBridgePlugin;

--- a/packages/plugins/plugin-crx-bridge/src/index.ts
+++ b/packages/plugins/plugin-crx-bridge/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2026 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const CrxBridgePlugin = Plugin.lazy(meta, () => import('./CrxBridgePlugin'));
+
 export * from './meta';
-export * from './CrxBridgePlugin';

--- a/packages/plugins/plugin-crx/src/CrxPlugin.tsx
+++ b/packages/plugins/plugin-crx/src/CrxPlugin.tsx
@@ -15,3 +15,5 @@ export const CrxPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default CrxPlugin;

--- a/packages/plugins/plugin-crx/src/index.ts
+++ b/packages/plugins/plugin-crx/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2026 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const CrxPlugin = Plugin.lazy(meta, () => import('./CrxPlugin'));
+
 export * from './meta';
-export * from './CrxPlugin';

--- a/packages/plugins/plugin-daily-summary/src/DailySummaryPlugin.tsx
+++ b/packages/plugins/plugin-daily-summary/src/DailySummaryPlugin.tsx
@@ -16,3 +16,5 @@ export const DailySummaryPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default DailySummaryPlugin;

--- a/packages/plugins/plugin-daily-summary/src/index.ts
+++ b/packages/plugins/plugin-daily-summary/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2026 DXOS.org
 //
 
-export { meta } from './meta';
-export { DailySummaryPlugin } from './DailySummaryPlugin';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const DailySummaryPlugin = Plugin.lazy(meta, () => import('./DailySummaryPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-debug/src/DebugPlugin.tsx
+++ b/packages/plugins/plugin-debug/src/DebugPlugin.tsx
@@ -53,3 +53,5 @@ const setupDevtools = () => {
     location.pathname = '/';
   };
 };
+
+export default DebugPlugin;

--- a/packages/plugins/plugin-debug/src/index.ts
+++ b/packages/plugins/plugin-debug/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './DebugPlugin';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const DebugPlugin = Plugin.lazy(meta, () => import('./DebugPlugin'));
+
 export * from './meta';

--- a/packages/plugins/plugin-deck/src/DeckPlugin.ts
+++ b/packages/plugins/plugin-deck/src/DeckPlugin.ts
@@ -63,3 +63,5 @@ export const DeckPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default DeckPlugin;

--- a/packages/plugins/plugin-deck/src/index.ts
+++ b/packages/plugins/plugin-deck/src/index.ts
@@ -2,7 +2,13 @@
 // Copyright 2023 DXOS.org
 //
 
-export { DeckCapabilities, DeckEvents } from './types';
-export * from './DeckPlugin';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const DeckPlugin = Plugin.lazy(meta, () => import('./DeckPlugin'));
+
 export * from './meta';
+
+export { DeckCapabilities, DeckEvents } from './types';
 export { useCompanions } from './hooks';

--- a/packages/plugins/plugin-discord/src/DiscordPlugin.tsx
+++ b/packages/plugins/plugin-discord/src/DiscordPlugin.tsx
@@ -50,3 +50,5 @@ export const DiscordPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default DiscordPlugin;

--- a/packages/plugins/plugin-discord/src/index.ts
+++ b/packages/plugins/plugin-discord/src/index.ts
@@ -2,7 +2,12 @@
 // Copyright 2026 DXOS.org
 //
 
-export * from './blueprints';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const DiscordPlugin = Plugin.lazy(meta, () => import('./DiscordPlugin'));
+
 export * from './meta';
 
-export * from './DiscordPlugin';
+export * from './blueprints';

--- a/packages/plugins/plugin-doctor/src/DoctorPlugin.tsx
+++ b/packages/plugins/plugin-doctor/src/DoctorPlugin.tsx
@@ -15,3 +15,5 @@ export const DoctorPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default DoctorPlugin;

--- a/packages/plugins/plugin-doctor/src/index.ts
+++ b/packages/plugins/plugin-doctor/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2026 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const DoctorPlugin = Plugin.lazy(meta, () => import('./DoctorPlugin'));
+
 export * from './meta';
-export * from './DoctorPlugin';

--- a/packages/plugins/plugin-explorer/src/ExplorerPlugin.tsx
+++ b/packages/plugins/plugin-explorer/src/ExplorerPlugin.tsx
@@ -47,3 +47,5 @@ export const ExplorerPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default ExplorerPlugin;

--- a/packages/plugins/plugin-explorer/src/index.ts
+++ b/packages/plugins/plugin-explorer/src/index.ts
@@ -2,7 +2,13 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const ExplorerPlugin = Plugin.lazy(meta, () => import('./ExplorerPlugin'));
+
+export * from './meta';
+
 export * from './components';
 export * from './hooks';
-
-export * from './ExplorerPlugin';

--- a/packages/plugins/plugin-feed/src/FeedPlugin.tsx
+++ b/packages/plugins/plugin-feed/src/FeedPlugin.tsx
@@ -113,3 +113,5 @@ export const FeedPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default FeedPlugin;

--- a/packages/plugins/plugin-feed/src/index.ts
+++ b/packages/plugins/plugin-feed/src/index.ts
@@ -2,4 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
-export * from './FeedPlugin';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const FeedPlugin = Plugin.lazy(meta, () => import('./FeedPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-files/src/FilesPlugin.tsx
+++ b/packages/plugins/plugin-files/src/FilesPlugin.tsx
@@ -62,3 +62,5 @@ export const FilesPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default FilesPlugin;

--- a/packages/plugins/plugin-files/src/index.ts
+++ b/packages/plugins/plugin-files/src/index.ts
@@ -2,7 +2,13 @@
 // Copyright 2023 DXOS.org
 //
 
-export { FileCapabilities } from './types';
-export * from './FilesPlugin';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const FilesPlugin = Plugin.lazy(meta, () => import('./FilesPlugin'));
+
 export * from './meta';
+
+export { FileCapabilities } from './types';
 export * from './types';

--- a/packages/plugins/plugin-gallery/src/GalleryPlugin.tsx
+++ b/packages/plugins/plugin-gallery/src/GalleryPlugin.tsx
@@ -44,3 +44,5 @@ export const GalleryPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default GalleryPlugin;

--- a/packages/plugins/plugin-gallery/src/index.ts
+++ b/packages/plugins/plugin-gallery/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
-export * from './GalleryPlugin';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const GalleryPlugin = Plugin.lazy(meta, () => import('./GalleryPlugin'));
+
 export * from './meta';

--- a/packages/plugins/plugin-graph/src/GraphPlugin.ts
+++ b/packages/plugins/plugin-graph/src/GraphPlugin.ts
@@ -23,3 +23,5 @@ export const GraphPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default GraphPlugin;

--- a/packages/plugins/plugin-graph/src/index.ts
+++ b/packages/plugins/plugin-graph/src/index.ts
@@ -2,9 +2,15 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const GraphPlugin = Plugin.lazy(meta, () => import('./GraphPlugin'));
+
+export * from './meta';
+
 export * from '@dxos/app-graph';
 
 export * from './action';
-export * from './GraphPlugin';
 export * from './hooks';
-export * from './meta';

--- a/packages/plugins/plugin-help/src/HelpPlugin.tsx
+++ b/packages/plugins/plugin-help/src/HelpPlugin.tsx
@@ -28,3 +28,5 @@ export const HelpPlugin = Plugin.define<HelpPluginOptions>(meta).pipe(
   })),
   Plugin.make,
 );
+
+export default HelpPlugin;

--- a/packages/plugins/plugin-help/src/index.ts
+++ b/packages/plugins/plugin-help/src/index.ts
@@ -2,8 +2,15 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const HelpPlugin = Plugin.lazy(meta, () => import('./HelpPlugin'));
+
+export * from './meta';
+
 export { HelpCapabilities } from './types';
 export * from './components';
 export * from './constants';
-export * from './HelpPlugin';
 export * from './hooks';

--- a/packages/plugins/plugin-inbox/src/InboxPlugin.tsx
+++ b/packages/plugins/plugin-inbox/src/InboxPlugin.tsx
@@ -131,3 +131,5 @@ export const InboxPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default InboxPlugin;

--- a/packages/plugins/plugin-inbox/src/index.ts
+++ b/packages/plugins/plugin-inbox/src/index.ts
@@ -2,7 +2,12 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './meta';
-// TODO(wittjosiah): Remove. This is needed for debug plugin currently.
+import { Plugin } from '@dxos/app-framework';
 
-export * from './InboxPlugin';
+import { meta } from './meta';
+
+export const InboxPlugin = Plugin.lazy(meta, () => import('./InboxPlugin'));
+
+export * from './meta';
+
+// TODO(wittjosiah): Remove. This is needed for debug plugin currently.

--- a/packages/plugins/plugin-integration/src/IntegrationPlugin.ts
+++ b/packages/plugins/plugin-integration/src/IntegrationPlugin.ts
@@ -77,3 +77,5 @@ export const IntegrationPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default IntegrationPlugin;

--- a/packages/plugins/plugin-integration/src/index.ts
+++ b/packages/plugins/plugin-integration/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const IntegrationPlugin = Plugin.lazy(meta, () => import('./IntegrationPlugin'));
+
 export * from './meta';
-export * from './IntegrationPlugin';

--- a/packages/plugins/plugin-iroh-beacon/src/IrohBeaconPlugin.ts
+++ b/packages/plugins/plugin-iroh-beacon/src/IrohBeaconPlugin.ts
@@ -25,3 +25,5 @@ export const IrohBeaconPlugin = Plugin.define(meta).pipe(
 
   Plugin.make,
 );
+
+export default IrohBeaconPlugin;

--- a/packages/plugins/plugin-iroh-beacon/src/index.ts
+++ b/packages/plugins/plugin-iroh-beacon/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2026 DXOS.org
 //
 
-export { meta } from './meta';
-export { IrohBeaconPlugin } from './IrohBeaconPlugin';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const IrohBeaconPlugin = Plugin.lazy(meta, () => import('./IrohBeaconPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-kanban/src/KanbanPlugin.tsx
+++ b/packages/plugins/plugin-kanban/src/KanbanPlugin.tsx
@@ -59,3 +59,5 @@ export const KanbanPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default KanbanPlugin;

--- a/packages/plugins/plugin-kanban/src/index.ts
+++ b/packages/plugins/plugin-kanban/src/index.ts
@@ -2,6 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './meta';
+import { Plugin } from '@dxos/app-framework';
 
-export * from './KanbanPlugin';
+import { meta } from './meta';
+
+export const KanbanPlugin = Plugin.lazy(meta, () => import('./KanbanPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-map-solid/src/MapPlugin.tsx
+++ b/packages/plugins/plugin-map-solid/src/MapPlugin.tsx
@@ -15,3 +15,5 @@ export const MapPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default MapPlugin;

--- a/packages/plugins/plugin-map-solid/src/index.ts
+++ b/packages/plugins/plugin-map-solid/src/index.ts
@@ -2,6 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
-export * from './meta';
+import { Plugin } from '@dxos/app-framework';
 
-export * from './MapPlugin';
+import { meta } from './meta';
+
+export const MapPlugin = Plugin.lazy(meta, () => import('./MapPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-map/src/MapPlugin.tsx
+++ b/packages/plugins/plugin-map/src/MapPlugin.tsx
@@ -66,3 +66,5 @@ export const MapPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default MapPlugin;

--- a/packages/plugins/plugin-map/src/index.ts
+++ b/packages/plugins/plugin-map/src/index.ts
@@ -2,7 +2,12 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './components';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const MapPlugin = Plugin.lazy(meta, () => import('./MapPlugin'));
+
 export * from './meta';
 
-export * from './MapPlugin';
+export * from './components';

--- a/packages/plugins/plugin-markdown/src/MarkdownPlugin.tsx
+++ b/packages/plugins/plugin-markdown/src/MarkdownPlugin.tsx
@@ -102,3 +102,5 @@ export const MarkdownPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default MarkdownPlugin;

--- a/packages/plugins/plugin-markdown/src/index.ts
+++ b/packages/plugins/plugin-markdown/src/index.ts
@@ -2,12 +2,17 @@
 // Copyright 2023 DXOS.org
 //
 
-export { MarkdownCapabilities, MarkdownEvents } from './types';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const MarkdownPlugin = Plugin.lazy(meta, () => import('./MarkdownPlugin'));
 
 export * from './meta';
-export * from './util';
 
-export * from './MarkdownPlugin';
+export { MarkdownCapabilities, MarkdownEvents } from './types';
+
+export * from './util';
 
 export { MarkdownEditor, MarkdownEditorProvider } from './components';
 export type { MarkdownEditorEditorRootProps } from './components';

--- a/packages/plugins/plugin-masonry/src/MasonryPlugin.tsx
+++ b/packages/plugins/plugin-masonry/src/MasonryPlugin.tsx
@@ -47,3 +47,5 @@ export const MasonryPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default MasonryPlugin;

--- a/packages/plugins/plugin-masonry/src/index.ts
+++ b/packages/plugins/plugin-masonry/src/index.ts
@@ -2,6 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
-export * from './meta';
+import { Plugin } from '@dxos/app-framework';
 
-export * from './MasonryPlugin';
+import { meta } from './meta';
+
+export const MasonryPlugin = Plugin.lazy(meta, () => import('./MasonryPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-meeting/src/MeetingPlugin.ts
+++ b/packages/plugins/plugin-meeting/src/MeetingPlugin.ts
@@ -58,3 +58,5 @@ export const MeetingPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default MeetingPlugin;

--- a/packages/plugins/plugin-meeting/src/index.ts
+++ b/packages/plugins/plugin-meeting/src/index.ts
@@ -2,6 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './meta';
+import { Plugin } from '@dxos/app-framework';
 
-export * from './MeetingPlugin';
+import { meta } from './meta';
+
+export const MeetingPlugin = Plugin.lazy(meta, () => import('./MeetingPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-mermaid/src/MermaidPlugin.tsx
+++ b/packages/plugins/plugin-mermaid/src/MermaidPlugin.tsx
@@ -19,3 +19,5 @@ export const MermaidPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default MermaidPlugin;

--- a/packages/plugins/plugin-mermaid/src/index.ts
+++ b/packages/plugins/plugin-mermaid/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './MermaidPlugin';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const MermaidPlugin = Plugin.lazy(meta, () => import('./MermaidPlugin'));
+
 export * from './meta';

--- a/packages/plugins/plugin-native-filesystem/src/NativeFilesystemPlugin.tsx
+++ b/packages/plugins/plugin-native-filesystem/src/NativeFilesystemPlugin.tsx
@@ -38,3 +38,5 @@ export const NativeFilesystemPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default NativeFilesystemPlugin;

--- a/packages/plugins/plugin-native-filesystem/src/index.ts
+++ b/packages/plugins/plugin-native-filesystem/src/index.ts
@@ -2,6 +2,12 @@
 // Copyright 2025 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const NativeFilesystemPlugin = Plugin.lazy(meta, () => import('./NativeFilesystemPlugin'));
+
 export * from './meta';
-export * from './NativeFilesystemPlugin';
+
 export * from './types';

--- a/packages/plugins/plugin-native/src/NativePlugin.tsx
+++ b/packages/plugins/plugin-native/src/NativePlugin.tsx
@@ -29,3 +29,5 @@ export const NativePlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default NativePlugin;

--- a/packages/plugins/plugin-native/src/index.ts
+++ b/packages/plugins/plugin-native/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const NativePlugin = Plugin.lazy(meta, () => import('./NativePlugin'));
+
 export * from './meta';
-export * from './NativePlugin';

--- a/packages/plugins/plugin-navtree/src/NavTreePlugin.tsx
+++ b/packages/plugins/plugin-navtree/src/NavTreePlugin.tsx
@@ -73,3 +73,5 @@ export const NavTreePlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default NavTreePlugin;

--- a/packages/plugins/plugin-navtree/src/index.ts
+++ b/packages/plugins/plugin-navtree/src/index.ts
@@ -2,7 +2,13 @@
 // Copyright 2023 DXOS.org
 //
 
-export { NavTreeCapabilities, NavTreeEvents } from './types';
-export * from './NavTreePlugin';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const NavTreePlugin = Plugin.lazy(meta, () => import('./NavTreePlugin'));
+
 export * from './meta';
+
+export { NavTreeCapabilities, NavTreeEvents } from './types';
 export * from './util';

--- a/packages/plugins/plugin-observability/src/ObservabilityPlugin.ts
+++ b/packages/plugins/plugin-observability/src/ObservabilityPlugin.ts
@@ -83,3 +83,5 @@ export const ObservabilityPlugin = Plugin.define<ObservabilityPluginOptions>(met
   })),
   Plugin.make,
 );
+
+export default ObservabilityPlugin;

--- a/packages/plugins/plugin-observability/src/index.ts
+++ b/packages/plugins/plugin-observability/src/index.ts
@@ -2,7 +2,13 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const ObservabilityPlugin = Plugin.lazy(meta, () => import('./ObservabilityPlugin'));
+
+export * from './meta';
+
 export { ObservabilityCapabilities, ObservabilityEvents } from './types';
 export * from './components';
-export * from './meta';
-export * from './ObservabilityPlugin';

--- a/packages/plugins/plugin-outliner/src/OutlinerPlugin.tsx
+++ b/packages/plugins/plugin-outliner/src/OutlinerPlugin.tsx
@@ -70,3 +70,5 @@ export const OutlinerPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default OutlinerPlugin;

--- a/packages/plugins/plugin-outliner/src/index.ts
+++ b/packages/plugins/plugin-outliner/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const OutlinerPlugin = Plugin.lazy(meta, () => import('./OutlinerPlugin'));
+
 export * from './meta';
-export * from './OutlinerPlugin';

--- a/packages/plugins/plugin-pipeline/src/PipelinePlugin.tsx
+++ b/packages/plugins/plugin-pipeline/src/PipelinePlugin.tsx
@@ -44,3 +44,5 @@ export const PipelinePlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default PipelinePlugin;

--- a/packages/plugins/plugin-pipeline/src/index.ts
+++ b/packages/plugins/plugin-pipeline/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const PipelinePlugin = Plugin.lazy(meta, () => import('./PipelinePlugin'));
+
 export * from './meta';
-export * from './PipelinePlugin';

--- a/packages/plugins/plugin-presenter/src/PresenterPlugin.tsx
+++ b/packages/plugins/plugin-presenter/src/PresenterPlugin.tsx
@@ -19,3 +19,5 @@ export const PresenterPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default PresenterPlugin;

--- a/packages/plugins/plugin-presenter/src/index.ts
+++ b/packages/plugins/plugin-presenter/src/index.ts
@@ -2,7 +2,12 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './components';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const PresenterPlugin = Plugin.lazy(meta, () => import('./PresenterPlugin'));
 
 export * from './meta';
-export * from './PresenterPlugin';
+
+export * from './components';

--- a/packages/plugins/plugin-preview/src/PreviewPlugin.tsx
+++ b/packages/plugins/plugin-preview/src/PreviewPlugin.tsx
@@ -21,3 +21,5 @@ export const PreviewPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default PreviewPlugin;

--- a/packages/plugins/plugin-preview/src/index.ts
+++ b/packages/plugins/plugin-preview/src/index.ts
@@ -2,6 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './meta';
+import { Plugin } from '@dxos/app-framework';
 
-export * from './PreviewPlugin';
+import { meta } from './meta';
+
+export const PreviewPlugin = Plugin.lazy(meta, () => import('./PreviewPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-pwa/src/PwaPlugin.tsx
+++ b/packages/plugins/plugin-pwa/src/PwaPlugin.tsx
@@ -47,3 +47,5 @@ export const PwaPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default PwaPlugin;

--- a/packages/plugins/plugin-pwa/src/index.ts
+++ b/packages/plugins/plugin-pwa/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const PwaPlugin = Plugin.lazy(meta, () => import('./PwaPlugin'));
+
 export * from './meta';
-export * from './PwaPlugin';

--- a/packages/plugins/plugin-registry/src/RegistryPlugin.tsx
+++ b/packages/plugins/plugin-registry/src/RegistryPlugin.tsx
@@ -21,3 +21,5 @@ export const RegistryPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default RegistryPlugin;

--- a/packages/plugins/plugin-registry/src/index.ts
+++ b/packages/plugins/plugin-registry/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const RegistryPlugin = Plugin.lazy(meta, () => import('./RegistryPlugin'));
+
 export * from './meta';
-export * from './RegistryPlugin';

--- a/packages/plugins/plugin-sample/src/SamplePlugin.ts
+++ b/packages/plugins/plugin-sample/src/SamplePlugin.ts
@@ -70,3 +70,5 @@ export const SamplePlugin = Plugin.define(meta).pipe(
   // Finalizes the plugin. Must be the last call in the chain.
   Plugin.make,
 );
+
+export default SamplePlugin;

--- a/packages/plugins/plugin-sample/src/index.ts
+++ b/packages/plugins/plugin-sample/src/index.ts
@@ -6,5 +6,10 @@
 // Only export what external consumers need: the plugin factory and metadata.
 // Types and operations are available via the `./types` and `./operations` subpath exports.
 
-export { meta } from './meta';
-export { SamplePlugin } from './SamplePlugin';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const SamplePlugin = Plugin.lazy(meta, () => import('./SamplePlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-script/src/ScriptPlugin.tsx
+++ b/packages/plugins/plugin-script/src/ScriptPlugin.tsx
@@ -86,3 +86,5 @@ export const ScriptPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default ScriptPlugin;

--- a/packages/plugins/plugin-script/src/index.ts
+++ b/packages/plugins/plugin-script/src/index.ts
@@ -2,10 +2,15 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const ScriptPlugin = Plugin.lazy(meta, () => import('./ScriptPlugin'));
+
+export * from './meta';
+
 export { ScriptCapabilities, ScriptEvents } from './types';
 export * from './components';
 export * from './containers';
-export * from './meta';
 export * from './util';
-
-export * from './ScriptPlugin';

--- a/packages/plugins/plugin-search/src/SearchPlugin.tsx
+++ b/packages/plugins/plugin-search/src/SearchPlugin.tsx
@@ -34,3 +34,5 @@ export const SearchPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default SearchPlugin;

--- a/packages/plugins/plugin-search/src/index.ts
+++ b/packages/plugins/plugin-search/src/index.ts
@@ -2,8 +2,13 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './hooks';
-export * from './meta';
-export * from './types';
+import { Plugin } from '@dxos/app-framework';
 
-export * from './SearchPlugin';
+import { meta } from './meta';
+
+export const SearchPlugin = Plugin.lazy(meta, () => import('./SearchPlugin'));
+
+export * from './meta';
+
+export * from './hooks';
+export * from './types';

--- a/packages/plugins/plugin-settings/src/SettingsPlugin.ts
+++ b/packages/plugins/plugin-settings/src/SettingsPlugin.ts
@@ -15,3 +15,5 @@ export const SettingsPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default SettingsPlugin;

--- a/packages/plugins/plugin-settings/src/index.ts
+++ b/packages/plugins/plugin-settings/src/index.ts
@@ -2,5 +2,12 @@
 // Copyright 2024 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const SettingsPlugin = Plugin.lazy(meta, () => import('./SettingsPlugin'));
+
+export * from './meta';
+
 export * from './actions';
-export * from './SettingsPlugin';

--- a/packages/plugins/plugin-sheet/src/SheetPlugin.tsx
+++ b/packages/plugins/plugin-sheet/src/SheetPlugin.tsx
@@ -79,3 +79,5 @@ export const SheetPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default SheetPlugin;

--- a/packages/plugins/plugin-sheet/src/index.ts
+++ b/packages/plugins/plugin-sheet/src/index.ts
@@ -2,6 +2,12 @@
 // Copyright 2023 DXOS.org
 //
 
-export { SheetCapabilities } from './types';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const SheetPlugin = Plugin.lazy(meta, () => import('./SheetPlugin'));
+
 export * from './meta';
-export * from './SheetPlugin';
+
+export { SheetCapabilities } from './types';

--- a/packages/plugins/plugin-sidekick/src/SidekickPlugin.tsx
+++ b/packages/plugins/plugin-sidekick/src/SidekickPlugin.tsx
@@ -29,3 +29,5 @@ export const SidekickPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default SidekickPlugin;

--- a/packages/plugins/plugin-sidekick/src/index.ts
+++ b/packages/plugins/plugin-sidekick/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const SidekickPlugin = Plugin.lazy(meta, () => import('./SidekickPlugin'));
+
 export * from './meta';
-export * from './SidekickPlugin';

--- a/packages/plugins/plugin-simple-layout/src/SimpleLayoutPlugin.ts
+++ b/packages/plugins/plugin-simple-layout/src/SimpleLayoutPlugin.ts
@@ -55,3 +55,5 @@ export const SimpleLayoutPlugin = Plugin.define<SimpleLayoutPluginOptions>(meta)
   }),
   Plugin.make,
 );
+
+export default SimpleLayoutPlugin;

--- a/packages/plugins/plugin-simple-layout/src/index.ts
+++ b/packages/plugins/plugin-simple-layout/src/index.ts
@@ -2,4 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
-export * from './SimpleLayoutPlugin';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const SimpleLayoutPlugin = Plugin.lazy(meta, () => import('./SimpleLayoutPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-sketch/src/SketchPlugin.tsx
+++ b/packages/plugins/plugin-sketch/src/SketchPlugin.tsx
@@ -54,3 +54,5 @@ export const SketchPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default SketchPlugin;

--- a/packages/plugins/plugin-sketch/src/index.ts
+++ b/packages/plugins/plugin-sketch/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const SketchPlugin = Plugin.lazy(meta, () => import('./SketchPlugin'));
+
 export * from './meta';
-export * from './SketchPlugin';

--- a/packages/plugins/plugin-space/src/SpacePlugin.ts
+++ b/packages/plugins/plugin-space/src/SpacePlugin.ts
@@ -263,3 +263,5 @@ export const SpacePlugin = Plugin.define<SpacePluginOptions>(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default SpacePlugin;

--- a/packages/plugins/plugin-space/src/index.ts
+++ b/packages/plugins/plugin-space/src/index.ts
@@ -2,9 +2,15 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const SpacePlugin = Plugin.lazy(meta, () => import('./SpacePlugin'));
+
+export * from './meta';
+
 export { SpaceCapabilities, SpaceEvents } from './types';
 
 export * from './components';
 export * from './util';
-
-export * from './SpacePlugin';

--- a/packages/plugins/plugin-spacetime/src/SpacetimePlugin.tsx
+++ b/packages/plugins/plugin-spacetime/src/SpacetimePlugin.tsx
@@ -43,3 +43,5 @@ export const SpacetimePlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default SpacetimePlugin;

--- a/packages/plugins/plugin-spacetime/src/index.ts
+++ b/packages/plugins/plugin-spacetime/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2026 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const SpacetimePlugin = Plugin.lazy(meta, () => import('./SpacetimePlugin'));
+
 export * from './meta';
-export * from './SpacetimePlugin';

--- a/packages/plugins/plugin-spotlight/src/SpotlightPlugin.ts
+++ b/packages/plugins/plugin-spotlight/src/SpotlightPlugin.ts
@@ -31,3 +31,5 @@ export const SpotlightPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default SpotlightPlugin;

--- a/packages/plugins/plugin-spotlight/src/index.ts
+++ b/packages/plugins/plugin-spotlight/src/index.ts
@@ -2,4 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
-export * from './SpotlightPlugin';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const SpotlightPlugin = Plugin.lazy(meta, () => import('./SpotlightPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-stack/src/StackPlugin.ts
+++ b/packages/plugins/plugin-stack/src/StackPlugin.ts
@@ -34,3 +34,5 @@ export const StackPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default StackPlugin;

--- a/packages/plugins/plugin-stack/src/index.ts
+++ b/packages/plugins/plugin-stack/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const StackPlugin = Plugin.lazy(meta, () => import('./StackPlugin'));
+
 export * from './meta';
-export * from './StackPlugin';

--- a/packages/plugins/plugin-status-bar/src/StatusBarPlugin.ts
+++ b/packages/plugins/plugin-status-bar/src/StatusBarPlugin.ts
@@ -14,3 +14,5 @@ export const StatusBarPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default StatusBarPlugin;

--- a/packages/plugins/plugin-status-bar/src/index.ts
+++ b/packages/plugins/plugin-status-bar/src/index.ts
@@ -2,6 +2,12 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './components';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const StatusBarPlugin = Plugin.lazy(meta, () => import('./StatusBarPlugin'));
+
 export * from './meta';
-export * from './StatusBarPlugin';
+
+export * from './components';

--- a/packages/plugins/plugin-table/src/TablePlugin.tsx
+++ b/packages/plugins/plugin-table/src/TablePlugin.tsx
@@ -76,3 +76,5 @@ export const TablePlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default TablePlugin;

--- a/packages/plugins/plugin-table/src/index.ts
+++ b/packages/plugins/plugin-table/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const TablePlugin = Plugin.lazy(meta, () => import('./TablePlugin'));
+
 export * from './meta';
-export * from './TablePlugin';

--- a/packages/plugins/plugin-template/src/TemplatePlugin.tsx
+++ b/packages/plugins/plugin-template/src/TemplatePlugin.tsx
@@ -42,3 +42,5 @@ export const TemplatePlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default TemplatePlugin;

--- a/packages/plugins/plugin-theme/src/ThemePlugin.ts
+++ b/packages/plugins/plugin-theme/src/ThemePlugin.ts
@@ -20,3 +20,5 @@ export const ThemePlugin = Plugin.define<ThemePluginOptions>(meta).pipe(
   })),
   Plugin.make,
 );
+
+export default ThemePlugin;

--- a/packages/plugins/plugin-theme/src/index.ts
+++ b/packages/plugins/plugin-theme/src/index.ts
@@ -2,4 +2,10 @@
 // Copyright 2023 DXOS.org
 //
 
-export * from './ThemePlugin';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const ThemePlugin = Plugin.lazy(meta, () => import('./ThemePlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-thread/src/ThreadPlugin.tsx
+++ b/packages/plugins/plugin-thread/src/ThreadPlugin.tsx
@@ -128,3 +128,5 @@ export const ThreadPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default ThreadPlugin;

--- a/packages/plugins/plugin-thread/src/index.ts
+++ b/packages/plugins/plugin-thread/src/index.ts
@@ -2,9 +2,14 @@
 // Copyright 2023 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const ThreadPlugin = Plugin.lazy(meta, () => import('./ThreadPlugin'));
+
+export * from './meta';
+
 export { ThreadCapabilities } from './types';
 export * from './calls';
 export * from './hooks';
-export * from './meta';
-
-export * from './ThreadPlugin';

--- a/packages/plugins/plugin-tictactoe/src/TicTacToePlugin.tsx
+++ b/packages/plugins/plugin-tictactoe/src/TicTacToePlugin.tsx
@@ -46,3 +46,5 @@ export const TicTacToePlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default TicTacToePlugin;

--- a/packages/plugins/plugin-tictactoe/src/index.ts
+++ b/packages/plugins/plugin-tictactoe/src/index.ts
@@ -2,6 +2,10 @@
 // Copyright 2026 DXOS.org
 //
 
-export * from './meta';
+import { Plugin } from '@dxos/app-framework';
 
-export * from './TicTacToePlugin';
+import { meta } from './meta';
+
+export const TicTacToePlugin = Plugin.lazy(meta, () => import('./TicTacToePlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-transcription/src/TranscriptionPlugin.tsx
+++ b/packages/plugins/plugin-transcription/src/TranscriptionPlugin.tsx
@@ -52,3 +52,5 @@ export const TranscriptionPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default TranscriptionPlugin;

--- a/packages/plugins/plugin-transcription/src/index.ts
+++ b/packages/plugins/plugin-transcription/src/index.ts
@@ -2,11 +2,16 @@
 // Copyright 2025 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const TranscriptionPlugin = Plugin.lazy(meta, () => import('./TranscriptionPlugin'));
+
+export * from './meta';
+
 export { TranscriptionCapabilities } from './types';
 
 export * from './components';
 export * from './hooks';
-export * from './meta';
 export * from './transcriber';
-
-export * from './TranscriptionPlugin';

--- a/packages/plugins/plugin-transformer/src/TransformerPlugin.tsx
+++ b/packages/plugins/plugin-transformer/src/TransformerPlugin.tsx
@@ -19,3 +19,5 @@ export const TransformerPlugin = Plugin.define(meta).pipe(
   // }),
   Plugin.make,
 );
+
+export default TransformerPlugin;

--- a/packages/plugins/plugin-transformer/src/index.ts
+++ b/packages/plugins/plugin-transformer/src/index.ts
@@ -2,6 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
-export * from './meta';
+import { Plugin } from '@dxos/app-framework';
 
-export * from './TransformerPlugin';
+import { meta } from './meta';
+
+export const TransformerPlugin = Plugin.lazy(meta, () => import('./TransformerPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-trello/src/TrelloPlugin.ts
+++ b/packages/plugins/plugin-trello/src/TrelloPlugin.ts
@@ -20,3 +20,5 @@ export const TrelloPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default TrelloPlugin;

--- a/packages/plugins/plugin-trello/src/index.ts
+++ b/packages/plugins/plugin-trello/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2026 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const TrelloPlugin = Plugin.lazy(meta, () => import('./TrelloPlugin'));
+
 export * from './meta';
-export * from './TrelloPlugin';

--- a/packages/plugins/plugin-voxel/src/VoxelPlugin.tsx
+++ b/packages/plugins/plugin-voxel/src/VoxelPlugin.tsx
@@ -43,3 +43,5 @@ export const VoxelPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default VoxelPlugin;

--- a/packages/plugins/plugin-voxel/src/index.ts
+++ b/packages/plugins/plugin-voxel/src/index.ts
@@ -2,8 +2,13 @@
 // Copyright 2026 DXOS.org
 //
 
-export * from './components';
-export * from './meta';
-export * from './models';
+import { Plugin } from '@dxos/app-framework';
 
-export * from './VoxelPlugin';
+import { meta } from './meta';
+
+export const VoxelPlugin = Plugin.lazy(meta, () => import('./VoxelPlugin'));
+
+export * from './meta';
+
+export * from './components';
+export * from './models';

--- a/packages/plugins/plugin-wnfs/src/WnfsPlugin.tsx
+++ b/packages/plugins/plugin-wnfs/src/WnfsPlugin.tsx
@@ -72,3 +72,5 @@ export const WnfsPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default WnfsPlugin;

--- a/packages/plugins/plugin-wnfs/src/index.ts
+++ b/packages/plugins/plugin-wnfs/src/index.ts
@@ -2,6 +2,12 @@
 // Copyright 2024 DXOS.org
 //
 
-export { WnfsCapabilities } from './types';
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const WnfsPlugin = Plugin.lazy(meta, () => import('./WnfsPlugin'));
+
 export * from './meta';
-export * from './WnfsPlugin';
+
+export { WnfsCapabilities } from './types';

--- a/packages/plugins/plugin-zen/src/ZenPlugin.tsx
+++ b/packages/plugins/plugin-zen/src/ZenPlugin.tsx
@@ -43,3 +43,5 @@ export const ZenPlugin = Plugin.define(meta).pipe(
   AppPlugin.addTranslationsModule({ translations }),
   Plugin.make,
 );
+
+export default ZenPlugin;

--- a/packages/plugins/plugin-zen/src/index.ts
+++ b/packages/plugins/plugin-zen/src/index.ts
@@ -2,6 +2,10 @@
 // Copyright 2025 DXOS.org
 //
 
-export * from './meta';
+import { Plugin } from '@dxos/app-framework';
 
-export * from './ZenPlugin';
+import { meta } from './meta';
+
+export const ZenPlugin = Plugin.lazy(meta, () => import('./ZenPlugin'));
+
+export * from './meta';

--- a/packages/sdk/app-framework/src/core/plugin-manager.test.ts
+++ b/packages/sdk/app-framework/src/core/plugin-manager.test.ts
@@ -1139,4 +1139,216 @@ describe('PluginManager', () => {
       assert.strictEqual(manager.capabilities.getAll(String).length, 1);
     }),
   );
+
+  describe('Plugin.lazy', () => {
+    const lazyMeta = { id: 'org.dxos.plugin.lazy', name: 'Lazy' };
+
+    it('exposes meta synchronously without invoking the loader', () => {
+      let loaderCalls = 0;
+      const Real = Plugin.make(Plugin.define<void>(lazyMeta));
+      const LazyTest = Plugin.lazy(lazyMeta, () => {
+        loaderCalls++;
+        return Promise.resolve({ default: Real });
+      });
+
+      assert.strictEqual(LazyTest.meta.id, lazyMeta.id);
+      assert.strictEqual(LazyTest.meta.name, 'Lazy');
+      assert.strictEqual(loaderCalls, 0);
+
+      const stub = LazyTest();
+      assert.strictEqual(stub.meta.id, lazyMeta.id);
+      assert.deepStrictEqual([...stub.modules], []);
+      assert.isTrue(Plugin.isLazy(stub));
+      assert.strictEqual(loaderCalls, 0);
+    });
+
+    it.effect('resolves the loader on enable and registers the real plugin modules', () =>
+      Effect.gen(function* () {
+        let loaderCalls = 0;
+        const Real = Plugin.define(lazyMeta).pipe(
+          Plugin.addModule({
+            id: 'Hello',
+            activatesOn: ActivationEvents.Startup,
+            activate: () => Effect.succeed(Capability.contributes(String, { string: 'hello' })),
+          }),
+          Plugin.make,
+        );
+        const LazyTest = Plugin.lazy(lazyMeta, () => {
+          loaderCalls++;
+          return Promise.resolve({ default: Real });
+        });
+
+        const lazyStub = LazyTest();
+        plugins = [lazyStub];
+
+        const manager = PluginManager.make({ pluginLoader });
+        yield* manager.add(lazyMeta.id);
+        // Loader has not been invoked yet — only meta is exposed.
+        assert.strictEqual(loaderCalls, 0);
+        assert.deepStrictEqual(manager.getModules(), []);
+
+        yield* manager.enable(lazyMeta.id);
+        assert.strictEqual(loaderCalls, 1);
+        // After enable the registered plugin should be the real one (not the stub),
+        // and its modules should be registered with the manager.
+        const registered = manager.getPlugins().find((p) => p.meta.id === lazyMeta.id);
+        assert.isDefined(registered);
+        assert.isFalse(Plugin.isLazy(registered!));
+        assert.strictEqual(registered!.modules.length, 1);
+
+        yield* manager.activate(ActivationEvents.Startup);
+        assert.strictEqual(manager.capabilities.getAll(String).length, 1);
+      }),
+    );
+
+    it.effect('does not invoke the loader if the plugin is never enabled', () =>
+      Effect.gen(function* () {
+        let loaderCalls = 0;
+        const Real = Plugin.make(Plugin.define<void>(lazyMeta));
+        const LazyTest = Plugin.lazy(lazyMeta, () => {
+          loaderCalls++;
+          return Promise.resolve({ default: Real });
+        });
+        const lazyStub = LazyTest();
+        plugins = [lazyStub];
+
+        const manager = PluginManager.make({ pluginLoader });
+        yield* manager.add(lazyMeta.id);
+
+        // Activate an event that has no listeners — the lazy plugin must not load.
+        yield* manager.activate(ActivationEvents.Startup);
+        assert.strictEqual(loaderCalls, 0);
+      }),
+    );
+
+    it.effect('forwards factory options to the real plugin factory', () =>
+      Effect.gen(function* () {
+        type Opts = { greeting: string };
+        const RealFactory = (opts: Opts) =>
+          Plugin.define(lazyMeta).pipe(
+            Plugin.addModule({
+              id: 'Hello',
+              activatesOn: ActivationEvents.Startup,
+              activate: () => Effect.succeed(Capability.contributes(String, { string: opts.greeting })),
+            }),
+            Plugin.make,
+          )(undefined as void);
+
+        const RealFactoryWithMeta = Object.assign(RealFactory, { meta: lazyMeta });
+
+        const LazyTest = Plugin.lazy<Opts>(lazyMeta, () => Promise.resolve({ default: RealFactoryWithMeta }));
+        const lazyStub = LazyTest({ greeting: 'hola' });
+        plugins = [lazyStub];
+
+        const manager = PluginManager.make({ pluginLoader });
+        yield* manager.add(lazyMeta.id);
+        yield* manager.enable(lazyMeta.id);
+        yield* manager.activate(ActivationEvents.Startup);
+
+        const all = manager.capabilities.getAll(String);
+        assert.strictEqual(all.length, 1);
+        assert.strictEqual(all[0].string, 'hola');
+      }),
+    );
+
+    it.effect('wraps loader rejections in a descriptive error', () =>
+      Effect.gen(function* () {
+        const LazyTest = Plugin.lazy(lazyMeta, () =>
+          Promise.reject<{ default: Plugin.PluginFactory }>(new Error('boom')),
+        );
+        const lazyStub = LazyTest();
+        plugins = [lazyStub];
+
+        const manager = PluginManager.make({ pluginLoader });
+        yield* manager.add(lazyMeta.id);
+
+        const exit = yield* Effect.exit(manager.enable(lazyMeta.id));
+        assert.isTrue(Exit.isFailure(exit));
+        if (Exit.isFailure(exit)) {
+          const failure = Cause.failureOption(exit.cause);
+          assert.isTrue(failure._tag === 'Some');
+          if (failure._tag === 'Some') {
+            assert.isTrue(Plugin.LazyPluginError.is(failure.value));
+            assert.strictEqual((failure.value as Plugin.LazyPluginError).context.id, lazyMeta.id);
+            assert.strictEqual((failure.value as Plugin.LazyPluginError).context.reason, 'load-failed');
+          }
+        }
+      }),
+    );
+
+    it.effect('publishes a lazy:<id> error message when resolution fails', () =>
+      Effect.gen(function* () {
+        const LazyTest = Plugin.lazy(lazyMeta, () =>
+          Promise.reject<{ default: Plugin.PluginFactory }>(new Error('boom')),
+        );
+        const lazyStub = LazyTest();
+        plugins = [lazyStub];
+
+        const manager = PluginManager.make({ pluginLoader });
+        // Subscribe first so we don't miss the activating/error pair.
+        const queue = yield* PubSub.subscribe(manager.activation);
+        yield* manager.add(lazyMeta.id);
+        yield* Effect.exit(manager.enable(lazyMeta.id));
+        const messages = yield* Queue.takeAll(queue);
+
+        const errorMessage = [...messages].find((m) => m.module === `lazy:${lazyMeta.id}` && m.state === 'error');
+        assert.isDefined(errorMessage);
+        assert.isDefined(errorMessage!.error);
+      }).pipe(Effect.scoped),
+    );
+
+    it.effect('coalesces concurrent lazy resolutions of the same plugin id', () =>
+      Effect.gen(function* () {
+        let factoryCalls = 0;
+        const Real = (() => {
+          const inner = Plugin.make(
+            Plugin.define<void>(lazyMeta).pipe(
+              Plugin.addModule({
+                id: 'Hello',
+                activatesOn: ActivationEvents.Startup,
+                activate: () => Effect.succeed(Capability.contributes(String, { string: 'hello' })),
+              }),
+            ),
+          );
+          const factory = (() => {
+            factoryCalls++;
+            return inner();
+          }) as Plugin.PluginFactory;
+          return Object.assign(factory, { meta: lazyMeta });
+        })();
+        const LazyTest = Plugin.lazy(lazyMeta, () => Promise.resolve({ default: Real }));
+        const lazyStub = LazyTest();
+        // `manager.enable(id)` is implicitly called twice — once from the
+        // constructor's core/enabled chain, once from our explicit call. With
+        // coalescing, the underlying factory should still run exactly once.
+        plugins = [lazyStub];
+        const manager = PluginManager.make({ pluginLoader, plugins, core: [lazyMeta.id] });
+        yield* manager.enable(lazyMeta.id);
+        assert.strictEqual(factoryCalls, 1);
+      }),
+    );
+
+    it.effect('fails with a tagged error when the factory output is not a Plugin', () =>
+      Effect.gen(function* () {
+        const BadFactory = Object.assign(() => ({ not: 'a plugin' }) as any, { meta: lazyMeta });
+        const LazyTest = Plugin.lazy(lazyMeta, () => Promise.resolve({ default: BadFactory }));
+        const lazyStub = LazyTest();
+        plugins = [lazyStub];
+
+        const manager = PluginManager.make({ pluginLoader });
+        yield* manager.add(lazyMeta.id);
+
+        const exit = yield* Effect.exit(manager.enable(lazyMeta.id));
+        assert.isTrue(Exit.isFailure(exit));
+        if (Exit.isFailure(exit)) {
+          const failure = Cause.failureOption(exit.cause);
+          assert.isTrue(failure._tag === 'Some');
+          if (failure._tag === 'Some') {
+            assert.isTrue(Plugin.LazyPluginError.is(failure.value));
+            assert.strictEqual((failure.value as Plugin.LazyPluginError).context.reason, 'invalid-plugin');
+          }
+        }
+      }),
+    );
+  });
 });

--- a/packages/sdk/app-framework/src/core/plugin-manager.ts
+++ b/packages/sdk/app-framework/src/core/plugin-manager.ts
@@ -16,12 +16,25 @@ import * as Ref from 'effect/Ref';
 
 import { runAndForwardErrors } from '@dxos/effect';
 import { Performance } from '@dxos/effect';
+import { BaseError } from '@dxos/errors';
 import { log } from '@dxos/log';
 
 import * as ActivationEvent from './activation-event';
 import * as Capability from './capability';
 import * as CapabilityManager from './capability-manager';
 import * as Plugin from './plugin';
+
+/**
+ * Tagged error for failures during the constructor-launched core/enabled
+ * `enable()` chain. Surfaces via {@link PluginManager.activate}'s wait on
+ * `_initialization` so a caller blocked on initialization gets a typed
+ * failure (with the original error preserved as `cause`) instead of an
+ * untyped `Error`.
+ */
+export class PluginInitializationError extends BaseError.extend(
+  'PluginInitializationError',
+  'Plugin manager initialization failed',
+) {}
 
 /**
  * Identifier denoting a Manager.
@@ -129,11 +142,25 @@ class ManagerImpl implements PluginManager {
   private readonly _capabilities = new Map<string, Capability.Any[]>();
   private readonly _moduleMemoMap = new Map<Plugin.PluginModule['id'], Deferred.Deferred<Capability.Any[], Error>>();
   private readonly _moduleSemaphores = new Map<Plugin.PluginModule['id'], Effect.Semaphore>();
+  // Coalesces concurrent `_resolveLazyPlugin` calls per plugin id. Without
+  // this, two callers entering `enable(id)` before the swap completes would
+  // each invoke `mod.default(options)` and produce distinct module objects,
+  // defeating `_addModule`'s reference-equality dedupe and racing the
+  // `_pluginsAtom` swap.
+  private readonly _resolvingPlugins = new Map<string, Deferred.Deferred<Plugin.Plugin, Plugin.LazyPluginError>>();
   private readonly _activatingEvents = Effect.runSync(Ref.make<string[]>([]));
   private readonly _activatingModules = Effect.runSync(Ref.make<string[]>([]));
   private readonly _inFlightFibers = Effect.runSync(Ref.make<Array<Fiber.Fiber<unknown, unknown>>>([]));
   private readonly _shutdownSemaphore = Effect.runSync(Effect.makeSemaphore(1));
   private readonly _shuttingDown = Effect.runSync(Ref.make(false));
+  // Tracks the constructor-launched core/enabled `enable()` calls so that
+  // `activate` can wait for module registration before dispatching events.
+  // Lazy plugins make `enable` asynchronous (a dynamic `import()` happens
+  // inside it), so without this synchronization an `activate` triggered
+  // immediately after `make` could fire on an empty module set. Failures
+  // are wrapped in `PluginInitializationError` so awaiters get a tagged
+  // error rather than the wide `Error` produced by the underlying chain.
+  private readonly _initialization = Effect.runSync(Deferred.make<void, PluginInitializationError>());
 
   constructor({
     pluginLoader,
@@ -158,7 +185,19 @@ class ManagerImpl implements PluginManager {
     this._eventsFiredAtom = Atom.make<string[]>([]).pipe(Atom.keepAlive);
     this._pendingResetAtom = Atom.make<string[]>([]).pipe(Atom.keepAlive);
     plugins.forEach((plugin) => this._addPlugin(plugin));
-    void Effect.all([...core, ...enabled].map((id) => this.enable(id))).pipe(runAndForwardErrors);
+    // Dedupe before mapping to `enable` — `core` and `enabled` may overlap (an
+    // app-supplied plugin can be in both), and concurrent `enable(id)` calls
+    // for the same id are not idempotent (each would re-run the lazy resolve
+    // and double-register modules). `new Set([...])` preserves first-seen
+    // order which matches the natural core-before-enabled precedence.
+    const initialIds = [...new Set([...core, ...enabled])];
+    void Effect.all(initialIds.map((id) => this.enable(id)))
+      .pipe(
+        Effect.mapError((cause) => new PluginInitializationError({ cause })),
+        Effect.tap(() => Deferred.succeed(this._initialization, undefined)),
+        Effect.tapErrorCause((cause) => Deferred.failCause(this._initialization, cause)),
+      )
+      .pipe(runAndForwardErrors);
   }
 
   get plugins(): Atom.Atom<readonly Plugin.Plugin[]> {
@@ -253,10 +292,12 @@ class ManagerImpl implements PluginManager {
   enable(id: string): Effect.Effect<boolean, Error> {
     return Effect.gen(this, function* () {
       log('enable plugin', { id });
-      const plugin = this._getPlugin(id);
-      if (!plugin) {
+      const stub = this._getPlugin(id);
+      if (!stub) {
         return false;
       }
+
+      const plugin = yield* this._resolveLazyPlugin(stub);
 
       this._update(this._enabledAtom, (enabled) => (enabled.includes(id) ? enabled : [...enabled, id]));
 
@@ -272,6 +313,52 @@ class ManagerImpl implements PluginManager {
       );
 
       return true;
+    });
+  }
+
+  /**
+   * Resolves a lazy plugin stub (returned by {@link Plugin.lazy}) to its
+   * loaded form and swaps it into `_pluginsAtom`. Returns the input unchanged
+   * when the plugin is already resolved, so callers can `yield*` this
+   * unconditionally. The lazy stub carries `meta` synchronously but its
+   * `modules` list is empty until the loader resolves; the swap ensures
+   * subsequent enable/disable operations see the resolved plugin.
+   *
+   * Concurrent calls for the same id are coalesced via `_resolvingPlugins`:
+   * the first caller starts the resolution, every subsequent caller awaits
+   * the same `Deferred`. On failure we publish a `lazy:<id>` error message
+   * and skip the atom swap so the failure is observable to the activation
+   * subscriber and a retry can be attempted.
+   */
+  private _resolveLazyPlugin(plugin: Plugin.Plugin): Effect.Effect<Plugin.Plugin, Plugin.LazyPluginError> {
+    return Effect.gen(this, function* () {
+      if (!Plugin.isLazy(plugin)) {
+        return plugin;
+      }
+      const id = plugin.meta.id;
+
+      const existing = this._resolvingPlugins.get(id);
+      if (existing) {
+        return yield* Deferred.await(existing);
+      }
+      const deferred = yield* Deferred.make<Plugin.Plugin, Plugin.LazyPluginError>();
+      this._resolvingPlugins.set(id, deferred);
+
+      return yield* Effect.gen(this, function* () {
+        log('resolving lazy plugin', { id });
+        yield* PubSub.publish(this.activation, { event: '', state: 'activating', module: `lazy:${id}` });
+        const resolvedPlugin = yield* Plugin.resolveLazy(plugin);
+        this._update(this._pluginsAtom, (plugins) => plugins.map((p) => (p.meta.id === id ? resolvedPlugin : p)));
+        yield* PubSub.publish(this.activation, { event: '', state: 'activated', module: `lazy:${id}` });
+        return resolvedPlugin;
+      }).pipe(
+        Effect.tapError((error) =>
+          PubSub.publish(this.activation, { event: '', state: 'error', module: `lazy:${id}`, error }),
+        ),
+        Effect.tap((value) => Deferred.succeed(deferred, value)),
+        Effect.tapErrorCause((cause) => Deferred.failCause(deferred, cause)),
+        Effect.ensuring(Effect.sync(() => this._resolvingPlugins.delete(id))),
+      );
     });
   }
 
@@ -345,6 +432,12 @@ class ManagerImpl implements PluginManager {
         log('skipping activation during shutdown', { key, ...params });
         return false;
       }
+
+      // Wait for the constructor's core/enabled `enable()` chain — including
+      // any async dynamic imports for lazy plugins — to finish registering
+      // modules. Without this, dispatching to an empty module set is the
+      // observable symptom of the race.
+      yield* Deferred.await(this._initialization);
 
       return yield* Effect.withFiberRuntime<boolean, Error>((fiber) =>
         this._activateEvent(key, params, fiber).pipe(

--- a/packages/sdk/app-framework/src/core/plugin.ts
+++ b/packages/sdk/app-framework/src/core/plugin.ts
@@ -7,6 +7,7 @@ import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 import * as Pipeable from 'effect/Pipeable';
 
+import { BaseError } from '@dxos/errors';
 import { invariant } from '@dxos/invariant';
 
 import type * as ActivationEvent from './activation-event';
@@ -353,3 +354,105 @@ export function make<T>(builder: PluginBuilder<T>): PluginFactory<T> {
 
   return Object.assign(factory, { meta });
 }
+
+//
+// Lazy plugin loading
+//
+
+/**
+ * Symbol used to tag lazy plugin stubs with their loader closure.
+ * Hidden from enumeration so plugin manager iteration / serialization paths
+ * don't trip over it.
+ */
+const LazyTag: unique symbol = Symbol.for('@dxos/app-framework/Plugin/Lazy');
+
+/**
+ * Async loader for a lazy plugin's real implementation.
+ * The default export of the loaded module must be a `PluginFactory<T>` —
+ * i.e. the same shape `Plugin.make` produces.
+ */
+export type LazyLoader<T = void> = () => Promise<{ default: PluginFactory<T> }>;
+
+/** Internal: payload carried on a lazy stub. */
+type LazyPayload = { loader: LazyLoader<any>; options: unknown };
+
+/**
+ * Defines a lazy plugin whose body is loaded on first enable.
+ *
+ * The returned factory produces a stub `Plugin` that exposes `meta`
+ * synchronously (so callers can read `Plugin.meta.id` for free) but defers
+ * loading the real plugin's modules until the manager calls
+ * `Plugin.resolveLazy`. This lets the plugin's main entry point ship as a
+ * tiny meta-only chunk — the heavy capabilities, schema, React surfaces,
+ * etc. live behind the dynamic `import()` and become a separate Rollup
+ * chunk that is only fetched when the plugin is enabled.
+ *
+ * @example
+ * ```ts
+ * // plugin-markdown/src/index.ts
+ * import { Plugin } from '@dxos/app-framework';
+ * import { meta } from './meta';
+ *
+ * export const MarkdownPlugin = Plugin.lazy(meta, () => import('./MarkdownPlugin'));
+ *
+ * // plugin-markdown/src/MarkdownPlugin.tsx
+ * export const MarkdownPlugin = Plugin.define(meta).pipe(...heavy modules..., Plugin.make);
+ * export default MarkdownPlugin;
+ * ```
+ */
+export const lazy = <T = void>(meta: Meta, loader: LazyLoader<T>): PluginFactory<T> => {
+  const factory = (options: T): Plugin => {
+    const stub = new PluginImpl(meta, []);
+    Object.defineProperty(stub, LazyTag, {
+      value: { loader, options } satisfies LazyPayload,
+      enumerable: false,
+    });
+    return stub;
+  };
+  return Object.assign(factory, { meta });
+};
+
+/**
+ * Type guard for lazy plugin stubs produced by {@link lazy}.
+ */
+export const isLazy = (plugin: Plugin): boolean => LazyTag in plugin;
+
+/**
+ * Tagged error for failures during lazy plugin resolution. `context.id` is
+ * the lazy plugin's `meta.id`; `context.reason` discriminates the failure
+ * mode (`'load-failed' | 'missing-default' | 'invalid-plugin' |
+ * 'meta-mismatch'`) so callers can route on it.
+ */
+export class LazyPluginError extends BaseError.extend('LazyPluginError', 'Failed to resolve lazy plugin') {}
+
+/**
+ * Resolves a lazy plugin stub to its real plugin.
+ * Returns the plugin unchanged if it is not lazy. Failures surface as
+ * {@link LazyPluginError} with `context.reason` indicating the failure mode
+ * and (for loader failures) `cause` set to the original error.
+ */
+export const resolveLazy = (plugin: Plugin): Effect.Effect<Plugin, LazyPluginError> =>
+  Effect.gen(function* () {
+    if (!isLazy(plugin)) {
+      return plugin;
+    }
+    const id = plugin.meta.id;
+    const { loader, options } = (plugin as unknown as { [LazyTag]: LazyPayload })[LazyTag];
+    const mod = yield* Effect.tryPromise({
+      try: loader,
+      catch: (error) => new LazyPluginError({ context: { id, reason: 'load-failed' }, cause: error }),
+    });
+    if (!mod || typeof mod.default !== 'function') {
+      return yield* Effect.fail(new LazyPluginError({ context: { id, reason: 'missing-default' } }));
+    }
+    const result = mod.default(options);
+    if (!isPlugin(result)) {
+      return yield* Effect.fail(new LazyPluginError({ context: { id, reason: 'invalid-plugin' } }));
+    }
+    if (result.meta.id !== id) {
+      return yield* Effect.fail(
+        new LazyPluginError({ context: { id, reason: 'meta-mismatch', returnedId: result.meta.id } }),
+      );
+    }
+    return result;
+  });

--- a/packages/sdk/app-framework/src/core/url-loader.ts
+++ b/packages/sdk/app-framework/src/core/url-loader.ts
@@ -43,6 +43,18 @@ export type Options = {
 };
 
 /**
+ * Options for the preload entry point. Adds an optional progress hook so hosts
+ * can drive a boot-loader counter (`Loading plugins (3/12)…`) as remote plugin
+ * manifests resolve. Resolution order is *not* deterministic — each entry races
+ * its own network fetch — so callers should treat `loaded` as a count, not an
+ * index. Failures are still swallowed; `loaded` advances on both success and
+ * recoverable failure so the counter always reaches `total`.
+ */
+export type PreloadOptions = Options & {
+  onPluginLoaded?: (loaded: number, total: number) => void;
+};
+
+/**
  * Persisted record of a remote plugin that has been loaded previously.
  *
  * `url` is the URL of the plugin manifest (`plugin.json`), not the entry module.
@@ -222,22 +234,39 @@ const loadFromManifest = (
  * are logged and swallowed — the returned effect always succeeds with whichever
  * plugins loaded cleanly, so a single bad entry can't block the host's startup.
  */
-export const preload = (options: Options = {}): Effect.Effect<Plugin.Plugin[], never> =>
+export const preload = (options: PreloadOptions = {}): Effect.Effect<Plugin.Plugin[], never> =>
   Effect.gen(function* () {
     const storage = options.storage ?? defaultStorage();
     const key = options.key ?? DEFAULT_KEY;
     const cache = options.cache ?? PluginAssetCache.noop();
+    const onPluginLoaded = options.onPluginLoaded;
 
     const entries = getPersistedRemotePlugins(storage, key);
     if (entries.length === 0) {
       return [];
     }
     log.info('preloading remote plugins', { count: entries.length });
+    const total = entries.length;
+    let loaded = 0;
     const results = yield* Effect.all(
       entries.map((entry) =>
         loadFromManifest(entry.url, cache).pipe(
           Effect.tapError((error) => Effect.sync(() => log.warn('failed to preload remote plugin', { entry, error }))),
           Effect.option,
+          // Tick the progress hook on both success and recoverable failure so
+          // the counter monotonically reaches `total`. The host-supplied
+          // callback is best-effort: any synchronous throw flows through
+          // `Effect.try` and gets logged + ignored so a buggy hook can't
+          // derail the preload.
+          Effect.tap(() =>
+            Effect.sync(() => {
+              loaded += 1;
+            }).pipe(
+              Effect.andThen(Effect.try(() => onPluginLoaded?.(loaded, total))),
+              Effect.tapError((error) => Effect.sync(() => log.warn('onPluginLoaded threw', { loaded, total, error }))),
+              Effect.ignore,
+            ),
+          ),
         ),
       ),
       { concurrency: 'unbounded' },


### PR DESCRIPTION
## Summary

Adds `Plugin.lazy(meta, () => import('./FooPlugin'))` so each plugin package internalizes its own lazy-loading. The plugin's main entry exposes `meta` synchronously and defers the heavy body behind a dynamic `import()`; the plugin manager's `enable` resolves the lazy stub on first enable, swaps the real plugin into the registry, and proceeds with normal module registration.

This removes the need for the app-side workaround landed in #11135 (composer-app's `Promise.all([...])` orchestration in `plugin-defs.tsx` plus a hand-maintained `ID = { ... }` constant table that mirrored each plugin's `meta.id`). Apps go back to the natural `import { FooPlugin } from '@dxos/plugin-foo'` and the import cost stays small because the package's main entry is just `meta` plus the lazy stub.

Branch is rebased onto `claude/eager-pare-d403af` and squashed to a single commit.

## Framework

- **`packages/sdk/app-framework/src/core/plugin.ts`** — `Plugin.lazy(meta, loader)` returns a `PluginFactory<T>` whose call produces a stub `Plugin.Plugin` carrying meta synchronously and a hidden `LazyTag` symbol with the loader closure. `Plugin.isLazy` + `Plugin.resolveLazy` complete the contract.
- **`packages/sdk/app-framework/src/core/plugin-manager.ts`** — `enable` detects a lazy stub, awaits the loader, swaps the plugin in `_pluginsAtom`, and continues with the real plugin's modules. PubSub `lazy:<id>` activation messages drive the existing startup-progress UI. The constructor's fire-and-forget `enable` chain now resolves a `Deferred` and `activate` awaits it before dispatching, so a caller doing the natural `make(...) → activate(Startup)` pattern doesn't race the lazy `import()` chain.
- **`packages/sdk/app-framework/src/core/plugin-manager.test.ts`** — five new tests: (a) sync meta access without invoking the loader, (b) loader runs on enable, (c) loader stays cold if the plugin is never enabled, (d) factory-options forward through to the real factory, (e) loader rejection wraps in a descriptive error.
- **`packages/sdk/app-framework/src/core/url-loader.ts`** — `UrlLoader.preload` gains an `onPluginLoaded(loaded, total)` option so the host can drive a boot-loader counter as remote plugin manifests resolve.

## Plugin authoring shape

Every `packages/plugins/plugin-*/src/index.ts` follows:

```ts
import { Plugin } from '@dxos/app-framework';

import { meta } from './meta';

export const FooPlugin = Plugin.lazy(meta, () => import('./FooPlugin'));

export * from './meta';
// …any pre-existing barrel re-exports kept in their original groupings…
```

Every `FooPlugin.{ts,tsx}` keeps its body unchanged and exports both:

```ts
export const FooPlugin = Plugin.define(meta).pipe(...);
export default FooPlugin;
```

The default is what `Plugin.lazy(() => import('./FooPlugin'))` resolves on; the named matches what stories/tests already used. **No story import across the workspace had to flip from named to default.**

## Composer-app

- `composer-app/src/plugin-defs.tsx` reverts to natural static imports — the 60-entry `ID = { … }` mirror of every plugin's `meta.id` is gone, `getCore`/`getDefaults` reference `FooPlugin.meta.id` directly, and `getPlugins` is synchronous again (each factory call is cheap because each main entry is just `meta` + the lazy stub).
- `composer-app/src/main.tsx` drops the `Promise.all([getPlugins(...), …])` orchestration; pre-React boot-loader progress now follows `UrlLoader.preload`'s `onPluginLoaded` (0 → 50% during remote-plugin preload), and the React `Placeholder` takes over at 50% during module activation as it did before.

## Bundle expectations

Eager bundle should match #11135's 393 KB target — every plugin's main entry contains only `meta` + the lazy stub, and Rollup splits each `() => import('./XxxPlugin')` into a separate chunk loaded only when the plugin's `enable` runs (core/default at startup, optional plugins on first user invocation). Plugin authors can prune extra re-exports plugin-by-plugin in follow-up PRs to maximize lazy-chunk granularity; nothing in the framework requires it.

## Test plan

- [x] `moon run app-framework:test` — 31/31 pass, including 5 new `Plugin.lazy` tests
- [x] `moon run plugin-sample:test` — 3/3 pass (validates the init-Deferred gate)
- [x] `moon run plugin-markdown:test` — 7/7 pass
- [x] `moon run :build --affected` — 459 tasks green
- [x] `pnpm run format-check` — green
- [ ] CI Check workflow on the new base

https://claude.ai/code/session_01QamtsePdK2CE9Td5kkkWQD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * More reliable plugin startup with improved activation progress and remote asset preloading for smoother launches.

* **Plugins**
  * Vastly expanded plugin set; most plugins now load lazily to reduce initial load and improve responsiveness.
  * Sidekick is now available more broadly in dev and labs modes.
  * Many plugins now support default imports for easier consumption.

* **Tests**
  * New tests cover lazy plugin loading, resolution, coalescing, and error handling to improve startup stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->