### PR TITLE
fix(plugin-token-manager): use write-only scope for Linear

### DIFF
--- a/packages/plugins/plugin-token-manager/src/cli/commands/integration/util.ts
+++ b/packages/plugins/plugin-token-manager/src/cli/commands/integration/util.ts
@@ -39,7 +39,7 @@ export const OAUTH_PRESETS: OAuthPreset[] = [
     provider: OAuthProvider.LINEAR,
     source: 'linear.app',
     label: 'Linear',
-    scopes: ['read', 'write'],
+    scopes: ['write'],
   },
   {
     provider: OAuthProvider.SLACK,

--- a/packages/plugins/plugin-token-manager/src/defs/presets.ts
+++ b/packages/plugins/plugin-token-manager/src/defs/presets.ts
@@ -36,7 +36,7 @@ export const OAUTH_PRESETS: OAuthPreset[] = [
     provider: OAuthProvider.LINEAR,
     source: 'linear.app',
     label: 'Linear',
-    scopes: ['read', 'write'],
+    scopes: ['write'],
   },
   {
     provider: OAuthProvider.SLACK,


### PR DESCRIPTION
## Summary

Linear's `write` scope already grants full read+write access. When both `read` and `write` are requested, Linear normalizes the token response to just `"write"` — causing our scope validation to fail with "Grant scopes did not match requested scopes".

Changed Linear's preset from `['read', 'write']` to `['write']` in both:
- `packages/plugins/plugin-token-manager/src/defs/presets.ts`
- `packages/plugins/plugin-token-manager/src/cli/commands/integration/util.ts`

The server-side OAuth changes (Trello fragment bridge, Slack `token_type: "bot"`, GitHub App empty scope) are in `dxos/edge#533`.

https://claude.ai/code/session_014BtQuBVqEX4D15hNZ7N29D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized Linear integration OAuth authentication. The Linear OAuth preset has been updated to require write access only, removing the previous read permission requirement. This adjustment maintains all necessary functionality while reducing the overall permission scope required for Linear connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->