### PR TITLE
feat(plugin-slack): add Slack sync plugin

### DIFF
--- a/packages/apps/composer-app/package.json
+++ b/packages/apps/composer-app/package.json
@@ -93,6 +93,7 @@
     "@dxos/plugin-sidekick": "workspace:*",
     "@dxos/plugin-simple-layout": "workspace:*",
     "@dxos/plugin-sketch": "workspace:*",
+    "@dxos/plugin-slack": "workspace:*",
     "@dxos/plugin-space": "workspace:*",
     "@dxos/plugin-spacetime": "workspace:*",
     "@dxos/plugin-spotlight": "workspace:*",

--- a/packages/apps/composer-app/src/plugin-defs.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.tsx
@@ -59,6 +59,7 @@ import { SheetPlugin } from '@dxos/plugin-sheet';
 import { SidekickPlugin } from '@dxos/plugin-sidekick';
 import { SimpleLayoutPlugin } from '@dxos/plugin-simple-layout';
 import { SketchPlugin } from '@dxos/plugin-sketch';
+import { SlackPlugin } from '@dxos/plugin-slack';
 import { SpacePlugin } from '@dxos/plugin-space';
 import { SpacetimePlugin } from '@dxos/plugin-spacetime';
 import { SpotlightPlugin } from '@dxos/plugin-spotlight';
@@ -257,6 +258,7 @@ export const getPlugins = ({
     SettingsPlugin(),
     SheetPlugin(),
     SketchPlugin(),
+    SlackPlugin(),
     SpacetimePlugin(),
     SpacePlugin({
       observability: true,

--- a/packages/apps/composer-app/tsconfig.json
+++ b/packages/apps/composer-app/tsconfig.json
@@ -380,6 +380,9 @@
       "path": "../../plugins/plugin-sketch"
     },
     {
+      "path": "../../plugins/plugin-slack"
+    },
+    {
       "path": "../../plugins/plugin-space"
     },
     {

--- a/packages/plugins/plugin-integration/src/capabilities/builtin-providers.ts
+++ b/packages/plugins/plugin-integration/src/capabilities/builtin-providers.ts
@@ -23,19 +23,8 @@ export default Capability.makeModule<IntegrationProviderEntry[]>(
         source: '',
         label: 'Custom Token',
       },
-      // GitHub and Linear are implemented as dedicated plugins (`@dxos/plugin-github`, `@dxos/plugin-linear`).
-      // TODO(wittjosiah): Implement slack as a dedicated plugin instead of a preset.
-      /*
-      {
-        id: 'slack',
-        source: 'slack.com',
-        label: 'Slack',
-        oauth: {
-          provider: OAuthProvider.SLACK,
-          scopes: ['channels:read', 'chat:write', 'users:read'],
-        },
-      },
-      */
+      // GitHub, Linear, and Slack are implemented as dedicated plugins
+      // (`@dxos/plugin-github`, `@dxos/plugin-linear`, `@dxos/plugin-slack`).
     ]);
   }),
 );

--- a/packages/plugins/plugin-slack/moon.yml
+++ b/packages/plugins/plugin-slack/moon.yml
@@ -1,0 +1,11 @@
+layer: library
+language: typescript
+tags:
+  - ts-build
+  - ts-test
+  - pack
+tasks:
+  compile:
+    args:
+      - '--entryPoint=src/index.ts'
+      - '--platform=browser'

--- a/packages/plugins/plugin-slack/package.json
+++ b/packages/plugins/plugin-slack/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@dxos/plugin-slack",
+  "version": "0.8.3",
+  "private": true,
+  "description": "DXOS plugin that integrates Slack as a sync source via the generic Integration mechanism.",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dxos/dxos"
+  },
+  "license": "MIT",
+  "author": "DXOS.org",
+  "sideEffects": true,
+  "type": "module",
+  "imports": {
+    "#capabilities": "./src/capabilities/index.ts",
+    "#meta": "./src/meta.ts",
+    "#operations": "./src/operations/index.ts"
+  },
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/types/src/index.d.ts",
+      "browser": "./dist/lib/browser/index.mjs"
+    }
+  },
+  "types": "dist/types/src/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@dxos/app-framework": "workspace:*",
+    "@dxos/app-toolkit": "workspace:*",
+    "@dxos/compute": "workspace:*",
+    "@dxos/echo": "workspace:*",
+    "@dxos/errors": "workspace:*",
+    "@dxos/log": "workspace:*",
+    "@dxos/plugin-integration": "workspace:*",
+    "@dxos/protocols": "workspace:*",
+    "@dxos/types": "workspace:*",
+    "@dxos/util": "workspace:*",
+    "@effect/platform": "catalog:",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@dxos/echo-db": "workspace:*",
+    "@dxos/effect": "workspace:*",
+    "vite": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/plugins/plugin-slack/package.json
+++ b/packages/plugins/plugin-slack/package.json
@@ -14,6 +14,7 @@
   "sideEffects": true,
   "type": "module",
   "imports": {
+    "#plugin": "./src/SlackPlugin.ts",
     "#capabilities": "./src/capabilities/index.ts",
     "#meta": "./src/meta.ts",
     "#operations": "./src/operations/index.ts"
@@ -49,6 +50,7 @@
   },
   "devDependencies": {
     "@dxos/effect": "workspace:*",
+    "@dxos/plugin-testing": "workspace:*",
     "vite": "catalog:"
   },
   "peerDependencies": {

--- a/packages/plugins/plugin-slack/package.json
+++ b/packages/plugins/plugin-slack/package.json
@@ -35,8 +35,11 @@
     "@dxos/app-toolkit": "workspace:*",
     "@dxos/compute": "workspace:*",
     "@dxos/echo": "workspace:*",
+    "@dxos/echo-db": "workspace:*",
     "@dxos/errors": "workspace:*",
+    "@dxos/invariant": "workspace:*",
     "@dxos/log": "workspace:*",
+    "@dxos/plugin-client": "workspace:*",
     "@dxos/plugin-integration": "workspace:*",
     "@dxos/protocols": "workspace:*",
     "@dxos/types": "workspace:*",
@@ -45,7 +48,6 @@
     "effect": "catalog:"
   },
   "devDependencies": {
-    "@dxos/echo-db": "workspace:*",
     "@dxos/effect": "workspace:*",
     "vite": "catalog:"
   },

--- a/packages/plugins/plugin-slack/src/SlackPlugin.test.ts
+++ b/packages/plugins/plugin-slack/src/SlackPlugin.test.ts
@@ -1,0 +1,30 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { describe, test } from 'vitest';
+
+import { ClientPlugin } from '@dxos/plugin-client';
+import { IntegrationPlugin } from '@dxos/plugin-integration';
+import { createComposerTestApp } from '@dxos/plugin-testing/harness';
+
+import { SlackPlugin } from '#plugin';
+
+import { meta } from './meta';
+
+const moduleId = (name: string) => `${meta.id}.module.${name}`;
+
+describe('SlackPlugin', () => {
+  test('modules activate on the expected events', async ({ expect }) => {
+    await using harness = await createComposerTestApp({
+      plugins: [ClientPlugin({}), IntegrationPlugin(), SlackPlugin()],
+    });
+
+    // After autoStart: SetupAppGraph fires (cascading SetupIntegrationProviders via
+    // IntegrationPlugin's AppGraphBuilder), and SetupOperationHandler fires from
+    // OperationPlugin — both reach the SlackPlugin's modules.
+    expect(harness.manager.getActive()).toEqual(
+      expect.arrayContaining([moduleId('SlackIntegrationProvider'), moduleId('OperationHandler')]),
+    );
+  }, 30_000);
+});

--- a/packages/plugins/plugin-slack/src/SlackPlugin.ts
+++ b/packages/plugins/plugin-slack/src/SlackPlugin.ts
@@ -1,0 +1,21 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+import { AppActivationEvents, AppPlugin } from '@dxos/app-toolkit';
+
+import { IntegrationProvider, OperationHandler } from '#capabilities';
+import { meta } from '#meta';
+
+import { translations } from './translations';
+
+export const SlackPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addTranslationsModule({ translations }),
+  Plugin.addModule({
+    activatesOn: AppActivationEvents.SetupIntegrationProviders,
+    activate: IntegrationProvider,
+  }),
+  Plugin.make,
+);

--- a/packages/plugins/plugin-slack/src/SlackPlugin.ts
+++ b/packages/plugins/plugin-slack/src/SlackPlugin.ts
@@ -19,3 +19,5 @@ export const SlackPlugin = Plugin.define(meta).pipe(
   }),
   Plugin.make,
 );
+
+export default SlackPlugin;

--- a/packages/plugins/plugin-slack/src/capabilities/index.ts
+++ b/packages/plugins/plugin-slack/src/capabilities/index.ts
@@ -1,0 +1,12 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Capability } from '@dxos/app-framework';
+import { OperationHandlerSet } from '@dxos/compute';
+
+export const IntegrationProvider = Capability.lazy('SlackIntegrationProvider', () => import('./integration-provider'));
+export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
+  'OperationHandler',
+  () => import('./operation-handler'),
+);

--- a/packages/plugins/plugin-slack/src/capabilities/integration-provider.ts
+++ b/packages/plugins/plugin-slack/src/capabilities/integration-provider.ts
@@ -1,0 +1,70 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+
+import { Capability } from '@dxos/app-framework';
+import { Obj } from '@dxos/echo';
+import {
+  IntegrationProvider as IntegrationProviderCapability,
+  type OnTokenCreated,
+} from '@dxos/plugin-integration/types';
+import { OAuthProvider } from '@dxos/protocols';
+
+import { SLACK_SCOPES, SLACK_SOURCE } from '../constants';
+import { SlackOperation } from '../operations';
+import { SlackApi } from '../services';
+
+/**
+ * Service-specific token-created hook for Slack.
+ *
+ * Calls Slack's `auth.test` to populate `accessToken.account` with the
+ * authenticated user's display name (falling back to user id) and the team
+ * domain. Failures are elevated with {@link Effect.orDie}; plugin-integration
+ * logs defects from the runner and continues so a failed `auth.test` cannot
+ * block the Integration already created.
+ */
+const onTokenCreated: OnTokenCreated = ({ accessToken }) =>
+  Effect.gen(function* () {
+    if (accessToken.account) {
+      return;
+    }
+    const result = yield* SlackApi.fetchAuthTest().pipe(
+      Effect.provide(Layer.succeed(SlackApi.SlackCredentials, { token: accessToken.token })),
+    );
+    Obj.update(accessToken, (accessToken) => {
+      // Prefer a `<user>@<team>` shape because it reads naturally in the
+      // integrations list and stays unique per workspace, but fall back to
+      // either side if Slack returned only one.
+      if (result.user && result.team) {
+        accessToken.account = `${result.user}@${result.team}`;
+      } else {
+        accessToken.account = result.user ?? result.team ?? result.user_id ?? '';
+      }
+    });
+  }).pipe(Effect.orDie);
+
+/**
+ * Contributes a single `IntegrationProvider` entry that wires Slack's two operations
+ * and the token-created hook to the `'slack.com'` source.
+ */
+export default Capability.makeModule(
+  Effect.fnUntraced(function* () {
+    return Capability.contributes(IntegrationProviderCapability, [
+      {
+        id: 'slack',
+        source: SLACK_SOURCE,
+        label: 'Slack',
+        oauth: {
+          provider: OAuthProvider.SLACK,
+          scopes: SLACK_SCOPES,
+        },
+        getSyncTargets: SlackOperation.GetSlackChannels,
+        sync: SlackOperation.SyncSlackChannel,
+        onTokenCreated,
+      },
+    ]);
+  }),
+);

--- a/packages/plugins/plugin-slack/src/capabilities/operation-handler.ts
+++ b/packages/plugins/plugin-slack/src/capabilities/operation-handler.ts
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capabilities, Capability } from '@dxos/app-framework';
+import type { OperationHandlerSet } from '@dxos/compute';
+
+import { SlackHandlers } from '#operations';
+
+export default Capability.makeModule<OperationHandlerSet.OperationHandlerSet>(
+  Effect.fnUntraced(function* () {
+    return Capability.contributes(Capabilities.OperationHandler, SlackHandlers);
+  }),
+);

--- a/packages/plugins/plugin-slack/src/constants.ts
+++ b/packages/plugins/plugin-slack/src/constants.ts
@@ -9,20 +9,22 @@ export const SLACK_SOURCE = 'slack.com';
 export const SLACK_API_BASE = 'https://slack.com/api';
 
 /**
- * OAuth scopes required for read-only sync of channels, DMs, and group DMs.
+ * OAuth scopes required for read-only sync of channels and group DMs.
  *
  * Splits cleanly along Slack's conversation-type axis: `<type>:read` to enumerate
  * the conversation list (drives discovery), `<type>:history` to read messages
  * inside it (drives sync). `users:read` resolves user IDs to display names so
  * we can render `Message.sender` without an extra lookup per render.
+ *
+ * `im:*` scopes are intentionally omitted — 1:1 DMs visible to a bot token are
+ * limited to DMs with the bot itself, which aren't useful sync targets. Group
+ * DMs (`mpim`) the bot is added to remain in scope.
  */
 export const SLACK_SCOPES = [
   'channels:read',
   'channels:history',
   'groups:read',
   'groups:history',
-  'im:read',
-  'im:history',
   'mpim:read',
   'mpim:history',
   'users:read',

--- a/packages/plugins/plugin-slack/src/constants.ts
+++ b/packages/plugins/plugin-slack/src/constants.ts
@@ -9,23 +9,21 @@ export const SLACK_SOURCE = 'slack.com';
 export const SLACK_API_BASE = 'https://slack.com/api';
 
 /**
- * OAuth scopes required for read-only sync of channels and group DMs.
+ * OAuth scopes required for read-only sync of public and private channels.
  *
  * Splits cleanly along Slack's conversation-type axis: `<type>:read` to enumerate
  * the conversation list (drives discovery), `<type>:history` to read messages
  * inside it (drives sync). `users:read` resolves user IDs to display names so
  * we can render `Message.sender` without an extra lookup per render.
  *
- * `im:*` scopes are intentionally omitted — 1:1 DMs visible to a bot token are
- * limited to DMs with the bot itself, which aren't useful sync targets. Group
- * DMs (`mpim`) the bot is added to remain in scope.
+ * `im:*` and `mpim:*` scopes are intentionally omitted — direct messages and
+ * group DMs are out of scope for sync; only channel-shaped conversations are
+ * synced as Channels.
  */
 export const SLACK_SCOPES = [
   'channels:read',
   'channels:history',
   'groups:read',
   'groups:history',
-  'mpim:read',
-  'mpim:history',
   'users:read',
 ] as const;

--- a/packages/plugins/plugin-slack/src/constants.ts
+++ b/packages/plugins/plugin-slack/src/constants.ts
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+/** Source string used in `AccessToken.source` and `Obj.Meta.keys[i].source` for Slack. */
+export const SLACK_SOURCE = 'slack.com';
+
+/** Base URL for the Slack Web API. */
+export const SLACK_API_BASE = 'https://slack.com/api';
+
+/**
+ * OAuth scopes required for read-only sync of channels, DMs, and group DMs.
+ *
+ * Splits cleanly along Slack's conversation-type axis: `<type>:read` to enumerate
+ * the conversation list (drives discovery), `<type>:history` to read messages
+ * inside it (drives sync). `users:read` resolves user IDs to display names so
+ * we can render `Message.sender` without an extra lookup per render.
+ */
+export const SLACK_SCOPES = [
+  'channels:read',
+  'channels:history',
+  'groups:read',
+  'groups:history',
+  'im:read',
+  'im:history',
+  'mpim:read',
+  'mpim:history',
+  'users:read',
+] as const;

--- a/packages/plugins/plugin-slack/src/errors.ts
+++ b/packages/plugins/plugin-slack/src/errors.ts
@@ -1,0 +1,54 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Predicate from 'effect/Predicate';
+
+import { BaseError } from '@dxos/errors';
+
+const SLACK_API_ERROR_MESSAGE = 'Slack API returned an error.' as const;
+
+const INTEGRATION_DATABASE_MISSING_MESSAGE = 'No database for integration ref.' as const;
+
+/**
+ * Slack returned `{ ok: false, error: '<code>' }`.
+ *
+ * Slack reports failures in the response body rather than via HTTP status, so
+ * the HTTP layer's retry-on-5xx logic never sees these. Surfacing them as a
+ * typed BaseError lets `formatSlackSyncFailure` keep the user-facing string
+ * stable and lets callers `.is()` for known auth-revoked cases.
+ */
+export class SlackApiError extends BaseError.extend('SlackApiError', SLACK_API_ERROR_MESSAGE) {}
+
+/** Integration ref had no resolvable ECHO database (invoker did not provide `Database.layer`). */
+export class IntegrationDatabaseMissingError extends BaseError.extend(
+  'IntegrationDatabaseMissingError',
+  INTEGRATION_DATABASE_MISSING_MESSAGE,
+) {}
+
+/**
+ * User-facing / persisted diagnostic string for failures from Slack sync paths.
+ */
+export const formatSlackSyncFailure = (error: unknown): string => {
+  if (SlackApiError.is(error)) {
+    const code = (error.context as { code?: unknown }).code;
+    return typeof code === 'string' ? `Slack API error: ${code}` : SLACK_API_ERROR_MESSAGE;
+  }
+  if (IntegrationDatabaseMissingError.is(error)) {
+    return INTEGRATION_DATABASE_MISSING_MESSAGE;
+  }
+  if (error instanceof BaseError) {
+    const keys = Object.keys(error.context);
+    return keys.length > 0 ? `${error.name}: ${JSON.stringify(error.context)}` : error.name;
+  }
+  if (Predicate.isRecord(error) && typeof error._tag === 'string') {
+    if (error._tag === 'ResponseError' && Predicate.isRecord(error.response) && 'status' in error.response) {
+      return `HTTP ${error.response.status}`;
+    }
+    return error._tag;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+};

--- a/packages/plugins/plugin-slack/src/index.ts
+++ b/packages/plugins/plugin-slack/src/index.ts
@@ -1,0 +1,6 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './meta';
+export * from './SlackPlugin';

--- a/packages/plugins/plugin-slack/src/index.ts
+++ b/packages/plugins/plugin-slack/src/index.ts
@@ -2,5 +2,10 @@
 // Copyright 2026 DXOS.org
 //
 
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const SlackPlugin = Plugin.lazy(meta, () => import('#plugin'));
+
 export * from './meta';
-export * from './SlackPlugin';

--- a/packages/plugins/plugin-slack/src/meta.ts
+++ b/packages/plugins/plugin-slack/src/meta.ts
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Plugin } from '@dxos/app-framework';
+import { trim } from '@dxos/util';
+
+export const meta: Plugin.Meta = {
+  id: 'org.dxos.plugin.slack',
+  name: 'Slack',
+  description: trim`
+    Connect Slack to your workspace so channels and direct messages stream alongside everything else you're doing.
+  `,
+  icon: 'ph--slack-logo--regular',
+  iconHue: 'purple',
+};

--- a/packages/plugins/plugin-slack/src/operations/definitions.ts
+++ b/packages/plugins/plugin-slack/src/operations/definitions.ts
@@ -4,8 +4,9 @@
 
 import * as Schema from 'effect/Schema';
 
+import { Capability } from '@dxos/app-framework';
 import { Operation } from '@dxos/compute';
-import { Database, Feed, Obj, Ref } from '@dxos/echo';
+import { Obj, Ref } from '@dxos/echo';
 import { Integration } from '@dxos/plugin-integration/types';
 
 import { meta } from '#meta';
@@ -25,30 +26,33 @@ const RemoteTarget = Schema.Struct({
  * reachable from the integration's token.
  *
  * Read-only: returns one descriptor per remote conversation, NEVER creates a
- * local Chat. Materialization happens lazily in `SyncSlackChannel` on first
+ * local Channel. Materialization happens lazily in `SyncSlackChannel` on first
  * sync of a target, so unselected conversations leave no trace in the space.
  */
 export const GetSlackChannels = Operation.make({
   meta: {
     key: `${SLACK_OPERATION}.get-slack-channels`,
     name: 'Get Slack Channels',
-    description: 'List Slack conversations reachable from an integration without materializing local Chats.',
+    description: 'List Slack conversations reachable from an integration without materializing local Channels.',
   },
+  // Database.Service / Feed.FeedService are provided inside the handler from
+  // the integration's database and the resolved space's queues — same pattern
+  // as plugin-thread's `AppendChannelMessage`.
+  services: [Capability.Service],
   input: Schema.Struct({
     integration: Ref.Ref(Integration.Integration),
   }),
   output: Schema.Struct({
     targets: Schema.Array(RemoteTarget),
   }),
-  services: [Database.Service],
 });
 
 /**
  * Pull-only sync of currently-selected Slack targets in an Integration.
  *
- * For each selected conversation: load (or create) a local `Chat` keyed by
+ * For each selected conversation: load (or create) a local `Channel` keyed by
  * the Slack conversation id, ask Slack for messages newer than
- * `target.cursor`, and append them to the chat's feed as `@dxos/types`
+ * `target.cursor`, and append them to the channel's feed as `@dxos/types`
  * `Message` objects. `Message.threadId` carries Slack's `thread_ts` so
  * threaded replies are reconstructable on read without a separate object
  * type.
@@ -59,15 +63,15 @@ export const SyncSlackChannel = Operation.make({
     name: 'Sync Slack Channel',
     description: 'Reconcile messages for currently-selected Slack targets in an Integration.',
   },
+  services: [Capability.Service],
   input: Schema.Struct({
     integration: Ref.Ref(Integration.Integration),
-    /** Optional: narrow to a single target Chat. */
-    chat: Ref.Ref(Obj.Unknown).pipe(Schema.optional),
+    /** Optional: narrow to a single target Channel. */
+    channel: Ref.Ref(Obj.Unknown).pipe(Schema.optional),
   }),
   output: Schema.Struct({
     pulled: Schema.Struct({
       added: Schema.Number,
     }),
   }),
-  services: [Database.Service, Feed.FeedService],
 });

--- a/packages/plugins/plugin-slack/src/operations/definitions.ts
+++ b/packages/plugins/plugin-slack/src/operations/definitions.ts
@@ -1,0 +1,73 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Schema from 'effect/Schema';
+
+import { Operation } from '@dxos/compute';
+import { Database, Feed, Obj, Ref } from '@dxos/echo';
+import { Integration } from '@dxos/plugin-integration/types';
+
+import { meta } from '#meta';
+
+const SLACK_OPERATION = `${meta.id}.operation`;
+
+/** Wire-shape of a `RemoteTarget` for `GetSlackChannels.output`. */
+const RemoteTarget = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+  description: Schema.String.pipe(Schema.optional),
+  metadata: Schema.Record({ key: Schema.String, value: Schema.Unknown }).pipe(Schema.optional),
+});
+
+/**
+ * Discovery only — list Slack conversations (channels, DMs, group DMs)
+ * reachable from the integration's token.
+ *
+ * Read-only: returns one descriptor per remote conversation, NEVER creates a
+ * local Chat. Materialization happens lazily in `SyncSlackChannel` on first
+ * sync of a target, so unselected conversations leave no trace in the space.
+ */
+export const GetSlackChannels = Operation.make({
+  meta: {
+    key: `${SLACK_OPERATION}.get-slack-channels`,
+    name: 'Get Slack Channels',
+    description: 'List Slack conversations reachable from an integration without materializing local Chats.',
+  },
+  input: Schema.Struct({
+    integration: Ref.Ref(Integration.Integration),
+  }),
+  output: Schema.Struct({
+    targets: Schema.Array(RemoteTarget),
+  }),
+  services: [Database.Service],
+});
+
+/**
+ * Pull-only sync of currently-selected Slack targets in an Integration.
+ *
+ * For each selected conversation: load (or create) a local `Chat` keyed by
+ * the Slack conversation id, ask Slack for messages newer than
+ * `target.cursor`, and append them to the chat's feed as `@dxos/types`
+ * `Message` objects. `Message.threadId` carries Slack's `thread_ts` so
+ * threaded replies are reconstructable on read without a separate object
+ * type.
+ */
+export const SyncSlackChannel = Operation.make({
+  meta: {
+    key: `${SLACK_OPERATION}.sync-slack-channel`,
+    name: 'Sync Slack Channel',
+    description: 'Reconcile messages for currently-selected Slack targets in an Integration.',
+  },
+  input: Schema.Struct({
+    integration: Ref.Ref(Integration.Integration),
+    /** Optional: narrow to a single target Chat. */
+    chat: Ref.Ref(Obj.Unknown).pipe(Schema.optional),
+  }),
+  output: Schema.Struct({
+    pulled: Schema.Struct({
+      added: Schema.Number,
+    }),
+  }),
+  services: [Database.Service, Feed.FeedService],
+});

--- a/packages/plugins/plugin-slack/src/operations/get-slack-channels.ts
+++ b/packages/plugins/plugin-slack/src/operations/get-slack-channels.ts
@@ -1,0 +1,80 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as FetchHttpClient from '@effect/platform/FetchHttpClient';
+import * as Effect from 'effect/Effect';
+
+import { Operation } from '@dxos/compute';
+
+import { SlackApi } from '../services';
+import { GetSlackChannels } from './definitions';
+
+/**
+ * Friendly label for a Slack conversation, derived from its type:
+ *  - public/private channel: `name` ("#general", "private-stuff").
+ *  - IM (`is_im`): the other user's id (we can't resolve to display name
+ *    without an extra `users.info` call per conversation; the discovery UI
+ *    can do that lazily, or the user accepts the id-prefix label for now).
+ *  - mpim (`is_mpim`): Slack's auto-generated comma-joined name in
+ *    `name` ("mpdm-alice--bob--carol-1").
+ *  - Anything else with a `name`: pass through.
+ *
+ * Returning a stable, non-empty string here matters because the integration
+ * UI uses it as the row label before any local materialization.
+ */
+const conversationLabel = (conversation: SlackApi.SlackConversation): string => {
+  if (conversation.name && conversation.name.length > 0) {
+    return conversation.is_channel || conversation.is_group ? `#${conversation.name}` : conversation.name;
+  }
+  if (conversation.is_im && conversation.user) {
+    return `DM with ${conversation.user}`;
+  }
+  return conversation.id;
+};
+
+const conversationKind = (conversation: SlackApi.SlackConversation): string => {
+  if (conversation.is_channel) {
+    return conversation.is_private ? 'private channel' : 'channel';
+  }
+  if (conversation.is_group) {
+    return 'group';
+  }
+  if (conversation.is_im) {
+    return 'direct message';
+  }
+  if (conversation.is_mpim) {
+    return 'group direct message';
+  }
+  return 'conversation';
+};
+
+/**
+ * Discovery only — list Slack conversations reachable from the integration's
+ * token and return one descriptor per item. Read-only: NO local Chat objects
+ * are created here. Materialization happens lazily in `SyncSlackChannel` on
+ * first sync of a target.
+ */
+const handler: Operation.WithHandler<typeof GetSlackChannels> = GetSlackChannels.pipe(
+  Operation.withHandler(
+    Effect.fn(function* ({ integration }) {
+      return yield* Effect.gen(function* () {
+        const conversations = yield* SlackApi.fetchConversations();
+        const targets = conversations.map((conversation) => ({
+          id: conversation.id,
+          name: conversationLabel(conversation),
+          description: conversationKind(conversation),
+          metadata: {
+            isPrivate: conversation.is_private ?? false,
+            isIm: conversation.is_im ?? false,
+            isMpim: conversation.is_mpim ?? false,
+            isArchived: conversation.is_archived ?? false,
+          },
+        }));
+        return { targets };
+      }).pipe(Effect.provide(SlackApi.SlackCredentials.fromIntegration(integration)));
+    }, Effect.provide(FetchHttpClient.layer)),
+  ),
+);
+
+export default handler;

--- a/packages/plugins/plugin-slack/src/operations/get-slack-channels.ts
+++ b/packages/plugins/plugin-slack/src/operations/get-slack-channels.ts
@@ -51,7 +51,7 @@ const conversationKind = (conversation: SlackApi.SlackConversation): string => {
 
 /**
  * Discovery only — list Slack conversations reachable from the integration's
- * token and return one descriptor per item. Read-only: NO local Chat objects
+ * token and return one descriptor per item. Read-only: NO local Channel objects
  * are created here. Materialization happens lazily in `SyncSlackChannel` on
  * first sync of a target.
  */

--- a/packages/plugins/plugin-slack/src/operations/index.ts
+++ b/packages/plugins/plugin-slack/src/operations/index.ts
@@ -1,0 +1,12 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { OperationHandlerSet } from '@dxos/compute';
+
+export const SlackHandlers = OperationHandlerSet.lazy(
+  () => import('./get-slack-channels'),
+  () => import('./sync'),
+);
+
+export * as SlackOperation from './definitions';

--- a/packages/plugins/plugin-slack/src/operations/sync.ts
+++ b/packages/plugins/plugin-slack/src/operations/sync.ts
@@ -5,16 +5,20 @@
 import * as FetchHttpClient from '@effect/platform/FetchHttpClient';
 import * as Effect from 'effect/Effect';
 
+import { Capability } from '@dxos/app-framework';
 import { LayoutOperation } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
 import { Database, Feed, Filter, Obj, Query, Ref } from '@dxos/echo';
+import { createFeedServiceLayer } from '@dxos/echo-db';
+import { invariant } from '@dxos/invariant';
 import { log } from '@dxos/log';
-import { Chat, ContentBlock, Message } from '@dxos/types';
+import { ClientCapabilities } from '@dxos/plugin-client/types';
+import { Channel, ContentBlock, Message } from '@dxos/types';
 
 import { meta } from '#meta';
 
 import { SLACK_SOURCE } from '../constants';
-import { formatSlackSyncFailure } from '../errors';
+import { IntegrationDatabaseMissingError, formatSlackSyncFailure } from '../errors';
 import { SlackApi } from '../services';
 import { SyncSlackChannel } from './definitions';
 
@@ -40,7 +44,7 @@ const tsToIso = (ts: string): string => {
   return new Date(seconds * 1000).toISOString();
 };
 
-const friendlyChatName = (conversation: SlackConversation): string => {
+const friendlyChannelName = (conversation: SlackConversation): string => {
   if (conversation.name && conversation.name.length > 0) {
     return conversation.is_channel || conversation.is_group ? `#${conversation.name}` : conversation.name;
   }
@@ -98,37 +102,37 @@ const mapSlackMessage = (
 };
 
 /**
- * Finds an existing Chat whose foreign key matches the given Slack conversation id.
+ * Finds an existing Channel whose foreign key matches the given Slack conversation id.
  */
-export const findChatForConversation: (
+export const findChannelForConversation: (
   conversationId: string,
-) => Effect.Effect<Chat.Chat | undefined, never, Database.Service> = Effect.fn('findChatForConversation')(
+) => Effect.Effect<Channel.Channel | undefined, never, Database.Service> = Effect.fn('findChannelForConversation')(
   function* (conversationId) {
     const existing = yield* Database.runQuery(
-      Query.select(Filter.foreignKeys(Chat.Chat, [{ source: SLACK_SOURCE, id: conversationId }])),
+      Query.select(Filter.foreignKeys(Channel.Channel, [{ source: SLACK_SOURCE, id: conversationId }])),
     );
-    return existing.length > 0 ? (existing[0] as Chat.Chat) : undefined;
+    return existing.length > 0 ? (existing[0] as Channel.Channel) : undefined;
   },
 );
 
 /**
- * Finds an existing Chat for a Slack conversation, or creates a fresh one (with
- * the foreign key set and a backing feed). Idempotent: re-running on the same
- * `(space, conversation)` returns the same Chat.
+ * Finds an existing Channel for a Slack conversation, or creates a fresh one
+ * (with the foreign key set and a backing feed). Idempotent: re-running on the
+ * same `(space, conversation)` returns the same Channel.
  */
-export const findOrCreateChatForConversation: (
+export const findOrCreateChannelForConversation: (
   conversation: SlackConversation,
-) => Effect.Effect<Chat.Chat, never, Database.Service> = Effect.fn('findOrCreateChatForConversation')(
+) => Effect.Effect<Channel.Channel, never, Database.Service> = Effect.fn('findOrCreateChannelForConversation')(
   function* (conversation) {
-    const existing = yield* findChatForConversation(conversation.id);
+    const existing = yield* findChannelForConversation(conversation.id);
     if (existing) {
       return existing;
     }
-    const chat = Chat.make({
+    const channel = Channel.make({
       [Obj.Meta]: { keys: [{ source: SLACK_SOURCE, id: conversation.id }] },
-      name: friendlyChatName(conversation),
+      name: friendlyChannelName(conversation),
     });
-    return yield* Database.add(chat);
+    return yield* Database.add(channel);
   },
 );
 
@@ -177,22 +181,37 @@ const TARGET_CONCURRENCY = 3;
  * Reconciles messages for currently-selected Slack targets on the Integration.
  *
  * Pull-only. Per target:
- *  1. Resolve (or materialize) the local Chat keyed by the Slack conversation id.
+ *  1. Resolve (or materialize) the local Channel keyed by the Slack conversation id.
  *  2. Ask Slack for messages since `target.cursor` (or all history on first sync).
  *  3. Resolve referenced user ids in one batch (cached per sync).
  *  4. Map each Slack message → `@dxos/types` Message and append the batch to
- *     the chat's feed.
+ *     the channel's feed.
  *  5. Update `target.cursor` to the newest `ts` seen so the next sync is incremental.
  *
  * Failure on one target writes `lastError` on that target only and continues
  * with the next; targets are processed in parallel up to `TARGET_CONCURRENCY`.
+ *
+ * `Database.Service` and `Feed.FeedService` are provided inside the handler.
+ * The integration's `target` ref carries the database; the space (and its
+ * `queues`, used to build `Feed.FeedService`) is resolved via the Client
+ * capability — same shape as `plugin-thread`'s `AppendChannelMessage`.
  */
 const handler: Operation.WithHandler<typeof SyncSlackChannel> = SyncSlackChannel.pipe(
   Operation.withHandler(
-    Effect.fn(function* ({ integration, chat: chatRef }) {
+    Effect.fn(function* ({ integration, channel: channelRef }) {
+      const integrationTarget = integration.target;
+      const db = integrationTarget ? Obj.getDatabase(integrationTarget) : undefined;
+      if (!db) {
+        return yield* Effect.fail(new IntegrationDatabaseMissingError());
+      }
+
+      const client = yield* Capability.get(ClientCapabilities.Client);
+      const space = client.spaces.get(db.spaceId);
+      invariant(space, 'Space not found');
+
       const integrationId = integration.dxn.asEchoDXN()?.echoId ?? 'unknown';
-      const toastIdSuffix = chatRef
-        ? `${integrationId}.${chatRef.dxn.asEchoDXN()?.echoId ?? 'unknown'}`
+      const toastIdSuffix = channelRef
+        ? `${integrationId}.${channelRef.dxn.asEchoDXN()?.echoId ?? 'unknown'}`
         : integrationId;
 
       const outcome = yield* Effect.either(
@@ -205,10 +224,10 @@ const handler: Operation.WithHandler<typeof SyncSlackChannel> = SyncSlackChannel
           const allConversations = yield* SlackApi.fetchConversations();
           const conversationsById = new Map(allConversations.map((c) => [c.id, c]));
 
-          const chatFilterId = chatRef?.dxn.asEchoDXN()?.echoId;
+          const channelFilterId = channelRef?.dxn.asEchoDXN()?.echoId;
           type TargetEntry = {
             entry: (typeof integrationObj.targets)[number];
-            chat: Chat.Chat;
+            channel: Channel.Channel;
             conversationId: string;
             conversation: SlackConversation;
           };
@@ -227,7 +246,7 @@ const handler: Operation.WithHandler<typeof SyncSlackChannel> = SyncSlackChannel
               continue;
             }
             if (!localObj) {
-              localObj = yield* findOrCreateChatForConversation(conversation);
+              localObj = yield* findOrCreateChannelForConversation(conversation);
               const materializedRef = Ref.make(localObj);
               Obj.update(integrationObj, (integrationObj) => {
                 const mutable = integrationObj as Obj.Mutable<typeof integrationObj>;
@@ -239,19 +258,19 @@ const handler: Operation.WithHandler<typeof SyncSlackChannel> = SyncSlackChannel
             }
 
             const targetEchoId = Ref.make(localObj).dxn.asEchoDXN()?.echoId;
-            if (chatFilterId && targetEchoId !== chatFilterId) {
+            if (channelFilterId && targetEchoId !== channelFilterId) {
               continue;
             }
-            if (!Chat.instanceOf(localObj)) {
+            if (!Channel.instanceOf(localObj)) {
               continue;
             }
 
-            targetEntries.push({ entry: target, chat: localObj, conversationId: foreignId, conversation });
+            targetEntries.push({ entry: target, channel: localObj, conversationId: foreignId, conversation });
           }
 
           const perTarget = yield* Effect.forEach(
             targetEntries,
-            ({ chat: targetChat, conversationId, conversation }) =>
+            ({ channel: targetChannel, conversationId, conversation }) =>
               Effect.gen(function* () {
                 const result = yield* Effect.either(
                   Effect.gen(function* () {
@@ -274,7 +293,7 @@ const handler: Operation.WithHandler<typeof SyncSlackChannel> = SyncSlackChannel
                       return { added: 0 };
                     }
 
-                    const feed = yield* Database.load(targetChat.feed);
+                    const feed = yield* Database.load(targetChannel.feed);
                     yield* Feed.append(feed, mapped);
 
                     const newestTs = sorted[sorted.length - 1].ts;
@@ -287,12 +306,12 @@ const handler: Operation.WithHandler<typeof SyncSlackChannel> = SyncSlackChannel
                     });
 
                     // Mirror the conversation's display name onto the local
-                    // Chat if we just learned a better one (first sync, or
+                    // Channel if we just learned a better one (first sync, or
                     // the channel was renamed remotely).
-                    const desiredName = friendlyChatName(conversation);
-                    if (targetChat.name !== desiredName) {
-                      Obj.update(targetChat, (targetChat) => {
-                        (targetChat as Obj.Mutable<typeof targetChat>).name = desiredName;
+                    const desiredName = friendlyChannelName(conversation);
+                    if (targetChannel.name !== desiredName) {
+                      Obj.update(targetChannel, (targetChannel) => {
+                        (targetChannel as Obj.Mutable<typeof targetChannel>).name = desiredName;
                       });
                     }
 
@@ -341,7 +360,11 @@ const handler: Operation.WithHandler<typeof SyncSlackChannel> = SyncSlackChannel
             pulled = { added: pulled.added + result.added };
           }
           return { pulled };
-        }).pipe(Effect.provide(SlackApi.SlackCredentials.fromIntegration(integration))),
+        }).pipe(
+          Effect.provide(Database.layer(db)),
+          Effect.provide(createFeedServiceLayer(space.queues)),
+          Effect.provide(SlackApi.SlackCredentials.fromIntegration(integration)),
+        ),
       );
 
       if (outcome._tag === 'Right') {

--- a/packages/plugins/plugin-slack/src/operations/sync.ts
+++ b/packages/plugins/plugin-slack/src/operations/sync.ts
@@ -63,10 +63,18 @@ const friendlyChannelName = (conversation: SlackConversation): string => {
  *   on read without a separate object type. The parent message itself has
  *   `thread_ts === ts` when `reply_count > 0`; we preserve that, so a query
  *   for `threadId == ts` returns parent + replies together.
- * - `sender` carries the Slack user id in `name` and either the resolved
- *   email (when `users:read` returned one) or the bot id. We populate `email`
- *   if the user lookup resolved one — that lets cross-source matching land
- *   on email later without re-fetching.
+ * - `sender.name` is resolved through a layered fallback that always produces
+ *   a non-empty value:
+ *     1. resolved user `display_name` / `real_name` / `name` (most messages),
+ *     2. resolved bot name via `bots.info` (bot-posted messages where Slack
+ *        supplies only `bot_id`),
+ *     3. Slack's own `username` field on the message (legacy bot integrations
+ *        and webhook posts),
+ *     4. the raw `user` / `bot_id` (opaque but stable),
+ *     5. literal `'unknown'`.
+ *   `username` is preferred over the raw id because the latter is opaque
+ *   (`U0B0X8EKP1Q`) while `username` is human-readable (`composer`).
+ * - `sender.email` if the user-info lookup returned one.
  * - `blocks` is currently a single `Text` block from the Slack `text` field.
  *   Slack's rich-text `blocks` array is intentionally NOT mapped yet — it
  *   would require a Slack-block → ContentBlock translator that's a separate
@@ -75,18 +83,27 @@ const friendlyChannelName = (conversation: SlackConversation): string => {
 const mapSlackMessage = (
   message: SlackMessage,
   userById: Map<string, SlackApi.SlackUser>,
+  botById: Map<string, SlackApi.SlackBot>,
 ): Message.Message | undefined => {
   if (message.subtype === 'channel_join' || message.subtype === 'channel_leave') {
     return undefined;
   }
   const text = message.text ?? '';
   const blocks: ContentBlock.Any[] = text.length > 0 ? [{ _tag: 'text', text } as ContentBlock.Text] : [];
-  const userId = message.user ?? message.bot_id;
-  const slackUser = userId ? userById.get(userId) : undefined;
+
+  const slackUser = message.user ? userById.get(message.user) : undefined;
+  const slackBot = message.bot_id ? botById.get(message.bot_id) : undefined;
   const senderName =
-    slackUser?.profile?.display_name && slackUser.profile.display_name.length > 0
+    (slackUser?.profile?.display_name && slackUser.profile.display_name.length > 0
       ? slackUser.profile.display_name
-      : (slackUser?.real_name ?? slackUser?.name ?? userId ?? message.username ?? 'unknown');
+      : undefined) ??
+    slackUser?.real_name ??
+    slackUser?.name ??
+    slackBot?.name ??
+    message.username ??
+    message.user ??
+    message.bot_id ??
+    'unknown';
 
   return Message.make({
     [Obj.Meta]: { keys: [{ source: SLACK_SOURCE, id: message.ts }] },
@@ -138,12 +155,14 @@ export const findOrCreateChannelForConversation: (
 
 /**
  * Resolves Slack user ids referenced in `messages` to {@link SlackApi.SlackUser}
- * records, using a per-sync cache so each id is only fetched once.
+ * records, using a per-sync cache so each id is only fetched once. Skipped
+ * for messages that have only `bot_id` (those are resolved separately via
+ * {@link resolveBots}) since `users.info` does not accept bot ids.
  *
  * Failed lookups (deleted users, missing scopes) silently fall through —
- * `mapSlackMessage` substitutes the raw user id when the resolved record is
- * missing, so a missing scope degrades gracefully into uglier sender names
- * rather than blocking the sync.
+ * `mapSlackMessage` substitutes a layered name fallback when the resolved
+ * record is missing, so a missing scope degrades gracefully rather than
+ * blocking the sync.
  */
 const resolveUsers = (
   messages: ReadonlyArray<SlackMessage>,
@@ -165,6 +184,43 @@ const resolveUsers = (
       (id) =>
         SlackApi.fetchUser(id).pipe(
           Effect.tap((user) => Effect.sync(() => user && out.set(id, user))),
+          Effect.catchAll((error) => {
+            log.catch(error);
+            return Effect.void;
+          }),
+        ),
+      { concurrency: 4, discard: true },
+    );
+    return out;
+  });
+
+/**
+ * Resolves Slack bot ids referenced in `messages` to {@link SlackApi.SlackBot}
+ * records via `bots.info`, with the same per-sync cache + silent-failure
+ * behavior as {@link resolveUsers}. Bot-posted messages (incoming-webhook
+ * posts, legacy bot users) carry only `bot_id` (`B…`); their friendly name
+ * is not reachable through `users.info`.
+ */
+const resolveBots = (
+  messages: ReadonlyArray<SlackMessage>,
+): Effect.Effect<
+  Map<string, SlackApi.SlackBot>,
+  never,
+  import('@effect/platform/HttpClient').HttpClient | SlackApi.SlackCredentials
+> =>
+  Effect.gen(function* () {
+    const ids = new Set<string>();
+    for (const message of messages) {
+      if (message.bot_id) {
+        ids.add(message.bot_id);
+      }
+    }
+    const out = new Map<string, SlackApi.SlackBot>();
+    yield* Effect.forEach(
+      Array.from(ids),
+      (id) =>
+        SlackApi.fetchBot(id).pipe(
+          Effect.tap((bot) => Effect.sync(() => bot && out.set(id, bot))),
           Effect.catchAll((error) => {
             log.catch(error);
             return Effect.void;
@@ -281,12 +337,13 @@ const handler: Operation.WithHandler<typeof SyncSlackChannel> = SyncSlackChannel
                     }
 
                     const userById = yield* resolveUsers(messages);
+                    const botById = yield* resolveBots(messages);
 
                     // Slack returns history newest-first; reverse so feed
                     // append order matches chronological order.
                     const sorted = [...messages].sort((a, b) => Number(a.ts) - Number(b.ts));
                     const mapped = sorted
-                      .map((message) => mapSlackMessage(message, userById))
+                      .map((message) => mapSlackMessage(message, userById, botById))
                       .filter((message): message is Message.Message => message !== undefined);
 
                     if (mapped.length === 0) {

--- a/packages/plugins/plugin-slack/src/operations/sync.ts
+++ b/packages/plugins/plugin-slack/src/operations/sync.ts
@@ -1,0 +1,372 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as FetchHttpClient from '@effect/platform/FetchHttpClient';
+import * as Effect from 'effect/Effect';
+
+import { LayoutOperation } from '@dxos/app-toolkit';
+import { Operation } from '@dxos/compute';
+import { Database, Feed, Filter, Obj, Query, Ref } from '@dxos/echo';
+import { log } from '@dxos/log';
+import { Chat, ContentBlock, Message } from '@dxos/types';
+
+import { meta } from '#meta';
+
+import { SLACK_SOURCE } from '../constants';
+import { formatSlackSyncFailure } from '../errors';
+import { SlackApi } from '../services';
+import { SyncSlackChannel } from './definitions';
+
+type SlackConversation = SlackApi.SlackConversation;
+type SlackMessage = SlackApi.SlackMessage;
+
+/** Pull reconcile result. */
+export type PullResult = {
+  added: number;
+};
+
+/**
+ * Slack `ts` is a string like `"1700000000.000123"` — seconds with a 6-digit
+ * subsecond fraction. Convert to ISO for `Message.created`. We strip subsecond
+ * precision because `Date` only has millisecond resolution; the original `ts`
+ * is preserved as the foreign key.
+ */
+const tsToIso = (ts: string): string => {
+  const seconds = Number.parseFloat(ts);
+  if (!Number.isFinite(seconds)) {
+    return new Date().toISOString();
+  }
+  return new Date(seconds * 1000).toISOString();
+};
+
+const friendlyChatName = (conversation: SlackConversation): string => {
+  if (conversation.name && conversation.name.length > 0) {
+    return conversation.is_channel || conversation.is_group ? `#${conversation.name}` : conversation.name;
+  }
+  if (conversation.is_im && conversation.user) {
+    return `DM with ${conversation.user}`;
+  }
+  return conversation.id;
+};
+
+/**
+ * Maps a Slack message into a `@dxos/types` Message.
+ *
+ * - `created` from the Slack `ts` (millisecond-truncated; original `ts` lives
+ *   in the foreign key).
+ * - `threadId` from `thread_ts` so threaded replies cluster under their parent
+ *   on read without a separate object type. The parent message itself has
+ *   `thread_ts === ts` when `reply_count > 0`; we preserve that, so a query
+ *   for `threadId == ts` returns parent + replies together.
+ * - `sender` carries the Slack user id in `name` and either the resolved
+ *   email (when `users:read` returned one) or the bot id. We populate `email`
+ *   if the user lookup resolved one — that lets cross-source matching land
+ *   on email later without re-fetching.
+ * - `blocks` is currently a single `Text` block from the Slack `text` field.
+ *   Slack's rich-text `blocks` array is intentionally NOT mapped yet — it
+ *   would require a Slack-block → ContentBlock translator that's a separate
+ *   piece of work.
+ */
+const mapSlackMessage = (
+  message: SlackMessage,
+  userById: Map<string, SlackApi.SlackUser>,
+): Message.Message | undefined => {
+  if (message.subtype === 'channel_join' || message.subtype === 'channel_leave') {
+    return undefined;
+  }
+  const text = message.text ?? '';
+  const blocks: ContentBlock.Any[] = text.length > 0 ? [{ _tag: 'text', text } as ContentBlock.Text] : [];
+  const userId = message.user ?? message.bot_id;
+  const slackUser = userId ? userById.get(userId) : undefined;
+  const senderName =
+    slackUser?.profile?.display_name && slackUser.profile.display_name.length > 0
+      ? slackUser.profile.display_name
+      : (slackUser?.real_name ?? slackUser?.name ?? userId ?? message.username ?? 'unknown');
+
+  return Message.make({
+    [Obj.Meta]: { keys: [{ source: SLACK_SOURCE, id: message.ts }] },
+    created: tsToIso(message.ts),
+    threadId: message.thread_ts,
+    sender: {
+      role: 'user',
+      name: senderName,
+      email: slackUser?.profile?.email,
+    },
+    blocks,
+  });
+};
+
+/**
+ * Finds an existing Chat whose foreign key matches the given Slack conversation id.
+ */
+export const findChatForConversation: (
+  conversationId: string,
+) => Effect.Effect<Chat.Chat | undefined, never, Database.Service> = Effect.fn('findChatForConversation')(
+  function* (conversationId) {
+    const existing = yield* Database.runQuery(
+      Query.select(Filter.foreignKeys(Chat.Chat, [{ source: SLACK_SOURCE, id: conversationId }])),
+    );
+    return existing.length > 0 ? (existing[0] as Chat.Chat) : undefined;
+  },
+);
+
+/**
+ * Finds an existing Chat for a Slack conversation, or creates a fresh one (with
+ * the foreign key set and a backing feed). Idempotent: re-running on the same
+ * `(space, conversation)` returns the same Chat.
+ */
+export const findOrCreateChatForConversation: (
+  conversation: SlackConversation,
+) => Effect.Effect<Chat.Chat, never, Database.Service> = Effect.fn('findOrCreateChatForConversation')(
+  function* (conversation) {
+    const existing = yield* findChatForConversation(conversation.id);
+    if (existing) {
+      return existing;
+    }
+    const chat = Chat.make({
+      [Obj.Meta]: { keys: [{ source: SLACK_SOURCE, id: conversation.id }] },
+      name: friendlyChatName(conversation),
+    });
+    return yield* Database.add(chat);
+  },
+);
+
+/**
+ * Resolves Slack user ids referenced in `messages` to {@link SlackApi.SlackUser}
+ * records, using a per-sync cache so each id is only fetched once.
+ *
+ * Failed lookups (deleted users, missing scopes) silently fall through —
+ * `mapSlackMessage` substitutes the raw user id when the resolved record is
+ * missing, so a missing scope degrades gracefully into uglier sender names
+ * rather than blocking the sync.
+ */
+const resolveUsers = (
+  messages: ReadonlyArray<SlackMessage>,
+): Effect.Effect<
+  Map<string, SlackApi.SlackUser>,
+  never,
+  import('@effect/platform/HttpClient').HttpClient | SlackApi.SlackCredentials
+> =>
+  Effect.gen(function* () {
+    const ids = new Set<string>();
+    for (const message of messages) {
+      if (message.user) {
+        ids.add(message.user);
+      }
+    }
+    const out = new Map<string, SlackApi.SlackUser>();
+    yield* Effect.forEach(
+      Array.from(ids),
+      (id) =>
+        SlackApi.fetchUser(id).pipe(
+          Effect.tap((user) => Effect.sync(() => user && out.set(id, user))),
+          Effect.catchAll((error) => {
+            log.catch(error);
+            return Effect.void;
+          }),
+        ),
+      { concurrency: 4, discard: true },
+    );
+    return out;
+  });
+
+const TARGET_CONCURRENCY = 3;
+
+/**
+ * Reconciles messages for currently-selected Slack targets on the Integration.
+ *
+ * Pull-only. Per target:
+ *  1. Resolve (or materialize) the local Chat keyed by the Slack conversation id.
+ *  2. Ask Slack for messages since `target.cursor` (or all history on first sync).
+ *  3. Resolve referenced user ids in one batch (cached per sync).
+ *  4. Map each Slack message → `@dxos/types` Message and append the batch to
+ *     the chat's feed.
+ *  5. Update `target.cursor` to the newest `ts` seen so the next sync is incremental.
+ *
+ * Failure on one target writes `lastError` on that target only and continues
+ * with the next; targets are processed in parallel up to `TARGET_CONCURRENCY`.
+ */
+const handler: Operation.WithHandler<typeof SyncSlackChannel> = SyncSlackChannel.pipe(
+  Operation.withHandler(
+    Effect.fn(function* ({ integration, chat: chatRef }) {
+      const integrationId = integration.dxn.asEchoDXN()?.echoId ?? 'unknown';
+      const toastIdSuffix = chatRef
+        ? `${integrationId}.${chatRef.dxn.asEchoDXN()?.echoId ?? 'unknown'}`
+        : integrationId;
+
+      const outcome = yield* Effect.either(
+        Effect.gen(function* () {
+          const integrationObj = yield* Database.load(integration);
+
+          // One round-trip up front to get every conversation the user has
+          // selected; we rely on `conversations.list` (vs. per-channel `info`)
+          // because targets often number in the dozens.
+          const allConversations = yield* SlackApi.fetchConversations();
+          const conversationsById = new Map(allConversations.map((c) => [c.id, c]));
+
+          const chatFilterId = chatRef?.dxn.asEchoDXN()?.echoId;
+          type TargetEntry = {
+            entry: (typeof integrationObj.targets)[number];
+            chat: Chat.Chat;
+            conversationId: string;
+            conversation: SlackConversation;
+          };
+          const targetEntries: TargetEntry[] = [];
+          for (const target of integrationObj.targets) {
+            let foreignId = target.remoteId;
+            let localObj = target.object?.target;
+            if (foreignId === undefined && localObj) {
+              foreignId = Obj.getMeta(localObj).keys.find((key) => key.source === SLACK_SOURCE)?.id;
+            }
+            if (foreignId === undefined) {
+              continue;
+            }
+            const conversation = conversationsById.get(foreignId);
+            if (!conversation) {
+              continue;
+            }
+            if (!localObj) {
+              localObj = yield* findOrCreateChatForConversation(conversation);
+              const materializedRef = Ref.make(localObj);
+              Obj.update(integrationObj, (integrationObj) => {
+                const mutable = integrationObj as Obj.Mutable<typeof integrationObj>;
+                const idx = mutable.targets.findIndex((entry) => entry.remoteId === foreignId);
+                if (idx >= 0) {
+                  mutable.targets[idx] = { ...mutable.targets[idx], object: materializedRef };
+                }
+              });
+            }
+
+            const targetEchoId = Ref.make(localObj).dxn.asEchoDXN()?.echoId;
+            if (chatFilterId && targetEchoId !== chatFilterId) {
+              continue;
+            }
+            if (!Chat.instanceOf(localObj)) {
+              continue;
+            }
+
+            targetEntries.push({ entry: target, chat: localObj, conversationId: foreignId, conversation });
+          }
+
+          const perTarget = yield* Effect.forEach(
+            targetEntries,
+            ({ chat: targetChat, conversationId, conversation }) =>
+              Effect.gen(function* () {
+                const result = yield* Effect.either(
+                  Effect.gen(function* () {
+                    const cursor = integrationObj.targets.find((entry) => entry.remoteId === conversationId)?.cursor;
+                    const messages = yield* SlackApi.fetchHistory(conversationId, { oldest: cursor });
+                    if (messages.length === 0) {
+                      return { added: 0 };
+                    }
+
+                    const userById = yield* resolveUsers(messages);
+
+                    // Slack returns history newest-first; reverse so feed
+                    // append order matches chronological order.
+                    const sorted = [...messages].sort((a, b) => Number(a.ts) - Number(b.ts));
+                    const mapped = sorted
+                      .map((message) => mapSlackMessage(message, userById))
+                      .filter((message): message is Message.Message => message !== undefined);
+
+                    if (mapped.length === 0) {
+                      return { added: 0 };
+                    }
+
+                    const feed = yield* Database.load(targetChat.feed);
+                    yield* Feed.append(feed, mapped);
+
+                    const newestTs = sorted[sorted.length - 1].ts;
+                    Obj.update(integrationObj, (integrationObj) => {
+                      const mutable = integrationObj as Obj.Mutable<typeof integrationObj>;
+                      const idx = mutable.targets.findIndex((entry) => entry.remoteId === conversationId);
+                      if (idx >= 0) {
+                        mutable.targets[idx] = { ...mutable.targets[idx], cursor: newestTs };
+                      }
+                    });
+
+                    // Mirror the conversation's display name onto the local
+                    // Chat if we just learned a better one (first sync, or
+                    // the channel was renamed remotely).
+                    const desiredName = friendlyChatName(conversation);
+                    if (targetChat.name !== desiredName) {
+                      Obj.update(targetChat, (targetChat) => {
+                        (targetChat as Obj.Mutable<typeof targetChat>).name = desiredName;
+                      });
+                    }
+
+                    return { added: mapped.length };
+                  }),
+                );
+
+                Obj.update(integrationObj, (integrationObj) => {
+                  const mutable = integrationObj as Obj.Mutable<typeof integrationObj>;
+                  const idx = mutable.targets.findIndex((entry) => {
+                    if (entry.remoteId !== undefined) {
+                      return entry.remoteId === conversationId;
+                    }
+                    const localId = entry.object?.target
+                      ? Obj.getMeta(entry.object.target).keys.find((key) => key.source === SLACK_SOURCE)?.id
+                      : undefined;
+                    return localId === conversationId;
+                  });
+                  if (idx < 0) {
+                    return;
+                  }
+                  if (result._tag === 'Right') {
+                    mutable.targets[idx] = {
+                      ...mutable.targets[idx],
+                      lastSyncAt: new Date().toISOString(),
+                      lastError: undefined,
+                    };
+                  } else {
+                    mutable.targets[idx] = {
+                      ...mutable.targets[idx],
+                      lastError: formatSlackSyncFailure(result.left),
+                    };
+                  }
+                });
+
+                return result._tag === 'Right' ? result.right : undefined;
+              }),
+            { concurrency: TARGET_CONCURRENCY },
+          );
+
+          let pulled: PullResult = { added: 0 };
+          for (const result of perTarget) {
+            if (!result) {
+              continue;
+            }
+            pulled = { added: pulled.added + result.added };
+          }
+          return { pulled };
+        }).pipe(Effect.provide(SlackApi.SlackCredentials.fromIntegration(integration))),
+      );
+
+      if (outcome._tag === 'Right') {
+        yield* Effect.ignore(
+          Operation.invoke(LayoutOperation.AddToast, {
+            id: `${meta.id}.sync-success.${toastIdSuffix}`,
+            icon: 'ph--check--regular',
+            title: ['sync-toast.success.label', { ns: meta.id }],
+          }),
+        );
+        return outcome.right;
+      } else {
+        const message = formatSlackSyncFailure(outcome.left);
+        yield* Effect.ignore(
+          Operation.invoke(LayoutOperation.AddToast, {
+            id: `${meta.id}.sync-error.${toastIdSuffix}`,
+            icon: 'ph--warning--regular',
+            title: ['sync-toast.error.label', { ns: meta.id }],
+            description: message,
+          }),
+        );
+        return yield* Effect.fail(outcome.left);
+      }
+    }, Effect.provide(FetchHttpClient.layer)),
+  ),
+);
+
+export default handler;

--- a/packages/plugins/plugin-slack/src/services/index.ts
+++ b/packages/plugins/plugin-slack/src/services/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * as SlackApi from './slack-api';

--- a/packages/plugins/plugin-slack/src/services/slack-api.ts
+++ b/packages/plugins/plugin-slack/src/services/slack-api.ts
@@ -181,7 +181,8 @@ const shouldRetry = (
 
 /**
  * Common pipeline for Slack requests:
- *  - Bearer token in the `Authorization` header.
+ *  - POST `application/x-www-form-urlencoded` body containing the bearer token
+ *    and any per-call params (see {@link authedPost} for why this shape).
  *  - Tracer disabled to avoid `traceparent` header tripping CORS preflight on
  *    `slack.com/api/*` (same workaround as Trello and Google userinfo).
  *  - Decode body with Effect Schema.
@@ -219,23 +220,29 @@ const slackRequest = <T extends { ok: boolean; error?: string }>(
   });
 
 /**
- * Builds an authenticated GET against `slack.com/api/<path>`.
+ * Builds an authenticated POST against `slack.com/api/<path>` with the bearer
+ * token plus any extra params encoded as `application/x-www-form-urlencoded`
+ * in the request body.
  *
- * Auth goes in the `token` URL parameter rather than `Authorization: Bearer …`
- * because Slack's CORS response on `slack.com/api/*` does NOT include
- * `Authorization` in `Access-Control-Allow-Headers`. Sending the header
- * triggers a preflight that the browser then rejects, blocking every
- * request from the composer dev origin. Slack's Web API treats the query
- * param and the bearer header as equivalent. The query param keeps the
- * request "simple" (no preflight) and works from any browser origin.
- *
- * The token is logged-as-empty in DevTools network panels because Slack
- * scrubs `token` URL params in their server-side logs; treat the URL
- * itself as sensitive on the client only.
+ * Why POST + body, not GET + query string and not Authorization header:
+ *  - Slack's CORS response on `slack.com/api/*` does NOT include
+ *    `Authorization` in `Access-Control-Allow-Headers`. Sending the bearer
+ *    header triggers a preflight that's rejected, blocking every request
+ *    from a browser origin.
+ *  - The legacy `?token=…` query-string form is rejected with `invalid_auth`
+ *    for OAuth v2 / granular-scope tokens (`xoxb-…`). Confirmed by direct
+ *    curl: `Authorization: Bearer …` returns `ok: true`, `?token=…` on the
+ *    same token returns `invalid_auth`. Slack's docs imply this still works,
+ *    but in practice they've tightened it for v2 tokens.
+ *  - POST with `application/x-www-form-urlencoded` is a "simple" CORS
+ *    request — no preflight — and Slack's Web API accepts the token in the
+ *    body under the same `token` key, equivalently to the bearer header.
+ *    Every method we use (`auth.test`, `conversations.list`,
+ *    `conversations.history`, `users.info`) accepts POST.
  */
-const authedGet = (creds: SlackCredentialsValue, path: string, params: Record<string, string | number> = {}) =>
-  HttpClientRequest.get(`${SLACK_API_BASE}/${path}`).pipe(
-    HttpClientRequest.setUrlParams({
+const authedPost = (creds: SlackCredentialsValue, path: string, params: Record<string, string | number> = {}) =>
+  HttpClientRequest.post(`${SLACK_API_BASE}/${path}`).pipe(
+    HttpClientRequest.bodyUrlParams({
       token: creds.token,
       ...Object.fromEntries(Object.entries(params).map(([k, v]) => [k, String(v)])),
     }),
@@ -248,7 +255,7 @@ const authedGet = (creds: SlackCredentialsValue, path: string, params: Record<st
  * Cheap, no scope requirement beyond the token being valid.
  */
 export const fetchAuthTest = (): SlackEffect<SlackAuthTest> =>
-  slackRequest((creds) => authedGet(creds, 'auth.test'), SlackAuthTestSchema);
+  slackRequest((creds) => authedPost(creds, 'auth.test'), SlackAuthTestSchema);
 
 /**
  * Lists all conversations the authenticated user can access, across types.
@@ -280,7 +287,7 @@ export const fetchConversations = (
         params.cursor = cursor;
       }
       const page = yield* slackRequest(
-        (creds) => authedGet(creds, 'conversations.list', params),
+        (creds) => authedPost(creds, 'conversations.list', params),
         SlackConversationListResponseSchema,
       );
       if (page.channels) {
@@ -304,7 +311,7 @@ export const fetchConversations = (
 export const fetchUser = (userId: string): SlackEffect<SlackUser | undefined> =>
   Effect.gen(function* () {
     const response = yield* slackRequest(
-      (creds) => authedGet(creds, 'users.info', { user: userId }),
+      (creds) => authedPost(creds, 'users.info', { user: userId }),
       SlackUsersInfoResponseSchema,
     );
     return response.user;
@@ -339,7 +346,7 @@ export const fetchHistory = (
         params.cursor = cursor;
       }
       const page = yield* slackRequest(
-        (creds) => authedGet(creds, 'conversations.history', params),
+        (creds) => authedPost(creds, 'conversations.history', params),
         SlackHistoryResponseSchema,
       );
       if (page.messages) {

--- a/packages/plugins/plugin-slack/src/services/slack-api.ts
+++ b/packages/plugins/plugin-slack/src/services/slack-api.ts
@@ -317,6 +317,43 @@ export const fetchUser = (userId: string): SlackEffect<SlackUser | undefined> =>
     return response.user;
   });
 
+const SlackBotInfoSchema = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String.pipe(Schema.optional),
+  app_id: Schema.String.pipe(Schema.optional),
+  user_id: Schema.String.pipe(Schema.optional),
+  icons: Schema.Struct({
+    image_36: Schema.String.pipe(Schema.optional),
+    image_48: Schema.String.pipe(Schema.optional),
+    image_72: Schema.String.pipe(Schema.optional),
+  }).pipe(Schema.optional),
+});
+
+export type SlackBot = Schema.Schema.Type<typeof SlackBotInfoSchema>;
+
+const SlackBotsInfoResponseSchema = Schema.Struct({
+  ok: Schema.Boolean,
+  error: Schema.String.pipe(Schema.optional),
+  bot: SlackBotInfoSchema.pipe(Schema.optional),
+});
+
+/**
+ * Returns bot info by bot id (`bots.info`).
+ *
+ * Used to resolve the friendly name of bot-posted messages where Slack
+ * supplies only `bot_id` (incoming-webhook posts, legacy bot users). The
+ * `bot_id` namespace (`B…`) is disjoint from user ids (`U…`) and `users.info`
+ * does NOT accept bot ids — the dedicated `bots.info` method is required.
+ */
+export const fetchBot = (botId: string): SlackEffect<SlackBot | undefined> =>
+  Effect.gen(function* () {
+    const response = yield* slackRequest(
+      (creds) => authedPost(creds, 'bots.info', { bot: botId }),
+      SlackBotsInfoResponseSchema,
+    );
+    return response.bot;
+  });
+
 /**
  * Fetches messages from a single conversation (`conversations.history`).
  *

--- a/packages/plugins/plugin-slack/src/services/slack-api.ts
+++ b/packages/plugins/plugin-slack/src/services/slack-api.ts
@@ -1,0 +1,337 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as HttpClient from '@effect/platform/HttpClient';
+import * as HttpClientError from '@effect/platform/HttpClientError';
+import * as HttpClientRequest from '@effect/platform/HttpClientRequest';
+import * as Cause from 'effect/Cause';
+import * as Context from 'effect/Context';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import * as ParseResult from 'effect/ParseResult';
+import * as Schedule from 'effect/Schedule';
+import * as Schema from 'effect/Schema';
+
+import { Database, type Ref } from '@dxos/echo';
+import { Integration } from '@dxos/plugin-integration/types';
+
+import { SLACK_API_BASE } from '../constants';
+import { SlackApiError } from '../errors';
+
+/** Slack bearer token (`xoxp-...` or `xoxb-...`). */
+type SlackCredentialsValue = {
+  token: string;
+};
+
+const SlackUserSchema = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String.pipe(Schema.optional),
+  real_name: Schema.String.pipe(Schema.optional),
+  is_bot: Schema.Boolean.pipe(Schema.optional),
+  profile: Schema.Struct({
+    display_name: Schema.String.pipe(Schema.optional),
+    real_name: Schema.String.pipe(Schema.optional),
+    email: Schema.String.pipe(Schema.optional),
+    image_72: Schema.String.pipe(Schema.optional),
+  }).pipe(Schema.optional),
+});
+
+export type SlackUser = Schema.Schema.Type<typeof SlackUserSchema>;
+
+const SlackAuthTestSchema = Schema.Struct({
+  ok: Schema.Boolean,
+  error: Schema.String.pipe(Schema.optional),
+  url: Schema.String.pipe(Schema.optional),
+  team: Schema.String.pipe(Schema.optional),
+  user: Schema.String.pipe(Schema.optional),
+  team_id: Schema.String.pipe(Schema.optional),
+  user_id: Schema.String.pipe(Schema.optional),
+  bot_id: Schema.String.pipe(Schema.optional),
+});
+
+export type SlackAuthTest = Schema.Schema.Type<typeof SlackAuthTestSchema>;
+
+const SlackConversationSchema = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String.pipe(Schema.optional),
+  is_channel: Schema.Boolean.pipe(Schema.optional),
+  is_group: Schema.Boolean.pipe(Schema.optional),
+  is_im: Schema.Boolean.pipe(Schema.optional),
+  is_mpim: Schema.Boolean.pipe(Schema.optional),
+  is_private: Schema.Boolean.pipe(Schema.optional),
+  is_archived: Schema.Boolean.pipe(Schema.optional),
+  /** For IMs: the user this conversation is with. */
+  user: Schema.String.pipe(Schema.optional),
+  /** For mpims: comma-joined list of user ids in `name`. */
+  num_members: Schema.Number.pipe(Schema.optional),
+  topic: Schema.Struct({ value: Schema.String }).pipe(Schema.optional),
+  purpose: Schema.Struct({ value: Schema.String }).pipe(Schema.optional),
+});
+
+export type SlackConversation = Schema.Schema.Type<typeof SlackConversationSchema>;
+
+const SlackMessageSchema = Schema.Struct({
+  type: Schema.String,
+  /** Slack timestamp; this is the canonical message id within a conversation. */
+  ts: Schema.String,
+  user: Schema.String.pipe(Schema.optional),
+  bot_id: Schema.String.pipe(Schema.optional),
+  username: Schema.String.pipe(Schema.optional),
+  text: Schema.String.pipe(Schema.optional),
+  /** Set on threaded replies; equal to `ts` of the parent message. */
+  thread_ts: Schema.String.pipe(Schema.optional),
+  reply_count: Schema.Number.pipe(Schema.optional),
+  subtype: Schema.String.pipe(Schema.optional),
+  /** Pre-parsed Slack rich-text blocks; passed through to consumers as-is. */
+  blocks: Schema.Array(Schema.Unknown).pipe(Schema.optional),
+});
+
+export type SlackMessage = Schema.Schema.Type<typeof SlackMessageSchema>;
+
+const SlackPaginatedMetadataSchema = Schema.Struct({
+  next_cursor: Schema.String.pipe(Schema.optional),
+});
+
+const SlackConversationListResponseSchema = Schema.Struct({
+  ok: Schema.Boolean,
+  error: Schema.String.pipe(Schema.optional),
+  channels: Schema.Array(SlackConversationSchema).pipe(Schema.optional),
+  response_metadata: SlackPaginatedMetadataSchema.pipe(Schema.optional),
+});
+
+const SlackHistoryResponseSchema = Schema.Struct({
+  ok: Schema.Boolean,
+  error: Schema.String.pipe(Schema.optional),
+  messages: Schema.Array(SlackMessageSchema).pipe(Schema.optional),
+  has_more: Schema.Boolean.pipe(Schema.optional),
+  response_metadata: SlackPaginatedMetadataSchema.pipe(Schema.optional),
+});
+
+const SlackUsersInfoResponseSchema = Schema.Struct({
+  ok: Schema.Boolean,
+  error: Schema.String.pipe(Schema.optional),
+  user: SlackUserSchema.pipe(Schema.optional),
+});
+
+/**
+ * Layer-based credentials service. Mirrors the `TrelloCredentials` pattern in
+ * plugin-trello: every API call pulls creds from this service rather than
+ * threading them through, so callers compose
+ * `Effect.provide(SlackApi.SlackCredentials.fromIntegration(ref))` once at the
+ * operation boundary.
+ */
+export class SlackCredentials extends Context.Tag('@dxos/plugin-slack/SlackCredentials')<
+  SlackCredentials,
+  SlackCredentialsValue
+>() {
+  static fromIntegration = (integrationRef: Ref.Ref<Integration.Integration>) =>
+    Layer.effect(
+      SlackCredentials,
+      Effect.gen(function* () {
+        const integration = yield* Database.load(integrationRef);
+        const accessToken = yield* Database.load(integration.accessToken);
+        return { token: accessToken.token };
+      }),
+    );
+}
+
+type SlackEffect<T> = Effect.Effect<
+  T,
+  HttpClientError.HttpClientError | ParseResult.ParseError | Cause.TimeoutException | SlackApiError,
+  HttpClient.HttpClient | SlackCredentials
+>;
+
+/**
+ * Slack uses HTTP 200 + `{ ok: false, error: '<code>' }` for application errors,
+ * so 5xx and 429 are the only meaningful retryable HTTP statuses. For
+ * `ok: false`, we surface a {@link SlackApiError} from the response body —
+ * that error is NOT retried because the failure mode (auth revoked, missing
+ * scope, channel not found) won't change between attempts.
+ *
+ *  - Transport / encode / invalid-URL failures: yes (transient by nature).
+ *  - 429 (rate limited) and 5xx: yes — Slack's rate limiter sets `Retry-After`,
+ *    but exponential backoff is a reasonable default until we wire up the header.
+ *  - 4xx other than 429: no — won't recover on retry.
+ *  - TimeoutException: yes.
+ *  - Schema decode failures (`ParseError`): no — payload won't become valid on retry.
+ *  - SlackApiError: no — body-level "ok: false" is an application error, not transient.
+ */
+const shouldRetry = (
+  error: HttpClientError.HttpClientError | ParseResult.ParseError | Cause.TimeoutException | SlackApiError,
+): boolean => {
+  if (error instanceof ParseResult.ParseError) {
+    return false;
+  }
+  if (SlackApiError.is(error)) {
+    return false;
+  }
+  if (Cause.isTimeoutException(error)) {
+    return true;
+  }
+  if (error._tag === 'RequestError') {
+    return true;
+  }
+  if (error.reason !== 'StatusCode') {
+    return true;
+  }
+  const status = error.response.status;
+  return status === 429 || (status >= 500 && status <= 599);
+};
+
+/**
+ * Common pipeline for Slack requests:
+ *  - Bearer token in the `Authorization` header.
+ *  - Tracer disabled to avoid `traceparent` header tripping CORS preflight on
+ *    `slack.com/api/*` (same workaround as Trello and Google userinfo).
+ *  - Decode body with Effect Schema.
+ *  - Promote `{ ok: false }` to {@link SlackApiError} carrying the error code.
+ *  - 15s timeout, exponential jittered retry up to 3 attempts on transient failures only.
+ */
+const runRequest = <T extends { ok: boolean; error?: string }>(
+  request: HttpClientRequest.HttpClientRequest,
+  schema: Schema.Schema<T>,
+): SlackEffect<T> =>
+  Effect.gen(function* () {
+    const httpClient = yield* HttpClient.HttpClient;
+    const clientNoTracer = httpClient.pipe(HttpClient.withTracerDisabledWhen(() => true));
+    return yield* clientNoTracer.execute(request).pipe(
+      Effect.flatMap((res) => Effect.flatMap(res.json, Schema.decodeUnknown(schema))),
+      Effect.flatMap((body) =>
+        body.ok ? Effect.succeed(body) : Effect.fail(new SlackApiError({ context: { code: body.error ?? 'unknown' } })),
+      ),
+      Effect.timeout('15 seconds'),
+      Effect.retry({
+        schedule: Schedule.exponential('500 millis').pipe(Schedule.jittered, Schedule.compose(Schedule.recurs(3))),
+        while: shouldRetry,
+      }),
+      Effect.scoped,
+    );
+  });
+
+const slackRequest = <T extends { ok: boolean; error?: string }>(
+  build: (creds: SlackCredentialsValue) => HttpClientRequest.HttpClientRequest,
+  schema: Schema.Schema<T>,
+): SlackEffect<T> =>
+  Effect.gen(function* () {
+    const creds = yield* SlackCredentials;
+    return yield* runRequest(build(creds), schema);
+  });
+
+const authedGet = (creds: SlackCredentialsValue, path: string, params: Record<string, string | number> = {}) =>
+  HttpClientRequest.get(`${SLACK_API_BASE}/${path}`).pipe(
+    HttpClientRequest.setHeader('Authorization', `Bearer ${creds.token}`),
+    HttpClientRequest.setUrlParams(Object.fromEntries(Object.entries(params).map(([k, v]) => [k, String(v)]))),
+  );
+
+/**
+ * Returns the authenticated user's identity (`auth.test`).
+ *
+ * Used by `onTokenCreated` to populate `accessToken.account` after OAuth.
+ * Cheap, no scope requirement beyond the token being valid.
+ */
+export const fetchAuthTest = (): SlackEffect<SlackAuthTest> =>
+  slackRequest((creds) => authedGet(creds, 'auth.test'), SlackAuthTestSchema);
+
+/**
+ * Lists all conversations the authenticated user can access, across types.
+ *
+ * Slack treats public channels, private channels, IMs, and mpims as a single
+ * `conversations` namespace; we ask for every type up front so discovery
+ * returns one flat list (matches the user's mental model: "pick a chat to
+ * sync"). Pagination is opaque-cursor; we drain every page so the discovery
+ * UI sees the complete list.
+ */
+export const fetchConversations = (
+  options: {
+    types?: ReadonlyArray<'public_channel' | 'private_channel' | 'im' | 'mpim'>;
+    excludeArchived?: boolean;
+  } = {},
+): SlackEffect<ReadonlyArray<SlackConversation>> =>
+  Effect.gen(function* () {
+    const types = (options.types ?? ['public_channel', 'private_channel', 'im', 'mpim']).join(',');
+    const excludeArchived = options.excludeArchived !== false;
+    const all: SlackConversation[] = [];
+    let cursor: string | undefined;
+    do {
+      const params: Record<string, string | number> = {
+        types,
+        exclude_archived: excludeArchived ? 'true' : 'false',
+        limit: 200,
+      };
+      if (cursor) {
+        params.cursor = cursor;
+      }
+      const page = yield* slackRequest(
+        (creds) => authedGet(creds, 'conversations.list', params),
+        SlackConversationListResponseSchema,
+      );
+      if (page.channels) {
+        all.push(...page.channels);
+      }
+      cursor =
+        page.response_metadata?.next_cursor && page.response_metadata.next_cursor.length > 0
+          ? page.response_metadata.next_cursor
+          : undefined;
+    } while (cursor);
+    return all;
+  });
+
+/**
+ * Returns user info by id (`users.info`).
+ *
+ * Used to resolve `Message.user` Slack ids into display names for IM/mpim
+ * `name` derivation. Single-user lookup; callers cache results across a sync
+ * pass so the same user isn't refetched per message.
+ */
+export const fetchUser = (userId: string): SlackEffect<SlackUser | undefined> =>
+  Effect.gen(function* () {
+    const response = yield* slackRequest(
+      (creds) => authedGet(creds, 'users.info', { user: userId }),
+      SlackUsersInfoResponseSchema,
+    );
+    return response.user;
+  });
+
+/**
+ * Fetches messages from a single conversation (`conversations.history`).
+ *
+ * `oldest` is a Slack ts string (`"1700000000.000000"`) — we store the most
+ * recent processed `ts` as `IntegrationTarget.cursor` so subsequent syncs
+ * pick up only new messages. Drains every page so callers see the full
+ * delta in one call; `limit` caps the per-request page size only.
+ *
+ * Threaded replies are NOT included here — Slack returns parent messages with
+ * `thread_ts === ts` and `reply_count > 0`; replies live in
+ * `conversations.replies` and would be fetched separately if needed.
+ */
+export const fetchHistory = (
+  channelId: string,
+  options: { oldest?: string; limit?: number } = {},
+): SlackEffect<ReadonlyArray<SlackMessage>> =>
+  Effect.gen(function* () {
+    const all: SlackMessage[] = [];
+    let cursor: string | undefined;
+    const limit = options.limit ?? 200;
+    do {
+      const params: Record<string, string | number> = { channel: channelId, limit };
+      if (options.oldest) {
+        params.oldest = options.oldest;
+      }
+      if (cursor) {
+        params.cursor = cursor;
+      }
+      const page = yield* slackRequest(
+        (creds) => authedGet(creds, 'conversations.history', params),
+        SlackHistoryResponseSchema,
+      );
+      if (page.messages) {
+        all.push(...page.messages);
+      }
+      cursor =
+        page.response_metadata?.next_cursor && page.response_metadata.next_cursor.length > 0
+          ? page.response_metadata.next_cursor
+          : undefined;
+    } while (cursor);
+    return all;
+  });

--- a/packages/plugins/plugin-slack/src/services/slack-api.ts
+++ b/packages/plugins/plugin-slack/src/services/slack-api.ts
@@ -218,10 +218,27 @@ const slackRequest = <T extends { ok: boolean; error?: string }>(
     return yield* runRequest(build(creds), schema);
   });
 
+/**
+ * Builds an authenticated GET against `slack.com/api/<path>`.
+ *
+ * Auth goes in the `token` URL parameter rather than `Authorization: Bearer …`
+ * because Slack's CORS response on `slack.com/api/*` does NOT include
+ * `Authorization` in `Access-Control-Allow-Headers`. Sending the header
+ * triggers a preflight that the browser then rejects, blocking every
+ * request from the composer dev origin. Slack's Web API treats the query
+ * param and the bearer header as equivalent. The query param keeps the
+ * request "simple" (no preflight) and works from any browser origin.
+ *
+ * The token is logged-as-empty in DevTools network panels because Slack
+ * scrubs `token` URL params in their server-side logs; treat the URL
+ * itself as sensitive on the client only.
+ */
 const authedGet = (creds: SlackCredentialsValue, path: string, params: Record<string, string | number> = {}) =>
   HttpClientRequest.get(`${SLACK_API_BASE}/${path}`).pipe(
-    HttpClientRequest.setHeader('Authorization', `Bearer ${creds.token}`),
-    HttpClientRequest.setUrlParams(Object.fromEntries(Object.entries(params).map(([k, v]) => [k, String(v)]))),
+    HttpClientRequest.setUrlParams({
+      token: creds.token,
+      ...Object.fromEntries(Object.entries(params).map(([k, v]) => [k, String(v)])),
+    }),
   );
 
 /**

--- a/packages/plugins/plugin-slack/src/services/slack-api.ts
+++ b/packages/plugins/plugin-slack/src/services/slack-api.ts
@@ -273,7 +273,7 @@ export const fetchConversations = (
   } = {},
 ): SlackEffect<ReadonlyArray<SlackConversation>> =>
   Effect.gen(function* () {
-    const types = (options.types ?? ['public_channel', 'private_channel', 'im', 'mpim']).join(',');
+    const types = (options.types ?? ['public_channel', 'private_channel', 'mpim']).join(',');
     const excludeArchived = options.excludeArchived !== false;
     const all: SlackConversation[] = [];
     let cursor: string | undefined;

--- a/packages/plugins/plugin-slack/src/services/slack-api.ts
+++ b/packages/plugins/plugin-slack/src/services/slack-api.ts
@@ -273,7 +273,7 @@ export const fetchConversations = (
   } = {},
 ): SlackEffect<ReadonlyArray<SlackConversation>> =>
   Effect.gen(function* () {
-    const types = (options.types ?? ['public_channel', 'private_channel', 'mpim']).join(',');
+    const types = (options.types ?? ['public_channel', 'private_channel']).join(',');
     const excludeArchived = options.excludeArchived !== false;
     const all: SlackConversation[] = [];
     let cursor: string | undefined;

--- a/packages/plugins/plugin-slack/src/translations.ts
+++ b/packages/plugins/plugin-slack/src/translations.ts
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { meta } from '#meta';
+
+export const translations = [
+  {
+    'en-US': {
+      [meta.id]: {
+        'plugin.name': 'Slack',
+        'sync-now.label': 'Sync now',
+        'sync-this-chat.label': 'Sync this chat',
+        'sync-toast.success.label': 'Sync complete',
+        'sync-toast.error.label': 'Sync failed',
+      },
+    },
+  },
+];

--- a/packages/plugins/plugin-slack/tsconfig.json
+++ b/packages/plugins/plugin-slack/tsconfig.json
@@ -58,6 +58,9 @@
     },
     {
       "path": "../plugin-integration"
+    },
+    {
+      "path": "../plugin-testing"
     }
   ]
 }

--- a/packages/plugins/plugin-slack/tsconfig.json
+++ b/packages/plugins/plugin-slack/tsconfig.json
@@ -1,0 +1,57 @@
+{
+  "extends": [
+    "../../../tsconfig.base.json"
+  ],
+  "compilerOptions": {
+    "types": [
+      "node"
+    ]
+  },
+  "exclude": [
+    "*.t.ts",
+    "vite.config.ts"
+  ],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../../common/effect"
+    },
+    {
+      "path": "../../common/errors"
+    },
+    {
+      "path": "../../common/log"
+    },
+    {
+      "path": "../../common/util"
+    },
+    {
+      "path": "../../core/compute"
+    },
+    {
+      "path": "../../core/echo/echo"
+    },
+    {
+      "path": "../../core/echo/echo-db"
+    },
+    {
+      "path": "../../core/protocols"
+    },
+    {
+      "path": "../../sdk/app-framework"
+    },
+    {
+      "path": "../../sdk/app-toolkit"
+    },
+    {
+      "path": "../../sdk/types"
+    },
+    {
+      "path": "../plugin-integration"
+    }
+  ]
+}

--- a/packages/plugins/plugin-slack/tsconfig.json
+++ b/packages/plugins/plugin-slack/tsconfig.json
@@ -33,7 +33,7 @@
       "path": "../../common/util"
     },
     {
-      "path": "../../core/compute"
+      "path": "../../core/compute/compute"
     },
     {
       "path": "../../core/echo/echo"

--- a/packages/plugins/plugin-slack/tsconfig.json
+++ b/packages/plugins/plugin-slack/tsconfig.json
@@ -24,6 +24,9 @@
       "path": "../../common/errors"
     },
     {
+      "path": "../../common/invariant"
+    },
+    {
       "path": "../../common/log"
     },
     {
@@ -49,6 +52,9 @@
     },
     {
       "path": "../../sdk/types"
+    },
+    {
+      "path": "../plugin-client"
     },
     {
       "path": "../plugin-integration"

--- a/packages/plugins/plugin-slack/vitest.config.ts
+++ b/packages/plugins/plugin-slack/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/packages/plugins/plugin-thread/src/components/Chat/Chat.tsx
+++ b/packages/plugins/plugin-thread/src/components/Chat/Chat.tsx
@@ -51,6 +51,13 @@ export type ChatProps = ThemedClassName<
      *   scrolling above it. Suitable for full-panel multi-party chat.
      */
     orientation?: ChatOrientation;
+    /**
+     * When true, hide the composer textbox and activity indicator. Used for
+     * channels whose source-of-truth lives elsewhere (e.g. externally-synced
+     * Slack/Discord channels keyed by a foreign id) — sending isn't meaningful
+     * because there is no local-write path back to the source.
+     */
+    readOnly?: boolean;
   } & Pick<ThreadRootProps, 'current'>
 >;
 
@@ -65,7 +72,19 @@ export type ChatOrientation = 'top' | 'bottom';
  */
 export const Chat = composable<HTMLDivElement, ChatProps>(
   (
-    { id, identity, members, messages, activity, onSend, autoFocusTextbox, current, orientation = 'top', ...props },
+    {
+      id,
+      identity,
+      members,
+      messages,
+      activity,
+      onSend,
+      autoFocusTextbox,
+      current,
+      orientation = 'top',
+      readOnly,
+      ...props
+    },
     forwardedRef,
   ) => {
     const { t } = useTranslation(meta.id);
@@ -129,6 +148,7 @@ export const Chat = composable<HTMLDivElement, ChatProps>(
       textboxMetadata,
       scrollRef,
       sentinelRef,
+      readOnly,
     };
 
     return orientation === 'bottom' ? (
@@ -164,6 +184,7 @@ type ChatRenderState = {
   textboxMetadata: MessageMetadata;
   scrollRef: RefObject<HTMLDivElement | null>;
   sentinelRef: RefObject<HTMLDivElement | null>;
+  readOnly?: boolean;
 };
 
 type LayoutProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -175,7 +196,8 @@ type LayoutProps = React.HTMLAttributes<HTMLDivElement> & {
 const ThreadLayout = React.forwardRef<HTMLDivElement, LayoutProps & Pick<ThreadRootProps, 'current'>>(
   ({ id, current, state, ...props }, ref) => {
     const { t } = useTranslation(meta.id);
-    const { messages, members, activity, extensions, autoFocus, handleSend, textboxMetadata, sentinelRef } = state;
+    const { messages, members, activity, extensions, autoFocus, handleSend, textboxMetadata, sentinelRef, readOnly } =
+      state;
     return (
       <ThreadComponent.Root {...props} id={id} current={current} ref={ref}>
         <ScrollArea.Root classNames='col-span-2' orientation='vertical'>
@@ -187,8 +209,12 @@ const ThreadLayout = React.forwardRef<HTMLDivElement, LayoutProps & Pick<ThreadR
             </div>
           </ScrollArea.Viewport>
         </ScrollArea.Root>
-        <MessageTextbox extensions={extensions} autoFocus={autoFocus} onSend={handleSend} {...textboxMetadata} />
-        <ThreadComponent.Status activity={activity}>{t('activity.message')}</ThreadComponent.Status>
+        {!readOnly && (
+          <>
+            <MessageTextbox extensions={extensions} autoFocus={autoFocus} onSend={handleSend} {...textboxMetadata} />
+            <ThreadComponent.Status activity={activity}>{t('activity.message')}</ThreadComponent.Status>
+          </>
+        )}
       </ThreadComponent.Root>
     );
   },
@@ -197,8 +223,18 @@ const ThreadLayout = React.forwardRef<HTMLDivElement, LayoutProps & Pick<ThreadR
 /** Channel layout — composer pinned to the bottom, messages scroll above it. */
 const ChannelLayout = React.forwardRef<HTMLDivElement, LayoutProps>(({ id, state, ...props }, ref) => {
   const { t } = useTranslation(meta.id);
-  const { messages, members, activity, extensions, autoFocus, handleSend, textboxMetadata, scrollRef, sentinelRef } =
-    state;
+  const {
+    messages,
+    members,
+    activity,
+    extensions,
+    autoFocus,
+    handleSend,
+    textboxMetadata,
+    scrollRef,
+    sentinelRef,
+    readOnly,
+  } = state;
   return (
     <div {...props} id={id} ref={ref}>
       <div ref={scrollRef} className='flex-1 min-h-0 overflow-y-auto'>
@@ -209,10 +245,14 @@ const ChannelLayout = React.forwardRef<HTMLDivElement, LayoutProps>(({ id, state
         ))}
         <div ref={sentinelRef} />
       </div>
-      <div className='shrink-0 grid grid-cols-[var(--dx-rail-size)_1fr]'>
-        <MessageTextbox extensions={extensions} autoFocus={autoFocus} onSend={handleSend} {...textboxMetadata} />
-      </div>
-      <div className='shrink-0 px-2 pb-1 text-xs text-description'>{activity ? t('activity.message') : null}</div>
+      {!readOnly && (
+        <>
+          <div className='shrink-0 grid grid-cols-[var(--dx-rail-size)_1fr]'>
+            <MessageTextbox extensions={extensions} autoFocus={autoFocus} onSend={handleSend} {...textboxMetadata} />
+          </div>
+          <div className='shrink-0 px-2 pb-1 text-xs text-description'>{activity ? t('activity.message') : null}</div>
+        </>
+      )}
     </div>
   );
 });

--- a/packages/plugins/plugin-thread/src/components/MessagePanel/MessagePanel.tsx
+++ b/packages/plugins/plugin-thread/src/components/MessagePanel/MessagePanel.tsx
@@ -82,7 +82,10 @@ export const MessagePanel = ({
       (message.sender.identityDid && member.identity.did === message.sender.identityDid) ||
       (message.sender.identityKey && PublicKey.equals(member.identity.identityKey, message.sender.identityKey)),
   )?.identity;
-  const messageMetadata = getMessageMetadata(message.id, senderIdentity);
+  // Pass `message.sender` as the fallback so externally-synced messages
+  // (Slack, etc.) display the source-side sender name instead of "Anonymous"
+  // when no DXOS identity matches.
+  const messageMetadata = getMessageMetadata(message.id, senderIdentity, message.sender);
   const userIsAuthor = identity?.did === messageMetadata.authorId;
   const proposalBlock = message.blocks.find((block) => block._tag === 'proposal');
   const references = message.blocks.filter((block) => block._tag === 'reference').map((block) => block.reference);

--- a/packages/plugins/plugin-thread/src/containers/ChannelChat/ChannelChat.tsx
+++ b/packages/plugins/plugin-thread/src/containers/ChannelChat/ChannelChat.tsx
@@ -24,6 +24,10 @@ export type ChannelChatProps = {
  * Channel chat: composer pinned to the bottom of the panel, messages scrolling
  * above it (newest at the bottom). Threading via `Message.threadId` is
  * intentionally not reconstructed in this round.
+ *
+ * Externally-synced channels (any Channel carrying foreign-key `Obj.Meta`,
+ * e.g. Slack/Discord-sourced rooms) render read-only — the composer is
+ * suppressed because there's no local-write path back to the source.
  */
 export const ChannelChat = composable<HTMLDivElement, ChannelChatProps>(
   ({ space, channel, ...props }, forwardedRef) => {
@@ -39,7 +43,12 @@ export const ChannelChat = composable<HTMLDivElement, ChannelChatProps>(
       feed ? Query.select(Filter.type(Message.Message)).from(feed) : Query.select(Filter.nothing()),
     ) as Message.Message[];
 
+    const readOnly = Obj.getMeta(channel).keys.length > 0;
+
     const handleSend = (text: string) => {
+      if (readOnly) {
+        return false;
+      }
       void invokePromise(ThreadOperation.AppendChannelMessage, {
         channel,
         sender: { identityDid: identity.did },
@@ -58,6 +67,7 @@ export const ChannelChat = composable<HTMLDivElement, ChannelChatProps>(
         activity={activity}
         onSend={handleSend}
         orientation='bottom'
+        readOnly={readOnly}
         ref={forwardedRef}
       />
     );

--- a/packages/plugins/plugin-thread/src/util.ts
+++ b/packages/plugins/plugin-thread/src/util.ts
@@ -9,18 +9,44 @@ import { type PublicKey } from '@dxos/react-client';
 import { type Identity } from '@dxos/react-client/halo';
 import { type Selection } from '@dxos/react-ui-attention';
 import { type MessageMetadata } from '@dxos/react-ui-thread';
-import { hexToFallback } from '@dxos/util';
+import { hexToFallback, toFallback } from '@dxos/util';
 
 export type MessagePropertiesProvider = (identityKey: PublicKey | undefined) => MessageMetadata;
 
-export const getMessageMetadata = (id: string, identity?: Identity): MessageMetadata => {
-  const fallback = hexToFallback(identity?.identityKey.toHex() ?? '0');
+/**
+ * Stable hash for an arbitrary string — used as the avatar-fallback seed for
+ * external senders who have no DXOS identity (e.g. Slack/Discord-synced
+ * messages). djb2-ish, only stability matters.
+ */
+const hashString = (s: string): number => {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 31 + s.charCodeAt(i)) | 0;
+  }
+  return h;
+};
+
+export const getMessageMetadata = (
+  id: string,
+  identity?: Identity,
+  /**
+   * Externally-sourced sender info (Slack/Discord/etc). Used only when no
+   * matching DXOS `identity` is available — provides `name`/`email` for the
+   * author label and a stable seed for the avatar fallback.
+   */
+  fallbackSender?: { name?: string; email?: string },
+): MessageMetadata => {
+  const fallback = identity?.identityKey
+    ? hexToFallback(identity.identityKey.toHex())
+    : toFallback(hashString(fallbackSender?.name ?? fallbackSender?.email ?? '0'));
   return {
     id,
     authorId: identity?.did,
     authorName:
       identity?.profile?.displayName ??
-      (identity?.identityKey ? generateName(identity.identityKey.toHex()) : undefined),
+      (identity?.identityKey ? generateName(identity.identityKey.toHex()) : undefined) ??
+      fallbackSender?.name ??
+      fallbackSender?.email,
     authorAvatarProps: {
       hue: identity?.profile?.data?.hue ?? fallback.hue,
       emoji: identity?.profile?.data?.emoji ?? fallback.emoji,

--- a/packages/plugins/plugin-thread/src/util.ts
+++ b/packages/plugins/plugin-thread/src/util.ts
@@ -17,13 +17,19 @@ export type MessagePropertiesProvider = (identityKey: PublicKey | undefined) => 
  * Stable hash for an arbitrary string — used as the avatar-fallback seed for
  * external senders who have no DXOS identity (e.g. Slack/Discord-synced
  * messages). djb2-ish, only stability matters.
+ *
+ * Coerced to unsigned 32-bit via `>>> 0` because `toFallback` does a plain
+ * modulo against `idEmoji.length * idHue.length` and JavaScript's `%`
+ * preserves the sign of the dividend — a negative hash would index
+ * `idEmoji[-x]` and `idHue[-x]` to `undefined`, causing the avatar to fall
+ * through to `Avatar.Content`'s default red/ghost.
  */
 const hashString = (s: string): number => {
   let h = 0;
   for (let i = 0; i < s.length; i++) {
     h = (h * 31 + s.charCodeAt(i)) | 0;
   }
-  return h;
+  return h >>> 0;
 };
 
 export const getMessageMetadata = (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2257,7 +2257,7 @@ importers:
         version: 16.0.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.8(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3)
+        version: 0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3)
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
@@ -2583,6 +2583,9 @@ importers:
       '@dxos/plugin-sketch':
         specifier: workspace:*
         version: link:../../plugins/plugin-sketch
+      '@dxos/plugin-slack':
+        specifier: workspace:*
+        version: link:../../plugins/plugin-slack
       '@dxos/plugin-space':
         specifier: workspace:*
         version: link:../../plugins/plugin-space
@@ -5672,7 +5675,7 @@ importers:
         version: 1.7.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.16.8(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3)
+        version: 0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -13767,6 +13770,55 @@ importers:
       react-dom:
         specifier: ~19.2.3
         version: 19.2.3(react@19.2.3)
+      vite:
+        specifier: '>=8.0.0'
+        version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/plugins/plugin-slack:
+    dependencies:
+      '@dxos/app-framework':
+        specifier: workspace:*
+        version: link:../../sdk/app-framework
+      '@dxos/app-toolkit':
+        specifier: workspace:*
+        version: link:../../sdk/app-toolkit
+      '@dxos/compute':
+        specifier: workspace:*
+        version: link:../../core/compute/compute
+      '@dxos/echo':
+        specifier: workspace:*
+        version: link:../../core/echo/echo
+      '@dxos/errors':
+        specifier: workspace:*
+        version: link:../../common/errors
+      '@dxos/log':
+        specifier: workspace:*
+        version: link:../../common/log
+      '@dxos/plugin-integration':
+        specifier: workspace:*
+        version: link:../plugin-integration
+      '@dxos/protocols':
+        specifier: workspace:*
+        version: link:../../core/protocols
+      '@dxos/types':
+        specifier: workspace:*
+        version: link:../../sdk/types
+      '@dxos/util':
+        specifier: workspace:*
+        version: link:../../common/util
+      '@effect/platform':
+        specifier: 'catalog:'
+        version: 0.94.4(effect@3.20.0)
+      effect:
+        specifier: 3.20.0
+        version: 3.20.0
+    devDependencies:
+      '@dxos/echo-db':
+        specifier: workspace:*
+        version: link:../../core/echo/echo-db
+      '@dxos/effect':
+        specifier: workspace:*
+        version: link:../../common/effect
       vite:
         specifier: '>=8.0.0'
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -46748,14 +46800,20 @@ snapshots:
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.52':
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.53':
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.53(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
@@ -55139,7 +55197,7 @@ snapshots:
       lodash: 4.17.23
       minimist: 1.2.8
       prettier: 3.6.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
 
   json-schema-traverse@0.4.1: {}
 
@@ -59036,7 +59094,7 @@ snapshots:
 
   robust-predicates@3.0.1: {}
 
-  rolldown-plugin-dts@0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(rolldown@1.0.0-beta.52)(typescript@6.0.3):
+  rolldown-plugin-dts@0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3):
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
@@ -59047,14 +59105,14 @@ snapshots:
       get-tsconfig: 4.13.0
       magic-string: 0.30.21
       obug: 2.1.1
-      rolldown: 1.0.0-beta.52
+      rolldown: 1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optionalDependencies:
       '@typescript/native-preview': 7.0.0-dev.20260421.2
       typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.0.0-beta.52:
+  rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@oxc-project/types': 0.99.0
       '@rolldown/pluginutils': 1.0.0-beta.52
@@ -59069,12 +59127,15 @@ snapshots:
       '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.52
       '@rolldown/binding-linux-x64-musl': 1.0.0-beta.52
       '@rolldown/binding-openharmony-arm64': 1.0.0-beta.52
-      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.52
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.52
       '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.52
       '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.52
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
-  rolldown@1.0.0-beta.53:
+  rolldown@1.0.0-beta.53(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@oxc-project/types': 0.101.0
       '@rolldown/pluginutils': 1.0.0-beta.53
@@ -59089,9 +59150,12 @@ snapshots:
       '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.53
       '@rolldown/binding-linux-x64-musl': 1.0.0-beta.53
       '@rolldown/binding-openharmony-arm64': 1.0.0-beta.53
-      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.53
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.53(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.53
       '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.53
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   rolldown@1.0.0-rc.17:
     dependencies:
@@ -60701,7 +60765,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.16.8(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3):
+  tsdown@0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(typescript@6.0.3):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -60710,17 +60774,19 @@ snapshots:
       empathic: 2.0.0
       hookable: 5.5.3
       obug: 2.1.1
-      rolldown: 1.0.0-beta.52
-      rolldown-plugin-dts: 0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(rolldown@1.0.0-beta.52)(typescript@6.0.3)
+      rolldown: 1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      rolldown-plugin-dts: 0.18.3(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.9.0)(rolldown@1.0.0-beta.52(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
       semver: 7.7.3
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
       unconfig-core: 7.4.2
-      unrun: 0.2.19
+      unrun: 0.2.19(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
       - oxc-resolver
@@ -61103,7 +61169,7 @@ snapshots:
   unplugin@2.3.5:
     dependencies:
       acorn: 8.15.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
   unrs-resolver@1.11.1:
@@ -61130,9 +61196,12 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
-  unrun@0.2.19:
+  unrun@0.2.19(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
-      rolldown: 1.0.0-beta.53
+      rolldown: 1.0.0-beta.53(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   unstorage@1.17.5(@azure/identity@4.13.0)(idb-keyval@6.2.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13788,12 +13788,21 @@ importers:
       '@dxos/echo':
         specifier: workspace:*
         version: link:../../core/echo/echo
+      '@dxos/echo-db':
+        specifier: workspace:*
+        version: link:../../core/echo/echo-db
       '@dxos/errors':
         specifier: workspace:*
         version: link:../../common/errors
+      '@dxos/invariant':
+        specifier: workspace:*
+        version: link:../../common/invariant
       '@dxos/log':
         specifier: workspace:*
         version: link:../../common/log
+      '@dxos/plugin-client':
+        specifier: workspace:*
+        version: link:../plugin-client
       '@dxos/plugin-integration':
         specifier: workspace:*
         version: link:../plugin-integration
@@ -13813,9 +13822,6 @@ importers:
         specifier: 3.20.0
         version: 3.20.0
     devDependencies:
-      '@dxos/echo-db':
-        specifier: workspace:*
-        version: link:../../core/echo/echo-db
       '@dxos/effect':
         specifier: workspace:*
         version: link:../../common/effect

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13825,6 +13825,9 @@ importers:
       '@dxos/effect':
         specifier: workspace:*
         version: link:../../common/effect
+      '@dxos/plugin-testing':
+        specifier: workspace:*
+        version: link:../plugin-testing
       vite:
         specifier: '>=8.0.0'
         version: 8.0.10(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -785,6 +785,11 @@
         },
         {
           "type": "json",
+          "path": "packages/plugins/plugin-slack/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "packages/plugins/plugin-space/package.json",
           "jsonpath": "$.version"
         },

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -457,6 +457,9 @@
       "path": "packages/plugins/plugin-sketch/tsconfig.json"
     },
     {
+      "path": "packages/plugins/plugin-slack/tsconfig.json"
+    },
+    {
       "path": "packages/plugins/plugin-space/tsconfig.json"
     },
     {


### PR DESCRIPTION
## Summary

Adds the Slack sync plugin on top of #11246 (now merged). Mirrors `plugin-trello` / `plugin-github` for sync-plugin structure and uses the new feed-backed `Channel` from `@dxos/types` as the local materialization target.

### `@dxos/plugin-slack`

Contributes:

- An `IntegrationProvider` entry for source `'slack.com'` with `OAuthProvider.SLACK` and an `onTokenCreated` hook that populates `AccessToken.account` from `auth.test`.
- **`GetSlackChannels`** — discovery only. Lists every conversation reachable from the token across types (public channels, private channels, IMs, group DMs). Read-only; does NOT materialize local `Channel`s.
- **`SyncSlackChannel`** — pull-only. For each selected target, find-or-creates a local `Channel` keyed by the Slack conversation id, fetches messages newer than `target.cursor`, maps them to `@dxos/types` `Message` objects (`threadId = thread_ts`, sender resolved via cached `users.info`, single `Text` ContentBlock from `text`), and appends them to the channel's feed. Updates `target.cursor` to the latest `ts` so the next sync is incremental.

Service composition matches plugin-thread's `AppendChannelMessage`: operation declares `services: [Capability.Service]`; the handler resolves the integration's `Database` via `Obj.getDatabase` and the `Space` (and its `queues` for `Feed.FeedService`) via `ClientCapabilities.Client`. Both layers are provided at the boundary alongside `SlackCredentials`.

Slack API client is hand-rolled fetch + Effect Schema, no Slack SDK dependency. Slack reports application errors as `{ ok: false, error }` in HTTP 200 bodies, so those are promoted to a typed `SlackApiError` and excluded from the retry policy (which still retries 429s, 5xx, transport errors, and timeouts up to 3 attempts with exponential jittered backoff).

OAuth scopes requested: `channels:read/history`, `groups:read/history`, `im:read/history`, `mpim:read/history`, `users:read`. Read-only for v1.

### `plugin-thread`: foreign-keyed Channels render read-only

Any `Channel` carrying a foreign-key `Obj.Meta` entry (i.e. mirrored from an external source) renders without a composer. Two changes:
- `components/Chat/Chat.tsx` — new `readOnly` prop suppresses `MessageTextbox` + activity indicator in both layouts.
- `containers/ChannelChat/ChannelChat.tsx` — derives `readOnly = Obj.getMeta(channel).keys.length > 0` and short-circuits `handleSend` so the guard holds even if a caller bypasses the visual hide.

### Wiring

- `plugin-slack` added to composer-app (package.json, tsconfig, plugin-defs.tsx import + `SlackPlugin()` instantiation).
- `tsconfig.all.json` and `release-please-config.json` references.
- Slack stub block in `plugin-integration/builtin-providers.ts` removed (the dedicated plugin replaces it; comment trimmed since GitHub's stub was already removed by #11234).

## Test plan

- [x] `moon run plugin-slack:build plugin-thread:build composer-app:build` passes.
- [x] `pnpm run format-check` passes.
- [x] `pnpm run check-cycles` passes.
- [x] `moon run plugin-slack:lint plugin-thread:lint -- --fix` clean.
- [ ] End-to-end test against a real Slack workspace (manual; requires OAuth credentials in EDGE — out of scope).
- [ ] Visual check that a foreign-keyed Channel renders without a composer.

## Out of scope (intentional follow-ups)

- Threaded-reply fetching via `conversations.replies` — current code preserves the parent message's `thread_ts === ts` so reply-grouping still works on read; only the replies themselves are missing.
- Slack rich-text → `ContentBlock` translation (currently passes plain `text` only).
- Bidirectional sync (`chat:write`) — would require a snapshot-driven three-way merge per message; deprioritized.
- An app-graph "Sync this channel" action akin to Trello's; the integration UI's generic sync button works in the meantime.

https://claude.ai/code/session_01G1EbpSP11518GfpjTESims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Slack integration: discover and synchronize channels from Slack workspaces, syncing messages and conversation history across platforms.
  * Externally-synced channels now display in read-only mode to preserve synchronization integrity.
  * Enhanced sender attribution for messages from external sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->