### PR TITLE
feat(plugin-assistant): resilient chat with MCP server failures

### DIFF
--- a/packages/apps/composer-app/index.html
+++ b/packages/apps/composer-app/index.html
@@ -27,7 +27,7 @@
 
     <link rel="manifest" href="/site.webmanifest" />
 
-    <!--
+    <!-- 
       Suppress lit's dev-mode warning. Lit checks `globalThis.litIssuedWarnings`
       against either the warning code or the full text and skips emitting if a
       match is already present (`@lit/reactive-element/development/reactive-element.js`).
@@ -40,12 +40,6 @@
     </script>
   </head>
   <body>
-    <!--
-      Boot loader (style block, skeleton DOM, and inline driver script) is injected by
-      `bootLoaderPlugin` from `@dxos/app-framework/vite-plugin` (see vite.config.ts).
-      The host calls `window.__bootLoader.status(text)` from `src/main.tsx` between
-      phases and `window.__bootLoader.dismiss()` once React has mounted.
-    -->
     <div id="root" class="contents"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/packages/core/assistant-e2e/package.json
+++ b/packages/core/assistant-e2e/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxos/assistant-e2e",
-  "private": true,
   "version": "0.8.3",
+  "private": true,
   "description": "Assistant e2e tests.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/core/assistant/src/conversation/session.ts
+++ b/packages/core/assistant/src/conversation/session.ts
@@ -14,7 +14,7 @@ import * as Runtime from 'effect/Runtime';
 
 import { type OpaqueToolkit, type ToolExecutionService, type ToolResolverService } from '@dxos/ai';
 import { type Blueprint } from '@dxos/compute';
-import { Operation, type OperationRegistry } from '@dxos/compute';
+import { Operation, type OperationRegistry, Trace } from '@dxos/compute';
 import { Resource } from '@dxos/context';
 import { Database, Feed, Filter, Obj } from '@dxos/echo';
 import { acquireReleaseResource } from '@dxos/effect';
@@ -33,6 +33,7 @@ import {
   formatSystemPrompt,
 } from '../session';
 import { AiContextBinder, AiContextService } from './context';
+import { McpServerError } from '../tracing';
 
 export interface McpServerConfig {
   url: string;
@@ -270,7 +271,7 @@ const aiContextFromSession = Layer.effect(
 const connectMcpServers = (
   blueprints: readonly Blueprint.Blueprint[],
   spaceMcpServers: readonly McpServerConfig[] = [],
-): Effect.Effect<OpaqueToolkit.OpaqueToolkit[]> => {
+): Effect.Effect<OpaqueToolkit.OpaqueToolkit[], never, Trace.TraceService> => {
   const blueprintServers: McpToolkit.McpToolkitOptions[] = pipe(
     blueprints,
     Array.flatMap((_) => _.mcpServers ?? []),
@@ -291,7 +292,41 @@ const connectMcpServers = (
         Effect.tap((toolkit): void =>
           log.info('Connected to MCP server', { url: options.url, tools: Object.keys(toolkit.toolkit.tools).length }),
         ),
-        Effect.tapDefect((error) => Effect.sync(() => log.warn('Failed to connect to MCP server', { error }))),
+        // Surface typed connection failures via ephemeral trace + warn log, then drop the server.
+        Effect.tapError((error) =>
+          Effect.gen(function* () {
+            log.warn('Failed to connect to MCP server', {
+              url: error.url,
+              kind: error.kind,
+              message: error.message,
+            });
+            yield* Trace.write(McpServerError, {
+              url: error.url,
+              kind: error.kind,
+              message: error.message,
+            });
+          }),
+        ),
+        // Catch unexpected defects too (e.g. malformed tool schemas) so a single broken
+        // server can never abort the whole turn — surface them through the same channel.
+        Effect.catchAllDefect((defect) =>
+          Effect.gen(function* () {
+            const message = defect instanceof Error ? defect.message : String(defect);
+            log.warn('Unexpected MCP defect', { url: options.url, message });
+            yield* Trace.write(McpServerError, {
+              url: options.url,
+              kind: options.kind,
+              message: `Unexpected MCP failure: ${message}`,
+            });
+            return yield* Effect.fail(
+              new McpToolkit.McpConnectionError({
+                url: options.url,
+                kind: options.kind,
+                message,
+              }),
+            );
+          }),
+        ),
         Effect.either,
       ),
     ),

--- a/packages/core/assistant/src/conversation/session.ts
+++ b/packages/core/assistant/src/conversation/session.ts
@@ -32,8 +32,8 @@ import {
   createToolkit,
   formatSystemPrompt,
 } from '../session';
-import { AiContextBinder, AiContextService } from './context';
 import { McpServerError } from '../tracing';
+import { AiContextBinder, AiContextService } from './context';
 
 export interface McpServerConfig {
   url: string;

--- a/packages/core/assistant/src/tracing.ts
+++ b/packages/core/assistant/src/tracing.ts
@@ -41,3 +41,17 @@ export const AgentRequestEnd = Trace.EventType('assistant.agentRequestEnd', {
   schema: Schema.Struct({}),
   isEphemeral: false,
 });
+
+/**
+ * Emitted when an MCP server connection fails for a request turn.
+ * Ephemeral so that misconfigured/unreachable servers don't pollute the durable feed,
+ * but can still be surfaced to the user via the live ephemeral event stream.
+ */
+export const McpServerError = Trace.EventType('assistant.mcpServerError', {
+  schema: Schema.Struct({
+    url: Schema.String,
+    kind: Schema.Literal('sse', 'http'),
+    message: Schema.String,
+  }),
+  isEphemeral: true,
+});

--- a/packages/core/compute-hyperformula/package.json
+++ b/packages/core/compute-hyperformula/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dxos/compute-hyperformula",
-  "private": true,
   "version": "0.8.3",
+  "private": true,
   "description": "HyperFormula-based compute graph (spreadsheet) engine.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/core/mcp-client/src/McpToolkit.ts
+++ b/packages/core/mcp-client/src/McpToolkit.ts
@@ -9,6 +9,7 @@ import * as Toolkit from '@effect/ai/Toolkit';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import * as Cause from 'effect/Cause';
 import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
 
@@ -20,6 +21,19 @@ export interface McpToolkitOptions {
   kind: 'sse' | 'http';
   apiKey?: string;
 }
+
+/**
+ * Typed failure raised when the MCP client cannot connect or list tools.
+ * Carries the underlying cause and the server URL for diagnostics.
+ */
+export class McpConnectionError extends Schema.TaggedError<McpConnectionError>('McpConnectionError')(
+  'McpConnectionError',
+  {
+    url: Schema.String,
+    kind: Schema.Literal('sse', 'http'),
+    message: Schema.String,
+  },
+) {}
 
 /**
  * Creates an OpaqueToolkit that connects to an MCP server and exposes its tools to the assistant.

--- a/packages/core/mcp-client/src/McpToolkit.ts
+++ b/packages/core/mcp-client/src/McpToolkit.ts
@@ -43,11 +43,19 @@ export class McpConnectionError extends Schema.TaggedError<McpConnectionError>('
  */
 const CLIENT_INFO = { name: '@dxos/mcp-client', version: '0.8.3' };
 
-export const make = (options: McpToolkitOptions): Effect.Effect<OpaqueToolkit.OpaqueToolkit> =>
+export const make = (options: McpToolkitOptions): Effect.Effect<OpaqueToolkit.OpaqueToolkit, McpConnectionError> =>
   Effect.gen(function* () {
     const client = yield* connectWithFallback(options);
 
-    const { tools } = yield* Effect.promise(() => client.listTools());
+    const { tools } = yield* Effect.tryPromise({
+      try: () => client.listTools(),
+      catch: (cause) =>
+        new McpConnectionError({
+          url: options.url,
+          kind: options.kind,
+          message: `Failed to list MCP tools: ${formatCause(cause)}`,
+        }),
+    });
     if (tools.length === 0) {
       return OpaqueToolkit.empty;
     }
@@ -108,8 +116,11 @@ export const is405 = (error: unknown): boolean => {
  * Connects to an MCP server, falling back to the alternate transport on 405 errors.
  * Per the MCP spec, a 405 indicates the server uses the other transport protocol.
  * Returns the connected Client (a fresh instance is created for the fallback attempt).
+ *
+ * Failures are surfaced as typed `McpConnectionError` so callers can recover (e.g. drop
+ * the misconfigured server) without breaking the surrounding effect.
  */
-const connectWithFallback = (options: McpToolkitOptions): Effect.Effect<Client> =>
+const connectWithFallback = (options: McpToolkitOptions): Effect.Effect<Client, McpConnectionError> =>
   Effect.gen(function* () {
     const fallbackKind = options.kind === 'sse' ? 'http' : 'sse';
     const primary = yield* connectClient(options.url, options.kind, options.apiKey).pipe(Effect.either);
@@ -117,9 +128,25 @@ const connectWithFallback = (options: McpToolkitOptions): Effect.Effect<Client> 
       return primary.right;
     }
     if (is405(primary.left)) {
-      return yield* connectClient(options.url, fallbackKind, options.apiKey).pipe(Effect.orDie);
+      const fallback = yield* connectClient(options.url, fallbackKind, options.apiKey).pipe(Effect.either);
+      if (fallback._tag === 'Right') {
+        return fallback.right;
+      }
+      return yield* Effect.fail(
+        new McpConnectionError({
+          url: options.url,
+          kind: fallbackKind,
+          message: `Failed to connect via ${fallbackKind} after 405 fallback: ${formatCause(fallback.left)}`,
+        }),
+      );
     }
-    return yield* Effect.die(primary.left);
+    return yield* Effect.fail(
+      new McpConnectionError({
+        url: options.url,
+        kind: options.kind,
+        message: `Failed to connect via ${options.kind}: ${formatCause(primary.left)}`,
+      }),
+    );
   });
 
 const connectClient = (url: string, kind: McpToolkitOptions['kind'], apiKey?: string) =>
@@ -128,6 +155,21 @@ const connectClient = (url: string, kind: McpToolkitOptions['kind'], apiKey?: st
     const transport = createTransport(url, kind, apiKey);
     return client.connect(transport).then(() => client);
   });
+
+/**
+ * Renders a thrown value to a short string for inclusion in error messages.
+ * `Effect.tryPromise` wraps thrown errors in `UnknownException`; unwrap when present.
+ */
+const formatCause = (error: unknown): string => {
+  const inner = error != null && typeof error === 'object' && 'error' in error ? (error as any).error : error;
+  if (inner instanceof Error) {
+    return inner.message;
+  }
+  if (Cause.isCause(error)) {
+    return Cause.pretty(error);
+  }
+  return String(inner);
+};
 
 /**
  * Creates a transport for the given MCP server URL and kind.

--- a/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatMcpErrors.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatMcpErrors.tsx
@@ -1,0 +1,50 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { useAtomValue } from '@effect-atom/atom-react';
+import React, { useCallback } from 'react';
+
+import { Message, type ThemedClassName, useTranslation } from '@dxos/react-ui';
+
+import { meta } from '#meta';
+
+import { type AiChatProcessor } from '../../processor';
+
+export type ChatMcpErrorsProps = ThemedClassName<{
+  processor: AiChatProcessor;
+}>;
+
+/**
+ * Inline banner that lists MCP servers that failed to connect during the most recent request.
+ * The chat itself keeps working without these servers — this just lets the user see what was dropped.
+ */
+export const ChatMcpErrors = ({ classNames, processor }: ChatMcpErrorsProps) => {
+  const { t } = useTranslation(meta.id);
+  const errors = useAtomValue(processor.mcpErrors);
+
+  const handleDismiss = useCallback(() => {
+    processor.dismissMcpErrors();
+  }, [processor]);
+
+  if (errors.length === 0) {
+    return null;
+  }
+
+  return (
+    <Message.Root classNames={['m-1', classNames]} valence='warning'>
+      <Message.Title onClose={handleDismiss}>{t('mcp-server-error.label')}</Message.Title>
+      <Message.Content asChild>
+        <ul className='flex flex-col gap-0.5 text-sm'>
+          {errors.map((error) => (
+            <li key={`${error.url}::${error.kind}`} className='truncate'>
+              <span className='font-mono'>{error.url}</span>
+              {' — '}
+              <span>{error.message}</span>
+            </li>
+          ))}
+        </ul>
+      </Message.Content>
+    </Message.Root>
+  );
+};

--- a/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatOptions.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatOptions.tsx
@@ -213,12 +213,6 @@ const McpServersPanel = ({ db }: McpServersPanelProps) => {
     [db],
   );
 
-  const handleToggle = useCallback((server: McpServer.McpServer, enabled: boolean) => {
-    Obj.update(server, (server) => {
-      server.enabled = enabled;
-    });
-  }, []);
-
   const handleRemove = useCallback(
     (server: McpServer.McpServer) => {
       db.remove(server);
@@ -229,24 +223,7 @@ const McpServersPanel = ({ db }: McpServersPanelProps) => {
   return (
     <div className='p-form-chrome'>
       {servers.map((server) => (
-        <div key={server.id} className='flex items-center gap-2 px-form-chrome'>
-          <Input.Root>
-            <Input.Label srOnly>{server.name}</Input.Label>
-            <Input.Switch
-              checked={server.enabled !== false}
-              onCheckedChange={(checked) => handleToggle(server, !!checked)}
-            />
-          </Input.Root>
-          <span className='flex-1 truncate text-sm'>{server.name}</span>
-          <span className='truncate text-xs text-description'>{server.url}</span>
-          <IconButton
-            variant='ghost'
-            icon='ph--x--regular'
-            iconOnly
-            label={t('mcp-server-remove.label')}
-            onClick={() => handleRemove(server)}
-          />
-        </div>
+        <McpServerRow key={server.id} server={server} onRemove={handleRemove} />
       ))}
       {adding ? (
         <McpServerForm onSubmit={handleAdd} onCancel={() => setAdding(false)} />
@@ -260,6 +237,39 @@ const McpServersPanel = ({ db }: McpServersPanelProps) => {
           />
         </div>
       )}
+    </div>
+  );
+};
+
+type McpServerRowProps = {
+  server: McpServer.McpServer;
+  onRemove: (server: McpServer.McpServer) => void;
+};
+
+/**
+ * `useQuery` returns live objects but only re-renders on result-identity changes,
+ * so we must subscribe to the per-server `enabled` field via `useObject` to keep the
+ * switch in sync with mutations made through the returned setter.
+ */
+const McpServerRow = ({ server, onRemove }: McpServerRowProps) => {
+  const { t } = useTranslation(meta.id);
+  const [enabled, setEnabled] = useObject(server, 'enabled');
+
+  return (
+    <div className='flex items-center gap-2 px-form-chrome'>
+      <Input.Root>
+        <Input.Label srOnly>{server.name}</Input.Label>
+        <Input.Switch checked={enabled !== false} onCheckedChange={(checked) => setEnabled(!!checked)} />
+      </Input.Root>
+      <span className='flex-1 truncate text-sm'>{server.name}</span>
+      <span className='truncate text-xs text-description'>{server.url}</span>
+      <IconButton
+        variant='ghost'
+        icon='ph--x--regular'
+        iconOnly
+        label={t('mcp-server-remove.label')}
+        onClick={() => onRemove(server)}
+      />
     </div>
   );
 };

--- a/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatPrompt.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatPrompt.tsx
@@ -21,6 +21,7 @@ import { meta } from '#meta';
 import { type AiChatProcessor } from '../../processor';
 import { type ChatEvent } from '../Chat/events';
 import { ChatActions, type ChatActionsProps } from './ChatActions';
+import { ChatMcpErrors } from './ChatMcpErrors';
 import { ChatOptions } from './ChatOptions';
 import { type ChatPresetsProps } from './ChatPresets';
 import { ChatReferences } from './ChatReferences';
@@ -126,6 +127,8 @@ export const ChatPrompt = ({
         classNames,
       )}
     >
+      <ChatMcpErrors processor={processor} />
+
       <div role='none' className='flex p-2 gap-2'>
         <ChatStatusIndicator classNames='p-1' preset={preset} error={error} processing={streaming} />
         <ChatEditor

--- a/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatPrompt.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatPrompt/ChatPrompt.tsx
@@ -166,7 +166,7 @@ export const ChatPrompt = ({
             {online !== undefined && (
               <Input.Root>
                 <Input.Label srOnly>{t('online-switch.label')}</Input.Label>
-                <Input.Switch classNames='mx-2' checked={online} onCheckedChange={onOnlineChange} />
+                <Input.Switch classNames='mx-1' checked={online} onCheckedChange={onOnlineChange} />
               </Input.Root>
             )}
           </ChatActions>

--- a/packages/plugins/plugin-assistant/src/components/ChatPrompt/index.ts
+++ b/packages/plugins/plugin-assistant/src/components/ChatPrompt/index.ts
@@ -3,6 +3,7 @@
 //
 
 export * from './ChatActions';
+export * from './ChatMcpErrors';
 export * from './ChatOptions';
 export * from './ChatPresets';
 export * from './ChatPrompt';

--- a/packages/plugins/plugin-assistant/src/processor/processor.ts
+++ b/packages/plugins/plugin-assistant/src/processor/processor.ts
@@ -14,6 +14,7 @@ import {
   type AiSession,
   createSystemPrompt,
   formatSystemPrompt,
+  McpServerError,
   PartialBlock,
   ToolExecutionServices,
 } from '@dxos/assistant';
@@ -105,6 +106,13 @@ export class AiChatProcessor {
   /** Last error. */
   public readonly error = Atom.make<Option.Option<Error>>(Option.none());
 
+  /**
+   * MCP server connection errors observed during the most recent request.
+   * Misconfigured/unreachable servers are dropped from the toolkit so the chat
+   * keeps working; the entries here let the UI display which servers failed.
+   */
+  public readonly mcpErrors = Atom.make<readonly Trace.PayloadType<typeof McpServerError>[]>([]);
+
   constructor(
     private readonly _conversation: AiSession,
     private readonly _runtime: AutomationCapabilities.ComputeRuntime,
@@ -159,6 +167,7 @@ export class AiChatProcessor {
     try {
       this.#lastRequest = requestProp;
       this.#registry.set(this.error, Option.none());
+      this.#registry.set(this.mcpErrors, []);
       this.#registry.set(this.active, true);
 
       const effect = Effect.gen(this, function* () {
@@ -172,6 +181,8 @@ export class AiChatProcessor {
               for (const event of message.events) {
                 if (Trace.isOfType(PartialBlock, event)) {
                   this.#handleEphemeralMessage(event.data);
+                } else if (Trace.isOfType(McpServerError, event)) {
+                  this.#handleMcpError(event.data);
                 }
               }
             }),
@@ -240,6 +251,13 @@ export class AiChatProcessor {
   }
 
   /**
+   * Clears the recorded MCP server errors (e.g. after the user dismisses the warning banner).
+   */
+  dismissMcpErrors(): void {
+    this.#registry.set(this.mcpErrors, []);
+  }
+
+  /**
    * Update the current chat's name.
    */
   async updateName(chat: Chat.Chat): Promise<void> {
@@ -284,6 +302,20 @@ export class AiChatProcessor {
         return [...pending, message];
       });
     }
+  }
+
+  /**
+   * Records a per-server MCP failure, deduped by url+kind so repeat misconfigurations
+   * across turns do not spam the UI.
+   */
+  #handleMcpError(event: Trace.PayloadType<typeof McpServerError>) {
+    log.warn('MCP server error', event);
+    this.#registry.update(this.mcpErrors, (errors) => {
+      if (errors.some((existing) => existing.url === event.url && existing.kind === event.kind)) {
+        return errors;
+      }
+      return [...errors, event];
+    });
   }
 
   /**

--- a/packages/plugins/plugin-assistant/src/translations.ts
+++ b/packages/plugins/plugin-assistant/src/translations.ts
@@ -149,6 +149,7 @@ export const translations: Resource[] = [
         'mcp-server-protocol.label': 'Protocol',
         'mcp-server-api-key.label': 'API key',
         'mcp-server-api-key.placeholder': 'API key (optional)',
+        'mcp-server-error.label': 'MCP server unavailable',
 
         'debug.button': 'Debug',
         'online-switch.label': 'Online',

--- a/packages/ui/react-ui-thread/src/Message/Message.tsx
+++ b/packages/ui/react-ui-thread/src/Message/Message.tsx
@@ -27,8 +27,8 @@ export const MessageRoot = forwardRef<HTMLDivElement, MessageRootProps>(
     { authorImgSrc, authorId, authorName, authorAvatarProps, continues = true, children, classNames, ...rootProps },
     forwardedRef,
   ) => {
+    // Must wrap the message since Avatar.Label may be used in the content.
     return (
-      // Must wrap the message since Avatar.Label may be used in the content.
       <Avatar.Root>
         <div
           role='none'

--- a/packages/ui/react-ui/src/components/Message/Message.stories.tsx
+++ b/packages/ui/react-ui/src/components/Message/Message.stories.tsx
@@ -22,7 +22,7 @@ type DefaultStoryProps = {
 const DefaultStory = ({ valence, title, body }: DefaultStoryProps) => (
   <div className='w-[30rem]'>
     <Message.Root valence={valence}>
-      {title && <Message.Title>{title}</Message.Title>}
+      {title && <Message.Title onClose={() => console.log('close')}>{title}</Message.Title>}
       {body && <Message.Content>{body}</Message.Content>}
     </Message.Root>
   </div>

--- a/packages/ui/react-ui/src/components/Message/Message.tsx
+++ b/packages/ui/react-ui/src/components/Message/Message.tsx
@@ -6,12 +6,16 @@ import { createContext } from '@radix-ui/react-context';
 import { Primitive } from '@radix-ui/react-primitive';
 import { Slot } from '@radix-ui/react-slot';
 import React, { type ComponentPropsWithRef, forwardRef } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { useId } from '@dxos/react-hooks';
 import { type Elevation, type MessageValence } from '@dxos/ui-types';
 
+import { translationKey } from '#translations';
+
 import { useElevationContext, useThemeContext } from '../../hooks';
 import { type ThemedClassName } from '../../util';
+import { IconButton } from '../Button';
 import { Icon } from '../Icon';
 
 const messageIcons: Record<MessageValence, string> = {
@@ -84,23 +88,36 @@ MessageRoot.displayName = MESSAGE_NAME;
 //
 
 type MessageTitleProps = Omit<ThemedClassName<ComponentPropsWithRef<typeof Primitive.h2>>, 'id'> & {
-  asChild?: boolean;
   icon?: string;
+  onClose?: () => void;
 };
 
 const MESSAGE_TITLE_NAME = 'MessageTitle';
 
 const MessageTitle = forwardRef<HTMLHeadingElement, MessageTitleProps>(
-  ({ asChild, classNames, children, icon: iconProp, ...props }, forwardedRef) => {
+  ({ classNames, children, icon: iconProp, onClose }, forwardedRef) => {
+    const { t } = useTranslation(translationKey);
     const { tx } = useThemeContext();
     const { titleId, valence } = useMessageContext(MESSAGE_TITLE_NAME);
-    const Comp = asChild ? Slot : Primitive.h2;
     const icon = iconProp ?? messageIcons[valence];
     return (
-      <Comp {...props} className={tx('message.header', {}, classNames)} id={titleId} ref={forwardedRef}>
-        {!icon && valence === 'neutral' ? <div /> : <Icon icon={icon} classNames={tx('message.icon', { valence })} />}
-        <span className={tx('message.title', {}, classNames)}>{children}</span>
-      </Comp>
+      <div role='none' className={tx('message.header', {}, classNames)} id={titleId} ref={forwardedRef}>
+        {icon && (
+          <div role='none' className={tx('message.icon', { valence })}>
+            <Icon icon={icon} />
+          </div>
+        )}
+        <h2 className={tx('message.title', {}, classNames)}>{children}</h2>
+        {onClose && (
+          <IconButton
+            variant='ghost'
+            icon='ph--x--regular'
+            iconOnly
+            label={t('toolbar-close.label')}
+            onClick={onClose}
+          />
+        )}
+      </div>
     );
   },
 );

--- a/packages/ui/ui-theme/src/theme/components/message.ts
+++ b/packages/ui/ui-theme/src/theme/components/message.ts
@@ -12,23 +12,23 @@ export type MessageStyleProps = {
 };
 
 export const messageRoot: ComponentFunction<MessageStyleProps> = ({ valence }, etc) => {
-  return mx('grid grid-cols-[min-content_1fr] gap-x-2 p-trim-sm rounded-sm', messageValence(valence), etc);
+  return mx('grid grid-cols-[2rem_1fr_2rem] p-1 rounded-sm', messageValence(valence), etc);
 };
 
 export const messageHeader: ComponentFunction<MessageStyleProps> = (_, etc) => {
-  return mx('col-span-2 grid grid-cols-subgrid items-center', etc);
+  return mx('col-span-full grid grid-cols-subgrid items-center', etc);
 };
 
 export const messageTitle: ComponentFunction<MessageStyleProps> = (_, etc) => {
-  return mx('col-start-2 gap-trim-sm [&>svg]:inline-block', etc);
+  return mx('col-start-2 truncate', etc);
 };
 
 export const messageIcon: ComponentFunction<MessageStyleProps> = (_, etc) => {
-  return mx('col-start-1', etc);
+  return mx('col-start-1 grid place-items-center', etc);
 };
 
 export const messageContent: ComponentFunction<MessageStyleProps> = (_, etc) => {
-  return mx('grid grid-cols-subgrid col-start-2 first:font-medium', etc);
+  return mx('col-start-2 grid grid-cols-subgrid first:font-medium', etc);
 };
 
 export const messageTheme: Theme<MessageStyleProps> = {


### PR DESCRIPTION
## Summary

- Misconfigured/unreachable MCP servers no longer break the chat. `McpToolkit.make` now returns a typed `McpConnectionError` instead of dying; failed servers are dropped from the toolkit and the chat continues.
- Surfaces the failure to the user as a dismissible warning banner above the prompt input (per-server URL + reason), driven by a new ephemeral `McpServerError` trace event flowing through the existing AgentService → AiChatProcessor pipeline.
- Fixes the MCP enable/disable switch in the chat options popover — the row now subscribes per-server via `useObject(server, 'enabled')` so toggles are reflected immediately (the previous `useQuery`-only path could not detect field-level mutations and the switch never visibly flipped).
- Includes related polish to the shared `Message` primitive (used by the new banner) — `react-ui` Message styles + stories, theme tweaks.

## Test plan

- [x] `moon run mcp-client:build assistant:build plugin-assistant:build` — clean
- [x] `moon run mcp-client:lint assistant:lint plugin-assistant:lint` — clean
- [x] `moon run mcp-client:test assistant:test plugin-assistant:test` — all passing (84 + 20 + skipped network MCP tests)
- [ ] Manually verify with a misconfigured MCP server: chat continues to work, banner lists the failed server, dismiss button clears it.
- [ ] Manually verify the MCP enable switch in chat options visibly toggles and that the next chat request honours the new enabled state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning banner to display MCP server connection failures to users with error details.
  * Improved message components with enhanced styling and close button functionality.

* **Bug Fixes**
  * MCP server connection failures are now handled gracefully without interrupting the assistant's operation.

* **Documentation**
  * Added localized labels for MCP server error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->