### PR TITLE
fix: un-quarantine flaky CI tests in react-ui-table and phoenix

### DIFF
--- a/packages/common/phoenix/moon.yml
+++ b/packages/common/phoenix/moon.yml
@@ -10,3 +10,6 @@ tasks:
       - '--entryPoint=src/index.ts'
       - '--platform=node'
       - '--injectGlobals'
+  test:
+    deps:
+      - ~:compile

--- a/packages/common/phoenix/src/phoenix.node.test.ts
+++ b/packages/common/phoenix/src/phoenix.node.test.ts
@@ -12,7 +12,7 @@ import { Trigger } from '@dxos/async';
 import { Phoenix } from './phoenix';
 import { TEST_DIR, clearFiles, neverEndingProcess } from './testing-utils';
 
-describe.skipIf(process.env.CI)('DaemonManager', () => {
+describe('DaemonManager', () => {
   test('kill process by pid', async () => {
     const child = spawn('node', ['-e', `(${neverEndingProcess.toString()})()`]);
     const trigger = new Trigger();
@@ -24,9 +24,7 @@ describe.skipIf(process.env.CI)('DaemonManager', () => {
     await trigger.wait({ timeout: 1_000 });
   });
 
-  // Quarantined: flaky on CI (timeout starting the detached watchdog process under
-  // the moon test runner). Local runs still cover the suite during development.
-  test.skip('start/stop detached watchdog', async () => {
+  test('start/stop detached watchdog', async () => {
     const runId = Math.random().toString();
     const pidFile = join(TEST_DIR, `pid-${runId}.pid`);
     const logFile = join(TEST_DIR, `file-${runId}.log`);
@@ -45,9 +43,11 @@ describe.skipIf(process.env.CI)('DaemonManager', () => {
         errFile,
       });
 
-      await expect.poll(() => existsSync(params.logFile), { timeout: 1000 }).toBe(true);
-      const logs = readFileSync(params.logFile, { encoding: 'utf-8' });
-      expect(logs).to.contain('neverEndingProcess started');
+      await expect
+        .poll(() => (existsSync(params.logFile) ? readFileSync(params.logFile, { encoding: 'utf-8' }) : ''), {
+          timeout: 5_000,
+        })
+        .toContain('neverEndingProcess started');
     }
 
     // Stop

--- a/packages/ui/react-ui-grid/package.json
+++ b/packages/ui/react-ui-grid/package.json
@@ -16,7 +16,8 @@
     ".": {
       "source": "./src/index.ts",
       "types": "./dist/types/src/index.d.ts",
-      "browser": "./dist/lib/browser/index.mjs"
+      "browser": "./dist/lib/browser/index.mjs",
+      "node": "./dist/lib/browser/index.mjs"
     }
   },
   "types": "dist/types/src/index.d.ts",

--- a/packages/ui/react-ui-table/src/model/table-presentation.test.ts
+++ b/packages/ui/react-ui-table/src/model/table-presentation.test.ts
@@ -14,14 +14,7 @@ import { Table } from '../types';
 import { TableModel, type TableModelProps } from './table-model';
 import { TablePresentation } from './table-presentation';
 
-// Quarantined in CI only — vite resolves `@dxos/react-ui-grid` to the hoisted
-// node_modules copy, which fails the `node` export condition under the
-// workflow's `--no-file-parallelism` runner. Tests pass locally so the suite
-// still runs during development.
-// Trunk.io tracking:
-//   https://app.trunk.io/dxos/flaky-tests/test/e027ed98-4aea-5a63-b5ed-10baf76fb11e
-const describeOutsideCI = process.env.CI ? describe.skip : describe;
-describeOutsideCI('TablePresentation', () => {
+describe('TablePresentation', () => {
   describe('getCells', () => {
     let registry: Registry.Registry;
     let data: any[];

--- a/packages/ui/react-ui-table/src/util/dynamic-table.test.ts
+++ b/packages/ui/react-ui-table/src/util/dynamic-table.test.ts
@@ -9,14 +9,7 @@ import { Format } from '@dxos/echo';
 
 import { type TablePropertyDefinition, getBaseSchema, makeDynamicTable } from './dynamic-table';
 
-// Quarantined in CI only — flaky under the workflow's `--no-file-parallelism`
-// runner / hoisted node_modules layout. Local runs still cover the suite so
-// regressions surface during development.
-// Trunk.io tracking:
-//   https://app.trunk.io/dxos/flaky-tests/test/fe424f97-f8a1-5f2f-a191-5b3ec4e8f6b7
-//   https://app.trunk.io/dxos/flaky-tests/test/ee00f293-9b9b-55ed-b4cd-48a07edea96c
-const describeOutsideCI = process.env.CI ? describe.skip : describe;
-describeOutsideCI('makeDynamicTable', () => {
+describe('makeDynamicTable', () => {
   /**
    * Base case: plain jsonSchema (not from Echo / JsonSchema.toJsonSchema). Does not exercise the path
    * where projection or schema are reactive, so this does not reproduce the Obj.update regression.


### PR DESCRIPTION
## Summary

Fixes two groups of tests that were quarantined/skipped in CI due to Trunk flaky-test detection.

### react-ui-table (Trunk investigations: e027ed98, fe424f97, ee00f293)

- **Root cause**: `@dxos/react-ui-grid/package.json` was missing a `node` export condition. Under CI's `--no-file-parallelism` runner with hoisted `node_modules`, Vitest resolves packages via a `node` condition which `react-ui-grid` lacked — causing an import resolution error.
- **Fix**: Add `"node": "./dist/lib/browser/index.mjs"` to `react-ui-grid/package.json` (same pattern already used by `@dxos/lit-grid`).
- **Un-quarantine**: Remove `describeOutsideCI` guards from `table-presentation.test.ts` and `dynamic-table.test.ts`.

### phoenix (Trunk investigation: b4ffebc2)

- **Root cause 1**: `bin/watchdog.mjs` imports from `../dist/lib/node-esm/index.mjs`. The inherited `:test` task only builds upstream deps (`^:compile`), not the package itself (`~:compile`), so the dist was missing when tests ran in a clean environment.
- **Root cause 2**: Race condition — `Phoenix.start()` pre-creates an empty log file, so polling for file *existence* resolved immediately before the child process had written anything.
- **Fix**: Add `~:compile` to the `test` task deps in `moon.yml` + poll for log file *content* with a 5 s timeout instead of polling for existence.
- **Un-quarantine**: Remove `describe.skipIf(process.env.CI)` and `test.skip` guards.

## Test plan

- [x] `moon run react-ui-table:test -- --no-file-parallelism` — 14 tests pass (was 6 skipped before fix)
- [x] `moon run phoenix:test` — all 3 tests pass including `start/stop detached watchdog` (725ms)

https://claude.ai/code/session_01XqYuxZVGmR3HRT9TWxvsio

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqYuxZVGmR3HRT9TWxvsio)_