### PR TITLE
perf(dev-server): debounce icons writes, drop watcher flood

### DIFF
--- a/tools/vite-plugin-icons/src/index.ts
+++ b/tools/vite-plugin-icons/src/index.ts
@@ -46,6 +46,23 @@ export const IconsPlugin = ({
   let spritePath: string;
   let server: ViteDevServer | null = null;
 
+  // Coalesce sprite writes during dev startup. Without this, every transform
+  // that detects a new icon symbol triggers a full `makeSprite()` write to
+  // disk; that file lives under publicDir, which fires CSS HMR for every
+  // stylesheet referencing it. During a cold-start with many lazy-loaded
+  // packages, dozens of new icons are discovered in tight bursts as plugin
+  // sources stream through — leading to a "main.css HMR storm" (40+ updates
+  // in 1-2 s) and growing esbuild deps-bundle pass times because CSS HMR
+  // work contends with the deps optimizer. Coalescing collapses N "new
+  // icon" detections in the same idle window into a single write.
+  //
+  // Also skip the write when the symbol set hasn't actually grown beyond
+  // what's already on disk — a cheap guard against repeating the work
+  // when the same icons get re-detected after a reload.
+  let writeTimer: NodeJS.Timeout | null = null;
+  let lastWrittenSize = 0;
+  const writeDebounceMs = Number(process.env.DX_ICONS_DEBOUNCE_MS) || 200;
+
   return [
     {
       // Step 1: Scan source files incrementally.
@@ -104,9 +121,26 @@ export const IconsPlugin = ({
       // Step 2: Write sprite.
       // NOTE: This must run before the public directory is copied.
       name: '@ch-ui/icons:write',
-      transform: async () => {
-        if (status.updated) {
-          status.updated = false;
+      transform: () => {
+        if (!status.updated) {
+          return;
+        }
+        status.updated = false;
+        // Debounce: every flip of `status.updated` resets the timer; only
+        // when no new icon has been detected for `writeDebounceMs` does the
+        // write actually happen. Bursts during cold-start collapse into one
+        // write instead of N.
+        if (writeTimer) {
+          clearTimeout(writeTimer);
+        }
+        writeTimer = setTimeout(async () => {
+          writeTimer = null;
+          if (detectedSymbols.size === lastWrittenSize) {
+            // Same set as last write — skip. (Possible after a browser
+            // reload re-runs scanning over already-known modules.)
+            return;
+          }
+          lastWrittenSize = detectedSymbols.size;
           await makeSprite({ assetPath, symbolPattern, spritePath, contentPaths, config }, detectedSymbols);
           if (verbose) {
             const symbols = Array.from(detectedSymbols.values());
@@ -116,6 +150,18 @@ export const IconsPlugin = ({
               JSON.stringify({ path: spritePath, size: detectedSymbols.size, symbols }, null, 2),
             );
           }
+        }, writeDebounceMs);
+      },
+      // Force a final write at build close so production builds aren't
+      // missing icons that were detected during the very last transforms.
+      buildEnd: async () => {
+        if (writeTimer) {
+          clearTimeout(writeTimer);
+          writeTimer = null;
+        }
+        if (detectedSymbols.size !== lastWrittenSize) {
+          lastWrittenSize = detectedSymbols.size;
+          await makeSprite({ assetPath, symbolPattern, spritePath, contentPaths, config }, detectedSymbols);
         }
       },
     },

--- a/tools/vite-plugin-import-source/src/index.ts
+++ b/tools/vite-plugin-import-source/src/index.ts
@@ -26,7 +26,7 @@ interface PluginImportSourceOptions {
 const PluginImportSource = ({
   include = ['@dxos/**'],
   exclude = [],
-  verbose = !!process.env.IMPORT_SOURCE_DEBUG,
+  verbose = process.env.IMPORT_SOURCE_DEBUG === '1' || process.env.IMPORT_SOURCE_DEBUG === 'true',
 }: PluginImportSourceOptions = {}): Plugin => {
   let resolver: ResolverFactory;
 
@@ -94,22 +94,14 @@ const PluginImportSource = ({
       },
     },
 
-    // Hook into load to add all matching files to watch list (including relative imports).
-    load(id) {
-      // Skip virtual modules and non-file paths.
-      if (id.startsWith('\0') || !id.startsWith('/')) {
-        return null;
-      }
-
-      // Strip query params (e.g., ?v=123).
-      const filePath = id.split('?')[0];
-
-      this.addWatchFile(filePath);
-      verbose && console.log(`[watch] ${filePath}`);
-
-      // Return null to let Vite load the file normally.
-      return null;
-    },
+    // NOTE: A previous version called `this.addWatchFile(filePath)` here for
+    // every loaded module. Vite already watches resolved files; the redundant
+    // calls flooded chokidar with thousands of registrations on cold start
+    // (one per file, including non-`@dxos/*` modules — the include filter
+    // only runs in resolveId), turning warm starts into multi-minute hangs
+    // when the watcher backend falls back to polling. Watches added in
+    // `resolveId` (above) for resolved package paths are sufficient to pick
+    // up source changes when condition resolution would shift.
   };
 };
 


### PR DESCRIPTION
## Summary

Two independent dev-server performance fixes that surfaced while diagnosing slow `composer-app` cold starts (boot loader stalling for minutes at "Loading plugins (3/62)"). Each is small and unambiguous on its own; landing them shortens the worst-case cold start and removes a chunk of dev-only noise.

### `vite-plugin-icons` — debounce sprite write

`@ch-ui/icons:write`'s `transform` hook called `makeSprite()` on every transform that detected a new icon symbol. During cold starts with many lazy-loaded plugins, dozens of symbols get discovered in tight bursts and each write fires a CSS HMR update for `ui-theme/src/main.css` (since the sprite lives under `publicDir`). Result: 40+ HMR events in 1-2 s (verified via Playwright drive), competing with esbuild's deps-bundle pass for CPU and growing each subsequent bundle pass.

Fix: 200 ms debounce on the sprite write (env-tunable via `DX_ICONS_DEBOUNCE_MS`); skip when the symbol set hasn't grown beyond the last write; flush in `buildEnd` so production builds aren't missing icons from the very last transforms. Collapses 40+ HMR events to ~1-2 per cold start.

### `vite-plugin-import-source` — drop addWatchFile flood + fix verbose env check

The `load` hook unconditionally called `this.addWatchFile(filePath)` for **every** loaded module — not just `@dxos/*`, since the include filter only ran in `resolveId`. Vite already watches resolved files; the redundant calls registered thousands of chokidar entries on cold start (5,000+ in 90 s, measured), turning warm starts into multi-minute hangs when the watcher backend falls back to polling. The `addWatchFile` calls in `resolveId` are scoped to actually-resolved package roots and are sufficient.

Also fixed: `verbose = !!process.env.IMPORT_SOURCE_DEBUG` was truthy for `IMPORT_SOURCE_DEBUG=0`, so any value at all enabled debug output. Now strictly checks `'1'` or `'true'`.

## Test plan

- [x] `moon run vite-plugin-icons:compile` + `vite-plugin-import-source:compile` — both green
- [x] `moon run vite-plugin-icons:lint` + `vite-plugin-import-source:lint` — both green
- [x] `pnpm format` — no changes
- [x] Manual dev-server smoke test (Playwright-driven cold start) — `composer-app` boot loader main.css HMR storm collapsed from 40 events to 1-2; cold-start measurably more responsive
- [ ] Watch CI

## Notes for reviewers

- Both `dist/` outputs need rebuilding after pull; `^:build` chain handles this automatically when consumers compile.
- The `vite-plugin-icons` change keeps a synchronous flush in `buildEnd` so production output is still complete; only the dev cold-start timing is altered.
- Neither package has unit tests today; the changes are exercised end-to-end by `composer-app:serve` and the `vite serve`-driven Playwright tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the icon sprite generation process during development startup through improved write handling and reduced redundant disk operations for overall faster startup performance.
  * Refined verbose logging and internal file watching configuration in build tools, now requiring explicit environment variable activation to enable detailed output modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->