### PR TITLE
feat(plugin-inbox): configurable sync options for Mailbox and Calendar

### DIFF
--- a/packages/plugins/plugin-inbox/src/apis/google/GoogleCalendar/api.ts
+++ b/packages/plugins/plugin-inbox/src/apis/google/GoogleCalendar/api.ts
@@ -26,12 +26,14 @@ export const listEventsByStartTime = Effect.fn(function* (
   timeMax: string,
   pageSize: number,
   pageToken?: string | undefined,
+  q?: string | undefined,
 ) {
   const url = createUrl([API_URL, 'calendars', encodeURIComponent(calendarId), 'events'], {
     timeMin,
     timeMax,
     maxResults: pageSize,
     pageToken,
+    q,
     // NOTE: `singleEvents=false` is not compatible with `orderBy=startTime`.
     //   Expanded instances can be deduplicated downstream by recurringEventId.
     singleEvents: true,
@@ -51,11 +53,13 @@ export const listEventsByUpdated = Effect.fn(function* (
   updatedMin: string,
   pageSize: number,
   pageToken?: string | undefined,
+  q?: string | undefined,
 ) {
   const url = createUrl([API_URL, 'calendars', encodeURIComponent(calendarId), 'events'], {
     updatedMin,
     maxResults: pageSize,
     pageToken,
+    q,
     // Don't create individual instances of recurring events.
     singleEvents: false,
     orderBy: 'updated',

--- a/packages/plugins/plugin-inbox/src/operations/definitions.ts
+++ b/packages/plugins/plugin-inbox/src/operations/definitions.ts
@@ -133,6 +133,13 @@ export const GoogleMailSync = Operation.make({
       }),
       Schema.optional,
     ),
+    filter: Schema.String.pipe(
+      Schema.annotations({
+        description:
+          'Optional Gmail search expression appended to the query (e.g., `label:important OR label:investor`).',
+      }),
+      Schema.optional,
+    ),
     restrictedMode: Schema.Boolean.pipe(
       Schema.annotations({
         description: 'Use restricted mode to limit to single date range and max 20 messages. Reduces subrequests.',
@@ -175,6 +182,12 @@ export const GoogleCalendarSync = Operation.make({
     syncBackDays: Schema.optional(Schema.Number),
     syncForwardDays: Schema.optional(Schema.Number),
     pageSize: Schema.optional(Schema.Number),
+    filter: Schema.String.pipe(
+      Schema.annotations({
+        description: 'Optional Google Calendar free-text search query (passed as `q`).',
+      }),
+      Schema.optional,
+    ),
   }),
   output: Schema.Struct({
     newEvents: Schema.Number,

--- a/packages/plugins/plugin-inbox/src/operations/google/calendar/sync.ts
+++ b/packages/plugins/plugin-inbox/src/operations/google/calendar/sync.ts
@@ -26,6 +26,7 @@ import { mapEvent } from './mapper';
 type BaseSyncProps<T = unknown> = {
   googleCalendarId: string;
   pageSize: number;
+  filter: string | undefined;
   newEvents: Ref.Ref<Event.Event[]>;
   nextPage: Ref.Ref<string | undefined>;
   latestUpdate: Ref.Ref<string | undefined>;
@@ -39,6 +40,7 @@ export default GoogleCalendarSync.pipe(
       syncBackDays = 30,
       syncForwardDays = 365,
       pageSize = 100,
+      filter,
     }) =>
       Effect.gen(function* () {
         log('syncing google calendar', {
@@ -47,6 +49,7 @@ export default GoogleCalendarSync.pipe(
           syncBackDays,
           syncForwardDays,
           pageSize,
+          filter,
         });
 
         const calendar = yield* Database.load(calendarRef);
@@ -63,6 +66,7 @@ export default GoogleCalendarSync.pipe(
             syncBackDays,
             syncForwardDays,
             pageSize,
+            filter,
             newEvents,
             nextPage,
             latestUpdate,
@@ -72,6 +76,7 @@ export default GoogleCalendarSync.pipe(
             googleCalendarId,
             updatedMin: calendar.lastSyncedUpdate!,
             pageSize,
+            filter,
             newEvents,
             nextPage,
             latestUpdate,
@@ -112,6 +117,7 @@ export default GoogleCalendarSync.pipe(
 const performInitialSync = Effect.fn(function* ({
   googleCalendarId,
   pageSize,
+  filter,
   newEvents,
   nextPage,
   latestUpdate,
@@ -121,7 +127,7 @@ const performInitialSync = Effect.fn(function* ({
   syncBackDays: number;
   syncForwardDays: number;
 }>) {
-  log('performing initial sync', { syncBackDays, syncForwardDays });
+  log('performing initial sync', { syncBackDays, syncForwardDays, filter });
   const now = new Date();
   const timeMin = addDays(now, -syncBackDays).toISOString();
   const timeMax = addDays(now, syncForwardDays).toISOString();
@@ -130,13 +136,14 @@ const performInitialSync = Effect.fn(function* ({
 
   do {
     const pageToken = yield* Ref.get(nextPage);
-    log('requesting events by start time', { timeMin, timeMax, pageToken });
+    log('requesting events by start time', { timeMin, timeMax, pageToken, filter });
     const { items = [], nextPageToken } = yield* GoogleCalendar.listEventsByStartTime(
       googleCalendarId,
       timeMin,
       timeMax,
       pageSize,
       pageToken,
+      filter,
     );
     yield* Ref.update(nextPage, () => nextPageToken);
     yield* processEvents({ items, newEvents, latestUpdate, seenRecurringEventIds });
@@ -146,6 +153,7 @@ const performInitialSync = Effect.fn(function* ({
 const performIncrementalSync = Effect.fn(function* ({
   googleCalendarId,
   pageSize,
+  filter,
   newEvents,
   nextPage,
   latestUpdate,
@@ -153,16 +161,17 @@ const performIncrementalSync = Effect.fn(function* ({
 }: BaseSyncProps<{
   updatedMin: string;
 }>) {
-  log('performing incremental sync', { updatedMin });
+  log('performing incremental sync', { updatedMin, filter });
 
   do {
     const pageToken = yield* Ref.get(nextPage);
-    log('requesting events by updated time', { updatedMin, pageToken });
+    log('requesting events by updated time', { updatedMin, pageToken, filter });
     const { items = [], nextPageToken } = yield* GoogleCalendar.listEventsByUpdated(
       googleCalendarId,
       updatedMin,
       pageSize,
       pageToken,
+      filter,
     );
     yield* Ref.update(nextPage, () => nextPageToken);
 

--- a/packages/plugins/plugin-inbox/src/operations/google/gmail/sync.ts
+++ b/packages/plugins/plugin-inbox/src/operations/google/gmail/sync.ts
@@ -51,10 +51,11 @@ export default GoogleMailSync.pipe(
       userId = 'me',
       label = 'inbox',
       after = format(subDays(new Date(), 30), 'yyyy-MM-dd'),
+      filter,
       restrictedMode = false,
     }) =>
       Effect.gen(function* () {
-        log('syncing gmail', { mailbox: mailboxRef.dxn.toString(), userId, after, restrictedMode });
+        log('syncing gmail', { mailbox: mailboxRef.dxn.toString(), userId, after, filter, restrictedMode });
         const mailbox = yield* Database.load(mailboxRef);
         const feed = yield* Database.load(mailbox.feed);
 
@@ -88,6 +89,7 @@ export default GoogleMailSync.pipe(
           feed,
           userId,
           label,
+          filter,
           existingGmailIds,
           restrictedMode,
         );
@@ -139,14 +141,22 @@ const generateDateRanges = (config: DateRangeConfig): Stream.Stream<DateChunk> =
   );
 };
 
-const fetchMessagesForDateRange = (userId: string, label: string, dateChunk: DateChunk) => {
+const fetchMessagesForDateRange = (userId: string, label: string, filter: string | undefined, dateChunk: DateChunk) => {
   return Stream.unfoldChunkEffect({ pageToken: Option.none<string>(), done: false }, (state) =>
     Effect.gen(function* () {
       if (state.done) {
         return Option.none();
       }
 
-      const query = `in:anywhere label:${label} after:${format(dateChunk.start, 'yyyy/MM/dd')} before:${format(dateChunk.end, 'yyyy/MM/dd')}`;
+      const query = [
+        `in:anywhere`,
+        `label:${label}`,
+        `after:${format(dateChunk.start, 'yyyy/MM/dd')}`,
+        `before:${format(dateChunk.end, 'yyyy/MM/dd')}`,
+        filter ? `(${filter})` : undefined,
+      ]
+        .filter(Boolean)
+        .join(' ');
       log('fetching message IDs', {
         query,
         pageToken: Option.getOrUndefined(state.pageToken),
@@ -180,6 +190,7 @@ const streamGmailMessagesToFeed = Effect.fn(function* (
   feed: Feed.Feed,
   userId: string,
   label: string,
+  filter: string | undefined,
   existingGmailIds: Set<string>,
   restricted: boolean,
 ) {
@@ -191,7 +202,7 @@ const streamGmailMessagesToFeed = Effect.fn(function* (
 
   const count = yield* Function.pipe(
     generateDateRanges(config),
-    Stream.flatMap((dateChunk) => fetchMessagesForDateRange(userId, label, dateChunk), { concurrency: 1 }),
+    Stream.flatMap((dateChunk) => fetchMessagesForDateRange(userId, label, filter, dateChunk), { concurrency: 1 }),
     Stream.filter((messageId) => {
       const isDuplicate = existingGmailIds.has(messageId);
       if (isDuplicate) {

--- a/packages/plugins/plugin-inbox/src/operations/sync-calendar.ts
+++ b/packages/plugins/plugin-inbox/src/operations/sync-calendar.ts
@@ -24,10 +24,14 @@ const handler: Operation.WithHandler<typeof SyncCalendar> = SyncCalendar.pipe(
       invariant(db);
       const runtime = computeRuntime.getRuntime(db.spaceId);
       const { CalendarFunctions } = yield* Effect.promise(() => import('./google/calendar'));
+      const { syncBackDays, syncForwardDays, filter } = calendar.sync ?? {};
       yield* Effect.tryPromise(() =>
         runtime.runPromise(
           Operation.invoke(CalendarFunctions.Sync, {
             calendar: Ref.make(calendar),
+            syncBackDays,
+            syncForwardDays,
+            filter,
           }),
         ),
       ).pipe(

--- a/packages/plugins/plugin-inbox/src/operations/sync-mailbox.ts
+++ b/packages/plugins/plugin-inbox/src/operations/sync-mailbox.ts
@@ -2,6 +2,7 @@
 // Copyright 2025 DXOS.org
 //
 
+import { format, subDays } from 'date-fns';
 import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
@@ -24,10 +25,14 @@ const handler: Operation.WithHandler<typeof SyncMailbox> = SyncMailbox.pipe(
       invariant(db);
       const runtime = computeRuntime.getRuntime(db.spaceId);
       const { GmailFunctions } = yield* Effect.promise(() => import('./google/gmail'));
+      const { syncBackDays, filter } = mailbox.sync ?? {};
+      const after = syncBackDays != null ? format(subDays(new Date(), syncBackDays), 'yyyy-MM-dd') : undefined;
       yield* Effect.tryPromise(() =>
         runtime.runPromise(
           Operation.invoke(GmailFunctions.Sync, {
             mailbox: Ref.make(mailbox),
+            after,
+            filter,
           }),
         ),
       ).pipe(

--- a/packages/plugins/plugin-inbox/src/types/Calendar.ts
+++ b/packages/plugins/plugin-inbox/src/types/Calendar.ts
@@ -9,6 +9,8 @@ import { FormInputAnnotation } from '@dxos/echo/internal';
 import { FeedAnnotation } from '@dxos/schema';
 import { AccessToken } from '@dxos/types';
 
+import { CalendarSyncOptions } from './SyncOptions';
+
 /** Calendar object schema. */
 export const Calendar = Schema.Struct({
   name: Schema.String.pipe(Schema.optional),
@@ -19,6 +21,12 @@ export const Calendar = Schema.Struct({
     Ref.Ref(AccessToken.AccessToken).annotations({
       title: 'Account',
       description: 'Google account credentials for syncing this calendar.',
+    }),
+  ),
+  sync: Schema.optional(
+    CalendarSyncOptions.annotations({
+      title: 'Sync',
+      description: 'Configures how events are synced from the upstream provider.',
     }),
   ),
 }).pipe(

--- a/packages/plugins/plugin-inbox/src/types/Mailbox.ts
+++ b/packages/plugins/plugin-inbox/src/types/Mailbox.ts
@@ -9,6 +9,8 @@ import { FormInputAnnotation } from '@dxos/echo/internal';
 import { FeedAnnotation } from '@dxos/schema';
 import { AccessToken } from '@dxos/types';
 
+import { SyncOptions } from './SyncOptions';
+
 // TODO(burdon): Implement as labels?
 export enum MessageState {
   NONE = 0,
@@ -40,6 +42,12 @@ export const Mailbox = Schema.Struct({
     Ref.Ref(AccessToken.AccessToken).annotations({
       title: 'Account',
       description: 'Google account credentials for syncing this mailbox.',
+    }),
+  ),
+  sync: Schema.optional(
+    SyncOptions.annotations({
+      title: 'Sync',
+      description: 'Configures how messages are synced from the upstream provider.',
     }),
   ),
 }).pipe(

--- a/packages/plugins/plugin-inbox/src/types/SyncOptions.ts
+++ b/packages/plugins/plugin-inbox/src/types/SyncOptions.ts
@@ -1,0 +1,48 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Schema from 'effect/Schema';
+
+/**
+ * Common options for syncing data from external providers (e.g., Gmail, Google Calendar).
+ * Applied in addition to provider-specific defaults (e.g., Gmail label, Calendar id).
+ */
+export const SyncOptions = Schema.Struct({
+  /** Sync messages or events from this many days back. */
+  syncBackDays: Schema.optional(
+    Schema.Number.annotations({
+      title: 'Sync back days',
+      description: 'Sync messages or events from this many days back.',
+    }),
+  ),
+  /**
+   * Optional provider-specific search query, applied in addition to the date range and standard properties.
+   * For Gmail: a search expression (e.g., `label:important OR label:investor`).
+   * For Google Calendar: a free-text search across event fields.
+   */
+  filter: Schema.optional(
+    Schema.String.annotations({
+      title: 'Filter',
+      description: 'Optional provider-specific search query applied in addition to the date range.',
+    }),
+  ),
+});
+
+export interface SyncOptions extends Schema.Schema.Type<typeof SyncOptions> {}
+
+/**
+ * Sync options for sources that have a forward time horizon (e.g., calendars).
+ */
+export const CalendarSyncOptions = Schema.Struct({
+  ...SyncOptions.fields,
+  /** Sync events forward from today by this many days. */
+  syncForwardDays: Schema.optional(
+    Schema.Number.annotations({
+      title: 'Sync forward days',
+      description: 'Sync events forward from today by this many days.',
+    }),
+  ),
+});
+
+export interface CalendarSyncOptions extends Schema.Schema.Type<typeof CalendarSyncOptions> {}

--- a/packages/plugins/plugin-inbox/src/types/index.ts
+++ b/packages/plugins/plugin-inbox/src/types/index.ts
@@ -5,6 +5,7 @@
 export * as Calendar from './Calendar';
 export * as DraftMessage from './DraftMessage';
 export * as Mailbox from './Mailbox';
+export * from './SyncOptions';
 export * from './capabilities';
 export * from './events';
 export * as Settings from './Settings';


### PR DESCRIPTION
## Summary
- Adds an optional `sync` field to `Mailbox` and `Calendar` ECHO types backed by a shared `SyncOptions` schema (`syncBackDays`, `filter`) plus a `CalendarSyncOptions` extension that adds `syncForwardDays`.
- `SyncMailbox` / `SyncCalendar` wrapper operations now read these options off the persisted object and forward them to the underlying Google Mail / Calendar sync operations.
- Gmail sync appends the configured filter to its query (e.g. `(label:important OR label:investor)`) in addition to the existing label and date-range clauses; Google Calendar passes the filter through as the `q` query parameter.

## Test plan
- [x] `moon run plugin-inbox:build`
- [x] `moon run plugin-inbox:test` (e2e Gmail/Calendar sync tests remain skipped — they require live credentials)
- [ ] Manual: configure a Mailbox with `sync.syncBackDays` + `sync.filter` and verify the timer trigger picks them up
- [ ] Manual: configure a Calendar with `sync.syncForwardDays` + `sync.filter` and verify the initial vs incremental sync paths use them

🤖 Generated with [Claude Code](https://claude.com/claude-code)