### PR TITLE
fix(react-ui-grid): add node export condition to fix CI test resolution

### DIFF
--- a/packages/ui/react-ui-grid/package.json
+++ b/packages/ui/react-ui-grid/package.json
@@ -16,7 +16,8 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./dist/types/src/index.d.ts",
-      "browser": "./dist/lib/browser/index.mjs"
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": "./dist/lib/browser/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/ui/react-ui-table/src/model/table-presentation.test.ts
+++ b/packages/ui/react-ui-table/src/model/table-presentation.test.ts
@@ -14,14 +14,7 @@ import { Table } from '../types';
 import { TableModel, type TableModelProps } from './table-model';
 import { TablePresentation } from './table-presentation';
 
-// Quarantined in CI only — vite resolves `@dxos/react-ui-grid` to the hoisted
-// node_modules copy, which fails the `node` export condition under the
-// workflow's `--no-file-parallelism` runner. Tests pass locally so the suite
-// still runs during development.
-// Trunk.io tracking:
-//   https://app.trunk.io/dxos/flaky-tests/test/e027ed98-4aea-5a63-b5ed-10baf76fb11e
-const describeOutsideCI = process.env.CI ? describe.skip : describe;
-describeOutsideCI('TablePresentation', () => {
+describe('TablePresentation', () => {
   describe('getCells', () => {
     let registry: Registry.Registry;
     let data: any[];

--- a/packages/ui/react-ui-table/src/util/dynamic-table.test.ts
+++ b/packages/ui/react-ui-table/src/util/dynamic-table.test.ts
@@ -9,14 +9,7 @@ import { Format } from '@dxos/echo';
 
 import { type TablePropertyDefinition, getBaseSchema, makeDynamicTable } from './dynamic-table';
 
-// Quarantined in CI only — flaky under the workflow's `--no-file-parallelism`
-// runner / hoisted node_modules layout. Local runs still cover the suite so
-// regressions surface during development.
-// Trunk.io tracking:
-//   https://app.trunk.io/dxos/flaky-tests/test/fe424f97-f8a1-5f2f-a191-5b3ec4e8f6b7
-//   https://app.trunk.io/dxos/flaky-tests/test/ee00f293-9b9b-55ed-b4cd-48a07edea96c
-const describeOutsideCI = process.env.CI ? describe.skip : describe;
-describeOutsideCI('makeDynamicTable', () => {
+describe('makeDynamicTable', () => {
   /**
    * Base case: plain jsonSchema (not from Echo / JsonSchema.toJsonSchema). Does not exercise the path
    * where projection or schema are reactive, so this does not reproduce the Obj.update regression.


### PR DESCRIPTION
## Summary

- Adds a `node` export condition to `@dxos/react-ui-grid/package.json` pointing to the browser build. Under `--no-file-parallelism` with the hoisted `node_modules` layout in CI, Vite/Vitest was failing to resolve the package because it lacked a `node` condition (same pattern already used by `@dxos/lit-grid`).
- Removes the `describeOutsideCI` quarantine guards from `react-ui-table/src/model/table-presentation.test.ts` and `react-ui-table/src/util/dynamic-table.test.ts` — both suites now run in CI.

## Test plan

- [x] `moon run react-ui-table:test` passes locally without `CI=true`
- [x] `CI=true moon run react-ui-table:test -- ... --no-file-parallelism` passes with all 14 tests green (was 6 skipped before fix)
- Trunk flaky-test investigations resolved: e027ed98, fe424f97, ee00f293 (all created 2026-05-10)

https://claude.ai/code/session_018usuY7ZxCtjH2ik7g4QHRA

---
_Generated by [Claude Code](https://claude.ai/code/session_018usuY7ZxCtjH2ik7g4QHRA)_