### PR TITLE
feat(plugin-linear,plugin-github): bidirectional project + task sync

### DIFF
--- a/packages/plugins/plugin-github/src/operations/sync.test.ts
+++ b/packages/plugins/plugin-github/src/operations/sync.test.ts
@@ -1,0 +1,265 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import { afterEach, beforeEach, describe, test } from 'vitest';
+
+import { Database, Obj, Ref } from '@dxos/echo';
+import { EchoTestBuilder } from '@dxos/echo-db/testing';
+import { runAndForwardErrors } from '@dxos/effect';
+import { Integration } from '@dxos/plugin-integration/types';
+import { AccessToken, Organization, Person, Project, Task } from '@dxos/types';
+
+import { GITHUB_SOURCE } from '../constants';
+import { GitHubApi } from '../services';
+import { pushRepoUpdates } from './sync';
+
+const repo = (overrides: Partial<GitHubApi.GitHubRepo> = {}): GitHubApi.GitHubRepo => ({
+  id: 1234,
+  name: 'composer',
+  full_name: 'dxos/composer',
+  description: 'composer monorepo',
+  owner: { id: 1, login: 'dxos' },
+  ...overrides,
+});
+
+const issue = (overrides: Partial<GitHubApi.GitHubIssue> = {}): GitHubApi.GitHubIssue => ({
+  id: 5678,
+  number: 42,
+  title: 'Investigate flake',
+  body: 'desc',
+  state: 'open',
+  ...overrides,
+});
+
+describe('plugin-github sync — push (snapshot diff → PATCH)', () => {
+  let builder: EchoTestBuilder;
+
+  beforeEach(async () => {
+    builder = await new EchoTestBuilder().open();
+  });
+
+  afterEach(async () => {
+    await builder.close();
+  });
+
+  const setup = async () => {
+    const { db, graph } = await builder.createDatabase();
+    await graph.schemaRegistry.register([
+      AccessToken.AccessToken,
+      Integration.Integration,
+      Organization.Organization,
+      Person.Person,
+      Project.Project,
+      Task.Task,
+    ]);
+    const token = db.add(Obj.make(AccessToken.AccessToken, { source: GITHUB_SOURCE, token: 'tok' }));
+    const integration = db.add(Obj.make(Integration.Integration, { accessToken: Ref.make(token), targets: [] }));
+    return { db, integration };
+  };
+
+  test('locally-edited issue title PATCHes only diverged fields', async ({ expect }) => {
+    const { db, integration } = await setup();
+
+    // Seed snapshot + local task as if a previous pull had run.
+    Obj.update(integration, (integration) => {
+      const m = integration as Obj.Mutable<typeof integration>;
+      m.snapshots = {
+        '5678': { title: 'Investigate flake', description: 'desc', status: 'todo' },
+      };
+    });
+    const localTask = db.add(
+      Task.make({
+        [Obj.Meta]: { keys: [{ source: GITHUB_SOURCE, id: '5678' }] },
+        title: 'Edited locally',
+        description: 'desc',
+        status: 'todo',
+      }),
+    );
+
+    let updateIssueInput: GitHubApi.IssueUpdateInput | undefined;
+    let updateIssueNumber: number | undefined;
+    const result = await Effect.gen(function* () {
+      return yield* pushRepoUpdates(integration, repo(), new Map([['5678', issue()]]), {
+        updateIssue: (_owner, _repo, num, input) => {
+          updateIssueInput = input;
+          updateIssueNumber = num;
+          return Effect.succeed(undefined);
+        },
+        updateRepo: () => Effect.succeed(undefined),
+      });
+    }).pipe(Effect.provide(Database.layer(db)), runAndForwardErrors);
+
+    expect(result.tasks).toBe(1);
+    expect(updateIssueNumber).toBe(42);
+    expect(updateIssueInput).toEqual({ title: 'Edited locally' });
+    // Snapshot refreshed.
+    const snapshots = (integration.snapshots ?? {}) as Record<string, any>;
+    expect(snapshots['5678']?.title).toBe('Edited locally');
+    void localTask;
+  });
+
+  test('snapshot-equal task is not pushed', async ({ expect }) => {
+    const { db, integration } = await setup();
+
+    Obj.update(integration, (integration) => {
+      const m = integration as Obj.Mutable<typeof integration>;
+      m.snapshots = {
+        '5678': { title: 'Investigate flake', description: 'desc', status: 'todo' },
+      };
+    });
+    db.add(
+      Task.make({
+        [Obj.Meta]: { keys: [{ source: GITHUB_SOURCE, id: '5678' }] },
+        title: 'Investigate flake',
+        description: 'desc',
+        status: 'todo',
+      }),
+    );
+
+    let calls = 0;
+    const result = await Effect.gen(function* () {
+      return yield* pushRepoUpdates(integration, repo(), new Map([['5678', issue()]]), {
+        updateIssue: () => {
+          calls++;
+          return Effect.succeed(undefined);
+        },
+        updateRepo: () => Effect.succeed(undefined),
+      });
+    }).pipe(Effect.provide(Database.layer(db)), runAndForwardErrors);
+
+    expect(result.tasks).toBe(0);
+    expect(calls).toBe(0);
+  });
+
+  test('local status flip → PATCH state', async ({ expect }) => {
+    const { db, integration } = await setup();
+
+    Obj.update(integration, (integration) => {
+      const m = integration as Obj.Mutable<typeof integration>;
+      m.snapshots = {
+        '5678': { title: 'Investigate flake', description: 'desc', status: 'todo' },
+      };
+    });
+    db.add(
+      Task.make({
+        [Obj.Meta]: { keys: [{ source: GITHUB_SOURCE, id: '5678' }] },
+        title: 'Investigate flake',
+        description: 'desc',
+        status: 'done',
+      }),
+    );
+
+    let updateIssueInput: GitHubApi.IssueUpdateInput | undefined;
+    await Effect.gen(function* () {
+      yield* pushRepoUpdates(integration, repo(), new Map([['5678', issue()]]), {
+        updateIssue: (_owner, _repo, _num, input) => {
+          updateIssueInput = input;
+          return Effect.succeed(undefined);
+        },
+        updateRepo: () => Effect.succeed(undefined),
+      });
+    }).pipe(Effect.provide(Database.layer(db)), runAndForwardErrors);
+
+    expect(updateIssueInput?.state).toBe('closed');
+  });
+
+  test('locally-edited repo description → PATCH /repos', async ({ expect }) => {
+    const { db, integration } = await setup();
+
+    Obj.update(integration, (integration) => {
+      const m = integration as Obj.Mutable<typeof integration>;
+      m.snapshots = {
+        '1234': { name: 'dxos/composer', description: 'composer monorepo' },
+      };
+    });
+    db.add(
+      Obj.make(Project.Project, {
+        [Obj.Meta]: { keys: [{ source: GITHUB_SOURCE, id: '1234' }] },
+        name: 'dxos/composer',
+        description: 'rewritten',
+      }),
+    );
+
+    let updateRepoInput: GitHubApi.RepoUpdateInput | undefined;
+    const result = await Effect.gen(function* () {
+      return yield* pushRepoUpdates(integration, repo(), new Map(), {
+        updateIssue: () => Effect.succeed(undefined),
+        updateRepo: (_owner, _repo, input) => {
+          updateRepoInput = input;
+          return Effect.succeed(undefined);
+        },
+      });
+    }).pipe(Effect.provide(Database.layer(db)), runAndForwardErrors);
+
+    expect(result.projects).toBe(1);
+    expect(updateRepoInput).toEqual({ description: 'rewritten' });
+  });
+
+  test('repo rename diverges locally → logged but NOT pushed', async ({ expect }) => {
+    const { db, integration } = await setup();
+
+    Obj.update(integration, (integration) => {
+      const m = integration as Obj.Mutable<typeof integration>;
+      m.snapshots = {
+        '1234': { name: 'dxos/composer', description: 'composer monorepo' },
+      };
+    });
+    db.add(
+      Obj.make(Project.Project, {
+        [Obj.Meta]: { keys: [{ source: GITHUB_SOURCE, id: '1234' }] },
+        name: 'dxos/composer-renamed',
+        description: 'composer monorepo',
+      }),
+    );
+
+    let calls = 0;
+    const result = await Effect.gen(function* () {
+      return yield* pushRepoUpdates(integration, repo(), new Map(), {
+        updateIssue: () => Effect.succeed(undefined),
+        updateRepo: () => {
+          calls++;
+          return Effect.succeed(undefined);
+        },
+      });
+    }).pipe(Effect.provide(Database.layer(db)), runAndForwardErrors);
+
+    expect(result.projects).toBe(0);
+    expect(calls).toBe(0);
+  });
+
+  test('soft-deleted local task is not pushed', async ({ expect }) => {
+    const { db, integration } = await setup();
+
+    Obj.update(integration, (integration) => {
+      const m = integration as Obj.Mutable<typeof integration>;
+      m.snapshots = {
+        '5678': { title: 'orig', description: '', status: 'todo' },
+      };
+    });
+    const task = db.add(
+      Task.make({
+        [Obj.Meta]: { keys: [{ source: GITHUB_SOURCE, id: '5678' }] },
+        title: 'edited locally',
+        description: '',
+        status: 'todo',
+      }),
+    );
+    await db.remove(task);
+
+    let calls = 0;
+    const result = await Effect.gen(function* () {
+      return yield* pushRepoUpdates(integration, repo(), new Map([['5678', issue()]]), {
+        updateIssue: () => {
+          calls++;
+          return Effect.succeed(undefined);
+        },
+        updateRepo: () => Effect.succeed(undefined),
+      });
+    }).pipe(Effect.provide(Database.layer(db)), runAndForwardErrors);
+
+    expect(result.tasks).toBe(0);
+    expect(calls).toBe(0);
+  });
+});

--- a/packages/plugins/plugin-github/src/operations/sync.test.ts
+++ b/packages/plugins/plugin-github/src/operations/sync.test.ts
@@ -64,8 +64,7 @@ describe('plugin-github sync — push (snapshot diff → PATCH)', () => {
 
     // Seed snapshot + local task as if a previous pull had run.
     Obj.update(integration, (integration) => {
-      const m = integration as Obj.Mutable<typeof integration>;
-      m.snapshots = {
+      integration.snapshots = {
         '5678': { title: 'Investigate flake', description: 'desc', status: 'todo' },
       };
     });
@@ -104,8 +103,7 @@ describe('plugin-github sync — push (snapshot diff → PATCH)', () => {
     const { db, integration } = await setup();
 
     Obj.update(integration, (integration) => {
-      const m = integration as Obj.Mutable<typeof integration>;
-      m.snapshots = {
+      integration.snapshots = {
         '5678': { title: 'Investigate flake', description: 'desc', status: 'todo' },
       };
     });
@@ -137,8 +135,7 @@ describe('plugin-github sync — push (snapshot diff → PATCH)', () => {
     const { db, integration } = await setup();
 
     Obj.update(integration, (integration) => {
-      const m = integration as Obj.Mutable<typeof integration>;
-      m.snapshots = {
+      integration.snapshots = {
         '5678': { title: 'Investigate flake', description: 'desc', status: 'todo' },
       };
     });
@@ -169,8 +166,7 @@ describe('plugin-github sync — push (snapshot diff → PATCH)', () => {
     const { db, integration } = await setup();
 
     Obj.update(integration, (integration) => {
-      const m = integration as Obj.Mutable<typeof integration>;
-      m.snapshots = {
+      integration.snapshots = {
         '1234': { name: 'dxos/composer', description: 'composer monorepo' },
       };
     });
@@ -201,8 +197,7 @@ describe('plugin-github sync — push (snapshot diff → PATCH)', () => {
     const { db, integration } = await setup();
 
     Obj.update(integration, (integration) => {
-      const m = integration as Obj.Mutable<typeof integration>;
-      m.snapshots = {
+      integration.snapshots = {
         '1234': { name: 'dxos/composer', description: 'composer monorepo' },
       };
     });
@@ -233,8 +228,7 @@ describe('plugin-github sync — push (snapshot diff → PATCH)', () => {
     const { db, integration } = await setup();
 
     Obj.update(integration, (integration) => {
-      const m = integration as Obj.Mutable<typeof integration>;
-      m.snapshots = {
+      integration.snapshots = {
         '5678': { title: 'orig', description: '', status: 'todo' },
       };
     });

--- a/packages/plugins/plugin-github/src/operations/sync.test.ts
+++ b/packages/plugins/plugin-github/src/operations/sync.test.ts
@@ -266,6 +266,11 @@ describe('plugin-github sync — push (snapshot diff → PATCH)', () => {
     expect(result.tasks).toBe(0);
     expect(calls).toBe(0);
     expect(updateIssueInput).toBeUndefined();
+    // Snapshot status stays at the previous remote-pulled value so the
+    // divergence warning keeps firing each sync until either the user
+    // reverts locally or GitHub catches up.
+    const snapshots = (integration.snapshots ?? {}) as Record<string, any>;
+    expect(snapshots['5678']?.status).toBe('todo');
   });
 
   test('PR title divergence still pushes (only status is pull-only)', async ({ expect }) => {

--- a/packages/plugins/plugin-github/src/operations/sync.test.ts
+++ b/packages/plugins/plugin-github/src/operations/sync.test.ts
@@ -224,6 +224,86 @@ describe('plugin-github sync — push (snapshot diff → PATCH)', () => {
     expect(calls).toBe(0);
   });
 
+  test('PR status divergence is NOT pushed (status is pull-only for PRs)', async ({ expect }) => {
+    // GitHub's /issues/{n} endpoint accepts state changes for both issues and
+    // PRs, but `closed` on a PR rejects it (closed-without-merge). The push
+    // path skips status changes for PRs and logs instead.
+    const { db, integration } = await setup();
+
+    Obj.update(integration, (integration) => {
+      integration.snapshots = {
+        '5678': { title: 'fix flake', description: 'desc', status: 'todo' },
+      };
+    });
+    db.add(
+      Task.make({
+        [Obj.Meta]: { keys: [{ source: GITHUB_SOURCE, id: '5678' }] },
+        title: 'fix flake',
+        description: 'desc',
+        status: 'done',
+      }),
+    );
+
+    const pullRequestIssue = issue({
+      pull_request: { url: 'https://api.github.com/repos/dxos/dxos/pulls/42', merged_at: null },
+    });
+
+    let updateIssueInput: GitHubApi.IssueUpdateInput | undefined;
+    let calls = 0;
+    const result = await Effect.gen(function* () {
+      return yield* pushRepoUpdates(integration, repo(), new Map([['5678', pullRequestIssue]]), {
+        updateIssue: (_owner, _repo, _num, input) => {
+          calls++;
+          updateIssueInput = input;
+          return Effect.succeed(undefined);
+        },
+        updateRepo: () => Effect.succeed(undefined),
+      });
+    }).pipe(Effect.provide(Database.layer(db)), runAndForwardErrors);
+
+    // No task push (status was the only diverging field, and PR status is
+    // pull-only).
+    expect(result.tasks).toBe(0);
+    expect(calls).toBe(0);
+    expect(updateIssueInput).toBeUndefined();
+  });
+
+  test('PR title divergence still pushes (only status is pull-only)', async ({ expect }) => {
+    const { db, integration } = await setup();
+
+    Obj.update(integration, (integration) => {
+      integration.snapshots = {
+        '5678': { title: 'fix flake', description: 'desc', status: 'todo' },
+      };
+    });
+    db.add(
+      Task.make({
+        [Obj.Meta]: { keys: [{ source: GITHUB_SOURCE, id: '5678' }] },
+        title: 'fix flake (renamed)',
+        description: 'desc',
+        status: 'todo',
+      }),
+    );
+
+    const pullRequestIssue = issue({
+      pull_request: { url: 'https://api.github.com/repos/dxos/dxos/pulls/42', merged_at: null },
+    });
+
+    let updateIssueInput: GitHubApi.IssueUpdateInput | undefined;
+    await Effect.gen(function* () {
+      yield* pushRepoUpdates(integration, repo(), new Map([['5678', pullRequestIssue]]), {
+        updateIssue: (_owner, _repo, _num, input) => {
+          updateIssueInput = input;
+          return Effect.succeed(undefined);
+        },
+        updateRepo: () => Effect.succeed(undefined),
+      });
+    }).pipe(Effect.provide(Database.layer(db)), runAndForwardErrors);
+
+    expect(updateIssueInput).toEqual({ title: 'fix flake (renamed)' });
+    expect(updateIssueInput?.state).toBeUndefined();
+  });
+
   test('soft-deleted local task is not pushed', async ({ expect }) => {
     const { db, integration } = await setup();
 

--- a/packages/plugins/plugin-github/src/operations/sync.ts
+++ b/packages/plugins/plugin-github/src/operations/sync.ts
@@ -652,7 +652,7 @@ const handler: Operation.WithHandler<typeof SyncGitHubRepositories> = SyncGitHub
                     // for this target so partial progress on other targets
                     // is preserved.
                     //
-                    // TODO(burdon): `remoteIssuesById` is built from
+                    // TODO(wittjosiah): `remoteIssuesById` is built from
                     //   `fetchRepoIssues(..., { since })`, so when
                     //   `maxDaysBack` is set this push pass cannot see
                     //   locally-edited tasks whose remote issue is older

--- a/packages/plugins/plugin-github/src/operations/sync.ts
+++ b/packages/plugins/plugin-github/src/operations/sync.ts
@@ -6,11 +6,11 @@ import * as FetchHttpClient from '@effect/platform/FetchHttpClient';
 import * as Effect from 'effect/Effect';
 import type * as Schema from 'effect/Schema';
 
-import { LayoutOperation } from '@dxos/app-toolkit';
+import { LayoutOperation, mergeField, readSnapshot, writeSnapshot } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
 import { Database, Filter, Obj, Query, Ref } from '@dxos/echo';
 import { log } from '@dxos/log';
-import { Actor, Message, Organization, Person, Project, Task, Thread } from '@dxos/types';
+import { Organization, Person, Project, Task } from '@dxos/types';
 
 import { meta } from '#meta';
 
@@ -20,25 +20,37 @@ import { GitHubApi } from '../services';
 import { type SyncOptions, SyncGitHubRepositories } from './definitions';
 
 //
-// Direction: pull-only.
+// Direction: bidirectional (pull-then-push) for projects and tasks.
 //
-// v1 of this plugin pulls Organization, Person, Project, Task (issue/PR), and
-// Thread/Message (comments) from GitHub into ECHO and never writes back. Push
-// is intentionally deferred — the open question is attribution: a user-to-server
-// OAuth token attributes any write to the authorizing user, which is wrong in
-// shared spaces; an installation token attributes to the GitHub App with body-
-// prefix attribution but needs server-side minting (KMS). Both options are real
-// follow-ups but neither is in scope here.
+// Each sync pass first pulls every reachable Organization, Person, Project,
+// and Task from GitHub into ECHO, then walks the local mirrors and pushes
+// any field that diverged from the snapshot taken at the end of the previous
+// pull. Snapshots live on `Integration.snapshots[<github id>]` (where ids
+// are the GitHub-issued numeric ids, stringified for stable foreign-key
+// matching).
 //
-// Practical consequence: local edits to mapped fields (Task.title,
-// Task.description, Task.status, Org.name, etc.) are overwritten by the remote
-// value on every sync. Local edits to NON-mapped fields (Task.priority,
-// Task.estimate, Task.project, Person.notes, etc.) are preserved.
+// Mapped fields per object:
+//   Project (repo): description (description-only — see updateRepo for why
+//                   `name` is intentionally not pushed)
+//   Task (issue):   title, description, status (open/closed)
 //
-// Sync target shape: the user picks REPOSITORIES. The repos' owning orgs (and
-// org members) are auto-pulled — a single Organization per unique owner across
-// the selected repos, deduped within one sync pass. The user does not pick
-// orgs directly.
+// Conflict policy is remote-wins (mirrors Trello/Linear). Comments are NOT
+// synced (the chunked-yield rewrite is still pending; see TODO below).
+//
+// Attribution caveat: pushed edits are attributed to the GitHub App / OAuth
+// user that owns the integration token, not to the local user who made the
+// edit. This is unavoidable with the current token model — a write from
+// "Person A in space" appears on GitHub as a write from the App. Document
+// before enabling for shared spaces.
+//
+// New local objects (no GitHub foreign key) are NOT pushed in this pass —
+// creating a new GitHub issue requires (owner, repo) which we currently
+// don't surface from local Tasks unambiguously.
+//
+// Sync target shape: the user picks REPOSITORIES. The repos' owning orgs
+// (and org members) are auto-pulled — a single Organization per unique owner
+// across the selected repos, deduped within one sync pass. The user does
+// not pick orgs directly.
 //
 
 //
@@ -48,6 +60,23 @@ import { type SyncOptions, SyncGitHubRepositories } from './definitions';
 /** Per-target parallelism across selected repos. */
 const REPO_CONCURRENCY = 4;
 const ISSUE_CONCURRENCY = 4;
+
+//
+// Snapshot field shapes (stored on `Integration.snapshots`)
+//
+
+/** Snapshot for a GitHub repo (mirrored as a Project locally). `name` is read but not pushed. */
+type ProjectSnapshot = {
+  name?: string;
+  description?: string;
+};
+
+/** Snapshot for a GitHub issue (mirrored as a Task locally). */
+type TaskSnapshot = {
+  title?: string;
+  description?: string;
+  status?: 'todo' | 'done';
+};
 
 //
 // Foreign-key + lookup helpers
@@ -67,7 +96,7 @@ const findByForeignId = <T>(schema: Schema.Schema<any, any>, id: string | number
   });
 
 //
-// Field mappers (GitHub → DXOS)
+// Field mappers (GitHub ↔ DXOS)
 //
 
 /**
@@ -78,6 +107,23 @@ const findByForeignId = <T>(schema: Schema.Schema<any, any>, id: string | number
  */
 const issueStateToTaskStatus = (state: string): 'todo' | 'done' => (state === 'closed' ? 'done' : 'todo');
 
+/**
+ * Reverse of {@link issueStateToTaskStatus}. `'in-progress'` is collapsed to
+ * `open` since GitHub has no equivalent state. Returns undefined when the
+ * status is unrecognised so the caller can skip the push instead of failing.
+ */
+const taskStatusToIssueState = (status: string | undefined): 'open' | 'closed' | undefined => {
+  switch (status) {
+    case 'done':
+      return 'closed';
+    case 'todo':
+    case 'in-progress':
+      return 'open';
+    default:
+      return undefined;
+  }
+};
+
 const sinceFromOptions = (options: SyncOptions | undefined): string | undefined => {
   const days = options?.maxDaysBack;
   if (typeof days !== 'number' || days <= 0) {
@@ -87,7 +133,7 @@ const sinceFromOptions = (options: SyncOptions | undefined): string | undefined 
 };
 
 //
-// Upsert helpers (all pull-only)
+// Pull (snapshot-driven three-way merge for Project + Task; simple upsert for Org/Person)
 //
 
 const upsertOrganization = Effect.fn('upsertOrganization')(function* (org: GitHubApi.GitHubOrg) {
@@ -149,55 +195,116 @@ const upsertPerson = Effect.fn('upsertPerson')(function* (
   return yield* Database.add(created);
 });
 
-const upsertProject = Effect.fn('upsertProject')(function* (repo: GitHubApi.GitHubRepo) {
+/**
+ * Pull a GitHub repo into ECHO as a Project. Mapped fields go through
+ * three-way merge against `integration.snapshots[<repo id>]`; the snapshot
+ * is then refreshed to remote-current so the next push pass sees only
+ * fields the user has edited locally. `name` is recorded in the snapshot
+ * (so we can detect divergence) but is not pushed back — see
+ * {@link GitHubApi.updateRepo}.
+ */
+const upsertProject = Effect.fn('upsertProject')(function* (
+  integration: Obj.Unknown & { snapshots?: Record<string, unknown> },
+  repo: GitHubApi.GitHubRepo,
+) {
+  const remoteFields: Required<ProjectSnapshot> = {
+    name: repo.full_name,
+    description: repo.description ?? '',
+  };
+  const fid = String(repo.id);
   const existing = yield* findByForeignId<Project.Project>(Project.Project, repo.id);
+
   if (existing) {
-    Obj.update(existing, (existing) => {
-      existing.name = repo.full_name;
-      if (repo.description != null) {
-        existing.description = repo.description;
+    const snapshot = readSnapshot<ProjectSnapshot>(integration, fid) ?? {};
+    const local = existing as unknown as Record<string, unknown>;
+    const writes: Partial<typeof remoteFields> = {};
+    for (const key of ['name', 'description'] as const) {
+      const result = mergeField(local[key] as string | undefined, remoteFields[key], snapshot[key]);
+      if (result.source === 'remote' && local[key] !== result.value) {
+        writes[key] = result.value;
       }
-    });
+    }
+    if (Object.keys(writes).length > 0) {
+      Obj.update(existing, (existing) => {
+        const m = existing as unknown as Record<string, unknown>;
+        for (const [k, v] of Object.entries(writes)) {
+          m[k] = v;
+        }
+      });
+    }
+    writeSnapshot(integration, fid, remoteFields);
     return existing;
   }
+
   const created = Obj.make(Project.Project, {
     [Obj.Meta]: { keys: [fkFor(repo.id)] },
     name: repo.full_name,
     description: repo.description ?? undefined,
   });
-  return yield* Database.add(created);
+  const persisted = yield* Database.add(created);
+  writeSnapshot(integration, fid, remoteFields);
+  return persisted;
 });
 
 /**
- * Pull-only upsert for issue/PR → Task. Mapped fields (title, description,
- * status) are overwritten by remote on every sync; non-mapped fields (priority,
- * estimate, etc.) are preserved.
+ * Pull a GitHub issue into ECHO as a Task. Same merge shape as
+ * {@link upsertProject}, against snapshot fields {title, description, status}.
+ * Non-mapped fields (`Task.priority`, `Task.estimate`, etc.) are preserved.
  */
 const upsertTask = Effect.fn('upsertTask')(function* (
+  integration: Obj.Unknown & { snapshots?: Record<string, unknown> },
   issue: GitHubApi.GitHubIssue,
   assignedPerson: Person.Person | undefined,
   project: Project.Project,
 ) {
+  const remoteFields: Required<TaskSnapshot> = {
+    title: issue.title,
+    description: issue.body ?? '',
+    status: issueStateToTaskStatus(issue.state),
+  };
+  const fid = String(issue.id);
   const existing = yield* findByForeignId<Task.Task>(Task.Task, issue.id);
+
   if (existing) {
+    const snapshot = readSnapshot<TaskSnapshot>(integration, fid) ?? {};
+    const local = existing as unknown as Record<string, unknown>;
+    const writes: Partial<TaskSnapshot> = {};
+    {
+      const r = mergeField(local.title as string | undefined, remoteFields.title, snapshot.title);
+      if (r.source === 'remote' && local.title !== r.value) {
+        writes.title = r.value;
+      }
+    }
+    {
+      const r = mergeField(local.description as string | undefined, remoteFields.description, snapshot.description);
+      if (r.source === 'remote' && local.description !== r.value) {
+        writes.description = r.value;
+      }
+    }
+    {
+      const r = mergeField(local.status as TaskSnapshot['status'], remoteFields.status, snapshot.status);
+      if (r.source === 'remote' && local.status !== r.value) {
+        writes.status = r.value;
+      }
+    }
     Obj.update(existing, (existing) => {
-      existing.title = issue.title;
-      existing.description = issue.body ?? '';
-      existing.status = issueStateToTaskStatus(issue.state);
+      const m = existing as unknown as Record<string, unknown>;
+      for (const [k, v] of Object.entries(writes)) {
+        m[k] = v;
+      }
       if (assignedPerson && !existing.assigned) {
         existing.assigned = Ref.make(assignedPerson);
       }
-      // Maintain the Task → Project ref. Only overwrite when missing or
-      // pointing somewhere else (e.g. transferred-repo edge case); leave a
-      // user-set project alone if it already matches.
       const currentProjectId = existing.project?.dxn.asEchoDXN()?.echoId;
       const projectId = Ref.make(project).dxn.asEchoDXN()?.echoId;
       if (!existing.project || (currentProjectId && projectId && currentProjectId !== projectId)) {
         existing.project = Ref.make(project);
       }
     });
+    writeSnapshot(integration, fid, remoteFields);
     return { task: existing, created: false };
   }
+
   const created = Task.make({
     [Obj.Meta]: { keys: [fkFor(issue.id)] },
     title: issue.title,
@@ -207,96 +314,149 @@ const upsertTask = Effect.fn('upsertTask')(function* (
     project: Ref.make(project),
   });
   const persisted = yield* Database.add(created);
+  writeSnapshot(integration, fid, remoteFields);
   return { task: persisted, created: true };
 });
 
+//
+// Push (snapshot diff → GitHub mutations)
+//
+
+export type GitHubPushResult = {
+  projects: number;
+  tasks: number;
+};
+
 /**
- * Pull-only upsert for issue/PR comments. One {@link Thread.Thread} per Task
- * (foreign-keyed `task:<task-fid>`); one {@link Message.Message} per remote
- * comment (foreign-keyed by comment.id). Local Messages without a foreign key
- * are preserved (the user might have added their own commentary). Remote
- * deletions are NOT mirrored — keep history.
+ * Push reconciler for one repo. Walks the locally-mirrored Project for the
+ * given repo plus every Task whose foreign key matches one of the issues we
+ * just pulled, diffs against the snapshot, and PATCHes any diverged field
+ * back to GitHub.
+ *
+ * Behaviour:
+ *   - Project description divergence → PATCH /repos/{owner}/{repo}.
+ *     `name` divergence is logged but NOT pushed (rename is destructive and
+ *     almost never desired from a sync mirror).
+ *   - Task title / description / status divergence → PATCH the issue.
+ *   - Tombstones (`Obj.isDeleted`) are skipped.
+ *
+ * After a successful push the snapshot is refreshed with the values just
+ * sent so the next pass sees no divergence even before the next pull.
  */
-const syncCommentsForTask = Effect.fn('syncCommentsForTask')(function* (
-  task: Task.Task,
-  comments: ReadonlyArray<GitHubApi.GitHubComment>,
-  authorByLogin: Map<string, Person.Person>,
+export const pushRepoUpdates: <R>(
+  integration: Obj.Unknown & { snapshots?: Record<string, unknown> },
+  repo: GitHubApi.GitHubRepo,
+  remoteIssuesById: ReadonlyMap<string, GitHubApi.GitHubIssue>,
+  push: {
+    /** Wraps `GitHubApi.updateIssue`. */
+    updateIssue: (
+      owner: string,
+      repo: string,
+      issueNumber: number,
+      input: GitHubApi.IssueUpdateInput,
+    ) => Effect.Effect<void, Error, R>;
+    /** Wraps `GitHubApi.updateRepo`. */
+    updateRepo: (owner: string, repo: string, input: GitHubApi.RepoUpdateInput) => Effect.Effect<void, Error, R>;
+  },
+) => Effect.Effect<GitHubPushResult, Error, Database.Service | R> = Effect.fn('pushRepoUpdates')(function* (
+  integration,
+  repo,
+  remoteIssuesById,
+  push,
 ) {
-  if (comments.length === 0) {
-    return 0;
-  }
+  let projects = 0;
+  let tasks = 0;
 
-  // Find or create the thread anchored to this task.
-  const taskFid = Obj.getMeta(task).keys.find((key) => key.source === GITHUB_SOURCE)?.id;
-  if (!taskFid) {
-    return yield* Effect.dieMessage('Task missing GitHub foreign key — upsertTask must run first.');
-  }
-  let thread = yield* findByForeignId<Thread.Thread>(Thread.Thread, `task:${taskFid}`);
-  if (!thread) {
-    const created = Thread.make({
-      [Obj.Meta]: { keys: [{ source: GITHUB_SOURCE, id: `task:${taskFid}` }] },
-      name: 'Comments',
-      status: 'active',
-      messages: [],
-    });
-    thread = yield* Database.add(created);
-    // TODO(wittjosiah): Anchor thread → task via AnchoredTo relation. Skipped in
-    //   v1 because the relation API requires a Database service round-trip
-    //   that didn't fit the current handler shape; comments still discoverable
-    //   via the foreign key (`task:<fid>`) but won't show in document/table
-    //   comments-companion plank until the relation is added.
-  }
-
-  // Index existing messages by comment foreign id so we can update in place.
-  const existingByFid = new Map<string, Message.Message>();
-  for (const ref of thread.messages) {
-    const target = ref.target;
-    if (!target) {
-      continue;
-    }
-    const fid = Obj.getMeta(target).keys.find((key) => key.source === GITHUB_SOURCE)?.id;
-    if (fid) {
-      existingByFid.set(fid, target);
-    }
-  }
-
-  let added = 0;
-  const newRefs: Array<Ref.Ref<Message.Message>> = [];
-  for (const comment of comments) {
-    const existing = existingByFid.get(String(comment.id));
-    const senderLogin = comment.user?.login ?? 'unknown';
-    // TODO(wittjosiah): Upsert a Person for unknown comment authors via
-    //   `ensurePerson` (in the main handler scope) once comments are re-enabled,
-    //   so external commenters get a `contact` ref like assignees do.
-    const sender = authorByLogin.get(senderLogin);
-    const senderActor: Actor.Actor = sender ? { name: senderLogin, contact: Ref.make(sender) } : { name: senderLogin };
-    if (existing) {
-      Obj.update(existing, (existing) => {
-        existing.blocks = [{ _tag: 'text', text: comment.body ?? '' }];
-        if (comment.created_at) {
-          existing.created = comment.created_at;
+  // Project (repo) push — description only.
+  {
+    const fid = String(repo.id);
+    const local = yield* findByForeignId<Project.Project>(Project.Project, repo.id);
+    if (local && !Obj.isDeleted(local)) {
+      const snapshot = readSnapshot<ProjectSnapshot>(integration, fid);
+      if (snapshot) {
+        const localFields = local as unknown as Record<string, unknown>;
+        const localName = (localFields.name as string | undefined) ?? '';
+        const localDescription = (localFields.description as string | undefined) ?? '';
+        const input: GitHubApi.RepoUpdateInput = {};
+        let diverged = false;
+        if (snapshot.description !== undefined && snapshot.description !== localDescription) {
+          input.description = localDescription;
+          diverged = true;
         }
-      });
+        if (snapshot.name !== undefined && snapshot.name !== localName) {
+          // We deliberately don't push repo renames — see updateRepo above.
+          // Log instead so the user can chase down via the audit channel.
+          log.warn('github push: local repo name diverges from remote; rename push is intentionally disabled', {
+            repoId: fid,
+            localName,
+            snapshotName: snapshot.name,
+          });
+        }
+        if (diverged) {
+          yield* push.updateRepo(repo.owner.login, repo.name, input);
+          writeSnapshot(integration, fid, {
+            ...snapshot,
+            description: localDescription,
+          });
+          projects++;
+        }
+      }
+    }
+  }
+
+  // Task (issue) push — title / body / state.
+  for (const [id, remoteIssue] of remoteIssuesById) {
+    const local = yield* findByForeignId<Task.Task>(Task.Task, id);
+    if (!local || Obj.isDeleted(local)) {
       continue;
     }
-    const message = Message.make({
-      [Obj.Meta]: { keys: [fkFor(comment.id)] },
-      created: comment.created_at ?? new Date().toISOString(),
-      sender: senderActor,
-      blocks: [{ _tag: 'text', text: comment.body ?? '' }],
+    const snapshot = readSnapshot<TaskSnapshot>(integration, id);
+    if (!snapshot) {
+      continue;
+    }
+    const localFields = local as unknown as Record<string, unknown>;
+    const localTitle = (localFields.title as string | undefined) ?? '';
+    const localDescription = (localFields.description as string | undefined) ?? '';
+    const localStatus = localFields.status as string | undefined;
+    const desiredStatusForSnapshot: 'todo' | 'done' | undefined =
+      localStatus === 'done' ? 'done' : localStatus === 'todo' || localStatus === 'in-progress' ? 'todo' : undefined;
+
+    const input: GitHubApi.IssueUpdateInput = {};
+    let diverged = false;
+    if (snapshot.title !== undefined && snapshot.title !== localTitle) {
+      input.title = localTitle;
+      diverged = true;
+    }
+    if (snapshot.description !== undefined && snapshot.description !== localDescription) {
+      input.body = localDescription;
+      diverged = true;
+    }
+    if (
+      snapshot.status !== undefined &&
+      desiredStatusForSnapshot !== undefined &&
+      snapshot.status !== desiredStatusForSnapshot
+    ) {
+      const issueState = taskStatusToIssueState(localStatus);
+      if (issueState) {
+        input.state = issueState;
+        diverged = true;
+      }
+    }
+    if (!diverged) {
+      continue;
+    }
+
+    yield* push.updateIssue(repo.owner.login, repo.name, remoteIssue.number, input);
+    writeSnapshot(integration, id, {
+      ...snapshot,
+      title: localTitle,
+      description: localDescription,
+      status: desiredStatusForSnapshot ?? snapshot.status,
     });
-    const persisted = yield* Database.add(message);
-    newRefs.push(Ref.make(persisted));
-    added++;
+    tasks++;
   }
 
-  if (newRefs.length > 0) {
-    Obj.update(thread, (thread) => {
-      thread.messages = [...thread.messages, ...newRefs];
-    });
-  }
-
-  return added;
+  return { projects, tasks };
 });
 
 //
@@ -373,7 +533,7 @@ const handler: Operation.WithHandler<typeof SyncGitHubRepositories> = SyncGitHub
             // a different object, the upsert may have created a new Project (or
             // resolved an unrelated one); rewire `target.object` to whatever the
             // upsert returned so the user-visible target tracks the actual record.
-            const project = yield* upsertProject(remoteRepo);
+            const project = yield* upsertProject(integrationObj, remoteRepo);
             const rewireRef = !localObj || localObj.id !== project.id ? Ref.make(project) : undefined;
 
             if (repoFilterId && project.id !== repoFilterId) {
@@ -435,6 +595,8 @@ const handler: Operation.WithHandler<typeof SyncGitHubRepositories> = SyncGitHub
           }
 
           let pulledTasks = 0;
+          let pushedProjects = 0;
+          let pushedTasks = 0;
 
           const perTarget = yield* Effect.forEach(
             targetEntries,
@@ -446,6 +608,7 @@ const handler: Operation.WithHandler<typeof SyncGitHubRepositories> = SyncGitHub
                     const issues = yield* GitHubApi.fetchRepoIssues(remoteRepo.owner.login, remoteRepo.name, {
                       since,
                     });
+                    const remoteIssuesById = new Map<string, GitHubApi.GitHubIssue>();
                     yield* Effect.forEach(
                       issues,
                       (issue) =>
@@ -458,7 +621,8 @@ const handler: Operation.WithHandler<typeof SyncGitHubRepositories> = SyncGitHub
                             ? yield* ensurePerson(assigneeUser, undefined)
                             : undefined;
 
-                          const { created } = yield* upsertTask(issue, assignedPerson, project);
+                          const { created } = yield* upsertTask(integrationObj, issue, assignedPerson, project);
+                          remoteIssuesById.set(String(issue.id), issue);
                           if (created) {
                             pulledTasks++;
                           }
@@ -469,6 +633,26 @@ const handler: Operation.WithHandler<typeof SyncGitHubRepositories> = SyncGitHub
                         }),
                       { concurrency: ISSUE_CONCURRENCY },
                     );
+
+                    // Push: snapshot-diff the local Project + Tasks for this
+                    // repo and PATCH only the diverged fields. Errors on
+                    // individual PATCHes propagate as a single Either-Left
+                    // for this target so partial progress on other targets
+                    // is preserved.
+                    const pushResult = yield* pushRepoUpdates(integrationObj, remoteRepo, remoteIssuesById, {
+                      updateIssue: (owner, repoName, issueNumber, input) =>
+                        GitHubApi.updateIssue(owner, repoName, issueNumber, input).pipe(
+                          Effect.map(() => undefined),
+                          Effect.mapError((error) => error as Error),
+                        ),
+                      updateRepo: (owner, repoName, input) =>
+                        GitHubApi.updateRepo(owner, repoName, input).pipe(
+                          Effect.map(() => undefined),
+                          Effect.mapError((error) => error as Error),
+                        ),
+                    });
+                    pushedProjects += pushResult.projects;
+                    pushedTasks += pushResult.tasks;
                   }),
                 );
                 return { remoteId, result };
@@ -526,6 +710,10 @@ const handler: Operation.WithHandler<typeof SyncGitHubRepositories> = SyncGitHub
               projects: targetEntries.length,
               tasks: pulledTasks,
               comments: 0,
+            },
+            pushed: {
+              projects: pushedProjects,
+              tasks: pushedTasks,
             },
           };
         }).pipe(

--- a/packages/plugins/plugin-github/src/operations/sync.ts
+++ b/packages/plugins/plugin-github/src/operations/sync.ts
@@ -6,7 +6,7 @@ import * as FetchHttpClient from '@effect/platform/FetchHttpClient';
 import * as Effect from 'effect/Effect';
 import type * as Schema from 'effect/Schema';
 
-import { LayoutOperation, mergeField, readSnapshot, writeSnapshot } from '@dxos/app-toolkit';
+import { LayoutOperation, mergeField, readSnapshot, snapshotField, writeSnapshot } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
 import { Database, Filter, Obj, Query, Ref } from '@dxos/echo';
 import { log } from '@dxos/log';
@@ -65,17 +65,21 @@ const ISSUE_CONCURRENCY = 4;
 // Snapshot field shapes (stored on `Integration.snapshots`)
 //
 
-/** Snapshot for a GitHub repo (mirrored as a Project locally). `name` is read but not pushed. */
+/**
+ * Snapshot shapes. Fields are required (not `?`) because every snapshot is
+ * written in one shot via {@link writeSnapshot} after a pull; absence-of-
+ * snapshot is modeled by `readSnapshot` returning `undefined`. `name` on a
+ * Project is recorded but not pushed — see {@link GitHubApi.updateRepo}.
+ */
 type ProjectSnapshot = {
-  name?: string;
-  description?: string;
+  name: string;
+  description: string;
 };
 
-/** Snapshot for a GitHub issue (mirrored as a Task locally). */
 type TaskSnapshot = {
-  title?: string;
-  description?: string;
-  status?: 'todo' | 'done';
+  title: string;
+  description: string;
+  status: 'todo' | 'done';
 };
 
 //
@@ -215,12 +219,16 @@ const upsertProject = Effect.fn('upsertProject')(function* (
   const existing = yield* findByForeignId<Project.Project>(Project.Project, repo.id);
 
   if (existing) {
-    const snapshot = readSnapshot<ProjectSnapshot>(integration, fid) ?? {};
-    const nameResult = mergeField<string | undefined>(existing.name, remoteFields.name, snapshot.name);
+    const snapshot = readSnapshot<ProjectSnapshot>(integration, fid);
+    const nameResult = mergeField<string | undefined>(
+      existing.name,
+      remoteFields.name,
+      snapshotField(snapshot, 'name'),
+    );
     const descriptionResult = mergeField<string | undefined>(
       existing.description,
       remoteFields.description,
-      snapshot.description,
+      snapshotField(snapshot, 'description'),
     );
     const writeName = nameResult.source === 'remote' && existing.name !== nameResult.value;
     const writeDescription = descriptionResult.source === 'remote' && existing.description !== descriptionResult.value;
@@ -268,13 +276,13 @@ const upsertTask = Effect.fn('upsertTask')(function* (
   const existing = yield* findByForeignId<Task.Task>(Task.Task, issue.id);
 
   if (existing) {
-    const snapshot = readSnapshot<TaskSnapshot>(integration, fid) ?? {};
+    const snapshot = readSnapshot<TaskSnapshot>(integration, fid);
     // Task.title is required (non-optional) so the merge produces a string.
-    const titleResult = mergeField<string>(existing.title, remoteFields.title, snapshot.title);
+    const titleResult = mergeField<string>(existing.title, remoteFields.title, snapshotField(snapshot, 'title'));
     const descriptionResult = mergeField<string | undefined>(
       existing.description,
       remoteFields.description,
-      snapshot.description,
+      snapshotField(snapshot, 'description'),
     );
     // existing.status is the full Task status union ('todo' | 'in-progress' | 'done' | undefined);
     // the snapshot only ever holds GitHub's collapsed shape ('todo' | 'done'). Widen the merge
@@ -282,7 +290,7 @@ const upsertTask = Effect.fn('upsertTask')(function* (
     const statusResult = mergeField<'todo' | 'in-progress' | 'done' | undefined>(
       existing.status,
       remoteFields.status,
-      snapshot.status,
+      snapshotField(snapshot, 'status'),
     );
     const writeTitle = titleResult.source === 'remote' && existing.title !== titleResult.value;
     const writeDescription = descriptionResult.source === 'remote' && existing.description !== descriptionResult.value;

--- a/packages/plugins/plugin-github/src/operations/sync.ts
+++ b/packages/plugins/plugin-github/src/operations/sync.ts
@@ -531,6 +531,17 @@ const handler: Operation.WithHandler<typeof SyncGitHubRepositories> = SyncGitHub
               continue;
             }
 
+            // Project echo id for the filter is only available after upsert;
+            // when filtering to a single repo, resolve the existing local
+            // Project (if any) first and bail out before upsertProject's
+            // pull/merge side effects on unrelated repos.
+            if (repoFilterId) {
+              const existing = yield* findByForeignId<Project.Project>(Project.Project, remoteRepo.id);
+              if (!existing || existing.id !== repoFilterId) {
+                continue;
+              }
+            }
+
             // Always upsert by foreign-key. If `target.object` is already pointing
             // at the same Project (the normal round-trip), the upsert finds it,
             // refreshes its fields, and returns the same instance — and we leave
@@ -540,10 +551,6 @@ const handler: Operation.WithHandler<typeof SyncGitHubRepositories> = SyncGitHub
             // upsert returned so the user-visible target tracks the actual record.
             const project = yield* upsertProject(integrationObj, remoteRepo);
             const rewireRef = !localObj || localObj.id !== project.id ? Ref.make(project) : undefined;
-
-            if (repoFilterId && project.id !== repoFilterId) {
-              continue;
-            }
 
             targetEntries.push({
               entry: target,
@@ -644,6 +651,15 @@ const handler: Operation.WithHandler<typeof SyncGitHubRepositories> = SyncGitHub
                     // individual PATCHes propagate as a single Either-Left
                     // for this target so partial progress on other targets
                     // is preserved.
+                    //
+                    // TODO(burdon): `remoteIssuesById` is built from
+                    //   `fetchRepoIssues(..., { since })`, so when
+                    //   `maxDaysBack` is set this push pass cannot see
+                    //   locally-edited tasks whose remote issue is older
+                    //   than the window. Switch the candidate set to the
+                    //   local mirror (every Task with a GITHUB_SOURCE fk
+                    //   under this repo) once we store `number` per task
+                    //   so we don't need the remote payload to PATCH.
                     const pushResult = yield* pushRepoUpdates(integrationObj, remoteRepo, remoteIssuesById, {
                       updateIssue: (owner, repoName, issueNumber, input) =>
                         GitHubApi.updateIssue(owner, repoName, issueNumber, input).pipe(Effect.map(() => undefined)),

--- a/packages/plugins/plugin-github/src/operations/sync.ts
+++ b/packages/plugins/plugin-github/src/operations/sync.ts
@@ -347,8 +347,13 @@ export type GitHubPushResult = {
  *
  * After a successful push the snapshot is refreshed with the values just
  * sent so the next pass sees no divergence even before the next pull.
+ *
+ * The push callbacks' error type is generic. The reconciler doesn't inspect
+ * or recover from those errors — it propagates so the outer `Effect.either`
+ * at the call site can record a per-target `lastError`. Generic-`E` keeps
+ * this module decoupled from the HTTP error hierarchy of `GitHubApi`.
  */
-export const pushRepoUpdates: <R>(
+export const pushRepoUpdates: <E, R>(
   integration: Obj.Unknown & { snapshots?: Record<string, unknown> },
   repo: GitHubApi.GitHubRepo,
   remoteIssuesById: ReadonlyMap<string, GitHubApi.GitHubIssue>,
@@ -359,11 +364,11 @@ export const pushRepoUpdates: <R>(
       repo: string,
       issueNumber: number,
       input: GitHubApi.IssueUpdateInput,
-    ) => Effect.Effect<void, Error, R>;
+    ) => Effect.Effect<void, E, R>;
     /** Wraps `GitHubApi.updateRepo`. */
-    updateRepo: (owner: string, repo: string, input: GitHubApi.RepoUpdateInput) => Effect.Effect<void, Error, R>;
+    updateRepo: (owner: string, repo: string, input: GitHubApi.RepoUpdateInput) => Effect.Effect<void, E, R>;
   },
-) => Effect.Effect<GitHubPushResult, Error, Database.Service | R> = Effect.fn('pushRepoUpdates')(
+) => Effect.Effect<GitHubPushResult, E, Database.Service | R> = Effect.fn('pushRepoUpdates')(
   function* (integration, repo, remoteIssuesById, push) {
     let projects = 0;
     let tasks = 0;
@@ -641,15 +646,9 @@ const handler: Operation.WithHandler<typeof SyncGitHubRepositories> = SyncGitHub
                     // is preserved.
                     const pushResult = yield* pushRepoUpdates(integrationObj, remoteRepo, remoteIssuesById, {
                       updateIssue: (owner, repoName, issueNumber, input) =>
-                        GitHubApi.updateIssue(owner, repoName, issueNumber, input).pipe(
-                          Effect.map(() => undefined),
-                          Effect.mapError((error) => error as Error),
-                        ),
+                        GitHubApi.updateIssue(owner, repoName, issueNumber, input).pipe(Effect.map(() => undefined)),
                       updateRepo: (owner, repoName, input) =>
-                        GitHubApi.updateRepo(owner, repoName, input).pipe(
-                          Effect.map(() => undefined),
-                          Effect.mapError((error) => error as Error),
-                        ),
+                        GitHubApi.updateRepo(owner, repoName, input).pipe(Effect.map(() => undefined)),
                     });
                     pushedProjects += pushResult.projects;
                     pushedTasks += pushResult.tasks;

--- a/packages/plugins/plugin-github/src/operations/sync.ts
+++ b/packages/plugins/plugin-github/src/operations/sync.ts
@@ -443,7 +443,15 @@ export const pushRepoUpdates: <E, R>(
         input.body = localDescription;
         diverged = true;
       }
+      // Status push is pull-only for PRs. GitHub uses the same /issues/{n}
+      // endpoint for issues and PRs, but `state: 'closed'` on a PR rejects
+      // it (the closed-without-merge red badge), and merging requires a
+      // separate `PUT /pulls/{n}/merge` endpoint we don't support. The safe
+      // default is to never push a status change for a PR — log if local
+      // and snapshot diverge so the divergence is auditable.
+      const isPullRequest = remoteIssue.pull_request != null;
       if (
+        !isPullRequest &&
         snapshot.status !== undefined &&
         desiredStatusForSnapshot !== undefined &&
         snapshot.status !== desiredStatusForSnapshot
@@ -453,17 +461,34 @@ export const pushRepoUpdates: <E, R>(
           input.state = issueState;
           diverged = true;
         }
+      } else if (
+        isPullRequest &&
+        snapshot.status !== undefined &&
+        desiredStatusForSnapshot !== undefined &&
+        snapshot.status !== desiredStatusForSnapshot
+      ) {
+        log.warn('github push: PR status diverged locally; pull-only for PRs (status will not be pushed)', {
+          issueId: id,
+          number: remoteIssue.number,
+          localStatus,
+          snapshotStatus: snapshot.status,
+        });
       }
       if (!diverged) {
         continue;
       }
 
       yield* push.updateIssue(repo.owner.login, repo.name, remoteIssue.number, input);
+      // Refresh the snapshot: title / description / status sent. Status only
+      // gets refreshed when we actually pushed a state change (issues only) —
+      // for PRs we keep the snapshot's previous status, so the warning above
+      // keeps firing until either the user reverts locally or the PR's state
+      // changes on GitHub and a pull catches up.
       writeSnapshot(integration, id, {
         ...snapshot,
         title: localTitle,
         description: localDescription,
-        status: desiredStatusForSnapshot ?? snapshot.status,
+        status: input.state !== undefined ? (desiredStatusForSnapshot ?? snapshot.status) : snapshot.status,
       });
       tasks++;
     }

--- a/packages/plugins/plugin-github/src/operations/sync.ts
+++ b/packages/plugins/plugin-github/src/operations/sync.ts
@@ -362,104 +362,101 @@ export const pushRepoUpdates: <R>(
     /** Wraps `GitHubApi.updateRepo`. */
     updateRepo: (owner: string, repo: string, input: GitHubApi.RepoUpdateInput) => Effect.Effect<void, Error, R>;
   },
-) => Effect.Effect<GitHubPushResult, Error, Database.Service | R> = Effect.fn('pushRepoUpdates')(function* (
-  integration,
-  repo,
-  remoteIssuesById,
-  push,
-) {
-  let projects = 0;
-  let tasks = 0;
+) => Effect.Effect<GitHubPushResult, Error, Database.Service | R> = Effect.fn('pushRepoUpdates')(
+  function* (integration, repo, remoteIssuesById, push) {
+    let projects = 0;
+    let tasks = 0;
 
-  // Project (repo) push — description only.
-  {
-    const fid = String(repo.id);
-    const local = yield* findByForeignId<Project.Project>(Project.Project, repo.id);
-    if (local && !Obj.isDeleted(local)) {
-      const snapshot = readSnapshot<ProjectSnapshot>(integration, fid);
-      if (snapshot) {
-        const localName = local.name ?? '';
-        const localDescription = local.description ?? '';
-        const input: GitHubApi.RepoUpdateInput = {};
-        let diverged = false;
-        if (snapshot.description !== undefined && snapshot.description !== localDescription) {
-          input.description = localDescription;
-          diverged = true;
-        }
-        if (snapshot.name !== undefined && snapshot.name !== localName) {
-          // We deliberately don't push repo renames — see updateRepo above.
-          // Log instead so the user can chase down via the audit channel.
-          log.warn('github push: local repo name diverges from remote; rename push is intentionally disabled', {
-            repoId: fid,
-            localName,
-            snapshotName: snapshot.name,
-          });
-        }
-        if (diverged) {
-          yield* push.updateRepo(repo.owner.login, repo.name, input);
-          writeSnapshot(integration, fid, {
-            ...snapshot,
-            description: localDescription,
-          });
-          projects++;
+    // Project (repo) push — description only.
+    {
+      const fid = String(repo.id);
+      const local = yield* findByForeignId<Project.Project>(Project.Project, repo.id);
+      if (local && !Obj.isDeleted(local)) {
+        const snapshot = readSnapshot<ProjectSnapshot>(integration, fid);
+        if (snapshot) {
+          const localName = local.name ?? '';
+          const localDescription = local.description ?? '';
+          const input: GitHubApi.RepoUpdateInput = {};
+          let diverged = false;
+          if (snapshot.description !== undefined && snapshot.description !== localDescription) {
+            input.description = localDescription;
+            diverged = true;
+          }
+          if (snapshot.name !== undefined && snapshot.name !== localName) {
+            // We deliberately don't push repo renames — see updateRepo above.
+            // Log instead so the user can chase down via the audit channel.
+            log.warn('github push: local repo name diverges from remote; rename push is intentionally disabled', {
+              repoId: fid,
+              localName,
+              snapshotName: snapshot.name,
+            });
+          }
+          if (diverged) {
+            yield* push.updateRepo(repo.owner.login, repo.name, input);
+            writeSnapshot(integration, fid, {
+              ...snapshot,
+              description: localDescription,
+            });
+            projects++;
+          }
         }
       }
     }
-  }
 
-  // Task (issue) push — title / body / state.
-  for (const [id, remoteIssue] of remoteIssuesById) {
-    const local = yield* findByForeignId<Task.Task>(Task.Task, id);
-    if (!local || Obj.isDeleted(local)) {
-      continue;
-    }
-    const snapshot = readSnapshot<TaskSnapshot>(integration, id);
-    if (!snapshot) {
-      continue;
-    }
-    const localTitle = local.title ?? '';
-    const localDescription = local.description ?? '';
-    const localStatus = local.status;
-    const desiredStatusForSnapshot: 'todo' | 'done' | undefined =
-      localStatus === 'done' ? 'done' : localStatus === 'todo' || localStatus === 'in-progress' ? 'todo' : undefined;
+    // Task (issue) push — title / body / state.
+    for (const [id, remoteIssue] of remoteIssuesById) {
+      const local = yield* findByForeignId<Task.Task>(Task.Task, id);
+      if (!local || Obj.isDeleted(local)) {
+        continue;
+      }
+      const snapshot = readSnapshot<TaskSnapshot>(integration, id);
+      if (!snapshot) {
+        continue;
+      }
+      const localTitle = local.title ?? '';
+      const localDescription = local.description ?? '';
+      const localStatus = local.status;
+      const desiredStatusForSnapshot: 'todo' | 'done' | undefined =
+        localStatus === 'done' ? 'done' : localStatus === 'todo' || localStatus === 'in-progress' ? 'todo' : undefined;
 
-    const input: GitHubApi.IssueUpdateInput = {};
-    let diverged = false;
-    if (snapshot.title !== undefined && snapshot.title !== localTitle) {
-      input.title = localTitle;
-      diverged = true;
-    }
-    if (snapshot.description !== undefined && snapshot.description !== localDescription) {
-      input.body = localDescription;
-      diverged = true;
-    }
-    if (
-      snapshot.status !== undefined &&
-      desiredStatusForSnapshot !== undefined &&
-      snapshot.status !== desiredStatusForSnapshot
-    ) {
-      const issueState = taskStatusToIssueState(localStatus);
-      if (issueState) {
-        input.state = issueState;
+      const input: GitHubApi.IssueUpdateInput = {};
+      let diverged = false;
+      if (snapshot.title !== undefined && snapshot.title !== localTitle) {
+        input.title = localTitle;
         diverged = true;
       }
-    }
-    if (!diverged) {
-      continue;
+      if (snapshot.description !== undefined && snapshot.description !== localDescription) {
+        input.body = localDescription;
+        diverged = true;
+      }
+      if (
+        snapshot.status !== undefined &&
+        desiredStatusForSnapshot !== undefined &&
+        snapshot.status !== desiredStatusForSnapshot
+      ) {
+        const issueState = taskStatusToIssueState(localStatus);
+        if (issueState) {
+          input.state = issueState;
+          diverged = true;
+        }
+      }
+      if (!diverged) {
+        continue;
+      }
+
+      yield* push.updateIssue(repo.owner.login, repo.name, remoteIssue.number, input);
+      writeSnapshot(integration, id, {
+        ...snapshot,
+        title: localTitle,
+        description: localDescription,
+        status: desiredStatusForSnapshot ?? snapshot.status,
+      });
+      tasks++;
     }
 
-    yield* push.updateIssue(repo.owner.login, repo.name, remoteIssue.number, input);
-    writeSnapshot(integration, id, {
-      ...snapshot,
-      title: localTitle,
-      description: localDescription,
-      status: desiredStatusForSnapshot ?? snapshot.status,
-    });
-    tasks++;
-  }
-
-  return { projects, tasks };
-});
+    return { projects, tasks };
+  },
+);
 
 //
 // Main handler

--- a/packages/plugins/plugin-github/src/operations/sync.ts
+++ b/packages/plugins/plugin-github/src/operations/sync.ts
@@ -216,19 +216,21 @@ const upsertProject = Effect.fn('upsertProject')(function* (
 
   if (existing) {
     const snapshot = readSnapshot<ProjectSnapshot>(integration, fid) ?? {};
-    const local = existing as unknown as Record<string, unknown>;
-    const writes: Partial<typeof remoteFields> = {};
-    for (const key of ['name', 'description'] as const) {
-      const result = mergeField(local[key] as string | undefined, remoteFields[key], snapshot[key]);
-      if (result.source === 'remote' && local[key] !== result.value) {
-        writes[key] = result.value;
-      }
-    }
-    if (Object.keys(writes).length > 0) {
+    const nameResult = mergeField<string | undefined>(existing.name, remoteFields.name, snapshot.name);
+    const descriptionResult = mergeField<string | undefined>(
+      existing.description,
+      remoteFields.description,
+      snapshot.description,
+    );
+    const writeName = nameResult.source === 'remote' && existing.name !== nameResult.value;
+    const writeDescription = descriptionResult.source === 'remote' && existing.description !== descriptionResult.value;
+    if (writeName || writeDescription) {
       Obj.update(existing, (existing) => {
-        const m = existing as unknown as Record<string, unknown>;
-        for (const [k, v] of Object.entries(writes)) {
-          m[k] = v;
+        if (writeName) {
+          existing.name = nameResult.value;
+        }
+        if (writeDescription) {
+          existing.description = descriptionResult.value;
         }
       });
     }
@@ -267,30 +269,32 @@ const upsertTask = Effect.fn('upsertTask')(function* (
 
   if (existing) {
     const snapshot = readSnapshot<TaskSnapshot>(integration, fid) ?? {};
-    const local = existing as unknown as Record<string, unknown>;
-    const writes: Partial<TaskSnapshot> = {};
-    {
-      const r = mergeField(local.title as string | undefined, remoteFields.title, snapshot.title);
-      if (r.source === 'remote' && local.title !== r.value) {
-        writes.title = r.value;
-      }
-    }
-    {
-      const r = mergeField(local.description as string | undefined, remoteFields.description, snapshot.description);
-      if (r.source === 'remote' && local.description !== r.value) {
-        writes.description = r.value;
-      }
-    }
-    {
-      const r = mergeField(local.status as TaskSnapshot['status'], remoteFields.status, snapshot.status);
-      if (r.source === 'remote' && local.status !== r.value) {
-        writes.status = r.value;
-      }
-    }
+    const titleResult = mergeField<string | undefined>(existing.title, remoteFields.title, snapshot.title);
+    const descriptionResult = mergeField<string | undefined>(
+      existing.description,
+      remoteFields.description,
+      snapshot.description,
+    );
+    // existing.status is the full Task status union ('todo' | 'in-progress' | 'done' | undefined);
+    // the snapshot only ever holds GitHub's collapsed shape ('todo' | 'done'). Widen the merge
+    // type so both sides typecheck and let mergeField compare them as plain values.
+    const statusResult = mergeField<'todo' | 'in-progress' | 'done' | undefined>(
+      existing.status,
+      remoteFields.status,
+      snapshot.status,
+    );
+    const writeTitle = titleResult.source === 'remote' && existing.title !== titleResult.value;
+    const writeDescription = descriptionResult.source === 'remote' && existing.description !== descriptionResult.value;
+    const writeStatus = statusResult.source === 'remote' && existing.status !== statusResult.value;
     Obj.update(existing, (existing) => {
-      const m = existing as unknown as Record<string, unknown>;
-      for (const [k, v] of Object.entries(writes)) {
-        m[k] = v;
+      if (writeTitle) {
+        existing.title = titleResult.value;
+      }
+      if (writeDescription) {
+        existing.description = descriptionResult.value;
+      }
+      if (writeStatus) {
+        existing.status = statusResult.value;
       }
       if (assignedPerson && !existing.assigned) {
         existing.assigned = Ref.make(assignedPerson);
@@ -374,9 +378,8 @@ export const pushRepoUpdates: <R>(
     if (local && !Obj.isDeleted(local)) {
       const snapshot = readSnapshot<ProjectSnapshot>(integration, fid);
       if (snapshot) {
-        const localFields = local as unknown as Record<string, unknown>;
-        const localName = (localFields.name as string | undefined) ?? '';
-        const localDescription = (localFields.description as string | undefined) ?? '';
+        const localName = local.name ?? '';
+        const localDescription = local.description ?? '';
         const input: GitHubApi.RepoUpdateInput = {};
         let diverged = false;
         if (snapshot.description !== undefined && snapshot.description !== localDescription) {
@@ -414,10 +417,9 @@ export const pushRepoUpdates: <R>(
     if (!snapshot) {
       continue;
     }
-    const localFields = local as unknown as Record<string, unknown>;
-    const localTitle = (localFields.title as string | undefined) ?? '';
-    const localDescription = (localFields.description as string | undefined) ?? '';
-    const localStatus = localFields.status as string | undefined;
+    const localTitle = local.title ?? '';
+    const localDescription = local.description ?? '';
+    const localStatus = local.status;
     const desiredStatusForSnapshot: 'todo' | 'done' | undefined =
       localStatus === 'done' ? 'done' : localStatus === 'todo' || localStatus === 'in-progress' ? 'todo' : undefined;
 

--- a/packages/plugins/plugin-github/src/operations/sync.ts
+++ b/packages/plugins/plugin-github/src/operations/sync.ts
@@ -269,7 +269,8 @@ const upsertTask = Effect.fn('upsertTask')(function* (
 
   if (existing) {
     const snapshot = readSnapshot<TaskSnapshot>(integration, fid) ?? {};
-    const titleResult = mergeField<string | undefined>(existing.title, remoteFields.title, snapshot.title);
+    // Task.title is required (non-optional) so the merge produces a string.
+    const titleResult = mergeField<string>(existing.title, remoteFields.title, snapshot.title);
     const descriptionResult = mergeField<string | undefined>(
       existing.description,
       remoteFields.description,

--- a/packages/plugins/plugin-github/src/services/github-api.ts
+++ b/packages/plugins/plugin-github/src/services/github-api.ts
@@ -186,6 +186,12 @@ const withAuth = (req: HttpClientRequest.HttpClientRequest, creds: GitHubCredent
  * Build an unauthenticated GitHub API request, fetch + decode it as a single JSON
  * response, and apply timeout + retry. `withAuth` is applied here so callers never
  * have to remember to attach credentials (forgetting would silently 401).
+ *
+ * `filterStatusOk` converts non-2xx responses into a typed `ResponseError`
+ * (carrying `status` and the raw body) BEFORE we try to decode the body —
+ * otherwise GitHub error envelopes (`{ message, documentation_url }`) would
+ * blow up against the success schema with a `ParseError`, masking the real
+ * cause (e.g. a 403 from an integration token that lacks issue write).
  */
 const githubRequest = <T>(
   build: () => HttpClientRequest.HttpClientRequest,
@@ -194,7 +200,10 @@ const githubRequest = <T>(
   Effect.gen(function* () {
     const creds = yield* GitHubCredentials;
     const httpClient = yield* HttpClient.HttpClient;
-    const clientNoTracer = httpClient.pipe(HttpClient.withTracerDisabledWhen(() => true));
+    const clientNoTracer = httpClient.pipe(
+      HttpClient.withTracerDisabledWhen(() => true),
+      HttpClient.filterStatusOk,
+    );
     return yield* clientNoTracer.execute(withAuth(build(), creds)).pipe(
       Effect.flatMap((res) => Effect.flatMap(res.json, Schema.decodeUnknown(schema))),
       Effect.timeout('15 seconds'),
@@ -242,7 +251,10 @@ const githubPaginated = <T>(
   Effect.gen(function* () {
     const httpClient = yield* HttpClient.HttpClient;
     const creds = yield* GitHubCredentials;
-    const clientNoTracer = httpClient.pipe(HttpClient.withTracerDisabledWhen(() => true));
+    const clientNoTracer = httpClient.pipe(
+      HttpClient.withTracerDisabledWhen(() => true),
+      HttpClient.filterStatusOk,
+    );
     const arraySchema = Schema.Array(itemSchema);
 
     let nextUrl: string | undefined;
@@ -377,7 +389,10 @@ const githubPatch = <T>(
   Effect.gen(function* () {
     const creds = yield* GitHubCredentials;
     const httpClient = yield* HttpClient.HttpClient;
-    const clientNoTracer = httpClient.pipe(HttpClient.withTracerDisabledWhen(() => true));
+    const clientNoTracer = httpClient.pipe(
+      HttpClient.withTracerDisabledWhen(() => true),
+      HttpClient.filterStatusOk,
+    );
     const request = withAuth(build(), creds).pipe(HttpClientRequest.bodyUnsafeJson(body));
     return yield* clientNoTracer.execute(request).pipe(
       Effect.flatMap((res) => Effect.flatMap(res.json, Schema.decodeUnknown(schema))),

--- a/packages/plugins/plugin-github/src/services/github-api.ts
+++ b/packages/plugins/plugin-github/src/services/github-api.ts
@@ -358,3 +358,83 @@ export const fetchIssueComments = (
       ),
     GitHubCommentSchema,
   );
+
+//
+// Mutations (push)
+//
+
+/**
+ * PATCH a GitHub object. The shape mirrors {@link githubRequest} except the
+ * request method is PATCH and the body is `application/json`. Failures are
+ * propagated unchanged; the caller is expected to surface them on the target
+ * row's `lastError`. Retry rules are the same — 429 / 5xx retry, 4xx don't.
+ */
+const githubPatch = <T>(
+  build: () => HttpClientRequest.HttpClientRequest,
+  body: Record<string, unknown>,
+  schema: Schema.Schema<T>,
+): GitHubEffect<T> =>
+  Effect.gen(function* () {
+    const creds = yield* GitHubCredentials;
+    const httpClient = yield* HttpClient.HttpClient;
+    const clientNoTracer = httpClient.pipe(HttpClient.withTracerDisabledWhen(() => true));
+    const request = withAuth(build(), creds).pipe(HttpClientRequest.bodyUnsafeJson(body));
+    return yield* clientNoTracer.execute(request).pipe(
+      Effect.flatMap((res) => Effect.flatMap(res.json, Schema.decodeUnknown(schema))),
+      Effect.timeout('15 seconds'),
+      Effect.retry({
+        schedule: Schedule.exponential('500 millis').pipe(Schedule.jittered, Schedule.compose(Schedule.recurs(3))),
+        while: shouldRetry,
+      }),
+      Effect.scoped,
+    );
+  });
+
+export type IssueUpdateInput = {
+  title?: string;
+  body?: string;
+  state?: 'open' | 'closed';
+  state_reason?: 'completed' | 'not_planned' | 'reopened' | null;
+};
+
+/**
+ * PATCH /repos/{owner}/{repo}/issues/{number} — update title / body / state.
+ *
+ * GitHub conflates issues and PRs at this endpoint: the same PATCH works for
+ * both, but PR-specific fields (head/base/draft) must go through the
+ * `/pulls/{n}` endpoint. We only touch issue-mappable fields here.
+ */
+export const updateIssue = (
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  input: IssueUpdateInput,
+): GitHubEffect<GitHubIssue> =>
+  githubPatch(
+    () =>
+      HttpClientRequest.patch(
+        `${GITHUB_API_BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${issueNumber}`,
+      ),
+    input as unknown as Record<string, unknown>,
+    GitHubIssueSchema,
+  );
+
+export type RepoUpdateInput = {
+  /** GitHub allows the owner of a repo to rename it; this is rare and risky and we currently don't push it. */
+  name?: string;
+  description?: string;
+  homepage?: string;
+};
+
+/**
+ * PATCH /repos/{owner}/{repo} — update repo description and a small set of
+ * mapped metadata. Renames (`name`) are accepted by the API but we don't push
+ * them by default: a rename invalidates clones, breaks pinned URLs, and is
+ * almost never what a user wants from a sync mirror.
+ */
+export const updateRepo = (owner: string, repo: string, input: RepoUpdateInput): GitHubEffect<GitHubRepo> =>
+  githubPatch(
+    () => HttpClientRequest.patch(`${GITHUB_API_BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`),
+    input as unknown as Record<string, unknown>,
+    GitHubRepoSchema,
+  );

--- a/packages/plugins/plugin-linear/src/capabilities/integration-provider.ts
+++ b/packages/plugins/plugin-linear/src/capabilities/integration-provider.ts
@@ -47,8 +47,15 @@ const onTokenCreated: OnTokenCreated = ({ accessToken }) =>
  * Sync targets are Linear teams. Per-target `SyncOptions.maxDaysBack` caps
  * how far back issues are pulled by `Issue.updatedAt`.
  *
- * Scope `read` is sufficient for v1 (pull-only). `write`/`issues:create`
- * would be needed if/when bidirectional Task sync is added.
+ * Scopes:
+ *   - `read`  — required for pull (projects, issues, workflow states).
+ *   - `write` — required to push local edits back via `issueUpdate` and
+ *               `projectUpdate`. Linear treats issue and project mutations
+ *               under a single umbrella `write` scope; there's no narrower
+ *               permission for "edit only, never create".
+ *
+ * Note: existing tokens issued with `read` only will return permission errors
+ * on push. Re-consent via the integration setup flow upgrades the scope.
  */
 export default Capability.makeModule(
   Effect.fnUntraced(function* () {
@@ -59,7 +66,7 @@ export default Capability.makeModule(
         label: 'Linear',
         oauth: {
           provider: OAuthProvider.LINEAR,
-          scopes: ['read'],
+          scopes: ['read', 'write'],
         },
         getSyncTargets: LinearOperation.GetLinearTeams,
         sync: LinearOperation.SyncLinearTeams,

--- a/packages/plugins/plugin-linear/src/operations/sync.test.ts
+++ b/packages/plugins/plugin-linear/src/operations/sync.test.ts
@@ -50,12 +50,7 @@ describe('plugin-linear sync', () => {
 
   const setup = async () => {
     const { db, graph } = await builder.createDatabase();
-    await graph.schemaRegistry.register([
-      AccessToken.AccessToken,
-      Integration.Integration,
-      Project.Project,
-      Task.Task,
-    ]);
+    await graph.schemaRegistry.register([AccessToken.AccessToken, Integration.Integration, Project.Project, Task.Task]);
     const token = db.add(Obj.make(AccessToken.AccessToken, { source: LINEAR_SOURCE, token: 'tok' }));
     const integration = db.add(Obj.make(Integration.Integration, { accessToken: Ref.make(token), targets: [] }));
     return { db, integration };
@@ -240,8 +235,8 @@ describe('plugin-linear sync', () => {
       return yield* upsertProject(integration, project());
     }).pipe(Effect.provide(layer), runAndForwardErrors);
 
-    Obj.update(local, (proj) => {
-      proj.description = 'rewritten';
+    Obj.update(local, (local) => {
+      local.description = 'rewritten';
     });
 
     let projectInput: LinearApi.ProjectUpdateInput | undefined;

--- a/packages/plugins/plugin-linear/src/operations/sync.test.ts
+++ b/packages/plugins/plugin-linear/src/operations/sync.test.ts
@@ -227,6 +227,68 @@ describe('plugin-linear sync', () => {
     expect(issueUpdateInput?.stateId).toBe('state-completed-id');
   });
 
+  test('push: priority assigned to previously-unprioritised issue is pushed', async ({ expect }) => {
+    // Regression: an earlier guard `snapshot.priority !== undefined` silently
+    // dropped pushes when the remote had no priority — exactly the common
+    // "user sets a priority on a freshly-pulled issue" case.
+    const { db, integration } = await setup();
+    const layer = Database.layer(db);
+
+    const first = await Effect.gen(function* () {
+      return yield* upsertTask(integration, issue({ priority: 0 }), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    // Sanity check: the seeded snapshot really does say "no priority".
+    const snapshots = (integration.snapshots ?? {}) as Record<string, any>;
+    expect(snapshots['issue-1']?.priority).toBeUndefined();
+
+    Obj.update(first.task, (task) => {
+      task.priority = 'medium';
+    });
+
+    let issueUpdateInput: LinearApi.IssueUpdateInput | undefined;
+    await Effect.gen(function* () {
+      yield* pushTeamUpdates(integration, new Map([['issue-1', issue({ priority: 0 })]]), new Map(), {
+        updateIssue: (_id, input) => {
+          issueUpdateInput = input;
+          return Effect.succeed(undefined);
+        },
+        updateProject: () => Effect.succeed(undefined),
+        resolveStateId: () => undefined,
+      });
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    // Linear maps medium → 3.
+    expect(issueUpdateInput?.priority).toBe(3);
+  });
+
+  test('push: locally clearing priority sends null to Linear', async ({ expect }) => {
+    const { db, integration } = await setup();
+    const layer = Database.layer(db);
+
+    const first = await Effect.gen(function* () {
+      return yield* upsertTask(integration, issue(), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    Obj.update(first.task, (task) => {
+      task.priority = undefined;
+    });
+
+    let issueUpdateInput: LinearApi.IssueUpdateInput | undefined;
+    await Effect.gen(function* () {
+      yield* pushTeamUpdates(integration, new Map([['issue-1', issue()]]), new Map(), {
+        updateIssue: (_id, input) => {
+          issueUpdateInput = input;
+          return Effect.succeed(undefined);
+        },
+        updateProject: () => Effect.succeed(undefined),
+        resolveStateId: () => undefined,
+      });
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    expect(issueUpdateInput?.priority).toBeNull();
+  });
+
   test('push: project description divergence calls updateProject', async ({ expect }) => {
     const { db, integration } = await setup();
     const layer = Database.layer(db);

--- a/packages/plugins/plugin-linear/src/operations/sync.test.ts
+++ b/packages/plugins/plugin-linear/src/operations/sync.test.ts
@@ -1,0 +1,262 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+import { afterEach, beforeEach, describe, test } from 'vitest';
+
+import { Database, Obj, Ref } from '@dxos/echo';
+import { EchoTestBuilder } from '@dxos/echo-db/testing';
+import { runAndForwardErrors } from '@dxos/effect';
+import { Integration } from '@dxos/plugin-integration/types';
+import { AccessToken, Project, Task } from '@dxos/types';
+
+import { LINEAR_SOURCE } from '../constants';
+import { LinearApi } from '../services';
+import { pushTeamUpdates, upsertProject, upsertTask } from './sync';
+
+const issue = (overrides: Partial<LinearApi.Issue> = {}): LinearApi.Issue => ({
+  id: 'issue-1',
+  identifier: 'TEAM-1',
+  title: 'Investigate flake',
+  description: 'desc',
+  priority: 3,
+  estimate: 2,
+  state: { id: 'st-1', name: 'In Progress', type: 'started' },
+  assignee: undefined,
+  project: undefined,
+  createdAt: '2026-04-01T00:00:00Z',
+  updatedAt: '2026-04-01T00:00:00Z',
+  ...overrides,
+});
+
+const project = (overrides: Partial<LinearApi.Project> = {}): LinearApi.Project => ({
+  id: 'proj-1',
+  name: 'Q2 launch',
+  description: 'high level scope',
+  ...overrides,
+});
+
+describe('plugin-linear sync', () => {
+  let builder: EchoTestBuilder;
+
+  beforeEach(async () => {
+    builder = await new EchoTestBuilder().open();
+  });
+
+  afterEach(async () => {
+    await builder.close();
+  });
+
+  const setup = async () => {
+    const { db, graph } = await builder.createDatabase();
+    await graph.schemaRegistry.register([
+      AccessToken.AccessToken,
+      Integration.Integration,
+      Project.Project,
+      Task.Task,
+    ]);
+    const token = db.add(Obj.make(AccessToken.AccessToken, { source: LINEAR_SOURCE, token: 'tok' }));
+    const integration = db.add(Obj.make(Integration.Integration, { accessToken: Ref.make(token), targets: [] }));
+    return { db, integration };
+  };
+
+  test('first pull seeds snapshot and creates a Task', async ({ expect }) => {
+    const { db, integration } = await setup();
+    const layer = Database.layer(db);
+
+    const result = await Effect.gen(function* () {
+      return yield* upsertTask(integration, issue(), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    expect(result.created).toBe(true);
+    const snapshots = (integration.snapshots ?? {}) as Record<string, any>;
+    expect(snapshots['issue-1']?.title).toBe('Investigate flake');
+    expect(snapshots['issue-1']?.status).toBe('in-progress');
+    expect(snapshots['issue-1']?.priority).toBe('medium');
+    expect(result.task.title).toBe('Investigate flake');
+  });
+
+  test('second pull is idempotent (no changes either side)', async ({ expect }) => {
+    const { db, integration } = await setup();
+    const layer = Database.layer(db);
+
+    await Effect.gen(function* () {
+      yield* upsertTask(integration, issue(), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    const second = await Effect.gen(function* () {
+      return yield* upsertTask(integration, issue(), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    expect(second.created).toBe(false);
+    // Title still correct, no field flipping.
+    expect(second.task.title).toBe('Investigate flake');
+  });
+
+  test('local-only edit is preserved across pull', async ({ expect }) => {
+    const { db, integration } = await setup();
+    const layer = Database.layer(db);
+
+    const first = await Effect.gen(function* () {
+      return yield* upsertTask(integration, issue(), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    Obj.update(first.task, (task) => {
+      task.description = 'edited locally';
+    });
+
+    // Pull again with unchanged remote — local edit must survive.
+    await Effect.gen(function* () {
+      yield* upsertTask(integration, issue(), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    expect(first.task.description).toBe('edited locally');
+  });
+
+  test('remote-only change pulls into local and refreshes snapshot', async ({ expect }) => {
+    const { db, integration } = await setup();
+    const layer = Database.layer(db);
+
+    await Effect.gen(function* () {
+      yield* upsertTask(integration, issue(), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    const second = await Effect.gen(function* () {
+      return yield* upsertTask(integration, issue({ title: 'Renamed remotely' }), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    expect(second.task.title).toBe('Renamed remotely');
+    const snapshots = (integration.snapshots ?? {}) as Record<string, any>;
+    expect(snapshots['issue-1']?.title).toBe('Renamed remotely');
+  });
+
+  test('both-changed → remote wins (conflict policy)', async ({ expect }) => {
+    const { db, integration } = await setup();
+    const layer = Database.layer(db);
+
+    const first = await Effect.gen(function* () {
+      return yield* upsertTask(integration, issue({ description: 'orig' }), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    Obj.update(first.task, (task) => {
+      task.description = 'local edit';
+    });
+
+    await Effect.gen(function* () {
+      yield* upsertTask(integration, issue({ description: 'remote edit' }), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    expect(first.task.description).toBe('remote edit');
+  });
+
+  test('push: locally-edited title PATCHes only diverged fields', async ({ expect }) => {
+    const { db, integration } = await setup();
+    const layer = Database.layer(db);
+
+    const first = await Effect.gen(function* () {
+      return yield* upsertTask(integration, issue(), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    Obj.update(first.task, (task) => {
+      task.title = 'Edited locally';
+    });
+
+    let issueUpdateInput: LinearApi.IssueUpdateInput | undefined;
+    const result = await Effect.gen(function* () {
+      return yield* pushTeamUpdates(integration, new Map([['issue-1', issue()]]), new Map(), {
+        updateIssue: (_id, input) => {
+          issueUpdateInput = input;
+          return Effect.succeed(undefined);
+        },
+        updateProject: () => Effect.succeed(undefined),
+        resolveStateId: () => undefined,
+      });
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    expect(result.tasks).toBe(1);
+    expect(issueUpdateInput).toEqual({ title: 'Edited locally' });
+    // Snapshot refreshed so a subsequent push is a no-op.
+    const snapshots = (integration.snapshots ?? {}) as Record<string, any>;
+    expect(snapshots['issue-1']?.title).toBe('Edited locally');
+  });
+
+  test('push: snapshot-equal task is not pushed (no bouncing)', async ({ expect }) => {
+    const { db, integration } = await setup();
+    const layer = Database.layer(db);
+
+    await Effect.gen(function* () {
+      yield* upsertTask(integration, issue(), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    let calls = 0;
+    const result = await Effect.gen(function* () {
+      return yield* pushTeamUpdates(integration, new Map([['issue-1', issue()]]), new Map(), {
+        updateIssue: () => {
+          calls++;
+          return Effect.succeed(undefined);
+        },
+        updateProject: () => Effect.succeed(undefined),
+        resolveStateId: () => undefined,
+      });
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    expect(result.tasks).toBe(0);
+    expect(calls).toBe(0);
+  });
+
+  test('push: status divergence resolves to a Linear stateId', async ({ expect }) => {
+    const { db, integration } = await setup();
+    const layer = Database.layer(db);
+
+    const first = await Effect.gen(function* () {
+      return yield* upsertTask(integration, issue(), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    Obj.update(first.task, (task) => {
+      task.status = 'done';
+    });
+
+    let issueUpdateInput: LinearApi.IssueUpdateInput | undefined;
+    await Effect.gen(function* () {
+      yield* pushTeamUpdates(integration, new Map([['issue-1', issue()]]), new Map(), {
+        updateIssue: (_id, input) => {
+          issueUpdateInput = input;
+          return Effect.succeed(undefined);
+        },
+        updateProject: () => Effect.succeed(undefined),
+        resolveStateId: (_iss, status) => (status === 'done' ? 'state-completed-id' : undefined),
+      });
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    expect(issueUpdateInput?.stateId).toBe('state-completed-id');
+  });
+
+  test('push: project description divergence calls updateProject', async ({ expect }) => {
+    const { db, integration } = await setup();
+    const layer = Database.layer(db);
+
+    const local = await Effect.gen(function* () {
+      return yield* upsertProject(integration, project());
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    Obj.update(local, (proj) => {
+      proj.description = 'rewritten';
+    });
+
+    let projectInput: LinearApi.ProjectUpdateInput | undefined;
+    const result = await Effect.gen(function* () {
+      return yield* pushTeamUpdates(integration, new Map(), new Map([['proj-1', project()]]), {
+        updateIssue: () => Effect.succeed(undefined),
+        updateProject: (_id, input) => {
+          projectInput = input;
+          return Effect.succeed(undefined);
+        },
+        resolveStateId: () => undefined,
+      });
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    expect(result.projects).toBe(1);
+    expect(projectInput).toEqual({ description: 'rewritten' });
+  });
+});

--- a/packages/plugins/plugin-linear/src/operations/sync.test.ts
+++ b/packages/plugins/plugin-linear/src/operations/sync.test.ts
@@ -289,6 +289,35 @@ describe('plugin-linear sync', () => {
     expect(issueUpdateInput?.priority).toBeNull();
   });
 
+  test('pull: local priority on previously-unprioritised issue survives re-pull', async ({ expect }) => {
+    // Regression: when remote priority is undefined and snapshot.priority is
+    // also undefined (a *recorded* "no priority"), the merge must not treat
+    // it as "first sync" and clobber the user's local edit. This is the bug
+    // path that motivated the snapshotField/Snapshot wrapper API in
+    // app-toolkit/integration-sync.
+    const { db, integration } = await setup();
+    const layer = Database.layer(db);
+
+    // First pull: Linear says "no priority" (0 → undefined via the mapper).
+    const first = await Effect.gen(function* () {
+      return yield* upsertTask(integration, issue({ priority: 0 }), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    // User assigns priority locally.
+    Obj.update(first.task, (task) => {
+      task.priority = 'medium';
+    });
+    expect(first.task.priority).toBe('medium');
+
+    // Second pull with unchanged remote (still no priority). The local edit
+    // must survive.
+    await Effect.gen(function* () {
+      yield* upsertTask(integration, issue({ priority: 0 }), undefined);
+    }).pipe(Effect.provide(layer), runAndForwardErrors);
+
+    expect(first.task.priority).toBe('medium');
+  });
+
   test('push: project description divergence calls updateProject', async ({ expect }) => {
     const { db, integration } = await setup();
     const layer = Database.layer(db);

--- a/packages/plugins/plugin-linear/src/operations/sync.test.ts
+++ b/packages/plugins/plugin-linear/src/operations/sync.test.ts
@@ -231,7 +231,7 @@ describe('plugin-linear sync', () => {
     const { db, integration } = await setup();
     const layer = Database.layer(db);
 
-    const local = await Effect.gen(function* () {
+    const { project: local } = await Effect.gen(function* () {
       return yield* upsertProject(integration, project());
     }).pipe(Effect.provide(layer), runAndForwardErrors);
 

--- a/packages/plugins/plugin-linear/src/operations/sync.ts
+++ b/packages/plugins/plugin-linear/src/operations/sync.ts
@@ -176,7 +176,11 @@ export const upsertTask = Effect.fn('upsertTask')(function* (
 ) {
   const status = LinearApi.stateTypeToTaskStatus(issue.state.type);
   const priority = LinearApi.priorityNumberToTaskPriority(issue.priority);
-  const remoteFields: TaskSnapshot = {
+  // No explicit annotation: TS infers each property at its exact type
+  // (`title: string`, etc.). Annotating as TaskSnapshot would widen
+  // `title` to `string | undefined` and break the `mergeField<string>`
+  // call below, since Task.title is required.
+  const remoteFields = {
     title: issue.title,
     description: issue.description ?? '',
     status,
@@ -188,14 +192,20 @@ export const upsertTask = Effect.fn('upsertTask')(function* (
 
   if (existing) {
     const snapshot = readSnapshot<TaskSnapshot>(integration, issue.id) ?? {};
-    const titleResult = mergeField<string | undefined>(existing.title, remoteFields.title, snapshot.title);
+    // Task.title is required (non-optional), so widen the merge to plain string —
+    // the remote always provides one, and a snapshot is allowed to be undefined
+    // (first sync) since `mergeField` accepts `T | undefined` for snapshot.
+    const titleResult = mergeField<string>(existing.title, remoteFields.title, snapshot.title);
     const descriptionResult = mergeField<string | undefined>(
       existing.description,
       remoteFields.description,
       snapshot.description,
     );
     const statusResult = mergeField<TaskSnapshot['status']>(existing.status, remoteFields.status, snapshot.status);
-    const priorityResult = mergeField<TaskSnapshot['priority']>(
+    // Linear's reverse mapper drops `0` (no priority) → undefined, so the
+    // remote/snapshot side never holds 'none'. Widen to the full Task priority
+    // union so a locally-set 'none' typechecks too.
+    const priorityResult = mergeField<'none' | 'low' | 'medium' | 'high' | 'urgent' | undefined>(
       existing.priority,
       remoteFields.priority,
       snapshot.priority,

--- a/packages/plugins/plugin-linear/src/operations/sync.ts
+++ b/packages/plugins/plugin-linear/src/operations/sync.ts
@@ -382,9 +382,15 @@ export const pushTeamUpdates: <E, R>(
           });
         }
       }
-      if (snapshot.priority !== undefined && snapshot.priority !== localPriority) {
-        // priority can legitimately be `undefined` (no priority); send `null`
-        // to clear, otherwise the 1..4 numeric form.
+      if (snapshot.priority !== localPriority) {
+        // Unlike title/description/status, `undefined` is a meaningful value
+        // for priority on both sides ("no priority"). We compare by value
+        // only — gating on `snapshot.priority !== undefined` would silently
+        // drop pushes when the user assigns priority to a previously-empty
+        // issue.
+        //
+        // Send `null` to clear (Linear treats null distinctly from undefined),
+        // otherwise the 1..4 numeric form.
         input.priority = LinearApi.taskPriorityToPriorityNumber(localPriority) ?? null;
         diverged = true;
       }

--- a/packages/plugins/plugin-linear/src/operations/sync.ts
+++ b/packages/plugins/plugin-linear/src/operations/sync.ts
@@ -288,116 +288,113 @@ export const pushTeamUpdates: <R>(
     /** Resolve a desired Task status → Linear workflow-state id. Returns undefined when no mapping is known. */
     resolveStateId: (issue: LinearApi.Issue, status: 'todo' | 'in-progress' | 'done') => string | undefined;
   },
-) => Effect.Effect<LinearPushResult, Error, Database.Service | R> = Effect.fn('pushTeamUpdates')(function* (
-  integration,
-  remoteIssuesById,
-  remoteProjectsById,
-  push,
-) {
-  let projects = 0;
-  let tasks = 0;
+) => Effect.Effect<LinearPushResult, Error, Database.Service | R> = Effect.fn('pushTeamUpdates')(
+  function* (integration, remoteIssuesById, remoteProjectsById, push) {
+    let projects = 0;
+    let tasks = 0;
 
-  // Iterate all locally-known objects with a Linear foreign key. We re-query
-  // by-foreign-key for each remote id rather than walking every Project/Task
-  // in the database — both yield the same set, and the by-fid query keeps
-  // memory bounded for spaces with thousands of unrelated tasks.
-  for (const [id] of remoteProjectsById) {
-    const local = yield* findByForeignId<Project.Project>(Project.Project, id);
-    if (!local || Obj.isDeleted(local)) {
-      continue;
-    }
-    const snapshot = readSnapshot<ProjectSnapshot>(integration, id);
-    if (!snapshot) {
-      continue;
-    }
-    const localName = local.name ?? '';
-    const localDescription = local.description ?? '';
-    const input: LinearApi.ProjectUpdateInput = {};
-    let diverged = false;
-    if (snapshot.name !== undefined && snapshot.name !== localName) {
-      input.name = localName;
-      diverged = true;
-    }
-    if (snapshot.description !== undefined && snapshot.description !== localDescription) {
-      input.description = localDescription;
-      diverged = true;
-    }
-    if (!diverged) {
-      continue;
-    }
-    yield* push.updateProject(id, input);
-    writeSnapshot(integration, id, {
-      ...snapshot,
-      name: localName,
-      description: localDescription,
-    });
-    projects++;
-  }
-
-  for (const [id, remoteIssue] of remoteIssuesById) {
-    const local = yield* findByForeignId<Task.Task>(Task.Task, id);
-    if (!local || Obj.isDeleted(local)) {
-      continue;
-    }
-    const snapshot = readSnapshot<TaskSnapshot>(integration, id);
-    if (!snapshot) {
-      continue;
-    }
-    const localTitle = local.title ?? '';
-    const localDescription = local.description ?? '';
-    const localStatus = local.status;
-    const localPriority = local.priority;
-    const localEstimate = local.estimate;
-
-    const input: LinearApi.IssueUpdateInput = {};
-    let diverged = false;
-    if (snapshot.title !== undefined && snapshot.title !== localTitle) {
-      input.title = localTitle;
-      diverged = true;
-    }
-    if (snapshot.description !== undefined && snapshot.description !== localDescription) {
-      input.description = localDescription;
-      diverged = true;
-    }
-    if (snapshot.status !== undefined && localStatus !== undefined && snapshot.status !== localStatus) {
-      const stateId = push.resolveStateId(remoteIssue, localStatus);
-      if (stateId) {
-        input.stateId = stateId;
-        diverged = true;
-      } else {
-        log.warn('linear push: no workflow state mapping for status; skipping status push', {
-          issueId: id,
-          status: localStatus,
-        });
+    // Iterate all locally-known objects with a Linear foreign key. We re-query
+    // by-foreign-key for each remote id rather than walking every Project/Task
+    // in the database — both yield the same set, and the by-fid query keeps
+    // memory bounded for spaces with thousands of unrelated tasks.
+    for (const [id] of remoteProjectsById) {
+      const local = yield* findByForeignId<Project.Project>(Project.Project, id);
+      if (!local || Obj.isDeleted(local)) {
+        continue;
       }
+      const snapshot = readSnapshot<ProjectSnapshot>(integration, id);
+      if (!snapshot) {
+        continue;
+      }
+      const localName = local.name ?? '';
+      const localDescription = local.description ?? '';
+      const input: LinearApi.ProjectUpdateInput = {};
+      let diverged = false;
+      if (snapshot.name !== undefined && snapshot.name !== localName) {
+        input.name = localName;
+        diverged = true;
+      }
+      if (snapshot.description !== undefined && snapshot.description !== localDescription) {
+        input.description = localDescription;
+        diverged = true;
+      }
+      if (!diverged) {
+        continue;
+      }
+      yield* push.updateProject(id, input);
+      writeSnapshot(integration, id, {
+        ...snapshot,
+        name: localName,
+        description: localDescription,
+      });
+      projects++;
     }
-    if (snapshot.priority !== localPriority) {
-      // priority can legitimately be `undefined` (no priority); send 0 to clear.
-      const priorityNumber = LinearApi.taskPriorityToPriorityNumber(localPriority) ?? 0;
-      input.priority = priorityNumber;
-      diverged = true;
-    }
-    if (snapshot.estimate !== localEstimate && localEstimate !== undefined) {
-      input.estimate = localEstimate;
-      diverged = true;
-    }
-    if (!diverged) {
-      continue;
-    }
-    yield* push.updateIssue(id, input);
-    writeSnapshot(integration, id, {
-      ...snapshot,
-      title: localTitle,
-      description: localDescription,
-      status: localStatus ?? snapshot.status,
-      priority: localPriority,
-      estimate: localEstimate ?? snapshot.estimate,
-    });
-    tasks++;
-  }
 
-  return { projects, tasks };
-});
+    for (const [id, remoteIssue] of remoteIssuesById) {
+      const local = yield* findByForeignId<Task.Task>(Task.Task, id);
+      if (!local || Obj.isDeleted(local)) {
+        continue;
+      }
+      const snapshot = readSnapshot<TaskSnapshot>(integration, id);
+      if (!snapshot) {
+        continue;
+      }
+      const localTitle = local.title ?? '';
+      const localDescription = local.description ?? '';
+      const localStatus = local.status;
+      const localPriority = local.priority;
+      const localEstimate = local.estimate;
+
+      const input: LinearApi.IssueUpdateInput = {};
+      let diverged = false;
+      if (snapshot.title !== undefined && snapshot.title !== localTitle) {
+        input.title = localTitle;
+        diverged = true;
+      }
+      if (snapshot.description !== undefined && snapshot.description !== localDescription) {
+        input.description = localDescription;
+        diverged = true;
+      }
+      if (snapshot.status !== undefined && localStatus !== undefined && snapshot.status !== localStatus) {
+        const stateId = push.resolveStateId(remoteIssue, localStatus);
+        if (stateId) {
+          input.stateId = stateId;
+          diverged = true;
+        } else {
+          log.warn('linear push: no workflow state mapping for status; skipping status push', {
+            issueId: id,
+            status: localStatus,
+          });
+        }
+      }
+      if (snapshot.priority !== localPriority) {
+        // priority can legitimately be `undefined` (no priority); send 0 to clear.
+        const priorityNumber = LinearApi.taskPriorityToPriorityNumber(localPriority) ?? 0;
+        input.priority = priorityNumber;
+        diverged = true;
+      }
+      if (snapshot.estimate !== localEstimate && localEstimate !== undefined) {
+        input.estimate = localEstimate;
+        diverged = true;
+      }
+      if (!diverged) {
+        continue;
+      }
+      yield* push.updateIssue(id, input);
+      writeSnapshot(integration, id, {
+        ...snapshot,
+        title: localTitle,
+        description: localDescription,
+        status: localStatus ?? snapshot.status,
+        priority: localPriority,
+        estimate: localEstimate ?? snapshot.estimate,
+      });
+      tasks++;
+    }
+
+    return { projects, tasks };
+  },
+);
 
 //
 // Main handler
@@ -543,8 +540,10 @@ const handler: Operation.WithHandler<typeof SyncLinearTeams> = SyncLinearTeams.p
                     }
 
                     const pushResult = yield* pushTeamUpdates(integrationObj, remoteIssuesById, remoteProjectsById, {
-                      updateProject: (id, input) => LinearApi.updateProject(id, input).pipe(Effect.mapError((error) => error as Error)),
-                      updateIssue: (id, input) => LinearApi.updateIssue(id, input).pipe(Effect.mapError((error) => error as Error)),
+                      updateProject: (id, input) =>
+                        LinearApi.updateProject(id, input).pipe(Effect.mapError((error) => error as Error)),
+                      updateIssue: (id, input) =>
+                        LinearApi.updateIssue(id, input).pipe(Effect.mapError((error) => error as Error)),
                       resolveStateId,
                     });
                     pushedProjects += pushResult.projects;

--- a/packages/plugins/plugin-linear/src/operations/sync.ts
+++ b/packages/plugins/plugin-linear/src/operations/sync.ts
@@ -6,7 +6,7 @@ import * as FetchHttpClient from '@effect/platform/FetchHttpClient';
 import * as Effect from 'effect/Effect';
 import type * as Schema from 'effect/Schema';
 
-import { LayoutOperation } from '@dxos/app-toolkit';
+import { LayoutOperation, mergeField, readSnapshot, writeSnapshot } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
 import { Database, Filter, Obj, Query, Ref } from '@dxos/echo';
 import { log } from '@dxos/log';
@@ -20,23 +20,28 @@ import { LinearApi } from '../services';
 import { type SyncOptions, SyncLinearTeams } from './definitions';
 
 //
-// Direction: pull-only.
+// Direction: bidirectional (pull-then-push) for projects and tasks.
 //
-// v1 of this plugin pulls Project and Task (issue) from Linear into ECHO and
-// never writes back. Push is intentionally deferred.
+// On each sync pass we first pull every project + issue Linear can see into
+// ECHO, then walk the local objects we've synced and push any field that
+// diverged from the snapshot taken at the end of the previous pull. The
+// snapshot lives on `Integration.snapshots[<linear id>]` and is refreshed at
+// every pull and successful push so subsequent passes know exactly which
+// fields the user touched locally.
 //
-// Practical consequence: local edits to mapped fields (Task.title,
-// Task.description, Task.status, Task.priority, Task.estimate) are
-// overwritten by the remote value on every sync. Local edits to NON-mapped
-// fields (Project.image, etc.) are preserved.
+// Mapped fields per object:
+//   Project: name, description
+//   Task:    title, description, status, priority, estimate
 //
-// People are NOT synced. `Task.assigned` is left unset; the Linear assignee's
-// display name is intentionally dropped. (See the cross-source duplicates
-// note below for why we don't try to fuzzy-match local Persons.)
+// Conflict policy is remote-wins (mirrors Trello). People are NOT synced and
+// `Task.assigned` is left untouched. Comments are NOT synced (see plugin-github
+// for the chunking-required reason — same constraint applies here).
 //
-// Comments are NOT synced in v1 — mirrors plugin-github's stance: re-enable
-// once chunked/yielded to avoid automerge_wasm crashes when upserting many
-// messages in one tick.
+// New local objects (no Linear foreign key) are NOT pushed in this pass —
+// creating a Linear issue requires a target team and creating a project
+// requires a target team plus a state, and we don't currently surface either
+// at the call site. Update-only push covers the round-trip flow where the
+// user edits a synced item locally.
 //
 // Sync target shape: the user picks Linear TEAMS. Each team's projects and
 // issues are pulled. The user does not pick projects directly.
@@ -58,6 +63,25 @@ import { type SyncOptions, SyncLinearTeams } from './definitions';
 
 /** Per-target parallelism across selected teams. */
 const TEAM_CONCURRENCY = 2;
+
+//
+// Snapshot field shapes (stored on `Integration.snapshots`)
+//
+
+/** Snapshot for a Linear Project. */
+type ProjectSnapshot = {
+  name?: string;
+  description?: string;
+};
+
+/** Snapshot for a Linear Issue (mirrored as a Task locally). */
+type TaskSnapshot = {
+  title?: string;
+  description?: string;
+  status?: 'todo' | 'in-progress' | 'done';
+  priority?: 'low' | 'medium' | 'high' | 'urgent' | undefined;
+  estimate?: number | undefined;
+};
 
 //
 // Foreign-key + lookup helpers
@@ -84,49 +108,134 @@ const sinceFromOptions = (options: SyncOptions | undefined): string | undefined 
 };
 
 //
-// Upsert helpers (all pull-only)
+// Pull (snapshot-driven three-way merge)
 //
 
-const upsertProject = Effect.fn('upsertProject')(function* (project: LinearApi.Project) {
-  const existing = yield* findByForeignId<Project.Project>(Project.Project, project.id);
+/**
+ * Pull a Linear project into ECHO. Mapped fields (`name`, `description`) go
+ * through three-way merge against the snapshot at `integration.snapshots[id]`,
+ * then the snapshot is refreshed to remote-current so the next push knows
+ * exactly which fields the user has edited locally. Non-mapped fields
+ * (`Project.image`, etc.) are preserved.
+ */
+export const upsertProject = Effect.fn('upsertProject')(function* (
+  integration: Obj.Unknown & { snapshots?: Record<string, unknown> },
+  remote: LinearApi.Project,
+) {
+  const remoteFields: Required<ProjectSnapshot> = {
+    name: remote.name,
+    description: remote.description ?? '',
+  };
+  const existing = yield* findByForeignId<Project.Project>(Project.Project, remote.id);
+
   if (existing) {
-    Obj.update(existing, (existing) => {
-      existing.name = project.name;
-      if (project.description != null) {
-        existing.description = project.description;
+    const snapshot = readSnapshot<ProjectSnapshot>(integration, remote.id) ?? {};
+    const local = existing as unknown as Record<string, unknown>;
+    const writes: Partial<typeof remoteFields> = {};
+    for (const key of ['name', 'description'] as const) {
+      const result = mergeField(local[key] as string | undefined, remoteFields[key], snapshot[key]);
+      if (result.source === 'remote' && local[key] !== result.value) {
+        writes[key] = result.value;
       }
-    });
+    }
+    if (Object.keys(writes).length > 0) {
+      Obj.update(existing, (existing) => {
+        const m = existing as unknown as Record<string, unknown>;
+        for (const [k, v] of Object.entries(writes)) {
+          m[k] = v;
+        }
+      });
+    }
+    writeSnapshot(integration, remote.id, remoteFields);
     return existing;
   }
+
   const created = Obj.make(Project.Project, {
-    [Obj.Meta]: { keys: [fkFor(project.id)] },
-    name: project.name,
-    description: project.description ?? undefined,
+    [Obj.Meta]: { keys: [fkFor(remote.id)] },
+    name: remote.name,
+    description: remote.description ?? undefined,
   });
-  return yield* Database.add(created);
+  const persisted = yield* Database.add(created);
+  writeSnapshot(integration, remote.id, remoteFields);
+  return persisted;
 });
 
 /**
- * Pull-only upsert for a Linear issue → Task. Mapped fields (title,
- * description, status, priority, estimate) are overwritten by remote on every
- * sync; non-mapped fields are preserved. The Task → Project ref is wired on
- * create and refreshed if the issue's project changes.
+ * Pull a Linear issue into ECHO as a Task. Same merge shape as
+ * {@link upsertProject}, against snapshot fields {title, description, status,
+ * priority, estimate}. The Task → Project ref is wired on create and
+ * refreshed if the issue's project changes; assignees are intentionally not
+ * synced.
  */
-const upsertTask = Effect.fn('upsertTask')(function* (issue: LinearApi.Issue, project: Project.Project | undefined) {
+export const upsertTask = Effect.fn('upsertTask')(function* (
+  integration: Obj.Unknown & { snapshots?: Record<string, unknown> },
+  issue: LinearApi.Issue,
+  project: Project.Project | undefined,
+) {
   const status = LinearApi.stateTypeToTaskStatus(issue.state.type);
   const priority = LinearApi.priorityNumberToTaskPriority(issue.priority);
+  const remoteFields: TaskSnapshot = {
+    title: issue.title,
+    description: issue.description ?? '',
+    status,
+    priority,
+    estimate: issue.estimate ?? undefined,
+  };
 
   const existing = yield* findByForeignId<Task.Task>(Task.Task, issue.id);
+
   if (existing) {
-    Obj.update(existing, (existing) => {
-      existing.title = issue.title;
-      existing.description = issue.description ?? '';
-      existing.status = status;
-      if (priority !== undefined) {
-        existing.priority = priority;
+    const snapshot = readSnapshot<TaskSnapshot>(integration, issue.id) ?? {};
+    const local = existing as unknown as Record<string, unknown>;
+    const writes: Partial<TaskSnapshot> = {};
+    // title + description: simple string-typed merge.
+    {
+      const r = mergeField(local.title as string | undefined, remoteFields.title, snapshot.title);
+      if (r.source === 'remote' && local.title !== r.value) {
+        writes.title = r.value;
       }
-      if (issue.estimate != null) {
-        existing.estimate = issue.estimate;
+    }
+    {
+      const r = mergeField(local.description as string | undefined, remoteFields.description, snapshot.description);
+      if (r.source === 'remote' && local.description !== r.value) {
+        writes.description = r.value;
+      }
+    }
+    {
+      const r = mergeField(
+        local.status as TaskSnapshot['status'],
+        remoteFields.status,
+        snapshot.status,
+      );
+      if (r.source === 'remote' && local.status !== r.value) {
+        writes.status = r.value;
+      }
+    }
+    {
+      const r = mergeField(
+        local.priority as TaskSnapshot['priority'],
+        remoteFields.priority,
+        snapshot.priority,
+      );
+      // priority can legitimately be `undefined` on either side.
+      if (r.source === 'remote' && local.priority !== r.value) {
+        writes.priority = r.value;
+      }
+    }
+    {
+      const r = mergeField(
+        local.estimate as number | undefined,
+        remoteFields.estimate,
+        snapshot.estimate,
+      );
+      if (r.source === 'remote' && local.estimate !== r.value) {
+        writes.estimate = r.value;
+      }
+    }
+    Obj.update(existing, (existing) => {
+      const m = existing as unknown as Record<string, unknown>;
+      for (const [k, v] of Object.entries(writes)) {
+        m[k] = v;
       }
       if (project) {
         const currentProjectId = existing.project?.dxn.asEchoDXN()?.echoId;
@@ -136,6 +245,7 @@ const upsertTask = Effect.fn('upsertTask')(function* (issue: LinearApi.Issue, pr
         }
       }
     });
+    writeSnapshot(integration, issue.id, remoteFields);
     return { task: existing, created: false };
   }
 
@@ -149,7 +259,162 @@ const upsertTask = Effect.fn('upsertTask')(function* (issue: LinearApi.Issue, pr
     project: project ? Ref.make(project) : undefined,
   });
   const persisted = yield* Database.add(created);
+  writeSnapshot(integration, issue.id, remoteFields);
   return { task: persisted, created: true };
+});
+
+//
+// Push (snapshot diff → Linear mutations)
+//
+
+/** Result of one push pass over a single team's local-mirror objects. */
+export type LinearPushResult = {
+  projects: number;
+  tasks: number;
+};
+
+/**
+ * Push reconciler. For every Project/Task carrying a `LINEAR_SOURCE` foreign
+ * key, diff its mapped fields against the snapshot in
+ * `integration.snapshots[<id>]` and PATCH only the diverged fields back to
+ * Linear via `LinearApi.updateProject` / `updateIssue`.
+ *
+ * Tombstones (`Obj.isDeleted`) are skipped — Linear's `archived` lifecycle is
+ * one-way (we treat archived-on-Linear as "still present for sync", not as
+ * "should be deleted locally"), so the inverse direction is also a no-op.
+ *
+ * After a successful push we refresh the snapshot to the values just sent, so
+ * the next pass sees no divergence even before the next pull confirms it.
+ *
+ * `stateIdByTeamMember` resolves a Task `status` to a Linear workflow-state
+ * id for the issue's team. Status changes are only pushed when we have a
+ * mapping (otherwise the push silently skips status — better than failing
+ * the whole pass over an unrecognised workflow).
+ */
+export const pushTeamUpdates: <R>(
+  integration: Obj.Unknown & { snapshots?: Record<string, unknown> },
+  remoteIssuesById: ReadonlyMap<string, LinearApi.Issue>,
+  remoteProjectsById: ReadonlyMap<string, LinearApi.Project>,
+  push: {
+    /** Wraps `LinearApi.updateProject`. */
+    updateProject: (id: string, input: LinearApi.ProjectUpdateInput) => Effect.Effect<void, Error, R>;
+    /** Wraps `LinearApi.updateIssue`. */
+    updateIssue: (id: string, input: LinearApi.IssueUpdateInput) => Effect.Effect<void, Error, R>;
+    /** Resolve a desired Task status → Linear workflow-state id. Returns undefined when no mapping is known. */
+    resolveStateId: (issue: LinearApi.Issue, status: 'todo' | 'in-progress' | 'done') => string | undefined;
+  },
+) => Effect.Effect<LinearPushResult, Error, Database.Service | R> = Effect.fn('pushTeamUpdates')(function* (
+  integration,
+  remoteIssuesById,
+  remoteProjectsById,
+  push,
+) {
+  let projects = 0;
+  let tasks = 0;
+
+  // Iterate all locally-known objects with a Linear foreign key. We re-query
+  // by-foreign-key for each remote id rather than walking every Project/Task
+  // in the database — both yield the same set, and the by-fid query keeps
+  // memory bounded for spaces with thousands of unrelated tasks.
+  for (const [id, remoteProject] of remoteProjectsById) {
+    const local = yield* findByForeignId<Project.Project>(Project.Project, id);
+    if (!local || Obj.isDeleted(local)) {
+      continue;
+    }
+    const snapshot = readSnapshot<ProjectSnapshot>(integration, id);
+    if (!snapshot) {
+      continue;
+    }
+    const localFields = local as unknown as Record<string, unknown>;
+    const localName = (localFields.name as string | undefined) ?? '';
+    const localDescription = (localFields.description as string | undefined) ?? '';
+    const input: LinearApi.ProjectUpdateInput = {};
+    let diverged = false;
+    if (snapshot.name !== undefined && snapshot.name !== localName) {
+      input.name = localName;
+      diverged = true;
+    }
+    if (snapshot.description !== undefined && snapshot.description !== localDescription) {
+      input.description = localDescription;
+      diverged = true;
+    }
+    if (!diverged) {
+      continue;
+    }
+    yield* push.updateProject(id, input);
+    writeSnapshot(integration, id, {
+      ...snapshot,
+      name: localName,
+      description: localDescription,
+    });
+    void remoteProject; // referenced for symmetry with task loop / future state checks.
+    projects++;
+  }
+
+  for (const [id, remoteIssue] of remoteIssuesById) {
+    const local = yield* findByForeignId<Task.Task>(Task.Task, id);
+    if (!local || Obj.isDeleted(local)) {
+      continue;
+    }
+    const snapshot = readSnapshot<TaskSnapshot>(integration, id);
+    if (!snapshot) {
+      continue;
+    }
+    const localFields = local as unknown as Record<string, unknown>;
+    const localTitle = (localFields.title as string | undefined) ?? '';
+    const localDescription = (localFields.description as string | undefined) ?? '';
+    const localStatus = localFields.status as TaskSnapshot['status'];
+    const localPriority = localFields.priority as TaskSnapshot['priority'];
+    const localEstimate = localFields.estimate as number | undefined;
+
+    const input: LinearApi.IssueUpdateInput = {};
+    let diverged = false;
+    if (snapshot.title !== undefined && snapshot.title !== localTitle) {
+      input.title = localTitle;
+      diverged = true;
+    }
+    if (snapshot.description !== undefined && snapshot.description !== localDescription) {
+      input.description = localDescription;
+      diverged = true;
+    }
+    if (snapshot.status !== undefined && localStatus !== undefined && snapshot.status !== localStatus) {
+      const stateId = push.resolveStateId(remoteIssue, localStatus);
+      if (stateId) {
+        input.stateId = stateId;
+        diverged = true;
+      } else {
+        log.warn('linear push: no workflow state mapping for status; skipping status push', {
+          issueId: id,
+          status: localStatus,
+        });
+      }
+    }
+    if (snapshot.priority !== localPriority) {
+      // priority can legitimately be `undefined` (no priority); send 0 to clear.
+      const priorityNumber = LinearApi.taskPriorityToPriorityNumber(localPriority) ?? 0;
+      input.priority = priorityNumber;
+      diverged = true;
+    }
+    if (snapshot.estimate !== localEstimate && localEstimate !== undefined) {
+      input.estimate = localEstimate;
+      diverged = true;
+    }
+    if (!diverged) {
+      continue;
+    }
+    yield* push.updateIssue(id, input);
+    writeSnapshot(integration, id, {
+      ...snapshot,
+      title: localTitle,
+      description: localDescription,
+      status: localStatus ?? snapshot.status,
+      priority: localPriority,
+      estimate: localEstimate ?? snapshot.estimate,
+    });
+    tasks++;
+  }
+
+  return { projects, tasks };
 });
 
 //
@@ -223,6 +488,8 @@ const handler: Operation.WithHandler<typeof SyncLinearTeams> = SyncLinearTeams.p
 
           let pulledProjects = 0;
           let pulledTasks = 0;
+          let pushedProjects = 0;
+          let pushedTasks = 0;
 
           const perTarget = yield* Effect.forEach(
             targetEntries,
@@ -230,25 +497,76 @@ const handler: Operation.WithHandler<typeof SyncLinearTeams> = SyncLinearTeams.p
               Effect.gen(function* () {
                 const result = yield* Effect.either(
                   Effect.gen(function* () {
-                    // Projects → DXOS Projects.
+                    // Pull: projects → DXOS Projects, issues → DXOS Tasks.
+                    // Each upsert refreshes `integration.snapshots[<id>]` to
+                    // remote-current so the push pass below sees only
+                    // fields the user has edited locally since the last pull.
                     const projects = yield* LinearApi.fetchTeamProjects(remoteTeam.id);
                     const projectByRemoteId = new Map<string, Project.Project>();
+                    const remoteProjectsById = new Map<string, LinearApi.Project>();
                     for (const project of projects) {
-                      const local = yield* upsertProject(project);
+                      const local = yield* upsertProject(integrationObj, project);
                       projectByRemoteId.set(project.id, local);
+                      remoteProjectsById.set(project.id, project);
                       pulledProjects++;
                     }
 
-                    // Issues → DXOS Tasks.
                     const since = sinceFromOptions(options);
                     const issues = yield* LinearApi.fetchTeamIssues(remoteTeam.id, { since });
+                    const remoteIssuesById = new Map<string, LinearApi.Issue>();
                     for (const issue of issues) {
                       const project = issue.project ? projectByRemoteId.get(issue.project.id) : undefined;
-                      const { created } = yield* upsertTask(issue, project);
+                      const { created } = yield* upsertTask(integrationObj, issue, project);
+                      remoteIssuesById.set(issue.id, issue);
                       if (created) {
                         pulledTasks++;
                       }
                     }
+
+                    // Push: snapshot-diff every locally-mirrored object back
+                    // to Linear. Workflow states are fetched lazily — only
+                    // when at least one local Task status diverged — so
+                    // read-only syncs don't pay the round-trip.
+                    let workflowStates: ReadonlyArray<LinearApi.WorkflowState> | undefined;
+                    const resolveStateId = (issue: LinearApi.Issue, status: 'todo' | 'in-progress' | 'done') => {
+                      const desiredType = LinearApi.taskStatusToStateType(status);
+                      const states = workflowStates;
+                      if (!states) {
+                        return undefined;
+                      }
+                      // Match by category. Workspaces commonly have multiple
+                      // states per category (e.g. "In Review" + "In Progress"
+                      // both `started`); pick the first match for stability.
+                      return states.find((s) => s.type === desiredType)?.id;
+                    };
+
+                    // Probe local mirrors for any status divergence before
+                    // paying for /states. Cheap pre-check: we already have
+                    // the remote issues + snapshots in scope.
+                    const needsStates = (() => {
+                      for (const [id] of remoteIssuesById) {
+                        const snapshot = readSnapshot<TaskSnapshot>(integrationObj, id);
+                        if (!snapshot) {
+                          continue;
+                        }
+                        // Same lookup pattern as pushTeamUpdates would do; we
+                        // inline it here only as a heuristic to skip /states.
+                        // Worst case (false positive): one extra round-trip.
+                        return true;
+                      }
+                      return false;
+                    })();
+                    if (needsStates) {
+                      workflowStates = yield* LinearApi.fetchTeamWorkflowStates(remoteTeam.id);
+                    }
+
+                    const pushResult = yield* pushTeamUpdates(integrationObj, remoteIssuesById, remoteProjectsById, {
+                      updateProject: (id, input) => LinearApi.updateProject(id, input).pipe(Effect.mapError((error) => error as Error)),
+                      updateIssue: (id, input) => LinearApi.updateIssue(id, input).pipe(Effect.mapError((error) => error as Error)),
+                      resolveStateId,
+                    });
+                    pushedProjects += pushResult.projects;
+                    pushedTasks += pushResult.tasks;
 
                     // TODO(wittjosiah): Comments sync disabled — re-enable
                     // once chunked/yielded to avoid automerge_wasm crash
@@ -294,6 +612,10 @@ const handler: Operation.WithHandler<typeof SyncLinearTeams> = SyncLinearTeams.p
               teams: targetEntries.length,
               projects: pulledProjects,
               tasks: pulledTasks,
+            },
+            pushed: {
+              projects: pushedProjects,
+              tasks: pushedTasks,
             },
           };
         }).pipe(

--- a/packages/plugins/plugin-linear/src/operations/sync.ts
+++ b/packages/plugins/plugin-linear/src/operations/sync.ts
@@ -149,7 +149,7 @@ export const upsertProject = Effect.fn('upsertProject')(function* (
       });
     }
     writeSnapshot(integration, remote.id, remoteFields);
-    return existing;
+    return { project: existing, created: false };
   }
 
   const created = Obj.make(Project.Project, {
@@ -159,7 +159,7 @@ export const upsertProject = Effect.fn('upsertProject')(function* (
   });
   const persisted = yield* Database.add(created);
   writeSnapshot(integration, remote.id, remoteFields);
-  return persisted;
+  return { project: persisted, created: true };
 });
 
 /**
@@ -382,14 +382,17 @@ export const pushTeamUpdates: <E, R>(
           });
         }
       }
-      if (snapshot.priority !== localPriority) {
-        // priority can legitimately be `undefined` (no priority); send 0 to clear.
-        const priorityNumber = LinearApi.taskPriorityToPriorityNumber(localPriority) ?? 0;
-        input.priority = priorityNumber;
+      if (snapshot.priority !== undefined && snapshot.priority !== localPriority) {
+        // priority can legitimately be `undefined` (no priority); send `null`
+        // to clear, otherwise the 1..4 numeric form.
+        input.priority = LinearApi.taskPriorityToPriorityNumber(localPriority) ?? null;
         diverged = true;
       }
-      if (snapshot.estimate !== localEstimate && localEstimate !== undefined) {
-        input.estimate = localEstimate;
+      if (snapshot.estimate !== localEstimate) {
+        // Send `null` when the user cleared the estimate locally; Linear
+        // treats explicit `null` as a clear (undefined would leave it
+        // unchanged on the remote).
+        input.estimate = localEstimate ?? null;
         diverged = true;
       }
       if (!diverged) {
@@ -499,10 +502,12 @@ const handler: Operation.WithHandler<typeof SyncLinearTeams> = SyncLinearTeams.p
                     const projectByRemoteId = new Map<string, Project.Project>();
                     const remoteProjectsById = new Map<string, LinearApi.Project>();
                     for (const project of projects) {
-                      const local = yield* upsertProject(integrationObj, project);
+                      const { project: local, created } = yield* upsertProject(integrationObj, project);
                       projectByRemoteId.set(project.id, local);
                       remoteProjectsById.set(project.id, project);
-                      pulledProjects++;
+                      if (created) {
+                        pulledProjects++;
+                      }
                     }
 
                     const since = sinceFromOptions(options);
@@ -534,23 +539,15 @@ const handler: Operation.WithHandler<typeof SyncLinearTeams> = SyncLinearTeams.p
                       return states.find((s) => s.type === desiredType)?.id;
                     };
 
-                    // Probe local mirrors for any status divergence before
-                    // paying for /states. Cheap pre-check: we already have
-                    // the remote issues + snapshots in scope.
-                    const needsStates = (() => {
-                      for (const [id] of remoteIssuesById) {
-                        const snapshot = readSnapshot<TaskSnapshot>(integrationObj, id);
-                        if (!snapshot) {
-                          continue;
-                        }
-                        // Same lookup pattern as pushTeamUpdates would do; we
-                        // inline it here only as a heuristic to skip /states.
-                        // Worst case (false positive): one extra round-trip.
-                        return true;
-                      }
-                      return false;
-                    })();
-                    if (needsStates) {
+                    // Lazy fetch: we only need workflow states if there are
+                    // candidate issues to push. By this point `upsertTask`
+                    // above has seeded a snapshot for every id in
+                    // `remoteIssuesById`, so the existence of issues is
+                    // equivalent to "at least one candidate" — a stronger
+                    // pre-check (e.g. checking for divergent local status)
+                    // would need a synchronous DB read per id and isn't
+                    // worth the complexity for a single round-trip.
+                    if (remoteIssuesById.size > 0) {
                       workflowStates = yield* LinearApi.fetchTeamWorkflowStates(remoteTeam.id);
                     }
 

--- a/packages/plugins/plugin-linear/src/operations/sync.ts
+++ b/packages/plugins/plugin-linear/src/operations/sync.ts
@@ -285,20 +285,25 @@ export type LinearPushResult = {
  * id for the issue's team. Status changes are only pushed when we have a
  * mapping (otherwise the push silently skips status — better than failing
  * the whole pass over an unrecognised workflow).
+ *
+ * The push callbacks' error type is generic. The reconciler doesn't inspect
+ * or recover from those errors — it propagates so the outer `Effect.either`
+ * at the call site can record a per-target `lastError`. Generic-`E` keeps
+ * this module decoupled from the GraphQL error hierarchy of `LinearApi`.
  */
-export const pushTeamUpdates: <R>(
+export const pushTeamUpdates: <E, R>(
   integration: Obj.Unknown & { snapshots?: Record<string, unknown> },
   remoteIssuesById: ReadonlyMap<string, LinearApi.Issue>,
   remoteProjectsById: ReadonlyMap<string, LinearApi.Project>,
   push: {
     /** Wraps `LinearApi.updateProject`. */
-    updateProject: (id: string, input: LinearApi.ProjectUpdateInput) => Effect.Effect<void, Error, R>;
+    updateProject: (id: string, input: LinearApi.ProjectUpdateInput) => Effect.Effect<void, E, R>;
     /** Wraps `LinearApi.updateIssue`. */
-    updateIssue: (id: string, input: LinearApi.IssueUpdateInput) => Effect.Effect<void, Error, R>;
+    updateIssue: (id: string, input: LinearApi.IssueUpdateInput) => Effect.Effect<void, E, R>;
     /** Resolve a desired Task status → Linear workflow-state id. Returns undefined when no mapping is known. */
     resolveStateId: (issue: LinearApi.Issue, status: 'todo' | 'in-progress' | 'done') => string | undefined;
   },
-) => Effect.Effect<LinearPushResult, Error, Database.Service | R> = Effect.fn('pushTeamUpdates')(
+) => Effect.Effect<LinearPushResult, E, Database.Service | R> = Effect.fn('pushTeamUpdates')(
   function* (integration, remoteIssuesById, remoteProjectsById, push) {
     let projects = 0;
     let tasks = 0;
@@ -550,10 +555,8 @@ const handler: Operation.WithHandler<typeof SyncLinearTeams> = SyncLinearTeams.p
                     }
 
                     const pushResult = yield* pushTeamUpdates(integrationObj, remoteIssuesById, remoteProjectsById, {
-                      updateProject: (id, input) =>
-                        LinearApi.updateProject(id, input).pipe(Effect.mapError((error) => error as Error)),
-                      updateIssue: (id, input) =>
-                        LinearApi.updateIssue(id, input).pipe(Effect.mapError((error) => error as Error)),
+                      updateProject: (id, input) => LinearApi.updateProject(id, input),
+                      updateIssue: (id, input) => LinearApi.updateIssue(id, input),
                       resolveStateId,
                     });
                     pushedProjects += pushResult.projects;

--- a/packages/plugins/plugin-linear/src/operations/sync.ts
+++ b/packages/plugins/plugin-linear/src/operations/sync.ts
@@ -130,19 +130,21 @@ export const upsertProject = Effect.fn('upsertProject')(function* (
 
   if (existing) {
     const snapshot = readSnapshot<ProjectSnapshot>(integration, remote.id) ?? {};
-    const local = existing as unknown as Record<string, unknown>;
-    const writes: Partial<typeof remoteFields> = {};
-    for (const key of ['name', 'description'] as const) {
-      const result = mergeField(local[key] as string | undefined, remoteFields[key], snapshot[key]);
-      if (result.source === 'remote' && local[key] !== result.value) {
-        writes[key] = result.value;
-      }
-    }
-    if (Object.keys(writes).length > 0) {
+    const nameResult = mergeField<string | undefined>(existing.name, remoteFields.name, snapshot.name);
+    const descriptionResult = mergeField<string | undefined>(
+      existing.description,
+      remoteFields.description,
+      snapshot.description,
+    );
+    const writeName = nameResult.source === 'remote' && existing.name !== nameResult.value;
+    const writeDescription = descriptionResult.source === 'remote' && existing.description !== descriptionResult.value;
+    if (writeName || writeDescription) {
       Obj.update(existing, (existing) => {
-        const m = existing as unknown as Record<string, unknown>;
-        for (const [k, v] of Object.entries(writes)) {
-          m[k] = v;
+        if (writeName) {
+          existing.name = nameResult.value;
+        }
+        if (writeDescription) {
+          existing.description = descriptionResult.value;
         }
       });
     }
@@ -186,56 +188,39 @@ export const upsertTask = Effect.fn('upsertTask')(function* (
 
   if (existing) {
     const snapshot = readSnapshot<TaskSnapshot>(integration, issue.id) ?? {};
-    const local = existing as unknown as Record<string, unknown>;
-    const writes: Partial<TaskSnapshot> = {};
-    // title + description: simple string-typed merge.
-    {
-      const r = mergeField(local.title as string | undefined, remoteFields.title, snapshot.title);
-      if (r.source === 'remote' && local.title !== r.value) {
-        writes.title = r.value;
-      }
-    }
-    {
-      const r = mergeField(local.description as string | undefined, remoteFields.description, snapshot.description);
-      if (r.source === 'remote' && local.description !== r.value) {
-        writes.description = r.value;
-      }
-    }
-    {
-      const r = mergeField(
-        local.status as TaskSnapshot['status'],
-        remoteFields.status,
-        snapshot.status,
-      );
-      if (r.source === 'remote' && local.status !== r.value) {
-        writes.status = r.value;
-      }
-    }
-    {
-      const r = mergeField(
-        local.priority as TaskSnapshot['priority'],
-        remoteFields.priority,
-        snapshot.priority,
-      );
-      // priority can legitimately be `undefined` on either side.
-      if (r.source === 'remote' && local.priority !== r.value) {
-        writes.priority = r.value;
-      }
-    }
-    {
-      const r = mergeField(
-        local.estimate as number | undefined,
-        remoteFields.estimate,
-        snapshot.estimate,
-      );
-      if (r.source === 'remote' && local.estimate !== r.value) {
-        writes.estimate = r.value;
-      }
-    }
+    const titleResult = mergeField<string | undefined>(existing.title, remoteFields.title, snapshot.title);
+    const descriptionResult = mergeField<string | undefined>(
+      existing.description,
+      remoteFields.description,
+      snapshot.description,
+    );
+    const statusResult = mergeField<TaskSnapshot['status']>(existing.status, remoteFields.status, snapshot.status);
+    const priorityResult = mergeField<TaskSnapshot['priority']>(
+      existing.priority,
+      remoteFields.priority,
+      snapshot.priority,
+    );
+    const estimateResult = mergeField<number | undefined>(existing.estimate, remoteFields.estimate, snapshot.estimate);
+    const writeTitle = titleResult.source === 'remote' && existing.title !== titleResult.value;
+    const writeDescription = descriptionResult.source === 'remote' && existing.description !== descriptionResult.value;
+    const writeStatus = statusResult.source === 'remote' && existing.status !== statusResult.value;
+    const writePriority = priorityResult.source === 'remote' && existing.priority !== priorityResult.value;
+    const writeEstimate = estimateResult.source === 'remote' && existing.estimate !== estimateResult.value;
     Obj.update(existing, (existing) => {
-      const m = existing as unknown as Record<string, unknown>;
-      for (const [k, v] of Object.entries(writes)) {
-        m[k] = v;
+      if (writeTitle) {
+        existing.title = titleResult.value;
+      }
+      if (writeDescription) {
+        existing.description = descriptionResult.value;
+      }
+      if (writeStatus) {
+        existing.status = statusResult.value;
+      }
+      if (writePriority) {
+        existing.priority = priorityResult.value;
+      }
+      if (writeEstimate) {
+        existing.estimate = estimateResult.value;
       }
       if (project) {
         const currentProjectId = existing.project?.dxn.asEchoDXN()?.echoId;
@@ -316,7 +301,7 @@ export const pushTeamUpdates: <R>(
   // by-foreign-key for each remote id rather than walking every Project/Task
   // in the database — both yield the same set, and the by-fid query keeps
   // memory bounded for spaces with thousands of unrelated tasks.
-  for (const [id, remoteProject] of remoteProjectsById) {
+  for (const [id] of remoteProjectsById) {
     const local = yield* findByForeignId<Project.Project>(Project.Project, id);
     if (!local || Obj.isDeleted(local)) {
       continue;
@@ -325,9 +310,8 @@ export const pushTeamUpdates: <R>(
     if (!snapshot) {
       continue;
     }
-    const localFields = local as unknown as Record<string, unknown>;
-    const localName = (localFields.name as string | undefined) ?? '';
-    const localDescription = (localFields.description as string | undefined) ?? '';
+    const localName = local.name ?? '';
+    const localDescription = local.description ?? '';
     const input: LinearApi.ProjectUpdateInput = {};
     let diverged = false;
     if (snapshot.name !== undefined && snapshot.name !== localName) {
@@ -347,7 +331,6 @@ export const pushTeamUpdates: <R>(
       name: localName,
       description: localDescription,
     });
-    void remoteProject; // referenced for symmetry with task loop / future state checks.
     projects++;
   }
 
@@ -360,12 +343,11 @@ export const pushTeamUpdates: <R>(
     if (!snapshot) {
       continue;
     }
-    const localFields = local as unknown as Record<string, unknown>;
-    const localTitle = (localFields.title as string | undefined) ?? '';
-    const localDescription = (localFields.description as string | undefined) ?? '';
-    const localStatus = localFields.status as TaskSnapshot['status'];
-    const localPriority = localFields.priority as TaskSnapshot['priority'];
-    const localEstimate = localFields.estimate as number | undefined;
+    const localTitle = local.title ?? '';
+    const localDescription = local.description ?? '';
+    const localStatus = local.status;
+    const localPriority = local.priority;
+    const localEstimate = local.estimate;
 
     const input: LinearApi.IssueUpdateInput = {};
     let diverged = false;

--- a/packages/plugins/plugin-linear/src/operations/sync.ts
+++ b/packages/plugins/plugin-linear/src/operations/sync.ts
@@ -6,7 +6,7 @@ import * as FetchHttpClient from '@effect/platform/FetchHttpClient';
 import * as Effect from 'effect/Effect';
 import type * as Schema from 'effect/Schema';
 
-import { LayoutOperation, mergeField, readSnapshot, writeSnapshot } from '@dxos/app-toolkit';
+import { LayoutOperation, mergeField, readSnapshot, snapshotField, writeSnapshot } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
 import { Database, Filter, Obj, Query, Ref } from '@dxos/echo';
 import { log } from '@dxos/log';
@@ -68,19 +68,24 @@ const TEAM_CONCURRENCY = 2;
 // Snapshot field shapes (stored on `Integration.snapshots`)
 //
 
-/** Snapshot for a Linear Project. */
+/**
+ * Snapshot shapes. Fields are typed `required` (not `?`) because every
+ * snapshot is written in one shot via {@link writeSnapshot} after a pull;
+ * the absence-of-snapshot case is modeled by `readSnapshot` returning
+ * `undefined`, not by partially-populated objects. `priority` and `estimate`
+ * carry `undefined` as a valid recorded value ("no priority", "no estimate").
+ */
 type ProjectSnapshot = {
-  name?: string;
-  description?: string;
+  name: string;
+  description: string;
 };
 
-/** Snapshot for a Linear Issue (mirrored as a Task locally). */
 type TaskSnapshot = {
-  title?: string;
-  description?: string;
-  status?: 'todo' | 'in-progress' | 'done';
-  priority?: 'low' | 'medium' | 'high' | 'urgent' | undefined;
-  estimate?: number | undefined;
+  title: string;
+  description: string;
+  status: 'todo' | 'in-progress' | 'done';
+  priority: 'low' | 'medium' | 'high' | 'urgent' | undefined;
+  estimate: number | undefined;
 };
 
 //
@@ -129,12 +134,16 @@ export const upsertProject = Effect.fn('upsertProject')(function* (
   const existing = yield* findByForeignId<Project.Project>(Project.Project, remote.id);
 
   if (existing) {
-    const snapshot = readSnapshot<ProjectSnapshot>(integration, remote.id) ?? {};
-    const nameResult = mergeField<string | undefined>(existing.name, remoteFields.name, snapshot.name);
+    const snapshot = readSnapshot<ProjectSnapshot>(integration, remote.id);
+    const nameResult = mergeField<string | undefined>(
+      existing.name,
+      remoteFields.name,
+      snapshotField(snapshot, 'name'),
+    );
     const descriptionResult = mergeField<string | undefined>(
       existing.description,
       remoteFields.description,
-      snapshot.description,
+      snapshotField(snapshot, 'description'),
     );
     const writeName = nameResult.source === 'remote' && existing.name !== nameResult.value;
     const writeDescription = descriptionResult.source === 'remote' && existing.description !== descriptionResult.value;
@@ -191,26 +200,35 @@ export const upsertTask = Effect.fn('upsertTask')(function* (
   const existing = yield* findByForeignId<Task.Task>(Task.Task, issue.id);
 
   if (existing) {
-    const snapshot = readSnapshot<TaskSnapshot>(integration, issue.id) ?? {};
-    // Task.title is required (non-optional), so widen the merge to plain string —
-    // the remote always provides one, and a snapshot is allowed to be undefined
-    // (first sync) since `mergeField` accepts `T | undefined` for snapshot.
-    const titleResult = mergeField<string>(existing.title, remoteFields.title, snapshot.title);
+    const snapshot = readSnapshot<TaskSnapshot>(integration, issue.id);
+    // Task.title is required (non-optional), so widen the merge to plain string.
+    const titleResult = mergeField<string>(existing.title, remoteFields.title, snapshotField(snapshot, 'title'));
     const descriptionResult = mergeField<string | undefined>(
       existing.description,
       remoteFields.description,
-      snapshot.description,
+      snapshotField(snapshot, 'description'),
     );
-    const statusResult = mergeField<TaskSnapshot['status']>(existing.status, remoteFields.status, snapshot.status);
+    // Task.status is optional on the schema (may be `undefined` locally), but
+    // every snapshot writes a concrete status — so widen to include undefined
+    // for the local side while the snapshot side stays narrow.
+    const statusResult = mergeField<TaskSnapshot['status'] | undefined>(
+      existing.status,
+      remoteFields.status,
+      snapshotField(snapshot, 'status'),
+    );
     // Linear's reverse mapper drops `0` (no priority) → undefined, so the
     // remote/snapshot side never holds 'none'. Widen to the full Task priority
     // union so a locally-set 'none' typechecks too.
     const priorityResult = mergeField<'none' | 'low' | 'medium' | 'high' | 'urgent' | undefined>(
       existing.priority,
       remoteFields.priority,
-      snapshot.priority,
+      snapshotField(snapshot, 'priority'),
     );
-    const estimateResult = mergeField<number | undefined>(existing.estimate, remoteFields.estimate, snapshot.estimate);
+    const estimateResult = mergeField<number | undefined>(
+      existing.estimate,
+      remoteFields.estimate,
+      snapshotField(snapshot, 'estimate'),
+    );
     const writeTitle = titleResult.source === 'remote' && existing.title !== titleResult.value;
     const writeDescription = descriptionResult.source === 'remote' && existing.description !== descriptionResult.value;
     const writeStatus = statusResult.source === 'remote' && existing.status !== statusResult.value;

--- a/packages/plugins/plugin-linear/src/services/linear-api.ts
+++ b/packages/plugins/plugin-linear/src/services/linear-api.ts
@@ -549,12 +549,17 @@ const IssueUpdateResponseSchema = Schema.Struct({
  * Fails with {@link LinearGraphQLError} when Linear returns `success: false`
  * or the GraphQL envelope contains errors (e.g. token lacks `write` scope).
  */
+/**
+ * `description`, `priority`, and `estimate` accept `null` to clear the field
+ * on Linear. `undefined` means "leave unchanged" — Linear treats the two
+ * distinctly. `title` and `stateId` cannot meaningfully be cleared.
+ */
 export type IssueUpdateInput = {
   title?: string;
-  description?: string;
+  description?: string | null;
   stateId?: string;
-  priority?: number;
-  estimate?: number;
+  priority?: number | null;
+  estimate?: number | null;
 };
 
 export const updateIssue = (id: string, input: IssueUpdateInput): LinearEffect<void> =>
@@ -562,7 +567,9 @@ export const updateIssue = (id: string, input: IssueUpdateInput): LinearEffect<v
     const response = yield* linearGraphQL(ISSUE_UPDATE_MUTATION, { id, input }, IssueUpdateResponseSchema);
     if (!response.issueUpdate.success) {
       return yield* Effect.fail(
-        new LinearGraphQLError({ context: { messages: [`issueUpdate(${id}) returned success=false`] } }),
+        new LinearGraphQLError({
+          context: { messages: [`issueUpdate(${id}) returned success=false`], variables: { id, input } },
+        }),
       );
     }
   });
@@ -587,7 +594,7 @@ const ProjectUpdateResponseSchema = Schema.Struct({
 
 export type ProjectUpdateInput = {
   name?: string;
-  description?: string;
+  description?: string | null;
 };
 
 /** Update fields on a Linear project. Same semantics as {@link updateIssue}. */
@@ -596,7 +603,9 @@ export const updateProject = (id: string, input: ProjectUpdateInput): LinearEffe
     const response = yield* linearGraphQL(PROJECT_UPDATE_MUTATION, { id, input }, ProjectUpdateResponseSchema);
     if (!response.projectUpdate.success) {
       return yield* Effect.fail(
-        new LinearGraphQLError({ context: { messages: [`projectUpdate(${id}) returned success=false`] } }),
+        new LinearGraphQLError({
+          context: { messages: [`projectUpdate(${id}) returned success=false`], variables: { id, input } },
+        }),
       );
     }
   });

--- a/packages/plugins/plugin-linear/src/services/linear-api.ts
+++ b/packages/plugins/plugin-linear/src/services/linear-api.ts
@@ -424,12 +424,9 @@ export const priorityNumberToTaskPriority = (
  * the Task model treats absent as "no opinion", so a round-tripped issue
  * keeps whatever priority it had on Linear if local has none.
  */
-export const taskPriorityToPriorityNumber = (priority: 'low' | 'medium' | 'high' | 'urgent' | undefined):
-  | 1
-  | 2
-  | 3
-  | 4
-  | undefined => {
+export const taskPriorityToPriorityNumber = (
+  priority: 'none' | 'low' | 'medium' | 'high' | 'urgent' | undefined,
+): 1 | 2 | 3 | 4 | undefined => {
   switch (priority) {
     case 'urgent':
       return 1;
@@ -439,6 +436,7 @@ export const taskPriorityToPriorityNumber = (priority: 'low' | 'medium' | 'high'
       return 3;
     case 'low':
       return 4;
+    case 'none':
     default:
       return undefined;
   }

--- a/packages/plugins/plugin-linear/src/services/linear-api.ts
+++ b/packages/plugins/plugin-linear/src/services/linear-api.ts
@@ -417,3 +417,188 @@ export const priorityNumberToTaskPriority = (
       return undefined;
   }
 };
+
+/**
+ * Reverse of {@link priorityNumberToTaskPriority}. Used when pushing local
+ * priority edits back to Linear. We never produce 0 (No priority) on push —
+ * the Task model treats absent as "no opinion", so a round-tripped issue
+ * keeps whatever priority it had on Linear if local has none.
+ */
+export const taskPriorityToPriorityNumber = (priority: 'low' | 'medium' | 'high' | 'urgent' | undefined):
+  | 1
+  | 2
+  | 3
+  | 4
+  | undefined => {
+  switch (priority) {
+    case 'urgent':
+      return 1;
+    case 'high':
+      return 2;
+    case 'medium':
+      return 3;
+    case 'low':
+      return 4;
+    default:
+      return undefined;
+  }
+};
+
+/**
+ * Reverse of {@link stateTypeToTaskStatus}. Used to pick a Linear workflow
+ * state when pushing a local status change. The Task → state-type mapping is
+ * lossy in one direction (canceled and completed both map to `done`), so on
+ * push we pick a single canonical Linear state-type per Task status:
+ *
+ * - `todo`        → `unstarted`
+ * - `in-progress` → `started`
+ * - `done`        → `completed`
+ *
+ * Callers resolve the resulting state-type to an actual workflow-state ID via
+ * {@link fetchTeamWorkflowStates} per team.
+ */
+export const taskStatusToStateType = (status: 'todo' | 'in-progress' | 'done'): StateType => {
+  switch (status) {
+    case 'in-progress':
+      return 'started';
+    case 'done':
+      return 'completed';
+    case 'todo':
+    default:
+      return 'unstarted';
+  }
+};
+
+//
+// Workflow states (needed to map Task.status → Linear state ID on push)
+//
+
+const WorkflowStateSchema = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+  type: StateTypeSchema,
+});
+export type WorkflowState = Schema.Schema.Type<typeof WorkflowStateSchema>;
+
+const TEAM_WORKFLOW_STATES_QUERY = /* GraphQL */ `
+  query TeamWorkflowStates($teamId: String!, $first: Int!, $after: String) {
+    team(id: $teamId) {
+      states(first: $first, after: $after) {
+        nodes {
+          id
+          name
+          type
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`;
+
+const TeamWorkflowStatesSchema = Schema.Struct({
+  team: Schema.Struct({
+    states: Schema.Struct({
+      nodes: Schema.Array(WorkflowStateSchema),
+      pageInfo: PageInfoSchema,
+    }),
+  }),
+});
+
+/**
+ * List workflow states (Backlog, In Progress, Done, etc.) for a team. Each
+ * state has a `type` (the cross-workspace category) plus an `id` we can pass
+ * to `issueUpdate(stateId: ...)`. State names are workspace-customisable; we
+ * never match by name on push.
+ */
+export const fetchTeamWorkflowStates = (teamId: string): LinearEffect<readonly WorkflowState[]> =>
+  paginate(TEAM_WORKFLOW_STATES_QUERY, { teamId }, (d) => d.team.states, TeamWorkflowStatesSchema);
+
+//
+// Mutations
+//
+
+const ISSUE_UPDATE_MUTATION = /* GraphQL */ `
+  mutation IssueUpdate($id: String!, $input: IssueUpdateInput!) {
+    issueUpdate(id: $id, input: $input) {
+      success
+      issue {
+        id
+      }
+    }
+  }
+`;
+
+const IssueUpdateResponseSchema = Schema.Struct({
+  issueUpdate: Schema.Struct({
+    success: Schema.Boolean,
+    issue: Schema.NullOr(Schema.Struct({ id: Schema.String })).pipe(Schema.optional),
+  }),
+});
+
+/**
+ * Update fields on a Linear issue. All input fields are optional; only fields
+ * explicitly set are sent (so `description: undefined` is dropped, vs. `null`
+ * or empty string which Linear treats as a clear).
+ *
+ * `stateId` must be a state from the issue's team — see
+ * {@link fetchTeamWorkflowStates}. `priority` is the 0–4 numeric form (use
+ * {@link taskPriorityToPriorityNumber}); `estimate` is the team's estimate
+ * unit (typically points).
+ *
+ * Fails with {@link LinearGraphQLError} when Linear returns `success: false`
+ * or the GraphQL envelope contains errors (e.g. token lacks `write` scope).
+ */
+export type IssueUpdateInput = {
+  title?: string;
+  description?: string;
+  stateId?: string;
+  priority?: number;
+  estimate?: number;
+};
+
+export const updateIssue = (id: string, input: IssueUpdateInput): LinearEffect<void> =>
+  Effect.gen(function* () {
+    const response = yield* linearGraphQL(ISSUE_UPDATE_MUTATION, { id, input }, IssueUpdateResponseSchema);
+    if (!response.issueUpdate.success) {
+      return yield* Effect.fail(
+        new LinearGraphQLError({ context: { messages: [`issueUpdate(${id}) returned success=false`] } }),
+      );
+    }
+  });
+
+const PROJECT_UPDATE_MUTATION = /* GraphQL */ `
+  mutation ProjectUpdate($id: String!, $input: ProjectUpdateInput!) {
+    projectUpdate(id: $id, input: $input) {
+      success
+      project {
+        id
+      }
+    }
+  }
+`;
+
+const ProjectUpdateResponseSchema = Schema.Struct({
+  projectUpdate: Schema.Struct({
+    success: Schema.Boolean,
+    project: Schema.NullOr(Schema.Struct({ id: Schema.String })).pipe(Schema.optional),
+  }),
+});
+
+export type ProjectUpdateInput = {
+  name?: string;
+  description?: string;
+};
+
+/** Update fields on a Linear project. Same semantics as {@link updateIssue}. */
+export const updateProject = (id: string, input: ProjectUpdateInput): LinearEffect<void> =>
+  Effect.gen(function* () {
+    const response = yield* linearGraphQL(PROJECT_UPDATE_MUTATION, { id, input }, ProjectUpdateResponseSchema);
+    if (!response.projectUpdate.success) {
+      return yield* Effect.fail(
+        new LinearGraphQLError({ context: { messages: [`projectUpdate(${id}) returned success=false`] } }),
+      );
+    }
+  });

--- a/packages/plugins/plugin-trello/src/operations/handlers.test.ts
+++ b/packages/plugins/plugin-trello/src/operations/handlers.test.ts
@@ -195,8 +195,7 @@ describe('Trello operation handlers (e2e with stubbed API)', () => {
     // `SetIntegrationTargets` op is covered by its own test; here we just
     // simulate the dialog's effect on `integration.targets`.
     Obj.update(integration, (integration) => {
-      const m = integration as Obj.Mutable<typeof integration>;
-      m.targets = [{ remoteId: boardA.id, name: boardA.name }];
+      integration.targets = [{ remoteId: boardA.id, name: boardA.name }];
     });
     expect(integration.targets).toHaveLength(1);
     expect(integration.targets[0].object).toBeUndefined();
@@ -238,8 +237,7 @@ describe('Trello operation handlers (e2e with stubbed API)', () => {
 
     // Select both boards by recording `{ remoteId, name }` entries.
     Obj.update(integration, (integration) => {
-      const m = integration as Obj.Mutable<typeof integration>;
-      m.targets = discovered.targets.map((t) => ({ remoteId: t.id, name: t.name }));
+      integration.targets = discovered.targets.map((target) => ({ remoteId: target.id, name: target.name }));
     });
 
     await syncTrelloBoardHandler

--- a/packages/plugins/plugin-trello/src/operations/sync.test.ts
+++ b/packages/plugins/plugin-trello/src/operations/sync.test.ts
@@ -388,8 +388,7 @@ describe('pushBoardCards (push)', () => {
 
     // Seed a snapshot so we can detect a local divergence on `description` only.
     Obj.update(integration, (integration) => {
-      const mut = integration as Obj.Mutable<typeof integration>;
-      mut.snapshots = {
+      integration.snapshots = {
         card1: { name: 'Task A', description: 'orig', listName: 'To Do' },
       };
     });
@@ -434,8 +433,7 @@ describe('pushBoardCards (push)', () => {
     const { db, integration } = await setup();
 
     Obj.update(integration, (integration) => {
-      const mut = integration as Obj.Mutable<typeof integration>;
-      mut.snapshots = {
+      integration.snapshots = {
         card1: { name: 'Pulled', description: '', listName: 'To Do' },
       };
     });

--- a/packages/plugins/plugin-trello/src/operations/sync.ts
+++ b/packages/plugins/plugin-trello/src/operations/sync.ts
@@ -5,7 +5,7 @@
 import * as FetchHttpClient from '@effect/platform/FetchHttpClient';
 import * as Effect from 'effect/Effect';
 
-import { LayoutOperation, mergeDeep, mergeField, readSnapshot, writeSnapshot } from '@dxos/app-toolkit';
+import { LayoutOperation, mergeDeep, mergeField, readSnapshot, snapshotField, writeSnapshot } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
 import { Database, Filter, Obj, Query, Ref } from '@dxos/echo';
 import { log } from '@dxos/log';
@@ -44,15 +44,19 @@ type MappedField = (typeof MAPPED_FIELDS)[number];
 type CardSnapshot = Partial<Record<MappedField, unknown>>;
 
 type BoardSnapshot = {
-  name?: string;
+  name: string;
   /**
    * Canonical column order at last pull (Trello list `pos` order). Display
    * reads this instead of `Object.keys(arrangement.columns)` because ECHO /
    * Automerge does not preserve insertion order across reload — keys come
    * back in canonical (alphabetical) order.
+   *
+   * Fields are required (not `?`) because the snapshot is always written in
+   * one shot at the end of a pull; the "no snapshot yet" state is modeled
+   * by `readSnapshot` returning `undefined`.
    */
-  order?: string[];
-  columns?: Record<string, { ids: string[] }>;
+  order: string[];
+  columns: Record<string, { ids: string[] }>;
 };
 
 // Per-field three-way merge primitives are shared with other integration plugins
@@ -145,12 +149,12 @@ export const reconcileBoardCards: (
           log.warn('trello pull: foreign-keyed local object is not an Expando; skipping', { cardId: card.id });
           continue;
         }
-        const snapshot = readSnapshot<CardSnapshot>(integration, card.id) ?? {};
+        const snapshot = readSnapshot<CardSnapshot>(integration, card.id);
 
         const merged: Record<MappedField, unknown> = { ...remoteFields };
         const writes: Partial<Record<MappedField, unknown>> = {};
         for (const field of MAPPED_FIELDS) {
-          const result = mergeField(existing[field], remoteFields[field], snapshot[field]);
+          const result = mergeField(existing[field], remoteFields[field], snapshotField(snapshot, field));
           merged[field] = result.value;
           if (result.source === 'remote' && existing[field] !== result.value) {
             writes[field] = result.value;
@@ -238,13 +242,21 @@ export const reconcileBoardCards: (
     // Board-level three-way merge: name + arrangement.order + arrangement.columns.
     // Local-wins outputs are left in place but currently NOT pushed back to
     // Trello — board rename and arrangement reorder push aren't implemented yet.
-    const boardSnapshot = readSnapshot<BoardSnapshot>(integration, remoteBoard.id) ?? {};
-    const nameMerge = mergeField<string | undefined>(kanban.name, remoteBoard.name, boardSnapshot.name);
-    const orderMerge = mergeDeep<string[]>([...kanban.arrangement.order], orderedListNames, boardSnapshot.order);
+    const boardSnapshot = readSnapshot<BoardSnapshot>(integration, remoteBoard.id);
+    const nameMerge = mergeField<string | undefined>(
+      kanban.name,
+      remoteBoard.name,
+      snapshotField(boardSnapshot, 'name'),
+    );
+    const orderMerge = mergeDeep<string[]>(
+      [...kanban.arrangement.order],
+      orderedListNames,
+      snapshotField(boardSnapshot, 'order'),
+    );
     const columnsMerge = mergeDeep<Record<string, { ids: string[] }>>(
       kanban.arrangement.columns as Record<string, { ids: string[] }>,
       remoteColumns,
-      boardSnapshot.columns,
+      snapshotField(boardSnapshot, 'columns'),
     );
 
     if (nameMerge.source === 'remote' && kanban.name !== nameMerge.value) {

--- a/packages/plugins/plugin-trello/src/operations/sync.ts
+++ b/packages/plugins/plugin-trello/src/operations/sync.ts
@@ -153,9 +153,9 @@ export const reconcileBoardCards: (
 
         if (Object.keys(writes).length > 0) {
           Obj.update(existing, (existing) => {
-            const m = existing as unknown as Record<string, unknown>;
-            for (const [k, v] of Object.entries(writes)) {
-              m[k] = v;
+            const fields = existing as unknown as Record<string, unknown>;
+            for (const [key, value] of Object.entries(writes)) {
+              fields[key] = value;
             }
           });
           updated++;
@@ -195,9 +195,8 @@ export const reconcileBoardCards: (
 
     if (newRefs.length > 0) {
       Obj.update(kanban, (kanban) => {
-        const m = kanban as Obj.Mutable<typeof kanban>;
-        if (m.spec.kind === 'items') {
-          m.spec.items = [...(m.spec.items as ReadonlyArray<Ref.Ref<Obj.Unknown>>), ...newRefs];
+        if (kanban.spec.kind === 'items') {
+          kanban.spec.items = [...(kanban.spec.items as ReadonlyArray<Ref.Ref<Obj.Unknown>>), ...newRefs];
         }
       });
     }
@@ -245,14 +244,12 @@ export const reconcileBoardCards: (
 
     if (nameMerge.source === 'remote' && kanban.name !== nameMerge.value) {
       Obj.update(kanban, (kanban) => {
-        const m = kanban as Obj.Mutable<typeof kanban>;
-        m.name = nameMerge.value;
+        kanban.name = nameMerge.value;
       });
     }
     if (orderMerge.source === 'remote') {
       Obj.update(kanban, (kanban) => {
-        const m = kanban as Obj.Mutable<typeof kanban>;
-        m.arrangement.order = orderMerge.value;
+        kanban.arrangement.order = orderMerge.value;
       });
     } else if (orderMerge.source === 'local') {
       log.warn('trello pull: local column order diverged from snapshot; push of reorders is not yet implemented', {
@@ -261,14 +258,13 @@ export const reconcileBoardCards: (
     }
     if (columnsMerge.source === 'remote') {
       Obj.update(kanban, (kanban) => {
-        const m = kanban as Obj.Mutable<typeof kanban>;
-        const prev = m.arrangement.columns as Record<string, { ids: string[]; hidden?: boolean }>;
+        const prev = kanban.arrangement.columns as Record<string, { ids: string[]; hidden?: boolean }>;
         const merged = columnsMerge.value as Record<string, { ids: string[]; hidden?: boolean }>;
         // Remote columns are only Trello lists — never include UNCATEGORIZED. mergeDeep(remote-wins)
         // would drop the initial `{ hidden: true }` bucket from findOrCreateKanbanForBoard.
         const uncategorizedIds = merged[UNCATEGORIZED_VALUE]?.ids ?? prev[UNCATEGORIZED_VALUE]?.ids ?? [];
         const uncategorizedHidden = merged[UNCATEGORIZED_VALUE]?.hidden ?? prev[UNCATEGORIZED_VALUE]?.hidden ?? true;
-        m.arrangement.columns = {
+        kanban.arrangement.columns = {
           ...merged,
           [UNCATEGORIZED_VALUE]: { ids: uncategorizedIds, hidden: uncategorizedHidden },
         };
@@ -557,10 +553,9 @@ const handler: Operation.WithHandler<typeof SyncTrelloBoard> = SyncTrelloBoard.p
               localObj = yield* findOrCreateKanbanForBoard(remoteBoard);
               const materializedRef = Ref.make(localObj);
               Obj.update(integrationObj, (integrationObj) => {
-                const mutable = integrationObj as Obj.Mutable<typeof integrationObj>;
-                const idx = mutable.targets.findIndex((t) => t.remoteId === foreignId);
+                const idx = integrationObj.targets.findIndex((target) => target.remoteId === foreignId);
                 if (idx >= 0) {
-                  mutable.targets[idx] = { ...mutable.targets[idx], object: materializedRef };
+                  integrationObj.targets[idx] = { ...integrationObj.targets[idx], object: materializedRef };
                 }
               });
             }
@@ -621,13 +616,12 @@ const handler: Operation.WithHandler<typeof SyncTrelloBoard> = SyncTrelloBoard.p
                 // Match by `remoteId` (stable across runs) with a fallback to
                 // local-object echo id for legacy entries that lack `remoteId`.
                 Obj.update(integrationObj, (integrationObj) => {
-                  const m = integrationObj as Obj.Mutable<typeof integrationObj>;
-                  const idx = m.targets.findIndex((t) => {
-                    if (t.remoteId !== undefined) {
-                      return t.remoteId === boardId;
+                  const idx = integrationObj.targets.findIndex((target) => {
+                    if (target.remoteId !== undefined) {
+                      return target.remoteId === boardId;
                     }
-                    const localId = t.object?.target
-                      ? Obj.getMeta(t.object.target).keys.find((k) => k.source === TRELLO_SOURCE)?.id
+                    const localId = target.object?.target
+                      ? Obj.getMeta(target.object.target).keys.find((key) => key.source === TRELLO_SOURCE)?.id
                       : undefined;
                     return localId === boardId;
                   });
@@ -635,14 +629,14 @@ const handler: Operation.WithHandler<typeof SyncTrelloBoard> = SyncTrelloBoard.p
                     return;
                   }
                   if (result._tag === 'Right') {
-                    m.targets[idx] = {
-                      ...m.targets[idx],
+                    integrationObj.targets[idx] = {
+                      ...integrationObj.targets[idx],
                       lastSyncAt: new Date().toISOString(),
                       lastError: undefined,
                     };
                   } else {
-                    m.targets[idx] = {
-                      ...m.targets[idx],
+                    integrationObj.targets[idx] = {
+                      ...integrationObj.targets[idx],
                       lastError: formatTrelloSyncFailure(result.left),
                     };
                   }

--- a/packages/plugins/plugin-trello/src/operations/sync.ts
+++ b/packages/plugins/plugin-trello/src/operations/sync.ts
@@ -138,24 +138,29 @@ export const reconcileBoardCards: (
       }
 
       if (existing) {
+        // Trello-managed cards are always Expandos (see the else branch below
+        // for the only create site). Narrowing here lets us index fields
+        // without an `unknown` cast.
+        if (!Obj.instanceOf(Expando.Expando, existing)) {
+          log.warn('trello pull: foreign-keyed local object is not an Expando; skipping', { cardId: card.id });
+          continue;
+        }
         const snapshot = readSnapshot<CardSnapshot>(integration, card.id) ?? {};
-        const fields = existing as unknown as Record<string, unknown>;
 
         const merged: Record<MappedField, unknown> = { ...remoteFields };
         const writes: Partial<Record<MappedField, unknown>> = {};
-        for (const k of MAPPED_FIELDS) {
-          const result = mergeField(fields[k], remoteFields[k], snapshot[k]);
-          merged[k] = result.value;
-          if (result.source === 'remote' && fields[k] !== result.value) {
-            writes[k] = result.value;
+        for (const field of MAPPED_FIELDS) {
+          const result = mergeField(existing[field], remoteFields[field], snapshot[field]);
+          merged[field] = result.value;
+          if (result.source === 'remote' && existing[field] !== result.value) {
+            writes[field] = result.value;
           }
         }
 
         if (Object.keys(writes).length > 0) {
           Obj.update(existing, (existing) => {
-            const fields = existing as unknown as Record<string, unknown>;
             for (const [key, value] of Object.entries(writes)) {
-              fields[key] = value;
+              existing[key] = value;
             }
           });
           updated++;
@@ -343,13 +348,16 @@ export const pushBoardCards = Effect.fn('pushBoardCards')(function* <R>(
     if (Obj.isDeleted(target)) {
       continue;
     }
+    // Trello-managed cards are always Expandos; narrowing here lets us
+    // index fields without an `unknown` cast.
+    if (!Obj.instanceOf(Expando.Expando, target)) {
+      continue;
+    }
 
-    const fields = target as unknown as Record<string, unknown>;
-
-    const foreignId = Obj.getMeta(target).keys.find((k) => k.source === TRELLO_SOURCE)?.id;
-    const name = typeof fields.name === 'string' ? fields.name : '';
-    const desc = typeof fields.description === 'string' ? fields.description : '';
-    const localListName = typeof fields.listName === 'string' ? fields.listName : undefined;
+    const foreignId = Obj.getMeta(target).keys.find((key) => key.source === TRELLO_SOURCE)?.id;
+    const name = typeof target.name === 'string' ? target.name : '';
+    const desc = typeof target.description === 'string' ? target.description : '';
+    const localListName = typeof target.listName === 'string' ? target.listName : undefined;
     const listId = localListName ? listIdByName.get(localListName) : undefined;
 
     if (localListName && !listId) {

--- a/packages/plugins/plugin-trello/src/operations/sync.ts
+++ b/packages/plugins/plugin-trello/src/operations/sync.ts
@@ -5,7 +5,7 @@
 import * as FetchHttpClient from '@effect/platform/FetchHttpClient';
 import * as Effect from 'effect/Effect';
 
-import { LayoutOperation } from '@dxos/app-toolkit';
+import { LayoutOperation, mergeDeep, mergeField, readSnapshot, writeSnapshot } from '@dxos/app-toolkit';
 import { Operation } from '@dxos/compute';
 import { Database, Filter, Obj, Query, Ref } from '@dxos/echo';
 import { log } from '@dxos/log';
@@ -55,77 +55,8 @@ type BoardSnapshot = {
   columns?: Record<string, { ids: string[] }>;
 };
 
-/**
- * Per-field three-way merge over `(local, remote, snapshot)`.
- *
- * - No snapshot (first sync of this id): take remote.
- * - Local unchanged, remote unchanged → no-op (return local).
- * - Local unchanged, remote changed → take remote (pull).
- * - Local changed, remote unchanged → keep local (push will write it).
- * - Both changed → **remote wins** (Trello is source of truth; local edit is lost).
- *
- * Equality is `===` for primitives (which is what Trello's mapped fields are).
- * For object/array values use `mergeDeep` instead.
- */
-const mergeField = <T>(
-  local: T,
-  remote: T,
-  snapshot: T | undefined,
-): { value: T; source: 'local' | 'remote' | 'unchanged' } => {
-  if (snapshot === undefined) {
-    return { value: remote, source: local === remote ? 'unchanged' : 'remote' };
-  }
-  const localChanged = local !== snapshot;
-  const remoteChanged = remote !== snapshot;
-  if (!localChanged && !remoteChanged) {
-    return { value: local, source: 'unchanged' };
-  }
-  if (!localChanged && remoteChanged) {
-    return { value: remote, source: 'remote' };
-  }
-  if (localChanged && !remoteChanged) {
-    return { value: local, source: 'local' };
-  }
-  return { value: remote, source: 'remote' };
-};
-
-/** Deep-equal merge for object values (e.g. arrangement). Same policy as `mergeField`. */
-const mergeDeep = <T>(
-  local: T,
-  remote: T,
-  snapshot: T | undefined,
-): { value: T; source: 'local' | 'remote' | 'unchanged' } => {
-  const eq = (a: unknown, b: unknown) => JSON.stringify(a) === JSON.stringify(b);
-  if (snapshot === undefined) {
-    return { value: remote, source: eq(local, remote) ? 'unchanged' : 'remote' };
-  }
-  const localChanged = !eq(local, snapshot);
-  const remoteChanged = !eq(remote, snapshot);
-  if (!localChanged && !remoteChanged) {
-    return { value: local, source: 'unchanged' };
-  }
-  if (!localChanged && remoteChanged) {
-    return { value: remote, source: 'remote' };
-  }
-  if (localChanged && !remoteChanged) {
-    return { value: local, source: 'local' };
-  }
-  return { value: remote, source: 'remote' };
-};
-
-/** Mutates `integration.snapshots[foreignId] = snapshot` inside an `Obj.update`. */
-const writeSnapshot = (integration: Integration.Integration, foreignId: string, snapshot: object): void => {
-  Obj.update(integration, (integration) => {
-    const m = integration as Obj.Mutable<typeof integration>;
-    const existing = (m.snapshots ?? {}) as Record<string, unknown>;
-    m.snapshots = { ...existing, [foreignId]: snapshot };
-  });
-};
-
-const readSnapshot = <T extends object>(integration: Integration.Integration, foreignId: string): T | undefined => {
-  const snapshots = (integration.snapshots ?? {}) as Record<string, unknown>;
-  return snapshots[foreignId] as T | undefined;
-};
+// Per-field three-way merge primitives are shared with other integration plugins
+// (Linear, GitHub) and live in `@dxos/app-toolkit`.
 
 /**
  * Pull reconciler with snapshot-driven three-way merge.

--- a/packages/sdk/app-toolkit/src/index.ts
+++ b/packages/sdk/app-toolkit/src/index.ts
@@ -12,6 +12,7 @@ export * from './collaboration';
 export * from './companion-types';
 export * from './file';
 export * from './graph';
+export * from './integration-sync';
 export * from './object-node';
 export * from './not-found';
 export * from './operations';

--- a/packages/sdk/app-toolkit/src/integration-sync.ts
+++ b/packages/sdk/app-toolkit/src/integration-sync.ts
@@ -21,6 +21,21 @@ import { Obj } from '@dxos/echo';
 export type MergeResult<T> = { value: T; source: 'local' | 'remote' | 'unchanged' };
 
 /**
+ * Snapshot wrapper passed to the merge primitives.
+ *
+ * `undefined` means "no snapshot has ever been recorded for this id" — the
+ * merge treats it as first-sync and takes remote.
+ *
+ * `{ value }` means "the snapshot has a recorded value" — and `value` may
+ * itself be `undefined` (e.g. Linear's "no priority" sentinel). This is the
+ * critical distinction: if a caller collapses "no snapshot" and "snapshot
+ * value is undefined" into the same `undefined`, then a local edit that
+ * disagrees with a recorded-undefined snapshot gets clobbered on pull as if
+ * the user had never edited it.
+ */
+export type Snapshot<T> = { value: T } | undefined;
+
+/**
  * Per-field three-way merge over `(local, remote, snapshot)`.
  *
  * - No snapshot (first sync of this id): take remote.
@@ -32,12 +47,13 @@ export type MergeResult<T> = { value: T; source: 'local' | 'remote' | 'unchanged
  * Equality is `===` for primitives (numbers, strings, booleans). For object /
  * array values use {@link mergeDeep} instead.
  */
-export const mergeField = <T>(local: T, remote: T, snapshot: T | undefined): MergeResult<T> => {
+export const mergeField = <T>(local: T, remote: T, snapshot: Snapshot<T>): MergeResult<T> => {
   if (snapshot === undefined) {
     return { value: remote, source: local === remote ? 'unchanged' : 'remote' };
   }
-  const localChanged = local !== snapshot;
-  const remoteChanged = remote !== snapshot;
+  const snapshotValue = snapshot.value;
+  const localChanged = local !== snapshotValue;
+  const remoteChanged = remote !== snapshotValue;
   if (!localChanged && !remoteChanged) {
     return { value: local, source: 'unchanged' };
   }
@@ -72,13 +88,14 @@ const stableStringify = (value: unknown): string =>
   });
 
 /** Deep-equal merge for object values (e.g. arrangement). Same policy as {@link mergeField}. */
-export const mergeDeep = <T>(local: T, remote: T, snapshot: T | undefined): MergeResult<T> => {
+export const mergeDeep = <T>(local: T, remote: T, snapshot: Snapshot<T>): MergeResult<T> => {
   const eq = (a: unknown, b: unknown) => stableStringify(a) === stableStringify(b);
   if (snapshot === undefined) {
     return { value: remote, source: eq(local, remote) ? 'unchanged' : 'remote' };
   }
-  const localChanged = !eq(local, snapshot);
-  const remoteChanged = !eq(remote, snapshot);
+  const snapshotValue = snapshot.value;
+  const localChanged = !eq(local, snapshotValue);
+  const remoteChanged = !eq(remote, snapshotValue);
   if (!localChanged && !remoteChanged) {
     return { value: local, source: 'unchanged' };
   }
@@ -100,6 +117,22 @@ export const readSnapshot = <T extends object>(carrier: SnapshotCarrier, foreign
   const snapshots = (carrier.snapshots ?? {}) as Record<string, unknown>;
   return snapshots[foreignId] as T | undefined;
 };
+
+/**
+ * Build a {@link Snapshot} wrapper for one field of a snapshot object.
+ *
+ * Returns `undefined` when no snapshot exists for the id at all (first sync),
+ * or `{ value }` when the snapshot exists — `value` may itself be `undefined`
+ * if the field is a legitimate "no value" sentinel (e.g. Linear's priority).
+ */
+export const snapshotField = <T extends object, K extends keyof T>(snapshot: T | undefined, key: K): Snapshot<T[K]> =>
+  snapshot === undefined ? undefined : { value: snapshot[key] };
+
+/**
+ * Build a {@link Snapshot} wrapper from an optional raw value. Use when the
+ * caller already has the conditional "do I have a snapshot" check.
+ */
+export const snapshotOf = <T>(present: boolean, value: T): Snapshot<T> => (present ? { value } : undefined);
 
 /**
  * Writes `carrier.snapshots[foreignId] = snapshot` inside an `Obj.update`. Allocates

--- a/packages/sdk/app-toolkit/src/integration-sync.ts
+++ b/packages/sdk/app-toolkit/src/integration-sync.ts
@@ -1,0 +1,92 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Obj } from '@dxos/echo';
+
+/**
+ * Three-way merge primitives shared by integration sync handlers (Trello, Linear,
+ * GitHub, ...). Each integration stores per-remote-id snapshots on its
+ * `Integration` object's `.snapshots` field so the next pull/push pass can
+ * decide, per field, whether the local or the remote side has changed since
+ * the last successful sync.
+ *
+ * The merge primitives are pure; the snapshot accessors operate on any ECHO
+ * object that exposes `.snapshots: Record<string, unknown>` — typically the
+ * `Integration` schema in `@dxos/plugin-integration` — but app-toolkit does
+ * not import that schema directly to avoid a cycle.
+ */
+
+/** Result of {@link mergeField} / {@link mergeDeep}. */
+export type MergeResult<T> = { value: T; source: 'local' | 'remote' | 'unchanged' };
+
+/**
+ * Per-field three-way merge over `(local, remote, snapshot)`.
+ *
+ * - No snapshot (first sync of this id): take remote.
+ * - Local unchanged, remote unchanged → no-op (return local).
+ * - Local unchanged, remote changed → take remote (pull).
+ * - Local changed, remote unchanged → keep local (push will write it).
+ * - Both changed → **remote wins** (the integration's source-of-truth policy).
+ *
+ * Equality is `===` for primitives (numbers, strings, booleans). For object /
+ * array values use {@link mergeDeep} instead.
+ */
+export const mergeField = <T>(local: T, remote: T, snapshot: T | undefined): MergeResult<T> => {
+  if (snapshot === undefined) {
+    return { value: remote, source: local === remote ? 'unchanged' : 'remote' };
+  }
+  const localChanged = local !== snapshot;
+  const remoteChanged = remote !== snapshot;
+  if (!localChanged && !remoteChanged) {
+    return { value: local, source: 'unchanged' };
+  }
+  if (!localChanged && remoteChanged) {
+    return { value: remote, source: 'remote' };
+  }
+  if (localChanged && !remoteChanged) {
+    return { value: local, source: 'local' };
+  }
+  return { value: remote, source: 'remote' };
+};
+
+/** Deep-equal merge for object values (e.g. arrangement). Same policy as {@link mergeField}. */
+export const mergeDeep = <T>(local: T, remote: T, snapshot: T | undefined): MergeResult<T> => {
+  const eq = (a: unknown, b: unknown) => JSON.stringify(a) === JSON.stringify(b);
+  if (snapshot === undefined) {
+    return { value: remote, source: eq(local, remote) ? 'unchanged' : 'remote' };
+  }
+  const localChanged = !eq(local, snapshot);
+  const remoteChanged = !eq(remote, snapshot);
+  if (!localChanged && !remoteChanged) {
+    return { value: local, source: 'unchanged' };
+  }
+  if (!localChanged && remoteChanged) {
+    return { value: remote, source: 'remote' };
+  }
+  if (localChanged && !remoteChanged) {
+    return { value: local, source: 'local' };
+  }
+  return { value: remote, source: 'remote' };
+};
+
+/** Type alias for the integration-side carrier of snapshots. */
+export type SnapshotCarrier = Obj.Unknown & { snapshots?: Record<string, unknown> };
+
+/** Reads `carrier.snapshots[foreignId]` typed as `T`. Returns undefined if absent. */
+export const readSnapshot = <T extends object>(carrier: SnapshotCarrier, foreignId: string): T | undefined => {
+  const snapshots = (carrier.snapshots ?? {}) as Record<string, unknown>;
+  return snapshots[foreignId] as T | undefined;
+};
+
+/**
+ * Writes `carrier.snapshots[foreignId] = snapshot` inside an `Obj.update`. Allocates
+ * a fresh map so the assignment is safe under ECHO's structural-sharing semantics.
+ */
+export const writeSnapshot = (carrier: SnapshotCarrier, foreignId: string, snapshot: object): void => {
+  Obj.update(carrier, (carrier) => {
+    const m = carrier as Obj.Mutable<typeof carrier>;
+    const existing = (m.snapshots ?? {}) as Record<string, unknown>;
+    m.snapshots = { ...existing, [foreignId]: snapshot };
+  });
+};

--- a/packages/sdk/app-toolkit/src/integration-sync.ts
+++ b/packages/sdk/app-toolkit/src/integration-sync.ts
@@ -85,8 +85,7 @@ export const readSnapshot = <T extends object>(carrier: SnapshotCarrier, foreign
  */
 export const writeSnapshot = (carrier: SnapshotCarrier, foreignId: string, snapshot: object): void => {
   Obj.update(carrier, (carrier) => {
-    const m = carrier as Obj.Mutable<typeof carrier>;
-    const existing = (m.snapshots ?? {}) as Record<string, unknown>;
-    m.snapshots = { ...existing, [foreignId]: snapshot };
+    const existing = (carrier.snapshots ?? {}) as Record<string, unknown>;
+    carrier.snapshots = { ...existing, [foreignId]: snapshot };
   });
 };

--- a/packages/sdk/app-toolkit/src/integration-sync.ts
+++ b/packages/sdk/app-toolkit/src/integration-sync.ts
@@ -47,12 +47,33 @@ export const mergeField = <T>(local: T, remote: T, snapshot: T | undefined): Mer
   if (localChanged && !remoteChanged) {
     return { value: local, source: 'local' };
   }
+  // Both changed → remote-wins by policy.
   return { value: remote, source: 'remote' };
 };
 
+/**
+ * Stable JSON stringify: sorts object keys recursively so structurally-equal
+ * objects with different insertion order serialize to the same string. ECHO /
+ * Automerge canonicalizes maps to alphabetical key order on reload, while a
+ * remote-derived map (e.g. Trello's `arrangement.columns` built in `pos`
+ * order) preserves insertion order — without sorting, the equality check
+ * below would flag a no-op merge as `remote` and force a write every sync.
+ */
+const stableStringify = (value: unknown): string =>
+  JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      const sorted: Record<string, unknown> = {};
+      for (const key of Object.keys(val as Record<string, unknown>).sort()) {
+        sorted[key] = (val as Record<string, unknown>)[key];
+      }
+      return sorted;
+    }
+    return val;
+  });
+
 /** Deep-equal merge for object values (e.g. arrangement). Same policy as {@link mergeField}. */
 export const mergeDeep = <T>(local: T, remote: T, snapshot: T | undefined): MergeResult<T> => {
-  const eq = (a: unknown, b: unknown) => JSON.stringify(a) === JSON.stringify(b);
+  const eq = (a: unknown, b: unknown) => stableStringify(a) === stableStringify(b);
   if (snapshot === undefined) {
     return { value: remote, source: eq(local, remote) ? 'unchanged' : 'remote' };
   }
@@ -67,6 +88,7 @@ export const mergeDeep = <T>(local: T, remote: T, snapshot: T | undefined): Merg
   if (localChanged && !remoteChanged) {
     return { value: local, source: 'local' };
   }
+  // Both changed → remote-wins by policy.
   return { value: remote, source: 'remote' };
 };
 


### PR DESCRIPTION
## Summary

Adds bidirectional sync for projects and tasks to the Linear and GitHub plugins, modelled on what plugin-trello already does for kanban cards. Comments stay out of scope (GitHub's existing comment sync remains disabled pending the chunking rewrite, and Linear has the same constraint).

The shared three-way-merge primitives live in `@dxos/app-toolkit` so all three plugins (Trello, Linear, GitHub) — and any future integration — use one implementation.

### How it works

Every sync pass is pull-then-push:

1. **Pull**: each mapped field of every remote object is fed into `mergeField(local, remote, snapshot)`:
   - no snapshot (first sync) → take remote
   - one side changed → take that side
   - both changed → **remote wins**
   At the end of the pull, `Integration.snapshots[<remote-id>]` is refreshed to remote-current — so the next pass knows exactly which fields the user has edited locally since.

2. **Push**: walk every locally-mirrored object with a foreign key and PATCH only the fields where local diverges from the snapshot. After a successful push the snapshot is refreshed with the values just sent so the same edit isn't bounced back next pass.

### Scope-mapped fields

| Object | Linear | GitHub |
|---|---|---|
| Project | name, description | description (`name` is logged but not pushed — repo renames are destructive) |
| Task | title, description, status, priority, estimate | title, description, status |

Status push for Linear lazily fetches `team.states` and resolves Task `status` (todo / in-progress / done) → workspace-specific workflow-state id by `state.type` category. GitHub's open/closed maps trivially.

### Out of scope (intentional, deferred)

- New local objects (no foreign key) are not pushed yet — creating a Linear issue needs a target team, and creating a GitHub issue needs (owner, repo); we don't currently surface either at the call site.
- Comments — GitHub's `syncCommentsForTask` was removed since it was already disabled; both will need the chunked-yield rewrite before they can be enabled.
- Person sync from Linear (still intentionally dropped per the v1 design note).
- Repo renames in GitHub (logged on divergence; not pushed).

### Notable changes

- **OAuth scope on Linear** upgraded from `['read']` to `['read', 'write']`. **Existing tokens issued read-only will hit permission errors on push until the user re-consents.** GitHub's scope was already empty (App-driven) and didn't change.
- **GitHub attribution caveat**: pushed edits are attributed to the App / token holder, not the local user. Documented in the file header but worth being aware of for shared spaces.

### Tests

- `plugin-linear/src/operations/sync.test.ts` — 9 tests covering first pull, idempotent pull, local-edit preservation, remote-only change, both-changed → remote wins, push (title), push no-op (snapshot equal), push status → stateId resolution, push project description.
- `plugin-github/src/operations/sync.test.ts` — 6 tests covering push (title), push no-op, push status flip, push repo description, repo rename suppression, soft-delete skip.
- All previous Trello, Linear, and GitHub plugin tests continue to pass.

### Test plan

- [ ] CI green on the **Check** workflow.
- [ ] Manual round-trip on a Linear team: pull a real issue, edit description locally, sync, confirm Linear shows the new description.
- [ ] Manual round-trip on a GitHub repo: pull issues, close one locally (status → done), sync, confirm GitHub shows the issue closed.
- [ ] Conflict probe: edit the same field on both sides between two syncs, confirm remote wins after the next pull.

https://claude.ai/code/session_011LGFoi7GxTzmpLWwtPKqqs

---
_Generated by [Claude Code](https://claude.ai/code/session_011LGFoi7GxTzmpLWwtPKqqs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bidirectional sync for GitHub, Linear, and Trello: local edits to projects/tasks are now pushed back; repo renames are detected but not auto-applied.

* **Behavior Changes**
  * Pushes selectively update only diverged fields (titles, descriptions, statuses/priorities); deleted items are skipped.

* **Tests**
  * Added/expanded integration tests covering push diffs, no-op semantics, and snapshot refreshes.

* **Refactor**
  * Shared three-way-merge and snapshot utilities introduced and adopted.

* **Chore**
  * SDK now re-exports integration-sync utilities; Linear OAuth requests write scope.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11287)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->