### PR TITLE
feat(functions-runtime): make agent tool backgrounding configurable

### DIFF
--- a/packages/core/functions-runtime/src/agent-service/AgentService.test.ts
+++ b/packages/core/functions-runtime/src/agent-service/AgentService.test.ts
@@ -120,6 +120,7 @@ const TestLayer = AssistantTestLayer({
   operationHandlers: [handlers],
   blueprints: [ResearchBlueprint],
   systemPrompt: SYSTEM_PROMPT,
+  enableToolBackgrounding: true,
 });
 
 describe('Agent Executable', () => {

--- a/packages/core/functions-runtime/src/agent-service/AgentService.ts
+++ b/packages/core/functions-runtime/src/agent-service/AgentService.ts
@@ -114,6 +114,14 @@ export const layer = (opts?: {
    * Provider for space-level MCP server configs.
    */
   getMcpServers?: () => McpServerConfig[];
+
+  /**
+   * If true, long-running tool calls are moved to the background and the agent is notified
+   * asynchronously when they complete. Currently unstable — disabled by default.
+   *
+   * @default false
+   */
+  enableToolBackgrounding?: boolean;
 }): Layer.Layer<AgentService, never, ProcessManager.Service> =>
   Layer.effect(
     AgentService,
@@ -134,6 +142,7 @@ export const layer = (opts?: {
               systemPrompt: opts?.systemPrompt,
               model: options?.model ?? opts?.model,
               getMcpServers: opts?.getMcpServers,
+              enableToolBackgrounding: opts?.enableToolBackgrounding,
             });
             const processes = yield* processManager.list({ target, key: executable.key });
 

--- a/packages/core/functions-runtime/src/agent-service/agent-process.ts
+++ b/packages/core/functions-runtime/src/agent-service/agent-process.ts
@@ -312,7 +312,7 @@ const ToolExecutionService = ({
                 conversationId: feed.id,
               },
             });
-            toolCallManager.beginCall(fiber.pid);
+            yield* toolCallManager.beginCall(fiber.pid);
             log('invoked operation', { operationDef, input, fiber });
 
             const awaitWithReport = fiber.await.pipe(Effect.tap(() => toolCallManager.markAsReported(fiber.pid)));

--- a/packages/core/functions-runtime/src/agent-service/agent-process.ts
+++ b/packages/core/functions-runtime/src/agent-service/agent-process.ts
@@ -41,6 +41,16 @@ interface AgentProcessOptions {
    * Provider for space-level MCP server configs, called on each turn.
    */
   getMcpServers?: () => McpServerConfig[];
+
+  /**
+   * If true, long-running tool calls are moved to the background after `backgroundThreshold`
+   * and the agent is notified asynchronously when they complete.
+   *
+   * Currently unstable — disabled by default.
+   *
+   * @default false
+   */
+  enableToolBackgrounding?: boolean;
 }
 
 export const AGENT_PROCESS_KEY = 'org.dxos.testing.process.agent';
@@ -142,6 +152,7 @@ export const AgentProcess = (options: AgentProcessOptions) =>
                 ToolExecutionService({
                   toolCallManager,
                   feed,
+                  enableBackgrounding: options.enableToolBackgrounding ?? false,
                 }),
                 AsynchronousExectionToolkitLayer,
                 AiService.model(options.model ?? '@anthropic/claude-opus-4-6'),
@@ -189,7 +200,14 @@ export const AgentProcess = (options: AgentProcessOptions) =>
 
 interface ToolExecutionServiceOptions {
   /**
+   * If true, tool calls that exceed `backgroundThreshold` are detached and the agent is told
+   * the call is running in the background. If false, the executor always blocks on the call.
+   */
+  enableBackgrounding: boolean;
+
+  /**
    * Threshold after which the tool execution is placed in the background.
+   * Ignored when `enableBackgrounding` is false.
    */
   // TODO(dmaretskyi): Tool annotation to never run in background.
   backgroundThreshold?: Duration.Duration;
@@ -273,6 +291,7 @@ class ToolCallManager {
 }
 
 const ToolExecutionService = ({
+  enableBackgrounding,
   backgroundThreshold = Duration.seconds(1),
   toolCallManager,
   feed,
@@ -296,11 +315,15 @@ const ToolExecutionService = ({
             toolCallManager.beginCall(fiber.pid);
             log('invoked operation', { operationDef, input, fiber });
 
-            const result = yield* fiber.await.pipe(
-              Effect.tap(() => toolCallManager.markAsReported(fiber.pid)),
-              Effect.timeout(backgroundThreshold),
-              Effect.catchTag('TimeoutException', () => Effect.succeed(toolIsRunningInBackgroundResponse(fiber.pid))),
-            );
+            const awaitWithReport = fiber.await.pipe(Effect.tap(() => toolCallManager.markAsReported(fiber.pid)));
+            const result = enableBackgrounding
+              ? yield* awaitWithReport.pipe(
+                  Effect.timeout(backgroundThreshold),
+                  Effect.catchTag('TimeoutException', () =>
+                    Effect.succeed(toolIsRunningInBackgroundResponse(fiber.pid)),
+                  ),
+                )
+              : yield* awaitWithReport;
             log('result', { result });
             return result;
           }),

--- a/packages/core/functions-runtime/src/testing/assistant-test-layer.ts
+++ b/packages/core/functions-runtime/src/testing/assistant-test-layer.ts
@@ -60,6 +60,14 @@ interface TestLayerOptions {
    * Core system prompt for the agent.
    */
   systemPrompt?: string;
+
+  /**
+   * If true, long-running tool calls are moved to the background and the agent is notified
+   * asynchronously when they complete. Currently unstable — disabled by default.
+   *
+   * @default false
+   */
+  enableToolBackgrounding?: boolean;
 }
 
 export type AssistantTestServices =
@@ -95,6 +103,7 @@ export const AssistantTestLayer = ({
   disableLlmMemoization = false,
   blueprints = [],
   systemPrompt,
+  enableToolBackgrounding = false,
 }: TestLayerOptions = {}): Layer.Layer<AssistantTestServices, never, TestContextService> => {
   const resolvedModel: ModelName =
     model ?? (aiServicePreset === 'ollama' ? 'gpt-oss:20b' : '@anthropic/claude-opus-4-6');
@@ -108,7 +117,7 @@ export const AssistantTestLayer = ({
   return Layer.empty.pipe(
     Layer.provideMerge(ProcessManager.ProcessOperationInvoker.layer),
     Layer.provideMerge(Trace.testTraceService({ meta: { processName: 'test' } })),
-    Layer.provideMerge(AgentService.layer({ systemPrompt, model: resolvedModel })),
+    Layer.provideMerge(AgentService.layer({ systemPrompt, model: resolvedModel, enableToolBackgrounding })),
     Layer.provideMerge(ProcessManager.layer({ idGenerator: ProcessManager.SequentialIdGenerator })),
     Layer.provideMerge(
       Layer.effect(


### PR DESCRIPTION
## Summary

The agent tool backgrounding path (when a tool exceeds `backgroundThreshold`, the executor returns a `Tool is running in the background` placeholder and notifies the agent asynchronously when the fiber completes) is currently unstable. This PR makes it opt-in so it stops affecting tests and runtime users that don't need it.

## Changes

- `AgentProcess` (`agent-process.ts`): adds `enableToolBackgrounding?: boolean` (default `false`) to `AgentProcessOptions`. When `false`, `ToolExecutionService` awaits the tool fiber directly without `Effect.timeout` / `TimeoutException` handling.
- `AgentService.layer`: forwards a new `enableToolBackgrounding` option to `AgentProcess`.
- `AssistantTestLayer`: adds a matching option (default `false`) and forwards it.
- `AgentService.test.ts`: the only existing test that actually exercises background tool execution now opts in via `enableToolBackgrounding: true`. All other call sites (`assistant-test-layer` defaults, `plugin-automation` `compute-runtime`) keep backgrounding disabled.

## Test plan

- [x] `moon run functions-runtime:build`
- [x] `moon run plugin-automation:build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional background execution for long-running tool calls, returning asynchronous notifications instead of blocking. (Disabled by default; unstable feature)

* **Tests**
  * Test layer/configuration updated to support and enable background tool execution in test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->