### PR TITLE
fix(plugin-wnfs): hide image decorations in source view mode

### DIFF
--- a/packages/plugins/plugin-markdown/src/containers/MarkdownContainer/MarkdownContainer.tsx
+++ b/packages/plugins/plugin-markdown/src/containers/MarkdownContainer/MarkdownContainer.tsx
@@ -54,11 +54,11 @@ export const MarkdownContainer = forwardRef<HTMLDivElement, MarkdownContainerPro
         return [];
       }
 
+      const document = Obj.instanceOf(Markdown.Document, object) ? object : undefined;
       return [...(otherExtensionProviders ?? []), ...(extensionProviders ?? [])]
         .flat()
         .reduce((acc: Extension[], provider) => {
-          const extension =
-            typeof provider === 'function' ? provider({ document: object as Markdown.Document, viewMode }) : provider;
+          const extension = typeof provider === 'function' ? provider({ document, viewMode }) : provider;
           if (extension) {
             acc.push(extension);
           }

--- a/packages/plugins/plugin-markdown/src/containers/MarkdownContainer/MarkdownContainer.tsx
+++ b/packages/plugins/plugin-markdown/src/containers/MarkdownContainer/MarkdownContainer.tsx
@@ -39,7 +39,7 @@ export type MarkdownContainerProps = AppSurface.ObjectArticleProps<
 
 export const MarkdownContainer = forwardRef<HTMLDivElement, MarkdownContainerProps>(
   (
-    { role, subject: object, id, attendableId, settings, extensionProviders, onSelectObject, ...props },
+    { role, subject: object, id, attendableId, settings, extensionProviders, onSelectObject, viewMode, ...props },
     forwardedRef,
   ) => {
     const db = Obj.isObject(object) ? Obj.getDatabase(object) : undefined;
@@ -58,14 +58,16 @@ export const MarkdownContainer = forwardRef<HTMLDivElement, MarkdownContainerPro
         .flat()
         .reduce((acc: Extension[], provider) => {
           const extension =
-            typeof provider === 'function' ? provider({ document: object as Markdown.Document }) : provider;
+            typeof provider === 'function'
+              ? provider({ document: object as Markdown.Document, viewMode })
+              : provider;
           if (extension) {
             acc.push(extension);
           }
 
           return acc;
         }, []);
-    }, [extensionProviders, otherExtensionProviders, object]);
+    }, [extensionProviders, otherExtensionProviders, object, viewMode]);
 
     // Toolbar actions from app graph.
     const { graph } = useAppGraph();
@@ -118,6 +120,7 @@ export const MarkdownContainer = forwardRef<HTMLDivElement, MarkdownContainerPro
         compact={role !== 'article'}
         extensions={extensions}
         settings={settings}
+        viewMode={viewMode}
         onAction={runAction}
         onFileUpload={handleFileUpload}
         onLinkQuery={handleLinkQuery}

--- a/packages/plugins/plugin-markdown/src/containers/MarkdownContainer/MarkdownContainer.tsx
+++ b/packages/plugins/plugin-markdown/src/containers/MarkdownContainer/MarkdownContainer.tsx
@@ -58,9 +58,7 @@ export const MarkdownContainer = forwardRef<HTMLDivElement, MarkdownContainerPro
         .flat()
         .reduce((acc: Extension[], provider) => {
           const extension =
-            typeof provider === 'function'
-              ? provider({ document: object as Markdown.Document, viewMode })
-              : provider;
+            typeof provider === 'function' ? provider({ document: object as Markdown.Document, viewMode }) : provider;
           if (extension) {
             acc.push(extension);
           }

--- a/packages/plugins/plugin-markdown/src/types/types.ts
+++ b/packages/plugins/plugin-markdown/src/types/types.ts
@@ -12,7 +12,10 @@ import { type Document } from './Markdown';
 // TODO(wittjosiah): MarkdownExtensionProvider is a part of the MarkdownCapabilities api which should be in ./types.
 
 // TODO(burdon): Async?
-export type MarkdownExtensionProvider = (props: { document?: Document }) => Extension | undefined;
+export type MarkdownExtensionProvider = (props: {
+  document?: Document;
+  viewMode?: EditorViewMode;
+}) => Extension | undefined;
 
 export type MarkdownPluginState = {
   // Codemirror extensions provided by other plugins.

--- a/packages/plugins/plugin-wnfs/src/capabilities/markdown.ts
+++ b/packages/plugins/plugin-wnfs/src/capabilities/markdown.ts
@@ -7,6 +7,7 @@ import * as Effect from 'effect/Effect';
 import { Capability } from '@dxos/app-framework';
 import { MarkdownCapabilities } from '@dxos/plugin-markdown/types';
 import { getSpace } from '@dxos/react-client/echo';
+import { type EditorViewMode } from '@dxos/ui-editor/types';
 
 import { WnfsCapabilities } from '#types';
 
@@ -18,7 +19,11 @@ export default Capability.makeModule(
     const capabilities = yield* Capability.Service;
 
     return Capability.contributes(MarkdownCapabilities.Extensions, [
-      ({ document }: { document?: any }) => {
+      ({ document, viewMode }: { document?: any; viewMode?: EditorViewMode }) => {
+        if (viewMode === 'source') {
+          return undefined;
+        }
+
         const blockstore = capabilities.get(WnfsCapabilities.Blockstore);
         const instances = capabilities.get(WnfsCapabilities.Instances);
 

--- a/packages/plugins/plugin-wnfs/src/capabilities/markdown.ts
+++ b/packages/plugins/plugin-wnfs/src/capabilities/markdown.ts
@@ -5,9 +5,8 @@
 import * as Effect from 'effect/Effect';
 
 import { Capability } from '@dxos/app-framework';
-import { MarkdownCapabilities } from '@dxos/plugin-markdown/types';
+import { type MarkdownExtensionProvider, MarkdownCapabilities } from '@dxos/plugin-markdown/types';
 import { getSpace } from '@dxos/react-client/echo';
-import { type EditorViewMode } from '@dxos/ui-editor/types';
 
 import { WnfsCapabilities } from '#types';
 
@@ -18,22 +17,22 @@ export default Capability.makeModule(
     // Get context for lazy capability access in callbacks.
     const capabilities = yield* Capability.Service;
 
-    return Capability.contributes(MarkdownCapabilities.Extensions, [
-      ({ document, viewMode }: { document?: any; viewMode?: EditorViewMode }) => {
-        if (viewMode === 'source') {
-          return undefined;
-        }
+    const provider: MarkdownExtensionProvider = ({ document, viewMode }) => {
+      if (viewMode === 'source') {
+        return undefined;
+      }
 
-        const blockstore = capabilities.get(WnfsCapabilities.Blockstore);
-        const instances = capabilities.get(WnfsCapabilities.Instances);
+      const blockstore = capabilities.get(WnfsCapabilities.Blockstore);
+      const instances = capabilities.get(WnfsCapabilities.Instances);
 
-        if (document) {
-          const space = getSpace(document);
-          return space ? [image({ blockstore, instances, space })] : [];
-        }
+      if (document) {
+        const space = getSpace(document);
+        return space ? [image({ blockstore, instances, space })] : undefined;
+      }
 
-        return [];
-      },
-    ]);
+      return undefined;
+    };
+
+    return Capability.contributes(MarkdownCapabilities.Extensions, [provider]);
   }),
 );


### PR DESCRIPTION
## Summary

- The plugin-wnfs image extension replaced `wnfs://` URLs with image widgets even when the markdown editor was in `source` (plain-text) view mode, so users saw images instead of the raw URL.
- Threaded `viewMode` through `MarkdownExtensionProvider` (extending the props the callback receives) so other plugins can opt out per view mode.
- Updated `plugin-wnfs`'s contribution to skip the image extension when `viewMode === 'source'`, mirroring the existing gate on plugin-markdown's core decorations in `useExtensions.tsx`.

## Test plan

- [ ] Open a markdown document containing a `wnfs://...` image link.
- [ ] Verify the image renders inline in `preview` and `readonly` modes.
- [ ] Toggle to `source` mode and verify the raw `![](wnfs://...)` markdown is shown (no image).
- [ ] Confirm other plugins contributing markdown extensions (mermaid, sheet, thread, files, etc.) continue to work — `viewMode` was only added as an optional prop on the provider callback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown editor is view-mode aware; extension providers now receive the current mode.
  * Extensions regenerate when editor mode or document changes, so the UI updates when switching modes.
  * Certain extensions (e.g., media/inline) are automatically disabled in the raw/source view to prevent inappropriate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->