### PR TITLE
fix(plugin-assistant): keep multi-line tag widgets intact and align editor automerge tests

### DIFF
--- a/packages/core/ai/src/AiParser.test.ts
+++ b/packages/core/ai/src/AiParser.test.ts
@@ -265,6 +265,35 @@ describe('parser', () => {
       }),
     );
 
+    // Repro: third <reasoning> block in a chat doc — multi-line content with newlines,
+    // list items, single + double quotes, mixed with `<status>` and `<toolCall/>` tags
+    // around it. Verify all three reasoning blocks are preserved verbatim.
+    it.effect(
+      'multi-line reasoning content with quotes and list items is preserved',
+      Effect.fn(function* ({ expect }) {
+        const r1 = '<reasoning>The user wants me to summarize.</reasoning>';
+        const r2 = '<reasoning>The magazine has 10 posts already curated.</reasoning>';
+        const r3 = [
+          '<reasoning>The magazine has 10 posts, but several are duplicates. Unique articles:',
+          '1. "FBI affidavit quotes White House press dinner shooting suspect expressing rage at \'a pedophile, rapist and traitor\' – US politics live" - About Cole Allen.',
+          '2. "Australia news live: UK inquiry says \'cracks already beginning to show\' on Aukus" - Live blog.',
+          '5. "\'Shortcomings and failures\' could sink Aukus nuclear submarines plan" - UK inquiry warns.</reasoning>',
+        ].join('\n');
+        const input = [r1, '<status>Loading…</status>', r2, '<status>OK</status>', r3, 'Done.'].join('\n');
+
+        const result = yield* makeInputStream([...text(splitByCharacter(input))])
+          .pipe(AiParser.parseResponse())
+          .pipe(Stream.runCollect)
+          .pipe(Effect.map(Chunk.toArray));
+
+        const reasonings = result.filter((b) => b._tag === 'text' && b.text.startsWith('<reasoning>'));
+        expect(reasonings).toHaveLength(3);
+        expect(reasonings[0]).toEqual({ _tag: 'text', text: r1 });
+        expect(reasonings[1]).toEqual({ _tag: 'text', text: r2 });
+        expect(reasonings[2]).toEqual({ _tag: 'text', text: r3 });
+      }),
+    );
+
     it.effect(
       'works when every character is streamed individually',
       Effect.fn(function* ({ expect }) {

--- a/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
+++ b/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
@@ -200,9 +200,9 @@ ChatToolbar.displayName = CHAT_TOOLBAR_NAME;
 
 const CHAT_VIEWPORT_NAME = 'Chat.Viewport';
 
-type ChatViewportProps = {};
+type ChatContentProps = {};
 
-const ChatViewport = composable<HTMLDivElement, ChatViewportProps>(({ children, ...props }, forwardedRef) => {
+const ChatContent = composable<HTMLDivElement, ChatContentProps>(({ children, ...props }, forwardedRef) => {
   return (
     <div {...composableProps(props, { classNames: 'dx-expander flex flex-col' })} ref={forwardedRef}>
       {children}
@@ -210,7 +210,7 @@ const ChatViewport = composable<HTMLDivElement, ChatViewportProps>(({ children, 
   );
 });
 
-ChatViewport.displayName = CHAT_VIEWPORT_NAME;
+ChatContent.displayName = CHAT_VIEWPORT_NAME;
 
 //
 // Thread
@@ -274,19 +274,16 @@ const ChatThread = (props: ChatThreadProps) => {
   }
 
   return (
-    <div role='none' className='dx-container relative'>
-      <NaturalChatThread
-        {...props}
-        identity={identity}
-        messages={messages}
-        error={error}
-        debug={debug}
-        extensions={extensions}
-        onEvent={handleEvent}
-        ref={controllerRef}
-      />
-      <ChatStreamStatus classNames='absolute left-0 bottom-2 px-3 rounded-sm bg-group-surface' />
-    </div>
+    <NaturalChatThread
+      {...props}
+      identity={identity}
+      messages={messages}
+      error={error}
+      debug={debug}
+      extensions={extensions}
+      onEvent={handleEvent}
+      ref={controllerRef}
+    />
   );
 };
 
@@ -521,9 +518,10 @@ const useChatKeymapExtensions = ({
 export const Chat = {
   Root: ChatRoot,
   Toolbar: ChatToolbar,
-  Viewport: ChatViewport,
+  Content: ChatContent,
   Thread: ChatThread,
+  Status: ChatStreamStatus,
   Prompt: ChatPrompt,
 };
 
-export type { ChatRootProps, ChatToolbarProps, ChatViewportProps, ChatThreadProps, ChatPromptProps, ChatEvent };
+export type { ChatRootProps, ChatToolbarProps, ChatContentProps, ChatThreadProps, ChatPromptProps, ChatEvent };

--- a/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
+++ b/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
@@ -195,10 +195,10 @@ const ChatToolbar = composable<HTMLDivElement, ChatToolbarProps>(
 ChatToolbar.displayName = CHAT_TOOLBAR_NAME;
 
 //
-// Viewport
+// Content
 //
 
-const CHAT_VIEWPORT_NAME = 'Chat.Viewport';
+const CHAT_CONTENT_NAME = 'Chat.Content';
 
 type ChatContentProps = {};
 
@@ -210,7 +210,7 @@ const ChatContent = composable<HTMLDivElement, ChatContentProps>(({ children, ..
   );
 });
 
-ChatContent.displayName = CHAT_VIEWPORT_NAME;
+ChatContent.displayName = CHAT_CONTENT_NAME;
 
 //
 // Thread

--- a/packages/plugins/plugin-assistant/src/components/Chat/ChatStreamStatus.tsx
+++ b/packages/plugins/plugin-assistant/src/components/Chat/ChatStreamStatus.tsx
@@ -15,7 +15,7 @@ import { type ChatRequestTiming, useChatContext } from './context';
 const CHAT_STREAM_STATUS_NAME = 'Chat.StreamStatus';
 const TICK_MS = 1_000;
 
-export type ChatStreamStatusProps = ThemedClassName;
+export type ChatStreamStatusProps = ThemedClassName<{ icon?: boolean }>;
 
 /**
  * Live status pill rendered at the bottom of the chat thread.
@@ -30,7 +30,7 @@ export type ChatStreamStatusProps = ThemedClassName;
  * - last completed turn's output token count (from the most recent `stats` content block)
  * - cumulative session total tokens across all `stats` content blocks
  */
-export const ChatStreamStatus = ({ classNames }: ChatStreamStatusProps) => {
+export const ChatStreamStatus = ({ classNames, icon }: ChatStreamStatusProps) => {
   // Read `messages` from the chat context (combines `useQuery(queue)` + the processor's
   // pending atom) rather than `processor.messages` directly — the latter only contains
   // blocks streamed via the ephemeral `PartialBlock` channel, while finalized blocks
@@ -60,7 +60,7 @@ export const ChatStreamStatus = ({ classNames }: ChatStreamStatusProps) => {
 
   return (
     <ChatStatus.Root defaultRunning={false} classNames={['py-2 gap-2 text-sm', classNames]}>
-      {false && (
+      {icon && (
         <ChatStatus.Icon>
           <Matrix
             classNames='w-5 h-5'
@@ -82,13 +82,13 @@ export const ChatStreamStatus = ({ classNames }: ChatStreamStatusProps) => {
           )}
           {lastOutputTokens != null && (
             <>
-              <ChatStatus.Separator />
+              {requestTiming && <ChatStatus.Separator />}
               <ChatStatus.Text>↓ {Unit.Thousand(lastOutputTokens).toString()}</ChatStatus.Text>
             </>
           )}
           {sessionTotalTokens > 0 && (
             <>
-              <ChatStatus.Separator />
+              {(requestTiming || lastOutputTokens != null) && <ChatStatus.Separator />}
               <ChatStatus.Text>Σ {Unit.Thousand(sessionTotalTokens).toString()}</ChatStatus.Text>
             </>
           )}
@@ -110,11 +110,12 @@ const Elapsed = ({ timing }: { timing: ChatRequestTiming }) => {
     if (!isRunning) {
       return;
     }
+
     const id = setInterval(() => setNow(Date.now()), TICK_MS);
     return () => clearInterval(id);
   }, [isRunning]);
-  const elapsedMs = (timing.endedAt ?? now) - timing.startedAt;
-  return <>{formatElapsed(elapsedMs)}</>;
+
+  return <>{formatElapsed((timing.endedAt ?? now) - timing.startedAt)}</>;
 };
 
 const isStats = (block: ContentBlock.Any): block is ContentBlock.Stats => block._tag === 'stats';

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/ChatThread.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/ChatThread.tsx
@@ -18,7 +18,7 @@ import { MessageSyncer } from './sync';
 const defaultOptions: MarkdownStreamProps['options'] = {
   autoScroll: true,
   cursor: false,
-  fader: true,
+  fader: false,
   typewriter: true,
 };
 

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/registry.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/registry.tsx
@@ -25,11 +25,23 @@ import {
 /**
  * Custom XML tags registry.
  *
- * NOTE: `<prompt>` is intentionally NOT registered here. It is rendered via mark + line
- * decorations (`xmlBlockDecoration`) in MarkdownStream so the prompt text remains part of
- * the document and can be highlighted by `xmlFormatting`.
+ * NOTE: `<prompt>` has no widget — it is rendered via mark + line decorations
+ * (`xmlBlockDecoration`) in MarkdownStream so the prompt text remains part of the document
+ * and can be highlighted by `xmlFormatting`. It is still listed here so the markdown block
+ * parser (`xmlBlockParsers`) knows to keep `<prompt>...</prompt>` as a single HTMLBlock
+ * — otherwise an unregistered prompt opens a Paragraph that lazy-continues into the
+ * following lines and breaks parsing of subsequent multi-line tags (e.g. a `<reasoning>`
+ * block whose content contains an ordered list).
  */
 export const componentRegistry: XmlWidgetRegistry = {
+  //
+  // Block-only (no widget — see note above).
+  //
+
+  prompt: {
+    block: true,
+  },
+
   //
   // DOM Widgets
   //

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/ReasoningWidget.ts
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/ReasoningWidget.ts
@@ -38,7 +38,7 @@ export class ReasoningWidget extends WidgetType {
   }
 
   override toDOM() {
-    const root = Domino.of('div')
+    return Domino.of('div')
       .classNames(styles.padding)
       .append(
         Domino.of('div')
@@ -56,8 +56,6 @@ export class ReasoningWidget extends WidgetType {
             Domino.of('div').attributes({ 'data-id': this.#pos }),
           ),
       ).root;
-
-    return root;
   }
 
   override updateDOM(dom: HTMLElement) {

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/SuggestionWidget.ts
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/widgets/SuggestionWidget.ts
@@ -19,7 +19,7 @@ export class SuggestionWidget extends WidgetType {
   }
 
   override toDOM() {
-    // NOTE: Container must have `dx-size-container` to support cqi.
+    // NOTE: Container must have `dx-inline-size-container` (or `dx-size-container`) to support cqi.
     return Domino.of('span')
       .classNames(mx('inline-flex max-w-[calc(100cqi-8px)] my-1 pe-2 overflow-hidden'))
       .append(

--- a/packages/plugins/plugin-assistant/src/containers/ChatContainer/ChatContainer.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/ChatContainer/ChatContainer.tsx
@@ -76,9 +76,16 @@ export const ChatContainer = forwardRef<HTMLDivElement, ChatContainerProps>((pro
           <ChatComponent.Toolbar classNames='dx-document' attendableId={attendableId} companionTo={companionTo} />
         </Panel.Toolbar>
         <Panel.Content>
-          <ChatComponent.Viewport>
-            <ChatComponent.Thread />
-            <div role='none' className='dx-document p-4'>
+          <ChatComponent.Content>
+            <div role='none' className='dx-container relative'>
+              <ChatComponent.Thread />
+              <div role='none' className='absolute bottom-2 left-0 right-0'>
+                <div role='none' className='dx-document px-4'>
+                  <ChatComponent.Status classNames='px-3 rounded-sm bg-group-surface' />
+                </div>
+              </div>
+            </div>
+            <div role='none' className='dx-document px-4 pb-4'>
               <ChatComponent.Prompt
                 {...chatProps}
                 outline
@@ -87,7 +94,7 @@ export const ChatContainer = forwardRef<HTMLDivElement, ChatContainerProps>((pro
                 onOnlineChange={setOnline}
               />
             </div>
-          </ChatComponent.Viewport>
+          </ChatComponent.Content>
         </Panel.Content>
       </Panel.Root>
     </ChatComponent.Root>

--- a/packages/stories/stories-assistant/src/components/ChatModule.tsx
+++ b/packages/stories/stories-assistant/src/components/ChatModule.tsx
@@ -41,7 +41,7 @@ export const ChatModule = ({ space }: ComponentProps) => {
         </Panel.Toolbar>
         <Panel.Content asChild>
           {/* TODO(burdon): Remove relative. */}
-          <Chat.Viewport classNames='relative'>
+          <Chat.Content classNames='relative'>
             <Toolbar.Root>
               <Toolbar.Text classNames='text-subdued'>{chat?.name}</Toolbar.Text>
               <Popover.Root>
@@ -65,7 +65,7 @@ export const ChatModule = ({ space }: ComponentProps) => {
               online={online}
               onOnlineChange={setOnline}
             />
-          </Chat.Viewport>
+          </Chat.Content>
         </Panel.Content>
       </Panel.Root>
     </Chat.Root>

--- a/packages/ui/react-ui-markdown/src/MarkdownStream/MarkdownStream.tsx
+++ b/packages/ui/react-ui-markdown/src/MarkdownStream/MarkdownStream.tsx
@@ -264,6 +264,7 @@ const useMarkdownStreamTextEditor = (
         }),
         createThemeExtensions({
           slots: documentSlots,
+          scrollbarThin: true,
           syntaxHighlighting: true,
           themeMode,
         }),

--- a/packages/ui/ui-editor/src/defaults.ts
+++ b/packages/ui/ui-editor/src/defaults.ts
@@ -22,8 +22,11 @@ export const documentSlots: ThemeExtensionsOptions['slots'] = {
      * NOTE: Max width - 4rem = 2rem left/right margin (or 2rem gutter plus 1rem left/right margin).
      */
     className: mx(
-      // NOTE: Container for widget sizing (must have `max-w-[100cqi]`).
-      'dx-size-container',
+      // Inline-size container for widget sizing (children use `max-w-[100cqi]`).
+      // NOTE: Use inline-size, not full size containment — `container-type: size` on the
+      // editor content breaks CodeMirror's viewport measurement, leaving blank gaps during
+      // scroll until a click forces a re-measure.
+      'dx-inline-size-container',
       // Wider margin for web (vs. mobile).
       'pointer-fine:max-w-[min(50rem,100%-4rem)] pointer-coarse:max-w-[min(50rem,100%-2rem)]',
       'mx-auto! w-full',

--- a/packages/ui/ui-editor/src/extensions/automerge/automerge.test.tsx
+++ b/packages/ui/ui-editor/src/extensions/automerge/automerge.test.tsx
@@ -2,22 +2,42 @@
 // Copyright 2024 DXOS.org
 //
 
-import { type DocHandle, Repo } from '@automerge/automerge-repo';
+import { type ChangeFn, type ChangeOptions, type Doc, type Heads } from '@automerge/automerge';
+import { type DocHandle, Repo, decodeHeads, encodeHeads } from '@automerge/automerge-repo';
 import { EditorState } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { render, screen } from '@testing-library/react';
 import React, { type FC, useEffect, useRef, useState } from 'react';
 import { describe, test } from 'vitest';
 
+import { type IDocHandle } from '@dxos/echo-db';
 import { getDeep } from '@dxos/util';
 
 import { automerge } from './automerge';
 
+// Adapter: `IDocHandle` (used by `DocHandleProxy` in production) takes raw `Heads` (hex)
+// at `changeAt`, but automerge-repo's `DocHandle.changeAt` expects bs58check-encoded
+// `UrlHeads`. Encode on the way in, decode on the way out so the test's repo-backed
+// handle satisfies the extension's `IDocHandle` contract.
+const adaptRepoHandle = <T,>(handle: DocHandle<T>): IDocHandle<T> => ({
+  doc: () => handle.doc() as Doc<T> | undefined,
+  change: (callback: ChangeFn<T>, options?: ChangeOptions<T>) =>
+    options ? handle.change(callback, options) : handle.change(callback),
+  changeAt: (heads: Heads, callback: ChangeFn<T>, options?: ChangeOptions<T>): Heads | undefined => {
+    const encoded = options
+      ? handle.changeAt(encodeHeads(heads), callback, options)
+      : handle.changeAt(encodeHeads(heads), callback);
+    return encoded ? decodeHeads(encoded) : undefined;
+  },
+  addListener: (event, listener) => handle.on(event, listener),
+  removeListener: (event, listener) => handle.off(event, listener),
+});
+
+const path = ['text'];
+
 type TestObject = {
   text: string;
 };
-
-const path = ['text'];
 
 class Generator {
   constructor(private readonly _handle: DocHandle<TestObject>) {}
@@ -33,8 +53,7 @@ const Test: FC<{ handle: DocHandle<TestObject>; generator: Generator }> = ({ han
   const [view, setView] = useState<EditorView>();
   useEffect(() => {
     const extensions = [
-      // TODO(mykola): Fix types.
-      automerge({ handle: handle as any, path }),
+      automerge({ handle: adaptRepoHandle(handle), path }),
       EditorView.updateListener.of((update) => {
         if (view.state.doc.toString() === 'hello!') {
           // Update editor.

--- a/packages/ui/ui-editor/src/extensions/automerge/automerge.test.tsx
+++ b/packages/ui/ui-editor/src/extensions/automerge/automerge.test.tsx
@@ -58,19 +58,20 @@ const Test: FC<{ handle: DocHandle<TestObject>; generator: Generator }> = ({ han
   return <div ref={ref} data-testid='editor' />;
 };
 
+// TODO(burdon): Test history/undo.
+// TODO(burdon): https://testing-library.com/docs/react-testing-library/example-intro/
+
 describe('Automerge', () => {
   test('basic sync', ({ expect }) => {
     const repo = new Repo({ network: [] });
     const handle = repo.create<TestObject>();
     const generator = new Generator(handle);
     render(<Test handle={handle} generator={generator} />);
+
     const editor = screen.getByTestId('editor');
     expect(editor.textContent).toBe('');
 
     generator.update('hello!');
     expect(editor.textContent).toBe('hello world!');
   });
-
-  // TODO(burdon): Test history/undo.
-  // TODO(burdon): https://testing-library.com/docs/react-testing-library/example-intro/
 });

--- a/packages/ui/ui-editor/src/extensions/automerge/update-automerge.ts
+++ b/packages/ui/ui-editor/src/extensions/automerge/update-automerge.ts
@@ -5,6 +5,7 @@
 //
 
 import { next as A, type Heads } from '@automerge/automerge';
+import { decodeHeads, encodeHeads } from '@automerge/automerge-repo';
 import { type EditorState, type StateField, type Text, type Transaction } from '@codemirror/state';
 
 import { type IDocHandle } from '@dxos/echo-db';
@@ -32,7 +33,9 @@ export const updateAutomerge = (
     return undefined;
   }
 
-  const newHeads = handle.changeAt(lastHeads, (doc: A.Doc<unknown>) => {
+  // `DocHandle.changeAt` expects bs58check-encoded `UrlHeads`, but our state stores raw
+  // `Heads` (hex) from `A.getHeads()`. Encode on the way in, decode on the way out.
+  const encodedNewHeads = handle.changeAt(encodeHeads(lastHeads), (doc: A.Doc<unknown>) => {
     const invertedTransactions: { from: number; del: number; insert: Text }[] = [];
     for (const tr of transactions) {
       tr.changes.iterChanges((fromA, toA, _fromB, _toB, insert) => {
@@ -46,5 +49,5 @@ export const updateAutomerge = (
     });
   });
 
-  return newHeads ?? undefined;
+  return encodedNewHeads ? decodeHeads(encodedNewHeads) : undefined;
 };

--- a/packages/ui/ui-editor/src/extensions/automerge/update-automerge.ts
+++ b/packages/ui/ui-editor/src/extensions/automerge/update-automerge.ts
@@ -5,7 +5,6 @@
 //
 
 import { next as A, type Heads } from '@automerge/automerge';
-import { decodeHeads, encodeHeads } from '@automerge/automerge-repo';
 import { type EditorState, type StateField, type Text, type Transaction } from '@codemirror/state';
 
 import { type IDocHandle } from '@dxos/echo-db';
@@ -33,9 +32,7 @@ export const updateAutomerge = (
     return undefined;
   }
 
-  // `DocHandle.changeAt` expects bs58check-encoded `UrlHeads`, but our state stores raw
-  // `Heads` (hex) from `A.getHeads()`. Encode on the way in, decode on the way out.
-  const encodedNewHeads = handle.changeAt(encodeHeads(lastHeads), (doc: A.Doc<unknown>) => {
+  const newHeads = handle.changeAt(lastHeads, (doc: A.Doc<unknown>) => {
     const invertedTransactions: { from: number; del: number; insert: Text }[] = [];
     for (const tr of transactions) {
       tr.changes.iterChanges((fromA, toA, _fromB, _toB, insert) => {
@@ -49,5 +46,5 @@ export const updateAutomerge = (
     });
   });
 
-  return encodedNewHeads ? decodeHeads(encodedNewHeads) : undefined;
+  return newHeads ?? undefined;
 };

--- a/packages/ui/ui-editor/src/extensions/factories.test.ts
+++ b/packages/ui/ui-editor/src/extensions/factories.test.ts
@@ -1,0 +1,60 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { markdown, markdownLanguage, insertNewlineContinueMarkup } from '@codemirror/lang-markdown';
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { describe, test } from 'vitest';
+
+import { createBasicExtensions } from './factories';
+
+describe('createBasicExtensions readOnly', () => {
+  test('drops doc-changing transactions when readOnly is true', ({ expect }) => {
+    const state = EditorState.create({
+      doc: 'hello',
+      extensions: [createBasicExtensions({ readOnly: true })],
+    });
+    const tr = state.update({ changes: { from: state.doc.length, insert: ' world' } });
+    expect(tr.state.doc.toString()).toBe('hello');
+  });
+
+  test('selection-only transactions still apply when readOnly', ({ expect }) => {
+    const state = EditorState.create({
+      doc: 'hello',
+      extensions: [createBasicExtensions({ readOnly: true })],
+    });
+    const tr = state.update({ selection: EditorSelection.cursor(2) });
+    expect(tr.state.selection.main.head).toBe(2);
+  });
+
+  test('doc-changing transactions apply normally when readOnly is false', ({ expect }) => {
+    const state = EditorState.create({
+      doc: 'hello',
+      extensions: [createBasicExtensions({ readOnly: false })],
+    });
+    const tr = state.update({ changes: { from: state.doc.length, insert: ' world' } });
+    expect(tr.state.doc.toString()).toBe('hello world');
+  });
+
+  // Regression: in MarkdownStream `readOnly: true` must also block the markdown extension's
+  // Enter handler (`insertNewlineContinueMarkup`), which programmatically dispatches a list
+  // continuation regardless of the readOnly facet.
+  test('markdown insertNewlineContinueMarkup is suppressed when readOnly', ({ expect }) => {
+    const doc = '- one\n- two';
+    const state = EditorState.create({
+      doc,
+      selection: EditorSelection.cursor(doc.length),
+      extensions: [createBasicExtensions({ readOnly: true }), markdown({ base: markdownLanguage })],
+    });
+    let dispatched: any;
+    insertNewlineContinueMarkup({
+      state,
+      dispatch: (tr) => {
+        dispatched = tr;
+      },
+    });
+    if (dispatched) {
+      expect(dispatched.state.doc.toString()).toBe(doc);
+    }
+  });
+});

--- a/packages/ui/ui-editor/src/extensions/factories.ts
+++ b/packages/ui/ui-editor/src/extensions/factories.ts
@@ -143,6 +143,10 @@ export const createBasicExtensions = (propsProp?: BasicExtensionsOptions): Exten
     props.lineWrapping && EditorView.lineWrapping,
     props.placeholder && placeholder(props.placeholder),
     props.readOnly !== undefined && EditorState.readOnly.of(props.readOnly),
+    // `EditorState.readOnly` is advisory — CodeMirror doesn't auto-reject doc-changing
+    // transactions. Some extensions (e.g. `@codemirror/lang-markdown`'s Enter handler that
+    // continues a list) dispatch programmatic edits regardless. Drop them here.
+    props.readOnly && EditorState.transactionFilter.of((tr) => (tr.docChanged ? [] : tr)),
     props.scrollPastEnd && scrollPastEnd(),
     props.tabbable && tabbable,
     props.tabSize && EditorState.tabSize.of(props.tabSize),

--- a/packages/ui/ui-editor/src/extensions/factories.ts
+++ b/packages/ui/ui-editor/src/extensions/factories.ts
@@ -183,6 +183,7 @@ export const createBasicExtensions = (propsProp?: BasicExtensionsOptions): Exten
 export type ThemeExtensionsOptions = {
   monospace?: boolean;
   themeMode?: ThemeMode;
+  /** When true, sets `--scrollbar-width: 4px` on the scroll container for a thinner scrollbar. */
   scrollbarThin?: boolean;
   slots?: {
     editor?: {

--- a/packages/ui/ui-editor/src/extensions/factories.ts
+++ b/packages/ui/ui-editor/src/extensions/factories.ts
@@ -179,6 +179,7 @@ export const createBasicExtensions = (propsProp?: BasicExtensionsOptions): Exten
 export type ThemeExtensionsOptions = {
   monospace?: boolean;
   themeMode?: ThemeMode;
+  scrollbarThin?: boolean;
   slots?: {
     editor?: {
       className?: string;
@@ -217,9 +218,10 @@ export const defaultStyles = {
  */
 export const createThemeExtensions = ({
   monospace,
-  themeMode,
+  scrollbarThin,
   slots: slotsProp,
   syntaxHighlighting: syntaxHighlightingProp,
+  themeMode,
 }: ThemeExtensionsOptions = {}): Extension => {
   const slots: NonNullable<ThemeExtensionsOptions['slots']> = defaultsDeep({}, slotsProp, defaultThemeSlots);
   return [
@@ -230,12 +232,15 @@ export const createThemeExtensions = ({
       syntaxHighlighting(HighlightStyle.define(themeMode === 'dark' ? defaultStyles.dark : defaultStyles.light)),
     slots.editor?.className && EditorView.editorAttributes.of({ class: slots.editor.className }),
     slots.content?.className && EditorView.contentAttributes.of({ class: slots.content.className }),
-    slots.scroller?.className &&
+    (slots.scroller?.className || scrollbarThin) &&
       ViewPlugin.fromClass(
         class {
           constructor(view: EditorView) {
             if (slots.scroller?.className) {
               view.scrollDOM.classList.add(...slots.scroller.className.split(/\s+/));
+            }
+            if (scrollbarThin) {
+              view.scrollDOM.style.setProperty('--scrollbar-width', '4px');
             }
           }
         },

--- a/packages/ui/ui-editor/src/extensions/tags/testing/text.md
+++ b/packages/ui/ui-editor/src/extensions/tags/testing/text.md
@@ -1,0 +1,35 @@
+<prompt>summarize the posts</prompt>
+<reasoning>The user wants me to summarize the posts related to the magazine in context. Let me first load the magazine object to understand its structure, and then list the candidate posts.</reasoning>
+<status>Loading the magazine and listing candidate posts…</status>
+<toolCall id="toolu_01WMMcsaHxTvuGxcMh2CkfL4" />
+<toolCall id="toolu_01CxWNvXZ4jExfLEJumfMzqm" />
+<reasoning>The magazine has 10 posts already curated, and there are no uncurated candidate posts. The user wants me to summarize the posts that are already in the magazine. Let me load them.</reasoning>
+<status>No uncurated candidates — loading the 10 posts already in the magazine…</status>
+<toolCall id="toolu_0152ftz33GL5M1DDi8GGDHi2" />
+<reasoning>The magazine has 10 posts, but several are duplicates. Let me deduplicate by title/guid and summarize the unique articles. Unique articles:
+1. "FBI affidavit quotes White House press dinner shooting suspect expressing rage at 'a pedophile, rapist and traitor' – US politics live" - About Cole Allen's manifesto and charges, plus King Charles visiting Trump at the White House.
+2. "Australia news live: UK inquiry says 'cracks already beginning to show' on Aukus; search for missing five-year-old near Alice Springs grows" - Live blog covering Aukus inquiry, David Brat nominated as ambassador to Australia, fuel reserve crisis. 
+3. "Rebel Wilson gives evidence in high-profile defamation case against star of directorial debut" - Rebel Wilson testifying in defamation case brought by Charlotte MacInnes.
+4. "Baby on board: US woman gives birth on Delta flight" - Ashley Blair delivered her baby aboard a Delta flight traveling from Atlanta to Portland.
+5. "'Shortcomings and failures' could sink Aukus nuclear submarines plan, UK inquiry warns" - A UK House of Commons defence committee report identifies significant funding gaps threatening the Aukus submarine program.</reasoning>
+Here's a summary of the **5 unique articles** currently in the magazine (some posts are duplicates):
+
+1. **FBI affidavit quotes White House press dinner shooting suspect**
+   Federal charges filed against Cole Allen include excerpts from a manifesto he emailed to family and friends before attempting to charge into the White House Correspondents' Dinner. Separately, King Charles and Queen Camilla visited Donald Trump at the White House for tea and a beehive tour.
+
+2. **Australia news live: Aukus 'cracks' & missing child search**
+   A UK House of Commons inquiry reveals "shortcomings and failings" in the Aukus submarine program. Also covered: David Brat nominated as the next US ambassador to Australia, and a push to extend Australia's fuel reserves from 30 to 60 days amid rising security concerns.
+
+3. **Rebel Wilson testifies in defamation case**
+   Hollywood star Rebel Wilson gave evidence in a defamation lawsuit brought by Charlotte MacInnes, the lead actor of Wilson's directorial debut *The Deb*. The case centres on claims MacInnes confided to Wilson about being uncomfortable with a bathing request from a colleague.
+
+4. **Baby born on Delta flight**
+   Passenger Ashley Blair went into labor on a packed Delta flight from Atlanta to Portland. Two off-duty EMTs on the plane delivered baby Brielle Renee just before landing — using a shoelace as a tourniquet for an IV. Mother and baby were healthy on arrival.
+
+5. **UK inquiry warns Aukus submarine plan at risk**
+   A detailed House of Commons defence committee report finds UK submarine funding has "cracks already beginning to show," with chronic under-investment in shipbuilding and only one submarine yard (Barrow-in-Furness) already behind schedule. Australia has committed A$4.6 billion to help, but the committee warns political drift could derail the entire program.
+<prompt>how many articles are there?</prompt>
+<reasoning>The user is asking about the number of articles. From my previous analysis, there are 10 posts in the magazine, but only 5 unique articles (the rest are duplicates). Let me answer based on what I already know.</reasoning>
+There are **10 posts** in the magazine, but only **5 unique articles** — each article appears twice (as duplicates from the two feeds).
+<prompt>say your name inside an xml tag</prompt>
+<name>Kai</name>

--- a/packages/ui/ui-editor/src/extensions/tags/testing/text.md
+++ b/packages/ui/ui-editor/src/extensions/tags/testing/text.md
@@ -7,29 +7,30 @@
 <status>No uncurated candidates — loading the 10 posts already in the magazine…</status>
 <toolCall id="toolu_0152ftz33GL5M1DDi8GGDHi2" />
 <reasoning>The magazine has 10 posts, but several are duplicates. Let me deduplicate by title/guid and summarize the unique articles. Unique articles:
+
 1. "FBI affidavit quotes White House press dinner shooting suspect expressing rage at 'a pedophile, rapist and traitor' – US politics live" - About Cole Allen's manifesto and charges, plus King Charles visiting Trump at the White House.
-2. "Australia news live: UK inquiry says 'cracks already beginning to show' on Aukus; search for missing five-year-old near Alice Springs grows" - Live blog covering Aukus inquiry, David Brat nominated as ambassador to Australia, fuel reserve crisis. 
+2. "Australia news live: UK inquiry says 'cracks already beginning to show' on Aukus; search for missing five-year-old near Alice Springs grows" - Live blog covering Aukus inquiry, David Brat nominated as ambassador to Australia, fuel reserve crisis.
 3. "Rebel Wilson gives evidence in high-profile defamation case against star of directorial debut" - Rebel Wilson testifying in defamation case brought by Charlotte MacInnes.
 4. "Baby on board: US woman gives birth on Delta flight" - Ashley Blair delivered her baby aboard a Delta flight traveling from Atlanta to Portland.
 5. "'Shortcomings and failures' could sink Aukus nuclear submarines plan, UK inquiry warns" - A UK House of Commons defence committee report identifies significant funding gaps threatening the Aukus submarine program.</reasoning>
-Here's a summary of the **5 unique articles** currently in the magazine (some posts are duplicates):
+   Here's a summary of the **5 unique articles** currently in the magazine (some posts are duplicates):
 
-1. **FBI affidavit quotes White House press dinner shooting suspect**
+6. **FBI affidavit quotes White House press dinner shooting suspect**
    Federal charges filed against Cole Allen include excerpts from a manifesto he emailed to family and friends before attempting to charge into the White House Correspondents' Dinner. Separately, King Charles and Queen Camilla visited Donald Trump at the White House for tea and a beehive tour.
 
-2. **Australia news live: Aukus 'cracks' & missing child search**
+7. **Australia news live: Aukus 'cracks' & missing child search**
    A UK House of Commons inquiry reveals "shortcomings and failings" in the Aukus submarine program. Also covered: David Brat nominated as the next US ambassador to Australia, and a push to extend Australia's fuel reserves from 30 to 60 days amid rising security concerns.
 
-3. **Rebel Wilson testifies in defamation case**
-   Hollywood star Rebel Wilson gave evidence in a defamation lawsuit brought by Charlotte MacInnes, the lead actor of Wilson's directorial debut *The Deb*. The case centres on claims MacInnes confided to Wilson about being uncomfortable with a bathing request from a colleague.
+8. **Rebel Wilson testifies in defamation case**
+   Hollywood star Rebel Wilson gave evidence in a defamation lawsuit brought by Charlotte MacInnes, the lead actor of Wilson's directorial debut _The Deb_. The case centres on claims MacInnes confided to Wilson about being uncomfortable with a bathing request from a colleague.
 
-4. **Baby born on Delta flight**
+9. **Baby born on Delta flight**
    Passenger Ashley Blair went into labor on a packed Delta flight from Atlanta to Portland. Two off-duty EMTs on the plane delivered baby Brielle Renee just before landing — using a shoelace as a tourniquet for an IV. Mother and baby were healthy on arrival.
 
-5. **UK inquiry warns Aukus submarine plan at risk**
-   A detailed House of Commons defence committee report finds UK submarine funding has "cracks already beginning to show," with chronic under-investment in shipbuilding and only one submarine yard (Barrow-in-Furness) already behind schedule. Australia has committed A$4.6 billion to help, but the committee warns political drift could derail the entire program.
-<prompt>how many articles are there?</prompt>
-<reasoning>The user is asking about the number of articles. From my previous analysis, there are 10 posts in the magazine, but only 5 unique articles (the rest are duplicates). Let me answer based on what I already know.</reasoning>
-There are **10 posts** in the magazine, but only **5 unique articles** — each article appears twice (as duplicates from the two feeds).
-<prompt>say your name inside an xml tag</prompt>
-<name>Kai</name>
+10. **UK inquiry warns Aukus submarine plan at risk**
+    A detailed House of Commons defence committee report finds UK submarine funding has "cracks already beginning to show," with chronic under-investment in shipbuilding and only one submarine yard (Barrow-in-Furness) already behind schedule. Australia has committed A$4.6 billion to help, but the committee warns political drift could derail the entire program.
+    <prompt>how many articles are there?</prompt>
+    <reasoning>The user is asking about the number of articles. From my previous analysis, there are 10 posts in the magazine, but only 5 unique articles (the rest are duplicates). Let me answer based on what I already know.</reasoning>
+    There are **10 posts** in the magazine, but only **5 unique articles** — each article appears twice (as duplicates from the two feeds).
+    <prompt>say your name inside an xml tag</prompt>
+    <name>Kai</name>

--- a/packages/ui/ui-editor/src/extensions/tags/testing/text.txt
+++ b/packages/ui/ui-editor/src/extensions/tags/testing/text.txt
@@ -1,0 +1,36 @@
+<prompt>summarize the posts</prompt>
+<reasoning>The user wants me to summarize the posts related to the magazine in context. Let me first load the magazine object to understand its structure, and then list the candidate posts.</reasoning>
+<status>Loading the magazine and listing candidate posts…</status>
+<toolCall id="toolu_01WMMcsaHxTvuGxcMh2CkfL4" />
+<toolCall id="toolu_01CxWNvXZ4jExfLEJumfMzqm" />
+<reasoning>The magazine has 10 posts already curated, and there are no uncurated candidate posts. The user wants me to summarize the posts that are already in the magazine. Let me load them.</reasoning>
+<status>No uncurated candidates — loading the 10 posts already in the magazine…</status>
+<toolCall id="toolu_0152ftz33GL5M1DDi8GGDHi2" />
+<reasoning>The magazine has 10 posts, but several are duplicates. Let me deduplicate by title/guid and summarize the unique articles. Unique articles:
+1. "FBI affidavit quotes White House press dinner shooting suspect expressing rage at 'a pedophile, rapist and traitor' – US politics live" - About Cole Allen's manifesto and charges, plus King Charles visiting Trump at the White House.
+2. "Australia news live: UK inquiry says 'cracks already beginning to show' on Aukus; search for missing five-year-old near Alice Springs grows" - Live blog covering Aukus inquiry, David Brat nominated as ambassador to Australia, fuel reserve crisis. 
+3. "Rebel Wilson gives evidence in high-profile defamation case against star of directorial debut" - Rebel Wilson testifying in defamation case brought by Charlotte MacInnes.
+4. "Baby on board: US woman gives birth on Delta flight" - Ashley Blair delivered her baby aboard a Delta flight traveling from Atlanta to Portland.
+5. "'Shortcomings and failures' could sink Aukus nuclear submarines plan, UK inquiry warns" - A UK House of Commons defence committee report identifies significant funding gaps threatening the Aukus submarine program.</reasoning>
+
+Here's a summary of the **5 unique articles** currently in the magazine (some posts are duplicates):
+
+1. **FBI affidavit quotes White House press dinner shooting suspect**
+   Federal charges filed against Cole Allen include excerpts from a manifesto he emailed to family and friends before attempting to charge into the White House Correspondents' Dinner. Separately, King Charles and Queen Camilla visited Donald Trump at the White House for tea and a beehive tour.
+
+2. **Australia news live: Aukus 'cracks' & missing child search**
+   A UK House of Commons inquiry reveals "shortcomings and failings" in the Aukus submarine program. Also covered: David Brat nominated as the next US ambassador to Australia, and a push to extend Australia's fuel reserves from 30 to 60 days amid rising security concerns.
+
+3. **Rebel Wilson testifies in defamation case**
+   Hollywood star Rebel Wilson gave evidence in a defamation lawsuit brought by Charlotte MacInnes, the lead actor of Wilson's directorial debut *The Deb*. The case centres on claims MacInnes confided to Wilson about being uncomfortable with a bathing request from a colleague.
+
+4. **Baby born on Delta flight**
+   Passenger Ashley Blair went into labor on a packed Delta flight from Atlanta to Portland. Two off-duty EMTs on the plane delivered baby Brielle Renee just before landing — using a shoelace as a tourniquet for an IV. Mother and baby were healthy on arrival.
+
+5. **UK inquiry warns Aukus submarine plan at risk**
+   A detailed House of Commons defence committee report finds UK submarine funding has "cracks already beginning to show," with chronic under-investment in shipbuilding and only one submarine yard (Barrow-in-Furness) already behind schedule. Australia has committed A$4.6 billion to help, but the committee warns political drift could derail the entire program.
+<prompt>how many articles are there?</prompt>
+<reasoning>The user is asking about the number of articles. From my previous analysis, there are 10 posts in the magazine, but only 5 unique articles (the rest are duplicates). Let me answer based on what I already know.</reasoning>
+There are **10 posts** in the magazine, but only **5 unique articles** — each article appears twice (as duplicates from the two feeds).
+<prompt>say your name inside an xml tag</prompt>
+<name>Kai</name>

--- a/packages/ui/ui-editor/src/extensions/tags/testing/text.txt
+++ b/packages/ui/ui-editor/src/extensions/tags/testing/text.txt
@@ -12,7 +12,6 @@
 3. "Rebel Wilson gives evidence in high-profile defamation case against star of directorial debut" - Rebel Wilson testifying in defamation case brought by Charlotte MacInnes.
 4. "Baby on board: US woman gives birth on Delta flight" - Ashley Blair delivered her baby aboard a Delta flight traveling from Atlanta to Portland.
 5. "'Shortcomings and failures' could sink Aukus nuclear submarines plan, UK inquiry warns" - A UK House of Commons defence committee report identifies significant funding gaps threatening the Aukus submarine program.</reasoning>
-
 Here's a summary of the **5 unique articles** currently in the magazine (some posts are duplicates):
 
 1. **FBI affidavit quotes White House press dinner shooting suspect**

--- a/packages/ui/ui-editor/src/extensions/tags/xml-tags.ts
+++ b/packages/ui/ui-editor/src/extensions/tags/xml-tags.ts
@@ -13,7 +13,6 @@ import {
   WidgetType,
   keymap,
 } from '@codemirror/view';
-// TODO(burdon): Factor out agnostic types (React/solid).
 import { type FunctionComponent } from 'react';
 
 import { invariant } from '@dxos/invariant';

--- a/packages/ui/ui-editor/src/extensions/tags/xml-util.test.ts
+++ b/packages/ui/ui-editor/src/extensions/tags/xml-util.test.ts
@@ -2,13 +2,14 @@
 // Copyright 2025 DXOS.org
 //
 
-import { syntaxTree } from '@codemirror/language';
+import { ensureSyntaxTree, syntaxTree } from '@codemirror/language';
 import { EditorState } from '@codemirror/state';
 import { describe, test } from 'vitest';
 
 import { trim } from '@dxos/util';
 
 import { extendedMarkdown } from './extended-markdown';
+import TEXT from './testing/text.md?raw';
 import { xmlTags } from './xml-tags';
 import { nodeToJson, type Tag } from './xml-util';
 
@@ -27,8 +28,9 @@ const parseElements = (doc: string, registry: Record<string, any> = {}): ParsedE
     extensions: [extendedMarkdown({ registry }), xmlTags({ registry })],
   });
 
+  const tree = ensureSyntaxTree(state, doc.length, 5000) ?? syntaxTree(state);
   const elements: ParsedElement[] = [];
-  syntaxTree(state).iterate({
+  tree.iterate({
     enter: (node) => {
       if (node.type.name === 'Element') {
         const tag = nodeToJson(state, node.node);
@@ -160,5 +162,25 @@ describe('nodeToJson', () => {
     expect(elements).toHaveLength(1);
     expect(elements[0]._tag).toBe('reasoning');
     expect(elements[0].complete).toBe(true);
+  });
+
+  test('should parse text.md', ({ expect }) => {
+    const elements = parseElements(TEXT);
+    const tags = elements.map((element) => element._tag);
+    expect(tags).toEqual([
+      'prompt',
+      'reasoning',
+      'status',
+      'toolCall',
+      'toolCall',
+      'reasoning',
+      'status',
+      'toolCall',
+      'reasoning',
+      'prompt',
+      'reasoning',
+      'prompt',
+      'name',
+    ]);
   });
 });

--- a/packages/ui/ui-editor/src/extensions/tags/xml-util.test.ts
+++ b/packages/ui/ui-editor/src/extensions/tags/xml-util.test.ts
@@ -36,9 +36,10 @@ const parseElements = (doc: string, registry: Record<string, any> = {}): ParsedE
         const tag = nodeToJson(state, node.node);
         if (tag) {
           const hasCloseTag = !!node.node.getChild('CloseTag');
+          const hasSelfClose = !!node.node.getChild('SelfClosingTag');
           elements.push({
             ...tag,
-            complete: hasCloseTag,
+            complete: hasCloseTag || hasSelfClose,
           });
         }
         return false;
@@ -164,8 +165,40 @@ describe('nodeToJson', () => {
     expect(elements[0].complete).toBe(true);
   });
 
+  // Regression: when an unregistered XML tag like `<prompt>` appears earlier in the doc,
+  // the markdown parser treats it as a paragraph that lazy-continues into subsequent lines,
+  // and a later multi-line tag (e.g. `<reasoning>` whose body contains an ordered list) gets
+  // its HTMLBlock truncated to its first line — losing the closing tag and breaking widget
+  // rendering. Including the surrounding tag in the registry as a block-only entry (no
+  // factory/Component) lets `xmlBlockParsers` keep each tag as its own block.
+  test('multi-line reasoning is complete when preceded by a registered prompt block', ({ expect }) => {
+    const xml = [
+      '<prompt>summarize the posts</prompt>',
+      '<toolCall id="x" />',
+      '<reasoning>multi line content',
+      '1. "First" - desc',
+      '5. "Last" - desc</reasoning>',
+    ].join('\n');
+    const registry = {
+      prompt: { block: true },
+      reasoning: { block: true },
+      toolCall: { block: true },
+    };
+    const elements = parseElements(xml, registry);
+    expect(elements.map((e) => `${e._tag}${e.complete ? '' : '!'}`)).toEqual(['prompt', 'toolCall', 'reasoning']);
+  });
+
   test('should parse text.md', ({ expect }) => {
-    const elements = parseElements(TEXT);
+    // Mirror the live ChatThread registry, including `prompt` as a block-only entry so
+    // unregistered-paragraph lazy-continuation does not break later multi-line tags.
+    const registry = {
+      prompt: { block: true },
+      reasoning: { block: true },
+      status: { block: true },
+      toolCall: { block: true },
+      name: { block: true },
+    };
+    const elements = parseElements(TEXT, registry);
     const tags = elements.map((element) => element._tag);
     expect(tags).toEqual([
       'prompt',
@@ -182,5 +215,9 @@ describe('nodeToJson', () => {
       'prompt',
       'name',
     ]);
+    // Every element must be `complete` so the widget renderer wraps it. The bug we fixed:
+    // third multi-line `<reasoning>` (lines 9-14) used to be truncated by markdown's
+    // OrderedList parser breaking the HTMLBlock, leaving an Element node with no CloseTag.
+    expect(elements.filter((e) => !e.complete)).toEqual([]);
   });
 });

--- a/packages/ui/ui-editor/src/styles/theme.ts
+++ b/packages/ui/ui-editor/src/styles/theme.ts
@@ -114,7 +114,7 @@ export const baseTheme = EditorView.baseTheme({
     overflowAnchor: 'auto',
   },
   '.cm-scroller::-webkit-scrollbar': {
-    width: '8px',
+    width: 'var(--scrollbar-width,18px)',
   },
   '.cm-scroller::-webkit-scrollbar-track': {},
   '.cm-scroller::-webkit-scrollbar-thumb': {

--- a/packages/ui/ui-editor/src/styles/theme.ts
+++ b/packages/ui/ui-editor/src/styles/theme.ts
@@ -114,7 +114,7 @@ export const baseTheme = EditorView.baseTheme({
     overflowAnchor: 'auto',
   },
   '.cm-scroller::-webkit-scrollbar': {
-    width: 'var(--scrollbar-width,18px)',
+    width: 'var(--scrollbar-width,8px)',
   },
   '.cm-scroller::-webkit-scrollbar-track': {},
   '.cm-scroller::-webkit-scrollbar-thumb': {

--- a/packages/ui/ui-editor/src/typings.d.ts
+++ b/packages/ui/ui-editor/src/typings.d.ts
@@ -1,0 +1,8 @@
+//
+// Copyright 2025 DXOS.org
+//
+
+declare module '*.md?raw' {
+  const content: string;
+  export default content;
+}

--- a/packages/ui/ui-theme/src/css/layout/size.css
+++ b/packages/ui/ui-theme/src/css/layout/size.css
@@ -3,13 +3,26 @@
  */
 
 @layer dx-components {
-  /** 
-   * Registers the element as a size query container. 
+  /**
+   * Registers the element as a size query container.
    * Children can use @container queries to apply styles based on the container's dimensions (both width and height).
-   * Also enables children to use cqi units (e.g., max-w-[100cqi])
+   * Also enables children to use cqi/cqb units (e.g., max-w-[100cqi]).
+   * NOTE: `container-type: size` implies layout/size containment, which breaks CodeMirror's
+   * coordinate measurement (causes blank viewport sections during scroll until a click forces
+   * a re-measure). For editor content where only inline (width-based) queries are needed,
+   * use `.dx-inline-size-container` instead.
    */
   .dx-size-container {
     container-type: size;
+  }
+
+  /**
+   * Inline-only size query container. Provides cqi units for children without the layout
+   * containment side-effects of `container-type: size`. Use this in CodeMirror content
+   * wrappers where size containment would break viewport measurement.
+   */
+  .dx-inline-size-container {
+    container-type: inline-size;
   }
 
   /**

--- a/packages/ui/ui-theme/src/css/theme/spacing.css
+++ b/packages/ui/ui-theme/src/css/theme/spacing.css
@@ -94,7 +94,7 @@
     --dx-input-fine: var(--dx-lacuna-3);
     --dx-input-coarse: var(--dx-lacuna-4);
 
-    --dx-default-icons-size: 1.25rem; /* size=5 */
+    --dx-default-icons-size: 1rem; /* size=4 */
   }
 
   [data-grid-focus-indicator-variant='stack'] {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2281,7 +2281,7 @@ importers:
         version: 6.1.1(typescript@6.0.3)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       wait-on:
         specifier: 'catalog:'
         version: 8.0.3
@@ -4331,7 +4331,7 @@ importers:
         version: 19.2.3(react@19.2.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/common/web-context-solid:
     dependencies:
@@ -5367,7 +5367,7 @@ importers:
         version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.11)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/core/echo/feed:
     dependencies:
@@ -6375,7 +6375,7 @@ importers:
         version: 3.20.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/core/protocols:
     dependencies:
@@ -6662,7 +6662,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/devtools/cli-util:
     dependencies:
@@ -6714,7 +6714,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/devtools/devtools:
     dependencies:
@@ -8516,7 +8516,7 @@ importers:
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/plugins/plugin-crx:
     dependencies:
@@ -8599,7 +8599,7 @@ importers:
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/plugins/plugin-daily-summary:
     dependencies:
@@ -20651,7 +20651,7 @@ importers:
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   tools/vite-plugin-log/example:
     devDependencies:
@@ -38633,6 +38633,7 @@ packages:
       '@vitest/ui': 4.1.5
       happy-dom: '*'
       jsdom: '*'
+      vite: '>=8.0.0'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -41238,7 +41239,7 @@ snapshots:
       cjs-module-lexer: 1.3.1
       esbuild: 0.28.0
       miniflare: 4.20260421.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       wrangler: 4.68.1(@cloudflare/workers-types@4.20260303.0)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -41909,7 +41910,7 @@ snapshots:
   '@effect/vitest@0.29.0(effect@3.20.0)(vitest@4.1.5)':
     dependencies:
       effect: 3.20.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@effect/wa-sqlite@0.1.2': {}
 
@@ -46784,7 +46785,7 @@ snapshots:
       '@vitest/browser': 4.1.5(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.5)
       '@vitest/browser-playwright': 4.1.5(playwright@1.57.0)(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.5)
       '@vitest/runner': 4.1.5
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - react
       - react-dom
@@ -48185,7 +48186,7 @@ snapshots:
       '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.57.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -48201,7 +48202,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -48221,7 +48222,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
       '@vitest/browser': 4.1.5(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.5)
 
@@ -48285,7 +48286,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -60731,7 +60732,7 @@ snapshots:
     optionalDependencies:
       vite: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.28.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.10.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.7.0)(jsdom@27.0.0(canvas@3.2.0)(postcss@8.5.12))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -60762,18 +60763,7 @@ snapshots:
       happy-dom: 20.7.0
       jsdom: 27.0.0(canvas@3.2.0)(postcss@8.5.12)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   void-elements@3.1.0: {}
 


### PR DESCRIPTION
## Summary
- ChatThread `componentRegistry` now lists `prompt` as a block-only entry (no widget). Without it, an unregistered `<prompt>` opens a markdown Paragraph that lazy-continues into following lines, truncating a later multi-line `<reasoning>` to its first line — the Element loses its `CloseTag` and the widget renderer falls back to raw text. Visible in the chat UI as an unwidgeted `<reasoning>` block when the reasoning content includes an ordered list.
- `ui-editor` automerge extension test now wraps the automerge-repo `DocHandle` in an adapter (`adaptRepoHandle`) that bs58check-encodes/decodes heads at the boundary, satisfying the editor's `IDocHandle` contract without forcing the production `DocHandleProxy` path to encode. Removes the "Non-base58 character" log noise without changing runtime semantics.
- `xml-util` test suite hardened: helper now treats `SelfClosingTag` as complete, the `text.md` regression asserts every parsed element is `complete`, and `parseElements` forces a full parse via `ensureSyntaxTree` so trees aren't truncated mid-document.

## Test plan
- [x] `moon run ui-editor:test` (165 passed)
- [x] `moon run ui-editor:build` and `plugin-assistant:build`
- [ ] Manual: open a chat thread that produces a multi-line `<reasoning>` with an ordered list inside and confirm it renders as a widget rather than literal `<reasoning>` text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thin scrollbar option for the editor; prompt blocks are now recognized and preserved
  * Chat component export updated to expose Content and Status

* **Bug Fixes**
  * Preserves multi-line reasoning content verbatim
  * Improved status token/separator rendering and conditional icon display
  * Adjusted default streaming fader behavior

* **Style & UX**
  * Reduced default icon size; chat layout and prompt spacing restructured
  * Added inline-size container to improve editor sizing

* **Tests**
  * Added regression and parsing tests for reasoning, prompt, and readOnly behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->