### PR TITLE
chore(deps): upgrade codemirror and lezer ecosystem

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,50 +94,50 @@ catalogs:
       specifier: ^4.20260302.0
       version: 4.20260303.0
     '@codemirror/autocomplete':
-      specifier: ^6.19.0
-      version: 6.19.0
+      specifier: ^6.20.2
+      version: 6.20.2
     '@codemirror/commands':
-      specifier: ^6.8.1
-      version: 6.8.1
+      specifier: ^6.10.3
+      version: 6.10.3
     '@codemirror/lang-html':
       specifier: ^6.4.11
       version: 6.4.11
     '@codemirror/lang-javascript':
-      specifier: ^6.2.4
-      version: 6.2.4
+      specifier: ^6.2.5
+      version: 6.2.5
     '@codemirror/lang-json':
       specifier: ^6.0.2
       version: 6.0.2
     '@codemirror/lang-markdown':
-      specifier: 6.3.4
-      version: 6.3.4
+      specifier: 6.5.0
+      version: 6.5.0
     '@codemirror/lang-xml':
       specifier: ^6.1.0
       version: 6.1.0
     '@codemirror/lang-yaml':
-      specifier: ^6.1.2
-      version: 6.1.2
+      specifier: ^6.1.3
+      version: 6.1.3
     '@codemirror/language':
-      specifier: ^6.11.3
-      version: 6.11.3
+      specifier: ^6.12.3
+      version: 6.12.3
     '@codemirror/language-data':
-      specifier: ^6.5.1
-      version: 6.5.1
-    '@codemirror/lint':
-      specifier: 6.8.5
-      version: 6.8.5
-    '@codemirror/search':
-      specifier: ^6.5.11
-      version: 6.5.11
-    '@codemirror/state':
       specifier: ^6.5.2
       version: 6.5.2
+    '@codemirror/lint':
+      specifier: 6.9.6
+      version: 6.9.6
+    '@codemirror/search':
+      specifier: ^6.7.0
+      version: 6.7.0
+    '@codemirror/state':
+      specifier: ^6.6.0
+      version: 6.6.0
     '@codemirror/theme-one-dark':
       specifier: ^6.1.3
       version: 6.1.3
     '@codemirror/view':
-      specifier: ^6.38.5
-      version: 6.38.5
+      specifier: ^6.43.0
+      version: 6.43.0
     '@crxjs/vite-plugin':
       specifier: ^2.4.0
       version: 2.4.0
@@ -264,21 +264,12 @@ catalogs:
     '@jitl/quickjs-wasmfile-release-sync':
       specifier: ^0.31.0
       version: 0.31.0
-    '@lezer/common':
-      specifier: ^1.2.2
-      version: 1.2.2
     '@lezer/generator':
-      specifier: ^1.7.1
-      version: 1.7.1
-    '@lezer/highlight':
-      specifier: ^1.2.1
-      version: 1.2.1
+      specifier: ^1.8.0
+      version: 1.8.0
     '@lezer/lezer':
       specifier: ^1.1.2
       version: 1.1.2
-    '@lezer/markdown':
-      specifier: ^1.3.1
-      version: 1.3.1
     '@lezer/xml':
       specifier: ^1.0.6
       version: 1.0.6
@@ -508,8 +499,8 @@ catalogs:
       specifier: ^9.5.0
       version: 9.5.0
     '@replit/codemirror-vim':
-      specifier: ^6.2.1
-      version: 6.2.1
+      specifier: ^6.3.0
+      version: 6.3.0
     '@replit/codemirror-vscode-keymap':
       specifier: ^6.0.2
       version: 6.0.2
@@ -1006,8 +997,8 @@ catalogs:
       specifier: ^2.1.11
       version: 2.1.11
     codemirror:
-      specifier: ^6.0.1
-      version: 6.0.1
+      specifier: ^6.0.2
+      version: 6.0.2
     codemirror-lang-spreadsheet:
       specifier: ^1.3.0
       version: 1.3.0
@@ -1904,7 +1895,10 @@ overrides:
   '@automerge/automerge': 3.2.6
   '@automerge/automerge-subduction': 0.12.1
   '@grpc/grpc-js': '>=1.10.9'
-  '@lezer/lr': ^1.4.2
+  '@lezer/common': ^1.5.2
+  '@lezer/highlight': ^1.2.3
+  '@lezer/lr': ^1.4.10
+  '@lezer/markdown': ^1.6.3
   '@modelcontextprotocol/sdk': '>=1.26.0'
   '@remix-run/router': '>=1.23.2'
   '@swc/core': 1.15.40
@@ -2427,31 +2421,31 @@ importers:
         version: 2.6.0-subduction.20(patch_hash=0c21d251fbbc2e2c0525cd4dee59cb62182405dcd8316a6d874d0426be598091)
       '@codemirror/autocomplete':
         specifier: 'catalog:'
-        version: 6.19.0
+        version: 6.20.2
       '@codemirror/commands':
         specifier: 'catalog:'
-        version: 6.8.1
+        version: 6.10.3
       '@codemirror/lang-javascript':
         specifier: 'catalog:'
-        version: 6.2.4
+        version: 6.2.5
       '@codemirror/lang-json':
         specifier: 'catalog:'
         version: 6.0.2
       '@codemirror/lang-markdown':
         specifier: 'catalog:'
-        version: 6.3.4
+        version: 6.5.0
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.3
+        version: 6.12.3
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/theme-one-dark':
         specifier: 'catalog:'
         version: 6.1.3
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -2808,7 +2802,7 @@ importers:
         version: 2.3.2
       codemirror:
         specifier: 'catalog:'
-        version: 6.0.1
+        version: 6.0.2
       date-fns:
         specifier: 'catalog:'
         version: 3.6.0
@@ -5946,14 +5940,14 @@ importers:
         specifier: workspace:*
         version: link:../../../../vendor/quickjs
       '@lezer/common':
-        specifier: 'catalog:'
-        version: 1.2.2
+        specifier: ^1.5.2
+        version: 1.5.2
       '@lezer/lezer':
         specifier: 'catalog:'
         version: 1.1.2
       '@lezer/lr':
-        specifier: ^1.4.2
-        version: 1.4.2
+        specifier: ^1.4.10
+        version: 1.4.10
     devDependencies:
       '@dxos/echo-generator':
         specifier: workspace:*
@@ -5963,7 +5957,7 @@ importers:
         version: link:../../../common/random
       '@lezer/generator':
         specifier: 'catalog:'
-        version: 1.7.1
+        version: 1.8.0
       tsdown:
         specifier: 'catalog:'
         version: 0.16.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
@@ -6956,11 +6950,11 @@ importers:
         specifier: 'catalog:'
         version: 0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
       '@lezer/common':
-        specifier: 'catalog:'
-        version: 1.2.2
+        specifier: ^1.5.2
+        version: 1.5.2
       '@lezer/markdown':
-        specifier: 'catalog:'
-        version: 1.3.1
+        specifier: ^1.6.3
+        version: 1.6.3
       '@opentui/core':
         specifier: 'catalog:'
         version: 0.1.61(stage-js@1.0.0-alpha.17)(typescript@6.0.3)(web-tree-sitter@0.25.10)
@@ -7847,28 +7841,28 @@ importers:
     dependencies:
       '@codemirror/autocomplete':
         specifier: 'catalog:'
-        version: 6.19.0
+        version: 6.20.2
       '@codemirror/lang-html':
         specifier: 'catalog:'
         version: 6.4.11
       '@codemirror/lang-markdown':
         specifier: 'catalog:'
-        version: 6.3.4
+        version: 6.5.0
       '@codemirror/lang-xml':
         specifier: 'catalog:'
         version: 6.1.0
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.3
+        version: 6.12.3
       '@codemirror/lint':
         specifier: 'catalog:'
-        version: 6.8.5
+        version: 6.9.6
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -8992,10 +8986,10 @@ importers:
     dependencies:
       '@codemirror/lang-javascript':
         specifier: 'catalog:'
-        version: 6.2.4
+        version: 6.2.5
       '@codemirror/lang-markdown':
         specifier: 'catalog:'
-        version: 6.3.4
+        version: 6.5.0
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -10112,13 +10106,13 @@ importers:
     dependencies:
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.3
+        version: 6.12.3
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -10607,10 +10601,10 @@ importers:
     dependencies:
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -11427,13 +11421,13 @@ importers:
         version: 3.2.6
       '@codemirror/search':
         specifier: 'catalog:'
-        version: 6.5.11
+        version: 6.7.0
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -11889,13 +11883,13 @@ importers:
     dependencies:
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.3
+        version: 6.12.3
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -12374,10 +12368,10 @@ importers:
     dependencies:
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -13161,25 +13155,25 @@ importers:
         version: 3.2.6
       '@codemirror/autocomplete':
         specifier: 'catalog:'
-        version: 6.19.0
+        version: 6.20.2
       '@codemirror/lang-javascript':
         specifier: 'catalog:'
-        version: 6.2.4
+        version: 6.2.5
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.3
+        version: 6.12.3
       '@codemirror/lint':
         specifier: 'catalog:'
-        version: 6.8.5
+        version: 6.9.6
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/theme-one-dark':
         specifier: 'catalog:'
         version: 6.1.3
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -13355,11 +13349,11 @@ importers:
         specifier: 'catalog:'
         version: 0.5.0(@effect/experimental@0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2))(@effect/platform@0.94.4(effect@3.20.0))(@effect/rpc@0.73.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)(react@19.2.6)(scheduler@0.27.0)
       '@lezer/common':
-        specifier: 'catalog:'
-        version: 1.2.2
+        specifier: ^1.5.2
+        version: 1.5.2
       '@lezer/highlight':
-        specifier: 'catalog:'
-        version: 1.2.1
+        specifier: ^1.2.3
+        version: 1.2.3
       '@octokit/core':
         specifier: 'catalog:'
         version: 7.0.6
@@ -13371,13 +13365,13 @@ importers:
         version: 1.6.2(typescript@6.0.3)
       '@valtown/codemirror-continue':
         specifier: 'catalog:'
-        version: 2.3.1(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.5)(@lezer/common@1.2.2)
+        version: 2.3.1(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)(@lezer/common@1.5.2)
       '@valtown/codemirror-ts':
         specifier: 'catalog:'
-        version: 2.3.1(@codemirror/autocomplete@6.19.0)(@codemirror/lint@6.8.5)(@codemirror/state@6.5.2)(@codemirror/view@6.38.5)
+        version: 2.3.1(@codemirror/autocomplete@6.20.2)(@codemirror/lint@6.9.6)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)
       codemirror:
         specifier: 'catalog:'
-        version: 6.0.1
+        version: 6.0.2
       date-fns:
         specifier: 'catalog:'
         version: 3.6.0
@@ -13696,16 +13690,16 @@ importers:
     dependencies:
       '@codemirror/autocomplete':
         specifier: 'catalog:'
-        version: 6.19.0
+        version: 6.20.2
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.3
+        version: 6.12.3
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dnd-kit/core':
         specifier: 'catalog:'
         version: 6.0.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -13839,17 +13833,17 @@ importers:
         specifier: workspace:*
         version: link:../../common/util
       '@lezer/common':
-        specifier: 'catalog:'
-        version: 1.2.2
+        specifier: ^1.5.2
+        version: 1.5.2
       '@lezer/highlight':
-        specifier: 'catalog:'
-        version: 1.2.1
+        specifier: ^1.2.3
+        version: 1.2.3
       '@lezer/lezer':
         specifier: 'catalog:'
         version: 1.1.2
       '@lezer/lr':
-        specifier: ^1.4.2
-        version: 1.4.2
+        specifier: ^1.4.10
+        version: 1.4.10
       '@radix-ui/react-context':
         specifier: 'catalog:'
         version: 1.1.1(@types/react@19.2.14)(react@19.2.6)
@@ -13907,7 +13901,7 @@ importers:
         version: 0.94.4(effect@3.20.0)
       '@lezer/generator':
         specifier: 'catalog:'
-        version: 1.7.1
+        version: 1.8.0
       '@tldraw/indices':
         specifier: 'catalog:'
         version: 2.0.0-canary.e43b0103fdf5
@@ -15346,13 +15340,13 @@ importers:
     dependencies:
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.3
+        version: 6.12.3
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -15624,10 +15618,10 @@ importers:
     dependencies:
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -16199,13 +16193,13 @@ importers:
     dependencies:
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.3
+        version: 6.12.3
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/app-framework':
         specifier: workspace:*
         version: link:../../sdk/app-framework
@@ -16420,32 +16414,32 @@ importers:
     dependencies:
       '@codemirror/autocomplete':
         specifier: 'catalog:'
-        version: 6.19.0
+        version: 6.20.2
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.3
+        version: 6.12.3
       '@codemirror/lint':
         specifier: 'catalog:'
-        version: 6.8.5
+        version: 6.9.6
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@lezer/common':
-        specifier: 'catalog:'
-        version: 1.2.2
+        specifier: ^1.5.2
+        version: 1.5.2
       '@lezer/highlight':
-        specifier: 'catalog:'
-        version: 1.2.1
+        specifier: ^1.2.3
+        version: 1.2.3
       '@lezer/lr':
-        specifier: ^1.4.2
-        version: 1.4.2
+        specifier: ^1.4.10
+        version: 1.4.10
     devDependencies:
       '@lezer/generator':
         specifier: 'catalog:'
-        version: 1.7.1
+        version: 1.8.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -18195,10 +18189,10 @@ importers:
         version: 3.2.10(@types/react@19.2.14)(react@19.2.6)
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -19217,10 +19211,10 @@ importers:
         version: 6.0.2
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/conductor':
         specifier: workspace:*
         version: link:../../core/compute/conductor
@@ -19332,19 +19326,19 @@ importers:
     dependencies:
       '@codemirror/autocomplete':
         specifier: 'catalog:'
-        version: 6.19.0
+        version: 6.20.2
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.3
+        version: 6.12.3
       '@codemirror/search':
         specifier: 'catalog:'
-        version: 6.5.11
+        version: 6.7.0
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -19435,16 +19429,16 @@ importers:
     dependencies:
       '@codemirror/autocomplete':
         specifier: 'catalog:'
-        version: 6.19.0
+        version: 6.20.2
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.3
+        version: 6.12.3
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/ai':
         specifier: workspace:*
         version: link:../../core/compute/ai
@@ -19503,11 +19497,11 @@ importers:
         specifier: 'catalog:'
         version: 0.58.0(@effect/platform@0.94.4(effect@3.20.0))(effect@3.20.0)(ioredis@5.3.2)
       '@lezer/common':
-        specifier: 'catalog:'
-        version: 1.2.2
+        specifier: ^1.5.2
+        version: 1.5.2
       '@lezer/highlight':
-        specifier: 'catalog:'
-        version: 1.2.1
+        specifier: ^1.2.3
+        version: 1.2.3
       '@lezer/xml':
         specifier: 'catalog:'
         version: 1.0.6
@@ -19614,49 +19608,49 @@ importers:
         version: 3.2.6
       '@codemirror/autocomplete':
         specifier: 'catalog:'
-        version: 6.19.0
+        version: 6.20.2
       '@codemirror/commands':
         specifier: 'catalog:'
-        version: 6.8.1
+        version: 6.10.3
       '@codemirror/lang-html':
         specifier: 'catalog:'
         version: 6.4.11
       '@codemirror/lang-javascript':
         specifier: 'catalog:'
-        version: 6.2.4
+        version: 6.2.5
       '@codemirror/lang-json':
         specifier: 'catalog:'
         version: 6.0.2
       '@codemirror/lang-markdown':
         specifier: 'catalog:'
-        version: 6.3.4
+        version: 6.5.0
       '@codemirror/lang-xml':
         specifier: 'catalog:'
         version: 6.1.0
       '@codemirror/lang-yaml':
         specifier: 'catalog:'
-        version: 6.1.2
+        version: 6.1.3
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.3
+        version: 6.12.3
       '@codemirror/language-data':
         specifier: 'catalog:'
-        version: 6.5.1
+        version: 6.5.2
       '@codemirror/lint':
         specifier: 'catalog:'
-        version: 6.8.5
+        version: 6.9.6
       '@codemirror/search':
         specifier: 'catalog:'
-        version: 6.5.11
+        version: 6.7.0
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/theme-one-dark':
         specifier: 'catalog:'
         version: 6.1.3
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/app-graph':
         specifier: workspace:*
         version: link:../../sdk/app-graph
@@ -19721,17 +19715,17 @@ importers:
         specifier: 'catalog:'
         version: 9.26.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@lezer/common':
-        specifier: 'catalog:'
-        version: 1.2.2
+        specifier: ^1.5.2
+        version: 1.5.2
       '@lezer/generator':
         specifier: 'catalog:'
-        version: 1.7.1
+        version: 1.8.0
       '@lezer/highlight':
-        specifier: 'catalog:'
-        version: 1.2.1
+        specifier: ^1.2.3
+        version: 1.2.3
       '@lezer/markdown':
-        specifier: 'catalog:'
-        version: 1.3.1
+        specifier: ^1.6.3
+        version: 1.6.3
       '@radix-ui/react-context':
         specifier: 'catalog:'
         version: 1.1.1(@types/react@19.2.14)(react@19.2.6)
@@ -19740,13 +19734,13 @@ importers:
         version: 1.1.0(@types/react@19.2.14)(react@19.2.6)
       '@replit/codemirror-vim':
         specifier: 'catalog:'
-        version: 6.2.1(@codemirror/commands@6.8.1)(@codemirror/language@6.11.3)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.5)
+        version: 6.3.0(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)
       '@replit/codemirror-vscode-keymap':
         specifier: 'catalog:'
-        version: 6.0.2(@codemirror/autocomplete@6.19.0)(@codemirror/commands@6.8.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.5)
+        version: 6.0.2(@codemirror/autocomplete@6.20.2)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.6)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)
       '@uiw/codemirror-theme-vscode':
         specifier: 'catalog:'
-        version: 4.25.2(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.5)
+        version: 4.25.2(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)
       ajv:
         specifier: 'catalog:'
         version: 8.18.0
@@ -19755,7 +19749,7 @@ importers:
         version: 3.0.0
       codemirror:
         specifier: 'catalog:'
-        version: 6.0.1
+        version: 6.0.2
       lib0:
         specifier: 'catalog:'
         version: 0.2.78
@@ -20301,13 +20295,13 @@ importers:
     dependencies:
       '@codemirror/autocomplete':
         specifier: 'catalog:'
-        version: 6.19.0
+        version: 6.20.2
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/lit-grid':
         specifier: workspace:*
         version: link:../lit-grid
@@ -20502,16 +20496,16 @@ importers:
     dependencies:
       '@codemirror/autocomplete':
         specifier: 'catalog:'
-        version: 6.19.0
+        version: 6.20.2
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.3
+        version: 6.12.3
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -20549,14 +20543,14 @@ importers:
         specifier: workspace:*
         version: link:../../common/util
       '@lezer/common':
-        specifier: 'catalog:'
-        version: 1.2.2
+        specifier: ^1.5.2
+        version: 1.5.2
       '@lezer/highlight':
-        specifier: 'catalog:'
-        version: 1.2.1
+        specifier: ^1.2.3
+        version: 1.2.3
       '@lezer/markdown':
-        specifier: 'catalog:'
-        version: 1.3.1
+        specifier: ^1.6.3
+        version: 1.6.3
       '@lezer/xml':
         specifier: 'catalog:'
         version: 1.0.6
@@ -20830,10 +20824,10 @@ importers:
         version: 3.2.10(@types/react@19.2.14)(react@19.2.6)
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -21301,13 +21295,13 @@ importers:
     dependencies:
       '@codemirror/autocomplete':
         specifier: 'catalog:'
-        version: 6.19.0
+        version: 6.20.2
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/async':
         specifier: workspace:*
         version: link:../../common/async
@@ -21748,49 +21742,49 @@ importers:
         version: 3.2.6
       '@codemirror/autocomplete':
         specifier: 'catalog:'
-        version: 6.19.0
+        version: 6.20.2
       '@codemirror/commands':
         specifier: 'catalog:'
-        version: 6.8.1
+        version: 6.10.3
       '@codemirror/lang-html':
         specifier: 'catalog:'
         version: 6.4.11
       '@codemirror/lang-javascript':
         specifier: 'catalog:'
-        version: 6.2.4
+        version: 6.2.5
       '@codemirror/lang-json':
         specifier: 'catalog:'
         version: 6.0.2
       '@codemirror/lang-markdown':
         specifier: 'catalog:'
-        version: 6.3.4
+        version: 6.5.0
       '@codemirror/lang-xml':
         specifier: 'catalog:'
         version: 6.1.0
       '@codemirror/lang-yaml':
         specifier: 'catalog:'
-        version: 6.1.2
+        version: 6.1.3
       '@codemirror/language':
         specifier: 'catalog:'
-        version: 6.11.3
+        version: 6.12.3
       '@codemirror/language-data':
         specifier: 'catalog:'
-        version: 6.5.1
+        version: 6.5.2
       '@codemirror/lint':
         specifier: 'catalog:'
-        version: 6.8.5
+        version: 6.9.6
       '@codemirror/search':
         specifier: 'catalog:'
-        version: 6.5.11
+        version: 6.7.0
       '@codemirror/state':
         specifier: 'catalog:'
-        version: 6.5.2
+        version: 6.6.0
       '@codemirror/theme-one-dark':
         specifier: 'catalog:'
         version: 6.1.3
       '@codemirror/view':
         specifier: 'catalog:'
-        version: 6.38.5
+        version: 6.43.0
       '@dxos/app-graph':
         specifier: workspace:*
         version: link:../../sdk/app-graph
@@ -21840,32 +21834,32 @@ importers:
         specifier: workspace:*
         version: link:../../common/util
       '@lezer/common':
-        specifier: 'catalog:'
-        version: 1.2.2
+        specifier: ^1.5.2
+        version: 1.5.2
       '@lezer/generator':
         specifier: 'catalog:'
-        version: 1.7.1
+        version: 1.8.0
       '@lezer/highlight':
-        specifier: 'catalog:'
-        version: 1.2.1
+        specifier: ^1.2.3
+        version: 1.2.3
       '@lezer/markdown':
-        specifier: 'catalog:'
-        version: 1.3.1
+        specifier: ^1.6.3
+        version: 1.6.3
       '@replit/codemirror-vim':
         specifier: 'catalog:'
-        version: 6.2.1(@codemirror/commands@6.8.1)(@codemirror/language@6.11.3)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.5)
+        version: 6.3.0(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)
       '@replit/codemirror-vscode-keymap':
         specifier: 'catalog:'
-        version: 6.0.2(@codemirror/autocomplete@6.19.0)(@codemirror/commands@6.8.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.5)
+        version: 6.0.2(@codemirror/autocomplete@6.20.2)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.6)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)
       '@uiw/codemirror-theme-vscode':
         specifier: 'catalog:'
-        version: 4.25.2(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.5)
+        version: 4.25.2(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)
       ajv:
         specifier: 'catalog:'
         version: 8.18.0
       codemirror:
         specifier: 'catalog:'
-        version: 6.0.1
+        version: 6.0.2
       lib0:
         specifier: 'catalog:'
         version: 0.2.78
@@ -23895,11 +23889,11 @@ packages:
   '@cloudflare/workers-types@4.20260303.0':
     resolution: {integrity: sha512-soUlr4NJVkh5dR09RwtziTMbBQ+lbdoEesTGw8WUlvmnQ2M4h7CmJzAjC6a7IivUodiiCSjbLcGV/8PyZpvZkA==}
 
-  '@codemirror/autocomplete@6.19.0':
-    resolution: {integrity: sha512-61Hfv3cF07XvUxNeC3E7jhG8XNi1Yom1G0lRC936oLnlF+jrbrv8rc/J98XlYzcsAoTVupfsf5fLej1aI8kyIg==}
+  '@codemirror/autocomplete@6.20.2':
+    resolution: {integrity: sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==}
 
-  '@codemirror/commands@6.8.1':
-    resolution: {integrity: sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==}
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
 
   '@codemirror/lang-angular@0.1.2':
     resolution: {integrity: sha512-Nq7lmx9SU+JyoaRcs6SaJs7uAmW2W06HpgJVQYeZptVGNWDzDvzhjwVb/ZuG1rwTlOocY4Y9GwNOBuKCeJbKtw==}
@@ -23922,6 +23916,12 @@ packages:
   '@codemirror/lang-javascript@6.2.4':
     resolution: {integrity: sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==}
 
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-jinja@6.0.1':
+    resolution: {integrity: sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==}
+
   '@codemirror/lang-json@6.0.2':
     resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
 
@@ -23931,8 +23931,8 @@ packages:
   '@codemirror/lang-liquid@6.2.1':
     resolution: {integrity: sha512-J1Mratcm6JLNEiX+U2OlCDTysGuwbHD76XwuL5o5bo9soJtSbz2g6RU3vGHFyS5DC8rgVmFSzi7i6oBftm7tnA==}
 
-  '@codemirror/lang-markdown@6.3.4':
-    resolution: {integrity: sha512-fBm0BO03azXnTAsxhONDYHi/qWSI+uSEIpzKM7h/bkIc9fHnFp9y7KTMXKON0teNT97pFhc1a9DQTtWBYEZ7ug==}
+  '@codemirror/lang-markdown@6.5.0':
+    resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
 
   '@codemirror/lang-php@6.0.1':
     resolution: {integrity: sha512-ublojMdw/PNWa7qdN5TMsjmqkNuTBD3k6ndZ4Z0S25SBAiweFGyY68AS3xNcIOlb6DDFDvKlinLQ40vSLqf8xA==}
@@ -23958,14 +23958,14 @@ packages:
   '@codemirror/lang-xml@6.1.0':
     resolution: {integrity: sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==}
 
-  '@codemirror/lang-yaml@6.1.2':
-    resolution: {integrity: sha512-dxrfG8w5Ce/QbT7YID7mWZFKhdhsaTNOYjOkSIMt1qmC4VQnXSDSYVHHHn8k6kJUfIhtLo8t1JJgltlxWdsITw==}
+  '@codemirror/lang-yaml@6.1.3':
+    resolution: {integrity: sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==}
 
-  '@codemirror/language-data@6.5.1':
-    resolution: {integrity: sha512-0sWxeUSNlBr6OmkqybUTImADFUP0M3P0IiSde4nc24bz/6jIYzqYSgkOSLS+CBIoW1vU8Q9KUWXscBXeoMVC9w==}
+  '@codemirror/language-data@6.5.2':
+    resolution: {integrity: sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==}
 
-  '@codemirror/language@6.11.3':
-    resolution: {integrity: sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==}
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
 
   '@codemirror/legacy-modes@6.4.0':
     resolution: {integrity: sha512-5m/K+1A6gYR0e+h/dEde7LoGimMjRtWXZFg4Lo70cc8HzjSdHe3fLwjWMR0VRl5KFT1SxalSap7uMgPKF28wBA==}
@@ -23973,17 +23973,23 @@ packages:
   '@codemirror/lint@6.8.5':
     resolution: {integrity: sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==}
 
+  '@codemirror/lint@6.9.6':
+    resolution: {integrity: sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==}
+
   '@codemirror/search@6.5.11':
     resolution: {integrity: sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==}
 
-  '@codemirror/state@6.5.2':
-    resolution: {integrity: sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==}
+  '@codemirror/search@6.7.0':
+    resolution: {integrity: sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
 
   '@codemirror/theme-one-dark@6.1.3':
     resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
 
-  '@codemirror/view@6.38.5':
-    resolution: {integrity: sha512-SFVsNAgsAoou+BjRewMqN+m9jaztB9wCWN9RSRgePqUbq8UVlvJfku5zB2KVhLPgH/h0RLk38tvd4tGeAhygnw==}
+  '@codemirror/view@6.43.0':
+    resolution: {integrity: sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -25235,8 +25241,8 @@ packages:
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
 
-  '@lezer/common@1.2.2':
-    resolution: {integrity: sha512-Z+R3hN6kXbgBWAuejUNPihylAL1Z5CaFqnIe0nTX8Ej+XlIy3EGtXxn6WtLMO+os2hRkQvm2yvaGMYliUzlJaw==}
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
 
   '@lezer/cpp@1.1.0':
     resolution: {integrity: sha512-zUHrjNFuY/DOZCkOBJ6qItQIkcopHM/Zv/QOE0a4XNG3HDNahxTNu5fQYl8dIuKCpxCqRdMl5cEwl5zekFc7BA==}
@@ -25244,15 +25250,15 @@ packages:
   '@lezer/css@1.1.1':
     resolution: {integrity: sha512-mSjx+unLLapEqdOYDejnGBokB5+AiJKZVclmud0MKQOKx3DLJ5b5VTCstgDDknR6iIV4gVrN6euzsCnj0A2gQA==}
 
-  '@lezer/generator@1.7.1':
-    resolution: {integrity: sha512-MgPJN9Si+ccxzXl3OAmCeZuUKw4XiPl4y664FX/hnnyG9CTqUPq65N3/VGPA2jD23D7QgMTtNqflta+cPN+5mQ==}
+  '@lezer/generator@1.8.0':
+    resolution: {integrity: sha512-/SF4EDWowPqV1jOgoGSGTIFsE7Ezdr7ZYxyihl5eMKVO5tlnpIhFcDavgm1hHY5GEonoOAEnJ0CU0x+tvuAuUg==}
     hasBin: true
 
   '@lezer/go@1.0.0':
     resolution: {integrity: sha512-co9JfT3QqX1YkrMmourYw2Z8meGC50Ko4d54QEcQbEYpvdUvN4yb0NBZdn/9ertgvjsySxHsKzH3lbm3vqJ4Jw==}
 
-  '@lezer/highlight@1.2.1':
-    resolution: {integrity: sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==}
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
 
   '@lezer/html@1.3.12':
     resolution: {integrity: sha512-RJ7eRWdaJe3bsiiLLHjCFT1JMk8m1YP9kaUbvu2rMLEoOnke9mcTVDyfOslsln0LtujdWespjJ39w6zo+RsQYw==}
@@ -25269,11 +25275,11 @@ packages:
   '@lezer/lezer@1.1.2':
     resolution: {integrity: sha512-O8yw3CxPhzYHB1hvwbdozjnAslhhR8A5BH7vfEMof0xk3p+/DFDfZkA9Tde6J+88WgtwaHy4Sy6ThZSkaI0Evw==}
 
-  '@lezer/lr@1.4.2':
-    resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
 
-  '@lezer/markdown@1.3.1':
-    resolution: {integrity: sha512-DGlzU/i8DC8k0uz1F+jeePrkATl0jWakauTzftMQOcbaMkHbNSRki/4E2tOzJWsVpoKYhe7iTJ03aepdwVUXUA==}
+  '@lezer/markdown@1.6.3':
+    resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
 
   '@lezer/php@1.0.1':
     resolution: {integrity: sha512-aqdCQJOXJ66De22vzdwnuC502hIaG9EnPK2rSi+ebXyUd+j7GAX1mRjWZOVOmf3GST1YUfUCu6WXDiEgDGOVwA==}
@@ -28297,14 +28303,14 @@ packages:
     resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
     engines: {node: '>=14.0.0'}
 
-  '@replit/codemirror-vim@6.2.1':
-    resolution: {integrity: sha512-qDAcGSHBYU5RrdO//qCmD8K9t6vbP327iCj/iqrkVnjbrpFhrjOt92weGXGHmTNRh16cUtkUZ7Xq7rZf+8HVow==}
+  '@replit/codemirror-vim@6.3.0':
+    resolution: {integrity: sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ==}
     peerDependencies:
-      '@codemirror/commands': ^6.0.0
-      '@codemirror/language': ^6.1.0
-      '@codemirror/search': ^6.2.0
-      '@codemirror/state': ^6.0.1
-      '@codemirror/view': ^6.0.3
+      '@codemirror/commands': 6.x.x
+      '@codemirror/language': 6.x.x
+      '@codemirror/search': 6.x.x
+      '@codemirror/state': 6.x.x
+      '@codemirror/view': 6.x.x
 
   '@replit/codemirror-vscode-keymap@6.0.2':
     resolution: {integrity: sha512-j45qTwGxzpsv82lMD/NreGDORFKSctMDVkGRopaP+OrzSzv+pXDQuU3LnFvKpasyjVT0lf+PKG1v2DSCn/vxxg==}
@@ -30704,7 +30710,7 @@ packages:
       '@codemirror/language': ^6
       '@codemirror/state': ^6
       '@codemirror/view': ^6
-      '@lezer/common': ^1
+      '@lezer/common': ^1.5.2
 
   '@valtown/codemirror-ts@2.3.1':
     resolution: {integrity: sha512-v5XiI4WA+bUy0XDgkrqZksqBWgIUeyLZuC94Px/rhXBph8ASmVXaimlGDtt0vH/9t8aDdIZYdr59r9H3oKMFOg==}
@@ -32399,8 +32405,8 @@ packages:
   codemirror-lang-spreadsheet@1.3.0:
     resolution: {integrity: sha512-Gudwf+QYesPP2202iGcFV5NiS8fzlBM3xDRv0M4NgBDyTbzkN9mHLggMziKxfB9o2jz6yL53w7D11Kt12cQlhQ==}
 
-  codemirror@6.0.1:
-    resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
+  codemirror@6.0.2:
+    resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -43513,180 +43519,201 @@ snapshots:
 
   '@cloudflare/workers-types@4.20260303.0': {}
 
-  '@codemirror/autocomplete@6.19.0':
+  '@codemirror/autocomplete@6.20.2':
     dependencies:
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
-      '@lezer/common': 1.2.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
 
-  '@codemirror/commands@6.8.1':
+  '@codemirror/commands@6.10.3':
     dependencies:
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
-      '@lezer/common': 1.2.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
 
   '@codemirror/lang-angular@0.1.2':
     dependencies:
       '@codemirror/lang-html': 6.4.11
-      '@codemirror/lang-javascript': 6.2.4
-      '@codemirror/language': 6.11.3
-      '@lezer/common': 1.2.2
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@codemirror/lang-cpp@6.0.2':
     dependencies:
-      '@codemirror/language': 6.11.3
+      '@codemirror/language': 6.12.3
       '@lezer/cpp': 1.1.0
 
   '@codemirror/lang-css@6.2.1':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@lezer/common': 1.2.2
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
       '@lezer/css': 1.1.1
 
   '@codemirror/lang-go@6.0.1':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@lezer/common': 1.2.2
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
       '@lezer/go': 1.0.0
 
   '@codemirror/lang-html@6.4.11':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/lang-css': 6.2.1
       '@codemirror/lang-javascript': 6.2.4
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
-      '@lezer/common': 1.2.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
       '@lezer/css': 1.1.1
       '@lezer/html': 1.3.12
 
   '@codemirror/lang-java@6.0.1':
     dependencies:
-      '@codemirror/language': 6.11.3
+      '@codemirror/language': 6.12.3
       '@lezer/java': 1.0.3
 
   '@codemirror/lang-javascript@6.2.4':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
-      '@codemirror/language': 6.11.3
-      '@codemirror/lint': 6.8.5
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
-      '@lezer/common': 1.2.2
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.6
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
       '@lezer/javascript': 1.4.1
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.8.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.4.1
+
+  '@codemirror/lang-jinja@6.0.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@codemirror/lang-json@6.0.2':
     dependencies:
-      '@codemirror/language': 6.11.3
+      '@codemirror/language': 6.12.3
       '@lezer/json': 1.0.0
 
   '@codemirror/lang-less@6.0.1':
     dependencies:
       '@codemirror/lang-css': 6.2.1
-      '@codemirror/language': 6.11.3
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@codemirror/language': 6.12.3
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@codemirror/lang-liquid@6.2.1':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/lang-html': 6.4.11
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
-      '@lezer/common': 1.2.2
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
-  '@codemirror/lang-markdown@6.3.4':
+  '@codemirror/lang-markdown@6.5.0':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/lang-html': 6.4.11
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
-      '@lezer/common': 1.2.2
-      '@lezer/markdown': 1.3.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.6.3
 
   '@codemirror/lang-php@6.0.1':
     dependencies:
       '@codemirror/lang-html': 6.4.11
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@lezer/common': 1.2.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
       '@lezer/php': 1.0.1
 
   '@codemirror/lang-python@6.1.2':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
-      '@codemirror/language': 6.11.3
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
       '@lezer/python': 1.1.2
 
   '@codemirror/lang-rust@6.0.1':
     dependencies:
-      '@codemirror/language': 6.11.3
+      '@codemirror/language': 6.12.3
       '@lezer/rust': 1.0.0
 
   '@codemirror/lang-sass@6.0.2':
     dependencies:
       '@codemirror/lang-css': 6.2.1
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@lezer/common': 1.2.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
       '@lezer/sass': 1.0.3
 
   '@codemirror/lang-sql@6.4.0':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@codemirror/lang-vue@0.1.2':
     dependencies:
       '@codemirror/lang-html': 6.4.11
-      '@codemirror/lang-javascript': 6.2.4
-      '@codemirror/language': 6.11.3
-      '@lezer/common': 1.2.2
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@codemirror/lang-wast@6.0.1':
     dependencies:
-      '@codemirror/language': 6.11.3
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@codemirror/language': 6.12.3
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@codemirror/lang-xml@6.1.0':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
-      '@lezer/common': 1.2.2
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
       '@lezer/xml': 1.0.6
 
-  '@codemirror/lang-yaml@6.1.2':
+  '@codemirror/lang-yaml@6.1.3':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@lezer/common': 1.2.2
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
       '@lezer/yaml': 1.0.3
 
-  '@codemirror/language-data@6.5.1':
+  '@codemirror/language-data@6.5.2':
     dependencies:
       '@codemirror/lang-angular': 0.1.2
       '@codemirror/lang-cpp': 6.0.2
@@ -43694,11 +43721,12 @@ snapshots:
       '@codemirror/lang-go': 6.0.1
       '@codemirror/lang-html': 6.4.11
       '@codemirror/lang-java': 6.0.1
-      '@codemirror/lang-javascript': 6.2.4
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/lang-jinja': 6.0.1
       '@codemirror/lang-json': 6.0.2
       '@codemirror/lang-less': 6.0.1
       '@codemirror/lang-liquid': 6.2.1
-      '@codemirror/lang-markdown': 6.3.4
+      '@codemirror/lang-markdown': 6.5.0
       '@codemirror/lang-php': 6.0.1
       '@codemirror/lang-python': 6.1.2
       '@codemirror/lang-rust': 6.0.1
@@ -43707,49 +43735,61 @@ snapshots:
       '@codemirror/lang-vue': 0.1.2
       '@codemirror/lang-wast': 6.0.1
       '@codemirror/lang-xml': 6.1.0
-      '@codemirror/lang-yaml': 6.1.2
-      '@codemirror/language': 6.11.3
+      '@codemirror/lang-yaml': 6.1.3
+      '@codemirror/language': 6.12.3
       '@codemirror/legacy-modes': 6.4.0
 
-  '@codemirror/language@6.11.3':
+  '@codemirror/language@6.12.3':
     dependencies:
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
-      '@lezer/common': 1.2.2
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
       style-mod: 4.1.0
 
   '@codemirror/legacy-modes@6.4.0':
     dependencies:
-      '@codemirror/language': 6.11.3
+      '@codemirror/language': 6.12.3
 
   '@codemirror/lint@6.8.5':
     dependencies:
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      crelt: 1.0.6
+
+  '@codemirror/lint@6.9.6':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
       crelt: 1.0.6
 
   '@codemirror/search@6.5.11':
     dependencies:
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
       crelt: 1.0.6
 
-  '@codemirror/state@6.5.2':
+  '@codemirror/search@6.7.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
 
   '@codemirror/theme-one-dark@6.1.3':
     dependencies:
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
-      '@lezer/highlight': 1.2.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/highlight': 1.2.3
 
-  '@codemirror/view@6.38.5':
+  '@codemirror/view@6.43.0':
     dependencies:
-      '@codemirror/state': 6.5.2
+      '@codemirror/state': 6.6.0
       crelt: 1.0.6
       style-mod: 4.1.0
       w3c-keyname: 2.2.6
@@ -45000,99 +45040,99 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
-  '@lezer/common@1.2.2': {}
+  '@lezer/common@1.5.2': {}
 
   '@lezer/cpp@1.1.0':
     dependencies:
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@lezer/css@1.1.1':
     dependencies:
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
-  '@lezer/generator@1.7.1':
+  '@lezer/generator@1.8.0':
     dependencies:
-      '@lezer/common': 1.2.2
-      '@lezer/lr': 1.4.2
+      '@lezer/common': 1.5.2
+      '@lezer/lr': 1.4.10
 
   '@lezer/go@1.0.0':
     dependencies:
-      '@lezer/common': 1.2.2
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
-  '@lezer/highlight@1.2.1':
+  '@lezer/highlight@1.2.3':
     dependencies:
-      '@lezer/common': 1.2.2
+      '@lezer/common': 1.5.2
 
   '@lezer/html@1.3.12':
     dependencies:
-      '@lezer/common': 1.2.2
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@lezer/java@1.0.3':
     dependencies:
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@lezer/javascript@1.4.1':
     dependencies:
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@lezer/json@1.0.0':
     dependencies:
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@lezer/lezer@1.1.2':
     dependencies:
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
-  '@lezer/lr@1.4.2':
+  '@lezer/lr@1.4.10':
     dependencies:
-      '@lezer/common': 1.2.2
+      '@lezer/common': 1.5.2
 
-  '@lezer/markdown@1.3.1':
+  '@lezer/markdown@1.6.3':
     dependencies:
-      '@lezer/common': 1.2.2
-      '@lezer/highlight': 1.2.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
 
   '@lezer/php@1.0.1':
     dependencies:
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@lezer/python@1.1.2':
     dependencies:
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@lezer/rust@1.0.0':
     dependencies:
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@lezer/sass@1.0.3':
     dependencies:
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@lezer/xml@1.0.6':
     dependencies:
-      '@lezer/common': 1.2.2
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@lezer/yaml@1.0.3':
     dependencies:
-      '@lezer/common': 1.2.2
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@libp2p/interface@2.2.0':
     dependencies:
@@ -48167,23 +48207,23 @@ snapshots:
 
   '@remix-run/router@1.23.2': {}
 
-  '@replit/codemirror-vim@6.2.1(@codemirror/commands@6.8.1)(@codemirror/language@6.11.3)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.5)':
+  '@replit/codemirror-vim@6.3.0(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)':
     dependencies:
-      '@codemirror/commands': 6.8.1
-      '@codemirror/language': 6.11.3
-      '@codemirror/search': 6.5.11
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/search': 6.7.0
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
 
-  '@replit/codemirror-vscode-keymap@6.0.2(@codemirror/autocomplete@6.19.0)(@codemirror/commands@6.8.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.5)':
+  '@replit/codemirror-vscode-keymap@6.0.2(@codemirror/autocomplete@6.20.2)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.6)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
-      '@codemirror/commands': 6.8.1
-      '@codemirror/language': 6.11.3
-      '@codemirror/lint': 6.8.5
-      '@codemirror/search': 6.5.11
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.6
+      '@codemirror/search': 6.7.0
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
 
   '@resvg/resvg-js-android-arm-eabi@2.6.2':
     optional: true
@@ -50479,19 +50519,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@uiw/codemirror-theme-vscode@4.25.2(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.5)':
+  '@uiw/codemirror-theme-vscode@4.25.2(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)':
     dependencies:
-      '@uiw/codemirror-themes': 4.25.2(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.5)
+      '@uiw/codemirror-themes': 4.25.2(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)
     transitivePeerDependencies:
       - '@codemirror/language'
       - '@codemirror/state'
       - '@codemirror/view'
 
-  '@uiw/codemirror-themes@4.25.2(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.5)':
+  '@uiw/codemirror-themes@4.25.2(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)':
     dependencies:
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
 
   '@ungap/structured-clone@1.2.0': {}
 
@@ -50561,19 +50601,19 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.6
 
-  '@valtown/codemirror-continue@2.3.1(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.5)(@lezer/common@1.2.2)':
+  '@valtown/codemirror-continue@2.3.1(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)(@lezer/common@1.5.2)':
     dependencies:
-      '@codemirror/language': 6.11.3
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
-      '@lezer/common': 1.2.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
 
-  '@valtown/codemirror-ts@2.3.1(@codemirror/autocomplete@6.19.0)(@codemirror/lint@6.8.5)(@codemirror/state@6.5.2)(@codemirror/view@6.38.5)':
+  '@valtown/codemirror-ts@2.3.1(@codemirror/autocomplete@6.20.2)(@codemirror/lint@6.9.6)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)':
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
-      '@codemirror/lint': 6.8.5
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/lint': 6.9.6
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
 
   '@vercel/oidc@3.1.0': {}
 
@@ -52894,19 +52934,19 @@ snapshots:
 
   codemirror-lang-spreadsheet@1.3.0:
     dependencies:
-      '@codemirror/language': 6.11.3
-      '@lezer/highlight': 1.2.1
-      '@lezer/lr': 1.4.2
+      '@codemirror/language': 6.12.3
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
-  codemirror@6.0.1:
+  codemirror@6.0.2:
     dependencies:
-      '@codemirror/autocomplete': 6.19.0
-      '@codemirror/commands': 6.8.1
-      '@codemirror/language': 6.11.3
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.3
       '@codemirror/lint': 6.8.5
       '@codemirror/search': 6.5.11
-      '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
 
   collapse-white-space@2.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,21 +46,21 @@ catalog:
   '@cloudflare/ai-chat': ^0.0.6
   '@cloudflare/vitest-pool-workers': ^0.14.1
   '@cloudflare/workers-types': ^4.20260302.0
-  '@codemirror/autocomplete': ^6.19.0
-  '@codemirror/commands': ^6.8.1
+  '@codemirror/autocomplete': ^6.20.2
+  '@codemirror/commands': ^6.10.3
   '@codemirror/lang-html': ^6.4.11
-  '@codemirror/lang-javascript': ^6.2.4
+  '@codemirror/lang-javascript': ^6.2.5
   '@codemirror/lang-json': ^6.0.2
-  '@codemirror/lang-markdown': 6.3.4
+  '@codemirror/lang-markdown': 6.5.0
   '@codemirror/lang-xml': ^6.1.0
-  '@codemirror/lang-yaml': ^6.1.2
-  '@codemirror/language': ^6.11.3
-  '@codemirror/language-data': ^6.5.1
-  '@codemirror/lint': 6.8.5
-  '@codemirror/search': ^6.5.11
-  '@codemirror/state': ^6.5.2
+  '@codemirror/lang-yaml': ^6.1.3
+  '@codemirror/language': ^6.12.3
+  '@codemirror/language-data': ^6.5.2
+  '@codemirror/lint': 6.9.6
+  '@codemirror/search': ^6.7.0
+  '@codemirror/state': ^6.6.0
   '@codemirror/theme-one-dark': ^6.1.3
-  '@codemirror/view': ^6.38.5
+  '@codemirror/view': ^6.43.0
   '@crxjs/vite-plugin': ^2.4.0
   '@dnd-kit/core': ^6.0.5
   '@dnd-kit/modifiers': ^6.0.0
@@ -107,12 +107,12 @@ catalog:
   '@huggingface/transformers': ^3.8.1
   '@ipld/car': ^5.3.3
   '@jitl/quickjs-wasmfile-release-sync': ^0.31.0
-  '@lezer/common': ^1.2.2
-  '@lezer/generator': ^1.7.1
-  '@lezer/highlight': ^1.2.1
+  '@lezer/common': ^1.5.2
+  '@lezer/generator': ^1.8.0
+  '@lezer/highlight': ^1.2.3
   '@lezer/lezer': ^1.1.2
-  '@lezer/lr': ^1.4.2
-  '@lezer/markdown': ^1.3.1
+  '@lezer/lr': ^1.4.10
+  '@lezer/markdown': ^1.6.3
   '@lezer/xml': ^1.0.6
   '@lit/react': ^1.0.8
   '@modelcontextprotocol/sdk': ^1.27.1
@@ -190,7 +190,7 @@ catalog:
   '@radix-ui/react-visually-hidden': 1.1.2
   '@react-three/drei': ^10.7.7
   '@react-three/fiber': ^9.5.0
-  '@replit/codemirror-vim': ^6.2.1
+  '@replit/codemirror-vim': ^6.3.0
   '@replit/codemirror-vscode-keymap': ^6.0.2
   '@rive-app/react-canvas': ^4.14.0
   '@robloche/chartjs-plugin-streaming': 3.1.0
@@ -362,7 +362,7 @@ catalog:
   cjs-module-lexer: ^2.2.0
   classnames: ^2.3.2
   cli-highlight: ^2.1.11
-  codemirror: ^6.0.1
+  codemirror: ^6.0.2
   codemirror-lang-spreadsheet: ^1.3.0
   color-hash: ^1.0.3
   columnify: ^1.6.0
@@ -709,7 +709,10 @@ overrides:
   '@automerge/automerge': 'catalog:'
   '@automerge/automerge-subduction': 'catalog:'
   '@grpc/grpc-js': '>=1.10.9'
+  '@lezer/common': 'catalog:'
+  '@lezer/highlight': 'catalog:'
   '@lezer/lr': 'catalog:'
+  '@lezer/markdown': 'catalog:'
   '@modelcontextprotocol/sdk': '>=1.26.0'
   '@remix-run/router': '>=1.23.2'
   '@swc/core': 'catalog:'


### PR DESCRIPTION
## Dependency upgrades — codemirror group

### CodeMirror

| Package | Old | New | Kind |
|---------|-----|-----|------|
| `@codemirror/autocomplete` | ^6.19.0 | ^6.20.2 | minor |
| `@codemirror/commands` | ^6.8.1 | ^6.10.3 | minor |
| `@codemirror/lang-javascript` | ^6.2.4 | ^6.2.5 | patch |
| `@codemirror/lang-markdown` | 6.3.4 | 6.5.0 | minor (exact pin) |
| `@codemirror/lang-yaml` | ^6.1.2 | ^6.1.3 | patch |
| `@codemirror/language` | ^6.11.3 | ^6.12.3 | minor |
| `@codemirror/language-data` | ^6.5.1 | ^6.5.2 | patch |
| `@codemirror/lint` | 6.8.5 | 6.9.6 | minor (exact pin) |
| `@codemirror/search` | ^6.5.11 | ^6.7.0 | minor |
| `@codemirror/state` | ^6.5.2 | ^6.6.0 | minor |
| `@codemirror/view` | ^6.38.5 | ^6.43.0 | minor |
| `codemirror` | ^6.0.1 | ^6.0.2 | patch |
| `@replit/codemirror-vim` | ^6.2.1 | ^6.3.0 | minor |

No changes: `@codemirror/lang-html`, `@codemirror/lang-json`, `@codemirror/lang-xml`, `@codemirror/theme-one-dark`, `@replit/codemirror-vscode-keymap`, `codemirror-lang-spreadsheet` (all at latest)

### Lezer (pulled in by codemirror bump)

| Package | Old | New | Kind |
|---------|-----|-----|------|
| `@lezer/common` | ^1.2.2 | ^1.5.2 | minor |
| `@lezer/generator` | ^1.7.1 | ^1.8.0 | minor |
| `@lezer/highlight` | ^1.2.1 | ^1.2.3 | patch |
| `@lezer/lr` | ^1.4.2 | ^1.4.10 | patch |
| `@lezer/markdown` | ^1.3.1 | ^1.6.3 | minor |

### pnpm overrides

Added `@lezer/common`, `@lezer/highlight`, and `@lezer/markdown` to `overrides` (joining the existing `@lezer/lr` entry). The newer codemirror packages use a loose `^1.0.0` peer dependency on these lezer packages, causing pnpm to install two copies — one for codemirror's transitive deps and one for our direct catalog dependency. The `catalog:` overrides deduplicate them to the single catalog version and fix a TypeScript build error in `ui-editor` where two incompatible `@lezer/markdown` type definitions were in scope.

## Validation

- `pnpm install --no-frozen-lockfile`: clean
- `moon run ui-editor:build`: **165 tasks completed**
- `moon run react-ui-editor:build react-ui-markdown:build`: **179 tasks completed**

## Classification

**Trivial** — all minor/patch bumps within codemirror 6.x and lezer 1.x, no source changes required, builds clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhkTaBTDQp4jYpnvSQWCE8)_
