### PR TITLE
fix(plugin-sheet): update e2e test to use renamed SheetArticle story URL

### DIFF
--- a/packages/plugins/plugin-sheet/src/playwright/sheet.spec.ts
+++ b/packages/plugins/plugin-sheet/src/playwright/sheet.spec.ts
@@ -15,7 +15,7 @@ test.describe('plugin-sheet', () => {
 
   test.beforeEach(async ({ browser }) => {
     const setup = await setupPage(browser, {
-      url: storybookUrl('plugins-plugin-sheet-containers-sheetcontainer--spec', 9005),
+      url: storybookUrl('plugins-plugin-sheet-containers-sheetarticle--spec', 9005),
       viewportSize: { width: 1280, height: 720 },
     });
     page = setup.page;


### PR DESCRIPTION
## Summary

- Updates the playwright e2e test story URL from `sheetcontainer` to `sheetarticle` to match the renamed Storybook story.

## Root Cause

PR #11373 (`refactor(plugins): rename article-role Container components to Article suffix`) renamed `SheetContainer` → `SheetArticle` and updated the Storybook story title from `plugins/plugin-sheet/containers/SheetContainer` to `plugins/plugin-sheet/containers/SheetArticle`. This changed the Storybook story ID from `plugins-plugin-sheet-containers-sheetcontainer--spec` to `plugins-plugin-sheet-containers-sheetarticle--spec`.

The playwright e2e test in `sheet.spec.ts` was not updated in that PR, causing the e2e job on main to fail when it tries to navigate to the old (now 404) story URL.

## Test plan

- [ ] `moon run plugin-sheet:e2e` passes with the updated story URL

https://claude.ai/code/session_011WzDzCcfqMFUnUU7je28kp

---
_Generated by [Claude Code](https://claude.ai/code/session_011WzDzCcfqMFUnUU7je28kp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to target a different test scenario.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->