### PR TITLE
fix(observability): fix OTel proxy and bump feedback log upload limit to 50 MB

### DIFF
--- a/packages/apps/composer-app/src/config.ts
+++ b/packages/apps/composer-app/src/config.ts
@@ -65,7 +65,6 @@ export const initializeObservability = async (config: Config, isTauri: boolean, 
         serviceName: 'composer',
         serviceVersion: DXOS_VERSION,
         environment: config.values.runtime?.app?.env?.DX_ENVIRONMENT ?? 'unknown',
-        // Default to the Cloudflare worker reverse-proxy; override with DX_OTEL_ENDPOINT at build time.
         endpoint: '/api/otel',
         config,
         logs: true,

--- a/packages/apps/composer-app/src/config.ts
+++ b/packages/apps/composer-app/src/config.ts
@@ -12,6 +12,8 @@ import { type IdbLogStore } from '@dxos/log-store-idb';
 import { Observability, ObservabilityExtension, ObservabilityProvider } from '@dxos/observability';
 import { getHostPlatform } from '@dxos/util';
 
+import { FEEDBACK_LOGS_MAX_SIZE } from './constants';
+
 export const PARAM_PROFILER = 'profiler';
 export const PARAM_SAFE_MODE = 'safe';
 export const PARAM_LOG_LEVEL = 'log';
@@ -63,6 +65,8 @@ export const initializeObservability = async (config: Config, isTauri: boolean, 
         serviceName: 'composer',
         serviceVersion: DXOS_VERSION,
         environment: config.values.runtime?.app?.env?.DX_ENVIRONMENT ?? 'unknown',
+        // Default to the Cloudflare worker reverse-proxy; override with DX_OTEL_ENDPOINT at build time.
+        endpoint: '/api/otel',
         config,
         logs: true,
         metrics: true,
@@ -75,6 +79,7 @@ export const initializeObservability = async (config: Config, isTauri: boolean, 
         release: DXOS_VERSION,
         environment: config.values.runtime?.app?.env?.DX_ENVIRONMENT ?? 'unknown',
         logStore,
+        feedbackLogMaxSize: FEEDBACK_LOGS_MAX_SIZE,
       }),
     ),
     Observability.addDataProvider(ObservabilityProvider.IPData.provider(config)),

--- a/packages/apps/composer-app/src/constants.ts
+++ b/packages/apps/composer-app/src/constants.ts
@@ -10,3 +10,10 @@ export const APP_KEY = 'composer.dxos.org';
  * store and can be exported together.
  */
 export const LOG_STORE_DB_NAME = 'composer-logs';
+
+/**
+ * Maximum byte size for a feedback log upload.
+ * Must match the limit enforced in the Cloudflare worker (`_worker.ts`).
+ * Export trims to this size so the upload never exceeds the worker's cap.
+ */
+export const FEEDBACK_LOGS_MAX_SIZE = 50 * 1024 * 1024; // 50 MB

--- a/packages/apps/composer-app/src/functions/_worker.ts
+++ b/packages/apps/composer-app/src/functions/_worker.ts
@@ -2,6 +2,8 @@
 // Copyright 2024 DXOS.org
 //
 
+import { FEEDBACK_LOGS_MAX_SIZE } from '../constants';
+
 type Env = {
   ASSETS: Fetcher;
   ENVIRONMENT?: string;
@@ -11,7 +13,7 @@ type Env = {
 };
 
 const OTEL_MAX_BODY_SIZE = 800 * 1024 * 1024; // 800MB.
-const FEEDBACK_LOGS_MAX_BODY_SIZE = 8 * 1024 * 1024; // 8MB.
+const FEEDBACK_LOGS_MAX_BODY_SIZE = FEEDBACK_LOGS_MAX_SIZE;
 
 const ALLOWED_ORIGINS = new Set([
   'https://composer.space',

--- a/packages/sdk/observability/src/extensions/otel/extension.ts
+++ b/packages/sdk/observability/src/extensions/otel/extension.ts
@@ -63,7 +63,7 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Extension
 
   const endpoint = isNode()
     ? (process.env.DX_OTEL_ENDPOINT ?? _endpoint ?? buildSecrets.OTEL_ENDPOINT)
-    : config.values.runtime?.app?.env?.DX_OTEL_ENDPOINT;
+    : (config.values.runtime?.app?.env?.DX_OTEL_ENDPOINT ?? _endpoint);
   const headers =
     _headers ??
     Match.value(isNode()).pipe(
@@ -74,10 +74,12 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Extension
       Option.getOrElse(() => undefined),
     );
 
-  if (!endpoint || !headers) {
-    log.info('Missing OTEL_ENDPOINT or OTEL_HEADERS');
+  if (!endpoint) {
+    log.info('Missing OTEL_ENDPOINT');
     return stubExtension;
   }
+  // Headers are optional when using a proxy that injects auth server-side.
+  const resolvedHeaders = headers ?? {};
 
   // Matches edge's `ctx.tag` span attribute (stamped by the edge log middleware
   // when it reads the `X-DXOS-Client-Tag` header, see
@@ -110,7 +112,7 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Extension
   const logs = logsEnabled
     ? new OtelLogs({
         endpoint,
-        headers,
+        headers: resolvedHeaders,
         resource,
         getTags: () => Object.fromEntries(tags),
         logLevel,
@@ -120,7 +122,7 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Extension
   const metrics = metricsEnabled
     ? new OtelMetrics({
         endpoint,
-        headers,
+        headers: resolvedHeaders,
         resource,
         getTags: () => Object.fromEntries(tags),
       })
@@ -129,7 +131,7 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Extension
   const traces = tracesEnabled
     ? new OtelTraces({
         endpoint,
-        headers,
+        headers: resolvedHeaders,
         resource,
         getTags: () => Object.fromEntries(tags),
       })

--- a/packages/sdk/observability/src/extensions/posthog/extension.ts
+++ b/packages/sdk/observability/src/extensions/posthog/extension.ts
@@ -25,6 +25,12 @@ export type ExtensionsOptions = {
    * this extension only consumes the buffered logs (via `export()`).
    */
   logStore?: IdbLogStore;
+  /**
+   * Maximum byte size passed to `logStore.export()` when uploading feedback logs.
+   * Should match the upload limit enforced by the server receiving the logs.
+   * When omitted the full store is exported without trimming.
+   */
+  feedbackLogMaxSize?: number;
 };
 
 /** Upload serialized logs to the feedback-logs endpoint. Returns the R2 key on success. */
@@ -54,6 +60,7 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Extension
   environment,
   posthog: posthogConfig,
   logStore,
+  feedbackLogMaxSize,
 }) {
   if (typeof window === 'undefined') {
     log('PostHog is being stubbed because it is running in a worker.');
@@ -158,7 +165,7 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Extension
 
             let debugLogDumpKey: string | null = null;
             if (form.includeLogs !== false && logStore !== undefined) {
-              const ndjson = await logStore.export();
+              const ndjson = await logStore.export({ maxSize: feedbackLogMaxSize });
               if (ndjson.length > 0) {
                 debugLogDumpKey = (await uploadLogs(ndjson)) ?? 'failed';
               }


### PR DESCRIPTION
## Summary

- **OTel proxy was silently disabled on every deployment**: `DX_OTEL_ENDPOINT=/api/otel` was correctly set in all env files, but `DX_OTEL_HEADERS` was intentionally absent (the Cloudflare worker injects `signoz-ingestion-key` server-side). The old guard `if (!endpoint || !headers)` treated missing headers as a misconfiguration and returned `stubExtension`, disabling OTel entirely.
- **Feedback log uploads were capped at 8 MB** with no size-trimming on export, and the cap was a hardcoded literal with no connection to the client-side export call.

## Changes

- `packages/sdk/observability/src/extensions/otel/extension.ts`: browser context now falls back to `_endpoint` option; `DX_OTEL_HEADERS` is no longer required; headers default to `{}` when absent.
- `packages/apps/composer-app/src/config.ts`: pass `endpoint: '/api/otel'` as the default OTel proxy path so OTel works without a build-time env override.
- `packages/apps/composer-app/src/constants.ts`: introduce `FEEDBACK_LOGS_MAX_SIZE = 50 MB` as the single source of truth for the upload cap.
- `packages/apps/composer-app/src/functions/_worker.ts`: use `FEEDBACK_LOGS_MAX_SIZE` constant (up from 8 MB).
- `packages/sdk/observability/src/extensions/posthog/extension.ts`: add `feedbackLogMaxSize` option; pass to `logStore.export({ maxSize })` so NDJSON is trimmed before upload.

## Test plan

- [ ] Deploy to labs/staging and confirm OTel traces/logs/metrics appear in SigNoz
- [ ] Submit feedback with logs included and confirm the R2 key is returned and the object appears in the bucket
- [ ] Verify no "Missing OTEL_ENDPOINT" console messages on labs.composer.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established unified feedback log size limit of 50MB across observability services to ensure consistency between client-side data collection and server-side processing
  * Enhanced OTEL observability extension with explicit endpoint configuration and improved header handling
  * Added configurable feedback log size support to PostHog observability extension for better resource management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11327)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->