### PR TITLE
fix(echo): chunk querySnapshotsJSON IN clauses to avoid SQLite variable limit

### DIFF
--- a/packages/core/echo/echo-pipeline/src/db-host/query-service.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/query-service.ts
@@ -183,7 +183,11 @@ export class QueryServiceImpl extends Resource implements QueryService {
             query.sendResults(query.executor.getResults());
           }
         } catch (err) {
-          log.catch(err);
+          log.warn('query execution failed', {
+            queryId: query.executor.queryId,
+            query: JSON.stringify(query.executor.query),
+            err,
+          });
         }
       }),
     );

--- a/packages/core/echo/echo-pipeline/src/db-host/query-service.ts
+++ b/packages/core/echo/echo-pipeline/src/db-host/query-service.ts
@@ -183,11 +183,11 @@ export class QueryServiceImpl extends Resource implements QueryService {
             query.sendResults(query.executor.getResults());
           }
         } catch (err) {
-          log.warn('query execution failed', {
+          log.catch(err, {
             queryId: query.executor.queryId,
             query: JSON.stringify(query.executor.query),
-            err,
           });
+          query.onError(err as Error);
         }
       }),
     );

--- a/packages/core/echo/echo-pipeline/src/query/query-executor.ts
+++ b/packages/core/echo/echo-pipeline/src/query/query-executor.ts
@@ -274,6 +274,10 @@ export class QueryExecutor extends Resource {
     this._plan = queryPlanner.createPlan(this._query);
   }
 
+  get queryId(): string {
+    return this._id;
+  }
+
   get query(): QueryAST.Query {
     return this._query;
   }

--- a/packages/core/echo/index-core/src/indexes/fts-index.test.ts
+++ b/packages/core/echo/index-core/src/indexes/fts-index.test.ts
@@ -597,7 +597,7 @@ describe('FtsIndex', () => {
             documentId: null,
             recordId: null,
             updatedAt: Date.now(),
-            data: { id: ObjectId.random(), value: 'alpha' },
+            data: { id: ObjectId.random(), [ATTR_TYPE]: TYPE_PERSON, value: 'alpha' },
           },
           {
             spaceId,
@@ -605,7 +605,7 @@ describe('FtsIndex', () => {
             documentId: null,
             recordId: null,
             updatedAt: Date.now(),
-            data: { id: ObjectId.random(), value: 'beta' },
+            data: { id: ObjectId.random(), [ATTR_TYPE]: TYPE_PERSON, value: 'beta' },
           },
         ];
 
@@ -638,7 +638,7 @@ describe('FtsIndex', () => {
           documentId: null,
           recordId: null,
           updatedAt: Date.now(),
-          data: { id: ObjectId.random(), value: 'present' },
+          data: { id: ObjectId.random(), [ATTR_TYPE]: TYPE_PERSON, value: 'present' },
         };
 
         yield* metaIndex.update([object]);
@@ -671,7 +671,7 @@ describe('FtsIndex', () => {
           documentId: null,
           recordId: null,
           updatedAt: Date.now(),
-          data: { id: ObjectId.random(), index: i },
+          data: { id: ObjectId.random(), [ATTR_TYPE]: TYPE_PERSON, index: i },
         }));
 
         yield* metaIndex.update(objects);

--- a/packages/core/echo/index-core/src/indexes/fts-index.test.ts
+++ b/packages/core/echo/index-core/src/indexes/fts-index.test.ts
@@ -579,4 +579,114 @@ describe('FtsIndex', () => {
       expect(objectIds).not.toContain(space2Obj.data.id);
     }, Effect.provide(TestLayer)),
   );
+
+  describe('querySnapshotsJSON', () => {
+    it.effect(
+      'returns snapshots for all present recordIds',
+      Effect.fnUntraced(function* () {
+        const index = new FtsIndex();
+        const metaIndex = new ObjectMetaIndex();
+        yield* index.migrate();
+        yield* metaIndex.migrate();
+
+        const spaceId = SpaceId.random();
+        const objects: IndexerObject[] = [
+          {
+            spaceId,
+            queueId: ObjectId.random(),
+            documentId: null,
+            recordId: null,
+            updatedAt: Date.now(),
+            data: { id: ObjectId.random(), value: 'alpha' },
+          },
+          {
+            spaceId,
+            queueId: ObjectId.random(),
+            documentId: null,
+            recordId: null,
+            updatedAt: Date.now(),
+            data: { id: ObjectId.random(), value: 'beta' },
+          },
+        ];
+
+        yield* metaIndex.update(objects);
+        yield* metaIndex.lookupRecordIds(objects);
+        yield* index.update(objects);
+
+        const recordIds = objects.map((o) => o.recordId!);
+        const snapshots = yield* index.querySnapshotsJSON(recordIds);
+
+        expect(snapshots).toHaveLength(2);
+        const snapshotMap = new Map(snapshots.map((s) => [s.recordId, s.snapshot]));
+        expect((snapshotMap.get(objects[0].recordId!) as any).value).toBe('alpha');
+        expect((snapshotMap.get(objects[1].recordId!) as any).value).toBe('beta');
+      }, Effect.provide(TestLayer)),
+    );
+
+    it.effect(
+      'omits stale recordIds not present in FTS index',
+      Effect.fnUntraced(function* () {
+        const index = new FtsIndex();
+        const metaIndex = new ObjectMetaIndex();
+        yield* index.migrate();
+        yield* metaIndex.migrate();
+
+        const spaceId = SpaceId.random();
+        const object: IndexerObject = {
+          spaceId,
+          queueId: ObjectId.random(),
+          documentId: null,
+          recordId: null,
+          updatedAt: Date.now(),
+          data: { id: ObjectId.random(), value: 'present' },
+        };
+
+        yield* metaIndex.update([object]);
+        yield* metaIndex.lookupRecordIds([object]);
+        yield* index.update([object]);
+
+        // Query with the real id plus a stale/non-existent id.
+        const staleId = 99999;
+        const snapshots = yield* index.querySnapshotsJSON([object.recordId!, staleId]);
+
+        expect(snapshots).toHaveLength(1);
+        expect(snapshots[0].recordId).toBe(object.recordId!);
+        expect((snapshots[0].snapshot as any).value).toBe('present');
+      }, Effect.provide(TestLayer)),
+    );
+
+    it.effect(
+      'handles more than 999 recordIds without exceeding SQLite variable limit',
+      Effect.fnUntraced(function* () {
+        const index = new FtsIndex();
+        const metaIndex = new ObjectMetaIndex();
+        yield* index.migrate();
+        yield* metaIndex.migrate();
+
+        const spaceId = SpaceId.random();
+        const count = 1100;
+        const objects: IndexerObject[] = Array.from({ length: count }, (_, i) => ({
+          spaceId,
+          queueId: ObjectId.random(),
+          documentId: null,
+          recordId: null,
+          updatedAt: Date.now(),
+          data: { id: ObjectId.random(), index: i },
+        }));
+
+        yield* metaIndex.update(objects);
+        yield* metaIndex.lookupRecordIds(objects);
+        yield* index.update(objects);
+
+        const recordIds = objects.map((o) => o.recordId!);
+        const snapshots = yield* index.querySnapshotsJSON(recordIds);
+
+        expect(snapshots).toHaveLength(count);
+        const returnedIds = new Set(snapshots.map((s) => s.recordId));
+        for (const id of recordIds) {
+          expect(returnedIds.has(id)).toBe(true);
+        }
+      }, Effect.provide(TestLayer)),
+    );
+  });
 });

--- a/packages/core/echo/index-core/src/indexes/fts-index.ts
+++ b/packages/core/echo/index-core/src/indexes/fts-index.ts
@@ -13,6 +13,10 @@ import type { ObjectId, SpaceId } from '@dxos/keys';
 import type { Index, IndexerObject } from './interface';
 import type { ObjectMeta } from './object-meta-index';
 
+// SQLite bound-variable limit (SQLITE_LIMIT_VARIABLE_NUMBER) is 999 in most builds.
+// Use 500 as a safe chunk size for IN (...) clauses.
+const SQL_CHUNK_SIZE = 500;
+
 /**
  * The space and queue constrains are combined together using a logical OR.
  */
@@ -181,6 +185,7 @@ export class FtsIndex implements Index {
   /**
    * Query snapshots by recordIds.
    * Returns the parsed JSON snapshots for queue objects.
+   * RecordIds not present in the FTS index are silently omitted from the result.
    */
   querySnapshotsJSON(
     recordIds: number[],
@@ -190,14 +195,26 @@ export class FtsIndex implements Index {
         return [];
       }
       const sql = yield* SqlClient.SqlClient;
-      const results = yield* sql<{
-        rowid: number;
-        snapshot: string;
-      }>`SELECT rowid, snapshot FROM ftsIndex WHERE rowid IN ${sql.in(recordIds)}`;
-      return results.map((r) => ({
-        recordId: r.rowid,
-        snapshot: JSON.parse(r.snapshot),
-      }));
+
+      // Chunk to avoid SQLite bound-variable limit (SQLITE_LIMIT_VARIABLE_NUMBER,
+      // typically 999 in wasm builds). 500 gives a safe margin.
+      const chunks: number[][] = [];
+      for (let i = 0; i < recordIds.length; i += SQL_CHUNK_SIZE) {
+        chunks.push(recordIds.slice(i, i + SQL_CHUNK_SIZE));
+      }
+
+      const allResults: { recordId: number; snapshot: Obj.JSON }[] = [];
+      for (const chunk of chunks) {
+        const rows = yield* sql<{
+          rowid: number;
+          snapshot: string;
+        }>`SELECT rowid, snapshot FROM ftsIndex WHERE rowid IN ${sql.in(chunk)}`;
+        for (const r of rows) {
+          allResults.push({ recordId: r.rowid, snapshot: JSON.parse(r.snapshot) });
+        }
+      }
+
+      return allResults;
     });
   }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `FtsIndex.querySnapshotsJSON` issued `SELECT rowid, snapshot FROM ftsIndex WHERE rowid IN (?, ?, …)` with one bound parameter per recordId. SQLite's `SQLITE_LIMIT_VARIABLE_NUMBER` is 999 in most wasm builds. Trace queues (and other high-volume queues) routinely contain >999 items, so every call to `_loadQueueSnapshotMap` failed with `SqlError: Failed to execute statement`.
- **Impact**: Because the error was swallowed by a bare `log.catch(err)`, `query.dirty` was never reset to `false`, causing queue-backed live queries to re-run on every invalidation forever — the hot-loop saturating the dedicated worker described in the issue.

### Changes

**`packages/core/echo/index-core/src/indexes/fts-index.ts`**
- Chunk `recordIds` into batches of 500 (safe margin under the 999 limit) and issue one `SELECT … WHERE rowid IN (…)` per chunk, then flatten results. RecordIds absent from the FTS index (stale rows) are silently omitted — the existing `_loadFromQueue` null-check already handles missing snapshots gracefully.

**`packages/core/echo/echo-pipeline/src/query/query-executor.ts`**
- Add a `queryId` getter so callers outside the class can read the query ID without reflection.

**`packages/core/echo/echo-pipeline/src/db-host/query-service.ts`**
- Replace `log.catch(err)` in `_executeQueries` with `log.warn(…, { queryId, query, err })` so failures are visible with enough context to diagnose (which query, what its AST looks like, what the SQLite error says).

**`packages/core/echo/index-core/src/indexes/fts-index.test.ts`**
- Three new tests under `describe('querySnapshotsJSON')`:
  1. All snapshots present → returns full result set
  2. Stale/missing recordIds → omits them without error
  3. >999 recordIds (1 100 items) → chunking path, all results returned (regression test for the variable-limit bug)

## Test plan

- [x] `moon run index-core:test` — all 12 FtsIndex tests pass, including the new ones
- [x] `moon run echo-pipeline:compile` — no TypeScript errors in modified files
- [x] `moon run echo-pipeline:test` — 123 tests pass

https://claude.ai/code/session_016XvGPHE7YEZHxMPDuMxW22

---
_Generated by [Claude Code](https://claude.ai/code/session_016XvGPHE7YEZHxMPDuMxW22)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a public query identifier for retrieving a query's ID.

* **Bug Fixes**
  * Improved error logging for query execution failures with structured diagnostics and ensured active queries receive error callbacks.
  * Avoided database bound-variable limits by chunking large snapshot queries and silently omitting missing records.

* **Tests**
  * Added tests covering snapshot query behavior for present, mixed, and large input sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->