### PR TITLE
fix: identity-recovery race and view-holder navigation paths

### DIFF
--- a/packages/apps/composer-app/src/plugins/welcome/components/WelcomeScreen.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/components/WelcomeScreen.tsx
@@ -96,16 +96,40 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
   );
 
   const handlePasskey = useCallback(async () => {
-    await invokePromise(ClientOperation.RedeemPasskey);
-  }, [invokePromise]);
+    if (pendingRef.current || identity) {
+      return;
+    }
+    try {
+      pendingRef.current = true;
+      await invokePromise(ClientOperation.RedeemPasskey);
+    } finally {
+      pendingRef.current = false;
+    }
+  }, [invokePromise, identity]);
 
   const handleJoinIdentity = useCallback(async () => {
-    await invokePromise(ClientOperation.JoinIdentity, {});
-  }, [invokePromise]);
+    if (pendingRef.current || identity) {
+      return;
+    }
+    try {
+      pendingRef.current = true;
+      await invokePromise(ClientOperation.JoinIdentity, {});
+    } finally {
+      pendingRef.current = false;
+    }
+  }, [invokePromise, identity]);
 
   const handleRecoverIdentity = useCallback(async () => {
-    await invokePromise(ClientOperation.RecoverIdentity);
-  }, [invokePromise]);
+    if (pendingRef.current || identity) {
+      return;
+    }
+    try {
+      pendingRef.current = true;
+      await invokePromise(ClientOperation.RecoverIdentity);
+    } finally {
+      pendingRef.current = false;
+    }
+  }, [invokePromise, identity]);
 
   const handleSpaceInvitation = async () => {
     let identityCreated = true;

--- a/packages/apps/composer-app/src/plugins/welcome/components/WelcomeScreen.tsx
+++ b/packages/apps/composer-app/src/plugins/welcome/components/WelcomeScreen.tsx
@@ -99,37 +99,55 @@ export const WelcomeScreen = ({ hubUrl }: { hubUrl: string }) => {
     if (pendingRef.current || identity) {
       return;
     }
+    if (error) {
+      setError(false);
+    }
     try {
       pendingRef.current = true;
       await invokePromise(ClientOperation.RedeemPasskey);
+    } catch (err) {
+      log.catch(err);
+      setError(true);
     } finally {
       pendingRef.current = false;
     }
-  }, [invokePromise, identity]);
+  }, [invokePromise, identity, error]);
 
   const handleJoinIdentity = useCallback(async () => {
     if (pendingRef.current || identity) {
       return;
     }
+    if (error) {
+      setError(false);
+    }
     try {
       pendingRef.current = true;
       await invokePromise(ClientOperation.JoinIdentity, {});
+    } catch (err) {
+      log.catch(err);
+      setError(true);
     } finally {
       pendingRef.current = false;
     }
-  }, [invokePromise, identity]);
+  }, [invokePromise, identity, error]);
 
   const handleRecoverIdentity = useCallback(async () => {
     if (pendingRef.current || identity) {
       return;
     }
+    if (error) {
+      setError(false);
+    }
     try {
       pendingRef.current = true;
       await invokePromise(ClientOperation.RecoverIdentity);
+    } catch (err) {
+      log.catch(err);
+      setError(true);
     } finally {
       pendingRef.current = false;
     }
-  }, [invokePromise, identity]);
+  }, [invokePromise, identity, error]);
 
   const handleSpaceInvitation = async () => {
     let identityCreated = true;

--- a/packages/plugins/plugin-space/src/capabilities/navigation-resolver.ts
+++ b/packages/plugins/plugin-space/src/capabilities/navigation-resolver.ts
@@ -9,11 +9,12 @@ import { Capability } from '@dxos/app-framework';
 import {
   AppCapabilities,
   getObjectPath,
+  getObjectPathFromObject,
   getSpaceIdFromPath,
   getSpacePath,
   type AppCapabilities as AppCaps,
 } from '@dxos/app-toolkit';
-import { Database, Entity, Key } from '@dxos/echo';
+import { Database, Entity, Key, Obj } from '@dxos/echo';
 import { DXN } from '@dxos/keys';
 import { ClientCapabilities } from '@dxos/plugin-client/types';
 import { SETTINGS_ID, SETTINGS_KEY } from '@dxos/plugin-settings/types';
@@ -54,7 +55,7 @@ export default Capability.makeModule(
 
         return [
           {
-            path: getObjectPath(db.spaceId, typename, object.id),
+            path: Obj.isObject(object) ? getObjectPathFromObject(object) : getObjectPath(db.spaceId, typename, object.id),
             label: Entity.getLabel(object) ?? '',
             type: typename,
           },

--- a/packages/plugins/plugin-space/src/capabilities/navigation-resolver.ts
+++ b/packages/plugins/plugin-space/src/capabilities/navigation-resolver.ts
@@ -55,7 +55,9 @@ export default Capability.makeModule(
 
         return [
           {
-            path: Obj.isObject(object) ? getObjectPathFromObject(object) : getObjectPath(db.spaceId, typename, object.id),
+            path: Obj.isObject(object)
+              ? getObjectPathFromObject(object)
+              : getObjectPath(db.spaceId, typename, object.id),
             label: Entity.getLabel(object) ?? '',
             type: typename,
           },

--- a/packages/sdk/app-toolkit/src/paths.ts
+++ b/packages/sdk/app-toolkit/src/paths.ts
@@ -2,9 +2,12 @@
 // Copyright 2025 DXOS.org
 //
 
+import * as Option from 'effect/Option';
+
 import { Node } from '@dxos/app-graph';
 import { Key, Obj } from '@dxos/echo';
 import { invariant } from '@dxos/invariant';
+import { ViewAnnotation, getTypenameFromQuery } from '@dxos/schema';
 
 /**
  * Prefix for pinned (non-space) workspace IDs in the graph.
@@ -65,11 +68,28 @@ export const getObjectPath = (spaceId: string, typename: string, objectId: strin
 /**
  * Derive the canonical graph path for a reactive ECHO object.
  * Throws if the object has no database or typename.
+ *
+ * View-holder objects (schemas annotated with `ViewAnnotation`) are placed in the
+ * graph as siblings of the `all` virtual node — under their target type, not inside
+ * its `all` collection. When the held view is hydrated and its query targets a
+ * concrete typename, returns `getTypePath(spaceId, viewTargetTypename, objectId)`.
+ * Otherwise falls back to `getObjectPath`.
  */
 export const getObjectPathFromObject = (object: Obj.Unknown): string => {
   const db = Obj.getDatabase(object);
   const typename = Obj.getTypename(object);
   invariant(db && typename, 'Cannot derive graph path: object has no database or typename.');
+
+  const schema = Obj.getSchema(object);
+  if (schema && ViewAnnotation.has(schema)) {
+    const path = ViewAnnotation.get(schema).pipe(Option.getOrElse(() => [] as readonly string[]));
+    const view = path.length > 0 ? ViewAnnotation.tryGetTargetAlongPath(object, path) : undefined;
+    const viewTargetTypename = view ? getTypenameFromQuery(view.query.ast) : undefined;
+    if (viewTargetTypename) {
+      return getTypePath(db.spaceId, viewTargetTypename, object.id);
+    }
+  }
+
   return getObjectPath(db.spaceId, typename, object.id);
 };
 


### PR DESCRIPTION
## Summary

Two user-visible bugs surfaced from an `app.log` capture:

- **\`Identity already exists.\` on passkey redeem.** [WelcomeScreen.tsx](packages/apps/composer-app/src/plugins/welcome/components/WelcomeScreen.tsx) gated the passkey / join / recover buttons on \`useIdentity()\`, but that hook starts \`undefined\` while the local identity is still loading. A click in that window kicks off recovery; by the time it reaches \`_acceptIdentity\` → \`prepareIdentity\`, \`_identity\` is already set and the invariant at [identity-manager.ts:246](packages/sdk/client-services/src/packlets/identity/identity-manager.ts:246) trips. Added a \`pendingRef\` debounce + \`!identity\` guard to all three handlers, mirroring the existing \`handleSignup\` pattern.

- **Nothing visible in 1-up views (\`PlankError\` TimeoutError).** View-holder objects (Masonry / Table / Kanban) are placed in the graph as **siblings of the \`all\` virtual node** at \`root/<spaceId>/types/<typename>/<viewId>\` (see [types.ts:171](packages/plugins/plugin-space/src/capabilities/app-graph-builder/extensions/types.ts:171)). But [getObjectPathFromObject](packages/sdk/app-toolkit/src/paths.ts) and the space \`NavigationTargetResolver\` in [navigation-resolver.ts](packages/plugins/plugin-space/src/capabilities/navigation-resolver.ts) always called \`getObjectPath()\`, producing \`…/all/<viewId>\`. The path resolver then validates that bogus path (the DXN exists), but \`useNode(graph, …)\` finds nothing → 5s timeout → PlankError. Made \`getObjectPathFromObject\` view-aware (matches the existing logic in [add-object.ts:44](packages/plugins/plugin-space/src/operations/add-object.ts:44)) and routed the target resolver through it.

## Test plan

- [x] \`moon run app-toolkit:build plugin-space:build composer-app:build\` passes.
- [x] \`moon run app-toolkit:lint plugin-space:lint composer-app:lint\` passes.
- [ ] Manually verify passkey login no longer fires \`Identity already exists\` when the local identity is already present.
- [ ] Manually verify opening a Masonry/Table view by DXN renders the view (no 5s \`PlankError\` timeout).

## Notes for reviewers

- Existing wrong-URL bookmarks (saved with \`/all/<viewId>\`) won't auto-redirect to the canonical path. Adding a redirect inside \`validateNavigationTarget\` is a reasonable follow-up but felt out of scope here.
- Neither fix is exercisable in a clean preview without setup (passkey hardware + edge connection for #1; populated CRM space with custom views for #2), so no preview verification was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent execution of identity flows to avoid duplicate operations when flows are triggered simultaneously or when an identity already exists.

* **Improvements**
  * Improved navigation target resolution to choose more accurate object paths based on the loaded object's shape.
  * Refined object path derivation to respect view-holder schema annotations for more precise graph navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->