### PR TITLE
fix(plugin-chess): make info panel toggle button a true toggle

### DIFF
--- a/packages/plugins/plugin-chess/src/containers/ChessArticle/ChessArticle.tsx
+++ b/packages/plugins/plugin-chess/src/containers/ChessArticle/ChessArticle.tsx
@@ -1,6 +1,7 @@
 //
 // Copyright 2024 DXOS.org
 //
+//
 
 import React, { useCallback, useRef, useState } from 'react';
 

--- a/packages/plugins/plugin-chess/src/containers/ChessArticle/ChessArticle.tsx
+++ b/packages/plugins/plugin-chess/src/containers/ChessArticle/ChessArticle.tsx
@@ -34,7 +34,6 @@ export const ChessArticle = ({ role, attendableId: _attendableId, subject: game 
               icon='ph--info--regular'
               iconOnly
               label={t('toggle-info.button')}
-              disabled={showInfo}
               classNames={mx('invisible @3xl:visible')}
               onClick={() => setShowInfo((open) => !open)}
             />


### PR DESCRIPTION
## Summary

- Removes `disabled={showInfo}` from the toolbar "Toggle info" icon button in `ChessArticle`
- The button was labelled "Toggle info" but could only *show* the info panel — `disabled={showInfo}` made it one-directional
- With this fix the toolbar button hides the panel when open and shows it when hidden, matching the label and standard toggle UX

## Test plan

- [ ] Open a chess game in Composer at `@3xl` container width
- [ ] Verify the info panel is visible by default and the toolbar info button is now clickable (not greyed out)
- [ ] Click the toolbar info button — info panel should hide
- [ ] Click it again — info panel should reappear
- [ ] Verify the X button inside the info panel still closes it independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the info toggle in the chess plugin so the button stays clickable while the info panel is shown or hidden. Added a clear, translated accessibility label for the toggle button while keeping its icon-only appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->