### PR TITLE
fix: resolve TypeDoc warnings and manualChunks build failures

### DIFF
--- a/packages/apps/testbench-app/vite.config.ts
+++ b/packages/apps/testbench-app/vite.config.ts
@@ -74,11 +74,25 @@ export default defineConfig(
             shell: path.resolve(dirname, './shell.html'),
           },
           output: {
-            manualChunks: {
-              react: ['react', 'react-dom', 'react-router-dom'],
-              dxos: ['@dxos/react-client'],
-              ui: ['@dxos/react-ui', '@dxos/ui-theme'],
-              editor: ['@dxos/react-ui-editor'],
+            // Rolldown (used by Vite 8) requires `manualChunks` to be a function — the
+            // record form that worked in Rollup is rejected at runtime.
+            manualChunks: (id: string) => {
+              if (
+                id.includes('/node_modules/react/') ||
+                id.includes('/node_modules/react-dom/') ||
+                id.includes('/node_modules/react-router-dom/')
+              ) {
+                return 'react';
+              }
+              if (id.includes('/node_modules/@dxos/react-client/')) {
+                return 'dxos';
+              }
+              if (id.includes('/node_modules/@dxos/react-ui/') || id.includes('/node_modules/@dxos/ui-theme/')) {
+                return 'ui';
+              }
+              if (id.includes('/node_modules/@dxos/react-ui-editor/')) {
+                return 'editor';
+              }
             },
           },
         },

--- a/packages/apps/todomvc/vite.config.ts
+++ b/packages/apps/todomvc/vite.config.ts
@@ -47,9 +47,19 @@ export default defineConfig({
         shell: resolve(__dirname, './shell.html'),
       },
       output: {
-        manualChunks: {
-          react: ['react', 'react-dom', 'react-router-dom'],
-          dxos: ['@dxos/react-client'],
+        // Rolldown (used by Vite 8) requires `manualChunks` to be a function — the
+        // record form that worked in Rollup is rejected at runtime.
+        manualChunks: (id: string) => {
+          if (
+            id.includes('/node_modules/react/') ||
+            id.includes('/node_modules/react-dom/') ||
+            id.includes('/node_modules/react-router-dom/')
+          ) {
+            return 'react';
+          }
+          if (id.includes('/node_modules/@dxos/react-client/')) {
+            return 'dxos';
+          }
         },
       },
     },

--- a/packages/common/protobuf-compiler/src/generator/message.ts
+++ b/packages/common/protobuf-compiler/src/generator/message.ts
@@ -2,7 +2,7 @@
 // Copyright 2020 DXOS.org
 //
 
-import { dirname, relative } from 'path';
+import { dirname, relative, sep } from 'path';
 import type * as protobufjs from 'protobufjs';
 import * as ts from 'typescript';
 
@@ -39,7 +39,7 @@ export const createMessageDeclaration = (type: protobufjs.Type, ctx: GeneratorCo
 
   const commentSections = type.comment ? [type.comment] : [];
   if (type.filename) {
-    commentSections.push(`Defined in: \`${relative(dirname(ctx.outputFilename), type.filename)}\``);
+    commentSections.push(`Defined in: \`${relative(dirname(ctx.outputFilename), type.filename).split(sep).join('/')}\``);
   }
 
   if (commentSections.length === 0) {

--- a/packages/common/protobuf-compiler/src/generator/message.ts
+++ b/packages/common/protobuf-compiler/src/generator/message.ts
@@ -39,7 +39,7 @@ export const createMessageDeclaration = (type: protobufjs.Type, ctx: GeneratorCo
 
   const commentSections = type.comment ? [type.comment] : [];
   if (type.filename) {
-    commentSections.push(`Defined in:\n  {@link file://./${relative(dirname(ctx.outputFilename), type.filename)}}`);
+    commentSections.push(`Defined in: \`${relative(dirname(ctx.outputFilename), type.filename)}\``);
   }
 
   if (commentSections.length === 0) {

--- a/packages/common/protobuf-compiler/src/generator/message.ts
+++ b/packages/common/protobuf-compiler/src/generator/message.ts
@@ -39,7 +39,9 @@ export const createMessageDeclaration = (type: protobufjs.Type, ctx: GeneratorCo
 
   const commentSections = type.comment ? [type.comment] : [];
   if (type.filename) {
-    commentSections.push(`Defined in: \`${relative(dirname(ctx.outputFilename), type.filename).split(sep).join('/')}\``);
+    commentSections.push(
+      `Defined in: \`${relative(dirname(ctx.outputFilename), type.filename).split(sep).join('/')}\``,
+    );
   }
 
   if (commentSections.length === 0) {

--- a/packages/devtools/devtools/vite.config.ts
+++ b/packages/devtools/devtools/vite.config.ts
@@ -39,8 +39,16 @@ export default defineConfig({
     sourcemap: true,
     rollupOptions: {
       output: {
-        manualChunks: {
-          vendor: ['react', 'react-router-dom', 'react-dom'],
+        // Rolldown (used by Vite 8) requires `manualChunks` to be a function — the
+        // record form that worked in Rollup is rejected at runtime.
+        manualChunks: (id: string) => {
+          if (
+            id.includes('/node_modules/react/') ||
+            id.includes('/node_modules/react-router-dom/') ||
+            id.includes('/node_modules/react-dom/')
+          ) {
+            return 'vendor';
+          }
         },
       },
     },


### PR DESCRIPTION
## Summary

- **Fix `todomvc:bundle` failure**: Rolldown (Vite 8) requires `manualChunks` to be a function — the record/object form accepted by Rollup is rejected at runtime with `TypeError: manualChunks is not a function`. Converted all three remaining object-form usages in `todomvc`, `testbench-app`, and `devtools` vite configs to the function form (following the pattern already used in `composer-app`).
- **Fix TypeDoc warnings**: The protobuf compiler's `message.ts` generated JSDoc comments containing `{@link file://./...gossip.proto}` for every proto message type. TypeDoc cannot resolve `file://` links to `.proto` files, producing 55 warnings per run. Changed the comment to use plain backtick formatting instead of the `{@link}` tag.

## Test plan

- [ ] `moon run todomvc:bundle` completes without `TypeError: manualChunks is not a function`
- [ ] `moon run testbench-app:bundle` completes without `manualChunks` error
- [ ] `moon run devtools:bundle` completes without `manualChunks` error
- [ ] `moon run t-client:typedoc` produces 0 warnings about unresolved proto file links

https://claude.ai/code/session_0164v91iLzYHx3Hs6tKhuVgX

---
_Generated by [Claude Code](https://claude.ai/code/session_0164v91iLzYHx3Hs6tKhuVgX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized build chunking across apps by switching manual chunk assignment to a function-based strategy for bundling, improving compatibility with the newer build pipeline.
* **Documentation**
  * Improved generated doc-comment formatting for message references by normalizing paths and inlining the "Defined in" note for clearer, more consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->