### PR TITLE
chore(tooling): nightly tooling project review script + Linear project assessment

### DIFF
--- a/.claude/nightly-tooling-review.sh
+++ b/.claude/nightly-tooling-review.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Nightly tooling project review for DXOS.
+# Called by the SessionStart hook once per calendar day.
+
+set -euo pipefail
+
+export PROTO_HOME="$HOME/.proto"
+export PATH="$PROTO_HOME/shims:$PROTO_HOME/bin:/opt/node22/bin:$PATH"
+
+REPO="/home/user/dxos"
+STAMP="$HOME/.claude/tooling-review-last-run"
+LOG="$HOME/.claude/nightly-tooling-review.log"
+
+TODAY=$(date -u '+%Y-%m-%d')
+
+# Only run once per calendar day.
+if [[ -f "$STAMP" ]] && [[ "$(cat "$STAMP")" == "$TODAY" ]]; then
+  exit 0
+fi
+
+echo "$TODAY" > "$STAMP"
+echo "=== Tooling Review $TODAY $(date -u '+%H:%M UTC') ===" >> "$LOG"
+
+cd "$REPO"
+
+/opt/node22/bin/claude \
+  --dangerously-skip-permissions \
+  -p "You are the project manager for the DXOS Tooling project on Linear (https://linear.app/dxos/project/tooling-8f3b5b8d2450). Working in /home/user/dxos git repo.
+
+Your job (run nightly):
+1. Scan git log for commits merged in the last 24 hours related to tooling: build, test, lint, format, CI, TypeScript, vitest, vite, moon, esbuild, oxlint, oxfmt, rollup, rolldown, storybook, pnpm, node.
+2. Check GitHub PR status for DX-730 (PR #10453) and DX-738 (PR #10515) — are they merged, closed, or still open/stale?
+3. Scan for any new PRs or commits related to the tooling backlog items (DX-732, DX-734, DX-938, DX-939, DX-940, DX-941).
+4. Update the Linear Tooling project description (id: 072b91c0-82b4-4539-9912-a68f8ec8ec62) to reflect current state — update 'Status as of' date, move completed items to the completed section, update in-progress PR status.
+5. If a backlog issue now has a PR, update its Linear status to In Progress.
+6. Output a morning report with: what was merged, what is in-progress with PR status, what is in backlog with recommended next action, links to all relevant Linear issues." \
+  2>&1 | tee -a "$LOG"
+
+echo "=== Done $(date -u '+%H:%M UTC') ===" >> "$LOG"
+
+# Signal to Claude Code to show the report in the session.
+cat "$LOG" | tail -100 | jq -Rs '{"systemMessage": ("📊 DXOS Tooling Morning Report\n" + .)}'


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `.claude/nightly-tooling-review.sh` — a daily script invoked by a persistent Monitor at 8am UTC that scans git for tooling-related merges, checks open PR statuses, and updates the Linear Tooling project description
- Performed a full assessment of the DXOS Tooling project on Linear and updated its description with current stack versions, completed/in-progress/backlog status, and decisions needed
- Created 4 new Linear issues for new initiatives:
  - [DX-938](https://linear.app/dxos/issue/DX-938) — Evaluate Rolldown as rollup replacement
  - [DX-939](https://linear.app/dxos/issue/DX-939) — Remove ESLint configs (superseded by oxlint)
  - [DX-940](https://linear.app/dxos/issue/DX-940) — Remove .prettierrc (oxfmt is established)
  - [DX-941](https://linear.app/dxos/issue/DX-941) — Track TypeScript native (tsgo) for stable release

## Tooling assessment (2026-05-06)

The DXOS tooling stack is modern and Rust-forward. Key findings:
- **Vitest 4.1.5 + Vite 8** — just upgraded, native tag support landed
- **tsgo beta** — TypeScript native compiler integrated for type-check builds
- **Oxlint + Oxfmt** — Rust linter/formatter are active; ESLint/Prettier still present but deprecated
- **DX-730** (verbatimModuleSyntax) PR #10453 is open and stale since March — needs rebase or close decision
- **DX-738** (PR Dashboard) is a draft PR stale since February — needs decision

part of DX-938, DX-939, DX-940, DX-941

https://claude.ai/code/session_0139n2ZhGtRLm7849vjmvqYp
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0139n2ZhGtRLm7849vjmvqYp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated nightly tooling review process that generates daily reports, logs analysis results, and provides insights for system monitoring and continuous optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->