### PR TITLE
ci: fix concurrency group to prevent pull_request cancelling pull_request_target

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,7 +42,8 @@ env:
 
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Include event_name so pull_request and pull_request_target runs don't cancel each other.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # https://moonrepo.dev/docs/guides/ci

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,8 +50,11 @@ concurrency:
 jobs:
   check:
     # pull_request handles same-repo PRs; pull_request_target handles fork PRs.
-    # Skip pull_request_target for same-repo PRs to avoid double runs.
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository
+    # Skip pull_request_target for same-repo PRs (avoid double runs) and
+    # skip pull_request for fork PRs (no secrets, would fail).
+    if: >-
+      (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository) &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     # Gate fork PRs on maintainer approval before running fork code with secrets in scope.
     environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external-pr' || '' }}
     runs-on: depot-ubuntu-24.04-8
@@ -108,8 +111,11 @@ jobs:
 
   test:
     # pull_request handles same-repo PRs; pull_request_target handles fork PRs.
-    # Skip pull_request_target for same-repo PRs to avoid double runs.
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository
+    # Skip pull_request_target for same-repo PRs (avoid double runs) and
+    # skip pull_request for fork PRs (no secrets, would fail).
+    if: >-
+      (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name != github.repository) &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     strategy:
       matrix:
         node-version: ['24.11.1']


### PR DESCRIPTION
## Summary

- Adds `${{ github.event_name }}` to the concurrency group key so `pull_request` and `pull_request_target` runs for the same PR no longer cancel each other.
- Without this, approving the `pull_request` fork workflows (via "Approve workflows to run") would cancel the already-waiting `pull_request_target` run, resulting in spurious "Error" deployment failures on the `external-pr` environment.

## Test plan
- [ ] Open a fork PR; verify `pull_request_target` jobs pause at environment gate
- [ ] Approve the `pull_request` workflows; verify both sets of runs proceed independently without cancelling each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow concurrency to prevent duplicate or canceled job runs during pull request processing.
  * Adjusted CI gating so forked PRs no longer trigger runs that require repository secrets, reducing unnecessary executions and avoiding secret exposure.
  * Reduced redundant workflow runs for same-repo PRs to streamline CI usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->