### PR TITLE
fix: use pinned cloud-release CLI to work around build failures

### DIFF
--- a/.github/actions/cn-release/action.yml
+++ b/.github/actions/cn-release/action.yml
@@ -26,7 +26,7 @@ runs:
       if: github.ref_name != 'labs'
       id: release-channel
 
-    - uses: crabnebula-dev/cloud-release@v0
+    - uses: FabianLars-crabnebula/cloud-release@e0bb6ccebcb78f71883ebde2320f76aae6b9eb92
       with:
         # TODO(wittjosiah): Switch to production.
         command: release ${{ inputs.command }} ${{ inputs.application }} --framework ${{ inputs.framework }}${{ github.ref_name != 'labs' && format(' --channel {0}', steps.release-channel.outputs.channel) || '' }}


### PR DESCRIPTION
## Summary

- Switches `crabnebula-dev/cloud-release@v0` to `FabianLars-crabnebula/cloud-release@e0bb6ccebcb78f71883ebde2320f76aae6b9eb92` in `.github/actions/cn-release/action.yml`
- The pinned commit uses an older CLI version that avoids recent Tauri release build failures
- Per FabianLars' suggestion, the timing of the upstream CLI release and our build failures appears to be the root cause

## Test plan

- [ ] Trigger a Tauri release build and verify it completes successfully with the pinned CLI version

https://claude.ai/code/session_01LACBAFPkoBsL25mJF65f5Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01LACBAFPkoBsL25mJF65f5Y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependency to a pinned commit version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->