### PR TITLE
feat(compute): trace runtime name & flush ECHO writes before function close

### DIFF
--- a/packages/core/compute/compute/src/Trace.ts
+++ b/packages/core/compute/compute/src/Trace.ts
@@ -24,7 +24,7 @@ export interface TraceWriter {
  * Service that writes events to the trace.
  * Exposed to processes and operations to record events to the trace.
  */
-export class TraceService extends Context.Tag('@dxos/functions/TraceService')<TraceService, TraceWriter>() { }
+export class TraceService extends Context.Tag('@dxos/functions/TraceService')<TraceService, TraceWriter>() {}
 
 /**
  * Writes an event to the trace.
@@ -67,7 +67,7 @@ export const Event = Schema.Struct({
   type: Schema.String,
   data: Schema.Unknown, // Type-specific payload;
 });
-export interface Event extends Schema.Schema.Type<typeof Event> { }
+export interface Event extends Schema.Schema.Type<typeof Event> {}
 
 /**
  * Checks if an event is of a given type.
@@ -143,7 +143,7 @@ export const MessageData = Schema.Struct({
   isEphemeral: Schema.Boolean,
   events: Schema.Array(Event),
 });
-export interface MessageData extends Schema.Schema.Type<typeof MessageData> { }
+export interface MessageData extends Schema.Schema.Type<typeof MessageData> {}
 
 export const Message = MessageData.pipe(
   Type.object({
@@ -155,7 +155,7 @@ export const Message = MessageData.pipe(
     hue: 'rose',
   }),
 );
-export interface Message extends Schema.Schema.Type<typeof Message> { }
+export interface Message extends Schema.Schema.Type<typeof Message> {}
 
 /**
  * Flattened representation of a signle event in a trace message.
@@ -177,7 +177,6 @@ export const flatten = (message: Message): FlatEvent[] => {
   }));
 };
 
-
 /**
  * Sink for complete trace messages.
  */
@@ -190,16 +189,16 @@ export interface Sink {
  * The Process Manager forwards trace messages to it.
  */
 // TODO(dmaretskyi): Consider moving sink to the Process Manager.
-export class TraceSink extends Context.Tag('@dxos/functions/TraceSink')<TraceSink, Sink>() { }
+export class TraceSink extends Context.Tag('@dxos/functions/TraceSink')<TraceSink, Sink>() {}
 
 export const noopWriter: TraceWriter = {
-  write: () => { },
+  write: () => {},
 };
 
 export const writerLayerNoop: Layer.Layer<TraceService> = Layer.succeed(TraceService, noopWriter);
 
 export const layerNoop: Layer.Layer<TraceSink> = Layer.succeed(TraceSink, {
-  write: () => { },
+  write: () => {},
 });
 
 export const layerConsole: Layer.Layer<TraceSink> = Layer.succeed(TraceSink, {

--- a/packages/core/compute/compute/src/Trace.ts
+++ b/packages/core/compute/compute/src/Trace.ts
@@ -99,8 +99,32 @@ export const Meta = Schema.Struct({
    * ID of the tool call that created the current process.
    */
   toolCallId: Schema.optional(Schema.String),
+
+  /**
+   * Extensible name informing which runtime executed the code that produced the event.
+   */
+  runtimeName: Schema.optional(Schema.String),
 });
 export interface Meta extends Schema.Schema.Type<typeof Meta> { }
+
+/**
+ * Extensible name informing which runtime executed the code that produced the event.
+ */
+export const RuntimeName = Schema.String.pipe(Schema.brand('@dxos/compute/Trace/RuntimeName'));
+export type RuntimeName = Schema.Schema.Type<typeof RuntimeName>;
+
+/**
+ * Common runtime names.
+ */
+export const CommonRuntimeName = {
+  webApp: RuntimeName.make('browser'),
+  cli: RuntimeName.make('cli'),
+  desktopApp: RuntimeName.make('desktop-app'),
+  mobileApp: RuntimeName.make('mobile-app'),
+  edgeIntrinsic: RuntimeName.make('edge-intrinsic'),
+  edgeWorkerLoader: RuntimeName.make('edge-worker-loader'),
+  edgeWorkerForPlatforms: RuntimeName.make('edge-worker-for-platforms'),
+}
 
 /**
  * Envelope for a set of events.

--- a/packages/core/compute/compute/src/Trace.ts
+++ b/packages/core/compute/compute/src/Trace.ts
@@ -127,6 +127,14 @@ export const CommonRuntimeName = {
 }
 
 /**
+ * Checks if a runtime is an edge runtime.
+ */
+export const isEdgeRuntime = (name: RuntimeName): boolean =>
+  name === CommonRuntimeName.edgeIntrinsic ||
+  name === CommonRuntimeName.edgeWorkerLoader ||
+  name === CommonRuntimeName.edgeWorkerForPlatforms;
+
+/**
  * Envelope for a set of events.
  */
 export const MessageData = Schema.Struct({

--- a/packages/core/compute/compute/src/Trace.ts
+++ b/packages/core/compute/compute/src/Trace.ts
@@ -77,6 +77,25 @@ export const isOfType = <T, E extends Event>(eventType: EventType<T>, event: E):
 };
 
 /**
+ * Extensible name informing which runtime executed the code that produced the event.
+ */
+export const RuntimeName = Schema.String.pipe(Schema.brand('@dxos/compute/Trace/RuntimeName'));
+export type RuntimeName = Schema.Schema.Type<typeof RuntimeName>;
+
+/**
+ * Common runtime names.
+ */
+export const CommonRuntimeName = {
+  /**
+   * Web app / CLI / Desktop app / Mobile app.
+   */
+  local: RuntimeName.make('local'),
+  edgeIntrinsic: RuntimeName.make('edge-intrinsic'),
+  edgeWorkerLoader: RuntimeName.make('edge-worker-loader'),
+  edgeWorkerForPlatforms: RuntimeName.make('edge-worker-for-platforms'),
+};
+
+/**
  * Metadata on the context of a trace message.
  */
 // TODO(dmaretskyi): Expand on this: conversation id, tool call id, etc.
@@ -103,28 +122,9 @@ export const Meta = Schema.Struct({
   /**
    * Extensible name informing which runtime executed the code that produced the event.
    */
-  runtimeName: Schema.optional(Schema.String),
+  runtimeName: Schema.optional(RuntimeName),
 });
-export interface Meta extends Schema.Schema.Type<typeof Meta> { }
-
-/**
- * Extensible name informing which runtime executed the code that produced the event.
- */
-export const RuntimeName = Schema.String.pipe(Schema.brand('@dxos/compute/Trace/RuntimeName'));
-export type RuntimeName = Schema.Schema.Type<typeof RuntimeName>;
-
-/**
- * Common runtime names.
- */
-export const CommonRuntimeName = {
-  webApp: RuntimeName.make('browser'),
-  cli: RuntimeName.make('cli'),
-  desktopApp: RuntimeName.make('desktop-app'),
-  mobileApp: RuntimeName.make('mobile-app'),
-  edgeIntrinsic: RuntimeName.make('edge-intrinsic'),
-  edgeWorkerLoader: RuntimeName.make('edge-worker-loader'),
-  edgeWorkerForPlatforms: RuntimeName.make('edge-worker-for-platforms'),
-}
+export interface Meta extends Schema.Schema.Type<typeof Meta> {}
 
 /**
  * Checks if a runtime is an edge runtime.

--- a/packages/core/compute/compute/src/Trace.ts
+++ b/packages/core/compute/compute/src/Trace.ts
@@ -24,7 +24,7 @@ export interface TraceWriter {
  * Service that writes events to the trace.
  * Exposed to processes and operations to record events to the trace.
  */
-export class TraceService extends Context.Tag('@dxos/functions/TraceService')<TraceService, TraceWriter>() {}
+export class TraceService extends Context.Tag('@dxos/functions/TraceService')<TraceService, TraceWriter>() { }
 
 /**
  * Writes an event to the trace.
@@ -67,7 +67,7 @@ export const Event = Schema.Struct({
   type: Schema.String,
   data: Schema.Unknown, // Type-specific payload;
 });
-export interface Event extends Schema.Schema.Type<typeof Event> {}
+export interface Event extends Schema.Schema.Type<typeof Event> { }
 
 /**
  * Checks if an event is of a given type.
@@ -100,7 +100,7 @@ export const Meta = Schema.Struct({
    */
   toolCallId: Schema.optional(Schema.String),
 });
-export interface Meta extends Schema.Schema.Type<typeof Meta> {}
+export interface Meta extends Schema.Schema.Type<typeof Meta> { }
 
 /**
  * Envelope for a set of events.
@@ -111,7 +111,7 @@ export const MessageData = Schema.Struct({
   isEphemeral: Schema.Boolean,
   events: Schema.Array(Event),
 });
-export interface MessageData extends Schema.Schema.Type<typeof MessageData> {}
+export interface MessageData extends Schema.Schema.Type<typeof MessageData> { }
 
 export const Message = MessageData.pipe(
   Type.object({
@@ -123,7 +123,28 @@ export const Message = MessageData.pipe(
     hue: 'rose',
   }),
 );
-export interface Message extends Schema.Schema.Type<typeof Message> {}
+export interface Message extends Schema.Schema.Type<typeof Message> { }
+
+/**
+ * Flattened representation of a signle event in a trace message.
+ * Events are stored in batched messages for efficiency, but flat representation is more convenient for consumption.
+ */
+export interface FlatEvent extends Event {
+  readonly meta: Meta;
+  readonly isEphemeral: boolean;
+}
+
+/**
+ * Flattens a trace message into a list of flat events.
+ */
+export const flatten = (message: Message): FlatEvent[] => {
+  return message.events.map((event) => ({
+    ...event,
+    meta: message.meta,
+    isEphemeral: message.isEphemeral,
+  }));
+};
+
 
 /**
  * Sink for complete trace messages.
@@ -137,16 +158,16 @@ export interface Sink {
  * The Process Manager forwards trace messages to it.
  */
 // TODO(dmaretskyi): Consider moving sink to the Process Manager.
-export class TraceSink extends Context.Tag('@dxos/functions/TraceSink')<TraceSink, Sink>() {}
+export class TraceSink extends Context.Tag('@dxos/functions/TraceSink')<TraceSink, Sink>() { }
 
 export const noopWriter: TraceWriter = {
-  write: () => {},
+  write: () => { },
 };
 
 export const writerLayerNoop: Layer.Layer<TraceService> = Layer.succeed(TraceService, noopWriter);
 
 export const layerNoop: Layer.Layer<TraceSink> = Layer.succeed(TraceSink, {
-  write: () => {},
+  write: () => { },
 });
 
 export const layerConsole: Layer.Layer<TraceSink> = Layer.succeed(TraceSink, {

--- a/packages/core/compute/functions-runtime/src/process/ProcessManager.ts
+++ b/packages/core/compute/functions-runtime/src/process/ProcessManager.ts
@@ -661,6 +661,13 @@ export interface ManagerImplOptions {
   readonly serviceResolver?: ServiceResolver.ServiceResolver;
   readonly handlerSet?: OperationHandlerSet.OperationHandlerSet;
   readonly idGenerator?: IdGenerator;
+
+  /**
+   * Runtime name to stamp on trace messages emitted by processes spawned by this manager.
+   * Identifies which runtime (local app, edge intrinsic, edge worker, ...) executed the code.
+   * Per-spawn `SpawnOptions.traceMeta.runtimeName` takes precedence over this default.
+   */
+  readonly runtimeName?: Trace.RuntimeName;
 }
 
 export class ManagerImpl implements Manager {
@@ -670,6 +677,7 @@ export class ManagerImpl implements Manager {
   readonly #serviceResolver: ServiceResolver.ServiceResolver;
   readonly #handlerSet: OperationHandlerSet.OperationHandlerSet | undefined;
   readonly #traceSink: Trace.Sink;
+  readonly #runtimeName: Trace.RuntimeName | undefined;
   readonly #handles = new Map<Process.ID, HandleImpl<any, any, any>>();
   readonly #processTreeAtom: Atom.Writable<readonly Process.Info[]>;
   readonly #monitor: Process.Monitor;
@@ -681,6 +689,7 @@ export class ManagerImpl implements Manager {
     this.#serviceResolver = options.serviceResolver ?? ServiceResolver.empty;
     this.#handlerSet = options.handlerSet;
     this.#traceSink = options.traceSink;
+    this.#runtimeName = options.runtimeName;
     this.#processTreeAtom = Atom.make<readonly Process.Info[]>([]);
     this.#registry.mount(this.#processTreeAtom);
     this.#monitor = {
@@ -781,6 +790,7 @@ export class ManagerImpl implements Manager {
             // TODO(dmaretskyi): Batching.
             const message = Obj.make(Trace.Message, {
               meta: {
+                runtimeName: this.#runtimeName,
                 ...(options?.traceMeta ?? {}),
                 pid: id,
                 parentPid: options?.parentProcessId,
@@ -1012,6 +1022,11 @@ export class ManagerImpl implements Manager {
  */
 export const layer = (opts?: {
   idGenerator?: IdGenerator;
+  /**
+   * Runtime name stamped on every trace message emitted by processes spawned by this manager.
+   * See {@link Trace.CommonRuntimeName} for well-known values.
+   */
+  runtimeName?: Trace.RuntimeName;
 }): Layer.Layer<
   Service | Process.ProcessMonitorService,
   never,
@@ -1037,6 +1052,7 @@ export const layer = (opts?: {
         serviceResolver,
         handlerSet,
         idGenerator: opts?.idGenerator,
+        runtimeName: opts?.runtimeName,
       });
 
       yield* Effect.addFinalizer(() => manager.shutdown());

--- a/packages/core/compute/functions/src/protocol/protocol.ts
+++ b/packages/core/compute/functions/src/protocol/protocol.ts
@@ -121,6 +121,18 @@ export const wrapFunctionHandler = (
           );
         }
 
+        // Flush in-memory ECHO writes before the function scope closes.
+        // Writes performed by `db.add` / `db.remove` are buffered in the in-memory
+        // `EchoDatabaseImpl` and only pushed across the `DataService` binding when
+        // `db.flush({ disk })` is called. `FunctionContext._close` (invoked by the
+        // `await using` above) calls `db.close()` but does NOT flush, so mutations
+        // performed by handlers that declare `Database.Service` (e.g. `object-create`,
+        // `object-update`, `relation-create`) would be silently dropped before reaching
+        // the edge `AutomergeReplicator`. Flushing here closes that hole.
+        if (serviceTags.includes(Database.Service.key) && funcContext.db) {
+          await funcContext.db.flush({ disk: true, indexes: false });
+        }
+
         if (func.output && !SchemaAST.isAnyKeyword(func.output.ast)) {
           try {
             Schema.validateSync(func.output, { onExcessProperty: 'error' })(result);

--- a/packages/devtools/cli/src/util/trigger-runtime.ts
+++ b/packages/devtools/cli/src/util/trigger-runtime.ts
@@ -86,7 +86,7 @@ export const triggerRuntimeLayer = ({
       // Add trigger-specific services on top
       // Note: Tool services use the merged toolkit, matching how ChatProcessor.execute() does it
       return TriggerDispatcher.layer({ timeControl: 'natural', livePollInterval }).pipe(
-        Layer.provide(ProcessManager.layer()),
+        Layer.provide(ProcessManager.layer({ runtimeName: Trace.CommonRuntimeName.local })),
         Layer.provide(ServiceResolver.layerRequirements(Database.Service, OpaqueToolkit.OpaqueToolkitProvider)),
         Layer.provide(Registry.layer),
         Layer.provideMerge(triggerStateStoreLayer),

--- a/packages/plugins/plugin-automation/src/capabilities/compute-runtime.ts
+++ b/packages/plugins/plugin-automation/src/capabilities/compute-runtime.ts
@@ -25,6 +25,7 @@ import {
   OperationHandlerSet,
   OperationRegistry,
   ServiceNotAvailableError,
+  Trace,
 } from '@dxos/compute';
 import { Resource } from '@dxos/context';
 import { Database, DXN, Feed, Filter, Obj } from '@dxos/echo';
@@ -201,7 +202,7 @@ class ComputeRuntimeProviderImpl extends Resource implements AutomationCapabilit
               }),
             ),
             Layer.provideMerge(ProcessManager.ProcessOperationInvoker.layer),
-            Layer.provideMerge(ProcessManager.layer()),
+            Layer.provideMerge(ProcessManager.layer({ runtimeName: Trace.CommonRuntimeName.local })),
             // TODO(dmaretskyi): Duped in assistant testing layer.
             Layer.provideMerge(
               // TODO(dmaretskyi): Refactor to be able to merge resovler layers, also consider service mesh achitecture.


### PR DESCRIPTION
## Summary

Two improvements to the compute/functions runtime:

1. **Trace runtime identification**: Adds a `runtimeName` field to `Trace.Meta` and a `Trace.CommonRuntimeName` registry (`local`, `edge-intrinsic`, `edge-worker-loader`, `edge-worker-for-platforms`). `ProcessManager.layer()` now accepts a `runtimeName` option that is stamped on every trace message emitted by spawned processes (per-spawn `traceMeta.runtimeName` still overrides it). Also adds the `isEdgeRuntime` helper and a `Trace.flatten` helper that flattens batched messages into per-event records for downstream consumption. Wires `Trace.CommonRuntimeName.local` through the devtools CLI `trigger-runtime` and the automation plugin compute runtime.

2. **Flush in-memory ECHO writes before function scope closes**: Mutations performed by function handlers that declare `Database.Service` (e.g. `object-create`, `object-update`, `relation-create`) were being silently dropped before reaching the edge `AutomergeReplicator`. Writes go through the in-memory `EchoDatabaseImpl` and only cross the `DataService` binding on `db.flush({ disk })`. `FunctionContext._close` calls `db.close()` but not `flush()`, so the buffered writes were never pushed. `wrapFunctionHandler` now calls `db.flush({ disk: true, indexes: false })` before the context closes when `Database.Service` is in the handler's service tags.

## Test plan

- [x] `moon run echo-db:test` (passes)
- [x] `moon run introspect-mcp:test` (passes)
- [ ] CI green

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Runtime identification: Trace messages now identify which execution environment (local or edge) processed operations, improving debugging and observability.

* **Bug Fixes**
  * Fixed database mutations being dropped when using database operations within functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxos/dxos/pull/11378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->