### PR TITLE
fix(react-ui-table): un-quarantine flaky tests by adding node export to react-ui-grid

### DIFF
--- a/packages/ui/react-ui-grid/package.json
+++ b/packages/ui/react-ui-grid/package.json
@@ -16,7 +16,8 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./dist/types/src/index.d.ts",
-      "browser": "./dist/lib/browser/index.mjs"
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": "./dist/lib/browser/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/ui/react-ui-table/src/model/table-presentation.test.ts
+++ b/packages/ui/react-ui-table/src/model/table-presentation.test.ts
@@ -14,14 +14,7 @@ import { Table } from '../types';
 import { TableModel, type TableModelProps } from './table-model';
 import { TablePresentation } from './table-presentation';
 
-// Quarantined in CI only — vite resolves `@dxos/react-ui-grid` to the hoisted
-// node_modules copy, which fails the `node` export condition under the
-// workflow's `--no-file-parallelism` runner. Tests pass locally so the suite
-// still runs during development.
-// Trunk.io tracking:
-//   https://app.trunk.io/dxos/flaky-tests/test/e027ed98-4aea-5a63-b5ed-10baf76fb11e
-const describeOutsideCI = process.env.CI ? describe.skip : describe;
-describeOutsideCI('TablePresentation', () => {
+describe('TablePresentation', () => {
   describe('getCells', () => {
     let registry: Registry.Registry;
     let data: any[];

--- a/packages/ui/react-ui-table/src/util/dynamic-table.test.ts
+++ b/packages/ui/react-ui-table/src/util/dynamic-table.test.ts
@@ -9,14 +9,7 @@ import { Format } from '@dxos/echo';
 
 import { type TablePropertyDefinition, getBaseSchema, makeDynamicTable } from './dynamic-table';
 
-// Quarantined in CI only — flaky under the workflow's `--no-file-parallelism`
-// runner / hoisted node_modules layout. Local runs still cover the suite so
-// regressions surface during development.
-// Trunk.io tracking:
-//   https://app.trunk.io/dxos/flaky-tests/test/fe424f97-f8a1-5f2f-a191-5b3ec4e8f6b7
-//   https://app.trunk.io/dxos/flaky-tests/test/ee00f293-9b9b-55ed-b4cd-48a07edea96c
-const describeOutsideCI = process.env.CI ? describe.skip : describe;
-describeOutsideCI('makeDynamicTable', () => {
+describe('makeDynamicTable', () => {
   /**
    * Base case: plain jsonSchema (not from Echo / JsonSchema.toJsonSchema). Does not exercise the path
    * where projection or schema are reactive, so this does not reproduce the Obj.update regression.


### PR DESCRIPTION
## Summary

- Adds `"node": "./dist/lib/browser/index.mjs"` export condition to `@dxos/react-ui-grid/package.json` (same pattern already used by `@dxos/lit-grid`)
- Removes CI-only `describe.skip` guards from `table-presentation.test.ts` and `dynamic-table.test.ts`, un-quarantining tests tracked at:
  - https://app.trunk.io/dxos/flaky-tests/test/e027ed98-4aea-5a63-b5ed-10baf76fb11e
  - https://app.trunk.io/dxos/flaky-tests/test/fe424f97-f8a1-5f2f-a191-5b3ec4e8f6b7
  - https://app.trunk.io/dxos/flaky-tests/test/ee00f293-9b9b-55ed-b4cd-48a07edea96c

## Root cause

Under CI's `--no-file-parallelism` runner, Vite's `PluginImportSource` (which resolves `@dxos/**` via the `source` export condition) fails to find the workspace package and falls back to Vite's default resolver. The default resolver in node/jsdom context requires a `node` export condition, which `@dxos/react-ui-grid` was missing — causing an import resolution error.

## Test plan

- [x] `moon run react-ui-table:test -- --no-file-parallelism --project=node` passes all 14 tests including the previously quarantined `TablePresentation` (4 tests) and `makeDynamicTable` (2 tests)

https://claude.ai/code/session_01GLGbAdrcFUTvriUkvFv6Uw

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLGbAdrcFUTvriUkvFv6Uw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced package export configuration for improved Node.js compatibility.
  * Improved test execution by removing environment-specific conditional test skips.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11289)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->