### PR TITLE
feat(plugin-inbox): parse property and text filters in mailbox query

### DIFF
--- a/packages/core/echo/echo-query/src/parser/query-builder.ts
+++ b/packages/core/echo/echo-query/src/parser/query-builder.ts
@@ -40,8 +40,9 @@ export class QueryBuilder {
    */
   build(input: string): BuildResult {
     try {
-      const tree = this._parser.parse(input);
-      return this.buildQuery(tree, input);
+      const normalized = normalizeInput(input);
+      const tree = this._parser.parse(normalized);
+      return this.buildQuery(tree, normalized);
     } catch {
       return {};
     }
@@ -537,3 +538,191 @@ export class QueryBuilder {
     return input.slice(cursor.from, cursor.to);
   }
 }
+
+const KEYWORDS = new Set(['AND', 'OR', 'NOT']);
+const VALUE_LITERALS = new Set(['true', 'false', 'null']);
+const SPECIAL_CHARS = /[\s(){}\[\],"']/;
+const PROPERTY_KEY = /^[a-zA-Z_][a-zA-Z0-9_.]*$/;
+const NUMBER_LITERAL = /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
+
+/**
+ * Normalize raw user input into a form the lezer grammar can parse.
+ * - Bare text fragments (e.g. `foo`) are wrapped in quotes so they parse as TextFilter.
+ * - Property values that aren't already quoted/numeric/boolean (e.g. `from:rich@dxos.org`) are quoted.
+ * - Tags, type filters, operators, parens, braces, quoted strings, and assignments pass through unchanged.
+ */
+export const normalizeInput = (input: string): string => {
+  const out: string[] = [];
+  let i = 0;
+  while (i < input.length) {
+    const c = input[i];
+
+    // Whitespace.
+    if (/\s/.test(c)) {
+      out.push(c);
+      i++;
+      continue;
+    }
+
+    // Quoted string (already a valid TextFilter / Value).
+    if (c === '"' || c === "'") {
+      const quote = c;
+      let j = i + 1;
+      while (j < input.length && input[j] !== quote) {
+        if (input[j] === '\\' && j + 1 < input.length) {
+          j += 2;
+        } else {
+          j++;
+        }
+      }
+      out.push(input.slice(i, Math.min(j + 1, input.length)));
+      i = j + 1;
+      continue;
+    }
+
+    // Object/array literals: pass through (contents already structured).
+    if (c === '{' || c === '[') {
+      const close = c === '{' ? '}' : ']';
+      let depth = 1;
+      let j = i + 1;
+      while (j < input.length && depth > 0) {
+        const ch = input[j];
+        if (ch === '"' || ch === "'") {
+          const q = ch;
+          j++;
+          while (j < input.length && input[j] !== q) {
+            if (input[j] === '\\' && j + 1 < input.length) {
+              j += 2;
+            } else {
+              j++;
+            }
+          }
+          j++;
+        } else if (ch === c) {
+          depth++;
+          j++;
+        } else if (ch === close) {
+          depth--;
+          j++;
+        } else {
+          j++;
+        }
+      }
+      out.push(input.slice(i, j));
+      i = j;
+      continue;
+    }
+
+    // Single-char structural tokens.
+    if (c === '(' || c === ')' || c === '=' || c === ',') {
+      out.push(c);
+      i++;
+      continue;
+    }
+
+    // Relations.
+    if ((c === '-' && input[i + 1] === '>') || (c === '<' && input[i + 1] === '-')) {
+      out.push(input.slice(i, i + 2));
+      i += 2;
+      continue;
+    }
+
+    // NOT prefix (`!`) — single token.
+    if (c === '!') {
+      out.push(c);
+      i++;
+      continue;
+    }
+
+    // Tag.
+    if (c === '#') {
+      let j = i + 1;
+      while (j < input.length && /[a-zA-Z0-9_-]/.test(input[j])) {
+        j++;
+      }
+      out.push(input.slice(i, j));
+      i = j;
+      continue;
+    }
+
+    // Bareword: scan until next whitespace or special char.
+    let j = i;
+    while (j < input.length) {
+      const ch = input[j];
+      if (SPECIAL_CHARS.test(ch)) break;
+      if (ch === '-' && input[j + 1] === '>') break;
+      if (ch === '<' && input[j + 1] === '-') break;
+      j++;
+    }
+    const token = input.slice(i, j);
+    i = j;
+
+    // NOT prefix `!`.
+    if (token === '!') {
+      out.push(token);
+      continue;
+    }
+
+    // Operators.
+    if (KEYWORDS.has(token.toUpperCase())) {
+      out.push(token);
+      continue;
+    }
+
+    // Property/type filter (`key:value`).
+    const colonIdx = token.indexOf(':');
+    if (colonIdx > 0) {
+      const key = token.slice(0, colonIdx);
+      const rest = token.slice(colonIdx + 1);
+
+      // type:typename — leave for grammar's TypeFilter (Identifier value).
+      if (key === 'type') {
+        out.push(token);
+        continue;
+      }
+
+      if (PROPERTY_KEY.test(key)) {
+        if (rest.length === 0) {
+          // Trailing colon while typing — pass through.
+          out.push(token);
+          continue;
+        }
+        const first = rest[0];
+        if (first === '"' || first === "'") {
+          // Already quoted.
+          out.push(token);
+          continue;
+        }
+        if (first === '{' || first === '[') {
+          // Object/array literal value.
+          out.push(token);
+          continue;
+        }
+        if (VALUE_LITERALS.has(rest) || NUMBER_LITERAL.test(rest)) {
+          // Boolean / null / number literal.
+          out.push(token);
+          continue;
+        }
+        out.push(`${key}:"${rest.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`);
+        continue;
+      }
+
+      // Unknown key shape — fall through to text.
+    }
+
+    // Identifier followed by `=` is the LHS of an Assignment — keep as-is.
+    if (PROPERTY_KEY.test(token)) {
+      let k = i;
+      while (k < input.length && /\s/.test(input[k])) k++;
+      if (input[k] === '=') {
+        out.push(token);
+        continue;
+      }
+    }
+
+    // Bare text fragment: quote so it parses as TextFilter.
+    out.push(`"${token.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`);
+  }
+
+  return out.join('');
+};

--- a/packages/core/echo/echo-query/src/parser/query-builder.ts
+++ b/packages/core/echo/echo-query/src/parser/query-builder.ts
@@ -553,115 +553,131 @@ const NUMBER_LITERAL = /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
  */
 export const normalizeInput = (input: string): string => {
   const out: string[] = [];
-  let i = 0;
-  while (i < input.length) {
-    const c = input[i];
+  let pos = 0;
+  while (pos < input.length) {
+    const currentChar = input[pos];
 
     // Whitespace.
-    if (/\s/.test(c)) {
-      out.push(c);
-      i++;
+    if (/\s/.test(currentChar)) {
+      out.push(currentChar);
+      pos++;
       continue;
     }
 
     // Quoted string (already a valid TextFilter / Value).
-    if (c === '"' || c === "'") {
-      const quote = c;
-      let j = i + 1;
-      while (j < input.length && input[j] !== quote) {
-        if (input[j] === '\\' && j + 1 < input.length) {
-          j += 2;
+    // Single-quote only opens a string if the previous char isn't a word-char,
+    // so apostrophes inside barewords (e.g. `don't`, `O'Connor`) stay attached.
+    const prevChar = pos > 0 ? input[pos - 1] : '';
+    const isStringOpener =
+      currentChar === '"' || (currentChar === "'" && (pos === 0 || !/[a-zA-Z0-9_]/.test(prevChar)));
+    if (isStringOpener) {
+      const quoteChar = currentChar;
+      let scanIndex = pos + 1;
+      while (scanIndex < input.length && input[scanIndex] !== quoteChar) {
+        if (input[scanIndex] === '\\' && scanIndex + 1 < input.length) {
+          scanIndex += 2;
         } else {
-          j++;
+          scanIndex++;
         }
       }
-      out.push(input.slice(i, Math.min(j + 1, input.length)));
-      i = j + 1;
+      out.push(input.slice(pos, Math.min(scanIndex + 1, input.length)));
+      pos = scanIndex + 1;
       continue;
     }
 
     // Object/array literals: pass through (contents already structured).
-    if (c === '{' || c === '[') {
-      const close = c === '{' ? '}' : ']';
+    if (currentChar === '{' || currentChar === '[') {
+      const closeChar = currentChar === '{' ? '}' : ']';
       let depth = 1;
-      let j = i + 1;
-      while (j < input.length && depth > 0) {
-        const ch = input[j];
-        if (ch === '"' || ch === "'") {
-          const q = ch;
-          j++;
-          while (j < input.length && input[j] !== q) {
-            if (input[j] === '\\' && j + 1 < input.length) {
-              j += 2;
+      let scanIndex = pos + 1;
+      while (scanIndex < input.length && depth > 0) {
+        const innerChar = input[scanIndex];
+        if (innerChar === '"' || innerChar === "'") {
+          const quoteChar = innerChar;
+          scanIndex++;
+          while (scanIndex < input.length && input[scanIndex] !== quoteChar) {
+            if (input[scanIndex] === '\\' && scanIndex + 1 < input.length) {
+              scanIndex += 2;
             } else {
-              j++;
+              scanIndex++;
             }
           }
-          j++;
-        } else if (ch === c) {
+          scanIndex++;
+        } else if (innerChar === currentChar) {
           depth++;
-          j++;
-        } else if (ch === close) {
+          scanIndex++;
+        } else if (innerChar === closeChar) {
           depth--;
-          j++;
+          scanIndex++;
         } else {
-          j++;
+          scanIndex++;
         }
       }
-      out.push(input.slice(i, j));
-      i = j;
+      out.push(input.slice(pos, scanIndex));
+      pos = scanIndex;
       continue;
     }
 
-    // Single-char structural tokens.
-    if (c === '(' || c === ')' || c === '=' || c === ',') {
-      out.push(c);
-      i++;
+    // Single-char structural tokens. `}` / `]` only reach here when unmatched —
+    // pass them through so the lezer parser can produce a clear error rather than spinning.
+    if (
+      currentChar === '(' ||
+      currentChar === ')' ||
+      currentChar === '=' ||
+      currentChar === ',' ||
+      currentChar === '}' ||
+      currentChar === ']'
+    ) {
+      out.push(currentChar);
+      pos++;
       continue;
     }
 
     // Relations.
-    if ((c === '-' && input[i + 1] === '>') || (c === '<' && input[i + 1] === '-')) {
-      out.push(input.slice(i, i + 2));
-      i += 2;
+    if ((currentChar === '-' && input[pos + 1] === '>') || (currentChar === '<' && input[pos + 1] === '-')) {
+      out.push(input.slice(pos, pos + 2));
+      pos += 2;
       continue;
     }
 
     // NOT prefix (`!`) — single token.
-    if (c === '!') {
-      out.push(c);
-      i++;
+    if (currentChar === '!') {
+      out.push(currentChar);
+      pos++;
       continue;
     }
 
     // Tag.
-    if (c === '#') {
-      let j = i + 1;
-      while (j < input.length && /[a-zA-Z0-9_-]/.test(input[j])) {
-        j++;
+    if (currentChar === '#') {
+      let scanIndex = pos + 1;
+      while (scanIndex < input.length && /[a-zA-Z0-9_-]/.test(input[scanIndex])) {
+        scanIndex++;
       }
-      out.push(input.slice(i, j));
-      i = j;
+      out.push(input.slice(pos, scanIndex));
+      pos = scanIndex;
       continue;
     }
 
     // Bareword: scan until next whitespace or special char.
-    let j = i;
-    while (j < input.length) {
-      const ch = input[j];
-      if (SPECIAL_CHARS.test(ch)) break;
-      if (ch === '-' && input[j + 1] === '>') break;
-      if (ch === '<' && input[j + 1] === '-') break;
-      j++;
+    let scanIndex = pos;
+    while (scanIndex < input.length) {
+      const innerChar = input[scanIndex];
+      if (innerChar === '"') break;
+      if (innerChar === "'" && scanIndex > pos && !/[a-zA-Z0-9_]/.test(input[scanIndex - 1])) break;
+      if (innerChar === "'" && scanIndex === pos) break;
+      if (innerChar !== "'" && SPECIAL_CHARS.test(innerChar)) break;
+      if (innerChar === '-' && input[scanIndex + 1] === '>') break;
+      if (innerChar === '<' && input[scanIndex + 1] === '-') break;
+      scanIndex++;
     }
-    const token = input.slice(i, j);
-    i = j;
-
-    // NOT prefix `!`.
-    if (token === '!') {
-      out.push(token);
+    // Defensive: if no characters were consumed, advance one to avoid infinite loops.
+    if (scanIndex === pos) {
+      out.push(currentChar);
+      pos++;
       continue;
     }
+    const token = input.slice(pos, scanIndex);
+    pos = scanIndex;
 
     // Operators.
     if (KEYWORDS.has(token.toUpperCase())) {
@@ -687,13 +703,13 @@ export const normalizeInput = (input: string): string => {
           out.push(token);
           continue;
         }
-        const first = rest[0];
-        if (first === '"' || first === "'") {
+        const firstValueChar = rest[0];
+        if (firstValueChar === '"' || firstValueChar === "'") {
           // Already quoted.
           out.push(token);
           continue;
         }
-        if (first === '{' || first === '[') {
+        if (firstValueChar === '{' || firstValueChar === '[') {
           // Object/array literal value.
           out.push(token);
           continue;
@@ -712,9 +728,11 @@ export const normalizeInput = (input: string): string => {
 
     // Identifier followed by `=` is the LHS of an Assignment — keep as-is.
     if (PROPERTY_KEY.test(token)) {
-      let k = i;
-      while (k < input.length && /\s/.test(input[k])) k++;
-      if (input[k] === '=') {
+      let lookahead = pos;
+      while (lookahead < input.length && /\s/.test(input[lookahead])) {
+        lookahead++;
+      }
+      if (input[lookahead] === '=') {
         out.push(token);
         continue;
       }

--- a/packages/core/echo/echo-query/src/parser/query-builder.ts
+++ b/packages/core/echo/echo-query/src/parser/query-builder.ts
@@ -28,7 +28,7 @@ export class QueryBuilder {
    */
   validate(input: string): boolean {
     try {
-      const tree = this._parser.parse(input);
+      const tree = this._parser.parse(normalizeInput(input));
       return tree.cursor().node.name === 'Query';
     } catch {
       return false;

--- a/packages/core/echo/echo-query/src/parser/query-builder.ts
+++ b/packages/core/echo/echo-query/src/parser/query-builder.ts
@@ -356,8 +356,8 @@ export class QueryBuilder {
     cursor.firstChild(); // Move to String node.
     const text = this._getNodeText(cursor, input);
     cursor.parent(); // Go back to TextFilter.
-    // Remove quotes.
-    return Filter.text(text.slice(1, -1));
+    // Remove quotes and decode escapes.
+    return Filter.text(unescapeStringLiteral(text.slice(1, -1)));
   }
 
   /**
@@ -480,9 +480,9 @@ export class QueryBuilder {
 
     switch (valueType) {
       case 'String': {
-        // Remove quotes.
+        // Remove quotes and decode escapes.
         const str = this._getNodeText(cursor, input);
-        return str.slice(1, -1);
+        return unescapeStringLiteral(str.slice(1, -1));
       }
 
       case 'Number':
@@ -544,6 +544,25 @@ const VALUE_LITERALS = new Set(['true', 'false', 'null']);
 const SPECIAL_CHARS = /[\s(){}\[\],"']/;
 const PROPERTY_KEY = /^[a-zA-Z_][a-zA-Z0-9_.]*$/;
 const NUMBER_LITERAL = /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
+
+// Common URL schemes — `http://...`, `mailto:rich@...` etc. should be searched as text,
+// not auto-promoted to property filters.
+const URL_SCHEMES = new Set([
+  'http',
+  'https',
+  'ftp',
+  'ftps',
+  'file',
+  'mailto',
+  'tel',
+  'sms',
+  'data',
+  'javascript',
+  'ws',
+  'wss',
+  'ssh',
+  'git',
+]);
 
 /**
  * Normalize raw user input into a form the lezer grammar can parse.
@@ -697,7 +716,10 @@ export const normalizeInput = (input: string): string => {
         continue;
       }
 
-      if (PROPERTY_KEY.test(key)) {
+      // URLs (`http://...`, `mailto:rich@...`) and URL-paths starting with `//`
+      // are searched as text rather than auto-promoted to property filters.
+      const isUrlScheme = URL_SCHEMES.has(key.toLowerCase()) || rest.startsWith('//');
+      if (!isUrlScheme && PROPERTY_KEY.test(key)) {
         if (rest.length === 0) {
           // Trailing colon while typing — pass through.
           out.push(token);
@@ -719,11 +741,11 @@ export const normalizeInput = (input: string): string => {
           out.push(token);
           continue;
         }
-        out.push(`${key}:"${rest.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`);
+        out.push(`${key}:"${escapeStringLiteral(rest)}"`);
         continue;
       }
 
-      // Unknown key shape — fall through to text.
+      // URL or unknown key shape — fall through to text.
     }
 
     // Identifier followed by `=` is the LHS of an Assignment — keep as-is.
@@ -739,8 +761,26 @@ export const normalizeInput = (input: string): string => {
     }
 
     // Bare text fragment: quote so it parses as TextFilter.
-    out.push(`"${token.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`);
+    out.push(`"${escapeStringLiteral(token)}"`);
   }
 
   return out.join('');
+};
+
+/** Escape a raw value into a string literal body (without surrounding quotes). */
+const escapeStringLiteral = (value: string): string => value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+/** Decode `\\` and `\"` escapes inside a string literal body. */
+const unescapeStringLiteral = (literalBody: string): string => {
+  let out = '';
+  for (let i = 0; i < literalBody.length; i++) {
+    const ch = literalBody[i];
+    if (ch === '\\' && i + 1 < literalBody.length) {
+      out += literalBody[i + 1];
+      i++;
+    } else {
+      out += ch;
+    }
+  }
+  return out;
 };

--- a/packages/core/echo/echo-query/src/parser/query.test.ts
+++ b/packages/core/echo/echo-query/src/parser/query.test.ts
@@ -8,7 +8,7 @@ import { describe, it } from 'vitest';
 import { Filter, Tag } from '@dxos/echo';
 
 import { QueryDSL } from './gen';
-import { type BuildResult, QueryBuilder } from './query-builder';
+import { type BuildResult, QueryBuilder, normalizeInput } from './query-builder';
 
 // TODO(burdon): Ref/Relation traversal.
 
@@ -406,6 +406,90 @@ describe('query', () => {
       //     .targetOf(Relation.of('org.dxos.relation.hasSubject')) // TODO(burdon): Invert?
       //     .source(),
       // },
+    ];
+
+    tests.forEach(({ input, expected }) => {
+      const result = queryBuilder.build(input);
+      expect(result, JSON.stringify({ input, result, expected }, null, 2)).toEqual(expected);
+    });
+  });
+
+  it('normalizeInput', ({ expect }) => {
+    type Test = { input: string; expected: string };
+    const tests: Test[] = [
+      { input: 'foo', expected: '"foo"' },
+      { input: 'foo bar', expected: '"foo" "bar"' },
+      { input: 'foo  bar', expected: '"foo"  "bar"' },
+      { input: '"already" bare', expected: '"already" "bare"' },
+      { input: 'from:rich@dxos.org', expected: 'from:"rich@dxos.org"' },
+      { input: 'from:rich@dxos.org urgent', expected: 'from:"rich@dxos.org" "urgent"' },
+      { input: 'name:DXOS', expected: 'name:"DXOS"' },
+      { input: 'count:42', expected: 'count:42' },
+      { input: 'active:true', expected: 'active:true' },
+      { input: 'value:null', expected: 'value:null' },
+      { input: 'name:"DXOS"', expected: 'name:"DXOS"' },
+      { input: 'type:org.dxos.type.person', expected: 'type:org.dxos.type.person' },
+      { input: '#tag', expected: '#tag' },
+      { input: '#tag foo', expected: '#tag "foo"' },
+      { input: 'foo AND bar', expected: '"foo" AND "bar"' },
+      { input: 'foo OR bar', expected: '"foo" OR "bar"' },
+      { input: 'NOT foo', expected: 'NOT "foo"' },
+      { input: '!foo', expected: '!"foo"' },
+      { input: '(foo bar)', expected: '("foo" "bar")' },
+      { input: 'x = ( foo )', expected: 'x = ( "foo" )' },
+      { input: '{ name: "DXOS" }', expected: '{ name: "DXOS" }' },
+    ];
+
+    for (const { input, expected } of tests) {
+      expect(normalizeInput(input), input).toEqual(expected);
+    }
+  });
+
+  it('build with property and text fragments', ({ expect }) => {
+    const queryBuilder = new QueryBuilder({
+      tag_1: Tag.make({ label: 'foo' }),
+    });
+
+    type Test = { input: string; expected: BuildResult };
+    const tests: Test[] = [
+      // Property filter from `key:value` text input.
+      {
+        input: 'from:rich@dxos.org',
+        expected: { filter: Filter.props({ from: 'rich@dxos.org' }) },
+      },
+      {
+        input: 'name:DXOS',
+        expected: { filter: Filter.props({ name: 'DXOS' }) },
+      },
+      // Bare text fragment becomes text search.
+      {
+        input: 'urgent',
+        expected: { filter: Filter.text('urgent') },
+      },
+      // Multiple bare fragments are AND-joined.
+      {
+        input: 'urgent review',
+        expected: { filter: Filter.and(Filter.text('urgent'), Filter.text('review')) },
+      },
+      // Mixed property + text fragment.
+      {
+        input: 'from:rich@dxos.org urgent',
+        expected: {
+          filter: Filter.and(Filter.props({ from: 'rich@dxos.org' }), Filter.text('urgent')),
+        },
+      },
+      // Tag + text fragment.
+      {
+        input: '#foo bar',
+        expected: { filter: Filter.and(Filter.tag('tag_1'), Filter.text('bar')) },
+      },
+      // Three fragments AND-joined.
+      {
+        input: 'a b c',
+        expected: {
+          filter: Filter.and(Filter.text('a'), Filter.text('b'), Filter.text('c')),
+        },
+      },
     ];
 
     tests.forEach(({ input, expected }) => {

--- a/packages/core/echo/echo-query/src/parser/query.test.ts
+++ b/packages/core/echo/echo-query/src/parser/query.test.ts
@@ -447,6 +447,12 @@ describe('query', () => {
       { input: 'foo]bar', expected: '"foo"]"bar"' },
       // Genuine single-quoted string still works.
       { input: "'foo bar'", expected: "'foo bar'" },
+      // URLs are searched as text rather than auto-promoted to property filters.
+      { input: 'https://dxos.org', expected: '"https://dxos.org"' },
+      { input: 'http://example.com/foo', expected: '"http://example.com/foo"' },
+      { input: 'mailto:rich@dxos.org', expected: '"mailto:rich@dxos.org"' },
+      // Escapes round-trip: backslashes are escaped in the literal body.
+      { input: 'foo\\bar', expected: '"foo\\\\bar"' },
     ];
 
     for (const { input, expected } of tests) {
@@ -498,6 +504,20 @@ describe('query', () => {
         expected: {
           filter: Filter.and(Filter.text('a'), Filter.text('b'), Filter.text('c')),
         },
+      },
+      // URLs are text-searched, not promoted to property filters.
+      {
+        input: 'https://dxos.org',
+        expected: { filter: Filter.text('https://dxos.org') },
+      },
+      {
+        input: 'mailto:rich@dxos.org',
+        expected: { filter: Filter.text('mailto:rich@dxos.org') },
+      },
+      // Escapes decode back to the original input.
+      {
+        input: 'foo\\bar',
+        expected: { filter: Filter.text('foo\\bar') },
       },
     ];
 

--- a/packages/core/echo/echo-query/src/parser/query.test.ts
+++ b/packages/core/echo/echo-query/src/parser/query.test.ts
@@ -3,7 +3,7 @@
 //
 
 import { type Tree } from '@lezer/common';
-import { describe, it } from 'vitest';
+import { describe, it, test } from 'vitest';
 
 import { Filter, Tag } from '@dxos/echo';
 
@@ -414,7 +414,7 @@ describe('query', () => {
     });
   });
 
-  it('normalizeInput', ({ expect }) => {
+  test('normalizeInput', ({ expect }) => {
     type Test = { input: string; expected: string };
     const tests: Test[] = [
       { input: 'foo', expected: '"foo"' },
@@ -445,7 +445,7 @@ describe('query', () => {
     }
   });
 
-  it('build with property and text fragments', ({ expect }) => {
+  test('build with property and text fragments', ({ expect }) => {
     const queryBuilder = new QueryBuilder({
       tag_1: Tag.make({ label: 'foo' }),
     });

--- a/packages/core/echo/echo-query/src/parser/query.test.ts
+++ b/packages/core/echo/echo-query/src/parser/query.test.ts
@@ -438,6 +438,15 @@ describe('query', () => {
       { input: '(foo bar)', expected: '("foo" "bar")' },
       { input: 'x = ( foo )', expected: 'x = ( "foo" )' },
       { input: '{ name: "DXOS" }', expected: '{ name: "DXOS" }' },
+      // Apostrophes inside barewords don't open a quoted string.
+      { input: "don't", expected: '"don\'t"' },
+      { input: "O'Connor", expected: '"O\'Connor"' },
+      { input: "don't worry", expected: '"don\'t" "worry"' },
+      // Unmatched closing brace/bracket — passed through, no infinite loop.
+      { input: 'foo}', expected: '"foo"}' },
+      { input: 'foo]bar', expected: '"foo"]"bar"' },
+      // Genuine single-quoted string still works.
+      { input: "'foo bar'", expected: "'foo bar'" },
     ];
 
     for (const { input, expected } of tests) {

--- a/packages/plugins/plugin-inbox/package.json
+++ b/packages/plugins/plugin-inbox/package.json
@@ -105,6 +105,7 @@
     "@dxos/plugin-space": "workspace:*",
     "@dxos/plugin-table": "workspace:*",
     "@dxos/react-client": "workspace:*",
+    "@dxos/react-hooks": "workspace:*",
     "@dxos/react-ui-attention": "workspace:*",
     "@dxos/react-ui-calendar": "workspace:*",
     "@dxos/react-ui-components": "workspace:*",

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
@@ -2,7 +2,7 @@
 // Copyright 2025 DXOS.org
 //
 
-import { Atom, useAtomSet, useAtomValue } from '@effect-atom/atom-react';
+import { Atom } from '@effect-atom/atom-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAtomCapability, useOperationInvoker } from '@dxos/app-framework/ui';
@@ -12,6 +12,7 @@ import { type Database, type Feed, Obj, Query, Relation, Tag } from '@dxos/echo'
 import { QueryBuilder } from '@dxos/echo-query';
 import { invariant } from '@dxos/invariant';
 import { Filter, useObject, useQuery } from '@dxos/react-client/echo';
+import { useAtomState } from '@dxos/react-hooks';
 import { ElevationProvider, IconButton, Panel, useTranslation } from '@dxos/react-ui';
 import { linkedSegment } from '@dxos/react-ui-attention';
 import { useSelected } from '@dxos/react-ui-attention';
@@ -27,7 +28,7 @@ import { InboxCapabilities, type Mailbox } from '#types';
 
 import { POPOVER_SAVE_FILTER } from '../../constants';
 import { getMailboxMessagePath } from '../../paths';
-import { sortByCreated } from '../../util';
+import { matchesFilter, sortByCreated } from '../../util';
 import { InitializeMailbox } from './InitializeMailbox';
 
 export type MailboxArticleProps = AppSurface.ObjectArticleProps<
@@ -44,44 +45,52 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
   const id = attendableId ?? Obj.getDXN(mailbox).toString();
   const currentId = useSelected(id, 'single');
   const db = Obj.getDatabase(mailbox);
+  const showItem = useShowItem();
 
   // TODO(wittjosiah): Should be `const feed = useObjectValue(mailbox.feed)`.
   useObject(mailbox);
   const feed = mailbox.feed?.target as Feed.Feed | undefined;
 
+  const filterEditorRef = useRef<EditorController>(null);
+  const filterSaveButtonRef = useRef<HTMLButtonElement>(null);
+
   // Menu state.
   const sortDescending = useAtomState(true);
   const menuActions = useMailboxActions({ db, mailbox, sortDescending: sortDescending.atom });
 
-  // Filter and messages.
-  const [filter, setFilter] = useState<Filter.Any>();
-  const [filterText, setFilterText] = useState<string>(filterProp ?? '');
-  const messages: Message.Message[] = useQuery(
-    db,
-    feed ? Query.select(filter ?? Filter.type(Message.Message)).from(feed) : Query.select(Filter.nothing()),
-  ) as Message.Message[];
-  const sortedMessages = useMemo(
-    () => [...messages].sort(sortByCreated('created', sortDescending.value)),
-    [messages, sortDescending.value],
-  );
-
-  // Parse filter.
-  const tags = useQuery(db, Filter.type(Tag.Tag));
-  const tagMap = useMemo(() => {
-    return tags.reduce((acc, tag) => {
-      acc[tag.id] = tag;
-      return acc;
-    }, {} as Tag.Map);
-  }, [tags]);
-  const parser = useMemo(() => new QueryBuilder(tagMap), [tagMap]);
-  useEffect(() => setFilter(parser.build(filterText).filter), [filterText, parser]);
-
-  const showItem = useShowItem();
-  const filterEditorRef = useRef<EditorController>(null);
-  const filterSaveButtonRef = useRef<HTMLButtonElement>(null);
-
   // Build message-to-tags map from HasSubject relations incrementally.
   const messageTagsMap = useMessageTagsMap(db, feed);
+  const tags = useTags(db);
+
+  // Filter.
+  const builder = useMemo(() => new QueryBuilder(tags), [tags]);
+  const [filterText, setFilterText] = useState<string>(filterProp ?? '');
+  const [filter, setFilter] = useState<Filter.Any>();
+  useEffect(() => {
+    const { filter } = builder.build(filterText);
+    setFilter(filter);
+  }, [filterText, builder]);
+
+  // Messages.
+  const messages: Message.Message[] = useQuery(
+    db,
+    feed ? Query.select(Filter.type(Message.Message)).from(feed) : Query.select(Filter.nothing()),
+  ) as Message.Message[];
+
+  // Feed/queue queries don't yet support text-search and complex filter combinations,
+  // so query Messages by type only and apply the parsed filter client-side.
+  const filteredMessages = useMemo(
+    () =>
+      filter
+        ? messages.filter((message) => matchesFilter(filter, message, messageTagsMap[message.id] ?? []))
+        : messages,
+    [messages, filter, messageTagsMap],
+  );
+
+  const sortedMessages = useMemo(
+    () => [...filteredMessages].sort(sortByCreated('created', sortDescending.value)),
+    [filteredMessages, sortDescending.value],
+  );
 
   // Merge tags into mailbox labels.
   const mergedLabels = useMemo(() => {
@@ -92,7 +101,7 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
       }
     }
     return labels;
-  }, [mailbox.labels, messageTagsMap]);
+  }, [messageTagsMap, mailbox.labels]);
 
   // Update message properties to include tag IDs in labels array.
   const messagesWithTags = useMemo(() => {
@@ -119,10 +128,15 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
   const [isEmpty, setEmpty] = useState<boolean>(false);
   useEffect(() => {
     const t = setTimeout(() => {
-      setEmpty(sortedMessages.length === 0);
+      setEmpty(messages.length === 0);
     }, 1_000);
     return () => clearTimeout(t);
-  }, [sortedMessages]);
+  }, [messages]);
+
+  const handleClear = useCallback(() => {
+    setFilterText(filterProp ?? '');
+    setFilter(builder.build(filterProp ?? '').filter);
+  }, [filterProp, builder]);
 
   const handleAction = useCallback<MessageStackActionHandler>(
     (action) => {
@@ -172,11 +186,6 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
     [db, id, mailbox, sortedMessages, invokePromise, showItem],
   );
 
-  const handleClear = useCallback(() => {
-    setFilterText(filterProp ?? '');
-    setFilter(parser.build(filterProp ?? '').filter);
-  }, [filterProp, parser]);
-
   return (
     <Panel.Root>
       {!isEmpty && (
@@ -187,7 +196,7 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
                 <QueryEditor
                   classNames='grow min-w-0 ps-1'
                   db={db}
-                  tags={tagMap}
+                  tags={tags}
                   value={filterText}
                   onChange={setFilterText}
                   ref={filterEditorRef}
@@ -230,17 +239,34 @@ export const MailboxArticle = ({ subject: mailbox, filter: filterProp, attendabl
 };
 
 /**
+ * Return map of tags;
+ */
+// TODO(burdon): Factor out.
+const useTags = (db: Database.Database | undefined): Tag.Map => {
+  const tags = useQuery(db, Filter.type(Tag.Tag));
+  return useMemo(
+    () =>
+      tags.reduce<Tag.Map>((acc, tag) => {
+        acc[tag.id] = tag;
+        return acc;
+      }, {}),
+    [tags],
+  );
+};
+
+/**
  * Hook that builds an object mapping message IDs to tags from HasSubject relations.
  */
 const useMessageTagsMap = (
   db: Database.Database | undefined,
   feed: Feed.Feed | undefined,
 ): Record<string, Tag.Tag[]> => {
+  const [messageTagsMap, setMessageTagsMap] = useState<Record<string, Tag.Tag[]>>({});
+
   const hasSubjectRelations = useQuery(
     db,
     feed ? Query.select(Filter.type(HasSubject.HasSubject)).from(feed) : Query.select(Filter.nothing()),
   );
-  const [messageTagsMap, setMessageTagsMap] = useState<Record<string, Tag.Tag[]>>({});
 
   useEffect(() => {
     const map: Record<string, Tag.Tag[]> = {};
@@ -290,15 +316,13 @@ const useMessageTagsMap = (
   return messageTagsMap;
 };
 
-const useMailboxActions = ({
-  db,
-  mailbox,
-  sortDescending,
-}: {
+type UseMailboxActionsProps = {
   db?: Database.Database;
   mailbox?: Mailbox.Mailbox;
   sortDescending: Atom.Writable<boolean>;
-}) => {
+};
+
+const useMailboxActions = ({ db, mailbox, sortDescending }: UseMailboxActionsProps) => {
   const { t } = useTranslation(meta.id);
   const { invokePromise } = useOperationInvoker();
 
@@ -333,18 +357,4 @@ const useMailboxActions = ({
   );
 
   return useMenuActions(menu);
-};
-
-// TODO(wittjosiah): Factor out.
-type AtomState<T> = {
-  atom: Atom.Writable<T>;
-  value: T;
-  set: (value: T | ((value: T) => T)) => void;
-};
-
-const useAtomState = <T,>(initialValue: T): AtomState<T> => {
-  const atom = useMemo(() => Atom.make(initialValue), [initialValue]);
-  const value = useAtomValue(atom);
-  const set = useAtomSet(atom);
-  return useMemo(() => ({ atom, value, set }), [atom, value, set]);
 };

--- a/packages/plugins/plugin-inbox/src/util/index.ts
+++ b/packages/plugins/plugin-inbox/src/util/index.ts
@@ -2,4 +2,5 @@
 // Copyright 2026 DXOS.org
 //
 
+export * from './match-filter';
 export * from './util';

--- a/packages/plugins/plugin-inbox/src/util/match-filter.test.ts
+++ b/packages/plugins/plugin-inbox/src/util/match-filter.test.ts
@@ -1,0 +1,112 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { Tag } from '@dxos/echo';
+import { QueryBuilder } from '@dxos/echo-query';
+import { Message } from '@dxos/types';
+
+import { matchesFilter } from './match-filter';
+
+const tagFoo = Tag.make({ label: 'foo' });
+const tagBar = Tag.make({ label: 'bar' });
+const tags: Tag.Map = { [tagFoo.id]: tagFoo, [tagBar.id]: tagBar };
+
+const makeMessage = (overrides: Partial<Message.Message>): Message.Message =>
+  ({
+    id: 'msg_1',
+    created: '2026-01-01T00:00:00Z',
+    sender: { name: 'Rich', email: 'rich@dxos.org' },
+    blocks: [{ _tag: 'text', text: 'Hello world' }],
+    properties: { subject: 'Project update', to: 'team@dxos.org' },
+    ...overrides,
+  }) as unknown as Message.Message;
+
+describe('matchesFilter', () => {
+  const builder = new QueryBuilder(tags);
+  const build = (input: string) => {
+    const { filter } = builder.build(input);
+    if (!filter) {
+      throw new Error(`Failed to build filter from input: ${input}`);
+    }
+    return filter;
+  };
+
+  test('property filter matches sender email', ({ expect }) => {
+    const message = makeMessage({});
+    expect(matchesFilter(build('sender.email:rich@dxos.org'), message, [])).toBe(true);
+    expect(matchesFilter(build('sender.email:other@dxos.org'), message, [])).toBe(false);
+  });
+
+  test('string property filter matches case-insensitive substring', ({ expect }) => {
+    const message = makeMessage({});
+    expect(matchesFilter(build('sender.email:RICH'), message, [])).toBe(true);
+    expect(matchesFilter(build('sender.name:rich'), message, [])).toBe(true);
+  });
+
+  test('property filter on object value matches any field', ({ expect }) => {
+    const message = makeMessage({});
+    // `sender` is an Actor — should match if any of its fields contain the query.
+    expect(matchesFilter(build('sender:rich'), message, [])).toBe(true);
+    expect(matchesFilter(build('sender:dxos.org'), message, [])).toBe(true);
+    expect(matchesFilter(build('sender:absent'), message, [])).toBe(false);
+  });
+
+  test('from: alias maps to sender', ({ expect }) => {
+    const message = makeMessage({});
+    expect(matchesFilter(build('from:rich'), message, [])).toBe(true);
+    expect(matchesFilter(build('from.email:rich@dxos.org'), message, [])).toBe(true);
+    expect(matchesFilter(build('from.name:Rich'), message, [])).toBe(true);
+    expect(matchesFilter(build('from:absent'), message, [])).toBe(false);
+  });
+
+  test('to: alias maps to properties.to', ({ expect }) => {
+    const message = makeMessage({});
+    expect(matchesFilter(build('to:team@dxos.org'), message, [])).toBe(true);
+    expect(matchesFilter(build('to:team'), message, [])).toBe(true);
+    expect(matchesFilter(build('to:absent'), message, [])).toBe(false);
+  });
+
+  test('text fragment matches subject substring', ({ expect }) => {
+    const message = makeMessage({});
+    expect(matchesFilter(build('project'), message, [])).toBe(true);
+    expect(matchesFilter(build('absent'), message, [])).toBe(false);
+  });
+
+  test('text fragment matches block content', ({ expect }) => {
+    const message = makeMessage({});
+    expect(matchesFilter(build('hello'), message, [])).toBe(true);
+  });
+
+  test('multiple fragments are AND-joined', ({ expect }) => {
+    const message = makeMessage({});
+    expect(matchesFilter(build('project hello'), message, [])).toBe(true);
+    expect(matchesFilter(build('project absent'), message, [])).toBe(false);
+  });
+
+  test('property + text fragment combined', ({ expect }) => {
+    const message = makeMessage({});
+    expect(matchesFilter(build('sender.email:rich@dxos.org project'), message, [])).toBe(true);
+    expect(matchesFilter(build('sender.email:other@dxos.org project'), message, [])).toBe(false);
+  });
+
+  test('tag filter matches via passed tags', ({ expect }) => {
+    const message = makeMessage({});
+    expect(matchesFilter(build('#foo'), message, [tagFoo])).toBe(true);
+    expect(matchesFilter(build('#foo'), message, [tagBar])).toBe(false);
+  });
+
+  test('OR matches either', ({ expect }) => {
+    const message = makeMessage({});
+    expect(matchesFilter(build('absent OR project'), message, [])).toBe(true);
+    expect(matchesFilter(build('absent OR missing'), message, [])).toBe(false);
+  });
+
+  test('NOT inverts', ({ expect }) => {
+    const message = makeMessage({});
+    expect(matchesFilter(build('NOT absent'), message, [])).toBe(true);
+    expect(matchesFilter(build('NOT project'), message, [])).toBe(false);
+  });
+});

--- a/packages/plugins/plugin-inbox/src/util/match-filter.ts
+++ b/packages/plugins/plugin-inbox/src/util/match-filter.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
-import { type Filter, type Tag } from '@dxos/echo';
+import { type Filter, Obj, type Tag } from '@dxos/echo';
 import { type Message } from '@dxos/types';
 
 /**
@@ -28,8 +28,20 @@ const matchesAst = (ast: any, message: Message.Message, tags: Tag.Tag[]): boolea
     case 'text-search':
       return matchesText(ast.text ?? '', message);
     case 'object': {
-      // Filter.everything() and Filter.typename() emit `{ type: 'object', props: {} }`;
-      // typename pre-filtering happens at the query layer, so here an empty props means match-all.
+      // ast.typename is null for Filter.everything() / Filter.props() (match any type).
+      // For Filter.typename()/Filter.type() it's a fully-qualified DXN string we compare
+      // against the message's DXN-qualified typename.
+      if (ast.typename) {
+        let messageTypeDxn: string | undefined;
+        try {
+          messageTypeDxn = Obj.getTypeDXN(message).toString();
+        } catch {
+          messageTypeDxn = undefined;
+        }
+        if (messageTypeDxn !== ast.typename) {
+          return false;
+        }
+      }
       if (ast.props) {
         for (const [key, predicate] of Object.entries(ast.props)) {
           const path = resolvePropertyAlias(key);

--- a/packages/plugins/plugin-inbox/src/util/match-filter.ts
+++ b/packages/plugins/plugin-inbox/src/util/match-filter.ts
@@ -28,6 +28,8 @@ const matchesAst = (ast: any, message: Message.Message, tags: Tag.Tag[]): boolea
     case 'text-search':
       return matchesText(ast.text ?? '', message);
     case 'object': {
+      // Filter.everything() and Filter.typename() emit `{ type: 'object', props: {} }`;
+      // typename pre-filtering happens at the query layer, so here an empty props means match-all.
       if (ast.props) {
         for (const [key, predicate] of Object.entries(ast.props)) {
           const path = resolvePropertyAlias(key);
@@ -39,7 +41,8 @@ const matchesAst = (ast: any, message: Message.Message, tags: Tag.Tag[]): boolea
       return true;
     }
     default:
-      return true;
+      // Unknown / unsupported AST node — fail closed so unhandled filters never silently broaden results.
+      return false;
   }
 };
 

--- a/packages/plugins/plugin-inbox/src/util/match-filter.ts
+++ b/packages/plugins/plugin-inbox/src/util/match-filter.ts
@@ -1,0 +1,156 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Filter, type Tag } from '@dxos/echo';
+import { type Message } from '@dxos/types';
+
+/**
+ * Evaluate a parsed Filter AST against a Message client-side.
+ *
+ * Feed/queue queries don't yet support text-search and complex filter combinations,
+ * so the mailbox UI fetches all messages from the feed and applies the user filter here.
+ */
+export const matchesFilter = (filter: Filter.Any, message: Message.Message, tags: Tag.Tag[]): boolean => {
+  return matchesAst(filter.ast, message, tags);
+};
+
+const matchesAst = (ast: any, message: Message.Message, tags: Tag.Tag[]): boolean => {
+  switch (ast.type) {
+    case 'and':
+      return (ast.filters as any[]).every((f) => matchesAst(f, message, tags));
+    case 'or':
+      return (ast.filters as any[]).some((f) => matchesAst(f, message, tags));
+    case 'not':
+      return !matchesAst(ast.filter, message, tags);
+    case 'tag':
+      return tags.some((tag) => tag.id === ast.tag);
+    case 'text-search':
+      return matchesText(ast.text ?? '', message);
+    case 'object': {
+      if (ast.props) {
+        for (const [key, predicate] of Object.entries(ast.props)) {
+          const path = resolvePropertyAlias(key);
+          if (!matchesPredicate(predicate, getPath(message, path), message, tags)) {
+            return false;
+          }
+        }
+      }
+      return true;
+    }
+    default:
+      return true;
+  }
+};
+
+const matchesPredicate = (ast: any, value: any, message: Message.Message, tags: Tag.Tag[]): boolean => {
+  switch (ast?.type) {
+    case 'compare': {
+      switch (ast.operator) {
+        case 'eq':
+          return matchesValue(value, ast.value);
+        case 'neq':
+          return !matchesValue(value, ast.value);
+        case 'gt':
+          return value > ast.value;
+        case 'gte':
+          return value >= ast.value;
+        case 'lt':
+          return value < ast.value;
+        case 'lte':
+          return value <= ast.value;
+        default:
+          return false;
+      }
+    }
+    case 'object': {
+      if (typeof value !== 'object' || value === null) {
+        return false;
+      }
+      for (const [key, sub] of Object.entries(ast.props ?? {})) {
+        if (!matchesPredicate(sub, getPath(value, key), message, tags)) {
+          return false;
+        }
+      }
+      return true;
+    }
+    default:
+      return matchesAst(ast, message, tags);
+  }
+};
+
+/**
+ * Match a property value against a query value.
+ * - Strings: case-insensitive substring match (so `from:rich` matches `rich@dxos.org`).
+ * - Objects: recurse into fields (so `from:rich` matches an Actor's `email` or `name`).
+ * - Arrays: any element matches.
+ * - Other primitives: strict equality.
+ */
+const matchesValue = (value: any, query: any): boolean => {
+  if (value === query) {
+    return true;
+  }
+  if (typeof query === 'string' && typeof value === 'string') {
+    return value.toLowerCase().includes(query.toLowerCase());
+  }
+  if (Array.isArray(value)) {
+    return value.some((v) => matchesValue(v, query));
+  }
+  if (typeof query === 'string' && typeof value === 'object' && value !== null) {
+    return Object.values(value).some((v) => matchesValue(v, query));
+  }
+  return false;
+};
+
+const getPath = (obj: any, path: string): any => {
+  return path.split('.').reduce<any>((acc, key) => (acc != null ? acc[key] : undefined), obj);
+};
+
+/**
+ * User-facing aliases that map common email-style property names onto Message fields.
+ */
+const PROPERTY_ALIASES: Record<string, string> = {
+  from: 'sender',
+  to: 'properties.to',
+};
+
+const resolvePropertyAlias = (path: string): string => {
+  for (const [alias, target] of Object.entries(PROPERTY_ALIASES)) {
+    if (path === alias) {
+      return target;
+    }
+    if (path.startsWith(alias + '.')) {
+      return target + path.slice(alias.length);
+    }
+  }
+  return path;
+};
+
+const matchesText = (needle: string, message: Message.Message): boolean => {
+  if (!needle) {
+    return true;
+  }
+  const lower = needle.toLowerCase();
+  const haystacks: string[] = [];
+  if (message.properties) {
+    for (const value of Object.values(message.properties)) {
+      if (typeof value === 'string') {
+        haystacks.push(value);
+      }
+    }
+  }
+  if (message.sender) {
+    if (message.sender.email) {
+      haystacks.push(message.sender.email);
+    }
+    if (message.sender.name) {
+      haystacks.push(message.sender.name);
+    }
+  }
+  for (const block of message.blocks ?? []) {
+    if (block && typeof (block as any).text === 'string') {
+      haystacks.push((block as any).text);
+    }
+  }
+  return haystacks.some((s) => s.toLowerCase().includes(lower));
+};

--- a/packages/plugins/plugin-inbox/src/util/match-filter.ts
+++ b/packages/plugins/plugin-inbox/src/util/match-filter.ts
@@ -16,13 +16,16 @@ export const matchesFilter = (filter: Filter.Any, message: Message.Message, tags
 };
 
 const matchesAst = (ast: any, message: Message.Message, tags: Tag.Tag[]): boolean => {
+  if (!ast || typeof ast !== 'object') {
+    return false;
+  }
   switch (ast.type) {
     case 'and':
-      return (ast.filters as any[]).every((f) => matchesAst(f, message, tags));
+      return Array.isArray(ast.filters) && ast.filters.every((sub: any) => matchesAst(sub, message, tags));
     case 'or':
-      return (ast.filters as any[]).some((f) => matchesAst(f, message, tags));
+      return Array.isArray(ast.filters) && ast.filters.some((sub: any) => matchesAst(sub, message, tags));
     case 'not':
-      return !matchesAst(ast.filter, message, tags);
+      return ast.filter != null && !matchesAst(ast.filter, message, tags);
     case 'tag':
       return tags.some((tag) => tag.id === ast.tag);
     case 'text-search':

--- a/packages/plugins/plugin-inbox/tsconfig.json
+++ b/packages/plugins/plugin-inbox/tsconfig.json
@@ -117,6 +117,9 @@
       "path": "../../ui/lit-ui"
     },
     {
+      "path": "../../ui/react-primitives/react-hooks"
+    },
+    {
       "path": "../../ui/react-ui"
     },
     {

--- a/packages/ui/react-primitives/react-hooks/package.json
+++ b/packages/ui/react-primitives/react-hooks/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@dxos/async": "workspace:*",
     "@dxos/log": "workspace:*",
+    "@effect-atom/atom-react": "catalog:",
     "@radix-ui/react-compose-refs": "catalog:",
     "@radix-ui/react-id": "catalog:",
     "alea": "catalog:",

--- a/packages/ui/react-primitives/react-hooks/src/index.ts
+++ b/packages/ui/react-primitives/react-hooks/src/index.ts
@@ -6,6 +6,7 @@ export { useComposedRefs } from '@radix-ui/react-compose-refs';
 export { useSize, useScroller } from 'mini-virtual-list';
 
 export * from './useAsyncEffect';
+export * from './useAtomState';
 export * from './useAsyncState';
 export * from './useControlledState';
 export * from './useDebugDeps';

--- a/packages/ui/react-primitives/react-hooks/src/useAtomState.ts
+++ b/packages/ui/react-primitives/react-hooks/src/useAtomState.ts
@@ -1,0 +1,22 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+import { Atom, useAtomSet, useAtomValue } from '@effect-atom/atom-react';
+import { useMemo } from 'react';
+
+export type AtomState<T> = {
+  atom: Atom.Writable<T>;
+  value: T;
+  set: (value: T | ((value: T) => T)) => void;
+};
+
+/**
+ * Wraps a writable atom together with its current value and setter.
+ */
+export const useAtomState = <T>(initialValue: T): AtomState<T> => {
+  const atom = useMemo(() => Atom.make(initialValue), [initialValue]);
+  const value = useAtomValue(atom);
+  const set = useAtomSet(atom);
+  return useMemo(() => ({ atom, value, set }), [atom, value, set]);
+};

--- a/packages/ui/react-primitives/react-hooks/src/useAtomState.ts
+++ b/packages/ui/react-primitives/react-hooks/src/useAtomState.ts
@@ -3,7 +3,7 @@
 //
 
 import { Atom, useAtomSet, useAtomValue } from '@effect-atom/atom-react';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 export type AtomState<T> = {
   atom: Atom.Writable<T>;
@@ -13,9 +13,10 @@ export type AtomState<T> = {
 
 /**
  * Wraps a writable atom together with its current value and setter.
+ * The atom is created once on first render; `initialValue` is only used to seed it.
  */
 export const useAtomState = <T>(initialValue: T): AtomState<T> => {
-  const atom = useMemo(() => Atom.make(initialValue), [initialValue]);
+  const [atom] = useState(() => Atom.make(initialValue));
   const value = useAtomValue(atom);
   const set = useAtomSet(atom);
   return useMemo(() => ({ atom, value, set }), [atom, value, set]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9842,6 +9842,9 @@ importers:
       '@dxos/react-client':
         specifier: workspace:*
         version: link:../../sdk/react-client
+      '@dxos/react-hooks':
+        specifier: workspace:*
+        version: link:../../ui/react-primitives/react-hooks
       '@dxos/react-ui-attention':
         specifier: workspace:*
         version: link:../../ui/react-ui-attention
@@ -16835,6 +16838,9 @@ importers:
       '@dxos/log':
         specifier: workspace:*
         version: link:../../../common/log
+      '@effect-atom/atom-react':
+        specifier: 'catalog:'
+        version: 0.5.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)(react@19.2.3)(scheduler@0.27.0)
       '@radix-ui/react-compose-refs':
         specifier: 'catalog:'
         version: 1.1.1(@types/react@19.2.7)(react@19.2.3)


### PR DESCRIPTION
## Summary

- Extend `@dxos/echo-query` `QueryBuilder` to accept bare text fragments (`urgent`) and unquoted property values (`from:rich@dxos.org`). Multiple fragments AND-join via the existing `ImplicitAnd` rule. Tags, type filters, operators, parens, braces and `x = (...)` assignments pass through unchanged.
- Filter messages client-side in `MailboxArticle` against the parsed filter — feed/queue queries don't yet support `text-search` and complex filter combinations, so `Query.select(Filter.type(Message)).from(feed)` runs at the query layer and the user filter is evaluated in-process.
- `matchesFilter` supports:
  - case-insensitive substring matching for string property values,
  - recursive matching into object property values (so `sender:rich` matches an `Actor`'s `email` or `name`),
  - `from` / `to` aliases that map onto `sender` and `properties.to` respectively (`from.email` → `sender.email`).
- Move `useAtomState` from MailboxArticle into `@dxos/react-hooks`.

## Test plan

- [x] `moon run echo-query:test` (parser + new `normalizeInput` + property/text build cases)
- [x] `moon run plugin-inbox:test` (new `matchesFilter` tests cover property filters, text fragments, AND/OR/NOT, tags, alias resolution, and nested object matching)
- [x] `moon run react-hooks:test`
- [x] `moon run plugin-inbox:build`, `moon run react-hooks:build`
- [x] `moon run plugin-inbox:lint`, `moon run echo-query:lint`, `moon run react-hooks:lint`
- [x] Manual verification in Composer mailbox (`from:rich`, plain text, `#tag`, mixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query inputs are auto-normalized for more reliable parsing (quoting barewords, preserving operators/tags, handling key:value).
  * Inbox filtering now runs client-side with richer property, tag, and full-text matching; added a matcher to evaluate filters against messages.
  * Added a new atom-based state hook for component-local state.

* **Tests**
  * Added tests covering normalization, filter building, and match semantics (properties, tags, boolean logic, free text).

* **Chores**
  * Exposed the new hook via package exports and added supporting build/config changes and runtime dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->