### PR TITLE
build: migrate to TypeScript native (tsgo) beta for builds

### DIFF
--- a/.moon/tasks/tag-typecheck.yml
+++ b/.moon/tasks/tag-typecheck.yml
@@ -1,7 +1,7 @@
 $schema: https://moonrepo.dev/schemas/tasks.json
 tasks:
   build:
-    command: pnpm exec tsgo --noEmit
+    command: sh -c 'if [ "${DX_USE_TSC}" = "1" ]; then pnpm exec tsc --noEmit; else pnpm exec tsgo --noEmit; fi'
     deps:
       - ^:build
       - ^:compile

--- a/.moon/tasks/tag-typecheck.yml
+++ b/.moon/tasks/tag-typecheck.yml
@@ -1,7 +1,7 @@
 $schema: https://moonrepo.dev/schemas/tasks.json
 tasks:
   build:
-    command: pnpm exec tsc --noEmit
+    command: pnpm exec tsgo --noEmit
     deps:
       - ^:build
       - ^:compile

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@types/uuid": "catalog:",
     "@types/wicg-file-system-access": "catalog:",
     "@types/zen-observable": "catalog:",
+    "@typescript/native-preview": "catalog:",
     "@vitejs/plugin-react-swc": "catalog:",
     "@vitest/browser": "catalog:",
     "@vitest/browser-playwright": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -807,6 +807,9 @@ catalogs:
     '@types/zen-observable':
       specifier: ^0.8.3
       version: 0.8.3
+    '@typescript/native-preview':
+      specifier: 7.0.0-dev.20260421.2
+      version: 7.0.0-dev.20260421.2
     '@typescript/vfs':
       specifier: ^1.6.0
       version: 1.6.2
@@ -2066,6 +2069,9 @@ importers:
       '@types/zen-observable':
         specifier: 'catalog:'
         version: 0.8.3
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260421.2
       '@vitejs/plugin-react-swc':
         specifier: 'catalog:'
         version: 4.3.0(@swc/helpers@0.5.17)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -2239,7 +2245,7 @@ importers:
         version: 16.0.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.8(oxc-resolver@11.9.0)(typescript@6.0.3)
+        version: 0.16.8(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3)
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
@@ -5290,7 +5296,7 @@ importers:
         version: 1.7.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.8(oxc-resolver@11.9.0)(typescript@6.0.3)
+        version: 0.16.8(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -28257,6 +28263,45 @@ packages:
     resolution: {integrity: sha512-ldgiJ+VAhQCfIjeOgu8Kj5nSxds0ktPOSO9p4+0VDH2R2pLvQraaM5Oen2d7NxzMCm+Sn/vJT+mv2H5u6b/3fA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==}
+    hasBin: true
+
   '@typescript/vfs@1.6.2':
     resolution: {integrity: sha512-hoBwJwcbKHmvd2QVebiytN1aELvpk9B74B4L1mFm/XT1Q/VOYAWl2vQ9AWRFtQq8zmz6enTpfTV8WRc4ATjW/g==}
     peerDependencies:
@@ -47914,6 +47959,37 @@ snapshots:
       '@typescript-eslint/types': 8.39.0
       eslint-visitor-keys: 4.2.1
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260421.2':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260421.2
+
   '@typescript/vfs@1.6.2(typescript@6.0.3)':
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
@@ -58150,7 +58226,7 @@ snapshots:
 
   robust-predicates@3.0.1: {}
 
-  rolldown-plugin-dts@0.18.3(oxc-resolver@11.9.0)(rolldown@1.0.0-beta.52)(typescript@6.0.3):
+  rolldown-plugin-dts@0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(rolldown@1.0.0-beta.52)(typescript@6.0.3):
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
@@ -58163,6 +58239,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.0-beta.52
     optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260421.2
       typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
@@ -59816,7 +59893,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.16.8(oxc-resolver@11.9.0)(typescript@6.0.3):
+  tsdown@0.16.8(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -59826,7 +59903,7 @@ snapshots:
       hookable: 5.5.3
       obug: 2.1.1
       rolldown: 1.0.0-beta.52
-      rolldown-plugin-dts: 0.18.3(oxc-resolver@11.9.0)(rolldown@1.0.0-beta.52)(typescript@6.0.3)
+      rolldown-plugin-dts: 0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(rolldown@1.0.0-beta.52)(typescript@6.0.3)
       semver: 7.7.3
       tinyexec: 1.0.2
       tinyglobby: 0.2.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -293,6 +293,7 @@ catalog:
   '@types/wtfnode': ^0.10.0
   '@types/yargs': ~16.0.1
   '@types/zen-observable': ^0.8.3
+  '@typescript/native-preview': 7.0.0-dev.20260421.2
   '@typescript/vfs': ^1.6.0
   '@uiw/codemirror-theme-vscode': ^4.25.2
   '@valtown/codemirror-continue': ^2.3.1

--- a/tools/dx-build/src/main.ts
+++ b/tools/dx-build/src/main.ts
@@ -79,9 +79,10 @@ const main = async () => {
   );
   VERBOSE && console.log('Clean complete.');
 
-  // Run tsc after cleaning.
-  VERBOSE && console.log('Running tsc...');
-  const tsc = spawnSync(USE_TSGO ? 'tsgo' : 'tsc', [], { encoding: 'utf-8' });
+  // Run the compiler after cleaning.
+  const compiler = USE_TSGO ? 'tsgo' : 'tsc';
+  VERBOSE && console.log(`Running ${compiler}...`);
+  const tsc = spawnSync(compiler, [], { encoding: 'utf-8' });
 
   // Process output to prepend repo root to relative paths.
   const cwd = process.cwd();
@@ -103,7 +104,7 @@ const main = async () => {
     process.stderr.write(processedStderr);
   }
 
-  VERBOSE && console.log(`tsc exited with status ${tsc.status}`);
+  VERBOSE && console.log(`${compiler} exited with status ${tsc.status}`);
   process.exit(tsc.status ?? 1);
 };
 

--- a/tools/dx-build/src/main.ts
+++ b/tools/dx-build/src/main.ts
@@ -10,7 +10,7 @@ import { dirname, join, relative, resolve } from 'node:path';
 import ts from 'typescript';
 
 const VERBOSE = false,
-  USE_TSGO = false;
+  USE_TSGO = process.env.DX_USE_TSC !== '1';
 
 const main = async () => {
   // Find and parse tsconfig.json.


### PR DESCRIPTION
## Summary

- Adds `@typescript/native-preview` (`tsgo`, the Go-based TS compiler) to the workspace catalog and pulls it in as a root devDependency so the `tsgo` binary is on `PATH` for every package.
- Flips `dx-build` (the per-package build wrapper invoked by every `tag-ts-build` / `tag-ts-compile` moon task) to spawn `tsgo` instead of `tsc`.
- Switches the `typecheck` moon task to `tsgo --noEmit` as well.
- Both build and typecheck respect a `DX_USE_TSC=1` env var as a fallback to the classic `tsc` if tsgo regresses.
- Verified by running `moon exec --on-failure continue :build` across the entire monorepo — all 447 build tasks succeed under `tsgo`.

Pinned to `7.0.0-dev.20260421.2` (the current `beta` dist-tag) for reproducibility.

## Test plan

- [x] `moon run keys:build` succeeds with `tsgo` on a leaf package.
- [x] `moon exec --on-failure continue :build` succeeds across the monorepo (447/447 tasks).
- [x] `moon run composer-app:build` (typecheck) succeeds with the new conditional command.
- [x] CI **Check** workflow passes on this branch.
- [ ] Set `DX_USE_TSC=1` locally to verify the fallback path still works if tsgo regresses.

https://claude.ai/code/session_01Tph8u6XT7orYKREX3GW3DB