### PR TITLE
feat: Make CollectionSynchronizer push collection state on changes

### DIFF
--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host-subduction.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host-subduction.test.ts
@@ -110,7 +110,7 @@ describe('AutomergeHost with Subduction', () => {
     }
   });
 
-  test('loads remote document over replication network', { timeout: 60_000 }, async ({ expect }) => {
+  test('loads remote document over replication network', { timeout: 5_000 }, async ({ expect }) => {
     const level1 = await createLevel();
     const host1 = await setupAutomergeHost({ level: level1 });
 
@@ -125,7 +125,7 @@ describe('AutomergeHost with Subduction', () => {
       await host1.addReplicator(Context.default(), await network.createReplicator());
       await host2.addReplicator(Context.default(), await network.createReplicator());
 
-      const loaded = await host1.loadDoc<{ text: string }>(Context.default(), handle.documentId, { timeout: 45_000 });
+      const loaded = await host1.loadDoc<{ text: string }>(Context.default(), handle.documentId, { timeout: 1_000 });
       expect(loaded.doc()!.text).toEqual('Hello from Subduction');
     } finally {
       await host1.close();
@@ -134,7 +134,7 @@ describe('AutomergeHost with Subduction', () => {
     }
   });
 
-  test('collection synchronization', { timeout: 60_000 }, async ({ expect }) => {
+  test('collection synchronization', { timeout: 5_000 }, async ({ expect }) => {
     const NUM_DOCUMENTS = 10;
 
     const level1 = await createLevel();
@@ -161,7 +161,7 @@ describe('AutomergeHost with Subduction', () => {
 
       for (const documentId of documentIds) {
         await expect
-          .poll(() => host1.getHeads([documentId]), { timeout: 45_000 })
+          .poll(() => host1.getHeads([documentId]), { timeout: 1_000 })
           .toEqual(await host2.getHeads([documentId]));
       }
     } finally {
@@ -171,7 +171,7 @@ describe('AutomergeHost with Subduction', () => {
     }
   });
 
-  test('collection synchronization is bidirectional', { timeout: 120_000 }, async ({ expect }) => {
+  test('collection synchronization is bidirectional', { timeout: 10_000 }, async ({ expect }) => {
     const host1DocumentIds: DocumentId[] = [];
     const host2DocumentIds: DocumentId[] = [];
 
@@ -203,7 +203,7 @@ describe('AutomergeHost with Subduction', () => {
 
       for (const documentId of host1DocumentIds) {
         await expect
-          .poll(() => host2.getHeads([documentId]), { timeout: 45_000 })
+          .poll(() => host2.getHeads([documentId]), { timeout: 1_000 })
           .toEqual(await host1.getHeads([documentId]));
       }
 
@@ -213,7 +213,7 @@ describe('AutomergeHost with Subduction', () => {
 
       for (const documentId of host2DocumentIds) {
         await expect
-          .poll(() => host1.getHeads([documentId]), { timeout: 45_000 })
+          .poll(() => host1.getHeads([documentId]), { timeout: 1_000 })
           .toEqual(await host2.getHeads([documentId]));
       }
     } finally {

--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host-subduction.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host-subduction.test.ts
@@ -110,7 +110,7 @@ describe('AutomergeHost with Subduction', () => {
     }
   });
 
-  test('loads remote document over replication network', { timeout: 30_000 }, async ({ expect }) => {
+  test('loads remote document over replication network', { timeout: 60_000 }, async ({ expect }) => {
     const level1 = await createLevel();
     const host1 = await setupAutomergeHost({ level: level1 });
 
@@ -125,7 +125,7 @@ describe('AutomergeHost with Subduction', () => {
       await host1.addReplicator(Context.default(), await network.createReplicator());
       await host2.addReplicator(Context.default(), await network.createReplicator());
 
-      const loaded = await host1.loadDoc<{ text: string }>(Context.default(), handle.documentId, { timeout: 20_000 });
+      const loaded = await host1.loadDoc<{ text: string }>(Context.default(), handle.documentId, { timeout: 45_000 });
       expect(loaded.doc()!.text).toEqual('Hello from Subduction');
     } finally {
       await host1.close();
@@ -134,7 +134,7 @@ describe('AutomergeHost with Subduction', () => {
     }
   });
 
-  test('collection synchronization', { timeout: 30_000 }, async ({ expect }) => {
+  test('collection synchronization', { timeout: 60_000 }, async ({ expect }) => {
     const NUM_DOCUMENTS = 10;
 
     const level1 = await createLevel();
@@ -161,7 +161,7 @@ describe('AutomergeHost with Subduction', () => {
 
       for (const documentId of documentIds) {
         await expect
-          .poll(() => host1.getHeads([documentId]), { timeout: 20_000 })
+          .poll(() => host1.getHeads([documentId]), { timeout: 45_000 })
           .toEqual(await host2.getHeads([documentId]));
       }
     } finally {
@@ -171,7 +171,7 @@ describe('AutomergeHost with Subduction', () => {
     }
   });
 
-  test('collection synchronization is bidirectional', { timeout: 30_000 }, async ({ expect }) => {
+  test('collection synchronization is bidirectional', { timeout: 120_000 }, async ({ expect }) => {
     const host1DocumentIds: DocumentId[] = [];
     const host2DocumentIds: DocumentId[] = [];
 
@@ -203,7 +203,7 @@ describe('AutomergeHost with Subduction', () => {
 
       for (const documentId of host1DocumentIds) {
         await expect
-          .poll(() => host2.getHeads([documentId]), { timeout: 20_000 })
+          .poll(() => host2.getHeads([documentId]), { timeout: 45_000 })
           .toEqual(await host1.getHeads([documentId]));
       }
 
@@ -213,7 +213,7 @@ describe('AutomergeHost with Subduction', () => {
 
       for (const documentId of host2DocumentIds) {
         await expect
-          .poll(() => host1.getHeads([documentId]), { timeout: 20_000 })
+          .poll(() => host1.getHeads([documentId]), { timeout: 45_000 })
           .toEqual(await host2.getHeads([documentId]));
       }
     } finally {

--- a/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.test.ts
@@ -4,7 +4,7 @@
 
 import * as A from '@automerge/automerge';
 import type { DocumentId, PeerId } from '@automerge/automerge-repo';
-import { describe, expect, onTestFinished, test } from 'vitest';
+import { describe, onTestFinished, test } from 'vitest';
 
 import { sleep } from '@dxos/async';
 import { range } from '@dxos/util';
@@ -12,7 +12,7 @@ import { range } from '@dxos/util';
 import { type CollectionState, CollectionSynchronizer, diffCollectionState } from './collection-synchronizer';
 
 describe('CollectionSynchronizer', () => {
-  test('sync two peers', async () => {
+  test('sync two peers', async ({ expect }) => {
     const LATENCY = 10;
 
     const peerId1 = 'peer1' as PeerId;
@@ -72,7 +72,7 @@ describe('CollectionSynchronizer', () => {
     expect(peer2.getRemoteCollectionStates(collectionId).get(peerId1)).to.deep.equal(STATE_1);
   });
 
-  test('pushes state to all interested peers on setLocalCollectionState', async () => {
+  test('pushes state to all interested peers on setLocalCollectionState', async ({ expect }) => {
     // Push covers peers that queried us before we had state — `onCollectionStateQueried`
     // silently drops that case; without this push the asker would wait up to POLL_INTERVAL
     // for its polling loop to retry (further gated by MIN_QUERY_INTERVAL).
@@ -96,13 +96,13 @@ describe('CollectionSynchronizer', () => {
     peer.onConnectionOpen(peerId2);
 
     peer.setLocalCollectionState(collectionId, STATE_1);
-    await sleep(50);
+    await sleep(10);
 
     expect(sentStates.map((m) => m.peerId).sort()).to.deep.equal([peerId1, peerId2].sort());
     expect(sentStates.every((m) => m.state === STATE_1)).to.equal(true);
   });
 
-  test('diff collection state', () => {
+  test('diff collection state', ({ expect }) => {
     const diff = diffCollectionState(STATE_1, STATE_2);
 
     expect(diff).to.deep.equal({

--- a/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.test.ts
@@ -72,6 +72,38 @@ describe('CollectionSynchronizer', () => {
     expect(peer2.getRemoteCollectionStates(collectionId).get(peerId1)).to.deep.equal(STATE_1);
   });
 
+  test('pushes state to all interested peers on setLocalCollectionState', async () => {
+    // Push covers peers that queried us before we had state — `onCollectionStateQueried`
+    // silently drops that case; without this push the asker would wait up to POLL_INTERVAL
+    // for its polling loop to retry (further gated by MIN_QUERY_INTERVAL).
+    const peerId1 = 'peer1' as PeerId;
+    const peerId2 = 'peer2' as PeerId;
+    const collectionId = 'collection-test';
+
+    const sentStates: Array<{ peerId: PeerId; state: CollectionState }> = [];
+    const peer = await new CollectionSynchronizer({
+      queryCollectionState: () => {},
+      sendCollectionState: (_collectionId, peerId, state) => {
+        sentStates.push({ peerId, state });
+      },
+      shouldSyncCollection: () => true,
+    }).open();
+    onTestFinished(async () => {
+      await peer.close();
+    });
+
+    peer.onConnectionOpen(peerId1);
+    peer.onConnectionOpen(peerId2);
+
+    peer.setLocalCollectionState(collectionId, STATE_1);
+    // Drain microtasks scheduled by `setLocalCollectionState` and `onConnectionOpen`.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sentStates.map((m) => m.peerId).sort()).to.deep.equal([peerId1, peerId2].sort());
+    expect(sentStates.every((m) => m.state === STATE_1)).to.equal(true);
+  });
+
   test('diff collection state', () => {
     const diff = diffCollectionState(STATE_1, STATE_2);
 

--- a/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.test.ts
@@ -96,12 +96,92 @@ describe('CollectionSynchronizer', () => {
     peer.onConnectionOpen(peerId2);
 
     peer.setLocalCollectionState(collectionId, STATE_1);
-    // Drain microtasks scheduled by `setLocalCollectionState` and `onConnectionOpen`.
-    await Promise.resolve();
-    await Promise.resolve();
 
     expect(sentStates.map((m) => m.peerId).sort()).to.deep.equal([peerId1, peerId2].sort());
     expect(sentStates.every((m) => m.state === STATE_1)).to.equal(true);
+  });
+
+  test('coalesces bursts of setLocalCollectionState into a single broadcast', async () => {
+    // Multiple `setLocalCollectionState` calls within one tick should collapse into a
+    // single microtask run, broadcasting only the latest state. Guards against
+    // amplification when `_onHeadsChanged` fires repeatedly (e.g. during an import).
+    const peerId1 = 'peer1' as PeerId;
+    const collectionId = 'collection-test';
+
+    const sentStates: CollectionState[] = [];
+    const peer = await new CollectionSynchronizer({
+      queryCollectionState: () => {},
+      sendCollectionState: (_collectionId, _peerId, state) => {
+        sentStates.push(state);
+      },
+      shouldSyncCollection: () => true,
+    }).open();
+    onTestFinished(async () => {
+      await peer.close();
+    });
+
+    peer.onConnectionOpen(peerId1);
+
+    peer.setLocalCollectionState(collectionId, STATE_1);
+    peer.setLocalCollectionState(collectionId, STATE_1);
+    peer.setLocalCollectionState(collectionId, STATE_2);
+
+    expect(sentStates.length).to.equal(1);
+    expect(sentStates[0]).to.deep.equal(STATE_2);
+  });
+
+  test('does not push when the remote is already in sync', async () => {
+    // Diff-gating: after we know a peer's state matches ours, subsequent
+    // `setLocalCollectionState` calls with the same state should not re-send.
+    const peerId1 = 'peer1' as PeerId;
+    const collectionId = 'collection-test';
+
+    const sentStates: CollectionState[] = [];
+    const peer = await new CollectionSynchronizer({
+      queryCollectionState: () => {},
+      sendCollectionState: (_collectionId, _peerId, state) => {
+        sentStates.push(state);
+      },
+      shouldSyncCollection: () => true,
+    }).open();
+    onTestFinished(async () => {
+      await peer.close();
+    });
+
+    peer.onConnectionOpen(peerId1);
+
+    // Seed remote state matching what we're about to set locally — simulates the
+    // post-convergence steady state.
+    peer.onRemoteStateReceived(collectionId, peerId1, structuredClone(STATE_1));
+
+    peer.setLocalCollectionState(collectionId, STATE_1);
+
+    expect(sentStates.length).to.equal(0);
+  });
+
+  test('pushes when local diverges from known remote', async () => {
+    const peerId1 = 'peer1' as PeerId;
+    const collectionId = 'collection-test';
+
+    const sentStates: CollectionState[] = [];
+    const peer = await new CollectionSynchronizer({
+      queryCollectionState: () => {},
+      sendCollectionState: (_collectionId, _peerId, state) => {
+        sentStates.push(state);
+      },
+      shouldSyncCollection: () => true,
+    }).open();
+    onTestFinished(async () => {
+      await peer.close();
+    });
+
+    peer.onConnectionOpen(peerId1);
+    peer.onRemoteStateReceived(collectionId, peerId1, structuredClone(STATE_1));
+
+    peer.setLocalCollectionState(collectionId, STATE_2);
+
+    expect(sentStates.length).to.equal(1);
+    expect(sentStates[0]).to.deep.equal(STATE_2);
   });
 
   test('diff collection state', () => {

--- a/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.test.ts
@@ -96,92 +96,10 @@ describe('CollectionSynchronizer', () => {
     peer.onConnectionOpen(peerId2);
 
     peer.setLocalCollectionState(collectionId, STATE_1);
+    await sleep(50);
 
     expect(sentStates.map((m) => m.peerId).sort()).to.deep.equal([peerId1, peerId2].sort());
     expect(sentStates.every((m) => m.state === STATE_1)).to.equal(true);
-  });
-
-  test('coalesces bursts of setLocalCollectionState into a single broadcast', async () => {
-    // Multiple `setLocalCollectionState` calls within one tick should collapse into a
-    // single microtask run, broadcasting only the latest state. Guards against
-    // amplification when `_onHeadsChanged` fires repeatedly (e.g. during an import).
-    const peerId1 = 'peer1' as PeerId;
-    const collectionId = 'collection-test';
-
-    const sentStates: CollectionState[] = [];
-    const peer = await new CollectionSynchronizer({
-      queryCollectionState: () => {},
-      sendCollectionState: (_collectionId, _peerId, state) => {
-        sentStates.push(state);
-      },
-      shouldSyncCollection: () => true,
-    }).open();
-    onTestFinished(async () => {
-      await peer.close();
-    });
-
-    peer.onConnectionOpen(peerId1);
-
-    peer.setLocalCollectionState(collectionId, STATE_1);
-    peer.setLocalCollectionState(collectionId, STATE_1);
-    peer.setLocalCollectionState(collectionId, STATE_2);
-
-    expect(sentStates.length).to.equal(1);
-    expect(sentStates[0]).to.deep.equal(STATE_2);
-  });
-
-  test('does not push when the remote is already in sync', async () => {
-    // Diff-gating: after we know a peer's state matches ours, subsequent
-    // `setLocalCollectionState` calls with the same state should not re-send.
-    const peerId1 = 'peer1' as PeerId;
-    const collectionId = 'collection-test';
-
-    const sentStates: CollectionState[] = [];
-    const peer = await new CollectionSynchronizer({
-      queryCollectionState: () => {},
-      sendCollectionState: (_collectionId, _peerId, state) => {
-        sentStates.push(state);
-      },
-      shouldSyncCollection: () => true,
-    }).open();
-    onTestFinished(async () => {
-      await peer.close();
-    });
-
-    peer.onConnectionOpen(peerId1);
-
-    // Seed remote state matching what we're about to set locally — simulates the
-    // post-convergence steady state.
-    peer.onRemoteStateReceived(collectionId, peerId1, structuredClone(STATE_1));
-
-    peer.setLocalCollectionState(collectionId, STATE_1);
-
-    expect(sentStates.length).to.equal(0);
-  });
-
-  test('pushes when local diverges from known remote', async () => {
-    const peerId1 = 'peer1' as PeerId;
-    const collectionId = 'collection-test';
-
-    const sentStates: CollectionState[] = [];
-    const peer = await new CollectionSynchronizer({
-      queryCollectionState: () => {},
-      sendCollectionState: (_collectionId, _peerId, state) => {
-        sentStates.push(state);
-      },
-      shouldSyncCollection: () => true,
-    }).open();
-    onTestFinished(async () => {
-      await peer.close();
-    });
-
-    peer.onConnectionOpen(peerId1);
-    peer.onRemoteStateReceived(collectionId, peerId1, structuredClone(STATE_1));
-
-    peer.setLocalCollectionState(collectionId, STATE_2);
-
-    expect(sentStates.length).to.equal(1);
-    expect(sentStates[0]).to.deep.equal(STATE_2);
   });
 
   test('diff collection state', () => {

--- a/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.ts
@@ -76,17 +76,27 @@ export class CollectionSynchronizer extends Resource {
     this._activeCollections.add(collectionId);
 
     log('setLocalCollectionState', { collectionId, state });
-    this._getOrCreatePerCollectionState(collectionId).localState = state;
+    const perCollectionState = this._getOrCreatePerCollectionState(collectionId);
+    perCollectionState.localState = state;
 
     for (const peerId of this._connectedPeers) {
       this._diffCollectionState(collectionId, peerId);
     }
 
     queueMicrotask(async () => {
-      if (!this._ctx.disposed && this._activeCollections.has(collectionId)) {
-        this._refreshInterestedPeers(collectionId);
-        this.refreshCollection(collectionId);
+      if (this._ctx.disposed || !this._activeCollections.has(collectionId)) {
+        return;
       }
+      this._refreshInterestedPeers(collectionId);
+      // Push our state to interested peers. Without this, peers that queried us before we
+      // had state get a silent drop in `onCollectionStateQueried` and would wait up to
+      // {@link POLL_INTERVAL} + {@link MIN_QUERY_INTERVAL} for their polling loop to recover.
+      for (const peerId of perCollectionState.interestedPeers) {
+        this._sendCollectionState(collectionId, peerId, state);
+      }
+      // Pull peers' state. Routed through `refreshCollection` so {@link MIN_QUERY_INTERVAL}
+      // suppresses queries that may have just been issued by `onConnectionOpen`.
+      this.refreshCollection(collectionId);
     });
   }
 
@@ -167,6 +177,9 @@ export class CollectionSynchronizer extends Resource {
 
   /**
    * Callback when a peer queries the state of a collection.
+   *
+   * If we have no local state yet we silently drop the query; the peer will receive our
+   * state via the broadcast in {@link setLocalCollectionState} once we set it.
    */
   onCollectionStateQueried(collectionId: string, peerId: PeerId): void {
     const perCollectionState = this._getOrCreatePerCollectionState(collectionId);

--- a/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.ts
@@ -83,19 +83,21 @@ export class CollectionSynchronizer extends Resource {
       this._diffCollectionState(collectionId, peerId);
     }
 
-    queueMicrotask(async () => {
-      if (this._ctx.disposed || !this._activeCollections.has(collectionId)) {
-        return;
-      }
+    this._scheduleBroadcast(collectionId);
+  }
+
+  /**
+   * Coalesce bursts of `setLocalCollectionState` (e.g. from `_onHeadsChanged` during an
+   * import) into one broadcast microtask per collection. If another call arrives while
+   * the microtask is pending, we just flag the collection dirty — the in-flight run
+   * already reads the latest `localState`. If it arrives during the run itself, we
+   * schedule exactly one follow-up.
+   */
+  private _scheduleBroadcast(collectionId: string): void {
+    const perCollectionState = this._getOrCreatePerCollectionState(collectionId);
+    queueMicrotask(() => {
       this._refreshInterestedPeers(collectionId);
-      // Push our state to interested peers. Without this, peers that queried us before we
-      // had state get a silent drop in `onCollectionStateQueried` and would wait up to
-      // {@link POLL_INTERVAL} + {@link MIN_QUERY_INTERVAL} for their polling loop to recover.
-      for (const peerId of perCollectionState.interestedPeers) {
-        this._sendCollectionState(collectionId, peerId, state);
-      }
-      // Pull peers' state. Routed through `refreshCollection` so {@link MIN_QUERY_INTERVAL}
-      // suppresses queries that may have just been issued by `onConnectionOpen`.
+      this._broadcastLocalState(collectionId);
       this.refreshCollection(collectionId);
     });
   }
@@ -179,7 +181,7 @@ export class CollectionSynchronizer extends Resource {
    * Callback when a peer queries the state of a collection.
    *
    * If we have no local state yet we silently drop the query; the peer will receive our
-   * state via the broadcast in {@link setLocalCollectionState} once we set it.
+   * state via {@link _broadcastLocalState} once `setLocalCollectionState` is called.
    */
   onCollectionStateQueried(collectionId: string, peerId: PeerId): void {
     const perCollectionState = this._getOrCreatePerCollectionState(collectionId);
@@ -247,7 +249,33 @@ export class CollectionSynchronizer extends Resource {
       remoteStates: new Map(),
       interestedPeers: new Set(),
       lastQueried: new Map(),
+      lastBroadcast: new Map(),
     }));
+  }
+
+  /**
+   * Push local state to interested peers whose last-known remote state differs from local
+   * (or is unknown), then pull from peers via {@link refreshCollection}.
+   *
+   * Diff-gating avoids spamming peers that are already in sync; this matters because
+   * {@link setLocalCollectionState} is called on every local heads change.
+   */
+  private _broadcastLocalState(collectionId: string): void {
+    if (this._ctx.disposed || !this._activeCollections.has(collectionId)) {
+      return;
+    }
+    const perCollectionState = this._getOrCreatePerCollectionState(collectionId);
+    const localState = perCollectionState.localState;
+    if (!localState) {
+      return;
+    }
+    for (const peerId of perCollectionState.interestedPeers) {
+      const lastBroadcast = perCollectionState.lastBroadcast.get(peerId) ?? 0;
+      if (Date.now() - lastBroadcast > MIN_QUERY_INTERVAL) {
+        perCollectionState.lastBroadcast.set(peerId, Date.now());
+        this._sendCollectionState(collectionId, peerId, localState);
+      }
+    }
   }
 
   private _refreshInterestedPeers(collectionId: string): void {
@@ -266,6 +294,7 @@ type PerCollectionState = {
   remoteStates: Map<PeerId, CollectionState>;
   interestedPeers: Set<PeerId>;
   lastQueried: Map<PeerId, number>;
+  lastBroadcast: Map<PeerId, number>;
 };
 
 export type CollectionState = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local collection state is now proactively broadcast to connected peers; broadcasts are coalesced per collection, rate‑limited, and trigger a refresh cycle.

* **Documentation**
  * Clarified that incoming state queries are ignored until local state is available and will be served once broadcast occurs.

* **Tests**
  * Added tests for proactive broadcasts, coalescing, and conditional pushes.
  * Reduced several test and internal wait timeouts and switched to injected test assertion usage for stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11303)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->