### PR TITLE
feat(automerge): enhance loadDoc functionality with fetchFromNetwork option for improved document retrieval

### DIFF
--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.test.ts
@@ -6,6 +6,7 @@ import * as A from '@automerge/automerge';
 import { type DocumentId, type Heads, generateAutomergeUrl, parseAutomergeUrl } from '@automerge/automerge-repo';
 import { describe, expect, onTestFinished, test } from 'vitest';
 
+import { sleep } from '@dxos/async';
 import { Context } from '@dxos/context';
 import { PublicKey } from '@dxos/keys';
 import type { LevelDB } from '@dxos/kv-store';
@@ -15,6 +16,7 @@ import { range } from '@dxos/util';
 
 import { TestReplicationNetwork } from '../testing';
 import { AutomergeHost } from './automerge-host';
+import { type EchoNetworkAdapter } from './echo-network-adapter';
 
 describe('AutomergeHost', () => {
   test('can create documents', async () => {
@@ -113,6 +115,99 @@ describe('AutomergeHost', () => {
       await level.close();
     }
   });
+
+  test('loadDoc respects fetchFromNetwork', { timeout: 10_000 }, async () => {
+    const level1 = await createLevel();
+    const host1 = await setupAutomergeHost({ level: level1 });
+
+    const level2 = await createLevel();
+    const host2 = await setupAutomergeHost({ level: level2 });
+    const handle = await host2.createDoc({ text: 'Hello world' });
+    await host2.flush(Context.default());
+
+    const network = await new TestReplicationNetwork().open();
+    await host1.addReplicator(Context.default(), await network.createReplicator());
+    await host2.addReplicator(Context.default(), await network.createReplicator());
+
+    // (1) fetchFromNetwork=false on a doc not yet on disk: throws unavailable
+    // without waiting on the network, even though host2 has it.
+    await expect(
+      host1.loadDoc(Context.default(), handle.documentId, { fetchFromNetwork: false, timeout: 1_000 }),
+    ).rejects.toThrow(/unavailable/i);
+
+    // (2) fetchFromNetwork=true: host1 announces, host2 sends bytes, doc syncs.
+    const loaded = await host1.loadDoc<{ text: string }>(Context.default(), handle.documentId, {
+      fetchFromNetwork: true,
+      timeout: 5_000,
+    });
+    expect(loaded.doc()!.text).toEqual('Hello world');
+
+    // (3) Now that host1 has the doc on disk, fetchFromNetwork=false succeeds.
+    await host1.flush(Context.default());
+    const localOnly = await host1.loadDoc<{ text: string }>(Context.default(), handle.documentId, {
+      fetchFromNetwork: false,
+    });
+    expect(localOnly.doc()!.text).toEqual('Hello world');
+
+    await host1.close();
+    await host2.close();
+    await network.close();
+  });
+
+  test(
+    'loadDoc with fetchFromNetwork=false does not announce when doc is in storage',
+    { timeout: 5_000 },
+    async () => {
+      // Pre-populate host1's storage with the doc, then close so that the
+      // host1 we test with has the doc on disk but did not author it (i.e.
+      // it's not in `_createdDocuments` and won't auto-announce).
+      const tmpPath = `/tmp/dxos-${PublicKey.random().toHex()}`;
+      let documentId: DocumentId;
+      {
+        const level = await createLevel(tmpPath);
+        const provider = await setupAutomergeHost({ level });
+        const handle = await provider.createDoc({ text: 'Hello world' });
+        documentId = handle.documentId;
+        await provider.flush(Context.default());
+        await provider.close();
+        await level.close();
+      }
+
+      const level1 = await createLevel(tmpPath);
+      const host1 = await setupAutomergeHost({ level: level1 });
+
+      const level2 = await createLevel();
+      const host2 = await setupAutomergeHost({ level: level2 });
+
+      const network = await new TestReplicationNetwork().open();
+      await host1.addReplicator(Context.default(), await network.createReplicator());
+      await host2.addReplicator(Context.default(), await network.createReplicator());
+
+      // Spy on host2's incoming-request event — fires when any peer sends
+      // an automerge `request` message for a doc to host2. If host1 ever
+      // announced wanting `documentId`, this would trigger.
+      const requests: DocumentId[] = [];
+      const adapter = (host2 as unknown as { _echoNetworkAdapter: EchoNetworkAdapter })._echoNetworkAdapter;
+      adapter.documentRequested.on(({ documentId: requestedId }) => {
+        requests.push(requestedId);
+      });
+
+      // Load the doc that's already on disk; should resolve from storage.
+      const loaded = await host1.loadDoc<{ text: string }>(Context.default(), documentId, {
+        fetchFromNetwork: false,
+      });
+      expect(loaded.doc()!.text).toEqual('Hello world');
+
+      // Give any in-flight share-policy debounce a chance to fire.
+      await sleep(100);
+
+      expect(requests).not.toContain(documentId);
+
+      await host1.close();
+      await host2.close();
+      await network.close();
+    },
+  );
 
   test('collection synchronization', { timeout: 30_000 }, async () => {
     const NUM_DOCUMENTS = 10;

--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.test.ts
@@ -154,60 +154,56 @@ describe('AutomergeHost', () => {
     await network.close();
   });
 
-  test(
-    'loadDoc with fetchFromNetwork=false does not announce when doc is in storage',
-    { timeout: 5_000 },
-    async () => {
-      // Pre-populate host1's storage with the doc, then close so that the
-      // host1 we test with has the doc on disk but did not author it (i.e.
-      // it's not in `_createdDocuments` and won't auto-announce).
-      const tmpPath = `/tmp/dxos-${PublicKey.random().toHex()}`;
-      let documentId: DocumentId;
-      {
-        const level = await createLevel(tmpPath);
-        const provider = await setupAutomergeHost({ level });
-        const handle = await provider.createDoc({ text: 'Hello world' });
-        documentId = handle.documentId;
-        await provider.flush(Context.default());
-        await provider.close();
-        await level.close();
-      }
+  test('loadDoc with fetchFromNetwork=false does not announce when doc is in storage', { timeout: 5_000 }, async () => {
+    // Pre-populate host1's storage with the doc, then close so that the
+    // host1 we test with has the doc on disk but did not author it (i.e.
+    // it's not in `_createdDocuments` and won't auto-announce).
+    const tmpPath = `/tmp/dxos-${PublicKey.random().toHex()}`;
+    let documentId: DocumentId;
+    {
+      const level = await createLevel(tmpPath);
+      const provider = await setupAutomergeHost({ level });
+      const handle = await provider.createDoc({ text: 'Hello world' });
+      documentId = handle.documentId;
+      await provider.flush(Context.default());
+      await provider.close();
+      await level.close();
+    }
 
-      const level1 = await createLevel(tmpPath);
-      const host1 = await setupAutomergeHost({ level: level1 });
+    const level1 = await createLevel(tmpPath);
+    const host1 = await setupAutomergeHost({ level: level1 });
 
-      const level2 = await createLevel();
-      const host2 = await setupAutomergeHost({ level: level2 });
+    const level2 = await createLevel();
+    const host2 = await setupAutomergeHost({ level: level2 });
 
-      const network = await new TestReplicationNetwork().open();
-      await host1.addReplicator(Context.default(), await network.createReplicator());
-      await host2.addReplicator(Context.default(), await network.createReplicator());
+    const network = await new TestReplicationNetwork().open();
+    await host1.addReplicator(Context.default(), await network.createReplicator());
+    await host2.addReplicator(Context.default(), await network.createReplicator());
 
-      // Spy on host2's incoming-request event — fires when any peer sends
-      // an automerge `request` message for a doc to host2. If host1 ever
-      // announced wanting `documentId`, this would trigger.
-      const requests: DocumentId[] = [];
-      const adapter = (host2 as unknown as { _echoNetworkAdapter: EchoNetworkAdapter })._echoNetworkAdapter;
-      adapter.documentRequested.on(({ documentId: requestedId }) => {
-        requests.push(requestedId);
-      });
+    // Spy on host2's incoming-request event — fires when any peer sends
+    // an automerge `request` message for a doc to host2. If host1 ever
+    // announced wanting `documentId`, this would trigger.
+    const requests: DocumentId[] = [];
+    const adapter = (host2 as unknown as { _echoNetworkAdapter: EchoNetworkAdapter })._echoNetworkAdapter;
+    adapter.documentRequested.on(({ documentId: requestedId }) => {
+      requests.push(requestedId);
+    });
 
-      // Load the doc that's already on disk; should resolve from storage.
-      const loaded = await host1.loadDoc<{ text: string }>(Context.default(), documentId, {
-        fetchFromNetwork: false,
-      });
-      expect(loaded.doc()!.text).toEqual('Hello world');
+    // Load the doc that's already on disk; should resolve from storage.
+    const loaded = await host1.loadDoc<{ text: string }>(Context.default(), documentId, {
+      fetchFromNetwork: false,
+    });
+    expect(loaded.doc()!.text).toEqual('Hello world');
 
-      // Give any in-flight share-policy debounce a chance to fire.
-      await sleep(100);
+    // Give any in-flight share-policy debounce a chance to fire.
+    await sleep(100);
 
-      expect(requests).not.toContain(documentId);
+    expect(requests).not.toContain(documentId);
 
-      await host1.close();
-      await host2.close();
-      await network.close();
-    },
-  );
+    await host1.close();
+    await host2.close();
+    await network.close();
+  });
 
   test('collection synchronization', { timeout: 30_000 }, async () => {
     const NUM_DOCUMENTS = 10;

--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
@@ -80,8 +80,16 @@ export type LoadDocOptions = {
   timeout?: number;
 
   /**
-   * If true, the document will be fetched from the network if it is not found in the local storage.
-   * Setting this to false does not guarantee that the document will not be fetched from the network.
+   * Controls whether `loadDoc` is allowed to wait on the network.
+   *
+   * - `true` / unset (default): announce that we want the doc and wait
+   *   until any source (storage OR network) delivers it.
+   * - `false`: probe local storage only. If chunks for the doc exist
+   *   on disk, wait for storage to populate the handle; otherwise
+   *   throw `'unavailable'` immediately without ever consulting the
+   *   network. Note that this does not guarantee that the document
+   *   will not be fetched from the network — an inbound peer announce
+   *   can still deliver bytes — but the host will never request it.
    */
   fetchFromNetwork?: boolean;
 };
@@ -367,14 +375,55 @@ export class AutomergeHost extends Resource {
     // Readiness lives on the `DocumentQuery`, not the `DocHandle` — see
     // {@link getHandleState}.
     const progress = this._repo.findWithProgress<T>(documentId as DocumentId);
-    const state = progress.peek();
-    if (state.state === 'ready') {
-      return state.handle;
+    const initial = progress.peek();
+    if (initial.state === 'ready') {
+      return initial.handle;
     }
-    if (!this._useSubduction) {
-      this._documentsToRequest.add(progress.documentId);
-      this._sharePolicyChangedTask!.schedule();
+
+    // Default: when `fetchFromNetwork` is unset, behave as if it were
+    // `true` — wait on any source. Only an explicit `false` activates
+    // the storage-only branch.
+    if (opts?.fetchFromNetwork !== false) {
+      // Network branch: announce that we want the doc, then fall through
+      // to `whenReady()` and wait for any source (storage or network) to
+      // deliver it.
+      if (!this._useSubduction) {
+        this._documentsToRequest.add(progress.documentId);
+        this._sharePolicyChangedTask!.schedule();
+      }
+    } else {
+      // Storage-only branch.
+      //
+      // HACK: the subduction fork's `DocumentQuery` collapsed the old
+      // `'loading'` (storage) and `'requesting'` (network) states into a
+      // single `'loading'` state, with per-source state living on a
+      // private `#sources` map. So we can't ask the query "is storage
+      // still pending?" vs "is the network still pending?" off
+      // `progress.peek()`.
+      //
+      // Workaround: probe the storage adapter directly. If chunks exist
+      // for the doc id, `StorageSubsystem` will populate the handle on
+      // its own and the shared `whenReady()` below will resolve from
+      // storage. We never schedule `_sharePolicyChangedTask`, so under
+      // {@link OPTIMIZED_SHARE_POLICY} no outbound announce goes out and
+      // the network sources stay dormant — storage effectively always
+      // wins the race. If chunks don't exist, throw `'unavailable'`
+      // immediately without ever consulting the network.
+      //
+      // The JSDoc on {@link LoadDocOptions.fetchFromNetwork} already
+      // calls out the residual race: an inbound peer announce can still
+      // deliver the doc, but the resulting handle is identical
+      // regardless of which source got there first.
+      //
+      // TODO(mykola): replace with per-source state inspection once the
+      // patched fork exposes it on `DocumentProgress`.
+      const chunks = await this._storage.loadRange([progress.documentId]);
+      const onDisk = chunks.some((chunk) => chunk.data && chunk.data.length > 0);
+      if (!onDisk) {
+        throw new Error(`Document ${progress.documentId} is unavailable`);
+      }
     }
+
     const readyPromise = progress.whenReady();
     return opts?.timeout
       ? await cancelWithContext(ctx, asyncTimeout(readyPromise, opts.timeout))

--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-host.ts
@@ -392,29 +392,13 @@ export class AutomergeHost extends Resource {
         this._sharePolicyChangedTask!.schedule();
       }
     } else {
-      // Storage-only branch.
-      //
-      // HACK: the subduction fork's `DocumentQuery` collapsed the old
-      // `'loading'` (storage) and `'requesting'` (network) states into a
-      // single `'loading'` state, with per-source state living on a
-      // private `#sources` map. So we can't ask the query "is storage
-      // still pending?" vs "is the network still pending?" off
-      // `progress.peek()`.
-      //
-      // Workaround: probe the storage adapter directly. If chunks exist
-      // for the doc id, `StorageSubsystem` will populate the handle on
-      // its own and the shared `whenReady()` below will resolve from
-      // storage. We never schedule `_sharePolicyChangedTask`, so under
-      // {@link OPTIMIZED_SHARE_POLICY} no outbound announce goes out and
-      // the network sources stay dormant — storage effectively always
-      // wins the race. If chunks don't exist, throw `'unavailable'`
-      // immediately without ever consulting the network.
-      //
-      // The JSDoc on {@link LoadDocOptions.fetchFromNetwork} already
-      // calls out the residual race: an inbound peer announce can still
-      // deliver the doc, but the resulting handle is identical
-      // regardless of which source got there first.
-      //
+      // Note: This is a Hack.
+      // Storage-only branch. The subduction fork's `DocumentQuery` merged
+      // storage/network into a single `'loading'` state, so we can't tell
+      // them apart via `progress.peek()`. Workaround: probe storage
+      // directly and throw `'unavailable'` if nothing is on disk, without
+      // ever scheduling a network announce. See `fetchFromNetwork` JSDoc
+      // for the residual inbound-announce race.
       // TODO(mykola): replace with per-source state inspection once the
       // patched fork exposes it on `DocumentProgress`.
       const chunks = await this._storage.loadRange([progress.documentId]);

--- a/packages/core/echo/echo-pipeline/src/automerge/automerge-repo-subduction.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/automerge-repo-subduction.test.ts
@@ -514,11 +514,11 @@ describe('AutomergeRepo with Subduction', () => {
         await waitForSubductionSave();
 
         await expect
-          .poll(async () => (await client.find<{ text?: string }>(handle.url)).doc()?.text, { timeout: 5_000 })
+          .poll(async () => (await client.find<{ text?: string }>(handle.url)).doc()?.text, { timeout: 10_000 })
           .toEqual('connect/accept');
       });
 
-      test('accept/connect syncs', async () => {
+      test('accept/connect syncs', { timeout: 15_000 }, async () => {
         const { repos, adapters } = await createHostClientRepoTopology({
           roles: { host: 'accept', client: 'connect' },
         });
@@ -531,8 +531,13 @@ describe('AutomergeRepo with Subduction', () => {
         });
         await waitForSubductionSave();
 
+        // Bumped from 5_000 to 10_000: on a loaded CI box, the underlying
+        // subduction `RequestId` round-trip can hit its own internal timeout
+        // (~5s) and only the retry succeeds, which pushes us past the poll
+        // window. Local runs land in ~200-300 ms; CI was occasionally flaking
+        // at exactly 5005 ms.
         await expect
-          .poll(async () => (await client.find<{ text?: string }>(handle.url)).doc()?.text, { timeout: 5_000 })
+          .poll(async () => (await client.find<{ text?: string }>(handle.url)).doc()?.text, { timeout: 10_000 })
           .toEqual('accept/connect');
       });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering document load flows: local-only probe, network-fetch path after replication, and verification that peers are not announced when loading from local storage.
  * Adjusted test polling timeouts to improve CI reliability.

* **Improvements**
  * Document loading now respects a local-only mode that probes on-disk storage and returns a clear error if the document is unavailable; network fetch behavior remains available when enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11328)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->