### PR TITLE
chore(effect-zod): publish package publicly

### DIFF
--- a/packages/common/effect-zod/package.json
+++ b/packages/common/effect-zod/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/effect-zod",
   "version": "0.8.3",
-  "private": true,
   "description": "Convert Effect Schema definitions to Zod schemas. Useful when integrating with libraries that require Zod (e.g. the MCP SDK) while keeping Effect Schema as the source of truth.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
@@ -33,5 +32,8 @@
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary
- Remove `"private": true` and add `publishConfig.access=public` to [@dxos/effect-zod](packages/common/effect-zod/package.json) so the package can be published to npm.
- Required because [@dxos/introspect-mcp](packages/core/introspect-mcp/package.json) depends on `@dxos/effect-zod` and is itself publicly published; without this change consumers cannot install it.

The other dxos dependencies of `@dxos/introspect-mcp` (`@dxos/introspect`, `@dxos/introspect-tools`, `@dxos/log`, `@dxos/util`) are already public.

## Test plan
- [x] `moon run effect-zod:build`
- [x] `moon run effect-zod:test`
- [x] `moon run effect-zod:lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The `@dxos/effect-zod` package is now publicly available on npm for installation and use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->