### PR TITLE
docs(composer-plugins): point skill at dxos-introspect MCP

### DIFF
--- a/.agents/skills/composer-plugins/SKILL.md
+++ b/.agents/skills/composer-plugins/SKILL.md
@@ -9,6 +9,18 @@ description: Use when working on files in packages/plugins/, adding new plugins,
 
 Exemplar: `packages/plugins/plugin-chess`. Read its source files to understand every pattern below.
 
+## Discovery
+
+Use the `dxos-introspect` MCP server as the source of truth for plugin metadata — not directory listings.
+A "plugin" is a package whose `src/meta.ts` exports a `Plugin.Meta`, so `ls packages/plugins/` overcounts (e.g. `plugin-spec` is tooling, not a plugin).
+
+- `mcp__dxos-introspect__list_plugins` — enumerate plugins (filter by `id` substring; pass `compact: true` for identifying fields only).
+- `mcp__dxos-introspect__get_package` — package details for a given plugin.
+- `mcp__dxos-introspect__list_surfaces` / `list_capabilities` / `list_operations` / `list_schemas` — drill into a plugin's contributions.
+- `mcp__dxos-introspect__find_symbol` / `get_symbol` / `list_symbols` — locate code by symbol rather than grepping paths.
+
+Reach for these first when answering questions like "how many plugins", "which plugin contributes X surface", or "where is symbol Y defined".
+
 ## Specification
 
 Each plugin MUST have a `PLUGIN.mdl` specification written in the MDL language defined by `plugin-spec` (see `packages/plugins/plugin-spec/docs/` and `src/extension/mdl.grammar` for syntax).

--- a/packages/core/echo/echo/src/exemplars.test.ts
+++ b/packages/core/echo/echo/src/exemplars.test.ts
@@ -10,7 +10,7 @@ import type * as Type from './Type';
 
 describe('Exemplars', () => {
   test('factory', ({ expect }) => {
-    const factory = <S extends Type.Obj.Any>(schema: S) => {
+    const factory = <S extends Type.AnyObj>(schema: S) => {
       return (props: Obj.MakeProps<S>) => Obj.make(schema, props);
     };
 

--- a/packages/plugins/plugin-status-bar/src/containers/VersionNumber/VersionNumber.tsx
+++ b/packages/plugins/plugin-status-bar/src/containers/VersionNumber/VersionNumber.tsx
@@ -37,7 +37,7 @@ export const VersionNumber = (_props: VersionNumberProps) => {
       </Popover.Trigger>
       <Popover.Portal>
         <Popover.Content side='top' role='message' classNames='z-[12] max-w-[min(calc(100vw-16px),40ch)]'>
-          <Message.Root valence='info' classNames='rounded-b-none p-4'>
+          <Message.Root valence='info' classNames='p-2 rounded-b-none'>
             <Message.Title>{t('warning.title')}</Message.Title>
             <Message.Content>
               {t('technology-preview.message')}
@@ -48,7 +48,7 @@ export const VersionNumber = (_props: VersionNumberProps) => {
               </Link>
             </Message.Content>
           </Message.Root>
-          <div role='none' className='flex flex-col ps-9 pe-4 py-2 gap-1 space-b-2 text-base-surface-text'>
+          <div role='none' className='flex flex-col ps-10 pe-4 py-2 gap-1 space-b-2 text-base-surface-text'>
             {timestamp && (
               <div>
                 <p>

--- a/packages/ui/react-ui-introspect/src/components/ToolsExplorer/ToolsExplorer.tsx
+++ b/packages/ui/react-ui-introspect/src/components/ToolsExplorer/ToolsExplorer.tsx
@@ -8,7 +8,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { MAX_LIST_LIMIT, TOOL_METADATA, type PickerKind } from '@dxos/introspect-tools';
 import { Message, useTranslation, type ThemedClassName } from '@dxos/react-ui';
-import { composable, composableProps } from '@dxos/ui-theme';
+import { composable, composableProps, mx } from '@dxos/ui-theme';
 
 import { translationKey } from '#translations';
 
@@ -136,7 +136,10 @@ export const ToolsExplorer = composable<HTMLDivElement, ToolsExplorerProps>(
         {...composableProps(props, { classNames: 'dx-container grid grid-cols-[30rem_1fr] divide-x divide-separator' })}
         ref={forwardedRef}
       >
-        <div role='none' className='dx-container grid grid-rows-[2fr_3fr] divide-y divide-separator'>
+        <div
+          role='none'
+          className={mx('dx-container grid divide-y divide-separator', selectedTool && 'grid-rows-[2fr_3fr]')}
+        >
           <ToolList tools={TOOL_METADATA} selected={selected} onSelect={handleSelect} />
           {selectedTool && <ToolForm tool={selectedTool} onSubmit={handleSubmit} pickerOptions={pickerOptions} />}
         </div>


### PR DESCRIPTION
## Summary

- Add **Discovery** section to `.agents/skills/composer-plugins/SKILL.md` directing agents to the `dxos-introspect` MCP tools (`list_plugins`, `get_package`, `list_surfaces`, `list_capabilities`, `list_operations`, `list_schemas`, `find_symbol`/`get_symbol`/`list_symbols`) as the source of truth for plugin metadata.
- Note that `ls packages/plugins/` overcounts — a "plugin" is a package that exports `Plugin.Meta` from `src/meta.ts`, so tooling packages like `plugin-spec` get included otherwise.
- Minor `VersionNumber` popover padding tweaks (`p-4` → `p-2` on `Message.Root`, `ps-9` → `ps-10` on the metadata block) for tighter alignment.

## Why

When asked "how many composer plugins are there?", the natural answer is `mcp__dxos-introspect__list_plugins` — but the skill didn't mention the MCP, so agents fall back to directory listings and get the wrong number. The skill is the right place to make discovery the default reflex.

## Test plan

- [ ] Skill renders correctly in the agent's skill index.
- [ ] Future plugin-related questions reach for the introspect MCP first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Discovery section to the composer-plugins skill guide with instructions for using the MCP server to retrieve and inspect plugin metadata.

* **Style**
  * Adjusted padding in the status bar version popover display.
  * Updated tools explorer layout to conditionally change grid row sizing when a tool is selected.

* **Tests**
  * Tightened a type constraint in a test helper utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->