### PR TITLE
feat(composer-app): add /mail entry point with minimal mailbox layout

### DIFF
--- a/packages/apps/composer-app/mail.html
+++ b/packages/apps/composer-app/mail.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="description" content="DXOS Composer Mail" />
+    <!-- NOTE: viewport-fit=cover defines safe-area-inset-top, etc. for iOS. -->
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1.0,user-scalable=no,interactive-widget=resizes-content,viewport-fit=cover"
+    />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="msapplication-TileColor" content="#003E70" />
+    <!-- Match the boot loader and `@dxos/ui-theme`'s `--color-base-surface`
+         (Tailwind `neutral-50` / `neutral-950`) so the mobile-browser chrome
+         tints match what the app renders. -->
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#fafafa" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0a0a0a" />
+
+    <title>Composer Mail</title>
+
+    <!-- https://realfavicongenerator.net -->
+    <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+
+    <link rel="manifest" href="/site.webmanifest" />
+
+    <!--
+      Suppress lit's dev-mode warning. See `index.html` for the full rationale.
+    -->
+    <script>
+      (window.litIssuedWarnings ??= new Set()).add('dev-mode');
+    </script>
+  </head>
+  <body>
+    <div id="root" class="contents"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/apps/composer-app/package.json
+++ b/packages/apps/composer-app/package.json
@@ -85,6 +85,7 @@
     "@dxos/plugin-iroh-beacon": "workspace:*",
     "@dxos/plugin-kanban": "workspace:*",
     "@dxos/plugin-linear": "workspace:*",
+    "@dxos/plugin-mail-layout": "workspace:*",
     "@dxos/plugin-map": "workspace:*",
     "@dxos/plugin-map-solid": "workspace:*",
     "@dxos/plugin-markdown": "workspace:*",

--- a/packages/apps/composer-app/src/main.tsx
+++ b/packages/apps/composer-app/src/main.tsx
@@ -400,6 +400,7 @@ const main = async () => {
   profiler?.mark('plugins:start');
 
   const isPwa = !isFalse(config.values.runtime?.app?.env?.DX_PWA);
+  const isMail = url.pathname === '/mail' || url.pathname.startsWith('/mail/') || url.pathname.endsWith('/mail.html');
   const conf: PluginConfig = {
     appKey: APP_KEY,
     config,
@@ -413,6 +414,7 @@ const main = async () => {
     isTauri,
     isPopover,
     isMobile,
+    isMail,
     isLabs: isTrue(config.values.runtime?.app?.env?.DX_LABS),
     isStrict: !isFalse(config.values.runtime?.app?.env?.DX_STRICT),
   };

--- a/packages/apps/composer-app/src/plugin-defs.tsx
+++ b/packages/apps/composer-app/src/plugin-defs.tsx
@@ -42,6 +42,7 @@ import { IntegrationPlugin } from '@dxos/plugin-integration/plugin';
 import { IrohBeaconPlugin } from '@dxos/plugin-iroh-beacon/plugin';
 import { KanbanPlugin } from '@dxos/plugin-kanban/plugin';
 import { LinearPlugin } from '@dxos/plugin-linear/plugin';
+import { MailLayoutPlugin } from '@dxos/plugin-mail-layout';
 import { MapPlugin as MapPluginSolid } from '@dxos/plugin-map-solid/plugin';
 import { MapPlugin } from '@dxos/plugin-map/plugin';
 import { MarkdownPlugin } from '@dxos/plugin-markdown/plugin';
@@ -110,6 +111,7 @@ export type PluginConfig = State & {
   isStrict?: boolean;
   isPopover?: boolean;
   isMobile?: boolean;
+  isMail?: boolean;
 };
 
 export const getDefaults = ({ isDev, isLocal, isLabs }: PluginConfig): string[] =>
@@ -173,8 +175,15 @@ export const getPlugins = ({
   isTauri,
   isPopover,
   isMobile,
+  isMail,
 }: PluginConfig): Plugin.Plugin[] => {
-  const layoutPlugin = isPopover ? SpotlightPlugin() : isMobile ? SimpleLayoutPlugin({}) : DeckPlugin();
+  const layoutPlugin = isMail
+    ? MailLayoutPlugin()
+    : isPopover
+      ? SpotlightPlugin()
+      : isMobile
+        ? SimpleLayoutPlugin({})
+        : DeckPlugin();
   const origin = isTauri ? APP_LINK_ORIGIN : window.location.origin;
   return [
     AssistantPlugin(),

--- a/packages/apps/composer-app/tsconfig.json
+++ b/packages/apps/composer-app/tsconfig.json
@@ -319,6 +319,9 @@
       "path": "../../plugins/plugin-linear"
     },
     {
+      "path": "../../plugins/plugin-mail-layout"
+    },
+    {
       "path": "../../plugins/plugin-map"
     },
     {

--- a/packages/apps/composer-app/vite.config.ts
+++ b/packages/apps/composer-app/vite.config.ts
@@ -140,6 +140,7 @@ export default defineConfig((env) => ({
       input: {
         internal: path.resolve(dirname, './internal.html'),
         main: path.resolve(dirname, './index.html'),
+        mail: path.resolve(dirname, './mail.html'),
         devtools: path.resolve(dirname, './devtools.html'),
         reset: path.resolve(dirname, './reset.html'),
         recovery: path.resolve(dirname, './recovery.html'),
@@ -277,6 +278,7 @@ export default defineConfig((env) => ({
     entries: [
       './index.html',
       './internal.html',
+      './mail.html',
       './devtools.html',
       './reset.html',
       './recovery.html',
@@ -304,6 +306,10 @@ export default defineConfig((env) => ({
       // NOTE: This is a workaround to fix "dual package hazard" where dist output and local sources
       //   might resolve differently, resulting in two distinct module instances.
       { find: '@dxos/solid-ui-geo', replacement: path.resolve(rootDir, 'packages/ui/solid-ui-geo/src') },
+      {
+        find: '@dxos/plugin-mail-layout',
+        replacement: path.resolve(rootDir, 'packages/plugins/plugin-mail-layout/src'),
+      },
       { find: '@dxos/plugin-map-solid', replacement: path.resolve(rootDir, 'packages/plugins/plugin-map-solid/src') },
       { find: '@dxos/web-context-solid', replacement: path.resolve(rootDir, 'packages/common/web-context-solid/src') },
       { find: '@dxos/effect-atom-solid', replacement: path.resolve(rootDir, 'packages/common/effect-atom-solid/src') },

--- a/packages/plugins/plugin-mail-layout/LICENSE
+++ b/packages/plugins/plugin-mail-layout/LICENSE
@@ -1,0 +1,8 @@
+MIT License 
+Copyright (c) 2022 DXOS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/plugins/plugin-mail-layout/dx.config.ts
+++ b/packages/plugins/plugin-mail-layout/dx.config.ts
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Config2 } from '@dxos/app-framework/config';
+
+export default Config2.make({
+  plugin: {
+    key: 'org.dxos.plugin.mailLayout',
+    name: 'Mail Layout',
+    author: 'DXOS',
+    description: 'Minimal master/detail layout for the Composer /mail entry point.',
+    icon: { key: 'ph--tray--regular', hue: 'indigo' },
+    source: 'https://github.com/dxos/dxos/tree/main/packages/plugins/plugin-mail-layout',
+  },
+});

--- a/packages/plugins/plugin-mail-layout/moon.yml
+++ b/packages/plugins/plugin-mail-layout/moon.yml
@@ -1,0 +1,11 @@
+layer: library
+language: typescript
+tags:
+  - ts-build
+  - ts-test
+  - pack
+tasks:
+  compile:
+    args:
+      - '--entryPoint=src/index.ts'
+      - '--entryPoint=src/translations.ts'

--- a/packages/plugins/plugin-mail-layout/package.json
+++ b/packages/plugins/plugin-mail-layout/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@dxos/plugin-mail-layout",
+  "version": "0.9.0",
+  "private": true,
+  "description": "Minimal master/detail mail layout plugin for the Composer mail entry point.",
+  "homepage": "https://dxos.org",
+  "bugs": "https://github.com/dxos/dxos/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dxos/dxos"
+  },
+  "license": "FSL-1.1-Apache-2.0",
+  "author": "DXOS.org",
+  "sideEffects": true,
+  "type": "module",
+  "imports": {
+    "#capabilities": "./src/capabilities/index.ts",
+    "#components": "./src/components/index.ts",
+    "#meta": "./src/meta.ts",
+    "#operations": "./src/operations/index.ts",
+    "#translations": "./src/translations.ts"
+  },
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": "./dist/lib/node-esm/index.mjs",
+      "types": "./dist/types/src/index.d.ts"
+    },
+    "./translations": {
+      "source": "./src/translations.ts",
+      "types": "./dist/types/src/translations.d.ts",
+      "browser": "./dist/lib/browser/translations.mjs",
+      "node": "./dist/lib/node-esm/translations.mjs"
+    }
+  },
+  "types": "dist/types/src/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@dxos/app-framework": "workspace:*",
+    "@dxos/app-toolkit": "workspace:*",
+    "@dxos/compute": "workspace:*",
+    "@dxos/echo": "workspace:*",
+    "@dxos/log": "workspace:*",
+    "@dxos/plugin-graph": "workspace:*",
+    "@dxos/plugin-inbox": "workspace:*",
+    "@dxos/react-client": "workspace:*",
+    "@dxos/react-ui": "workspace:*",
+    "@dxos/react-ui-attention": "workspace:*",
+    "@dxos/react-ui-mosaic": "workspace:*",
+    "@dxos/types": "workspace:*",
+    "@effect-atom/atom-react": "catalog:",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "vite": "catalog:"
+  },
+  "peerDependencies": {
+    "@dxos/react-ui": "workspace:*",
+    "effect": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  }
+}

--- a/packages/plugins/plugin-mail-layout/src/MailLayoutPlugin.tsx
+++ b/packages/plugins/plugin-mail-layout/src/MailLayoutPlugin.tsx
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { ActivationEvents, Capability, Plugin } from '@dxos/app-framework';
+import { AppActivationEvents, AppPlugin } from '@dxos/app-toolkit';
+
+import { LayoutState, OperationHandler, ReactRoot } from '#capabilities';
+import { meta } from '#meta';
+import { translations } from '#translations';
+
+export const MailLayoutPlugin = Plugin.define(meta).pipe(
+  AppPlugin.addOperationHandlerModule({ activate: OperationHandler }),
+  AppPlugin.addTranslationsModule({ translations }),
+  Plugin.addModule({
+    id: Capability.getModuleTag(LayoutState),
+    activatesOn: ActivationEvents.Startup,
+    firesAfterActivation: [AppActivationEvents.LayoutReady],
+    activate: LayoutState,
+  }),
+  Plugin.addModule({
+    id: Capability.getModuleTag(ReactRoot),
+    activatesOn: ActivationEvents.Startup,
+    activate: ReactRoot,
+  }),
+  Plugin.make,
+);
+
+export default MailLayoutPlugin;

--- a/packages/plugins/plugin-mail-layout/src/capabilities/index.ts
+++ b/packages/plugins/plugin-mail-layout/src/capabilities/index.ts
@@ -1,0 +1,15 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Capability } from '@dxos/app-framework';
+import { OperationHandlerSet } from '@dxos/compute';
+
+export { MailLayoutState } from './layout-state';
+
+export const ReactRoot = Capability.lazy('ReactRoot', () => import('./react-root'));
+export const LayoutState = Capability.lazy('LayoutState', () => import('./layout-state'));
+export const OperationHandler = Capability.lazy<OperationHandlerSet.OperationHandlerSet>(
+  'OperationHandler',
+  () => import('./operation-handler'),
+);

--- a/packages/plugins/plugin-mail-layout/src/capabilities/layout-state.ts
+++ b/packages/plugins/plugin-mail-layout/src/capabilities/layout-state.ts
@@ -1,0 +1,45 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Atom } from '@effect-atom/atom-react';
+import * as Effect from 'effect/Effect';
+
+import { Capability } from '@dxos/app-framework';
+import { AppCapabilities } from '@dxos/app-toolkit';
+import { Node } from '@dxos/plugin-graph';
+
+import { meta } from '#meta';
+
+export type MailLayoutState = {
+  /** Qualified path of the active workspace (e.g. `${RootId}/${spaceId}`). */
+  workspace: string;
+};
+
+/** Writable mail layout state — `MailLayout` updates `workspace` once it resolves the personal space. */
+export const MailLayoutState = Capability.make<Atom.Writable<MailLayoutState>>(`${meta.profile.key}.state`);
+
+export default Capability.makeModule(() =>
+  Effect.sync(() => {
+    const stateAtom = Atom.make<MailLayoutState>({ workspace: Node.RootId });
+
+    const layoutAtom = Atom.make((get): AppCapabilities.Layout => {
+      const state = get(stateAtom);
+      return {
+        mode: 'mail',
+        dialogOpen: false,
+        sidebarOpen: false,
+        complementarySidebarOpen: false,
+        workspace: state.workspace,
+        active: [],
+        inactive: [],
+        scrollIntoView: undefined,
+      };
+    });
+
+    return [
+      Capability.contributes(MailLayoutState, stateAtom),
+      Capability.contributes(AppCapabilities.Layout, layoutAtom),
+    ];
+  }),
+);

--- a/packages/plugins/plugin-mail-layout/src/capabilities/operation-handler.ts
+++ b/packages/plugins/plugin-mail-layout/src/capabilities/operation-handler.ts
@@ -1,0 +1,16 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capabilities, Capability } from '@dxos/app-framework';
+import type { OperationHandlerSet } from '@dxos/compute';
+
+import { MailLayoutOperationHandlerSet } from '#operations';
+
+export default Capability.makeModule<OperationHandlerSet.OperationHandlerSet>(
+  Effect.fnUntraced(function* () {
+    return Capability.contributes(Capabilities.OperationHandler, MailLayoutOperationHandlerSet);
+  }),
+);

--- a/packages/plugins/plugin-mail-layout/src/capabilities/react-root.tsx
+++ b/packages/plugins/plugin-mail-layout/src/capabilities/react-root.tsx
@@ -1,0 +1,20 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import React from 'react';
+
+import { Capabilities, Capability } from '@dxos/app-framework';
+
+import { MailLayout } from '#components';
+import { meta } from '#meta';
+
+export default Capability.makeModule(() =>
+  Effect.succeed(
+    Capability.contributes(Capabilities.ReactRoot, {
+      id: meta.profile.key,
+      root: () => <MailLayout />,
+    }),
+  ),
+);

--- a/packages/plugins/plugin-mail-layout/src/components/MailLayout.tsx
+++ b/packages/plugins/plugin-mail-layout/src/components/MailLayout.tsx
@@ -1,0 +1,189 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { RegistryContext } from '@effect-atom/atom-react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
+
+import { Surface, useCapability, useOperationInvoker } from '@dxos/app-framework/ui';
+import { AppSpace, Paths } from '@dxos/app-toolkit';
+import { AppSurface } from '@dxos/app-toolkit/ui';
+import { Filter, type Feed, Query } from '@dxos/echo';
+import { log } from '@dxos/log';
+import { Node } from '@dxos/plugin-graph';
+import { InboxOperation, Mailbox } from '@dxos/plugin-inbox/types';
+import { useClient } from '@dxos/react-client';
+import { type Space, useQuery } from '@dxos/react-client/echo';
+import { ErrorFallback, Panel, useTranslation } from '@dxos/react-ui';
+import { linkedSegment, useSelection } from '@dxos/react-ui-attention';
+import { Mosaic } from '@dxos/react-ui-mosaic';
+import { Message } from '@dxos/types';
+
+import { MailLayoutState } from '#capabilities';
+import { meta } from '#meta';
+
+// Mirrors the (unexported) path helpers in plugin-inbox/src/paths.ts. The
+// MailboxArticle dispatches `showItem` with these exact paths, and we read the
+// same selection state via `useSelected`, so the formats must match.
+const mailboxPath = (spaceId: string, mailboxId: string) => `${Node.RootId}/${spaceId}/mailboxes/${mailboxId}`;
+const messagePath = (spaceId: string, mailboxId: string, messageId: string) =>
+  `${mailboxPath(spaceId, mailboxId)}/${linkedSegment(messageId)}`;
+
+const Loading = () => <div className='dx-document grid place-items-center text-description'>Loading…</div>;
+
+const Empty = ({ message }: { message: string }) => (
+  <div className='dx-document grid place-items-center text-description'>{message}</div>
+);
+
+/**
+ * Minimal master/detail layout for the Composer `/mail` entry point.
+ *
+ * Renders the user's personal-space `Mailbox` on the left and the
+ * currently-selected message on the right. Auto-creates a `Mailbox` in the
+ * personal space if none exists. Selection is driven by the attention
+ * manager — `MailboxArticle`'s row clicks already dispatch
+ * `LayoutOperation.Select`, so reading `useSelected()` here is enough.
+ */
+export const MailLayout = () => {
+  const { t } = useTranslation(meta.profile.key);
+  const client = useClient();
+  const personal = AppSpace.resolvePersonalSpace(client);
+  const space = personal?.space;
+
+  // Publish the personal-space path as the active workspace so plugins that
+  // resolve via `useActiveSpace()` (e.g. plugin-integration's auth surface,
+  // which renders the Gmail connect button in the mailbox's empty state) work.
+  useWriteWorkspace(space);
+
+  const { mailbox, ready } = useEnsureMailbox(space);
+  const spaceId = space?.id;
+
+  const mailboxAttendableId = useMemo(
+    () => (spaceId && mailbox ? mailboxPath(spaceId, mailbox.id) : undefined),
+    [spaceId, mailbox],
+  );
+  const selectedMessageId = useSelection(mailboxAttendableId, 'single');
+
+  const feed = mailbox?.feed?.target as Feed.Feed | undefined;
+  const messages = useQuery(
+    space?.db,
+    feed ? Query.select(Filter.type(Message.Message)).from(feed) : Query.select(Filter.nothing()),
+  ) as Message.Message[];
+
+  const selectedMessage = useMemo(
+    () => (selectedMessageId ? messages.find((message) => message.id === selectedMessageId) : undefined),
+    [selectedMessageId, messages],
+  );
+  const messageAttendableId = useMemo(
+    () => (spaceId && mailbox && selectedMessage ? messagePath(spaceId, mailbox.id, selectedMessage.id) : undefined),
+    [spaceId, mailbox, selectedMessage],
+  );
+
+  if (!space || !ready) {
+    return <Loading />;
+  }
+
+  if (!mailbox || !mailboxAttendableId) {
+    return <Loading />;
+  }
+
+  return (
+    <Mosaic.Root>
+      <div className='dx-container grid grid-cols-2 bs-dvh bg-base-surface'>
+        <Panel.Root className='border-ie border-separator'>
+          <Panel.Content role='article'>
+            <Surface.Surface
+              type={AppSurface.Article}
+              data={{ subject: mailbox, attendableId: mailboxAttendableId }}
+              limit={1}
+              fallback={ErrorFallback}
+              placeholder={<Loading />}
+            />
+          </Panel.Content>
+        </Panel.Root>
+        <Panel.Root>
+          <Panel.Content role='article'>
+            {selectedMessage && messageAttendableId ? (
+              <Surface.Surface
+                key={messageAttendableId}
+                type={AppSurface.Article}
+                data={{
+                  subject: selectedMessage,
+                  attendableId: messageAttendableId,
+                  companionTo: mailbox,
+                }}
+                limit={1}
+                fallback={ErrorFallback}
+                placeholder={<Loading />}
+              />
+            ) : (
+              <Empty message={t('detail.placeholder')} />
+            )}
+          </Panel.Content>
+        </Panel.Root>
+      </div>
+    </Mosaic.Root>
+  );
+};
+
+/** Set the layout's `workspace` to the personal space's path once it resolves. */
+const useWriteWorkspace = (space: Space | undefined) => {
+  const registry = useContext(RegistryContext);
+  const stateAtom = useCapability(MailLayoutState);
+  useEffect(() => {
+    if (!space) {
+      return;
+    }
+    const next = Paths.getSpacePath(space.id);
+    if (registry.get(stateAtom).workspace !== next) {
+      registry.set(stateAtom, { workspace: next });
+    }
+  }, [space, registry, stateAtom]);
+};
+
+/**
+ * Find or create a Mailbox in the personal space. Avoids the `useQuery`
+ * load-race that would create a duplicate by awaiting an explicit
+ * `Query.run()` before deciding to create.
+ */
+const useEnsureMailbox = (space: Space | undefined): { mailbox: Mailbox.Mailbox | undefined; ready: boolean } => {
+  const { invokePromise } = useOperationInvoker();
+  const [ready, setReady] = useState(false);
+  const mailboxes = useQuery(space?.db, Filter.type(Mailbox.Mailbox));
+  const mailbox = mailboxes[0];
+
+  useEffect(() => {
+    if (!space) {
+      setReady(false);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const existing = await space.db.query(Query.select(Filter.type(Mailbox.Mailbox))).run();
+      if (cancelled) {
+        return;
+      }
+      if (existing.length > 0) {
+        setReady(true);
+        return;
+      }
+      try {
+        await invokePromise(InboxOperation.AddMailbox, {
+          object: Mailbox.make({ name: 'Inbox' }),
+          target: space.db,
+        });
+      } catch (error) {
+        log.catch(error);
+      } finally {
+        if (!cancelled) {
+          setReady(true);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [space, invokePromise]);
+
+  return { mailbox, ready };
+};

--- a/packages/plugins/plugin-mail-layout/src/components/index.ts
+++ b/packages/plugins/plugin-mail-layout/src/components/index.ts
@@ -1,0 +1,5 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+export * from './MailLayout';

--- a/packages/plugins/plugin-mail-layout/src/index.ts
+++ b/packages/plugins/plugin-mail-layout/src/index.ts
@@ -1,0 +1,11 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+
+import { meta } from './meta';
+
+export const MailLayoutPlugin = Plugin.lazy(meta, () => import('./MailLayoutPlugin'));
+
+export * from './meta';

--- a/packages/plugins/plugin-mail-layout/src/meta.ts
+++ b/packages/plugins/plugin-mail-layout/src/meta.ts
@@ -1,0 +1,9 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Plugin } from '@dxos/app-framework';
+
+import config from '../dx.config';
+
+export const meta = Plugin.getMetaFromConfig(config);

--- a/packages/plugins/plugin-mail-layout/src/operations/index.ts
+++ b/packages/plugins/plugin-mail-layout/src/operations/index.ts
@@ -1,0 +1,7 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { OperationHandlerSet } from '@dxos/compute';
+
+export const MailLayoutOperationHandlerSet = OperationHandlerSet.lazy(() => import('./update-companion'));

--- a/packages/plugins/plugin-mail-layout/src/operations/update-companion.ts
+++ b/packages/plugins/plugin-mail-layout/src/operations/update-companion.ts
@@ -1,0 +1,17 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { LayoutOperation } from '@dxos/app-toolkit';
+import { Operation } from '@dxos/compute';
+
+// The mail layout doesn't have a companion plank — selection alone drives the
+// detail pane. Provide a no-op handler so `useShowItem`'s default-mode dispatch
+// resolves cleanly instead of throwing on an unhandled operation.
+const handler: Operation.WithHandler<typeof LayoutOperation.UpdateCompanion> = LayoutOperation.UpdateCompanion.pipe(
+  Operation.withHandler(Effect.fnUntraced(function* () {})),
+);
+
+export default handler;

--- a/packages/plugins/plugin-mail-layout/src/sanity.test.ts
+++ b/packages/plugins/plugin-mail-layout/src/sanity.test.ts
@@ -1,0 +1,11 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { expect, test } from 'vitest';
+
+// TODO(dmaretskyi): For some reason vitest hangs if there are no test files in a package.
+
+test('sanity', () => {
+  expect(true).toBe(true);
+});

--- a/packages/plugins/plugin-mail-layout/src/translations.ts
+++ b/packages/plugins/plugin-mail-layout/src/translations.ts
@@ -1,0 +1,18 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { type Resource } from '@dxos/react-ui';
+
+import { meta } from '#meta';
+
+export const translations = [
+  {
+    'en-US': {
+      [meta.profile.key]: {
+        'plugin.name': 'Mail Layout',
+        'detail.placeholder': 'Select a message to read.',
+      },
+    },
+  },
+] as const satisfies Resource[];

--- a/packages/plugins/plugin-mail-layout/tsconfig.json
+++ b/packages/plugins/plugin-mail-layout/tsconfig.json
@@ -1,0 +1,45 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": [
+    "dx.config.ts",
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../../common/log"
+    },
+    {
+      "path": "../../core/compute/compute"
+    },
+    {
+      "path": "../../core/echo/echo"
+    },
+    {
+      "path": "../../sdk/app-framework"
+    },
+    {
+      "path": "../../sdk/app-toolkit"
+    },
+    {
+      "path": "../../sdk/react-client"
+    },
+    {
+      "path": "../../sdk/types"
+    },
+    {
+      "path": "../../ui/react-ui"
+    },
+    {
+      "path": "../../ui/react-ui-attention"
+    },
+    {
+      "path": "../../ui/react-ui-mosaic"
+    },
+    {
+      "path": "../plugin-graph"
+    },
+    {
+      "path": "../plugin-inbox"
+    }
+  ]
+}

--- a/packages/plugins/plugin-mail-layout/vitest.config.ts
+++ b/packages/plugins/plugin-mail-layout/vitest.config.ts
@@ -1,0 +1,13 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createConfig } from '../../../vitest.base.config';
+
+export default createConfig({
+  dirname: typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url)),
+  node: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11528,9 +11528,6 @@ importers:
       '@dxos/types':
         specifier: workspace:*
         version: link:../../sdk/types
-      '@dxos/util':
-        specifier: workspace:*
-        version: link:../../common/util
       '@effect-atom/atom-react':
         specifier: 'catalog:'
         version: 0.5.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)(ioredis@5.3.2))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)(react@19.2.6)(scheduler@0.27.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2574,6 +2574,9 @@ importers:
       '@dxos/plugin-linear':
         specifier: workspace:*
         version: link:../../plugins/plugin-linear
+      '@dxos/plugin-mail-layout':
+        specifier: workspace:*
+        version: link:../../plugins/plugin-mail-layout
       '@dxos/plugin-map':
         specifier: workspace:*
         version: link:../../plugins/plugin-map
@@ -11486,6 +11489,70 @@ importers:
       '@dxos/plugin-testing':
         specifier: workspace:*
         version: link:../plugin-testing
+
+  packages/plugins/plugin-mail-layout:
+    dependencies:
+      '@dxos/app-framework':
+        specifier: workspace:*
+        version: link:../../sdk/app-framework
+      '@dxos/app-toolkit':
+        specifier: workspace:*
+        version: link:../../sdk/app-toolkit
+      '@dxos/compute':
+        specifier: workspace:*
+        version: link:../../core/compute/compute
+      '@dxos/echo':
+        specifier: workspace:*
+        version: link:../../core/echo/echo
+      '@dxos/log':
+        specifier: workspace:*
+        version: link:../../common/log
+      '@dxos/plugin-graph':
+        specifier: workspace:*
+        version: link:../plugin-graph
+      '@dxos/plugin-inbox':
+        specifier: workspace:*
+        version: link:../plugin-inbox
+      '@dxos/react-client':
+        specifier: workspace:*
+        version: link:../../sdk/react-client
+      '@dxos/react-ui':
+        specifier: workspace:*
+        version: link:../../ui/react-ui
+      '@dxos/react-ui-attention':
+        specifier: workspace:*
+        version: link:../../ui/react-ui-attention
+      '@dxos/react-ui-mosaic':
+        specifier: workspace:*
+        version: link:../../ui/react-ui-mosaic
+      '@dxos/types':
+        specifier: workspace:*
+        version: link:../../sdk/types
+      '@dxos/util':
+        specifier: workspace:*
+        version: link:../../common/util
+      '@effect-atom/atom-react':
+        specifier: 'catalog:'
+        version: 0.5.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)(ioredis@5.3.2))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)(react@19.2.6)(scheduler@0.27.0)
+      effect:
+        specifier: 3.21.3
+        version: 3.21.3
+    devDependencies:
+      '@types/react':
+        specifier: ~19.2.7
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ~19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      react:
+        specifier: ~19.2.3
+        version: 19.2.6
+      react-dom:
+        specifier: ~19.2.3
+        version: 19.2.6(react@19.2.6)
+      vite:
+        specifier: '>=8.0.16'
+        version: 8.0.16(@types/node@22.10.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/plugins/plugin-map:
     dependencies:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -715,6 +715,11 @@
         },
         {
           "type": "json",
+          "path": "packages/plugins/plugin-mail-layout/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "packages/plugins/plugin-map/package.json",
           "jsonpath": "$.version"
         },

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -412,6 +412,9 @@
       "path": "packages/plugins/plugin-linear/tsconfig.json"
     },
     {
+      "path": "packages/plugins/plugin-mail-layout/tsconfig.json"
+    },
+    {
       "path": "packages/plugins/plugin-map/tsconfig.json"
     },
     {


### PR DESCRIPTION
## Summary

Adds a second public entry point at `composer.space/mail` that boots the same Composer client (same `main.tsx`, plugin set, and worker services) but renders a stripped-down mail-only UI: no deck, no sidebars, no navtree.

- New `mail.html` Vite entry, wired into `vite.config.ts`; CF Pages clean-URLs serve `/mail` automatically.
- `main.tsx` reads `window.location.pathname` once at boot, sets `isMail` on `PluginConfig`.
- `plugin-defs.tsx` swaps the layout plugin (DeckPlugin → MailLayoutPlugin) when `isMail`, mirroring how `isPopover`/`isMobile` are handled. The rest of the plugin set is unchanged so `InboxPlugin`'s `MailboxArticle`/`MessageArticle` surfaces are reused.
- New `@dxos/plugin-mail-layout` package:
  - `Capabilities.ReactRoot` rendering a two-column grid (mailbox surface | message surface).
  - `AppCapabilities.Layout` with `mode: 'mail'`; publishes the personal-space path to `workspace` so `useActiveSpace()` (and plugin-integration's Gmail connect button) works correctly in empty-mailbox state.
  - A no-op `LayoutOperation.UpdateCompanion` handler so `useShowItem`'s default-mode dispatch resolves cleanly.
- `useEnsureMailbox` awaits an explicit `Query.run()` before creating a mailbox, preventing the duplicate-creation race that `useQuery` (which returns `[]` on first render) would cause.
- Selection uses `useSelection(contextId, 'single')` from `react-ui-attention` to drive the detail pane.
- Vite alias `@dxos/plugin-mail-layout → src/` allows the bundle build to resolve the package without a pre-built dist.

## Test plan

- [ ] `moon run plugin-mail-layout:build` – passes.
- [ ] `moon run composer-app:build` – passes.
- [ ] `moon run composer-app:bundle` – `out/composer/mail.html` emitted alongside `index.html`.
- [ ] `moon run :lint -- --fix` – no new lint issues.
- [ ] Local: `moon run composer-app:serve`, open `/mail.html`. With fresh profile: Mailbox auto-creates in personal space, two-pane layout renders (mailbox left, "Select a message to read." right), Gmail connect button visible.
- [ ] Clicking a message populates the right pane with `MessageArticle`. Clicking another swaps the detail.
- [ ] Opening `/` in another tab confirms the same auto-created Mailbox is visible (no duplicate creation).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4AyvBJJQbqMbjcKFF3gQz)_