### PR TITLE
fix(vendor-kbn-handlebars): publish publicly so @dxos/compute installs

### DIFF
--- a/vendor/kbn-handlebars/package.json
+++ b/vendor/kbn-handlebars/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/vendor-kbn-handlebars",
   "version": "0.8.3",
-  "private": true,
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
   "repository": {


### PR DESCRIPTION
## Summary

Every published `main` snapshot from [#11247](https://github.com/dxos/dxos/pull/11247) onward fails to install for external consumers — `@dxos/compute` declares `@dxos/vendor-kbn-handlebars` as a runtime `dependencies` entry, but the vendor package is `"private": true` (the default set when the package was added per the repo convention for new packages) and never publishes to npm.

Reproducible:

```sh
$ pnpm add @dxos/compute@0.8.4-main.3fbcb4aa9b
 ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/@dxos%2Fvendor-kbn-handlebars: Not Found

This error happened while installing the dependencies of @dxos/compute@0.8.4-main.3fbcb4aa9b
```

Affects every external consumer that tracks the `main` dist-tag (e.g. `dxos/plugin-excalidraw`).

## Fix

Drop `"private": true` from `vendor/kbn-handlebars/package.json` so the vendor publishes alongside compute. `publishConfig.access: "public"` is already set on this package.

## Heads-up

Per CLAUDE.md:

> "Any new package created in this repo MUST have `"private": true` in its `package.json`. The `private` flag can only be removed manually once a trusted publisher has been configured for the package."

**A trusted publisher needs to be configured for `@dxos/vendor-kbn-handlebars` on npm before merging this**, otherwise the publish workflow will fail at the npm-side authorization step rather than fix the 404.

## Test plan

- [x] `pnpm build` clean.
- [x] `moon run :lint -- --fix` clean.
- [x] `pnpm format` clean.
- [ ] Confirm trusted publisher configured for `@dxos/vendor-kbn-handlebars`.
- [ ] After merge + publish, verify `pnpm add @dxos/compute@<new-snapshot>` succeeds without 404'ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11322)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->