### PR TITLE
fix(plugin-deck): disable native redirect by default

### DIFF
--- a/packages/plugins/plugin-deck/src/capabilities/settings.ts
+++ b/packages/plugins/plugin-deck/src/capabilities/settings.ts
@@ -20,7 +20,7 @@ export default Capability.makeModule(() =>
         showHints: false,
         enableDeck: false,
         enableStatusbar: false,
-        enableNativeRedirect: !import.meta.env.DEV,
+        enableNativeRedirect: false,
         encapsulatedPlanks: false,
       }),
     });


### PR DESCRIPTION
## Summary

- Changes the default value of `enableNativeRedirect` in the deck plugin settings from `!import.meta.env.DEV` (enabled in production) to `false` (always disabled by default).
- Users can still enable it manually via the deck plugin settings UI.

## Test plan

- [ ] Open the app in a browser (non-Tauri, non-dev mode) and confirm it no longer attempts to redirect to the native app on load.
- [ ] Open Settings → Deck and confirm the "Native Redirect" toggle is off by default.
- [ ] Enable the toggle and confirm the native redirect behavior works as expected.

https://claude.ai/code/session_016t21mch97sWMELakhHuAsr

---
_Generated by [Claude Code](https://claude.ai/code/session_016t21mch97sWMELakhHuAsr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Native redirect is now disabled by default across all environments, replacing the previous environment-dependent configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->