### PR TITLE
refactor(plugin-inbox): move Connect button into toolbar

### DIFF
--- a/packages/plugins/plugin-inbox/src/components/Initialize/Initialize.tsx
+++ b/packages/plugins/plugin-inbox/src/components/Initialize/Initialize.tsx
@@ -2,12 +2,10 @@
 // Copyright 2026 DXOS.org
 //
 
-import React, { type ReactNode } from 'react';
+import React from 'react';
 
-import { Surface, usePluginManager } from '@dxos/app-framework/ui';
-import { type Operation } from '@dxos/compute';
-import { type Obj, Ref } from '@dxos/echo';
-import { IconButton, Message } from '@dxos/react-ui';
+import { type Obj } from '@dxos/echo';
+import { Message } from '@dxos/react-ui';
 import { composable } from '@dxos/ui-theme';
 
 import { InitializeEmpty } from './InitializeEmpty';
@@ -16,59 +14,24 @@ import { useTargetIntegration } from './useTargetIntegration';
 export type InitializeProps<T extends Obj.Any> = {
   /** The object whose Integration we're connecting / syncing. */
   target: T;
-  /** Key under which `target` is passed to `operation`'s payload (e.g. `'mailbox'`, `'calendar'`). */
-  targetKey: string;
-  /** Provider id forwarded to the auth Surface (`'gmail'`, `'google-calendar'`, …). */
-  providerId: string;
-  /** Operation invoked when the user clicks sync. Must accept `{ integration, [targetKey]: target }`. */
-  operation: Operation.Definition<any, any>;
-  /** Already-translated label for the sync action. */
-  syncLabel: string;
   /** Already-translated warning shown when no integration targets `target`. */
   noIntegrationMessage: string;
-  /** Already-translated message shown above the sync action when an integration exists (optional). */
+  /** Already-translated message shown when an integration exists but the target is still empty. */
   emptyMessage?: string;
 };
 
 /**
- * Shared "connect or sync" empty state. When no `Integration` targets the
- * given object we render a warning and (if registered) the
- * `integration--auth` Surface. When one exists we render an `IconButton`
- * that invokes `operation`, paired with an optional `emptyMessage` for
- * the case where the integration is wired but the target's content is
- * still empty (e.g. a calendar that hasn't synced yet).
+ * Shared empty-state body for "initialize / connect this thing" panels.
+ * Renders a warning message that depends on whether an `Integration` targets
+ * `target`. The connect / sync action lives in `InitializeAction` so it can
+ * be slotted into the surrounding panel's toolbar.
  *
  * Used by `InitializeMailbox` and `InitializeCalendar`.
  */
 export const Initialize = composable<HTMLDivElement, InitializeProps<any>>(
-  (
-    { target, targetKey, providerId, operation, syncLabel, noIntegrationMessage, emptyMessage, ...props },
-    forwardedRef,
-  ) => {
-    const pluginManager = usePluginManager();
-    const { integration, sync, syncing } = useTargetIntegration(target, operation, targetKey);
-
-    let message: string | undefined;
-    let action: ReactNode;
-    if (integration) {
-      message = emptyMessage;
-      action = (
-        <IconButton
-          disabled={syncing}
-          variant='primary'
-          iconClassNames={syncing ? 'animate-spin' : undefined}
-          icon={syncing ? 'ph--spinner-gap--regular' : 'ph--arrow-clockwise--regular'}
-          label={syncLabel}
-          onClick={sync}
-        />
-      );
-    } else {
-      message = noIntegrationMessage;
-      const data = { providerId, existingTarget: Ref.make(target) };
-      action = Surface.isAvailable(pluginManager.capabilities, { role: 'integration--auth', data }) ? (
-        <Surface.Surface role='integration--auth' data={data} limit={1} />
-      ) : null;
-    }
+  ({ target, noIntegrationMessage, emptyMessage, ...props }, forwardedRef) => {
+    const { integration } = useTargetIntegration(target);
+    const message = integration ? emptyMessage : noIntegrationMessage;
 
     return (
       <InitializeEmpty {...props} ref={forwardedRef}>
@@ -77,7 +40,6 @@ export const Initialize = composable<HTMLDivElement, InitializeProps<any>>(
             <Message.Title>{message}</Message.Title>
           </Message.Root>
         )}
-        {action}
       </InitializeEmpty>
     );
   },

--- a/packages/plugins/plugin-inbox/src/components/Initialize/InitializeAction.tsx
+++ b/packages/plugins/plugin-inbox/src/components/Initialize/InitializeAction.tsx
@@ -1,0 +1,62 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import React from 'react';
+
+import { Surface, usePluginManager } from '@dxos/app-framework/ui';
+import { type Operation } from '@dxos/compute';
+import { type Obj, Ref } from '@dxos/echo';
+import { IconButton } from '@dxos/react-ui';
+
+import { useTargetSync } from './useTargetIntegration';
+
+export type InitializeActionProps<T extends Obj.Any> = {
+  /** The object whose Integration we're connecting / syncing. */
+  target: T;
+  /** Key under which `target` is passed to `operation`'s payload (e.g. `'mailbox'`, `'calendar'`). */
+  targetKey: string;
+  /** Provider id forwarded to the auth Surface (`'gmail'`, `'google-calendar'`, …). */
+  providerId: string;
+  /** Operation invoked when the user clicks sync. Must accept `{ integration, [targetKey]: target }`. */
+  operation: Operation.Definition<any, any>;
+  /** Already-translated label for the sync action. */
+  syncLabel: string;
+};
+
+/**
+ * Toolbar action for the "initialize / connect this thing" empty state.
+ * When an `Integration` targets `target` we render an `IconButton` that
+ * invokes `operation`; otherwise we render the `integration--auth` Surface
+ * (if registered) so the user can connect a provider.
+ *
+ * Used by `InitializeMailboxAction` and `InitializeCalendarAction`.
+ */
+export const InitializeAction = <T extends Obj.Any>({
+  target,
+  targetKey,
+  providerId,
+  operation,
+  syncLabel,
+}: InitializeActionProps<T>) => {
+  const pluginManager = usePluginManager();
+  const { integration, sync, syncing } = useTargetSync(target, operation, targetKey);
+
+  if (integration) {
+    return (
+      <IconButton
+        disabled={syncing}
+        variant='primary'
+        iconClassNames={syncing ? 'animate-spin' : undefined}
+        icon={syncing ? 'ph--spinner-gap--regular' : 'ph--arrow-clockwise--regular'}
+        label={syncLabel}
+        onClick={sync}
+      />
+    );
+  }
+
+  const data = { providerId, existingTarget: Ref.make(target) };
+  return Surface.isAvailable(pluginManager.capabilities, { role: 'integration--auth', data }) ? (
+    <Surface.Surface role='integration--auth' data={data} limit={1} />
+  ) : null;
+};

--- a/packages/plugins/plugin-inbox/src/components/Initialize/index.ts
+++ b/packages/plugins/plugin-inbox/src/components/Initialize/index.ts
@@ -3,4 +3,5 @@
 //
 
 export * from './Initialize';
+export * from './InitializeAction';
 export * from './InitializeEmpty';

--- a/packages/plugins/plugin-inbox/src/components/Initialize/useTargetIntegration.ts
+++ b/packages/plugins/plugin-inbox/src/components/Initialize/useTargetIntegration.ts
@@ -12,17 +12,29 @@ import { Filter, useQuery } from '@dxos/react-client/echo';
 
 /**
  * Find the `Integration` whose `targets` include the given `target` object.
- *
- * Returns the matching integration (or `undefined` if none exists),
- * a `sync` callback that invokes `operation` with
+ * Returns the matching integration (or `undefined` if none exists).
+ */
+export const useTargetIntegration = <T extends Obj.Any>(
+  target: T,
+): { integration: Integration.Integration | undefined } => {
+  const db = Obj.getDatabase(target);
+  const integrations = useQuery(db, Filter.type(Integration.Integration));
+  const integration = integrations.find((candidate) =>
+    candidate.targets.some((entry) => entry.object?.dxn.asEchoDXN()?.echoId === target.id),
+  );
+  return { integration };
+};
+
+/**
+ * Build a `sync` callback that invokes `operation` with
  * `{ integration, [targetKey]: target }` payload and tracks an in-flight
  * `syncing` flag, so the empty-state UI can render a spinner / disabled
  * button without each callsite repeating the boilerplate.
  *
- * Used by `InitializeMailbox` (`targetKey='mailbox'`) and
- * `InitializeCalendar` (`targetKey='calendar'`).
+ * Used by `InitializeMailboxAction` (`targetKey='mailbox'`) and
+ * `InitializeCalendarAction` (`targetKey='calendar'`).
  */
-export const useTargetIntegration = <T extends Obj.Any>(
+export const useTargetSync = <T extends Obj.Any>(
   target: T,
   operation: Operation.Definition<any, any>,
   targetKey: string,
@@ -31,14 +43,9 @@ export const useTargetIntegration = <T extends Obj.Any>(
   sync: () => Promise<void>;
   syncing: boolean;
 } => {
-  const db = Obj.getDatabase(target);
+  const { integration } = useTargetIntegration(target);
   const { invokePromise } = useOperationInvoker();
   const [syncing, setSyncing] = useState(false);
-
-  const integrations = useQuery(db, Filter.type(Integration.Integration));
-  const integration = integrations.find((candidate) =>
-    candidate.targets.some((entry) => entry.object?.dxn.asEchoDXN()?.echoId === target.id),
-  );
 
   const sync = useCallback(async () => {
     if (!integration) {

--- a/packages/plugins/plugin-inbox/src/containers/CalendarArticle/CalendarArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/CalendarArticle/CalendarArticle.tsx
@@ -19,7 +19,7 @@ import { EventStack, type EventStackActionHandler } from '#components';
 import { meta } from '#meta';
 import { type Calendar } from '#types';
 
-import { InitializeCalendar } from './InitializeCalendar';
+import { InitializeCalendar, InitializeCalendarAction } from './InitializeCalendar';
 
 const byDate =
   (direction = -1) =>
@@ -94,10 +94,9 @@ export const CalendarArticle = ({ role, subject, attendableId }: CalendarArticle
             </Panel.Content>
           </NaturalCalendar.Root>
         </Panel.Root>
-
         <Panel.Root>
           <Panel.Toolbar asChild>
-            <Toolbar.Root />
+            <Toolbar.Root>{isEmpty && <InitializeCalendarAction calendar={subject} />}</Toolbar.Root>
           </Panel.Toolbar>
           <Panel.Content asChild>
             {isEmpty ? (

--- a/packages/plugins/plugin-inbox/src/containers/CalendarArticle/InitializeCalendar.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/CalendarArticle/InitializeCalendar.tsx
@@ -11,7 +11,7 @@ import { meta } from '#meta';
 import { InboxOperation } from '#operations';
 import { type Calendar } from '#types';
 
-import { Initialize } from '../../components';
+import { Initialize, InitializeAction } from '../../components';
 import { GOOGLE_CALENDAR_PROVIDER_ID } from '../../constants';
 
 export type InitializeCalendarProps = {
@@ -25,10 +25,6 @@ export const InitializeCalendar = composable<HTMLDivElement, InitializeCalendarP
       <Initialize
         {...props}
         target={calendar}
-        targetKey='calendar'
-        providerId={GOOGLE_CALENDAR_PROVIDER_ID}
-        operation={InboxOperation.SyncCalendar}
-        syncLabel={t('sync-calendar.label')}
         noIntegrationMessage={t('no-integrations.label')}
         emptyMessage={t('empty-calendar.message')}
         ref={forwardedRef}
@@ -38,3 +34,16 @@ export const InitializeCalendar = composable<HTMLDivElement, InitializeCalendarP
 );
 
 InitializeCalendar.displayName = 'InitializeCalendar';
+
+export const InitializeCalendarAction = ({ calendar }: InitializeCalendarProps) => {
+  const { t } = useTranslation(meta.id);
+  return (
+    <InitializeAction
+      target={calendar}
+      targetKey='calendar'
+      providerId={GOOGLE_CALENDAR_PROVIDER_ID}
+      operation={InboxOperation.SyncCalendar}
+      syncLabel={t('sync-calendar.label')}
+    />
+  );
+};

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/InitializeMailbox.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/InitializeMailbox.tsx
@@ -11,7 +11,7 @@ import { meta } from '#meta';
 import { InboxOperation } from '#operations';
 import { type Mailbox } from '#types';
 
-import { Initialize } from '../../components';
+import { Initialize, InitializeAction } from '../../components';
 import { GMAIL_PROVIDER_ID } from '../../constants';
 
 export type InitializeMailboxProps = {
@@ -25,10 +25,6 @@ export const InitializeMailbox = composable<HTMLDivElement, InitializeMailboxPro
       <Initialize
         {...props}
         target={mailbox}
-        targetKey='mailbox'
-        providerId={GMAIL_PROVIDER_ID}
-        operation={InboxOperation.SyncMailbox}
-        syncLabel={t('sync-mailbox.label')}
         noIntegrationMessage={t('no-integrations.label')}
         emptyMessage={t('empty-mailbox.message')}
         ref={forwardedRef}
@@ -38,3 +34,16 @@ export const InitializeMailbox = composable<HTMLDivElement, InitializeMailboxPro
 );
 
 InitializeMailbox.displayName = 'InitializeMailbox';
+
+export const InitializeMailboxAction = ({ mailbox }: InitializeMailboxProps) => {
+  const { t } = useTranslation(meta.id);
+  return (
+    <InitializeAction
+      target={mailbox}
+      targetKey='mailbox'
+      providerId={GMAIL_PROVIDER_ID}
+      operation={InboxOperation.SyncMailbox}
+      syncLabel={t('sync-mailbox.label')}
+    />
+  );
+};

--- a/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
+++ b/packages/plugins/plugin-inbox/src/containers/MailboxArticle/MailboxArticle.tsx
@@ -13,7 +13,7 @@ import { QueryBuilder } from '@dxos/echo-query';
 import { invariant } from '@dxos/invariant';
 import { Filter, useObject, useQuery } from '@dxos/react-client/echo';
 import { useAtomState } from '@dxos/react-hooks';
-import { ElevationProvider, IconButton, Panel, useTranslation } from '@dxos/react-ui';
+import { ElevationProvider, IconButton, Panel, Toolbar, useTranslation } from '@dxos/react-ui';
 import { linkedSegment } from '@dxos/react-ui-attention';
 import { useSelected } from '@dxos/react-ui-attention';
 import { QueryEditor } from '@dxos/react-ui-components';
@@ -29,7 +29,7 @@ import { InboxCapabilities, type Mailbox } from '#types';
 import { POPOVER_SAVE_FILTER } from '../../constants';
 import { getMailboxMessagePath } from '../../paths';
 import { matchesFilter, sortByCreated } from '../../util';
-import { InitializeMailbox } from './InitializeMailbox';
+import { InitializeMailbox, InitializeMailboxAction } from './InitializeMailbox';
 
 export type MailboxArticleProps = AppSurface.ObjectArticleProps<
   Mailbox.Mailbox,
@@ -188,10 +188,14 @@ export const MailboxArticle = ({ subject, filter: filterProp, attendableId }: Ma
 
   return (
     <Panel.Root>
-      {!isEmpty && (
-        <ElevationProvider elevation='positioned'>
-          <Menu.Root {...menuActions} attendableId={id}>
-            <Panel.Toolbar asChild>
+      <Panel.Toolbar asChild>
+        {isEmpty ? (
+          <Toolbar.Root>
+            <InitializeMailboxAction mailbox={subject} />
+          </Toolbar.Root>
+        ) : (
+          <ElevationProvider elevation='positioned'>
+            <Menu.Root {...menuActions} attendableId={id}>
               <Menu.Toolbar>
                 <QueryEditor
                   classNames='grow min-w-0 ps-1'
@@ -213,13 +217,13 @@ export const MailboxArticle = ({ subject, filter: filterProp, attendableId }: Ma
                   icon='ph--x--regular'
                   iconOnly
                   label={t('mailbox-toolbar-clear-button.label')}
-                  onClick={() => handleClear()}
+                  onClick={handleClear}
                 />
               </Menu.Toolbar>
-            </Panel.Toolbar>
-          </Menu.Root>
-        </ElevationProvider>
-      )}
+            </Menu.Root>
+          </ElevationProvider>
+        )}
+      </Panel.Toolbar>
       <Panel.Content asChild>
         {isEmpty ? (
           <InitializeMailbox mailbox={subject} />

--- a/packages/plugins/plugin-integration/src/components/IntegrationAuthButton/IntegrationAuthButton.tsx
+++ b/packages/plugins/plugin-integration/src/components/IntegrationAuthButton/IntegrationAuthButton.tsx
@@ -7,7 +7,7 @@ import React, { useCallback } from 'react';
 import { usePluginManager } from '@dxos/app-framework/ui';
 import { type Database, type Obj, type Ref } from '@dxos/echo';
 import { runAndForwardErrors } from '@dxos/effect';
-import { Button, useTranslation } from '@dxos/react-ui';
+import { IconButton, useTranslation } from '@dxos/react-ui';
 
 import { meta } from '#meta';
 import { IntegrationCoordinator, IntegrationProvider } from '#types';
@@ -52,6 +52,12 @@ export const IntegrationAuthButton = ({ providerId, db, existingTarget }: Integr
   }
 
   return (
-    <Button onClick={handleClick}>{t('connect-integration.label', { provider: provider.label ?? provider.id })}</Button>
+    <IconButton
+      onClick={handleClick}
+      icon='ph--plugs--regular'
+      label={t('connect-integration.label', {
+        provider: provider.label ?? provider.id,
+      })}
+    />
   );
 };

--- a/packages/plugins/plugin-space/src/components/CreateDialog/CreateObjectPanel.tsx
+++ b/packages/plugins/plugin-space/src/components/CreateDialog/CreateObjectPanel.tsx
@@ -86,12 +86,12 @@ export const CreateObjectPanel = ({
   );
   const inputSurfaceLookup = useInputSurfaceLookup({ target });
 
-  // TODO(wittjosiah): These inputs should be rolled into a `Form` once it supports the necessary variants.
+  // TODO(wittjosiah): Extends and use react-ui-form to handle variants.
+
   if (!metadata) {
     return <SelectType options={sortedOptions} onChange={handleSelectOption} />;
   }
 
-  // TODO(burdon): Remove.
   if (!target) {
     return <SelectSpace spaces={spaces} defaultSpaceId={defaultSpaceId} onChange={onTargetChange} />;
   }

--- a/packages/ui/react-ui-list/src/components/Picker/Picker.tsx
+++ b/packages/ui/react-ui-list/src/components/Picker/Picker.tsx
@@ -2,44 +2,12 @@
 // Copyright 2026 DXOS.org
 //
 
-// `Picker` — generic listbox-with-input compound (the WAI-ARIA combobox
-// keyboard pattern, sans the search-domain bits).
+// `Picker` — generic listbox-with-input compound implementing the
+// WAI-ARIA combobox keyboard pattern. Search / filtering live one layer
+// up in `@dxos/react-ui-search`.
 //
-// Owns:
-//   - The virtual-highlight selection model (`selectedValue` updated by
-//     arrow keys; items don't receive browser focus, the input retains it).
-//   - An item registry (`registerItem` / `unregisterItem`) used by the
-//     input's keyboard handler to walk DOM-order siblings.
-//   - Auto-select-first-when-items-change behaviour.
-//   - `triggerSelect` so Enter from the input fires the highlighted
-//     item's `onSelect`.
-//
-// Does NOT own:
-//   - Query / search state (`query`, `onSearch`, `debounceMs`) — that
-//     lives in `@dxos/react-ui-search`'s `SearchList`, which composes
-//     `Picker` + adds the search-themed wrapper.
-//   - Filtering / ranking — same, see `useSearchListResults`.
-//   - The `<ul role='listbox'>` wrapper. Caller provides one (today's
-//     `SearchList.Viewport` / future `Combobox.Content` puts the role
-//     on the scroll surface).
-//   - Translations.
-//
-// Compound shape (matches Radix Select / Combobox patterns):
-//
-//   <Picker.Root>
-//     <Picker.Input value={query} onValueChange={setQuery} />
-//     <YourScrollWrapper role='listbox'>
-//       {items.map(item => (
-//         <Picker.Item key={item.id} value={item.id} onSelect={…}>
-//           {item.label}
-//         </Picker.Item>
-//       ))}
-//     </YourScrollWrapper>
-//   </Picker.Root>
-//
-// Why two contexts (Item / Input) — performance: items don't re-render
-// when the input value changes; the input doesn't re-render when an
-// item registers / unregisters.
+// The two contexts (Input / Item) are split so items don't re-render on
+// every keystroke and the input doesn't re-render on every (un)register.
 
 import { Slot } from '@radix-ui/react-slot';
 import React, {
@@ -67,10 +35,6 @@ import {
   usePickerItemContext,
 } from './context';
 
-//
-// Internal types.
-//
-
 type ItemData = {
   element: HTMLElement;
   disabled?: boolean;
@@ -78,22 +42,19 @@ type ItemData = {
 };
 
 //
-// Root — context provider; renders no DOM.
+// Root
 //
 
 type PickerRootProps = PropsWithChildren<{}>;
 
 const PickerRoot = ({ children }: PickerRootProps) => {
   const [selectedValue, setSelectedValue] = useState<string | undefined>(undefined);
-
-  // Item registry: value → { element, onSelect, disabled }.
   const itemsRef = useRef<Map<string, ItemData>>(new Map());
-
-  // Bumped on every (un)register so the auto-select-first effect can fire.
+  // Bumped on every (un)register to retrigger auto-select.
   const [itemVersion, setItemVersion] = useState(0);
 
-  // Auto-select first non-disabled item when the registry changes and the
-  // current selection is no longer valid (gone or disabled).
+  // Auto-select first non-disabled item when the current selection is
+  // gone or disabled.
   useEffect(() => {
     const current = selectedValue !== undefined ? itemsRef.current.get(selectedValue) : undefined;
     const isValid = current !== undefined && !current.disabled;
@@ -135,7 +96,7 @@ const PickerRoot = ({ children }: PickerRootProps) => {
     setItemVersion((v) => v + 1);
   }, []);
 
-  // DOM-order traversal of registered items (excludes disabled).
+  // DOM-order list of enabled item values.
   const getItemValues = useCallback(() => {
     return Array.from(itemsRef.current.entries())
       .filter(([, data]) => !data.disabled)
@@ -153,8 +114,7 @@ const PickerRoot = ({ children }: PickerRootProps) => {
     }
   }, [selectedValue]);
 
-  // Stable: items subscribe to this. Excludes the volatile bits (input
-  // helpers) that change with every keystroke.
+  // Stable values items subscribe to.
   const itemContextValue = useMemo(
     () => ({
       selectedValue,
@@ -165,7 +125,7 @@ const PickerRoot = ({ children }: PickerRootProps) => {
     [selectedValue, registerItem, unregisterItem],
   );
 
-  // Volatile: input subscribes to this. Includes the keyboard helpers.
+  // Volatile values the input subscribes to (keyboard helpers).
   const inputContextValue = useMemo(
     () => ({
       selectedValue,
@@ -186,7 +146,7 @@ const PickerRoot = ({ children }: PickerRootProps) => {
 PickerRoot.displayName = 'Picker.Root';
 
 //
-// Input — text input with virtual-highlight keyboard handling.
+// Input
 //
 
 type InputVariant = 'default' | 'subdued';
@@ -289,13 +249,8 @@ const PickerInput = forwardRef<HTMLInputElement, PickerInputProps>(
       [selectedValue, onSelectedValueChange, getItemValues, triggerSelect, onValueChange, onKeyDown],
     );
 
-    // Spread `value` only when defined: a caller that wants a
-    // controlled input passes `value` + `onValueChange`; a caller that
-    // just wants the keyboard pattern (Default story) passes neither
-    // and gets an uncontrolled input that accepts keystrokes normally.
-    // Without this guard `value={value ?? ''}` would force-control the
-    // input, swallowing every keystroke when no `onValueChange` is
-    // wired (input visually accepts characters then re-renders empty).
+    // Only force-control when `value` is provided; otherwise leave the
+    // input uncontrolled so it accepts keystrokes without `onValueChange`.
     return (
       <Input.Root>
         <Input.TextInput
@@ -314,7 +269,7 @@ const PickerInput = forwardRef<HTMLInputElement, PickerInputProps>(
 PickerInput.displayName = 'Picker.Input';
 
 //
-// Item — option that registers in the parent's registry.
+// Item
 //
 
 type PickerItemProps = ThemedClassName<{
@@ -335,7 +290,6 @@ const PickerItem = forwardRef<HTMLDivElement, PickerItemProps>(
 
     const isSelected = selectedValue === value && !disabled;
 
-    // Register on mount, unregister on unmount.
     useEffect(() => {
       const element = internalRef.current;
       if (element) {
@@ -344,7 +298,6 @@ const PickerItem = forwardRef<HTMLDivElement, PickerItemProps>(
       return () => unregisterItem(value);
     }, [value, onSelect, disabled, registerItem, unregisterItem]);
 
-    // Smooth-scroll the selected option into view.
     useEffect(() => {
       if (isSelected && internalRef.current) {
         internalRef.current.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
@@ -355,34 +308,20 @@ const PickerItem = forwardRef<HTMLDivElement, PickerItemProps>(
       if (disabled) {
         return;
       }
-      // Move the virtual highlight to the clicked item so subsequent
-      // arrow keys continue from here, then fire the caller's select.
       onSelectedValueChange(value);
       onSelect?.();
     }, [disabled, value, onSelectedValueChange, onSelect]);
 
-    // Prevent the mousedown from moving focus off `Picker.Input` —
-    // browsers focus an element with any `tabIndex` (including `-1`) on
-    // click, which would steal focus from the input and break the
-    // input's arrow-key handler. Cancelling on `mousedown` keeps focus
-    // on the input while still letting the subsequent `click` fire.
+    // Keep focus on `Picker.Input`: any `tabIndex` (incl. `-1`) would
+    // steal focus on click and break the input's arrow-key handler.
     const handleMouseDown = useCallback((event: ReactMouseEvent<HTMLElement>) => {
       event.preventDefault();
     }, []);
 
     const Comp: any = asChild ? Slot : 'div';
 
-    // Default styling: pair `aria-selected` with `dx-selected` and add
-    // `dx-hover` for the standard hover affordance. Same grammar `Row`
-    // uses (see `ui-theme/src/css/components/selected.md`). Horizontal
-    // padding follows `--gutter` so item text aligns with sibling
-    // `Column.Center` content (input, status row); falls back to
-    // `0.75rem` (≈ `px-3`) when not nested under `Column.Root`. Vertical
-    // padding and the pointer cursor are baked in so callsites don't
-    // have to repeat them; callers can still append / override via
-    // `classNames`. `dx-selected` only fires when `aria-selected="true"`,
-    // which we set below from the virtual highlight — so unfocused
-    // items render plain.
+    // Padding follows `--gutter` to align with sibling `Column.Center`
+    // content; falls back to `0.75rem` when not nested under `Column.Root`.
     return (
       <Comp
         {...props}
@@ -400,10 +339,7 @@ const PickerItem = forwardRef<HTMLDivElement, PickerItemProps>(
         data-selected={isSelected}
         data-disabled={disabled}
         data-value={value}
-        // tabIndex={-1} — combobox pattern keeps browser focus on the
-        // input; the selected option is highlighted via `aria-selected`,
-        // not via DOM focus. Differs from `Row` (listbox pattern,
-        // tabIndex={0}). See header comment.
+        // Browser focus stays on the input; highlight is via `aria-selected`.
         tabIndex={-1}
         className={mx(
           'dx-hover dx-selected px-[var(--gutter,0.75rem)] py-1 cursor-pointer select-none',
@@ -421,10 +357,6 @@ const PickerItem = forwardRef<HTMLDivElement, PickerItemProps>(
 
 PickerItem.displayName = 'Picker.Item';
 
-//
-// Public namespace.
-//
-
 export const Picker = {
   Root: PickerRoot,
   Input: PickerInput,
@@ -433,7 +365,4 @@ export const Picker = {
 
 export type { PickerRootProps, PickerInputProps, PickerItemProps };
 
-// Re-export context hooks for higher layers (SearchList) that need to
-// compose: `useSearchListInputContext` etc. previously read these
-// values; they now route through Picker.
 export { usePickerInputContext, usePickerItemContext } from './context';

--- a/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
+++ b/packages/ui/react-ui-search/src/components/SearchList/SearchList.tsx
@@ -253,14 +253,8 @@ const SearchListItem = forwardRef<HTMLDivElement, SearchListItemProps>(
         value={value}
         onSelect={onSelect}
         disabled={disabled}
+        classNames={mx('flex gap-2 items-center px-2 rounded-xs', classNames)}
         ref={forwardedRef}
-        classNames={mx(
-          'flex gap-2 items-center',
-          'py-1 px-2 rounded-xs select-none',
-          'cursor-pointer data-[selected=true]:bg-hover-overlay hover:bg-hover-overlay',
-          disabled && 'opacity-50 cursor-not-allowed hover:bg-transparent data-[selected=true]:bg-transparent',
-          classNames,
-        )}
       >
         {icon && <Icon icon={icon} classNames={iconClassNames} />}
         <span className='w-0 grow truncate'>{label}</span>

--- a/packages/ui/ui-theme/src/css/components/selected.css
+++ b/packages/ui/ui-theme/src/css/components/selected.css
@@ -8,7 +8,7 @@
 @layer dx-components {
   /* Pure visual affordance, no ARIA pair. Combine with dx-selected or dx-current. */
   .dx-hover {
-    @apply cursor-pointer hover:bg-highlight-surface! hover:text-highlight-surface-text!;
+    @apply cursor-pointer hover:bg-highlight-surface-hover! hover:text-highlight-surface-text!;
   }
 
   /* Pairs with Radix-managed `data-highlighted`. Don't set the attribute manually. */


### PR DESCRIPTION
## Summary
- Split the shared empty-state into a message-only `Initialize` body and a new `InitializeAction` that renders the connect/sync control, designed to slot into the surrounding panel's toolbar.
- `MailboxArticle` and `CalendarArticle` now render `InitializeMailboxAction` / `InitializeCalendarAction` inside `Panel.Toolbar` when the target is empty, replacing the previously disabled / empty toolbar.
- Split `useTargetIntegration` into `useTargetIntegration` (integration lookup) and `useTargetSync` (sync mutation) so the body and the toolbar action can each use what they need.
- Restyles `IntegrationAuthButton` as an `IconButton` with a \`ph--plugs--regular\` icon to fit alongside the other toolbar controls.

## Why
The connect / sync affordance was previously stacked inside the centered empty-state body next to the warning message. Moving it into the toolbar gives the empty state a more conventional structure (action lives in the toolbar, status/explanation in the body) and keeps the body content lighter.

## Test plan
- [x] \`moon run plugin-inbox:build\` passes
- [x] \`moon run plugin-integration:build\` passes
- [x] \`moon run plugin-inbox:lint plugin-integration:lint\` passes
- [x] Storybook \`MailboxArticle\` empty story renders the warning message (action surface is null because no integration / mock auth surface is registered in that story)
- [x] Storybook \`MailboxArticle\` default story renders the regular toolbar (no regression)
- [ ] Manual: exercise an actual integration in Composer to verify the Connect / sync IconButton appears in the toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toolbars now show sync/connect actions when calendar or mailbox feeds are empty; standalone sync action components added.

* **UI Improvements**
  * Integration connect control updated to an icon button for a more compact toolbar.

* **Refactor**
  * Initialization UI split so empty-state warnings and sync/connect actions are handled separately.

* **Style**
  * Hover background token updated for highlight utilities.

* **Documentation**
  * Picker and search list comments clarified.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11301)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->