### PR TITLE
feat(introspect): emit and upload plugin metadata sidecar

### DIFF
--- a/.github/workflows/introspect-cache.yml
+++ b/.github/workflows/introspect-cache.yml
@@ -64,14 +64,20 @@ jobs:
 
       - name: Show cache stats
         run: |
-          ls -lh node_modules/.cache/dxos-introspect/cache.json
-          echo "Packages indexed: $(jq '.entries | length' node_modules/.cache/dxos-introspect/cache.json)"
+          ls -lh \
+            node_modules/.cache/dxos-introspect/core.json \
+            node_modules/.cache/dxos-introspect/plugins.json
+          echo "Packages indexed: $(jq '.entries | length' node_modules/.cache/dxos-introspect/core.json)"
+          echo "Plugins indexed:  $(jq '.plugins | length' node_modules/.cache/dxos-introspect/plugins.json)"
 
       - name: Upload cache artifact
         uses: actions/upload-artifact@v4
         with:
           name: dxos-introspect-cache
-          path: node_modules/.cache/dxos-introspect/cache.json
+          # Both files share an artifact (single download for `fetch-cache`).
+          path: |
+            node_modules/.cache/dxos-introspect/core.json
+            node_modules/.cache/dxos-introspect/plugins.json
           # 30 days is enough for typical dev usage; older caches will likely
           # be mostly stale anyway because most main commits invalidate at
           # least one package's tree SHA.

--- a/.github/workflows/upload-introspect-cache.yml
+++ b/.github/workflows/upload-introspect-cache.yml
@@ -1,5 +1,6 @@
-# Builds the @dxos/introspect cache.json and uploads it to R2 so the
-# @dxos/introspect-service edge worker can read it. Triggers on push to the
+# Builds the @dxos/introspect core.json (symbol cache) and plugins.json
+# (plugin metadata sidecar) and uploads both to R2 so the
+# @dxos/introspect-service edge worker can read them. Triggers on push to the
 # `labs` branch; manual dispatch is also supported for ad-hoc reruns.
 #
 # Secrets required:
@@ -54,9 +55,16 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          ls -lh node_modules/.cache/dxos-introspect/cache.json
+          ls -lh \
+            node_modules/.cache/dxos-introspect/core.json \
+            node_modules/.cache/dxos-introspect/plugins.json
           pnpm exec wrangler r2 object put \
-            dxos-introspect-cache/dxos/labs/cache.json \
-            --file=node_modules/.cache/dxos-introspect/cache.json \
+            dxos-introspect-cache/dxos/labs/core.json \
+            --file=node_modules/.cache/dxos-introspect/core.json \
+            --content-type=application/json \
+            --remote
+          pnpm exec wrangler r2 object put \
+            dxos-introspect-cache/dxos/labs/plugins.json \
+            --file=node_modules/.cache/dxos-introspect/plugins.json \
             --content-type=application/json \
             --remote

--- a/packages/core/introspect-mcp/README.md
+++ b/packages/core/introspect-mcp/README.md
@@ -179,7 +179,12 @@ The package.json `exports` field has a `source` condition pointing at `src/index
 
 ## Cache
 
-The indexer stores extracted symbols at `<repo-root>/node_modules/.cache/dxos-introspect/cache.json` (~13 MB for 250 packages). Following the babel/swc/eslint convention so it's auto-gitignored and gets nuked by `pnpm clean`. Saves are atomic (write-temp-then-rename), so concurrent introspector processes can't corrupt each other.
+The indexer writes two files under `<repo-root>/node_modules/.cache/dxos-introspect/`:
+
+- `core.json` — symbol cache (~13 MB for 250 packages), reused across runs and invalidated per-package by git tree SHA.
+- `plugins.json` — plugin metadata sidecar (~200 KB), regenerated every run since plugin extraction is cheap.
+
+Following the babel/swc/eslint convention so the directory is auto-gitignored and gets nuked by `pnpm clean`. Saves are atomic (write-temp-then-rename), so concurrent introspector processes can't corrupt each other.
 
 ### Invalidation
 

--- a/packages/core/introspect-mcp/moon.yml
+++ b/packages/core/introspect-mcp/moon.yml
@@ -68,7 +68,7 @@ tasks:
       cache: false
   # Download the prebuilt symbol cache from the most recent successful
   # `Introspect Cache` GitHub Actions run on main and install it at
-  # node_modules/.cache/dxos-introspect/cache.json. Skips the ~80s cold-start
+  # node_modules/.cache/dxos-introspect/{core,plugins}.json. Skips the ~80s cold-start
   # ts-morph parse — entries are matched by per-package git tree SHA, so a
   # cache built in CI reuses cleanly on any clone of the same commit. Re-run
   # whenever you pull a batch of new commits.

--- a/packages/core/introspect-mcp/scripts/fetch-cache.mjs
+++ b/packages/core/introspect-mcp/scripts/fetch-cache.mjs
@@ -5,7 +5,10 @@
 
 // Downloads the `dxos-introspect-cache` artifact built by the
 // `Introspect Cache` GitHub workflow on the most recent successful commit to
-// main, and installs it at `<repo-root>/node_modules/.cache/dxos-introspect/cache.json`.
+// main and installs both files under
+// `<repo-root>/node_modules/.cache/dxos-introspect/`:
+//   - core.json    (symbol cache)
+//   - plugins.json (plugin metadata sidecar)
 //
 // Run from the worktree root:
 //   moon run introspect-mcp:fetch-cache
@@ -39,7 +42,9 @@ const findRepoRoot = (start) => {
 };
 
 const REPO_ROOT = findRepoRoot(__dirname);
-const CACHE_DEST = join(REPO_ROOT, 'node_modules/.cache/dxos-introspect/cache.json');
+const CACHE_DIR = join(REPO_ROOT, 'node_modules/.cache/dxos-introspect');
+const CACHE_DEST = join(CACHE_DIR, 'core.json');
+const PLUGINS_DEST = join(CACHE_DIR, 'plugins.json');
 const ARTIFACT_NAME = 'dxos-introspect-cache';
 const REPO = 'dxos/dxos';
 const WORKFLOW = 'introspect-cache.yml';
@@ -100,7 +105,7 @@ const main = async () => {
   log(`Found run #${latest.databaseId} (commit ${latest.headSha.slice(0, 12)}, ${latest.createdAt}).`);
 
   // `gh run download` extracts the artifact into a directory named after it
-  // (so the cache.json lands at <tmp>/dxos-introspect-cache/cache.json). Use a
+  // (so the core.json lands at <tmp>/dxos-introspect-cache/core.json). Use a
   // dedicated tmp dir under node_modules/.cache so we don't pollute the repo
   // root and so a partial download is easy to discard.
   const tmpDir = join(REPO_ROOT, 'node_modules/.cache/dxos-introspect-fetch');
@@ -112,34 +117,40 @@ const main = async () => {
   log(`Downloading "${ARTIFACT_NAME}" into ${tmpDir}…`);
   run('gh', ['run', 'download', String(latest.databaseId), '--repo', REPO, '--name', ARTIFACT_NAME, '--dir', tmpDir]);
 
-  // Locate the downloaded file. The artifact contains exactly one file
-  // (cache.json), but `gh run download --name` extracts directly into the
-  // dir, so the file should be at `<tmpDir>/cache.json`.
-  const downloaded = (() => {
-    const direct = join(tmpDir, 'cache.json');
+  // Locate downloaded files. The artifact bundles two siblings, core.json
+  // (symbol cache) and plugins.json (plugin metadata sidecar). `gh run
+  // download --name` extracts directly into the dir, so each lands at
+  // `<tmpDir>/<name>`.
+  const locate = (basename) => {
+    const direct = join(tmpDir, basename);
     if (existsSync(direct)) {
       return direct;
     }
     // Fallback: walk one level deep in case `gh` decides to nest.
     for (const entry of readdirSync(tmpDir)) {
-      const candidate = join(tmpDir, entry);
-      if (statSync(candidate).isFile() && entry.endsWith('.json')) {
+      const candidate = join(tmpDir, entry, basename);
+      if (existsSync(candidate) && statSync(candidate).isFile()) {
         return candidate;
       }
     }
-    throw new Error(`Could not find cache.json in ${tmpDir}`);
-  })();
+    throw new Error(`Could not find ${basename} in ${tmpDir}`);
+  };
+  const coreSrc = locate('core.json');
+  const pluginsSrc = locate('plugins.json');
 
   // Atomic install — rename only after the download succeeded so we never
-  // leave the destination half-written. Same convention as introspect's own
+  // leave a destination half-written. Same convention as introspect's own
   // saveCache.
-  mkdirSync(dirname(CACHE_DEST), { recursive: true });
-  renameSync(downloaded, CACHE_DEST);
+  mkdirSync(CACHE_DIR, { recursive: true });
+  renameSync(coreSrc, CACHE_DEST);
+  renameSync(pluginsSrc, PLUGINS_DEST);
   rmSync(tmpDir, { recursive: true, force: true });
 
-  const sizeKb = Math.round(statSync(CACHE_DEST).size / 1024);
-  log(`Installed cache at ${CACHE_DEST} (${sizeKb} KB).`);
-  log('Next MCP server start will reuse this cache for any package whose tree SHA matches HEAD.');
+  const coreKb = Math.round(statSync(CACHE_DEST).size / 1024);
+  const pluginsKb = Math.round(statSync(PLUGINS_DEST).size / 1024);
+  log(`Installed core cache at ${CACHE_DEST} (${coreKb} KB).`);
+  log(`Installed plugins sidecar at ${PLUGINS_DEST} (${pluginsKb} KB).`);
+  log('Next MCP server start will reuse these for any package whose tree SHA matches HEAD.');
 };
 
 main().catch((err) => {

--- a/packages/core/introspect/scripts/build-index.ts
+++ b/packages/core/introspect/scripts/build-index.ts
@@ -9,17 +9,25 @@
 //   pnpm exec tsx --conditions=source packages/core/introspect/scripts/build-index.ts
 //
 // The script walks up to find the monorepo root, creates an introspector
-// with `prewarm: true, cache: true`, awaits `ready`, prints a one-line
-// summary, and exits. The cache lands at `<root>/.dxos-introspect/cache.json`
-// and is reused by every subsequent introspector run (MCP server, tests, etc.)
-// until source files change.
+// with `prewarm: true, cache: true`, awaits `ready`, and writes two files:
+//
+//   - core.json    — symbol cache (~14 MB), reused across runs
+//   - plugins.json — plugin metadata sidecar (~200 KB), regenerated every run
+//
+// Both land under `<root>/node_modules/.cache/dxos-introspect/`. The MCP
+// edge worker reads each from R2 independently (different update cadences,
+// different schema versions).
 
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
 import { dirname, isAbsolute, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 
-import { createIntrospector } from '../src';
+import { createIntrospector, pluginsFilePath } from '../src';
+
+// Bumped whenever the sidecar shape changes. Must match the worker's
+// `fetchPluginsJson` version check (currently 1).
+const PLUGINS_SIDECAR_VERSION = 1;
 
 const USAGE = [
   'Usage: build-index [options]',
@@ -104,6 +112,26 @@ if (verbose) {
     logVerbose(`indexed ${pkg.name}`);
   }
 }
+
+// Write the plugin metadata sidecar. Atomic rename — same convention as
+// saveCache. Worker reads `{plugins, surfaces, capabilities, operations,
+// schemas}` directly off R2; keep the keys identical.
+const pluginsPath = pluginsFilePath(root);
+const pluginsTmp = `${pluginsPath}.tmp`;
+mkdirSync(dirname(pluginsPath), { recursive: true });
+const sidecar = {
+  version: PLUGINS_SIDECAR_VERSION,
+  plugins: intro.listPlugins(),
+  surfaces: intro.listSurfaces(),
+  capabilities: intro.listCapabilities(),
+  operations: intro.listOperations(),
+  schemas: intro.listSchemas(),
+};
+writeFileSync(pluginsTmp, JSON.stringify(sidecar));
+renameSync(pluginsTmp, pluginsPath);
+log(
+  `wrote plugins sidecar: ${sidecar.plugins.length} plugins, ${sidecar.surfaces.length} surfaces, ${sidecar.capabilities.length} capabilities, ${sidecar.operations.length} operations, ${sidecar.schemas.length} schemas → ${pluginsPath}`,
+);
 
 const elapsed = ((Date.now() - start) / 1000).toFixed(1);
 log(`done in ${elapsed}s — ${packages.length} packages indexed.`);

--- a/packages/core/introspect/src/cache.test.ts
+++ b/packages/core/introspect/src/cache.test.ts
@@ -21,7 +21,7 @@ const FIXTURE_SRC = join(__dirname, '__fixtures__');
 
 // Each test gets its own temp copy of the fixture so the cache file lands at
 // a known path we control. The cache lives under <root>/node_modules/.cache/
-// dxos-introspect/cache.json — relative to whatever monorepo root we point
+// dxos-introspect/core.json — relative to whatever monorepo root we point
 // the introspector at.
 
 describe('symbol cache reuse', { timeout: 30_000 }, () => {

--- a/packages/core/introspect/src/index.ts
+++ b/packages/core/introspect/src/index.ts
@@ -3,6 +3,7 @@
 //
 
 export { createIntrospector, type Introspector, type IntrospectorOptions } from './introspector';
+export { cacheFilePath, pluginsFilePath } from './indexer';
 export {
   formatCapabilityRef,
   formatOperationRef,

--- a/packages/core/introspect/src/indexer/cache.ts
+++ b/packages/core/introspect/src/indexer/cache.ts
@@ -71,9 +71,19 @@ const CACHE_VERSION = 3;
 // (babel, swc, eslint, vite all live here). Pros: auto-gitignored, easy to
 // nuke via `pnpm clean`/`rm -rf node_modules`, lives next to the deps the
 // cache indexes. Cons: a fresh `pnpm install` wipes it (rebuild ~80s once).
-const DEFAULT_CACHE_PATH = 'node_modules/.cache/dxos-introspect/cache.json';
+const DEFAULT_CACHE_PATH = 'node_modules/.cache/dxos-introspect/core.json';
+const DEFAULT_PLUGINS_PATH = 'node_modules/.cache/dxos-introspect/plugins.json';
 
 export const cacheFilePath = (rootPath: string): string => join(rootPath, DEFAULT_CACHE_PATH);
+
+/**
+ * Path to the plugin metadata sidecar (`{plugins, surfaces, capabilities,
+ * operations, schemas}` — the runtime output of `extractPlugins`). Lives next
+ * to `core.json` but versioned and uploaded independently because plugin
+ * extraction is cheap (~seconds) and changes far more often than the
+ * full-monorepo symbol cache (~minutes).
+ */
+export const pluginsFilePath = (rootPath: string): string => join(rootPath, DEFAULT_PLUGINS_PATH);
 
 /**
  * Compute the current src/ mtime + git tree SHA for every package. Used both

--- a/packages/core/introspect/src/indexer/plugins.ts
+++ b/packages/core/introspect/src/indexer/plugins.ts
@@ -108,13 +108,39 @@ const tryExtract = (rootPath: string, pkg: PackageLike): PluginRecord | null => 
     extractFromFile(sourceFile, rootPath, meta.id, { surfaces, capabilities, operations, schemas });
   }
 
+  // Plugins commonly ship multiple entrypoint variants (e.g.
+  // `FooPlugin.node.ts` + `FooPlugin.tsx` + `cli/plugin.ts`) that each call
+  // `addSchemaModule({ schema: [...] })` with the same set of types. Each
+  // `addSchemaModule` call produces a separate Schema record, so the same
+  // (pluginId, name) ends up duplicated 2-3x. Dedupe — keep first occurrence
+  // so the surfaced location is deterministic (first source file walked).
+  // Capabilities and operations are intentionally NOT deduped: their `type`
+  // field is the slot name (e.g. `Capabilities.OperationHandler`), and
+  // multiple `Capability.contributes` calls to the same slot represent
+  // genuinely distinct contributions.
+  const dedupedSchemas = dedupeBy(schemas, (s) => `${s.pluginId}|${s.name}`);
+
   return {
     plugin: meta,
     surfaces,
     capabilities,
     operations,
-    schemas,
+    schemas: dedupedSchemas,
   };
+};
+
+const dedupeBy = <T>(items: T[], keyFn: (item: T) => string): T[] => {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const item of items) {
+    const key = keyFn(item);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
 };
 
 const readPluginMeta = (file: SourceFile, pkg: PackageLike): Plugin | null => {

--- a/packages/core/introspect/src/introspector/introspector.ts
+++ b/packages/core/introspect/src/introspector/introspector.ts
@@ -53,7 +53,7 @@ export type IntrospectorOptions = {
   /**
    * If true (default), persist the symbol cache to disk and reuse it across
    * runs when no source files have changed. The cache lives at
-   * `<rootPath>/.dxos-introspect/cache.json`. Pass `false` to disable
+   * `<rootPath>/.dxos-introspect/core.json`. Pass `false` to disable
    * (e.g. for tests).
    */
   cache?: boolean;


### PR DESCRIPTION
## Summary

- The introspect MCP edge worker reads plugin metadata from a separate R2 object (`plugins.json`) that was never produced by any pipeline in this repo — it was created manually at deploy time and never refreshed. This is why plugin descriptions and schemas silently went stale (e.g. only 1 of 70 plugins surfaced a description; chess showed `Chess.Game` twice).
- Rename `cache.json` → `core.json` to disambiguate it from the new `plugins.json` sidecar; both live under `node_modules/.cache/dxos-introspect/` and on R2 at `dxos/labs/`.
- `build-index` (run by `introspect:index`) now writes **both** `core.json` (symbol cache, ~14 MB) and `plugins.json` (plugin metadata, ~165 KB). Workflows and `fetch-cache.mjs` were updated to handle both files.
- Dedupe schemas by `(pluginId, name)`: plugins commonly ship multiple entrypoint variants (`.node.ts` + `.tsx` + `cli/plugin.ts`) that each call `addSchemaModule` with overlapping types, producing 2-3x copies. Capabilities and operations are intentionally **not** deduped — multiple contributions to the same slot represent genuinely distinct values.

## Why two R2 files?

The worker fetches them independently with separate ETags (different update cadences, different schema versions). `core.json` is the symbol cache (v3, all 250 packages); `plugins.json` is the plugin metadata sidecar (v1, just `{plugins, surfaces, capabilities, operations, schemas}`). Plugin extraction is cheap (~seconds) and changes far more often than the full-monorepo symbol cache (~minutes), so keeping them separable lets one refresh without invalidating the other.

## Manual action required after merge

The deployed `introspect-service-labs` worker still has `INTROSPECT_CACHE_KEY=dxos/labs/cache.json` baked in. Both `cache.json` (the old key) and `core.json` (the new key) currently exist in R2, so nothing breaks today. After merge, update the worker's env var to `dxos/labs/core.json` so it picks up the new file going forward.

## Test plan

- [x] `moon run introspect:test` passes
- [x] `moon run introspect-mcp:test` passes
- [x] `moon run introspect:lint --fix` clean
- [x] `pnpm format` clean
- [x] Fresh `moon run introspect:index` writes both `core.json` (250 pkgs) and `plugins.json` (70 plugins, 69 with descriptions, 83 unique schemas)
- [x] Live MCP `list_plugins(id=board)` returns description after R2 upload
- [x] Live MCP `list_schemas(id=org.dxos.plugin.chess)` returns 1 record for `Chess.Game` (was 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured introspection cache to separate symbol indexing from plugin metadata
  * Updated CI/CD workflows and build scripts to support the new cache structure

* **Bug Fixes**
  * Fixed duplicate plugin schema records from multiple entrypoint variants

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11291)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->