### PR TITLE
fix(echo-pipeline): guard against undefined doc in filterMatchObject

### DIFF
--- a/packages/core/echo/echo-pipeline/src/filter/filter-match.ts
+++ b/packages/core/echo/echo-pipeline/src/filter/filter-match.ts
@@ -22,7 +22,7 @@ export const filterMatchObject = (filter: QueryAST.Filter, obj: MatchedObject): 
       // Check typename if specified.
       if (filter.typename !== null) {
         // TODO(dmaretskyi): `system` is missing in some cases.
-        if (!obj.doc.system?.type?.['/']) {
+        if (!obj.doc?.system?.type?.['/']) {
           // Objects with no type are deprecated.
           return false;
         } else {


### PR DESCRIPTION
## Summary

One-character defensive fix in `filterMatchObject` (`packages/core/echo/echo-pipeline/src/filter/filter-match.ts:25`): change `obj.doc.system?.type?.['/']` → `obj.doc?.system?.type?.['/']`.

## Why

A live ECHO query subscription can fire after a test has completed (during teardown). When the underlying object is in a transient/post-deletion state, `obj.doc` is `undefined`, and reading `.system` throws:

```
TypeError: Cannot read properties of undefined (reading 'system')
```

This surfaces as an **unhandled async rejection** from Vitest — tests still pass (`exit 0`), but the run logs an error. The risk Vitest warns about ("might cause false positive tests") is theoretical here because the throw happens during teardown, not during an assertion window, but it pollutes logs and could mask a real regression later.

Stack of the trigger:

```
EventListener.trigger (@dxos/async events.ts)
  → _onUpdate (echo-db query subscription)
  → prohibitSignalActions (graph-query-context)
  → predicate run (query-result.ts:75/85)
  → SpaceQuerySource.filteredResults
  → filterMatchObject ← throws
```

The function was already defensive about a missing `system` (see the existing `TODO(dmaretskyi)` and the `?.` on `system`). This change extends the same defensiveness to `doc` itself, which is also nullable in practice during teardown.

## Test plan

- [x] Build `echo-pipeline` locally.
- [ ] CI on this branch (Check workflow).
- [ ] Confirm the unhandled rejection no longer appears in suites that exercise late query subscriptions.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk72ejQJbe5f4k58zRrWcz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential runtime error that could occur during object matching when certain internal data structures were missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11349)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->