### PR TITLE
feat(composer-app): adjust default plugin set

### DIFF
--- a/packages/apps/composer-app/src/plugin-defs.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.tsx
@@ -137,7 +137,7 @@ export const getCore = ({ isPwa, isTauri, isPopover, isMobile }: PluginConfig): 
 export const getDefaults = ({ isDev, isLocal, isLabs }: PluginConfig): string[] =>
   [
     // Default
-    GalleryPlugin.meta.id,
+    AssistantPlugin.meta.id,
     InboxPlugin.meta.id,
     KanbanPlugin.meta.id,
     MarkdownPlugin.meta.id,
@@ -148,8 +148,6 @@ export const getDefaults = ({ isDev, isLocal, isLabs }: PluginConfig): string[] 
     ThreadPlugin.meta.id,
     WnfsPlugin.meta.id,
 
-    CodePlugin.meta.id,
-
     // Dev
     isDev && DebugPlugin.meta.id,
 
@@ -158,9 +156,9 @@ export const getDefaults = ({ isDev, isLocal, isLabs }: PluginConfig): string[] 
 
     // Labs
     (isDev || isLabs) && [
-      AssistantPlugin.meta.id,
-      DiscordPlugin.meta.id,
+      CodePlugin.meta.id,
       FeedPlugin.meta.id,
+      GalleryPlugin.meta.id,
       IrohBeaconPlugin.meta.id,
       MeetingPlugin.meta.id,
       OutlinerPlugin.meta.id,


### PR DESCRIPTION
## Summary

- `AssistantPlugin` moved to always-enabled defaults (was dev/labs only)
- `CodePlugin` and `GalleryPlugin` moved to dev/labs only (were always enabled)
- `DiscordPlugin` removed from defaults entirely (was dev/labs only)

## Test plan

- [ ] Verify production build shows Assistant but not Code Project, Gallery, or Discord Bot in "Create Object" dialog
- [ ] Verify dev build shows Code Project and Gallery in addition to Assistant
- [ ] Verify Discord Bot does not appear in any default configuration

https://claude.ai/code/session_01VTrJEyaULqevFd2FU2f8mU

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTrJEyaULqevFd2FU2f8mU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The Assistant plugin is now available in default mode
  * Code and Gallery plugins are now available in developer/labs mode
  * Discord plugin is no longer available in developer/labs mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->