### PR TITLE
feat(storybook): integrate vite-plugin-log for log transform

### DIFF
--- a/.moon/tasks/tag-ts-test-storybook.yml
+++ b/.moon/tasks/tag-ts-test-storybook.yml
@@ -8,6 +8,7 @@ tasks:
       - storybook-addon-logger:compile
       - vite-plugin-icons:compile
       - vite-plugin-import-source:compile
+      - vite-plugin-log:compile
       - ^:compile
     inputs:
       - '@group(sources)'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20622,6 +20622,9 @@ importers:
       '@dxos/vite-plugin-icons':
         specifier: workspace:*
         version: link:../vite-plugin-icons
+      '@dxos/vite-plugin-log':
+        specifier: workspace:*
+        version: link:../vite-plugin-log
       '@storybook/addon-docs':
         specifier: 'catalog:'
         version: 10.3.6(@types/react@19.2.7)(esbuild@0.28.0)(rollup@3.30.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.28.0))
@@ -20670,6 +20673,9 @@ importers:
       '@dxos/vite-plugin-import-source':
         specifier: workspace:*
         version: link:../vite-plugin-import-source
+      '@dxos/vite-plugin-log':
+        specifier: workspace:*
+        version: link:../vite-plugin-log
       '@storybook/addon-docs':
         specifier: 'catalog:'
         version: 10.3.6(@types/react@19.2.7)(esbuild@0.28.0)(rollup@3.30.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.28.0))
@@ -20742,6 +20748,9 @@ importers:
       '@dxos/vite-plugin-icons':
         specifier: workspace:*
         version: link:../vite-plugin-icons
+      '@dxos/vite-plugin-log':
+        specifier: workspace:*
+        version: link:../vite-plugin-log
       '@storybook/addon-docs':
         specifier: 'catalog:'
         version: 10.3.6(@types/react@19.2.7)(esbuild@0.28.0)(rollup@3.30.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.28.0))

--- a/tools/storybook-lit/.storybook/main.ts
+++ b/tools/storybook-lit/.storybook/main.ts
@@ -45,10 +45,13 @@ export const config = ({ stories: baseStories, ...baseConfig }: Partial<Storyboo
     // NOTE: Dynamic imports seems to help avoid conflicts with storybook's internal esbuild-register usage & Vite 7.
     const { mergeConfig } = await import('vite');
     const { default: Inspect } = await import('vite-plugin-inspect');
+    const { DxosLogPlugin } = await import('@dxos/vite-plugin-log');
 
     return mergeConfig(config, {
       plugins: [
         isTrue(process.env.DX_INSPECT) && Inspect(),
+
+        DxosLogPlugin(),
 
         IconsPlugin({
           symbolPattern: 'ph--([a-z]+[a-z-]*)--(bold|duotone|fill|light|regular|thin)',

--- a/tools/storybook-lit/package.json
+++ b/tools/storybook-lit/package.json
@@ -17,6 +17,7 @@
     "@dxos/log": "workspace:*",
     "@dxos/ui-theme": "workspace:*",
     "@dxos/vite-plugin-icons": "workspace:*",
+    "@dxos/vite-plugin-log": "workspace:*",
     "@storybook/addon-docs": "catalog:",
     "@storybook/addon-links": "catalog:",
     "@storybook/addon-themes": "catalog:",

--- a/tools/storybook-lit/tsconfig.json
+++ b/tools/storybook-lit/tsconfig.json
@@ -19,6 +19,9 @@
     },
     {
       "path": "../vite-plugin-icons"
+    },
+    {
+      "path": "../vite-plugin-log"
     }
   ]
 }

--- a/tools/storybook-react/.storybook/main.ts
+++ b/tools/storybook-react/.storybook/main.ts
@@ -96,6 +96,7 @@ export const createConfig = ({
     const { default: react } = await import('@vitejs/plugin-react-swc');
     const { mergeConfig } = await import('vite');
     const { default: inspect } = await import('vite-plugin-inspect');
+    const { DxosLogPlugin } = await import('@dxos/vite-plugin-log');
 
     const finalConfig = mergeConfig(
       {
@@ -285,6 +286,8 @@ export const createConfig = ({
           //
           // Custom DXOS plugins.
           //
+
+          DxosLogPlugin(),
 
           IconsPlugin({
             assetPath: (name, variant) =>

--- a/tools/storybook-react/package.json
+++ b/tools/storybook-react/package.json
@@ -24,6 +24,7 @@
     "@dxos/ui-theme": "workspace:*",
     "@dxos/vite-plugin-icons": "workspace:*",
     "@dxos/vite-plugin-import-source": "workspace:*",
+    "@dxos/vite-plugin-log": "workspace:*",
     "@storybook/addon-docs": "catalog:",
     "@storybook/addon-links": "catalog:",
     "@storybook/addon-themes": "catalog:",

--- a/tools/storybook-react/tsconfig.json
+++ b/tools/storybook-react/tsconfig.json
@@ -31,6 +31,9 @@
     },
     {
       "path": "../vite-plugin-import-source"
+    },
+    {
+      "path": "../vite-plugin-log"
     }
   ]
 }

--- a/tools/storybook-solid/.storybook/main.ts
+++ b/tools/storybook-solid/.storybook/main.ts
@@ -46,10 +46,13 @@ export const config = ({ stories: baseStories, ...baseConfig }: Partial<Storyboo
     const { mergeConfig } = await import('vite');
     const { default: Inspect } = await import('vite-plugin-inspect');
     const { default: solidPlugin } = await import('vite-plugin-solid');
+    const { DxosLogPlugin } = await import('@dxos/vite-plugin-log');
 
     return mergeConfig(config, {
       plugins: [
         isTrue(process.env.DX_INSPECT) && Inspect(),
+
+        DxosLogPlugin(),
 
         solidPlugin(),
 

--- a/tools/storybook-solid/package.json
+++ b/tools/storybook-solid/package.json
@@ -17,6 +17,7 @@
     "@dxos/log": "workspace:*",
     "@dxos/ui-theme": "workspace:*",
     "@dxos/vite-plugin-icons": "workspace:*",
+    "@dxos/vite-plugin-log": "workspace:*",
     "@storybook/addon-docs": "catalog:",
     "@storybook/addon-links": "catalog:",
     "@storybook/addon-themes": "catalog:",

--- a/tools/storybook-solid/tsconfig.json
+++ b/tools/storybook-solid/tsconfig.json
@@ -20,6 +20,9 @@
     },
     {
       "path": "../vite-plugin-icons"
+    },
+    {
+      "path": "../vite-plugin-log"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `@dxos/vite-plugin-log` as a `workspace:*` dev dependency to `storybook-react`, `storybook-solid`, and `storybook-lit`
- Calls `DxosLogPlugin()` inside each storybook's `viteFinal` hook (using dynamic import, consistent with existing plugin loading pattern)
- Enables both the log-meta call-site transform and the dev log-to-file sink in all three storybook flavors, matching behavior already present in `composer-app` and `testbench-app`

## Test plan

- [ ] `moon run storybook-react:serve` starts without errors and storybook loads
- [ ] `@dxos/log` call-site metadata (file, line, scope) is injected into log output during storybook dev
- [ ] `app.log` is written during storybook dev session
- [ ] `moon run storybook-solid:serve` and `storybook-lit:serve` start without errors

---
_Generated by [Claude Code](https://claude.ai/code/session_019mzGtwZhofFs3ziLubUAuh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Storybook dev environments (Lit, React, Solid) updated to include a new logging plugin for improved runtime logs.
  * Development dependencies and build/test task dependencies updated to support the plugin.
  * TypeScript project references adjusted for the Storybook toolchains to include the new plugin project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->