### PR TITLE
fix(ui-theme): force-emit grid color tokens consumed by lit-grid

### DIFF
--- a/packages/ui/lit-grid/src/dx-grid.pcss
+++ b/packages/ui/lit-grid/src/dx-grid.pcss
@@ -78,7 +78,6 @@
       cursor: pointer;
       position: relative;
 
-      /** TODO(burdon): It this performant? */
       border-right: 1px solid var(--color-grid-line);
       border-bottom: 1px solid var(--color-grid-line);
 

--- a/packages/ui/ui-theme/src/main.css
+++ b/packages/ui/ui-theme/src/main.css
@@ -92,6 +92,13 @@
 @source inline("border-{info,success,warning,error}-border");
 
 /**
+ * Force-emit tokens consumed by web components / .pcss files outside the
+ * Tailwind source-scan graph (e.g. lit-grid's dx-grid.pcss uses
+ * var(--color-grid-line)).
+ */
+@source inline("bg-grid-{surface,highlight,comment,comment-active,hover-overlay,selection-overlay,line,focus-indicator}");
+
+/**
  * Plugins must come after all imports.
  */
 @plugin '@tailwindcss/forms';


### PR DESCRIPTION
## Summary

- Tailwind v4 tree-shakes `@theme` tokens it doesn't see referenced in its source-scan graph. `lit-grid`'s `dx-grid.pcss` is compiled into the Lit web component separately and isn't part of that graph, so its `var(--color-grid-line)` usage went unseen — leaving the cell-border variable undefined at runtime in devtools.
- Add `@source inline("bg-grid-{surface,highlight,…,line,focus-indicator}")` to force-emit all `--color-grid-*` tokens to `:root`. Same trick already used for the color palette, brace-expanded over the eight grid tokens.
- Drop a stray `TODO(burdon): It this performant?` from `dx-grid.pcss`.

## Why now

Before [#10818](https://github.com/dxos/dxos/pull/10818) (6 weeks ago) the only `var(--color-grid-line)` consumer was a `background:` on a frozen plane that's rarely visible. That PR moved it to `border-right`/`border-bottom` on every gridcell, making the missing variable suddenly conspicuous. The tree-shaking itself dates back to the [Tailwind v4 migration (#10611)](https://github.com/dxos/dxos/pull/10611); v3 emitted all `@theme` tokens unconditionally.

## Test plan

- [x] In Storybook (`storybook-react`), `getComputedStyle(document.documentElement).getPropertyValue('--color-grid-X')` resolves for all eight grid tokens (`surface`, `highlight`, `comment`, `comment-active`, `hover-overlay`, `selection-overlay`, `line`, `focus-indicator`).
- [ ] Visual: dx-grid cell borders render in light + dark modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved grid styling and theme variable generation for enhanced consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->