### PR TITLE
feat(plugin-transcription): pluggable transcribe transport, file-upload story, unit tests

### DIFF
--- a/packages/plugins/plugin-transcription/src/capabilities/transcriber.ts
+++ b/packages/plugins/plugin-transcription/src/capabilities/transcriber.ts
@@ -43,6 +43,7 @@ export default Capability.makeModule(
       onSegments,
       transcriberConfig,
       recorderConfig,
+      transcribe,
     }) => {
       // Initialize audio transcription.
       return new Transcriber({
@@ -59,6 +60,7 @@ export default Capability.makeModule(
           },
         }),
         onSegments,
+        transcribe,
       });
     };
 

--- a/packages/plugins/plugin-transcription/src/hooks/useTranscriber.ts
+++ b/packages/plugins/plugin-transcription/src/hooks/useTranscriber.ts
@@ -18,6 +18,7 @@ export const useTranscriber = ({
   recorderConfig,
   transcriberConfig,
   onSegments,
+  transcribe,
 }: Partial<TranscriptionCapabilities.GetTranscriberProps>) => {
   const [getTranscriber] = useCapabilities(TranscriptionCapabilities.Transcriber);
 
@@ -32,8 +33,9 @@ export const useTranscriber = ({
       recorderConfig,
       transcriberConfig,
       onSegments,
+      transcribe,
     });
-  }, [getTranscriber, audioStreamTrack, recorderConfig, transcriberConfig, onSegments]);
+  }, [getTranscriber, audioStreamTrack, recorderConfig, transcriberConfig, onSegments, transcribe]);
 
   useEffect(() => {
     return () => {

--- a/packages/plugins/plugin-transcription/src/stories/FileTranscription.stories.tsx
+++ b/packages/plugins/plugin-transcription/src/stories/FileTranscription.stories.tsx
@@ -52,8 +52,30 @@ const AudioFile = ({
   const [running, setRunning] = useState(false);
   const actor: Actor.Actor = useMemo(() => ({ name: 'You' }), []);
 
+  // Optional uploaded file overrides the default URL.
+  const [uploadedUrl, setUploadedUrl] = useState<string>();
+  useEffect(() => {
+    return () => {
+      if (uploadedUrl) {
+        URL.revokeObjectURL(uploadedUrl);
+      }
+    };
+  }, [uploadedUrl]);
+
+  const handleUpload = useCallback((file: File) => {
+    setRunning(false);
+    setUploadedUrl((prev) => {
+      if (prev) {
+        URL.revokeObjectURL(prev);
+      }
+      return URL.createObjectURL(file);
+    });
+  }, []);
+
+  const sourceUrl = uploadedUrl ?? audioUrl;
+
   // Audio.
-  const { audio, track, stream } = useAudioFile(audioUrl, audioConstraints);
+  const { audio, track, stream } = useAudioFile(sourceUrl, audioConstraints);
 
   // Speaking.
   const isSpeaking = detectSpeaking ? useIsSpeaking(track) : true;
@@ -180,6 +202,7 @@ const AudioFile = ({
       running={running}
       onRunningChange={setRunning}
       audioRef={ref}
+      onUpload={handleUpload}
     />
   );
 };

--- a/packages/plugins/plugin-transcription/src/stories/FileTranscription.stories.tsx
+++ b/packages/plugins/plugin-transcription/src/stories/FileTranscription.stories.tsx
@@ -53,6 +53,7 @@ const AudioFile = ({
   const actor: Actor.Actor = useMemo(() => ({ name: 'You' }), []);
 
   // Optional uploaded file overrides the default URL.
+  // The useEffect below revokes the previous URL whenever it changes (and on unmount).
   const [uploadedUrl, setUploadedUrl] = useState<string>();
   useEffect(() => {
     return () => {
@@ -64,12 +65,7 @@ const AudioFile = ({
 
   const handleUpload = useCallback((file: File) => {
     setRunning(false);
-    setUploadedUrl((prev) => {
-      if (prev) {
-        URL.revokeObjectURL(prev);
-      }
-      return URL.createObjectURL(file);
-    });
+    setUploadedUrl(URL.createObjectURL(file));
   }, []);
 
   const sourceUrl = uploadedUrl ?? audioUrl;

--- a/packages/plugins/plugin-transcription/src/stories/KeyWordRecognition.stories.tsx
+++ b/packages/plugins/plugin-transcription/src/stories/KeyWordRecognition.stories.tsx
@@ -6,7 +6,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import React, { useEffect, useMemo, useState } from 'react';
 
 import { log } from '@dxos/log';
-import { Toolbar } from '@dxos/react-ui';
+import { Panel, Toolbar } from '@dxos/react-ui';
 import { withLayout, withTheme } from '@dxos/react-ui/testing';
 import { mx } from '@dxos/ui-theme';
 
@@ -86,32 +86,34 @@ const DefaultStory = ({ keywords }: DefaultStoryProps) => {
   }, [running, recognition]);
 
   return (
-    <div className={mx('flex flex-col gap-2 w-[30rem]')}>
-      <Toolbar.Root>
-        <Toolbar.IconButton
-          iconOnly
-          icon={running ? 'ph--pause--regular' : 'ph--play--regular'}
-          label={running ? 'Pause' : 'Play'}
-          onClick={() => setRunning((running) => !running)}
-        />
-      </Toolbar.Root>
+    <Panel.Root>
+      <Panel.Toolbar asChild>
+        <Toolbar.Root>
+          <Toolbar.IconButton
+            iconOnly
+            icon={running ? 'ph--pause--regular' : 'ph--play--regular'}
+            label={running ? 'Pause' : 'Play'}
+            onClick={() => setRunning((running) => !running)}
+          />
+        </Toolbar.Root>
+      </Panel.Toolbar>
 
-      <div className='flex flex-wrap'>
-        {matchingWords.map((word, index) => (
-          <span
-            key={index}
-            className={mx(
-              'px-3 py-1 m-2 rounded-sm border',
-              word.matched ? 'bg-red-200 text-red-800 border-red-300' : 'bg-gray-200 text-gray-600 border-gray-300',
-            )}
-          >
-            {word.text}
-          </span>
-        ))}
-      </div>
-
-      <span>{transcript || (running ? 'Listening...' : 'Click play to start speech recognition')}</span>
-    </div>
+      <Panel.Content>
+        <div className='p-4 grid grid-cols-[repeat(auto-fill,minmax(6rem,1fr))] gap-2'>
+          {matchingWords.map((word, index) => (
+            <span
+              key={index}
+              className={mx(
+                'grid place-items-center p-2 aspect-square rounded-sm border border-separator',
+                word.matched && 'border-red-300',
+              )}
+            >
+              {word.text}
+            </span>
+          ))}
+        </div>
+      </Panel.Content>
+    </Panel.Root>
   );
 };
 
@@ -127,6 +129,6 @@ type Story = StoryObj<typeof meta>;
 
 export const SpeechRecognitionAPI: Story = {
   args: {
-    keywords: ['kai', 'computer', 'hello'],
+    keywords: ['kai', 'computer', 'hello', 'dxos'],
   },
 };

--- a/packages/plugins/plugin-transcription/src/stories/TranscriptionStory.tsx
+++ b/packages/plugins/plugin-transcription/src/stories/TranscriptionStory.tsx
@@ -42,7 +42,7 @@ export const TranscriptionStory: FC<{
   };
 
   return (
-    <div className='flex flex-col w-[30rem]'>
+    <>
       {audioRef && <audio ref={audioRef} autoPlay />}
       <Toolbar.Root>
         <IconButton
@@ -78,6 +78,6 @@ export const TranscriptionStory: FC<{
           </ScrollContainer.Viewport>
         </ScrollContainer.Content>
       </ScrollContainer.Root>
-    </div>
+    </>
   );
 };

--- a/packages/plugins/plugin-transcription/src/stories/TranscriptionStory.tsx
+++ b/packages/plugins/plugin-transcription/src/stories/TranscriptionStory.tsx
@@ -20,6 +20,14 @@ import { type Message } from '@dxos/types';
 import { Transcription } from '../components';
 import { type SerializationModel } from '../model';
 
+/**
+ * Story wrapper that renders a transcript with playback controls, an optional audio file
+ * upload affordance, and a toolbar slot for additional controls.
+ *
+ * @param onUpload - Callback fired when the user picks a local audio file via the upload button.
+ * @param uploadAccept - HTML `accept` filter for the hidden file input. Defaults to `audio/*`.
+ * @param toolbarSlot - Extra content rendered after the upload button inside the toolbar.
+ */
 export const TranscriptionStory: FC<{
   model: SerializationModel<Message.Message>;
   disabled?: boolean;

--- a/packages/plugins/plugin-transcription/src/stories/TranscriptionStory.tsx
+++ b/packages/plugins/plugin-transcription/src/stories/TranscriptionStory.tsx
@@ -4,7 +4,15 @@
 
 import '@dxos-theme';
 
-import React, { type Dispatch, type FC, type RefObject, type SetStateAction } from 'react';
+import React, {
+  type ChangeEvent,
+  type Dispatch,
+  type FC,
+  type ReactNode,
+  type RefObject,
+  type SetStateAction,
+  useRef,
+} from 'react';
 
 import { IconButton, ScrollContainer, Toolbar } from '@dxos/react-ui';
 import { type Message } from '@dxos/types';
@@ -18,7 +26,21 @@ export const TranscriptionStory: FC<{
   running: boolean;
   onRunningChange: Dispatch<SetStateAction<boolean>>;
   audioRef?: RefObject<HTMLAudioElement | null>;
-}> = ({ model, running, onRunningChange, audioRef, disabled }) => {
+  onUpload?: (file: File) => void;
+  uploadAccept?: string;
+  toolbarSlot?: ReactNode;
+}> = ({ model, running, onRunningChange, audioRef, disabled, onUpload, uploadAccept = 'audio/*', toolbarSlot }) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file && onUpload) {
+      onUpload(file);
+    }
+    // Reset so the same file can be re-selected.
+    event.target.value = '';
+  };
+
   return (
     <div className='flex flex-col w-[30rem]'>
       {audioRef && <audio ref={audioRef} autoPlay />}
@@ -30,6 +52,24 @@ export const TranscriptionStory: FC<{
           label={running ? 'Pause' : 'Play'}
           onClick={() => onRunningChange((running) => !running)}
         />
+        {onUpload && (
+          <>
+            <input
+              ref={fileInputRef}
+              type='file'
+              accept={uploadAccept}
+              className='hidden'
+              onChange={handleFileChange}
+            />
+            <IconButton
+              iconOnly
+              icon='ph--upload--regular'
+              label='Upload audio'
+              onClick={() => fileInputRef.current?.click()}
+            />
+          </>
+        )}
+        {toolbarSlot}
       </Toolbar.Root>
       <ScrollContainer.Root pin>
         <ScrollContainer.Content>

--- a/packages/plugins/plugin-transcription/src/stories/TranscriptionStory.tsx
+++ b/packages/plugins/plugin-transcription/src/stories/TranscriptionStory.tsx
@@ -58,11 +58,13 @@ export const TranscriptionStory: FC<{
               ref={fileInputRef}
               type='file'
               accept={uploadAccept}
+              disabled={disabled}
               className='hidden'
               onChange={handleFileChange}
             />
             <IconButton
               iconOnly
+              disabled={disabled}
               icon='ph--upload--regular'
               label='Upload audio'
               onClick={() => fileInputRef.current?.click()}

--- a/packages/plugins/plugin-transcription/src/transcriber/transcriber.test.ts
+++ b/packages/plugins/plugin-transcription/src/transcriber/transcriber.test.ts
@@ -1,0 +1,100 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, expect, test } from 'vitest';
+
+import { type AudioChunk } from './audio-recorder';
+import { alignWhisperSegments, type WhisperSegment } from './transcriber';
+
+const T0 = Date.parse('2026-01-01T00:00:00.000Z');
+
+const chunk = (offsetMs = 0, samples = 16): AudioChunk => ({
+  timestamp: T0 + offsetMs,
+  data: new Float64Array(samples),
+});
+
+const segment = (overrides: Partial<WhisperSegment>): WhisperSegment => ({
+  text: '',
+  start: 0,
+  end: 0,
+  no_speech_prob: 0,
+  words: [],
+  ...overrides,
+});
+
+describe('alignWhisperSegments', () => {
+  test('returns empty when no chunks were transcribed', () => {
+    const result = alignWhisperSegments([segment({ text: 'x', end: 1, words: [{ word: 'x', start: 0, end: 1 }] })], [], 0);
+    expect(result.transcripts).toEqual([]);
+    expect(result.lastUsedTimestamp).toBeUndefined();
+  });
+
+  test('absolute-timestamps and deduplicates segments against lastUsedTimestamp', () => {
+    const segments: WhisperSegment[] = [
+      segment({
+        text: 'hello world',
+        start: 0,
+        end: 1,
+        words: [
+          { word: 'hello ', start: 0, end: 0.5 },
+          { word: 'world', start: 0.5, end: 1 },
+        ],
+      }),
+    ];
+
+    const first = alignWhisperSegments(segments, [chunk(0)], 0);
+    expect(first.transcripts).toHaveLength(1);
+    expect(first.transcripts[0]._tag).toBe('transcript');
+    expect(first.transcripts[0].text).toBe('hello world');
+    expect(new Date(first.transcripts[0].started).getTime()).toBe(T0);
+    expect(first.lastUsedTimestamp).toBe(T0 + 1_000);
+
+    // Same segments, same chunk start: every word's absolute start is < lastUsedTimestamp -> filtered out.
+    const second = alignWhisperSegments(segments, [chunk(0)], first.lastUsedTimestamp!);
+    expect(second.transcripts).toEqual([]);
+    expect(second.lastUsedTimestamp).toBeUndefined();
+  });
+
+  test('keeps later words when earlier words fall before lastUsedTimestamp', () => {
+    const segments: WhisperSegment[] = [
+      segment({
+        text: 'old new',
+        start: 0,
+        end: 2,
+        words: [
+          { word: 'old ', start: 0, end: 1 },
+          { word: 'new', start: 1.5, end: 2 },
+        ],
+      }),
+    ];
+
+    // First word starts at T0, second at T0+1500 — only the second survives a cursor at T0+1000.
+    const result = alignWhisperSegments(segments, [chunk(0)], T0 + 1_000);
+    expect(result.transcripts).toHaveLength(1);
+    expect(result.transcripts[0].text).toBe('new');
+    expect(new Date(result.transcripts[0].started).getTime()).toBe(T0 + 1_500);
+    expect(result.lastUsedTimestamp).toBe(T0 + 2_000);
+  });
+
+  test('drops segments that end before lastUsedTimestamp', () => {
+    const segments: WhisperSegment[] = [
+      segment({
+        text: 'stale',
+        start: 0,
+        end: 0.5,
+        words: [{ word: 'stale', start: 0, end: 0.5 }],
+      }),
+      segment({
+        text: 'fresh',
+        start: 1,
+        end: 2,
+        words: [{ word: 'fresh', start: 1.5, end: 2 }],
+      }),
+    ];
+
+    const result = alignWhisperSegments(segments, [chunk(0)], T0 + 1_000);
+    expect(result.transcripts).toHaveLength(1);
+    expect(result.transcripts[0].text).toBe('fresh');
+  });
+});

--- a/packages/plugins/plugin-transcription/src/transcriber/transcriber.test.ts
+++ b/packages/plugins/plugin-transcription/src/transcriber/transcriber.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
-import { describe, expect, test } from 'vitest';
+import { describe, test } from 'vitest';
 
 import { type AudioChunk } from './audio-recorder';
 import { alignWhisperSegments, type WhisperSegment } from './transcriber';
@@ -24,7 +24,7 @@ const segment = (overrides: Partial<WhisperSegment>): WhisperSegment => ({
 });
 
 describe('alignWhisperSegments', () => {
-  test('returns empty when no chunks were transcribed', () => {
+  test('returns empty when no chunks were transcribed', ({ expect }) => {
     const result = alignWhisperSegments(
       [segment({ text: 'x', end: 1, words: [{ word: 'x', start: 0, end: 1 }] })],
       [],
@@ -34,7 +34,7 @@ describe('alignWhisperSegments', () => {
     expect(result.lastUsedTimestamp).toBeUndefined();
   });
 
-  test('absolute-timestamps and deduplicates segments against lastUsedTimestamp', () => {
+  test('absolute-timestamps and deduplicates segments against lastUsedTimestamp', ({ expect }) => {
     const segments: WhisperSegment[] = [
       segment({
         text: 'hello world',
@@ -60,7 +60,7 @@ describe('alignWhisperSegments', () => {
     expect(second.lastUsedTimestamp).toBeUndefined();
   });
 
-  test('keeps later words when earlier words fall before lastUsedTimestamp', () => {
+  test('keeps later words when earlier words fall before lastUsedTimestamp', ({ expect }) => {
     const segments: WhisperSegment[] = [
       segment({
         text: 'old new',
@@ -81,7 +81,7 @@ describe('alignWhisperSegments', () => {
     expect(result.lastUsedTimestamp).toBe(T0 + 2_000);
   });
 
-  test('drops segments that end before lastUsedTimestamp', () => {
+  test('drops segments that end before lastUsedTimestamp', ({ expect }) => {
     const segments: WhisperSegment[] = [
       segment({
         text: 'stale',

--- a/packages/plugins/plugin-transcription/src/transcriber/transcriber.test.ts
+++ b/packages/plugins/plugin-transcription/src/transcriber/transcriber.test.ts
@@ -25,7 +25,11 @@ const segment = (overrides: Partial<WhisperSegment>): WhisperSegment => ({
 
 describe('alignWhisperSegments', () => {
   test('returns empty when no chunks were transcribed', () => {
-    const result = alignWhisperSegments([segment({ text: 'x', end: 1, words: [{ word: 'x', start: 0, end: 1 }] })], [], 0);
+    const result = alignWhisperSegments(
+      [segment({ text: 'x', end: 1, words: [{ word: 'x', start: 0, end: 1 }] })],
+      [],
+      0,
+    );
     expect(result.transcripts).toEqual([]);
     expect(result.lastUsedTimestamp).toBeUndefined();
   });

--- a/packages/plugins/plugin-transcription/src/transcriber/transcriber.ts
+++ b/packages/plugins/plugin-transcription/src/transcriber/transcriber.ts
@@ -213,7 +213,7 @@ export class Transcriber extends Resource {
       throw new Error('No audio to send for transcribing');
     }
 
-    let segments: WhisperSegment[];
+    let segments: unknown;
     if (this._transcribeFn) {
       segments = await this._transcribeFn(audio);
     } else {
@@ -230,12 +230,16 @@ export class Transcriber extends Resource {
         throw new Error(`Transcription failed: ${response.statusText}`);
       }
 
-      ({ segments } = (await response.json()) as { segments: WhisperSegment[] });
+      ({ segments } = (await response.json()) as { segments?: unknown });
+    }
+
+    if (!Array.isArray(segments)) {
+      throw new Error('Transcription response payload is invalid');
     }
 
     log.info('transcription response', { segments: segments.length });
 
-    return segments;
+    return segments as WhisperSegment[];
   }
 
   private _alignSegments(segments: WhisperSegment[], originalChunks: AudioChunk[]): ContentBlock.Transcript[] {
@@ -253,8 +257,8 @@ export class Transcriber extends Resource {
  *
  * @param segments - Raw segments returned by the Whisper service for `originalChunks`.
  * @param originalChunks - Chunks fed into the transcription request (used for the zero timestamp).
- * @param lastUsedTimestamp - Most recent absolute timestamp already emitted; segments at or before
- *   this point are deduped out.
+ * @param lastUsedTimestamp - Most recent absolute timestamp already emitted; segments whose end
+ *   falls strictly before this point are deduped out, as are individual words whose start does.
  */
 export const alignWhisperSegments = (
   segments: WhisperSegment[],

--- a/packages/plugins/plugin-transcription/src/transcriber/transcriber.ts
+++ b/packages/plugins/plugin-transcription/src/transcriber/transcriber.ts
@@ -210,39 +210,30 @@ export class Transcriber extends Resource {
   @trace.span({ showInBrowserTimeline: true })
   private async _fetchTranscription(audio: string): Promise<WhisperSegment[]> {
     if (audio.length === 0) {
-      this._audioChunks = [];
       throw new Error('No audio to send for transcribing');
     }
 
     let segments: WhisperSegment[];
-    try {
-      if (this._transcribeFn) {
-        segments = await this._transcribeFn(audio);
-      } else {
-        const endpoint = this._config.endpoint ?? TRANSCRIPTION_URL;
-        const response = await fetch(`${endpoint}/transcribe`, {
-          method: 'POST',
-          body: JSON.stringify({ audio }),
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        });
+    if (this._transcribeFn) {
+      segments = await this._transcribeFn(audio);
+    } else {
+      const endpoint = this._config.endpoint ?? TRANSCRIPTION_URL;
+      const response = await fetch(`${endpoint}/transcribe`, {
+        method: 'POST',
+        body: JSON.stringify({ audio }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
 
-        if (!response.ok) {
-          throw new Error(`Transcription failed: ${response.statusText}`);
-        }
-
-        ({ segments } = (await response.json()) as { segments: WhisperSegment[] });
+      if (!response.ok) {
+        throw new Error(`Transcription failed: ${response.statusText}`);
       }
-    } catch (err) {
-      this._audioChunks = [];
-      throw err;
+
+      ({ segments } = (await response.json()) as { segments: WhisperSegment[] });
     }
 
-    log.info('transcription response', {
-      segments: segments.length,
-      string: segments.map((segment) => segment.text).join(' '),
-    });
+    log.info('transcription response', { segments: segments.length });
 
     return segments;
   }

--- a/packages/plugins/plugin-transcription/src/transcriber/transcriber.ts
+++ b/packages/plugins/plugin-transcription/src/transcriber/transcriber.ts
@@ -15,7 +15,7 @@ import { TRANSCRIPTION_URL } from '#types';
 import { mergeFloat64Arrays } from '../util';
 import { type AudioChunk, type AudioRecorder } from './audio-recorder';
 
-type WhisperWord = {
+export type WhisperWord = {
   word: string;
 
   /**
@@ -29,7 +29,7 @@ type WhisperWord = {
   end: number;
 };
 
-type WhisperSegment = {
+export type WhisperSegment = {
   text: string;
 
   /**
@@ -61,7 +61,19 @@ export type TranscribeConfig = {
    * This is needed to catch the beginning of the user's speech.
    */
   prefixBufferChunksAmount: number;
+
+  /**
+   * Override the transcription endpoint base URL.
+   * Defaults to the DXOS calls service.
+   */
+  endpoint?: string;
 };
+
+/**
+ * Function that converts a base64-encoded WAV payload into Whisper segments.
+ * Allows callers to swap in alternative providers or mock the transport.
+ */
+export type TranscribeFn = (audio: string) => Promise<WhisperSegment[]>;
 
 export type TranscriberProps = {
   config: TranscribeConfig;
@@ -71,6 +83,10 @@ export type TranscriberProps = {
    * @param segments - The transcribed segments.
    */
   onSegments: (segments: ContentBlock.Transcript[]) => Promise<void>;
+  /**
+   * Optional override of the transcription transport. When provided, supersedes `config.endpoint`.
+   */
+  transcribe?: TranscribeFn;
 };
 
 /**
@@ -87,15 +103,17 @@ export class Transcriber extends Resource {
   private readonly _config: TranscribeConfig;
   private readonly _recorder: AudioRecorder;
   private readonly _onSegments: TranscriberProps['onSegments'];
+  private readonly _transcribeFn?: TranscribeFn;
 
   private _recording = false;
   private _transcribeTask?: DeferredTask = undefined;
 
-  constructor({ config, recorder, onSegments }: TranscriberProps) {
+  constructor({ config, recorder, onSegments, transcribe }: TranscriberProps) {
     super();
     this._config = config;
     this._recorder = recorder;
     this._onSegments = onSegments;
+    this._transcribeFn = transcribe;
   }
 
   protected override async _open(ctx: Context): Promise<void> {
@@ -196,63 +214,91 @@ export class Transcriber extends Resource {
       throw new Error('No audio to send for transcribing');
     }
 
-    const response = await fetch(`${TRANSCRIPTION_URL}/transcribe`, {
-      method: 'POST',
-      body: JSON.stringify({ audio }),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
+    let segments: WhisperSegment[];
+    try {
+      if (this._transcribeFn) {
+        segments = await this._transcribeFn(audio);
+      } else {
+        const endpoint = this._config.endpoint ?? TRANSCRIPTION_URL;
+        const response = await fetch(`${endpoint}/transcribe`, {
+          method: 'POST',
+          body: JSON.stringify({ audio }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
 
-    if (!response.ok) {
+        if (!response.ok) {
+          throw new Error(`Transcription failed: ${response.statusText}`);
+        }
+
+        ({ segments } = (await response.json()) as { segments: WhisperSegment[] });
+      }
+    } catch (err) {
       this._audioChunks = [];
-      throw new Error(`Transcription failed: ${response.statusText}`);
+      throw err;
     }
-
-    const { segments } = (await response.json()) as {
-      segments: WhisperSegment[];
-    };
 
     log.info('transcription response', {
       segments: segments.length,
-      string: segments.map((segments) => segments.text).join(' '),
+      string: segments.map((segment) => segment.text).join(' '),
     });
 
     return segments;
   }
 
   private _alignSegments(segments: WhisperSegment[], originalChunks: AudioChunk[]): ContentBlock.Transcript[] {
-    // Absolute zero for all relative timestamps in the segments.
-    const zeroTimestamp = originalChunks.at(0)!.timestamp;
-
-    const filteredSegments = segments
-      // Use segments that end after the last used timestamp.
-      // Segments could overlap, so we need to filter words that starts after the last used timestamp.
-      .filter((segment) => zeroTimestamp + segment.end * 1_000 >= this._lastUsedTimestamp)
-      // Use words that starts after the last used timestamp.
-      .map((segment) => {
-        const words = segment.words.filter((word) => zeroTimestamp + word.start * 1_000 >= this._lastUsedTimestamp);
-        return {
-          ...segment,
-          words,
-          text: words.map((word) => word.word).join(''),
-          start: words.at(0)?.start ?? segment.end,
-        };
-      })
-      .filter((segment) => segment.words.length > 0);
-
-    if (filteredSegments.length === 0) {
-      return [];
+    const result = alignWhisperSegments(segments, originalChunks, this._lastUsedTimestamp);
+    if (result.lastUsedTimestamp !== undefined) {
+      this._lastUsedTimestamp = result.lastUsedTimestamp;
     }
+    return result.transcripts;
+  }
+}
 
-    // Update last timestamp.
-    this._lastUsedTimestamp = zeroTimestamp + filteredSegments.at(-1)!.end * 1_000;
+/**
+ * Pure helper that filters and absolute-timestamps Whisper segments against a chunk timeline.
+ * Exported for testing.
+ *
+ * @param segments - Raw segments returned by the Whisper service for `originalChunks`.
+ * @param originalChunks - Chunks fed into the transcription request (used for the zero timestamp).
+ * @param lastUsedTimestamp - Most recent absolute timestamp already emitted; segments at or before
+ *   this point are deduped out.
+ */
+export const alignWhisperSegments = (
+  segments: WhisperSegment[],
+  originalChunks: AudioChunk[],
+  lastUsedTimestamp: number,
+): { transcripts: ContentBlock.Transcript[]; lastUsedTimestamp?: number } => {
+  if (originalChunks.length === 0) {
+    return { transcripts: [] };
+  }
 
-    // Add absolute timestamp to each segment.
-    return filteredSegments.map((segment) => ({
+  const zeroTimestamp = originalChunks[0].timestamp;
+
+  const filteredSegments = segments
+    .filter((segment) => zeroTimestamp + segment.end * 1_000 >= lastUsedTimestamp)
+    .map((segment) => {
+      const words = segment.words.filter((word) => zeroTimestamp + word.start * 1_000 >= lastUsedTimestamp);
+      return {
+        ...segment,
+        words,
+        text: words.map((word) => word.word).join(''),
+        start: words.at(0)?.start ?? segment.end,
+      };
+    })
+    .filter((segment) => segment.words.length > 0);
+
+  if (filteredSegments.length === 0) {
+    return { transcripts: [] };
+  }
+
+  return {
+    transcripts: filteredSegments.map((segment) => ({
       _tag: 'transcript',
       started: new Date(zeroTimestamp + segment.start * 1_000).toISOString(),
       text: segment.text.trim(),
-    }));
-  }
-}
+    })),
+    lastUsedTimestamp: zeroTimestamp + filteredSegments.at(-1)!.end * 1_000,
+  };
+};

--- a/packages/plugins/plugin-transcription/src/types/capabilities.ts
+++ b/packages/plugins/plugin-transcription/src/types/capabilities.ts
@@ -20,6 +20,7 @@ export namespace TranscriptionCapabilities {
     recorderConfig?: Partial<MediaStreamRecorderProps['config']>;
     transcriberConfig?: Partial<TranscriberProps['config']>;
     onSegments: TranscriberProps['onSegments'];
+    transcribe?: TranscriberProps['transcribe'];
   };
 
   export type GetTranscriber = (props: GetTranscriberProps) => Transcriber;


### PR DESCRIPTION
## Summary

Refresh of the transcription plugin: makes the Whisper transport pluggable, adds an audio-upload affordance to the storybook, and introduces basic unit tests for the segment-alignment logic.

- **Pluggable transport**: `Transcriber` now takes an optional `transcribe: TranscribeFn` and a `config.endpoint` override. The default behavior (POST to the DXOS calls service) is unchanged. The new options are threaded through the `Transcriber` capability and the `useTranscriber` hook.
- **File upload**: `TranscriptionStory` exposes an upload control, and `FileTranscription.stories.tsx` uses it so users can transcribe a local audio file (the existing remote-URL default still works).
- **Unit tests**: `alignWhisperSegments` was extracted as a pure helper (semantics unchanged) and is exercised by `transcriber.test.ts` covering empty-chunks, dedup against `lastUsedTimestamp`, partial-word filtering, and stale-segment dropping.

## AI service review

- The plugin only uses `@dxos/ai`'s `AiService` in the `summarize` operation (`AiService.model('@anthropic/claude-sonnet-4-0')`), which already matches the current API — no overhaul needed.
- Transcription itself stays on the Cloudflare calls service. `@dxos/ai`'s `AiService` is `LanguageModel`-only today and has no transcription primitive, so there is nothing in the new API to migrate to. The injectable `TranscribeFn` keeps the door open if/when we add a transcription service tag.

## Test plan

- [x] `moon run plugin-transcription:test` (4 new tests pass; full suite green)
- [x] `moon run plugin-transcription:build`
- [x] `moon run plugin-transcription:lint -- --fix`
- [ ] Manually exercise `FileTranscription` story with an uploaded audio file in storybook
- [ ] Manually exercise `MicrophoneTranscription` story to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio file upload button in the transcription toolbar and support for uploaded audio sources
  * Option to supply a custom transcription function or override the transcription endpoint
  * Pluggable toolbar slot to extend the transcription UI
  * Updated keyword-recognition demo layout and added demo keyword

* **Improvements**
  * Improved segment alignment to reduce duplicates and omit stale words

* **Tests**
  * Added unit tests for segment alignment, deduplication, and timestamp filtering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->