### PR TITLE
feat(plugin-assistant): chat view type setting (normal/thinking/verbose/summary)

### DIFF
--- a/packages/plugins/plugin-assistant/src/components/AssistantSettings/AssistantSettings.tsx
+++ b/packages/plugins/plugin-assistant/src/components/AssistantSettings/AssistantSettings.tsx
@@ -10,7 +10,7 @@ import { Input, Select, useTranslation } from '@dxos/react-ui';
 import { Settings as SettingsForm } from '@dxos/react-ui-form';
 
 import { meta } from '#meta';
-import { type Assistant, LLM_PROVIDERS } from '#types';
+import { type Assistant, CHAT_VIEW_TYPES, LLM_PROVIDERS } from '#types';
 
 // TODO(burdon): Factor out default Selector.
 const DEFAULT_VALUE = '__default';
@@ -19,6 +19,13 @@ const LLM_PROVIDER_LABELS = {
   edge: 'DXOS',
   ollama: 'Ollama',
   lmstudio: 'LM Studio',
+} as const;
+
+const CHAT_VIEW_TYPE_LABELS = {
+  normal: 'Normal',
+  thinking: 'Thinking',
+  verbose: 'Verbose',
+  summary: 'Summary',
 } as const;
 
 export type AssistantSettingsProps = AppSurface.SettingsArticleProps<Assistant.Settings>;
@@ -38,6 +45,36 @@ export const AssistantSettings = ({ settings, onSettingsChange }: AssistantSetti
             checked={!!settings.customPrompts}
             onCheckedChange={(checked) => onSettingsChange?.((s) => ({ ...s, customPrompts: checked }))}
           />
+        </SettingsForm.Item>
+
+        <SettingsForm.Item
+          title={t('settings.chat-view-type.label')}
+          description={t('settings.chat-view-type.description')}
+        >
+          <Select.Root
+            disabled={!onSettingsChange}
+            value={settings.chatViewType ?? 'normal'}
+            onValueChange={(value) => {
+              onSettingsChange?.((s) => ({
+                ...s,
+                chatViewType: value === DEFAULT_VALUE ? undefined : (value as any),
+              }));
+            }}
+          >
+            <Select.TriggerButton disabled={!onSettingsChange} placeholder={t('settings.chat-view-type.label')} />
+            <Select.Portal>
+              <Select.Content>
+                <Select.Viewport>
+                  {CHAT_VIEW_TYPES.map((type) => (
+                    <Select.Option key={type} value={type}>
+                      {CHAT_VIEW_TYPE_LABELS[type]}
+                    </Select.Option>
+                  ))}
+                </Select.Viewport>
+                <Select.Arrow />
+              </Select.Content>
+            </Select.Portal>
+          </Select.Root>
         </SettingsForm.Item>
 
         <SettingsForm.Item

--- a/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
+++ b/packages/plugins/plugin-assistant/src/components/Chat/Chat.tsx
@@ -220,8 +220,9 @@ const CHAT_THREAD_NAME = 'Chat.Thread';
 
 type ChatThreadProps = Omit<NaturalChatThreadProps, 'identity' | 'messages' | 'tools'>;
 
-const ChatThread = (props: ChatThreadProps) => {
+const ChatThread = ({ viewType, debug: debugProp, ...props }: ChatThreadProps) => {
   const { debug, event, messages, processor } = useChatContext(CHAT_THREAD_NAME);
+  const verbose = viewType === 'verbose';
   const identity = useIdentity();
   const error = useAtomValue(processor.error).pipe(Option.getOrUndefined);
   const active = useAtomValue(processor.active);
@@ -280,7 +281,8 @@ const ChatThread = (props: ChatThreadProps) => {
         identity={identity}
         messages={messages}
         error={error}
-        debug={debug}
+        debug={debugProp ?? (debug || verbose)}
+        viewType={viewType}
         extensions={extensions}
         onEvent={handleEvent}
         ref={controllerRef}

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/ChatThread.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/ChatThread.tsx
@@ -11,8 +11,9 @@ import { MarkdownStream, type MarkdownStreamController, type MarkdownStreamProps
 import { type Message } from '@dxos/types';
 import { keyToFallback } from '@dxos/util';
 
+import { type ChatViewType } from '../../types';
 import { type ChatEvent } from '../Chat';
-import { blockToMarkdown, componentRegistry } from './registry';
+import { componentRegistry, createBlockRenderer } from './registry';
 import { MessageSyncer } from './sync';
 
 const defaultOptions: MarkdownStreamProps['options'] = {
@@ -27,6 +28,7 @@ export type ChatThreadProps = ThemedClassName<
     identity?: Identity;
     messages?: Message.Message[];
     error?: Error;
+    viewType?: ChatViewType;
     onEvent?: (event: ChatEvent) => void;
   } & Pick<MarkdownStreamProps, 'options' | 'debug' | 'extensions' | 'footer'>
 >;
@@ -42,6 +44,7 @@ export const ChatThread = forwardRef<MarkdownStreamController | null, ChatThread
       footer,
       debug = false,
       extensions,
+      viewType = 'normal',
       onEvent,
     },
     forwardedRef,
@@ -66,7 +69,8 @@ export const ChatThread = forwardRef<MarkdownStreamController | null, ChatThread
     }, [controller, error]);
 
     // Update document.
-    const syncer = useMemo(() => controller && new MessageSyncer(controller, blockToMarkdown), [controller]);
+    const renderer = useMemo(() => createBlockRenderer(viewType), [viewType]);
+    const syncer = useMemo(() => controller && new MessageSyncer(controller, renderer), [controller, renderer]);
     useEffect(() => {
       if (!syncer) {
         return;

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/registry.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/registry.tsx
@@ -8,6 +8,7 @@ import { log } from '@dxos/log';
 import { ContentBlock, type Message } from '@dxos/types';
 import { type XmlWidgetRegistry, getXmlTextChild } from '@dxos/ui-editor';
 
+import { type ChatViewType } from '../../types';
 import { type BlockRenderer, type MessageThreadContext } from './sync';
 import { applyToolBlockToWidgetState } from './tool-widget-state';
 import {
@@ -129,17 +130,45 @@ export const componentRegistry: XmlWidgetRegistry = {
 /**
  * Convert block to markdown.
  */
-export const blockToMarkdown: BlockRenderer = (
-  context: MessageThreadContext,
-  message: Message.Message,
-  block: ContentBlock.Any,
-) => {
-  let str = blockToMarkdownImpl(context, message, block);
-  if (str && !block.pending) {
-    return (str += '\n');
-  }
+export const blockToMarkdown: BlockRenderer = createBlockRenderer('normal');
 
-  return str;
+/**
+ * Create a {@link BlockRenderer} that filters blocks based on the chat view type.
+ *
+ * - `summary`: only user prompts.
+ * - `normal`: user prompts + assistant text + tool calls + summary/select/suggestion/reference + status. Hides reasoning.
+ * - `thinking`: same as normal plus reasoning.
+ * - `verbose`: renders every block (debug fallbacks visible).
+ */
+export function createBlockRenderer(viewType: ChatViewType): BlockRenderer {
+  return (context, message, block) => {
+    if (!isBlockVisible(viewType, message, block)) {
+      return;
+    }
+    let str = blockToMarkdownImpl(context, message, block);
+    if (str && !block.pending) {
+      return (str += '\n');
+    }
+    return str;
+  };
+}
+
+const isBlockVisible = (viewType: ChatViewType, message: Message.Message, block: ContentBlock.Any): boolean => {
+  if (viewType === 'verbose') {
+    return true;
+  }
+  if (viewType === 'summary') {
+    return (
+      message.sender.role === 'user' &&
+      block._tag === 'text' &&
+      (block as ContentBlock.Text).disposition !== 'synthetic'
+    );
+  }
+  // normal & thinking: hide reasoning unless thinking.
+  if (block._tag === 'reasoning') {
+    return viewType === 'thinking';
+  }
+  return true;
 };
 
 const blockToMarkdownImpl = (context: MessageThreadContext, message: Message.Message, block: ContentBlock.Any) => {

--- a/packages/plugins/plugin-assistant/src/containers/ChatContainer/ChatContainer.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/ChatContainer/ChatContainer.tsx
@@ -77,7 +77,7 @@ export const ChatContainer = forwardRef<HTMLDivElement, ChatContainerProps>((pro
         </Panel.Toolbar>
         <Panel.Content>
           <ChatComponent.Viewport>
-            <ChatComponent.Thread />
+            <ChatComponent.Thread viewType={settings.chatViewType} />
             <div role='none' className='dx-document p-4'>
               <ChatComponent.Prompt
                 {...chatProps}

--- a/packages/plugins/plugin-assistant/src/containers/ChatDialog/ChatDialog.tsx
+++ b/packages/plugins/plugin-assistant/src/containers/ChatDialog/ChatDialog.tsx
@@ -61,7 +61,7 @@ export const ChatDialog = ({ chat }: ChatDialogProps) => {
       <NaturalChatDialog.Root open={open} expanded={expanded} onOpenChange={setOpen}>
         <NaturalChatDialog.Header title={t('assistant-dialog.title')} />
         <NaturalChatDialog.Content>
-          <Chat.Thread />
+          <Chat.Thread viewType={settings.chatViewType} />
         </NaturalChatDialog.Content>
         <NaturalChatDialog.Footer classNames='p-1.5'>
           <Chat.Prompt {...chatProps} preset={preset?.id} online={online} onOnlineChange={setOnline} expandable />

--- a/packages/plugins/plugin-assistant/src/translations.ts
+++ b/packages/plugins/plugin-assistant/src/translations.ts
@@ -154,6 +154,9 @@ export const translations: Resource[] = [
         'settings.default.label': 'Default',
         'settings.custom-prompts.label': 'Use custom prompts',
         'settings.custom-prompts.description': 'Allow the assistant to use custom prompts defined in your spaces.',
+        'settings.chat-view-type.label': 'Chat view',
+        'settings.chat-view-type.description':
+          'Controls which message blocks are shown in the chat: normal hides reasoning, thinking shows reasoning, verbose shows debug data, summary shows only your prompts.',
         'settings.llm-provider.label': 'LLM provider',
         'settings.llm-provider.description': 'Select which language model service to use for AI responses.',
         'settings.edge-llm-model.label': 'Remote language model',

--- a/packages/plugins/plugin-assistant/src/types/Assistant.ts
+++ b/packages/plugins/plugin-assistant/src/types/Assistant.ts
@@ -12,3 +12,5 @@ export type Chat = ChatModule.Chat;
 import * as SettingsModule from './Settings';
 export const Settings = SettingsModule.Settings;
 export type Settings = SettingsModule.Settings;
+export const CHAT_VIEW_TYPES = SettingsModule.CHAT_VIEW_TYPES;
+export type ChatViewType = SettingsModule.ChatViewType;

--- a/packages/plugins/plugin-assistant/src/types/Settings.ts
+++ b/packages/plugins/plugin-assistant/src/types/Settings.ts
@@ -8,6 +8,9 @@ import * as Schema from 'effect/Schema';
 
 import { LLM_PROVIDERS } from './defs';
 
+export const CHAT_VIEW_TYPES = ['normal', 'thinking', 'verbose', 'summary'] as const;
+export type ChatViewType = (typeof CHAT_VIEW_TYPES)[number];
+
 export const Settings = Schema.mutable(
   Schema.Struct({
     llmProvider: Schema.optional(Schema.Literal(...LLM_PROVIDERS)),
@@ -15,6 +18,7 @@ export const Settings = Schema.mutable(
     ollamaModel: Schema.optional(Schema.String),
     lmstudioModel: Schema.optional(Schema.String),
     customPrompts: Schema.optional(Schema.Boolean),
+    chatViewType: Schema.optional(Schema.Literal(...CHAT_VIEW_TYPES)),
   }),
 );
 

--- a/packages/plugins/plugin-assistant/src/types/index.ts
+++ b/packages/plugins/plugin-assistant/src/types/index.ts
@@ -9,5 +9,6 @@ export * as Assistant from './Assistant';
 
 export * from './capabilities';
 export * from './defs';
+export { CHAT_VIEW_TYPES, type ChatViewType } from './Settings';
 export * from './events';
 export * from './service';


### PR DESCRIPTION
## Summary
- New `chatViewType` plugin setting (`normal` | `thinking` | `verbose` | `summary`) controls which message blocks the chat renders.
- Wired through `Chat.Thread` → `ChatThread` → `MessageSyncer` via a new `createBlockRenderer(viewType)` factory in `registry.tsx`.
- `verbose` also flips on the underlying `MarkdownStream` debug view.

## View modes
- **normal** — user prompts + assistant text + tool calls; hides reasoning.
- **thinking** — normal + reasoning blocks.
- **verbose** — every block, debug view enabled.
- **summary** — only user prompt text.

## Test plan
- [ ] Open settings → switch chat view → verify ChatThread re-renders with the new filter.
- [ ] In each mode, send a prompt that triggers reasoning and a tool call; confirm visibility matches the mode.
- [ ] Verify `verbose` shows debug fallbacks and `MarkdownStream` debug view.
- [ ] Confirm existing default behaviour (`undefined` setting → `normal`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Chat view" setting with four display options to customize which message blocks appear in conversations:
    - Normal: hides reasoning blocks
    - Thinking: displays reasoning blocks
    - Verbose: shows all debug data
    - Summary: displays key responses only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->