### PR TITLE
fix(plugin-chess): make info panel toggle button a true toggle

### DIFF
--- a/packages/plugins/plugin-chess/src/containers/ChessArticle/ChessArticle.tsx
+++ b/packages/plugins/plugin-chess/src/containers/ChessArticle/ChessArticle.tsx
@@ -34,7 +34,6 @@ export const ChessArticle = ({ role, attendableId: _attendableId, subject: game 
               icon='ph--info--regular'
               iconOnly
               label={t('toggle-info.button')}
-              disabled={showInfo}
               classNames={mx('invisible @3xl:visible')}
               onClick={() => setShowInfo((open) => !open)}
             />


### PR DESCRIPTION
## Summary

- Removes `disabled={showInfo}` from the toolbar "Toggle info" icon button in `ChessArticle`
- The button was labeled "Toggle info" but could only *show* the info panel, not hide it — the `disabled` prop made the toggle one-directional
- With this fix the toolbar button hides the info panel when it is open, making the button label semantically accurate and consistent with standard toggle UX

## Test plan

- [ ] Open a chess game in Composer at `@3xl` container width
- [ ] Verify the info panel is visible by default and the toolbar info button is clickable (not greyed out)
- [ ] Click the toolbar info button — info panel should hide
- [ ] Click it again — info panel should re-appear
- [ ] Verify the X button inside the info panel still closes the panel independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The info toggle button in chess articles is now always clickable, allowing users to toggle the info panel at any time without restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->