### PR TITLE
fix(plugin-client): dedupe contributed schemas by DXN before addTypes

### DIFF
--- a/packages/plugins/plugin-client/src/capabilities/schema-defs.ts
+++ b/packages/plugins/plugin-client/src/capabilities/schema-defs.ts
@@ -18,13 +18,13 @@ export default Capability.makeModule(
     const schemasAtom = yield* Capability.atom(AppCapabilities.Schema);
 
     // TODO(wittjosiah): Unregister schemas when they are disabled.
-    let previous: Type.AnyEntity[] = [];
+    let previousDxns = new Set<string>();
     const cancel = registry.subscribe(
       schemasAtom,
-      async (_schemas) => {
+      async (schemas) => {
         const seenSchemaDxns = new Set<string>();
-        const schemas: Type.AnyEntity[] = [];
-        for (const schema of _schemas.flat()) {
+        const batch: { schema: Type.AnyEntity; dxnKey: string }[] = [];
+        for (const schema of schemas.flat()) {
           const dxn = Type.getDXN(schema);
           if (!dxn) {
             log.warn('skipping schema without dxn');
@@ -38,13 +38,15 @@ export default Capability.makeModule(
           }
 
           seenSchemaDxns.add(key);
-          schemas.push(schema);
+          batch.push({ schema, dxnKey: key });
         }
 
-        // TODO(wittjosiah): Filter out schemas which the client has already registered.
-        const newSchemas = schemas.filter((schema) => !previous.includes(schema));
-        previous = schemas;
-        await client.addTypes(newSchemas);
+        const toRegister = batch.filter(({ dxnKey }) => !previousDxns.has(dxnKey));
+
+        await client.addTypes(toRegister.map(({ schema }) => schema));
+        for (const { dxnKey } of toRegister) {
+          previousDxns.add(dxnKey);
+        }
       },
       { immediate: true },
     );

--- a/packages/plugins/plugin-client/src/capabilities/schema-defs.ts
+++ b/packages/plugins/plugin-client/src/capabilities/schema-defs.ts
@@ -6,7 +6,8 @@ import * as Effect from 'effect/Effect';
 
 import { Capabilities, Capability } from '@dxos/app-framework';
 import { AppCapabilities } from '@dxos/app-toolkit';
-import { type Type } from '@dxos/echo';
+import { Type } from '@dxos/echo';
+import { log } from '@dxos/log';
 
 import { ClientCapabilities } from '#types';
 
@@ -20,9 +21,26 @@ export default Capability.makeModule(
     let previous: Type.AnyEntity[] = [];
     const cancel = registry.subscribe(
       schemasAtom,
-      async (_schemas: any[]) => {
-        // TODO(wittjosiah): This doesn't seem to de-dupe schemas as expected.
-        const schemas = Array.from(new Set(_schemas.flat())) as Type.AnyEntity[];
+      async (_schemas) => {
+        const seenSchemaDxns = new Set<string>();
+        const schemas: Type.AnyEntity[] = [];
+        for (const schema of _schemas.flat()) {
+          const dxn = Type.getDXN(schema);
+          if (!dxn) {
+            log.warn('skipping schema without dxn');
+            continue;
+          }
+
+          const key = dxn.toString();
+          if (seenSchemaDxns.has(key)) {
+            log.warn('skipping duplicate schema for echo registration', { dxn: key });
+            continue;
+          }
+
+          seenSchemaDxns.add(key);
+          schemas.push(schema);
+        }
+
         // TODO(wittjosiah): Filter out schemas which the client has already registered.
         const newSchemas = schemas.filter((schema) => !previous.includes(schema));
         previous = schemas;


### PR DESCRIPTION
## Summary

- When the schema capability fires, flatten plugin contributions with `_schemas.flat()` (no reference `Set` dedupe).
- For each schema, derive a canonical key from `Type.getDXN(schema).toString()`. Keep the first occurrence per DXN; log `log.warn` and skip duplicates (avoids "Schema version already registered" from `RuntimeSchemaRegistry.register`).
- Skip entries without a DXN with a warning.
- Replace temporary console debug instrumentation (already absent in this patch).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema synchronization to deterministically deduplicate and register types: invalid or duplicate schemas are skipped (with logging), only truly new schemas are registered, and tracking is updated to prevent re-registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->