### PR TITLE
fix(echo-pipeline): clean up per-collection state on connection close

### DIFF
--- a/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.test.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.test.ts
@@ -102,6 +102,51 @@ describe('CollectionSynchronizer', () => {
     expect(sentStates.every((m) => m.state === STATE_1)).to.equal(true);
   });
 
+  test('does not send to a peer after onConnectionClosed', async ({ expect }) => {
+    // Regression: `onConnectionClosed` must remove the peer from `interestedPeers`,
+    // otherwise the next `_broadcastLocalState` calls `sendCollectionState` for a
+    // now-stale peerId and the real network adapter throws "Connection not found.".
+    const peerId1 = 'peer1' as PeerId;
+    const peerId2 = 'peer2' as PeerId;
+    const collectionId = 'collection-test';
+
+    const connected = new Set<PeerId>([peerId1, peerId2]);
+    const sentTo: PeerId[] = [];
+    const peer = await new CollectionSynchronizer({
+      queryCollectionState: () => {},
+      sendCollectionState: (_collectionId, peerId) => {
+        if (!connected.has(peerId)) {
+          throw new Error('Connection not found.');
+        }
+        sentTo.push(peerId);
+      },
+      shouldSyncCollection: () => true,
+    }).open();
+    onTestFinished(async () => {
+      await peer.close();
+    });
+
+    // Activate the collection before any peer connects so the connect-time
+    // microtask adds peers to `interestedPeers` without ever calling
+    // `_broadcastLocalState` (so `lastBroadcast` stays unset for them).
+    peer.setLocalCollectionState(collectionId, STATE_1);
+    await sleep(10);
+
+    peer.onConnectionOpen(peerId1);
+    peer.onConnectionOpen(peerId2);
+    await sleep(10);
+
+    connected.delete(peerId2);
+    peer.onConnectionClosed(peerId2);
+
+    // Without the fix, peer2 is still in `interestedPeers` with no `lastBroadcast`
+    // entry, so the broadcast gate passes and `sendCollectionState` throws.
+    peer.setLocalCollectionState(collectionId, STATE_2);
+    await sleep(10);
+
+    expect(sentTo).to.deep.equal([peerId1]);
+  });
+
   test('diff collection state', ({ expect }) => {
     const diff = diffCollectionState(STATE_1, STATE_2);
 

--- a/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.ts
+++ b/packages/core/echo/echo-pipeline/src/automerge/collection-synchronizer.ts
@@ -174,6 +174,9 @@ export class CollectionSynchronizer extends Resource {
 
     for (const perCollectionState of this._perCollectionStates.values()) {
       perCollectionState.remoteStates.delete(peerId);
+      perCollectionState.interestedPeers.delete(peerId);
+      perCollectionState.lastQueried.delete(peerId);
+      perCollectionState.lastBroadcast.delete(peerId);
     }
   }
 


### PR DESCRIPTION
## Summary

- `CollectionSynchronizer.onConnectionClosed` only cleared `_connectedPeers` and `remoteStates`, leaving disconnected peers in `interestedPeers`, `lastQueried`, and `lastBroadcast`.
- The `_broadcastLocalState` added in #11303 iterates `interestedPeers` directly, so a subsequent local heads change tried to send to a now-stale peer and the network adapter threw `Connection not found.` ([echo-network-adapter.ts:243](https://github.com/dxos/dxos/blob/main/packages/core/echo/echo-pipeline/src/automerge/echo-network-adapter.ts#L243)).
- Fix: also remove the peer from the three per-collection maps in `onConnectionClosed`.

## Repro stack (from Composer console)

```
Uncaught Error: Connection not found.
    at EchoNetworkAdapter._send (echo-network-adapter.ts:245)
    at EchoNetworkAdapter.sendCollectionState (echo-network-adapter.ts:204)
    at AutomergeHost._sendCollectionState (automerge-host.ts:812)
    at CollectionSynchronizer._broadcastLocalState (collection-synchronizer.ts:278)
```

The race: a peer was added to `interestedPeers` via `onConnectionOpen` (collection already active), then disconnected before any broadcast set `lastBroadcast` for it. The next `setLocalCollectionState` → `_broadcastLocalState` sees `lastBroadcast.get(stalePeer) ?? 0`, the gate passes, and the adapter throws.

## Test plan

- [x] New regression test `does not send to a peer after onConnectionClosed` reproduces the throw without the fix (verified via stash) and passes with it.
- [x] `moon run echo-pipeline:test` — all 194 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the synchronizer could attempt to communicate with closed peer connections, which would cause errors during state broadcasts.

* **Tests**
  * Added a regression test to verify proper cleanup of disconnected peer connections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11335)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->