### PR TITLE
feat(devtools): add browser CPU load diagnostic panel

### DIFF
--- a/packages/devtools/devtools/src/components/performance/StatsPanel.tsx
+++ b/packages/devtools/devtools/src/components/performance/StatsPanel.tsx
@@ -7,9 +7,10 @@ import React, { type PropsWithChildren, useCallback, useEffect, useState } from 
 import { getSyncSummary, useSyncState } from '@dxos/react-client/echo';
 import { Icon, ScrollArea, Toggle } from '@dxos/react-ui';
 
-import { type Stats, removeEmpty } from '../../hooks';
+import { type Stats, removeEmpty, useCpuLoad } from '../../hooks';
 import { Panel } from './Panel';
 import {
+  CpuPanel,
   DatabasePanel,
   EdgePanel,
   LoggingPanel,
@@ -30,6 +31,7 @@ const LOCAL_STORAGE_KEY = 'org.dxos.plugin.debug.panels';
 
 const PANEL_KEYS = [
   'ts',
+  'cpu',
   'performance',
   'surfaceProfiler',
   'edge',
@@ -84,6 +86,7 @@ export const StatsPanel = ({
   const queries = [...(stats?.queries ?? [])];
   queries.reverse();
 
+  const cpu = useCpuLoad();
   const syncState = useSyncState();
   const syncSummary = getSyncSummary(syncState);
 
@@ -124,6 +127,7 @@ export const StatsPanel = ({
         />
         <LoggingPanel {...props('logging')} />
         <MemoryPanel id='memory' memory={stats?.memory} />
+        <CpuPanel id='cpu' cpu={cpu} />
         <NetworkPanel id='network' network={stats?.network} />
         <EdgePanel id='edge' open={panelState.edge} edge={stats?.edge} onToggle={handleToggle} />
         <PerformancePanel

--- a/packages/devtools/devtools/src/components/performance/panels/CpuPanel.tsx
+++ b/packages/devtools/devtools/src/components/performance/panels/CpuPanel.tsx
@@ -1,0 +1,33 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React from 'react';
+
+import { mx } from '@dxos/ui-theme';
+import { Unit } from '@dxos/util';
+
+import { type CpuInfo } from '../../../hooks';
+import { type CustomPanelProps, Panel } from '../Panel';
+
+const HIGH_LOAD = 0.5;
+
+export const CpuPanel = ({ cpu, ...props }: CustomPanelProps<{ cpu?: CpuInfo }>) => {
+  return (
+    <Panel
+      {...props}
+      icon='ph--cpu--regular'
+      title='CPU'
+      info={
+        <div className='flex items-center gap-2'>
+          {cpu?.frameRate !== undefined && <span title='Frame rate'>{cpu.frameRate} fps</span>}
+          {cpu?.load !== undefined && (
+            <span title='Main-thread load (5 s window)' className={mx(cpu.load > HIGH_LOAD && 'text-error-text')}>
+              {String(Unit.Percent(cpu.load))}
+            </span>
+          )}
+        </div>
+      }
+    />
+  );
+};

--- a/packages/devtools/devtools/src/components/performance/panels/index.ts
+++ b/packages/devtools/devtools/src/components/performance/panels/index.ts
@@ -2,6 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
+export * from './CpuPanel';
 export * from './Database';
 export * from './EdgePanel';
 export * from './LoggingPanel';

--- a/packages/devtools/devtools/src/hooks/index.ts
+++ b/packages/devtools/devtools/src/hooks/index.ts
@@ -2,6 +2,7 @@
 // Copyright 2020 DXOS.org
 //
 
+export * from './useCpuLoad';
 export * from './useCredentials';
 export * from './useDevtoolsContext';
 export * from './useFeedMessages';

--- a/packages/devtools/devtools/src/hooks/useCpuLoad.ts
+++ b/packages/devtools/devtools/src/hooks/useCpuLoad.ts
@@ -55,9 +55,7 @@ export const useCpuLoad = (): CpuInfo => {
       const now = performance.now();
 
       const fps =
-        frameTimes.length > 1
-          ? Math.round(1000 / (frameTimes.reduce((acc, t) => acc + t, 0) / frameTimes.length))
-          : 0;
+        frameTimes.length > 1 ? Math.round(1000 / (frameTimes.reduce((acc, t) => acc + t, 0) / frameTimes.length)) : 0;
 
       const cutoff = now - LOAD_WINDOW_MS;
       while (longTaskEntries.length > 0 && longTaskEntries[0].start < cutoff) {

--- a/packages/devtools/devtools/src/hooks/useCpuLoad.ts
+++ b/packages/devtools/devtools/src/hooks/useCpuLoad.ts
@@ -1,0 +1,80 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { useEffect, useState } from 'react';
+
+export type CpuInfo = {
+  /** Estimated frames per second (60 = smooth, lower = main-thread pressure). */
+  frameRate: number;
+  /** Fraction of main-thread time blocked by long tasks in the last 5 s (0–1). */
+  load: number;
+};
+
+const FRAME_WINDOW = 30;
+const LOAD_WINDOW_MS = 5_000;
+
+/**
+ * Estimates browser main-thread load using rAF frame timing and PerformanceObserver longtask entries.
+ * Updates once per second.
+ */
+export const useCpuLoad = (): CpuInfo => {
+  const [info, setInfo] = useState<CpuInfo>({ frameRate: 0, load: 0 });
+
+  useEffect(() => {
+    const frameTimes: number[] = [];
+    let rafId: number;
+    let lastTs: number | undefined;
+
+    const onFrame = (ts: number) => {
+      if (lastTs !== undefined) {
+        frameTimes.push(ts - lastTs);
+        if (frameTimes.length > FRAME_WINDOW) {
+          frameTimes.shift();
+        }
+      }
+      lastTs = ts;
+      rafId = requestAnimationFrame(onFrame);
+    };
+    rafId = requestAnimationFrame(onFrame);
+
+    const longTaskEntries: { start: number; duration: number }[] = [];
+    let observer: PerformanceObserver | undefined;
+    try {
+      observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          longTaskEntries.push({ start: entry.startTime, duration: entry.duration });
+        }
+      });
+      observer.observe({ entryTypes: ['longtask'] });
+    } catch {
+      // longtask not supported in this environment.
+    }
+
+    const interval = setInterval(() => {
+      const now = performance.now();
+
+      const fps =
+        frameTimes.length > 1
+          ? Math.round(1000 / (frameTimes.reduce((acc, t) => acc + t, 0) / frameTimes.length))
+          : 0;
+
+      const cutoff = now - LOAD_WINDOW_MS;
+      while (longTaskEntries.length > 0 && longTaskEntries[0].start < cutoff) {
+        longTaskEntries.shift();
+      }
+      const busyMs = longTaskEntries.reduce((sum, entry) => sum + entry.duration, 0);
+      const load = Math.min(1, busyMs / LOAD_WINDOW_MS);
+
+      setInfo({ frameRate: fps, load });
+    }, 1_000);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      observer?.disconnect();
+      clearInterval(interval);
+    };
+  }, []);
+
+  return info;
+};


### PR DESCRIPTION
## Summary

- Adds `useCpuLoad` hook that estimates main-thread load using two browser-native signals: `requestAnimationFrame` timing (actual FPS) and `PerformanceObserver` longtask entries (fraction of time blocked over a 5-second rolling window)
- Adds `CpuPanel` component to the devtools StatsPanel, showing FPS and load % inline, with a red highlight when load exceeds 50%
- Wires the new panel between Memory and Network in the existing Stats sidebar

## Test plan

- [ ] Open Composer devtools → Stats panel
- [ ] Confirm "CPU" row appears between Memory and Network
- [ ] Row shows current FPS (should be ~60 on idle) and a load percentage (should be low on idle)
- [ ] Trigger heavy JS work (e.g. paste a large document) and confirm load % rises and turns red above 50%
- [ ] Confirm memory and network panels are unaffected

https://claude.ai/code/session_01FeurZhtRrE4qj9CeD644N8

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeurZhtRrE4qj9CeD644N8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CPU performance monitoring added to the DevTools stats panel.
  * New CPU panel shows real-time frame rate and estimated main-thread load.
  * High-load conditions are visually highlighted to draw attention to potential bottlenecks.
  * CPU panel is integrated with existing panels and preserves its open/closed state across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->