### PR TITLE
feat(plugin-markdown): editable card variant for in-place editing

### DIFF
--- a/packages/plugins/plugin-board/src/containers/BoardContainer/BoardContainer.tsx
+++ b/packages/plugins/plugin-board/src/containers/BoardContainer/BoardContainer.tsx
@@ -165,7 +165,8 @@ export const BoardContainer = ({ role, subject: board, attendableId }: BoardCont
                 <Board.Content>
                   {items?.map((item, index) => (
                     <Board.Cell item={item} key={index} layout={board.layout?.cells[item.id] ?? { x: 0, y: 0 }}>
-                      <Surface.Surface type={AppSurface.Card} data={{ subject: item }} limit={1} />
+                      {/* `editable` opts the cell into the in-place editor variant — surfaces that don't recognize the flag fall back to the read-only card. */}
+                      <Surface.Surface type={AppSurface.Card} data={{ subject: item, editable: true }} limit={1} />
                     </Board.Cell>
                   ))}
                 </Board.Content>

--- a/packages/plugins/plugin-markdown/src/capabilities/react-surface.tsx
+++ b/packages/plugins/plugin-markdown/src/capabilities/react-surface.tsx
@@ -20,7 +20,7 @@ import { Text } from '@dxos/schema';
 import { type EditorViewMode } from '@dxos/ui-editor/types';
 
 import { MarkdownSettings } from '#components';
-import { MarkdownCard, MarkdownContainer, type MarkdownContainerProps } from '#containers';
+import { MarkdownCard, MarkdownEditableCard, MarkdownContainer, type MarkdownContainerProps } from '#containers';
 import { meta } from '#meta';
 import { Markdown, MarkdownCapabilities } from '#types';
 
@@ -75,8 +75,14 @@ export default Capability.makeModule(() =>
         },
       }),
       Surface.create({
+        id: 'surface.editable',
+        position: 'hoist',
+        filter: AppSurface.object(AppSurface.Card, [Markdown.Document, Text.Text], (data) => data.editable === true),
+        component: ({ data }) => <MarkdownEditableCard subject={data.subject} />,
+      }),
+      Surface.create({
         id: 'surface.preview',
-        filter: AppSurface.object(AppSurface.Card, [Markdown.Document, Text.Text]),
+        filter: AppSurface.object(AppSurface.Card, [Markdown.Document, Text.Text], (data) => data.editable !== true),
         component: ({ data }) => <MarkdownCard {...data} />,
       }),
     ]),

--- a/packages/plugins/plugin-markdown/src/containers/MarkdownCard/MarkdownEditableCard.tsx
+++ b/packages/plugins/plugin-markdown/src/containers/MarkdownCard/MarkdownEditableCard.tsx
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React from 'react';
+
+import { Obj } from '@dxos/echo';
+import { useObject } from '@dxos/react-client/echo';
+import { Card } from '@dxos/react-ui';
+import { Editor } from '@dxos/react-ui-editor';
+import { Text } from '@dxos/schema';
+
+import { MarkdownEditor, MarkdownEditorProvider } from '#components';
+import { Markdown } from '#types';
+
+export type MarkdownEditableCardProps = { subject: Markdown.Document | Text.Text };
+
+/**
+ * Full-bleed editable variant of {@link MarkdownCard}. Activated by the host
+ * passing `editable: true` on the card surface data (e.g. plugin-board cells).
+ * Renders a plain editor (no app-graph toolbar / file upload / link queries)
+ * so it stays self-contained inside the card; the regular MarkdownContainer
+ * remains the canonical surface for full article views.
+ */
+export const MarkdownEditableCard = ({ subject }: MarkdownEditableCardProps) => {
+  const id = Obj.getDXN(subject).toString();
+  const [docContent] = useObject(Obj.instanceOf(Markdown.Document, subject) ? subject.content : undefined, 'content');
+  const [textContent] = useObject(Obj.instanceOf(Text.Text, subject) ? subject : undefined, 'content');
+  const initialValue = docContent ?? textContent;
+
+  return (
+    <Card.Section classNames='col-span-3 min-h-0'>
+      <MarkdownEditorProvider id={id} object={subject} viewMode='source'>
+        {(editorRootProps) => (
+          <Editor.Root {...editorRootProps}>
+            <MarkdownEditor.Content initialValue={initialValue} />
+          </Editor.Root>
+        )}
+      </MarkdownEditorProvider>
+    </Card.Section>
+  );
+};

--- a/packages/plugins/plugin-markdown/src/containers/MarkdownCard/index.ts
+++ b/packages/plugins/plugin-markdown/src/containers/MarkdownCard/index.ts
@@ -3,3 +3,4 @@
 //
 
 export { MarkdownCard as default } from './MarkdownCard';
+export { MarkdownEditableCard } from './MarkdownEditableCard';

--- a/packages/plugins/plugin-markdown/src/containers/index.ts
+++ b/packages/plugins/plugin-markdown/src/containers/index.ts
@@ -7,4 +7,7 @@ import { type ComponentType, lazy } from 'react';
 export type { MarkdownContainerProps } from './MarkdownContainer';
 
 export const MarkdownCard: ComponentType<any> = lazy(() => import('./MarkdownCard'));
+export const MarkdownEditableCard: ComponentType<any> = lazy(() =>
+  import('./MarkdownCard').then((m) => ({ default: m.MarkdownEditableCard })),
+);
 export const MarkdownContainer: ComponentType<any> = lazy(() => import('./MarkdownContainer'));

--- a/packages/sdk/app-toolkit/src/ui/components/app-surface.ts
+++ b/packages/sdk/app-toolkit/src/ui/components/app-surface.ts
@@ -80,17 +80,27 @@ export const allOf = <TFilters extends ReadonlyArray<Surface.Filter<any>>>(
 
 /**
  * Filter: matches an ECHO object at the given role token's subject position.
+ *
+ * An optional `predicate` narrows on the rest of the data — most useful for
+ * surfaces that distinguish variants by a flag (e.g. `editable`, `compact`)
+ * without having to hand-roll a fully typed `Surface.Filter`.
  */
 export const object: {
   <TToken extends Surface.RoleToken<{ subject?: any }>, S extends Type.AnyEntity>(
     token: TToken,
     schema: S,
+    predicate?: (data: NonNullable<TokenData<TToken>>) => boolean,
   ): Surface.Filter<Omit<NonNullable<TokenData<TToken>>, 'subject'> & { subject: Schema.Schema.Type<S> }>;
   <TToken extends Surface.RoleToken<{ subject?: any }>, S extends Type.AnyEntity[]>(
     token: TToken,
     schemas: [...S],
+    predicate?: (data: NonNullable<TokenData<TToken>>) => boolean,
   ): Surface.Filter<Omit<NonNullable<TokenData<TToken>>, 'subject'> & { subject: Schema.Schema.Type<S[number]> }>;
-} = (token: Surface.RoleToken<any>, schemaOrSchemas: Type.AnyEntity | Type.AnyEntity[]): Surface.Filter<any> => {
+} = (
+  token: Surface.RoleToken<any>,
+  schemaOrSchemas: Type.AnyEntity | Type.AnyEntity[],
+  predicate?: (data: any) => boolean,
+): Surface.Filter<any> => {
   const schemas = Array.isArray(schemaOrSchemas) ? schemaOrSchemas : [schemaOrSchemas];
   const guard = (data: unknown): boolean => {
     if (typeof data !== 'object' || data === null) {
@@ -107,7 +117,10 @@ export const object: {
     ) {
       return false;
     }
-    return schemas.some((schema) => Obj.instanceOf(schema, subject));
+    if (!schemas.some((schema) => Obj.instanceOf(schema, subject))) {
+      return false;
+    }
+    return predicate ? predicate(data) : true;
   };
   return { bindings: [{ role: token.role, guard }] };
 };
@@ -404,6 +417,8 @@ export type CardData<Subject = unknown, Props extends {} = {}> = {
   projection?: ProjectionModel;
   /** Paths to omit from the card body (caller-defined redundancy; e.g. Kanban hides pivot). Dynamic-schema cards honor this; fixed-shape cards may ignore. */
   ignorePaths?: ReadonlyArray<string>;
+  /** When true, card surfaces should render an editable variant of the subject (full-bleed editor) rather than a read-only preview. Hosts opt in per-cell — e.g. plugin-board passes editable for in-place editing in grid cells. */
+  editable?: boolean;
 } & Props;
 
 /** Component props for card role. */

--- a/packages/ui/react-ui-board/src/components/Board/BoardCell.tsx
+++ b/packages/ui/react-ui-board/src/components/Board/BoardCell.tsx
@@ -66,9 +66,10 @@ export const BoardCell = ({ classNames, children, item, layout, draggable: isDra
     <Card.Root
       ref={rootRef}
       classNames={mx(
-        // Card.Root is flex-col; stretching the inner Column.Root to fill the cell
-        // and giving the surface row 1fr keeps the card from leaving a blank row at the bottom.
-        'absolute p-0 [&>.dx-column-root]:grow [&>.dx-column-root]:[grid-auto-rows:min-content] [&>.dx-column-root]:[align-content:space-between]',
+        // Card.Root is flex-col; stretch Column.Root to fill the cell and give the first surface
+        // row 1fr so it absorbs free space (e.g. the snippet body). Toolbar stays on row 1 (auto);
+        // any additional rows after row 2 auto-flow at min content.
+        'absolute p-0 [&>.dx-column-root]:grow [&>.dx-column-root]:[grid-template-rows:auto_minmax(0,1fr)]',
         dragState === 'dragging' && 'opacity-50',
         classNames,
       )}


### PR DESCRIPTION
## Summary

Adds a `MarkdownEditableCard` variant so card surfaces can render a full-bleed editor instead of the read-only preview when the host opts in. plugin-board uses this for the new Markdown documents it creates from the grid backdrop `+` button — they're now editable in place.

- `AppSurface.CardData` gains an optional `editable?: boolean` field. Hosts pass it on the surface data; surfaces that don't recognize it keep rendering the existing read-only card.
- `AppSurface.object(token, schemas, predicate?)` accepts an optional data predicate so variants can be discriminated declaratively without hand-rolling a typed `Surface.Filter`.
- New `MarkdownEditableCard` component — full-bleed, `viewMode: 'source'`, no app-graph toolbar / link query / file-upload wiring. It's intentionally self-contained so it composes inside a card cell.
- plugin-markdown registers two card surfaces:
  - `surface.editable` (hoisted) — matches when `data.editable === true`.
  - `surface.preview` (default) — explicitly excludes `editable === true` so the two never collide.
- `BoardContainer` passes `editable: true` for every cell.

## Test plan
- [x] `moon run app-toolkit:build plugin-markdown:build plugin-board:build` — green
- [x] `moon run app-toolkit:lint plugin-markdown:lint plugin-board:lint` — green
- [ ] Manual: open a Board, click `+` on an empty grid cell — the new Markdown document renders as an editable in-place editor (typing updates the underlying Text).
- [ ] Manual: existing card-mode previews (e.g. linked-doc cards in popovers) continue to render read-only `MarkdownCard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline editing for markdown cards — edit markdown content directly within cards on the board.
  * Cards now support an “editable” rendering variant for editable vs. preview displays.

* **Bug Fixes**
  * Board cell layout updated so columns stretch and absorb remaining space correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->