### PR TITLE
feat(plugin-generator): Gemini (Veo) provider; provider-keyed settings

### DIFF
--- a/packages/plugins/plugin-generator/src/capabilities/settings.ts
+++ b/packages/plugins/plugin-generator/src/capabilities/settings.ts
@@ -16,7 +16,7 @@ export default Capability.makeModule(() =>
     const settingsAtom = createKvsStore({
       key: meta.id,
       schema: Settings.Settings,
-      defaultValue: () => ({ apiKey: undefined }),
+      defaultValue: () => ({ providers: {} }),
     });
 
     return [

--- a/packages/plugins/plugin-generator/src/containers/GenerationArticle/GenerationArticle.stories.tsx
+++ b/packages/plugins/plugin-generator/src/containers/GenerationArticle/GenerationArticle.stories.tsx
@@ -55,15 +55,6 @@ export const WithVideo: Story = {
     urls: ['https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4'],
   },
 };
-export const WithAudio: Story = {
-  args: {
-    type: 'audio',
-    prompt: 'A 30-second jazz piano piece in the key of D minor.',
-    urls: [
-      'https://commondatastorage.googleapis.com/codeskulptor-demos/DDR_assets/Kangaroo_MusiQue_-_The_Neverwritten_Role_Playing_Game.mp3',
-    ],
-  },
-};
 export const MultipleUrls: Story = {
   args: {
     type: 'video',

--- a/packages/plugins/plugin-generator/src/containers/GenerationArticle/GenerationArticle.tsx
+++ b/packages/plugins/plugin-generator/src/containers/GenerationArticle/GenerationArticle.tsx
@@ -26,10 +26,18 @@ export const GenerationArticle = ({ role, subject, attendableId }: GenerationArt
   const { t } = useTranslation(meta.id);
   const [generation] = useObject(subject);
   const settings = useAtomCapability(GeneratorCapabilities.Settings);
+  // Two distinct provider ids:
+  //   - `providerId` is the *selection* (what a new job would use).
+  //   - `jobProviderId` is the *in-flight* provider snapshotted at enqueue time;
+  //     polling must use this so a mid-job selection change doesn't talk to the
+  //     wrong backend or use the wrong api key.
   const providerId = Generation.getProvider(generation);
+  const jobProviderId = generation.jobProvider ?? providerId;
   const apiKey = settings?.providers?.[providerId]?.apiKey;
+  const jobApiKey = settings?.providers?.[jobProviderId]?.apiKey;
   const provider = useGenerationProvider(providerId);
-  const { status, error } = useGenerationProgress(subject, provider, apiKey);
+  const jobProvider = useGenerationProvider(jobProviderId);
+  const { status, error } = useGenerationProgress(subject, jobProvider, jobApiKey);
   const urls = generation.urls ?? [];
 
   const handleGenerate = useCallback(async () => {
@@ -44,9 +52,11 @@ export const GenerationArticle = ({ role, subject, attendableId }: GenerationArt
       );
       // Persisting `jobId` flips `useGenerationProgress` to 'busy' and starts
       // polling; if the user navigates away mid-job the next mount picks the
-      // stored id up and resumes.
+      // stored id up and resumes. `jobProvider` snapshots which backend owns
+      // the job so a later provider change doesn't reroute polling.
       Obj.update(subject, (subject) => {
         subject.jobId = jobId;
+        subject.jobProvider = providerId;
       });
     } catch (err) {
       log.catch(err);
@@ -64,6 +74,7 @@ export const GenerationArticle = ({ role, subject, attendableId }: GenerationArt
     Obj.update(subject, (subject) => {
       subject.urls = undefined;
       subject.jobId = undefined;
+      subject.jobProvider = undefined;
     });
   }, [subject]);
 
@@ -204,6 +215,7 @@ const useGenerationProgress = (
           // carousel surfaces by default and what users expect after clicking ▶.
           subject.urls = [url, ...(subject.urls ?? [])];
           subject.jobId = undefined;
+          subject.jobProvider = undefined;
         });
         setStatus('idle');
       })

--- a/packages/plugins/plugin-generator/src/containers/GenerationArticle/GenerationArticle.tsx
+++ b/packages/plugins/plugin-generator/src/containers/GenerationArticle/GenerationArticle.tsx
@@ -15,8 +15,8 @@ import { type ActionGraphProps, Menu, MenuBuilder, useMenuActions } from '@dxos/
 
 import { PromptEditor } from '#components';
 import { meta } from '#meta';
-import { HeyGenProvider, type GenerationProvider, MissingApiKeyError } from '#services';
-import { type Generation, GeneratorCapabilities } from '#types';
+import { createProvider, type GenerationProvider, MissingApiKeyError } from '#services';
+import { Generation, GeneratorCapabilities } from '#types';
 
 type Status = 'idle' | 'busy' | 'error';
 
@@ -26,8 +26,9 @@ export const GenerationArticle = ({ role, subject, attendableId }: GenerationArt
   const { t } = useTranslation(meta.id);
   const [generation] = useObject(subject);
   const settings = useAtomCapability(GeneratorCapabilities.Settings);
-  const apiKey = settings?.apiKey;
-  const provider = useGenerationProvider();
+  const providerId = Generation.getProvider(generation);
+  const apiKey = settings?.providers?.[providerId]?.apiKey;
+  const provider = useGenerationProvider(providerId);
   const { status, error } = useGenerationProgress(subject, provider, apiKey);
   const urls = generation.urls ?? [];
 
@@ -220,5 +221,6 @@ const useGenerationProgress = (
   return { status, error };
 };
 
-/** Resolves the active GenerationProvider. The default is the HeyGen adapter. */
-const useGenerationProvider = (): GenerationProvider => useMemo(() => new HeyGenProvider(), []);
+/** Resolves the active GenerationProvider for the given provider id. */
+const useGenerationProvider = (providerId: Generation.ProviderId): GenerationProvider =>
+  useMemo(() => createProvider(providerId), [providerId]);

--- a/packages/plugins/plugin-generator/src/containers/GenerationProperties/GenerationProperties.tsx
+++ b/packages/plugins/plugin-generator/src/containers/GenerationProperties/GenerationProperties.tsx
@@ -13,8 +13,8 @@ import { useTranslation } from '@dxos/react-ui';
 import { Form, type FormFieldMap, SelectField } from '@dxos/react-ui-form';
 
 import { meta } from '#meta';
-import { HeyGenProvider, type GenerationOption, type GenerationProvider } from '#services';
-import { type Generation, GeneratorCapabilities } from '#types';
+import { createProvider, type GenerationOption, type GenerationProvider } from '#services';
+import { Generation, GeneratorCapabilities } from '#types';
 
 type Status = 'idle' | 'loading' | 'ready' | 'error';
 
@@ -43,8 +43,9 @@ export const GenerationProperties = ({ subject }: GenerationPropertiesProps) => 
   const { t } = useTranslation(meta.id);
   const [generation] = useObject(subject);
   const settings = useAtomCapability(GeneratorCapabilities.Settings);
-  const apiKey = settings?.apiKey;
-  const provider = useGenerationProvider();
+  const providerId = Generation.getProvider(generation);
+  const apiKey = settings?.providers?.[providerId]?.apiKey;
+  const provider = useGenerationProvider(providerId);
   const [{ avatars, voices }, setOptions] = useState<Options>(EMPTY_OPTIONS);
   const [status, setStatus] = useState<Status>('idle');
   const [error, setError] = useState<string>();
@@ -127,6 +128,19 @@ export const GenerationProperties = ({ subject }: GenerationPropertiesProps) => 
     [avatars, voices, placeholder, status, generation.avatarId, generation.voiceId, t],
   );
 
+  // Providers like Gemini have no concept of avatars / voices — once we know the
+  // lists are empty AND the object isn't already carrying values for them there's
+  // nothing useful to render, so skip the surface entirely.
+  const hasAvatarOrVoice =
+    status !== 'ready' ||
+    avatars.length > 0 ||
+    voices.length > 0 ||
+    Boolean(generation.avatarId) ||
+    Boolean(generation.voiceId);
+  if (!hasAvatarOrVoice) {
+    return null;
+  }
+
   return (
     <Form.Root
       schema={PropertiesSchema}
@@ -154,5 +168,6 @@ const makeOptions = (options: GenerationOption[], current?: string): Array<{ val
   return [{ value: current, label: current }, ...base];
 };
 
-// TODO(burdon): Move to capability.
-const useGenerationProvider = (): GenerationProvider => useMemo(() => new HeyGenProvider(), []);
+// TODO(burdon): Move to capability so the same provider instance is shared across surfaces.
+const useGenerationProvider = (providerId: Generation.ProviderId): GenerationProvider =>
+  useMemo(() => createProvider(providerId), [providerId]);

--- a/packages/plugins/plugin-generator/src/containers/GeneratorSettings/GeneratorSettings.tsx
+++ b/packages/plugins/plugin-generator/src/containers/GeneratorSettings/GeneratorSettings.tsx
@@ -2,29 +2,52 @@
 // Copyright 2026 DXOS.org
 //
 
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { type AppSurface } from '@dxos/app-toolkit/ui';
-import { useTranslation } from '@dxos/react-ui';
 import { Settings as SettingsForm } from '@dxos/react-ui-form';
 
-import { meta } from '#meta';
 import { Settings } from '#types';
+
+const PROVIDER_SECTIONS: Array<{ id: 'heygen' | 'gemini'; title: string }> = [
+  { id: 'heygen', title: 'HeyGen' },
+  { id: 'gemini', title: 'Gemini (Veo)' },
+];
 
 export type GeneratorSettingsProps = AppSurface.SettingsArticleProps<Settings.Settings>;
 
+/**
+ * Per-provider settings panel. We explicitly render one `Section` per provider
+ * (rather than letting `SettingsForm.FieldSet` auto-render the nested struct)
+ * because the auto-renderer doesn't use struct titles as headings, which leaves
+ * the user with multiple unlabelled "API key" inputs.
+ */
 export const GeneratorSettings = ({ settings, onSettingsChange }: GeneratorSettingsProps) => {
-  const { t } = useTranslation(meta.id);
+  const handleProviderChange = useCallback(
+    (id: 'heygen' | 'gemini', value: Settings.ProviderSettings) => {
+      onSettingsChange?.((current) => ({
+        ...current,
+        providers: {
+          ...current.providers,
+          [id]: value,
+        },
+      }));
+    },
+    [onSettingsChange],
+  );
+
   return (
     <SettingsForm.Viewport>
-      <SettingsForm.Section title={t('plugin.name')}>
-        <SettingsForm.FieldSet
-          readonly={!onSettingsChange}
-          schema={Settings.Settings}
-          values={settings}
-          onValuesChanged={(values) => onSettingsChange?.(() => values)}
-        />
-      </SettingsForm.Section>
+      {PROVIDER_SECTIONS.map(({ id, title }) => (
+        <SettingsForm.Section key={id} title={title}>
+          <SettingsForm.FieldSet
+            readonly={!onSettingsChange}
+            schema={Settings.ProviderSettings}
+            values={settings?.providers?.[id] ?? {}}
+            onValuesChanged={(value) => handleProviderChange(id, value)}
+          />
+        </SettingsForm.Section>
+      ))}
     </SettingsForm.Viewport>
   );
 };

--- a/packages/plugins/plugin-generator/src/services/GeminiProvider.ts
+++ b/packages/plugins/plugin-generator/src/services/GeminiProvider.ts
@@ -1,0 +1,226 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { invariant } from '@dxos/invariant';
+
+import { type Generation } from '#types';
+
+import {
+  type GenerateInput,
+  type GenerateResult,
+  type GenerationOption,
+  type GenerationProvider,
+  MissingApiKeyError,
+  type ProviderCallOptions,
+  ProviderFailureError,
+  UnsupportedKindError,
+} from './GenerationProvider';
+
+const API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
+
+// Veo 3.1 preview is the current generally-available video model on the
+// Generative Language API. The `:predictLongRunning` action returns an
+// Operation that we poll until `done === true`.
+// https://ai.google.dev/api/generate-content#video
+const MODEL = 'veo-3.1-generate-preview';
+const GENERATE_URL = `${API_BASE}/models/${MODEL}:predictLongRunning`;
+
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_TIMEOUT_MS = 5 * 60_000;
+
+export type GeminiProviderOptions = {
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  fetch?: typeof globalThis.fetch;
+};
+
+/**
+ * Google Gemini (Veo 3.1) video generation adapter.
+ *
+ * The Generative Language API exposes Veo via a Long-Running Operation:
+ * `POST {model}:predictLongRunning` enqueues, and `GET {operationName}` polls.
+ * The generated video URI returned by the operation requires the api key
+ * to download (it isn't a public CDN url), so `awaitResult` fetches the bytes
+ * with the api key and hands back a `blob:` URL the player can stream.
+ *
+ * TODO(burdon): Persist the downloaded bytes to WNFS so the URL survives
+ * reloads — `blob:` URLs only live for the lifetime of the page.
+ *
+ * Veo has no concept of avatars / voices, so the picker methods return empty
+ * arrays.
+ */
+export class GeminiProvider implements GenerationProvider {
+  readonly id = 'gemini';
+  readonly #pollIntervalMs: number;
+  readonly #timeoutMs: number;
+  readonly #fetch: typeof globalThis.fetch;
+
+  constructor(options: GeminiProviderOptions = {}) {
+    this.#pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.#timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.#fetch = options.fetch ?? globalThis.fetch.bind(globalThis);
+  }
+
+  supports(kind: Generation.Kind): boolean {
+    return kind === 'video';
+  }
+
+  async enqueue(input: GenerateInput, options: ProviderCallOptions): Promise<{ jobId: string }> {
+    if (!options.apiKey) {
+      throw new MissingApiKeyError();
+    }
+    if (!this.supports(input.type)) {
+      throw new UnsupportedKindError(input.type, this.id);
+    }
+
+    return { jobId: await this.#postGenerate(input, options) };
+  }
+
+  async awaitResult(jobId: string, options: ProviderCallOptions): Promise<GenerateResult> {
+    if (!options.apiKey) {
+      throw new MissingApiKeyError();
+    }
+
+    const remoteUri = await this.#poll(jobId, options);
+    const url = await this.#downloadAsBlobUrl(remoteUri, options);
+    return { url };
+  }
+
+  async generate(input: GenerateInput, options: ProviderCallOptions): Promise<GenerateResult> {
+    const { jobId } = await this.enqueue(input, options);
+    return this.awaitResult(jobId, options);
+  }
+
+  async listAvatars(_options: ProviderCallOptions): Promise<GenerationOption[]> {
+    return [];
+  }
+
+  async listVoices(_options: ProviderCallOptions): Promise<GenerationOption[]> {
+    return [];
+  }
+
+  async #postGenerate(input: GenerateInput, options: ProviderCallOptions): Promise<string> {
+    const response = await this.#fetch(GENERATE_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': options.apiKey,
+      },
+      body: JSON.stringify({
+        instances: [{ prompt: input.prompt }],
+        // TODO(burdon): Make configurable via props.
+        parameters: {
+          aspectRatio: '16:9',
+          personGeneration: 'allow_all',
+        },
+      }),
+      signal: options.signal,
+    });
+
+    if (!response.ok) {
+      throw new ProviderFailureError(`Gemini generate failed: ${response.status} ${await readErrorBody(response)}`);
+    }
+
+    const body = (await response.json()) as { name?: string; error?: { message?: string } };
+    if (body.error?.message) {
+      throw new ProviderFailureError(body.error.message);
+    }
+    invariant(body.name, 'Gemini response missing operation name');
+    return body.name;
+  }
+
+  async #poll(operationName: string, options: ProviderCallOptions): Promise<string> {
+    const deadline = Date.now() + this.#timeoutMs;
+    const url = `${API_BASE}/${operationName}`;
+    while (Date.now() < deadline) {
+      const response = await this.#fetch(url, {
+        method: 'GET',
+        headers: { 'x-goog-api-key': options.apiKey },
+        signal: options.signal,
+      });
+      if (!response.ok) {
+        throw new ProviderFailureError(`Gemini status failed: ${response.status} ${await readErrorBody(response)}`);
+      }
+
+      // Veo's Operation payload nests the artefact under
+      // `response.generateVideoResponse.generatedSamples[0].video.uri`.
+      const body = (await response.json()) as {
+        done?: boolean;
+        error?: { message?: string };
+        response?: {
+          generateVideoResponse?: {
+            generatedSamples?: Array<{ video?: { uri?: string } }>;
+          };
+        };
+      };
+      if (body.error?.message) {
+        throw new ProviderFailureError(body.error.message);
+      }
+      if (body.done) {
+        const uri = body.response?.generateVideoResponse?.generatedSamples?.[0]?.video?.uri;
+        if (!uri) {
+          throw new ProviderFailureError('Gemini operation completed without a video uri.');
+        }
+        return uri;
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        // Register a named abort handler so we can remove it when the timer
+        // fires — `{ once: true }` only auto-removes after an abort, so without
+        // explicit cleanup listeners would pile up on the (long-lived) signal
+        // across every poll iteration.
+        const onAbort = () => {
+          clearTimeout(timer);
+          reject(options.signal?.reason);
+        };
+        const timer = setTimeout(() => {
+          options.signal?.removeEventListener('abort', onAbort);
+          resolve();
+        }, this.#pollIntervalMs);
+        options.signal?.addEventListener('abort', onAbort, { once: true });
+      });
+    }
+
+    throw new ProviderFailureError('Gemini job timed out.');
+  }
+
+  /**
+   * The Veo artefact URI requires the api key to download. We can't hand the
+   * raw URL to a `<video>` element because the element won't attach the
+   * `x-goog-api-key` header, so we fetch the bytes here and wrap them in a
+   * `blob:` URL the player can consume directly.
+   */
+  async #downloadAsBlobUrl(remoteUri: string, options: ProviderCallOptions): Promise<string> {
+    const response = await this.#fetch(remoteUri, {
+      method: 'GET',
+      headers: { 'x-goog-api-key': options.apiKey },
+      signal: options.signal,
+    });
+    if (!response.ok) {
+      throw new ProviderFailureError(`Gemini download failed: ${response.status} ${await readErrorBody(response)}`);
+    }
+    const blob = await response.blob();
+    return URL.createObjectURL(blob);
+  }
+}
+
+/** Best-effort decode of an error response body so the user sees the actual reason instead of a bare status. */
+const readErrorBody = async (response: Response): Promise<string> => {
+  try {
+    const text = await response.text();
+    if (!text) {
+      return response.statusText;
+    }
+
+    try {
+      const json = JSON.parse(text);
+      const message = json?.error?.message ?? json?.message ?? json?.error;
+      return typeof message === 'string' ? message : text;
+    } catch {
+      return text;
+    }
+  } catch {
+    return response.statusText;
+  }
+};

--- a/packages/plugins/plugin-generator/src/services/HeyGenProvider.ts
+++ b/packages/plugins/plugin-generator/src/services/HeyGenProvider.ts
@@ -173,7 +173,7 @@ export class HeyGenProvider implements GenerationProvider {
         voice_id: input.voiceId,
         script: input.prompt,
         // TODO(burdon): Make configurable via props.
-        // fit: 'contain',
+        fit: 'cover',
         aspect_ratio: '16:9',
         resolution: '1080p',
         remove_background: true,

--- a/packages/plugins/plugin-generator/src/services/createProvider.ts
+++ b/packages/plugins/plugin-generator/src/services/createProvider.ts
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 DXOS.org
+//
+
+import { Generation } from '#types';
+
+import { GeminiProvider, type GeminiProviderOptions } from './GeminiProvider';
+import { type GenerationProvider } from './GenerationProvider';
+import { HeyGenProvider, type HeyGenProviderOptions } from './HeyGenProvider';
+
+export type CreateProviderOptions = {
+  heygen?: HeyGenProviderOptions;
+  gemini?: GeminiProviderOptions;
+};
+
+/**
+ * Factory for `GenerationProvider` instances keyed by `Generation.ProviderId`.
+ * Centralising construction here keeps consumers (the article + properties
+ * surfaces) ignorant of which concrete adapter they're talking to — they only
+ * see the generic interface.
+ */
+export const createProvider = (id: Generation.ProviderId, options: CreateProviderOptions = {}): GenerationProvider => {
+  switch (id) {
+    case 'heygen':
+      return new HeyGenProvider(options.heygen);
+    case 'gemini':
+      return new GeminiProvider(options.gemini);
+  }
+};

--- a/packages/plugins/plugin-generator/src/services/createProvider.ts
+++ b/packages/plugins/plugin-generator/src/services/createProvider.ts
@@ -25,5 +25,12 @@ export const createProvider = (id: Generation.ProviderId, options: CreateProvide
       return new HeyGenProvider(options.heygen);
     case 'gemini':
       return new GeminiProvider(options.gemini);
+    default: {
+      // Defensive: TypeScript enforces exhaustiveness, but a malformed runtime
+      // value (e.g. stale persisted data after a schema change) would otherwise
+      // fall through and return `undefined`.
+      const exhaustiveId: never = id;
+      throw new Error(`Unsupported provider id: ${String(exhaustiveId)}`);
+    }
   }
 };

--- a/packages/plugins/plugin-generator/src/services/index.ts
+++ b/packages/plugins/plugin-generator/src/services/index.ts
@@ -2,5 +2,7 @@
 // Copyright 2026 DXOS.org
 //
 
+export * from './createProvider';
+export * from './GeminiProvider';
 export * from './GenerationProvider';
 export * from './HeyGenProvider';

--- a/packages/plugins/plugin-generator/src/types/Generation.ts
+++ b/packages/plugins/plugin-generator/src/types/Generation.ts
@@ -10,13 +10,21 @@ import { Annotation, Obj, Ref, Type } from '@dxos/echo';
 import { FormInputAnnotation, LabelAnnotation } from '@dxos/echo/internal';
 import { Text } from '@dxos/schema';
 
-/** Media kind produced by a Generation. */
-export const Kind = Schema.Literal('video', 'audio');
+/** Media kind produced by a Generation. Video-only for now; an audio kind will return when there's a real audio provider. */
+export const Kind = Schema.Literal('video');
 export type Kind = Schema.Schema.Type<typeof Kind>;
+
+/** Known provider identifiers. Matches `GenerationProvider.id`. */
+export const ProviderId = Schema.Literal('heygen', 'gemini');
+export type ProviderId = Schema.Schema.Type<typeof ProviderId>;
+
+export const DEFAULT_PROVIDER: ProviderId = 'heygen';
 
 /**
  * AI media generation artefact.
  * `prompt` is a ref to a markdown Text document the user edits inline.
+ * `provider` selects which `GenerationProvider` services this clip; defaults
+ * to `DEFAULT_PROVIDER` when missing (back-compat for phase-1 objects).
  * `urls` is a most-recent-first list of every completed generation for this
  * object — each successful `awaitResult` prepends. The article renders them
  * as a carousel so prior renders remain accessible.
@@ -31,6 +39,7 @@ export type Kind = Schema.Schema.Type<typeof Kind>;
 export const Generation = Schema.Struct({
   name: Schema.optional(Schema.String.annotations({ title: 'Name' })),
   type: Kind.annotations({ title: 'Type' }),
+  provider: Schema.optional(ProviderId.annotations({ title: 'Provider' })),
   avatarId: Schema.optional(
     Schema.String.annotations({
       title: 'Avatar',
@@ -65,17 +74,26 @@ export interface Generation extends Schema.Schema.Type<typeof Generation> {}
 export type MakeProps = Partial<{
   name: string;
   type: Kind;
+  provider: ProviderId;
   prompt: string;
   avatarId: string;
   voiceId: string;
 }>;
 
 /** Creates a Generation with an attached empty markdown Text prompt. */
-export const make = ({ name, type = 'video', prompt = '', avatarId, voiceId }: MakeProps = {}): Generation => {
+export const make = ({
+  name,
+  type = 'video',
+  provider = DEFAULT_PROVIDER,
+  prompt = '',
+  avatarId,
+  voiceId,
+}: MakeProps = {}): Generation => {
   const text = Text.make({ content: prompt });
   const generation = Obj.make(Generation, {
     name,
     type,
+    provider,
     avatarId,
     voiceId,
     prompt: Ref.make(text),
@@ -83,6 +101,14 @@ export const make = ({ name, type = 'video', prompt = '', avatarId, voiceId }: M
   Obj.setParent(text, generation);
   return generation;
 };
+
+/**
+ * Returns the active provider id for a Generation, defaulting to `DEFAULT_PROVIDER`
+ * when missing. Accepts a structural shape so it can be called with either the
+ * live ECHO object or its snapshot returned by `useObject`.
+ */
+export const getProvider = (generation: { provider?: ProviderId }): ProviderId =>
+  generation.provider ?? DEFAULT_PROVIDER;
 
 /** Type guard for Generation instances. */
 export const instanceOf = (value: unknown): value is Generation => Obj.instanceOf(Generation, value);

--- a/packages/plugins/plugin-generator/src/types/Generation.ts
+++ b/packages/plugins/plugin-generator/src/types/Generation.ts
@@ -35,6 +35,9 @@ export const DEFAULT_PROVIDER: ProviderId = 'heygen';
  * once `provider.awaitResult` returns a `url`; resuming on remount means a
  * crash or navigation away mid-job won't strand the user — the next mount
  * sees the stored id and continues polling.
+ * `jobProvider` is snapshotted from `provider` when the job is enqueued so the
+ * polling loop always talks to the backend that owns `jobId` even if the user
+ * switches `provider` in the gear pane mid-flight.
  */
 export const Generation = Schema.Struct({
   name: Schema.optional(Schema.String.annotations({ title: 'Name' })),
@@ -57,6 +60,7 @@ export const Generation = Schema.Struct({
     Schema.Array(Schema.String).annotations({ title: 'URLs' }).pipe(FormInputAnnotation.set(false)),
   ),
   jobId: Schema.optional(Schema.String.annotations({ title: 'Job ID' }).pipe(FormInputAnnotation.set(false))),
+  jobProvider: Schema.optional(ProviderId.annotations({ title: 'Job Provider' }).pipe(FormInputAnnotation.set(false))),
 }).pipe(
   Type.object({
     typename: 'org.dxos.type.generation',

--- a/packages/plugins/plugin-generator/src/types/Settings.ts
+++ b/packages/plugins/plugin-generator/src/types/Settings.ts
@@ -6,13 +6,37 @@
 
 import * as Schema from 'effect/Schema';
 
-export const Settings = Schema.mutable(
+/**
+ * Per-provider settings (api key + future provider-specific knobs).
+ * Each Generation picks its provider via `Generation.provider`; the article
+ * looks up the matching entry here to source the api key.
+ */
+export const ProviderSettings = Schema.mutable(
   Schema.Struct({
     apiKey: Schema.optional(
       Schema.String.annotations({
         title: 'API key',
-        description: 'Credentials for the active media generation provider.',
       }),
+    ),
+  }),
+);
+export interface ProviderSettings extends Schema.Schema.Type<typeof ProviderSettings> {}
+
+/**
+ * Plugin-level settings. `providers` is a map keyed by `provider.id` whose
+ * values are `ProviderSettings` so each provider can grow its own settings
+ * surface without changing the top-level schema. Provider ids match
+ * `GenerationProvider.id` (currently `'heygen'`, `'gemini'`).
+ */
+export const Settings = Schema.mutable(
+  Schema.Struct({
+    providers: Schema.optional(
+      Schema.mutable(
+        Schema.Struct({
+          heygen: Schema.optional(ProviderSettings.annotations({ title: 'HeyGen' })),
+          gemini: Schema.optional(ProviderSettings.annotations({ title: 'Gemini (Veo)' })),
+        }),
+      ),
     ),
   }),
 );


### PR DESCRIPTION
## Summary

Phase 2 of `plugin-generator` (follow-up to #11367):

- **Gemini (Veo 3.1) provider** alongside HeyGen. Uses the Generative Language API's `predictLongRunning` operation pattern: enqueue returns the operation name, poll until `done`. The generated video URI requires the api key to download, so `awaitResult` fetches the bytes and wraps them in a `blob:` URL. _Future:_ persist the bytes to WNFS so the URL survives reloads.
- **`Generation.provider` field** (`'heygen' | 'gemini'`, optional) selects which provider services a clip. Defaults to `heygen` at read-time via `Generation.getProvider()` for back-compat with phase-1 objects. Renders as a Select in the gear pane via `Schema.Literal`.
- **Provider registry** (`createProvider(id, options)`) decouples the article + properties surfaces from any concrete adapter.
- **Settings shape** is now `{ providers: { heygen?: { apiKey? }, gemini?: { apiKey? } } }` — each provider can grow its own settings without touching the top level. `GeneratorSettings` renders one labelled section per provider (the auto-FieldSet recursion doesn't surface struct titles).
- **Kind** is video-only now (`Schema.Literal('video')`); the audio literal will return when there's a real audio provider.
- Hide avatar/voice selects when the active provider yields no options (e.g. Gemini).
- Fix carried over from phase 1: HeyGen `fit: 'cover'`.

## Test plan

- [ ] Create a Generation with provider `heygen` — gear pane shows Provider select, Avatar/Voice pickers populate, generate produces a clip.
- [ ] Switch provider to `gemini` — Avatar/Voice section hides; generate produces a clip (requires Gemini api key set).
- [ ] Settings panel shows two labelled sections (HeyGen, Gemini (Veo)) each with an API key input.
- [ ] Existing phase-1 Generation objects (no `provider` field) continue to use HeyGen via `getProvider()` fallback.

Part of follow-up to #11367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Gemini (Veo 3.1) video generation support.

* **Improvements**
  * Generator selects and uses the correct provider per generation.
  * Better video framing for improved output.

* **Changes**
  * Audio generation removed — video only.
  * Settings redesigned for per-provider API keys; defaults now initialize provider configs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->