### PR TITLE
fix(app-graph): reactively remove inline nodes when connector re-runs

### DIFF
--- a/packages/sdk/app-graph/src/graph-builder.test.ts
+++ b/packages/sdk/app-graph/src/graph-builder.test.ts
@@ -485,6 +485,76 @@ describe('GraphBuilder', () => {
       expect(exists).to.be.true;
     });
 
+    test('inline nodes are removed when connector re-runs with data change', async () => {
+      const registry = Registry.make();
+      const builder = GraphBuilder.make({ registry });
+
+      const nodesAtom = Atom.make<Node.NodeArg<any>[]>([
+        {
+          id: 'parent-node',
+          type: EXAMPLE_TYPE,
+          data: 'v1',
+          nodes: [{ id: 'inline-child', type: EXAMPLE_TYPE, data: null }],
+        },
+      ]);
+
+      GraphBuilder.addExtension(
+        builder,
+        GraphBuilder.createExtensionRaw({
+          id: 'inline-connector',
+          connector: () => Atom.make((get) => get(nodesAtom)),
+        }),
+      );
+
+      const graph = builder.graph;
+      Graph.expand(graph, Node.RootId, 'child');
+      await GraphBuilder.flush(builder);
+
+      expect(Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull)).to.not.be.null;
+
+      // Remove inline child while changing data so the update is triggered.
+      registry.set(nodesAtom, [{ id: 'parent-node', type: EXAMPLE_TYPE, data: 'v2' }]);
+      await GraphBuilder.flush(builder);
+
+      // Inline child should no longer exist in the graph.
+      expect(Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull)).to.be.null;
+    });
+
+    test('inline nodes are removed when only inline children change', async () => {
+      const registry = Registry.make();
+      const builder = GraphBuilder.make({ registry });
+
+      const nodesAtom = Atom.make<Node.NodeArg<any>[]>([
+        {
+          id: 'parent-node',
+          type: EXAMPLE_TYPE,
+          data: null,
+          nodes: [{ id: 'inline-child', type: EXAMPLE_TYPE, data: null }],
+        },
+      ]);
+
+      GraphBuilder.addExtension(
+        builder,
+        GraphBuilder.createExtensionRaw({
+          id: 'inline-connector',
+          connector: () => Atom.make((get) => get(nodesAtom)),
+        }),
+      );
+
+      const graph = builder.graph;
+      Graph.expand(graph, Node.RootId, 'child');
+      await GraphBuilder.flush(builder);
+
+      expect(Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull)).to.not.be.null;
+
+      // Remove inline child without changing data — tests that change detection also covers inline children.
+      registry.set(nodesAtom, [{ id: 'parent-node', type: EXAMPLE_TYPE, data: null }]);
+      await GraphBuilder.flush(builder);
+
+      // Inline child should no longer exist in the graph.
+      expect(Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull)).to.be.null;
+    });
+
     test('sort edges', async () => {
       const registry = Registry.make();
       const builder = GraphBuilder.make({ registry });

--- a/packages/sdk/app-graph/src/graph-builder.test.ts
+++ b/packages/sdk/app-graph/src/graph-builder.test.ts
@@ -485,228 +485,125 @@ describe('GraphBuilder', () => {
       expect(exists).to.be.true;
     });
 
-    test('inline nodes are removed when connector re-runs with data change', async () => {
-      const registry = Registry.make();
-      const builder = GraphBuilder.make({ registry });
+    describe('inline nodes', () => {
+      const parent = (child?: Node.NodeArg<any>): Node.NodeArg<any> => ({
+        id: 'parent-node',
+        type: EXAMPLE_TYPE,
+        data: null,
+        nodes: child ? [child] : [],
+      });
 
-      const nodesAtom = Atom.make<Node.NodeArg<any>[]>([
-        {
-          id: 'parent-node',
-          type: EXAMPLE_TYPE,
-          data: 'v1',
-          nodes: [{ id: 'inline-child', type: EXAMPLE_TYPE, data: null }],
-        },
-      ]);
+      const inlineChild = (overrides?: Partial<Node.NodeArg<any>>): Node.NodeArg<any> => ({
+        id: 'inline-child',
+        type: EXAMPLE_TYPE,
+        data: null,
+        ...overrides,
+      });
 
-      GraphBuilder.addExtension(
-        builder,
-        GraphBuilder.createExtensionRaw({
-          id: 'inline-connector',
-          connector: () => Atom.make((get) => get(nodesAtom)),
-        }),
-      );
+      const makeGraph = () => {
+        const registry = Registry.make();
+        const builder = GraphBuilder.make({ registry });
+        const nodesAtom = Atom.make<Node.NodeArg<any>[]>([]);
+        GraphBuilder.addExtension(
+          builder,
+          GraphBuilder.createExtensionRaw({
+            id: 'inline-connector',
+            connector: () => Atom.make((get) => get(nodesAtom)),
+          }),
+        );
+        const graph = builder.graph;
+        Graph.expand(graph, Node.RootId, 'child');
+        return { registry, builder, graph, nodesAtom };
+      };
 
-      const graph = builder.graph;
-      Graph.expand(graph, Node.RootId, 'child');
-      await GraphBuilder.flush(builder);
+      const getInlineChild = (graph: Graph.ExpandableGraph) =>
+        Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull);
 
-      expect(Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull)).to.not.be.null;
+      test('are removed when connector re-runs with data change', async () => {
+        const { registry, builder, graph, nodesAtom } = makeGraph();
+        registry.set(nodesAtom, [parent(inlineChild())]);
+        await GraphBuilder.flush(builder);
 
-      // Remove inline child while changing data so the update is triggered.
-      registry.set(nodesAtom, [{ id: 'parent-node', type: EXAMPLE_TYPE, data: 'v2' }]);
-      await GraphBuilder.flush(builder);
+        expect(getInlineChild(graph)).to.not.be.null;
 
-      // Inline child should no longer exist in the graph.
-      expect(Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull)).to.be.null;
-    });
+        // Remove inline child while also changing parent data to trigger the update.
+        registry.set(nodesAtom, [{ ...parent(), data: 'v2' }]);
+        await GraphBuilder.flush(builder);
 
-    test('inline nodes are removed when only inline children change', async () => {
-      const registry = Registry.make();
-      const builder = GraphBuilder.make({ registry });
+        expect(getInlineChild(graph)).to.be.null;
+      });
 
-      const nodesAtom = Atom.make<Node.NodeArg<any>[]>([
-        {
-          id: 'parent-node',
-          type: EXAMPLE_TYPE,
-          data: null,
-          nodes: [{ id: 'inline-child', type: EXAMPLE_TYPE, data: null }],
-        },
-      ]);
+      test('are removed when only inline children change', async () => {
+        const { registry, builder, graph, nodesAtom } = makeGraph();
+        registry.set(nodesAtom, [parent(inlineChild())]);
+        await GraphBuilder.flush(builder);
 
-      GraphBuilder.addExtension(
-        builder,
-        GraphBuilder.createExtensionRaw({
-          id: 'inline-connector',
-          connector: () => Atom.make((get) => get(nodesAtom)),
-        }),
-      );
+        expect(getInlineChild(graph)).to.not.be.null;
 
-      const graph = builder.graph;
-      Graph.expand(graph, Node.RootId, 'child');
-      await GraphBuilder.flush(builder);
+        // Remove inline child without touching parent — tests change detection covers inline children.
+        registry.set(nodesAtom, [parent()]);
+        await GraphBuilder.flush(builder);
 
-      expect(Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull)).to.not.be.null;
+        expect(getInlineChild(graph)).to.be.null;
+      });
 
-      // Remove inline child without changing data — tests that change detection also covers inline children.
-      registry.set(nodesAtom, [{ id: 'parent-node', type: EXAMPLE_TYPE, data: null }]);
-      await GraphBuilder.flush(builder);
+      test('are added when connector re-runs', async () => {
+        const { registry, builder, graph, nodesAtom } = makeGraph();
+        registry.set(nodesAtom, [parent()]);
+        await GraphBuilder.flush(builder);
 
-      // Inline child should no longer exist in the graph.
-      expect(Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull)).to.be.null;
-    });
+        expect(getInlineChild(graph)).to.be.null;
 
-    test('inline nodes reactively update data', async ({ expect }) => {
-      const registry = Registry.make();
-      const builder = GraphBuilder.make({ registry });
+        registry.set(nodesAtom, [parent(inlineChild())]);
+        await GraphBuilder.flush(builder);
 
-      const nodesAtom = Atom.make<Node.NodeArg<any>[]>([
-        {
-          id: 'parent-node',
-          type: EXAMPLE_TYPE,
-          data: null,
-          nodes: [{ id: 'inline-child', type: EXAMPLE_TYPE, data: 'v1' }],
-        },
-      ]);
+        expect(getInlineChild(graph)).to.not.be.null;
+      });
 
-      GraphBuilder.addExtension(
-        builder,
-        GraphBuilder.createExtensionRaw({
-          id: 'inline-connector',
-          connector: () => Atom.make((get) => get(nodesAtom)),
-        }),
-      );
+      test('reactively update data', async ({ expect }) => {
+        const { registry, builder, graph, nodesAtom } = makeGraph();
+        registry.set(nodesAtom, [parent(inlineChild({ data: 'v1' }))]);
+        await GraphBuilder.flush(builder);
 
-      const graph = builder.graph;
-      Graph.expand(graph, Node.RootId, 'child');
-      await GraphBuilder.flush(builder);
+        expect(getInlineChild(graph)?.data).to.equal('v1');
 
-      {
-        const node = Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull);
-        expect(node?.data).to.equal('v1');
-      }
+        // Change only the inline child's data — parent is unchanged.
+        registry.set(nodesAtom, [parent(inlineChild({ data: 'v2' }))]);
+        await GraphBuilder.flush(builder);
 
-      // Change only the inline child's data — parent is unchanged.
-      registry.set(nodesAtom, [
-        {
-          id: 'parent-node',
-          type: EXAMPLE_TYPE,
-          data: null,
-          nodes: [{ id: 'inline-child', type: EXAMPLE_TYPE, data: 'v2' }],
-        },
-      ]);
-      await GraphBuilder.flush(builder);
+        expect(getInlineChild(graph)?.data).to.equal('v2');
+      });
 
-      {
-        const node = Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull);
-        expect(node?.data).to.equal('v2');
-      }
-    });
+      test('reactively update properties', async ({ expect }) => {
+        const { registry, builder, graph, nodesAtom } = makeGraph();
+        registry.set(nodesAtom, [parent(inlineChild({ properties: { label: 'before' } }))]);
+        await GraphBuilder.flush(builder);
 
-    test('inline nodes reactively update properties', async ({ expect }) => {
-      const registry = Registry.make();
-      const builder = GraphBuilder.make({ registry });
+        expect(getInlineChild(graph)?.properties.label).to.equal('before');
 
-      const nodesAtom = Atom.make<Node.NodeArg<any>[]>([
-        {
-          id: 'parent-node',
-          type: EXAMPLE_TYPE,
-          data: null,
-          nodes: [{ id: 'inline-child', type: EXAMPLE_TYPE, data: null, properties: { label: 'before' } }],
-        },
-      ]);
+        registry.set(nodesAtom, [parent(inlineChild({ properties: { label: 'after' } }))]);
+        await GraphBuilder.flush(builder);
 
-      GraphBuilder.addExtension(
-        builder,
-        GraphBuilder.createExtensionRaw({
-          id: 'inline-connector',
-          connector: () => Atom.make((get) => get(nodesAtom)),
-        }),
-      );
+        expect(getInlineChild(graph)?.properties.label).to.equal('after');
+      });
 
-      const graph = builder.graph;
-      Graph.expand(graph, Node.RootId, 'child');
-      await GraphBuilder.flush(builder);
+      test('deeply nested inline nodes reactively update', async ({ expect }) => {
+        const { registry, builder, graph, nodesAtom } = makeGraph();
 
-      {
-        const node = Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull);
-        expect(node?.properties.label).to.equal('before');
-      }
+        const withGrandchild = (data: string) =>
+          parent({ id: 'child', type: EXAMPLE_TYPE, data: null, nodes: [{ id: 'grandchild', type: EXAMPLE_TYPE, data }] });
 
-      registry.set(nodesAtom, [
-        {
-          id: 'parent-node',
-          type: EXAMPLE_TYPE,
-          data: null,
-          nodes: [{ id: 'inline-child', type: EXAMPLE_TYPE, data: null, properties: { label: 'after' } }],
-        },
-      ]);
-      await GraphBuilder.flush(builder);
+        registry.set(nodesAtom, [withGrandchild('v1')]);
+        await GraphBuilder.flush(builder);
 
-      {
-        const node = Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull);
-        expect(node?.properties.label).to.equal('after');
-      }
-    });
+        expect(Graph.getNode(graph, 'root/parent-node/child/grandchild').pipe(Option.getOrNull)?.data).to.equal('v1');
 
-    test('deeply nested inline nodes reactively update', async ({ expect }) => {
-      const registry = Registry.make();
-      const builder = GraphBuilder.make({ registry });
+        // Change only the grandchild's data — all ancestors unchanged.
+        registry.set(nodesAtom, [withGrandchild('v2')]);
+        await GraphBuilder.flush(builder);
 
-      const nodesAtom = Atom.make<Node.NodeArg<any>[]>([
-        {
-          id: 'parent-node',
-          type: EXAMPLE_TYPE,
-          data: null,
-          nodes: [
-            {
-              id: 'child',
-              type: EXAMPLE_TYPE,
-              data: null,
-              nodes: [{ id: 'grandchild', type: EXAMPLE_TYPE, data: 'v1' }],
-            },
-          ],
-        },
-      ]);
-
-      GraphBuilder.addExtension(
-        builder,
-        GraphBuilder.createExtensionRaw({
-          id: 'inline-connector',
-          connector: () => Atom.make((get) => get(nodesAtom)),
-        }),
-      );
-
-      const graph = builder.graph;
-      Graph.expand(graph, Node.RootId, 'child');
-      await GraphBuilder.flush(builder);
-
-      {
-        const node = Graph.getNode(graph, 'root/parent-node/child/grandchild').pipe(Option.getOrNull);
-        expect(node?.data).to.equal('v1');
-      }
-
-      // Change only the grandchild's data — all ancestors unchanged.
-      registry.set(nodesAtom, [
-        {
-          id: 'parent-node',
-          type: EXAMPLE_TYPE,
-          data: null,
-          nodes: [
-            {
-              id: 'child',
-              type: EXAMPLE_TYPE,
-              data: null,
-              nodes: [{ id: 'grandchild', type: EXAMPLE_TYPE, data: 'v2' }],
-            },
-          ],
-        },
-      ]);
-      await GraphBuilder.flush(builder);
-
-      {
-        const node = Graph.getNode(graph, 'root/parent-node/child/grandchild').pipe(Option.getOrNull);
-        expect(node?.data).to.equal('v2');
-      }
+        expect(Graph.getNode(graph, 'root/parent-node/child/grandchild').pipe(Option.getOrNull)?.data).to.equal('v2');
+      });
     });
 
     test('sort edges', async () => {

--- a/packages/sdk/app-graph/src/graph-builder.test.ts
+++ b/packages/sdk/app-graph/src/graph-builder.test.ts
@@ -591,7 +591,12 @@ describe('GraphBuilder', () => {
         const { registry, builder, graph, nodesAtom } = makeGraph();
 
         const withGrandchild = (data: string) =>
-          parent({ id: 'child', type: EXAMPLE_TYPE, data: null, nodes: [{ id: 'grandchild', type: EXAMPLE_TYPE, data }] });
+          parent({
+            id: 'child',
+            type: EXAMPLE_TYPE,
+            data: null,
+            nodes: [{ id: 'grandchild', type: EXAMPLE_TYPE, data }],
+          });
 
         registry.set(nodesAtom, [withGrandchild('v1')]);
         await GraphBuilder.flush(builder);

--- a/packages/sdk/app-graph/src/graph-builder.test.ts
+++ b/packages/sdk/app-graph/src/graph-builder.test.ts
@@ -555,6 +555,160 @@ describe('GraphBuilder', () => {
       expect(Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull)).to.be.null;
     });
 
+    test('inline nodes reactively update data', async ({ expect }) => {
+      const registry = Registry.make();
+      const builder = GraphBuilder.make({ registry });
+
+      const nodesAtom = Atom.make<Node.NodeArg<any>[]>([
+        {
+          id: 'parent-node',
+          type: EXAMPLE_TYPE,
+          data: null,
+          nodes: [{ id: 'inline-child', type: EXAMPLE_TYPE, data: 'v1' }],
+        },
+      ]);
+
+      GraphBuilder.addExtension(
+        builder,
+        GraphBuilder.createExtensionRaw({
+          id: 'inline-connector',
+          connector: () => Atom.make((get) => get(nodesAtom)),
+        }),
+      );
+
+      const graph = builder.graph;
+      Graph.expand(graph, Node.RootId, 'child');
+      await GraphBuilder.flush(builder);
+
+      {
+        const node = Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull);
+        expect(node?.data).to.equal('v1');
+      }
+
+      // Change only the inline child's data — parent is unchanged.
+      registry.set(nodesAtom, [
+        {
+          id: 'parent-node',
+          type: EXAMPLE_TYPE,
+          data: null,
+          nodes: [{ id: 'inline-child', type: EXAMPLE_TYPE, data: 'v2' }],
+        },
+      ]);
+      await GraphBuilder.flush(builder);
+
+      {
+        const node = Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull);
+        expect(node?.data).to.equal('v2');
+      }
+    });
+
+    test('inline nodes reactively update properties', async ({ expect }) => {
+      const registry = Registry.make();
+      const builder = GraphBuilder.make({ registry });
+
+      const nodesAtom = Atom.make<Node.NodeArg<any>[]>([
+        {
+          id: 'parent-node',
+          type: EXAMPLE_TYPE,
+          data: null,
+          nodes: [{ id: 'inline-child', type: EXAMPLE_TYPE, data: null, properties: { label: 'before' } }],
+        },
+      ]);
+
+      GraphBuilder.addExtension(
+        builder,
+        GraphBuilder.createExtensionRaw({
+          id: 'inline-connector',
+          connector: () => Atom.make((get) => get(nodesAtom)),
+        }),
+      );
+
+      const graph = builder.graph;
+      Graph.expand(graph, Node.RootId, 'child');
+      await GraphBuilder.flush(builder);
+
+      {
+        const node = Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull);
+        expect(node?.properties.label).to.equal('before');
+      }
+
+      registry.set(nodesAtom, [
+        {
+          id: 'parent-node',
+          type: EXAMPLE_TYPE,
+          data: null,
+          nodes: [{ id: 'inline-child', type: EXAMPLE_TYPE, data: null, properties: { label: 'after' } }],
+        },
+      ]);
+      await GraphBuilder.flush(builder);
+
+      {
+        const node = Graph.getNode(graph, 'root/parent-node/inline-child').pipe(Option.getOrNull);
+        expect(node?.properties.label).to.equal('after');
+      }
+    });
+
+    test('deeply nested inline nodes reactively update', async ({ expect }) => {
+      const registry = Registry.make();
+      const builder = GraphBuilder.make({ registry });
+
+      const nodesAtom = Atom.make<Node.NodeArg<any>[]>([
+        {
+          id: 'parent-node',
+          type: EXAMPLE_TYPE,
+          data: null,
+          nodes: [
+            {
+              id: 'child',
+              type: EXAMPLE_TYPE,
+              data: null,
+              nodes: [{ id: 'grandchild', type: EXAMPLE_TYPE, data: 'v1' }],
+            },
+          ],
+        },
+      ]);
+
+      GraphBuilder.addExtension(
+        builder,
+        GraphBuilder.createExtensionRaw({
+          id: 'inline-connector',
+          connector: () => Atom.make((get) => get(nodesAtom)),
+        }),
+      );
+
+      const graph = builder.graph;
+      Graph.expand(graph, Node.RootId, 'child');
+      await GraphBuilder.flush(builder);
+
+      {
+        const node = Graph.getNode(graph, 'root/parent-node/child/grandchild').pipe(Option.getOrNull);
+        expect(node?.data).to.equal('v1');
+      }
+
+      // Change only the grandchild's data — all ancestors unchanged.
+      registry.set(nodesAtom, [
+        {
+          id: 'parent-node',
+          type: EXAMPLE_TYPE,
+          data: null,
+          nodes: [
+            {
+              id: 'child',
+              type: EXAMPLE_TYPE,
+              data: null,
+              nodes: [{ id: 'grandchild', type: EXAMPLE_TYPE, data: 'v2' }],
+            },
+          ],
+        },
+      ]);
+      await GraphBuilder.flush(builder);
+
+      {
+        const node = Graph.getNode(graph, 'root/parent-node/child/grandchild').pipe(Option.getOrNull);
+        expect(node?.data).to.equal('v2');
+      }
+    });
+
     test('sort edges', async () => {
       const registry = Registry.make();
       const builder = GraphBuilder.make({ registry });

--- a/packages/sdk/app-graph/src/graph-builder.ts
+++ b/packages/sdk/app-graph/src/graph-builder.ts
@@ -125,6 +125,8 @@ class GraphBuilderImpl implements GraphBuilder {
   >();
   /** Last-flushed node IDs per connector key, used for edge removal on update. */
   readonly _connectorPrevious = new Map<string, string[]>();
+  /** All inline-descendant IDs per connector key, used to remove stale inline nodes on update. */
+  readonly _connectorPreviousInlineIds = new Map<string, string[]>();
   /** Last-flushed node args per connector key, used for change detection. */
   readonly _connectorPreviousArgs = new Map<string, Node.NodeArg<any>[]>();
   /** Whether a dirty-flush task is already scheduled. */
@@ -178,6 +180,12 @@ class GraphBuilderImpl implements GraphBuilder {
     this._connectorPrevious.set(key, ids);
     this._connectorPreviousArgs.set(key, nodes);
 
+    const currentInlineIds = collectAllInlineIds(nodes);
+    const previousInlineIds = this._connectorPreviousInlineIds.get(key) ?? [];
+    const staleInlineIds = previousInlineIds.filter((pid) => !currentInlineIds.includes(pid));
+    this._connectorPreviousInlineIds.set(key, currentInlineIds);
+
+    Graph.removeNodes(this._graph, staleInlineIds, true);
     Graph.removeEdges(
       this._graph,
       removed.map((target) => ({ source: id, target, relation })),
@@ -840,6 +848,21 @@ const qualifyNodeArgs =
         nodes: node.nodes ? qualifyNodeArgs(qualified)(node.nodes) : undefined,
       };
     });
+
+/**
+ * Recursively collect all inline-descendant IDs (the `nodes` arrays at every level)
+ * from a list of top-level NodeArgs. Top-level IDs are excluded because they are
+ * already tracked via `_connectorPrevious`.
+ */
+const collectAllInlineIds = (nodes: Node.NodeArg<any>[]): string[] =>
+  nodes.flatMap((node) =>
+    node.nodes
+      ? [
+          ...node.nodes.map((child) => child.id),
+          ...collectAllInlineIds(node.nodes),
+        ]
+      : [],
+  );
 
 const connectorKey = (id: string, relation: Node.RelationInput): string => primaryKey(id, Graph.relationKey(relation));
 

--- a/packages/sdk/app-graph/src/graph-builder.ts
+++ b/packages/sdk/app-graph/src/graph-builder.ts
@@ -856,12 +856,7 @@ const qualifyNodeArgs =
  */
 const collectAllInlineIds = (nodes: Node.NodeArg<any>[]): string[] =>
   nodes.flatMap((node) =>
-    node.nodes
-      ? [
-          ...node.nodes.map((child) => child.id),
-          ...collectAllInlineIds(node.nodes),
-        ]
-      : [],
+    node.nodes ? [...node.nodes.map((child) => child.id), ...collectAllInlineIds(node.nodes)] : [],
   );
 
 const connectorKey = (id: string, relation: Node.RelationInput): string => primaryKey(id, Graph.relationKey(relation));

--- a/packages/sdk/app-graph/src/util.ts
+++ b/packages/sdk/app-graph/src/util.ts
@@ -53,6 +53,7 @@ export const shallowEqual = (a: unknown, b: unknown): boolean => {
 
 /**
  * Returns true if two NodeArg arrays are semantically identical (same id, type, data, properties per index).
+ * Inline child nodes (the `nodes` field) are compared recursively.
  */
 export const nodeArgsUnchanged = (prev: Node.NodeArg<any>[], next: Node.NodeArg<any>[]): boolean => {
   if (prev.length !== next.length) {
@@ -65,7 +66,8 @@ export const nodeArgsUnchanged = (prev: Node.NodeArg<any>[], next: Node.NodeArg<
       prevNode.id === nextNode.id &&
       prevNode.type === nextNode.type &&
       shallowEqual(prevNode.data, nextNode.data) &&
-      shallowEqual(prevNode.properties, nextNode.properties)
+      shallowEqual(prevNode.properties, nextNode.properties) &&
+      nodeArgsUnchanged(prevNode.nodes ?? [], nextNode.nodes ?? [])
     );
   });
 };


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Bug 1 — change detection miss**: `nodeArgsUnchanged` did not compare the `nodes` (inline children) field recursively, so a connector update that only added/removed inline children would be silently swallowed by the early-return guard in `_expandRelation`.
- **Bug 2 — missing removal**: `_applyConnectorUpdate` only tracked and diffed top-level node IDs in `_connectorPrevious`. Stale inline descendants were never removed from the graph even when an update did fire (e.g. when data also changed).

### Changes

| File | Change |
|---|---|
| `util.ts` | `nodeArgsUnchanged` now recurses into `nodes` arrays so inline-child changes trigger a dirty-connector flush. |
| `graph-builder.ts` | Added `_connectorPreviousInlineIds` map and `collectAllInlineIds` helper. Each `_applyConnectorUpdate` call diffs the full inline-descendant set and calls `Graph.removeNodes` on any stale inline nodes before re-adding the current set. |
| `graph-builder.test.ts` | Two new failing-first tests: one where data also changes (exercises the removal path), one where only inline children change (exercises the change-detection path). |

## Test plan

- [ ] `inline nodes are removed when connector re-runs with data change` — previously failing, now passing
- [ ] `inline nodes are removed when only inline children change` — previously failing, now passing
- [ ] All existing 35 `app-graph` tests continue to pass (37 total with the 2 new ones)
- [ ] `moon run app-graph:lint` passes

https://claude.ai/code/session_01BQ1T8MXq7zukisACdiuuHN
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQ1T8MXq7zukisACdiuuHN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved inline node lifecycle management—nodes now properly update reactively when data or properties change, and are correctly removed or added when connector outputs change.

* **Tests**
  * Added comprehensive test coverage for inline node behavior, including deeply nested structures and connector reconnection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->