### PR TITLE
feat(protocols): add Trello as an OAuth provider

### DIFF
--- a/packages/core/protocols/src/edge/edge.ts
+++ b/packages/core/protocols/src/edge/edge.ts
@@ -316,6 +316,7 @@ export type EdgeAuthChallenge = {
 export enum OAuthProvider {
   GOOGLE = 'google',
   BLUESKY = 'bluesky',
+  TRELLO = 'trello',
 }
 
 export const InitiateOAuthFlowRequestSchema = Schema.Struct({

--- a/packages/core/protocols/src/edge/edge.ts
+++ b/packages/core/protocols/src/edge/edge.ts
@@ -315,8 +315,10 @@ export type EdgeAuthChallenge = {
 
 export enum OAuthProvider {
   GOOGLE = 'google',
+  /** @deprecated Use ATPROTO instead. */
   BLUESKY = 'bluesky',
   TRELLO = 'trello',
+  ATPROTO = 'atproto',
 }
 
 export const InitiateOAuthFlowRequestSchema = Schema.Struct({

--- a/packages/core/protocols/src/edge/edge.ts
+++ b/packages/core/protocols/src/edge/edge.ts
@@ -320,6 +320,7 @@ export enum OAuthProvider {
   GITHUB = 'github',
   GOOGLE = 'google',
   LINEAR = 'linear',
+  SLACK = 'slack',
   TRELLO = 'trello',
 }
 

--- a/packages/core/protocols/src/edge/edge.ts
+++ b/packages/core/protocols/src/edge/edge.ts
@@ -317,7 +317,9 @@ export enum OAuthProvider {
   ATPROTO = 'atproto',
   /** @deprecated Use ATPROTO instead. */
   BLUESKY = 'bluesky',
+  GITHUB = 'github',
   GOOGLE = 'google',
+  LINEAR = 'linear',
   TRELLO = 'trello',
 }
 

--- a/packages/core/protocols/src/edge/edge.ts
+++ b/packages/core/protocols/src/edge/edge.ts
@@ -314,11 +314,11 @@ export type EdgeAuthChallenge = {
 };
 
 export enum OAuthProvider {
-  GOOGLE = 'google',
+  ATPROTO = 'atproto',
   /** @deprecated Use ATPROTO instead. */
   BLUESKY = 'bluesky',
+  GOOGLE = 'google',
   TRELLO = 'trello',
-  ATPROTO = 'atproto',
 }
 
 export const InitiateOAuthFlowRequestSchema = Schema.Struct({

--- a/packages/plugins/plugin-token-manager/src/cli/commands/integration/util.ts
+++ b/packages/plugins/plugin-token-manager/src/cli/commands/integration/util.ts
@@ -29,6 +29,12 @@ export const OAUTH_PRESETS: OAuthPreset[] = [
       'https://www.googleapis.com/auth/youtube.force-ssl',
     ],
   },
+  {
+    provider: OAuthProvider.TRELLO,
+    source: 'trello.com',
+    label: 'Trello',
+    scopes: ['read', 'write'],
+  },
 ];
 
 /**

--- a/packages/plugins/plugin-token-manager/src/cli/commands/integration/util.ts
+++ b/packages/plugins/plugin-token-manager/src/cli/commands/integration/util.ts
@@ -17,6 +17,12 @@ export type OAuthPreset = {
 // TODO(wittjosiah): Copied from plugin-token-manager.
 export const OAUTH_PRESETS: OAuthPreset[] = [
   {
+    provider: OAuthProvider.GITHUB,
+    source: 'github.com',
+    label: 'GitHub',
+    scopes: ['repo', 'read:user'],
+  },
+  {
     provider: OAuthProvider.GOOGLE,
     source: 'google.com',
     label: 'Google',
@@ -28,6 +34,12 @@ export const OAUTH_PRESETS: OAuthPreset[] = [
       'https://www.googleapis.com/auth/youtube.readonly',
       'https://www.googleapis.com/auth/youtube.force-ssl',
     ],
+  },
+  {
+    provider: OAuthProvider.LINEAR,
+    source: 'linear.app',
+    label: 'Linear',
+    scopes: ['read', 'write'],
   },
   {
     provider: OAuthProvider.TRELLO,

--- a/packages/plugins/plugin-token-manager/src/cli/commands/integration/util.ts
+++ b/packages/plugins/plugin-token-manager/src/cli/commands/integration/util.ts
@@ -42,6 +42,12 @@ export const OAUTH_PRESETS: OAuthPreset[] = [
     scopes: ['read', 'write'],
   },
   {
+    provider: OAuthProvider.SLACK,
+    source: 'slack.com',
+    label: 'Slack',
+    scopes: ['channels:read', 'chat:write', 'users:read'],
+  },
+  {
     provider: OAuthProvider.TRELLO,
     source: 'trello.com',
     label: 'Trello',

--- a/packages/plugins/plugin-token-manager/src/defs/presets.ts
+++ b/packages/plugins/plugin-token-manager/src/defs/presets.ts
@@ -14,6 +14,12 @@ export type OAuthPreset = {
 
 export const OAUTH_PRESETS: OAuthPreset[] = [
   {
+    provider: OAuthProvider.GITHUB,
+    source: 'github.com',
+    label: 'GitHub',
+    scopes: ['repo', 'read:user'],
+  },
+  {
     provider: OAuthProvider.GOOGLE,
     source: 'google.com',
     label: 'Google',
@@ -25,6 +31,12 @@ export const OAUTH_PRESETS: OAuthPreset[] = [
       'https://www.googleapis.com/auth/youtube.readonly',
       'https://www.googleapis.com/auth/youtube.force-ssl',
     ],
+  },
+  {
+    provider: OAuthProvider.LINEAR,
+    source: 'linear.app',
+    label: 'Linear',
+    scopes: ['read', 'write'],
   },
   {
     provider: OAuthProvider.TRELLO,

--- a/packages/plugins/plugin-token-manager/src/defs/presets.ts
+++ b/packages/plugins/plugin-token-manager/src/defs/presets.ts
@@ -39,6 +39,12 @@ export const OAUTH_PRESETS: OAuthPreset[] = [
     scopes: ['read', 'write'],
   },
   {
+    provider: OAuthProvider.SLACK,
+    source: 'slack.com',
+    label: 'Slack',
+    scopes: ['channels:read', 'chat:write', 'users:read'],
+  },
+  {
     provider: OAuthProvider.TRELLO,
     source: 'trello.com',
     label: 'Trello',

--- a/packages/plugins/plugin-token-manager/src/defs/presets.ts
+++ b/packages/plugins/plugin-token-manager/src/defs/presets.ts
@@ -26,4 +26,10 @@ export const OAUTH_PRESETS: OAuthPreset[] = [
       'https://www.googleapis.com/auth/youtube.force-ssl',
     ],
   },
+  {
+    provider: OAuthProvider.TRELLO,
+    source: 'trello.com',
+    label: 'Trello',
+    scopes: ['read', 'write'],
+  },
 ];


### PR DESCRIPTION
## Summary

- Adds `OAuthProvider.TRELLO = 'trello'` to the protocol enum in `@dxos/protocols`
- Adds a Trello preset to `plugin-token-manager` (presets.ts) and its CLI copy (util.ts) with scopes `['read', 'write']`

## Background

Trello uses an implicit token flow (`response_type=token`) — the access token is returned directly in the OAuth callback URL rather than via a code exchange. This is handled on the edge side by the companion PR in `dxos/edge`. Atlassian is working on OAuth 2.0 3LO for Trello (RFC-89), but it is not yet available as of April 2026; when it lands, a separate `OAuthProvider.ATLASSIAN` with Trello scopes should be added.

## Pre-deployment requirements

Before deploying to any environment, a DXOS team member must:
1. Create a Trello Power-Up at https://trello.com/power-ups/admin
2. Generate an API key
3. Configure **allowed origins** to include all edge callback URLs (`edge.dxos.workers.dev`, `edge-main.dxos.workers.dev`, `edge-labs.dxos.workers.dev`, `edge-staging.dxos.workers.dev`, `edge-production.dxos.workers.dev`)
4. Set `TRELLO_API_KEY` via `wrangler secret put` for each environment

## Test plan

- [ ] `moon run @dxos/protocols:compile` passes
- [ ] `moon run @dxos/plugin-token-manager:build` passes
- [ ] Trello appears in the token manager integration list in Composer

https://claude.ai/code/session_014BtQuBVqEX4D15hNZ7N29D

---
_Generated by [Claude Code](https://claude.ai/code/session_014BtQuBVqEX4D15hNZ7N29D)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GitHub, Linear, Slack, Trello, and atproto OAuth authentication.
  * Introduced atproto as a new primary provider; Bluesky is now deprecated.
  * Configured authentication scopes and presets for new OAuth providers in CLI integration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->