### PR TITLE
feat(tools): add composer-plugin-dev Claude Code plugin

### DIFF
--- a/tools/composer-plugin-dev/.claude-plugin/plugin.json
+++ b/tools/composer-plugin-dev/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "composer-plugin-dev",
+  "version": "0.1.0",
+  "description": "Authoring guide for DXOS Composer plugins: scaffolding, capabilities, surfaces, operations, blueprints, testing, and community-plugin packaging.",
+  "author": "DXOS.org",
+  "homepage": "https://github.com/dxos/dxos",
+  "keywords": ["dxos", "composer", "plugin"]
+}

--- a/tools/composer-plugin-dev/README.md
+++ b/tools/composer-plugin-dev/README.md
@@ -1,0 +1,17 @@
+# composer-plugin-dev
+
+A Claude Code plugin that bundles authoring guidance for **DXOS Composer plugins**.
+
+The default audience is community authors building a plugin in their **own repository** (Vite + `composerPlugin`, GitHub release with `manifest.json` + `plugin.mjs`, registered via [`dxos/community-plugins`](https://github.com/dxos/community-plugins)). Each topic has a "**Inside the dxos monorepo**" callout that flags how the in-repo workflow differs (moon, `workspace:*` deps, exports subpaths, `composer-app` registration, `PLUGIN.mdl`).
+
+## Contents
+
+- `skills/composer-plugin-dev/SKILL.md` — topic index. Start here.
+- `skills/composer-plugin-dev/references/*.md` — one file per topic.
+- `commands/new-composer-plugin.md` — `/new-composer-plugin <name>` scaffold.
+- `commands/audit-composer-plugin.md` — `/audit-composer-plugin <path>` review.
+- `agents/composer-plugin-reviewer.md` — review subagent.
+
+## Install (local marketplace)
+
+Lives at `tools/composer-plugin-dev/` in the dxos monorepo. Add this directory as a local plugin source in `~/.claude/settings.json`, or invoke via `/plugin` after pointing Claude Code at it.

--- a/tools/composer-plugin-dev/agents/composer-plugin-reviewer.md
+++ b/tools/composer-plugin-dev/agents/composer-plugin-reviewer.md
@@ -1,0 +1,47 @@
+---
+name: composer-plugin-reviewer
+description: Reviews a DXOS Composer plugin (community or in-repo) against the conventions in the composer-plugin-dev skill. Use when the user asks for a review of a Composer plugin, before opening a PR for one, or after scaffolding a new plugin.
+tools: Read, Bash, Grep, Glob
+---
+
+You are a code reviewer specialized in DXOS Composer plugins.
+
+## Source of truth
+
+The `composer-plugin-dev` skill — specifically the references under `tools/composer-plugin-dev/skills/composer-plugin-dev/references/` — defines the conventions you enforce. Read them on demand; don't summarize the whole skill upfront.
+
+The default audience for plugins is **community/external authors** (own repo, Vite + `composerPlugin`, GitHub release, registered via [`dxos/community-plugins`](https://github.com/dxos/community-plugins)). Inside the dxos monorepo a few things differ; the skill calls these out.
+
+## Method
+
+1. Run `git status` and `git diff main...HEAD` (or against the appropriate base) to see what changed.
+2. Walk the plugin tree (or just changed files for a PR review) and check each category:
+   - **Layout** — `directory-structure.md`.
+   - **Components vs containers** — `components-vs-containers.md`. Treat any `@dxos/app-framework`/`@dxos/app-toolkit` import in `src/components/` as **critical**.
+   - **Behavior placement** — `operations-vs-ui.md`. Any `fetch`, LLM call, or heavy compute in a container is **critical**.
+   - **Auth** — `external-services.md`. Credentials must be `AccessToken` Refs.
+   - **AI** — `ai-service.md`. LLM calls go through operations + `AiService`.
+   - **Operations** — `operations.md`. Definitions + per-handler files + lazy `OperationHandlerSet`.
+   - **Blueprints** — `blueprints.md`. Plugins should ship a blueprint exposing operations as tools.
+   - **Types** — `types-schema.md`. Typename, version, `LabelAnnotation`, `IconAnnotation`, `make()` factory.
+   - **Capabilities** — `capabilities.md`. Barrel uses only `Capability.lazy()`.
+   - **Packaging** — `package-json.md`. Especially the **CLI entrypoint contract** — no React in `./cli`.
+   - **Build** — `vite-config.md` (community) or `moon-yml.md` (in-repo).
+   - **Tests** — `testing.md`. Smoke + operation test minimum.
+   - **Style** — `coding-style.md`.
+   - **Spec** (in-repo only) — `specification.md`. `PLUGIN.mdl` must reflect current behavior.
+3. For community plugins, also verify packaging readiness per `publishing.md` (deps pinned to Composer host, manifest emitted, release workflow present).
+
+## Output
+
+Markdown report grouped by severity:
+
+- **🚨 Critical** — must fix before merging (broken contracts, security issues, anti-patterns from `operations-vs-ui.md`).
+- **⚠️ Important** — should fix (missing tests, missing blueprint, layout deviations).
+- **💡 Nit** — style and polish.
+
+Each finding cites `file:line` and proposes a concrete change. Skip categories that are clean — silence is approval.
+
+## What you are not
+
+You are **not** a general code reviewer. Stick to Composer-plugin conventions. For broader code review, the user should run a separate review.

--- a/tools/composer-plugin-dev/agents/composer-plugin-reviewer.md
+++ b/tools/composer-plugin-dev/agents/composer-plugin-reviewer.md
@@ -14,7 +14,7 @@ The default audience for plugins is **community/external authors** (own repo, Vi
 
 ## Method
 
-1. Run `git status` and `git diff main...HEAD` (or against the appropriate base) to see what changed.
+1. Run `git status` and diff against the **PR's actual base branch** (do not hardcode `main`). If you know the base, use `git diff <base>...HEAD`; otherwise infer it (e.g. via `gh pr view --json baseRefName -q .baseRefName`) or fall back to the merge-base: `git diff $(git merge-base origin/HEAD HEAD)..HEAD`. Reviewing the wrong base will surface unrelated changes.
 2. Walk the plugin tree (or just changed files for a PR review) and check each category:
    - **Layout** — `directory-structure.md`.
    - **Components vs containers** — `components-vs-containers.md`. Treat any `@dxos/app-framework`/`@dxos/app-toolkit` import in `src/components/` as **critical**.

--- a/tools/composer-plugin-dev/commands/audit-composer-plugin.md
+++ b/tools/composer-plugin-dev/commands/audit-composer-plugin.md
@@ -1,0 +1,59 @@
+---
+description: Audit a Composer plugin against the conventions in the composer-plugin-dev skill.
+argument-hint: [path-to-plugin]
+---
+
+You are auditing a Composer plugin. The path is `$ARGUMENTS` (default: current directory).
+
+## Checklist
+
+Walk the plugin tree and report **every deviation** from the rules in `skills/composer-plugin-dev/references/`. Use the topic index in `SKILL.md` to navigate. Be specific — cite file paths and line numbers.
+
+### Layout
+- `src/` matches `directory-structure.md`?
+- `src/index.ts` is minimal (only plugin + meta)?
+- Each capability in its own file; barrel uses only `Capability.lazy()`?
+
+### Components vs containers (`components-vs-containers.md`)
+- Any `src/components/*` file imports `@dxos/app-framework` or `@dxos/app-toolkit`? **Critical.**
+- Containers use `Panel`/`ScrollArea`/`Toolbar`/`Card` instead of custom Tailwind?
+- Per-container `index.ts` bridges named → default for `React.lazy`?
+
+### Behavior placement (`operations-vs-ui.md`)
+- Any `fetch` / external calls / heavy logic in containers? **Critical.**
+- `AccessToken` used for credentials; never in component state?
+- `AiService` used for inference; no direct LLM SDK calls in UI?
+
+### Operations & blueprints
+- Operations split between `definitions.ts` and per-handler files?
+- `OperationHandlerSet.lazy()` in the barrel?
+- Blueprint defined and registered? Type metadata references `blueprints: [...]`?
+
+### Types
+- Typename is dotted and namespaced; version present?
+- `LabelAnnotation` and `IconAnnotation` set?
+- `make()` factory using `Obj.make()`?
+
+### Packaging
+- `"private": true` (mandatory for new packages)?
+- `@dxos/*` deps: `workspace:*` (in-repo) or pinned to Composer host dist-tag (community)?
+- Externals via `catalog:` (in-repo)?
+- CLI entrypoint imports React or `@dxos/react-ui`? **Critical.**
+- Each `exports` subpath matched by a `--entryPoint` in `moon.yml`?
+
+### Tests (`testing.md`)
+- A smoke test verifies module activation?
+- At least one operation test using `harness.invoke`?
+- Tests use `@dxos/plugin-client/cli`, not the main entrypoint?
+
+### Style
+- No default exports outside per-container `index.ts`?
+- Barrel imports via `#aliases`, no deep relative paths?
+- `invariant` for preconditions, not throws?
+
+### Spec (in-repo only)
+- `PLUGIN.mdl` exists and matches current behavior?
+
+## Output
+
+Report findings as a structured Markdown summary, grouped by severity (**critical / important / nit**) with file paths and concrete fix suggestions. Skip categories that are clean.

--- a/tools/composer-plugin-dev/commands/audit-composer-plugin.md
+++ b/tools/composer-plugin-dev/commands/audit-composer-plugin.md
@@ -10,31 +10,37 @@ You are auditing a Composer plugin. The path is `$ARGUMENTS` (default: current d
 Walk the plugin tree and report **every deviation** from the rules in `skills/composer-plugin-dev/references/`. Use the topic index in `SKILL.md` to navigate. Be specific — cite file paths and line numbers.
 
 ### Layout
+
 - `src/` matches `directory-structure.md`?
 - `src/index.ts` is minimal (only plugin + meta)?
 - Each capability in its own file; barrel uses only `Capability.lazy()`?
 
 ### Components vs containers (`components-vs-containers.md`)
+
 - Any `src/components/*` file imports `@dxos/app-framework` or `@dxos/app-toolkit`? **Critical.**
 - Containers use `Panel`/`ScrollArea`/`Toolbar`/`Card` instead of custom Tailwind?
 - Per-container `index.ts` bridges named → default for `React.lazy`?
 
 ### Behavior placement (`operations-vs-ui.md`)
+
 - Any `fetch` / external calls / heavy logic in containers? **Critical.**
 - `AccessToken` used for credentials; never in component state?
 - `AiService` used for inference; no direct LLM SDK calls in UI?
 
 ### Operations & blueprints
+
 - Operations split between `definitions.ts` and per-handler files?
 - `OperationHandlerSet.lazy()` in the barrel?
 - Blueprint defined and registered? Type metadata references `blueprints: [...]`?
 
 ### Types
+
 - Typename is dotted and namespaced; version present?
 - `LabelAnnotation` and `IconAnnotation` set?
 - `make()` factory using `Obj.make()`?
 
 ### Packaging
+
 - `"private": true` (mandatory for new packages)?
 - `@dxos/*` deps: `workspace:*` (in-repo) or pinned to Composer host dist-tag (community)?
 - Externals via `catalog:` (in-repo)?
@@ -42,16 +48,19 @@ Walk the plugin tree and report **every deviation** from the rules in `skills/co
 - Each `exports` subpath matched by a `--entryPoint` in `moon.yml`?
 
 ### Tests (`testing.md`)
+
 - A smoke test verifies module activation?
 - At least one operation test using `harness.invoke`?
 - Tests use `@dxos/plugin-client/cli`, not the main entrypoint?
 
 ### Style
+
 - No default exports outside per-container `index.ts`?
 - Barrel imports via `#aliases`, no deep relative paths?
 - `invariant` for preconditions, not throws?
 
 ### Spec (in-repo only)
+
 - `PLUGIN.mdl` exists and matches current behavior?
 
 ## Output

--- a/tools/composer-plugin-dev/commands/audit-composer-plugin.md
+++ b/tools/composer-plugin-dev/commands/audit-composer-plugin.md
@@ -9,6 +9,13 @@ You are auditing a Composer plugin. The path is `$ARGUMENTS` (default: current d
 
 Walk the plugin tree and report **every deviation** from the rules in `skills/composer-plugin-dev/references/`. Use the topic index in `SKILL.md` to navigate. Be specific — cite file paths and line numbers.
 
+### Architecture (`before-you-build.md`)
+
+- Does this plugin duplicate domain types that already exist in another plugin or `@dxos/types` (e.g. service-prefixed copies of `Kanban.Card`)? **Critical.**
+- Does it ship a bespoke UI for entities an existing plugin already renders? Should it be a headless sync layer over the existing UI instead?
+- For sync/integration plugins: is sync state modeled as a dedicated ECHO object (cursor, external-id mapping, last-sync timestamp)?
+- Any cross-object atomicity assumptions that conflict with non-atomic writes in the store? Flag for human review.
+
 ### Layout
 
 - `src/` matches `directory-structure.md`?

--- a/tools/composer-plugin-dev/commands/new-composer-plugin.md
+++ b/tools/composer-plugin-dev/commands/new-composer-plugin.md
@@ -1,0 +1,26 @@
+---
+description: Scaffold a new DXOS Composer plugin (community-style by default).
+argument-hint: <plugin-name> [--monorepo]
+---
+
+You are scaffolding a new DXOS Composer plugin.
+
+**Args:** `$ARGUMENTS`
+
+The first positional argument is the plugin name in kebab-case (e.g. `pomodoro`). If `--monorepo` is passed, scaffold inside `packages/plugins/plugin-<name>/`. Otherwise scaffold at the repo root for a standalone community plugin.
+
+## Procedure
+
+1. Read the relevant references in this order, **only the ones you need**:
+   - `skills/composer-plugin-dev/references/scaffolding.md`
+   - `skills/composer-plugin-dev/references/directory-structure.md`
+   - `skills/composer-plugin-dev/references/plugin-definition.md`
+   - `skills/composer-plugin-dev/references/types-schema.md`
+   - `skills/composer-plugin-dev/references/translations.md`
+   - For monorepo only: `skills/composer-plugin-dev/references/specification.md`, `skills/composer-plugin-dev/references/moon-yml.md`, `skills/composer-plugin-dev/references/registration.md`
+2. **Confirm with the user before writing files**: plugin name, typename namespace (e.g. `com.example.type.thing`), icon (Phosphor `ph--*--regular`), iconHue, one initial ECHO type and its fields.
+3. Generate the minimum skeleton from `scaffolding.md` — `meta.ts`, `translations.ts`, one type, one container, one surface, plugin file, `package.json`, `vite.config.ts` (community) or `moon.yml` + `PLUGIN.mdl` (monorepo).
+4. **Do not** add operations, blueprints, or settings yet — the user adds those incrementally.
+5. Build and verify before declaring done.
+
+For monorepo plugins, **the `PLUGIN.mdl` must be approved by the user before any code is written.**

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/SKILL.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: composer-plugin-dev
+description: Author DXOS Composer plugins — primarily community plugins built in their own repo (Vite + composerPlugin, GitHub release, registered via dxos/community-plugins), with notes on how the in-repo workflow differs. Use when scaffolding a new Composer plugin, wiring capabilities (surfaces, operations, blueprints), exposing operations to AI agents, integrating external services, testing with the composer testing harness, or publishing to the community registry.
+---
+
+# Composer Plugin Authoring
+
+**Audience.** This skill is for authors building a Composer plugin **outside the dxos monorepo** — in your own GitHub repository, packaged as a community plugin. Inside the monorepo (`packages/plugins/plugin-*`), most patterns are identical, but a handful of things change (build system, dep specifiers, package layout, registration, spec language). Each section below has an **"Inside the dxos monorepo"** callout where it differs.
+
+**Reference plugins.**
+
+- Community: [`dxos/plugin-excalidraw`](https://github.com/dxos/plugin-excalidraw), [`dxos/plugin-youtube`](https://github.com/dxos/plugin-youtube).
+- Registry: [`dxos/community-plugins`](https://github.com/dxos/community-plugins) — the JSON index Composer reads.
+- In-repo exemplar: [`packages/plugins/plugin-chess`](https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-chess).
+
+When in doubt, copy a working plugin and modify.
+
+---
+
+## How to use this skill
+
+Each topic below links to a focused reference file under `references/`. Read the index first, then jump to the file you need. Files are short and self-contained; don't try to read them all at once.
+
+## Topics
+
+### Getting started
+
+1. **[Scaffolding a community plugin](references/scaffolding.md)** — minimum viable repo: `package.json`, `vite.config.ts`, `tsconfig.json`, `src/plugin.tsx`, `src/meta.ts`. What to clone from `plugin-excalidraw`.
+2. **[Directory structure](references/directory-structure.md)** — the canonical `src/` layout (`capabilities/`, `components/`, `containers/`, `types/`, `operations/`, `blueprints/`, `translations.ts`, `meta.ts`, `plugin.tsx`).
+3. **[Plugin definition](references/plugin-definition.md)** — `Plugin.define(meta).pipe(...)` with `AppPlugin.add*Module` helpers. Activation events. The wiring order that works.
+
+### UI
+
+4. **[Components vs containers](references/components-vs-containers.md)** — the **non-negotiable separation**. `src/components/` are presentational primitives with **no `@dxos/app-framework` or `@dxos/app-toolkit` dependency**. `src/containers/` consume capabilities, are surface-aware, and are always lazy-loaded. Why this split exists and how it keeps your plugin testable.
+5. **[Components](references/components.md)** — named exports only, one subdir per component, basic storybook each.
+6. **[Containers & UI primitives](references/containers.md)** — `Panel.Root` / `Panel.Toolbar` / `Panel.Content` / `ScrollArea` / `Toolbar` / `Card` patterns. **Never write custom layout classNames** when a primitive exists. Article/Card/Section role suffix conventions.
+7. **[React surface](references/react-surface.md)** — `Surface.create()` with `AppSurface.object(role, Type)` filters. Common roles: `article`, `section`, `card--content`, `object-properties`, `dialog`.
+
+### Data
+
+8. **[ECHO types & schemas](references/types-schema.md)** — `Type.object({ typename, version })`, `LabelAnnotation`, `Annotation.IconAnnotation`, namespace re-export (`export * as Foo from './Foo'`), `make()` factory using `Obj.make()`, `FormInputAnnotation`.
+9. **[Translations](references/translations.md)** — keyed by **typename** (object labels) **and** `meta.id` (plugin-scoped strings). `useTranslation(meta.id)` in components.
+
+### Behavior — keep it out of the UI
+
+10. **[Operations vs UI: where logic belongs](references/operations-vs-ui.md)** — **put large computations, side effects, and external-service integrations into operations, not UI code.** UI components stay thin. Operations are testable, schema-typed, reusable from blueprints, callable from CLI, and re-runnable.
+11. **[Operations](references/operations.md)** — `Operation.make({ meta, input, output, services })`, `Operation.withHandler(Effect.fn(...))`, `OperationHandlerSet.lazy()`. Splitting `definitions.ts` from per-handler files. Why services declare what they need.
+12. **[External services & authentication (`AccessToken`)](references/external-services.md)** — store credentials as `AccessToken` ECHO objects referenced by `Ref.Ref<AccessToken>`; load inside an operation using an Effect helper. **Never** read raw secrets in containers. Worked example modeled after `plugin-inbox`.
+13. **[AI inference (`AiService`)](references/ai-service.md)** — when you need an LLM call, do it inside an operation with `AiService.model('@anthropic/claude-sonnet-4-5')`, tools via `OpaqueToolkit`, executor via `ToolExecutionService`. Don't call models from React.
+14. **[Blueprints — let agents use your plugin](references/blueprints.md)** — define a blueprint key, gather your operations, `Blueprint.toolDefinitions({ operations })`, write a short instruction template. **Every plugin worth writing should ship a blueprint** so the assistant can drive it. How to register via `addBlueprintDefinitionModule`.
+15. **[Capabilities](references/capabilities.md)** — `Capability.lazy()` in `capabilities/index.ts`, `Capability.makeModule()` per file, `Capability.contributes(Capabilities.X, ...)`. Why everything is lazy.
+
+### Packaging & publishing
+
+16. **[`package.json`](references/package-json.md)** — community-plugin form (single bundled module, deps pinned to a Composer release tag) vs. monorepo form (`workspace:*`, multiple `exports`, `imports` aliases, `"private": true`). The **CLI entrypoint contract**: `cli` must export **only blueprint, operations, and types** — no React, no app-framework UI capabilities — so it can run under Node.
+17. **[`vite.config.ts` (community plugins)](references/vite-config.md)** — `composerPlugin({ entry: 'src/plugin.tsx', meta })` from `@dxos/app-framework/vite-plugin`, plus `react()` and `wasm()`. Emits `dist/plugin.mjs` and `dist/manifest.json`.
+18. **[`moon.yml` (in-repo only)](references/moon-yml.md)** — `compile.args` lists one `--entryPoint` per `package.json` `exports` subpath. Skip if you're outside the monorepo.
+19. **[Publishing to the community registry](references/publishing.md)** — full release workflow:
+    - GitHub Actions build → release with `manifest.json` + `plugin.mjs` assets.
+    - Pin all `@dxos/*` deps to the Composer host's main dist-tag.
+    - Local testing via Composer **Settings → Plugins → Load by URL**.
+    - Submit a PR to [`dxos/community-plugins`](https://github.com/dxos/community-plugins) adding `{ "repo": "owner/repo" }` to `community-plugins.json`.
+    - Registry syncs into Composer roughly every 5 minutes.
+
+### Quality
+
+20. **[Testing with the composer harness](references/testing.md)** — `createComposerTestApp({ plugins: [...] })` from `@dxos/plugin-testing/harness`. Two minimum tests every plugin should have: a **smoke test** (modules activate on the right events) and an **operation test** (`harness.invoke(MyOp, input)`). Use the CLI variant of `ClientPlugin` (the main one references browser-only capabilities). Storybook for containers.
+21. **[Coding style](references/coding-style.md)** — `invariant` over throws; barrel imports (`#capabilities`, `#components`, etc.); no default exports except container `index.ts` (for `React.lazy`); ESM `#private` over TS `private` in new code; reactive ECHO (`useQuery`, `useObject`, atoms).
+22. **[Build & verify](references/build-test.md)** — community: `pnpm build`, `pnpm test`. Monorepo: `moon run plugin-foo:build|lint|test|test-storybook`.
+
+### Inside the dxos monorepo (only)
+
+23. **[`PLUGIN.mdl` specification](references/specification.md)** — the design-first spec language (MDL). **The `PLUGIN.mdl` is the design document.** Approve before writing code; update before changing features. Template at `packages/plugins/plugin-spec/docs/PLUGIN-.template.mdl`. Community plugins can adopt this voluntarily, but it isn't required.
+24. **[Registering with `composer-app`](references/registration.md)** — for in-repo plugins only: add to the composer app's plugin list. Community plugins are loaded dynamically by Composer from the registry; no registration step.
+
+---
+
+## Quick decision tree
+
+- **"Where do I put this code?"** Heavy logic → `operations/`. External call → `operations/` (with `AccessToken`). LLM call → `operations/` (with `AiService`). Layout → `containers/` using `Panel`/`ScrollArea`/`Toolbar`/`Card`. Reusable presentational → `components/` (no framework deps).
+- **"Should agents be able to do this?"** If yes — and the answer is usually yes — define an `Operation` and reference it from a `Blueprint`.
+- **"Where does this belong in `package.json` exports?"** Browser/UI surfaces → main entry. Headless logic the CLI/agents need → `./blueprints`, `./operations`, `./types`. Keep `./cli` free of React.
+- **"Do I need `moon.yml`?"** Only inside the monorepo.
+
+## Common mistakes
+
+- Importing `@dxos/app-framework` from `src/components/`. (Use `containers/`.)
+- Calling `fetch` / external APIs / LLMs directly from a container. (Move to an operation.)
+- Skipping the blueprint, leaving the assistant unable to drive the plugin.
+- Writing custom Tailwind layout instead of using `Panel` / `ScrollArea` / `Toolbar` / `Card`.
+- Adding non-lazy exports to `capabilities/index.ts`.
+- Putting React imports in the CLI entrypoint.
+- Hard-coding secrets instead of using `AccessToken` Refs.
+- Pinning `@dxos/*` deps to arbitrary versions instead of the Composer host's main dist-tag.

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/SKILL.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/SKILL.md
@@ -5,7 +5,7 @@ description: Author DXOS Composer plugins — primarily community plugins built 
 
 # Composer Plugin Authoring
 
-**Audience.** This skill is for authors building a Composer plugin **outside the dxos monorepo** — in your own GitHub repository, packaged as a community plugin. Inside the monorepo (`packages/plugins/plugin-*`), most patterns are identical, but a handful of things change (build system, dep specifiers, package layout, registration, spec language). Each section below has an **"Inside the dxos monorepo"** callout where it differs.
+**Audience.** This skill is for authors building a Composer plugin **outside the dxos monorepo**. For v1, the recommended layout is an **external monorepo** containing many community plugins (so refactoring/abstractions can move across them); standalone per-plugin repos like `dxos/plugin-excalidraw` are also supported and may become the preferred shape in v2. Inside the dxos monorepo (`packages/plugins/plugin-*`), most patterns are identical, but a handful of things change (build system, dep specifiers, package layout, registration, spec language). Each section below has an **"Inside the dxos monorepo"** callout where it differs.
 
 **Reference plugins.**
 
@@ -21,7 +21,13 @@ When in doubt, copy a working plugin and modify.
 
 Each topic below links to a focused reference file under `references/`. Read the index first, then jump to the file you need. Files are short and self-contained; don't try to read them all at once.
 
+> **Read [before-you-build.md](references/before-you-build.md) first.** It covers the architectural decisions that should precede any scaffolding: surveying existing plugins, reusing internal types, preferring headless sync layers over bespoke UI, sync-state design, the open question around non-atomic writes, and when to stop and ask a human.
+
 ## Topics
+
+### Before you build
+
+0. **[Before you build](references/before-you-build.md)** — survey existing plugins, reuse internal types, prefer headless sync over bespoke UI, build reusable sync infrastructure, watch out for non-atomic writes, and know when to flag architectural decisions to a human.
 
 ### Getting started
 

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/ai-service.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/ai-service.md
@@ -7,13 +7,7 @@ Run LLM calls **inside operations**, never from React. `AiService` from `@dxos/a
 ```ts
 // src/operations/summarize.ts
 import * as Effect from 'effect/Effect';
-import {
-  AiService,
-  ConsolePrinter,
-  OpaqueToolkit,
-  ToolExecutionService,
-  ToolResolverService,
-} from '@dxos/ai';
+import { AiService, ConsolePrinter, OpaqueToolkit, ToolExecutionService, ToolResolverService } from '@dxos/ai';
 import { Operation } from '@dxos/operation';
 
 import { Summarize } from './definitions';

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/ai-service.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/ai-service.md
@@ -1,0 +1,75 @@
+# AI inference (`AiService`)
+
+Run LLM calls **inside operations**, never from React. `AiService` from `@dxos/ai` gives you a host-managed model client with tracing, tools, and tool execution.
+
+## Minimum example
+
+```ts
+// src/operations/summarize.ts
+import * as Effect from 'effect/Effect';
+import {
+  AiService,
+  ConsolePrinter,
+  OpaqueToolkit,
+  ToolExecutionService,
+  ToolResolverService,
+} from '@dxos/ai';
+import { Operation } from '@dxos/operation';
+
+import { Summarize } from './definitions';
+
+const handler = Summarize.pipe(
+  Operation.withHandler(
+    Effect.fn(function* ({ text }) {
+      const result = yield* AiService.run({
+        model: AiService.model('@anthropic/claude-sonnet-4-5'),
+        system: 'You are a concise summarizer. Reply in one sentence.',
+        messages: [{ role: 'user', content: text }],
+      });
+      return { summary: result.content };
+    }),
+  ),
+);
+
+export default handler;
+```
+
+## Tools and tool execution
+
+When the model needs to call other operations as tools:
+
+```ts
+const result = yield* AiService.run({
+  model: AiService.model('@anthropic/claude-sonnet-4-5'),
+  toolkit: OpaqueToolkit.fromOperations([Search, Fetch]),
+  toolExecutor: ToolExecutionService,
+  toolResolver: ToolResolverService,
+  printer: ConsolePrinter,
+  messages: [...],
+});
+```
+
+## Service declaration
+
+Add `AiService` to the operation's `services` array so the platform wires it in:
+
+```ts
+export const Summarize = Operation.make({
+  meta: { key: 'com.example.function.foo.summarize', name: 'Summarize', description: '...' },
+  input: Schema.Struct({ text: Schema.String }),
+  output: Schema.Struct({ summary: Schema.String }),
+  services: [AiService],
+});
+```
+
+## Why not call the SDK directly?
+
+- **Model selection** is centralized — switch from Sonnet 4.5 to a future model in one place.
+- **Auth** flows through the host; you don't ship API keys in your bundle.
+- **Tracing & cost accounting** show up in Composer's diagnostics.
+- **Tool calls round-trip through your operations**, so the assistant can reuse them.
+
+## Reference
+
+- `packages/plugins/plugin-inbox/src/operations/summarize-mailbox.ts`
+- `packages/plugins/plugin-inbox/src/operations/classify-email.ts`

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/ai-service.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/ai-service.md
@@ -58,7 +58,7 @@ export const Summarize = Operation.make({
   meta: { key: 'com.example.function.foo.summarize', name: 'Summarize', description: '...' },
   input: Schema.Struct({ text: Schema.String }),
   output: Schema.Struct({ summary: Schema.String }),
-  services: [AiService],
+  services: [AiService.AiService],
 });
 ```
 

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/before-you-build.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/before-you-build.md
@@ -1,0 +1,96 @@
+# Before you build
+
+Plugins are easy to generate; the architectural choices around them are not. Read this before scaffolding anything — most of the value is in **what you don't build**.
+
+## Survey first, scaffold second
+
+Before writing a new plugin, **read the relevant existing plugins** in `packages/plugins/` (or in the community monorepo). Look for:
+
+- A plugin that already targets the same domain (kanban, mailbox, sketch, …).
+- Shared UI primitives or plugin-level patterns you can reuse.
+- Domain types in `@dxos/types` or another plugin's `./types` export that already model your entities.
+
+If a similar plugin exists, your job is usually to **factor out a shared abstraction**, not to duplicate it. Copy-paste produces drift; abstraction produces leverage.
+
+## Don't invent duplicate domain types
+
+When integrating an external service (Trello, GitHub, Linear, Gmail), do **not** create service-prefixed echoes of types that already exist (`Trello.Card`, `Trello.Board`). That's a smell:
+
+- Composer users will end up with parallel, incompatible "card" types they can't move between.
+- Other plugins (kanban, table, board) won't recognise your types.
+- The next service integration will repeat the mistake.
+
+The right move:
+
+- **Map onto an existing internal type** (e.g. `Kanban.Card`, `Markdown.Document`).
+- If no internal type fits, **propose a new shared type** and place it in a neutral location, not in your plugin.
+
+## Prefer headless sync over bespoke UI
+
+If you're integrating a service whose entities map onto an existing internal type, **don't ship a new UI for them**. Build a **headless sync layer** that reads/writes the existing types, and let the existing plugin (e.g. kanban) render them.
+
+Concretely, a Trello integration should look like:
+
+- A sync operation: pulls Trello → writes/updates `Kanban.Card` objects in ECHO.
+- An `AccessToken` for the Trello API (see [external-services.md](./external-services.md)).
+- A **sync-state object** that records the cursor / last-sync timestamp / per-record IDs (see below).
+- **No** custom Trello article surface. The kanban plugin already has one.
+
+This keeps the experience uniform, and it makes the next sync integration (Linear, GitHub Projects, …) a much smaller change.
+
+## Build reusable sync infrastructure
+
+When your plugin syncs with an external store, model the sync state as an ECHO object:
+
+- Cursor / etag / last-sync timestamp.
+- Per-record mapping (external ID ↔ ECHO object ID).
+- Conflict / failure log, if needed.
+
+A clean sync-state schema is groundwork for **every future OAuth/sync plugin**, not a one-off. If you find yourself stuffing this state into ad-hoc fields on the domain object, stop and lift it out.
+
+## Architecture is not solved — don't paint yourself into a corner
+
+The store currently has open issues, notably:
+
+- **Non-atomic writes across the store.** Code that assumes "I can mutate N objects atomically" will hit edge cases. Sync layers in particular need to be tolerant of partial writes (idempotent, replayable, cursor-driven).
+
+Avoid patterns that make these problems worse: cross-object invariants enforced from UI code, "transactional" multi-object mutations, monolithic agents that touch everything in one go.
+
+When in doubt, **flag the open question** to a human reviewer rather than encoding a guess into the plugin.
+
+## Repo layout — current preference (v1)
+
+For v1, the team's preference is an **external monorepo** containing multiple community plugins (similar to how `packages/plugins/` works in-repo) — **not** a per-plugin standalone repo.
+
+Why:
+
+- One PR can refactor many plugins together.
+- Shared utilities, sync infrastructure, and design tokens live in one place.
+- Search-and-replace across the plugin family is trivial.
+
+Standalone per-plugin repos (like `dxos/plugin-excalidraw`) are still supported and may become the preferred shape in v2 once the shared abstractions stabilise. For now, default to a monorepo unless you have a specific reason not to.
+
+The mechanical authoring guidance in this skill (Vite + `composerPlugin`, manifest emission, `Load by URL`, registry PR) applies in both setups — it's per-plugin, not per-repo.
+
+## Expect architectural intervention
+
+There will be cases where the obvious-looking plugin is **the wrong plugin to build**. The agent should not generate it just because it can. Surface trade-offs to a human when:
+
+- A natural mapping exists onto an existing internal type, but the user asked for a service-prefixed copy.
+- The proposed UI duplicates an existing plugin's UI.
+- Cross-object atomicity would be required for correctness.
+- The plugin's scope overlaps materially with an existing plugin.
+
+Stop and ask. The cost of a 30-second clarification is much lower than the cost of a wrongly-shaped plugin entrenched in users' Spaces.
+
+## Checklist before scaffolding
+
+- [ ] Read 2-3 existing plugins in the same neighbourhood.
+- [ ] Identified which existing types the new plugin should reuse.
+- [ ] Decided whether this is a **new UI** or a **headless sync layer** for an existing UI.
+- [ ] Designed the sync-state object (if applicable) before writing handlers.
+- [ ] Flagged any cross-object atomicity needs to a human.
+- [ ] Confirmed the repo layout (external monorepo unless told otherwise).
+- [ ] Spec written and approved (see [specification.md](./specification.md)).
+
+Only then proceed to [scaffolding.md](./scaffolding.md).

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/blueprints.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/blueprints.md
@@ -1,0 +1,99 @@
+# Blueprints — let agents use your plugin
+
+A **blueprint** advertises your plugin's capabilities to the assistant. Without one, the agent can't drive your plugin. **Every plugin worth shipping should ship a blueprint.**
+
+A blueprint pairs:
+
+- A unique key.
+- A list of operations exposed as **tools**.
+- A short, behavioral **instruction template**.
+
+## Definition
+
+```ts
+// src/blueprints/my-blueprint.ts
+import { type AppCapabilities } from '@dxos/app-toolkit';
+import { Blueprint, Template } from '@dxos/blueprints';
+import { trim } from '@dxos/util';
+
+import { Create, Move, Play, Print } from '#operations';
+
+const BLUEPRINT_KEY = 'com.example.blueprint.foo';
+
+const operations = [Create, Move, Play, Print];
+
+const make = () =>
+  Blueprint.make({
+    key: BLUEPRINT_KEY,
+    name: 'Foo',
+    tools: Blueprint.toolDefinitions({ operations }),
+    instructions: Template.make({
+      source: trim`
+        You can manage Foo objects via the Create, Move, Play, and Print tools.
+        Don't take destructive actions unless asked. Prefer Print to inspect state before acting.
+      `,
+    }),
+  });
+
+export const FooBlueprint: AppCapabilities.BlueprintDefinition = {
+  key: BLUEPRINT_KEY,
+  make,
+};
+
+export default FooBlueprint;
+```
+
+## Capability wiring
+
+```ts
+// src/capabilities/blueprint-definition.ts
+import * as Effect from 'effect/Effect';
+import { Capability } from '@dxos/app-framework';
+import { AppCapabilities } from '@dxos/app-toolkit';
+
+import { FooBlueprint } from '#blueprints';
+
+export default Capability.makeModule<
+  [],
+  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
+>(() =>
+  Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, FooBlueprint)]),
+);
+```
+
+Then in the plugin file:
+
+```ts
+AppPlugin.addBlueprintDefinitionModule({ activate: BlueprintDefinition })
+```
+
+And on the **type's metadata**, attach the blueprint key so the assistant knows the blueprint applies when working with that type:
+
+```ts
+AppPlugin.addMetadataModule({
+  metadata: {
+    id: Foo.Thing.typename,
+    metadata: { /* ... */ blueprints: [FooBlueprint.key] },
+  },
+})
+```
+
+## Writing instructions
+
+Keep the instruction template short. Describe **behaviors and policies**, not API surface — the tool schemas already cover that. Useful patterns:
+
+- "Prefer reading before writing."
+- "Don't perform destructive actions without confirmation."
+- "When asked X, use tool Y."
+- Domain expertise the agent wouldn't otherwise have.
+
+## Index barrel
+
+```ts
+// src/blueprints/index.ts
+export { default as FooBlueprint } from './my-blueprint';
+```
+
+## Reference
+
+- `packages/plugins/plugin-chess/src/blueprints/chess-blueprint.ts`

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/blueprints.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/blueprints.md
@@ -53,10 +53,7 @@ import { AppCapabilities } from '@dxos/app-toolkit';
 
 import { FooBlueprint } from '#blueprints';
 
-export default Capability.makeModule<
-  [],
-  Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]
->(() =>
+export default Capability.makeModule<[], Capability.Capability<typeof AppCapabilities.BlueprintDefinition>[]>(() =>
   Effect.succeed([Capability.contributes(AppCapabilities.BlueprintDefinition, FooBlueprint)]),
 );
 ```
@@ -64,7 +61,7 @@ export default Capability.makeModule<
 Then in the plugin file:
 
 ```ts
-AppPlugin.addBlueprintDefinitionModule({ activate: BlueprintDefinition })
+AppPlugin.addBlueprintDefinitionModule({ activate: BlueprintDefinition });
 ```
 
 And on the **type's metadata**, attach the blueprint key so the assistant knows the blueprint applies when working with that type:
@@ -75,7 +72,7 @@ AppPlugin.addMetadataModule({
     id: Foo.Thing.typename,
     metadata: { /* ... */ blueprints: [FooBlueprint.key] },
   },
-})
+});
 ```
 
 ## Writing instructions

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/build-test.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/build-test.md
@@ -1,0 +1,36 @@
+# Build & verify
+
+## Community plugin
+
+```sh
+pnpm install
+pnpm build       # vite build → dist/plugin.mjs + dist/manifest.json
+pnpm test        # vitest run
+pnpm preview     # serve dist/ for "Load by URL" testing in Composer
+```
+
+A full pre-release check:
+
+1. `pnpm build` — ensure no Vite errors and `dist/manifest.json` looks right.
+2. `pnpm test` — smoke + operation tests pass.
+3. Load via Composer Settings → Plugins → Load by URL.
+4. Smoke-test the plugin manually in the running Composer.
+
+## Inside the dxos monorepo
+
+```sh
+moon run plugin-foo:build
+moon run plugin-foo:lint -- --fix
+moon run plugin-foo:test
+moon run plugin-foo:test-storybook
+```
+
+Repository-wide:
+
+```sh
+moon exec --on-failure continue --quiet :build
+MOON_CONCURRENCY=4 moon run :test -- --no-file-parallelism
+moon run :lint -- --fix
+```
+
+The `Auth token DEPOT_TOKEN does not exist` warning is normal. Filter it out.

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/capabilities.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/capabilities.md
@@ -1,0 +1,59 @@
+# Capabilities
+
+A capability is a lazy module that contributes some functionality to the framework. The barrel `capabilities/index.ts` declares which capabilities exist; each one lives in its own file.
+
+## Barrel — only `Capability.lazy()`
+
+```ts
+// src/capabilities/index.ts
+import { Capability } from '@dxos/app-framework';
+import { OperationHandlerSet } from '@dxos/operation';
+
+export const BlueprintDefinition = Capability.lazy(
+  'BlueprintDefinition',
+  () => import('./blueprint-definition'),
+);
+export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
+  'OperationHandler',
+  () => import('./operation-handler'),
+);
+export const ReactSurface = Capability.lazy(
+  'ReactSurface',
+  () => import('./react-surface'),
+);
+```
+
+**Do not** add eager exports here. The barrel is consumed during plugin definition before the framework has decided whether to activate each module.
+
+## Module file — `Capability.makeModule()` default export
+
+Each capability file exports a `Capability.makeModule(...)`:
+
+```ts
+// src/capabilities/react-surface.tsx
+import * as Effect from 'effect/Effect';
+import { Capabilities, Capability } from '@dxos/app-framework';
+
+export default Capability.makeModule(() =>
+  Effect.succeed(
+    Capability.contributes(Capabilities.ReactSurface, [/* surfaces */]),
+  ),
+);
+```
+
+The pattern:
+
+1. Import the capability registry (`Capabilities.X` or `AppCapabilities.X`).
+2. Build your contribution.
+3. `Capability.contributes(Registry, value)` declares it.
+4. Wrap in `Capability.makeModule(...)` so the framework can activate it under the right event.
+
+## Why everything is lazy
+
+- Capabilities are large (surfaces pull React, operation handlers pull domain logic).
+- The framework uses **activation events** to decide when each capability is needed.
+- Lazy imports keep the initial bundle small — operation handlers, for example, never load until an operation is invoked.
+
+## Reference
+
+- `packages/plugins/plugin-chess/src/capabilities/`

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/capabilities.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/capabilities.md
@@ -9,18 +9,12 @@ A capability is a lazy module that contributes some functionality to the framewo
 import { Capability } from '@dxos/app-framework';
 import { OperationHandlerSet } from '@dxos/operation';
 
-export const BlueprintDefinition = Capability.lazy(
-  'BlueprintDefinition',
-  () => import('./blueprint-definition'),
-);
+export const BlueprintDefinition = Capability.lazy('BlueprintDefinition', () => import('./blueprint-definition'));
 export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
   'OperationHandler',
   () => import('./operation-handler'),
 );
-export const ReactSurface = Capability.lazy(
-  'ReactSurface',
-  () => import('./react-surface'),
-);
+export const ReactSurface = Capability.lazy('ReactSurface', () => import('./react-surface'));
 ```
 
 **Do not** add eager exports here. The barrel is consumed during plugin definition before the framework has decided whether to activate each module.
@@ -36,7 +30,9 @@ import { Capabilities, Capability } from '@dxos/app-framework';
 
 export default Capability.makeModule(() =>
   Effect.succeed(
-    Capability.contributes(Capabilities.ReactSurface, [/* surfaces */]),
+    Capability.contributes(Capabilities.ReactSurface, [
+      /* surfaces */
+    ]),
   ),
 );
 ```

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/coding-style.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/coding-style.md
@@ -23,7 +23,7 @@ These rules keep plugins consistent and avoid recurring review nits.
 ## Comments
 
 - Default to **no comments**.
-- Add a comment when the *why* is non-obvious — a hidden constraint, a workaround, a subtle invariant.
+- Add a comment when the _why_ is non-obvious — a hidden constraint, a workaround, a subtle invariant.
 - All JSDoc/code comments end with a period.
 
 ## General rules

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/coding-style.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/coding-style.md
@@ -1,0 +1,33 @@
+# Coding style
+
+These rules keep plugins consistent and avoid recurring review nits.
+
+- Use `invariant(cond, msg)` for preconditions instead of throwing.
+- Use barrel imports — `#capabilities`, `#components`, `#containers`, `#meta`, `#operations`, `#types` — never deep relative paths.
+- **No default exports**, except per-container `index.ts` files (so `React.lazy` can import them).
+- Container-to-container imports use the default form: `import OtherContainer from '../OtherContainer';`.
+- Prefer ES `#private` fields/methods over TypeScript `private`. Existing `_private` is fine to keep.
+- Use `Panel.Root` with a `role` prop on every article/section container.
+- All ECHO interfaces must be reactive (`useQuery`, `useObject`, atoms). Don't memoize ECHO objects across renders.
+- Avoid casting to silence the type checker — refactor instead, or ask before casting.
+- Single quotes for strings; arrow components; named exports for components.
+- TODOs are fine but must be removed/updated as you go.
+- Avoid single-letter variable names.
+- Imports order: builtin → external → `@dxos` → internal → parent → sibling, with blank lines between groups.
+
+## React specifics
+
+- Import named symbols from React (`useMemo`, `type Ref`) — not `React.useMemo` / `React.Ref`.
+- When using `forwardRef`, name the param `forwardedRef`.
+
+## Comments
+
+- Default to **no comments**.
+- Add a comment when the *why* is non-obvious — a hidden constraint, a workaround, a subtle invariant.
+- All JSDoc/code comments end with a period.
+
+## General rules
+
+- `src/components/` and `src/containers/` contain only barrels and per-component subdirectories.
+- `src/index.ts` is minimal — only the plugin and meta.
+- Other plugins should import deep paths (`./types`, `./operations`), never the top barrel for everything.

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/components-vs-containers.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/components-vs-containers.md
@@ -1,0 +1,45 @@
+# Components vs containers
+
+This separation is **non-negotiable**. It's the single biggest determinant of whether your plugin stays maintainable.
+
+## Components (`src/components/`)
+
+Presentational primitives. Reusable. Testable in isolation.
+
+- **MUST NOT depend on** `@dxos/app-framework` or `@dxos/app-toolkit`.
+- **MUST NOT** read from ECHO, capabilities, or surfaces.
+- Receive everything as props.
+- Named exports only — no default exports.
+- One subdirectory per component with its own `index.ts` barrel and a basic storybook.
+
+If a component needs framework data, it's actually a container — move it.
+
+## Containers (`src/containers/`)
+
+Surface components. They consume capabilities, query ECHO, dispatch operations, and render the right primitives.
+
+- Each container has its own subdirectory.
+- The subdirectory `index.ts` bridges named → default export so `React.lazy` works:
+  ```ts
+  export { FooArticle as default } from './FooArticle';
+  ```
+- The top-level `containers/index.ts` lazy-loads them:
+  ```ts
+  export const FooArticle: ComponentType<any> = lazy(() => import('./FooArticle'));
+  ```
+- Surface containers use suffixes matching their role: `Article`, `Card`, `Section`, `Dialog`, `Popover`, `Settings`.
+- Container-to-container imports use the default import: `import OtherContainer from '../OtherContainer';`.
+- Add a basic storybook for each.
+
+## Why split?
+
+- **Bundle size.** Containers are lazy; the bundle for an article only loads when that article is rendered.
+- **Testability.** Components have no DXOS deps and can be unit-tested or storied without a harness.
+- **Reuse.** A `Chessboard` component is reusable; a `ChessArticle` container is not.
+- **Refactor safety.** Changes to capabilities don't ripple into presentational code.
+
+## Heuristic
+
+> If you `import { useQuery }` or anything from `@dxos/app-framework`, you're in a container, not a component.
+
+See also: [containers.md](./containers.md), [components.md](./components.md).

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/components.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/components.md
@@ -7,7 +7,7 @@ Presentational UI primitives in `src/components/`. **No DXOS framework deps.**
 - **Forbidden imports:** `@dxos/app-framework`, `@dxos/app-toolkit`, capability barrels, `useQuery`/`useObject`. If you need them, you're writing a container.
 - **Allowed:** `@dxos/react-ui`, `@dxos/ui-theme`, plain React, libraries owned by the component.
 - One subdirectory per component:
-  ```
+  ```text
   components/
     index.ts                # barrel: export * from './Thing';
     Thing/

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/components.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/components.md
@@ -1,0 +1,33 @@
+# Components
+
+Presentational UI primitives in `src/components/`. **No DXOS framework deps.**
+
+## Rules
+
+- **Forbidden imports:** `@dxos/app-framework`, `@dxos/app-toolkit`, capability barrels, `useQuery`/`useObject`. If you need them, you're writing a container.
+- **Allowed:** `@dxos/react-ui`, `@dxos/ui-theme`, plain React, libraries owned by the component.
+- One subdirectory per component:
+  ```
+  components/
+    index.ts                # barrel: export * from './Thing';
+    Thing/
+      index.ts              # export { Thing } from './Thing';
+      Thing.tsx             # named export only
+      Thing.stories.tsx
+  ```
+- **No default exports** anywhere in `components/`.
+- Each component ships a basic storybook that exercises its visual states.
+
+## Public re-export
+
+If another plugin needs the component, also re-export it from the package root via `src/index.ts`:
+
+```ts
+export * from './components/Chessboard';
+```
+
+(Per-component public exports are fine; `export *` from the top-level barrel is not — keep `src/index.ts` minimal.)
+
+## Reference
+
+- `packages/plugins/plugin-chess/src/components/Chessboard/`

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/containers.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/containers.md
@@ -4,17 +4,17 @@ Containers render surfaces. They **must** use standard `@dxos/react-ui` primitiv
 
 ## Primitives
 
-| Primitive                                                | Use for                                  |
-| -------------------------------------------------------- | ---------------------------------------- |
-| `Panel.Root` / `Panel.Toolbar` / `Panel.Content`         | Article / section structure              |
-| `ScrollArea.Root` + `ScrollArea.Viewport`                | Scrollable content (inside `Panel.Content asChild`) |
-| `Input.Root` / `Input.Label` / `Input.TextInput`         | Form fields                              |
-| `Button` (with `variant`)                                | Actions                                  |
-| `Clipboard.IconButton`                                   | Copy-to-clipboard                        |
-| `Toolbar.Root` / `Toolbar.IconButton`                    | Toolbar actions                          |
-| `Card.Root` / `Card.Toolbar` / `Card.Content`            | Card surfaces                            |
-| `Icon`                                                   | Phosphor icons                           |
-| `useTranslation(meta.id)`                                | i18n strings                             |
+| Primitive                                        | Use for                                             |
+| ------------------------------------------------ | --------------------------------------------------- |
+| `Panel.Root` / `Panel.Toolbar` / `Panel.Content` | Article / section structure                         |
+| `ScrollArea.Root` + `ScrollArea.Viewport`        | Scrollable content (inside `Panel.Content asChild`) |
+| `Input.Root` / `Input.Label` / `Input.TextInput` | Form fields                                         |
+| `Button` (with `variant`)                        | Actions                                             |
+| `Clipboard.IconButton`                           | Copy-to-clipboard                                   |
+| `Toolbar.Root` / `Toolbar.IconButton`            | Toolbar actions                                     |
+| `Card.Root` / `Card.Toolbar` / `Card.Content`    | Card surfaces                                       |
+| `Icon`                                           | Phosphor icons                                      |
+| `useTranslation(meta.id)`                        | i18n strings                                        |
 
 The **only** acceptable classNames are functional layout hints on `ScrollArea.Viewport` (e.g. `p-4 space-y-4`) or responsive `@container` queries.
 
@@ -33,9 +33,7 @@ export const FooArticle = ({ role, subject }: FooArticleProps) => {
       </Panel.Toolbar>
       <Panel.Content asChild>
         <ScrollArea.Root orientation='vertical'>
-          <ScrollArea.Viewport classNames='p-4 space-y-4'>
-            {/* Input.Root, Button, etc. */}
-          </ScrollArea.Viewport>
+          <ScrollArea.Viewport classNames='p-4 space-y-4'>{/* Input.Root, Button, etc. */}</ScrollArea.Viewport>
         </ScrollArea.Root>
       </Panel.Content>
     </Panel.Root>

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/containers.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/containers.md
@@ -1,0 +1,64 @@
+# Containers & UI primitives
+
+Containers render surfaces. They **must** use standard `@dxos/react-ui` primitives — never custom Tailwind layout/styling. If you find yourself writing custom classNames for layout, you're missing a primitive.
+
+## Primitives
+
+| Primitive                                                | Use for                                  |
+| -------------------------------------------------------- | ---------------------------------------- |
+| `Panel.Root` / `Panel.Toolbar` / `Panel.Content`         | Article / section structure              |
+| `ScrollArea.Root` + `ScrollArea.Viewport`                | Scrollable content (inside `Panel.Content asChild`) |
+| `Input.Root` / `Input.Label` / `Input.TextInput`         | Form fields                              |
+| `Button` (with `variant`)                                | Actions                                  |
+| `Clipboard.IconButton`                                   | Copy-to-clipboard                        |
+| `Toolbar.Root` / `Toolbar.IconButton`                    | Toolbar actions                          |
+| `Card.Root` / `Card.Toolbar` / `Card.Content`            | Card surfaces                            |
+| `Icon`                                                   | Phosphor icons                           |
+| `useTranslation(meta.id)`                                | i18n strings                             |
+
+The **only** acceptable classNames are functional layout hints on `ScrollArea.Viewport` (e.g. `p-4 space-y-4`) or responsive `@container` queries.
+
+## Standard article container
+
+```tsx
+import { Panel, ScrollArea, Toolbar, useTranslation } from '@dxos/react-ui';
+import { meta } from '#meta';
+
+export const FooArticle = ({ role, subject }: FooArticleProps) => {
+  const { t } = useTranslation(meta.id);
+  return (
+    <Panel.Root role={role}>
+      <Panel.Toolbar asChild>
+        <Toolbar.Root>{/* toolbar */}</Toolbar.Root>
+      </Panel.Toolbar>
+      <Panel.Content asChild>
+        <ScrollArea.Root orientation='vertical'>
+          <ScrollArea.Viewport classNames='p-4 space-y-4'>
+            {/* Input.Root, Button, etc. */}
+          </ScrollArea.Viewport>
+        </ScrollArea.Root>
+      </Panel.Content>
+    </Panel.Root>
+  );
+};
+```
+
+## Suffix conventions
+
+- `FooArticle` — `article` role.
+- `FooSection` — `section` role.
+- `FooCard` — `card--content` role.
+- `FooDialog` / `FooPopover` / `FooSettings` — corresponding roles.
+
+## Reactivity
+
+All ECHO interfaces must be reactive. Use `useQuery`, `useObject`, atoms (`@effect-atom/atom-react`). Don't memoize ECHO objects across renders.
+
+## Suspense
+
+The `Surface` component wraps lazy containers in a top-level `<Suspense>`. Individual containers only need their own `<Suspense>` if they call `React.use()` or render lazy sub-components themselves.
+
+## Reference
+
+- `packages/plugins/plugin-chess/src/containers/ChessArticle/`
+- `packages/plugins/plugin-discord/src/containers/BotArticle/`

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/directory-structure.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/directory-structure.md
@@ -2,7 +2,7 @@
 
 Standard layout for `src/`. Same shape inside and outside the monorepo; only the build wiring around it differs.
 
-```
+```text
 src/
   plugin.tsx              # Plugin.define(meta).pipe(...)   (FooPlugin.tsx in-repo)
   meta.ts                 # Plugin.Meta

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/directory-structure.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/directory-structure.md
@@ -1,0 +1,50 @@
+# Directory structure
+
+Standard layout for `src/`. Same shape inside and outside the monorepo; only the build wiring around it differs.
+
+```
+src/
+  plugin.tsx              # Plugin.define(meta).pipe(...)   (FooPlugin.tsx in-repo)
+  meta.ts                 # Plugin.Meta
+  translations.ts         # i18n by typename + meta.id
+  index.ts                # exports plugin + meta only
+  blueprints/
+    index.ts
+    my-blueprint.ts
+  capabilities/
+    index.ts              # Capability.lazy() exports only
+    react-surface.tsx
+    operation-handler.ts
+    blueprint-definition.ts
+  components/             # NO @dxos/app-framework / @dxos/app-toolkit
+    index.ts
+    Thing/
+      index.ts
+      Thing.tsx
+      Thing.stories.tsx
+  containers/             # surface components (lazy)
+    index.ts              # lazy(() => import('./X'))
+    FooArticle/
+      index.ts            # bridges named -> default
+      FooArticle.tsx
+      FooArticle.stories.tsx
+  operations/
+    index.ts              # OperationHandlerSet.lazy(...) + re-export defs
+    definitions.ts
+    create.ts
+    move.ts
+  types/
+    index.ts              # export * as Foo from './Foo';
+    Foo.ts
+  cli/                    # in-repo only — headless entrypoint
+    index.ts
+    plugin.ts
+```
+
+## Rules
+
+- `src/components/` and `src/containers/` contain **only** index files and per-component subdirectories.
+- `src/index.ts` is minimal: re-export the plugin and meta. Other plugins import deep paths (`./types`, `./operations`) instead.
+- Every barrel uses **named exports**. The only default exports are the per-container `index.ts` files (so `React.lazy` works).
+- Container-to-container imports use the default form: `import OtherContainer from '../OtherContainer';`.
+- Each capability lives in its **own file** with a single `default export` of `Capability.makeModule(...)`. The `capabilities/index.ts` barrel uses **only** `Capability.lazy(...)`.

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/external-services.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/external-services.md
@@ -5,6 +5,7 @@ When your plugin integrates with a third-party API (Gmail, GitHub, Slack, custom
 ## Pattern
 
 1. **Reference an `AccessToken`** from your domain object.
+
    ```ts
    // src/types/Foo.ts
    import { Ref, Schema } from '@dxos/echo';
@@ -24,10 +25,7 @@ When your plugin integrates with a third-party API (Gmail, GitHub, Slack, custom
    import { Database, Ref } from '@dxos/echo';
    import { type AccessToken } from '@dxos/types';
 
-   export const loadAccessToken = (
-     accessTokenRef: Ref.Ref<AccessToken.AccessToken> | undefined,
-     label: string,
-   ) =>
+   export const loadAccessToken = (accessTokenRef: Ref.Ref<AccessToken.AccessToken> | undefined, label: string) =>
      Effect.gen(function* () {
        if (!accessTokenRef) return yield* Effect.fail(new Error(`Missing ${label} access token`));
        const token = yield* Database.load(accessTokenRef);
@@ -44,9 +42,10 @@ When your plugin integrates with a third-party API (Gmail, GitHub, Slack, custom
          const mailbox = yield* Database.load(ref);
          const token = yield* loadAccessToken(mailbox.accessToken, 'mailbox');
          const res = yield* Effect.tryPromise({
-           try: () => fetch('https://gmail.googleapis.com/...', {
-             headers: { Authorization: `Bearer ${token}` },
-           }),
+           try: () =>
+             fetch('https://gmail.googleapis.com/...', {
+               headers: { Authorization: `Bearer ${token}` },
+             }),
            catch: (e) => new Error(`Gmail API failed: ${e}`),
          });
          // ...

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/external-services.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/external-services.md
@@ -1,0 +1,73 @@
+# External services & authentication (`AccessToken`)
+
+When your plugin integrates with a third-party API (Gmail, GitHub, Slack, custom backend), credentials live in ECHO as **`AccessToken`** objects. Operations load them via Refs.
+
+## Pattern
+
+1. **Reference an `AccessToken`** from your domain object.
+   ```ts
+   // src/types/Foo.ts
+   import { Ref, Schema } from '@dxos/echo';
+   import { AccessToken } from '@dxos/types';
+
+   export const Mailbox = Schema.Struct({
+     name: Schema.optional(Schema.String),
+     accessToken: Schema.optional(Ref.Ref(AccessToken.AccessToken)),
+   }).pipe(Type.object({ typename: 'com.example.type.mailbox', version: '0.1.0' }));
+   ```
+
+2. **Load it inside the operation** via an Effect helper. Never resolve it in a container.
+
+   ```ts
+   // src/services/credentials.ts
+   import * as Effect from 'effect/Effect';
+   import { Database, Ref } from '@dxos/echo';
+   import { type AccessToken } from '@dxos/types';
+
+   export const loadAccessToken = (
+     accessTokenRef: Ref.Ref<AccessToken.AccessToken> | undefined,
+     label: string,
+   ) =>
+     Effect.gen(function* () {
+       if (!accessTokenRef) return yield* Effect.fail(new Error(`Missing ${label} access token`));
+       const token = yield* Database.load(accessTokenRef);
+       return token.token;
+     });
+   ```
+
+3. **Use it in a handler.**
+
+   ```ts
+   const handler = SyncMailbox.pipe(
+     Operation.withHandler(
+       Effect.fn(function* ({ mailbox: ref }) {
+         const mailbox = yield* Database.load(ref);
+         const token = yield* loadAccessToken(mailbox.accessToken, 'mailbox');
+         const res = yield* Effect.tryPromise({
+           try: () => fetch('https://gmail.googleapis.com/...', {
+             headers: { Authorization: `Bearer ${token}` },
+           }),
+           catch: (e) => new Error(`Gmail API failed: ${e}`),
+         });
+         // ...
+       }),
+     ),
+   );
+   ```
+
+## Why `AccessToken`?
+
+- **Encrypted at rest** in ECHO; never in your bundle, code, or logs.
+- **Per-space, per-user.** Different identities can have different credentials.
+- **Refreshable.** Token rotation updates the ECHO object; running operations re-load.
+- **Auditable.** Reads happen through the database service.
+
+## UI for granting access
+
+For OAuth flows, render a button in your container that opens the provider's auth page and stores the resulting token via an operation. Don't put the token in component state.
+
+## Reference
+
+- `packages/plugins/plugin-inbox/src/services/google-credentials.ts` — `loadAccessToken` helper.
+- `packages/plugins/plugin-inbox/src/types/Mailbox.ts` — `AccessToken` field on a domain object.
+- `packages/plugins/plugin-inbox/src/operations/google/gmail/sync-e2e.test.ts` — operation that consumes the token.

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/moon-yml.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/moon-yml.md
@@ -37,6 +37,7 @@ moon run plugin-foo:test-storybook
 For optional server-side functions (e.g. webhooks, scheduled jobs) add a `deploy-functions` task pointing to the Operation file:
 
 ```yaml
+tasks:
   deploy-functions:
     command: $workspaceRoot/scripts/dxnext --profile main function deploy --runtime worker-loader $workspaceRoot/packages/plugins/plugin-foo/src/operations/my-fn.ts
     preset: server

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/moon-yml.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/moon-yml.md
@@ -1,0 +1,47 @@
+# `moon.yml` (in-repo only)
+
+Skip if you're building a community plugin — moon is the dxos monorepo's task runner, not part of community packaging.
+
+## Required shape
+
+```yaml
+layer: library
+language: typescript
+tags:
+  - ts-build
+  - ts-test
+  - ts-test-storybook
+  - pack
+  - storybook
+tasks:
+  compile:
+    args:
+      - '--entryPoint=src/index.ts'
+      - '--entryPoint=src/blueprints/index.ts'
+      - '--entryPoint=src/cli/index.ts'
+      - '--entryPoint=src/operations/index.ts'
+      - '--entryPoint=src/types/index.ts'
+```
+
+**Every `exports` subpath in `package.json` must have a matching `--entryPoint`.** If the entry points and exports drift apart, builds succeed locally but type resolution breaks for other packages.
+
+## Common tasks
+
+```sh
+moon run plugin-foo:build
+moon run plugin-foo:lint -- --fix
+moon run plugin-foo:test
+moon run plugin-foo:test-storybook
+```
+
+For optional server-side functions (e.g. webhooks, scheduled jobs) add a `deploy-functions` task pointing to the Operation file:
+
+```yaml
+  deploy-functions:
+    command: $workspaceRoot/scripts/dxnext --profile main function deploy --runtime worker-loader $workspaceRoot/packages/plugins/plugin-foo/src/operations/my-fn.ts
+    preset: server
+```
+
+## Reference
+
+- `packages/plugins/plugin-chess/moon.yml`

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/operations-vs-ui.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/operations-vs-ui.md
@@ -1,0 +1,59 @@
+# Operations vs UI: where logic belongs
+
+**Rule of thumb: heavy logic does not live in containers.** Push it into operations.
+
+## What belongs in operations
+
+- Anything that **mutates ECHO** beyond a trivial property write.
+- Any **external service** call (HTTP, Gmail, GitHub, OpenAI, etc.).
+- Any **LLM** call (use `AiService` — see [ai-service.md](./ai-service.md)).
+- Anything **non-trivial to compute** (parsing, rendering, simulation, search).
+- Anything you'd want an **agent** to be able to do (operations become blueprint tools — see [blueprints.md](./blueprints.md)).
+- Anything you'd want to **invoke from the CLI** (operations are headless — see [package-json.md](./package-json.md)).
+
+## What stays in containers
+
+- Reading reactive ECHO state via `useQuery`/`useObject`/atoms.
+- Local UI state (open/closed, selected tab).
+- Wiring user gestures to operation invocations.
+- Layout composition with `Panel` / `ScrollArea` / `Toolbar` / `Card`.
+
+## Why
+
+- **Testable.** Operations have schema-typed input/output and run under the composer testing harness without mounting React.
+- **Reusable.** The same operation backs the UI button, the CLI command, the agent tool, and the test.
+- **Type-safe at the boundary.** Schema validates input; `services` declares dependencies up-front.
+- **Resumable & observable.** Effect spans, retries, and tracing hang off operations naturally.
+- **Auth-aware.** Credentials live in ECHO as `AccessToken` and are loaded inside operations — never read from a React tree.
+
+## Pattern: invoke an operation from a container
+
+```tsx
+import { useOperationInvoker } from '@dxos/operation-react';
+import { Move } from '#operations';
+
+const invoke = useOperationInvoker();
+const onClick = () => invoke(Move, { game: Ref.make(game), move: 'e4' });
+```
+
+The container stays a thin shell. All chess logic, validation, persistence, and engine calls live in `Move`'s handler.
+
+## Anti-pattern
+
+```tsx
+// ❌ Don't do this.
+const onClick = async () => {
+  const res = await fetch(`https://api.example.com/x?token=${secret}`);
+  const data = await res.json();
+  game.pgn = renderPgn(data); // mutating ECHO from a click handler
+};
+```
+
+Move the fetch + transform into an operation, declare its services, and invoke it.
+
+## See also
+
+- [operations.md](./operations.md) — operation definition and handler patterns.
+- [external-services.md](./external-services.md) — auth and HTTP integration.
+- [ai-service.md](./ai-service.md) — LLM inference inside operations.
+- [blueprints.md](./blueprints.md) — surface operations to the assistant.

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/operations.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/operations.md
@@ -1,0 +1,108 @@
+# Operations
+
+An operation is a schema-typed, Effect-based unit of work. Definition and handler are split.
+
+## Definition (`src/operations/definitions.ts`)
+
+```ts
+import * as Schema from 'effect/Schema';
+import { Database, Ref } from '@dxos/echo';
+import { Operation } from '@dxos/operation';
+
+import { Foo } from '../types';
+
+export const Create = Operation.make({
+  meta: {
+    key: 'com.example.function.foo.create',
+    name: 'Create Thing',
+    description: 'Creates a new thing.',
+  },
+  input: Schema.Struct({
+    name: Schema.optional(Schema.String),
+  }),
+  output: Foo.Thing,
+  services: [Database.Service],
+});
+
+export const Move = Operation.make({
+  meta: { key: 'com.example.function.foo.move', name: 'Move', description: '...' },
+  input: Schema.Struct({
+    thing: Ref.Ref(Foo.Thing),
+    move: Schema.String.annotations({ description: 'The move to make.', examples: ['e4'] }),
+  }),
+  output: Schema.Struct({ pgn: Schema.String }),
+  services: [Database.Service],
+});
+```
+
+## Handler (one file per operation, default export)
+
+```ts
+// src/operations/create.ts
+import * as Effect from 'effect/Effect';
+import { Database } from '@dxos/echo';
+import { Operation } from '@dxos/operation';
+
+import { Foo } from '../types';
+import { Create } from './definitions';
+
+const handler: Operation.WithHandler<typeof Create> = Create.pipe(
+  Operation.withHandler(
+    Effect.fn(function* ({ name }) {
+      return yield* Database.add(Foo.make({ name }));
+    }),
+  ),
+);
+
+export default handler;
+```
+
+## Barrel (`src/operations/index.ts`)
+
+```ts
+import { OperationHandlerSet } from '@dxos/operation';
+
+const Handlers = OperationHandlerSet.lazy(
+  () => import('./create'),
+  () => import('./move'),
+);
+
+export { Create, Move } from './definitions';
+export const FooHandlers = Handlers;
+```
+
+Why two layers? Definitions are imported by **anyone** (UI, blueprints, CLI, tests) and must stay light. Handlers contain the heavy code path (HTTP, AI, DB writes) and are loaded lazily only when invoked.
+
+## Wire as a capability
+
+```ts
+// src/capabilities/operation-handler.ts
+import * as Effect from 'effect/Effect';
+import { Capabilities, Capability } from '@dxos/app-framework';
+import type { OperationHandlerSet } from '@dxos/operation';
+
+import { FooHandlers } from '#operations';
+
+export default Capability.makeModule<OperationHandlerSet.OperationHandlerSet>(
+  Effect.fnUntraced(function* () {
+    return Capability.contributes(Capabilities.OperationHandler, FooHandlers);
+  }),
+);
+```
+
+Then `AppPlugin.addOperationHandlerModule({ activate: OperationHandler })` in your plugin file.
+
+## Services
+
+The `services` array on a definition declares what the handler will need. Common ones:
+
+- `Database.Service` — read/write ECHO objects.
+- `AiService` — LLM inference (see [ai-service.md](./ai-service.md)).
+- Custom services for external APIs (declared via `Effect.Tag`).
+
+## Invoking
+
+- From the UI: `useOperationInvoker()` (returns `(op, input) => Promise<output>`).
+- From a test: `harness.invoke(Op, input)`.
+- From another operation: `yield* Operation.invoke(Op, input)`.
+- From an agent: register in a blueprint's tools.

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/package-json.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/package-json.md
@@ -1,0 +1,122 @@
+# `package.json`
+
+Two flavors: **community** (your own repo, single bundle) and **monorepo** (multiple `exports`, `workspace:*` deps, moon build).
+
+## Community plugin
+
+```json
+{
+  "name": "@example/plugin-foo",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest run"
+  },
+  "imports": {
+    "#blueprints": "./src/blueprints/index.ts",
+    "#capabilities": "./src/capabilities/index.ts",
+    "#components": "./src/components/index.ts",
+    "#containers": "./src/containers/index.ts",
+    "#meta": "./src/meta.ts",
+    "#operations": "./src/operations/index.ts",
+    "#types": "./src/types/index.ts"
+  },
+  "dependencies": {
+    "@dxos/app-framework": "0.8.4-main.fcfe5033a5",
+    "@dxos/app-toolkit": "0.8.4-main.fcfe5033a5",
+    "@dxos/echo": "0.8.4-main.fcfe5033a5",
+    "@dxos/operation": "0.8.4-main.fcfe5033a5",
+    "@dxos/blueprints": "0.8.4-main.fcfe5033a5",
+    "@dxos/react-ui": "0.8.4-main.fcfe5033a5",
+    "@dxos/types": "0.8.4-main.fcfe5033a5",
+    "@dxos/util": "0.8.4-main.fcfe5033a5",
+    "effect": "^3.x",
+    "react": "^19.x"
+  }
+}
+```
+
+**All `@dxos/*` deps must be pinned to the Composer host's main dist-tag.** Pin them in lockstep — see [publishing.md](./publishing.md).
+
+The community build emits **one file**: `dist/plugin.mjs` (plus `dist/manifest.json`). No `exports` map needed; Composer dynamically imports the module.
+
+## Monorepo plugin
+
+Multiple `exports` subpaths so other in-repo plugins, the assistant, and the CLI can import slices of your plugin without dragging in React:
+
+```jsonc
+{
+  "name": "@dxos/plugin-foo",
+  "private": true,
+  "type": "module",
+  "imports": { /* same #aliases as community */ },
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/types/src/index.d.ts",
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": "./dist/lib/node-esm/index.mjs"
+    },
+    "./blueprints": { "source": "./src/blueprints/index.ts", /* ... */ },
+    "./cli":        { "source": "./src/cli/index.ts",        /* ... */ },
+    "./operations": { "source": "./src/operations/index.ts", /* ... */ },
+    "./types":      { "source": "./src/types/index.ts",      /* ... */ }
+  },
+  "dependencies": {
+    "@dxos/app-framework": "workspace:*",
+    "@dxos/app-toolkit":   "workspace:*",
+    "@dxos/echo":          "workspace:*",
+    "effect":              "catalog:",
+    "react":               "catalog:"
+  }
+}
+```
+
+- **`workspace:*`** for any in-repo `@dxos/*` package. Never the catalog.
+- **`catalog:`** for external packages. Versions live in the root pnpm catalog.
+- **`"private": true`** is mandatory for new packages until a trusted publisher is configured.
+
+Each `exports` subpath needs a matching `--entryPoint` in `moon.yml` — see [moon-yml.md](./moon-yml.md).
+
+## CLI entrypoint contract
+
+The `./cli` subpath is the **headless** entrypoint, intended to run under Node (CLI tools, agents, tests).
+
+**`src/cli/` MUST export only:**
+
+- The plugin definition with **schema** + **metadata** + **operations** + **blueprint** modules.
+- `types`, `operations`, `blueprints`.
+
+**`src/cli/` MUST NOT import:**
+
+- `react`, `react-dom`, anything from `@dxos/react-ui`.
+- The browser variants of capability modules (e.g. the surface-rendering plugin).
+- `@dxos/plugin-client` main entrypoint — use `@dxos/plugin-client/cli` instead.
+
+A typical CLI plugin file is a stripped-down twin of the main plugin, omitting `addSurfaceModule` and `addBlueprintDefinitionModule` if the latter pulls UI:
+
+```ts
+// src/cli/plugin.ts
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+
+import { meta } from '#meta';
+import { Foo } from '#types';
+
+export const FooPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addMetadataModule({ metadata: { id: Foo.Thing.typename, metadata: { /* createObject only */ } } }),
+  AppPlugin.addSchemaModule({ schema: [Foo.Thing] }),
+  Plugin.make,
+);
+```
+
+Why? The CLI runs under Node. React imports break. Tests that rely on the harness use this entrypoint to avoid loading the browser bundle.
+
+## Reference
+
+- `packages/plugins/plugin-chess/package.json` — full monorepo example.
+- `packages/plugins/plugin-chess/src/cli/plugin.ts` — CLI plugin.

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/package-json.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/package-json.md
@@ -27,13 +27,13 @@ Two flavors: **community** (your own repo, single bundle) and **monorepo** (mult
   },
   "dependencies": {
     "@dxos/app-framework": "<COMPOSER_HOST_MAIN_DIST_TAG>",
-    "@dxos/app-toolkit":   "<COMPOSER_HOST_MAIN_DIST_TAG>",
-    "@dxos/echo":          "<COMPOSER_HOST_MAIN_DIST_TAG>",
-    "@dxos/operation":     "<COMPOSER_HOST_MAIN_DIST_TAG>",
-    "@dxos/blueprints":    "<COMPOSER_HOST_MAIN_DIST_TAG>",
-    "@dxos/react-ui":      "<COMPOSER_HOST_MAIN_DIST_TAG>",
-    "@dxos/types":         "<COMPOSER_HOST_MAIN_DIST_TAG>",
-    "@dxos/util":          "<COMPOSER_HOST_MAIN_DIST_TAG>",
+    "@dxos/app-toolkit": "<COMPOSER_HOST_MAIN_DIST_TAG>",
+    "@dxos/echo": "<COMPOSER_HOST_MAIN_DIST_TAG>",
+    "@dxos/operation": "<COMPOSER_HOST_MAIN_DIST_TAG>",
+    "@dxos/blueprints": "<COMPOSER_HOST_MAIN_DIST_TAG>",
+    "@dxos/react-ui": "<COMPOSER_HOST_MAIN_DIST_TAG>",
+    "@dxos/types": "<COMPOSER_HOST_MAIN_DIST_TAG>",
+    "@dxos/util": "<COMPOSER_HOST_MAIN_DIST_TAG>",
     "effect": "^3.x",
     "react": "^19.x"
   }
@@ -53,26 +53,28 @@ Multiple `exports` subpaths so other in-repo plugins, the assistant, and the CLI
   "name": "@dxos/plugin-foo",
   "private": true,
   "type": "module",
-  "imports": { /* same #aliases as community */ },
+  "imports": {
+    /* same #aliases as community */
+  },
   "exports": {
     ".": {
       "source": "./src/index.ts",
       "types": "./dist/types/src/index.d.ts",
       "browser": "./dist/lib/browser/index.mjs",
-      "node": "./dist/lib/node-esm/index.mjs"
+      "node": "./dist/lib/node-esm/index.mjs",
     },
-    "./blueprints": { "source": "./src/blueprints/index.ts", /* ... */ },
-    "./cli":        { "source": "./src/cli/index.ts",        /* ... */ },
-    "./operations": { "source": "./src/operations/index.ts", /* ... */ },
-    "./types":      { "source": "./src/types/index.ts",      /* ... */ }
+    "./blueprints": { "source": "./src/blueprints/index.ts" /* ... */ },
+    "./cli": { "source": "./src/cli/index.ts" /* ... */ },
+    "./operations": { "source": "./src/operations/index.ts" /* ... */ },
+    "./types": { "source": "./src/types/index.ts" /* ... */ },
   },
   "dependencies": {
     "@dxos/app-framework": "workspace:*",
-    "@dxos/app-toolkit":   "workspace:*",
-    "@dxos/echo":          "workspace:*",
-    "effect":              "catalog:",
-    "react":               "catalog:"
-  }
+    "@dxos/app-toolkit": "workspace:*",
+    "@dxos/echo": "workspace:*",
+    "effect": "catalog:",
+    "react": "catalog:",
+  },
 }
 ```
 
@@ -108,7 +110,14 @@ import { meta } from '#meta';
 import { Foo } from '#types';
 
 export const FooPlugin = Plugin.define(meta).pipe(
-  AppPlugin.addMetadataModule({ metadata: { id: Foo.Thing.typename, metadata: { /* createObject only */ } } }),
+  AppPlugin.addMetadataModule({
+    metadata: {
+      id: Foo.Thing.typename,
+      metadata: {
+        /* createObject only */
+      },
+    },
+  }),
   AppPlugin.addSchemaModule({ schema: [Foo.Thing] }),
   Plugin.make,
 );

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/package-json.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/package-json.md
@@ -26,21 +26,21 @@ Two flavors: **community** (your own repo, single bundle) and **monorepo** (mult
     "#types": "./src/types/index.ts"
   },
   "dependencies": {
-    "@dxos/app-framework": "0.8.4-main.fcfe5033a5",
-    "@dxos/app-toolkit": "0.8.4-main.fcfe5033a5",
-    "@dxos/echo": "0.8.4-main.fcfe5033a5",
-    "@dxos/operation": "0.8.4-main.fcfe5033a5",
-    "@dxos/blueprints": "0.8.4-main.fcfe5033a5",
-    "@dxos/react-ui": "0.8.4-main.fcfe5033a5",
-    "@dxos/types": "0.8.4-main.fcfe5033a5",
-    "@dxos/util": "0.8.4-main.fcfe5033a5",
+    "@dxos/app-framework": "<COMPOSER_HOST_MAIN_DIST_TAG>",
+    "@dxos/app-toolkit":   "<COMPOSER_HOST_MAIN_DIST_TAG>",
+    "@dxos/echo":          "<COMPOSER_HOST_MAIN_DIST_TAG>",
+    "@dxos/operation":     "<COMPOSER_HOST_MAIN_DIST_TAG>",
+    "@dxos/blueprints":    "<COMPOSER_HOST_MAIN_DIST_TAG>",
+    "@dxos/react-ui":      "<COMPOSER_HOST_MAIN_DIST_TAG>",
+    "@dxos/types":         "<COMPOSER_HOST_MAIN_DIST_TAG>",
+    "@dxos/util":          "<COMPOSER_HOST_MAIN_DIST_TAG>",
     "effect": "^3.x",
     "react": "^19.x"
   }
 }
 ```
 
-**All `@dxos/*` deps must be pinned to the Composer host's main dist-tag.** Pin them in lockstep — see [publishing.md](./publishing.md).
+**Replace `<COMPOSER_HOST_MAIN_DIST_TAG>` with the actual version that Composer is shipping** — look it up via `npm dist-tag ls @dxos/app-framework` or follow the steps in [publishing.md](./publishing.md). Pinning to a stale hash here causes runtime mismatches; all `@dxos/*` deps must move in lockstep with the Composer host.
 
 The community build emits **one file**: `dist/plugin.mjs` (plus `dist/manifest.json`). No `exports` map needed; Composer dynamically imports the module.
 

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/plugin-definition.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/plugin-definition.md
@@ -1,0 +1,58 @@
+# Plugin definition
+
+The plugin file wires modules using `Plugin.define(meta).pipe(...)` with `AppPlugin.add*Module` helpers.
+
+```tsx
+// src/plugin.tsx
+import { Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
+
+import { MyBlueprint } from '#blueprints';
+import { BlueprintDefinition, OperationHandler, ReactSurface } from '#capabilities';
+import { meta } from '#meta';
+import { Foo } from '#types';
+import { translations } from './translations';
+
+export const FooPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addBlueprintDefinitionModule({ activate: BlueprintDefinition }),
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addMetadataModule({
+    metadata: {
+      id: Foo.Thing.typename,
+      metadata: { icon: '...', iconHue: '...', blueprints: [MyBlueprint.key], createObject: ... },
+    },
+  }),
+  AppPlugin.addSchemaModule({ schema: [Foo.Thing] }),
+  AppPlugin.addSurfaceModule({ activate: ReactSurface }),
+  AppPlugin.addTranslationsModule({ translations }),
+  Plugin.make,
+);
+```
+
+## Module → activation event reference
+
+| Method                         | Purpose                        | Activation event          |
+| ------------------------------ | ------------------------------ | ------------------------- |
+| `addSurfaceModule`             | React surface components       | `SetupReactSurface`       |
+| `addMetadataModule`            | Type metadata (icon, creation) | `SetupMetadata`           |
+| `addSchemaModule`              | ECHO type registration         | `SetupSchema`             |
+| `addOperationHandlerModule`    | Operation handlers             | `SetupOperationHandler`   |
+| `addTranslationsModule`        | i18n resources                 | `SetupTranslations`       |
+| `addBlueprintDefinitionModule` | AI blueprints                  | `SetupArtifactDefinition` |
+| `addSettingsModule`            | Plugin settings                | `SetupSettings`           |
+| `addAppGraphModule`            | Graph builder extensions       | `SetupAppGraph`           |
+| `addCommandModule`             | CLI commands                   | `Startup`                 |
+| `addReactContextModule`        | React context provider         | `Startup`                 |
+| `addNavigationResolverModule`  | Navigation resolvers           | `OperationInvokerReady`   |
+| `addNavigationHandlerModule`   | Navigation handlers            | `OperationInvokerReady`   |
+
+## Activation timing
+
+Operation handlers are loaded **lazily** when first invoked, not on startup. Schema, metadata, and surface modules activate at startup. Blueprint definition activates when `AssistantPlugin` fires `SetupArtifactDefinition`.
+
+This matters for testing — see [testing.md](./testing.md).
+
+## Inside the dxos monorepo
+
+- File is named for the plugin (e.g. `ChessPlugin.tsx`), exported from `src/index.ts`.
+- Otherwise identical.

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/publishing.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/publishing.md
@@ -47,7 +47,7 @@ jobs:
             dist/manifest.json
 ```
 
-Tag a release: `git tag v0.1.0 && git push --tags`. The workflow attaches the assets.
+Tag a release: `git tag v0.1.0 && git push origin v0.1.0` (push the single tag — avoid `git push --tags` so unrelated local tags don't trigger releases). The workflow attaches the assets.
 
 ## 3. Local testing before release
 
@@ -59,11 +59,7 @@ Fork [`dxos/community-plugins`](https://github.com/dxos/community-plugins), add 
 
 ```json
 {
-  "plugins": [
-    { "repo": "dxos/plugin-excalidraw" },
-    { "repo": "dxos/plugin-youtube" },
-    { "repo": "owner/your-plugin" }
-  ]
+  "plugins": [{ "repo": "dxos/plugin-excalidraw" }, { "repo": "dxos/plugin-youtube" }, { "repo": "owner/your-plugin" }]
 }
 ```
 

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/publishing.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/publishing.md
@@ -28,6 +28,8 @@ name: Release
 on:
   push:
     tags: ['v*']
+permissions:
+  contents: write
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/publishing.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/publishing.md
@@ -1,0 +1,97 @@
+# Publishing to the community registry
+
+Community plugins are loaded by Composer at runtime from **GitHub releases**. The registry lives at [`dxos/community-plugins`](https://github.com/dxos/community-plugins) and syncs into Composer roughly every 5 minutes.
+
+## End-to-end flow
+
+1. Build the plugin → produces `dist/plugin.mjs` + `dist/manifest.json`.
+2. Cut a GitHub Release; attach both files as assets.
+3. (One-time) PR to [`dxos/community-plugins`](https://github.com/dxos/community-plugins) adding `{ "repo": "owner/repo" }` to `community-plugins.json`.
+4. Composer picks up the new version on its next sync.
+
+## 1. Pin `@dxos/*` to the Composer host
+
+Find the Composer host's main dist-tag (e.g. `0.8.4-main.fcfe5033a5`) and pin **all** `@dxos/*` deps to it:
+
+```sh
+npm dist-tag ls @dxos/app-framework
+```
+
+Bump these in lockstep when Composer releases — see Excalidraw's release workflow for an automated bump.
+
+## 2. GitHub Actions release workflow
+
+Adapt this from [`dxos/plugin-excalidraw`](https://github.com/dxos/plugin-excalidraw)'s `.github/workflows/release.yml`:
+
+```yaml
+name: Release
+on:
+  push:
+    tags: ['v*']
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+      - uses: actions/setup-node@v4
+        with: { node-version: '20', cache: 'pnpm' }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/plugin.mjs
+            dist/manifest.json
+```
+
+Tag a release: `git tag v0.1.0 && git push --tags`. The workflow attaches the assets.
+
+## 3. Local testing before release
+
+In Composer: **Settings → Plugins → Load by URL** → point at your local `manifest.json` (e.g. via `pnpm preview`). This avoids round-tripping through GitHub for every change.
+
+## 4. Register in the community index
+
+Fork [`dxos/community-plugins`](https://github.com/dxos/community-plugins), add a single entry to `community-plugins.json`:
+
+```json
+{
+  "plugins": [
+    { "repo": "dxos/plugin-excalidraw" },
+    { "repo": "dxos/plugin-youtube" },
+    { "repo": "owner/your-plugin" }
+  ]
+}
+```
+
+Open a PR. After it merges, Composer's Community section lists the plugin within ~5 minutes.
+
+## `manifest.json` shape
+
+`composerPlugin` emits this for you. It should look like:
+
+```json
+{
+  "id": "com.example.plugin.foo",
+  "name": "Foo",
+  "description": "...",
+  "icon": "ph--cube--regular",
+  "iconHue": "indigo",
+  "moduleFile": "plugin.mjs",
+  "version": "0.1.0"
+}
+```
+
+## Updating
+
+For each new release:
+
+1. Bump `version` in `package.json`.
+2. (If Composer host moved) bump every `@dxos/*` dep to the new dist-tag.
+3. Tag and push; the workflow attaches new assets.
+4. Composer picks up the new version automatically — no PR to `community-plugins` needed for updates.
+
+## Inside the dxos monorepo
+
+In-repo plugins ship with Composer itself. There is **no GitHub release, no manifest, no community-plugins PR**. Instead, register the plugin with `composer-app` directly — see [registration.md](./registration.md).

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/publishing.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/publishing.md
@@ -67,7 +67,7 @@ Open a PR. After it merges, Composer's Community section lists the plugin within
 
 ## `manifest.json` shape
 
-`composerPlugin` emits this for you. It should look like:
+`composerPlugin` emits this for you — the manifest is your `Plugin.Meta` plus `moduleFile`. It should look like:
 
 ```json
 {
@@ -76,8 +76,7 @@ Open a PR. After it merges, Composer's Community section lists the plugin within
   "description": "...",
   "icon": "ph--cube--regular",
   "iconHue": "indigo",
-  "moduleFile": "plugin.mjs",
-  "version": "0.1.0"
+  "moduleFile": "plugin.mjs"
 }
 ```
 

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/react-surface.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/react-surface.md
@@ -37,14 +37,14 @@ export default Capability.makeModule(() =>
 
 ## Common roles
 
-| Role                  | Usage                                                  |
-| --------------------- | ------------------------------------------------------ |
-| `article`             | Full-width object editor.                              |
-| `section`             | Smaller embedded form.                                 |
-| `card--content`       | Card preview.                                          |
-| `object-properties`   | Sidebar property panel.                                |
-| `form-input`          | Custom form input for a schema field.                  |
-| `dialog` / `popover`  | Modal surfaces.                                        |
+| Role                 | Usage                                 |
+| -------------------- | ------------------------------------- |
+| `article`            | Full-width object editor.             |
+| `section`            | Smaller embedded form.                |
+| `card--content`      | Card preview.                         |
+| `object-properties`  | Sidebar property panel.               |
+| `form-input`         | Custom form input for a schema field. |
+| `dialog` / `popover` | Modal surfaces.                       |
 
 ## Filters
 

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/react-surface.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/react-surface.md
@@ -1,0 +1,57 @@
+# React surface
+
+Surfaces let other plugins render components for objects of your types. Contribute them via the `ReactSurface` capability.
+
+```tsx
+// src/capabilities/react-surface.tsx
+import * as Effect from 'effect/Effect';
+import { Capabilities, Capability } from '@dxos/app-framework';
+import { Surface } from '@dxos/app-framework/ui';
+import { AppSurface } from '@dxos/app-toolkit/ui';
+
+import { FooArticle, FooCard } from '#containers';
+import { Foo } from '#types';
+
+export default Capability.makeModule(() =>
+  Effect.succeed(
+    Capability.contributes(Capabilities.ReactSurface, [
+      Surface.create({
+        id: 'thing',
+        filter: AppSurface.oneOf(
+          AppSurface.object(AppSurface.Article, Foo.Thing),
+          AppSurface.object(AppSurface.Section, Foo.Thing),
+        ),
+        component: ({ data, role }) => (
+          <FooArticle role={role} subject={data.subject} attendableId={data.attendableId} />
+        ),
+      }),
+      Surface.create({
+        id: 'thing-card',
+        filter: AppSurface.object(AppSurface.Card, Foo.Thing),
+        component: ({ data, role }) => <FooCard role={role} subject={data.subject} />,
+      }),
+    ]),
+  ),
+);
+```
+
+## Common roles
+
+| Role                  | Usage                                                  |
+| --------------------- | ------------------------------------------------------ |
+| `article`             | Full-width object editor.                              |
+| `section`             | Smaller embedded form.                                 |
+| `card--content`       | Card preview.                                          |
+| `object-properties`   | Sidebar property panel.                                |
+| `form-input`          | Custom form input for a schema field.                  |
+| `dialog` / `popover`  | Modal surfaces.                                        |
+
+## Filters
+
+- `AppSurface.object(AppSurface.Article, Type)` — match an article surface for a specific ECHO type.
+- `AppSurface.objectProperties(Type)` — match the property sidebar for a type.
+- `AppSurface.oneOf(filter1, filter2)` — match any of several filters.
+
+## Reference
+
+- `packages/plugins/plugin-chess/src/capabilities/react-surface.tsx`

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/registration.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/registration.md
@@ -1,0 +1,14 @@
+# Registering with `composer-app` (in-repo only)
+
+In-repo plugins are bundled into Composer at build time. After creating the plugin under `packages/plugins/plugin-foo/`, register it with the `composer-app` package so it loads at startup.
+
+## Steps
+
+1. Add `@dxos/plugin-foo` to `packages/apps/composer-app/package.json` as a `workspace:*` dependency.
+2. Import and register the plugin in `composer-app`'s plugin list (search for an existing plugin name to find the right file).
+3. Run `pnpm install` to update the lockfile.
+4. `moon run composer-app:serve --quiet` and verify the plugin loads without errors.
+
+## Community plugins
+
+**Skip this entirely.** Community plugins are loaded dynamically by Composer from the registry — see [publishing.md](./publishing.md). There is no source-level registration step.

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/scaffolding.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/scaffolding.md
@@ -1,0 +1,62 @@
+# Scaffolding a community plugin
+
+A community plugin lives in **its own GitHub repo** and ships a single bundled module. The fastest start is to clone [`dxos/plugin-excalidraw`](https://github.com/dxos/plugin-excalidraw) and rename.
+
+## Minimum files
+
+```
+my-plugin/
+  package.json
+  vite.config.ts          # composerPlugin({ entry: 'src/plugin.tsx', meta })
+  vitest.config.ts
+  tsconfig.json
+  .github/workflows/release.yml
+  src/
+    plugin.tsx            # Plugin.define(meta).pipe(...)
+    meta.ts               # Plugin.Meta — id, name, description, icon, iconHue
+    translations.ts
+    capabilities/
+      index.ts            # Capability.lazy(...) only
+      react-surface.tsx
+    containers/
+      index.ts            # lazy(() => import('./X'))
+      MyArticle/
+        index.ts          # default export bridge
+        MyArticle.tsx
+    components/
+      index.ts
+    types/
+      index.ts            # export * as Foo from './Foo';
+      Foo.ts
+    operations/
+      index.ts
+      definitions.ts
+    blueprints/
+      index.ts
+      my-blueprint.ts
+```
+
+## Skeleton order
+
+Build the smallest thing that runs, then add features:
+
+1. `package.json` with `"private": true`, deps pinned to the **Composer host's main dist-tag** (e.g. `0.8.4-main.fcfe5033a5`).
+2. `vite.config.ts` with `composerPlugin`, `react()`, `wasm()`.
+3. `src/meta.ts` — id namespaced (e.g. `com.example.plugin.foo`), icon (Phosphor `ph--*--regular`), `iconHue`, `description`, `source`.
+4. `src/types/Foo.ts` — one ECHO type with `make()` factory.
+5. `src/translations.ts` — typename labels and `meta.id` plugin strings.
+6. `src/capabilities/react-surface.tsx` — one `article` surface.
+7. `src/containers/FooArticle/` — minimal `Panel.Root` shell.
+8. `src/plugin.tsx` — `Plugin.define(meta).pipe(addSchemaModule, addSurfaceModule, addTranslationsModule, Plugin.make)`.
+
+Build, then load the dev URL into Composer (Settings → Plugins → Load by URL). Iterate. Add operations, blueprints, settings as features land.
+
+## Inside the dxos monorepo
+
+- Live in `packages/plugins/plugin-foo/`.
+- `package.json` deps are `workspace:*` for `@dxos/*` and `catalog:` for everything else.
+- No `vite.config.ts`; build is driven by `moon.yml` with one `--entryPoint` per `exports` subpath.
+- The plugin file is named after the plugin (e.g. `FooPlugin.tsx`), not `plugin.tsx`.
+- Add a `PLUGIN.mdl` spec **before** writing code — see [specification.md](./specification.md).
+- Register with `composer-app` — see [registration.md](./registration.md).
+- New packages **must** include `"private": true` in `package.json`.

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/scaffolding.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/scaffolding.md
@@ -4,7 +4,7 @@ A community plugin lives in **its own GitHub repo** and ships a single bundled m
 
 ## Minimum files
 
-```
+```text
 my-plugin/
   package.json
   vite.config.ts          # composerPlugin({ entry: 'src/plugin.tsx', meta })

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/specification.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/specification.md
@@ -20,12 +20,13 @@ Do **not** write a separate design doc. The `PLUGIN.mdl` is the source of truth 
 
 ## Minimal shape
 
-```mdl
+```yaml
 ---
 id: org.dxos.plugin.foo
 name: FooPlugin
 version: 0.1.0
 ---
+```
 
 A short prose description of the plugin.
 
@@ -59,7 +60,6 @@ test T-1:
   given: a Space with no Things
   when: the user clicks "Add thing"
   then: a new Thing is created with default name
-```
 ```
 
 ## Workflow

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/specification.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/specification.md
@@ -1,0 +1,71 @@
+# `PLUGIN.mdl` specification (in-repo only)
+
+Inside the dxos monorepo, every plugin must have a `PLUGIN.mdl` file written in **MDL** — the spec language defined by `plugin-spec`. Community plugins can adopt this voluntarily but it isn't required.
+
+## The spec is the design document
+
+Do **not** write a separate design doc. The `PLUGIN.mdl` is the source of truth for what the plugin does. It must be:
+
+- **Created first** — before any code.
+- **Approved** by the user before implementation.
+- **Kept up-to-date** — when features change, update the spec first.
+- **Used to derive tests** — `feat`, `req`, and `test` blocks map to acceptance tests.
+
+## Files
+
+- Template: `packages/plugins/plugin-spec/docs/PLUGIN-.template.mdl`.
+- Reference: `packages/plugins/plugin-chess/PLUGIN.mdl`.
+- Grammar: `packages/plugins/plugin-spec/src/extension/mdl.grammar`.
+- Design rationale: `packages/plugins/plugin-spec/docs/DESIGN.md`.
+
+## Minimal shape
+
+```mdl
+---
+id: org.dxos.plugin.foo
+name: FooPlugin
+version: 0.1.0
+---
+
+A short prose description of the plugin.
+
+## Types
+
+```mdl
+type Thing
+  fields:
+    name: string
+    notes?: string
+```
+
+## Components
+
+```mdl
+component FooArticle
+  desc: Full-width article for editing a Thing.
+```
+
+## Features
+
+```mdl
+feat F-1: Manage Things
+  req F-1.1: Users can create, rename, and delete Things.
+```
+
+## Acceptance
+
+```mdl
+test T-1:
+  given: a Space with no Things
+  when: the user clicks "Add thing"
+  then: a new Thing is created with default name
+```
+```
+
+## Workflow
+
+For non-trivial plugin work, use `/superpowers:writing-plans` (Subagent-Driven). Once the spec is approved, write the skeleton (see [scaffolding.md](./scaffolding.md)) and add features incrementally — updating the spec each time.
+
+## Community plugins
+
+This file does not apply outside the monorepo. A `SPEC.md` (free-form Markdown) is sometimes useful, but there's no toolchain integration.

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/testing.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/testing.md
@@ -32,11 +32,7 @@ describe('FooPlugin', () => {
 
     // Active after a normal startup.
     expect(harness.manager.getActive()).toEqual(
-      expect.arrayContaining([
-        moduleId('metadata'),
-        moduleId('schema'),
-        moduleId('ReactSurface'),
-      ]),
+      expect.arrayContaining([moduleId('metadata'), moduleId('schema'), moduleId('ReactSurface')]),
     );
 
     // Blueprint definitions activate when SetupArtifactDefinition fires

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/testing.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/testing.md
@@ -1,0 +1,82 @@
+# Testing with the composer harness
+
+Two tests every plugin should ship: a **smoke test** (modules activate) and an **operation test** (operations run end-to-end). Both use `createComposerTestApp` from `@dxos/plugin-testing/harness`.
+
+## Setup
+
+```ts
+// src/FooPlugin.test.ts
+import { describe, test } from 'vitest';
+
+import { ActivationEvents } from '@dxos/app-framework';
+import { AppActivationEvents } from '@dxos/app-toolkit';
+// IMPORTANT: use the CLI variant — the main ClientPlugin references browser-only capabilities.
+import { ClientPlugin } from '@dxos/plugin-client/cli';
+import { createComposerTestApp } from '@dxos/plugin-testing/harness';
+
+import { FooPlugin } from './FooPlugin';
+import { meta } from './meta';
+import { Print } from './operations';
+
+const moduleId = (name: string) => `${meta.id}.module.${name}`;
+```
+
+## Smoke test — modules activate
+
+```ts
+describe('FooPlugin', () => {
+  test('modules activate on the expected events', async ({ expect }) => {
+    await using harness = await createComposerTestApp({
+      plugins: [ClientPlugin({}), FooPlugin()],
+    });
+
+    // Active after a normal startup.
+    expect(harness.manager.getActive()).toEqual(
+      expect.arrayContaining([
+        moduleId('metadata'),
+        moduleId('schema'),
+        moduleId('ReactSurface'),
+      ]),
+    );
+
+    // Blueprint definitions activate when SetupArtifactDefinition fires
+    // (normally fired by AssistantPlugin).
+    await harness.fire(AppActivationEvents.SetupArtifactDefinition);
+    expect(harness.manager.getActive()).toContain(moduleId('BlueprintDefinition'));
+
+    // Operation handlers are lazy — fire SetupOperationHandler to load them.
+    await harness.fire(ActivationEvents.SetupOperationHandler);
+    expect(harness.manager.getActive()).toContain(moduleId('OperationHandler'));
+  });
+});
+```
+
+This catches the most common bugs: typoed activation events, missing module wiring, and accidentally tree-shaken modules.
+
+## Operation test — invoke real handlers
+
+```ts
+test('Print renders ASCII', async ({ expect }) => {
+  await using harness = await createComposerTestApp({ plugins: [FooPlugin()] });
+  const { ascii } = await harness.invoke(Print, { pgn: '1. e4 e5' });
+  expect(ascii).toContain('a  b  c  d  e  f  g  h');
+});
+```
+
+`harness.invoke(Op, input)` validates the input, loads the handler, runs it under Effect with the declared services, and returns the typed output.
+
+## Why the CLI `ClientPlugin`
+
+The main `@dxos/plugin-client` references browser capabilities that resolve to `undefined` under Node and crash the harness. Always import:
+
+```ts
+import { ClientPlugin } from '@dxos/plugin-client/cli';
+```
+
+## Storybook
+
+Container storybooks complement these tests by exercising rendering. They aren't a substitute — `test-storybook` doesn't catch missing capabilities or operation regressions.
+
+## Reference
+
+- `packages/plugins/plugin-chess/src/ChessPlugin.test.ts` — smoke + operation tests.

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/translations.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/translations.md
@@ -48,5 +48,5 @@ Object-shaped strings (`typename.label`, `add-object.label`, etc.) are resolved 
 ## Registration
 
 ```tsx
-AppPlugin.addTranslationsModule({ translations })
+AppPlugin.addTranslationsModule({ translations });
 ```

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/translations.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/translations.md
@@ -1,0 +1,52 @@
+# Translations
+
+Translations are keyed at **two** levels: by **typename** for object-shaped strings, and by `meta.id` for plugin-scoped strings.
+
+```ts
+// src/translations.ts
+import { type Resource } from '@dxos/react-ui';
+import { meta } from '#meta';
+import { Foo } from '#types';
+
+export const translations = [
+  {
+    'en-US': {
+      [Foo.Thing.typename]: {
+        'typename.label': 'Thing',
+        'typename.label_zero': 'Things',
+        'typename.label_one': 'Thing',
+        'typename.label_other': 'Things',
+        'object-name.placeholder': 'New thing',
+        'add-object.label': 'Add thing',
+        'rename-object.label': 'Rename thing',
+        'delete-object.label': 'Delete thing',
+        'object-deleted.label': 'Thing deleted',
+      },
+      [meta.id]: {
+        'plugin.name': 'Foo',
+        'do-something.button': 'Do something',
+      },
+    },
+  },
+] as const satisfies Resource[];
+```
+
+## Usage
+
+In containers and components, scope the translation hook to your plugin id:
+
+```tsx
+import { useTranslation } from '@dxos/react-ui';
+import { meta } from '#meta';
+
+const { t } = useTranslation(meta.id);
+return <Button>{t('do-something.button')}</Button>;
+```
+
+Object-shaped strings (`typename.label`, `add-object.label`, etc.) are resolved automatically by Composer when it renders chrome around your objects — you usually don't reference them directly.
+
+## Registration
+
+```tsx
+AppPlugin.addTranslationsModule({ translations })
+```

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/types-schema.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/types-schema.md
@@ -1,0 +1,66 @@
+# ECHO types & schemas
+
+Types are Effect Schema definitions registered with ECHO via `Type.object()`.
+
+```ts
+// src/types/Foo.ts
+import * as Schema from 'effect/Schema';
+import { Annotation, Obj, Type } from '@dxos/echo';
+import { FormInputAnnotation, LabelAnnotation } from '@dxos/echo/internal';
+
+export const Thing = Schema.Struct({
+  name: Schema.optional(Schema.String),
+  notes: Schema.optional(Schema.String).pipe(FormInputAnnotation.set(false)),
+}).pipe(
+  Type.object({
+    typename: 'com.example.type.thing',   // dotted, namespaced — globally unique.
+    version: '0.1.0',
+  }),
+  LabelAnnotation.set(['name']),
+  Annotation.IconAnnotation.set({
+    icon: 'ph--cube--regular',
+    hue: 'indigo',
+  }),
+);
+
+export interface Thing extends Schema.Schema.Type<typeof Thing> {}
+
+export const make = ({ name, notes }: { name?: string; notes?: string } = {}) =>
+  Obj.make(Thing, { name, notes });
+```
+
+## Conventions
+
+- **Typename** is a globally unique dotted identifier (`com.example.type.thing`). Use your domain.
+- **Version** uses semver; bump on schema changes.
+- Always add `LabelAnnotation` so the UI knows what to display as the title.
+- Always add `IconAnnotation` (Phosphor icon + hue) for visual identity.
+- Provide a `make()` factory using `Obj.make()` — never `new` an ECHO object.
+- Use `FormInputAnnotation.set(false)` to hide a field from auto-generated forms.
+
+## Namespace re-export
+
+```ts
+// src/types/index.ts
+export * as Foo from './Foo';
+```
+
+Other code imports as `import { Foo } from '#types'` then uses `Foo.Thing`, `Foo.make()`. This keeps namespaces clean as more types are added.
+
+## Refs
+
+For relationships between objects, use `Ref.Ref(OtherType)`:
+
+```ts
+import { Ref } from '@dxos/echo';
+
+owner: Ref.Ref(Person).annotations({ description: 'Owner of the thing' }),
+```
+
+## Registration
+
+Register your types via `AppPlugin.addSchemaModule({ schema: [Foo.Thing] })` in your plugin definition.
+
+## Reference
+
+- `packages/plugins/plugin-chess/src/types/Chess.ts`

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/types-schema.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/types-schema.md
@@ -13,7 +13,7 @@ export const Thing = Schema.Struct({
   notes: Schema.optional(Schema.String).pipe(FormInputAnnotation.set(false)),
 }).pipe(
   Type.object({
-    typename: 'com.example.type.thing',   // dotted, namespaced — globally unique.
+    typename: 'com.example.type.thing', // dotted, namespaced — globally unique.
     version: '0.1.0',
   }),
   LabelAnnotation.set(['name']),
@@ -25,8 +25,7 @@ export const Thing = Schema.Struct({
 
 export interface Thing extends Schema.Schema.Type<typeof Thing> {}
 
-export const make = ({ name, notes }: { name?: string; notes?: string } = {}) =>
-  Obj.make(Thing, { name, notes });
+export const make = ({ name, notes }: { name?: string; notes?: string } = {}) => Obj.make(Thing, { name, notes });
 ```
 
 ## Conventions

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/vite-config.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/vite-config.md
@@ -31,7 +31,7 @@ export default defineConfig({
 
 ## Output
 
-```
+```text
 dist/
   plugin.mjs       # ES module, imported by Composer
   manifest.json    # Composer reads this to register the plugin

--- a/tools/composer-plugin-dev/skills/composer-plugin-dev/references/vite-config.md
+++ b/tools/composer-plugin-dev/skills/composer-plugin-dev/references/vite-config.md
@@ -1,0 +1,53 @@
+# `vite.config.ts` (community plugins)
+
+Community plugins build with Vite + the `composerPlugin` Vite plugin from `@dxos/app-framework/vite-plugin`. The plugin emits a single ES module (`dist/plugin.mjs`) plus the `dist/manifest.json` Composer needs to load it.
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import wasm from 'vite-plugin-wasm';
+import { composerPlugin } from '@dxos/app-framework/vite-plugin';
+
+import { meta } from './src/meta';
+
+export default defineConfig({
+  plugins: [
+    wasm(),
+    composerPlugin({
+      entry: 'src/plugin.tsx',
+      meta,
+    }),
+    react(),
+  ],
+});
+```
+
+## What it does
+
+- **`composerPlugin`** wraps your entry, injects activation glue, and emits `dist/manifest.json` alongside the bundle. The manifest copies your `meta` (id, name, description, icon, iconHue) and points `moduleFile` at `plugin.mjs`.
+- **`wasm()`** is needed because some `@dxos/*` deps (echo, automerge) ship WASM.
+- **`react()`** for JSX + Fast Refresh.
+
+## Output
+
+```
+dist/
+  plugin.mjs       # ES module, imported by Composer
+  manifest.json    # Composer reads this to register the plugin
+```
+
+Both files become **GitHub release assets** — see [publishing.md](./publishing.md).
+
+## Local testing
+
+```sh
+pnpm build
+pnpm preview   # serves dist/ on localhost:4173 (or similar)
+```
+
+In Composer: **Settings → Plugins → Load by URL** → paste the local `manifest.json` URL. The plugin loads dynamically; reloading rebuilds it.
+
+## Inside the dxos monorepo
+
+In-repo plugins do **not** use Vite. Builds are driven by `moon.yml`'s `compile` task, which calls the workspace TypeScript bundler with one `--entryPoint` per `exports` subpath. Skip this file entirely.


### PR DESCRIPTION
## Summary

Adds `tools/composer-plugin-dev/` — a Claude Code plugin that bundles authoring guidance for DXOS Composer plugins.

- **Audience:** primarily community authors building plugins in their **own repo** (Vite + `composerPlugin`, GitHub release with `manifest.json` + `plugin.mjs`, registered via [`dxos/community-plugins`](https://github.com/dxos/community-plugins)). Each topic has an "Inside the dxos monorepo" callout for how the in-repo workflow differs (moon, `workspace:*`, exports subpaths, `composer-app` registration, `PLUGIN.mdl`).
- **Structure:** topic-indexed core `SKILL.md` linking to focused reference subfiles under `references/` — keeps the index small and lets the model load only what it needs.

### Topics covered

Scaffolding · Directory structure · Plugin definition (activation events) · Components vs containers (the non-negotiable separation) · UI primitives (`Panel` / `ScrollArea` / `Toolbar` / `Card`) · React surface · ECHO types & schemas · Translations · **Operations vs UI: where logic belongs** · Operations (definitions + lazy handlers) · **External services & `AccessToken`** · **`AiService` for inference** · **Blueprints — letting agents drive the plugin** · Capabilities · `package.json` (community vs monorepo, **CLI entrypoint contract**) · Vite config · `moon.yml` · **Publishing** (release workflow, registry PR, "Load by URL" testing) · **Testing with the composer harness** (smoke + operation tests) · Coding style · Build & verify · `PLUGIN.mdl` spec (in-repo) · Registering with `composer-app` (in-repo).

### Also includes

- `/new-composer-plugin <name>` — scaffold a new plugin (community by default, `--monorepo` for in-repo).
- `/audit-composer-plugin [path]` — convention audit with severity grouping.
- `composer-plugin-reviewer` subagent for review before merge.

## Test plan

- [ ] Install locally via Claude Code `/plugin` against `tools/composer-plugin-dev/`.
- [ ] Run `/new-composer-plugin demo` end-to-end and verify the skeleton builds.
- [ ] Run `/audit-composer-plugin packages/plugins/plugin-chess` against the exemplar — expect mostly clean.
- [ ] Spot-check that subfile links in `SKILL.md` resolve.

https://claude.ai/code/session_01SVuNJQapPbxbaZyGcsY9jx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVuNJQapPbxbaZyGcsY9jx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local Composer plugin authoring toolkit: manifest and tooling to scaffold, audit, review, and preview Composer plugins.

* **Documentation**
  * Comprehensive guides on plugin anatomy, scaffolding, components vs containers, operations vs UI, capabilities/blueprints, packaging/build/test/publishing flows, external auth/services, translations, coding style, and testing best practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->