### PR TITLE
fix(plugin-bluesky): revert to transition:generic OAuth scope

### DIFF
--- a/packages/plugins/plugin-bluesky/src/capabilities/integration-provider.ts
+++ b/packages/plugins/plugin-bluesky/src/capabilities/integration-provider.ts
@@ -19,28 +19,24 @@ import { BlueskyTargetOptions } from '../types';
 /**
  * OAuth scopes for Bluesky.
  *
- * `include:app.bsky.authFullApp` is the published Bluesky permission set
- * for full read + write access to `app.bsky.*`: timeline, posts, likes,
- * bookmarks, feed generators, preferences, plus creating/deleting
- * posts/likes/reposts/bookmarks. The `?aud=` parameter pins the AppView
- * the auth context targets — `bsky_appview` is Bluesky's official one.
+ * `transition:generic` is the legacy coarse scope that maps to the same
+ * surface area as an app password: read + write across `app.bsky.*`
+ * (timeline, posts, likes, bookmarks, feed generators, preferences).
+ * It is the only scope edge currently declares in its atproto
+ * `client_metadata` alongside `atproto`.
  *
- * Replaces the legacy `transition:generic` / `transition:email` coarse
- * scopes. We request the full-app set rather than `authViewAll` so the
- * user only authorizes once and we can ship post-creation flows later
- * without forcing a re-OAuth.
- *
- * Note: atproto auth servers don't enumerate concrete permission-set
- * strings in their well-known `scopes_supported` (they resolve them
- * dynamically at PAR time). Edge's `pushAuthRequest` pre-flight check
- * was updated to allow granular-permission scope prefixes through.
+ * Granular permission-set scopes (`include:app.bsky.authFullApp?aud=…`)
+ * are the long-term replacement, but bsky.social's auth server validates
+ * requested scopes against `client_metadata.scope` with literal string
+ * equality (no wildcard subsumption), so each granular scope would have
+ * to be enumerated upfront in edge's metadata. Until that is wired up
+ * we stay on the transition scope.
  *
  * Refs:
- * - https://atproto.com/specs/permission
- * - https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/authFullApp.json
+ * - https://atproto.com/specs/oauth
  * - https://github.com/bluesky-social/atproto/discussions/4437
  */
-const BSKY_OAUTH_SCOPES = ['include:app.bsky.authFullApp?aud=did:web:api.bsky.app#bsky_appview'] as const;
+const BSKY_OAUTH_SCOPES = ['transition:generic'] as const;
 
 /** Schema for the atproto pre-flight form (handle / DID). */
 const AtprotoPreflightForm = Schema.Struct({


### PR DESCRIPTION
## Summary

Reverts the Bluesky integration provider's OAuth scope from the granular permission-set form back to `transition:generic`, to match the corresponding revert on the edge side.

## Why

bsky.social's `@atproto/oauth-provider` validates per-PAR requested scopes against `client_metadata.scope` with **literal string equality** — no wildcard subsumption, no permission-set expansion at validation time:

```ts
// packages/oauth/oauth-provider/src/client/client.ts (main + authscope-lexicon-scratch)
for (const scope of parameters.scope.split(' ')) {
  if (!declaredScopes.includes(scope)) {
    throw new InvalidScopeError(parameters,
      `Scope "${scope}" is not declared in the client metadata`)
  }
}
```

That means edge declaring `repo:* rpc:*?aud=* …` in `client_metadata.scope` doesn't actually authorise concrete permission-set requests like `include:app.bsky.authFullApp?aud=did:web:api.bsky.app#bsky_appview`. The PAR was being rejected with `Bad Request` before ever reaching the consent screen.

Edge has been reverted to declaring only `atproto transition:email transition:generic`, so the plugin needs to request a literal subset of those.

Granular permission-set scopes remain the long-term plan (and the docstring now says so), but they need either upstream wildcard subsumption support or an edge-side scope-aggregation pipeline first.

## Test plan

- [ ] Add Integration → Bluesky in space settings; submit handle.
- [ ] OAuth tab opens, bsky.social shows consent for legacy `transition:generic` permissions.
- [ ] Approve; redirect lands and the integration is created in the space.

https://claude.ai/code/session_017aeDHnLQCGf2VtcjRPzU3w

---
_Generated by [Claude Code](https://claude.ai/code/session_017aeDHnLQCGf2VtcjRPzU3w)_