### PR TITLE
fix(phoenix): unquarantine start/stop detached watchdog test

### DIFF
--- a/packages/common/phoenix/moon.yml
+++ b/packages/common/phoenix/moon.yml
@@ -10,3 +10,9 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--platform=node'
       - '--injectGlobals'
+  # `bin/watchdog.mjs` imports from `../dist/lib/node-esm/index.mjs`, so the
+  # package's own dist must exist before tests run. The inherited `:test` task
+  # only depends on upstream compile (`^:compile`), not the package's own.
+  test:
+    deps:
+      - ~:compile

--- a/packages/common/phoenix/src/phoenix.node.test.ts
+++ b/packages/common/phoenix/src/phoenix.node.test.ts
@@ -3,7 +3,7 @@
 //
 
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, onTestFinished, test } from 'vitest';
 
@@ -24,9 +24,7 @@ describe.skipIf(process.env.CI)('DaemonManager', () => {
     await trigger.wait({ timeout: 1_000 });
   });
 
-  // Quarantined: flaky on CI (timeout starting the detached watchdog process under
-  // the moon test runner). Local runs still cover the suite during development.
-  test.skip('start/stop detached watchdog', async () => {
+  test('start/stop detached watchdog', async () => {
     const runId = Math.random().toString();
     const pidFile = join(TEST_DIR, `pid-${runId}.pid`);
     const logFile = join(TEST_DIR, `file-${runId}.log`);
@@ -45,9 +43,11 @@ describe.skipIf(process.env.CI)('DaemonManager', () => {
         errFile,
       });
 
-      await expect.poll(() => existsSync(params.logFile), { timeout: 1000 }).toBe(true);
-      const logs = readFileSync(params.logFile, { encoding: 'utf-8' });
-      expect(logs).to.contain('neverEndingProcess started');
+      // Poll for log content directly — the file is pre-created empty by Phoenix.start(),
+      // so polling for existence would resolve immediately before the child writes its output.
+      await expect
+        .poll(() => readFileSync(params.logFile, { encoding: 'utf-8' }), { timeout: 5000 })
+        .toContain('neverEndingProcess started');
     }
 
     // Stop


### PR DESCRIPTION
## Summary

- Adds `~:compile` to the phoenix test task deps so `bin/watchdog.mjs` can find `../dist/lib/node-esm/index.mjs` (the package's own built output) before vitest starts — same pattern already used by `network-manager`.
- Fixes a race condition in the test: the log file is pre-created empty by `Phoenix.start()`, so polling for its *existence* resolved immediately before the child process had written anything. Now polls for the actual log *content* with a 5 s timeout.
- Removes `test.skip` quarantine added in #11258.

## Root cause

`bin/watchdog.mjs` is a plain `.mjs` script that imports `WatchDog` from the compiled dist:
```js
import { WatchDog } from '../dist/lib/node-esm/index.mjs';
```
The inherited `:test` task only runs `^:compile` (upstream deps), not `~:compile` (the package itself). Without the dist, the forked watchdog process exits immediately, `waitForPidFileBeingFilledWithInfo` waits the full 10 s, and the test times out.

## Test plan

- [x] `moon run phoenix:compile` — green
- [x] `moon run phoenix:test` — all 3 tests pass including `start/stop detached watchdog` (467 ms)

https://claude.ai/code/session_01AL3tYbFEtTUpfy6bxQa1K1

---
_Generated by [Claude Code](https://claude.ai/code/session_01AL3tYbFEtTUpfy6bxQa1K1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by refactoring daemon manager test assertions and polling mechanisms.

* **Chores**
  * Updated workspace configuration to establish proper task dependencies for test execution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11286)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->