### PR TITLE
fix(plugin-assistant): always render prompt bubble on its own line

### DIFF
--- a/packages/plugins/plugin-assistant/src/components/ChatThread/registry.tsx
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/registry.tsx
@@ -159,7 +159,11 @@ export function createBlockRenderer(viewType: Assistant.ChatView | undefined): B
     }
     let str = blockToMarkdownImpl(context, message, block);
     if (str && !block.pending) {
-      return (str += '\n');
+      // Use a blank line as the block separator so each rendered block parses as its own
+      // markdown block. A single newline lets CommonMark absorb a following `<prompt>` (an
+      // HTML type-7 tag, which can't interrupt an open paragraph) into the previous
+      // paragraph, rendering the prompt bubble inline next to the prior assistant text.
+      return (str += '\n\n');
     }
     return str;
   };

--- a/packages/plugins/plugin-assistant/src/components/ChatThread/sync.test.ts
+++ b/packages/plugins/plugin-assistant/src/components/ChatThread/sync.test.ts
@@ -56,13 +56,13 @@ describe('reducers', () => {
       ];
 
       syncer.update(messages);
-      expect(doc.content).toEqual(['<prompt>Hello</prompt>', 'Hi there!', ''].join('\n'));
+      expect(doc.content).toEqual('<prompt>Hello</prompt>\n\nHi there!\n\n');
 
       Obj.update(messages[1], (obj) => {
         obj.blocks.push({ _tag: 'text', text: 'How can I help?' });
       });
       syncer.update(messages);
-      expect(doc.content).toEqual(['<prompt>Hello</prompt>', 'Hi there!', 'How can I help?', ''].join('\n'));
+      expect(doc.content).toEqual('<prompt>Hello</prompt>\n\nHi there!\n\nHow can I help?\n\n');
     }),
   );
 
@@ -78,7 +78,7 @@ describe('reducers', () => {
       ];
 
       syncer.update(messages);
-      expect(doc.content).toEqual(['<prompt>Hello</prompt>', 'Hi there!'].join('\n'));
+      expect(doc.content).toEqual('<prompt>Hello</prompt>\n\nHi there!');
 
       Obj.update(messages[1], (obj) => {
         const block = obj.blocks[0] as Mutable<ContentBlock.Text>;
@@ -91,9 +91,7 @@ describe('reducers', () => {
         obj.blocks.push({ _tag: 'text', text: 'How can I help?' });
       });
       syncer.update(messages);
-      expect(doc.content).toEqual(
-        ['<prompt>Hello</prompt>', 'Hi there! How are you?', 'How can I help?', ''].join('\n'),
-      );
+      expect(doc.content).toEqual('<prompt>Hello</prompt>\n\nHi there! How are you?\n\nHow can I help?\n\n');
     }),
   );
 


### PR DESCRIPTION
## Summary

- `MarkdownStream` sometimes rendered the user prompt bubble inline next to the previous assistant reply (e.g. `Want me to play O? [yes]` on a single visual line).
- Blocks were joined with a single `\n` in `createBlockRenderer`, so a `<prompt>` immediately following assistant text was absorbed into the same CommonMark paragraph — HTML type-7 tags can't interrupt an open paragraph.
- Switched the block terminator to `\n\n` so every block parses as its own markdown block and the prompt always lands on its own line. Test fixtures already used blank-line separators, which is why they rendered correctly.

## Changes

- `packages/plugins/plugin-assistant/src/components/ChatThread/registry.tsx` — block separator `\n` → `\n\n`, with a comment explaining the CommonMark behavior.
- `packages/plugins/plugin-assistant/src/components/ChatThread/sync.test.ts` — updated expectations to match the new blank-line-separated source.

## Test plan

- [x] `moon run plugin-assistant:test` (sync.test.ts passes)
- [x] Verified visually in `storybook-react` — `ChatThread` `Default` story now shows the second user-prompt bubble on its own line with proper vertical spacing, both above and below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown content block rendering by adjusting spacing between blocks to ensure proper parsing and prevent unintended content merging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11297)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->