### PR TITLE
fix(observability): resolve relative OTel endpoint to absolute URL in browser

### DIFF
--- a/packages/sdk/observability/src/extensions/otel/extension.ts
+++ b/packages/sdk/observability/src/extensions/otel/extension.ts
@@ -80,6 +80,10 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Extension
   }
   // Headers are optional when using a proxy that injects auth server-side.
   const resolvedHeaders = headers ?? {};
+  // OTLP HTTP exporters require an absolute URL. Resolve relative paths using the current origin.
+  // globalThis.location is defined in all browser contexts (main thread, dedicated/service workers).
+  const resolvedEndpoint =
+    !isNode() && endpoint.startsWith('/') ? `${globalThis.location.origin}${endpoint}` : endpoint;
 
   // Matches edge's `ctx.tag` span attribute (stamped by the edge log middleware
   // when it reads the `X-DXOS-Client-Tag` header, see
@@ -111,7 +115,7 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Extension
 
   const logs = logsEnabled
     ? new OtelLogs({
-        endpoint,
+        endpoint: resolvedEndpoint,
         headers: resolvedHeaders,
         resource,
         getTags: () => Object.fromEntries(tags),
@@ -121,7 +125,7 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Extension
 
   const metrics = metricsEnabled
     ? new OtelMetrics({
-        endpoint,
+        endpoint: resolvedEndpoint,
         headers: resolvedHeaders,
         resource,
         getTags: () => Object.fromEntries(tags),
@@ -130,7 +134,7 @@ export const extensions: (options: ExtensionsOptions) => Effect.Effect<Extension
 
   const traces = tracesEnabled
     ? new OtelTraces({
-        endpoint,
+        endpoint: resolvedEndpoint,
         headers: resolvedHeaders,
         resource,
         getTags: () => Object.fromEntries(tags),


### PR DESCRIPTION
## Summary

- OTLP HTTP exporters (`OTLPLogExporter`, `OTLPTraceExporter`, etc.) reject relative paths — they require an absolute URL
- `.github/workflows/env/*` files set `DX_OTEL_ENDPOINT=/api/otel` (a relative path pointing to the Cloudflare worker reverse-proxy)
- In the browser, resolve the configured endpoint against `window.location.origin` before passing it to the exporters, so `/api/otel` becomes e.g. `https://labs.composer.space/api/otel`
- Node.js builds already use an absolute URL from `buildSecrets.OTEL_ENDPOINT`, so no change there

Fixes the `Could not parse user-provided export URL: '/api/otel/v1/logs'` error seen on labs after #11334 deployed.

## Test plan

- [ ] Deploy to labs and confirm OTel logs/metrics/traces appear in SigNoz without the URL parse error
- [ ] Confirm local dev still stubs OTel (no `DX_OTEL_ENDPOINT` set → `stubExtension`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OTEL endpoint handling in non-Node (browser) environments: relative endpoints starting with "/" are now converted to absolute URLs using the page origin so logs, metrics, and traces export correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11336)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->