### PR TITLE
fix(devtools-extension): stub tiktoken/lite to fix bundle build

### DIFF
--- a/packages/devtools/devtools-extension/stub.mjs
+++ b/packages/devtools/devtools-extension/stub.mjs
@@ -1,0 +1,6 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export {};
+export default {};

--- a/packages/devtools/devtools-extension/vite.config.ts
+++ b/packages/devtools/devtools-extension/vite.config.ts
@@ -34,6 +34,13 @@ export default defineConfig({
       },
     },
   },
+  resolve: {
+    alias: {
+      // `@anthropic-ai/tokenizer` transitively pulls in `tiktoken/lite`, whose wasm uses top-level await
+      // that rolldown can't put behind a CJS require. The tokenizer isn't needed in the extension bundle.
+      ['tiktoken/lite']: resolve(__dirname, 'stub.mjs'),
+    },
+  },
   worker: {
     format: 'es',
     plugins: () => [WasmPlugin(), SourceMapsPlugin()],


### PR DESCRIPTION
## Summary

The `devtools-extension:bundle` task was failing with:

```
[REQUIRE_TLA] Error: This require call is not allowed because the transitive dependency
"tiktoken/lite/tiktoken_bg.wasm" contains a top-level await
```

`@anthropic-ai/tokenizer` is pulled in transitively (via `@dxos/devtools` → assistant packages) and its `tiktoken/lite` wasm uses top-level await, which rolldown can't put behind a CJS `require()`.

The tokenizer isn't needed in the extension bundle, so we alias `tiktoken/lite` to a no-op stub. This matches the pattern already used by `composer-app` and `testbench-app`.

## Changes

- Added `packages/devtools/devtools-extension/stub.mjs` (empty module stub).
- Added `resolve.alias` for `tiktoken/lite` → `stub.mjs` in `vite.config.ts`.

## Test plan

- [x] `moon run devtools-extension:bundle` succeeds locally.
- [ ] CI Check workflow passes.

https://claude.ai/code/session_01Sc93Xv9SLZbRfAxui3EDuM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sc93Xv9SLZbRfAxui3EDuM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved bundling compatibility issue in the developer tools extension to improve startup performance.

* **Chores**
  * Updated build configuration for the developer tools extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->