### PR TITLE
fix(plugin-crx): lazy-load clip listener to unbreak webkit e2e

### DIFF
--- a/packages/apps/composer-app/src/playwright/README.md
+++ b/packages/apps/composer-app/src/playwright/README.md
@@ -7,3 +7,7 @@ DX_PWA=false moon run composer-app:e2e
 ```
 
 To debug, add `--inspect` to step through each Playwright test.
+
+To target a single browser, set `PLAYWRIGHT_BROWSER=webkit` (or `chromium` / `firefox`); the default in CI is `all`.
+
+Note: the webkit boot path is sensitive to plugin chunk-graph shape. Plugins should keep their top-level `Plugin.ts` static imports minimal and put module `activate` bodies behind `Capability.lazy` — broad top-level imports can shift bundler chunk ordering and trip ESM init order in Linux webkit.

--- a/packages/apps/composer-app/src/playwright/app-manager.ts
+++ b/packages/apps/composer-app/src/playwright/app-manager.ts
@@ -18,6 +18,7 @@ import { DeckManager } from './plugins';
 //   At least via `navigator.userAgent.platform`.
 const isMac = os.platform() === 'darwin';
 const modifier = isMac ? 'Meta' : 'Control';
+
 export const INITIAL_URL = 'http://localhost:4173';
 
 export class AppManager {

--- a/packages/plugins/plugin-crx/src/CrxPlugin.tsx
+++ b/packages/plugins/plugin-crx/src/CrxPlugin.tsx
@@ -2,31 +2,12 @@
 // Copyright 2026 DXOS.org
 //
 
-import * as Effect from 'effect/Effect';
+import { ActivationEvents, Plugin } from '@dxos/app-framework';
+import { AppPlugin } from '@dxos/app-toolkit';
 
-import { ActivationEvents, Capabilities, Capability, Plugin } from '@dxos/app-framework';
-import { AppPlugin, LayoutOperation } from '@dxos/app-toolkit';
-import { log } from '@dxos/log';
-
-import { CrxSettings, ReactSurface } from '#capabilities';
+import { CrxSettings, InstallClipListener, ReactSurface } from '#capabilities';
 import { meta } from '#meta';
 import { translations } from '#translations';
-
-import { installClipListener } from './listener';
-
-const SUCCESS_TOAST_BY_KIND: Record<string, string> = {
-  person: 'toast.person.title',
-  organization: 'toast.organization.title',
-  note: 'toast.note.title',
-};
-
-const ERROR_TOAST_BY_CODE: Record<string, string> = {
-  invalidPayload: 'toast.error.invalidPayload.message',
-  unsupportedVersion: 'toast.error.unsupportedVersion.message',
-  unsupportedKind: 'toast.error.unsupportedKind.message',
-  noSpace: 'toast.error.noSpace.message',
-  internal: 'toast.error.internal.message',
-};
 
 export const CrxPlugin = Plugin.define(meta).pipe(
   AppPlugin.addSettingsModule({ activate: CrxSettings }),
@@ -35,30 +16,7 @@ export const CrxPlugin = Plugin.define(meta).pipe(
   Plugin.addModule({
     id: 'install-crx-bridge',
     activatesOn: ActivationEvents.OperationInvokerReady,
-    activate: Effect.fnUntraced(function* () {
-      const capabilityManager = yield* Capability.Service;
-      const invoker = yield* Capability.get(Capabilities.OperationInvoker);
-
-      installClipListener(capabilityManager, invoker, (ack, detail) => {
-        const kind = (detail as { kind?: string } | null)?.kind;
-        if (ack.ok) {
-          const key = (kind && SUCCESS_TOAST_BY_KIND[kind]) ?? 'toast.person.title';
-          void invoker.invokePromise(LayoutOperation.AddToast, {
-            id: `${meta.id}.clip-${ack.id}`,
-            title: [key, { ns: meta.id }],
-          });
-        } else {
-          const errorKey = ERROR_TOAST_BY_CODE[ack.error] ?? 'toast.error.internal.message';
-          void invoker.invokePromise(LayoutOperation.AddToast, {
-            id: `${meta.id}.error-${Date.now()}`,
-            title: ['toast.error.title', { ns: meta.id }],
-            description: [errorKey, { ns: meta.id }],
-          });
-        }
-      });
-
-      log.info('CRX bridge installed');
-    }),
+    activate: InstallClipListener,
   }),
   Plugin.make,
 );

--- a/packages/plugins/plugin-crx/src/capabilities/index.ts
+++ b/packages/plugins/plugin-crx/src/capabilities/index.ts
@@ -5,4 +5,5 @@
 import { Capability } from '@dxos/app-framework';
 
 export const CrxSettings = Capability.lazy('CrxSettings', () => import('./settings'));
+export const InstallClipListener = Capability.lazy('InstallClipListener', () => import('./install-clip-listener'));
 export const ReactSurface = Capability.lazy('ReactSurface', () => import('./react-surface'));

--- a/packages/plugins/plugin-crx/src/capabilities/install-clip-listener.ts
+++ b/packages/plugins/plugin-crx/src/capabilities/install-clip-listener.ts
@@ -1,0 +1,53 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import * as Effect from 'effect/Effect';
+
+import { Capabilities, Capability } from '@dxos/app-framework';
+import { LayoutOperation } from '@dxos/app-toolkit';
+import { log } from '@dxos/log';
+
+import { installClipListener } from '../listener';
+import { meta } from '../meta';
+
+const SUCCESS_TOAST_BY_KIND: Record<string, string> = {
+  person: 'toast.person.title',
+  organization: 'toast.organization.title',
+  note: 'toast.note.title',
+};
+
+const ERROR_TOAST_BY_CODE: Record<string, string> = {
+  invalidPayload: 'toast.error.invalidPayload.message',
+  unsupportedVersion: 'toast.error.unsupportedVersion.message',
+  unsupportedKind: 'toast.error.unsupportedKind.message',
+  noSpace: 'toast.error.noSpace.message',
+  internal: 'toast.error.internal.message',
+};
+
+export default Capability.makeModule(
+  Effect.fnUntraced(function* () {
+    const capabilityManager = yield* Capability.Service;
+    const invoker = yield* Capability.get(Capabilities.OperationInvoker);
+
+    installClipListener(capabilityManager, invoker, (ack, detail) => {
+      const kind = (detail as { kind?: string } | null)?.kind;
+      if (ack.ok) {
+        const key = (kind && SUCCESS_TOAST_BY_KIND[kind]) ?? 'toast.person.title';
+        void invoker.invokePromise(LayoutOperation.AddToast, {
+          id: `${meta.id}.clip-${ack.id}`,
+          title: [key, { ns: meta.id }],
+        });
+      } else {
+        const errorKey = ERROR_TOAST_BY_CODE[ack.error] ?? 'toast.error.internal.message';
+        void invoker.invokePromise(LayoutOperation.AddToast, {
+          id: `${meta.id}.error-${Date.now()}`,
+          title: ['toast.error.title', { ns: meta.id }],
+          description: [errorKey, { ns: meta.id }],
+        });
+      }
+    });
+
+    log.info('CRX bridge installed');
+  }),
+);


### PR DESCRIPTION
## Summary

- Move `install-crx-bridge`'s activate body into `capabilities/install-clip-listener.ts` behind `Capability.lazy`, matching the convention used by `CrxSettings` and `ReactSurface`.
- Restores `CrxPlugin.tsx` to a small static import graph (just `@dxos/app-framework`, `@dxos/app-toolkit`, `#capabilities`, `#meta`, `#translations`) — pre-#11292 shape.
- Adds a short note to the composer-app playwright README about webkit's sensitivity to plugin chunk-graph shape.

## Why

The Check workflow's `e2e` job has been timing out at 1h on every push to main since 2026-05-09 ([example run](https://github.com/dxos/dxos/actions/runs/25687508179)). Every webkit `composer-app:e2e` test was failing identically:

```
module failed to activate {
  module: org.dxos.plugin.crx.module.ReactSurface,
  error: undefined is not an object (evaluating 'u.settings'),
  isDefect: true
}
```

…which surfaced as a "System Error" dialog during boot, so `treeView.userAccount` never appeared and every basic.spec / collections.spec test timed out 3× before moving on, exhausting the hour budget.

Looking at the bundled `react-surface-*.js` chunk for plugin-crx:

```js
import { i as u } from "./ui-DA62G_k5.js";   // AppSurface namespace
...
var h = i.makeModule(() => t(i.contributes(a.ReactSurface, [
  o.create({
    filter: u.settings(u.Article, d.id),     // <- u undefined in Linux webkit
    ...
```

`AppSurface` (`S` in the ui chunk) is initialized as `var S = {}` and then populated via the `__export` helper. When `u` resolves to `undefined` at activation time, the destructure/access throws exactly the observed error.

[#11292](https://github.com/dxos/dxos/pull/11292) defined the new `install-crx-bridge` module inline in `CrxPlugin.tsx`, which pulled `listener.ts`, `mapping.ts`, and their transitive deps (`@dxos/plugin-client`, `@dxos/plugin-space`, `@dxos/plugin-markdown`, `@dxos/types`) into the eagerly-loaded `CrxPlugin` chunk. That widened the chunk graph rooted at the plugin enough that the bundler's chunk ordering shifted, and Linux webkit (stricter about ESM init order here than v8/SpiderMonkey, and stricter than Mac webkit in our test runs) tripped on the namespace binding.

Moving the activate body behind `Capability.lazy` restores the pre-#11292 chunk shape. Verified locally: the bundled crx React Surface chunk now imports `meta` from its own small chunk rather than the heavy combined `types-*` chunk.

Caveat: I couldn't reproduce the failure on Mac webkit (passed both before and after the fix). Confirmation requires Linux CI — kicked off [run 25694808520](https://github.com/dxos/dxos/actions/runs/25694808520) with `e2e=true`.

## Test plan

- [x] `moon run plugin-crx:lint plugin-crx:test` — passes
- [x] `moon run plugin-crx:build` — chunk shape inspected, `listener.ts` no longer in eagerly-loaded chunk
- [x] Local webkit `moon run composer-app:e2e -- src/playwright/basic.spec.ts` — passes (1 passed, 2 flaky-passing-on-retry, 3 skipped)
- [ ] CI: webkit `composer-app:e2e` no longer surfaces "System Error" / `u.settings` failure
- [ ] CI: `e2e` job completes under the 1h budget

Note: plugin-kanban webkit failures are a separate, unrelated TDZ issue (`Cannot access 'default' before initialization` in Effect's `errors.ts`) inside the Storybook dev-mode bundle — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Playwright E2E testing documentation with browser selection configuration options and environment-specific guidance.

* **Refactor**
  * Reorganized CRX plugin clipboard listener module activation for improved code maintainability. Clipboard operation feedback via notifications remains unchanged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11312)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->