### PR TITLE
fix(assistant): tighten Kai status-tag rules to prevent lead-in narration

### DIFF
--- a/packages/core/assistant/src/templates/instructions/system.tpl
+++ b/packages/core/assistant/src/templates/instructions/system.tpl
@@ -56,8 +56,10 @@
 
 ## Response format
 
+- NEVER output narration text outside `<status>` tags or the final user-facing answer. Any progress update, transition sentence, or "let me…" lead-in MUST be wrapped in `<status>...</status>`. Violating this is an error.
 - When updating the user about the progress of the work you are doing, put the update in a <status> XML tag.
 - Only when you need to show the result to the user or ask a question use a text block without status tags.
+- After a `</status>` tag, the next output must be either another `<status>` tag, a tool call, or the final user-facing answer — never a transition sentence.
 
 <example>
 // reasoning...
@@ -80,6 +82,15 @@ I found 2 emails from Depot. Let me load their details:
 I found **2 emails from Depot**:
 </incorrect_example>
 
+Do not do (transition sentence after a status tag, before tool calls):
+
+<incorrect_example>
+<status>Doing X</status>
+Let me start by doing X:
+// tool call
+</incorrect_example>
+
+- NEVER write a lead-in sentence before a tool call. Use a `<status>` tag instead.
 - Avoid using plain text to tell the user what you are about to do; instead, use status blocks.
 - WRONG: Let me get...
 - CORRECT: <status>Getting...</status>


### PR DESCRIPTION
## Summary

The Kai assistant blueprint instructed the model to wrap progress updates in `<status>` tags, but the rule was phrased as soft guidance ("Avoid…"). In practice the model still emitted plain-text lead-in sentences before tool calls (e.g. `"Let me start by creating…"`) right after a `</status>` tag — exactly the case the existing `<incorrect_example>` did not cover.

This patch updates `packages/core/assistant/src/templates/instructions/system.tpl`:

- Promotes the guidance to a hard **NEVER** rule at the top of the Response format section.
- Adds an explicit rule that the next output after `</status>` must be another status tag, a tool call, or the final answer — never a transition sentence.
- Adds a new `<incorrect_example>` showing the lead-in-sentence-before-tool-call failure mode that was previously slipping through.
- Adds an explicit `NEVER write a lead-in sentence before a tool call` bullet next to the existing WRONG/CORRECT pair.

## Test plan

- [ ] Manually verify Kai no longer emits transition sentences between `</status>` and the first tool call in a fresh session.
- [ ] Confirm existing memoized assistant conversations still pass (`moon run :test` for assistant packages).

https://claude.ai/code/session_01RvSsfBVfPdSFsZifYoKKD8

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvSsfBVfPdSFsZifYoKKD8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined system prompt instructions to enforce stricter output formatting standards, ensuring consistent structure for progress updates and response delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->