### PR TITLE
refactor: rename ObjectDetails to ObjectProperties; MagazineArticle UX hooks

### DIFF
--- a/packages/plugins/plugin-deck/src/containers/Deck/DeckViewport.tsx
+++ b/packages/plugins/plugin-deck/src/containers/Deck/DeckViewport.tsx
@@ -31,8 +31,8 @@ import { getMode } from '#types';
 import { layoutAppliesTopbar } from '../../util';
 import { Plank, PlankRootProps, type PlankComponentProps } from '../Plank';
 import {
-  ToggleComplementarySidebarButton as NativeToggleComplementarySidebarButton,
-  ToggleSidebarButton as NativeToggleSidebarButton,
+  ToggleComplementarySidebarButton as NaturalToggleComplementarySidebarButton,
+  ToggleSidebarButton as NaturalToggleSidebarButton,
 } from '../Sidebar';
 import { useDeckContext } from './DeckRoot';
 
@@ -272,9 +272,9 @@ export const DeckMultiMode = () => {
 
 const sidebarToggleStyles = 'h-(--dx-rail-item) w-(--dx-rail-item) absolute bottom-2 z-[1] bg-deck-surface! lg:hidden';
 
-const ToggleSidebarButton = () => <NativeToggleSidebarButton classNames={mx(sidebarToggleStyles, 'left-2')} />;
+const ToggleSidebarButton = () => <NaturalToggleSidebarButton classNames={mx(sidebarToggleStyles, 'left-2')} />;
 const ToggleComplementarySidebarButton = () => (
-  <NativeToggleComplementarySidebarButton classNames={mx(sidebarToggleStyles, 'right-2')} />
+  <NaturalToggleComplementarySidebarButton classNames={mx(sidebarToggleStyles, 'right-2')} />
 );
 
 const ExitFullscreenButton = ({ onExit }: { onExit: () => void }) => {

--- a/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
+++ b/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
@@ -2,10 +2,10 @@
 // Copyright 2026 DXOS.org
 //
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useOperationInvoker } from '@dxos/app-framework/ui';
-import { getObjectPathFromObject } from '@dxos/app-toolkit';
+import { LayoutOperation, getObjectPathFromObject } from '@dxos/app-toolkit';
 import { type AppSurface, useShowItem } from '@dxos/app-toolkit/ui';
 import { Filter, Obj, Ref, type Tag } from '@dxos/echo';
 import { log } from '@dxos/log';
@@ -256,6 +256,27 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
     },
     [id, showItem, invokePromise],
   );
+
+  // Auto-curate when the set of subscribed feeds changes so the post list reflects
+  // the new selection without requiring a manual Curate click.
+  const feedCount = subject.feeds.length;
+  const previousFeedCount = useRef(feedCount);
+  useEffect(() => {
+    if (previousFeedCount.current !== feedCount) {
+      previousFeedCount.current = feedCount;
+      void invokePromise(FeedOperation.CurateMagazine, { magazine: Ref.make(subject) }).catch((err) => log.catch(err));
+    }
+  }, [feedCount, subject, invokePromise]);
+
+  // Open the ObjectProperties companion when the magazine has no posts so the user
+  // can configure subscription feeds without an empty pane staring back at them.
+  useEffect(() => {
+    if (posts.length === 0) {
+      void invokePromise(LayoutOperation.UpdateCompanion, {
+        subject: linkedSegment('settings'),
+      }).catch((err) => log.catch(err));
+    }
+  }, [posts.length, invokePromise]);
 
   const tileItems = useMemo<TileData[]>(
     () =>

--- a/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
+++ b/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
@@ -272,7 +272,10 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
   // magazine with the same feeds still triggers curation for the new magazine.
   const previousCurateKey = useRef({ subject, feedFingerprint });
   useEffect(() => {
-    if (previousCurateKey.current.subject !== subject || previousCurateKey.current.feedFingerprint !== feedFingerprint) {
+    if (
+      previousCurateKey.current.subject !== subject ||
+      previousCurateKey.current.feedFingerprint !== feedFingerprint
+    ) {
       previousCurateKey.current = { subject, feedFingerprint };
       void invokePromise(FeedOperation.CurateMagazine, { magazine: Ref.make(subject) }).catch((err) => log.catch(err));
     }

--- a/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
+++ b/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
@@ -258,25 +258,34 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
   );
 
   // Auto-curate when the set of subscribed feeds changes so the post list reflects
-  // the new selection without requiring a manual Curate click.
-  const feedCount = subject.feeds.length;
-  const previousFeedCount = useRef(feedCount);
+  // the new selection without requiring a manual Curate click. Fingerprint by sorted
+  // DXN so swaps that preserve `feeds.length` still trigger.
+  const feedFingerprint = useMemo(
+    () =>
+      subject.feeds
+        .map((ref) => ref.dxn.toString())
+        .sort()
+        .join(),
+    [subject.feeds],
+  );
+  const previousFeedFingerprint = useRef(feedFingerprint);
   useEffect(() => {
-    if (previousFeedCount.current !== feedCount) {
-      previousFeedCount.current = feedCount;
+    if (previousFeedFingerprint.current !== feedFingerprint) {
+      previousFeedFingerprint.current = feedFingerprint;
       void invokePromise(FeedOperation.CurateMagazine, { magazine: Ref.make(subject) }).catch((err) => log.catch(err));
     }
-  }, [feedCount, subject, invokePromise]);
+  }, [feedFingerprint, subject, invokePromise]);
 
   // Open the ObjectProperties companion when the magazine has no posts so the user
   // can configure subscription feeds without an empty pane staring back at them.
+  // Depend on `subject` so switching between two empty magazines also reopens it.
   useEffect(() => {
     if (posts.length === 0) {
       void invokePromise(LayoutOperation.UpdateCompanion, {
         subject: linkedSegment('settings'),
       }).catch((err) => log.catch(err));
     }
-  }, [posts.length, invokePromise]);
+  }, [subject, posts.length, invokePromise]);
 
   const tileItems = useMemo<TileData[]>(
     () =>

--- a/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
+++ b/packages/plugins/plugin-feed/src/containers/MagazineArticle/MagazineArticle.tsx
@@ -268,24 +268,27 @@ export const MagazineArticle = ({ role, subject, attendableId }: MagazineArticle
         .join(),
     [subject.feeds],
   );
-  const previousFeedFingerprint = useRef(feedFingerprint);
+  // Key on both magazine identity and feed fingerprint so switching to a different
+  // magazine with the same feeds still triggers curation for the new magazine.
+  const previousCurateKey = useRef({ subject, feedFingerprint });
   useEffect(() => {
-    if (previousFeedFingerprint.current !== feedFingerprint) {
-      previousFeedFingerprint.current = feedFingerprint;
+    if (previousCurateKey.current.subject !== subject || previousCurateKey.current.feedFingerprint !== feedFingerprint) {
+      previousCurateKey.current = { subject, feedFingerprint };
       void invokePromise(FeedOperation.CurateMagazine, { magazine: Ref.make(subject) }).catch((err) => log.catch(err));
     }
   }, [feedFingerprint, subject, invokePromise]);
 
   // Open the ObjectProperties companion when the magazine has no posts so the user
   // can configure subscription feeds without an empty pane staring back at them.
-  // Depend on `subject` so switching between two empty magazines also reopens it.
+  // Use `subject.posts.length` (the unfiltered set) so view filters like 'archived'
+  // or 'starred' don't trigger this when the magazine actually still has posts.
   useEffect(() => {
-    if (posts.length === 0) {
+    if (subject.posts.length === 0) {
       void invokePromise(LayoutOperation.UpdateCompanion, {
         subject: linkedSegment('settings'),
       }).catch((err) => log.catch(err));
     }
-  }, [subject, posts.length, invokePromise]);
+  }, [subject, subject.posts.length, invokePromise]);
 
   const tileItems = useMemo<TileData[]>(
     () =>

--- a/packages/plugins/plugin-space/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-space/src/capabilities/react-surface.tsx
@@ -30,7 +30,7 @@ import {
   MembersContainer,
   MenuFooter,
   ObjectCardStack,
-  ObjectDetails,
+  ObjectProperties,
   ObjectRenamePopover,
   RecordArticle,
   RelatedArticle,
@@ -103,7 +103,7 @@ export default Capability.makeModule(
           AppSurface.literal(AppSurface.Article, 'settings'),
           AppSurface.companion(AppSurface.Article),
         ),
-        component: ({ ref, data, role }) => <ObjectDetails role={role} subject={data.companionTo} ref={ref} />,
+        component: ({ ref, data, role }) => <ObjectProperties role={role} subject={data.companionTo} ref={ref} />,
       }),
       Surface.create({
         id: 'companion.related',

--- a/packages/plugins/plugin-space/src/containers/ObjectDetails/index.ts
+++ b/packages/plugins/plugin-space/src/containers/ObjectDetails/index.ts
@@ -1,5 +1,0 @@
-//
-// Copyright 2025 DXOS.org
-//
-
-export { ObjectDetails as default } from './ObjectDetails';

--- a/packages/plugins/plugin-space/src/containers/ObjectProperties/ObjectProperties.tsx
+++ b/packages/plugins/plugin-space/src/containers/ObjectProperties/ObjectProperties.tsx
@@ -8,11 +8,11 @@ import { Surface } from '@dxos/app-framework/ui';
 import { AppSurface } from '@dxos/app-toolkit/ui';
 import { type Obj } from '@dxos/echo';
 import { Panel, Toolbar } from '@dxos/react-ui';
-import { ObjectProperties } from '@dxos/react-ui-form';
+import { ObjectProperties as NaturalObjectProperties } from '@dxos/react-ui-form';
 
-export type ObjectDetailsProps = AppSurface.ObjectPropertiesProps<Obj.Unknown>;
+export type ObjectPropertiesProps = AppSurface.ObjectPropertiesProps<Obj.Unknown>;
 
-export const ObjectDetails = forwardRef<HTMLDivElement, ObjectDetailsProps>(
+export const ObjectProperties = forwardRef<HTMLDivElement, ObjectPropertiesProps>(
   ({ role, subject: object }, forwardedRef) => {
     const data = useMemo<AppSurface.ObjectPropertiesData>(() => ({ subject: object }), [object]);
 
@@ -22,9 +22,9 @@ export const ObjectDetails = forwardRef<HTMLDivElement, ObjectDetailsProps>(
           <Toolbar.Root />
         </Panel.Toolbar>
         <Panel.Content asChild>
-          <ObjectProperties object={object}>
+          <NaturalObjectProperties object={object}>
             <Surface.Surface type={AppSurface.ObjectProperties} data={data} />
-          </ObjectProperties>
+          </NaturalObjectProperties>
         </Panel.Content>
       </Panel.Root>
     );

--- a/packages/plugins/plugin-space/src/containers/ObjectProperties/index.ts
+++ b/packages/plugins/plugin-space/src/containers/ObjectProperties/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+export { ObjectProperties as default } from './ObjectProperties';

--- a/packages/plugins/plugin-space/src/containers/index.ts
+++ b/packages/plugins/plugin-space/src/containers/index.ts
@@ -15,7 +15,7 @@ export const JoinDialog: ComponentType<any> = lazy(() => import('./JoinDialog'))
 export const MembersContainer: ComponentType<any> = lazy(() => import('./MembersContainer'));
 export const MenuFooter: ComponentType<any> = lazy(() => import('./MenuFooter'));
 export const ObjectCardStack: ComponentType<any> = lazy(() => import('./ObjectCardStack'));
-export const ObjectDetails: ComponentType<any> = lazy(() => import('./ObjectDetails'));
+export const ObjectProperties: ComponentType<any> = lazy(() => import('./ObjectProperties'));
 export const ObjectRenamePopover: ComponentType<any> = lazy(() => import('./ObjectRenamePopover'));
 export const RecordArticle: ComponentType<any> = lazy(() => import('./RecordArticle'));
 export const RelatedArticle: ComponentType<any> = lazy(() => import('./RelatedArticle'));

--- a/packages/ui/react-ui-syntax-highlighter/src/SyntaxHighlighter/SyntaxHighlighter.tsx
+++ b/packages/ui/react-ui-syntax-highlighter/src/SyntaxHighlighter/SyntaxHighlighter.tsx
@@ -3,7 +3,7 @@
 //
 
 import React, { Children } from 'react';
-import { type SyntaxHighlighterProps as NativeSyntaxHighlighterProps } from 'react-syntax-highlighter';
+import { type SyntaxHighlighterProps as NaturalSyntaxHighlighterProps } from 'react-syntax-highlighter';
 import NativeSyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism-async-light';
 import { coldarkDark as dark, coldarkCold as light } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
@@ -18,7 +18,7 @@ const languages = {
 };
 
 export type SyntaxHighlighterProps = Pick<
-  NativeSyntaxHighlighterProps,
+  NaturalSyntaxHighlighterProps,
   | 'language'
   | 'renderer'
   | 'showLineNumbers'
@@ -28,7 +28,7 @@ export type SyntaxHighlighterProps = Pick<
   | 'wrapLongLines'
   | 'PreTag'
 > & {
-  themeStyle?: NativeSyntaxHighlighterProps['style'];
+  themeStyle?: NaturalSyntaxHighlighterProps['style'];
   fallback?: string;
   copyButton?: boolean;
 };


### PR DESCRIPTION
## Summary
- Rename plugin-space's `ObjectDetails` container to `ObjectProperties`; the inner reference to `@dxos/react-ui-form`'s `ObjectProperties` is aliased as `NaturalObjectProperties` to avoid the name collision.
- `MagazineArticle`: open the `ObjectProperties` (settings) companion when the magazine has no posts so the configuration pane is reachable from an empty state.
- `MagazineArticle`: invoke `FeedOperation.CurateMagazine` whenever the count of subscribed feeds changes, so the post list reflects the new selection without a manual Curate click.
- Replace `as Native*` import aliases with `as Natural*` in `SyntaxHighlighter` and `DeckViewport` (the existing convention across the codebase; "Native" was a typo).

## Test plan
- [x] `moon run plugin-feed:build plugin-space:build react-ui-syntax-highlighter:build plugin-deck:build`
- [x] `moon run plugin-feed:test`
- [x] `moon run plugin-feed:lint plugin-space:lint react-ui-syntax-highlighter:lint plugin-deck:lint -- --fix`
- [x] Manually verify Magazine empty state opens the properties companion.
- [x] Manually verify adding/removing a feed triggers curation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Magazine view now auto-curates when its feed selection changes.
  * Object properties (settings) panel now automatically opens when a magazine has no posts.

* **Refactor**
  * UI container and component names reorganized and unified across surfaces.
  * Internal toggle and syntax-highlighting types cleaned up for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->