### PR TITLE
fix(ci): repair Upload Introspect Cache workflow

### DIFF
--- a/.github/workflows/upload-introspect-cache.yml
+++ b/.github/workflows/upload-introspect-cache.yml
@@ -1,5 +1,3 @@
-# Workflow stub — copy into dxos/dxos/.github/workflows/upload-introspect-cache.yml.
-#
 # Builds the @dxos/introspect cache.json and uploads it to R2 so the
 # @dxos/introspect-service edge worker can read it. Triggers on push to the
 # `labs` branch; manual dispatch is also supported for ad-hoc reruns.
@@ -49,16 +47,15 @@ jobs:
       - name: Build symbol cache
         run: moon run introspect:index
 
-      - name: Install wrangler
-        run: npm install -g wrangler@4
-
+      # Use the workspace-pinned wrangler from the pnpm catalog (root devDep) —
+      # global `npm install -g` fails with EACCES inside the gh-actions container.
       - name: Upload to R2
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           ls -lh node_modules/.cache/dxos-introspect/cache.json
-          wrangler r2 object put \
+          pnpm exec wrangler r2 object put \
             dxos-introspect-cache/dxos/labs/cache.json \
             --file=node_modules/.cache/dxos-introspect/cache.json \
             --content-type=application/json \


### PR DESCRIPTION
## Summary

- Replace failing `npm install -g wrangler@4` with `pnpm exec wrangler` — the gh-actions container's non-root user can't write to `/usr/local/lib/node_modules`, and wrangler is already pinned in the pnpm catalog as a root devDep.
- Rename `upload-cache.workflow.yml` → `upload-introspect-cache.yml` (standard `.yml` convention) and drop the misleading "Workflow stub — copy into ..." preamble. GitHub Actions had been picking the file up as an active workflow all along regardless of the unusual naming.

## Why

Every run of **Upload Introspect Cache to R2** since 2026-05-07 has failed at the `Install wrangler` step:

```
npm error code EACCES
npm error path /usr/local/lib/node_modules/wrangler
npm error errno -13
```

The `introspect:index` step succeeds (~248 packages indexed in ~460s), but the artifact never reaches R2. As a result the `dxos-introspect-cache/dxos/labs/cache.json` object hasn't been refreshed in ~36h.

Recent failed runs:

| Run | Date |
|---|---|
| [25575876236](https://github.com/dxos/dxos/actions/runs/25575876236) | 2026-05-08 |
| [25525558246](https://github.com/dxos/dxos/actions/runs/25525558246) | 2026-05-07 |
| [25524660134](https://github.com/dxos/dxos/actions/runs/25524660134) | 2026-05-07 |
| [25515570072](https://github.com/dxos/dxos/actions/runs/25515570072) | 2026-05-07 |

## Test plan

- [ ] CI green on this branch (the renamed workflow only fires on push to `labs`, so it won't run here — main `Check` workflow must still pass).
- [ ] After merge to main, merge to `labs` and verify the renamed workflow uploads `cache.json` to R2 successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the introspect cache upload workflow to use workspace-pinned package tooling instead of global installation, improving build process reliability and resolving permission issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->