### PR TITLE
fix: Disable costly sqlite quick_check

### DIFF
--- a/packages/core/echo/echo-pipeline/src/db-host/echo-host.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/echo-host.ts
@@ -41,6 +41,14 @@ import { QueryServiceImpl } from './query-service';
 import { QueueDataSource } from './queue-data-source';
 import { SpaceStateManager } from './space-state-manager';
 
+/**
+ * Executes "PRAGMA quick_check;" on SQLite database on startup.
+ *
+ * NOTE: Keep DISABLED in production, "quick" check is O(dbSize) which took 6 seconds for my relatively-small profile.
+ *
+ */
+const RUN_SQLITE_QUICK_CHECK_ON_STARTUP = false;
+
 export type EchoHostProps = {
   kv: LevelDB;
   peerIdProvider?: PeerIdProvider;
@@ -440,15 +448,41 @@ export type EchoStatsDiagnostic = {
 
 /**
  * Sqlite health check on startup.
+ *
+ * Always runs a cheap schema-level probe (`PRAGMA schema_version` + a read from
+ * `sqlite_schema`). These do not walk user data, but they fail fast if the DB
+ * file header or schema root page is unreadable.
+ *
+ * Additionally runs `PRAGMA quick_check` when `RUN_SQLITE_QUICK_CHECK_ON_STARTUP`
+ * is enabled. That walks every page and is O(dbSize) — slow on OPFS.
  */
 const testSqlite = () =>
   Effect.gen(function* () {
+    log('begin sqlite health check');
     const sql = yield* SqlClient.SqlClient;
     const databases = yield* sql<{ seq: number; name: string; file: string }>`PRAGMA database_list`;
     log('SQLite databases', { databases });
-    const [result] = yield* sql<{ quick_check: string }>`PRAGMA quick_check`;
-    if (result.quick_check !== 'ok') {
-      throw new Error('SQLite quick check failed');
+
+    // Cheap header/schema probe: forces SQLite to read the file header and
+    // schema root page. Catches catastrophic corruption (bad header,
+    // unreadable schema) without walking user data.
+    const [schemaVersion] = yield* sql<{ schema_version: number }>`PRAGMA schema_version`;
+    const [schemaCount] = yield* sql<{ n: number }>`SELECT count(*) AS n FROM sqlite_schema`;
+    log('sqlite schema probe passed', {
+      schemaVersion: schemaVersion.schema_version,
+      objectCount: schemaCount.n,
+    });
+
+    if (RUN_SQLITE_QUICK_CHECK_ON_STARTUP) {
+      // NOTE: This is slow on non-trivial databases: O(dbSize).
+      log('starting sqlite quick_check');
+      const [result] = yield* sql<{ quick_check: string }>`PRAGMA quick_check`;
+      if (result.quick_check !== 'ok') {
+        throw new Error('SQLite quick check failed');
+      }
+      log('sqlite quick_check passed');
+    } else {
+      log('sqlite quick_check skipped');
     }
-    log('SQLite quick check passed');
+    log('sqlite health check complete');
   });


### PR DESCRIPTION
Added a configuration option to enable a "quick check" on the SQLite database during startup. This check is disabled by default due to its performance impact on larger databases. Improved logging for health check processes to provide clearer insights into the database state.