### PR TITLE
feat(functions-runtime): cooldown failed triggers in TriggerDispatcher

### DIFF
--- a/packages/core/functions-runtime/src/triggers/trigger-dispatcher.test.ts
+++ b/packages/core/functions-runtime/src/triggers/trigger-dispatcher.test.ts
@@ -48,7 +48,9 @@ const TestLayer = Layer.mergeAll(
 
 /** Full environment for trigger tests; cast so `it.effect` accepts the provided service union. */
 const makeTestTriggerDispatcherLayer = (
-  options: { timeControl: 'natural' } | { timeControl: 'manual'; startingTime: Date },
+  options: ({ timeControl: 'natural' } | { timeControl: 'manual'; startingTime: Date }) & {
+    failureCooldown?: Duration.Duration;
+  },
 ) => Layer.provideMerge(TriggerDispatcher.layer(options), TestLayer);
 
 const TestTriggerDispatcherLayer = makeTestTriggerDispatcherLayer({
@@ -199,6 +201,54 @@ describe('TriggerDispatcher', () => {
         results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['timer'] });
         expect(results.length).toBe(1);
       }, Effect.provide(TestTriggerDispatcherLayer)),
+    );
+  });
+
+  describe('Failure Cooldown', () => {
+    it.effect(
+      'failed trigger is skipped during cooldown and resumes after',
+      Effect.fnUntraced(
+        function* ({ expect }) {
+          // Use a Person object as the function ref so trigger invocation fails the
+          // `Obj.instanceOf(Operation.PersistentOperation, ...)` invariant.
+          const badFn = Obj.make(Person.Person, { fullName: 'not-an-operation' });
+          yield* Database.add(badFn);
+
+          const trigger = Trigger.make({
+            function: Ref.make(badFn) as any,
+            enabled: true,
+            spec: Trigger.specTimer('* * * * *'),
+          });
+          yield* Database.add(trigger);
+
+          const dispatcher = yield* TriggerDispatcher;
+          yield* dispatcher.refreshTriggers();
+
+          // First scheduled run -- fails and arms the cooldown.
+          yield* dispatcher.advanceTime(Duration.minutes(1));
+          let results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['timer'] });
+          expect(results.length).toBe(1);
+          expect(Exit.isFailure(results[0].result)).toBe(true);
+
+          // Within cooldown window (cron would otherwise fire) -- skipped.
+          yield* dispatcher.advanceTime(Duration.minutes(2));
+          results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['timer'] });
+          expect(results.length).toBe(0);
+
+          // Past cooldown -- runs again (and fails again).
+          yield* dispatcher.advanceTime(Duration.minutes(4));
+          results = yield* dispatcher.invokeScheduledTriggers({ kinds: ['timer'] });
+          expect(results.length).toBe(1);
+          expect(Exit.isFailure(results[0].result)).toBe(true);
+        },
+        Effect.provide(
+          makeTestTriggerDispatcherLayer({
+            timeControl: 'manual',
+            startingTime: new Date('2025-09-05T15:01:00.000Z'),
+            failureCooldown: Duration.minutes(5),
+          }),
+        ),
+      ),
     );
   });
 

--- a/packages/core/functions-runtime/src/triggers/trigger-dispatcher.ts
+++ b/packages/core/functions-runtime/src/triggers/trigger-dispatcher.ts
@@ -65,6 +65,14 @@ export interface TriggerDispatcherOptions {
    * @default 5
    */
   maxConcurrency?: number;
+
+  /**
+   * Cooldown applied to a trigger after it fails.
+   * While in cooldown, scheduled invocations of that trigger are skipped.
+   * Manual {@link TriggerDispatcher.invokeTrigger} calls bypass the cooldown.
+   * @default 30 seconds
+   */
+  failureCooldown?: Duration.Duration;
 }
 
 export interface InvokeTriggerOptions {
@@ -179,6 +187,7 @@ export class TriggerDispatcher extends Context.Tag('@dxos/functions/TriggerDispa
 }
 
 const DEFAULT_MAX_CONCURRENCY = 5;
+const DEFAULT_FAILURE_COOLDOWN = Duration.seconds(30);
 
 class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
   readonly livePollInterval: Duration.Duration;
@@ -196,6 +205,8 @@ class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
     errors: [],
   });
   private _maxConcurrency: number;
+  private _failureCooldown: Duration.Duration;
+  private _cooldownUntil = new Map<string, Date>();
 
   constructor(options: TriggerDispatcherOptions) {
     this._services = options.services;
@@ -203,7 +214,20 @@ class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
     this.livePollInterval = options.livePollInterval ?? Duration.seconds(1);
     this._internalTime = options.startingTime ?? new Date();
     this._maxConcurrency = options.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY;
+    this._failureCooldown = options.failureCooldown ?? DEFAULT_FAILURE_COOLDOWN;
   }
+
+  private _isInCooldown = (triggerId: string): boolean => {
+    const until = this._cooldownUntil.get(triggerId);
+    if (!until) {
+      return false;
+    }
+    if (until.getTime() <= this.getCurrentTime().getTime()) {
+      this._cooldownUntil.delete(triggerId);
+      return false;
+    }
+    return true;
+  };
 
   get running(): boolean {
     return this._running;
@@ -354,8 +378,14 @@ class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
         log('trigger execution success', {
           triggerId: trigger.id,
         });
+        this._cooldownUntil.delete(trigger.id);
       } else {
+        const cooldownMs = Duration.toMillis(this._failureCooldown);
+        const until = new Date(this.getCurrentTime().getTime() + cooldownMs);
+        this._cooldownUntil.set(trigger.id, until);
         log.error('trigger execution failure', {
+          triggerId: trigger.id,
+          cooldownUntil: until,
           error: causeToError(result.cause),
         });
       }
@@ -387,10 +417,14 @@ class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
 
               for (const [triggerId, scheduledTrigger] of this._scheduledTriggers.entries()) {
                 if (scheduledTrigger.nextExecution <= now) {
-                  triggersToInvoke.push(scheduledTrigger.trigger);
-
                   // Update next execution time using Effect's Cron
                   scheduledTrigger.nextExecution = Cron.next(scheduledTrigger.cron, now);
+
+                  if (this._isInCooldown(triggerId)) {
+                    log('skipping trigger in cooldown', { triggerId });
+                    continue;
+                  }
+                  triggersToInvoke.push(scheduledTrigger.trigger);
                 }
               }
 
@@ -412,6 +446,10 @@ class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
             for (const trigger of this._triggers) {
               const spec = trigger.spec;
               if (spec?.kind !== 'queue') {
+                continue;
+              }
+              if (this._isInCooldown(trigger.id)) {
+                log('skipping trigger in cooldown', { triggerId: trigger.id });
                 continue;
               }
               const cursor = Obj.getKeys(trigger, KEY_QUEUE_CURSOR).at(0)?.id;
@@ -472,6 +510,10 @@ class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
             for (const trigger of this._triggers) {
               const spec = trigger.spec;
               if (spec?.kind !== 'subscription') {
+                continue;
+              }
+              if (this._isInCooldown(trigger.id)) {
+                log('skipping trigger in cooldown', { triggerId: trigger.id });
                 continue;
               }
 

--- a/packages/core/functions-runtime/src/triggers/trigger-dispatcher.ts
+++ b/packages/core/functions-runtime/src/triggers/trigger-dispatcher.ts
@@ -301,6 +301,7 @@ class TriggerDispatcherImpl implements Context.Tag.Service<TriggerDispatcher> {
 
       // Clear scheduled triggers
       this._scheduledTriggers.clear();
+      this._cooldownUntil.clear();
 
       log.info('TriggerDispatcher stopped');
     }).pipe(Effect.provide(this._services));


### PR DESCRIPTION
## Summary

When a trigger invocation fails, `TriggerDispatcher` now suppresses scheduled re-invocation of that trigger for a configurable cooldown window (default **30 seconds**). This prevents the dispatcher from hammering a broken trigger every poll interval / on every queue or subscription update.

- New `failureCooldown?: Duration.Duration` option on `TriggerDispatcherOptions` (default `Duration.seconds(30)`).
- Cooldown is tracked per `trigger.id` and applied uniformly to `timer`, `queue`, and `subscription` kinds inside `invokeScheduledTriggers`.
- For `timer` triggers, `nextExecution` still advances on cron ticks while the trigger is in cooldown so the trigger doesn't accumulate a backlog.
- A successful invocation clears any prior cooldown.
- Manual `invokeTrigger` calls bypass the cooldown check, but a failed manual call still arms the cooldown for subsequent scheduled runs.

## Test plan

- [x] `moon run functions-runtime:test -- src/triggers/trigger-dispatcher.test.ts` (76 passed, 9 skipped)
- [x] New test: `Failure Cooldown > failed trigger is skipped during cooldown and resumes after` — verifies a failing trigger is invoked, skipped within the cooldown window even when its cron tick is due, and re-invoked after the cooldown elapses.
- [x] `moon run functions-runtime:lint -- --fix`
- [x] `pnpm format`


---
_Generated by [Claude Code](https://claude.ai/code/session_0188KQQzFvFy4b7syAAPgQxH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable failureCooldown option (default 30s) to trigger dispatchers so failed triggers enter a cooldown window.

* **Behavior Changes**
  * Triggers skip scheduled executions while in cooldown; cooldown is cleared on successful execution.
  * Stopping the dispatcher now resets scheduled triggers and clears cooldown state.

* **Tests**
  * Added coverage for failure cooldown behavior and timer/skip logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->