### PR TITLE
fix(async): make AsyncTask.schedule a no-op when closed

### DIFF
--- a/packages/common/async/src/task-scheduling.ts
+++ b/packages/common/async/src/task-scheduling.ts
@@ -117,11 +117,14 @@ export class AsyncTask {
 
   /**
    * Schedule the task to run asynchronously.
+   *
+   * No-op once the task has been closed: callbacks routinely reschedule themselves and
+   * legitimately race with `close()` (e.g. an Effect that finishes after dispose has run).
    */
   // TODO(dmaretskyi): Add scheduleAt. Where the earlier time will override the later one.
   schedule(): void {
     if (!this.#ctx || this.#ctx.disposed) {
-      throw new Error('AsyncTask not open');
+      return;
     }
 
     if (this.#scheduled) {

--- a/packages/common/async/src/task-scheduling.ts
+++ b/packages/common/async/src/task-scheduling.ts
@@ -157,7 +157,7 @@ export class AsyncTask {
    * Schedule the task to run and wait for it to finish.
    */
   async runBlocking(): Promise<void> {
-    if (this.#ctx?.disposed) {
+    if (!this.#ctx || this.#ctx.disposed) {
       throw new ContextDisposedError();
     }
 


### PR DESCRIPTION
## Summary

`AsyncTask.schedule()` threw `Error: AsyncTask not open` when its ctx had been disposed. Several callers reschedule themselves from inside their own callback body (e.g. `FeedSyncer`'s `#pollTask` calls `this.#pollTask.schedule()` at [feed-syncer.ts:295](packages/sdk/client-services/src/packlets/services/feed-syncer.ts:295) / [:298](packages/sdk/client-services/src/packlets/services/feed-syncer.ts:298)), so a `close()` racing with a running callback would surface as an unhandled error in production logs.

Closing should be idempotent against in-flight callbacks. Made `schedule()` a silent no-op when `#ctx` is missing or already disposed.

## Diagnosis context

Spotted while triaging Composer logs that included `Uncaught (in promise) Error: AsyncTask not open` originating from an Effect runtime stack. Other errors in the same logs (`NoHandlerError` for `org.dxos.function.project.qualifier` / `inbox.google-mail-sync`, `ServiceNotAvailableError: @dxos/functions/TracingService`, `UNIQUE constraint failed: blocks.feedPrivateId, blocks.position`) trace to a stale deployed bundle that predates recent renames/refactors and are not reproducible against current `main` — not addressed here.

## Test plan

- [ ] Build passes (`moon run async:build` — verified locally)
- [ ] No regression in resources that intentionally call `schedule()` after `close()` during shutdown
- [ ] Manual: exercise FeedSyncer close while pollTask is mid-callback; previously logged `AsyncTask not open`, now silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduling a closed task or a task whose context was disposed is now a no-op instead of throwing, preventing unnecessary exceptions.
  * Blocking-run checks now correctly detect disposed contexts and raise the appropriate error only when applicable.
  * Clarified async scheduling behavior to avoid races where callbacks reschedule after close; subsequent schedules are ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->