### PR TITLE
chore(log-store-idb): mark publishable

### DIFF
--- a/packages/common/log-store-idb/package.json
+++ b/packages/common/log-store-idb/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/log-store-idb",
   "version": "0.8.3",
-  "private": true,
   "description": "IndexedDB-backed log store for @dxos/log.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -32,5 +31,8 @@
   "dependencies": {
     "@dxos/log": "workspace:*"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
## Summary

Removes `"private": true` from `@dxos/log-store-idb` and adds the standard `publishConfig.access: public` so the CI publish flow includes the package going forward.

A one-off `npm publish --access public` of `0.0.0` is being performed manually to claim the name on npm. The next CI publish will pick up from the workspace version (`0.8.3`) and continue with the usual `0.8.4-main.<sha>` cadence.

## Why publish at all

`@dxos/observability` and `@dxos/plugin-debug` both declare a runtime `workspace:*` dep on `@dxos/log-store-idb`. When those packages are published to npm, pnpm rewrites the workspace reference to a concrete version. Consumers (e.g. plugin-excalidraw) then try to install that version and 404 because log-store-idb was never on the registry.

## Pre-merge

- [ ] Trusted publisher for `@dxos/log-store-idb` configured in the npm dashboard so the next CI provenance attempt doesn't fail and stall the publish stream the same way `assistant-e2e` / `compute-hyperformula` did before #11223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing configuration to enable public access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->