### PR TITLE
fix(plugins): restore publishable status of 13 plugins

### DIFF
--- a/packages/plugins/plugin-attention/package.json
+++ b/packages/plugins/plugin-attention/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-attention",
   "version": "0.8.3",
-  "private": true,
   "description": "Plugin for attention",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/plugins/plugin-chess/package.json
+++ b/packages/plugins/plugin-chess/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-chess",
   "version": "0.8.3",
-  "private": true,
   "description": "Chess for new plugin",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/plugins/plugin-client/package.json
+++ b/packages/plugins/plugin-client/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-client",
   "version": "0.8.3",
-  "private": true,
   "description": "DXOS Surface plugin for DXOS Client",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/plugins/plugin-deck/package.json
+++ b/packages/plugins/plugin-deck/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-deck",
   "version": "0.8.3",
-  "private": true,
   "description": "DXOS Surface plugin for the main application layout.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/plugins/plugin-files/package.json
+++ b/packages/plugins/plugin-files/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-files",
   "version": "0.8.3",
-  "private": true,
   "description": "DXOS Surface plugin for managing files.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/plugins/plugin-graph/package.json
+++ b/packages/plugins/plugin-graph/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-graph",
   "version": "0.8.3",
-  "private": true,
   "description": "DXOS Surface plugin for constructing knowledge graphs",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/plugins/plugin-map/package.json
+++ b/packages/plugins/plugin-map/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-map",
   "version": "0.8.3",
-  "private": true,
   "description": "Map plugin",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/plugins/plugin-navtree/package.json
+++ b/packages/plugins/plugin-navtree/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-navtree",
   "version": "0.8.3",
-  "private": true,
   "description": "DXOS Surface plugin for a tree view visualization of the graph.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/plugins/plugin-observability/package.json
+++ b/packages/plugins/plugin-observability/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-observability",
   "version": "0.8.3",
-  "private": true,
   "description": "DXOS app framework plugin for hooking up app observability",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/plugins/plugin-settings/package.json
+++ b/packages/plugins/plugin-settings/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-settings",
   "version": "0.8.3",
-  "private": true,
   "description": "DXOS Settings plugin for managing application settings.",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/plugins/plugin-space/package.json
+++ b/packages/plugins/plugin-space/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-space",
   "version": "0.8.3",
-  "private": true,
   "description": "DXOS Surface plugin for DXOS ECHO Spaces",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/plugins/plugin-thread/package.json
+++ b/packages/plugins/plugin-thread/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-thread",
   "version": "0.8.3",
-  "private": true,
   "description": "DXOS Threads Surface plugin",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/packages/plugins/plugin-wnfs/package.json
+++ b/packages/plugins/plugin-wnfs/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/plugin-wnfs",
   "version": "0.8.3",
-  "private": true,
   "description": "WNFS file management plugin",
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",

--- a/vendor/kbn-handlebars/package.json
+++ b/vendor/kbn-handlebars/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dxos/vendor-kbn-handlebars",
   "version": "0.8.3",
-  "private": true,
   "homepage": "https://dxos.org",
   "bugs": "https://github.com/dxos/dxos/issues",
   "repository": {


### PR DESCRIPTION
## Summary

[#11309](https://github.com/dxos/dxos/pull/11309) accidentally added `"private": true` to 13 plugins that were already publicly published. The publish workflow's `pnpm publish --filter-prod=...` step skips private packages, so the next two main snapshots (`3fbcb4aa9b`, `dfabb4ec29`) silently dropped these from the dist-tag rotation:

- plugin-attention, plugin-chess, plugin-client, plugin-deck, plugin-files, plugin-graph, plugin-map, plugin-navtree, plugin-observability, plugin-settings, plugin-space, plugin-thread, plugin-wnfs

External consumers that track the `main` dist-tag (e.g. `dxos/plugin-excalidraw`) end up stuck on whatever the last pre-#11309 snapshot was — currently `0.8.4-main.1c7ec43d41` for plugin-space — which pulls a stale `@dxos/compute` that transitively references the unpublished `@dxos/vendor-kbn-handlebars@1c7ec43d41`, **404'ing the install**.

Confirmed via the [Publish run for `dfabb4ec29`](https://github.com/dxos/dxos/actions/runs/25764673086/job/75674248856) — 37 plugin packages published, but none of these 13 were in the publish list.

## Fix

Drop `"private": true` from those 13 packages so the next publish republishes them at the current main SHA, restoring lockstep with the rest of the workspace.

(The CLAUDE.md "new packages MUST be private" rule was applied too broadly during the wave migration — it only governs **newly-added** packages, not existing public ones.)

The other 21 plugins still marked private (plugin-bluesky, plugin-code, etc.) were already private before [#11309](https://github.com/dxos/dxos/pull/11309) and stay that way pending their own trusted-publisher setup.

## Test plan

- [x] `pnpm build` clean.
- [x] `moon run :lint -- --fix` clean.
- [x] `pnpm format` clean.
- [ ] After publish, verify `npm view @dxos/plugin-space dist-tags.main` shows the new SHA (not stuck on `1c7ec43d41`).
- [ ] After publish, verify `pnpm add @dxos/plugin-space@<new-snapshot>` installs without 404'ing on the transitive vendor package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled public distribution of multiple plugin packages (attention, chess, client, deck, files, graph, map, navtree, observability, settings, space, thread, and wnfs).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11323)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->