### PR TITLE
fix(ui-editor): allow programmatic dispatches in read-only editors

### DIFF
--- a/packages/ui/react-ui-markdown/src/MarkdownStream/MarkdownStream.tsx
+++ b/packages/ui/react-ui-markdown/src/MarkdownStream/MarkdownStream.tsx
@@ -260,7 +260,6 @@ const useMarkdownStreamTextEditor = (
         createBasicExtensions({
           lineWrapping: true,
           readOnly: true,
-          scrollPastEnd: true,
         }),
         createThemeExtensions({
           slots: documentSlots,

--- a/packages/ui/ui-editor/src/extensions/factories.test.ts
+++ b/packages/ui/ui-editor/src/extensions/factories.test.ts
@@ -9,13 +9,27 @@ import { describe, test } from 'vitest';
 import { createBasicExtensions } from './factories';
 
 describe('createBasicExtensions readOnly', () => {
-  test('drops doc-changing transactions when readOnly is true', ({ expect }) => {
+  test('drops user-initiated edits when readOnly is true', ({ expect }) => {
+    const state = EditorState.create({
+      doc: 'hello',
+      extensions: [createBasicExtensions({ readOnly: true })],
+    });
+    const tr = state.update({
+      changes: { from: state.doc.length, insert: ' world' },
+      userEvent: 'input.type',
+    });
+    expect(tr.state.doc.toString()).toBe('hello');
+  });
+
+  test('allows programmatic dispatches (no userEvent) when readOnly is true', ({ expect }) => {
+    // Streaming consumers (e.g. MarkdownStream) populate the doc programmatically — those
+    // transactions must pass even though the editor is read-only to the user.
     const state = EditorState.create({
       doc: 'hello',
       extensions: [createBasicExtensions({ readOnly: true })],
     });
     const tr = state.update({ changes: { from: state.doc.length, insert: ' world' } });
-    expect(tr.state.doc.toString()).toBe('hello');
+    expect(tr.state.doc.toString()).toBe('hello world');
   });
 
   test('selection-only transactions still apply when readOnly', ({ expect }) => {

--- a/packages/ui/ui-editor/src/extensions/factories.test.ts
+++ b/packages/ui/ui-editor/src/extensions/factories.test.ts
@@ -21,6 +21,20 @@ describe('createBasicExtensions readOnly', () => {
     expect(tr.state.doc.toString()).toBe('hello');
   });
 
+  for (const userEvent of ['delete.forward', 'undo', 'redo']) {
+    test(`drops '${userEvent}' user events when readOnly is true`, ({ expect }) => {
+      const state = EditorState.create({
+        doc: 'hello',
+        extensions: [createBasicExtensions({ readOnly: true })],
+      });
+      const tr = state.update({
+        changes: { from: state.doc.length, insert: ' world' },
+        userEvent,
+      });
+      expect(tr.state.doc.toString()).toBe('hello');
+    });
+  }
+
   test('allows programmatic dispatches (no userEvent) when readOnly is true', ({ expect }) => {
     // Streaming consumers (e.g. MarkdownStream) populate the doc programmatically — those
     // transactions must pass even though the editor is read-only to the user.

--- a/packages/ui/ui-editor/src/extensions/factories.ts
+++ b/packages/ui/ui-editor/src/extensions/factories.ts
@@ -152,10 +152,7 @@ export const createBasicExtensions = (propsProp?: BasicExtensionsOptions): Exten
     props.readOnly &&
       EditorState.transactionFilter.of((tr) =>
         tr.docChanged &&
-        (tr.isUserEvent('input') ||
-          tr.isUserEvent('delete') ||
-          tr.isUserEvent('undo') ||
-          tr.isUserEvent('redo'))
+        (tr.isUserEvent('input') || tr.isUserEvent('delete') || tr.isUserEvent('undo') || tr.isUserEvent('redo'))
           ? []
           : tr,
       ),

--- a/packages/ui/ui-editor/src/extensions/factories.ts
+++ b/packages/ui/ui-editor/src/extensions/factories.ts
@@ -146,12 +146,18 @@ export const createBasicExtensions = (propsProp?: BasicExtensionsOptions): Exten
     // `EditorState.readOnly` is advisory — CodeMirror doesn't auto-reject doc-changing
     // transactions. Some extensions (e.g. `@codemirror/lang-markdown`'s Enter handler that
     // continues a list) dispatch programmatic edits regardless. Drop user-initiated edits
-    // (anything carrying a `userEvent` annotation) but pass programmatic dispatches —
-    // streaming `MarkdownStream` and similar consumers depend on being able to populate the
-    // doc themselves.
+    // (`input` / `delete` keymap dispatches plus `undo` / `redo` from the history extension)
+    // but pass programmatic dispatches — streaming `MarkdownStream` and similar consumers
+    // depend on being able to populate the doc themselves.
     props.readOnly &&
       EditorState.transactionFilter.of((tr) =>
-        tr.docChanged && (tr.isUserEvent('input') || tr.isUserEvent('delete')) ? [] : tr,
+        tr.docChanged &&
+        (tr.isUserEvent('input') ||
+          tr.isUserEvent('delete') ||
+          tr.isUserEvent('undo') ||
+          tr.isUserEvent('redo'))
+          ? []
+          : tr,
       ),
     props.scrollPastEnd && scrollPastEnd(),
     props.tabbable && tabbable,

--- a/packages/ui/ui-editor/src/extensions/factories.ts
+++ b/packages/ui/ui-editor/src/extensions/factories.ts
@@ -145,8 +145,14 @@ export const createBasicExtensions = (propsProp?: BasicExtensionsOptions): Exten
     props.readOnly !== undefined && EditorState.readOnly.of(props.readOnly),
     // `EditorState.readOnly` is advisory — CodeMirror doesn't auto-reject doc-changing
     // transactions. Some extensions (e.g. `@codemirror/lang-markdown`'s Enter handler that
-    // continues a list) dispatch programmatic edits regardless. Drop them here.
-    props.readOnly && EditorState.transactionFilter.of((tr) => (tr.docChanged ? [] : tr)),
+    // continues a list) dispatch programmatic edits regardless. Drop user-initiated edits
+    // (anything carrying a `userEvent` annotation) but pass programmatic dispatches —
+    // streaming `MarkdownStream` and similar consumers depend on being able to populate the
+    // doc themselves.
+    props.readOnly &&
+      EditorState.transactionFilter.of((tr) =>
+        tr.docChanged && (tr.isUserEvent('input') || tr.isUserEvent('delete')) ? [] : tr,
+      ),
     props.scrollPastEnd && scrollPastEnd(),
     props.tabbable && tabbable,
     props.tabSize && EditorState.tabSize.of(props.tabSize),


### PR DESCRIPTION
## Summary

- Scope the read-only `transactionFilter` (added in #11190) to user-initiated edits — programmatic dispatches now pass through, restoring `MarkdownStream`'s ability to populate the chat thread doc.
- Drop `scrollPastEnd: true` from `MarkdownStream` — combined with the post-reset `scrollToBottom('instant')` it was pushing freshly-rendered content off-screen behind ~viewport-sized bottom padding.

## Why

The read-only filter introduced in #11190 was correctly intended to block `@codemirror/lang-markdown`'s Enter handler from continuing a list inside a read-only editor, but it ran on *every* doc-changing transaction:

```ts
props.readOnly && EditorState.transactionFilter.of((tr) => (tr.docChanged ? [] : tr)),
```

That stripped the legitimate dispatches from `MarkdownStream.onReset` (the `setContent` path) and the streaming queue, so the chat thread's content was stored in `contentRef` but never made it into the editor's doc. It only appeared after a `debug` toggle rebuilt the view with `initialValue: contentRef.current` — which is exactly the symptom reported (raw content visible in debug mode, formatted content visible after toggling back).

The fix narrows the filter to transactions carrying a `userEvent` annotation. The markdown Enter handler dispatches with `userEvent: 'input'` so it stays blocked; programmatic `view.dispatch` from streaming consumers passes.

The bonus `scrollPastEnd` removal addresses the other reported regression: after the syncer's first `setContent`, `controller.scrollToBottom('instant')` ran with ~`clientHeight`-px bottom padding in place, scrolling the new content above the viewport.

## Test plan

- [x] `moon run ui-editor:test` — updated `factories.test.ts` covers both branches (user edits suppressed, programmatic dispatches pass) and the `insertNewlineContinueMarkup` regression test still passes.
- [x] `moon run react-ui-markdown:test`
- [x] `moon run plugin-assistant:test -- src/components/ChatThread/sync.test.ts`
- [x] Verified in `stories/stories-assistant/Chat — Default` storybook: prompt + assistant response now render immediately on first message, content sits at the top of the thread instead of being pushed off-screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Read-only editor now blocks user-initiated edits (typing, delete, undo/redo) while permitting programmatic or extension-driven document updates and streaming content.
  * Markdown editor scrolling behavior adjusted to remove extra end padding.

* **Tests**
  * Read-only tests clarified to distinguish user-initiated transactions from programmatic updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->