### PR TITLE
fix(sql-sqlite): demote OpfsWorker query errors to debug level

### DIFF
--- a/packages/common/sql-sqlite/src/OpfsWorker.ts
+++ b/packages/common/sql-sqlite/src/OpfsWorker.ts
@@ -110,7 +110,9 @@ export const run = (options: OpfsWorkerConfig): Effect.Effect<void, SqlError.Sql
             }
           }
         } catch (e: any) {
-          log.catch(e);
+          // Logged at debug level: SQL errors are returned to the caller via postMessage,
+          // and some are expected (e.g. ALTER TABLE ADD COLUMN against an already-migrated DB).
+          log('sqlite error', { error: e });
           const message = 'message' in e ? e.message : String(e);
           options.port.postMessage([messageId!, message, undefined]);
         }


### PR DESCRIPTION
## Summary

Demotes the per-query \`log.catch\` in \`OpfsWorker\` to a plain debug-level \`log()\` call. SQL errors are already returned to the caller through \`postMessage\` and surfaced upstream by code that cares about them — logging at error level here just produced noise from expected failures.

The motivating case: \`ObjectMetaIndex.migrate\` in [object-meta-index.ts:101-104](https://github.com/dxos/dxos/blob/main/packages/core/echo/index-core/src/indexes/object-meta-index.ts) defensively runs \`ALTER TABLE objectMeta ADD COLUMN parent/createdAt/updatedAt\` for old DBs and wraps each in \`Effect.catchAll(..., () => Effect.void)\`. On any DB created with the current schema, those three statements fail with \`duplicate column name: …\` — the Effect catches them, but \`OpfsWorker\` had already emitted three loud errors to the console first.

## Test plan

- [x] \`moon run sql-sqlite:lint\` passes
- [x] \`moon run sql-sqlite:build\` passes
- [ ] Confirm in Composer that the three \`duplicate column name: parent/createdAt/updatedAt\` errors no longer appear at error level on app start

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and reporting in SQLite operations to ensure errors are logged and communicated more reliably to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->