### PR TITLE
refactor(echo-pipeline): standardize automerge namespace import to A

### DIFF
--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.test.ts
@@ -2,8 +2,7 @@
 // Copyright 2023 DXOS.org
 //
 
-import { getHeads } from '@automerge/automerge';
-import * as Automerge from '@automerge/automerge';
+import * as A from '@automerge/automerge';
 import { type DocumentId, type Heads, generateAutomergeUrl, parseAutomergeUrl } from '@automerge/automerge-repo';
 import { describe, expect, onTestFinished, test } from 'vitest';
 
@@ -53,8 +52,8 @@ describe('AutomergeHost', () => {
     const host = await setupAutomergeHost({ level });
 
     // Create a document to get its binary representation
-    const document = Automerge.from({ text: 'Hello world' });
-    const binary = Automerge.save(document);
+    const document = A.from({ text: 'Hello world' });
+    const binary = A.save(document);
     const { documentId } = parseAutomergeUrl(generateAutomergeUrl());
 
     // Start loading a non-existent document (should hang until created)
@@ -74,7 +73,7 @@ describe('AutomergeHost', () => {
     const level = await createLevel(tmpPath);
     const host = await setupAutomergeHost({ level });
     const handle = await host.createDoc({ text: 'Hello world' });
-    const expectedHeads = getHeads(handle.doc()!);
+    const expectedHeads = A.getHeads(handle.doc()!);
     await host.flush(Context.default());
 
     expect(await host.getHeads([handle.documentId])).toEqual([expectedHeads]);
@@ -94,7 +93,7 @@ describe('AutomergeHost', () => {
     const level = await createLevel(tmpPath);
     const host = await setupAutomergeHost({ level });
     const handles = await Promise.all(range(2, () => host.createDoc({ text: 'Hello world' })));
-    const expectedHeads: (Heads | undefined)[] = handles.map((handle) => getHeads(handle.doc()!));
+    const expectedHeads: (Heads | undefined)[] = handles.map((handle) => A.getHeads(handle.doc()!));
     await host.flush(Context.default());
 
     const ids = handles.map((handle) => handle.documentId);

--- a/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.test.ts
@@ -2,8 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import { type Heads } from '@automerge/automerge';
-import * as Automerge from '@automerge/automerge';
+import * as A from '@automerge/automerge';
 import type { DocumentId, PeerId } from '@automerge/automerge-repo';
 import { describe, expect, onTestFinished, test } from 'vitest';
 
@@ -84,14 +83,14 @@ describe('CollectionSynchronizer', () => {
   });
 });
 
-const TEST_HEADS = range(4).map((i) => Automerge.getHeads(Automerge.from({ i: i.toString() })));
+const TEST_HEADS = range(4).map((i) => A.getHeads(A.from({ i: i.toString() })));
 
 const STATE_1: CollectionState = {
   documents: {
     a: TEST_HEADS[0],
     b: TEST_HEADS[1],
     c: TEST_HEADS[2],
-  } as Record<DocumentId, Heads>,
+  } as Record<DocumentId, A.Heads>,
 };
 
 const STATE_2: CollectionState = {
@@ -99,5 +98,5 @@ const STATE_2: CollectionState = {
     a: TEST_HEADS[0],
     b: TEST_HEADS[3],
     d: TEST_HEADS[2],
-  } as Record<DocumentId, Heads>,
+  } as Record<DocumentId, A.Heads>,
 };

--- a/packages/core/echo/echo-pipeline/src/db-host/automerge-data-source.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/automerge-data-source.ts
@@ -3,7 +3,6 @@
 //
 
 import * as A from '@automerge/automerge';
-import { type Heads } from '@automerge/automerge';
 import { type DocumentId } from '@automerge/automerge-repo';
 import * as Effect from 'effect/Effect';
 
@@ -27,7 +26,7 @@ export const headsCodec = {
    * Serialize automerge heads to a cursor string.
    * Heads are sorted to ensure consistent comparison.
    */
-  encode: (heads: Heads): string => [...heads].sort().join(HEADS_DELIMITER),
+  encode: (heads: A.Heads): string => [...heads].sort().join(HEADS_DELIMITER),
 
   /**
    * Deserialize a cursor string back to heads array.
@@ -38,7 +37,7 @@ export const headsCodec = {
 /**
  * Check if document has changed by comparing cursor with current heads.
  */
-const hasChanged = (cursor: string | undefined, currentHeads: Heads): boolean => {
+const hasChanged = (cursor: string | undefined, currentHeads: A.Heads): boolean => {
   if (!cursor) {
     return true; // New document.
   }
@@ -74,7 +73,7 @@ export class AutomergeDataSource implements IndexDataSource {
 
       // Find changed documents by iterating all documents from HeadsStore.
       const changedDocuments = yield* Effect.promise(async () => {
-        const result: { documentId: DocumentId; heads: Heads }[] = [];
+        const result: { documentId: DocumentId; heads: A.Heads }[] = [];
         const limit = opts?.limit ?? Infinity;
 
         for await (const { documentId, heads } of this.#automergeHost.listDocumentHeads()) {

--- a/packages/core/echo/echo-pipeline/src/edge/echo-edge-replicator.ts
+++ b/packages/core/echo/echo-pipeline/src/edge/echo-edge-replicator.ts
@@ -2,7 +2,7 @@
 // Copyright 2024 DXOS.org
 //
 
-import * as Automerge from '@automerge/automerge';
+import * as A from '@automerge/automerge';
 import { type DocumentId, type Heads, cbor } from '@automerge/automerge-repo';
 
 import { Mutex, scheduleMicroTask, scheduleTask } from '@dxos/async';
@@ -445,7 +445,7 @@ class EdgeReplicatorConnection extends Resource implements AutomergeReplicatorCo
 const isErrorMessage = (message: AutomergeProtocolMessage) => message.type === 'error';
 
 const getMessageInfo = (msg: AutomergeProtocolMessage) => {
-  const { have, heads, need, changes } = msg.type === 'sync' ? Automerge.decodeSyncMessage(msg.data) : {};
+  const { have, heads, need, changes } = msg.type === 'sync' ? A.decodeSyncMessage(msg.data) : {};
   return {
     type: msg.type,
     documentId: 'documentId' in msg ? msg.documentId : undefined,


### PR DESCRIPTION
## Summary

Standardizes the namespace alias for `@automerge/automerge` across echo-pipeline:
- Renames `import * as Automerge` → `import * as A` (matches the convention already used elsewhere in the repo).
- Collapses separate named imports from the same module into the namespace import where possible (since `import * as A` cannot be syntactically merged with `import { x }`, this means dropping the named import and using `A.x` at call sites).

## Files changed

- `packages/core/echo/echo-pipeline/src/automerge/automerge-host.test.ts` — merged `{ getHeads }` + `* as Automerge` into `* as A`; rewrote call sites to `A.getHeads`, `A.from`, `A.save`.
- `packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.test.ts` — merged `{ type Heads }` + `* as Automerge` into `* as A`; `Heads` → `A.Heads`.
- `packages/core/echo/echo-pipeline/src/edge/echo-edge-replicator.ts` — `* as Automerge` → `* as A`.
- `packages/core/echo/echo-pipeline/src/db-host/automerge-data-source.ts` — dropped redundant `{ type Heads }` (already had `* as A`); `Heads` → `A.Heads`.

## Notes for reviewer

- Out of scope: the codebase still has `A` aliasing two different things across files — `import * as A from '@automerge/automerge'` (stable API) vs. `import { next as A } from '@automerge/automerge'` (next API, different runtime semantics for text). Reconciling those is a separate decision and was not touched here.
- All `Heads` references that remain in the changed files come from `@automerge/automerge-repo` (a different package), not `@automerge/automerge`.

## Test plan

- [x] `moon run echo-pipeline:build` succeeds locally.
- [ ] CI **Check** workflow passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code consistency across core modules through updated import and type reference patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->