### PR TITLE
ci: move test report out of reusable workflow into check.yml

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -235,3 +235,20 @@ jobs:
         with:
           name: ${{ github.job }}
           result: ${{ job.status }}
+
+  report:
+    needs: test
+    if: always() && github.event_name == 'schedule'
+    runs-on: depot-ubuntu-24.04-8
+    container:
+      image: ghcr.io/dxos/gh-actions:24.11.1
+      credentials:
+        username: dxos-bot
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Send test report
+        uses: ./.github/actions/test-report
+        with:
+          name: test-24.11.1
+          result: ${{ needs.test.result }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -108,9 +108,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
-      - name: Send test report
-        if: ${{ always() && github.event_name == 'schedule' }}
-        uses: ./.github/actions/test-report
-        with:
-          name: 'test-${{ inputs.node-version }}'
-          result: ${{ job.status }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -107,4 +107,3 @@ jobs:
           handle_no_reports_found: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
-


### PR DESCRIPTION
## Summary

- Removes the "Send test report" step from `run-tests.yml` and adds a `report` job in `check.yml` that runs after `test` completes, only on scheduled runs.
- `DISCORD_TEST_REPORT_WEBHOOK` is already in `check.yml`'s workflow-level `env:` block so the `report` job picks it up without any explicit secret passing — keeping it out of the gated `external-pr` environment entirely.

Fixes a regression from #11218 where the step silently no-oped because `env:` blocks from the caller workflow are not inherited by reusable workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI test reporting: introduced a dedicated scheduled report job and removed the prior schedule-triggered report step so scheduled test reports now run via the new job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->