### PR TITLE
fix(plugin-registry): hide uninstall for non-community plugins; restrict native-filesystem to tauri

### DIFF
--- a/packages/apps/composer-app/src/plugin-defs.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.tsx
@@ -410,7 +410,7 @@ export const getPlugins = async (
     MeetingPlugin(),
     MermaidPlugin(),
     isTauri && !isMobile && !isPopover && NativePlugin(),
-    NativeFilesystemPlugin(),
+    isTauri && !isMobile && !isPopover && NativeFilesystemPlugin(),
     NavTreePlugin(),
     ObservabilityPlugin({
       namespace: appKey,

--- a/packages/plugins/plugin-registry/src/containers/PluginArticle/PluginArticle.tsx
+++ b/packages/plugins/plugin-registry/src/containers/PluginArticle/PluginArticle.tsx
@@ -12,7 +12,7 @@ import { runAndForwardErrors } from '@dxos/effect';
 
 import { PluginDetail } from '#components';
 
-import { useCommunityPlugins } from '../../hooks';
+import { useCommunityPlugins, useRemotePluginIds } from '../../hooks';
 
 // TODO(burdon): Convert to ECHO type.
 export type PluginArticleProps = { subject: Plugin.Plugin };
@@ -21,6 +21,7 @@ export const PluginArticle = ({ subject: plugin }: PluginArticleProps) => {
   const manager = usePluginManager();
   const plugins = useAtomValue(manager.plugins);
   const { entries } = useCommunityPlugins();
+  const remotePluginIds = useRemotePluginIds();
   const [installing, setInstalling] = useState(false);
 
   const enabled = manager.getEnabled().includes(plugin.meta.id);
@@ -29,7 +30,7 @@ export const PluginArticle = ({ subject: plugin }: PluginArticleProps) => {
     [plugins, plugin.meta.id],
   );
   const isCore = manager.getCore().includes(plugin.meta.id);
-  const canUninstall = isInstalled && !isCore;
+  const canUninstall = isInstalled && !isCore && remotePluginIds.has(plugin.meta.id);
 
   const moduleUrl = useMemo(
     () => entries.find((entry) => entry.meta.id === plugin.meta.id)?.moduleUrl,


### PR DESCRIPTION
## Summary

- **Uninstall button**: The "Uninstall" button on the plugin details page is now only shown for plugins that were dynamically loaded from a remote URL (community registry or local dev URL). Bundled/official plugins — which were always non-removable — no longer show the button at all.
- **Native Filesystem plugin**: `NativeFilesystemPlugin` is now only instantiated when running in the Tauri desktop app (matching the existing `NativePlugin` guard: `isTauri && !isMobile && !isPopover`). It will not appear in the registry or be available on web/PWA/mobile.

## Changes

- `packages/plugins/plugin-registry/src/containers/PluginArticle/PluginArticle.tsx`: import `useRemotePluginIds` and add it as a third condition to `canUninstall`.
- `packages/apps/composer-app/src/plugin-defs.tsx`: gate `NativeFilesystemPlugin()` with `isTauri && !isMobile && !isPopover`.

https://claude.ai/code/session_01QJhJ2crUcZkrLwosgpm3TB

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJhJ2crUcZkrLwosgpm3TB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed native filesystem plugin handling based on application environment
  * Enhanced plugin uninstall controls to prevent removing ineligible plugins

<!-- end of auto-generated comment: release notes by coderabbit.ai -->